### PR TITLE
fix: add migration retry logic and reduce DB connection pool size

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -26,7 +26,7 @@ services:
     envs:
       - key: DATABASE_URL
         scope: RUN_TIME
-        value: ${db.DATABASE_URL}
+        value: ${db.DATABASE_URL}?connection_limit=3&pool_timeout=30
       - key: NODE_ENV
         scope: RUN_AND_BUILD_TIME
         value: production

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,24 @@
 #!/bin/sh
 set -e
 
-echo "Running database migrations..."
-./node_modules/.bin/prisma migrate deploy --schema=./apps/api/prisma/schema.prisma
+# Run migrations with retry (DB may have connection limits on small plans)
+MAX_RETRIES=5
+RETRY_DELAY=5
+for i in $(seq 1 $MAX_RETRIES); do
+  echo "Running database migrations (attempt $i/$MAX_RETRIES)..."
+  if ./node_modules/.bin/prisma migrate deploy --schema=./apps/api/prisma/schema.prisma; then
+    echo "Migrations completed successfully."
+    break
+  else
+    if [ "$i" -eq "$MAX_RETRIES" ]; then
+      echo "Migrations failed after $MAX_RETRIES attempts. Exiting."
+      exit 1
+    fi
+    echo "Migration failed. Retrying in ${RETRY_DELAY}s..."
+    sleep $RETRY_DELAY
+    RETRY_DELAY=$((RETRY_DELAY * 2))
+  fi
+done
 
 echo "Seeding database..."
 node apps/api/dist/prisma/seed.js || echo "Seed skipped (may already exist)"


### PR DESCRIPTION
DigitalOcean dev database has low connection limits (~22). When deploying, the migration can fail with "remaining connection slots are reserved for SUPERUSER". This adds retry with exponential backoff for migrations and limits Prisma connection pool to 3 to prevent exhausting connections.

https://claude.ai/code/session_01K6NfNvgPttYetDTjq83i8p