### PR TITLE
feat(rich-menu): programmatic template generator for FINANCE channel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -49,6 +49,7 @@
     "class-validator": "^0.15.1",
     "cookie-parser": "^1.4.7",
     "ioredis": "^5.10.1",
+    "lucide-static": "^1.8.0",
     "nodemailer": "^8.0.5",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/apps/api/src/modules/line-oa/line-oa.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa.controller.ts
@@ -25,6 +25,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { PromptPayQrService } from './promptpay/promptpay-qr.service';
 import { RichMenuService } from './rich-menu/rich-menu.service';
 import { SetAliasDto } from './rich-menu/dto/set-alias.dto';
+import { DeployTemplateDto, SetCallCenterPhoneDto } from './rich-menu/dto/deploy-template.dto';
 
 /**
  * LINE OA Settings + Admin — owner-only configuration and test endpoints.
@@ -348,6 +349,35 @@ export class LineOaController {
   async setRichMenuAlias(@Param('id') id: string, @Body() dto: SetAliasDto) {
     await this.richMenuService.setRichMenuAlias(dto.channel, dto.variant, id);
     return { success: true, message: 'ตั้งค่า alias สำเร็จ' };
+  }
+
+  @Post('rich-menu/deploy-template')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async deployRichMenuTemplate(@Body() dto: DeployTemplateDto) {
+    const richMenuId = await this.richMenuService.deployFromTemplate(dto.templateKey);
+    return {
+      success: true,
+      richMenuId,
+      message: 'Generate + deploy rich menu จาก template สำเร็จ',
+    };
+  }
+
+  @Get('rich-menu/call-center-phone')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async getCallCenterPhone(@Query('channel') channel?: string) {
+    const ch = this.parseChannel(channel);
+    const phone = await this.richMenuService.getCallCenterPhone(ch);
+    return { phone };
+  }
+
+  @Post('rich-menu/call-center-phone')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER')
+  async setCallCenterPhone(@Body() dto: SetCallCenterPhoneDto) {
+    await this.richMenuService.setCallCenterPhone(dto.channel, dto.phone);
+    return { success: true, message: 'บันทึกเบอร์ติดต่อเรียบร้อย' };
   }
 
   private parseChannel(channel?: string): 'shop' | 'finance' {

--- a/apps/api/src/modules/line-oa/line-oa.module.ts
+++ b/apps/api/src/modules/line-oa/line-oa.module.ts
@@ -13,6 +13,7 @@ import { LiffTokenGuard } from './guards/liff-token.guard';
 import { PromptPayQrService } from './promptpay/promptpay-qr.service';
 import { PaymentLinkService } from './payment-links/payment-link.service';
 import { RichMenuService } from './rich-menu/rich-menu.service';
+import { RichMenuRendererService } from './rich-menu/rich-menu-renderer.service';
 import { ChatbotService } from './chatbot.service';
 import { QuickReplyService } from './quick-reply.service';
 import { ShopDomainHandler } from './shop-domain.handler';
@@ -42,6 +43,7 @@ import { ChatEngineModule } from '../chat-engine/chat-engine.module';
     PromptPayQrService,
     PaymentLinkService,
     RichMenuService,
+    RichMenuRendererService,
     ChatbotService,
     QuickReplyService,
     ShopDomainHandler,

--- a/apps/api/src/modules/line-oa/rich-menu/dto/deploy-template.dto.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/dto/deploy-template.dto.ts
@@ -1,0 +1,21 @@
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+
+export class DeployTemplateDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุ template' })
+  @IsIn(['finance-default', 'finance-verified'], {
+    message: 'template ไม่ถูกต้อง',
+  })
+  templateKey!: 'finance-default' | 'finance-verified';
+}
+
+export class SetCallCenterPhoneDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุ channel' })
+  @IsIn(['shop', 'finance'], { message: 'channel ต้องเป็น shop หรือ finance' })
+  channel!: 'shop' | 'finance';
+
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุเบอร์โทร' })
+  phone!: string;
+}

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu-renderer.service.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu-renderer.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as puppeteer from 'puppeteer';
+
+@Injectable()
+export class RichMenuRendererService {
+  private readonly logger = new Logger(RichMenuRendererService.name);
+
+  /**
+   * Render a rich-menu HTML template to a 2500×1686 PNG buffer.
+   *
+   * Uses a headless browser so Thai text shaping, web fonts, and CSS grid all
+   * work as they do in production — far more reliable than node-canvas for Thai.
+   */
+  async render(html: string): Promise<Buffer> {
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    try {
+      const page = await browser.newPage();
+      await page.setViewport({
+        width: 2500,
+        height: 1686,
+        deviceScaleFactor: 1,
+      });
+      await page.setContent(html, { waitUntil: 'networkidle0', timeout: 30000 });
+      await page.evaluateHandle('document.fonts.ready');
+
+      const buffer = await page.screenshot({
+        type: 'png',
+        omitBackground: false,
+        clip: { x: 0, y: 0, width: 2500, height: 1686 },
+      });
+      this.logger.log(`Rendered rich-menu image: ${buffer.length} bytes`);
+      return Buffer.from(buffer);
+    } finally {
+      await browser.close();
+    }
+  }
+}

