### PR TITLE
fix: OTP SMS ส่งไม่ได้ในโหมด dev และ rate limit นับผิดเมื่อส่งไม่สำเร็จ

### DIFF
--- a/apps/api/src/modules/kyc/kyc.service.spec.ts
+++ b/apps/api/src/modules/kyc/kyc.service.spec.ts
@@ -152,6 +152,17 @@ describe('KycService', () => {
       notifications.send.mockRejectedValueOnce(new Error('Send failed'));
 
       await expect(service.sendOtp('contract-1', 'SMS', req)).rejects.toThrow(BadRequestException);
+      // No DB record should be created when send fails
+      expect(prisma.kycVerification.create).not.toHaveBeenCalled();
+      expect(prisma.kycVerification.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('should not create KYC record when notification returns FAILED status', async () => {
+      notifications.send.mockResolvedValueOnce({ id: 'notif-1', status: 'FAILED' });
+
+      await expect(service.sendOtp('contract-1', 'SMS', req)).rejects.toThrow(BadRequestException);
+      expect(prisma.kycVerification.create).not.toHaveBeenCalled();
+      expect(prisma.kycVerification.updateMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/kyc/kyc.service.ts
+++ b/apps/api/src/modules/kyc/kyc.service.ts
@@ -60,6 +60,27 @@ export class KycService {
     const otpHash = crypto.createHash('sha256').update(otp).digest('hex');
     const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
 
+    // Send OTP via notification service FIRST (before creating DB record)
+    const message = `[BESTCHOICE] รหัส OTP ของคุณคือ ${otp} (หมดอายุใน ${OTP_EXPIRY_MINUTES} นาที) สำหรับสัญญาเลขที่ ${contract.contractNumber}`;
+    try {
+      const result = await this.notificationsService.send({
+        channel: channel as 'SMS' | 'LINE',
+        recipient,
+        message,
+        relatedId: contractId,
+        fallbackPhone: channel === 'LINE' ? customer.phone : undefined,
+      });
+      if (result.status === 'FAILED') {
+        throw new Error('Notification service returned FAILED status');
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to send OTP for contract ${contractId} via ${channel}: ${err instanceof Error ? err.message : err}`,
+      );
+      throw new BadRequestException('ไม่สามารถส่ง OTP ได้ กรุณาลองใหม่');
+    }
+
+    // OTP sent successfully — now persist to database
     // Expire any existing pending verifications for this contract
     await this.prisma.kycVerification.updateMany({
       where: { contractId, status: { in: ['PENDING', 'OTP_VERIFIED'] } },
@@ -80,24 +101,6 @@ export class KycService {
         expiresAt,
       },
     });
-
-    // Send OTP via notification service
-    const message = `[BESTCHOICE] รหัส OTP ของคุณคือ ${otp} (หมดอายุใน ${OTP_EXPIRY_MINUTES} นาที) สำหรับสัญญาเลขที่ ${contract.contractNumber}`;
-    try {
-      const result = await this.notificationsService.send({
-        channel: channel as 'SMS' | 'LINE',
-        recipient,
-        message,
-        relatedId: contractId,
-        fallbackPhone: channel === 'LINE' ? customer.phone : undefined,
-      });
-      if (result.status === 'FAILED') {
-        throw new Error('Notification service returned FAILED status');
-      }
-    } catch (err) {
-      this.logger.error(`Failed to send OTP: ${err}`);
-      throw new BadRequestException('ไม่สามารถส่ง OTP ได้ กรุณาลองใหม่');
-    }
 
     return {
       id: kyc.id,

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -169,12 +169,13 @@ export class NotificationsService {
    * Supports both ThaiBulkSMS and Twilio-compatible APIs
    */
   private async sendSms(recipient: string, message: string): Promise<void> {
+    // In non-production, skip actual SMS sending
+    if (this.configService.get('NODE_ENV') !== 'production') {
+      this.logger.warn(`[SMS-DEV] Skipping real SMS. Message to ${recipient}: ${message}`);
+      return;
+    }
+
     if (!this.smsApiKey) {
-      // In development, log the SMS instead of sending it
-      if (this.configService.get('NODE_ENV') !== 'production') {
-        this.logger.warn(`[SMS-DEV] SMS_API_KEY not configured. Message to ${recipient}: ${message}`);
-        return;
-      }
       throw new Error('SMS API key not configured');
     }
 
@@ -199,8 +200,31 @@ export class NotificationsService {
     });
     const responseText = await response.text();
 
-    if (!response.ok || responseText.includes('error')) {
-      throw new Error(`SMS API error: ${responseText}`);
+    if (!response.ok) {
+      throw new Error(`SMS API HTTP error ${response.status}: ${responseText}`);
+    }
+
+    // Parse ThaiBulkSMS response
+    try {
+      const result = JSON.parse(responseText);
+      if (
+        result.status &&
+        result.status !== 'success' &&
+        result.status !== '0' &&
+        result.status !== 0
+      ) {
+        throw new Error(`SMS API error: ${result.message || JSON.stringify(result)}`);
+      }
+    } catch (parseErr) {
+      if (parseErr instanceof SyntaxError) {
+        // Non-JSON response: check for error keywords (case-insensitive)
+        const lower = responseText.toLowerCase();
+        if (lower.includes('error') || lower.includes('fail')) {
+          throw new Error(`SMS API error: ${responseText}`);
+        }
+      } else {
+        throw parseErr;
+      }
     }
 
     this.logger.log(`[SMS] Message sent to ${cleanPhone}`);


### PR DESCRIPTION
- sendSms: ในโหมด non-production ให้ skip ส่ง SMS จริง return สำเร็จเลย
- sendSms: แก้ ThaiBulkSMS response parsing จาก includes('error') เป็น JSON parse
- sendOtp: สลับลำดับให้ส่ง OTP ก่อนแล้วค่อยสร้าง KYC record เพื่อไม่ให้ rate limit นับเมื่อส่งไม่สำเร็จ
- เพิ่ม test: ส่งไม่สำเร็จ → ไม่สร้าง KYC record

https://claude.ai/code/session_019vE1n9rdBmWcVCmdcPpsGH