### PR TITLE
fix(todos): harden S3 attachment upload/download security

### DIFF
--- a/apps/api/src/modules/todos/dto/todo.dto.ts
+++ b/apps/api/src/modules/todos/dto/todo.dto.ts
@@ -6,7 +6,6 @@ import {
   IsDateString,
   IsUUID,
   IsInt,
-  IsNumber,
   Min,
   Max,
   MaxLength,
@@ -76,14 +75,15 @@ export class AttachmentDto {
   @IsString()
   name!: string;
 
-  @IsNumber()
+  @IsInt()
+  @Min(0)
   size!: number;
 
   @IsString()
   mimeType!: string;
 
   @IsOptional()
-  @IsString()
+  @IsDateString()
   uploadedAt?: string;
 }
 

--- a/apps/api/src/modules/todos/todos.controller.ts
+++ b/apps/api/src/modules/todos/todos.controller.ts
@@ -12,8 +12,11 @@ import {
   UploadedFile,
   ParseFilePipe,
   MaxFileSizeValidator,
+  FileTypeValidator,
+  ForbiddenException,
 } from '@nestjs/common';
 import { Res } from '@nestjs/common';
+import { randomUUID } from 'crypto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { Response } from 'express';
@@ -66,6 +69,9 @@ export class TodosController {
             maxSize: 10 * 1024 * 1024,
             message: 'ไฟล์มีขนาดเกิน 10MB',
           }),
+          new FileTypeValidator({
+            fileType: /^(image\/(jpeg|png|gif|webp)|application\/(pdf|msword|vnd\.openxmlformats-officedocument\.wordprocessingml\.document)|video\/(mp4|quicktime))$/,
+          }),
         ],
         fileIsRequired: true,
         errorHttpStatusCode: 400,
@@ -74,7 +80,7 @@ export class TodosController {
     file: Express.Multer.File,
   ) {
     const safeName = file.originalname.replace(/[^\w.-]/g, '_');
-    const key = `todos/${Date.now()}-${Math.random().toString(36).substring(2, 8)}-${safeName}`;
+    const key = `todos/${Date.now()}-${randomUUID()}-${safeName}`;
     await this.storage.upload(key, file.buffer, file.mimetype);
 
     return {
@@ -90,7 +96,12 @@ export class TodosController {
   @Get('attachments/*')
   async downloadAttachment(@Param() params: Record<string, string>, @Res() res: Response) {
     const key = decodeURIComponent(params['0']);
+    if (!key.startsWith('todos/')) {
+      throw new ForbiddenException('ไม่มีสิทธิ์เข้าถึงไฟล์นี้');
+    }
     const stream = await this.storage.getStream(key);
+    res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(key.split('/').pop() ?? 'file')}"`);
+    res.setHeader('Content-Type', 'application/octet-stream');
     stream.pipe(res);
   }
 

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -8,7 +8,7 @@
  * directly in components — use these helpers instead so พ.ศ. is consistent.
  */
 
-const THAI_MONTHS_FULL = [
+export const THAI_MONTHS_FULL = [
   'มกราคม',
   'กุมภาพันธ์',
   'มีนาคม',

--- a/apps/web/src/pages/TaxReportsPage.tsx
+++ b/apps/web/src/pages/TaxReportsPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
-import { formatThaiDateShort } from '@/lib/date';
+import { formatThaiDateShort, THAI_MONTHS_FULL } from '@/lib/date';
 import PageHeader from '@/components/ui/PageHeader';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -60,10 +60,7 @@ function fmt(n: number | null | undefined): string {
   return n.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
-const MONTHS = [
-  'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
-  'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม',
-];
+const MONTHS = THAI_MONTHS_FULL;
 
 const reportTypeLabels: Record<string, string> = {
   PP30: 'ภ.พ.30',


### PR DESCRIPTION
## Summary
- MIME type whitelist on upload — อนุญาตเฉพาะ image, pdf, word, video (ป้องกัน .exe/.svg XSS)
- S3 key prefix guard on download — ต้องขึ้นต้นด้วย `todos/` ป้องกัน path traversal ข้าม prefix อื่น
- Set `Content-Type: application/octet-stream` + `Content-Disposition: attachment` ป้องกัน browser render SVG/HTML
- เปลี่ยน `Math.random()` key generation → `crypto.randomUUID()` (cryptographically secure)
- `AttachmentDto.size` เปลี่ยนเป็น `@IsInt() @Min(0)`
- `AttachmentDto.uploadedAt` เปลี่ยนเป็น `@IsDateString()`
- ลบ duplicate `MONTHS` array ใน TaxReportsPage — ใช้ `THAI_MONTHS_FULL` จาก `@/lib/date` แทน

> แก้ตาม code-reviewer warnings จาก PR #427

## Test plan
- [ ] อัปโหลด attachment ปกติ (image/pdf) — ต้องผ่าน
- [ ] อัปโหลด `.exe` หรือ `.svg` — ต้อง reject 400
- [ ] เปิด attachment download URL ปกติ — ต้อง download ได้
- [ ] เปิด URL ด้วย key นอก `todos/` — ต้อง 403
- [ ] `./tools/check-types.sh all` ผ่าน ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)