### PR TITLE
chore(web): migrate react-router-dom v6.28 → react-router v7.14 — Tier 3 chunk 9

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -78,7 +78,7 @@
     "react-hook-form": "^7.72.0",
     "react-qr-code": "^2.0.18",
     "react-resizable-panels": "^4.9.0",
-    "react-router-dom": "^6.28.0",
+    "react-router": "^7.14.0",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router';
 import { useAuth } from '@/contexts/AuthContext';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import MainLayout from '@/components/layout/MainLayout';

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   Command,
   CommandEmpty,

--- a/apps/web/src/components/ProtectedRoute.tsx
+++ b/apps/web/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuth } from '@/contexts/AuthContext';
 
 interface ProtectedRouteProps {

--- a/apps/web/src/components/landing/LandingNav.tsx
+++ b/apps/web/src/components/landing/LandingNav.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 interface LandingNavProps {
   onScrollTo?: (section: string) => void;

--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 interface AuthLayoutProps {
   children: ReactNode;

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useGlobalShortcuts } from '@/hooks/useGlobalShortcuts';
 import { LayoutProvider, useLayout } from './LayoutContext';

--- a/apps/web/src/components/layout/MobileBottomNav.tsx
+++ b/apps/web/src/components/layout/MobileBottomNav.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { Home, ShoppingCart, FileCheck, HandCoins, MoreHorizontal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useLayout } from './LayoutContext';

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback, memo, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { useAuth } from '@/contexts/AuthContext';
 import { cn } from '@/lib/utils';
 import {

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useAuth } from '@/contexts/AuthContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useTheme } from 'next-themes';

--- a/apps/web/src/components/signing/StepComplete.tsx
+++ b/apps/web/src/components/signing/StepComplete.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import api, { getErrorMessage } from '@/lib/api';
 import { toast } from 'sonner';
 

--- a/apps/web/src/hooks/useGlobalShortcuts.ts
+++ b/apps/web/src/hooks/useGlobalShortcuts.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 /**
  * Global keyboard shortcuts for the app.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,7 +2,7 @@ import '@/lib/env';
 import * as Sentry from '@sentry/react';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import {
   QueryClient,
   QueryClientProvider,

--- a/apps/web/src/pages/ChatbotFinanceAnalyticsPage.tsx
+++ b/apps/web/src/pages/ChatbotFinanceAnalyticsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import QueryBoundary from '@/components/QueryBoundary';
 
 interface AnalyticsOverview {

--- a/apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts
+++ b/apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import { serializeAddress, AddressData, emptyAddress } from '@/components/ui/AddressForm';

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/ContractSignPage.tsx
+++ b/apps/web/src/pages/ContractSignPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';

--- a/apps/web/src/pages/ContractTemplatesPage.tsx
+++ b/apps/web/src/pages/ContractTemplatesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTemplateStore } from '@/store/templateStore';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';

--- a/apps/web/src/pages/ContractVerifyPage.tsx
+++ b/apps/web/src/pages/ContractVerifyPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { formatDateMedium } from '@/utils/formatters';

--- a/apps/web/src/pages/ContractsPage.tsx
+++ b/apps/web/src/pages/ContractsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback, useState } from 'react';
-import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { useNavigate, useSearchParams, Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { useDebounce } from '@/hooks/useDebounce';

--- a/apps/web/src/pages/CreditChecksPage/CreditCheckTable.tsx
+++ b/apps/web/src/pages/CreditChecksPage/CreditCheckTable.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import DataTable from '@/components/ui/DataTable';
 import QueryBoundary from '@/components/QueryBoundary';
 import { formatDateShort } from '@/utils/formatters';

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/CustomerPortalPage.tsx
+++ b/apps/web/src/pages/CustomerPortalPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { formatDateShort, formatDateTime } from '@/utils/formatters';

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -3,7 +3,7 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { exportToExcel, type ExcelColumn } from '@/utils/excel.util';
 import { formatDateShort } from '@/utils/formatters';
 import { toast } from 'sonner';

--- a/apps/web/src/pages/DashboardPage/components/DashboardAlerts.tsx
+++ b/apps/web/src/pages/DashboardPage/components/DashboardAlerts.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { DashboardAlert } from '../types';

--- a/apps/web/src/pages/DashboardPage/components/DashboardKPIs.tsx
+++ b/apps/web/src/pages/DashboardPage/components/DashboardKPIs.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   FileCheck,

--- a/apps/web/src/pages/DashboardPage/components/DashboardRevenue.tsx
+++ b/apps/web/src/pages/DashboardPage/components/DashboardRevenue.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle, CardToolbar } from '@/components/ui/card';

--- a/apps/web/src/pages/DashboardPage/components/DashboardTables.tsx
+++ b/apps/web/src/pages/DashboardPage/components/DashboardTables.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Card, CardContent, CardHeader, CardTitle, CardToolbar, CardTable } from '@/components/ui/card';
 import { Layers } from 'lucide-react';
 import { cn } from '@/lib/utils';

--- a/apps/web/src/pages/DashboardPage/components/DashboardWatchList.tsx
+++ b/apps/web/src/pages/DashboardPage/components/DashboardWatchList.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Card, CardHeader, CardTitle, CardToolbar, CardTable } from '@/components/ui/card';
 import {
   ShieldAlert,

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/FinancePortfolioPage.tsx
+++ b/apps/web/src/pages/FinancePortfolioPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';

--- a/apps/web/src/pages/FinanceReceivablePage.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { toast } from 'sonner';
 import api from '@/lib/api';
 import AuthLayout from '@/components/layout/AuthLayout';

--- a/apps/web/src/pages/InspectionDetailPage.tsx
+++ b/apps/web/src/pages/InspectionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/InspectionPage.tsx
+++ b/apps/web/src/pages/InspectionPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import api, { getErrorMessage } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDebounce } from '@/hooks/useDebounce';

--- a/apps/web/src/pages/InventoryWorkflowPage.tsx
+++ b/apps/web/src/pages/InventoryWorkflowPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import api, { getErrorMessage } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import QueryBoundary from '@/components/QueryBoundary';

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { useRef, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import LandingNav from '@/components/landing/LandingNav';
 import ProductCard from '@/components/landing/ProductCard';

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import AuthLayout from '@/components/layout/AuthLayout';

--- a/apps/web/src/pages/OverduePage.tsx
+++ b/apps/web/src/pages/OverduePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';

--- a/apps/web/src/pages/POSPage.tsx
+++ b/apps/web/src/pages/POSPage.tsx
@@ -3,7 +3,7 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { Copy } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';

--- a/apps/web/src/pages/ProductCreatePage.tsx
+++ b/apps/web/src/pages/ProductCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/ProductDetailPage.tsx
+++ b/apps/web/src/pages/ProductDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/ReceiptVerifyPage.tsx
+++ b/apps/web/src/pages/ReceiptVerifyPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import MobileReceipt from '@/components/payment/MobileReceipt';

--- a/apps/web/src/pages/RegisterInvitePage.tsx
+++ b/apps/web/src/pages/RegisterInvitePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FormEvent } from 'react';
-import { Link, useSearchParams, useNavigate } from 'react-router-dom';
+import { Link, useSearchParams, useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import api from '@/lib/api';
 import AuthLayout from '@/components/layout/AuthLayout';

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react';
-import { Link, useSearchParams, useNavigate } from 'react-router-dom';
+import { Link, useSearchParams, useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import api from '@/lib/api';
 import AuthLayout from '@/components/layout/AuthLayout';

--- a/apps/web/src/pages/SalesHistoryPage.tsx
+++ b/apps/web/src/pages/SalesHistoryPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { exportToExcel, type ExcelColumn } from '@/utils/excel.util';
 import { toast } from 'sonner';
 import api from '@/lib/api';

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';

--- a/apps/web/src/pages/StockPage/hooks/useStockFilters.ts
+++ b/apps/web/src/pages/StockPage/hooks/useStockFilters.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useAuth } from '@/contexts/AuthContext';

--- a/apps/web/src/pages/StockPage/index.tsx
+++ b/apps/web/src/pages/StockPage/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import { Button } from '@/components/ui/button';

--- a/apps/web/src/pages/StockTransfersPage.tsx
+++ b/apps/web/src/pages/StockTransfersPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import clsx from 'clsx';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/SupplierDetailPage.tsx
+++ b/apps/web/src/pages/SupplierDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';

--- a/apps/web/src/pages/SuppliersPage.tsx
+++ b/apps/web/src/pages/SuppliersPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import { useDebounce } from '@/hooks/useDebounce';

--- a/apps/web/src/pages/liff/LiffPayment.tsx
+++ b/apps/web/src/pages/liff/LiffPayment.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { formatDateShort, formatDateTime } from '@/utils/formatters';
 import {
   CreditCard,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          vendor: ['react', 'react-dom', 'react-router-dom'],
+          vendor: ['react', 'react-dom', 'react-router'],
           query: ['@tanstack/react-query'],
           liff: ['@line/liff'],
           // Heavy libs split into separate chunks so the initial JS bundle

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,7 +184,7 @@
         "react-hook-form": "^7.72.0",
         "react-qr-code": "^2.0.18",
         "react-resizable-panels": "^4.9.0",
-        "react-router-dom": "^6.28.0",
+        "react-router": "^7.14.0",
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -7928,15 +7928,6 @@
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "license": "MIT"
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -21506,35 +21497,38 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-style-singleton": {
@@ -22343,6 +22337,12 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",


### PR DESCRIPTION
## Summary
- Replace `react-router-dom` ^6.28.0 with unified `react-router` ^7.14.0
- Update imports in 53 source files
- Update Vite `manualChunks` vendor entry

## Why this is safe
React Router 7 has **zero breaking changes** for our usage pattern:
- We use `BrowserRouter` (not `createBrowserRouter`) — no data router features to migrate
- All hooks (`useNavigate`, `useParams`, `useSearchParams`, `useLocation`) are identical
- All components (`Link`, `Navigate`, `Outlet`, `Routes`, `Route`) are identical
- The only change is the package name: `react-router-dom` → `react-router`

## Verification
- [x] TypeScript check — **0 errors**
- [x] `vite build` — passes (29s)

## Test plan
- [ ] Navigate between pages (dashboard, contracts, customers, POS)
- [ ] Test URL params pages (customer detail, contract detail)
- [ ] Test LIFF routes (/liff/contract, /liff/payment)
- [ ] Test auth flow (login → redirect → protected pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)