### PR TITLE
fix(api): ultraplan v4.2 — Decimal precision + bad debt journal

### DIFF
--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -1,0 +1,80 @@
+# Accounting Rules (TFRS for NPAEs)
+
+## มาตรฐาน
+- ใช้ **TFRS for NPAEs** (มาตรฐานรายงานทางการเงินสำหรับกิจการที่ไม่มีส่วนได้เสียสาธารณะ)
+- ระบบบันทึกบัญชีแบบ **double-entry** ผ่าน `JournalAutoService`
+
+## Revenue Recognition
+- **Cash basis** สำหรับรายได้ — รับรู้เมื่อลูกค้าจ่ายเงิน
+- **Accrual basis** สำหรับค่าใช้จ่าย — รับรู้เมื่อเกิดรายการ
+- **Straight-line interest** — ดอกเบี้ยเช่าซื้อรับรู้แบบ straight-line (ไม่ใช้ effective interest rate method)
+- ดอกเบี้ยรับรู้ **upfront ณ วันเปิดสัญญา** เป็นส่วนหนึ่งของ HP Receivable (policy decision — ดู N-005 สำหรับ future consideration)
+
+## VAT Policy
+- **SHOP** ไม่จด VAT → ไม่คิด VAT
+- **FINANCE** จด VAT 7% → คิดจาก (เงินต้น + ค่าคอม + ดอกเบี้ย) ← **CR-001 deferred**: ต้องปรึกษานักบัญชีว่าดอกเบี้ยเช่าซื้อตาม ม.81(1)(ช) ควรยกเว้น VAT หรือไม่
+- **ค่าปรับล่าช้า (Late fees) ไม่คิด VAT** — policy decision ของเจ้าของ (ถูกต้องตามกฎหมาย: ค่าปรับไม่อยู่ในฐาน VAT)
+- **ไม่มีภาษีหัก ณ ที่จ่าย (WHT)** สำหรับธุรกรรมกับลูกค้า
+
+## Chart of Accounts (Key Codes)
+```
+11-1101  เงินสด/ธนาคาร (Cash & Bank)
+11-2102  ลูกหนี้เช่าซื้อ (HP Receivable)
+11-2901  ค่าเผื่อหนี้สงสัยจะสูญ (Allowance for Doubtful)
+11-3101  สินค้าคงเหลือ — เครื่องใหม่ (Inventory New)
+11-3102  สินค้าคงเหลือ — มือสอง (Inventory Used)
+11-4101  ภาษีซื้อ (VAT Input)
+21-2101  ภาษีขาย (VAT Output)
+21-5101  เครดิตลูกค้า (Customer Credit)
+41-1101  รายได้ขายเครื่องใหม่ (Revenue New)
+41-1102  รายได้ขายมือสอง (Revenue Used)
+42-1102  รายได้ค่าปรับล่าช้า (Late Fee Income)
+42-1105  รายได้ค่าคอมมิชชัน (Commission Income)
+51-1101  ต้นทุนขายเครื่องใหม่ (COGS New)
+51-1102  ต้นทุนขายมือสอง (COGS Used)
+53-1101  หนี้สูญ (Bad Debt Expense)
+```
+
+## Journal Entries (Auto-generated)
+
+### Payment Received
+```
+Dr. Cash/Bank              [amountPaid]
+  Cr. HP Receivable        [principal + interest]
+  Cr. Commission Income    [monthlyCommission]
+  Cr. VAT Output           [vatAmount]
+  Cr. Late Fee Income      [lateFee — if any, NOT VAT]
+```
+
+### Contract Activation
+```
+Dr. HP Receivable          [financedAmount + interest + commission + VAT]
+  Cr. Revenue              [sellingPrice + interest + commission]
+  Cr. VAT Output           [vatAmount]
+Dr. COGS                   [costPrice]
+  Cr. Inventory            [costPrice]
+```
+
+### Bad Debt Write-Off
+```
+Dr. Bad Debt Expense       [writeOffAmount - provisionAmount]
+Dr. Allowance for Doubtful [provisionAmount — if any]
+  Cr. HP Receivable        [writeOffAmount]
+```
+
+### Expense Paid
+```
+Dr. Expense Account        [amount excl. VAT]
+Dr. VAT Input              [vatAmount — if any]
+  Cr. Cash/Bank            [totalAmount]
+```
+
+## Inter-Company Transactions
+- ใช้ **single `InterCompanyTransaction` record** (ไม่ใช่ double-entry ข้ามนิติบุคคล)
+- เหตุผล: ปัจจุบันยังเป็นนิติบุคคลเดียวกัน — เมื่อแยกนิติบุคคลจริงต้อง refactor เป็น double-entry
+- Track FINANCE↔SHOP flows ผ่าน `ownedByCompanyId` บน Product
+
+## Deferred Items
+- **CR-001**: VAT on interest — รอ business decision จากเจ้าของ + นักบัญชี
+- **N-005**: Interest recognized upfront vs accrual ตามงวด — ต้อง CPA review
+- **GFIN integration**: รอ API spec จาก partner

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -405,10 +405,10 @@ export class AccountingService {
     let pendingCount = 0;
 
     for (const e of expenses) {
-      const amt = Number(e.totalAmount);
-      totalAmount += amt;
-      byAccountType[e.accountType] = (byAccountType[e.accountType] || 0) + amt;
-      byCategory[e.category] = (byCategory[e.category] || 0) + amt;
+      const amt = new Prisma.Decimal(e.totalAmount);
+      totalAmount = new Prisma.Decimal(totalAmount).add(amt).toNumber();
+      byAccountType[e.accountType] = new Prisma.Decimal(byAccountType[e.accountType] ?? 0).add(amt).toNumber();
+      byCategory[e.category] = new Prisma.Decimal(byCategory[e.category] ?? 0).add(amt).toNumber();
       if (e.status === 'PENDING_APPROVAL' || e.status === 'DRAFT') pendingCount++;
     }
 
@@ -438,7 +438,7 @@ export class AccountingService {
       if (!breakdown[e.category]) {
         breakdown[e.category] = { accountType: e.accountType, accountCode: e.accountCode, total: 0, count: 0 };
       }
-      breakdown[e.category].total += Number(e.totalAmount);
+      breakdown[e.category].total = new Prisma.Decimal(breakdown[e.category].total).add(new Prisma.Decimal(e.totalAmount)).toNumber();
       breakdown[e.category].count++;
     }
 
@@ -513,54 +513,58 @@ export class AccountingService {
       }),
     ]);
 
-    const cashSales = Number(cashSalesAgg._sum.netAmount || 0);
-    const installmentDownPayments = Number(installmentSales._sum.downPaymentAmount || 0);
-    const financeDownPayments = Number(externalFinanceSales._sum.downPaymentAmount || 0);
-    const financeReceivedAmount = Number(financeReceived._sum.receivedAmount || 0);
+    const cashSales = new Prisma.Decimal(cashSalesAgg._sum.netAmount ?? 0);
+    const installmentDownPayments = new Prisma.Decimal(installmentSales._sum.downPaymentAmount ?? 0);
+    const financeDownPayments = new Prisma.Decimal(externalFinanceSales._sum.downPaymentAmount ?? 0);
+    const financeReceivedAmount = new Prisma.Decimal(financeReceived._sum.receivedAmount ?? 0);
 
     // Payment breakdown: use stored breakdowns when available, fallback for legacy payments
-    let installmentPaymentsTotal = 0; // ยอดรับชำระจากค่างวดรวม (amountPaid)
-    let interestIncome = 0;           // ดอกเบี้ย (4210) — breakdown info
-    let commissionIncome = 0;         // ค่าคอม (4400) — breakdown info
-    let principalIncome = 0;          // เงินต้น — breakdown info
-    let lateFeeIncome = 0;            // ค่าปรับ (4300)
-    let vatCollected = 0;             // VAT ที่เก็บ (2210 - liability not revenue)
+    let installmentPaymentsTotal = new Prisma.Decimal(0); // ยอดรับชำระจากค่างวดรวม (amountPaid)
+    let interestIncome = new Prisma.Decimal(0);           // ดอกเบี้ย (4210) — breakdown info
+    let commissionIncome = new Prisma.Decimal(0);         // ค่าคอม (4400) — breakdown info
+    let principalIncome = new Prisma.Decimal(0);          // เงินต้น — breakdown info
+    let lateFeeIncome = new Prisma.Decimal(0);            // ค่าปรับ (4300)
+    let vatCollected = new Prisma.Decimal(0);             // VAT ที่เก็บ (2210 - liability not revenue)
 
     for (const p of paidPayments) {
-      const paid = Number(p.amountPaid);
-      installmentPaymentsTotal += paid;
+      const paid = new Prisma.Decimal(p.amountPaid);
+      installmentPaymentsTotal = installmentPaymentsTotal.add(paid);
 
       if (p.monthlyPrincipal !== null) {
         // New: use stored breakdowns for detailed reporting
-        principalIncome += Number(p.monthlyPrincipal);
-        interestIncome += Number(p.monthlyInterest);
-        commissionIncome += Number(p.monthlyCommission);
-        vatCollected += Number(p.vatAmount ?? 0);
+        principalIncome = principalIncome.add(new Prisma.Decimal(p.monthlyPrincipal));
+        interestIncome = interestIncome.add(new Prisma.Decimal(p.monthlyInterest ?? 0));
+        commissionIncome = commissionIncome.add(new Prisma.Decimal(p.monthlyCommission ?? 0));
+        vatCollected = vatCollected.add(new Prisma.Decimal(p.vatAmount ?? 0));
       } else {
         // Legacy fallback: estimate interest from contract data
-        principalIncome += paid;
-        interestIncome += Math.round(Number(p.contract.interestTotal) / p.contract.totalMonths * 100) / 100;
+        principalIncome = principalIncome.add(paid);
+        interestIncome = interestIncome.add(
+          new Prisma.Decimal(p.contract.interestTotal).div(p.contract.totalMonths),
+        );
       }
-      if (!p.lateFeeWaived) lateFeeIncome += Number(p.lateFee);
+      if (!p.lateFeeWaived) lateFeeIncome = lateFeeIncome.add(new Prisma.Decimal(p.lateFee));
     }
 
     // installmentPayments = total amountPaid from installment contracts (includes principal+interest+commission+VAT)
     // Interest/commission/VAT breakdowns are informational, NOT additive on top of installmentPayments
     const installmentPayments = installmentPaymentsTotal;
 
