### PR TITLE
fix: make OTP input boxes responsive for mobile screens

### DIFF
--- a/apps/web/src/components/signing/OtpInput.tsx
+++ b/apps/web/src/components/signing/OtpInput.tsx
@@ -42,7 +42,7 @@ export default function OtpInput({ value, onChange, length = 6, disabled }: OtpI
   };
 
   return (
-    <div className="flex gap-3 justify-center">
+    <div className="flex gap-2 sm:gap-3 justify-center">
       {digits.map((digit, i) => (
         <input
           key={i}
@@ -55,7 +55,7 @@ export default function OtpInput({ value, onChange, length = 6, disabled }: OtpI
           onKeyDown={(e) => handleKeyDown(i, e)}
           onPaste={i === 0 ? handlePaste : undefined}
           disabled={disabled}
-          className="w-14 h-16 text-center text-2xl font-bold border-2 border-gray-300 rounded-xl bg-white shadow-sm focus:border-primary focus:ring-2 focus:ring-primary/20 outline-none disabled:opacity-50 transition-colors"
+          className="w-11 sm:w-14 h-14 sm:h-16 text-center text-xl sm:text-2xl font-bold border-2 border-gray-300 rounded-xl bg-white shadow-sm focus:border-primary focus:ring-2 focus:ring-primary/20 outline-none disabled:opacity-50 transition-colors"
           autoComplete="one-time-code"
         />
       ))}


### PR DESCRIPTION
OTP input boxes (w-14 × 6 = 396px) overflowed mobile viewport (~343px), making them invisible. Now uses w-11 on mobile, w-14 on sm+ screens.

https://claude.ai/code/session_019vE1n9rdBmWcVCmdcPpsGH