### PR TITLE
fix: add migration to remove condition_grade column from products table

### DIFF
--- a/apps/api/prisma/migrations/20260306000000_remove_condition_grade_from_product/migration.sql
+++ b/apps/api/prisma/migrations/20260306000000_remove_condition_grade_from_product/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "products" DROP COLUMN IF EXISTS "condition_grade";


### PR DESCRIPTION
Without this migration, prisma migrate deploy won't drop the column and the CI/CD deploy step will have schema drift.

https://claude.ai/code/session_01LcaqkVhxMTB9N6dzqPBKRS