### PR TITLE
fix(todos): allow opening attachment files in browser

### DIFF
--- a/apps/api/src/modules/todos/todos.controller.ts
+++ b/apps/api/src/modules/todos/todos.controller.ts
@@ -99,9 +99,24 @@ export class TodosController {
     if (!key.startsWith('todos/')) {
       throw new ForbiddenException('ไม่มีสิทธิ์เข้าถึงไฟล์นี้');
     }
+    const filename = key.split('/').pop() ?? 'file';
+    // Infer content type from extension so the browser can render
+    // images/PDFs inline. Without this everything was sent as
+    // octet-stream + attachment, forcing a download dialog for every
+    // preview click.
+    const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+    const mimeMap: Record<string, string> = {
+      jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
+      gif: 'image/gif', webp: 'image/webp', heic: 'image/heic',
+      pdf: 'application/pdf',
+    };
+    const contentType = mimeMap[ext] || 'application/octet-stream';
+    const isInlineable = contentType.startsWith('image/') || contentType === 'application/pdf';
+    const disposition = isInlineable ? 'inline' : 'attachment';
+
     const stream = await this.storage.getStream(key);
-    res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(key.split('/').pop() ?? 'file')}"`);
-    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Disposition', `${disposition}; filename="${encodeURIComponent(filename)}"`);
     stream.pipe(res);
   }
 

--- a/apps/web/src/pages/TodosPage.tsx
+++ b/apps/web/src/pages/TodosPage.tsx
@@ -360,6 +360,27 @@ export default function TodosPage() {
       attachments: (form.attachments || []).filter((a) => a.url !== url),
     });
 
+  /**
+   * Open an attachment in a new tab. The download endpoint requires JWT
+   * auth, but a plain <a href> click doesn't send the Authorization
+   * header (token lives in memory, not cookies). Fetch as a blob via
+   * the api client (which DOES send the token) and open the resulting
+   * object URL. The blob URL is revoked after a short delay so the
+   * new tab has time to render before we free the memory.
+   */
+  const openAttachment = async (att: Attachment) => {
+    try {
+      const response = await api.get(att.url, { responseType: 'blob' });
+      const blob = response.data as Blob;
+      const objectUrl = URL.createObjectURL(blob);
+      window.open(objectUrl, '_blank', 'noopener,noreferrer');
+      // Free the blob after the new tab has had time to load it
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+    } catch (err) {
+      toast.error(getErrorMessage(err));
+    }
+  };
+
 
   const addTag = () => {
     const v = (form.tagsInput || '').trim();
@@ -933,14 +954,13 @@ export default function TodosPage() {
                           )}
                         </div>
                         <div className="flex-1 min-w-0">
-                          <a
-                            href={a.url}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-sm font-medium truncate block hover:text-primary transition-colors"
+                          <button
+                            type="button"
+                            onClick={() => openAttachment(a)}
+                            className="text-sm font-medium truncate block hover:text-primary transition-colors text-left w-full"
                           >
                             {a.name || 'ไฟล์แนบ'}
-                          </a>
+                          </button>
                           <p className="text-2xs text-muted-foreground">
                             {formatBytes(a.size)}
                           </p>


### PR DESCRIPTION
## Summary
User reported attachment files in todos cannot be opened. Two bugs combined:

1. **Auth header missing on `<a href>` click** — JWT lives in memory, not cookies, so plain link clicks don't authenticate against the protected download endpoint
2. **Backend forced octet-stream + attachment disposition** — even if auth worked, images couldn't preview

## Fix
- **Backend**: infer mime from extension (jpg/png/gif/webp/heic/pdf), use \`inline\` disposition for images/PDFs
- **Frontend**: replace \`<a>\` with \`<button onClick>\` that fetches via \`api.get(..., responseType: 'blob')\` and opens via \`URL.createObjectURL\`

## Test plan
- [x] \`./tools/check-types.sh all\` → OK
- [x] \`npm test\` → 400/400
- [ ] Manual: open todo with image → click → image opens in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)