### PR TITLE
feat(receivable-recon): per-branch daily recon + breach alert (T1-C4)

### DIFF
--- a/apps/api/prisma/migrations/20260524200000_add_receivable_recon_log/migration.sql
+++ b/apps/api/prisma/migrations/20260524200000_add_receivable_recon_log/migration.sql
@@ -1,0 +1,31 @@
+-- Per-branch daily reconciliation snapshot (T1-C4). Paired with a daily
+-- cron that computes branch-level HP receivable balance vs aggregated
+-- contract outstanding. 90-day retention via existing cron pattern.
+
+CREATE TABLE "receivable_recon_logs" (
+  "id"                   TEXT NOT NULL,
+  "run_date"             DATE NOT NULL,
+  "branch_id"            TEXT,
+  "journal_balance"      DECIMAL(14,2) NOT NULL,
+  "contract_outstanding" DECIMAL(14,2) NOT NULL,
+  "gap"                  DECIMAL(14,2) NOT NULL,
+  "threshold"            DECIMAL(14,2) NOT NULL,
+  "breached"             BOOLEAN NOT NULL,
+  "created_at"           TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "receivable_recon_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- one row per branch per day (null branch = company-wide)
+CREATE UNIQUE INDEX "receivable_recon_logs_run_date_branch_id_key"
+  ON "receivable_recon_logs"("run_date", "branch_id");
+CREATE INDEX "receivable_recon_logs_run_date_idx"
+  ON "receivable_recon_logs"("run_date");
+CREATE INDEX "receivable_recon_logs_branch_id_run_date_idx"
+  ON "receivable_recon_logs"("branch_id", "run_date");
+CREATE INDEX "receivable_recon_logs_breached_run_date_idx"
+  ON "receivable_recon_logs"("breached", "run_date");
+
+ALTER TABLE "receivable_recon_logs"
+  ADD CONSTRAINT "receivable_recon_logs_branch_id_fkey"
+  FOREIGN KEY ("branch_id") REFERENCES "branches"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -345,6 +345,7 @@ model Branch {
   fixedAssets              FixedAsset[]
   tradeIns                 TradeIn[]
   crmLeads                 CrmLead[]
+  receivableReconLogs      ReceivableReconLog[] @relation("ReceivableReconBranch")
 
   @@index([companyId])
   @@map("branches")
@@ -3763,6 +3764,31 @@ model AiAutoReplyLog {
   @@index([roomId])
   @@index([autoSent, createdAt])
   @@map("ai_auto_reply_logs")
+}
+
+/// Per-branch daily snapshot of HP receivable balance vs aggregated payment
+/// outstanding. Feeds T1-C4 alert cron (>1000฿ gap = Sentry warning) and the
+/// data-audit dashboard. 90-day retention via cron.
+///
+/// Immutable — updatedAt/deletedAt intentionally omitted
+model ReceivableReconLog {
+  id                   String   @id @default(uuid())
+  runDate              DateTime @map("run_date") @db.Date // one row per branch per day
+  branchId             String?  @map("branch_id") // null = company-wide row
+  journalBalance       Decimal  @map("journal_balance") @db.Decimal(14, 2)
+  contractOutstanding  Decimal  @map("contract_outstanding") @db.Decimal(14, 2)
+  gap                  Decimal  @db.Decimal(14, 2) // signed: journal - outstanding
+  threshold            Decimal  @db.Decimal(14, 2)
+  breached             Boolean // |gap| > threshold
+  createdAt            DateTime @default(now()) @map("created_at")
+
+  branch Branch? @relation("ReceivableReconBranch", fields: [branchId], references: [id], onDelete: SetNull)
+
+  @@unique([runDate, branchId])
+  @@index([runDate])
+  @@index([branchId, runDate])
+  @@index([breached, runDate])
+  @@map("receivable_recon_logs")
 }
 
 /// Append-only log of every authentication attempt (success + failure). Used

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -32,6 +32,7 @@ import { AuditModule } from './modules/audit/audit.module';
 import { WebhookSecurityModule } from './modules/webhook-security/webhook-security.module';
 import { AiUsageModule } from './modules/ai-usage/ai-usage.module';
 import { RefundsModule } from './modules/refunds/refunds.module';
+import { ReceivableReconModule } from './modules/receivable-recon/receivable-recon.module';
 import { UsersModule } from './modules/users/users.module';
 import { SettingsModule } from './modules/settings/settings.module';
 import { InventoryModule } from './modules/inventory/inventory.module';
@@ -144,6 +145,7 @@ import { AppCacheModule } from './cache/cache.module';
     WebhookSecurityModule,
     AiUsageModule,
     RefundsModule,
+    ReceivableReconModule,
     // Legal Compliance & PDPA
     PDPAModule,
     KycModule,

--- a/apps/api/src/modules/receivable-recon/receivable-recon.controller.ts
+++ b/apps/api/src/modules/receivable-recon/receivable-recon.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Prisma } from '@prisma/client';
+
+@ApiTags('Receivable Recon')
+@ApiBearerAuth('JWT')
+@Controller('receivable-recon')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+export class ReceivableReconController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Get('history')
+  async history(
+    @Query('branchId') branchId?: string,
+    @Query('days') daysQ?: string,
+  ) {
+    const days = Math.min(90, Math.max(1, daysQ ? Number(daysQ) : 30));
+    const since = new Date();
+    since.setHours(0, 0, 0, 0);
+    since.setDate(since.getDate() - days);
+
+    const where: Prisma.ReceivableReconLogWhereInput = { runDate: { gte: since } };
+    if (branchId) where.branchId = branchId;
+
+    return this.prisma.receivableReconLog.findMany({
+      where,
+      orderBy: [{ runDate: 'desc' }, { branchId: 'asc' }],
+      include: { branch: { select: { id: true, name: true } } },
+    });
+  }
+
+  @Get('latest')
+  async latest() {
+    // Most recent run per branch
+    const rows = await this.prisma.receivableReconLog.findMany({
+      orderBy: { runDate: 'desc' },
+      take: 500,
+      include: { branch: { select: { id: true, name: true } } },
+    });
+    // Dedupe — keep newest per branch
+    const seen = new Set<string>();
+    return rows.filter((r) => {
+      const key = r.branchId ?? '__null__';
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+}

--- a/apps/api/src/modules/receivable-recon/receivable-recon.cron.ts
+++ b/apps/api/src/modules/receivable-recon/receivable-recon.cron.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { ReceivableReconService } from './receivable-recon.service';
+
+/**
+ * Daily 02:00 Asia/Bangkok — after close-of-business, before dashboards
+ * materialize. Two responsibilities:
+ *   1) Snapshot per-branch receivable vs payment outstanding (cron job)
+ *   2) Purge rows older than the retention window
+ */
+@Injectable()
+export class ReceivableReconCron {
+  private readonly logger = new Logger(ReceivableReconCron.name);
+
+  constructor(private readonly service: ReceivableReconService) {}
+
+  @Cron('0 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async dailyRecon(): Promise<void> {
+    try {
+      const result = await this.service.reconcileBranches();
+      this.logger.log(
+        `Receivable recon: ${result.rows} branch row(s), ${result.breached.length} breach(es)`,
+      );
+    } catch (err) {
+      this.logger.error(`Receivable recon failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'receivable-recon' },
+      });
+    }
+
+    try {
+      const purge = await this.service.purgeOldLogs();
+      if (purge.deleted > 0) {
+        this.logger.log(`Purged ${purge.deleted} old receivable recon row(s)`);
+      }
+    } catch (err) {
+      this.logger.error(`Receivable recon purge failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'receivable-recon-purge' },
+      });
+    }
+  }
+}

--- a/apps/api/src/modules/receivable-recon/receivable-recon.module.ts
+++ b/apps/api/src/modules/receivable-recon/receivable-recon.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ReceivableReconService } from './receivable-recon.service';
+import { ReceivableReconCron } from './receivable-recon.cron';
+import { ReceivableReconController } from './receivable-recon.controller';
+
+@Module({
+  controllers: [ReceivableReconController],
+  providers: [ReceivableReconService, ReceivableReconCron],
+  exports: [ReceivableReconService],
+})
+export class ReceivableReconModule {}

