### PR TITLE
fix(chat): staff LINE messages silently failing — register adapters + surface errors

### DIFF
--- a/apps/api/src/modules/chat-adapters/chat-adapters.module.ts
+++ b/apps/api/src/modules/chat-adapters/chat-adapters.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { LineFinanceAdapter } from './line-finance.adapter';
 import { LineShopAdapter } from './line-shop.adapter';
 import { FacebookAdapter } from './facebook.adapter';
@@ -10,6 +10,7 @@ import { ChatbotFinanceModule } from '../chatbot-finance/chatbot-finance.module'
 import { LineOaModule } from '../line-oa/line-oa.module';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 import { FacebookDomainModule } from '../facebook-domain/facebook-domain.module';
+import { MessageRouterService } from '../chat-engine/services/message-router.service';
 
 /**
  * ChatAdaptersModule — provides IChannelAdapter implementations for all channels.
@@ -56,4 +57,21 @@ import { FacebookDomainModule } from '../facebook-domain/facebook-domain.module'
     WebWidgetAdapter,
   ],
 })
-export class ChatAdaptersModule {}
+export class ChatAdaptersModule implements OnModuleInit {
+  constructor(
+    private messageRouter: MessageRouterService,
+    private lineFinance: LineFinanceAdapter,
+    private lineShop: LineShopAdapter,
+    private facebook: FacebookAdapter,
+    private tiktok: TiktokAdapter,
+    private web: WebWidgetAdapter,
+  ) {}
+
+  onModuleInit(): void {
+    this.messageRouter.registerAdapter(this.lineFinance);
+    this.messageRouter.registerAdapter(this.lineShop);
+    this.messageRouter.registerAdapter(this.facebook);
+    this.messageRouter.registerAdapter(this.tiktok);
+    this.messageRouter.registerAdapter(this.web);
+  }
+}

--- a/apps/api/src/modules/chat-adapters/line-finance.adapter.ts
+++ b/apps/api/src/modules/chat-adapters/line-finance.adapter.ts
@@ -21,7 +21,7 @@ export class LineFinanceAdapter implements IChannelAdapter {
 
   async sendMessage(message: OutboundMessage): Promise<SendResult> {
     try {
-      if (!this.lineClient.isConfigured) {
+      if (!(await this.lineClient.isConfigured())) {
         return { success: false, error: 'LINE Finance token not configured' };
       }
 

--- a/apps/api/src/modules/chat-engine/constants/chat-events.ts
+++ b/apps/api/src/modules/chat-engine/constants/chat-events.ts
@@ -23,6 +23,8 @@ export const CHAT_EVENTS = {
   VIEWERS: 'chat:viewers',
   /** Collision warning — another staff is viewing the same room */
   COLLISION_WARNING: 'chat:collision',
+  /** Outbound delivery to external channel failed (LINE push error etc.) */
+  MESSAGE_SEND_FAILED: 'chat:message:send-failed',
 } as const;
 
 // Client → Server events

