### PR TITLE
feat(accounting): Thai accounting standards audit fixes

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -7,8 +7,8 @@ generator client {
 // Local / TCP connection format:
 //   postgresql://USER:PASS@HOST:5432/DB
 datasource db {
-  provider  = "postgresql"
-  url       = env("DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 // ============================================================
@@ -35,11 +35,11 @@ enum ContractStatus {
 
 // Dunning escalation stages for overdue debt collection
 enum DunningStage {
-  NONE           // ปกติ ยังไม่ overdue
-  REMINDER       // แจ้งเตือน (1-7 วัน overdue)
-  NOTICE         // แจ้งค้างชำระ (8-30 วัน)
-  FINAL_WARNING  // เตือนครั้งสุดท้าย (31-60 วัน)
-  LEGAL_ACTION   // ดำเนินคดี/ยึดคืน (>60 วัน)
+  NONE // ปกติ ยังไม่ overdue
+  REMINDER // แจ้งเตือน (1-7 วัน overdue)
+  NOTICE // แจ้งค้างชำระ (8-30 วัน)
+  FINAL_WARNING // เตือนครั้งสุดท้าย (31-60 วัน)
+  LEGAL_ACTION // ดำเนินคดี/ยึดคืน (>60 วัน)
 }
 
 enum PlanType {
@@ -195,9 +195,9 @@ enum SaleType {
 }
 
 enum InterCompanyTransactionType {
-  FINANCE_PURCHASE    // Finance ซื้อลูกหนี้จาก Shop (principal + commission)
-  COMMISSION_PAYMENT  // Finance จ่าย commission ให้ Shop
-  LATE_FEE_SHARE      // ส่วนแบ่งค่าปรับล่าช้า
+  FINANCE_PURCHASE // Finance ซื้อลูกหนี้จาก Shop (principal + commission)
+  COMMISSION_PAYMENT // Finance จ่าย commission ให้ Shop
+  LATE_FEE_SHARE // ส่วนแบ่งค่าปรับล่าช้า
 }
 
 enum InterCompanyTransactionStatus {
@@ -256,82 +256,83 @@ model Branch {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  isMainWarehouse Boolean @default(false) @map("is_main_warehouse")
-  deletedAt DateTime? @map("deleted_at")
+  isMainWarehouse Boolean   @default(false) @map("is_main_warehouse")
+  deletedAt       DateTime? @map("deleted_at")
 
-  users            User[]
-  products         Product[]
-  contracts        Contract[]
-  sales            Sale[]
-  stockFroms       StockTransfer[]   @relation("TransferFrom")
-  stockTos         StockTransfer[]   @relation("TransferTo")
-  stockAdjustments StockAdjustment[]
-  reorderPoints    ReorderPoint[]
-  stockAlerts      StockAlert[]
-  stockCounts      StockCount[]
-  inviteTokens     InviteToken[]
-  financeReceivables FinanceReceivable[]
-  expenses           Expense[]
+  users                    User[]
+  products                 Product[]
+  contracts                Contract[]
+  sales                    Sale[]
+  stockFroms               StockTransfer[]           @relation("TransferFrom")
+  stockTos                 StockTransfer[]           @relation("TransferTo")
+  stockAdjustments         StockAdjustment[]
+  reorderPoints            ReorderPoint[]
+  stockAlerts              StockAlert[]
+  stockCounts              StockCount[]
+  inviteTokens             InviteToken[]
+  financeReceivables       FinanceReceivable[]
+  expenses                 Expense[]
   interCompanyTransactions InterCompanyTransaction[]
 
   @@map("branches")
 }
 
 model User {
-  id             String   @id @default(uuid())
-  email          String   @unique
-  password       String
-  name           String
-  role           UserRole @default(SALES)
-  branchId       String?  @map("branch_id")
-  isActive       Boolean  @default(true) @map("is_active")
-  savedSignature String?  @map("saved_signature") @db.Text
-  employeeId     String?  @unique @map("employee_id")
-  nickname       String?  @map("nickname")
-  phone          String?  @map("phone")
-  lineId         String?  @map("line_id")
-  address        String?  @map("address") @db.Text
-  avatarUrl      String?  @map("avatar_url") @db.Text
-  startDate      DateTime? @map("start_date")
-  nationalId     String?   @map("national_id")
-  birthDate      DateTime? @map("birth_date")
+  id               String    @id @default(uuid())
+  email            String    @unique
+  password         String
+  name             String
+  role             UserRole  @default(SALES)
+  branchId         String?   @map("branch_id")
+  isActive         Boolean   @default(true) @map("is_active")
+  savedSignature   String?   @map("saved_signature") @db.Text
+  employeeId       String?   @unique @map("employee_id")
+  nickname         String?   @map("nickname")
+  phone            String?   @map("phone")
+  lineId           String?   @map("line_id")
+  address          String?   @map("address") @db.Text
+  avatarUrl        String?   @map("avatar_url") @db.Text
+  startDate        DateTime? @map("start_date")
+  nationalId       String?   @map("national_id")
+  birthDate        DateTime? @map("birth_date")
   // Two-Factor Authentication (TOTP)
-  twoFactorEnabled Boolean  @default(false) @map("two_factor_enabled")
-  twoFactorSecret  String?  @map("two_factor_secret")  // encrypted TOTP secret
-  twoFactorBackup  String?  @map("two_factor_backup")  // encrypted recovery codes (JSON)
+  twoFactorEnabled Boolean   @default(false) @map("two_factor_enabled")
+  twoFactorSecret  String?   @map("two_factor_secret") // encrypted TOTP secret
+  twoFactorBackup  String?   @map("two_factor_backup") // encrypted recovery codes (JSON)
 
-  createdAt      DateTime @default(now()) @map("created_at")
-  updatedAt      DateTime @updatedAt @map("updated_at")
-  deletedAt      DateTime? @map("deleted_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
 
   branch Branch? @relation(fields: [branchId], references: [id])
 
-  contractsAsSalesperson Contract[]         @relation("Salesperson")
-  contractsReviewed      Contract[]         @relation("ContractReviewer")
-  salesAsSalesperson     Sale[]             @relation("SalesSalesperson")
-  paymentsRecorded       Payment[]          @relation("RecordedBy")
+  contractsAsSalesperson Contract[]           @relation("Salesperson")
+  contractsReviewed      Contract[]           @relation("ContractReviewer")
+  salesAsSalesperson     Sale[]               @relation("SalesSalesperson")
+  paymentsRecorded       Payment[]            @relation("RecordedBy")
   inspections            Inspection[]
   callLogs               CallLog[]
   auditLogs              AuditLog[]
-  purchaseOrdersCreated  PurchaseOrder[]    @relation("POCreatedBy")
-  purchaseOrdersApproved PurchaseOrder[]    @relation("POApprovedBy")
-  repossessionsAppraised Repossession[]     @relation("AppraisedBy")
-  goodsReceivings        GoodsReceiving[]   @relation("GoodsReceivedBy")
-  transfersConfirmed     StockTransfer[]    @relation("TransferConfirmedBy")
-  transfersDispatched    StockTransfer[]    @relation("TransferDispatchedBy")
-  stockAdjustments       StockAdjustment[]  @relation("StockAdjustedBy")
-  documentsUploaded      ContractDocument[] @relation("DocumentUploadedBy")
-  creditChecks           CreditCheck[]      @relation("CreditCheckedBy")
-  branchReceivings       BranchReceiving[]  @relation("BranchReceivedBy")
-  stockCounts            StockCount[]       @relation("StockCountedBy")
-  productPhotosUploaded  ProductPhoto[]     @relation("ProductPhotoUploadedBy")
+  purchaseOrdersCreated  PurchaseOrder[]      @relation("POCreatedBy")
+  purchaseOrdersApproved PurchaseOrder[]      @relation("POApprovedBy")
+  repossessionsAppraised Repossession[]       @relation("AppraisedBy")
+  goodsReceivings        GoodsReceiving[]     @relation("GoodsReceivedBy")
+  transfersConfirmed     StockTransfer[]      @relation("TransferConfirmedBy")
+  transfersDispatched    StockTransfer[]      @relation("TransferDispatchedBy")
+  stockAdjustments       StockAdjustment[]    @relation("StockAdjustedBy")
+  documentsUploaded      ContractDocument[]   @relation("DocumentUploadedBy")
+  creditChecks           CreditCheck[]        @relation("CreditCheckedBy")
+  branchReceivings       BranchReceiving[]    @relation("BranchReceivedBy")
+  stockCounts            StockCount[]         @relation("StockCountedBy")
+  productPhotosUploaded  ProductPhoto[]       @relation("ProductPhotoUploadedBy")
   refreshTokens          RefreshToken[]
   passwordResetTokens    PasswordResetToken[]
-  reviewedEvidences      PaymentEvidence[]  @relation("EvidenceReviewedBy")
+  reviewedEvidences      PaymentEvidence[]    @relation("EvidenceReviewedBy")
   inviteTokens           InviteToken[]
-  financeRecorded        FinanceReceivable[] @relation("FinanceRecordedBy")
-  expensesCreated        Expense[]           @relation("ExpenseCreatedBy")
-  expensesApproved       Expense[]           @relation("ExpenseApprovedBy")
+  financeRecorded        FinanceReceivable[]  @relation("FinanceRecordedBy")
+  expensesCreated        Expense[]            @relation("ExpenseCreatedBy")
+  expensesApproved       Expense[]            @relation("ExpenseApprovedBy")
+  expensesVoided         Expense[]            @relation("ExpenseVoidedBy")
 
   @@index([branchId])
   @@map("users")
@@ -371,8 +372,8 @@ model Customer {
   guardianAddress    String? @map("guardian_address")
 
   // Referral — ลูกค้าที่แนะนำมา
-  referredById String?   @map("referred_by_id")
-  referredBy   Customer? @relation("Referral", fields: [referredById], references: [id])
+  referredById String?    @map("referred_by_id")
+  referredBy   Customer?  @relation("Referral", fields: [referredById], references: [id])
   referrals    Customer[] @relation("Referral")
 
   createdAt DateTime  @default(now()) @map("created_at")
@@ -468,21 +469,22 @@ model Contract {
   retentionExpiry DateTime?               @map("retention_expiry")
   legalHoldReason String?                 @map("legal_hold_reason")
 
-  payments          Payment[]
-  signatures        Signature[]
-  eDocuments        EDocument[]
-  callLogs          CallLog[]
-  repossession      Repossession?
-  sale              Sale?
-  contractDocuments ContractDocument[]
-  creditCheck       CreditCheck?
-  pdpaConsent       PDPAConsent?       @relation(fields: [pdpaConsentId], references: [id])
-  receipts          Receipt[]
-  paymentLinks      PaymentLink[]
-  paymentEvidences  PaymentEvidence[]
-  kycVerifications  KycVerification[]
-  loyaltyPoints     LoyaltyPoint[]
+  payments                 Payment[]
+  signatures               Signature[]
+  eDocuments               EDocument[]
+  callLogs                 CallLog[]
+  repossession             Repossession?
+  sale                     Sale?
+  contractDocuments        ContractDocument[]
+  creditCheck              CreditCheck?
+  pdpaConsent              PDPAConsent?              @relation(fields: [pdpaConsentId], references: [id])
+  receipts                 Receipt[]
+  paymentLinks             PaymentLink[]
+  paymentEvidences         PaymentEvidence[]
+  kycVerifications         KycVerification[]
+  loyaltyPoints            LoyaltyPoint[]
   interCompanyTransactions InterCompanyTransaction[]
+  provisions               BadDebtProvision[]
 
   @@index([customerId])
   @@index([branchId])
@@ -498,16 +500,16 @@ model Contract {
 }
 
 model Payment {
-  id            String         @id @default(uuid())
-  contractId    String         @map("contract_id")
-  installmentNo Int            @map("installment_no")
-  dueDate       DateTime       @map("due_date")
-  amountDue     Decimal        @map("amount_due") @db.Decimal(12, 2)
-  amountPaid    Decimal        @default(0) @map("amount_paid") @db.Decimal(12, 2)
-  paidDate      DateTime?      @map("paid_date")
-  paymentMethod PaymentMethod? @map("payment_method")
-  lateFee       Decimal        @default(0) @map("late_fee") @db.Decimal(12, 2)
-  lateFeeWaived Boolean        @default(false) @map("late_fee_waived")
+  id              String         @id @default(uuid())
+  contractId      String         @map("contract_id")
+  installmentNo   Int            @map("installment_no")
+  dueDate         DateTime       @map("due_date")
+  amountDue       Decimal        @map("amount_due") @db.Decimal(12, 2)
+  amountPaid      Decimal        @default(0) @map("amount_paid") @db.Decimal(12, 2)
+  paidDate        DateTime?      @map("paid_date")
+  paymentMethod   PaymentMethod? @map("payment_method")
+  lateFee         Decimal        @default(0) @map("late_fee") @db.Decimal(12, 2)
+  lateFeeWaived   Boolean        @default(false) @map("late_fee_waived")
   evidenceUrl     String?        @map("evidence_url")
   notes           String?
   status          PaymentStatus  @default(PENDING)
@@ -541,20 +543,20 @@ model Payment {
 // ============================================================
 
 model Supplier {
-  id             String   @id @default(uuid())
+  id             String    @id @default(uuid())
   name           String
-  contactName    String   @map("contact_name")
+  contactName    String    @map("contact_name")
   nickname       String?
   phone          String
-  phoneSecondary String?  @map("phone_secondary")
-  lineId         String?  @map("line_id")
+  phoneSecondary String?   @map("phone_secondary")
+  lineId         String?   @map("line_id")
   address        String?
-  taxId          String?  @map("tax_id")
-  hasVat         Boolean  @default(false) @map("has_vat")
+  taxId          String?   @map("tax_id")
+  hasVat         Boolean   @default(false) @map("has_vat")
   notes          String?
-  isActive       Boolean  @default(true) @map("is_active")
-  createdAt      DateTime @default(now()) @map("created_at")
-  updatedAt      DateTime @updatedAt @map("updated_at")
+  isActive       Boolean   @default(true) @map("is_active")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
   deletedAt      DateTime? @map("deleted_at")
 
   products       Product[]
@@ -566,14 +568,14 @@ model Supplier {
 }
 
 model SupplierPaymentMethod {
-  id                String   @id @default(uuid())
-  supplierId        String   @map("supplier_id")
-  paymentMethod     String   @map("payment_method") // CASH, BANK_TRANSFER, CHECK, CREDIT
-  bankName          String?  @map("bank_name")
-  bankAccountName   String?  @map("bank_account_name")
-  bankAccountNumber String?  @map("bank_account_number")
-  creditTermDays    Int?     @map("credit_term_days")
-  isDefault         Boolean  @default(false) @map("is_default")
+  id                String    @id @default(uuid())
+  supplierId        String    @map("supplier_id")
+  paymentMethod     String    @map("payment_method") // CASH, BANK_TRANSFER, CHECK, CREDIT
+  bankName          String?   @map("bank_name")
+  bankAccountName   String?   @map("bank_account_name")
+  bankAccountNumber String?   @map("bank_account_number")
+  creditTermDays    Int?      @map("credit_term_days")
+  isDefault         Boolean   @default(false) @map("is_default")
   createdAt         DateTime  @default(now()) @map("created_at")
   updatedAt         DateTime  @updatedAt @map("updated_at")
   deletedAt         DateTime? @map("deleted_at")
@@ -706,18 +708,18 @@ model Product {
 }
 
 model ProductPhoto {
-  id           String   @id @default(uuid())
-  productId    String   @unique @map("product_id")
+  id           String    @id @default(uuid())
+  productId    String    @unique @map("product_id")
   front        String? // ด้านหน้า
   back         String? // ด้านหลัง
   left         String? // ข้างซ้าย
   right        String? // ข้างขวา
   top          String? // ด้านบน
   bottom       String? // ด้านล่าง
-  isCompleted  Boolean  @default(false) @map("is_completed")
-  uploadedById String?  @map("uploaded_by_id")
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
+  isCompleted  Boolean   @default(false) @map("is_completed")
+  uploadedById String?   @map("uploaded_by_id")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
   deletedAt    DateTime? @map("deleted_at")
 
   product    Product @relation(fields: [productId], references: [id], onDelete: Cascade)
@@ -727,13 +729,13 @@ model ProductPhoto {
 }
 
 model ProductPrice {
-  id        String   @id @default(uuid())
-  productId String   @map("product_id")
+  id        String    @id @default(uuid())
+  productId String    @map("product_id")
   label     String // e.g. "ราคาเงินสด", "ราคาผ่อน"
-  amount    Decimal  @db.Decimal(12, 2)
-  isDefault Boolean  @default(false) @map("is_default")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  amount    Decimal   @db.Decimal(12, 2)
+  isDefault Boolean   @default(false) @map("is_default")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
 
   product Product @relation(fields: [productId], references: [id], onDelete: Cascade)
@@ -801,12 +803,12 @@ model StockTransfer {
 }
 
 model GoodsReceiving {
-  id           String   @id @default(uuid())
-  poId         String   @map("po_id")
-  receivedById String   @map("received_by_id")
+  id           String    @id @default(uuid())
+  poId         String    @map("po_id")
+  receivedById String    @map("received_by_id")
   notes        String?
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
   deletedAt    DateTime? @map("deleted_at")
 
   po         PurchaseOrder        @relation(fields: [poId], references: [id], onDelete: Cascade)
@@ -874,12 +876,12 @@ model StockAdjustment {
 // ============================================================
 
 model InspectionTemplate {
-  id         String   @id @default(uuid())
+  id         String    @id @default(uuid())
   name       String
-  deviceType String   @map("device_type") // PHONE, TABLET
-  isActive   Boolean  @default(true) @map("is_active")
-  createdAt  DateTime @default(now()) @map("created_at")
-  updatedAt  DateTime @updatedAt @map("updated_at")
+  deviceType String    @map("device_type") // PHONE, TABLET
+  isActive   Boolean   @default(true) @map("is_active")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  updatedAt  DateTime  @updatedAt @map("updated_at")
   deletedAt  DateTime? @map("deleted_at")
 
   items       InspectionTemplateItem[]
@@ -960,28 +962,28 @@ model InspectionResult {
 // ============================================================
 
 model ContractTemplate {
-  id           String   @id @default(uuid())
+  id           String    @id @default(uuid())
   name         String
   type         String // e.g. STORE_DIRECT, CREDIT_CARD, EXCHANGE
-  contentHtml  String   @map("content_html")
-  placeholders String[] @default([])
-  blocks       Json?    @default("[]") // Block-based editor content (JSON array)
+  contentHtml  String    @map("content_html")
+  placeholders String[]  @default([])
+  blocks       Json?     @default("[]") // Block-based editor content (JSON array)
   settings     Json? // Template settings (letterhead, margins, font sizes, etc.)
-  isActive     Boolean  @default(true) @map("is_active")
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
+  isActive     Boolean   @default(true) @map("is_active")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
   deletedAt    DateTime? @map("deleted_at")
 
   @@map("contract_templates")
 }
 
 model EDocument {
-  id           String   @id @default(uuid())
-  contractId   String   @map("contract_id")
-  documentType String   @map("document_type") // CONTRACT, RECEIPT_DOWN, RECEIPT_INSTALLMENT, PAYOFF
-  fileUrl      String   @map("file_url")
-  fileHash     String   @map("file_hash") // SHA-256
-  createdById  String   @map("created_by_id")
+  id           String    @id @default(uuid())
+  contractId   String    @map("contract_id")
+  documentType String    @map("document_type") // CONTRACT, RECEIPT_DOWN, RECEIPT_INSTALLMENT, PAYOFF
+  fileUrl      String    @map("file_url")
+  fileHash     String    @map("file_hash") // SHA-256
+  createdById  String    @map("created_by_id")
   createdAt    DateTime  @default(now()) @map("created_at")
   updatedAt    DateTime  @updatedAt @map("updated_at")
   deletedAt    DateTime? @map("deleted_at")
@@ -1019,15 +1021,15 @@ model Signature {
 }
 
 model StickerTemplate {
-  id           String   @id @default(uuid())
+  id           String    @id @default(uuid())
   name         String
-  sizeWidthMm  Int      @map("size_width_mm")
-  sizeHeightMm Int      @map("size_height_mm")
-  layoutConfig Json     @map("layout_config")
-  placeholders String[] @default([])
-  isActive     Boolean  @default(true) @map("is_active")
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
+  sizeWidthMm  Int       @map("size_width_mm")
+  sizeHeightMm Int       @map("size_height_mm")
+  layoutConfig Json      @map("layout_config")
+  placeholders String[]  @default([])
+  isActive     Boolean   @default(true) @map("is_active")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
   deletedAt    DateTime? @map("deleted_at")
 
   @@map("sticker_templates")
@@ -1097,10 +1099,10 @@ model NotificationLog {
 }
 
 model CallLog {
-  id         String   @id @default(uuid())
-  contractId String   @map("contract_id")
-  callerId   String   @map("caller_id")
-  calledAt   DateTime @map("called_at")
+  id         String    @id @default(uuid())
+  contractId String    @map("contract_id")
+  callerId   String    @map("caller_id")
+  calledAt   DateTime  @map("called_at")
   result     String // e.g. ANSWERED, NO_ANSWER, PROMISED, REFUSED
   notes      String?
   createdAt  DateTime  @default(now()) @map("created_at")
@@ -1127,7 +1129,6 @@ model AuditLog {
   userAgent String?  @map("user_agent")
   duration  Int? // request duration in ms
   createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id])
 
@@ -1138,12 +1139,12 @@ model AuditLog {
 }
 
 model SystemConfig {
-  id        String   @id @default(uuid())
-  key       String   @unique
+  id        String    @id @default(uuid())
+  key       String    @unique
   value     String
   label     String? // Thai description
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
 
   @@map("system_config")
@@ -1177,12 +1178,12 @@ model Sale {
   updatedAt         DateTime       @updatedAt @map("updated_at")
   deletedAt         DateTime?      @map("deleted_at")
 
-  customer           Customer           @relation(fields: [customerId], references: [id])
-  product            Product            @relation(fields: [productId], references: [id])
-  branch             Branch             @relation(fields: [branchId], references: [id])
-  salesperson        User               @relation("SalesSalesperson", fields: [salespersonId], references: [id])
-  contract           Contract?          @relation(fields: [contractId], references: [id])
-  financeReceivable  FinanceReceivable?
+  customer                 Customer                  @relation(fields: [customerId], references: [id])
+  product                  Product                   @relation(fields: [productId], references: [id])
+  branch                   Branch                    @relation(fields: [branchId], references: [id])
+  salesperson              User                      @relation("SalesSalesperson", fields: [salespersonId], references: [id])
+  contract                 Contract?                 @relation(fields: [contractId], references: [id])
+  financeReceivable        FinanceReceivable?
   interCompanyTransactions InterCompanyTransaction[]
 
   @@index([saleType])
@@ -1200,18 +1201,18 @@ model Sale {
 // ============================================================
 
 model InterestConfig {
-  id                   String   @id @default(uuid())
+  id                   String    @id @default(uuid())
   name                 String // เช่น "มือ 1", "มือ 2"
-  productCategories    String[] @default([]) @map("product_categories")
-  interestRate         Decimal  @map("interest_rate") @db.Decimal(5, 4)
-  minDownPaymentPct    Decimal  @map("min_down_payment_pct") @db.Decimal(5, 4)
-  storeCommissionPct   Decimal  @default(0.10) @map("store_commission_pct") @db.Decimal(5, 4)
-  vatPct               Decimal  @default(0.07) @map("vat_pct") @db.Decimal(5, 4)
-  maxInstallmentMonths Int      @map("max_installment_months")
-  minInstallmentMonths Int      @map("min_installment_months")
-  isActive             Boolean  @default(true) @map("is_active")
-  createdAt            DateTime @default(now()) @map("created_at")
-  updatedAt            DateTime @updatedAt @map("updated_at")
+  productCategories    String[]  @default([]) @map("product_categories")
+  interestRate         Decimal   @map("interest_rate") @db.Decimal(5, 4)
+  minDownPaymentPct    Decimal   @map("min_down_payment_pct") @db.Decimal(5, 4)
+  storeCommissionPct   Decimal   @default(0.10) @map("store_commission_pct") @db.Decimal(5, 4)
+  vatPct               Decimal   @default(0.07) @map("vat_pct") @db.Decimal(5, 4)
+  maxInstallmentMonths Int       @map("max_installment_months")
+  minInstallmentMonths Int       @map("min_installment_months")
+  isActive             Boolean   @default(true) @map("is_active")
+  createdAt            DateTime  @default(now()) @map("created_at")
+  updatedAt            DateTime  @updatedAt @map("updated_at")
   deletedAt            DateTime? @map("deleted_at")
 
   contracts Contract[]
@@ -1360,13 +1361,13 @@ model StockCount {
 }
 
 model StockCountItem {
-  id             String   @id @default(uuid())
-  stockCountId   String   @map("stock_count_id")
-  productId      String   @map("product_id")
-  expectedStatus String   @map("expected_status") // status ในระบบ
-  actualFound    Boolean  @default(false) @map("actual_found") // พบสินค้าจริง (default: ยังไม่ตรวจนับ)
-  conditionNotes String?  @map("condition_notes")
-  scannedImei    String?  @map("scanned_imei") // IMEI ที่สแกนยืนยัน
+  id             String    @id @default(uuid())
+  stockCountId   String    @map("stock_count_id")
+  productId      String    @map("product_id")
+  expectedStatus String    @map("expected_status") // status ในระบบ
+  actualFound    Boolean   @default(false) @map("actual_found") // พบสินค้าจริง (default: ยังไม่ตรวจนับ)
+  conditionNotes String?   @map("condition_notes")
+  scannedImei    String?   @map("scanned_imei") // IMEI ที่สแกนยืนยัน
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")
   deletedAt      DateTime? @map("deleted_at")
@@ -1385,10 +1386,10 @@ model StockCountItem {
 // ============================================================
 
 model BranchReceiving {
-  id           String   @id @default(uuid())
-  transferId   String   @unique @map("transfer_id")
-  receivedById String   @map("received_by_id")
-  status       String   @default("PENDING") // PENDING, COMPLETED, PARTIAL_REJECT
+  id           String    @id @default(uuid())
+  transferId   String    @unique @map("transfer_id")
+  receivedById String    @map("received_by_id")
+  status       String    @default("PENDING") // PENDING, COMPLETED, PARTIAL_REJECT
   notes        String?
   createdAt    DateTime  @default(now()) @map("created_at")
   updatedAt    DateTime  @default(now()) @updatedAt @map("updated_at")
@@ -1403,14 +1404,14 @@ model BranchReceiving {
 }
 
 model BranchReceivingItem {
-  id             String   @id @default(uuid())
-  receivingId    String   @map("receiving_id")
-  productId      String   @map("product_id")
-  imeiSerial     String?  @map("imei_serial") // สแกนยืนยัน
-  status         String   @default("PASS") // PASS, REJECT
-  conditionNotes String?  @map("condition_notes")
-  photos         String[] @default([])
-  rejectReason   String?  @map("reject_reason")
+  id             String    @id @default(uuid())
+  receivingId    String    @map("receiving_id")
+  productId      String    @map("product_id")
+  imeiSerial     String?   @map("imei_serial") // สแกนยืนยัน
+  status         String    @default("PASS") // PASS, REJECT
+  conditionNotes String?   @map("condition_notes")
+  photos         String[]  @default([])
+  rejectReason   String?   @map("reject_reason")
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")
   deletedAt      DateTime? @map("deleted_at")
@@ -1460,7 +1461,7 @@ model PasswordResetToken {
 
 model InviteToken {
   id        String    @id @default(uuid())
-  token     String    @unique                    // SHA-256 hash of raw token
+  token     String    @unique // SHA-256 hash of raw token
   email     String
   role      UserRole
   branchId  String?   @map("branch_id")
@@ -1537,31 +1538,31 @@ model DSARRequest {
 // ============================================================
 
 model KycVerification {
-  id             String   @id @default(uuid())
-  contractId     String   @map("contract_id")
-  customerId     String   @map("customer_id")
+  id         String @id @default(uuid())
+  contractId String @map("contract_id")
+  customerId String @map("customer_id")
 
   // OTP verification
-  otpHash        String?  @map("otp_hash") // SHA-256 hash of OTP (never store plaintext)
-  otpPhone       String   @map("otp_phone") // phone number OTP was sent to
-  otpChannel     String   @map("otp_channel") // SMS | LINE
-  otpAttempts    Int      @default(0) @map("otp_attempts") // failed attempts
-  otpSentCount   Int      @default(0) @map("otp_sent_count") // times OTP was sent
-  otpRefCode     String?  @map("otp_ref_code") // 4-char ref code shown to user
-  otpVerifiedAt  DateTime? @map("otp_verified_at")
+  otpHash       String?   @map("otp_hash") // SHA-256 hash of OTP (never store plaintext)
+  otpPhone      String    @map("otp_phone") // phone number OTP was sent to
+  otpChannel    String    @map("otp_channel") // SMS | LINE
+  otpAttempts   Int       @default(0) @map("otp_attempts") // failed attempts
+  otpSentCount  Int       @default(0) @map("otp_sent_count") // times OTP was sent
+  otpRefCode    String?   @map("otp_ref_code") // 4-char ref code shown to user
+  otpVerifiedAt DateTime? @map("otp_verified_at")
 
   // ID Card photo verification
-  idCardImageUrl String?  @map("id_card_image_url") // S3 path
-  idCardVerified Boolean  @default(false) @map("id_card_verified")
+  idCardImageUrl String? @map("id_card_image_url") // S3 path
+  idCardVerified Boolean @default(false) @map("id_card_verified")
 
   // Metadata
-  ipAddress      String?  @map("ip_address")
-  deviceInfo     String?  @map("device_info") // User-Agent
-  status         String   @default("PENDING") // PENDING, OTP_VERIFIED, VERIFIED, EXPIRED, FAILED
-  expiresAt      DateTime @map("expires_at") // OTP expiry (10 min)
-  createdAt      DateTime  @default(now()) @map("created_at")
-  updatedAt      DateTime  @default(now()) @updatedAt @map("updated_at")
-  deletedAt      DateTime? @map("deleted_at")
+  ipAddress  String?   @map("ip_address")
+  deviceInfo String?   @map("device_info") // User-Agent
+  status     String    @default("PENDING") // PENDING, OTP_VERIFIED, VERIFIED, EXPIRED, FAILED
+  expiresAt  DateTime  @map("expires_at") // OTP expiry (10 min)
+  createdAt  DateTime  @default(now()) @map("created_at")
+  updatedAt  DateTime  @default(now()) @updatedAt @map("updated_at")
+  deletedAt  DateTime? @map("deleted_at")
 
   contract Contract @relation(fields: [contractId], references: [id])
   customer Customer @relation(fields: [customerId], references: [id])
@@ -1577,26 +1578,33 @@ model KycVerification {
 // ============================================================
 
 model Receipt {
-  id               String   @id @default(uuid())
-  receiptNumber    String   @unique @map("receipt_number") // RC-YYYY-MM-NNNNN
-  contractId       String   @map("contract_id")
-  paymentId        String?  @map("payment_id")
-  receiptType      String   @default("PAYMENT") // PAYMENT, DOWN_PAYMENT, EARLY_PAYOFF, CREDIT_NOTE
-  payerName        String   @map("payer_name")
-  receiverName     String   @map("receiver_name")
-  amount           Decimal  @db.Decimal(12, 2)
-  installmentNo    Int?     @map("installment_no") // งวดที่
-  remainingBalance Decimal? @map("remaining_balance") @db.Decimal(12, 2)
-  remainingMonths  Int?     @map("remaining_months")
-  paymentMethod    String?  @map("payment_method")
-  transactionRef   String?  @map("transaction_ref") // เลขอ้างอิงธุรกรรม
-  paidDate         DateTime @map("paid_date")
-  fileUrl          String?  @map("file_url") // PDF URL
-  fileHash         String?  @map("file_hash") // SHA-256
-  isVoided         Boolean  @default(false) @map("is_voided")
-  voidReason       String?  @map("void_reason")
-  voidedReceiptId  String?  @map("voided_receipt_id") // อ้างอิงใบเสร็จที่ถูกยกเลิก
-  issuedById       String   @map("issued_by_id")
+  id               String    @id @default(uuid())
+  receiptNumber    String    @unique @map("receipt_number") // RC-YYYY-MM-NNNNN
+  contractId       String    @map("contract_id")
+  paymentId        String?   @map("payment_id")
+  receiptType      String    @default("PAYMENT") // PAYMENT, DOWN_PAYMENT, EARLY_PAYOFF, CREDIT_NOTE
+  payerName        String    @map("payer_name")
+  payerAddress     String?   @map("payer_address")
+  payerTaxId       String?   @map("payer_tax_id") // เลขประจำตัวผู้เสียภาษีผู้ซื้อ
+  receiverName     String    @map("receiver_name")
+  amount           Decimal   @db.Decimal(12, 2)
+  amountBeforeVat  Decimal?  @map("amount_before_vat") @db.Decimal(12, 2) // ราคาก่อน VAT
+  vatAmount        Decimal?  @map("vat_amount") @db.Decimal(12, 2) // จำนวน VAT
+  installmentNo    Int?      @map("installment_no") // งวดที่
+  remainingBalance Decimal?  @map("remaining_balance") @db.Decimal(12, 2)
+  remainingMonths  Int?      @map("remaining_months")
+  paymentMethod    String?   @map("payment_method")
+  transactionRef   String?   @map("transaction_ref") // เลขอ้างอิงธุรกรรม
+  itemDescription  String?   @map("item_description") // รายละเอียดสินค้า/บริการ
+  paidDate         DateTime  @map("paid_date")
+  fileUrl          String?   @map("file_url") // PDF URL
+  fileHash         String?   @map("file_hash") // SHA-256
+  isVoided         Boolean   @default(false) @map("is_voided")
+  voidReason       String?   @map("void_reason")
+  voidApprovedById String?   @map("void_approved_by_id") // ผู้อนุมัติการยกเลิก
+  voidApprovedAt   DateTime? @map("void_approved_at")
+  voidedReceiptId  String?   @map("voided_receipt_id") // อ้างอิงใบเสร็จที่ถูกยกเลิก
+  issuedById       String    @map("issued_by_id")
   createdAt        DateTime  @default(now()) @map("created_at")
   updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at")
   deletedAt        DateTime? @map("deleted_at")
@@ -1656,20 +1664,20 @@ model DocumentAuditLog {
 // ============================================================
 
 model CompanyInfo {
-  id                 String   @id @default(uuid())
-  nameTh             String   @map("name_th")
-  nameEn             String?  @map("name_en")
-  taxId              String   @map("tax_id") // เลขทะเบียนนิติบุคคล/ผู้เสียภาษี
+  id                 String    @id @default(uuid())
+  nameTh             String    @map("name_th")
+  nameEn             String?   @map("name_en")
+  taxId              String    @map("tax_id") // เลขทะเบียนนิติบุคคล/ผู้เสียภาษี
   address            String
   phone              String?
-  directorName       String   @map("director_name") // ชื่อผู้มีอำนาจลงนาม
-  directorPosition   String?  @map("director_position") // ตำแหน่ง
-  directorNationalId String?  @map("director_national_id")
-  directorAddress    String?  @map("director_address")
-  logoUrl            String?  @map("logo_url")
-  isActive           Boolean  @default(true) @map("is_active")
-  createdAt          DateTime @default(now()) @map("created_at")
-  updatedAt          DateTime @updatedAt @map("updated_at")
+  directorName       String    @map("director_name") // ชื่อผู้มีอำนาจลงนาม
+  directorPosition   String?   @map("director_position") // ตำแหน่ง
+  directorNationalId String?   @map("director_national_id")
+  directorAddress    String?   @map("director_address")
+  logoUrl            String?   @map("logo_url")
+  isActive           Boolean   @default(true) @map("is_active")
+  createdAt          DateTime  @default(now()) @map("created_at")
+  updatedAt          DateTime  @updatedAt @map("updated_at")
   deletedAt          DateTime? @map("deleted_at")
 
   @@map("company_info")
@@ -1770,9 +1778,9 @@ model FinanceReceivable {
   updatedAt         DateTime                @updatedAt @map("updated_at")
   deletedAt         DateTime?               @map("deleted_at")
 
-  sale       Sale    @relation(fields: [saleId], references: [id])
-  branch     Branch  @relation(fields: [branchId], references: [id])
-  recordedBy User?   @relation("FinanceRecordedBy", fields: [recordedById], references: [id])
+  sale       Sale   @relation(fields: [saleId], references: [id])
+  branch     Branch @relation(fields: [branchId], references: [id])
+  recordedBy User?  @relation("FinanceRecordedBy", fields: [recordedById], references: [id])
 
   @@index([status])
   @@index([financeCompany])
@@ -1780,6 +1788,35 @@ model FinanceReceivable {
   @@index([expectedDate])
   @@index([deletedAt])
   @@map("finance_receivables")
+}
+
+// ============================================================
+// CHART OF ACCOUNTS (ผังบัญชี)
+// ============================================================
+
+enum AccountGroup {
+  ASSET // 1xxx สินทรัพย์
+  LIABILITY // 2xxx หนี้สิน
+  EQUITY // 3xxx ส่วนของเจ้าของ
+  REVENUE // 4xxx รายได้
+  EXPENSE // 5xxx ค่าใช้จ่าย
+}
+
+model ChartOfAccount {
+  id           String       @id @default(uuid())
+  code         String       @unique // e.g. "1100", "4100"
+  nameTh       String       @map("name_th") // ชื่อบัญชีภาษาไทย
+  nameEn       String?      @map("name_en") // English name (optional)
+  accountGroup AccountGroup @map("account_group")
+  parentCode   String?      @map("parent_code") // parent account code for hierarchy
+  level        Int          @default(1) // 1=group, 2=sub-group, 3=detail
+  isActive     Boolean      @default(true) @map("is_active")
+  createdAt    DateTime     @default(now()) @map("created_at")
+  updatedAt    DateTime     @updatedAt @map("updated_at")
+
+  @@index([accountGroup])
+  @@index([code])
+  @@map("chart_of_accounts")
 }
 
 // ============================================================
@@ -1831,46 +1868,53 @@ enum ExpenseStatus {
 }
 
 model Expense {
-  id              String             @id @default(uuid())
-  expenseNumber   String             @unique @map("expense_number")
-  branchId        String             @map("branch_id")
-  accountType     ExpenseAccountType @map("account_type")
-  category        ExpenseCategory
-  accountCode     String?            @map("account_code")
-  description     String
-  amount          Decimal            @db.Decimal(12, 2)
-  vatAmount       Decimal            @default(0) @map("vat_amount") @db.Decimal(12, 2)
-  totalAmount     Decimal            @map("total_amount") @db.Decimal(12, 2)
-  withholdingTax  Decimal            @default(0) @map("withholding_tax") @db.Decimal(12, 2)
+  id             String             @id @default(uuid())
+  expenseNumber  String             @unique @map("expense_number")
+  branchId       String             @map("branch_id")
+  accountType    ExpenseAccountType @map("account_type")
+  category       ExpenseCategory
+  accountCode    String?            @map("account_code")
+  description    String
+  amount         Decimal            @db.Decimal(12, 2)
+  vatAmount      Decimal            @default(0) @map("vat_amount") @db.Decimal(12, 2)
+  totalAmount    Decimal            @map("total_amount") @db.Decimal(12, 2)
+  withholdingTax Decimal            @default(0) @map("withholding_tax") @db.Decimal(12, 2)
+  whtRate        Decimal?           @map("wht_rate") @db.Decimal(5, 4) // อัตราภาษีหัก ณ ที่จ่าย (0.01, 0.02, 0.03, 0.05)
+  whtIncomeType  String?            @map("wht_income_type") // ประเภทเงินได้ เช่น 40(2), 40(5), 40(8)
+  netPayment     Decimal?           @map("net_payment") @db.Decimal(12, 2) // จำนวนจ่ายจริง = totalAmount - withholdingTax
 
-  expenseDate     DateTime           @map("expense_date")
-  paymentMethod   PaymentMethod?     @map("payment_method")
-  paymentDate     DateTime?          @map("payment_date")
-  reference       String?
+  expenseDate   DateTime       @map("expense_date")
+  paymentMethod PaymentMethod? @map("payment_method")
+  paymentDate   DateTime?      @map("payment_date")
+  reference     String?
 
-  vendorName      String?            @map("vendor_name")
-  vendorTaxId     String?            @map("vendor_tax_id")
-  receiptImageUrl String?            @map("receipt_image_url")
-  taxInvoiceNo    String?            @map("tax_invoice_no")
+  vendorName      String? @map("vendor_name")
+  vendorTaxId     String? @map("vendor_tax_id")
+  receiptImageUrl String? @map("receipt_image_url")
+  taxInvoiceNo    String? @map("tax_invoice_no")
 
-  status          ExpenseStatus      @default(DRAFT)
-  approvedById    String?            @map("approved_by_id")
-  approvedAt      DateTime?          @map("approved_at")
-  rejectReason    String?            @map("reject_reason")
-  createdById     String             @map("created_by_id")
+  status       ExpenseStatus @default(DRAFT)
+  approvedById String?       @map("approved_by_id")
+  approvedAt   DateTime?     @map("approved_at")
+  rejectReason String?       @map("reject_reason")
+  voidReason   String?       @map("void_reason")
+  voidedById   String?       @map("voided_by_id")
+  voidedAt     DateTime?     @map("voided_at")
+  createdById  String        @map("created_by_id")
 
-  isRecurring     Boolean            @default(false) @map("is_recurring")
-  recurringDay    Int?               @map("recurring_day")
+  isRecurring  Boolean @default(false) @map("is_recurring")
+  recurringDay Int?    @map("recurring_day")
 
-  note            String?
+  note String?
 
-  createdAt       DateTime           @default(now()) @map("created_at")
-  updatedAt       DateTime           @updatedAt @map("updated_at")
-  deletedAt       DateTime?          @map("deleted_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
 
   branch     Branch @relation(fields: [branchId], references: [id])
   createdBy  User   @relation("ExpenseCreatedBy", fields: [createdById], references: [id])
   approvedBy User?  @relation("ExpenseApprovedBy", fields: [approvedById], references: [id])
+  voidedBy   User?  @relation("ExpenseVoidedBy", fields: [voidedById], references: [id])
 
   @@index([branchId])
   @@index([accountType])
@@ -1891,7 +1935,7 @@ model LoyaltyPoint {
   customerId String    @map("customer_id")
   paymentId  String    @unique @map("payment_id") // idempotent: 1 payment = 1 point record
   contractId String    @map("contract_id")
-  points     Int       // 1 point per 100 baht, on-time only
+  points     Int // 1 point per 100 baht, on-time only
   reason     String    @default("ON_TIME_PAYMENT")
   createdAt  DateTime  @default(now()) @map("created_at")
   updatedAt  DateTime  @updatedAt @map("updated_at")
@@ -1911,38 +1955,38 @@ model LoyaltyPoint {
 // ============================================================
 
 model InterCompanyTransaction {
-  id              String                        @id @default(uuid())
-  saleId          String                        @map("sale_id")
-  contractId      String?                       @map("contract_id")
-  branchId        String                        @map("branch_id")
-  type            InterCompanyTransactionType
-  status          InterCompanyTransactionStatus  @default(PENDING)
+  id         String                        @id @default(uuid())
+  saleId     String                        @map("sale_id")
+  contractId String?                       @map("contract_id")
+  branchId   String                        @map("branch_id")
+  type       InterCompanyTransactionType
+  status     InterCompanyTransactionStatus @default(PENDING)
 
   // Entity identification
-  fromEntity      String                        @map("from_entity")  // e.g. "BESTCHOICE FINANCE"
-  toEntity        String                        @map("to_entity")    // e.g. "BESTCHOICE SHOP"
+  fromEntity String @map("from_entity") // e.g. "BESTCHOICE FINANCE"
+  toEntity   String @map("to_entity") // e.g. "BESTCHOICE SHOP"
 
   // Financial fields
-  principal       Decimal                       @db.Decimal(12, 2)   // ยอดจัดไฟแนนซ์ (sellingPrice - downPayment)
-  commission      Decimal                       @db.Decimal(12, 2)   // Store commission (principal × commissionPct)
-  commissionPct   Decimal                       @map("commission_pct") @db.Decimal(5, 4) // e.g. 0.10
-  vatAmount       Decimal                       @map("vat_amount") @db.Decimal(12, 2)
-  vatPct          Decimal                       @map("vat_pct") @db.Decimal(5, 4) // e.g. 0.07
-  totalAmount     Decimal                       @map("total_amount") @db.Decimal(12, 2) // principal + commission (Finance จ่ายให้ Shop)
-  interestTotal   Decimal                       @map("interest_total") @db.Decimal(12, 2)
-  costPrice       Decimal                       @map("cost_price") @db.Decimal(12, 2)
-  downPayment     Decimal                       @map("down_payment") @db.Decimal(12, 2)
-  sellingPrice    Decimal                       @map("selling_price") @db.Decimal(12, 2)
+  principal     Decimal @db.Decimal(12, 2) // ยอดจัดไฟแนนซ์ (sellingPrice - downPayment)
+  commission    Decimal @db.Decimal(12, 2) // Store commission (principal × commissionPct)
+  commissionPct Decimal @map("commission_pct") @db.Decimal(5, 4) // e.g. 0.10
+  vatAmount     Decimal @map("vat_amount") @db.Decimal(12, 2)
+  vatPct        Decimal @map("vat_pct") @db.Decimal(5, 4) // e.g. 0.07
+  totalAmount   Decimal @map("total_amount") @db.Decimal(12, 2) // principal + commission (Finance จ่ายให้ Shop)
+  interestTotal Decimal @map("interest_total") @db.Decimal(12, 2)
+  costPrice     Decimal @map("cost_price") @db.Decimal(12, 2)
+  downPayment   Decimal @map("down_payment") @db.Decimal(12, 2)
+  sellingPrice  Decimal @map("selling_price") @db.Decimal(12, 2)
 
   // Calculated profits (snapshot at creation time)
-  shopProfit      Decimal                       @map("shop_profit") @db.Decimal(12, 2)    // downPayment + principal + commission - costPrice
-  financeProfit   Decimal                       @map("finance_profit") @db.Decimal(12, 2) // interestTotal - commission (+ lateFees later)
+  shopProfit    Decimal @map("shop_profit") @db.Decimal(12, 2) // downPayment + principal + commission - costPrice
+  financeProfit Decimal @map("finance_profit") @db.Decimal(12, 2) // interestTotal - commission (+ lateFees later)
 
-  note            String?
-  reconciledAt    DateTime?                     @map("reconciled_at")
-  createdAt       DateTime                      @default(now()) @map("created_at")
-  updatedAt       DateTime                      @updatedAt @map("updated_at")
-  deletedAt       DateTime?                     @map("deleted_at")
+  note         String?
+  reconciledAt DateTime? @map("reconciled_at")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+  deletedAt    DateTime? @map("deleted_at")
 
   sale     Sale      @relation(fields: [saleId], references: [id])
   contract Contract? @relation(fields: [contractId], references: [id])
@@ -1958,4 +2002,34 @@ model InterCompanyTransaction {
   @@index([createdAt])
   @@index([deletedAt])
   @@map("inter_company_transactions")
+}
+
+// ============================================================
+// BAD DEBT PROVISIONING (ค่าเผื่อหนี้สงสัยจะสูญ)
+// ============================================================
+
+model BadDebtProvision {
+  id                String    @id @default(uuid())
+  contractId        String    @map("contract_id")
+  provisionDate     DateTime  @map("provision_date")
+  agingBucket       String    @map("aging_bucket") // "1-30", "31-60", "61-90", "91-180", "181-360", "360+"
+  daysOverdue       Int       @map("days_overdue")
+  outstandingAmount Decimal   @map("outstanding_amount") @db.Decimal(12, 2)
+  provisionRate     Decimal   @map("provision_rate") @db.Decimal(5, 4) // e.g. 0.05 = 5%
+  provisionAmount   Decimal   @map("provision_amount") @db.Decimal(12, 2)
+  status            String    @default("ACTIVE") // ACTIVE, REVERSED, WRITTEN_OFF
+  writtenOffAt      DateTime? @map("written_off_at")
+  writtenOffById    String?   @map("written_off_by_id")
+  approvedById      String?   @map("approved_by_id")
+  approvedAt        DateTime? @map("approved_at")
+  notes             String?
+  createdAt         DateTime  @default(now()) @map("created_at")
+  updatedAt         DateTime  @updatedAt @map("updated_at")
+
+  contract Contract @relation(fields: [contractId], references: [id])
+
+  @@index([contractId])
+  @@index([provisionDate])
+  @@index([status])
+  @@map("bad_debt_provisions")
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import * as fs from 'fs';
 import * as path from 'path';
+import { seedChartOfAccounts } from './seeds/chart-of-accounts';
 
 const prisma = new PrismaClient();
 
@@ -58,6 +59,7 @@ async function main() {
   await prisma.systemConfig.deleteMany();
   await prisma.contractTemplate.deleteMany();
   await prisma.stickerTemplate.deleteMany();
+  await prisma.chartOfAccount.deleteMany();
   await prisma.companyInfo.deleteMany();
   console.log('All data deleted.');
 
@@ -110,6 +112,7 @@ async function main() {
     { key: 'line_oa_welcome_message', value: 'ยินดีต้อนรับสู่ BESTCHOICE Mobile! พิมพ์เลขสัญญาเพื่อตรวจสอบยอดชำระ', label: 'ข้อความต้อนรับ LINE OA' },
     { key: 'line_oa_payment_reminder_template', value: 'แจ้งเตือน: สัญญา {contractNo} ครบกำหนดชำระงวดที่ {installment} จำนวน {amount} บาท ภายในวันที่ {dueDate}', label: 'เทมเพลตแจ้งเตือนชำระเงิน LINE OA' },
     { key: 'line_oa_overdue_template', value: 'แจ้งเตือน: สัญญา {contractNo} เลยกำหนดชำระ {overdueDays} วัน กรุณาชำระโดยเร็ว', label: 'เทมเพลตแจ้งเตือนค้างชำระ LINE OA' },
+    { key: 'bad_debt_provision_rates', value: JSON.stringify({ '1-30': 0.02, '31-60': 0.10, '61-90': 0.25, '91-180': 0.50, '181-360': 0.75, '360+': 1.00 }), label: 'อัตราค่าเผื่อหนี้สงสัยจะสูญ ตามอายุหนี้' },
   ];
 
   for (const c of configs) {
@@ -1291,6 +1294,11 @@ async function main() {
   // SUMMARY
   // ============================================================
   console.log('\n========================================');
+  // ============================================================
+  // CHART OF ACCOUNTS (ผังบัญชี)
+  // ============================================================
+  await seedChartOfAccounts(prisma);
+
   console.log('=== SEED COMPLETED SUCCESSFULLY ===');
   console.log('========================================');
   console.log('CompanyInfo: 1');
@@ -1326,6 +1334,7 @@ async function main() {
   console.log('AuditLogs: 10');
   console.log('ContractTemplates: 1');
   console.log('StickerTemplates: 2');
+  console.log('ChartOfAccounts: 76 (full Thai SME chart)');
   console.log('========================================\n');
 }
 

--- a/apps/api/prisma/seeds/chart-of-accounts.ts
+++ b/apps/api/prisma/seeds/chart-of-accounts.ts
@@ -1,0 +1,172 @@
+import { PrismaClient, AccountGroup } from '@prisma/client';
+
+interface ChartOfAccountSeed {
+  code: string;
+  nameTh: string;
+  nameEn?: string;
+  accountGroup: AccountGroup;
+  parentCode?: string;
+  level: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const CHART_OF_ACCOUNTS: ChartOfAccountSeed[] = [
+  // ════════════════════════════════════════════════════════════
+  // 1xxx สินทรัพย์ (ASSET)
+  // ════════════════════════════════════════════════════════════
+  { code: '1000', nameTh: 'สินทรัพย์', nameEn: 'Assets', accountGroup: AccountGroup.ASSET, level: 1 },
+
+  // 1100 เงินสดและเงินฝากธนาคาร
+  { code: '1100', nameTh: 'เงินสดและเงินฝากธนาคาร', nameEn: 'Cash and Bank Deposits', accountGroup: AccountGroup.ASSET, parentCode: '1000', level: 2 },
+  { code: '1110', nameTh: 'เงินสด', nameEn: 'Cash on Hand', accountGroup: AccountGroup.ASSET, parentCode: '1100', level: 3 },
+  { code: '1120', nameTh: 'เงินฝากธนาคาร', nameEn: 'Bank Deposits', accountGroup: AccountGroup.ASSET, parentCode: '1100', level: 3 },
+
+  // 1200 ลูกหนี้การค้า
+  { code: '1200', nameTh: 'ลูกหนี้การค้า', nameEn: 'Accounts Receivable', accountGroup: AccountGroup.ASSET, parentCode: '1000', level: 2 },
+  { code: '1210', nameTh: 'ลูกหนี้การค้า - เงินสด', nameEn: 'Accounts Receivable - Cash Sales', accountGroup: AccountGroup.ASSET, parentCode: '1200', level: 3 },
+  { code: '1220', nameTh: 'ลูกหนี้เช่าซื้อ', nameEn: 'Hire-Purchase Receivable', accountGroup: AccountGroup.ASSET, parentCode: '1200', level: 3 },
+  { code: '1229', nameTh: 'หัก: ค่าเผื่อหนี้สงสัยจะสูญ', nameEn: 'Less: Allowance for Doubtful Accounts', accountGroup: AccountGroup.ASSET, parentCode: '1200', level: 3 },
+  { code: '1230', nameTh: 'ลูกหนี้ไฟแนนซ์ภายนอก', nameEn: 'External Finance Receivable', accountGroup: AccountGroup.ASSET, parentCode: '1200', level: 3 },
+
+  // 1300 สินค้าคงเหลือ
+  { code: '1300', nameTh: 'สินค้าคงเหลือ', nameEn: 'Inventory', accountGroup: AccountGroup.ASSET, parentCode: '1000', level: 2 },
+  { code: '1310', nameTh: 'สินค้าสำเร็จรูป (มือถือใหม่)', nameEn: 'Finished Goods (New Phones)', accountGroup: AccountGroup.ASSET, parentCode: '1300', level: 3 },
+  { code: '1320', nameTh: 'สินค้ามือสอง', nameEn: 'Used Goods', accountGroup: AccountGroup.ASSET, parentCode: '1300', level: 3 },
+  { code: '1330', nameTh: 'สินค้ายึดคืน/ซ่อมแล้ว', nameEn: 'Repossessed/Refurbished Goods', accountGroup: AccountGroup.ASSET, parentCode: '1300', level: 3 },
+
+  // 1400 ภาษีซื้อ
+  { code: '1400', nameTh: 'ภาษีซื้อ', nameEn: 'Input VAT', accountGroup: AccountGroup.ASSET, parentCode: '1000', level: 2 },
+  { code: '1410', nameTh: 'ภาษีซื้อ', nameEn: 'Input VAT', accountGroup: AccountGroup.ASSET, parentCode: '1400', level: 3 },
+  { code: '1420', nameTh: 'ภาษีซื้อรอเคลม', nameEn: 'Input VAT Pending Claim', accountGroup: AccountGroup.ASSET, parentCode: '1400', level: 3 },
+
+  // 1500 สินทรัพย์หมุนเวียนอื่น
+  { code: '1500', nameTh: 'สินทรัพย์หมุนเวียนอื่น', nameEn: 'Other Current Assets', accountGroup: AccountGroup.ASSET, parentCode: '1000', level: 2 },
+  { code: '1510', nameTh: 'เงินมัดจำ', nameEn: 'Deposits', accountGroup: AccountGroup.ASSET, parentCode: '1500', level: 3 },
+  { code: '1520', nameTh: 'ค่าใช้จ่ายจ่ายล่วงหน้า', nameEn: 'Prepaid Expenses', accountGroup: AccountGroup.ASSET, parentCode: '1500', level: 3 },
+
+  // 1600 ดอกเบี้ยรอรับรู้
+  { code: '1600', nameTh: 'ดอกเบี้ยรอรับรู้', nameEn: 'Unearned Interest Receivable', accountGroup: AccountGroup.ASSET, parentCode: '1000', level: 2 },
+
+  // ════════════════════════════════════════════════════════════
+  // 2xxx หนี้สิน (LIABILITY)
+  // ════════════════════════════════════════════════════════════
+  { code: '2000', nameTh: 'หนี้สิน', nameEn: 'Liabilities', accountGroup: AccountGroup.LIABILITY, level: 1 },
+
+  { code: '2100', nameTh: 'เจ้าหนี้การค้า', nameEn: 'Accounts Payable', accountGroup: AccountGroup.LIABILITY, parentCode: '2000', level: 2 },
+
+  // 2200 ภาษีขาย
+  { code: '2200', nameTh: 'ภาษีขาย', nameEn: 'Output VAT', accountGroup: AccountGroup.LIABILITY, parentCode: '2000', level: 2 },
+  { code: '2210', nameTh: 'ภาษีขาย', nameEn: 'Output VAT', accountGroup: AccountGroup.LIABILITY, parentCode: '2200', level: 3 },
+  { code: '2220', nameTh: 'ภาษีมูลค่าเพิ่มค้างจ่าย', nameEn: 'VAT Payable', accountGroup: AccountGroup.LIABILITY, parentCode: '2200', level: 3 },
+
+  { code: '2300', nameTh: 'ภาษีหัก ณ ที่จ่ายค้างจ่าย', nameEn: 'Withholding Tax Payable', accountGroup: AccountGroup.LIABILITY, parentCode: '2000', level: 2 },
+
+  { code: '2400', nameTh: 'เงินรับล่วงหน้า / เงินมัดจำรับ', nameEn: 'Advance Receipts / Deposits Received', accountGroup: AccountGroup.LIABILITY, parentCode: '2000', level: 2 },
+
+  // 2500 เจ้าหนี้อื่น
+  { code: '2500', nameTh: 'เจ้าหนี้อื่น', nameEn: 'Other Payables', accountGroup: AccountGroup.LIABILITY, parentCode: '2000', level: 2 },
+  { code: '2510', nameTh: 'เงินเกินของลูกค้า', nameEn: 'Customer Credit Balance', accountGroup: AccountGroup.LIABILITY, parentCode: '2500', level: 3 },
+
+  { code: '2600', nameTh: 'ค่าใช้จ่ายค้างจ่าย', nameEn: 'Accrued Expenses', accountGroup: AccountGroup.LIABILITY, parentCode: '2000', level: 2 },
+
+  // ════════════════════════════════════════════════════════════
+  // 3xxx ส่วนของเจ้าของ (EQUITY)
+  // ════════════════════════════════════════════════════════════
+  { code: '3000', nameTh: 'ส่วนของเจ้าของ', nameEn: 'Equity', accountGroup: AccountGroup.EQUITY, level: 1 },
+  { code: '3100', nameTh: 'ทุนจดทะเบียน', nameEn: 'Registered Capital', accountGroup: AccountGroup.EQUITY, parentCode: '3000', level: 2 },
+  { code: '3200', nameTh: 'กำไร(ขาดทุน)สะสม', nameEn: 'Retained Earnings (Deficit)', accountGroup: AccountGroup.EQUITY, parentCode: '3000', level: 2 },
+  { code: '3300', nameTh: 'กำไร(ขาดทุน)สุทธิประจำปี', nameEn: 'Net Income (Loss) for the Year', accountGroup: AccountGroup.EQUITY, parentCode: '3000', level: 2 },
+
+  // ════════════════════════════════════════════════════════════
+  // 4xxx รายได้ (REVENUE)
+  // ════════════════════════════════════════════════════════════
+  { code: '4000', nameTh: 'รายได้', nameEn: 'Revenue', accountGroup: AccountGroup.REVENUE, level: 1 },
+
+  // 4100 รายได้จากการขาย
+  { code: '4100', nameTh: 'รายได้จากการขาย', nameEn: 'Sales Revenue', accountGroup: AccountGroup.REVENUE, parentCode: '4000', level: 2 },
+  { code: '4110', nameTh: 'รายได้จากการขายเงินสด', nameEn: 'Cash Sales Revenue', accountGroup: AccountGroup.REVENUE, parentCode: '4100', level: 3 },
+  { code: '4120', nameTh: 'รายได้จากการขายผ่อนชำระ', nameEn: 'Installment Sales Revenue', accountGroup: AccountGroup.REVENUE, parentCode: '4100', level: 3 },
+  { code: '4130', nameTh: 'รายได้จากขายผ่านไฟแนนซ์ภายนอก', nameEn: 'External Finance Sales Revenue', accountGroup: AccountGroup.REVENUE, parentCode: '4100', level: 3 },
+  { code: '4140', nameTh: 'รายได้จากขายสินค้ามือสอง', nameEn: 'Used Goods Sales Revenue', accountGroup: AccountGroup.REVENUE, parentCode: '4100', level: 3 },
+  { code: '4199', nameTh: 'หัก: ส่วนลดจ่าย', nameEn: 'Less: Sales Discounts', accountGroup: AccountGroup.REVENUE, parentCode: '4100', level: 3 },
+
+  // 4200 รายได้ดอกเบี้ย
+  { code: '4200', nameTh: 'รายได้ดอกเบี้ย', nameEn: 'Interest Income', accountGroup: AccountGroup.REVENUE, parentCode: '4000', level: 2 },
+  { code: '4210', nameTh: 'รายได้ดอกเบี้ยเช่าซื้อ', nameEn: 'Hire-Purchase Interest Income', accountGroup: AccountGroup.REVENUE, parentCode: '4200', level: 3 },
+
+  { code: '4300', nameTh: 'รายได้ค่าปรับล่าช้า', nameEn: 'Late Payment Penalty Income', accountGroup: AccountGroup.REVENUE, parentCode: '4000', level: 2 },
+  { code: '4400', nameTh: 'รายได้ค่านายหน้า', nameEn: 'Commission Income', accountGroup: AccountGroup.REVENUE, parentCode: '4000', level: 2 },
+  { code: '4500', nameTh: 'รายได้อื่น', nameEn: 'Other Income', accountGroup: AccountGroup.REVENUE, parentCode: '4000', level: 2 },
+
+  // ════════════════════════════════════════════════════════════
+  // 5xxx ค่าใช้จ่าย (EXPENSE)
+  // ════════════════════════════════════════════════════════════
+  { code: '5000', nameTh: 'ค่าใช้จ่าย', nameEn: 'Expenses', accountGroup: AccountGroup.EXPENSE, level: 1 },
+
+  // 5100 ต้นทุนขาย
+  { code: '5100', nameTh: 'ต้นทุนขาย', nameEn: 'Cost of Goods Sold', accountGroup: AccountGroup.EXPENSE, parentCode: '5000', level: 2 },
+  { code: '5101', nameTh: 'ต้นทุนสินค้า', nameEn: 'Cost of Products', accountGroup: AccountGroup.EXPENSE, parentCode: '5100', level: 3 },
+  { code: '5102', nameTh: 'ต้นทุนอะไหล่ซ่อม', nameEn: 'Cost of Repair Parts', accountGroup: AccountGroup.EXPENSE, parentCode: '5100', level: 3 },
+
+  // 5200 ค่าใช้จ่ายในการขาย
+  { code: '5200', nameTh: 'ค่าใช้จ่ายในการขาย', nameEn: 'Selling Expenses', accountGroup: AccountGroup.EXPENSE, parentCode: '5000', level: 2 },
+  { code: '5201', nameTh: 'ค่าคอมมิชชั่นการขาย', nameEn: 'Sales Commission', accountGroup: AccountGroup.EXPENSE, parentCode: '5200', level: 3 },
+  { code: '5202', nameTh: 'ค่าโฆษณา', nameEn: 'Advertising Expense', accountGroup: AccountGroup.EXPENSE, parentCode: '5200', level: 3 },
+  { code: '5203', nameTh: 'ค่าขนส่ง', nameEn: 'Transportation Expense', accountGroup: AccountGroup.EXPENSE, parentCode: '5200', level: 3 },
+  { code: '5204', nameTh: 'ค่าบรรจุภัณฑ์', nameEn: 'Packaging Expense', accountGroup: AccountGroup.EXPENSE, parentCode: '5200', level: 3 },
+
+  // 5300 ค่าใช้จ่ายในการบริหาร
+  { code: '5300', nameTh: 'ค่าใช้จ่ายในการบริหาร', nameEn: 'Administrative Expenses', accountGroup: AccountGroup.EXPENSE, parentCode: '5000', level: 2 },
+  { code: '5301', nameTh: 'เงินเดือนและค่าจ้าง', nameEn: 'Salaries and Wages', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5302', nameTh: 'ประกันสังคม', nameEn: 'Social Security', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5303', nameTh: 'ค่าเช่าสำนักงาน', nameEn: 'Office Rent', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5304', nameTh: 'ค่าน้ำ/ค่าไฟ', nameEn: 'Utilities', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5305', nameTh: 'วัสดุสำนักงาน', nameEn: 'Office Supplies', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5306', nameTh: 'ค่าเสื่อมราคา', nameEn: 'Depreciation', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5307', nameTh: 'ค่าประกันภัย', nameEn: 'Insurance', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5308', nameTh: 'ค่าภาษีอากร', nameEn: 'Taxes and Fees', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5309', nameTh: 'ค่าซ่อมแซมบำรุงรักษา', nameEn: 'Repairs and Maintenance', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5310', nameTh: 'ค่าเดินทาง', nameEn: 'Travel Expense', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+  { code: '5311', nameTh: 'ค่าโทรศัพท์/อินเทอร์เน็ต', nameEn: 'Telephone/Internet', accountGroup: AccountGroup.EXPENSE, parentCode: '5300', level: 3 },
+
+  // 5800 หนี้สูญและค่าเผื่อหนี้สงสัยจะสูญ
+  { code: '5800', nameTh: 'หนี้สูญและค่าเผื่อหนี้สงสัยจะสูญ', nameEn: 'Bad Debts and Allowance for Doubtful Accounts', accountGroup: AccountGroup.EXPENSE, parentCode: '5000', level: 2 },
+  { code: '5810', nameTh: 'หนี้สูญ', nameEn: 'Bad Debts', accountGroup: AccountGroup.EXPENSE, parentCode: '5800', level: 3 },
+  { code: '5820', nameTh: 'ค่าเผื่อหนี้สงสัยจะสูญ', nameEn: 'Allowance for Doubtful Accounts', accountGroup: AccountGroup.EXPENSE, parentCode: '5800', level: 3 },
+
+  // 5900 ค่าใช้จ่ายอื่น
+  { code: '5900', nameTh: 'ค่าใช้จ่ายอื่น', nameEn: 'Other Expenses', accountGroup: AccountGroup.EXPENSE, parentCode: '5000', level: 2 },
+  { code: '5901', nameTh: 'ดอกเบี้ยจ่าย', nameEn: 'Interest Expense', accountGroup: AccountGroup.EXPENSE, parentCode: '5900', level: 3 },
+  { code: '5902', nameTh: 'ขาดทุนจากการจำหน่ายสินทรัพย์', nameEn: 'Loss on Disposal of Assets', accountGroup: AccountGroup.EXPENSE, parentCode: '5900', level: 3 },
+  { code: '5903', nameTh: 'ค่าปรับ', nameEn: 'Fines and Penalties', accountGroup: AccountGroup.EXPENSE, parentCode: '5900', level: 3 },
+  { code: '5999', nameTh: 'ค่าใช้จ่ายเบ็ดเตล็ด', nameEn: 'Miscellaneous Expenses', accountGroup: AccountGroup.EXPENSE, parentCode: '5900', level: 3 },
+];
+
+export async function seedChartOfAccounts(prisma: PrismaClient): Promise<void> {
+  console.log('Seeding Chart of Accounts (ผังบัญชี)...');
+
+  for (const account of CHART_OF_ACCOUNTS) {
+    await prisma.chartOfAccount.upsert({
+      where: { code: account.code },
+      update: {
+        nameTh: account.nameTh,
+        nameEn: account.nameEn,
+        accountGroup: account.accountGroup,
+        parentCode: account.parentCode,
+        level: account.level,
+        isActive: true,
+      },
+      create: {
+        code: account.code,
+        nameTh: account.nameTh,
+        nameEn: account.nameEn ?? undefined,
+        accountGroup: account.accountGroup,
+        parentCode: account.parentCode ?? undefined,
+        level: account.level,
+        isActive: true,
+      },
+    });
+  }
+
+  console.log(`  ✓ Chart of Accounts: ${CHART_OF_ACCOUNTS.length} accounts seeded`);
+}

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AccountingService } from './accounting.service';
+import { BadDebtService } from './bad-debt.service';
 import { CreateExpenseDto, UpdateExpenseDto, RejectExpenseDto } from './dto/expense.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -22,7 +23,10 @@ import { ExpenseAccountType, ExpenseCategory, ExpenseStatus } from '@prisma/clie
 @Controller('expenses')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class AccountingController {
-  constructor(private service: AccountingService) {}
+  constructor(
+    private service: AccountingService,
+    private badDebtService: BadDebtService,
+  ) {}
 
   @Post()
   @Roles('OWNER', 'BRANCH_MANAGER', 'ACCOUNTANT')
@@ -145,7 +149,87 @@ export class AccountingController {
 
   @Post(':id/void')
   @Roles('OWNER')
-  void(@Param('id') id: string) {
-    return this.service.voidExpense(id);
+  void(
+    @Param('id') id: string,
+    @Request() req: { user: { id: string } },
+    @Body('reason') reason: string,
+  ) {
+    return this.service.voidExpense(id, req.user.id, reason);
+  }
+
+  // ============================================================
+  // Balance Sheet & Cash Flow Statement
+  // ============================================================
+
+  @Get('balance-sheet')
+  @Roles('OWNER', 'ACCOUNTANT')
+  getBalanceSheet(
+    @Query('asOfDate') asOfDate?: string,
+    @Query('branchId') branchId?: string,
+  ) {
+    return this.service.getBalanceSheet(
+      asOfDate || new Date().toISOString().split('T')[0],
+      branchId,
+    );
+  }
+
+  @Get('cash-flow')
+  @Roles('OWNER', 'ACCOUNTANT')
+  getCashFlowStatement(
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+    @Query('branchId') branchId?: string,
+  ) {
+    return this.service.getCashFlowStatement(startDate, endDate, branchId);
+  }
+
+  // ============================================================
+  // W-013: Period Closing Lock
+  // ============================================================
+
+  @Get('period-status')
+  @Roles('OWNER')
+  getPeriodStatus() {
+    return this.service.getAccountingPeriodStatus();
+  }
+
+  @Post('close-period')
+  @Roles('OWNER')
+  closePeriod(@Body('closedUntil') closedUntil: string) {
+    return this.service.closeAccountingPeriod(closedUntil);
+  }
+
+  // ============================================================
+  // Bad Debt Provisioning (ค่าเผื่อหนี้สงสัยจะสูญ)
+  // ============================================================
+
+  @Post('bad-debt/calculate')
+  @Roles('OWNER', 'ACCOUNTANT')
+  calculateProvisions(
+    @Request() req: { user: { id: string } },
+    @Query('branchId') branchId?: string,
+  ) {
+    return this.badDebtService.calculateProvisions(req.user.id, branchId);
+  }
+
+  @Get('bad-debt/summary')
+  @Roles('OWNER', 'ACCOUNTANT')
+  getProvisionSummary() {
+    return this.badDebtService.getProvisionSummary();
+  }
+
+  @Post('bad-debt/write-off/:contractId')
+  @Roles('OWNER')
+  writeOffBadDebt(
+    @Param('contractId') contractId: string,
+    @Body() body: { approvedById: string; notes?: string },
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.badDebtService.writeOffBadDebt(
+      contractId,
+      req.user.id,
+      body.approvedById,
+      body.notes,
+    );
   }
 }

--- a/apps/api/src/modules/accounting/accounting.module.ts
+++ b/apps/api/src/modules/accounting/accounting.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AccountingController } from './accounting.controller';
 import { AccountingService } from './accounting.service';
+import { BadDebtService } from './bad-debt.service';
 
 @Module({
   controllers: [AccountingController],
-  providers: [AccountingService],
-  exports: [AccountingService],
+  providers: [AccountingService, BadDebtService],
+  exports: [AccountingService, BadDebtService],
 })
 export class AccountingModule {}

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -62,6 +62,9 @@ export class AccountingService {
   // ─── Expenses CRUD ───────────────────────────────────────────────────────────
 
   async createExpense(dto: CreateExpenseDto, createdById: string) {
+    // W-013: Validate expense date is not in a closed period
+    await this.validatePeriodOpen(new Date(dto.expenseDate));
+
     const expectedAccountType = CATEGORY_ACCOUNT_MAP[dto.category];
     if (expectedAccountType && expectedAccountType !== dto.accountType) {
       throw new BadRequestException(
@@ -76,7 +79,10 @@ export class AccountingService {
       vatAmount = Math.round(dto.amount * vatRate * 100) / 100;
     }
     const withholdingTax = dto.withholdingTax || 0;
+    const whtRate = dto.whtRate || null;
+    const whtIncomeType = dto.whtIncomeType || null;
     const totalAmount = dto.amount + vatAmount;
+    const netPayment = Math.round((totalAmount - withholdingTax) * 100) / 100;
     const accountCode = dto.accountCode || CATEGORY_CODE_MAP[dto.category] || null;
 
     return this.prisma.$transaction(async (tx) => {
@@ -94,6 +100,9 @@ export class AccountingService {
           vatAmount,
           totalAmount,
           withholdingTax,
+          whtRate,
+          whtIncomeType,
+          netPayment,
           expenseDate: new Date(dto.expenseDate),
           paymentMethod: dto.paymentMethod,
           paymentDate: dto.paymentDate ? new Date(dto.paymentDate) : null,
@@ -244,6 +253,9 @@ export class AccountingService {
     if (expense.status !== 'PENDING_APPROVAL') {
       throw new BadRequestException('รายจ่ายนี้ไม่ได้อยู่ในสถานะรออนุมัติ');
     }
+    if (expense.createdById === approvedById) {
+      throw new BadRequestException('ผู้อนุมัติต้องไม่ใช่ผู้สร้างรายการ (Segregation of Duties)');
+    }
     return this.prisma.expense.update({
       where: { id },
       data: { status: 'APPROVED', approvedById, approvedAt: new Date() },
@@ -274,13 +286,19 @@ export class AccountingService {
     });
   }
 
-  async voidExpense(id: string) {
+  async voidExpense(id: string, voidedById: string, voidReason: string) {
+    if (!voidReason?.trim()) {
+      throw new BadRequestException('กรุณาระบุเหตุผลในการยกเลิก');
+    }
     const expense = await this.prisma.expense.findFirst({ where: { id, deletedAt: null } });
     if (!expense) throw new NotFoundException('ไม่พบรายจ่าย');
     if (expense.status === 'VOIDED') {
       throw new BadRequestException('รายจ่ายนี้ถูกยกเลิกไปแล้ว');
     }
-    return this.prisma.expense.update({ where: { id }, data: { status: 'VOIDED' } });
+    return this.prisma.expense.update({
+      where: { id },
+      data: { status: 'VOIDED', voidReason: voidReason.trim(), voidedById, voidedAt: new Date() },
+    });
   }
 
   async getExpenseSummary(filters: { branchId?: string; startDate?: string; endDate?: string }) {
@@ -407,7 +425,7 @@ export class AccountingService {
       }),
       this.prisma.sale.findMany({
         where: { createdAt: dateRange, ...branchFilter },
-        select: { product: { select: { costPrice: true } } },
+        select: { product: { select: { costPrice: true } }, bundleProductIds: true },
       }),
     ]);
 
@@ -421,19 +439,36 @@ export class AccountingService {
     let lateFeeIncome = 0;
     for (const p of paidPayments) {
       installmentPayments += Number(p.amountPaid);
+      // Accounting policy: Interest income recognized using straight-line method (เกณฑ์เส้นตรง)
+      // for flat-rate hire-purchase contracts per TFRS for NPAEs.
+      // Monthly interest = total interest / total months (equal allocation per payment received)
       interestIncome += Number(p.contract.interestTotal) / p.contract.totalMonths;
       if (!p.lateFeeWaived) lateFeeIncome += Number(p.lateFee);
     }
 
-    const totalRevenue = cashSales + installmentDownPayments + installmentPayments
-      + lateFeeIncome + financeDownPayments + financeReceivedAmount;
+    // R-011: Separate operating revenue from other income per TAS 1
+    const operatingRevenue = cashSales + installmentDownPayments + installmentPayments
+      + financeDownPayments + financeReceivedAmount;
+    const otherIncomeTotal = interestIncome + lateFeeIncome;
+    const totalRevenue = operatingRevenue + otherIncomeTotal;
 
     const expMap: Record<string, number> = {};
     for (const e of expensesByCategory) {
       expMap[e.category] = (expMap[e.category] || 0) + Number(e.totalAmount);
     }
 
-    const purchaseOrderCost = productCosts.reduce((sum, s) => sum + Number(s.product.costPrice || 0), 0);
+    // COGS: main product cost + bundle product costs
+    const allBundleIds = productCosts.flatMap((s) => s.bundleProductIds || []);
+    let bundleCost = 0;
+    if (allBundleIds.length > 0) {
+      const bundleProducts = await this.prisma.product.findMany({
+        where: { id: { in: allBundleIds } },
+        select: { costPrice: true },
+      });
+      bundleCost = bundleProducts.reduce((sum, p) => sum + Number(p.costPrice || 0), 0);
+    }
+    const purchaseOrderCost = productCosts.reduce((sum, s) => sum + Number(s.product.costPrice || 0), 0)
+      + bundleCost;
 
     const costOfSales = {
       cogsProduct: expMap['COGS_PRODUCT'] || 0,
@@ -442,7 +477,8 @@ export class AccountingService {
       totalCOGS: (expMap['COGS_PRODUCT'] || 0) + (expMap['COGS_REPAIR_PARTS'] || 0) + purchaseOrderCost,
     };
 
-    const grossProfit = totalRevenue - costOfSales.totalCOGS;
+    // Gross profit from operating revenue only (excludes interest/late fees)
+    const grossProfit = operatingRevenue - costOfSales.totalCOGS;
 
     const sellingExpenses = {
       commission: expMap['SELL_COMMISSION'] || 0,
@@ -472,7 +508,7 @@ export class AccountingService {
       + adminExpenses.depreciation + adminExpenses.insurance + adminExpenses.taxFee
       + adminExpenses.maintenance + adminExpenses.travel + adminExpenses.telephone;
 
-    const operatingProfit = grossProfit - sellingExpenses.totalSelling - adminExpenses.totalAdmin;
+    const operatingProfit = grossProfit - sellingExpenses.totalSelling - adminExpenses.totalAdmin + otherIncomeTotal;
 
     const otherExpenses = {
       interest: expMap['OTHER_INTEREST'] || 0,
@@ -493,11 +529,15 @@ export class AccountingService {
         cashSales,
         installmentDownPayments,
         installmentPayments,
-        interestIncome: Math.round(interestIncome),
-        lateFeeIncome,
         financeDownPayments,
         financeReceived: financeReceivedAmount,
+        operatingRevenue,
         totalRevenue,
+      },
+      otherIncome: {
+        interestIncome: Math.round(interestIncome),
+        lateFeeIncome,
+        totalOtherIncome: otherIncomeTotal,
       },
       costOfSales,
       grossProfit,
@@ -589,5 +629,366 @@ export class AccountingService {
     });
 
     return { year, months };
+  }
+
+  // ─── W-012: Comparative P&L (MoM / YoY) ──────────────────────────────────────
+
+  async getComparativePL(year: number, month: number, branchId?: string) {
+    // Helper: get last day of month as YYYY-MM-DD string (local time, no UTC shift)
+    const lastDayOf = (y: number, m: number) => {
+      const d = new Date(y, m, 0); // day 0 of next month = last day of m
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    };
+
+    const startCurrent = `${year}-${String(month).padStart(2, '0')}-01`;
+    const endCurrent = lastDayOf(year, month);
+
+    // Previous month
+    const prevMonth = month === 1 ? 12 : month - 1;
+    const prevYear = month === 1 ? year - 1 : year;
+    const startPrev = `${prevYear}-${String(prevMonth).padStart(2, '0')}-01`;
+    const endPrev = lastDayOf(prevYear, prevMonth);
+
+    // Same month last year
+    const startYoY = `${year - 1}-${String(month).padStart(2, '0')}-01`;
+    const endYoY = lastDayOf(year - 1, month);
+
+    const [current, prevPeriod, lastYear] = await Promise.all([
+      this.getProfitLossReport(startCurrent, endCurrent, branchId),
+      this.getProfitLossReport(startPrev, endPrev, branchId),
+      this.getProfitLossReport(startYoY, endYoY, branchId),
+    ]);
+
+    const pctChange = (curr: number, prev: number) =>
+      prev === 0
+        ? curr > 0
+          ? 100
+          : 0
+        : Math.round(((curr - prev) / Math.abs(prev)) * 10000) / 100;
+
+    return {
+      current,
+      previousMonth: prevPeriod,
+      lastYear,
+      momChange: {
+        revenue: pctChange(current.revenue.totalRevenue, prevPeriod.revenue.totalRevenue),
+        grossProfit: pctChange(current.grossProfit, prevPeriod.grossProfit),
+        netProfit: pctChange(current.netProfit, prevPeriod.netProfit),
+      },
+      yoyChange: {
+        revenue: pctChange(current.revenue.totalRevenue, lastYear.revenue.totalRevenue),
+        grossProfit: pctChange(current.grossProfit, lastYear.grossProfit),
+        netProfit: pctChange(current.netProfit, lastYear.netProfit),
+      },
+    };
+  }
+
+  // ─── W-013: Period Closing Lock ───────────────────────────────────────────────
+
+  /** Check if a date falls in a closed accounting period */
+  private async validatePeriodOpen(date: Date): Promise<void> {
+    const config = await this.prisma.systemConfig.findUnique({
+      where: { key: 'accounting_period_closed_until' },
+    });
+    if (config) {
+      const closedUntil = new Date(config.value);
+      if (date <= closedUntil) {
+        throw new BadRequestException(
+          `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (ปิดถึง ${closedUntil.toISOString().split('T')[0]})`,
+        );
+      }
+    }
+  }
+
+  async closeAccountingPeriod(closedUntil: string) {
+    await this.prisma.systemConfig.upsert({
+      where: { key: 'accounting_period_closed_until' },
+      update: { value: closedUntil },
+      create: { key: 'accounting_period_closed_until', value: closedUntil },
+    });
+    return { closedUntil };
+  }
+
+  async getAccountingPeriodStatus() {
+    const config = await this.prisma.systemConfig.findUnique({
+      where: { key: 'accounting_period_closed_until' },
+    });
+    return { closedUntil: config?.value || null };
+  }
+
+  // ─── Balance Sheet (derived from existing data, no general ledger) ────────────
+
+  async getBalanceSheet(asOfDate: string, branchId?: string) {
+    const endDate = new Date(asOfDate);
+    endDate.setHours(23, 59, 59, 999);
+    const branchFilter = branchId ? { branchId } : {};
+
+    // ── ASSETS ──
+
+    // 1110 Cash & Bank: Derived from cash inflows minus cash outflows
+    const [paymentsReceived, cashSalesTotal, downPaymentsTotal, financeReceivedTotal, expensesPaid] =
+      await Promise.all([
+        // Installment payments received
+        this.prisma.payment.aggregate({
+          where: {
+            status: 'PAID',
+            paidDate: { lte: endDate },
+            contract: { deletedAt: null, ...branchFilter },
+          },
+          _sum: { amountPaid: true },
+        }),
+        // Cash sales revenue
+        this.prisma.sale.aggregate({
+          where: { saleType: 'CASH', createdAt: { lte: endDate }, deletedAt: null, ...branchFilter },
+          _sum: { netAmount: true },
+        }),
+        // Down payments from installment & external finance sales
+        this.prisma.sale.aggregate({
+          where: {
+            saleType: { in: ['INSTALLMENT', 'EXTERNAL_FINANCE'] },
+            createdAt: { lte: endDate },
+            deletedAt: null,
+            ...branchFilter,
+          },
+          _sum: { downPaymentAmount: true },
+        }),
+        // Finance company payments received
+        this.prisma.financeReceivable.aggregate({
+          where: { status: 'RECEIVED', receivedDate: { lte: endDate }, deletedAt: null, ...branchFilter },
+          _sum: { receivedAmount: true },
+        }),
+        // Expenses paid (cash outflow)
+        this.prisma.expense.aggregate({
+          where: { status: 'PAID', paymentDate: { lte: endDate }, deletedAt: null, ...branchFilter },
+          _sum: { totalAmount: true },
+        }),
+      ]);
+
+    // Purchase orders paid (cash outflow for inventory)
+    const purchaseOrdersPaid = await this.prisma.purchaseOrder.aggregate({
+      where: {
+        paymentStatus: 'FULLY_PAID',
+        orderDate: { lte: endDate },
+        deletedAt: null,
+      },
+      _sum: { paidAmount: true },
+    });
+
+    const totalCashInflows =
+      Number(paymentsReceived._sum.amountPaid || 0) +
+      Number(cashSalesTotal._sum.netAmount || 0) +
+      Number(downPaymentsTotal._sum.downPaymentAmount || 0) +
+      Number(financeReceivedTotal._sum.receivedAmount || 0);
+    const totalCashOutflows =
+      Number(expensesPaid._sum.totalAmount || 0) +
+      Number(purchaseOrdersPaid._sum.paidAmount || 0);
+    const cashAndBank = totalCashInflows - totalCashOutflows;
+
+    // 1220 Hire-purchase receivables: Outstanding installments on active contracts
+    const [hpReceivables, provisions, pendingFinance, inventory, creditBalances, whtPayable, accruedExpenses] =
+      await Promise.all([
+        // Unpaid/partially-paid installments on active contracts
+        this.prisma.payment.aggregate({
+          where: {
+            status: { in: ['PENDING', 'PARTIALLY_PAID'] },
+            contract: {
+              deletedAt: null,
+              status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT'] },
+              ...branchFilter,
+            },
+          },
+          _sum: { amountDue: true, amountPaid: true },
+        }),
+        // 1229 Allowance for doubtful accounts
+        this.prisma.badDebtProvision.aggregate({
+          where: { status: 'ACTIVE' },
+          _sum: { provisionAmount: true },
+        }),
+        // 1230 Finance receivables (pending from external finance companies)
+        this.prisma.financeReceivable.aggregate({
+          where: { status: 'PENDING', deletedAt: null, ...branchFilter },
+          _sum: { expectedAmount: true },
+        }),
+        // 1300 Inventory at cost
+        this.prisma.product.aggregate({
+          where: { status: 'IN_STOCK', deletedAt: null, ...(branchId ? { branchId } : {}) },
+          _sum: { costPrice: true },
+          _count: true,
+        }),
+        // 2510 Customer credit balances (overpayments held)
+        this.prisma.contract.aggregate({
+          where: { creditBalance: { gt: 0 }, deletedAt: null, ...branchFilter },
+          _sum: { creditBalance: true },
+        }),
+        // 2300 WHT payable (from expenses with withholding tax)
+        this.prisma.expense.aggregate({
+          where: {
+            status: { in: ['APPROVED', 'PAID'] },
+            deletedAt: null,
+            withholdingTax: { gt: 0 },
+            expenseDate: { lte: endDate },
+            ...branchFilter,
+          },
+          _sum: { withholdingTax: true },
+        }),
+        // 2600 Accrued expenses (approved but not yet paid)
+        this.prisma.expense.aggregate({
+          where: { status: 'APPROVED', deletedAt: null, expenseDate: { lte: endDate }, ...branchFilter },
+          _sum: { totalAmount: true },
+        }),
+      ]);
+
+    const grossReceivables = Number(hpReceivables._sum.amountDue || 0);
+    const paidOnReceivables = Number(hpReceivables._sum.amountPaid || 0);
+    const netReceivables = grossReceivables - paidOnReceivables;
+    const allowanceForDoubtful = Number(provisions._sum.provisionAmount || 0);
+    const financeReceivables = Number(pendingFinance._sum.expectedAmount || 0);
+    const inventoryValue = Number(inventory._sum.costPrice || 0);
+    const inventoryCount = inventory._count || 0;
+
+    const totalCurrentAssets =
+      cashAndBank + netReceivables - allowanceForDoubtful + financeReceivables + inventoryValue;
+    const totalAssets = totalCurrentAssets; // No fixed assets tracked in system
+
+    // ── LIABILITIES ──
+
+    const customerCreditBalances = Number(creditBalances._sum.creditBalance || 0);
+    const totalWhtPayable = Number(whtPayable._sum.withholdingTax || 0);
+    const totalAccrued = Number(accruedExpenses._sum.totalAmount || 0);
+
+    const totalLiabilities = customerCreditBalances + totalWhtPayable + totalAccrued;
+
+    // ── EQUITY ──
+    // Retained earnings = Total Assets - Total Liabilities (balancing figure)
+    // In a full accounting system this would come from accumulated P&L; here we derive it.
+    const retainedEarnings = totalAssets - totalLiabilities;
+
+    return {
+      asOfDate,
+      assets: {
+        currentAssets: {
+          cashAndBank,
+          hirePurchaseReceivables: {
+            gross: grossReceivables,
+            paid: paidOnReceivables,
+            net: netReceivables,
+            allowanceForDoubtful: -allowanceForDoubtful,
+            netAfterAllowance: netReceivables - allowanceForDoubtful,
+          },
+          financeReceivables,
+          inventory: { value: inventoryValue, count: inventoryCount },
+          totalCurrentAssets,
+        },
+        totalAssets,
+      },
+      liabilities: {
+        currentLiabilities: {
+          customerCreditBalances,
+          withholdingTaxPayable: totalWhtPayable,
+          accruedExpenses: totalAccrued,
+        },
+        totalLiabilities,
+      },
+      equity: {
+        retainedEarnings,
+        totalEquity: retainedEarnings,
+      },
+      // Note: Balance Sheet is derived (not from general ledger). Retained earnings is
+      // calculated as Assets - Liabilities, so it always balances by definition.
+      // When a general ledger is implemented, this should verify A = L + E independently.
+    };
+  }
+
+  // ─── Cash Flow Statement (derived from existing data, no general ledger) ──────
+
+  async getCashFlowStatement(startDate: string, endDate: string, branchId?: string) {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    end.setHours(23, 59, 59, 999);
+    const dateRange = { gte: start, lte: end };
+    const branchFilter = branchId ? { branchId } : {};
+
+    // ── OPERATING ACTIVITIES ──
+
+    const [cashSales, downPayments, installmentPayments, financeReceived, expensesPaid] =
+      await Promise.all([
+        // Cash received from direct cash sales
+        this.prisma.sale.aggregate({
+          where: { saleType: 'CASH', createdAt: dateRange, deletedAt: null, ...branchFilter },
+          _sum: { netAmount: true },
+        }),
+        // Cash received from down payments (installment + external finance)
+        this.prisma.sale.aggregate({
+          where: {
+            saleType: { in: ['INSTALLMENT', 'EXTERNAL_FINANCE'] },
+            createdAt: dateRange,
+            deletedAt: null,
+            ...branchFilter,
+          },
+          _sum: { downPaymentAmount: true },
+        }),
+        // Cash received from installment payments
+        this.prisma.payment.aggregate({
+          where: {
+            status: 'PAID',
+            paidDate: dateRange,
+            contract: { deletedAt: null, ...branchFilter },
+          },
+          _sum: { amountPaid: true, lateFee: true },
+        }),
+        // Cash received from finance companies
+        this.prisma.financeReceivable.aggregate({
+          where: { status: 'RECEIVED', receivedDate: dateRange, deletedAt: null, ...branchFilter },
+          _sum: { receivedAmount: true },
+        }),
+        // Cash paid for expenses
+        this.prisma.expense.aggregate({
+          where: { status: 'PAID', paymentDate: dateRange, deletedAt: null, ...branchFilter },
+          _sum: { totalAmount: true },
+        }),
+      ]);
+
+    // Cash paid for inventory (purchase orders paid in the period)
+    const purchaseOrdersPaid = await this.prisma.purchaseOrder.aggregate({
+      where: {
+        paymentStatus: { in: ['FULLY_PAID', 'DEPOSIT_PAID', 'PARTIALLY_PAID'] },
+        orderDate: dateRange,
+        deletedAt: null,
+      },
+      _sum: { paidAmount: true },
+    });
+
+    const cashFromSales = Number(cashSales._sum.netAmount || 0);
+    const cashFromDownPayments = Number(downPayments._sum.downPaymentAmount || 0);
+    const cashFromInstallments = Number(installmentPayments._sum.amountPaid || 0);
+    const cashFromLateFees = Number(installmentPayments._sum.lateFee || 0);
+    const cashFromFinanceCompanies = Number(financeReceived._sum.receivedAmount || 0);
+
+    const cashFromCustomers =
+      cashFromSales + cashFromDownPayments + cashFromInstallments + cashFromLateFees + cashFromFinanceCompanies;
+
+    const cashPaidForExpenses = Number(expensesPaid._sum.totalAmount || 0);
+    const cashPaidForInventory = Number(purchaseOrdersPaid._sum.paidAmount || 0);
+
+    const netOperating = cashFromCustomers - cashPaidForExpenses - cashPaidForInventory;
+
+    // No investing or financing activities are tracked separately in this system
+    const netCashChange = netOperating;
+
+    return {
+      period: { start: startDate, end: endDate },
+      operatingActivities: {
+        cashFromCustomers,
+        cashFromSales,
+        cashFromDownPayments,
+        cashFromInstallments,
+        cashFromLateFees,
+        cashFromFinanceCompanies,
+        cashPaidForExpenses: -cashPaidForExpenses,
+        cashPaidForInventory: -cashPaidForInventory,
+        netOperatingCashFlow: netOperating,
+      },
+      netCashChange,
+    };
   }
 }

--- a/apps/api/src/modules/accounting/bad-debt.service.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.ts
@@ -1,0 +1,248 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+const DEFAULT_PROVISION_RATES: Record<string, number> = {
+  '1-30': 0.02,
+  '31-60': 0.10,
+  '61-90': 0.25,
+  '91-180': 0.50,
+  '181-360': 0.75,
+  '360+': 1.00,
+};
+
+@Injectable()
+export class BadDebtService {
+  constructor(private prisma: PrismaService) {}
+
+  /** Load provision rates from system config or use defaults */
+  private async getProvisionRates(): Promise<Record<string, number>> {
+    const config = await this.prisma.systemConfig.findUnique({
+      where: { key: 'bad_debt_provision_rates' },
+    });
+    if (config) {
+      try {
+        return JSON.parse(config.value);
+      } catch {
+        /* fall through to defaults */
+      }
+    }
+    return DEFAULT_PROVISION_RATES;
+  }
+
+  /** Determine aging bucket for a given number of overdue days */
+  private getAgingBucket(daysOverdue: number): string {
+    if (daysOverdue <= 30) return '1-30';
+    if (daysOverdue <= 60) return '31-60';
+    if (daysOverdue <= 90) return '61-90';
+    if (daysOverdue <= 180) return '91-180';
+    if (daysOverdue <= 360) return '181-360';
+    return '360+';
+  }
+
+  /**
+   * Calculate provisions for all overdue contracts.
+   * Reverses existing ACTIVE provisions and creates fresh ones.
+   */
+  async calculateProvisions(calculatedById: string, branchId?: string): Promise<{
+    created: number;
+    totalProvision: number;
+    byBucket: Record<string, { count: number; amount: number }>;
+  }> {
+    const rates = await this.getProvisionRates();
+    const now = new Date();
+    const branchFilter = branchId ? { branchId } : {};
+
+    // Find all overdue payments from active contracts
+    const overduePayments = await this.prisma.payment.findMany({
+      where: {
+        status: { in: ['PENDING', 'PARTIALLY_PAID'] },
+        dueDate: { lt: now },
+        contract: {
+          deletedAt: null,
+          status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT'] },
+          ...branchFilter,
+        },
+      },
+      include: {
+        contract: { select: { id: true, status: true } },
+      },
+      orderBy: { dueDate: 'asc' },
+    });
+
+    // Group by contract and calculate total outstanding per contract
+    const contractOutstanding = new Map<
+      string,
+      { amount: number; oldestDueDate: Date }
+    >();
+    for (const p of overduePayments) {
+      const existing = contractOutstanding.get(p.contract.id);
+      const remaining = Number(p.amountDue) - Number(p.amountPaid);
+      if (existing) {
+        existing.amount += remaining;
+      } else {
+        contractOutstanding.set(p.contract.id, {
+          amount: remaining,
+          oldestDueDate: p.dueDate,
+        });
+      }
+    }
+
+    // Reverse existing ACTIVE provisions only for contracts in scope
+    const contractIdsInScope = [...contractOutstanding.keys()];
+    if (contractIdsInScope.length > 0) {
+      await this.prisma.badDebtProvision.updateMany({
+        where: { status: 'ACTIVE', contractId: { in: contractIdsInScope } },
+        data: { status: 'REVERSED' },
+      });
+    }
+
+    // Create new provisions
+    const byBucket: Record<string, { count: number; amount: number }> = {};
+    const provisions: Array<{
+      contractId: string;
+      provisionDate: Date;
+      agingBucket: string;
+      daysOverdue: number;
+      outstandingAmount: number;
+      provisionRate: number;
+      provisionAmount: number;
+    }> = [];
+
+    for (const [contractId, data] of contractOutstanding) {
+      const daysOverdue = Math.floor(
+        (now.getTime() - data.oldestDueDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      const bucket = this.getAgingBucket(daysOverdue);
+      const rate = rates[bucket] || 0;
+      const provisionAmount = Math.round(data.amount * rate * 100) / 100;
+
+      provisions.push({
+        contractId,
+        provisionDate: now,
+        agingBucket: bucket,
+        daysOverdue,
+        outstandingAmount: data.amount,
+        provisionRate: rate,
+        provisionAmount,
+      });
+
+      if (!byBucket[bucket]) byBucket[bucket] = { count: 0, amount: 0 };
+      byBucket[bucket].count++;
+      byBucket[bucket].amount += provisionAmount;
+    }
+
+    if (provisions.length > 0) {
+      await this.prisma.badDebtProvision.createMany({ data: provisions });
+    }
+
+    const totalProvision = provisions.reduce((sum, p) => sum + p.provisionAmount, 0);
+    return { created: provisions.length, totalProvision, byBucket };
+  }
+
+  /**
+   * Get provision summary (current ACTIVE provisions)
+   */
+  async getProvisionSummary() {
+    const provisions = await this.prisma.badDebtProvision.findMany({
+      where: { status: 'ACTIVE' },
+      include: {
+        contract: {
+          select: {
+            contractNumber: true,
+            customerId: true,
+            customer: { select: { name: true } },
+          },
+        },
+      },
+      orderBy: { daysOverdue: 'desc' },
+    });
+
+    const summary = {
+      totalOutstanding: 0,
+      totalProvision: 0,
+      byBucket: {} as Record<
+        string,
+        { count: number; outstanding: number; provision: number; rate: number }
+      >,
+      details: provisions.map((p) => ({
+        contractId: p.contractId,
+        contractNumber: p.contract.contractNumber,
+        customerName: p.contract.customer?.name,
+        agingBucket: p.agingBucket,
+        daysOverdue: p.daysOverdue,
+        outstandingAmount: Number(p.outstandingAmount),
+        provisionRate: Number(p.provisionRate),
+        provisionAmount: Number(p.provisionAmount),
+      })),
+    };
+
+    for (const p of provisions) {
+      summary.totalOutstanding += Number(p.outstandingAmount);
+      summary.totalProvision += Number(p.provisionAmount);
+      const bucket = p.agingBucket;
+      if (!summary.byBucket[bucket]) {
+        summary.byBucket[bucket] = {
+          count: 0,
+          outstanding: 0,
+          provision: 0,
+          rate: Number(p.provisionRate),
+        };
+      }
+      summary.byBucket[bucket].count++;
+      summary.byBucket[bucket].outstanding += Number(p.outstandingAmount);
+      summary.byBucket[bucket].provision += Number(p.provisionAmount);
+    }
+
+    return summary;
+  }
+
+  /**
+   * Write off a bad debt (ตัดหนี้สูญ)
+   * Requires OWNER approval — writer and approver must be different persons
+   */
+  async writeOffBadDebt(
+    contractId: string,
+    writtenOffById: string,
+    approvedById: string,
+    notes?: string,
+  ) {
+    if (writtenOffById === approvedById) {
+      throw new BadRequestException('ผู้ตัดหนี้สูญต้องไม่ใช่ผู้อนุมัติ');
+    }
+
+    const contract = await this.prisma.contract.findFirst({
+      where: { id: contractId, deletedAt: null },
+    });
+    if (!contract) throw new NotFoundException('ไม่พบสัญญา');
+    if (contract.status === 'CLOSED_BAD_DEBT') {
+      throw new BadRequestException('สัญญานี้ถูกตัดหนี้สูญไปแล้ว');
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      // Update contract status to CLOSED_BAD_DEBT
+      await tx.contract.update({
+        where: { id: contractId },
+        data: { status: 'CLOSED_BAD_DEBT' },
+      });
+
+      // Update active provisions to WRITTEN_OFF
+      await tx.badDebtProvision.updateMany({
+        where: { contractId, status: 'ACTIVE' },
+        data: {
+          status: 'WRITTEN_OFF',
+          writtenOffAt: new Date(),
+          writtenOffById,
+          approvedById,
+          approvedAt: new Date(),
+          notes,
+        },
+      });
+
+      return { contractId, status: 'CLOSED_BAD_DEBT', writtenOffAt: new Date() };
+    });
+  }
+}

--- a/apps/api/src/modules/accounting/dto/expense.dto.ts
+++ b/apps/api/src/modules/accounting/dto/expense.dto.ts
@@ -51,6 +51,16 @@ export class CreateExpenseDto {
   @Min(0)
   withholdingTax?: number;
 
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  whtRate?: number; // อัตราภาษีหัก ณ ที่จ่าย เช่น 0.01, 0.02, 0.03, 0.05
+
+  @IsOptional()
+  @IsString()
+  whtIncomeType?: string; // ประเภทเงินได้ เช่น '40(2)', '40(5)', '40(8)'
+
   @IsDateString()
   expenseDate: string;
 

--- a/apps/api/src/modules/audit/audit.interceptor.ts
+++ b/apps/api/src/modules/audit/audit.interceptor.ts
@@ -85,14 +85,16 @@ export class AuditInterceptor implements NestInterceptor {
     const path = url.replace(/^\/api\//, '').split('?')[0];
     const parts = path.split('/').filter(Boolean);
 
-    // Find the last non-UUID segment for nested resources
-    // e.g. /contracts/uuid/payments → "payments"
-    // e.g. /products/uuid → "products"
-    // e.g. /auth/login → "auth"
+    // R-013: Extract the FIRST meaningful segment (primary entity) for nested URLs.
+    // For /contracts/uuid/payments/uuid → "contracts" (the primary resource)
+    // For /products/uuid → "products"
+    // For /auth/login → "auth"
+    // Previously walked backwards which returned "payments" for nested URLs,
+    // losing the primary resource context in audit logs.
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-    // Walk backwards to find the last meaningful entity name
-    for (let i = parts.length - 1; i >= 0; i--) {
+    // Walk forward to find the first non-UUID segment (the primary entity)
+    for (let i = 0; i < parts.length; i++) {
       if (!uuidRegex.test(parts[i])) {
         return parts[i];
       }

--- a/apps/api/src/modules/inter-company/inter-company.controller.ts
+++ b/apps/api/src/modules/inter-company/inter-company.controller.ts
@@ -59,6 +59,12 @@ export class InterCompanyController {
     return this.interCompanyService.createFromSale(dto);
   }
 
+  @Patch(':id/confirm')
+  @Roles('OWNER', 'ACCOUNTANT')
+  confirm(@Param('id') id: string) {
+    return this.interCompanyService.confirmTransaction(id);
+  }
+
   @Patch(':id/reconcile')
   @Roles('OWNER', 'ACCOUNTANT')
   reconcile(@Param('id') id: string) {

--- a/apps/api/src/modules/inter-company/inter-company.service.ts
+++ b/apps/api/src/modules/inter-company/inter-company.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateInterCompanyTransactionDto } from './dto/inter-company.dto';
 import { Prisma, InterCompanyTransactionStatus } from '@prisma/client';
@@ -60,6 +60,9 @@ export class InterCompanyService {
       financeProfit: number;
     },
   ) {
+    // W-009: Double-entry description for both entities
+    const note = `SHOP: Debit ลูกหนี้เช่าซื้อ ${data.principal}, Credit รายได้จากการขาย ${data.principal + data.commission}; FINANCE: Debit ลูกหนี้เช่าซื้อ ${data.principal + data.interestTotal}, Credit เจ้าหนี้ SHOP ${data.principal + data.commission}`;
+
     return tx.interCompanyTransaction.create({
       data: {
         saleId: data.saleId,
@@ -80,6 +83,7 @@ export class InterCompanyService {
         sellingPrice: data.sellingPrice,
         shopProfit: data.shopProfit,
         financeProfit: data.financeProfit,
+        note,
       },
     });
   }
@@ -154,13 +158,33 @@ export class InterCompanyService {
   }
 
   /**
-   * Reconcile a transaction (mark as confirmed after verification)
+   * W-010: Confirm a PENDING transaction (PENDING → CONFIRMED)
+   */
+  async confirmTransaction(id: string) {
+    const record = await this.prisma.interCompanyTransaction.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!record) throw new NotFoundException('ไม่พบรายการ');
+    if (record.status !== 'PENDING') {
+      throw new BadRequestException('รายการต้องอยู่ในสถานะ PENDING เท่านั้น');
+    }
+    return this.prisma.interCompanyTransaction.update({
+      where: { id },
+      data: { status: 'CONFIRMED' as InterCompanyTransactionStatus },
+    });
+  }
+
+  /**
+   * Reconcile a transaction (CONFIRMED → RECONCILED)
    */
   async reconcile(id: string) {
     const record = await this.prisma.interCompanyTransaction.findFirst({
       where: { id, deletedAt: null },
     });
     if (!record) throw new NotFoundException('ไม่พบรายการ');
+    if (record.status !== 'CONFIRMED') {
+      throw new BadRequestException('รายการต้อง CONFIRMED ก่อนจึงจะ reconcile ได้');
+    }
 
     return this.prisma.interCompanyTransaction.update({
       where: { id },

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -57,16 +57,23 @@ export class PaymentsService {
     // Use serializable transaction to prevent concurrent duplicate payments
     const updated = await this.prisma.$transaction(async (tx) => {
       // Idempotency: reject duplicate transactionRef INSIDE transaction
-      // to prevent race condition where two concurrent requests both pass the check
+      // to prevent race condition where two concurrent requests both pass the check.
+      // R-012: Use exact ref: tag match to avoid false positives from substring matching.
+      // We search for the exact tag "ref:<value>" and verify it matches fully,
+      // preventing e.g. "ref:ABC" from matching "ref:ABC123".
       if (transactionRef) {
-        const existing = await tx.payment.findFirst({
+        const candidates = await tx.payment.findMany({
           where: {
             contractId,
             deletedAt: null,
             notes: { contains: `ref:${transactionRef}` },
             status: { in: ['PAID', 'PARTIALLY_PAID'] },
           },
+          select: { id: true, notes: true },
         });
+        // Verify exact match: the ref tag must be followed by end-of-string, ' |', or whitespace
+        const exactRefPattern = new RegExp(`ref:${transactionRef.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\\s*\\||\\s*$)`);
+        const existing = candidates.find(c => c.notes && exactRefPattern.test(c.notes));
         if (existing) {
           throw new BadRequestException(`ธุรกรรมนี้ถูกบันทึกแล้ว (อ้างอิง: ${transactionRef})`);
         }

--- a/apps/api/src/modules/receipts/dto/void-receipt.dto.ts
+++ b/apps/api/src/modules/receipts/dto/void-receipt.dto.ts
@@ -1,6 +1,10 @@
-import { IsString } from 'class-validator';
+import { IsString, IsOptional } from 'class-validator';
 
 export class VoidReceiptDto {
   @IsString({ message: 'กรุณาระบุเหตุผลในการยกเลิก' })
   reason: string;
+
+  @IsOptional()
+  @IsString()
+  approvedById?: string; // ผู้อนุมัติการยกเลิก (���้าไม่ระบุ = ผู้ร้องขอเอง สำหรับ OWNER)
 }

--- a/apps/api/src/modules/receipts/receipts.controller.ts
+++ b/apps/api/src/modules/receipts/receipts.controller.ts
@@ -62,7 +62,7 @@ export class ReceiptsController {
     @Body() dto: VoidReceiptDto,
     @CurrentUser() user: { id: string },
   ) {
-    return this.receiptsService.voidReceipt(id, dto.reason, user.id);
+    return this.receiptsService.voidReceipt(id, dto.reason, user.id, dto.approvedById || user.id);
   }
 
   @Get(':id/pdf')

--- a/apps/api/src/modules/receipts/receipts.service.ts
+++ b/apps/api/src/modules/receipts/receipts.service.ts
@@ -154,7 +154,7 @@ export class ReceiptsService {
   }) {
     const page = filters.page || 1;
     const limit = Math.min(filters.limit || 20, 200);
-    const where: Prisma.ReceiptWhereInput = { deletedAt: null };
+    const where: Prisma.ReceiptWhereInput = { deletedAt: null, isVoided: false };
 
     if (filters.search) {
       where.OR = [
@@ -227,7 +227,7 @@ export class ReceiptsService {
   /** Get receipts for a contract */
   async getContractReceipts(contractId: string) {
     return this.prisma.receipt.findMany({
-      where: { contractId, deletedAt: null },
+      where: { contractId, deletedAt: null, isVoided: false },
       orderBy: { createdAt: 'desc' },
     });
   }
@@ -330,11 +330,22 @@ export class ReceiptsService {
    * Void a receipt (ถ้าผิด → ออกใบลดหนี้/ใบแก้ไขแทน)
    * ใบเสร็จที่ออกแล้วห้ามแก้ไข/ลบ
    */
-  async voidReceipt(id: string, reason: string, issuedById: string) {
+  async voidReceipt(id: string, reason: string, issuedById: string, approvedById: string) {
+    if (!reason?.trim()) {
+      throw new BadRequestException('กรุณาระบุเหตุผลในการยกเลิก');
+    }
     return this.prisma.$transaction(async (tx) => {
       const receipt = await tx.receipt.findUnique({ where: { id } });
       if (!receipt || receipt.deletedAt) throw new NotFoundException('ไม่พบใบเสร็จ');
       if (receipt.isVoided) throw new BadRequestException('ใบเสร็จนี้ถูกยกเลิกแล้ว');
+
+      // W-006: Credit Note 30-day time limit
+      const daysSinceIssue = Math.floor(
+        (Date.now() - receipt.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      if (daysSinceIssue > 30) {
+        throw new BadRequestException('ไม่สามารถยกเลิกใบเสร็จที่ออกเกิน 30 วัน');
+      }
 
       // Generate credit note number inside transaction (uses FOR UPDATE lock)
       const creditNoteNumber = await this.generateReceiptNumber(tx);
@@ -355,10 +366,15 @@ export class ReceiptsService {
         },
       });
 
-      // Mark original as voided
+      // Mark original as voided with approval trail
       await tx.receipt.update({
         where: { id },
-        data: { isVoided: true, voidReason: reason },
+        data: {
+          isVoided: true,
+          voidReason: reason.trim(),
+          voidApprovedById: approvedById,
+          voidApprovedAt: new Date(),
+        },
       });
 
       return { voidedReceipt: receipt, creditNote };

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -55,6 +55,46 @@ export class ReportsController {
     return this.reportsService.getProfitLossReport(startDate, endDate, effectiveBranch);
   }
 
+  @Get('comparative-pl')
+  @Roles('OWNER', 'ACCOUNTANT')
+  getComparativePL(
+    @Query('year') year: string,
+    @Query('month') month: string,
+    @CurrentUser() user: { role: string; branchId: string | null },
+    @Query('branchId') branchId?: string,
+  ) {
+    const effectiveBranch = user.role === 'BRANCH_MANAGER' ? user.branchId || undefined : branchId;
+    return this.reportsService.getComparativePL(
+      parseInt(year) || new Date().getFullYear(),
+      parseInt(month) || new Date().getMonth() + 1,
+      effectiveBranch,
+    );
+  }
+
+  @Get('balance-sheet')
+  @Roles('OWNER', 'ACCOUNTANT')
+  getBalanceSheet(
+    @Query('asOfDate') asOfDate?: string,
+    @Query('branchId') branchId?: string,
+  ) {
+    return this.reportsService.getBalanceSheet(
+      asOfDate || new Date().toISOString().split('T')[0],
+      branchId,
+    );
+  }
+
+  @Get('cash-flow')
+  @Roles('OWNER', 'ACCOUNTANT')
+  getCashFlowStatement(
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+    @CurrentUser() user: { role: string; branchId: string | null },
+    @Query('branchId') branchId?: string,
+  ) {
+    const effectiveBranch = user.role === 'BRANCH_MANAGER' ? user.branchId || undefined : branchId;
+    return this.reportsService.getCashFlowStatement(startDate, endDate, effectiveBranch);
+  }
+
   @Get('high-risk')
   getHighRisk(
     @CurrentUser() user: { role: string; branchId: string | null },
@@ -139,6 +179,22 @@ export class ReportsController {
     @Query('entity') entity?: string,
   ) {
     return this.reportsService.getEntityProfitReport(startDate, endDate, branchId, entity);
+  }
+
+  @Get('quarterly')
+  @Roles('OWNER', 'ACCOUNTANT', 'BRANCH_MANAGER')
+  getQuarterly(
+    @Query('year') year: string,
+    @Query('quarter') quarter: string,
+    @CurrentUser() user: { role: string; branchId: string | null },
+    @Query('branchId') branchId?: string,
+  ) {
+    const effectiveBranch = user.role === 'BRANCH_MANAGER' ? user.branchId || undefined : branchId;
+    return this.reportsService.getQuarterlyReport(
+      parseInt(year) || new Date().getFullYear(),
+      parseInt(quarter) || 1,
+      effectiveBranch,
+    );
   }
 
   @Get('export/contracts')

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AccountingService } from '../accounting/accounting.service';
 
@@ -127,6 +127,19 @@ export class ReportsService {
 
   getMonthlyPLSummary(year: number, branchId?: string) {
     return this.accounting.getMonthlyPLSummary(year, branchId);
+  }
+
+  getComparativePL(year: number, month: number, branchId?: string) {
+    return this.accounting.getComparativePL(year, month, branchId);
+  }
+
+  // Balance Sheet & Cash Flow delegated to AccountingService
+  getBalanceSheet(asOfDate: string, branchId?: string) {
+    return this.accounting.getBalanceSheet(asOfDate, branchId);
+  }
+
+  getCashFlowStatement(startDate: string, endDate: string, branchId?: string) {
+    return this.accounting.getCashFlowStatement(startDate, endDate, branchId);
   }
 
   /**
@@ -562,5 +575,20 @@ export class ReportsService {
       },
       details,
     };
+  }
+
+  /**
+   * R-015: Quarterly P&L report aggregation
+   * Calculates start/end dates for the given quarter and delegates to AccountingService.
+   */
+  async getQuarterlyReport(year: number, quarter: number, branchId?: string) {
+    if (quarter < 1 || quarter > 4) {
+      throw new BadRequestException('ไตรมาสต้องอยู่ระหว่าง 1-4');
+    }
+    const startMonth = (quarter - 1) * 3 + 1;
+    const endMonth = startMonth + 2;
+    const startDate = `${year}-${String(startMonth).padStart(2, '0')}-01`;
+    const endDate = new Date(year, endMonth, 0).toISOString().split('T')[0];
+    return this.accounting.getProfitLossReport(startDate, endDate, branchId);
   }
 }

--- a/apps/api/src/modules/repossessions/repossessions.service.ts
+++ b/apps/api/src/modules/repossessions/repossessions.service.ts
@@ -224,9 +224,17 @@ export class RepossessionsService {
       const newProductStatus = productStatusMap[dto.status];
       if (newProductStatus) {
         return this.prisma.$transaction(async (tx) => {
+          const productUpdateData: Record<string, unknown> = { status: newProductStatus };
+          // R-007: Adjust costPrice to appraised/fair value per TAS 2 when moving to REFURBISHED
+          if (dto.status === 'READY_FOR_SALE') {
+            const appraisalPrice = dto.resellPrice ?? Number(repo.appraisalPrice || 0);
+            if (appraisalPrice > 0) {
+              productUpdateData.costPrice = appraisalPrice;
+            }
+          }
           await tx.product.update({
             where: { id: repo.product.id },
-            data: { status: newProductStatus },
+            data: productUpdateData,
           });
           return tx.repossession.update({
             where: { id },
@@ -276,10 +284,13 @@ export class RepossessionsService {
         where: { isMainWarehouse: true, isActive: true },
       });
 
+      // R-007: Adjust costPrice to appraised/fair value per TAS 2 when refurbishing
+      const appraisalPrice = Number(repo.appraisalPrice || 0);
       await tx.product.update({
         where: { id: repo.product.id },
         data: {
           status: 'REFURBISHED',
+          costPrice: appraisalPrice || resellPrice, // Adjust cost to appraised/fair value per TAS 2
           stockInDate: new Date(),
           ...(mainWarehouse ? { branchId: mainWarehouse.id } : {}),
         },

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -208,6 +208,7 @@ export class SalesService {
       await this.markBundleProductsSold(tx, dto.bundleProductIds || []);
       const saleNumber = await generateSaleNumber(tx);
 
+      // Tax point (จุดความรับผิดทางภาษี): วันส่งมอบสินค้า = วันที่สร้างรายการขาย
       const sale = await tx.sale.create({
         data: {
           saleNumber,
@@ -231,6 +232,11 @@ export class SalesService {
         where: { id: dto.productId },
         data: { status: 'SOLD_CASH' },
       });
+
+      // W-007: COGS tracked via sale.product.costPrice relationship.
+      // P&L report (AccountingService.getProfitLossReport) captures product cost
+      // by joining Sale → Product.costPrice, including bundle products.
+      // TODO: Implement perpetual inventory journal for real-time COGS ledger entries.
 
       return sale;
     }, { isolationLevel: 'Serializable' });
@@ -304,6 +310,7 @@ export class SalesService {
       );
       await tx.payment.createMany({ data: payments });
 
+      // Tax point (จุดความรับผิดทางภาษี): วันส่งมอบสินค้า = วันที่สร้างรายการขาย
       // Create sale record linked to contract
       const sale = await tx.sale.create({
         data: {
@@ -331,6 +338,10 @@ export class SalesService {
         data: { status: 'RESERVED' },
       });
 
+      // W-007: COGS tracked via sale.product.costPrice + InterCompanyTransaction.costPrice.
+      // P&L report captures product cost by joining Sale → Product.costPrice.
+      // TODO: Implement perpetual inventory journal for real-time COGS ledger entries.
+
       // ── Inter-Company Transaction: BESTCHOICE SHOP ↔ BESTCHOICE FINANCE ──
       const costPrice = product ? Number(product.costPrice) : 0;
       const downPaymentNum = dto.downPayment!;
@@ -338,6 +349,9 @@ export class SalesService {
       const shopProfit = downPaymentNum + calc.principal + calc.storeCommission - costPrice;
       // Finance profit = interestTotal - commission (late fees added later)
       const financeProfit = calc.interestTotal - calc.storeCommission;
+
+      // W-009: Double-entry description for both entities
+      const interCompanyNote = `SHOP: Debit ลูกหนี้เช่าซื้อ ${calc.principal}, Credit รายได้จากการขาย ${calc.principal + calc.storeCommission}; FINANCE: Debit ลูกหนี้เช่าซื้อ ${calc.principal + calc.interestTotal}, Credit เจ้าหนี้ SHOP ${calc.principal + calc.storeCommission}`;
 
       await tx.interCompanyTransaction.create({
         data: {
@@ -359,6 +373,7 @@ export class SalesService {
           sellingPrice: netAmount,
           shopProfit,
           financeProfit,
+          note: interCompanyNote,
         },
       });
 
@@ -393,6 +408,7 @@ export class SalesService {
       await this.markBundleProductsSold(tx, dto.bundleProductIds || []);
       const saleNumber = await generateSaleNumber(tx);
 
+      // Tax point (จุดความรับผิดทางภาษี): วันส่งมอบสินค้า = วันที่สร้างรายการขาย
       const sale = await tx.sale.create({
         data: {
           saleNumber,
@@ -420,6 +436,10 @@ export class SalesService {
         where: { id: dto.productId },
         data: { status: 'SOLD_INSTALLMENT' },
       });
+
+      // W-007: COGS tracked via sale.product.costPrice relationship.
+      // P&L report captures product cost by joining Sale → Product.costPrice.
+      // TODO: Implement perpetual inventory journal for real-time COGS ledger entries.
 
       // Auto-create FinanceReceivable to track money from finance company
       const expectedDate = new Date();

--- a/docs/prompts/ACCOUNTING-AUDIT-PROMPT.md
+++ b/docs/prompts/ACCOUNTING-AUDIT-PROMPT.md
@@ -1,0 +1,378 @@
+# Prompt: ตรวจสอบระบบบัญชี BESTCHOICE ตามหลักบัญชีไทย
+
+## บทบาทของคุณ
+
+คุณเป็น **ผู้สอบบัญชีรับอนุญาต (CPA)** ที่เชี่ยวชาญมาตรฐานการบัญชีไทยและกฎหมายภาษีอากร มีหน้าที่ตรวจสอบว่าระบบซอฟต์แวร์บัญชีของ BESTCHOICE (ระบบผ่อนชำระสำหรับร้านมือถือ) ปฏิบัติถูกต้องตามหลักบัญชีไทยหรือไม่
+
+## ข้อมูลพื้นฐานของระบบ
+
+BESTCHOICE เป็นระบบ **Hire-Purchase / ผ่อนชำระ** สำหรับร้านขายมือถือในประเทศไทย ประกอบด้วย:
+- ขายเงินสด (CASH), ขายผ่อน (INSTALLMENT), ขายผ่านไฟแนนซ์ภายนอก (EXTERNAL_FINANCE)
+- สัญญาผ่อนชำระ 6-12 เดือน ดอกเบี้ยแบบ flat rate
+- บัญชีระหว่างกัน 2 นิติบุคคล: BESTCHOICE SHOP (ขายสินค้า) และ BESTCHOICE FINANCE (จัดไฟแนนซ์)
+- ระบบค่าใช้จ่ายพร้อม workflow อนุมัติ
+- รายงาน P&L, Aging Report, Entity Profit
+
+### Tech Stack
+- Backend: NestJS + Prisma + PostgreSQL
+- Frontend: React + TypeScript
+- เงิน: ใช้ Decimal(12,2) ทุก field
+
+---
+
+## หมวดการตรวจสอบ
+
+### หมวดที่ 1: ผังบัญชี (Chart of Accounts)
+
+**มาตรฐานอ้างอิง:** กรมพัฒนาธุรกิจการค้า, มาตรฐานผังบัญชี สำหรับ SMEs
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/accounting/accounting.service.ts` — CATEGORY_ACCOUNT_MAP, CATEGORY_CODE_MAP
+
+**Checklist:**
+- [ ] ผังบัญชีครบ 5 หมวด: สินทรัพย์ (1xxx), หนี้สิน (2xxx), ส่วนของเจ้าของ (3xxx), รายได้ (4xxx), ค่าใช้จ่าย (5xxx)
+- [ ] รหัสบัญชีค่าใช้จ่าย (5xxx) จัดกลุ่มถูกต้อง: ต้นทุนขาย, ค่าใช้จ่ายในการขาย, ค่าใช้จ่ายบริหาร, ค่าใช้จ่ายอื่น
+- [ ] มีบัญชีสำหรับ: ลูกหนี้การค้า, สินค้าคงเหลือ, ลูกหนี้เช่าซื้อ, รายได้ดอกเบี้ย, รายได้ค่าปรับ, ภาษีซื้อ, ภาษีขาย
+- [ ] รหัสบัญชีไม่ซ้ำซ้อนและเรียงลำดับถูกต้อง
+- [ ] มีบัญชีสำหรับ: ค่าเผื่อหนี้สงสัยจะสูญ, หนี้สูญ, ส่วนลดรับ/จ่าย
+- [ ] บัญชีรายได้แยกประเภท: ขายเงินสด, รายได้ดอกเบี้ยเช่าซื้อ, รายได้ค่าปรับล่าช้า, รายได้ค่านายหน้า
+
+---
+
+### หมวดที่ 2: การรับรู้รายได้ (Revenue Recognition)
+
+**มาตรฐานอ้างอิง:** TFRS 15 (รายได้จากสัญญากับลูกค้า), TAS 18 (รายได้)
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/accounting/accounting.service.ts` — getProfitLossReport()
+- `apps/api/src/modules/reports/reports.service.ts` — getRevenuePLReport()
+- `apps/api/src/modules/sales/sales.service.ts` — createCashSale(), createInstallmentSale()
+- `apps/api/src/modules/contracts/contracts.service.ts` — create()
+
+**Checklist:**
+- [ ] **ขายเงินสด**: รับรู้รายได้ทั้งจำนวนเมื่อส่งมอบสินค้า (ถูกต้องตาม TFRS 15)
+- [ ] **ขายผ่อน (เงินดาวน์)**: รับรู้เงินดาวน์เป็นรายได้ ณ วันขาย
+- [ ] **ขายผ่อน (งวดผ่อน)**: รับรู้รายได้เมื่อได้รับชำระเงินแต่ละงวด — ไม่ใช่รับรู้ทั้งจำนวนล่วงหน้า
+- [ ] **รายได้ดอกเบี้ย**: แยกจากรายได้ขายสินค้า — ตรวจว่ามีการแยก principal กับ interest ในแต่ละงวด
+- [ ] **รายได้ค่าปรับล่าช้า**: รับรู้เมื่อมีสิทธิเรียกเก็บ (วันครบกำหนดผ่านแล้ว)
+- [ ] **รายได้ค่า commission**: รับรู้เมื่อธุรกรรมเสร็จสมบูรณ์
+- [ ] **ไฟแนนซ์ภายนอก**: รับรู้รายได้เมื่อได้รับเงินจากบริษัทไฟแนนซ์ (ไม่ใช่ ณ วันขาย)
+- [ ] P&L Report คำนวณ: รายได้รวม = ขายเงินสด + เงินดาวน์ + งวดผ่อนที่ได้รับ + ดอกเบี้ย + ค่าปรับ + เงินจากไฟแนนซ์
+- [ ] ไม่มีการรับรู้รายได้ซ้ำซ้อน (double counting) ระหว่าง modules
+
+---
+
+### หมวดที่ 3: ภาษีมูลค่าเพิ่ม (VAT)
+
+**มาตรฐานอ้างอิง:** ประมวลรัษฎากร มาตรา 77-90, พ.ร.บ.ภาษีมูลค่าเพิ่ม
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/accounting/accounting.service.ts` — VAT calculation
+- `apps/api/src/modules/interest-config/interest-config.service.ts` — vatPct
+- `apps/api/src/modules/inter-company/inter-company.service.ts` — vatAmount, vatPct
+- `apps/api/prisma/schema.prisma` — Expense model (vatAmount field)
+
+**Checklist:**
+- [ ] VAT rate = 7% (ตรงกับอัตราปัจจุบัน)
+- [ ] **ภาษีขาย (Output VAT)**: คำนวณจากราคาขายสินค้า (ไม่ใช่จากดอกเบี้ย — ดอกเบี้ยเช่าซื้อได้รับยกเว้น VAT ตามมาตรา 81(1)(ช))
+- [ ] **ภาษีซื้อ (Input VAT)**: บันทึกจากใบกำกับภาษีของค่าใช้จ่าย
+- [ ] VAT คำนวณบน base amount ที่ถูกต้อง: `vatAmount = baseAmount × 7/107` (กรณีราคารวม VAT) หรือ `baseAmount × 0.07` (กรณีราคาไม่รวม VAT)
+- [ ] มีการแยก: ราคาก่อน VAT, จำนวน VAT, ราคารวม VAT ในทุก transaction
+- [ ] Expense model มี field vatAmount — ตรวจว่าคำนวณถูกทุกกรณี
+- [ ] Inter-company transactions คำนวณ VAT ถูกต้อง
+- [ ] ระบบรองรับกรณียกเว้น VAT (เช่น ดอกเบี้ยเช่าซื้อ)
+- [ ] **จุดความรับผิดทางภาษี (Tax Point)**: ขายสินค้า = วันส่งมอบ, บริการ = วันรับชำระ
+
+---
+
+### หมวดที่ 4: ภาษีหัก ณ ที่จ่าย (Withholding Tax)
+
+**มาตรฐานอ้างอิง:** ประมวลรัษฎากร มาตรา 3 เตรส, 50, 69 ทวิ
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/accounting/accounting.service.ts` — withholdingTax handling
+- `apps/api/prisma/schema.prisma` — Expense.withholdingTax field
+- `apps/api/src/modules/accounting/dto/expense.dto.ts`
+
+**Checklist:**
+- [ ] รองรับอัตราภาษีหัก ณ ที่จ่ายหลายอัตรา: 1%, 2%, 3%, 5% ตามประเภทเงินได้
+- [ ] คำนวณ: `withholdingTax = paymentAmount × rate` (ก่อน VAT)
+- [ ] จ่ายจริง = จำนวนเงิน - ภาษีหัก ณ ที่จ่าย
+- [ ] มี field เพียงพอสำหรับ: อัตราภาษี, จำนวนภาษีที่หัก, ประเภทเงินได้
+- [ ] บันทึก tax invoice number ของผู้รับเงิน
+- [ ] มีรายงานสรุปภาษีหัก ณ ที่จ่ายรายเดือน (สำหรับยื่น ภ.ง.ด.3, ภ.ง.ด.53)
+- [ ] กรณีจ่ายค่านายหน้า (commission) ให้บุคคลธรรมดา หัก 5% (มาตรา 40(2))
+- [ ] กรณีจ่ายค่าเช่า หัก 5% (มาตรา 40(5))
+- [ ] กรณีจ่ายค่าบริการ/ค่าจ้าง หัก 3% (มาตรา 40(8))
+
+---
+
+### หมวดที่ 5: ลูกหนี้เช่าซื้อและการตั้งสำรองหนี้สงสัยจะสูญ
+
+**มาตรฐานอ้างอิง:** TAS 32 (เครื่องมือทางการเงิน: การนำเสนอ), TFRS 9 (เครื่องมือทางการเงิน), มาตรฐานบัญชี PAEs/NPAEs
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/contracts/contracts.service.ts` — contract lifecycle
+- `apps/api/src/modules/contracts/contract-payment.service.ts` — early payoff
+- `apps/api/src/modules/overdue/overdue.service.ts` — overdue tracking
+- `apps/api/src/modules/reports/reports.service.ts` — getAgingReport()
+- `apps/api/prisma/schema.prisma` — Contract model, Payment model
+
+**Checklist:**
+- [ ] **Aging Report** แบ่งกลุ่มอายุหนี้ถูกต้อง: ยังไม่ถึงกำหนด, 1-30 วัน, 31-60 วัน, 61-90 วัน, มากกว่า 90 วัน
+- [ ] มีระบบตั้งค่าเผื่อหนี้สงสัยจะสูญ (Allowance for Doubtful Accounts) ตามอายุหนี้
+- [ ] อัตราการตั้งสำรอง:
+  - 1-30 วัน: X%
+  - 31-60 วัน: X%
+  - 61-90 วัน: X%
+  - >90 วัน: X%
+  - >360 วัน: ตัดเป็นหนี้สูญ
+- [ ] สถานะสัญญา DEFAULT → มีกระบวนการตัดหนี้สูญ (Bad Debt Write-off)
+- [ ] การตัดหนี้สูญต้องมี: หลักฐานการติดตาม, อนุมัติจากผู้มีอำนาจ
+- [ ] ลูกหนี้เช่าซื้อแสดงเป็น: ยอดรวมลูกหนี้ - ดอกเบี้ยรอรับรู้ = มูลค่าสุทธิ
+- [ ] Early payoff: ส่วนลดดอกเบี้ย 50% → ตรวจว่าบันทึกเป็น "ส่วนลดจ่าย" หรือ "รายได้ดอกเบี้ยลดลง" อย่างถูกต้อง
+- [ ] Credit balance (เงินเกิน) บันทึกเป็นเจ้าหนี้ (หนี้สินหมุนเวียน) ไม่ใช่หักจากลูกหนี้
+
+---
+
+### หมวดที่ 6: ใบเสร็จรับเงิน / ใบกำกับภาษี
+
+**มาตรฐานอ้างอิง:** ประมวลรัษฎากร มาตรา 86/4 (ใบกำกับภาษี), พ.ร.บ.การบัญชี พ.ศ. 2543
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/receipts/receipts.service.ts` — generateReceipt()
+- `apps/api/prisma/schema.prisma` — Receipt model
+
+**Checklist:**
+- [ ] เลขที่ใบเสร็จ (RC-YYYY-MM-NNNNN) เรียงลำดับต่อเนื่อง ไม่ข้ามเลข
+- [ ] ข้อมูลครบตามกฎหมาย:
+  - ชื่อ/ที่อยู่/เลขประจำตัวผู้เสียภาษีของผู้ออก
+  - ชื่อ/ที่อยู่ของผู้รับ
+  - วันที่ออก
+  - รายละเอียดสินค้า/บริการ
+  - จำนวนเงิน (แยกก่อน VAT, VAT, รวม VAT ถ้าเป็นใบกำกับภาษี)
+- [ ] การยกเลิกใบเสร็จ (Void): มีเหตุผล, มีผู้อนุมัติ, ออก Credit Note อ้างอิง
+- [ ] ใบเสร็จที่ยกเลิกยังคงอยู่ในระบบ (ไม่ลบ) — ตรวจสอบ soft delete
+- [ ] ประเภทใบเสร็จ (PAYMENT, DOWN_PAYMENT, EARLY_PAYOFF, CREDIT_NOTE) ครอบคลุมทุกกรณี
+- [ ] File hash (SHA-256) ป้องกันการแก้ไขหลังออก → ดีสำหรับ integrity
+- [ ] เก็บข้อมูลผู้ออก (issuedById) สำหรับ audit trail
+
+---
+
+### หมวดที่ 7: ต้นทุนขาย (Cost of Goods Sold)
+
+**มาตรฐานอ้างอิง:** TAS 2 (สินค้าคงเหลือ)
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/sales/sales.service.ts` — costPrice tracking
+- `apps/api/src/modules/stock/` — inventory management
+- `apps/api/src/modules/accounting/accounting.service.ts` — COGS calculation in P&L
+- `apps/api/prisma/schema.prisma` — Product model, Sale model
+
+**Checklist:**
+- [ ] ต้นทุนสินค้า (costPrice) บันทึกถูกต้องเมื่อรับสินค้าเข้า
+- [ ] วิธีคำนวณต้นทุน: FIFO, Weighted Average, หรือ Specific Identification — ระบุให้ชัดเจน
+- [ ] เมื่อขายสินค้า: ตัดต้นทุนออกจากสินค้าคงเหลือและบันทึกเป็นต้นทุนขาย
+- [ ] P&L: ต้นทุนขาย = sum(costPrice) ของสินค้าที่ขายในงวด
+- [ ] กำไรขั้นต้น = รายได้ขาย - ต้นทุนขาย
+- [ ] สินค้าที่ยึดคืน (Repossession): มีการบันทึกกลับเข้าสต็อกด้วยมูลค่าที่เหมาะสม
+- [ ] Bundle products: ต้นทุนของสินค้าแถมบันทึกถูกต้อง (รวมในต้นทุนขาย หรือค่าส่งเสริมการขาย)
+
+---
+
+### หมวดที่ 8: ค่าใช้จ่ายและ Workflow อนุมัติ
+
+**มาตรฐานอ้างอิง:** พ.ร.บ.การบัญชี พ.ศ. 2543, หลักการควบคุมภายใน
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/accounting/accounting.service.ts` — expense CRUD + approval
+- `apps/api/src/modules/accounting/accounting.controller.ts` — role-based access
+- `apps/api/src/modules/accounting/dto/expense.dto.ts`
+- `apps/api/prisma/schema.prisma` — Expense model
+
+**Checklist:**
+- [ ] Workflow: DRAFT → PENDING_APPROVAL → APPROVED → PAID (มีการแบ่งแยกหน้าที่)
+- [ ] ผู้สร้าง ≠ ผู้อนุมัติ (Segregation of Duties)
+- [ ] ค่าใช้จ่ายที่ APPROVED/PAID แล้วแก้ไขไม่ได้
+- [ ] การ Void ต้องมีเหตุผลและอนุมัติโดย OWNER เท่านั้น
+- [ ] Account code mapping ถูกต้อง:
+  - 5101: ต้นทุนสินค้า
+  - 5102: ต้นทุนอะไหล่ซ่อม
+  - 5201-5204: ค่าใช้จ่ายในการขาย
+  - 5301-5311: ค่าใช้จ่ายบริหาร
+  - 5901-5999: ค่าใช้จ่ายอื่น
+- [ ] ค่าใช้จ่ายที่เกิดขึ้นประจำ (isRecurring) บันทึกตามเกณฑ์คงค้าง
+- [ ] มี tax invoice reference สำหรับค่าใช้จ่ายที่มี VAT
+- [ ] ค่าใช้จ่ายแต่ละรายการมี: วันที่, ผู้รับเงิน, คำอธิบาย, จำนวนเงิน, หมวดบัญชี
+
+---
+
+### หมวดที่ 9: บัญชีระหว่างกัน (Inter-Company Accounting)
+
+**มาตรฐานอ้างอิง:** TAS 24 (การเปิดเผยข้อมูลเกี่ยวกับบุคคลหรือกิจการที่เกี่ยวข้องกัน), TFRS 10 (งบการเงินรวม)
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/inter-company/inter-company.service.ts` — createFromSale(), getProfitSummary()
+- `apps/api/src/modules/inter-company/inter-company.controller.ts`
+- `apps/api/src/modules/reports/reports.service.ts` — getEntityProfitReport()
+- `apps/api/prisma/schema.prisma` — InterCompanyTransaction model
+
+**Checklist:**
+- [ ] ทุก transaction ระหว่าง SHOP ↔ FINANCE มีบันทึกครบทั้ง 2 ฝั่ง (debit/credit)
+- [ ] Reconciliation: มีกระบวนการกระทบยอดระหว่างกัน (reconciledAt)
+- [ ] Profit allocation ถูกต้อง:
+  - Shop Profit = เงินดาวน์ + เงินต้น + commission - ต้นทุน
+  - Finance Profit = ดอกเบี้ยรวม - commission
+- [ ] Snapshot ราคา ณ วันทำรายการ (ไม่เปลี่ยนตามราคาปัจจุบัน)
+- [ ] สถานะ: PENDING → CONFIRMED → RECONCILED — มี audit trail
+- [ ] VAT ระหว่างกัน: คำนวณถูกต้องและไม่นับซ้ำ
+- [ ] รายงาน Entity Profit แยก SHOP/FINANCE ถูกต้อง — ตรวจยอดรวมว่าตรงกับ P&L รวม
+- [ ] ค่า commission ระหว่างกันเป็นราคาตลาด (arm's length principle)
+- [ ] Late fee sharing: ส่วนแบ่งค่าปรับบันทึกถูกต้องทั้ง 2 ฝั่ง
+
+---
+
+### หมวดที่ 10: รายงานทางการเงิน (Financial Statements)
+
+**มาตรฐานอ้างอิง:** พ.ร.บ.การบัญชี พ.ศ. 2543, TFRS for NPAEs (กิจการที่ไม่มีส่วนได้เสียสาธารณะ)
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/accounting/accounting.service.ts` — getProfitLossReport(), getMonthlyPLSummary()
+- `apps/api/src/modules/reports/reports.service.ts` — all report methods
+- `apps/web/src/pages/ReportsPage.tsx`
+
+**Checklist:**
+- [ ] **งบกำไรขาดทุน (P&L)** มีโครงสร้าง:
+  - รายได้จากการขาย (ขายเงินสด + ขายผ่อน)
+  - (-) ต้นทุนขาย
+  - = กำไรขั้นต้น
+  - (-) ค่าใช้จ่ายในการขาย
+  - (-) ค่าใช้จ่ายบริหาร
+  - = กำไรจากการดำเนินงาน
+  - (+) รายได้อื่น (ดอกเบี้ย, ค่าปรับ)
+  - (-) ค่าใช้จ่ายอื่น
+  - = กำไรสุทธิก่อนภาษี
+  - (-) ภาษีเงินได้
+  - = กำไรสุทธิ
+- [ ] Aging Report ข้อมูลตรงกับ Payment records จริง
+- [ ] รายงาน P&L ตรงกับข้อมูลจริงใน database (ไม่มีตัวเลขฮาร์ดโค้ด)
+- [ ] รองรับกรอบเวลา: รายวัน, รายเดือน, รายไตรมาส, รายปี
+- [ ] มีรายงานเปรียบเทียบ (เดือนต่อเดือน, ปีต่อปี)
+- [ ] ระบบมี/ขาด งบดุล (Balance Sheet), งบกระแสเงินสด (Cash Flow Statement)
+
+---
+
+### หมวดที่ 11: การชำระเงินและการจัดสรร (Payment Allocation)
+
+**มาตรฐานอ้างอิง:** หลักปฏิบัติทางบัญชีสำหรับสัญญาเช่าซื้อ
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/payments/payments.service.ts` — recordPayment(), autoAllocatePayment()
+- `apps/api/src/utils/installment.util.ts` — calculateInstallment(), generatePaymentSchedule()
+- `apps/api/src/modules/contracts/contract-payment.service.ts` — getEarlyPayoffQuote()
+
+**Checklist:**
+- [ ] การจัดสรรเงินชำระ: ชำระงวดเก่าสุดก่อน (FIFO) → ถูกต้อง
+- [ ] แยกเงินต้น/ดอกเบี้ยในแต่ละงวด: monthlyPrincipal vs monthlyInterest
+- [ ] ค่าปรับล่าช้า (late fee): คำนวณตาม วันล่าช้า × อัตราต่อวัน, มี cap → ตรวจว่าไม่เกินที่กฎหมายกำหนด
+- [ ] Overpayment → บันทึกเป็น creditBalance ในสัญญา → ตรวจว่าใช้หักงวดถัดไปถูกต้อง
+- [ ] Idempotent payment (transactionRef) → ป้องกันรายการซ้ำ
+- [ ] Early payoff discount: ส่วนลด 50% ของดอกเบี้ยคงเหลือ → บันทึกในบัญชีถูกต้อง
+- [ ] Payment schedule: สร้างตารางผ่อนที่ยอดรวมตรงกับ financedAmount
+- [ ] Rounding: ใช้ satang precision (×100) → ตรวจว่ายอดรวมทุกงวด = financedAmount พอดี
+- [ ] Partial payment: บันทึกสถานะ PARTIALLY_PAID ถูกต้อง
+
+---
+
+### หมวดที่ 12: Audit Trail และการควบคุมภายใน
+
+**มาตรฐานอ้างอิง:** พ.ร.บ.การบัญชี พ.ศ. 2543 มาตรา 12, หลักการควบคุมภายใน COSO Framework
+
+**ไฟล์ที่ต้องตรวจ:**
+- `apps/api/src/modules/audit/audit.service.ts` — logPaymentEvent(), logReceiptEvent()
+- `apps/api/src/modules/audit/audit.interceptor.ts`
+- `apps/api/src/modules/audit/security.middleware.ts`
+- `apps/api/src/modules/audit/audit.controller.ts`
+- `apps/api/prisma/schema.prisma` — AuditLog model
+
+**Checklist:**
+- [ ] ทุก transaction ทางการเงินมี audit log: สร้าง, แก้ไข, อนุมัติ, ยกเลิก
+- [ ] Audit log เก็บ: userId, action, entity, old/new values, timestamp, IP address
+- [ ] Audit log เป็น **immutable** — ไม่สามารถแก้ไขหรือลบได้
+- [ ] ข้อมูลที่ sensitive (password, token) ถูก redact ออกจาก log
+- [ ] Financial audit trail: ครอบคลุม payment, receipt, contract status changes
+- [ ] Role-based access control:
+  - OWNER: เข้าถึงทุกอย่าง
+  - ACCOUNTANT: เข้าถึงข้อมูลการเงิน, ไม่แก้ไขสัญญา
+  - BRANCH_MANAGER: เฉพาะสาขาตัวเอง
+  - SALES: เฉพาะ POS และลูกค้า
+- [ ] Segregation of Duties: ผู้สร้างรายการ ≠ ผู้อนุมัติ ≠ ผู้ตรวจสอบ
+- [ ] Soft delete ทุก model — ไม่มีการลบข้อมูลถาวร (ตรงตามกฎหมาย: เก็บ 5 ปี)
+- [ ] ระบบ lock ป้องกันการแก้ไขข้อมูลย้อนหลัง (period closing)
+
+---
+
+## รูปแบบรายงานผลตรวจสอบ
+
+ให้รายงานผลตรวจสอบในรูปแบบนี้:
+
+```markdown
+# รายงานผลตรวจสอบระบบบัญชี BESTCHOICE
+วันที่ตรวจสอบ: [วันที่]
+
+## สรุปผลรวม
+| หมวด | สถานะ | ประเด็นวิกฤต | ประเด็นเตือน | ข้อเสนอแนะ |
+|------|--------|-------------|-------------|------------|
+| 1. ผังบัญชี | PASS/FAIL/PARTIAL | 0 | 0 | 0 |
+| 2. รับรู้รายได้ | ... | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+## ประเด็นวิกฤต (Critical) — ต้องแก้ไขทันที
+### [C-001] ชื่อประเด็น
+- **หมวด**: X
+- **ไฟล์**: path/to/file.ts:line
+- **ปัญหา**: อธิบายปัญหา
+- **มาตรฐานที่ขัด**: TAS/TFRS/กฎหมายที่เกี่ยวข้อง
+- **ความเสี่ยง**: ผลกระทบทางกฎหมาย/การเงิน
+- **แนวทางแก้ไข**: วิธีแก้ที่เสนอ
+
+## ประเด็นเตือน (Warning) — ควรแก้ไข
+### [W-001] ชื่อประเด็น
+- (รูปแบบเดียวกัน)
+
+## ข้อเสนอแนะ (Recommendation) — ควรปรับปรุง
+### [R-001] ชื่อประเด็น
+- (รูปแบบเดียวกัน)
+
+## สิ่งที่ทำได้ดี (Good Practices)
+- รายการสิ่งที่ระบบทำถูกต้องแล้ว
+
+## Action Items
+| ลำดับ | ประเด็น | ความเร่งด่วน | ผู้รับผิดชอบ | กำหนดเสร็จ |
+|-------|---------|-------------|-------------|-----------|
+| 1 | ... | สูง/กลาง/ต่ำ | ... | ... |
+```
+
+---
+
+## ขอบเขตที่ไม่ต้องตรวจ
+
+- ~~ดอกเบี้ย flat rate กับ พ.ร.บ.ผ่อนชำระ~~ (ไม่ต้องตรวจ)
+- ไม่ตรวจ performance / scalability
+- ไม่ตรวจ UI/UX design
+- ไม่ตรวจ security vulnerabilities (มี audit แยกต่างหาก)
+
+---
+
+## วิธีใช้ Prompt นี้
+
+1. **Copy Prompt ทั้งหมด** ข้างบนไปใช้ใน Claude Code conversation ใหม่
+2. Claude จะ **อ่านไฟล์ทุกไฟล์** ที่ระบุในแต่ละหมวด
+3. ตรวจสอบตาม **Checklist** ทีละข้อ
+4. สร้าง **รายงานผลตรวจสอบ** ตามรูปแบบที่กำหนด
+5. Review ผลและดำเนินการตาม Action Items
+
+### คำสั่งเริ่มต้น:
+```
+ตรวจสอบระบบบัญชี BESTCHOICE ตามหลักบัญชีไทย โดยใช้ Prompt ใน docs/prompts/ACCOUNTING-AUDIT-PROMPT.md — อ่านทุกไฟล์ที่ระบุ, ตรวจตาม Checklist ทุกข้อ, และสร้างรายงานผลตรวจสอบ
+```

--- a/docs/reports/ACCOUNTING-AUDIT-REPORT-2026-04-05.md
+++ b/docs/reports/ACCOUNTING-AUDIT-REPORT-2026-04-05.md
@@ -1,0 +1,394 @@
+# รายงานผลตรวจสอบระบบบัญชี BESTCHOICE
+
+**วันที่ตรวจสอบ:** 5 เมษายน 2569 (2026-04-05)
+**ผู้ตรวจสอบ:** AI Auditor (Claude) — ตรวจตามหลักบัญชีไทยและมาตรฐานที่ระบุใน ACCOUNTING-AUDIT-PROMPT.md
+**ขอบเขต:** 12 หมวดการตรวจสอบ ครอบคลุม source code ทั้ง backend (NestJS + Prisma) และ frontend (React)
+
+---
+
+## สรุปผลรวม
+
+| # | หมวด | สถานะ | วิกฤต (C) | เตือน (W) | ข้อเสนอแนะ (R) |
+|---|------|--------|:---------:|:---------:|:--------------:|
+| 1 | ผังบัญชี (Chart of Accounts) | **FAIL** | 1 | 1 | 1 |
+| 2 | รับรู้รายได้ (Revenue Recognition) | **PASS** | 0 | 1 | 1 |
+| 3 | ภาษีมูลค่าเพิ่ม (VAT) | **FAIL** | 1 | 1 | 1 |
+| 4 | ภาษีหัก ณ ที่จ่าย (WHT) | **FAIL** | 1 | 1 | 1 |
+| 5 | ลูกหนี้เช่าซื้อ & หนี้สงสัยจะสูญ | **FAIL** | 1 | 2 | 1 |
+| 6 | ใบเสร็จ / ใบกำกับภาษี | **PARTIAL** | 1 | 2 | 2 |
+| 7 | ต้นทุนขาย (COGS) | **PARTIAL** | 1 | 1 | 1 |
+| 8 | ค่าใช้จ่าย & Workflow อนุมัติ | **PARTIAL** | 1 | 1 | 1 |
+| 9 | บัญชีระหว่างกัน (Inter-Company) | **PARTIAL** | 0 | 2 | 2 |
+| 10 | รายงานทางการเงิน | **PARTIAL** | 1 | 2 | 1 |
+| 11 | การชำระเงินและการจัดสรร | **PASS** | 0 | 0 | 1 |
+| 12 | Audit Trail & การควบคุมภายใน | **PARTIAL** | 0 | 2 | 2 |
+| | **รวม** | | **8** | **16** | **15** |
+
+**สรุป: FAIL — พบประเด็นวิกฤต 8 รายการที่ต้องแก้ไขก่อนใช้งานจริงในเชิงบัญชีภาษี**
+
+---
+
+## ประเด็นวิกฤต (Critical) — ต้องแก้ไขทันที
+
+### [C-001] ผังบัญชีไม่ครบ 5 หมวด — มีเฉพาะค่าใช้จ่าย (5xxx)
+- **หมวด**: 1 — ผังบัญชี
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts:11-43`
+- **ปัญหา**: ระบบกำหนดเฉพาะ `CATEGORY_ACCOUNT_MAP` และ `CATEGORY_CODE_MAP` สำหรับค่าใช้จ่าย (5xxx) เท่านั้น ไม่มีบัญชีหมวด 1xxx (สินทรัพย์), 2xxx (หนี้สิน), 3xxx (ส่วนของเจ้าของ), 4xxx (รายได้)
+- **มาตรฐานที่ขัด**: กรมพัฒนาธุรกิจการค้า — ผังบัญชีมาตรฐาน SMEs ต้องครบ 5 หมวด
+- **ความเสี่ยง**: ไม่สามารถสร้างงบการเงินที่ถูกต้องตามกฎหมาย (งบดุล, งบกำไรขาดทุน) ได้ เนื่องจากไม่มีบัญชีสินทรัพย์/หนี้สิน/ทุน/รายได้อย่างเป็นทางการ
+- **บัญชีที่ขาด**:
+  - 1100 ลูกหนี้การค้า, 1150 ลูกหนี้เช่าซื้อ, 1200 สินค้าคงเหลือ, 1300 ภาษีซื้อ
+  - 2100 ภาษีขาย, 2110 ภาษีมูลค่าเพิ่มค้างจ่าย
+  - 3xxx ทุน/กำไรสะสม
+  - 4100 รายได้จากการขาย, 4400 รายได้ดอกเบี้ย, 4500 รายได้ค่าปรับ
+  - 1110 ค่าเผื่อหนี้สงสัยจะสูญ, 5800 หนี้สูญ
+- **แนวทางแก้ไข**: สร้างตาราง `ChartOfAccount` ใน Prisma schema พร้อม seed ผังบัญชีครบ 5 หมวด และเชื่อมกับทุก transaction
+
+---
+
+### [C-002] VAT คำนวณรวมดอกเบี้ยเช่าซื้อ — ผิดกฎหมายภาษี
+- **หมวด**: 3 — VAT
+- **ไฟล์**: `apps/api/src/utils/installment.util.ts:54`
+- **ปัญหา**: สูตร VAT คำนวณจาก `(principal + storeCommission + interestTotal) × vatPct` — **รวมดอกเบี้ยเช่าซื้อในฐาน VAT**
+- **มาตรฐานที่ขัด**: ประมวลรัษฎากร มาตรา 81(1)(ช) — ดอกเบี้ยเช่าซื้อ **ได้รับยกเว้น VAT**
+- **ความเสี่ยง**:
+  - ลูกค้าถูกเรียกเก็บ VAT เกินจริง (ตัวอย่าง: principal 10,000 + commission 1,000 + interest 1,500 → VAT เกิน 105 บาท/รายการ)
+  - อาจถูกสรรพากรเรียกคืนภาษีขายที่เก็บเกิน
+  - เป็นความเสี่ยงทางกฎหมายต่อลูกค้าทุกราย
+- **แนวทางแก้ไข**: แก้สูตรเป็น `vatAmount = roundBaht((principal + storeCommission) * vatPct)` — ตัด interestTotal ออกจากฐาน VAT
+
+---
+
+### [C-003] ระบบภาษีหัก ณ ที่จ่ายไม่สมบูรณ์ — ไม่สามารถยื่น ภ.ง.ด.3/53 ได้
+- **หมวด**: 4 — WHT
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts:78`, `apps/api/src/modules/accounting/dto/expense.dto.ts`
+- **ปัญหา**:
+  1. ไม่มีการ validate อัตราภาษีหัก ณ ที่จ่าย (1%, 2%, 3%, 5%) — รับค่า arbitrary
+  2. ไม่มี field ประเภทเงินได้ (income type) สำหรับจำแนก WHT
+  3. ไม่มีรายงานสรุป WHT รายเดือน (ภ.ง.ด.3, ภ.ง.ด.53)
+  4. ไม่มี field อัตราภาษี (`whtRate`), เลขประจำตัวผู้เสียภาษีผู้รับ
+  5. `totalAmount` ไม่หัก WHT ออก → ยอดจ่ายจริงไม่ถูกต้อง
+- **มาตรฐานที่ขัด**: ประมวลรัษฎากร มาตรา 3 เตรส, 50, 69 ทวิ
+- **ความเสี่ยง**: ไม่สามารถยื่นแบบภาษีหัก ณ ที่จ่ายรายเดือนตามกฎหมาย → อาจถูกปรับ
+- **แนวทางแก้ไข**:
+  1. เพิ่ม fields ใน Expense: `whtRate`, `whtIncomeType`, `payeeTaxId`
+  2. คำนวณ: `netPayment = amount + vatAmount - withholdingTax`
+  3. สร้าง report service สำหรับ ภ.ง.ด.3 (บุคคลธรรมดา) และ ภ.ง.ด.53 (นิติบุคคล)
+
+---
+
+### [C-004] ไม่มีระบบตั้งสำรองหนี้สงสัยจะสูญ
+- **หมวด**: 5 — ลูกหนี้เช่าซื้อ
+- **ไฟล์**: `apps/api/src/modules/reports/reports.service.ts:15-59`
+- **ปัญหา**: Aging Report มี bucket (1-30, 31-60, 61-90, 90+) แต่ **ไม่มีการตั้งค่าเผื่อหนี้สงสัยจะสูญ** (Allowance for Doubtful Accounts) ตามอายุหนี้ นอกจากนี้:
+  - Contract มี status `CLOSED_BAD_DEBT` แต่ไม่มี service/method สำหรับ write-off ทางบัญชี
+  - ไม่มีบันทึกรายการบัญชี (journal entry) เมื่อตัดหนี้สูญ
+  - ไม่มีกระบวนการอนุมัติการตัดหนี้สูญ
+- **มาตรฐานที่ขัด**: TFRS 9 (เครื่องมือทางการเงิน), TAS — ต้องประมาณการผลขาดทุนจากลูกหนี้
+- **ความเสี่ยง**: งบการเงินแสดงลูกหนี้สูงเกินจริง (overstatement of receivables)
+- **แนวทางแก้ไข**:
+  1. เพิ่มอัตราตั้งสำรองตามอายุหนี้ (configurable)
+  2. สร้าง Bad Debt Write-off service พร้อม approval workflow
+  3. บันทึก journal entry: เดบิตหนี้สูญ / เครดิตค่าเผื่อฯ
+
+---
+
+### [C-005] ใบเสร็จ/ใบกำกับภาษีขาดข้อมูลตามกฎหมาย
+- **หมวด**: 6 — ใบเสร็จ
+- **ไฟล์**: `apps/api/src/modules/receipts/receipts.service.ts`, `apps/api/prisma/schema.prisma` (Receipt model)
+- **ปัญหา**:
+  1. ไม่มีข้อมูลที่อยู่/เลขประจำตัวผู้เสียภาษีของผู้ซื้อบนใบเสร็จ
+  2. ไม่มี itemized line items (รายละเอียดสินค้า, จำนวน, ราคาต่อหน่วย)
+  3. ไม่มี VAT breakdown (ราคาก่อน VAT / VAT / รวม VAT) บนใบเสร็จ
+  4. การ Void ไม่มี approval workflow — user คนใดก็ void ได้
+  5. CompanyInfo เป็น optional → อาจออกใบเสร็จโดยไม่มีข้อมูลผู้ออก (fallback เป็น hardcoded)
+- **มาตรฐานที่ขัด**: ประมวลรัษฎากร มาตรา 86/4 (ข้อมูลใบกำกับภาษี), พ.ร.บ.การบัญชี พ.ศ. 2543
+- **ความเสี่ยง**: ใบเสร็จไม่สามารถใช้เป็นใบกำกับภาษีได้ → ลูกค้านิติบุคคลไม่สามารถนำไปขอคืน VAT
+- **แนวทางแก้ไข**:
+  1. เพิ่ม fields ใน Receipt: `buyerAddress`, `buyerTaxId`, line items, VAT detail
+  2. บังคับ CompanyInfo ก่อนออกใบเสร็จ
+  3. เพิ่ม Void approval workflow (ต้องได้รับอนุมัติจาก OWNER/ACCOUNTANT)
+
+---
+
+### [C-006] ต้นทุน Bundle Products ไม่ถูกรวมใน COGS
+- **หมวด**: 7 — COGS
+- **ไฟล์**: `apps/api/src/modules/sales/sales.service.ts:177-201`, `apps/api/src/modules/accounting/accounting.service.ts:436`
+- **ปัญหา**: เมื่อขายสินค้าพร้อม bundle/freebie:
+  - สินค้า bundle ถูก mark เป็น `SOLD_CASH` (line 199)
+  - แต่ **costPrice ของ bundle ไม่ถูกรวมใน COGS calculation**
+  - P&L `purchaseOrderCost` คำนวณเฉพาะ `s.product.costPrice` ของสินค้าหลัก
+  - ตัวอย่าง: สินค้าหลัก cost 5,000 + bundle cost 2,000 → COGS ควรเป็น 7,000 แต่ระบบบันทึก 5,000
+- **มาตรฐานที่ขัด**: TAS 2 (สินค้าคงเหลือ) — ต้นทุนที่เกี่ยวข้องกับการขายต้องบันทึกเป็น COGS ทั้งหมด
+- **ความเสี่ยง**: COGS ต่ำเกินจริง → กำไรขั้นต้นสูงเกินจริง (overstatement of gross profit)
+- **แนวทางแก้ไข**: รวม costPrice ของ bundleProductIds ทั้งหมดเข้าใน COGS calculation ของแต่ละรายการขาย
+
+---
+
+### [C-007] ค่าใช้จ่าย Void ไม่มี reason และ approval trail
+- **หมวด**: 8 — ค่าใช้จ่าย
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts:277-284`
+- **ปัญหา**:
+  1. `voidExpense()` ไม่บันทึกเหตุผลการยกเลิก (ไม่มี `voidReason` field)
+  2. ไม่มี `voidApprovedBy` / `voidApprovedAt` — ไม่มี audit trail ว่าใครอนุมัติ
+  3. Schema มี `rejectReason` แต่ไม่มี `voidReason` แยกต่างหาก
+- **มาตรฐานที่ขัด**: พ.ร.บ.การบัญชี พ.ศ. 2543 — ทุกรายการยกเลิกต้องมีเหตุผลและผู้อนุมัติ, COSO Framework
+- **ความเสี่ยง**: ไม่สามารถตรวจสอบย้อนหลังได้ว่า ค่าใช้จ่ายถูกยกเลิกเพราะอะไรและใครอนุมัติ
+- **แนวทางแก้ไข**:
+  1. เพิ่ม fields: `voidReason`, `voidedById`, `voidedAt` ใน Expense model
+  2. บังคับให้ระบุ reason เมื่อ void
+  3. เก็บ audit trail ของ void action
+
+---
+
+### [C-008] ขาดงบดุล (Balance Sheet) และงบกระแสเงินสด (Cash Flow Statement)
+- **หมวด**: 10 — รายงานทางการเงิน
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts`, `apps/api/src/modules/reports/reports.service.ts`
+- **ปัญหา**: ระบบมีเฉพาะ P&L Report และ Monthly Summary — **ไม่มีงบดุลและงบกระแสเงินสด**
+- **มาตรฐานที่ขัด**: พ.ร.บ.การบัญชี พ.ศ. 2543, TFRS for NPAEs — ต้องจัดทำงบการเงินครบชุด
+- **ความเสี่ยง**: ไม่สามารถยื่นงบการเงินตามที่กฎหมายกำหนด (ยื่นกรมพัฒนาธุรกิจการค้าภายใน 5 เดือนหลังปิดรอบบัญชี)
+- **แนวทางแก้ไข**: สร้างงบดุล (ต้องมีผังบัญชีครบก่อน — เชื่อมกับ C-001) และงบกระแสเงินสด
+
+---
+
+## ประเด็นเตือน (Warning) — ควรแก้ไข
+
+### [W-001] ไม่มีบัญชี Input VAT / Output VAT แยกต่างหาก
+- **หมวด**: 1, 3
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts`, `apps/api/prisma/schema.prisma`
+- **ปัญหา**: VAT ถูก track ใน field ของ Expense/InterCompanyTransaction แต่ไม่มีบัญชีภาษีซื้อ (1300) / ภาษีขาย (2100) แยก → ไม่สามารถกระทบยอด VAT สำหรับการยื่น ภ.พ.30 ได้
+- **แนวทางแก้ไข**: สร้าง VAT ledger accounts เมื่อ implement ผังบัญชีครบ (เชื่อมกับ C-001)
+
+### [W-002] Revenue recognition: ดอกเบี้ยรับรู้แบบ straight-line ไม่ใช่ effective interest rate
+- **หมวด**: 2
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts:424`
+- **ปัญหา**: `interestIncome += interestTotal / totalMonths` — แบ่งเฉลี่ยเท่ากันทุกเดือน (straight-line) ซึ่งไม่ตรงตาม TFRS 9 ที่แนะนำ effective interest rate method
+- **หมายเหตุ**: สำหรับ NPAEs (กิจการ SME) straight-line อาจยอมรับได้ แต่ควร document ว่าเลือกใช้วิธีนี้โดยเจตนา
+- **แนวทางแก้ไข**: Document นโยบายบัญชีว่าใช้ straight-line method สำหรับ flat-rate hire-purchase
+
+### [W-003] ลูกหนี้เช่าซื้อไม่แสดงเป็น Gross - Unearned Interest = Net
+- **หมวด**: 5
+- **ไฟล์**: `apps/api/src/modules/contracts/contract-payment.service.ts:44-46`
+- **ปัญหา**: ระบบคำนวณ `truePrincipal = financedAmount - interestTotal` แต่ไม่มีการแสดงลูกหนี้ในรูปแบบ: ลูกหนี้รวม - ดอกเบี้ยรอรับรู้ = มูลค่าสุทธิ ตามมาตรฐาน
+- **แนวทางแก้ไข**: เพิ่ม field `unearnedInterest` หรือสร้าง report view ที่แสดงลูกหนี้สุทธิ
+
+### [W-004] Credit Balance ไม่จำแนกเป็นหนี้สินหมุนเวียน
+- **หมวด**: 5
+- **ไฟล์**: `apps/api/prisma/schema.prisma` (Contract.creditBalance)
+- **ปัญหา**: เงินเกินของลูกค้า (creditBalance) ถูกเก็บใน Contract model แต่ไม่จำแนกเป็นเจ้าหนี้/หนี้สินหมุนเวียน ไม่แสดงใน Balance Sheet
+- **แนวทางแก้ไข**: จำแนก credit balance เป็นหนี้สินหมุนเวียนในงบดุล (เชื่อมกับ C-008)
+
+### [W-005] ใบเสร็จ Void ไม่ set deletedAt — ยังปรากฏใน queries
+- **หมวด**: 6
+- **ไฟล์**: `apps/api/src/modules/receipts/receipts.service.ts:361`
+- **ปัญหา**: Void ใช้ `isVoided: true` แต่ไม่ set `deletedAt` → receipt ที่ void แล้วยังปรากฏใน queries ที่ filter `deletedAt: null`
+- **แนวทางแก้ไข**: ใช้ dual mechanism: `isVoided` สำหรับ display + `deletedAt` สำหรับ query filtering, หรือเพิ่ม `isVoided: false` ในทุก query
+
+### [W-006] Credit Note ไม่มี time limit validation (30 วันตามกฎหมาย)
+- **หมวด**: 6
+- **ไฟล์**: `apps/api/src/modules/receipts/receipts.service.ts:339-365`
+- **ปัญหา**: Credit Note ออกได้ทุกเมื่อ ไม่มี validation ว่าต้องออกภายใน 30 วันตามที่กฎหมายกำหนด
+- **แนวทางแก้ไข**: เพิ่ม validation: `originalReceiptDate + 30 days >= now`
+
+### [W-007] COGS ไม่มี inventory journal deduction per sale
+- **หมวด**: 7
+- **ไฟล์**: `apps/api/src/modules/sales/sales.service.ts:229-233`
+- **ปัญหา**: Product status เปลี่ยนเป็น SOLD แต่ไม่มี inventory journal entry — COGS คำนวณย้อนหลังจาก sum ไม่ใช่ perpetual method
+- **แนวทางแก้ไข**: บันทึก inventory movement record ทุกครั้งที่ขาย (debit COGS / credit Inventory)
+
+### [W-008] ผู้สร้างค่าใช้จ่าย = ผู้อนุมัติ ได้ (Segregation of Duties)
+- **หมวด**: 8
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts:241-249`
+- **ปัญหา**: `approveExpense()` ไม่ validate ว่า `approvedById !== expense.createdById` — คนเดียวกันสร้างและอนุมัติได้
+- **แนวทางแก้ไข**: เพิ่ม validation: `if (expense.createdById === approvedById) throw new BadRequestException('ผู้อนุมัติต้องไม่ใช่ผู้สร้างรายการ')`
+
+### [W-009] Inter-Company บันทึกฝั่งเดียว (single transaction record)
+- **หมวด**: 9
+- **ไฟล์**: `apps/api/src/modules/inter-company/inter-company.service.ts:14-37`
+- **ปัญหา**: สร้าง InterCompanyTransaction record เดียวต่อ sale แทนที่จะบันทึกทั้ง 2 ฝั่ง (debit/credit) ตาม double-entry
+- **แนวทางแก้ไข**: ใช้ paired entries (SHOP debit + FINANCE credit) หรือ document ว่า single record ใช้แยก profit allocation ได้เพียงพอ
+
+### [W-010] Inter-Company ไม่มี CONFIRMED status ก่อน RECONCILED
+- **หมวด**: 9
+- **ไฟล์**: `apps/api/src/modules/inter-company/inter-company.service.ts:159-172`
+- **ปัญหา**: Status flow เป็น PENDING → RECONCILED เท่านั้น ไม่มี CONFIRMED stage — reconcile เป็น manual flag ไม่มี matching logic
+- **แนวทางแก้ไข**: เพิ่ม CONFIRMED status + matching verification ก่อนอนุญาต reconcile
+
+### [W-011] AuditLog มี updatedAt field — ขัดหลัก immutability
+- **หมวด**: 12
+- **ไฟล์**: `apps/api/prisma/schema.prisma:1130`
+- **ปัญหา**: AuditLog table มี `updatedAt DateTime @updatedAt` — Prisma auto-update ทุกครั้งที่แก้ไข record ขัดกับหลักว่า audit log ต้อง immutable
+- **แนวทางแก้ไข**: ลบ `updatedAt` ออกจาก AuditLog model (เก็บเฉพาะ `createdAt`)
+
+### [W-012] ไม่มีรายงานเปรียบเทียบ MoM / YoY
+- **หมวด**: 10
+- **ไฟล์**: `apps/api/src/modules/accounting/accounting.service.ts:518-589`
+- **ปัญหา**: `getMonthlyPLSummary()` สร้าง P&L รายเดือน แต่ไม่มีการเปรียบเทียบ Month-over-Month หรือ Year-over-Year
+- **แนวทางแก้ไข**: เพิ่ม comparison logic ที่ return ทั้งเดือนปัจจุบันและเดือนก่อน พร้อม % change
+
+### [W-013] ไม่มีระบบ Period Closing lock
+- **หมวด**: 12
+- **ไฟล์**: ไม่พบในระบบ
+- **ปัญหา**: ไม่มีกลไกล็อกงวดบัญชี (period closing) เพื่อป้องกันการแก้ไขข้อมูลย้อนหลังหลังปิดงบ
+- **แนวทางแก้ไข**: สร้าง `AccountingPeriod` model พร้อมสถานะ OPEN/CLOSED และ validate ทุก transaction ว่าอยู่ในงวดที่เปิดอยู่
+
+### [W-014] Segregation of Duties ไม่ครบ 3 ฝ่าย (สร้าง ≠ อนุมัติ ≠ ตรวจสอบ)
+- **หมวด**: 12
+- **ไฟล์**: `apps/api/src/modules/audit/audit.controller.ts`
+- **ปัญหา**: RBAC มี 4 roles แต่ไม่แยก "ผู้ตรวจสอบ" ออกจาก "ผู้อนุมัติ" อย่างชัดเจน — COSO Framework แนะนำ 3-way segregation
+- **แนวทางแก้ไข**: Review role permissions ให้แน่ใจว่า ACCOUNTANT ทำหน้าที่ตรวจสอบ ไม่ใช่อนุมัติ
+
+---
+
+## ข้อเสนอแนะ (Recommendation) — ควรปรับปรุง
+
+### [R-001] Document นโยบายบัญชีสำหรับ interest recognition method
+- **หมวด**: 2
+- **รายละเอียด**: ระบบใช้ straight-line method สำหรับรับรู้ดอกเบี้ย ซึ่งเหมาะสำหรับ NPAEs แต่ควร document อย่างเป็นทางการว่าเลือกใช้วิธีนี้
+
+### [R-002] เพิ่ม Tax Point validation (จุดความรับผิดทางภาษี)
+- **หมวด**: 3
+- **รายละเอียด**: ขายสินค้า tax point = วันส่งมอบ, บริการ = วันรับชำระ — ควร validate ว่า receipt date ตรงกับ tax point
+
+### [R-003] เพิ่มรายงาน WHT สรุปรายเดือนสำหรับยื่นภาษี
+- **หมวด**: 4
+- **รายละเอียด**: แม้ C-003 แก้ field แล้ว ควรมี report ที่ export ได้เป็น format ที่ยื่น ภ.ง.ด.3/53 ได้ทันที
+
+### [R-004] เพิ่ม Bad Debt write-off workflow พร้อม approval chain
+- **หมวด**: 5
+- **รายละเอียด**: สร้าง service method สำหรับ write-off พร้อม: หลักฐานการติดตาม, อนุมัติจาก OWNER, journal entry อัตโนมัติ
+
+### [R-005] เพิ่ม hash verification สำหรับตรวจสอบ tampering ของใบเสร็จ
+- **หมวด**: 6
+- **รายละเอียด**: SHA-256 hash สร้างแล้วแต่ไม่มีการ verify เมื่อดึงข้อมูล — เพิ่ม verification endpoint
+
+### [R-006] เพิ่ม receipt types: DEPOSIT_REFUND, EXCHANGE
+- **หมวด**: 6
+- **รายละเอียด**: ปัจจุบันรองรับ PAYMENT, DOWN_PAYMENT, EARLY_PAYOFF, CREDIT_NOTE — ขาด refund และ exchange types
+
+### [R-007] Repossessed goods ควรปรับ costPrice ตาม appraised value
+- **หมวด**: 7
+- **ไฟล์**: `apps/api/src/modules/repossessions/repossessions.service.ts:279-306`
+- **รายละเอียด**: สินค้ายึดคืนเข้าสต็อกเป็น REFURBISHED แต่ไม่ปรับ costPrice → ต้นทุนเดิมไม่สะท้อนมูลค่าจริง
+
+### [R-008] Recurring expenses ควร auto-generate ตามเกณฑ์คงค้าง
+- **หมวด**: 8
+- **รายละเอียด**: Schema มี `isRecurring` + `recurringDay` แต่ไม่มี service ที่ auto-generate — ควรสร้าง cron job
+
+### [R-009] Document Inter-Company transfer pricing policy (arm's length)
+- **หมวด**: 9
+- **รายละเอียด**: Commission rate 10% default ไม่มี arm's length study — ควร document transfer pricing policy ตาม TAS 24
+
+### [R-010] เพิ่ม late fee sharing configuration ระหว่าง SHOP/FINANCE
+- **หมวด**: 9
+- **รายละเอียด**: ปัจจุบัน FINANCE รับค่าปรับ 100% — ควรทำเป็น configurable
+
+### [R-011] P&L ควรแสดงรายได้อื่น (ดอกเบี้ย, ค่าปรับ) แยกจากรายได้หลัก
+- **หมวด**: 10
+- **รายละเอียด**: ปัจจุบัน P&L รวมรายได้ทุกประเภทเป็น totalRevenue — ควรแยก operating revenue vs other income ให้ชัดเจน (มีอยู่บางส่วนแล้วแต่ควรปรับโครงสร้าง)
+
+### [R-012] Payment idempotency ใช้ string search ใน notes field
+- **หมวด**: 11
+- **ไฟล์**: `apps/api/src/modules/payments/payments.service.ts:66`
+- **รายละเอียด**: `transactionRef` check ใช้ `notes.contains` ซึ่งอาจ false positive — ควรใช้ dedicated unique field แทน
+
+### [R-013] Audit interceptor entity extraction อาจผิดพลาดกับ nested URLs
+- **หมวด**: 12
+- **ไฟล์**: `apps/api/src/modules/audit/audit.interceptor.ts:83-111`
+- **รายละเอียด**: URL parsing อาจได้ entity ผิดสำหรับ nested routes เช่น `/contracts/{id}/payments/{paymentId}` → extracts "payments" แทน "contracts"
+
+### [R-014] Expense model: ควรเพิ่ม field สำหรับ payment method
+- **หมวด**: 8
+- **รายละเอียด**: ค่าใช้จ่ายไม่มี field ระบุวิธีจ่ายเงิน (เงินสด, โอน, เช็ค) — จำเป็นสำหรับ audit trail
+
+### [R-015] เพิ่ม Quarterly report aggregation
+- **หมวด**: 10
+- **รายละเอียด**: ปัจจุบันมี daily/monthly — เพิ่ม quarterly aggregation สำหรับยื่นภาษีรายไตรมาส
+
+---
+
+## สิ่งที่ทำได้ดี (Good Practices)
+
+### Revenue Recognition (หมวด 2) — ✅ ดีเยี่ยม
+- **Cash sales**: รับรู้ทันทีเมื่อส่งมอบ — ถูกต้องตาม TFRS 15
+- **Down payment**: รับรู้ ณ วันขาย — ถูกต้อง
+- **Installment payments**: รับรู้เมื่อได้รับชำระ (paidDate) ไม่ใช่ dueDate — ถูกต้อง
+- **External finance**: รับรู้เมื่อ FinanceReceivable status = RECEIVED — ถูกต้อง
+- **Late fees**: รับรู้เฉพาะที่ไม่ waive — ถูกต้อง
+- **ไม่มี double counting** ระหว่าง modules — ตรวจสอบแล้ว
+
+### Payment Allocation (หมวด 11) — ✅ ดีเยี่ยม
+- **FIFO allocation**: จ่ายงวดเก่าสุดก่อน (`orderBy: installmentNo asc`) — ถูกต้อง
+- **Late fee**: คำนวณ `daysOverdue × feePerDay` พร้อม cap 1,500 บาท — สมเหตุสมผล
+- **Overpayment**: บันทึกเป็น creditBalance ใน Contract — ถูกต้อง
+- **Idempotent payment**: ป้องกัน duplicate ด้วย transactionRef — ดี
+- **Early payoff 50% discount**: คำนวณจากดอกเบี้ยคงเหลือ — ถูกต้อง
+- **Satang precision**: `roundBaht()` ใช้ `Math.round(value * 100) / 100` ทั่วทั้งระบบ — ดี
+- **Last payment adjustment**: งวดสุดท้ายปรับยอดให้ตรง financedAmount — ป้องกัน rounding error
+
+### Expense Workflow (หมวด 8) — ✅ ดี
+- Status flow: DRAFT → PENDING_APPROVAL → APPROVED → PAID — ครบถ้วน
+- APPROVED/PAID expenses ล็อกไม่ให้แก้ไข — ถูกต้อง
+- Account code mapping (5101-5999) ครบและถูกต้อง — ดี
+- VAT calculation ใช้ 7% จาก system config — configurable และถูกต้อง
+
+### Audit Trail (หมวด 12) — ✅ ดี
+- Payment/Receipt/Contract events ถูก log ครบ — ดี
+- Audit log เก็บ: userId, action, entity, entityId, oldValue, newValue, ipAddress, userAgent — ครบถ้วน
+- Sensitive data redacted (password, token, secret, accessToken, refreshToken) — ดี
+- Security middleware: HSTS, CSP, XSS protection, X-Frame-Options — ดี
+- RBAC enforced ทุก controller — ดี
+
+### Inter-Company (หมวด 9) — ✅ ดี
+- Profit allocation ถูกต้อง: Shop = downPayment + principal + commission - cost, Finance = interest - commission
+- Price snapshot ณ วันทำรายการ (immutable) — ถูกต้อง
+- VAT ไม่นับซ้ำระหว่าง entities — ดี
+- Entity Profit Report แยก SHOP/FINANCE — ใช้งานได้
+
+### Receipt Integrity (หมวด 6) — ✅ ดี
+- Sequential numbering RC-YYYY-MM-NNNNN พร้อม concurrency lock — ดีมาก
+- SHA-256 file hash ป้องกัน tampering — ดี
+- Issuer tracking (issuedById) — ดี
+- Credit Note auto-generate เมื่อ void — ดี
+- Receipt types ครอบคลุม: PAYMENT, DOWN_PAYMENT, EARLY_PAYOFF, CREDIT_NOTE
+
+### Database Design — ✅ ดี
+- Money fields ใช้ `Decimal(12,2)` ทั้งหมด — ไม่มี Float
+- Soft delete ทุก model (ยกเว้น AuditLog ที่ต้อง immutable) — ถูกต้อง
+- UUID สำหรับ ID ทุก model — ดี
+- Timestamps (createdAt, updatedAt, deletedAt) ครบทุก model — ดี
+
+---
+
+## Action Items
+
+| ลำดับ | ประเด็น | ความเร่งด่วน | ผู้รับผิดชอบ | หมายเหตุ |
+|:-----:|---------|:----------:|:-----------:|---------|
+| 1 | **C-002** VAT รวมดอกเบี้ย — แก้สูตร installment.util.ts | **สูงมาก** | Backend Dev | ผิดกฎหมาย — แก้ก่อนใช้งานจริง |
+| 2 | **C-006** Bundle cost ไม่รวมใน COGS | **สูง** | Backend Dev | กำไรขั้นต้น overstate |
+| 3 | **C-005** ใบเสร็จขาดข้อมูลตามกฎหมาย | **สูง** | Full-stack | ใช้เป็นใบกำกับภาษีไม่ได้ |
+| 4 | **C-007** Expense void ไม่มี trail | **สูง** | Backend Dev | เพิ่ม 3 fields + validation |
+| 5 | **W-008** Creator = Approver ได้ | **สูง** | Backend Dev | เพิ่ม 1 line validation |
+| 6 | **C-001** ผังบัญชีไม่ครบ 5 หมวด | **สูง** | Backend Dev + Accountant | Foundation สำหรับ C-008 |
+| 7 | **C-004** ไม่มีระบบตั้งสำรองหนี้สงสัยจะสูญ | **สูง** | Backend Dev + Accountant | ลูกหนี้ overstate |
+| 8 | **C-003** WHT ไม่สมบูรณ์ | **สูง** | Backend Dev | ต้องยื่น ภ.ง.ด.3/53 |
+| 9 | **C-008** ขาดงบดุล + งบกระแสเงินสด | **กลาง** | Backend Dev + Accountant | ต้องมีผังบัญชีก่อน (C-001) |
+| 10 | **W-011** AuditLog updatedAt | **กลาง** | Backend Dev | ลบ 1 field |
+| 11 | **W-013** Period Closing lock | **กลาง** | Backend Dev | ป้องกันแก้ไขย้อนหลัง |
+| 12 | **W-009** Inter-Company single entry | **กลาง** | Backend Dev | หรือ document ว่ายอมรับได้ |
+| 13 | **W-005** Voided receipt still in queries | **กลาง** | Backend Dev | เพิ่ม filter |
+| 14 | **W-012** ไม่มี MoM/YoY comparison | **ต่ำ** | Backend Dev | Nice to have |
+| 15 | **R-001 - R-015** ข้อเสนอแนะทั้งหมด | **ต่ำ** | ทีม | ปรับปรุงตามลำดับ |
+
+---
+
+## หมายเหตุ
+
+1. **ขอบเขตการตรวจสอบ**: ตรวจจาก source code เท่านั้น ไม่ได้ตรวจ runtime behavior หรือ production data
+2. **มาตรฐานอ้างอิง**: TFRS 15, TAS 2, TAS 18, TAS 24, TFRS 9, TFRS 10, TFRS for NPAEs, ประมวลรัษฎากร, พ.ร.บ.การบัญชี พ.ศ. 2543, COSO Framework
+3. **Positive note**: ระบบมีพื้นฐานที่ดี โดยเฉพาะ Revenue Recognition, Payment Allocation, และ Audit Trail — ส่วนใหญ่ที่ต้องแก้ไขเป็นเรื่อง completeness ของข้อมูลบัญชี ไม่ใช่ logic ผิด
+4. **Priority recommendation**: แก้ C-002 (VAT) ก่อนเป็นอันดับแรก เพราะมีผลกระทบทางกฎหมายโดยตรงกับลูกค้าทุกราย
+
+---
+
+*รายงานฉบับนี้สร้างโดย AI Auditor — ควรให้ผู้สอบบัญชีรับอนุญาต (CPA) ตรวจทานอีกครั้งก่อนดำเนินการ*


### PR DESCRIPTION
## Summary
- **7 Critical fixes**: Chart of Accounts (76 accounts), WHT fields, bad debt provisioning, receipt legal compliance, bundle COGS, expense void trail, Balance Sheet + Cash Flow
- **14 Warning fixes**: voided receipt filtering, credit note 30-day limit, segregation of duties, inter-company CONFIRMED status, AuditLog immutability, MoM/YoY reports, period closing lock
- **15 Recommendations**: tax point documentation, repossession cost adjustment, P&L income separation, payment idempotency, quarterly reports, and more

## What's NOT included
- **C-002 (VAT on hire-purchase interest)**: Deferred pending business structure decision (markup vs interest)

## Post-merge steps
```bash
cd apps/api
npx prisma generate
npx prisma migrate dev --name accounting_audit_fixes
npx prisma db seed
```

## New API endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/expenses/bad-debt/calculate` | Calculate bad debt provisions |
| GET | `/expenses/bad-debt/summary` | Get provision summary |
| POST | `/expenses/bad-debt/write-off/:contractId` | Write off bad debt |
| GET | `/expenses/balance-sheet` | Derived Balance Sheet |
| GET | `/expenses/cash-flow` | Cash Flow Statement |
| GET | `/reports/balance-sheet` | Balance Sheet (via reports) |
| GET | `/reports/cash-flow` | Cash Flow (via reports) |
| GET | `/reports/comparative-pl` | MoM/YoY P&L comparison |
| GET | `/reports/quarterly` | Quarterly P&L report |
| POST | `/expenses/close-period` | Close accounting period |
| GET | `/expenses/period-status` | Get period lock status |
| PATCH | `/inter-company/:id/confirm` | Confirm inter-company tx |

## Test plan
- [ ] Run `prisma migrate dev` and verify migration succeeds
- [ ] Run `prisma db seed` and verify 76 Chart of Accounts entries created
- [ ] Test Balance Sheet endpoint returns correct asset/liability/equity breakdown
- [ ] Test bad debt provisioning calculates correct rates per aging bucket
- [ ] Test expense void requires reason and tracks voidedById
- [ ] Test segregation of duties (creator cannot approve own expense)
- [ ] Test period closing prevents backdated expense creation
- [ ] Test voided receipts excluded from default queries
- [ ] Test Credit Note rejected after 30 days
- [ ] Verify P&L grossProfit uses operatingRevenue (not totalRevenue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)