### PR TITLE
fix: fallback to process.env for ANTHROPIC_API_KEY in Docker

### DIFF
--- a/apps/api/src/modules/credit-check/credit-check.service.ts
+++ b/apps/api/src/modules/credit-check/credit-check.service.ts
@@ -14,7 +14,9 @@ export class CreditCheckService {
     private prisma: PrismaService,
     private configService: ConfigService,
   ) {
-    const apiKey = this.configService.get<string>('ANTHROPIC_API_KEY');
+    const apiKey =
+      this.configService.get<string>('ANTHROPIC_API_KEY') ||
+      process.env.ANTHROPIC_API_KEY;
     if (apiKey) {
       this.anthropic = new Anthropic({ apiKey });
     }

--- a/apps/api/src/modules/ocr/ocr.service.ts
+++ b/apps/api/src/modules/ocr/ocr.service.ts
@@ -9,7 +9,9 @@ export class OcrService {
   private anthropic: Anthropic | null = null;
 
   constructor(private configService: ConfigService) {
-    const apiKey = this.configService.get<string>('ANTHROPIC_API_KEY');
+    const apiKey =
+      this.configService.get<string>('ANTHROPIC_API_KEY') ||
+      process.env.ANTHROPIC_API_KEY;
     if (apiKey) {
       this.anthropic = new Anthropic({ apiKey });
       this.logger.log('OCR service initialized with Anthropic API key');


### PR DESCRIPTION
ConfigService may not find env vars when .env file is not present in Docker container. Add process.env fallback for both OcrService and CreditCheckService.

https://claude.ai/code/session_01KoqYXT5ZtceFpD6Mgjeh41