### PR TITLE
feat: support template variables in footer text (e.g. {{= CONTRACT.NU…

### DIFF
--- a/apps/web/src/components/template-editor/pdf/pdfGenerator.ts
+++ b/apps/web/src/components/template-editor/pdf/pdfGenerator.ts
@@ -96,7 +96,8 @@ export async function generatePDF(template: Template): Promise<Blob> {
     doc.setFontSize(settings.fontSize.footer);
     doc.setFont(PDF_FONT_FAMILY, 'normal');
     doc.setTextColor(150);
-    doc.text(settings.footerText, margin.left, footerY);
+    const resolvedFooter = renderVariables(settings.footerText, ctx);
+    doc.text(resolvedFooter, margin.left, footerY);
     if (settings.showPageNumber) {
       const pageText = settings.pageNumberFormat
         .replace('{page}', String(pageNum))

--- a/apps/web/src/components/template-editor/preview/DocumentPreview.tsx
+++ b/apps/web/src/components/template-editor/preview/DocumentPreview.tsx
@@ -1,9 +1,13 @@
 import { useTemplateStore } from '@/store/templateStore';
+import { renderVariables, buildSampleContext } from '@/utils/templateRenderer';
+import { AVAILABLE_VARIABLES } from '@/constants/variables';
 import BlockRenderer from './BlockRenderer';
 
 export default function DocumentPreview() {
   const { currentTemplate, previewMode } = useTemplateStore();
   const { blocks, settings } = currentTemplate;
+  const ctx = previewMode ? buildSampleContext(AVAILABLE_VARIABLES) : {};
+  const resolvedFooter = previewMode ? renderVariables(settings.footerText, ctx) : settings.footerText;
 
   return (
     <div className="flex-1 bg-slate-100 overflow-y-auto p-8">
@@ -53,7 +57,7 @@ export default function DocumentPreview() {
             borderTop: '1px solid #d1d5db',
           }}
         >
-          <span style={{ color: '#9ca3af' }}>{settings.footerText}</span>
+          <span style={{ color: '#9ca3af' }}>{resolvedFooter}</span>
           {settings.showPageNumber && (
             <span style={{ color: '#9ca3af' }}>
               {settings.pageNumberFormat.replace('{page}', '1').replace('{total}', '6')}


### PR DESCRIPTION
…MBER}})

- Preview: render footerText through renderVariables when in preview mode
- PDF: render footerText through renderVariables in addFooter

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23