### PR TITLE
fix: remove DATABASE_URL_DIRECT and PgBouncer config

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -26,9 +26,6 @@ services:
     envs:
       - key: DATABASE_URL
         scope: RUN_TIME
-        value: ${db.DATABASE_URL}?connection_limit=3&pool_timeout=30&pgbouncer=true
-      - key: DATABASE_URL_DIRECT
-        scope: RUN_TIME
         value: ${db.DATABASE_URL}
       - key: NODE_ENV
         scope: RUN_AND_BUILD_TIME

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # Database
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/installment_db?schema=public"
-DATABASE_URL_DIRECT="postgresql://postgres:postgres@localhost:5432/installment_db?schema=public"
 DB_USER=installment
 DB_PASSWORD=changeme
 DB_NAME=installment_db

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,15 +43,11 @@ jobs:
 
       - name: Generate Prisma Client
         run: npx prisma generate --schema=apps/api/prisma/schema.prisma
-        env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
-          DATABASE_URL_DIRECT: postgresql://test:test@localhost:5432/test_db?schema=public
 
       - name: Run DB migrations
         run: npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
-          DATABASE_URL_DIRECT: postgresql://test:test@localhost:5432/test_db?schema=public
 
       - name: Lint API
         run: npm run lint --workspace=apps/api
@@ -63,7 +59,6 @@ jobs:
         run: npm run test --workspace=apps/api
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
-          DATABASE_URL_DIRECT: postgresql://test:test@localhost:5432/test_db?schema=public
           JWT_SECRET: test-secret
 
       - name: Build API

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 datasource db {
   provider  = "postgresql"
   url       = env("DATABASE_URL")
-  directUrl = env("DATABASE_URL_DIRECT")
 }
 
 // ============================================================


### PR DESCRIPTION
Database is using direct connection (upsize only, no PgBouncer), so directUrl in Prisma schema and DATABASE_URL_DIRECT env are no longer needed. This also fixes the CI failure.

https://claude.ai/code/session_01K6NfNvgPttYetDTjq83i8p