-    const operatingRevenue = cashSales + installmentDownPayments + installmentPayments
-      + financeDownPayments + financeReceivedAmount;
+    const operatingRevenue = cashSales.add(installmentDownPayments).add(installmentPayments)
+      .add(financeDownPayments).add(financeReceivedAmount);
     // Late fee income is additive (it's separate from amountPaid — stored in lateFee field)
-    const totalRevenue = operatingRevenue + lateFeeIncome;
+    const totalRevenue = operatingRevenue.add(lateFeeIncome);
 
-    const expMap: Record<string, number> = {};
+    const expMap: Record<string, Prisma.Decimal> = {};
     for (const e of expensesByCategory) {
-      expMap[e.category] = (expMap[e.category] || 0) + Number(e.totalAmount);
+      expMap[e.category] = (expMap[e.category] ?? new Prisma.Decimal(0)).add(new Prisma.Decimal(e.totalAmount));
     }
+
+    const getExp = (key: string) => expMap[key] ?? new Prisma.Decimal(0);
 
     // COGS: main product cost + bundle product costs
     const allBundleIds = productCosts.flatMap((s) => s.bundleProductIds || []);
-    let bundleCost = 0;
+    let bundleCost = new Prisma.Decimal(0);
     if (allBundleIds.length > 0) {
       const bundleProducts = await this.prisma.product.findMany({
         where: { id: { in: allBundleIds } },
@@ -572,105 +576,139 @@ export class AccountingService {
           `COGS bundle mismatch: expected ${allBundleIds.length} products, found ${bundleProducts.length}`,
         );
       }
-      bundleCost = bundleProducts.reduce((sum, p) => sum + Number(p.costPrice || 0), 0);
+      bundleCost = bundleProducts.reduce(
+        (sum, p) => sum.add(new Prisma.Decimal(p.costPrice ?? 0)),
+        new Prisma.Decimal(0),
+      );
     }
-    const purchaseOrderCost = productCosts.reduce((sum, s) => sum + Number(s.product.costPrice || 0), 0)
-      + bundleCost;
+    const purchaseOrderCost = productCosts
+      .reduce(
+        (sum, s) => sum.add(new Prisma.Decimal(s.product.costPrice ?? 0)),
+        new Prisma.Decimal(0),
+      )
+      .add(bundleCost);
+
+    const cogsProduct = getExp('COGS_PRODUCT');
+    const cogsRepairParts = getExp('COGS_REPAIR_PARTS');
+    const totalCOGS = cogsProduct.add(cogsRepairParts).add(purchaseOrderCost);
 
     const costOfSales = {
-      cogsProduct: expMap['COGS_PRODUCT'] || 0,
-      cogsRepairParts: expMap['COGS_REPAIR_PARTS'] || 0,
-      purchaseOrderCost,
-      totalCOGS: (expMap['COGS_PRODUCT'] || 0) + (expMap['COGS_REPAIR_PARTS'] || 0) + purchaseOrderCost,
+      cogsProduct: cogsProduct.toNumber(),
+      cogsRepairParts: cogsRepairParts.toNumber(),
+      purchaseOrderCost: purchaseOrderCost.toNumber(),
+      totalCOGS: totalCOGS.toNumber(),
     };
 
     // Gross profit from operating revenue only (excludes interest/late fees)
-    const grossProfit = operatingRevenue - costOfSales.totalCOGS;
+    const grossProfit = operatingRevenue.sub(totalCOGS);
+
+    const sellCommission = getExp('SELL_COMMISSION');
+    const sellAdvertising = getExp('SELL_ADVERTISING');
+    const sellTransport = getExp('SELL_TRANSPORT');
+    const sellPackaging = getExp('SELL_PACKAGING');
+    const totalSelling = sellCommission.add(sellAdvertising).add(sellTransport).add(sellPackaging);
 
     const sellingExpenses = {
-      commission: expMap['SELL_COMMISSION'] || 0,
-      advertising: expMap['SELL_ADVERTISING'] || 0,
-      transport: expMap['SELL_TRANSPORT'] || 0,
-      packaging: expMap['SELL_PACKAGING'] || 0,
-      totalSelling: (expMap['SELL_COMMISSION'] || 0) + (expMap['SELL_ADVERTISING'] || 0)
-        + (expMap['SELL_TRANSPORT'] || 0) + (expMap['SELL_PACKAGING'] || 0),
+      commission: sellCommission.toNumber(),
+      advertising: sellAdvertising.toNumber(),
+      transport: sellTransport.toNumber(),
+      packaging: sellPackaging.toNumber(),
+      totalSelling: totalSelling.toNumber(),
     };
+
+    const adminSalary = getExp('ADMIN_SALARY');
+    const adminSocialSecurity = getExp('ADMIN_SOCIAL_SECURITY');
+    const adminRent = getExp('ADMIN_RENT');
+    const adminUtilities = getExp('ADMIN_UTILITIES');
+    const adminOfficeSupplies = getExp('ADMIN_OFFICE_SUPPLIES');
+    const adminDepreciation = getExp('ADMIN_DEPRECIATION');
+    const adminInsurance = getExp('ADMIN_INSURANCE');
+    const adminTaxFee = getExp('ADMIN_TAX_FEE');
+    const adminMaintenance = getExp('ADMIN_MAINTENANCE');
+    const adminTravel = getExp('ADMIN_TRAVEL');
+    const adminTelephone = getExp('ADMIN_TELEPHONE');
+    const totalAdmin = adminSalary.add(adminSocialSecurity).add(adminRent).add(adminUtilities)
+      .add(adminOfficeSupplies).add(adminDepreciation).add(adminInsurance).add(adminTaxFee)
+      .add(adminMaintenance).add(adminTravel).add(adminTelephone);
 
     const adminExpenses = {
-      salary: expMap['ADMIN_SALARY'] || 0,
-      socialSecurity: expMap['ADMIN_SOCIAL_SECURITY'] || 0,
-      rent: expMap['ADMIN_RENT'] || 0,
-      utilities: expMap['ADMIN_UTILITIES'] || 0,
-      officeSupplies: expMap['ADMIN_OFFICE_SUPPLIES'] || 0,
-      depreciation: expMap['ADMIN_DEPRECIATION'] || 0,
-      insurance: expMap['ADMIN_INSURANCE'] || 0,
-      taxFee: expMap['ADMIN_TAX_FEE'] || 0,
-      maintenance: expMap['ADMIN_MAINTENANCE'] || 0,
-      travel: expMap['ADMIN_TRAVEL'] || 0,
-      telephone: expMap['ADMIN_TELEPHONE'] || 0,
-      totalAdmin: 0,
+      salary: adminSalary.toNumber(),
+      socialSecurity: adminSocialSecurity.toNumber(),
+      rent: adminRent.toNumber(),
+      utilities: adminUtilities.toNumber(),
+      officeSupplies: adminOfficeSupplies.toNumber(),
+      depreciation: adminDepreciation.toNumber(),
+      insurance: adminInsurance.toNumber(),
+      taxFee: adminTaxFee.toNumber(),
+      maintenance: adminMaintenance.toNumber(),
+      travel: adminTravel.toNumber(),
+      telephone: adminTelephone.toNumber(),
+      totalAdmin: totalAdmin.toNumber(),
     };
-    adminExpenses.totalAdmin = adminExpenses.salary + adminExpenses.socialSecurity
-      + adminExpenses.rent + adminExpenses.utilities + adminExpenses.officeSupplies
-      + adminExpenses.depreciation + adminExpenses.insurance + adminExpenses.taxFee
-      + adminExpenses.maintenance + adminExpenses.travel + adminExpenses.telephone;
 
     // C-1 fix: TAS 1 structure — operatingProfit excludes other income/expenses
-    const operatingProfit = grossProfit - sellingExpenses.totalSelling - adminExpenses.totalAdmin;
+    const operatingProfit = grossProfit.sub(totalSelling).sub(totalAdmin);
+
+    const otherInterest = getExp('OTHER_INTEREST');
+    const otherLoss = getExp('OTHER_LOSS');
+    const otherFine = getExp('OTHER_FINE');
+    const otherMisc = getExp('OTHER_MISC');
+    const totalOther = otherInterest.add(otherLoss).add(otherFine).add(otherMisc);
 
     const otherExpenses = {
-      interest: expMap['OTHER_INTEREST'] || 0,
-      loss: expMap['OTHER_LOSS'] || 0,
-      fine: expMap['OTHER_FINE'] || 0,
-      misc: expMap['OTHER_MISC'] || 0,
-      totalOther: (expMap['OTHER_INTEREST'] || 0) + (expMap['OTHER_LOSS'] || 0)
-        + (expMap['OTHER_FINE'] || 0) + (expMap['OTHER_MISC'] || 0),
+      interest: otherInterest.toNumber(),
+      loss: otherLoss.toNumber(),
+      fine: otherFine.toNumber(),
+      misc: otherMisc.toNumber(),
+      totalOther: totalOther.toNumber(),
     };
 
     // C-1 fix: netProfit = operatingProfit + lateFeeIncome - otherExpenses (TAS 1)
     // Interest/commission/VAT are already inside installmentPayments (amountPaid).
     // Only lateFee is truly additive (stored separately in lateFee field).
-    const netProfit = operatingProfit + lateFeeIncome - otherExpenses.totalOther;
-    const totalExpenses = costOfSales.totalCOGS + sellingExpenses.totalSelling
-      + adminExpenses.totalAdmin + otherExpenses.totalOther;
+    const netProfit = operatingProfit.add(lateFeeIncome).sub(totalOther);
+    const totalExpenses = totalCOGS.add(totalSelling).add(totalAdmin).add(totalOther);
+
+    const totalRevenueNum = totalRevenue.toNumber();
+    const netProfitNum = netProfit.toNumber();
 
     return {
       period: { start: startDate, end: endDate },
       revenue: {
-        cashSales,
-        installmentDownPayments,
-        installmentPayments,
-        financeDownPayments,
-        financeReceived: financeReceivedAmount,
-        operatingRevenue,
-        lateFeeIncome: Math.round(lateFeeIncome * 100) / 100,
-        totalRevenue,
+        cashSales: cashSales.toNumber(),
+        installmentDownPayments: installmentDownPayments.toNumber(),
+        installmentPayments: installmentPayments.toNumber(),
+        financeDownPayments: financeDownPayments.toNumber(),
+        financeReceived: financeReceivedAmount.toNumber(),
+        operatingRevenue: operatingRevenue.toNumber(),
+        lateFeeIncome: lateFeeIncome.toNumber(),
+        totalRevenue: totalRevenueNum,
       },
       // Breakdown of installmentPayments (informational — already included in installmentPayments)
       paymentBreakdown: {
-        principalIncome: Math.round(principalIncome * 100) / 100,
-        interestIncome: Math.round(interestIncome * 100) / 100,
-        commissionIncome: Math.round(commissionIncome * 100) / 100,
+        principalIncome: principalIncome.toNumber(),
+        interestIncome: interestIncome.toNumber(),
+        commissionIncome: commissionIncome.toNumber(),
         note: 'เงินต้น/ดอกเบี้ย/ค่าคอม รวมอยู่ใน installmentPayments แล้ว — แสดงเพื่อแยกรายได้ตามหมวดบัญชี',
       },
       vatOutput: {
         accountCode: '21-2101',
         label: 'ภาษีขาย (Output VAT)',
-        amount: Math.round(vatCollected * 100) / 100,
+        amount: vatCollected.toNumber(),
         note: 'เก็บจากค่างวดผ่อนชำระ — เป็นหนี้สินไม่ใช่รายได้',
       },
       costOfSales,
-      grossProfit,
+      grossProfit: grossProfit.toNumber(),
       sellingExpenses,
       adminExpenses,
-      operatingProfit,
+      operatingProfit: operatingProfit.toNumber(),
       otherExpenses,
-      netProfit,
+      netProfit: netProfitNum,
       summary: {
-        totalRevenue,
-        totalExpenses,
-        netProfit,
-        profitMargin: totalRevenue > 0 ? Math.round((netProfit / totalRevenue) * 10000) / 100 : 0,
+        totalRevenue: totalRevenueNum,
+        totalExpenses: totalExpenses.toNumber(),
+        netProfit: netProfitNum,
+        profitMargin: totalRevenueNum > 0 ? Math.round((netProfitNum / totalRevenueNum) * 10000) / 100 : 0,
       },
     };
   }
