### PR TITLE
feat(slip): auto-approve สลิป confidence >= 0.9 + 4hr SLA cron (P2Q10=A)

### DIFF
--- a/apps/api/src/modules/chatbot-finance/chatbot-finance.module.ts
+++ b/apps/api/src/modules/chatbot-finance/chatbot-finance.module.ts
@@ -24,6 +24,7 @@ import { WeeklyAnalysisService } from './services/weekly-analysis.service';
 import { LineFinanceWebhookGuard } from './guards/line-finance-webhook.guard';
 import { WebhookDedupService } from './services/webhook-dedup.service';
 import { FinanceDomainHandler } from './finance-domain.handler';
+import { SlipSlaCron } from './crons/slip-sla.cron';
 import { LiffTokenGuard } from '../line-oa/guards/liff-token.guard';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { StaffChatModule } from '../staff-chat/staff-chat.module';
@@ -73,6 +74,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     LiffTokenGuard,
     WebhookDedupService,
     FinanceDomainHandler,
+    SlipSlaCron,
   ],
   exports: [LineFinanceClientService, ChatRoomService, VerificationService, WebhookDedupService, FinanceDomainHandler],
 })

--- a/apps/api/src/modules/chatbot-finance/crons/slip-sla.cron.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/crons/slip-sla.cron.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SlipSlaCron } from './slip-sla.cron';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { StaffNotificationService } from '../services/staff-notification.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('SlipSlaCron.scanOverdueEvidences', () => {
+  let cron: SlipSlaCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let staffNotify: any;
+
+  const hoursAgo = (hours: number) => new Date(Date.now() - hours * 60 * 60 * 1000);
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+
+    prisma = {
+      paymentEvidence: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+    staffNotify = {
+      notifySlipSlaBreached: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        SlipSlaCron,
+        { provide: PrismaService, useValue: prisma },
+        { provide: StaffNotificationService, useValue: staffNotify },
+      ],
+    }).compile();
+    cron = mod.get(SlipSlaCron);
+  });
+
+  it('returns count=0 and does not alert when no stuck evidences', async () => {
+    const result = await cron.scanOverdueEvidences();
+    expect(result.count).toBe(0);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(staffNotify.notifySlipSlaBreached).not.toHaveBeenCalled();
+  });
+
+  it('queries PENDING_REVIEW evidences between 24h and 4h old', async () => {
+    await cron.scanOverdueEvidences();
+    const where = prisma.paymentEvidence.findMany.mock.calls[0][0].where;
+    expect(where.status).toBe('PENDING_REVIEW');
+    expect(where.deletedAt).toBeNull();
+    expect(where.createdAt.lte).toBeInstanceOf(Date);
+    expect(where.createdAt.gte).toBeInstanceOf(Date);
+  });
+
+  it('alerts staff + Sentry when 2 evidences are stuck', async () => {
+    prisma.paymentEvidence.findMany.mockResolvedValue([
+      { id: 'ev-1', createdAt: hoursAgo(6) },
+      { id: 'ev-2', createdAt: hoursAgo(5) },
+    ]);
+
+    const result = await cron.scanOverdueEvidences();
+
+    expect(result.count).toBe(2);
+    expect(result.oldestAgeHours).toBeGreaterThanOrEqual(5.9);
+    expect(staffNotify.notifySlipSlaBreached).toHaveBeenCalledWith(
+      expect.objectContaining({ count: 2 }),
+    );
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Slip review SLA breached'),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ cron: 'slip-sla' }),
+      }),
+    );
+  });
+
+  it('captures exception on DB failure (does NOT throw)', async () => {
+    prisma.paymentEvidence.findMany.mockRejectedValue(new Error('db down'));
+
+    const result = await cron.scanOverdueEvidences();
+
+    expect(result.count).toBe(0);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: expect.objectContaining({ cron: 'slip-sla' }) }),
+    );
+  });
+});

