### PR TITLE
fix: prevent browser hanging - add request timeouts, fix redirect loo…

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -43,7 +43,7 @@ import { SecurityMiddleware } from './modules/audit/security.middleware';
       {
         name: 'short',
         ttl: 1000,
-        limit: 10,
+        limit: 30, // Allow 30 req/sec (dashboard fires many parallel queries)
       },
       {
         name: 'login',

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -37,7 +37,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setIsLoading(false);
         return;
       }
-      const { data } = await api.get('/auth/me');
+      const { data } = await api.get('/auth/me', { timeout: 10000 });
       setUser({
         id: data.id,
         email: data.email,
@@ -47,11 +47,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         branchName: data.branch?.name || null,
       });
     } catch (error: unknown) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      if (status === 401) {
+      const axiosError = error as { response?: { status?: number }; code?: string };
+      if (axiosError.response?.status === 401) {
         logout();
       }
-      // Don't logout on 429 (rate limit) or network errors - keep current session
+      // On timeout or network error, clear loading so the app doesn't hang
+      // User will see login page and can try again
+      if (axiosError.code === 'ECONNABORTED' || !axiosError.response) {
+        logout();
+      }
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || '/api',
+  timeout: 15000, // 15 second timeout to prevent hanging forever
   headers: {
     'Content-Type': 'application/json',
   },
@@ -23,7 +24,10 @@ api.interceptors.response.use(
     if (error.response?.status === 401) {
       localStorage.removeItem('access_token');
       localStorage.removeItem('refresh_token');
-      window.location.href = '/login';
+      // Only redirect if not already on login page (prevent redirect loop)
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
     }
     // On 429 rate limit, wait before rejecting so React Query backoff works properly
     if (error.response?.status === 429) {


### PR DESCRIPTION
…p, relax rate limiter

- Add 15s global timeout on axios to prevent requests from hanging forever
- Add 10s timeout specifically on /auth/me call during initial auth check
- Handle timeout/network errors in AuthContext so isLoading always resolves
- Fix 401 redirect loop (skip redirect if already on /login)
- Increase rate limiter from 10 to 30 req/sec (dashboard fires 5+ parallel queries)

https://claude.ai/code/session_013p47LupRr3vJZfWFuWeMcu