### PR TITLE
feat(crm): lead assignment history + changedBy audit (T5-C7)

### DIFF
--- a/apps/api/prisma/migrations/20260524500000_add_crm_lead_assignment_history/migration.sql
+++ b/apps/api/prisma/migrations/20260524500000_add_crm_lead_assignment_history/migration.sql
@@ -1,0 +1,41 @@
+-- CRM lead assignment history (T5-C7). Prevents silent lead theft —
+-- every reassignment writes one immutable row; UI surfaces the history.
+-- Current owner remains on CrmLead.assignedToId for query speed.
+
+CREATE TABLE "crm_lead_assignments" (
+  "id"             TEXT NOT NULL,
+  "lead_id"        TEXT NOT NULL,
+  "from_user_id"   TEXT,
+  "to_user_id"     TEXT NOT NULL,
+  "changed_by_id"  TEXT NOT NULL,
+  "reason"         TEXT,
+  "created_at"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "crm_lead_assignments_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "crm_lead_assignments_lead_id_created_at_idx"
+  ON "crm_lead_assignments"("lead_id", "created_at");
+CREATE INDEX "crm_lead_assignments_to_user_id_idx"
+  ON "crm_lead_assignments"("to_user_id");
+CREATE INDEX "crm_lead_assignments_changed_by_id_created_at_idx"
+  ON "crm_lead_assignments"("changed_by_id", "created_at");
+
+ALTER TABLE "crm_lead_assignments"
+  ADD CONSTRAINT "crm_lead_assignments_lead_id_fkey"
+  FOREIGN KEY ("lead_id") REFERENCES "crm_leads"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "crm_lead_assignments"
+  ADD CONSTRAINT "crm_lead_assignments_from_user_id_fkey"
+  FOREIGN KEY ("from_user_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "crm_lead_assignments"
+  ADD CONSTRAINT "crm_lead_assignments_to_user_id_fkey"
+  FOREIGN KEY ("to_user_id") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "crm_lead_assignments"
+  ADD CONSTRAINT "crm_lead_assignments_changed_by_id_fkey"
+  FOREIGN KEY ("changed_by_id") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -455,6 +455,9 @@ model User {
   loginAudits            LoginAuditLog[]      @relation("LoginAudits")
   dataAuditAcknowledgements DataAuditLog[]    @relation("DataAuditAcknowledgedBy")
   warrantyAudits         WarrantyAuditLog[]   @relation("WarrantyAuditUser")
+  crmLeadAssignFromHistory CrmLeadAssignment[] @relation("CrmLeadAssignFrom")
+  crmLeadAssignToHistory   CrmLeadAssignment[] @relation("CrmLeadAssignTo")
+  crmLeadAssignChangedBy   CrmLeadAssignment[] @relation("CrmLeadAssignChangedBy")
 
   @@index([branchId])
   @@map("users")
@@ -3628,11 +3631,39 @@ model CrmLead {
   updatedAt    DateTime         @updatedAt @map("updated_at")
   deletedAt    DateTime?        @map("deleted_at")
 
+  assignmentHistory CrmLeadAssignment[] @relation("CrmLeadHistory")
+
   @@index([stage, assignedToId])
   @@index([customerId])
   @@index([branchId, stage])
   @@index([deletedAt])
   @@map("crm_leads")
+}
+
+/// Immutable history of lead ownership changes (T5-C7). Prevents silent
+/// lead theft — e.g. MANAGER pulls a hot lead from a junior SALES into
+/// their own queue. Every assignLead() writes one row; the current
+/// owner is still CrmLead.assignedToId for query speed.
+///
+/// Immutable audit — updatedAt/deletedAt intentionally omitted
+model CrmLeadAssignment {
+  id            String   @id @default(uuid())
+  leadId        String   @map("lead_id")
+  fromUserId    String?  @map("from_user_id") // null = first assignment
+  toUserId      String   @map("to_user_id")
+  changedById   String   @map("changed_by_id") // the manager/user who made the change
+  reason        String?
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  lead      CrmLead @relation("CrmLeadHistory", fields: [leadId], references: [id], onDelete: Restrict)
+  fromUser  User?   @relation("CrmLeadAssignFrom", fields: [fromUserId], references: [id], onDelete: SetNull)
+  toUser    User    @relation("CrmLeadAssignTo", fields: [toUserId], references: [id])
+  changedBy User    @relation("CrmLeadAssignChangedBy", fields: [changedById], references: [id])
+
+  @@index([leadId, createdAt])
+  @@index([toUserId])
+  @@index([changedById, createdAt])
+  @@map("crm_lead_assignments")
 }
 
 model CrmNote {

--- a/apps/api/src/modules/crm/crm.controller.ts
+++ b/apps/api/src/modules/crm/crm.controller.ts
@@ -11,6 +11,7 @@ import {
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { CrmPipelineService } from './services/crm-pipeline.service';
 import { CustomerScoringService } from './services/customer-scoring.service';
 import { LeadStage, LeadSource } from '@prisma/client';
@@ -74,8 +75,16 @@ export class CrmController {
   async assignLead(
     @Param('id') id: string,
     @Body('staffId') staffId: string,
+    @Body('reason') reason: string | undefined,
+    @CurrentUser() user: { id: string },
   ) {
-    return this.pipeline.assignLead(id, staffId);
+    return this.pipeline.assignLead(id, staffId, user.id, reason);
+  }
+
+  @Get('leads/:id/assignment-history')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  async getAssignmentHistory(@Param('id') id: string) {
+    return this.pipeline.getAssignmentHistory(id);
   }
 
   @Post('leads/:id/notes')

--- a/apps/api/src/modules/crm/services/crm-pipeline.service.spec.ts
+++ b/apps/api/src/modules/crm/services/crm-pipeline.service.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CrmPipelineService } from './crm-pipeline.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+describe('CrmPipelineService.assignLead (T5-C7 history)', () => {
+  let service: CrmPipelineService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      crmLead: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'lead-1', assignedToId: 'u-old' }),
+        update: jest.fn((args) => Promise.resolve({ id: 'lead-1', ...args.data })),
+      },
+      crmLeadAssignment: {
+        create: jest.fn().mockResolvedValue({ id: 'ass-1' }),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [CrmPipelineService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(CrmPipelineService);
+  });
+
+  it('writes history row with from/to/changedBy + reason', async () => {
+    await service.assignLead('lead-1', 'u-new', 'u-manager', 'reassign to branch specialist');
+    const assignArgs = prisma.crmLeadAssignment.create.mock.calls[0][0];
+    expect(assignArgs.data.leadId).toBe('lead-1');
+    expect(assignArgs.data.fromUserId).toBe('u-old');
+    expect(assignArgs.data.toUserId).toBe('u-new');
+    expect(assignArgs.data.changedById).toBe('u-manager');
+    expect(assignArgs.data.reason).toBe('reassign to branch specialist');
+  });
+
+  it('fromUserId null when first assignment', async () => {
+    prisma.crmLead.findUnique.mockResolvedValue({ id: 'lead-1', assignedToId: null });
+    await service.assignLead('lead-1', 'u-new', 'u-manager');
+    const assignArgs = prisma.crmLeadAssignment.create.mock.calls[0][0];
+    expect(assignArgs.data.fromUserId).toBeNull();
+  });
+
+  it('skips no-op (same owner) — no history row', async () => {
+    prisma.crmLead.findUnique.mockResolvedValue({ id: 'lead-1', assignedToId: 'u-same' });
+    await service.assignLead('lead-1', 'u-same', 'u-manager');
+    expect(prisma.crmLeadAssignment.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when lead not found', async () => {
+    prisma.crmLead.findUnique.mockResolvedValue(null);
+    await expect(
+      service.assignLead('missing', 'u-new', 'u-manager'),
+    ).rejects.toThrow();
+  });
+
+  it('trims empty reason to null', async () => {
+    await service.assignLead('lead-1', 'u-new', 'u-manager', '   ');
+    const assignArgs = prisma.crmLeadAssignment.create.mock.calls[0][0];
+    expect(assignArgs.data.reason).toBeNull();
+  });
+
+  it('getAssignmentHistory returns ordered history with user details', async () => {
+    await service.getAssignmentHistory('lead-1');
+    const args = prisma.crmLeadAssignment.findMany.mock.calls[0][0];
+    expect(args.where.leadId).toBe('lead-1');
+    expect(args.orderBy).toEqual({ createdAt: 'desc' });
+    expect(args.include.fromUser).toBeDefined();
+    expect(args.include.toUser).toBeDefined();
+    expect(args.include.changedBy).toBeDefined();
+  });
+});

--- a/apps/api/src/modules/crm/services/crm-pipeline.service.ts
+++ b/apps/api/src/modules/crm/services/crm-pipeline.service.ts
@@ -105,10 +105,57 @@ export class CrmPipelineService {
     return this.prisma.crmLead.update({ where: { id }, data });
   }
 
-  async assignLead(id: string, staffId: string) {
-    return this.prisma.crmLead.update({
+  /**
+   * Reassign a lead. Writes an immutable history row alongside the update
+   * so any later "who took my lead?" question has a definitive answer.
+   * `changedById` is the user making the change (often a manager reassigning
+   * a junior's lead); `toUserId` is the new owner.
+   */
+  async assignLead(
+    id: string,
+    staffId: string,
+    changedById: string,
+    reason?: string,
+  ) {
+    const existing = await this.prisma.crmLead.findUnique({
       where: { id },
-      data: { assignedToId: staffId },
+      select: { id: true, assignedToId: true },
+    });
+    if (!existing) {
+      throw new Error(`CRM lead ${id} not found`);
+    }
+    if (existing.assignedToId === staffId) {
+      // No-op — don't pad the history log with repeats of the same owner
+      return this.prisma.crmLead.findUnique({ where: { id } });
+    }
+
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.crmLead.update({
+        where: { id },
+        data: { assignedToId: staffId },
+      }),
+      this.prisma.crmLeadAssignment.create({
+        data: {
+          leadId: id,
+          fromUserId: existing.assignedToId,
+          toUserId: staffId,
+          changedById,
+          reason: reason?.trim() || null,
+        },
+      }),
+    ]);
+    return updated;
+  }
+
+  async getAssignmentHistory(leadId: string) {
+    return this.prisma.crmLeadAssignment.findMany({
+      where: { leadId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        fromUser: { select: { id: true, name: true } },
+        toUser: { select: { id: true, name: true } },
+        changedBy: { select: { id: true, name: true } },
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
ป้องกัน lead theft — manager ดึง hot lead จาก junior sales โดยไม่มีหลักฐาน

## Changes
- **CrmLeadAssignment** model (immutable history)
- `assignLead()` เขียน history + ยังคง `CrmLead.assignedToId` เป็น pointer ปัจจุบันเพื่อ query เร็ว
- No-op (same owner) → skip history
- `getAssignmentHistory()` + GET endpoint

## Test plan
- [x] +6 tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)