### PR TITLE
feat: change signature layout from dots to inline signature image

### DIFF
--- a/apps/api/prisma/migrations/20260320100000_inline_signature_layout/migration.sql
+++ b/apps/api/prisma/migrations/20260320100000_inline_signature_layout/migration.sql
@@ -1,0 +1,57 @@
+-- Update contract templates: change signature layout from dots to inline signature placeholders
+-- Old format: ลงชื่อ..............................................ผู้ให้เช่าซื้อ  (separate {staff_signature} below)
+-- New format: ลงชื่อ {staff_signature} ผู้ให้เช่าซื้อ  (signature inline)
+
+-- Replace dot-based signature lines with inline placeholder format
+-- and remove standalone signature placeholder lines that followed
+
+UPDATE "contract_templates"
+SET "content_html" = REGEXP_REPLACE(
+  REGEXP_REPLACE(
+    REGEXP_REPLACE(
+      REGEXP_REPLACE(
+        "content_html",
+        E'ลงชื่อ[.…]{3,}ผู้ให้เช่าซื้อ(</p>\\s*\\n?\\s*\\{staff_signature\\})',
+        E'ลงชื่อ {staff_signature} ผู้ให้เช่าซื้อ\\1',
+        'g'
+      ),
+      E'ลงชื่อ[.…]{3,}ผู้เช่าซื้อ(</p>\\s*\\n?\\s*\\{customer_signature\\})',
+      E'ลงชื่อ {customer_signature} ผู้เช่าซื้อ\\1',
+      'g'
+    ),
+    E'ลงชื่อ[.…]{3,}พยาน(</p>\\s*\\n?\\s*\\{witness1_signature\\})',
+    E'ลงชื่อ {witness1_signature} พยาน\\1',
+    'g'
+  ),
+  E'ลงชื่อ[.…]{3,}พยาน(</p>\\s*\\n?\\s*\\{witness2_signature\\})',
+  E'ลงชื่อ {witness2_signature} พยาน\\1',
+  'g'
+)
+WHERE "content_html" LIKE '%ลงชื่อ%ผู้ให้เช่าซื้อ%'
+  AND "content_html" LIKE '%{staff_signature}%';
+
+-- Also clean up: remove standalone signature placeholder lines
+-- that are no longer needed (they're now inline)
+UPDATE "contract_templates"
+SET "content_html" = REGEXP_REPLACE(
+  REGEXP_REPLACE(
+    REGEXP_REPLACE(
+      REGEXP_REPLACE(
+        "content_html",
+        E'\\n\\{staff_signature\\}\\n',
+        E'\\n',
+        'g'
+      ),
+      E'\\n\\{customer_signature\\}\\n',
+      E'\\n',
+      'g'
+    ),
+    E'\\n\\{witness1_signature\\}\\n',
+    E'\\n',
+    'g'
+  ),
+  E'\\n\\{witness2_signature\\}\\n',
+  E'\\n',
+  'g'
+)
+WHERE "content_html" LIKE '%ลงชื่อ%{staff_signature}%ผู้ให้เช่าซื้อ%';

--- a/apps/api/src/modules/documents/documents.service.ts
+++ b/apps/api/src/modules/documents/documents.service.ts
@@ -827,10 +827,10 @@ ${(() => {
       '{staff_signer_name}': esc(contract.salesperson?.name || ''),
       '{date}': new Date().toLocaleDateString('th-TH'),
       '{payment_schedule_table}': `<table border="1" cellpadding="6" style="border-collapse:collapse;width:100%;margin:10px auto"><thead><tr style="background:#f5f5f5"><th style="text-align:center">งวดที่</th><th style="text-align:center">วันที่ครบกำหนดชำระ</th><th style="text-align:center">จำนวนเงิน</th></tr></thead><tbody>${paymentScheduleRows}</tbody></table>`,
-      '{customer_signature}': customerSigSafe ? `<img src="${customerSig.signatureImage}" style="max-height:80px;display:block;margin:0 auto"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:80px"></div>',
-      '{staff_signature}': staffSigSafe ? `<img src="${staffSig.signatureImage}" style="max-height:80px;display:block;margin:0 auto"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:80px"></div>',
-      '{witness1_signature}': witness1SigSafe ? `<img src="${witness1Sig.signatureImage}" style="max-height:80px;display:block;margin:0 auto"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:80px"></div>',
-      '{witness2_signature}': witness2SigSafe ? `<img src="${witness2Sig.signatureImage}" style="max-height:80px;display:block;margin:0 auto"/>` : '<div style="border-bottom:1px solid #000;width:200px;height:80px"></div>',
+      '{customer_signature}': customerSigSafe ? `<img src="${customerSig.signatureImage}" style="max-height:60px;display:inline-block;vertical-align:middle;margin:0 4px"/>` : '<span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span>',
+      '{staff_signature}': staffSigSafe ? `<img src="${staffSig.signatureImage}" style="max-height:60px;display:inline-block;vertical-align:middle;margin:0 4px"/>` : '<span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span>',
+      '{witness1_signature}': witness1SigSafe ? `<img src="${witness1Sig.signatureImage}" style="max-height:60px;display:inline-block;vertical-align:middle;margin:0 4px"/>` : '<span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span>',
+      '{witness2_signature}': witness2SigSafe ? `<img src="${witness2Sig.signatureImage}" style="max-height:60px;display:inline-block;vertical-align:middle;margin:0 4px"/>` : '<span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span>',
     };
 
     let result = html;
@@ -1162,29 +1162,21 @@ ${(() => {
     <h3 style="margin:0 0 8px;border-bottom:1px solid #eee;padding-bottom:4px">ลงนาม</h3>
     <div style="display:flex;justify-content:space-around;margin-top:20px">
       <div style="text-align:center">
-        <div style="font-size:13px">ลงชื่อ</div>
-        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{customer_signature}</div>
-        <div style="font-size:13px">ผู้เช่าซื้อ</div>
+        <p style="margin:0;font-size:13px">ลงชื่อ {customer_signature} ผู้เช่าซื้อ</p>
         <p style="margin:4px 0 0;font-size:13px">({customer_name})</p>
       </div>
       <div style="text-align:center">
-        <div style="font-size:13px">ลงชื่อ</div>
-        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{staff_signature}</div>
-        <div style="font-size:13px">ผู้ให้เช่าซื้อ</div>
+        <p style="margin:0;font-size:13px">ลงชื่อ {staff_signature} ผู้ให้เช่าซื้อ</p>
         <p style="margin:4px 0 0;font-size:13px">({salesperson_name})</p>
       </div>
     </div>
     <div style="display:flex;justify-content:space-around;margin-top:30px">
       <div style="text-align:center">
-        <div style="font-size:13px">ลงชื่อ</div>
-        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{witness1_signature}</div>
-        <div style="font-size:13px">พยาน</div>
+        <p style="margin:0;font-size:13px">ลงชื่อ {witness1_signature} พยาน</p>
         <p style="margin:4px 0 0;font-size:13px">({witness1_name})</p>
       </div>
       <div style="text-align:center">
-        <div style="font-size:13px">ลงชื่อ</div>
-        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{witness2_signature}</div>
-        <div style="font-size:13px">พยาน</div>
+        <p style="margin:0;font-size:13px">ลงชื่อ {witness2_signature} พยาน</p>
         <p style="margin:4px 0 0;font-size:13px">({witness2_name})</p>
       </div>
     </div>
@@ -1254,16 +1246,12 @@ ${(() => {
   <div class="no-break" style="margin-top:30px">
     <div style="display:flex;justify-content:space-around;margin-top:20px">
       <div style="text-align:center">
-        <div style="font-size:13px">ลงชื่อ</div>
-        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{pdpa_signature}</div>
-        <div style="font-size:13px">ผู้ให้ความยินยอม</div>
+        <p style="margin:0;font-size:13px">ลงชื่อ {pdpa_signature} ผู้ให้ความยินยอม</p>
         <p style="margin:4px 0 0;font-size:13px">({customer_name})</p>
         <p style="margin:2px 0 0;font-size:11px;color:#666">วันที่ {pdpa_consent_date}</p>
       </div>
       <div style="text-align:center">
-        <div style="font-size:13px">ลงชื่อ</div>
-        <div style="min-height:50px;display:flex;align-items:center;justify-content:center">{staff_signature}</div>
-        <div style="font-size:13px">ผู้รับความยินยอม</div>
+        <p style="margin:0;font-size:13px">ลงชื่อ {staff_signature} ผู้รับความยินยอม</p>
         <p style="margin:4px 0 0;font-size:13px">({salesperson_name})</p>
       </div>
     </div>

--- a/apps/api/src/modules/documents/templates/hire-purchase-contract.html
+++ b/apps/api/src/modules/documents/templates/hire-purchase-contract.html
@@ -286,25 +286,21 @@ Facebook Link <u>&nbsp;&nbsp;{customer_facebook}&nbsp;&nbsp;</u>
 <table style="width:100%;margin-top:40px">
 <tr>
 <td style="width:50%;text-align:center;padding:20px 15px;vertical-align:top">
-<p style="margin:0;white-space:nowrap">ลงชื่อ..............................................ผู้ให้เช่าซื้อ</p>
-{staff_signature}
+<p style="margin:0;white-space:nowrap">ลงชื่อ {staff_signature} ผู้ให้เช่าซื้อ</p>
 <p style="margin:5px 0 0">( {salesperson_name} )</p>
 </td>
 <td style="width:50%;text-align:center;padding:20px 15px;vertical-align:top">
-<p style="margin:0;white-space:nowrap">ลงชื่อ..............................................ผู้เช่าซื้อ</p>
-{customer_signature}
+<p style="margin:0;white-space:nowrap">ลงชื่อ {customer_signature} ผู้เช่าซื้อ</p>
 <p style="margin:5px 0 0">( {customer_name} )</p>
 </td>
 </tr>
 <tr>
 <td style="width:50%;text-align:center;padding:20px 15px;vertical-align:top">
-<p style="margin:0;white-space:nowrap">ลงชื่อ..............................................พยาน</p>
-{witness1_signature}
+<p style="margin:0;white-space:nowrap">ลงชื่อ {witness1_signature} พยาน</p>
 <p style="margin:5px 0 0">( {witness1_name} )</p>
 </td>
 <td style="width:50%;text-align:center;padding:20px 15px;vertical-align:top">
-<p style="margin:0;white-space:nowrap">ลงชื่อ..............................................พยาน</p>
-{witness2_signature}
+<p style="margin:0;white-space:nowrap">ลงชื่อ {witness2_signature} พยาน</p>
 <p style="margin:5px 0 0">( {witness2_name} )</p>
 </td>
 </tr>

--- a/apps/web/src/components/template-editor/pdf/pdfGenerator.ts
+++ b/apps/web/src/components/template-editor/pdf/pdfGenerator.ts
@@ -559,7 +559,7 @@ export async function generatePDF(template: Template): Promise<Blob> {
 
         // ผู้ให้เช่าซื้อ
         const leftX = margin.left + colWidth / 2;
-        doc.text('ลงชื่อ..................................................ผู้ให้เช่าซื้อ', leftX, y, { align: 'center' });
+        doc.text('ลงชื่อ _________________ ผู้ให้เช่าซื้อ', leftX, y, { align: 'center' });
         doc.text(`( ${managerName} )`, leftX, y + 6, { align: 'center' });
         doc.setFontSize(sigFontSize - 2);
         doc.setTextColor(100);
@@ -569,7 +569,7 @@ export async function generatePDF(template: Template): Promise<Blob> {
         // ผู้เช่าซื้อ
         const rightX = margin.left + colWidth + colWidth / 2;
         doc.setFontSize(sigFontSize);
-        doc.text('ลงชื่อ..................................................ผู้เช่าซื้อ', rightX, y, { align: 'center' });
+        doc.text('ลงชื่อ _________________ ผู้เช่าซื้อ', rightX, y, { align: 'center' });
         doc.text(`( ${customerName} )`, rightX, y + 6, { align: 'center' });
 
         y += 22;
@@ -578,7 +578,7 @@ export async function generatePDF(template: Template): Promise<Blob> {
         doc.setFontSize(sigFontSize);
         for (let c = 0; c < 2; c++) {
           const x = margin.left + c * colWidth + colWidth / 2;
-          doc.text('ลงชื่อ..................................................พยาน', x, y, { align: 'center' });
+          doc.text('ลงชื่อ _________________ พยาน', x, y, { align: 'center' });
           doc.text(`(${' '.repeat(40)})`, x, y + 6, { align: 'center' });
         }
         y += 18;

--- a/apps/web/src/components/template-editor/preview/SignatureBlock.tsx
+++ b/apps/web/src/components/template-editor/preview/SignatureBlock.tsx
@@ -25,13 +25,13 @@ export default function SignatureBlock({ previewMode = false }: Props) {
       <div className="grid grid-cols-2 gap-x-8 mb-8">
         {/* ผู้ให้เช่าซื้อ */}
         <div className="text-center">
-          <div>ลงชื่อ..................................................ผู้ให้เช่าซื้อ</div>
+          <div>ลงชื่อ <span style={{ display: 'inline-block', width: 150, borderBottom: '1px solid #000', verticalAlign: 'middle', margin: '0 4px' }}>&nbsp;</span> ผู้ให้เช่าซื้อ</div>
           <div>( {managerName} )</div>
           <div style={{ fontSize: '14px', color: '#666' }}>ผู้จัดการ บริษัท เบสท์ช้อยส์โฟน จำกัด</div>
         </div>
         {/* ผู้เช่าซื้อ */}
         <div className="text-center">
-          <div>ลงชื่อ..................................................ผู้เช่าซื้อ</div>
+          <div>ลงชื่อ <span style={{ display: 'inline-block', width: 150, borderBottom: '1px solid #000', verticalAlign: 'middle', margin: '0 4px' }}>&nbsp;</span> ผู้เช่าซื้อ</div>
           <div>( {customerName} )</div>
         </div>
       </div>
@@ -39,11 +39,11 @@ export default function SignatureBlock({ previewMode = false }: Props) {
       {/* Row 2: Witnesses */}
       <div className="grid grid-cols-2 gap-x-8">
         <div className="text-center">
-          <div>ลงชื่อ..................................................พยาน</div>
+          <div>ลงชื่อ <span style={{ display: 'inline-block', width: 150, borderBottom: '1px solid #000', verticalAlign: 'middle', margin: '0 4px' }}>&nbsp;</span> พยาน</div>
           <div>({'  '.repeat(15)})</div>
         </div>
         <div className="text-center">
-          <div>ลงชื่อ..................................................พยาน</div>
+          <div>ลงชื่อ <span style={{ display: 'inline-block', width: 150, borderBottom: '1px solid #000', verticalAlign: 'middle', margin: '0 4px' }}>&nbsp;</span> พยาน</div>
           <div>({'  '.repeat(15)})</div>
         </div>
       </div>

--- a/apps/web/src/store/templateStore.ts
+++ b/apps/web/src/store/templateStore.ts
@@ -193,15 +193,15 @@ function blocksToHtml(blocks: Block[]): string {
         return `<div style="margin:12px 0">{{= INSTALLMENTS }}</div>`;
 
       case 'signature-block':
-        // Must match SignatureBlock.tsx exactly: 2 rows, dot-line style, 16px font, line-height 2
+        // Must match SignatureBlock.tsx exactly: 2 rows, inline signature style, 16px font, line-height 2
         return `<div style="margin:32px 0;font-size:16px;line-height:2">
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:0 32px;margin-bottom:32px">
-            <div style="text-align:center"><div>ลงชื่อ..................................................ผู้ให้เช่าซื้อ</div><div>( {{= COMPANY.DIRECTOR }} )</div><div style="font-size:14px;color:#666">ผู้จัดการ {{= COMPANY.NAME_TH }}</div></div>
-            <div style="text-align:center"><div>ลงชื่อ..................................................ผู้เช่าซื้อ</div><div>( {{= CUSTOMER.NAME }} )</div></div>
+            <div style="text-align:center"><div>ลงชื่อ <span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span> ผู้ให้เช่าซื้อ</div><div>( {{= COMPANY.DIRECTOR }} )</div><div style="font-size:14px;color:#666">ผู้จัดการ {{= COMPANY.NAME_TH }}</div></div>
+            <div style="text-align:center"><div>ลงชื่อ <span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span> ผู้เช่าซื้อ</div><div>( {{= CUSTOMER.NAME }} )</div></div>
           </div>
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:0 32px">
-            <div style="text-align:center"><div>ลงชื่อ..................................................พยาน</div><div>(${' '.repeat(30)})</div></div>
-            <div style="text-align:center"><div>ลงชื่อ..................................................พยาน</div><div>(${' '.repeat(30)})</div></div>
+            <div style="text-align:center"><div>ลงชื่อ <span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span> พยาน</div><div>(${' '.repeat(30)})</div></div>
+            <div style="text-align:center"><div>ลงชื่อ <span style="display:inline-block;width:150px;border-bottom:1px solid #000;vertical-align:middle;margin:0 4px">&nbsp;</span> พยาน</div><div>(${' '.repeat(30)})</div></div>
           </div>
         </div>`;
 


### PR DESCRIPTION
Replace "ลงชื่อ..............ผู้ให้เช่าซื้อ" format with "ลงชื่อ [ลายเซ็น] ผู้ให้เช่าซื้อ" so the signature image appears inline between the label text instead of on a separate line below the dots.

Updated files:
- hire-purchase-contract.html: inline {signature} placeholders
- documents.service.ts: inline img styles + fallback template
- SignatureBlock.tsx: preview component
- templateStore.ts: default signature block HTML
- pdfGenerator.ts: PDF text rendering
- New migration to update existing DB templates

https://claude.ai/code/session_016CL2x6BnABj9GK2Xh2c64E