### PR TITLE
fix(perf+ops): idempotency, indexes, retention, backup encryption (ultraplan v3 phase 3)

### DIFF
--- a/apps/api/prisma/migrations/20260409120000_add_missing_fk_indexes/migration.sql
+++ b/apps/api/prisma/migrations/20260409120000_add_missing_fk_indexes/migration.sql
@@ -1,0 +1,24 @@
+-- FK indexes that the audit found missing. Each index speeds up a
+-- specific dashboard or report query that currently does a full-table
+-- scan when filtering by the indexed column.
+--
+-- All CREATE INDEX statements are non-blocking on PostgreSQL with
+-- CONCURRENTLY — but Prisma's `migrate deploy` runs each statement
+-- in its own implicit transaction, and CREATE INDEX CONCURRENTLY
+-- can't run inside a transaction. So we use plain CREATE INDEX, which
+-- briefly locks the table for writes. Tables affected are
+-- low-traffic enough (bad_debt_provisions, trade_ins, expenses)
+-- that the lock is acceptable during deploy.
+
+-- bad_debt_provisions: "writeoffs by approver" + "pending approvals"
+CREATE INDEX "bad_debt_provisions_written_off_by_id_idx" ON "bad_debt_provisions"("written_off_by_id");
+CREATE INDEX "bad_debt_provisions_approved_by_id_idx" ON "bad_debt_provisions"("approved_by_id");
+
+-- trade_ins: "appraisal queue by staff"
+CREATE INDEX "trade_ins_appraised_by_id_idx" ON "trade_ins"("appraised_by_id");
+CREATE INDEX "trade_ins_id_card_verified_by_id_idx" ON "trade_ins"("id_card_verified_by_id");
+
+-- expenses: "expenses by branch in date range" dashboard query
+CREATE INDEX "expenses_branch_id_expense_date_idx" ON "expenses"("branch_id", "expense_date");
+-- expenses: approver dropdown filter
+CREATE INDEX "expenses_approved_by_id_idx" ON "expenses"("approved_by_id");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2262,6 +2262,12 @@ model Expense {
   @@index([expenseDate])
   @@index([createdById])
   @@index([deletedAt])
+  // Compound index for "expenses by branch in date range" — the most
+  // common dashboard query. Single-column branchId + expenseDate scans
+  // can't be combined as efficiently as a compound index.
+  @@index([branchId, expenseDate])
+  // Index for the approver dropdown filter on the expenses list
+  @@index([approvedById])
   @@map("expenses")
 }
 
@@ -2518,6 +2524,9 @@ model TradeIn {
   @@index([createdAt])
   @@index([imei])
   @@index([branchId])
+  // FK indexes for "appraisals by staff" and "id card verifications by staff" reports
+  @@index([appraisedById])
+  @@index([idCardVerifiedById])
   @@map("trade_ins")
 }
 
@@ -2604,6 +2613,9 @@ model BadDebtProvision {
   @@index([contractId])
   @@index([provisionDate])
   @@index([status])
+  // FK indexes for the "writeoffs by approver" + "pending approvals" reports
+  @@index([writtenOffById])
+  @@index([approvedById])
   @@map("bad_debt_provisions")
 }
 

--- a/apps/api/src/modules/notifications/scheduler.service.ts
+++ b/apps/api/src/modules/notifications/scheduler.service.ts
@@ -464,9 +464,39 @@ export class SchedulerService {
         // PDPAConsent table might not exist yet
       }
 
