### PR TITLE
fix(api): master plan phase 4 — PDPA consent check before all notifications

### DIFF
--- a/apps/api/src/modules/line-oa/line-oa.module.ts
+++ b/apps/api/src/modules/line-oa/line-oa.module.ts
@@ -9,9 +9,10 @@ import { PaymentLinkService } from './payment-links/payment-link.service';
 import { RichMenuService } from './rich-menu/rich-menu.service';
 import { ChatbotService } from './chatbot.service';
 import { ContractsModule } from '../contracts/contracts.module';
+import { PDPAModule } from '../pdpa/pdpa.module';
 
 @Module({
-  imports: [ContractsModule],
+  imports: [ContractsModule, PDPAModule],
   controllers: [LineOaController, LineOaPaymentController, LineOaCampaignController],
   providers: [
     LineOaService,

--- a/apps/api/src/modules/line-oa/line-oa.service.ts
+++ b/apps/api/src/modules/line-oa/line-oa.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, BadRequestException, InternalServerErrorException }
 import { CHATBOT_RESPONSES } from './chatbot-system-prompt.constants';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../prisma/prisma.service';
+import { PDPAService } from '../pdpa/pdpa.service';
 import { LineMessagePayload } from './dto/webhook-event.dto';
 import { FlexMessagePayload } from './flex-messages/base-template';
 import { buildPaymentSuccessFlex, PaymentSuccessData } from './flex-messages/payment-success.flex';
@@ -32,6 +33,7 @@ export class LineOaService {
   constructor(
     private configService: ConfigService,
     private prisma: PrismaService,
+    private pdpaService: PDPAService,
   ) {
     this.lineChannelAccessToken = this.configService.get<string>('LINE_CHANNEL_ACCESS_TOKEN');
     // Load from DB on startup (async)
@@ -321,6 +323,13 @@ export class LineOaService {
 
       if (!customer?.lineId) {
         this.logger.log('[LINE] Customer not linked to LINE, skipping receipt send');
+        return false;
+      }
+
+      // Check PDPA consent before sending
+      const hasConsent = await this.pdpaService.hasActiveConsent(customerId);
+      if (!hasConsent) {
+        this.logger.debug(`[LINE] PDPA consent not granted for customer ${customerId} — skipping payment receipt`);
         return false;
       }
 
@@ -811,7 +820,7 @@ export class LineOaService {
     switch (targetGroup) {
       case CampaignTargetGroup.ALL: {
         const customers = await this.prisma.customer.findMany({
-          where: { lineId: { not: null }, deletedAt: null },
+          where: { lineId: { not: null }, deletedAt: null, pdpaConsents: { some: { status: 'GRANTED', deletedAt: null } } },
           select: { lineId: true, name: true },
         });
         return customers.filter((c): c is { lineId: string; name: string } => c.lineId !== null);
@@ -822,6 +831,7 @@ export class LineOaService {
           where: {
             lineId: { not: null },
             deletedAt: null,
+            pdpaConsents: { some: { status: 'GRANTED', deletedAt: null } },
             contracts: {
               some: { status: 'ACTIVE', deletedAt: null },
             },
@@ -836,6 +846,7 @@ export class LineOaService {
           where: {
             lineId: { not: null },
             deletedAt: null,
+            pdpaConsents: { some: { status: 'GRANTED', deletedAt: null } },
             contracts: {
               some: { status: { in: ['OVERDUE', 'DEFAULT'] }, deletedAt: null },
             },
@@ -851,6 +862,7 @@ export class LineOaService {
           where: {
             lineId: { not: null },
             deletedAt: null,
+            pdpaConsents: { some: { status: 'GRANTED', deletedAt: null } },
             contracts: {
               some: { deletedAt: null },
             },

--- a/apps/api/src/modules/notifications/scheduler.module.ts
+++ b/apps/api/src/modules/notifications/scheduler.module.ts
@@ -7,9 +7,10 @@ import { ProductsModule } from '../products/products.module';
 import { ReportsModule } from '../reports/reports.module';
 import { LineOaModule } from '../line-oa/line-oa.module';
 import { DashboardModule } from '../dashboard/dashboard.module';
+import { PDPAModule } from '../pdpa/pdpa.module';
 
 @Module({
-  imports: [NotificationsModule, OverdueModule, InventoryModule, ProductsModule, ReportsModule, LineOaModule, DashboardModule],
+  imports: [NotificationsModule, OverdueModule, InventoryModule, ProductsModule, ReportsModule, LineOaModule, DashboardModule, PDPAModule],
   providers: [SchedulerService],
 })
 export class SchedulerModule {}

--- a/apps/api/src/modules/notifications/scheduler.service.ts
+++ b/apps/api/src/modules/notifications/scheduler.service.ts
@@ -14,6 +14,7 @@ import { buildOverdueNoticeFlex } from '../line-oa/flex-messages/overdue-notice.
 import { buildPaymentReminderFlex } from '../line-oa/flex-messages/payment-reminder.flex';
 import { buildDailyReportFlex } from '../line-oa/flex-messages/daily-report.flex';
 import { DashboardService } from '../dashboard/dashboard.service';
+import { PDPAService } from '../pdpa/pdpa.service';
 
 @Injectable()
 export class SchedulerService {
@@ -29,6 +30,7 @@ export class SchedulerService {
     private lineOaService: LineOaService,
     private paymentLinkService: PaymentLinkService,
     private dashboardService: DashboardService,
+    private pdpaService: PDPAService,
   ) {}
 
   /**
@@ -85,7 +87,7 @@ export class SchedulerService {
     const contracts = await this.prisma.contract.findMany({
       where: { id: { in: contractIds } },
       include: {
-        customer: { select: { name: true, lineId: true, phone: true } },
+        customer: { select: { id: true, name: true, lineId: true, phone: true } },
         payments: {
           where: { status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] }, dueDate: { lt: new Date() } },
           orderBy: { installmentNo: 'asc' },
@@ -97,6 +99,15 @@ export class SchedulerService {
     for (const contract of contracts) {
       const lineId = contract.customer?.lineId;
       if (!lineId) continue;
+
+      // Check PDPA consent before sending
+      if (contract.customer?.id) {
+        const hasConsent = await this.pdpaService.hasActiveConsent(contract.customer.id);
+        if (!hasConsent) {
+          this.logger.debug(`PDPA: skipping status notification for customer ${contract.customer.id}`);
+          continue;
+        }
+      }
 
       try {
         const totalOverdue = contract.payments.reduce(

--- a/apps/api/src/modules/pdpa/pdpa.service.ts
+++ b/apps/api/src/modules/pdpa/pdpa.service.ts
@@ -107,6 +107,15 @@ export class PDPAService {
     });
   }
 
+  /** Check whether a customer currently has an active (GRANTED) PDPA consent */
+  async hasActiveConsent(customerId: string): Promise<boolean> {
+    const consent = await this.prisma.pDPAConsent.findFirst({
+      where: { customerId, status: 'GRANTED', deletedAt: null },
+      select: { id: true },
+    });
+    return !!consent;
+  }
+
   /** Get all consents for a customer */
   async getCustomerConsents(customerId: string) {
     return this.prisma.pDPAConsent.findMany({


### PR DESCRIPTION
## Summary

Master Plan Phase 4 completion — ปิด gap สุดท้าย: consent revocation → stop notifications.

### PDPA Consent Enforcement
- Added `hasActiveConsent(customerId)` to `PDPAService`
- **Gap 1**: `sendPaymentReceipt()` — consent check before sending LINE receipt
- **Gap 2**: `getCampaignTargetCustomers()` — Prisma relation filter `pdpaConsents: { some: { status: 'GRANTED' } }` on all 4 target groups (ALL/ACTIVE/OVERDUE/COMPLETED)
- **Gap 3**: `notifyStatusChangedCustomers()` — per-contract consent check before LINE status notification

Now **ALL** customer-facing notification channels respect PDPA consent:
| Channel | Guard |
|---|---|
| Payment reminders | ✅ (already had inline check) |
| Overdue notices | ✅ (already had inline check) |
| Payment receipts | ✅ **(new)** |
| Campaign sends | ✅ **(new — query-level)** |
| Status change alerts | ✅ **(new)** |

### Verification
- API: **577 tests passed** (26 suites)
- TypeScript: **0 errors**

## Test plan
- [ ] Revoke PDPA consent for test customer → verify no LINE notifications sent
- [ ] Campaign send → only customers with GRANTED consent receive messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)