### PR TITLE
fix(contracts): stale workflow UI after submit

### DIFF
--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -142,6 +142,8 @@ export default function ContractDetailPage() {
     queryClient.invalidateQueries({ queryKey: ['contract', id] });
     queryClient.invalidateQueries({ queryKey: ['contract-preview', id] });
     queryClient.invalidateQueries({ queryKey: ['contract-payoff', id] });
+    queryClient.invalidateQueries({ queryKey: ['contract-edocuments', id] });
+    queryClient.invalidateQueries({ queryKey: ['contract-doc-checklist', id] });
     queryClient.invalidateQueries({ queryKey: ['contracts'] });
   };
 
@@ -369,11 +371,14 @@ const deleteMutation = useMutation({
           { text: '' },
           { text: 'อัปโหลดเอกสารที่จำเป็น', action: () => setActiveTab('documents'), actionLabel: 'ไปแนบเอกสาร' },
           { text: 'ให้ลูกค้ายินยอม PDPA และลงนามสัญญา', action: () => navigate(`/contracts/${id}/sign`), actionLabel: 'ไปลงนาม' },
-          {
-            text: isCreator && allSigned ? 'ลงนามครบแล้ว พร้อมส่งตรวจสอบ' : !allSigned ? 'ลงนามให้ครบก่อนส่งตรวจสอบ' : 'รอผู้จัดการตรวจสอบสัญญา',
-            action: isCreator && allSigned ? () => setShowSubmitConfirm(true) : undefined,
-            actionLabel: isCreator && allSigned ? 'ส่งตรวจสอบ' : undefined,
-          },
+          (() => {
+            const canSubmit = isCreator && allSigned && (contract.workflowStatus === 'CREATING' || contract.workflowStatus === 'REJECTED');
+            return {
+              text: canSubmit ? 'ลงนามครบแล้ว พร้อมส่งตรวจสอบ' : !allSigned ? 'ลงนามให้ครบก่อนส่งตรวจสอบ' : 'รอผู้จัดการตรวจสอบสัญญา',
+              action: canSubmit ? () => setShowSubmitConfirm(true) : undefined,
+              actionLabel: canSubmit ? 'ส่งตรวจสอบ' : undefined,
+            };
+          })(),
           {
             text: allSigned ? 'สัญญาอนุมัติแล้ว พร้อมเปิดใช้งาน' : 'ต้องลงนามครบก่อนเปิดใช้งาน',
             action: allSigned ? () => activateMutation.mutate() : undefined,


### PR DESCRIPTION
## Summary
- เคสที่เจอ: กด "ส่งตรวจสอบ" แล้วปุ่มยังโชว์ซ้อนกับ approve panel จนกว่าจะ refresh
- `invalidateContract()` ลืม invalidate คิว `contract-edocuments` + `contract-doc-checklist` ทำให้ UI เอกสาร/checklist เก่า
- Stepper step-4 เช็คแค่ `isCreator && allSigned` ไม่ได้ดู `workflowStatus` — ต่อให้ส่งตรวจสอบไปแล้ว (PENDING_REVIEW) ปุ่มก็ยังโผล่อยู่
- Gate ปุ่มใหม่: แสดงก็ต่อเมื่อ `workflowStatus ∈ {CREATING, REJECTED}` เท่านั้น

## Test plan
- [x] TypeScript: `./tools/check-types.sh web` — OK
- [ ] Manual: สร้างสัญญา → ลงนาม → กด "ส่งตรวจสอบ" → ตรวจว่าปุ่มหายทันทีโดยไม่ต้อง refresh
- [ ] Manual: กด "ปฏิเสธ" (REJECTED) → ตรวจว่าปุ่ม "ส่งตรวจสอบ" กลับมาให้กดใหม่ได้

🤖 Generated with [Claude Code](https://claude.com/claude-code)