@@ -712,15 +750,15 @@ export class AccountingService {
     ]);
 
     const months = Array.from({ length: 12 }, (_, i) => {
-      let revenue = 0;
-      let cogs = 0;
-      let expenseTotal = 0;
+      let revenue = new Prisma.Decimal(0);
+      let cogs = new Prisma.Decimal(0);
+      let expenseTotal = new Prisma.Decimal(0);
 
       for (const s of sales) {
         if (getMonth(s.createdAt) !== i) continue;
-        if (s.saleType === 'CASH') revenue += Number(s.netAmount);
+        if (s.saleType === 'CASH') revenue = revenue.add(new Prisma.Decimal(s.netAmount ?? 0));
         if (s.saleType === 'INSTALLMENT' || s.saleType === 'EXTERNAL_FINANCE') {
-          revenue += Number(s.downPaymentAmount || 0);
+          revenue = revenue.add(new Prisma.Decimal(s.downPaymentAmount ?? 0));
         }
       }
 
@@ -728,32 +766,36 @@ export class AccountingService {
         if (getMonth(p.paidDate) !== i) continue;
         if (p.monthlyPrincipal !== null) {
           // New: use stored breakdowns — principal + commission + interest + lateFee
-          revenue += Number(p.monthlyPrincipal) + Number(p.monthlyCommission)
-            + Number(p.monthlyInterest);
-          if (!p.lateFeeWaived) revenue += Number(p.lateFee);
+          revenue = revenue
+            .add(new Prisma.Decimal(p.monthlyPrincipal))
+            .add(new Prisma.Decimal(p.monthlyCommission ?? 0))
+            .add(new Prisma.Decimal(p.monthlyInterest ?? 0));
+          if (!p.lateFeeWaived) revenue = revenue.add(new Prisma.Decimal(p.lateFee));
         } else {
           // Legacy fallback: amountPaid already includes everything
-          revenue += Number(p.amountPaid);
+          revenue = revenue.add(new Prisma.Decimal(p.amountPaid));
         }
       }
 
       for (const f of financeRecs) {
         if (getMonth(f.receivedDate) !== i) continue;
-        revenue += Number(f.receivedAmount || 0);
+        revenue = revenue.add(new Prisma.Decimal(f.receivedAmount ?? 0));
       }
 
       for (const s of productSales) {
         if (getMonth(s.createdAt) !== i) continue;
-        cogs += Number(s.product.costPrice || 0);
+        cogs = cogs.add(new Prisma.Decimal(s.product.costPrice ?? 0));
       }
 
       for (const e of expenses) {
         if (getMonth(e.expenseDate) !== i) continue;
-        expenseTotal += Number(e.totalAmount);
+        expenseTotal = expenseTotal.add(new Prisma.Decimal(e.totalAmount));
       }
 
-      const totalExpenses = cogs + expenseTotal;
-      return { month: i + 1, label: thaiMonths[i], revenue, expenses: totalExpenses, netProfit: revenue - totalExpenses };
+      const totalExpenses = cogs.add(expenseTotal);
+      const revenueNum = revenue.toNumber();
+      const expensesNum = totalExpenses.toNumber();
+      return { month: i + 1, label: thaiMonths[i], revenue: revenueNum, expenses: expensesNum, netProfit: revenueNum - expensesNum };
     });
 
     return { year, months };
@@ -894,15 +936,13 @@ export class AccountingService {
       _sum: { paidAmount: true },
     });
 
-    const totalCashInflows =
-      Number(paymentsReceived._sum.amountPaid || 0) +
-      Number(cashSalesTotal._sum.netAmount || 0) +
-      Number(downPaymentsTotal._sum.downPaymentAmount || 0) +
-      Number(financeReceivedTotal._sum.receivedAmount || 0);
-    const totalCashOutflows =
-      Number(expensesPaid._sum.totalAmount || 0) +
-      Number(purchaseOrdersPaid._sum.paidAmount || 0);
-    const cashAndBank = totalCashInflows - totalCashOutflows;
+    const totalCashInflows = new Prisma.Decimal(paymentsReceived._sum.amountPaid ?? 0)
+      .add(new Prisma.Decimal(cashSalesTotal._sum.netAmount ?? 0))
+      .add(new Prisma.Decimal(downPaymentsTotal._sum.downPaymentAmount ?? 0))
+      .add(new Prisma.Decimal(financeReceivedTotal._sum.receivedAmount ?? 0));
+    const totalCashOutflows = new Prisma.Decimal(expensesPaid._sum.totalAmount ?? 0)
+      .add(new Prisma.Decimal(purchaseOrdersPaid._sum.paidAmount ?? 0));
+    const cashAndBank = totalCashInflows.sub(totalCashOutflows);
 
     // 1220 Hire-purchase receivables: Outstanding installments on active contracts
     const [hpReceivables, provisions, pendingFinance, inventory, creditBalances, whtPayable, accruedExpenses] =
@@ -958,60 +998,78 @@ export class AccountingService {
         }),
       ]);
 
-    const grossReceivables = Number(hpReceivables._sum.amountDue || 0);
-    const paidOnReceivables = Number(hpReceivables._sum.amountPaid || 0);
-    const netReceivables = grossReceivables - paidOnReceivables;
-    const allowanceForDoubtful = Number(provisions._sum.provisionAmount || 0);
-    const financeReceivables = Number(pendingFinance._sum.expectedAmount || 0);
-    const inventoryValue = Number(inventory._sum.costPrice || 0);
+    const grossReceivables = new Prisma.Decimal(hpReceivables._sum.amountDue ?? 0);
+    const paidOnReceivables = new Prisma.Decimal(hpReceivables._sum.amountPaid ?? 0);
+    const netReceivables = grossReceivables.sub(paidOnReceivables);
+    const allowanceForDoubtful = new Prisma.Decimal(provisions._sum.provisionAmount ?? 0);
+    const financeReceivables = new Prisma.Decimal(pendingFinance._sum.expectedAmount ?? 0);
+    const inventoryValue = new Prisma.Decimal(inventory._sum.costPrice ?? 0);
     const inventoryCount = inventory._count || 0;
 
-    const totalCurrentAssets =
-      cashAndBank + netReceivables - allowanceForDoubtful + financeReceivables + inventoryValue;
+    const totalCurrentAssets = cashAndBank
+      .add(netReceivables)
+      .sub(allowanceForDoubtful)
+      .add(financeReceivables)
+      .add(inventoryValue);
     const totalAssets = totalCurrentAssets; // No fixed assets tracked in system
 
     // ── LIABILITIES ──
 
-    const customerCreditBalances = Number(creditBalances._sum.creditBalance || 0);
-    const totalWhtPayable = Number(whtPayable._sum.withholdingTax || 0);
-    const totalAccrued = Number(accruedExpenses._sum.totalAmount || 0);
+    const customerCreditBalances = new Prisma.Decimal(creditBalances._sum.creditBalance ?? 0);
+    const totalWhtPayable = new Prisma.Decimal(whtPayable._sum.withholdingTax ?? 0);
+    const totalAccrued = new Prisma.Decimal(accruedExpenses._sum.totalAmount ?? 0);
 
-    const totalLiabilities = customerCreditBalances + totalWhtPayable + totalAccrued;
+    const totalLiabilities = customerCreditBalances.add(totalWhtPayable).add(totalAccrued);
 
     // ── EQUITY ──
     // Retained earnings = Total Assets - Total Liabilities (balancing figure)
     // In a full accounting system this would come from accumulated P&L; here we derive it.
