### PR TITLE
fix(line-login): line_id_token cookie missing COOKIE_DOMAIN — blocks LIFF verify after same-origin proxy

### DIFF
--- a/apps/api/src/modules/line-oa/line-login.controller.ts
+++ b/apps/api/src/modules/line-oa/line-login.controller.ts
@@ -140,12 +140,16 @@ export class LineLoginController {
         redirectUrl.searchParams.set('line_picture', profile.pictureUrl);
       }
       // Set ID token in httpOnly cookie instead of URL (prevents leaking in browser history/Referrer)
+      // COOKIE_DOMAIN (e.g. '.bestchoicephone.app') makes the cookie readable from
+      // the root domain frontend, not only the api.* subdomain that served this callback.
+      const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
       res.cookie('line_id_token', tokenData.id_token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: process.env.NODE_ENV === 'production' || !!cookieDomain,
         sameSite: 'lax',
         maxAge: 60000, // 60 seconds — one-time use
         path: '/',
+        ...(cookieDomain ? { domain: cookieDomain } : {}),
       });
 
       res.redirect(redirectUrl.toString());
@@ -171,7 +175,11 @@ export class LineLoginController {
   @Get('id-token')
   getIdToken(@Req() req: Request, @Res() res: Response) {
     const token = (req.cookies as Record<string, string> | undefined)?.line_id_token;
-    res.clearCookie('line_id_token', { path: '/' });
+    const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
+    res.clearCookie('line_id_token', {
+      path: '/',
+      ...(cookieDomain ? { domain: cookieDomain } : {}),
+    });
     if (!token) {
       return res.status(401).json({ error: 'No id_token cookie' });
     }


### PR DESCRIPTION
## Regression from PR #500

หลัง PR #500 เปลี่ยน frontend ให้เรียก \`/api\` แบบ same-origin ผ่าน Firebase rewrite, flow LIFF verify (เปิดจาก flex message) พังเพราะ:

1. Flex message → \`api.bestchoicephone.app/api/line-oa/line-login/authorize\` (LINE OAuth)
2. Callback set cookie \`line_id_token\` บน \`api.bestchoicephone.app\` **โดยไม่มี \`domain\` attribute**
3. Redirect กลับ \`bestchoicephone.app/liff/finance-verify?line_login=true\`
4. Frontend fetch \`bestchoicephone.app/api/line-oa/line-login/id-token\` (same-origin หลัง #500)
5. ❌ Browser ไม่ส่ง cookie เพราะถูก scope ไว้แค่ \`api.*\` subdomain → token null → guard 401 \"กรุณาเปิดผ่าน LINE\"

## Fix

ใช้ \`COOKIE_DOMAIN\` (เช่น \`.bestchoicephone.app\`) แบบเดียวกับ \`refresh_token\` cookie ใน \`auth.controller.ts\` — ทำให้ cookie อ่านได้ทั้ง api.* และ root domain.

## Test plan
- [x] TypeScript: \`./tools/check-types.sh api\` — OK
- [ ] Prod: กด flex message verify → ระบบ set cookie ได้บน root domain → frontend อ่านได้ → guard ยอมรับ → ส่ง OTP ได้

🤖 Generated with [Claude Code](https://claude.com/claude-code)