### PR TITLE
feat(webhook-security): centralized anomaly log + spike cron (Sprint 5a — P2Q12=A)

### DIFF
--- a/apps/api/prisma/migrations/20260523000000_add_webhook_anomaly/migration.sql
+++ b/apps/api/prisma/migrations/20260523000000_add_webhook_anomaly/migration.sql
@@ -1,0 +1,19 @@
+-- Append-only log of suspicious webhook events (HMAC failures,
+-- missing-signature attempts, merchantid mismatches). Feeds an hourly
+-- observation cron that alerts on spikes.
+
+CREATE TABLE "webhook_anomalies" (
+  "id"         TEXT NOT NULL,
+  "provider"   TEXT NOT NULL,
+  "reason"     TEXT NOT NULL,
+  "ip_address" TEXT,
+  "user_agent" TEXT,
+  "meta"       JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "webhook_anomalies_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "webhook_anomalies_provider_created_at_idx"
+  ON "webhook_anomalies"("provider", "created_at");
+CREATE INDEX "webhook_anomalies_created_at_idx"
+  ON "webhook_anomalies"("created_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3697,6 +3697,26 @@ model AiAutoReplyLog {
   @@map("ai_auto_reply_logs")
 }
 
+/// Append-only log of suspicious webhook events: HMAC signature mismatches,
+/// missing-secret attempts, merchantid mismatches. Used by the observation
+/// cron to detect spikes that may signal credential-stuffing or a rotated
+/// secret that didn't propagate to prod.
+///
+/// Immutable audit log — updatedAt/deletedAt intentionally omitted
+model WebhookAnomaly {
+  id         String   @id @default(uuid())
+  provider   String // 'line-finance' | 'line-shop' | 'paysolutions' | 'sms' | 'facebook'
+  reason     String // 'invalid_signature' | 'missing_signature' | 'missing_secret' | 'merchant_mismatch' | 'other'
+  ipAddress  String?  @map("ip_address")
+  userAgent  String?  @map("user_agent") @db.Text
+  meta       Json? // provider-specific payload fragment (no PII)
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@index([provider, createdAt])
+  @@index([createdAt])
+  @@map("webhook_anomalies")
+}
+
 model BroadcastMessage {
   id            String    @id @default(uuid())
   messages      Json      // array: [{ type, content }] — supports up to 5 messages

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,6 +29,7 @@ import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { ReportsModule } from './modules/reports/reports.module';
 import { MigrationModule } from './modules/migration/migration.module';
 import { AuditModule } from './modules/audit/audit.module';
+import { WebhookSecurityModule } from './modules/webhook-security/webhook-security.module';
 import { UsersModule } from './modules/users/users.module';
 import { SettingsModule } from './modules/settings/settings.module';
 import { InventoryModule } from './modules/inventory/inventory.module';
@@ -138,6 +139,7 @@ import { AppCacheModule } from './cache/cache.module';
     // MASTER: Polish
     MigrationModule,
     AuditModule,
+    WebhookSecurityModule,
     // Legal Compliance & PDPA
     PDPAModule,
     KycModule,

--- a/apps/api/src/modules/chatbot-finance/guards/line-finance-webhook.guard.ts
+++ b/apps/api/src/modules/chatbot-finance/guards/line-finance-webhook.guard.ts
@@ -9,6 +9,7 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import { Request } from 'express';
 import { RawBodyRequest } from '../../../common/types/raw-body-request';
 import { IntegrationConfigService } from '../../integrations/integration-config.service';
+import { WebhookAnomalyService } from '../../webhook-security/webhook-anomaly.service';
 
 /**
  * Verify LINE webhook signature สำหรับ Finance OA
@@ -18,13 +19,18 @@ import { IntegrationConfigService } from '../../integrations/integration-config.
 export class LineFinanceWebhookGuard implements CanActivate {
   private readonly logger = new Logger(LineFinanceWebhookGuard.name);
 
-  constructor(private readonly integrationConfig: IntegrationConfigService) {}
+  constructor(
+    private readonly integrationConfig: IntegrationConfigService,
+    private readonly anomaly: WebhookAnomalyService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const channelSecret =
       (await this.integrationConfig.getValue('line-finance', 'channelSecret')) || undefined;
 
     const request = context.switchToHttp().getRequest<Request>();
+    const ipAddress = request.ip;
+    const userAgent = request.headers['user-agent'] as string | undefined;
 
     if (!channelSecret) {
       // SECURITY: dev-only bypass. In production, missing secret = hard
@@ -36,12 +42,24 @@ export class LineFinanceWebhookGuard implements CanActivate {
         return true;
       }
       this.logger.error('LINE Finance channel secret missing in production — refusing webhook');
+      void this.anomaly.record({
+        provider: 'line-finance',
+        reason: 'missing_secret',
+        ipAddress,
+        userAgent,
+      });
       throw new UnauthorizedException('Webhook signature verification not configured');
     }
 
     const signature = request.headers['x-line-signature'] as string | undefined;
     if (!signature) {
       this.logger.warn('Missing x-line-signature header');
+      void this.anomaly.record({
+        provider: 'line-finance',
+        reason: 'missing_signature',
+        ipAddress,
+        userAgent,
+      });
       throw new UnauthorizedException('Missing LINE signature');
     }
 
@@ -62,6 +80,12 @@ export class LineFinanceWebhookGuard implements CanActivate {
     const expBuf = Buffer.from(expected, 'base64');
     if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
       this.logger.warn('Invalid LINE Finance webhook signature');
+      void this.anomaly.record({
+        provider: 'line-finance',
+        reason: 'invalid_signature',
+        ipAddress,
+        userAgent,
+      });
       throw new UnauthorizedException('Invalid LINE signature');
     }
     return true;

--- a/apps/api/src/modules/paysolutions/paysolutions.controller.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.controller.ts
@@ -8,14 +8,17 @@ import {
   Logger,
   BadRequestException,
   ParseUUIDPipe,
+  Req,
   UseGuards,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 import { PaySolutionsService } from './paysolutions.service';
 import { CreatePaymentIntentDto } from './dto';
 import { LiffTokenGuard } from '../line-oa/guards/liff-token.guard';
+import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
 
 /**
  * PaySolutions Payment Gateway Controller
@@ -29,7 +32,10 @@ import { LiffTokenGuard } from '../line-oa/guards/liff-token.guard';
 export class PaySolutionsController {
   private readonly logger = new Logger(PaySolutionsController.name);
 
-  constructor(private readonly paySolutionsService: PaySolutionsService) {}
+  constructor(
+    private readonly paySolutionsService: PaySolutionsService,
+    private readonly anomaly: WebhookAnomalyService,
+  ) {}
 
   /**
    * POST /api/paysolutions/create-intent
@@ -73,7 +79,7 @@ export class PaySolutionsController {
   @Post('webhook')
   @SkipCsrf()
   @HttpCode(200)
-  async handleWebhook(@Body() body: Record<string, string>) {
+  async handleWebhook(@Body() body: Record<string, string>, @Req() req: Request) {
     // PII-safe log: only fields needed to trace a webhook in support
     // tickets. Customer email/phone/name are NOT in the v2 webhook
     // payload but we still want a positive allow-list to prevent
@@ -95,6 +101,13 @@ export class PaySolutionsController {
     const isValid = await this.paySolutionsService.verifyWebhookMerchant(body.merchantid || '');
     if (!isValid) {
       this.logger.warn('Invalid webhook merchantid');
+      void this.anomaly.record({
+        provider: 'paysolutions',
+        reason: 'merchant_mismatch',
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'] as string | undefined,
+        meta: { refno: body.refno, order_no: body.order_no },
+      });
       return { received: true, processed: false };
     }
 

--- a/apps/api/src/modules/webhook-security/webhook-anomaly.cron.spec.ts
+++ b/apps/api/src/modules/webhook-security/webhook-anomaly.cron.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhookAnomalyCron } from './webhook-anomaly.cron';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('WebhookAnomalyCron.detectSpikes', () => {
+  let cron: WebhookAnomalyCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    prisma = {
+      webhookAnomaly: { groupBy: jest.fn().mockResolvedValue([]) },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [WebhookAnomalyCron, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    cron = mod.get(WebhookAnomalyCron);
+  });
+
+  it('returns empty when no anomalies', async () => {
+    const result = await cron.detectSpikes();
+    expect(result.total).toBe(0);
+    expect(result.spikes).toEqual([]);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not alert when counts are below threshold', async () => {
+    prisma.webhookAnomaly.groupBy.mockResolvedValue([
+      { provider: 'line-finance', reason: 'invalid_signature', _count: 3 },
+      { provider: 'paysolutions', reason: 'merchant_mismatch', _count: 2 },
+    ]);
+    const result = await cron.detectSpikes();
+    expect(result.total).toBe(5);
+    expect(result.spikes).toEqual([]);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('alerts when provider crosses SPIKE_THRESHOLD (10)', async () => {
+    prisma.webhookAnomaly.groupBy.mockResolvedValue([
+      { provider: 'line-finance', reason: 'invalid_signature', _count: 8 },
+      { provider: 'line-finance', reason: 'missing_signature', _count: 4 },
+    ]);
+    const result = await cron.detectSpikes();
+    expect(result.spikes).toEqual([{ provider: 'line-finance', count: 12 }]);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Webhook anomaly spike'),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ cron: 'webhook-anomaly' }),
+      }),
+    );
+  });
+
+  it('captures exception on DB error (does NOT throw)', async () => {
+    prisma.webhookAnomaly.groupBy.mockRejectedValue(new Error('db down'));
+    const result = await cron.detectSpikes();
+    expect(result.total).toBe(0);
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/webhook-security/webhook-anomaly.cron.ts
+++ b/apps/api/src/modules/webhook-security/webhook-anomaly.cron.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Hourly observation of webhook anomalies. Alerts Sentry if any single
+ * provider crosses the spike threshold — more than that in one hour usually
+ * means a credential-stuffing probe or a mis-rotated secret, and we want
+ * someone to look.
+ */
+@Injectable()
+export class WebhookAnomalyCron {
+  private readonly logger = new Logger(WebhookAnomalyCron.name);
+  static readonly SPIKE_THRESHOLD = 10;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Cron('5 * * * *', { timeZone: 'Asia/Bangkok' })
+  async detectSpikes(): Promise<{ total: number; spikes: Array<{ provider: string; count: number }> }> {
+    try {
+      const since = new Date(Date.now() - 60 * 60 * 1000);
+      const rows = await this.prisma.webhookAnomaly.groupBy({
+        by: ['provider', 'reason'],
+        where: { createdAt: { gte: since } },
+        _count: true,
+      });
+
+      const byProvider = new Map<string, number>();
+      for (const row of rows) {
+        byProvider.set(row.provider, (byProvider.get(row.provider) ?? 0) + row._count);
+      }
+
+      const total = Array.from(byProvider.values()).reduce((a, b) => a + b, 0);
+      const spikes = Array.from(byProvider.entries())
+        .filter(([, count]) => count >= WebhookAnomalyCron.SPIKE_THRESHOLD)
+        .map(([provider, count]) => ({ provider, count }));
+
+      if (spikes.length > 0) {
+        this.logger.warn(
+          `Webhook anomaly spike(s): ${spikes.map((s) => `${s.provider}=${s.count}`).join(', ')}`,
+        );
+        Sentry.captureMessage(
+          `Webhook anomaly spike in last hour: ${spikes.map((s) => `${s.provider}(${s.count})`).join(', ')}`,
+          {
+            level: 'warning',
+            tags: { kind: 'cron-job', cron: 'webhook-anomaly' },
+            extra: { spikes, totalAnomalies: total },
+          },
+        );
+      }
+
+      return { total, spikes };
+    } catch (err) {
+      this.logger.error(`Webhook anomaly cron failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'webhook-anomaly' } });
+      return { total: 0, spikes: [] };
+    }
+  }
+}

--- a/apps/api/src/modules/webhook-security/webhook-anomaly.service.spec.ts
+++ b/apps/api/src/modules/webhook-security/webhook-anomaly.service.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhookAnomalyService } from './webhook-anomaly.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('WebhookAnomalyService.record', () => {
+  let service: WebhookAnomalyService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      webhookAnomaly: {
+        create: jest.fn().mockResolvedValue({ id: 'wa-1' }),
+      },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [WebhookAnomalyService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(WebhookAnomalyService);
+  });
+
+  it('persists anomaly with required fields', async () => {
+    await service.record({
+      provider: 'line-finance',
+      reason: 'invalid_signature',
+      ipAddress: '1.2.3.4',
+      userAgent: 'line-bot/1.0',
+    });
+    expect(prisma.webhookAnomaly.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          provider: 'line-finance',
+          reason: 'invalid_signature',
+          ipAddress: '1.2.3.4',
+          userAgent: 'line-bot/1.0',
+        }),
+      }),
+    );
+  });
+
+  it('truncates excessively long user agent to 500 chars', async () => {
+    const longUa = 'x'.repeat(2000);
+    await service.record({
+      provider: 'paysolutions',
+      reason: 'merchant_mismatch',
+      userAgent: longUa,
+    });
+    const data = prisma.webhookAnomaly.create.mock.calls[0][0].data;
+    expect(data.userAgent.length).toBe(500);
+  });
+
+  it('swallows DB failure (observability must not block webhooks)', async () => {
+    prisma.webhookAnomaly.create.mockRejectedValue(new Error('table missing'));
+    await expect(
+      service.record({ provider: 'line-finance', reason: 'invalid_signature' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/webhook-security/webhook-anomaly.service.ts
+++ b/apps/api/src/modules/webhook-security/webhook-anomaly.service.ts
@@ -1,0 +1,67 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export type WebhookProvider =
+  | 'line-finance'
+  | 'line-shop'
+  | 'line-staff'
+  | 'paysolutions'
+  | 'sms'
+  | 'facebook';
+
+export type AnomalyReason =
+  | 'invalid_signature'
+  | 'missing_signature'
+  | 'missing_secret'
+  | 'merchant_mismatch'
+  | 'replay_suspicion'
+  | 'other';
+
+export interface AnomalyRecord {
+  provider: WebhookProvider;
+  reason: AnomalyReason;
+  ipAddress?: string;
+  userAgent?: string;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Centralized observability for webhook signature anomalies.
+ *
+ * Rather than building per-provider logging paths, every webhook that verifies
+ * its source funnels its rejections through this service. The hourly cron
+ * (WebhookAnomalyCron) then looks for spikes — a sustained stream of invalid
+ * signatures usually means either a bad secret rotation or a probing attacker.
+ *
+ * Writes are fire-and-forget: anomaly logging must never block webhook
+ * processing, and failures to log are noted in-process only.
+ */
+@Injectable()
+export class WebhookAnomalyService {
+  private readonly logger = new Logger(WebhookAnomalyService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async record(entry: AnomalyRecord): Promise<void> {
+    try {
+      await this.prisma.webhookAnomaly.create({
+        data: {
+          provider: entry.provider,
+          reason: entry.reason,
+          ipAddress: entry.ipAddress ?? null,
+          userAgent: entry.userAgent ? entry.userAgent.slice(0, 500) : null,
+          meta: (entry.meta as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to persist webhook anomaly for ${entry.provider}: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { module: 'webhook-security', action: 'record_anomaly' },
+      });
+    }
+  }
+}

--- a/apps/api/src/modules/webhook-security/webhook-security.module.ts
+++ b/apps/api/src/modules/webhook-security/webhook-security.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { WebhookAnomalyService } from './webhook-anomaly.service';
+import { WebhookAnomalyCron } from './webhook-anomaly.cron';
+
+/**
+ * Global because every webhook controller/guard needs access to
+ * WebhookAnomalyService without importing a module chain.
+ */
+@Global()
+@Module({
+  providers: [WebhookAnomalyService, WebhookAnomalyCron],
+  exports: [WebhookAnomalyService],
+})
+export class WebhookSecurityModule {}


### PR DESCRIPTION
## Summary
Webhook signature verification แยกกันตาม provider → ไม่มีที่รวม observability เมื่อมี attack/secret rotation fail

## Changes
- `WebhookAnomaly` model (append-only): provider/reason/ip/ua/meta
- `WebhookAnomalyService` (@Global): fire-and-forget, ไม่ block webhook
- `WebhookAnomalyCron` (hourly offset 5 min): spike ≥10/hr/provider → Sentry warning
- Wire LINE Finance guard (3 reasons) + PaySolutions (merchant_mismatch)

Providers เหลือ (LINE shop, SMS, Facebook) behavior เดิม — ค่อย wire เพิ่มเมื่อพร้อม

## Test plan
- [x] +7 tests (service + cron)
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)