### PR TITLE
fix(eslint): แก้ any + unused param ใน user-throttler guard ที่บล็อก CI deploy

### DIFF
--- a/apps/api/src/guards/user-throttler.guard.ts
+++ b/apps/api/src/guards/user-throttler.guard.ts
@@ -9,19 +9,23 @@ import { ThrottlerGuard, ThrottlerException } from '@nestjs/throttler';
  * This prevents a single user from overwhelming financial endpoints
  * (e.g., rapid payment recording) even if they share an IP with others.
  */
+interface ThrottlerRequest {
+  user?: { id?: string; sub?: string };
+  ips?: string[];
+  ip?: string;
+}
+
 @Injectable()
 export class UserThrottlerGuard extends ThrottlerGuard {
-  protected async getTracker(req: Record<string, any>): Promise<string> {
-    // If user is authenticated, use user ID as the tracker
+  protected async getTracker(req: ThrottlerRequest): Promise<string> {
     const userId = req.user?.id || req.user?.sub;
     if (userId) {
       return `user:${userId}`;
     }
-    // Fall back to IP-based tracking
-    return req.ips?.length ? req.ips[0] : req.ip;
+    return req.ips?.length ? req.ips[0] : (req.ip ?? 'unknown');
   }
 
-  protected async throwThrottlingException(context: ExecutionContext): Promise<void> {
+  protected async throwThrottlingException(_context: ExecutionContext): Promise<void> {
     throw new ThrottlerException('คำขอมากเกินไป กรุณารอสักครู่แล้วลองใหม่');
   }
 }


### PR DESCRIPTION
## Summary
Deploy บน main ล้มเหลว (run #26) เพราะ ESLint เจอ 2 ปัญหาใน `user-throttler.guard.ts`:

- `Record<string, any>` — no-explicit-any rule
- `context` unused parameter — unused-vars rule

Fix:
- เพิ่ม `ThrottlerRequest` interface แทน `Record<string, any>`
- `context` → `_context` (unused param prefix)
- `req.ip ?? 'unknown'` fallback

ผลกระทบ: PR #528 (health endpoint fix) merged เข้า main แล้วแต่ deploy ล้มเหลว — prod ยังใช้ code เก่าอยู่ PR นี้จะปลด block ให้ deploy ผ่านได้

## Test plan
- [x] `./tools/check-types.sh api` passes
- [x] `npx eslint src/guards/user-throttler.guard.ts` passes
- [ ] CI "Deploy to GCP" ผ่าน → prod /api/health คืน format ใหม่

🤖 Generated with [Claude Code](https://claude.com/claude-code)