### PR TITLE
feat(contract): approve-panel readability (both modes) + auto-save signed PDF

### DIFF
--- a/apps/api/src/modules/contracts/documents.service.ts
+++ b/apps/api/src/modules/contracts/documents.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
-import { SignerType, Prisma } from '@prisma/client';
+import { SignerType, Prisma, ContractDocumentType } from '@prisma/client';
 import { formatDateShort, formatDateMedium, formatDateLong, getThaiDateParts } from '../../utils/thai-date.util';
 import { PrismaService } from '../../prisma/prisma.service';
 import { StorageService } from '../storage/storage.service';
@@ -148,7 +148,101 @@ export class DocumentsService {
       },
     });
 
+    // After all 4 required signatures are present, auto-generate the signed
+    // contract PDF and save it as a ContractDocument (SIGNED_CONTRACT).
+    // This satisfies the reviewer checklist without the user having to
+    // manually upload a signed PDF — the system already has everything it
+    // needs to produce one deterministically.
+    const REQUIRED: Array<'CUSTOMER' | 'COMPANY' | 'WITNESS_1' | 'WITNESS_2'> = [
+      'CUSTOMER',
+      'COMPANY',
+      'WITNESS_1',
+      'WITNESS_2',
+    ];
+    const allSignerTypes = new Set<string>([
+      ...contract.signatures.map((s) => (s.signerType === 'STAFF' ? 'COMPANY' : s.signerType)),
+      normalizedType,
+    ]);
+    const allSigned = REQUIRED.every((t) => allSignerTypes.has(t));
+    if (allSigned) {
+      // Fire-and-forget — don't block the signing response on PDF generation
+      // (puppeteer can take a few seconds). A salesperson fallback handles
+      // the CUSTOMER-signs-via-LIFF case where staffUserId is null.
+      const uploaderId = options?.staffUserId || contract.salespersonId;
+      this.ensureSignedContractDocument(contractId, uploaderId).catch((err) =>
+        this.logger.error(
+          `Auto-save SIGNED_CONTRACT for ${contractId} failed: ${err instanceof Error ? err.message : err}`,
+        ),
+      );
+    }
+
     return signature;
+  }
+
+  // ─── Auto-save signed contract PDF as ContractDocument ───
+  // Called after all 4 required signatures are in place. Generates the
+  // contract PDF (reusing the existing eDocument pipeline, which handles
+  // template resolution + placeholder substitution + puppeteer + S3), then
+  // creates a ContractDocument row pointing at the same S3 file so the
+  // reviewer checklist sees SIGNED_CONTRACT as present.
+  async ensureSignedContractDocument(contractId: string, uploadedByUserId: string) {
+    const existing = await this.prisma.contractDocument.findFirst({
+      where: {
+        contractId,
+        documentType: ContractDocumentType.SIGNED_CONTRACT,
+        isLatest: true,
+        deletedAt: null,
+      },
+    });
+    if (existing) {
+      this.logger.log(`SIGNED_CONTRACT already exists for contract ${contractId} — skipping auto-save`);
+      return existing;
+    }
+
+    const edoc = await this.generateDocument(contractId, uploadedByUserId, 'CONTRACT');
+    if (!edoc.pdfGenerated) {
+      this.logger.warn(
+        `Auto-save SIGNED_CONTRACT for ${contractId}: PDF generation fell back to HTML — not saving as ContractDocument`,
+      );
+      return null;
+    }
+
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+      select: { contractNumber: true },
+    });
+    const fileName = `${contract?.contractNumber || contractId}_signed.pdf`;
+
+    const doc = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.contractDocument.create({
+        data: {
+          contractId,
+          documentType: ContractDocumentType.SIGNED_CONTRACT,
+          fileName,
+          originalName: fileName,
+          fileUrl: edoc.fileUrl,
+          fileHash: edoc.fileHash,
+          mimeType: 'application/pdf',
+          version: 1,
+          isLatest: true,
+          isImmutable: false,
+          uploadedById: uploadedByUserId,
+        },
+      });
+      await tx.documentAuditLog.create({
+        data: {
+          documentId: created.id,
+          contractId,
+          action: 'UPLOAD',
+          userId: uploadedByUserId,
+          details: { source: 'auto-signed-contract', fileName, fileHash: edoc.fileHash } as Prisma.InputJsonValue,
+        },
+      });
+      return created;
+    });
+
+    this.logger.log(`Auto-saved SIGNED_CONTRACT document ${doc.id} for contract ${contractId}`);
+    return doc;
   }
 
   // ─── Delete Signature (ลบลายเซ็นเพื่อเซ็นใหม่, เฉพาะก่อน ACTIVE) ───

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -17,7 +17,7 @@ import ContractDocuments from '@/components/contract/ContractDocuments';
 import { ContractEarlyPayoffQuote, EarlyPayoffOverlay } from '@/components/contract/ContractEarlyPayoff';
 import { toast } from 'sonner';
 import { useState, useRef, useEffect } from 'react';
