### PR TITLE
fix(fraud-audit): Phase 1 SoD — journal period lock + BM approval + commission clawback

### DIFF
--- a/apps/api/prisma/migrations/20260520200000_add_commission_clawback/migration.sql
+++ b/apps/api/prisma/migrations/20260520200000_add_commission_clawback/migration.sql
@@ -1,0 +1,22 @@
+-- T2-C6: Commission clawback on contract default
+--
+-- Adds two new enum values to CommissionStatus plus clawback tracking
+-- columns on sales_commissions. The clawback schedule is:
+--   - First-payment default (0-1 งวดจ่าย):  100%
+--   - 2-3 งวดจ่าย:                           75%
+--   - 4-6 งวดจ่าย:                           50%
+--   - 7-12 งวดจ่าย:                          25%
+--   - >12 งวดจ่าย:                             0%
+-- The policy lives in code; these columns just record the result.
+
+-- 1. Extend the enum
+ALTER TYPE "CommissionStatus" ADD VALUE IF NOT EXISTS 'CLAWED_BACK';
+ALTER TYPE "CommissionStatus" ADD VALUE IF NOT EXISTS 'PARTIALLY_CLAWED_BACK';
+
+-- 2. Add clawback bookkeeping columns on the per-commission row
+ALTER TABLE "sales_commissions"
+  ADD COLUMN "clawback_amount"              DECIMAL(12, 2),
+  ADD COLUMN "clawback_percent"             INT,
+  ADD COLUMN "clawback_at"                  TIMESTAMP(3),
+  ADD COLUMN "clawback_reason"              TEXT,
+  ADD COLUMN "months_paid_before_default"   INT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2512,6 +2512,8 @@ enum CommissionStatus {
   PENDING
   APPROVED
   PAID
+  CLAWED_BACK
+  PARTIALLY_CLAWED_BACK
 }
 
 enum CommissionRuleType {
@@ -2554,6 +2556,13 @@ model SalesCommission {
   approvedAt       DateTime?        @map("approved_at")
   paidAt           DateTime?        @map("paid_at")
   paidAmount       Decimal?         @map("paid_amount") @db.Decimal(12, 2)
+  // Clawback on contract default. percent is 0-100 and amount = commission_amount × percent/100.
+  // Set when the referenced contract enters DEFAULTED / WRITTEN_OFF / CLOSED_BAD_DEBT.
+  clawbackAmount         Decimal?  @map("clawback_amount") @db.Decimal(12, 2)
+  clawbackPercent        Int?      @map("clawback_percent")
+  clawbackAt             DateTime? @map("clawback_at")
+  clawbackReason         String?   @map("clawback_reason")
+  monthsPaidBeforeDefault Int?     @map("months_paid_before_default")
   notes            String?
   createdAt        DateTime         @default(now()) @map("created_at")
   updatedAt        DateTime         @updatedAt @map("updated_at")

--- a/apps/api/src/modules/commission/commission.service.spec.ts
+++ b/apps/api/src/modules/commission/commission.service.spec.ts
@@ -28,6 +28,11 @@ describe('CommissionService', () => {
         findFirst: jest.fn(),
         update: jest.fn(),
       },
+      // Simple pass-through — callers supply their own tx mock via closure
+      // in describe blocks that need it. Default echoes the parent prisma so
+      // tests that don't inspect tx work unchanged.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: jest.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(prisma)),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -381,6 +386,158 @@ describe('CommissionService', () => {
       await expect(
         service.approvePayout('payout-1', 'manager-1', {}),
       ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // Prevent the master commission rate from drifting mid-cycle. If a rate
+  // change were allowed while PENDING commissions exist in the current
+  // period, the per-commission snapshot on SalesCommission would be fine
+  // for already-created rows, but the PENDING queue would become ambiguous
+  // to auditors about which rate was in force when.
+  describe('updateRule — period lock on rate changes', () => {
+    it('rejects rate change while PENDING commissions exist in current period', async () => {
+      prisma.commissionRule.findFirst.mockResolvedValue({
+        id: 'rule-1',
+        rate: new Prisma.Decimal('0.03'),
+      });
+      prisma.salesCommission.count.mockResolvedValue(4);
+
+      await expect(
+        service.updateRule('rule-1', { rate: 0.05 }),
+      ).rejects.toThrow(/มี commission ที่รอดำเนินการ/);
+      expect(prisma.commissionRule.update).not.toHaveBeenCalled();
+    });
+
+    it('allows rate change when no PENDING commissions exist in the current period', async () => {
+      prisma.commissionRule.findFirst.mockResolvedValue({
+        id: 'rule-1',
+        rate: new Prisma.Decimal('0.03'),
+      });
+      prisma.salesCommission.count.mockResolvedValue(0);
+      prisma.commissionRule.update.mockResolvedValue({ id: 'rule-1' });
+
+      await expect(service.updateRule('rule-1', { rate: 0.05 })).resolves.toBeDefined();
+      expect(prisma.commissionRule.update).toHaveBeenCalled();
+    });
+
+    it('allows non-rate updates even when PENDING commissions exist', async () => {
+      prisma.commissionRule.findFirst.mockResolvedValue({
+        id: 'rule-1',
+        rate: new Prisma.Decimal('0.03'),
+      });
+      prisma.salesCommission.count.mockResolvedValue(10);
+      prisma.commissionRule.update.mockResolvedValue({ id: 'rule-1' });
+
+      await expect(service.updateRule('rule-1', { name: 'renamed' })).resolves.toBeDefined();
+      expect(prisma.commissionRule.update).toHaveBeenCalled();
+    });
+
+    it('allows rate update that equals existing rate (no-op)', async () => {
+      prisma.commissionRule.findFirst.mockResolvedValue({
+        id: 'rule-1',
+        rate: new Prisma.Decimal('0.03'),
+      });
+      prisma.commissionRule.update.mockResolvedValue({ id: 'rule-1' });
+      // count should not be queried when the rate value is unchanged
+      prisma.salesCommission.count.mockResolvedValue(999);
+
+      await expect(service.updateRule('rule-1', { rate: 0.03 })).resolves.toBeDefined();
+    });
+  });
+
+  // T2-C6 — clawback policy on defaulted contracts. The schedule encodes
+  // risk appetite: the earlier a contract defaults, the more of the
+  // commission should be reversed.
+  describe('applyClawbackForContract — tiered clawback', () => {
+    const mkCommission = (overrides = {}) => ({
+      id: 'sc-1',
+      contractId: 'contract-1',
+      salespersonId: 'sp-1',
+      commissionAmount: new Prisma.Decimal('500'),
+      status: 'PAID',
+      clawbackAt: null,
+      deletedAt: null,
+      ...overrides,
+    });
+
+    it('claws back 100% on first-payment default (monthsPaid = 0 or 1)', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([mkCommission()]);
+
+      const res = await service.applyClawbackForContract('contract-1', 0, 'FPD');
+
+      expect(res.percent).toBe(100);
+      expect(res.clawedBackCount).toBe(1);
+      expect(res.totalAmount).toBe('500');
+      expect(prisma.salesCommission.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'CLAWED_BACK',
+            clawbackAmount: expect.any(Prisma.Decimal),
+            clawbackPercent: 100,
+            monthsPaidBeforeDefault: 0,
+          }),
+        }),
+      );
+    });
+
+    it('claws back 75% at 2-3 months paid', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([mkCommission()]);
+      const res = await service.applyClawbackForContract('contract-1', 3, 'early default');
+
+      expect(res.percent).toBe(75);
+      expect(res.totalAmount).toBe('375');
+      expect(prisma.salesCommission.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'PARTIALLY_CLAWED_BACK',
+            clawbackPercent: 75,
+          }),
+        }),
+      );
+    });
+
+    it('claws back 50% at 4-6 months paid', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([mkCommission()]);
+      const res = await service.applyClawbackForContract('contract-1', 5, 'mid default');
+      expect(res.percent).toBe(50);
+      expect(res.totalAmount).toBe('250');
+    });
+
+    it('claws back 25% at 7-12 months paid', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([mkCommission()]);
+      const res = await service.applyClawbackForContract('contract-1', 10, 'late default');
+      expect(res.percent).toBe(25);
+      expect(res.totalAmount).toBe('125');
+    });
+
+    it('does nothing (0%) when the contract paid >12 months', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([mkCommission()]);
+      const res = await service.applyClawbackForContract('contract-1', 18, 'very late');
+      expect(res.percent).toBe(0);
+      expect(res.clawedBackCount).toBe(0);
+      expect(prisma.salesCommission.findMany).not.toHaveBeenCalled();
+      expect(prisma.salesCommission.update).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: already-clawed rows are filtered out via clawbackAt IS NULL', async () => {
+      prisma.salesCommission.findMany.mockResolvedValue([]); // no rows match the where clause
+      const res = await service.applyClawbackForContract('contract-1', 0, 'retry');
+      expect(res.clawedBackCount).toBe(0);
+      expect(prisma.salesCommission.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            contractId: 'contract-1',
+            clawbackAt: null,
+            status: { in: ['APPROVED', 'PAID'] },
+          }),
+        }),
+      );
+      expect(prisma.salesCommission.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects negative or non-finite monthsPaid', async () => {
+      await expect(service.applyClawbackForContract('c', -1, 'bad')).rejects.toThrow(BadRequestException);
+      await expect(service.applyClawbackForContract('c', Number.NaN, 'bad')).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/apps/api/src/modules/commission/commission.service.ts
+++ b/apps/api/src/modules/commission/commission.service.ts
@@ -197,6 +197,83 @@ export class CommissionService {
   }
 
   /**
+   * Clawback policy: how much of a commission to reverse based on how many
+   * months were paid on the contract before it defaulted. First-payment
+   * default is worst (sale never took); the further the contract
+   * progressed, the less we claw back.
+   */
+  private clawbackPercentForMonthsPaid(monthsPaid: number): number {
+    if (monthsPaid <= 1) return 100;
+    if (monthsPaid <= 3) return 75;
+    if (monthsPaid <= 6) return 50;
+    if (monthsPaid <= 12) return 25;
+    return 0;
+  }
+
+  /**
+   * Reverse commissions tied to a contract that has defaulted / been
+   * written off. Called by the contract or bad-debt flow; idempotent —
+   * rows already clawed back are skipped via clawbackAt IS NULL.
+   */
+  async applyClawbackForContract(
+    contractId: string,
+    monthsPaid: number,
+    reason: string,
+  ): Promise<{ clawedBackCount: number; totalAmount: string; percent: number }> {
+    if (!Number.isFinite(monthsPaid) || monthsPaid < 0) {
+      throw new BadRequestException('monthsPaid ต้องเป็นจำนวนเต็มไม่ติดลบ');
+    }
+
+    const percent = this.clawbackPercentForMonthsPaid(monthsPaid);
+    if (percent === 0) {
+      return { clawedBackCount: 0, totalAmount: '0', percent };
+    }
+
+    const commissions = await this.prisma.salesCommission.findMany({
+      where: {
+        contractId,
+        deletedAt: null,
+        status: { in: ['APPROVED', 'PAID'] },
+        clawbackAt: null,
+      },
+    });
+    if (commissions.length === 0) {
+      return { clawedBackCount: 0, totalAmount: '0', percent };
+    }
+
+    const now = new Date();
+    const factor = new Prisma.Decimal(percent).div(100);
+    let total = new Prisma.Decimal(0);
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const c of commissions) {
+        const amount = new Prisma.Decimal(c.commissionAmount)
+          .mul(factor)
+          .toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
+        total = total.add(amount);
+
+        await tx.salesCommission.update({
+          where: { id: c.id },
+          data: {
+            status: percent === 100 ? 'CLAWED_BACK' : 'PARTIALLY_CLAWED_BACK',
+            clawbackAmount: amount,
+            clawbackPercent: percent,
+            clawbackAt: now,
+            clawbackReason: reason,
+            monthsPaidBeforeDefault: monthsPaid,
+          },
+        });
+      }
+    });
+
+    return {
+      clawedBackCount: commissions.length,
+      totalAmount: total.toString(),
+      percent,
+    };
+  }
+
+  /**
    * List active commission rules
    */
   async findAllRules() {
@@ -231,6 +308,29 @@ export class CommissionService {
       where: { id, deletedAt: null },
     });
     if (!rule) throw new NotFoundException('ไม่พบกฎค่าคอมมิชชัน');
