### PR TITLE
feat: improve contract/customer pages with signatures, references, ed…

### DIFF
--- a/apps/api/prisma/migrations/20260311200000_add_customer_snapshot/migration.sql
+++ b/apps/api/prisma/migrations/20260311200000_add_customer_snapshot/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "contracts" ADD COLUMN "customer_snapshot" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -380,6 +380,9 @@ model Contract {
   // Contract document hash (SHA-256) สำหรับ verify integrity
   contractHash  String? @map("contract_hash")
 
+  // Snapshot ข้อมูลลูกค้า ณ เวลาที่สร้างสัญญา (ป้องกันการเปลี่ยนย้อนหลัง)
+  customerSnapshot Json? @map("customer_snapshot")
+
   // Legal clauses flags (ข้อความตามกฎหมาย)
   hasOwnershipClause     Boolean @default(false) @map("has_ownership_clause") // ม.572
   hasRepossessionClause  Boolean @default(false) @map("has_repossession_clause")

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -261,6 +261,30 @@ export class ContractsService {
             throw new BadRequestException('สินค้าไม่พร้อมขาย (อาจถูกจองแล้ว)');
           }
 
+          // Fetch customer data for snapshot (isolation from future edits)
+          const customerData = await tx.customer.findUnique({ where: { id: dto.customerId } });
+          const customerSnapshot: Prisma.InputJsonValue | undefined = customerData ? {
+            name: customerData.name,
+            prefix: customerData.prefix,
+            nickname: customerData.nickname,
+            nationalId: customerData.nationalId,
+            phone: customerData.phone,
+            phoneSecondary: customerData.phoneSecondary,
+            email: customerData.email,
+            lineId: customerData.lineId,
+            occupation: customerData.occupation,
+            salary: customerData.salary ? customerData.salary.toString() : null,
+            workplace: customerData.workplace,
+            addressIdCard: customerData.addressIdCard,
+            addressCurrent: customerData.addressCurrent,
+            addressWork: customerData.addressWork,
+            references: customerData.references,
+            birthDate: customerData.birthDate,
+            facebookLink: customerData.facebookLink,
+            facebookName: customerData.facebookName,
+            googleMapLink: customerData.googleMapLink,
+          } : undefined;
+
           // Generate contract number
           const contractNumber = await generateContractNumber(tx);
 
@@ -284,6 +308,7 @@ export class ContractsService {
               notes: dto.notes,
               paymentDueDay: dto.paymentDueDay,
               interestConfigId: interestConfig?.id,
+              customerSnapshot,
             },
           });
 

