### PR TITLE
fix(test): update payment test mocks for idempotency change

### DIFF
--- a/apps/api/src/modules/payments/payments-financial.integration.spec.ts
+++ b/apps/api/src/modules/payments/payments-financial.integration.spec.ts
@@ -52,8 +52,9 @@ describe('PaymentsService — Financial Integration', () => {
       payment: {
         findFirst: jest.fn().mockImplementation(({ where }) => {
           if (where.installmentNo != null) return payments.find(p => p.installmentNo === where.installmentNo) ?? null;
-          return null; // idempotency check → no duplicate
+          return null;
         }),
+        findMany: jest.fn().mockResolvedValue([]), // idempotency check → no duplicate
         update: jest.fn().mockImplementation(({ where, data }) => {
           const p = payments.find(pp => pp.id === where.id);
           if (p) Object.assign(p, data);

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -261,7 +261,7 @@ describe('PaymentsService', () => {
       await service.getContractPayments('contract-1');
       expect(prisma.payment.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { contractId: 'contract-1' },
+          where: expect.objectContaining({ contractId: 'contract-1' }),
           orderBy: { installmentNo: 'asc' },
         }),
       );

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -145,21 +145,18 @@ describe('PaymentsService', () => {
     it('should accept payment with transaction ref instead of evidence URL', async () => {
       const updatedPayment = { ...mockPayment, amountPaid: 3000, status: 'PAID', paidDate: new Date() };
       prisma.payment.update.mockResolvedValue(updatedPayment);
-      prisma.payment.findFirst
-        .mockResolvedValueOnce(null) // idempotency check - no duplicate
-        .mockResolvedValueOnce(mockPayment); // inside transaction
+      prisma.payment.findMany.mockResolvedValueOnce([]); // idempotency check - no duplicate
 
       const result = await service.recordPayment('contract-1', 1, 3000, 'TRANSFER', 'user-1', undefined, undefined, 'TXN-12345');
       expect(result.status).toBe('PAID');
     });
 
     it('should reject duplicate transactionRef (idempotency)', async () => {
-      // First findFirst call returns an existing paid payment with the same ref
-      prisma.payment.findFirst.mockResolvedValueOnce({
-        ...mockPayment,
-        status: 'PAID',
+      // findMany returns a candidate with exact matching ref tag
+      prisma.payment.findMany.mockResolvedValueOnce([{
+        id: 'payment-dup',
         notes: 'ref:TXN-DUPLICATE',
-      });
+      }]);
 
       await expect(
         service.recordPayment('contract-1', 1, 3000, 'TRANSFER', 'user-1', undefined, undefined, 'TXN-DUPLICATE'),
@@ -169,9 +166,7 @@ describe('PaymentsService', () => {
     it('should append transactionRef to notes for tracking', async () => {
       const updatedPayment = { ...mockPayment, amountPaid: 3000, status: 'PAID', paidDate: new Date() };
       prisma.payment.update.mockResolvedValue(updatedPayment);
-      prisma.payment.findFirst
-        .mockResolvedValueOnce(null) // idempotency check
-        .mockResolvedValueOnce(mockPayment); // inside transaction
+      prisma.payment.findMany.mockResolvedValueOnce([]); // idempotency check - no dup
 
       await service.recordPayment('contract-1', 1, 3000, 'TRANSFER', 'user-1', undefined, 'customer note', 'TXN-99');
       expect(prisma.payment.update).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Fix 2 failing test specs caused by R-012 idempotency change (findFirst → findMany)
- `payments.service.spec.ts`: mock `findMany` instead of `findFirst` for transactionRef checks
- `payments-financial.integration.spec.ts`: add `findMany` to tx mock

## Context
PR #408 changed the payment idempotency check from `tx.payment.findFirst` to `tx.payment.findMany` for exact-match verification. The test mocks were not updated, causing `TypeError: tx.payment.findMany is not a function`.

## Test plan
- [ ] CI passes: 292/292 tests green
- [ ] Deploy workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)