### PR TITLE
feat: support multiple payment methods per Supplier

### DIFF
--- a/apps/api/prisma/migrations/20260227160000_add_supplier_payment_info/migration.sql
+++ b/apps/api/prisma/migrations/20260227160000_add_supplier_payment_info/migration.sql
@@ -1,6 +1,0 @@
--- AlterTable
-ALTER TABLE "suppliers" ADD COLUMN "payment_method" TEXT;
-ALTER TABLE "suppliers" ADD COLUMN "bank_name" TEXT;
-ALTER TABLE "suppliers" ADD COLUMN "bank_account_name" TEXT;
-ALTER TABLE "suppliers" ADD COLUMN "bank_account_number" TEXT;
-ALTER TABLE "suppliers" ADD COLUMN "credit_term_days" INTEGER;

--- a/apps/api/prisma/migrations/20260227180000_add_supplier_payment_methods/migration.sql
+++ b/apps/api/prisma/migrations/20260227180000_add_supplier_payment_methods/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "supplier_payment_methods" (
+    "id" TEXT NOT NULL,
+    "supplier_id" TEXT NOT NULL,
+    "payment_method" TEXT NOT NULL,
+    "bank_name" TEXT,
+    "bank_account_name" TEXT,
+    "bank_account_number" TEXT,
+    "credit_term_days" INTEGER,
+    "is_default" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "supplier_payment_methods_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "supplier_payment_methods_supplier_id_idx" ON "supplier_payment_methods"("supplier_id");
+
+-- AddForeignKey
+ALTER TABLE "supplier_payment_methods" ADD CONSTRAINT "supplier_payment_methods_supplier_id_fkey" FOREIGN KEY ("supplier_id") REFERENCES "suppliers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Migrate existing data: move payment info from suppliers to payment_methods table
+INSERT INTO "supplier_payment_methods" ("id", "supplier_id", "payment_method", "bank_name", "bank_account_name", "bank_account_number", "credit_term_days", "is_default", "created_at", "updated_at")
+SELECT gen_random_uuid(), "id", "payment_method", "bank_name", "bank_account_name", "bank_account_number", "credit_term_days", true, NOW(), NOW()
+FROM "suppliers"
+WHERE "payment_method" IS NOT NULL;
+
+-- Drop old columns from suppliers
+ALTER TABLE "suppliers" DROP COLUMN IF EXISTS "payment_method";
+ALTER TABLE "suppliers" DROP COLUMN IF EXISTS "bank_name";
+ALTER TABLE "suppliers" DROP COLUMN IF EXISTS "bank_account_name";
+ALTER TABLE "suppliers" DROP COLUMN IF EXISTS "bank_account_number";
+ALTER TABLE "suppliers" DROP COLUMN IF EXISTS "credit_term_days";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -289,11 +289,6 @@ model Supplier {
   address     String?
   taxId       String?  @map("tax_id")
   hasVat      Boolean  @default(false) @map("has_vat")
-  paymentMethod     String?  @map("payment_method")       // CASH, BANK_TRANSFER, CHECK, CREDIT
-  bankName          String?  @map("bank_name")
-  bankAccountName   String?  @map("bank_account_name")
-  bankAccountNumber String?  @map("bank_account_number")
-  creditTermDays    Int?     @map("credit_term_days")      // เครดิตกี่วัน
   notes       String?
   isActive    Boolean  @default(true) @map("is_active")
   createdAt   DateTime @default(now()) @map("created_at")
@@ -301,8 +296,27 @@ model Supplier {
 
   products       Product[]
   purchaseOrders PurchaseOrder[]
+  paymentMethods SupplierPaymentMethod[]
 
   @@map("suppliers")
+}
+
+model SupplierPaymentMethod {
+  id                String   @id @default(uuid())
+  supplierId        String   @map("supplier_id")
+  paymentMethod     String   @map("payment_method")       // CASH, BANK_TRANSFER, CHECK, CREDIT
+  bankName          String?  @map("bank_name")
+  bankAccountName   String?  @map("bank_account_name")
+  bankAccountNumber String?  @map("bank_account_number")
+  creditTermDays    Int?     @map("credit_term_days")
+  isDefault         Boolean  @default(false) @map("is_default")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  supplier Supplier @relation(fields: [supplierId], references: [id], onDelete: Cascade)
+
+  @@index([supplierId])
+  @@map("supplier_payment_methods")
 }
 
 model PurchaseOrder {

--- a/apps/api/src/modules/suppliers/dto/create-supplier.dto.ts
+++ b/apps/api/src/modules/suppliers/dto/create-supplier.dto.ts
@@ -1,4 +1,31 @@
-import { IsString, IsOptional, IsBoolean, IsInt, Min } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsArray, ValidateNested, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PaymentMethodDto {
+  @IsString()
+  paymentMethod: string;
+
+  @IsString()
+  @IsOptional()
+  bankName?: string;
+
+  @IsString()
+  @IsOptional()
+  bankAccountName?: string;
+
+  @IsString()
+  @IsOptional()
+  bankAccountNumber?: string;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  creditTermDays?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  isDefault?: boolean;
+}
 
 export class CreateSupplierDto {
   @IsString()
@@ -36,30 +63,15 @@ export class CreateSupplierDto {
 
   @IsString()
   @IsOptional()
-  paymentMethod?: string;
-
-  @IsString()
-  @IsOptional()
-  bankName?: string;
-
-  @IsString()
-  @IsOptional()
-  bankAccountName?: string;
-
-  @IsString()
-  @IsOptional()
-  bankAccountNumber?: string;
-
-  @IsInt()
-  @Min(0)
-  @IsOptional()
-  creditTermDays?: number;
-
-  @IsString()
-  @IsOptional()
   notes?: string;
 
   @IsBoolean()
   @IsOptional()
   isActive?: boolean;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PaymentMethodDto)
+  @IsOptional()
+  paymentMethods?: PaymentMethodDto[];
 }

--- a/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
+++ b/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
@@ -1,4 +1,35 @@
-import { IsString, IsOptional, IsBoolean, IsInt, Min } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsArray, ValidateNested, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PaymentMethodUpdateDto {
+  @IsString()
+  @IsOptional()
+  id?: string;
+
+  @IsString()
+  paymentMethod: string;
+
+  @IsString()
+  @IsOptional()
+  bankName?: string;
+
+  @IsString()
+  @IsOptional()
+  bankAccountName?: string;
+
+  @IsString()
+  @IsOptional()
+  bankAccountNumber?: string;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  creditTermDays?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  isDefault?: boolean;
+}
 
 export class UpdateSupplierDto {
   @IsString()
@@ -39,30 +70,15 @@ export class UpdateSupplierDto {
 
   @IsString()
   @IsOptional()
-  paymentMethod?: string;
-
-  @IsString()
-  @IsOptional()
-  bankName?: string;
-
-  @IsString()
-  @IsOptional()
-  bankAccountName?: string;
-
-  @IsString()
-  @IsOptional()
-  bankAccountNumber?: string;
-
-  @IsInt()
-  @Min(0)
-  @IsOptional()
-  creditTermDays?: number;
-
-  @IsString()
-  @IsOptional()
   notes?: string;
 
   @IsBoolean()
   @IsOptional()
   isActive?: boolean;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PaymentMethodUpdateDto)
+  @IsOptional()
+  paymentMethods?: PaymentMethodUpdateDto[];
 }

--- a/apps/api/src/modules/suppliers/suppliers.service.ts
+++ b/apps/api/src/modules/suppliers/suppliers.service.ts
@@ -53,6 +53,7 @@ export class SuppliersService {
         take: limit,
         include: {
           _count: { select: { products: true, purchaseOrders: true } },
+          paymentMethods: { orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }] },
         },
       }),
       this.prisma.supplier.count({ where }),
