### PR TITLE
feat(credit-check): override audit trail + role guard (Sprint 3b)

### DIFF
--- a/apps/api/prisma/migrations/20260522100000_add_credit_check_override_audit/migration.sql
+++ b/apps/api/prisma/migrations/20260522100000_add_credit_check_override_audit/migration.sql
@@ -1,0 +1,17 @@
+-- Credit-check override audit: track who overrode an AI decision, from what
+-- state, and why. Reason is required at the service layer; DB keeps the
+-- column nullable so historical rows don't need backfill.
+
+ALTER TABLE "credit_checks"
+  ADD COLUMN "original_status" "CreditCheckStatus",
+  ADD COLUMN "original_score" INTEGER,
+  ADD COLUMN "overridden_at" TIMESTAMP(3),
+  ADD COLUMN "overridden_by_id" TEXT,
+  ADD COLUMN "override_reason" TEXT;
+
+CREATE INDEX "credit_checks_overridden_by_id_idx" ON "credit_checks"("overridden_by_id");
+
+ALTER TABLE "credit_checks"
+  ADD CONSTRAINT "credit_checks_overridden_by_id_fkey"
+  FOREIGN KEY ("overridden_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -404,6 +404,7 @@ model User {
   stockAdjustmentsApproved StockAdjustment[] @relation("StockAdjustmentApprovedBy")
   documentsUploaded      ContractDocument[]   @relation("DocumentUploadedBy")
   creditChecks           CreditCheck[]        @relation("CreditCheckedBy")
+  creditOverrides        CreditCheck[]        @relation("CreditOverriddenBy")
   branchReceivings       BranchReceiving[]    @relation("BranchReceivedBy")
   stockCounts            StockCount[]         @relation("StockCountedBy")
   productPhotosUploaded  ProductPhoto[]       @relation("ProductPhotoUploadedBy")
@@ -1586,17 +1587,28 @@ model CreditCheck {
   checkedById String?   @map("checked_by_id")
   checkedAt   DateTime? @map("checked_at")
   reviewNotes String?   @map("review_notes")
+
+  // Override audit — เมื่อ manager เปลี่ยนผลจาก AI ต้องบันทึก original เพื่อ
+  // ตรวจย้อนหลัง และบังคับให้ใส่ reason เพื่อสร้าง accountability
+  originalStatus CreditCheckStatus? @map("original_status")
+  originalScore  Int?               @map("original_score")
+  overriddenAt   DateTime?          @map("overridden_at")
+  overriddenById String?            @map("overridden_by_id")
+  overrideReason String?            @map("override_reason")
+
   createdAt   DateTime  @default(now()) @map("created_at")
   updatedAt   DateTime  @updatedAt @map("updated_at")
   deletedAt   DateTime? @map("deleted_at")
 
-  contract  Contract? @relation(fields: [contractId], references: [id])
-  customer  Customer  @relation(fields: [customerId], references: [id])
-  checkedBy User?     @relation("CreditCheckedBy", fields: [checkedById], references: [id])
+  contract     Contract? @relation(fields: [contractId], references: [id])
+  customer     Customer  @relation(fields: [customerId], references: [id])
+  checkedBy    User?     @relation("CreditCheckedBy", fields: [checkedById], references: [id])
+  overriddenBy User?     @relation("CreditOverriddenBy", fields: [overriddenById], references: [id])
 
   @@index([contractId])
   @@index([customerId])
   @@index([status])
+  @@index([overriddenById])
   @@map("credit_checks")
 }
 

--- a/apps/api/src/modules/credit-check/credit-check.controller.ts
+++ b/apps/api/src/modules/credit-check/credit-check.controller.ts
@@ -113,13 +113,13 @@ export class CreditCheckController {
   }
 
   @Post('override')
-  @Roles('OWNER', 'BRANCH_MANAGER')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
   override(
     @Param('contractId') contractId: string,
     @Body() dto: OverrideCreditCheckDto,
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string; role: string },
   ) {
-    return this.service.override(contractId, dto, user.id);
+    return this.service.override(contractId, dto, user.id, user.role);
   }
 }
 
