### PR TITLE
feat: redesign incoming tab with batch grouping and per-item QC receive

### DIFF
--- a/apps/web/src/pages/StockTransfersPage.tsx
+++ b/apps/web/src/pages/StockTransfersPage.tsx
@@ -56,17 +56,15 @@ export default function StockTransfersPage() {
 
   // --- Branch receiving state ---
   const [selectedBranch, setSelectedBranch] = useState('');
-  const [isReceiveModalOpen, setIsReceiveModalOpen] = useState(false);
-  const [selectedTransfer, setSelectedTransfer] = useState<StockTransfer | null>(null);
-  const [scannedImei, setScannedImei] = useState('');
-  const [receiveStatus, setReceiveStatus] = useState<'PASS' | 'REJECT'>('PASS');
-  const [conditionNotes, setConditionNotes] = useState('');
-  const [rejectReason, setRejectReason] = useState('');
-  const [receiveNotes, setReceiveNotes] = useState('');
+  const [isBatchReceiveModalOpen, setIsBatchReceiveModalOpen] = useState(false);
+  const [receivingBatch, setReceivingBatch] = useState<StockTransfer[]>([]);
+  const [itemStatuses, setItemStatuses] = useState<Record<string, { status: 'PASS' | 'REJECT'; imei: string; conditionNotes: string; rejectReason: string }>>({});
+  const [batchReceiveNotes, setBatchReceiveNotes] = useState('');
+  const [batchSubmitting, setBatchSubmitting] = useState(false);
 
-  // --- Transfer slip modal state ---
+  // --- Transfer slip modal state (outgoing only) ---
   const [isSlipModalOpen, setIsSlipModalOpen] = useState(false);
-  const [slipTransfer, setSlipTransfer] = useState<StockTransfer | null>(null);
+  const [slipBatchItems, setSlipBatchItems] = useState<StockTransfer[]>([]);
 
   const goToTab = (key: TabKey) => setSearchParams({ view: key });
 
@@ -120,27 +118,7 @@ export default function StockTransfersPage() {
     enabled: activeTab === 'incoming' && !!selectedBranch,
   });
 
