### PR TITLE
feat(refunds): refund endpoint + 2-person approval + bank reversal (T1-C1 / P2Q7=F)

### DIFF
--- a/apps/api/prisma/migrations/20260524000000_add_refund/migration.sql
+++ b/apps/api/prisma/migrations/20260524000000_add_refund/migration.sql
@@ -1,0 +1,57 @@
+-- Refund workflow with 2-person approval + bank reversal tracking (T1-C1).
+-- BESTCHOICE does NOT pay refunds from our own account — staff call the
+-- bank to reverse the original charge. This table records the request,
+-- the approval chain, and whatever reference the bank returns.
+
+CREATE TYPE "RefundStatus" AS ENUM ('REQUESTED', 'APPROVED', 'PROCESSED', 'FAILED', 'REJECTED');
+
+CREATE TABLE "refunds" (
+  "id"                  TEXT NOT NULL,
+  "payment_id"          TEXT NOT NULL,
+  "contract_id"         TEXT NOT NULL,
+  "amount"              DECIMAL(12,2) NOT NULL,
+  "reason"              TEXT NOT NULL,
+  "status"              "RefundStatus" NOT NULL DEFAULT 'REQUESTED',
+  "requested_by_id"     TEXT NOT NULL,
+  "requested_at"        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "approved_by_id"      TEXT,
+  "approved_at"         TIMESTAMP(3),
+  "rejected_by_id"      TEXT,
+  "rejected_at"         TIMESTAMP(3),
+  "rejected_reason"     TEXT,
+  "bank_reversal_ref"   TEXT,
+  "bank_reversal_at"    TIMESTAMP(3),
+  "bank_reversal_notes" TEXT,
+  "failure_reason"      TEXT,
+  "created_at"          TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"          TIMESTAMP(3) NOT NULL,
+  "deleted_at"          TIMESTAMP(3),
+  CONSTRAINT "refunds_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "refunds_payment_id_idx"      ON "refunds"("payment_id");
+CREATE INDEX "refunds_contract_id_idx"     ON "refunds"("contract_id");
+CREATE INDEX "refunds_status_idx"          ON "refunds"("status");
+CREATE INDEX "refunds_requested_by_id_idx" ON "refunds"("requested_by_id");
+CREATE INDEX "refunds_approved_by_id_idx"  ON "refunds"("approved_by_id");
+CREATE INDEX "refunds_created_at_idx"      ON "refunds"("created_at");
+
+ALTER TABLE "refunds"
+  ADD CONSTRAINT "refunds_payment_id_fkey"
+  FOREIGN KEY ("payment_id") REFERENCES "payments"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "refunds"
+  ADD CONSTRAINT "refunds_requested_by_id_fkey"
+  FOREIGN KEY ("requested_by_id") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "refunds"
+  ADD CONSTRAINT "refunds_approved_by_id_fkey"
+  FOREIGN KEY ("approved_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "refunds"
+  ADD CONSTRAINT "refunds_rejected_by_id_fkey"
+  FOREIGN KEY ("rejected_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -448,6 +448,9 @@ model User {
   broadcastMessages      BroadcastMessage[]   @relation("BroadcastCreatedBy")
   broadcastsApproved     BroadcastMessage[]   @relation("BroadcastApprovedBy")
   broadcastsRejected     BroadcastMessage[]   @relation("BroadcastRejectedBy")
+  refundsRequested       Refund[]             @relation("RefundRequestedBy")
+  refundsApproved        Refund[]             @relation("RefundApprovedBy")
+  refundsRejected        Refund[]             @relation("RefundRejectedBy")
 
   @@index([branchId])
   @@map("users")
@@ -719,6 +722,7 @@ model Payment {
   paymentEvidences PaymentEvidence[]
   loyaltyPoint     LoyaltyPoint?
   dunningActions   DunningAction[]
+  refunds          Refund[]
 
   @@unique([contractId, installmentNo])
   @@index([contractId])
@@ -728,6 +732,69 @@ model Payment {
   @@index([status, dueDate])
   @@index([recordedById])
   @@map("payments")
+}
+
+/// Refund workflow (T1-C1 / P2Q7=F — bank reversal model):
+///   REQUESTED (staff creates)
+///     → APPROVED (OWNER/FINANCE_MANAGER, ≠ requester)
+///         → PROCESSED (bank confirms reversal; bankReversalRef captured)
+///         → FAILED    (bank refused or operational error)
+///     → REJECTED (approver declines with reason)
+///
+/// We do NOT pay out from our account — staff calls the bank to reverse
+/// the original charge back to the customer. The record exists to track the
+/// request, the approval, and what the bank said back.
+enum RefundStatus {
+  REQUESTED
+  APPROVED
+  PROCESSED
+  FAILED
+  REJECTED
+}
+
+model Refund {
+  id             String       @id @default(uuid())
+  paymentId      String       @map("payment_id")
+  contractId     String       @map("contract_id")
+  amount         Decimal      @db.Decimal(12, 2)
+  reason         String // staff-entered justification
+  status         RefundStatus @default(REQUESTED)
+
+  requestedById  String       @map("requested_by_id")
+  requestedAt    DateTime     @default(now()) @map("requested_at")
+
+  /// 2-person SoD: must differ from requestedById. Enforced in service layer.
+  approvedById   String?      @map("approved_by_id")
+  approvedAt     DateTime?    @map("approved_at")
+
+  rejectedById   String?      @map("rejected_by_id")
+  rejectedAt     DateTime?    @map("rejected_at")
+  rejectedReason String?      @map("rejected_reason")
+
+  /// Set after the bank confirms the reversal. bankReversalRef is whatever
+  /// reference number the bank's call centre gives (keep as string — formats
+  /// vary by provider and by channel).
+  bankReversalRef String?     @map("bank_reversal_ref")
+  bankReversalAt  DateTime?   @map("bank_reversal_at")
+  bankReversalNotes String?   @map("bank_reversal_notes")
+  failureReason   String?     @map("failure_reason")
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  payment     Payment  @relation(fields: [paymentId], references: [id], onDelete: Restrict)
+  requestedBy User     @relation("RefundRequestedBy", fields: [requestedById], references: [id])
+  approvedBy  User?    @relation("RefundApprovedBy", fields: [approvedById], references: [id])
+  rejectedBy  User?    @relation("RefundRejectedBy", fields: [rejectedById], references: [id])
+
+  @@index([paymentId])
+  @@index([contractId])
+  @@index([status])
+  @@index([requestedById])
+  @@index([approvedById])
+  @@index([createdAt])
+  @@map("refunds")
 }
 
 // ============================================================

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -31,6 +31,7 @@ import { MigrationModule } from './modules/migration/migration.module';
 import { AuditModule } from './modules/audit/audit.module';
 import { WebhookSecurityModule } from './modules/webhook-security/webhook-security.module';
 import { AiUsageModule } from './modules/ai-usage/ai-usage.module';
+import { RefundsModule } from './modules/refunds/refunds.module';
 import { UsersModule } from './modules/users/users.module';
 import { SettingsModule } from './modules/settings/settings.module';
 import { InventoryModule } from './modules/inventory/inventory.module';
@@ -142,6 +143,7 @@ import { AppCacheModule } from './cache/cache.module';
     AuditModule,
     WebhookSecurityModule,
     AiUsageModule,
+    RefundsModule,
     // Legal Compliance & PDPA
     PDPAModule,
     KycModule,

--- a/apps/api/src/modules/refunds/dto/refund.dto.ts
+++ b/apps/api/src/modules/refunds/dto/refund.dto.ts
@@ -1,0 +1,40 @@
+import { IsNumber, IsString, Min, MinLength, MaxLength } from 'class-validator';
+
+export class RequestRefundDto {
+  @IsString()
+  paymentId!: string;
+
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'จำนวนเงินต้องเป็นตัวเลข ทศนิยมไม่เกิน 2 ตำแหน่ง' })
+  @Min(0.01, { message: 'จำนวนเงินต้องมากกว่า 0' })
+  amount!: number;
+
+  @IsString({ message: 'ต้องระบุเหตุผล' })
+  @MinLength(10, { message: 'เหตุผลต้องมีอย่างน้อย 10 ตัวอักษร' })
+  @MaxLength(2000)
+  reason!: string;
+}
+
+export class MarkRefundReversedDto {
+  @IsString({ message: 'ต้องระบุเลขอ้างอิงจากธนาคาร' })
+  @MinLength(3)
+  @MaxLength(200)
+  bankReversalRef!: string;
+
+  @IsString()
+  @MaxLength(2000)
+  notes!: string;
+}
+
+export class RejectRefundDto {
+  @IsString({ message: 'ต้องระบุเหตุผลการปฏิเสธ' })
+  @MinLength(5)
+  @MaxLength(2000)
+  reason!: string;
+}
+
+export class MarkRefundFailedDto {
+  @IsString({ message: 'ต้องระบุเหตุผลที่ธนาคาร reverse ไม่สำเร็จ' })
+  @MinLength(5)
+  @MaxLength(2000)
+  failureReason!: string;
+}

--- a/apps/api/src/modules/refunds/refunds.controller.ts
+++ b/apps/api/src/modules/refunds/refunds.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { RefundsService } from './refunds.service';
+import {
+  RequestRefundDto,
+  MarkRefundReversedDto,
+  RejectRefundDto,
+  MarkRefundFailedDto,
+} from './dto/refund.dto';
+
+@ApiTags('Refunds')
+@ApiBearerAuth('JWT')
+@Controller('refunds')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class RefundsController {
+  constructor(private readonly refunds: RefundsService) {}
+
+  @Get()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  findAll(
+    @Query('status') status?: string,
+    @Query('contractId') contractId?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.refunds.findAll({
+      status,
+      contractId,
+      page: page ? Number(page) : undefined,
+      limit: limit ? Number(limit) : undefined,
+    });
+  }
+
+  @Get(':id')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  findOne(@Param('id') id: string) {
+    return this.refunds.findOne(id);
+  }
+
+  @Post('request')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  request(@Body() dto: RequestRefundDto, @CurrentUser() user: { id: string }) {
+    return this.refunds.requestRefund(dto, user.id);
+  }
+
+  @Post(':id/approve')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  approve(@Param('id') id: string, @CurrentUser() user: { id: string; role: string }) {
+    return this.refunds.approveRefund(id, user.id, user.role);
+  }
+
+  @Post(':id/reject')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  reject(
+    @Param('id') id: string,
+    @Body() dto: RejectRefundDto,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.refunds.rejectRefund(id, dto, user.id, user.role);
+  }
+
+  @Post(':id/mark-reversed')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markReversed(
+    @Param('id') id: string,
+    @Body() dto: MarkRefundReversedDto,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.refunds.markReversed(id, dto, user.id, user.role);
+  }
+
+  @Post(':id/mark-failed')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markFailed(
+    @Param('id') id: string,
+    @Body() dto: MarkRefundFailedDto,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.refunds.markFailed(id, dto, user.id, user.role);
+  }
+}

--- a/apps/api/src/modules/refunds/refunds.module.ts
+++ b/apps/api/src/modules/refunds/refunds.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RefundsController } from './refunds.controller';
+import { RefundsService } from './refunds.service';
+
+@Module({
+  controllers: [RefundsController],
+  providers: [RefundsService],
+  exports: [RefundsService],
+})
+export class RefundsModule {}

--- a/apps/api/src/modules/refunds/refunds.service.spec.ts
+++ b/apps/api/src/modules/refunds/refunds.service.spec.ts
@@ -1,0 +1,208 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { RefundsService } from './refunds.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+describe('RefundsService', () => {
+  let service: RefundsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let audit: any;
+
+  const paidPayment = (overrides: Record<string, unknown> = {}) => ({
+    id: 'pay-1',
+    contractId: 'con-1',
+    amountPaid: new Prisma.Decimal(1000),
+    status: 'PAID',
+    deletedAt: null,
+    refunds: [],
+    ...overrides,
+  });
+
+  const refundRecord = (overrides: Record<string, unknown> = {}) => ({
+    id: 'rf-1',
+    paymentId: 'pay-1',
+    contractId: 'con-1',
+    amount: new Prisma.Decimal(500),
+    reason: 'customer double-paid',
+    status: 'REQUESTED',
+    requestedById: 'u-staff',
+    requestedAt: new Date(),
+    approvedById: null,
+    approvedAt: null,
+    rejectedById: null,
+    rejectedAt: null,
+    deletedAt: null,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      payment: { findUnique: jest.fn().mockResolvedValue(paidPayment()) },
+      refund: {
+        create: jest.fn((args) => Promise.resolve({ id: 'rf-1', ...args.data })),
+        update: jest.fn((args) => Promise.resolve({ ...refundRecord(), ...args.data })),
+        findUnique: jest.fn().mockResolvedValue(refundRecord()),
+        findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        RefundsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = mod.get(RefundsService);
+  });
+
+  describe('requestRefund', () => {
+    it('creates REQUESTED refund + writes audit', async () => {
+      const result = await service.requestRefund(
+        { paymentId: 'pay-1', amount: 500, reason: 'customer double-paid ชำระซ้ำ' },
+        'u-staff',
+      );
+      expect(result.id).toBe('rf-1');
+      expect(prisma.refund.create).toHaveBeenCalled();
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'REFUND_REQUESTED', entity: 'Refund' }),
+      );
+    });
+
+    it('throws NotFound when payment missing', async () => {
+      prisma.payment.findUnique.mockResolvedValue(null);
+      await expect(
+        service.requestRefund({ paymentId: 'missing', amount: 500, reason: 'xxxxxxxxxx' }, 'u-staff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects when payment is PENDING (not paid)', async () => {
+      prisma.payment.findUnique.mockResolvedValue(paidPayment({ status: 'PENDING' }));
+      await expect(
+        service.requestRefund({ paymentId: 'pay-1', amount: 500, reason: 'xxxxxxxxxx' }, 'u-staff'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when open refund already exists (REQUESTED/APPROVED)', async () => {
+      prisma.payment.findUnique.mockResolvedValue(
+        paidPayment({ refunds: [refundRecord({ status: 'REQUESTED' })] }),
+      );
+      await expect(
+        service.requestRefund({ paymentId: 'pay-1', amount: 500, reason: 'xxxxxxxxxx' }, 'u-staff'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when total refunds would exceed amount paid', async () => {
+      prisma.payment.findUnique.mockResolvedValue(
+        paidPayment({
+          amountPaid: new Prisma.Decimal(1000),
+          refunds: [
+            { ...refundRecord(), status: 'PROCESSED', amount: new Prisma.Decimal(600) },
+          ],
+        }),
+      );
+      await expect(
+        service.requestRefund({ paymentId: 'pay-1', amount: 500, reason: 'xxxxxxxxxx' }, 'u-staff'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('approveRefund', () => {
+    it('blocks self-approval', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ requestedById: 'u-same' }));
+      await expect(service.approveRefund('rf-1', 'u-same', 'OWNER')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('blocks BRANCH_MANAGER role (OWNER/FM only)', async () => {
+      await expect(
+        service.approveRefund('rf-1', 'u-other', 'BRANCH_MANAGER'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects non-REQUESTED status', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      await expect(
+        service.approveRefund('rf-1', 'u-fm', 'FINANCE_MANAGER'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('OWNER can approve (different user than requester) + audit', async () => {
+      await service.approveRefund('rf-1', 'u-owner', 'OWNER');
+      expect(prisma.refund.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'APPROVED', approvedById: 'u-owner' }),
+        }),
+      );
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'REFUND_APPROVED' }),
+      );
+    });
+  });
+
+  describe('rejectRefund', () => {
+    it('rejects self-rejection', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ requestedById: 'u-same' }));
+      await expect(
+        service.rejectRefund('rf-1', { reason: 'no basis' }, 'u-same', 'OWNER'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('updates status REJECTED + stores reason', async () => {
+      await service.rejectRefund('rf-1', { reason: 'insufficient evidence' }, 'u-fm', 'FINANCE_MANAGER');
+      const data = prisma.refund.update.mock.calls[0][0].data;
+      expect(data.status).toBe('REJECTED');
+      expect(data.rejectedReason).toBe('insufficient evidence');
+    });
+  });
+
+  describe('markReversed', () => {
+    it('requires APPROVED status', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'REQUESTED' }));
+      await expect(
+        service.markReversed(
+          'rf-1',
+          { bankReversalRef: 'KBANK-12345', notes: 'confirmed by phone' },
+          'u-owner',
+          'OWNER',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('sets PROCESSED with bank ref + audit', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      await service.markReversed(
+        'rf-1',
+        { bankReversalRef: 'KBANK-12345', notes: 'confirmed phone call' },
+        'u-fm',
+        'FINANCE_MANAGER',
+      );
+      const data = prisma.refund.update.mock.calls[0][0].data;
+      expect(data.status).toBe('PROCESSED');
+      expect(data.bankReversalRef).toBe('KBANK-12345');
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'REFUND_PROCESSED' }),
+      );
+    });
+  });
+
+  describe('markFailed', () => {
+    it('sets FAILED with reason when bank declined', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      await service.markFailed(
+        'rf-1',
+        { failureReason: 'bank refused reversal after 7 days' },
+        'u-owner',
+        'OWNER',
+      );
+      const data = prisma.refund.update.mock.calls[0][0].data;
+      expect(data.status).toBe('FAILED');
+      expect(data.failureReason).toContain('bank refused');
+    });
+  });
+});

--- a/apps/api/src/modules/refunds/refunds.service.ts
+++ b/apps/api/src/modules/refunds/refunds.service.ts
@@ -1,0 +1,295 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import {
+  RequestRefundDto,
+  MarkRefundReversedDto,
+  RejectRefundDto,
+  MarkRefundFailedDto,
+} from './dto/refund.dto';
+
+/**
+ * Refund workflow — T1-C1 / P2Q7=F (bank reversal policy).
+ *
+ * The company does NOT pay refunds from its own bank. Staff call the bank to
+ * reverse the original charge back to the customer. This service is the
+ * bookkeeping layer: one row per refund request, one approval slot, one
+ * bank-confirmation slot. Every state change goes to AuditLog.
+ *
+ * Approval roles: OWNER or FINANCE_MANAGER.
+ * SoD: approver ≠ requester (cannot self-approve).
+ */
+@Injectable()
+export class RefundsService {
+  private readonly logger = new Logger(RefundsService.name);
+  static readonly APPROVER_ROLES = ['OWNER', 'FINANCE_MANAGER'];
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async requestRefund(dto: RequestRefundDto, userId: string) {
+    const payment = await this.prisma.payment.findUnique({
+      where: { id: dto.paymentId },
+      include: { refunds: { where: { deletedAt: null } } },
+    });
+    if (!payment || payment.deletedAt) {
+      throw new NotFoundException('ไม่พบรายการชำระเงิน');
+    }
+    if (payment.status !== 'PAID' && payment.status !== 'PARTIALLY_PAID') {
+      throw new BadRequestException(
+        `ขอคืนเงินได้เฉพาะงวดที่ชำระแล้ว (สถานะปัจจุบัน: ${payment.status})`,
+      );
+    }
+
+    const openRefund = payment.refunds.find(
+      (r) => r.status === 'REQUESTED' || r.status === 'APPROVED',
+    );
+    if (openRefund) {
+      throw new BadRequestException(
+        'มีคำขอคืนเงินที่ยังไม่ปิดสำหรับงวดนี้ — กรุณาจัดการคำขอเดิมก่อน',
+      );
+    }
+
+    // Total not-yet-failed/rejected refunds + this request must not exceed paid.
+    const alreadyRefunded = payment.refunds
+      .filter((r) => r.status === 'PROCESSED')
+      .reduce((sum, r) => sum.plus(r.amount), new Prisma.Decimal(0));
+    const remaining = new Prisma.Decimal(payment.amountPaid).minus(alreadyRefunded);
+    if (new Prisma.Decimal(dto.amount).gt(remaining)) {
+      throw new BadRequestException(
+        `จำนวนเงินคืน (${dto.amount.toLocaleString()}) เกินยอดคงเหลือที่คืนได้ ` +
+          `(${remaining.toFixed(2)} บาท)`,
+      );
+    }
+
+    const refund = await this.prisma.refund.create({
+      data: {
+        paymentId: payment.id,
+        contractId: payment.contractId,
+        amount: new Prisma.Decimal(dto.amount),
+        reason: dto.reason,
+        status: 'REQUESTED',
+        requestedById: userId,
+      },
+    });
+
+    await this.audit.log({
+      userId,
+      action: 'REFUND_REQUESTED',
+      entity: 'Refund',
+      entityId: refund.id,
+      newValue: {
+        paymentId: payment.id,
+        contractId: payment.contractId,
+        amount: dto.amount,
+        reason: dto.reason,
+      },
+    });
+
+    return refund;
+  }
+
+  async approveRefund(refundId: string, userId: string, userRole: string) {
+    const refund = await this.prisma.refund.findUnique({ where: { id: refundId } });
+    if (!refund || refund.deletedAt) throw new NotFoundException('ไม่พบคำขอคืนเงิน');
+    if (refund.status !== 'REQUESTED') {
+      throw new BadRequestException(
+        `อนุมัติได้เฉพาะคำขอสถานะ REQUESTED (สถานะปัจจุบัน: ${refund.status})`,
+      );
+    }
+    if (!RefundsService.APPROVER_ROLES.includes(userRole)) {
+      throw new ForbiddenException(
+        `ผู้อนุมัติต้องเป็น ${RefundsService.APPROVER_ROLES.join(' / ')} เท่านั้น`,
+      );
+    }
+    if (refund.requestedById === userId) {
+      throw new ForbiddenException(
+        'ผู้อนุมัติต้องไม่ใช่ผู้ขอคืนเงิน (Segregation of Duties)',
+      );
+    }
+
+    const updated = await this.prisma.refund.update({
+      where: { id: refundId },
+      data: {
+        status: 'APPROVED',
+        approvedById: userId,
+        approvedAt: new Date(),
+      },
+    });
+
+    await this.audit.log({
+      userId,
+      action: 'REFUND_APPROVED',
+      entity: 'Refund',
+      entityId: refundId,
+      oldValue: { status: 'REQUESTED' },
+      newValue: { status: 'APPROVED', approvedById: userId },
+    });
+
+    return updated;
+  }
+
+  async rejectRefund(refundId: string, dto: RejectRefundDto, userId: string, userRole: string) {
+    const refund = await this.prisma.refund.findUnique({ where: { id: refundId } });
+    if (!refund || refund.deletedAt) throw new NotFoundException('ไม่พบคำขอคืนเงิน');
+    if (refund.status !== 'REQUESTED') {
+      throw new BadRequestException(
+        `ปฏิเสธได้เฉพาะคำขอสถานะ REQUESTED (สถานะปัจจุบัน: ${refund.status})`,
+      );
+    }
+    if (!RefundsService.APPROVER_ROLES.includes(userRole)) {
+      throw new ForbiddenException(
+        `ผู้ปฏิเสธต้องเป็น ${RefundsService.APPROVER_ROLES.join(' / ')} เท่านั้น`,
+      );
+    }
+    if (refund.requestedById === userId) {
+      throw new ForbiddenException('ผู้ปฏิเสธต้องไม่ใช่ผู้ขอคืนเงิน');
+    }
+
+    const updated = await this.prisma.refund.update({
+      where: { id: refundId },
+      data: {
+        status: 'REJECTED',
+        rejectedById: userId,
+        rejectedAt: new Date(),
+        rejectedReason: dto.reason,
+      },
+    });
+
+    await this.audit.log({
+      userId,
+      action: 'REFUND_REJECTED',
+      entity: 'Refund',
+      entityId: refundId,
+      oldValue: { status: 'REQUESTED' },
+      newValue: { status: 'REJECTED', rejectedReason: dto.reason },
+    });
+
+    return updated;
+  }
+
+  /** Called after staff manually confirms with the bank that reversal went through. */
+  async markReversed(refundId: string, dto: MarkRefundReversedDto, userId: string, userRole: string) {
+    const refund = await this.prisma.refund.findUnique({ where: { id: refundId } });
+    if (!refund || refund.deletedAt) throw new NotFoundException('ไม่พบคำขอคืนเงิน');
+    if (refund.status !== 'APPROVED') {
+      throw new BadRequestException(
+        `บันทึกว่าธนาคาร reverse สำเร็จได้เฉพาะคำขอสถานะ APPROVED ` +
+          `(สถานะปัจจุบัน: ${refund.status})`,
+      );
+    }
+    if (!RefundsService.APPROVER_ROLES.includes(userRole)) {
+      throw new ForbiddenException(
+        `สิทธิ์บันทึก bank reversal เฉพาะ ${RefundsService.APPROVER_ROLES.join(' / ')}`,
+      );
+    }
+
+    const updated = await this.prisma.refund.update({
+      where: { id: refundId },
+      data: {
+        status: 'PROCESSED',
+        bankReversalRef: dto.bankReversalRef,
+        bankReversalAt: new Date(),
+        bankReversalNotes: dto.notes,
+      },
+    });
+
+    await this.audit.log({
+      userId,
+      action: 'REFUND_PROCESSED',
+      entity: 'Refund',
+      entityId: refundId,
+      oldValue: { status: 'APPROVED' },
+      newValue: {
+        status: 'PROCESSED',
+        bankReversalRef: dto.bankReversalRef,
+      },
+    });
+
+    return updated;
+  }
+
+  async markFailed(refundId: string, dto: MarkRefundFailedDto, userId: string, userRole: string) {
+    const refund = await this.prisma.refund.findUnique({ where: { id: refundId } });
+    if (!refund || refund.deletedAt) throw new NotFoundException('ไม่พบคำขอคืนเงิน');
+    if (refund.status !== 'APPROVED') {
+      throw new BadRequestException(
+        `บันทึกว่าธนาคาร reverse ไม่สำเร็จได้เฉพาะคำขอสถานะ APPROVED ` +
+          `(สถานะปัจจุบัน: ${refund.status})`,
+      );
+    }
+    if (!RefundsService.APPROVER_ROLES.includes(userRole)) {
+      throw new ForbiddenException(
+        `สิทธิ์บันทึก bank reversal failure เฉพาะ ${RefundsService.APPROVER_ROLES.join(' / ')}`,
+      );
+    }
+
+    const updated = await this.prisma.refund.update({
+      where: { id: refundId },
+      data: {
+        status: 'FAILED',
+        failureReason: dto.failureReason,
+      },
+    });
+
+    await this.audit.log({
+      userId,
+      action: 'REFUND_FAILED',
+      entity: 'Refund',
+      entityId: refundId,
+      oldValue: { status: 'APPROVED' },
+      newValue: { status: 'FAILED', failureReason: dto.failureReason },
+    });
+
+    return updated;
+  }
+
+  async findAll(filters: { status?: string; contractId?: string; page?: number; limit?: number }) {
+    const page = Math.max(1, filters.page ?? 1);
+    const limit = Math.min(100, Math.max(1, filters.limit ?? 50));
+    const where: Prisma.RefundWhereInput = { deletedAt: null };
+    if (filters.status) where.status = filters.status as Prisma.EnumRefundStatusFilter['equals'];
+    if (filters.contractId) where.contractId = filters.contractId;
+
+    const [data, total] = await Promise.all([
+      this.prisma.refund.findMany({
+        where,
+        include: {
+          payment: { select: { id: true, installmentNo: true, amountPaid: true } },
+          requestedBy: { select: { id: true, name: true } },
+          approvedBy: { select: { id: true, name: true } },
+          rejectedBy: { select: { id: true, name: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.refund.count({ where }),
+    ]);
+
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  async findOne(id: string) {
+    const refund = await this.prisma.refund.findUnique({
+      where: { id },
+      include: {
+        payment: true,
+        requestedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+        rejectedBy: { select: { id: true, name: true } },
+      },
+    });
+    if (!refund) throw new NotFoundException('ไม่พบคำขอคืนเงิน');
+    return refund;
+  }
+}


### PR DESCRIPTION
## Summary
บริษัทไม่จ่ายเงินคืนจากบัญชีเอง — staff โทรหาธนาคาร reverse ยอดเดิม (P2Q7=F) Refund table ทำหน้าที่ bookkeeping layer

## State machine
REQUESTED → APPROVED → PROCESSED | FAILED
REQUESTED → REJECTED

## Policy
- approve: OWNER / FINANCE_MANAGER + ≠ requester (SoD)
- reject: OWNER / FM
- mark-reversed / mark-failed: OWNER / FM
- amount ≤ (amountPaid − processed refunds)
- no open refund ซ้ำ

## Audit
ทุก state change → AuditLog (REFUND_REQUESTED / APPROVED / REJECTED / PROCESSED / FAILED)

## Test plan
- [x] +14 tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)