### PR TITLE
fix(staff-chat): chat_rooms.status enum type mismatch → 500 บน prod

### DIFF
--- a/apps/api/prisma/migrations/20260506000000_fix_chat_rooms_status_enum/migration.sql
+++ b/apps/api/prisma/migrations/20260506000000_fix_chat_rooms_status_enum/migration.sql
@@ -1,0 +1,33 @@
+-- Fix chat_rooms.status column type mismatch.
+-- Prior migration (20260421_room_based_chat_and_warranty) intended to replace
+-- the status column but used IF NOT EXISTS / IF EXISTS guards that were no-ops,
+-- leaving the column as the legacy "ChatStatus" enum (ACTIVE/ARCHIVED/BLOCKED)
+-- while the Prisma schema declares "ChatRoomStatus" (ACTIVE/IDLE).
+-- The mismatch causes every query against chat_rooms.status to throw 500.
+
+-- 1. Create the new enum if it does not yet exist
+DO $$ BEGIN
+    CREATE TYPE "ChatRoomStatus" AS ENUM ('ACTIVE', 'IDLE');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 2. Normalize legacy values (ARCHIVED/BLOCKED → IDLE) before casting.
+--    Only rows whose current text value is not in the new enum are touched.
+UPDATE "chat_rooms"
+   SET "status" = 'IDLE'
+ WHERE "status"::text NOT IN ('ACTIVE', 'IDLE');
+
+-- 3. Swap the column type from the legacy enum to the new one.
+ALTER TABLE "chat_rooms"
+    ALTER COLUMN "status" DROP DEFAULT;
+
+ALTER TABLE "chat_rooms"
+    ALTER COLUMN "status" TYPE "ChatRoomStatus"
+        USING ("status"::text::"ChatRoomStatus");
+
+ALTER TABLE "chat_rooms"
+    ALTER COLUMN "status" SET DEFAULT 'ACTIVE';
+
+-- 4. Drop the now-unused legacy enum (no other tables reference it).
+DROP TYPE IF EXISTS "ChatStatus";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2913,12 +2913,6 @@ enum ChatPriority {
   CRITICAL
 }
 
-enum ChatStatus {
-  ACTIVE
-  ARCHIVED
-  BLOCKED
-}
-
 enum MessageRole {
   CUSTOMER
   BOT


### PR DESCRIPTION
## Summary
- Migration `20260421_room_based_chat_and_warranty` ใช้ `IF EXISTS`/`IF NOT EXISTS` กับ column ที่ชื่อไม่ตรง → no-op จริง
- ฐานข้อมูลเหลือ column type = `ChatStatus` (ACTIVE/ARCHIVED/BLOCKED) แต่ Prisma schema บอกเป็น `ChatRoomStatus` (ACTIVE/IDLE)
- ทุก query ที่ filter `status` (เช่น `staff-chat/unread-count`) → 500 บน prod
- Fix: migration ใหม่ normalize ค่า + swap type + drop enum เก่า + ลบ declaration ที่กำพร้า

## Test plan
- [ ] Deploy → `/api/staff-chat/unread-count` ต้องคืน 200 (ไม่ใช่ 500)
- [ ] หน้าแชทโหลด rooms list ได้ปกติ
- [ ] ทดสอบ migration rollback/re-apply (dev DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)