-  const receiveMutation = useMutation({
-    mutationFn: (data: {
-      transferId: string;
-      items: { productId: string; imeiSerial?: string; status: string; conditionNotes?: string; rejectReason?: string }[];
-      notes?: string;
-    }) => api.post('/branch-receiving', data),
-    onSuccess: (res) => {
-      queryClient.invalidateQueries({ queryKey: ['branch-receiving'] });
-      queryClient.invalidateQueries({ queryKey: ['branch-receiving-pending'] });
-      queryClient.invalidateQueries({ queryKey: ['branch-receiving-history'] });
-      queryClient.invalidateQueries({ queryKey: ['stock-transfers'] });
-      const d = res.data;
-      if (d.productMoved) {
-        toast.success(`รับสินค้าเข้าสาขา ${d.toBranch} สำเร็จ`);
-      } else {
-        toast.error(`ปฏิเสธสินค้า - ส่งกลับคลัง`);
-      }
-      setIsReceiveModalOpen(false);
-    },
-    onError: (err: unknown) => toast.error(getErrorMessage(err)),
-  });
+  // No single receiveMutation needed — batch submit handles it
 
   // ============ HISTORY TAB QUERIES ============
   const { data: receivingHistory } = useQuery({
@@ -150,48 +128,112 @@ export default function StockTransfersPage() {
   });
 
   // ============ HELPERS ============
-  const openSlipModal = (transfer: StockTransfer) => {
-    setSlipTransfer(transfer);
+  const openSlipModal = (items: StockTransfer[]) => {
+    setSlipBatchItems(items);
     setIsSlipModalOpen(true);
   };
 
-  const handleSlipReceive = (transfer: StockTransfer) => {
+  const openBatchReceiveModal = (items: StockTransfer[]) => {
     setIsSlipModalOpen(false);
-    openReceiveModal(transfer);
-  };
-
-  const openReceiveModal = (transfer: StockTransfer) => {
-    setSelectedTransfer(transfer);
-    setScannedImei('');
-    setReceiveStatus('PASS');
-    setConditionNotes('');
-    setRejectReason('');
-    setReceiveNotes('');
-    setIsReceiveModalOpen(true);
-  };
-
-  const handleReceiveSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!selectedTransfer) return;
-    if (receiveStatus === 'REJECT' && !rejectReason) {
-      toast.error('กรุณาระบุเหตุผลที่ไม่ผ่าน');
-      return;
+    setReceivingBatch(items);
+    const initial: typeof itemStatuses = {};
+    for (const t of items) {
+      initial[t.id] = { status: 'PASS', imei: '', conditionNotes: '', rejectReason: '' };
     }
-    receiveMutation.mutate({
-      transferId: selectedTransfer.id,
-      items: [{
-        productId: selectedTransfer.product.id,
-        imeiSerial: scannedImei || undefined,
-        status: receiveStatus,
-        conditionNotes: conditionNotes || undefined,
-        rejectReason: receiveStatus === 'REJECT' ? rejectReason : undefined,
-      }],
-      notes: receiveNotes || undefined,
-    });
+    setItemStatuses(initial);
+    setBatchReceiveNotes('');
+    setIsBatchReceiveModalOpen(true);
+  };
+
+  const updateItemStatus = (transferId: string, field: string, value: string) => {
+    setItemStatuses((prev) => ({
+      ...prev,
+      [transferId]: { ...prev[transferId], [field]: value },
+    }));
+  };
+
+  const handleBatchReceiveSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    // Validate: rejected items must have reason
+    for (const t of receivingBatch) {
+      const s = itemStatuses[t.id];
+      if (s.status === 'REJECT' && !s.rejectReason) {
+        toast.error(`กรุณาระบุเหตุผลที่ไม่ผ่านสำหรับ ${t.product.brand} ${t.product.model}`);
+        return;
+      }
+    }
+    setBatchSubmitting(true);
+    let passCount = 0;
+    let rejectCount = 0;
+    let errorCount = 0;
+    for (const t of receivingBatch) {
+      const s = itemStatuses[t.id];
+      try {
+        await api.post('/branch-receiving', {
+          transferId: t.id,
+          items: [{
+            productId: t.product.id,
+            imeiSerial: s.imei || undefined,
+            status: s.status,
+            conditionNotes: s.conditionNotes || undefined,
+            rejectReason: s.status === 'REJECT' ? s.rejectReason : undefined,
+          }],
+          notes: batchReceiveNotes || undefined,
+        });
+        if (s.status === 'PASS') passCount++;
+        else rejectCount++;
+      } catch (err) {
+        errorCount++;
+        toast.error(`${t.product.brand} ${t.product.model}: ${getErrorMessage(err)}`);
+      }
+    }
+    setBatchSubmitting(false);
+    queryClient.invalidateQueries({ queryKey: ['branch-receiving'] });
+    queryClient.invalidateQueries({ queryKey: ['branch-receiving-pending'] });
+    queryClient.invalidateQueries({ queryKey: ['branch-receiving-history'] });
+    queryClient.invalidateQueries({ queryKey: ['stock-transfers'] });
+    if (errorCount === 0) {
+      if (rejectCount === 0) {
+        toast.success(`รับสินค้าทั้งหมด ${passCount} รายการสำเร็จ`);
+      } else {
+        toast.success(`รับ ${passCount} ปฏิเสธ ${rejectCount} รายการ`);
+      }
+      setIsBatchReceiveModalOpen(false);
+    }
   };
 
   const pendingList: StockTransfer[] = pendingDeliveries || [];
   const historyList = receivingHistory?.data || [];
+
+  // ============ INCOMING: GROUP BY BATCH ============
+  const [expandedIncoming, setExpandedIncoming] = useState<Set<string>>(new Set());
+
+  const toggleIncoming = (batchKey: string) => {
+    setExpandedIncoming((prev) => {
+      const next = new Set(prev);
+      if (next.has(batchKey)) next.delete(batchKey);
+      else next.add(batchKey);
+      return next;
+    });
+  };
+
+  const incomingBatchGroups = useMemo(() => {
+    const map = new Map<string, StockTransfer[]>();
+    for (const t of pendingList) {
+      const key = t.batchNumber || `_single_${t.id}`;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(t);
+    }
+    return Array.from(map.entries()).map(([batchKey, items]) => ({
+      batchKey,
+      batchNumber: items[0].batchNumber,
+      items,
+      fromBranch: items[0].fromBranch,
+      toBranch: items[0].toBranch,
+      dispatchedAt: items[0].dispatchedAt,
+      trackingNote: items[0].trackingNote,
+    }));
+  }, [pendingList]);
 
   // ============ OUTGOING: GROUP BY BATCH ============
   const [expandedBatches, setExpandedBatches] = useState<Set<string>>(new Set());
@@ -360,7 +402,7 @@ export default function StockTransfersPage() {
                         )}
                         {batch.status === 'IN_TRANSIT' && (
                           <button
-                            onClick={() => openSlipModal(batch.items[0])}
+                            onClick={() => openSlipModal(batch.items)}
                             className="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700"
                           >
                             ใบโอนสินค้า
@@ -455,29 +497,91 @@ export default function StockTransfersPage() {
             <div className="text-center py-10 text-gray-500">กรุณาเลือกสาขาเพื่อดูรายการรอรับ</div>
           ) : loadingPending ? (
             <div className="text-center py-4 text-gray-500">กำลังโหลด...</div>
-          ) : pendingList.length === 0 ? (
+          ) : incomingBatchGroups.length === 0 ? (
             <div className="text-center py-10 text-gray-400 text-sm">ไม่มีสินค้ารอรับเข้าสาขานี้</div>
           ) : (
-            <div className="grid gap-3">
-              {pendingList.map((t) => (
-                <div key={t.id} className="bg-white border border-yellow-200 rounded-lg p-4 flex items-center justify-between">
-                  <div>
-                    <div className="font-medium">{t.product.name}</div>
-                    <div className="text-xs text-gray-500 space-x-3">
-                      <span>จาก: {t.fromBranch.name}</span>
-                      {t.product.imeiSerial && <span className="font-mono">IMEI: {t.product.imeiSerial}</span>}
-                      {t.dispatchedAt && <span>จัดส่ง: {new Date(t.dispatchedAt).toLocaleDateString('th-TH')}</span>}
-                    </div>
-                    {t.trackingNote && <div className="text-xs text-blue-600 mt-1">{t.trackingNote}</div>}
+            <div className="space-y-2">
+              {incomingBatchGroups.map((batch) => {
+                const isExpanded = expandedIncoming.has(batch.batchKey);
+                return (
+                  <div key={batch.batchKey} className="bg-white rounded-lg border border-yellow-200 overflow-hidden">
+                    {/* Batch Header */}
+                    <button
+                      onClick={() => toggleIncoming(batch.batchKey)}
+                      className="w-full px-4 py-3 flex items-center gap-4 hover:bg-yellow-50 transition-colors text-left"
+                    >
+                      <svg
+                        className={`w-4 h-4 text-gray-400 transition-transform flex-shrink-0 ${isExpanded ? 'rotate-90' : ''}`}
+                        fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                      <div className="flex-1 min-w-0 flex items-center gap-3 flex-wrap">
+                        <span className="font-mono text-sm font-semibold text-blue-600">
+                          {batch.batchNumber || '-'}
+                        </span>
+                        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700">
+                          รอตรวจรับ
+                        </span>
+                        <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                          {batch.items.length} รายการ
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-4 text-xs text-gray-500 flex-shrink-0">
+                        <span>จาก: {batch.fromBranch.name}</span>
+                        {batch.dispatchedAt && <span>ส่ง: {new Date(batch.dispatchedAt).toLocaleDateString('th-TH')}</span>}
+                      </div>
+                      <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                        <button
+                          onClick={() => openBatchReceiveModal(batch.items)}
+                          className="px-3 py-1.5 bg-green-600 text-white rounded text-xs font-medium hover:bg-green-700"
+                        >
+                          ตรวจรับทั้งใบ
+                        </button>
+                      </div>
+                    </button>
+
+                    {/* Expanded Product List */}
+                    {isExpanded && (
+                      <div className="border-t border-yellow-100">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="bg-yellow-50">
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 w-8">#</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">สินค้า</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">IMEI / S/N</th>
+                              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">สี / ความจุ</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-yellow-50">
+                            {batch.items.map((t, idx) => (
+                              <tr key={t.id} className="hover:bg-yellow-50">
+                                <td className="px-4 py-2 text-xs text-gray-400">{idx + 1}</td>
+                                <td className="px-4 py-2">
+                                  <span className="font-medium text-gray-800">
+                                    {t.product.brand} {t.product.model}
+                                  </span>
+                                </td>
+                                <td className="px-4 py-2 font-mono text-xs text-gray-500">
+                                  {t.product.imeiSerial || t.product.serialNumber || '-'}
+                                </td>
+                                <td className="px-4 py-2 text-xs text-gray-500">
+                                  {[t.product.color, t.product.storage].filter(Boolean).join(' / ') || '-'}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                        {batch.trackingNote && (
+                          <div className="px-4 py-2 bg-yellow-50 text-xs text-blue-600">
+                            หมายเหตุจัดส่ง: {batch.trackingNote}
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
-                  <button
-                    onClick={() => openSlipModal(t)}
-                    className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
-                  >
-                    ดูใบโอนสินค้า
-                  </button>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>
@@ -541,221 +645,236 @@ export default function StockTransfersPage() {
         </div>
       )}
 
-      {/* ============ TRANSFER SLIP MODAL ============ */}
+      {/* ============ TRANSFER SLIP MODAL (outgoing) ============ */}
       <Modal isOpen={isSlipModalOpen} onClose={() => setIsSlipModalOpen(false)} title="ใบโอนสินค้า" size="lg">
-        {slipTransfer && (
-          <div className="space-y-5">
-            {/* Header */}
-            <div className="flex items-center justify-between border-b border-dashed border-gray-300 pb-4">
-              <div>
-                <h3 className="text-lg font-bold text-gray-800">ใบโอนสินค้า</h3>
-                <p className="text-sm text-gray-500 font-mono mt-0.5">{slipTransfer.batchNumber || '-'}</p>
+        {slipBatchItems.length > 0 && (() => {
+          const first = slipBatchItems[0];
+          return (
+            <div className="space-y-5">
+              {/* Header */}
+              <div className="flex items-center justify-between border-b border-dashed border-gray-300 pb-4">
+                <div>
+                  <h3 className="text-lg font-bold text-gray-800">ใบโอนสินค้า</h3>
+                  <p className="text-sm text-gray-500 font-mono mt-0.5">{first.batchNumber || '-'}</p>
+                </div>
+                <span className="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-medium">
+                  {slipBatchItems.length} รายการ
+                </span>
               </div>
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-medium">
-                ระหว่างโอนสินค้า
-              </span>
-            </div>
 
-            {/* Branch Info */}
-            <div className="grid grid-cols-2 gap-4">
-              <div className="bg-orange-50 rounded-lg p-3">
-                <div className="text-xs text-orange-600 font-medium mb-1">ต้นทาง</div>
-                <div className="font-semibold text-gray-800">{slipTransfer.fromBranch.name}</div>
+              {/* Branch Info */}
+              <div className="grid grid-cols-2 gap-4">
+                <div className="bg-orange-50 rounded-lg p-3">
+                  <div className="text-xs text-orange-600 font-medium mb-1">ต้นทาง</div>
+                  <div className="font-semibold text-gray-800">{first.fromBranch.name}</div>
+                </div>
+                <div className="bg-green-50 rounded-lg p-3">
+                  <div className="text-xs text-green-600 font-medium mb-1">ปลายทาง</div>
+                  <div className="font-semibold text-gray-800">{first.toBranch.name}</div>
+                </div>
               </div>
-              <div className="bg-green-50 rounded-lg p-3">
-                <div className="text-xs text-green-600 font-medium mb-1">ปลายทาง</div>
-                <div className="font-semibold text-gray-800">{slipTransfer.toBranch.name}</div>
-              </div>
-            </div>
 
-            {/* Product Details */}
-            <div className="bg-gray-50 rounded-lg p-4">
-              <div className="text-xs text-gray-500 font-medium mb-2">รายการสินค้า</div>
-              <div className="flex items-start gap-3">
-                {slipTransfer.product.photos?.[0] && (
-                  <img
-                    src={slipTransfer.product.photos[0]}
-                    alt={slipTransfer.product.name}
-                    className="w-16 h-16 object-cover rounded-lg border"
-                  />
-                )}
-                <div className="flex-1">
-                  <div className="font-semibold text-gray-800">{slipTransfer.product.brand} {slipTransfer.product.model}</div>
-                  <div className="text-sm text-gray-500 mt-1 space-y-0.5">
-                    {slipTransfer.product.color && <div>สี: {slipTransfer.product.color}</div>}
-                    {slipTransfer.product.storage && <div>ความจุ: {slipTransfer.product.storage}</div>}
-                    {slipTransfer.product.imeiSerial && (
-                      <div className="font-mono text-xs">IMEI: {slipTransfer.product.imeiSerial}</div>
-                    )}
-                    {slipTransfer.product.serialNumber && (
-                      <div className="font-mono text-xs">S/N: {slipTransfer.product.serialNumber}</div>
-                    )}
+              {/* Product List */}
+              <div className="bg-gray-50 rounded-lg p-4">
+                <div className="text-xs text-gray-500 font-medium mb-3">รายการสินค้า ({slipBatchItems.length})</div>
+                <div className="space-y-3">
+                  {slipBatchItems.map((t, idx) => (
+                    <div key={t.id} className="flex items-start gap-3">
+                      <span className="text-xs text-gray-400 mt-1 w-5">{idx + 1}.</span>
+                      {t.product.photos?.[0] && (
+                        <img src={t.product.photos[0]} alt="" className="w-12 h-12 object-cover rounded-lg border" />
+                      )}
+                      <div className="flex-1">
+                        <div className="font-semibold text-gray-800 text-sm">{t.product.brand} {t.product.model}</div>
+                        <div className="text-xs text-gray-500 space-y-0.5">
+                          {t.product.color && <span>สี: {t.product.color} </span>}
+                          {t.product.storage && <span>ความจุ: {t.product.storage}</span>}
+                          {t.product.imeiSerial && <div className="font-mono">IMEI: {t.product.imeiSerial}</div>}
+                          {t.product.serialNumber && <div className="font-mono">S/N: {t.product.serialNumber}</div>}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Transfer Info */}
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <span className="text-gray-500">วันที่สร้างใบโอน:</span>
+                  <span className="ml-2 font-medium">{new Date(first.createdAt).toLocaleDateString('th-TH')}</span>
+                </div>
+                {first.dispatchedAt && (
+                  <div>
+                    <span className="text-gray-500">วันที่จัดส่ง:</span>
+                    <span className="ml-2 font-medium">{new Date(first.dispatchedAt).toLocaleDateString('th-TH')}</span>
                   </div>
-                </div>
+                )}
+                {first.dispatchedBy && (
+                  <div>
+                    <span className="text-gray-500">จัดส่งโดย:</span>
+                    <span className="ml-2 font-medium">{first.dispatchedBy.name}</span>
+                  </div>
+                )}
               </div>
-            </div>
 
-            {/* Transfer Info */}
-            <div className="grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <span className="text-gray-500">วันที่สร้างใบโอน:</span>
-                <span className="ml-2 font-medium">{new Date(slipTransfer.createdAt).toLocaleDateString('th-TH')}</span>
-              </div>
-              {slipTransfer.dispatchedAt && (
-                <div>
-                  <span className="text-gray-500">วันที่จัดส่ง:</span>
-                  <span className="ml-2 font-medium">{new Date(slipTransfer.dispatchedAt).toLocaleDateString('th-TH')}</span>
+              {/* Notes */}
+              {(first.notes || first.trackingNote) && (
+                <div className="bg-blue-50 rounded-lg p-3">
+                  {first.notes && <div className="text-sm text-gray-700">หมายเหตุ: {first.notes}</div>}
+                  {first.trackingNote && <div className="text-sm text-blue-700">หมายเหตุจัดส่ง: {first.trackingNote}</div>}
                 </div>
               )}
-              {slipTransfer.dispatchedBy && (
-                <div>
-                  <span className="text-gray-500">จัดส่งโดย:</span>
-                  <span className="ml-2 font-medium">{slipTransfer.dispatchedBy.name}</span>
-                </div>
-              )}
-              {slipTransfer.expectedDeliveryDate && (
-                <div>
-                  <span className="text-gray-500">คาดว่าถึง:</span>
-                  <span className="ml-2 font-medium">{new Date(slipTransfer.expectedDeliveryDate).toLocaleDateString('th-TH')}</span>
-                </div>
-              )}
-            </div>
 
-            {/* Notes */}
-            {(slipTransfer.notes || slipTransfer.trackingNote) && (
-              <div className="bg-blue-50 rounded-lg p-3">
-                {slipTransfer.notes && <div className="text-sm text-gray-700">หมายเหตุ: {slipTransfer.notes}</div>}
-                {slipTransfer.trackingNote && <div className="text-sm text-blue-700">หมายเหตุจัดส่ง: {slipTransfer.trackingNote}</div>}
+              <div className="border-t border-gray-200 pt-4">
+                <button
+                  onClick={() => setIsSlipModalOpen(false)}
+                  className="w-full py-2.5 bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200 transition-colors"
+                >
+                  ปิด
+                </button>
               </div>
-            )}
-
-            {/* Actions */}
-            <div className="border-t border-gray-200 pt-4 flex gap-3">
-              <button
-                onClick={() => handleSlipReceive(slipTransfer)}
-                className="flex-1 py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 transition-colors"
-              >
-                ตรวจรับสินค้า
-              </button>
-              <button
-                onClick={() => {
-                  const reason = prompt(`เหตุผลที่ปฏิเสธ ${slipTransfer.product.brand} ${slipTransfer.product.model}:`);
-                  if (reason !== null) {
-                    rejectMutation.mutate({ transferId: slipTransfer.id, reason: reason || undefined });
-                    setIsSlipModalOpen(false);
-                  }
-                }}
-                disabled={rejectMutation.isPending}
-                className="flex-1 py-2.5 bg-red-600 text-white rounded-lg font-medium hover:bg-red-700 transition-colors disabled:opacity-50"
-              >
-                ปฏิเสธ - ส่งกลับ
-              </button>
             </div>
-          </div>
-        )}
+          );
+        })()}
       </Modal>
 
-      {/* ============ RECEIVE MODAL ============ */}
-      <Modal isOpen={isReceiveModalOpen} onClose={() => setIsReceiveModalOpen(false)} title="ตรวจรับสินค้า">
-        {selectedTransfer && (
-          <form onSubmit={handleReceiveSubmit} className="space-y-4">
-            <div className="bg-gray-50 rounded-lg p-3">
-              <div className="font-medium">{selectedTransfer.product.name}</div>
-              <div className="text-xs text-gray-500 mt-1 space-y-0.5">
-                <div>จาก: {selectedTransfer.fromBranch.name} → {selectedTransfer.toBranch.name}</div>
-                {selectedTransfer.product.imeiSerial && (
-                  <div className="font-mono">IMEI ที่ต้องตรง: {selectedTransfer.product.imeiSerial}</div>
-                )}
+      {/* ============ BATCH RECEIVE MODAL ============ */}
+      <Modal
+        isOpen={isBatchReceiveModalOpen}
+        onClose={() => !batchSubmitting && setIsBatchReceiveModalOpen(false)}
+        title={`ตรวจรับสินค้า${receivingBatch[0]?.batchNumber ? ` - ${receivingBatch[0].batchNumber}` : ''}`}
+        size="lg"
+      >
+        {receivingBatch.length > 0 && (
+          <form onSubmit={handleBatchReceiveSubmit} className="space-y-4">
+            {/* Batch info */}
+            <div className="bg-gray-50 rounded-lg p-3 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-500">จาก: <span className="font-medium text-gray-800">{receivingBatch[0].fromBranch.name}</span></span>
+                <span className="text-gray-500">ไป: <span className="font-medium text-gray-800">{receivingBatch[0].toBranch.name}</span></span>
               </div>
+              <div className="text-xs text-gray-400 mt-1">{receivingBatch.length} รายการ</div>
             </div>
 
-            {selectedTransfer.product.imeiSerial && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">สแกน IMEI ยืนยัน</label>
-                <input
-                  type="text"
-                  value={scannedImei}
-                  onChange={(e) => setScannedImei(e.target.value)}
-                  placeholder="สแกนหรือพิมพ์ IMEI"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono"
-                />
-                {scannedImei && scannedImei === selectedTransfer.product.imeiSerial && (
-                  <div className="text-xs text-green-600 mt-1">IMEI ตรงกัน</div>
-                )}
-                {scannedImei && scannedImei !== selectedTransfer.product.imeiSerial && (
-                  <div className="text-xs text-red-600 mt-1">IMEI ไม่ตรง!</div>
-                )}
-              </div>
-            )}
+            {/* Per-item QC */}
+            <div className="space-y-3 max-h-[50vh] overflow-y-auto">
+              {receivingBatch.map((t, idx) => {
+                const s = itemStatuses[t.id];
+                if (!s) return null;
+                return (
+                  <div key={t.id} className={`border rounded-lg p-3 ${s.status === 'REJECT' ? 'border-red-200 bg-red-50' : 'border-gray-200'}`}>
+                    {/* Item header */}
+                    <div className="flex items-start gap-3 mb-2">
+                      <span className="text-xs text-gray-400 mt-0.5 w-5 flex-shrink-0">{idx + 1}.</span>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium text-sm">{t.product.brand} {t.product.model}</div>
+                        <div className="text-xs text-gray-500">
+                          {t.product.imeiSerial && <span className="font-mono">IMEI: {t.product.imeiSerial} </span>}
+                          {t.product.color && <span>สี: {t.product.color} </span>}
+                          {t.product.storage && <span>{t.product.storage}</span>}
+                        </div>
+                      </div>
+                      {/* PASS/REJECT toggle */}
+                      <div className="flex gap-1 flex-shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => updateItemStatus(t.id, 'status', 'PASS')}
+                          className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                            s.status === 'PASS' ? 'bg-green-600 text-white' : 'bg-gray-100 text-gray-500 hover:bg-green-100'
+                          }`}
+                        >
+                          ผ่าน
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => updateItemStatus(t.id, 'status', 'REJECT')}
+                          className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                            s.status === 'REJECT' ? 'bg-red-600 text-white' : 'bg-gray-100 text-gray-500 hover:bg-red-100'
+                          }`}
+                        >
+                          ไม่ผ่าน
+                        </button>
+                      </div>
+                    </div>
 
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">ผลตรวจ</label>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => setReceiveStatus('PASS')}
-                  className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    receiveStatus === 'PASS' ? 'bg-green-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-green-100'
-                  }`}
-                >
-                  ผ่าน - รับเข้าสาขา
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setReceiveStatus('REJECT')}
-                  className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    receiveStatus === 'REJECT' ? 'bg-red-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-red-100'
-                  }`}
-                >
-                  ไม่ผ่าน - ส่งกลับ
-                </button>
-              </div>
+                    {/* IMEI scan if product has IMEI */}
+                    {t.product.imeiSerial && (
+                      <div className="ml-8 mb-2">
+                        <input
+                          type="text"
+                          value={s.imei}
+                          onChange={(e) => updateItemStatus(t.id, 'imei', e.target.value)}
+                          placeholder="สแกน IMEI ยืนยัน"
+                          className="w-full px-2 py-1 border border-gray-300 rounded text-xs font-mono"
+                        />
+                        {s.imei && s.imei === t.product.imeiSerial && (
+                          <span className="text-xs text-green-600">IMEI ตรงกัน</span>
+                        )}
+                        {s.imei && s.imei !== t.product.imeiSerial && (
+                          <span className="text-xs text-red-600">IMEI ไม่ตรง!</span>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Condition notes */}
+                    <div className="ml-8">
+                      <input
+                        type="text"
+                        value={s.conditionNotes}
+                        onChange={(e) => updateItemStatus(t.id, 'conditionNotes', e.target.value)}
+                        placeholder="หมายเหตุสภาพ"
+                        className="w-full px-2 py-1 border border-gray-200 rounded text-xs"
+                      />
+                    </div>
+
+                    {/* Reject reason */}
+                    {s.status === 'REJECT' && (
+                      <div className="ml-8 mt-1">
+                        <input
+                          type="text"
+                          value={s.rejectReason}
+                          onChange={(e) => updateItemStatus(t.id, 'rejectReason', e.target.value)}
+                          placeholder="เหตุผลที่ไม่ผ่าน *"
+                          className="w-full px-2 py-1 border border-red-300 rounded text-xs"
+                          required
+                        />
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
 
+            {/* Batch notes */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">หมายเหตุสภาพ</label>
-              <input
-                type="text"
-                value={conditionNotes}
-                onChange={(e) => setConditionNotes(e.target.value)}
-                placeholder="สภาพสินค้าตอนรับ"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
-              />
-            </div>
-
-            {receiveStatus === 'REJECT' && (
-              <div>
-                <label className="block text-sm font-medium text-red-700 mb-1">เหตุผลที่ไม่ผ่าน *</label>
-                <input
-                  type="text"
-                  value={rejectReason}
-                  onChange={(e) => setRejectReason(e.target.value)}
-                  placeholder="เช่น หน้าจอแตก, สินค้าไม่ตรงตามรายการ"
-                  className="w-full px-3 py-2 border border-red-300 rounded-lg text-sm"
-                  required
-                />
-              </div>
-            )}
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">หมายเหตุเพิ่มเติม</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">หมายเหตุรวม</label>
               <textarea
-                value={receiveNotes}
-                onChange={(e) => setReceiveNotes(e.target.value)}
+                value={batchReceiveNotes}
+                onChange={(e) => setBatchReceiveNotes(e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
                 rows={2}
+                placeholder="หมายเหตุสำหรับใบโอนนี้"
               />
             </div>
 
-            <button
-              type="submit"
-              disabled={receiveMutation.isPending}
-              className={`w-full py-2 rounded-lg font-medium text-white ${
-                receiveStatus === 'PASS' ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'
-              } disabled:opacity-50`}
-            >
-              {receiveMutation.isPending ? 'กำลังบันทึก...' : receiveStatus === 'PASS' ? 'ยืนยันรับเข้าสาขา' : 'ปฏิเสธ - ส่งกลับคลัง'}
-            </button>
+            {/* Summary & Submit */}
+            <div className="border-t border-gray-200 pt-3">
+              <div className="flex items-center justify-between mb-3 text-sm">
+                <span className="text-gray-500">
+                  ผ่าน: <span className="text-green-600 font-medium">{Object.values(itemStatuses).filter((s) => s.status === 'PASS').length}</span>
+                  {' / '}
+                  ไม่ผ่าน: <span className="text-red-600 font-medium">{Object.values(itemStatuses).filter((s) => s.status === 'REJECT').length}</span>
+                </span>
+              </div>
+              <button
+                type="submit"
+                disabled={batchSubmitting}
+                className="w-full py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 disabled:opacity-50"
+              >
+                {batchSubmitting ? 'กำลังบันทึก...' : `ยืนยันตรวจรับ ${receivingBatch.length} รายการ`}
+              </button>
+            </div>
           </form>
         )}
       </Modal>


### PR DESCRIPTION
แท็บรอรับเข้าเปลี่ยนเป็นจัดกลุ่มตามใบโอน (batchNumber) เหมือนใบ PO:
- แต่ละใบโอนแสดงเลขใบ, จำนวนรายการ, สาขาต้นทาง
- กดขยายดูรายละเอียดสินค้าแต่ละเครื่อง
- ปุ่ม "ตรวจรับทั้งใบ" เปิด modal ตรวจรับรวม
- ใน modal แยก PASS/REJECT ทีละเครื่อง พร้อมสแกน IMEI
- แสดง condition notes และ reject reason ต่อเครื่อง
- สรุปจำนวนผ่าน/ไม่ผ่าน ก่อนกดยืนยัน
- ใบโอนสินค้า (slip modal) อัพเดทแสดงหลายเครื่องในใบเดียว

https://claude.ai/code/session_0181r1pNCMNF1CocjaRgctBJ