### PR TITLE
refactor: move supplier page from inventory tabs to system section

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,6 +35,7 @@ const POSPage = lazy(() => import('@/pages/POSPage'));
 const SalesHistoryPage = lazy(() => import('@/pages/SalesHistoryPage'));
 const InterestConfigPage = lazy(() => import('@/pages/InterestConfigPage'));
 const CreditChecksPage = lazy(() => import('@/pages/CreditChecksPage'));
+const SuppliersPage = lazy(() => import('@/pages/SuppliersPage'));
 const InventoryWorkflowPage = lazy(() => import('@/pages/InventoryWorkflowPage'));
 
 const PageLoader = () => (
@@ -92,7 +93,14 @@ function App() {
 
           {/* Redirect old inventory routes to unified page */}
           <Route path="/stock" element={<Navigate to="/inventory?tab=stock" replace />} />
-          <Route path="/suppliers" element={<Navigate to="/inventory?tab=suppliers" replace />} />
+          <Route
+            path="/suppliers"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER']}>
+                <SuppliersPage />
+              </ProtectedRoute>
+            }
+          />
           <Route path="/purchase-orders" element={<Navigate to="/inventory?tab=purchase-orders" replace />} />
           <Route path="/inspections" element={<Navigate to="/inventory?tab=inspections" replace />} />
           <Route path="/products" element={<Navigate to="/inventory?tab=products" replace />} />

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -61,6 +61,7 @@ const navItems: NavItem[] = [
   { label: 'แจ้งเตือน', path: '/notifications', roles: ['OWNER', 'BRANCH_MANAGER'], section: 'reports' },
 
   // ระบบ (OWNER)
+  { label: 'Supplier', path: '/suppliers', roles: ['OWNER', 'BRANCH_MANAGER'], section: 'system' },
   { label: 'สาขา', path: '/branches', roles: ['OWNER'], section: 'system' },
   { label: 'จัดการผู้ใช้', path: '/users', roles: ['OWNER'], section: 'system' },
   { label: 'ตั้งค่าระบบ', path: '/settings', roles: ['OWNER'], section: 'system' },

--- a/apps/web/src/pages/InventoryWorkflowPage.tsx
+++ b/apps/web/src/pages/InventoryWorkflowPage.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { useAuth } from '@/contexts/AuthContext';
 
 const StockPage = lazy(() => import('@/pages/StockPage'));
-const SuppliersPage = lazy(() => import('@/pages/SuppliersPage'));
+
 const PurchaseOrdersPage = lazy(() => import('@/pages/PurchaseOrdersPage'));
 const InspectionPage = lazy(() => import('@/pages/InspectionPage'));
 const ProductsPage = lazy(() => import('@/pages/ProductsPage'));
@@ -18,7 +18,7 @@ interface Tab {
 
 const allTabs: Tab[] = [
   { key: 'stock', label: 'สต็อก', roles: ['OWNER', 'BRANCH_MANAGER', 'ACCOUNTANT'] },
-  { key: 'suppliers', label: 'Supplier', roles: ['OWNER', 'BRANCH_MANAGER'] },
+
   { key: 'purchase-orders', label: 'สั่งซื้อ', roles: ['OWNER', 'BRANCH_MANAGER'] },
   { key: 'inspections', label: 'ตรวจเช็ค' },
   { key: 'products', label: 'สินค้าในคลัง' },
@@ -27,7 +27,7 @@ const allTabs: Tab[] = [
 
 const tabComponents: Record<string, React.LazyExoticComponent<() => JSX.Element>> = {
   'stock': StockPage,
-  'suppliers': SuppliersPage,
+
   'purchase-orders': PurchaseOrdersPage,
   'inspections': InspectionPage,
   'products': ProductsPage,


### PR DESCRIPTION
- Remove suppliers tab from InventoryWorkflowPage
- Add Supplier as standalone page under ระบบ section in sidebar
- Update route from redirect to direct SuppliersPage with role protection

https://claude.ai/code/session_01Cx28dpEfTUcz1iohG5yT3K