### PR TITLE
test: 66 tests covering financial calc + Phase 1 fixes (ultraplan v2 phase 2)

### DIFF
--- a/apps/api/src/modules/commission/commission.service.spec.ts
+++ b/apps/api/src/modules/commission/commission.service.spec.ts
@@ -1,0 +1,302 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { CommissionService } from './commission.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('CommissionService', () => {
+  let service: CommissionService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      salesCommission: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+      commissionRule: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommissionService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<CommissionService>(CommissionService);
+  });
+
+  describe('createCommissionForSale', () => {
+    it('uses Decimal arithmetic so 2.5% of 19999.99 lands exactly', async () => {
+      prisma.salesCommission.create.mockImplementation(({ data }: { data: { commissionAmount: Prisma.Decimal } }) => ({
+        id: 'c1',
+        ...data,
+      }));
+
+      await service.createCommissionForSale('s1', 'sp1', 19999.99, 0.025);
+
+      const arg = prisma.salesCommission.create.mock.calls[0][0];
+      // 19999.99 * 0.025 = 499.99975 → ROUND_HALF_UP at 2dp = 500.00
+      expect(arg.data.commissionAmount).toBeInstanceOf(Prisma.Decimal);
+      expect((arg.data.commissionAmount as Prisma.Decimal).toString()).toBe('500');
+    });
+
+    it('handles a tiny rate × small amount without float drift', async () => {
+      prisma.salesCommission.create.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+
+      // Classic float problem: 0.1 * 0.1 in JS = 0.010000000000000002
+      await service.createCommissionForSale('s1', 'sp1', 0.1, 0.1);
+
+      const arg = prisma.salesCommission.create.mock.calls[0][0];
+      // 0.1 * 0.1 = 0.01 → at 2dp = 0.01
+      expect((arg.data.commissionAmount as Prisma.Decimal).toString()).toBe('0.01');
+    });
+
+    it('rounds half-up at 2 decimal places (not banker\'s rounding)', async () => {
+      prisma.salesCommission.create.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+
+      // 100 * 0.045 = 4.5 → ROUND_HALF_UP gives 4.5 (no rounding needed)
+      // 100 * 0.0455 = 4.55 → exact, no rounding
+      // 100 * 0.04555 = 4.555 → ROUND_HALF_UP gives 4.56
+      await service.createCommissionForSale('s1', 'sp1', 100, 0.04555);
+
+      const arg = prisma.salesCommission.create.mock.calls[0][0];
+      expect((arg.data.commissionAmount as Prisma.Decimal).toString()).toBe('4.56');
+    });
+
+    it('persists period as YYYY-MM of the current month', async () => {
+      jest.useFakeTimers().setSystemTime(new Date(2026, 3, 9)); // April 2026
+      prisma.salesCommission.create.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+
+      await service.createCommissionForSale('s1', 'sp1', 1000, 0.05);
+
+      const arg = prisma.salesCommission.create.mock.calls[0][0];
+      expect(arg.data.period).toBe('2026-04');
+      jest.useRealTimers();
+    });
+
+    it('starts every commission as PENDING', async () => {
+      prisma.salesCommission.create.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+
+      await service.createCommissionForSale('s1', 'sp1', 1000, 0.05);
+      const arg = prisma.salesCommission.create.mock.calls[0][0];
+      expect(arg.data.status).toBe('PENDING');
+    });
+  });
+
+  describe('getSummary', () => {
+    it('filters out soft-deleted commissions', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([]);
+      await service.getSummary();
+      expect(prisma.salesCommission.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ deletedAt: null }) }),
+      );
+    });
+
+    it('groups by salesperson with Decimal-precise totals (no float drift)', async () => {
+      // 1000 satang-level commissions of 0.999 baht each.
+      // Number() accumulation would drift; Decimal must land at exactly 999.
+      const rows = Array.from({ length: 1000 }, (_, i) => ({
+        id: `c${i}`,
+        salespersonId: 'sp1',
+        salesperson: { id: 'sp1', name: 'Test Sales' },
+        saleAmount: new Prisma.Decimal('100'),
+        commissionAmount: new Prisma.Decimal('0.999'),
+        status: 'APPROVED',
+      }));
+      prisma.salesCommission.findMany.mockResolvedValue(rows);
+
+      const summary = await service.getSummary();
+
+      expect(summary).toHaveLength(1);
+      // 100 × 1000 = 100000 (totalSales)
+      expect(summary[0].totalSales).toBe('100000');
+      // 0.999 × 1000 = 999 — exact, no drift
+      expect(summary[0].totalCommission).toBe('999');
+      expect(summary[0].count).toBe(1000);
+      expect(summary[0].approved).toBe(1000);
+      expect(summary[0].pending).toBe(0);
+    });
+
+    it('counts APPROVED and PAID together as approved', async () => {
+      const rows = [
+        {
+          id: 'c1',
+          salespersonId: 'sp1',
+          salesperson: { id: 'sp1', name: 'A' },
+          saleAmount: new Prisma.Decimal('100'),
+          commissionAmount: new Prisma.Decimal('5'),
+          status: 'APPROVED',
+        },
+        {
+          id: 'c2',
+          salespersonId: 'sp1',
+          salesperson: { id: 'sp1', name: 'A' },
+          saleAmount: new Prisma.Decimal('200'),
+          commissionAmount: new Prisma.Decimal('10'),
+          status: 'PAID',
+        },
+        {
+          id: 'c3',
+          salespersonId: 'sp1',
+          salesperson: { id: 'sp1', name: 'A' },
+          saleAmount: new Prisma.Decimal('50'),
+          commissionAmount: new Prisma.Decimal('2.5'),
+          status: 'PENDING',
+        },
+      ];
+      prisma.salesCommission.findMany.mockResolvedValue(rows);
+      const summary = await service.getSummary();
+
+      expect(summary[0].approved).toBe(2);
+      expect(summary[0].pending).toBe(1);
+      expect(summary[0].count).toBe(3);
+      expect(summary[0].totalSales).toBe('350');
+      expect(summary[0].totalCommission).toBe('17.5');
+    });
+
+    it('groups separately when there are multiple salespeople', async () => {
+      const rows = [
+        { id: 'c1', salespersonId: 'sp1', salesperson: { id: 'sp1', name: 'A' }, saleAmount: new Prisma.Decimal('100'), commissionAmount: new Prisma.Decimal('5'), status: 'APPROVED' },
+        { id: 'c2', salespersonId: 'sp2', salesperson: { id: 'sp2', name: 'B' }, saleAmount: new Prisma.Decimal('200'), commissionAmount: new Prisma.Decimal('10'), status: 'APPROVED' },
+      ];
+      prisma.salesCommission.findMany.mockResolvedValue(rows);
+      const summary = await service.getSummary();
+
+      expect(summary).toHaveLength(2);
+      const a = summary.find((s) => s.salesperson.id === 'sp1')!;
+      const b = summary.find((s) => s.salesperson.id === 'sp2')!;
+      expect(a.totalCommission).toBe('5');
+      expect(b.totalCommission).toBe('10');
+    });
+
+    it('serializes Decimal totals as strings (frontend uses parseFloat)', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([
+        { id: 'c1', salespersonId: 'sp1', salesperson: { id: 'sp1', name: 'A' }, saleAmount: new Prisma.Decimal('123.45'), commissionAmount: new Prisma.Decimal('6.17'), status: 'APPROVED' },
+      ]);
+      const summary = await service.getSummary();
+      expect(typeof summary[0].totalSales).toBe('string');
+      expect(typeof summary[0].totalCommission).toBe('string');
+    });
+  });
+
+  describe('approve', () => {
+    it('throws NotFoundException when commission missing', async () => {
+      prisma.salesCommission.findFirst.mockResolvedValue(null);
+      await expect(service.approve('missing', 'u1')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('refuses to approve a non-PENDING commission', async () => {
+      prisma.salesCommission.findFirst.mockResolvedValue({ id: 'c1', status: 'APPROVED' });
+      await expect(service.approve('c1', 'u1')).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('flips PENDING to APPROVED with approver and timestamp', async () => {
+      prisma.salesCommission.findFirst.mockResolvedValue({ id: 'c1', status: 'PENDING' });
+      prisma.salesCommission.update.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+
+      const result = await service.approve('c1', 'manager1');
+
+      expect(prisma.salesCommission.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: expect.objectContaining({
+          status: 'APPROVED',
+          approvedById: 'manager1',
+          approvedAt: expect.any(Date),
+        }),
+      });
+      expect(result.status).toBe('APPROVED');
+    });
+
+    it('does NOT filter soft-deleted in update (only in lookup)', async () => {
+      prisma.salesCommission.findFirst.mockResolvedValue({ id: 'c1', status: 'PENDING' });
+      prisma.salesCommission.update.mockResolvedValue({ id: 'c1', status: 'APPROVED' });
+
+      await service.approve('c1', 'manager1');
+
+      // Lookup must filter
+      expect(prisma.salesCommission.findFirst).toHaveBeenCalledWith({
+        where: { id: 'c1', deletedAt: null },
+      });
+    });
+  });
+
+  describe('markPaid', () => {
+    it('throws NotFoundException when commission missing', async () => {
+      prisma.salesCommission.findFirst.mockResolvedValue(null);
+      await expect(service.markPaid('missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('refuses to pay a non-APPROVED commission', async () => {
+      prisma.salesCommission.findFirst.mockResolvedValue({ id: 'c1', status: 'PENDING' });
+      await expect(service.markPaid('c1')).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('uses the original commissionAmount for paidAmount', async () => {
+      const original = new Prisma.Decimal('123.45');
+      prisma.salesCommission.findFirst.mockResolvedValue({
+        id: 'c1',
+        status: 'APPROVED',
+        commissionAmount: original,
+      });
+      prisma.salesCommission.update.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+
+      await service.markPaid('c1');
+
+      const callArg = prisma.salesCommission.update.mock.calls[0][0];
+      expect(callArg.data.status).toBe('PAID');
+      expect(callArg.data.paidAmount).toBe(original);
+    });
+  });
+
+  describe('findAll', () => {
+    it('filters out soft-deleted commissions', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([]);
+      prisma.salesCommission.count.mockResolvedValue(0);
+
+      await service.findAll({});
+
+      expect(prisma.salesCommission.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ deletedAt: null }) }),
+      );
+    });
+
+    it('caps page size to 100 even when caller asks for more', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([]);
+      prisma.salesCommission.count.mockResolvedValue(0);
+
+      const result = await service.findAll({ limit: 1000 });
+      expect(result.limit).toBe(100);
+    });
+
+    it('returns shape { data, total, page, limit, totalPages }', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([]);
+      prisma.salesCommission.count.mockResolvedValue(0);
+
+      const result = await service.findAll({ page: 1, limit: 50 });
+      expect(result).toEqual({ data: [], total: 0, page: 1, limit: 50, totalPages: 0 });
+    });
+  });
+});

