### PR TITLE
fix(card-reader): fix pcsclite native module not found in distribution

### DIFF
--- a/.github/workflows/build-card-reader.yml
+++ b/.github/workflows/build-card-reader.yml
@@ -46,9 +46,9 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Install dependencies
+      - name: Install dependencies (isolated, no hoisting)
         working-directory: apps/card-reader
-        run: npm install
+        run: npm install --install-strategy=nested
 
       - name: Bundle with esbuild
         working-directory: apps/card-reader
@@ -77,8 +77,18 @@ jobs:
           New-Item -ItemType Directory -Force -Path $dist/app/dist
           Copy-Item apps/card-reader/dist/index.js $dist/app/dist/index.js
 
-          # Copy pcsclite native module (required for smart card reader access)
-          Copy-Item -Recurse apps/card-reader/node_modules $dist/app/node_modules
+          # Copy only pcsclite and its required dependencies (bindings, file-uri-to-path)
+          New-Item -ItemType Directory -Force -Path $dist/app/node_modules
+          $requiredModules = @("pcsclite", "bindings", "file-uri-to-path", "nan")
+          foreach ($mod in $requiredModules) {
+            $src = "apps/card-reader/node_modules/$mod"
+            if (Test-Path $src) {
+              Copy-Item -Recurse $src "$dist/app/node_modules/$mod"
+              Write-Host "Copied $mod"
+            } else {
+              Write-Host "WARNING: $mod not found at $src"
+            }
+          }
 
           # Copy scripts
           Copy-Item apps/card-reader/scripts/BestchoiceCardReader.bat $dist/

--- a/apps/card-reader/src/index.ts
+++ b/apps/card-reader/src/index.ts
@@ -113,6 +113,10 @@ function initPCSC(): void {
     readerStatus = 'no_pcsc';
     readerError = err.message || 'ไม่สามารถเริ่ม PC/SC service ได้';
     console.error('[Card Reader] Failed to initialize PC/SC:', err.message);
+    if (err.code === 'MODULE_NOT_FOUND') {
+      console.error('[Card Reader] Missing module — check that pcsclite and bindings are in node_modules');
+      console.error('[Card Reader] Module search paths:', module.paths);
+    }
   }
 }
 


### PR DESCRIPTION
The pcsclite dependencies (bindings, file-uri-to-path) were being hoisted to the monorepo root by npm workspaces, so they were missing from the distribution ZIP. Fix by using --install-strategy=nested to keep all deps local, and copy only the required native modules instead of all node_modules.

https://claude.ai/code/session_01QR6KtGGCWQS7gyXUqHUX8e