### PR TITLE
feat(rich-menu): multi-channel alias system (SHOP + FINANCE)

### DIFF
--- a/apps/api/src/modules/integrations/integration-registry.ts
+++ b/apps/api/src/modules/integrations/integration-registry.ts
@@ -82,6 +82,13 @@ export const INTEGRATIONS: IntegrationDef[] = [
         required: true,
         envVar: 'LINE_FINANCE_CHANNEL_SECRET',
       },
+      {
+        key: 'liffId',
+        label: 'LIFF ID',
+        sensitive: false,
+        required: false,
+        envVar: 'VITE_LIFF_ID_FINANCE',
+      },
     ],
   },
   {

--- a/apps/api/src/modules/line-oa/line-oa.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Req,
   Param,
+  Query,
   UseGuards,
   Logger,
   BadRequestException,
@@ -23,6 +24,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { PrismaService } from '../../prisma/prisma.service';
 import { PromptPayQrService } from './promptpay/promptpay-qr.service';
 import { RichMenuService } from './rich-menu/rich-menu.service';
+import { SetAliasDto } from './rich-menu/dto/set-alias.dto';
 
 /**
  * LINE OA Settings + Admin — owner-only configuration and test endpoints.
@@ -236,38 +238,46 @@ export class LineOaController {
   }
 
   // ─── Rich Menu Management (Owner) ───────────────────
+  // All endpoints accept ?channel=shop|finance (default: shop)
 
   @Get('rich-menu/list')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER')
-  async listRichMenus() {
-    const richmenus = await this.richMenuService.listRichMenus();
-    const defaultId = await this.richMenuService.getDefaultRichMenuId().catch(() => null);
+  async listRichMenus(@Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    const richmenus = await this.richMenuService.listRichMenus(ch);
+    const defaultId = await this.richMenuService.getDefaultRichMenuId(ch).catch(() => null);
     return { richmenus, defaultRichMenuId: defaultId };
   }
 
   @Get('rich-menu/default')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER')
-  async getDefaultRichMenu() {
-    const richMenuId = await this.richMenuService.getDefaultRichMenuId();
+  async getDefaultRichMenu(@Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    const richMenuId = await this.richMenuService.getDefaultRichMenuId(ch);
     return { richMenuId };
   }
 
   @Post('rich-menu/create-default')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER')
-  async createDefaultRichMenu(@Body() body: {
-    liffUrl?: string;
-    name?: string;
-    chatBarText?: string;
-    layout?: string;
-    buttons?: any[];
-  }) {
-    const result = await this.richMenuService.createCustomRichMenu({
-      ...body,
-      layout: body.layout as '2x3' | '1x3' | '2x2' | undefined,
-    });
+  async createDefaultRichMenu(
+    @Body()
+    body: {
+      liffUrl?: string;
+      name?: string;
+      chatBarText?: string;
+      layout?: string;
+      buttons?: any[];
+      channel?: string;
+    },
+  ) {
+    const ch = this.parseChannel(body.channel);
+    const result = await this.richMenuService.createCustomRichMenu(
+      { ...body, layout: body.layout as '2x3' | '1x3' | '2x2' | undefined },
+      ch,
+    );
     return { success: true, richMenuId: result.richMenuId };
   }
 
@@ -278,9 +288,11 @@ export class LineOaController {
   async uploadRichMenuImage(
     @Param('id') id: string,
     @UploadedFile() file: Express.Multer.File,
+    @Query('channel') channel?: string,
   ) {
     if (!file) throw new BadRequestException('กรุณาอัปโหลดรูปภาพ');
-    await this.richMenuService.uploadRichMenuImage(id, file.buffer);
+    const ch = this.parseChannel(channel);
+    await this.richMenuService.uploadRichMenuImage(id, file.buffer, ch);
     return { success: true, message: 'อัปโหลดรูป Rich Menu สำเร็จ' };
   }
 
@@ -288,23 +300,18 @@ export class LineOaController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER')
   @UseInterceptors(FileInterceptor('image'))
-  async createWithImage(
-    @UploadedFile() file: Express.Multer.File,
-    @Body() body: any,
-  ) {
+  async createWithImage(@UploadedFile() file: Express.Multer.File, @Body() body: any) {
     const config = typeof body.config === 'string' ? JSON.parse(body.config) : (body.config ?? {});
+    const ch = this.parseChannel(config.channel);
 
-    // 1. Create the menu structure
-    const result = await this.richMenuService.createCustomRichMenu(config);
+    const result = await this.richMenuService.createCustomRichMenu(config, ch);
 
-    // 2. Upload the image if provided
     if (file && result.richMenuId) {
-      await this.richMenuService.uploadRichMenuImage(result.richMenuId, file.buffer);
+      await this.richMenuService.uploadRichMenuImage(result.richMenuId, file.buffer, ch);
     }
 
-    // 3. Optionally set as default
     if (config.setAsDefault && result.richMenuId) {
-      await this.richMenuService.setDefaultRichMenu(result.richMenuId);
+      await this.richMenuService.setDefaultRichMenu(result.richMenuId, ch);
     }
 
     return { success: true, richMenuId: result.richMenuId };
@@ -313,16 +320,24 @@ export class LineOaController {
   @Post('rich-menu/:id/set-default')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER')
-  async setDefaultRichMenu(@Param('id') id: string) {
-    await this.richMenuService.setDefaultRichMenu(id);
+  async setDefaultRichMenu(@Param('id') id: string, @Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    await this.richMenuService.setDefaultRichMenu(id, ch);
     return { success: true, message: 'ตั้งค่า Rich Menu เริ่มต้นเรียบร้อย' };
   }
 
   @Delete('rich-menu/:id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('OWNER')
-  async deleteRichMenu(@Param('id') id: string) {
-    await this.richMenuService.deleteRichMenu(id);
+  async deleteRichMenu(@Param('id') id: string, @Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    await this.richMenuService.deleteRichMenu(id, ch);
     return { success: true, message: 'ลบ Rich Menu เรียบร้อย' };
+  }
+
+  private parseChannel(channel?: string): 'shop' | 'finance' {
+    if (channel === 'finance') return 'finance';
+    if (channel === 'shop' || channel === undefined || channel === '') return 'shop';
+    throw new BadRequestException('channel ต้องเป็น shop หรือ finance');
   }
 }

--- a/apps/api/src/modules/line-oa/line-oa.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa.controller.ts
@@ -335,6 +335,21 @@ export class LineOaController {
     return { success: true, message: 'ลบ Rich Menu เรียบร้อย' };
   }
 
+  @Get('rich-menu/aliases')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async getRichMenuAliases() {
+    return this.richMenuService.getRichMenuAliases();
+  }
+
+  @Post('rich-menu/:id/set-alias')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async setRichMenuAlias(@Param('id') id: string, @Body() dto: SetAliasDto) {
+    await this.richMenuService.setRichMenuAlias(dto.channel, dto.variant, id);
+    return { success: true, message: 'ตั้งค่า alias สำเร็จ' };
+  }
+
   private parseChannel(channel?: string): 'shop' | 'finance' {
     if (channel === 'finance') return 'finance';
     if (channel === 'shop' || channel === undefined || channel === '') return 'shop';

--- a/apps/api/src/modules/line-oa/rich-menu/dto/set-alias.dto.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/dto/set-alias.dto.ts
@@ -1,0 +1,13 @@
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+
+export class SetAliasDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุ channel' })
+  @IsIn(['shop', 'finance'], { message: 'channel ต้องเป็น shop หรือ finance' })
+  channel!: 'shop' | 'finance';
+
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุ variant' })
+  @IsIn(['default', 'verified'], { message: 'variant ต้องเป็น default หรือ verified' })
+  variant!: 'default' | 'verified';
+}

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
@@ -53,4 +53,49 @@ describe('RichMenuService', () => {
       await expect((service as any).getChannelToken('finance')).rejects.toThrow(BadRequestException);
     });
   });
+
+  describe('listRichMenus', () => {
+    const originalFetch = global.fetch;
+    afterEach(() => { global.fetch = originalFetch; });
+
+    it('uses FINANCE token when channel=finance', async () => {
+      integrationConfig.getValue.mockImplementation((key) =>
+        Promise.resolve(key === 'line-finance' ? 'finance-token' : null),
+      );
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ richmenus: [] }),
+      });
+      global.fetch = fetchMock as any;
+
+      await service.listRichMenus('finance');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/richmenu/list'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer finance-token' }),
+        }),
+      );
+    });
+
+    it('defaults to SHOP token when channel omitted', async () => {
+      integrationConfig.getValue.mockImplementation((key) =>
+        Promise.resolve(key === 'line-shop' ? 'shop-token' : null),
+      );
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ richmenus: [] }),
+      });
+      global.fetch = fetchMock as any;
+
+      await service.listRichMenus();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer shop-token' }),
+        }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { RichMenuService } from './rich-menu.service';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { IntegrationConfigService } from '../../integrations/integration-config.service';
+
+describe('RichMenuService', () => {
+  let service: RichMenuService;
+  let integrationConfig: { getValue: jest.Mock };
+
+  beforeEach(async () => {
+    integrationConfig = { getValue: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RichMenuService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: PrismaService, useValue: { systemConfig: { findFirst: jest.fn(), upsert: jest.fn() } } },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
+      ],
+    }).compile();
+
+    service = module.get<RichMenuService>(RichMenuService);
+  });
+
+  describe('getChannelToken', () => {
+    it('returns SHOP token when channel=shop', async () => {
+      integrationConfig.getValue.mockImplementation((key, field) =>
+        Promise.resolve(key === 'line-shop' && field === 'channelToken' ? 'shop-token-123' : null),
+      );
+
+      const token = await (service as any).getChannelToken('shop');
+
+      expect(integrationConfig.getValue).toHaveBeenCalledWith('line-shop', 'channelToken');
+      expect(token).toBe('shop-token-123');
+    });
+
+    it('returns FINANCE token when channel=finance', async () => {
+      integrationConfig.getValue.mockImplementation((key, field) =>
+        Promise.resolve(key === 'line-finance' && field === 'channelToken' ? 'finance-token-456' : null),
+      );
+
+      const token = await (service as any).getChannelToken('finance');
+
+      expect(integrationConfig.getValue).toHaveBeenCalledWith('line-finance', 'channelToken');
+      expect(token).toBe('finance-token-456');
+    });
+
+    it('throws BadRequestException when token not configured', async () => {
+      integrationConfig.getValue.mockResolvedValue(null);
+
+      await expect((service as any).getChannelToken('finance')).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
@@ -54,6 +54,69 @@ describe('RichMenuService', () => {
     });
   });
 
+  describe('setRichMenuAlias', () => {
+    it('writes SystemConfig with correct key for shop/default', async () => {
+      const prismaUpsert = jest.fn().mockResolvedValue({});
+      (service as any).prisma = {
+        systemConfig: { upsert: prismaUpsert, findFirst: jest.fn() },
+      };
+      // Mock setDefaultRichMenu (variant=default triggers LINE API)
+      const setDefaultSpy = jest.spyOn(service, 'setDefaultRichMenu').mockResolvedValue(undefined);
+
+      await service.setRichMenuAlias('shop', 'default', 'rm-123');
+
+      expect(prismaUpsert).toHaveBeenCalledWith({
+        where: { key: 'line.richMenu.shopDefault' },
+        create: { key: 'line.richMenu.shopDefault', value: 'rm-123' },
+        update: { value: 'rm-123', deletedAt: null },
+      });
+      expect(setDefaultSpy).toHaveBeenCalledWith('rm-123', 'shop');
+    });
+
+    it('writes SystemConfig for finance/verified without calling setDefaultRichMenu', async () => {
+      const prismaUpsert = jest.fn().mockResolvedValue({});
+      (service as any).prisma = {
+        systemConfig: { upsert: prismaUpsert, findFirst: jest.fn() },
+      };
+      const setDefaultSpy = jest.spyOn(service, 'setDefaultRichMenu').mockResolvedValue(undefined);
+
+      await service.setRichMenuAlias('finance', 'verified', 'rm-456');
+
+      expect(prismaUpsert).toHaveBeenCalledWith({
+        where: { key: 'line.richMenu.financeVerified' },
+        create: { key: 'line.richMenu.financeVerified', value: 'rm-456' },
+        update: { value: 'rm-456', deletedAt: null },
+      });
+      expect(setDefaultSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRichMenuAliases', () => {
+    it('returns all 4 alias values with null for missing keys', async () => {
+      const prismaFindFirst = jest.fn().mockImplementation(({ where }) => {
+        if (where.key === 'line.richMenu.shopDefault') {
+          return Promise.resolve({ value: 'rm-shop-default' });
+        }
+        if (where.key === 'line.richMenu.financeVerified') {
+          return Promise.resolve({ value: 'rm-finance-verified' });
+        }
+        return Promise.resolve(null);
+      });
+      (service as any).prisma = {
+        systemConfig: { findFirst: prismaFindFirst, upsert: jest.fn() },
+      };
+
+      const aliases = await service.getRichMenuAliases();
+
+      expect(aliases).toEqual({
+        shopDefault: 'rm-shop-default',
+        shopVerified: null,
+        financeDefault: null,
+        financeVerified: 'rm-finance-verified',
+      });
+    });
+  });
+
   describe('listRichMenus', () => {
     const originalFetch = global.fetch;
     afterEach(() => { global.fetch = originalFetch; });

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
@@ -113,7 +113,7 @@ export class RichMenuService {
       ],
     };
 
-    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, richMenu);
+    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, richMenu, 'shop');
     const data = await response.json();
     this.logger.log(`SHOP Rich Menu created: ${data.richMenuId}`);
     return data.richMenuId;
@@ -168,7 +168,7 @@ export class RichMenuService {
       ],
     };
 
-    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, richMenu);
+    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, richMenu, 'finance');
     const data = await response.json();
     this.logger.log(`FINANCE Rich Menu created: ${data.richMenuId}`);
     return data.richMenuId;
@@ -198,7 +198,10 @@ export class RichMenuService {
    * Create a fully customizable rich menu.
    * Supports 2x3 (default), 1x3, and 2x2 layouts with custom buttons and actions.
    */
-  async createCustomRichMenu(params: CreateMenuParams): Promise<{ richMenuId: string }> {
+  async createCustomRichMenu(
+    params: CreateMenuParams,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<{ richMenuId: string }> {
     const {
       name = 'BESTCHOICE Menu',
       chatBarText = 'เมนู',
@@ -273,9 +276,9 @@ export class RichMenuService {
       areas,
     };
 
-    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, body);
+    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, body, channel);
     const data = await response.json();
-    this.logger.log(`Custom Rich Menu created: ${data.richMenuId} (layout=${layout})`);
+    this.logger.log(`Custom Rich Menu created: ${data.richMenuId} (layout=${layout}, channel=${channel})`);
     return { richMenuId: data.richMenuId };
   }
 
@@ -294,12 +297,8 @@ export class RichMenuService {
   /**
    * Get current default Rich Menu ID
    */
-  async getDefaultRichMenuId(): Promise<string | null> {
-    const token = await this.getShopChannelToken();
-    if (!token) {
-      throw new BadRequestException('LINE channel access token not configured');
-    }
-
+  async getDefaultRichMenuId(channel: 'shop' | 'finance' = 'shop'): Promise<string | null> {
+    const token = await this.getChannelToken(channel);
     const url = `${this.lineApiBaseUrl}/user/all/richmenu`;
     const response = await fetch(url, {
       method: 'GET',
@@ -307,9 +306,7 @@ export class RichMenuService {
       signal: AbortSignal.timeout(15000),
     });
 
-    if (response.status === 404) {
-      return null;
-    }
+    if (response.status === 404) return null;
 
     if (!response.ok) {
       const errorBody = await response.text();
@@ -324,92 +321,81 @@ export class RichMenuService {
    * Upload Rich Menu image
    * The image should be 2500x1686 pixels, JPEG or PNG
    */
-  async uploadRichMenuImage(richMenuId: string, imageBuffer: Buffer): Promise<void> {
-    const token = await this.getShopChannelToken();
-    if (!token) {
-      throw new BadRequestException('LINE channel access token not configured');
-    }
-
+  async uploadRichMenuImage(
+    richMenuId: string,
+    imageBuffer: Buffer,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
     const url = `https://api-data.line.me/v2/bot/richmenu/${richMenuId}/content`;
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'image/png',
-      },
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'image/png' },
       body: new Uint8Array(imageBuffer),
       signal: AbortSignal.timeout(15000),
     });
-
     if (!response.ok) {
       const errorBody = await response.text();
       throw new InternalServerErrorException(`Failed to upload Rich Menu image: ${response.status} ${errorBody}`);
     }
-
-    this.logger.log(`Rich Menu image uploaded for ${richMenuId}`);
+    this.logger.log(`Rich Menu image uploaded for ${richMenuId} (channel=${channel})`);
   }
 
   /**
    * Set default Rich Menu for all users
    */
-  async setDefaultRichMenu(richMenuId: string): Promise<void> {
-    const token = await this.getShopChannelToken();
+  async setDefaultRichMenu(
+    richMenuId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
     const url = `${this.lineApiBaseUrl}/user/all/richmenu/${richMenuId}`;
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(15000),
     });
-
     if (!response.ok) {
       const errorBody = await response.text();
       throw new InternalServerErrorException(`Failed to set default Rich Menu: ${response.status} ${errorBody}`);
     }
-
-    this.logger.log(`Default Rich Menu set to ${richMenuId}`);
+    this.logger.log(`Default Rich Menu set to ${richMenuId} (channel=${channel})`);
   }
 
   /**
    * Delete a Rich Menu
    */
-  async deleteRichMenu(richMenuId: string): Promise<void> {
-    const token = await this.getShopChannelToken();
+  async deleteRichMenu(
+    richMenuId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
     const url = `${this.lineApiBaseUrl}/richmenu/${richMenuId}`;
     const response = await fetch(url, {
       method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(15000),
     });
-
     if (!response.ok) {
       const errorBody = await response.text();
       throw new InternalServerErrorException(`Failed to delete Rich Menu: ${response.status} ${errorBody}`);
     }
-
-    this.logger.log(`Rich Menu deleted: ${richMenuId}`);
+    this.logger.log(`Rich Menu deleted: ${richMenuId} (channel=${channel})`);
   }
 
   /**
    * List all Rich Menus
    */
-  async listRichMenus(): Promise<unknown[]> {
-    const token = await this.getShopChannelToken();
+  async listRichMenus(channel: 'shop' | 'finance' = 'shop'): Promise<unknown[]> {
+    const token = await this.getChannelToken(channel);
     const url = `${this.lineApiBaseUrl}/richmenu/list`;
     const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(15000),
     });
-
     if (!response.ok) {
       throw new InternalServerErrorException(`Failed to list Rich Menus: ${response.status}`);
     }
-
     const data = await response.json();
     return data.richmenus || [];
   }
@@ -417,59 +403,50 @@ export class RichMenuService {
   /**
    * Link a specific Rich Menu to a LINE user
    */
-  async linkRichMenuToUser(userId: string, richMenuId: string): Promise<void> {
-    const token = await this.getShopChannelToken();
+  async linkRichMenuToUser(
+    userId: string,
+    richMenuId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
     const url = `${this.lineApiBaseUrl}/user/${userId}/richmenu/${richMenuId}`;
     const response = await fetch(url, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(15000),
     });
-
-    if (response.status === 404) {
-      // User may have blocked the OA — ignore silently
-      return;
-    }
-
+    if (response.status === 404) return;
     if (!response.ok) {
       const errorBody = await response.text();
       throw new InternalServerErrorException(
         `Failed to link Rich Menu to user ${userId}: ${response.status} ${errorBody}`,
       );
     }
-
-    this.logger.log(`Rich Menu ${richMenuId} linked to user ${userId}`);
+    this.logger.log(`Rich Menu ${richMenuId} linked to user ${userId} (channel=${channel})`);
   }
 
   /**
    * Unlink Rich Menu from a LINE user (revert to default)
    */
-  async unlinkRichMenuFromUser(userId: string): Promise<void> {
-    const token = await this.getShopChannelToken();
+  async unlinkRichMenuFromUser(
+    userId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
     const url = `${this.lineApiBaseUrl}/user/${userId}/richmenu`;
     const response = await fetch(url, {
       method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(15000),
     });
-
-    if (response.status === 404) {
-      // No menu linked — ignore
-      return;
-    }
-
+    if (response.status === 404) return;
     if (!response.ok) {
       const errorBody = await response.text();
       throw new InternalServerErrorException(
         `Failed to unlink Rich Menu from user ${userId}: ${response.status} ${errorBody}`,
       );
     }
-
-    this.logger.log(`Rich Menu unlinked from user ${userId}`);
+    this.logger.log(`Rich Menu unlinked from user ${userId} (channel=${channel})`);
   }
 
   /**
@@ -501,15 +478,15 @@ export class RichMenuService {
       return;
     }
 
-    await this.linkRichMenuToUser(userId, richMenuId);
+    await this.linkRichMenuToUser(userId, richMenuId, channel);
   }
 
-  private async callLineApi(url: string, body: unknown): Promise<Response> {
-    const token = await this.getShopChannelToken();
-    if (!token) {
-      throw new BadRequestException('LINE channel access token not configured');
-    }
-
+  private async callLineApi(
+    url: string,
+    body: unknown,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<Response> {
+    const token = await this.getChannelToken(channel);
     const response = await fetch(url, {
       method: 'POST',
       headers: {
@@ -519,12 +496,10 @@ export class RichMenuService {
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(15000),
     });
-
     if (!response.ok) {
       const errorBody = await response.text();
       throw new InternalServerErrorException(`LINE API error ${response.status}: ${errorBody}`);
     }
-
     return response;
   }
 }

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
@@ -48,8 +48,20 @@ export class RichMenuService {
     private integrationConfig: IntegrationConfigService,
   ) {}
 
+  private async getChannelToken(channel: 'shop' | 'finance' = 'shop'): Promise<string> {
+    const key = channel === 'shop' ? 'line-shop' : 'line-finance';
+    const token = await this.integrationConfig.getValue(key, 'channelToken');
+    if (!token) {
+      throw new BadRequestException(
+        `LINE ${channel === 'shop' ? 'SHOP' : 'FINANCE'} channel token ยังไม่ถูกตั้งค่า — กรุณาไปที่ /settings/integrations`,
+      );
+    }
+    return token;
+  }
+
+  /** @deprecated Use getChannelToken('shop') instead */
   private async getShopChannelToken(): Promise<string> {
-    return (await this.integrationConfig.getValue('line-shop', 'channelToken')) || '';
+    return this.getChannelToken('shop');
   }
 
   /**

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
@@ -502,4 +502,58 @@ export class RichMenuService {
     }
     return response;
   }
+
+  /**
+   * Set Rich Menu alias for a channel/variant combination.
+   * Writes SystemConfig key `line.richMenu.{channel}{Variant}`.
+   * For variant='default', also calls LINE setDefaultRichMenu (new friends see this menu).
+   */
+  async setRichMenuAlias(
+    channel: 'shop' | 'finance',
+    variant: 'default' | 'verified',
+    richMenuId: string,
+  ): Promise<void> {
+    const variantPart = variant === 'default' ? 'Default' : 'Verified';
+    const key = `line.richMenu.${channel}${variantPart}`;
+
+    await this.prisma.systemConfig.upsert({
+      where: { key },
+      create: { key, value: richMenuId },
+      update: { value: richMenuId, deletedAt: null },
+    });
+
+    if (variant === 'default') {
+      await this.setDefaultRichMenu(richMenuId, channel);
+    }
+
+    this.logger.log(`Rich Menu alias set: ${key} = ${richMenuId}`);
+  }
+
+  /**
+   * Read all 4 Rich Menu aliases from SystemConfig.
+   */
+  async getRichMenuAliases(): Promise<{
+    shopDefault: string | null;
+    shopVerified: string | null;
+    financeDefault: string | null;
+    financeVerified: string | null;
+  }> {
+    const keys = [
+      'line.richMenu.shopDefault',
+      'line.richMenu.shopVerified',
+      'line.richMenu.financeDefault',
+      'line.richMenu.financeVerified',
+    ];
+    const records = await Promise.all(
+      keys.map((key) =>
+        this.prisma.systemConfig.findFirst({ where: { key, deletedAt: null } }),
+      ),
+    );
+    return {
+      shopDefault: records[0]?.value ?? null,
+      shopVerified: records[1]?.value ?? null,
+      financeDefault: records[2]?.value ?? null,
+      financeVerified: records[3]?.value ?? null,
+    };
+  }
 }

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
@@ -59,11 +59,6 @@ export class RichMenuService {
     return token;
   }
 
-  /** @deprecated Use getChannelToken('shop') instead */
-  private async getShopChannelToken(): Promise<string> {
-    return this.getChannelToken('shop');
-  }
-
   /**
    * BESTCHOICE SHOP Rich Menu (2026 Brand — v3)
    * Layout: 2 rows x 3 columns (2500x1686)

--- a/apps/web/src/pages/RichMenuPage.tsx
+++ b/apps/web/src/pages/RichMenuPage.tsx
@@ -75,11 +75,13 @@ function PhonePreview({
   selectedButton,
   onSelectButton,
   layout,
+  hasCustomImage = false,
 }: {
   buttons: MenuButton[];
   selectedButton: number;
   onSelectButton: (i: number) => void;
   layout: LayoutType;
+  hasCustomImage?: boolean;
 }) {
   const layoutCfg = LAYOUT_OPTIONS.find((l) => l.value === layout) ?? LAYOUT_OPTIONS[0];
   const visibleButtons = buttons.slice(0, layoutCfg.cols * layoutCfg.rows);
@@ -127,17 +129,23 @@ function PhonePreview({
                 <button
                   key={i}
                   onClick={() => onSelectButton(i)}
-                  aria-label={btn.label || `เลือกปุ่ม ${i + 1}`}
+                  aria-label={`เลือกช่อง ${i + 1}`}
                   className="relative flex flex-col items-center justify-center py-3 gap-1 transition-all hover:brightness-90 focus:outline-none"
-                  style={{ backgroundColor: btn.color }}
+                  style={{ backgroundColor: hasCustomImage ? '#9ca3af' : btn.color }}
                 >
                   {i === selectedButton && (
                     <div className="absolute inset-0 border-2 border-primary rounded-sm z-10 pointer-events-none" />
                   )}
-                  <span className="text-lg leading-snug">{btn.emoji}</span>
-                  <span className="text-white text-[9px] font-semibold leading-tight px-1 text-center">
-                    {btn.label}
-                  </span>
+                  {hasCustomImage ? (
+                    <span className="text-white text-xs font-bold">ช่อง {i + 1}</span>
+                  ) : (
+                    <>
+                      <span className="text-lg leading-snug">{btn.emoji}</span>
+                      <span className="text-white text-[9px] font-semibold leading-tight px-1 text-center">
+                        {btn.label}
+                      </span>
+                    </>
+                  )}
                 </button>
               ))}
             </div>
@@ -166,6 +174,7 @@ function ButtonEditor({
   onUpdateButton,
   layout,
   onLayoutChange,
+  hasCustomImage = false,
 }: {
   buttons: MenuButton[];
   selectedButton: number;
@@ -173,6 +182,7 @@ function ButtonEditor({
   onUpdateButton: (i: number, updates: Partial<MenuButton>) => void;
   layout: LayoutType;
   onLayoutChange: (l: LayoutType) => void;
+  hasCustomImage?: boolean;
 }) {
   const layoutCfg = LAYOUT_OPTIONS.find((l) => l.value === layout) ?? LAYOUT_OPTIONS[0];
   const visibleCount = layoutCfg.cols * layoutCfg.rows;
@@ -198,7 +208,7 @@ function ButtonEditor({
 
       {/* Button tabs */}
       <div>
-        <label className="block text-sm font-medium text-foreground mb-1.5">เลือกปุ่ม</label>
+        <label className="block text-sm font-medium text-foreground mb-1.5">เลือกช่อง</label>
         <div className="flex flex-wrap gap-1.5">
           {buttons.slice(0, visibleCount).map((b, i) => (
             <button
@@ -209,10 +219,20 @@ function ButtonEditor({
                   ? 'border-transparent text-white shadow-sm'
                   : 'border-border bg-background text-muted-foreground hover:border-primary/50'
               }`}
-              style={i === selectedButton ? { backgroundColor: b.color } : {}}
+              style={
+                i === selectedButton
+                  ? { backgroundColor: hasCustomImage ? 'hsl(var(--primary))' : b.color }
+                  : {}
+              }
             >
-              <span>{b.emoji}</span>
-              <span>{b.label}</span>
+              {hasCustomImage ? (
+                <span>ช่อง {i + 1}</span>
+              ) : (
+                <>
+                  <span>{b.emoji}</span>
+                  <span>{b.label}</span>
+                </>
+              )}
             </button>
           ))}
         </div>
@@ -223,53 +243,63 @@ function ButtonEditor({
         <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
           <div
             className="flex items-center gap-2 pb-2 border-b border-border"
-            style={{ color: btn.color }}
+            style={{ color: hasCustomImage ? 'hsl(var(--foreground))' : btn.color }}
           >
-            <span className="text-lg">{btn.emoji}</span>
-            <span className="font-semibold text-sm">ปุ่มที่ {selectedButton + 1}: {btn.label}</span>
+            {hasCustomImage ? (
+              <span className="font-semibold text-sm">ช่องที่ {selectedButton + 1}</span>
+            ) : (
+              <>
+                <span className="text-lg">{btn.emoji}</span>
+                <span className="font-semibold text-sm">ปุ่มที่ {selectedButton + 1}: {btn.label}</span>
+              </>
+            )}
           </div>
 
-          {/* Emoji */}
-          <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1">ไอคอน (Emoji)</label>
-            <Input
-              value={btn.emoji}
-              onChange={(e) => onUpdateButton(selectedButton, { emoji: e.target.value })}
-              className="w-16 text-center text-lg"
-              maxLength={2}
-            />
-          </div>
-
-          {/* Label */}
-          <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1">ชื่อปุ่ม</label>
-            <Input
-              value={btn.label}
-              onChange={(e) => onUpdateButton(selectedButton, { label: e.target.value })}
-              placeholder="เช่น ดูสินค้า"
-              maxLength={12}
-            />
-            <p className="text-xs text-muted-foreground mt-0.5">{btn.label.length}/12 ตัวอักษร</p>
-          </div>
-
-          {/* Color */}
-          <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1.5">สีพื้นหลัง</label>
-            <div className="flex flex-wrap gap-1.5">
-              {COLOR_PRESETS.map((preset) => (
-                <button
-                  key={preset.value}
-                  onClick={() => onUpdateButton(selectedButton, { color: preset.value })}
-                  title={preset.name}
-                  aria-label={preset.name}
-                  className={`w-7 h-7 rounded-full border-2 transition-transform hover:scale-110 ${
-                    btn.color === preset.value ? 'border-foreground scale-110' : 'border-transparent'
-                  }`}
-                  style={{ backgroundColor: preset.value }}
+          {!hasCustomImage && (
+            <>
+              {/* Emoji */}
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">ไอคอน (Emoji)</label>
+                <Input
+                  value={btn.emoji}
+                  onChange={(e) => onUpdateButton(selectedButton, { emoji: e.target.value })}
+                  className="w-16 text-center text-lg"
+                  maxLength={2}
                 />
-              ))}
-            </div>
-          </div>
+              </div>
+
+              {/* Label */}
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">ชื่อปุ่ม</label>
+                <Input
+                  value={btn.label}
+                  onChange={(e) => onUpdateButton(selectedButton, { label: e.target.value })}
+                  placeholder="เช่น ดูสินค้า"
+                  maxLength={12}
+                />
+                <p className="text-xs text-muted-foreground mt-0.5">{btn.label.length}/12 ตัวอักษร</p>
+              </div>
+
+              {/* Color */}
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1.5">สีพื้นหลัง</label>
+                <div className="flex flex-wrap gap-1.5">
+                  {COLOR_PRESETS.map((preset) => (
+                    <button
+                      key={preset.value}
+                      onClick={() => onUpdateButton(selectedButton, { color: preset.value })}
+                      title={preset.name}
+                      aria-label={preset.name}
+                      className={`w-7 h-7 rounded-full border-2 transition-transform hover:scale-110 ${
+                        btn.color === preset.value ? 'border-foreground scale-110' : 'border-transparent'
+                      }`}
+                      style={{ backgroundColor: preset.value }}
+                    />
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
 
           {/* Action type */}
           <div>
@@ -636,6 +666,7 @@ export default function RichMenuPage() {
                 selectedButton={selectedButton}
                 onSelectButton={setSelectedButton}
                 layout={layout}
+                hasCustomImage={customImageFile !== null}
               />
 
               {/* Button Editor */}
@@ -646,6 +677,7 @@ export default function RichMenuPage() {
                 onUpdateButton={updateButton}
                 layout={layout}
                 onLayoutChange={setLayout}
+                hasCustomImage={customImageFile !== null}
               />
             </div>
           </div>

--- a/apps/web/src/pages/RichMenuPage.tsx
+++ b/apps/web/src/pages/RichMenuPage.tsx
@@ -9,6 +9,12 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -387,7 +393,6 @@ export default function RichMenuPage() {
       };
     },
   });
-  void aliases; // consumed in Task 10
 
   const shopLiffId = lineSettings?.settings?.liff_id;
   const financeLiffId = financeIntegration?.config?.liffId;
@@ -426,6 +431,7 @@ export default function RichMenuPage() {
             layout,
             buttons: visibleButtons,
             setAsDefault: true,
+            channel,
           }),
         );
         const res = await api.post('/line-oa/rich-menu/create-with-image', fd, {
@@ -441,6 +447,7 @@ export default function RichMenuPage() {
         chatBarText,
         layout,
         buttons: visibleButtons,
+        channel,
       });
       return res.data as { richMenuId: string };
     },
@@ -450,19 +457,18 @@ export default function RichMenuPage() {
       if (editingMenuId) {
         const oldMenuId = editingMenuId;
         try {
-          // Set new menu as default first
           if (data?.richMenuId) {
-            await api.post(`/line-oa/rich-menu/${data.richMenuId}/set-default`);
+            await api.post(`/line-oa/rich-menu/${data.richMenuId}/set-default?channel=${channel}`);
           }
-          // Delete old menu
-          await api.delete(`/line-oa/rich-menu/${oldMenuId}`);
+          await api.delete(`/line-oa/rich-menu/${oldMenuId}?channel=${channel}`);
         } catch (err) {
           console.error('Failed to cleanup old menu', err);
         }
         setEditingMenuId(null);
       }
 
-      queryClient.invalidateQueries({ queryKey: ['rich-menu-list'] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
       setActiveTab('list');
     },
     onError: (err) => toast.error(getErrorMessage(err)),
@@ -470,22 +476,24 @@ export default function RichMenuPage() {
 
   const setDefaultMutation = useMutation({
     mutationFn: async (menuId: string) => {
-      await api.post(`/line-oa/rich-menu/${menuId}/set-default`);
+      await api.post(`/line-oa/rich-menu/${menuId}/set-default?channel=${channel}`);
     },
     onSuccess: () => {
       toast.success('ตั้งเป็น Default แล้ว');
-      queryClient.invalidateQueries({ queryKey: ['rich-menu-list'] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   const deleteMutation = useMutation({
     mutationFn: async (menuId: string) => {
-      await api.delete(`/line-oa/rich-menu/${menuId}`);
+      await api.delete(`/line-oa/rich-menu/${menuId}?channel=${channel}`);
     },
     onSuccess: () => {
       toast.success('ลบ Rich Menu แล้ว');
-      queryClient.invalidateQueries({ queryKey: ['rich-menu-list'] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   });
@@ -494,13 +502,25 @@ export default function RichMenuPage() {
     mutationFn: async ({ menuId, file }: { menuId: string; file: File }) => {
       const formData = new FormData();
       formData.append('image', file);
-      await api.post(`/line-oa/rich-menu/${menuId}/upload-image`, formData, {
+      await api.post(`/line-oa/rich-menu/${menuId}/upload-image?channel=${channel}`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
     },
     onSuccess: () => {
       toast.success('อัปโหลดรูป Rich Menu สำเร็จ');
-      queryClient.invalidateQueries({ queryKey: ['rich-menu-list'] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const setAliasMutation = useMutation({
+    mutationFn: async ({ menuId, variant }: { menuId: string; variant: 'default' | 'verified' }) => {
+      await api.post(`/line-oa/rich-menu/${menuId}/set-alias`, { channel, variant });
+    },
+    onSuccess: (_, vars) => {
+      toast.success(`ตั้งเป็น ${vars.variant === 'default' ? 'Default' : 'Verified'} แล้ว`);
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   });
@@ -798,18 +818,25 @@ export default function RichMenuPage() {
             </div>
           ) : (
             data.menus.map((menu) => {
-              const isDefault = menu.richMenuId === data.defaultMenuId;
+              const channelAliases = aliases
+                ? {
+                    default: channel === 'shop' ? aliases.shopDefault : aliases.financeDefault,
+                    verified: channel === 'shop' ? aliases.shopVerified : aliases.financeVerified,
+                  }
+                : { default: null, verified: null };
+              const isDefault = menu.richMenuId === channelAliases.default;
+              const isVerified = menu.richMenuId === channelAliases.verified;
               return (
                 <div
                   key={menu.richMenuId}
                   className={`rounded-xl border shadow-sm hover:shadow-md transition-shadow bg-card overflow-hidden ${
-                    isDefault ? 'border-success/30' : 'border-border/50'
+                    isDefault || isVerified ? 'border-success/30' : 'border-border/50'
                   }`}
                 >
-                  <div className={`px-5 py-3 ${isDefault ? 'bg-success/10' : 'bg-muted/20'}`}>
+                  <div className={`px-5 py-3 ${isDefault || isVerified ? 'bg-success/10' : 'bg-muted/20'}`}>
                     <div className="flex items-center justify-between gap-3">
                       <div className="flex items-center gap-3 min-w-0">
-                        {isDefault && (
+                        {(isDefault || isVerified) && (
                           <Star size={16} className="text-success shrink-0" fill="currentColor" />
                         )}
                         <div className="min-w-0">
@@ -820,22 +847,40 @@ export default function RichMenuPage() {
                         </div>
                         {isDefault && (
                           <Badge className="bg-success/10 text-success hover:bg-success/10 border-success/30 shrink-0">
-                            Default
+                            ⭐ Default
+                          </Badge>
+                        )}
+                        {isVerified && (
+                          <Badge className="bg-primary/10 text-primary hover:bg-primary/10 border-primary/30 shrink-0">
+                            ✓ Verified
                           </Badge>
                         )}
                       </div>
                       <div className="flex flex-wrap items-center gap-2 shrink-0">
-                        {!isDefault && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => setDefaultMutation.mutate(menu.richMenuId)}
-                            disabled={setDefaultMutation.isPending}
-                          >
-                            <Star size={13} className="mr-1" />
-                            ตั้งเป็น Default
-                          </Button>
-                        )}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button size="sm" variant="outline">
+                              <Star size={13} className="mr-1" />
+                              ตั้งเป็น...
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() =>
+                                setAliasMutation.mutate({ menuId: menu.richMenuId, variant: 'default' })
+                              }
+                            >
+                              ⭐ Default (ลูกค้าใหม่)
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() =>
+                                setAliasMutation.mutate({ menuId: menu.richMenuId, variant: 'verified' })
+                              }
+                            >
+                              ✓ Verified (ลูกค้าที่ verify แล้ว)
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                         <Button
                           size="sm"
                           variant="outline"

--- a/apps/web/src/pages/RichMenuPage.tsx
+++ b/apps/web/src/pages/RichMenuPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { LayoutGrid, Trash2, Star, Upload, Plus, ImageIcon, Pencil, Copy } from 'lucide-react';
@@ -341,12 +341,19 @@ export default function RichMenuPage() {
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [editingMenuId, setEditingMenuId] = useState<string | null>(null);
 
+  useEffect(() => {
+    setLiffUrl('');
+    setEditingMenuId(null);
+    setCustomImageFile(null);
+    setCustomImagePreview(null);
+  }, [channel]);
+
   // ── Queries ──────────────────────────────────────────────────────────────
 
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ['rich-menu-list'],
+    queryKey: ['rich-menu-list', channel],
     queryFn: async () => {
-      const res = await api.get('/line-oa/rich-menu/list');
+      const res = await api.get(`/line-oa/rich-menu/list?channel=${channel}`);
       return res.data as RichMenuListResponse;
     },
     retry: 1,
@@ -360,10 +367,32 @@ export default function RichMenuPage() {
     },
   });
 
-  const defaultLiffUrl = lineSettings?.settings?.liff_id
-    ? `https://liff.line.me/${lineSettings.settings.liff_id}`
-    : '';
+  const { data: financeIntegration } = useQuery({
+    queryKey: ['integration-config', 'line-finance'],
+    queryFn: async () => {
+      const res = await api.get('/integrations/line-finance/config');
+      return res.data as { config: Record<string, string> };
+    },
+  });
 
+  const { data: aliases } = useQuery({
+    queryKey: ['rich-menu-aliases'],
+    queryFn: async () => {
+      const res = await api.get('/line-oa/rich-menu/aliases');
+      return res.data as {
+        shopDefault: string | null;
+        shopVerified: string | null;
+        financeDefault: string | null;
+        financeVerified: string | null;
+      };
+    },
+  });
+  void aliases; // consumed in Task 10
+
+  const shopLiffId = lineSettings?.settings?.liff_id;
+  const financeLiffId = financeIntegration?.config?.liffId;
+  const activeLiffId = channel === 'shop' ? shopLiffId : financeLiffId;
+  const defaultLiffUrl = activeLiffId ? `https://liff.line.me/${activeLiffId}` : '';
   const effectiveLiffUrl = liffUrl || defaultLiffUrl;
 
   // ── Mutations ─────────────────────────────────────────────────────────────

--- a/apps/web/src/pages/RichMenuPage.tsx
+++ b/apps/web/src/pages/RichMenuPage.tsx
@@ -26,8 +26,8 @@ interface RichMenu {
 }
 
 interface RichMenuListResponse {
-  menus: RichMenu[];
-  defaultMenuId: string | null;
+  richmenus: RichMenu[];
+  defaultRichMenuId: string | null;
 }
 
 interface MenuButton {
@@ -799,7 +799,7 @@ export default function RichMenuPage() {
             <div className="rounded-xl border border-border/50 bg-card shadow-sm p-10 text-center">
               <div className="text-sm text-muted-foreground">กำลังโหลด...</div>
             </div>
-          ) : !data?.menus?.length ? (
+          ) : !data?.richmenus?.length ? (
             <div className="rounded-xl border border-border/50 bg-card shadow-sm p-12 text-center">
               <LayoutGrid size={40} className="mx-auto mb-3 text-muted-foreground/40" />
               <p className="text-sm font-medium text-muted-foreground">ยังไม่มี Rich Menu</p>
@@ -817,7 +817,7 @@ export default function RichMenuPage() {
               </Button>
             </div>
           ) : (
-            data.menus.map((menu) => {
+            data.richmenus.map((menu) => {
               const channelAliases = aliases
                 ? {
                     default: channel === 'shop' ? aliases.shopDefault : aliases.financeDefault,
@@ -934,7 +934,7 @@ export default function RichMenuPage() {
           )}
 
           {/* Add new button */}
-          {(data?.menus?.length ?? 0) > 0 && (
+          {(data?.richmenus?.length ?? 0) > 0 && (
             <div className="flex justify-end">
               <Button
                 variant="outline"

--- a/apps/web/src/pages/RichMenuPage.tsx
+++ b/apps/web/src/pages/RichMenuPage.tsx
@@ -318,6 +318,9 @@ function ButtonEditor({
 export default function RichMenuPage() {
   const queryClient = useQueryClient();
 
+  // Channel
+  const [channel, setChannel] = useState<'shop' | 'finance'>('shop');
+
   // Tab
   const [activeTab, setActiveTab] = useState<'create' | 'list'>('create');
 
@@ -512,6 +515,26 @@ export default function RichMenuPage() {
         subtitle="จัดการเมนูลัด LINE OA ที่ลูกค้าเห็นในหน้าแชท"
         icon={<LayoutGrid size={22} />}
       />
+
+      {/* Channel tabs (SHOP / FINANCE) */}
+      <div className="flex gap-1 mb-6 border-b border-border">
+        {[
+          { key: 'shop', label: '🛍 SHOP' },
+          { key: 'finance', label: '💰 FINANCE' },
+        ].map((ch) => (
+          <button
+            key={ch.key}
+            onClick={() => setChannel(ch.key as 'shop' | 'finance')}
+            className={`px-5 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px ${
+              channel === ch.key
+                ? 'border-[#06C755] text-[#06C755]'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {ch.label}
+          </button>
+        ))}
+      </div>
 
       {/* Tabs */}
       <div className="flex gap-1 mb-6 border-b border-border">

--- a/docs/superpowers/plans/2026-04-17-rich-menu-alias-multi-channel.md
+++ b/docs/superpowers/plans/2026-04-17-rich-menu-alias-multi-channel.md
@@ -1,0 +1,1501 @@
+# Rich Menu Alias Multi-Channel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable Rich Menu management for both SHOP and FINANCE LINE OA channels with alias-based switching (default/verified) so `switchRichMenu()` works for both channels end-to-end.
+
+**Architecture:** Make `RichMenuService` channel-aware by replacing hardcoded `getShopChannelToken()` with `getChannelToken(channel)`. Add `setRichMenuAlias` + `getRichMenuAliases` service methods that read/write SystemConfig (4 alias keys). Update existing controller endpoints to accept `channel` param and add 2 new alias endpoints. Frontend adds top-level SHOP/FINANCE tabs on `/settings/rich-menu`, keys queries by channel, and adds alias dropdown + badges on menu cards.
+
+**Tech Stack:** NestJS + Prisma (API), React + react-query + shadcn/ui (Web), Jest (tests)
+
+**Spec:** [2026-04-17-rich-menu-alias-multi-channel-design.md](../specs/2026-04-17-rich-menu-alias-multi-channel-design.md)
+
+---
+
+## File Structure
+
+**Modify:**
+- `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts` — channel-aware methods, alias methods
+- `apps/api/src/modules/line-oa/line-oa.controller.ts` — rich-menu endpoints (lines 238-327)
+- `apps/api/src/modules/integrations/integration-registry.ts` — add `liffId` to `line-finance` (lines 64-86)
+- `apps/web/src/pages/RichMenuPage.tsx` — channel tabs, channel-aware state, alias UI
+
+**Create:**
+- `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts` — unit tests
+- `apps/api/src/modules/line-oa/rich-menu/dto/set-alias.dto.ts` — validation DTO
+
+**No DB migration required** — SystemConfig table already exists.
+
+---
+
+### Task 1: Backend — Add `getChannelToken` helper with tests
+
+**Files:**
+- Create: `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts`
+- Modify: `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts` (lines 51-53)
+
+- [ ] **Step 1: Create the spec file with failing test**
+
+Create `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts`:
+
+```ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { RichMenuService } from './rich-menu.service';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { IntegrationConfigService } from '../../integrations/integration-config.service';
+
+describe('RichMenuService', () => {
+  let service: RichMenuService;
+  let integrationConfig: { getValue: jest.Mock };
+
+  beforeEach(async () => {
+    integrationConfig = { getValue: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RichMenuService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: PrismaService, useValue: { systemConfig: { findFirst: jest.fn(), upsert: jest.fn() } } },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
+      ],
+    }).compile();
+
+    service = module.get<RichMenuService>(RichMenuService);
+  });
+
+  describe('getChannelToken', () => {
+    it('returns SHOP token when channel=shop', async () => {
+      integrationConfig.getValue.mockImplementation((key, field) =>
+        Promise.resolve(key === 'line-shop' && field === 'channelToken' ? 'shop-token-123' : null),
+      );
+
+      const token = await (service as any).getChannelToken('shop');
+
+      expect(integrationConfig.getValue).toHaveBeenCalledWith('line-shop', 'channelToken');
+      expect(token).toBe('shop-token-123');
+    });
+
+    it('returns FINANCE token when channel=finance', async () => {
+      integrationConfig.getValue.mockImplementation((key, field) =>
+        Promise.resolve(key === 'line-finance' && field === 'channelToken' ? 'finance-token-456' : null),
+      );
+
+      const token = await (service as any).getChannelToken('finance');
+
+      expect(integrationConfig.getValue).toHaveBeenCalledWith('line-finance', 'channelToken');
+      expect(token).toBe('finance-token-456');
+    });
+
+    it('throws BadRequestException when token not configured', async () => {
+      integrationConfig.getValue.mockResolvedValue(null);
+
+      await expect((service as any).getChannelToken('finance')).rejects.toThrow(BadRequestException);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest rich-menu.service.spec.ts
+```
+
+Expected: FAIL — `getChannelToken is not a function` or similar
+
+- [ ] **Step 3: Replace `getShopChannelToken` with `getChannelToken` in service**
+
+Edit `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts` lines 51-53, replace:
+
+```ts
+  private async getShopChannelToken(): Promise<string> {
+    return (await this.integrationConfig.getValue('line-shop', 'channelToken')) || '';
+  }
+```
+
+with:
+
+```ts
+  private async getChannelToken(channel: 'shop' | 'finance' = 'shop'): Promise<string> {
+    const key = channel === 'shop' ? 'line-shop' : 'line-finance';
+    const token = await this.integrationConfig.getValue(key, 'channelToken');
+    if (!token) {
+      throw new BadRequestException(
+        `LINE ${channel === 'shop' ? 'SHOP' : 'FINANCE'} channel token ยังไม่ถูกตั้งค่า — กรุณาไปที่ /settings/integrations`,
+      );
+    }
+    return token;
+  }
+
+  /** @deprecated Use getChannelToken('shop') instead */
+  private async getShopChannelToken(): Promise<string> {
+    return this.getChannelToken('shop');
+  }
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+cd apps/api && npx jest rich-menu.service.spec.ts
+```
+
+Expected: PASS — 3 tests passed
+
+- [ ] **Step 5: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+git commit -m "feat(rich-menu): add channel-aware getChannelToken helper"
+```
+
+---
+
+### Task 2: Backend — Propagate `channel` param through all LINE API methods
+
+**Files:**
+- Modify: `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts`
+- Modify: `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts`
+
+- [ ] **Step 1: Add failing test for channel propagation in listRichMenus**
+
+Append to `rich-menu.service.spec.ts` (inside the `describe('RichMenuService', ...)` block):
+
+```ts
+  describe('listRichMenus', () => {
+    const originalFetch = global.fetch;
+    afterEach(() => { global.fetch = originalFetch; });
+
+    it('uses FINANCE token when channel=finance', async () => {
+      integrationConfig.getValue.mockImplementation((key) =>
+        Promise.resolve(key === 'line-finance' ? 'finance-token' : null),
+      );
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ richmenus: [] }),
+      });
+      global.fetch = fetchMock as any;
+
+      await service.listRichMenus('finance');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/richmenu/list'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer finance-token' }),
+        }),
+      );
+    });
+
+    it('defaults to SHOP token when channel omitted', async () => {
+      integrationConfig.getValue.mockImplementation((key) =>
+        Promise.resolve(key === 'line-shop' ? 'shop-token' : null),
+      );
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ richmenus: [] }),
+      });
+      global.fetch = fetchMock as any;
+
+      await service.listRichMenus();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer shop-token' }),
+        }),
+      );
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest rich-menu.service.spec.ts
+```
+
+Expected: FAIL — `listRichMenus` doesn't accept channel param, FINANCE test fails
+
+- [ ] **Step 3: Update all service methods to accept `channel` param**
+
+In `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts`:
+
+**3a.** Update `getDefaultRichMenuId` (around line 285):
+
+```ts
+  async getDefaultRichMenuId(channel: 'shop' | 'finance' = 'shop'): Promise<string | null> {
+    const token = await this.getChannelToken(channel);
+    const url = `${this.lineApiBaseUrl}/user/all/richmenu`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (response.status === 404) return null;
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new InternalServerErrorException(`Failed to get default Rich Menu: ${response.status} ${errorBody}`);
+    }
+
+    const data = await response.json();
+    return (data as { richMenuId?: string }).richMenuId ?? null;
+  }
+```
+
+**3b.** Update `uploadRichMenuImage` (around line 315):
+
+```ts
+  async uploadRichMenuImage(
+    richMenuId: string,
+    imageBuffer: Buffer,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
+    const url = `https://api-data.line.me/v2/bot/richmenu/${richMenuId}/content`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'image/png' },
+      body: new Uint8Array(imageBuffer),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new InternalServerErrorException(`Failed to upload Rich Menu image: ${response.status} ${errorBody}`);
+    }
+    this.logger.log(`Rich Menu image uploaded for ${richMenuId} (channel=${channel})`);
+  }
+```
+
+**3c.** Update `setDefaultRichMenu` (around line 343):
+
+```ts
+  async setDefaultRichMenu(
+    richMenuId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
+    const url = `${this.lineApiBaseUrl}/user/all/richmenu/${richMenuId}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new InternalServerErrorException(`Failed to set default Rich Menu: ${response.status} ${errorBody}`);
+    }
+    this.logger.log(`Default Rich Menu set to ${richMenuId} (channel=${channel})`);
+  }
+```
+
+**3d.** Update `deleteRichMenu` (around line 365):
+
+```ts
+  async deleteRichMenu(
+    richMenuId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
+    const url = `${this.lineApiBaseUrl}/richmenu/${richMenuId}`;
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new InternalServerErrorException(`Failed to delete Rich Menu: ${response.status} ${errorBody}`);
+    }
+    this.logger.log(`Rich Menu deleted: ${richMenuId} (channel=${channel})`);
+  }
+```
+
+**3e.** Update `listRichMenus` (around line 387):
+
+```ts
+  async listRichMenus(channel: 'shop' | 'finance' = 'shop'): Promise<unknown[]> {
+    const token = await this.getChannelToken(channel);
+    const url = `${this.lineApiBaseUrl}/richmenu/list`;
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      throw new InternalServerErrorException(`Failed to list Rich Menus: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.richmenus || [];
+  }
+```
+
+**3f.** Update `linkRichMenuToUser` (around line 408):
+
+```ts
+  async linkRichMenuToUser(
+    userId: string,
+    richMenuId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
+    const url = `${this.lineApiBaseUrl}/user/${userId}/richmenu/${richMenuId}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (response.status === 404) return;
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new InternalServerErrorException(
+        `Failed to link Rich Menu to user ${userId}: ${response.status} ${errorBody}`,
+      );
+    }
+    this.logger.log(`Rich Menu ${richMenuId} linked to user ${userId} (channel=${channel})`);
+  }
+```
+
+**3g.** Update `unlinkRichMenuFromUser` (around line 437):
+
+```ts
+  async unlinkRichMenuFromUser(
+    userId: string,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<void> {
+    const token = await this.getChannelToken(channel);
+    const url = `${this.lineApiBaseUrl}/user/${userId}/richmenu`;
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (response.status === 404) return;
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new InternalServerErrorException(
+        `Failed to unlink Rich Menu from user ${userId}: ${response.status} ${errorBody}`,
+      );
+    }
+    this.logger.log(`Rich Menu unlinked from user ${userId} (channel=${channel})`);
+  }
+```
+
+**3h.** Update `callLineApi` private helper (around line 495) to accept channel:
+
+```ts
+  private async callLineApi(
+    url: string,
+    body: unknown,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<Response> {
+    const token = await this.getChannelToken(channel);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new InternalServerErrorException(`LINE API error ${response.status}: ${errorBody}`);
+    }
+    return response;
+  }
+```
+
+**3i.** Update `createCustomRichMenu` signature (around line 189) to accept channel:
+
+```ts
+  async createCustomRichMenu(
+    params: CreateMenuParams,
+    channel: 'shop' | 'finance' = 'shop',
+  ): Promise<{ richMenuId: string }> {
+    // ... existing body unchanged until the final call ...
+
+    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, body, channel);
+    const data = await response.json();
+    this.logger.log(`Custom Rich Menu created: ${data.richMenuId} (layout=${layout}, channel=${channel})`);
+    return { richMenuId: data.richMenuId };
+  }
+```
+
+**3j.** Update `switchRichMenu` (around line 477) to pass channel:
+
+```ts
+  async switchRichMenu(
+    userId: string,
+    isVerified: boolean,
+    channel: 'shop' | 'finance',
+  ): Promise<void> {
+    const channelPart = channel === 'shop' ? 'shop' : 'finance';
+    const statusPart = isVerified ? 'Verified' : 'Default';
+    const key = `line.richMenu.${channelPart}${statusPart}`;
+
+    const richMenuId = await this.getRichMenuIdFromConfig(key);
+    if (!richMenuId) {
+      this.logger.warn(`Rich Menu config not found for key "${key}" — skipping switch`);
+      return;
+    }
+
+    await this.linkRichMenuToUser(userId, richMenuId, channel);
+  }
+```
+
+**3k.** Also update `createShopRichMenu` and `createFinanceRichMenu` (legacy methods around lines 68 and 123) to pass channel explicitly:
+
+In `createShopRichMenu`:
+```ts
+    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, richMenu, 'shop');
+```
+
+In `createFinanceRichMenu`:
+```ts
+    const response = await this.callLineApi(`${this.lineApiBaseUrl}/richmenu`, richMenu, 'finance');
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+cd apps/api && npx jest rich-menu.service.spec.ts
+```
+
+Expected: PASS — all 5 tests passed
+
+- [ ] **Step 5: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors (existing callers pass without channel → use default 'shop')
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+git commit -m "feat(rich-menu): propagate channel param through all LINE API methods"
+```
+
+---
+
+### Task 3: Backend — Add alias management methods (`setRichMenuAlias`, `getRichMenuAliases`)
+
+**Files:**
+- Modify: `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts`
+- Modify: `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts`
+
+- [ ] **Step 1: Add failing test for alias methods**
+
+Append to `rich-menu.service.spec.ts`:
+
+```ts
+  describe('setRichMenuAlias', () => {
+    it('writes SystemConfig with correct key for shop/default', async () => {
+      const prismaUpsert = jest.fn().mockResolvedValue({});
+      (service as any).prisma = {
+        systemConfig: { upsert: prismaUpsert, findFirst: jest.fn() },
+      };
+      // Mock setDefaultRichMenu (variant=default triggers LINE API)
+      const setDefaultSpy = jest.spyOn(service, 'setDefaultRichMenu').mockResolvedValue(undefined);
+
+      await service.setRichMenuAlias('shop', 'default', 'rm-123');
+
+      expect(prismaUpsert).toHaveBeenCalledWith({
+        where: { key: 'line.richMenu.shopDefault' },
+        create: { key: 'line.richMenu.shopDefault', value: 'rm-123' },
+        update: { value: 'rm-123', deletedAt: null },
+      });
+      expect(setDefaultSpy).toHaveBeenCalledWith('rm-123', 'shop');
+    });
+
+    it('writes SystemConfig for finance/verified without calling setDefaultRichMenu', async () => {
+      const prismaUpsert = jest.fn().mockResolvedValue({});
+      (service as any).prisma = {
+        systemConfig: { upsert: prismaUpsert, findFirst: jest.fn() },
+      };
+      const setDefaultSpy = jest.spyOn(service, 'setDefaultRichMenu').mockResolvedValue(undefined);
+
+      await service.setRichMenuAlias('finance', 'verified', 'rm-456');
+
+      expect(prismaUpsert).toHaveBeenCalledWith({
+        where: { key: 'line.richMenu.financeVerified' },
+        create: { key: 'line.richMenu.financeVerified', value: 'rm-456' },
+        update: { value: 'rm-456', deletedAt: null },
+      });
+      expect(setDefaultSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRichMenuAliases', () => {
+    it('returns all 4 alias values with null for missing keys', async () => {
+      const prismaFindFirst = jest.fn().mockImplementation(({ where }) => {
+        if (where.key === 'line.richMenu.shopDefault') {
+          return Promise.resolve({ value: 'rm-shop-default' });
+        }
+        if (where.key === 'line.richMenu.financeVerified') {
+          return Promise.resolve({ value: 'rm-finance-verified' });
+        }
+        return Promise.resolve(null);
+      });
+      (service as any).prisma = {
+        systemConfig: { findFirst: prismaFindFirst, upsert: jest.fn() },
+      };
+
+      const aliases = await service.getRichMenuAliases();
+
+      expect(aliases).toEqual({
+        shopDefault: 'rm-shop-default',
+        shopVerified: null,
+        financeDefault: null,
+        financeVerified: 'rm-finance-verified',
+      });
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify fail**
+
+```bash
+cd apps/api && npx jest rich-menu.service.spec.ts
+```
+
+Expected: FAIL — `setRichMenuAlias` / `getRichMenuAliases` not defined
+
+- [ ] **Step 3: Implement both methods**
+
+Add to `apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts` (before the closing `}` of the class):
+
+```ts
+  /**
+   * Set Rich Menu alias for a channel/variant combination.
+   * Writes SystemConfig key `line.richMenu.{channel}{Variant}`.
+   * For variant='default', also calls LINE setDefaultRichMenu (new friends see this menu).
+   */
+  async setRichMenuAlias(
+    channel: 'shop' | 'finance',
+    variant: 'default' | 'verified',
+    richMenuId: string,
+  ): Promise<void> {
+    const variantPart = variant === 'default' ? 'Default' : 'Verified';
+    const key = `line.richMenu.${channel}${variantPart}`;
+
+    await this.prisma.systemConfig.upsert({
+      where: { key },
+      create: { key, value: richMenuId },
+      update: { value: richMenuId, deletedAt: null },
+    });
+
+    if (variant === 'default') {
+      await this.setDefaultRichMenu(richMenuId, channel);
+    }
+
+    this.logger.log(`Rich Menu alias set: ${key} = ${richMenuId}`);
+  }
+
+  /**
+   * Read all 4 Rich Menu aliases from SystemConfig.
+   */
+  async getRichMenuAliases(): Promise<{
+    shopDefault: string | null;
+    shopVerified: string | null;
+    financeDefault: string | null;
+    financeVerified: string | null;
+  }> {
+    const keys = [
+      'line.richMenu.shopDefault',
+      'line.richMenu.shopVerified',
+      'line.richMenu.financeDefault',
+      'line.richMenu.financeVerified',
+    ];
+    const records = await Promise.all(
+      keys.map((key) =>
+        this.prisma.systemConfig.findFirst({ where: { key, deletedAt: null } }),
+      ),
+    );
+    return {
+      shopDefault: records[0]?.value ?? null,
+      shopVerified: records[1]?.value ?? null,
+      financeDefault: records[2]?.value ?? null,
+      financeVerified: records[3]?.value ?? null,
+    };
+  }
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+cd apps/api && npx jest rich-menu.service.spec.ts
+```
+
+Expected: PASS — all 7 tests passed
+
+- [ ] **Step 5: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+git commit -m "feat(rich-menu): add setRichMenuAlias and getRichMenuAliases"
+```
+
+---
+
+### Task 4: Backend — Create `SetAliasDto`
+
+**Files:**
+- Create: `apps/api/src/modules/line-oa/rich-menu/dto/set-alias.dto.ts`
+
+- [ ] **Step 1: Create DTO file**
+
+Create `apps/api/src/modules/line-oa/rich-menu/dto/set-alias.dto.ts`:
+
+```ts
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+
+export class SetAliasDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุ channel' })
+  @IsIn(['shop', 'finance'], { message: 'channel ต้องเป็น shop หรือ finance' })
+  channel!: 'shop' | 'finance';
+
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุ variant' })
+  @IsIn(['default', 'verified'], { message: 'variant ต้องเป็น default หรือ verified' })
+  variant!: 'default' | 'verified';
+}
+```
+
+- [ ] **Step 2: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/modules/line-oa/rich-menu/dto/set-alias.dto.ts
+git commit -m "feat(rich-menu): add SetAliasDto"
+```
+
+---
+
+### Task 5: Backend — Add `channel` param to existing controller endpoints
+
+**Files:**
+- Modify: `apps/api/src/modules/line-oa/line-oa.controller.ts` (lines 238-327)
+
+- [ ] **Step 1: Update imports and all 7 endpoints to accept channel**
+
+Ensure `Query` is in the imports at the top of `line-oa.controller.ts`:
+
+```ts
+import { Query } from '@nestjs/common';
+```
+
+Replace the entire block from `@Get('rich-menu/list')` (line 240) through `@Delete('rich-menu/:id')` (ends around line 327) with:
+
+```ts
+  // ─── Rich Menu Management (Owner) ───────────────────
+  // All endpoints accept ?channel=shop|finance (default: shop)
+
+  @Get('rich-menu/list')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async listRichMenus(@Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    const richmenus = await this.richMenuService.listRichMenus(ch);
+    const defaultId = await this.richMenuService.getDefaultRichMenuId(ch).catch(() => null);
+    return { richmenus, defaultRichMenuId: defaultId };
+  }
+
+  @Get('rich-menu/default')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async getDefaultRichMenu(@Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    const richMenuId = await this.richMenuService.getDefaultRichMenuId(ch);
+    return { richMenuId };
+  }
+
+  @Post('rich-menu/create-default')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async createDefaultRichMenu(
+    @Body()
+    body: {
+      liffUrl?: string;
+      name?: string;
+      chatBarText?: string;
+      layout?: string;
+      buttons?: any[];
+      channel?: string;
+    },
+  ) {
+    const ch = this.parseChannel(body.channel);
+    const result = await this.richMenuService.createCustomRichMenu(
+      { ...body, layout: body.layout as '2x3' | '1x3' | '2x2' | undefined },
+      ch,
+    );
+    return { success: true, richMenuId: result.richMenuId };
+  }
+
+  @Post('rich-menu/:id/upload-image')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  @UseInterceptors(FileInterceptor('image'))
+  async uploadRichMenuImage(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Query('channel') channel?: string,
+  ) {
+    if (!file) throw new BadRequestException('กรุณาอัปโหลดรูปภาพ');
+    const ch = this.parseChannel(channel);
+    await this.richMenuService.uploadRichMenuImage(id, file.buffer, ch);
+    return { success: true, message: 'อัปโหลดรูป Rich Menu สำเร็จ' };
+  }
+
+  @Post('rich-menu/create-with-image')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  @UseInterceptors(FileInterceptor('image'))
+  async createWithImage(@UploadedFile() file: Express.Multer.File, @Body() body: any) {
+    const config = typeof body.config === 'string' ? JSON.parse(body.config) : (body.config ?? {});
+    const ch = this.parseChannel(config.channel);
+
+    const result = await this.richMenuService.createCustomRichMenu(config, ch);
+
+    if (file && result.richMenuId) {
+      await this.richMenuService.uploadRichMenuImage(result.richMenuId, file.buffer, ch);
+    }
+
+    if (config.setAsDefault && result.richMenuId) {
+      await this.richMenuService.setDefaultRichMenu(result.richMenuId, ch);
+    }
+
+    return { success: true, richMenuId: result.richMenuId };
+  }
+
+  @Post('rich-menu/:id/set-default')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async setDefaultRichMenu(@Param('id') id: string, @Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    await this.richMenuService.setDefaultRichMenu(id, ch);
+    return { success: true, message: 'ตั้งค่า Rich Menu เริ่มต้นเรียบร้อย' };
+  }
+
+  @Delete('rich-menu/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async deleteRichMenu(@Param('id') id: string, @Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    await this.richMenuService.deleteRichMenu(id, ch);
+    return { success: true, message: 'ลบ Rich Menu เรียบร้อย' };
+  }
+
+  private parseChannel(channel?: string): 'shop' | 'finance' {
+    if (channel === 'finance') return 'finance';
+    if (channel === 'shop' || channel === undefined || channel === '') return 'shop';
+    throw new BadRequestException('channel ต้องเป็น shop หรือ finance');
+  }
+```
+
+- [ ] **Step 2: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors
+
+- [ ] **Step 3: Run existing tests (no regression)**
+
+```bash
+cd apps/api && npx jest
+```
+
+Expected: PASS — all existing tests still pass (frontend not changed yet so default `channel='shop'` keeps behavior)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/modules/line-oa/line-oa.controller.ts
+git commit -m "feat(rich-menu): accept channel param on existing rich-menu endpoints"
+```
+
+---
+
+### Task 6: Backend — Add new alias controller endpoints
+
+**Files:**
+- Modify: `apps/api/src/modules/line-oa/line-oa.controller.ts`
+
+- [ ] **Step 1: Add 2 new endpoints at the end of the Rich Menu Management section**
+
+After the `@Delete('rich-menu/:id')` endpoint but before `parseChannel` helper (or keep `parseChannel` last — just ensure these are inside the class), add:
+
+```ts
+  @Get('rich-menu/aliases')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async getRichMenuAliases() {
+    return this.richMenuService.getRichMenuAliases();
+  }
+
+  @Post('rich-menu/:id/set-alias')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async setRichMenuAlias(@Param('id') id: string, @Body() dto: SetAliasDto) {
+    await this.richMenuService.setRichMenuAlias(dto.channel, dto.variant, id);
+    return { success: true, message: 'ตั้งค่า alias สำเร็จ' };
+  }
+```
+
+Add import at top of file:
+
+```ts
+import { SetAliasDto } from './rich-menu/dto/set-alias.dto';
+```
+
+**Note:** `aliases` route must come BEFORE `:id` routes with same HTTP method — but since `aliases` is GET and `:id/set-alias` is POST, no conflict. However if any future `GET rich-menu/:id` is added, move `aliases` above it.
+
+- [ ] **Step 2: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors
+
+- [ ] **Step 3: Run existing tests**
+
+```bash
+cd apps/api && npx jest
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/modules/line-oa/line-oa.controller.ts
+git commit -m "feat(rich-menu): add GET /aliases and POST /:id/set-alias endpoints"
+```
+
+---
+
+### Task 7: Backend — Add `liffId` field to `line-finance` integration
+
+**Files:**
+- Modify: `apps/api/src/modules/integrations/integration-registry.ts` (lines 64-86)
+
+- [ ] **Step 1: Add `liffId` field to `line-finance` fields array**
+
+In `apps/api/src/modules/integrations/integration-registry.ts`, replace the `line-finance` entry (around lines 63-86):
+
+```ts
+  {
+    key: 'line-finance',
+    name: 'LINE FINANCE (น้องเบส)',
+    description: 'ไลน์การเงิน — แจ้งค่างวด, รับชำระ',
+    icon: 'line',
+    webhookUrl: `${BASE}/api/chatbot/finance/webhook`,
+    webhookNote: 'ตั้งค่า Webhook URL นี้ที่ LINE Developers Console → Messaging API → Webhook URL',
+    fields: [
+      {
+        key: 'channelToken',
+        label: 'Channel Access Token',
+        sensitive: true,
+        required: true,
+        envVar: 'LINE_FINANCE_CHANNEL_ACCESS_TOKEN',
+      },
+      {
+        key: 'channelSecret',
+        label: 'Channel Secret',
+        sensitive: true,
+        required: true,
+        envVar: 'LINE_FINANCE_CHANNEL_SECRET',
+      },
+      {
+        key: 'liffId',
+        label: 'LIFF ID',
+        sensitive: false,
+        required: false,
+        envVar: 'VITE_LIFF_ID_FINANCE',
+      },
+    ],
+  },
+```
+
+- [ ] **Step 2: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/modules/integrations/integration-registry.ts
+git commit -m "feat(integrations): add liffId field to line-finance"
+```
+
+---
+
+### Task 8: Frontend — Add channel tab state + top-level tabs UI
+
+**Files:**
+- Modify: `apps/web/src/pages/RichMenuPage.tsx`
+
+- [ ] **Step 1: Verify Tabs component exists**
+
+```bash
+ls /Users/iamnaii/Desktop/App/BESTCHOICE/apps/web/src/components/ui/tabs.tsx 2>&1
+```
+
+Expected: File exists (shadcn tabs component). If not, check for existing tab usage pattern:
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/web/src && grep -rn "TabsList\|TabsTrigger" --include="*.tsx" | head -3
+```
+
+If shadcn Tabs not installed, use the existing sub-tab pattern (border-b buttons) for the channel tabs instead.
+
+- [ ] **Step 2: Add channel state and channel tabs at top of page render**
+
+In `apps/web/src/pages/RichMenuPage.tsx`, inside the `RichMenuPage` function (after other `useState` declarations around line 322), add:
+
+```ts
+  const [channel, setChannel] = useState<'shop' | 'finance'>('shop');
+```
+
+Then in the JSX, right after `<PageHeader ... />` (around line 514) and before the existing sub-tabs div, insert:
+
+```tsx
+      {/* Channel tabs (top-level) */}
+      <div className="flex gap-1 mb-4 border-b border-border">
+        {[
+          { key: 'shop', label: '🛍 SHOP' },
+          { key: 'finance', label: '💰 FINANCE' },
+        ].map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setChannel(tab.key as 'shop' | 'finance')}
+            className={`px-5 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px ${
+              channel === tab.key
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/RichMenuPage.tsx
+git commit -m "feat(rich-menu): add channel tabs (SHOP/FINANCE) to settings page"
+```
+
+---
+
+### Task 9: Frontend — Channel-aware queries + FINANCE liffId source
+
+**Files:**
+- Modify: `apps/web/src/pages/RichMenuPage.tsx`
+
+- [ ] **Step 1: Update `rich-menu-list` query to include channel in key**
+
+In `apps/web/src/pages/RichMenuPage.tsx`, replace the existing `useQuery` for rich-menu-list (around lines 343-350):
+
+```ts
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ['rich-menu-list', channel],
+    queryFn: async () => {
+      const res = await api.get(`/line-oa/rich-menu/list?channel=${channel}`);
+      return res.data as RichMenuListResponse;
+    },
+    retry: 1,
+  });
+```
+
+- [ ] **Step 2: Add new query for FINANCE integration settings**
+
+Right after the `lineSettings` query (around line 358), add:
+
+```ts
+  const { data: financeIntegration } = useQuery({
+    queryKey: ['integration', 'line-finance'],
+    queryFn: async () => {
+      const res = await api.get('/integrations/line-finance');
+      return res.data as { values: Record<string, string> };
+    },
+  });
+```
+
+**Note:** The exact endpoint path may differ — verify by:
+```bash
+grep -rn "@Get\|@Controller" /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api/src/modules/integrations/integrations.controller.ts | head -10
+```
+Adjust the path if needed (e.g. `/integrations/:key` or `/integrations?key=line-finance`).
+
+- [ ] **Step 3: Add alias query**
+
+Right after the `financeIntegration` query, add:
+
+```ts
+  const { data: aliases } = useQuery({
+    queryKey: ['rich-menu-aliases'],
+    queryFn: async () => {
+      const res = await api.get('/line-oa/rich-menu/aliases');
+      return res.data as {
+        shopDefault: string | null;
+        shopVerified: string | null;
+        financeDefault: string | null;
+        financeVerified: string | null;
+      };
+    },
+  });
+```
+
+- [ ] **Step 4: Update `defaultLiffUrl` to resolve per channel**
+
+Replace the existing `defaultLiffUrl` block (around lines 360-363):
+
+```ts
+  const shopLiffId = lineSettings?.settings?.liff_id;
+  const financeLiffId = financeIntegration?.values?.liffId;
+  const activeLiffId = channel === 'shop' ? shopLiffId : financeLiffId;
+  const defaultLiffUrl = activeLiffId ? `https://liff.line.me/${activeLiffId}` : '';
+  const effectiveLiffUrl = liffUrl || defaultLiffUrl;
+```
+
+- [ ] **Step 5: Reset liffUrl + editingMenuId when channel changes**
+
+After the `setChannel` state declaration, add a `useEffect` that resets per-channel state on channel switch:
+
+```ts
+  useEffect(() => {
+    setLiffUrl('');
+    setEditingMenuId(null);
+    setCustomImageFile(null);
+    setCustomImagePreview(null);
+  }, [channel]);
+```
+
+And ensure `useEffect` is imported from React at the top of the file:
+
+```ts
+import { useState, useRef, useEffect } from 'react';
+```
+
+- [ ] **Step 6: Verify build**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+Expected: 0 errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/pages/RichMenuPage.tsx
+git commit -m "feat(rich-menu): channel-aware queries and LIFF URL resolution"
+```
+
+---
+
+### Task 10: Frontend — Channel-aware mutations + alias UI
+
+**Files:**
+- Modify: `apps/web/src/pages/RichMenuPage.tsx`
+
+- [ ] **Step 1: Pass `channel` in all mutations**
+
+Update `createMutation` (around lines 374-413):
+
+In the `create-with-image` FormData section, add channel to the config JSON:
+
+```ts
+        fd.append(
+          'config',
+          JSON.stringify({
+            name: menuName,
+            chatBarText,
+            liffUrl: effectiveLiffUrl,
+            layout,
+            buttons: visibleButtons,
+            setAsDefault: true,
+            channel,  // ← add this line
+          }),
+        );
+```
+
+In the standard `create-default` JSON body, add channel:
+
+```ts
+      const res = await api.post('/line-oa/rich-menu/create-default', {
+        liffUrl: effectiveLiffUrl,
+        name: menuName,
+        chatBarText,
+        layout,
+        buttons: visibleButtons,
+        channel,  // ← add this line
+      });
+```
+
+Update `setDefaultMutation` (around lines 439-448):
+
+```ts
+  const setDefaultMutation = useMutation({
+    mutationFn: async (menuId: string) => {
+      await api.post(`/line-oa/rich-menu/${menuId}/set-default?channel=${channel}`);
+    },
+    onSuccess: () => {
+      toast.success('ตั้งเป็น Default แล้ว');
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+```
+
+Update `deleteMutation`:
+
+```ts
+  const deleteMutation = useMutation({
+    mutationFn: async (menuId: string) => {
+      await api.delete(`/line-oa/rich-menu/${menuId}?channel=${channel}`);
+    },
+    onSuccess: () => {
+      toast.success('ลบ Rich Menu แล้ว');
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+```
+
+Update `uploadImageMutation`:
+
+```ts
+  const uploadImageMutation = useMutation({
+    mutationFn: async ({ menuId, file }: { menuId: string; file: File }) => {
+      const formData = new FormData();
+      formData.append('image', file);
+      await api.post(`/line-oa/rich-menu/${menuId}/upload-image?channel=${channel}`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    },
+    onSuccess: () => {
+      toast.success('อัปโหลดรูป Rich Menu สำเร็จ');
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+```
+
+Also update the cleanup of old menu in `createMutation.onSuccess` (around lines 418-431):
+
+```ts
+      if (editingMenuId) {
+        const oldMenuId = editingMenuId;
+        try {
+          if (data?.richMenuId) {
+            await api.post(`/line-oa/rich-menu/${data.richMenuId}/set-default?channel=${channel}`);
+          }
+          await api.delete(`/line-oa/rich-menu/${oldMenuId}?channel=${channel}`);
+        } catch (err) {
+          console.error('Failed to cleanup old menu', err);
+        }
+        setEditingMenuId(null);
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
+```
+
+- [ ] **Step 2: Add `setAliasMutation`**
+
+After `uploadImageMutation`, add:
+
+```ts
+  const setAliasMutation = useMutation({
+    mutationFn: async ({ menuId, variant }: { menuId: string; variant: 'default' | 'verified' }) => {
+      await api.post(`/line-oa/rich-menu/${menuId}/set-alias`, { channel, variant });
+    },
+    onSuccess: (_, vars) => {
+      toast.success(`ตั้งเป็น ${vars.variant === 'default' ? 'Default' : 'Verified'} แล้ว`);
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+```
+
+- [ ] **Step 3: Replace "ตั้งเป็น Default" button with alias dropdown**
+
+In the menu card render (around lines 776-786), replace the conditional "ตั้งเป็น Default" `<Button>` block with a dropdown:
+
+First, import DropdownMenu components at the top of the file (check if file already imports them):
+
+```bash
+grep "DropdownMenu" /Users/iamnaii/Desktop/App/BESTCHOICE/apps/web/src/pages/RichMenuPage.tsx
+```
+
+If not present, verify the shadcn component exists:
+```bash
+ls /Users/iamnaii/Desktop/App/BESTCHOICE/apps/web/src/components/ui/dropdown-menu.tsx
+```
+
+Then add to imports:
+
+```ts
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+```
+
+Replace the existing `{!isDefault && <Button ...>ตั้งเป็น Default</Button>}` block with:
+
+```tsx
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button size="sm" variant="outline">
+                              <Star size={13} className="mr-1" />
+                              ตั้งเป็น...
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() =>
+                                setAliasMutation.mutate({ menuId: menu.richMenuId, variant: 'default' })
+                              }
+                            >
+                              ⭐ Default (ลูกค้าใหม่)
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() =>
+                                setAliasMutation.mutate({ menuId: menu.richMenuId, variant: 'verified' })
+                              }
+                            >
+                              ✓ Verified (ลูกค้าที่ verify แล้ว)
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+```
+
+- [ ] **Step 4: Show Default / Verified badges per alias assignment**
+
+Still inside the menu card render, update the `isDefault` computation logic. Replace (around line 749):
+
+```ts
+              const isDefault = menu.richMenuId === data.defaultMenuId;
+```
+
+with:
+
+```ts
+              const channelAliases = aliases
+                ? {
+                    default: channel === 'shop' ? aliases.shopDefault : aliases.financeDefault,
+                    verified: channel === 'shop' ? aliases.shopVerified : aliases.financeVerified,
+                  }
+                : { default: null, verified: null };
+              const isDefault = menu.richMenuId === channelAliases.default;
+              const isVerified = menu.richMenuId === channelAliases.verified;
+```
+
+Then in the badge render section (around lines 769-773), replace:
+
+```tsx
+                        {isDefault && (
+                          <Badge className="bg-success/10 text-success hover:bg-success/10 border-success/30 shrink-0">
+                            Default
+                          </Badge>
+                        )}
+```
+
+with:
+
+```tsx
+                        {isDefault && (
+                          <Badge className="bg-success/10 text-success hover:bg-success/10 border-success/30 shrink-0">
+                            ⭐ Default
+                          </Badge>
+                        )}
+                        {isVerified && (
+                          <Badge className="bg-primary/10 text-primary hover:bg-primary/10 border-primary/30 shrink-0">
+                            ✓ Verified
+                          </Badge>
+                        )}
+```
+
+Also update the card border condition so it highlights when EITHER alias matches (around line 753):
+
+```tsx
+                <div
+                  key={menu.richMenuId}
+                  className={`rounded-xl border shadow-sm hover:shadow-md transition-shadow bg-card overflow-hidden ${
+                    isDefault || isVerified ? 'border-success/30' : 'border-border/50'
+                  }`}
+                >
+                  <div className={`px-5 py-3 ${isDefault || isVerified ? 'bg-success/10' : 'bg-muted/20'}`}>
+```
+
+And the Star icon:
+
+```tsx
+                        {(isDefault || isVerified) && (
+                          <Star size={16} className="text-success shrink-0" fill="currentColor" />
+                        )}
+```
+
+- [ ] **Step 5: Verify build**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+Expected: 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/RichMenuPage.tsx
+git commit -m "feat(rich-menu): alias dropdown + badges, channel-aware mutations"
+```
+
+---
+
+### Task 11: Final verification — full type check + run all tests
+
+**Files:** none — verification only
+
+- [ ] **Step 1: Full TypeScript check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh all
+```
+
+Expected: 0 errors (both api + web)
+
+- [ ] **Step 2: Run full API test suite**
+
+```bash
+cd apps/api && npx jest
+```
+
+Expected: PASS — all tests including existing 577 + new rich-menu.service tests
+
+- [ ] **Step 3: Run web tests**
+
+```bash
+cd apps/web && npx vitest run
+```
+
+Expected: PASS — existing 129 tests still pass
+
+- [ ] **Step 4: Lint**
+
+```bash
+cd apps/api && npm run lint
+cd ../web && npm run lint
+```
+
+Expected: 0 errors
+
+- [ ] **Step 5: Manual QA checklist (to be run against dev server)**
+
+Start dev server:
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && npm run dev
+```
+
+Then verify in browser:
+
+1. Navigate to http://localhost:5173/settings/integrations → configure `line-finance.channelToken` (if not yet set) and `line-finance.liffId`
+2. Navigate to http://localhost:5173/settings/rich-menu
+3. ✅ See two tabs: `🛍 SHOP` and `💰 FINANCE` at top
+4. ✅ SHOP tab selected by default
+5. Switch to FINANCE tab → list is empty initially (fresh FINANCE channel)
+6. Create a menu in FINANCE tab → verify toast success + menu appears in list
+7. On menu card, click "ตั้งเป็น..." → select "Default" → toast success, `⭐ Default` badge appears
+8. Reload page → FINANCE tab still shows menu with Default badge
+9. Switch to SHOP tab → menu from step 7 does NOT appear (scoped to FINANCE)
+10. Create another menu in FINANCE tab → set it as `Verified` → `✓ Verified` badge appears
+11. Verify LINE Developers Console → FINANCE channel shows 2 menus, SHOP channel unaffected
+
+- [ ] **Step 6: Final commit (if any cleanup needed)**
+
+If manual QA revealed small issues, fix and commit. Otherwise skip.
+
+```bash
+# Only if changes made during QA
+git add -A
+git commit -m "fix(rich-menu): address manual QA findings"
+```
+
+---
+
+## Self-Review Summary
+
+**Spec coverage check:**
+- §4.1 Channel resolution → Task 1, 2 ✓
+- §4.2 SystemConfig alias keys → Task 3 ✓
+- §4.3 Data flow → covered by existing `switchRichMenu` callers (out of scope per spec §3) + Task 3 alias writing
+- §5.1 Method signatures → Task 2 ✓
+- §5.2 setRichMenuAlias → Task 3 ✓
+- §5.3 getRichMenuAliases → Task 3 ✓
+- §5.4 Controller endpoints → Task 5 (existing), Task 6 (new) ✓
+- §5.5 Integration registry → Task 7 ✓
+- §6 Frontend → Task 8, 9, 10 ✓
+- §7 Testing strategy → Task 1, 2, 3 (unit) + Task 11 (integration + manual) ✓
+- §9 Risks — token-not-configured → Task 1 Step 3 (BadRequestException with Thai message) ✓
+- §9 Risks — alias points to deleted menu → **Deferred to future work** (listed as post-MVP — user can re-assign)
+- §9 Risks — LIFF per channel → Task 9 ✓
+- §9 Risks — channel change mid-edit → Task 9 Step 5 (useEffect resets state on channel change) ✓
+
+**Placeholder scan:** No TBD/TODO/placeholders. All steps include exact code or exact commands.
+
+**Type consistency:** `channel: 'shop' | 'finance'` used consistently. Service method names match throughout (`setRichMenuAlias`, `getRichMenuAliases`, `getChannelToken`).

--- a/docs/superpowers/specs/2026-04-17-rich-menu-alias-multi-channel-design.md
+++ b/docs/superpowers/specs/2026-04-17-rich-menu-alias-multi-channel-design.md
@@ -1,0 +1,313 @@
+# Rich Menu Alias: Multi-Channel Management (SHOP + FINANCE)
+
+**Date:** 2026-04-17
+**Status:** Design — approved, ready for implementation plan
+**Scope:** Standard (Option B from brainstorm)
+**Related:** [line-experience-upgrade plan](../plans/2026-04-16-line-experience-upgrade.md)
+
+## 1. Problem Statement
+
+BESTCHOICE ใช้ LINE OA แยก 2 ช่อง: `line-shop` (ลูกค้า) และ `line-finance` (น้องเบส — การเงิน) ผู้ใช้ต้องการจัดการ Rich Menu ของทั้ง 2 channel พร้อม alias system เพื่อรองรับการสลับเมนูตามสถานะ verified ของลูกค้า
+
+ปัจจุบัน:
+- หน้า [/settings/rich-menu](../../../apps/web/src/pages/RichMenuPage.tsx) จัดการเมนูได้แค่ SHOP channel — ไม่มี channel selector
+- [`RichMenuService`](../../../apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts) ใช้ `getShopChannelToken()` ตายตัว — สร้างเมนูฝั่ง FINANCE ไม่ได้
+- `switchRichMenu(userId, isVerified, channel)` ([rich-menu.service.ts:477](../../../apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts#L477)) มีอยู่แล้วแต่ทำงานผิด — เรียก `linkRichMenuToUser()` ซึ่ง hardcoded ใช้ SHOP token
+- 4 alias keys (`line.richMenu.shopDefault`, `shopVerified`, `financeDefault`, `financeVerified`) เป็นเพียง concept — ไม่มี UI ให้เซ็ต, ต้องเข้า SQL ตรงๆ
+- `line-finance` integration ไม่มี `liffId` field (มีแต่ใน `line-shop`)
+
+## 2. Goals
+
+- จัดการ Rich Menu ของ SHOP + FINANCE แยกกันผ่าน UI เดียว
+- เซ็ต alias (`default` / `verified` per channel) ผ่าน UI ได้
+- Backend รองรับทั้ง 2 channel token ผ่าน param ไม่ต้อง hardcode
+- ไม่แตะ `switchRichMenu()` caller (liff-api, line-oa-chatbot) — ให้ทำงานได้ทันทีหลัง alias ถูกเซ็ต
+
+## 3. Non-Goals
+
+- ไม่ย้ายเมนูเก่าที่สร้างไว้ — ผู้ใช้เลือกย้ายเอง (หรือลบแล้วสร้างใหม่)
+- ไม่แก้ logic ใน LIFF controllers ที่เรียก `switchRichMenu` — ถ้า caller มี bug ทำในแผนแยก
+- ไม่ทำ per-user assignment UI (manual link เมนูให้ user คนเดียว) — ใช้แค่ alias-based switching
+- ไม่ทำ dunning/overdue state (เช่น `financeOverdue` alias) — ถ้าต้องการ เพิ่มภายหลัง
+
+## 4. Architecture
+
+### 4.1 Channel resolution
+
+Backend มี helper เดียวที่ route token ตาม channel:
+
+```ts
+// rich-menu.service.ts
+private async getChannelToken(channel: 'shop' | 'finance'): Promise<string> {
+  const key = channel === 'shop' ? 'line-shop' : 'line-finance';
+  const token = await this.integrationConfig.getValue(key, 'channelToken');
+  if (!token) {
+    throw new BadRequestException(`LINE ${channel} channel token not configured`);
+  }
+  return token;
+}
+
+/** @deprecated — delegate to getChannelToken('shop') */
+private async getShopChannelToken(): Promise<string> {
+  return this.getChannelToken('shop');
+}
+```
+
+ทุก method ที่เคยเรียก `getShopChannelToken()` เปลี่ยนเป็นรับ `channel: 'shop' | 'finance'` และเรียก `getChannelToken(channel)` แทน
+
+### 4.2 SystemConfig alias keys
+
+คง keys เดิม (ตรงกับที่ `switchRichMenu` อ่านอยู่):
+
+| Key | ใช้เมื่อ |
+|---|---|
+| `line.richMenu.shopDefault` | ลูกค้า add SHOP OA ยังไม่ verify |
+| `line.richMenu.shopVerified` | ลูกค้า verify แล้ว (มีสัญญา active) |
+| `line.richMenu.financeDefault` | ลูกค้า add FINANCE OA ยังไม่ verify |
+| `line.richMenu.financeVerified` | ลูกค้า verify แล้วใน FINANCE |
+
+### 4.3 Data flow
+
+```
+ลูกค้า add SHOP OA
+  → LINE auto-uses default (ตั้งผ่าน setDefaultRichMenu)
+  → ปกติจะตรงกับ shopDefault alias
+  
+ลูกค้า verify ผ่าน LIFF contract:
+  liff-api.controller.ts → richMenuService.switchRichMenu(userId, true, 'shop')
+  → อ่าน SystemConfig "line.richMenu.shopVerified"
+  → linkRichMenuToUser(userId, richMenuId, 'shop')  ← ใช้ SHOP token
+  → LINE แสดง shopVerified menu
+```
+
+## 5. Backend Changes
+
+### 5.1 `RichMenuService` method signatures
+
+ทุก method ที่ทำ LINE API call เพิ่ม `channel` param (default `'shop'` เพื่อ back-compat ถ้า caller ยังไม่ส่ง):
+
+```ts
+createCustomRichMenu(params: CreateMenuParams, channel: 'shop' | 'finance' = 'shop')
+uploadRichMenuImage(richMenuId: string, imageBuffer: Buffer, channel: 'shop' | 'finance' = 'shop')
+setDefaultRichMenu(richMenuId: string, channel: 'shop' | 'finance' = 'shop')
+deleteRichMenu(richMenuId: string, channel: 'shop' | 'finance' = 'shop')
+listRichMenus(channel: 'shop' | 'finance' = 'shop')
+getDefaultRichMenuId(channel: 'shop' | 'finance' = 'shop')
+linkRichMenuToUser(userId: string, richMenuId: string, channel: 'shop' | 'finance' = 'shop')
+unlinkRichMenuFromUser(userId: string, channel: 'shop' | 'finance' = 'shop')
+```
+
+`switchRichMenu` ปรับให้ส่ง channel ต่อไปยัง `linkRichMenuToUser`:
+
+```ts
+async switchRichMenu(userId: string, isVerified: boolean, channel: 'shop' | 'finance') {
+  const key = `line.richMenu.${channel}${isVerified ? 'Verified' : 'Default'}`;
+  const richMenuId = await this.getRichMenuIdFromConfig(key);
+  if (!richMenuId) {
+    this.logger.warn(`Rich Menu alias not set for ${key}`);
+    return;
+  }
+  await this.linkRichMenuToUser(userId, richMenuId, channel); // ← pass channel
+}
+```
+
+### 5.2 New method: `setRichMenuAlias`
+
+```ts
+async setRichMenuAlias(
+  channel: 'shop' | 'finance',
+  variant: 'default' | 'verified',
+  richMenuId: string,
+): Promise<void>
+```
+
+- Writes SystemConfig: key = `line.richMenu.{channel}{Variant}`, value = richMenuId
+- Uses `upsert` (soft-deleted config ถูก restore หรือสร้างใหม่)
+- เมื่อ `variant === 'default'` → เรียก `setDefaultRichMenu(richMenuId, channel)` ด้วยเสมอ (LINE's default-for-all-users = ตรงกับความหมาย "Default" ของเรา สำหรับลูกค้าที่เพิ่ง add friend)
+- เมื่อ `variant === 'verified'` → เขียนเฉพาะ SystemConfig (ไม่แตะ LINE default)
+
+### 5.3 New method: `getRichMenuAliases`
+
+```ts
+async getRichMenuAliases(): Promise<{
+  shopDefault: string | null;
+  shopVerified: string | null;
+  financeDefault: string | null;
+  financeVerified: string | null;
+}>
+```
+
+- อ่าน SystemConfig 4 keys คืนค่า richMenuId หรือ null
+
+### 5.4 Controller endpoints
+
+เดิม ([line-oa-chatbot.controller.ts](../../../apps/api/src/modules/line-oa/line-oa-chatbot.controller.ts) หรือ controller เฉพาะ rich-menu):
+
+| Method | Path | Changes |
+|---|---|---|
+| GET | `/line-oa/rich-menu/list` | เพิ่ม `?channel=shop\|finance` (default `shop`) |
+| POST | `/line-oa/rich-menu/create-default` | body เพิ่ม field `channel` |
+| POST | `/line-oa/rich-menu/create-with-image` | form field เพิ่ม `channel` ใน JSON config |
+| POST | `/line-oa/rich-menu/:id/set-default` | เพิ่ม `?channel=...` |
+| POST | `/line-oa/rich-menu/:id/upload-image` | เพิ่ม `?channel=...` |
+| DELETE | `/line-oa/rich-menu/:id` | เพิ่ม `?channel=...` |
+
+ใหม่:
+
+| Method | Path | Body/Params |
+|---|---|---|
+| POST | `/line-oa/rich-menu/:id/set-alias` | body: `{channel: 'shop'\|'finance', variant: 'default'\|'verified'}` |
+| GET | `/line-oa/rich-menu/aliases` | returns all 4 aliases |
+
+Validation:
+- `channel` ต้องเป็น `'shop'` หรือ `'finance'` — throw `BadRequestException` ถ้าไม่ใช่
+- Use class-validator DTO: `SetAliasDto { @IsIn(['shop','finance']) channel; @IsIn(['default','verified']) variant }`
+
+### 5.5 Integration registry
+
+เพิ่ม `liffId` field ใน `line-finance` integration ([integration-registry.ts:64](../../../apps/api/src/modules/integrations/integration-registry.ts#L64)):
+
+```ts
+{
+  key: 'line-finance',
+  // ... existing fields
+  fields: [
+    { key: 'channelToken', ... },
+    { key: 'channelSecret', ... },
+    { key: 'liffId', label: 'LIFF ID', sensitive: false, required: false,
+      envVar: 'VITE_LIFF_ID_FINANCE' },  // ← NEW
+  ],
+}
+```
+
+## 6. Frontend Changes
+
+### 6.1 New state + channel resolution ([RichMenuPage.tsx](../../../apps/web/src/pages/RichMenuPage.tsx))
+
+```ts
+const [channel, setChannel] = useState<'shop' | 'finance'>('shop');
+const [activeSubTab, setActiveSubTab] = useState<'create' | 'list'>('create');
+```
+
+### 6.2 UI structure
+
+```tsx
+<PageHeader title="Rich Menu" subtitle="..." icon={<LayoutGrid />} />
+
+<Tabs value={channel} onValueChange={(v) => setChannel(v as 'shop' | 'finance')}>
+  <TabsList>
+    <TabsTrigger value="shop">🛍 SHOP</TabsTrigger>
+    <TabsTrigger value="finance">💰 FINANCE</TabsTrigger>
+  </TabsList>
+</Tabs>
+
+<div className="flex gap-1 mb-6 border-b">
+  {/* existing create/list sub-tabs */}
+</div>
+
+{/* existing content, scoped to {channel} */}
+```
+
+### 6.3 Queries keyed by channel
+
+```ts
+useQuery({
+  queryKey: ['rich-menu-list', channel],
+  queryFn: () => api.get(`/line-oa/rich-menu/list?channel=${channel}`).then(r => r.data),
+});
+
+useQuery({
+  queryKey: ['rich-menu-aliases'],
+  queryFn: () => api.get('/line-oa/rich-menu/aliases').then(r => r.data),
+});
+```
+
+LIFF URL source:
+- SHOP → `useQuery(['line-oa-settings'])` เดิม → `settings.liff_id`
+- FINANCE → new query `useQuery(['chatbot-finance-settings'])` → `settings.liffId`
+- `defaultLiffUrl = channel === 'shop' ? shopLiff : financeLiff`
+
+### 6.4 Mutations เพิ่ม channel
+
+```ts
+createMutation: api.post('/line-oa/rich-menu/create-default', { ..., channel })
+setDefaultMutation: api.post(`/line-oa/rich-menu/${id}/set-default?channel=${channel}`)
+deleteMutation: api.delete(`/line-oa/rich-menu/${id}?channel=${channel}`)
+// etc.
+```
+
+หลัง mutation invalidate `['rich-menu-list', channel]` และ `['rich-menu-aliases']`
+
+### 6.5 Alias UI ใน list tab
+
+แทนที่ปุ่ม "ตั้งเป็น Default" เดิม:
+
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button size="sm" variant="outline">
+      <Star /> ตั้งเป็น...
+    </Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem onClick={() => setAlias('default')}>
+      Default (ลูกค้าใหม่)
+    </DropdownMenuItem>
+    <DropdownMenuItem onClick={() => setAlias('verified')}>
+      Verified (ลูกค้าที่ verify แล้ว)
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+Badges ใน menu card:
+- ถ้า `menu.richMenuId === aliases[`${channel}Default`]` → `<Badge>⭐ Default</Badge>`
+- ถ้า `menu.richMenuId === aliases[`${channel}Verified`]` → `<Badge>✓ Verified</Badge>`
+- เมนูเดียวสามารถเป็นทั้ง Default + Verified พร้อมกันได้ (แสดง 2 badges)
+
+`setAlias` mutation:
+```ts
+api.post(`/line-oa/rich-menu/${id}/set-alias`, { channel, variant })
+```
+
+## 7. Testing Strategy
+
+### 7.1 Unit tests (API)
+- `rich-menu.service.spec.ts` (new file):
+  - `getChannelToken('shop')` returns shop token
+  - `getChannelToken('finance')` returns finance token
+  - `getChannelToken('finance')` throws when finance not configured
+  - `setRichMenuAlias('shop', 'default', 'id1')` writes correct SystemConfig key
+  - `getRichMenuAliases()` returns all 4 keys (null if not set)
+  - `switchRichMenu(userId, true, 'finance')` uses finance token (mock fetch, assert Authorization header)
+
+### 7.2 Integration test
+- Create menu with `channel=finance` → mock LINE API → assert it called FINANCE endpoint with FINANCE token
+- Set alias → verify SystemConfig record created
+
+### 7.3 Manual QA checklist
+1. Configure `line-finance.channelToken` ใน [/settings/integrations](/settings/integrations)
+2. เพิ่ม `line-finance.liffId`
+3. เข้า [/settings/rich-menu](/settings/rich-menu) → สลับ tab FINANCE → create menu → ตรวจว่าเมนูปรากฏใน LINE Developers Console ของ FINANCE channel (ไม่ใช่ SHOP)
+4. Set alias Default บน menu → ลูกค้า add LINE FINANCE → เห็นเมนูนี้
+5. Trigger verify flow ใน LIFF → ตรวจว่า richMenuId ที่ link ให้ user เปลี่ยนเป็น Verified menu
+
+## 8. Migration & Rollout
+
+- ไม่ต้อง DB migration (SystemConfig table มีอยู่แล้ว, soft-delete model)
+- Existing menus ที่สร้างก่อนหน้า → อยู่ใน SHOP channel ต่อไป (ไม่มี channel field ใน LINE API, เมนูถูกสร้างใน channel ของ token ที่ใช้ขณะนั้น — คือ SHOP)
+- ไม่มี breaking change บน API (default `channel='shop'` ถ้า caller ไม่ส่ง)
+- Rollout: deploy backend ก่อน → deploy frontend → ทำ manual QA ตาม checklist ใน §7.3
+
+## 9. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| FINANCE channel token ยังไม่ถูก config → สร้างเมนู error | Validate ใน `getChannelToken`, error message ภาษาไทย + toast ไปที่ /settings/integrations |
+| Alias คือ richMenuId ที่ถูก delete แล้ว → `switchRichMenu` link เมนูที่ไม่มีอยู่ | Delete endpoint ตรวจว่าเมนูนี้เป็น alias อยู่ไหม → ถ้าเป็น ต้องยืนยัน |
+| 2 channels ใช้ liff_id คนละตัวแต่ UI เดิมอ่านแค่ `line-oa/settings` | เพิ่ม query `chatbot-finance/settings` เลือก liff URL ตาม channel tab |
+| User create menu ใน tab SHOP แต่กดสลับไป FINANCE ก่อน save → ส่ง channel ผิด | Snapshot `channel` เข้า mutation closure หรือ disable tab switch ขณะ pending |
+
+## 10. Open Questions
+
+None at this stage — all decisions made during brainstorm. Revisit if QA reveals issues with `switchRichMenu` caller behavior (out of scope per §3).


### PR DESCRIPTION
## Summary

- Adds channel parameter (`shop | finance`) end-to-end across Rich Menu flows so both LINE OAs (SHOP + FINANCE) can be managed from the same settings page
- Adds Rich Menu Alias system (4 slots: `shopDefault`, `shopVerified`, `financeDefault`, `financeVerified`) stored in SystemConfig + two new endpoints (`GET /rich-menu/aliases`, `POST /rich-menu/:id/set-alias`)
- Frontend: top-level SHOP/FINANCE tabs, channel-aware queries/mutations, Default/Verified dropdown + badges, hides cosmetic fields (emoji/color/label) when user uploads a custom image
- Fixes pre-existing `switchRichMenu` bug (was hardcoded to SHOP token — now channel-aware) and frontend type mismatch with `/rich-menu/list` response shape
- Adds `liffId` field to the `line-finance` integration so the Finance channel can resolve its own LIFF URL

## Scope out

- `line-oa.service.ts` still has SHOP-hardcoded token in non-rich-menu paths (`sendFlexMessage`, `testConnection`, chatbot push). Pre-existing, flagged in review, deferred.
- `switchRichMenu` key-composition unit test — recommended as follow-up.
- Custom hotspot editor (free-form area drag) — grid layouts cover current use cases; defer per product discussion.

## Design + plan

- Spec: `docs/superpowers/specs/2026-04-17-rich-menu-alias-multi-channel-design.md`
- Plan: `docs/superpowers/plans/2026-04-17-rich-menu-alias-multi-channel.md`

## Test plan

- [ ] Verify SHOP tab still works end-to-end: create grid-rendered menu → set as Default → badge appears
- [ ] Verify FINANCE tab loads after configuring FINANCE channel token + liffId via `/settings/integrations`
- [ ] Create FINANCE menu with custom image → emoji/color/label fields hidden, "ช่อง 1..6" shown
- [ ] Set variant='verified' → only SystemConfig alias updated, LINE default not changed
- [ ] Set variant='default' → both SystemConfig alias AND LINE default-for-all-users updated
- [ ] Missing FINANCE token → BadRequestException with Thai message surfaces to toast
- [ ] LIFF verify flow still links the correct rich menu via `switchRichMenu(userId, isVerified, channel)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)