### PR TITLE
fix: use undefined instead of null for Prisma Json field checklistRes…

### DIFF
--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -677,7 +677,7 @@ export class PurchaseOrdersService {
               warrantyExpired: item.warrantyExpired ?? null,
               warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
               hasBox: item.hasBox ?? null,
-              checklistResults: item.checklistResults || null,
+              checklistResults: item.checklistResults ?? undefined,
               accessoryType: poItem.accessoryType || null,
               accessoryBrand: poItem.accessoryBrand || null,
             },
@@ -697,7 +697,7 @@ export class PurchaseOrdersService {
               warrantyExpired: item.warrantyExpired ?? null,
               warrantyExpireDate: item.warrantyExpireDate ? new Date(item.warrantyExpireDate) : null,
               hasBox: item.hasBox ?? null,
-              checklistResults: item.checklistResults || null,
+              checklistResults: item.checklistResults ?? undefined,
             },
           });
 


### PR DESCRIPTION
…ults

Prisma Json? fields don't accept raw null — must use Prisma.JsonNull or undefined. Using undefined skips the field entirely when no checklist is provided.

https://claude.ai/code/session_01Cx28dpEfTUcz1iohG5yT3K