-import { Copy } from 'lucide-react';
+import { Copy, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useAuth } from '@/contexts/AuthContext';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -507,57 +507,92 @@ const deleteMutation = useMutation({
       </div>
 
       {/* Workflow Actions for Reviewer */}
-      {contract.workflowStatus === 'PENDING_REVIEW' && isReviewer && (
-        <div className="bg-warning/5 dark:bg-warning/10 border border-warning/20 rounded-xl p-5 mb-6 relative overflow-hidden">
-          <div className="absolute left-0 top-0 bottom-0 w-1 rounded-r-full bg-warning" />
-          <h3 className="text-sm font-semibold text-warning mb-3">รอการตรวจสอบจากคุณ</h3>
-          <div className="space-y-3">
-            {/* Document checklist */}
+      {contract.workflowStatus === 'PENDING_REVIEW' && isReviewer && (() => {
+        const missingItems = docChecklist?.checklist.filter((i) => !i.present) ?? [];
+        const presentItems = docChecklist?.checklist.filter((i) => i.present) ?? [];
+        const total = docChecklist?.checklist.length ?? 0;
+        const completeCount = presentItems.length;
+        return (
+          <div className="bg-warning/5 dark:bg-warning/10 border border-warning/20 rounded-xl p-6 mb-6 relative overflow-hidden">
+            <div className="absolute left-0 top-0 bottom-0 w-1 rounded-r-full bg-warning" />
+
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-base font-semibold text-warning">รอการตรวจสอบจากคุณ</h3>
+              {docChecklist && (
+                <span className={`text-sm font-medium ${docChecklist.complete ? 'text-success' : 'text-destructive'}`}>
+                  เอกสารครบ {completeCount}/{total}
+                </span>
+              )}
+            </div>
+
             {docChecklist && (
-              <div className="space-y-1">
-                <p className="text-xs font-medium text-warning">เอกสารที่ต้องมี:</p>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
-                  {docChecklist.checklist.map((item) => (
-                    <div key={item.type} className={`flex items-center gap-1.5 text-xs ${item.present ? 'text-success' : 'text-destructive'}`}>
-                      <span>{item.present ? '✓' : '✗'}</span>
-                      <span>{item.label}</span>
+              <div className="space-y-4 mb-5">
+                {/* Missing items — highlighted at top */}
+                {missingItems.length > 0 && (
+                  <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-4">
+                    <div className="flex items-start gap-2 mb-2">
+                      <AlertTriangle className="w-4 h-4 text-destructive flex-shrink-0 mt-0.5" />
+                      <p className="text-sm font-semibold text-destructive">เอกสารที่ยังขาด ({missingItems.length})</p>
                     </div>
-                  ))}
-                </div>
-                {!docChecklist.complete && (
-                  <p className="text-xs text-destructive font-medium mt-1">กรุณาอัปโหลดเอกสารให้ครบก่อนอนุมัติ</p>
+                    <ul className="space-y-1.5 pl-6">
+                      {missingItems.map((item) => (
+                        <li key={item.type} className="flex items-start gap-2 text-sm text-destructive">
+                          <XCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                          <span>{item.label}</span>
+                        </li>
+                      ))}
+                    </ul>
+                    <p className="text-xs text-destructive/80 mt-3 pl-6">กรุณาอัปโหลดเอกสารให้ครบก่อนอนุมัติ</p>
+                  </div>
+                )}
+
+                {/* Present items — collapsed-style list */}
+                {presentItems.length > 0 && (
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground mb-2">เอกสารที่พร้อมแล้ว</p>
+                    <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+                      {presentItems.map((item) => (
+                        <li key={item.type} className="flex items-start gap-2 text-sm text-success">
+                          <CheckCircle2 className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                          <span className="text-foreground">{item.label}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 )}
               </div>
             )}
-            <div>
-              <label className="block text-xs text-warning mb-1">หมายเหตุ (ไม่บังคับ)</label>
+
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-foreground mb-1.5">หมายเหตุ (ไม่บังคับ)</label>
               <input
                 type="text"
                 value={approveNotes}
                 onChange={(e) => setApproveNotes(e.target.value)}
                 placeholder="หมายเหตุการอนุมัติ..."
-                className="w-full px-3 py-2 border border-warning/40 rounded-lg text-sm"
+                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
               />
             </div>
+
             <div className="flex gap-2">
               <button
                 onClick={() => approveMutation.mutate()}
                 disabled={approveMutation.isPending || (docChecklist && !docChecklist.complete)}
                 title={docChecklist && !docChecklist.complete ? 'เอกสารยังไม่ครบ' : ''}
-                className="px-6 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                className="px-6 py-2.5 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {approveMutation.isPending ? 'กำลังอนุมัติ...' : 'อนุมัติสัญญา'}
               </button>
               <button
                 onClick={() => setShowRejectModal(true)}
-                className="px-6 py-2 text-sm bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90"
+                className="px-6 py-2.5 text-sm font-medium bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90"
               >
                 ปฏิเสธ
               </button>
             </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Rejection notes */}
       {contract.workflowStatus === 'REJECTED' && contract.reviewNotes && (

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -513,79 +513,100 @@ const deleteMutation = useMutation({
         const total = docChecklist?.checklist.length ?? 0;
         const completeCount = presentItems.length;
         return (
-          <div className="bg-warning/5 dark:bg-warning/10 border border-warning/20 rounded-xl p-6 mb-6 relative overflow-hidden">
-            <div className="absolute left-0 top-0 bottom-0 w-1 rounded-r-full bg-warning" />
+          <div className="bg-card border border-border rounded-xl shadow-sm p-6 mb-6 relative overflow-hidden">
+            <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-warning" />
 
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-base font-semibold text-warning">รอการตรวจสอบจากคุณ</h3>
+            {/* Header */}
+            <div className="flex items-center justify-between gap-3 mb-5 flex-wrap">
+              <div className="flex items-center gap-2.5">
+                <div className="w-9 h-9 rounded-full bg-warning/15 dark:bg-warning/25 flex items-center justify-center flex-shrink-0">
+                  <AlertTriangle className="w-5 h-5 text-warning" />
+                </div>
+                <h3 className="text-lg font-semibold text-foreground">รอการตรวจสอบจากคุณ</h3>
+              </div>
               {docChecklist && (
-                <span className={`text-sm font-medium ${docChecklist.complete ? 'text-success' : 'text-destructive'}`}>
-                  เอกสารครบ {completeCount}/{total}
+                <span
+                  className={`text-sm font-semibold px-3 py-1 rounded-full ${
+                    docChecklist.complete
+                      ? 'bg-success/15 text-success dark:bg-success/25'
+                      : 'bg-destructive/15 text-destructive dark:bg-destructive/25'
+                  }`}
+                >
+                  เอกสาร {completeCount}/{total}
                 </span>
               )}
             </div>
 
             {docChecklist && (
               <div className="space-y-4 mb-5">
-                {/* Missing items — highlighted at top */}
+                {/* Missing items — highlighted red box */}
                 {missingItems.length > 0 && (
-                  <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-4">
-                    <div className="flex items-start gap-2 mb-2">
-                      <AlertTriangle className="w-4 h-4 text-destructive flex-shrink-0 mt-0.5" />
-                      <p className="text-sm font-semibold text-destructive">เอกสารที่ยังขาด ({missingItems.length})</p>
+                  <div className="bg-destructive/10 dark:bg-destructive/20 border-2 border-destructive/40 rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-3">
+                      <XCircle className="w-5 h-5 text-destructive flex-shrink-0" />
+                      <p className="text-sm font-bold text-destructive">
+                        ยังขาดเอกสาร {missingItems.length} รายการ
+                      </p>
                     </div>
-                    <ul className="space-y-1.5 pl-6">
+                    <ul className="space-y-2">
                       {missingItems.map((item) => (
-                        <li key={item.type} className="flex items-start gap-2 text-sm text-destructive">
-                          <XCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                        <li key={item.type} className="flex items-start gap-2 text-sm text-destructive font-medium">
+                          <span className="text-destructive mt-0.5">•</span>
                           <span>{item.label}</span>
                         </li>
                       ))}
                     </ul>
-                    <p className="text-xs text-destructive/80 mt-3 pl-6">กรุณาอัปโหลดเอกสารให้ครบก่อนอนุมัติ</p>
+                    <p className="text-xs text-destructive/90 dark:text-destructive mt-3 pt-3 border-t border-destructive/30">
+                      กรุณาอัปโหลดเอกสารให้ครบก่อนจึงจะสามารถอนุมัติสัญญาได้
+                    </p>
                   </div>
                 )}
 
-                {/* Present items — collapsed-style list */}
+                {/* Present items — clean list */}
                 {presentItems.length > 0 && (
-                  <div>
-                    <p className="text-sm font-medium text-muted-foreground mb-2">เอกสารที่พร้อมแล้ว</p>
-                    <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+                  <details open={missingItems.length === 0} className="group">
+                    <summary className="text-sm font-medium text-muted-foreground mb-2 cursor-pointer hover:text-foreground select-none list-none flex items-center gap-1.5">
+                      <span className="group-open:rotate-90 transition-transform inline-block">▶</span>
+                      เอกสารที่พร้อมแล้ว ({presentItems.length})
+                    </summary>
+                    <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2 mt-2 pl-5">
                       {presentItems.map((item) => (
-                        <li key={item.type} className="flex items-start gap-2 text-sm text-success">
-                          <CheckCircle2 className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                        <li key={item.type} className="flex items-start gap-2 text-sm">
+                          <CheckCircle2 className="w-4 h-4 text-success flex-shrink-0 mt-0.5" />
                           <span className="text-foreground">{item.label}</span>
                         </li>
                       ))}
                     </ul>
-                  </div>
+                  </details>
                 )}
               </div>
             )}
 
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-foreground mb-1.5">หมายเหตุ (ไม่บังคับ)</label>
+            <div className="mb-5">
+              <label className="block text-sm font-medium text-foreground mb-1.5">
+                หมายเหตุ <span className="text-muted-foreground font-normal">(ไม่บังคับ)</span>
+              </label>
               <input
                 type="text"
                 value={approveNotes}
                 onChange={(e) => setApproveNotes(e.target.value)}
-                placeholder="หมายเหตุการอนุมัติ..."
-                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+                placeholder="เช่น ตรวจสอบเอกสารครบแล้ว..."
+                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
               />
             </div>
 
-            <div className="flex gap-2">
+            <div className="flex gap-2 flex-wrap">
               <button
                 onClick={() => approveMutation.mutate()}
                 disabled={approveMutation.isPending || (docChecklist && !docChecklist.complete)}
                 title={docChecklist && !docChecklist.complete ? 'เอกสารยังไม่ครบ' : ''}
-                className="px-6 py-2.5 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-6 py-2.5 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {approveMutation.isPending ? 'กำลังอนุมัติ...' : 'อนุมัติสัญญา'}
               </button>
               <button
                 onClick={() => setShowRejectModal(true)}
-                className="px-6 py-2.5 text-sm font-medium bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90"
+                className="px-6 py-2.5 text-sm font-semibold bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90 transition-colors"
               >
                 ปฏิเสธ
               </button>


### PR DESCRIPTION
## Part 1 — Approve panel redesign (dark + light readable)

Before: tinted amber background washed out against both dark and light themes; tiny text; mixed ✓/✗ icons in one grid.

After:
- **Neutral card** (`bg-card`) with subtle shadow instead of amber tint — text contrast is now consistent across both modes
- **Warning stripe** (left edge) + circular badge around the warning icon keep the urgency cue without tinting the whole surface
- **Counter pill** (e.g. "เอกสาร 5/6") with filled bg for at-a-glance state
- **Missing items** get a bolder red box (border-2) with a divider before the hint text
- **Present items** are collapsed by default when anything is missing — reviewer focuses on the blocker; auto-expanded when everything is ready
- Explicit `dark:` variants on every tinted surface so colors never blend into the background

## Part 2 — Auto-save signed contract PDF

When all 4 required signatures (CUSTOMER, COMPANY, WITNESS_1, WITNESS_2) are present, the system now fire-and-forget generates the signed contract PDF and saves it as a `ContractDocument` with type `SIGNED_CONTRACT`. The reviewer checklist stops showing "สัญญาผ่อนชำระ PDF (e-Signature ครบ)" as missing — the user no longer has to manually upload a file the system already knows how to produce.

- Reuses the existing `generateDocument()` pipeline (template resolve → placeholder substitution → puppeteer htmlToPdf → S3 upload)
- Creates a `ContractDocument` row + `DocumentAuditLog` entry (source=`auto-signed-contract`) inside a transaction
- **Idempotent**: skips if a SIGNED_CONTRACT row (isLatest, not deleted) already exists
- Uploader defaults to `contract.salespersonId` when customer signs via LIFF (staffUserId is null on that path)

## Test plan
- [ ] Open a contract in PENDING_REVIEW in **light mode** → verify text contrast on header, missing box, counter pill, input
- [ ] Switch to **dark mode** → same visual inspection
- [ ] Sign all 4 signers → refresh → the SIGNED_CONTRACT row appears in checklist as ✓ without manual upload
- [ ] Re-sign scenario (delete + re-create COMPANY signature) → no duplicate ContractDocument row
- [ ] PDF fallback case: if puppeteer fails and eDoc stores HTML, ContractDocument is NOT created (log warns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)