### PR TITLE
fix: add contents:write permission to card reader workflow

### DIFF
--- a/.github/workflows/build-card-reader.yml
+++ b/.github/workflows/build-card-reader.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: 'dev'
 
+permissions:
+  contents: write
+
 env:
   NODE_VERSION: '20'
 


### PR DESCRIPTION
GitHub Actions needs explicit write permission to create releases.

https://claude.ai/code/session_01QR6KtGGCWQS7gyXUqHUX8e