-    const retainedEarnings = totalAssets - totalLiabilities;
+    const retainedEarnings = totalAssets.sub(totalLiabilities);
+
+    const grossReceivablesNum = grossReceivables.toNumber();
+    const paidOnReceivablesNum = paidOnReceivables.toNumber();
+    const netReceivablesNum = netReceivables.toNumber();
+    const allowanceForDoubtfulNum = allowanceForDoubtful.toNumber();
+    const financeReceivablesNum = financeReceivables.toNumber();
+    const inventoryValueNum = inventoryValue.toNumber();
+    const cashAndBankNum = cashAndBank.toNumber();
+    const totalCurrentAssetsNum = totalCurrentAssets.toNumber();
+    const totalAssetsNum = totalAssets.toNumber();
+    const customerCreditBalancesNum = customerCreditBalances.toNumber();
+    const totalWhtPayableNum = totalWhtPayable.toNumber();
+    const totalAccruedNum = totalAccrued.toNumber();
+    const totalLiabilitiesNum = totalLiabilities.toNumber();
+    const retainedEarningsNum = retainedEarnings.toNumber();
 
     return {
       asOfDate,
       assets: {
         currentAssets: {
-          cashAndBank,
+          cashAndBank: cashAndBankNum,
           hirePurchaseReceivables: {
-            gross: grossReceivables,
-            paid: paidOnReceivables,
-            net: netReceivables,
-            allowanceForDoubtful: -allowanceForDoubtful,
-            netAfterAllowance: netReceivables - allowanceForDoubtful,
+            gross: grossReceivablesNum,
+            paid: paidOnReceivablesNum,
+            net: netReceivablesNum,
+            allowanceForDoubtful: -allowanceForDoubtfulNum,
+            netAfterAllowance: netReceivablesNum - allowanceForDoubtfulNum,
           },
-          financeReceivables,
-          inventory: { value: inventoryValue, count: inventoryCount },
-          totalCurrentAssets,
+          financeReceivables: financeReceivablesNum,
+          inventory: { value: inventoryValueNum, count: inventoryCount },
+          totalCurrentAssets: totalCurrentAssetsNum,
         },
-        totalAssets,
+        totalAssets: totalAssetsNum,
       },
       liabilities: {
         currentLiabilities: {
-          customerCreditBalances,
-          withholdingTaxPayable: totalWhtPayable,
-          accruedExpenses: totalAccrued,
+          customerCreditBalances: customerCreditBalancesNum,
+          withholdingTaxPayable: totalWhtPayableNum,
+          accruedExpenses: totalAccruedNum,
         },
-        totalLiabilities,
+        totalLiabilities: totalLiabilitiesNum,
       },
       equity: {
-        retainedEarnings,
-        totalEquity: retainedEarnings,
+        retainedEarnings: retainedEarningsNum,
+        totalEquity: retainedEarningsNum,
       },
       // Note: Balance Sheet is derived (not from general ledger). Retained earnings is
       // calculated as Assets - Liabilities, so it always balances by definition.
@@ -1079,37 +1137,48 @@ export class AccountingService {
       _sum: { paidAmount: true },
     });
 
-    const cashFromSales = Number(cashSales._sum.netAmount || 0);
-    const cashFromDownPayments = Number(downPayments._sum.downPaymentAmount || 0);
+    const cashFromSales = new Prisma.Decimal(cashSales._sum.netAmount ?? 0);
+    const cashFromDownPayments = new Prisma.Decimal(downPayments._sum.downPaymentAmount ?? 0);
     // C-3 fix: amountPaid already includes lateFee portion (customer pays amountDue + lateFee as one sum)
     // so we don't add lateFee separately to avoid double-counting
-    const cashFromInstallments = Number(installmentPayments._sum.amountPaid || 0);
-    const cashFromFinanceCompanies = Number(financeReceived._sum.receivedAmount || 0);
+    const cashFromInstallments = new Prisma.Decimal(installmentPayments._sum.amountPaid ?? 0);
+    const cashFromFinanceCompanies = new Prisma.Decimal(financeReceived._sum.receivedAmount ?? 0);
 
-    const cashFromCustomers =
-      cashFromSales + cashFromDownPayments + cashFromInstallments + cashFromFinanceCompanies;
+    const cashFromCustomers = cashFromSales
+      .add(cashFromDownPayments)
+      .add(cashFromInstallments)
+      .add(cashFromFinanceCompanies);
 
-    const cashPaidForExpenses = Number(expensesPaid._sum.totalAmount || 0);
-    const cashPaidForInventory = Number(purchaseOrdersPaid._sum.paidAmount || 0);
+    const cashPaidForExpenses = new Prisma.Decimal(expensesPaid._sum.totalAmount ?? 0);
+    const cashPaidForInventory = new Prisma.Decimal(purchaseOrdersPaid._sum.paidAmount ?? 0);
 
-    const netOperating = cashFromCustomers - cashPaidForExpenses - cashPaidForInventory;
+    const netOperating = cashFromCustomers.sub(cashPaidForExpenses).sub(cashPaidForInventory);
 
     // No investing or financing activities are tracked separately in this system
     const netCashChange = netOperating;
 
+    const cashFromCustomersNum = cashFromCustomers.toNumber();
+    const cashFromSalesNum = cashFromSales.toNumber();
+    const cashFromDownPaymentsNum = cashFromDownPayments.toNumber();
+    const cashFromInstallmentsNum = cashFromInstallments.toNumber();
+    const cashFromFinanceCompaniesNum = cashFromFinanceCompanies.toNumber();
+    const cashPaidForExpensesNum = cashPaidForExpenses.toNumber();
+    const cashPaidForInventoryNum = cashPaidForInventory.toNumber();
+    const netOperatingNum = netOperating.toNumber();
+
     return {
       period: { start: startDate, end: endDate },
       operatingActivities: {
-        cashFromCustomers,
-        cashFromSales,
-        cashFromDownPayments,
-        cashFromInstallments, // includes lateFee portion (amountPaid = principal + interest + lateFee)
-        cashFromFinanceCompanies,
-        cashPaidForExpenses: -cashPaidForExpenses,
-        cashPaidForInventory: -cashPaidForInventory,
-        netOperatingCashFlow: netOperating,
+        cashFromCustomers: cashFromCustomersNum,
+        cashFromSales: cashFromSalesNum,
+        cashFromDownPayments: cashFromDownPaymentsNum,
+        cashFromInstallments: cashFromInstallmentsNum, // includes lateFee portion (amountPaid = principal + interest + lateFee)
+        cashFromFinanceCompanies: cashFromFinanceCompaniesNum,
+        cashPaidForExpenses: -cashPaidForExpensesNum,
+        cashPaidForInventory: -cashPaidForInventoryNum,
+        netOperatingCashFlow: netOperatingNum,
       },
-      netCashChange,
+      netCashChange: netCashChange.toNumber(),
     };
   }
 }

