### PR TITLE
feat: redesign dashboard with business status and staff management sections

### DIFF
--- a/apps/api/src/modules/dashboard/dashboard.controller.ts
+++ b/apps/api/src/modules/dashboard/dashboard.controller.ts
@@ -61,4 +61,40 @@ export class DashboardController {
   getBranchComparison() {
     return this.dashboardService.getBranchComparison();
   }
+
+  @Get('monthly-revenue')
+  getMonthlyRevenue(
+    @CurrentUser() user: { role: string; branchId: string | null },
+    @Query('branchId') branchId?: string,
+  ) {
+    const effectiveBranch =
+      user.role === 'SALES' || user.role === 'BRANCH_MANAGER'
+        ? user.branchId || undefined
+        : branchId || undefined;
+    return this.dashboardService.getMonthlyRevenue(effectiveBranch);
+  }
+
+  @Get('aging-summary')
+  getAgingSummary(
+    @CurrentUser() user: { role: string; branchId: string | null },
+    @Query('branchId') branchId?: string,
+  ) {
+    const effectiveBranch =
+      user.role === 'SALES' || user.role === 'BRANCH_MANAGER'
+        ? user.branchId || undefined
+        : branchId || undefined;
+    return this.dashboardService.getAgingSummary(effectiveBranch);
+  }
+
+  @Get('staff-performance')
+  getStaffPerformance(
+    @CurrentUser() user: { role: string; branchId: string | null },
+    @Query('branchId') branchId?: string,
+  ) {
+    const effectiveBranch =
+      user.role === 'SALES' || user.role === 'BRANCH_MANAGER'
+        ? user.branchId || undefined
+        : branchId || undefined;
+    return this.dashboardService.getStaffPerformance(effectiveBranch);
+  }
 }

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -254,4 +254,188 @@ export class DashboardService {
       monthlyPayments: paymentTotalByBranch.get(branch.id) || 0,
     }));
   }
