### PR TITLE
ui: scale up font sizes globally for Thai readability

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -21,8 +21,11 @@
 
 body {
   font-family: 'TH Sarabun PSK', 'Noto Sans Thai', sans-serif;
-  font-size: 16px;
+  font-size: 17px;
   line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 @layer utilities {
@@ -43,7 +46,7 @@ body {
   padding: 14px 18px;
   outline: none;
   font-family: 'TH Sarabun PSK', 'Noto Sans Thai', sans-serif;
-  font-size: 16px;
+  font-size: 17px;
   line-height: 1.8;
   color: #1a1a1a;
 }

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -3,6 +3,20 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      /* ── Thai-friendly font scale ─────────────────────────
+         TH Sarabun PSK renders smaller than Latin fonts at the
+         same px value.  Bump every step ~1-2px so Thai text
+         stays legible, especially at the small end.
+         ──────────────────────────────────────────────────── */
+      fontSize: {
+        'xs':   ['13px', { lineHeight: '1.5' }],
+        'sm':   ['15px', { lineHeight: '1.55' }],
+        'base': ['17px', { lineHeight: '1.6' }],
+        'lg':   ['19px', { lineHeight: '1.55' }],
+        'xl':   ['21px', { lineHeight: '1.5' }],
+        '2xl':  ['26px', { lineHeight: '1.4' }],
+        '3xl':  ['32px', { lineHeight: '1.35' }],
+      },
       keyframes: {
         fadeIn: {
           '0%': { opacity: '0', transform: 'translateY(8px)' },


### PR DESCRIPTION
Thai characters (TH Sarabun PSK) are more complex than Latin and render visually smaller at the same pixel size. Override Tailwind's default font scale so every text-xs/sm/base/lg/xl/2xl/3xl step is ~1-2px larger with appropriate line-heights:

  text-xs  12→13px   text-sm  14→15px   text-base 16→17px
  text-lg  18→19px   text-xl  20→21px   text-2xl  24→26px

Also add font smoothing (antialiased + optimizeLegibility) to body for crisper rendering, and bump Tiptap editor to 17px to match.

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23