### PR TITLE
feat(stock): เพิ่มปุ่ม "ดูรายละเอียด" ในตาราง Stock list

### DIFF
--- a/apps/web/src/pages/StockPage/index.tsx
+++ b/apps/web/src/pages/StockPage/index.tsx
@@ -7,7 +7,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import { Button } from '@/components/ui/button';
 import { statusLabels, categoryLabels } from '@/lib/constants';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { ArrowRightLeft, Download, Plus } from 'lucide-react';
+import { ArrowRightLeft, Download, Eye, Plus } from 'lucide-react';
 import { StockProduct } from './types';
 import { useStockData, useEditingProductSync } from './hooks/useStockData';
 import { useStockFilters } from './hooks/useStockFilters';
@@ -200,6 +200,20 @@ export default function StockPage() {
       key: 'branch',
       label: 'สาขา',
       render: (p: StockProduct) => <span className="text-xs font-medium">{p.branch.name}</span>,
+    },
+    {
+      key: 'actions',
+      label: '',
+      render: (p: StockProduct) => (
+        <button
+          onClick={(e) => { e.stopPropagation(); navigateToProduct(p.id); }}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium text-muted-foreground hover:text-primary hover:bg-accent transition-colors"
+          title="ดูรายละเอียดสินค้า"
+        >
+          <Eye className="size-3.5" />
+          ดูรายละเอียด
+        </button>
+      ),
     },
   ], [navigateToProduct, openPriceEdit, isManager, selectedIds, listProducts]);
 


### PR DESCRIPTION
## Summary
- เพิ่ม action column ท้ายตาราง Stock list → ปุ่ม "ดูรายละเอียด" (Eye icon + label)
- คลิกแล้ว navigate ไปหน้า `/products/:id` (ใช้ `navigateToProduct` callback เดิม)
- ใช้ semantic tokens: `text-muted-foreground`, `hover:text-primary`, `hover:bg-accent`

## เหตุผล
ชื่อสินค้าคอลัมน์แรกคลิกได้อยู่แล้ว แต่มองไม่ออกว่าเป็นลิงก์ — user ขอให้เพิ่มปุ่ม dedicated ที่เห็นและกดง่ายขึ้น

## Test plan (local)
- [x] TypeScript check (`./tools/check-types.sh web`) ผ่าน
- [x] Playwright test: 34 แถว มีปุ่มทุกแถว, คลิกแล้วไป `/products/:id` ได้, 0 JS errors
- [x] ใช้ lucide icon (Eye) ไม่มี emoji