### PR TITLE
feat(defect-exchange): เปลี่ยนเครื่องเสีย 7 วัน + active-contract guard

### DIFF
--- a/apps/api/prisma/migrations/20260505000000_add_defect_exchange/migration.sql
+++ b/apps/api/prisma/migrations/20260505000000_add_defect_exchange/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "ContractStatus" ADD VALUE 'DEFECT_EXCHANGED';
+
+-- AlterEnum
+ALTER TYPE "ProductStatus" ADD VALUE 'DEFECT_RETURN';
+
+-- AlterTable
+ALTER TABLE "contracts" ADD COLUMN "device_received_at" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -36,6 +36,7 @@ enum ContractStatus {
   EARLY_PAYOFF
   COMPLETED
   EXCHANGED
+  DEFECT_EXCHANGED
   CLOSED_BAD_DEBT
 }
 
@@ -80,6 +81,7 @@ enum ProductStatus {
   REFURBISHED
   SOLD_RESELL
   DAMAGED
+  DEFECT_RETURN
   LOST
   WRITTEN_OFF
 }
@@ -647,6 +649,10 @@ model Contract {
   // Shop warranty tracking
   shopWarrantyStartDate DateTime? @map("shop_warranty_start_date")
   shopWarrantyEndDate   DateTime? @map("shop_warranty_end_date")
+
+  // วันที่ลูกค้ารับเครื่องจริง (ใช้เป็น baseline นับ 7-day defect exchange window)
+  // Defaults to activatedAt/createdAt if not set
+  deviceReceivedAt DateTime? @map("device_received_at")
 
   @@index([customerId])
   @@index([branchId])

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { PaymentsModule } from './modules/payments/payments.module';
 // MASTER-only modules
 import { OverdueModule } from './modules/overdue/overdue.module';
 import { ExchangeModule } from './modules/exchange/exchange.module';
+import { DefectExchangeModule } from './modules/defect-exchange/defect-exchange.module';
 import { RepossessionsModule } from './modules/repossessions/repossessions.module';
 import { PurchaseOrdersModule } from './modules/purchase-orders/purchase-orders.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
@@ -123,6 +124,7 @@ import { AppCacheModule } from './cache/cache.module';
     // MASTER: Operations
     OverdueModule,
     ExchangeModule,
+    DefectExchangeModule,
     RepossessionsModule,
     PurchaseOrdersModule,
     InventoryModule,

--- a/apps/api/src/modules/contracts/contracts.controller.ts
+++ b/apps/api/src/modules/contracts/contracts.controller.ts
@@ -89,8 +89,8 @@ export class ContractsController {
 
   @Post()
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
-  create(@Body() dto: CreateContractDto, @CurrentUser() user: { id: string }) {
-    return this.contractsService.create(dto, user.id);
+  create(@Body() dto: CreateContractDto, @CurrentUser() user: { id: string; role: string }) {
+    return this.contractsService.create(dto, user.id, user.role);
   }
 
   @Patch(':id')

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Optional, NotFoundException, BadRequestException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, Logger, Optional, NotFoundException, BadRequestException, ForbiddenException, ConflictException, InternalServerErrorException } from '@nestjs/common';
 import { StructuredLoggerService } from '../../common/logger';
 import { PlanType, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -248,7 +248,28 @@ export class ContractsService {
     };
   }
 
-  async create(dto: CreateContractDto, salespersonId: string) {
+  async create(dto: CreateContractDto, salespersonId: string, salespersonRole?: string) {
+    // Block if customer already has active contract(s), unless OWNER/BRANCH_MANAGER overrides
+    const activeContracts = await this.prisma.contract.findMany({
+      where: {
+        customerId: dto.customerId,
+        deletedAt: null,
+        status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT'] },
+      },
+      select: { id: true, contractNumber: true, status: true },
+    });
+    if (activeContracts.length > 0) {
+      const canOverride = salespersonRole === 'OWNER' || salespersonRole === 'BRANCH_MANAGER';
+      if (!(canOverride && dto.overrideActiveContractCheck)) {
+        throw new ConflictException({
+          message: 'ลูกค้ายังมีสัญญาที่กำลังผ่อนอยู่ ไม่สามารถเปิดสัญญาใหม่ได้',
+          code: 'CUSTOMER_HAS_ACTIVE_CONTRACT',
+          activeContracts,
+          canOverride,
+        });
+      }
+    }
+
     // Try to find interest config by product category
     const product = await this.prisma.product.findUnique({ where: { id: dto.productId } });
     if (!product || product.deletedAt || product.status !== 'IN_STOCK') {

--- a/apps/api/src/modules/contracts/dto/contract.dto.ts
+++ b/apps/api/src/modules/contracts/dto/contract.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNumber, IsOptional, IsInt, Min, Max, Matches } from 'class-validator';
+import { IsString, IsNumber, IsOptional, IsInt, IsBoolean, Min, Max, Matches } from 'class-validator';
 
 export class CreateContractDto {
   @IsString()
@@ -46,6 +46,11 @@ export class CreateContractDto {
   @Max(31, { message: 'วันครบกำหนดชำระต้องอยู่ระหว่าง 1-31' })
   @IsOptional()
   paymentDueDay?: number;
+
+  /** OWNER/BRANCH_MANAGER อนุญาตให้ลูกค้าผ่อนซ้อนได้ (override active-contract check) */
+  @IsBoolean()
+  @IsOptional()
+  overrideActiveContractCheck?: boolean;
 }
 
 export class UpdateContractDto {

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -225,7 +225,7 @@ export class CustomersService {
   }
 
   async search(q: string) {
-    return this.prisma.customer.findMany({
+    const rows = await this.prisma.customer.findMany({
       where: {
         deletedAt: null,
         OR: [
@@ -240,10 +240,25 @@ export class CustomersService {
         phone: true,
         nationalId: true,
         _count: { select: { contracts: true } },
+        contracts: {
+          where: {
+            deletedAt: null,
+            status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT'] },
+          },
+          select: { id: true },
+        },
       },
       take: 10,
       orderBy: { name: 'asc' },
     });
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      phone: r.phone,
+      nationalId: r.nationalId,
+      _count: r._count,
+      activeContractCount: r.contracts.length,
+    }));
   }
 
   async create(dto: CreateCustomerDto) {

--- a/apps/api/src/modules/defect-exchange/defect-exchange.controller.ts
+++ b/apps/api/src/modules/defect-exchange/defect-exchange.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Post, Body, Query, UseGuards, Param } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { DefectExchangeService } from './defect-exchange.service';
+import { ExecuteDefectExchangeDto } from './dto/defect-exchange.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+
+@ApiTags('Defect Exchange')
+@ApiBearerAuth('JWT')
+@Controller('defect-exchange')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class DefectExchangeController {
+  constructor(private service: DefectExchangeService) {}
+
+  @Get('eligibility/:contractId')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
+  getEligibility(
+    @Param('contractId') contractId: string,
+    @Query('newProductId') newProductId?: string,
+  ) {
+    return this.service.checkEligibility(contractId, newProductId);
+  }
+
+  @Post('execute')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  execute(@Body() dto: ExecuteDefectExchangeDto, @CurrentUser() user: { id: string }) {
+    return this.service.execute(dto, user.id);
+  }
+
+  @Get()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  list(
+    @Query('branchId') branchId?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.service.list({ branchId, from, to });
+  }
+}

--- a/apps/api/src/modules/defect-exchange/defect-exchange.module.ts
+++ b/apps/api/src/modules/defect-exchange/defect-exchange.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DefectExchangeController } from './defect-exchange.controller';
+import { DefectExchangeService } from './defect-exchange.service';
+import { JournalModule } from '../journal/journal.module';
+
+@Module({
+  imports: [JournalModule],
+  controllers: [DefectExchangeController],
+  providers: [DefectExchangeService],
+  exports: [DefectExchangeService],
+})
+export class DefectExchangeModule {}

--- a/apps/api/src/modules/defect-exchange/defect-exchange.service.ts
+++ b/apps/api/src/modules/defect-exchange/defect-exchange.service.ts
@@ -1,0 +1,311 @@
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { ExecuteDefectExchangeDto } from './dto/defect-exchange.dto';
+import { generateContractNumber } from '../../utils/sequence.util';
+import { Decimal } from '@prisma/client/runtime/library';
+
+const DEFECT_WINDOW_DAYS = 7;
+const ELIGIBLE_CATEGORIES = ['PHONE_USED'];
+
+@Injectable()
+export class DefectExchangeService {
+  private readonly logger = new Logger(DefectExchangeService.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private journalAutoService: JournalAutoService,
+  ) {}
+
+  /**
+   * Check if a contract is eligible for 7-day defect exchange
+   * and if the replacement product matches the rules (same model + storage).
+   */
+  async checkEligibility(oldContractId: string, newProductId?: string) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: oldContractId },
+      include: {
+        product: true,
+        payments: { where: { deletedAt: null } },
+      },
+    });
+
+    if (!contract || contract.deletedAt) {
+      throw new NotFoundException('ไม่พบสัญญา');
+    }
+
+    const reasons: string[] = [];
+
+    // Must be ACTIVE
+    if (!['ACTIVE', 'OVERDUE'].includes(contract.status)) {
+      reasons.push('สัญญาต้องอยู่ในสถานะ ACTIVE เท่านั้น');
+    }
+
+    // Used phone only
+    if (!ELIGIBLE_CATEGORIES.includes(contract.product.category)) {
+      reasons.push('เปลี่ยนเครื่องได้เฉพาะมือสอง (PHONE_USED)');
+    }
+
+    // Within 7 days from deviceReceivedAt (fallback to shopWarrantyStartDate, then createdAt)
+    const baseDate = contract.deviceReceivedAt || contract.shopWarrantyStartDate || contract.createdAt;
+    const windowEnd = new Date(baseDate);
+    windowEnd.setDate(windowEnd.getDate() + DEFECT_WINDOW_DAYS);
+    const now = new Date();
+    const daysRemaining = Math.ceil((windowEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (now > windowEnd) {
+      reasons.push(`พ้นกำหนด 7 วันแล้ว (รับเครื่องเมื่อ ${baseDate.toISOString().slice(0, 10)})`);
+    }
+
+    let newProduct: { id: string; brand: string; model: string; storage: string | null; category: string; status: string } | null = null;
+    let supplierClaimEligible = false;
+
+    if (newProductId) {
+      const p = await this.prisma.product.findUnique({
+        where: { id: newProductId },
+        select: {
+          id: true, brand: true, model: true, storage: true, category: true, status: true,
+          shopWarrantyDays: true, stockInDate: true, supplierId: true,
+        },
+      });
+      if (!p || p.status !== 'IN_STOCK') {
+        reasons.push('สินค้าใหม่ไม่พร้อมจำหน่าย');
+      } else {
+        // Q2: รุ่น+ความจุต้องตรง (สีเปลี่ยนได้)
+        const oldP = contract.product;
+        if (p.brand !== oldP.brand || p.model !== oldP.model || p.storage !== oldP.storage) {
+          reasons.push(`รุ่น/ความจุ ไม่ตรงกับของเดิม (${oldP.brand} ${oldP.model} ${oldP.storage ?? ''})`);
+        }
+      }
+      newProduct = p && { id: p.id, brand: p.brand, model: p.model, storage: p.storage, category: p.category, status: p.status };
+
+      // Supplier warranty eligibility on the OLD device (for claiming back)
+      const old = contract.product;
+      if (old.supplierId && old.stockInDate && old.shopWarrantyDays) {
+        const warrantyEnd = new Date(old.stockInDate);
+        warrantyEnd.setDate(warrantyEnd.getDate() + old.shopWarrantyDays);
+        supplierClaimEligible = now <= warrantyEnd;
+      }
+    }
+
+    return {
+      eligible: reasons.length === 0,
+      reasons,
+      daysRemaining,
+      windowEnd,
+      oldContract: {
+        id: contract.id,
+        contractNumber: contract.contractNumber,
+        product: {
+          id: contract.product.id,
+          brand: contract.product.brand,
+          model: contract.product.model,
+          storage: contract.product.storage,
+          imeiSerial: contract.product.imeiSerial,
+        },
+        paidAmount: contract.payments
+          .reduce((sum, p) => sum.add(new Decimal(p.amountPaid)), new Decimal(0))
+          .toNumber(),
+      },
+      newProduct,
+      supplierClaimEligible,
+    };
+  }
+
+  /**
+   * Execute a 7-day defect exchange (MANAGER only):
+   *   - Close old contract → DEFECT_EXCHANGED
+   *   - Create new contract with IDENTICAL terms
+   *   - Transfer already-paid amounts as credit to new contract (amountPaid)
+   *   - Old product → DEFECT_RETURN
+   *   - New product → RESERVED (→ SOLD_INSTALLMENT on activate)
+   *   - Reversal journal on old + new activation journal (net zero until new activates)
+   */
+  async execute(dto: ExecuteDefectExchangeDto, userId: string) {
+    return this.prisma.$transaction(
+      async (tx) => {
+        const elig = await this.checkEligibility(dto.oldContractId, dto.newProductId);
+        if (!elig.eligible) {
+          throw new BadRequestException(`ไม่เข้าเกณฑ์: ${elig.reasons.join(', ')}`);
+        }
+
+        const oldContract = await tx.contract.findUnique({
+          where: { id: dto.oldContractId },
+          include: { product: true, payments: true },
+        });
+        if (!oldContract) throw new NotFoundException('ไม่พบสัญญา');
+
+        const newProductRec = await tx.product.findUnique({ where: { id: dto.newProductId } });
+        if (!newProductRec) throw new NotFoundException('ไม่พบสินค้าใหม่');
+
+        // Close old contract
+        await tx.contract.update({
+          where: { id: dto.oldContractId },
+          data: {
+            status: 'DEFECT_EXCHANGED',
+            notes: [oldContract.notes, `เปลี่ยนเครื่องเพราะตำหนิ: ${dto.defectReason}`].filter(Boolean).join('\n'),
+          },
+        });
+
+        // Old product → DEFECT_RETURN (so shop can decide repair vs supplier claim)
+        await tx.product.update({
+          where: { id: oldContract.productId },
+          data: { status: 'DEFECT_RETURN' },
+        });
+
+        // Reverse original activation journal to avoid double-counting revenue/receivable
+        const originalJe = await tx.journalEntry.findFirst({
+          where: { referenceType: 'CONTRACT', referenceId: oldContract.id, deletedAt: null },
+          orderBy: { createdAt: 'asc' },
+        });
+        if (originalJe) {
+          await this.journalAutoService.createReversalJournal(tx, {
+            originalEntryId: originalJe.id,
+            reason: `Defect exchange: ${oldContract.contractNumber}`,
+            userId,
+          });
+        }
+        // Also reverse COGS journal if it exists
+        const cogsJe = await tx.journalEntry.findFirst({
+          where: { referenceType: 'CONTRACT_COGS', referenceId: oldContract.id, deletedAt: null },
+          orderBy: { createdAt: 'asc' },
+        });
+        if (cogsJe) {
+          await this.journalAutoService.createReversalJournal(tx, {
+            originalEntryId: cogsJe.id,
+            reason: `Defect exchange: ${oldContract.contractNumber}`,
+            userId,
+          });
+        }
+
+        // Total paid by customer on old contract = down payment + sum of installment payments received
+        const paidInstallments = oldContract.payments
+          .filter((p) => p.status === 'PAID' || Number(p.amountPaid) > 0)
+          .reduce((sum, p) => sum.add(new Decimal(p.amountPaid)), new Decimal(0));
+
+        // Create new contract — copy terms verbatim, link to old
+        const contractNumber = await generateContractNumber(tx);
+        const newContract = await tx.contract.create({
+          data: {
+            contractNumber,
+            customerId: oldContract.customerId,
+            productId: dto.newProductId,
+            branchId: oldContract.branchId,
+            salespersonId: oldContract.salespersonId,
+            planType: oldContract.planType,
+            sellingPrice: oldContract.sellingPrice,
+            downPayment: oldContract.downPayment,
+            interestRate: oldContract.interestRate,
+            totalMonths: oldContract.totalMonths,
+            interestTotal: oldContract.interestTotal,
+            financedAmount: oldContract.financedAmount,
+            storeCommission: oldContract.storeCommission,
+            vatAmount: oldContract.vatAmount,
+            vatPct: oldContract.vatPct,
+            monthlyPayment: oldContract.monthlyPayment,
+            paymentDueDay: oldContract.paymentDueDay,
+            interestConfigId: oldContract.interestConfigId,
+            parentContractId: oldContract.id,
+            status: 'DRAFT',
+            workflowStatus: 'CREATING',
+            notes: `เปลี่ยนเครื่องจากสัญญา ${oldContract.contractNumber} (ภายใน 7 วัน)\nอาการ: ${dto.defectReason}${dto.notes ? '\n' + dto.notes : ''}`,
+          },
+        });
+
+        // Copy payment schedule from old (same dueDates, same amountDue, but reset amountPaid/status)
+        const newPayments = oldContract.payments
+          .sort((a, b) => a.installmentNo - b.installmentNo)
+          .map((p) => ({
+            contractId: newContract.id,
+            installmentNo: p.installmentNo,
+            dueDate: p.dueDate,
+            amountDue: p.amountDue,
+          }));
+        if (newPayments.length > 0) {
+          await tx.payment.createMany({ data: newPayments });
+        }
+
+        // If customer had already paid installments, credit them to new contract via creditBalance
+        if (paidInstallments.greaterThan(0)) {
+          await tx.contract.update({
+            where: { id: newContract.id },
+            data: { creditBalance: paidInstallments },
+          });
+        }
+
+        // Reserve new product (will flip to SOLD_INSTALLMENT on activation)
+        await tx.product.update({
+          where: { id: dto.newProductId },
+          data: { status: 'RESERVED' },
+        });
+
+        // Audit log
+        await tx.auditLog.create({
+          data: {
+            userId,
+            action: 'DEFECT_EXCHANGE',
+            entity: 'contract',
+            entityId: newContract.id,
+            newValue: {
+              oldContractId: oldContract.id,
+              oldContractNumber: oldContract.contractNumber,
+              newContractId: newContract.id,
+              newContractNumber: contractNumber,
+              oldProductId: oldContract.productId,
+              newProductId: dto.newProductId,
+              defectReason: dto.defectReason,
+              photoUrls: dto.photoUrls ?? [],
+              transferredCredit: paidInstallments.toNumber(),
+              supplierClaimEligible: elig.supplierClaimEligible,
+            },
+            ipAddress: '',
+          },
+        });
+
+        this.logger.log(
+          `Defect exchange: ${oldContract.contractNumber} → ${contractNumber} (credit ${paidInstallments})`,
+        );
+
+        return {
+          oldContract: {
+            id: oldContract.id,
+            contractNumber: oldContract.contractNumber,
+            status: 'DEFECT_EXCHANGED',
+          },
+          newContract: {
+            id: newContract.id,
+            contractNumber,
+            status: 'DRAFT',
+            workflowStatus: 'CREATING',
+            creditBalance: paidInstallments.toNumber(),
+          },
+          supplierClaimEligible: elig.supplierClaimEligible,
+        };
+      },
+      { isolationLevel: 'Serializable' },
+    );
+  }
+
+  /**
+   * List defect-exchange history — read from AuditLog to avoid adding a new model.
+   */
+  async list(filters: { branchId?: string; from?: string; to?: string }) {
+    const where: Record<string, unknown> = { action: 'DEFECT_EXCHANGE' };
+    if (filters.from || filters.to) {
+      where.createdAt = {
+        ...(filters.from ? { gte: new Date(filters.from) } : {}),
+        ...(filters.to ? { lte: new Date(filters.to) } : {}),
+      };
+    }
+    const rows = await this.prisma.auditLog.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+      select: {
+        id: true, createdAt: true, userId: true, entityId: true, newValue: true,
+        user: { select: { id: true, email: true, name: true } },
+      },
+    });
+    return rows;
+  }
+}

--- a/apps/api/src/modules/defect-exchange/dto/defect-exchange.dto.ts
+++ b/apps/api/src/modules/defect-exchange/dto/defect-exchange.dto.ts
@@ -1,0 +1,21 @@
+import { IsString, IsArray, IsOptional } from 'class-validator';
+
+export class ExecuteDefectExchangeDto {
+  @IsString({ message: 'กรุณาระบุสัญญาเดิม' })
+  oldContractId: string;
+
+  @IsString({ message: 'กรุณาระบุสินค้าใหม่' })
+  newProductId: string;
+
+  @IsString({ message: 'กรุณาระบุอาการเครื่องเสีย' })
+  defectReason: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  photoUrls?: string[];
+
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,6 +34,7 @@ const MigrationPage = lazy(() => import('@/pages/MigrationPage'));
 const UsersPage = lazy(() => import('@/pages/UsersPage'));
 const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
 const ExchangePage = lazy(() => import('@/pages/ExchangePage'));
+const DefectExchangePage = lazy(() => import('@/pages/DefectExchangePage'));
 const AuditLogsPage = lazy(() => import('@/pages/AuditLogsPage'));
 const FinancialAuditPage = lazy(() => import('@/pages/FinancialAuditPage'));
 const PaymentCsvImportPage = lazy(() => import('@/pages/PaymentCsvImportPage'));
@@ -417,6 +418,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER']}>
                 <ExchangePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/defect-exchange"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}>
+                <DefectExchangePage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -20,6 +20,7 @@ import {
   Banknote,
   FileText,
   RefreshCw,
+  Wrench,
   Lock,
   Receipt,
   PieChart,
@@ -203,6 +204,7 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'ติดตามหนี้', path: '/overdue', icon: AlertTriangle },
         { label: 'เปลี่ยนเครื่อง', path: '/exchange', icon: RefreshCw },
+        { label: 'เปลี่ยนเครื่องเสีย (7 วัน)', path: '/defect-exchange', icon: Wrench },
         { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
       ],
     },
@@ -327,6 +329,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'ติดตามหนี้', path: '/overdue', icon: AlertTriangle },
         { label: 'เปลี่ยนเครื่อง', path: '/exchange', icon: RefreshCw },
+        { label: 'เปลี่ยนเครื่องเสีย (7 วัน)', path: '/defect-exchange', icon: Wrench },
         { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
       ],
     },

