### PR TITLE
fix: use structured content for bold variable insertion in Tiptap

### DIFF
--- a/apps/web/src/components/template-editor/editor/BlockEditModal.tsx
+++ b/apps/web/src/components/template-editor/editor/BlockEditModal.tsx
@@ -40,9 +40,12 @@ export default function BlockEditModal() {
     const tag = `{{= ${key}}}`;
     const editor = editorInstanceRef.current;
     if (editor) {
-      // Insert variable as bold HTML, then continue with previous style
+      // Insert variable as bold using structured content (HTML string may not parse correctly with {{ }})
       editor.chain().focus()
-        .insertContent(`<strong>${tag}</strong> `)
+        .insertContent([
+          { type: 'text', marks: [{ type: 'bold' }], text: tag },
+          { type: 'text', text: ' ' },
+        ])
         .run();
       return;
     }


### PR DESCRIPTION
insertContent('<strong>{{= VAR}}</strong>') doesn't render bold because Tiptap's HTML parser struggles with {{ }} characters. Use structured content format with explicit bold mark instead.

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23