### PR TITLE
feat(customers): normalize national ID before dedup check (T3-C8)

### DIFF
--- a/apps/api/src/modules/customers/customers.service.spec.ts
+++ b/apps/api/src/modules/customers/customers.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException } from '@nestjs/common';
+import { CustomersService } from './customers.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * T3-C8: NID dedup — the @unique constraint on nationalId only catches byte-
+ * identical strings. Users can defeat it with space/dash variations unless
+ * we normalize before both the lookup and the write.
+ */
+describe('CustomersService.create — NID normalization', () => {
+  let service: CustomersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      customer: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn((args) => Promise.resolve({ id: 'cust-new', ...args.data })),
+      },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [CustomersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(CustomersService);
+  });
+
+  const baseDto = (nid: string) => ({
+    name: 'John Doe',
+    nationalId: nid,
+    isForeigner: true, // skip Thai checksum for test convenience
+    phone: '0812345678',
+  }) as unknown as Parameters<CustomersService['create']>[0];
+
+  it('normalizes NID with dashes before dedup check', async () => {
+    await service.create(baseDto('1-1234-56789-00-1'));
+    const findArgs = prisma.customer.findUnique.mock.calls[0][0];
+    expect(findArgs.where.nationalId).toBe('1123456789001');
+  });
+
+  it('normalizes NID with spaces', async () => {
+    await service.create(baseDto('1 1234 56789 00 1'));
+    const findArgs = prisma.customer.findUnique.mock.calls[0][0];
+    expect(findArgs.where.nationalId).toBe('1123456789001');
+  });
+
+  it('uppercases letters (passport-style IDs)', async () => {
+    await service.create(baseDto('ab1234567'));
+    const createArgs = prisma.customer.create.mock.calls[0][0];
+    expect(createArgs.data.nationalId).toBe('AB1234567');
+  });
+
+  it('rejects duplicate NID after normalization', async () => {
+    prisma.customer.findUnique.mockResolvedValue({
+      id: 'cust-existing',
+      name: 'Existing',
+      deletedAt: null,
+    });
+
+    await expect(service.create(baseDto('1-1234-56789-00-1'))).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  it('writes normalized NID to DB (strips dashes)', async () => {
+    await service.create(baseDto('1-1234-56789-00-1'));
+    const createArgs = prisma.customer.create.mock.calls[0][0];
+    expect(createArgs.data.nationalId).toBe('1123456789001');
+  });
+
+  it('ignores soft-deleted customer with same NID', async () => {
+    prisma.customer.findUnique.mockResolvedValue({
+      id: 'cust-old',
+      name: 'Deleted',
+      deletedAt: new Date(),
+    });
+    // Should not throw — soft-deleted doesn't block new create
+    await expect(service.create(baseDto('1123456789001'))).resolves.toBeDefined();
+  });
+});

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -261,10 +261,22 @@ export class CustomersService {
     }));
   }
 
+  /**
+   * Normalize NID/passport for dedup. Strips spaces, dashes, then uppercases.
+   * "1-1234-56789-00-1" → "1123456789001". Without this, the @unique constraint
+   * is only effective when callers happen to pass already-clean strings —
+   * which isn't guaranteed across LIFF, POS, chatbot, and legacy import paths.
+   */
+  private normalizeNationalId(raw: string): string {
+    return raw.replace(/[\s-]/g, '').toUpperCase();
+  }
+
   async create(dto: CreateCustomerDto) {
-    // Check duplicate national ID
+    const normalizedNid = this.normalizeNationalId(dto.nationalId);
+
+    // Check duplicate national ID (normalized — so format variations still collide)
     const existing = await this.prisma.customer.findUnique({
-      where: { nationalId: dto.nationalId },
+      where: { nationalId: normalizedNid },
     });
     if (existing && !existing.deletedAt) {
       throw new ConflictException({
@@ -274,12 +286,13 @@ export class CustomersService {
     }
 
     // Validate Thai national ID checksum (skip for foreigners)
-    if (!dto.isForeigner && !this.validateNationalId(dto.nationalId)) {
+    if (!dto.isForeigner && !this.validateNationalId(normalizedNid)) {
       throw new ConflictException('เลขบัตรประชาชนไม่ถูกต้อง');
     }
 
     const data: Prisma.CustomerCreateInput = {
       ...dto,
+      nationalId: normalizedNid,
       references: dto.references !== undefined
         ? (dto.references as Prisma.InputJsonValue)
         : undefined,
@@ -289,6 +302,9 @@ export class CustomersService {
 
   async update(id: string, dto: UpdateCustomerDto) {
     await this.findOne(id);
+    // NID is intentionally not in UpdateCustomerDto — customers can't change
+    // their ID through this endpoint. If NID needs correction, create a
+    // dedicated admin-only flow that writes to an audit log.
     const data: Prisma.CustomerUpdateInput = {
       ...dto,
       references: dto.references !== undefined


### PR DESCRIPTION
## Summary
@unique constraint บน NID block แค่ string identical — format variations (dashes/spaces) slip through → duplicate records, fraud vector

## Fix
- `normalizeNationalId()` strips dashes/spaces + uppercase
- `create()` normalizes ก่อน findUnique + write normalized form

## Test plan
- [x] +6 tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)