### PR TITLE
fix(dashboard): cache wrap ป้องกันล่มถ้า Redis ดาวน์ (Sprint 2b)

### DIFF
--- a/apps/api/src/modules/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { DashboardService } from './dashboard.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('DashboardService cache graceful degrade', () => {
+  let service: DashboardService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let cache: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    cache = {
+      get: jest.fn(),
+      set: jest.fn(),
+    };
+    // Minimal prisma mock — _computeKPIs uses contract.count, product.count,
+    // payment.aggregate, payment.count. Return 0 for counts and empty aggregates.
+    prisma = {
+      contract: {
+        count: jest.fn().mockResolvedValue(0),
+        groupBy: jest.fn().mockResolvedValue([]),
+        aggregate: jest.fn().mockResolvedValue({ _sum: {} }),
+      },
+      product: { count: jest.fn().mockResolvedValue(0) },
+      payment: {
+        count: jest.fn().mockResolvedValue(0),
+        aggregate: jest.fn().mockResolvedValue({
+          _sum: { amountDue: 0, amountPaid: 0, lateFee: 0 },
+        }),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CACHE_MANAGER, useValue: cache },
+      ],
+    }).compile();
+    service = mod.get(DashboardService);
+  });
+
+  it('returns cached value on hit without hitting DB', async () => {
+    cache.get.mockResolvedValue({ totalContracts: 99 });
+    const result = await service.getKPIs();
+    expect(result).toEqual({ totalContracts: 99 });
+    expect(prisma.contract.count).not.toHaveBeenCalled();
+  });
+
+  it('falls through and computes on cache miss', async () => {
+    cache.get.mockResolvedValue(undefined);
+    cache.set.mockResolvedValue(undefined);
+    await service.getKPIs();
+    expect(prisma.contract.count).toHaveBeenCalled();
+    expect(cache.set).toHaveBeenCalled();
+  });
+
+  it('computes + returns when cache.get throws (Redis down)', async () => {
+    cache.get.mockRejectedValue(new Error('ECONNREFUSED'));
+    cache.set.mockResolvedValue(undefined);
+    // Should NOT throw — must degrade gracefully
+    await expect(service.getKPIs()).resolves.toBeDefined();
+    expect(prisma.contract.count).toHaveBeenCalled();
+  });
+
+  it('returns computed value when cache.set throws (Redis down)', async () => {
+    cache.get.mockResolvedValue(undefined);
+    cache.set.mockRejectedValue(new Error('EPIPE'));
+    // Should NOT throw — compute succeeded, cache write is best-effort
+    await expect(service.getKPIs()).resolves.toBeDefined();
+  });
+});

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -14,13 +14,37 @@ export class DashboardService {
     @Inject(CACHE_MANAGER) private cache: Cache,
   ) {}
 
-  /** Cache helper: get from cache or compute and store */
+  /**
+   * Cache helper: get from cache or compute and store.
+   *
+   * Cache is a nice-to-have here, never the source of truth. If Redis is
+   * offline or wedged, compute directly and skip the write — the dashboard
+   * should always render rather than 500. Log the failure once per call so
+   * observability still sees the degraded state.
+   */
   private async cached<T>(key: string, ttl: number, compute: () => Promise<T>): Promise<T> {
-    const cached = await this.cache.get<T>(key);
+    let cached: T | null | undefined;
+    try {
+      cached = await this.cache.get<T>(key);
+    } catch (err) {
+      this.structuredLogger.warn('dashboard.cache.get_failed', {
+        key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     if (cached !== undefined && cached !== null) return cached;
+
     const start = Date.now();
     const result = await compute();
-    await this.cache.set(key, result, ttl);
+
+    try {
+      await this.cache.set(key, result, ttl);
+    } catch (err) {
+      this.structuredLogger.warn('dashboard.cache.set_failed', {
+        key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     this.structuredLogger.debug('dashboard.cache.miss', { key, computeMs: Date.now() - start });
     return result;
   }


### PR DESCRIPTION
## Summary
DashboardService.cached() ไม่ wrap cache.get/set ใน try/catch เดิม → ถ้า Redis connection drop ทุก dashboard query throw → หน้าแดสบอร์ดขึ้น 500

**Fix**: wrap cache ops — log warn + degrade ไปคำนวณจริง (cache เป็น nice-to-have)

## Why ไม่ผุ Sentry
Cache failure ควร log เฉยๆ ไม่ใช่ critical error — ตราบใดที่ dashboard ยังแสดงได้แม้ latency ช้าขึ้น ถ้าจะ alert ควรอยู่ที่ Redis monitoring layer ไม่ใช่ per-request

## Test plan
- [x] +4 unit tests (hit/miss/get-throws/set-throws)
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)