### PR TITLE
fix(customers): bypass class-transformer coercion on references (followup to #490)

### DIFF
--- a/apps/api/src/modules/customers/dto/customer.dto.ts
+++ b/apps/api/src/modules/customers/dto/customer.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, IsOptional, IsArray, IsBoolean, IsDateString, IsEmail, IsNumber, Length, Matches } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 
 export class CreateCustomerDto {
   @IsString()
@@ -93,6 +93,7 @@ export class CreateCustomerDto {
 
   @IsArray()
   @IsOptional()
+  @Transform(({ value }) => value, { toClassOnly: true })
   references?: Record<string, unknown>[];
 
   @IsString()
@@ -195,6 +196,7 @@ export class UpdateCustomerDto {
 
   @IsArray()
   @IsOptional()
+  @Transform(({ value }) => value, { toClassOnly: true })
   references?: Record<string, unknown>[];
 
   @IsString()


### PR DESCRIPTION
## Summary
- #490 removed `@ValidateNested()` but **references still persists as `[[], []]` on prod**.
- Verified on prod after deploy: PATCH sends `[{name,phone}, ...]`, DB stores `[[], []]`.
- Root cause: `ValidationPipe({transform: true, whitelist: true})` + `@IsArray()` on `Record<string, unknown>[]` — no reflection metadata for item type. class-transformer's implicit conversion coerces each plain object into `Array.from(obj) = []`.

## Fix
Add `@Transform(({value}) => value, {toClassOnly: true})` to short-circuit the default plainToInstance conversion and preserve the raw JSON array.

## Test plan
- [x] Type check passes
- [ ] After deploy: PATCH customer references on prod, verify real objects stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)