### PR TITLE
fix: skip CSRF check on LINE webhook endpoint

### DIFF
--- a/apps/api/src/guards/csrf.guard.ts
+++ b/apps/api/src/guards/csrf.guard.ts
@@ -1,5 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
+import { SKIP_CSRF_KEY } from './skip-csrf.decorator';
 
 /**
  * CSRF defense-in-depth: requires X-Requested-With header on state-changing requests.
@@ -9,7 +11,15 @@ import { Request } from 'express';
  */
 @Injectable()
 export class CsrfGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
   canActivate(context: ExecutionContext): boolean {
+    const skipCsrf = this.reflector.getAllAndOverride<boolean>(SKIP_CSRF_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (skipCsrf) return true;
+
     const request = context.switchToHttp().getRequest<Request>();
     const method = request.method.toUpperCase();
 

--- a/apps/api/src/guards/skip-csrf.decorator.ts
+++ b/apps/api/src/guards/skip-csrf.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const SKIP_CSRF_KEY = 'skipCsrf';
+export const SkipCsrf = () => SetMetadata(SKIP_CSRF_KEY, true);

--- a/apps/api/src/modules/line-oa/line-oa.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa.controller.ts
@@ -24,6 +24,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { PrismaService } from '../../prisma/prisma.service';
 import { PromptPayQrService } from './promptpay/promptpay-qr.service';
 import { PaymentLinkService } from './payment-links/payment-link.service';
+import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -41,6 +42,7 @@ export class LineOaController {
   // ─── LINE Webhook ─────────────────────────────────────
 
   @Post('webhook')
+  @SkipCsrf()
   @UseGuards(LineWebhookGuard)
   @HttpCode(200)
   async handleWebhook(@Req() req: Request): Promise<string> {


### PR DESCRIPTION
LINE Platform doesn't send X-Requested-With header, causing the global CsrfGuard to return 403 Forbidden. Added @SkipCsrf() decorator to bypass CSRF for the webhook endpoint (protected by HMAC-SHA256 signature verification via LineWebhookGuard instead).

https://claude.ai/code/session_01K6NfNvgPttYetDTjq83i8p