### PR TITLE
fix(docker): remove BuildKit mount + add PATH for nest binary on kaniko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,20 @@ COPY apps/api/package.json apps/api/
 # and hoists all workspace deps (including @nestjs/cli from apps/api devDeps)
 COPY apps/web/package.json apps/web/
 COPY packages/ packages/
-# Force --include=dev so @nestjs/cli and other build-time devDeps are installed
-# even when the build environment has NODE_ENV=production set (e.g. DigitalOcean)
-RUN --mount=type=cache,target=/root/.npm npm ci --include=dev
+# --include=dev: force devDeps even when NODE_ENV=production (DigitalOcean sets this)
+# No --mount=type=cache: kaniko (used by DigitalOcean) doesn't support BuildKit mounts
+# and its layer cache ignores command-text changes, causing stale layers
+RUN npm ci --include=dev
 
 # ============================================
 # Stage 2: Build API
 # ============================================
 FROM node:20-alpine AS builder
 WORKDIR /app
+
+# Ensure hoisted workspace binaries (nest, prisma) are in PATH
+ENV PATH="/app/node_modules/.bin:$PATH"
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
 COPY apps/api ./apps/api


### PR DESCRIPTION
DigitalOcean uses kaniko (not Docker/BuildKit) to build images. Two issues:

1. --mount=type=cache is not supported by kaniko. Kaniko converts it to its own layer cache but ignores command-text changes, so switching from `npm ci` to `npm ci --include=dev` still reused the stale cached layer that was missing @nestjs/cli.

2. When `npm run build` runs `nest build` inside apps/api, the `nest` binary lives at /app/node_modules/.bin/nest (hoisted by workspaces). npm may not add the workspace root bin dir to PATH in all environments.

Fixes:
- Remove --mount=type=cache to force kaniko to re-run npm ci
- Keep --include=dev to override NODE_ENV=production omit behavior
- Add ENV PATH="/app/node_modules/.bin:$PATH" to builder stage so hoisted binaries are always discoverable

https://claude.ai/code/session_013oF35MmbBoW4HN7Cy9awGe