### PR TITLE
Fix contract preview bugs and audit contracts flow

### DIFF
--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -300,13 +300,13 @@ export class ContractsService {
         },
       });
 
-      // Delete existing unpaid payments and recreate only remaining installments
+      // Delete only PENDING payments (preserve PAID and PARTIALLY_PAID history)
       const paidCount = await tx.payment.count({
-        where: { contractId: id, status: 'PAID' },
+        where: { contractId: id, status: { in: ['PAID', 'PARTIALLY_PAID'] } },
       });
 
       await tx.payment.deleteMany({
-        where: { contractId: id, status: { not: 'PAID' } },
+        where: { contractId: id, status: { in: ['PENDING', 'OVERDUE'] } },
       });
 
       const remainingMonths = totalMonths - paidCount;
@@ -414,6 +414,12 @@ export class ContractsService {
       throw new BadRequestException('ต้องลงนามครบทั้งลูกค้าและพนักงานก่อนเปิดใช้งานสัญญา');
     }
 
+    // Verify product is still reserved for this contract
+    const product = await this.prisma.product.findUnique({ where: { id: contract.productId } });
+    if (!product || (product.status !== 'RESERVED' && product.status !== 'IN_STOCK')) {
+      throw new BadRequestException('สินค้าไม่พร้อมสำหรับเปิดสัญญา (อาจถูกขายหรือลบไปแล้ว)');
+    }
+
     await this.prisma.$transaction([
       this.prisma.contract.update({ where: { id }, data: { status: 'ACTIVE' } }),
       this.prisma.product.update({ where: { id: contract.productId }, data: { status: 'SOLD_INSTALLMENT' } }),
@@ -432,8 +438,8 @@ export class ContractsService {
 
   async getEarlyPayoffQuote(id: string) {
     const contract = await this.findOne(id);
-    if (!['ACTIVE', 'OVERDUE'].includes(contract.status)) {
-      throw new BadRequestException('สัญญาต้องอยู่ในสถานะ ACTIVE หรือ OVERDUE');
+    if (!['ACTIVE', 'OVERDUE', 'DEFAULT'].includes(contract.status)) {
+      throw new BadRequestException('สัญญาต้องอยู่ในสถานะ ACTIVE, OVERDUE หรือ DEFAULT');
     }
 
     const paidPayments = contract.payments.filter((p) => p.status === 'PAID');

--- a/apps/api/src/modules/documents/documents.service.ts
+++ b/apps/api/src/modules/documents/documents.service.ts
@@ -523,6 +523,9 @@ ${bodyHtml}
       'BRANCH.ADDRESS': replacements['{branch_address}'],
       'BRANCH.PHONE': replacements['{branch_phone}'],
       'SALESPERSON.NAME': replacements['{salesperson_name}'],
+
+      // === Aliases ===
+      'CUSTOMER.FULLNAME': replacements['{customer_name}'],
     };
 
     // Handle date format pipes for new syntax (MUST run before general replacement)

--- a/apps/web/src/components/template-editor/preview/SignatureBlock.tsx
+++ b/apps/web/src/components/template-editor/preview/SignatureBlock.tsx
@@ -15,8 +15,8 @@ function getCtx() {
 export default function SignatureBlock({ previewMode = false }: Props) {
   const ctx = getCtx();
   const customerName = previewMode
-    ? String(ctx['CUSTOMER.FULLNAME'] || '...................................')
-    : '{{= CUSTOMER.FULLNAME}}';
+    ? String(ctx['CUSTOMER.NAME'] || '...................................')
+    : '{{= CUSTOMER.NAME}}';
   const managerName = 'เอกนรินทร์ คงเดช';
 
   return (

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -103,7 +103,7 @@ export default function ContractDetailPage() {
   const { data: payoffQuote } = useQuery<EarlyPayoffQuote>({
     queryKey: ['contract-payoff', id],
     queryFn: async () => { const { data } = await api.get(`/contracts/${id}/early-payoff-quote`); return data; },
-    enabled: !!contract && ['ACTIVE', 'OVERDUE'].includes(contract.status),
+    enabled: !!contract && ['ACTIVE', 'OVERDUE', 'DEFAULT'].includes(contract.status),
   });
 
   const { data: preview, isLoading: previewLoading } = useQuery<{ html: string }>({
@@ -112,7 +112,12 @@ export default function ContractDetailPage() {
     enabled: activeTab === 'preview',
   });
 
-  const invalidateContract = () => queryClient.invalidateQueries({ queryKey: ['contract', id] });
+  const invalidateContract = () => {
+    queryClient.invalidateQueries({ queryKey: ['contract', id] });
+    queryClient.invalidateQueries({ queryKey: ['contract-preview', id] });
+    queryClient.invalidateQueries({ queryKey: ['contract-payoff', id] });
+    queryClient.invalidateQueries({ queryKey: ['contracts'] });
+  };
 
   const submitReviewMutation = useMutation({
     mutationFn: async () => { const { data } = await api.post(`/contracts/${id}/submit-review`); return data; },
@@ -246,7 +251,7 @@ export default function ContractDetailPage() {
               </button>
             )}
 
-            {['ACTIVE', 'OVERDUE'].includes(contract.status) && (
+            {['ACTIVE', 'OVERDUE', 'DEFAULT'].includes(contract.status) && (
               <button onClick={() => setShowPayoffModal(true)} className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700">
                 ปิดก่อนกำหนด
               </button>
@@ -516,7 +521,7 @@ export default function ContractDetailPage() {
       </div>
 
       {/* Early Payoff Quote */}
-      {payoffQuote && ['ACTIVE', 'OVERDUE'].includes(contract.status) && (
+      {payoffQuote && ['ACTIVE', 'OVERDUE', 'DEFAULT'].includes(contract.status) && (
         <div className="bg-primary-50 rounded-lg border border-primary-200 p-6 mb-6">
           <h2 className="text-lg font-semibold text-primary-800 mb-3">ประเมินปิดก่อนกำหนด</h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/apps/web/src/pages/ContractSignPage.tsx
+++ b/apps/web/src/pages/ContractSignPage.tsx
@@ -47,6 +47,8 @@ export default function ContractSignPage() {
     onSuccess: () => {
       toast.success(`ลงนาม ${signerType === 'CUSTOMER' ? 'ลูกค้า' : 'พนักงาน'} สำเร็จ`);
       queryClient.invalidateQueries({ queryKey: ['contract-signatures', id] });
+      queryClient.invalidateQueries({ queryKey: ['contract', id] });
+      queryClient.invalidateQueries({ queryKey: ['contract-preview', id] });
       clearCanvas();
       // Auto-switch to staff if customer just signed
       if (signerType === 'CUSTOMER') setSignerType('STAFF');

--- a/apps/web/src/store/templateStore.ts
+++ b/apps/web/src/store/templateStore.ts
@@ -136,12 +136,13 @@ function blocksToHtml(blocks: Block[]): string {
 
     switch (b.type) {
       case 'contract-header': {
-        const plain = rich ? stripHtmlToText(content) : content;
-        if (plain.includes('||')) {
-          const [left, right] = plain.split('||').map(s => s.trim());
+        // Preserve rich HTML (bold, etc.) — only strip block tags to keep inline
+        const inline = rich ? content.replace(/<\/?(?:p|div)[^>]*>/gi, '').trim() : content;
+        if (inline.includes('||')) {
+          const [left, right] = inline.split('||').map(s => s.trim());
           return `<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;font-size:15px;color:#4a4a4a"><div>${left}</div><div>${right || ''}</div></div>`;
         }
-        return `<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;font-size:15px;color:#4a4a4a"><div>${plain}</div></div>`;
+        return `<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;font-size:15px;color:#4a4a4a"><div>${inline}</div></div>`;
       }
 
       case 'heading':
@@ -193,8 +194,8 @@ function blocksToHtml(blocks: Block[]): string {
 
       case 'signature-block':
         return `<div style="margin:24px 0;display:grid;grid-template-columns:1fr 1fr;gap:32px 32px">
-          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ..................................................ผู้ให้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
-          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ..................................................ผู้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
+          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ {staff_signature} ผู้ให้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">( {{= COMPANY.DIRECTOR }} )</div><div style="font-size:11px;color:#999">ผู้จัดการ {{= COMPANY.NAME_TH }}</div></div>
+          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ {customer_signature} ผู้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">( {{= CUSTOMER.NAME }} )</div></div>
           <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ..................................................พยาน</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
           <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ..................................................พยาน</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
         </div>`;


### PR DESCRIPTION
Preview fixes:
- Signature block now includes customer/staff names and signature images
- Contract-header preserves rich text (bold) when saving template
- Fix CUSTOMER.FULLNAME → CUSTOMER.NAME in SignatureBlock
- Add CUSTOMER.FULLNAME alias in backend newSyntaxMap

Query cache fixes:
- invalidateContract() now clears preview, payoff, and list queries
- Sign mutation invalidates contract and preview queries

Backend fixes:
- update() preserves PARTIALLY_PAID payment records (was deleting them)
- activate() verifies product status before activation
- Early payoff now supports DEFAULT status (consistent with payment recording)
- DEFAULT contracts can now use early payoff from UI

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23