--- a/apps/api/src/modules/accounting/bad-debt.service.spec.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.spec.ts
@@ -3,6 +3,7 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { BadDebtService } from './bad-debt.service';
 import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
 
 /**
  * BadDebtService is the financial provisioning engine. It maps overdue
@@ -51,6 +52,10 @@ describe('BadDebtService', () => {
       providers: [
         BadDebtService,
         { provide: PrismaService, useValue: prisma },
+        {
+          provide: JournalAutoService,
+          useValue: { createBadDebtWriteOffJournal: jest.fn().mockResolvedValue('je-mock') },
+        },
       ],
     }).compile();
 

--- a/apps/api/src/modules/accounting/bad-debt.service.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
 
 const DEFAULT_PROVISION_RATES: Record<string, number> = {
   '1-30': 0.02,
@@ -16,7 +17,10 @@ const DEFAULT_PROVISION_RATES: Record<string, number> = {
 
 @Injectable()
 export class BadDebtService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private journalAutoService: JournalAutoService,
+  ) {}
 
   /** Load provision rates from system config or use defaults */
   private async getProvisionRates(): Promise<Record<string, number>> {
@@ -227,6 +231,30 @@ export class BadDebtService {
     }
 
     return this.prisma.$transaction(async (tx) => {
+      // Calculate outstanding amount from unpaid/partial payments
+      const unpaidPayments = await tx.payment.findMany({
+        where: {
+          contractId,
+          status: { in: ['PENDING', 'PARTIALLY_PAID'] },
+          deletedAt: null,
+        },
+        select: { amountDue: true, amountPaid: true, lateFee: true, lateFeeWaived: true },
+      });
+      const outstandingAmount = unpaidPayments.reduce((sum, p) => {
+        const unpaidLateFee = !p.lateFeeWaived ? Number(p.lateFee) : 0;
+        return sum + Number(p.amountDue) - Number(p.amountPaid) + unpaidLateFee;
+      }, 0);
+
+      // Capture total active provision amount before updating status
+      const activeProvisions = await tx.badDebtProvision.findMany({
+        where: { contractId, status: 'ACTIVE', deletedAt: null },
+        select: { provisionAmount: true },
+      });
+      const existingProvisionAmount = activeProvisions.reduce(
+        (sum, p) => sum + Number(p.provisionAmount),
+        0,
+      );
+
       // Update contract status to CLOSED_BAD_DEBT
       await tx.contract.update({
         where: { id: contractId },
@@ -244,6 +272,15 @@ export class BadDebtService {
           approvedAt: new Date(),
           notes,
         },
+      });
+
+      // Create double-entry journal for the write-off
+      await this.journalAutoService.createBadDebtWriteOffJournal(tx, {
+        contractId: contract.id,
+        contractNumber: contract.contractNumber,
+        writeOffAmount: outstandingAmount,
+        provisionAmount: existingProvisionAmount,
+        createdById: approvedById,
       });
 
       return { contractId, status: 'CLOSED_BAD_DEBT', writtenOffAt: new Date() };

--- a/apps/api/src/modules/chatbot-finance/services/admin-analytics.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/admin-analytics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
-import { ChatChannel, MessageRole } from '@prisma/client';
+import { ChatChannel, MessageRole, Prisma } from '@prisma/client';
 
 export interface AnalyticsOverview {
   today: {
@@ -118,7 +118,7 @@ export class AdminAnalyticsService {
         messages: messagesToday,
         handoffs: handoffsToday,
         autoTriggers: autoTriggersToday,
-        totalCostUsd: Number(todayCostAgg._sum.costUsd ?? 0),
+        totalCostUsd: new Prisma.Decimal(todayCostAgg._sum.costUsd ?? 0).toNumber(),
       },
       total: {
         sessions: totalSessions,

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -99,7 +99,7 @@ export class ContractsService {
         totalContracts: total,
         activeContracts: totalActive,
         overdueContracts: totalOverdue,
-        portfolioValue: Number(portfolioValue._sum.sellingPrice || 0),
+        portfolioValue: new Prisma.Decimal(portfolioValue._sum.sellingPrice ?? 0).toNumber(),
       },
     };
   }

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -76,8 +76,9 @@ export class DashboardService {
       }),
     ]);
 
-    const totalReceivable = Number(receivables._sum.amountDue || 0) - Number(receivables._sum.amountPaid || 0);
-    const totalLateFees = Number(receivables._sum.lateFee || 0);
+    const totalReceivable = new Prisma.Decimal(receivables._sum.amountDue ?? 0)
+      .sub(new Prisma.Decimal(receivables._sum.amountPaid ?? 0)).toNumber();
+    const totalLateFees = new Prisma.Decimal(receivables._sum.lateFee ?? 0).toNumber();
     const overdueRate = totalContracts > 0
       ? ((overdueContracts + defaultContracts) / totalContracts * 100).toFixed(1)
       : '0.0';
@@ -88,7 +89,7 @@ export class DashboardService {
       financial: {
         totalReceivable,
         totalLateFees,
-        todayPayments: Number(todayPayments._sum.amountPaid || 0),
+        todayPayments: new Prisma.Decimal(todayPayments._sum.amountPaid ?? 0).toNumber(),
         todayPaymentCount: todayPayments._count || 0,
       },
       overdueRate: Number(overdueRate),
@@ -133,7 +134,8 @@ export class DashboardService {
 
       const paymentsReceived = payments
         .filter((p) => p.paidDate && p.paidDate >= start && p.paidDate < end)
-        .reduce((sum, p) => sum + Number(p.amountPaid), 0);
+        .reduce((sum, p) => sum.add(new Prisma.Decimal(p.amountPaid ?? 0)), new Prisma.Decimal(0))
+        .toNumber();
 
       months.push({ month: monthLabel, newContracts, paymentsReceived });
     }
@@ -162,8 +164,12 @@ export class DashboardService {
 
     const results = contracts.map((c) => {
       const totalOutstanding = c.payments.reduce(
-        (sum, p) => sum + Number(p.amountDue) - Number(p.amountPaid) + Number(p.lateFee), 0,
-      );
+        (sum, p) => sum
+          .add(new Prisma.Decimal(p.amountDue ?? 0))
+          .sub(new Prisma.Decimal(p.amountPaid ?? 0))
+          .add(new Prisma.Decimal(p.lateFee ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber();
       const oldestDue = c.payments.length > 0
         ? c.payments.reduce((oldest, p) => {
             const d = new Date(p.dueDate);
@@ -259,7 +265,12 @@ export class DashboardService {
     const paymentTotalByBranch = new Map<string, number>();
     for (const p of paidPayments) {
       const bid = p.contract.branchId;
-      paymentTotalByBranch.set(bid, (paymentTotalByBranch.get(bid) || 0) + Number(p.amountPaid));
+      paymentTotalByBranch.set(
+        bid,
+        new Prisma.Decimal(paymentTotalByBranch.get(bid) ?? 0)
+          .add(new Prisma.Decimal(p.amountPaid ?? 0))
+          .toNumber(),
+      );
     }
 
     const overdueMap = new Map(overdueByBranch.map((o) => [o.branchId, o._count]));
@@ -305,16 +316,20 @@ export class DashboardService {
       }),
     ]);
 
-    const totalPayments = paidPayments.reduce((sum, p) => sum + Number(p.amountPaid), 0);
+    const totalPayments = paidPayments.reduce(
+      (sum, p) => sum.add(new Prisma.Decimal(p.amountPaid ?? 0)),
+      new Prisma.Decimal(0),
+    ).toNumber();
     const interestIncome = paidPayments.reduce((sum, p) => {
-      const monthlyInterest = Number(p.contract.interestTotal) / p.contract.totalMonths;
-      return sum + monthlyInterest;
-    }, 0);
+      const monthlyInterest = new Prisma.Decimal(p.contract.interestTotal ?? 0)
+        .div(p.contract.totalMonths);
+      return sum.add(monthlyInterest);
+    }, new Prisma.Decimal(0));
 
     return {
       totalPayments,
-      interestIncome: Math.round(interestIncome),
-      lateFeeIncome: Number(lateFeeAgg._sum.lateFee || 0),
+      interestIncome: Math.round(interestIncome.toNumber()),
+      lateFeeIncome: new Prisma.Decimal(lateFeeAgg._sum.lateFee ?? 0).toNumber(),
       paymentCount: paidPayments.length,
     };
   }
@@ -349,7 +364,10 @@ export class DashboardService {
         const days = calculateDaysElapsed(p.dueDate, now);
         return days >= def.min && days <= def.max;
       });
-      const amount = items.reduce((s, p) => s + Number(p.amountDue) - Number(p.amountPaid), 0);
+      const amount = items.reduce(
+        (s, p) => s.add(new Prisma.Decimal(p.amountDue ?? 0)).sub(new Prisma.Decimal(p.amountPaid ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber();
       return { range: def.range, count: items.length, amount, color: def.color };
     });
 
@@ -561,7 +579,8 @@ export class DashboardService {
         totalContracts: 0, totalSales: 0, overdueCount: 0,
       };
       existing.totalContracts++;
-      existing.totalSales += Number(c.sellingPrice);
+      existing.totalSales = new Prisma.Decimal(existing.totalSales)
+        .add(new Prisma.Decimal(c.sellingPrice ?? 0)).toNumber();
       if (['OVERDUE', 'DEFAULT'].includes(c.status)) existing.overdueCount++;
       staffMap.set(key, existing);
     }
@@ -613,7 +632,7 @@ export class DashboardService {
         type: 'contract_created' as const,
         userName: c.salesperson.name,
         description: `สร้างสัญญา ${c.contractNumber} — ${c.customer.name}`,
-        amount: Number(c.sellingPrice),
+        amount: new Prisma.Decimal(c.sellingPrice ?? 0).toNumber(),
         createdAt: c.createdAt.toISOString(),
       })),
       ...recentPayments.map((p) => ({
@@ -621,7 +640,7 @@ export class DashboardService {
         type: 'payment_recorded' as const,
         userName: p.recordedBy?.name || '-',
         description: `บันทึกชำระ ${p.contract.contractNumber} — ${p.contract.customer.name}`,
-        amount: Number(p.amountPaid),
+        amount: new Prisma.Decimal(p.amountPaid ?? 0).toNumber(),
         createdAt: p.paidDate?.toISOString() || new Date().toISOString(),
       })),
     ].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -712,7 +731,7 @@ export class DashboardService {
         riskLevel,
         reasons,
         nextDueDate: r.nextDueDate,
-        nextAmountDue: r.nextAmountDue ? Number(r.nextAmountDue) : null,
+        nextAmountDue: r.nextAmountDue ? new Prisma.Decimal(r.nextAmountDue).toNumber() : null,
       };
     });
 

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -31,6 +31,7 @@ export class JournalAutoService {
     INVENTORY_USED: '11-3102',
     VAT_INPUT: '11-4101',
     VAT_OUTPUT: '21-2101',
+    ALLOWANCE_DOUBTFUL: '11-2901',  // ค่าเผื่อหนี้สงสัยจะสูญ (contra asset)
     CUSTOMER_CREDIT: '21-5101',
     REVENUE_NEW: '41-1101',
     REVENUE_USED: '41-1102',
@@ -38,6 +39,7 @@ export class JournalAutoService {
     COMMISSION_INCOME: '42-1105',
     COGS_NEW: '51-1101',
     COGS_USED: '51-1102',
+    BAD_DEBT_EXPENSE: '53-1101',    // หนี้สูญ
   } as const;
 
   constructor(private prisma: PrismaService) {}
@@ -162,19 +164,20 @@ export class JournalAutoService {
       return null;
     }
 
-    const amountPaid = Number(params.payment.amountPaid);
-    const principal = Number(params.payment.monthlyPrincipal || 0);
-    const interest = Number(params.payment.monthlyInterest || 0);
-    const commission = Number(params.payment.monthlyCommission || 0);
-    const vat = Number(params.payment.vatAmount || 0);
-    const lateFee = params.payment.lateFeeWaived ? 0 : Number(params.payment.lateFee || 0);
+    const amountPaid = new Prisma.Decimal(params.payment.amountPaid ?? 0);
+    const principal = new Prisma.Decimal(params.payment.monthlyPrincipal ?? 0);
+    const interest = new Prisma.Decimal(params.payment.monthlyInterest ?? 0);
+    const commission = new Prisma.Decimal(params.payment.monthlyCommission ?? 0);
+    const vat = new Prisma.Decimal(params.payment.vatAmount ?? 0);
+    const lateFee = params.payment.lateFeeWaived
+      ? new Prisma.Decimal(0)
+      : new Prisma.Decimal(params.payment.lateFee ?? 0);
 
     // Settle HP receivable = principal + interest (both reduce the receivable)
-    const hpSettled = principal + interest;
+    const hpSettled = principal.add(interest);
     // If breakdown is missing, settle whole amount against receivable as fallback
-    const fallbackHp = hpSettled === 0 && commission === 0 && vat === 0 && lateFee === 0
-      ? amountPaid - lateFee
-      : hpSettled;
+    const isZeroBreakdown = hpSettled.isZero() && commission.isZero() && vat.isZero() && lateFee.isZero();
+    const fallbackHp = isZeroBreakdown ? amountPaid.sub(lateFee) : hpSettled;
 
     return this.createAndPost(tx, {
       companyId,
@@ -184,11 +187,11 @@ export class JournalAutoService {
       referenceId: params.payment.id,
       createdById: params.userId,
       lines: [
-        { accountCode: JournalAutoService.ACC.CASH, description: 'รับชำระเงิน', debit: amountPaid, credit: 0 },
-        { accountCode: JournalAutoService.ACC.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: fallbackHp },
-        { accountCode: JournalAutoService.ACC.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: commission },
-        { accountCode: JournalAutoService.ACC.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat },
-        { accountCode: JournalAutoService.ACC.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: lateFee },
+        { accountCode: JournalAutoService.ACC.CASH, description: 'รับชำระเงิน', debit: amountPaid.toNumber(), credit: 0 },
+        { accountCode: JournalAutoService.ACC.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: fallbackHp.toNumber() },
+        { accountCode: JournalAutoService.ACC.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: commission.toNumber() },
+        { accountCode: JournalAutoService.ACC.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
+        { accountCode: JournalAutoService.ACC.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: lateFee.toNumber() },
       ],
     });
   }
@@ -225,9 +228,9 @@ export class JournalAutoService {
       return null;
     }
 
-    const amount = Number(params.expense.amount);
-    const vat = Number(params.expense.vatAmount || 0);
-    const total = Number(params.expense.totalAmount);
+    const amount = new Prisma.Decimal(params.expense.amount ?? 0);
+    const vat = new Prisma.Decimal(params.expense.vatAmount ?? 0);
+    const total = new Prisma.Decimal(params.expense.totalAmount ?? 0);
 
     return this.createAndPost(tx, {
       companyId,
@@ -237,9 +240,9 @@ export class JournalAutoService {
       referenceId: params.expense.id,
       createdById: params.userId,
       lines: [
-        { accountCode: params.expense.accountCode, description: params.expense.description, debit: amount, credit: 0 },
-        { accountCode: JournalAutoService.ACC.VAT_INPUT, description: 'ภาษีซื้อ', debit: vat, credit: 0 },
-        { accountCode: JournalAutoService.ACC.CASH, description: 'จ่ายเงิน', debit: 0, credit: total },
+        { accountCode: params.expense.accountCode, description: params.expense.description, debit: amount.toNumber(), credit: 0 },
+        { accountCode: JournalAutoService.ACC.VAT_INPUT, description: 'ภาษีซื้อ', debit: vat.toNumber(), credit: 0 },
+        { accountCode: JournalAutoService.ACC.CASH, description: 'จ่ายเงิน', debit: 0, credit: total.toNumber() },
       ],
     });
   }
@@ -277,16 +280,16 @@ export class JournalAutoService {
     const companyId = await this.resolveCompanyId(tx, params.companyId);
     if (!companyId) return null;
 
-    const sellingPrice = Number(params.contract.sellingPrice);
-    const downPayment = Number(params.contract.downPayment);
-    const financedAmount = Number(params.contract.financedAmount);
-    const interest = Number(params.contract.interestTotal);
-    const commission = Number(params.contract.storeCommission);
-    const vat = Number(params.contract.vatAmount);
-    const cost = Number(params.product.costPrice || 0);
+    const sellingPrice = new Prisma.Decimal(params.contract.sellingPrice ?? 0);
+    const downPayment = new Prisma.Decimal(params.contract.downPayment ?? 0);
+    const financedAmount = new Prisma.Decimal(params.contract.financedAmount ?? 0);
+    const interest = new Prisma.Decimal(params.contract.interestTotal ?? 0);
+    const commission = new Prisma.Decimal(params.contract.storeCommission ?? 0);
+    const vat = new Prisma.Decimal(params.contract.vatAmount ?? 0);
+    const cost = new Prisma.Decimal(params.product.costPrice ?? 0);
 
     // Sales revenue = sellingPrice + interest + commission (full deal value, excl. VAT)
-    const revenue = sellingPrice + interest + commission;
+    const revenue = sellingPrice.add(interest).add(commission);
     const isUsed = (params.product.category || '').toLowerCase().includes('used') ||
       (params.product.category || '').includes('มือสอง');
     const revenueAcc = isUsed ? JournalAutoService.ACC.REVENUE_USED : JournalAutoService.ACC.REVENUE_NEW;
@@ -302,15 +305,15 @@ export class JournalAutoService {
       referenceId: params.contract.id,
       createdById: params.userId,
       lines: [
-        { accountCode: JournalAutoService.ACC.CASH, description: 'รับเงินดาวน์', debit: downPayment, credit: 0 },
-        { accountCode: JournalAutoService.ACC.HP_RECEIVABLE, description: 'ลูกหนี้เช่าซื้อ', debit: financedAmount, credit: 0 },
-        { accountCode: revenueAcc, description: 'รายได้จากการขาย', debit: 0, credit: revenue },
-        { accountCode: JournalAutoService.ACC.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat },
+        { accountCode: JournalAutoService.ACC.CASH, description: 'รับเงินดาวน์', debit: downPayment.toNumber(), credit: 0 },
+        { accountCode: JournalAutoService.ACC.HP_RECEIVABLE, description: 'ลูกหนี้เช่าซื้อ', debit: financedAmount.toNumber(), credit: 0 },
+        { accountCode: revenueAcc, description: 'รายได้จากการขาย', debit: 0, credit: revenue.toNumber() },
+        { accountCode: JournalAutoService.ACC.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
       ],
     });
 
     // COGS entry (if cost available)
-    if (cost > 0) {
+    if (cost.greaterThan(0)) {
       await this.createAndPost(tx, {
         companyId,
         entryDate: new Date(),
@@ -319,8 +322,8 @@ export class JournalAutoService {
         referenceId: params.contract.id,
         createdById: params.userId,
         lines: [
-          { accountCode: cogsAcc, description: 'ต้นทุนขาย', debit: cost, credit: 0 },
-          { accountCode: inventoryAcc, description: 'ตัดสินค้าคงเหลือ', debit: 0, credit: cost },
+          { accountCode: cogsAcc, description: 'ต้นทุนขาย', debit: cost.toNumber(), credit: 0 },
+          { accountCode: inventoryAcc, description: 'ตัดสินค้าคงเหลือ', debit: 0, credit: cost.toNumber() },
         ],
       });
     }
@@ -356,9 +359,82 @@ export class JournalAutoService {
       lines: original.lines.map((l) => ({
         accountCode: l.accountCode,
         description: `กลับรายการ: ${l.description || ''}`,
-        debit: Number(l.credit), // swap
-        credit: Number(l.debit),
+        debit: new Prisma.Decimal(l.credit ?? 0).toNumber(), // swap
+        credit: new Prisma.Decimal(l.debit ?? 0).toNumber(),
       })),
+    });
+  }
+
+  /**
+   * Auto journal — Bad debt write-off (ตัดหนี้สูญ).
+   *
+   * When no prior provision exists:
+   *   Dr. Bad Debt Expense             [writeOffAmount]
+   *     Cr. HP Receivable              [writeOffAmount]
+   *
+   * When a provision exists (partial or full):
+   *   Dr. Bad Debt Expense             [writeOffAmount - provisionAmount]  (incremental charge)
+   *   Dr. Allowance for Doubtful Accts [provisionAmount]                   (utilise reserve)
+   *     Cr. HP Receivable              [writeOffAmount]
+   *
+   * The zero-line filter in createAndPost ensures lines with amount = 0 are dropped
+   * automatically, so partial-provision and full-provision cases both produce
+   * correctly balanced entries.
+   */
+  async createBadDebtWriteOffJournal(
+    tx: Prisma.TransactionClient,
+    params: {
+      contractId: string;
+      contractNumber: string;
+      writeOffAmount: Decimal | number;
+      provisionAmount?: Decimal | number;
+      createdById: string;
+      companyId?: string | null;
+    },
+  ): Promise<string | null> {
+    const companyId = await this.resolveCompanyId(tx, params.companyId);
+    if (!companyId) {
+      this.logger.warn(
+        `No active company found — skipping bad-debt write-off journal for contract ${params.contractId}`,
+      );
+      return null;
+    }
+
+    const writeOff = new Prisma.Decimal(params.writeOffAmount ?? 0);
+    const provision = new Prisma.Decimal(params.provisionAmount ?? 0);
+
+    // Incremental expense = amount not already provisioned (may be 0 if fully provisioned)
+    const incrementalExpense = writeOff.sub(provision).greaterThan(0)
+      ? writeOff.sub(provision)
+      : new Prisma.Decimal(0);
+
+    return this.createAndPost(tx, {
+      companyId,
+      entryDate: new Date(),
+      description: `ตัดหนี้สูญ สัญญา ${params.contractNumber}`,
+      referenceType: 'BAD_DEBT_WRITE_OFF',
+      referenceId: params.contractId,
+      createdById: params.createdById,
+      lines: [
+        {
+          accountCode: JournalAutoService.ACC.BAD_DEBT_EXPENSE,
+          description: 'ค่าใช้จ่ายหนี้สูญ',
+          debit: incrementalExpense.toNumber(),
+          credit: 0,
+        },
+        {
+          accountCode: JournalAutoService.ACC.ALLOWANCE_DOUBTFUL,
+          description: 'ใช้ค่าเผื่อหนี้สงสัยจะสูญ',
+          debit: provision.toNumber(),
+          credit: 0,
+        },
+        {
+          accountCode: JournalAutoService.ACC.HP_RECEIVABLE,
+          description: 'ตัดลูกหนี้เช่าซื้อ',
+          debit: 0,
+          credit: writeOff.toNumber(),
+        },
+      ],
     });
   }
 
@@ -400,11 +476,14 @@ export class JournalAutoService {
       select: { accountCode: true, debit: true, credit: true },
     });
 
-    const accountMap = new Map<string, { totalDebit: number; totalCredit: number }>();
+    const accountMap = new Map<string, { totalDebit: Prisma.Decimal; totalCredit: Prisma.Decimal }>();
     for (const line of lines) {
-      const acc = accountMap.get(line.accountCode) || { totalDebit: 0, totalCredit: 0 };
-      acc.totalDebit += Number(line.debit);
-      acc.totalCredit += Number(line.credit);
+      const acc = accountMap.get(line.accountCode) || {
+        totalDebit: new Prisma.Decimal(0),
+        totalCredit: new Prisma.Decimal(0),
+      };
+      acc.totalDebit = acc.totalDebit.add(new Prisma.Decimal(line.debit ?? 0));
+      acc.totalCredit = acc.totalCredit.add(new Prisma.Decimal(line.credit ?? 0));
       accountMap.set(line.accountCode, acc);
     }
 
@@ -426,9 +505,9 @@ export class JournalAutoService {
           code,
           nameTh: chart?.nameTh || '(ไม่พบในผังบัญชี)',
           accountGroup: chart?.accountGroup || 'UNKNOWN',
-          totalDebit: Math.round(sums.totalDebit * 100) / 100,
-          totalCredit: Math.round(sums.totalCredit * 100) / 100,
-          balance: Math.round((sums.totalDebit - sums.totalCredit) * 100) / 100,
+          totalDebit: sums.totalDebit.toDecimalPlaces(2).toNumber(),
+          totalCredit: sums.totalCredit.toDecimalPlaces(2).toNumber(),
+          balance: sums.totalDebit.sub(sums.totalCredit).toDecimalPlaces(2).toNumber(),
         };
       })
       .sort((a, b) => a.code.localeCompare(b.code));

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -112,15 +112,15 @@ export class OverdueService {
       }),
     ]);
 
