### PR TITLE
fix: login throttler was blocking ALL requests after 5 calls (white s…

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -45,11 +45,6 @@ import { SecurityMiddleware } from './modules/audit/security.middleware';
         ttl: 1000,
         limit: 30, // Allow 30 req/sec (dashboard fires many parallel queries)
       },
-      {
-        name: 'login',
-        ttl: 900000, // 15 minutes
-        limit: 5,
-      },
     ]),
     PrismaModule,
     AuthModule,

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Get, Body, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
@@ -10,6 +11,7 @@ export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('login')
+  @Throttle({ short: { ttl: 900000, limit: 5 } }) // 5 login attempts per 15 minutes
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
   }


### PR DESCRIPTION
…creen)

The 'login' named throttler (5 req/15min) was in the global ThrottlerModule config, meaning it applied to EVERY API endpoint - not just login. After login + /auth/me + a few dashboard queries, all subsequent requests got 429'd causing a white screen.

Fix: Remove 'login' throttler from global config, apply it specifically to the POST /auth/login endpoint using @Throttle() decorator.

https://claude.ai/code/session_013p47LupRr3vJZfWFuWeMcu