### PR TITLE
fix(migration): correct table name "User" → "users" in last_login_at migration

### DIFF
--- a/apps/api/prisma/migrations/20260501000000_add_user_last_login_at/migration.sql
+++ b/apps/api/prisma/migrations/20260501000000_add_user_last_login_at/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "User" ADD COLUMN "last_login_at" TIMESTAMP(3);
+ALTER TABLE "users" ADD COLUMN "last_login_at" TIMESTAMP(3);


### PR DESCRIPTION
## Summary
- Fix migration `20260501000000_add_user_last_login_at` that referenced `"User"` (PascalCase) instead of the real table name `"users"` (snake_case, via `@@map("users")`)
- Blocks the PR #507 deploy — Lint & Test job failed with `P3018: relation "User" does not exist`
- Prod DB untouched because deploy job gated by failed CI

## Test plan
- [ ] CI Lint & Test passes (migration applies cleanly on fresh test DB)
- [ ] `migrate-db` Cloud Run job succeeds on prod Cloud SQL
- [ ] API redeploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)