### PR TITLE
feat(trade-in): add buyer column + datetime + larger voucher text

### DIFF
--- a/apps/api/src/modules/trade-in/trade-in.service.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.ts
@@ -226,6 +226,8 @@ export class TradeInService {
         include: {
           customer: { select: { id: true, name: true, phone: true } },
           branch: { select: { id: true, name: true } },
+          appraisedBy: { select: { id: true, name: true } },
+          idCardVerifiedBy: { select: { id: true, name: true } },
         },
       }),
       this.prisma.tradeIn.count({ where }),

--- a/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
+++ b/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { getStatusBadgeProps, tradeInStatusMap } from '@/lib/status-badges';
-import { formatThaiDate } from '@/lib/date';
+import { formatThaiDateTime } from '@/lib/date';
 import {
   RefreshCw,
   CheckCircle,
@@ -39,16 +39,6 @@ interface TradeInTableProps {
   onVoucher: (item: TradeIn) => void;
   isRejectPending: boolean;
   voucherLoadingId: string | null;
-}
-
-function formatRelativeDate(iso: string): string {
-  const diffDays = Math.floor((Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) return 'วันนี้';
-  if (diffDays === 1) return 'เมื่อวาน';
-  if (diffDays < 7) return `${diffDays} วันก่อน`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} สัปดาห์ก่อน`;
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)} เดือนก่อน`;
-  return formatThaiDate(iso);
 }
 
 export default function TradeInTable({
@@ -132,24 +122,36 @@ export default function TradeInTable({
       },
     },
     {
+      key: 'buyer',
+      label: 'ผู้รับซื้อ',
+      hideable: true,
+      render: (item) => {
+        const buyer = item.idCardVerifiedBy ?? item.appraisedBy;
+        if (!buyer) return <span className="text-sm text-muted-foreground">รอรับซื้อ</span>;
+        return <span className="text-sm text-foreground">{buyer.name}</span>;
+      },
+    },
+    {
       key: 'voucherNumber',
       label: 'เลขใบสำคัญ',
       hideable: true,
       render: (item) =>
         item.voucherNumber ? (
-          <span className="text-xs font-mono text-foreground">{item.voucherNumber}</span>
+          <span className="text-sm font-mono font-semibold text-foreground">
+            {item.voucherNumber}
+          </span>
         ) : (
-          <span className="text-xs text-muted-foreground">-</span>
+          <span className="text-sm text-muted-foreground">-</span>
         ),
     },
     {
       key: 'createdAt',
-      label: 'วันที่',
+      label: 'วันที่ / เวลา',
       sortable: true,
       hideable: true,
       render: (item) => (
-        <span className="text-xs text-muted-foreground whitespace-nowrap">
-          {formatRelativeDate(item.createdAt)}
+        <span className="text-sm text-foreground whitespace-nowrap">
+          {formatThaiDateTime(item.idCardVerifiedAt ?? item.createdAt)}
         </span>
       ),
     },

--- a/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
+++ b/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
@@ -114,10 +114,20 @@ export default function TradeInTable({
       sortable: true,
       render: (item) => {
         const value = item.agreedPrice ?? item.offeredPrice ?? item.estimatedValue;
-        return value != null ? (
-          <span className="font-medium">฿{Number(value).toLocaleString()}</span>
-        ) : (
-          <span className="text-muted-foreground">-</span>
+        if (value == null) return <span className="text-muted-foreground">-</span>;
+        const methodLabel =
+          item.paymentMethod === 'CASH'
+            ? 'เงินสด'
+            : item.paymentMethod === 'TRANSFER'
+              ? 'โอน'
+              : null;
+        return (
+          <div>
+            <div className="font-medium">฿{Number(value).toLocaleString()}</div>
+            {methodLabel && (
+              <div className="text-xs text-muted-foreground">{methodLabel}</div>
+            )}
+          </div>
         );
       },
     },
@@ -130,6 +140,17 @@ export default function TradeInTable({
         if (!buyer) return <span className="text-sm text-muted-foreground">รอรับซื้อ</span>;
         return <span className="text-sm text-foreground">{buyer.name}</span>;
       },
+    },
+    {
+      key: 'branch',
+      label: 'สาขา',
+      hideable: true,
+      render: (item) =>
+        item.branch ? (
+          <span className="text-sm text-foreground">{item.branch.name}</span>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        ),
     },
     {
       key: 'voucherNumber',

--- a/apps/web/src/pages/TradeInPage/types.ts
+++ b/apps/web/src/pages/TradeInPage/types.ts
@@ -15,7 +15,10 @@ export interface TradeIn {
   voucherNumber: string | null;
   voucherPdfUrl: string | null;
   createdAt: string;
+  idCardVerifiedAt?: string | null;
   customer: { id: string; name: string } | null;
+  appraisedBy?: { id: string; name: string } | null;
+  idCardVerifiedBy?: { id: string; name: string } | null;
 }
 
 export interface TradeInsResponse {

--- a/apps/web/src/pages/TradeInPage/types.ts
+++ b/apps/web/src/pages/TradeInPage/types.ts
@@ -16,7 +16,9 @@ export interface TradeIn {
   voucherPdfUrl: string | null;
   createdAt: string;
   idCardVerifiedAt?: string | null;
+  paymentMethod?: 'CASH' | 'TRANSFER' | null;
   customer: { id: string; name: string } | null;
+  branch?: { id: string; name: string } | null;
   appraisedBy?: { id: string; name: string } | null;
   idCardVerifiedBy?: { id: string; name: string } | null;
 }


### PR DESCRIPTION
## Summary
ปรับหน้า Trade-In list ตามที่เจ้าของขอ:
- เพิ่มคอลัมน์ **ผู้รับซื้อ** (ใช้ `idCardVerifiedBy` — fallback เป็น `appraisedBy` ถ้ายังไม่ accept)
- เปลี่ยน **วันที่** เป็น **วันที่ / เวลา** (DD/MM/YYYY HH:mm, พ.ศ.) — ใช้ `idCardVerifiedAt` ถ้ามี ไม่งั้น `createdAt`
- ขยายตัวอักษร **เลขใบสำคัญ** จาก `text-xs` → `text-sm font-semibold` อ่านง่ายขึ้น

## Backend
- `trade-in.service.ts` `findAll()` include `appraisedBy` + `idCardVerifiedBy` `{ id, name }` (detail view มีอยู่แล้ว)

## Test plan
- [x] `./tools/check-types.sh all` — 0 errors
- [ ] เปิดหน้า /trade-in prod → verify คอลัมน์ใหม่แสดง, วันที่มีเวลา, ใบสำคัญชัดขึ้น

🤖 Generated with [Claude Code](https://claude.com/claude-code)