### PR TITLE
fix: skip QC step - goods receiving sets status directly to PHOTO_PEN…

### DIFF
--- a/apps/api/src/modules/product-photos/product-photos.service.ts
+++ b/apps/api/src/modules/product-photos/product-photos.service.ts
@@ -4,7 +4,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 const ANGLES = ['front', 'back', 'left', 'right', 'top', 'bottom'] as const;
 type Angle = typeof ANGLES[number];
 
-const ALLOWED_UPLOAD_STATUSES = ['PHOTO_PENDING', 'IN_STOCK'];
+const ALLOWED_UPLOAD_STATUSES = ['PHOTO_PENDING', 'IN_STOCK', 'RESERVED'];
 
 @Injectable()
 export class ProductPhotosService {

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -656,7 +656,10 @@ export class PurchaseOrdersService {
             productName = nameParts.join(' ');
           }
 
-          // Create product for passed items → QC_PENDING (ต้องยืนยัน QC ก่อนเข้าคลัง)
+          // Create product for passed items
+          // PHONE_USED → PHOTO_PENDING (ต้องถ่ายรูป 6 มุมก่อนเข้าคลัง)
+          // PHONE_NEW / ACCESSORY → IN_STOCK (เข้าคลังได้เลย)
+          const initialStatus = productCategory === 'PHONE_USED' ? 'PHOTO_PENDING' : 'IN_STOCK';
           const product = await tx.product.create({
             data: {
               name: productName,
@@ -669,7 +672,7 @@ export class PurchaseOrdersService {
               supplierId: po.supplierId,
               poId: po.id,
               branchId: mainWarehouse!.id,
-              status: 'QC_PENDING',
+              status: initialStatus,
               imeiSerial: item.imeiSerial || null,
               serialNumber: item.serialNumber || null,
               photos: item.photos || [],

--- a/apps/web/src/components/product/ProductPhotosPanel.tsx
+++ b/apps/web/src/components/product/ProductPhotosPanel.tsx
@@ -210,7 +210,7 @@ export default function ProductPhotosPanel({
                 {ANGLE_LABELS[angle]}
               </div>
               {photo ? (
-                <div className="relative group">
+                <div className="relative">
                   <div
                     className="w-full aspect-[4/3] rounded overflow-hidden border border-green-300 cursor-pointer"
                     onClick={() => setPreviewPhoto({ angle, src: photo })}
@@ -221,21 +221,21 @@ export default function ProductPhotosPanel({
                       className="w-full h-full object-cover"
                     />
                   </div>
-                  {canEdit && !isCompleted && (
-                    <div className="absolute top-0.5 right-0.5 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  {canEdit && (
+                    <div className="flex gap-1 mt-1">
                       <button
                         onClick={() => triggerUpload(angle)}
-                        className="p-0.5 bg-white/90 rounded text-[10px] text-blue-600 hover:bg-white shadow-sm leading-none"
-                        title="เปลี่ยนรูป"
+                        disabled={uploadMutation.isPending || deleteMutation.isPending}
+                        className="flex-1 px-1 py-0.5 bg-blue-50 rounded text-[10px] text-blue-600 hover:bg-blue-100 font-medium disabled:opacity-50"
                       >
-                        แก้
+                        เปลี่ยน
                       </button>
                       <button
                         onClick={() => {
                           if (confirm(`ลบรูป${ANGLE_LABELS[angle]}?`)) deleteMutation.mutate(angle);
                         }}
-                        className="p-0.5 bg-white/90 rounded text-[10px] text-red-600 hover:bg-white shadow-sm leading-none"
-                        title="ลบรูป"
+                        disabled={deleteMutation.isPending}
+                        className="flex-1 px-1 py-0.5 bg-red-50 rounded text-[10px] text-red-600 hover:bg-red-100 font-medium disabled:opacity-50"
                       >
                         ลบ
                       </button>


### PR DESCRIPTION
…DING or IN_STOCK

When receiving goods, products now get their correct status immediately:
- PHONE_USED → PHOTO_PENDING (need 6-angle photos before stocking)
- PHONE_NEW / ACCESSORY → IN_STOCK (ready for sale immediately)

Previously all products were set to QC_PENDING requiring a separate confirm QC step, but inspection happens at the counter during receiving.

https://claude.ai/code/session_01LcaqkVhxMTB9N6dzqPBKRS