+      // ─── Append-only log retention (audit + notifications) ────────────
+      // PDPA: ลูกค้ามีสิทธิ์ขอให้ลบข้อมูลส่วนตัว — append-only logs ที่
+      // โตแบบไม่มีหยุดเป็น compliance risk + ทำให้ DB ช้า. นโยบาย:
+      //   - AuditLog:        เก็บ 1 ปี (PDPA + ขนาด)
+      //   - NotificationLog: เก็บ 6 เดือน (delivery report ไม่ต้องเก็บนาน)
+      // ใช้ hard delete เพราะเป็นข้อมูลที่ไม่ต้องเก็บ trail (เป็น trail เอง)
+      const oneYearAgoForLogs = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+      const sixMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 6, now.getDate());
+
+      let auditLogsCleared = 0;
+      try {
+        const result = await this.prisma.auditLog.deleteMany({
+          where: { createdAt: { lt: oneYearAgoForLogs } },
+        });
+        auditLogsCleared = result.count;
+      } catch (err) {
+        this.logger.warn(`AuditLog cleanup failed: ${err instanceof Error ? err.message : err}`);
+      }
+
+      let notificationLogsCleared = 0;
+      try {
+        const result = await this.prisma.notificationLog.deleteMany({
+          where: { createdAt: { lt: sixMonthsAgo } },
+        });
+        notificationLogsCleared = result.count;
+      } catch (err) {
+        this.logger.warn(`NotificationLog cleanup failed: ${err instanceof Error ? err.message : err}`);
+      }
+
       this.logger.log(
         `Data retention complete: ${completedAnonymized.count} completed, ${cancelledAnonymized.count} cancelled soft-deleted, ` +
-        `${tokensCleared} expired tokens, ${consentsCleared} withdrawn consents cleaned`,
+        `${tokensCleared} expired tokens, ${consentsCleared} withdrawn consents, ` +
+        `${auditLogsCleared} audit logs, ${notificationLogsCleared} notification logs cleared`,
       );
     } catch (error) {
       this.reportCronFailure('data-retention', error);

--- a/apps/api/src/modules/paysolutions/paysolutions.service.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.ts
@@ -304,9 +304,12 @@ export class PaySolutionsService {
       `Webhook received: refno=${refno}, result_code=${result_code}, order_no=${order_no}`,
     );
 
-    // หา payment จาก gatewayRef หรือ PaymentLink token
+    // หา payment ด้วย token — ไม่ filter status เพราะ PaySolutions retry
+    // policy คือถ้า webhook ของเราตอบช้า/ผิด เขาจะ retry (max 3 ครั้ง).
+    // ครั้งที่ 2/3 link.status จะเป็น USED แล้ว — ถ้า filter ACTIVE จะเข้าใจผิด
+    // ว่า "unknown refno" และส่ง Sentry fatal alarm
     const paymentLink = await this.prisma.paymentLink.findFirst({
-      where: { token: refno, status: 'ACTIVE' },
+      where: { token: refno },
       include: { payment: true },
     });
 
@@ -329,6 +332,26 @@ export class PaySolutionsService {
         );
       }
       return; // ไม่ throw — return 200 OK ให้ Pay Solutions
+    }
+
+    // IDEMPOTENCY: ถ้า link ถูกใช้ไปแล้ว (link.status === 'USED') แสดงว่า
+    // เป็น duplicate webhook — log แล้ว return 200 ทันที ไม่ทำอะไร.
+    // ถ้าไม่เช็คตรงนี้ Payment.amountPaid จะถูก double-count ทุกครั้งที่
+    // PaySolutions retry webhook
+    if (paymentLink.status === 'USED') {
+      this.logger.log(
+        `Duplicate webhook for refno=${refno} (link already USED, idempotent skip)`,
+      );
+      return;
+    }
+
+    // ถ้า link ถูก expire ไปแล้วแต่มี webhook callback มา — log warn
+    // และ skip (ไม่ใช่ orphan, ลูกค้าอาจปล่อย session ค้างก่อนชำระ)
+    if (paymentLink.status === 'EXPIRED') {
+      this.logger.warn(
+        `Webhook for EXPIRED link refno=${refno} result_code=${result_code} — ignoring`,
+      );
+      return;
     }
 
     const isSuccess = result_code === '00';

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,30 +1,60 @@
 #!/bin/bash
-# Database backup script
+# Database backup script — encrypted with AES-256
 # Usage: ./scripts/backup.sh
 # Cron: 0 2 * * * /opt/installment-system/scripts/backup.sh
+#
+# Required environment:
+#   BACKUP_ENCRYPTION_KEY  Passphrase for openssl AES-256. MUST be set in
+#                          production or the script refuses to run.
+#                          Recommended: 32+ random bytes from `openssl rand -hex 32`,
+#                          stored in GCP Secret Manager / Vault, NEVER in git.
+#
+# Optional environment:
+#   BACKUP_DIR             default /opt/backups/installment
+#   RETENTION_DAYS         default 30
+#   DB_USER                default installment
+#   DB_NAME                default installment_db
+#
+# Restore (manual):
+#   openssl enc -d -aes-256-cbc -pbkdf2 -in installment_YYYYMMDD_HHMMSS.sql.gz.enc \
+#     -pass env:BACKUP_ENCRYPTION_KEY | gunzip | psql -U installment installment_db
+#
+# Why encryption matters: backups previously sat as plain gzip on the
+# same disk as the DB. Disk theft, ransomware, or shared-host backup
+# misconfiguration would expose the entire database (PII, passwords,
+# financial records). PDPA Section 37 requires "appropriate security
+# measures" and unencrypted backups don't qualify.
 
 set -euo pipefail
 
 BACKUP_DIR="${BACKUP_DIR:-/opt/backups/installment}"
 RETENTION_DAYS="${RETENTION_DAYS:-30}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_FILE="${BACKUP_DIR}/installment_${TIMESTAMP}.sql.gz"
