### PR TITLE
feat: saved signature system with proper positioning in contract preview

### DIFF
--- a/apps/api/prisma/migrations/20260310000000_add_saved_signature_to_user/migration.sql
+++ b/apps/api/prisma/migrations/20260310000000_add_saved_signature_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "saved_signature" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -203,15 +203,16 @@ model Branch {
 }
 
 model User {
-  id        String   @id @default(uuid())
-  email     String   @unique
-  password  String
-  name      String
-  role      UserRole @default(SALES)
-  branchId  String?  @map("branch_id")
-  isActive  Boolean  @default(true) @map("is_active")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  id             String   @id @default(uuid())
+  email          String   @unique
+  password       String
+  name           String
+  role           UserRole @default(SALES)
+  branchId       String?  @map("branch_id")
+  isActive       Boolean  @default(true) @map("is_active")
+  savedSignature String?  @map("saved_signature") @db.Text
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
 
   branch Branch? @relation(fields: [branchId], references: [id])
 

--- a/apps/api/src/modules/documents/documents.service.ts
+++ b/apps/api/src/modules/documents/documents.service.ts
@@ -450,8 +450,8 @@ ${bodyHtml}
       '{salesperson_name}': esc(contract.salesperson?.name || ''),
       '{date}': new Date().toLocaleDateString('th-TH'),
       '{payment_schedule_table}': `<table border="1" cellpadding="6" style="border-collapse:collapse;width:100%;margin:10px auto"><thead><tr style="background:#f5f5f5"><th style="text-align:center">งวดที่</th><th style="text-align:center">วันที่ครบกำหนดชำระ</th><th style="text-align:center">จำนวนเงิน</th></tr></thead><tbody>${paymentScheduleRows}</tbody></table>`,
-      '{customer_signature}': customerSigSafe ? `<img src="${customerSig.signatureImage}" style="max-height:60px"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:60px"></div>',
-      '{staff_signature}': staffSigSafe ? `<img src="${staffSig.signatureImage}" style="max-height:60px"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:60px"></div>',
+      '{customer_signature}': customerSigSafe ? `<img src="${customerSig.signatureImage}" style="max-height:50px;display:block;margin:0 auto"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:50px"></div>',
+      '{staff_signature}': staffSigSafe ? `<img src="${staffSig.signatureImage}" style="max-height:50px;display:block;margin:0 auto"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:50px"></div>',
     };
 
     let result = html;
@@ -623,21 +623,21 @@ ${bodyHtml}
     );
 
     // Post-process: inject real signature images for templates that lack {staff_signature}/{customer_signature} placeholders
-    // Only applies when template used dots (e.g. "ลงชื่อ..........ผู้ให้เช่าซื้อ") instead of placeholders
+    // Replaces the dots between "ลงชื่อ" and "ผู้ให้เช่าซื้อ/ผู้เช่าซื้อ" with the signature image
     const hadStaffPlaceholder = html.includes('{staff_signature}');
     const hadCustomerPlaceholder = html.includes('{customer_signature}');
-    const sigImgStyle = 'max-height:60px;display:block;margin:4px auto';
+    const sigImgStyle = 'max-height:50px;display:block;margin:0 auto';
 
     if (staffSigSafe && !hadStaffPlaceholder) {
       result = result.replace(
-        /(ลงชื่อ[.…]{3,}ผู้ให้เช่าซื้อ<\/(?:p|div)>)/,
-        `$1<div style="text-align:center"><img src="${staffSig.signatureImage}" style="${sigImgStyle}"/></div>`,
+        /(ลงชื่อ)[.…]{3,}(ผู้ให้เช่าซื้อ)/,
+        `$1</div><div style="min-height:50px;display:flex;align-items:center;justify-content:center"><img src="${staffSig.signatureImage}" style="${sigImgStyle}"/></div><div style="font-size:13px">$2`,
       );
     }
     if (customerSigSafe && !hadCustomerPlaceholder) {
       result = result.replace(
-        /(ลงชื่อ[.…]{3,}ผู้เช่าซื้อ<\/(?:p|div)>)/,
-        `$1<div style="text-align:center"><img src="${customerSig.signatureImage}" style="${sigImgStyle}"/></div>`,
+        /(ลงชื่อ)[.…]{3,}(ผู้เช่าซื้อ)/,
+        `$1</div><div style="min-height:50px;display:flex;align-items:center;justify-content:center"><img src="${customerSig.signatureImage}" style="${sigImgStyle}"/></div><div style="font-size:13px">$2`,
       );
     }
 
