### PR TITLE
fix(kyc): surface real OTP send error for diagnostics

### DIFF
--- a/apps/api/src/modules/kyc/kyc.service.ts
+++ b/apps/api/src/modules/kyc/kyc.service.ts
@@ -72,7 +72,9 @@ export class KycService {
         fallbackPhone: channel === 'LINE' ? customer.phone : undefined,
       });
       if (result.status === 'FAILED') {
-        throw new InternalServerErrorException('Notification service returned FAILED status');
+        throw new InternalServerErrorException(
+          result.errorMsg || 'Notification service returned FAILED status',
+        );
       }
     } catch (err) {
       const errMessage = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -49,7 +49,7 @@ export class NotificationsService {
   /**
    * Send a notification via LINE, SMS, or IN_APP with retry support
    */
-  async send(dto: SendNotificationDto): Promise<{ id: string; status: string }> {
+  async send(dto: SendNotificationDto): Promise<{ id: string; status: string; errorMsg?: string }> {
     let status = 'PENDING';
     let errorMsg: string | null = null;
     let sentAt: Date | null = null;
@@ -127,7 +127,7 @@ export class NotificationsService {
       await this.markForRetry(log.id, 0);
     }
 
-    return { id: log.id, status };
+    return { id: log.id, status, errorMsg: errorMsg ?? undefined };
   }
 
   /**


### PR DESCRIPTION
## Summary
- `NotificationsService.send` swallowed provider errors (credentials invalid, not configured, number invalid) and returned `{status:'FAILED'}` with the real reason only in the DB log.
- `KycService.sendOtp` re-threw with `'Notification service returned FAILED status'` → classifier never matched → user always saw generic `'ไม่สามารถส่ง OTP ได้ กรุณาลองใหม่'`.
- Now `send()` returns `errorMsg`, and `sendOtp` re-throws it so the existing keyword classifier produces a useful message.

## Context
Owner hit this signing contract `BCP2604-00471` on prod — no way to tell from the error whether SMS creds were missing, wrong, or the customer's phone was rejected by ThaiBulkSMS.

## Test plan
- [x] `./tools/check-types.sh api` — passes
- [ ] Post-deploy: retry OTP on prod; confirm error message now reflects real cause (e.g. "ระบบ SMS ยังไม่ได้ตั้งค่า" if integration not configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)