### PR TITLE
fix(health): ลบ GET /health ซ้ำใน AppController ที่ชนกับ HealthController

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, UseGuards, Inject, Optional } from '@nestjs/common';
+import { Controller, Get, UseGuards, Inject, Optional } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
@@ -29,33 +29,6 @@ export class AppController {
       version: process.env.npm_package_version || '1.0.0',
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
-    };
-  }
-
-  @Get('health')
-  @HttpCode(200)
-  async deepHealthCheck() {
-    const checks: Record<string, string> = {};
-
-    try {
-      await this.prisma.$queryRaw`SELECT 1`;
-      checks.database = 'ok';
-    } catch {
-      checks.database = 'error';
-    }
-
-    const memUsage = process.memoryUsage();
-    const memMB = Math.round(memUsage.heapUsed / 1024 / 1024);
-    checks.memory = `${memMB}MB`;
-
-    const allOk = checks.database === 'ok';
-
-    return {
-      status: allOk ? 'ok' : 'degraded',
-      service: 'installment-api',
-      timestamp: new Date().toISOString(),
-      uptime: process.uptime(),
-      checks,
     };
   }
 


### PR DESCRIPTION
## Summary
- `AppController.deepHealthCheck` (legacy `@Get('health')`) ชนกับ `HealthController.check` → prod ใช้ route เก่าแทนที่จะเป็น split public/detailed ตาม T7-C11
- ลบ `deepHealthCheck` ทิ้ง — ให้ `HealthController` จัดการ route `/api/health` (public minimal) + `/api/health/detailed` (auth) ตามที่ออกแบบ

## Symptom ที่พบ
prod คืน:
\`\`\`json
{"success":true,"data":{"status":"ok","service":"installment-api","uptime":338.26,"checks":{"database":"ok","memory":"67MB"}}}
\`\`\`
ซึ่งเป็น response ของ AppController ไม่ใช่ HealthController ใหม่

หลัง fix จะคืน:
\`\`\`json
{"success":true,"data":{"status":"ok","timestamp":"..."}}
\`\`\`

## Test plan
- [x] `./tools/check-types.sh api` — 0 TS errors
- [ ] หลัง deploy: curl `https://api.bestchoicephone.app/api/health` → ไม่มี field `service`/`uptime`/`checks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)