### PR TITLE
feat(auth): LoginAuditLog + 90d retention cron (T2-C8)

### DIFF
--- a/apps/api/prisma/migrations/20260524100000_add_login_audit_log/migration.sql
+++ b/apps/api/prisma/migrations/20260524100000_add_login_audit_log/migration.sql
@@ -1,0 +1,26 @@
+-- LoginAuditLog — every auth attempt (success + failure). Retention: 90 days
+-- via dedicated cron. Keep immutable; don't hard-delete here (soft-delete is
+-- not appropriate — the whole point is drop-old).
+
+CREATE TABLE "login_audit_logs" (
+  "id"              TEXT NOT NULL,
+  "user_id"         TEXT,
+  "email_tried"     TEXT NOT NULL,
+  "success"         BOOLEAN NOT NULL,
+  "failure_kind"    TEXT,
+  "ip_address"      TEXT,
+  "user_agent"      TEXT,
+  "two_factor_used" BOOLEAN NOT NULL DEFAULT false,
+  "created_at"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "login_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "login_audit_logs_user_id_created_at_idx"     ON "login_audit_logs"("user_id", "created_at");
+CREATE INDEX "login_audit_logs_email_tried_created_at_idx" ON "login_audit_logs"("email_tried", "created_at");
+CREATE INDEX "login_audit_logs_success_created_at_idx"     ON "login_audit_logs"("success", "created_at");
+CREATE INDEX "login_audit_logs_created_at_idx"             ON "login_audit_logs"("created_at");
+
+ALTER TABLE "login_audit_logs"
+  ADD CONSTRAINT "login_audit_logs_user_id_fkey"
+  FOREIGN KEY ("user_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -451,6 +451,7 @@ model User {
   refundsRequested       Refund[]             @relation("RefundRequestedBy")
   refundsApproved        Refund[]             @relation("RefundApprovedBy")
   refundsRejected        Refund[]             @relation("RefundRejectedBy")
+  loginAudits            LoginAuditLog[]      @relation("LoginAudits")
 
   @@index([branchId])
   @@map("users")
@@ -3762,6 +3763,34 @@ model AiAutoReplyLog {
   @@index([roomId])
   @@index([autoSent, createdAt])
   @@map("ai_auto_reply_logs")
+}
+
+/// Append-only log of every authentication attempt (success + failure). Used
+/// by SOC + fraud analytics to spot credential stuffing, brute force, and
+/// credential-sharing patterns. Retention is 90 days via dedicated cron —
+/// any longer is a PDPA burden with little incident-response value.
+///
+/// Immutable audit log — updatedAt/deletedAt intentionally omitted
+model LoginAuditLog {
+  id          String   @id @default(uuid())
+  userId      String?  @map("user_id") // null when attempt matched no account
+  emailTried  String   @map("email_tried")
+  success     Boolean
+  /// failure reason when success=false: 'wrong_password' | 'user_not_found' |
+  /// 'account_locked' | 'account_disabled' | '2fa_invalid' | 'other'
+  failureKind String?  @map("failure_kind")
+  ipAddress   String?  @map("ip_address")
+  userAgent   String?  @map("user_agent") @db.Text
+  twoFactorUsed Boolean @default(false) @map("two_factor_used")
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  user User? @relation("LoginAudits", fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([emailTried, createdAt])
+  @@index([success, createdAt])
+  @@index([createdAt])
+  @@map("login_audit_logs")
 }
 
 /// Append-only log of Claude API calls: one row per request. Used by the

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -59,8 +59,13 @@ export class AuthController {
   @Post('login')
   @Throttle({ short: { ttl: 60000, limit: 10 } })
   @ApiOperation({ summary: 'เข้าสู่ระบบ (email + password)' })
-  async login(@Body() loginDto: LoginDto, @Res({ passthrough: true }) res: Response) {
-    const result = await this.authService.login(loginDto);
+  async login(
+    @Body() loginDto: LoginDto,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const meta = { ipAddress: req.ip, userAgent: req.headers['user-agent'] as string | undefined };
+    const result = await this.authService.login(loginDto, meta);
 
     // If user has 2FA enabled, require verification before issuing tokens
     if (result.user && await this.twoFactorService.isTwoFactorEnabled(result.user.id)) {
@@ -82,9 +87,19 @@ export class AuthController {
   @Post('login/2fa')
   @Throttle({ short: { ttl: 60000, limit: 5 } })
   @ApiOperation({ summary: 'เข้าสู่ระบบด้วย 2FA (email + password + OTP)' })
-  async loginWith2FA(@Body() body: { email: string; password: string; code: string }, @Res({ passthrough: true }) res: Response) {
-    // Re-authenticate + verify 2FA code in one step
-    const result = await this.authService.loginWith2FA(body.email, body.password, body.code, this.twoFactorService);
+  async loginWith2FA(
+    @Body() body: { email: string; password: string; code: string },
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const meta = { ipAddress: req.ip, userAgent: req.headers['user-agent'] as string | undefined };
+    const result = await this.authService.loginWith2FA(
+      body.email,
+      body.password,
+      body.code,
+      this.twoFactorService,
+      meta,
+    );
     setRefreshCookie(res, result.refreshToken);
     return { accessToken: result.accessToken, user: result.user };
   }

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -6,6 +6,8 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { TwoFactorService } from './two-factor.service';
 import { AuthTokenCleanupService } from './auth-token-cleanup.service';
+import { LoginAuditService } from './login-audit.service';
+import { LoginAuditRetentionCron } from './login-audit-retention.cron';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { EmailModule } from '../email/email.module';
 
@@ -27,7 +29,14 @@ import { EmailModule } from '../email/email.module';
     EmailModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, TwoFactorService, AuthTokenCleanupService, JwtStrategy],
-  exports: [AuthService, TwoFactorService, JwtStrategy, PassportModule],
+  providers: [
+    AuthService,
+    TwoFactorService,
+    AuthTokenCleanupService,
+    LoginAuditService,
+    LoginAuditRetentionCron,
+    JwtStrategy,
+  ],
+  exports: [AuthService, TwoFactorService, LoginAuditService, JwtStrategy, PassportModule],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
+import { LoginAuditService } from './login-audit.service';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -80,6 +81,10 @@ describe('AuthService', () => {
           useValue: {
             sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
           },
+        },
+        {
+          provide: LoginAuditService,
+          useValue: { record: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -12,10 +12,16 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { LoginDto } from './dto/login.dto';
 import { ForgotPasswordDto, ResetPasswordDto } from './dto/password-reset.dto';
 import { EmailService } from '../email/email.service';
+import { LoginAuditService, LoginFailureKind } from './login-audit.service';
 
 // Account lockout configuration. Tunable via env if needed later.
 const LOCKOUT_THRESHOLD = 5; // failures before lock
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15 minutes
+
+export interface AuthMeta {
+  ipAddress?: string;
+  userAgent?: string;
+}
 
 @Injectable()
 export class AuthService {
@@ -26,7 +32,27 @@ export class AuthService {
     private jwtService: JwtService,
     private configService: ConfigService,
     private emailService: EmailService,
+    private loginAudit: LoginAuditService,
   ) {}
+
+  private async auditLogin(
+    emailTried: string,
+    success: boolean,
+    meta: AuthMeta | undefined,
+    userId?: string | null,
+    failureKind?: LoginFailureKind,
+    twoFactorUsed = false,
+  ): Promise<void> {
+    void this.loginAudit.record({
+      emailTried,
+      success,
+      userId,
+      failureKind,
+      ipAddress: meta?.ipAddress,
+      userAgent: meta?.userAgent,
+      twoFactorUsed,
+    });
+  }
 
   /**
    * Hash a raw refresh token using SHA-256 for secure DB storage.
@@ -37,13 +63,18 @@ export class AuthService {
     return crypto.createHash('sha256').update(rawToken).digest('hex');
   }
 
-  async login(loginDto: LoginDto) {
+  async login(loginDto: LoginDto, meta?: AuthMeta) {
     const user = await this.prisma.user.findUnique({
       where: { email: loginDto.email },
       include: { branch: true },
     });
 
-    if (!user || user.deletedAt || !user.isActive) {
+    if (!user) {
+      await this.auditLogin(loginDto.email, false, meta, null, 'user_not_found');
+      throw new UnauthorizedException('อีเมลหรือรหัสผ่านไม่ถูกต้อง');
+    }
+    if (user.deletedAt || !user.isActive) {
+      await this.auditLogin(loginDto.email, false, meta, user.id, 'account_disabled');
       throw new UnauthorizedException('อีเมลหรือรหัสผ่านไม่ถูกต้อง');
     }
 
@@ -51,6 +82,7 @@ export class AuthService {
     // distinguish "wrong password" from "locked" — both surface the same error.
     if (user.lockedUntil && user.lockedUntil > new Date()) {
       this.logger.warn(`Login attempt on locked account ${user.id}`);
+      await this.auditLogin(loginDto.email, false, meta, user.id, 'account_locked');
       throw new UnauthorizedException(
         'บัญชีถูกล็อคชั่วคราว กรุณาลองใหม่ในอีกสักครู่',
       );
@@ -77,6 +109,7 @@ export class AuthService {
           `Account ${user.id} locked after ${nextAttempts} failed attempts`,
         );
       }
+      await this.auditLogin(loginDto.email, false, meta, user.id, 'wrong_password');
       throw new UnauthorizedException('อีเมลหรือรหัสผ่านไม่ถูกต้อง');
     }
 
@@ -89,6 +122,8 @@ export class AuthService {
         lastLoginAt: new Date(),
       },
     });
+
+    await this.auditLogin(loginDto.email, true, meta, user.id);
 
     const payload = {
       sub: user.id,
@@ -121,8 +156,17 @@ export class AuthService {
   /**
    * Login with 2FA verification (re-authenticates credentials + verifies TOTP).
    */
-  async loginWith2FA(email: string, password: string, code: string, twoFactorService: { verifyCode: (s: string, b: string | null, c: string) => boolean; consumeRecoveryCode: (id: string, c: string) => Promise<void> }) {
-    const result = await this.login({ email, password });
+  async loginWith2FA(
+    email: string,
+    password: string,
+    code: string,
+    twoFactorService: {
+      verifyCode: (s: string, b: string | null, c: string) => boolean;
+      consumeRecoveryCode: (id: string, c: string) => Promise<void>;
+    },
+    meta?: AuthMeta,
+  ) {
+    const result = await this.login({ email, password }, meta);
 
     const user = await this.prisma.user.findUnique({
       where: { id: result.user.id },
@@ -132,12 +176,14 @@ export class AuthService {
     if (user?.twoFactorEnabled && user.twoFactorSecret) {
       const isValid = twoFactorService.verifyCode(user.twoFactorSecret, user.twoFactorBackup, code);
       if (!isValid) {
+        await this.auditLogin(email, false, meta, result.user.id, '2fa_invalid', true);
         throw new UnauthorizedException('รหัส OTP ไม่ถูกต้อง');
       }
       // Consume recovery code if used (8-char hex)
       if (code.length === 8) {
         await twoFactorService.consumeRecoveryCode(result.user.id, code);
       }
+      await this.auditLogin(email, true, meta, result.user.id, undefined, true);
     }
 
     return result;

--- a/apps/api/src/modules/auth/login-audit-retention.cron.spec.ts
+++ b/apps/api/src/modules/auth/login-audit-retention.cron.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoginAuditRetentionCron } from './login-audit-retention.cron';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('LoginAuditRetentionCron.purgeOldEntries', () => {
+  let cron: LoginAuditRetentionCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    (Sentry.captureException as jest.Mock).mockClear();
+    prisma = {
+      loginAuditLog: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [LoginAuditRetentionCron, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    cron = mod.get(LoginAuditRetentionCron);
+  });
+
+  it('uses 90d cutoff', async () => {
+    await cron.purgeOldEntries();
+    const where = prisma.loginAuditLog.deleteMany.mock.calls[0][0].where;
+    const cutoff = where.createdAt.lt as Date;
+    const ageMs = Date.now() - cutoff.getTime();
+    const ageDays = ageMs / (24 * 60 * 60 * 1000);
+    expect(ageDays).toBeGreaterThan(89.9);
+    expect(ageDays).toBeLessThan(90.1);
+  });
+
+  it('returns deletion count', async () => {
+    prisma.loginAuditLog.deleteMany.mockResolvedValue({ count: 17 });
+    const result = await cron.purgeOldEntries();
+    expect(result.deleted).toBe(17);
+  });
+
+  it('captures exception on DB failure (no throw)', async () => {
+    prisma.loginAuditLog.deleteMany.mockRejectedValue(new Error('table locked'));
+    const result = await cron.purgeOldEntries();
+    expect(result.deleted).toBe(0);
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/auth/login-audit-retention.cron.ts
+++ b/apps/api/src/modules/auth/login-audit-retention.cron.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * LoginAuditLog retention: hard-delete rows older than 90 days.
+ *
+ * Why 90d: PDPA pressure (keep the minimum needed); 90 days captures most
+ * incident-response windows (brute-force waves, credential-stuffing campaigns).
+ * Runs daily at 03:30 Asia/Bangkok — after the 03:00 heavy cleanups but before
+ * the 04:00 retention waves so we don't compete for locks.
+ */
+@Injectable()
+export class LoginAuditRetentionCron {
+  private readonly logger = new Logger(LoginAuditRetentionCron.name);
+  static readonly RETENTION_DAYS = 90;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Cron('30 3 * * *', { timeZone: 'Asia/Bangkok' })
+  async purgeOldEntries(): Promise<{ deleted: number }> {
+    try {
+      const cutoff = new Date(
+        Date.now() - LoginAuditRetentionCron.RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      );
+      const result = await this.prisma.loginAuditLog.deleteMany({
+        where: { createdAt: { lt: cutoff } },
+      });
+      if (result.count > 0) {
+        this.logger.log(`LoginAuditLog retention: deleted ${result.count} row(s) older than ${LoginAuditRetentionCron.RETENTION_DAYS}d`);
+      }
+      return { deleted: result.count };
+    } catch (err) {
+      this.logger.error(`Login audit retention failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'login-audit-retention' } });
+      return { deleted: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/auth/login-audit.service.spec.ts
+++ b/apps/api/src/modules/auth/login-audit.service.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoginAuditService } from './login-audit.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('LoginAuditService.record', () => {
+  let service: LoginAuditService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      loginAuditLog: { create: jest.fn().mockResolvedValue({ id: 'la-1' }) },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [LoginAuditService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(LoginAuditService);
+  });
+
+  it('persists success entry', async () => {
+    await service.record({
+      userId: 'u-1',
+      emailTried: 'test@example.com',
+      success: true,
+      ipAddress: '1.2.3.4',
+    });
+    const data = prisma.loginAuditLog.create.mock.calls[0][0].data;
+    expect(data.userId).toBe('u-1');
+    expect(data.success).toBe(true);
+    expect(data.failureKind).toBeNull();
+  });
+
+  it('persists failure entry with kind', async () => {
+    await service.record({
+      emailTried: 'attacker@example.com',
+      success: false,
+      failureKind: 'wrong_password',
+      ipAddress: '9.9.9.9',
+    });
+    const data = prisma.loginAuditLog.create.mock.calls[0][0].data;
+    expect(data.success).toBe(false);
+    expect(data.failureKind).toBe('wrong_password');
+    expect(data.userId).toBeNull();
+  });
+
+  it('truncates long userAgent to 500 chars', async () => {
+    await service.record({
+      emailTried: 'x@x',
+      success: true,
+      userAgent: 'x'.repeat(2000),
+    });
+    expect(prisma.loginAuditLog.create.mock.calls[0][0].data.userAgent.length).toBe(500);
+  });
+
+  it('swallows DB failure (never blocks login)', async () => {
+    prisma.loginAuditLog.create.mockRejectedValue(new Error('db down'));
+    await expect(
+      service.record({ emailTried: 'x@x', success: true }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/auth/login-audit.service.ts
+++ b/apps/api/src/modules/auth/login-audit.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export type LoginFailureKind =
+  | 'wrong_password'
+  | 'user_not_found'
+  | 'account_locked'
+  | 'account_disabled'
+  | '2fa_invalid'
+  | 'other';
+
+export interface LoginAuditInput {
+  userId?: string | null;
+  emailTried: string;
+  success: boolean;
+  failureKind?: LoginFailureKind;
+  ipAddress?: string;
+  userAgent?: string;
+  twoFactorUsed?: boolean;
+}
+
+/**
+ * Fire-and-forget audit writer for auth attempts. Must never block the login
+ * path, must never throw. If the table is gone or the DB is wedged, we still
+ * want the user to be able to sign in (or not) on the path they're on.
+ */
+@Injectable()
+export class LoginAuditService {
+  private readonly logger = new Logger(LoginAuditService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async record(entry: LoginAuditInput): Promise<void> {
+    try {
+      await this.prisma.loginAuditLog.create({
+        data: {
+          userId: entry.userId ?? null,
+          emailTried: entry.emailTried.slice(0, 320),
+          success: entry.success,
+          failureKind: entry.failureKind ?? null,
+          ipAddress: entry.ipAddress ?? null,
+          userAgent: entry.userAgent ? entry.userAgent.slice(0, 500) : null,
+          twoFactorUsed: entry.twoFactorUsed ?? false,
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to persist login audit: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, { tags: { module: 'auth', action: 'login_audit' } });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
ก่อนหน้านี้ login flow ใช้แค่ logger — ไม่มี persistent audit → security/fraud ไม่สามารถย้อนสืบ brute force / credential stuffing / session sharing

## Changes
- **LoginAuditLog** model (immutable, 90d): userId (nullable), emailTried, success, failureKind, ipAddress, userAgent, twoFactorUsed
- **LoginAuditService** fire-and-forget, swallow DB failure
- **Retention cron** daily 03:30 — hard-delete > 90d (PDPA minimum)
- Wire AuthService `login()` + `loginWith2FA()` รับ `meta: {ip, ua}` จาก controller
- Audit ทุก path: not-found / disabled / locked / wrong-password / 2FA-invalid / success

## Test plan
- [x] +7 new tests
- [x] All 43 auth tests pass
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)