--- a/apps/api/src/modules/receivable-recon/receivable-recon.service.spec.ts
+++ b/apps/api/src/modules/receivable-recon/receivable-recon.service.spec.ts
@@ -1,0 +1,160 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { ReceivableReconService } from './receivable-recon.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('ReceivableReconService.reconcileBranches', () => {
+  let service: ReceivableReconService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    prisma = {
+      $queryRaw: jest.fn(),
+      receivableReconLog: {
+        upsert: jest.fn().mockResolvedValue({}),
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReceivableReconService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = mod.get(ReceivableReconService);
+  });
+
+  /**
+   * The service runs 2 $queryRaw calls — journal first, payment second.
+   * Mock them in order.
+   */
+  const queueQueries = (
+    journalRows: Array<{ branch_id: string; balance: string | number }>,
+    paymentRows: Array<{ branch_id: string; outstanding: string | number }>,
+  ) => {
+    prisma.$queryRaw
+      .mockResolvedValueOnce(
+        journalRows.map((r) => ({ ...r, balance: new Prisma.Decimal(r.balance) })),
+      )
+      .mockResolvedValueOnce(
+        paymentRows.map((r) => ({ ...r, outstanding: new Prisma.Decimal(r.outstanding) })),
+      );
+  };
+
+  it('records 0 breaches when journal matches payment per branch', async () => {
+    queueQueries(
+      [{ branch_id: 'b-1', balance: 100000 }],
+      [{ branch_id: 'b-1', outstanding: 100000 }],
+    );
+
+    const result = await service.reconcileBranches();
+    expect(result.rows).toBe(1);
+    expect(result.breached).toHaveLength(0);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('flags breach when gap exceeds threshold (min ฿1000)', async () => {
+    queueQueries(
+      [{ branch_id: 'b-1', balance: 100000 }],
+      [{ branch_id: 'b-1', outstanding: 98000 }], // gap = 2000 > max(100k*0.001=100, 1000)
+    );
+
+    const result = await service.reconcileBranches();
+    expect(result.breached).toHaveLength(1);
+    expect(result.breached[0].branchId).toBe('b-1');
+    expect(Sentry.captureMessage).toHaveBeenCalled();
+  });
+
+  it('does NOT flag tiny gap below ฿1000 minimum', async () => {
+    queueQueries(
+      [{ branch_id: 'b-1', balance: 100000 }],
+      [{ branch_id: 'b-1', outstanding: 99500 }], // gap = 500 < 1000 minimum
+    );
+
+    const result = await service.reconcileBranches();
+    expect(result.breached).toHaveLength(0);
+  });
+
+  it('applies 0.1% threshold for large branches', async () => {
+    // outstanding 10M → threshold = max(10M * 0.001 = 10k, 1k) = 10k
+    // gap 5000 < 10000 → no breach (min floor doesn't help when branch is huge)
+    queueQueries(
+      [{ branch_id: 'b-big', balance: 10_005_000 }],
+      [{ branch_id: 'b-big', outstanding: 10_000_000 }],
+    );
+    const withinPct = await service.reconcileBranches();
+    expect(withinPct.breached).toHaveLength(0);
+
+    // gap 15000 > threshold 10000 → breach
+    queueQueries(
+      [{ branch_id: 'b-big', balance: 10_015_000 }],
+      [{ branch_id: 'b-big', outstanding: 10_000_000 }],
+    );
+    const overPct = await service.reconcileBranches();
+    expect(overPct.breached).toHaveLength(1);
+  });
+
+  it('handles branches present in one table but not the other', async () => {
+    queueQueries(
+      [{ branch_id: 'b-journal-only', balance: 5000 }],
+      [{ branch_id: 'b-payment-only', outstanding: 7000 }],
+    );
+
+    const result = await service.reconcileBranches();
+    // Both branches get a row written (gap = full amount each)
+    expect(result.rows).toBe(2);
+    expect(result.breached.length).toBe(2);
+  });
+
+  it('persists each branch row with correct fields', async () => {
+    queueQueries(
+      [{ branch_id: 'b-1', balance: 100000 }],
+      [{ branch_id: 'b-1', outstanding: 95000 }],
+    );
+    await service.reconcileBranches();
+    const upsertArgs = prisma.receivableReconLog.upsert.mock.calls[0][0];
+    expect(upsertArgs.create.branchId).toBe('b-1');
+    expect(Number(upsertArgs.create.gap)).toBe(5000);
+    expect(upsertArgs.create.breached).toBe(true);
+  });
+});
+
+describe('ReceivableReconService.purgeOldLogs', () => {
+  let service: ReceivableReconService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      receivableReconLog: { deleteMany: jest.fn().mockResolvedValue({ count: 5 }) },
+      $queryRaw: jest.fn(),
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReceivableReconService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = mod.get(ReceivableReconService);
+  });
+
+  it('deletes rows older than 90 days', async () => {
+    const result = await service.purgeOldLogs();
+    expect(result.deleted).toBe(5);
+    const where = prisma.receivableReconLog.deleteMany.mock.calls[0][0].where;
+    const cutoff = where.createdAt.lt as Date;
+    const ageDays = (Date.now() - cutoff.getTime()) / (24 * 60 * 60 * 1000);
+    expect(ageDays).toBeGreaterThan(89.9);
+    expect(ageDays).toBeLessThan(90.1);
+  });
+});

