### PR TITLE
fix(docker): include card-reader package.json so express resolves at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,17 @@ COPY apps/api/package.json apps/api/
 # apps/web/package.json must be present so npm workspaces correctly resolves
 # and hoists all workspace deps (including @nestjs/cli from apps/api devDeps)
 COPY apps/web/package.json apps/web/
+# apps/card-reader/package.json is required for `npm ci` to install the
+# card-reader workspace's transitive deps. Card-reader is a local-only
+# service not deployed to Cloud Run, but its `express: ^4.21.0` dependency
+# is load-bearing for the Docker build: after the NestJS 11 bump,
+# @nestjs/platform-express@11 pulls express@5 and npm nests it under
+# node_modules/@nestjs/platform-express/node_modules/express. Without
+# card-reader also present, there is no express at root node_modules,
+# and `require('express')` from apps/api/dist/src/main.js fails at runtime
+# with `Cannot find module 'express'`. Card-reader brings express@4.21.x
+# to root node_modules, which main.js resolves via the standard walk.
+COPY apps/card-reader/package.json apps/card-reader/
 COPY packages/ packages/
 # --include=dev: force devDeps even when NODE_ENV=production
 RUN npm ci --include=dev


### PR DESCRIPTION
## Summary

Prod deploy hotfix. Cloud Run revision 00153 (post-#459 merge) failed to start with `Cannot find module 'express'` from `apps/api/dist/src/main.js`.

## Root cause

After #459 bumped @nestjs/platform-express@10 → @11, the lock file records express@5 nested under `@nestjs/platform-express/node_modules`, while card-reader's express@4 sits at root (hoisted). The Dockerfile deps stage only copies `apps/api` + `apps/web` package.json, never `apps/card-reader`, so `npm ci` in Docker never installs card-reader's express@4 at root. Node's module resolver walks up from main.js but finds no express anywhere accessible.

## Fix

One line: `COPY apps/card-reader/package.json apps/card-reader/` in deps stage, plus a detailed comment explaining why card-reader package.json is load-bearing even though the service itself is not deployed.

## Local verification

- `docker build` with updated Dockerfile succeeds
- `docker run` + Postgres: container starts cleanly, Nest bootstraps, `/api/health` returns `{"success":true,"status":"ok"}`
- `/app/node_modules/express/package.json`: version 4.22.1 present (from card-reader)

## Impact

- **Prod is currently broken** — Cloud Run stuck on old revision since chunk 1 merge. This PR unblocks the next main deploy.
- Not a regression from #459 per se — Dockerfile was already incomplete in how it handled the multi-workspace tree; the NestJS 11 bump exposed the gap by introducing a version conflict on express.

## Long-term follow-up (separate PR)

- Upgrade `apps/card-reader` to express@5 so both workspaces share one version and hoisting is uniform. Out of scope for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)