### PR TITLE
feat(chat): Flex verify + sticker delivery + Customer360 drawer

### DIFF
--- a/apps/api/src/modules/chat-adapters/line-finance.adapter.ts
+++ b/apps/api/src/modules/chat-adapters/line-finance.adapter.ts
@@ -7,6 +7,7 @@ import {
   UserProfile,
 } from '../chat-engine/interfaces/channel-adapter.interface';
 import { LineFinanceClientService } from '../chatbot-finance/services/line-finance-client.service';
+import { parseStickerToken } from '../chat-engine/utils/sticker-token.util';
 
 /**
  * LINE Finance adapter — wraps LineFinanceClientService
@@ -26,7 +27,16 @@ export class LineFinanceAdapter implements IChannelAdapter {
       }
 
       if (message.text) {
-        await this.lineClient.pushText(message.externalUserId, message.text);
+        const sticker = parseStickerToken(message.text);
+        if (sticker) {
+          await this.lineClient.pushSticker(
+            message.externalUserId,
+            sticker.packageId,
+            sticker.stickerId,
+          );
+        } else {
+          await this.lineClient.pushText(message.externalUserId, message.text);
+        }
       }
       // TODO: support Flex messages via templatePayload
 

--- a/apps/api/src/modules/chat-adapters/line-shop.adapter.ts
+++ b/apps/api/src/modules/chat-adapters/line-shop.adapter.ts
@@ -6,7 +6,9 @@ import {
   SendResult,
   UserProfile,
 } from '../chat-engine/interfaces/channel-adapter.interface';
+import { parseStickerToken } from '../chat-engine/utils/sticker-token.util';
 import { LineOaService } from '../line-oa/line-oa.service';
+import type { LineMessagePayload } from '../line-oa/dto/webhook-event.dto';
 
 /**
  * LINE Shop adapter — wraps LineOaService (Shop OA)
@@ -21,11 +23,14 @@ export class LineShopAdapter implements IChannelAdapter {
 
   async sendMessage(message: OutboundMessage): Promise<SendResult> {
     try {
-      if (message.text) {
-        await this.lineOaService.pushMessage(message.externalUserId, [
-          { type: 'text', text: message.text },
-        ]);
-      }
+      if (!message.text) return { success: true };
+
+      const sticker = parseStickerToken(message.text);
+      const payload: LineMessagePayload = sticker
+        ? { type: 'sticker', packageId: sticker.packageId, stickerId: sticker.stickerId }
+        : { type: 'text', text: message.text };
+
+      await this.lineOaService.pushMessage(message.externalUserId, [payload]);
       return { success: true };
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/modules/chat-engine/utils/sticker-token.util.ts
+++ b/apps/api/src/modules/chat-engine/utils/sticker-token.util.ts
@@ -1,0 +1,28 @@
+/**
+ * Sticker token format used between Unified Inbox UI and channel adapters.
+ *
+ * The frontend sends stickers as a plain text message of the form
+ * `[sticker:<packageId>:<stickerId>]` because the chat protocol carries text
+ * only. Channel adapters detect this token and translate it into a
+ * platform-specific sticker payload (LINE sticker message, etc.). Inbound
+ * webhooks re-encode customer stickers into the same token so MessageBubble
+ * can render them as an animated image.
+ */
+
+const STICKER_RE = /^\[sticker:(\d+):(\d+)\]$/;
+
+export interface ParsedSticker {
+  packageId: string;
+  stickerId: string;
+}
+
+export function parseStickerToken(text: string | null | undefined): ParsedSticker | null {
+  if (!text) return null;
+  const m = text.trim().match(STICKER_RE);
+  if (!m) return null;
+  return { packageId: m[1], stickerId: m[2] };
+}
+
+export function formatStickerToken(packageId: string | number, stickerId: string | number): string {
+  return `[sticker:${packageId}:${stickerId}]`;
+}

