### PR TITLE
feat: add proper indent/outdent support to rich text editor

### DIFF
--- a/apps/web/src/components/template-editor/editor/IndentExtension.ts
+++ b/apps/web/src/components/template-editor/editor/IndentExtension.ts
@@ -1,0 +1,113 @@
+import { Extension } from '@tiptap/core';
+
+export interface IndentOptions {
+  types: string[];
+  minLevel: number;
+  maxLevel: number;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    indent: {
+      indent: () => ReturnType;
+      outdent: () => ReturnType;
+    };
+  }
+}
+
+const Indent = Extension.create<IndentOptions>({
+  name: 'indent',
+
+  addOptions() {
+    return {
+      types: ['paragraph', 'heading'],
+      minLevel: 0,
+      maxLevel: 8,
+    };
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          indent: {
+            default: 0,
+            parseHTML: (element) => {
+              const ml = element.style.marginLeft;
+              if (!ml) return 0;
+              return Math.round(parseFloat(ml) / 2) || 0;
+            },
+            renderHTML: (attributes) => {
+              if (!attributes.indent || attributes.indent <= 0) return {};
+              return { style: `margin-left: ${attributes.indent * 2}em` };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      indent:
+        () =>
+        ({ tr, state, dispatch }) => {
+          const { selection } = state;
+          const { from, to } = selection;
+          let applied = false;
+
+          state.doc.nodesBetween(from, to, (node, pos) => {
+            if (this.options.types.includes(node.type.name)) {
+              const currentLevel = node.attrs.indent || 0;
+              if (currentLevel < this.options.maxLevel) {
+                if (dispatch) {
+                  tr.setNodeMarkup(pos, undefined, {
+                    ...node.attrs,
+                    indent: currentLevel + 1,
+                  });
+                }
+                applied = true;
+              }
+            }
+          });
+
+          return applied;
+        },
+
+      outdent:
+        () =>
+        ({ tr, state, dispatch }) => {
+          const { selection } = state;
+          const { from, to } = selection;
+          let applied = false;
+
+          state.doc.nodesBetween(from, to, (node, pos) => {
+            if (this.options.types.includes(node.type.name)) {
+              const currentLevel = node.attrs.indent || 0;
+              if (currentLevel > this.options.minLevel) {
+                if (dispatch) {
+                  tr.setNodeMarkup(pos, undefined, {
+                    ...node.attrs,
+                    indent: currentLevel - 1,
+                  });
+                }
+                applied = true;
+              }
+            }
+          });
+
+          return applied;
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => this.editor.commands.indent(),
+      'Shift-Tab': () => this.editor.commands.outdent(),
+    };
+  },
+});
+
+export default Indent;

--- a/apps/web/src/components/template-editor/editor/RichTextEditor.tsx
+++ b/apps/web/src/components/template-editor/editor/RichTextEditor.tsx
@@ -8,12 +8,13 @@ import { TextStyle } from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
 import Highlight from '@tiptap/extension-highlight';
 import Placeholder from '@tiptap/extension-placeholder';
+import IndentExtension from './IndentExtension';
 import {
   Bold, Italic, Underline as UnderlineIcon, Strikethrough,
   AlignLeft, AlignCenter, AlignRight, AlignJustify,
   List, ListOrdered, Undo2, Redo2,
   Heading1, Heading2, Heading3, Palette, Highlighter,
-  RemoveFormatting, Indent,
+  RemoveFormatting, Indent, Outdent,
 } from 'lucide-react';
 
 interface Props {
@@ -51,6 +52,7 @@ export default function RichTextEditor({ value, onChange, onEditorReady, placeho
       TextStyle,
       Color,
       Highlight.configure({ multicolor: true }),
+      IndentExtension,
       Placeholder.configure({
         placeholder: placeholder || 'พิมพ์เนื้อหา...',
       }),
@@ -236,13 +238,18 @@ export default function RichTextEditor({ value, onChange, onEditorReady, placeho
           <ListOrdered size={15} />
         </ToolbarButton>
 
-        {/* Indent / Outdent using blockquote as proxy */}
+        {/* Indent / Outdent */}
         <ToolbarButton
-          onClick={() => editor.chain().focus().toggleBlockquote().run()}
-          active={editor.isActive('blockquote')}
-          title="ย่อหน้า"
+          onClick={() => editor.chain().focus().indent().run()}
+          title="เพิ่มย่อหน้า (Tab)"
         >
           <Indent size={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().outdent().run()}
+          title="ลดย่อหน้า (Shift+Tab)"
+        >
+          <Outdent size={15} />
         </ToolbarButton>
 
         <Divider />


### PR DESCRIPTION
Replace blockquote proxy with custom Tiptap IndentExtension that:
- Adds margin-left in 2em increments (up to 8 levels)
- Supports Tab / Shift+Tab keyboard shortcuts
- Parses margin-left from existing HTML
- Works on paragraph and heading nodes
- Adds separate indent/outdent toolbar buttons

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23