### PR TITLE
feat(suppliers): นิติบุคคล vs บุคคลธรรมดา + รหัสสาขาใบกำกับภาษี

### DIFF
--- a/apps/api/prisma/migrations/20260502000000_add_supplier_type_branch_code/migration.sql
+++ b/apps/api/prisma/migrations/20260502000000_add_supplier_type_branch_code/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "SupplierType" AS ENUM ('INDIVIDUAL', 'JURISTIC');
+
+-- AlterTable: add new columns (all optional / with default so existing rows backfill safely)
+ALTER TABLE "suppliers"
+  ADD COLUMN "type" "SupplierType" NOT NULL DEFAULT 'JURISTIC',
+  ADD COLUMN "title_name" TEXT,
+  ADD COLUMN "branch_code" TEXT;

--- a/apps/api/prisma/migrations/20260502100000_supplier_contact_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260502100000_supplier_contact_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: make contact_name optional + add contact_phone + contact_position
+ALTER TABLE "suppliers"
+  ALTER COLUMN "contact_name" DROP NOT NULL,
+  ADD COLUMN "contact_phone" TEXT,
+  ADD COLUMN "contact_position" TEXT;

--- a/apps/api/prisma/migrations/20260503000000_po_discount_after_vat/migration.sql
+++ b/apps/api/prisma/migrations/20260503000000_po_discount_after_vat/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "purchase_orders"
+  ADD COLUMN "discount_after_vat" DECIMAL(12,2) NOT NULL DEFAULT 0;

--- a/apps/api/prisma/migrations/20260504000000_contract_template_lessor_name/migration.sql
+++ b/apps/api/prisma/migrations/20260504000000_contract_template_lessor_name/migration.sql
@@ -1,0 +1,16 @@
+-- Replace {salesperson_name} with {lessor_name} ONLY under the ผู้ให้เช่าซื้อ (lessor) signature block.
+-- The ผู้ให้เช่าซื้อ section is identified by the preceding {staff_signature} placeholder.
+-- The customer side uses {customer_signature} + {customer_name}, so it is unaffected.
+
+UPDATE "contract_templates"
+SET
+  "content_html" = REPLACE(
+    "content_html",
+    $REPL${staff_signature}
+<p>( {salesperson_name} )</p>$REPL$,
+    $REPL${staff_signature}
+<p>( {lessor_name} )</p>$REPL$
+  ),
+  "updated_at" = NOW()
+WHERE "content_html" LIKE '%{staff_signature}%{salesperson_name}%'
+  AND "deleted_at" IS NULL;

--- a/apps/api/prisma/migrations/20260504010000_remove_device_photos_section/migration.sql
+++ b/apps/api/prisma/migrations/20260504010000_remove_device_photos_section/migration.sql
@@ -1,0 +1,15 @@
+-- Remove the "รูปถ่ายโทรศัพท์จำนวน 6 ภาพแนบท้าย" section from any DB contract template
+-- that may have been edited to include it. The photo grid + trailing signature line are
+-- no longer wanted in the contract PDF.
+
+UPDATE "contract_templates"
+SET
+  "content_html" = REGEXP_REPLACE(
+    "content_html",
+    '<div class="no-break"[^>]*>\s*<h3[^>]*>รูปถ่ายโทรศัพท์[^<]*</h3>.*?</div>\s*</div>',
+    '',
+    'gs'
+  ),
+  "updated_at" = NOW()
+WHERE "content_html" LIKE '%รูปถ่ายโทรศัพท์%ภาพแนบท้าย%'
+  AND "deleted_at" IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -23,6 +23,11 @@ enum UserRole {
   OWNER
 }
 
