### PR TITLE
ui: improve font sizes, spacing, and contrast for better readability

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -139,7 +139,7 @@ function Sidebar() {
             <h1 className="text-lg font-bold text-white leading-tight">
               best<span className="text-primary-400">choice</span>
             </h1>
-            <p className="text-[10px] text-gray-500">ระบบจัดการร้าน</p>
+            <p className="text-xs text-gray-500">ระบบจัดการร้าน</p>
           </div>
         </div>
       </div>
@@ -195,7 +195,7 @@ function Sidebar() {
                   >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d={section.icon} />
                   </svg>
-                  <span className="text-[11px] font-semibold uppercase tracking-wider">
+                  <span className="text-xs font-semibold uppercase tracking-wider">
                     {section.label}
                   </span>
                 </NavLink>
@@ -228,7 +228,7 @@ function Sidebar() {
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d={section.icon} />
                 </svg>
-                <span className="flex-1 text-left text-[11px] font-semibold uppercase tracking-wider group-hover:text-gray-300 transition-colors">
+                <span className="flex-1 text-left text-xs font-semibold uppercase tracking-wider group-hover:text-gray-300 transition-colors">
                   {section.label}
                 </span>
                 <div className="flex items-center gap-1.5">
@@ -264,7 +264,7 @@ function Sidebar() {
                       <div key={item.path}>
                         {showGroupHeader && (
                           <div className={clsx('flex items-center gap-2 px-3', idx > 0 ? 'mt-3 mb-1' : 'mb-1')}>
-                            <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-600">
+                            <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-600">
                               {item.group}
                             </span>
                             <div className="flex-1 h-px bg-white/5" />
@@ -283,7 +283,7 @@ function Sidebar() {
                           }
                         >
                           {item.step != null && (
-                            <span className="w-5 h-5 rounded-full bg-white/10 flex items-center justify-center text-[10px] font-bold shrink-0">
+                            <span className="w-5 h-5 rounded-full bg-white/10 flex items-center justify-center text-[11px] font-bold shrink-0">
                               {item.step}
                             </span>
                           )}

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -24,8 +24,8 @@ export default function TopBar() {
       </div>
       <div className="flex items-center gap-4">
         <div className="text-right">
-          <p className="text-sm font-semibold text-gray-900">{user?.name}</p>
-          <p className="text-xs text-gray-500">
+          <p className="text-sm font-semibold text-gray-800">{user?.name}</p>
+          <p className="text-sm text-gray-500">
             {user?.role && roleLabels[user.role]}
           </p>
         </div>
@@ -34,7 +34,7 @@ export default function TopBar() {
         </div>
         <button
           onClick={logout}
-          className="px-3 py-1.5 text-sm text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          className="px-3.5 py-2 text-sm text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
         >
           ออก
         </button>

--- a/apps/web/src/components/template-editor/editor/BlockItem.tsx
+++ b/apps/web/src/components/template-editor/editor/BlockItem.tsx
@@ -46,7 +46,7 @@ export default function BlockItem({ block, index, totalBlocks }: Props) {
       }`}
     >
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-gray-100">
         {/* Drag handle */}
         <button
           {...attributes}
@@ -65,7 +65,7 @@ export default function BlockItem({ block, index, totalBlocks }: Props) {
         </button>
 
         {/* Type badge */}
-        <span className="text-[10px] px-2 py-0.5 bg-violet-50 text-violet-700 rounded-full font-medium">
+        <span className="text-xs px-2.5 py-0.5 bg-violet-50 text-violet-700 rounded-full font-medium">
           {label}
         </span>
 
@@ -79,7 +79,7 @@ export default function BlockItem({ block, index, totalBlocks }: Props) {
         <div className="flex-1" />
 
         {/* Controls */}
-        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
           <button
             onClick={() => moveBlock(index, Math.max(0, index - 1))}
             disabled={index === 0}

--- a/apps/web/src/components/template-editor/layout/CheatSheet.tsx
+++ b/apps/web/src/components/template-editor/layout/CheatSheet.tsx
@@ -12,25 +12,25 @@ export default function CheatSheet() {
   };
 
   return (
-    <div className="w-[260px] bg-gray-50 border-r border-gray-200 overflow-y-auto p-3">
-      <h3 className="text-xs font-bold text-gray-500 uppercase mb-3">Template Syntax</h3>
+    <div className="w-[280px] bg-gray-50 border-r border-gray-200 overflow-y-auto p-4">
+      <h3 className="text-sm font-bold text-gray-500 uppercase mb-3">Template Syntax</h3>
 
       {SYNTAX_REFERENCE.map(group => (
-        <div key={group.group} className="mb-3">
-          <div className="text-[10px] font-bold text-gray-400 uppercase mb-1.5">{group.group}</div>
-          <div className="flex flex-wrap gap-1">
+        <div key={group.group} className="mb-4">
+          <div className="text-xs font-bold text-gray-400 uppercase mb-2">{group.group}</div>
+          <div className="flex flex-wrap gap-1.5">
             {group.items.map(item => (
               <button
                 key={item.syntax}
                 onClick={() => handleCopy(item.syntax)}
-                className={`group relative inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] font-mono transition-all ${item.bgColor} ${item.color} hover:opacity-80`}
+                className={`group relative inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-mono transition-all ${item.bgColor} ${item.color} hover:opacity-80`}
                 title={`คลิกเพื่อ copy: ${item.syntax}`}
               >
-                <span className="truncate max-w-[180px]">{item.label}</span>
+                <span className="truncate max-w-[190px]">{item.label}</span>
                 {copied === item.syntax ? (
-                  <Check size={10} className="text-green-600 flex-shrink-0" />
+                  <Check size={12} className="text-green-600 flex-shrink-0" />
                 ) : (
-                  <Copy size={10} className="opacity-0 group-hover:opacity-100 flex-shrink-0 transition-opacity" />
+                  <Copy size={12} className="opacity-0 group-hover:opacity-100 flex-shrink-0 transition-opacity" />
                 )}
               </button>
             ))}
@@ -40,8 +40,8 @@ export default function CheatSheet() {
 
       {/* Quick variable reference */}
       <div className="mt-4 pt-3 border-t border-gray-200">
-        <div className="text-[10px] font-bold text-gray-400 uppercase mb-2">ตัวอย่าง</div>
-        <div className="space-y-1.5 text-[10px] text-gray-600 font-mono">
+        <div className="text-xs font-bold text-gray-400 uppercase mb-2">ตัวอย่าง</div>
+        <div className="space-y-1.5 text-xs text-gray-600 font-mono">
           <p><span className="text-violet-600">{'{{= CONTRACT.NUMBER}}'}</span></p>
           <p><span className="text-teal-600">{'{{= CONTRACT.DATE | date:l}}'}</span></p>
           <p><span className="text-teal-600">{'{{= CONTRACT.TOTAL_AMOUNT | num:2}}'}</span></p>

--- a/apps/web/src/components/template-editor/layout/EditorSidebar.tsx
+++ b/apps/web/src/components/template-editor/layout/EditorSidebar.tsx
@@ -33,14 +33,14 @@ export default function EditorSidebar({ activeId, onSelect, onBack }: Props) {
         {onBack && (
           <button
             onClick={onBack}
-            className="flex items-center gap-1.5 text-[#A5A0C0] hover:text-white text-xs mb-2 transition-colors"
+            className="flex items-center gap-1.5 text-gray-300 hover:text-white text-sm mb-2 transition-colors"
           >
             <ArrowLeft size={14} />
             กลับหน้าหลัก
           </button>
         )}
         <h1 className="text-white font-bold text-sm">BESTCHOICEPHONE</h1>
-        <p className="text-[#A5A0C0] text-[10px]">Document Template Editor</p>
+        <p className="text-gray-400 text-xs">Document Template Editor</p>
       </div>
 
       {/* Menu */}
@@ -52,7 +52,7 @@ export default function EditorSidebar({ activeId, onSelect, onBack }: Props) {
             className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors ${
               activeId === item.id
                 ? 'bg-[#6D28D9] text-white'
-                : 'text-[#A5A0C0] hover:bg-white/5 hover:text-white'
+                : 'text-gray-300 hover:bg-white/5 hover:text-white'
             }`}
           >
             {item.icon}
@@ -63,7 +63,7 @@ export default function EditorSidebar({ activeId, onSelect, onBack }: Props) {
 
       {/* Footer */}
       <div className="px-4 py-3 border-t border-white/10">
-        <p className="text-[#A5A0C0] text-[10px]">BESTCHOICEPHONE Co., Ltd.</p>
+        <p className="text-gray-400 text-xs">BESTCHOICEPHONE Co., Ltd.</p>
       </div>
     </div>
   );

--- a/apps/web/src/components/template-editor/layout/HeaderBar.tsx
+++ b/apps/web/src/components/template-editor/layout/HeaderBar.tsx
@@ -57,7 +57,7 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
   };
 
   return (
-    <div className="h-14 bg-white border-b border-gray-200 flex items-center px-4 gap-2">
+    <div className="h-14 bg-white border-b border-gray-200 flex items-center px-4 gap-2.5">
       {/* Back button */}
       {onBack && (
         <button
@@ -94,22 +94,22 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
       {onToggleCheatSheet && (
         <button
           onClick={onToggleCheatSheet}
-          className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg transition-colors ${
+          className={`flex items-center gap-1.5 px-3.5 py-2 text-sm rounded-lg transition-colors ${
             showCheatSheet
               ? 'bg-amber-100 text-amber-700 border border-amber-300'
               : 'text-gray-700 border border-gray-300 hover:bg-gray-50'
           }`}
         >
-          <BookOpen size={14} />
+          <BookOpen size={16} />
           ตัวแปร
         </button>
       )}
 
       <button
         onClick={() => setShowSettings(true)}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+        className="flex items-center gap-1.5 px-3.5 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
       >
-        <Settings size={14} />
+        <Settings size={16} />
         ตั้งค่า
       </button>
 
@@ -117,9 +117,9 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
       <div className="relative" ref={addMenuRef}>
         <button
           onClick={() => setShowAddMenu(!showAddMenu)}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          className="flex items-center gap-1.5 px-3.5 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
         >
-          <Plus size={14} />
+          <Plus size={16} />
           เพิ่ม
         </button>
         {showAddMenu && (
@@ -140,37 +140,37 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
       <button
         onClick={() => saveTemplateToApi()}
         disabled={isSaving}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+        className="flex items-center gap-1.5 px-3.5 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
       >
-        {isSaving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+        {isSaving ? <Loader2 size={16} className="animate-spin" /> : <Save size={16} />}
         บันทึก
       </button>
 
       <button
         onClick={() => undo()}
-        className="flex items-center gap-1.5 px-2 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+        className="flex items-center gap-1.5 px-2.5 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
         title="Undo (Ctrl+Z)"
       >
-        <Undo2 size={14} />
+        <Undo2 size={16} />
       </button>
 
       <button
         onClick={() => setPreviewMode(!previewMode)}
-        className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg transition-colors ${
+        className={`flex items-center gap-1.5 px-3.5 py-2 text-sm rounded-lg transition-colors ${
           previewMode
             ? 'bg-violet-600 text-white hover:bg-violet-700'
             : 'text-gray-700 border border-gray-300 hover:bg-gray-50'
         }`}
       >
-        {previewMode ? <EyeOff size={14} /> : <Eye size={14} />}
+        {previewMode ? <EyeOff size={16} /> : <Eye size={16} />}
         {previewMode ? 'แก้ไข' : 'Preview'}
       </button>
 
       <button
         onClick={() => setShowExportModal(true)}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 transition-colors"
+        className="flex items-center gap-1.5 px-3.5 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 transition-colors"
       >
-        <Download size={14} />
+        <Download size={16} />
         PDF
       </button>
     </div>

--- a/apps/web/src/components/ui/DataTable.tsx
+++ b/apps/web/src/components/ui/DataTable.tsx
@@ -50,7 +50,7 @@ function DataTable<T extends { id: string }>({
               {columns.map((col) => (
                 <th
                   key={col.key}
-                  className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
+                  className="px-5 py-3.5 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
                 >
                   {col.label}
                 </th>
@@ -68,7 +68,7 @@ function DataTable<T extends { id: string }>({
               data.map((item, idx) => (
                 <tr key={item.id} className={`hover:bg-gray-50 transition-colors${onRowClick || onRowDoubleClick ? ' cursor-pointer' : ''}`} onClick={() => onRowClick?.(item)} onDoubleClick={() => onRowDoubleClick?.(item)}>
                   {columns.map((col) => (
-                    <td key={col.key} className="px-4 py-3 text-sm text-gray-700">
+                    <td key={col.key} className="px-5 py-3.5 text-sm text-gray-700">
                       {col.render
                         ? col.render(item, col, idx)
                         : (item as Record<string, unknown>)[col.key]?.toString() || '-'}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -21,6 +21,8 @@
 
 body {
   font-family: 'TH Sarabun PSK', 'Noto Sans Thai', sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
 }
 
 @layer utilities {
@@ -38,10 +40,10 @@ body {
 /* ── Tiptap Rich Text Editor ──────────────────────────── */
 .tiptap.ProseMirror {
   min-height: 240px;
-  padding: 12px 16px;
+  padding: 14px 18px;
   outline: none;
   font-family: 'TH Sarabun PSK', 'Noto Sans Thai', sans-serif;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.8;
   color: #1a1a1a;
 }


### PR DESCRIPTION
- Sidebar: increase section headers from 10-11px to 12px (text-xs)
- CheatSheet: widen panel to 280px, increase font sizes from 10-11px to 12px, larger copy icons and button padding
- DataTable: increase cell padding (py-3 → py-3.5, px-4 → px-5) for better touch targets and breathing room
- BlockItem: increase type badge from 10px to 12px (text-xs), more header padding, wider action button gaps
- EditorSidebar: fix low-contrast text (#A5A0C0 → gray-300/400), increase subtitle from 10px to 12px
- HeaderBar: increase all toolbar icons from 14px to 16px, larger button padding (py-1.5 → py-2)
- TopBar: increase role label to text-sm, larger logout button
- Global: set body base font to 16px with 1.6 line-height, increase Tiptap editor font from 14px to 16px

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23