--- a/apps/api/src/modules/chat-engine/services/message-router.service.ts
+++ b/apps/api/src/modules/chat-engine/services/message-router.service.ts
@@ -48,23 +48,40 @@ export class MessageRouterService {
     @Inject(CHAT_GATEWAY_TOKEN)
     private gateway?: IChatGateway,
   ) {
-    // Register adapters by channel
+    // Register adapters by channel (via constructor — only works when ChatEngineModule
+    // imports a module that exports CHANNEL_ADAPTER_TOKEN. For the current wiring where
+    // ChatAdaptersModule imports ChatEngineModule instead, adapters self-register via
+    // registerAdapter() in ChatAdaptersModule.onModuleInit().)
     if (adapters) {
       for (const adapter of Array.isArray(adapters) ? adapters : [adapters]) {
-        this.adapterMap.set(adapter.channel, adapter);
-        this.logger.log(`Registered adapter: ${adapter.channel}`);
+        this.registerAdapter(adapter);
       }
     }
 
-    // Register domain handlers
     if (handlers) {
-      this.domainHandlers.push(
-        ...(Array.isArray(handlers) ? handlers : [handlers]),
-      );
-      this.logger.log(
-        `Registered ${this.domainHandlers.length} domain handler(s)`,
-      );
+      for (const handler of Array.isArray(handlers) ? handlers : [handlers]) {
+        this.registerDomainHandler(handler);
+      }
     }
+  }
+
+  /**
+   * Register a channel adapter. Idempotent — safe to call from module init hooks
+   * when the DI token-based registration isn't reachable due to module scope.
+   */
+  registerAdapter(adapter: IChannelAdapter): void {
+    const existing = this.adapterMap.get(adapter.channel);
+    if (existing === adapter) return;
+    this.adapterMap.set(adapter.channel, adapter);
+    this.logger.log(`Registered adapter: ${adapter.channel}`);
+  }
+
+  registerDomainHandler(handler: IDomainHandler): void {
+    if (this.domainHandlers.includes(handler)) return;
+    this.domainHandlers.push(handler);
+    this.logger.log(
+      `Registered domain handler (${this.domainHandlers.length} total)`,
+    );
   }
 
   /**
@@ -363,16 +380,20 @@ export class MessageRouterService {
     });
   }
 
-  /** Send a staff message through the appropriate adapter */
+  /**
+   * Send a staff message through the appropriate adapter.
+   * Returns { success, error? } so the caller (WS gateway) can notify the UI
+   * when delivery to the external channel fails (LINE push quota, blocked OA, etc.)
+   */
   async sendStaffMessage(params: {
     roomId: string;
     staffId: string;
     text: string;
-  }): Promise<void> {
+  }): Promise<{ success: boolean; error?: string }> {
     const room = await this.roomManager.findById(params.roomId);
     if (!room) {
       this.logger.error(`Room not found: ${params.roomId}`);
-      return;
+      return { success: false, error: 'Room not found' };
     }
 
     // Resolve the external user ID (externalUserId for FB/TikTok, lineUserId for LINE)
@@ -389,20 +410,27 @@ export class MessageRouterService {
 
     // Send through adapter
     const adapter = this.adapterMap.get(room.channel);
-    if (adapter) {
-      const result = await adapter.sendMessage({
-        externalUserId,
-        channel: room.channel,
-        type: 'TEXT' as any,
-        text: params.text,
-      });
-
-      if (!result.success) {
-        this.logger.error(
-          `Failed to send staff message on ${room.channel}: ${result.error}`,
-        );
-      }
+    if (!adapter) {
+      const error = `No adapter registered for channel ${room.channel}`;
+      this.logger.error(error);
+      return { success: false, error };
     }
+
+    const result = await adapter.sendMessage({
+      externalUserId,
+      channel: room.channel,
+      type: 'TEXT' as any,
+      text: params.text,
+    });
+
+    if (!result.success) {
+      this.logger.error(
+        `Failed to send staff message on ${room.channel}: ${result.error}`,
+      );
+      return { success: false, error: result.error ?? 'send failed' };
+    }
+
+    return { success: true };
   }
 
   /** Get registered adapter for a channel */

--- a/apps/api/src/modules/facebook-domain/facebook-domain.module.ts
+++ b/apps/api/src/modules/facebook-domain/facebook-domain.module.ts
@@ -1,9 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { FacebookDomainHandler } from './facebook-domain.handler';
 import { FacebookQuickReplyService } from './facebook-quick-reply.service';
 import { FacebookTemplateService } from './facebook-template.service';
 import { FacebookPersistentMenuService } from './facebook-persistent-menu.service';
 import { DOMAIN_HANDLER_TOKEN } from '../chat-engine/interfaces/domain-handler.interface';
+import { MessageRouterService } from '../chat-engine/services/message-router.service';
+import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 
 /**
  * FacebookDomainModule — handles Facebook Messenger business logic.
@@ -15,6 +17,7 @@ import { DOMAIN_HANDLER_TOKEN } from '../chat-engine/interfaces/domain-handler.i
  * - FacebookPersistentMenuService (persistent menu setup)
  */
 @Module({
+  imports: [ChatEngineModule],
   providers: [
     FacebookDomainHandler,
     FacebookQuickReplyService,
@@ -33,4 +36,13 @@ import { DOMAIN_HANDLER_TOKEN } from '../chat-engine/interfaces/domain-handler.i
     DOMAIN_HANDLER_TOKEN,
   ],
 })
-export class FacebookDomainModule {}
+export class FacebookDomainModule implements OnModuleInit {
+  constructor(
+    private messageRouter: MessageRouterService,
+    private facebookHandler: FacebookDomainHandler,
+  ) {}
+
+  onModuleInit(): void {
+    this.messageRouter.registerDomainHandler(this.facebookHandler);
+  }
+}

--- a/apps/api/src/modules/staff-chat/staff-chat.gateway.ts
+++ b/apps/api/src/modules/staff-chat/staff-chat.gateway.ts
@@ -178,7 +178,7 @@ export class StaffChatGateway implements OnGatewayConnection, OnGatewayDisconnec
     }
 
     // Send through engine (saves message + sends to customer via adapter)
-    await this.messageRouter.sendStaffMessage({
+    const sendResult = await this.messageRouter.sendStaffMessage({
       roomId: data.roomId,
       staffId: userId,
       text: data.text,
@@ -192,6 +192,16 @@ export class StaffChatGateway implements OnGatewayConnection, OnGatewayDisconnec
       text: data.text,
       createdAt: new Date().toISOString(),
     });
+
+    // Notify the sending staff if external delivery (LINE/FB/etc.) failed so the
+    // UI can show the message as "not delivered" instead of a silent success tick.
+    if (!sendResult.success) {
+      client.emit(CHAT_EVENTS.MESSAGE_SEND_FAILED, {
+        roomId: data.roomId,
+        text: data.text,
+        error: sendResult.error,
+      });
+    }
 
     // Auto-update lead score after new message
     this.leadScoring.scoreSession(data.roomId).catch((err) =>

--- a/apps/web/src/pages/UnifiedInboxPage/hooks/useChatSocket.ts
+++ b/apps/web/src/pages/UnifiedInboxPage/hooks/useChatSocket.ts
@@ -41,6 +41,12 @@ export interface ChatCollisionEvent {
   viewers: ChatViewer[];
 }
 
+export interface ChatSendFailedEvent {
+  roomId: string;
+  text: string;
+  error?: string;
+}
+
 interface ChatSocketEvents {
   onNewMessage?: (data: ChatMessageEvent) => void;
   onRoomUpdate?: (data: ChatRoomUpdateEvent) => void;
@@ -48,6 +54,7 @@ interface ChatSocketEvents {
   onPresence?: (data: ChatPresenceEvent) => void;
   onViewers?: (data: ChatViewersEvent) => void;
   onCollision?: (data: ChatCollisionEvent) => void;
+  onSendFailed?: (data: ChatSendFailedEvent) => void;
 }
 
 // Resolve WebSocket base URL: in dev, API runs on port 3000
@@ -109,6 +116,9 @@ export function useChatSocket(events: ChatSocketEvents, activeRoomId?: string | 
     socket.on('chat:presence', (data) => eventsRef.current.onPresence?.(data));
     socket.on('chat:viewers', (data) => eventsRef.current.onViewers?.(data));
     socket.on('chat:collision', (data) => eventsRef.current.onCollision?.(data));
+    socket.on('chat:message:send-failed', (data) =>
+      eventsRef.current.onSendFailed?.(data),
+    );
     socket.on('connect_error', () => {
       // Silent — reconnection handles retry
     });

--- a/apps/web/src/pages/UnifiedInboxPage/index.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/index.tsx
@@ -86,6 +86,10 @@ export default function UnifiedInboxPage() {
       const viewerNames = data.viewers?.map((v) => v.userName).join(', ');
       toast.warning(`⚠️ ${viewerNames} กำลังดูแชทนี้อยู่`);
     },
+    onSendFailed: (data) => {
+      toast.error(`ส่งข้อความไปยังลูกค้าไม่สำเร็จ${data.error ? ` — ${data.error}` : ''}`);
+      queryClient.invalidateQueries({ queryKey: ['chat-messages', data.roomId] });
+    },
   }, activeRoomId);
 
   // Fetch sessions — send search to backend; tab/channel filtering is client-side


### PR DESCRIPTION
## Summary
- **P0 prod bug**: staff replies from `/inbox` showed ✓ but never reached LINE customers. Only bot auto-replies worked.
- **Root cause**: `CHANNEL_ADAPTER_TOKEN` / `DOMAIN_HANDLER_TOKEN` multi-providers were only visible inside `ChatAdaptersModule` / `FacebookDomainModule` (which import `ChatEngineModule`, not the reverse). `MessageRouterService.@Inject+@Optional` resolved them as `undefined` → `adapterMap` stayed empty in prod → `sendStaffMessage` silently no-op'd at the missing-adapter guard.
- **Fix**: `OnModuleInit` self-registration + UI error-surfacing pipeline so staff see delivery failures instead of false ✓.

## Changes
- `MessageRouterService`: `registerAdapter` / `registerDomainHandler` public methods; `sendStaffMessage` returns `{success, error}` instead of void
- `ChatAdaptersModule`: `OnModuleInit` self-registers all 5 adapters (LINE Finance/Shop, FB, TikTok, Web)
- `FacebookDomainModule`: same pattern for domain handler
- `line-finance.adapter`: `await isConfigured()` — latent getter→async method bug from commit 9f06ea9f
- `chat-events`: new `MESSAGE_SEND_FAILED` event
- `staff-chat.gateway`: emits `chat:message:send-failed` to sender on failure
- `useChatSocket` + `UnifiedInboxPage`: `toast.error` on delivery failure + query invalidate

## Test plan
- [ ] TypeScript: `./tools/check-types.sh all` (passed locally)
- [ ] Smoke: deploy to prod, staff sends message from `/inbox` to a LINE customer → verify delivery
- [ ] Smoke: with LINE token removed → verify `toast.error` shown instead of silent ✓
- [ ] Cloud Run logs: grep for `Registered adapter:` lines on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)