--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.ts
@@ -2,6 +2,9 @@ import { Injectable, Logger, BadRequestException, InternalServerErrorException }
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { IntegrationConfigService } from '../../integrations/integration-config.service';
+import { RichMenuRendererService } from './rich-menu-renderer.service';
+import { getTemplateEntry, TemplateKey } from './templates/registry';
+import { TemplateContext } from './templates/types';
 
 export interface MenuButton {
   label: string;
@@ -46,6 +49,7 @@ export class RichMenuService {
     private configService: ConfigService,
     private prisma: PrismaService,
     private integrationConfig: IntegrationConfigService,
+    private renderer: RichMenuRendererService,
   ) {}
 
   private async getChannelToken(channel: 'shop' | 'finance' = 'shop'): Promise<string> {
@@ -522,6 +526,111 @@ export class RichMenuService {
     }
 
     this.logger.log(`Rich Menu alias set: ${key} = ${richMenuId}`);
+  }
+
+  /**
+   * Deploy a rich menu from a built-in HTML/CSS template.
+   *
+   * End-to-end flow: load template context (LIFF id, call-center phone) →
+   * build template → render HTML to PNG via puppeteer → create LINE rich
+   * menu → upload PNG → set alias (and if variant=default, set as channel
+   * default for new friends).
+   *
+   * Returns the newly created richMenuId.
+   */
+  async deployFromTemplate(templateKey: TemplateKey): Promise<string> {
+    const entry = getTemplateEntry(templateKey);
+    if (!entry) {
+      throw new BadRequestException(`ไม่พบ template: ${templateKey}`);
+    }
+
+    const ctx = await this.loadTemplateContext(entry.channel, entry.requires);
+    const template = entry.build(ctx);
+
+    const imageBuffer = await this.renderer.render(template.html);
+
+    const createResponse = await this.callLineApi(
+      `${this.lineApiBaseUrl}/richmenu`,
+      {
+        size: template.size,
+        selected: true,
+        name: template.name,
+        chatBarText: template.chatBarText,
+        areas: template.areas,
+      },
+      entry.channel,
+    );
+    const { richMenuId } = (await createResponse.json()) as { richMenuId: string };
+    this.logger.log(`Rich menu created from template "${templateKey}": ${richMenuId}`);
+
+    await this.uploadRichMenuImage(richMenuId, imageBuffer, entry.channel);
+    await this.setRichMenuAlias(entry.channel, entry.variant, richMenuId);
+
+    return richMenuId;
+  }
+
+  /**
+   * Load all TemplateContext fields that a template declares it needs.
+   * liffId comes from the channel's integration config; callCenterPhone from
+   * a dedicated SystemConfig key. Throws if a required field is missing so the
+   * caller gets a clear error instead of a broken template.
+   */
+  private async loadTemplateContext(
+    channel: 'shop' | 'finance',
+    required: Array<keyof TemplateContext>,
+  ): Promise<TemplateContext> {
+    const integrationKey = channel === 'shop' ? 'line-shop' : 'line-finance';
+    const ctx: TemplateContext = { liffId: '' };
+
+    if (required.includes('liffId')) {
+      const liffId = (await this.integrationConfig.getValue(integrationKey, 'liffId')) || '';
+      if (!liffId) {
+        throw new BadRequestException(
+          `LIFF ID ของ ${channel === 'shop' ? 'SHOP' : 'FINANCE'} ยังไม่ถูกตั้งค่า — กรุณาไปที่ /settings/integrations`,
+        );
+      }
+      ctx.liffId = liffId;
+    }
+
+    if (required.includes('callCenterPhone')) {
+      const phoneKey = `richMenu.${channel}.callCenterPhone`;
+      const record = await this.prisma.systemConfig.findFirst({
+        where: { key: phoneKey, deletedAt: null },
+      });
+      if (!record?.value) {
+        throw new BadRequestException(
+          `ยังไม่ได้ตั้งเบอร์ call center — ระบุที่ช่อง "เบอร์ติดต่อเจ้าหน้าที่" ก่อน generate`,
+        );
+      }
+      ctx.callCenterPhone = record.value;
+    }
+
+    return ctx;
+  }
+
+  /**
+   * Upsert the call-center phone used by Verified rich menu templates.
+   * Stored in SystemConfig under `richMenu.{channel}.callCenterPhone`.
+   */
+  async setCallCenterPhone(channel: 'shop' | 'finance', phone: string): Promise<void> {
+    const trimmed = phone.trim();
+    if (!trimmed) {
+      throw new BadRequestException('กรุณาระบุเบอร์โทร');
+    }
+    const key = `richMenu.${channel}.callCenterPhone`;
+    await this.prisma.systemConfig.upsert({
+      where: { key },
+      create: { key, value: trimmed },
+      update: { value: trimmed, deletedAt: null },
+    });
+  }
+
+  async getCallCenterPhone(channel: 'shop' | 'finance'): Promise<string | null> {
+    const key = `richMenu.${channel}.callCenterPhone`;
+    const record = await this.prisma.systemConfig.findFirst({
+      where: { key, deletedAt: null },
+    });
+    return record?.value ?? null;
   }
 
   /**

--- a/apps/api/src/modules/line-oa/rich-menu/templates/base-html.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/templates/base-html.ts
@@ -1,0 +1,185 @@
+import { RichMenuArea } from './types';
+
+export interface CellContent {
+  /** Inline Lucide SVG (from loadIcon). Rendered inside .cell .icon wrapper. */
+  iconSvg: string;
+  /** Thai label rendered below the icon */
+  label: string;
+  /** Hero cell gets gold accent ring — reserved for primary call-to-action */
+  hero?: boolean;
+  /** Urgent cell gets red label color — reserved for "pay now" style actions */
+  urgent?: boolean;
+}
+
+export interface BaseHtmlOptions {
+  /** 6 cells, order = top-left → top-right → bottom-left → bottom-right */
+  cells: CellContent[];
+  /** Background gradient — default mint→white. Verified variant uses deeper mint. */
+  bgGradient?: { from: string; to: string };
+}
+
+const DEFAULT_BG_FROM = '#F0FDF4';
+const DEFAULT_BG_TO = '#FFFFFF';
+const DIVIDER_COLOR = '#D1FAE5';
+const STROKE_COLOR = '#059669';
+const TEXT_COLOR = '#065F46';
+const URGENT_COLOR = '#DC2626';
+const HERO_ACCENT = '#D4AF37';
+
+/**
+ * Build the rich-menu HTML document. Puppeteer loads this string, waits for
+ * fonts, then screenshots the body at 2500×1686 — no JS, no network beyond fonts.
+ */
+export function buildRichMenuHtml(opts: BaseHtmlOptions): string {
+  if (opts.cells.length !== 6) {
+    throw new Error(`rich menu template requires exactly 6 cells, got ${opts.cells.length}`);
+  }
+
+  const bgFrom = opts.bgGradient?.from ?? DEFAULT_BG_FROM;
+  const bgTo = opts.bgGradient?.to ?? DEFAULT_BG_TO;
+
+  const cellsHtml = opts.cells
+    .map((cell, idx) => {
+      const classes = ['cell'];
+      if (cell.hero) classes.push('hero');
+      if (cell.urgent) classes.push('urgent');
+      return `
+        <div class="${classes.join(' ')}" data-cell="${idx + 1}">
+          <div class="icon-wrap">${cell.iconSvg}</div>
+          <div class="label">${escapeHtml(cell.label)}</div>
+        </div>`;
+    })
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="th">
+<head>
+<meta charset="utf-8" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Thai:wght@500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html, body {
+    width: 2500px;
+    height: 1686px;
+    overflow: hidden;
+    font-family: 'IBM Plex Sans Thai', system-ui, sans-serif;
+    background: linear-gradient(180deg, ${bgFrom} 0%, ${bgTo} 100%);
+  }
+
+  .grid {
+    width: 2500px;
+    height: 1586px;   /* reserve bottom 100px for LINE chat-bar overlay */
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+    gap: 1px;
+    background: ${DIVIDER_COLOR};
+  }
+
+  .chat-bar-gap {
+    width: 2500px;
+    height: 100px;
+    background: ${bgTo};
+  }
+
+  .cell {
+    background: linear-gradient(180deg, ${bgFrom} 0%, ${bgTo} 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 40px 40px;
+    gap: 36px;
+    position: relative;
+  }
+
+  .cell.hero::before {
+    content: '';
+    position: absolute;
+    inset: 14px;
+    border: 4px solid ${HERO_ACCENT};
+    border-radius: 12px;
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  .icon-wrap {
+    width: 300px;
+    height: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: ${STROKE_COLOR};
+  }
+
+  .cell.urgent .icon-wrap { color: ${URGENT_COLOR}; }
+
+  .icon-wrap svg {
+    width: 100%;
+    height: 100%;
+    stroke-width: 2;
+  }
+
+  .label {
+    font-size: 72px;
+    font-weight: 600;
+    color: ${TEXT_COLOR};
+    line-height: 1.3;
+    text-align: center;
+    letter-spacing: -0.5px;
+    max-width: 100%;
+    word-break: keep-all;
+  }
+
+  .cell.urgent .label { color: ${URGENT_COLOR}; }
+</style>
+</head>
+<body>
+  <div class="grid">${cellsHtml}
+  </div>
+  <div class="chat-bar-gap"></div>
+</body>
+</html>`;
+}
+
+/**
+ * Generate the standard 2×3 LINE rich-menu tap-area bounds.
+ * Each cell is 833×843 — width uses integer division (last column absorbs the
+ * +1 remainder) to keep the total at exactly 2500×1686 as LINE requires.
+ */
+export function build2x3Areas(actions: RichMenuArea['action'][]): RichMenuArea[] {
+  if (actions.length !== 6) {
+    throw new Error(`2×3 rich menu requires exactly 6 actions, got ${actions.length}`);
+  }
+  const cols = 3;
+  const rows = 2;
+  const baseWidth = Math.floor(2500 / cols);
+  const cellHeight = 1686 / rows;
+  const lastColWidth = 2500 - baseWidth * (cols - 1);
+
+  return actions.map((action, i) => {
+    const row = Math.floor(i / cols);
+    const col = i % cols;
+    const width = col === cols - 1 ? lastColWidth : baseWidth;
+    return {
+      bounds: {
+        x: col * baseWidth,
+        y: row * cellHeight,
+        width,
+        height: cellHeight,
+      },
+      action,
+    };
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/apps/api/src/modules/line-oa/rich-menu/templates/finance-default.template.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/templates/finance-default.template.ts
@@ -1,0 +1,44 @@
+import { build2x3Areas, buildRichMenuHtml } from './base-html';
+import { loadIcon } from './icons';
+import { RichMenuTemplate, TemplateContext } from './types';
+
+/**
+ * FINANCE Default (Pre-Verify) rich menu.
+ * Audience: LINE users who have added the OA but not yet linked their phone.
+ * Goal: drive verification; avoid actions that require contract data.
+ */
+export function buildFinanceDefaultTemplate(ctx: TemplateContext): RichMenuTemplate {
+  if (!ctx.liffId) {
+    throw new Error('liffId is required to build finance default template');
+  }
+
+  const liffBase = `https://liff.line.me/${ctx.liffId}`;
+
+  const html = buildRichMenuHtml({
+    cells: [
+      { iconSvg: loadIcon('key-round'), label: 'ผูกเบอร์เริ่มใช้งาน', hero: true },
+      { iconSvg: loadIcon('credit-card'), label: 'วิธีชำระค่างวด' },
+      { iconSvg: loadIcon('book-open'), label: 'วิธีใช้งาน' },
+      { iconSvg: loadIcon('headset'), label: 'ติดต่อเจ้าหน้าที่' },
+      { iconSvg: loadIcon('circle-help'), label: 'คำถามที่พบบ่อย' },
+      { iconSvg: loadIcon('refresh-cw'), label: 'เปลี่ยนเบอร์' },
+    ],
+  });
+
+  const areas = build2x3Areas([
+    { type: 'uri', label: 'ผูกเบอร์', uri: `${liffBase}/finance-verify` },
+    { type: 'message', label: 'วิธีชำระ', text: 'วิธีชำระ' },
+    { type: 'message', label: 'วิธีใช้งาน', text: 'วิธีใช้งาน' },
+    { type: 'message', label: 'ติดต่อ', text: 'ติดต่อเจ้าหน้าที่' },
+    { type: 'message', label: 'FAQ', text: 'FAQ' },
+    { type: 'message', label: 'เปลี่ยนเบอร์', text: 'เปลี่ยนเบอร์' },
+  ]);
+
+  return {
+    name: 'BESTCHOICE FINANCE — Default (Pre-Verify)',
+    chatBarText: 'เมนูน้องเบส',
+    size: { width: 2500, height: 1686 },
+    html,
+    areas,
+  };
+}

--- a/apps/api/src/modules/line-oa/rich-menu/templates/finance-verified.template.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/templates/finance-verified.template.ts
@@ -1,0 +1,50 @@
+import { build2x3Areas, buildRichMenuHtml } from './base-html';
+import { loadIcon } from './icons';
+import { RichMenuTemplate, TemplateContext } from './types';
+
+/**
+ * FINANCE Verified rich menu.
+ * Audience: customers who have linked their phone — system knows their
+ * contracts and can show balance, schedule, history.
+ */
+export function buildFinanceVerifiedTemplate(ctx: TemplateContext): RichMenuTemplate {
+  if (!ctx.liffId) {
+    throw new Error('liffId is required to build finance verified template');
+  }
+  if (!ctx.callCenterPhone) {
+    throw new Error('callCenterPhone is required to build finance verified template');
+  }
+
+  const liffBase = `https://liff.line.me/${ctx.liffId}`;
+  const telUri = `tel:${ctx.callCenterPhone.replace(/[^\d+]/g, '')}`;
+
+  const html = buildRichMenuHtml({
+    // Slightly deeper mint tint signals "activated" state vs Default.
+    bgGradient: { from: '#ECFDF5', to: '#FFFFFF' },
+    cells: [
+      { iconSvg: loadIcon('wallet'), label: 'เช็คยอด', hero: true },
+      { iconSvg: loadIcon('calendar-days'), label: 'ดูตารางงวด' },
+      { iconSvg: loadIcon('credit-card'), label: 'ชำระเงิน', urgent: true },
+      { iconSvg: loadIcon('receipt'), label: 'ประวัติชำระ' },
+      { iconSvg: loadIcon('file-text'), label: 'เช็คสัญญา' },
+      { iconSvg: loadIcon('phone'), label: 'โทรหาเจ้าหน้าที่' },
+    ],
+  });
+
+  const areas = build2x3Areas([
+    { type: 'message', label: 'เช็คยอด', text: 'เช็คยอด' },
+    { type: 'message', label: 'ตารางงวด', text: 'ดูตารางงวด' },
+    { type: 'message', label: 'ชำระเงิน', text: 'ชำระเงิน' },
+    { type: 'uri', label: 'ประวัติ', uri: `${liffBase}/history` },
+    { type: 'uri', label: 'สัญญา', uri: `${liffBase}/contract` },
+    { type: 'uri', label: 'โทร', uri: telUri },
+  ]);
+
+  return {
+    name: 'BESTCHOICE FINANCE — Verified',
+    chatBarText: 'เมนูน้องเบส',
+    size: { width: 2500, height: 1686 },
+    html,
+    areas,
+  };
+}

--- a/apps/api/src/modules/line-oa/rich-menu/templates/icons.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/templates/icons.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+let cachedIconsDir: string | null = null;
+
+function resolveIconsDir(): string {
+  if (cachedIconsDir) return cachedIconsDir;
+  const pkgPath = require.resolve('lucide-static/package.json');
+  cachedIconsDir = join(dirname(pkgPath), 'icons');
+  return cachedIconsDir;
+}
+
+/**
+ * Load a Lucide SVG icon as an inline string.
+ * The returned SVG has `stroke="currentColor"` so callers can color it via CSS.
+ */
+export function loadIcon(name: string): string {
+  const filePath = join(resolveIconsDir(), `${name}.svg`);
+  return readFileSync(filePath, 'utf8').replace(/<!--[\s\S]*?-->/g, '').trim();
+}

--- a/apps/api/src/modules/line-oa/rich-menu/templates/registry.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/templates/registry.ts
@@ -1,0 +1,37 @@
+import { buildFinanceDefaultTemplate } from './finance-default.template';
+import { buildFinanceVerifiedTemplate } from './finance-verified.template';
+import { RichMenuTemplate, TemplateContext } from './types';
+
+export type TemplateKey =
+  | 'finance-default'
+  | 'finance-verified';
+
+export interface TemplateEntry {
+  key: TemplateKey;
+  channel: 'shop' | 'finance';
+  variant: 'default' | 'verified';
+  build: (ctx: TemplateContext) => RichMenuTemplate;
+  /** Which TemplateContext fields this template needs */
+  requires: Array<keyof TemplateContext>;
+}
+
+export const TEMPLATE_REGISTRY: TemplateEntry[] = [
+  {
+    key: 'finance-default',
+    channel: 'finance',
+    variant: 'default',
+    build: buildFinanceDefaultTemplate,
+    requires: ['liffId'],
+  },
+  {
+    key: 'finance-verified',
+    channel: 'finance',
+    variant: 'verified',
+    build: buildFinanceVerifiedTemplate,
+    requires: ['liffId', 'callCenterPhone'],
+  },
+];
+
+export function getTemplateEntry(key: string): TemplateEntry | undefined {
+  return TEMPLATE_REGISTRY.find((e) => e.key === key);
+}

--- a/apps/api/src/modules/line-oa/rich-menu/templates/types.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/templates/types.ts
@@ -1,0 +1,27 @@
+export type RichMenuAction =
+  | { type: 'uri'; label: string; uri: string }
+  | { type: 'message'; label: string; text: string };
+
+export interface RichMenuArea {
+  bounds: { x: number; y: number; width: number; height: number };
+  action: RichMenuAction;
+}
+
+export interface RichMenuTemplate {
+  /** LINE rich menu name (internal reference, ≤ 300 chars) */
+  name: string;
+  /** Chat-bar label shown under the menu icon (≤ 14 chars) */
+  chatBarText: string;
+  /** Rendered HTML string — passed to puppeteer to rasterize to PNG */
+  html: string;
+  size: { width: number; height: number };
+  /** LINE rich menu tap-area definitions (must match the grid in html) */
+  areas: RichMenuArea[];
+}
+
+export interface TemplateContext {
+  /** LIFF app id, used to build LIFF URIs (https://liff.line.me/{id}/...) */
+  liffId: string;
+  /** Call-center number for tel: actions (Verified menu). Required for finance. */
+  callCenterPhone?: string;
+}

--- a/apps/web/src/pages/RichMenuPage.tsx
+++ b/apps/web/src/pages/RichMenuPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { LayoutGrid, Trash2, Star, Upload, Plus, ImageIcon, Pencil, Copy } from 'lucide-react';
+import { LayoutGrid, Trash2, Star, Upload, Plus, ImageIcon, Pencil, Copy, Sparkles, Phone } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
@@ -555,6 +555,48 @@ export default function RichMenuPage() {
     onError: (err) => toast.error(getErrorMessage(err)),
   });
 
+  // Template deployment (FINANCE only for now)
+  const { data: callCenterPhoneData, refetch: refetchCallCenterPhone } = useQuery({
+    queryKey: ['rich-menu-call-center-phone', channel],
+    queryFn: async () => {
+      const res = await api.get(`/line-oa/rich-menu/call-center-phone?channel=${channel}`);
+      return res.data as { phone: string | null };
+    },
+    enabled: channel === 'finance',
+  });
+
+  const [callCenterPhone, setCallCenterPhone] = useState('');
+  useEffect(() => {
+    if (callCenterPhoneData?.phone) {
+      setCallCenterPhone(callCenterPhoneData.phone);
+    }
+  }, [callCenterPhoneData]);
+
+  const saveCallCenterPhoneMutation = useMutation({
+    mutationFn: async (phone: string) => {
+      await api.post('/line-oa/rich-menu/call-center-phone', { channel, phone });
+    },
+    onSuccess: () => {
+      toast.success('บันทึกเบอร์ติดต่อเรียบร้อย');
+      refetchCallCenterPhone();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const deployTemplateMutation = useMutation({
+    mutationFn: async (templateKey: 'finance-default' | 'finance-verified') => {
+      const res = await api.post('/line-oa/rich-menu/deploy-template', { templateKey });
+      return res.data as { richMenuId: string };
+    },
+    onSuccess: () => {
+      toast.success('สร้าง + deploy Rich Menu จาก template สำเร็จ');
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-list', channel] });
+      queryClient.invalidateQueries({ queryKey: ['rich-menu-aliases'] });
+      setActiveTab('list');
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
   // ── Handlers ──────────────────────────────────────────────────────────────
 
   function handleEditMenu(menu: RichMenu) {
@@ -638,6 +680,100 @@ export default function RichMenuPage() {
       {/* ── TAB: สร้างเมนู ─────────────────────────────────────────────────── */}
       {activeTab === 'create' && (
         <div className="space-y-6">
+          {/* FINANCE-only: Generate from template */}
+          {channel === 'finance' && !editingMenuId && (
+            <div className="rounded-xl border border-primary/20 bg-primary/5 shadow-sm overflow-hidden">
+              <div className="px-5 py-3.5 border-b border-primary/20 bg-primary/10 flex items-center gap-2">
+                <Sparkles size={18} className="text-primary" />
+                <div>
+                  <h2 className="text-base font-semibold text-foreground">สร้างอัตโนมัติจาก Template</h2>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    ระบบจะ generate รูป + ติดตั้ง alias ให้ครบในคลิกเดียว
+                  </p>
+                </div>
+              </div>
+              <div className="p-5 space-y-4">
+                {/* Call center phone input */}
+                <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-2 items-end">
+                  <div>
+                    <label className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
+                      <Phone size={14} />
+                      เบอร์โทรศูนย์บริการ (Call Center)
+                    </label>
+                    <Input
+                      type="tel"
+                      value={callCenterPhone}
+                      onChange={(e) => setCallCenterPhone(e.target.value)}
+                      placeholder="เช่น 02-xxx-xxxx"
+                      className="font-mono"
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      ใช้บนปุ่ม "โทรหาเจ้าหน้าที่" ในเมนูหลัง verify
+                    </p>
+                  </div>
+                  <Button
+                    variant="outline"
+                    onClick={() => saveCallCenterPhoneMutation.mutate(callCenterPhone)}
+                    disabled={!callCenterPhone || saveCallCenterPhoneMutation.isPending}
+                  >
+                    บันทึก
+                  </Button>
+                </div>
+
+                {/* Template cards */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Badge className="bg-muted text-muted-foreground border-0">Pre-verify</Badge>
+                      <span className="font-semibold text-sm">FINANCE — Default</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      เมนูก่อนลูกค้าผูกเบอร์: ผูกเบอร์ (hero) · วิธีชำระ · วิธีใช้งาน · ติดต่อ · FAQ · เปลี่ยนเบอร์
+                    </p>
+                    <Button
+                      className="w-full bg-gradient-to-r from-[#06C755] to-[#04a844] hover:from-[#04a844] hover:to-[#038537] text-white border-0"
+                      onClick={() => deployTemplateMutation.mutate('finance-default')}
+                      disabled={deployTemplateMutation.isPending}
+                    >
+                      <Sparkles size={14} className="mr-1.5" />
+                      {deployTemplateMutation.isPending &&
+                      deployTemplateMutation.variables === 'finance-default'
+                        ? 'กำลัง generate...'
+                        : 'Generate + Deploy'}
+                    </Button>
+                  </div>
+
+                  <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Badge className="bg-primary/10 text-primary border-primary/30">Verified</Badge>
+                      <span className="font-semibold text-sm">FINANCE — Verified</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      เมนูหลังผูกเบอร์: เช็คยอด (hero) · ตารางงวด · ชำระเงิน · ประวัติ · สัญญา · โทรหาเจ้าหน้าที่
+                    </p>
+                    <Button
+                      className="w-full bg-gradient-to-r from-[#06C755] to-[#04a844] hover:from-[#04a844] hover:to-[#038537] text-white border-0"
+                      onClick={() => deployTemplateMutation.mutate('finance-verified')}
+                      disabled={deployTemplateMutation.isPending || !callCenterPhoneData?.phone}
+                      title={!callCenterPhoneData?.phone ? 'กรุณาบันทึกเบอร์โทรก่อน' : undefined}
+                    >
+                      <Sparkles size={14} className="mr-1.5" />
+                      {deployTemplateMutation.isPending &&
+                      deployTemplateMutation.variables === 'finance-verified'
+                        ? 'กำลัง generate...'
+                        : 'Generate + Deploy'}
+                    </Button>
+                    {!callCenterPhoneData?.phone && (
+                      <p className="text-xs text-destructive">
+                        ต้องบันทึกเบอร์โทรก่อนจึงจะ deploy ได้
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
           {editingMenuId && (
             <div className="bg-warning/10 border border-warning/20 rounded-xl p-3 flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "class-validator": "^0.15.1",
         "cookie-parser": "^1.4.7",
         "ioredis": "^5.10.1",
+        "lucide-static": "^1.8.0",
         "nodemailer": "^8.0.5",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -19095,6 +19096,12 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/lucide-static": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-1.8.0.tgz",
+      "integrity": "sha512-eQJCJuDg3tyQrjP0PwD5eIA4ePd5CMdxkrfyqk3iUQA4VOtsJ0v5T6IBJ5UyR3SYHzUn8HOAEL+I+SLVnOJNIA==",
+      "license": "ISC"
     },
     "node_modules/luxon": {
       "version": "3.7.2",


### PR DESCRIPTION
## Summary
- Generate LINE Rich Menu images from HTML templates using puppeteer (better Thai text shaping than node-canvas, reuses web fonts/CSS)
- Two FINANCE templates: **finance-default** (pre-verify) and **finance-verified** (verified), each 6 cells / 2x3 grid
- One-click "Generate + Deploy" button on `/settings/rich-menu` (FINANCE tab) — renders PNG, creates LINE Rich Menu, uploads image, sets alias

## Changes

**Backend (new):**
- `rich-menu-renderer.service.ts` — puppeteer HTML→PNG (2500×1686, waits for fonts.ready)
- `templates/base-html.ts` — shared CSS (IBM Plex Sans Thai via Google Fonts, emerald/gold/red accents)
- `templates/finance-default.template.ts` — Pre-verify menu: ผูกเบอร์ (hero) / วิธีชำระ / วิธีใช้งาน / ติดต่อ / FAQ / เปลี่ยนเบอร์
- `templates/finance-verified.template.ts` — Verified menu: เช็คยอด (hero) / ตารางงวด / ชำระเงิน (urgent) / ประวัติ (LIFF) / สัญญา (LIFF) / โทรหาเจ้าหน้าที่ (tel:)
- `templates/icons.ts` — loads lucide-static SVGs (matches frontend lucide-react)
- `templates/registry.ts` — key→builder mapping with `requires` metadata
- `dto/deploy-template.dto.ts` — DeployTemplateDto + SetCallCenterPhoneDto (Thai error messages)

**Backend (modified):**
- `rich-menu.service.ts` — `deployFromTemplate(templateKey)` orchestrates render → LINE create → upload → alias; `{get,set}CallCenterPhone(channel)` via SystemConfig
- `line-oa.module.ts` — registers RichMenuRendererService
- `line-oa.controller.ts` — 3 endpoints under `/line-oa/rich-menu/`:
  - `POST deploy-template` (OWNER)
  - `GET|POST call-center-phone`

**Frontend:**
- `RichMenuPage.tsx` — adds "สร้างอัตโนมัติจาก Template" section (FINANCE only) with call-center phone input + 2 template cards

**Deps:**
- `lucide-static` ^1.8.0 (hoisted to root, ~2MB, provides ~2000 SVG icons)

## Test plan
- [ ] `./tools/check-types.sh all` passes ✅ (verified locally — API + Web both clean)
- [ ] Open `/settings/rich-menu` → FINANCE tab → see "สร้างอัตโนมัติจาก Template" card
- [ ] Enter call-center phone → บันทึก → refetch returns same phone
- [ ] Click "Generate + Deploy" on finance-default → toast success → menu appears in list → alias `richmenu-alias-default-finance` points to new menuId
- [ ] Repeat for finance-verified (requires phone saved first — button disabled without it)
- [ ] Verified menu has "โทรหาเจ้าหน้าที่" action = `tel:{phone}`
- [ ] LINE OA app preview shows rendered PNG with Thai text correctly shaped

## Notes
- Uses puppeteer already installed for PDF generation — no new heavyweight dep
- Templates are pure functions (HTML + areas) — easy to add more variants later (e.g., shop-default, shop-verified)
- SystemConfig keys: `richMenu.{channel}.callCenterPhone` — isolated from SHOP
- Frontend button disabled until phone set (prevents deploying verified template with placeholder 02-000-0000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)