+
+  /**
+   * Monthly revenue summary for current month
+   */
+  async getMonthlyRevenue(branchId?: string) {
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const branchFilter = branchId ? { branchId } : {};
+
+    const [paidPayments, lateFeeAgg] = await Promise.all([
+      this.prisma.payment.findMany({
+        where: {
+          paidDate: { gte: monthStart, lt: monthEnd },
+          status: 'PAID',
+          contract: { deletedAt: null, ...branchFilter },
+        },
+        select: {
+          amountPaid: true,
+          contract: { select: { interestTotal: true, totalMonths: true } },
+        },
+      }),
+      this.prisma.payment.aggregate({
+        where: {
+          paidDate: { gte: monthStart, lt: monthEnd },
+          contract: { deletedAt: null, ...branchFilter },
+        },
+        _sum: { lateFee: true },
+      }),
+    ]);
+
+    const totalPayments = paidPayments.reduce((sum, p) => sum + Number(p.amountPaid), 0);
+    const interestIncome = paidPayments.reduce((sum, p) => {
+      const monthlyInterest = Number(p.contract.interestTotal) / p.contract.totalMonths;
+      return sum + monthlyInterest;
+    }, 0);
+
+    return {
+      totalPayments,
+      interestIncome: Math.round(interestIncome),
+      lateFeeIncome: Number(lateFeeAgg._sum.lateFee || 0),
+      paymentCount: paidPayments.length,
+    };
+  }
+
+  /**
+   * Aging summary: overdue payments grouped by age buckets
+   */
+  async getAgingSummary(branchId?: string) {
+    const now = new Date();
+    const branchFilter = branchId
+      ? { contract: { branchId, deletedAt: null } }
+      : { contract: { deletedAt: null } };
+
+    const overduePayments = await this.prisma.payment.findMany({
+      where: {
+        status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+        dueDate: { lt: now },
+        ...branchFilter,
+      },
+      select: { amountDue: true, amountPaid: true, lateFee: true, dueDate: true },
+    });
+
+    const bucketDefs = [
+      { range: '1-30', min: 1, max: 30, color: 'green' },
+      { range: '31-60', min: 31, max: 60, color: 'yellow' },
+      { range: '61-90', min: 61, max: 90, color: 'orange' },
+      { range: '90+', min: 91, max: Infinity, color: 'red' },
+    ];
+
+    const buckets = bucketDefs.map((def) => {
+      const items = overduePayments.filter((p) => {
+        const days = Math.floor((now.getTime() - new Date(p.dueDate).getTime()) / (1000 * 60 * 60 * 24));
+        return days >= def.min && days <= def.max;
+      });
+      const amount = items.reduce((s, p) => s + Number(p.amountDue) - Number(p.amountPaid), 0);
+      return { range: def.range, count: items.length, amount, color: def.color };
+    });
+
+    const totalCount = buckets.reduce((s, b) => s + b.count, 0);
+    const totalAmount = buckets.reduce((s, b) => s + b.amount, 0);
+
+    return { buckets, total: { count: totalCount, amount: totalAmount } };
+  }
+
+  /**
+   * Staff performance: sales metrics (current month) + recent activity (last 7 days)
+   */
+  async getStaffPerformance(branchId?: string) {
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const branchFilter = branchId ? { branchId } : {};
+
+    // Sales metrics: contracts this month grouped by salesperson
+    const contracts = await this.prisma.contract.findMany({
+      where: { createdAt: { gte: monthStart, lt: monthEnd }, deletedAt: null, ...branchFilter },
+      include: {
+        salesperson: { select: { id: true, name: true } },
+        branch: { select: { name: true } },
+      },
+    });
+
+    const staffMap = new Map<string, {
+      name: string; branch: string; totalContracts: number;
+      totalSales: number; overdueCount: number;
+    }>();
+
+    for (const c of contracts) {
+      const key = c.salespersonId;
+      const existing = staffMap.get(key) || {
+        name: c.salesperson.name, branch: c.branch.name,
+        totalContracts: 0, totalSales: 0, overdueCount: 0,
+      };
+      existing.totalContracts++;
+      existing.totalSales += Number(c.sellingPrice);
+      if (['OVERDUE', 'DEFAULT'].includes(c.status)) existing.overdueCount++;
+      staffMap.set(key, existing);
+    }
+
+    const salesMetrics = Array.from(staffMap.entries()).map(([id, data]) => ({
+      salespersonId: id,
+      ...data,
+      overdueRate: data.totalContracts > 0
+        ? Number(((data.overdueCount / data.totalContracts) * 100).toFixed(1))
+        : 0,
+    })).sort((a, b) => b.totalSales - a.totalSales);
+
+    // Recent activity: contracts created + payments recorded in last 7 days
+    const [recentContracts, recentPayments] = await Promise.all([
+      this.prisma.contract.findMany({
+        where: { createdAt: { gte: weekAgo }, deletedAt: null, ...branchFilter },
+        select: {
+          id: true,
+          contractNumber: true,
+          sellingPrice: true,
+          createdAt: true,
+          salesperson: { select: { name: true } },
+          customer: { select: { name: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 10,
+      }),
+      this.prisma.payment.findMany({
+        where: {
+          paidDate: { gte: weekAgo },
+          status: 'PAID',
+          contract: { deletedAt: null, ...branchFilter },
+        },
+        select: {
+          id: true,
+          amountPaid: true,
+          paidDate: true,
+          recordedBy: { select: { name: true } },
+          contract: { select: { contractNumber: true, customer: { select: { name: true } } } },
+        },
+        orderBy: { paidDate: 'desc' },
+        take: 10,
+      }),
+    ]);
+
+    const recentActivity = [
+      ...recentContracts.map((c) => ({
+        id: c.id,
+        type: 'contract_created' as const,
+        userName: c.salesperson.name,
+        description: `สร้างสัญญา ${c.contractNumber} — ${c.customer.name}`,
+        amount: Number(c.sellingPrice),
+        createdAt: c.createdAt.toISOString(),
+      })),
+      ...recentPayments.map((p) => ({
+        id: p.id,
+        type: 'payment_recorded' as const,
+        userName: p.recordedBy?.name || '-',
+        description: `บันทึกชำระ ${p.contract.contractNumber} — ${p.contract.customer.name}`,
+        amount: Number(p.amountPaid),
+        createdAt: p.paidDate?.toISOString() || new Date().toISOString(),
+      })),
+    ].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 20);
+
+    return { salesMetrics, recentActivity };
+  }
 }

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -4,8 +4,6 @@ import { useAuth } from '@/contexts/AuthContext';
 import { cn } from '@/lib/utils';
 import {
   ShoppingCart,
-  Clock,
-  Package,
   Warehouse,
   BarChart3,
   Settings,
@@ -75,24 +73,31 @@ interface NavSection {
 const navSections: NavSection[] = [
   {
     key: 'sales',
-    label: 'ขาย & ผ่อนชำระ',
+    label: 'ขายสินค้า',
     icon: ShoppingCart,
     items: [
       { label: 'POS ขายสินค้า', path: '/pos', icon: ShoppingCart },
       { label: 'ประวัติการขาย', path: '/sales', icon: Receipt },
       { label: 'ลูกค้า', path: '/customers', icon: Users },
       { label: 'ตรวจเครดิต', path: '/credit-checks', icon: CreditCard },
+    ],
+  },
+  {
+    key: 'contracts',
+    label: 'สัญญา & ชำระเงิน',
+    icon: FileCheck,
+    items: [
       { label: 'สัญญาผ่อน', path: '/contracts', icon: FileCheck },
       { label: 'ชำระเงิน', path: '/payments', icon: DollarSign },
-      { label: 'สถานะเอกสาร', path: '/document-dashboard', icon: FileText, roles: ['OWNER', 'BRANCH_MANAGER'] },
       { label: 'ใบเสร็จรับเงิน', path: '/receipts', icon: Receipt, roles: ['OWNER', 'BRANCH_MANAGER', 'ACCOUNTANT'] },
       { label: 'ตรวจสอบสลิป', path: '/slip-review', icon: FileCheck, roles: ['OWNER', 'BRANCH_MANAGER', 'ACCOUNTANT'] },
+      { label: 'สถานะเอกสาร', path: '/document-dashboard', icon: FileText, roles: ['OWNER', 'BRANCH_MANAGER'] },
     ],
   },
   {
     key: 'debt',
-    label: 'ติดตาม & จัดการหนี้',
-    icon: Clock,
+    label: 'ติดตามหนี้',
+    icon: AlertTriangle,
     items: [
       { label: 'ติดตามหนี้', path: '/overdue', icon: AlertTriangle },
       { label: 'เปลี่ยนเครื่อง', path: '/exchange', icon: RefreshCw, roles: ['OWNER', 'BRANCH_MANAGER'] },
@@ -100,23 +105,16 @@ const navSections: NavSection[] = [
     ],
   },
   {
-    key: 'purchasing',
-    label: 'จัดซื้อ',
-    icon: Package,
-    items: [
-      { label: 'สั่งซื้อ', path: '/purchase-orders', icon: ClipboardList, roles: ['OWNER', 'BRANCH_MANAGER'] },
-      { label: 'แจ้งเตือนสต็อก', path: '/stock/alerts', icon: Bell, roles: ['OWNER', 'BRANCH_MANAGER'] },
-    ],
-  },
-  {
-    key: 'warehouse',
-    label: 'คลังสินค้า',
+    key: 'inventory',
+    label: 'คลังสินค้า & จัดซื้อ',
     icon: Warehouse,
     items: [
       { label: 'คลังสินค้า', path: '/stock', icon: Warehouse, roles: ['OWNER', 'BRANCH_MANAGER', 'ACCOUNTANT', 'SALES'] },
+      { label: 'สั่งซื้อ', path: '/purchase-orders', icon: ClipboardList, roles: ['OWNER', 'BRANCH_MANAGER'] },
       { label: 'โอนสาขา', path: '/stock/transfers', icon: ArrowRightLeft, roles: ['OWNER', 'BRANCH_MANAGER'] },
       { label: 'ปรับสต็อก', path: '/stock/adjustments', icon: Sliders, roles: ['OWNER', 'BRANCH_MANAGER'] },
-      { label: 'ตรวจนับสต๊อก', path: '/stock/count', icon: ClipboardCheck, roles: ['OWNER', 'BRANCH_MANAGER'] },
+      { label: 'ตรวจนับสต็อก', path: '/stock/count', icon: ClipboardCheck, roles: ['OWNER', 'BRANCH_MANAGER'] },
+      { label: 'แจ้งเตือนสต็อก', path: '/stock/alerts', icon: Bell, roles: ['OWNER', 'BRANCH_MANAGER'] },
     ],
   },
   {
@@ -129,8 +127,8 @@ const navSections: NavSection[] = [
     ],
   },
   {
-    key: 'system',
-    label: 'ระบบ',
+    key: 'settings',
+    label: 'ตั้งค่า & ผู้ใช้',
     icon: Settings,
     items: [
       { label: 'ผู้ขาย', path: '/suppliers', icon: Building2, roles: ['OWNER', 'BRANCH_MANAGER'] },
@@ -141,9 +139,16 @@ const navSections: NavSection[] = [
       { label: 'ตั้งค่าดอกเบี้ย', path: '/settings/interest-config', icon: Percent, roles: ['OWNER'] },
       { label: 'ราคาตั้งต้น', path: '/settings/pricing-templates', icon: DollarSign, roles: ['OWNER'] },
       { label: 'เทมเพลตสัญญา', path: '/contract-templates', icon: FileSignature, roles: ['OWNER'] },
-      { label: 'สถานะระบบ', path: '/system-status', icon: Activity, roles: ['OWNER'] },
+    ],
+  },
+  {
+    key: 'admin',
+    label: 'ผู้ดูแลระบบ',
+    icon: Shield,
+    items: [
       { label: 'PDPA', path: '/pdpa', icon: Shield, roles: ['OWNER', 'BRANCH_MANAGER'] },
       { label: 'Audit Logs', path: '/audit-logs', icon: ScrollText, roles: ['OWNER'] },
+      { label: 'สถานะระบบ', path: '/system-status', icon: Activity, roles: ['OWNER'] },
       { label: 'นำเข้าข้อมูล', path: '/migration', icon: Database, roles: ['OWNER'] },
     ],
   },

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import api from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle, CardToolbar, CardTable } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
   ShoppingCart,
   FileCheck,
@@ -14,9 +15,13 @@ import {
   AlertTriangle,
   TrendingUp,
   ArrowRight,
+  Clock,
+  UserCheck,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+
+/* ─── Types ─── */
 
 interface KPIs {
   contracts: { total: number; active: number; overdue: number; default: number; completed: number };
@@ -53,6 +58,44 @@ interface BranchComparison {
   monthlyPayments: number;
 }
 
+interface MonthlyRevenue {
+  totalPayments: number;
+  interestIncome: number;
+  lateFeeIncome: number;
+  paymentCount: number;
+}
+
+interface AgingSummary {
+  buckets: { range: string; count: number; amount: number; color: string }[];
+  total: { count: number; amount: number };
+}
+
+interface StaffSalesMetric {
+  salespersonId: string;
+  name: string;
+  branch: string;
+  totalContracts: number;
+  totalSales: number;
+  overdueCount: number;
+  overdueRate: number;
+}
+
+interface StaffActivity {
+  id: string;
+  type: 'contract_created' | 'payment_recorded';
+  userName: string;
+  description: string;
+  amount: number;
+  createdAt: string;
+}
+
+interface StaffPerformance {
+  salesMetrics: StaffSalesMetric[];
+  recentActivity: StaffActivity[];
+}
+
+/* ─── Constants ─── */
+
 const statusLabels: Record<string, string> = {
   ACTIVE: 'ปกติ',
   OVERDUE: 'ค้างชำระ',
@@ -69,6 +112,20 @@ const statusColors: Record<string, string> = {
   COMPLETED: 'bg-blue-500',
   EXCHANGED: 'bg-purple-500',
   CLOSED_BAD_DEBT: 'bg-zinc-400',
+};
+
+const agingBarColors: Record<string, string> = {
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+  orange: 'bg-orange-500',
+  red: 'bg-red-500',
+};
+
+const agingTextColors: Record<string, string> = {
+  green: 'text-green-600 dark:text-green-400',
+  yellow: 'text-yellow-600 dark:text-yellow-400',
+  orange: 'text-orange-600 dark:text-orange-400',
+  red: 'text-red-600 dark:text-red-400',
 };
 
 /* ─── Quick Action Shortcut Card (Demo 9 style) ─── */
@@ -89,12 +146,36 @@ function ShortcutCard({ icon: Icon, label, path, color }: { icon: LucideIcon; la
   );
 }
 
+/* ─── Retry Error Block ─── */
+function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="text-center py-8">
+      <p className="text-sm text-destructive mb-2">{message}</p>
+      <button onClick={onRetry} className="text-xs text-primary hover:underline">ลองใหม่</button>
+    </div>
+  );
+}
+
+/* ─── Time ago helper ─── */
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins} นาทีที่แล้ว`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} ชม.ที่แล้ว`;
+  const days = Math.floor(hours / 24);
+  return `${days} วันที่แล้ว`;
+}
+
+/* ═══════════════════════════════════════════════════════════════ */
+
 export default function DashboardPage() {
   const { user } = useAuth();
   const navigate = useNavigate();
 
   const dashboardStaleTime = 5 * 60 * 1000;
 
+  /* ─── Existing queries ─── */
   const { data: kpis, isError: kpisError, refetch: refetchKpis } = useQuery<KPIs>({
     queryKey: ['dashboard-kpis'],
     queryFn: async () => (await api.get('/dashboard/kpis')).data,
@@ -126,16 +207,37 @@ export default function DashboardPage() {
     staleTime: dashboardStaleTime,
   });
 
+  /* ─── New queries ─── */
+  const { data: revenue, isError: revenueError, refetch: refetchRevenue } = useQuery<MonthlyRevenue>({
+    queryKey: ['dashboard-revenue'],
+    queryFn: async () => (await api.get('/dashboard/monthly-revenue')).data,
+    staleTime: dashboardStaleTime,
+  });
+
+  const { data: aging, isError: agingError, refetch: refetchAging } = useQuery<AgingSummary>({
+    queryKey: ['dashboard-aging'],
+    queryFn: async () => (await api.get('/dashboard/aging-summary')).data,
+    staleTime: dashboardStaleTime,
+  });
+
+  const { data: staffPerf, isError: staffError, refetch: refetchStaff } = useQuery<StaffPerformance>({
+    queryKey: ['dashboard-staff'],
+    queryFn: async () => (await api.get('/dashboard/staff-performance')).data,
+    staleTime: dashboardStaleTime,
+  });
+
+  /* ─── Computed ─── */
   const totalStatusCount = useMemo(() => statusDist.reduce((sum, s) => sum + s.count, 0), [statusDist]);
   const trendMax = useMemo(() => Math.max(...trend.map((t) => Math.max(t.newContracts, t.paymentsReceived)), 1), [trend]);
+  const agingMax = useMemo(() => (aging ? Math.max(...aging.buckets.map((b) => b.amount), 1) : 1), [aging]);
 
   return (
     <div className="flex flex-col gap-5 lg:gap-7">
-      {/* Page Title — Demo 9 pattern */}
+      {/* Page Title */}
       <div>
         <h1 className="text-xl font-semibold text-foreground">Dashboard</h1>
         <p className="text-sm text-muted-foreground mt-0.5">
-          สวัสดี {user?.name} — ภาพรวมระบบจัดการร้านของคุณวันนี้
+          สวัสดี {user?.name} — ภาพรวมธุรกิจและการกำกับพนักงาน
         </p>
       </div>
 
@@ -149,11 +251,50 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* ═══ Demo 9 Two-Column Layout ═══ */}
+      {/* ═══ KPI Banner (full-width) ═══ */}
+      {kpis && (
+        <div className="rounded-xl bg-gradient-to-br from-blue-500 via-blue-600 to-indigo-700 text-white p-6 lg:p-8">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="cursor-pointer" onClick={() => navigate('/contracts')}>
+              <div className="flex items-center gap-2 mb-2">
+                <FileCheck className="size-4 opacity-70" />
+                <span className="text-xs text-white/70 font-medium">สัญญาทั้งหมด</span>
+              </div>
+              <div className="text-2xl lg:text-3xl font-bold">{kpis.contracts.total}</div>
+              <div className="text-xs text-white/60 mt-1">ปกติ {kpis.contracts.active}</div>
+            </div>
+            <div className="cursor-pointer" onClick={() => navigate('/overdue')}>
+              <div className="flex items-center gap-2 mb-2">
+                <AlertTriangle className="size-4 opacity-70" />
+                <span className="text-xs text-white/70 font-medium">ค้าง/ผิดนัด</span>
+              </div>
+              <div className="text-2xl lg:text-3xl font-bold">{kpis.contracts.overdue + kpis.contracts.default}</div>
+              <div className="text-xs text-white/60 mt-1">{kpis.overdueRate.toFixed(1)}%</div>
+            </div>
+            <div className="cursor-pointer" onClick={() => navigate('/payments')}>
+              <div className="flex items-center gap-2 mb-2">
+                <TrendingUp className="size-4 opacity-70" />
+                <span className="text-xs text-white/70 font-medium">ยอดรับวันนี้</span>
+              </div>
+              <div className="text-2xl lg:text-3xl font-bold">฿{kpis.financial.todayPayments.toLocaleString()}</div>
+              <div className="text-xs text-white/60 mt-1">{kpis.financial.todayPaymentCount} รายการ</div>
+            </div>
+            <div className="cursor-pointer" onClick={() => navigate('/stock')}>
+              <div className="flex items-center gap-2 mb-2">
+                <Warehouse className="size-4 opacity-70" />
+                <span className="text-xs text-white/70 font-medium">สินค้าในสต็อก</span>
+              </div>
+              <div className="text-2xl lg:text-3xl font-bold">{kpis.products.inStock}</div>
+              <div className="text-xs text-white/60 mt-1">จาก {kpis.products.total}</div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ═══ Two-Column: Shortcuts + Monthly Revenue ═══ */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-5 lg:gap-7">
-        {/* ─── Left Column: Shortcuts + Activities ─── */}
-        <div className="lg:col-span-5 flex flex-col gap-5 lg:gap-7">
-          {/* Quick Action Shortcuts — Demo 9 icon card grid */}
+        {/* Quick Action Shortcuts */}
+        <div className="lg:col-span-5">
           <div className="grid grid-cols-2 gap-4">
             <ShortcutCard icon={ShoppingCart} label="POS ขายสินค้า" path="/pos" color="bg-blue-500" />
             <ShortcutCard icon={FileCheck} label="สัญญาผ่อน" path="/contracts" color="bg-indigo-500" />
@@ -162,146 +303,58 @@ export default function DashboardPage() {
             <ShortcutCard icon={Warehouse} label="คลังสินค้า" path="/stock" color="bg-orange-500" />
             <ShortcutCard icon={BarChart3} label="รายงาน" path="/reports" color="bg-cyan-500" />
           </div>
-
-          {/* Activities — Monthly Trend (styled as timeline) */}
-          <Card>
-            <CardHeader>
-              <CardTitle>แนวโน้ม 12 เดือน</CardTitle>
-              <CardToolbar>
-                <span className="text-2xs text-muted-foreground">Latest trends</span>
-              </CardToolbar>
-            </CardHeader>
-            <CardContent>
-              {trendError ? (
-                <div className="text-center py-8">
-                  <p className="text-sm text-destructive mb-2">โหลดข้อมูลไม่สำเร็จ</p>
-                  <button onClick={() => refetchTrend()} className="text-xs text-primary hover:underline">ลองใหม่</button>
-                </div>
-              ) : trend.length > 0 ? (
-                <div className="space-y-2">
-                  {trend.map((t) => (
-                    <div key={t.month} className="flex items-center gap-3 text-xs">
-                      <div className="w-14 text-muted-foreground shrink-0 font-medium">{t.month}</div>
-                      <div className="flex-1 space-y-1">
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="h-2.5 bg-primary rounded-full"
-                            style={{ width: `${(t.newContracts / trendMax) * 100}%`, minWidth: '2px' }}
-                          />
-                          <span className="text-foreground font-medium">{t.newContracts}</span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="h-2.5 bg-success rounded-full"
-                            style={{ width: `${(t.paymentsReceived / trendMax) * 100}%`, minWidth: '2px' }}
-                          />
-                          <span className="text-foreground font-medium">{t.paymentsReceived.toLocaleString()}</span>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                  <div className="flex gap-4 text-2xs text-muted-foreground mt-4 pt-3 border-t border-border/50">
-                    <span className="flex items-center gap-1.5">
-                      <span className="size-2.5 bg-primary rounded-full inline-block" /> สัญญาใหม่
-                    </span>
-                    <span className="flex items-center gap-1.5">
-                      <span className="size-2.5 bg-success rounded-full inline-block" /> ยอดชำระ (บาท)
-                    </span>
-                  </div>
-                </div>
-              ) : (
-                <div className="text-center text-muted-foreground py-8 text-sm">ไม่มีข้อมูล</div>
-              )}
-            </CardContent>
-          </Card>
         </div>
 
-        {/* ─── Right Column: KPI Banner + Status + Todo ─── */}
+        {/* Monthly Revenue */}
         <div className="lg:col-span-7 flex flex-col gap-5 lg:gap-7">
-          {/* KPI Summary Banner — Demo 9 blue promo style */}
-          {kpis && (
-            <div className="rounded-xl bg-gradient-to-br from-blue-500 via-blue-600 to-indigo-700 text-white p-6 lg:p-8">
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
-                <div className="cursor-pointer" onClick={() => navigate('/contracts')}>
-                  <div className="flex items-center gap-2 mb-2">
-                    <FileCheck className="size-4 opacity-70" />
-                    <span className="text-xs text-white/70 font-medium">สัญญาทั้งหมด</span>
-                  </div>
-                  <div className="text-2xl lg:text-3xl font-bold">{kpis.contracts.total}</div>
-                  <div className="text-xs text-white/60 mt-1">ปกติ {kpis.contracts.active}</div>
-                </div>
-                <div className="cursor-pointer" onClick={() => navigate('/overdue')}>
-                  <div className="flex items-center gap-2 mb-2">
-                    <AlertTriangle className="size-4 opacity-70" />
-                    <span className="text-xs text-white/70 font-medium">ค้าง/ผิดนัด</span>
-                  </div>
-                  <div className="text-2xl lg:text-3xl font-bold">{kpis.contracts.overdue + kpis.contracts.default}</div>
-                  <div className="text-xs text-white/60 mt-1">{kpis.overdueRate.toFixed(1)}%</div>
-                </div>
-                <div className="cursor-pointer" onClick={() => navigate('/payments')}>
-                  <div className="flex items-center gap-2 mb-2">
-                    <TrendingUp className="size-4 opacity-70" />
-                    <span className="text-xs text-white/70 font-medium">ยอดรับวันนี้</span>
-                  </div>
-                  <div className="text-2xl lg:text-3xl font-bold">฿{kpis.financial.todayPayments.toLocaleString()}</div>
-                  <div className="text-xs text-white/60 mt-1">{kpis.financial.todayPaymentCount} รายการ</div>
-                </div>
-                <div className="cursor-pointer" onClick={() => navigate('/stock')}>
-                  <div className="flex items-center gap-2 mb-2">
-                    <Warehouse className="size-4 opacity-70" />
-                    <span className="text-xs text-white/70 font-medium">สินค้าในสต็อก</span>
-                  </div>
-                  <div className="text-2xl lg:text-3xl font-bold">{kpis.products.inStock}</div>
-                  <div className="text-xs text-white/60 mt-1">จาก {kpis.products.total}</div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Status Distribution — Demo 9 "Trends" card style */}
           <Card>
             <CardHeader>
-              <CardTitle>สถานะสัญญา</CardTitle>
+              <CardTitle>รายได้เดือนนี้</CardTitle>
               <CardToolbar>
-                <span className="text-2xs text-muted-foreground bg-muted px-2.5 py-1 rounded-md font-medium">
-                  ทั้งหมด {totalStatusCount}
-                </span>
+                {revenue && (
+                  <span className="text-2xs text-muted-foreground bg-muted px-2.5 py-1 rounded-md font-medium">
+                    {revenue.paymentCount} รายการ
+                  </span>
+                )}
               </CardToolbar>
             </CardHeader>
-            <CardContent>
-              {statusDistError ? (
-                <div className="text-center py-8">
-                  <p className="text-sm text-destructive mb-2">โหลดข้อมูลไม่สำเร็จ</p>
-                  <button onClick={() => refetchStatusDist()} className="text-xs text-primary hover:underline">ลองใหม่</button>
-                </div>
-              ) : statusDist.length > 0 ? (
-                <div className="space-y-3">
-                  {statusDist.map((s) => (
-                    <div key={s.status} className="flex items-center gap-3">
-                      <div className="w-24 text-xs text-foreground font-medium flex items-center gap-2">
-                        <span className={cn('size-2 rounded-full', statusColors[s.status] || 'bg-zinc-400')} />
-                        {statusLabels[s.status] || s.status}
-                      </div>
-                      <div className="flex-1 bg-muted rounded-full h-3 overflow-hidden">
-                        <div
-                          className={cn('h-full rounded-full opacity-80', statusColors[s.status] || 'bg-zinc-400')}
-                          style={{
-                            width: totalStatusCount > 0 ? `${(s.count / totalStatusCount) * 100}%` : '0%',
-                            minWidth: s.count > 0 ? '8px' : '0',
-                          }}
-                        />
-                      </div>
-                      <div className="w-10 text-right text-2sm font-semibold text-foreground">{s.count}</div>
+            <CardContent className="p-0">
+              {revenueError ? (
+                <ErrorBlock message="โหลดข้อมูลรายได้ไม่สำเร็จ" onRetry={() => refetchRevenue()} />
+              ) : revenue ? (
+                <div className="divide-y divide-border/50">
+                  <div className="flex items-center gap-4 px-5 py-3.5">
+                    <div className="w-1 h-8 rounded-full bg-blue-500" />
+                    <div className="flex-1">
+                      <div className="text-sm font-medium text-foreground">ยอดชำระรวม</div>
+                      <div className="text-2xs text-muted-foreground">รับชำระทั้งเดือน</div>
                     </div>
-                  ))}
+                    <div className="text-sm font-semibold text-foreground">{revenue.totalPayments.toLocaleString()} ฿</div>
+                  </div>
+                  <div className="flex items-center gap-4 px-5 py-3.5">
+                    <div className="w-1 h-8 rounded-full bg-green-500" />
+                    <div className="flex-1">
+                      <div className="text-sm font-medium text-foreground">ดอกเบี้ยรับ</div>
+                      <div className="text-2xs text-muted-foreground">ส่วนดอกเบี้ยจากค่างวด</div>
+                    </div>
+                    <div className="text-sm font-semibold text-success">{revenue.interestIncome.toLocaleString()} ฿</div>
+                  </div>
+                  <div className="flex items-center gap-4 px-5 py-3.5">
+                    <div className="w-1 h-8 rounded-full bg-yellow-500" />
+                    <div className="flex-1">
+                      <div className="text-sm font-medium text-foreground">ค่าปรับ</div>
+                      <div className="text-2xs text-muted-foreground">ค่าปรับล่าช้าสะสม</div>
+                    </div>
+                    <div className="text-sm font-semibold text-warning">{revenue.lateFeeIncome.toLocaleString()} ฿</div>
+                  </div>
                 </div>
               ) : (
-                <div className="text-center text-muted-foreground py-8 text-sm">ไม่มีข้อมูล</div>
+                <div className="text-center text-muted-foreground py-8 text-sm">กำลังโหลด...</div>
               )}
             </CardContent>
           </Card>
 
-          {/* Secondary KPI Cards — Demo 9 "Todo" style with colored left border */}
+          {/* Financial Summary (existing) */}
           {kpis && (
             <Card>
               <CardHeader>
@@ -364,14 +417,269 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* ═══ Full-Width Sections Below ═══ */}
+      {/* ═══ Aging Buckets (full-width) ═══ */}
+      <Card>
+        <CardHeader>
+          <CardTitle>อายุหนี้ค้างชำระ (Aging)</CardTitle>
+          <CardToolbar>
+            {aging && (
+              <span className="text-2xs text-destructive bg-destructive/10 px-2.5 py-1 rounded-md font-medium">
+                {aging.total.count} รายการ — {aging.total.amount.toLocaleString()} ฿
+              </span>
+            )}
+          </CardToolbar>
+        </CardHeader>
+        <CardContent>
+          {agingError ? (
+            <ErrorBlock message="โหลดข้อมูลอายุหนี้ไม่สำเร็จ" onRetry={() => refetchAging()} />
+          ) : aging ? (
+            <div className="space-y-4">
+              {aging.buckets.map((bucket) => (
+                <div key={bucket.range} className="flex items-center gap-4">
+                  <div className="w-16 text-xs font-medium text-foreground shrink-0">{bucket.range} วัน</div>
+                  <div className="flex-1 bg-muted rounded-full h-4 overflow-hidden">
+                    <div
+                      className={cn('h-full rounded-full opacity-80', agingBarColors[bucket.color] || 'bg-zinc-400')}
+                      style={{
+                        width: agingMax > 0 ? `${(bucket.amount / agingMax) * 100}%` : '0%',
+                        minWidth: bucket.amount > 0 ? '8px' : '0',
+                      }}
+                    />
+                  </div>
+                  <div className="w-14 text-right text-xs font-medium text-muted-foreground">{bucket.count} รายการ</div>
+                  <div className={cn('w-28 text-right text-sm font-semibold', agingTextColors[bucket.color] || 'text-foreground')}>
+                    {bucket.amount.toLocaleString()} ฿
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center text-muted-foreground py-8 text-sm">กำลังโหลด...</div>
+          )}
+        </CardContent>
+      </Card>
 
-      {/* Top Overdue Table — Demo 9 "Latest Products" table style */}
+      {/* ═══ Staff Performance (Tabs) ═══ */}
+      <Card>
+        <CardHeader>
+          <CardTitle>กำกับพนักงาน</CardTitle>
+          <CardToolbar>
+            {staffPerf && (
+              <span className="text-2xs text-muted-foreground bg-muted px-2.5 py-1 rounded-md font-medium">
+                เดือนนี้
+              </span>
+            )}
+          </CardToolbar>
+        </CardHeader>
+        <CardContent>
+          {staffError ? (
+            <ErrorBlock message="โหลดข้อมูลพนักงานไม่สำเร็จ" onRetry={() => refetchStaff()} />
+          ) : staffPerf ? (
+            <Tabs defaultValue="sales">
+              <TabsList variant="line" size="sm">
+                <TabsTrigger value="sales">
+                  <UserCheck className="size-3.5" />
+                  ยอดขายรายคน
+                </TabsTrigger>
+                <TabsTrigger value="activity">
+                  <Clock className="size-3.5" />
+                  กิจกรรมล่าสุด
+                </TabsTrigger>
+              </TabsList>
+
+              {/* Tab: Sales by person */}
+              <TabsContent value="sales">
+                {staffPerf.salesMetrics.length > 0 ? (
+                  <div className="overflow-x-auto -mx-1">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-border/50 text-left text-muted-foreground">
+                          <th className="px-3 pb-3 pt-2 font-medium text-xs">พนักงาน</th>
+                          <th className="px-3 pb-3 pt-2 font-medium text-xs">สาขา</th>
+                          <th className="px-3 pb-3 pt-2 font-medium text-xs text-right">สัญญา</th>
+                          <th className="px-3 pb-3 pt-2 font-medium text-xs text-right">ยอดขาย</th>
+                          <th className="px-3 pb-3 pt-2 font-medium text-xs text-right">ค้างชำระ</th>
+                          <th className="px-3 pb-3 pt-2 font-medium text-xs text-right">อัตราค้าง</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {staffPerf.salesMetrics.map((s) => (
+                          <tr key={s.salespersonId} className="border-b border-border/30 last:border-0 hover:bg-muted/50 transition-colors">
+                            <td className="px-3 py-2.5 font-medium text-foreground">{s.name}</td>
+                            <td className="px-3 py-2.5 text-muted-foreground">{s.branch}</td>
+                            <td className="px-3 py-2.5 text-right text-foreground">{s.totalContracts}</td>
+                            <td className="px-3 py-2.5 text-right text-foreground font-medium">{s.totalSales.toLocaleString()} ฿</td>
+                            <td className="px-3 py-2.5 text-right">
+                              <span className={s.overdueCount > 0 ? 'text-destructive font-semibold' : 'text-foreground'}>
+                                {s.overdueCount}
+                              </span>
+                            </td>
+                            <td className="px-3 py-2.5 text-right">
+                              <span
+                                className={cn(
+                                  'px-2 py-0.5 rounded-md text-2xs font-medium',
+                                  s.overdueRate > 20
+                                    ? 'bg-destructive/10 text-destructive'
+                                    : s.overdueRate > 10
+                                      ? 'bg-warning/10 text-warning'
+                                      : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+                                )}
+                              >
+                                {s.overdueRate}%
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="text-center text-muted-foreground py-8 text-sm">ยังไม่มีข้อมูลเดือนนี้</div>
+                )}
+              </TabsContent>
+
+              {/* Tab: Recent Activity */}
+              <TabsContent value="activity">
+                {staffPerf.recentActivity.length > 0 ? (
+                  <div className="space-y-1">
+                    {staffPerf.recentActivity.map((a) => (
+                      <div key={`${a.type}-${a.id}`} className="flex items-start gap-3 py-2.5 border-b border-border/30 last:border-0">
+                        <div className={cn(
+                          'size-8 rounded-lg flex items-center justify-center shrink-0 mt-0.5',
+                          a.type === 'contract_created' ? 'bg-primary/10' : 'bg-success/10',
+                        )}>
+                          {a.type === 'contract_created'
+                            ? <FileCheck className="size-4 text-primary" />
+                            : <DollarSign className="size-4 text-success" />
+                          }
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm text-foreground">
+                            <span className="font-medium">{a.userName}</span>{' '}
+                            <span className="text-muted-foreground">{a.description}</span>
+                          </div>
+                          <div className="flex items-center gap-2 mt-0.5">
+                            <span className="text-2xs text-muted-foreground">{timeAgo(a.createdAt)}</span>
+                          </div>
+                        </div>
+                        <div className="text-sm font-semibold text-foreground shrink-0">
+                          {a.amount.toLocaleString()} ฿
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-center text-muted-foreground py-8 text-sm">ยังไม่มีกิจกรรมใน 7 วันที่ผ่านมา</div>
+                )}
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <div className="text-center text-muted-foreground py-8 text-sm">กำลังโหลด...</div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ═══ Two-Column: Trend + Status Distribution ═══ */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-5 lg:gap-7">
+        {/* Monthly Trend */}
+        <div className="lg:col-span-5">
+          <Card>
+            <CardHeader>
+              <CardTitle>แนวโน้ม 12 เดือน</CardTitle>
+              <CardToolbar>
+                <span className="text-2xs text-muted-foreground">Latest trends</span>
+              </CardToolbar>
+            </CardHeader>
+            <CardContent>
+              {trendError ? (
+                <ErrorBlock message="โหลดข้อมูลไม่สำเร็จ" onRetry={() => refetchTrend()} />
+              ) : trend.length > 0 ? (
+                <div className="space-y-2">
+                  {trend.map((t) => (
+                    <div key={t.month} className="flex items-center gap-3 text-xs">
+                      <div className="w-14 text-muted-foreground shrink-0 font-medium">{t.month}</div>
+                      <div className="flex-1 space-y-1">
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="h-2.5 bg-primary rounded-full"
+                            style={{ width: `${(t.newContracts / trendMax) * 100}%`, minWidth: '2px' }}
+                          />
+                          <span className="text-foreground font-medium">{t.newContracts}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="h-2.5 bg-success rounded-full"
+                            style={{ width: `${(t.paymentsReceived / trendMax) * 100}%`, minWidth: '2px' }}
+                          />
+                          <span className="text-foreground font-medium">{t.paymentsReceived.toLocaleString()}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                  <div className="flex gap-4 text-2xs text-muted-foreground mt-4 pt-3 border-t border-border/50">
+                    <span className="flex items-center gap-1.5">
+                      <span className="size-2.5 bg-primary rounded-full inline-block" /> สัญญาใหม่
+                    </span>
+                    <span className="flex items-center gap-1.5">
+                      <span className="size-2.5 bg-success rounded-full inline-block" /> ยอดชำระ (บาท)
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-center text-muted-foreground py-8 text-sm">ไม่มีข้อมูล</div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Status Distribution */}
+        <div className="lg:col-span-7">
+          <Card>
+            <CardHeader>
+              <CardTitle>สถานะสัญญา</CardTitle>
+              <CardToolbar>
+                <span className="text-2xs text-muted-foreground bg-muted px-2.5 py-1 rounded-md font-medium">
+                  ทั้งหมด {totalStatusCount}
+                </span>
+              </CardToolbar>
+            </CardHeader>
+            <CardContent>
+              {statusDistError ? (
+                <ErrorBlock message="โหลดข้อมูลไม่สำเร็จ" onRetry={() => refetchStatusDist()} />
+              ) : statusDist.length > 0 ? (
+                <div className="space-y-3">
+                  {statusDist.map((s) => (
+                    <div key={s.status} className="flex items-center gap-3">
+                      <div className="w-24 text-xs text-foreground font-medium flex items-center gap-2">
+                        <span className={cn('size-2 rounded-full', statusColors[s.status] || 'bg-zinc-400')} />
+                        {statusLabels[s.status] || s.status}
+                      </div>
+                      <div className="flex-1 bg-muted rounded-full h-3 overflow-hidden">
+                        <div
+                          className={cn('h-full rounded-full opacity-80', statusColors[s.status] || 'bg-zinc-400')}
+                          style={{
+                            width: totalStatusCount > 0 ? `${(s.count / totalStatusCount) * 100}%` : '0%',
+                            minWidth: s.count > 0 ? '8px' : '0',
+                          }}
+                        />
+                      </div>
+                      <div className="w-10 text-right text-2sm font-semibold text-foreground">{s.count}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-center text-muted-foreground py-8 text-sm">ไม่มีข้อมูล</div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* ═══ Top Overdue Table ═══ */}
       {topOverdueError && (
         <Card>
-          <CardContent className="text-center py-8">
-            <p className="text-sm text-destructive mb-2">โหลดข้อมูลค้างชำระไม่สำเร็จ</p>
-            <button onClick={() => refetchTopOverdue()} className="text-xs text-primary hover:underline">ลองใหม่</button>
+          <CardContent>
+            <ErrorBlock message="โหลดข้อมูลค้างชำระไม่สำเร็จ" onRetry={() => refetchTopOverdue()} />
           </CardContent>
         </Card>
       )}
@@ -429,12 +737,11 @@ export default function DashboardPage() {
         </Card>
       )}
 
-      {/* Branch Comparison (OWNER only) */}
+      {/* ═══ Branch Comparison (OWNER only) ═══ */}
       {user?.role === 'OWNER' && branchError && (
         <Card>
-          <CardContent className="text-center py-8">
-            <p className="text-sm text-destructive mb-2">โหลดข้อมูลสาขาไม่สำเร็จ</p>
-            <button onClick={() => refetchBranch()} className="text-xs text-primary hover:underline">ลองใหม่</button>
+          <CardContent>
+            <ErrorBlock message="โหลดข้อมูลสาขาไม่สำเร็จ" onRetry={() => refetchBranch()} />
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
Add revenue/profit tracking, aging buckets visualization, and staff
performance monitoring (sales ranking + activity timeline) to replace
the existing dashboard with a comprehensive business management view.

https://claude.ai/code/session_01K6NfNvgPttYetDTjq83i8p