### PR TITLE
fix: OCR timeout — compress images, fix nginx limits, add AI proxy ti…

### DIFF
--- a/apps/web/src/components/contract/DocumentUpload.tsx
+++ b/apps/web/src/components/contract/DocumentUpload.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
+import { compressImageForOcr } from '@/lib/compressImage';
 import toast from 'react-hot-toast';
 
 interface ContractDocument {
@@ -114,13 +115,8 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
   const performOcr = async (file: File) => {
     setOcrLoading(true);
     try {
-      const reader = new FileReader();
-      const imageBase64 = await new Promise<string>((resolve, reject) => {
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
-        reader.readAsDataURL(file);
-      });
-      const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
+      const imageBase64 = await compressImageForOcr(file);
+      const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 90000 });
       setOcrResult(data);
       setShowOcrPanel(true);
       const pct = (data.confidence * 100).toFixed(0);

--- a/apps/web/src/lib/compressImage.ts
+++ b/apps/web/src/lib/compressImage.ts
@@ -1,0 +1,43 @@
+/**
+ * Compress an image file to a base64 data URL suitable for OCR.
+ * Resizes to maxWidth (default 1600px) and compresses as JPEG (quality 0.8).
+ * ID cards don't need full-resolution photos — 1600px is plenty for Claude Vision.
+ */
+export function compressImageForOcr(
+  file: File,
+  maxWidth = 1600,
+  quality = 0.8,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      let { width, height } = img;
+
+      // Only downscale, never upscale
+      if (width > maxWidth) {
+        height = Math.round((height * maxWidth) / width);
+        width = maxWidth;
+      }
+
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Canvas not supported'));
+        return;
+      }
+      ctx.drawImage(img, 0, 0, width, height);
+
+      const dataUrl = canvas.toDataURL('image/jpeg', quality);
+      URL.revokeObjectURL(img.src);
+      resolve(dataUrl);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(img.src);
+      reject(new Error('ไม่สามารถอ่านไฟล์รูปภาพได้'));
+    };
+    img.src = URL.createObjectURL(file);
+  });
+}

--- a/apps/web/src/pages/ContractCreatePage.tsx
+++ b/apps/web/src/pages/ContractCreatePage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import api from '@/lib/api';
+import { compressImageForOcr } from '@/lib/compressImage';
 import PageHeader from '@/components/ui/PageHeader';
 import toast from 'react-hot-toast';
 
@@ -301,13 +302,8 @@ export default function ContractCreatePage() {
     setOcrScannedFile(file);
 
     try {
-      const reader = new FileReader();
-      const imageBase64 = await new Promise<string>((resolve, reject) => {
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
-        reader.readAsDataURL(file);
-      });
-      const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
+      const imageBase64 = await compressImageForOcr(file);
+      const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 90000 });
       setOcrResult(data);
       setShowOcrPanel(true);
 
@@ -462,13 +458,8 @@ export default function ContractCreatePage() {
       (async () => {
         setOcrLoading(true);
         try {
-          const reader = new FileReader();
-          const imageBase64 = await new Promise<string>((resolve, reject) => {
-            reader.onload = () => resolve(reader.result as string);
-            reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
-            reader.readAsDataURL(file);
-          });
-          const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
+          const imageBase64 = await compressImageForOcr(file);
+          const { data } = await api.post('/ocr/id-card', { imageBase64 }, { timeout: 90000 });
           setOcrResult(data);
           setShowOcrPanel(true);
           setShowCreateCustomer(false);

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import api, { getErrorMessage } from '@/lib/api';
+import { compressImageForOcr } from '@/lib/compressImage';
 import { useDebounce } from '@/hooks/useDebounce';
 import PageHeader from '@/components/ui/PageHeader';
 import DataTable from '@/components/ui/DataTable';
@@ -193,13 +194,8 @@ export default function CustomersPage() {
 
     setOcrLoading(true);
     try {
-      const reader = new FileReader();
-      const imageBase64 = await new Promise<string>((resolve, reject) => {
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
-        reader.readAsDataURL(file);
-      });
-      const { data } = await api.post<OcrResult>('/ocr/id-card', { imageBase64 }, { timeout: 60000 });
+      const imageBase64 = await compressImageForOcr(file);
+      const { data } = await api.post<OcrResult>('/ocr/id-card', { imageBase64 }, { timeout: 90000 });
 
       // Auto-fill form fields
       const updates: Partial<typeof emptyForm> = {};

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -26,8 +26,8 @@ server {
     gzip_comp_level 6;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
 
-    # Max body size for file uploads
-    client_max_body_size 10M;
+    # Max body size for file uploads (must match API's 20MB limit + JSON overhead)
+    client_max_body_size 25M;
 
     # API proxy
     location /api/ {
@@ -43,6 +43,33 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 60s;
+        proxy_connect_timeout 10s;
+    }
+
+    # OCR & Credit Check — longer timeout for AI processing
+    location /api/ocr/ {
+        limit_req zone=api_limit burst=10 nodelay;
+
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 10s;
+    }
+
+    location /api/credit-check/ {
+        limit_req zone=api_limit burst=10 nodelay;
+
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
         proxy_connect_timeout 10s;
     }
 


### PR DESCRIPTION
…meout

- Add compressImageForOcr() util: resize to 1600px + JPEG 0.8 before sending
- Fix nginx client_max_body_size 10M → 25M (was blocking 20MB API limit)
- Add separate nginx locations for /api/ocr/ and /api/credit-check/ with 120s proxy_read_timeout
- Increase frontend axios timeout to 90s for OCR calls
- Fixes "เซิร์ฟเวอร์ไม่ตอบสนอง" error caused by nginx 413 + proxy timeout

https://claude.ai/code/session_01KoqYXT5ZtceFpD6Mgjeh41