-    const amountDue = Number(totalOverdueAmount._sum.amountDue || 0);
-    const amountPaid = Number(totalOverdueAmount._sum.amountPaid || 0);
-    const lateFees = Number(totalOverdueAmount._sum.lateFee || 0);
+    const amountDue = new Prisma.Decimal(totalOverdueAmount._sum.amountDue ?? 0);
+    const amountPaid = new Prisma.Decimal(totalOverdueAmount._sum.amountPaid ?? 0);
+    const lateFees = new Prisma.Decimal(totalOverdueAmount._sum.lateFee ?? 0);
 
     return {
       overdueCount,
       defaultCount,
-      totalOverdueAmount: amountDue - amountPaid,
-      totalLateFees: lateFees,
+      totalOverdueAmount: amountDue.sub(amountPaid).toNumber(),
+      totalLateFees: lateFees.toNumber(),
     };
   }
 
@@ -544,7 +544,7 @@ export class OverdueService {
         stage,
         label: stageLabels[stage],
         count: found?._count._all ?? 0,
-        totalAmount: Number(found?._sum?.financedAmount ?? 0),
+        totalAmount: new Prisma.Decimal(found?._sum?.financedAmount ?? 0).toNumber(),
       };
     });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -488,14 +488,18 @@ export class PaymentsService {
     const byMethod: Record<string, number> = {};
     payments.forEach((p) => {
       const method = p.paymentMethod || 'UNKNOWN';
-      byMethod[method] = roundBaht((byMethod[method] || 0) + Number(p.amountPaid));
+      byMethod[method] = roundBaht(
+        new Prisma.Decimal(byMethod[method] ?? 0)
+          .add(new Prisma.Decimal(p.amountPaid ?? 0))
+          .toNumber(),
+      );
     });
 
     return {
       date,
       totalPayments: total,
-      totalAmount: Math.round(Number(aggregation._sum.amountPaid || 0)),
-      totalLateFees: Math.round(Number(aggregation._sum.lateFee || 0)),
+      totalAmount: Math.round(new Prisma.Decimal(aggregation._sum.amountPaid ?? 0).toNumber()),
+      totalLateFees: Math.round(new Prisma.Decimal(aggregation._sum.lateFee ?? 0).toNumber()),
       byMethod,
       data: payments,
       total,

--- a/apps/api/src/modules/products/products-stock.service.ts
+++ b/apps/api/src/modules/products/products-stock.service.ts
@@ -495,7 +495,7 @@ export class ProductsStockService {
       const totalCount = branchRows.reduce((sum, r) => sum + r._count, 0);
       const inStockRow = branchRows.find((r) => r.status === 'IN_STOCK');
       const inStock = inStockRow?._count || 0;
-      const totalValue = Number(inStockRow?._sum?.costPrice || 0);
+      const totalValue = new Prisma.Decimal(inStockRow?._sum?.costPrice ?? 0).toNumber();
       return { branch, total: totalCount, inStock, totalValue };
     });
 

--- a/apps/api/src/modules/reports/report-generator.service.ts
+++ b/apps/api/src/modules/reports/report-generator.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ReportsService } from './reports.service';
 
