### PR TITLE
fix: run prisma generate before nest build to ensure up-to-date client

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "nest build",
+    "build": "prisma generate && nest build",
     "dev": "nest start --watch",
     "start": "node dist/main",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
The build was failing because 'nest build' runs TypeScript compilation without first regenerating the Prisma client, so new fields like checklistResults were not recognized in the types.

https://claude.ai/code/session_01Cx28dpEfTUcz1iohG5yT3K