+BACKUP_FILE="${BACKUP_DIR}/installment_${TIMESTAMP}.sql.gz.enc"
+
+# Refuse to run without an encryption key — fail loud, not silently
+if [ -z "${BACKUP_ENCRYPTION_KEY:-}" ]; then
+  echo "[$(date)] ERROR: BACKUP_ENCRYPTION_KEY is not set — refusing to write unencrypted backup" >&2
+  exit 1
+fi
 
 # Ensure backup directory exists
 mkdir -p "$BACKUP_DIR"
 
 echo "[$(date)] Starting database backup..."
 
-# Dump database using docker compose
+# Dump → gzip → encrypt in one stream so the plaintext never touches disk
 docker compose -f /opt/installment-system/docker-compose.prod.yml exec -T db \
   pg_dump -U "${DB_USER:-installment}" "${DB_NAME:-installment_db}" \
-  | gzip > "$BACKUP_FILE"
+  | gzip \
+  | openssl enc -aes-256-cbc -salt -pbkdf2 -pass env:BACKUP_ENCRYPTION_KEY \
+  > "$BACKUP_FILE"
 
 FILE_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
-echo "[$(date)] Backup created: $BACKUP_FILE ($FILE_SIZE)"
+echo "[$(date)] Encrypted backup created: $BACKUP_FILE ($FILE_SIZE)"
 
-# Cleanup old backups
-DELETED=$(find "$BACKUP_DIR" -name "installment_*.sql.gz" -mtime +${RETENTION_DAYS} -delete -print | wc -l)
+# Cleanup old backups (cover both new .enc and legacy .gz files)
+DELETED=$(find "$BACKUP_DIR" \( -name "installment_*.sql.gz.enc" -o -name "installment_*.sql.gz" \) -mtime +${RETENTION_DAYS} -delete -print | wc -l)
 if [ "$DELETED" -gt 0 ]; then
   echo "[$(date)] Cleaned up $DELETED old backup(s)"
 fi


### PR DESCRIPTION
## Summary

ultraplan v3 Phase 3 — 4 perf+ops fixes from the audit, batched into one PR.

| # | Area | Fix |
|---|---|---|
| 1 | **Webhook idempotency** | PaySolutions retry no longer double-credits payments or fires false orphan alarms |
| 2 | **DB indexes** | 6 missing FK / compound indexes (bad-debt approver, trade-in appraiser, expense compound) |
| 3 | **Log retention** | AuditLog 1yr + NotificationLog 6mo cleanup in existing weekly cron |
| 4 | **Backup encryption** | AES-256 via openssl, refuses to run without BACKUP_ENCRYPTION_KEY |

### Migration
- `20260409120000_add_missing_fk_indexes` — 6 CREATE INDEX statements, additive

### Test Plan
- [x] `./tools/check-types.sh api` → OK
- [x] `npm test` → 400/400 (no regression)
- [ ] Manual: trigger PaySolutions webhook twice with same refno → 2nd is idempotent skip (no double payment, no Sentry alarm)
- [ ] Prod: set `BACKUP_ENCRYPTION_KEY` in deploy env BEFORE next backup cron run, otherwise the script will refuse and exit 1
- [ ] Restore drill: decrypt + restore one backup to staging to verify the encryption pipeline

### Out of scope
- Off-site backup replication (GCS sync) — separate infra task
- Restore testing in CI — needs ephemeral DB
- ChatMessage / DocumentAuditLog retention — separate review needed

### Stacked deploy notes
After merge: prod deploy will:
1. Apply the index migration (additive, ~seconds even on large tables)
2. Start using the new idempotent webhook handler immediately
3. The retention cron runs Sunday 02:00 — first run will delete old audit/notification rows in one shot (could be large; consider running once manually first if logs are big)
4. **CRITICAL:** backup cron will FAIL until `BACKUP_ENCRYPTION_KEY` is set in the deploy env

🤖 Generated with [Claude Code](https://claude.com/claude-code)