### PR TITLE
ui: Blue Ocean theme + larger Thai font scale for readability

### DIFF
--- a/apps/web/src/components/contract/CreditCheckPanel.tsx
+++ b/apps/web/src/components/contract/CreditCheckPanel.tsx
@@ -187,7 +187,7 @@ export default function CreditCheckPanel({ contractId }: { contractId: string })
             <button
               onClick={() => analyzeMutation.mutate()}
               disabled={analyzeMutation.isPending}
-              className="px-4 py-2 text-sm bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
             >
               {analyzeMutation.isPending ? 'กำลังวิเคราะห์...' : 'AI วิเคราะห์เครดิต'}
             </button>

--- a/apps/web/src/components/landing/LandingNav.tsx
+++ b/apps/web/src/components/landing/LandingNav.tsx
@@ -26,7 +26,7 @@ export default function LandingNav({ onScrollTo }: LandingNavProps) {
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <div className="flex items-center gap-2">
-            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-400 to-purple-500 flex items-center justify-center">
+            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-400 to-sky-500 flex items-center justify-center">
               <span className="text-white font-bold text-sm">B</span>
             </div>
             <span className="text-xl font-bold text-white">

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -132,7 +132,7 @@ function Sidebar() {
       {/* Logo */}
       <div className="p-5 border-b border-white/10">
         <div className="flex items-center gap-2.5">
-          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary-400 to-purple-500 flex items-center justify-center shadow-lg shadow-primary-500/20">
+          <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary-400 to-sky-400 flex items-center justify-center shadow-lg shadow-primary-500/20">
             <span className="text-white font-bold text-sm">B</span>
           </div>
           <div>
@@ -264,7 +264,7 @@ function Sidebar() {
                       <div key={item.path}>
                         {showGroupHeader && (
                           <div className={clsx('flex items-center gap-2 px-3', idx > 0 ? 'mt-3 mb-1' : 'mb-1')}>
-                            <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-600">
+                            <span className="text-xs font-semibold uppercase tracking-wider text-gray-600">
                               {item.group}
                             </span>
                             <div className="flex-1 h-px bg-white/5" />
@@ -283,7 +283,7 @@ function Sidebar() {
                           }
                         >
                           {item.step != null && (
-                            <span className="w-5 h-5 rounded-full bg-white/10 flex items-center justify-center text-[11px] font-bold shrink-0">
+                            <span className="w-5 h-5 rounded-full bg-white/10 flex items-center justify-center text-xs font-bold shrink-0">
                               {item.step}
                             </span>
                           )}

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -29,7 +29,7 @@ export default function TopBar() {
             {user?.role && roleLabels[user.role]}
           </p>
         </div>
-        <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary-500 to-purple-600 flex items-center justify-center">
+        <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary-500 to-sky-400 flex items-center justify-center">
           <span className="text-white text-sm font-bold">{user?.name?.charAt(0)}</span>
         </div>
         <button

--- a/apps/web/src/components/template-editor/editor/BlockEditModal.tsx
+++ b/apps/web/src/components/template-editor/editor/BlockEditModal.tsx
@@ -106,7 +106,7 @@ export default function BlockEditModal() {
               <select
                 value={form.type}
                 onChange={e => setForm(prev => ({ ...prev, type: e.target.value as BlockType }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-violet-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
               >
                 {BLOCK_TYPES.map(t => (
                   <option key={t.value} value={t.value}>{t.label} — {t.description}</option>
@@ -161,7 +161,7 @@ export default function BlockEditModal() {
                   onChange={e => setForm(prev => ({ ...prev, content: e.target.value }))}
                   placeholder="เนื้อหาสำหรับ block นี้..."
                   rows={6}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-violet-500 resize-y"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-blue-500 resize-y"
                 />
               )}
             </div>
@@ -173,7 +173,7 @@ export default function BlockEditModal() {
                   <label className="text-sm font-medium text-gray-700">ข้อย่อย</label>
                   <button
                     onClick={addSubItem}
-                    className="flex items-center gap-1 text-xs text-violet-600 hover:text-violet-700"
+                    className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700"
                   >
                     <Plus size={12} /> เพิ่มข้อย่อย
                   </button>
@@ -237,11 +237,11 @@ export default function BlockEditModal() {
                             <button
                               key={v.key}
                               onClick={() => insertVariable(v.key)}
-                              className="w-full flex items-center gap-2 px-2 py-1.5 text-left rounded hover:bg-violet-50 hover:text-violet-700 transition-colors group"
+                              className="w-full flex items-center gap-2 px-2 py-1.5 text-left rounded hover:bg-blue-50 hover:text-blue-700 transition-colors group"
                               title={`ตัวอย่าง: ${v.sampleValue}`}
                             >
-                              <span className="text-xs text-gray-700 group-hover:text-violet-700 truncate flex-1">{v.label}</span>
-                              <span className="text-[9px] px-1 py-0.5 rounded bg-gray-200 text-gray-500 group-hover:bg-violet-100 group-hover:text-violet-600 shrink-0">
+                              <span className="text-xs text-gray-700 group-hover:text-blue-700 truncate flex-1">{v.label}</span>
+                              <span className="text-[9px] px-1 py-0.5 rounded bg-gray-200 text-gray-500 group-hover:bg-blue-100 group-hover:text-blue-600 shrink-0">
                                 แทรก
                               </span>
                             </button>
@@ -279,7 +279,7 @@ export default function BlockEditModal() {
         <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200">
           <button
             onClick={() => setShowVarPanel(!showVarPanel)}
-            className="text-xs text-gray-500 hover:text-violet-600"
+            className="text-xs text-gray-500 hover:text-blue-600"
           >
             {showVarPanel ? 'ซ่อนตัวแปร' : 'แสดงตัวแปร'}
           </button>
@@ -292,7 +292,7 @@ export default function BlockEditModal() {
             </button>
             <button
               onClick={handleSave}
-              className="px-4 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700"
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700"
             >
               บันทึก
             </button>

--- a/apps/web/src/components/template-editor/editor/BlockItem.tsx
+++ b/apps/web/src/components/template-editor/editor/BlockItem.tsx
@@ -42,7 +42,7 @@ export default function BlockItem({ block, index, totalBlocks }: Props) {
       ref={setNodeRef}
       style={style}
       className={`group border rounded-lg bg-white transition-shadow ${
-        isDragging ? 'shadow-lg border-violet-300' : 'border-gray-200 hover:border-violet-200 hover:shadow-sm'
+        isDragging ? 'shadow-lg border-blue-300' : 'border-gray-200 hover:border-blue-200 hover:shadow-sm'
       }`}
     >
       {/* Header */}
@@ -65,7 +65,7 @@ export default function BlockItem({ block, index, totalBlocks }: Props) {
         </button>
 
         {/* Type badge */}
-        <span className="text-xs px-2.5 py-0.5 bg-violet-50 text-violet-700 rounded-full font-medium">
+        <span className="text-xs px-2.5 py-0.5 bg-blue-50 text-blue-700 rounded-full font-medium">
           {label}
         </span>
 

--- a/apps/web/src/components/template-editor/editor/RichTextEditor.tsx
+++ b/apps/web/src/components/template-editor/editor/RichTextEditor.tsx
@@ -90,7 +90,7 @@ export default function RichTextEditor({ value, onChange, onEditorReady, placeho
   if (!editor) return null;
 
   return (
-    <div className="border border-gray-300 rounded-lg overflow-hidden focus-within:ring-2 focus-within:ring-violet-500 focus-within:border-violet-500">
+    <div className="border border-gray-300 rounded-lg overflow-hidden focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500">
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-0.5 px-2 py-1.5 bg-gray-50 border-b border-gray-200">
         {/* Undo / Redo */}
@@ -293,7 +293,7 @@ function ToolbarButton({ onClick, active, disabled, title, children }: {
       title={title}
       className={`p-1.5 rounded transition-colors ${
         active
-          ? 'bg-violet-100 text-violet-700'
+          ? 'bg-blue-100 text-blue-700'
           : 'text-gray-600 hover:bg-gray-200 hover:text-gray-800'
       } ${disabled ? 'opacity-30 cursor-not-allowed' : ''}`}
     >
@@ -319,7 +319,7 @@ function ColorDropdown({ icon, colors, activeColor, onSelect, onClear, title }: 
       <button
         type="button"
         className={`p-1.5 rounded transition-colors flex items-center gap-0.5 ${
-          activeColor ? 'bg-violet-50 text-violet-700' : 'text-gray-600 hover:bg-gray-200'
+          activeColor ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-200'
         }`}
         title={title}
       >
@@ -336,7 +336,7 @@ function ColorDropdown({ icon, colors, activeColor, onSelect, onClear, title }: 
               type="button"
               onClick={() => onSelect(color)}
               className={`w-8 h-8 rounded border-2 transition-transform hover:scale-110 ${
-                activeColor === color ? 'border-violet-500 ring-1 ring-violet-300' : 'border-gray-200'
+                activeColor === color ? 'border-blue-500 ring-1 ring-blue-300' : 'border-gray-200'
               }`}
               style={{ backgroundColor: color }}
               title={color}

--- a/apps/web/src/components/template-editor/editor/VariableAutocomplete.tsx
+++ b/apps/web/src/components/template-editor/editor/VariableAutocomplete.tsx
@@ -91,7 +91,7 @@ export default function VariableAutocomplete({ value, onChange, placeholder, row
         onChange={handleInput}
         placeholder={placeholder}
         rows={rows}
-        className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-violet-500 focus:border-violet-500 resize-y"
+        className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-y"
         spellCheck={false}
       />
 
@@ -117,9 +117,9 @@ export default function VariableAutocomplete({ value, onChange, placeholder, row
                   <button
                     key={v.key}
                     onClick={() => insertVariable(v.key)}
-                    className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-violet-50 transition-colors"
+                    className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-blue-50 transition-colors"
                   >
-                    <span className="text-xs font-mono text-violet-700">{v.key}</span>
+                    <span className="text-xs font-mono text-blue-700">{v.key}</span>
                     <span className="text-[10px] text-gray-400 flex-1 truncate">{v.label}</span>
                     <span className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-500">{v.type}</span>
                   </button>

--- a/apps/web/src/components/template-editor/layout/CheatSheet.tsx
+++ b/apps/web/src/components/template-editor/layout/CheatSheet.tsx
@@ -42,11 +42,11 @@ export default function CheatSheet() {
       <div className="mt-4 pt-3 border-t border-gray-200">
         <div className="text-xs font-bold text-gray-400 uppercase mb-2">ตัวอย่าง</div>
         <div className="space-y-1.5 text-xs text-gray-600 font-mono">
-          <p><span className="text-violet-600">{'{{= CONTRACT.NUMBER}}'}</span></p>
+          <p><span className="text-blue-600">{'{{= CONTRACT.NUMBER}}'}</span></p>
           <p><span className="text-teal-600">{'{{= CONTRACT.DATE | date:l}}'}</span></p>
           <p><span className="text-teal-600">{'{{= CONTRACT.TOTAL_AMOUNT | num:2}}'}</span></p>
           <p className="text-blue-600">{'{{for ITEM in INSTALLMENTS}}'}</p>
-          <p className="ml-2 text-violet-600">{'{{= ITEM.NO}} {{= ITEM.AMOUNT | num:2}}'}</p>
+          <p className="ml-2 text-blue-600">{'{{= ITEM.NO}} {{= ITEM.AMOUNT | num:2}}'}</p>
           <p className="text-blue-600">{'{{/for}}'}</p>
         </div>
       </div>

--- a/apps/web/src/components/template-editor/layout/EditorSidebar.tsx
+++ b/apps/web/src/components/template-editor/layout/EditorSidebar.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 export default function EditorSidebar({ activeId, onSelect, onBack }: Props) {
   return (
-    <div className="w-[200px] min-h-full bg-[#1E1B2E] flex flex-col flex-shrink-0">
+    <div className="w-[200px] min-h-full bg-primary-950 flex flex-col flex-shrink-0">
       {/* Logo + Back */}
       <div className="px-4 py-4 border-b border-white/10">
         {onBack && (
@@ -51,7 +51,7 @@ export default function EditorSidebar({ activeId, onSelect, onBack }: Props) {
             onClick={() => onSelect(item.id)}
             className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors ${
               activeId === item.id
-                ? 'bg-[#6D28D9] text-white'
+                ? 'bg-primary-600 text-white'
                 : 'text-gray-300 hover:bg-white/5 hover:text-white'
             }`}
           >

--- a/apps/web/src/components/template-editor/layout/HeaderBar.tsx
+++ b/apps/web/src/components/template-editor/layout/HeaderBar.tsx
@@ -73,7 +73,7 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
         value={currentTemplate.id}
         onChange={handleTemplateChange}
         disabled={isLoading}
-        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-violet-500 focus:border-violet-500 max-w-[320px] disabled:opacity-50"
+        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 max-w-[320px] disabled:opacity-50"
       >
         {templates.length === 0 && (
           <option value="">กำลังโหลด...</option>
@@ -128,7 +128,7 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
               <button
                 key={b.type}
                 onClick={() => handleAddBlock(b.type)}
-                className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-violet-50 hover:text-violet-700 transition-colors"
+                className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 transition-colors"
               >
                 {b.label}
               </button>
@@ -158,7 +158,7 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
         onClick={() => setPreviewMode(!previewMode)}
         className={`flex items-center gap-1.5 px-3.5 py-2 text-sm rounded-lg transition-colors ${
           previewMode
-            ? 'bg-violet-600 text-white hover:bg-violet-700'
+            ? 'bg-blue-600 text-white hover:bg-blue-700'
             : 'text-gray-700 border border-gray-300 hover:bg-gray-50'
         }`}
       >
@@ -168,7 +168,7 @@ export default function HeaderBar({ onBack, onToggleCheatSheet, showCheatSheet }
 
       <button
         onClick={() => setShowExportModal(true)}
-        className="flex items-center gap-1.5 px-3.5 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 transition-colors"
+        className="flex items-center gap-1.5 px-3.5 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
       >
         <Download size={16} />
         PDF

--- a/apps/web/src/components/template-editor/modals/SettingsModal.tsx
+++ b/apps/web/src/components/template-editor/modals/SettingsModal.tsx
@@ -34,7 +34,7 @@ export default function SettingsModal() {
                     name="letterhead"
                     checked={settings.letterhead === opt.value}
                     onChange={() => updateSettings({ letterhead: opt.value as typeof settings.letterhead })}
-                    className="text-violet-600 focus:ring-violet-500"
+                    className="text-blue-600 focus:ring-blue-500"
                   />
                   {opt.label}
                 </label>
@@ -48,7 +48,7 @@ export default function SettingsModal() {
               type="checkbox"
               checked={settings.showPageNumber}
               onChange={e => updateSettings({ showPageNumber: e.target.checked })}
-              className="rounded text-violet-600 focus:ring-violet-500"
+              className="rounded text-blue-600 focus:ring-blue-500"
             />
             เพิ่มเลขหน้า (หน้า X/Y)
           </label>
@@ -59,7 +59,7 @@ export default function SettingsModal() {
               type="checkbox"
               checked={settings.showSignatureExceptLastPage}
               onChange={e => updateSettings({ showSignatureExceptLastPage: e.target.checked })}
-              className="rounded text-violet-600 focus:ring-violet-500"
+              className="rounded text-blue-600 focus:ring-blue-500"
             />
             เพิ่มลายเซ็น ยกเว้นหน้าสุดท้าย
           </label>
@@ -71,7 +71,7 @@ export default function SettingsModal() {
               type="text"
               value={settings.footerText}
               onChange={e => updateSettings({ footerText: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-violet-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
@@ -136,7 +136,7 @@ export default function SettingsModal() {
         <div className="flex justify-end px-6 py-4 border-t border-gray-200">
           <button
             onClick={() => setShowSettings(false)}
-            className="px-4 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700"
+            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700"
           >
             ปิด
           </button>

--- a/apps/web/src/components/template-editor/pdf/PDFExportModal.tsx
+++ b/apps/web/src/components/template-editor/pdf/PDFExportModal.tsx
@@ -75,7 +75,7 @@ export default function PDFExportModal() {
                 <button
                   onClick={() => handleGenerate('preview')}
                   disabled={isGenerating}
-                  className="flex items-center gap-2 px-6 py-3 text-sm border border-violet-300 text-violet-700 rounded-lg hover:bg-violet-50 disabled:opacity-50 transition-colors"
+                  className="flex items-center gap-2 px-6 py-3 text-sm border border-blue-300 text-blue-700 rounded-lg hover:bg-blue-50 disabled:opacity-50 transition-colors"
                 >
                   {isGenerating ? <Loader2 size={16} className="animate-spin" /> : <Eye size={16} />}
                   Preview
@@ -83,7 +83,7 @@ export default function PDFExportModal() {
                 <button
                   onClick={() => handleGenerate('download')}
                   disabled={isGenerating}
-                  className="flex items-center gap-2 px-6 py-3 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 disabled:opacity-50 transition-colors"
+                  className="flex items-center gap-2 px-6 py-3 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
                 >
                   {isGenerating ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
                   ดาวน์โหลด PDF
@@ -105,7 +105,7 @@ export default function PDFExportModal() {
             <button
               onClick={() => handleGenerate('download')}
               disabled={isGenerating}
-              className="flex items-center gap-2 px-4 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 disabled:opacity-50"
+              className="flex items-center gap-2 px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
             >
               <Download size={14} />
               ดาวน์โหลด PDF

--- a/apps/web/src/components/template-editor/preview/BlockRenderer.tsx
+++ b/apps/web/src/components/template-editor/preview/BlockRenderer.tsx
@@ -33,7 +33,7 @@ function RichHtmlContent({ html, previewMode, ctx }: { html: string; previewMode
     ? resolved
     : resolved.replace(
         /\{\{=\s*([^}]*)\}\}/g,
-        '<span style="background:#ede9fe;color:#6d28d9;padding:1px 4px;border-radius:3px;font-family:monospace;font-size:0.85em">{{= $1}}</span>'
+        '<span style="background:#dbeafe;color:#1d4ed8;padding:1px 4px;border-radius:3px;font-family:monospace;font-size:0.85em">{{= $1}}</span>'
       );
   const clean = DOMPurify.sanitize(withHighlights, {
     ADD_TAGS: ['span'],
@@ -50,7 +50,7 @@ export default function BlockRenderer({ block, previewMode }: Props) {
   switch (block.type) {
     case 'contract-header':
       return (
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px', fontSize: '13px', color: '#4a4a4a' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px', fontSize: '15px', color: '#4a4a4a' }}>
           {isRich
             ? <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
             : <VariableHighlighter text={block.content} previewMode={previewMode} resolvedText={resolved} />
@@ -60,7 +60,7 @@ export default function BlockRenderer({ block, previewMode }: Props) {
 
     case 'heading':
       return (
-        <h2 style={{ textAlign: 'center', fontWeight: 700, fontSize: '18px', margin: '16px 0 12px', letterSpacing: '0.5px', color: '#111' }}>
+        <h2 style={{ textAlign: 'center', fontWeight: 700, fontSize: '20px', margin: '16px 0 12px', letterSpacing: '0.5px', color: '#111' }}>
           {isRich
             ? <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
             : <VariableHighlighter text={block.content} previewMode={previewMode} resolvedText={resolved} />
@@ -70,7 +70,7 @@ export default function BlockRenderer({ block, previewMode }: Props) {
 
     case 'subheading':
       return (
-        <h3 style={{ fontWeight: 700, fontSize: '15px', marginTop: '14px', marginBottom: '6px', color: '#222' }}>
+        <h3 style={{ fontWeight: 700, fontSize: '17px', marginTop: '14px', marginBottom: '6px', color: '#222' }}>
           {isRich
             ? <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
             : <VariableHighlighter text={block.content} previewMode={previewMode} resolvedText={resolved} />
@@ -84,13 +84,13 @@ export default function BlockRenderer({ block, previewMode }: Props) {
     case 'agreement':
       if (isRich) {
         return (
-          <div style={{ fontSize: '14px', lineHeight: 1.8, margin: '4px 0', color: '#1a1a1a' }}>
+          <div style={{ fontSize: '16px', lineHeight: 1.8, margin: '4px 0', color: '#1a1a1a' }}>
             <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
           </div>
         );
       }
       return (
-        <p style={{ fontSize: '14px', lineHeight: 1.8, margin: '4px 0', textIndent: '2em', color: '#1a1a1a' }}>
+        <p style={{ fontSize: '16px', lineHeight: 1.8, margin: '4px 0', textIndent: '2em', color: '#1a1a1a' }}>
           <VariableHighlighter text={block.content} previewMode={previewMode} resolvedText={resolved} />
         </p>
       );
@@ -99,7 +99,7 @@ export default function BlockRenderer({ block, previewMode }: Props) {
       if (previewMode) {
         const contacts = (ctx['EMERGENCY_CONTACTS'] || []) as { NAME: string; TEL: string; RELATION: string }[];
         return (
-          <div style={{ margin: '8px 0', fontSize: '14px' }}>
+          <div style={{ margin: '8px 0', fontSize: '16px' }}>
             <p style={{ marginBottom: '4px' }}>(กรณีที่ผู้ให้เช่าซื้อติดต่อผู้เช่าซื้อไม่ได้ ขอให้ติดต่อบุคคลดังต่อไปนี้)</p>
             <table style={{ width: '100%', borderCollapse: 'collapse', marginLeft: '2em' }}>
               <tbody>
@@ -117,7 +117,7 @@ export default function BlockRenderer({ block, previewMode }: Props) {
         );
       }
       return (
-        <div style={{ margin: '8px 0', fontSize: '14px' }}>
+        <div style={{ margin: '8px 0', fontSize: '16px' }}>
           {isRich
             ? <RichHtmlContent html={block.content} previewMode={false} ctx={ctx} />
             : <VariableHighlighter text={block.content} previewMode={false} />
@@ -129,10 +129,10 @@ export default function BlockRenderer({ block, previewMode }: Props) {
       const resolvedClause = previewMode ? renderVariables(block.content, ctx) : '';
       return (
         <div style={{ margin: '10px 0' }}>
-          <p style={{ fontSize: '14px', fontWeight: 700, color: '#111' }}>
+          <p style={{ fontSize: '16px', fontWeight: 700, color: '#111' }}>
             ข้อ {block.clauseNumber} {block.clauseTitle}
           </p>
-          <div style={{ fontSize: '14px', lineHeight: 1.8, marginTop: '4px', color: '#1a1a1a' }}>
+          <div style={{ fontSize: '16px', lineHeight: 1.8, marginTop: '4px', color: '#1a1a1a' }}>
             {isRich
               ? <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
               : (
@@ -148,11 +148,11 @@ export default function BlockRenderer({ block, previewMode }: Props) {
                 const resolvedItem = previewMode ? renderVariables(item, ctx) : '';
                 const subIsRich = isHtmlContent(item);
                 return subIsRich ? (
-                  <div key={i} style={{ fontSize: '13px', lineHeight: 1.7, marginBottom: '2px', color: '#333' }}>
+                  <div key={i} style={{ fontSize: '15px', lineHeight: 1.7, marginBottom: '2px', color: '#333' }}>
                     <RichHtmlContent html={item} previewMode={previewMode} ctx={ctx} />
                   </div>
                 ) : (
-                  <p key={i} style={{ fontSize: '13px', lineHeight: 1.7, marginBottom: '2px', color: '#333' }}>
+                  <p key={i} style={{ fontSize: '15px', lineHeight: 1.7, marginBottom: '2px', color: '#333' }}>
                     <VariableHighlighter text={item} previewMode={previewMode} resolvedText={resolvedItem} />
                   </p>
                 );
@@ -172,15 +172,15 @@ export default function BlockRenderer({ block, previewMode }: Props) {
     case 'photo-attachment':
       return (
         <div style={{ margin: '20px 0', pageBreakBefore: 'always' }}>
-          <p style={{ fontSize: '14px', fontWeight: 700, marginBottom: '12px', textAlign: 'center' }}>รูปถ่ายโทรศัพท์แนบท้ายสัญญา</p>
+          <p style={{ fontSize: '16px', fontWeight: 700, marginBottom: '12px', textAlign: 'center' }}>รูปถ่ายโทรศัพท์แนบท้ายสัญญา</p>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
             {[1, 2, 3, 4, 5, 6].map(n => (
-              <div key={n} style={{ border: '2px dashed #d1d5db', borderRadius: '8px', height: '120px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#9ca3af', fontSize: '13px' }}>
+              <div key={n} style={{ border: '2px dashed #d1d5db', borderRadius: '8px', height: '120px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#9ca3af', fontSize: '15px' }}>
                 รูปภาพ {n}
               </div>
             ))}
           </div>
-          <div style={{ marginTop: '16px', textAlign: 'center', fontSize: '14px' }}>
+          <div style={{ marginTop: '16px', textAlign: 'center', fontSize: '16px' }}>
             <p>ชื่อ .............................. ผู้เช่าซื้อ</p>
             <p>วันที่ .......... เดือน .................. พ.ศ ............</p>
           </div>
@@ -190,13 +190,13 @@ export default function BlockRenderer({ block, previewMode }: Props) {
     case 'attachment-list':
       if (isRich) {
         return (
-          <div style={{ margin: '12px 0', fontSize: '14px' }}>
+          <div style={{ margin: '12px 0', fontSize: '16px' }}>
             <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
           </div>
         );
       }
       return (
-        <div style={{ margin: '12px 0', fontSize: '14px' }}>
+        <div style={{ margin: '12px 0', fontSize: '16px' }}>
           {block.content.split('\n').map((line, i) => (
             <p key={i} style={{ fontWeight: i === 0 ? 700 : 400, marginLeft: i === 0 ? 0 : '2em', marginBottom: '2px' }}>
               <VariableHighlighter text={line} previewMode={previewMode} resolvedText={previewMode ? renderVariables(line, ctx) : ''} />
@@ -209,13 +209,13 @@ export default function BlockRenderer({ block, previewMode }: Props) {
     case 'column-vertical':
       if (isRich) {
         return (
-          <div style={{ margin: '8px 0', fontSize: '14px' }}>
+          <div style={{ margin: '8px 0', fontSize: '16px' }}>
             <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
           </div>
         );
       }
       return (
-        <div style={{ margin: '8px 0', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px', fontSize: '14px', alignItems: block.type === 'column-vertical' ? 'start' : 'center' }}>
+        <div style={{ margin: '8px 0', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px', fontSize: '16px', alignItems: block.type === 'column-vertical' ? 'start' : 'center' }}>
           {block.content.split('||').map((col, i) => (
             <div key={i}>
               <VariableHighlighter text={col.trim()} previewMode={previewMode} resolvedText={previewMode ? renderVariables(col.trim(), ctx) : ''} />
@@ -227,13 +227,13 @@ export default function BlockRenderer({ block, previewMode }: Props) {
     case 'numbered':
       if (isRich) {
         return (
-          <div style={{ margin: '4px 0', marginLeft: '2em', fontSize: '14px' }}>
+          <div style={{ margin: '4px 0', marginLeft: '2em', fontSize: '16px' }}>
             <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
           </div>
         );
       }
       return (
-        <div style={{ margin: '4px 0', marginLeft: '2em', fontSize: '14px' }}>
+        <div style={{ margin: '4px 0', marginLeft: '2em', fontSize: '16px' }}>
           <VariableHighlighter text={block.content} previewMode={previewMode} resolvedText={resolved} />
         </div>
       );
@@ -241,13 +241,13 @@ export default function BlockRenderer({ block, previewMode }: Props) {
     default:
       if (isRich) {
         return (
-          <div style={{ fontSize: '14px', margin: '4px 0' }}>
+          <div style={{ fontSize: '16px', margin: '4px 0' }}>
             <RichHtmlContent html={block.content} previewMode={previewMode} ctx={ctx} />
           </div>
         );
       }
       return (
-        <p style={{ fontSize: '14px', margin: '4px 0' }}>
+        <p style={{ fontSize: '16px', margin: '4px 0' }}>
           <VariableHighlighter text={block.content} previewMode={previewMode} resolvedText={resolved} />
         </p>
       );

--- a/apps/web/src/components/template-editor/preview/DocumentPreview.tsx
+++ b/apps/web/src/components/template-editor/preview/DocumentPreview.tsx
@@ -6,7 +6,7 @@ export default function DocumentPreview() {
   const { blocks, settings } = currentTemplate;
 
   return (
-    <div className="flex-1 bg-[#E8E6EE] overflow-y-auto p-8">
+    <div className="flex-1 bg-slate-100 overflow-y-auto p-8">
       {/* A4 Paper simulation */}
       <div
         className="mx-auto bg-white rounded-sm"
@@ -23,14 +23,14 @@ export default function DocumentPreview() {
       >
         {/* Letterhead */}
         {settings.letterhead === 'bestchoice' && (
-          <div className="text-center mb-5 pb-3" style={{ borderBottom: '2px solid #6D28D9' }}>
-            <h1 style={{ fontSize: '18px', fontWeight: 700, color: '#6D28D9', letterSpacing: '1px', marginBottom: '4px' }}>
+          <div className="text-center mb-5 pb-3" style={{ borderBottom: '2px solid #2563eb' }}>
+            <h1 style={{ fontSize: '20px', fontWeight: 700, color: '#1d4ed8', letterSpacing: '1px', marginBottom: '4px' }}>
               BESTCHOICEPHONE Co., Ltd.
             </h1>
-            <p style={{ fontSize: '12px', color: '#4a4a4a', marginBottom: '2px' }}>
+            <p style={{ fontSize: '14px', color: '#4a4a4a', marginBottom: '2px' }}>
               บริษัท เบสท์ช้อยส์โฟน จำกัด | เลขประจำตัวผู้เสียภาษี 0165568000050
             </p>
-            <p style={{ fontSize: '10px', color: '#888' }}>
+            <p style={{ fontSize: '12px', color: '#888' }}>
               456/21 ชั้น 2 ถนนนารายณ์มหาราช ตำบลทะเลชุบศร อำเภอเมือง จังหวัดลพบุรี 15000
             </p>
           </div>

--- a/apps/web/src/components/template-editor/preview/PaymentTable.tsx
+++ b/apps/web/src/components/template-editor/preview/PaymentTable.tsx
@@ -25,9 +25,9 @@ export default function PaymentTable({ previewMode }: Props) {
           </thead>
           <tbody>
             <tr>
-              <td className="border border-gray-300 px-3 py-1.5 text-xs font-mono text-violet-600">{'{{= INSTALLMENT.NO}}'}</td>
-              <td className="border border-gray-300 px-3 py-1.5 text-xs font-mono text-violet-600">{'{{= INSTALLMENT.DUE_DATE | date:m}}'}</td>
-              <td className="border border-gray-300 px-3 py-1.5 text-xs font-mono text-violet-600 text-right">{'{{= INSTALLMENT.AMOUNT | num:2}}'}</td>
+              <td className="border border-gray-300 px-3 py-1.5 text-xs font-mono text-blue-600">{'{{= INSTALLMENT.NO}}'}</td>
+              <td className="border border-gray-300 px-3 py-1.5 text-xs font-mono text-blue-600">{'{{= INSTALLMENT.DUE_DATE | date:m}}'}</td>
+              <td className="border border-gray-300 px-3 py-1.5 text-xs font-mono text-blue-600 text-right">{'{{= INSTALLMENT.AMOUNT | num:2}}'}</td>
             </tr>
           </tbody>
         </table>

--- a/apps/web/src/components/template-editor/preview/VariableHighlighter.tsx
+++ b/apps/web/src/components/template-editor/preview/VariableHighlighter.tsx
@@ -73,7 +73,7 @@ export default function VariableHighlighter({ text, previewMode, resolvedText }:
 
   const colorMap = {
     text: '',
-    print: 'bg-violet-100 text-violet-700 px-1 rounded',
+    print: 'bg-blue-100 text-blue-700 px-1 rounded',
     loop: 'bg-blue-100 text-blue-700 px-1 rounded',
     condition: 'bg-amber-100 text-amber-700 px-1 rounded',
     signature: 'bg-emerald-100 text-emerald-700 px-1 rounded',

--- a/apps/web/src/constants/syntaxReference.ts
+++ b/apps/web/src/constants/syntaxReference.ts
@@ -9,7 +9,7 @@ export const SYNTAX_REFERENCE: { group: string; items: SyntaxItem[] }[] = [
   {
     group: 'PRINT',
     items: [
-      { label: 'แสดงค่า', syntax: '{{= VAR.MEMBER}}', color: 'text-violet-700', bgColor: 'bg-violet-100' },
+      { label: 'แสดงค่า', syntax: '{{= VAR.MEMBER}}', color: 'text-blue-700', bgColor: 'bg-blue-100' },
     ],
   },
   {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -21,7 +21,7 @@
 
 body {
   font-family: 'TH Sarabun PSK', 'Noto Sans Thai', sans-serif;
-  font-size: 17px;
+  font-size: 18px;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -30,10 +30,10 @@ body {
 
 @layer utilities {
   .text-gradient {
-    @apply bg-clip-text text-transparent bg-gradient-to-r from-primary-400 to-purple-400;
+    @apply bg-clip-text text-transparent bg-gradient-to-r from-primary-400 to-sky-400;
   }
   .bg-hero-gradient {
-    background: linear-gradient(135deg, #1e1b4b 0%, #312e81 25%, #4338ca 50%, #6366f1 75%, #818cf8 100%);
+    background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 25%, #1d4ed8 50%, #2563eb 75%, #60a5fa 100%);
   }
   .glass-card {
     @apply bg-white/80 backdrop-blur-sm border border-white/20;
@@ -46,7 +46,7 @@ body {
   padding: 14px 18px;
   outline: none;
   font-family: 'TH Sarabun PSK', 'Noto Sans Thai', sans-serif;
-  font-size: 17px;
+  font-size: 18px;
   line-height: 1.8;
   color: #1a1a1a;
 }
@@ -100,8 +100,8 @@ body {
 
 /* Variable tag styling inside editor */
 .tiptap.ProseMirror .variable-tag {
-  background-color: #ede9fe;
-  color: #6d28d9;
+  background-color: #dbeafe;
+  color: #1d4ed8;
   padding: 1px 4px;
   border-radius: 3px;
   font-family: 'SF Mono', 'Fira Code', monospace;

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -6,10 +6,10 @@
 export const statusLabels: Record<string, { label: string; className: string }> = {
   PO_RECEIVED: { label: 'รับจาก PO', className: 'bg-blue-100 text-blue-700' },
   QC_PENDING: { label: 'รอตรวจรับ', className: 'bg-amber-100 text-amber-700' },
-  PHOTO_PENDING: { label: 'รอถ่ายรูป', className: 'bg-violet-100 text-violet-700' },
+  PHOTO_PENDING: { label: 'รอถ่ายรูป', className: 'bg-blue-100 text-blue-700' },
   INSPECTION: { label: 'กำลังตรวจ', className: 'bg-yellow-100 text-yellow-700' },
   IN_STOCK: { label: 'พร้อมขาย', className: 'bg-green-100 text-green-700' },
-  RESERVED: { label: 'จอง', className: 'bg-purple-100 text-purple-700' },
+  RESERVED: { label: 'จอง', className: 'bg-blue-100 text-blue-700' },
   SOLD_INSTALLMENT: { label: 'ขายผ่อน', className: 'bg-indigo-100 text-indigo-700' },
   SOLD_CASH: { label: 'ขายสด', className: 'bg-teal-100 text-teal-700' },
   REPOSSESSED: { label: 'ยึดคืน', className: 'bg-red-100 text-red-700' },
@@ -53,7 +53,7 @@ export type SaleType = 'CASH' | 'INSTALLMENT' | 'EXTERNAL_FINANCE';
 export const saleTypeConfig: Record<SaleType, { label: string; color: string; bg: string }> = {
   CASH: { label: 'เงินสด', color: 'text-green-700', bg: 'bg-green-50 border-green-300 ring-green-500' },
   INSTALLMENT: { label: 'ผ่อนกับ BESTCHOICE', color: 'text-blue-700', bg: 'bg-blue-50 border-blue-300 ring-blue-500' },
-  EXTERNAL_FINANCE: { label: 'ผ่อนไฟแนนซ์', color: 'text-purple-700', bg: 'bg-purple-50 border-purple-300 ring-purple-500' },
+  EXTERNAL_FINANCE: { label: 'ผ่อนไฟแนนซ์', color: 'text-blue-700', bg: 'bg-blue-50 border-blue-300 ring-blue-500' },
 };
 
 // --- Plan Type (single type: STORE_DIRECT) ---

--- a/apps/web/src/pages/AuditLogsPage.tsx
+++ b/apps/web/src/pages/AuditLogsPage.tsx
@@ -31,7 +31,7 @@ const actionColors: Record<string, string> = {
   PUT: 'bg-blue-100 text-blue-700',
   PATCH: 'bg-yellow-100 text-yellow-700',
   DELETE: 'bg-red-100 text-red-700',
-  EXCHANGE: 'bg-purple-100 text-purple-700',
+  EXCHANGE: 'bg-blue-100 text-blue-700',
   REPOSSESSION: 'bg-orange-100 text-orange-700',
   CREATE_CALL_LOG: 'bg-teal-100 text-teal-700',
   STATUS_CHANGE: 'bg-indigo-100 text-indigo-700',

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -70,7 +70,7 @@ const statusLabels: Record<string, { label: string; className: string }> = {
   DEFAULT: { label: 'ผิดนัด', className: 'bg-red-100 text-red-700' },
   EARLY_PAYOFF: { label: 'ปิดก่อน', className: 'bg-blue-100 text-blue-700' },
   COMPLETED: { label: 'ครบ', className: 'bg-teal-100 text-teal-700' },
-  EXCHANGED: { label: 'เปลี่ยนเครื่อง', className: 'bg-purple-100 text-purple-700' },
+  EXCHANGED: { label: 'เปลี่ยนเครื่อง', className: 'bg-blue-100 text-blue-700' },
   CLOSED_BAD_DEBT: { label: 'หนี้สูญ', className: 'bg-red-200 text-red-800' },
 };
 
@@ -223,7 +223,7 @@ export default function ContractDetailPage() {
         subtitle="รายละเอียดสัญญาผ่อนชำระ"
         action={
           <div className="flex gap-2 flex-wrap">
-            <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-4 py-2 text-sm bg-purple-600 text-white rounded-lg hover:bg-purple-700">
+            <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700">
               ลงนาม/เอกสาร
             </button>
 
@@ -332,7 +332,7 @@ export default function ContractDetailPage() {
               พนักงาน {staffSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
             </span>
             {!allSigned && (
-              <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-2 py-1 bg-purple-600 text-white rounded text-xs hover:bg-purple-700">
+              <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-2 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">
                 ไปลงนาม
               </button>
             )}
@@ -379,7 +379,7 @@ export default function ContractDetailPage() {
                 พนักงาน {staffSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
               </span>
               {!allSigned && (
-                <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-2 py-1 bg-purple-600 text-white rounded text-xs hover:bg-purple-700">
+                <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-2 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">
                   ไปลงนาม
                 </button>
               )}

--- a/apps/web/src/pages/ContractsPage.tsx
+++ b/apps/web/src/pages/ContractsPage.tsx
@@ -34,7 +34,7 @@ const statusLabels: Record<string, { label: string; className: string }> = {
   DEFAULT: { label: 'ผิดนัด', className: 'bg-red-100 text-red-700' },
   EARLY_PAYOFF: { label: 'ปิดก่อน', className: 'bg-blue-100 text-blue-700' },
   COMPLETED: { label: 'ครบ', className: 'bg-teal-100 text-teal-700' },
-  EXCHANGED: { label: 'เปลี่ยนเครื่อง', className: 'bg-purple-100 text-purple-700' },
+  EXCHANGED: { label: 'เปลี่ยนเครื่อง', className: 'bg-blue-100 text-blue-700' },
   CLOSED_BAD_DEBT: { label: 'หนี้สูญ', className: 'bg-red-200 text-red-800' },
 };
 

--- a/apps/web/src/pages/CreditChecksPage.tsx
+++ b/apps/web/src/pages/CreditChecksPage.tsx
@@ -261,7 +261,7 @@ export default function CreditChecksPage() {
             <button
               onClick={() => analyzeMutation.mutate({ customerId: cc.customer.id, creditCheckId: cc.id })}
               disabled={analyzeMutation.isPending}
-              className="px-3 py-1 text-xs bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
+              className="px-3 py-1 text-xs bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
             >
               AI วิเคราะห์
             </button>
@@ -387,11 +387,11 @@ export default function CreditChecksPage() {
 
                 <div className="mt-4 space-y-3">
                   {/* Book Bank OCR */}
-                  <div className="bg-purple-50 border border-purple-200 rounded-lg p-3">
+                  <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
                     <div className="flex items-center justify-between mb-1">
-                      <h4 className="text-sm font-semibold text-purple-800">สแกนหน้าสมุดบัญชี (OCR)</h4>
+                      <h4 className="text-sm font-semibold text-blue-800">สแกนหน้าสมุดบัญชี (OCR)</h4>
                     </div>
-                    <p className="text-xs text-purple-600 mb-2">ถ่ายรูปหน้าสมุดบัญชีเพื่อกรอกชื่อธนาคารอัตโนมัติ</p>
+                    <p className="text-xs text-blue-600 mb-2">ถ่ายรูปหน้าสมุดบัญชีเพื่อกรอกชื่อธนาคารอัตโนมัติ</p>
                     <input
                       ref={bookBankFileRef}
                       type="file"
@@ -404,7 +404,7 @@ export default function CreditChecksPage() {
                       type="button"
                       onClick={() => bookBankFileRef.current?.click()}
                       disabled={bookBankLoading}
-                      className="inline-flex items-center gap-2 px-3 py-1.5 bg-purple-600 text-white rounded-lg text-xs font-medium hover:bg-purple-700 disabled:opacity-50"
+                      className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-600 text-white rounded-lg text-xs font-medium hover:bg-blue-700 disabled:opacity-50"
                     >
                       {bookBankLoading ? (
                         <>
@@ -421,7 +421,7 @@ export default function CreditChecksPage() {
 
                     {/* Book bank OCR result */}
                     {bookBankResult && (
-                      <div className="mt-2 p-2 bg-white rounded border border-purple-200 space-y-1">
+                      <div className="mt-2 p-2 bg-white rounded border border-blue-200 space-y-1">
                         <div className="text-xs text-gray-500">ผลการสแกน:</div>
                         {bookBankResult.accountName && <div className="text-xs"><span className="text-gray-500">ชื่อบัญชี:</span> <span className="font-medium">{bookBankResult.accountName}</span></div>}
                         {bookBankResult.accountNo && <div className="text-xs"><span className="text-gray-500">เลขที่บัญชี:</span> <span className="font-mono">{bookBankResult.accountNo}</span></div>}

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -67,7 +67,7 @@ const statusLabels: Record<string, { label: string; className: string }> = {
   DEFAULT: { label: 'ผิดนัด', className: 'bg-red-100 text-red-700' },
   EARLY_PAYOFF: { label: 'ปิดก่อน', className: 'bg-blue-100 text-blue-700' },
   COMPLETED: { label: 'ครบ', className: 'bg-teal-100 text-teal-700' },
-  EXCHANGED: { label: 'เปลี่ยนเครื่อง', className: 'bg-purple-100 text-purple-700' },
+  EXCHANGED: { label: 'เปลี่ยนเครื่อง', className: 'bg-blue-100 text-blue-700' },
   CLOSED_BAD_DEBT: { label: 'หนี้สูญ', className: 'bg-red-200 text-red-800' },
 };
 
@@ -311,7 +311,7 @@ export default function CustomerDetailPage() {
                       {cc.contract && <span className="text-xs text-primary-600">สัญญา: {cc.contract.contractNumber}</span>}
                     </div>
                     {cc.status === 'PENDING' && (
-                      <button onClick={() => analyzeCreditMutation.mutate(cc.id)} disabled={analyzeCreditMutation.isPending} className="px-3 py-1 text-xs bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50">
+                      <button onClick={() => analyzeCreditMutation.mutate(cc.id)} disabled={analyzeCreditMutation.isPending} className="px-3 py-1 text-xs bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50">
                         {analyzeCreditMutation.isPending ? 'กำลังวิเคราะห์...' : 'AI วิเคราะห์'}
                       </button>
                     )}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -53,7 +53,7 @@ const statusColors: Record<string, string> = {
   OVERDUE: 'bg-yellow-500',
   DEFAULT: 'bg-red-500',
   COMPLETED: 'bg-blue-500',
-  EXCHANGED: 'bg-purple-500',
+  EXCHANGED: 'bg-blue-500',
   CLOSED_BAD_DEBT: 'bg-gray-500',
 };
 
@@ -173,7 +173,7 @@ export default function DashboardPage() {
           </div>
 
           <div
-            className="bg-gradient-to-br from-violet-500 to-violet-600 rounded-2xl p-5 cursor-pointer hover:shadow-xl hover:shadow-violet-500/20 transition-all duration-300 hover:-translate-y-0.5"
+            className="bg-gradient-to-br from-blue-500 to-blue-600 rounded-2xl p-5 cursor-pointer hover:shadow-xl hover:shadow-blue-500/20 transition-all duration-300 hover:-translate-y-0.5"
             onClick={() => navigate('/products')}
           >
             <div className="flex items-center justify-between mb-3">
@@ -184,8 +184,8 @@ export default function DashboardPage() {
               </div>
             </div>
             <div className="text-2xl font-bold text-white">{kpis.products.inStock}</div>
-            <div className="text-sm text-violet-200 mt-1">สินค้าในสต็อก</div>
-            <div className="text-xs text-violet-300 mt-1">จาก {kpis.products.total} ชิ้น</div>
+            <div className="text-sm text-blue-200 mt-1">สินค้าในสต็อก</div>
+            <div className="text-xs text-blue-300 mt-1">จาก {kpis.products.total} ชิ้น</div>
           </div>
         </div>
       )}

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -116,7 +116,7 @@ export default function LandingPage() {
                     </div>
                   </div>
                   {/* Decorative circles */}
-                  <div className="absolute -top-8 -right-8 w-24 h-24 bg-purple-500/20 rounded-full blur-xl" />
+                  <div className="absolute -top-8 -right-8 w-24 h-24 bg-blue-500/20 rounded-full blur-xl" />
                   <div className="absolute -bottom-8 -left-8 w-32 h-32 bg-primary-500/20 rounded-full blur-xl" />
                 </div>
               </div>
@@ -337,7 +337,7 @@ export default function LandingPage() {
           <div className="grid md:grid-cols-4 gap-8">
             <div className="md:col-span-2">
               <div className="flex items-center gap-2 mb-4">
-                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-400 to-purple-500 flex items-center justify-center">
+                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-400 to-blue-500 flex items-center justify-center">
                   <span className="text-white font-bold text-sm">B</span>
                 </div>
                 <span className="text-xl font-bold text-white">

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -73,7 +73,7 @@ export default function LoginPage() {
         </div>
 
         {/* Decorative elements */}
-        <div className="absolute top-20 right-20 w-64 h-64 bg-purple-500/10 rounded-full blur-3xl" />
+        <div className="absolute top-20 right-20 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl" />
         <div className="absolute bottom-20 left-20 w-48 h-48 bg-primary-400/10 rounded-full blur-3xl" />
       </div>
 
@@ -81,7 +81,7 @@ export default function LoginPage() {
       <div className="flex-1 flex items-center justify-center px-6 bg-gray-50">
         <div className="max-w-md w-full">
           <div className="lg:hidden flex items-center gap-2 mb-8">
-            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-500 to-purple-600 flex items-center justify-center">
+            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-primary-500 to-blue-600 flex items-center justify-center">
               <span className="text-white font-bold text-sm">B</span>
             </div>
             <span className="text-xl font-bold text-gray-900">

--- a/apps/web/src/pages/POSPage.tsx
+++ b/apps/web/src/pages/POSPage.tsx
@@ -610,9 +610,9 @@ export default function POSPage() {
                 </div>
                 {/* Finance transfer amount highlight */}
                 {transferAmount > 0 && (
-                  <div className="bg-purple-50 border border-purple-200 rounded-lg p-3">
-                    <div className="text-xs text-purple-600">ยอดที่ไฟแนนซ์ต้องโอนให้ร้าน (หลังหักดาวน์)</div>
-                    <div className="text-lg font-bold text-purple-700">{transferAmount.toLocaleString()} ฿</div>
+                  <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                    <div className="text-xs text-blue-600">ยอดที่ไฟแนนซ์ต้องโอนให้ร้าน (หลังหักดาวน์)</div>
+                    <div className="text-lg font-bold text-blue-700">{transferAmount.toLocaleString()} ฿</div>
                   </div>
                 )}
               </div>
@@ -730,7 +730,7 @@ export default function POSPage() {
                     <span>{parseFloat(downPayment).toLocaleString()} ฿</span>
                   </div>
                 )}
-                <div className="flex justify-between text-sm font-bold text-purple-600">
+                <div className="flex justify-between text-sm font-bold text-blue-600">
                   <span>ยอดที่ไฟแนนซ์ต้องโอน</span>
                   <span>{transferAmount.toLocaleString()} ฿</span>
                 </div>

--- a/apps/web/src/pages/ProductCreatePage.tsx
+++ b/apps/web/src/pages/ProductCreatePage.tsx
@@ -370,8 +370,8 @@ export default function ProductCreatePage() {
                             onClick={() => toggleModel(m.name)}
                             className={`px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
                               isSelected
-                                ? 'bg-purple-600 text-white border-purple-600'
-                                : 'bg-white text-gray-600 border-gray-300 hover:border-purple-400 hover:text-purple-600'
+                                ? 'bg-blue-600 text-white border-blue-600'
+                                : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400 hover:text-blue-600'
                             }`}
                           >
                             {m.name}
@@ -380,7 +380,7 @@ export default function ProductCreatePage() {
                       })}
                     </div>
                     {form.model && (
-                      <div className="text-xs text-purple-500 mt-1">เลือกแล้ว {form.model.split(', ').filter(Boolean).length} รุ่น</div>
+                      <div className="text-xs text-blue-500 mt-1">เลือกแล้ว {form.model.split(', ').filter(Boolean).length} รุ่น</div>
                     )}
                   </div>
                 )}
@@ -493,7 +493,7 @@ export default function ProductCreatePage() {
 
           {/* Accessory auto name preview */}
           {form.category === 'ACCESSORY' && (form.accessoryType || form.accessoryBrand) && (
-            <div className="mt-3 text-sm text-purple-600 bg-purple-50 border border-purple-200 rounded-lg px-3 py-2">
+            <div className="mt-3 text-sm text-blue-600 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2">
               ชื่อสินค้าอัตโนมัติ: {(() => {
                 const isCharger = form.accessoryType === 'ชุดชาร์จ';
                 if (isCharger) return [form.accessoryType, form.accessoryBrand, form.model].filter(Boolean).join(' ');

--- a/apps/web/src/pages/PurchaseOrdersPage.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage.tsx
@@ -953,7 +953,7 @@ export default function PurchaseOrdersPage() {
                 })() : '';
 
                 return (
-                  <div key={idx} className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-purple-200 bg-purple-50' : 'border-gray-200 bg-gray-50'}`}>
+                  <div key={idx} className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-blue-200 bg-blue-50' : 'border-gray-200 bg-gray-50'}`}>
                     {items.length > 1 && (
                       <button
                         type="button"
@@ -965,7 +965,7 @@ export default function PurchaseOrdersPage() {
                     )}
                     <div className="text-xs font-medium text-gray-500 mb-1">
                       รายการ #{idx + 1}
-                      {isAccessory && <span className="ml-2 px-1.5 py-0.5 bg-purple-200 text-purple-700 rounded text-xs">อุปกรณ์เสริม</span>}
+                      {isAccessory && <span className="ml-2 px-1.5 py-0.5 bg-blue-200 text-blue-700 rounded text-xs">อุปกรณ์เสริม</span>}
                     </div>
 
                     {/* Row 1: Category FIRST, then Brand/Model or AccessoryType */}
@@ -1087,8 +1087,8 @@ export default function PurchaseOrdersPage() {
                                 onClick={() => toggleModel(idx, m.name)}
                                 className={`px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
                                   isSelected
-                                    ? 'bg-purple-600 text-white border-purple-600'
-                                    : 'bg-white text-gray-600 border-gray-300 hover:border-purple-400 hover:text-purple-600'
+                                    ? 'bg-blue-600 text-white border-blue-600'
+                                    : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400 hover:text-blue-600'
                                 }`}
                               >
                                 {m.name}
@@ -1097,7 +1097,7 @@ export default function PurchaseOrdersPage() {
                           })}
                         </div>
                         {selectedModels.length > 0 && (
-                          <div className="text-xs text-purple-500 mt-1">เลือกแล้ว {selectedModels.length} รุ่น</div>
+                          <div className="text-xs text-blue-500 mt-1">เลือกแล้ว {selectedModels.length} รุ่น</div>
                         )}
                       </div>
                     )}
@@ -1140,7 +1140,7 @@ export default function PurchaseOrdersPage() {
                         </div>
                         {/* Auto name preview */}
                         {accessoryAutoName && (
-                          <div className="text-xs text-purple-600 bg-purple-100 rounded px-2 py-1">
+                          <div className="text-xs text-blue-600 bg-blue-100 rounded px-2 py-1">
                             ชื่อสินค้า: {accessoryAutoName}
                           </div>
                         )}
@@ -1331,7 +1331,7 @@ export default function PurchaseOrdersPage() {
               <div className="mt-3">
                 <label className="block text-xs text-gray-500 mb-0.5">แนบสลิป/เอกสาร</label>
                 <div className="flex gap-2">
-                  <label className="flex items-center gap-1 px-3 py-2 bg-purple-50 text-purple-700 border border-purple-200 rounded-lg text-xs cursor-pointer hover:bg-purple-100 whitespace-nowrap">
+                  <label className="flex items-center gap-1 px-3 py-2 bg-blue-50 text-blue-700 border border-blue-200 rounded-lg text-xs cursor-pointer hover:bg-blue-100 whitespace-nowrap">
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
                     เลือกรูป
                     <input
@@ -1524,7 +1524,7 @@ export default function PurchaseOrdersPage() {
                 </div>
                 <button
                   onClick={() => openPaymentModal(selectedPO)}
-                  className="px-3 py-1.5 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700 transition-colors"
+                  className="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
                 >
                   อัปเดตการจ่ายเงิน
                 </button>
@@ -1576,7 +1576,7 @@ export default function PurchaseOrdersPage() {
                       <td className="px-3 py-2">
                         {item.brand}
                         {item.category === 'ACCESSORY' && (
-                          <div className="text-xs text-purple-600">(อุปกรณ์เสริม)</div>
+                          <div className="text-xs text-blue-600">(อุปกรณ์เสริม)</div>
                         )}
                       </td>
                       <td className="px-3 py-2">{item.model}</td>
@@ -1846,7 +1846,7 @@ export default function PurchaseOrdersPage() {
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">แนบสลิป/เอกสาร</label>
               <div className="flex gap-2">
-                <label className="flex items-center gap-1.5 px-3 py-2 bg-purple-50 text-purple-700 border border-purple-200 rounded-lg text-sm cursor-pointer hover:bg-purple-100 whitespace-nowrap">
+                <label className="flex items-center gap-1.5 px-3 py-2 bg-blue-50 text-blue-700 border border-blue-200 rounded-lg text-sm cursor-pointer hover:bg-blue-100 whitespace-nowrap">
                   <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
                   เลือกรูป
                   <input
@@ -1918,7 +1918,7 @@ export default function PurchaseOrdersPage() {
               <button
                 type="submit"
                 disabled={paymentMutation.isPending}
-                className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700 disabled:opacity-50 transition-colors"
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
               >
                 {paymentMutation.isPending ? 'กำลังบันทึก...' : 'บันทึก'}
               </button>

--- a/apps/web/src/pages/ReportsPage.tsx
+++ b/apps/web/src/pages/ReportsPage.tsx
@@ -294,7 +294,7 @@ function DailyPaymentReport({ date, onDateChange }: { date: string; onDateChange
         <SummaryCard label="รายการชำระ" value={data?.totalCount || 0} isCurrency={false} />
         <SummaryCard label="ยอดรวม" value={data?.totalAmount || 0} color="text-green-600" />
         <SummaryCard label="เงินสด" value={data?.byMethod?.CASH || 0} color="text-blue-600" />
-        <SummaryCard label="โอน" value={data?.byMethod?.TRANSFER || 0} color="text-purple-600" />
+        <SummaryCard label="โอน" value={data?.byMethod?.TRANSFER || 0} color="text-blue-600" />
       </div>
       {data?.byBranch && data.byBranch.length > 0 && (
         <div className="overflow-x-auto">

--- a/apps/web/src/pages/SalesHistoryPage.tsx
+++ b/apps/web/src/pages/SalesHistoryPage.tsx
@@ -37,7 +37,7 @@ interface SalesResponse {
 const saleTypeLabels: Record<string, { label: string; className: string }> = {
   CASH: { label: 'เงินสด', className: 'bg-green-100 text-green-700' },
   INSTALLMENT: { label: 'ผ่อนร้าน', className: 'bg-blue-100 text-blue-700' },
-  EXTERNAL_FINANCE: { label: 'ไฟแนนซ์', className: 'bg-purple-100 text-purple-700' },
+  EXTERNAL_FINANCE: { label: 'ไฟแนนซ์', className: 'bg-blue-100 text-blue-700' },
 };
 
 const paymentMethodLabels: Record<string, string> = {
@@ -156,7 +156,7 @@ export default function SalesHistoryPage() {
             </div>
           )}
           {s.saleType === 'EXTERNAL_FINANCE' && s.financeCompany && (
-            <div className="text-purple-600">
+            <div className="text-blue-600">
               {s.financeCompany}
               {s.downPaymentAmount && Number(s.downPaymentAmount) > 0 && (
                 <span> / ดาวน์ {Number(s.downPaymentAmount).toLocaleString()} ฿</span>
@@ -243,8 +243,8 @@ export default function SalesHistoryPage() {
           </div>
           <div className="bg-white rounded-lg border p-4">
             <div className="text-xs text-gray-500 mb-1">ไฟแนนซ์ (หน้านี้)</div>
-            <div className="text-xl font-bold text-purple-600">{stats.financeCount}</div>
-            <div className="text-sm text-purple-600 mt-1">{stats.financeRevenue.toLocaleString()} ฿</div>
+            <div className="text-xl font-bold text-blue-600">{stats.financeCount}</div>
+            <div className="text-sm text-blue-600 mt-1">{stats.financeRevenue.toLocaleString()} ฿</div>
           </div>
         </div>
       )}

--- a/apps/web/src/pages/StockPage.tsx
+++ b/apps/web/src/pages/StockPage.tsx
@@ -539,11 +539,11 @@ export default function StockPage() {
                   </div>
                 )}
                 {(dashboard.actionRequired.photoPending || 0) > 0 && (
-                  <div className="flex items-center gap-3 p-3 bg-violet-50 rounded-lg">
-                    <div className="w-10 h-10 bg-violet-100 rounded-full flex items-center justify-center text-violet-600 text-lg font-bold">
+                  <div className="flex items-center gap-3 p-3 bg-blue-50 rounded-lg">
+                    <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center text-blue-600 text-lg font-bold">
                       {dashboard.actionRequired.photoPending}
                     </div>
-                    <div className="text-sm text-violet-700">รอถ่ายรูป</div>
+                    <div className="text-sm text-blue-700">รอถ่ายรูป</div>
                   </div>
                 )}
                 {dashboard.actionRequired.pendingTransfers > 0 && (
@@ -695,7 +695,7 @@ export default function StockPage() {
                     label={item.name}
                     count={item.count}
                     total={dashboard.stockTurnover.currentStock}
-                    color="bg-purple-400"
+                    color="bg-blue-400"
                   />
                 ))}
                 {dashboard.byBrand.length === 0 && <div className="text-sm text-gray-400 text-center py-2">-</div>}

--- a/apps/web/src/pages/SupplierDetailPage.tsx
+++ b/apps/web/src/pages/SupplierDetailPage.tsx
@@ -77,7 +77,7 @@ const statusLabels: Record<string, { label: string; className: string }> = {
   PO_RECEIVED: { label: 'รับจาก PO', className: 'bg-blue-100 text-blue-700' },
   INSPECTION: { label: 'กำลังตรวจ', className: 'bg-yellow-100 text-yellow-700' },
   IN_STOCK: { label: 'พร้อมขาย', className: 'bg-green-100 text-green-700' },
-  RESERVED: { label: 'จอง', className: 'bg-purple-100 text-purple-700' },
+  RESERVED: { label: 'จอง', className: 'bg-blue-100 text-blue-700' },
   SOLD_INSTALLMENT: { label: 'ขายผ่อน', className: 'bg-indigo-100 text-indigo-700' },
   SOLD_CASH: { label: 'ขายสด', className: 'bg-teal-100 text-teal-700' },
   REPOSSESSED: { label: 'ยึดคืน', className: 'bg-red-100 text-red-700' },

--- a/apps/web/src/pages/SystemStatusPage.tsx
+++ b/apps/web/src/pages/SystemStatusPage.tsx
@@ -199,7 +199,7 @@ export default function SystemStatusPage() {
                   { label: 'API Key', value: data!.ai.configured ? 'ตั้งค่าแล้ว' : 'ยังไม่ได้ตั้งค่า' },
                   ...(data!.ai.error ? [{ label: 'Error', value: data!.ai.error }] : []),
                 ]}
-                color="purple"
+                color="blue"
                 full
               />
             </div>
@@ -338,13 +338,11 @@ function ServiceCard({
     blue: 'bg-blue-50 border-blue-200',
     indigo: 'bg-indigo-50 border-indigo-200',
     emerald: 'bg-emerald-50 border-emerald-200',
-    purple: 'bg-purple-50 border-purple-200',
   };
   const iconColors: Record<string, string> = {
     blue: 'text-blue-600',
     indigo: 'text-indigo-600',
     emerald: 'text-emerald-600',
-    purple: 'text-purple-600',
   };
   const statusColors: Record<string, string> = {
     ok: 'text-green-700',

--- a/apps/web/src/pages/UsersPage.tsx
+++ b/apps/web/src/pages/UsersPage.tsx
@@ -25,7 +25,7 @@ const roleLabels: Record<string, string> = {
 };
 
 const roleColors: Record<string, string> = {
-  OWNER: 'bg-purple-100 text-purple-700',
+  OWNER: 'bg-blue-100 text-blue-700',
   BRANCH_MANAGER: 'bg-blue-100 text-blue-700',
   SALES: 'bg-green-100 text-green-700',
   ACCOUNTANT: 'bg-orange-100 text-orange-700',

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -5,17 +5,17 @@ export default {
     extend: {
       /* ── Thai-friendly font scale ─────────────────────────
          TH Sarabun PSK renders smaller than Latin fonts at the
-         same px value.  Bump every step ~1-2px so Thai text
-         stays legible, especially at the small end.
+         same px value.  Bump every step so Thai text stays
+         legible, especially at the small end.
          ──────────────────────────────────────────────────── */
       fontSize: {
-        'xs':   ['13px', { lineHeight: '1.5' }],
-        'sm':   ['15px', { lineHeight: '1.55' }],
-        'base': ['17px', { lineHeight: '1.6' }],
-        'lg':   ['19px', { lineHeight: '1.55' }],
-        'xl':   ['21px', { lineHeight: '1.5' }],
-        '2xl':  ['26px', { lineHeight: '1.4' }],
-        '3xl':  ['32px', { lineHeight: '1.35' }],
+        'xs':   ['14px', { lineHeight: '1.5' }],
+        'sm':   ['16px', { lineHeight: '1.55' }],
+        'base': ['18px', { lineHeight: '1.6' }],
+        'lg':   ['20px', { lineHeight: '1.55' }],
+        'xl':   ['23px', { lineHeight: '1.5' }],
+        '2xl':  ['28px', { lineHeight: '1.4' }],
+        '3xl':  ['34px', { lineHeight: '1.35' }],
       },
       keyframes: {
         fadeIn: {
@@ -38,17 +38,17 @@ export default {
       },
       colors: {
         primary: {
-          50: '#eef2ff',
-          100: '#e0e7ff',
-          200: '#c7d2fe',
-          300: '#a5b4fc',
-          400: '#818cf8',
-          500: '#6366f1',
-          600: '#4f46e5',
-          700: '#4338ca',
-          800: '#3730a3',
-          900: '#312e81',
-          950: '#1e1b4b',
+          50: '#eff6ff',
+          100: '#dbeafe',
+          200: '#bfdbfe',
+          300: '#93c5fd',
+          400: '#60a5fa',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+          800: '#1e40af',
+          900: '#1e3a5f',
+          950: '#0f172a',
         },
       },
     },


### PR DESCRIPTION
Color theme:
- Replace indigo/violet/purple palette with Blue Ocean (blue/sky) Primary: #2563eb, Sidebar: #0f172a, Accent: #60a5fa
- Update all 38 files: components, pages, constants, CSS
- Gradients now use primary→sky instead of primary→purple

Font scale (Thai-optimized):
- text-xs: 12→14px, text-sm: 14→16px, text-base: 16→18px
- text-lg: 18→20px, text-xl: 20→23px, text-2xl: 24→28px
- Body base: 18px with 1.6 line-height
- BlockRenderer inline sizes: 13→15, 14→16, 15→17, 18→20px
- DocumentPreview letterhead: 18→20, 12→14, 10→12px

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23