### PR TITLE
fix(pos): improve product/customer search UX and add sales history page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,6 +37,7 @@ const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
 const ExchangePage = lazy(() => import('@/pages/ExchangePage'));
 const AuditLogsPage = lazy(() => import('@/pages/AuditLogsPage'));
 const POSPage = lazy(() => import('@/pages/POSPage'));
+const SalesHistoryPage = lazy(() => import('@/pages/SalesHistoryPage'));
 
 const PageLoader = () => (
   <div className="flex items-center justify-center py-20">
@@ -106,6 +107,7 @@ function App() {
           <Route path="/inspections/:id" element={<InspectionDetailPage />} />
           <Route path="/stickers" element={<StickerPrintPage />} />
           <Route path="/pos" element={<POSPage />} />
+          <Route path="/sales" element={<SalesHistoryPage />} />
           <Route path="/customers" element={<CustomersPage />} />
           <Route path="/customers/:id" element={<CustomerDetailPage />} />
           <Route path="/contracts" element={<ContractsPage />} />

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -24,6 +24,7 @@ const navItems: NavItem[] = [
 
   // ขาย & ผ่อนชำระ — ใช้ทุกวัน
   { label: 'POS ขายสินค้า', path: '/pos', section: 'sales' },
+  { label: 'ประวัติการขาย', path: '/sales', section: 'sales' },
   { label: 'ลูกค้า', path: '/customers', section: 'sales' },
   { label: 'สัญญาผ่อน', path: '/contracts', section: 'sales' },
   { label: 'ชำระเงิน', path: '/payments', section: 'sales' },

--- a/apps/web/src/pages/POSPage.tsx
+++ b/apps/web/src/pages/POSPage.tsx
@@ -87,7 +87,7 @@ export default function POSPage() {
   const [financeAmount, setFinanceAmount] = useState('');
 
   // Product search query
-  const { data: products } = useQuery<Product[]>({
+  const { data: products, isFetching: productsFetching } = useQuery<Product[]>({
     queryKey: ['pos-products', debouncedProductSearch],
     queryFn: async () => {
       if (!debouncedProductSearch || debouncedProductSearch.length < 2) return [];
@@ -100,7 +100,7 @@ export default function POSPage() {
   });
 
   // Customer search query
-  const { data: customers } = useQuery<Customer[]>({
+  const { data: customers, isFetching: customersFetching } = useQuery<Customer[]>({
     queryKey: ['pos-customers', debouncedCustomerSearch],
     queryFn: async () => {
       if (!debouncedCustomerSearch || debouncedCustomerSearch.length < 2) return [];
@@ -288,29 +288,40 @@ export default function POSPage() {
                   type="text"
                   value={productSearch}
                   onChange={(e) => setProductSearch(e.target.value)}
-                  placeholder="ค้นหา IMEI, ชื่อ, รุ่น..."
+                  placeholder="พิมพ์อย่างน้อย 2 ตัวอักษร เช่น IMEI, ชื่อ, รุ่น..."
                   className={inputClass}
                 />
-                {productSearch.length >= 2 && products && products.length > 0 && (
-                  <div className="absolute z-10 w-full mt-1 bg-white border rounded-lg shadow-lg max-h-60 overflow-y-auto">
-                    {products.map((p) => (
-                      <button
-                        key={p.id}
-                        onClick={() => handleSelectProduct(p)}
-                        className="w-full text-left px-3 py-2 hover:bg-gray-50 border-b last:border-b-0"
-                      >
-                        <div className="text-sm font-medium">{p.brand} {p.model}</div>
-                        <div className="text-xs text-gray-500">
-                          {p.imeiSerial && <span className="font-mono">IMEI: {p.imeiSerial}</span>}
-                          <span className="ml-2">{p.branch?.name}</span>
-                          {p.prices.find(pr => pr.isDefault) && (
-                            <span className="ml-2 text-primary-600 font-medium">
-                              {parseFloat(p.prices.find(pr => pr.isDefault)!.amount).toLocaleString()} ฿
-                            </span>
-                          )}
-                        </div>
-                      </button>
-                    ))}
+                {productSearch.length >= 2 && (
+                  <div className="absolute z-50 w-full mt-1 bg-white border rounded-lg shadow-lg max-h-60 overflow-y-auto">
+                    {productsFetching ? (
+                      <div className="px-3 py-4 text-center text-sm text-gray-500">
+                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary-600 mx-auto mb-2"></div>
+                        กำลังค้นหา...
+                      </div>
+                    ) : products && products.length > 0 ? (
+                      products.map((p) => (
+                        <button
+                          key={p.id}
+                          onClick={() => handleSelectProduct(p)}
+                          className="w-full text-left px-3 py-2 hover:bg-gray-50 border-b last:border-b-0"
+                        >
+                          <div className="text-sm font-medium">{p.brand} {p.model}</div>
+                          <div className="text-xs text-gray-500">
+                            {p.imeiSerial && <span className="font-mono">IMEI: {p.imeiSerial}</span>}
+                            <span className="ml-2">{p.branch?.name}</span>
+                            {p.prices.find(pr => pr.isDefault) && (
+                              <span className="ml-2 text-primary-600 font-medium">
+                                {parseFloat(p.prices.find(pr => pr.isDefault)!.amount).toLocaleString()} ฿
+                              </span>
+                            )}
+                          </div>
+                        </button>
+                      ))
+                    ) : (
+                      <div className="px-3 py-4 text-center text-sm text-gray-500">
+                        ไม่พบสินค้าที่ตรงกับ &quot;{productSearch}&quot;
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
@@ -334,21 +345,32 @@ export default function POSPage() {
                   type="text"
                   value={customerSearch}
                   onChange={(e) => setCustomerSearch(e.target.value)}
-                  placeholder="ค้นหาชื่อ, เบอร์โทร, เลขบัตร..."
+                  placeholder="พิมพ์อย่างน้อย 2 ตัวอักษร เช่น ชื่อ, เบอร์โทร, เลขบัตร..."
                   className={inputClass}
                 />
-                {customerSearch.length >= 2 && customers && customers.length > 0 && (
-                  <div className="absolute z-10 w-full mt-1 bg-white border rounded-lg shadow-lg max-h-60 overflow-y-auto">
-                    {customers.map((c) => (
-                      <button
-                        key={c.id}
-                        onClick={() => { setSelectedCustomer(c); setCustomerSearch(''); }}
-                        className="w-full text-left px-3 py-2 hover:bg-gray-50 border-b last:border-b-0"
-                      >
-                        <div className="text-sm font-medium">{c.name}</div>
-                        <div className="text-xs text-gray-500">{c.phone}</div>
-                      </button>
-                    ))}
+                {customerSearch.length >= 2 && (
+                  <div className="absolute z-50 w-full mt-1 bg-white border rounded-lg shadow-lg max-h-60 overflow-y-auto">
+                    {customersFetching ? (
+                      <div className="px-3 py-4 text-center text-sm text-gray-500">
+                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary-600 mx-auto mb-2"></div>
+                        กำลังค้นหา...
+                      </div>
+                    ) : customers && customers.length > 0 ? (
+                      customers.map((c) => (
+                        <button
+                          key={c.id}
+                          onClick={() => { setSelectedCustomer(c); setCustomerSearch(''); }}
+                          className="w-full text-left px-3 py-2 hover:bg-gray-50 border-b last:border-b-0"
+                        >
+                          <div className="text-sm font-medium">{c.name}</div>
+                          <div className="text-xs text-gray-500">{c.phone}</div>
+                        </button>
+                      ))
+                    ) : (
+                      <div className="px-3 py-4 text-center text-sm text-gray-500">
+                        ไม่พบลูกค้าที่ตรงกับ &quot;{customerSearch}&quot;
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/apps/web/src/pages/SalesHistoryPage.tsx
+++ b/apps/web/src/pages/SalesHistoryPage.tsx
@@ -1,0 +1,215 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import api from '@/lib/api';
+import PageHeader from '@/components/ui/PageHeader';
+import DataTable from '@/components/ui/DataTable';
+
+interface Sale {
+  id: string;
+  saleNumber: string;
+  saleType: string;
+  sellingPrice: string;
+  discount: string;
+  netAmount: string;
+  paymentMethod: string;
+  amountReceived: string;
+  financeCompany: string | null;
+  notes: string | null;
+  createdAt: string;
+  customer: { id: string; name: string; phone: string };
+  product: { id: string; name: string; brand: string; model: string; imeiSerial: string | null };
+  branch: { id: string; name: string };
+  salesperson: { id: string; name: string };
+}
+
+interface SalesResponse {
+  data: Sale[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+const saleTypeLabels: Record<string, { label: string; className: string }> = {
+  CASH: { label: 'เงินสด', className: 'bg-green-100 text-green-700' },
+  INSTALLMENT: { label: 'ผ่อนร้าน', className: 'bg-blue-100 text-blue-700' },
+  EXTERNAL_FINANCE: { label: 'ไฟแนนซ์', className: 'bg-purple-100 text-purple-700' },
+};
+
+const paymentMethodLabels: Record<string, string> = {
+  CASH: 'เงินสด',
+  BANK_TRANSFER: 'โอนเงิน',
+  QR_EWALLET: 'QR/E-Wallet',
+};
+
+export default function SalesHistoryPage() {
+  const navigate = useNavigate();
+  const [saleTypeFilter, setSaleTypeFilter] = useState('');
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const limit = 20;
+
+  const { data: salesData, isLoading } = useQuery<SalesResponse>({
+    queryKey: ['sales-history', saleTypeFilter, search, page],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (saleTypeFilter) params.set('saleType', saleTypeFilter);
+      if (search) params.set('search', search);
+      params.set('page', String(page));
+      params.set('limit', String(limit));
+      const { data } = await api.get(`/sales?${params}`);
+      return data;
+    },
+  });
+
+  const columns = useMemo(() => [
+    {
+      key: 'saleNumber',
+      label: 'เลขที่',
+      render: (s: Sale) => (
+        <span className="font-mono text-sm text-primary-600 font-medium">{s.saleNumber}</span>
+      ),
+    },
+    {
+      key: 'createdAt',
+      label: 'วันที่',
+      render: (s: Sale) => (
+        <div>
+          <div className="text-sm">{new Date(s.createdAt).toLocaleDateString('th-TH')}</div>
+          <div className="text-xs text-gray-400">{new Date(s.createdAt).toLocaleTimeString('th-TH', { hour: '2-digit', minute: '2-digit' })}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'saleType',
+      label: 'ประเภท',
+      render: (s: Sale) => {
+        const st = saleTypeLabels[s.saleType] || { label: s.saleType, className: 'bg-gray-100 text-gray-700' };
+        return <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${st.className}`}>{st.label}</span>;
+      },
+    },
+    {
+      key: 'product',
+      label: 'สินค้า',
+      render: (s: Sale) => (
+        <div>
+          <div className="text-sm font-medium">{s.product.brand} {s.product.model}</div>
+          {s.product.imeiSerial && <div className="text-xs text-gray-400 font-mono">{s.product.imeiSerial}</div>}
+        </div>
+      ),
+    },
+    {
+      key: 'customer',
+      label: 'ลูกค้า',
+      render: (s: Sale) => (
+        <div>
+          <div className="text-sm">{s.customer.name}</div>
+          <div className="text-xs text-gray-400">{s.customer.phone}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'netAmount',
+      label: 'ยอดสุทธิ',
+      render: (s: Sale) => (
+        <span className="text-sm font-medium">{Number(s.netAmount).toLocaleString()} ฿</span>
+      ),
+    },
+    {
+      key: 'paymentMethod',
+      label: 'วิธีชำระ',
+      render: (s: Sale) => (
+        <div>
+          <div className="text-xs">{paymentMethodLabels[s.paymentMethod] || s.paymentMethod}</div>
+          {s.financeCompany && <div className="text-xs text-purple-600">{s.financeCompany}</div>}
+        </div>
+      ),
+    },
+    {
+      key: 'salesperson',
+      label: 'พนักงาน',
+      render: (s: Sale) => <span className="text-xs">{s.salesperson.name}</span>,
+    },
+    {
+      key: 'branch',
+      label: 'สาขา',
+      render: (s: Sale) => <span className="text-xs">{s.branch.name}</span>,
+    },
+  ], []);
+
+  // Summary stats
+  const stats = useMemo(() => {
+    if (!salesData?.data) return null;
+    const sales = salesData.data;
+    const totalRevenue = sales.reduce((sum, s) => sum + Number(s.netAmount), 0);
+    const cashCount = sales.filter(s => s.saleType === 'CASH').length;
+    const installmentCount = sales.filter(s => s.saleType === 'INSTALLMENT').length;
+    const financeCount = sales.filter(s => s.saleType === 'EXTERNAL_FINANCE').length;
+    return { totalRevenue, cashCount, installmentCount, financeCount };
+  }, [salesData]);
+
+  return (
+    <div>
+      <PageHeader title="ประวัติการขาย" subtitle="ดูรายการขายทั้งหมด" />
+
+      {/* Summary Cards */}
+      {stats && salesData && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          <div className="bg-white rounded-lg border p-4">
+            <div className="text-xs text-gray-500 mb-1">ทั้งหมด</div>
+            <div className="text-xl font-bold">{salesData.total.toLocaleString()} <span className="text-sm font-normal text-gray-400">รายการ</span></div>
+          </div>
+          <div className="bg-white rounded-lg border p-4">
+            <div className="text-xs text-gray-500 mb-1">เงินสด</div>
+            <div className="text-xl font-bold text-green-600">{stats.cashCount}</div>
+          </div>
+          <div className="bg-white rounded-lg border p-4">
+            <div className="text-xs text-gray-500 mb-1">ผ่อนร้าน</div>
+            <div className="text-xl font-bold text-blue-600">{stats.installmentCount}</div>
+          </div>
+          <div className="bg-white rounded-lg border p-4">
+            <div className="text-xs text-gray-500 mb-1">ไฟแนนซ์</div>
+            <div className="text-xl font-bold text-purple-600">{stats.financeCount}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 mb-4">
+        <select
+          value={saleTypeFilter}
+          onChange={(e) => { setSaleTypeFilter(e.target.value); setPage(1); }}
+          className="px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+        >
+          <option value="">ทุกประเภท</option>
+          <option value="CASH">เงินสด</option>
+          <option value="INSTALLMENT">ผ่อนร้าน</option>
+          <option value="EXTERNAL_FINANCE">ไฟแนนซ์</option>
+        </select>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+          placeholder="ค้นหาเลขที่ขาย, ชื่อลูกค้า, ชื่อสินค้า..."
+          className="px-3 py-2 border border-gray-300 rounded-lg text-sm w-72"
+        />
+      </div>
+
+      {/* Sales Table */}
+      <DataTable
+        columns={columns}
+        data={salesData?.data || []}
+        isLoading={isLoading}
+        emptyMessage="ยังไม่มีรายการขาย"
+        onRowClick={(sale) => navigate(`/products/${sale.product.id}`)}
+        pagination={salesData ? {
+          page: salesData.page,
+          totalPages: salesData.totalPages,
+          total: salesData.total,
+          onPageChange: setPage,
+        } : undefined}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
POS search dropdown fixes:
- Add loading spinner while searching products/customers
- Show "not found" message when search returns empty results
- Improve placeholder text to hint minimum 2 characters
- Increase dropdown z-index from z-10 to z-50 to prevent overlapping

Sales history page:
- New /sales route with SalesHistoryPage showing all completed sales
- Table with sale number, date, type, product, customer, amount, payment method
- Filter by sale type (cash/installment/finance) and text search
- Pagination support using existing GET /sales API
- Summary stats cards showing totals by type
- Added "ประวัติการขาย" to sidebar navigation under sales section

https://claude.ai/code/session_013P3pQGzgHBx6BUUg6oLtQv