### PR TITLE
feat(warranty): audit log + backward-adjust OWNER gate (T5-C6)

### DIFF
--- a/apps/api/prisma/migrations/20260524400000_add_warranty_audit_log/migration.sql
+++ b/apps/api/prisma/migrations/20260524400000_add_warranty_audit_log/migration.sql
@@ -1,0 +1,32 @@
+-- WarrantyAuditLog (T5-C6). Every manual shopWarrantyEndDate adjustment
+-- goes through WarrantyService.adjustShopWarranty() which writes one row
+-- here. Backward adjustments are OWNER-only; a reason is always required.
+
+CREATE TABLE "warranty_audit_logs" (
+  "id"           TEXT NOT NULL,
+  "contract_id"  TEXT NOT NULL,
+  "user_id"      TEXT NOT NULL,
+  "old_end_date" TIMESTAMP(3),
+  "new_end_date" TIMESTAMP(3) NOT NULL,
+  "direction"    TEXT NOT NULL,
+  "reason"       TEXT NOT NULL,
+  "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "warranty_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "warranty_audit_logs_contract_id_idx"
+  ON "warranty_audit_logs"("contract_id");
+CREATE INDEX "warranty_audit_logs_user_id_created_at_idx"
+  ON "warranty_audit_logs"("user_id", "created_at");
+CREATE INDEX "warranty_audit_logs_direction_created_at_idx"
+  ON "warranty_audit_logs"("direction", "created_at");
+
+ALTER TABLE "warranty_audit_logs"
+  ADD CONSTRAINT "warranty_audit_logs_contract_id_fkey"
+  FOREIGN KEY ("contract_id") REFERENCES "contracts"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "warranty_audit_logs"
+  ADD CONSTRAINT "warranty_audit_logs_user_id_fkey"
+  FOREIGN KEY ("user_id") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -454,6 +454,7 @@ model User {
   refundsRejected        Refund[]             @relation("RefundRejectedBy")
   loginAudits            LoginAuditLog[]      @relation("LoginAudits")
   dataAuditAcknowledgements DataAuditLog[]    @relation("DataAuditAcknowledgedBy")
+  warrantyAudits         WarrantyAuditLog[]   @relation("WarrantyAuditUser")
 
   @@index([branchId])
   @@map("users")
@@ -667,6 +668,8 @@ model Contract {
   // วันที่ลูกค้ารับเครื่องจริง (ใช้เป็น baseline นับ 7-day defect exchange window)
   // Defaults to activatedAt/createdAt if not set
   deviceReceivedAt DateTime? @map("device_received_at")
+
+  warrantyAudits WarrantyAuditLog[] @relation("WarrantyAuditContract")
 
   @@index([customerId])
   @@index([branchId])
@@ -3776,6 +3779,32 @@ model AiAutoReplyLog {
   @@index([roomId])
   @@index([autoSent, createdAt])
   @@map("ai_auto_reply_logs")
+}
+
+/// Warranty date audit trail (T5-C6). Every manual shopWarrantyEndDate
+/// adjustment goes through WarrantyService.adjustShopWarranty() which writes
+/// one row here. Backward adjustments are OWNER-only; any adjustment requires
+/// a reason (can't be "just because"). This table plus the service guard is
+/// the full control — there's no external endpoint touching the field today.
+///
+/// Immutable — updatedAt/deletedAt intentionally omitted
+model WarrantyAuditLog {
+  id         String   @id @default(uuid())
+  contractId String   @map("contract_id")
+  userId     String   @map("user_id")
+  oldEndDate DateTime? @map("old_end_date")
+  newEndDate DateTime  @map("new_end_date")
+  direction  String // 'FORWARD' | 'BACKWARD' | 'INITIAL'
+  reason     String
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  user     User     @relation("WarrantyAuditUser", fields: [userId], references: [id])
+  contract Contract @relation("WarrantyAuditContract", fields: [contractId], references: [id], onDelete: Restrict)
+
+  @@index([contractId])
+  @@index([userId, createdAt])
+  @@index([direction, createdAt])
+  @@map("warranty_audit_logs")
 }
 
 /// Per-branch daily snapshot of HP receivable balance vs aggregated payment

--- a/apps/api/src/modules/warranty/warranty.service.spec.ts
+++ b/apps/api/src/modules/warranty/warranty.service.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { WarrantyService } from './warranty.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('WarrantyService.adjustShopWarranty', () => {
+  let service: WarrantyService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const contractWithWarranty = (end: Date | null) => ({
+    id: 'c-1',
+    shopWarrantyEndDate: end,
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      contract: {
+        findUnique: jest.fn().mockResolvedValue(contractWithWarranty(new Date('2026-08-01'))),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      warrantyAuditLog: { create: jest.fn().mockResolvedValue({}) },
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [WarrantyService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(WarrantyService);
+  });
+
+  it('rejects reason < 10 chars', async () => {
+    await expect(
+      service.adjustShopWarranty('c-1', new Date('2026-09-01'), 'short', 'u', 'OWNER'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws NotFound when contract missing', async () => {
+    prisma.contract.findUnique.mockResolvedValue(null);
+    await expect(
+      service.adjustShopWarranty(
+        'c-missing',
+        new Date('2026-09-01'),
+        'reason ten chars plus',
+        'u',
+        'OWNER',
+      ),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('BACKWARD direction rejected for non-OWNER', async () => {
+    await expect(
+      service.adjustShopWarranty(
+        'c-1',
+        new Date('2026-07-01'), // earlier than current 2026-08-01
+        'customer handover delayed — correcting end date',
+        'u',
+        'BRANCH_MANAGER',
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('BACKWARD allowed by OWNER — writes audit direction=BACKWARD', async () => {
+    await service.adjustShopWarranty(
+      'c-1',
+      new Date('2026-07-01'),
+      'fix data-entry error from activation',
+      'u-owner',
+      'OWNER',
+    );
+    const auditArgs = prisma.warrantyAuditLog.create.mock.calls[0][0];
+    expect(auditArgs.data.direction).toBe('BACKWARD');
+    expect(auditArgs.data.reason).toContain('fix data-entry');
+  });
+
+  it('FORWARD allowed for BRANCH_MANAGER — writes audit direction=FORWARD', async () => {
+    await service.adjustShopWarranty(
+      'c-1',
+      new Date('2026-12-01'), // later than current
+      'customer bought extended warranty add-on',
+      'u-bm',
+      'BRANCH_MANAGER',
+    );
+    const auditArgs = prisma.warrantyAuditLog.create.mock.calls[0][0];
+    expect(auditArgs.data.direction).toBe('FORWARD');
+  });
+
+  it('INITIAL direction when oldEnd was null', async () => {
+    prisma.contract.findUnique.mockResolvedValue(contractWithWarranty(null));
+    await service.adjustShopWarranty(
+      'c-1',
+      new Date('2026-12-01'),
+      'manual warranty set for legacy contract',
+      'u-owner',
+      'OWNER',
+    );
+    const auditArgs = prisma.warrantyAuditLog.create.mock.calls[0][0];
+    expect(auditArgs.data.direction).toBe('INITIAL');
+    expect(auditArgs.data.oldEndDate).toBeNull();
+  });
+
+  it('FORWARD adjustment rejected for SALES (not in allowed list)', async () => {
+    await expect(
+      service.adjustShopWarranty(
+        'c-1',
+        new Date('2026-12-01'),
+        'attempting unauthorized forward change',
+        'u-sales',
+        'SALES',
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/apps/api/src/modules/warranty/warranty.service.ts
+++ b/apps/api/src/modules/warranty/warranty.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { addDays, isPast, differenceInDays } from 'date-fns';
 
@@ -96,12 +102,104 @@ export class WarrantyService {
         },
       });
 
+      // Initial warranty set — audit trail row with direction=INITIAL.
+      // Only write when salespersonId is a real user (FK requires it). If
+      // the contract has no salesperson, skip — the audit table is for
+      // manual adjustments anyway; auto-set on activation is self-documenting.
+      if (contract.salespersonId) {
+        await this.prisma.warrantyAuditLog
+          .create({
+            data: {
+              contractId,
+              userId: contract.salespersonId,
+              oldEndDate: null,
+              newEndDate: endDate,
+              direction: 'INITIAL',
+              reason: `auto-set on contract activation (${warrantyDays} days)`,
+            },
+          })
+          .catch((err) =>
+            this.logger.warn(`WarrantyAuditLog write failed (initial): ${err.message}`),
+          );
+      }
+
       this.logger.log(
         `Shop warranty set for contract ${contractId}: ${warrantyDays} days until ${endDate.toISOString()}`,
       );
     } catch (error) {
       this.logger.error(`Failed to set shop warranty for contract ${contractId}`, error);
     }
+  }
+
+  /**
+   * Manual shop-warranty adjustment (T5-C6). The ONLY path allowed to mutate
+   * `shopWarrantyEndDate` after initial activation. Every call writes an
+   * immutable audit row.
+   *
+   * Policy:
+   *   - reason is required (≥ 10 chars)
+   *   - BACKWARD adjustment (newEnd < oldEnd) → OWNER only. This is the fraud
+   *     vector: MANAGER shortens warranty so customer can't claim, then staff
+   *     resells the faulty device.
+   *   - FORWARD adjustment → OWNER / FINANCE_MANAGER / BRANCH_MANAGER
+   */
+  async adjustShopWarranty(
+    contractId: string,
+    newEndDate: Date,
+    reason: string,
+    userId: string,
+    userRole: string,
+  ): Promise<void> {
+    if (!reason || reason.trim().length < 10) {
+      throw new BadRequestException('ต้องระบุเหตุผลอย่างน้อย 10 ตัวอักษร');
+    }
+
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+      select: { id: true, shopWarrantyEndDate: true },
+    });
+    if (!contract) throw new NotFoundException('ไม่พบสัญญา');
+
+    const oldEnd = contract.shopWarrantyEndDate;
+    const isBackward = oldEnd !== null && newEndDate.getTime() < oldEnd.getTime();
+    const direction = oldEnd === null
+      ? 'INITIAL'
+      : isBackward
+        ? 'BACKWARD'
+        : 'FORWARD';
+
+    if (isBackward && userRole !== 'OWNER') {
+      throw new ForbiddenException(
+        'การย่นวันสิ้นสุดประกันต้องได้รับอนุมัติจาก OWNER เท่านั้น',
+      );
+    }
+    const allowedForward = ['OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER'];
+    if (!isBackward && !allowedForward.includes(userRole)) {
+      throw new ForbiddenException(
+        `ผู้ปรับประกันต้องเป็น ${allowedForward.join(' / ')}`,
+      );
+    }
+
+    await this.prisma.$transaction([
+      this.prisma.contract.update({
+        where: { id: contractId },
+        data: { shopWarrantyEndDate: newEndDate },
+      }),
+      this.prisma.warrantyAuditLog.create({
+        data: {
+          contractId,
+          userId,
+          oldEndDate: oldEnd,
+          newEndDate,
+          direction,
+          reason: reason.trim(),
+        },
+      }),
+    ]);
+
+    this.logger.log(
+      `Shop warranty adjusted for ${contractId}: ${direction} by ${userId}`,
+    );
   }
 
   async getExpiringWarranties(daysAhead: number = 7): Promise<any[]> {


### PR DESCRIPTION
## Summary
ป้องกัน MANAGER แก้ shopWarrantyEndDate ถอยหลังเพื่อให้ลูกค้าเคลมไม่ได้ + staff resell faulty device

## Changes
- **WarrantyAuditLog** model (immutable, FK Restrict)
- **adjustShopWarranty** method — ONLY path to mutate warranty end date
  - reason ≥ 10 chars
  - BACKWARD → OWNER only
  - FORWARD → OWNER / FM / BM
  - SALES blocked
- `setShopWarranty` (initial) writes INITIAL audit row เมื่อมี salesperson

## Test plan
- [x] +7 tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)