--- a/apps/web/src/pages/ContractCreatePage/components/CustomerSelectStep.tsx
+++ b/apps/web/src/pages/ContractCreatePage/components/CustomerSelectStep.tsx
@@ -1,4 +1,6 @@
+import { AlertTriangle } from 'lucide-react';
 import { maskNationalId } from '@/utils/mask.util';
+import { useAuth } from '@/contexts/AuthContext';
 import type { Customer } from '../types';
 
 export interface CustomerSelectStepProps {
@@ -12,6 +14,8 @@ export interface CustomerSelectStepProps {
   customerCreditApproved: boolean;
   navigate: (path: string) => void;
   onOpenCustomerModal: () => void;
+  overrideActiveContractCheck: boolean;
+  setOverrideActiveContractCheck: (v: boolean) => void;
 }
 
 export function CustomerSelectStep({
@@ -25,7 +29,14 @@ export function CustomerSelectStep({
   customerCreditApproved,
   navigate,
   onOpenCustomerModal,
+  overrideActiveContractCheck,
+  setOverrideActiveContractCheck,
 }: CustomerSelectStepProps) {
+  const { user } = useAuth();
+  const canOverride = user?.role === 'OWNER' || user?.role === 'BRANCH_MANAGER';
+  const activeBlockingCount =
+    (selectedCustomer?.activeContracts ?? 0) + (selectedCustomer?.overdueContracts ?? 0);
+
   return (
     <div>
       {/* Add new customer button - at top */}
@@ -47,30 +58,69 @@ export function CustomerSelectStep({
         className="w-full px-3 py-2 border border-input rounded-lg text-sm mb-4"
       />
       <div className="grid gap-3">
-        {customers.map((c) => (
-          <div
-            key={c.id}
-            onClick={() => setSelectedCustomer(c)}
-            onDoubleClick={() => { setSelectedCustomer(c); onNext(); }}
-            className={`p-4 rounded-xl border cursor-pointer transition-all hover:shadow-sm ${selectedCustomer?.id === c.id ? 'border-primary bg-primary/5 shadow-sm' : 'border-border/60 hover:border-border bg-card'}`}
-          >
-            <div className="flex justify-between items-center">
-              <div>
-                <div className="font-medium text-sm">{c.name}</div>
-                <div className="text-xs text-muted-foreground mt-1">{c.phone}</div>
-                {c.salary && <div className="text-xs text-muted-foreground mt-1">เงินเดือน: <span className="tabular-nums font-mono">{parseFloat(c.salary).toLocaleString()}</span> ฿</div>}
-              </div>
-              <div className="text-xs text-muted-foreground font-mono">
-                {maskNationalId(c.nationalId)}
+        {customers.map((c) => {
+          const blocking = (c.activeContracts ?? 0) + (c.overdueContracts ?? 0);
+          return (
+            <div
+              key={c.id}
+              onClick={() => setSelectedCustomer(c)}
+              onDoubleClick={() => { setSelectedCustomer(c); onNext(); }}
+              className={`p-4 rounded-xl border cursor-pointer transition-all hover:shadow-sm ${selectedCustomer?.id === c.id ? 'border-primary bg-primary/5 shadow-sm' : 'border-border/60 hover:border-border bg-card'}`}
+            >
+              <div className="flex justify-between items-center">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <div className="font-medium text-sm">{c.name}</div>
+                    {blocking > 0 && (
+                      <span className="inline-flex items-center gap-1 rounded-md bg-destructive/10 text-destructive px-1.5 py-0.5 text-[10px] font-semibold border border-destructive/20">
+                        <AlertTriangle className="size-3" />
+                        กำลังผ่อน {blocking} เครื่อง
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1">{c.phone}</div>
+                  {c.salary && <div className="text-xs text-muted-foreground mt-1">เงินเดือน: <span className="tabular-nums font-mono">{parseFloat(c.salary).toLocaleString()}</span> ฿</div>}
+                </div>
+                <div className="text-xs text-muted-foreground font-mono">
+                  {maskNationalId(c.nationalId)}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
         {customers.length === 0 && (
           <div className="text-center py-8 text-muted-foreground text-sm">ไม่พบลูกค้า</div>
         )}
       </div>
 
+      {/* Active-contract warning banner */}
+      {selectedCustomer && activeBlockingCount > 0 && (
+        <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="size-5 text-destructive flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <div className="text-sm font-semibold text-destructive">
+                ลูกค้ายังมีสัญญาที่กำลังผ่อนอยู่ {activeBlockingCount} รายการ
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                ตามนโยบาย — ลูกค้าที่มีสัญญาค้างผ่อนไม่สามารถเปิดสัญญาใหม่ได้
+                {canOverride ? ' ผู้จัดการสามารถอนุมัติข้ามได้' : ' กรุณาติดต่อผู้จัดการเพื่ออนุมัติ'}
+              </div>
+              {canOverride && (
+                <label className="mt-3 flex items-center gap-2 text-xs cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={overrideActiveContractCheck}
+                    onChange={(e) => setOverrideActiveContractCheck(e.target.checked)}
+                    className="size-4 rounded border-input"
+                  />
+                  <span className="font-medium">อนุมัติผ่อนซ้อน (ในฐานะ {user?.role === 'OWNER' ? 'เจ้าของ' : 'ผู้จัดการสาขา'})</span>
+                </label>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Credit check status for selected customer */}
       {selectedCustomer && (

--- a/apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts
+++ b/apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts
@@ -24,6 +24,7 @@ export function useContractCreateData() {
   const [totalMonths, setTotalMonths] = useState(6);
   const [notes, setNotes] = useState('');
   const [paymentDueDay, setPaymentDueDay] = useState<number>(1);
+  const [overrideActiveContractCheck, setOverrideActiveContractCheck] = useState(false);
 
   const submitForReviewRef = useRef(false);
 
@@ -47,6 +48,11 @@ export function useContractCreateData() {
       setPaymentDueDay(selectedCustomer.salaryPayDay);
     }
   }, [selectedCustomer]);
+
+  // Reset override flag when customer changes
+  useEffect(() => {
+    setOverrideActiveContractCheck(false);
+  }, [selectedCustomer?.id]);
 
   // Restore draft on mount
   useEffect(() => {
@@ -324,6 +330,7 @@ export function useContractCreateData() {
         totalMonths,
         notes: notes || undefined,
         paymentDueDay,
+        ...(overrideActiveContractCheck ? { overrideActiveContractCheck: true } : {}),
       },
       pendingDocs,
     });
@@ -336,7 +343,12 @@ export function useContractCreateData() {
 
   const canNext = (sellingPrice: number, minDownPct: number, minMonths: number, maxMonths: number) => {
     if (step === 0) return !!selectedProduct;
-    if (step === 1) return !!selectedCustomer && customerCreditApproved;
+    if (step === 1) {
+      if (!selectedCustomer || !customerCreditApproved) return false;
+      const blocking = (selectedCustomer.activeContracts ?? 0) + (selectedCustomer.overdueContracts ?? 0);
+      if (blocking > 0 && !overrideActiveContractCheck) return false;
+      return true;
+    }
     if (step === 2) return downPayment >= sellingPrice * minDownPct && totalMonths >= minMonths && totalMonths <= maxMonths;
     return true;
   };
@@ -361,6 +373,8 @@ export function useContractCreateData() {
     setNotes,
     paymentDueDay,
     setPaymentDueDay,
+    overrideActiveContractCheck,
+    setOverrideActiveContractCheck,
     submitForReviewRef,
 
     // Queries

--- a/apps/web/src/pages/ContractCreatePage/index.tsx
+++ b/apps/web/src/pages/ContractCreatePage/index.tsx
@@ -114,6 +114,8 @@ export default function ContractCreatePage() {
           customerCreditApproved={data.customerCreditApproved}
           navigate={data.navigate}
           onOpenCustomerModal={() => { data.resetCustForm(); data.setShowCustomerModal(true); }}
+          overrideActiveContractCheck={data.overrideActiveContractCheck}
+          setOverrideActiveContractCheck={data.setOverrideActiveContractCheck}
         />
       )}
 

--- a/apps/web/src/pages/ContractCreatePage/types.ts
+++ b/apps/web/src/pages/ContractCreatePage/types.ts
@@ -18,6 +18,8 @@ export interface Customer {
   salary: string | null;
   occupation: string | null;
   salaryPayDay: number | null;
+  activeContracts?: number;
+  overdueContracts?: number;
 }
 
 export interface InterestConfig {

--- a/apps/web/src/pages/DefectExchangePage.tsx
+++ b/apps/web/src/pages/DefectExchangePage.tsx
@@ -1,0 +1,359 @@
+import { useState, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { AlertTriangle, CheckCircle2, ArrowRight, ShieldCheck } from 'lucide-react';
+import api, { getErrorMessage } from '@/lib/api';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { formatNumber } from '@/utils/formatters';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface ContractRow {
+  id: string;
+  contractNumber: string;
+  status: string;
+  createdAt: string;
+  deviceReceivedAt: string | null;
+  shopWarrantyStartDate: string | null;
+  customer: { id: string; name: string };
+  product: { id: string; name: string; brand: string; model: string; storage: string | null; category: string };
+}
+
+interface ProductRow {
+  id: string;
+  name: string;
+  brand: string;
+  model: string;
+  storage: string | null;
+  color: string | null;
+  status: string;
+  category: string;
+  imeiSerial: string | null;
+}
+
+interface Eligibility {
+  eligible: boolean;
+  reasons: string[];
+  daysRemaining: number;
+  windowEnd: string;
+  oldContract: {
+    id: string;
+    contractNumber: string;
+    product: { id: string; brand: string; model: string; storage: string | null; imeiSerial: string | null };
+    paidAmount: number;
+  };
+  newProduct: { id: string; brand: string; model: string; storage: string | null; category: string; status: string } | null;
+  supplierClaimEligible: boolean;
+}
+
+interface HistoryRow {
+  id: string;
+  createdAt: string;
+  user: { id: string; email: string; name: string | null } | null;
+  newValue: {
+    oldContractNumber: string;
+    newContractNumber: string;
+    defectReason: string;
+    transferredCredit: number;
+    supplierClaimEligible: boolean;
+  };
+}
+
+export default function DefectExchangePage() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const canExecute = user?.role === 'OWNER' || user?.role === 'BRANCH_MANAGER';
+
+  const [selectedContractId, setSelectedContractId] = useState('');
+  const [selectedProductId, setSelectedProductId] = useState('');
+  const [defectReason, setDefectReason] = useState('');
+  const [notes, setNotes] = useState('');
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const contractsQ = useQuery<ContractRow[]>({
+    queryKey: ['defect-exchange-contracts'],
+    queryFn: async () => {
+      const { data } = await api.get('/contracts?status=ACTIVE&limit=200');
+      const rows: ContractRow[] = data.data || [];
+      return rows.filter((c) => c.product.category === 'PHONE_USED');
+    },
+  });
+
+  const productsQ = useQuery<ProductRow[]>({
+    queryKey: ['defect-exchange-products'],
+    queryFn: async () => (await api.get('/products?status=IN_STOCK&category=PHONE_USED&limit=300')).data.data || [],
+  });
+
+  const eligibilityQ = useQuery<Eligibility>({
+    queryKey: ['defect-exchange-eligibility', selectedContractId, selectedProductId],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (selectedProductId) params.set('newProductId', selectedProductId);
+      const { data } = await api.get(`/defect-exchange/eligibility/${selectedContractId}?${params}`);
+      return data;
+    },
+    enabled: !!selectedContractId,
+  });
+
+  const historyQ = useQuery<HistoryRow[]>({
+    queryKey: ['defect-exchange-history'],
+    queryFn: async () => (await api.get('/defect-exchange')).data,
+  });
+
+  // Narrow replacement products to same brand+model+storage
+  const matchingProducts = useMemo(() => {
+    const selected = contractsQ.data?.find((c) => c.id === selectedContractId);
+    if (!selected) return [];
+    return (productsQ.data || []).filter(
+      (p) =>
+        p.brand === selected.product.brand &&
+        p.model === selected.product.model &&
+        (p.storage ?? null) === (selected.product.storage ?? null),
+    );
+  }, [contractsQ.data, productsQ.data, selectedContractId]);
+
+  const executeM = useMutation({
+    mutationFn: async () => {
+      const { data } = await api.post('/defect-exchange/execute', {
+        oldContractId: selectedContractId,
+        newProductId: selectedProductId,
+        defectReason,
+        notes: notes || undefined,
+      });
+      return data;
+    },
+    onSuccess: (data) => {
+      toast.success(`เปลี่ยนเครื่องสำเร็จ — สัญญาใหม่ ${data.newContract.contractNumber}`);
+      queryClient.invalidateQueries({ queryKey: ['defect-exchange-contracts'] });
+      queryClient.invalidateQueries({ queryKey: ['defect-exchange-products'] });
+      queryClient.invalidateQueries({ queryKey: ['defect-exchange-history'] });
+      queryClient.invalidateQueries({ queryKey: ['contracts'] });
+      setSelectedContractId('');
+      setSelectedProductId('');
+      setDefectReason('');
+      setNotes('');
+      setShowConfirm(false);
+    },
+    onError: (err: unknown) => {
+      toast.error(getErrorMessage(err));
+      setShowConfirm(false);
+    },
+  });
+
+  const elig = eligibilityQ.data;
+  const selectedContract = contractsQ.data?.find((c) => c.id === selectedContractId);
+
+  return (
+    <div>
+      <PageHeader
+        title="เปลี่ยนเครื่อง (ประกันร้าน 7 วัน)"
+        subtitle="สำหรับมือสองที่มีตำหนิภายใน 7 วันแรกหลังรับเครื่อง"
+      />
+
+      <div className="grid lg:grid-cols-2 gap-6">
+        {/* Left: Form */}
+        <Card>
+          <CardContent className="p-5 space-y-4">
+            <div>
+              <div className="text-sm font-semibold mb-2">1. เลือกสัญญาเดิม</div>
+              <QueryBoundary isLoading={contractsQ.isLoading} isError={contractsQ.isError} error={contractsQ.error} onRetry={contractsQ.refetch}>
+                <select
+                  value={selectedContractId}
+                  onChange={(e) => {
+                    setSelectedContractId(e.target.value);
+                    setSelectedProductId('');
+                  }}
+                  className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+                >
+                  <option value="">-- เลือกสัญญา --</option>
+                  {contractsQ.data?.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.contractNumber} — {c.customer.name} — {c.product.brand} {c.product.model} {c.product.storage ?? ''}
+                    </option>
+                  ))}
+                </select>
+              </QueryBoundary>
+            </div>
+
+            {selectedContract && (
+              <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-xs space-y-1">
+                <div><span className="text-muted-foreground">ลูกค้า:</span> {selectedContract.customer.name}</div>
+                <div><span className="text-muted-foreground">เครื่องเดิม:</span> {selectedContract.product.brand} {selectedContract.product.model} {selectedContract.product.storage ?? ''}</div>
+                <div><span className="text-muted-foreground">วันรับเครื่อง:</span> {(selectedContract.deviceReceivedAt || selectedContract.shopWarrantyStartDate || selectedContract.createdAt).slice(0, 10)}</div>
+              </div>
+            )}
+
+            {elig && (
+              <div
+                className={`rounded-lg border p-3 text-xs ${
+                  elig.eligible
+                    ? 'bg-success/5 border-success/30 text-success'
+                    : 'bg-destructive/5 border-destructive/30 text-destructive'
+                }`}
+              >
+                <div className="flex items-center gap-2 font-semibold mb-1">
+                  {elig.eligible ? <CheckCircle2 className="size-4" /> : <AlertTriangle className="size-4" />}
+                  {elig.eligible ? `เข้าเกณฑ์ — เหลือ ${elig.daysRemaining} วัน` : 'ไม่เข้าเกณฑ์'}
+                </div>
+                {!elig.eligible && (
+                  <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
+                    {elig.reasons.map((r, i) => (
+                      <li key={i}>{r}</li>
+                    ))}
+                  </ul>
+                )}
+                {elig.eligible && elig.supplierClaimEligible && (
+                  <div className="mt-2 flex items-center gap-1 text-primary">
+                    <ShieldCheck className="size-3.5" />
+                    เครื่องเดิมยังอยู่ในประกัน supplier — เคลมคืนได้
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div>
+              <div className="text-sm font-semibold mb-2">2. เลือกเครื่องทดแทน (รุ่น/ความจุเดียวกัน)</div>
+              <QueryBoundary isLoading={productsQ.isLoading} isError={productsQ.isError} error={productsQ.error} onRetry={productsQ.refetch}>
+                <select
+                  value={selectedProductId}
+                  onChange={(e) => setSelectedProductId(e.target.value)}
+                  disabled={!selectedContractId}
+                  className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background disabled:opacity-50"
+                >
+                  <option value="">-- เลือกเครื่องทดแทน --</option>
+                  {matchingProducts.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.brand} {p.model} {p.storage ?? ''} {p.color ? `(${p.color})` : ''} — IMEI {p.imeiSerial ?? 'ยังไม่ระบุ'}
+                    </option>
+                  ))}
+                </select>
+                {selectedContractId && matchingProducts.length === 0 && (
+                  <div className="text-xs text-destructive mt-2">ไม่มีสต็อกรุ่น/ความจุเดียวกันในขณะนี้</div>
+                )}
+              </QueryBoundary>
+            </div>
+
+            <div>
+              <div className="text-sm font-semibold mb-2">3. อาการเครื่องเสีย</div>
+              <textarea
+                value={defectReason}
+                onChange={(e) => setDefectReason(e.target.value)}
+                placeholder="เช่น หน้าจอกระพริบ, เครื่องดับเอง, แบตหมดไว..."
+                className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background min-h-[80px]"
+              />
+            </div>
+
+            <div>
+              <div className="text-sm font-semibold mb-2">หมายเหตุเพิ่มเติม</div>
+              <input
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+              />
+            </div>
+
+            {canExecute ? (
+              <Button
+                variant="primary"
+                size="lg"
+                className="w-full"
+                disabled={
+                  !elig?.eligible ||
+                  !selectedProductId ||
+                  !defectReason.trim() ||
+                  executeM.isPending
+                }
+                onClick={() => setShowConfirm(true)}
+              >
+                ดำเนินการเปลี่ยนเครื่อง
+                <ArrowRight className="size-4" />
+              </Button>
+            ) : (
+              <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+                เฉพาะ OWNER / BRANCH_MANAGER เท่านั้นที่อนุมัติเปลี่ยนเครื่องได้
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Right: History */}
+        <Card>
+          <CardContent className="p-5">
+            <div className="text-sm font-semibold mb-3">ประวัติการเปลี่ยนเครื่องล่าสุด</div>
+            <QueryBoundary isLoading={historyQ.isLoading} isError={historyQ.isError} error={historyQ.error} onRetry={historyQ.refetch}>
+              {historyQ.data && historyQ.data.length > 0 ? (
+                <div className="space-y-2">
+                  {historyQ.data.map((h) => (
+                    <div key={h.id} className="rounded-lg border border-border/60 bg-card p-3 text-xs">
+                      <div className="flex justify-between items-start">
+                        <div className="min-w-0 flex-1">
+                          <div className="font-mono font-semibold">
+                            {h.newValue.oldContractNumber} → {h.newValue.newContractNumber}
+                          </div>
+                          <div className="text-muted-foreground mt-1">{h.newValue.defectReason}</div>
+                          <div className="flex gap-3 mt-1 text-[10px] text-muted-foreground">
+                            <span>{new Date(h.createdAt).toLocaleString('th-TH')}</span>
+                            <span>โดย {h.user?.name ?? h.user?.email ?? '—'}</span>
+                          </div>
+                        </div>
+                        {h.newValue.supplierClaimEligible && (
+                          <span className="inline-flex items-center gap-1 rounded-md bg-primary/10 text-primary px-1.5 py-0.5 text-[10px] font-medium">
+                            <ShieldCheck className="size-3" />
+                            claim ได้
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-xs text-muted-foreground text-center py-8">ยังไม่มีประวัติ</div>
+              )}
+            </QueryBoundary>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Confirmation modal */}
+      {showConfirm && elig?.eligible && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+          <div className="bg-card rounded-xl max-w-md w-full p-6">
+            <div className="text-lg font-semibold mb-3">ยืนยันการเปลี่ยนเครื่อง</div>
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">สัญญาเดิม:</span>
+                <span className="font-mono">{elig.oldContract.contractNumber}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">เครื่องเดิม (IMEI):</span>
+                <span className="font-mono text-xs">{elig.oldContract.product.imeiSerial ?? '—'}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">เครื่องใหม่:</span>
+                <span>{elig.newProduct?.brand} {elig.newProduct?.model} {elig.newProduct?.storage ?? ''}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">เครดิตที่โอนไปสัญญาใหม่:</span>
+                <span className="tabular-nums font-mono">{formatNumber(elig.oldContract.paidAmount)} บาท</span>
+              </div>
+            </div>
+            <div className="mt-4 p-3 rounded-lg bg-warning/5 border border-warning/30 text-xs text-warning">
+              <AlertTriangle className="size-3.5 inline mr-1" />
+              ลูกค้าต้องเซ็นสัญญาใหม่ที่ร้านก่อนรับเครื่อง (เพื่อยืนยัน IMEI ใหม่ตามกฎหมาย)
+            </div>
+            <div className="flex gap-2 mt-4">
+              <Button variant="outline" size="lg" className="flex-1" onClick={() => setShowConfirm(false)} disabled={executeM.isPending}>
+                ยกเลิก
+              </Button>
+              <Button variant="primary" size="lg" className="flex-1" onClick={() => executeM.mutate()} disabled={executeM.isPending}>
+                {executeM.isPending ? 'กำลังดำเนินการ...' : 'ยืนยัน'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- เพิ่ม module `/defect-exchange` — MANAGER อนุมัติได้, เฉพาะ PHONE_USED, รุ่น/ความจุเดียวกัน, ไม่มียอดเพิ่ม
- Contract เพิ่ม status `DEFECT_EXCHANGED` + field `deviceReceivedAt`; Product เพิ่ม status `DEFECT_RETURN`
- ContractCreate บล็อกลูกค้าที่มีสัญญา ACTIVE อยู่แล้ว (ลด double-booking)
- Sidebar: เพิ่มเมนู "เปลี่ยนเครื่องเสีย (7 วัน)" ใน owner + finance-manager

## Test plan
- [ ] เปิดสัญญาใหม่ → ลูกค้าที่มีสัญญา ACTIVE ค้าง → ระบบบล็อก
- [ ] /defect-exchange → เลือกสัญญา ACTIVE ที่ < 7 วัน → เลือกเครื่องใหม่รุ่นเดียวกัน → MANAGER approve → สัญญา → DEFECT_EXCHANGED
- [ ] Sidebar เห็น "เปลี่ยนเครื่องเสีย (7 วัน)" ใน role OWNER + FINANCE_MANAGER เท่านั้น

🤖 Generated with [Claude Code](https://claude.com/claude-code)