### PR TITLE
fix(auth): proxy /api/** through Firebase Hosting — kill cross-origin cookie issues

### DIFF
--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,10 +1,20 @@
 // Environment variable validation — runs at startup via side-effect import in main.tsx
 
-// In production, always use same-origin "/api" — Firebase Hosting rewrites
-// /api/** to the Cloud Run API service. This keeps API calls same-origin so
-// refresh_token cookie is first-party (no SameSite / 3rd-party cookie issues).
-// VITE_API_URL is only honored in dev (where the Vite proxy forwards to :3000).
-export const API_URL = import.meta.env.PROD ? '/api' : import.meta.env.VITE_API_URL || '/api';
+// In real production (Firebase Hosting) we want same-origin "/api" so the
+// refresh_token cookie stays first-party — Firebase rewrites /api/** to the
+// Cloud Run API service. In dev (Vite proxy) and in CI E2E (the prod bundle
+// served at localhost:5173 with API on :3000) we honor VITE_API_URL so the
+// built bundle can still reach the API at a different origin.
+function resolveApiUrl(): string {
+  const configured = import.meta.env.VITE_API_URL || '/api';
+  if (import.meta.env.DEV) return configured;
+  if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+    return configured;
+  }
+  return '/api';
+}
+
+export const API_URL = resolveApiUrl();
 export const LIFF_ID = import.meta.env.VITE_LIFF_ID || '';
 
 if (import.meta.env.PROD) {

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,12 +1,13 @@
 // Environment variable validation — runs at startup via side-effect import in main.tsx
 
-export const API_URL = import.meta.env.VITE_API_URL || '/api';
+// In production, always use same-origin "/api" — Firebase Hosting rewrites
+// /api/** to the Cloud Run API service. This keeps API calls same-origin so
+// refresh_token cookie is first-party (no SameSite / 3rd-party cookie issues).
+// VITE_API_URL is only honored in dev (where the Vite proxy forwards to :3000).
+export const API_URL = import.meta.env.PROD ? '/api' : import.meta.env.VITE_API_URL || '/api';
 export const LIFF_ID = import.meta.env.VITE_LIFF_ID || '';
 
 if (import.meta.env.PROD) {
-  if (!import.meta.env.VITE_API_URL) {
-    console.warn('[env] VITE_API_URL is not set — using default "/api"');
-  }
   if (!import.meta.env.VITE_LIFF_ID) {
     console.warn('[env] VITE_LIFF_ID is not set — LIFF features will be unavailable');
   }

--- a/firebase.json
+++ b/firebase.json
@@ -4,6 +4,13 @@
     "ignore": ["firebase.json", "**/node_modules/**"],
     "rewrites": [
       {
+        "source": "/api/**",
+        "run": {
+          "serviceId": "bestchoice-api",
+          "region": "asia-southeast1"
+        }
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }


### PR DESCRIPTION
## Summary

Root cause of the repeated 'refresh every F5' behavior: `bestchoicephone.app` → `api.bestchoicephone.app` is cross-origin (same-site but different host), so the `refresh_token` cookie kept hitting browser 3rd-party cookie blocking (Safari ITP, Chrome 3rd-party, Brave shields) regardless of whether it was `SameSite=None` or `SameSite=Lax`.

This PR routes `/api/**` through Firebase Hosting's Cloud Run rewrite, making all frontend → API calls **same-origin**. The `refresh_token` cookie is now strictly first-party — sent on every XHR regardless of browser privacy settings.

## Changes

- `firebase.json`: add rewrite `/api/**` → Cloud Run `bestchoice-api` (asia-southeast1)
- `apps/web/src/lib/env.ts`: force `API_URL="/api"` in production, ignoring any `VITE_API_URL` build env (so existing CI picks it up without workflow edits)

`api.bestchoicephone.app` subdomain stays live for LIFF + direct API consumers. `COOKIE_DOMAIN` env var and `SameSite=Lax` remain (still work for same-origin, and keep subdomain consumers backward-compatible).

## Test plan
- [ ] Deploy green
- [ ] Login at https://bestchoicephone.app works
- [ ] F5 does NOT force re-login
- [ ] Network tab: XHR calls go to `https://bestchoicephone.app/api/*` (no `api.` subdomain)
- [ ] DevTools → Application → Cookies → `bestchoicephone.app` shows `refresh_token` after login
- [ ] LIFF flows still work (customer mobile, `/liff/*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)