### PR TITLE
chore(web): bump zod ^3.25.76 → ^4.3.6 — Tier 3 chunk 8

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -84,7 +84,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.25.76",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/apps/web/src/lib/schemas.ts
+++ b/apps/web/src/lib/schemas.ts
@@ -1,12 +1,12 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 /**
  * Reusable Zod schemas สำหรับ validation ทั้งระบบ BESTCHOICE
- * ใช้คู่กับ React Hook Form + @hookform/resolvers/zod
+ * ใช้คู่กับ React Hook Form + @hookform/resolvers/standard-schema
  *
  * Usage:
  *   import { customerSchema } from '@/lib/schemas';
- *   const form = useForm({ resolver: zodResolver(customerSchema) });
+ *   const form = useForm({ resolver: standardSchemaResolver(customerSchema) });
  */
 
 /* ─── Thai National ID validation (13 digits + checksum) ─── */
@@ -44,7 +44,7 @@ export const customerSchema = z.object({
   lastName: z.string().min(1, 'กรุณากรอกนามสกุล'),
   nickname: z.string().optional(),
   nationalId: nationalIdSchema,
-  isForeigner: z.boolean().default(false),
+  isForeigner: z.boolean(),
   birthDate: z.string().optional(),
   phone: phoneSchema,
   phoneSecondary: z.string().optional(),
@@ -69,7 +69,7 @@ export const productSchema = z.object({
   imeiSerial: z.string().optional(),
   serialNumber: z.string().optional(),
   category: z.enum(['PHONE_NEW', 'PHONE_USED', 'TABLET_NEW', 'TABLET_USED', 'ACCESSORY'], {
-    required_error: 'กรุณาเลือกประเภทสินค้า',
+    error: 'กรุณาเลือกประเภทสินค้า',
   }),
   costPrice: z.string().min(1, 'กรุณากรอกราคาทุน').refine(
     (v) => !isNaN(Number(v)) && Number(v) > 0,

--- a/apps/web/src/pages/ContractCreatePage/components/PlanDetailsStep.tsx
+++ b/apps/web/src/pages/ContractCreatePage/components/PlanDetailsStep.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import type { Product, InterestConfig, Customer } from '../types';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
@@ -87,7 +87,7 @@ export function PlanDetailsStep({
   monthOptions,
 }: PlanDetailsStepProps) {
   const form = useForm<ContractPlanFormData>({
-    resolver: zodResolver(contractPlanSchema),
+    resolver: standardSchemaResolver(contractPlanSchema),
     defaultValues: {
       downPayment,
       totalMonths,

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { exportToExcel, type ExcelColumn } from '@/utils/excel.util';
@@ -113,9 +113,8 @@ export default function CustomersPage() {
   const [sortBy, setSortBy] = useState('');
   const [sortOrder, setSortOrder] = useState('asc');
   const [isModalOpen, setIsModalOpen] = useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const form = useForm<CustomerFormData>({
-    resolver: zodResolver(customerSchema) as any,
+    resolver: standardSchemaResolver(customerSchema),
     defaultValues: emptyForm,
   });
   // Extra fields not in customerSchema (managed as separate state)

--- a/apps/web/src/pages/POSPage.tsx
+++ b/apps/web/src/pages/POSPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -91,7 +91,7 @@ export default function POSPage() {
 
   // Sale form — replaces individual useState for sale detail fields
   const saleForm = useForm<PosSaleFormData>({
-    resolver: zodResolver(posSaleSchema),
+    resolver: standardSchemaResolver(posSaleSchema),
     defaultValues: {
       saleType: 'CASH',
       sellingPrice: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
-        "zod": "^3.25.76",
+        "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -279,6 +279,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "apps/web/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Summary
- Upgrade `zod` from ^3.25.76 → ^4.3.6
- Migrate `zodResolver` → `standardSchemaResolver` (fixes type incompatibility between `@hookform/resolvers@5.2.2` and `zod@4.3.x`)
- Fix `required_error` → `error` param in `z.enum()` (Zod 4 breaking change)
- Import from `zod/v4` instead of `zod` (default export is v3 compat layer)

## Files changed
- [schemas.ts](apps/web/src/lib/schemas.ts) — `zod/v4` import, `required_error` → `error`, remove `.default(false)`
- [CustomersPage.tsx](apps/web/src/pages/CustomersPage.tsx) — `standardSchemaResolver`, remove `as any` cast
- [POSPage.tsx](apps/web/src/pages/POSPage.tsx) — `standardSchemaResolver`
- [PlanDetailsStep.tsx](apps/web/src/pages/ContractCreatePage/components/PlanDetailsStep.tsx) — `standardSchemaResolver`

## Why standardSchemaResolver?
`@hookform/resolvers@5.2.2` (Sep 2025) has a `zodResolver` overload that checks `_zod.version.minor === 0` (built for zod 4.0.x). Zod 4.3.x bumped minor to `3`, causing a type literal mismatch. The `standardSchemaResolver` uses the Standard Schema protocol which Zod 4 implements natively — no version coupling.

## Verification
- [x] TypeScript check — **0 errors**
- [x] `vite build` — passes (18s)

## Test plan
- [ ] Smoke test POS page — create cash sale, validate form errors display
- [ ] Smoke test Customers page — create/edit customer form validation
- [ ] Smoke test Contract Create — plan details step validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)