### PR TITLE
fix(fraud-audit): Phase 2 SoD — write-off tiers + stock adjustment 4-eyes

### DIFF
--- a/apps/api/prisma/migrations/20260521000000_stock_adjustment_approver/migration.sql
+++ b/apps/api/prisma/migrations/20260521000000_stock_adjustment_approver/migration.sql
@@ -1,0 +1,31 @@
+-- T5-C3: 4-eyes on every stock adjustment
+--
+-- Add approver columns. Historical rows are back-filled with adjusted_by_id
+-- to satisfy NOT NULL + FK constraints; they are flagged as "self-approved"
+-- only for historical context and cannot happen going forward (the service
+-- now rejects adjustedById === approvedById in every create call).
+
+-- 1. Add nullable columns first
+ALTER TABLE "stock_adjustments"
+  ADD COLUMN "approved_by_id" TEXT,
+  ADD COLUMN "approved_at"    TIMESTAMP(3);
+
+-- 2. Backfill historical rows (safe: same user ID, records the state before
+--    the 4-eyes rule existed). updated_at is untouched so audit is honest.
+UPDATE "stock_adjustments"
+SET
+  "approved_by_id" = "adjusted_by_id",
+  "approved_at"    = "created_at"
+WHERE "approved_by_id" IS NULL;
+
+-- 3. Promote to NOT NULL + default for new rows
+ALTER TABLE "stock_adjustments"
+  ALTER COLUMN "approved_by_id" SET NOT NULL,
+  ALTER COLUMN "approved_at"    SET NOT NULL,
+  ALTER COLUMN "approved_at"    SET DEFAULT CURRENT_TIMESTAMP;
+
+-- 4. FK constraint to users(id)
+ALTER TABLE "stock_adjustments"
+  ADD CONSTRAINT "stock_adjustments_approved_by_id_fkey"
+  FOREIGN KEY ("approved_by_id") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -401,6 +401,7 @@ model User {
   transfersConfirmed     StockTransfer[]      @relation("TransferConfirmedBy")
   transfersDispatched    StockTransfer[]      @relation("TransferDispatchedBy")
   stockAdjustments       StockAdjustment[]    @relation("StockAdjustedBy")
+  stockAdjustmentsApproved StockAdjustment[] @relation("StockAdjustmentApprovedBy")
   documentsUploaded      ContractDocument[]   @relation("DocumentUploadedBy")
   creditChecks           CreditCheck[]        @relation("CreditCheckedBy")
   branchReceivings       BranchReceiving[]    @relation("BranchReceivedBy")
@@ -1067,6 +1068,13 @@ model StockAdjustment {
   notes          String?
   photos         String[]              @default([])
   adjustedById   String                @map("adjusted_by_id")
+  // T5-C3 — every stock adjustment is 4-eyes: the adjuster records the
+  // change, a different manager-tier user signs off as approver. These
+  // fields are required in the service layer (DTO-validated). Existing
+  // rows created before T5-C3 have NULL here — back-filled by migration
+  // with adjustedById to preserve referential integrity.
+  approvedById   String                @map("approved_by_id")
+  approvedAt     DateTime              @default(now()) @map("approved_at")
   createdAt      DateTime              @default(now()) @map("created_at")
   updatedAt      DateTime              @updatedAt @map("updated_at")
   deletedAt      DateTime?             @map("deleted_at")
@@ -1074,6 +1082,7 @@ model StockAdjustment {
   product    Product @relation(fields: [productId], references: [id])
   branch     Branch  @relation(fields: [branchId], references: [id])
   adjustedBy User    @relation("StockAdjustedBy", fields: [adjustedById], references: [id])
+  approvedBy User    @relation("StockAdjustmentApprovedBy", fields: [approvedById], references: [id])
 
   @@index([productId])
   @@index([branchId])

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1141,14 +1141,17 @@ async function main() {
   // ============================================================
   console.log('STEP 26: Creating StockAdjustments...');
 
+  // Seed data keeps the 4-eyes invariant: adjuster and approver are always
+  // different users. Production data must satisfy the same rule (enforced
+  // by StockAdjustmentsService at the service layer).
   await prisma.stockAdjustment.create({
-    data: { productId: 'prod-031', branchId: 'branch-001', reason: 'DAMAGED', previousStatus: 'IN_STOCK', notes: 'หน้าจอแตก ตัวเครื่องบุบ จากการตรวจสอบ', adjustedById: 'user-001' },
+    data: { productId: 'prod-031', branchId: 'branch-001', reason: 'DAMAGED', previousStatus: 'IN_STOCK', notes: 'หน้าจอแตก ตัวเครื่องบุบ จากการตรวจสอบ', adjustedById: 'user-001', approvedById: 'user-002' },
   });
   await prisma.stockAdjustment.create({
-    data: { productId: 'prod-003', branchId: 'branch-002', reason: 'CORRECTION', previousStatus: 'IN_STOCK', notes: 'แก้ไขสถานะหลังโอนย้ายสาขา', adjustedById: 'user-002' },
+    data: { productId: 'prod-003', branchId: 'branch-002', reason: 'CORRECTION', previousStatus: 'IN_STOCK', notes: 'แก้ไขสถานะหลังโอนย้ายสาขา', adjustedById: 'user-002', approvedById: 'user-001' },
   });
   await prisma.stockAdjustment.create({
-    data: { productId: 'prod-033', branchId: 'branch-004', reason: 'FOUND', previousStatus: 'DAMAGED', notes: 'พบเครื่องที่แจ้งหาย สภาพดี', adjustedById: 'user-008' },
+    data: { productId: 'prod-033', branchId: 'branch-004', reason: 'FOUND', previousStatus: 'DAMAGED', notes: 'พบเครื่องที่แจ้งหาย สภาพดี', adjustedById: 'user-008', approvedById: 'user-001' },
   });
 
   console.log('StockAdjustments created: 3');

--- a/apps/api/src/modules/accounting/bad-debt.service.spec.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { BadDebtService } from './bad-debt.service';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -39,6 +39,20 @@ describe('BadDebtService', () => {
         findMany: jest.fn().mockResolvedValue([]),
         updateMany: jest.fn().mockResolvedValue({ count: 0 }),
         createMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      user: {
+        findUnique: jest.fn().mockImplementation(({ where: { id } }) =>
+          Promise.resolve({
+            id,
+            role: id.startsWith('owner') ? 'OWNER'
+              : id.startsWith('fm') ? 'FINANCE_MANAGER'
+              : id.startsWith('acct') ? 'ACCOUNTANT'
+              : id.startsWith('bm') ? 'BRANCH_MANAGER'
+              : 'SALES',
+            isActive: true,
+            deletedAt: null,
+          }),
+        ),
       },
       $transaction: jest.fn().mockImplementation(async (fn) => {
         if (typeof fn === 'function') {
@@ -331,24 +345,24 @@ describe('BadDebtService', () => {
     });
   });
 
-  describe('writeOffBadDebt — segregation of duties', () => {
+  describe('writeOffBadDebt — segregation of duties + T3-C6 tiers', () => {
     it('refuses when writer and approver are the same person', async () => {
       await expect(
-        service.writeOffBadDebt('c1', 'user-1', 'user-1', 'reason'),
+        service.writeOffBadDebt('c1', 'bm-1', 'bm-1', 'reason'),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
     it('throws NotFoundException when contract is missing', async () => {
       prisma.contract.findFirst.mockResolvedValue(null);
       await expect(
-        service.writeOffBadDebt('missing', 'writer', 'approver'),
+        service.writeOffBadDebt('missing', 'bm-1', 'fm-1'),
       ).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('refuses to write off an already CLOSED_BAD_DEBT contract', async () => {
       prisma.contract.findFirst.mockResolvedValue({ id: 'c1', status: 'CLOSED_BAD_DEBT' });
       await expect(
-        service.writeOffBadDebt('c1', 'writer', 'approver'),
+        service.writeOffBadDebt('c1', 'bm-1', 'fm-1'),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
@@ -357,7 +371,7 @@ describe('BadDebtService', () => {
       prisma.contract.update.mockResolvedValue({});
       prisma.badDebtProvision.updateMany.mockResolvedValue({ count: 1 });
 
-      const result = await service.writeOffBadDebt('c1', 'writer', 'approver', 'court order');
+      const result = await service.writeOffBadDebt('c1', 'bm-1', 'fm-1', 'court order');
 
       expect(prisma.contract.update).toHaveBeenCalledWith({
         where: { id: 'c1' },
@@ -367,12 +381,92 @@ describe('BadDebtService', () => {
         where: { contractId: 'c1', status: 'ACTIVE', deletedAt: null },
         data: expect.objectContaining({
           status: 'WRITTEN_OFF',
-          writtenOffById: 'writer',
-          approvedById: 'approver',
+          writtenOffById: 'bm-1',
+          approvedById: 'fm-1',
           notes: 'court order',
         }),
       });
       expect(result.status).toBe('CLOSED_BAD_DEBT');
+    });
+
+    // T3-C6 tier tests. The outstandingAmount is driven by what
+    // prisma.payment.findMany returns inside the transaction.
+    const mkUnpaid = (amountDue: number) => [{
+      id: 'p1',
+      contractId: 'c1',
+      installmentNo: 1,
+      amountDue: new Prisma.Decimal(amountDue),
+      amountPaid: new Prisma.Decimal(0),
+      lateFee: new Prisma.Decimal(0),
+      lateFeeWaived: false,
+    }];
+
+    it('tier 1 (≤10k): BM writer + ACCT approver is rejected (ACCT not in BM/FM/OWNER allowed list)', async () => {
+      prisma.contract.findFirst.mockResolvedValue({ id: 'c1', status: 'OVERDUE' });
+      prisma.payment.findMany.mockResolvedValue(mkUnpaid(5000));
+
+      await expect(
+        service.writeOffBadDebt('c1', 'bm-1', 'acct-1'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('tier 2 (10-30k): BM approver rejected — must be FM or OWNER', async () => {
+      prisma.contract.findFirst.mockResolvedValue({ id: 'c1', status: 'OVERDUE' });
+      prisma.payment.findMany.mockResolvedValue(mkUnpaid(20000));
+
+      await expect(
+        service.writeOffBadDebt('c1', 'bm-1', 'bm-2'),
+      ).rejects.toThrow(/FINANCE_MANAGER|OWNER/);
+    });
+
+    it('tier 2 (10-30k): FM approver accepted', async () => {
+      prisma.contract.findFirst.mockResolvedValue({ id: 'c1', status: 'OVERDUE' });
+      prisma.payment.findMany.mockResolvedValue(mkUnpaid(20000));
+      prisma.contract.update.mockResolvedValue({});
+
+      const result = await service.writeOffBadDebt('c1', 'bm-1', 'fm-1');
+      expect(result.status).toBe('CLOSED_BAD_DEBT');
+    });
+
+    it('tier 3 (>30k): non-OWNER approver rejected', async () => {
+      prisma.contract.findFirst.mockResolvedValue({ id: 'c1', status: 'OVERDUE' });
+      prisma.payment.findMany.mockResolvedValue(mkUnpaid(50000));
+
+      await expect(
+        service.writeOffBadDebt('c1', 'fm-1', 'fm-2'),
+      ).rejects.toThrow(/OWNER/);
+    });
+
+    it('tier 3 (>30k): BM writer rejected (must be FM or OWNER)', async () => {
+      prisma.contract.findFirst.mockResolvedValue({ id: 'c1', status: 'OVERDUE' });
+      prisma.payment.findMany.mockResolvedValue(mkUnpaid(50000));
+
+      await expect(
+        service.writeOffBadDebt('c1', 'bm-1', 'owner-1'),
+      ).rejects.toThrow(/FINANCE_MANAGER/);
+    });
+
+    it('tier 3 (>30k): FM writer + OWNER approver accepted', async () => {
+      prisma.contract.findFirst.mockResolvedValue({ id: 'c1', status: 'OVERDUE' });
+      prisma.payment.findMany.mockResolvedValue(mkUnpaid(50000));
+      prisma.contract.update.mockResolvedValue({});
+
+      const result = await service.writeOffBadDebt('c1', 'fm-1', 'owner-1');
+      expect(result.status).toBe('CLOSED_BAD_DEBT');
+    });
+
+    it('rejects when approver account is deactivated', async () => {
+      prisma.user.findUnique.mockImplementation(({ where: { id } }: { where: { id: string } }) =>
+        Promise.resolve({
+          id,
+          role: id.startsWith('fm') ? 'FINANCE_MANAGER' : 'BRANCH_MANAGER',
+          isActive: id !== 'fm-1', // fm-1 is deactivated
+          deletedAt: null,
+        }),
+      );
+      await expect(
+        service.writeOffBadDebt('c1', 'bm-1', 'fm-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
     });
   });
 

--- a/apps/api/src/modules/accounting/bad-debt.service.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
@@ -211,8 +212,46 @@ export class BadDebtService {
 
   /**
    * Write off a bad debt (ตัดหนี้สูญ)
-   * Requires OWNER approval — writer and approver must be different persons
+   *
+   * T3-C6 — amount-based approval tiers (phone-shop pricing reality):
+   *   0-10,000฿:  writer BM/ACCT/FM/OWNER,  approver must be BM/FM/OWNER
+   *   10,000-30,000฿: approver must be FM or OWNER
+   *   30,000฿+:  approver must be OWNER, writer must be FM or OWNER
+   *
+   * Writer and approver must always be different people (Segregation of Duties
+   * — pre-existing rule).
    */
+  private assertWriteOffTierPermitted(
+    outstandingAmount: number,
+    writerRole: string,
+    approverRole: string,
+  ): void {
+    const approverAllowedByTier =
+      outstandingAmount <= 10_000
+        ? ['BRANCH_MANAGER', 'FINANCE_MANAGER', 'OWNER']
+        : outstandingAmount <= 30_000
+          ? ['FINANCE_MANAGER', 'OWNER']
+          : ['OWNER'];
+
+    if (!approverAllowedByTier.includes(approverRole)) {
+      throw new ForbiddenException(
+        `ตัดหนี้สูญ ${outstandingAmount.toLocaleString()} บาท ต้องอนุมัติโดย ${approverAllowedByTier.join(' หรือ ')} (ปัจจุบัน: ${approverRole})`,
+      );
+    }
+
+    // Top tier (>30k) also constrains who can _originate_ the request so the
+    // OWNER isn't paired with a low-privilege writer who might not
+    // understand what they are signing off on.
+    if (outstandingAmount > 30_000) {
+      const writerAllowed = ['FINANCE_MANAGER', 'OWNER'];
+      if (!writerAllowed.includes(writerRole)) {
+        throw new ForbiddenException(
+          `ตัดหนี้สูญ > 30,000 บาท ผู้ขอต้องเป็น FINANCE_MANAGER หรือ OWNER (ปัจจุบัน: ${writerRole})`,
+        );
+      }
+    }
+  }
+
   async writeOffBadDebt(
     contractId: string,
     writtenOffById: string,
@@ -221,6 +260,25 @@ export class BadDebtService {
   ) {
     if (writtenOffById === approvedById) {
       throw new BadRequestException('ผู้ตัดหนี้สูญต้องไม่ใช่ผู้อนุมัติ');
+    }
+
+    // Resolve both users' roles up front so we can apply the T3-C6 tier
+    // rules before any write.
+    const [writer, approver] = await Promise.all([
+      this.prisma.user.findUnique({
+        where: { id: writtenOffById },
+        select: { id: true, role: true, isActive: true, deletedAt: true },
+      }),
+      this.prisma.user.findUnique({
+        where: { id: approvedById },
+        select: { id: true, role: true, isActive: true, deletedAt: true },
+      }),
+    ]);
+    if (!writer || !writer.isActive || writer.deletedAt) {
+      throw new NotFoundException('ไม่พบผู้ขอตัดหนี้สูญ หรือถูกปิดการใช้งาน');
+    }
+    if (!approver || !approver.isActive || approver.deletedAt) {
+      throw new NotFoundException('ไม่พบผู้อนุมัติ หรือถูกปิดการใช้งาน');
     }
 
     const contract = await this.prisma.contract.findFirst({
@@ -245,6 +303,9 @@ export class BadDebtService {
         const unpaidLateFee = !p.lateFeeWaived ? Number(p.lateFee) : 0;
         return sum + Number(p.amountDue) - Number(p.amountPaid) + unpaidLateFee;
       }, 0);
+
+      // T3-C6 — enforce amount-tier approval rule before any write.
+      this.assertWriteOffTierPermitted(outstandingAmount, writer.role, approver.role);
 
       // Capture total active provision amount before updating status
       const activeProvisions = await tx.badDebtProvision.findMany({

--- a/apps/api/src/modules/inventory/dto/create-stock-adjustment.dto.ts
+++ b/apps/api/src/modules/inventory/dto/create-stock-adjustment.dto.ts
@@ -16,4 +16,11 @@ export class CreateStockAdjustmentDto {
   @IsString({ each: true })
   @IsOptional()
   photos?: string[];
+
+  // T5-C3 — every stock adjustment requires a second-person approver.
+  // The service rejects any submission where approverId equals the caller
+  // (the adjuster), or where the approver is not manager-tier.
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุผู้อนุมัติ (approverId)' })
+  approverId: string;
 }

--- a/apps/api/src/modules/inventory/stock-adjustments.service.spec.ts
+++ b/apps/api/src/modules/inventory/stock-adjustments.service.spec.ts
@@ -1,0 +1,121 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { StockAdjustmentsService } from './stock-adjustments.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * T5-C3 — 4-eyes on every stock adjustment. The adjuster (userId) and the
+ * approver (dto.approverId) must be different people, and the approver must
+ * be manager-tier (OWNER / FINANCE_MANAGER / BRANCH_MANAGER). Historical
+ * rule that BRANCH_MANAGER could self-approve is removed.
+ */
+describe('StockAdjustmentsService.create — T5-C3 4-eyes', () => {
+  let service: StockAdjustmentsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const baseDto = {
+    productId: 'p1',
+    reason: 'CORRECTION' as const,
+    approverId: 'approver-bm',
+    notes: 'audit correction',
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      product: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'p1',
+          status: 'IN_STOCK',
+          branchId: 'branch-1',
+          deletedAt: null,
+        }),
+        update: jest.fn(),
+      },
+      stockAdjustment: {
+        create: jest.fn().mockResolvedValue({ id: 'adj-1' }),
+        findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+      user: {
+        findUnique: jest.fn().mockImplementation(({ where: { id } }) =>
+          Promise.resolve({
+            id,
+            role: id.startsWith('approver-bm') ? 'BRANCH_MANAGER'
+              : id.startsWith('approver-fm') ? 'FINANCE_MANAGER'
+              : id.startsWith('approver-owner') ? 'OWNER'
+              : id.startsWith('approver-sales') ? 'SALES'
+              : 'SALES',
+            isActive: true,
+            deletedAt: null,
+          }),
+        ),
+      },
+      $transaction: jest.fn((cb: (tx: unknown) => Promise<unknown>) => cb(prisma)),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [StockAdjustmentsService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(StockAdjustmentsService);
+  });
+
+  it('rejects when approverId is missing', async () => {
+    const dto = { ...baseDto, approverId: '' };
+    await expect(service.create(dto, 'user-1')).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects self-approval (adjuster === approver)', async () => {
+    await expect(
+      service.create({ ...baseDto, approverId: 'user-1' }, 'user-1'),
+    ).rejects.toThrow(ForbiddenException);
+    expect(prisma.stockAdjustment.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects when approver does not exist', async () => {
+    prisma.user.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      service.create({ ...baseDto, approverId: 'ghost' }, 'user-1'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects when approver is deactivated', async () => {
+    prisma.user.findUnique.mockResolvedValueOnce({
+      id: 'approver-bm',
+      role: 'BRANCH_MANAGER',
+      isActive: false,
+      deletedAt: null,
+    });
+    await expect(service.create(baseDto, 'user-1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects when approver is not manager-tier (e.g. SALES)', async () => {
+    await expect(
+      service.create({ ...baseDto, approverId: 'approver-sales' }, 'user-1'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('accepts BRANCH_MANAGER approver for a non-self adjustment', async () => {
+    await expect(service.create(baseDto, 'user-1')).resolves.toBeDefined();
+    expect(prisma.stockAdjustment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          adjustedById: 'user-1',
+          approvedById: 'approver-bm',
+          approvedAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it('accepts OWNER approver', async () => {
+    await expect(
+      service.create({ ...baseDto, approverId: 'approver-owner' }, 'user-1'),
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/api/src/modules/inventory/stock-adjustments.service.ts
+++ b/apps/api/src/modules/inventory/stock-adjustments.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { Prisma, StockAdjustmentReason } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateStockAdjustmentDto } from './dto/create-stock-adjustment.dto';
@@ -8,6 +13,29 @@ export class StockAdjustmentsService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateStockAdjustmentDto, userId: string) {
+    // T5-C3 — 4-eyes: approver ≠ adjuster, must be manager-tier + active.
+    if (!dto.approverId) {
+      throw new BadRequestException('ต้องระบุผู้อนุมัติ (approverId)');
+    }
+    if (dto.approverId === userId) {
+      throw new ForbiddenException(
+        'ผู้ปรับสต๊อคและผู้อนุมัติต้องเป็นคนละคน (Segregation of Duties)',
+      );
+    }
+    const approver = await this.prisma.user.findUnique({
+      where: { id: dto.approverId },
+      select: { id: true, role: true, isActive: true, deletedAt: true },
+    });
+    if (!approver || !approver.isActive || approver.deletedAt) {
+      throw new NotFoundException('ไม่พบผู้อนุมัติ หรือถูกปิดการใช้งาน');
+    }
+    const approverAllowed = ['OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER'];
+    if (!approverAllowed.includes(approver.role)) {
+      throw new ForbiddenException(
+        `ผู้อนุมัติต้องเป็น ${approverAllowed.join(' / ')} (role ปัจจุบัน: ${approver.role})`,
+      );
+    }
+
     return this.prisma.$transaction(async (tx) => {
       // Find product inside transaction to prevent race conditions
       const product = await tx.product.findUnique({
@@ -36,7 +64,7 @@ export class StockAdjustmentsService {
         }
       }
 
-      // Create adjustment record
+      // Create adjustment record (with 4-eyes approver captured)
       const adjustment = await tx.stockAdjustment.create({
         data: {
           productId: dto.productId,
@@ -46,11 +74,14 @@ export class StockAdjustmentsService {
           notes: dto.notes,
           photos: dto.photos || [],
           adjustedById: userId,
+          approvedById: dto.approverId,
+          approvedAt: new Date(),
         },
         include: {
           product: { select: { id: true, name: true, imeiSerial: true, brand: true, model: true } },
           branch: { select: { id: true, name: true } },
           adjustedBy: { select: { id: true, name: true } },
+          approvedBy: { select: { id: true, name: true } },
         },
       });
 


### PR DESCRIPTION
## Summary
Phase 2 Sprint 1 — 2 items from the fraud-audit backlog (per P2 decisions).

## Fixes

| ID | Decision | Fix |
|---|---|---|
| **T3-C6** | P2Q5 = A (scaled for phone pricing) | Amount-tier approval on bad-debt write-off |
| **T5-C3** | P2Q1 = B (all adjustments 4-eyes) | Required approver ≠ adjuster + manager-tier guard |

## Write-off tiers (T3-C6)
| Outstanding | Required approver | Required writer |
|---|---|---|
| 0-10,000฿ | BM / FM / OWNER | any |
| 10-30k฿ | FM or OWNER | any |
| > 30k฿ | OWNER | FM or OWNER |

Writer ≠ approver (existing rule, preserved).

## Stock adjustment 4-eyes (T5-C3)
- Schema: `stock_adjustments.approved_by_id` + `approved_at` (NOT NULL, FK → users)
- Migration `20260521000000` back-fills historical rows
- DTO requires `approverId`; service rejects:
  - empty `approverId`
  - self-approval (`approverId === userId`)
  - deactivated/missing approver
  - non manager-tier approver (SALES/ACCOUNTANT)
- Seed updated to satisfy new invariant

## Test plan
- [x] 7 new stock-adjustments tests
- [x] 7 new bad-debt tier tests (existing 22 still green → 29 total)
- [x] `./tools/check-types.sh all` → api + web OK
- [ ] Apply migration on dev DB
- [ ] Manual: SALES tries to approve — 403; OWNER approves 25k — allowed

## Breaking changes
- **POST /inventory/stock-adjustments** now requires `approverId` in body
- **bad-debt write-off** now fails if approver isn't allowed for the outstanding-amount tier (see table above)

## Notes
- Refund endpoint (T1-C1) and bank reconciliation (T1-C3) follow in separate PRs to keep this one reviewable
- Seed.ts updated — dev DB reseed needed after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)