--- a/apps/web/src/pages/ContractCreatePage.tsx
+++ b/apps/web/src/pages/ContractCreatePage.tsx
@@ -170,7 +170,7 @@ export default function ContractCreatePage() {
   const [custAddrCurrent, setCustAddrCurrent] = useState<AddressData>(emptyAddress);
   const [custSameAddress, setCustSameAddress] = useState(false);
   const [custAddrWork, setCustAddrWork] = useState<AddressData>(emptyAddress);
-  const [custReferences, setCustReferences] = useState<CustReferenceData[]>([{ ...emptyCustReference }, { ...emptyCustReference }]);
+  const [custReferences, setCustReferences] = useState<CustReferenceData[]>([{ ...emptyCustReference }, { ...emptyCustReference }, { ...emptyCustReference }, { ...emptyCustReference }]);
   const queryClient = useQueryClient();
 
   // Sync custAddrCurrent when "same as ID card" is checked
@@ -184,7 +184,7 @@ export default function ContractCreatePage() {
     setCustAddrCurrent(emptyAddress);
     setCustAddrWork(emptyAddress);
     setCustSameAddress(false);
-    setCustReferences([{ ...emptyCustReference }, { ...emptyCustReference }]);
+    setCustReferences([{ ...emptyCustReference }, { ...emptyCustReference }, { ...emptyCustReference }, { ...emptyCustReference }]);
   };
 
   const updateCustRef = (index: number, field: keyof CustReferenceData, value: string) => {
@@ -350,6 +350,66 @@ export default function ContractCreatePage() {
     onError: (err: any) => {
       toast.error(getErrorMessage(err));
     },
+  });
+
+  // Edit product modal state (before contract creation)
+  const [showEditProductModal, setShowEditProductModal] = useState(false);
+  const [editProductForm, setEditProductForm] = useState<Record<string, any>>({});
+
+  const startEditProduct = () => {
+    if (!selectedProduct) return;
+    setEditProductForm({
+      name: selectedProduct.name,
+      brand: selectedProduct.brand,
+      model: selectedProduct.model,
+    });
+    setShowEditProductModal(true);
+  };
+
+  const editProductMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedProduct) return;
+      const { data } = await api.patch(`/products/${selectedProduct.id}`, editProductForm);
+      return data;
+    },
+    onSuccess: (data) => {
+      toast.success('แก้ไขข้อมูลสินค้าสำเร็จ');
+      if (data) setSelectedProduct({ ...selectedProduct!, ...data });
+      queryClient.invalidateQueries({ queryKey: ['products-available'] });
+      setShowEditProductModal(false);
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  // Edit customer modal state (before contract creation)
+  const [showEditCustomerModal, setShowEditCustomerModal] = useState(false);
+  const [editCustForm, setEditCustForm] = useState<Record<string, any>>({});
+
+  const startEditCustomer = () => {
+    if (!selectedCustomer) return;
+    setEditCustForm({
+      name: selectedCustomer.name,
+      phone: selectedCustomer.phone,
+    });
+    setShowEditCustomerModal(true);
+  };
+
+  const editCustomerMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedCustomer) return;
+      const payload: Record<string, unknown> = {};
+      if (editCustForm.name) payload.name = editCustForm.name;
+      if (editCustForm.phone) payload.phone = editCustForm.phone;
+      const { data } = await api.patch(`/customers/${selectedCustomer.id}`, payload);
+      return data;
+    },
+    onSuccess: (data) => {
+      toast.success('แก้ไขข้อมูลลูกค้าสำเร็จ');
+      if (data) setSelectedCustomer({ ...selectedCustomer!, name: data.name, phone: data.phone });
+      queryClient.invalidateQueries({ queryKey: ['customers-search'] });
+      setShowEditCustomerModal(false);
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });
 
   // Calculate installment
@@ -1239,13 +1299,19 @@ export default function ContractCreatePage() {
 
             <div className="space-y-3">
               <div className="bg-gray-50 rounded-lg p-4">
-                <div className="text-xs text-gray-500">สินค้า</div>
+                <div className="flex items-center justify-between">
+                  <div className="text-xs text-gray-500">สินค้า</div>
+                  <button type="button" onClick={startEditProduct} className="text-xs text-primary-600 hover:text-primary-700 hover:underline">แก้ไข</button>
+                </div>
                 <div className="font-medium">{selectedProduct?.brand} {selectedProduct?.model}</div>
                 <div className="text-sm text-gray-500">{selectedProduct?.name}</div>
               </div>
 
               <div className="bg-gray-50 rounded-lg p-4">
-                <div className="text-xs text-gray-500">ลูกค้า</div>
+                <div className="flex items-center justify-between">
+                  <div className="text-xs text-gray-500">ลูกค้า</div>
+                  <button type="button" onClick={startEditCustomer} className="text-xs text-primary-600 hover:text-primary-700 hover:underline">แก้ไข</button>
+                </div>
                 <div className="font-medium">{selectedCustomer?.name}</div>
                 <div className="text-sm text-gray-500">{selectedCustomer?.phone}</div>
               </div>
@@ -1307,6 +1373,52 @@ export default function ContractCreatePage() {
           </div>
         )}
       </div>