--- a/apps/api/src/modules/finance-receivable/finance-receivable.service.spec.ts
+++ b/apps/api/src/modules/finance-receivable/finance-receivable.service.spec.ts
@@ -1,0 +1,307 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { FinanceReceivableService } from './finance-receivable.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('FinanceReceivableService', () => {
+  let service: FinanceReceivableService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      financeReceivable: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FinanceReceivableService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<FinanceReceivableService>(FinanceReceivableService);
+  });
+
+  describe('findAll', () => {
+    it('always filters out soft-deleted rows', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      prisma.financeReceivable.count.mockResolvedValue(0);
+
+      await service.findAll({});
+
+      const arg = prisma.financeReceivable.findMany.mock.calls[0][0];
+      expect(arg.where.deletedAt).toBeNull();
+    });
+
+    it('caps page size to 100 even when caller requests 1000', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      prisma.financeReceivable.count.mockResolvedValue(0);
+
+      const result = await service.findAll({ limit: 1000 });
+      expect(result.limit).toBe(100);
+    });
+
+    it('coerces page < 1 to 1', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      prisma.financeReceivable.count.mockResolvedValue(0);
+
+      const result = await service.findAll({ page: -5 });
+      expect(result.page).toBe(1);
+    });
+
+    it('builds an OR search clause across refNumber/bankRef/sale/customer', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      prisma.financeReceivable.count.mockResolvedValue(0);
+
+      await service.findAll({ search: 'GFIN-123' });
+
+      const arg = prisma.financeReceivable.findMany.mock.calls[0][0];
+      expect(arg.where.OR).toBeDefined();
+      expect(arg.where.OR).toHaveLength(4);
+      expect(arg.where.OR[0].financeRefNumber.contains).toBe('GFIN-123');
+    });
+
+    it('passes branchId / status / financeCompany filters through verbatim', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      prisma.financeReceivable.count.mockResolvedValue(0);
+
+      await service.findAll({ branchId: 'b1', status: 'PENDING', financeCompany: 'GFIN' });
+
+      const arg = prisma.financeReceivable.findMany.mock.calls[0][0];
+      expect(arg.where.branchId).toBe('b1');
+      expect(arg.where.status).toBe('PENDING');
+      expect(arg.where.financeCompany).toBe('GFIN');
+    });
+
+    it('expands endDate to end-of-day so the bound is inclusive', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      prisma.financeReceivable.count.mockResolvedValue(0);
+
+      await service.findAll({ endDate: '2026-04-09' });
+
+      const arg = prisma.financeReceivable.findMany.mock.calls[0][0];
+      const lte = arg.where.expectedDate.lte as Date;
+      expect(lte.getHours()).toBe(23);
+      expect(lte.getMinutes()).toBe(59);
+      expect(lte.getSeconds()).toBe(59);
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFoundException when missing or soft-deleted', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue(null);
+      await expect(service.findOne('missing')).rejects.toBeInstanceOf(NotFoundException);
+      // verify it filters soft-deleted
+      const where = prisma.financeReceivable.findFirst.mock.calls[0][0].where;
+      expect(where.deletedAt).toBeNull();
+    });
+  });
+
+  describe('recordReceive', () => {
+    const baseRecord = {
+      id: 'fr1',
+      status: 'PENDING' as const,
+      netExpectedAmount: new Prisma.Decimal('10000'),
+      receivedAmount: null,
+      note: 'old note',
+    };
+
+    beforeEach(() => {
+      prisma.financeReceivable.update.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ ...baseRecord, ...data }),
+      );
+    });
+
+    it('throws NotFoundException when record missing', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue(null);
+      await expect(
+        service.recordReceive('missing', { receivedAmount: 100, receivedDate: '2026-04-09', bankRef: 'TX1' }, 'u1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('refuses to record on an already RECEIVED row', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue({ ...baseRecord, status: 'RECEIVED' });
+      await expect(
+        service.recordReceive('fr1', { receivedAmount: 100, receivedDate: '2026-04-09', bankRef: 'TX1' }, 'u1'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('marks status RECEIVED when received >= expected', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue(baseRecord);
+
+      await service.recordReceive(
+        'fr1',
+        { receivedAmount: 10000, receivedDate: '2026-04-09', bankRef: 'TX1' },
+        'u1',
+      );
+
+      const data = prisma.financeReceivable.update.mock.calls[0][0].data;
+      expect(data.status).toBe('RECEIVED');
+    });
+
+    it('marks status PARTIALLY_RECEIVED when received < expected', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue(baseRecord);
+
+      await service.recordReceive(
+        'fr1',
+        { receivedAmount: 5000, receivedDate: '2026-04-09', bankRef: 'TX1' },
+        'u1',
+      );
+
+      const data = prisma.financeReceivable.update.mock.calls[0][0].data;
+      expect(data.status).toBe('PARTIALLY_RECEIVED');
+    });
+
+    it('still marks RECEIVED when received exceeds expected (no overpayment guard)', async () => {
+      // Documents the current behavior — overpayment is ALLOWED.
+      prisma.financeReceivable.findFirst.mockResolvedValue(baseRecord);
+
+      await service.recordReceive(
+        'fr1',
+        { receivedAmount: 12000, receivedDate: '2026-04-09', bankRef: 'TX1' },
+        'u1',
+      );
+
+      const data = prisma.financeReceivable.update.mock.calls[0][0].data;
+      expect(data.status).toBe('RECEIVED');
+    });
+
+    it('preserves the original note when caller does not supply one', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue(baseRecord);
+
+      await service.recordReceive(
+        'fr1',
+        { receivedAmount: 10000, receivedDate: '2026-04-09', bankRef: 'TX1' },
+        'u1',
+      );
+
+      const data = prisma.financeReceivable.update.mock.calls[0][0].data;
+      expect(data.note).toBe('old note');
+    });
+
+    it('records the receivedAmount as a Prisma.Decimal', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue(baseRecord);
+
+      await service.recordReceive(
+        'fr1',
+        { receivedAmount: 9999.99, receivedDate: '2026-04-09', bankRef: 'TX1' },
+        'u1',
+      );
+
+      const data = prisma.financeReceivable.update.mock.calls[0][0].data;
+      expect(data.receivedAmount).toBeInstanceOf(Prisma.Decimal);
+      expect((data.receivedAmount as Prisma.Decimal).toString()).toBe('9999.99');
+    });
+  });
+
+  describe('update — commission rate recomputation', () => {
+    it('recomputes commissionAmount and netExpectedAmount when commissionRate changes', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue({
+        id: 'fr1',
+        expectedAmount: new Prisma.Decimal('10000'),
+      });
+      prisma.financeReceivable.update.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => data,
+      );
+
+      await service.update('fr1', { commissionRate: 0.05 });
+
+      const data = prisma.financeReceivable.update.mock.calls[0][0].data;
+      // 10000 × 0.05 = 500 commission, net = 9500
+      expect((data.commissionAmount as Prisma.Decimal).toString()).toBe('500');
+      expect((data.netExpectedAmount as Prisma.Decimal).toString()).toBe('9500');
+    });
+
+    it('does NOT touch commission fields when commissionRate is undefined', async () => {
+      prisma.financeReceivable.findFirst.mockResolvedValue({
+        id: 'fr1',
+        expectedAmount: new Prisma.Decimal('10000'),
+      });
+      prisma.financeReceivable.update.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => data,
+      );
+
+      await service.update('fr1', { note: 'updated' });
+
+      const data = prisma.financeReceivable.update.mock.calls[0][0].data;
+      expect(data.commissionRate).toBeUndefined();
+      expect(data.commissionAmount).toBeUndefined();
+      expect(data.netExpectedAmount).toBeUndefined();
+      expect(data.note).toBe('updated');
+    });
+  });
+
+  describe('getSummary', () => {
+    it('aggregates by status with Decimal-precise sums', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([
+        { status: 'PENDING', netExpectedAmount: new Prisma.Decimal('1000'), receivedAmount: null },
+        { status: 'PENDING', netExpectedAmount: new Prisma.Decimal('500'), receivedAmount: null },
+        { status: 'RECEIVED', netExpectedAmount: new Prisma.Decimal('2000'), receivedAmount: new Prisma.Decimal('2000') },
+        { status: 'OVERDUE', netExpectedAmount: new Prisma.Decimal('800'), receivedAmount: new Prisma.Decimal('300') },
+        { status: 'DISPUTED', netExpectedAmount: new Prisma.Decimal('700'), receivedAmount: null },
+      ]);
+
+      const summary = await service.getSummary();
+
+      expect(summary.totalPending).toBe(2);
+      expect(summary.totalReceived).toBe(1);
+      expect(summary.totalOverdue).toBe(1);
+      expect(summary.totalDisputed).toBe(1);
+      // pending = 1000 + 500 = 1500 (received is null → 0)
+      expect(summary.pendingAmount.toString()).toBe('1500');
+      expect(summary.receivedAmount.toString()).toBe('2000');
+      // overdue = 800 - 300 = 500
+      expect(summary.overdueAmount.toString()).toBe('500');
+      expect(summary.disputedAmount.toString()).toBe('700');
+    });
+
+    it('counts PARTIALLY_RECEIVED inside the Pending bucket', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([
+        { status: 'PARTIALLY_RECEIVED', netExpectedAmount: new Prisma.Decimal('1000'), receivedAmount: new Prisma.Decimal('400') },
+      ]);
+
+      const summary = await service.getSummary();
+      expect(summary.totalPending).toBe(1);
+      expect(summary.pendingAmount.toString()).toBe('600');
+    });
+
+    it('filters by branchId when provided', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      await service.getSummary('b1');
+
+      const where = prisma.financeReceivable.findMany.mock.calls[0][0].where;
+      expect(where.branchId).toBe('b1');
+      expect(where.deletedAt).toBeNull();
+    });
+
+    it('returns zeros for an empty dataset', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([]);
+      const summary = await service.getSummary();
+      expect(summary.totalPending).toBe(0);
+      expect(summary.pendingAmount.toString()).toBe('0');
+    });
+  });
+
+  describe('getFinanceCompanies', () => {
+    it('returns distinct finance company names sorted ASC', async () => {
+      prisma.financeReceivable.findMany.mockResolvedValue([
+        { financeCompany: 'GFIN' },
+        { financeCompany: 'KTC' },
+      ]);
+
+      const companies = await service.getFinanceCompanies();
+      expect(companies).toEqual(['GFIN', 'KTC']);
+
+      const arg = prisma.financeReceivable.findMany.mock.calls[0][0];
+      expect(arg.distinct).toEqual(['financeCompany']);
+      expect(arg.where.deletedAt).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/pages/ContractCreatePage/hooks/useContractCalculation.test.ts
+++ b/apps/web/src/pages/ContractCreatePage/hooks/useContractCalculation.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useState } from 'react';
+import { useContractCalculation } from './useContractCalculation';
+import type { Product, InterestConfig } from '../types';
+
+/**
+ * useContractCalculation is the single source of truth for contract pricing.
+ * It computes principal, store commission, interest, VAT, financed amount,
+ * and monthly payment for every installment sale created in the system.
+ *
+ * Formula (per CLAUDE.md "Flow เงินเมื่อขายผ่อน"):
+ *   principal       = max(sellingPrice - downPayment, 0)
+ *   storeCommission = principal * storeCommPct
+ *   interestTotal   = principal * interestRate * totalMonths   (flat rate)
+ *   vatAmount       = (principal + storeCommission + interestTotal) * vatPct
+ *   financedAmount  = principal + storeCommission + interestTotal + vatAmount
+ *   monthlyPayment  = ceil(financedAmount / totalMonths)
+ *
+ * If this hook drifts, every contract gets the wrong numbers.
+ */
+
+const makeProduct = (price: number): Product =>
+  ({
+    id: 'p1',
+    name: 'iPhone 15',
+    brand: 'Apple',
+    model: '15',
+    prices: [
+      { label: 'ราคาผ่อน BESTCHOICE', amount: String(price), isDefault: true },
+    ],
+  }) as unknown as Product;
+
+const makeConfig = (overrides: Partial<InterestConfig> = {}): InterestConfig =>
+  ({
+    interestRate: '0.015', // 1.5%/เดือน flat
+    minDownPaymentPct: '0.20',
+    storeCommissionPct: '0.10',
+    vatPct: '0.07',
+    minInstallmentMonths: 6,
+    maxInstallmentMonths: 24,
+    ...overrides,
+  }) as unknown as InterestConfig;
+
+/**
+ * Wrapper that lets tests pass plain values + observe outputs without
+ * having to hand-roll setState wiring inside every test.
+ */
+function setupHook(opts: {
+  product: Product | null;
+  config?: InterestConfig | null;
+  initialDownPayment?: number;
+  initialMonths?: number;
+}) {
+  return renderHook(() => {
+    const [downPayment, setDownPayment] = useState(opts.initialDownPayment ?? 0);
+    const [totalMonths, setTotalMonths] = useState(opts.initialMonths ?? 12);
+    const calc = useContractCalculation({
+      selectedProduct: opts.product,
+      interestConfig: opts.config ?? null,
+      posConfig: undefined,
+      downPayment,
+      setDownPayment,
+      totalMonths,
+      setTotalMonths,
+    });
+    return { ...calc, downPayment, totalMonths, setDownPayment, setTotalMonths };
+  });
+}
+
+describe('useContractCalculation', () => {
+  describe('selling price extraction', () => {
+    it('returns 0 when no product is selected', () => {
+      const { result } = setupHook({ product: null });
+      expect(result.current.sellingPrice).toBe(0);
+      expect(result.current.principal).toBe(0);
+      expect(result.current.financedAmount).toBe(0);
+      expect(result.current.monthlyPayment).toBe(0);
+    });
+
+    it('uses "ราคาผ่อน BESTCHOICE" price when present', () => {
+      const product = {
+        id: 'p1',
+        name: 'iPhone',
+        brand: 'Apple',
+        model: '15',
+        prices: [
+          { label: 'ราคาเงินสด', amount: '20000', isDefault: false },
+          { label: 'ราคาผ่อน BESTCHOICE', amount: '25000', isDefault: false },
+        ],
+      } as unknown as Product;
+      const { result } = setupHook({ product });
+      expect(result.current.sellingPrice).toBe(25000);
+    });
+
+    it('falls back to default price when no installment price is set', () => {
+      const product = {
+        id: 'p1',
+        name: 'iPhone',
+        brand: 'Apple',
+        model: '15',
+        prices: [
+          { label: 'ราคาขาย', amount: '18000', isDefault: true },
+        ],
+      } as unknown as Product;
+      const { result } = setupHook({ product });
+      expect(result.current.sellingPrice).toBe(18000);
+    });
+  });
+
+  describe('canonical 12-month installment', () => {
+    // Reference case used by the rest of the suite to anchor the formula.
+    // sellingPrice 25000, down 5000, 12 months, 1.5%, comm 10%, VAT 7%
+    //   principal       = 20000
+    //   storeCommission = 2000
+    //   interestTotal   = 20000 * 0.015 * 12 = 3600
+    //   subtotalForVat  = 20000 + 2000 + 3600 = 25600
+    //   vatAmount       = 25600 * 0.07 = 1792
+    //   financedAmount  = 25600 + 1792 = 27392
+    //   monthlyPayment  = ceil(27392 / 12) = 2283
+    it('matches the canonical numbers for the 25000/5000/12 case', () => {
+      const { result } = setupHook({
+        product: makeProduct(25000),
+        config: makeConfig(),
+        initialDownPayment: 5000,
+        initialMonths: 12,
+      });
+      expect(result.current.sellingPrice).toBe(25000);
+      expect(result.current.principal).toBe(20000);
+      expect(result.current.storeCommission).toBe(2000);
+      expect(result.current.interestTotal).toBe(3600);
+      expect(result.current.vatAmount).toBeCloseTo(1792, 6);
+      expect(result.current.financedAmount).toBeCloseTo(27392, 6);
+      expect(result.current.monthlyPayment).toBe(2283);
+    });
+  });
+
+  describe('zero-interest plan', () => {
+    it('still applies storeCommission and VAT', () => {
+      const { result } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig({ interestRate: '0' }),
+        initialDownPayment: 0,
+        initialMonths: 10,
+      });
+      // Mark touched so auto-set effect doesn't override our 0 down payment
+      act(() => {
+        result.current.setDownPaymentTouched(true);
+        result.current.setDownPayment(0);
+      });
+      // principal=10000, comm=1000, interest=0
+      // vatable=11000, vat=770, financed=11770, monthly=ceil(1177)=1177
+      expect(result.current.principal).toBe(10000);
+      expect(result.current.storeCommission).toBe(1000);
+      expect(result.current.interestTotal).toBe(0);
+      expect(result.current.vatAmount).toBeCloseTo(770, 6);
+      expect(result.current.financedAmount).toBeCloseTo(11770, 6);
+      expect(result.current.monthlyPayment).toBe(1177);
+    });
+  });
+
+  describe('24-month plan', () => {
+    it('scales interest linearly with months (flat rate)', () => {
+      const { result } = setupHook({
+        product: makeProduct(30000),
+        config: makeConfig(),
+        initialDownPayment: 6000,
+        initialMonths: 24,
+      });
+      // principal=24000, comm=2400, interest=24000*0.015*24=8640
+      // vatable=35040, vat=2452.8, financed=37492.8, monthly=ceil(37492.8/24)=ceil(1562.2)=1563
+      expect(result.current.principal).toBe(24000);
+      expect(result.current.interestTotal).toBe(8640);
+      expect(result.current.vatAmount).toBeCloseTo(2452.8, 4);
+      expect(result.current.financedAmount).toBeCloseTo(37492.8, 4);
+      expect(result.current.monthlyPayment).toBe(1563);
+    });
+  });
+
+  describe('cash-equivalent (downPayment >= sellingPrice)', () => {
+    it('clamps principal to 0 — no interest, no commission, no VAT', () => {
+      const { result } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig(),
+        initialDownPayment: 10000,
+        initialMonths: 12,
+      });
+      // Need to mark touched so the auto-set effect doesn't override
+      act(() => {
+        result.current.setDownPaymentTouched(true);
+        result.current.setDownPayment(10000);
+      });
+      expect(result.current.principal).toBe(0);
+      expect(result.current.storeCommission).toBe(0);
+      expect(result.current.interestTotal).toBe(0);
+      expect(result.current.vatAmount).toBe(0);
+      expect(result.current.financedAmount).toBe(0);
+      expect(result.current.monthlyPayment).toBe(0);
+    });
+
+    it('also clamps when downPayment overshoots the selling price', () => {
+      const { result } = setupHook({
+        product: makeProduct(8000),
+        config: makeConfig(),
+        initialDownPayment: 10000,
+        initialMonths: 12,
+      });
+      act(() => {
+        result.current.setDownPaymentTouched(true);
+        result.current.setDownPayment(10000);
+      });
+      expect(result.current.principal).toBe(0);
+    });
+  });
+
+  describe('totalMonths === 0 guard', () => {
+    it('returns monthlyPayment 0 instead of dividing by zero', () => {
+      const { result } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig({ minInstallmentMonths: 0, maxInstallmentMonths: 12 }),
+        initialDownPayment: 1000,
+        initialMonths: 0,
+      });
+      expect(result.current.monthlyPayment).toBe(0);
+      expect(Number.isFinite(result.current.monthlyPayment)).toBe(true);
+    });
+  });
+
+  describe('config defaults', () => {
+    it('falls back to posConfig when interestConfig is null', () => {
+      const { result } = renderHook(() => {
+        const [downPayment, setDownPayment] = useState(0);
+        const [totalMonths, setTotalMonths] = useState(12);
+        return useContractCalculation({
+          selectedProduct: makeProduct(20000),
+          interestConfig: null,
+          posConfig: {
+            interestRate: 0.02,
+            minDownPaymentPct: 0.25,
+            storeCommissionPct: 0.05,
+            vatPct: 0.07,
+            minInstallmentMonths: 6,
+            maxInstallmentMonths: 12,
+          },
+          downPayment,
+          setDownPayment,
+          totalMonths,
+          setTotalMonths,
+        });
+      });
+      expect(result.current.interestRate).toBe(0.02);
+      expect(result.current.storeCommPct).toBe(0.05);
+      expect(result.current.minDownPct).toBe(0.25);
+    });
+
+    it('falls back to hard-coded defaults when both config sources are missing', () => {
+      const { result } = renderHook(() => {
+        const [downPayment, setDownPayment] = useState(0);
+        const [totalMonths, setTotalMonths] = useState(12);
+        return useContractCalculation({
+          selectedProduct: makeProduct(20000),
+          interestConfig: null,
+          posConfig: undefined,
+          downPayment,
+          setDownPayment,
+          totalMonths,
+          setTotalMonths,
+        });
+      });
+      // Defaults from the hook source
+      expect(result.current.interestRate).toBe(0.08);
+      expect(result.current.minDownPct).toBe(0.15);
+      expect(result.current.storeCommPct).toBe(0.10);
+      expect(result.current.vatPct).toBe(0.07);
+      expect(result.current.minMonths).toBe(6);
+      expect(result.current.maxMonths).toBe(12);
+    });
+  });
+
+  describe('auto down payment', () => {
+    it('auto-sets downPayment to ceil(sellingPrice * minDownPct) on first render', () => {
+      const { result } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig({ minDownPaymentPct: '0.15' }),
+        initialDownPayment: 0,
+        initialMonths: 12,
+      });
+      // 10000 * 0.15 = 1500 → ceil(1500) = 1500
+      expect(result.current.downPayment).toBe(1500);
+    });
+
+    it('does NOT overwrite downPayment after the user has touched it', () => {
+      const { result, rerender } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig({ minDownPaymentPct: '0.20' }),
+        initialDownPayment: 2000, // already at min
+        initialMonths: 12,
+      });
+      // user touches it
+      act(() => {
+        result.current.setDownPaymentTouched(true);
+        result.current.setDownPayment(500); // intentionally below min
+      });
+      rerender();
+      // hook should NOT auto-correct now
+      expect(result.current.downPayment).toBe(500);
+    });
+  });
+
+  describe('months range clamping', () => {
+    it('clamps totalMonths up to minMonths when current value is below range', () => {
+      const { result } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig({ minInstallmentMonths: 12, maxInstallmentMonths: 24 }),
+        initialDownPayment: 2000,
+        initialMonths: 6,
+      });
+      // After mount + effect, totalMonths should be clamped up to 12
+      expect(result.current.totalMonths).toBe(12);
+    });
+
+    it('clamps totalMonths down to maxMonths when current value is above range', () => {
+      const { result } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig({ minInstallmentMonths: 6, maxInstallmentMonths: 10 }),
+        initialDownPayment: 2000,
+        initialMonths: 24,
+      });
+      expect(result.current.totalMonths).toBe(10);
+    });
+
+    it('produces a contiguous monthOptions array between min and max', () => {
+      const { result } = setupHook({
+        product: makeProduct(10000),
+        config: makeConfig({ minInstallmentMonths: 6, maxInstallmentMonths: 10 }),
+      });
+      expect(result.current.monthOptions).toEqual([6, 7, 8, 9, 10]);
+    });
+  });
+});

