### PR TITLE
fix(docker): copy apps/api/node_modules from deps to fix nest not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,11 @@ RUN npm ci --include=dev
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-# Ensure hoisted workspace binaries (nest, prisma) are in PATH
-ENV PATH="/app/node_modules/.bin:$PATH"
-
+# @nestjs/cli is recorded in package-lock.json under apps/api/node_modules
+# (not hoisted to root node_modules) so we must copy it separately.
+# node_modules/.bin/nest lives at apps/api/node_modules/.bin/nest.
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
 COPY package.json ./
 COPY apps/api ./apps/api
 COPY packages ./packages


### PR DESCRIPTION
@nestjs/cli is NOT hoisted to the root node_modules in package-lock.json. It is installed at apps/api/node_modules/@nestjs/cli, so the nest binary lives at apps/api/node_modules/.bin/nest.

The builder stage was only copying /app/node_modules from the deps stage, so apps/api/node_modules/.bin/nest never existed in the builder and every invocation of `nest build` (via npm run build) failed with exit 127.

Fix: also COPY --from=deps /app/apps/api/node_modules into the builder. The subsequent COPY apps/api ./apps/api does not overwrite this because node_modules is excluded from the build context via .dockerignore.

https://claude.ai/code/session_013oF35MmbBoW4HN7Cy9awGe