### PR TITLE
fix(ci): remove --ignore-scripts to allow pcsclite native compilation

### DIFF
--- a/.github/workflows/build-card-reader.yml
+++ b/.github/workflows/build-card-reader.yml
@@ -46,13 +46,9 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Install dependencies (standalone, outside workspace)
+      - name: Install dependencies
         working-directory: apps/card-reader
-        run: |
-          npm install --install-strategy=nested --ignore-scripts
-          npm install pcsclite --install-strategy=nested
-        env:
-          npm_config_ignore_workspace_root_check: true
+        run: npm install --install-strategy=nested
 
       - name: Verify pcsclite native module
         working-directory: apps/card-reader


### PR DESCRIPTION
The --ignore-scripts flag prevented node-gyp from compiling the pcsclite native addon (.node binary), causing the verify step to fail.

https://claude.ai/code/session_01QR6KtGGCWQS7gyXUqHUX8e