### PR TITLE
fix(trade-in test): add product mocks for new accept() flow

### DIFF
--- a/apps/api/src/modules/trade-in/trade-in.service.spec.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.spec.ts
@@ -74,6 +74,8 @@ describe('TradeInService', () => {
       },
       product: {
         findUnique: jest.fn(),
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'prod-new-1' }),
       },
       $transaction: jest.fn().mockImplementation(async (fn: unknown) => {
         if (typeof fn === 'function') return fn(prisma);


### PR DESCRIPTION
## Summary
- Added `findFirst` + `create` mocks on the Prisma `product` model in `trade-in.service.spec.ts`
- Unblocks the Test API job in the deploy pipeline (was failing with `TypeError: tx.product.findFirst is not a function`)

## Why
PR #507 taught `accept()` to auto-create a Product on trade-in acceptance (IMEI dedupe via `findFirst`, then `create`). The spec mock still only had `findUnique`, so the accept tests crashed during CI and blocked prod deploy.

## Test plan
- [x] `npx jest src/modules/trade-in/trade-in.service.spec.ts` → 23/23 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)