--- a/apps/api/src/modules/chatbot-finance/services/chatbot-finance.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/chatbot-finance.service.spec.ts
@@ -35,6 +35,7 @@ describe('ChatbotFinanceService', () => {
     };
     lineClient = {
       replyText: jest.fn().mockResolvedValue(undefined),
+      replyMessage: jest.fn().mockResolvedValue(undefined),
       getMessageContent: jest.fn().mockResolvedValue(Buffer.from('img')),
     };
     sessions = {
@@ -101,15 +102,20 @@ describe('ChatbotFinanceService', () => {
     expect(lineClient.replyText).toHaveBeenCalledWith('rt-1', 'สวัสดีค่ะ');
   });
 
-  it('sends verify prompt when not linked', async () => {
+  it('sends verify Flex prompt when not linked', async () => {
     verification.isLinked.mockResolvedValue({ linked: false });
 
     await service.handleEvent(makeTextEvent('สวัสดี'));
 
     expect(ai.generateReply).not.toHaveBeenCalled();
-    expect(lineClient.replyText).toHaveBeenCalledWith(
+    expect(lineClient.replyMessage).toHaveBeenCalledWith(
       'rt-1',
-      expect.stringContaining('ยืนยันตัวตน'),
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'flex',
+          altText: expect.stringContaining('ยืนยันตัวตน'),
+        }),
+      ]),
     );
   });
 
@@ -153,7 +159,7 @@ describe('ChatbotFinanceService', () => {
     );
   });
 
