### PR TITLE
fix(db): add missing chart_of_accounts migration

### DIFF
--- a/apps/api/prisma/migrations/20260408100000_add_chart_of_accounts/migration.sql
+++ b/apps/api/prisma/migrations/20260408100000_add_chart_of_accounts/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "AccountGroup" AS ENUM ('ASSET', 'LIABILITY', 'EQUITY', 'REVENUE', 'EXPENSE');
+
+-- CreateTable
+CREATE TABLE "chart_of_accounts" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "name_th" TEXT NOT NULL,
+    "name_en" TEXT,
+    "account_group" "AccountGroup" NOT NULL,
+    "parent_code" TEXT,
+    "level" INTEGER NOT NULL DEFAULT 1,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "chart_of_accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "chart_of_accounts_code_key" ON "chart_of_accounts"("code");
+
+-- CreateIndex
+CREATE INDEX "chart_of_accounts_account_group_idx" ON "chart_of_accounts"("account_group");
+
+-- CreateIndex
+CREATE INDEX "chart_of_accounts_code_idx" ON "chart_of_accounts"("code");

--- a/apps/api/prisma/seed-chart-of-accounts-only.ts
+++ b/apps/api/prisma/seed-chart-of-accounts-only.ts
@@ -1,0 +1,31 @@
+/**
+ * Standalone seed script — populates ONLY the chart_of_accounts table.
+ *
+ * Why this exists:
+ *   The main `seed.ts` creates demo users/branches/contracts and must
+ *   never run on production. This script isolates the chart-of-accounts
+ *   seed so it can be executed safely on prod via a Cloud Run Job.
+ *
+ * Usage (one-time, after the add_chart_of_accounts migration is applied):
+ *   npx tsx apps/api/prisma/seed-chart-of-accounts-only.ts
+ *
+ * The underlying seedChartOfAccounts() uses upsert by `code`, so this
+ * script is idempotent — re-running it is safe.
+ */
+import { PrismaClient } from '@prisma/client';
+import { seedChartOfAccounts } from './seeds/chart-of-accounts';
+
+async function main() {
+  const prisma = new PrismaClient();
+  try {
+    await seedChartOfAccounts(prisma);
+    console.log('✅ Chart of Accounts seed completed successfully.');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('❌ Chart of Accounts seed failed:', err);
+  process.exit(1);
+});

--- a/scripts/seed-coa-prod.sh
+++ b/scripts/seed-coa-prod.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# One-shot script to seed the chart_of_accounts table on production.
+#
+# Prerequisites:
+#   1. PR #414 has been merged to main
+#   2. CI deploy completed successfully (migrate-db + deploy-api jobs green)
+#   3. gcloud is authenticated as a user/SA with Cloud Run + Secret Manager access
+#   4. The add_chart_of_accounts migration has been applied
+#      (verify: GET https://api.bestchoicephone.app/api/chart-of-accounts → 200 [])
+#
+# What it does:
+#   - Discovers the current API image + DB config from the existing
+#     bestchoice-migrate Cloud Run Job (so we always seed against the
+#     same image that's running in prod)
+#   - Creates (or updates) a one-shot Cloud Run Job: bestchoice-seed-coa
+#   - Executes it once and waits for completion
+#   - Prints the result; you can re-run safely (upsert by code)
+#
+# Optional cleanup after success:
+#   gcloud run jobs delete bestchoice-seed-coa --region=asia-southeast1 --quiet
+#
+set -euo pipefail
+
+REGION="${REGION:-asia-southeast1}"
+PROJECT="${PROJECT:-bestchoice-prod}"
+SOURCE_JOB="bestchoice-migrate"
+SEED_JOB="bestchoice-seed-coa"
+
+echo "→ Discovering image + Cloud SQL config from ${SOURCE_JOB}..."
+IMAGE=$(gcloud run jobs describe "${SOURCE_JOB}" \
+  --project="${PROJECT}" \
+  --region="${REGION}" \
+  --format='value(spec.template.spec.template.spec.containers[0].image)')
+
+CLOUDSQL=$(gcloud run jobs describe "${SOURCE_JOB}" \
+  --project="${PROJECT}" \
+  --region="${REGION}" \
+  --format='value(spec.template.metadata.annotations["run.googleapis.com/cloudsql-instances"])')
+
+if [[ -z "${IMAGE}" || -z "${CLOUDSQL}" ]]; then
+  echo "✗ Failed to discover image or Cloud SQL connection from ${SOURCE_JOB}" >&2
+  exit 1
+fi
+
+echo "  image:     ${IMAGE}"
+echo "  cloud sql: ${CLOUDSQL}"
+
+echo "→ Creating/updating ${SEED_JOB}..."
+gcloud run jobs update "${SEED_JOB}" \
+  --project="${PROJECT}" \
+  --region="${REGION}" \
+  --image="${IMAGE}" \
+  --set-cloudsql-instances="${CLOUDSQL}" \
+  --set-secrets=DATABASE_URL=DATABASE_URL:latest \
+  --command=npx \
+  --args=tsx,apps/api/prisma/seed-chart-of-accounts-only.ts \
+  --max-retries=1 \
+  --task-timeout=300s \
+  2>/dev/null || \
+gcloud run jobs create "${SEED_JOB}" \
+  --project="${PROJECT}" \
+  --region="${REGION}" \
+  --image="${IMAGE}" \
+  --set-cloudsql-instances="${CLOUDSQL}" \
+  --set-secrets=DATABASE_URL=DATABASE_URL:latest \
+  --command=npx \
+  --args=tsx,apps/api/prisma/seed-chart-of-accounts-only.ts \
+  --max-retries=1 \
+  --task-timeout=300s
+
+echo "→ Executing ${SEED_JOB} (waiting for completion)..."
+gcloud run jobs execute "${SEED_JOB}" \
+  --project="${PROJECT}" \
+  --region="${REGION}" \
+  --wait
+
+echo ""
+echo "✅ Done. Verify with:"
+echo "    curl -s https://api.bestchoicephone.app/api/chart-of-accounts -H 'Authorization: Bearer <TOKEN>' | jq 'length'"
+echo ""
+echo "To clean up the one-shot job:"
+echo "    gcloud run jobs delete ${SEED_JOB} --region=${REGION} --project=${PROJECT} --quiet"


### PR DESCRIPTION
## Summary
- Model `ChartOfAccount` existed in `schema.prisma` but no migration file was ever generated → table never created on prod
- Result: `GET /api/chart-of-accounts` → 500 `relation "public.chart_of_accounts" does not exist`
- This PR adds the missing migration `20260408100000_add_chart_of_accounts`

## Verification
Confirmed via Cloud Run logs (`bestchoice-api`):
```
prisma:error
Invalid prisma.chartOfAccount.findMany() invocation:
The table public.chart_of_accounts does not exist in the current database.
```

Confirmed via grep that no prior migration touches `chart_of_accounts` or `ChartOfAccount`.

## Migration content
- `CREATE TYPE "AccountGroup"` (5 values)
- `CREATE TABLE "chart_of_accounts"` (10 columns matching schema exactly)
- 3 indexes (unique on `code`, index on `account_group`, index on `code`)

## After merge
- CI job `migrate-db` will run `prisma migrate deploy` → table created on prod
- **Table will be empty** — chart of accounts seed (150+ entries) needs to be populated separately as a follow-up

## Test plan
- [ ] CI `migrate-db` job succeeds
- [ ] After deploy, `GET /api/chart-of-accounts` returns `200 []` (not 500)
- [ ] Plan & execute seed step to populate accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)