### PR TITLE
feat: group outgoing transfers by batch number with expandable details

### DIFF
--- a/apps/web/src/pages/StockTransfersPage.tsx
+++ b/apps/web/src/pages/StockTransfersPage.tsx
@@ -1,11 +1,10 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import clsx from 'clsx';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
-import DataTable from '@/components/ui/DataTable';
 import Modal from '@/components/ui/Modal';
 import { transferStatusLabels } from '@/lib/constants';
 
@@ -194,116 +193,60 @@ export default function StockTransfersPage() {
   const pendingList: StockTransfer[] = pendingDeliveries || [];
   const historyList = receivingHistory?.data || [];
 
-  // ============ OUTGOING COLUMNS ============
-  const outgoingColumns = [
-    {
-      key: 'batchNumber',
-      label: 'เลขใบโอน',
-      render: (t: StockTransfer) => (
-        <span className="text-xs font-mono font-medium text-blue-600">{t.batchNumber || '-'}</span>
-      ),
-    },
-    {
-      key: 'product',
-      label: 'สินค้า',
-      render: (t: StockTransfer) => (
-        <button
-          onClick={() => navigate(`/products/${t.product.id}`)}
-          className="text-left hover:underline"
-        >
-          <div className="text-primary-600 font-medium">{t.product.brand} {t.product.model}</div>
-          {t.product.imeiSerial && (
-            <div className="text-xs text-gray-400 font-mono">{t.product.imeiSerial}</div>
-          )}
-        </button>
-      ),
-    },
-    {
-      key: 'from',
-      label: 'จากสาขา',
-      render: (t: StockTransfer) => <span className="text-sm">{t.fromBranch.name}</span>,
-    },
-    {
-      key: 'to',
-      label: 'ไปสาขา',
-      render: (t: StockTransfer) => <span className="text-sm font-medium">{t.toBranch.name}</span>,
-    },
-    {
-      key: 'status',
-      label: 'สถานะ',
-      render: (t: StockTransfer) => {
-        const s = transferStatusLabels[t.status] || { label: t.status, className: 'bg-gray-100 text-gray-700' };
-        return <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${s.className}`}>{s.label}</span>;
-      },
-    },
-    {
-      key: 'createdAt',
-      label: 'วันที่โอน',
-      render: (t: StockTransfer) => (
-        <div className="text-xs">
-          <div>{new Date(t.createdAt).toLocaleString('th-TH')}</div>
-          {t.dispatchedAt && (
-            <div className="text-blue-500">ส่ง: {new Date(t.dispatchedAt).toLocaleString('th-TH')}</div>
-          )}
-        </div>
-      ),
-    },
-    {
-      key: 'confirmedBy',
-      label: 'ยืนยันโดย',
-      render: (t: StockTransfer) => (
-        <div className="text-xs">
-          {t.confirmedBy ? (
-            <>
-              <div>{t.confirmedBy.name}</div>
-              {t.confirmedAt && <div className="text-gray-400">{new Date(t.confirmedAt).toLocaleString('th-TH')}</div>}
-            </>
-          ) : t.dispatchedBy ? (
-            <div className="text-blue-600">จัดส่งโดย: {t.dispatchedBy.name}</div>
-          ) : (
-            <span className="text-gray-400">-</span>
-          )}
-        </div>
-      ),
-    },
-    {
-      key: 'notes',
-      label: 'หมายเหตุ',
-      render: (t: StockTransfer) => (
-        <span className="text-xs text-gray-500">{t.trackingNote || t.notes || '-'}</span>
-      ),
-    },
-    {
-      key: 'actions',
-      label: '',
-      render: (t: StockTransfer) => (
-        <div className="flex gap-2">
-          {t.status === 'PENDING' && (
-            <button
-              onClick={() => {
-                const note = prompt('หมายเหตุการจัดส่ง (ถ้ามี):');
-                if (note !== null) {
-                  dispatchMutation.mutate({ transferId: t.id, trackingNote: note || undefined });
-                }
-              }}
-              disabled={dispatchMutation.isPending}
-              className="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700 disabled:opacity-50"
-            >
-              จัดส่ง
-            </button>
-          )}
-          {t.status === 'IN_TRANSIT' && (
-            <button
-              onClick={() => openSlipModal(t)}
-              className="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700"
-            >
-              ใบโอนสินค้า
-            </button>
-          )}
-        </div>
-      ),
-    },
-  ];
+  // ============ OUTGOING: GROUP BY BATCH ============
+  const [expandedBatches, setExpandedBatches] = useState<Set<string>>(new Set());
+
+  const toggleBatch = (batchKey: string) => {
+    setExpandedBatches((prev) => {
+      const next = new Set(prev);
+      if (next.has(batchKey)) next.delete(batchKey);
+      else next.add(batchKey);
+      return next;
+    });
+  };
+
+  interface BatchGroup {
+    batchKey: string;
+    batchNumber: string | null;
+    items: StockTransfer[];
+    fromBranch: { id: string; name: string };
+    toBranch: { id: string; name: string };
+    status: string;
+    createdAt: string;
+    dispatchedAt: string | null;
+    dispatchedBy: { id: string; name: string } | null;
+    confirmedBy: { id: string; name: string } | null;
+    confirmedAt: string | null;
+    notes: string | null;
+    trackingNote: string | null;
+  }
+
+  const batchGroups: BatchGroup[] = useMemo(() => {
+    const map = new Map<string, StockTransfer[]>();
+    for (const t of transfers) {
+      const key = t.batchNumber || `_single_${t.id}`;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(t);
+    }
+    return Array.from(map.entries()).map(([batchKey, items]) => {
+      const first = items[0];
+      return {
+        batchKey,
+        batchNumber: first.batchNumber,
+        items,
+        fromBranch: first.fromBranch,
+        toBranch: first.toBranch,
+        status: first.status,
+        createdAt: first.createdAt,
+        dispatchedAt: first.dispatchedAt,
+        dispatchedBy: first.dispatchedBy,
+        confirmedBy: first.confirmedBy,
+        confirmedAt: first.confirmedAt,
+        notes: first.notes,
+        trackingNote: first.trackingNote,
+      };
+    });
+  }, [transfers]);
 
   return (
     <div>
@@ -354,16 +297,141 @@ export default function StockTransfersPage() {
             </select>
           </div>
 
-          <DataTable
-            columns={outgoingColumns}
-            data={transfers}
-            isLoading={loadingTransfers}
-            emptyMessage={
-              statusFilter === 'PENDING' ? 'ไม่มีรายการรอจัดส่ง'
-              : statusFilter === 'IN_TRANSIT' ? 'ไม่มีรายการระหว่างโอนสินค้า'
-              : 'ไม่พบรายการโอน'
-            }
-          />
+          {loadingTransfers ? (
+            <div className="bg-white rounded-lg border p-8 text-center text-gray-500">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto mb-3"></div>
+              กำลังโหลด...
+            </div>
+          ) : batchGroups.length === 0 ? (
+            <div className="bg-white rounded-lg border p-8 text-center text-gray-500">
+              {statusFilter === 'PENDING' ? 'ไม่มีรายการรอจัดส่ง'
+                : statusFilter === 'IN_TRANSIT' ? 'ไม่มีรายการระหว่างโอนสินค้า'
+                : 'ไม่พบรายการโอน'}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {batchGroups.map((batch) => {
+                const isExpanded = expandedBatches.has(batch.batchKey);
+                const s = transferStatusLabels[batch.status] || { label: batch.status, className: 'bg-gray-100 text-gray-700' };
+                return (
+                  <div key={batch.batchKey} className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                    {/* Batch Header */}
+                    <button
+                      onClick={() => toggleBatch(batch.batchKey)}
+                      className="w-full px-4 py-3 flex items-center gap-4 hover:bg-gray-50 transition-colors text-left"
+                    >
+                      <svg
+                        className={`w-4 h-4 text-gray-400 transition-transform flex-shrink-0 ${isExpanded ? 'rotate-90' : ''}`}
+                        fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                      <div className="flex-1 min-w-0 flex items-center gap-3 flex-wrap">
+                        <span className="font-mono text-sm font-semibold text-blue-600">
+                          {batch.batchNumber || '-'}
+                        </span>
+                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${s.className}`}>
+                          {s.label}
+                        </span>
+                        <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                          {batch.items.length} รายการ
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-4 text-xs text-gray-500 flex-shrink-0">
+                        <span>{batch.fromBranch.name} → {batch.toBranch.name}</span>
+                        <span>{new Date(batch.createdAt).toLocaleDateString('th-TH')}</span>
+                      </div>
+                      <div className="flex gap-2 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                        {batch.status === 'PENDING' && (
+                          <button
+                            onClick={() => {
+                              const note = prompt('หมายเหตุการจัดส่ง (ถ้ามี):');
+                              if (note !== null) {
+                                batch.items.forEach((item) => {
+                                  dispatchMutation.mutate({ transferId: item.id, trackingNote: note || undefined });
+                                });
+                              }
+                            }}
+                            disabled={dispatchMutation.isPending}
+                            className="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700 disabled:opacity-50"
+                          >
+                            จัดส่งทั้งใบ
+                          </button>
+                        )}
+                        {batch.status === 'IN_TRANSIT' && (
+                          <button
+                            onClick={() => openSlipModal(batch.items[0])}
+                            className="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700"
+                          >
+                            ใบโอนสินค้า
+                          </button>
+                        )}
+                      </div>
+                    </button>
+
+                    {/* Expanded Product List */}
+                    {isExpanded && (
+                      <div className="border-t border-gray-100">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="bg-gray-50">
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 w-8">#</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">สินค้า</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">IMEI / S/N</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">สี / ความจุ</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">สถานะ</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">หมายเหตุ</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-gray-50">
+                            {batch.items.map((t, idx) => {
+                              const itemStatus = transferStatusLabels[t.status] || { label: t.status, className: 'bg-gray-100 text-gray-700' };
+                              return (
+                                <tr key={t.id} className="hover:bg-gray-50">
+                                  <td className="px-4 py-2 text-xs text-gray-400">{idx + 1}</td>
+                                  <td className="px-4 py-2">
+                                    <button
+                                      onClick={() => navigate(`/products/${t.product.id}`)}
+                                      className="text-left hover:underline"
+                                    >
+                                      <span className="text-primary-600 font-medium">
+                                        {t.product.brand} {t.product.model}
+                                      </span>
+                                    </button>
+                                  </td>
+                                  <td className="px-4 py-2 font-mono text-xs text-gray-500">
+                                    {t.product.imeiSerial || t.product.serialNumber || '-'}
+                                  </td>
+                                  <td className="px-4 py-2 text-xs text-gray-500">
+                                    {[t.product.color, t.product.storage].filter(Boolean).join(' / ') || '-'}
+                                  </td>
+                                  <td className="px-4 py-2">
+                                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${itemStatus.className}`}>
+                                      {itemStatus.label}
+                                    </span>
+                                  </td>
+                                  <td className="px-4 py-2 text-xs text-gray-500">
+                                    {t.trackingNote || t.notes || '-'}
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                        </table>
+                        {/* Batch footer info */}
+                        <div className="px-4 py-2 bg-gray-50 text-xs text-gray-500 flex gap-4 flex-wrap">
+                          {batch.dispatchedBy && <span>จัดส่งโดย: {batch.dispatchedBy.name}</span>}
+                          {batch.dispatchedAt && <span>วันจัดส่ง: {new Date(batch.dispatchedAt).toLocaleString('th-TH')}</span>}
+                          {batch.confirmedBy && <span>ยืนยันโดย: {batch.confirmedBy.name}</span>}
+                          {batch.confirmedAt && <span>วันยืนยัน: {new Date(batch.confirmedAt).toLocaleString('th-TH')}</span>}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
แท็บโอนออกเปลี่ยนจากแสดงรายเครื่องเป็นจัดกลุ่มตามเลขใบโอน (batchNumber)
- แต่ละใบโอนแสดงเป็นแถวรวม พร้อมจำนวนรายการ, สาขาต้นทาง/ปลายทาง, สถานะ
- กดขยายดูรายละเอียดสินค้าแต่ละชิ้น (ยี่ห้อ, รุ่น, IMEI, สี, ความจุ)
- ปุ่ม "จัดส่งทั้งใบ" dispatch ทุกรายการในใบโอนพร้อมกัน
- แสดงข้อมูลผู้จัดส่ง/ผู้ยืนยันใน footer ของแต่ละใบ

https://claude.ai/code/session_0181r1pNCMNF1CocjaRgctBJ