--- a/apps/web/src/utils/excel.util.test.ts
+++ b/apps/web/src/utils/excel.util.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import ExcelJS from 'exceljs';
+import { importFromExcel } from './excel.util';
+
+/**
+ * importFromExcel parses payment-import xlsx files for the user.
+ * If it silently drops rows or mis-maps columns, the user thinks they
+ * imported 100 payments but only 87 actually got recorded — a real
+ * data-loss bug. These tests pin the contract.
+ *
+ * Note: importFromExcel takes a `File`. We build an xlsx Buffer with
+ * ExcelJS, wrap it in a File-like object that exposes `.arrayBuffer()`
+ * (which is what the implementation actually awaits).
+ */
+
+interface SheetSpec {
+  headers: string[];
+  rows: unknown[][];
+}
+
+async function makeXlsxFile(sheet: SheetSpec | null): Promise<File> {
+  const wb = new ExcelJS.Workbook();
+  if (sheet) {
+    const ws = wb.addWorksheet('Sheet1');
+    ws.addRow(sheet.headers);
+    for (const row of sheet.rows) ws.addRow(row);
+  }
+  const buffer = await wb.xlsx.writeBuffer();
+  // The implementation only calls file.arrayBuffer(), so we don't need
+  // a real Blob/File — a minimal duck-typed object works in jsdom.
+  return {
+    arrayBuffer: () => Promise.resolve(buffer as ArrayBuffer),
+  } as unknown as File;
+}
+
+describe('importFromExcel', () => {
+  describe('happy paths', () => {
+    it('parses headers + rows into objects keyed by header text', async () => {
+      const file = await makeXlsxFile({
+        headers: ['contractNumber', 'amount', 'paidDate'],
+        rows: [
+          ['CNT-001', 1500, '2026-04-09'],
+          ['CNT-002', 2000, '2026-04-08'],
+        ],
+      });
+
+      const rows = await importFromExcel(file);
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0].contractNumber).toBe('CNT-001');
+      expect(rows[0].amount).toBe(1500);
+      expect(rows[1].contractNumber).toBe('CNT-002');
+    });
+
+    it('preserves numeric types from cells (does not stringify)', async () => {
+      const file = await makeXlsxFile({
+        headers: ['amount'],
+        rows: [[1234.56]],
+      });
+
+      const rows = await importFromExcel(file);
+      expect(typeof rows[0].amount).toBe('number');
+      expect(rows[0].amount).toBe(1234.56);
+    });
+
+    it('returns an empty array when the only row is the header', async () => {
+      const file = await makeXlsxFile({
+        headers: ['a', 'b'],
+        rows: [],
+      });
+
+      const rows = await importFromExcel(file);
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe('edge cases that previously could swallow data', () => {
+    it('returns [] for an empty workbook (no sheets)', async () => {
+      const file = await makeXlsxFile(null);
+      const rows = await importFromExcel(file);
+      expect(rows).toEqual([]);
+    });
+
+    it('trims whitespace around header names', async () => {
+      const file = await makeXlsxFile({
+        headers: ['  contractNumber  ', '  amount  '],
+        rows: [['CNT-1', 100]],
+      });
+
+      const rows = await importFromExcel(file);
+      // Implementation trims headers, so the trimmed key is used:
+      expect(rows[0].contractNumber).toBe('CNT-1');
+      expect(rows[0].amount).toBe(100);
+      // The padded key should NOT exist
+      expect(rows[0]['  contractNumber  ']).toBeUndefined();
+    });
+
+    it('handles rows shorter than the header by leaving missing fields null', async () => {
+      const file = await makeXlsxFile({
+        headers: ['a', 'b', 'c'],
+        rows: [
+          ['x', 'y'], // missing c
+        ],
+      });
+
+      const rows = await importFromExcel(file);
+      expect(rows[0].a).toBe('x');
+      expect(rows[0].b).toBe('y');
+      // ExcelJS returns null for missing cells when accessed via getCell
+      expect(rows[0].c == null).toBe(true);
+    });
+
+    it('keeps duplicate headers — last write wins', async () => {
+      // Spreadsheets sometimes have duplicate column headers; document the
+      // current behavior so a user importing such a file is not surprised.
+      const file = await makeXlsxFile({
+        headers: ['amount', 'amount'],
+        rows: [[100, 200]],
+      });
+
+      const rows = await importFromExcel(file);
+      // Last column wins because the colIndex map stores by header string
+      expect(rows[0].amount).toBe(200);
+    });
+
+    it('processes 100 rows without dropping any', async () => {
+      // Regression guard against off-by-one in the eachRow loop
+      const rows = Array.from({ length: 100 }, (_, i) => [`CNT-${i + 1}`, i * 10]);
+      const file = await makeXlsxFile({
+        headers: ['contractNumber', 'amount'],
+        rows,
+      });
+
+      const parsed = await importFromExcel(file);
+      expect(parsed).toHaveLength(100);
+      expect(parsed[0].contractNumber).toBe('CNT-1');
+      expect(parsed[99].contractNumber).toBe('CNT-100');
+      expect(parsed[99].amount).toBe(990);
+    });
+  });
+
+  describe('robustness', () => {
+    it('rejects when given a non-xlsx file', async () => {
+      const garbage = {
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      } as unknown as File;
+
+      await expect(importFromExcel(garbage)).rejects.toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

ultraplan v2 Phase 2 — locks in business calculation behavior. Re-opened after Phase 1 (#432) merged.

### New tests (4 files, 66 tests)

| File | Tests |
|---|---|
| `useContractCalculation.test.ts` | 16 |
| `commission.service.spec.ts` | 20 |
| `finance-receivable.service.spec.ts` | 21 |
| `excel.util.test.ts` | 9 |

### Test counts
- API: 332 → **373**
- Web: 104 → **129**

### Test Plan
- [x] `./tools/check-types.sh all` → OK
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)