### PR TITLE
Fix circular dependency: ContractsService ↔ NotificationsService ↔ Li…

### DIFF
--- a/apps/api/src/modules/contracts/contracts.module.ts
+++ b/apps/api/src/modules/contracts/contracts.module.ts
@@ -1,10 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ContractsController } from './contracts.controller';
 import { ContractsService } from './contracts.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [NotificationsModule],
+  imports: [forwardRef(() => NotificationsModule)],
   controllers: [ContractsController],
   providers: [ContractsService],
   exports: [ContractsService],

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, BadRequestException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException, ForbiddenException, InternalServerErrorException, Optional, Inject, forwardRef } from '@nestjs/common';
 import { PaymentMethod, PlanType, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -22,6 +22,7 @@ export class ContractsService {
   private readonly logger = new Logger(ContractsService.name);
   constructor(
     private prisma: PrismaService,
+    @Optional() @Inject(forwardRef(() => NotificationsService))
     private notificationsService: NotificationsService,
   ) {}
 
@@ -737,6 +738,7 @@ export class ContractsService {
   }
 
   private async sendContractActivatedNotification(contract: any) {
+    if (!this.notificationsService) return;
     const customer = contract.customer;
     if (!customer) return;
 

--- a/apps/api/src/modules/line-oa/line-oa.module.ts
+++ b/apps/api/src/modules/line-oa/line-oa.module.ts
@@ -1,13 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { LineOaController } from './line-oa.controller';
 import { LineOaService } from './line-oa.service';
 import { LineWebhookGuard } from './line-webhook.guard';
 import { PromptPayQrService } from './promptpay/promptpay-qr.service';
 import { PaymentLinkService } from './payment-links/payment-link.service';
 import { RichMenuService } from './rich-menu/rich-menu.service';
-import { ContractsService } from '../contracts/contracts.service';
+import { ContractsModule } from '../contracts/contracts.module';
 
 @Module({
+  imports: [forwardRef(() => ContractsModule)],
   controllers: [LineOaController],
   providers: [
     LineOaService,
@@ -15,7 +16,6 @@ import { ContractsService } from '../contracts/contracts.service';
     PromptPayQrService,
     PaymentLinkService,
     RichMenuService,
-    ContractsService,
   ],
   exports: [LineOaService, PromptPayQrService, PaymentLinkService, RichMenuService],
 })


### PR DESCRIPTION
…neOaModule

ContractsService now depends on NotificationsService (for LINE notify on contract activation), but LineOaModule directly provided ContractsService, and NotificationsModule imports LineOaModule — creating a circular chain.

Fix:
- Use @Optional() + forwardRef for NotificationsService in ContractsService
- Use forwardRef in ContractsModule and LineOaModule imports
- LineOaModule now imports ContractsModule instead of directly providing the service

https://claude.ai/code/session_01Vf4JvvzNdPbvzsp28NxPF7