@@ -66,6 +67,7 @@ export class SuppliersService {
       where: { id },
       include: {
         _count: { select: { products: true, purchaseOrders: true } },
+        paymentMethods: { orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }] },
       },
     });
     if (!supplier) throw new NotFoundException('ไม่พบ Supplier');
@@ -73,12 +75,72 @@ export class SuppliersService {
   }
 
   async create(dto: CreateSupplierDto) {
-    return this.prisma.supplier.create({ data: dto });
+    const { paymentMethods, ...supplierData } = dto;
+    return this.prisma.supplier.create({
+      data: {
+        ...supplierData,
+        paymentMethods: paymentMethods?.length
+          ? {
+              create: paymentMethods.map((pm, index) => ({
+                paymentMethod: pm.paymentMethod,
+                bankName: pm.bankName,
+                bankAccountName: pm.bankAccountName,
+                bankAccountNumber: pm.bankAccountNumber,
+                creditTermDays: pm.creditTermDays,
+                isDefault: pm.isDefault ?? index === 0,
+              })),
+            }
+          : undefined,
+      },
+      include: {
+        paymentMethods: true,
+      },
+    });
   }
 
   async update(id: string, dto: UpdateSupplierDto) {
     await this.findOne(id);
-    return this.prisma.supplier.update({ where: { id }, data: dto });
+    const { paymentMethods, ...supplierData } = dto;
+
+    return this.prisma.$transaction(async (tx) => {
+      // Update supplier fields
+      const supplier = await tx.supplier.update({
+        where: { id },
+        data: supplierData,
+      });
+
+      // If paymentMethods is provided, replace all payment methods
+      if (paymentMethods !== undefined) {
+        // Delete existing payment methods
+        await tx.supplierPaymentMethod.deleteMany({
+          where: { supplierId: id },
+        });
+
+        // Create new payment methods
+        if (paymentMethods.length > 0) {
+          await tx.supplierPaymentMethod.createMany({
+            data: paymentMethods.map((pm, index) => ({
+              supplierId: id,
+              paymentMethod: pm.paymentMethod,
+              bankName: pm.bankName,
+              bankAccountName: pm.bankAccountName,
+              bankAccountNumber: pm.bankAccountNumber,
+              creditTermDays: pm.creditTermDays,
+              isDefault: pm.isDefault ?? index === 0,
+            })),
+          });
+        }
+      }
+
+      // Return with payment methods
+      return tx.supplier.findUnique({
+        where: { id: supplier.id },
+        include: {
+          _count: { select: { products: true, purchaseOrders: true } },
+          paymentMethods: { orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }] },
+        },
+      });
+    });
   }
 
   async remove(id: string) {

--- a/apps/web/src/pages/PurchaseOrdersPage.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage.tsx
@@ -152,7 +152,7 @@ export default function PurchaseOrdersPage() {
   });
   const [items, setItems] = useState<ItemForm[]>([{ ...emptyItem }]);
 
