### PR TITLE
chore: gitignore Claude runtime lock + ui-audit artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ backups/
 .claude/skills/**/*.pdf
 .claude/skills/**/*.png
 .claude/skills/**/*.jpg
+
+# Claude Code runtime
+.claude/scheduled_tasks.lock
+
+# UI audit tool outputs (generated artifacts)
+scripts/ui-audit/


### PR DESCRIPTION
## Summary
- เพิ่ม `.claude/scheduled_tasks.lock` (Claude Code runtime lock) ลง `.gitignore`
- เพิ่ม `scripts/ui-audit/` (UI audit tool outputs — generated) ลง `.gitignore`

## Why
ทั้งสองเป็น tooling artifacts ที่โผล่ใน VSCode Source Control ทุกครั้งที่รัน Claude Code / UI audit — ไม่ควร track ใน git

## Test plan
- [x] `git status` clean หลัง commit (ไฟล์ใน paths เหล่านี้ถูก ignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)