### PR TITLE
fix(customers): references stripped by ValidationPipe whitelist

### DIFF
--- a/apps/api/src/modules/customers/dto/customer.dto.ts
+++ b/apps/api/src/modules/customers/dto/customer.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsArray, IsBoolean, IsDateString, IsEmail, IsNumber, Length, Matches, ValidateNested } from 'class-validator';
+import { IsString, IsOptional, IsArray, IsBoolean, IsDateString, IsEmail, IsNumber, Length, Matches } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class CreateCustomerDto {
@@ -92,7 +92,6 @@ export class CreateCustomerDto {
   addressWork?: string;
 
   @IsArray()
-  @ValidateNested({ each: true })
   @IsOptional()
   references?: Record<string, unknown>[];
 
@@ -195,7 +194,6 @@ export class UpdateCustomerDto {
   addressWork?: string;
 
   @IsArray()
-  @ValidateNested({ each: true })
   @IsOptional()
   references?: Record<string, unknown>[];
 


### PR DESCRIPTION
## Summary
- `@ValidateNested({ each: true })` without `@Type()` combined with `whitelist: true` in ValidationPipe strips all nested object properties, causing `references` to persist as `[{}, {}, ...]` instead of the actual data.
- `references` is a JSON field (`Record<string, unknown>[]`) with no class schema, so nested validation doesn't apply. Removing the decorator lets the array pass through intact.

## Impact
- Unblocks `PATCH /customers/:id` for the references field — required by `submitForReview` which enforces at least 1 emergency contact in prod.
- Same path used by LIFF customer registration + staff CustomerDetail page.

## Test plan
- [x] `./tools/check-types.sh api` passes
- [ ] After deploy: PATCH customer references on prod, verify saved as real objects (not `[{}]`)
- [ ] `submitForReview` passes the references check

🤖 Generated with [Claude Code](https://claude.com/claude-code)