### PR TITLE
fix(tests): mock contract.findMany = [] ใน describe(create) (deploy unblock)

### DIFF
--- a/apps/api/src/modules/contracts/contracts.service.spec.ts
+++ b/apps/api/src/modules/contracts/contracts.service.spec.ts
@@ -353,6 +353,12 @@ describe('ContractsService', () => {
       totalMonths: 12,
     };
 
+    // The active-contract guard runs before all create-path validations.
+    // Default mock to "no active contracts" so these tests exercise downstream logic.
+    beforeEach(() => {
+      prisma.contract.findMany.mockResolvedValue([]);
+    });
+
     it('throws BadRequestException when product does not exist', async () => {
       prisma.product.findUnique.mockResolvedValue(null);
       await expect(service.create(validDto, 'user-1')).rejects.toBeInstanceOf(BadRequestException);


### PR DESCRIPTION
## Summary
PR #516 เพิ่ม active-contract guard ใน `contracts.service.create()` — เรียก `prisma.contract.findMany` ก่อน validation path เดิม

Default mock ใน spec คืน `[mockContract]` → guard throw `ConflictException: ลูกค้ายังมีสัญญาที่กำลังผ่อนอยู่ ไม่สามารถเปิดสัญญาใหม่ได้` → 13 tests ใน `describe('create')` ล้ม → block `Lint & Test` → block deploy

**Fix**: `beforeEach()` ภายใน `describe('create')` reset `findMany` → `[]` — tests ใน `findAll` ยังใช้ default mock เดิม

Local: `npx jest contracts.service.spec.ts` → 36/36 passed

## Test plan
- [ ] CI Lint & Test ผ่าน
- [ ] Deploy to GCP ผ่าน

🤖 Generated with [Claude Code](https://claude.com/claude-code)