@@ -707,14 +707,16 @@ ${bodyHtml}
     <h3 style="margin:0 0 8px;border-bottom:1px solid #eee;padding-bottom:4px">ลงนาม</h3>
     <div style="display:flex;justify-content:space-around;margin-top:20px">
       <div style="text-align:center">
-        <p style="margin:0 0 4px;font-size:12px;color:#666">ผู้ซื้อ (ลูกค้า)</p>
-        {customer_signature}
-        <p style="margin:8px 0 0;font-size:13px">({customer_name})</p>
+        <div style="font-size:13px">ลงชื่อ</div>
+        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{customer_signature}</div>
+        <div style="font-size:13px">ผู้เช่าซื้อ</div>
+        <p style="margin:4px 0 0;font-size:13px">({customer_name})</p>
       </div>
       <div style="text-align:center">
-        <p style="margin:0 0 4px;font-size:12px;color:#666">ผู้ขาย (พนักงาน)</p>
-        {staff_signature}
-        <p style="margin:8px 0 0;font-size:13px">({salesperson_name})</p>
+        <div style="font-size:13px">ลงชื่อ</div>
+        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{staff_signature}</div>
+        <div style="font-size:13px">ผู้ให้เช่าซื้อ</div>
+        <p style="margin:4px 0 0;font-size:13px">({salesperson_name})</p>
       </div>
     </div>
   </div>

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -1,28 +1,48 @@
-import { Controller, Get, Post, Patch, Param, Body, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Patch, Param, Body, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 
 @Controller('users')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles('OWNER')
 export class UsersController {
   constructor(private usersService: UsersService) {}
 
+  // ─── Saved Signature (any authenticated user) ──────
+  @Get('me/signature')
+  getSavedSignature(@CurrentUser('id') userId: string) {
+    return this.usersService.getSavedSignature(userId).then((sig) => ({ signatureImage: sig }));
+  }
+
+  @Put('me/signature')
+  saveSignature(@CurrentUser('id') userId: string, @Body('signatureImage') signatureImage: string) {
+    return this.usersService.saveSignature(userId, signatureImage);
+  }
+
+  @Delete('me/signature')
+  deleteSavedSignature(@CurrentUser('id') userId: string) {
+    return this.usersService.deleteSavedSignature(userId);
+  }
+
+  // ─── Admin user management (OWNER only) ────────────
   @Get()
+  @Roles('OWNER')
   findAll() {
     return this.usersService.findAll();
   }
 
   @Post()
+  @Roles('OWNER')
   create(@Body() dto: CreateUserDto) {
     return this.usersService.create(dto);
   }
 
   @Patch(':id')
+  @Roles('OWNER')
   update(@Param('id') id: string, @Body() dto: UpdateUserDto) {
     return this.usersService.update(id, dto);
   }

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -50,6 +50,30 @@ export class UsersService {
     });
   }
 
