### PR TITLE
feat: add double-click on customer row to navigate to detail page

### DIFF
--- a/apps/web/src/components/ui/DataTable.tsx
+++ b/apps/web/src/components/ui/DataTable.tsx
@@ -19,6 +19,7 @@ interface DataTableProps<T> {
   isLoading?: boolean;
   emptyMessage?: string;
   onRowClick?: (item: T) => void;
+  onRowDoubleClick?: (item: T) => void;
   pagination?: PaginationInfo;
 }
 
@@ -28,6 +29,7 @@ function DataTable<T extends { id: string }>({
   isLoading,
   emptyMessage = 'ไม่พบข้อมูล',
   onRowClick,
+  onRowDoubleClick,
   pagination,
 }: DataTableProps<T>) {
   if (isLoading) {
@@ -64,7 +66,7 @@ function DataTable<T extends { id: string }>({
               </tr>
             ) : (
               data.map((item, idx) => (
-                <tr key={item.id} className={`hover:bg-gray-50 transition-colors${onRowClick ? ' cursor-pointer' : ''}`} onClick={() => onRowClick?.(item)}>
+                <tr key={item.id} className={`hover:bg-gray-50 transition-colors${onRowClick || onRowDoubleClick ? ' cursor-pointer' : ''}`} onClick={() => onRowClick?.(item)} onDoubleClick={() => onRowDoubleClick?.(item)}>
                   {columns.map((col) => (
                     <td key={col.key} className="px-4 py-3 text-sm text-gray-700">
                       {col.render

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -454,6 +454,7 @@ export default function CustomersPage() {
         data={customers}
         isLoading={isLoading}
         emptyMessage="ไม่พบลูกค้า"
+        onRowDoubleClick={(c) => navigate(`/customers/${c.id}`)}
         pagination={result ? {
           page: result.page,
           totalPages: result.totalPages,


### PR DESCRIPTION
Add onRowDoubleClick support to DataTable component and use it in CustomersPage to navigate to customer detail on double-click.

https://claude.ai/code/session_0181r1pNCMNF1CocjaRgctBJ