### PR TITLE
fix(customer-detail): sanitize references to prevent crash on legacy garbage

### DIFF
--- a/apps/web/src/components/contract/CustomerEditModal.tsx
+++ b/apps/web/src/components/contract/CustomerEditModal.tsx
@@ -71,7 +71,12 @@ export default function CustomerEditModal({ customerId, customerSnapshot, custom
         setAddrCurrent(deserializeAddress(fc.addressCurrent));
         setAddrWork(deserializeAddress(fc.addressWork));
         setSameAddress(fc.addressIdCard != null && fc.addressIdCard === fc.addressCurrent);
-        const existingRefs = (fc.references || []) as CustReferenceData[];
+        // Sanitize: drop non-object garbage (legacy bug could persist null/strings/arrays)
+        const existingRefs = Array.isArray(fc.references)
+          ? (fc.references as unknown[]).filter(
+              (r): r is CustReferenceData => r !== null && typeof r === 'object' && !Array.isArray(r),
+            )
+          : [];
         const refs = [...existingRefs];
         while (refs.length < 4) refs.push({});
         setReferences(refs);

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -222,8 +222,12 @@ export default function CustomerDetailPage() {
     setEditSameAddress(
       customer.addressIdCard != null && customer.addressIdCard === customer.addressCurrent
     );
-    // Initialize references with 4 slots
-    const existingRefs = (customer.references || []) as ReferenceData[];
+    // Initialize references with 4 slots (sanitize: drop non-object garbage like null/strings/nested arrays)
+    const existingRefs = Array.isArray(customer.references)
+      ? customer.references.filter(
+          (r): r is ReferenceData => r !== null && typeof r === 'object' && !Array.isArray(r),
+        )
+      : [];
     const refs = [...existingRefs];
     while (refs.length < 4) refs.push({});
     setEditRefs(refs);
@@ -425,7 +429,11 @@ export default function CustomerDetailPage() {
   ];
 
   const displayName = [customer.prefix, customer.name].filter(Boolean).join('');
-  const refs = customer.references as ReferenceData[] | null;
+  const refs = Array.isArray(customer.references)
+    ? (customer.references.filter(
+        (r): r is ReferenceData => r !== null && typeof r === 'object' && !Array.isArray(r),
+      ))
+    : null;
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- \`CustomerDetailPage\` + \`CustomerEditModal\` crash บน \`null.prefix\` เมื่อเจอ legacy garbage ใน \`references\` field (จากบัค coercion ก่อน PR #493)
- Sanitize — filter ให้เหลือแค่ plain objects ก่อน render/edit

## Root cause
PR #490-493 แก้ backend แล้ว object ใหม่เก็บถูกต้อง แต่ customer ที่โดนบัคเดิมยังมีข้อมูลเก่าในฐาน เช่น \`["str", [], 42, null, [1,2]]\`
- \`null.prefix\` → TypeError crash
- \`[].prefix\` / \`"str".prefix\` → undefined (ไม่ crash)

## Test plan
- [x] Type check web passed
- [ ] Deploy แล้วเปิด CustomerDetailPage ของลูกค้าที่มี legacy references → ไม่ crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)