--- a/apps/api/src/modules/receivable-recon/receivable-recon.service.ts
+++ b/apps/api/src/modules/receivable-recon/receivable-recon.service.ts
@@ -1,0 +1,141 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Per-branch reconciliation between the journal "HP Receivable" balance
+ * (account 11-2102) and the aggregated Payment outstanding for active
+ * contracts. Built for T1-C4 — the existing data-audit check is company-wide,
+ * which hides which branch is drifting.
+ *
+ * Threshold policy: branch considered "breached" when
+ *   |gap| > max(outstanding × 0.001, 1000฿)
+ * — 0.1% for large branches, minimum ฿1,000 for small ones. Mirrors the
+ * existing data-audit.service.ts convention.
+ */
+@Injectable()
+export class ReceivableReconService {
+  private readonly logger = new Logger(ReceivableReconService.name);
+  static readonly MIN_THRESHOLD_BAHT = 1000;
+  static readonly THRESHOLD_PCT = 0.001;
+  static readonly RETENTION_DAYS = 90;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async reconcileBranches(): Promise<{
+    rows: number;
+    breached: Array<{ branchId: string; gap: number }>;
+  }> {
+    // Journal side: SUM(debit - credit) per branch for HP Receivable account.
+    // Only include journal entries whose referenced Contract has a branchId —
+    // orphan MANUAL journal lines without a contract aren't allocatable to
+    // a branch and end up in the data-audit's company-wide check, not here.
+    const journalRows = await this.prisma.$queryRaw<
+      Array<{ branch_id: string; balance: Prisma.Decimal }>
+    >`
+      SELECT c.branch_id, COALESCE(SUM(jl.debit - jl.credit), 0)::decimal AS balance
+      FROM journal_lines jl
+      JOIN journal_entries je ON je.id = jl.journal_entry_id
+      JOIN contracts c ON c.id = je.reference_id AND je.reference_type = 'CONTRACT'
+      WHERE jl.account_code = '11-2102'
+        AND je.status = 'POSTED'
+        AND je.deleted_at IS NULL
+        AND jl.deleted_at IS NULL
+        AND c.branch_id IS NOT NULL
+      GROUP BY c.branch_id
+    `;
+
+    const paymentRows = await this.prisma.$queryRaw<
+      Array<{ branch_id: string; outstanding: Prisma.Decimal }>
+    >`
+      SELECT c.branch_id, COALESCE(SUM(p.amount_due - p.amount_paid), 0)::decimal AS outstanding
+      FROM payments p
+      JOIN contracts c ON c.id = p.contract_id
+      WHERE p.deleted_at IS NULL
+        AND c.deleted_at IS NULL
+        AND c.status IN ('ACTIVE', 'OVERDUE', 'DEFAULT')
+        AND p.status IN ('PENDING', 'PARTIALLY_PAID')
+        AND c.branch_id IS NOT NULL
+      GROUP BY c.branch_id
+    `;
+
+    const journalMap = new Map<string, Prisma.Decimal>();
+    for (const r of journalRows) journalMap.set(r.branch_id, new Prisma.Decimal(r.balance));
+    const paymentMap = new Map<string, Prisma.Decimal>();
+    for (const r of paymentRows) paymentMap.set(r.branch_id, new Prisma.Decimal(r.outstanding));
+
+    const allBranchIds = new Set<string>([...journalMap.keys(), ...paymentMap.keys()]);
+
+    const runDate = this.todayDateOnly();
+    const breached: Array<{ branchId: string; gap: number }> = [];
+
+    for (const branchId of allBranchIds) {
+      const journalBalance = journalMap.get(branchId) ?? new Prisma.Decimal(0);
+      const contractOutstanding = paymentMap.get(branchId) ?? new Prisma.Decimal(0);
+      const gap = journalBalance.minus(contractOutstanding);
+      const threshold = Prisma.Decimal.max(
+        contractOutstanding.mul(ReceivableReconService.THRESHOLD_PCT),
+        new Prisma.Decimal(ReceivableReconService.MIN_THRESHOLD_BAHT),
+      );
+      const isBreached = gap.abs().gt(threshold);
+
+      await this.prisma.receivableReconLog.upsert({
+        where: { runDate_branchId: { runDate, branchId } },
+        update: {
+          journalBalance,
+          contractOutstanding,
+          gap,
+          threshold,
+          breached: isBreached,
+        },
+        create: {
+          runDate,
+          branchId,
+          journalBalance,
+          contractOutstanding,
+          gap,
+          threshold,
+          breached: isBreached,
+        },
+      });
+
+      if (isBreached) {
+        breached.push({ branchId, gap: gap.toNumber() });
+      }
+    }
+
+    if (breached.length > 0) {
+      this.logger.warn(
+        `Receivable recon breaches: ${breached.length} branch(es) — ` +
+          breached.map((b) => `${b.branchId}:${b.gap.toFixed(2)}`).join(', '),
+      );
+      Sentry.captureMessage(
+        `Receivable↔Payment reconciliation breach: ${breached.length} branch(es)`,
+        {
+          level: 'warning',
+          tags: { kind: 'cron-job', cron: 'receivable-recon' },
+          extra: { breached, runDate },
+        },
+      );
+    }
+
+    return { rows: allBranchIds.size, breached };
+  }
+
+  async purgeOldLogs(): Promise<{ deleted: number }> {
+    const cutoff = new Date(
+      Date.now() - ReceivableReconService.RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    );
+    const result = await this.prisma.receivableReconLog.deleteMany({
+      where: { createdAt: { lt: cutoff } },
+    });
+    return { deleted: result.count };
+  }
+
+  private todayDateOnly(): Date {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+}


### PR DESCRIPTION
## Summary
`hp_receivable_reconciliation` เดิมใน data-audit เช็คแค่ company-wide → ซ่อนว่าสาขาไหนมี gap เมื่อรวม

## Changes
- **ReceivableReconLog** model (unique runDate+branchId), 90-day retention
- **Service**: join journal HP balance vs aggregated payment outstanding per branch + Sentry alert เมื่อ gap > threshold
- **Threshold**: `max(outstanding × 0.1%, ฿1000)`
- **Cron** daily 02:00 Asia/Bangkok
- **Controller** `/receivable-recon/history`, `/latest` — OWNER/FM/ACCOUNTANT

## Test plan
- [x] +7 cases
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)