### PR TITLE
fix: installment price not showing on contract page

### DIFF
--- a/apps/web/src/pages/ContractCreatePage.tsx
+++ b/apps/web/src/pages/ContractCreatePage.tsx
@@ -344,9 +344,10 @@ export default function ContractCreatePage() {
   // Calculate installment
   const getSellingPrice = () => {
     if (!selectedProduct) return 0;
-    // For installment contracts, prefer "ราคาผ่อน" price, then default, then first available
+    // For installment contracts, prefer "ราคาผ่อน BESTCHOICE", then any "ราคาผ่อน*", then default, then first available
     const price =
-      selectedProduct.prices.find((p) => p.label === 'ราคาผ่อน') ||
+      selectedProduct.prices.find((p) => p.label === 'ราคาผ่อน BESTCHOICE') ||
+      selectedProduct.prices.find((p) => p.label.startsWith('ราคาผ่อน')) ||
       selectedProduct.prices.find((p) => p.isDefault) ||
       selectedProduct.prices[0];
     return price ? parseFloat(price.amount) : 0;


### PR DESCRIPTION
Product creation sets price label as "ราคาผ่อน BESTCHOICE" but contract creation page searched for exact match "ราคาผ่อน" — which never matched.

Updated getSellingPrice() to prioritize "ราคาผ่อน BESTCHOICE", then fall back to any label starting with "ราคาผ่อน", then default, then first price.

https://claude.ai/code/session_01UVrUcYuAQLGRoEcn8fijDb