--- a/apps/api/src/modules/chatbot-finance/crons/slip-sla.cron.ts
+++ b/apps/api/src/modules/chatbot-finance/crons/slip-sla.cron.ts
@@ -1,0 +1,77 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { StaffNotificationService } from '../services/staff-notification.service';
+
+/**
+ * Slip SLA cron — alert staff when PaymentEvidence sits in PENDING_REVIEW past
+ * the SLA window. Runs hourly. Pairs with auto-approve logic in
+ * SlipProcessingService: high-confidence matches skip review entirely, so the
+ * queue that hits this cron is the tail that actually needs human eyes.
+ *
+ * Window logic: alert for evidences created between (now - 24h) and (now - 4h).
+ * The lower bound avoids alerting forever on ancient stuck slips — if nobody
+ * touched it in 24h, the team either has a bigger problem or the slip is
+ * already known. Sentry dedups by message fingerprint anyway.
+ */
+@Injectable()
+export class SlipSlaCron {
+  private readonly logger = new Logger(SlipSlaCron.name);
+  static readonly SLA_HOURS = 4;
+  static readonly ALERT_WINDOW_HOURS = 24;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly staffNotify: StaffNotificationService,
+  ) {}
+
+  @Cron('0 * * * *', { timeZone: 'Asia/Bangkok' })
+  async scanOverdueEvidences(): Promise<{ count: number; oldestAgeHours: number }> {
+    try {
+      const now = Date.now();
+      const slaCutoff = new Date(now - SlipSlaCron.SLA_HOURS * 60 * 60 * 1000);
+      const windowFloor = new Date(now - SlipSlaCron.ALERT_WINDOW_HOURS * 60 * 60 * 1000);
+
+      const stuck = await this.prisma.paymentEvidence.findMany({
+        where: {
+          deletedAt: null,
+          status: 'PENDING_REVIEW',
+          createdAt: { lte: slaCutoff, gte: windowFloor },
+        },
+        select: { id: true, createdAt: true },
+        orderBy: { createdAt: 'asc' },
+      });
+
+      if (stuck.length === 0) {
+        return { count: 0, oldestAgeHours: 0 };
+      }
+
+      const oldestAgeHours = (now - stuck[0].createdAt.getTime()) / (60 * 60 * 1000);
+
+      this.logger.warn(
+        `Slip SLA breach: ${stuck.length} evidence(s) pending > ${SlipSlaCron.SLA_HOURS}h, oldest ${oldestAgeHours.toFixed(1)}h`,
+      );
+
+      Sentry.captureMessage(
+        `Slip review SLA breached: ${stuck.length} evidence(s) pending > ${SlipSlaCron.SLA_HOURS}h`,
+        {
+          level: 'warning',
+          tags: { kind: 'cron-job', cron: 'slip-sla' },
+          extra: { count: stuck.length, oldestAgeHours, evidenceIds: stuck.map((e) => e.id) },
+        },
+      );
+
+      await this.staffNotify.notifySlipSlaBreached({
+        count: stuck.length,
+        oldestAgeHours,
+      });
+
+      return { count: stuck.length, oldestAgeHours };
+    } catch (err) {
+      this.logger.error(`Slip SLA cron failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'slip-sla' } });
+      return { count: 0, oldestAgeHours: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/chatbot-finance/services/slip-processing.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/slip-processing.service.spec.ts
@@ -175,4 +175,86 @@ describe('SlipProcessingService', () => {
     const result = await service.processSlip(defaultParams);
     expect(result.matched).toBe(false);
   });
+
+  describe('auto-approve on high OCR confidence', () => {
+    // P2Q10=A: Auto-approve when confidence >= 0.9 AND amount matched AND correct account.
+    // Goal: reduce manual review load without sacrificing fraud controls.
+    // When ANY condition is missing (low confidence, wrong amount, wrong account)
+    // evidence stays PENDING_REVIEW and humans look at it.
+    it('auto-approves when confidence >= 0.9 + matched + valid account + paymentId', async () => {
+      vision.extractSlip.mockResolvedValue({
+        isSlip: true,
+        amount: 3500,
+        toAccount: '203-1-16520-5',
+        bankName: 'KBank',
+        confidence: 0.95,
+      });
+
+      await service.processSlip(defaultParams);
+
+      const createdPayload = prisma.paymentEvidence.create.mock.calls[0][0].data;
+      expect(createdPayload.status).toBe('APPROVED');
+      expect(createdPayload.reviewedById).toBeNull();
+      expect(createdPayload.reviewedAt).toBeInstanceOf(Date);
+      expect(createdPayload.reviewNote).toContain('auto-approved');
+    });
+
+    it('keeps PENDING_REVIEW when confidence below 0.9 even if matched', async () => {
+      vision.extractSlip.mockResolvedValue({
+        isSlip: true,
+        amount: 3500,
+        toAccount: '203-1-16520-5',
+        confidence: 0.85, // just below threshold
+      });
+
+      await service.processSlip(defaultParams);
+
+      const createdPayload = prisma.paymentEvidence.create.mock.calls[0][0].data;
+      expect(createdPayload.status).toBe('PENDING_REVIEW');
+    });
+
+    it('keeps PENDING_REVIEW when amount does not match (high confidence)', async () => {
+      vision.extractSlip.mockResolvedValue({
+        isSlip: true,
+        amount: 2000, // != 3500 expected
+        toAccount: '203-1-16520-5',
+        confidence: 0.99,
+      });
+
+      await service.processSlip(defaultParams);
+
+      const createdPayload = prisma.paymentEvidence.create.mock.calls[0][0].data;
+      expect(createdPayload.status).toBe('PENDING_REVIEW');
+    });
+
+    it('keeps PENDING_REVIEW when no active payment to match against', async () => {
+      prisma.payment.findFirst.mockResolvedValue(null);
+      vision.extractSlip.mockResolvedValue({
+        isSlip: true,
+        amount: 3500,
+        toAccount: '203-1-16520-5',
+        confidence: 0.99,
+      });
+
+      await service.processSlip(defaultParams);
+
+      const createdPayload = prisma.paymentEvidence.create.mock.calls[0][0].data;
+      expect(createdPayload.status).toBe('PENDING_REVIEW');
+    });
+
+    it('does NOT auto-approve wrong-account evidence (confidence irrelevant)', async () => {
+      financeConfig.isCompanyBankAccount.mockReturnValue(false);
+      vision.extractSlip.mockResolvedValue({
+        isSlip: true,
+        amount: 3500,
+        toAccount: '999-9-99999-9',
+        confidence: 1.0,
+      });
+
+      await service.processSlip(defaultParams);
+
+      const createdPayload = prisma.paymentEvidence.create.mock.calls[0][0].data;
+      expect(createdPayload.status).toBe('PENDING_REVIEW');
+    });
+  });
 });

--- a/apps/api/src/modules/chatbot-finance/services/slip-processing.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/slip-processing.service.ts
@@ -9,6 +9,14 @@ import { FinanceConfigService } from './finance-config.service';
 
 const AMOUNT_TOLERANCE = 0.5; // ±0.50 บาท
 
+/**
+ * OCR confidence threshold for auto-approving a slip.
+ * Below this, evidence stays PENDING_REVIEW for human verification.
+ * 0.90 is the team's calibrated minimum — Claude Haiku self-reports >= 0.90
+ * almost always when bank name + amount + ref are all legible.
+ */
+const AUTO_APPROVE_CONFIDENCE = 0.9;
+
 export interface SlipProcessResult {
   ok: boolean;
   reply: string;
@@ -146,14 +154,23 @@ export class SlipProcessingService {
         .abs()
         .lte(new Prisma.Decimal(AMOUNT_TOLERANCE));
 
-    // 6. สร้าง PaymentEvidence (status: PENDING_REVIEW เสมอ — admin อนุมัติ manual)
+    // 6. สร้าง PaymentEvidence
+    // Auto-approve เฉพาะกรณีที่ทุก guard ผ่าน: amount ตรง + บัญชีถูก + paymentId เจอ +
+    // OCR confidence >= 0.9 ถ้าเงื่อนไขใดขาดหาย → PENDING_REVIEW ให้ staff ตรวจ
+    const canAutoApprove =
+      matched &&
+      !!nextPayment &&
+      extracted.confidence !== undefined &&
+      extracted.confidence >= AUTO_APPROVE_CONFIDENCE;
+
     const evidence = await this.createEvidence({
       contractId: contract.id,
       paymentId: nextPayment?.id,
       lineUserId: params.lineUserId,
       imageUrl,
       amount: slipAmount,
-      note: this.buildExtractedNote(extracted),
+      note: this.buildExtractedNote(extracted, canAutoApprove),
+      autoApprove: canAutoApprove,
     });
 
     // 7. Reply
@@ -217,8 +234,9 @@ export class SlipProcessingService {
 
   // ─── helpers ─────────────────────────────────────────────
 
-  private buildExtractedNote(s: SlipExtraction): string {
+  private buildExtractedNote(s: SlipExtraction, autoApproved = false): string {
     const parts: string[] = ['[chatbot-finance]'];
+    if (autoApproved) parts.push('auto-approved');
     if (s.bankName) parts.push(`bank=${s.bankName}`);
     if (s.date) parts.push(`date=${s.date}`);
     if (s.time) parts.push(`time=${s.time}`);
@@ -234,6 +252,7 @@ export class SlipProcessingService {
     imageUrl: string;
     amount?: number;
     note: string;
+    autoApprove?: boolean;
   }) {
     return this.prisma.paymentEvidence.create({
       data: {
@@ -242,7 +261,9 @@ export class SlipProcessingService {
         lineUserId: params.lineUserId,
         imageUrl: params.imageUrl,
         amount: params.amount,
-        status: 'PENDING_REVIEW',
+        status: params.autoApprove ? 'APPROVED' : 'PENDING_REVIEW',
+        reviewedById: params.autoApprove ? null : undefined,
+        reviewedAt: params.autoApprove ? new Date() : undefined,
         reviewNote: params.note,
       },
     });

--- a/apps/api/src/modules/chatbot-finance/services/staff-notification.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/staff-notification.service.ts
@@ -143,6 +143,36 @@ export class StaffNotificationService {
     }
   }
 
+  // ─── Notification: Slip SLA breached ─────────────────────
+
+  /**
+   * Alert staff when slips have been sitting in PENDING_REVIEW past the SLA.
+   * Called by the slip-sla cron. One aggregate message per run — don't spam
+   * per-evidence since the cron re-runs hourly and the same stuck slip would
+   * alert forever.
+   */
+  async notifySlipSlaBreached(params: {
+    count: number;
+    oldestAgeHours: number;
+  }): Promise<void> {
+    if (!(await this.lineStaff.isConfigured())) return;
+    if (params.count === 0) return;
+
+    const text =
+      `⏰ สลิปรอตรวจสอบเกิน SLA\n\n` +
+      `📋 จำนวน: ${params.count} ใบ\n` +
+      `⏳ ใบเก่าสุดรอมาแล้ว ${params.oldestAgeHours.toFixed(1)} ชั่วโมง\n\n` +
+      `🔗 กดเข้าไปดูที่ admin › ตรวจสลิป`;
+
+    try {
+      await this.lineStaff.broadcastText(text);
+    } catch (err) {
+      this.logger.error(
+        `[StaffNotify] slip SLA broadcast failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
   // ─── helpers ─────────────────────────────────────────────
 
 }


### PR DESCRIPTION
## Summary
ลดภาระตรวจสลิป manual เมื่อทุก guard ชัดเจน + alert staff เมื่อมีสลิปค้าง

**Auto-approve** เงื่อนไขที่ครบทุกข้อถึง auto-approve:
- amount ตรงกับ payment.amountDue (±0.50 บาท — เดิม)
- toAccount ตรงกับ SystemConfig (เดิม)
- paymentId หาเจอ
- OCR confidence >= 0.9 (ใหม่)

ถ้าขาดข้อใด → PaymentEvidence.status = PENDING_REVIEW ตามเดิม

**SLA cron** (hourly)
- หา PaymentEvidence PENDING_REVIEW ที่สร้างเมื่อ 4–24 ชม.ก่อน
- Sentry warning + LINE staff broadcast (aggregate เดียวต่อรัน ไม่สแปม)
- Window 24h ป้องกัน alert ซ้ำตลอดไป

## Guards ที่ยังรักษา
- Wrong-account → ไม่มีวัน auto-approve แม้ confidence=1.0
- Unmatched amount → ไม่มีวัน auto-approve
- No active payment → ไม่มีวัน auto-approve

## Test plan
- [x] +5 auto-approve unit tests
- [x] +4 SLA cron tests
- [x] 71 chatbot-finance tests all pass
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)