### PR TITLE
Add E2E testing skill and session initialization hooks

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run full setup in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-/home/user/BESTCHOICE}"
+
+echo "[SessionStart] Installing npm dependencies..."
+cd "$PROJECT_DIR"
+npm install --prefer-offline 2>&1 | tail -5
+
+echo "[SessionStart] Generating Prisma client..."
+cd "$PROJECT_DIR/apps/api"
+npx prisma generate 2>&1 | tail -3
+
+echo "[SessionStart] Installing Playwright chromium..."
+cd "$PROJECT_DIR/apps/web"
+npx playwright install chromium --with-deps 2>&1 | tail -3
+
+echo "[SessionStart] Setup complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/run-e2e.md
+++ b/.claude/skills/run-e2e.md
@@ -1,0 +1,61 @@
+---
+name: run-e2e
+description: รัน Playwright E2E Tests โดยตรงผ่าน Claude Code
+user_invocable: true
+---
+
+# Skill: Run E2E Tests
+
+รัน Playwright E2E tests โดยตรงผ่าน Claude Code โดยไม่ต้องเปิด terminal แยก
+
+## Prerequisites (ต้องมีก่อนรัน)
+
+ตรวจว่า services เหล่านี้รันอยู่:
+1. **PostgreSQL** — `docker compose up -d db` (ถ้ายังไม่ได้รัน)
+2. **NestJS API** (port 3000) — `cd apps/api && npm run dev` (ถ้ายังไม่ได้รัน)
+3. **Playwright browsers** — SessionStart hook จัดการให้อัตโนมัติ
+
+Vite dev server (port 5173) จะถูก start อัตโนมัติโดย Playwright
+
+## ขั้นตอน
+
+### 1. ถามว่าต้องการรันอะไร
+
+| ตัวเลือก | คำสั่ง |
+|---|---|
+| รันทั้งหมด (chromium) | `cd apps/web && npx playwright test --project=chromium` |
+| รันไฟล์เดียว | `cd apps/web && npx playwright test e2e/<file>.spec.ts --project=chromium` |
+| รัน pattern | `cd apps/web && npx playwright test --grep "login" --project=chromium` |
+| Full suite (lint+types+E2E) | `./tools/run-tests.sh` |
+| E2E พร้อมดู browser | `cd apps/web && npx playwright test --headed --project=chromium` |
+
+### 2. ตรวจ Services
+
+```bash
+# ตรวจ API (port 3000)
+curl -s http://localhost:3000/health || echo "API ไม่ได้รัน — รัน: cd apps/api && npm run dev"
+
+# ตรวจ DB connection ผ่าน API health
+curl -s http://localhost:3000/api/health | grep -q "ok" && echo "API ready" || echo "API not ready"
+```
+
+### 3. รัน Tests
+
+รันตามที่ user ขอ แล้วรายงานผล:
+- จำนวน tests ที่ pass/fail
+- ถ้า fail → แสดง error message + แนะนำการ debug
+- รายงาน path ของ HTML report: `apps/web/playwright-report/index.html`
+
+### 4. ถ้ามี Failures
+
+- อ่าน error message จาก output
+- ดู screenshot ที่ fail: `apps/web/test-results/`
+- แนะนำ fix หรือเปิด `/fix-bug` skill ถ้าเจอ bug จริง
+
+## ตัวอย่างคำสั่งที่ user พูดได้
+
+- "รัน E2E ทั้งหมด" → รัน `npx playwright test --project=chromium`
+- "รัน E2E เทส login" → รัน `npx playwright test e2e/login.spec.ts --project=chromium`
+- "รัน human flow tests" → รัน `npx playwright test e2e/human-flows/ --project=chromium`
+- "รัน agent tests" → รัน `npx playwright test e2e/agents/ --project=chromium`
+- `/run-e2e login` → รัน login spec โดยตรง


### PR DESCRIPTION
## Summary
This PR adds Claude Code integration for running Playwright E2E tests directly within the IDE, along with automatic session initialization to ensure all required dependencies and services are properly set up.

## Key Changes

- **New E2E Testing Skill** (`.claude/skills/run-e2e.md`)
  - User-invocable skill for running Playwright E2E tests without opening a separate terminal
  - Provides clear prerequisites checklist (PostgreSQL, NestJS API, Playwright browsers)
  - Documents multiple test execution options (full suite, single file, pattern matching, headed mode)
  - Includes service health checks for API and database connectivity
  - Guides users through test result interpretation and failure debugging
  - Supports common user commands like "รัน E2E ทั้งหมด" and pattern-based test selection

- **Session Initialization Hook** (`.claude/hooks/session-start.sh`)
  - Automatically installs npm dependencies on session start
  - Generates Prisma client for database access
  - Installs Playwright chromium browser with system dependencies
  - Only runs in remote Claude Code environments to avoid unnecessary setup in local development

- **Updated Settings** (`.claude/settings.json`)
  - Registered SessionStart hook to execute initialization script
  - Maintains existing experimental agent teams configuration

## Implementation Details

The session hook uses environment detection (`CLAUDE_CODE_REMOTE`) to conditionally run setup only in web-based Claude Code environments, preventing redundant operations in local development setups. The E2E skill provides comprehensive documentation in Thai language with clear command examples and troubleshooting guidance for test failures.

https://claude.ai/code/session_014C2qGvtjNeSGWJGLuK7uku