### PR TITLE
fix: include pcsclite native module in card reader distribution

### DIFF
--- a/.github/workflows/build-card-reader.yml
+++ b/.github/workflows/build-card-reader.yml
@@ -73,9 +73,12 @@ jobs:
           # Copy portable Node.js
           Copy-Item -Recurse apps/card-reader/bundle/node $dist/node
 
-          # Copy bundled app (single file, no node_modules needed)
+          # Copy bundled app
           New-Item -ItemType Directory -Force -Path $dist/app/dist
           Copy-Item apps/card-reader/dist/index.js $dist/app/dist/index.js
+
+          # Copy pcsclite native module (required for smart card reader access)
+          Copy-Item -Recurse apps/card-reader/node_modules $dist/app/node_modules
 
           # Copy scripts
           Copy-Item apps/card-reader/scripts/BestchoiceCardReader.bat $dist/

--- a/apps/card-reader/scripts/BestchoiceCardReader.bat
+++ b/apps/card-reader/scripts/BestchoiceCardReader.bat
@@ -41,7 +41,9 @@ echo  ║   กดปุ่ม Ctrl+C เพื่อหยุดโปรแก
 echo  ╚══════════════════════════════════════════════════╝
 echo.
 
-"%NODE%" "%APP%"
+:: Change to app directory so Node.js can find node_modules/pcsclite
+cd /d "%ROOT%app"
+"%NODE%" "dist\index.js"
 
 if %ERRORLEVEL% neq 0 (
     echo.


### PR DESCRIPTION
The pcsclite module was marked as external in esbuild but was not copied to the distribution package. This caused require('pcsclite') to fail at runtime, resulting in "no_pcsc" status even when Windows Smart Card Service was running properly.

- Copy node_modules to distribution so pcsclite native addon is available
- Change working directory to app/ before running Node.js so require() can resolve node_modules/pcsclite correctly

https://claude.ai/code/session_01QR6KtGGCWQS7gyXUqHUX8e