+
+    // Block rate changes while PENDING commissions exist for the current
+    // period. Letting the rate move mid-cycle creates ambiguity about which
+    // rate was in effect when each commission row was created — the whole
+    // point of snapshotting the rate per SalesCommission record is defeated
+    // if the master rate can drift during an open period.
+    if (dto.rate !== undefined && !rule.rate.equals(new Prisma.Decimal(dto.rate))) {
+      const now = new Date();
+      const currentPeriod = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+      const pending = await this.prisma.salesCommission.count({
+        where: {
+          commissionRuleId: id,
+          period: currentPeriod,
+          status: 'PENDING',
+          deletedAt: null,
+        },
+      });
+      if (pending > 0) {
+        throw new ConflictException(
+          `เปลี่ยนอัตราไม่ได้ — มี commission ที่รอดำเนินการ ${pending} รายการใน period ${currentPeriod} ปิด period ก่อนหรือรอเดือนหน้า`,
+        );
+      }
+    }
 
     return this.prisma.commissionRule.update({
       where: { id },

--- a/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
+++ b/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
@@ -340,7 +340,7 @@ describe('Contract Signing & Workflow', () => {
         reviewedById: 'manager-1',
       });
 
-      await workflowService.approveContract('contract-1', 'manager-1', 'BRANCH_MANAGER');
+      await workflowService.approveContract('contract-1', 'manager-1', 'FINANCE_MANAGER');
       expect(prisma.contract.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -358,7 +358,7 @@ describe('Contract Signing & Workflow', () => {
       });
       prisma.contract.findUnique.mockResolvedValue(pendingContract());
 
-      await expect(workflowService.approveContract('contract-1', 'manager-1', 'BRANCH_MANAGER'))
+      await expect(workflowService.approveContract('contract-1', 'manager-1', 'FINANCE_MANAGER'))
         .rejects.toThrow('เอกสารไม่ครบ');
     });
 
@@ -370,7 +370,7 @@ describe('Contract Signing & Workflow', () => {
       });
       prisma.contract.findUnique.mockResolvedValue(pendingContract());
 
-      await expect(workflowService.approveContract('contract-1', 'manager-1', 'BRANCH_MANAGER'))
+      await expect(workflowService.approveContract('contract-1', 'manager-1', 'FINANCE_MANAGER'))
         .rejects.toThrow('ลายเซ็นไม่ครบ');
     });
 
