### PR TITLE
feat: add SMS settings menu item to sidebar navigation

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -34,6 +34,7 @@ import {
   LogOut,
   ChevronsRight,
   ChevronsLeft,
+  MessageSquare,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import {
@@ -139,6 +140,7 @@ const navSections: NavSection[] = [
       { label: 'จัดการผู้ใช้', path: '/users', icon: UserCog, roles: ['OWNER'] },
       { label: 'ตั้งค่าระบบ', path: '/settings', icon: Settings, roles: ['OWNER'] },
       { label: 'เชื่อมต่อ LINE OA', path: '/settings/line-oa', icon: Settings, roles: ['OWNER'] },
+      { label: 'ตั้งค่า SMS', path: '/settings/sms', icon: MessageSquare, roles: ['OWNER'] },
       { label: 'ตั้งค่าดอกเบี้ย', path: '/settings/interest-config', icon: Percent, roles: ['OWNER'] },
       { label: 'ราคาตั้งต้น', path: '/settings/pricing-templates', icon: DollarSign, roles: ['OWNER'] },
       { label: 'เทมเพลตสัญญา', path: '/contract-templates', icon: FileSignature, roles: ['OWNER'] },


### PR DESCRIPTION
Adds "ตั้งค่า SMS" link under the settings section in the sidebar, visible only to OWNER role, linking to the existing /settings/sms page.

https://claude.ai/code/session_019vE1n9rdBmWcVCmdcPpsGH