### PR TITLE
feat(ai-usage): per-call cost tracking + daily budget alert (Sprint 5b)

### DIFF
--- a/apps/api/prisma/migrations/20260523100000_add_ai_usage_log/migration.sql
+++ b/apps/api/prisma/migrations/20260523100000_add_ai_usage_log/migration.sql
@@ -1,0 +1,22 @@
+-- AiUsageLog — one row per Claude API call. Feeds the daily cost cron
+-- which alerts on runaway usage. Decimal(12,6) so sub-cent calls
+-- (common for haiku vision) stay precise.
+
+CREATE TABLE "ai_usage_logs" (
+  "id"            TEXT NOT NULL,
+  "service"       TEXT NOT NULL,
+  "method"        TEXT,
+  "model"         TEXT NOT NULL,
+  "input_tokens"  INTEGER NOT NULL,
+  "output_tokens" INTEGER NOT NULL,
+  "cost_usd"      DECIMAL(12,6) NOT NULL,
+  "user_id"       TEXT,
+  "status"        TEXT NOT NULL,
+  "error_kind"    TEXT,
+  "created_at"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ai_usage_logs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ai_usage_logs_service_created_at_idx" ON "ai_usage_logs"("service", "created_at");
+CREATE INDEX "ai_usage_logs_created_at_idx" ON "ai_usage_logs"("created_at");
+CREATE INDEX "ai_usage_logs_user_id_idx" ON "ai_usage_logs"("user_id");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3697,6 +3697,33 @@ model AiAutoReplyLog {
   @@map("ai_auto_reply_logs")
 }
 
+/// Append-only log of Claude API calls: one row per request. Used by the
+/// daily cost cron to detect runaway usage + budget alerts. Storing every
+/// call is cheap at current volume (~thousands/day) and far easier than
+/// reconstructing from logs.
+///
+/// Immutable — updatedAt/deletedAt intentionally omitted (cost history
+/// shouldn't be editable after the fact)
+model AiUsageLog {
+  id           String   @id @default(uuid())
+  service      String // 'finance-ai' | 'vision-slip' | 'ocr' | 'credit-check' | 'chatbot' | etc.
+  method       String? // optional: specific method inside the service
+  model        String // Claude model id (e.g. 'claude-haiku-4-5-20251001')
+  inputTokens  Int      @map("input_tokens")
+  outputTokens Int      @map("output_tokens")
+  /// USD — stored with 6 decimals so sub-cent calls stay precise
+  costUsd      Decimal  @map("cost_usd") @db.Decimal(12, 6)
+  userId       String?  @map("user_id")
+  status       String // 'success' | 'error'
+  errorKind    String?  @map("error_kind")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  @@index([service, createdAt])
+  @@index([createdAt])
+  @@index([userId])
+  @@map("ai_usage_logs")
+}
+
 /// Append-only log of suspicious webhook events: HMAC signature mismatches,
 /// missing-secret attempts, merchantid mismatches. Used by the observation
 /// cron to detect spikes that may signal credential-stuffing or a rotated

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -30,6 +30,7 @@ import { ReportsModule } from './modules/reports/reports.module';
 import { MigrationModule } from './modules/migration/migration.module';
 import { AuditModule } from './modules/audit/audit.module';
 import { WebhookSecurityModule } from './modules/webhook-security/webhook-security.module';
+import { AiUsageModule } from './modules/ai-usage/ai-usage.module';
 import { UsersModule } from './modules/users/users.module';
 import { SettingsModule } from './modules/settings/settings.module';
 import { InventoryModule } from './modules/inventory/inventory.module';
@@ -140,6 +141,7 @@ import { AppCacheModule } from './cache/cache.module';
     MigrationModule,
     AuditModule,
     WebhookSecurityModule,
+    AiUsageModule,
     // Legal Compliance & PDPA
     PDPAModule,
     KycModule,

--- a/apps/api/src/modules/ai-usage/ai-budget.cron.spec.ts
+++ b/apps/api/src/modules/ai-usage/ai-budget.cron.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Prisma } from '@prisma/client';
+import { AiBudgetCron } from './ai-budget.cron';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('AiBudgetCron.checkDailyBudget', () => {
+  let cron: AiBudgetCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let config: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    prisma = {
+      aiUsageLog: { groupBy: jest.fn().mockResolvedValue([]) },
+    };
+    config = { get: jest.fn().mockReturnValue('10') };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        AiBudgetCron,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: config },
+      ],
+    }).compile();
+    cron = mod.get(AiBudgetCron);
+  });
+
+  it('returns 0 breach when no usage', async () => {
+    const result = await cron.checkDailyBudget();
+    expect(result.totalUsd).toBe(0);
+    expect(result.breached).toBe(false);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('alerts warning when spend >= 80% of budget but not yet breached', async () => {
+    prisma.aiUsageLog.groupBy.mockResolvedValue([
+      { service: 'finance-ai', _sum: { costUsd: new Prisma.Decimal('8.5') } },
+    ]);
+    await cron.checkDailyBudget();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('of $10'),
+      expect.objectContaining({ level: 'warning' }),
+    );
+  });
+
+  it('alerts error when spend > budget', async () => {
+    prisma.aiUsageLog.groupBy.mockResolvedValue([
+      { service: 'finance-ai', _sum: { costUsd: new Prisma.Decimal('7.5') } },
+      { service: 'vision-slip', _sum: { costUsd: new Prisma.Decimal('3.5') } },
+    ]);
+    const result = await cron.checkDailyBudget();
+    expect(result.breached).toBe(true);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('breached'),
+      expect.objectContaining({ level: 'error' }),
+    );
+  });
+
+  it('uses default budget $10 when env var missing', async () => {
+    config.get.mockReturnValue(undefined);
+    prisma.aiUsageLog.groupBy.mockResolvedValue([
+      { service: 'finance-ai', _sum: { costUsd: new Prisma.Decimal('11') } },
+    ]);
+    const result = await cron.checkDailyBudget();
+    expect(result.breached).toBe(true);
+  });
+
+  it('captures exception on DB failure (no throw)', async () => {
+    prisma.aiUsageLog.groupBy.mockRejectedValue(new Error('db error'));
+    const result = await cron.checkDailyBudget();
+    expect(result.totalUsd).toBe(0);
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/ai-usage/ai-budget.cron.ts
+++ b/apps/api/src/modules/ai-usage/ai-budget.cron.ts
@@ -1,0 +1,82 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Hourly cost check. If cumulative USD spend for the current Asia/Bangkok
+ * day exceeds the configured budget (ANTHROPIC_DAILY_BUDGET_USD, default
+ * $10), emit a Sentry warning with a per-service breakdown.
+ *
+ * We intentionally do NOT hard-stop AI calls here — that belongs at the
+ * call site with idempotent checks. This cron is observability first;
+ * stopping runaway usage is a separate project.
+ */
+@Injectable()
+export class AiBudgetCron {
+  private readonly logger = new Logger(AiBudgetCron.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Cron('10 * * * *', { timeZone: 'Asia/Bangkok' })
+  async checkDailyBudget(): Promise<{ totalUsd: number; breached: boolean }> {
+    try {
+      const budget = Number(this.config.get<string>('ANTHROPIC_DAILY_BUDGET_USD') ?? '10');
+      const start = new Date();
+      start.setHours(0, 0, 0, 0);
+
+      const rows = await this.prisma.aiUsageLog.groupBy({
+        by: ['service'],
+        where: { createdAt: { gte: start } },
+        _sum: { costUsd: true },
+      });
+
+      const byService: Record<string, number> = {};
+      let totalUsd = 0;
+      for (const row of rows) {
+        const svcCost = Number(row._sum.costUsd ?? 0);
+        byService[row.service] = svcCost;
+        totalUsd += svcCost;
+      }
+
+      const breached = totalUsd > budget;
+      const alertThreshold = budget * 0.8;
+
+      if (breached) {
+        this.logger.error(
+          `AI daily budget breached: total $${totalUsd.toFixed(4)} > budget $${budget.toFixed(2)}`,
+        );
+        Sentry.captureMessage(
+          `AI daily budget breached: $${totalUsd.toFixed(4)} > $${budget.toFixed(2)}`,
+          {
+            level: 'error',
+            tags: { kind: 'cron-job', cron: 'ai-budget' },
+            extra: { totalUsd, budget, byService },
+          },
+        );
+      } else if (totalUsd >= alertThreshold) {
+        this.logger.warn(
+          `AI daily spend ${((totalUsd / budget) * 100).toFixed(0)}% of budget`,
+        );
+        Sentry.captureMessage(
+          `AI daily spend at ${((totalUsd / budget) * 100).toFixed(0)}% of $${budget.toFixed(2)}`,
+          {
+            level: 'warning',
+            tags: { kind: 'cron-job', cron: 'ai-budget' },
+            extra: { totalUsd, budget, byService },
+          },
+        );
+      }
+
+      return { totalUsd, breached };
+    } catch (err) {
+      this.logger.error(`AI budget cron failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'ai-budget' } });
+      return { totalUsd: 0, breached: false };
+    }
+  }
+}

--- a/apps/api/src/modules/ai-usage/ai-pricing.spec.ts
+++ b/apps/api/src/modules/ai-usage/ai-pricing.spec.ts
@@ -1,0 +1,39 @@
+import { computeCostUsd, ratesFor } from './ai-pricing';
+
+describe('ai-pricing', () => {
+  it('returns haiku rate for haiku model', () => {
+    const r = ratesFor('claude-haiku-4-5-20251001');
+    expect(r.inputPer1M).toBe(0.8);
+    expect(r.outputPer1M).toBe(4);
+  });
+
+  it('returns opus rate for opus model', () => {
+    const r = ratesFor('claude-opus-4-7');
+    expect(r.inputPer1M).toBe(15);
+    expect(r.outputPer1M).toBe(75);
+  });
+
+  it('falls back to default rate for unknown model id', () => {
+    const r = ratesFor('claude-future-model');
+    expect(r.inputPer1M).toBe(3);
+    expect(r.outputPer1M).toBe(15);
+  });
+
+  it('computes cost for haiku 10k in + 2k out', () => {
+    // 10k × 0.8/M = 0.008 ; 2k × 4/M = 0.008 → 0.016
+    const cost = computeCostUsd('claude-haiku-4-5-20251001', 10_000, 2_000);
+    expect(cost).toBeCloseTo(0.016, 6);
+  });
+
+  it('computes cost for sonnet 50k in + 10k out', () => {
+    // 50k × 3/M = 0.15 ; 10k × 15/M = 0.15 → 0.3
+    const cost = computeCostUsd('claude-sonnet-4-5-20250514', 50_000, 10_000);
+    expect(cost).toBeCloseTo(0.3, 6);
+  });
+
+  it('rounds to 6 decimals', () => {
+    const cost = computeCostUsd('claude-haiku-4-5-20251001', 1, 1);
+    // 1 × 0.8/1M = 0.0000008; 1 × 4/1M = 0.000004; total 0.0000048 → rounded to 0.000005
+    expect(cost).toBe(0.000005);
+  });
+});

--- a/apps/api/src/modules/ai-usage/ai-pricing.ts
+++ b/apps/api/src/modules/ai-usage/ai-pricing.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-model Claude pricing in USD per 1M tokens (Jan 2026 rate card).
+ *
+ * Kept as a static table because:
+ *  - The Anthropic API does not return cost in-band, only token counts
+ *  - We don't want to change price calculation by reaching out to the API
+ *  - When Anthropic changes prices, we edit this file and PR it so the
+ *    history shows exactly when the team updated the rates
+ *
+ * Unknown model ids fall through to a conservative default (haiku rate) so
+ * we always log _something_; usage tracking must never silently skip a call.
+ */
+
+export interface ModelRate {
+  inputPer1M: number;
+  outputPer1M: number;
+}
+
+// Prices in USD per 1 million tokens.
+// https://www.anthropic.com/pricing (snapshot 2026-01)
+const RATE_CARD: Record<string, ModelRate> = {
+  // Claude 4.x — Jan 2026
+  'claude-opus-4-7': { inputPer1M: 15, outputPer1M: 75 },
+  'claude-sonnet-4-5-20250514': { inputPer1M: 3, outputPer1M: 15 },
+  'claude-sonnet-4-6': { inputPer1M: 3, outputPer1M: 15 },
+  'claude-haiku-4-5-20251001': { inputPer1M: 0.8, outputPer1M: 4 },
+  // Fallback
+  default: { inputPer1M: 3, outputPer1M: 15 },
+};
+
+export function ratesFor(model: string): ModelRate {
+  return RATE_CARD[model] ?? RATE_CARD.default;
+}
+
+/** Returns USD cost rounded to 6 decimal places. */
+export function computeCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const rate = ratesFor(model);
+  const cost =
+    (inputTokens / 1_000_000) * rate.inputPer1M +
+    (outputTokens / 1_000_000) * rate.outputPer1M;
+  // 6 decimals — matches Decimal(12,6) in schema
+  return Math.round(cost * 1_000_000) / 1_000_000;
+}

--- a/apps/api/src/modules/ai-usage/ai-usage.module.ts
+++ b/apps/api/src/modules/ai-usage/ai-usage.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { AiUsageService } from './ai-usage.service';
+import { AiBudgetCron } from './ai-budget.cron';
+
+/**
+ * Global so any service that calls Claude can inject AiUsageService without
+ * a module import chain.
+ */
+@Global()
+@Module({
+  providers: [AiUsageService, AiBudgetCron],
+  exports: [AiUsageService],
+})
+export class AiUsageModule {}

--- a/apps/api/src/modules/ai-usage/ai-usage.service.spec.ts
+++ b/apps/api/src/modules/ai-usage/ai-usage.service.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiUsageService } from './ai-usage.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('AiUsageService.record', () => {
+  let service: AiUsageService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      aiUsageLog: { create: jest.fn().mockResolvedValue({ id: 'au-1' }) },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [AiUsageService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(AiUsageService);
+  });
+
+  it('writes one row with computed cost for haiku call', async () => {
+    await service.record({
+      service: 'finance-ai',
+      method: 'generateReply',
+      model: 'claude-haiku-4-5-20251001',
+      inputTokens: 10_000,
+      outputTokens: 2_000,
+      status: 'success',
+    });
+    const data = prisma.aiUsageLog.create.mock.calls[0][0].data;
+    expect(data.service).toBe('finance-ai');
+    expect(data.model).toBe('claude-haiku-4-5-20251001');
+    expect(data.inputTokens).toBe(10_000);
+    expect(Number(data.costUsd)).toBeCloseTo(0.016, 6);
+    expect(data.status).toBe('success');
+  });
+
+  it('captures errorKind on error calls', async () => {
+    await service.record({
+      service: 'finance-ai',
+      method: 'generateReply',
+      model: 'claude-sonnet-4-5-20250514',
+      inputTokens: 500,
+      outputTokens: 0,
+      status: 'error',
+      errorKind: 'empty_response',
+    });
+    const data = prisma.aiUsageLog.create.mock.calls[0][0].data;
+    expect(data.status).toBe('error');
+    expect(data.errorKind).toBe('empty_response');
+  });
+
+  it('swallows DB failure (never block AI call)', async () => {
+    prisma.aiUsageLog.create.mockRejectedValue(new Error('no table'));
+    await expect(
+      service.record({
+        service: 'finance-ai',
+        model: 'claude-haiku-4-5-20251001',
+        inputTokens: 100,
+        outputTokens: 50,
+        status: 'success',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/ai-usage/ai-usage.service.ts
+++ b/apps/api/src/modules/ai-usage/ai-usage.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+import { computeCostUsd } from './ai-pricing';
+
+export interface UsageRecord {
+  service: string;
+  method?: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  userId?: string;
+  status: 'success' | 'error';
+  errorKind?: string;
+}
+
+/**
+ * Centralized logger for every Claude API call. Kept fire-and-forget so
+ * audit logging never blocks or fails a customer-facing AI call. The hourly
+ * cron reads from this table to compute running daily spend.
+ */
+@Injectable()
+export class AiUsageService {
+  private readonly logger = new Logger(AiUsageService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async record(entry: UsageRecord): Promise<void> {
+    try {
+      const costUsd = computeCostUsd(entry.model, entry.inputTokens, entry.outputTokens);
+      await this.prisma.aiUsageLog.create({
+        data: {
+          service: entry.service,
+          method: entry.method ?? null,
+          model: entry.model,
+          inputTokens: entry.inputTokens,
+          outputTokens: entry.outputTokens,
+          costUsd: new Prisma.Decimal(costUsd),
+          userId: entry.userId ?? null,
+          status: entry.status,
+          errorKind: entry.errorKind ?? null,
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to persist AI usage for ${entry.service}: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, { tags: { module: 'ai-usage', action: 'record' } });
+    }
+  }
+}

--- a/apps/api/src/modules/chatbot-finance/services/finance-ai.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/finance-ai.service.spec.ts
@@ -4,6 +4,7 @@ import { FinanceAiService } from './finance-ai.service';
 import { FinanceToolExecutor } from '../tools/tool-executor';
 import { FinanceConfigService } from './finance-config.service';
 import { IntegrationConfigService } from '../../integrations/integration-config.service';
+import { AiUsageService } from '../../ai-usage/ai-usage.service';
 
 describe('FinanceAiService', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,6 +41,10 @@ describe('FinanceAiService', () => {
               saveConfig: jest.fn().mockResolvedValue(undefined),
               isConfigured: jest.fn().mockResolvedValue(false),
             },
+          },
+          {
+            provide: AiUsageService,
+            useValue: { record: jest.fn().mockResolvedValue(undefined) },
           },
         ],
       }).compile();
@@ -80,6 +85,10 @@ describe('FinanceAiService', () => {
               saveConfig: jest.fn().mockResolvedValue(undefined),
               isConfigured: jest.fn().mockResolvedValue(true),
             },
+          },
+          {
+            provide: AiUsageService,
+            useValue: { record: jest.fn().mockResolvedValue(undefined) },
           },
         ],
       }).compile();

--- a/apps/api/src/modules/chatbot-finance/services/finance-ai.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/finance-ai.service.ts
@@ -8,6 +8,7 @@ import { FinanceToolExecutor } from '../tools/tool-executor';
 import { FinanceConfigService } from './finance-config.service';
 import { FINANCE_BOT_SYSTEM_PROMPT } from '../prompts/system-prompt';
 import { IntegrationConfigService } from '../../integrations/integration-config.service';
+import { AiUsageService } from '../../ai-usage/ai-usage.service';
 
 export interface AiReply {
   text: string;
@@ -46,6 +47,7 @@ export class FinanceAiService {
     private toolExecutor: FinanceToolExecutor,
     private financeConfig: FinanceConfigService,
     private integrationConfig: IntegrationConfigService,
+    private aiUsage: AiUsageService,
   ) {}
 
   private async getAnthropicClient(): Promise<Anthropic | null> {
@@ -111,8 +113,25 @@ export class FinanceAiService {
           const text = textBlock && textBlock.type === 'text' ? textBlock.text : '';
           if (!text) {
             this.logger.warn('[FinanceAI] Empty text response');
+            void this.aiUsage.record({
+              service: 'finance-ai',
+              method: 'generateReply',
+              model: activeModel,
+              inputTokens: totalInput,
+              outputTokens: totalOutput,
+              status: 'error',
+              errorKind: 'empty_response',
+            });
             return null;
           }
+          void this.aiUsage.record({
+            service: 'finance-ai',
+            method: 'generateReply',
+            model: activeModel,
+            inputTokens: totalInput,
+            outputTokens: totalOutput,
+            status: 'success',
+          });
           return {
             text,
             model: activeModel,


### PR DESCRIPTION
## Summary
Claude API calls ไม่เคยถูกบันทึก → ไม่รู้ว่าเสียเงินไปเท่าไร/วัน ไม่เห็น service ไหนกินงบเยอะ

## Changes
- **AiUsageLog** model (append-only, Decimal(12,6) cost)
- **ai-pricing.ts**: rate card Jan 2026 (opus/sonnet/haiku) + fallback default
- **AiUsageService** (@Global, fire-and-forget)
- **AiBudgetCron** hourly: 80% → warning, >100% → error พร้อม breakdown
  - Default $10/day, override ผ่าน `ANTHROPIC_DAILY_BUDGET_USD`
- Wired into `finance-ai.service` (success + error paths)
- ยังไม่ hard-stop AI calls — สังเกตการณ์ก่อน

## Test plan
- [x] +14 tests (pricing 6 + service 3 + cron 5)
- [x] Finance-ai existing tests ยังผ่าน (updated mocks)
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)