### PR TITLE
fix(supplier): fix address not saving and edit not loading existing data

### DIFF
--- a/apps/web/src/components/ui/AddressForm.tsx
+++ b/apps/web/src/components/ui/AddressForm.tsx
@@ -55,6 +55,48 @@ export function composeAddress(addr: AddressData): string {
   return parts.join(' ');
 }
 
+export function serializeAddress(addr: AddressData): string {
+  const hasData = Object.values(addr).some((v) => v.trim() !== '');
+  if (!hasData) return '';
+  return JSON.stringify(addr);
+}
+
+export function deserializeAddress(str: string | null | undefined): AddressData {
+  if (!str) return { ...emptyAddress };
+  try {
+    const parsed = JSON.parse(str);
+    if (typeof parsed === 'object' && parsed !== null && 'province' in parsed) {
+      return {
+        houseNo: parsed.houseNo || '',
+        moo: parsed.moo || '',
+        village: parsed.village || '',
+        soi: parsed.soi || '',
+        road: parsed.road || '',
+        province: parsed.province || '',
+        district: parsed.district || '',
+        subdistrict: parsed.subdistrict || '',
+        postalCode: parsed.postalCode || '',
+      };
+    }
+  } catch {
+    // Not JSON - legacy composed address format
+  }
+  return { ...emptyAddress };
+}
+
+export function displayAddress(str: string | null | undefined): string {
+  if (!str) return '';
+  try {
+    const parsed = JSON.parse(str);
+    if (typeof parsed === 'object' && parsed !== null && 'province' in parsed) {
+      return composeAddress(parsed);
+    }
+  } catch {
+    // Not JSON - legacy format, return as-is
+  }
+  return str;
+}
+
 interface Props {
   value: AddressData;
   onChange: (addr: AddressData) => void;

--- a/apps/web/src/pages/SupplierDetailPage.tsx
+++ b/apps/web/src/pages/SupplierDetailPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import DataTable from '@/components/ui/DataTable';
+import { displayAddress } from '@/components/ui/AddressForm';
 
 interface Supplier {
   id: string;
@@ -205,7 +206,7 @@ export default function SupplierDetailPage() {
             label="วันที่เพิ่ม"
             value={new Date(supplier.createdAt).toLocaleDateString('th-TH')}
           />
-          <InfoField label="ที่อยู่" value={supplier.address} />
+          <InfoField label="ที่อยู่" value={displayAddress(supplier.address)} />
           {supplier.notes && <InfoField label="หมายเหตุ" value={supplier.notes} />}
         </div>
       </div>

--- a/apps/web/src/pages/SuppliersPage.tsx
+++ b/apps/web/src/pages/SuppliersPage.tsx
@@ -8,7 +8,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import DataTable from '@/components/ui/DataTable';
 import Modal from '@/components/ui/Modal';
 import { useAuth } from '@/contexts/AuthContext';
-import AddressForm, { AddressData, emptyAddress, composeAddress } from '@/components/ui/AddressForm';
+import AddressForm, { AddressData, emptyAddress, serializeAddress, deserializeAddress } from '@/components/ui/AddressForm';
 
 interface Supplier {
   id: string;
@@ -86,13 +86,13 @@ export default function SuppliersPage() {
 
   const saveMutation = useMutation({
     mutationFn: async (data: typeof emptyForm) => {
-      const composedAddress = composeAddress(supplierAddress);
+      const serializedAddress = serializeAddress(supplierAddress);
       const payload = {
         ...data,
         nickname: data.nickname || undefined,
         phoneSecondary: data.phoneSecondary || undefined,
         lineId: data.lineId || undefined,
-        address: composedAddress || undefined,
+        address: serializedAddress || undefined,
         taxId: data.taxId || undefined,
         notes: data.notes || undefined,
       };
@@ -156,7 +156,7 @@ export default function SuppliersPage() {
       taxId: supplier.taxId || '',
       notes: supplier.notes || '',
     });
-    setSupplierAddress(emptyAddress);
+    setSupplierAddress(deserializeAddress(supplier.address));
     setIsModalOpen(true);
   };
 


### PR DESCRIPTION
- Store address as JSON string for reliable round-tripping between create/edit
- Load existing address data when opening edit modal (was always resetting to empty)
- Add displayAddress() for human-readable display in detail page
- Backward compatible with legacy composed address strings

https://claude.ai/code/session_01EchTjyABh62Yo8euqLUGN7