### PR TITLE
fix(fraud-audit): Phase 1 quickwins — ปิดช่องโหว่ 8 จุด (OTP / SoD / roles / migrations)

### DIFF
--- a/apps/api/prisma/migrations/20260520000000_deactivate_legacy_import_user/migration.sql
+++ b/apps/api/prisma/migrations/20260520000000_deactivate_legacy_import_user/migration.sql
@@ -1,0 +1,15 @@
+-- T7-W9: Deactivate the legacy-import service account
+-- This user was created by scripts/import-legacy/index.ts for historical data
+-- import (used as the `createdById` FK for imported rows). The import job is
+-- finished and the account should not be usable for login any more.
+--
+-- We do NOT delete the row because imported records still reference its id.
+-- Instead: is_active = false so the login path rejects it, and the password
+-- is rotated to a value that cannot be matched by any bcrypt input.
+
+UPDATE "users"
+SET
+  is_active = false,
+  password = 'DISABLED_SERVICE_ACCOUNT_NOT_LOGIN_CAPABLE',
+  updated_at = NOW()
+WHERE email = 'legacy-import@bestchoice.com';

--- a/apps/api/prisma/migrations/20260520100000_add_customer_referral_awarded_at/migration.sql
+++ b/apps/api/prisma/migrations/20260520100000_add_customer_referral_awarded_at/migration.sql
@@ -1,0 +1,31 @@
+-- T6-C2: Add an atomic idempotency marker for referral point awards.
+--
+-- Background: awardReferralPoints() previously checked LoyaltyPoint rows that
+-- are never created for referrals, so retries or concurrent calls could award
+-- points more than once (race condition flagged during the fraud audit).
+--
+-- Fix: move the idempotency check into a single atomic UPDATE on the
+-- referred customer's row. The point-credit transaction is guarded by
+-- `referralAwardedAt IS NULL`; only the first caller wins.
+
+ALTER TABLE "customers"
+ADD COLUMN "referral_awarded_at" TIMESTAMP(3);
+
+-- Backfill: for any referred customer who already has at least one contract
+-- in the system, assume the referral was already awarded and mark it using
+-- the first contract's created_at so a new call cannot double-credit.
+-- Contract has no dedicated activation timestamp, so created_at is the
+-- closest proxy available in the schema.
+UPDATE "customers" c
+SET "referral_awarded_at" = sub.created_at
+FROM (
+  SELECT DISTINCT ON (co.customer_id)
+    co.customer_id,
+    co.created_at
+  FROM "contracts" co
+  WHERE co.deleted_at IS NULL
+  ORDER BY co.customer_id, co.created_at ASC
+) sub
+WHERE c.id = sub.customer_id
+  AND c.referred_by_id IS NOT NULL
+  AND c.deleted_at IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -485,9 +485,13 @@ model Customer {
   guardianAddress    String? @map("guardian_address")
 
   // Referral — ลูกค้าที่แนะนำมา
-  referredById String?    @map("referred_by_id")
-  referredBy   Customer?  @relation("Referral", fields: [referredById], references: [id])
-  referrals    Customer[] @relation("Referral")
+  referredById      String?    @map("referred_by_id")
+  referredBy        Customer?  @relation("Referral", fields: [referredById], references: [id])
+  referrals         Customer[] @relation("Referral")
+  // Atomic idempotency marker for awardReferralPoints. Set inside the same
+  // transaction that credits points to the referrer, so retries/races cannot
+  // award twice. NULL = not yet awarded.
+  referralAwardedAt DateTime?  @map("referral_awarded_at")
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime  @updatedAt @map("updated_at")

--- a/apps/api/src/modules/commission/commission.service.spec.ts
+++ b/apps/api/src/modules/commission/commission.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Prisma } from '@prisma/client';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CommissionService } from './commission.service';
 import { PrismaService } from '../../prisma/prisma.service';
 
