### PR TITLE
test(rich-menu): cover switchRichMenu + annotate SHOP-only client

### DIFF
--- a/apps/api/src/modules/line-oa/line-oa.service.ts
+++ b/apps/api/src/modules/line-oa/line-oa.service.ts
@@ -39,6 +39,12 @@ export class LineOaService {
     private integrationConfig: IntegrationConfigService,
   ) {}
 
+  /**
+   * LineOaService is SHOP-only by design. FINANCE has its own client at
+   * chatbot-finance/services/line-finance-client.service.ts which reads
+   * the `line-finance` integration independently. If you need FINANCE LINE
+   * messaging, use that service — do NOT generalize this one.
+   */
   private async getShopChannelToken(): Promise<string> {
     return (await this.integrationConfig.getValue('line-shop', 'channelToken')) || '';
   }

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
@@ -117,6 +117,63 @@ describe('RichMenuService', () => {
     });
   });
 
+  describe('switchRichMenu', () => {
+    it.each([
+      ['shop', true, 'line.richMenu.shopVerified'],
+      ['shop', false, 'line.richMenu.shopDefault'],
+      ['finance', true, 'line.richMenu.financeVerified'],
+      ['finance', false, 'line.richMenu.financeDefault'],
+    ] as const)(
+      'composes SystemConfig key for channel=%s verified=%s -> %s',
+      async (channel, isVerified, expectedKey) => {
+        const getConfigSpy = jest
+          .spyOn(service, 'getRichMenuIdFromConfig')
+          .mockResolvedValue(null);
+
+        await service.switchRichMenu('U123', isVerified, channel);
+
+        expect(getConfigSpy).toHaveBeenCalledWith(expectedKey);
+      },
+    );
+
+    it('uses channel-specific token when linking Rich Menu', async () => {
+      jest.spyOn(service, 'getRichMenuIdFromConfig').mockResolvedValue('rm-finance-99');
+      integrationConfig.getValue.mockImplementation((key) =>
+        Promise.resolve(key === 'line-finance' ? 'finance-token' : null),
+      );
+      const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+      const originalFetch = global.fetch;
+      global.fetch = fetchMock as any;
+
+      try {
+        await service.switchRichMenu('U123', true, 'finance');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          expect.stringContaining('/user/U123/richmenu/rm-finance-99'),
+          expect.objectContaining({
+            headers: expect.objectContaining({ Authorization: 'Bearer finance-token' }),
+          }),
+        );
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
+    it('skips LINE API call when config key has no value', async () => {
+      jest.spyOn(service, 'getRichMenuIdFromConfig').mockResolvedValue(null);
+      const fetchMock = jest.fn();
+      const originalFetch = global.fetch;
+      global.fetch = fetchMock as any;
+
+      try {
+        await service.switchRichMenu('U123', false, 'shop');
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+  });
+
   describe('listRichMenus', () => {
     const originalFetch = global.fetch;
     afterEach(() => { global.fetch = originalFetch; });


### PR DESCRIPTION
## Summary
Follow-ups from PR #487 reviewer feedback:

- Add 6 new unit tests for `switchRichMenu` covering all 4 channel×variant key compositions, channel-specific token selection on `linkRichMenuToUser`, and the no-config skip path.
- Annotate `LineOaService.getShopChannelToken` as SHOP-only by design — FINANCE flows already go through `chatbot-finance/services/line-finance-client.service.ts` independently, so the hardcoded `line-shop` key is correct (not a bug, just needed clarification).

## Test plan
- [x] `npx jest rich-menu.service.spec.ts` — 14/14 pass (6 new)
- [x] `./tools/check-types.sh api` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)