### PR TITLE
chore: a11y + finance-receivable index (ultraplan v2 phase 3)

### DIFF
--- a/apps/api/prisma/migrations/20260409080000_add_finance_receivable_status_branch_index/migration.sql
+++ b/apps/api/prisma/migrations/20260409080000_add_finance_receivable_status_branch_index/migration.sql
@@ -1,0 +1,5 @@
+-- Compound index to speed up the dashboard's "outstanding receivables by branch"
+-- query, which always filters on (status, branchId). Single-column indexes on
+-- status and branchId can't be combined as efficiently because PostgreSQL has
+-- to AND bitmap scans, and status has only ~5 distinct values.
+CREATE INDEX "finance_receivables_status_branch_id_idx" ON "finance_receivables"("status", "branch_id");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2038,6 +2038,11 @@ model FinanceReceivable {
   @@index([branchId])
   @@index([expectedDate])
   @@index([deletedAt])
+  // Compound index for the dashboard's "outstanding by branch" query
+  // (status + branchId is the most common WHERE combination — single
+  // -column indexes can't be combined efficiently for high-cardinality
+  // status filtering inside a branch).
+  @@index([status, branchId])
   @@map("finance_receivables")
 }
 

--- a/apps/web/src/pages/DashboardPage/components/DashboardAlerts.tsx
+++ b/apps/web/src/pages/DashboardPage/components/DashboardAlerts.tsx
@@ -19,15 +19,15 @@ export default function DashboardAlerts({ alerts }: DashboardAlertsProps) {
         const Icon = alertIconMap[alert.type] ?? AlertTriangle;
         const styles = alertSeverityStyles[alert.severity];
         return (
-          <div
+          <button
             key={alert.type}
-            role="button"
-            tabIndex={0}
+            type="button"
             onClick={() => navigate(alert.link)}
-            onKeyDown={(e) => e.key === 'Enter' && navigate(alert.link)}
+            aria-label={`${alert.message} (${alert.count} รายการ) — คลิกเพื่อดูรายละเอียด`}
             className={cn(
-              'flex items-center gap-3 px-4 py-3 rounded-xl border cursor-pointer',
+              'flex items-center gap-3 px-4 py-3 rounded-xl border cursor-pointer text-left w-full',
               'hover:-translate-y-0.5 hover:shadow-md transition-all duration-200',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
               styles.container,
             )}
           >
@@ -39,7 +39,7 @@ export default function DashboardAlerts({ alerts }: DashboardAlertsProps) {
               <p className="text-2xs text-muted-foreground mt-0.5">คลิกเพื่อดูรายละเอียด</p>
             </div>
             <span className={cn('text-xs font-bold shrink-0', styles.count)}>{alert.count}</span>
-          </div>
+          </button>
         );
       })}
     </div>

--- a/apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx
@@ -35,7 +35,13 @@ export default function PaymentTable({
       key: 'select',
       label: '',
       render: (p: PendingPayment) => (
-        <input type="checkbox" checked={selectedIds.has(p.id)} onChange={() => onToggleSelect(p.id)} className="rounded border-input" />
+        <input
+          type="checkbox"
+          checked={selectedIds.has(p.id)}
+          onChange={() => onToggleSelect(p.id)}
+          className="rounded border-input"
+          aria-label={`เลือกงวดที่ ${p.installmentNo} ของสัญญา ${p.contract.contractNumber}`}
+        />
       ),
     },
     {


### PR DESCRIPTION
## Summary

ultraplan v2 Phase 3 — final quick wins. Re-opened after Phase 2 (#435) merged.

| Area | File | Change |
|---|---|---|
| a11y | `PaymentTable.tsx` | Added `aria-label` to bare checkbox |
| a11y | `DashboardAlerts.tsx` | `<div role="button">` → native `<button>`, focus-visible ring |
| perf | `schema.prisma` + migration | New `@@index([status, branchId])` on FinanceReceivable |

### Test Plan
- [x] `./tools/check-types.sh all` → OK
- [x] All tests passing
- [ ] Apply migration via `prisma migrate deploy` in prod (index-only, safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)