### PR TITLE
fix(api+web): ultraplan v4.1 — silent bleeders, journal fix, a11y

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -24,6 +24,14 @@
 - **ห้ามเชื่อ client input** — validate ทุกอย่างฝั่ง server
 - Error messages เป็นภาษาไทย เช่น `{ message: 'กรุณาระบุชื่อ' }`
 
+## Intentionally Public Endpoints (ไม่มี JwtAuthGuard)
+- `chatbot-finance-liff` — LINE LIFF endpoints สำหรับลูกค้าเข้าถึงผ่าน LINE (ใช้ LIFF token แทน JWT)
+- `sms-webhook` — รับ SMS delivery callback จาก provider
+- `paysolutions` — รับ payment webhook จาก PaySolutions gateway (verify ด้วย merchantId)
+- `address` — ข้อมูล static จังหวัด/อำเภอ/ตำบล (read-only, ไม่มี sensitive data)
+
+**หมายเหตุ**: ถ้าพบ controller ที่ไม่มี guard ที่ไม่อยู่ในรายการนี้ → ถือว่าเป็น security bug
+
 ## Sensitive Data
 - **ห้าม commit** `.env` files
 - **ห้าม log** tokens, passwords, หรือ PII (ข้อมูลส่วนบุคคล)

--- a/apps/api/src/modules/asset/asset.service.ts
+++ b/apps/api/src/modules/asset/asset.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateFixedAssetDto, UpdateFixedAssetDto, DisposeAssetDto } from './dto/asset.dto';
 
@@ -387,6 +388,9 @@ export class AssetService {
       this.logger.error(
         `Scheduled depreciation failed: ${error instanceof Error ? error.message : error}`,
       );
+      Sentry.captureException(error, {
+        tags: { kind: 'cron-job', cron: 'monthly-depreciation' },
+      });
     }
   }
 }

--- a/apps/api/src/modules/auth/auth-token-cleanup.service.ts
+++ b/apps/api/src/modules/auth/auth-token-cleanup.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
 import { AuthService } from './auth.service';
 
 @Injectable()
@@ -22,6 +23,9 @@ export class AuthTokenCleanupService {
       }
     } catch (error) {
       this.logger.error('ล้มเหลวในการลบ refresh token ที่หมดอายุ', error);
+      Sentry.captureException(error, {
+        tags: { kind: 'cron-job', cron: 'token-cleanup' },
+      });
     }
   }
 }

--- a/apps/api/src/modules/chatbot-finance/services/auto-trigger.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/auto-trigger.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { LineFinanceClientService } from './line-finance-client.service';
 import { ChatSessionService } from './chat-session.service';
