### PR TITLE
fix: add DATABASE_URL_DIRECT to .env.example for Prisma migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/installment_db?schema=public"
+DATABASE_URL_DIRECT="postgresql://postgres:postgres@localhost:5432/installment_db?schema=public"
 DB_USER=installment
 DB_PASSWORD=changeme
 DB_NAME=installment_db

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,11 +43,15 @@ jobs:
 
       - name: Generate Prisma Client
         run: npx prisma generate --schema=apps/api/prisma/schema.prisma
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
+          DATABASE_URL_DIRECT: postgresql://test:test@localhost:5432/test_db?schema=public
 
       - name: Run DB migrations
         run: npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
+          DATABASE_URL_DIRECT: postgresql://test:test@localhost:5432/test_db?schema=public
 
       - name: Lint API
         run: npm run lint --workspace=apps/api
@@ -59,6 +63,7 @@ jobs:
         run: npm run test --workspace=apps/api
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
+          DATABASE_URL_DIRECT: postgresql://test:test@localhost:5432/test_db?schema=public
           JWT_SECRET: test-secret
 
       - name: Build API


### PR DESCRIPTION
Prisma schema requires DATABASE_URL_DIRECT for direct database connections (bypassing PgBouncer) during migrations.

https://claude.ai/code/session_01K6NfNvgPttYetDTjq83i8p