### PR TITLE
fix(todos): remove unknown eslint disable comment

### DIFF
--- a/apps/web/src/pages/TodosPage.tsx
+++ b/apps/web/src/pages/TodosPage.tsx
@@ -436,7 +436,8 @@ export default function TodosPage() {
       // for the rest of the dialog session.
       created.forEach((u) => URL.revokeObjectURL(u));
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // thumbUrls is intentionally read but not in deps — adding it would
+    // cause an infinite loop because we setState on it inside the effect.
   }, [dialogOpen, form.attachments]);
 
   // When the dialog closes, drop all thumbnails and revoke their URLs.


### PR DESCRIPTION
Hotfix for PR #441 lint failure. The disable comment referenced `react-hooks/exhaustive-deps` but the project doesn't have eslint-plugin-react-hooks installed → eslint hard-errored.

Replaced with a plain explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)