### PR TITLE
simplify PlanType to single STORE_DIRECT value

### DIFF
--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -163,7 +163,7 @@ export class ContractsService {
               productId: dto.productId,
               branchId: dto.branchId,
               salespersonId,
-              planType: dto.planType as PlanType,
+              planType: (dto.planType || 'STORE_DIRECT') as PlanType,
               sellingPrice: dto.sellingPrice,
               downPayment: dto.downPayment,
               interestRate: params.interestRate,

--- a/apps/api/src/modules/contracts/dto/contract.dto.ts
+++ b/apps/api/src/modules/contracts/dto/contract.dto.ts
@@ -11,8 +11,8 @@ export class CreateContractDto {
   branchId: string;
 
   @IsString()
-  @Matches(/^(STORE_DIRECT|CREDIT_CARD|STORE_WITH_INTEREST)$/, { message: 'planType ต้องเป็น STORE_DIRECT, CREDIT_CARD หรือ STORE_WITH_INTEREST' })
-  planType: string;
+  @IsOptional()
+  planType?: string = 'STORE_DIRECT';
 
   @IsNumber()
   @Min(1)

--- a/apps/api/src/modules/documents/documents.service.ts
+++ b/apps/api/src/modules/documents/documents.service.ts
@@ -28,7 +28,7 @@ export class DocumentsService {
     return this.prisma.contractTemplate.create({
       data: {
         name: dto.name,
-        type: dto.type,
+        type: dto.type || 'STORE_DIRECT',
         contentHtml: sanitizedHtml,
         placeholders,
         isActive: dto.isActive ?? true,
@@ -110,9 +110,9 @@ export class DocumentsService {
       const template = await this.findOneTemplate(templateId);
       htmlContent = template.contentHtml;
     } else {
-      // Find active template by contract type
+      // Find active template (single plan type: STORE_DIRECT)
       const template = await this.prisma.contractTemplate.findFirst({
-        where: { type: contract.planType, isActive: true },
+        where: { type: 'STORE_DIRECT', isActive: true },
         orderBy: { createdAt: 'desc' },
       });
       htmlContent = template?.contentHtml || this.getDefaultTemplate(documentType);
@@ -174,7 +174,7 @@ export class DocumentsService {
       htmlContent = template.contentHtml;
     } else {
       const template = await this.prisma.contractTemplate.findFirst({
-        where: { type: contract.planType, isActive: true },
+        where: { type: 'STORE_DIRECT', isActive: true },
         orderBy: { createdAt: 'desc' },
       });
       htmlContent = template?.contentHtml || this.getDefaultTemplate('CONTRACT');

--- a/apps/api/src/modules/documents/dto/document.dto.ts
+++ b/apps/api/src/modules/documents/dto/document.dto.ts
@@ -5,7 +5,8 @@ export class CreateTemplateDto {
   name: string;
 
   @IsString()
-  type: string; // STORE_DIRECT, CREDIT_CARD, STORE_WITH_INTEREST, EXCHANGE
+  @IsOptional()
+  type?: string = 'STORE_DIRECT';
 
   @IsString()
   contentHtml: string;

--- a/apps/api/src/modules/migration/dto/import.dto.ts
+++ b/apps/api/src/modules/migration/dto/import.dto.ts
@@ -50,7 +50,8 @@ export class ImportContractDto {
   salespersonEmail: string;
 
   @IsString()
-  planType: string;
+  @IsOptional()
+  planType?: string = 'STORE_DIRECT';
 
   @IsNumber()
   sellingPrice: number;

--- a/apps/api/src/modules/migration/migration.service.ts
+++ b/apps/api/src/modules/migration/migration.service.ts
@@ -173,7 +173,7 @@ export class MigrationService {
             productId: product.id,
             branchId: branch.id,
             salespersonId: salesperson.id,
-            planType: c.planType as 'STORE_DIRECT' | 'CREDIT_CARD' | 'STORE_WITH_INTEREST',
+            planType: 'STORE_DIRECT',
             sellingPrice: c.sellingPrice,
             downPayment: c.downPayment,
             interestRate: c.interestRate,

--- a/apps/api/src/modules/sales/dto/sale.dto.ts
+++ b/apps/api/src/modules/sales/dto/sale.dto.ts
@@ -45,9 +45,9 @@ export class CreateSaleDto {
   contractNumber?: string;
 
   // Installment fields
-  @IsIn(['STORE_DIRECT', 'CREDIT_CARD', 'STORE_WITH_INTEREST'])
+  @IsString()
   @IsOptional()
-  planType?: string;
+  planType?: string = 'STORE_DIRECT';
 
   @IsNumber()
   @IsOptional()

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -146,7 +146,8 @@ export class SalesService {
   }
 
   private async createInstallmentSale(dto: CreateSaleDto, salespersonId: string, netAmount: number, discount: number) {
-    if (!dto.planType) throw new BadRequestException('กรุณาเลือกแผนผ่อนชำระ');
+    // Default planType to STORE_DIRECT (single plan type)
+    if (!dto.planType) dto.planType = 'STORE_DIRECT';
     if (!dto.downPayment && dto.downPayment !== 0) throw new BadRequestException('กรุณาใส่เงินดาวน์');
     if (!dto.totalMonths) throw new BadRequestException('กรุณาเลือกจำนวนงวด');
 

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -56,13 +56,10 @@ export const saleTypeConfig: Record<SaleType, { label: string; color: string; bg
   EXTERNAL_FINANCE: { label: 'ผ่อนไฟแนนซ์', color: 'text-purple-700', bg: 'bg-purple-50 border-purple-300 ring-purple-500' },
 };
 
-// --- Plan Type ---
+// --- Plan Type (single type: STORE_DIRECT) ---
 
-export const planTypes = [
-  { value: 'STORE_DIRECT', label: 'ผ่อนกับ BESTCHOICE' },
-  { value: 'CREDIT_CARD', label: 'ผ่อนบัตรเครดิต' },
-  { value: 'STORE_WITH_INTEREST', label: 'ผ่อนกับ BESTCHOICE+ดอกเบี้ย' },
-];
+export const PLAN_TYPE = 'STORE_DIRECT';
+export const PLAN_TYPE_LABEL = 'ผ่อนกับ BESTCHOICE';
 
 // --- Payment Method ---
 

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -8,7 +8,6 @@ import WorkflowStatusBadge from '@/components/contract/WorkflowStatusBadge';
 import DocumentUpload from '@/components/contract/DocumentUpload';
 import CreditCheckPanel from '@/components/contract/CreditCheckPanel';
 import toast from 'react-hot-toast';
-import { planTypes } from '@/lib/constants';
 import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -470,7 +469,7 @@ export default function ContractDetailPage() {
             </div>
           ) : (
             <div className="grid grid-cols-2 gap-3">
-              <Info label="ประเภทแผน" value={planTypes.find(p => p.value === contract.planType)?.label ?? contract.planType} />
+              <Info label="ประเภทแผน" value="ผ่อนกับ BESTCHOICE" />
               <Info label="ราคาขาย" value={`${parseFloat(contract.sellingPrice).toLocaleString()} ฿`} />
               <Info label="เงินดาวน์" value={`${parseFloat(contract.downPayment).toLocaleString()} ฿`} />
               <Info label="ยอดปล่อย (Loan)" value={`${(parseFloat(contract.sellingPrice) - parseFloat(contract.downPayment)).toLocaleString()} ฿`} />

--- a/apps/web/src/pages/ContractTemplatesPage.tsx
+++ b/apps/web/src/pages/ContractTemplatesPage.tsx
@@ -35,7 +35,7 @@ export default function ContractTemplatesPage() {
 
   const [form, setForm] = useState({
     name: '',
-    type: 'STORE_DIRECT',
+    type: 'STORE_DIRECT' as const,
     contentHtml: '',
   });
 
@@ -72,13 +72,13 @@ export default function ContractTemplatesPage() {
 
   const openCreate = () => {
     setEditing(null);
-    setForm({ name: '', type: 'STORE_DIRECT', contentHtml: '' });
+    setForm({ name: '', type: 'STORE_DIRECT' as const, contentHtml: '' });
     setShowModal(true);
   };
 
   const openEdit = (t: Template) => {
     setEditing(t);
-    setForm({ name: t.name, type: t.type, contentHtml: t.contentHtml });
+    setForm({ name: t.name, type: 'STORE_DIRECT' as const, contentHtml: t.contentHtml });
     setShowModal(true);
   };
 
@@ -99,7 +99,7 @@ export default function ContractTemplatesPage() {
 
   const columns = [
     { key: 'name', label: 'ชื่อเทมเพลต', render: (t: Template) => <span className="font-medium text-sm">{t.name}</span> },
-    { key: 'type', label: 'ประเภท', render: (t: Template) => <span className="text-xs px-2 py-0.5 bg-gray-100 rounded">{t.type}</span> },
+    { key: 'type', label: 'ประเภท', render: () => <span className="text-xs px-2 py-0.5 bg-gray-100 rounded">ผ่อนกับ BESTCHOICE</span> },
     {
       key: 'isActive',
       label: 'สถานะ',
@@ -150,17 +150,6 @@ export default function ContractTemplatesPage() {
               <input type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
             </div>
 
-            {!editing && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">ประเภท</label>
-                <select value={form.type} onChange={(e) => setForm({ ...form, type: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
-                  <option value="STORE_DIRECT">ผ่อนกับร้าน (STORE_DIRECT)</option>
-                  <option value="CREDIT_CARD">ผ่อนบัตรเครดิต (CREDIT_CARD)</option>
-                  <option value="STORE_WITH_INTEREST">ผ่อน+ดอกเบี้ย (STORE_WITH_INTEREST)</option>
-                  <option value="EXCHANGE">เปลี่ยนเครื่อง (EXCHANGE)</option>
-                </select>
-              </div>
-            )}
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">เนื้อหา HTML</label>

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -38,11 +38,9 @@ export const PaymentMethod = {
   QR_EWALLET: 'QR_EWALLET',
 } as const;
 
-// Plan Types
+// Plan Type (single type)
 export const PlanType = {
   STORE_DIRECT: 'STORE_DIRECT',
-  CREDIT_CARD: 'CREDIT_CARD',
-  STORE_WITH_INTEREST: 'STORE_WITH_INTEREST',
 } as const;
 
 // Product Categories


### PR DESCRIPTION
Remove multi-PlanType selection since the business only uses one plan type.
- Remove PlanType selector from ContractTemplatesPage
- Remove planType display from ContractDetailPage
- Default planType to STORE_DIRECT in all DTOs and services
- Simplify shared constants to single PlanType value
- Template lookup now always uses STORE_DIRECT type

https://claude.ai/code/session_01DrduuHC9xbm2zhvmnjec39