@@ -158,12 +158,12 @@ export class CustomerCreditCheckController {
   }
 
   @Post(':creditCheckId/override')
-  @Roles('OWNER', 'BRANCH_MANAGER')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
   override(
     @Param('creditCheckId') creditCheckId: string,
     @Body() dto: OverrideCreditCheckDto,
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string; role: string },
   ) {
-    return this.service.overrideById(creditCheckId, dto, user.id);
+    return this.service.overrideById(creditCheckId, dto, user.id, user.role);
   }
 }

--- a/apps/api/src/modules/credit-check/credit-check.service.spec.ts
+++ b/apps/api/src/modules/credit-check/credit-check.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { CreditCheckService } from './credit-check.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+
+describe('CreditCheckService override audit', () => {
+  let service: CreditCheckService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let integrationConfig: any;
+
+  const baseCheck = {
+    id: 'cc-1',
+    contractId: 'con-1',
+    status: 'REJECTED',
+    aiScore: 35,
+    originalStatus: null,
+    originalScore: null,
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      creditCheck: {
+        findUnique: jest.fn().mockResolvedValue(baseCheck),
+        update: jest.fn((args) => Promise.resolve({ id: 'cc-1', ...args.data })),
+      },
+    };
+    integrationConfig = { getValue: jest.fn().mockResolvedValue(null) };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreditCheckService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
+      ],
+    }).compile();
+    service = mod.get(CreditCheckService);
+  });
+
+  it('throws NotFound when credit check missing', async () => {
+    prisma.creditCheck.findUnique.mockResolvedValue(null);
+    await expect(
+      service.override('con-missing', {
+        status: 'APPROVED',
+        overrideReason: 'lorem ipsum valid',
+      }, 'u-1', 'OWNER'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects REJECTED → APPROVED override by BRANCH_MANAGER', async () => {
+    await expect(
+      service.override('con-1', {
+        status: 'APPROVED',
+        overrideReason: 'customer provided additional income proof',
+      }, 'u-1', 'BRANCH_MANAGER'),
+    ).rejects.toThrow(ForbiddenException);
+    expect(prisma.creditCheck.update).not.toHaveBeenCalled();
+  });
+
+  it('allows REJECTED → APPROVED by OWNER and captures original state + reason', async () => {
+    await service.override('con-1', {
+      status: 'APPROVED',
+      overrideReason: 'customer produced additional salary slip from second job',
+    }, 'u-owner', 'OWNER');
+
+    const data = prisma.creditCheck.update.mock.calls[0][0].data;
+    expect(data.status).toBe('APPROVED');
+    expect(data.originalStatus).toBe('REJECTED');
+    expect(data.originalScore).toBe(35);
+    expect(data.overriddenById).toBe('u-owner');
+    expect(data.overrideReason).toContain('salary slip');
+    expect(data.overriddenAt).toBeInstanceOf(Date);
+  });
+
+  it('allows REJECTED → APPROVED by FINANCE_MANAGER', async () => {
+    await service.override('con-1', {
+      status: 'APPROVED',
+      overrideReason: 'manager review — employer confirmed salary verbally',
+    }, 'u-fm', 'FINANCE_MANAGER');
+    expect(prisma.creditCheck.update).toHaveBeenCalled();
+  });
+
+  it('allows MANUAL_REVIEW → APPROVED by BRANCH_MANAGER (lower risk)', async () => {
+    prisma.creditCheck.findUnique.mockResolvedValue({
+      ...baseCheck,
+      status: 'MANUAL_REVIEW',
+      aiScore: 52,
+    });
+    await service.override('con-1', {
+      status: 'APPROVED',
+      overrideReason: 'reviewed with customer — debts paid off',
+    }, 'u-bm', 'BRANCH_MANAGER');
+    expect(prisma.creditCheck.update).toHaveBeenCalled();
+  });
+
+  it('rejects no-op override (same status)', async () => {
+    prisma.creditCheck.findUnique.mockResolvedValue({
+      ...baseCheck,
+      status: 'APPROVED',
+    });
+    await expect(
+      service.override('con-1', {
+        status: 'APPROVED',
+        overrideReason: 'no-op change',
+      }, 'u-1', 'OWNER'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('preserves originalStatus across repeat overrides (first override wins)', async () => {
+    prisma.creditCheck.findUnique.mockResolvedValue({
+      ...baseCheck,
+      status: 'APPROVED', // already overridden once from REJECTED
+      originalStatus: 'REJECTED',
+      originalScore: 35,
+    });
+    await service.override('con-1', {
+      status: 'MANUAL_REVIEW',
+      overrideReason: 'reconsider on new info',
+    }, 'u-owner', 'OWNER');
+
+    const data = prisma.creditCheck.update.mock.calls[0][0].data;
+    // Still REJECTED / 35 — we don't lose the AI's original verdict
+    expect(data.originalStatus).toBe('REJECTED');
+    expect(data.originalScore).toBe(35);
+  });
+});

--- a/apps/api/src/modules/credit-check/credit-check.service.ts
+++ b/apps/api/src/modules/credit-check/credit-check.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, ForbiddenException, InternalServerErrorException, Logger } from '@nestjs/common';
 import { Prisma, CreditCheckStatus } from '@prisma/client';
 import Anthropic from '@anthropic-ai/sdk';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -215,14 +215,16 @@ export class CreditCheckService {
     });
   }
 
-  async overrideById(creditCheckId: string, dto: OverrideCreditCheckDto, userId: string) {
+  async overrideById(
+    creditCheckId: string,
+    dto: OverrideCreditCheckDto,
+    userId: string,
+    userRole: string,
+  ) {
     const creditCheck = await this.prisma.creditCheck.findUnique({ where: { id: creditCheckId } });
     if (!creditCheck || creditCheck.deletedAt) throw new NotFoundException('ไม่พบข้อมูลตรวจสอบเครดิต');
 
-    const validStatuses = ['APPROVED', 'REJECTED', 'MANUAL_REVIEW'];
-    if (!validStatuses.includes(dto.status)) {
-      throw new BadRequestException('สถานะไม่ถูกต้อง');
-    }
+    this.enforceOverridePolicy(creditCheck.status, dto.status, userRole);
 
     return this.prisma.creditCheck.update({
       where: { id: creditCheckId },
@@ -231,12 +233,48 @@ export class CreditCheckService {
         reviewNotes: dto.reviewNotes,
         checkedById: userId,
         checkedAt: new Date(),
+        // Freeze the AI decision at the first override so future audits can
+        // compare final vs original. Don't overwrite on repeat overrides.
+        originalStatus: creditCheck.originalStatus ?? creditCheck.status,
+        originalScore: creditCheck.originalScore ?? creditCheck.aiScore,
+        overriddenAt: new Date(),
+        overriddenById: userId,
+        overrideReason: dto.overrideReason,
       },
       include: {
         customer: { select: { id: true, name: true, phone: true, salary: true, occupation: true } },
         checkedBy: { select: { id: true, name: true } },
       },
     });
+  }
+
+  /**
+   * Enforce the override policy.
+   * - status must be one of the three valid values
+   * - must be a real change (no no-op overrides that pad the audit trail)
+   * - escalating REJECTED → APPROVED (AI said no, human says yes) is the
+   *   riskiest move and is restricted to OWNER / FINANCE_MANAGER
+   */
+  private enforceOverridePolicy(
+    currentStatus: CreditCheckStatus,
+    requestedStatus: string,
+    userRole: string,
+  ) {
+    const validStatuses = ['APPROVED', 'REJECTED', 'MANUAL_REVIEW'];
+    if (!validStatuses.includes(requestedStatus)) {
+      throw new BadRequestException('สถานะไม่ถูกต้อง');
+    }
+    if (currentStatus === requestedStatus) {
+      throw new BadRequestException('สถานะเดิมกับที่ขอเปลี่ยน — ไม่ต้องใช้ override');
+    }
+    if (currentStatus === 'REJECTED' && requestedStatus === 'APPROVED') {
+      const allowed = ['OWNER', 'FINANCE_MANAGER'];
+      if (!allowed.includes(userRole)) {
+        throw new ForbiddenException(
+          'การเปลี่ยนผลจาก REJECTED เป็น APPROVED ต้องได้รับอนุมัติจากผู้จัดการการเงินหรือเจ้าของ',
+        );
+      }
+    }
   }
 
   async create(contractId: string, dto: CreateCreditCheckDto, _userId: string) {
@@ -350,14 +388,16 @@ export class CreditCheckService {
     return updatedCheck;
   }
 
-  async override(contractId: string, dto: OverrideCreditCheckDto, userId: string) {
+  async override(
+    contractId: string,
+    dto: OverrideCreditCheckDto,
+    userId: string,
+    userRole: string,
+  ) {
     const creditCheck = await this.prisma.creditCheck.findUnique({ where: { contractId } });
     if (!creditCheck || creditCheck.deletedAt) throw new NotFoundException('ไม่พบข้อมูลตรวจสอบเครดิต');
 
-    const validStatuses = ['APPROVED', 'REJECTED', 'MANUAL_REVIEW'];
-    if (!validStatuses.includes(dto.status)) {
-      throw new BadRequestException('สถานะไม่ถูกต้อง');
-    }
+    this.enforceOverridePolicy(creditCheck.status, dto.status, userRole);
 
     return this.prisma.creditCheck.update({
       where: { contractId },
@@ -366,6 +406,11 @@ export class CreditCheckService {
         reviewNotes: dto.reviewNotes,
         checkedById: userId,
         checkedAt: new Date(),
+        originalStatus: creditCheck.originalStatus ?? creditCheck.status,
+        originalScore: creditCheck.originalScore ?? creditCheck.aiScore,
+        overriddenAt: new Date(),
+        overriddenById: userId,
+        overrideReason: dto.overrideReason,
       },
       include: {
         customer: { select: { id: true, name: true, phone: true, salary: true, occupation: true } },

--- a/apps/api/src/modules/credit-check/dto/credit-check.dto.ts
+++ b/apps/api/src/modules/credit-check/dto/credit-check.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsArray, IsNumber, Matches, MaxLength } from 'class-validator';
+import { IsString, IsOptional, IsArray, IsNumber, Matches, MaxLength, MinLength } from 'class-validator';
 
 export class CreateCreditCheckDto {
   @IsString()
@@ -18,6 +18,11 @@ export class OverrideCreditCheckDto {
   @IsString()
   @Matches(/^(APPROVED|REJECTED|MANUAL_REVIEW)$/, { message: 'status ต้องเป็น APPROVED, REJECTED หรือ MANUAL_REVIEW' })
   status: string;
+
+  @IsString({ message: 'ต้องระบุเหตุผลการเปลี่ยนผลตรวจเครดิต' })
+  @MinLength(10, { message: 'เหตุผลต้องมีอย่างน้อย 10 ตัวอักษร' })
+  @MaxLength(2000, { message: 'เหตุผลต้องไม่เกิน 2000 ตัวอักษร' })
+  overrideReason!: string;
 
   @IsString()
   @IsOptional()


### PR DESCRIPTION
## Summary
AI ทำ credit-check แล้ว manager override ได้ แต่ไม่มี audit ว่าใคร override จากผลไหนเป็นผลไหน + เหตุผลอะไร — ช่องโหว่ใหญ่ถ้า manager ปล่อยผ่านลูกค้าเสี่ยงสูง

## Changes
**Schema (CreditCheck)**: originalStatus, originalScore, overriddenAt, overriddenById, overrideReason + FK

**Policy**
- No-op override (status เดิม) → 400
- REJECTED → APPROVED = OWNER/FINANCE_MANAGER เท่านั้น
- BRANCH_MANAGER override ระดับต่ำยังได้ (MANUAL_REVIEW → APPROVED/REJECTED)
- overrideReason required + min 10 chars

**Audit freeze**: originalStatus/Score เซตครั้งแรกที่ override — re-overrides ไม่ทับ

## Test plan
- [x] +7 service tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)