### PR TITLE
refactor: align backend DTOs and frontend pages with coding conventions

### DIFF
--- a/apps/api/src/modules/auth/dto/login.dto.ts
+++ b/apps/api/src/modules/auth/dto/login.dto.ts
@@ -1,10 +1,10 @@
 import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
-  @IsEmail()
+  @IsEmail({}, { message: 'กรุณากรอกอีเมลที่ถูกต้อง' })
   email: string;
 
   @IsString()
-  @MinLength(6)
+  @MinLength(6, { message: 'รหัสผ่านต้องมีอย่างน้อย 6 ตัวอักษร' })
   password: string;
 }

--- a/apps/api/src/modules/contracts/dto/contract.dto.ts
+++ b/apps/api/src/modules/contracts/dto/contract.dto.ts
@@ -15,24 +15,24 @@ export class CreateContractDto {
   planType?: string = 'STORE_DIRECT';
 
   @IsNumber()
-  @Min(1)
-  @Max(9999999)
+  @Min(1, { message: 'ราคาขายต้องมากกว่า 0' })
+  @Max(9999999, { message: 'ราคาขายต้องไม่เกิน 9,999,999' })
   sellingPrice: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(9999999)
+  @Min(0, { message: 'เงินดาวน์ต้องไม่น้อยกว่า 0' })
+  @Max(9999999, { message: 'เงินดาวน์ต้องไม่เกิน 9,999,999' })
   downPayment: number;
 
   @IsNumber()
-  @IsInt()
-  @Min(1)
-  @Max(120)
+  @IsInt({ message: 'จำนวนงวดต้องเป็นจำนวนเต็ม' })
+  @Min(1, { message: 'จำนวนงวดต้องอย่างน้อย 1 งวด' })
+  @Max(120, { message: 'จำนวนงวดต้องไม่เกิน 120 งวด' })
   totalMonths: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(100)
+  @Min(0, { message: 'อัตราดอกเบี้ยต้องไม่น้อยกว่า 0' })
+  @Max(100, { message: 'อัตราดอกเบี้ยต้องไม่เกิน 100' })
   @IsOptional()
   interestRate?: number;
 
@@ -41,36 +41,36 @@ export class CreateContractDto {
   notes?: string;
 
   // วันที่ครบกำหนดชำระ ตามวันเงินเดือนออก (1-28 หรือ 31=สิ้นเดือน)
-  @IsInt()
-  @Min(1)
-  @Max(31)
+  @IsInt({ message: 'วันครบกำหนดชำระต้องเป็นจำนวนเต็ม' })
+  @Min(1, { message: 'วันครบกำหนดชำระต้องอยู่ระหว่าง 1-31' })
+  @Max(31, { message: 'วันครบกำหนดชำระต้องอยู่ระหว่าง 1-31' })
   @IsOptional()
   paymentDueDay?: number;
 }
 
 export class UpdateContractDto {
   @IsNumber()
-  @Min(1)
-  @Max(9999999)
+  @Min(1, { message: 'ราคาขายต้องมากกว่า 0' })
+  @Max(9999999, { message: 'ราคาขายต้องไม่เกิน 9,999,999' })
   @IsOptional()
   sellingPrice?: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(9999999)
+  @Min(0, { message: 'เงินดาวน์ต้องไม่น้อยกว่า 0' })
+  @Max(9999999, { message: 'เงินดาวน์ต้องไม่เกิน 9,999,999' })
   @IsOptional()
   downPayment?: number;
 
   @IsNumber()
-  @IsInt()
-  @Min(1)
-  @Max(120)
+  @IsInt({ message: 'จำนวนงวดต้องเป็นจำนวนเต็ม' })
+  @Min(1, { message: 'จำนวนงวดต้องอย่างน้อย 1 งวด' })
+  @Max(120, { message: 'จำนวนงวดต้องไม่เกิน 120 งวด' })
   @IsOptional()
   totalMonths?: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(100)
+  @Min(0, { message: 'อัตราดอกเบี้ยต้องไม่น้อยกว่า 0' })
+  @Max(100, { message: 'อัตราดอกเบี้ยต้องไม่เกิน 100' })
   @IsOptional()
   interestRate?: number;
 
@@ -78,9 +78,9 @@ export class UpdateContractDto {
   @IsOptional()
   notes?: string;
 
-  @IsInt()
-  @Min(1)
-  @Max(31)
+  @IsInt({ message: 'วันครบกำหนดชำระต้องเป็นจำนวนเต็ม' })
+  @Min(1, { message: 'วันครบกำหนดชำระต้องอยู่ระหว่าง 1-31' })
+  @Max(31, { message: 'วันครบกำหนดชำระต้องอยู่ระหว่าง 1-31' })
   @IsOptional()
   paymentDueDay?: number;
 }

--- a/apps/api/src/modules/interest-config/dto/interest-config.dto.ts
+++ b/apps/api/src/modules/interest-config/dto/interest-config.dto.ts
@@ -9,33 +9,33 @@ export class CreateInterestConfigDto {
   productCategories: string[]; // e.g. ["PHONE_NEW"], ["PHONE_USED"]
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'อัตราดอกเบี้ยต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'อัตราดอกเบี้ยต้องไม่เกิน 1' })
   interestRate: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'เงินดาวน์ขั้นต่ำต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'เงินดาวน์ขั้นต่ำต้องไม่เกิน 1' })
   minDownPaymentPct: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'ค่าคอมมิชชั่นต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'ค่าคอมมิชชั่นต้องไม่เกิน 1' })
   @IsOptional()
   storeCommissionPct?: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'VAT ต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'VAT ต้องไม่เกิน 1' })
   @IsOptional()
   vatPct?: number;
 
   @IsNumber()
-  @Min(1)
+  @Min(1, { message: 'จำนวนงวดขั้นต่ำต้องอย่างน้อย 1' })
   minInstallmentMonths: number;
 
   @IsNumber()
-  @Min(1)
+  @Min(1, { message: 'จำนวนงวดสูงสุดต้องอย่างน้อย 1' })
   maxInstallmentMonths: number;
 }
 
@@ -50,36 +50,36 @@ export class UpdateInterestConfigDto {
   productCategories?: string[];
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'อัตราดอกเบี้ยต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'อัตราดอกเบี้ยต้องไม่เกิน 1' })
   @IsOptional()
   interestRate?: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'เงินดาวน์ขั้นต่ำต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'เงินดาวน์ขั้นต่ำต้องไม่เกิน 1' })
   @IsOptional()
   minDownPaymentPct?: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'ค่าคอมมิชชั่นต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'ค่าคอมมิชชั่นต้องไม่เกิน 1' })
   @IsOptional()
   storeCommissionPct?: number;
 
   @IsNumber()
-  @Min(0)
-  @Max(1)
+  @Min(0, { message: 'VAT ต้องไม่น้อยกว่า 0' })
+  @Max(1, { message: 'VAT ต้องไม่เกิน 1' })
   @IsOptional()
   vatPct?: number;
 
   @IsNumber()
-  @Min(1)
+  @Min(1, { message: 'จำนวนงวดขั้นต่ำต้องอย่างน้อย 1' })
   @IsOptional()
   minInstallmentMonths?: number;
 
   @IsNumber()
-  @Min(1)
+  @Min(1, { message: 'จำนวนงวดสูงสุดต้องอย่างน้อย 1' })
   @IsOptional()
   maxInstallmentMonths?: number;
 

--- a/apps/api/src/modules/kyc/dto/kyc.dto.ts
+++ b/apps/api/src/modules/kyc/dto/kyc.dto.ts
@@ -2,13 +2,13 @@ import { IsString, IsIn, Length, IsOptional } from 'class-validator';
 
 export class SendOtpDto {
   @IsString()
-  @IsIn(['SMS', 'LINE'])
+  @IsIn(['SMS', 'LINE'], { message: 'ช่องทางต้องเป็น SMS หรือ LINE' })
   channel: string;
 }
 
 export class VerifyOtpDto {
   @IsString()
-  @Length(6, 6)
+  @Length(6, 6, { message: 'รหัส OTP ต้อง 6 หลัก' })
   otp: string;
 }
 

--- a/apps/api/src/modules/pricing-templates/dto/pricing-template.dto.ts
+++ b/apps/api/src/modules/pricing-templates/dto/pricing-template.dto.ts
@@ -18,7 +18,7 @@ export class CreatePricingTemplateDto {
   @IsOptional()
   storage?: string;
 
-  @IsEnum(ProductCategory)
+  @IsEnum(ProductCategory, { message: 'หมวดหมู่สินค้าต้องเป็น PHONE_NEW, PHONE_USED, TABLET หรือ ACCESSORY' })
   category: ProductCategory;
 
   @IsBoolean()

--- a/apps/api/src/modules/products/dto/create-product.dto.ts
+++ b/apps/api/src/modules/products/dto/create-product.dto.ts
@@ -39,7 +39,7 @@ export class CreateProductDto {
   @IsOptional()
   serialNumber?: string;
 
-  @IsIn(['PHONE_NEW', 'PHONE_USED', 'TABLET', 'ACCESSORY'])
+  @IsIn(['PHONE_NEW', 'PHONE_USED', 'TABLET', 'ACCESSORY'], { message: 'หมวดหมู่สินค้าต้องเป็น PHONE_NEW, PHONE_USED, TABLET หรือ ACCESSORY' })
   category: string;
 
   @IsNumber()
@@ -56,7 +56,7 @@ export class CreateProductDto {
   @IsString()
   branchId: string;
 
-  @IsIn(['PO_RECEIVED', 'QC_PENDING', 'PHOTO_PENDING', 'INSPECTION', 'IN_STOCK', 'RESERVED', 'SOLD_INSTALLMENT', 'SOLD_CASH', 'REPOSSESSED', 'REFURBISHED', 'SOLD_RESELL', 'DAMAGED', 'LOST', 'WRITTEN_OFF'])
+  @IsIn(['PO_RECEIVED', 'QC_PENDING', 'PHOTO_PENDING', 'INSPECTION', 'IN_STOCK', 'RESERVED', 'SOLD_INSTALLMENT', 'SOLD_CASH', 'REPOSSESSED', 'REFURBISHED', 'SOLD_RESELL', 'DAMAGED', 'LOST', 'WRITTEN_OFF'], { message: 'สถานะสินค้าไม่ถูกต้อง' })
   @IsOptional()
   status?: string;
 

--- a/apps/api/src/modules/stock-adjustments/dto/create-stock-adjustment.dto.ts
+++ b/apps/api/src/modules/stock-adjustments/dto/create-stock-adjustment.dto.ts
@@ -2,10 +2,10 @@ import { IsString, IsOptional, IsArray, IsIn, IsNotEmpty } from 'class-validator
 
 export class CreateStockAdjustmentDto {
   @IsString()
-  @IsNotEmpty()
+  @IsNotEmpty({ message: 'กรุณาระบุรหัสสินค้า' })
   productId: string;
 
-  @IsIn(['DAMAGED', 'LOST', 'FOUND', 'CORRECTION', 'WRITE_OFF', 'OTHER'])
+  @IsIn(['DAMAGED', 'LOST', 'FOUND', 'CORRECTION', 'WRITE_OFF', 'OTHER'], { message: 'เหตุผลต้องเป็น DAMAGED, LOST, FOUND, CORRECTION, WRITE_OFF หรือ OTHER' })
   reason: string;
 
   @IsString()

--- a/apps/web/src/pages/ContractVerifyPage.tsx
+++ b/apps/web/src/pages/ContractVerifyPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 
 interface VerifyResponse {
@@ -24,19 +24,17 @@ export default function ContractVerifyPage() {
   const [searchParams] = useSearchParams();
   const hash = searchParams.get('hash') || '';
 
-  const [data, setData] = useState<VerifyResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data, isLoading: loading, error: queryError } = useQuery({
+    queryKey: ['contract-verify', id, hash],
+    queryFn: async () => {
+      const res = await api.get(`/contracts/${id}/verify`, { params: { hash } });
+      return res.data as VerifyResponse;
+    },
+    enabled: !!id,
+    retry: false,
+  });
 
-  useEffect(() => {
-    if (!id) return;
-
-    api
-      .get(`/contracts/${id}/verify`, { params: { hash } })
-      .then((res) => setData(res.data))
-      .catch(() => setError('ไม่สามารถตรวจสอบสัญญาได้ กรุณาลองใหม่'))
-      .finally(() => setLoading(false));
-  }, [id, hash]);
+  const error = queryError ? 'ไม่สามารถตรวจสอบสัญญาได้ กรุณาลองใหม่' : null;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
@@ -71,7 +69,7 @@ export default function ContractVerifyPage() {
             </div>
           )}
 
-          {data && !loading && !error && (
+          {data && !loading && !queryError && (
             <>
               {data.verified ? (
                 <div className="flex flex-col items-center text-center mb-5">

--- a/apps/web/src/pages/CustomerPortalPage.tsx
+++ b/apps/web/src/pages/CustomerPortalPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 
 interface ContractAccess {
@@ -59,19 +59,20 @@ const paymentStatusColors: Record<string, string> = {
 
 function CustomerPortalPage() {
   const { token } = useParams<{ token: string }>();
-  const [data, setData] = useState<ContractAccess | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (!token) return;
-    api.get(`/customer-access/${token}`)
-      .then(({ data }) => setData(data))
-      .catch((err) => {
-        setError(err.response?.data?.message || 'ลิงก์ไม่ถูกต้องหรือหมดอายุ');
-      })
-      .finally(() => setLoading(false));
-  }, [token]);
+  const { data, error: queryError, isLoading: loading } = useQuery({
+    queryKey: ['customer-access', token],
+    queryFn: async () => {
+      const res = await api.get(`/customer-access/${token}`);
+      return res.data as ContractAccess;
+    },
+    enabled: !!token,
+    retry: false,
+  });
+
+  const error = queryError
+    ? ((queryError as any).response?.data?.message || 'ลิงก์ไม่ถูกต้องหรือหมดอายุ')
+    : null;
 
   if (loading) {
     return (

--- a/apps/web/src/pages/LineOaSettingsPage.tsx
+++ b/apps/web/src/pages/LineOaSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
+import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 

--- a/apps/web/src/pages/ReportsPage.tsx
+++ b/apps/web/src/pages/ReportsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import { toast } from 'sonner';
@@ -25,6 +25,20 @@ export default function ReportsPage() {
   const [activeTab, setActiveTab] = useState<ReportType>('aging');
   const [dateFilter, setDateFilter] = useState(new Date().toISOString().slice(0, 10));
 
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      const { data } = await api.get('/reports/export/contracts', { responseType: 'blob' });
+      const url = window.URL.createObjectURL(new Blob([data]));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `contracts-export-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      window.URL.revokeObjectURL(url);
+    },
+    onSuccess: () => toast.success('ดาวน์โหลด CSV สำเร็จ'),
+    onError: () => toast.error('ไม่สามารถดาวน์โหลดได้'),
+  });
+
   return (
     <div>
       <PageHeader
@@ -32,23 +46,11 @@ export default function ReportsPage() {
         subtitle="รายงานสรุปข้อมูลต่างๆ"
         action={
           <button
-            onClick={async () => {
-              try {
-                const { data } = await api.get('/reports/export/contracts', { responseType: 'blob' });
-                const url = window.URL.createObjectURL(new Blob([data]));
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = `contracts-export-${new Date().toISOString().slice(0, 10)}.csv`;
-                a.click();
-                window.URL.revokeObjectURL(url);
-                toast.success('ดาวน์โหลด CSV สำเร็จ');
-              } catch {
-                toast.error('ไม่สามารถดาวน์โหลดได้');
-              }
-            }}
-            className="px-4 py-2 text-sm border border-input rounded-lg hover:bg-muted"
+            onClick={() => exportMutation.mutate()}
+            disabled={exportMutation.isPending}
+            className="px-4 py-2 text-sm border border-input rounded-lg hover:bg-muted disabled:opacity-50"
           >
-            Export CSV
+            {exportMutation.isPending ? 'กำลังดาวน์โหลด...' : 'Export CSV'}
           </button>
         }
       />

--- a/apps/web/src/pages/SlipReviewPage.tsx
+++ b/apps/web/src/pages/SlipReviewPage.tsx
@@ -6,7 +6,7 @@ import Modal from '@/components/ui/Modal';
 import { Card, CardContent } from '@/components/ui/card';
 import { useDebounce } from '@/hooks/useDebounce';
 import ExcelJS from 'exceljs';
-import toast from 'react-hot-toast';
+import { toast } from 'sonner';
 
 interface PaymentEvidence {
   id: string;

--- a/apps/web/src/pages/SmsSettingsPage.tsx
+++ b/apps/web/src/pages/SmsSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
+import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 
@@ -39,15 +39,14 @@ export default function StickerPrintPage() {
     },
   });
 
-  const loadPreview = async () => {
-    if (!productId) return;
-    try {
+  const previewMutation = useMutation({
+    mutationFn: async () => {
       const { data } = await api.get(`/sticker-templates/product/${productId}/data`);
-      setPreviewData(data);
-    } catch {
-      setPreviewData(null);
-    }
-  };
+      return data as StickerData;
+    },
+    onSuccess: (data) => setPreviewData(data),
+    onError: () => setPreviewData(null),
+  });
 
   const template = templates.find((t) => t.id === selectedTemplate);
 
@@ -72,7 +71,7 @@ export default function StickerPrintPage() {
                   placeholder="ระบุ ID สินค้า"
                   className="flex-1 px-3 py-2 border border-input rounded-lg text-sm outline-none"
                 />
-                <button onClick={loadPreview} className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm">
+                <button onClick={() => productId && previewMutation.mutate()} disabled={!productId || previewMutation.isPending} className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm disabled:opacity-50">
                   โหลด
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- **Backend DTOs**: Added Thai validation error messages to class-validator decorators across 7 DTO files (login, contracts, interest-config, pricing-templates, products, stock-adjustments, kyc)
- **Frontend toast library**: Replaced `react-hot-toast` with `sonner` in 3 pages (SlipReviewPage, SmsSettingsPage, LineOaSettingsPage) to align with project convention
- **Frontend data fetching**: Converted `useEffect` + manual state data fetching to `useQuery` from `@tanstack/react-query` in ContractVerifyPage and CustomerPortalPage

## Out of scope (intentional)
- **LIFF pages** use direct `fetch()` intentionally — they authenticate via LINE LIFF SDK (lineId), not JWT, so the `api` client would not work
- **Prisma schema** (35 models missing `deletedAt`/`updatedAt`) — requires migrations + service updates, should be a separate effort
- **Soft delete refactor** for suppliers/stickers — `isActive` flag may be tied to business logic

## Test plan
- [ ] Verify API validation returns Thai error messages on invalid input
- [ ] Verify toast notifications work on SlipReviewPage, SmsSettingsPage, LineOaSettingsPage
- [ ] Verify ContractVerifyPage loads contract verification data correctly
- [ ] Verify CustomerPortalPage loads customer access data correctly
- [ ] Run `./tools/check-types.sh all` — no new TypeScript errors

https://claude.ai/code/session_01RZcfRjiLHFS5kGEhWjRPVM