### PR TITLE
feat(contracts): ghost sale + rapid-void detection cron (T5-C5)

### DIFF
--- a/apps/api/src/modules/contracts/contracts.module.ts
+++ b/apps/api/src/modules/contracts/contracts.module.ts
@@ -8,6 +8,7 @@ import { ContractDocumentsController } from './contract-documents.controller';
 import { ContractDocumentsService } from './contract-documents.service';
 import { DocumentsController } from './documents.controller';
 import { DocumentsService } from './documents.service';
+import { GhostSaleCron } from './crons/ghost-sale.cron';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { OcrModule } from '../ocr/ocr.module';
 import { SettingsModule } from '../settings/settings.module';
@@ -18,7 +19,7 @@ import { WarrantyModule } from '../warranty/warranty.module';
 @Module({
   imports: [NotificationsModule, OcrModule, SettingsModule, JournalModule, ProductsModule, WarrantyModule],
   controllers: [ContractsController, ContractDocumentsController, DocumentsController],
-  providers: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractDocumentsService, DocumentsService],
+  providers: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractDocumentsService, DocumentsService, GhostSaleCron],
   exports: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractDocumentsService, DocumentsService],
 })
 export class ContractsModule {}

--- a/apps/api/src/modules/contracts/crons/ghost-sale.cron.spec.ts
+++ b/apps/api/src/modules/contracts/crons/ghost-sale.cron.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GhostSaleCron } from './ghost-sale.cron';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('GhostSaleCron.scan', () => {
+  let cron: GhostSaleCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+
+    prisma = {
+      contract: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [GhostSaleCron, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    cron = mod.get(GhostSaleCron);
+  });
+
+  it('returns 0/0 when no suspicious contracts', async () => {
+    const result = await cron.scan();
+    expect(result.ghost).toBe(0);
+    expect(result.rapidVoid).toBe(0);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('ghost query: ACTIVE + age > 7d + no paid payments', async () => {
+    await cron.scan();
+    const ghostArgs = prisma.contract.findMany.mock.calls[0][0];
+    expect(ghostArgs.where.status).toBe('ACTIVE');
+    expect(ghostArgs.where.deletedAt).toBeNull();
+    expect(ghostArgs.where.payments.none.status.in).toContain('PAID');
+    const age = Date.now() - (ghostArgs.where.createdAt.lt as Date).getTime();
+    const days = age / (24 * 60 * 60 * 1000);
+    expect(days).toBeGreaterThan(6.9);
+    expect(days).toBeLessThan(7.1);
+  });
+
+  it('rapid-void query: deletedAt within 30d of creation', async () => {
+    await cron.scan();
+    const voidArgs = prisma.contract.findMany.mock.calls[1][0];
+    expect(voidArgs.where.deletedAt.gte).toBeInstanceOf(Date);
+    expect(voidArgs.where.createdAt.gte).toBeInstanceOf(Date);
+  });
+
+  it('alerts Sentry with per-branch breakdown for ghost contracts', async () => {
+    prisma.contract.findMany
+      .mockResolvedValueOnce([
+        { id: 'c-1', contractNumber: 'A', branchId: 'b-1', salespersonId: 's-1', createdAt: new Date() },
+        { id: 'c-2', contractNumber: 'B', branchId: 'b-1', salespersonId: 's-2', createdAt: new Date() },
+        { id: 'c-3', contractNumber: 'C', branchId: 'b-2', salespersonId: 's-3', createdAt: new Date() },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await cron.scan();
+    expect(result.ghost).toBe(3);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Ghost sale detection: 3'),
+      expect.objectContaining({ level: 'warning' }),
+    );
+    const call = (Sentry.captureMessage as jest.Mock).mock.calls[0][1];
+    expect(call.extra.byBranch).toEqual({ 'b-1': 2, 'b-2': 1 });
+  });
+
+  it('alerts Sentry for rapid voids with per-salesperson breakdown', async () => {
+    prisma.contract.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: 'c-1', contractNumber: 'X', branchId: 'b-1', salespersonId: 's-1', createdAt: new Date(), deletedAt: new Date() },
+        { id: 'c-2', contractNumber: 'Y', branchId: 'b-1', salespersonId: 's-1', createdAt: new Date(), deletedAt: new Date() },
+      ]);
+
+    const result = await cron.scan();
+    expect(result.rapidVoid).toBe(2);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Rapid void pattern'),
+      expect.any(Object),
+    );
+    const call = (Sentry.captureMessage as jest.Mock).mock.calls[0][1];
+    expect(call.extra.bySales).toEqual({ 's-1': 2 });
+  });
+
+  it('swallows DB failure (no throw)', async () => {
+    prisma.contract.findMany.mockRejectedValue(new Error('db down'));
+    const result = await cron.scan();
+    expect(result.ghost).toBe(0);
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/contracts/crons/ghost-sale.cron.ts
+++ b/apps/api/src/modules/contracts/crons/ghost-sale.cron.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * Ghost-sale detection (T5-C5). Flags two fraud patterns:
+ *
+ *   1. Ghost contract: status=ACTIVE, age > 7 days, zero paid installments.
+ *      If a real customer signed a contract, they almost always make at
+ *      least the first payment within the first week. A week-old contract
+ *      with no payments is either a data-entry error or a salesperson
+ *      farming commission on fake customers.
+ *
+ *   2. Rapid void: a CANCELLED/VOIDED contract whose commission was accrued
+ *      less than 30 days before the void. Commission paid, sale voided —
+ *      classic wash-sale pattern.
+ *
+ * Runs daily 02:30 Asia/Bangkok — after the receivable recon cron at 02:00.
+ */
+@Injectable()
+export class GhostSaleCron {
+  private readonly logger = new Logger(GhostSaleCron.name);
+  static readonly GHOST_THRESHOLD_DAYS = 7;
+  static readonly RAPID_VOID_DAYS = 30;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Cron('30 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async scan(): Promise<{ ghost: number; rapidVoid: number }> {
+    try {
+      const ghostCutoff = new Date(
+        Date.now() - GhostSaleCron.GHOST_THRESHOLD_DAYS * 24 * 60 * 60 * 1000,
+      );
+
+      // Pattern 1: ACTIVE contracts with 0 paid installments, age > 7 days
+      const ghostContracts = await this.prisma.contract.findMany({
+        where: {
+          deletedAt: null,
+          status: 'ACTIVE',
+          createdAt: { lt: ghostCutoff },
+          payments: {
+            none: {
+              status: { in: ['PAID', 'PARTIALLY_PAID'] },
+              deletedAt: null,
+            },
+          },
+        },
+        select: {
+          id: true,
+          contractNumber: true,
+          branchId: true,
+          salespersonId: true,
+          createdAt: true,
+        },
+        take: 200,
+      });
+
+      // Pattern 2: Contracts soft-deleted within RAPID_VOID_DAYS of creation.
+      // The system doesn't have a CANCELLED/VOIDED status — "void" here is
+      // modelled as soft-delete via deletedAt. We flag when deletedAt -
+      // createdAt < 30 days, i.e. the contract was rapidly killed after sale.
+      const rapidVoidCutoff = new Date(
+        Date.now() - GhostSaleCron.RAPID_VOID_DAYS * 24 * 60 * 60 * 1000,
+      );
+      const rapidVoids = await this.prisma.contract.findMany({
+        where: {
+          deletedAt: { gte: rapidVoidCutoff },
+          createdAt: { gte: rapidVoidCutoff },
+        },
+        select: {
+          id: true,
+          contractNumber: true,
+          branchId: true,
+          salespersonId: true,
+          createdAt: true,
+          deletedAt: true,
+        },
+        take: 200,
+      });
+
+      if (ghostContracts.length > 0) {
+        const byBranch = this.groupBy(ghostContracts, 'branchId');
+        this.logger.warn(
+          `Ghost sale cron flagged ${ghostContracts.length} contract(s)`,
+        );
+        Sentry.captureMessage(
+          `Ghost sale detection: ${ghostContracts.length} ACTIVE contract(s) > 7d with 0 payments`,
+          {
+            level: 'warning',
+            tags: { kind: 'cron-job', cron: 'ghost-sale' },
+            extra: { count: ghostContracts.length, byBranch, contractIds: ghostContracts.slice(0, 50).map((c) => c.id) },
+          },
+        );
+      }
+
+      if (rapidVoids.length > 0) {
+        const bySales = this.groupBy(rapidVoids, 'salespersonId');
+        this.logger.warn(`Rapid void pattern: ${rapidVoids.length} in last ${GhostSaleCron.RAPID_VOID_DAYS}d`);
+        Sentry.captureMessage(
+          `Rapid void pattern: ${rapidVoids.length} contract(s) voided within ${GhostSaleCron.RAPID_VOID_DAYS}d of creation`,
+          {
+            level: 'warning',
+            tags: { kind: 'cron-job', cron: 'ghost-sale' },
+            extra: { count: rapidVoids.length, bySales },
+          },
+        );
+      }
+
+      return { ghost: ghostContracts.length, rapidVoid: rapidVoids.length };
+    } catch (err) {
+      this.logger.error(`Ghost sale cron failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'ghost-sale' } });
+      return { ghost: 0, rapidVoid: 0 };
+    }
+  }
+
+  private groupBy<T extends Record<string, unknown>>(
+    rows: T[],
+    key: keyof T,
+  ): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const r of rows) {
+      const k = String(r[key] ?? 'UNKNOWN');
+      out[k] = (out[k] ?? 0) + 1;
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
## Summary
ไม่มีระบบตรวจ fake contract ที่ SALES สร้างเพื่อ farm commission แล้วลบทีหลัง

## Patterns
1. **Ghost contract**: ACTIVE + >7d + 0 paid payments → per-branch breakdown
2. **Rapid void**: deletedAt ≤ 30d from createdAt → per-salesperson breakdown

## Cron
Daily 02:30 Asia/Bangkok — Sentry warning + top-50 contractIds ใน extra

## Test plan
- [x] +6 tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)