-  const { data: suppliersRes } = useQuery<{ data: { id: string; name: string; contactName: string; hasVat: boolean; paymentMethod: string | null }[] }>({
+  const { data: suppliersRes } = useQuery<{ data: { id: string; name: string; contactName: string; hasVat: boolean; paymentMethods: { paymentMethod: string; isDefault: boolean }[] }[] }>({
     queryKey: ['suppliers-for-po'],
     queryFn: async () => (await api.get('/suppliers?limit=999&isActive=true')).data,
   });
@@ -555,10 +555,11 @@ export default function PurchaseOrdersPage() {
               onChange={(e) => {
                 const sid = e.target.value;
                 const sup = suppliers.find((s) => s.id === sid);
+                const defaultPm = sup?.paymentMethods?.find((pm) => pm.isDefault) || sup?.paymentMethods?.[0];
                 setForm({
                   ...form,
                   supplierId: sid,
-                  paymentMethod: sup?.paymentMethod || form.paymentMethod,
+                  paymentMethod: defaultPm?.paymentMethod || form.paymentMethod,
                 });
               }}
               className={selectClass}
@@ -578,9 +579,12 @@ export default function PurchaseOrdersPage() {
                 >
                   {supplierHasVat ? 'Supplier มี VAT - จะคำนวณ VAT 7% อัตโนมัติ' : 'Supplier ไม่มี VAT'}
                 </span>
-                {selectedSupplier.paymentMethod && (
+                {selectedSupplier.paymentMethods?.length > 0 && (
                   <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700">
-                    ชำระ: {selectedSupplier.paymentMethod === 'CASH' ? 'เงินสด' : selectedSupplier.paymentMethod === 'BANK_TRANSFER' ? 'โอนธนาคาร' : selectedSupplier.paymentMethod === 'CHECK' ? 'เช็ค' : selectedSupplier.paymentMethod === 'CREDIT' ? 'เครดิต' : selectedSupplier.paymentMethod}
+                    ชำระ: {selectedSupplier.paymentMethods.map((pm) => {
+                      const labels: Record<string, string> = { CASH: 'เงินสด', BANK_TRANSFER: 'โอนธนาคาร', CHECK: 'เช็ค', CREDIT: 'เครดิต' };
+                      return labels[pm.paymentMethod] || pm.paymentMethod;
+                    }).join(', ')}
                   </span>
                 )}
               </div>

--- a/apps/web/src/pages/SupplierDetailPage.tsx
+++ b/apps/web/src/pages/SupplierDetailPage.tsx
@@ -7,6 +7,16 @@ import PageHeader from '@/components/ui/PageHeader';
 import DataTable from '@/components/ui/DataTable';
 import { displayAddress } from '@/components/ui/AddressForm';
 
+interface SupplierPaymentMethod {
+  id: string;
+  paymentMethod: string;
+  bankName: string | null;
+  bankAccountName: string | null;
+  bankAccountNumber: string | null;
+  creditTermDays: number | null;
+  isDefault: boolean;
+}
+
 interface Supplier {
   id: string;
   name: string;
@@ -18,11 +28,7 @@ interface Supplier {
   address: string | null;
   taxId: string | null;
   hasVat: boolean;
-  paymentMethod: string | null;
-  bankName: string | null;
-  bankAccountName: string | null;
-  bankAccountNumber: string | null;
-  creditTermDays: number | null;
+  paymentMethods: SupplierPaymentMethod[];
   notes: string | null;
   isActive: boolean;
   createdAt: string;
@@ -297,27 +303,37 @@ export default function SupplierDetailPage() {
         </div>
       </div>
 
-      {/* Payment Info Card */}
+      {/* Payment Methods Card */}
       <div className="bg-white rounded-lg border p-6 mb-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">ข้อมูลการชำระเงิน</h2>
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-          <div>
-            <div className="text-xs text-gray-500 mb-0.5">วิธีชำระเงิน</div>
-            {supplier.paymentMethod ? (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700">
-                {paymentMethodLabels[supplier.paymentMethod] || supplier.paymentMethod}
-              </span>
-            ) : (
-              <span className="text-sm text-gray-400">ไม่ระบุ</span>
-            )}
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">ข้อมูลการชำระเงิน ({supplier.paymentMethods?.length || 0} วิธี)</h2>
+        {supplier.paymentMethods?.length ? (
+          <div className="space-y-3">
+            {supplier.paymentMethods.map((pm) => (
+              <div key={pm.id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700">
+                    {paymentMethodLabels[pm.paymentMethod] || pm.paymentMethod}
+                  </span>
+                  {pm.isDefault && (
+                    <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-yellow-100 text-yellow-700">
+                      ค่าเริ่มต้น
+                    </span>
+                  )}
+                </div>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                  {pm.creditTermDays != null && (
+                    <InfoField label="เครดิต" value={`${pm.creditTermDays} วัน`} />
+                  )}
+                  <InfoField label="ธนาคาร" value={pm.bankName} />
+                  <InfoField label="ชื่อบัญชี" value={pm.bankAccountName} />
+                  <InfoField label="เลขบัญชี" value={pm.bankAccountNumber} />
+                </div>
+              </div>
+            ))}
           </div>
-          {supplier.creditTermDays != null && (
-            <InfoField label="เครดิต" value={`${supplier.creditTermDays} วัน`} />
-          )}
-          <InfoField label="ธนาคาร" value={supplier.bankName} />
-          <InfoField label="ชื่อบัญชี" value={supplier.bankAccountName} />
-          <InfoField label="เลขบัญชี" value={supplier.bankAccountNumber} />
-        </div>
+        ) : (
+          <p className="text-sm text-gray-400">ยังไม่มีข้อมูลการชำระเงิน</p>
+        )}
       </div>
 
       {/* Summary Stats */}

--- a/apps/web/src/pages/SuppliersPage.tsx
+++ b/apps/web/src/pages/SuppliersPage.tsx
@@ -10,6 +10,16 @@ import Modal from '@/components/ui/Modal';
 import { useAuth } from '@/contexts/AuthContext';
 import AddressForm, { AddressData, emptyAddress, serializeAddress, deserializeAddress } from '@/components/ui/AddressForm';
 
+interface PaymentMethod {
+  id?: string;
+  paymentMethod: string;
+  bankName: string;
+  bankAccountName: string;
+  bankAccountNumber: string;
+  creditTermDays: string | number;
+  isDefault: boolean;
+}
+
 interface Supplier {
   id: string;
   name: string;
@@ -21,11 +31,7 @@ interface Supplier {
   address: string | null;
   taxId: string | null;
   hasVat: boolean;
-  paymentMethod: string | null;
-  bankName: string | null;
-  bankAccountName: string | null;
-  bankAccountNumber: string | null;
-  creditTermDays: number | null;
+  paymentMethods: PaymentMethod[];
   notes: string | null;
   isActive: boolean;
   createdAt: string;
@@ -41,12 +47,16 @@ const emptyForm = {
   lineId: '',
   taxId: '',
   hasVat: false,
+  notes: '',
+};
+
+const emptyPaymentMethod: PaymentMethod = {
   paymentMethod: '',
   bankName: '',
   bankAccountName: '',
   bankAccountNumber: '',
-  creditTermDays: '' as string | number,
-  notes: '',
+  creditTermDays: '',
+  isDefault: false,
 };
 
 const paymentMethodLabels: Record<string, string> = {
@@ -79,6 +89,7 @@ export default function SuppliersPage() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingSupplier, setEditingSupplier] = useState<Supplier | null>(null);
   const [form, setForm] = useState(emptyForm);
+  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
   const [search, setSearch] = useState('');
   const [filterActive, setFilterActive] = useState<string>('true');
   const [supplierAddress, setSupplierAddress] = useState<AddressData>(emptyAddress);
@@ -104,22 +115,31 @@ export default function SuppliersPage() {
   const suppliers = result?.data ?? [];
 
   const saveMutation = useMutation({
-    mutationFn: async ({ formData, addressData, editId }: { formData: typeof emptyForm; addressData: AddressData; editId?: string }) => {
+    mutationFn: async ({ formData, addressData, pmList, editId }: { formData: typeof emptyForm; addressData: AddressData; pmList: PaymentMethod[]; editId?: string }) => {
       const serializedAddress = serializeAddress(addressData);
+      const validPaymentMethods = pmList
+        .filter((pm) => pm.paymentMethod !== '')
+        .map((pm) => ({
+          paymentMethod: pm.paymentMethod,
+          bankName: pm.bankName || undefined,
+          bankAccountName: pm.bankAccountName || undefined,
+          bankAccountNumber: pm.bankAccountNumber || undefined,
+          creditTermDays: pm.creditTermDays ? Number(pm.creditTermDays) : undefined,
+          isDefault: pm.isDefault,
+        }));
+
       const payload = {
-        ...formData,
+        name: formData.name,
+        contactName: formData.contactName,
         nickname: formData.nickname || undefined,
+        phone: formData.phone,
         phoneSecondary: formData.phoneSecondary || undefined,
         lineId: formData.lineId || undefined,
         address: serializedAddress || undefined,
         taxId: formData.taxId || undefined,
         hasVat: formData.hasVat,
-        paymentMethod: formData.paymentMethod || undefined,
-        bankName: formData.bankName || undefined,
-        bankAccountName: formData.bankAccountName || undefined,
-        bankAccountNumber: formData.bankAccountNumber || undefined,
-        creditTermDays: formData.creditTermDays ? Number(formData.creditTermDays) : undefined,
         notes: formData.notes || undefined,
+        paymentMethods: validPaymentMethods,
       };
       if (editId) {
         return api.patch(`/suppliers/${editId}`, payload);
@@ -165,6 +185,7 @@ export default function SuppliersPage() {
   const openCreate = () => {
     setEditingSupplier(null);
     setForm(emptyForm);
+    setPaymentMethods([]);
     setSupplierAddress(emptyAddress);
     setIsModalOpen(true);
   };
@@ -180,13 +201,21 @@ export default function SuppliersPage() {
       lineId: supplier.lineId || '',
       taxId: supplier.taxId || '',
       hasVat: supplier.hasVat ?? false,
-      paymentMethod: supplier.paymentMethod || '',
-      bankName: supplier.bankName || '',
-      bankAccountName: supplier.bankAccountName || '',
-      bankAccountNumber: supplier.bankAccountNumber || '',
-      creditTermDays: supplier.creditTermDays ?? '',
       notes: supplier.notes || '',
     });
+    setPaymentMethods(
+      supplier.paymentMethods?.length
+        ? supplier.paymentMethods.map((pm) => ({
+            id: pm.id,
+            paymentMethod: pm.paymentMethod || '',
+            bankName: pm.bankName || '',
+            bankAccountName: pm.bankAccountName || '',
+            bankAccountNumber: pm.bankAccountNumber || '',
+            creditTermDays: pm.creditTermDays ?? '',
+            isDefault: pm.isDefault ?? false,
+          }))
+        : []
+    );
     setSupplierAddress(deserializeAddress(supplier.address));
     setIsModalOpen(true);
   };
@@ -198,7 +227,32 @@ export default function SuppliersPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    saveMutation.mutate({ formData: form, addressData: supplierAddress, editId: editingSupplier?.id });
+    saveMutation.mutate({ formData: form, addressData: supplierAddress, pmList: paymentMethods, editId: editingSupplier?.id });
+  };
+
+  const addPaymentMethod = () => {
+    setPaymentMethods([...paymentMethods, { ...emptyPaymentMethod, isDefault: paymentMethods.length === 0 }]);
+  };
+
+  const removePaymentMethod = (index: number) => {
+    const updated = paymentMethods.filter((_, i) => i !== index);
+    // If removed the default, make the first one default
+    if (updated.length > 0 && !updated.some((pm) => pm.isDefault)) {
+      updated[0].isDefault = true;
+    }
+    setPaymentMethods(updated);
+  };
+
+  const updatePaymentMethod = (index: number, field: keyof PaymentMethod, value: string | number | boolean) => {
+    const updated = [...paymentMethods];
+    if (field === 'isDefault' && value === true) {
+      // Only one default
+      updated.forEach((pm, i) => { pm.isDefault = i === index; });
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (updated[index] as any)[field] = value;
+    }
+    setPaymentMethods(updated);
   };
 
   const columns = [
@@ -243,12 +297,21 @@ export default function SuppliersPage() {
       ),
     },
     {
-      key: 'paymentMethod',
+      key: 'paymentMethods',
       label: 'วิธีชำระ',
       render: (s: Supplier) => (
-        <div>
-          <span className="text-sm">{s.paymentMethod ? (paymentMethodLabels[s.paymentMethod] || s.paymentMethod) : '-'}</span>
-          {s.bankName && <div className="text-xs text-gray-400">{s.bankName}</div>}
+        <div className="space-y-0.5">
+          {s.paymentMethods?.length ? (
+            s.paymentMethods.map((pm, i) => (
+              <div key={i} className="flex items-center gap-1">
+                <span className="text-sm">{paymentMethodLabels[pm.paymentMethod] || pm.paymentMethod}</span>
+                {pm.isDefault && <span className="text-[10px] bg-yellow-100 text-yellow-700 px-1 rounded">หลัก</span>}
+                {pm.bankName && <span className="text-xs text-gray-400">({pm.bankName})</span>}
+              </div>
+            ))
+          ) : (
+            <span className="text-sm text-gray-400">-</span>
+          )}
         </div>
       ),
     },
@@ -477,68 +540,113 @@ export default function SuppliersPage() {
                 </span>
               </label>
             </div>
-            {/* Payment Information */}
+
+            {/* Payment Methods Section */}
             <div className="col-span-2 border-t pt-4 mt-2">
-              <h3 className="text-sm font-semibold text-gray-800 mb-3">ข้อมูลการชำระเงิน</h3>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">วิธีชำระเงิน</label>
-              <select
-                value={form.paymentMethod}
-                onChange={(e) => setForm({ ...form, paymentMethod: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none"
-              >
-                <option value="">-- ไม่ระบุ --</option>
-                <option value="CASH">เงินสด</option>
-                <option value="BANK_TRANSFER">โอนธนาคาร</option>
-                <option value="CHECK">เช็ค</option>
-                <option value="CREDIT">เครดิต</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">เครดิต (วัน)</label>
-              <input
-                type="number"
-                value={form.creditTermDays}
-                onChange={(e) => setForm({ ...form, creditTermDays: e.target.value })}
-                placeholder="เช่น 30"
-                min={0}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none"
-              />
-            </div>
-            {(form.paymentMethod === 'BANK_TRANSFER' || form.paymentMethod === '') && (
-              <>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">ธนาคาร</label>
-                  <input
-                    type="text"
-                    value={form.bankName}
-                    onChange={(e) => setForm({ ...form, bankName: e.target.value })}
-                    placeholder="เช่น กสิกรไทย, กรุงเทพ"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none"
-                  />
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-semibold text-gray-800">ข้อมูลการชำระเงิน</h3>
+                <button
+                  type="button"
+                  onClick={addPaymentMethod}
+                  className="px-3 py-1 text-xs bg-blue-50 text-blue-600 rounded-lg hover:bg-blue-100 transition-colors font-medium"
+                >
+                  + เพิ่มวิธีชำระเงิน
+                </button>
+              </div>
+
+              {paymentMethods.length === 0 && (
+                <p className="text-sm text-gray-400 text-center py-3 bg-gray-50 rounded-lg">ยังไม่มีข้อมูลการชำระเงิน กดปุ่ม "เพิ่มวิธีชำระเงิน" เพื่อเพิ่ม</p>
+              )}
+
+              {paymentMethods.map((pm, index) => (
+                <div key={index} className="border border-gray-200 rounded-lg p-3 mb-3 bg-gray-50">
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-semibold text-gray-500">วิธีที่ {index + 1}</span>
+                      <label className="flex items-center gap-1 cursor-pointer">
+                        <input
+                          type="radio"
+                          name="defaultPayment"
+                          checked={pm.isDefault}
+                          onChange={() => updatePaymentMethod(index, 'isDefault', true)}
+                          className="text-blue-600"
+                        />
+                        <span className="text-xs text-gray-500">ค่าเริ่มต้น</span>
+                      </label>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removePaymentMethod(index)}
+                      className="text-red-400 hover:text-red-600 text-xs font-medium"
+                    >
+                      ลบ
+                    </button>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">วิธีชำระเงิน *</label>
+                      <select
+                        value={pm.paymentMethod}
+                        onChange={(e) => updatePaymentMethod(index, 'paymentMethod', e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none text-sm"
+                        required
+                      >
+                        <option value="">-- เลือก --</option>
+                        <option value="CASH">เงินสด</option>
+                        <option value="BANK_TRANSFER">โอนธนาคาร</option>
+                        <option value="CHECK">เช็ค</option>
+                        <option value="CREDIT">เครดิต</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">เครดิต (วัน)</label>
+                      <input
+                        type="number"
+                        value={pm.creditTermDays}
+                        onChange={(e) => updatePaymentMethod(index, 'creditTermDays', e.target.value)}
+                        placeholder="เช่น 30"
+                        min={0}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none text-sm"
+                      />
+                    </div>
+                    {(pm.paymentMethod === 'BANK_TRANSFER' || pm.paymentMethod === 'CHECK') && (
+                      <>
+                        <div>
+                          <label className="block text-xs text-gray-500 mb-1">ธนาคาร</label>
+                          <input
+                            type="text"
+                            value={pm.bankName}
+                            onChange={(e) => updatePaymentMethod(index, 'bankName', e.target.value)}
+                            placeholder="เช่น กสิกรไทย, กรุงเทพ"
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-500 mb-1">ชื่อบัญชี</label>
+                          <input
+                            type="text"
+                            value={pm.bankAccountName}
+                            onChange={(e) => updatePaymentMethod(index, 'bankAccountName', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none text-sm"
+                          />
+                        </div>
+                        <div className="col-span-2">
+                          <label className="block text-xs text-gray-500 mb-1">เลขบัญชี</label>
+                          <input
+                            type="text"
+                            value={pm.bankAccountNumber}
+                            onChange={(e) => updatePaymentMethod(index, 'bankAccountNumber', e.target.value)}
+                            placeholder="XXX-X-XXXXX-X"
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none text-sm"
+                          />
+                        </div>
+                      </>
+                    )}
+                  </div>
                 </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">ชื่อบัญชี</label>
-                  <input
-                    type="text"
-                    value={form.bankAccountName}
-                    onChange={(e) => setForm({ ...form, bankAccountName: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none"
-                  />
-                </div>
-                <div className="col-span-2">
-                  <label className="block text-sm font-medium text-gray-700 mb-1">เลขบัญชี</label>
-                  <input
-                    type="text"
-                    value={form.bankAccountNumber}
-                    onChange={(e) => setForm({ ...form, bankAccountNumber: e.target.value })}
-                    placeholder="XXX-X-XXXXX-X"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none"
-                  />
-                </div>
-              </>
-            )}
+              ))}
+            </div>
+
             <div className="col-span-2">
               <AddressForm value={supplierAddress} onChange={setSupplierAddress} label="ที่อยู่" />
             </div>


### PR DESCRIPTION
- Replace single paymentMethod field on Supplier with SupplierPaymentMethod table
- Each supplier can now have multiple payment methods (CASH, BANK_TRANSFER, CHECK, CREDIT)
- Each payment method stores bank info and credit term days independently
- One payment method can be marked as default (isDefault)
- Migration migrates existing single payment data to new table
- Frontend: add/remove payment method cards in create/edit modal
- SupplierDetailPage: show all payment methods with default badge
- PurchaseOrdersPage: auto-fill from supplier's default payment method
- Fix internal server error on supplier creation by removing invalid columns

https://claude.ai/code/session_019iSm9bFAoXEDBy9Wge7MR3