### PR TITLE
fix(rich-menu): add RichMenuRendererService provider to test module

### DIFF
--- a/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
+++ b/apps/api/src/modules/line-oa/rich-menu/rich-menu.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { RichMenuService } from './rich-menu.service';
+import { RichMenuRendererService } from './rich-menu-renderer.service';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { IntegrationConfigService } from '../../integrations/integration-config.service';
@@ -18,6 +19,7 @@ describe('RichMenuService', () => {
         { provide: ConfigService, useValue: { get: jest.fn() } },
         { provide: PrismaService, useValue: { systemConfig: { findFirst: jest.fn(), upsert: jest.fn() } } },
         { provide: IntegrationConfigService, useValue: integrationConfig },
+        { provide: RichMenuRendererService, useValue: { renderTemplate: jest.fn() } },
       ],
     }).compile();
 


### PR DESCRIPTION
## Summary
- PR #489 added `RichMenuRendererService` as a constructor dependency of `RichMenuService`, but the test spec wasn't updated → Nest DI resolution fails in all 14 tests.
- Deploy workflow has been red since PR #489 merged. This unblocks it.

## Test plan
- [x] `npx jest rich-menu.service.spec.ts` — 14 passed
- [ ] Deploy workflow green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)