### PR TITLE
feat(broadcast): two-person approval + SoD ก่อนส่ง (Sprint 4b — P2Q15=A)

### DIFF
--- a/apps/api/prisma/migrations/20260522300000_add_broadcast_approval/migration.sql
+++ b/apps/api/prisma/migrations/20260522300000_add_broadcast_approval/migration.sql
@@ -1,0 +1,29 @@
+-- Broadcast approval workflow (P2Q15=A): broadcasts now require a second
+-- OWNER/FINANCE_MANAGER to approve before they actually dispatch. Default
+-- status flips from SCHEDULED to PENDING_APPROVAL for new rows — existing
+-- rows keep whatever status they already have.
+
+ALTER TABLE "broadcast_messages"
+  ADD COLUMN "approved_by_id" TEXT,
+  ADD COLUMN "approved_at" TIMESTAMP(3),
+  ADD COLUMN "rejected_by_id" TEXT,
+  ADD COLUMN "rejected_at" TIMESTAMP(3),
+  ADD COLUMN "rejected_reason" TEXT;
+
+-- Change default status for rows inserted from now on. Existing rows keep
+-- their old statuses so the cron + history pages don't choke.
+ALTER TABLE "broadcast_messages"
+  ALTER COLUMN "status" SET DEFAULT 'PENDING_APPROVAL';
+
+CREATE INDEX "broadcast_messages_approved_by_id_idx" ON "broadcast_messages"("approved_by_id");
+CREATE INDEX "broadcast_messages_rejected_by_id_idx" ON "broadcast_messages"("rejected_by_id");
+
+ALTER TABLE "broadcast_messages"
+  ADD CONSTRAINT "broadcast_messages_approved_by_id_fkey"
+  FOREIGN KEY ("approved_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "broadcast_messages"
+  ADD CONSTRAINT "broadcast_messages_rejected_by_id_fkey"
+  FOREIGN KEY ("rejected_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -445,7 +445,9 @@ model User {
   dunningActionsExecuted DunningAction[]      @relation("DunningActionExecutor")
   periodsReviewStarted   AccountingPeriod[]   @relation("PeriodReviewStartedBy")
   periodsClosed          AccountingPeriod[]   @relation("PeriodClosedBy")
-  broadcastMessages      BroadcastMessage[]
+  broadcastMessages      BroadcastMessage[]   @relation("BroadcastCreatedBy")
+  broadcastsApproved     BroadcastMessage[]   @relation("BroadcastApprovedBy")
+  broadcastsRejected     BroadcastMessage[]   @relation("BroadcastRejectedBy")
 
   @@index([branchId])
   @@map("users")
@@ -3700,15 +3702,30 @@ model BroadcastMessage {
   messages      Json      // array: [{ type, content }] — supports up to 5 messages
   audience      String    // ALL, EXISTING, OVERDUE, NEW
   audienceCount Int       @map("audience_count")
-  status        String    @default("SCHEDULED") // SENT, SCHEDULED, FAILED, CANCELLED
+  /// PENDING_APPROVAL (default — creator submits for review)
+  /// APPROVED       (approver cleared; sent immediately or queued if scheduledAt in future)
+  /// SCHEDULED      (approved + scheduledAt in future; cron picks up)
+  /// SENT / FAILED / CANCELLED / REJECTED (terminal states)
+  status        String    @default("PENDING_APPROVAL")
   scheduledAt   DateTime? @map("scheduled_at")
   sentAt        DateTime? @map("sent_at")
   errorMessage  String?   @map("error_message")
   createdById   String    @map("created_by_id")
-  createdBy     User      @relation(fields: [createdById], references: [id])
+  createdBy     User      @relation("BroadcastCreatedBy", fields: [createdById], references: [id])
   createdAt     DateTime  @default(now()) @map("created_at")
+
+  /// SoD: approver ≠ creator. Enforced in service layer.
+  approvedById   String?   @map("approved_by_id")
+  approvedBy     User?     @relation("BroadcastApprovedBy", fields: [approvedById], references: [id])
+  approvedAt     DateTime? @map("approved_at")
+  rejectedById   String?   @map("rejected_by_id")
+  rejectedBy     User?     @relation("BroadcastRejectedBy", fields: [rejectedById], references: [id])
+  rejectedAt     DateTime? @map("rejected_at")
+  rejectedReason String?   @map("rejected_reason")
 
   @@index([status, scheduledAt])
   @@index([createdAt])
+  @@index([approvedById])
+  @@index([rejectedById])
   @@map("broadcast_messages")
 }

--- a/apps/api/src/modules/line-oa/broadcast.controller.ts
+++ b/apps/api/src/modules/line-oa/broadcast.controller.ts
@@ -105,4 +105,27 @@ export class BroadcastController {
   async cancelScheduled(@Param('id') id: string) {
     return this.broadcastService.cancelScheduled(id);
   }
+
+  /**
+   * Approve a PENDING_APPROVAL broadcast (P2Q15=A — SoD).
+   * FINANCE_MANAGER included so the owner doesn't have to approve every send.
+   */
+  @Post(':id/approve')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  async approveBroadcast(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.broadcastService.approveBroadcast(id, userId);
+  }
+
+  @Post(':id/reject')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  async rejectBroadcast(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.broadcastService.rejectBroadcast(id, userId, body.reason);
+  }
 }

--- a/apps/api/src/modules/line-oa/broadcast.service.spec.ts
+++ b/apps/api/src/modules/line-oa/broadcast.service.spec.ts
@@ -1,0 +1,130 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { BroadcastService } from './broadcast.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { StorageService } from '../storage/storage.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+
+describe('BroadcastService approval workflow (P2Q15=A)', () => {
+  let service: BroadcastService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const pendingRecord = (overrides: Record<string, unknown> = {}) => ({
+    id: 'br-1',
+    messages: [{ type: 'text', content: 'hi' }],
+    audience: 'ALL',
+    audienceCount: 100,
+    status: 'PENDING_APPROVAL',
+    scheduledAt: null,
+    createdById: 'u-creator',
+    approvedById: null,
+    approvedAt: null,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      broadcastMessage: {
+        findUnique: jest.fn().mockResolvedValue(pendingRecord()),
+        update: jest.fn((args) => Promise.resolve({ ...pendingRecord(), ...args.data })),
+        create: jest.fn((args) => Promise.resolve({ id: 'br-1', ...args.data })),
+      },
+      customer: { count: jest.fn().mockResolvedValue(0) },
+      customerLineLink: { count: jest.fn().mockResolvedValue(0) },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        BroadcastService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: StorageService, useValue: { upload: jest.fn() } },
+        { provide: IntegrationConfigService, useValue: { getValue: jest.fn() } },
+      ],
+    }).compile();
+    service = mod.get(BroadcastService);
+
+    // Stub the send dispatcher so we don't hit LINE
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).dispatchLineMessages = jest.fn().mockResolvedValue({
+      success: true,
+      message: 'sent',
+    });
+  });
+
+  it('sendBroadcast saves as PENDING_APPROVAL (no immediate dispatch)', async () => {
+    const result = await service.sendBroadcast({
+      messages: [{ type: 'text', content: 'hi' }],
+      audience: 'ALL',
+      createdById: 'u-creator',
+    });
+    expect(result.success).toBe(true);
+    expect(result.message).toMatch(/รอผู้อนุมัติ/);
+    const createArgs = prisma.broadcastMessage.create.mock.calls[0][0];
+    expect(createArgs.data.status).toBe('PENDING_APPROVAL');
+  });
+
+  it('approveBroadcast rejects self-approval by creator', async () => {
+    await expect(
+      service.approveBroadcast('br-1', 'u-creator'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('approveBroadcast rejects records already in SENT state', async () => {
+    prisma.broadcastMessage.findUnique.mockResolvedValue(pendingRecord({ status: 'SENT' }));
+    await expect(
+      service.approveBroadcast('br-1', 'u-approver'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('approveBroadcast throws NotFound for missing id', async () => {
+    prisma.broadcastMessage.findUnique.mockResolvedValue(null);
+    await expect(
+      service.approveBroadcast('missing', 'u-approver'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('approveBroadcast marks SCHEDULED when scheduledAt in future', async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    prisma.broadcastMessage.findUnique.mockResolvedValue(
+      pendingRecord({ scheduledAt: future }),
+    );
+
+    await service.approveBroadcast('br-1', 'u-approver');
+
+    const updateArgs = prisma.broadcastMessage.update.mock.calls[0][0];
+    expect(updateArgs.data.status).toBe('SCHEDULED');
+    expect(updateArgs.data.approvedById).toBe('u-approver');
+    expect(updateArgs.data.approvedAt).toBeInstanceOf(Date);
+  });
+
+  it('approveBroadcast dispatches immediately when not scheduled', async () => {
+    await service.approveBroadcast('br-1', 'u-approver');
+    const updateArgs = prisma.broadcastMessage.update.mock.calls[0][0];
+    expect(updateArgs.data.status).toBe('SENT');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((service as any).dispatchLineMessages).toHaveBeenCalled();
+  });
+
+  it('rejectBroadcast requires reason ≥ 5 chars', async () => {
+    await expect(
+      service.rejectBroadcast('br-1', 'u-approver', 'bad'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejectBroadcast blocks self-rejection by creator', async () => {
+    await expect(
+      service.rejectBroadcast('br-1', 'u-creator', 'looks fishy'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejectBroadcast updates status REJECTED with reason', async () => {
+    await service.rejectBroadcast('br-1', 'u-approver', 'message copy looks phishy');
+    const updateArgs = prisma.broadcastMessage.update.mock.calls[0][0];
+    expect(updateArgs.data.status).toBe('REJECTED');
+    expect(updateArgs.data.rejectedReason).toBe('message copy looks phishy');
+    expect(updateArgs.data.rejectedById).toBe('u-approver');
+  });
+});

--- a/apps/api/src/modules/line-oa/broadcast.service.ts
+++ b/apps/api/src/modules/line-oa/broadcast.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../prisma/prisma.service';
 import { StorageService } from '../storage/storage.service';
@@ -150,9 +150,13 @@ export class BroadcastService {
     return [];
   }
 
-  // ─── Send ─────────────────────────────────────────────────────────────────────
+  // ─── Send / Approve / Reject ─────────────────────────────────────────────
 
-  /** Send or schedule a broadcast */
+  /**
+   * Create a broadcast as PENDING_APPROVAL (P2Q15=A — two-person SoD).
+   * The request no longer dispatches immediately; a second manager must call
+   * approveBroadcast() to either send it now or queue it at scheduledAt.
+   */
   async sendBroadcast(params: SendBroadcastParams): Promise<{
     success: boolean;
     message: string;
@@ -160,7 +164,13 @@ export class BroadcastService {
   }> {
     const { messages, audience, scheduledAt, createdById } = params;
 
-    // Get audience count for saving
+    const lineMessages = messages
+      .map((m) => this.buildLineMessage(m.type, m.content))
+      .filter((m): m is LineMessage => m !== null);
+    if (lineMessages.length === 0) {
+      return { success: false, message: 'รูปแบบข้อความไม่ถูกต้อง' };
+    }
+
     const counts = await this.getAudienceCount();
     const audienceCount =
       audience === 'ALL'
@@ -171,44 +181,120 @@ export class BroadcastService {
             ? counts.overdue
             : counts.new;
 
-    // If scheduled → save as SCHEDULED, no send
-    if (scheduledAt && scheduledAt > new Date()) {
-      const record = await this.prisma.broadcastMessage.create({
-        data: {
-          messages: messages as any,
-          audience,
-          audienceCount,
-          status: 'SCHEDULED',
-          scheduledAt,
-          createdById,
-        },
-      });
-      return { success: true, message: 'บันทึกตั้งเวลาส่งสำเร็จ', id: record.id };
-    }
-
-    // Build LINE messages array (up to 5)
-    const lineMessages = messages
-      .map((m) => this.buildLineMessage(m.type, m.content))
-      .filter((m): m is LineMessage => m !== null);
-    if (lineMessages.length === 0) {
-      return { success: false, message: 'รูปแบบข้อความไม่ถูกต้อง' };
-    }
-
-    const result = await this.dispatchLineMessages(audience, lineMessages);
-
     const record = await this.prisma.broadcastMessage.create({
       data: {
         messages: messages as any,
         audience,
         audienceCount,
-        status: result.success ? 'SENT' : 'FAILED',
-        sentAt: result.success ? new Date() : null,
-        errorMessage: result.success ? null : result.message,
+        status: 'PENDING_APPROVAL',
+        scheduledAt: scheduledAt ?? null,
         createdById,
       },
     });
 
-    return { ...result, id: record.id };
+    return {
+      success: true,
+      message: 'บันทึก broadcast แล้ว รอผู้อนุมัติคนที่สองก่อนส่งจริง',
+      id: record.id,
+    };
+  }
+
+  /**
+   * Approve a PENDING_APPROVAL broadcast and dispatch / queue it.
+   *   - approverId must differ from createdById (SoD guard)
+   *   - scheduledAt in future  → status becomes SCHEDULED, cron picks up
+   *   - otherwise              → dispatch LINE messages immediately
+   */
+  async approveBroadcast(
+    id: string,
+    approverId: string,
+  ): Promise<{ success: boolean; message: string; id: string }> {
+    const record = await this.prisma.broadcastMessage.findUnique({ where: { id } });
+    if (!record) throw new NotFoundException('ไม่พบ broadcast');
+    if (record.status !== 'PENDING_APPROVAL') {
+      throw new BadRequestException(
+        `broadcast อยู่ในสถานะ ${record.status} — อนุมัติได้เฉพาะสถานะ PENDING_APPROVAL`,
+      );
+    }
+    if (record.createdById === approverId) {
+      throw new ForbiddenException(
+        'ผู้อนุมัติต้องไม่ใช่ผู้สร้าง broadcast (Segregation of Duties)',
+      );
+    }
+
+    const now = new Date();
+
+    // If scheduled in the future → just mark SCHEDULED, cron dispatches.
+    if (record.scheduledAt && record.scheduledAt > now) {
+      await this.prisma.broadcastMessage.update({
+        where: { id },
+        data: {
+          status: 'SCHEDULED',
+          approvedById: approverId,
+          approvedAt: now,
+        },
+      });
+      return {
+        success: true,
+        message: `อนุมัติแล้ว — จะถูกส่งตามเวลา ${record.scheduledAt.toLocaleString('th-TH')}`,
+        id,
+      };
+    }
+
+    // Otherwise dispatch now.
+    const msgItems = (record.messages as unknown as BroadcastMessageItem[]) ?? [];
+    const lineMessages = msgItems
+      .map((m) => this.buildLineMessage(m.type, m.content))
+      .filter((m): m is LineMessage => m !== null);
+
+    const result = await this.dispatchLineMessages(record.audience, lineMessages);
+
+    await this.prisma.broadcastMessage.update({
+      where: { id },
+      data: {
+        status: result.success ? 'SENT' : 'FAILED',
+        sentAt: result.success ? now : null,
+        errorMessage: result.success ? null : result.message,
+        approvedById: approverId,
+        approvedAt: now,
+      },
+    });
+
+    return { success: result.success, message: result.message, id };
+  }
+
+  async rejectBroadcast(
+    id: string,
+    rejecterId: string,
+    reason: string,
+  ): Promise<{ success: boolean; message: string; id: string }> {
+    if (!reason || reason.trim().length < 5) {
+      throw new BadRequestException('กรุณาระบุเหตุผลการปฏิเสธ (อย่างน้อย 5 ตัวอักษร)');
+    }
+    const record = await this.prisma.broadcastMessage.findUnique({ where: { id } });
+    if (!record) throw new NotFoundException('ไม่พบ broadcast');
+    if (record.status !== 'PENDING_APPROVAL') {
+      throw new BadRequestException(
+        `broadcast อยู่ในสถานะ ${record.status} — ปฏิเสธได้เฉพาะสถานะ PENDING_APPROVAL`,
+      );
+    }
+    if (record.createdById === rejecterId) {
+      throw new ForbiddenException(
+        'ผู้ปฏิเสธต้องไม่ใช่ผู้สร้าง broadcast (Segregation of Duties)',
+      );
+    }
+
+    await this.prisma.broadcastMessage.update({
+      where: { id },
+      data: {
+        status: 'REJECTED',
+        rejectedById: rejecterId,
+        rejectedAt: new Date(),
+        rejectedReason: reason.trim(),
+      },
+    });
+
+    return { success: true, message: 'ปฏิเสธ broadcast แล้ว', id };
   }
 
   /** Called by cron — process all due SCHEDULED messages */


### PR DESCRIPTION
## Summary
Broadcast ไปหาลูกค้า mass เดิม OWNER กดครั้งเดียว = ส่ง → เสี่ยง message ผิด/phishing/sensitive ไปถึงลูกค้าทั้งหมด

## Flow ใหม่
1. POST /line-oa/broadcast — สร้างเป็น PENDING_APPROVAL (ไม่ส่งทันที)
2. POST /line-oa/broadcast/:id/approve — manager คนที่สองอนุมัติ (SoD: approver ≠ creator, role OWNER/FM)
3. POST /line-oa/broadcast/:id/reject — ปฏิเสธพร้อมเหตุผล (≥ 5 ตัวอักษร)

**Schema**: BroadcastMessage +approvedById/At, +rejectedById/At, +rejectedReason; status default → PENDING_APPROVAL

## Test plan
- [x] +9 service tests (pending save, SoD checks, scheduled/immediate flows, reject flow)
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)