### PR TITLE
fix(supplier): fix phone search not matching digits-only input

### DIFF
--- a/apps/api/src/modules/suppliers/suppliers.service.ts
+++ b/apps/api/src/modules/suppliers/suppliers.service.ts
@@ -25,16 +25,18 @@ export class SuppliersService {
         { taxId: { contains: search } },
       ];
 
-      // If search is digits-only, also match against formatted phone/taxId
+      // Also match phone with/without dash formatting
       const digits = search.replace(/\D/g, '');
-      if (digits.length >= 3 && digits !== search) {
+      if (digits.length >= 3) {
         const formatted =
           digits.length <= 3
             ? digits
             : digits.length <= 6
               ? `${digits.slice(0, 3)}-${digits.slice(3)}`
               : `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
-        orConditions.push({ phone: { contains: formatted } });
+        if (formatted !== search) {
+          orConditions.push({ phone: { contains: formatted } });
+        }
       }
 
       andConditions.push({ OR: orConditions });


### PR DESCRIPTION
The condition `digits !== search` was always false when the user typed only digits (e.g. "0812345678"), so the formatted version ("081-234-5678") was never added to the search. Changed to always format when digits >= 3 and only skip if the formatted result equals the original search term.

https://claude.ai/code/session_01EchTjyABh62Yo8euqLUGN7