### PR TITLE
fix(docker): copy apps/api/node_modules from deps — real fix for nest not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,11 @@ RUN npm ci --include=dev
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-# Ensure hoisted workspace binaries (nest, prisma) are in PATH
-ENV PATH="/app/node_modules/.bin:$PATH"
-
+# @nestjs/cli is recorded in package-lock.json under apps/api/node_modules
+# (not hoisted to root node_modules) so we must copy it separately.
+# node_modules/.bin/nest lives at apps/api/node_modules/.bin/nest.
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
 COPY package.json ./
 COPY apps/api ./apps/api
 COPY packages ./packages


### PR DESCRIPTION
## Root Cause (definitive)

`@nestjs/cli` is **not hoisted** to the root `node_modules` in `package-lock.json`:

```
"apps/api/node_modules/@nestjs/cli": { ... }   ← workspace-local, NOT hoisted
```

So the `nest` binary lives at `apps/api/node_modules/.bin/nest`. The builder stage was only copying `/app/node_modules` from the deps stage — `apps/api/node_modules` was never present in the builder, causing `sh: nest: not found` (exit 127) every time.

## Fix

```dockerfile
COPY --from=deps /app/node_modules ./node_modules
COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules  ← added
```

The subsequent `COPY apps/api ./apps/api` does **not** overwrite `apps/api/node_modules` because `node_modules` is excluded from the Docker build context via `.dockerignore`.

## Previous fixes in this chain

1. Add `apps/web/package.json` to deps stage (workspace resolution)
2. `npm ci --include=dev` (force devDeps past `NODE_ENV=production`)
3. Remove `--mount=type=cache` (kaniko cache-busting)
4. **This PR** — copy workspace-local node_modules (actual root cause)

https://claude.ai/code/session_013oF35MmbBoW4HN7Cy9awGe