### PR TITLE
fix: add missing late_fee_waived column migration for payments table

### DIFF
--- a/apps/api/prisma/migrations/20260309000000_add_late_fee_waived_to_payments/migration.sql
+++ b/apps/api/prisma/migrations/20260309000000_add_late_fee_waived_to_payments/migration.sql
@@ -1,0 +1,2 @@
+-- Add late_fee_waived column to payments table
+ALTER TABLE "payments" ADD COLUMN "late_fee_waived" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
The column existed in Prisma schema but had no migration, causing "Invalid prisma.payment.createMany() invocation" error when creating contracts because Prisma tried to set default value for a column that doesn't exist in the database.

https://claude.ai/code/session_01DrduuHC9xbm2zhvmnjec39