### PR TITLE
fix(fraud-audit): Phase 1 governance — audit log immutable + session revoke on deactivate

### DIFF
--- a/apps/api/prisma/migrations/20260520300000_audit_log_archive_immutable/migration.sql
+++ b/apps/api/prisma/migrations/20260520300000_audit_log_archive_immutable/migration.sql
@@ -1,0 +1,31 @@
+-- T2-C4 — Make audit_logs effectively immutable.
+--
+-- Before: cron hard-deleted rows older than 1 year (violates Thai Revenue
+-- Code retention requirements and lets an insider with DB access erase
+-- forensic evidence).
+--
+-- After:
+--   1. A nullable `archived_at` column replaces delete with soft-archive.
+--   2. A BEFORE DELETE trigger rejects any DELETE statement on this table —
+--      no user / role can remove rows, whether via ORM, migration,
+--      or raw SQL, unless they first `ALTER TABLE ... DISABLE TRIGGER`.
+--   3. Retention is now 7 years (Thai business records standard), enforced
+--      by the scheduler cron which sets archived_at instead of deleting.
+
+-- 1. Add soft-archive column
+ALTER TABLE "audit_logs" ADD COLUMN "archived_at" TIMESTAMP(3);
+CREATE INDEX "audit_logs_archived_at_idx" ON "audit_logs"("archived_at");
+
+-- 2. Block DELETE on audit_logs
+CREATE OR REPLACE FUNCTION audit_logs_block_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_logs is immutable — DELETE is not allowed (T2-C4). Use archived_at to soft-archive instead.';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS audit_logs_no_delete ON "audit_logs";
+CREATE TRIGGER audit_logs_no_delete
+BEFORE DELETE ON "audit_logs"
+FOR EACH ROW
+EXECUTE FUNCTION audit_logs_block_delete();

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1411,12 +1411,18 @@ model AuditLog {
   userAgent String?  @map("user_agent")
   duration  Int? // request duration in ms
   createdAt DateTime @default(now()) @map("created_at")
+  // T2-C4 — soft archive instead of hard delete so the row remains
+  // queryable for forensics until the 7-year legal retention is actually
+  // hit. A Postgres trigger (installed by migration 20260520300000)
+  // rejects DELETE on this table regardless of path.
+  archivedAt DateTime? @map("archived_at")
 
   user User @relation(fields: [userId], references: [id])
 
   @@index([entity, entityId])
   @@index([userId])
   @@index([createdAt])
+  @@index([archivedAt])
   @@map("audit_logs")
 }
 

--- a/apps/api/src/modules/notifications/scheduler.service.ts
+++ b/apps/api/src/modules/notifications/scheduler.service.ts
@@ -507,20 +507,27 @@ export class SchedulerService {
       // ─── Append-only log retention (audit + notifications) ────────────
       // PDPA: ลูกค้ามีสิทธิ์ขอให้ลบข้อมูลส่วนตัว — append-only logs ที่
       // โตแบบไม่มีหยุดเป็น compliance risk + ทำให้ DB ช้า. นโยบาย:
-      //   - AuditLog:        เก็บ 1 ปี (PDPA + ขนาด)
+      //   - AuditLog:        เก็บ 7 ปี (Thai Revenue Code + financial industry
+      //                      standard). Soft-archive via archivedAt instead of
+      //                      DELETE — a DB trigger also rejects DELETE so this
+      //                      logic cannot be weaponised by a malicious path.
       //   - NotificationLog: เก็บ 6 เดือน (delivery report ไม่ต้องเก็บนาน)
-      // ใช้ hard delete เพราะเป็นข้อมูลที่ไม่ต้องเก็บ trail (เป็น trail เอง)
-      const oneYearAgoForLogs = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+      const sevenYearsAgo = new Date(
+        now.getFullYear() - 7,
+        now.getMonth(),
+        now.getDate(),
+      );
       const sixMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 6, now.getDate());
 
