### PR TITLE
feat(payments): late-fee waiver audit fields (T3-C10)

### DIFF
--- a/apps/api/prisma/migrations/20260524600000_add_late_fee_waiver_audit/migration.sql
+++ b/apps/api/prisma/migrations/20260524600000_add_late_fee_waiver_audit/migration.sql
@@ -1,0 +1,25 @@
+-- T3-C10: Late-fee waiver audit fields on Payment. Keeps a full record of
+-- who waived a fee, when, why, and who approved — the SoD guard lives in
+-- payments.service.waiveLateFee() (approver ≠ waiver enforced at service
+-- layer). These columns give accountants and auditors a single row per
+-- waiver to inspect.
+
+ALTER TABLE "payments"
+  ADD COLUMN "waived_by_id"            TEXT,
+  ADD COLUMN "waived_at"               TIMESTAMP(3),
+  ADD COLUMN "waived_reason"           TEXT,
+  ADD COLUMN "waived_approved_by_id"   TEXT,
+  ADD COLUMN "waived_amount"           DECIMAL(12,2);
+
+CREATE INDEX "payments_waived_by_id_idx"           ON "payments"("waived_by_id");
+CREATE INDEX "payments_waived_approved_by_id_idx"  ON "payments"("waived_approved_by_id");
+
+ALTER TABLE "payments"
+  ADD CONSTRAINT "payments_waived_by_id_fkey"
+  FOREIGN KEY ("waived_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "payments"
+  ADD CONSTRAINT "payments_waived_approved_by_id_fkey"
+  FOREIGN KEY ("waived_approved_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -458,6 +458,8 @@ model User {
   crmLeadAssignFromHistory CrmLeadAssignment[] @relation("CrmLeadAssignFrom")
   crmLeadAssignToHistory   CrmLeadAssignment[] @relation("CrmLeadAssignTo")
   crmLeadAssignChangedBy   CrmLeadAssignment[] @relation("CrmLeadAssignChangedBy")
+  paymentsWaived           Payment[]            @relation("PaymentWaivedBy")
+  paymentsWaivedApproved   Payment[]            @relation("PaymentWaivedApprovedBy")
 
   @@index([branchId])
   @@map("users")
@@ -708,6 +710,16 @@ model Payment {
   gatewayResponse Json?          @map("gateway_response")
   paidAt          DateTime?      @map("paid_at")
 
+  /// Late fee waiver audit (T3-C10). `lateFeeWaived` (bool) tells you "yes
+  /// the fee was waived"; these fields tell you WHO did it, WHEN, WHY, and
+  /// WHO approved. The approver must differ from waivedById per SoD
+  /// enforced by payments.service.waiveLateFee().
+  waivedById         String?   @map("waived_by_id")
+  waivedAt           DateTime? @map("waived_at")
+  waivedReason       String?   @map("waived_reason")
+  waivedApprovedById String?   @map("waived_approved_by_id")
+  waivedAmount       Decimal?  @map("waived_amount") @db.Decimal(12, 2)
+
   // Payment breakdown (เงินต้น + ค่าคอม + ดอกเบี้ย + VAT = amountDue)
   monthlyPrincipal  Decimal? @map("monthly_principal") @db.Decimal(12, 2)
   monthlyInterest   Decimal? @map("monthly_interest") @db.Decimal(12, 2)
@@ -727,6 +739,8 @@ model Payment {
   // trail in one accidental hard-delete (see ultraplan v3 audit).
   contract         Contract          @relation(fields: [contractId], references: [id], onDelete: Restrict)
   recordedBy       User?             @relation("RecordedBy", fields: [recordedById], references: [id])
+  waivedBy         User?             @relation("PaymentWaivedBy", fields: [waivedById], references: [id])
+  waivedApprovedBy User?             @relation("PaymentWaivedApprovedBy", fields: [waivedApprovedById], references: [id])
   paymentLinks     PaymentLink[]
   paymentEvidences PaymentEvidence[]
   loyaltyPoint     LoyaltyPoint?
@@ -740,6 +754,8 @@ model Payment {
   @@index([paidDate])
   @@index([status, dueDate])
   @@index([recordedById])
+  @@index([waivedById])
+  @@index([waivedApprovedById])
   @@map("payments")
 }
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -814,6 +814,11 @@ export class PaymentsService {
         data: {
           lateFee: 0,
           lateFeeWaived: true,
+          waivedById: userId,
+          waivedAt: new Date(),
+          waivedReason: reason,
+          waivedApprovedById: approverId,
+          waivedAmount: originalLateFee,
           notes,
           ...(isNowFullyPaid && payment.status !== 'PAID' ? { status: 'PAID', paidDate: new Date() } : {}),
         },


### PR DESCRIPTION
## Summary
Payment.lateFeeWaived เดิมเก็บแค่ bool — ไม่มี who/when/why/approver บน row เดียว → audit ต้อง join logs

## Changes
- +5 fields บน Payment: waivedById, waivedAt, waivedReason, waivedApprovedById, waivedAmount
- `waiveLateFee()` เขียน fields พร้อม `lateFeeWaived=true` ใน update เดียว
- SoD guard + structured log + AuditLog ยังเขียนเหมือนเดิม (complementary)

## Test plan
- [x] 51 payment tests pass
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)