### PR TITLE
fix: set contract margins to Moderate + remove double padding

### DIFF
--- a/apps/api/src/modules/documents/documents.service.ts
+++ b/apps/api/src/modules/documents/documents.service.ts
@@ -526,7 +526,7 @@ export class DocumentsService {
   /** Wrap rendered HTML with A4 page styles and page numbering */
   private wrapWithA4Styles(bodyHtml: string, templateSettings?: any, contractNumber?: string): string {
     // Use template settings if available, otherwise fallback to defaults
-    const margins = templateSettings?.margins || { top: 25, bottom: 20, left: 30, right: 25 };
+    const margins = templateSettings?.margins || { top: 25.4, bottom: 25.4, left: 19.1, right: 19.1 };
     const fontSize = templateSettings?.fontSize || { body: 16, heading: 20, footer: 12 };
     const letterhead = templateSettings?.letterhead || 'none';
     const showPageNumber = templateSettings?.showPageNumber ?? true;

--- a/apps/api/src/modules/documents/templates/hire-purchase-contract.html
+++ b/apps/api/src/modules/documents/templates/hire-purchase-contract.html
@@ -1,4 +1,4 @@
-<div style="font-family:'Sarabun','Noto Sans Thai',sans-serif;max-width:210mm;margin:0 auto;padding:40px 50px;font-size:15px;line-height:2;color:#000">
+<div style="font-family:'Sarabun','Noto Sans Thai',sans-serif;max-width:210mm;margin:0 auto;padding:0;font-size:15px;line-height:2;color:#000">
 
 <!-- ========== หน้า 1/6 ========== -->
 


### PR DESCRIPTION
- Change default margins from 25/20/30/25mm to Moderate (25.4mm top/bottom, 19.1mm left/right) matching Microsoft Word "Moderate"
- Remove duplicate padding:40px 50px from content div inline style (was causing double padding since .a4-page already applies margins)
- Witness signature structure and names already correct from prev fix

https://claude.ai/code/session_01LnDHyzpYCtRF1CQfR2jiBn