### PR TITLE
Fix double /api prefix in LIFF page API calls causing 404

### DIFF
--- a/apps/web/src/pages/liff/LiffContract.tsx
+++ b/apps/web/src/pages/liff/LiffContract.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 
-const API_BASE = import.meta.env.VITE_API_URL || '';
+const API_BASE = import.meta.env.VITE_API_URL || '/api';
 const LIFF_ID = import.meta.env.VITE_LIFF_ID || '';
 
 interface Payment {
@@ -101,7 +101,7 @@ export default function LiffContract() {
 
   async function fetchContracts(lineId: string) {
     try {
-      const res = await fetch(`${API_BASE}/api/line-oa/liff/contracts?lineId=${encodeURIComponent(lineId)}`);
+      const res = await fetch(`${API_BASE}/line-oa/liff/contracts?lineId=${encodeURIComponent(lineId)}`);
       if (res.status === 404) {
         setError('ยังไม่ได้ลงทะเบียน กรุณาลงทะเบียนก่อน');
         return;

--- a/apps/web/src/pages/liff/LiffPayment.tsx
+++ b/apps/web/src/pages/liff/LiffPayment.tsx
@@ -8,7 +8,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useMockPayment } from './useMockPayment';
 
-const API_BASE = import.meta.env.VITE_API_URL || '';
+const API_BASE = import.meta.env.VITE_API_URL || '/api';
 
 interface PaymentLinkData {
   id: string;
@@ -57,7 +57,7 @@ export default function LiffPayment() {
       return;
     }
 
-    fetch(`${API_BASE}/api/line-oa/pay/${token}`)
+    fetch(`${API_BASE}/line-oa/pay/${token}`)
       .then((res) => res.json())
       .then((result) => {
         if (!result || result.status === 'EXPIRED') {
@@ -68,7 +68,7 @@ export default function LiffPayment() {
           setView('error');
         } else {
           setData(result);
-          setQrUrl(`${API_BASE}/api/line-oa/payment/${result.payment?.id || 'default'}/qr`);
+          setQrUrl(`${API_BASE}/line-oa/payment/${result.payment?.id || 'default'}/qr`);
           setView('select-method');
         }
       })
@@ -113,7 +113,7 @@ export default function LiffPayment() {
       formData.append('contractId', data.contract.contractNumber);
       formData.append('token', data.token);
 
-      const res = await fetch(`${API_BASE}/api/line-oa/slip-upload`, {
+      const res = await fetch(`${API_BASE}/line-oa/slip-upload`, {
         method: 'POST',
         body: formData,
       });

--- a/apps/web/src/pages/liff/LiffRegister.tsx
+++ b/apps/web/src/pages/liff/LiffRegister.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import liff from '@line/liff';
 
-const API_BASE = import.meta.env.VITE_API_URL || '';
+const API_BASE = import.meta.env.VITE_API_URL || '/api';
 const LIFF_ID = import.meta.env.VITE_LIFF_ID || '';
 
 type Step = 'loading' | 'phone' | 'confirm' | 'success' | 'already_linked' | 'error';
@@ -39,7 +39,7 @@ export default function LiffRegister() {
         setProfile({ userId: p.userId, displayName: p.displayName, pictureUrl: p.pictureUrl });
 
         // Check if already linked
-        const res = await fetch(`${API_BASE}/api/line-oa/liff/contracts?lineId=${encodeURIComponent(p.userId)}`);
+        const res = await fetch(`${API_BASE}/line-oa/liff/contracts?lineId=${encodeURIComponent(p.userId)}`);
         if (res.ok) {
           setStep('already_linked');
           return;
@@ -78,7 +78,7 @@ export default function LiffRegister() {
 
     setSubmitting(true);
     try {
-      const res = await fetch(`${API_BASE}/api/line-oa/liff/register/lookup`, {
+      const res = await fetch(`${API_BASE}/line-oa/liff/register/lookup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone: cleaned, lineId: profile!.userId }),
@@ -109,7 +109,7 @@ export default function LiffRegister() {
 
     setSubmitting(true);
     try {
-      const res = await fetch(`${API_BASE}/api/line-oa/liff/register/confirm`, {
+      const res = await fetch(`${API_BASE}/line-oa/liff/register/confirm`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
LIFF pages used `${API_BASE}/api/line-oa/...` but API_BASE (VITE_API_URL) already includes `/api` on DigitalOcean, resulting in `/api/api/line-oa/...`. Changed fallback from '' to '/api' and removed hardcoded /api from URLs to match the pattern used by the regular app's axios instance.

https://claude.ai/code/session_0187RG3hWPW8G3uPoPGcvwkB