### PR TITLE
fix: add missing migration for dispatch fields on stock_transfers

### DIFF
--- a/apps/api/prisma/migrations/20260307100000_add_dispatch_fields_to_stock_transfers/migration.sql
+++ b/apps/api/prisma/migrations/20260307100000_add_dispatch_fields_to_stock_transfers/migration.sql
@@ -1,0 +1,8 @@
+-- Add dispatch/transit fields to stock_transfers
+ALTER TABLE "stock_transfers" ADD COLUMN "dispatched_by_id" TEXT;
+ALTER TABLE "stock_transfers" ADD COLUMN "dispatched_at" TIMESTAMP(3);
+ALTER TABLE "stock_transfers" ADD COLUMN "tracking_note" TEXT;
+ALTER TABLE "stock_transfers" ADD COLUMN "expected_delivery_date" TIMESTAMP(3);
+
+-- AddForeignKey for stock_transfers.dispatched_by_id
+ALTER TABLE "stock_transfers" ADD CONSTRAINT "stock_transfers_dispatched_by_id_fkey" FOREIGN KEY ("dispatched_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
The columns dispatched_by_id, dispatched_at, tracking_note, and expected_delivery_date were in the Prisma schema but had no migration, causing "column does not exist" errors during bulk transfer.

https://claude.ai/code/session_0181r1pNCMNF1CocjaRgctBJ