@@ -21,6 +21,10 @@ describe('CommissionService', () => {
       commissionRule: {
         create: jest.fn(),
         findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      commissionPayout: {
         findFirst: jest.fn(),
         update: jest.fn(),
       },
@@ -209,6 +213,19 @@ describe('CommissionService', () => {
       await expect(service.approve('c1', 'u1')).rejects.toBeInstanceOf(BadRequestException);
     });
 
+    it('refuses self-approval (Segregation of Duties — salesperson cannot approve own commission)', async () => {
+      prisma.salesCommission.findFirst.mockResolvedValue({
+        id: 'c1',
+        status: 'PENDING',
+        salespersonId: 'salesperson-1',
+      });
+
+      await expect(service.approve('c1', 'salesperson-1')).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(prisma.salesCommission.update).not.toHaveBeenCalled();
+    });
+
     it('flips PENDING to APPROVED with approver and timestamp', async () => {
       prisma.salesCommission.findFirst.mockResolvedValue({ id: 'c1', status: 'PENDING' });
       prisma.salesCommission.update.mockImplementation(
@@ -297,6 +314,73 @@ describe('CommissionService', () => {
 
       const result = await service.findAll({ page: 1, limit: 50 });
       expect(result).toEqual({ data: [], total: 0, page: 1, limit: 50, totalPages: 0 });
+    });
+  });
+
+  // Segregation of Duties on commission payout approval.
+  // Prevents the salesperson who earns a payout from self-approving it.
+  describe('approvePayout — Segregation of Duties', () => {
+    const draftPayout = {
+      id: 'payout-1',
+      salespersonId: 'salesperson-1',
+      status: 'DRAFT',
+      deletedAt: null,
+    };
+
+    it('throws ForbiddenException if approver is the salesperson (SoD violation)', async () => {
+      prisma.commissionPayout.findFirst.mockResolvedValue(draftPayout);
+
+      await expect(
+        service.approvePayout('payout-1', 'salesperson-1', { notes: 'self-approve attempt' }),
+      ).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.approvePayout('payout-1', 'salesperson-1', { notes: 'self-approve attempt' }),
+      ).rejects.toThrow(/Segregation of Duties|ห้ามอนุมัติ/);
+
+      // Must not call update when SoD violated
+      expect(prisma.commissionPayout.update).not.toHaveBeenCalled();
+    });
+
+    it('allows approval when approver is a different user from the salesperson', async () => {
+      prisma.commissionPayout.findFirst.mockResolvedValue(draftPayout);
+      prisma.commissionPayout.update.mockResolvedValue({
+        ...draftPayout,
+        status: 'APPROVED',
+        approvedById: 'manager-1',
+        approvedAt: new Date(),
+      });
+
+      const result = await service.approvePayout('payout-1', 'manager-1', { notes: 'ok' });
+
+      expect(result.status).toBe('APPROVED');
+      expect(prisma.commissionPayout.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'payout-1' },
+          data: expect.objectContaining({
+            status: 'APPROVED',
+            approvedById: 'manager-1',
+          }),
+        }),
+      );
+    });
+
+    it('throws NotFoundException when payout does not exist', async () => {
+      prisma.commissionPayout.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.approvePayout('missing', 'manager-1', {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when payout is not in DRAFT status', async () => {
+      prisma.commissionPayout.findFirst.mockResolvedValue({
+        ...draftPayout,
+        status: 'APPROVED',
+      });
+
+      await expect(
+        service.approvePayout('payout-1', 'manager-1', {}),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/apps/api/src/modules/commission/commission.service.ts
+++ b/apps/api/src/modules/commission/commission.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, NotFoundException, BadRequestException, ConflictException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateCommissionRuleDto, UpdateCommissionRuleDto } from './dto/commission.dto';
@@ -148,6 +154,14 @@ export class CommissionService {
     if (!commission) throw new NotFoundException('ไม่พบข้อมูลค่าคอมมิชชัน');
     if (commission.status !== 'PENDING') {
       throw new BadRequestException('สามารถอนุมัติได้เฉพาะรายการที่รอดำเนินการเท่านั้น');
+    }
+
+    // Segregation of Duties — salesperson who earns the commission must not
+    // self-approve. Mirrors the same guard in approvePayout() below.
+    if (commission.salespersonId === userId) {
+      throw new ForbiddenException(
+        'ผู้อนุมัติต้องไม่ใช่ผู้รับคอมมิชชัน (Segregation of Duties)',
+      );
     }
 
     return this.prisma.salesCommission.update({
@@ -398,6 +412,14 @@ export class CommissionService {
     if (!payout) throw new NotFoundException('ไม่พบใบจ่ายคอมมิชชัน');
     if (payout.status !== 'DRAFT') {
       throw new BadRequestException('สามารถอนุมัติได้เฉพาะรายการที่อยู่ในสถานะ DRAFT เท่านั้น');
+    }
+
+    // Segregation of Duties — salesperson who earns the payout must not
+    // self-approve. Mirrors bad-debt write-off guard.
+    if (payout.salespersonId === userId) {
+      throw new ForbiddenException(
+        'ผู้อนุมัติต้องไม่ใช่ผู้รับคอมมิชชัน (Segregation of Duties)',
+      );
     }
 
     return this.prisma.commissionPayout.update({

--- a/apps/api/src/modules/credit-check/credit-check.service.ts
+++ b/apps/api/src/modules/credit-check/credit-check.service.ts
@@ -918,7 +918,10 @@ export class CreditCheckService {
     });
 
     const response = await client.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      // Keep in sync with the Sonnet ID used in finance-ai.service.ts and ocr.service.ts.
+      // Mismatch (`claude-sonnet-4-20250514`) previously caused the API call to fail
+      // and silently fall back to rule-based scoring with no alert.
+      model: 'claude-sonnet-4-5-20250514',
       max_tokens: 1024,
       messages: [{ role: 'user', content: contentBlocks }],
     });

--- a/apps/api/src/modules/dashboard/dashboard.controller.spec.ts
+++ b/apps/api/src/modules/dashboard/dashboard.controller.spec.ts
@@ -1,0 +1,35 @@
+import { Reflector } from '@nestjs/core';
+import { DashboardController } from './dashboard.controller';
+import { ROLES_KEY } from '../auth/decorators/roles.decorator';
+
+describe('DashboardController — @Roles metadata', () => {
+  const reflector = new Reflector();
+
+  it('excludes SALES from the class-level Roles list', () => {
+    const classRoles = reflector.get<string[]>(ROLES_KEY, DashboardController);
+    expect(classRoles).toBeDefined();
+    expect(classRoles).not.toContain('SALES');
+    expect(classRoles).toEqual(
+      expect.arrayContaining(['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']),
+    );
+  });
+
+  it('never allows SALES on any dashboard handler (direct or inherited)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proto = DashboardController.prototype as any;
+    const handlerNames = Object.getOwnPropertyNames(proto).filter(
+      (name) => name !== 'constructor',
+    );
+
+    for (const name of handlerNames) {
+      const handler = proto[name];
+      if (typeof handler !== 'function') continue;
+
+      const methodRoles = reflector.get<string[]>(ROLES_KEY, handler);
+      const classRoles = reflector.get<string[]>(ROLES_KEY, DashboardController);
+      const effectiveRoles = methodRoles ?? classRoles ?? [];
+
+      expect(effectiveRoles).not.toContain('SALES');
+    }
+  });
+});

--- a/apps/api/src/modules/dashboard/dashboard.controller.ts
+++ b/apps/api/src/modules/dashboard/dashboard.controller.ts
@@ -11,7 +11,11 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 @ApiBearerAuth('JWT')
 @Controller('dashboard')
 @UseGuards(JwtAuthGuard, RolesGuard, BranchGuard)
-@Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+// SALES is intentionally excluded from the dashboard — all metrics here
+// expose collection / credit / financial intelligence that falls outside
+// a salesperson's need-to-know and could be abused for pricing leverage.
+// Reports controller follows the same rule.
+@Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
 export class DashboardController {
   constructor(private dashboardService: DashboardService) {}
 
@@ -127,7 +131,9 @@ export class DashboardController {
     branchId: string | undefined,
     user: { role: string; branchId: string | null },
   ): string | undefined {
-    return user.role === 'SALES' || user.role === 'BRANCH_MANAGER'
+    // BRANCH_MANAGER is always scoped to own branch; cross-branch roles
+    // (OWNER / FINANCE_MANAGER / ACCOUNTANT) may pass any branchId filter.
+    return user.role === 'BRANCH_MANAGER'
       ? user.branchId || undefined
       : branchId || undefined;
   }

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,6 +1,17 @@
-import { Controller, Get, HttpCode, HttpStatus, ServiceUnavailableException } from '@nestjs/common';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  ServiceUnavailableException,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { Public } from '../auth/decorators/public.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ConfigService } from '@nestjs/config';
 
@@ -9,9 +20,12 @@ interface CheckResult {
   message?: string;
 }
 
-interface HealthResponse {
+interface PublicHealthResponse {
   status: 'ok' | 'error';
   timestamp: string;
+}
+
+interface DetailedHealthResponse extends PublicHealthResponse {
   checks: {
     database: CheckResult;
     storage: CheckResult;
@@ -19,16 +33,14 @@ interface HealthResponse {
 }
 
 /**
- * HealthController — liveness / readiness probe for Cloud Run & load balancers.
+ * HealthController
  *
- * GET /api/health
- *   - Public (no auth required) — suitable as a Cloud Run liveness probe.
- *   - Returns 200 { status: 'ok', ... } when all checks pass.
- *   - Returns 503 { status: 'error', ... } when any check fails.
- *   - Excluded from global ResponseInterceptor envelope via the raw response shape
- *     (NestJS does NOT wrap 503 exceptions, and we throw ServiceUnavailableException
- *     only on failure, so the happy-path 200 is still wrapped — callers should read
- *     `data.status` or check HTTP status code, not the envelope `success` field).
+ * GET /api/health           — public liveness probe (minimal response so we
+ *                             don't leak which backends are deployed or why a
+ *                             check failed).
+ * GET /api/health/detailed  — OWNER / FINANCE_MANAGER only. Returns per-check
+ *                             messages (env var names, DB errors) that are
+ *                             useful for ops but should not be public.
  */
 @ApiTags('Health')
 @Controller('health')
@@ -41,31 +53,59 @@ export class HealthController {
   @Public()
   @Get()
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Health check — database + storage', description: 'Public liveness probe' })
-  async check(): Promise<HealthResponse> {
+  @ApiOperation({
+    summary: 'Public liveness probe',
+    description: 'Returns 200 {status:"ok"} or 503 {status:"error"}. No internal details.',
+  })
+  async check(): Promise<PublicHealthResponse> {
     const timestamp = new Date().toISOString();
-
     const [dbCheck, storageCheck] = await Promise.all([
       this.checkDatabase(),
       this.checkStorage(),
     ]);
 
     const allOk = dbCheck.status === 'ok' && storageCheck.status === 'ok';
-
-    const response: HealthResponse = {
+    const response: PublicHealthResponse = {
       status: allOk ? 'ok' : 'error',
       timestamp,
-      checks: {
-        database: dbCheck,
-        storage: storageCheck,
-      },
     };
 
     if (!allOk) {
-      // Throw so NestJS returns HTTP 503; the exception body carries our JSON
+      // Public callers get status only — never the message field.
       throw new ServiceUnavailableException(response);
     }
+    return response;
+  }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  @ApiBearerAuth('JWT')
+  @Get('detailed')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Detailed health check (auth required)',
+    description: 'Full per-check messages. OWNER / FINANCE_MANAGER only.',
+  })
+  async checkDetailed(): Promise<DetailedHealthResponse> {
+    const timestamp = new Date().toISOString();
+    const [dbCheck, storageCheck] = await Promise.all([
+      this.checkDatabase(),
+      this.checkStorage(),
+    ]);
+
+    const allOk = dbCheck.status === 'ok' && storageCheck.status === 'ok';
+    const response: DetailedHealthResponse = {
+      status: allOk ? 'ok' : 'error',
+      timestamp,
+      checks: { database: dbCheck, storage: storageCheck },
+    };
+
+    if (!allOk) {
+      // Use HttpException (not ServiceUnavailableException) so the full
+      // response shape — including checks.*.message — is preserved in the
+      // 503 body for ops debugging.
+      throw new HttpException(response, HttpStatus.SERVICE_UNAVAILABLE);
+    }
     return response;
   }
 
@@ -84,20 +124,14 @@ export class HealthController {
   }
 
   private checkStorage(): CheckResult {
-    // We verify that the four required S3 env vars are present and non-empty.
-    // A missing var means no uploads will work, which is treated as unhealthy.
-    // We avoid making a live HeadBucket call here to keep latency minimal and
-    // avoid coupling the probe to network I/O that could flap independently.
     const required = ['S3_ENDPOINT', 'S3_ACCESS_KEY', 'S3_SECRET_KEY', 'S3_BUCKET'];
     const missing = required.filter((key) => !this.configService.get<string>(key));
-
     if (missing.length > 0) {
       return {
         status: 'error',
         message: `missing env vars: ${missing.join(', ')}`,
       };
     }
-
     return { status: 'ok' };
   }
 }

--- a/apps/api/src/modules/kyc/kyc.service.spec.ts
+++ b/apps/api/src/modules/kyc/kyc.service.spec.ts
@@ -194,42 +194,72 @@ describe('KycService', () => {
       );
     });
 
-    it('should auto-accept any OTP in dev mode (NODE_ENV !== production)', async () => {
-      // In dev mode, verifyOtp auto-accepts any OTP code and returns verified: true
-      prisma.kycVerification.findFirst.mockResolvedValueOnce({
+    it('should reject invalid OTP in all environments (no dev bypass)', async () => {
+      // Security regression guard — invalid OTP must always be rejected,
+      // never silently accepted in non-prod environments.
+      prisma.kycVerification.findFirst.mockResolvedValue({
         ...mockKycRecord,
         otpHash: 'correct-hash-that-wont-match',
       });
 
-      const result = await service.verifyOtp('contract-1', 'wrong');
-      expect(result.verified).toBe(true);
-      expect(prisma.kycVerification.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ status: 'OTP_VERIFIED' }),
-        }),
-      );
+      await expect(service.verifyOtp('contract-1', 'wrong')).rejects.toThrow(BadRequestException);
+      await expect(service.verifyOtp('contract-1', 'wrong')).rejects.toThrow(/OTP ไม่ถูกต้อง/);
     });
 
-    it('should auto-accept even with expired OTP in dev mode', async () => {
-      // In dev mode, expiry and hash checks are skipped entirely
-      prisma.kycVerification.findFirst.mockResolvedValueOnce({
+    it('should throw when OTP expired (in all environments)', async () => {
+      // T3-C1 fix: expiry check runs regardless of NODE_ENV
+      prisma.kycVerification.findFirst.mockResolvedValue({
         ...mockKycRecord,
         expiresAt: new Date(Date.now() - 1000), // expired
       });
 
-      const result = await service.verifyOtp('contract-1', '123456');
-      expect(result.verified).toBe(true);
+      await expect(service.verifyOtp('contract-1', '123456')).rejects.toThrow(BadRequestException);
+      await expect(service.verifyOtp('contract-1', '123456')).rejects.toThrow(/หมดอายุ/);
     });
 
-    it('should auto-accept even when max attempts reached in dev mode', async () => {
-      // In dev mode, attempt count is not checked
-      prisma.kycVerification.findFirst.mockResolvedValueOnce({
+    it('should throw when max attempts reached (in all environments)', async () => {
+      // T3-C1 fix: attempt count check runs regardless of NODE_ENV
+      prisma.kycVerification.findFirst.mockResolvedValue({
         ...mockKycRecord,
         otpAttempts: 5,
       });
 
-      const result = await service.verifyOtp('contract-1', '123456');
-      expect(result.verified).toBe(true);
+      await expect(service.verifyOtp('contract-1', '123456')).rejects.toThrow(BadRequestException);
+      await expect(service.verifyOtp('contract-1', '123456')).rejects.toThrow(/เกินจำนวน/);
+    });
+
+    it('should increment otpAttempts on wrong OTP', async () => {
+      // T3-C1 fix: verify attempt counter increments correctly (no dev bypass short-circuits this)
+      prisma.kycVerification.findFirst.mockResolvedValueOnce({
+        ...mockKycRecord,
+        otpHash: 'correct-hash-that-wont-match',
+        otpAttempts: 2,
+      });
+
+      await expect(service.verifyOtp('contract-1', 'wrong')).rejects.toThrow(BadRequestException);
+      expect(prisma.kycVerification.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ otpAttempts: 3 }),
+        }),
+      );
+    });
+
+    it('should NOT bypass OTP even if NODE_ENV is development', async () => {
+      // T3-C1 security regression guard: prevent accidentally reintroducing the DEV bypass.
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      try {
+        prisma.kycVerification.findFirst.mockResolvedValueOnce({
+          ...mockKycRecord,
+          otpHash: 'correct-hash-that-wont-match',
+        });
+
+        await expect(service.verifyOtp('contract-1', 'anything')).rejects.toThrow(
+          BadRequestException,
+        );
+      } finally {
+        process.env.NODE_ENV = originalEnv;
+      }
     });
 
     it('should throw when no pending KYC record found', async () => {

--- a/apps/api/src/modules/kyc/kyc.service.ts
+++ b/apps/api/src/modules/kyc/kyc.service.ts
@@ -141,15 +141,9 @@ export class KycService {
     });
     if (!kyc) throw new BadRequestException('ไม่พบ OTP ที่รอยืนยัน กรุณาส่ง OTP ใหม่');
 
-    // Dev mode: accept any OTP code
-    if (process.env.NODE_ENV !== 'production') {
-      this.logger.warn(`[KYC-DEV] Auto-accepting OTP for contract ${contractId}`);
-      await this.prisma.kycVerification.update({
-        where: { id: kyc.id },
-        data: { otpVerifiedAt: new Date(), status: 'OTP_VERIFIED' },
-      });
-      return { verified: true, message: 'OTP ถูกต้อง (dev mode)' };
-    }
+    // OTP must always be validated via hash + expiry + attempt count,
+    // even in non-production environments, to prevent accidental auth bypass
+    // if NODE_ENV is mis-set in prod.
 
     // Check expiry
     if (new Date() > kyc.expiresAt) {

--- a/apps/api/src/modules/loyalty/loyalty.service.spec.ts
+++ b/apps/api/src/modules/loyalty/loyalty.service.spec.ts
@@ -1,0 +1,127 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoyaltyService } from './loyalty.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('LoyaltyService.awardReferralPoints — race-safe idempotency', () => {
+  let service: LoyaltyService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  // Shared tx mock so we can assert both updateMany + update in one transaction.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let txUpdateMany: jest.Mock<any, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let txUpdate: jest.Mock<any, any>;
+
+  beforeEach(async () => {
+    txUpdateMany = jest.fn();
+    txUpdate = jest.fn();
+
+    prisma = {
+      customer: {
+        findUnique: jest.fn(),
+      },
+      $transaction: jest.fn(
+        async (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cb: (tx: any) => Promise<unknown>,
+        ) => cb({ customer: { updateMany: txUpdateMany, update: txUpdate } }),
+      ),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [LoyaltyService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(LoyaltyService);
+  });
+
+  it('credits the referrer exactly once when called for the first time', async () => {
+    prisma.customer.findUnique
+      .mockResolvedValueOnce({
+        id: 'referred-1',
+        referredById: 'referrer-1',
+        referralAwardedAt: null,
+        deletedAt: null,
+      })
+      .mockResolvedValueOnce({ id: 'referrer-1', deletedAt: null });
+    txUpdateMany.mockResolvedValue({ count: 1 }); // we won the race
+    txUpdate.mockResolvedValue({ id: 'referrer-1' });
+
+    await service.awardReferralPoints('referred-1');
+
+    expect(txUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'referred-1', referralAwardedAt: null },
+      data: { referralAwardedAt: expect.any(Date) },
+    });
+    expect(txUpdate).toHaveBeenCalledTimes(1);
+    expect(txUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'referrer-1' },
+        data: { loyaltyBalance: { increment: service.referralPoints } },
+      }),
+    );
+  });
+
+  it('does NOT credit again when referralAwardedAt is already set (fast path)', async () => {
+    prisma.customer.findUnique.mockResolvedValueOnce({
+      id: 'referred-1',
+      referredById: 'referrer-1',
+      referralAwardedAt: new Date('2026-01-01'),
+      deletedAt: null,
+    });
+
+    await service.awardReferralPoints('referred-1');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(txUpdateMany).not.toHaveBeenCalled();
+    expect(txUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT credit when a concurrent caller already claimed the award (race loser)', async () => {
+    // findUnique returns the row as still unclaimed (stale read), but by the
+    // time we run the atomic UPDATE another caller has already claimed it —
+    // simulated by count: 0 from updateMany.
+    prisma.customer.findUnique
+      .mockResolvedValueOnce({
+        id: 'referred-1',
+        referredById: 'referrer-1',
+        referralAwardedAt: null,
+        deletedAt: null,
+      })
+      .mockResolvedValueOnce({ id: 'referrer-1', deletedAt: null });
+    txUpdateMany.mockResolvedValue({ count: 0 }); // someone else got there first
+
+    await service.awardReferralPoints('referred-1');
+
+    expect(txUpdateMany).toHaveBeenCalledTimes(1);
+    expect(txUpdate).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the customer has no referrer', async () => {
+    prisma.customer.findUnique.mockResolvedValueOnce({
+      id: 'referred-1',
+      referredById: null,
+      referralAwardedAt: null,
+      deletedAt: null,
+    });
+
+    await service.awardReferralPoints('referred-1');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the referrer has been soft-deleted', async () => {
+    prisma.customer.findUnique
+      .mockResolvedValueOnce({
+        id: 'referred-1',
+        referredById: 'referrer-1',
+        referralAwardedAt: null,
+        deletedAt: null,
+      })
+      .mockResolvedValueOnce({ id: 'referrer-1', deletedAt: new Date() });
+
+    await service.awardReferralPoints('referred-1');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/loyalty/loyalty.service.ts
+++ b/apps/api/src/modules/loyalty/loyalty.service.ts
@@ -320,72 +320,54 @@ export class LoyaltyService {
   // ─── Award referral points (called by CustomerService on contract activation) ─
 
   /**
-   * Award REFERRAL_POINTS (500) to referrer if referredById is set on the customer.
-   * Idempotent: no-op if referrer already received referral points for this customer.
+   * Award REFERRAL_POINTS (500) to the referrer if referredById is set on the
+   * customer. The atomic idempotency guarantee comes from the `updateMany`
+   * compare-and-swap inside `$transaction` (run at Serializable isolation to
+   * match the rest of the money-sensitive flows in this codebase). The outer
+   * `findUnique` calls are non-atomic fast-path optimizations only — two
+   * concurrent callers can both pass them; exactly one will then win the
+   * updateMany race and credit the referrer.
    */
   async awardReferralPoints(referredCustomerId: string): Promise<void> {
     const referredCustomer = await this.prisma.customer.findUnique({
       where: { id: referredCustomerId },
-      select: { id: true, referredById: true, name: true },
+      select: {
+        id: true,
+        referredById: true,
+        referralAwardedAt: true,
+        deletedAt: true,
+      },
     });
-    if (!referredCustomer?.referredById) return;
+    if (!referredCustomer || referredCustomer.deletedAt) return;
+    if (!referredCustomer.referredById) return;
+    if (referredCustomer.referralAwardedAt) return; // fast path — already awarded
 
     const referrerId = referredCustomer.referredById;
 
-    // Idempotency: check if referral points already awarded for this specific customer
-    const existing = await this.prisma.loyaltyPoint.findFirst({
-      where: {
-        customerId: referrerId,
-        reason: 'REFERRAL',
-        // referenceId stored as part of reason payload — we track via a lookup payment approach
-        // Since LoyaltyPoint requires paymentId (unique), referral points are stored in customer balance directly
-        deletedAt: null,
-      },
-    });
-
-    // For referrals we update balance directly (no paymentId required)
-    // Use a separate idempotency check via balance audit
     const referrer = await this.prisma.customer.findUnique({
       where: { id: referrerId },
-      select: { id: true, loyaltyBalance: true, deletedAt: true },
+      select: { id: true, deletedAt: true },
     });
     if (!referrer || referrer.deletedAt) return;
 
-    // Check if already awarded by looking for the first contract of the referred customer
-    const referredContract = await this.prisma.contract.findFirst({
-      where: { customerId: referredCustomerId, deletedAt: null },
-      orderBy: { createdAt: 'asc' },
-      select: { id: true },
-    });
-    if (!referredContract) return;
+    await this.prisma.$transaction(
+      async (tx) => {
+        const claimed = await tx.customer.updateMany({
+          where: { id: referredCustomerId, referralAwardedAt: null },
+          data: { referralAwardedAt: new Date() },
+        });
+        if (claimed.count === 0) return; // lost the race — someone else awarded
 
-    // Check via LoyaltyPoint — referral points use contractId of the referred customer's first contract
-    const alreadyAwarded = await this.prisma.loyaltyPoint.findFirst({
-      where: {
-        customerId: referrerId,
-        contractId: referredContract.id,
-        reason: 'REFERRAL',
-        deletedAt: null,
+        await tx.customer.update({
+          where: { id: referrerId },
+          data: { loyaltyBalance: { increment: REFERRAL_POINTS } },
+        });
+
+        this.logger.log(
+          `awardReferralPoints: +${REFERRAL_POINTS} pts to referrer ${referrerId} for customer ${referredCustomerId}`,
+        );
       },
-    });
-    if (alreadyAwarded) {
-      this.logger.warn(`awardReferralPoints: already awarded for contract ${referredContract.id}`);
-      return;
-    }
-
-    // Award using a mock paymentId pattern — requires a sentinel payment record
-    // Since LoyaltyPoint.paymentId is unique+required, we create a synthetic approach:
-    // We update balance directly + store a separate redemption-like audit record
-    await this.prisma.$transaction(async (tx) => {
-      // Directly increment balance (no LoyaltyPoint row needed for referral since no paymentId)
-      await tx.customer.update({
-        where: { id: referrerId },
-        data: { loyaltyBalance: { increment: REFERRAL_POINTS } },
-      });
-    });
-
-    this.logger.log(
-      `awardReferralPoints: +${REFERRAL_POINTS} pts to referrer ${referrerId} for customer ${referredCustomerId}`,
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     );
   }
 

--- a/apps/web/src/pages/DashboardPage/index.tsx
+++ b/apps/web/src/pages/DashboardPage/index.tsx
@@ -37,28 +37,37 @@ export default function DashboardPage() {
 
   const dashboardStaleTime = 5 * 60 * 1000;
 
+  // Backend now rejects SALES from every /dashboard/* endpoint (need-to-know).
+  // Gate all dashboard queries to non-SALES to avoid a flood of 403 toasts
+  // when a SALES user lands on this page.
+  const canReadDashboard = user?.role !== undefined && user.role !== 'SALES';
+
   /* ─── Queries ─── */
   const { data: kpis, isLoading: kpisLoading, isError: kpisError, refetch: refetchKpis } = useQuery<KPIs>({
     queryKey: ['dashboard-kpis'],
     queryFn: async () => (await api.get('/dashboard/kpis')).data,
+    enabled: canReadDashboard,
     staleTime: dashboardStaleTime,
   });
 
   const { data: trend = [], isError: trendError, refetch: refetchTrend } = useQuery<MonthlyTrend[]>({
     queryKey: ['dashboard-trend'],
     queryFn: async () => (await api.get('/dashboard/monthly-trend')).data,
+    enabled: canReadDashboard,
     staleTime: dashboardStaleTime,
   });
 
   const { data: topOverdue = [], isError: topOverdueError, refetch: refetchTopOverdue } = useQuery<TopOverdue[]>({
     queryKey: ['dashboard-top-overdue'],
     queryFn: async () => (await api.get('/dashboard/top-overdue')).data,
+    enabled: canReadDashboard,
     staleTime: dashboardStaleTime,
   });
 
   const { data: statusDist = [], isError: statusDistError, refetch: refetchStatusDist } = useQuery<StatusDistribution[]>({
     queryKey: ['dashboard-status-dist'],
     queryFn: async () => (await api.get('/dashboard/status-distribution')).data,
+    enabled: canReadDashboard,
     staleTime: dashboardStaleTime,
   });
 
@@ -79,6 +88,7 @@ export default function DashboardPage() {
   const { data: aging, isError: agingError, refetch: refetchAging } = useQuery<AgingSummary>({
     queryKey: ['dashboard-aging'],
     queryFn: async () => (await api.get('/dashboard/aging-summary')).data,
+    enabled: canReadDashboard,
     staleTime: dashboardStaleTime,
   });
 
@@ -98,6 +108,7 @@ export default function DashboardPage() {
   const { data: alerts = [] } = useQuery<DashboardAlert[]>({
     queryKey: ['dashboard-alerts'],
     queryFn: async () => (await api.get('/dashboard/alerts')).data,
+    enabled: canReadDashboard,
     staleTime: 30 * 1000,
     refetchInterval: 60 * 1000,
   });
@@ -111,6 +122,7 @@ export default function DashboardPage() {
   const { data: watchListData } = useQuery<WatchList>({
     queryKey: ['dashboard-watch-list'],
     queryFn: async () => (await api.get('/dashboard/watch-list')).data,
+    enabled: canReadDashboard,
     staleTime: 2 * 60 * 1000,
     refetchInterval: 5 * 60 * 1000,
   });


### PR DESCRIPTION
## Summary
Phase 1 Group A ของ CEO Fraud-Audit Deep Dive — quickwins 8 รายการ low-risk สูงด้วย tests ครบ

## Fixes

| ID | Fix | Impact |
|---|---|---|
| T3-C1 | ลบ DEV OTP bypass (`kyc.service.ts:145-152`) | ปิด prod backdoor ถ้า NODE_ENV mis-set |
| T2-C3 | Commission SoD guard (`approve()` + `approvePayout()`) | ห้าม salesperson อนุมัติ commission ของตัวเอง |
| T6-C11 | Dashboard class-level `@Roles` ตัด SALES + frontend enable-guard | Need-to-know compliance ไม่ flood 403 |
| T3-W9 | Credit-check model ID `claude-sonnet-4-20250514` → `4-5-20250514` | ก่อนนี้ call fail แล้ว silent fallback |
| T7-W9 | Migration deactivate `legacy-import@bestchoice.com` | ปิด service account ที่เลิกใช้ |
| T7-C11 | `/health` public minimal + `/health/detailed` OWNER/FM only | ปิด info disclosure (S3/Redis/AI config) |
| T6-C2 | `Customer.referralAwardedAt` atomic idempotency marker + Serializable tx | ปิด race condition ที่ award ซ้ำได้ |
| T6-W28 | Verified MDM unlock already restricted OWNER+FM (no change) | False positive จาก initial audit |

## Test plan
- [x] `npx jest src/modules/kyc src/modules/commission src/modules/dashboard src/modules/loyalty src/modules/health` → 54/54 pass
- [x] `./tools/check-types.sh all` → api + web OK
- [x] code-reviewer agent pass 2 รอบ (1 critical + 5 warnings fixed)
- [ ] Migrations `prisma migrate deploy` บน dev DB
- [ ] Manual smoke test: login OWNER + FM → health/detailed, SALES → dashboard blocked

## Migrations included
1. `20260520000000_deactivate_legacy_import_user` — set is_active=false + rotate password sentinel
2. `20260520100000_add_customer_referral_awarded_at` — ADD COLUMN + backfill จาก contracts.created_at

## Breaking changes
- **Dashboard**: SALES role จะเจอ 403 จาก `/dashboard/*` backend — frontend มี guard แล้ว (`enabled: canReadDashboard`)
- **Health endpoint**: ops scripts ที่ consume `/health` field `checks.*` ต้องย้ายไปเรียก `/health/detailed` (ต้อง auth)
- **Commission approve**: salesperson ของ commission นั้นจะ approve ไม่ได้ — ถ้ามี user เดียวทั้ง SALES+OWNER ต้องใช้ user อื่น

## Context
Part of 8-tier fraud audit — see `docs/ceo-review/tier-8-fraud-heatmap-master.md` for full context

🤖 Generated with [Claude Code](https://claude.com/claude-code)