### PR TITLE
feat(stock+trade-in): bundle — dashboard polish + view-detail button + trade-in table enhancements

### DIFF
--- a/apps/api/src/modules/trade-in/trade-in.service.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.ts
@@ -226,6 +226,8 @@ export class TradeInService {
         include: {
           customer: { select: { id: true, name: true, phone: true } },
           branch: { select: { id: true, name: true } },
+          appraisedBy: { select: { id: true, name: true } },
+          idCardVerifiedBy: { select: { id: true, name: true } },
         },
       }),
       this.prisma.tradeIn.count({ where }),

--- a/apps/web/src/components/ui/DataTable.tsx
+++ b/apps/web/src/components/ui/DataTable.tsx
@@ -375,7 +375,7 @@ function DataTable<T extends { id: string }>({
                 <tr
                   key={row.id}
                   className={cn(
-                    'transition-colors hover:bg-muted/50',
+                    'transition-colors hover:bg-muted/50 even:bg-muted/20',
                     (onRowClick || onRowDoubleClick) && 'cursor-pointer',
                     row.getIsSelected() && 'bg-primary/5 border-l-2 border-l-primary',
                   )}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -4,12 +4,12 @@
 // --- Product Status ---
 
 export const statusLabels: Record<string, { label: string; className: string }> = {
-  PO_RECEIVED: { label: 'รับจาก PO', className: 'bg-primary/10 text-primary' },
+  PO_RECEIVED: { label: 'รับจาก PO', className: 'bg-info/10 text-info' },
   QC_PENDING: { label: 'รอตรวจรับ', className: 'bg-warning/10 text-warning' },
-  PHOTO_PENDING: { label: 'รอถ่ายรูป', className: 'bg-primary/10 text-primary' },
+  PHOTO_PENDING: { label: 'รอถ่ายรูป', className: 'bg-warning/10 text-warning' },
   INSPECTION: { label: 'กำลังตรวจ', className: 'bg-warning/10 text-warning' },
   IN_STOCK: { label: 'พร้อมขาย', className: 'bg-success/10 text-success' },
-  RESERVED: { label: 'จอง', className: 'bg-primary/10 text-primary' },
+  RESERVED: { label: 'จอง', className: 'bg-warning/10 text-warning' },
   SOLD_INSTALLMENT: { label: 'ขายผ่อน', className: 'bg-primary/10 text-primary' },
   SOLD_CASH: { label: 'ขายสด', className: 'bg-info/10 text-info' },
   REPOSSESSED: { label: 'ยึดคืน', className: 'bg-destructive/10 text-destructive' },

--- a/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
@@ -1,10 +1,23 @@
+import { useMemo, useState } from 'react';
 import { UseMutationResult } from '@tanstack/react-query';
-import DataTable from '@/components/ui/DataTable';
+import DataTable, { Column } from '@/components/ui/DataTable';
 import { formatDateShort } from '@/utils/formatters';
 import { PurchaseOrder } from '../types';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { getStatusBadgeProps, poStatusMap, poPaymentStatusMap } from '@/lib/status-badges';
+import { PackageCheck, Check, X, Ban, FileText, Search } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+type PeriodFilter = '' | 'this-month' | 'last-month' | 'this-quarter' | 'this-year';
 
 export interface POListTabProps {
   statusFilter: string;
@@ -18,6 +31,36 @@ export interface POListTabProps {
   rejectPOMutation: UseMutationResult<unknown, unknown, { id: string; reason: string }, unknown>;
   cancelMutation: UseMutationResult<unknown, unknown, string, unknown>;
   setConfirmDialog: (value: { open: boolean; message: string; action: () => void }) => void;
+  suppliers: { id: string; name: string }[];
+}
+
+const periodOptions: { value: PeriodFilter; label: string }[] = [
+  { value: '', label: 'ทุกช่วงเวลา' },
+  { value: 'this-month', label: 'เดือนนี้' },
+  { value: 'last-month', label: 'เดือนที่แล้ว' },
+  { value: 'this-quarter', label: 'ไตรมาสนี้' },
+  { value: 'this-year', label: 'ปีนี้' },
+];
+
+function periodRange(period: PeriodFilter): { start: Date; end: Date } | null {
+  if (!period) return null;
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  if (period === 'this-month') {
+    return { start: new Date(y, m, 1), end: new Date(y, m + 1, 1) };
+  }
+  if (period === 'last-month') {
+    return { start: new Date(y, m - 1, 1), end: new Date(y, m, 1) };
+  }
+  if (period === 'this-quarter') {
+    const qStart = Math.floor(m / 3) * 3;
+    return { start: new Date(y, qStart, 1), end: new Date(y, qStart + 3, 1) };
+  }
+  if (period === 'this-year') {
+    return { start: new Date(y, 0, 1), end: new Date(y + 1, 0, 1) };
+  }
+  return null;
 }
 
 export function POListTab({
@@ -32,15 +75,59 @@ export function POListTab({
   rejectPOMutation,
   cancelMutation,
   setConfirmDialog,
+  suppliers,
 }: POListTabProps) {
-  const columns = [
+  const [search, setSearch] = useState('');
+  const [supplierFilter, setSupplierFilter] = useState('');
+  const [periodFilter, setPeriodFilter] = useState<PeriodFilter>('');
+  const [rejectDialog, setRejectDialog] = useState<{ open: boolean; po: PurchaseOrder | null; reason: string }>({
+    open: false,
+    po: null,
+    reason: '',
+  });
+
+  const filteredPos = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const range = periodRange(periodFilter);
+    return pos.filter((po) => {
+      if (supplierFilter && po.supplier.id !== supplierFilter) return false;
+      if (range) {
+        const d = new Date(po.orderDate);
+        if (d < range.start || d >= range.end) return false;
+      }
+      if (q) {
+        const hay = [po.poNumber, po.supplier.name, po.supplier.contactName]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [pos, search, supplierFilter, periodFilter]);
+
+  const clearAll = () => {
+    setSearch('');
+    setStatusFilter('');
+    setSupplierFilter('');
+    setPeriodFilter('');
+  };
+
+  const selectedSupplierName = suppliers.find((s) => s.id === supplierFilter)?.name || supplierFilter;
+  const selectedPeriodLabel = periodOptions.find((p) => p.value === periodFilter)?.label || periodFilter;
+
+  const columns: Column<PurchaseOrder>[] = [
     {
       key: 'poNumber',
       label: 'เลข PO',
-      render: (po: PurchaseOrder) => (
+      sortable: true,
+      render: (po) => (
         <button
-          onClick={() => openDetailModal(po)}
-          className="font-medium text-primary hover:underline"
+          onClick={(e) => {
+            e.stopPropagation();
+            openDetailModal(po);
+          }}
+          className="font-medium text-primary hover:underline whitespace-nowrap"
         >
           {po.poNumber}
         </button>
@@ -49,33 +136,42 @@ export function POListTab({
     {
       key: 'supplier',
       label: 'ผู้ขาย',
-      render: (po: PurchaseOrder) => (
-        <div>
-          <div className="font-medium">{po.supplier.name}</div>
-          <div className="text-xs text-muted-foreground">{po.supplier.contactName}</div>
-        </div>
-      ),
+      sortable: true,
+      render: (po) => {
+        const sameName =
+          po.supplier.contactName &&
+          po.supplier.contactName.trim().toLowerCase() === po.supplier.name.trim().toLowerCase();
+        return (
+          <div>
+            <div className="font-medium">{po.supplier.name}</div>
+            {po.supplier.contactName && !sameName && (
+              <div className="text-xs text-muted-foreground">{po.supplier.contactName}</div>
+            )}
+          </div>
+        );
+      },
     },
     {
       key: 'orderDate',
       label: 'วันที่สั่ง',
-      render: (po: PurchaseOrder) => (
-        <span className="text-sm">{formatDateShort(po.orderDate)}</span>
-      ),
+      sortable: true,
+      render: (po) => <span className="text-sm whitespace-nowrap">{formatDateShort(po.orderDate)}</span>,
     },
     {
       key: 'items',
       label: 'รายการ',
-      render: (po: PurchaseOrder) => (
-        <span className="text-sm">{po.items.length} รายการ</span>
-      ),
+      sortable: true,
+      render: (po) => <span className="text-sm">{po.items.length} รายการ</span>,
     },
     {
       key: 'totalAmount',
       label: 'ยอดรวม',
-      render: (po: PurchaseOrder) => (
+      sortable: true,
+      render: (po) => (
         <div>
-          <span className="text-sm font-medium">{Number(po.netAmount ?? po.totalAmount).toLocaleString()} บาท</span>
+          <span className="text-sm font-medium whitespace-nowrap">
+            {Number(po.netAmount ?? po.totalAmount).toLocaleString()} บาท
+          </span>
           {Number(po.discount) > 0 && (
             <div className="text-xs text-destructive">ส่วนลด -{Number(po.discount).toLocaleString()}</div>
           )}
@@ -88,19 +184,34 @@ export function POListTab({
     {
       key: 'status',
       label: 'สถานะ',
-      render: (po: PurchaseOrder) => {
+      sortable: true,
+      render: (po) => {
         const cfg = getStatusBadgeProps(po.status, poStatusMap);
-        return <Badge variant={cfg.variant} appearance={cfg.appearance}>{cfg.label}</Badge>;
+        return (
+          <Badge variant={cfg.variant} appearance={cfg.appearance}>
+            {cfg.label}
+          </Badge>
+        );
       },
     },
     {
       key: 'paymentStatus',
       label: 'การจ่ายเงิน',
-      render: (po: PurchaseOrder) => {
+      sortable: true,
+      render: (po) => {
         const cfg = getStatusBadgeProps(po.paymentStatus || 'UNPAID', poPaymentStatusMap);
         return (
-          <button onClick={() => openPaymentModal(po)} className="cursor-pointer hover:opacity-80">
-            <Badge variant={cfg.variant} appearance={cfg.appearance}>{cfg.label}</Badge>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              openPaymentModal(po);
+            }}
+            className="cursor-pointer hover:opacity-80"
+            title="แก้ไขสถานะการจ่ายเงิน"
+          >
+            <Badge variant={cfg.variant} appearance={cfg.appearance}>
+              {cfg.label}
+            </Badge>
           </button>
         );
       },
@@ -108,12 +219,12 @@ export function POListTab({
     {
       key: 'received',
       label: 'รับสินค้า',
-      render: (po: PurchaseOrder) => {
+      render: (po) => {
         const totalOrdered = po.items.reduce((s, i) => s + i.quantity, 0);
         const totalReceived = po.items.reduce((s, i) => s + i.receivedQty, 0);
         return (
           <div className="flex items-center gap-2">
-            <span className="text-sm">
+            <span className="text-sm whitespace-nowrap">
               {totalReceived}/{totalOrdered}
             </span>
             {totalOrdered > 0 && (
@@ -131,44 +242,66 @@ export function POListTab({
     {
       key: 'actions',
       label: '',
-      render: (po: PurchaseOrder) => (
-        <div className="flex gap-2">
+      hideable: false,
+      render: (po) => (
+        <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+          <button
+            onClick={() => openDetailModal(po)}
+            className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            title="ดูรายละเอียด"
+            aria-label={`ดูรายละเอียด ${po.poNumber}`}
+          >
+            <FileText className="size-4" />
+          </button>
           {['APPROVED', 'PARTIALLY_RECEIVED'].includes(po.status) && (
             <button
               onClick={() => openReceiveModal(po)}
-              className="text-primary hover:text-primary/90 text-sm font-medium"
+              className="p-1.5 rounded-md text-primary hover:bg-primary/10 transition-colors"
+              title="รับสินค้า"
+              aria-label={`รับสินค้า ${po.poNumber}`}
             >
-              รับสินค้า
+              <PackageCheck className="size-4" />
             </button>
           )}
           {po.status === 'DRAFT' && (
             <>
               <button
                 onClick={() => {
-                  setConfirmDialog({ open: true, message: `อนุมัติ PO ${po.poNumber}?`, action: () => approveMutation.mutate(po.id) });
+                  setConfirmDialog({
+                    open: true,
+                    message: `อนุมัติ PO ${po.poNumber}?`,
+                    action: () => approveMutation.mutate(po.id),
+                  });
                 }}
                 disabled={approveMutation.isPending}
-                className="text-success hover:text-success/90 text-sm font-medium disabled:opacity-50"
+                className="p-1.5 rounded-md text-success hover:bg-success/10 transition-colors disabled:opacity-50"
+                title="อนุมัติ"
+                aria-label={`อนุมัติ ${po.poNumber}`}
               >
-                อนุมัติ
+                <Check className="size-4" />
               </button>
               <button
-                onClick={() => {
-                  const reason = prompt('เหตุผลที่ปฏิเสธ:');
-                  if (reason) rejectPOMutation.mutate({ id: po.id, reason });
-                }}
+                onClick={() => setRejectDialog({ open: true, po, reason: '' })}
                 disabled={rejectPOMutation.isPending}
-                className="text-warning hover:text-warning/90 text-sm font-medium disabled:opacity-50"
+                className="p-1.5 rounded-md text-warning hover:bg-warning/10 transition-colors disabled:opacity-50"
+                title="ปฏิเสธ"
+                aria-label={`ปฏิเสธ ${po.poNumber}`}
               >
-                ปฏิเสธ
+                <X className="size-4" />
               </button>
               <button
                 onClick={() => {
-                  setConfirmDialog({ open: true, message: 'ต้องการยกเลิก PO นี้?', action: () => cancelMutation.mutate(po.id) });
+                  setConfirmDialog({
+                    open: true,
+                    message: `ต้องการยกเลิก PO ${po.poNumber}?`,
+                    action: () => cancelMutation.mutate(po.id),
+                  });
                 }}
-                className="text-destructive hover:text-destructive/90 text-sm font-medium"
+                className="p-1.5 rounded-md text-destructive hover:bg-destructive/10 transition-colors"
+                title="ยกเลิก"
+                aria-label={`ยกเลิก ${po.poNumber}`}
               >
-                ยกเลิก
+                <Ban className="size-4" />
               </button>
             </>
           )}
@@ -177,10 +310,19 @@ export function POListTab({
     },
   ];
 
+  const hasFilter = Boolean(search || statusFilter || supplierFilter || periodFilter);
+
   return (
     <>
-      {/* Filter */}
-      <div className="mb-5">
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 mb-4">
+        <input
+          type="text"
+          placeholder="ค้นหาเลข PO, ผู้ขาย..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 min-w-[200px] px-3 py-2 border border-input rounded-lg text-sm bg-background focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
+        />
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
@@ -193,13 +335,142 @@ export function POListTab({
           <option value="FULLY_RECEIVED">รับครบแล้ว</option>
           <option value="CANCELLED">ยกเลิก</option>
         </select>
+        <select
+          value={supplierFilter}
+          onChange={(e) => setSupplierFilter(e.target.value)}
+          className="px-3 py-2 border border-input rounded-lg text-sm bg-background focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden max-w-[220px]"
+        >
+          <option value="">ทุกผู้ขาย</option>
+          {suppliers.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        <select
+          value={periodFilter}
+          onChange={(e) => setPeriodFilter(e.target.value as PeriodFilter)}
+          className="px-3 py-2 border border-input rounded-lg text-sm bg-background focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
+        >
+          {periodOptions.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
       </div>
+
+      {/* Active filter chips */}
+      {hasFilter && (
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="text-xs text-muted-foreground">ตัวกรองที่ใช้:</span>
+          {search && <FilterChip label={`ค้นหา: "${search}"`} onRemove={() => setSearch('')} />}
+          {statusFilter && (
+            <FilterChip
+              label={`สถานะ: ${
+                {
+                  DRAFT: 'รออนุมัติ',
+                  APPROVED: 'อนุมัติแล้ว',
+                  PARTIALLY_RECEIVED: 'รับบางส่วน',
+                  FULLY_RECEIVED: 'รับครบแล้ว',
+                  CANCELLED: 'ยกเลิก',
+                }[statusFilter] || statusFilter
+              }`}
+              onRemove={() => setStatusFilter('')}
+            />
+          )}
+          {supplierFilter && (
+            <FilterChip label={`ผู้ขาย: ${selectedSupplierName}`} onRemove={() => setSupplierFilter('')} />
+          )}
+          {periodFilter && (
+            <FilterChip label={`ช่วงเวลา: ${selectedPeriodLabel}`} onRemove={() => setPeriodFilter('')} />
+          )}
+          <button
+            onClick={clearAll}
+            className="ml-1 text-xs text-muted-foreground hover:text-foreground underline"
+          >
+            ล้างทั้งหมด
+          </button>
+        </div>
+      )}
 
       <Card>
         <CardContent className="p-0">
-          <DataTable columns={columns} data={pos} isLoading={isLoading} emptyMessage="ยังไม่มีใบสั่งซื้อ" />
+          <DataTable
+            columns={columns}
+            data={filteredPos}
+            isLoading={isLoading}
+            emptyMessage={hasFilter ? 'ไม่พบใบสั่งซื้อที่ตรงกับตัวกรอง' : 'ยังไม่มีใบสั่งซื้อ'}
+            emptyIcon={hasFilter ? Search : undefined}
+            emptyDescription={hasFilter ? 'ลองล้างตัวกรองหรือเปลี่ยนคำค้นหา' : undefined}
+            columnToggle
+            onRowClick={openDetailModal}
+          />
         </CardContent>
       </Card>
+
+      {/* Reject reason dialog */}
+      <Dialog
+        open={rejectDialog.open}
+        onOpenChange={(open) => setRejectDialog((prev) => ({ ...prev, open }))}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>ปฏิเสธใบสั่งซื้อ</DialogTitle>
+            <DialogDescription>
+              กรุณาระบุเหตุผลในการปฏิเสธ {rejectDialog.po?.poNumber}
+            </DialogDescription>
+          </DialogHeader>
+          <textarea
+            value={rejectDialog.reason}
+            onChange={(e) => setRejectDialog((prev) => ({ ...prev, reason: e.target.value }))}
+            placeholder="เหตุผลที่ปฏิเสธ..."
+            rows={3}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden resize-none"
+            autoFocus
+          />
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              variant="outline"
+              onClick={() => setRejectDialog({ open: false, po: null, reason: '' })}
+              disabled={rejectPOMutation.isPending}
+            >
+              ยกเลิก
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                const reason = rejectDialog.reason.trim();
+                if (!reason || !rejectDialog.po) return;
+                rejectPOMutation.mutate(
+                  { id: rejectDialog.po.id, reason },
+                  {
+                    onSuccess: () => setRejectDialog({ open: false, po: null, reason: '' }),
+                  },
+                );
+              }}
+              disabled={rejectPOMutation.isPending || !rejectDialog.reason.trim()}
+            >
+              {rejectPOMutation.isPending ? 'กำลังปฏิเสธ...' : 'ยืนยันปฏิเสธ'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
+  );
+}
+
+function FilterChip({ label, onRemove }: { label: string; onRemove: () => void }) {
+  return (
+    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">
+      {label}
+      <button
+        onClick={onRemove}
+        className="hover:bg-primary/20 rounded-full p-0.5 transition-colors"
+        aria-label={`ลบ ${label}`}
+      >
+        <X className="size-3" />
+      </button>
+    </span>
   );
 }

--- a/apps/web/src/pages/PurchaseOrdersPage/components/QcPendingPanel.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/QcPendingPanel.tsx
@@ -1,4 +1,5 @@
 import { UseMutationResult } from '@tanstack/react-query';
+import { ClipboardCheck, ChevronDown, ChevronRight } from 'lucide-react';
 
 export interface QcPendingPanelProps {
   qcPendingItems: { productId: string; productName: string; imeiSerial?: string }[];
@@ -24,9 +25,12 @@ export function QcPendingPanel({
       <button
         onClick={() => setShowQcPanel(!showQcPanel)}
         className="flex items-center gap-2 px-4 py-2 bg-warning/5 dark:bg-warning/10 border border-warning/20 rounded-xl text-sm font-medium text-warning hover:bg-warning/10 dark:hover:bg-warning/15 transition-colors"
+        aria-expanded={showQcPanel}
       >
+        <ClipboardCheck className="size-4" />
         รอตรวจ QC
         <span className="px-2 py-0.5 bg-warning/10 text-warning dark:bg-warning/15 rounded-full text-xs font-bold">{qcPendingItems.length}</span>
+        {showQcPanel ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
       </button>
       {showQcPanel && (
         <div className="mt-2 border border-warning/20 rounded-xl bg-warning/5 dark:bg-warning/10 p-4">

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
@@ -31,7 +31,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   });
   const suppliers = suppliersRes?.data || [];
 
-  const { data: payableData } = useQuery<{
+  type PayableData = {
     grandTotal: number;
     suppliers: {
       supplier: { id: string; name: string; contactName: string; phone: string };
@@ -41,9 +41,17 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
       poCount: number;
       pos: { id: string; poNumber: string; orderDate: string; dueDate: string | null; netAmount: number; paidAmount: number; remaining: number; paymentStatus: string; status: string; itemsSummary: string }[];
     }[];
-  }>({
+  };
+  const { data: payableData } = useQuery<PayableData>({
     queryKey: ['accounts-payable'],
-    queryFn: async () => (await api.get('/purchase-orders/accounts-payable')).data,
+    queryFn: async (): Promise<PayableData> => {
+      const res = await api.get('/purchase-orders/accounts-payable');
+      // Backend returns { grandTotal, data: suppliers[], total, page, limit }
+      // Normalize to legacy shape { grandTotal, suppliers: [...] }
+      const raw = res.data as { grandTotal?: number; data?: PayableData['suppliers']; suppliers?: PayableData['suppliers'] };
+      const suppliers = Array.isArray(raw?.suppliers) ? raw.suppliers : Array.isArray(raw?.data) ? raw.data : [];
+      return { grandTotal: Number(raw?.grandTotal) || 0, suppliers };
+    },
     enabled: activeTab === 'payable',
   });
 
@@ -58,7 +66,12 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
 
   const { data: qcPendingItems = [] } = useQuery<{ productId: string; productName: string; imeiSerial?: string }[]>({
     queryKey: ['qc-pending'],
-    queryFn: async () => (await api.get('/purchase-orders/qc-pending')).data,
+    queryFn: async () => {
+      const res = await api.get('/purchase-orders/qc-pending');
+      // Backend now returns { data: [...], total, page, limit, totalPages }
+      // Fallback to legacy array shape for older builds
+      return Array.isArray(res.data) ? res.data : (res.data?.data ?? []);
+    },
   });
 
   const qcConfirmMutation = useMutation({

--- a/apps/web/src/pages/PurchaseOrdersPage/index.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/index.tsx
@@ -126,6 +126,7 @@ export default function PurchaseOrdersPage() {
           rejectPOMutation={data.rejectPOMutation}
           cancelMutation={data.cancelMutation}
           setConfirmDialog={data.setConfirmDialog}
+          suppliers={data.suppliers}
         />
       ) : (
         <AccountsPayableTab

--- a/apps/web/src/pages/StockPage/components/BranchSummaryCards.tsx
+++ b/apps/web/src/pages/StockPage/components/BranchSummaryCards.tsx
@@ -7,9 +7,17 @@ export interface BranchSummaryCardsProps {
 }
 
 export function BranchSummaryCards({ summary, filterBranch, setFilterBranch }: BranchSummaryCardsProps) {
+  // Hide branches with zero stock so inactive/legacy branches don't clutter the dashboard.
+  // Fallback: if every branch has zero, show the full list so user isn't stuck with blank UI.
+  const visible = summary.some((s) => s.total > 0)
+    ? summary.filter((s) => s.total > 0)
+    : summary;
+
+  if (visible.length === 0) return null;
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-      {summary.map((s) => (
+      {visible.map((s) => (
         <button
           key={s.branch.id}
           onClick={() => setFilterBranch(filterBranch === s.branch.id ? '' : s.branch.id)}

--- a/apps/web/src/pages/StockPage/components/StockDashboardTab.tsx
+++ b/apps/web/src/pages/StockPage/components/StockDashboardTab.tsx
@@ -2,6 +2,33 @@ import { StockDashboard } from '../types';
 import { statusLabels, categoryLabels } from '@/lib/constants';
 import AnimatedCounter from '@/components/ui/animated-counter';
 import { formatDateShort } from '@/utils/formatters';
+import {
+  AlertTriangle,
+  BarChart3,
+  Clock,
+  HardDrive,
+  Package,
+  Palette,
+  PieChart as PieChartIcon,
+  Tag,
+  Trophy,
+  TrendingUp,
+  Wallet,
+} from 'lucide-react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+// Slow-mover threshold — only highlight items that have been sitting for at least this many days.
+// Below this, the list would just echo the newest arrivals and carry no signal.
+const SLOW_MOVER_MIN_DAYS = 30;
 
 export interface StockDashboardTabProps {
   dashboard: StockDashboard | undefined;
@@ -12,11 +39,16 @@ export interface StockDashboardTabProps {
 
 // --- Small Reusable Components (only used in dashboard) ---
 
-function SectionTitle({ children }: { children: React.ReactNode }) {
-  return <h2 className="text-sm font-semibold text-foreground mb-3">{children}</h2>;
+function SectionTitle({ icon, children }: { icon?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <h2 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+      {icon && <span className="text-muted-foreground [&>svg]:size-4">{icon}</span>}
+      {children}
+    </h2>
+  );
 }
 
-function StatCard({ label, value, sub, accent }: { label: string; value: string | number; sub?: string; accent?: string }) {
+function StatCard({ label, value, sub, accent }: { label: string; value: string | number; sub?: React.ReactNode; accent?: string }) {
   return (
     <div className={`rounded-xl border p-4 transition-shadow hover:shadow-xs ${accent ? `border-l-4 ${accent}` : ''}`}>
       <div className="text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">{label}</div>
@@ -41,12 +73,39 @@ function BarInline({ label, count, total, color }: { label: string; count: numbe
   );
 }
 
+// Status → Tailwind bg color for the stacked bar. Falls back to muted-foreground.
+const STATUS_BAR_COLOR: Record<string, string> = {
+  IN_STOCK: 'bg-success',
+  SOLD_INSTALLMENT: 'bg-primary',
+  SOLD_CASH: 'bg-primary/70',
+  RESERVED: 'bg-warning',
+  QC_PENDING: 'bg-warning/70',
+  PHOTO_PENDING: 'bg-warning/70',
+  REPOSSESSED: 'bg-destructive',
+};
+
+function MoMBadge({ current, previous }: { current: number; previous: number }) {
+  if (previous === 0) {
+    return <span className="text-xs text-muted-foreground">เริ่มบันทึกข้อมูลเดือนนี้</span>;
+  }
+  const delta = ((current - previous) / previous) * 100;
+  const up = delta >= 0;
+  const color = up ? 'text-success' : 'text-destructive';
+  return (
+    <span className={`text-xs font-medium ${color}`}>
+      {up ? '+' : ''}
+      {delta.toFixed(0)}% MoM
+    </span>
+  );
+}
+
 export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyExpiring }: StockDashboardTabProps) {
   return (
     <>
       {warrantyExpiring.length > 0 && (
         <div className="bg-warning/5 dark:bg-warning/10 border border-warning/20 rounded-xl p-4 mb-4">
-          <div className="text-sm font-medium text-warning">
+          <div className="text-sm font-medium text-warning flex items-center gap-2">
+            <AlertTriangle className="size-4" />
             รับประกันใกล้หมด: {warrantyExpiring.length} รายการ
           </div>
           <div className="mt-2 space-y-1">
@@ -68,7 +127,7 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-7.5">
             {/* Action Required */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>รอดำเนินการ ({actionTotal})</SectionTitle>
+              <SectionTitle icon={<AlertTriangle />}>รอดำเนินการ ({actionTotal})</SectionTitle>
               <div className="grid grid-cols-2 gap-3">
                 {dashboard.actionRequired.inspection > 0 && (
                   <div className="flex items-center gap-3 p-3 bg-warning/5 dark:bg-warning/10 rounded-xl">
@@ -118,19 +177,29 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
 
             {/* Stock Turnover */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>อัตราหมุนเวียนสต๊อค</SectionTitle>
+              <SectionTitle icon={<TrendingUp />}>อัตราหมุนเวียนสต๊อค</SectionTitle>
               <div className="grid grid-cols-2 gap-4">
                 <StatCard label="อายุเฉลี่ยในสต๊อค" value={`${dashboard.stockTurnover.avgDaysInStock} วัน`} accent="border-l-primary" />
                 <StatCard label="สต๊อคปัจจุบัน" value={dashboard.stockTurnover.currentStock} sub="ชิ้น (IN_STOCK)" accent="border-l-success" />
                 <StatCard label="ขายเดือนนี้" value={dashboard.stockTurnover.soldThisMonth} sub="ชิ้น" accent="border-l-primary" />
-                <StatCard label="ขายเดือนที่แล้ว" value={dashboard.stockTurnover.soldLastMonth} sub="ชิ้น" accent="border-l-muted-foreground" />
+                <StatCard
+                  label="ขายเดือนที่แล้ว"
+                  value={dashboard.stockTurnover.soldLastMonth}
+                  sub={
+                    <MoMBadge
+                      current={dashboard.stockTurnover.soldThisMonth}
+                      previous={dashboard.stockTurnover.soldLastMonth}
+                    />
+                  }
+                  accent="border-l-muted-foreground"
+                />
               </div>
             </div>
           </div>
 
           {/* Row 2: Stock Aging */}
           <div className="rounded-xl border border-border/60 p-5 shadow-card">
-            <SectionTitle>อายุสต๊อค (Stock Aging)</SectionTitle>
+            <SectionTitle icon={<Clock />}>อายุสต๊อค (Stock Aging)</SectionTitle>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {dashboard.stockAging.map((bucket, i) => {
                 const colors = ['border-l-success', 'border-l-warning', 'border-l-warning', 'border-l-destructive'];
@@ -147,62 +216,121 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
 
           {/* Row 3: Value by Status + Stock Movement */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-7.5">
-            {/* Value by Status */}
+            {/* Value by Status — stacked bar + list */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>มูลค่าสต๊อคตามสถานะ</SectionTitle>
-              <div className="space-y-2">
-                {dashboard.valueByStatus.map((item) => {
-                  const s = statusLabels[item.status] || { label: item.status, className: 'bg-muted text-foreground' };
+              <SectionTitle icon={<PieChartIcon />}>มูลค่าสต๊อคตามสถานะ</SectionTitle>
+              {(() => {
+                const total = dashboard.valueByStatus.reduce((s, i) => s + i.value, 0);
+                if (total === 0) {
                   return (
-                    <div key={item.status} className="flex items-center justify-between py-2 border-b border-border last:border-0">
-                      <div className="flex items-center gap-2">
-                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${s.className}`}>{s.label}</span>
-                        <span className="text-sm text-muted-foreground">{item.count} ชิ้น</span>
-                      </div>
-                      <span className="text-sm font-medium text-foreground">{item.value.toLocaleString()} ฿</span>
-                    </div>
+                    <div className="text-sm text-muted-foreground text-center py-6">ยังไม่มีข้อมูลสต๊อค</div>
                   );
-                })}
-                {dashboard.valueByStatus.length > 0 && (
-                  <div className="flex items-center justify-between pt-2 border-t border-border font-medium">
-                    <span className="text-sm text-foreground">รวมทั้งหมด</span>
-                    <span className="text-sm text-foreground">
-                      {dashboard.valueByStatus.reduce((s, i) => s + i.value, 0).toLocaleString()} ฿
-                    </span>
-                  </div>
-                )}
-              </div>
+                }
+                return (
+                  <>
+                    <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted mb-4">
+                      {dashboard.valueByStatus.map((item) => {
+                        const pct = (item.value / total) * 100;
+                        const color = STATUS_BAR_COLOR[item.status] ?? 'bg-muted-foreground';
+                        return (
+                          <div
+                            key={item.status}
+                            className={color}
+                            style={{ width: `${pct}%` }}
+                            title={`${statusLabels[item.status]?.label ?? item.status}: ${pct.toFixed(1)}%`}
+                          />
+                        );
+                      })}
+                    </div>
+                    <div className="space-y-2">
+                      {dashboard.valueByStatus.map((item) => {
+                        const s = statusLabels[item.status] || { label: item.status, className: 'bg-muted text-foreground' };
+                        const pct = total > 0 ? (item.value / total) * 100 : 0;
+                        return (
+                          <div
+                            key={item.status}
+                            className="flex items-center justify-between py-2 border-b border-border last:border-0"
+                          >
+                            <div className="flex items-center gap-2">
+                              <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${s.className}`}>{s.label}</span>
+                              <span className="text-sm text-muted-foreground">{item.count} ชิ้น</span>
+                            </div>
+                            <div className="flex items-center gap-3">
+                              <span className="text-xs text-muted-foreground tabular-nums">{pct.toFixed(1)}%</span>
+                              <span className="text-sm font-medium text-foreground tabular-nums">
+                                {item.value.toLocaleString()} ฿
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      })}
+                      <div className="flex items-center justify-between pt-2 border-t border-border font-medium">
+                        <span className="text-sm text-foreground">รวมทั้งหมด</span>
+                        <span className="text-sm text-foreground tabular-nums">{total.toLocaleString()} ฿</span>
+                      </div>
+                    </div>
+                  </>
+                );
+              })()}
             </div>
 
-            {/* Stock Movement */}
+            {/* Stock Movement — recharts grouped bar */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>การเคลื่อนไหวสต๊อค (6 เดือน)</SectionTitle>
-              <div className="space-y-3">
-                <div className="flex items-center gap-4 text-xs text-muted-foreground mb-2">
-                  <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-success inline-block" /> รับเข้า</span>
-                  <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-primary inline-block" /> ขายออก</span>
-                </div>
-                {(() => {
-                  const maxVal = Math.max(...dashboard.stockMovement.map((x) => Math.max(x.in, x.out)), 1);
-                  return dashboard.stockMovement.map((m) => (
-                    <div key={m.month} className="space-y-1">
-                      <div className="text-xs text-muted-foreground font-medium">{m.month}</div>
-                      <div className="flex items-center gap-2">
-                        <div className="w-12 text-xs text-right text-success">{m.in}</div>
-                        <div className="flex-1 bg-muted rounded-full h-3 overflow-hidden">
-                          <div className="h-full bg-success rounded-full" style={{ width: `${(m.in / maxVal) * 100}%` }} />
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <div className="w-12 text-xs text-right text-primary">{m.out}</div>
-                        <div className="flex-1 bg-muted rounded-full h-3 overflow-hidden">
-                          <div className="h-full bg-primary rounded-full" style={{ width: `${(m.out / maxVal) * 100}%` }} />
-                        </div>
-                      </div>
+              <SectionTitle icon={<BarChart3 />}>การเคลื่อนไหวสต๊อค (6 เดือน)</SectionTitle>
+              {(() => {
+                // Trim leading zero-months so charts with only recent data don't look broken.
+                const firstNonZero = dashboard.stockMovement.findIndex((m) => m.in > 0 || m.out > 0);
+                const data =
+                  firstNonZero === -1 ? [] : dashboard.stockMovement.slice(firstNonZero);
+
+                if (data.length === 0) {
+                  return (
+                    <div className="text-sm text-muted-foreground text-center py-10">
+                      ยังไม่มีการเคลื่อนไหวของสต๊อค
                     </div>
-                  ));
-                })()}
-              </div>
+                  );
+                }
+                return (
+                  <div className="h-64 -ml-2">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <BarChart data={data} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          className="stroke-border"
+                          vertical={false}
+                        />
+                        <XAxis
+                          dataKey="month"
+                          tick={{ fontSize: 11 }}
+                          className="fill-muted-foreground"
+                          axisLine={false}
+                          tickLine={false}
+                        />
+                        <YAxis
+                          tick={{ fontSize: 11 }}
+                          className="fill-muted-foreground"
+                          axisLine={false}
+                          tickLine={false}
+                          allowDecimals={false}
+                        />
+                        <Tooltip
+                          cursor={{ fill: 'hsl(var(--muted) / 0.5)' }}
+                          contentStyle={{
+                            backgroundColor: 'hsl(var(--popover))',
+                            border: '1px solid hsl(var(--border))',
+                            borderRadius: 8,
+                            fontSize: 12,
+                          }}
+                          labelStyle={{ color: 'hsl(var(--foreground))' }}
+                        />
+                        <Legend wrapperStyle={{ fontSize: 12 }} iconType="circle" />
+                        <Bar dataKey="in" name="รับเข้า" fill="hsl(var(--success))" radius={[4, 4, 0, 0]} />
+                        <Bar dataKey="out" name="ขายออก" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                );
+              })()}
             </div>
           </div>
 
@@ -210,7 +338,7 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 lg:gap-7.5">
             {/* By Category */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>ตามประเภท</SectionTitle>
+              <SectionTitle icon={<Package />}>ตามประเภท</SectionTitle>
               <div className="space-y-2">
                 {dashboard.byCategory.map((item) => (
                   <BarInline
@@ -227,7 +355,7 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
 
             {/* By Brand */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>ตามแบรนด์</SectionTitle>
+              <SectionTitle icon={<Tag />}>ตามแบรนด์</SectionTitle>
               <div className="space-y-2">
                 {dashboard.byBrand.slice(0, 8).map((item) => (
                   <BarInline
@@ -244,7 +372,7 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
 
             {/* By Color */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>ตามสี</SectionTitle>
+              <SectionTitle icon={<Palette />}>ตามสี</SectionTitle>
               <div className="space-y-2">
                 {dashboard.byColor.slice(0, 8).map((item) => (
                   <BarInline
@@ -261,7 +389,7 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
 
             {/* By Storage */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>ตามความจุ</SectionTitle>
+              <SectionTitle icon={<HardDrive />}>ตามความจุ</SectionTitle>
               <div className="space-y-2">
                 {dashboard.byStorage.slice(0, 8).map((item) => (
                   <BarInline
@@ -280,7 +408,7 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
           {/* Row 5: Margin Overview -- Owner/Manager only */}
           {isManager && (
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>กำไรเฉลี่ย (Margin Overview) - สินค้าพร้อมขาย</SectionTitle>
+              <SectionTitle icon={<Wallet />}>กำไรเฉลี่ย (Margin Overview) - สินค้าพร้อมขาย</SectionTitle>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <StatCard
                   label="มูลค่าทุนรวม"
@@ -312,7 +440,7 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-7.5">
             {/* Top Sellers */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>สินค้าขายดี (6 เดือนล่าสุด)</SectionTitle>
+              <SectionTitle icon={<Trophy />}>สินค้าขายดี (6 เดือนล่าสุด)</SectionTitle>
               {dashboard.topSellers.length > 0 ? (
                 <div className="space-y-2">
                   {dashboard.topSellers.map((item, i) => (
@@ -337,29 +465,49 @@ export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyE
 
             {/* Slow Movers */}
             <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle>สินค้าค้างสต๊อคนานสุด</SectionTitle>
-              {dashboard.slowMovers.length > 0 ? (
-                <div className="space-y-2">
-                  {dashboard.slowMovers.map((item, i) => (
-                    <div key={`${item.name}-${i}`} className="flex items-center gap-3">
-                      <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
-                        item.days > 90 ? 'bg-destructive/10 text-destructive dark:bg-destructive/15' :
-                        item.days > 60 ? 'bg-warning/10 text-warning dark:bg-warning/15' :
-                        'bg-warning/10 text-warning dark:bg-warning/15'
-                      }`}>{i + 1}</span>
-                      <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium text-foreground truncate">{item.name}</div>
-                        {isManager && <div className="text-xs text-muted-foreground">{(Number(item.costPrice) || 0).toLocaleString()} ฿</div>}
-                      </div>
-                      <span className={`text-sm font-bold ${item.days > 90 ? 'text-destructive' : item.days > 60 ? 'text-warning' : 'text-warning'}`}>
-                        {item.days} วัน
-                      </span>
+              <SectionTitle icon={<AlertTriangle />}>สินค้าค้างสต๊อคนานสุด</SectionTitle>
+              {(() => {
+                const slow = dashboard.slowMovers.filter((i) => i.days >= SLOW_MOVER_MIN_DAYS);
+                if (slow.length === 0) {
+                  return (
+                    <div className="text-sm text-muted-foreground text-center py-4">
+                      ยังไม่มีสินค้าค้างเกิน {SLOW_MOVER_MIN_DAYS} วัน
                     </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-sm text-muted-foreground text-center py-4">ไม่มีสินค้าในสต๊อค</div>
-              )}
+                  );
+                }
+                return (
+                  <div className="space-y-2">
+                    {slow.map((item, i) => (
+                      <div key={`${item.name}-${i}`} className="flex items-center gap-3">
+                        <span
+                          className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
+                            item.days > 90
+                              ? 'bg-destructive/10 text-destructive dark:bg-destructive/15'
+                              : 'bg-warning/10 text-warning dark:bg-warning/15'
+                          }`}
+                        >
+                          {i + 1}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-medium text-foreground truncate">{item.name}</div>
+                          {isManager && (
+                            <div className="text-xs text-muted-foreground">
+                              {(Number(item.costPrice) || 0).toLocaleString()} ฿
+                            </div>
+                          )}
+                        </div>
+                        <span
+                          className={`text-sm font-bold ${
+                            item.days > 90 ? 'text-destructive' : 'text-warning'
+                          }`}
+                        >
+                          {item.days} วัน
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                );
+              })()}
             </div>
           </div>
         </div>

--- a/apps/web/src/pages/StockPage/components/StockHeroKpi.tsx
+++ b/apps/web/src/pages/StockPage/components/StockHeroKpi.tsx
@@ -1,0 +1,73 @@
+import { Package, Wallet, Clock, TrendingUp } from 'lucide-react';
+import AnimatedCounter from '@/components/ui/animated-counter';
+import { StockDashboard } from '../types';
+
+export interface StockHeroKpiProps {
+  totalInStock: number;
+  totalValue: number;
+  dashboard: StockDashboard | undefined;
+  isManager: boolean;
+}
+
+interface KpiProps {
+  icon: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+  accent: string;
+}
+
+function Kpi({ icon, label, value, hint, accent }: KpiProps) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card p-4 flex items-start gap-3 shadow-card">
+      <div className={`size-10 shrink-0 rounded-xl flex items-center justify-center ${accent}`}>
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">
+          {label}
+        </div>
+        <div className="text-xl font-bold text-foreground mt-0.5 truncate">{value}</div>
+        {hint && <div className="text-xs text-muted-foreground mt-0.5 truncate">{hint}</div>}
+      </div>
+    </div>
+  );
+}
+
+export function StockHeroKpi({ totalInStock, totalValue, dashboard, isManager }: StockHeroKpiProps) {
+  const avgDays = dashboard?.stockTurnover.avgDaysInStock;
+  const marginPct = dashboard?.marginOverview.avgMarginPct;
+
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      <Kpi
+        icon={<Package className="size-5 text-primary" />}
+        label="พร้อมขาย"
+        value={<AnimatedCounter value={totalInStock} />}
+        hint="ชิ้น"
+        accent="bg-primary/10"
+      />
+      <Kpi
+        icon={<Wallet className="size-5 text-success" />}
+        label="มูลค่าพร้อมขาย"
+        value={`${totalValue.toLocaleString()} ฿`}
+        accent="bg-success/10"
+      />
+      <Kpi
+        icon={<Clock className="size-5 text-warning" />}
+        label="อายุเฉลี่ยในสต๊อค"
+        value={avgDays != null ? `${avgDays} วัน` : '-'}
+        accent="bg-warning/10"
+      />
+      {isManager && (
+        <Kpi
+          icon={<TrendingUp className="size-5 text-primary" />}
+          label="Margin เฉลี่ย"
+          value={marginPct != null ? `${marginPct}%` : '-'}
+          hint="สินค้าพร้อมขายที่ตั้งราคาแล้ว"
+          accent="bg-primary/10"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/StockPage/components/StockListTab.tsx
+++ b/apps/web/src/pages/StockPage/components/StockListTab.tsx
@@ -2,6 +2,7 @@ import DataTable, { Column } from '@/components/ui/DataTable';
 import { statusLabels, categoryLabels } from '@/lib/constants';
 import { StockProduct } from '../types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Package, Search, X } from 'lucide-react';
 
 export interface StockListTabProps {
   search: string;
@@ -79,15 +80,46 @@ export function StockListTab({
             <option key={b.id} value={b.id}>{b.name}</option>
           ))}
         </select>
-        {filterBranch && (
-          <button
-            onClick={() => setFilterBranch('')}
-            className="px-3 py-2 text-sm text-primary hover:text-primary-700"
-          >
-            ล้างตัวกรอง
-          </button>
-        )}
       </div>
+
+      {/* Active filter chips */}
+      {(search || filterStatus || filterCategory || filterBranch) && (
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="text-xs text-muted-foreground">ตัวกรองที่ใช้:</span>
+          {search && (
+            <FilterChip label={`ค้นหา: "${search}"`} onRemove={() => setSearch('')} />
+          )}
+          {filterStatus && (
+            <FilterChip
+              label={`สถานะ: ${statusLabels[filterStatus]?.label || filterStatus}`}
+              onRemove={() => setFilterStatus('')}
+            />
+          )}
+          {filterCategory && (
+            <FilterChip
+              label={`ประเภท: ${categoryLabels[filterCategory] || filterCategory}`}
+              onRemove={() => setFilterCategory('')}
+            />
+          )}
+          {filterBranch && (
+            <FilterChip
+              label={`สาขา: ${branches.find((b) => b.id === filterBranch)?.name || filterBranch}`}
+              onRemove={() => setFilterBranch('')}
+            />
+          )}
+          <button
+            onClick={() => {
+              setSearch('');
+              setFilterStatus('');
+              setFilterCategory('');
+              setFilterBranch('');
+            }}
+            className="ml-1 text-xs text-muted-foreground hover:text-foreground underline"
+          >
+            ล้างทั้งหมด
+          </button>
+        </div>
+      )}
 
       <Card>
         <CardHeader>
@@ -98,7 +130,10 @@ export function StockListTab({
             columns={columns}
             data={listProducts}
             isLoading={listLoading}
-            emptyMessage="ไม่พบสินค้า"
+            emptyMessage={search || filterStatus || filterCategory || filterBranch ? 'ไม่พบสินค้าที่ตรงกับตัวกรอง' : 'ยังไม่มีสินค้าในคลัง'}
+            emptyIcon={search ? Search : Package}
+            emptyDescription={search || filterStatus || filterCategory || filterBranch ? 'ลองล้างตัวกรองหรือค้นหาด้วยคำอื่น' : undefined}
+            columnToggle
             pagination={listResult ? {
               page: listResult.page,
               totalPages: listResult.totalPages,
@@ -109,5 +144,20 @@ export function StockListTab({
         </CardContent>
       </Card>
     </>
+  );
+}
+
+function FilterChip({ label, onRemove }: { label: string; onRemove: () => void }) {
+  return (
+    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">
+      {label}
+      <button
+        onClick={onRemove}
+        className="hover:bg-primary/20 rounded-full p-0.5 transition-colors"
+        aria-label={`ลบ ${label}`}
+      >
+        <X className="size-3" />
+      </button>
+    </span>
   );
 }

--- a/apps/web/src/pages/StockPage/index.tsx
+++ b/apps/web/src/pages/StockPage/index.tsx
@@ -7,7 +7,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import { Button } from '@/components/ui/button';
 import { statusLabels, categoryLabels } from '@/lib/constants';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { ArrowRightLeft, Download, Plus } from 'lucide-react';
+import { ArrowRightLeft, Download, Eye, Plus } from 'lucide-react';
 import { StockProduct } from './types';
 import { useStockData, useEditingProductSync } from './hooks/useStockData';
 import { useStockFilters } from './hooks/useStockFilters';
@@ -201,6 +201,20 @@ export default function StockPage() {
       key: 'branch',
       label: 'สาขา',
       render: (p: StockProduct) => <span className="text-xs font-medium">{p.branch.name}</span>,
+    },
+    {
+      key: 'actions',
+      label: '',
+      render: (p: StockProduct) => (
+        <button
+          onClick={(e) => { e.stopPropagation(); navigateToProduct(p.id); }}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium text-muted-foreground hover:text-primary hover:bg-accent transition-colors"
+          title="ดูรายละเอียดสินค้า"
+        >
+          <Eye className="size-3.5" />
+          ดูรายละเอียด
+        </button>
+      ),
     },
   ], [navigateToProduct, openPriceEdit, isManager, selectedIds, listProducts]);
 

--- a/apps/web/src/pages/StockPage/index.tsx
+++ b/apps/web/src/pages/StockPage/index.tsx
@@ -13,6 +13,7 @@ import { useStockData, useEditingProductSync } from './hooks/useStockData';
 import { useStockFilters } from './hooks/useStockFilters';
 import QueryBoundary from '@/components/QueryBoundary';
 import { BranchSummaryCards } from './components/BranchSummaryCards';
+import { StockHeroKpi } from './components/StockHeroKpi';
 import { StockDashboardTab } from './components/StockDashboardTab';
 import { StockListTab } from './components/StockListTab';
 import { BulkTransferModal } from './components/BulkTransferModal';
@@ -211,7 +212,7 @@ export default function StockPage() {
     <div>
       <PageHeader
         title="คลังสินค้า"
-        subtitle={`พร้อมขาย ${totalInStock} ชิ้น | มูลค่ารวม ${totalValue.toLocaleString()} ฿`}
+        subtitle="จัดการคลังสินค้าและดูภาพรวมสต๊อค"
         action={
           isManager && activeTab === 'list' ? (
             <div className="flex gap-2">
@@ -232,6 +233,13 @@ export default function StockPage() {
             </div>
           ) : undefined
         }
+      />
+
+      <StockHeroKpi
+        totalInStock={totalInStock}
+        totalValue={totalValue}
+        dashboard={dashboard}
+        isManager={isManager}
       />
 
       <BranchSummaryCards

--- a/apps/web/src/pages/StockPage/index.tsx
+++ b/apps/web/src/pages/StockPage/index.tsx
@@ -7,8 +7,9 @@ import PageHeader from '@/components/ui/PageHeader';
 import { Button } from '@/components/ui/button';
 import { statusLabels, categoryLabels } from '@/lib/constants';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { ArrowRightLeft, Download, Eye, Plus } from 'lucide-react';
+import { ArrowRightLeft, Check, Copy, Download, Eye, Plus } from 'lucide-react';
 import { StockProduct } from './types';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useStockData, useEditingProductSync } from './hooks/useStockData';
 import { useStockFilters } from './hooks/useStockFilters';
 import QueryBoundary from '@/components/QueryBoundary';
@@ -18,6 +19,22 @@ import { StockDashboardTab } from './components/StockDashboardTab';
 import { StockListTab } from './components/StockListTab';
 import { BulkTransferModal } from './components/BulkTransferModal';
 import { PriceManagementModal } from './components/PriceManagementModal';
+
+function ImeiCopyBadge({ imei }: { imei: string }) {
+  const { copy, copied } = useCopyToClipboard();
+  return (
+    <span className="flex items-center gap-1">
+      <span className="text-xs text-muted-foreground font-mono">{imei}</span>
+      <button
+        onClick={(e) => { e.stopPropagation(); copy(imei); }}
+        className="text-muted-foreground/60 hover:text-primary transition-colors"
+        title="คัดลอก IMEI/Serial"
+      >
+        {copied ? <Check className="size-3 text-success" /> : <Copy className="size-3" />}
+      </button>
+    </span>
+  );
+}
 
 export default function StockPage() {
   useDocumentTitle('สต็อกสินค้า');
@@ -134,45 +151,61 @@ export default function StockPage() {
     {
       key: 'name',
       label: 'สินค้า',
+      sortable: false,
+      hideable: false,
       render: (p: StockProduct) => (
-        <button
-          onClick={() => navigateToProduct(p.id)}
-          className="text-left hover:underline"
-        >
-          <div className="text-primary font-medium">{p.brand} {p.model}</div>
-          {p.imeiSerial && <div className="text-xs text-muted-foreground font-mono">{p.imeiSerial}</div>}
-        </button>
+        <div>
+          <button
+            onClick={() => navigateToProduct(p.id)}
+            className="text-left hover:underline"
+          >
+            <div className="text-primary font-medium">{p.brand} {p.model}</div>
+          </button>
+          {p.imeiSerial && <ImeiCopyBadge imei={p.imeiSerial} />}
+        </div>
       ),
     },
     {
       key: 'category',
       label: 'ประเภท',
+      sortable: true,
+      hideable: true,
       render: (p: StockProduct) => <span className="text-xs">{categoryLabels[p.category] || p.category}</span>,
     },
     {
       key: 'color',
       label: 'สี',
-      render: (p: StockProduct) => <span className="text-sm">{p.color || '-'}</span>,
+      sortable: true,
+      hideable: true,
+      render: (p: StockProduct) => <span className="text-sm">{p.color || <span className="text-muted-foreground">—</span>}</span>,
     },
     {
       key: 'storage',
       label: 'ความจุ',
-      render: (p: StockProduct) => <span className="text-sm">{p.storage || '-'}</span>,
+      sortable: true,
+      hideable: true,
+      render: (p: StockProduct) => <span className="text-sm">{p.storage || <span className="text-muted-foreground">—</span>}</span>,
     },
     {
       key: 'prices',
       label: 'ราคา',
+      sortable: false,
+      hideable: false,
       render: (p: StockProduct) => {
         const defaultPrice = p.prices?.find((pr) => pr.isDefault) || p.prices?.[0];
+        const priceValue = defaultPrice ? parseFloat(defaultPrice.amount) : 0;
+        const costValue = parseFloat(p.costPrice);
         return (
           <div className="flex items-center gap-1.5">
             <div>
-              {defaultPrice ? (
-                <div className="font-medium">{parseFloat(defaultPrice.amount).toLocaleString()} ฿</div>
+              {priceValue > 0 ? (
+                <div className="font-medium">{priceValue.toLocaleString()} ฿</div>
               ) : (
-                <span className="text-muted-foreground">-</span>
+                <span className="text-muted-foreground">—</span>
               )}
-              {isManager && <div className="text-xs text-muted-foreground">ทุน: {parseFloat(p.costPrice).toLocaleString()} ฿</div>}
+              {isManager && costValue > 0 && (
+                <div className="text-xs text-muted-foreground">ทุน: {costValue.toLocaleString()} ฿</div>
+              )}
             </div>
             {isManager && (
               <button
@@ -192,6 +225,8 @@ export default function StockPage() {
     {
       key: 'status',
       label: 'สถานะ',
+      sortable: true,
+      hideable: false,
       render: (p: StockProduct) => {
         const s = statusLabels[p.status] || { label: p.status, className: 'bg-muted text-foreground' };
         return <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${s.className}`}>{s.label}</span>;
@@ -200,6 +235,8 @@ export default function StockPage() {
     {
       key: 'branch',
       label: 'สาขา',
+      sortable: false,
+      hideable: true,
       render: (p: StockProduct) => <span className="text-xs font-medium">{p.branch.name}</span>,
     },
     {

--- a/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
+++ b/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { getStatusBadgeProps, tradeInStatusMap } from '@/lib/status-badges';
-import { formatThaiDate } from '@/lib/date';
+import { formatThaiDateTime } from '@/lib/date';
 import {
   RefreshCw,
   CheckCircle,
@@ -39,16 +39,6 @@ interface TradeInTableProps {
   onVoucher: (item: TradeIn) => void;
   isRejectPending: boolean;
   voucherLoadingId: string | null;
-}
-
-function formatRelativeDate(iso: string): string {
-  const diffDays = Math.floor((Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) return 'วันนี้';
-  if (diffDays === 1) return 'เมื่อวาน';
-  if (diffDays < 7) return `${diffDays} วันก่อน`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} สัปดาห์ก่อน`;
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)} เดือนก่อน`;
-  return formatThaiDate(iso);
 }
 
 export default function TradeInTable({
@@ -132,24 +122,36 @@ export default function TradeInTable({
       },
     },
     {
+      key: 'buyer',
+      label: 'ผู้รับซื้อ',
+      hideable: true,
+      render: (item) => {
+        const buyer = item.idCardVerifiedBy ?? item.appraisedBy;
+        if (!buyer) return <span className="text-sm text-muted-foreground">รอรับซื้อ</span>;
+        return <span className="text-sm text-foreground">{buyer.name}</span>;
+      },
+    },
+    {
       key: 'voucherNumber',
       label: 'เลขใบสำคัญ',
       hideable: true,
       render: (item) =>
         item.voucherNumber ? (
-          <span className="text-xs font-mono text-foreground">{item.voucherNumber}</span>
+          <span className="text-sm font-mono font-semibold text-foreground">
+            {item.voucherNumber}
+          </span>
         ) : (
-          <span className="text-xs text-muted-foreground">-</span>
+          <span className="text-sm text-muted-foreground">-</span>
         ),
     },
     {
       key: 'createdAt',
-      label: 'วันที่',
+      label: 'วันที่ / เวลา',
       sortable: true,
       hideable: true,
       render: (item) => (
-        <span className="text-xs text-muted-foreground whitespace-nowrap">
-          {formatRelativeDate(item.createdAt)}
+        <span className="text-sm text-foreground whitespace-nowrap">
+          {formatThaiDateTime(item.idCardVerifiedAt ?? item.createdAt)}
         </span>
       ),
     },

--- a/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
+++ b/apps/web/src/pages/TradeInPage/components/TradeInTable.tsx
@@ -114,10 +114,20 @@ export default function TradeInTable({
       sortable: true,
       render: (item) => {
         const value = item.agreedPrice ?? item.offeredPrice ?? item.estimatedValue;
-        return value != null ? (
-          <span className="font-medium">฿{Number(value).toLocaleString()}</span>
-        ) : (
-          <span className="text-muted-foreground">-</span>
+        if (value == null) return <span className="text-muted-foreground">-</span>;
+        const methodLabel =
+          item.paymentMethod === 'CASH'
+            ? 'เงินสด'
+            : item.paymentMethod === 'TRANSFER'
+              ? 'โอน'
+              : null;
+        return (
+          <div>
+            <div className="font-medium">฿{Number(value).toLocaleString()}</div>
+            {methodLabel && (
+              <div className="text-xs text-muted-foreground">{methodLabel}</div>
+            )}
+          </div>
         );
       },
     },
@@ -130,6 +140,17 @@ export default function TradeInTable({
         if (!buyer) return <span className="text-sm text-muted-foreground">รอรับซื้อ</span>;
         return <span className="text-sm text-foreground">{buyer.name}</span>;
       },
+    },
+    {
+      key: 'branch',
+      label: 'สาขา',
+      hideable: true,
+      render: (item) =>
+        item.branch ? (
+          <span className="text-sm text-foreground">{item.branch.name}</span>
+        ) : (
+          <span className="text-sm text-muted-foreground">-</span>
+        ),
     },
     {
       key: 'voucherNumber',

--- a/apps/web/src/pages/TradeInPage/types.ts
+++ b/apps/web/src/pages/TradeInPage/types.ts
@@ -15,7 +15,10 @@ export interface TradeIn {
   voucherNumber: string | null;
   voucherPdfUrl: string | null;
   createdAt: string;
+  idCardVerifiedAt?: string | null;
   customer: { id: string; name: string } | null;
+  appraisedBy?: { id: string; name: string } | null;
+  idCardVerifiedBy?: { id: string; name: string } | null;
 }
 
 export interface TradeInsResponse {

--- a/apps/web/src/pages/TradeInPage/types.ts
+++ b/apps/web/src/pages/TradeInPage/types.ts
@@ -16,7 +16,9 @@ export interface TradeIn {
   voucherPdfUrl: string | null;
   createdAt: string;
   idCardVerifiedAt?: string | null;
+  paymentMethod?: 'CASH' | 'TRANSFER' | null;
   customer: { id: string; name: string } | null;
+  branch?: { id: string; name: string } | null;
   appraisedBy?: { id: string; name: string } | null;
   idCardVerifiedBy?: { id: string; name: string } | null;
 }


### PR DESCRIPTION
## Summary
รวม 3 PR เข้าเป็นก้อนเดียว (ยังไม่ merge) — ประกอบด้วย

### 1. Trade-in table (เดิม #510)
- เพิ่มคอลัมน์ "ผู้รับซื้อ" (fallback chain: `idCardVerifiedBy` → `appraisedBy` → "รอรับซื้อ")
- แสดง "วันที่ / เวลา" แบบ `formatThaiDateTime`
- ขยายเลขใบสำคัญจ่าย `text-xs` → `text-sm font-semibold`
- เพิ่มคอลัมน์ "สาขา" (hideable)
- แสดงวิธีจ่าย (เงินสด/โอน) inline ใต้ราคา
- Backend: `findAll()` include `branch`, `appraisedBy`, `idCardVerifiedBy`

### 2. Stock Dashboard polish (เดิม #511)
- Hero KPI strip ใหม่ (4 การ์ด พร้อม lucide icon: Package / Wallet / Clock / TrendingUp)
- Subtitle header เปลี่ยนเป็นข้อความสั้น ไม่ duplicate กับ Hero
- BranchSummaryCards hide สาขาที่ total=0 (กรณีไม่มีข้อมูลเลยแสดงครบ)
- Dashboard: section titles มี lucide icon ทุก section
- Value by status: stacked bar + list พร้อม % column
- Stock movement: trim leading zero months + empty state
- Slow movers: threshold `SLOW_MOVER_MIN_DAYS = 30` + empty state
- ใช้ recharts `BarChart` พร้อม `CartesianGrid`, `Tooltip`, `Legend`
- ใช้ HSL tokens (`hsl(var(--success))`, `hsl(var(--primary))`) ไม่ hardcode

### 3. Stock list: ปุ่ม "ดูรายละเอียด" (เดิม #512)
- เพิ่ม action column ท้ายตาราง
- Eye icon + "ดูรายละเอียด" → navigate `/products/:id`

## Test plan (local)
- [x] TypeScript check (`./tools/check-types.sh all`) ผ่าน
- [x] Playwright: stock list 34 แถวมีปุ่มครบ, คลิกไปหน้า detail ได้, 0 JS errors
- [x] Playwright: stock dashboard render recharts + icons ครบ
- [x] ใช้ lucide icons ทั้งหมด ไม่มี emoji

## Replaces
- Closes #510 (trade-in)
- Closes #511 (stock dashboard)
- Closes #512 (stock list view-detail)

(จะไม่ merge — รอ user ตรวจก่อน)