### PR TITLE
fix: settings cleanup + /purchase-orders crash + LIFF token UX

### DIFF
--- a/apps/web/src/hooks/useLiffInit.ts
+++ b/apps/web/src/hooks/useLiffInit.ts
@@ -70,7 +70,12 @@ export function useLiffInit(): UseLiffInitResult {
                 lineIdToken = body.token ?? null;
               }
             } catch {
-              // Cookie missing or network error — subsequent LIFF API calls will 401
+              // Cookie missing or network error
+            }
+
+            if (!lineIdToken) {
+              if (!cancelled) setError('ไม่สามารถรับ ID Token จาก LINE กรุณาปิดหน้านี้แล้วเปิดใหม่จาก LINE OA');
+              return;
             }
 
             if (!cancelled) {
@@ -101,6 +106,15 @@ export function useLiffInit(): UseLiffInitResult {
 
           const p = await liff.getProfile();
           const token = liff.getIDToken();
+
+          // No ID token = LIFF channel missing 'openid' scope OR token expired.
+          // Without ID token, server can't verify identity — surface a clear error
+          // instead of silently letting downstream API calls 401.
+          if (!token) {
+            if (!cancelled) setError('ไม่สามารถรับ ID Token จาก LINE กรุณาปิดหน้านี้แล้วเปิดใหม่จาก LINE OA');
+            return;
+          }
+
           if (!cancelled) {
             setLineId(p.userId);
             setIdToken(token);

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
@@ -51,7 +51,8 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     queryKey: ['purchase-orders', statusFilter],
     queryFn: async () => {
       const params = statusFilter ? `?status=${statusFilter}` : '';
-      return (await api.get(`/purchase-orders${params}`)).data;
+      const res = await api.get(`/purchase-orders${params}`);
+      return Array.isArray(res.data) ? res.data : (res.data?.data ?? []);
     },
   });
 

--- a/apps/web/src/pages/SettingsPage/components/SystemSettings.tsx
+++ b/apps/web/src/pages/SettingsPage/components/SystemSettings.tsx
@@ -161,21 +161,6 @@ function ExternalLinks() {
 
   return (
     <>
-      <div className="bg-success/5 dark:bg-success/10 border border-success/20 rounded-xl p-4 flex items-center justify-between">
-        <div>
-          <div className="text-sm font-medium text-success">เชื่อมต่อ LINE OA</div>
-          <div className="text-xs text-success mt-0.5">
-            เชื่อมต่อ LINE Official Account เพื่อส่งแจ้งเตือนค่างวด, สลิปชำระเงิน และติดตามหนี้ผ่าน LINE
-          </div>
-        </div>
-        <button
-          onClick={() => navigate('/settings/line-oa')}
-          className="px-4 py-2 text-sm bg-success text-success-foreground rounded-lg hover:bg-success/90 whitespace-nowrap"
-        >
-          ตั้งค่า LINE OA
-        </button>
-      </div>
-
       <div className="bg-primary/10 border border-primary/20 rounded-xl p-4 flex items-center justify-between">
         <div>
           <div className="text-sm font-medium text-primary">ตั้งค่าอัตราดอกเบี้ยตามประเภทสินค้า</div>


### PR DESCRIPTION
## Summary

Bundle of 3 independent small fixes:

1. **Settings page cleanup** — ลบ "เชื่อมต่อ LINE OA" quick-nav card ในหน้า /settings เพราะมีหน้า /settings/line-oa แยกอยู่แล้ว
2. **/purchase-orders crash** — "Cannot read properties of undefined (reading 'length')" API เปลี่ยนเป็น paginated \`{ data, total, page, limit, totalPages }\` แต่ frontend hook ยัง expect array → unwrap response
3. **LIFF null-token UX** — เมื่อ \`liff.getIDToken()\` คืน null (LIFF channel ขาด openid scope หรือ session expired) จะแสดง error card ชัดๆ แทนที่จะปล่อยให้ไป 401 "กรุณาเปิดผ่าน LINE" ตอนกดส่ง OTP

## Test plan
- [ ] เข้า /settings — ไม่เห็น card "เชื่อมต่อ LINE OA" แล้ว
- [ ] เข้า /purchase-orders — เห็น list ปกติ ไม่ crash
- [ ] LIFF verify — ถ้า token มี ใช้งานปกติ / ถ้า token null เห็น error card ชัดเจน

🤖 Generated with [Claude Code](https://claude.com/claude-code)