### PR TITLE
fix: skip rate limiting on health check endpoints to prevent 429 from…

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, HttpCode } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { PrismaService } from './prisma/prisma.service';
 
+@SkipThrottle()
 @Controller()
 export class AppController {
   constructor(private prisma: PrismaService) {}


### PR DESCRIPTION
… DO health probes

The ThrottlerGuard was applied globally, causing DigitalOcean health checks (every 30s) to exceed the login rate limit (5 req/15min) and return 429, making the API appear down.

https://claude.ai/code/session_013p47LupRr3vJZfWFuWeMcu