### PR TITLE
feat(overdue): promise-to-pay SLA + broken-promise cron (Sprint 3a)

### DIFF
--- a/apps/api/prisma/migrations/20260522000000_add_call_log_broken_at/migration.sql
+++ b/apps/api/prisma/migrations/20260522000000_add_call_log_broken_at/migration.sql
@@ -1,0 +1,8 @@
+-- Promise-to-pay SLA tracking: call logs that were PROMISED but not honored
+-- get flagged by a hourly cron so dunning can escalate automatically.
+
+ALTER TABLE "call_logs" ADD COLUMN "broken_at" TIMESTAMP(3);
+
+-- Index to make the cron scan cheap (PROMISED + settlementDate < now + brokenAt null).
+CREATE INDEX "call_logs_result_settlement_date_broken_at_idx"
+  ON "call_logs"("result", "settlement_date", "broken_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1345,6 +1345,10 @@ model CallLog {
   notes           String?
   settlementDate  DateTime? @map("settlement_date") // วันที่นัดชำระ (กรณี PROMISED)
   settlementNotes String?   @map("settlement_notes") // รายละเอียดการนัดชำระ
+  /// Timestamp เมื่อ cron พบว่าลูกค้าผิดคำสัญญาชำระ (settlementDate ผ่านแล้วแต่ยังไม่ชำระ).
+  /// ใช้ร่วมกับ result='PROMISED' เพื่อนับ broken-promise count → ป้อนเข้า dunning
+  /// escalation และ credit-check ถัดไป
+  brokenAt        DateTime? @map("broken_at")
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
   deletedAt       DateTime? @map("deleted_at")
@@ -1356,6 +1360,7 @@ model CallLog {
 
   @@index([contractId])
   @@index([callerId])
+  @@index([result, settlementDate, brokenAt])
   @@map("call_logs")
 }
 

--- a/apps/api/src/modules/overdue/crons/broken-promise.cron.spec.ts
+++ b/apps/api/src/modules/overdue/crons/broken-promise.cron.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BrokenPromiseCron } from './broken-promise.cron';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('BrokenPromiseCron.flagBrokenPromises', () => {
+  let cron: BrokenPromiseCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+
+    prisma = {
+      callLog: {
+        findMany: jest.fn().mockResolvedValue([]),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        BrokenPromiseCron,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    cron = mod.get(BrokenPromiseCron);
+  });
+
+  it('flags 0 when no candidates', async () => {
+    const result = await cron.flagBrokenPromises();
+    expect(result.flagged).toBe(0);
+    expect(prisma.callLog.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('only matches PROMISED + settlementDate in past + brokenAt null + contract OVERDUE/DEFAULT', async () => {
+    await cron.flagBrokenPromises();
+    const where = prisma.callLog.findMany.mock.calls[0][0].where;
+    expect(where.result).toBe('PROMISED');
+    expect(where.brokenAt).toBeNull();
+    expect(where.settlementDate.lt).toBeInstanceOf(Date);
+    expect(where.contract.status.in).toContain('OVERDUE');
+    expect(where.contract.status.in).toContain('DEFAULT');
+  });
+
+  it('sets brokenAt on matched call logs and reports count', async () => {
+    prisma.callLog.findMany.mockResolvedValue([
+      { id: 'cl-1', contractId: 'c-1', settlementDate: new Date('2026-04-10') },
+      { id: 'cl-2', contractId: 'c-2', settlementDate: new Date('2026-04-12') },
+    ]);
+
+    const result = await cron.flagBrokenPromises();
+
+    expect(result.flagged).toBe(2);
+    const updateArgs = prisma.callLog.updateMany.mock.calls[0][0];
+    expect(updateArgs.where.id.in).toEqual(['cl-1', 'cl-2']);
+    expect(updateArgs.data.brokenAt).toBeInstanceOf(Date);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Broken-promise cron flagged 2'),
+      expect.objectContaining({
+        tags: expect.objectContaining({ cron: 'broken-promise' }),
+      }),
+    );
+  });
+
+  it('captures exception on DB failure (does NOT throw)', async () => {
+    prisma.callLog.findMany.mockRejectedValue(new Error('db down'));
+
+    const result = await cron.flagBrokenPromises();
+
+    expect(result.flagged).toBe(0);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: expect.objectContaining({ cron: 'broken-promise' }) }),
+    );
+  });
+});