-  it('handles follow event with greeting', async () => {
+  it('handles follow event with greeting + verify Flex', async () => {
     const followEvent = {
       type: 'follow' as const,
       mode: 'active',
@@ -166,9 +172,15 @@ describe('ChatbotFinanceService', () => {
 
     await service.handleEvent(followEvent);
 
-    expect(lineClient.replyText).toHaveBeenCalledWith(
+    expect(lineClient.replyMessage).toHaveBeenCalledWith(
       'rt-3',
-      expect.stringContaining('ยินดีให้บริการ'),
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('ยินดีให้บริการ'),
+        }),
+        expect.objectContaining({ type: 'flex' }),
+      ]),
     );
   });
 

--- a/apps/api/src/modules/chatbot-finance/services/chatbot-finance.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/chatbot-finance.service.ts
@@ -17,6 +17,7 @@ import { SlipProcessingService } from './slip-processing.service';
 import { FeedbackService } from './feedback.service';
 import { INTENTS } from '../constants/intents';
 import { buildBrowserUrl } from '../../../utils/line-login.util';
+import { formatStickerToken } from '../../chat-engine/utils/sticker-token.util';
 
 const FALLBACK_REPLY =
   'ขออภัยค่ะ ระบบขัดข้องชั่วคราว 🙏\nรบกวนติดต่อเจ้าหน้าที่ 063-134-6356 ในเวลาทำการนะคะ';
@@ -161,6 +162,14 @@ export class ChatbotFinanceService {
     );
   }
 
+  /** Customer message → plain text for inbox storage.
+   *  Stickers become [sticker:packageId:stickerId] so MessageBubble renders the image. */
+  private inboundMessageToText(message: LineMessageEvent['message']): string {
+    if (message.type === 'text') return message.text;
+    if (message.type === 'sticker') return formatStickerToken(message.packageId, message.stickerId);
+    return `[${message.type}]`;
+  }
+
   // ─── message ─────────────────────────────────────────────
 
   private async handleMessage(event: LineMessageEvent): Promise<void> {
@@ -177,12 +186,10 @@ export class ChatbotFinanceService {
     const linkStatus = await this.verification.isLinked(userId);
     if (!linkStatus.linked) {
       // บันทึก customer message ก่อน
-      const msgText =
-        event.message.type === 'text' ? event.message.text : `[${event.message.type}]`;
       await this.sessions.saveMessage({
         roomId: session.id,
         role: MessageRole.CUSTOMER,
-        text: msgText,
+        text: this.inboundMessageToText(event.message),
       });
       await this.replyVerifyFlexAndSave(
         session.id,
@@ -202,12 +209,10 @@ export class ChatbotFinanceService {
     if (await this.handoff.isInHandoffMode(session.id)) {
       this.logger.log(`[Finance] Skip — session ${session.id} in handoff mode`);
       // ยังบันทึกข้อความเพื่อ history แต่ไม่ตอบ
-      const msgText =
-        event.message.type === 'text' ? event.message.text : `[${event.message.type}]`;
       await this.sessions.saveMessage({
         roomId: session.id,
         role: MessageRole.CUSTOMER,
-        text: msgText,
+        text: this.inboundMessageToText(event.message),
       });
       return;
     }
@@ -229,6 +234,16 @@ export class ChatbotFinanceService {
       return;
     }
 
+    // Sticker → mirror as token so inbox shows the sticker image; no bot reply needed
+    if (event.message.type === 'sticker') {
+      await this.sessions.saveMessage({
+        roomId: session.id,
+        role: MessageRole.CUSTOMER,
+        text: this.inboundMessageToText(event.message),
+      });
+      return;
+    }
+
     // Other non-text → unsupported
     if (event.message.type !== 'text') {
       const msg =
@@ -237,7 +252,7 @@ export class ChatbotFinanceService {
       await this.sessions.saveMessage({
         roomId: session.id,
         role: MessageRole.CUSTOMER,
-        text: `[${event.message.type}]`,
+        text: this.inboundMessageToText(event.message),
       });
       await this.replyAndSave(session.id, event.replyToken, msg);
       return;

--- a/apps/api/src/modules/chatbot-finance/services/chatbot-finance.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/chatbot-finance.service.ts
@@ -8,7 +8,7 @@ import {
   LinePostbackEvent,
 } from '../dto/line-webhook.dto';
 import { LineFinanceClientService } from './line-finance-client.service';
-import { LineQuickReply } from './line-finance-client.service';
+import { LineQuickReply, FlexContainer } from './line-finance-client.service';
 import { ChatRoomService } from './chat-room.service';
 import { VerificationService } from './verification.service';
 import { FinanceAiService } from './finance-ai.service';
@@ -21,18 +21,15 @@ import { buildBrowserUrl } from '../../../utils/line-login.util';
 const FALLBACK_REPLY =
   'ขออภัยค่ะ ระบบขัดข้องชั่วคราว 🙏\nรบกวนติดต่อเจ้าหน้าที่ 063-134-6356 ในเวลาทำการนะคะ';
 
-// Path removed — Endpoint URL in LINE Developers is set to full path
-// https://bestchoicephone.app/liff/finance-verify
-const VERIFY_PATH = '';
-
 /** Max chars sent to Claude — prevents token bomb from oversized messages */
 const MAX_USER_TEXT_LENGTH = 2000;
+
+const VERIFY_ALT_TEXT = 'รบกวนยืนยันตัวตนก่อนนะคะ เพื่อความปลอดภัยของข้อมูลค่ะ 🔐';
 
 /**
  * Orchestration สำหรับ Finance Bot
  *
- * Verification: ใช้ LIFF (เปิด page ใน LINE) — chat แค่ส่ง link
- * LIFF URL อ่านจาก SystemConfig.liff_id (เซ็ตผ่านหน้า /settings/line-oa)
+ * Verification: ส่ง Flex card พร้อมปุ่มเปิด LINE Login OAuth → /liff/finance-verify
  */
 @Injectable()
 export class ChatbotFinanceService {
@@ -49,38 +46,76 @@ export class ChatbotFinanceService {
     private feedback: FeedbackService,
   ) {}
 
-  /**
-   * อ่าน LIFF base URL จาก SystemConfig (pattern เดียวกับ line-oa.controller)
-   * Returns null ถ้ายังไม่ได้ตั้งค่า
-   */
-  private async getLiffVerifyUrl(): Promise<string | null> {
-    const liffConfig = await this.prisma.systemConfig.findUnique({
-      where: { key: 'liff_id' },
-    });
-    if (!liffConfig?.value) return null;
-    // LIFF รองรับ path-based routing: https://liff.line.me/{liffId}{path}
-    return `https://liff.line.me/${liffConfig.value}${VERIFY_PATH}`;
-  }
-
-
-  /** ข้อความให้ลูกค้าเปิด LIFF + fallback ถ้ายังไม่ได้ตั้งค่า */
-  private async buildVerifyPrompt(): Promise<string> {
-    const url = await this.getLiffVerifyUrl();
-    const browserUrl = buildBrowserUrl('/liff/finance-verify');
-    if (!url) {
-      this.logger.warn('[Finance] LIFF ID not configured in SystemConfig');
-      return (
-        'รบกวนยืนยันตัวตนก่อนนะคะ เพื่อความปลอดภัยของข้อมูลค่ะ 🔐\n\n' +
-        `👉 ยืนยันตัวตน:\n${browserUrl}\n\n` +
-        'ใช้เวลาประมาณ 1 นาทีค่ะ'
-      );
-    }
-    return (
-      'รบกวนยืนยันตัวตนก่อนนะคะ เพื่อความปลอดภัยของข้อมูลค่ะ 🔐\n\n' +
-      `👉 ${url}\n\n` +
-      `🌐 เปิดใน browser:\n${browserUrl}\n\n` +
-      'ใช้เวลาประมาณ 1 นาทีค่ะ'
-    );
+  /** Flex card สำหรับ prompt ยืนยันตัวตน — ปุ่มเปิด LINE Login OAuth */
+  private buildVerifyFlex(): FlexContainer {
+    const verifyUrl = buildBrowserUrl('/liff/finance-verify');
+    return {
+      type: 'bubble',
+      size: 'kilo',
+      header: {
+        type: 'box',
+        layout: 'vertical',
+        backgroundColor: '#059669',
+        paddingAll: '20px',
+        contents: [
+          { type: 'text', text: 'BEST CHOICE FINANCE', color: '#FFFFFF', size: 'xxs' },
+          {
+            type: 'text',
+            text: '🔐 ยืนยันตัวตน',
+            color: '#FFFFFF',
+            size: 'xl',
+            weight: 'bold',
+            margin: 'sm',
+          },
+        ],
+      },
+      body: {
+        type: 'box',
+        layout: 'vertical',
+        spacing: 'md',
+        paddingAll: '20px',
+        contents: [
+          {
+            type: 'text',
+            text: 'รบกวนยืนยันตัวตนก่อนนะคะ เพื่อความปลอดภัยของข้อมูลค่ะ',
+            wrap: true,
+            size: 'sm',
+            color: '#1F2937',
+          },
+          {
+            type: 'box',
+            layout: 'vertical',
+            backgroundColor: '#F9FAFB',
+            cornerRadius: 'md',
+            paddingAll: '12px',
+            margin: 'md',
+            spacing: 'sm',
+            contents: [
+              { type: 'text', text: '⏱️  ใช้เวลาประมาณ 1 นาที', size: 'xs', color: '#6B7280' },
+              { type: 'text', text: '📱  กรอกเบอร์ + รับ OTP ทาง SMS', size: 'xs', color: '#6B7280' },
+            ],
+          },
+        ],
+      },
+      footer: {
+        type: 'box',
+        layout: 'vertical',
+        paddingAll: '16px',
+        contents: [
+          {
+            type: 'button',
+            style: 'primary',
+            color: '#059669',
+            height: 'sm',
+            action: {
+              type: 'uri',
+              label: 'เริ่มยืนยันตัวตน',
+              uri: verifyUrl,
+            },
+          },
+        ],
+      },
+    };
   }
 
   async handleEvent(event: LineFinanceWebhookEvent): Promise<void> {
@@ -119,11 +154,11 @@ export class ChatbotFinanceService {
       text: '[follow event]',
     });
 
-    const greeting =
-      'สวัสดีค่ะ น้องเบสยินดีให้บริการนะคะ 😊\n\n' +
-      (await this.buildVerifyPrompt());
-
-    await this.replyAndSave(session.id, event.replyToken, greeting);
+    await this.replyVerifyFlexAndSave(
+      session.id,
+      event.replyToken,
+      'สวัสดีค่ะ น้องเบสยินดีให้บริการนะคะ 😊',
+    );
   }
 
   // ─── message ─────────────────────────────────────────────
@@ -149,8 +184,12 @@ export class ChatbotFinanceService {
         role: MessageRole.CUSTOMER,
         text: msgText,
       });
-      const reply = await this.buildVerifyPrompt();
-      await this.replyAndSave(session.id, event.replyToken, reply, INTENTS.VERIFY_REQUIRED);
+      await this.replyVerifyFlexAndSave(
+        session.id,
+        event.replyToken,
+        undefined,
+        INTENTS.VERIFY_REQUIRED,
+      );
       return;
     }
 
@@ -440,5 +479,44 @@ export class ChatbotFinanceService {
     }
 
     return savedMsg.id;
+  }
+
+  /**
+   * Reply with optional text greeting + verify Flex card (2 messages in one reply).
+   * Saves both messages for session history (flex saved with altText).
+   */
+  private async replyVerifyFlexAndSave(
+    roomId: string,
+    replyToken: string,
+    greeting?: string,
+    intent: string = INTENTS.VERIFY_REQUIRED,
+  ): Promise<void> {
+    if (greeting) {
+      await this.sessions.saveMessage({
+        roomId,
+        role: MessageRole.BOT,
+        text: greeting,
+      });
+    }
+    await this.sessions.saveMessage({
+      roomId,
+      role: MessageRole.BOT,
+      text: VERIFY_ALT_TEXT,
+      intent,
+    });
+
+    try {
+      const messages = greeting
+        ? [
+            { type: 'text' as const, text: greeting },
+            { type: 'flex' as const, altText: VERIFY_ALT_TEXT, contents: this.buildVerifyFlex() },
+          ]
+        : [{ type: 'flex' as const, altText: VERIFY_ALT_TEXT, contents: this.buildVerifyFlex() }];
+      await this.lineClient.replyMessage(replyToken, messages);
+    } catch (err) {
+      this.logger.error(
+        `[Finance] verify flex reply failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 }

--- a/apps/api/src/modules/chatbot-finance/services/line-finance-client.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/line-finance-client.service.ts
@@ -8,7 +8,17 @@ interface LineTextMessage {
   quickReply?: LineQuickReply;
 }
 
-type LineMessage = LineTextMessage;
+/** LINE Flex Message — see https://developers.line.biz/en/docs/messaging-api/using-flex-messages/ */
+export type FlexContainer = Record<string, unknown>;
+
+interface LineFlexMessage {
+  type: 'flex';
+  altText: string;
+  contents: FlexContainer;
+  quickReply?: LineQuickReply;
+}
+
+type LineMessage = LineTextMessage | LineFlexMessage;
 
 export interface LineQuickReplyItem {
   type: 'action';
@@ -52,6 +62,14 @@ export class LineFinanceClientService {
 
   async replyText(replyToken: string, text: string): Promise<void> {
     return this.replyMessage(replyToken, [{ type: 'text', text }]);
+  }
+
+  async replyFlex(
+    replyToken: string,
+    altText: string,
+    contents: FlexContainer,
+  ): Promise<void> {
+    return this.replyMessage(replyToken, [{ type: 'flex', altText, contents }]);
   }
 
   async replyWithQuickReply(

--- a/apps/api/src/modules/chatbot-finance/services/line-finance-client.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/line-finance-client.service.ts
@@ -18,7 +18,14 @@ interface LineFlexMessage {
   quickReply?: LineQuickReply;
 }
 
-type LineMessage = LineTextMessage | LineFlexMessage;
+interface LineStickerMessage {
+  type: 'sticker';
+  packageId: string;
+  stickerId: string;
+  quickReply?: LineQuickReply;
+}
+
+type LineMessage = LineTextMessage | LineFlexMessage | LineStickerMessage;
 
 export interface LineQuickReplyItem {
   type: 'action';
@@ -53,6 +60,10 @@ export class LineFinanceClientService {
 
   async pushText(to: string, text: string): Promise<void> {
     return this.pushMessage(to, [{ type: 'text', text }]);
+  }
+
+  async pushSticker(to: string, packageId: string, stickerId: string): Promise<void> {
+    return this.pushMessage(to, [{ type: 'sticker', packageId, stickerId }]);
   }
 
   async pushMessage(to: string, messages: LineMessage[]): Promise<void> {

--- a/apps/api/src/modules/line-oa/dto/webhook-event.dto.ts
+++ b/apps/api/src/modules/line-oa/dto/webhook-event.dto.ts
@@ -108,4 +108,14 @@ export interface LineFlexMessagePayload {
   quickReply?: LineQuickReply;
 }
 
-export type LineMessagePayload = LineTextMessagePayload | LineFlexMessagePayload;
+export interface LineStickerMessagePayload {
+  type: 'sticker';
+  packageId: string;
+  stickerId: string;
+  quickReply?: LineQuickReply;
+}
+
+export type LineMessagePayload =
+  | LineTextMessagePayload
+  | LineFlexMessagePayload
+  | LineStickerMessagePayload;

--- a/apps/api/src/modules/line-oa/line-oa-chatbot.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa-chatbot.controller.ts
@@ -33,6 +33,7 @@ import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 import { StorageService } from '../storage/storage.service';
 import { WebhookDedupService } from '../chatbot-finance/services/webhook-dedup.service';
 import { MessageRouterService } from '../chat-engine/services/message-router.service';
+import { formatStickerToken } from '../chat-engine/utils/sticker-token.util';
 import { ChatChannel, MessageType } from '@prisma/client';
 import { toNum as d, calcOutstanding as sumOutstanding } from '../../utils/decimal.util';
 import { buildBrowserUrl } from '../../utils/line-login.util';
@@ -104,6 +105,8 @@ export class LineOaChatbotController {
           await this.handleTextMessage(msgEvent);
         } else if (msgEvent.message.type === 'image') {
           await this.handleImageMessage(msgEvent);
+        } else if (msgEvent.message.type === 'sticker') {
+          await this.handleStickerMessage(msgEvent);
         }
         break;
       }
@@ -307,6 +310,26 @@ export class LineOaChatbotController {
       await this.handleIpadUsedRedirect(event.replyToken);
     } else {
       await this.handleFreeformMessage(text, event.replyToken, userId);
+    }
+  }
+
+  // ─── Sticker Handler ──────────────────────────────────
+  // Customer-sent stickers are mirrored to Unified Inbox as a
+  // [sticker:packageId:stickerId] token so MessageBubble can render the image.
+
+  private async handleStickerMessage(event: LineMessageEvent): Promise<void> {
+    if (event.message.type !== 'sticker') return;
+    const { packageId, stickerId } = event.message;
+    try {
+      await this.messageRouter.mirrorInbound({
+        externalMessageId: event.message.id,
+        externalUserId: event.source.userId,
+        channel: ChatChannel.LINE_SHOP,
+        type: MessageType.TEXT,
+        text: formatStickerToken(packageId, stickerId),
+      });
+    } catch (err) {
+      this.logger.warn(`[SHOP mirror] sticker: ${err instanceof Error ? err.message : err}`);
     }
   }
 

--- a/apps/web/src/pages/UnifiedInboxPage/components/ChatPanel.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState, useMemo } from 'react';
 import { useDebounce } from '@/hooks/useDebounce';
-import { Send, MoreVertical, ArrowLeft, Paperclip, Smile, Pin, PinOff, MessageSquare } from 'lucide-react';
+import { Send, MoreVertical, ArrowLeft, Paperclip, Smile, Pin, PinOff, MessageSquare, UserCircle2 } from 'lucide-react';
 import { format, isSameDay } from 'date-fns';
 import { th } from 'date-fns/locale/th';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -92,6 +92,7 @@ interface ChatPanelProps {
   onResolve: () => void;
   onReturnToAI: () => void;
   currentUserId: string;
+  onShowCustomerInfo?: () => void;
 }
 
 export default function ChatPanel({
@@ -108,6 +109,7 @@ export default function ChatPanel({
   onResolve,
   onReturnToAI,
   currentUserId,
+  onShowCustomerInfo,
 }: ChatPanelProps) {
   const [inputText, setInputText] = useState('');
   const [selectedSuggestion, setSelectedSuggestion] = useState<{ aiDraft: string; intent: string } | null>(null);
@@ -348,6 +350,16 @@ export default function ChatPanel({
           </div>
         </div>
         <div className="flex items-center gap-1">
+          {onShowCustomerInfo && (
+            <button
+              onClick={onShowCustomerInfo}
+              className="xl:hidden p-1.5 text-muted-foreground hover:text-foreground/70 hover:bg-accent rounded-lg"
+              title="ข้อมูลลูกค้า"
+              aria-label="เปิดข้อมูลลูกค้า"
+            >
+              <UserCircle2 className="w-5 h-5" />
+            </button>
+          )}
           <button
             onClick={() => pinMutation.mutate(!!session.pinnedAt)}
             disabled={pinMutation.isPending}

--- a/apps/web/src/pages/UnifiedInboxPage/index.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/index.tsx
@@ -9,6 +9,7 @@ import Customer360Panel from './components/Customer360Panel';
 import { useChatSocket, type ChatMessageEvent } from './hooks/useChatSocket';
 import { useAuth } from '@/contexts/AuthContext';
 import type { InboxTab } from './components/ChannelFilter';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 
 // Sound notification
 const NOTIFICATION_SOUND_URL = 'data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YU4GAAB/f39/f39/f39/f3+AgICBgYKCg4OEhIWFhoaHh4iIiYmKiouLjIyNjY6Oj4+QkJGRkpKTk5SUlZWWlpeXmJiZmZqam5ucnJ2dnp6fn6CgoaGioqOjpKSlpaampqeop6ioqamqqqqrq6ysra2urq+vsLCxsbKys7O0tLW1tra3t7i4ubm6uru7vLy9vb6+v7/AwMHBwsLDw8TExcXGxsfHyMjJycrKy8vMzM3Nzs7Pz9DQ0dHS0tPT1NTV1dbW19fY2NnZ2tra29vc3N3d3t7f3+Dg4eHi4uPj5OTl5ebm5+fo6Onp6urr6+zs7e3u7u/v8PDx8fLy8/P09PX19vb39/j4+fn6+vv7/Pz9/f7+/v7+/v7+';
@@ -24,6 +25,7 @@ export default function UnifiedInboxPage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const [activeRoomId, setActiveRoomId] = useState<string | null>(null);
+  const [customerPanelOpen, setCustomerPanelOpen] = useState(false);
   const [filters, setFilters] = useState<{
     tab: InboxTab;
     channels: string[];
@@ -268,13 +270,29 @@ export default function UnifiedInboxPage() {
           onResolve={() => activeRoomId && resolveMutation.mutate(activeRoomId)}
           onReturnToAI={() => activeRoomId && returnToAIMutation.mutate(activeRoomId)}
           currentUserId={user?.id ?? ''}
+          onShowCustomerInfo={() => setCustomerPanelOpen(true)}
         />
       </div>
 
-      {/* Right panel: Customer 360 */}
+      {/* Right panel: Customer 360 — always visible on xl+ */}
       <div className="hidden xl:block">
         <Customer360Panel customerId={customerId} activeRoomId={activeRoomId} onSelectRoom={handleSelectRoom} />
       </div>
+
+      {/* Right panel as Drawer on < xl */}
+      <Sheet open={customerPanelOpen} onOpenChange={setCustomerPanelOpen}>
+        <SheetContent side="right" className="w-80 p-0 xl:hidden">
+          <SheetTitle className="sr-only">ข้อมูลลูกค้า</SheetTitle>
+          <Customer360Panel
+            customerId={customerId}
+            activeRoomId={activeRoomId}
+            onSelectRoom={(id) => {
+              handleSelectRoom(id);
+              setCustomerPanelOpen(false);
+            }}
+          />
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Three focused improvements for the Finance chatbot + Unified Inbox:

### 1. Flex verify prompt + drop broken LIFF URL (`6c45ece2`)
- Replaces the text-with-URLs verify prompt with an emerald-themed Flex bubble (single **เริ่มยืนยันตัวตน** button → browser URL)
- Removes the dead LIFF URL path from chatbot-finance (liff.line.me/... was not reachable); `liff_id` config preserved — still used by Rich Menu + payment_link_base_url

### 2. Native sticker delivery (`e40e782b`)
- **Bug:** Staff-sent stickers arrived at LINE customers as literal text `[sticker:11537:52002739]` because both `LineShopAdapter` and `LineFinanceAdapter` forwarded the unified-chat token as a plain text message.
- **Fix:** Shared `sticker-token.util.ts` parses the token → adapters emit `{type:'sticker', packageId, stickerId}`. Symmetric fix on inbound: Shop OA webhook now mirrors customer stickers (previously dropped) and Finance OA saves them as the token form (previously `[sticker]`), so MessageBubble renders the image in both directions.
- Updates chatbot-finance unit tests for the Flex reply path.

### 3. Customer360 drawer on <xl (`da8551a8`)
- **Bug:** At screens < 1280px the right-hand Customer 360 panel was hidden with no way to re-open it.
- **Fix:** `xl+` keeps the permanent 3-panel layout; smaller screens get a `UserCircle2` button in the ChatPanel header that slides the panel in as a right-side Sheet.

## Test plan
- [x] `./tools/check-types.sh all` → API + Web OK
- [x] `npx jest chatbot-finance.service.spec.ts` → 8/8 passing
- [x] `vite build` → clean
- [ ] Prod smoke: customer sends sticker → staff inbox shows animated sticker
- [ ] Prod smoke: staff sends sticker via Unified Inbox → LINE customer receives native sticker
- [ ] Prod smoke: Finance bot verify prompt shows Flex card with working browser-URL button
- [ ] Prod smoke: resize viewport to < 1280px → UserCircle2 button opens Customer360 drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)