### PR TITLE
feat(api+web): multi-entity phase 2 — multi-branch P&L + Finance Portfolio

### DIFF
--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -470,11 +470,16 @@ export class AccountingService {
 
   // ─── P&L Calculation ─────────────────────────────────────────────────────────
 
-  async getProfitLossReport(startDate: string, endDate: string, branchId?: string) {
+  async getProfitLossReport(startDate: string, endDate: string, branchId?: string, branchIds?: string[]) {
     const start = new Date(startDate);
     const end = new Date(endDate);
     end.setHours(23, 59, 59, 999);
-    const branchFilter = branchId ? { branchId } : {};
+    const branchFilter =
+      branchIds !== undefined
+        ? { branchId: { in: branchIds } }
+        : branchId
+          ? { branchId }
+          : {};
     const dateRange = { gte: start, lte: end };
 
     const [
@@ -734,11 +739,16 @@ export class AccountingService {
     };
   }
 
-  async getMonthlyPLSummary(year: number, branchId?: string) {
+  async getMonthlyPLSummary(year: number, branchId?: string, branchIds?: string[]) {
     const thaiMonths = ['ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.', 'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.'];
     const yearStart = new Date(year, 0, 1);
     const yearEnd = new Date(year, 11, 31, 23, 59, 59, 999);
-    const branchFilter = branchId ? { branchId } : {};
+    const branchFilter =
+      branchIds !== undefined
+        ? { branchId: { in: branchIds } }
+        : branchId
+          ? { branchId }
+          : {};
     const dateRange = { gte: yearStart, lte: yearEnd };
 
     const getMonth = (d: Date | string | null) => (d ? new Date(d).getMonth() : -1);
@@ -824,7 +834,7 @@ export class AccountingService {
 
   // ─── W-012: Comparative P&L (MoM / YoY) ──────────────────────────────────────
 
-  async getComparativePL(year: number, month: number, branchId?: string) {
+  async getComparativePL(year: number, month: number, branchId?: string, branchIds?: string[]) {
     // Helper: get last day of month as YYYY-MM-DD string (local time, no UTC shift)
     const lastDayOf = (y: number, m: number) => {
       const d = new Date(y, m, 0); // day 0 of next month = last day of m
@@ -845,9 +855,9 @@ export class AccountingService {
     const endYoY = lastDayOf(year - 1, month);
 
     const [current, prevPeriod, lastYear] = await Promise.all([
-      this.getProfitLossReport(startCurrent, endCurrent, branchId),
-      this.getProfitLossReport(startPrev, endPrev, branchId),
-      this.getProfitLossReport(startYoY, endYoY, branchId),
+      this.getProfitLossReport(startCurrent, endCurrent, branchId, branchIds),
+      this.getProfitLossReport(startPrev, endPrev, branchId, branchIds),
+      this.getProfitLossReport(startYoY, endYoY, branchId, branchIds),
     ]);
 
     const pctChange = (curr: number, prev: number) =>
@@ -900,10 +910,15 @@ export class AccountingService {
 
   // ─── Balance Sheet (derived from existing data, no general ledger) ────────────
 
-  async getBalanceSheet(asOfDate: string, branchId?: string) {
+  async getBalanceSheet(asOfDate: string, branchId?: string, branchIds?: string[]) {
     const endDate = new Date(asOfDate);
     endDate.setHours(23, 59, 59, 999);
-    const branchFilter = branchId ? { branchId } : {};
+    const branchFilter =
+      branchIds !== undefined
+        ? { branchId: { in: branchIds } }
+        : branchId
+          ? { branchId }
+          : {};
 
     // ── ASSETS ──
 
@@ -1101,12 +1116,17 @@ export class AccountingService {
 
   // ─── Cash Flow Statement (derived from existing data, no general ledger) ──────
 
-  async getCashFlowStatement(startDate: string, endDate: string, branchId?: string) {
+  async getCashFlowStatement(startDate: string, endDate: string, branchId?: string, branchIds?: string[]) {
     const start = new Date(startDate);
     const end = new Date(endDate);
     end.setHours(23, 59, 59, 999);
     const dateRange = { gte: start, lte: end };
-    const branchFilter = branchId ? { branchId } : {};
+    const branchFilter =
+      branchIds !== undefined
+        ? { branchId: { in: branchIds } }
+        : branchId
+          ? { branchId }
+          : {};
 
     // ── OPERATING ACTIVITIES ──
 

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -42,10 +42,16 @@ export class ReportsController {
     @Query('branchId') branchId?: string,
     @Query('companyId') companyId?: string,
   ) {
-    const effectiveBranch = user.role === 'BRANCH_MANAGER'
-      ? user.branchId || undefined
-      : await this.reportsService.resolveCompanyBranch(companyId, branchId);
-    return this.reportsService.getMonthlyPLSummary(parseInt(year) || new Date().getFullYear(), effectiveBranch);
+    if (user.role === 'BRANCH_MANAGER') {
+      const effectiveBranch = user.branchId || undefined;
+      return this.reportsService.getMonthlyPLSummary(parseInt(year) || new Date().getFullYear(), effectiveBranch);
+    }
+    const resolvedBranchIds = await this.reportsService.resolveCompanyBranches(companyId, branchId);
+    return this.reportsService.getMonthlyPLSummary(
+      parseInt(year) || new Date().getFullYear(),
+      undefined,
+      resolvedBranchIds,
+    );
   }
 
   @Get('profit-loss')
@@ -56,10 +62,12 @@ export class ReportsController {
     @Query('branchId') branchId?: string,
     @Query('companyId') companyId?: string,
   ) {
-    const effectiveBranch = user.role === 'BRANCH_MANAGER'
-      ? user.branchId || undefined
-      : await this.reportsService.resolveCompanyBranch(companyId, branchId);
-    return this.reportsService.getProfitLossReport(startDate, endDate, effectiveBranch);
+    if (user.role === 'BRANCH_MANAGER') {
+      const effectiveBranch = user.branchId || undefined;
+      return this.reportsService.getProfitLossReport(startDate, endDate, effectiveBranch);
+    }
+    const resolvedBranchIds = await this.reportsService.resolveCompanyBranches(companyId, branchId);
+    return this.reportsService.getProfitLossReport(startDate, endDate, undefined, resolvedBranchIds);
   }
 
   @Get('comparative-pl')
@@ -85,10 +93,11 @@ export class ReportsController {
     @Query('branchId') branchId?: string,
     @Query('companyId') companyId?: string,
   ) {
-    const effectiveBranch = await this.reportsService.resolveCompanyBranch(companyId, branchId);
+    const resolvedBranchIds = await this.reportsService.resolveCompanyBranches(companyId, branchId);
     return this.reportsService.getBalanceSheet(
       asOfDate || new Date().toISOString().split('T')[0],
-      effectiveBranch,
+      undefined,
+      resolvedBranchIds,
     );
   }
 
@@ -188,7 +197,12 @@ export class ReportsController {
     @Query('entity') entity?: string,
     @Query('companyId') companyId?: string,
   ) {
-    const effectiveBranch = await this.reportsService.resolveCompanyBranch(companyId, branchId);
+    // entity-profit uses a single branchId filter on InterCompanyTransaction — resolve to first branch
+    // when company is given without a specific branch (multi-branch aggregation is done within the method)
+    const resolvedBranchIds = await this.reportsService.resolveCompanyBranches(companyId, branchId);
+    const effectiveBranch = resolvedBranchIds && resolvedBranchIds.length === 1
+      ? resolvedBranchIds[0]
+      : undefined;
     return this.reportsService.getEntityProfitReport(startDate, endDate, effectiveBranch, entity);
   }
 
@@ -205,6 +219,22 @@ export class ReportsController {
       parseInt(year) || new Date().getFullYear(),
       parseInt(quarter) || 1,
       effectiveBranch,
+    );
+  }
+
+  @Get('finance-portfolio')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getFinancePortfolio(
+    @Query('status') status?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const parsedPage = page ? parseInt(page, 10) : undefined;
+    const parsedLimit = limit ? Math.min(parseInt(limit, 10), 100) : undefined;
+    return this.reportsService.getFinancePortfolio(
+      status,
+      parsedPage && !isNaN(parsedPage) ? parsedPage : 1,
+      parsedLimit && !isNaN(parsedLimit) ? parsedLimit : 50,
     );
   }
 

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma, ContractStatus } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AccountingService } from '../accounting/accounting.service';
 import { calculateDaysOverdue, calculateDaysElapsed } from '../../utils/date.util';
@@ -12,22 +12,22 @@ export class ReportsService {
   ) {}
 
   /**
-   * Resolve companyId + branchId → effective branchId for report filtering.
-   * When companyId is set without branchId, picks the first branch of that company
-   * (FINANCE has 0 branches → returns '__none__' to ensure empty result, not all-data leak).
+   * Resolve companyId + branchId → effective branch ID list for report filtering.
+   * Returns:
+   * - [branchId]   — specific branch requested
+   * - string[]     — all branches under the given company (SHOP multi-branch)
+   * - []           — company exists but has no branches (FINANCE) → callers should return empty data
+   * - undefined    — no filter at all (all branches across all companies)
    */
-  async resolveCompanyBranch(companyId?: string, branchId?: string): Promise<string | undefined> {
-    if (!companyId) return branchId;
-    const branchIds = await this.accounting.getBranchIdsForCompany(companyId);
-    if (branchId) {
-      return branchIds.includes(branchId) ? branchId : '__none__';
-    }
-    // Company with no branches (e.g. FINANCE) → return sentinel to produce empty result
-    if (branchIds.length === 0) return '__none__';
-    // Company with 1 branch → return that branch
-    if (branchIds.length === 1) return branchIds[0];
-    // Company with multiple branches → return first (TODO: support multi-branch filter in accounting)
-    return branchIds[0];
+  async resolveCompanyBranches(companyId?: string, branchId?: string): Promise<string[] | undefined> {
+    if (branchId) return [branchId]; // specific branch requested
+    if (!companyId) return undefined; // no filter = all branches
+    const branches = await this.prisma.branch.findMany({
+      where: { companyId, deletedAt: null },
+      select: { id: true },
+    });
+    // FINANCE has no branches → empty array signals "no data for this company"
+    return branches.map((b) => b.id);
   }
 
   /**
@@ -152,25 +152,25 @@ export class ReportsService {
   }
 
   // P&L calculation delegated to AccountingService
-  getProfitLossReport(startDate: string, endDate: string, branchId?: string) {
-    return this.accounting.getProfitLossReport(startDate, endDate, branchId);
+  getProfitLossReport(startDate: string, endDate: string, branchId?: string, branchIds?: string[]) {
+    return this.accounting.getProfitLossReport(startDate, endDate, branchId, branchIds);
   }
 
-  getMonthlyPLSummary(year: number, branchId?: string) {
-    return this.accounting.getMonthlyPLSummary(year, branchId);
+  getMonthlyPLSummary(year: number, branchId?: string, branchIds?: string[]) {
+    return this.accounting.getMonthlyPLSummary(year, branchId, branchIds);
   }
 
-  getComparativePL(year: number, month: number, branchId?: string) {
-    return this.accounting.getComparativePL(year, month, branchId);
+  getComparativePL(year: number, month: number, branchId?: string, branchIds?: string[]) {
+    return this.accounting.getComparativePL(year, month, branchId, branchIds);
   }
 
   // Balance Sheet & Cash Flow delegated to AccountingService
-  getBalanceSheet(asOfDate: string, branchId?: string) {
-    return this.accounting.getBalanceSheet(asOfDate, branchId);
+  getBalanceSheet(asOfDate: string, branchId?: string, branchIds?: string[]) {
+    return this.accounting.getBalanceSheet(asOfDate, branchId, branchIds);
   }
 
-  getCashFlowStatement(startDate: string, endDate: string, branchId?: string) {
-    return this.accounting.getCashFlowStatement(startDate, endDate, branchId);
+  getCashFlowStatement(startDate: string, endDate: string, branchId?: string, branchIds?: string[]) {
+    return this.accounting.getCashFlowStatement(startDate, endDate, branchId, branchIds);
   }
 
   /**
@@ -667,10 +667,207 @@ export class ReportsService {
   }
 
   /**
+   * FINANCE Portfolio: all contracts owned by BESTCHOICE FINANCE
+   * Returns per-contract receivable calculations + portfolio summary + aging.
+   */
+  async getFinancePortfolio(status?: string, page = 1, limit = 50) {
+    const safeLimit = Math.min(limit, 100);
+
+    const financeCompany = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+    });
+    if (!financeCompany) {
+      return {
+        data: [],
+        summary: { totalContracts: 0, totalReceivable: 0, totalCollected: 0, totalOutstanding: 0, collectionRate: 0 },
+        aging: {
+          current: { count: 0, amount: 0 },
+          days1to30: { count: 0, amount: 0 },
+          days31to60: { count: 0, amount: 0 },
+          days61to90: { count: 0, amount: 0 },
+          over90: { count: 0, amount: 0 },
+        },
+        total: 0,
+        page,
+        limit: safeLimit,
+      };
+    }
+
+    const defaultStatuses = [
+      ContractStatus.ACTIVE,
+      ContractStatus.OVERDUE,
+      ContractStatus.DEFAULT,
+      ContractStatus.COMPLETED,
+      ContractStatus.EARLY_PAYOFF,
+      ContractStatus.EXCHANGED,
+    ] as const;
+
+    const statusFilter =
+      status && status !== 'ALL' && Object.values(ContractStatus).includes(status as ContractStatus)
+        ? [status as ContractStatus]
+        : [...defaultStatuses];
+
+    const where = {
+      deletedAt: null,
+      status: { in: statusFilter },
+      product: { ownedByCompanyId: financeCompany.id, deletedAt: null },
+    };
+
+    const [contracts, total] = await Promise.all([
+      this.prisma.contract.findMany({
+        where,
+        include: {
+          customer: { select: { id: true, name: true, phone: true } },
+          product: { select: { brand: true, model: true, imeiSerial: true } },
+          branch: { select: { name: true } },
+          payments: {
+            where: { deletedAt: null },
+            select: {
+              id: true,
+              installmentNo: true,
+              amountDue: true,
+              amountPaid: true,
+              lateFee: true,
+              dueDate: true,
+              status: true,
+            },
+            orderBy: { installmentNo: 'asc' },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * safeLimit,
+        take: safeLimit,
+      }),
+      this.prisma.contract.count({ where }),
+    ]);
+
+    const now = new Date();
+
+    const data = contracts.map((c) => {
+      const totalReceivable = c.payments.reduce(
+        (s, p) => s.add(new Prisma.Decimal(p.amountDue ?? 0)),
+        new Prisma.Decimal(0),
+      );
+      const totalPaid = c.payments.reduce(
+        (s, p) => s.add(new Prisma.Decimal(p.amountPaid ?? 0)),
+        new Prisma.Decimal(0),
+      );
+      const outstanding = totalReceivable.sub(totalPaid);
+      const paidInstallments = c.payments.filter((p) => p.status === 'PAID').length;
+      const remainingInstallments = c.totalMonths - paidInstallments;
+
+      const pendingPayments = c.payments
+        .filter((p) => p.status === 'PENDING' || p.status === 'OVERDUE' || p.status === 'PARTIALLY_PAID')
+        .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime());
+      const nextDueDate = pendingPayments.length > 0 ? pendingPayments[0].dueDate : null;
+
+      return {
+        id: c.id,
+        contractNumber: c.contractNumber,
+        status: c.status,
+        customer: c.customer,
+        product: c.product,
+        branch: c.branch.name,
+        sellingPrice: new Prisma.Decimal(c.sellingPrice ?? 0).toNumber(),
+        financedAmount: new Prisma.Decimal(c.financedAmount ?? 0).toNumber(),
+        monthlyPayment: new Prisma.Decimal(c.monthlyPayment ?? 0).toNumber(),
+        totalMonths: c.totalMonths,
+        paidInstallments,
+        remainingInstallments,
+        totalReceivable: totalReceivable.toNumber(),
+        totalPaid: totalPaid.toNumber(),
+        outstanding: outstanding.toNumber(),
+        nextDueDate,
+        createdAt: c.createdAt,
+      };
+    });
+
+    // Summary and aging computed over ALL matching contracts (not just current page)
+    const allContracts = await this.prisma.contract.findMany({
+      where,
+      include: {
+        payments: {
+          where: { deletedAt: null },
+          select: { amountDue: true, amountPaid: true, dueDate: true, status: true },
+        },
+      },
+    });
+
+    let sumReceivable = new Prisma.Decimal(0);
+    let sumCollected = new Prisma.Decimal(0);
+
+    const aging = {
+      current: { count: 0, amount: new Prisma.Decimal(0) },
+      days1to30: { count: 0, amount: new Prisma.Decimal(0) },
+      days31to60: { count: 0, amount: new Prisma.Decimal(0) },
+      days61to90: { count: 0, amount: new Prisma.Decimal(0) },
+      over90: { count: 0, amount: new Prisma.Decimal(0) },
+    };
+
+    for (const c of allContracts) {
+      for (const p of c.payments) {
+        const due = new Prisma.Decimal(p.amountDue ?? 0);
+        const paid = new Prisma.Decimal(p.amountPaid ?? 0);
+        sumReceivable = sumReceivable.add(due);
+        sumCollected = sumCollected.add(paid);
+        const pOutstanding = due.sub(paid);
+
+        if (p.status === 'PAID') continue;
+
+        const dueDate = new Date(p.dueDate);
+        const diffDays = Math.floor((now.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24));
+
+        if (diffDays <= 0) {
+          aging.current.count++;
+          aging.current.amount = aging.current.amount.add(pOutstanding);
+        } else if (diffDays <= 30) {
+          aging.days1to30.count++;
+          aging.days1to30.amount = aging.days1to30.amount.add(pOutstanding);
+        } else if (diffDays <= 60) {
+          aging.days31to60.count++;
+          aging.days31to60.amount = aging.days31to60.amount.add(pOutstanding);
+        } else if (diffDays <= 90) {
+          aging.days61to90.count++;
+          aging.days61to90.amount = aging.days61to90.amount.add(pOutstanding);
+        } else {
+          aging.over90.count++;
+          aging.over90.amount = aging.over90.amount.add(pOutstanding);
+        }
+      }
+    }
+
+    const sumReceivableNum = sumReceivable.toNumber();
+    const sumCollectedNum = sumCollected.toNumber();
+
+    return {
+      data,
+      summary: {
+        totalContracts: allContracts.length,
+        totalReceivable: sumReceivableNum,
+        totalCollected: sumCollectedNum,
+        totalOutstanding: new Prisma.Decimal(sumReceivableNum).sub(new Prisma.Decimal(sumCollectedNum)).toNumber(),
+        collectionRate: sumReceivableNum > 0
+          ? Math.round((sumCollectedNum / sumReceivableNum) * 10000) / 100
+          : 0,
+      },
+      aging: {
+        current: { count: aging.current.count, amount: aging.current.amount.toNumber() },
+        days1to30: { count: aging.days1to30.count, amount: aging.days1to30.amount.toNumber() },
+        days31to60: { count: aging.days31to60.count, amount: aging.days31to60.amount.toNumber() },
+        days61to90: { count: aging.days61to90.count, amount: aging.days61to90.amount.toNumber() },
+        over90: { count: aging.over90.count, amount: aging.over90.amount.toNumber() },
+      },
+      total,
+      page,
+      limit: safeLimit,
+    };
+  }
+
+  /**
    * R-015: Quarterly P&L report aggregation
    * Calculates start/end dates for the given quarter and delegates to AccountingService.
    */
-  async getQuarterlyReport(year: number, quarter: number, branchId?: string) {
+  async getQuarterlyReport(year: number, quarter: number, branchId?: string, branchIds?: string[]) {
     if (quarter < 1 || quarter > 4) {
       throw new BadRequestException('ไตรมาสต้องอยู่ระหว่าง 1-4');
     }
@@ -678,6 +875,6 @@ export class ReportsService {
     const endMonth = startMonth + 2;
     const startDate = `${year}-${String(startMonth).padStart(2, '0')}-01`;
     const endDate = new Date(year, endMonth, 0).toISOString().split('T')[0];
-    return this.accounting.getProfitLossReport(startDate, endDate, branchId);
+    return this.accounting.getProfitLossReport(startDate, endDate, branchId, branchIds);
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,6 +69,7 @@ const LiffFinanceVerify = lazy(() => import('@/pages/liff/LiffFinanceVerify'));
 const LineOaSettingsPage = lazy(() => import('@/pages/LineOaSettingsPage'));
 const SmsSettingsPage = lazy(() => import('@/pages/SmsSettingsPage'));
 const FinanceReceivablePage = lazy(() => import('@/pages/FinanceReceivablePage'));
+const FinancePortfolioPage = lazy(() => import('@/pages/FinancePortfolioPage'));
 const ExpensesPage = lazy(() => import('@/pages/ExpensesPage'));
 const ProfitLossPage = lazy(() => import('@/pages/ProfitLossPage'));
 const CompanySettingsPage = lazy(() => import('@/pages/CompanySettingsPage'));
@@ -301,6 +302,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <FinanceReceivablePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance-portfolio"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <FinancePortfolioPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -121,6 +121,7 @@ const navSections: NavSection[] = [
       { label: 'สัญญาผ่อนชำระ', path: '/contracts', icon: FileCheck },
       { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
       { label: 'เงินรับจาก FINANCE', path: '/finance-receivable', icon: Banknote, roles: ['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT'] },
+      { label: 'พอร์ตสัญญา FINANCE', path: '/finance-portfolio', icon: CircleDollarSign, roles: ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'] },
     ],
   },
   {

--- a/apps/web/src/pages/FinancePortfolioPage.tsx
+++ b/apps/web/src/pages/FinancePortfolioPage.tsx
@@ -1,0 +1,438 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import DataTable from '@/components/ui/DataTable';
+import { Card, CardContent } from '@/components/ui/card';
+import { formatDateShort } from '@/utils/formatters';
+import {
+  FileText,
+  Banknote,
+  CheckCircle2,
+  Clock,
+  TrendingUp,
+  AlertTriangle,
+  ShieldAlert,
+} from 'lucide-react';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface PortfolioContract {
+  id: string;
+  contractNumber: string;
+  status: string;
+  customer: { id: string; name: string; phone: string };
+  product: { brand: string | null; model: string | null; imeiSerial: string | null };
+  branch: string;
+  sellingPrice: number;
+  financedAmount: number;
+  monthlyPayment: number;
+  totalMonths: number;
+  paidInstallments: number;
+  remainingInstallments: number;
+  totalReceivable: number;
+  totalPaid: number;
+  outstanding: number;
+  nextDueDate: string | null;
+  createdAt: string;
+}
+
+interface AgingBucket {
+  count: number;
+  amount: number;
+}
+
+interface PortfolioResponse {
+  data: PortfolioContract[];
+  summary: {
+    totalContracts: number;
+    totalReceivable: number;
+    totalCollected: number;
+    totalOutstanding: number;
+    collectionRate: number;
+  };
+  aging: {
+    current: AgingBucket;
+    days1to30: AgingBucket;
+    days31to60: AgingBucket;
+    days61to90: AgingBucket;
+    over90: AgingBucket;
+  };
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmt(n: number | null | undefined): string {
+  if (n == null) return '-';
+  return n.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  ACTIVE: 'ปกติ',
+  OVERDUE: 'ค้างชำระ',
+  DEFAULT: 'ผิดนัด',
+  COMPLETED: 'ชำระครบ',
+  EARLY_PAYOFF: 'ปิดก่อนกำหนด',
+  EXCHANGED: 'เปลี่ยนเครื่อง',
+  CLOSED_BAD_DEBT: 'หนี้สูญ',
+  ALL: 'ทั้งหมด',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  ACTIVE: 'bg-success/10 text-success',
+  OVERDUE: 'bg-destructive/10 text-destructive',
+  DEFAULT: 'bg-destructive/10 text-destructive',
+  COMPLETED: 'bg-muted text-muted-foreground',
+  EARLY_PAYOFF: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  EXCHANGED: 'bg-warning/10 text-warning',
+  CLOSED_BAD_DEBT: 'bg-destructive/10 text-destructive',
+};
+
+const STATUS_OPTIONS = ['ALL', 'ACTIVE', 'OVERDUE', 'DEFAULT', 'COMPLETED', 'EARLY_PAYOFF', 'EXCHANGED'];
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+export default function FinancePortfolioPage() {
+  useDocumentTitle('พอร์ตสัญญา FINANCE');
+  const navigate = useNavigate();
+
+  const [statusFilter, setStatusFilter] = useState('ALL');
+  const [page, setPage] = useState(1);
+  const limit = 50;
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<PortfolioResponse>({
+    queryKey: ['finance-portfolio', statusFilter, page],
+    queryFn: async () => {
+      const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+      if (statusFilter !== 'ALL') params.set('status', statusFilter);
+      const { data } = await api.get(`/reports/finance-portfolio?${params}`);
+      return data;
+    },
+  });
+
+  const columns = [
+    {
+      key: 'contractNumber',
+      label: 'เลขสัญญา',
+      render: (row: PortfolioContract) => (
+        <div>
+          <div className="font-medium text-primary hover:underline cursor-pointer">{row.contractNumber}</div>
+          <div className="text-xs text-muted-foreground">{row.branch}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'customer',
+      label: 'ลูกค้า',
+      render: (row: PortfolioContract) => (
+        <div>
+          <div className="font-medium">{row.customer.name}</div>
+          <div className="text-xs text-muted-foreground">{row.customer.phone || '-'}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'product',
+      label: 'สินค้า',
+      render: (row: PortfolioContract) => (
+        <div>
+          <div className="font-medium">
+            {[row.product.brand, row.product.model].filter(Boolean).join(' ') || '-'}
+          </div>
+          {row.product.imeiSerial && (
+            <div className="text-xs text-muted-foreground font-mono">{row.product.imeiSerial}</div>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'financedAmount',
+      label: 'ยอดจัด',
+      render: (row: PortfolioContract) => (
+        <div className="text-right">
+          <div className="font-medium">{fmt(row.financedAmount)} ฿</div>
+          <div className="text-xs text-muted-foreground">{fmt(row.monthlyPayment)} ฿/เดือน</div>
+        </div>
+      ),
+    },
+    {
+      key: 'installments',
+      label: 'งวด',
+      render: (row: PortfolioContract) => (
+        <div className="text-center">
+          <div className="font-medium">{row.remainingInstallments}</div>
+          <div className="text-xs text-muted-foreground">เหลือ / {row.totalMonths} งวด</div>
+        </div>
+      ),
+    },
+    {
+      key: 'outstanding',
+      label: 'ยอดค้าง',
+      render: (row: PortfolioContract) => (
+        <div className="text-right">
+          <div
+            className={`font-semibold ${
+              row.outstanding > 0 ? 'text-destructive' : 'text-success'
+            }`}
+          >
+            {fmt(row.outstanding)} ฿
+          </div>
+          {row.nextDueDate && (
+            <div className="text-xs text-muted-foreground">
+              ครบ {formatDateShort(row.nextDueDate)}
+            </div>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'status',
+      label: 'สถานะ',
+      render: (row: PortfolioContract) => (
+        <span
+          className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+            STATUS_COLOR[row.status] || 'bg-muted text-muted-foreground'
+          }`}
+        >
+          {STATUS_LABEL[row.status] || row.status}
+        </span>
+      ),
+    },
+  ];
+
+  const summary = data?.summary;
+  const aging = data?.aging;
+
+  const summaryCards = [
+    {
+      label: 'สัญญาทั้งหมด',
+      value: summary?.totalContracts ?? 0,
+      isCount: true,
+      icon: FileText,
+      color: 'text-primary',
+      iconBg: 'bg-primary/10',
+      stripe: 'bg-primary',
+    },
+    {
+      label: 'ยอดลูกหนี้รวม',
+      value: summary?.totalReceivable ?? 0,
+      isCount: false,
+      icon: Banknote,
+      color: 'text-blue-600',
+      iconBg: 'bg-blue-100 dark:bg-blue-900/30',
+      stripe: 'bg-blue-500',
+    },
+    {
+      label: 'เก็บแล้ว',
+      value: summary?.totalCollected ?? 0,
+      isCount: false,
+      icon: CheckCircle2,
+      color: 'text-success',
+      iconBg: 'bg-success/10',
+      stripe: 'bg-success',
+    },
+    {
+      label: 'คงเหลือ',
+      value: summary?.totalOutstanding ?? 0,
+      isCount: false,
+      icon: Clock,
+      color: 'text-warning',
+      iconBg: 'bg-warning/10',
+      stripe: 'bg-warning',
+    },
+    {
+      label: 'อัตราเก็บเงิน',
+      value: summary?.collectionRate ?? 0,
+      isCount: false,
+      isPercent: true,
+      icon: TrendingUp,
+      color: 'text-emerald-600',
+      iconBg: 'bg-emerald-100 dark:bg-emerald-900/30',
+      stripe: 'bg-emerald-500',
+    },
+  ];
+
+  const agingCards = [
+    {
+      label: 'ปกติ (ยังไม่ถึงกำหนด)',
+      bucket: aging?.current,
+      color: 'text-success',
+      bg: 'bg-success/10',
+      border: 'border-success/20',
+      icon: CheckCircle2,
+    },
+    {
+      label: 'ค้าง 1-30 วัน',
+      bucket: aging?.days1to30,
+      color: 'text-yellow-600',
+      bg: 'bg-yellow-50 dark:bg-yellow-900/20',
+      border: 'border-yellow-200 dark:border-yellow-800',
+      icon: AlertTriangle,
+    },
+    {
+      label: 'ค้าง 31-60 วัน',
+      bucket: aging?.days31to60,
+      color: 'text-orange-600',
+      bg: 'bg-orange-50 dark:bg-orange-900/20',
+      border: 'border-orange-200 dark:border-orange-800',
+      icon: AlertTriangle,
+    },
+    {
+      label: 'ค้าง 61-90 วัน',
+      bucket: aging?.days61to90,
+      color: 'text-red-500',
+      bg: 'bg-red-50 dark:bg-red-900/20',
+      border: 'border-red-200 dark:border-red-800',
+      icon: ShieldAlert,
+    },
+    {
+      label: 'ค้างเกิน 90 วัน',
+      bucket: aging?.over90,
+      color: 'text-destructive',
+      bg: 'bg-destructive/10',
+      border: 'border-destructive/20',
+      icon: ShieldAlert,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="พอร์ตสัญญา BESTCHOICE FINANCE"
+        subtitle="สัญญาผ่อนชำระที่ FINANCE ถือกรรมสิทธิ์"
+      />
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {summaryCards.map((card) => (
+          <Card key={card.label} className="overflow-hidden">
+            <div className={`h-1 w-full ${card.stripe}`} />
+            <CardContent className="p-4">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-xs text-muted-foreground truncate">{card.label}</p>
+                  <p className={`mt-1 text-lg font-bold ${card.color}`}>
+                    {card.isCount
+                      ? card.value.toLocaleString('th-TH')
+                      : card.isPercent
+                      ? `${card.value.toFixed(1)}%`
+                      : `${Number(card.value).toLocaleString('th-TH', { maximumFractionDigits: 0 })} ฿`}
+                  </p>
+                </div>
+                <div className={`rounded-lg p-2 shrink-0 ${card.iconBg}`}>
+                  <card.icon className={`h-4 w-4 ${card.color}`} />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Aging Breakdown */}
+      <div>
+        <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+          การวิเคราะห์อายุหนี้ (Aging)
+        </h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+          {agingCards.map((card) => (
+            <div
+              key={card.label}
+              className={`rounded-lg border p-4 ${card.bg} ${card.border}`}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <card.icon className={`h-4 w-4 ${card.color}`} />
+                <p className="text-xs font-medium text-muted-foreground">{card.label}</p>
+              </div>
+              <p className={`text-lg font-bold ${card.color}`}>
+                {card.bucket?.count ?? 0} งวด
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {fmt(card.bucket?.amount ?? 0)} ฿
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Filter + Table */}
+      <Card>
+        <CardContent className="p-0">
+          {/* Status filter */}
+          <div className="flex flex-wrap gap-2 p-4 border-b">
+            {STATUS_OPTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => {
+                  setStatusFilter(s);
+                  setPage(1);
+                }}
+                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                  statusFilter === s
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+              >
+                {STATUS_LABEL[s] ?? s}
+              </button>
+            ))}
+          </div>
+
+          <QueryBoundary
+            isLoading={isLoading}
+            isError={isError}
+            error={error}
+            onRetry={refetch}
+          >
+            {data && (
+              <>
+                <DataTable
+                  columns={columns}
+                  data={data.data}
+                  onRowClick={(row) => navigate(`/contracts/${row.id}`)}
+                  emptyMessage="ไม่พบสัญญาที่ตรงกับเงื่อนไข"
+                />
+                {/* Pagination */}
+                {data.total > limit && (
+                  <div className="flex items-center justify-between px-4 py-3 border-t text-sm text-muted-foreground">
+                    <span>
+                      แสดง {(page - 1) * limit + 1}–{Math.min(page * limit, data.total)} จาก{' '}
+                      {data.total.toLocaleString('th-TH')} รายการ
+                    </span>
+                    <div className="flex gap-2">
+                      <button
+                        disabled={page === 1}
+                        onClick={() => setPage((p) => p - 1)}
+                        className="px-3 py-1 rounded border disabled:opacity-40 hover:bg-muted transition-colors"
+                      >
+                        ก่อนหน้า
+                      </button>
+                      <button
+                        disabled={page * limit >= data.total}
+                        onClick={() => setPage((p) => p + 1)}
+                        className="px-3 py-1 rounded border disabled:opacity-40 hover:bg-muted transition-colors"
+                      >
+                        ถัดไป
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </QueryBoundary>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Master Plan Phase 2 completion — ปิด 2 gaps ที่เหลือของ Multi-Entity Foundation.

### Gap 1: P&L รวมทุกสาขาของบริษัท
- `resolveCompanyBranch` → `resolveCompanyBranches` (คืน `string[]` แทน branch เดียว)
- P&L, Balance Sheet, Cash Flow รับ `branchIds[]` → `branchId: { in: branchIds }`
- SHOP P&L ตอนนี้รวมข้อมูลจาก **ทุกสาขา** (ไม่ใช่แค่สาขาแรก)
- Backwards-compatible: BRANCH_MANAGER ยังเห็นแค่สาขาตัวเอง

### Gap 2: หน้าพอร์ตโฟลิโอ BESTCHOICE FINANCE
- `GET /reports/finance-portfolio` — query contracts ที่ FINANCE ถือกรรมสิทธิ์
- สรุปยอด: สัญญาทั้งหมด, ยอดลูกหนี้, เก็บแล้ว, คงเหลือ, อัตราเก็บเงิน
- Aging breakdown: ปกติ / 1-30 / 31-60 / 61-90 / 90+ วัน
- DataTable + status filter + row click → contract detail
- Route `/finance-portfolio`, sidebar nav, roles: OWNER/FINANCE_MANAGER/ACCOUNTANT

### Verification
- API: **577 tests passed** (26 suites)
- TypeScript: **0 errors** (API + Web)

## Test plan
- [ ] P&L กับ companyId=SHOP → แสดงข้อมูลจากทุกสาขา (ไม่ใช่แค่สาขาแรก)
- [ ] `/finance-portfolio` → แสดงสัญญาที่ FINANCE ถือ + aging cards
- [ ] BRANCH_MANAGER ยังเห็นเฉพาะสาขาตัวเอง

🤖 Generated with [Claude Code](https://claude.com/claude-code)