### PR TITLE
feat: add LINE OA settings page for easy setup without coding

### DIFF
--- a/apps/api/src/modules/line-oa/line-oa.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa.controller.ts
@@ -637,4 +637,115 @@ export class LineOaController {
       ...result,
     };
   }
+
+  // ─── LINE OA Settings (Owner) ───────────────────────
+
+  private static readonly LINE_CONFIG_KEYS = [
+    'line_channel_access_token',
+    'line_channel_secret',
+    'liff_id',
+    'promptpay_id',
+    'promptpay_account_name',
+    'payment_link_base_url',
+  ];
+
+  @Get('settings')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async getLineSettings() {
+    const configs = await this.prisma.systemConfig.findMany({
+      where: { key: { in: LineOaController.LINE_CONFIG_KEYS } },
+    });
+
+    const settings: Record<string, string> = {};
+    for (const c of configs) {
+      settings[c.key] = c.value;
+    }
+
+    // Mask sensitive values for display
+    const masked = { ...settings };
+    if (masked.line_channel_access_token) {
+      const v = masked.line_channel_access_token;
+      masked.line_channel_access_token = v.length > 10
+        ? v.substring(0, 6) + '****' + v.substring(v.length - 4)
+        : '****';
+    }
+    if (masked.line_channel_secret) {
+      const v = masked.line_channel_secret;
+      masked.line_channel_secret = v.length > 8
+        ? v.substring(0, 4) + '****' + v.substring(v.length - 4)
+        : '****';
+    }
+
+    return {
+      settings: masked,
+      raw: settings, // full values for form (sent over HTTPS, OWNER only)
+      isConfigured: !!settings.line_channel_access_token && !!settings.line_channel_secret,
+    };
+  }
+
+  @Post('settings')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async saveLineSettings(
+    @Body() body: Record<string, string>,
+  ) {
+    const labels: Record<string, string> = {
+      line_channel_access_token: 'LINE Channel Access Token',
+      line_channel_secret: 'LINE Channel Secret',
+      liff_id: 'LIFF ID',
+      promptpay_id: 'PromptPay ID',
+      promptpay_account_name: 'PromptPay Account Name',
+      payment_link_base_url: 'Payment Link Base URL',
+    };
+
+    for (const key of LineOaController.LINE_CONFIG_KEYS) {
+      if (body[key] !== undefined && body[key] !== '') {
+        await this.prisma.systemConfig.upsert({
+          where: { key },
+          create: { key, value: body[key], label: labels[key] || key },
+          update: { value: body[key] },
+        });
+      }
+    }
+
+    // Reload config in services
+    await this.lineOaService.reloadConfig();
+    if (body.promptpay_id || body.promptpay_account_name) {
+      this.promptPayQrService.setConfig(
+        body.promptpay_id || '',
+        body.promptpay_account_name || '',
+      );
+    }
+
+    this.logger.log('[LINE] Settings updated by admin');
+    return { success: true, message: 'บันทึกการตั้งค่า LINE OA เรียบร้อย' };
+  }
+
+  @Post('settings/test-connection')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async testLineConnection() {
+    try {
+      // Test by calling LINE Bot Info endpoint
+      const result = await this.lineOaService.testConnection();
+      return { success: true, botInfo: result };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'ไม่สามารถเชื่อมต่อ LINE ได้',
+      };
+    }
+  }
+
+  @Get('settings/webhook-url')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async getWebhookUrl(@Req() req: Request) {
+    const protocol = req.headers['x-forwarded-proto'] || req.protocol;
+    const host = req.headers['x-forwarded-host'] || req.get('host');
+    const webhookUrl = `${protocol}://${host}/api/line-oa/webhook`;
+
+    return { webhookUrl };
+  }
 }

