### PR TITLE
add contract templates link to sidebar menu

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -78,6 +78,7 @@ const navItems: NavItem[] = [
   { label: 'ตั้งค่าระบบ', path: '/settings', roles: ['OWNER'], section: 'system' },
   { label: 'ตั้งค่าดอกเบี้ย', path: '/settings/interest-config', roles: ['OWNER'], section: 'system' },
   { label: 'ราคาตั้งต้น', path: '/settings/pricing-templates', roles: ['OWNER'], section: 'system' },
+  { label: 'เทมเพลตสัญญา', path: '/contract-templates', roles: ['OWNER'], section: 'system' },
   { label: 'Audit Logs', path: '/audit-logs', roles: ['OWNER'], section: 'system' },
   { label: 'นำเข้าข้อมูล', path: '/migration', roles: ['OWNER'], section: 'system' },
 ];


### PR DESCRIPTION
Add 'เทมเพลตสัญญา' menu item under system section (OWNER only) pointing to /contract-templates page.

https://claude.ai/code/session_01DrduuHC9xbm2zhvmnjec39