### PR TITLE
fix(kyc): don't queue OTP for retry — expires before retry fires

### DIFF
--- a/apps/api/src/modules/kyc/kyc.service.ts
+++ b/apps/api/src/modules/kyc/kyc.service.ts
@@ -70,6 +70,7 @@ export class KycService {
         message,
         relatedId: contractId,
         fallbackPhone: channel === 'LINE' ? customer.phone : undefined,
+        noRetry: true, // OTP expires in 10 min — retry queue would only spam
       });
       if (result.status === 'FAILED') {
         throw new InternalServerErrorException(

--- a/apps/api/src/modules/notifications/dto/create-notification.dto.ts
+++ b/apps/api/src/modules/notifications/dto/create-notification.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsArray, IsDateString } from 'class-validator';
+import { IsString, IsOptional, IsArray, IsDateString, IsBoolean } from 'class-validator';
 
 export class SendNotificationDto {
   @IsString()
@@ -21,6 +21,13 @@ export class SendNotificationDto {
   @IsString()
   @IsOptional()
   fallbackPhone?: string; // SMS fallback if LINE fails
+
+  // Time-sensitive messages (e.g. OTP with 10-min TTL) should not be queued
+  // for delayed retry — retries would arrive after the OTP has already expired
+  // and spam the recipient. Caller sets this to true to skip the retry queue.
+  @IsBoolean()
+  @IsOptional()
+  noRetry?: boolean;
 }
 
 export class CreateNotificationTemplateDto {

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -122,8 +122,10 @@ export class NotificationsService {
       },
     });
 
-    // If failed, schedule for persistent retry queue
-    if (status === 'FAILED' && dto.channel !== 'IN_APP') {
+    // If failed, schedule for persistent retry queue — unless the caller
+    // flagged the message as time-sensitive (e.g. OTP: the code expires in
+    // 10 min, so retrying later is useless and spammy).
+    if (status === 'FAILED' && dto.channel !== 'IN_APP' && !dto.noRetry) {
       await this.markForRetry(log.id, 0);
     }
 


### PR DESCRIPTION
## Summary
OTP SMS sends got queued into the persistent retry table when they failed. When the underlying SMS integration was fixed, the cron drained the backlog and the user received a flood of already-expired OTP codes.

## Fix
- `SendNotificationDto.noRetry?: boolean` — caller opts out of retry queue for time-sensitive messages.
- `NotificationsService.send` skips `markForRetry` when flag is set.
- `KycService.sendOtp` passes `noRetry: true` (OTP TTL = 10 min).

## Test plan
- [x] `./tools/check-types.sh api` passes
- [ ] Post-deploy: trigger an OTP send while SMS broken; verify no `RETRY_PENDING` row is created for that send (can check `notificationLog` table).
- [ ] Non-OTP alerts (PAYMENT_REMINDER etc.) still retry — behavior unchanged because they don't pass `noRetry`.

## Cleanup
**Also need to flush the existing backlog once** for contract `8e3cdfe3-646b-4e3a-b864-6d6a923becd5` (BCP2604-00471) — otherwise the queue will keep firing until this code is deployed + expired:

```sql
UPDATE "NotificationLog"
SET status = 'FAILED', "errorMsg" = 'manual-flush: stale OTP retry'
WHERE status = 'RETRY_PENDING'
  AND "relatedId" = '8e3cdfe3-646b-4e3a-b864-6d6a923becd5';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)