### PR TITLE
fix(docker): copy apps/web/package.json in deps stage to fix nest not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
 COPY apps/api/package.json apps/api/
+# apps/web/package.json must be present so npm workspaces correctly resolves
+# and hoists all workspace deps (including @nestjs/cli from apps/api devDeps)
+COPY apps/web/package.json apps/web/
 COPY packages/ packages/
 RUN --mount=type=cache,target=/root/.npm npm ci
 


### PR DESCRIPTION
## Summary

Fixes `sh: nest: not found` error on DigitalOcean App Platform Docker build.

## Root Cause

The `deps` stage in `Dockerfile` only copied `apps/api/package.json`, leaving the npm workspace setup incomplete during `npm ci`. With an incomplete workspace, npm did not hoist `@nestjs/cli` (a devDependency of `apps/api`) to `node_modules/.bin/nest`, so `nest build` failed with exit code 127.

## Fix

Add `COPY apps/web/package.json apps/web/` to the `deps` stage so all workspace `package.json` files are present when `npm ci` runs. This allows npm to correctly resolve and hoist all workspace dependencies.

```dockerfile
COPY apps/api/package.json apps/api/
# apps/web/package.json must be present so npm workspaces correctly resolves
# and hoists all workspace deps (including @nestjs/cli from apps/api devDeps)
COPY apps/web/package.json apps/web/
```

## Test plan
- [ ] DigitalOcean App Platform build completes without `nest: not found`
- [ ] `nest build` succeeds in Docker builder stage
- [ ] API container starts and passes health check

https://claude.ai/code/session_013oF35MmbBoW4HN7Cy9awGe