### PR TITLE
perf: optimize Docker build with npm cache mount and selective copy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,7 @@ coverage
 .next
 .cache
 *.log
+apps/web/dist
+**/*.test.ts
+**/*.spec.ts
+**/__tests__

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 COPY apps/api/package.json apps/api/
 COPY packages/ packages/
-RUN npm ci 2>/dev/null || npm install
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # ============================================
 # Stage 2: Build API
@@ -14,11 +14,11 @@ RUN npm ci 2>/dev/null || npm install
 FROM node:20-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
-# Generate Prisma client
-RUN cd apps/api && npx prisma generate
-# Build NestJS API
-RUN cd apps/api && npm run build
+COPY package.json ./
+COPY apps/api ./apps/api
+COPY packages ./packages
+# Generate Prisma client + Build NestJS API
+RUN cd apps/api && npx prisma generate && npm run build
 
 # ============================================
 # Stage 3: Production Runtime


### PR DESCRIPTION
- Add BuildKit cache mount for npm ci (reuses downloaded packages across builds)
- Copy only apps/api and packages instead of entire project (skip apps/web)
- Combine prisma generate + nest build into single RUN layer
- Add test/spec files to .dockerignore

https://claude.ai/code/session_01K6NfNvgPttYetDTjq83i8p