+enum SupplierType {
+  INDIVIDUAL
+  JURISTIC
+}
+
 enum ContractStatus {
   DRAFT
   ACTIVE
@@ -716,18 +721,24 @@ model Payment {
 // ============================================================
 
 model Supplier {
-  id             String    @id @default(uuid())
+  id             String       @id @default(uuid())
+  /// Entity type: JURISTIC = บริษัท/นิติบุคคล, INDIVIDUAL = บุคคลธรรมดา
+  type           SupplierType @default(JURISTIC)
   name           String
-  contactName    String    @map("contact_name")
+  contactName    String       @map("contact_name")
   nickname       String?
+  /// Salutation for INDIVIDUAL type (นาย/นาง/นางสาว/คุณ)
+  titleName      String?      @map("title_name")
+  /// 5-digit branch code for JURISTIC type. "00000" = สำนักงานใหญ่. Required on tax invoices for VAT registrants.
+  branchCode     String?      @map("branch_code")
   phone          String
-  phoneSecondary String?   @map("phone_secondary")
-  lineId         String?   @map("line_id")
+  phoneSecondary String?      @map("phone_secondary")
+  lineId         String?      @map("line_id")
   address        String?
-  taxId          String?   @map("tax_id")
-  hasVat         Boolean   @default(false) @map("has_vat")
+  taxId          String?      @map("tax_id")
+  hasVat         Boolean      @default(false) @map("has_vat")
   notes          String?
-  isActive       Boolean   @default(true) @map("is_active")
+  isActive       Boolean      @default(true) @map("is_active")
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")
   deletedAt      DateTime? @map("deleted_at")

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -725,7 +725,9 @@ model Supplier {
   /// Entity type: JURISTIC = บริษัท/นิติบุคคล, INDIVIDUAL = บุคคลธรรมดา
   type           SupplierType @default(JURISTIC)
   name           String
-  contactName    String       @map("contact_name")
+  contactName    String?      @map("contact_name")
+  contactPhone   String?      @map("contact_phone")
+  contactPosition String?     @map("contact_position")
   nickname       String?
   /// Salutation for INDIVIDUAL type (นาย/นาง/นางสาว/คุณ)
   titleName      String?      @map("title_name")
@@ -778,10 +780,11 @@ model PurchaseOrder {
   expectedDate  DateTime?       @map("expected_date")
   dueDate       DateTime?       @map("due_date")
   status        POStatus        @default(DRAFT)
-  totalAmount   Decimal         @map("total_amount") @db.Decimal(12, 2)
-  discount      Decimal         @default(0) @db.Decimal(12, 2)
-  vatAmount     Decimal         @default(0) @map("vat_amount") @db.Decimal(12, 2)
-  netAmount     Decimal         @default(0) @map("net_amount") @db.Decimal(12, 2)
+  totalAmount      Decimal         @map("total_amount") @db.Decimal(12, 2)
+  discount         Decimal         @default(0) @db.Decimal(12, 2) // ส่วนลดก่อน VAT
+  discountAfterVat Decimal         @default(0) @map("discount_after_vat") @db.Decimal(12, 2)
+  vatAmount        Decimal         @default(0) @map("vat_amount") @db.Decimal(12, 2)
+  netAmount        Decimal         @default(0) @map("net_amount") @db.Decimal(12, 2)
   paymentStatus POPaymentStatus @default(UNPAID) @map("payment_status")
   paymentMethod String?         @map("payment_method")
   paidAmount    Decimal         @default(0) @map("paid_amount") @db.Decimal(12, 2)

--- a/apps/api/src/modules/contracts/documents.controller.ts
+++ b/apps/api/src/modules/contracts/documents.controller.ts
@@ -151,6 +151,13 @@ export class DocumentsController {
     return this.documentsService.generateSignedDocuments(id, user.id);
   }
 
+  /** Bulk-regenerate signed contract PDFs after template changes. Old PDFs retained. */
+  @Post('contracts/admin/regenerate-signed-pdfs')
+  @Roles('OWNER')
+  regenerateSignedContractPdfs(@CurrentUser() user: { id: string }) {
+    return this.documentsService.regenerateSignedContractPdfs(user.id);
+  }
+
   @Post('contracts/:id/generate-pdpa-document')
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
   generatePdpaDocument(

--- a/apps/api/src/modules/contracts/documents.service.ts
+++ b/apps/api/src/modules/contracts/documents.service.ts
@@ -521,6 +521,41 @@ export class DocumentsService {
     return results;
   }
 
+  /**
+   * Bulk-regenerate CONTRACT PDFs for contracts that have a CUSTOMER signature.
+   * Use this after template changes (e.g. lessor name correction) to refresh already-signed
+   * contracts. Old PDFs remain in S3 as legal evidence — new rows are appended to EDocument.
+   */
+  async regenerateSignedContractPdfs(createdById: string, limit = 500) {
+    const contracts = await this.prisma.contract.findMany({
+      where: {
+        deletedAt: null,
+        signatures: { some: { signerType: 'CUSTOMER', deletedAt: null } },
+      },
+      select: { id: true, contractNumber: true },
+      take: limit,
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const success: string[] = [];
+    const failed: { contractNumber: string; error: string }[] = [];
+
+    for (const c of contracts) {
+      try {
+        await this.generateDocument(c.id, createdById, 'CONTRACT');
+        success.push(c.contractNumber);
+      } catch (err) {
+        failed.push({
+          contractNumber: c.contractNumber,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    this.logger.log(`Regenerated ${success.length}/${contracts.length} signed contract PDFs (${failed.length} failed)`);
+    return { total: contracts.length, success: success.length, failed };
+  }
+
   // ─── Preview ──────────────────────────────────────────
   async previewContract(contractId: string, templateId?: string) {
     const contract = await this.prisma.contract.findUnique({
@@ -880,16 +915,16 @@ ${(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const customerSig = contract.signatures?.find((s: any) => s.signerType === 'CUSTOMER');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let staffSig = contract.signatures?.find((s: any) => s.signerType === 'STAFF' || s.signerType === 'COMPANY');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const witness1Sig = contract.signatures?.find((s: any) => s.signerType === 'WITNESS_1');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const witness2Sig = contract.signatures?.find((s: any) => s.signerType === 'WITNESS_2');
 
-    // Fallback to system settings lessor signature if no COMPANY/STAFF signature on contract
-    if (!staffSig && lessorSig) {
-      staffSig = { signatureImage: lessorSig.image, signerName: lessorSig.name, signerType: 'COMPANY' };
-    }
+    // Lessor (ผู้ให้เช่าซื้อ) signature always comes from system settings — never per-contract.
+    // Falls back to contract STAFF/COMPANY signature only if system signature is missing.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let staffSig: any = lessorSig
+      ? { signatureImage: lessorSig.image, signerName: lessorSig.name, signerType: 'COMPANY' }
+      : contract.signatures?.find((s: any) => s.signerType === 'STAFF' || s.signerType === 'COMPANY');
 
     // Validate signature images are safe data URLs before embedding
     const customerSigSafe = customerSig && this.isSafeImageDataUrl(customerSig.signatureImage);
@@ -973,6 +1008,7 @@ ${(() => {
       '{branch_address}': esc(contract.branch?.location || ''),
       '{branch_phone}': esc(contract.branch?.phone || ''),
       '{salesperson_name}': esc(contract.salesperson?.name || ''),
+      '{lessor_name}': esc(lessorSig?.name || cfg('company_director', 'เอกนรินทร์ คงเดช')),
       '{witness1_name}': witness1Sig?.signerName ? esc(witness1Sig.signerName) : (references[0] ? esc(`${references[0].prefix || ''}${references[0].firstName || ''} ${references[0].lastName || ''}`.trim()) : ''),
       '{witness2_name}': witness2Sig?.signerName ? esc(witness2Sig.signerName) : (references[1] ? esc(`${references[1].prefix || ''}${references[1].firstName || ''} ${references[1].lastName || ''}`.trim()) : ''),
       '{staff_signer_name}': esc(contract.salesperson?.name || ''),

--- a/apps/api/src/modules/contracts/templates/hire-purchase-contract.html
+++ b/apps/api/src/modules/contracts/templates/hire-purchase-contract.html
@@ -274,7 +274,7 @@
 <tr>
 <td style="width:50%;text-align:center;padding:20px 15px;vertical-align:top">
 <p style="margin:0;white-space:nowrap">ลงชื่อ {staff_signature} ผู้ให้เช่าซื้อ</p>
-<p style="margin:5px 0 0">( {salesperson_name} )</p>
+<p style="margin:5px 0 0">( {lessor_name} )</p>
 </td>
 <td style="width:50%;text-align:center;padding:20px 15px;vertical-align:top">
 <p style="margin:0;white-space:nowrap">ลงชื่อ {customer_signature} ผู้เช่าซื้อ</p>
@@ -292,16 +292,6 @@
 </td>
 </tr>
 </table>
-</div>
-
-<div class="no-break" style="margin-top:40px">
-<h3 style="margin:0 0 12px 0;border-bottom:1px solid #ccc;padding-bottom:6px">รูปถ่ายโทรศัพท์จำนวน 6 ภาพแนบท้าย</h3>
-
-{device_photos_grid}
-
-<div style="margin-top:40px">
-<p>ชื่อ ........................................................... ผู้เช่าซื้อ วันที่ .............. เดือน .............................. พ.ศ ....................</p>
-</div>
 </div>
 
 </div>

--- a/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
+++ b/apps/api/src/modules/purchase-orders/dto/create-po.dto.ts
@@ -62,7 +62,13 @@ export class CreatePODto {
 
   @IsNumber()
   @IsOptional()
+  @Min(0)
   discount?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @Min(0)
+  discountAfterVat?: number;
 
   @IsIn(['UNPAID', 'DEPOSIT_PAID', 'PARTIALLY_PAID', 'FULLY_PAID'])
   @IsOptional()

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -85,12 +85,13 @@ export class PurchaseOrdersService {
 
     // Calculate total with discount & VAT (only if supplier has VAT)
     const totalAmount = dto.items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0);
-    const discount = dto.discount || 0;
+    const discount = dto.discount || 0; // ส่วนลดก่อน VAT
+    const discountAfterVat = supplier.hasVat ? dto.discountAfterVat || 0 : 0; // ส่วนลดหลัง VAT (เฉพาะ supplier มี VAT)
     const subtotalAfterDiscount = totalAmount - discount;
     const vatConfig = await this.prisma.systemConfig.findUnique({ where: { key: 'vat_pct' } });
     const vatRate = vatConfig ? Number(vatConfig.value) : 0.07;
     const vatAmount = supplier.hasVat ? Math.round(subtotalAfterDiscount * vatRate * 100) / 100 : 0;
-    const netAmount = subtotalAfterDiscount + vatAmount;
+    const netAmount = subtotalAfterDiscount + vatAmount - discountAfterVat;
 
     // Calculate due date from supplier credit terms
     const orderDateObj = new Date(dto.orderDate);
@@ -118,6 +119,7 @@ export class PurchaseOrdersService {
           dueDate,
           totalAmount,
           discount,
+          discountAfterVat,
           vatAmount,
           netAmount,
           notes: dto.notes,

--- a/apps/api/src/modules/suppliers/dto/create-supplier.dto.ts
+++ b/apps/api/src/modules/suppliers/dto/create-supplier.dto.ts
@@ -51,7 +51,16 @@ export class CreateSupplierDto {
   titleName?: string;
 
   @IsString()
-  contactName: string;
+  @IsOptional()
+  contactName?: string;
+
+  @IsString()
+  @IsOptional()
+  contactPhone?: string;
+
+  @IsString()
+  @IsOptional()
+  contactPosition?: string;
 
   @IsString()
   @IsOptional()

--- a/apps/api/src/modules/suppliers/dto/create-supplier.dto.ts
+++ b/apps/api/src/modules/suppliers/dto/create-supplier.dto.ts
@@ -1,5 +1,16 @@
-import { IsString, IsOptional, IsBoolean, IsArray, ValidateNested, IsInt, Min } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsArray,
+  ValidateNested,
+  IsInt,
+  Min,
+  IsEnum,
+  Matches,
+} from 'class-validator';
 import { Type } from 'class-transformer';
+import { SupplierType } from '@prisma/client';
 
 export class PaymentMethodDto {
   @IsString()
@@ -28,8 +39,16 @@ export class PaymentMethodDto {
 }
 
 export class CreateSupplierDto {
+  @IsEnum(SupplierType, { message: 'ประเภทผู้ขายไม่ถูกต้อง' })
+  @IsOptional()
+  type?: SupplierType;
+
   @IsString()
   name: string;
+
+  @IsString()
+  @IsOptional()
+  titleName?: string;
 
   @IsString()
   contactName: string;
@@ -37,6 +56,11 @@ export class CreateSupplierDto {
   @IsString()
   @IsOptional()
   nickname?: string;
+
+  @IsString()
+  @Matches(/^\d{5}$/, { message: 'รหัสสาขาต้องเป็นตัวเลข 5 หลัก' })
+  @IsOptional()
+  branchCode?: string;
 
   @IsString()
   phone: string;

--- a/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
+++ b/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
@@ -61,6 +61,14 @@ export class UpdateSupplierDto {
 
   @IsString()
   @IsOptional()
+  contactPhone?: string;
+
+  @IsString()
+  @IsOptional()
+  contactPosition?: string;
+
+  @IsString()
+  @IsOptional()
   nickname?: string;
 
   @IsString()

--- a/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
+++ b/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
@@ -1,5 +1,16 @@
-import { IsString, IsOptional, IsBoolean, IsArray, ValidateNested, IsInt, Min } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsArray,
+  ValidateNested,
+  IsInt,
+  Min,
+  IsEnum,
+  Matches,
+} from 'class-validator';
 import { Type } from 'class-transformer';
+import { SupplierType } from '@prisma/client';
 
 export class PaymentMethodUpdateDto {
   @IsString()
@@ -32,9 +43,17 @@ export class PaymentMethodUpdateDto {
 }
 
 export class UpdateSupplierDto {
+  @IsEnum(SupplierType, { message: 'ประเภทผู้ขายไม่ถูกต้อง' })
+  @IsOptional()
+  type?: SupplierType;
+
   @IsString()
   @IsOptional()
   name?: string;
+
+  @IsString()
+  @IsOptional()
+  titleName?: string;
 
   @IsString()
   @IsOptional()
@@ -43,6 +62,11 @@ export class UpdateSupplierDto {
   @IsString()
   @IsOptional()
   nickname?: string;
+
+  @IsString()
+  @Matches(/^\d{5}$/, { message: 'รหัสสาขาต้องเป็นตัวเลข 5 หลัก' })
+  @IsOptional()
+  branchCode?: string;
 
   @IsString()
   @IsOptional()

--- a/apps/api/src/utils/installment.util.ts
+++ b/apps/api/src/utils/installment.util.ts
@@ -29,7 +29,7 @@ export function roundBaht(value: number): number {
  * 3. interestTotal = principal × interestRate × totalMonths  (flat rate)
  * 4. vatAmount = (principal + storeCommission + interestTotal) × vatPct
  * 5. financedAmount = principal + storeCommission + interestTotal + vatAmount
- * 6. monthlyPayment = ceil(financedAmount / totalMonths) — rounded to whole baht
+ * 6. monthlyPayment = round(financedAmount / totalMonths, 2) — satang precision (no rounding up)
  *
  * All intermediate values are computed at satang precision (2 decimal places)
  * to prevent floating-point accumulation errors.
@@ -54,9 +54,9 @@ export function calculateInstallment(
   const interestTotal = roundBaht(principal * interestRate * totalMonths);
   const vatAmount = roundBaht((principal + storeCommission + interestTotal) * vatPct);
   const financedAmount = roundBaht(principal + storeCommission + interestTotal + vatAmount);
-  // Monthly payment rounded UP to whole baht (customer pays slightly more on earlier
-  // installments; last installment adjusts in generatePaymentSchedule)
-  const monthlyPayment = Math.ceil(financedAmount / totalMonths);
+  // Monthly payment at satang precision (no ceil). Last installment absorbs rounding
+  // remainder in generatePaymentSchedule.
+  const monthlyPayment = roundBaht(financedAmount / totalMonths);
 
   return { principal, interestTotal, storeCommission, vatAmount, financedAmount, monthlyPayment };
 }

--- a/apps/web/src/components/contract/DocumentUpload.tsx
+++ b/apps/web/src/components/contract/DocumentUpload.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, Circle, Plus, Eye, Trash2, Loader2, FileText, Link2 } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import { compressImageForOcr } from '@/lib/compressImage';
 import { formatDateShort } from '@/utils/formatters';
@@ -19,75 +20,80 @@ interface ContractDocument {
 }
 
 const DOCUMENT_TYPES = [
-  { value: 'ID_CARD_COPY', label: 'สำเนาบัตรประชาชน (หน้า)' },
-  { value: 'ID_CARD_BACK', label: 'สำเนาบัตรประชาชน (หลัง)' },
-  { value: 'KYC_SELFIE', label: 'รูปถ่ายลูกค้าถือบัตรประชาชน' },
-  { value: 'DEVICE_PHOTO', label: 'รูปถ่ายสินค้า' },
-  { value: 'DEVICE_IMEI_PHOTO', label: 'รูปถ่าย IMEI สินค้า' },
-  { value: 'DOWN_PAYMENT_RECEIPT', label: 'หลักฐานการชำระเงินดาวน์' },
-  { value: 'PDPA_CONSENT', label: 'เอกสาร Consent PDPA' },
-  { value: 'SIGNED_CONTRACT', label: 'PDF สัญญาที่เซ็นแล้ว' },
-  { value: 'GUARDIAN_DOC', label: 'เอกสารผู้ปกครอง (อายุ 17-19)' },
-  { value: 'KYC', label: 'เอกสาร KYC อื่นๆ' },
-  { value: 'FACEBOOK_PROFILE', label: 'Profile Facebook' },
-  { value: 'FACEBOOK_POST', label: 'Post Facebook ล่าสุด (ไม่เกิน 1 เดือน)' },
-  { value: 'LINE_PROFILE', label: 'Profile LINE' },
-  { value: 'DEVICE_RECEIPT_PHOTO', label: 'รูปรับเครื่อง' },
-  { value: 'BANK_STATEMENT', label: 'Statement ธนาคาร' },
-  { value: 'DRIVING_LICENSE', label: 'ใบขับขี่' },
-  { value: 'BOOK_BANK', label: 'หน้า Book Bank' },
-  { value: 'OTHER', label: 'อื่นๆ' },
+  { value: 'ID_CARD_COPY', label: 'สำเนาบัตรประชาชน (หน้า)', required: true },
+  { value: 'KYC_SELFIE', label: 'รูปถ่ายลูกค้าถือบัตรประชาชน', required: true },
+  { value: 'DEVICE_PHOTO', label: 'รูปถ่ายสินค้า', required: true },
+  { value: 'DEVICE_IMEI_PHOTO', label: 'รูปถ่าย IMEI สินค้า', required: true },
+  { value: 'SIGNED_CONTRACT', label: 'PDF สัญญาที่เซ็นแล้ว (อัตโนมัติจากระบบ)', required: true },
+  { value: 'FACEBOOK_PROFILE', label: 'Profile Facebook', required: true },
+  { value: 'FACEBOOK_POST', label: 'Post Facebook ล่าสุด (ไม่เกิน 1 เดือน)', required: true },
+  { value: 'LINE_PROFILE', label: 'Profile LINE', required: true },
+  { value: 'DEVICE_RECEIPT_PHOTO', label: 'รูปรับเครื่อง', required: true },
+  { value: 'BANK_STATEMENT', label: 'Statement ธนาคาร / หลักฐานการทำงาน', required: true },
 ];
+
+const OCR_TYPES: Record<string, { endpoint: string; label: string }> = {
+  ID_CARD_COPY: { endpoint: '/ocr/id-card', label: 'บัตรประชาชน' },
+};
 
 export default function DocumentUpload({ contractId, customerId }: { contractId: string; customerId?: string }) {
   const queryClient = useQueryClient();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [selectedType, setSelectedType] = useState('ID_CARD_COPY');
-  const [notes, setNotes] = useState('');
+  const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const [ocrResult, setOcrResult] = useState<OcrResult | null>(null);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [ocrLoading, setOcrLoading] = useState(false);
   const [showOcrPanel, setShowOcrPanel] = useState(false);
   const [viewingDoc, setViewingDoc] = useState<ContractDocument | null>(null);
-  const [isDragOver, setIsDragOver] = useState(false);
+  const [dragOverType, setDragOverType] = useState<string | null>(null);
+  const [uploadingType, setUploadingType] = useState<string | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<{ open: boolean; message: string; action: () => void }>({ open: false, message: '', action: () => {} });
 
   const { data: documents = [] } = useQuery<ContractDocument[]>({
     queryKey: ['contract-documents', contractId],
     queryFn: async () => {
-      const { data } = await api.get(`/contracts/${contractId}/documents`);
-      return data;
+      const { data } = await api.get(`/contracts/${contractId}/documents`, { params: { limit: 200 } });
+      return Array.isArray(data) ? data : (data?.data ?? []);
     },
   });
 
+  const { data: creditCheck } = useQuery<{ statementFiles: string[] } | null>({
+    queryKey: ['contract-credit-check-statement', contractId],
+    queryFn: async () => {
+      try {
+        const { data } = await api.get(`/contracts/${contractId}/credit-check`);
+        return data;
+      } catch {
+        return null;
+      }
+    },
+  });
+  const statementFiles = creditCheck?.statementFiles ?? [];
+
   const uploadMutation = useMutation({
-    mutationFn: async (file: File) => {
+    mutationFn: async ({ file, documentType }: { file: File; documentType: string }) => {
       const reader = new FileReader();
       const fileUrl = await new Promise<string>((resolve, reject) => {
         reader.onload = () => resolve(reader.result as string);
         reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
         reader.readAsDataURL(file);
       });
-
       const { data } = await api.post(`/contracts/${contractId}/documents`, {
-        documentType: selectedType,
+        documentType,
         fileName: file.name,
         fileUrl,
         fileSize: file.size,
         mimeType: file.type || undefined,
-        notes: notes || undefined,
       });
       return data;
     },
     onSuccess: () => {
       toast.success('อัปโหลดเอกสารสำเร็จ');
       queryClient.invalidateQueries({ queryKey: ['contract-documents', contractId] });
-      setNotes('');
-      setSelectedFile(null);
-      if (fileInputRef.current) fileInputRef.current.value = '';
     },
     onError: (err: unknown) => {
       toast.error(getErrorMessage(err));
+    },
+    onSettled: () => {
+      setUploadingType(null);
     },
   });
 
@@ -104,28 +110,19 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
     },
   });
 
-  const OCR_ENDPOINTS: Record<string, { endpoint: string; label: string }> = {
-    ID_CARD_COPY: { endpoint: '/ocr/id-card', label: 'บัตรประชาชน' },
-    DRIVING_LICENSE: { endpoint: '/ocr/driving-license', label: 'ใบขับขี่' },
-    BOOK_BANK: { endpoint: '/ocr/book-bank', label: 'Book Bank' },
-  };
-
-  const performOcr = async (file: File, docType = 'ID_CARD_COPY') => {
-    const ocrConfig = OCR_ENDPOINTS[docType] || OCR_ENDPOINTS.ID_CARD_COPY;
+  const performOcr = async (file: File, docType: string) => {
+    const cfg = OCR_TYPES[docType];
+    if (!cfg) return;
     setOcrLoading(true);
     try {
       const imageBase64 = await compressImageForOcr(file);
-      const { data } = await api.post(ocrConfig.endpoint, { imageBase64 }, { timeout: 90000 });
+      const { data } = await api.post(cfg.endpoint, { imageBase64 }, { timeout: 90000 });
       setOcrResult(data);
       setShowOcrPanel(true);
       const pct = (data.confidence * 100).toFixed(0);
-      if (data.confidence < 0.5) {
-        toast.error(`อ่าน${ocrConfig.label}ได้ แต่ความมั่นใจต่ำมาก (${pct}%) กรุณาตรวจสอบข้อมูล`);
-      } else if (data.confidence < 0.7) {
-        toast.warning(`อ่าน${ocrConfig.label}สำเร็จ แต่ความมั่นใจค่อนข้างต่ำ (${pct}%)`);
-      } else {
-        toast.success(`อ่าน${ocrConfig.label}สำเร็จ (ความมั่นใจ ${pct}%)`);
-      }
+      if (data.confidence < 0.5) toast.error(`อ่าน${cfg.label}ได้ แต่ความมั่นใจต่ำมาก (${pct}%) กรุณาตรวจสอบข้อมูล`);
+      else if (data.confidence < 0.7) toast.warning(`อ่าน${cfg.label}สำเร็จ แต่ความมั่นใจค่อนข้างต่ำ (${pct}%)`);
+      else toast.success(`อ่าน${cfg.label}สำเร็จ (ความมั่นใจ ${pct}%)`);
     } catch (err: unknown) {
       const axiosErr = err as { code?: string; response?: unknown };
       if (axiosErr.code === 'ECONNABORTED' || !axiosErr.response) {
@@ -138,7 +135,6 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
     }
   };
 
-  // Helper: build structured address JSON from OCR result
   const buildOcrAddressJson = (data: OcrResult): string | undefined => {
     if (data.addressStructured) {
       const a = data.addressStructured;
@@ -171,7 +167,6 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
       if (provinceMatch) addr.province = provinceMatch[1];
       const hasStructured = Object.values(addr).some((v) => v !== '');
       if (hasStructured) return JSON.stringify(addr);
-      // Wrap raw address text as JSON for consistent backend parsing
       return JSON.stringify({ ...addr, raw });
     }
     return undefined;
@@ -187,7 +182,6 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
       if (ocrResult.birthDate) updateData.birthDate = ocrResult.birthDate;
       const addrJson = buildOcrAddressJson(ocrResult);
       if (addrJson) updateData.addressIdCard = addrJson;
-
       await api.patch(`/customers/${customerId}`, updateData);
       toast.success('อัปเดตข้อมูลลูกค้าสำเร็จ');
       setShowOcrPanel(false);
@@ -196,86 +190,44 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
     }
   };
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragOver(true);
-  }, []);
-
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    // Only clear drag state when actually leaving the drop zone (not moving over children)
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setIsDragOver(false);
-    }
-  }, []);
-
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragOver(false);
-    const file = e.dataTransfer.files?.[0];
-    if (!file) return;
+  const validateFile = (file: File, docType: string): boolean => {
     if (file.size > 10 * 1024 * 1024) {
       toast.error('ไฟล์ต้องมีขนาดไม่เกิน 10MB');
-      return;
+      return false;
     }
     const validTypes = ['image/', 'application/pdf'];
     if (!validTypes.some((t) => file.type.startsWith(t))) {
       toast.error('รองรับเฉพาะไฟล์รูปภาพหรือ PDF เท่านั้น');
-      return;
+      return false;
     }
-    setSelectedFile(file);
-  }, []);
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    if (file.size > 10 * 1024 * 1024) {
-      toast.error('ไฟล์ต้องมีขนาดไม่เกิน 10MB');
-      if (fileInputRef.current) fileInputRef.current.value = '';
-      return;
-    }
-
-    // Check file type for ID card before uploading
-    const isIdCard = selectedType === 'ID_CARD_COPY';
-    if (isIdCard && !file.type.startsWith('image/')) {
+    if (docType === 'ID_CARD_COPY' && !file.type.startsWith('image/')) {
       toast.error('สำเนาบัตรประชาชนต้องเป็นไฟล์รูปภาพเท่านั้น');
-      if (fileInputRef.current) fileInputRef.current.value = '';
-      return;
+      return false;
     }
-
-    setSelectedFile(file);
+    return true;
   };
 
-  const handleUpload = () => {
-    if (!selectedFile) return;
-    const fileToProcess = selectedFile;
-    const typeToProcess = selectedType;
-
-    uploadMutation.mutate(fileToProcess, {
-      onSuccess: () => {
-        // Trigger OCR only after upload succeeds, using captured references
-        if (['ID_CARD_COPY', 'DRIVING_LICENSE', 'BOOK_BANK'].includes(typeToProcess) && fileToProcess.type.startsWith('image/') && !ocrLoading) {
-          performOcr(fileToProcess, typeToProcess);
-        }
-      },
+  const uploadFiles = useCallback((files: FileList | File[], docType: string) => {
+    const fileArr = Array.from(files);
+    const valid = fileArr.filter((f) => validateFile(f, docType));
+    if (valid.length === 0) return;
+    setUploadingType(docType);
+    valid.forEach((file, idx) => {
+      uploadMutation.mutate({ file, documentType: docType }, {
+        onSuccess: () => {
+          if (idx === 0 && OCR_TYPES[docType] && file.type.startsWith('image/') && !ocrLoading) {
+            performOcr(file, docType);
+          }
+        },
+      });
     });
-  };
-
-  const getTypeLabel = (type: string) => DOCUMENT_TYPES.find((t) => t.value === type)?.label || type;
+  }, [uploadMutation, ocrLoading]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const openDocument = (doc: ContractDocument) => {
     if (!doc.fileUrl) return;
-    // For base64 data URLs, convert to blob and open or show in modal
     if (doc.fileUrl.startsWith('data:')) {
       const isImage = doc.fileUrl.startsWith('data:image/');
-      if (isImage) {
-        setViewingDoc(doc);
-        return;
-      }
-      // For PDFs and other files, convert base64 to blob URL
+      if (isImage) { setViewingDoc(doc); return; }
       try {
         const commaIdx = doc.fileUrl.indexOf(',');
         if (commaIdx === -1) { setViewingDoc(doc); return; }
@@ -289,123 +241,247 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
         const blob = new Blob([bytes], { type: mime });
         const url = URL.createObjectURL(blob);
         const win = window.open(url, '_blank');
-        if (!win) {
-          // Popup blocked - fallback to modal view
-          URL.revokeObjectURL(url);
-          setViewingDoc(doc);
-          return;
-        }
-        // Revoke blob URL after new window loads (cleanup memory)
-        win.addEventListener('load', () => {
-          setTimeout(() => URL.revokeObjectURL(url), 5000);
-        });
+        if (!win) { URL.revokeObjectURL(url); setViewingDoc(doc); return; }
+        win.addEventListener('load', () => setTimeout(() => URL.revokeObjectURL(url), 5000));
       } catch {
-        // Fallback: show in modal
         setViewingDoc(doc);
       }
     } else {
       const win = window.open(doc.fileUrl, '_blank');
-      if (!win) {
-        toast.error('เบราว์เซอร์บล็อก popup กรุณาอนุญาต popup สำหรับเว็บนี้');
-      }
+      if (!win) toast.error('เบราว์เซอร์บล็อก popup กรุณาอนุญาต popup สำหรับเว็บนี้');
     }
+  };
+
+  const hasTypeFiles = (dt: typeof DOCUMENT_TYPES[number]) => {
+    if (dt.value === 'BANK_STATEMENT') return statementFiles.length > 0;
+    return documents.some((d) => d.documentType === dt.value);
+  };
+  const uploadedCount = DOCUMENT_TYPES.filter(hasTypeFiles).length;
+  const requiredTypes = DOCUMENT_TYPES.filter((dt) => dt.required);
+  const optionalTypes = DOCUMENT_TYPES.filter((dt) => !dt.required);
+  const requiredDone = requiredTypes.filter(hasTypeFiles).length;
+
+  const renderBankStatementCard = (dt: typeof DOCUMENT_TYPES[number]) => {
+    const hasFiles = statementFiles.length > 0;
+    return (
+      <div key={dt.value} className={`rounded-lg border overflow-hidden ${hasFiles ? 'border-primary/30 bg-card' : 'border-border bg-card'}`}>
+        <div className={`flex items-center gap-2 px-4 py-2.5 border-b border-border/50 ${hasFiles ? 'bg-primary/10' : 'bg-muted/40'}`}>
+          {hasFiles ? (
+            <CheckCircle2 className="w-4 h-4 text-primary shrink-0" />
+          ) : (
+            <Circle className={`w-4 h-4 shrink-0 ${dt.required ? 'text-destructive/70' : 'text-muted-foreground/50'}`} />
+          )}
+          <span className={`text-sm font-medium truncate ${hasFiles || dt.required ? 'text-foreground' : 'text-muted-foreground'}`}>
+            {dt.label} {dt.required && !hasFiles && <span className="text-destructive">*</span>}
+          </span>
+          {hasFiles && (
+            <span className="ml-auto px-1.5 py-0.5 rounded-full bg-primary/20 text-primary text-[10px] font-mono shrink-0">{statementFiles.length}</span>
+          )}
+        </div>
+        <div className="p-3 space-y-2">
+          {hasFiles ? (
+            <div className="grid grid-cols-3 gap-2">
+              {statementFiles.map((url, idx) => {
+                const isImage = url.startsWith('data:image/') || /\.(jpg|jpeg|png|gif|webp)(\?|$)/i.test(url);
+                return (
+                  <div key={idx} className="relative group aspect-square bg-muted rounded border border-border overflow-hidden">
+                    {isImage ? (
+                      <img src={url} alt={`statement-${idx + 1}`} className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex flex-col items-center justify-center gap-1 p-1">
+                        <FileText className="w-6 h-6 text-destructive" />
+                        <div className="text-[9px] text-muted-foreground text-center truncate w-full px-1">Statement {idx + 1}</div>
+                      </div>
+                    )}
+                    <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition flex items-center justify-center">
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="p-1.5 bg-background/90 rounded text-foreground hover:bg-background"
+                        aria-label="ดูเอกสาร"
+                      >
+                        <Eye className="w-3.5 h-3.5" />
+                      </a>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="w-full border-2 border-dashed border-border rounded-lg p-6 flex flex-col items-center gap-1 text-center">
+              <Link2 className="w-6 h-6 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">ยังไม่มีไฟล์</span>
+              <span className="text-[10px] text-muted-foreground/70">อัปโหลดที่หน้าเช็คเครดิตของสัญญานี้</span>
+            </div>
+          )}
+          <div className="text-[11px] text-muted-foreground flex items-center gap-1 pt-1 border-t border-border/40">
+            <Link2 className="w-3 h-3" />
+            <span>ข้อมูลจากหน้าเช็คเครดิต — แก้ไขได้ที่หน้านั้น</span>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderCard = (dt: typeof DOCUMENT_TYPES[number]) => {
+    if (dt.value === 'BANK_STATEMENT') return renderBankStatementCard(dt);
+    const docs = documents.filter((d) => d.documentType === dt.value);
+    const hasFiles = docs.length > 0;
+    const isOver = dragOverType === dt.value;
+    const isUploading = uploadingType === dt.value && uploadMutation.isPending;
+
+    return (
+      <div
+        key={dt.value}
+        className={`rounded-lg border overflow-hidden transition-colors ${
+          isOver ? 'border-primary bg-primary/5' : hasFiles ? 'border-primary/30 bg-card' : 'border-border bg-card'
+        }`}
+        onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); setDragOverType(dt.value); }}
+        onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOverType(null); }}
+        onDrop={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setDragOverType(null);
+          const files = e.dataTransfer.files;
+          if (files && files.length > 0) uploadFiles(files, dt.value);
+        }}
+      >
+        <div className={`flex items-center gap-2 px-4 py-2.5 border-b border-border/50 ${hasFiles ? 'bg-primary/10' : 'bg-muted/40'}`}>
+          {hasFiles ? (
+            <CheckCircle2 className="w-4 h-4 text-primary shrink-0" />
+          ) : (
+            <Circle className={`w-4 h-4 shrink-0 ${dt.required ? 'text-destructive/70' : 'text-muted-foreground/50'}`} />
+          )}
+          <span className={`text-sm font-medium truncate ${hasFiles || dt.required ? 'text-foreground' : 'text-muted-foreground'}`}>
+            {dt.label} {dt.required && !hasFiles && <span className="text-destructive">*</span>}
+          </span>
+          {hasFiles && (
+            <span className="ml-auto px-1.5 py-0.5 rounded-full bg-primary/20 text-primary text-[10px] font-mono shrink-0">{docs.length}</span>
+          )}
+        </div>
+
+        <div className="p-3">
+          <input
+            ref={(el) => { fileInputRefs.current[dt.value] = el; }}
+            type="file"
+            multiple
+            accept="image/*,.pdf"
+            onChange={(e) => {
+              const files = e.target.files;
+              if (files && files.length > 0) uploadFiles(files, dt.value);
+              if (fileInputRefs.current[dt.value]) fileInputRefs.current[dt.value]!.value = '';
+            }}
+            className="hidden"
+          />
+
+          {hasFiles ? (
+            <div className="grid grid-cols-3 gap-2">
+              {docs.map((doc) => {
+                const isImage = doc.fileUrl?.startsWith('data:image/') || /\.(jpg|jpeg|png|gif|webp)$/i.test(doc.fileName);
+                return (
+                  <div key={doc.id} className="relative group aspect-square bg-muted rounded border border-border overflow-hidden">
+                    {isImage && doc.fileUrl ? (
+                      <img src={doc.fileUrl} alt={doc.fileName} className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex flex-col items-center justify-center gap-1 p-1">
+                        <FileText className="w-6 h-6 text-destructive" />
+                        <div className="text-[9px] text-muted-foreground text-center truncate w-full px-1">{doc.fileName}</div>
+                      </div>
+                    )}
+                    <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition flex items-center justify-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openDocument(doc)}
+                        className="p-1.5 bg-background/90 rounded text-foreground hover:bg-background"
+                        aria-label="ดูเอกสาร"
+                      >
+                        <Eye className="w-3.5 h-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDialog({ open: true, message: `ต้องการลบเอกสาร "${doc.fileName}" หรือไม่?`, action: () => deleteMutation.mutate(doc.id) })}
+                        className="p-1.5 bg-destructive/90 rounded text-destructive-foreground hover:bg-destructive"
+                        aria-label="ลบเอกสาร"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+
+              <button
+                type="button"
+                onClick={() => fileInputRefs.current[dt.value]?.click()}
+                disabled={isUploading}
+                className="aspect-square border-2 border-dashed border-border hover:border-primary/50 rounded flex flex-col items-center justify-center gap-1 transition disabled:opacity-50"
+              >
+                {isUploading ? (
+                  <Loader2 className="w-5 h-5 text-primary animate-spin" />
+                ) : (
+                  <>
+                    <Plus className="w-5 h-5 text-muted-foreground" />
+                    <span className="text-[10px] text-muted-foreground">เพิ่ม</span>
+                  </>
+                )}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => fileInputRefs.current[dt.value]?.click()}
+              disabled={isUploading}
+              className={`w-full border-2 border-dashed rounded-lg p-6 flex flex-col items-center gap-1 transition disabled:opacity-50 ${
+                isOver ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/50 hover:bg-muted/50'
+              }`}
+            >
+              {isUploading ? (
+                <Loader2 className="w-6 h-6 text-primary animate-spin" />
+              ) : (
+                <>
+                  <Plus className={`w-6 h-6 ${isOver ? 'text-primary' : 'text-muted-foreground'}`} />
+                  <span className={`text-xs ${isOver ? 'text-primary font-medium' : 'text-muted-foreground'}`}>
+                    {isOver ? 'ปล่อยไฟล์ที่นี่' : 'ลากไฟล์หรือคลิกเพิ่ม'}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground/70">หลายไฟล์ได้</span>
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    );
   };
 
   return (
     <div className="space-y-4">
-      {/* Upload form */}
-      <div className="bg-card rounded-lg border p-4 space-y-3">
-        <h3 className="text-sm font-semibold text-foreground">อัปโหลดเอกสาร</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div>
-            <label className="block text-xs text-muted-foreground mb-1">ประเภทเอกสาร</label>
-            <select
-              value={selectedType}
-              onChange={(e) => setSelectedType(e.target.value)}
-              className="w-full px-3 py-2 border border-input rounded-lg text-sm"
-            >
-              {DOCUMENT_TYPES.map((t) => (
-                <option key={t.value} value={t.value}>{t.label}</option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-xs text-muted-foreground mb-1">หมายเหตุ (ไม่บังคับ)</label>
-            <input
-              type="text"
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              placeholder="หมายเหตุ..."
-              className="w-full px-3 py-2 border border-input rounded-lg text-sm"
-            />
-          </div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">อัปโหลดเอกสาร</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {uploadedCount} จาก {DOCUMENT_TYPES.length} ประเภทครบ · {documents.length} ไฟล์ · บังคับ {requiredDone}/{requiredTypes.length}
+          </p>
         </div>
-
-        {/* Drag & Drop Zone */}
-        <div
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-          onClick={() => fileInputRef.current?.click()}
-          className={`relative border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
-            isDragOver
-              ? 'border-primary bg-primary/5'
-              : selectedFile
-                ? 'border-success/40 bg-success/10'
-                : 'border-border hover:border-primary/40 hover:bg-muted'
-          }`}
-        >
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*,.pdf"
-            onChange={handleFileChange}
-            disabled={uploadMutation.isPending}
-            className="hidden"
-          />
-          <div className="flex flex-col items-center gap-2">
-            {selectedFile ? (
-              <>
-                <svg className="w-8 h-8 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <div className="text-sm font-medium text-success">{selectedFile.name}</div>
-                <p className="text-xs text-success">{(selectedFile.size / 1024).toFixed(0)} KB — คลิก &quot;อัปโหลดเอกสาร&quot; หรือเลือกไฟล์ใหม่</p>
-              </>
-            ) : (
-              <>
-                <svg className={`w-8 h-8 ${isDragOver ? 'text-primary' : 'text-muted-foreground'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-                </svg>
-                <div className={`text-sm font-medium ${isDragOver ? 'text-primary' : 'text-foreground'}`}>
-                  {isDragOver ? 'ปล่อยไฟล์เพื่ออัปโหลด' : 'ลากไฟล์มาวางที่นี่ หรือคลิกเพื่อเลือกไฟล์'}
-                </div>
-                <p className="text-xs text-muted-foreground">รองรับไฟล์ภาพ และ PDF ขนาดไม่เกิน 10MB</p>
-              </>
-            )}
-          </div>
-        </div>
-
-        <div className="flex items-center gap-3">
-          <button
-            onClick={handleUpload}
-            disabled={!selectedFile || uploadMutation.isPending}
-            className="px-5 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {uploadMutation.isPending ? (
-              <span className="flex items-center gap-2">
-                <span className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary-foreground" />
-                กำลังอัปโหลด...
-              </span>
-            ) : 'อัปโหลดเอกสาร'}
-          </button>
+        <div className="w-40 h-1.5 bg-muted rounded-full overflow-hidden">
+          <div className="h-full bg-primary transition-all" style={{ width: `${(uploadedCount / DOCUMENT_TYPES.length) * 100}%` }} />
         </div>
       </div>
 
-      {/* OCR Loading */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {requiredTypes.map(renderCard)}
+      </div>
+
+      <div className="pt-2">
+        <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide px-1 mb-2">เอกสารเพิ่มเติม (ไม่บังคับ)</h4>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {optionalTypes.map(renderCard)}
+        </div>
+      </div>
+
       {ocrLoading && (
         <div className="bg-primary/5 border border-primary/20 rounded-lg p-4 flex items-center gap-3">
-          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary" />
+          <Loader2 className="w-5 h-5 text-primary animate-spin" />
           <div>
             <div className="text-sm font-medium text-primary">กำลังอ่านข้อมูลจากบัตรประชาชน...</div>
             <div className="text-xs text-primary">ระบบ AI กำลังประมวลผลรูปภาพ</div>
@@ -413,7 +489,6 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
         </div>
       )}
 
-      {/* OCR Results Panel */}
       {showOcrPanel && ocrResult && (
         <div className={`${ocrResult.confidence < 0.7 ? 'bg-warning/10 border-warning/30' : 'bg-success/10 border-success/30'} border rounded-lg p-4 space-y-3`}>
           <div className="flex items-center justify-between">
@@ -488,61 +563,12 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
         </div>
       )}
 
-      {/* Document list */}
-      {documents.length > 0 && (
-        <div className="bg-card rounded-lg border">
-          <div className="px-4 py-3 border-b">
-            <h3 className="text-sm font-semibold text-foreground">เอกสารที่แนบ ({documents.length})</h3>
-          </div>
-          <div className="divide-y">
-            {documents.map((doc) => (
-              <div key={doc.id} className="px-4 py-3 flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className={`w-8 h-8 rounded-lg flex items-center justify-center text-xs font-bold ${
-                    doc.fileName.endsWith('.pdf') ? 'bg-destructive/10 text-destructive' : 'bg-primary/10 text-primary'
-                  }`}>
-                    {doc.fileName.endsWith('.pdf') ? 'PDF' : 'IMG'}
-                  </div>
-                  <div>
-                    <div className="text-sm font-medium text-foreground">{doc.fileName}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {getTypeLabel(doc.documentType)}
-                      {doc.notes && ` - ${doc.notes}`}
-                      {' | '}อัปโหลดโดย {doc.uploadedBy.name}
-                      {' | '}{formatDateShort(doc.createdAt)}
-                    </div>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {doc.fileUrl && (
-                    <button
-                      onClick={() => openDocument(doc)}
-                      className="text-xs text-primary hover:text-primary/90 px-2 py-1"
-                    >
-                      ดู
-                    </button>
-                  )}
-                  <button
-                    onClick={() => {
-                      setConfirmDialog({ open: true, message: `ต้องการลบเอกสาร "${doc.fileName}" (${getTypeLabel(doc.documentType)}) หรือไม่?`, action: () => deleteMutation.mutate(doc.id) });
-                    }}
-                    className="text-xs text-destructive hover:text-destructive/80 px-2 py-1"
-                  >
-                    ลบ
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-      {/* Document viewer modal */}
       {viewingDoc && (
         <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4" onClick={() => setViewingDoc(null)} onKeyDown={(e) => { if (e.key === 'Escape') setViewingDoc(null); }} role="dialog" aria-modal="true" aria-label={`ดูเอกสาร ${viewingDoc.fileName}`} tabIndex={-1} ref={(el) => el?.focus()}>
           <div className="relative max-w-4xl max-h-[90vh] w-full" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center justify-between bg-card rounded-t-lg px-4 py-2">
               <div className="text-sm font-medium text-foreground">
-                {getTypeLabel(viewingDoc.documentType)} - {viewingDoc.fileName}
+                {DOCUMENT_TYPES.find((t) => t.value === viewingDoc.documentType)?.label || viewingDoc.documentType} - {viewingDoc.fileName}
               </div>
               <button onClick={() => setViewingDoc(null)} className="text-muted-foreground hover:text-foreground text-lg font-bold px-2">
                 &times;
@@ -558,6 +584,7 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
           </div>
         </div>
       )}
+
       <ConfirmDialog open={confirmDialog.open} onOpenChange={(open) => setConfirmDialog(prev => ({ ...prev, open }))} description={confirmDialog.message} variant="destructive" onConfirm={confirmDialog.action} />
     </div>
   );

--- a/apps/web/src/components/signing/StepComplete.tsx
+++ b/apps/web/src/components/signing/StepComplete.tsx
@@ -39,7 +39,11 @@ export default function StepComplete({
         toast.error('ไม่สามารถสร้างเอกสารได้');
       }
       queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
+      queryClient.invalidateQueries({ queryKey: ['contract-edocuments', contractId] });
       queryClient.invalidateQueries({ queryKey: ['contract-documents', contractId] });
+      queryClient.invalidateQueries({ queryKey: ['contract-signatures', contractId] });
+      queryClient.invalidateQueries({ queryKey: ['contract-preview', contractId] });
+      queryClient.invalidateQueries({ queryKey: ['contract-doc-checklist', contractId] });
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });

--- a/apps/web/src/components/signing/StepSignature.tsx
+++ b/apps/web/src/components/signing/StepSignature.tsx
@@ -133,6 +133,9 @@ export default function StepSignature({
 
       // Invalidate + refetch to reliably update the UI
       await queryClient.invalidateQueries({ queryKey: ['contract-signatures', contractId] });
+      queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
+      queryClient.invalidateQueries({ queryKey: ['contract-edocuments', contractId] });
+      queryClient.invalidateQueries({ queryKey: ['contract-documents', contractId] });
       const freshSignatures = queryClient.getQueryData<Signature[]>(['contract-signatures', contractId]) || [];
 
       const freshSignedTypes = new Set(freshSignatures.map(s => normalizeSignerType(s.signerType)));

--- a/apps/web/src/pages/ContractCreatePage/components/ContractSummaryPanel.tsx
+++ b/apps/web/src/pages/ContractCreatePage/components/ContractSummaryPanel.tsx
@@ -30,11 +30,11 @@ export function ContractSummaryPanel({
         <div className="bg-muted/50 rounded-xl p-4 grid grid-cols-2 gap-3 text-sm">
           <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">สินค้า</span><div className="font-medium mt-0.5">{selectedProduct.brand} {selectedProduct.model}</div></div>
           <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">ลูกค้า</span><div className="font-medium mt-0.5">{selectedCustomer.name}</div></div>
-          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">ราคาขาย</span><div className="font-medium tabular-nums font-mono mt-0.5">{sellingPrice.toLocaleString()} ฿</div></div>
-          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">เงินดาวน์</span><div className="font-medium tabular-nums font-mono mt-0.5">{downPayment.toLocaleString()} ฿</div></div>
+          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">ราคาขาย</span><div className="font-medium tabular-nums font-mono mt-0.5">{sellingPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿</div></div>
+          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">เงินดาวน์</span><div className="font-medium tabular-nums font-mono mt-0.5">{downPayment.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿</div></div>
           <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">จำนวนงวด</span><div className="font-medium mt-0.5">{totalMonths} เดือน</div></div>
-          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">ค่างวด/เดือน</span><div className="font-bold text-primary tabular-nums font-mono mt-0.5">{monthlyPayment.toLocaleString()} ฿</div></div>
-          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">ดอกเบี้ย</span><div className="font-medium mt-0.5">{(interestRate * 100).toFixed(1)}%{interestConfig ? ` (${interestConfig.name})` : ''}</div></div>
+          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">ค่างวด/เดือน</span><div className="font-bold text-primary tabular-nums font-mono mt-0.5">{monthlyPayment.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿</div></div>
+          <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">ดอกเบี้ย</span><div className="font-medium mt-0.5">{(interestRate * 100).toFixed(2)}%{interestConfig ? ` (${interestConfig.name})` : ''}</div></div>
           <div><span className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">เอกสารแนบ</span><div className="font-medium mt-0.5">{pendingDocs.length} ไฟล์</div></div>
         </div>
       </div>

--- a/apps/web/src/pages/ContractCreatePage/components/PlanDetailsStep.tsx
+++ b/apps/web/src/pages/ContractCreatePage/components/PlanDetailsStep.tsx
@@ -139,14 +139,14 @@ export function PlanDetailsStep({
           <div className="bg-primary/5 border border-primary/30 rounded-lg p-3 flex items-center gap-2">
             <span className="text-xs text-primary">ใช้ดอกเบี้ยตาม:</span>
             <span className="text-sm font-medium text-primary">{interestConfig.name}</span>
-            <span className="text-xs text-primary">({(interestRate * 100).toFixed(1)}% | ดาวน์ขั้นต่ำ {(minDownPct * 100).toFixed(0)}% | {minMonths}-{maxMonths} เดือน)</span>
+            <span className="text-xs text-primary">({(interestRate * 100).toFixed(2)}% | ดาวน์ขั้นต่ำ {(minDownPct * 100).toFixed(0)}% | {minMonths}-{maxMonths} เดือน)</span>
           </div>
         )}
 
 
         <div className="bg-muted/60 rounded-xl p-4">
           <div className="text-sm font-medium text-foreground mb-2">สินค้า: {selectedProduct?.brand} {selectedProduct?.model}</div>
-          <div className="text-lg font-bold text-primary tabular-nums font-mono">{sellingPrice.toLocaleString()} ฿</div>
+          <div className="text-lg font-bold text-primary tabular-nums font-mono">{sellingPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿</div>
         </div>
 
         <FormField
@@ -171,7 +171,7 @@ export function PlanDetailsStep({
                   min={0}
                 />
               </FormControl>
-              <div className="text-xs text-muted-foreground">ขั้นต่ำ {(minDownPct * 100).toFixed(0)}% = {(sellingPrice * minDownPct).toLocaleString()} ฿</div>
+              <div className="text-xs text-muted-foreground">ขั้นต่ำ {(minDownPct * 100).toFixed(0)}% = {(sellingPrice * minDownPct).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿</div>
               <FormMessage />
             </FormItem>
           )}
@@ -258,43 +258,81 @@ export function PlanDetailsStep({
           )}
         />
 
-        {/* Calculation Summary */}
-        <div className="bg-primary/5 dark:bg-primary/10 border border-primary/20 rounded-xl p-4 space-y-2">
-          <h3 className="text-sm font-semibold text-primary">สรุปการคำนวณ</h3>
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">ราคาขาย</span>
-            <span className="tabular-nums font-mono">{sellingPrice.toLocaleString()} ฿</span>
-          </div>
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">เงินดาวน์</span>
-            <span className="tabular-nums font-mono">-{downPayment.toLocaleString()} ฿</span>
-          </div>
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">ยอดปล่อย <InfoTip text="ราคาขาย - เงินดาวน์ = ยอดที่ไฟแนนซ์ปล่อยให้ลูกค้าผ่อน" /></span>
-            <span className="tabular-nums font-mono">{principal.toLocaleString()} ฿</span>
-          </div>
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">ค่าคอมหน้าร้าน ({(storeCommPct * 100).toFixed(0)}%) <InfoTip text="ค่าคอมที่ไฟแนนซ์จ่ายให้หน้าร้าน เป็น % ของยอดปล่อย — รวมอยู่ในค่างวดลูกค้า" /></span>
-            <span className="tabular-nums font-mono">{storeCommission.toLocaleString(undefined, { maximumFractionDigits: 0 })} ฿</span>
-          </div>
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">ดอกเบี้ยรวม ({(interestRate * 100).toFixed(1)}% x {totalMonths} เดือน)</span>
-            <span className="tabular-nums font-mono">{interestTotal.toLocaleString(undefined, { maximumFractionDigits: 0 })} ฿</span>
-          </div>
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">VAT ({(vatPct * 100).toFixed(0)}%)</span>
-            <span className="tabular-nums font-mono">{vatAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })} ฿</span>
-          </div>
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">รวมยอดจัดไฟแนนซ์ <InfoTip text="ยอดปล่อย + ค่าคอม + ดอกเบี้ย + VAT = ยอดรวมที่ลูกค้าต้องผ่อนทั้งหมด" /></span>
-            <span className="tabular-nums font-mono">{financedAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })} ฿</span>
-          </div>
-          <div className="border-t border-primary/20 pt-2 flex justify-between text-base font-bold text-primary">
-            <span>ค่างวด/เดือน</span>
-            <span className="tabular-nums font-mono">{monthlyPayment.toLocaleString()} ฿</span>
-          </div>
-          <div className="text-xs text-muted-foreground text-right">ชำระ{paymentDueDay === 31 ? 'ทุกสิ้นเดือน' : `ทุกวันที่ ${paymentDueDay}`}</div>
-        </div>
+        {/* Calculation Summary — Customer-facing */}
+        {(() => {
+          const fmt = (n: number) => n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+          const totalPaid = downPayment + monthlyPayment * totalMonths;
+          const extraOverCash = totalPaid - sellingPrice;
+          const extraPct = sellingPrice > 0 ? (extraOverCash / sellingPrice) * 100 : 0;
+          const subtotalBeforeVat = principal + storeCommission + interestTotal;
+          return (
+            <div className="bg-primary/5 dark:bg-primary/10 border border-primary/20 rounded-xl p-4 space-y-3">
+              <h3 className="text-sm font-semibold text-primary">สรุปการคำนวณ</h3>
+
+              {/* Customer-facing summary */}
+              <div className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">ราคาเครื่อง</span>
+                  <span className="tabular-nums font-mono">{fmt(sellingPrice)} ฿</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">จ่ายวันนี้ (ดาวน์)</span>
+                  <span className="tabular-nums font-mono">-{fmt(downPayment)} ฿</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">ผ่อน {totalMonths} งวด × งวดละ</span>
+                  <span className="tabular-nums font-mono font-semibold text-primary">{fmt(monthlyPayment)} ฿</span>
+                </div>
+                <div className="border-t border-primary/20 pt-2 flex justify-between text-base font-bold text-primary">
+                  <span>รวมที่จ่ายทั้งหมด</span>
+                  <span className="tabular-nums font-mono">{fmt(totalPaid)} ฿</span>
+                </div>
+                {extraOverCash > 0 && (
+                  <div className="text-xs text-muted-foreground text-right">
+                    แพงกว่าเงินสด {fmt(extraOverCash)} ฿ ({extraPct.toFixed(1)}%)
+                  </div>
+                )}
+                <div className="text-xs text-muted-foreground text-right">
+                  ชำระ{paymentDueDay === 31 ? 'ทุกสิ้นเดือน' : `ทุกวันที่ ${paymentDueDay}`}
+                </div>
+              </div>
+
+              {/* Internal details — collapsible */}
+              <details className="group border-t border-primary/20 pt-2">
+                <summary className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-primary transition-colors select-none flex items-center gap-1">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="transition-transform group-open:rotate-90"><polyline points="9 18 15 12 9 6"/></svg>
+                  รายละเอียดการคำนวณ (ภายใน)
+                </summary>
+                <div className="mt-2 space-y-1.5 text-sm">
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">ยอดปล่อย <InfoTip text="ราคาขาย - เงินดาวน์" /></span>
+                    <span className="tabular-nums font-mono">{fmt(principal)} ฿</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">+ ค่าคอมหน้าร้าน ({(storeCommPct * 100).toFixed(0)}%)</span>
+                    <span className="tabular-nums font-mono">{fmt(storeCommission)} ฿</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">+ ดอกเบี้ย ({(interestRate * 100).toFixed(2)}% × {totalMonths} เดือน)</span>
+                    <span className="tabular-nums font-mono">{fmt(interestTotal)} ฿</span>
+                  </div>
+                  <div className="border-t border-primary/10 pt-1.5 flex justify-between font-medium">
+                    <span className="text-foreground">= ยอดรวมก่อน VAT</span>
+                    <span className="tabular-nums font-mono">{fmt(subtotalBeforeVat)} ฿</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">+ VAT ({(vatPct * 100).toFixed(0)}%)</span>
+                    <span className="tabular-nums font-mono">{fmt(vatAmount)} ฿</span>
+                  </div>
+                  <div className="border-t border-primary/10 pt-1.5 flex justify-between font-semibold text-primary">
+                    <span>= ยอดจัดไฟแนนซ์</span>
+                    <span className="tabular-nums font-mono">{fmt(financedAmount)} ฿</span>
+                  </div>
+                </div>
+              </details>
+            </div>
+          );
+        })()}
       </div>
     </div>
     </Form>

--- a/apps/web/src/pages/ContractCreatePage/hooks/useContractCalculation.test.ts
+++ b/apps/web/src/pages/ContractCreatePage/hooks/useContractCalculation.test.ts
@@ -15,7 +15,7 @@ import type { Product, InterestConfig } from '../types';
  *   interestTotal   = principal * interestRate * totalMonths   (flat rate)
  *   vatAmount       = (principal + storeCommission + interestTotal) * vatPct
  *   financedAmount  = principal + storeCommission + interestTotal + vatAmount
- *   monthlyPayment  = ceil(financedAmount / totalMonths)
+ *   monthlyPayment  = round(financedAmount / totalMonths, 2)   (satang precision)
  *
  * If this hook drifts, every contract gets the wrong numbers.
  */
@@ -117,7 +117,7 @@ describe('useContractCalculation', () => {
     //   subtotalForVat  = 20000 + 2000 + 3600 = 25600
     //   vatAmount       = 25600 * 0.07 = 1792
     //   financedAmount  = 25600 + 1792 = 27392
-    //   monthlyPayment  = ceil(27392 / 12) = 2283
+    //   monthlyPayment  = round(27392 / 12, 2) = 2282.67
     it('matches the canonical numbers for the 25000/5000/12 case', () => {
       const { result } = setupHook({
         product: makeProduct(25000),
@@ -131,7 +131,7 @@ describe('useContractCalculation', () => {
       expect(result.current.interestTotal).toBe(3600);
       expect(result.current.vatAmount).toBeCloseTo(1792, 6);
       expect(result.current.financedAmount).toBeCloseTo(27392, 6);
-      expect(result.current.monthlyPayment).toBe(2283);
+      expect(result.current.monthlyPayment).toBeCloseTo(2282.67, 2);
     });
   });
 
@@ -149,13 +149,13 @@ describe('useContractCalculation', () => {
         result.current.setDownPayment(0);
       });
       // principal=10000, comm=1000, interest=0
-      // vatable=11000, vat=770, financed=11770, monthly=ceil(1177)=1177
+      // vatable=11000, vat=770, financed=11770, monthly=11770/10=1177
       expect(result.current.principal).toBe(10000);
       expect(result.current.storeCommission).toBe(1000);
       expect(result.current.interestTotal).toBe(0);
       expect(result.current.vatAmount).toBeCloseTo(770, 6);
       expect(result.current.financedAmount).toBeCloseTo(11770, 6);
-      expect(result.current.monthlyPayment).toBe(1177);
+      expect(result.current.monthlyPayment).toBeCloseTo(1177, 2);
     });
   });
 
@@ -168,12 +168,12 @@ describe('useContractCalculation', () => {
         initialMonths: 24,
       });
       // principal=24000, comm=2400, interest=24000*0.015*24=8640
-      // vatable=35040, vat=2452.8, financed=37492.8, monthly=ceil(37492.8/24)=ceil(1562.2)=1563
+      // vatable=35040, vat=2452.8, financed=37492.8, monthly=round(37492.8/24,2)=1562.2
       expect(result.current.principal).toBe(24000);
       expect(result.current.interestTotal).toBe(8640);
       expect(result.current.vatAmount).toBeCloseTo(2452.8, 4);
       expect(result.current.financedAmount).toBeCloseTo(37492.8, 4);
-      expect(result.current.monthlyPayment).toBe(1563);
+      expect(result.current.monthlyPayment).toBeCloseTo(1562.2, 2);
     });
   });
 

--- a/apps/web/src/pages/ContractCreatePage/hooks/useContractCalculation.ts
+++ b/apps/web/src/pages/ContractCreatePage/hooks/useContractCalculation.ts
@@ -62,7 +62,7 @@ export function useContractCalculation({
   const interestTotal = principal * interestRate * totalMonths;
   const vatAmount = (principal + storeCommission + interestTotal) * vatPct;
   const financedAmount = principal + storeCommission + interestTotal + vatAmount;
-  const monthlyPayment = totalMonths > 0 ? Math.ceil(financedAmount / totalMonths) : 0;
+  const monthlyPayment = totalMonths > 0 ? Math.round((financedAmount / totalMonths) * 100) / 100 : 0;
 
   const monthOptions: number[] = [];
   for (let m = minMonths; m <= maxMonths; m++) {

--- a/apps/web/src/pages/ContractDetailPage.tsx
+++ b/apps/web/src/pages/ContractDetailPage.tsx
@@ -697,14 +697,15 @@ const deleteMutation = useMutation({
                 const interest = p * editForm.interestRate * editForm.totalMonths;
                 const vat = (p + comm + interest) * vPct;
                 const total = p + comm + interest + vat;
-                const monthly = Math.ceil(total / editForm.totalMonths);
+                const monthly = Math.round((total / editForm.totalMonths) * 100) / 100;
+                const fmt2 = (v: number) => v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
                 return (
                   <div className="bg-muted rounded-lg p-3 text-xs space-y-1">
-                    <div>ยอดปล่อย: {formatNumber(p)} บาท</div>
-                    <div>ค่าคอมหน้าร้าน ({(commPct * 100).toFixed(0)}%): {formatNumber(Math.round(comm))} บาท</div>
-                    <div>ดอกเบี้ยรวม: {formatNumber(Math.round(interest))} บาท</div>
-                    <div>VAT ({(vPct * 100).toFixed(0)}%): {formatNumber(Math.round(vat))} บาท</div>
-                    <div className="font-semibold">ค่างวด/เดือน: {formatNumber(monthly)} บาท</div>
+                    <div>ยอดปล่อย: {fmt2(p)} บาท</div>
+                    <div>ค่าคอมหน้าร้าน ({(commPct * 100).toFixed(0)}%): {fmt2(comm)} บาท</div>
+                    <div>ดอกเบี้ยรวม: {fmt2(interest)} บาท</div>
+                    <div>VAT ({(vPct * 100).toFixed(0)}%): {fmt2(vat)} บาท</div>
+                    <div className="font-semibold">ค่างวด/เดือน: {fmt2(monthly)} บาท</div>
                   </div>
                 );
               })()}
@@ -729,7 +730,7 @@ const deleteMutation = useMutation({
               <Info label="ราคาขาย" value={`${formatNumber(contract.sellingPrice)} บาท`} />
               <Info label="เงินดาวน์" value={`${formatNumber(contract.downPayment)} บาท`} />
               <Info label="ยอดปล่อย (Loan)" value={`${formatNumber(parseFloat(contract.sellingPrice) - parseFloat(contract.downPayment))} บาท`} />
-              <Info label="อัตราดอกเบี้ย" value={`${(parseFloat(contract.interestRate) * 100).toFixed(1)}%${contract.interestConfig ? ` (${contract.interestConfig.name})` : ''}`} />
+              <Info label="อัตราดอกเบี้ย" value={`${(parseFloat(contract.interestRate) * 100).toFixed(2)}%${contract.interestConfig ? ` (${contract.interestConfig.name})` : ''}`} />
               <Info label="ดอกเบี้ยรวม" value={`${formatNumber(contract.interestTotal)} บาท`} />
               <Info label="ยอดจัดไฟแนนซ์" value={`${formatNumber(contract.financedAmount)} บาท`} />
               <Info label="จำนวนงวด" value={`${contract.totalMonths} เดือน`} />

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -17,7 +17,7 @@ import { toast } from 'sonner';
 import { formatDateShort, formatDateTime } from '@/utils/formatters';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { DetailPageSkeleton } from '@/components/ui/page-skeletons';
-import { maskNationalId } from '@/utils/mask.util';
+import { maskNationalId, formatNationalId } from '@/utils/mask.util';
 import { THAI_NAME_PREFIXES, RELATIONSHIP_OPTIONS } from '@/lib/constants';
 import { Badge } from '@/components/ui/badge';
 import { getStatusBadgeProps, contractStatusMap, creditCheckStatusMap } from '@/lib/status-badges';
@@ -528,7 +528,7 @@ export default function CustomerDetailPage() {
             <Info label="คำนำหน้า" value={customer.prefix} />
             <Info label="ชื่อ-นามสกุล" value={customer.name} />
             <Info label="ชื่อเล่น" value={customer.nickname} />
-            <Info label="เลขบัตร ปชช." value={maskNationalId(customer.nationalId)} />
+            <Info label="เลขบัตร ปชช." value={user?.role === 'OWNER' ? formatNationalId(customer.nationalId) : maskNationalId(customer.nationalId)} />
             <Info label="วันเกิด" value={customer.birthDate ? formatDateShort(customer.birthDate) : null} />
             <Info label="อายุ" value={customer.birthDate ? (() => {
               const bd = new Date(customer.birthDate);

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -12,7 +12,7 @@ import { compressImageForOcr } from '@/lib/compressImage';
 import { checkCardReaderStatus, readSmartCard, type SmartCardData } from '@/lib/cardReader';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useAuth } from '@/contexts/AuthContext';
-import { maskNationalId } from '@/utils/mask.util';
+import { maskNationalId, formatNationalId } from '@/utils/mask.util';
 import { THAI_NAME_PREFIXES, RELATIONSHIP_OPTIONS } from '@/lib/constants';
 import { customerSchema, type CustomerFormData } from '@/lib/schemas';
 import PageHeader from '@/components/ui/PageHeader';
@@ -544,7 +544,7 @@ export default function CustomersPage() {
       hideable: true,
       render: (c: Customer) => (
         <div className="group inline-flex items-center gap-1.5">
-          <span className="font-mono text-xs text-muted-foreground">{maskNationalId(c.nationalId)}</span>
+          <span className="font-mono text-xs text-muted-foreground">{isOwner ? formatNationalId(c.nationalId) : maskNationalId(c.nationalId)}</span>
           {isOwnerOrManager && (
             <button
               type="button"

--- a/apps/web/src/pages/InterestConfigPage.tsx
+++ b/apps/web/src/pages/InterestConfigPage.tsx
@@ -357,7 +357,7 @@ export default function InterestConfigPage() {
                     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
                       <div>
                         <div className="text-xs text-muted-foreground">ดอกเบี้ย</div>
-                        <div className="text-lg font-bold text-primary">{(parseFloat(config.interestRate) * 100).toFixed(1)}%</div>
+                        <div className="text-lg font-bold text-primary">{(parseFloat(config.interestRate) * 100).toFixed(2)}%</div>
                       </div>
                       <div>
                         <div className="text-xs text-muted-foreground">ดาวน์ขั้นต่ำ</div>

--- a/apps/web/src/pages/PurchaseOrdersPage/components/AccountsPayableTab.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/AccountsPayableTab.tsx
@@ -8,7 +8,7 @@ export interface AccountsPayableTabProps {
   payableData: {
     grandTotal: number;
     suppliers: {
-      supplier: { id: string; name: string; contactName: string; phone: string };
+      supplier: { id: string; name: string; contactName: string | null; phone: string };
       totalNet: number;
       totalPaid: number;
       totalRemaining: number;
@@ -40,7 +40,9 @@ export function AccountsPayableTab({ payableData, onOpenDetail }: AccountsPayabl
           <div className="px-4 py-3 bg-muted/40 border-b border-border/50 flex items-center justify-between">
             <div>
               <div className="font-medium text-foreground">{entry.supplier.name}</div>
-              <div className="text-xs text-muted-foreground">{entry.supplier.contactName} | {entry.supplier.phone}</div>
+              <div className="text-xs text-muted-foreground">
+                {[entry.supplier.contactName, entry.supplier.phone].filter(Boolean).join(' | ')}
+              </div>
             </div>
             <div className="text-right">
               <div className="text-lg font-bold text-destructive tabular-nums font-mono">{(Number(entry.totalRemaining) || 0).toLocaleString()} บาท</div>

--- a/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
@@ -13,6 +13,7 @@ export interface CreatePOModalProps {
     expectedDate: string;
     notes: string;
     discount: string;
+    discountAfterVat: string;
     paymentStatus: string;
     paymentMethod: string;
     paidAmount: string;
@@ -25,7 +26,7 @@ export interface CreatePOModalProps {
   removeItem: (idx: number) => void;
   updateItem: (idx: number, field: string, value: string) => void;
   toggleModel: (idx: number, modelName: string) => void;
-  suppliers: { id: string; name: string; contactName: string; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[];
+  suppliers: { id: string; name: string; contactName: string | null; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[];
   suppliersLoading: boolean;
   suppliersError: boolean;
   selectedSupplier: CreatePOModalProps['suppliers'][number] | undefined;
@@ -34,6 +35,8 @@ export interface CreatePOModalProps {
   discountNum: number;
   subtotalAfterDiscount: number;
   vatAmount: number;
+  totalWithVat: number;
+  discountAfterVatNum: number;
   netAmount: number;
   createMutation: UseMutationResult<unknown, unknown, Record<string, unknown>, unknown>;
   handleCreate: (e: React.FormEvent) => void;
@@ -63,6 +66,8 @@ export function CreatePOModal({
   discountNum,
   subtotalAfterDiscount,
   vatAmount,
+  totalWithVat,
+  discountAfterVatNum,
   netAmount,
   createMutation,
   handleCreate,
@@ -126,14 +131,14 @@ export function CreatePOModal({
                   >
                     <option value="">{suppliersLoading ? 'กำลังโหลด...' : suppliersError ? '⚠ โหลดข้อมูลไม่ได้' : '-- เลือกผู้ขาย --'}</option>
                     {suppliers.map((s) => (
-                      <option key={s.id} value={s.id}>{s.name} ({s.contactName}){s.hasVat ? ' [VAT]' : ''}</option>
+                      <option key={s.id} value={s.id}>{s.name}{s.contactName && s.contactName !== s.name ? ` (${s.contactName})` : ''}{s.hasVat ? ' [VAT]' : ''}</option>
                     ))}
                   </select>
                   {selectedSupplier && (
                     <div className="mt-1 flex gap-2 flex-wrap">
                       <span
                         className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                          supplierHasVat ? 'bg-primary-100 text-primary-700' : 'bg-muted text-muted-foreground'
+                          supplierHasVat ? 'bg-primary/10 text-primary dark:bg-primary/15' : 'bg-muted text-muted-foreground'
                         }`}
                       >
                         {supplierHasVat ? 'ผู้ขายมี VAT - จะคำนวณ VAT 7% อัตโนมัติ' : 'ผู้ขายไม่มี VAT'}
@@ -208,7 +213,7 @@ export function CreatePOModal({
                   })() : '';
 
                   return (
-                    <div key={idx} className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-primary-200 bg-primary-50' : 'border-border bg-muted'}`}>
+                    <div key={idx} className={`border rounded-lg p-3 space-y-2 relative ${isAccessory ? 'border-primary/30 bg-primary/5 dark:bg-primary/10' : 'border-border bg-muted/50'}`}>
                       {items.length > 1 && (
                         <button
                           type="button"
@@ -220,7 +225,7 @@ export function CreatePOModal({
                       )}
                       <div className="text-xs font-medium text-muted-foreground mb-1">
                         รายการ #{idx + 1}
-                        {isAccessory && <span className="ml-2 px-1.5 py-0.5 bg-primary-200 text-primary-700 rounded text-xs">อุปกรณ์เสริม</span>}
+                        {isAccessory && <span className="ml-2 px-1.5 py-0.5 bg-primary/15 text-primary dark:bg-primary/20 rounded text-xs">อุปกรณ์เสริม</span>}
                       </div>
 
                       {/* Row 1: Category FIRST, then Brand/Model or AccessoryType */}
@@ -339,7 +344,7 @@ export function CreatePOModal({
                                   className={`px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
                                     isSelected
                                       ? 'bg-primary text-primary-foreground border-primary'
-                                      : 'bg-background text-muted-foreground border-input hover:border-primary-400 hover:text-primary'
+                                      : 'bg-background text-muted-foreground border-input hover:border-primary/50 hover:text-primary'
                                   }`}
                                 >
                                   {m.name}
@@ -348,7 +353,7 @@ export function CreatePOModal({
                             })}
                           </div>
                           {selectedModels.length > 0 && (
-                            <div className="text-xs text-primary-500 mt-1">เลือกแล้ว {selectedModels.length} รุ่น</div>
+                            <div className="text-xs text-primary mt-1">เลือกแล้ว {selectedModels.length} รุ่น</div>
                           )}
                         </div>
                       )}
@@ -389,7 +394,7 @@ export function CreatePOModal({
                             </div>
                           </div>
                           {accessoryAutoName && (
-                            <div className="text-xs text-primary bg-primary-100 rounded px-2 py-1">
+                            <div className="text-xs text-primary bg-primary/10 dark:bg-primary/15 rounded px-2 py-1">
                               ชื่อสินค้า: {accessoryAutoName}
                             </div>
                           )}
@@ -465,35 +470,70 @@ export function CreatePOModal({
                 </div>
               </div>
 
-              <div className="bg-muted rounded-lg p-3 space-y-1 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">ยอดรวมสินค้า</span>
-                  <span className="font-medium tabular-nums font-mono">{subtotal.toLocaleString()} บาท</span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-muted-foreground">ส่วนลด</span>
-                  <input
-                    type="number"
-                    value={form.discount}
-                    onChange={(e) => setForm({ ...form, discount: e.target.value })}
-                    className="w-32 px-2 py-1 border border-input rounded text-sm text-right focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
-                    min="0"
-                    placeholder="0"
-                  />
-                </div>
-                {discountNum > 0 && (
-                  <div className="flex justify-between text-muted-foreground">
-                    <span>หลังหักส่วนลด</span>
-                    <span>{subtotalAfterDiscount.toLocaleString()} บาท</span>
-                  </div>
+              <div className="bg-muted/50 rounded-lg p-3 space-y-1.5 text-sm">
+                {supplierHasVat ? (
+                  <>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">มูลค่าสินค้า (ก่อน VAT 7%)</span>
+                      <span className="font-medium tabular-nums font-mono">{subtotal.toLocaleString()} บาท</span>
+                    </div>
+                    <div className="flex justify-between items-center">
+                      <span className="text-muted-foreground">ส่วนลด (ก่อน VAT 7%)</span>
+                      <input
+                        type="number"
+                        value={form.discount}
+                        onChange={(e) => setForm({ ...form, discount: e.target.value })}
+                        className="w-32 px-2 py-1 border border-input rounded text-sm text-right focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
+                        min="0"
+                        placeholder="0"
+                      />
+                    </div>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>VAT 7%</span>
+                      <span className="tabular-nums font-mono">{vatAmount.toLocaleString()} บาท</span>
+                    </div>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>มูลค่าสินค้า (รวม VAT 7%)</span>
+                      <span className="tabular-nums font-mono">{totalWithVat.toLocaleString()} บาท</span>
+                    </div>
+                    <div className="flex justify-between items-center">
+                      <span className="text-muted-foreground">ส่วนลด (หลัง VAT 7%)</span>
+                      <input
+                        type="number"
+                        value={form.discountAfterVat}
+                        onChange={(e) => setForm({ ...form, discountAfterVat: e.target.value })}
+                        className="w-32 px-2 py-1 border border-input rounded text-sm text-right focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
+                        min="0"
+                        placeholder="0"
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">ยอดรวมสินค้า</span>
+                      <span className="font-medium tabular-nums font-mono">{subtotal.toLocaleString()} บาท</span>
+                    </div>
+                    <div className="flex justify-between items-center">
+                      <span className="text-muted-foreground">ส่วนลด</span>
+                      <input
+                        type="number"
+                        value={form.discount}
+                        onChange={(e) => setForm({ ...form, discount: e.target.value })}
+                        className="w-32 px-2 py-1 border border-input rounded text-sm text-right focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
+                        min="0"
+                        placeholder="0"
+                      />
+                    </div>
+                    {discountNum > 0 && (
+                      <div className="flex justify-between text-muted-foreground">
+                        <span>หลังหักส่วนลด</span>
+                        <span className="tabular-nums font-mono">{subtotalAfterDiscount.toLocaleString()} บาท</span>
+                      </div>
+                    )}
+                  </>
                 )}
-                {supplierHasVat && (
-                  <div className="flex justify-between text-muted-foreground">
-                    <span>VAT 7%</span>
-                    <span>{vatAmount.toLocaleString()} บาท</span>
-                  </div>
-                )}
-                <div className="flex justify-between border-t pt-1 mt-1 font-semibold text-base">
+                <div className="flex justify-between border-t pt-1.5 mt-1.5 font-semibold text-base">
                   <span>ยอดสุทธิ</span>
                   <span className="text-primary tabular-nums font-mono">{netAmount.toLocaleString()} บาท</span>
                 </div>
@@ -608,7 +648,7 @@ export function CreatePOModal({
                 </div>
 
                 <div className="flex gap-2">
-                  <label className="flex items-center gap-1 px-3 py-2 bg-primary-50 text-primary-700 border border-primary-200 rounded-lg text-xs cursor-pointer hover:bg-primary-100 whitespace-nowrap">
+                  <label className="flex items-center gap-1 px-3 py-2 bg-primary/10 text-primary border border-primary/30 rounded-lg text-xs cursor-pointer hover:bg-primary/15 dark:bg-primary/15 dark:hover:bg-primary/20 whitespace-nowrap">
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
                     เลือกรูป
                     <input
@@ -656,7 +696,7 @@ export function CreatePOModal({
                         {att.startsWith('data:image') ? (
                           <img src={att} alt={`แนบ ${idx + 1}`} className="h-16 w-16 object-cover rounded-lg border" />
                         ) : (
-                          <div className="h-16 w-16 flex items-center justify-center bg-primary-50 rounded-lg border text-2xs text-primary p-1 break-all overflow-hidden">
+                          <div className="h-16 w-16 flex items-center justify-center bg-primary/10 dark:bg-primary/15 rounded-lg border text-2xs text-primary p-1 break-all overflow-hidden">
                             <a href={att} target="_blank" rel="noopener noreferrer" className="hover:underline">{att.length > 20 ? att.slice(0, 20) + '...' : att}</a>
                           </div>
                         )}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/GoodsReceivingModal.tsx
@@ -108,22 +108,30 @@ export function GoodsReceivingModal({
                           </button>
                         </div>
                       </div>
-                      {unit.category !== 'ACCESSORY' && (
+                      {unit.category !== 'ACCESSORY' && unit.status === 'PASS' && (
                       <div className="grid grid-cols-2 gap-2">
-                        <input
-                          type="text"
-                          placeholder="IMEI"
-                          value={unit.imeiSerial}
-                          onChange={(e) => updateReceivingUnit(idx, 'imeiSerial', e.target.value)}
-                          className="px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden font-mono"
-                        />
-                        <input
-                          type="text"
-                          placeholder="หมายเลขซีเรียล"
-                          value={unit.serialNumber}
-                          onChange={(e) => updateReceivingUnit(idx, 'serialNumber', e.target.value)}
-                          className="px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden font-mono"
-                        />
+                        <div>
+                          <label className="block text-xs text-muted-foreground mb-0.5">IMEI <span className="text-destructive">*</span></label>
+                          <input
+                            type="text"
+                            placeholder="IMEI"
+                            value={unit.imeiSerial}
+                            onChange={(e) => updateReceivingUnit(idx, 'imeiSerial', e.target.value)}
+                            required
+                            className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden font-mono"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-muted-foreground mb-0.5">หมายเลขซีเรียล <span className="text-destructive">*</span></label>
+                          <input
+                            type="text"
+                            placeholder="หมายเลขซีเรียล"
+                            value={unit.serialNumber}
+                            onChange={(e) => updateReceivingUnit(idx, 'serialNumber', e.target.value)}
+                            required
+                            className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden font-mono"
+                          />
+                        </div>
                       </div>
                       )}
                       {unit.category === 'PHONE_USED' && unit.status === 'PASS' && (
@@ -131,12 +139,13 @@ export function GoodsReceivingModal({
                           <div className="text-xs font-medium text-warning mb-1">ข้อมูลมือสอง</div>
                           <div className="grid grid-cols-2 gap-2">
                             <div>
-                              <label className="block text-xs text-muted-foreground mb-0.5">% แบตเตอรี่</label>
+                              <label className="block text-xs text-muted-foreground mb-0.5">% แบตเตอรี่ <span className="text-destructive">*</span></label>
                               <input
                                 type="number"
                                 placeholder="เช่น 87"
                                 value={unit.batteryHealth}
                                 onChange={(e) => updateReceivingUnit(idx, 'batteryHealth', e.target.value)}
+                                required
                                 className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
                                 min="0"
                                 max="100"
@@ -163,7 +172,7 @@ export function GoodsReceivingModal({
                             </div>
                           </div>
                           <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ประกันศูนย์</label>
+                            <label className="block text-xs text-muted-foreground mb-0.5">ประกันศูนย์ <span className="text-destructive">*</span></label>
                             <div className="flex items-center gap-3">
                               <label className="flex items-center gap-1.5 cursor-pointer">
                                 <input
@@ -178,6 +187,7 @@ export function GoodsReceivingModal({
                                 <ThaiDateInput
                                   value={unit.warrantyExpireDate}
                                   onChange={(e) => updateReceivingUnit(idx, 'warrantyExpireDate', e.target.value)}
+                                  required
                                   className="flex-1 px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
                                 />
                               )}
@@ -231,12 +241,13 @@ export function GoodsReceivingModal({
                         <div className="mt-2 border border-primary/20 bg-primary/5 dark:bg-primary/10 rounded-xl p-3 space-y-2">
                           <div className="text-xs font-medium text-primary mb-1">ราคาขาย</div>
                           <div>
-                            <label className="block text-xs text-muted-foreground mb-0.5">ราคาขาย (บาท)</label>
+                            <label className="block text-xs text-muted-foreground mb-0.5">ราคาขาย (บาท) <span className="text-destructive">*</span></label>
                             <input
                               type="number"
                               placeholder="เช่น 15000"
                               value={unit.sellingPrice}
                               onChange={(e) => updateReceivingUnit(idx, 'sellingPrice', e.target.value)}
+                              required
                               className="w-full px-2 py-1.5 border border-input rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
                               min="0"
                             />
@@ -249,6 +260,7 @@ export function GoodsReceivingModal({
                           placeholder="เหตุผลที่ไม่ผ่าน *"
                           value={unit.rejectReason}
                           onChange={(e) => updateReceivingUnit(idx, 'rejectReason', e.target.value)}
+                          required
                           className="mt-2 w-full px-2 py-1.5 border border-destructive/30 rounded text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden"
                         />
                       )}

--- a/apps/web/src/pages/PurchaseOrdersPage/components/PODetailModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/PODetailModal.tsx
@@ -120,12 +120,23 @@ export function PODetailModal({
                 </div>
 
                 {/* Summary */}
-                {(Number(selectedPO.discount) > 0 || Number(selectedPO.vatAmount) > 0) && (
+                {(Number(selectedPO.discount) > 0 || Number(selectedPO.discountAfterVat) > 0 || Number(selectedPO.vatAmount) > 0) && (
                   <div className="bg-muted rounded-lg p-3 text-sm space-y-1 mb-3">
-                    <div className="flex justify-between"><span className="text-muted-foreground">ยอดรวมสินค้า</span><span>{Number(selectedPO.totalAmount).toLocaleString()} บาท</span></div>
-                    {Number(selectedPO.discount) > 0 && <div className="flex justify-between"><span className="text-muted-foreground">ส่วนลด</span><span className="text-destructive">-{Number(selectedPO.discount).toLocaleString()} บาท</span></div>}
-                    {Number(selectedPO.vatAmount) > 0 && <div className="flex justify-between"><span className="text-muted-foreground">VAT 7%</span><span>{Number(selectedPO.vatAmount).toLocaleString()} บาท</span></div>}
-                    <div className="flex justify-between font-semibold border-t pt-1"><span>ยอดสุทธิ</span><span>{Number(selectedPO.netAmount).toLocaleString()} บาท</span></div>
+                    {Number(selectedPO.vatAmount) > 0 ? (
+                      <>
+                        <div className="flex justify-between"><span className="text-muted-foreground">มูลค่าสินค้า (ก่อน VAT 7%)</span><span className="tabular-nums">{Number(selectedPO.totalAmount).toLocaleString()} บาท</span></div>
+                        {Number(selectedPO.discount) > 0 && <div className="flex justify-between"><span className="text-muted-foreground">ส่วนลด (ก่อน VAT 7%)</span><span className="text-destructive tabular-nums">-{Number(selectedPO.discount).toLocaleString()} บาท</span></div>}
+                        <div className="flex justify-between"><span className="text-muted-foreground">VAT 7%</span><span className="tabular-nums">{Number(selectedPO.vatAmount).toLocaleString()} บาท</span></div>
+                        <div className="flex justify-between"><span className="text-muted-foreground">มูลค่าสินค้า (รวม VAT 7%)</span><span className="tabular-nums">{(Number(selectedPO.totalAmount) - Number(selectedPO.discount) + Number(selectedPO.vatAmount)).toLocaleString()} บาท</span></div>
+                        {Number(selectedPO.discountAfterVat) > 0 && <div className="flex justify-between"><span className="text-muted-foreground">ส่วนลด (หลัง VAT 7%)</span><span className="text-destructive tabular-nums">-{Number(selectedPO.discountAfterVat).toLocaleString()} บาท</span></div>}
+                      </>
+                    ) : (
+                      <>
+                        <div className="flex justify-between"><span className="text-muted-foreground">ยอดรวมสินค้า</span><span className="tabular-nums">{Number(selectedPO.totalAmount).toLocaleString()} บาท</span></div>
+                        {Number(selectedPO.discount) > 0 && <div className="flex justify-between"><span className="text-muted-foreground">ส่วนลด</span><span className="text-destructive tabular-nums">-{Number(selectedPO.discount).toLocaleString()} บาท</span></div>}
+                      </>
+                    )}
+                    <div className="flex justify-between font-semibold border-t pt-1"><span>ยอดสุทธิ</span><span className="tabular-nums">{Number(selectedPO.netAmount).toLocaleString()} บาท</span></div>
                   </div>
                 )}
 

--- a/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/POListTab.tsx
@@ -173,7 +173,10 @@ export function POListTab({
             {Number(po.netAmount ?? po.totalAmount).toLocaleString()} บาท
           </span>
           {Number(po.discount) > 0 && (
-            <div className="text-xs text-destructive">ส่วนลด -{Number(po.discount).toLocaleString()}</div>
+            <div className="text-xs text-destructive">ส่วนลดก่อน VAT -{Number(po.discount).toLocaleString()}</div>
+          )}
+          {Number(po.discountAfterVat) > 0 && (
+            <div className="text-xs text-destructive">ส่วนลดหลัง VAT -{Number(po.discountAfterVat).toLocaleString()}</div>
           )}
           {Number(po.vatAmount) > 0 && (
             <div className="text-xs text-primary">รวม VAT {Number(po.vatAmount).toLocaleString()}</div>

--- a/apps/web/src/pages/PurchaseOrdersPage/components/PaymentModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/PaymentModal.tsx
@@ -6,7 +6,7 @@ export interface PaymentModalProps {
   isOpen: boolean;
   onClose: () => void;
   selectedPO: PurchaseOrder | null;
-  suppliers: { id: string; name: string; contactName: string; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[];
+  suppliers: { id: string; name: string; contactName: string | null; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[];
   paymentForm: { paymentStatus: string; paymentMethod: string; paidAmount: string; paymentNotes: string };
   setPaymentForm: React.Dispatch<React.SetStateAction<PaymentModalProps['paymentForm']>>;
   paymentAttachments: string[];
@@ -61,25 +61,50 @@ export function PaymentModal({
               </div>
             </div>
           <div className="bg-muted rounded-lg p-3 text-sm space-y-1">
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">ยอดรวมสินค้า:</span>
-              <span className="tabular-nums font-mono">{Number(selectedPO.totalAmount).toLocaleString()} บาท</span>
-            </div>
-            {Number(selectedPO.discount) > 0 && (
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">ส่วนลด:</span>
-                <span className="text-destructive">-{Number(selectedPO.discount).toLocaleString()} บาท</span>
-              </div>
-            )}
-            {Number(selectedPO.vatAmount) > 0 && (
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">VAT 7%:</span>
-                <span>{Number(selectedPO.vatAmount).toLocaleString()} บาท</span>
-              </div>
+            {Number(selectedPO.vatAmount) > 0 ? (
+              <>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">มูลค่าสินค้า (ก่อน VAT 7%):</span>
+                  <span className="tabular-nums font-mono">{Number(selectedPO.totalAmount).toLocaleString()} บาท</span>
+                </div>
+                {Number(selectedPO.discount) > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">ส่วนลด (ก่อน VAT 7%):</span>
+                    <span className="text-destructive tabular-nums">-{Number(selectedPO.discount).toLocaleString()} บาท</span>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">VAT 7%:</span>
+                  <span className="tabular-nums">{Number(selectedPO.vatAmount).toLocaleString()} บาท</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">มูลค่าสินค้า (รวม VAT 7%):</span>
+                  <span className="tabular-nums">{(Number(selectedPO.totalAmount) - Number(selectedPO.discount) + Number(selectedPO.vatAmount)).toLocaleString()} บาท</span>
+                </div>
+                {Number(selectedPO.discountAfterVat) > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">ส่วนลด (หลัง VAT 7%):</span>
+                    <span className="text-destructive tabular-nums">-{Number(selectedPO.discountAfterVat).toLocaleString()} บาท</span>
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">ยอดรวมสินค้า:</span>
+                  <span className="tabular-nums font-mono">{Number(selectedPO.totalAmount).toLocaleString()} บาท</span>
+                </div>
+                {Number(selectedPO.discount) > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">ส่วนลด:</span>
+                    <span className="text-destructive tabular-nums">-{Number(selectedPO.discount).toLocaleString()} บาท</span>
+                  </div>
+                )}
+              </>
             )}
             <div className="flex justify-between font-medium border-t pt-1">
               <span>ยอดสุทธิ:</span>
-              <span>{Number(selectedPO.netAmount ?? selectedPO.totalAmount).toLocaleString()} บาท</span>
+              <span className="tabular-nums">{Number(selectedPO.netAmount ?? selectedPO.totalAmount).toLocaleString()} บาท</span>
             </div>
             {Number(selectedPO.paidAmount) > 0 && (
               <>

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts
@@ -6,7 +6,7 @@ import { UseMutationResult } from '@tanstack/react-query';
 
 interface UsePOFormOptions {
   createMutation: UseMutationResult<unknown, unknown, Record<string, unknown>, unknown>;
-  suppliers: { id: string; name: string; contactName: string; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[];
+  suppliers: { id: string; name: string; contactName: string | null; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[];
 }
 
 export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
@@ -16,6 +16,7 @@ export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
     expectedDate: '',
     notes: '',
     discount: '',
+    discountAfterVat: '',
     paymentStatus: 'UNPAID',
     paymentMethod: '',
     paidAmount: '',
@@ -26,7 +27,7 @@ export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
   const [formAttachments, setFormAttachments] = useState<string[]>([]);
 
   const resetForm = () => {
-    setForm({ supplierId: '', orderDate: new Date().toISOString().split('T')[0], expectedDate: '', notes: '', discount: '', paymentStatus: 'UNPAID', paymentMethod: '', paidAmount: '', paymentNotes: '' });
+    setForm({ supplierId: '', orderDate: new Date().toISOString().split('T')[0], expectedDate: '', notes: '', discount: '', discountAfterVat: '', paymentStatus: 'UNPAID', paymentMethod: '', paidAmount: '', paymentNotes: '' });
     setItems([{ ...emptyItem }]);
     setFormAttachments([]);
     setAttachmentUrl('');
@@ -92,6 +93,7 @@ export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
       expectedDate: form.expectedDate || undefined,
       notes: form.notes || undefined,
       discount: form.discount ? Number(form.discount) : undefined,
+      discountAfterVat: form.discountAfterVat ? Number(form.discountAfterVat) : undefined,
       paymentStatus: form.paymentStatus !== 'UNPAID' ? form.paymentStatus : undefined,
       paymentMethod: form.paymentMethod || undefined,
       paidAmount: form.paidAmount ? Number(form.paidAmount) : undefined,
@@ -119,7 +121,11 @@ export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
   const discountNum = Math.min(Number(form.discount) || 0, subtotal);
   const subtotalAfterDiscount = subtotal - discountNum;
   const vatAmount = supplierHasVat ? Math.round(subtotalAfterDiscount * 0.07 * 100) / 100 : 0;
-  const netAmount = subtotalAfterDiscount + vatAmount;
+  const totalWithVat = subtotalAfterDiscount + vatAmount;
+  const discountAfterVatNum = supplierHasVat
+    ? Math.min(Number(form.discountAfterVat) || 0, totalWithVat)
+    : 0;
+  const netAmount = totalWithVat - discountAfterVatNum;
 
   return {
     form,
@@ -142,6 +148,8 @@ export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
     discountNum,
     subtotalAfterDiscount,
     vatAmount,
+    totalWithVat,
+    discountAfterVatNum,
     netAmount,
   };
 }

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePurchaseOrdersData.ts
@@ -24,7 +24,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   const [paymentAttachments, setPaymentAttachments] = useState<string[]>([]);
   const [paymentAttachmentUrl, setPaymentAttachmentUrl] = useState('');
 
-  const { data: suppliersRes, isLoading: suppliersLoading, isError: suppliersError } = useQuery<{ data: { id: string; name: string; contactName: string; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[] }>({
+  const { data: suppliersRes, isLoading: suppliersLoading, isError: suppliersError } = useQuery<{ data: { id: string; name: string; contactName: string | null; hasVat: boolean; paymentMethods: { paymentMethod: string; bankName?: string; bankAccountName?: string; bankAccountNumber?: string; creditTermDays?: number; isDefault: boolean }[] }[] }>({
     queryKey: ['suppliers-for-po'],
     queryFn: async () => (await api.get('/suppliers?limit=200&isActive=true')).data,
     retry: 2,
@@ -34,7 +34,7 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
   type PayableData = {
     grandTotal: number;
     suppliers: {
-      supplier: { id: string; name: string; contactName: string; phone: string };
+      supplier: { id: string; name: string; contactName: string | null; phone: string };
       totalNet: number;
       totalPaid: number;
       totalRemaining: number;
@@ -294,6 +294,40 @@ export function usePurchaseOrdersData(options?: { onCreateSuccess?: () => void }
     const missingReasons = receivingUnits.filter((u) => u.status === 'REJECT' && !u.rejectReason.trim());
     if (missingReasons.length > 0) {
       toast.error('กรุณาระบุเหตุผลสำหรับรายการที่ไม่ผ่าน');
+      return;
+    }
+
+    const passUnits = receivingUnits.filter((u) => u.status === 'PASS');
+
+    const missingImei = passUnits.filter((u) => u.category !== 'ACCESSORY' && !u.imeiSerial.trim());
+    if (missingImei.length > 0) {
+      toast.error('กรุณาระบุ IMEI ให้ครบทุกรายการที่ผ่าน');
+      return;
+    }
+
+    const missingSerial = passUnits.filter((u) => u.category !== 'ACCESSORY' && !u.serialNumber.trim());
+    if (missingSerial.length > 0) {
+      toast.error('กรุณาระบุหมายเลขซีเรียลให้ครบทุกรายการที่ผ่าน');
+      return;
+    }
+
+    const missingSellingPrice = passUnits.filter((u) => !u.sellingPrice.trim() || Number(u.sellingPrice) <= 0);
+    if (missingSellingPrice.length > 0) {
+      toast.error('กรุณาระบุราคาขายให้ครบทุกรายการที่ผ่าน');
+      return;
+    }
+
+    const usedPhonePass = passUnits.filter((u) => u.category === 'PHONE_USED');
+
+    const missingBattery = usedPhonePass.filter((u) => !u.batteryHealth.trim());
+    if (missingBattery.length > 0) {
+      toast.error('กรุณาระบุ % แบตเตอรี่สำหรับมือสองทุกเครื่อง');
+      return;
+    }
+
+    const missingWarranty = usedPhonePass.filter((u) => !u.warrantyExpired && !u.warrantyExpireDate.trim());
+    if (missingWarranty.length > 0) {
+      toast.error('กรุณาระบุวันหมดประกันหรือติ๊กหมดประกันแล้ว');
       return;
     }
 

--- a/apps/web/src/pages/PurchaseOrdersPage/index.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/index.tsx
@@ -106,7 +106,7 @@ export default function PurchaseOrdersPage() {
           onClick={() => data.setActiveTab('payable')}
           className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${data.activeTab === 'payable' ? 'border-destructive text-destructive' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
         >
-          ยอดค้างจ่ายผู้ขาย
+          ยอดค้างชำระ ( ผู้ขาย )
           {data.payableData && data.payableData.grandTotal > 0 && (
             <span className="ml-1.5 px-2 py-0.5 rounded-full text-xs font-semibold bg-destructive/10 text-destructive dark:bg-destructive/15">{(Number(data.payableData.grandTotal) || 0).toLocaleString()}</span>
           )}
@@ -159,6 +159,8 @@ export default function PurchaseOrdersPage() {
         discountNum={poForm.discountNum}
         subtotalAfterDiscount={poForm.subtotalAfterDiscount}
         vatAmount={poForm.vatAmount}
+        totalWithVat={poForm.totalWithVat}
+        discountAfterVatNum={poForm.discountAfterVatNum}
         netAmount={poForm.netAmount}
         createMutation={data.createMutation}
         handleCreate={poForm.handleCreate}

--- a/apps/web/src/pages/PurchaseOrdersPage/types.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/types.ts
@@ -41,6 +41,7 @@ export interface PurchaseOrder {
   vatAmount: string;
   totalAmount: string;
   discount: string;
+  discountAfterVat: string;
   netAmount: string;
   paymentStatus: string;
   paymentMethod: string | null;
@@ -48,7 +49,7 @@ export interface PurchaseOrder {
   paymentNotes: string | null;
   attachments: string[];
   notes: string | null;
-  supplier: { id: string; name: string; contactName: string; phone: string; hasVat: boolean };
+  supplier: { id: string; name: string; contactName: string | null; phone: string; hasVat: boolean };
   createdBy: { id: string; name: string };
   approvedBy: { id: string; name: string } | null;
   items: POItem[];

--- a/apps/web/src/pages/SupplierDetailPage.tsx
+++ b/apps/web/src/pages/SupplierDetailPage.tsx
@@ -27,9 +27,14 @@ interface SupplierPaymentMethod {
 
 interface Supplier {
   id: string;
+  type: 'INDIVIDUAL' | 'JURISTIC';
   name: string;
-  contactName: string;
+  titleName: string | null;
+  contactName: string | null;
+  contactPhone: string | null;
+  contactPosition: string | null;
   nickname: string | null;
+  branchCode: string | null;
   phone: string;
   phoneSecondary: string | null;
   lineId: string | null;
@@ -120,8 +125,8 @@ export default function SupplierDetailPage() {
   });
 
   const { data: history, isLoading: historyLoading } = useQuery<{
-    products: ProductRecord[];
-    purchaseOrders: PORecord[];
+    products: { data: ProductRecord[]; total: number; page: number; limit: number };
+    purchaseOrders: { data: PORecord[]; total: number; page: number; limit: number };
   }>({
     queryKey: ['supplier-history', id],
     queryFn: async () => {
@@ -129,6 +134,11 @@ export default function SupplierDetailPage() {
       return data;
     },
   });
+
+  const products = history?.products.data ?? [];
+  const purchaseOrders = history?.purchaseOrders.data ?? [];
+  const productsTotal = history?.products.total ?? 0;
+  const purchaseOrdersTotal = history?.purchaseOrders.total ?? 0;
 
   if (supplierLoading) {
     return <QueryBoundary isLoading={true} isError={false}>{null}</QueryBoundary>;
@@ -142,7 +152,7 @@ export default function SupplierDetailPage() {
     return <div className="text-center py-12 text-muted-foreground">ไม่พบข้อมูลผู้ขาย</div>;
   }
 
-  const totalCost = history?.products.reduce((sum, p) => sum + parseFloat(p.costPrice), 0) || 0;
+  const totalCost = products.reduce((sum, p) => sum + parseFloat(p.costPrice), 0);
 
   const productColumns = [
     { key: 'name', label: 'สินค้า', render: (p: ProductRecord) => (
@@ -258,18 +268,39 @@ export default function SupplierDetailPage() {
       <div className="rounded-xl border border-border/50 bg-card p-5 mb-6 shadow-sm relative overflow-hidden">
         <div className="absolute left-0 top-0 bottom-0 w-1 rounded-r-full bg-primary" />
         <div className="flex items-start justify-between mb-4">
-          <h2 className="text-lg font-semibold text-foreground">ข้อมูลผู้ขาย</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-foreground">ข้อมูลผู้ขาย</h2>
+            <Badge
+              variant={supplier.type === 'JURISTIC' ? 'primary' : 'secondary'}
+              appearance="light"
+              size="sm"
+            >
+              {supplier.type === 'JURISTIC' ? 'นิติบุคคล' : 'บุคคลธรรมดา'}
+            </Badge>
+          </div>
           <Badge variant={supplier.isActive ? 'success' : 'destructive'} appearance="light">
             {supplier.isActive ? 'เปิดใช้งาน' : 'ปิดใช้งาน'}
           </Badge>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-          <InfoField label="ชื่อ - นามสกุล (ผู้ติดต่อ)" value={supplier.contactName} />
-          <InfoField label="ชื่อเล่น" value={supplier.nickname} />
+          {supplier.type === 'INDIVIDUAL' ? (
+            <>
+              <InfoField
+                label="ชื่อ - นามสกุล"
+                value={[supplier.titleName, supplier.name].filter(Boolean).join(' ') || supplier.name}
+              />
+              <InfoField label="ชื่อเล่น" value={supplier.nickname} />
+            </>
+          ) : (
+            <InfoField label="ชื่อบริษัท" value={supplier.name} />
+          )}
           <InfoField label="เบอร์โทร" value={supplier.phone} />
           <InfoField label="เบอร์สำรอง" value={supplier.phoneSecondary} />
           <InfoField label="LINE ID" value={supplier.lineId} />
-          <InfoField label="เลขประจำตัวผู้เสียภาษี (Tax ID Number)" value={supplier.taxId} />
+          <InfoField label="เลขประจำตัวผู้เสียภาษี (Tax ID)" value={supplier.taxId} />
+          {supplier.type === 'JURISTIC' && (
+            <InfoField label="รหัสสาขา" value={supplier.branchCode} />
+          )}
           <div>
             <div className="text-xs text-muted-foreground mb-0.5">สถานะ VAT</div>
             <span
@@ -280,14 +311,24 @@ export default function SupplierDetailPage() {
               {supplier.hasVat ? 'มี VAT (7%)' : 'ไม่มี VAT'}
             </span>
           </div>
-          <InfoField
-            label="วันที่เพิ่ม"
-            value={formatDateShort(supplier.createdAt)}
-          />
+          <InfoField label="วันที่เพิ่ม" value={formatDateShort(supplier.createdAt)} />
           <InfoField label="ที่อยู่" value={displayAddress(supplier.address)} />
           {supplier.notes && <InfoField label="หมายเหตุ" value={supplier.notes} />}
         </div>
       </div>
+
+      {/* ผู้ติดต่อ (JURISTIC only) */}
+      {supplier.type === 'JURISTIC' &&
+        (supplier.contactName || supplier.contactPhone || supplier.contactPosition) && (
+          <div className="rounded-xl border border-border/50 bg-card p-5 mb-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-foreground mb-4">ผู้ติดต่อ</h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <InfoField label="ชื่อ - นามสกุล" value={supplier.contactName} />
+              <InfoField label="ตำแหน่ง" value={supplier.contactPosition} />
+              <InfoField label="เบอร์โทร" value={supplier.contactPhone} />
+            </div>
+          </div>
+        )}
 
       {/* Payment Methods Card */}
       <div className="rounded-xl border border-border/50 bg-card p-5 mb-6 shadow-sm">
@@ -332,12 +373,12 @@ export default function SupplierDetailPage() {
       {/* Purchase Orders */}
       <Card className="mb-6">
         <CardHeader>
-          <CardTitle>Purchase Orders ({history?.purchaseOrders.length || 0})</CardTitle>
+          <CardTitle>Purchase Orders ({purchaseOrdersTotal})</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           <DataTable
             columns={poColumns}
-            data={history?.purchaseOrders || []}
+            data={purchaseOrders}
             isLoading={historyLoading}
             emptyMessage="ยังไม่มี PO"
           />
@@ -347,12 +388,12 @@ export default function SupplierDetailPage() {
       {/* Products (Purchase History) */}
       <Card>
         <CardHeader>
-          <CardTitle>ประวัติการซื้อสินค้า ({history?.products.length || 0})</CardTitle>
+          <CardTitle>ประวัติการซื้อสินค้า ({productsTotal})</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           <DataTable
             columns={productColumns}
-            data={history?.products || []}
+            data={products}
             isLoading={historyLoading}
             emptyMessage="ยังไม่มีสินค้าจากผู้ขายนี้"
           />

--- a/apps/web/src/pages/SuppliersPage/components/SupplierForm.tsx
+++ b/apps/web/src/pages/SuppliersPage/components/SupplierForm.tsx
@@ -1,10 +1,17 @@
+import { Building2, User2 } from 'lucide-react';
 import AddressForm, { AddressData } from '@/components/ui/AddressForm';
+import { cn } from '@/lib/utils';
 import type { PaymentMethod } from './SupplierTable';
 
+export type SupplierType = 'INDIVIDUAL' | 'JURISTIC';
+
 export const emptyForm = {
+  type: 'JURISTIC' as SupplierType,
   name: '',
+  titleName: '',
   contactName: '',
   nickname: '',
+  branchCode: '',
   phone: '',
   phoneSecondary: '',
   lineId: '',
@@ -24,6 +31,8 @@ export const emptyPaymentMethod: PaymentMethod = {
   isDefault: false,
 };
 
+const TITLE_OPTIONS = ['นาย', 'นาง', 'นางสาว', 'คุณ'];
+
 export function formatPhone(value: string): string {
   const digits = value.replace(/\D/g, '').slice(0, 10);
   if (digits.length <= 3) return digits;
@@ -40,6 +49,10 @@ export function formatTaxId(value: string): string {
   if (digits.length <= 12)
     return `${digits.slice(0, 1)}-${digits.slice(1, 5)}-${digits.slice(5, 10)}-${digits.slice(10)}`;
   return `${digits.slice(0, 1)}-${digits.slice(1, 5)}-${digits.slice(5, 10)}-${digits.slice(10, 12)}-${digits.slice(12)}`;
+}
+
+export function formatBranchCode(value: string): string {
+  return value.replace(/\D/g, '').slice(0, 5);
 }
 
 interface SupplierFormProps {
@@ -67,6 +80,21 @@ export default function SupplierForm({
   onClose,
   onSubmit,
 }: SupplierFormProps) {
+  const isJuristic = form.type === 'JURISTIC';
+
+  const changeType = (nextType: SupplierType) => {
+    if (nextType === form.type) return;
+    setForm({
+      ...form,
+      type: nextType,
+      // reset type-specific fields so stale data ไม่ค้าง
+      titleName: nextType === 'INDIVIDUAL' ? form.titleName : '',
+      branchCode: nextType === 'JURISTIC' ? form.branchCode : '',
+      contactName: nextType === 'JURISTIC' ? form.contactName : '',
+      hasVat: nextType === 'JURISTIC' ? form.hasVat : false,
+    });
+  };
+
   const addPaymentMethod = () => {
     setPaymentMethods([
       ...paymentMethods,
@@ -136,50 +164,119 @@ export default function SupplierForm({
 
         <form onSubmit={onSubmit} className="flex-1 overflow-y-auto flex flex-col">
           <div className="p-6 space-y-5 flex-1">
-            {/* Supplier Info */}
+            {/* Type Selector */}
+            <div className="rounded-xl border border-border bg-card p-5">
+              <div className="mb-3">
+                <h3 className="text-sm font-semibold text-foreground">ประเภทผู้ขาย</h3>
+                <p className="text-xs text-muted-foreground">
+                  เลือกให้ตรงกับเอกสารประกอบใบกำกับภาษี
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <button
+                  type="button"
+                  onClick={() => changeType('JURISTIC')}
+                  className={cn(
+                    'flex items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                    isJuristic
+                      ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
+                      : 'border-input hover:border-primary/40 hover:bg-muted',
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'flex items-center justify-center size-9 rounded-lg shrink-0',
+                      isJuristic
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted text-muted-foreground',
+                    )}
+                  >
+                    <Building2 className="size-5" />
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-foreground">นิติบุคคล</div>
+                    <div className="text-xs text-muted-foreground leading-snug">
+                      บริษัท, ห้างหุ้นส่วน, ร้านค้าจดทะเบียน
+                    </div>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => changeType('INDIVIDUAL')}
+                  className={cn(
+                    'flex items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                    !isJuristic
+                      ? 'border-primary bg-primary/5 ring-2 ring-primary/20'
+                      : 'border-input hover:border-primary/40 hover:bg-muted',
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'flex items-center justify-center size-9 rounded-lg shrink-0',
+                      !isJuristic
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted text-muted-foreground',
+                    )}
+                  >
+                    <User2 className="size-5" />
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-foreground">บุคคลธรรมดา</div>
+                    <div className="text-xs text-muted-foreground leading-snug">
+                      ขายของมือสอง, freelancer, รายย่อย
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </div>
+
+            {/* Main Info */}
             <div className="rounded-xl border border-border bg-card p-5">
               <div className="flex items-center gap-2.5 mb-4">
                 <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M3 9 12 2l9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                  </svg>
+                  {isJuristic ? <Building2 className="size-4" /> : <User2 className="size-4" />}
                 </div>
                 <div>
-                  <h3 className="text-sm font-semibold text-foreground">ข้อมูลผู้ขาย</h3>
-                  <p className="text-xs text-muted-foreground">ชื่อบริษัท, ผู้ติดต่อ, ภาษี</p>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {isJuristic ? 'ข้อมูลบริษัท' : 'ข้อมูลผู้ขาย'}
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    {isJuristic
+                      ? 'ชื่อบริษัท, เลขผู้เสียภาษี, รหัสสาขา'
+                      : 'คำนำหน้า, ชื่อ-นามสกุล, เลขประชาชน'}
+                  </p>
                 </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <div className="col-span-2">
+                {!isJuristic && (
+                  <div>
+                    <label className="block text-xs font-medium text-foreground mb-1.5">
+                      คำนำหน้า
+                    </label>
+                    <select
+                      value={form.titleName}
+                      onChange={(e) => setForm({ ...form, titleName: e.target.value })}
+                      className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                    >
+                      <option value="">-- เลือก --</option>
+                      {TITLE_OPTIONS.map((t) => (
+                        <option key={t} value={t}>
+                          {t}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                <div className={cn(isJuristic ? 'col-span-2' : 'col-span-1')}>
                   <label className="block text-xs font-medium text-foreground mb-1.5">
-                    ชื่อผู้ขาย / บริษัท <span className="text-destructive">*</span>
+                    {isJuristic ? 'ชื่อบริษัท' : 'ชื่อ - นามสกุล'}{' '}
+                    <span className="text-destructive">*</span>
                   </label>
                   <input
                     type="text"
                     value={form.name}
                     onChange={(e) => setForm({ ...form, name: e.target.value })}
-                    className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
-                    required
-                  />
-                </div>
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">
-                    ชื่อ - นามสกุล (ผู้ติดต่อ) <span className="text-destructive">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={form.contactName}
-                    onChange={(e) => setForm({ ...form, contactName: e.target.value })}
+                    placeholder={isJuristic ? 'บริษัท ... จำกัด' : 'เช่น สมชาย ใจดี'}
                     className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
                     required
                   />
@@ -231,7 +328,7 @@ export default function SupplierForm({
                 </div>
                 <div>
                   <label className="block text-xs font-medium text-foreground mb-1.5">
-                    เลขประจำตัวผู้เสียภาษี (Tax ID Number)
+                    {isJuristic ? 'เลขประจำตัวผู้เสียภาษี' : 'เลขประจำตัวประชาชน'}
                   </label>
                   <input
                     type="text"
@@ -242,31 +339,83 @@ export default function SupplierForm({
                     className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
                   />
                 </div>
-                <div className="col-span-2">
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <span className="text-sm font-medium text-foreground">จดทะเบียน VAT</span>
-                    <button
-                      type="button"
-                      onClick={() => setForm({ ...form, hasVat: !form.hasVat })}
-                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                        form.hasVat ? 'bg-primary' : 'bg-border'
-                      }`}
-                    >
-                      <span
-                        className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
-                          form.hasVat ? 'translate-x-6' : 'translate-x-1'
+                {isJuristic && (
+                  <div className="col-span-2 flex flex-col gap-4 border-t pt-4">
+                    <label className="flex items-center gap-3 cursor-pointer">
+                      <span className="text-sm font-medium text-foreground">จดทะเบียน VAT</span>
+                      <button
+                        type="button"
+                        onClick={() => setForm({ ...form, hasVat: !form.hasVat })}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                          form.hasVat ? 'bg-primary' : 'bg-border'
                         }`}
-                      />
-                    </button>
-                    <span
-                      className={`text-sm font-medium ${form.hasVat ? 'text-primary' : 'text-muted-foreground'}`}
-                    >
-                      {form.hasVat ? 'มี VAT (7%)' : 'ไม่มี VAT'}
-                    </span>
-                  </label>
-                </div>
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
+                            form.hasVat ? 'translate-x-6' : 'translate-x-1'
+                          }`}
+                        />
+                      </button>
+                      <span
+                        className={`text-sm font-medium ${form.hasVat ? 'text-primary' : 'text-muted-foreground'}`}
+                      >
+                        {form.hasVat ? 'มี VAT (7%)' : 'ไม่มี VAT'}
+                      </span>
+                    </label>
+                    {form.hasVat && (
+                      <div>
+                        <label className="block text-xs font-medium text-foreground mb-1.5">
+                          รหัสสาขา (5 หลัก)
+                        </label>
+                        <input
+                          type="text"
+                          value={form.branchCode}
+                          onChange={(e) =>
+                            setForm({ ...form, branchCode: formatBranchCode(e.target.value) })
+                          }
+                          placeholder="00000 = สำนักงานใหญ่"
+                          maxLength={5}
+                          inputMode="numeric"
+                          className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm font-mono transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                        />
+                        <p className="mt-1 text-2xs text-muted-foreground">
+                          ใช้ในใบกำกับภาษี — "00000" สำหรับสำนักงานใหญ่
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
+
+            {/* Contact Person (JURISTIC only) */}
+            {isJuristic && (
+              <div className="rounded-xl border border-border bg-card p-5">
+                <div className="flex items-center gap-2.5 mb-4">
+                  <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+                    <User2 className="size-4" />
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-semibold text-foreground">ผู้ติดต่อ</h3>
+                    <p className="text-xs text-muted-foreground">
+                      ชื่อพนักงาน/ฝ่ายที่ติดต่อกับเรา
+                    </p>
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-foreground mb-1.5">
+                    ชื่อ - นามสกุล <span className="text-destructive">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={form.contactName}
+                    onChange={(e) => setForm({ ...form, contactName: e.target.value })}
+                    className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                    required
+                  />
+                </div>
+              </div>
+            )}
 
             {/* Payment Methods */}
             <div className="rounded-xl border border-border bg-card p-5">
@@ -435,8 +584,14 @@ export default function SupplierForm({
                   </svg>
                 </div>
                 <div>
-                  <h3 className="text-sm font-semibold text-foreground">ที่อยู่</h3>
-                  <p className="text-xs text-muted-foreground">ที่อยู่ผู้ขาย</p>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    {isJuristic ? 'ที่อยู่จดทะเบียน' : 'ที่อยู่ตามบัตรประชาชน'}
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    {isJuristic
+                      ? 'ที่อยู่บริษัทสำหรับใบกำกับภาษี'
+                      : 'ที่อยู่ผู้ขาย'}
+                  </p>
                 </div>
               </div>
               <AddressForm value={supplierAddress} onChange={setSupplierAddress} label="" />

--- a/apps/web/src/pages/SuppliersPage/components/SupplierForm.tsx
+++ b/apps/web/src/pages/SuppliersPage/components/SupplierForm.tsx
@@ -10,6 +10,8 @@ export const emptyForm = {
   name: '',
   titleName: '',
   contactName: '',
+  contactPhone: '',
+  contactPosition: '',
   nickname: '',
   branchCode: '',
   phone: '',
@@ -89,8 +91,11 @@ export default function SupplierForm({
       type: nextType,
       // reset type-specific fields so stale data ไม่ค้าง
       titleName: nextType === 'INDIVIDUAL' ? form.titleName : '',
+      nickname: nextType === 'INDIVIDUAL' ? form.nickname : '',
       branchCode: nextType === 'JURISTIC' ? form.branchCode : '',
       contactName: nextType === 'JURISTIC' ? form.contactName : '',
+      contactPhone: nextType === 'JURISTIC' ? form.contactPhone : '',
+      contactPosition: nextType === 'JURISTIC' ? form.contactPosition : '',
       hasVat: nextType === 'JURISTIC' ? form.hasVat : false,
     });
   };
@@ -282,15 +287,6 @@ export default function SupplierForm({
                   />
                 </div>
                 <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">ชื่อเล่น</label>
-                  <input
-                    type="text"
-                    value={form.nickname}
-                    onChange={(e) => setForm({ ...form, nickname: e.target.value })}
-                    className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
-                  />
-                </div>
-                <div>
                   <label className="block text-xs font-medium text-foreground mb-1.5">
                     เบอร์โทรศัพท์ <span className="text-destructive">*</span>
                   </label>
@@ -317,7 +313,7 @@ export default function SupplierForm({
                     className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
                   />
                 </div>
-                <div>
+                <div className={cn(isJuristic ? 'col-span-2' : 'col-span-1')}>
                   <label className="block text-xs font-medium text-foreground mb-1.5">LINE ID</label>
                   <input
                     type="text"
@@ -326,9 +322,21 @@ export default function SupplierForm({
                     className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
                   />
                 </div>
-                <div>
+                {!isJuristic && (
+                  <div>
+                    <label className="block text-xs font-medium text-foreground mb-1.5">ชื่อเล่น</label>
+                    <input
+                      type="text"
+                      value={form.nickname}
+                      onChange={(e) => setForm({ ...form, nickname: e.target.value })}
+                      className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                    />
+                  </div>
+                )}
+                <div className="col-span-2 border-t pt-4">
                   <label className="block text-xs font-medium text-foreground mb-1.5">
-                    {isJuristic ? 'เลขประจำตัวผู้เสียภาษี' : 'เลขประจำตัวประชาชน'}
+                    {isJuristic ? 'เลขประจำตัวผู้เสียภาษี' : 'เลขประจำตัวประชาชน'}{' '}
+                    <span className="text-destructive">*</span>
                   </label>
                   <input
                     type="text"
@@ -337,53 +345,55 @@ export default function SupplierForm({
                     placeholder="X-XXXX-XXXXX-XX-X"
                     maxLength={17}
                     className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                    required
                   />
                 </div>
                 {isJuristic && (
-                  <div className="col-span-2 flex flex-col gap-4 border-t pt-4">
-                    <label className="flex items-center gap-3 cursor-pointer">
-                      <span className="text-sm font-medium text-foreground">จดทะเบียน VAT</span>
-                      <button
-                        type="button"
-                        onClick={() => setForm({ ...form, hasVat: !form.hasVat })}
-                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                          form.hasVat ? 'bg-primary' : 'bg-border'
-                        }`}
-                      >
-                        <span
-                          className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
-                            form.hasVat ? 'translate-x-6' : 'translate-x-1'
+                  <>
+                    <div className="col-span-2">
+                      <label className="block text-xs font-medium text-foreground mb-1.5">
+                        รหัสสาขา (5 หลัก) <span className="text-destructive">*</span>
+                      </label>
+                      <input
+                        type="text"
+                        value={form.branchCode}
+                        onChange={(e) =>
+                          setForm({ ...form, branchCode: formatBranchCode(e.target.value) })
+                        }
+                        placeholder="00000 = สำนักงานใหญ่"
+                        maxLength={5}
+                        inputMode="numeric"
+                        className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm font-mono transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                        required
+                      />
+                      <p className="mt-1 text-2xs text-muted-foreground">
+                        "00000" สำหรับสำนักงานใหญ่ — ใช้ในใบกำกับภาษีของผู้จด VAT
+                      </p>
+                    </div>
+                    <div className="col-span-2">
+                      <label className="flex items-center gap-3 cursor-pointer">
+                        <span className="text-sm font-medium text-foreground">จดทะเบียน VAT</span>
+                        <button
+                          type="button"
+                          onClick={() => setForm({ ...form, hasVat: !form.hasVat })}
+                          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                            form.hasVat ? 'bg-primary' : 'bg-border'
                           }`}
-                        />
-                      </button>
-                      <span
-                        className={`text-sm font-medium ${form.hasVat ? 'text-primary' : 'text-muted-foreground'}`}
-                      >
-                        {form.hasVat ? 'มี VAT (7%)' : 'ไม่มี VAT'}
-                      </span>
-                    </label>
-                    {form.hasVat && (
-                      <div>
-                        <label className="block text-xs font-medium text-foreground mb-1.5">
-                          รหัสสาขา (5 หลัก)
-                        </label>
-                        <input
-                          type="text"
-                          value={form.branchCode}
-                          onChange={(e) =>
-                            setForm({ ...form, branchCode: formatBranchCode(e.target.value) })
-                          }
-                          placeholder="00000 = สำนักงานใหญ่"
-                          maxLength={5}
-                          inputMode="numeric"
-                          className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm font-mono transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
-                        />
-                        <p className="mt-1 text-2xs text-muted-foreground">
-                          ใช้ในใบกำกับภาษี — "00000" สำหรับสำนักงานใหญ่
-                        </p>
-                      </div>
-                    )}
-                  </div>
+                        >
+                          <span
+                            className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
+                              form.hasVat ? 'translate-x-6' : 'translate-x-1'
+                            }`}
+                          />
+                        </button>
+                        <span
+                          className={`text-sm font-medium ${form.hasVat ? 'text-primary' : 'text-muted-foreground'}`}
+                        >
+                          {form.hasVat ? 'มี VAT (7%)' : 'ไม่มี VAT'}
+                        </span>
+                      </label>
+                    </div>
+                  </>
                 )}
               </div>
             </div>
@@ -398,21 +408,50 @@ export default function SupplierForm({
                   <div>
                     <h3 className="text-sm font-semibold text-foreground">ผู้ติดต่อ</h3>
                     <p className="text-xs text-muted-foreground">
-                      ชื่อพนักงาน/ฝ่ายที่ติดต่อกับเรา
+                      ชื่อพนักงาน/ฝ่ายที่ติดต่อกับเรา (ไม่บังคับ)
                     </p>
                   </div>
                 </div>
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">
-                    ชื่อ - นามสกุล <span className="text-destructive">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={form.contactName}
-                    onChange={(e) => setForm({ ...form, contactName: e.target.value })}
-                    className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
-                    required
-                  />
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="col-span-2">
+                    <label className="block text-xs font-medium text-foreground mb-1.5">
+                      ชื่อ - นามสกุล
+                    </label>
+                    <input
+                      type="text"
+                      value={form.contactName}
+                      onChange={(e) => setForm({ ...form, contactName: e.target.value })}
+                      placeholder="เช่น สมหญิง ทองคำ"
+                      className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-foreground mb-1.5">
+                      เบอร์โทร
+                    </label>
+                    <input
+                      type="text"
+                      value={form.contactPhone}
+                      onChange={(e) =>
+                        setForm({ ...form, contactPhone: formatPhone(e.target.value) })
+                      }
+                      placeholder="0XX-XXX-XXXX"
+                      maxLength={12}
+                      className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-foreground mb-1.5">
+                      ตำแหน่ง
+                    </label>
+                    <input
+                      type="text"
+                      value={form.contactPosition}
+                      onChange={(e) => setForm({ ...form, contactPosition: e.target.value })}
+                      placeholder="เช่น เซลส์, บัญชี, จัดซื้อ"
+                      className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm transition-colors hover:border-primary/50 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+                    />
+                  </div>
                 </div>
               </div>
             )}

--- a/apps/web/src/pages/SuppliersPage/components/SupplierTable.tsx
+++ b/apps/web/src/pages/SuppliersPage/components/SupplierTable.tsx
@@ -19,7 +19,9 @@ export interface Supplier {
   type: 'INDIVIDUAL' | 'JURISTIC';
   name: string;
   titleName: string | null;
-  contactName: string;
+  contactName: string | null;
+  contactPhone: string | null;
+  contactPosition: string | null;
   nickname: string | null;
   branchCode: string | null;
   phone: string;
@@ -106,6 +108,12 @@ export default function SupplierTable({
       render: (s: Supplier) => (
         <div>
           <div className="text-foreground">{s.contactName || '-'}</div>
+          {s.contactPosition && (
+            <div className="text-xs text-muted-foreground">{s.contactPosition}</div>
+          )}
+          {s.contactPhone && (
+            <div className="text-xs text-muted-foreground">{s.contactPhone}</div>
+          )}
           {s.nickname && <div className="text-xs text-muted-foreground">({s.nickname})</div>}
         </div>
       ),

--- a/apps/web/src/pages/SuppliersPage/components/SupplierTable.tsx
+++ b/apps/web/src/pages/SuppliersPage/components/SupplierTable.tsx
@@ -16,9 +16,12 @@ export interface PaymentMethod {
 
 export interface Supplier {
   id: string;
+  type: 'INDIVIDUAL' | 'JURISTIC';
   name: string;
+  titleName: string | null;
   contactName: string;
   nickname: string | null;
+  branchCode: string | null;
   phone: string;
   phoneSecondary: string | null;
   lineId: string | null;
@@ -77,9 +80,25 @@ export default function SupplierTable({
     {
       key: 'name',
       label: 'ชื่อผู้ขาย',
-      render: (s: Supplier) => (
-        <span className="font-medium text-foreground">{s.name}</span>
-      ),
+      render: (s: Supplier) => {
+        const fullName =
+          s.type === 'INDIVIDUAL' && s.titleName ? `${s.titleName} ${s.name}` : s.name;
+        return (
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Badge
+                variant={s.type === 'JURISTIC' ? 'primary' : 'secondary'}
+                appearance="light"
+                size="sm"
+                className="whitespace-nowrap"
+              >
+                {s.type === 'JURISTIC' ? 'นิติบุคคล' : 'บุคคลธรรมดา'}
+              </Badge>
+            </div>
+            <div className="font-medium text-foreground mt-0.5">{fullName}</div>
+          </div>
+        );
+      },
     },
     {
       key: 'contactName',

--- a/apps/web/src/pages/SuppliersPage/index.tsx
+++ b/apps/web/src/pages/SuppliersPage/index.tsx
@@ -84,16 +84,25 @@ export default function SuppliersPage() {
           isDefault: pm.isDefault,
         }));
 
+      const isIndividual = formData.type === 'INDIVIDUAL';
+      // For individuals, contactName = person themselves (with title if present)
+      const resolvedContactName = isIndividual
+        ? [formData.titleName, formData.name].filter(Boolean).join(' ').trim() || formData.name
+        : formData.contactName;
+
       const payload = {
+        type: formData.type,
         name: formData.name,
-        contactName: formData.contactName,
+        titleName: isIndividual ? formData.titleName || undefined : undefined,
+        contactName: resolvedContactName,
         nickname: formData.nickname || undefined,
+        branchCode: !isIndividual && formData.hasVat ? formData.branchCode || undefined : undefined,
         phone: formData.phone,
         phoneSecondary: formData.phoneSecondary || undefined,
         lineId: formData.lineId || undefined,
         address: serializedAddress || undefined,
         taxId: formData.taxId || undefined,
-        hasVat: formData.hasVat,
+        hasVat: isIndividual ? false : formData.hasVat,
         notes: formData.notes || undefined,
         paymentMethods: validPaymentMethods,
       };
@@ -136,9 +145,12 @@ export default function SuppliersPage() {
   const openEdit = (supplier: Supplier) => {
     setEditingSupplier(supplier);
     setForm({
+      type: supplier.type ?? 'JURISTIC',
       name: supplier.name,
+      titleName: supplier.titleName || '',
       contactName: supplier.contactName,
       nickname: supplier.nickname || '',
+      branchCode: supplier.branchCode || '',
       phone: supplier.phone,
       phoneSecondary: supplier.phoneSecondary || '',
       lineId: supplier.lineId || '',

--- a/apps/web/src/pages/SuppliersPage/index.tsx
+++ b/apps/web/src/pages/SuppliersPage/index.tsx
@@ -88,15 +88,17 @@ export default function SuppliersPage() {
       // For individuals, contactName = person themselves (with title if present)
       const resolvedContactName = isIndividual
         ? [formData.titleName, formData.name].filter(Boolean).join(' ').trim() || formData.name
-        : formData.contactName;
+        : formData.contactName || undefined;
 
       const payload = {
         type: formData.type,
         name: formData.name,
         titleName: isIndividual ? formData.titleName || undefined : undefined,
         contactName: resolvedContactName,
-        nickname: formData.nickname || undefined,
-        branchCode: !isIndividual && formData.hasVat ? formData.branchCode || undefined : undefined,
+        contactPhone: isIndividual ? undefined : formData.contactPhone || undefined,
+        contactPosition: isIndividual ? undefined : formData.contactPosition || undefined,
+        nickname: isIndividual ? formData.nickname || undefined : undefined,
+        branchCode: isIndividual ? undefined : formData.branchCode || undefined,
         phone: formData.phone,
         phoneSecondary: formData.phoneSecondary || undefined,
         lineId: formData.lineId || undefined,
@@ -148,7 +150,9 @@ export default function SuppliersPage() {
       type: supplier.type ?? 'JURISTIC',
       name: supplier.name,
       titleName: supplier.titleName || '',
-      contactName: supplier.contactName,
+      contactName: supplier.contactName || '',
+      contactPhone: supplier.contactPhone || '',
+      contactPosition: supplier.contactPosition || '',
       nickname: supplier.nickname || '',
       branchCode: supplier.branchCode || '',
       phone: supplier.phone,


### PR DESCRIPTION
## Summary
- เพิ่ม `SupplierType` enum (JURISTIC | INDIVIDUAL) + migration ที่ backfill existing rows เป็น JURISTIC
- Form มี type selector 2 การ์ดด้านบน เปลี่ยนแล้ว field ปรับตาม
- **นิติบุคคล**: ชื่อบริษัท, เลขผู้เสียภาษี, ผู้ติดต่อแยกการ์ด, + **รหัสสาขา 5 หลัก** (แสดงเมื่อ hasVat = true)
- **บุคคลธรรมดา**: คำนำหน้า dropdown + ชื่อ-นามสกุลรวม + เลขประชาชน (no VAT, no branch code)
- Table badge บอกประเภทในคอลัมน์ชื่อ — INDIVIDUAL แสดง title นำหน้าอัตโนมัติ

## ทำไมต้องมี รหัสสาขา
ใบกำกับภาษี (ฟอร์มของ รง.) ต้องระบุรหัสสาขาของผู้ขายเมื่อเป็นนิติบุคคลที่จด VAT — "00000" = สำนักงานใหญ่. ก่อนหน้านี้ระบบเก็บแค่ Tax ID ทำให้ใบกำกับภาษีที่ออกให้ผู้ขายสาขาอื่นๆ ผิด form

## Test plan
- [ ] `./tools/check-types.sh all` → pass (run แล้ว)
- [ ] Manual: สร้าง supplier ใหม่ทั้ง JURISTIC + INDIVIDUAL
- [ ] Manual: edit supplier เดิม (ควร default เป็น JURISTIC)
- [ ] Manual: toggle VAT → branchCode field ปรากฏ/หาย
- [ ] Manual: เปลี่ยน type หลังกรอกข้อมูลแล้ว → ฟิลด์ที่ไม่ใช้ reset
- [ ] Migration: `npx prisma migrate deploy` ที่ staging