@@ -395,7 +395,7 @@ describe('Contract Signing & Workflow', () => {
     it('APR-6: สัญญาไม่อยู่ PENDING_REVIEW → BadRequestException', async () => {
       prisma.contract.findUnique.mockResolvedValue(makeContract({ workflowStatus: 'CREATING' }));
 
-      await expect(workflowService.approveContract('contract-1', 'manager-1', 'BRANCH_MANAGER'))
+      await expect(workflowService.approveContract('contract-1', 'manager-1', 'FINANCE_MANAGER'))
         .rejects.toThrow(BadRequestException);
     });
 
@@ -412,7 +412,7 @@ describe('Contract Signing & Workflow', () => {
         }),
       );
 
-      await expect(workflowService.approveContract('contract-1', 'manager-1', 'BRANCH_MANAGER'))
+      await expect(workflowService.approveContract('contract-1', 'manager-1', 'FINANCE_MANAGER'))
         .rejects.toThrow('เอกสารไม่ครบ');
     });
   });
@@ -424,7 +424,7 @@ describe('Contract Signing & Workflow', () => {
     it('REJ-1: ปฏิเสธสำเร็จ → REJECTED + reviewNotes', async () => {
       prisma.contract.findUnique.mockResolvedValue(makeContract({ workflowStatus: 'PENDING_REVIEW' }));
 
-      await workflowService.rejectContract('contract-1', 'manager-1', 'BRANCH_MANAGER', 'เอกสารไม่ชัด');
+      await workflowService.rejectContract('contract-1', 'manager-1', 'FINANCE_MANAGER', 'เอกสารไม่ชัด');
       expect(prisma.contract.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -456,7 +456,7 @@ describe('Contract Signing & Workflow', () => {
     it('REJ-4: สัญญาไม่อยู่ PENDING_REVIEW → BadRequestException', async () => {
       prisma.contract.findUnique.mockResolvedValue(makeContract({ workflowStatus: 'CREATING' }));
 
-      await expect(workflowService.rejectContract('contract-1', 'manager-1', 'BRANCH_MANAGER', 'ปฏิเสธ'))
+      await expect(workflowService.rejectContract('contract-1', 'manager-1', 'FINANCE_MANAGER', 'ปฏิเสธ'))
         .rejects.toThrow(BadRequestException);
     });
   });

--- a/apps/api/src/modules/contracts/contracts.controller.spec.ts
+++ b/apps/api/src/modules/contracts/contracts.controller.spec.ts
@@ -1,0 +1,37 @@
+import { Reflector } from '@nestjs/core';
+import { ContractsController } from './contracts.controller';
+import { ROLES_KEY } from '../auth/decorators/roles.decorator';
+
+/**
+ * Covers the T1-C5 fix: contract approval/reject must NOT be reachable by
+ * BRANCH_MANAGER. Letting BMs approve contracts enables BM↔BM peer approval
+ * inside the same branch, bypassing central finance review. These tests pin
+ * the @Roles metadata so a future edit cannot silently re-widen the set.
+ */
+describe('ContractsController — approve/reject role metadata', () => {
+  const reflector = new Reflector();
+
+  const rolesOn = (methodName: string): string[] | undefined => {
+    const handler = (ContractsController.prototype as unknown as Record<string, unknown>)[
+      methodName
+    ];
+    if (typeof handler !== 'function') return undefined;
+    return reflector.get<string[]>(ROLES_KEY, handler);
+  };
+
+  it('POST /contracts/:id/approve is restricted to OWNER + FINANCE_MANAGER', () => {
+    const roles = rolesOn('approve');
+    expect(roles).toBeDefined();
+    expect(roles).toEqual(expect.arrayContaining(['OWNER', 'FINANCE_MANAGER']));
+    expect(roles).not.toContain('BRANCH_MANAGER');
+    expect(roles).not.toContain('SALES');
+    expect(roles).not.toContain('ACCOUNTANT');
+  });
+
+  it('POST /contracts/:id/reject mirrors approve (OWNER + FINANCE_MANAGER only)', () => {
+    const roles = rolesOn('reject');
+    expect(roles).toBeDefined();
+    expect(roles).toEqual(expect.arrayContaining(['OWNER', 'FINANCE_MANAGER']));
+    expect(roles).not.toContain('BRANCH_MANAGER');
+  });
+});

--- a/apps/api/src/modules/contracts/contracts.controller.ts
+++ b/apps/api/src/modules/contracts/contracts.controller.ts
@@ -117,8 +117,12 @@ export class ContractsController {
     return this.workflowService.submitForReview(id, user.id);
   }
 
+  // Contract approval is restricted to OWNER + FINANCE_MANAGER. Letting a
+  // BRANCH_MANAGER approve contracts allowed BM-to-BM collusion within a
+  // branch (peer approval without central finance review). BRANCH_MANAGER
+  // can still submit-for-review; final approval must go through finance.
   @Post(':id/approve')
-  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER')
   approve(
     @Param('id') id: string,
     @Body() dto: ReviewContractDto,
@@ -127,8 +131,9 @@ export class ContractsController {
     return this.workflowService.approveContract(id, user.id, user.role, dto.reviewNotes);
   }
 
+  // Reject mirrors approve — same authority required to close the loop.
   @Post(':id/reject')
-  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER')
   reject(
     @Param('id') id: string,
     @Body() dto: RejectContractDto,

--- a/apps/api/src/modules/journal/journal.service.spec.ts
+++ b/apps/api/src/modules/journal/journal.service.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { JournalService } from './journal.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Covers the T2-C1 fix: JournalService.create() must reject entries dated
+ * inside a CLOSED or SYNCED accounting period. Without this guard, period
+ * close was cosmetic — a manual entry could backdate into a closed month.
+ */
+describe('JournalService.create — period lock enforcement', () => {
+  let service: JournalService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const companyId = 'company-1';
+
+  const balancedDto = () => ({
+    companyId,
+    entryDate: '2026-04-10',
+    description: 'test entry',
+    lines: [
+      { accountCode: '1100', description: 'debit', debit: 100, credit: 0 },
+      { accountCode: '2100', description: 'credit', debit: 0, credit: 100 },
+    ],
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: companyId, companyCode: 'BC' }),
+      },
+      chartOfAccount: {
+        findMany: jest.fn().mockResolvedValue([
+          { code: '1100', allowedCompanies: [] },
+          { code: '2100', allowedCompanies: [] },
+        ]),
+      },
+      journalEntry: {
+        count: jest.fn().mockResolvedValue(0),
+        create: jest.fn().mockResolvedValue({ id: 'je-1', entryNumber: 'JE-202604-0001' }),
+      },
+      accountingPeriod: {
+        findUnique: jest.fn(),
+      },
+      systemConfig: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      $transaction: jest.fn(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async (cb: (tx: any) => Promise<unknown>) =>
+          cb({
+            journalEntry: {
+              count: jest.fn().mockResolvedValue(0),
+              create: jest.fn().mockResolvedValue({ id: 'je-1', entryNumber: 'JE-202604-0001' }),
+            },
+          }),
+      ),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [JournalService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(JournalService);
+  });
+
+  it('rejects a manual entry when the AccountingPeriod is CLOSED', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
+
+    await expect(service.create(balancedDto(), 'user-1')).rejects.toThrow(BadRequestException);
+    await expect(service.create(balancedDto(), 'user-1')).rejects.toThrow(/ปิดแล้ว/);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects a manual entry when the AccountingPeriod is SYNCED', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'SYNCED' });
+
+    await expect(service.create(balancedDto(), 'user-1')).rejects.toThrow(BadRequestException);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('allows a manual entry when the AccountingPeriod is OPEN (or no record)', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue(null);
+
+    await expect(service.create(balancedDto(), 'user-1')).resolves.toBeDefined();
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+
+  it('allows a manual entry when the AccountingPeriod is REVIEW (soft lock)', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'REVIEW' });
+
+    await expect(service.create(balancedDto(), 'user-1')).resolves.toBeDefined();
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+
+  it('also rejects when legacy SystemConfig `accounting_period_closed_until` blocks the date', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue(null);
+    prisma.systemConfig.findUnique.mockResolvedValue({
+      key: 'accounting_period_closed_until',
+      value: '2026-12-31',
+    });
+
+    await expect(service.create(balancedDto(), 'user-1')).rejects.toThrow(BadRequestException);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/journal/journal.service.ts
+++ b/apps/api/src/modules/journal/journal.service.ts
@@ -2,6 +2,7 @@ import { Injectable, BadRequestException, NotFoundException } from '@nestjs/comm
 import { Decimal } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateJournalEntryDto } from './dto/journal.dto';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
 
 @Injectable()
 export class JournalService {
@@ -54,6 +55,11 @@ export class JournalService {
     if (!company) {
       throw new NotFoundException('ไม่พบบริษัท');
     }
+
+    // Block manual entries dated inside a closed/synced accounting period.
+    // Without this, period close is only cosmetic because this endpoint lets
+    // anyone backdate a journal into a closed month.
+    await validatePeriodOpen(this.prisma, new Date(dto.entryDate), dto.companyId);
 
     // 4. Validate accountCodes exist in ChartOfAccount + allowed for this company
     const accountCodes = dto.lines.map((line) => line.accountCode);


### PR DESCRIPTION
## Summary
Phase 1 Group B (SoD enforcement) — 4 fixes from the CEO fraud-audit review

## Fixes

| ID | Fix | Impact |
|---|---|---|
| **T2-C1** | Manual journal period lock (`JournalService.create`) | ปิดช่อง backdate เข้า CLOSED/SYNCED period |
| **T1-C5** | Remove BRANCH_MANAGER from contract approve/reject | ป้องกัน BM-peer approval ในสาขาเดียวกัน |
| **T2-C5** | Block rate change on CommissionRule while PENDING exist | Rate snapshot integrity per period |
| **T2-C6** | `applyClawbackForContract()` with 5-tier policy + schema + enum | Auto-reverse commission on contract default |

## Clawback policy (T2-C6)
| Months paid | Clawback % | Status |
|---|---|---|
| 0-1 (FPD) | 100% | CLAWED_BACK |
| 2-3 | 75% | PARTIALLY_CLAWED_BACK |
| 4-6 | 50% | PARTIALLY_CLAWED_BACK |
| 7-12 | 25% | PARTIALLY_CLAWED_BACK |
| >12 | 0% | (no-op) |

## Test plan
- [x] 36 commission tests pass
- [x] 67 contracts + journal tests pass
- [x] `./tools/check-types.sh all` OK
- [ ] Migration `20260520200000_add_commission_clawback` on dev DB
- [ ] Wire `applyClawbackForContract` call into contract/bad-debt status-change flow (Phase 2)

## Migrations
- `20260520200000_add_commission_clawback` — ADD enum values + clawback columns

## Breaking changes
- **BRANCH_MANAGER ไม่สามารถ approve/reject contract ได้** — submit-for-review ได้เท่านั้น, อนุมัติต้องส่งต่อ FM/OWNER
- **Commission rule rate change ถูก block** ถ้ามี PENDING commissions ในเดือนปัจจุบัน — ต้องรอเดือนหน้าหรือ approve commissions ก่อน
- **Manual journal backdated entries ถูก block** ถ้าเข้า CLOSED/SYNCED period

## Follow-up
- Wire `applyClawbackForContract` call in `contract.updateStatus(DEFAULTED)` — Phase 2
- Add clawback dashboard / audit report — Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)