### PR TITLE
Fix: handle SW 61XX (GET RESPONSE) in APDU transmit

### DIFF
--- a/apps/card-reader/src/thai-smart-card.ts
+++ b/apps/card-reader/src/thai-smart-card.ts
@@ -116,14 +116,43 @@ function parseAddress(raw: string): ThaiIdCardData['addressStructured'] & { full
   return { ...structured, fullAddress };
 }
 
-/** Transmit an APDU command to the card and return the response data */
-function transmit(reader: any, protocol: number, cmd: Buffer): Promise<Buffer> {
+/** Transmit a single APDU to the card (low-level, no GET RESPONSE handling) */
+function transmitRaw(reader: any, protocol: number, cmd: Buffer, receiveLen: number = 256): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    reader.transmit(cmd, 256, protocol, (err: Error | null, data: Buffer) => {
+    reader.transmit(cmd, receiveLen, protocol, (err: Error | null, data: Buffer) => {
       if (err) return reject(err);
       resolve(data);
     });
   });
+}
+
+/**
+ * Transmit an APDU command to the card, automatically handling SW 61XX
+ * (GET RESPONSE chaining) so the caller always gets the full response.
+ */
+async function transmit(reader: any, protocol: number, cmd: Buffer): Promise<Buffer> {
+  let response = await transmitRaw(reader, protocol, cmd);
+
+  // Handle SW 61XX: "XX bytes available — use GET RESPONSE to fetch"
+  while (response.length >= 2) {
+    const sw1 = response[response.length - 2];
+    const sw2 = response[response.length - 1];
+
+    if (sw1 !== 0x61) break;
+
+    const getResponseCmd = Buffer.from([0x00, 0xC0, 0x00, 0x00, sw2]);
+    const dataBeforeSW = response.subarray(0, response.length - 2);
+    const nextResponse = await transmitRaw(reader, protocol, getResponseCmd, sw2 + 2);
+
+    // Concatenate any data from the previous response with the GET RESPONSE data
+    if (dataBeforeSW.length > 0) {
+      response = Buffer.concat([dataBeforeSW, nextResponse]);
+    } else {
+      response = nextResponse;
+    }
+  }
+
+  return response;
 }
 
 /** Get the 2-byte status word from a response */


### PR DESCRIPTION
SW 610A means "10 bytes available via GET RESPONSE", not an error. The SELECT command was incorrectly treated as failed. Now transmit() automatically chains GET RESPONSE (00 C0 00 00 XX) to retrieve pending data when the card returns SW1=61.

https://claude.ai/code/session_01QR6KtGGCWQS7gyXUqHUX8e