### PR TITLE
fix(docker): remove BuildKit mount + add PATH for kaniko builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,20 @@ COPY apps/api/package.json apps/api/
 # and hoists all workspace deps (including @nestjs/cli from apps/api devDeps)
 COPY apps/web/package.json apps/web/
 COPY packages/ packages/
-# Force --include=dev so @nestjs/cli and other build-time devDeps are installed
-# even when the build environment has NODE_ENV=production set (e.g. DigitalOcean)
-RUN --mount=type=cache,target=/root/.npm npm ci --include=dev
+# --include=dev: force devDeps even when NODE_ENV=production (DigitalOcean sets this)
+# No --mount=type=cache: kaniko (used by DigitalOcean) doesn't support BuildKit mounts
+# and its layer cache ignores command-text changes, causing stale layers
+RUN npm ci --include=dev
 
 # ============================================
 # Stage 2: Build API
 # ============================================
 FROM node:20-alpine AS builder
 WORKDIR /app
+
+# Ensure hoisted workspace binaries (nest, prisma) are in PATH
+ENV PATH="/app/node_modules/.bin:$PATH"
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
 COPY apps/api ./apps/api


### PR DESCRIPTION
## Summary

- Remove `--mount=type=cache` from `npm ci` — kaniko (used by DigitalOcean) doesn't support BuildKit mounts and its layer cache ignored the command-text change to `--include=dev`, reusing a stale layer missing `@nestjs/cli`
- Add `ENV PATH="/app/node_modules/.bin:$PATH"` to builder stage so hoisted workspace binaries (`nest`, `prisma`) are always in PATH regardless of how npm resolves workspace bin dirs

## Root Cause

`sh: nest: not found` (exit 127) during `npm run build` → `nest build`. Two compounding issues:
1. **Stale kaniko cache**: previous `npm ci` layer (without `--include=dev`) was cached and reused even after changing the command
2. **PATH resolution**: `nest` binary is hoisted to `/app/node_modules/.bin/` by npm workspaces, but `npm run build` inside `apps/api` may not add the workspace root bin dir to PATH in kaniko's environment

## Test plan

- [ ] Verify DigitalOcean deployment builds successfully (no more `nest: not found`)
- [ ] Verify API container starts and `/api/health` returns 200

https://claude.ai/code/session_013oF35MmbBoW4HN7Cy9awGe