-      let auditLogsCleared = 0;
+      let auditLogsArchived = 0;
       try {
-        const result = await this.prisma.auditLog.deleteMany({
-          where: { createdAt: { lt: oneYearAgoForLogs } },
+        const result = await this.prisma.auditLog.updateMany({
+          where: { createdAt: { lt: sevenYearsAgo }, archivedAt: null },
+          data: { archivedAt: now },
         });
-        auditLogsCleared = result.count;
+        auditLogsArchived = result.count;
       } catch (err) {
-        this.logger.warn(`AuditLog cleanup failed: ${err instanceof Error ? err.message : err}`);
+        this.logger.warn(`AuditLog archive failed: ${err instanceof Error ? err.message : err}`);
       }
 
       let notificationLogsCleared = 0;
@@ -536,7 +543,7 @@ export class SchedulerService {
       this.logger.log(
         `Data retention complete: ${completedAnonymized.count} completed, ${cancelledAnonymized.count} cancelled soft-deleted, ` +
         `${tokensCleared} expired tokens, ${consentsCleared} withdrawn consents, ` +
-        `${auditLogsCleared} audit logs, ${notificationLogsCleared} notification logs cleared`,
+        `${auditLogsArchived} audit logs archived, ${notificationLogsCleared} notification logs cleared`,
       );
     } catch (error) {
       this.reportCronFailure('data-retention', error);

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('UsersService.update — T7-C7 deactivation revokes refresh tokens', () => {
+  let service: UsersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      user: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      refreshToken: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [UsersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(UsersService);
+  });
+
+  it('revokes all refresh tokens when the user transitions from active → inactive', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'u1', isActive: true });
+    prisma.user.update.mockResolvedValue({ id: 'u1', isActive: false });
+
+    await service.update('u1', { isActive: false });
+
+    expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'u1', revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+  });
+
+  it('does NOT touch refresh tokens on unrelated update (e.g. name change)', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'u1', isActive: true });
+    prisma.user.update.mockResolvedValue({ id: 'u1', isActive: true });
+
+    await service.update('u1', { name: 'renamed' });
+
+    expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('does NOT revoke again if the user was already inactive', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'u1', isActive: false });
+    prisma.user.update.mockResolvedValue({ id: 'u1', isActive: false });
+
+    await service.update('u1', { isActive: false });
+
+    expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('does NOT revoke on reactivation (false → true)', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'u1', isActive: false });
+    prisma.user.update.mockResolvedValue({ id: 'u1', isActive: true });
+
+    await service.update('u1', { isActive: true });
+
+    expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -126,6 +126,12 @@ export class UsersService {
     const user = await this.prisma.user.findUnique({ where: { id } });
     if (!user) throw new NotFoundException('ไม่พบผู้ใช้งาน');
 
+    // T7-C7 — if this update deactivates the user (true → false transition
+    // OR fresh deactivation request), revoke all of their refresh tokens so
+    // their sessions don't live on for up to 7 days past the deactivation.
+    const isNowBeingDeactivated =
+      dto.isActive === false && user.isActive === true;
+
     const data: Prisma.UserUncheckedUpdateInput = {};
     if (dto.name !== undefined) data.name = dto.name;
     if (dto.role !== undefined) data.role = dto.role as UserRole;
@@ -142,7 +148,7 @@ export class UsersService {
     if (dto.nationalId !== undefined) data.nationalId = dto.nationalId || null;
     if (dto.birthDate !== undefined) data.birthDate = dto.birthDate ? new Date(dto.birthDate) : null;
 
-    return this.prisma.user.update({
+    const updated = await this.prisma.user.update({
       where: { id },
       data,
       select: {
@@ -164,5 +170,22 @@ export class UsersService {
         branch: { select: { id: true, name: true } },
       },
     });
+
+    if (isNowBeingDeactivated) {
+      // Revoke every live refresh token so the just-deactivated user cannot
+      // continue to mint new access tokens from cookies already issued to
+      // their browser. Best-effort: never block the user update itself.
+      try {
+        await this.prisma.refreshToken.updateMany({
+          where: { userId: id, revokedAt: null },
+          data: { revokedAt: new Date() },
+        });
+      } catch {
+        // Intentionally swallowed — tokens will also be rejected by the
+        // isActive check in the auth guard, so this is defence-in-depth.
+      }
+    }
+
+    return updated;
   }
 }


### PR DESCRIPTION
## Summary
Phase 1 Group B governance — 2 fixes (1 deferred as backend-already-works)

## Fixes

| ID | Fix | Impact |
|---|---|---|
| **T2-C4** | AuditLog soft-archive + 7-yr retention + Postgres trigger blocking DELETE | Thai Revenue Code compliance + immutable forensic trail |
| **T7-C7** | Revoke all refresh tokens on user deactivation (isActive true→false) | Cut 7-day exfiltration window; double defense with JWT isActive check |
| T7-C1 | Deferred — backend multi-OWNER already works via `POST /users`; full admin UI in Phase 2 | — |

## Migration
- `20260520300000_audit_log_archive_immutable`
  - ADD `archived_at` TIMESTAMP(3) + index
  - CREATE FUNCTION `audit_logs_block_delete()` + BEFORE DELETE trigger
  - Existing rows preserved; cron will archive rows > 7 years on next weekly run

## Test plan
- [x] 4 user.service.spec tests — revoke on deactivate, no-op on name change, no-op if already inactive, no-op on reactivation
- [x] `./tools/check-types.sh all` OK
- [ ] Apply migration on dev DB + attempt manual DELETE — expect trigger exception

## Breaking changes
- **Cannot DELETE from audit_logs** at DB level — any code path (ORM, raw SQL, migration) must use `UPDATE archived_at` instead
- **Deactivated users lose sessions immediately** — legitimate re-enable can't reuse old refresh tokens (they're revoked)

## Notes
- Retention cron already running weekly — will start archiving historical rows on next Sunday run
- Trigger uses `plpgsql` + `RAISE EXCEPTION` — standard Postgres, no extension required

🤖 Generated with [Claude Code](https://claude.com/claude-code)