@@ -48,10 +49,17 @@ export class AutoTriggerService {
   @Cron('0 9 * * *', { timeZone: TIMEZONE })
   async runDailyReminders(): Promise<void> {
     this.logger.log('[AutoTrigger] === Daily reminders 09:00 ===');
-    await this.processOffset(5, AutoTriggerType.REMINDER_T_MINUS_5, TEMPLATES.T_MINUS_5);
-    await this.processOffset(3, AutoTriggerType.REMINDER_T_MINUS_3, TEMPLATES.T_MINUS_3);
-    await this.processOffset(1, AutoTriggerType.REMINDER_T_MINUS_1, TEMPLATES.T_MINUS_1);
-    await this.processOffset(0, AutoTriggerType.REMINDER_T_DAY, TEMPLATES.T_DAY);
+    try {
+      await this.processOffset(5, AutoTriggerType.REMINDER_T_MINUS_5, TEMPLATES.T_MINUS_5);
+      await this.processOffset(3, AutoTriggerType.REMINDER_T_MINUS_3, TEMPLATES.T_MINUS_3);
+      await this.processOffset(1, AutoTriggerType.REMINDER_T_MINUS_1, TEMPLATES.T_MINUS_1);
+      await this.processOffset(0, AutoTriggerType.REMINDER_T_DAY, TEMPLATES.T_DAY);
+    } catch (error) {
+      this.logger.error(`Daily reminders failed: ${error instanceof Error ? error.message : error}`);
+      Sentry.captureException(error, {
+        tags: { kind: 'cron-job', cron: 'daily-reminders' },
+      });
+    }
   }
 
   // ─── Daily escalations 10:00 ───────────────────────────────
@@ -59,8 +67,15 @@ export class AutoTriggerService {
   @Cron('0 10 * * *', { timeZone: TIMEZONE })
   async runDailyEscalations(): Promise<void> {
     this.logger.log('[AutoTrigger] === Daily escalations 10:00 ===');
-    await this.processOffset(-1, AutoTriggerType.ESCALATION_T_PLUS_1, TEMPLATES.T_PLUS_1);
-    await this.processOffset(-3, AutoTriggerType.ESCALATION_T_PLUS_3, TEMPLATES.T_PLUS_3);
+    try {
+      await this.processOffset(-1, AutoTriggerType.ESCALATION_T_PLUS_1, TEMPLATES.T_PLUS_1);
+      await this.processOffset(-3, AutoTriggerType.ESCALATION_T_PLUS_3, TEMPLATES.T_PLUS_3);
+    } catch (error) {
+      this.logger.error(`Daily escalations failed: ${error instanceof Error ? error.message : error}`);
+      Sentry.captureException(error, {
+        tags: { kind: 'cron-job', cron: 'daily-escalations' },
+      });
+    }
   }
 
   // ─── Core logic ───────────────────────────────────────────

--- a/apps/api/src/modules/chatbot-finance/services/verification.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
 import { createHash, randomInt } from 'crypto';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { NotificationsService } from '../../notifications/notifications.service';
@@ -205,11 +206,18 @@ export class VerificationService {
 
   @Cron(CronExpression.EVERY_10_MINUTES)
   async cleanupExpiredOtps(): Promise<void> {
-    const result = await this.prisma.chatbotOtpRequest.deleteMany({
-      where: { expiresAt: { lt: new Date() } },
-    });
-    if (result.count > 0) {
-      this.logger.debug(`[Verify] Cleaned ${result.count} expired OTP(s)`);
+    try {
+      const result = await this.prisma.chatbotOtpRequest.deleteMany({
+        where: { expiresAt: { lt: new Date() } },
+      });
+      if (result.count > 0) {
+        this.logger.debug(`[Verify] Cleaned ${result.count} expired OTP(s)`);
+      }
+    } catch (error) {
+      this.logger.error(`OTP cleanup failed: ${error instanceof Error ? error.message : error}`);
+      Sentry.captureException(error, {
+        tags: { kind: 'cron-job', cron: 'otp-cleanup' },
+      });
     }
   }
 

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
+import { JournalAutoService } from './journal-auto.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * JournalAutoService tests — validates the double-entry bookkeeping engine.
+ *
+ * Critical test: unbalanced journal lines must throw (never silently skip),
+ * because a silent skip means a financial transaction completes without
+ * its accounting record — causing the trial balance to drift.
+ */
+describe('JournalAutoService', () => {
+  let service: JournalAutoService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'company-1' }),
+      },
+      journalEntry: {
+        count: jest.fn().mockResolvedValue(0),
+        create: jest.fn().mockResolvedValue({ id: 'je-1' }),
+      },
+      contract: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'contract-1',
+          branchId: 'branch-1',
+          branch: { companyId: 'company-1' },
+          product: { category: 'NEW_PHONE', costPrice: { toNumber: () => 8000 } },
+          sellingPrice: { toNumber: () => 10000 },
+          totalInterest: { toNumber: () => 1200 },
+          storeCommission: { toNumber: () => 300 },
+          vatAmount: { toNumber: () => 700 },
+        }),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn: unknown) => {
+        if (typeof fn === 'function') {
+          return fn(prisma);
+        }
+        return Promise.all(fn as Promise<unknown>[]);
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JournalAutoService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<JournalAutoService>(JournalAutoService);
+  });
+
+  describe('createAndPost — balance validation', () => {
+    it('should throw InternalServerErrorException when Dr != Cr', async () => {
+      const tx = prisma;
+
+      // amountPaid (Dr) = 9999, but Cr side = principal(5000) + interest(500) + commission(100) + vat(300) + lateFee(50) = 5950
+      // Mismatch → should throw
+      await expect(
+        service.createPaymentJournal(tx, {
+          payment: {
+            id: 'pay-1',
+            installmentNo: 1,
+            amountPaid: 9999,
+            monthlyPrincipal: 5000,
+            monthlyInterest: 500,
+            monthlyCommission: 100,
+            vatAmount: 300,
+            lateFee: 50,
+            lateFeeWaived: false,
+          },
+          contract: { contractNumber: 'BC-202601-0001', branchId: 'branch-1' },
+          userId: 'user-1',
+          companyId: 'company-1',
+        }),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should return null when all lines are zero (no journal needed)', async () => {
+      const tx = prisma;
+      const result = await service.createPaymentJournal(tx, {
+        payment: {
+          id: 'pay-2',
+          installmentNo: 1,
+          amountPaid: 0,
+          monthlyPrincipal: 0,
+          monthlyInterest: 0,
+          monthlyCommission: 0,
+          vatAmount: 0,
+          lateFee: 0,
+          lateFeeWaived: false,
+        },
+        contract: { contractNumber: 'BC-202601-0002', branchId: 'branch-1' },
+        userId: 'user-1',
+        companyId: 'company-1',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('should create journal entry when Dr = Cr (balanced)', async () => {
+      const tx = prisma;
+      // Dr: amountPaid = 5900
+      // Cr: HP receivable (principal 5000 + interest 500) + commission 100 + VAT 300 = 5900
+      const result = await service.createPaymentJournal(tx, {
+        payment: {
+          id: 'pay-3',
+          installmentNo: 1,
+          amountPaid: 5900,
+          monthlyPrincipal: 5000,
+          monthlyInterest: 500,
+          monthlyCommission: 100,
+          vatAmount: 300,
+          lateFee: 0,
+          lateFeeWaived: false,
+        },
+        contract: { contractNumber: 'BC-202601-0003', branchId: 'branch-1' },
+        userId: 'user-1',
+        companyId: 'company-1',
+      });
+      expect(result).toBe('je-1');
+      expect(prisma.journalEntry.create).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../prisma/prisma.service';
 
 /**
@@ -66,7 +67,7 @@ export class JournalAutoService {
 
   /**
    * Create + auto-post a journal entry. Validates debit = credit.
-   * Returns the entry id, or null if validation fails (logs warning).
+   * Returns the entry id, or null if no lines. Throws if unbalanced.
    */
   private async createAndPost(
     tx: Prisma.TransactionClient,
@@ -87,10 +88,13 @@ export class JournalAutoService {
     const totalDebit = lines.reduce((s, l) => s + l.debit, 0);
     const totalCredit = lines.reduce((s, l) => s + l.credit, 0);
     if (Math.abs(totalDebit - totalCredit) > 0.001) {
-      this.logger.warn(
-        `Journal not balanced for ${params.referenceType} ${params.referenceId}: Dr ${totalDebit} ≠ Cr ${totalCredit}`,
-      );
-      return null;
+      const msg = `Journal not balanced for ${params.referenceType} ${params.referenceId}: Dr ${totalDebit} ≠ Cr ${totalCredit}`;
+      this.logger.error(msg);
+      Sentry.captureException(new Error(msg), {
+        tags: { kind: 'journal', referenceType: params.referenceType },
+        extra: { referenceId: params.referenceId, totalDebit, totalCredit },
+      });
+      throw new InternalServerErrorException(msg);
     }
 
     const entryNumber = await this.generateEntryNumber(tx);

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -7,10 +7,11 @@
       "jsx": true
     }
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "jsx-a11y"],
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:jsx-a11y/recommended"
   ],
   "root": true,
   "env": {
@@ -21,6 +22,7 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
-    "no-empty": "off"
+    "no-empty": "off",
+    "jsx-a11y/alt-text": "error"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -99,6 +99,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.20",
     "eslint": "~8.57.0",
+    "eslint-plugin-jsx-a11y": "^6.10.0",
     "jsdom": "^25.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.0",

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -9,6 +9,7 @@ import { Sheet, SheetContent, SheetBody } from '@/components/ui/sheet';
 import CommandPalette from '@/components/CommandPalette';
 import ShortcutsHelpOverlay from '@/components/ShortcutsHelpOverlay';
 import MobileBottomNav from './MobileBottomNav';
+import { SkipLink } from './SkipLink';
 
 function MobileSidebar() {
   const { mobileSidebarOpen, setMobileSidebarOpen } = useLayout();
@@ -38,6 +39,7 @@ function MainContent() {
 
   return (
     <div className="flex min-h-screen bg-background">
+      <SkipLink />
       {/* Desktop Sidebar */}
       {!isMobile && <Sidebar />}
 
@@ -52,7 +54,7 @@ function MainContent() {
         }}
       >
         <TopBar />
-        <main className="flex-1 grow pt-5 pb-20 lg:pb-7 bg-background" key={pathname}>
+        <main id="main" className="flex-1 grow pt-5 pb-20 lg:pb-7 bg-background" key={pathname}>
           <div className="container-fluid px-5 lg:px-7 animate-fadeIn">
             <Outlet />
           </div>

--- a/apps/web/src/components/layout/SkipLink.tsx
+++ b/apps/web/src/components/layout/SkipLink.tsx
@@ -1,0 +1,10 @@
+export function SkipLink() {
+  return (
+    <a
+      href="#main"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-lg focus:shadow-lg focus:outline-none"
+    >
+      ข้ามไปเนื้อหาหลัก
+    </a>
+  );
+}

--- a/apps/web/src/components/template-editor/layout/CheatSheet.tsx
+++ b/apps/web/src/components/template-editor/layout/CheatSheet.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { SYNTAX_REFERENCE } from '@/constants/syntaxReference';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 
 export default function CheatSheet() {
   const [copied, setCopied] = useState<string | null>(null);
+  const { copy } = useCopyToClipboard(1500);
 
   const handleCopy = (syntax: string) => {
-    navigator.clipboard.writeText(syntax);
+    copy(syntax);
     setCopied(syntax);
     setTimeout(() => setCopied(null), 1500);
   };

--- a/apps/web/src/components/trade-in/QuickBuyModal.tsx
+++ b/apps/web/src/components/trade-in/QuickBuyModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { readSmartCard } from '@/lib/cardReader';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -134,18 +135,7 @@ export default function QuickBuyModal({ open, onClose, onSuccess }: QuickBuyModa
   // ─── Card reader ─────────────────────────────────────
   async function readFromCardReader() {
     try {
-      const res = await fetch('http://localhost:3457/api/read-card');
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        toast.error(err.message || 'อ่านบัตรไม่สำเร็จ');
-        return;
-      }
-      const json = await res.json();
-      if (!json.success || !json.data) {
-        toast.error('ไม่พบข้อมูลบัตร');
-        return;
-      }
-      const d = json.data;
+      const d = await readSmartCard();
       const fullName = `${d.prefix || ''}${d.firstName || ''} ${d.lastName || ''}`.trim();
       setForm((f) => ({
         ...f,
@@ -172,8 +162,8 @@ export default function QuickBuyModal({ open, onClose, onSuccess }: QuickBuyModa
       // Auto-trigger seller history lookup
       if (d.nationalId) await fetchSellerHistory(d.nationalId);
       toast.success('อ่านบัตรเรียบร้อย');
-    } catch {
-      toast.error('ไม่พบเครื่องอ่านบัตร — ตรวจสอบว่า service รันอยู่');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'ไม่พบเครื่องอ่านบัตร — ตรวจสอบว่า service รันอยู่');
     }
   }
 

--- a/apps/web/src/components/ui/PageHeader.tsx
+++ b/apps/web/src/components/ui/PageHeader.tsx
@@ -5,23 +5,27 @@ interface PageHeaderProps {
   subtitle?: string;
   icon?: ReactNode;
   action?: ReactNode;
+  breadcrumb?: ReactNode;
 }
 
-export default function PageHeader({ title, subtitle, icon, action }: PageHeaderProps) {
+export default function PageHeader({ title, subtitle, icon, action, breadcrumb }: PageHeaderProps) {
   return (
-    <div data-testid="page-header" className="flex flex-wrap items-center justify-between gap-4 pb-6 lg:pb-7.5">
-      <div className="flex flex-col justify-center gap-1.5">
-        <div className="flex items-center gap-2.5">
-          {icon && <span className="text-primary">{icon}</span>}
-          <h1 className="text-xl font-bold leading-none text-foreground">{title}</h1>
-        </div>
-        {subtitle && (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            {subtitle}
+    <div data-testid="page-header" className="flex flex-col gap-2 pb-6 lg:pb-7.5">
+      {breadcrumb}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-col justify-center gap-1.5">
+          <div className="flex items-center gap-2.5">
+            {icon && <span className="text-primary">{icon}</span>}
+            <h1 className="text-xl font-bold leading-none text-foreground">{title}</h1>
           </div>
-        )}
+          {subtitle && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              {subtitle}
+            </div>
+          )}
+        </div>
+        {action && <div className="flex items-center gap-2.5">{action}</div>}
       </div>
-      {action && <div className="flex items-center gap-2.5">{action}</div>}
     </div>
   );
 }

--- a/apps/web/src/hooks/useCopyToClipboard.ts
+++ b/apps/web/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react';
+
+export function useCopyToClipboard(resetDelay = 2000) {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setError(null);
+      setTimeout(() => setCopied(false), resetDelay);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to copy'));
+      setCopied(false);
+      return false;
+    }
+  }, [resetDelay]);
+
+  return { copy, copied, error };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -351,3 +351,15 @@ body {
     padding: 0.875rem; /* 14px */
   }
 }
+
+/* Respect user's motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/apps/web/src/pages/ChartOfAccountsPage.tsx
+++ b/apps/web/src/pages/ChartOfAccountsPage.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
 type AccountGroup = 'ASSET' | 'LIABILITY' | 'EQUITY' | 'REVENUE' | 'EXPENSE';
 
@@ -72,6 +73,7 @@ export default function ChartOfAccountsPage() {
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<ChartOfAccount | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
+  const [deleteConfirm, setDeleteConfirm] = useState<{ open: boolean; id: string; label: string }>({ open: false, id: '', label: '' });
 
   const { data: accounts = [], isLoading, isError, error, refetch } = useQuery<ChartOfAccount[]>({
     queryKey: ['chart-of-accounts'],
@@ -290,9 +292,7 @@ export default function ChartOfAccountsPage() {
                             แก้ไข
                           </button>
                           <button
-                            onClick={() => {
-                              if (confirm(`ลบบัญชี ${a.code} ${a.nameTh}?`)) deleteMutation.mutate(a.id);
-                            }}
+                            onClick={() => setDeleteConfirm({ open: true, id: a.id, label: `${a.code} ${a.nameTh}` })}
                             className="text-xs px-2 py-1 text-destructive hover:underline"
                           >
                             ลบ
@@ -464,6 +464,14 @@ export default function ChartOfAccountsPage() {
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={deleteConfirm.open}
+        onOpenChange={(open) => setDeleteConfirm((prev) => ({ ...prev, open }))}
+        description={`ลบบัญชี ${deleteConfirm.label}?`}
+        variant="destructive"
+        onConfirm={() => deleteMutation.mutate(deleteConfirm.id)}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/ContractCreatePage/components/DocumentUploadStep.tsx
+++ b/apps/web/src/pages/ContractCreatePage/components/DocumentUploadStep.tsx
@@ -62,7 +62,7 @@ function DocTypeSection({
             {docs.map((doc) => (
               <div key={doc.id} className="flex items-center gap-2 bg-muted rounded px-3 py-1.5">
                 {doc.file.type.startsWith('image/') ? (
-                  <img src={doc.preview} alt="" className="w-8 h-8 rounded object-cover flex-shrink-0" />
+                  <img src={doc.preview} alt="ตัวอย่างเอกสาร" className="w-8 h-8 rounded object-cover flex-shrink-0" />
                 ) : (
                   <div className="w-8 h-8 rounded bg-red-100 flex items-center justify-center text-2xs font-bold text-destructive flex-shrink-0">PDF</div>
                 )}

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -1,8 +1,9 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import { Card, CardContent } from '@/components/ui/card';
 import PageHeader from '@/components/ui/PageHeader';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import QueryBoundary from '@/components/QueryBoundary';
 import Modal from '@/components/ui/Modal';
 import WorkflowStatusBadge from '@/components/contract/WorkflowStatusBadge';
@@ -15,6 +16,7 @@ import ContractDocuments from '@/components/contract/ContractDocuments';
 import { ContractEarlyPayoffQuote, EarlyPayoffOverlay } from '@/components/contract/ContractEarlyPayoff';
 import { toast } from 'sonner';
 import { useState, useRef, useEffect } from 'react';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useAuth } from '@/contexts/AuthContext';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { DetailPageSkeleton } from '@/components/ui/page-skeletons';
@@ -94,6 +96,7 @@ export default function ContractDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const { copy: copyToClipboard } = useCopyToClipboard();
   const [showPayoffModal, setShowPayoffModal] = useState(false);
   const [customerLink, setCustomerLink] = useState<string | null>(null);
   const [showRejectModal, setShowRejectModal] = useState(false);
@@ -284,6 +287,15 @@ const deleteMutation = useMutation({
       <PageHeader
         title={contract.contractNumber}
         subtitle="รายละเอียดสัญญาผ่อนชำระ"
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem><BreadcrumbLink asChild><Link to="/contracts">สัญญา</Link></BreadcrumbLink></BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem><BreadcrumbPage>{contract.contractNumber}</BreadcrumbPage></BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        }
         action={
           <div className="flex gap-2 flex-wrap">
             <button onClick={() => navigate(`/contracts/${id}/sign`)} className="px-4 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 shadow-sm">
@@ -881,7 +893,7 @@ const deleteMutation = useMutation({
                 className="flex-1 px-3 py-2 border rounded-lg text-sm bg-muted"
               />
               <button
-                onClick={() => { navigator.clipboard.writeText(customerLink); toast.success('คัดลอกลิงก์แล้ว'); }}
+                onClick={() => { copyToClipboard(customerLink); toast.success('คัดลอกลิงก์แล้ว'); }}
                 className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90"
               >
                 คัดลอก

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -1,7 +1,8 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import QueryBoundary from '@/components/QueryBoundary';
 import DataTable from '@/components/ui/DataTable';
 import AddressForm, { AddressData, emptyAddress, displayAddress, serializeAddress, deserializeAddress } from '@/components/ui/AddressForm';
@@ -380,7 +381,15 @@ export default function CustomerDetailPage() {
 
   return (
     <div>
-      <PageHeader title={displayName} subtitle="รายละเอียดลูกค้า" action={
+      <PageHeader title={displayName} subtitle="รายละเอียดลูกค้า" breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem><BreadcrumbLink asChild><Link to="/customers">ลูกค้า</Link></BreadcrumbLink></BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem><BreadcrumbPage>{displayName}</BreadcrumbPage></BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      } action={
         <div className="flex gap-2">
           {canEdit && (
             <Button variant="outline" size="md" onClick={startEdit}>

--- a/apps/web/src/pages/ExchangePage.tsx
+++ b/apps/web/src/pages/ExchangePage.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
 import { Card, CardContent } from '@/components/ui/card';
 
 interface Contract {
@@ -62,7 +63,7 @@ export default function ExchangePage() {
   } | null>(null);
 
   // Fetch eligible contracts (ACTIVE or OVERDUE)
-  const { data: contracts = [] } = useQuery<Contract[]>({
+  const { data: contracts = [], isLoading: contractsLoading, isError: contractsError, refetch: refetchContracts } = useQuery<Contract[]>({
     queryKey: ['exchange-contracts'],
     queryFn: async () => {
       const [active, overdue] = await Promise.all([
@@ -74,7 +75,7 @@ export default function ExchangePage() {
   });
 
   // Fetch available products (IN_STOCK)
-  const { data: products = [] } = useQuery<Product[]>({
+  const { data: products = [], isLoading: productsLoading, isError: productsError, refetch: refetchProducts } = useQuery<Product[]>({
     queryKey: ['exchange-products'],
     queryFn: async () => (await api.get('/products?status=IN_STOCK&limit=999')).data.data || [],
   });
@@ -161,6 +162,13 @@ export default function ExchangePage() {
   return (
     <div>
       <PageHeader title="เปลี่ยนเครื่อง" subtitle="เปลี่ยนเครื่องจากสัญญาเดิมเป็นเครื่องใหม่" />
+
+      <QueryBoundary
+        isLoading={contractsLoading || productsLoading}
+        isError={contractsError || productsError}
+        onRetry={() => { void refetchContracts(); void refetchProducts(); }}
+        errorTitle="ไม่สามารถโหลดข้อมูลการเปลี่ยนเครื่องได้"
+      >
 
       {/* Step Indicator */}
       <div className="flex items-center gap-2 mb-6">
@@ -473,6 +481,8 @@ export default function ExchangePage() {
           </CardContent>
         </Card>
       )}
+
+      </QueryBoundary>
     </div>
   );
 }

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -607,7 +607,7 @@ export default function ExpensesPage() {
   ];
 
   return (
-    <div onClick={() => setOpenMenuId(null)}>
+    <div onClick={() => setOpenMenuId(null)} onKeyDown={(e) => { if (e.key === 'Escape') setOpenMenuId(null); }}>
       <PageHeader title="บันทึกรายจ่าย" subtitle={`ทั้งหมด ${expensesData?.total || 0} รายการ`}
         action={
           <Button variant="primary" size="md" onClick={openCreate}>

--- a/apps/web/src/pages/FinanceReceivablePage.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage.tsx
@@ -374,7 +374,7 @@ export default function FinanceReceivablePage() {
   ];
 
   return (
-    <div onClick={() => setOpenMenuId(null)}>
+    <div onClick={() => setOpenMenuId(null)} onKeyDown={(e) => { if (e.key === 'Escape') setOpenMenuId(null); }}>
       <PageHeader title="เงินรับจากไฟแนนซ์" subtitle={`ทั้งหมด ${receivables?.total || 0} รายการ`} />
 
       <Tabs defaultValue="external" className="mb-6">

--- a/apps/web/src/pages/InspectionDetailPage.tsx
+++ b/apps/web/src/pages/InspectionDetailPage.tsx
@@ -1,10 +1,11 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import QueryBoundary from '@/components/QueryBoundary';
 import { useAuth } from '@/contexts/AuthContext';
 import PageHeader from '@/components/ui/PageHeader';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import {
   ArrowLeft,
   Package,
@@ -141,6 +142,15 @@ export default function InspectionDetailPage() {
       <PageHeader
         title="รายละเอียดการตรวจสอบ"
         subtitle={`${product.brand} ${product.model}`}
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem><BreadcrumbLink asChild><Link to="/inspections">ตรวจสอบ</Link></BreadcrumbLink></BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem><BreadcrumbPage>{product.brand} {product.model}</BreadcrumbPage></BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        }
         action={
           <button
             onClick={() => navigate('/inspections')}

--- a/apps/web/src/pages/LineOaSettingsPage.tsx
+++ b/apps/web/src/pages/LineOaSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import PageHeader from '@/components/ui/PageHeader';
 
 interface BotInfo {
@@ -25,6 +26,7 @@ const TEST_MESSAGE_TYPES = [
 
 export default function LineOaSettingsPage() {
   const queryClient = useQueryClient();
+  const { copy } = useCopyToClipboard();
   const [form, setForm] = useState<Record<string, string>>({});
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
   const [testResult, setTestResult] = useState<{ success: boolean; botInfo?: BotInfo; error?: string } | null>(null);
@@ -119,7 +121,7 @@ export default function LineOaSettingsPage() {
   };
 
   const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+    copy(text);
     toast.success('คัดลอกแล้ว');
   };
 

--- a/apps/web/src/pages/MigrationPage.tsx
+++ b/apps/web/src/pages/MigrationPage.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
 
 interface MigrationStatus {
   customers: number;
@@ -27,7 +28,7 @@ export default function MigrationPage() {
   const [jsonInput, setJsonInput] = useState('');
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
 
-  const { data: status } = useQuery<MigrationStatus>({
+  const { data: status, isLoading: statusLoading, isError: statusError, error: statusQueryError, refetch: refetchStatus } = useQuery<MigrationStatus>({
     queryKey: ['migration-status'],
     queryFn: async () => (await api.get('/migration/status')).data,
   });
@@ -126,23 +127,31 @@ export default function MigrationPage() {
       <PageHeader title="นำเข้าข้อมูล" subtitle="ย้ายข้อมูลจากระบบเดิม" />
 
       {/* Status Cards */}
-      {status && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-6">
-          {[
-            { label: 'ลูกค้า', count: status.customers },
-            { label: 'สัญญา', count: status.contracts },
-            { label: 'ชำระ', count: status.payments },
-            { label: 'สินค้า', count: status.products },
-            { label: 'สาขา', count: status.branches },
-            { label: 'ผู้ใช้', count: status.users },
-          ].map((item) => (
-            <div key={item.label} className="bg-card rounded-lg border border-border p-4 text-center">
-              <div className="text-2xl font-bold text-foreground">{item.count}</div>
-              <div className="text-xs text-muted-foreground">{item.label}</div>
-            </div>
-          ))}
-        </div>
-      )}
+      <QueryBoundary
+        isLoading={statusLoading}
+        isError={statusError}
+        error={statusQueryError}
+        onRetry={() => refetchStatus()}
+        errorTitle="ไม่สามารถโหลดสถานะข้อมูลได้"
+      >
+        {status && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-6">
+            {[
+              { label: 'ลูกค้า', count: status.customers },
+              { label: 'สัญญา', count: status.contracts },
+              { label: 'ชำระ', count: status.payments },
+              { label: 'สินค้า', count: status.products },
+              { label: 'สาขา', count: status.branches },
+              { label: 'ผู้ใช้', count: status.users },
+            ].map((item) => (
+              <div key={item.label} className="bg-card rounded-lg border border-border p-4 text-center">
+                <div className="text-2xl font-bold text-foreground">{item.count}</div>
+                <div className="text-xs text-muted-foreground">{item.label}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </QueryBoundary>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-7.5">
         {/* Import Form */}

--- a/apps/web/src/pages/OverduePage.tsx
+++ b/apps/web/src/pages/OverduePage.tsx
@@ -502,7 +502,13 @@ export default function OverduePage() {
 
       {/* Assign Collector Modal */}
       {assignContractId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={() => setAssignContractId(null)}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          role="button"
+          tabIndex={0}
+          onClick={() => setAssignContractId(null)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setAssignContractId(null); } }}
+        >
           <div className="absolute inset-0 bg-black/30" />
           <div className="relative bg-background rounded-xl shadow-xl w-full max-w-sm p-6" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-base font-semibold mb-4">มอบหมายผู้ติดตาม</h3>
@@ -542,7 +548,13 @@ export default function OverduePage() {
 
       {/* Record Settlement Modal */}
       {settlementContractId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={() => setSettlementContractId(null)}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          role="button"
+          tabIndex={0}
+          onClick={() => setSettlementContractId(null)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSettlementContractId(null); } }}
+        >
           <div className="absolute inset-0 bg-black/30" />
           <div className="relative bg-background rounded-xl shadow-xl w-full max-w-md p-6" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-base font-semibold mb-4">บันทึกนัดชำระ</h3>
@@ -609,7 +621,13 @@ export default function OverduePage() {
 
       {/* Timeline & Call Logs Drawer */}
       {timelineContractId && (
-        <div className="fixed inset-0 z-50 flex justify-end" onClick={() => setTimelineContractId(null)}>
+        <div
+          className="fixed inset-0 z-50 flex justify-end"
+          role="button"
+          tabIndex={0}
+          onClick={() => setTimelineContractId(null)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setTimelineContractId(null); } }}
+        >
           <div className="absolute inset-0 bg-black/30" />
           <div className="relative w-full max-w-md bg-background shadow-xl overflow-y-auto" onClick={(e) => e.stopPropagation()}>
             <div className="sticky top-0 bg-background border-b px-4 py-3 flex items-center justify-between">

--- a/apps/web/src/pages/PDPAPage.tsx
+++ b/apps/web/src/pages/PDPAPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
 import DataTable from '@/components/ui/DataTable';
 import Modal from '@/components/ui/Modal';
 import { toast } from 'sonner';
@@ -61,7 +62,7 @@ function PDPAPage() {
   const [dsarForm, setDsarForm] = useState({ customerId: '', requestType: 'ACCESS', description: '' });
 
   // DSAR requests list
-  const { data: dsarData, isLoading: dsarLoading } = useQuery({
+  const { data: dsarData, isLoading: dsarLoading, isError: dsarError, error: dsarQueryError, refetch: refetchDsar } = useQuery({
     queryKey: ['dsar-requests'],
     queryFn: async () => {
       const { data } = await api.get('/pdpa/dsar');
@@ -160,6 +161,13 @@ function PDPAPage() {
       </div>
 
       {tab === 'dsar' && (
+        <QueryBoundary
+          isLoading={dsarLoading}
+          isError={dsarError}
+          error={dsarQueryError}
+          onRetry={() => refetchDsar()}
+          errorTitle="ไม่สามารถโหลดรายการ DSAR ได้"
+        >
         <div className="bg-card rounded-lg border border-border">
           <DataTable
             data={dsarRequests}
@@ -224,6 +232,7 @@ function PDPAPage() {
             emptyMessage="ไม่มีคำร้อง DSAR"
           />
         </div>
+        </QueryBoundary>
       )}
 
       {tab === 'consent-lookup' && (

--- a/apps/web/src/pages/ProductCreatePage.tsx
+++ b/apps/web/src/pages/ProductCreatePage.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
 import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card';
 import { brands, getModels, getModelInfo } from '@/data/productCatalog';
 import { categoryOptions, createProductStatusOptions } from '@/lib/constants';
@@ -61,7 +62,7 @@ export default function ProductCreatePage() {
   const [photoFiles, setPhotoFiles] = useState<File[]>([]);
   const [photoPreviews, setPhotoPreviews] = useState<string[]>([]);
 
-  const { data: branchList = [] } = useQuery<{ id: string; name: string }[]>({
+  const { data: branchList = [], isLoading: branchesLoading, isError: branchesError, error: branchesQueryError, refetch: refetchBranches } = useQuery<{ id: string; name: string }[]>({
     queryKey: ['branches'],
     queryFn: async () => {
       const { data } = await api.get('/branches');
@@ -312,6 +313,14 @@ export default function ProductCreatePage() {
           </button>
         }
       />
+
+      <QueryBoundary
+        isLoading={branchesLoading}
+        isError={branchesError}
+        error={branchesQueryError}
+        onRetry={() => refetchBranches()}
+        errorTitle="ไม่สามารถโหลดข้อมูลสาขาได้"
+      >
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-5 lg:gap-7.5">
         {/* Product Info */}
@@ -743,6 +752,8 @@ export default function ProductCreatePage() {
           </button>
         </div>
       </form>
+
+      </QueryBoundary>
     </div>
   );
 }

--- a/apps/web/src/pages/ProductDetailPage.tsx
+++ b/apps/web/src/pages/ProductDetailPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import PageHeader from '@/components/ui/PageHeader';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import Modal from '@/components/ui/Modal';
 import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card';
 import ProductPhotosPanel from '@/components/product/ProductPhotosPanel';
@@ -281,6 +282,15 @@ export default function ProductDetailPage() {
       <PageHeader
         title={`${product.brand} ${product.model}`}
         subtitle={product.name}
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem><BreadcrumbLink asChild><Link to="/stock">สต็อก</Link></BreadcrumbLink></BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem><BreadcrumbPage>{product.brand} {product.model}</BreadcrumbPage></BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        }
         action={
           <div className="flex gap-2">
             {isManager && (

--- a/apps/web/src/pages/PromotionsPage.tsx
+++ b/apps/web/src/pages/PromotionsPage.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge';
 import { useDebounce } from '@/hooks/useDebounce';
 import { Zap, Plus, Pencil, Trash2 } from 'lucide-react';
 import QueryBoundary from '@/components/QueryBoundary';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
 /* ─── Types ─── */
 
@@ -76,6 +77,7 @@ export default function PromotionsPage() {
   const [showModal, setShowModal] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState(emptyForm);
+  const [deleteConfirm, setDeleteConfirm] = useState<{ open: boolean; id: string }>({ open: false, id: '' });
 
   /* ─── Queries ─── */
 
@@ -251,9 +253,7 @@ export default function PromotionsPage() {
             className="text-destructive hover:text-destructive"
             onClick={(e) => {
               e.stopPropagation();
-              if (window.confirm('ต้องการลบโปรโมชันนี้?')) {
-                deleteMutation.mutate(item.id);
-              }
+              setDeleteConfirm({ open: true, id: item.id });
             }}
             disabled={deleteMutation.isPending}
           >
@@ -416,6 +416,14 @@ export default function PromotionsPage() {
           </div>
         </form>
       </Modal>
+
+      <ConfirmDialog
+        open={deleteConfirm.open}
+        onOpenChange={(open) => setDeleteConfirm((prev) => ({ ...prev, open }))}
+        description="ต้องการลบโปรโมชันนี้?"
+        variant="destructive"
+        onConfirm={() => deleteMutation.mutate(deleteConfirm.id)}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/ReportsPage.tsx
+++ b/apps/web/src/pages/ReportsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
 import PageHeader from '@/components/ui/PageHeader';
 import { Button } from '@/components/ui/button';
 import AnimatedCounter from '@/components/ui/animated-counter';
@@ -97,13 +98,10 @@ export default function ReportsPage() {
 }
 
 function AgingReport() {
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-aging'],
     queryFn: async () => (await api.get('/reports/aging')).data,
   });
-
-  if (isLoading) return <LoadingState />;
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
 
   const buckets = data?.buckets || [];
   const total = data?.total || { count: 0, amount: 0 };
@@ -111,6 +109,7 @@ function AgingReport() {
   const agingColors = ['#22c55e', '#eab308', '#f97316', '#ef4444', '#dc2626'];
 
   return (
+    <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานอายุหนี้ได้">
     <div className="space-y-5">
       {/* Aging Bar Chart */}
       {buckets.length > 0 && (
@@ -170,41 +169,39 @@ function AgingReport() {
         </div>
       </div>
     </div>
+    </QueryBoundary>
   );
 }
 
 function RevenueReport() {
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-revenue'],
     queryFn: async () => (await api.get('/reports/revenue-pl')).data,
   });
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
-
-  if (isLoading) return <LoadingState />;
 
   return (
-    <div className="bg-card rounded-xl border border-border p-5">
-      <h3 className="text-sm font-semibold text-foreground mb-4">รายงานรายได้ / กำไร-ขาดทุน</h3>
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <SummaryCard label="รายได้ดอกเบี้ย" value={data?.interestIncome || 0} color="text-success" />
-        <SummaryCard label="ค่าปรับ" value={data?.lateFeeIncome || 0} color="text-warning" />
-        <SummaryCard label="ยอดชำระรับ" value={data?.paymentsReceived || 0} color="text-primary" />
-        <SummaryCard label="ยอดค้างชำระ" value={data?.outstandingTotal || 0} color="text-destructive" />
+    <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานรายได้ได้">
+      <div className="bg-card rounded-xl border border-border p-5">
+        <h3 className="text-sm font-semibold text-foreground mb-4">รายงานรายได้ / กำไร-ขาดทุน</h3>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <SummaryCard label="รายได้ดอกเบี้ย" value={data?.interestIncome || 0} color="text-success" />
+          <SummaryCard label="ค่าปรับ" value={data?.lateFeeIncome || 0} color="text-warning" />
+          <SummaryCard label="ยอดชำระรับ" value={data?.paymentsReceived || 0} color="text-primary" />
+          <SummaryCard label="ยอดค้างชำระ" value={data?.outstandingTotal || 0} color="text-destructive" />
+        </div>
       </div>
-    </div>
+    </QueryBoundary>
   );
 }
 
 function HighRiskReport() {
-  const { data = [], isLoading, isError, refetch } = useQuery({
+  const { data = [], isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-high-risk'],
     queryFn: async () => (await api.get('/reports/high-risk')).data,
   });
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
-
-  if (isLoading) return <LoadingState />;
 
   return (
+    <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานลูกค้าเสี่ยงสูงได้">
     <div className="bg-card rounded-lg border border-border p-5">
       <h3 className="text-sm font-semibold text-foreground mb-4">ลูกค้าเสี่ยงสูง</h3>
       <div className="overflow-x-auto">
@@ -237,19 +234,18 @@ function HighRiskReport() {
         </table>
       </div>
     </div>
+    </QueryBoundary>
   );
 }
 
 function SalesReport() {
-  const { data = [], isLoading, isError, refetch } = useQuery({
+  const { data = [], isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-sales'],
     queryFn: async () => (await api.get('/reports/sales-comparison')).data,
   });
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
-
-  if (isLoading) return <LoadingState />;
 
   return (
+    <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานพนักงานขายได้">
     <div className="bg-card rounded-lg border border-border p-5">
       <h3 className="text-sm font-semibold text-foreground mb-4">เปรียบเทียบพนักงานขาย</h3>
       <div className="overflow-x-auto">
@@ -293,19 +289,18 @@ function SalesReport() {
         </table>
       </div>
     </div>
+    </QueryBoundary>
   );
 }
 
 function BranchReport() {
-  const { data = [], isLoading, isError, refetch } = useQuery({
+  const { data = [], isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-branch'],
     queryFn: async () => (await api.get('/reports/branch-comparison')).data,
   });
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
-
-  if (isLoading) return <LoadingState />;
 
   return (
+    <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานเปรียบเทียบสาขาได้">
     <div className="bg-card rounded-lg border border-border p-5">
       <h3 className="text-sm font-semibold text-foreground mb-4">เปรียบเทียบสาขา</h3>
       <div className="overflow-x-auto">
@@ -335,19 +330,18 @@ function BranchReport() {
         </table>
       </div>
     </div>
+    </QueryBoundary>
   );
 }
 
 function DailyPaymentReport({ date, onDateChange }: { date: string; onDateChange: (d: string) => void }) {
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-daily-payment', date],
     queryFn: async () => (await api.get(`/reports/daily-payments?date=${date}`)).data,
   });
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
-
-  if (isLoading) return <LoadingState />;
 
   return (
+    <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานชำระรายวันได้">
     <div className="bg-card rounded-lg border border-border p-5">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-sm font-semibold text-foreground">สรุปชำระรายวัน</h3>
@@ -386,22 +380,21 @@ function DailyPaymentReport({ date, onDateChange }: { date: string; onDateChange
         </div>
       )}
     </div>
+    </QueryBoundary>
   );
 }
 
 function StockReport() {
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-stock'],
     queryFn: async () => (await api.get('/reports/stock')).data,
   });
-
-  if (isLoading) return <LoadingState />;
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
 
   const byStatus = data?.byStatus || [];
   const byBranch = data?.byBranch || [];
 
   return (
+    <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานสต็อกสินค้าได้">
     <div className="flex flex-col gap-5 lg:gap-7.5">
       <div className="bg-card rounded-lg border border-border p-5">
         <h3 className="text-sm font-semibold text-foreground mb-4">สต็อกตามสถานะ</h3>
@@ -457,6 +450,7 @@ function StockReport() {
         </div>
       )}
     </div>
+    </QueryBoundary>
   );
 }
 
@@ -468,7 +462,7 @@ function EntityProfitReport() {
   const [endDate, setEndDate] = useState(lastDay);
   const [entity, setEntity] = useState<string>('ALL');
 
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['report-entity-profit', startDate, endDate, entity],
     queryFn: async () => {
       const params = new URLSearchParams({ startDate, endDate });
@@ -476,9 +470,6 @@ function EntityProfitReport() {
       return (await api.get(`/reports/entity-profit?${params}`)).data;
     },
   });
-
-  if (isLoading) return <LoadingState />;
-  if (isError) return <ErrorState onRetry={() => refetch()} />;
 
   const shop = data?.shop || { revenue: 0, costOfGoods: 0, commission: 0, profit: 0, transactionCount: 0 };
   const finance = data?.finance || { interestIncome: 0, commissionExpense: 0, lateFeeIncome: 0, profit: 0, transactionCount: 0 };
@@ -512,6 +503,8 @@ function EntityProfitReport() {
           </div>
         </div>
       </div>
+
+      <QueryBoundary isLoading={isLoading} isError={isError} error={error} onRetry={() => refetch()} errorTitle="ไม่สามารถโหลดรายงานกำไร Shop/Finance ได้">
 
       {/* Summary Cards */}
       {(entity === 'ALL' || entity === 'SHOP') && (
@@ -604,6 +597,8 @@ function EntityProfitReport() {
           ไม่พบข้อมูล Inter-Company Transaction ในช่วงเวลาที่เลือก
         </div>
       )}
+
+      </QueryBoundary>
     </div>
   );
 }

--- a/apps/web/src/pages/StockTransfersPage.tsx
+++ b/apps/web/src/pages/StockTransfersPage.tsx
@@ -426,7 +426,7 @@ export default function StockTransfersPage() {
                         <span>{batch.fromBranch.name} → {batch.toBranch.name}</span>
                         <span>{formatDateShort(batch.createdAt)}</span>
                       </div>
-                      <div className="flex gap-2 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                      <div className="flex gap-2 flex-shrink-0" role="presentation" onClick={(e) => e.stopPropagation()}>
                         {batch.status === 'PENDING' && (
                           <button
                             onClick={() => {
@@ -575,7 +575,7 @@ export default function StockTransfersPage() {
                         <span>จาก: {batch.fromBranch.name}</span>
                         {batch.dispatchedAt && <span>ส่ง: {formatDateShort(batch.dispatchedAt)}</span>}
                       </div>
-                      <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                      <div className="flex-shrink-0" role="presentation" onClick={(e) => e.stopPropagation()}>
                         <button
                           onClick={() => openBatchReceiveModal(batch.items)}
                           className="px-3 py-1.5 bg-green-600 text-white rounded text-xs font-medium hover:bg-green-700"
@@ -726,7 +726,7 @@ export default function StockTransfersPage() {
                     <div key={t.id} className="flex items-start gap-3">
                       <span className="text-xs text-muted-foreground mt-1 w-5">{idx + 1}.</span>
                       {t.product.photos?.[0] && (
-                        <img src={t.product.photos[0]} alt="" className="w-12 h-12 object-cover rounded-lg border" />
+                        <img src={t.product.photos[0]} alt={`${t.product.brand} ${t.product.model}` || 'รูปสินค้า'} className="w-12 h-12 object-cover rounded-lg border" />
                       )}
                       <div className="flex-1">
                         <div className="font-semibold text-foreground text-sm">{t.product.brand} {t.product.model}</div>

--- a/apps/web/src/pages/SupplierDetailPage.tsx
+++ b/apps/web/src/pages/SupplierDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
@@ -8,6 +8,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { formatDateShort } from '@/utils/formatters';
 import { useAuth } from '@/contexts/AuthContext';
 import PageHeader from '@/components/ui/PageHeader';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import DataTable from '@/components/ui/DataTable';
 import { displayAddress } from '@/components/ui/AddressForm';
 
@@ -239,6 +240,15 @@ export default function SupplierDetailPage() {
       <PageHeader
         title={supplier.name}
         subtitle="รายละเอียดผู้ขาย"
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem><BreadcrumbLink asChild><Link to="/suppliers">ผู้ขาย</Link></BreadcrumbLink></BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem><BreadcrumbPage>{supplier.name}</BreadcrumbPage></BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        }
         action={
           <div className="flex gap-2">
             {isManager && (

--- a/apps/web/src/pages/SystemStatusPage.tsx
+++ b/apps/web/src/pages/SystemStatusPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
 import { formatDateMedium } from '@/utils/formatters';
 
 interface SystemStatus {
@@ -71,35 +72,8 @@ export default function SystemStatusPage() {
     setIsRefreshing(false);
   };
 
-  if (isLoading) {
-    return (
-      <div>
-        <PageHeader title="สถานะระบบ" subtitle="ตรวจสอบการเชื่อมต่อ API, ฐานข้อมูล และ AI" />
-        <div className="flex items-center justify-center py-20">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-        </div>
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div>
-        <PageHeader title="สถานะระบบ" subtitle="ตรวจสอบการเชื่อมต่อ API, ฐานข้อมูล และ AI" />
-        <div className="bg-destructive/5 dark:bg-destructive/10 border border-destructive/20 rounded-xl p-8 text-center max-w-lg mx-auto mt-8">
-          <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-3">
-            <svg className="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" /></svg>
-          </div>
-          <p className="text-destructive font-medium mb-1">ไม่สามารถเชื่อมต่อ API ได้</p>
-          <p className="text-destructive text-sm mb-4">{getErrorMessage(error)}</p>
-          <button onClick={() => refetch()} className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700">ลองใหม่</button>
-        </div>
-      </div>
-    );
-  }
-
-  const allOk = data!.api.status === 'ok' && data!.database.connected;
-  const svcs = data!.services;
+  const allOk = data?.api.status === 'ok' && data?.database.connected;
+  const svcs = data?.services;
   const totalPages = 3;
 
   return (
@@ -118,6 +92,14 @@ export default function SystemStatusPage() {
           </button>
         }
       />
+
+      <QueryBoundary
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        onRetry={() => refetch()}
+        errorTitle="ไม่สามารถโหลดสถานะระบบได้"
+      >
 
       {/* ═══════════════════ Page 1: Connection Diagram ═══════════════════ */}
       <A4Page pageNum={1} totalPages={totalPages}>
@@ -414,6 +396,8 @@ export default function SystemStatusPage() {
           </div>
         </div>
       </A4Page>
+
+      </QueryBoundary>
     </div>
   );
 }

--- a/apps/web/src/pages/TodosPage.tsx
+++ b/apps/web/src/pages/TodosPage.tsx
@@ -13,6 +13,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { toast } from 'sonner';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import {
   CheckSquare,
   Plus,
@@ -176,6 +177,7 @@ export default function TodosPage() {
   const [view, setView] = useState<TodoView>('all');
   const [search, setSearch] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<{ open: boolean; id: string }>({ open: false, id: '' });
   const [editing, setEditing] = useState<Todo | null>(null);
   const [form, setForm] = useState<typeof emptyForm>(emptyForm);
   // Map of attachment.url → blob object URL for inline image previews.
@@ -721,7 +723,7 @@ export default function TodosPage() {
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
-                            if (confirm('ลบรายการนี้?')) deleteMutation.mutate(t.id);
+                            setDeleteConfirm({ open: true, id: t.id });
                           }}
                           className="size-6 rounded-md text-muted-foreground hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/30 inline-flex items-center justify-center transition-colors opacity-0 group-hover:opacity-100"
                           aria-label="delete"
@@ -1131,6 +1133,13 @@ export default function TodosPage() {
         </div>
       )}
 
+      <ConfirmDialog
+        open={deleteConfirm.open}
+        onOpenChange={(open) => setDeleteConfirm((prev) => ({ ...prev, open }))}
+        description="ต้องการลบรายการนี้?"
+        variant="destructive"
+        onConfirm={() => deleteMutation.mutate(deleteConfirm.id)}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/TradeInPage.tsx
+++ b/apps/web/src/pages/TradeInPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { readSmartCard } from '@/lib/cardReader';
 import { formatThaiDate } from '@/lib/date';
 import PageHeader from '@/components/ui/PageHeader';
 import DataTable, { type Column } from '@/components/ui/DataTable';
@@ -325,18 +326,7 @@ export default function TradeInPage() {
   // อ่านบัตรจากเครื่องอ่านบัตร (card-reader service @ port 3457)
   async function readFromCardReader() {
     try {
-      const res = await fetch('http://localhost:3457/api/read-card');
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        toast.error(err.message || 'อ่านบัตรไม่สำเร็จ — กรุณาลองอีกครั้ง');
-        return;
-      }
-      const json = await res.json();
-      if (!json.success || !json.data) {
-        toast.error('ไม่พบข้อมูลบัตร');
-        return;
-      }
-      const d = json.data;
+      const d = await readSmartCard();
       const fullName = `${d.prefix || ''}${d.firstName || ''} ${d.lastName || ''}`.trim();
       setForm((f) => ({
         ...f,
@@ -346,8 +336,8 @@ export default function TradeInPage() {
         idCardSource: 'card_reader',
       }));
       toast.success('อ่านบัตรเรียบร้อย');
-    } catch {
-      toast.error('ไม่พบเครื่องอ่านบัตร — ตรวจสอบว่า card-reader service รันอยู่ที่ port 3457');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'ไม่พบเครื่องอ่านบัตร — ตรวจสอบว่า card-reader service รันอยู่ที่ port 3457');
     }
   }
 

--- a/apps/web/src/pages/UsersPage.tsx
+++ b/apps/web/src/pages/UsersPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { formatDateShort, formatDateMedium } from '@/utils/formatters';
 import PageHeader from '@/components/ui/PageHeader';
 import DataTable from '@/components/ui/DataTable';
@@ -80,6 +81,7 @@ const emptyForm = {
 export default function UsersPage() {
   const queryClient = useQueryClient();
   const { user: currentUser } = useAuth();
+  const { copy } = useCopyToClipboard();
   const isOwner = currentUser?.role === 'OWNER';
   const [activeTab, setActiveTab] = useState<'users' | 'invites'>('users');
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -187,7 +189,7 @@ export default function UsersPage() {
   };
 
   const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+    copy(text);
     toast.success('คัดลอกลิงก์แล้ว');
   };
 
@@ -299,7 +301,7 @@ export default function UsersPage() {
       render: (u: User) => (
         <div className="flex items-center gap-3">
           {u.avatarUrl ? (
-            <img src={u.avatarUrl} alt="" className="size-8 rounded-full object-cover shrink-0" />
+            <img src={u.avatarUrl} alt={u.name || 'รูปโปรไฟล์'} className="size-8 rounded-full object-cover shrink-0" />
           ) : (
             <div className="size-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground shrink-0">
               {u.name.charAt(0)}
@@ -637,7 +639,7 @@ export default function UsersPage() {
             <div className="flex items-center gap-4">
               <div className="relative">
                 {form.avatarUrl ? (
-                  <img src={form.avatarUrl} alt="" className="size-16 rounded-full object-cover" />
+                  <img src={form.avatarUrl} alt="รูปโปรไฟล์" className="size-16 rounded-full object-cover" />
                 ) : (
                   <div className="size-16 rounded-full bg-muted flex items-center justify-center">
                     <Camera className="size-6 text-muted-foreground" />

--- a/apps/web/src/pages/liff/LiffFinanceVerify.tsx
+++ b/apps/web/src/pages/liff/LiffFinanceVerify.tsx
@@ -206,7 +206,7 @@ export default function LiffFinanceVerify() {
         {profile && (
           <div className="bg-white rounded-2xl shadow-sm p-5 mb-4 flex items-center gap-4">
             {profile.pictureUrl ? (
-              <img src={profile.pictureUrl} alt="" className="w-12 h-12 rounded-full" />
+              <img src={profile.pictureUrl} alt="รูปโปรไฟล์ LINE" className="w-12 h-12 rounded-full" />
             ) : (
               <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 font-bold text-lg">
                 {profile.displayName.charAt(0)}

--- a/apps/web/src/pages/liff/LiffRegister.tsx
+++ b/apps/web/src/pages/liff/LiffRegister.tsx
@@ -180,7 +180,7 @@ export default function LiffRegister() {
         {profile && (
           <div className="bg-white rounded-2xl shadow-sm p-5 mb-4 flex items-center gap-4">
             {profile.pictureUrl ? (
-              <img src={profile.pictureUrl} alt="" className="w-12 h-12 rounded-full" />
+              <img src={profile.pictureUrl} alt="รูปโปรไฟล์ LINE" className="w-12 h-12 rounded-full" />
             ) : (
               <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center text-green-600 font-bold text-lg">
                 {profile.displayName.charAt(0)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1128,6 +1128,7 @@
         "@vitejs/plugin-react": "^4.3.0",
         "autoprefixer": "^10.4.20",
         "eslint": "~8.57.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
         "jsdom": "^25.0.1",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.0",
@@ -12288,11 +12289,51 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array-timsort": {
       "version": "1.0.3",
@@ -12309,6 +12350,66 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/assertion-error": {
@@ -12333,11 +12434,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -12382,6 +12500,32 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
@@ -12391,6 +12535,16 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-jest": {
@@ -13085,6 +13239,25 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -14014,6 +14187,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -14072,6 +14252,60 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/date-fns": {
@@ -14198,6 +14432,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -14643,6 +14913,75 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -14693,6 +15032,37 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-toolkit": {
@@ -14860,6 +15230,77 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-scope": {
@@ -15618,6 +16059,22 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.1.0.tgz",
@@ -15883,6 +16340,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -15969,6 +16467,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-uri": {
@@ -16095,6 +16611,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -16173,6 +16706,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -16180,6 +16726,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -16491,6 +17066,21 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -16548,11 +17138,65 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -16564,6 +17208,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -16581,6 +17255,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -16588,6 +17297,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -16607,6 +17332,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -16631,6 +17376,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -16638,6 +17409,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-inside": {
@@ -16657,6 +17445,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -16670,6 +17506,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -16681,6 +17568,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -17747,6 +18680,22 @@
         "jspdf": "^2 || ^3 || ^4"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -17833,6 +18782,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/lazystream": {
@@ -18788,6 +19757,75 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -18879,6 +19917,24 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -19407,6 +20463,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -20670,12 +21736,56 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -20977,6 +22087,33 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -20996,6 +22133,48 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -21138,6 +22317,55 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -21502,6 +22730,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -21556,6 +22798,80 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -22608,6 +23924,84 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typed-query-selector": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
@@ -22676,6 +24070,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/undici-types": {
@@ -24487,11 +25900,107 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",


### PR DESCRIPTION
## Summary

Ultraplan v4.1 — 27 tasks across Phase 1 (Silent Bleeders), Phase 4.1-4.2 (P0 Journal fix), and Phase 5A (Quick A11y).

### P0: Journal Silent Skip Fix
- **[N-002]** Unbalanced journal entries now `throw InternalServerErrorException` + Sentry alert instead of silently returning `null` — prevents financial transactions from completing without accounting records
- 3 new tests in `journal-auto.service.spec.ts`

### Phase 1: Silent Bleeders (18 tasks)
- Sentry capture on 5 cron jobs (depreciation, token cleanup, OTP cleanup, daily reminders, daily escalations)
- `confirm()` → `ConfirmDialog` in 3 pages (Todos, Promotions, ChartOfAccounts)
- Hardcoded `localhost:3457` → `readSmartCard()` util in 2 files (TradeIn, QuickBuyModal)
- QueryBoundary on 6 pages (Exchange, Reports, PDPA, SystemStatus, Migration, ProductCreate)
- a11y: `<div onClick>` → accessible patterns in 4 pages (Overdue, StockTransfers, Expenses, FinanceReceivable)
- Document intentionally public endpoints in `.claude/rules/security.md`

### Phase 5A: Quick A11y (7 tasks)
- Fix `alt=""` in 6 locations + ESLint `jsx-a11y/alt-text` rule to prevent regression
- `SkipLink` component + wired in MainLayout (WCAG 2.1 A)
- `@media (prefers-reduced-motion: reduce)` CSS
- `useCopyToClipboard` hook + replaced 4 inline `navigator.clipboard` call sites
- Breadcrumb wired into 5 detail pages via PageHeader `breadcrumb` prop

### Verification
- API: **403 tests passed** (22 suites, +3 new)
- TypeScript: **0 errors** (API + Web)
- Grep audit: 0 `confirm()` in pages, 0 `alt=""`, 0 inline `localhost:3457`

## Test plan
- [ ] Verify journal unbalanced throws (run `npx jest journal-auto`)
- [ ] Verify ConfirmDialog appears on delete in TodosPage, PromotionsPage, ChartOfAccountsPage
- [ ] Verify card reader works on TradeInPage (requires card reader service)
- [ ] Verify QueryBoundary loading/error states on 6 new pages
- [ ] Verify Breadcrumb navigation on detail pages (Contract, Customer, Product, Supplier, Inspection)
- [ ] Verify SkipLink visible on Tab key focus
- [ ] Run `npx tsc --noEmit` on both apps — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)