@@ -55,7 +56,7 @@ export class ReportGeneratorService {
 
     const summary = {
       date: dateStr,
-      revenue: Math.round(Number(payments._sum.amountPaid || 0)),
+      revenue: new Prisma.Decimal(payments._sum.amountPaid ?? 0).toDecimalPlaces(0).toNumber(),
       paymentsCount: payments._count,
       overdueCount,
       newContracts,

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AccountingService } from '../accounting/accounting.service';
 import { calculateDaysOverdue, calculateDaysElapsed } from '../../utils/date.util';
@@ -65,8 +66,14 @@ export class ReportsService {
 
     const summarize = (items: typeof overduePayments) => ({
       count: items.length,
-      totalOutstanding: items.reduce((s, p) => s + Number(p.amountDue) - Number(p.amountPaid), 0),
-      totalLateFees: items.reduce((s, p) => s + Number(p.lateFee), 0),
+      totalOutstanding: items.reduce(
+        (s, p) => s.add(new Prisma.Decimal(p.amountDue ?? 0)).sub(new Prisma.Decimal(p.amountPaid ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber(),
+      totalLateFees: items.reduce(
+        (s, p) => s.add(new Prisma.Decimal(p.lateFee ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber(),
     });
 
     return {
@@ -127,16 +134,17 @@ export class ReportsService {
 
     // Sum the interest portion of each payment received in this period
     const interestIncome = interestIncomePayments.reduce((sum, p) => {
-      const monthlyInterest = Number(p.contract.interestTotal) / p.contract.totalMonths;
-      return sum + monthlyInterest;
-    }, 0);
+      const monthlyInterest = new Prisma.Decimal(p.contract.interestTotal ?? 0)
+        .div(p.contract.totalMonths);
+      return sum.add(monthlyInterest);
+    }, new Prisma.Decimal(0));
 
     return {
       period: { start: startDate, end: endDate },
       revenue: {
-        interestIncome: Math.round(interestIncome),
-        lateFeeIncome: Number(lateFeeIncome._sum.lateFee || 0),
-        totalPaymentsReceived: Number(totalPayments._sum.amountPaid || 0),
+        interestIncome: Math.round(interestIncome.toNumber()),
+        lateFeeIncome: new Prisma.Decimal(lateFeeIncome._sum.lateFee ?? 0).toNumber(),
+        totalPaymentsReceived: new Prisma.Decimal(totalPayments._sum.amountPaid ?? 0).toNumber(),
         paymentCount: totalPayments._count || 0,
       },
       contracts: { newContracts },
@@ -193,8 +201,12 @@ export class ReportsService {
 
     const data = customers.map((c) => {
       const totalOutstanding = c.payments.reduce(
-        (sum, p) => sum + Number(p.amountDue) - Number(p.amountPaid) + Number(p.lateFee), 0,
-      );
+        (sum, p) => sum
+          .add(new Prisma.Decimal(p.amountDue ?? 0))
+          .sub(new Prisma.Decimal(p.amountPaid ?? 0))
+          .add(new Prisma.Decimal(p.lateFee ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber();
       const oldestDue = c.payments.reduce(
         (oldest, p) => (new Date(p.dueDate) < oldest ? new Date(p.dueDate) : oldest),
         new Date(),
@@ -243,7 +255,8 @@ export class ReportsService {
         totalContracts: 0, totalSales: 0, overdueCount: 0,
       };
       existing.totalContracts++;
-      existing.totalSales += Number(c.sellingPrice);
+      existing.totalSales = new Prisma.Decimal(existing.totalSales)
+        .add(new Prisma.Decimal(c.sellingPrice ?? 0)).toNumber();
       if (['OVERDUE', 'DEFAULT'].includes(c.status)) existing.overdueCount++;
       staffMap.set(key, existing);
     }
@@ -308,7 +321,12 @@ export class ReportsService {
         const result = new Map<string, number>();
         for (const g of groups) {
           const bid = contractBranchMap.get(g.contractId);
-          if (bid) result.set(bid, (result.get(bid) || 0) + Number(g._sum.amountPaid || 0));
+          if (bid) result.set(
+            bid,
+            new Prisma.Decimal(result.get(bid) ?? 0)
+              .add(new Prisma.Decimal(g._sum.amountPaid ?? 0))
+              .toNumber(),
+          );
         }
         return result;
       }),
@@ -383,18 +401,20 @@ export class ReportsService {
       const method = p.paymentMethod || 'CASH';
       if (!byMethod[method]) byMethod[method] = { count: 0, total: 0 };
       byMethod[method].count++;
-      byMethod[method].total += Number(p.amountPaid);
+      byMethod[method].total = new Prisma.Decimal(byMethod[method].total)
+        .add(new Prisma.Decimal(p.amountPaid ?? 0)).toNumber();
 
       const branch = p.contract.branch.name;
       if (!byBranch[branch]) byBranch[branch] = { count: 0, total: 0 };
       byBranch[branch].count++;
-      byBranch[branch].total += Number(p.amountPaid);
+      byBranch[branch].total = new Prisma.Decimal(byBranch[branch].total)
+        .add(new Prisma.Decimal(p.amountPaid ?? 0)).toNumber();
     }
 
     return {
       date,
       totalPayments: total,
-      totalAmount: Math.round(Number(aggregation._sum.amountPaid || 0)),
+      totalAmount: Math.round(new Prisma.Decimal(aggregation._sum.amountPaid ?? 0).toNumber()),
       byMethod,
       byBranch,
       data: payments.map((p) => ({
@@ -403,7 +423,7 @@ export class ReportsService {
         customer: p.contract.customer.name,
         branch: p.contract.branch.name,
         installmentNo: p.installmentNo,
-        amountPaid: Number(p.amountPaid),
+        amountPaid: new Prisma.Decimal(p.amountPaid ?? 0).toNumber(),
         method: p.paymentMethod,
         recordedBy: p.recordedBy?.name || '-',
         paidAt: p.paidDate,
@@ -446,7 +466,7 @@ export class ReportsService {
         count: p._count,
       })),
       totalInStock: stockValue._count || 0,
-      totalStockValue: Number(stockValue._sum.costPrice || 0),
+      totalStockValue: new Prisma.Decimal(stockValue._sum.costPrice ?? 0).toNumber(),
     };
   }
 
@@ -489,16 +509,22 @@ export class ReportsService {
       imei: c.product.imeiSerial,
       branch: c.branch.name,
       salesperson: c.salesperson.name,
-      sellingPrice: Number(c.sellingPrice),
-      downPayment: Number(c.downPayment),
-      interestRate: Number(c.interestRate),
+      sellingPrice: new Prisma.Decimal(c.sellingPrice ?? 0).toNumber(),
+      downPayment: new Prisma.Decimal(c.downPayment ?? 0).toNumber(),
+      interestRate: new Prisma.Decimal(c.interestRate ?? 0).toNumber(),
       totalMonths: c.totalMonths,
-      monthlyPayment: Number(c.monthlyPayment),
-      financedAmount: Number(c.financedAmount),
-      interestTotal: Number(c.interestTotal),
+      monthlyPayment: new Prisma.Decimal(c.monthlyPayment ?? 0).toNumber(),
+      financedAmount: new Prisma.Decimal(c.financedAmount ?? 0).toNumber(),
+      interestTotal: new Prisma.Decimal(c.interestTotal ?? 0).toNumber(),
       paidInstallments: c.payments.filter((p) => p.status === 'PAID').length,
-      totalPaid: c.payments.reduce((s, p) => s + Number(p.amountPaid), 0),
-      totalLateFees: c.payments.reduce((s, p) => s + Number(p.lateFee), 0),
+      totalPaid: c.payments.reduce(
+        (s, p) => s.add(new Prisma.Decimal(p.amountPaid ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber(),
+      totalLateFees: c.payments.reduce(
+        (s, p) => s.add(new Prisma.Decimal(p.lateFee ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber(),
       createdAt: c.createdAt,
     }));
   }
@@ -540,7 +566,7 @@ export class ReportsService {
       where: lateFeesWhere,
       _sum: { lateFee: true },
     });
-    const totalLateFees = Number(lateFeeAgg._sum.lateFee || 0);
+    const totalLateFees = new Prisma.Decimal(lateFeeAgg._sum.lateFee ?? 0).toNumber();
 
     // Summaries
     const shop = {
@@ -576,14 +602,14 @@ export class ReportsService {
     }> = [];
 
     for (const t of transactions) {
-      const shopProfit = Number(t.shopProfit);
-      const financeProfit = Number(t.financeProfit);
-      const commission = Number(t.commission);
-      const interestTotal = Number(t.interestTotal);
-      const costPrice = Number(t.costPrice);
-      const principal = Number(t.principal);
-      const downPayment = Number(t.downPayment);
-      const sellingPrice = Number(t.sellingPrice);
+      const shopProfit = new Prisma.Decimal(t.shopProfit ?? 0).toNumber();
+      const financeProfit = new Prisma.Decimal(t.financeProfit ?? 0).toNumber();
+      const commission = new Prisma.Decimal(t.commission ?? 0).toNumber();
+      const interestTotal = new Prisma.Decimal(t.interestTotal ?? 0).toNumber();
+      const costPrice = new Prisma.Decimal(t.costPrice ?? 0).toNumber();
+      const principal = new Prisma.Decimal(t.principal ?? 0).toNumber();
+      const downPayment = new Prisma.Decimal(t.downPayment ?? 0).toNumber();
+      const sellingPrice = new Prisma.Decimal(t.sellingPrice ?? 0).toNumber();
 
       shop.revenue += downPayment + principal + commission;
       shop.costOfGoods += costPrice;
@@ -631,7 +657,10 @@ export class ReportsService {
       finance,
       combined: {
         totalProfit: shop.profit + finance.profit,
-        totalVat: transactions.reduce((s, t) => s + Number(t.vatAmount), 0),
+        totalVat: transactions.reduce(
+          (s, t) => s.add(new Prisma.Decimal(t.vatAmount ?? 0)),
+          new Prisma.Decimal(0),
+        ).toNumber(),
       },
       details,
     };

--- a/apps/api/src/modules/repossessions/repossessions.service.ts
+++ b/apps/api/src/modules/repossessions/repossessions.service.ts
@@ -470,10 +470,10 @@ export class RepossessionsService {
     ]);
 
     const data = repos.map((r) => {
-      const appraisal = Number(r.appraisalPrice);
-      const repair = Number(r.repairCost);
-      const resell = Number(r.resellPrice || 0);
-      const profit = resell - appraisal - repair;
+      const appraisal = new Prisma.Decimal(r.appraisalPrice ?? 0);
+      const repair = new Prisma.Decimal(r.repairCost ?? 0);
+      const resell = new Prisma.Decimal(r.resellPrice ?? 0);
+      const profit = resell.sub(appraisal).sub(repair);
 
       return {
         id: r.id,
@@ -481,25 +481,27 @@ export class RepossessionsService {
         customer: r.contract.customer.name,
         product: `${r.product.brand} ${r.product.model}`,
         conditionGrade: r.conditionGrade,
-        appraisalPrice: appraisal,
-        repairCost: repair,
-        resellPrice: resell,
-        profit,
-        marginPct: resell > 0 ? ((profit / resell) * 100).toFixed(1) : '0',
+        appraisalPrice: appraisal.toNumber(),
+        repairCost: repair.toNumber(),
+        resellPrice: resell.toNumber(),
+        profit: profit.toNumber(),
+        marginPct: resell.greaterThan(0)
+          ? profit.div(resell).mul(100).toDecimalPlaces(1).toString()
+          : '0',
       };
     });
 
-    const totalAppraisal = Number(aggregation._sum.appraisalPrice || 0);
-    const totalRepairCost = Number(aggregation._sum.repairCost || 0);
-    const totalResellPrice = Number(aggregation._sum.resellPrice || 0);
+    const totalAppraisal = new Prisma.Decimal(aggregation._sum.appraisalPrice ?? 0);
+    const totalRepairCost = new Prisma.Decimal(aggregation._sum.repairCost ?? 0);
+    const totalResellPrice = new Prisma.Decimal(aggregation._sum.resellPrice ?? 0);
 
     return {
       summary: {
         count: total,
-        totalAppraisal,
-        totalRepairCost,
-        totalResellPrice,
-        totalProfit: totalResellPrice - totalAppraisal - totalRepairCost,
+        totalAppraisal: totalAppraisal.toNumber(),
+        totalRepairCost: totalRepairCost.toNumber(),
+        totalResellPrice: totalResellPrice.toNumber(),
+        totalProfit: totalResellPrice.sub(totalAppraisal).sub(totalRepairCost).toNumber(),
       },
       data,
       total,

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
-import { PaymentMethod, PlanType } from '@prisma/client';
+import { PaymentMethod, PlanType, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateSaleDto } from './dto/sale.dto';
 import { calculateInstallment, generatePaymentSchedule } from '../../utils/installment.util';
@@ -96,20 +96,23 @@ export class SalesService {
     if (userRole === 'OWNER') {
       // Calculate profit from already-fetched data to avoid duplicate query
       totalProfit = data.reduce(
-        (sum, s) => sum + Number(s.netAmount) - Number(s.product?.costPrice || 0), 0,
-      );
+        (sum, s) => sum
+          .add(new Prisma.Decimal(s.netAmount ?? 0))
+          .sub(new Prisma.Decimal(s.product?.costPrice ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber();
     }
 
     const summary = {
-      totalAmount: Number(agg._sum.netAmount || 0),
-      totalDiscount: Number(agg._sum.discount || 0),
+      totalAmount: new Prisma.Decimal(agg._sum.netAmount ?? 0).toNumber(),
+      totalDiscount: new Prisma.Decimal(agg._sum.discount ?? 0).toNumber(),
       totalProfit,
       cashCount: getGroup('CASH')?._count || 0,
-      cashAmount: Number(getGroup('CASH')?._sum.netAmount || 0),
+      cashAmount: new Prisma.Decimal(getGroup('CASH')?._sum.netAmount ?? 0).toNumber(),
       installmentCount: getGroup('INSTALLMENT')?._count || 0,
-      installmentAmount: Number(getGroup('INSTALLMENT')?._sum.netAmount || 0),
+      installmentAmount: new Prisma.Decimal(getGroup('INSTALLMENT')?._sum.netAmount ?? 0).toNumber(),
       financeCount: getGroup('EXTERNAL_FINANCE')?._count || 0,
-      financeAmount: Number(getGroup('EXTERNAL_FINANCE')?._sum.netAmount || 0),
+      financeAmount: new Prisma.Decimal(getGroup('EXTERNAL_FINANCE')?._sum.netAmount ?? 0).toNumber(),
     };
 
     // Strip costPrice from response for non-OWNER roles
@@ -553,7 +556,10 @@ export class SalesService {
       cashSales: sales.filter(s => s.saleType === 'CASH').length,
       installmentSales: sales.filter(s => s.saleType === 'INSTALLMENT').length,
       externalFinanceSales: sales.filter(s => s.saleType === 'EXTERNAL_FINANCE').length,
-      totalRevenue: sales.reduce((sum, s) => sum + Number(s.netAmount), 0),
+      totalRevenue: sales.reduce(
+        (sum, s) => sum.add(new Prisma.Decimal(s.netAmount ?? 0)),
+        new Prisma.Decimal(0),
+      ).toNumber(),
       sales,
     };
 


### PR DESCRIPTION
## Summary

Ultraplan v4.2 — Decimal precision cleanup across 12 services + bad debt journal entry + accounting policy documentation.

### Phase 2A: Decimal Precision Cleanup (~53 fixes)
- Replace ALL `Number()` on Prisma Decimal `_sum` aggregates with `Prisma.Decimal` arithmetic
- **0 `Number(.*_sum` patterns remaining** in entire codebase
- Services fixed: accounting, reports, sales, dashboard, overdue, repossessions, payments, contracts, journal-auto, admin-analytics, products-stock, report-generator
- Pattern: `new Prisma.Decimal(x ?? 0)` with `.add()/.sub()/.mul()` chain, `.toNumber()` only at JSON boundary

### Phase 4.3-4.4: Bad Debt Write-Off Journal
- New `createBadDebtWriteOffJournal()` method in JournalAutoService
- Handles both provisioned and non-provisioned write-offs:
  - `Dr. Bad Debt Expense [incremental] + Dr. Allowance for Doubtful [provision] / Cr. HP Receivable [total]`
- Wired into `bad-debt.service.ts` `writeOffBadDebt()` inside `$transaction` — Balance Sheet now correctly removes HP Receivable after write-off
- New account codes: `11-2901` (Allowance for Doubtful), `53-1101` (Bad Debt Expense)

### Phase 4.7: Accounting Policy Documentation
- Created `.claude/rules/accounting.md` — TFRS for NPAEs, chart of accounts, journal entry templates, VAT/WHT policy, inter-company rationale

### Verification
- API: **403 tests passed** (22 suites)
- TypeScript: **0 errors**
- Grep: **0 `Number(.*_sum` remaining**

## Test plan
- [ ] Verify `npx tsc --noEmit` — 0 errors
- [ ] Verify `npx jest` — all 403 tests pass
- [ ] Verify Balance Sheet/P&L/Cash Flow reports output unchanged (Decimal→Number at boundary)
- [ ] Verify bad debt write-off creates journal entry (manual test or future spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)