### PR TITLE
fix(liff): browser-fallback never retrieved id_token from cookie

### DIFF
--- a/apps/api/src/modules/line-oa/line-login.controller.ts
+++ b/apps/api/src/modules/line-oa/line-login.controller.ts
@@ -2,12 +2,13 @@ import {
   Controller,
   Get,
   Query,
+  Req,
   Res,
   Logger,
   BadRequestException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import * as Sentry from '@sentry/nestjs';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 
@@ -160,5 +161,20 @@ export class LineLoginController {
       }
       res.redirect(`${this.frontendBaseUrl}${returnPath}?login_error=true`);
     }
+  }
+
+  /**
+   * One-shot endpoint — returns id_token from httpOnly cookie then clears it.
+   * Frontend calls this right after the /callback redirect to pick up the token
+   * the callback stored. Token is then kept in JS memory for LIFF API headers.
+   */
+  @Get('id-token')
+  getIdToken(@Req() req: Request, @Res() res: Response) {
+    const token = (req.cookies as Record<string, string> | undefined)?.line_id_token;
+    res.clearCookie('line_id_token', { path: '/' });
+    if (!token) {
+      return res.status(401).json({ error: 'No id_token cookie' });
+    }
+    return res.json({ token });
   }
 }

--- a/apps/web/src/hooks/useLiffInit.ts
+++ b/apps/web/src/hooks/useLiffInit.ts
@@ -49,15 +49,29 @@ export function useLiffInit(): UseLiffInitResult {
           const userId = params.get('line_user_id');
           const displayName = params.get('line_display_name');
           const pictureUrl = params.get('line_picture');
-          const lineIdToken = params.get('line_id_token');
 
           if (userId && displayName) {
             // Clean URL — remove login params
             const cleanUrl = new URL(window.location.href);
-            ['line_login', 'line_user_id', 'line_display_name', 'line_picture', 'line_id_token'].forEach(
+            ['line_login', 'line_user_id', 'line_display_name', 'line_picture'].forEach(
               (k) => cleanUrl.searchParams.delete(k),
             );
             window.history.replaceState({}, '', cleanUrl.toString());
+
+            // Fetch id_token from one-shot cookie endpoint (httpOnly, not readable from JS)
+            let lineIdToken: string | null = null;
+            try {
+              const base = API_URL.startsWith('http') ? API_URL : `${window.location.origin}${API_URL}`;
+              const tokenRes = await fetch(`${base}/line-oa/line-login/id-token`, {
+                credentials: 'include',
+              });
+              if (tokenRes.ok) {
+                const body = (await tokenRes.json()) as { token?: string };
+                lineIdToken = body.token ?? null;
+              }
+            } catch {
+              // Cookie missing or network error — subsequent LIFF API calls will 401
+            }
 
             if (!cancelled) {
               setLineId(userId);


### PR DESCRIPTION
## Summary
หน้า LIFF ที่เปิดนอก LINE (browser fallback) โดน 401 **\"กรุณาเปิดผ่าน LINE\"** ตั้งแต่การ request-otp จนถึงทุก endpoint เพราะ frontend ไม่เคยได้ \`id_token\` มาแนบ header

**Root cause:** Callback [line-login.controller.ts:142](apps/api/src/modules/line-oa/line-login.controller.ts#L142) เก็บ id_token ใน httpOnly cookie (เพื่อเลี่ยง URL leak) แต่ [useLiffInit.ts:52](apps/web/src/hooks/useLiffInit.ts#L52) ยังอ่านจาก URL param \`line_id_token\` ที่ callback จงใจไม่ส่ง → \`setLiffIdToken(null)\` → \`X-Liff-Id-Token\` header ไม่ถูกแนบ → guard throw \`UnauthorizedException('กรุณาเปิดผ่าน LINE')\`

## Fix
- **Backend**: เพิ่ม \`GET /line-oa/line-login/id-token\` — อ่าน cookie, clear, คืน \`{ token }\`
- **Frontend**: หลัง callback redirect, fetch token ผ่าน endpoint ด้วย \`credentials: 'include'\`

Flow ใน LINE app (\`liff.getIDToken()\`) ไม่กระทบ

## Test plan
- [x] API + Web type check ผ่าน
- [ ] เปิด LIFF ใน Safari (นอก LINE) → ผ่าน LINE Login → กดส่ง OTP → ไม่ขึ้น \"กรุณาเปิดผ่าน LINE\"
- [ ] เปิด LIFF ใน LINE app → flow เดิมไม่เปลี่ยน

🤖 Generated with [Claude Code](https://claude.com/claude-code)