### PR TITLE
fix: แก้ OCR ไม่ทำงาน - env path และ timeout

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -42,7 +42,7 @@ import { SecurityMiddleware } from './modules/audit/security.middleware';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: '../../.env',
+      envFilePath: ['.env', '../../.env'],
     }),
     ScheduleModule.forRoot(),
     ThrottlerModule.forRoot([

--- a/apps/api/src/modules/ocr/ocr.service.ts
+++ b/apps/api/src/modules/ocr/ocr.service.ts
@@ -12,6 +12,9 @@ export class OcrService {
     const apiKey = this.configService.get<string>('ANTHROPIC_API_KEY');
     if (apiKey) {
       this.anthropic = new Anthropic({ apiKey });
+      this.logger.log('OCR service initialized with Anthropic API key');
+    } else {
+      this.logger.warn('ANTHROPIC_API_KEY not configured — OCR features will be unavailable');
     }
   }
 

--- a/apps/web/src/components/contract/DocumentUpload.tsx
+++ b/apps/web/src/components/contract/DocumentUpload.tsx
@@ -120,7 +120,7 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
         reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
         reader.readAsDataURL(file);
       });
-      const { data } = await api.post('/ocr/id-card', { imageBase64 });
+      const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
       setOcrResult(data);
       setShowOcrPanel(true);
       const pct = (data.confidence * 100).toFixed(0);

--- a/apps/web/src/pages/ContractCreatePage.tsx
+++ b/apps/web/src/pages/ContractCreatePage.tsx
@@ -307,7 +307,7 @@ export default function ContractCreatePage() {
         reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
         reader.readAsDataURL(file);
       });
-      const { data } = await api.post('/ocr/id-card', { imageBase64 });
+      const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
       setOcrResult(data);
       setShowOcrPanel(true);
 
@@ -468,7 +468,7 @@ export default function ContractCreatePage() {
             reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
             reader.readAsDataURL(file);
           });
-          const { data } = await api.post('/ocr/id-card', { imageBase64 });
+          const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
           setOcrResult(data);
           setShowOcrPanel(true);
           setShowCreateCustomer(false);

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -199,7 +199,7 @@ export default function CustomersPage() {
         reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
         reader.readAsDataURL(file);
       });
-      const { data } = await api.post<OcrResult>('/ocr/id-card', { imageBase64 });
+      const { data } = await api.post<OcrResult>('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
 
       // Auto-fill form fields
       const updates: Partial<typeof emptyForm> = {};


### PR DESCRIPTION
1. ConfigModule envFilePath รองรับทั้ง cwd=root (.env) และ cwd=apps/api (../../.env) แก้ปัญหา ANTHROPIC_API_KEY ไม่ถูกโหลด → "ระบบ OCR ยังไม่พร้อมใช้งาน"

2. เพิ่ม timeout OCR requests เป็น 60 วินาที (จากเดิม 15 วินาที) Claude Vision API ใช้เวลาประมวลผลนาน → "เซิร์ฟเวอร์ไม่ตอบสนอง"

3. เพิ่ม log เมื่อ OCR service เริ่มต้น เพื่อ debug ง่ายขึ้น

https://claude.ai/code/session_01KoqYXT5ZtceFpD6Mgjeh41