### PR TITLE
fix: show actual login error messages instead of generic "wrong passw…

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -29,13 +29,6 @@ api.interceptors.response.use(
         window.location.href = '/login';
       }
     }
-    // On 429 rate limit, wait before rejecting so React Query backoff works properly
-    if (error.response?.status === 429) {
-      const retryAfter = error.response.headers['retry-after'];
-      if (retryAfter) {
-        await new Promise((resolve) => setTimeout(resolve, Number(retryAfter) * 1000));
-      }
-    }
     return Promise.reject(error);
   },
 );

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -18,8 +18,19 @@ export default function LoginPage() {
       await login(email, password);
       toast.success('เข้าสู่ระบบสำเร็จ');
       navigate('/');
-    } catch {
-      toast.error('อีเมลหรือรหัสผ่านไม่ถูกต้อง');
+    } catch (error: unknown) {
+      const err = error as { response?: { status?: number; data?: { message?: string } }; code?: string };
+      if (err.code === 'ECONNABORTED') {
+        toast.error('เซิร์ฟเวอร์ไม่ตอบสนอง กรุณาลองใหม่');
+      } else if (!err.response) {
+        toast.error('ไม่สามารถเชื่อมต่อเซิร์ฟเวอร์ได้');
+      } else if (err.response.status === 429) {
+        toast.error('ลองเข้าสู่ระบบบ่อยเกินไป กรุณารอสักครู่');
+      } else if (err.response.status === 401) {
+        toast.error('อีเมลหรือรหัสผ่านไม่ถูกต้อง');
+      } else {
+        toast.error(err.response.data?.message || 'เกิดข้อผิดพลาด กรุณาลองใหม่');
+      }
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
…ord"

LoginPage catch block was showing "อีเมลหรือรหัสผ่านไม่ถูกต้อง" for ALL errors including network errors, timeouts, and 429 rate limits. Now shows:
- Timeout → "เซิร์ฟเวอร์ไม่ตอบสนอง"
- Network error → "ไม่สามารถเชื่อมต่อเซิร์ฟเวอร์ได้"
- 429 → "ลองเข้าสู่ระบบบ่อยเกินไป"
- 401 → "อีเมลหรือรหัสผ่านไม่ถูกต้อง"

Also removed 429 retry-after wait in api interceptor that caused login button to hang at "กำลังเข้าสู่ระบบ" for up to 15 minutes.

https://claude.ai/code/session_013p47LupRr3vJZfWFuWeMcu