+  async getSavedSignature(userId: string): Promise<string | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { savedSignature: true },
+    });
+    return user?.savedSignature || null;
+  }
+
+  async saveSignature(userId: string, signatureImage: string): Promise<{ success: boolean }> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { savedSignature: signatureImage },
+    });
+    return { success: true };
+  }
+
+  async deleteSavedSignature(userId: string): Promise<{ success: boolean }> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { savedSignature: null },
+    });
+    return { success: true };
+  }
+
   async update(id: string, dto: UpdateUserDto) {
     const user = await this.prisma.user.findUnique({ where: { id } });
     if (!user) throw new NotFoundException('ไม่พบผู้ใช้งาน');

--- a/apps/web/src/pages/ContractSignPage.tsx
+++ b/apps/web/src/pages/ContractSignPage.tsx
@@ -20,6 +20,7 @@ export default function ContractSignPage() {
   const [isDrawing, setIsDrawing] = useState(false);
   const [signerType, setSignerType] = useState<'CUSTOMER' | 'STAFF'>('CUSTOMER');
   const [hasDrawn, setHasDrawn] = useState(false);
+  const [signMode, setSignMode] = useState<'choose' | 'draw' | 'saved'>('choose');
 
   // Get contract detail to check workflow
   const { data: contract } = useQuery<{ id: string; status: string; workflowStatus: string; contractNumber: string }>({
@@ -39,21 +40,40 @@ export default function ContractSignPage() {
     queryFn: async () => { const { data } = await api.get(`/contracts/${id}/signatures`); return data; },
   });
 
+  // Get saved staff signature
+  const { data: savedSigData } = useQuery<{ signatureImage: string | null }>({
+    queryKey: ['saved-signature'],
+    queryFn: async () => { const { data } = await api.get('/users/me/signature'); return data; },
+  });
+  const savedSignature = savedSigData?.signatureImage || null;
+
   const signMutation = useMutation({
     mutationFn: async (body: { signatureImage: string; signerType: string }) => {
       const { data } = await api.post(`/contracts/${id}/sign`, body);
       return data;
     },
-    onSuccess: () => {
-      toast.success(`ลงนาม ${signerType === 'CUSTOMER' ? 'ลูกค้า' : 'พนักงาน'} สำเร็จ`);
+    onSuccess: (_data, variables) => {
+      toast.success(`ลงนาม ${variables.signerType === 'CUSTOMER' ? 'ลูกค้า' : 'พนักงาน'} สำเร็จ`);
       queryClient.invalidateQueries({ queryKey: ['contract-signatures', id] });
       queryClient.invalidateQueries({ queryKey: ['contract', id] });
       queryClient.invalidateQueries({ queryKey: ['contract-preview', id] });
       clearCanvas();
+      setSignMode('choose');
       // Auto-switch to staff if customer just signed
-      if (signerType === 'CUSTOMER') setSignerType('STAFF');
+      if (variables.signerType === 'CUSTOMER') setSignerType('STAFF');
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  // Save signature to user profile
+  const saveSignatureMutation = useMutation({
+    mutationFn: async (signatureImage: string) => {
+      const { data } = await api.put('/users/me/signature', { signatureImage });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['saved-signature'] });
+    },
   });
 
   const generateMutation = useMutation({
@@ -78,7 +98,7 @@ export default function ContractSignPage() {
     ctx.lineWidth = 2;
     ctx.lineCap = 'round';
     ctx.strokeStyle = '#000';
-  }, []);
+  }, [signMode]);
 
   const getPos = (e: React.MouseEvent | React.TouchEvent) => {
     const canvas = canvasRef.current!;
@@ -129,11 +149,20 @@ export default function ContractSignPage() {
     setHasDrawn(false);
   };
 
-  const handleSign = () => {
+  const handleSignFromCanvas = () => {
     const canvas = canvasRef.current;
     if (!canvas || !hasDrawn) { toast.error('กรุณาลงนามก่อน'); return; }
     const signatureImage = canvas.toDataURL('image/png');
+    // Save staff signature for future use
+    if (signerType === 'STAFF') {
+      saveSignatureMutation.mutate(signatureImage);
+    }
     signMutation.mutate({ signatureImage, signerType });
+  };
+
+  const handleSignFromSaved = () => {
+    if (!savedSignature) { toast.error('ไม่พบลายเซ็นที่บันทึกไว้'); return; }
+    signMutation.mutate({ signatureImage: savedSignature, signerType });
   };
 
   const customerSigned = signatures.some((s) => s.signerType === 'CUSTOMER');
@@ -141,6 +170,9 @@ export default function ContractSignPage() {
   const allSigned = customerSigned && staffSigned;
   // Allow signing when contract status is DRAFT (any workflow stage)
   const canSign = contract?.status === 'DRAFT';
+
+  // Determine if current signer type is already signed
+  const currentAlreadySigned = signerType === 'CUSTOMER' ? customerSigned : staffSigned;
 
   return (
     <div>
@@ -204,7 +236,7 @@ export default function ContractSignPage() {
                 <h2 className="text-lg font-semibold text-gray-900">ลงนาม</h2>
                 <select
                   value={signerType}
-                  onChange={(e) => setSignerType(e.target.value as 'CUSTOMER' | 'STAFF')}
+                  onChange={(e) => { setSignerType(e.target.value as 'CUSTOMER' | 'STAFF'); setSignMode('choose'); }}
                   className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm"
                 >
                   <option value="CUSTOMER" disabled={customerSigned}>ลูกค้า {customerSigned ? '(ลงนามแล้ว)' : ''}</option>
@@ -212,36 +244,80 @@ export default function ContractSignPage() {
                 </select>
               </div>
 
-              <div className="bg-white rounded-lg border p-4">
-                <div className="text-xs text-gray-500 mb-2 text-center">กรุณาลงนามในกรอบด้านล่าง</div>
-                <canvas
-                  ref={canvasRef}
-                  width={500}
-                  height={200}
-                  className="w-full border-2 border-dashed border-gray-300 rounded-lg cursor-crosshair touch-none"
-                  style={{ height: '200px' }}
-                  onMouseDown={startDraw}
-                  onMouseMove={draw}
-                  onMouseUp={endDraw}
-                  onMouseLeave={endDraw}
-                  onTouchStart={startDraw}
-                  onTouchMove={draw}
-                  onTouchEnd={endDraw}
-                />
-                <div className="flex gap-3 mt-3">
-                  <button onClick={clearCanvas} className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50">
-                    ล้าง
-                  </button>
-                  <div className="flex-1" />
-                  <button
-                    onClick={handleSign}
-                    disabled={!hasDrawn || signMutation.isPending}
-                    className="px-6 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
-                  >
-                    {signMutation.isPending ? 'กำลังบันทึก...' : 'ยืนยันลงนาม'}
-                  </button>
+              {!currentAlreadySigned && (
+                <div className="bg-white rounded-lg border p-4">
+                  {/* Mode chooser: show saved signature option for STAFF when available */}
+                  {signMode === 'choose' && (
+                    <div className="space-y-3">
+                      {/* Show saved signature option for STAFF */}
+                      {signerType === 'STAFF' && savedSignature && (
+                        <div className="border-2 border-primary-200 bg-primary-50 rounded-lg p-4">
+                          <div className="text-sm font-medium text-primary-800 mb-2">ลายเซ็นที่บันทึกไว้</div>
+                          <div className="bg-white rounded border p-3 flex justify-center mb-3">
+                            <img src={savedSignature} alt="saved-signature" className="h-16" />
+                          </div>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={handleSignFromSaved}
+                              disabled={signMutation.isPending}
+                              className="flex-1 px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+                            >
+                              {signMutation.isPending ? 'กำลังบันทึก...' : 'ใช้ลายเซ็นที่บันทึกไว้'}
+                            </button>
+                            <button
+                              onClick={() => setSignMode('draw')}
+                              className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50"
+                            >
+                              เซ็นใหม่
+                            </button>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* If no saved signature or is customer, go straight to draw mode */}
+                      {(signerType === 'CUSTOMER' || !savedSignature) && (
+                        <SignaturePad
+                          canvasRef={canvasRef}
+                          hasDrawn={hasDrawn}
+                          isPending={signMutation.isPending}
+                          onStartDraw={startDraw}
+                          onDraw={draw}
+                          onEndDraw={endDraw}
+                          onClear={clearCanvas}
+                          onSign={handleSignFromCanvas}
+                        />
+                      )}
+                    </div>
+                  )}
+
+                  {/* Draw mode (re-sign) */}
+                  {signMode === 'draw' && (
+                    <div>
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="text-xs text-gray-500">เซ็นลายเซ็นใหม่</div>
+                        {signerType === 'STAFF' && savedSignature && (
+                          <button
+                            onClick={() => setSignMode('choose')}
+                            className="text-xs text-primary-600 hover:underline"
+                          >
+                            ใช้ลายเซ็นที่บันทึกไว้
+                          </button>
+                        )}
+                      </div>
+                      <SignaturePad
+                        canvasRef={canvasRef}
+                        hasDrawn={hasDrawn}
+                        isPending={signMutation.isPending}
+                        onStartDraw={startDraw}
+                        onDraw={draw}
+                        onEndDraw={endDraw}
+                        onClear={clearCanvas}
+                        onSign={handleSignFromCanvas}
+                      />
+                    </div>
+                  )}
                 </div>
-              </div>
+              )}
             </div>
           )}
 
@@ -262,6 +338,60 @@ export default function ContractSignPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+/** Reusable signature drawing pad */
+function SignaturePad({
+  canvasRef,
+  hasDrawn,
+  isPending,
+  onStartDraw,
+  onDraw,
+  onEndDraw,
+  onClear,
+  onSign,
+}: {
+  canvasRef: React.RefObject<HTMLCanvasElement>;
+  hasDrawn: boolean;
+  isPending: boolean;
+  onStartDraw: (e: React.MouseEvent | React.TouchEvent) => void;
+  onDraw: (e: React.MouseEvent | React.TouchEvent) => void;
+  onEndDraw: () => void;
+  onClear: () => void;
+  onSign: () => void;
+}) {
+  return (
+    <>
+      <div className="text-xs text-gray-500 mb-2 text-center">กรุณาลงนามในกรอบด้านล่าง</div>
+      <canvas
+        ref={canvasRef}
+        width={500}
+        height={200}
+        className="w-full border-2 border-dashed border-gray-300 rounded-lg cursor-crosshair touch-none"
+        style={{ height: '200px' }}
+        onMouseDown={onStartDraw}
+        onMouseMove={onDraw}
+        onMouseUp={onEndDraw}
+        onMouseLeave={onEndDraw}
+        onTouchStart={onStartDraw}
+        onTouchMove={onDraw}
+        onTouchEnd={onEndDraw}
+      />
+      <div className="flex gap-3 mt-3">
+        <button onClick={onClear} className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50">
+          ล้าง
+        </button>
+        <div className="flex-1" />
+        <button
+          onClick={onSign}
+          disabled={!hasDrawn || isPending}
+          className="px-6 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+        >
+          {isPending ? 'กำลังบันทึก...' : 'ยืนยันลงนาม'}
+        </button>
+      </div>
+    </>
   );
 }
 

--- a/apps/web/src/store/templateStore.ts
+++ b/apps/web/src/store/templateStore.ts
@@ -194,10 +194,10 @@ function blocksToHtml(blocks: Block[]): string {
 
       case 'signature-block':
         return `<div style="margin:24px 0;display:grid;grid-template-columns:1fr 1fr;gap:32px 32px">
-          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ {staff_signature} ผู้ให้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">( {{= COMPANY.DIRECTOR }} )</div><div style="font-size:11px;color:#999">ผู้จัดการ {{= COMPANY.NAME_TH }}</div></div>
-          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ {customer_signature} ผู้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">( {{= CUSTOMER.NAME }} )</div></div>
-          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ..................................................พยาน</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
-          <div style="text-align:center"><div style="margin-bottom:4px;font-size:13px">ลงชื่อ..................................................พยาน</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
+          <div style="text-align:center"><div style="font-size:13px">ลงชื่อ</div><div style="min-height:50px;display:flex;align-items:center;justify-content:center">{staff_signature}</div><div style="font-size:13px">ผู้ให้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">( {{= COMPANY.DIRECTOR }} )</div><div style="font-size:11px;color:#999">ผู้จัดการ {{= COMPANY.NAME_TH }}</div></div>
+          <div style="text-align:center"><div style="font-size:13px">ลงชื่อ</div><div style="min-height:50px;display:flex;align-items:center;justify-content:center">{customer_signature}</div><div style="font-size:13px">ผู้เช่าซื้อ</div><div style="font-size:12px;color:#6b7280">( {{= CUSTOMER.NAME }} )</div></div>
+          <div style="text-align:center"><div style="font-size:13px">ลงชื่อ</div><div style="min-height:50px;border-bottom:1px dotted #000;width:80%;margin:0 auto"></div><div style="font-size:13px">พยาน</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
+          <div style="text-align:center"><div style="font-size:13px">ลงชื่อ</div><div style="min-height:50px;border-bottom:1px dotted #000;width:80%;margin:0 auto"></div><div style="font-size:13px">พยาน</div><div style="font-size:12px;color:#6b7280">(${' '.repeat(30)})</div></div>
         </div>`;
 
       case 'photo-attachment':


### PR DESCRIPTION
- Add savedSignature (text) field to User model for storing staff signatures
- Add GET/PUT/DELETE /users/me/signature API endpoints for saved signatures
- Update ContractSignPage with saved signature flow:
  - STAFF: shows "use saved signature" button when available, or "sign new"
  - CUSTOMER: goes directly to signature pad (no saved sig)
  - Auto-saves staff signature on first sign for future reuse
- Update signature positioning in contract preview:
  - Signatures now appear centered between "ลงชื่อ" (above) and "ผู้ให้เช่าซื้อ/ผู้เช่าซื้อ" (below) instead of inline with dots
  - Updated default template, blocksToHtml signature block, and post-processing regex for templates without placeholders

https://claude.ai/code/session_01RTVkFsmD8SBQPPxv8gUs23