+
+      {/* Edit product modal (before contract creation) */}
+      <Modal isOpen={showEditProductModal} onClose={() => setShowEditProductModal(false)} title="แก้ไขข้อมูลสินค้า">
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">ชื่อสินค้า</label>
+            <input type="text" value={editProductForm.name || ''} onChange={(e) => setEditProductForm({ ...editProductForm, name: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">ยี่ห้อ</label>
+              <input type="text" value={editProductForm.brand || ''} onChange={(e) => setEditProductForm({ ...editProductForm, brand: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">รุ่น</label>
+              <input type="text" value={editProductForm.model || ''} onChange={(e) => setEditProductForm({ ...editProductForm, model: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+            </div>
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button type="button" onClick={() => setShowEditProductModal(false)} className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg">ยกเลิก</button>
+            <button type="button" onClick={() => editProductMutation.mutate()} disabled={editProductMutation.isPending} className="px-6 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium disabled:opacity-50">
+              {editProductMutation.isPending ? 'กำลังบันทึก...' : 'บันทึก'}
+            </button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Edit customer modal (before contract creation) */}
+      <Modal isOpen={showEditCustomerModal} onClose={() => setShowEditCustomerModal(false)} title="แก้ไขข้อมูลลูกค้า">
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">ชื่อ-นามสกุล</label>
+            <input type="text" value={editCustForm.name || ''} onChange={(e) => setEditCustForm({ ...editCustForm, name: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">เบอร์โทร</label>
+            <input type="tel" value={editCustForm.phone || ''} onChange={(e) => setEditCustForm({ ...editCustForm, phone: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button type="button" onClick={() => setShowEditCustomerModal(false)} className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg">ยกเลิก</button>
+            <button type="button" onClick={() => editCustomerMutation.mutate()} disabled={editCustomerMutation.isPending} className="px-6 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium disabled:opacity-50">
+              {editCustomerMutation.isPending ? 'กำลังบันทึก...' : 'บันทึก'}
+            </button>
+          </div>
+        </div>
+      </Modal>
 
       {/* Customer creation modal (full form like CustomersPage) */}
       <Modal isOpen={showCustomerModal} onClose={() => setShowCustomerModal(false)} title="เพิ่มลูกค้าใหม่" size="lg">

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -44,6 +44,7 @@ interface ContractDetail {
   reviewedAt: string | null;
   salespersonId: string;
   customer: { id: string; name: string; phone: string; nationalId: string };
+  customerSnapshot: { name: string; phone: string; nationalId?: string; prefix?: string; nickname?: string; occupation?: string; salary?: string } | null;
   product: { id: string; name: string; brand: string; model: string; category: string; color: string | null; storage: string | null; serialNumber: string | null; imeiSerial: string | null; costPrice: string; batteryHealth: number | null; warrantyExpired: boolean | null; warrantyExpireDate: string | null; hasBox: boolean | null; accessoryType: string | null; accessoryBrand: string | null };
   branch: { id: string; name: string };
   salesperson: { id: string; name: string };
@@ -265,9 +266,12 @@ export default function ContractDetailPage() {
   const isOwner = user?.role === 'OWNER';
   const canEdit = (isCreator || isOwner) && (contract.workflowStatus === 'CREATING' || contract.workflowStatus === 'REJECTED');
   const canDelete = isOwner && (contract.workflowStatus === 'CREATING' || contract.workflowStatus === 'REJECTED');
-  const customerSigned = contract.signatures?.some((s) => s.signerType === 'CUSTOMER');
-  const staffSigned = contract.signatures?.some((s) => s.signerType === 'STAFF');
-  const allSigned = customerSigned && staffSigned;
+  const signedTypes = new Set(contract.signatures?.map((s) => s.signerType === 'STAFF' ? 'COMPANY' : s.signerType) || []);
+  const customerSigned = signedTypes.has('CUSTOMER');
+  const companySigned = signedTypes.has('COMPANY');
+  const witness1Signed = signedTypes.has('WITNESS_1');
+  const witness2Signed = signedTypes.has('WITNESS_2');
+  const allSigned = customerSigned && companySigned && witness1Signed && witness2Signed;
 
   const paymentColumns = [
     { key: 'installmentNo', label: 'งวดที่', render: (p: Payment) => <span className="font-medium">{p.installmentNo}</span> },
@@ -417,24 +421,34 @@ export default function ContractDetailPage() {
       {(contract.workflowStatus === 'CREATING' || contract.workflowStatus === 'REJECTED') && contract.status === 'DRAFT' && (
         <div className="bg-primary-50 border border-primary-200 rounded-lg p-4 mb-6">
           <h3 className="text-sm font-semibold text-primary-800">ขั้นตอน: ให้ลูกค้าเซ็นสัญญา แล้วส่งตรวจสอบ</h3>
-          <div className="mt-3 flex items-center gap-4 text-xs">
-            <span className="font-medium text-primary-700">ลงนาม:</span>
-            <span className={customerSigned ? 'text-green-700' : 'text-amber-600'}>
-              ลูกค้า {customerSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
-            </span>
-            <span className={staffSigned ? 'text-green-700' : 'text-amber-600'}>
-              พนักงาน {staffSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
-            </span>
-            {!allSigned && (
-              <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-2 py-1 bg-primary-600 text-white rounded text-xs hover:bg-primary-700">
-                ไปลงนาม
-              </button>
-            )}
-            {allSigned && isCreator && (
-              <button onClick={() => submitReviewMutation.mutate()} disabled={submitReviewMutation.isPending} className="px-2 py-1 bg-amber-600 text-white rounded text-xs hover:bg-amber-700 disabled:opacity-50">
-                {submitReviewMutation.isPending ? 'กำลังส่ง...' : 'ส่งตรวจสอบ'}
-              </button>
-            )}
+          <div className="mt-3">
+            <div className="flex items-center gap-2 text-xs flex-wrap">
+              <span className="font-medium text-primary-700">ลงนาม ({[customerSigned, companySigned, witness1Signed, witness2Signed].filter(Boolean).length}/4):</span>
+              <span className={customerSigned ? 'text-green-700' : 'text-amber-600'}>
+                ผู้เช่าซื้อ {customerSigned ? '✓' : '✗'}
+              </span>
+              <span className={companySigned ? 'text-green-700' : 'text-amber-600'}>
+                ผู้ให้เช่าซื้อ {companySigned ? '✓' : '✗'}
+              </span>
+              <span className={witness1Signed ? 'text-green-700' : 'text-amber-600'}>
+                พยาน 1 {witness1Signed ? '✓' : '✗'}
+              </span>
+              <span className={witness2Signed ? 'text-green-700' : 'text-amber-600'}>
+                พยาน 2 {witness2Signed ? '✓' : '✗'}
+              </span>
+            </div>
+            <div className="flex gap-2 mt-2">
+              {!allSigned && (
+                <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-2 py-1 bg-primary-600 text-white rounded text-xs hover:bg-primary-700">
+                  ไปลงนาม
+                </button>
+              )}
+              {allSigned && isCreator && (
+                <button onClick={() => submitReviewMutation.mutate()} disabled={submitReviewMutation.isPending} className="px-2 py-1 bg-amber-600 text-white rounded text-xs hover:bg-amber-700 disabled:opacity-50">
+                  {submitReviewMutation.isPending ? 'กำลังส่ง...' : 'ส่งตรวจสอบ'}
+                </button>
+              )}
+            </div>
           </div>
         </div>
       )}
@@ -443,12 +457,18 @@ export default function ContractDetailPage() {
       {contract.workflowStatus === 'PENDING_REVIEW' && !isReviewer && (
         <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
           <h3 className="text-sm font-semibold text-amber-800">รอผู้จัดการตรวจสอบสัญญา</h3>
-          <div className="mt-2 flex items-center gap-4 text-xs">
+          <div className="mt-2 flex items-center gap-2 text-xs flex-wrap">
             <span className={customerSigned ? 'text-green-700' : 'text-amber-600'}>
-              ลูกค้า {customerSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
+              ผู้เช่าซื้อ {customerSigned ? '✓' : '✗'}
             </span>
-            <span className={staffSigned ? 'text-green-700' : 'text-amber-600'}>
-              พนักงาน {staffSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
+            <span className={companySigned ? 'text-green-700' : 'text-amber-600'}>
+              ผู้ให้เช่าซื้อ {companySigned ? '✓' : '✗'}
+            </span>
+            <span className={witness1Signed ? 'text-green-700' : 'text-amber-600'}>
+              พยาน 1 {witness1Signed ? '✓' : '✗'}
+            </span>
+            <span className={witness2Signed ? 'text-green-700' : 'text-amber-600'}>
+              พยาน 2 {witness2Signed ? '✓' : '✗'}
             </span>
           </div>
         </div>
@@ -464,16 +484,24 @@ export default function ContractDetailPage() {
           </div>
           {/* Signature status */}
           {contract.status === 'DRAFT' && (
-            <div className="mt-3 flex items-center gap-4 text-xs">
-              <span className="font-medium text-green-700">ลงนาม:</span>
-              <span className={customerSigned ? 'text-green-700' : 'text-amber-600'}>
-                ลูกค้า {customerSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
-              </span>
-              <span className={staffSigned ? 'text-green-700' : 'text-amber-600'}>
-                พนักงาน {staffSigned ? 'เซ็นแล้ว' : 'ยังไม่เซ็น'}
-              </span>
+            <div className="mt-3">
+              <div className="flex items-center gap-2 text-xs flex-wrap">
+                <span className="font-medium text-green-700">ลงนาม ({[customerSigned, companySigned, witness1Signed, witness2Signed].filter(Boolean).length}/4):</span>
+                <span className={customerSigned ? 'text-green-700' : 'text-amber-600'}>
+                  ผู้เช่าซื้อ {customerSigned ? '✓' : '✗'}
+                </span>
+                <span className={companySigned ? 'text-green-700' : 'text-amber-600'}>
+                  ผู้ให้เช่าซื้อ {companySigned ? '✓' : '✗'}
+                </span>
+                <span className={witness1Signed ? 'text-green-700' : 'text-amber-600'}>
+                  พยาน 1 {witness1Signed ? '✓' : '✗'}
+                </span>
+                <span className={witness2Signed ? 'text-green-700' : 'text-amber-600'}>
+                  พยาน 2 {witness2Signed ? '✓' : '✗'}
+                </span>
+              </div>
               {!allSigned && (
-                <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-2 py-1 bg-primary-600 text-white rounded text-xs hover:bg-primary-700">
+                <button onClick={() => navigate(`/contracts/${id}/sign`)} className="mt-2 px-3 py-1 bg-primary-600 text-white rounded text-xs hover:bg-primary-700">
                   ไปลงนาม
                 </button>
               )}
@@ -582,12 +610,17 @@ export default function ContractDetailPage() {
 
         <div className="space-y-6">
           <div className="bg-white rounded-lg border p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">ข้อมูลลูกค้า</h2>
-            <div className="grid grid-cols-2 gap-3">
-              <Info label="ชื่อ" value={contract.customer.name} />
-              <Info label="เบอร์โทร" value={contract.customer.phone} />
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900">ข้อมูลลูกค้า</h2>
+              {contract.customerSnapshot && (
+                <span className="text-[10px] text-gray-400 bg-gray-100 px-2 py-0.5 rounded">ข้อมูล ณ วันที่สร้างสัญญา</span>
+              )}
             </div>
-            <button onClick={() => navigate(`/customers/${contract.customer.id}`)} className="mt-3 text-xs text-primary-600 hover:underline">ดูรายละเอียดลูกค้า</button>
+            <div className="grid grid-cols-2 gap-3">
+              <Info label="ชื่อ" value={contract.customerSnapshot?.name || contract.customer.name} />
+              <Info label="เบอร์โทร" value={contract.customerSnapshot?.phone || contract.customer.phone} />
+            </div>
+            <button onClick={() => navigate(`/customers/${contract.customer.id}`)} className="mt-3 text-xs text-primary-600 hover:underline">ดูรายละเอียดลูกค้า (ข้อมูลปัจจุบัน)</button>
           </div>
 
           <div className="bg-white rounded-lg border p-6">

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -3,8 +3,10 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import DataTable from '@/components/ui/DataTable';
-import { displayAddress } from '@/components/ui/AddressForm';
+import Modal from '@/components/ui/Modal';
+import AddressForm, { AddressData, emptyAddress, displayAddress, serializeAddress, deserializeAddress } from '@/components/ui/AddressForm';
 import { useState, useRef } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
 
 import toast from 'react-hot-toast';
 import { maskNationalId } from '@/utils/mask.util';
@@ -95,13 +97,32 @@ const creditStatusLabels: Record<string, { label: string; className: string }> =
   MANUAL_REVIEW: { label: 'ต้องตรวจเพิ่ม', className: 'bg-amber-100 text-amber-700' },
 };
 
+const custPrefixOptions = ['นาย', 'นาง', 'นางสาว'];
+const custRelationshipOptions = ['บิดา', 'มารดา', 'พี่น้อง', 'คู่สมรส', 'ญาติ', 'เพื่อน', 'อื่นๆ'];
+
 export default function CustomerDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user } = useAuth();
 
   const creditFileRef = useRef<HTMLInputElement>(null);
   const [creditBankName, setCreditBankName] = useState('');
+
+  // Edit customer state
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [editForm, setEditForm] = useState({
+    prefix: '', name: '', nickname: '', phone: '', phoneSecondary: '',
+    email: '', lineId: '', facebookLink: '', facebookName: '', facebookFriends: '',
+    googleMapLink: '', occupation: '', occupationDetail: '', salary: '', workplace: '',
+    birthDate: '',
+  });
+  const [editAddrIdCard, setEditAddrIdCard] = useState<AddressData>(emptyAddress);
+  const [editAddrCurrent, setEditAddrCurrent] = useState<AddressData>(emptyAddress);
+  const [editAddrWork, setEditAddrWork] = useState<AddressData>(emptyAddress);
+  const [editRefs, setEditRefs] = useState<ReferenceData[]>([]);
+
+  const canEdit = user && ['OWNER', 'BRANCH_MANAGER'].includes(user.role);
 
   const { data: customer, isLoading } = useQuery<CustomerDetail>({
     queryKey: ['customer', id],
@@ -146,6 +167,82 @@ export default function CustomerDetailPage() {
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });
 
+  const startEdit = () => {
+    if (!customer) return;
+    setEditForm({
+      prefix: customer.prefix || '',
+      name: customer.name,
+      nickname: customer.nickname || '',
+      phone: customer.phone,
+      phoneSecondary: customer.phoneSecondary || '',
+      email: customer.email || '',
+      lineId: customer.lineId || '',
+      facebookLink: customer.facebookLink || '',
+      facebookName: customer.facebookName || '',
+      facebookFriends: customer.facebookFriends || '',
+      googleMapLink: customer.googleMapLink || '',
+      occupation: customer.occupation || '',
+      occupationDetail: customer.occupationDetail || '',
+      salary: customer.salary || '',
+      workplace: customer.workplace || '',
+      birthDate: customer.birthDate ? customer.birthDate.split('T')[0] : '',
+    });
+    setEditAddrIdCard(deserializeAddress(customer.addressIdCard));
+    setEditAddrCurrent(deserializeAddress(customer.addressCurrent));
+    setEditAddrWork(deserializeAddress(customer.addressWork));
+    // Initialize references with 4 slots
+    const existingRefs = (customer.references || []) as ReferenceData[];
+    const refs = [...existingRefs];
+    while (refs.length < 4) refs.push({});
+    setEditRefs(refs);
+    setShowEditModal(true);
+  };
+
+  const updateEditRef = (index: number, field: keyof ReferenceData, value: string) => {
+    setEditRefs(prev => prev.map((r, i) => i === index ? { ...r, [field]: value } : r));
+  };
+
+  const updateCustomerMutation = useMutation({
+    mutationFn: async () => {
+      const payload: Record<string, unknown> = {};
+      if (editForm.prefix) payload.prefix = editForm.prefix;
+      if (editForm.name) payload.name = editForm.name;
+      if (editForm.nickname) payload.nickname = editForm.nickname;
+      if (editForm.phone) payload.phone = editForm.phone;
+      if (editForm.phoneSecondary) payload.phoneSecondary = editForm.phoneSecondary;
+      if (editForm.email) payload.email = editForm.email;
+      if (editForm.lineId) payload.lineId = editForm.lineId;
+      if (editForm.facebookLink) payload.facebookLink = editForm.facebookLink;
+      if (editForm.facebookName) payload.facebookName = editForm.facebookName;
+      if (editForm.facebookFriends) payload.facebookFriends = editForm.facebookFriends;
+      if (editForm.googleMapLink) payload.googleMapLink = editForm.googleMapLink;
+      if (editForm.occupation) payload.occupation = editForm.occupation;
+      if (editForm.occupationDetail) payload.occupationDetail = editForm.occupationDetail;
+      if (editForm.salary && !isNaN(parseFloat(editForm.salary))) payload.salary = parseFloat(editForm.salary);
+      if (editForm.workplace) payload.workplace = editForm.workplace;
+      if (editForm.birthDate) payload.birthDate = new Date(editForm.birthDate).toISOString();
+
+      const addrIdCard = serializeAddress(editAddrIdCard);
+      const addrCurrent = serializeAddress(editAddrCurrent);
+      const addrWork = serializeAddress(editAddrWork);
+      if (addrIdCard) payload.addressIdCard = addrIdCard;
+      if (addrCurrent) payload.addressCurrent = addrCurrent;
+      if (addrWork) payload.addressWork = addrWork;
+
+      const validRefs = editRefs.filter(r => r.firstName || r.lastName || r.phone);
+      payload.references = validRefs.length > 0 ? validRefs : [];
+
+      const { data } = await api.patch(`/customers/${id}`, payload);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('แก้ไขข้อมูลลูกค้าสำเร็จ');
+      queryClient.invalidateQueries({ queryKey: ['customer', id] });
+      setShowEditModal(false);
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
   const analyzeCreditMutation = useMutation({
     mutationFn: async (creditCheckId: string) => {
       const { data } = await api.post(`/customers/${id}/credit-check/${creditCheckId}/analyze`);
@@ -178,7 +275,16 @@ export default function CustomerDetailPage() {
 
   return (
     <div>
-      <PageHeader title={displayName} subtitle="รายละเอียดลูกค้า" action={<button onClick={() => navigate('/customers')} className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg">กลับ</button>} />
+      <PageHeader title={displayName} subtitle="รายละเอียดลูกค้า" action={
+        <div className="flex gap-2">
+          {canEdit && (
+            <button onClick={startEdit} className="px-4 py-2 text-sm bg-amber-100 text-amber-700 rounded-lg hover:bg-amber-200">
+              แก้ไขข้อมูล
+            </button>
+          )}
+          <button onClick={() => navigate('/customers')} className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg">กลับ</button>
+        </div>
+      } />
 
       {/* Risk Warning */}
       {risk?.hasRisk && (
@@ -344,6 +450,171 @@ export default function CustomerDetailPage() {
         <h2 className="text-lg font-semibold text-gray-900 mb-3">สัญญาทั้งหมด ({customer.contracts.length})</h2>
         <DataTable columns={contractColumns} data={customer.contracts} emptyMessage="ยังไม่มีสัญญา" />
       </div>
+
+      {/* Edit Customer Modal */}
+      <Modal isOpen={showEditModal} onClose={() => setShowEditModal(false)} title="แก้ไขข้อมูลลูกค้า" size="lg">
+        <form onSubmit={(e) => { e.preventDefault(); updateCustomerMutation.mutate(); }} className="space-y-5 max-h-[75vh] overflow-y-auto pr-1">
+
+          {/* ข้อมูลส่วนตัว */}
+          <div className="border border-gray-200 rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-gray-800 mb-3">ข้อมูลส่วนตัว</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">คำนำหน้า</label>
+                <select value={editForm.prefix} onChange={(e) => setEditForm({ ...editForm, prefix: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white">
+                  <option value="">-- เลือก --</option>
+                  {custPrefixOptions.map(p => <option key={p} value={p}>{p}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">ชื่อ-นามสกุล *</label>
+                <input type="text" value={editForm.name} onChange={(e) => setEditForm({ ...editForm, name: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" required />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">ชื่อเล่น</label>
+                <input type="text" value={editForm.nickname} onChange={(e) => setEditForm({ ...editForm, nickname: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">วันเกิด</label>
+                <input type="date" value={editForm.birthDate} onChange={(e) => setEditForm({ ...editForm, birthDate: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+            </div>
+          </div>
+
+          {/* ที่อยู่ */}
+          <div className="border border-gray-200 rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-gray-800 mb-3">ที่อยู่ตามบัตรประชาชน</h3>
+            <AddressForm value={editAddrIdCard} onChange={setEditAddrIdCard} />
+          </div>
+          <div className="border border-gray-200 rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-gray-800 mb-3">ที่อยู่ปัจจุบัน</h3>
+            <AddressForm value={editAddrCurrent} onChange={setEditAddrCurrent} />
+            <div className="mt-3">
+              <label className="block text-xs text-gray-500 mb-1">Link Google Map</label>
+              <input type="url" value={editForm.googleMapLink} onChange={(e) => setEditForm({ ...editForm, googleMapLink: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="https://maps.google.com/..." />
+            </div>
+          </div>
+
+          {/* ข้อมูลติดต่อ */}
+          <div className="border border-gray-200 rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-gray-800 mb-3">ข้อมูลติดต่อ</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">เบอร์หลัก *</label>
+                <input type="tel" value={editForm.phone} onChange={(e) => setEditForm({ ...editForm, phone: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" required />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">เบอร์สำรอง</label>
+                <input type="tel" value={editForm.phoneSecondary} onChange={(e) => setEditForm({ ...editForm, phoneSecondary: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">อีเมล</label>
+                <input type="email" value={editForm.email} onChange={(e) => setEditForm({ ...editForm, email: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">LINE ID</label>
+                <input type="text" value={editForm.lineId} onChange={(e) => setEditForm({ ...editForm, lineId: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">ลิงก์ Facebook</label>
+                <input type="url" value={editForm.facebookLink} onChange={(e) => setEditForm({ ...editForm, facebookLink: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">ชื่อ Facebook</label>
+                <input type="text" value={editForm.facebookName} onChange={(e) => setEditForm({ ...editForm, facebookName: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">จำนวนเพื่อน Facebook</label>
+                <input type="text" value={editForm.facebookFriends} onChange={(e) => setEditForm({ ...editForm, facebookFriends: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+            </div>
+          </div>
+
+          {/* ข้อมูลที่ทำงาน */}
+          <div className="border border-gray-200 rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-gray-800 mb-3">ข้อมูลที่ทำงาน</h3>
+            <div className="grid grid-cols-2 gap-3 mb-3">
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">ชื่อที่ทำงาน</label>
+                <input type="text" value={editForm.workplace} onChange={(e) => setEditForm({ ...editForm, workplace: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">อาชีพ</label>
+                <input type="text" value={editForm.occupation} onChange={(e) => setEditForm({ ...editForm, occupation: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">รายละเอียดอาชีพ</label>
+                <input type="text" value={editForm.occupationDetail} onChange={(e) => setEditForm({ ...editForm, occupationDetail: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">เงินเดือน</label>
+                <input type="number" value={editForm.salary} onChange={(e) => setEditForm({ ...editForm, salary: e.target.value })} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="0.00" />
+              </div>
+            </div>
+            <div className="mt-2">
+              <label className="block text-xs text-gray-500 mb-1">ที่อยู่ที่ทำงาน</label>
+              <AddressForm value={editAddrWork} onChange={setEditAddrWork} />
+            </div>
+          </div>
+
+          {/* รายชื่อบุคคลอ้างอิง */}
+          <div className="border border-gray-200 rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-gray-800 mb-3">รายชื่อบุคคลอ้างอิง</h3>
+            <div className="space-y-4">
+              {editRefs.map((ref, idx) => (
+                <div key={idx}>
+                  <div className="text-xs font-medium text-gray-600 mb-2">บุคคลอ้างอิง {idx + 1}</div>
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">คำนำหน้า</label>
+                      <select value={ref.prefix || ''} onChange={(e) => updateEditRef(idx, 'prefix', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white">
+                        <option value="">-- เลือก --</option>
+                        {custPrefixOptions.map(p => <option key={p} value={p}>{p}</option>)}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">ชื่อ</label>
+                      <input type="text" value={ref.firstName || ''} onChange={(e) => updateEditRef(idx, 'firstName', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">นามสกุล</label>
+                      <input type="text" value={ref.lastName || ''} onChange={(e) => updateEditRef(idx, 'lastName', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">เบอร์โทร</label>
+                      <input type="tel" value={ref.phone || ''} onChange={(e) => updateEditRef(idx, 'phone', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">ความสัมพันธ์</label>
+                      <select value={ref.relationship || ''} onChange={(e) => updateEditRef(idx, 'relationship', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white">
+                        <option value="">-- เลือก --</option>
+                        {custRelationshipOptions.map(r => <option key={r} value={r}>{r}</option>)}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Warning about existing contracts */}
+          {customer.contracts.length > 0 && (
+            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+              <div className="text-xs text-amber-700">
+                การแก้ไขข้อมูลลูกค้าจะไม่กระทบสัญญาที่สร้างไปแล้ว ({customer.contracts.length} สัญญา)
+              </div>
+            </div>
+          )}
+
+          {/* Submit */}
+          <div className="flex justify-end gap-3 pt-2 sticky bottom-0 bg-white py-3 border-t">
+            <button type="button" onClick={() => setShowEditModal(false)} className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg">ยกเลิก</button>
+            <button type="submit" disabled={updateCustomerMutation.isPending} className="px-6 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium disabled:opacity-50">
+              {updateCustomerMutation.isPending ? 'กำลังบันทึก...' : 'บันทึก'}
+            </button>
+          </div>
+        </form>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
…iting, and snapshots

- Fix signature display on ContractDetailPage: show all 4 required types (ผู้เช่าซื้อ, ผู้ให้เช่าซื้อ, พยาน 1, พยาน 2) instead of just CUSTOMER/STAFF
- Expand reference contacts from 2 to 4 in ContractCreatePage customer modal
- Add inline edit buttons for product and customer info on contract confirmation step
- Add full customer edit modal to CustomerDetailPage (OWNER/BRANCH_MANAGER only) with all fields: personal, address, contact, work, and 4 reference contacts
- Add customerSnapshot JSON field to Contract model to isolate contract data from future customer edits (migration: 20260311200000)
- Store customer snapshot at contract creation time in contracts.service

https://claude.ai/code/session_01UVrUcYuAQLGRoEcn8fijDb