### PR TITLE
feat(liff): payment polling recovery + offline banner (Sprint 2c)

### DIFF
--- a/apps/web/src/hooks/useOnlineStatus.test.ts
+++ b/apps/web/src/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react';
+import { useOnlineStatus } from './useOnlineStatus';
+
+describe('useOnlineStatus', () => {
+  const originalOnLine = navigator.onLine;
+  let onLineValue = true;
+
+  beforeEach(() => {
+    onLineValue = true;
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      get: () => onLineValue,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      value: originalOnLine,
+    });
+  });
+
+  it('returns initial value from navigator.onLine', () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  it('flips to false when offline event fires', () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('flips back to true when online event fires', () => {
+    onLineValue = false;
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('removes listeners on unmount (no stale state writes)', () => {
+    const { result, unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+    // result should still be the last-rendered value, no exceptions
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useOnlineStatus.ts
+++ b/apps/web/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks navigator.onLine and emits updates when connectivity changes.
+ * LIFF runs inside LINE's in-app browser where mobile data + WiFi handoffs
+ * are common — a failing poll is usually a dropped connection, not a dead
+ * server, and the recovery UI should reflect that.
+ */
+export function useOnlineStatus(): boolean {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine,
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return online;
+}

--- a/apps/web/src/pages/liff/LiffPayment.tsx
+++ b/apps/web/src/pages/liff/LiffPayment.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router';
 import { formatDateShort, formatDateTime } from '@/utils/formatters';
 import {
@@ -20,6 +20,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { liffApi } from '@/lib/api';
 import { LIFF_ERRORS, validateSlipFile } from '@/constants/liff-errors';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 
 import type { LiffPaymentLinkData as PaymentLinkData } from '@installment/shared';
 
@@ -129,7 +130,7 @@ export default function LiffPayment() {
   const pollInterval = pollCount < 10 ? 3000 : pollCount < 30 ? 5000 : 10000;
   const isPolling = !!activePaymentId && view === 'gateway-pending' && pollCount < MAX_POLL_ATTEMPTS;
 
-  const { data: paymentStatus } = useQuery<PaymentStatusResult>({
+  const { data: paymentStatus, isError: pollErrored } = useQuery<PaymentStatusResult>({
     queryKey: ['payment-status', activePaymentId],
     queryFn: async () => {
       setPollCount((c) => c + 1);
@@ -141,7 +142,22 @@ export default function LiffPayment() {
     enabled: isPolling,
     refetchInterval: isPolling ? pollInterval : false,
     refetchIntervalInBackground: false,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
   });
+
+  const online = useOnlineStatus();
+  const wasOffline = useRef(false);
+  useEffect(() => {
+    if (!online) {
+      wasOffline.current = true;
+      return;
+    }
+    if (wasOffline.current) {
+      toast.success('เชื่อมต่ออินเทอร์เน็ตอีกครั้งแล้ว');
+      wasOffline.current = false;
+    }
+  }, [online]);
 
   // Watch payment status changes
   useEffect(() => {
@@ -480,6 +496,18 @@ export default function LiffPayment() {
               <p className="text-xs text-muted-foreground mt-2">
                 เลขอ้างอิง: <span className="font-mono">{gatewayRef}</span>
               </p>
+            )}
+
+            {/* Connection recovery banner: offline or poll error while still polling */}
+            {isPolling && (!online || pollErrored) && (
+              <div className="mt-4 bg-muted/70 border border-border rounded-lg p-3 text-sm text-muted-foreground flex items-center gap-2 justify-center">
+                <Loader2 className="size-4 animate-spin" />
+                <span>
+                  {!online
+                    ? 'ไม่ได้เชื่อมต่ออินเทอร์เน็ต — กำลังรอสัญญาณ...'
+                    : 'เชื่อมต่อไม่เสถียร กำลังลองใหม่...'}
+                </span>
+              </div>
             )}
 
             {/* Polling indicator */}


### PR DESCRIPTION
## Summary
LiffPayment polling ไม่มี UI recovery เมื่อ connection drop หรือ poll fail ทำให้ลูกค้าเห็นแค่ spinner ไม่รู้ว่าระบบพยายามเชื่อมต่อใหม่อยู่ (LINE in-app browser มี WiFi↔4G handoff บ่อย)

## Changes
- `useOnlineStatus` hook — ใช้ navigator.onLine + online/offline events
- LiffPayment polling: retry 3 + exponential backoff 1s/2s/4s/8s
- Banner "ไม่ได้เชื่อมต่ออินเทอร์เน็ต — กำลังรอสัญญาณ..." เมื่อ offline
- Banner "เชื่อมต่อไม่เสถียร กำลังลองใหม่..." เมื่อ poll error (แต่ online)
- Toast success เมื่อ reconnect หลัง offline

## Test plan
- [x] +4 hook tests (149 web tests total, was 145)
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)