--- a/apps/api/src/modules/line-oa/line-oa.service.ts
+++ b/apps/api/src/modules/line-oa/line-oa.service.ts
@@ -12,7 +12,7 @@ import { buildPromptPayQrFlex, PromptPayQrData } from './flex-messages/promptpay
 @Injectable()
 export class LineOaService {
   private readonly logger = new Logger(LineOaService.name);
-  private readonly lineChannelAccessToken: string | undefined;
+  private lineChannelAccessToken: string | undefined;
   private readonly lineApiBaseUrl = 'https://api.line.me/v2/bot';
   private readonly lineDataApiBaseUrl = 'https://api-data.line.me/v2/bot';
 
@@ -21,6 +21,43 @@ export class LineOaService {
     private prisma: PrismaService,
   ) {
     this.lineChannelAccessToken = this.configService.get<string>('LINE_CHANNEL_ACCESS_TOKEN');
+    // Load from DB on startup (async)
+    this.loadConfigFromDb();
+  }
+
+  private async loadConfigFromDb(): Promise<void> {
+    try {
+      const config = await this.prisma.systemConfig.findUnique({
+        where: { key: 'line_channel_access_token' },
+      });
+      if (config?.value) {
+        this.lineChannelAccessToken = config.value;
+        this.logger.log('[LINE] Config loaded from database');
+      }
+    } catch {
+      // DB might not be ready yet on startup, that's fine
+    }
+  }
+
+  async reloadConfig(): Promise<void> {
+    await this.loadConfigFromDb();
+  }
+
+  async testConnection(): Promise<{ displayName: string; userId: string; pictureUrl?: string }> {
+    if (!this.lineChannelAccessToken) {
+      throw new Error('LINE Channel Access Token ยังไม่ได้ตั้งค่า');
+    }
+
+    const response = await fetch(`${this.lineApiBaseUrl}/info`, {
+      headers: { Authorization: `Bearer ${this.lineChannelAccessToken}` },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`LINE API error ${response.status}: ${errorBody}`);
+    }
+
+    return response.json();
   }
 
   // ─── LINE API Methods ─────────────────────────────────

--- a/apps/api/src/modules/line-oa/line-webhook.guard.ts
+++ b/apps/api/src/modules/line-oa/line-webhook.guard.ts
@@ -2,6 +2,7 @@ import { CanActivate, ExecutionContext, Injectable, Logger, UnauthorizedExceptio
 import { ConfigService } from '@nestjs/config';
 import { createHmac } from 'crypto';
 import { Request } from 'express';
+import { PrismaService } from '../../prisma/prisma.service';
 
 /**
  * Guard for LINE Webhook signature verification
@@ -11,16 +12,33 @@ import { Request } from 'express';
 @Injectable()
 export class LineWebhookGuard implements CanActivate {
   private readonly logger = new Logger(LineWebhookGuard.name);
-  private readonly channelSecret: string | undefined;
+  private channelSecret: string | undefined;
 
-  constructor(private configService: ConfigService) {
+  constructor(
+    private configService: ConfigService,
+    private prisma: PrismaService,
+  ) {
     this.channelSecret = this.configService.get<string>('LINE_CHANNEL_SECRET');
   }
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
 
-    // Skip verification in development if no secret is configured
+    // Try loading from DB if not set via env
+    if (!this.channelSecret) {
+      try {
+        const config = await this.prisma.systemConfig.findUnique({
+          where: { key: 'line_channel_secret' },
+        });
+        if (config?.value) {
+          this.channelSecret = config.value;
+        }
+      } catch {
+        // DB not ready
+      }
+    }
+
+    // Skip verification if no secret configured anywhere
     if (!this.channelSecret) {
       this.logger.warn('LINE_CHANNEL_SECRET not configured, skipping webhook verification');
       return true;

--- a/apps/api/src/modules/line-oa/promptpay/promptpay-qr.service.ts
+++ b/apps/api/src/modules/line-oa/promptpay/promptpay-qr.service.ts
@@ -11,12 +11,22 @@ import { ConfigService } from '@nestjs/config';
 @Injectable()
 export class PromptPayQrService {
   private readonly logger = new Logger(PromptPayQrService.name);
-  private readonly promptPayId: string | undefined;
-  private readonly accountName: string | undefined;
+  private promptPayId: string | undefined;
+  private accountName: string | undefined;
 
   constructor(private configService: ConfigService) {
     this.promptPayId = this.configService.get<string>('PROMPTPAY_ID');
     this.accountName = this.configService.get<string>('PROMPTPAY_ACCOUNT_NAME');
+  }
+
+  reloadConfig(): void {
+    // Will be called after DB config update; values loaded via ConfigService env
+    // For DB-stored values, the controller passes them directly
+  }
+
+  setConfig(promptPayId: string, accountName: string): void {
+    this.promptPayId = promptPayId;
+    this.accountName = accountName;
   }
 
   /**

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -51,6 +51,7 @@ const ReceiptsPage = lazy(() => import('@/pages/ReceiptsPage'));
 const CustomerPortalPage = lazy(() => import('@/pages/CustomerPortalPage'));
 const SlipReviewPage = lazy(() => import('@/pages/SlipReviewPage'));
 const LiffPayment = lazy(() => import('@/pages/liff/LiffPayment'));
+const LineOaSettingsPage = lazy(() => import('@/pages/LineOaSettingsPage'));
 
 const PageLoader = () => (
   <div className="flex items-center justify-center py-20">
@@ -329,6 +330,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER']}>
                 <MigrationPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/line-oa"
+            element={
+              <ProtectedRoute roles={['OWNER']}>
+                <LineOaSettingsPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -79,6 +79,7 @@ const navItems: NavItem[] = [
   { label: 'สาขา', path: '/branches', roles: ['OWNER'], section: 'system' },
   { label: 'จัดการผู้ใช้', path: '/users', roles: ['OWNER'], section: 'system' },
   { label: 'ตั้งค่าระบบ', path: '/settings', roles: ['OWNER'], section: 'system' },
+  { label: 'เชื่อมต่อ LINE OA', path: '/settings/line-oa', roles: ['OWNER'], section: 'system' },
   { label: 'ตั้งค่าดอกเบี้ย', path: '/settings/interest-config', roles: ['OWNER'], section: 'system' },
   { label: 'ราคาตั้งต้น', path: '/settings/pricing-templates', roles: ['OWNER'], section: 'system' },
   { label: 'เทมเพลตสัญญา', path: '/contract-templates', roles: ['OWNER'], section: 'system' },

--- a/apps/web/src/pages/LineOaSettingsPage.tsx
+++ b/apps/web/src/pages/LineOaSettingsPage.tsx
@@ -1,0 +1,434 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import api, { getErrorMessage } from '@/lib/api';
+import PageHeader from '@/components/ui/PageHeader';
+
+interface BotInfo {
+  displayName: string;
+  userId: string;
+  pictureUrl?: string;
+}
+
+export default function LineOaSettingsPage() {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<Record<string, string>>({});
+  const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
+  const [testResult, setTestResult] = useState<{ success: boolean; botInfo?: BotInfo; error?: string } | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['line-oa-settings'],
+    queryFn: async () => {
+      const res = await api.get('/line-oa/settings');
+      return res.data as { settings: Record<string, string>; raw: Record<string, string>; isConfigured: boolean };
+    },
+  });
+
+  const { data: webhookData } = useQuery({
+    queryKey: ['line-oa-webhook-url'],
+    queryFn: async () => {
+      const res = await api.get('/line-oa/settings/webhook-url');
+      return res.data as { webhookUrl: string };
+    },
+  });
+
+  useEffect(() => {
+    if (data?.raw) {
+      setForm(data.raw);
+    }
+  }, [data]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      return api.post('/line-oa/settings', form);
+    },
+    onSuccess: () => {
+      toast.success('บันทึกการตั้งค่าเรียบร้อย');
+      queryClient.invalidateQueries({ queryKey: ['line-oa-settings'] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const testMutation = useMutation({
+    mutationFn: async () => {
+      const res = await api.post('/line-oa/settings/test-connection');
+      return res.data as { success: boolean; botInfo?: BotInfo; error?: string };
+    },
+    onSuccess: (result) => {
+      setTestResult(result);
+      if (result.success && result.botInfo) {
+        toast.success(`เชื่อมต่อสำเร็จ!`);
+      } else {
+        toast.error(result.error || 'ไม่สามารถเชื่อมต่อได้');
+      }
+    },
+    onError: (err) => {
+      setTestResult({ success: false, error: getErrorMessage(err) });
+      toast.error(getErrorMessage(err));
+    },
+  });
+
+  const handleChange = (key: string, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+    toast.success('คัดลอกแล้ว');
+  };
+
+  // Check which steps are done
+  const hasToken = !!(form.line_channel_access_token);
+  const hasSecret = !!(form.line_channel_secret);
+  const hasPromptPay = !!(form.promptpay_id);
+  const hasLiff = !!(form.liff_id);
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <div className="text-center py-12 text-gray-500">กำลังโหลด...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <PageHeader
+        title="เชื่อมต่อ LINE OA"
+        subtitle="ตั้งค่าเชื่อมต่อ LINE Official Account เพื่อส่งแจ้งเตือนและรับชำระเงินผ่านไลน์"
+      />
+
+      {/* Connection Status Card */}
+      <div className={`mb-8 p-5 rounded-2xl border-2 ${
+        data?.isConfigured && testResult?.success
+          ? 'bg-green-50 border-green-300'
+          : data?.isConfigured
+            ? 'bg-blue-50 border-blue-300'
+            : 'bg-orange-50 border-orange-300'
+      }`}>
+        <div className="flex items-start gap-4">
+          <div className={`w-12 h-12 rounded-xl flex items-center justify-center text-2xl shrink-0 ${
+            data?.isConfigured && testResult?.success
+              ? 'bg-green-200'
+              : data?.isConfigured
+                ? 'bg-blue-200'
+                : 'bg-orange-200'
+          }`}>
+            {data?.isConfigured && testResult?.success ? '✅' : data?.isConfigured ? '🔗' : '⚠️'}
+          </div>
+          <div className="flex-1">
+            <h3 className="font-semibold text-lg">
+              {data?.isConfigured && testResult?.success
+                ? `เชื่อมต่อแล้ว: ${testResult.botInfo?.displayName}`
+                : data?.isConfigured
+                  ? 'ตั้งค่าแล้ว — กดทดสอบเพื่อยืนยัน'
+                  : 'ยังไม่ได้เชื่อมต่อ LINE OA'}
+            </h3>
+            <p className="text-sm text-gray-600 mt-1">
+              {data?.isConfigured
+                ? 'ระบบพร้อมส่งแจ้งเตือนค่างวด, รับสลิป, และแจ้งเตือนค้างชำระอัตโนมัติ'
+                : 'ทำตาม 3 ขั้นตอนด้านล่างเพื่อเชื่อมต่อ LINE OA กับระบบ'}
+            </p>
+            {testResult?.success && testResult.botInfo?.pictureUrl && (
+              <img src={testResult.botInfo.pictureUrl} alt="Bot" className="w-10 h-10 rounded-full mt-2" />
+            )}
+          </div>
+          {data?.isConfigured && (
+            <button
+              onClick={() => testMutation.mutate()}
+              disabled={testMutation.isPending}
+              className="px-5 py-2.5 bg-green-600 text-white rounded-xl font-medium hover:bg-green-700 disabled:bg-gray-300 shrink-0"
+            >
+              {testMutation.isPending ? 'กำลังทดสอบ...' : 'ทดสอบการเชื่อมต่อ'}
+            </button>
+          )}
+        </div>
+        {testResult && !testResult.success && (
+          <div className="mt-3 p-3 bg-red-100 border border-red-200 rounded-lg">
+            <p className="text-sm text-red-700">เชื่อมต่อไม่สำเร็จ: {testResult.error}</p>
+            <p className="text-xs text-red-500 mt-1">กรุณาตรวจสอบ Channel Access Token ว่าถูกต้อง</p>
+          </div>
+        )}
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          saveMutation.mutate();
+        }}
+      >
+        {/* Step 1: LINE Channel */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+              hasToken && hasSecret ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-600'
+            }`}>
+              {hasToken && hasSecret ? '✓' : '1'}
+            </div>
+            <div>
+              <h3 className="font-semibold">ขั้นตอนที่ 1: เชื่อมต่อ LINE Channel</h3>
+              <p className="text-xs text-gray-500">สำคัญที่สุด — ระบบจะส่งข้อความผ่าน Channel นี้</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border p-5 ml-4 border-l-4 border-l-blue-400">
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-5">
+              <p className="text-sm text-blue-800 font-medium mb-2">วิธีหา Token:</p>
+              <ol className="text-sm text-blue-700 space-y-1.5 list-decimal list-inside">
+                <li>เปิด <a href="https://developers.line.biz/" target="_blank" rel="noopener noreferrer" className="underline font-medium">developers.line.biz</a> แล้วล็อกอิน</li>
+                <li>กดสร้าง <strong>Provider</strong> ใหม่ (ตั้งชื่อบริษัท)</li>
+                <li>กด <strong>Create a Messaging API channel</strong></li>
+                <li>ไปที่ tab <strong>"Basic settings"</strong> &rarr; คัดลอก <strong>Channel secret</strong></li>
+                <li>ไปที่ tab <strong>"Messaging API"</strong> &rarr; กด <strong>Issue</strong> ที่ Channel access token</li>
+              </ol>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Channel Access Token <span className="text-red-500">*</span>
+                </label>
+                <div className="relative">
+                  <input
+                    type={showSecrets['token'] ? 'text' : 'password'}
+                    value={form.line_channel_access_token || ''}
+                    onChange={(e) => handleChange('line_channel_access_token', e.target.value)}
+                    placeholder="วาง Channel Access Token ที่นี่"
+                    className="w-full border rounded-lg px-3 py-2.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 pr-16 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowSecrets((p) => ({ ...p, token: !p.token }))}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-blue-600 hover:text-blue-800 px-2 py-1 bg-blue-50 rounded"
+                  >
+                    {showSecrets['token'] ? 'ซ่อน' : 'แสดง'}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Channel Secret <span className="text-red-500">*</span>
+                </label>
+                <div className="relative">
+                  <input
+                    type={showSecrets['secret'] ? 'text' : 'password'}
+                    value={form.line_channel_secret || ''}
+                    onChange={(e) => handleChange('line_channel_secret', e.target.value)}
+                    placeholder="วาง Channel Secret ที่นี่"
+                    className="w-full border rounded-lg px-3 py-2.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 pr-16 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowSecrets((p) => ({ ...p, secret: !p.secret }))}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-blue-600 hover:text-blue-800 px-2 py-1 bg-blue-50 rounded"
+                  >
+                    {showSecrets['secret'] ? 'ซ่อน' : 'แสดง'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Step 2: Webhook URL */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+              hasToken && hasSecret ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-600'
+            }`}>
+              2
+            </div>
+            <div>
+              <h3 className="font-semibold">ขั้นตอนที่ 2: ตั้งค่า Webhook</h3>
+              <p className="text-xs text-gray-500">เพื่อให้ระบบรับข้อความจากลูกค้า</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border p-5 ml-4 border-l-4 border-l-green-400">
+            <div className="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
+              <p className="text-sm text-green-800 font-medium mb-2">คัดลอก URL ด้านล่าง แล้วไปวางใน LINE Developers Console:</p>
+              <ol className="text-sm text-green-700 space-y-1 list-decimal list-inside">
+                <li>เปิด LINE Developers Console &rarr; เลือก Channel ของคุณ</li>
+                <li>ไปที่ tab <strong>"Messaging API"</strong></li>
+                <li>หา <strong>"Webhook URL"</strong> &rarr; กด Edit &rarr; วาง URL ด้านล่าง</li>
+                <li>เปิด <strong>"Use webhook"</strong> ให้เป็นสีเขียว</li>
+                <li>ปิด <strong>"Auto-reply messages"</strong> (เพราะระบบตอบอัตโนมัติเอง)</li>
+              </ol>
+            </div>
+
+            {webhookData?.webhookUrl && (
+              <div className="flex items-center gap-2">
+                <code className="flex-1 text-sm bg-gray-100 px-4 py-3 rounded-lg border text-gray-800 font-mono break-all">
+                  {webhookData.webhookUrl}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => copyToClipboard(webhookData.webhookUrl)}
+                  className="px-4 py-3 bg-green-600 text-white text-sm rounded-lg hover:bg-green-700 shrink-0 font-medium"
+                >
+                  คัดลอก
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Step 3: PromptPay (Optional) */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+              hasPromptPay ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-600'
+            }`}>
+              {hasPromptPay ? '✓' : '3'}
+            </div>
+            <div>
+              <h3 className="font-semibold">ขั้นตอนที่ 3: ตั้งค่า PromptPay <span className="text-xs font-normal text-gray-400">(ไม่บังคับ)</span></h3>
+              <p className="text-xs text-gray-500">สร้าง QR พร้อมเพย์ให้ลูกค้าสแกนจ่ายผ่านไลน์</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border p-5 ml-4 border-l-4 border-l-purple-400">
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  เลข PromptPay
+                </label>
+                <input
+                  type="text"
+                  value={form.promptpay_id || ''}
+                  onChange={(e) => handleChange('promptpay_id', e.target.value)}
+                  placeholder="เช่น 0812345678 หรือ เลขบัตรประชาชน 13 หลัก"
+                  className="w-full border rounded-lg px-3 py-2.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+                <p className="text-xs text-gray-400 mt-1">ใส่เบอร์โทรหรือเลขบัตรประชาชนที่ผูกกับ PromptPay</p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  ชื่อบัญชี (แสดงบน QR)
+                </label>
+                <input
+                  type="text"
+                  value={form.promptpay_account_name || ''}
+                  onChange={(e) => handleChange('promptpay_account_name', e.target.value)}
+                  placeholder="เช่น BESTCHOICE Co.,Ltd."
+                  className="w-full border rounded-lg px-3 py-2.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Step 4: LIFF (Optional) */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+              hasLiff ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-600'
+            }`}>
+              {hasLiff ? '✓' : '4'}
+            </div>
+            <div>
+              <h3 className="font-semibold">ขั้นตอนที่ 4: ตั้งค่า LIFF <span className="text-xs font-normal text-gray-400">(ไม่บังคับ)</span></h3>
+              <p className="text-xs text-gray-500">หน้าชำระเงินแบบ Mini App ภายในไลน์</p>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border p-5 ml-4 border-l-4 border-l-orange-400">
+            <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 mb-4">
+              <p className="text-sm text-orange-800 font-medium mb-2">วิธีสร้าง LIFF App:</p>
+              <ol className="text-sm text-orange-700 space-y-1 list-decimal list-inside">
+                <li>เปิด LINE Developers Console &rarr; เลือก Channel</li>
+                <li>ไปที่ tab <strong>"LIFF"</strong> &rarr; กด <strong>"Add"</strong></li>
+                <li>ตั้ง Size: <strong>Full</strong>, Scope: เลือก <strong>profile</strong></li>
+                <li>ใส่ Endpoint URL: <strong>{`${window.location.origin}/pay`}</strong></li>
+                <li>คัดลอก <strong>LIFF ID</strong> มาวางด้านล่าง</li>
+              </ol>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  LIFF ID
+                </label>
+                <input
+                  type="text"
+                  value={form.liff_id || ''}
+                  onChange={(e) => handleChange('liff_id', e.target.value)}
+                  placeholder="เช่น 1234567890-xxxxxxxx"
+                  className="w-full border rounded-lg px-3 py-2.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Payment Link URL
+                </label>
+                <input
+                  type="text"
+                  value={form.payment_link_base_url || ''}
+                  onChange={(e) => handleChange('payment_link_base_url', e.target.value)}
+                  placeholder={form.liff_id ? `https://liff.line.me/${form.liff_id}` : 'ใส่ LIFF ID ก่อน จะสร้าง URL ให้อัตโนมัติ'}
+                  className="w-full border rounded-lg px-3 py-2.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono"
+                />
+                {form.liff_id && !form.payment_link_base_url && (
+                  <button
+                    type="button"
+                    onClick={() => handleChange('payment_link_base_url', `https://liff.line.me/${form.liff_id}`)}
+                    className="mt-2 text-xs text-blue-600 hover:text-blue-800 underline"
+                  >
+                    ใช้ URL อัตโนมัติ: https://liff.line.me/{form.liff_id}
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Save Button */}
+        <div className="ml-4 flex gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={saveMutation.isPending || (!hasToken && !hasSecret)}
+            className="px-8 py-3 bg-blue-600 text-white rounded-xl font-semibold hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-base shadow-sm"
+          >
+            {saveMutation.isPending ? 'กำลังบันทึก...' : 'บันทึกการตั้งค่า'}
+          </button>
+          {data?.isConfigured && (
+            <button
+              type="button"
+              onClick={() => testMutation.mutate()}
+              disabled={testMutation.isPending}
+              className="px-6 py-3 bg-green-600 text-white rounded-xl font-semibold hover:bg-green-700 disabled:bg-gray-300 text-base shadow-sm"
+            >
+              {testMutation.isPending ? 'กำลังทดสอบ...' : 'ทดสอบการเชื่อมต่อ'}
+            </button>
+          )}
+        </div>
+      </form>
+
+      {/* Features Info */}
+      <div className="mt-10 bg-gradient-to-br from-green-50 to-blue-50 rounded-2xl border border-green-200 p-6">
+        <h3 className="font-semibold text-gray-800 mb-4">เมื่อเชื่อมต่อแล้ว ระบบจะทำสิ่งนี้ได้อัตโนมัติ</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {[
+            { icon: '📢', title: 'แจ้งเตือนค่างวด', desc: 'ส่ง Flex Message สวยๆ ก่อนถึงกำหนด 1 และ 3 วัน' },
+            { icon: '⚠️', title: 'แจ้งเตือนค้างชำระ', desc: 'ส่งเตือนอัตโนมัติเมื่อเลยกำหนดชำระ' },
+            { icon: '📱', title: 'QR พร้อมเพย์', desc: 'ลูกค้าพิมพ์ "ชำระ" แล้วได้ QR สแกนจ่ายทันที' },
+            { icon: '🧾', title: 'รับสลิปผ่านไลน์', desc: 'ลูกค้าส่งรูปสลิป เข้าระบบตรวจสอบทันที' },
+            { icon: '✅', title: 'แจ้งผลการชำระ', desc: 'อนุมัติสลิปแล้ว ส่ง Flex แจ้งลูกค้าอัตโนมัติ' },
+            { icon: '💬', title: 'ตอบอัตโนมัติ', desc: 'พิมพ์ "เช็คยอด" "งวด" "ช่วยเหลือ" ตอบทันที' },
+          ].map((f) => (
+            <div key={f.title} className="flex items-start gap-3 bg-white/70 rounded-lg p-3">
+              <span className="text-xl">{f.icon}</span>
+              <div>
+                <p className="text-sm font-medium text-gray-800">{f.title}</p>
+                <p className="text-xs text-gray-500">{f.desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- New settings page at /settings/line-oa with step-by-step wizard UI
- 4 guided steps: Channel credentials, Webhook URL, PromptPay, LIFF
- Visual progress indicators (green checkmarks when configured)
- Connection test button to verify LINE API connectivity
- Auto-copy Webhook URL for easy paste into LINE Developers Console
- Feature showcase showing all automated capabilities
- Dynamic config reload: settings saved to DB, services reload without restart
- LineWebhookGuard loads channel secret from DB if not in env
- Sidebar nav: "เชื่อมต่อ LINE OA" under system settings

https://claude.ai/code/session_01H6vFgX6v92kcikLVVfkTfz