--- a/apps/api/src/modules/overdue/crons/broken-promise.cron.ts
+++ b/apps/api/src/modules/overdue/crons/broken-promise.cron.ts
@@ -1,0 +1,72 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * Broken-promise cron — flags promise-to-pay entries (CallLog.result='PROMISED')
+ * where settlementDate has passed but the underlying contract is still overdue.
+ *
+ * Runs hourly (top of the hour). Sets CallLog.brokenAt=now — idempotent via
+ * the `brokenAt is null` filter so re-runs don't re-flag.
+ *
+ * Why matter: broken-promise count per contract feeds into dunning-stage
+ * escalation and credit-check for the customer's next purchase. Without this
+ * cron, broken promises accumulate silently and the collector sees nothing in
+ * the CRM.
+ */
+@Injectable()
+export class BrokenPromiseCron {
+  private readonly logger = new Logger(BrokenPromiseCron.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Cron('0 * * * *', { timeZone: 'Asia/Bangkok' })
+  async flagBrokenPromises(): Promise<{ flagged: number }> {
+    try {
+      const now = new Date();
+
+      const candidates = await this.prisma.callLog.findMany({
+        where: {
+          deletedAt: null,
+          result: 'PROMISED',
+          brokenAt: null,
+          settlementDate: { lt: now },
+          contract: {
+            deletedAt: null,
+            status: { in: ['OVERDUE', 'DEFAULT'] },
+          },
+        },
+        select: { id: true, contractId: true, settlementDate: true },
+        take: 500,
+      });
+
+      if (candidates.length === 0) {
+        return { flagged: 0 };
+      }
+
+      const ids = candidates.map((c) => c.id);
+      await this.prisma.callLog.updateMany({
+        where: { id: { in: ids } },
+        data: { brokenAt: now },
+      });
+
+      this.logger.warn(`Flagged ${candidates.length} broken promise(s)`);
+
+      Sentry.captureMessage(
+        `Broken-promise cron flagged ${candidates.length} entries`,
+        {
+          level: 'info',
+          tags: { kind: 'cron-job', cron: 'broken-promise' },
+          extra: { count: candidates.length, contractIds: candidates.map((c) => c.contractId) },
+        },
+      );
+
+      return { flagged: candidates.length };
+    } catch (err) {
+      this.logger.error(`Broken-promise cron failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'broken-promise' } });
+      return { flagged: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -4,6 +4,7 @@ import { OverdueService } from './overdue.service';
 import { OverdueChatService } from './overdue-chat.service';
 import { DunningRuleService } from './dunning-rule.service';
 import { DunningEngineService } from './dunning-engine.service';
+import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { LineOaModule } from '../line-oa/line-oa.module';
@@ -11,7 +12,13 @@ import { LineOaModule } from '../line-oa/line-oa.module';
 @Module({
   imports: [ChatEngineModule, NotificationsModule, LineOaModule],
   controllers: [OverdueController],
-  providers: [OverdueService, OverdueChatService, DunningRuleService, DunningEngineService],
+  providers: [
+    OverdueService,
+    OverdueChatService,
+    DunningRuleService,
+    DunningEngineService,
+    BrokenPromiseCron,
+  ],
   exports: [OverdueService, DunningRuleService, DunningEngineService],
 })
 export class OverdueModule {}

--- a/apps/api/src/modules/overdue/overdue.service.spec.ts
+++ b/apps/api/src/modules/overdue/overdue.service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { OverdueService } from './overdue.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('OverdueService.recordSettlement', () => {
+  let service: OverdueService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const futureDate = (days: number) =>
+    new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+  beforeEach(async () => {
+    prisma = {
+      contract: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'c-1' }),
+      },
+      callLog: {
+        create: jest.fn((args) => Promise.resolve({ id: 'cl-1', ...args.data })),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        OverdueService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = mod.get(OverdueService);
+  });
+
+  it('creates a PROMISED CallLog when settlementDate is a future date within 30 days', async () => {
+    const result = await service.recordSettlement('c-1', 'u-1', {
+      settlementDate: futureDate(5),
+      settlementNotes: 'ลูกค้าจะจ่ายสัปดาห์หน้า',
+    });
+    expect(result).toBeDefined();
+    expect(prisma.callLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          contractId: 'c-1',
+          result: 'PROMISED',
+        }),
+      }),
+    );
+  });
+
+  it('throws NotFound when contract missing', async () => {
+    prisma.contract.findFirst.mockResolvedValue(null);
+    await expect(
+      service.recordSettlement('c-missing', 'u-1', {
+        settlementDate: futureDate(5),
+        settlementNotes: 'x',
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects settlementDate in the past', async () => {
+    await expect(
+      service.recordSettlement('c-1', 'u-1', {
+        settlementDate: futureDate(-1),
+        settlementNotes: 'x',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects settlementDate more than 30 days out', async () => {
+    await expect(
+      service.recordSettlement('c-1', 'u-1', {
+        settlementDate: futureDate(31),
+        settlementNotes: 'x',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects malformed settlementDate string', async () => {
+    await expect(
+      service.recordSettlement('c-1', 'u-1', {
+        settlementDate: 'not-a-date',
+        settlementNotes: 'x',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, Logger, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { Prisma, DunningStage } from '@prisma/client';
@@ -570,7 +570,13 @@ export class OverdueService {
   }
 
   /**
-   * Record a settlement/promise-to-pay from a call
+   * Record a settlement/promise-to-pay from a call.
+   *
+   * Rules:
+   *  - settlementDate ต้อง > วันนี้ (จะ promise ย้อนหลังไม่ได้ — ป้องกันการกรอก
+   *    วันเก่าเพื่อเบนความสนใจจาก aging bucket)
+   *  - settlementDate ห่างจาก now เกิน 30 วัน → reject (นัดไกลเกินไป =
+   *    staff พยายามยืดเวลาลูกหนี้)
    */
   async recordSettlement(
     contractId: string,
@@ -582,14 +588,31 @@ export class OverdueService {
     });
     if (!contract) throw new NotFoundException('ไม่พบสัญญา');
 
+    const now = new Date();
+    const promised = new Date(dto.settlementDate);
+    const maxDays = 30;
+    const maxDate = new Date(now.getTime() + maxDays * 24 * 60 * 60 * 1000);
+
+    if (isNaN(promised.getTime())) {
+      throw new BadRequestException('วันนัดชำระไม่ถูกต้อง');
+    }
+    if (promised.getTime() <= now.getTime()) {
+      throw new BadRequestException('วันนัดชำระต้องเป็นวันในอนาคต');
+    }
+    if (promised.getTime() > maxDate.getTime()) {
+      throw new BadRequestException(
+        `วันนัดชำระห่างจากวันนี้เกิน ${maxDays} วัน — กรุณาติดต่อหัวหน้างาน`,
+      );
+    }
+
     return this.prisma.callLog.create({
       data: {
         contractId,
         callerId,
-        calledAt: new Date(),
+        calledAt: now,
         result: 'PROMISED',
         notes: dto.notes,
-        settlementDate: new Date(dto.settlementDate),
+        settlementDate: promised,
         settlementNotes: dto.settlementNotes,
       },
     });


### PR DESCRIPTION
## Summary
ป้องกันการใช้ promise-to-pay เป็นเครื่องมือยืดเวลา/ซ่อน aging bucket + auto-flag broken promises ให้เห็นใน CRM

**Validation ใน recordSettlement**
- settlementDate ต้อง > วันนี้
- settlementDate ≤ 30 วันจากวันนี้ (ไกลกว่าต้องขอหัวหน้างาน)
- malformed date → 400

**Broken-promise cron** (hourly)
- Find PROMISED ที่ settlementDate ผ่าน + brokenAt null + contract OVERDUE/DEFAULT
- updateMany brokenAt=now (idempotent)
- Sentry info log + contractIds

**Schema** - CallLog.brokenAt + compound index (result, settlementDate, brokenAt)

## Test plan
- [x] +5 validation tests
- [x] +4 cron tests
- [x] TS + 22 overdue tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)