### PR TITLE
fix(docker): force --include=dev in npm ci to fix nest not found on DO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ COPY apps/api/package.json apps/api/
 # and hoists all workspace deps (including @nestjs/cli from apps/api devDeps)
 COPY apps/web/package.json apps/web/
 COPY packages/ packages/
-RUN --mount=type=cache,target=/root/.npm npm ci
+# Force --include=dev so @nestjs/cli and other build-time devDeps are installed
+# even when the build environment has NODE_ENV=production set (e.g. DigitalOcean)
+RUN --mount=type=cache,target=/root/.npm npm ci --include=dev
 
 # ============================================
 # Stage 2: Build API


### PR DESCRIPTION
## Root Cause

DigitalOcean App Platform sets `NODE_ENV=production` during Docker builds. When npm sees `NODE_ENV=production`, it automatically treats it as `--omit=dev` and skips all devDependencies — including `@nestjs/cli` which provides the `nest` binary needed for `nest build`.

Previous fix (copying `apps/web/package.json`) was correct but not sufficient on its own.

## Fix

```dockerfile
RUN --mount=type=cache,target=/root/.npm npm ci --include=dev
```

`--include=dev` explicitly overrides the `NODE_ENV=production` omit behaviour, ensuring build-time tools like `@nestjs/cli` are always installed in the `deps` stage.

## Why This is Safe

The `runner` (production) stage only copies `apps/api/dist` + `node_modules` (runtime deps only via `.prisma`), so devDeps don't affect the final image size in a meaningful way.

https://claude.ai/code/session_013oF35MmbBoW4HN7Cy9awGe