### PR TITLE
fix(migration): แก้ลำดับ cast enum ใน chat_rooms.status migration (deploy unblock)

### DIFF
--- a/apps/api/prisma/migrations/20260506000000_fix_chat_rooms_status_enum/migration.sql
+++ b/apps/api/prisma/migrations/20260506000000_fix_chat_rooms_status_enum/migration.sql
@@ -12,22 +12,28 @@ EXCEPTION
     WHEN duplicate_object THEN NULL;
 END $$;
 
--- 2. Normalize legacy values (ARCHIVED/BLOCKED → IDLE) before casting.
---    Only rows whose current text value is not in the new enum are touched.
-UPDATE "chat_rooms"
-   SET "status" = 'IDLE'
- WHERE "status"::text NOT IN ('ACTIVE', 'IDLE');
-
--- 3. Swap the column type from the legacy enum to the new one.
+-- 2. Drop default so the column type can be changed
 ALTER TABLE "chat_rooms"
     ALTER COLUMN "status" DROP DEFAULT;
 
+-- 3. Cast column to TEXT first, so we can freely rewrite values
+--    (UPDATE cannot set 'IDLE' while the column is still the legacy enum).
+ALTER TABLE "chat_rooms"
+    ALTER COLUMN "status" TYPE TEXT USING "status"::text;
+
+-- 4. Normalize legacy values (ARCHIVED/BLOCKED/anything else → IDLE)
+UPDATE "chat_rooms"
+   SET "status" = 'IDLE'
+ WHERE "status" NOT IN ('ACTIVE', 'IDLE');
+
+-- 5. Swap TEXT → new enum
 ALTER TABLE "chat_rooms"
     ALTER COLUMN "status" TYPE "ChatRoomStatus"
-        USING ("status"::text::"ChatRoomStatus");
+        USING "status"::"ChatRoomStatus";
 
+-- 6. Restore default
 ALTER TABLE "chat_rooms"
     ALTER COLUMN "status" SET DEFAULT 'ACTIVE';
 
--- 4. Drop the now-unused legacy enum (no other tables reference it).
+-- 7. Drop the now-unused legacy enum (no other tables reference it).
 DROP TYPE IF EXISTS "ChatStatus";


### PR DESCRIPTION
## Summary
Migration เดิม (#517) พยายาม `UPDATE status = 'IDLE'` ก่อน cast column type → fail เพราะ column ยังเป็น `ChatStatus` ซึ่งไม่มี value `'IDLE'`:
```
ERROR: invalid input value for enum "ChatStatus": "IDLE"
```

Fix: cast column → TEXT ก่อน → UPDATE legacy values → cast TEXT → `ChatRoomStatus` → restore default → drop old enum

**Safety**: prod DB **ไม่เคย** รัน migration นี้สำเร็จ (deploy ล้มที่ CI test DB — `DATABASE_URL=localhost:5432/test_db`) — แก้ไฟล์ในที่เดิมปลอดภัย ไม่ต้องจัดการ `_prisma_migrations` บน prod

## Test plan
- [ ] CI `Lint & Test` ผ่าน (migration deploy บน test_db สำเร็จ)
- [ ] Deploy to GCP ผ่าน
- [ ] หลัง deploy — `/api/staff-chat/unread-count` คืน 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)