### PR TITLE
feat(overdue): FINAL_WARNING + LEGAL_ACTION approval gate (T4-C2)

### DIFF
--- a/apps/api/prisma/migrations/20260524700000_add_pending_dunning_stage/migration.sql
+++ b/apps/api/prisma/migrations/20260524700000_add_pending_dunning_stage/migration.sql
@@ -1,0 +1,8 @@
+-- T4-C2: auto-escalation can flip only up to NOTICE. FINAL_WARNING and
+-- LEGAL_ACTION are parked on `pending_dunning_stage` waiting for a human
+-- OWNER/FINANCE_MANAGER to approve. Cleared when approved (stage flips) or
+-- rejected (pending fields blanked).
+
+ALTER TABLE "contracts"
+  ADD COLUMN "pending_dunning_stage" "DunningStage",
+  ADD COLUMN "pending_dunning_since" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -623,6 +623,13 @@ model Contract {
   dunningStage        DunningStage @default(NONE) @map("dunning_stage")
   dunningEscalatedAt  DateTime?    @map("dunning_escalated_at")
   dunningLastActionAt DateTime?    @map("dunning_last_action_at")
+  /// T4-C2: auto-escalation can advance up to NOTICE only. FINAL_WARNING and
+  /// LEGAL_ACTION require human approval — the cron parks the proposed stage
+  /// here and waits. An OWNER/FINANCE_MANAGER approves via
+  /// overdue.approveDunningEscalation() which flips dunningStage and clears
+  /// these fields.
+  pendingDunningStage DunningStage? @map("pending_dunning_stage")
+  pendingDunningSince DateTime?    @map("pending_dunning_since")
 
   // Retention policy
   retentionStatus DocumentRetentionStatus @default(ACTIVE) @map("retention_status")

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -201,4 +201,36 @@ export class OverdueController {
   executeDunningRules() {
     return this.dunningEngineService.executeRules();
   }
+
+  // --- Dunning approval (T4-C2: FINAL_WARNING / LEGAL_ACTION) ---
+
+  @Get('pending-escalations')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  pendingEscalations() {
+    return this.overdueService.getPendingEscalations();
+  }
+
+  @Post('contracts/:id/approve-escalation')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  approveEscalation(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.overdueService.approveDunningEscalation(id, user.id, user.role);
+  }
+
+  @Post('contracts/:id/reject-escalation')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  rejectEscalation(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.overdueService.rejectDunningEscalation(
+      id,
+      user.id,
+      user.role,
+      body.reason,
+    );
+  }
 }

--- a/apps/api/src/modules/overdue/overdue.service.spec.ts
+++ b/apps/api/src/modules/overdue/overdue.service.spec.ts
@@ -83,3 +83,80 @@ describe('OverdueService.recordSettlement', () => {
     ).rejects.toThrow(BadRequestException);
   });
 });
+
+describe('OverdueService.approveDunningEscalation (T4-C2)', () => {
+  let service: OverdueService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const contractWithPending = (pending: string | null) => ({
+    id: 'c-1',
+    contractNumber: 'BC-001',
+    dunningStage: 'NOTICE',
+    pendingDunningStage: pending,
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      contract: {
+        findFirst: jest.fn().mockResolvedValue(contractWithPending('FINAL_WARNING')),
+        update: jest.fn().mockResolvedValue({}),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+    };
+    const mod = await Test.createTestingModule({
+      providers: [OverdueService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(OverdueService);
+  });
+
+  it('rejects non-OWNER/FM roles', async () => {
+    const { ForbiddenException } = await import('@nestjs/common');
+    await expect(
+      service.approveDunningEscalation('c-1', 'u-1', 'BRANCH_MANAGER'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects when no pending escalation', async () => {
+    prisma.contract.findFirst.mockResolvedValue(contractWithPending(null));
+    await expect(
+      service.approveDunningEscalation('c-1', 'u-owner', 'OWNER'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('flips dunningStage to pending target + clears pending + writes audit', async () => {
+    await service.approveDunningEscalation('c-1', 'u-fm', 'FINANCE_MANAGER');
+    const updateArgs = prisma.contract.update.mock.calls[0][0];
+    expect(updateArgs.data.dunningStage).toBe('FINAL_WARNING');
+    expect(updateArgs.data.pendingDunningStage).toBeNull();
+    expect(prisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'DUNNING_ESCALATION_APPROVED' }),
+      }),
+    );
+  });
+
+  it('rejectDunningEscalation requires reason ≥ 5 chars', async () => {
+    await expect(
+      service.rejectDunningEscalation('c-1', 'u-owner', 'OWNER', 'no'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejectDunningEscalation clears pending + audit log', async () => {
+    await service.rejectDunningEscalation(
+      'c-1',
+      'u-owner',
+      'OWNER',
+      'customer disputing — pause',
+    );
+    const updateArgs = prisma.contract.update.mock.calls[0][0];
+    expect(updateArgs.data.pendingDunningStage).toBeNull();
+    expect(prisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'DUNNING_ESCALATION_REJECTED' }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, NotFoundException, Logger, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  Logger,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { Prisma, DunningStage } from '@prisma/client';
@@ -470,6 +476,36 @@ export class OverdueService {
       const targetIdx = stageOrder.indexOf(targetStage);
 
       if (targetIdx > currentIdx) {
+        // T4-C2: FINAL_WARNING and LEGAL_ACTION messages carry legal +
+        // PDPA risk if fired auto on a disputed debt. Park them as pending
+        // and wait for a human OWNER/FM to approve.
+        const requiresApproval =
+          targetStage === 'FINAL_WARNING' || targetStage === 'LEGAL_ACTION';
+
+        if (requiresApproval) {
+          await this.prisma.contract.update({
+            where: { id: contract.id },
+            data: {
+              pendingDunningStage: targetStage,
+              pendingDunningSince: now,
+            },
+          });
+          if (systemUser) {
+            await this.prisma.auditLog.create({
+              data: {
+                userId: systemUser.id,
+                action: 'DUNNING_ESCALATION_PENDING',
+                entity: 'contract',
+                entityId: contract.id,
+                oldValue: { dunningStage: contract.dunningStage },
+                newValue: { pendingDunningStage: targetStage, daysOverdue },
+                ipAddress: 'system-cron',
+              },
+            });
+          }
+          continue; // no stage flip, no customer notification this round
+        }
+
         await this.prisma.contract.update({
           where: { id: contract.id },
           data: {
@@ -479,7 +515,6 @@ export class OverdueService {
           },
         });
 
-        // Audit log
         if (systemUser) {
           await this.prisma.auditLog.create({
             data: {
@@ -506,6 +541,126 @@ export class OverdueService {
 
     this.logger.log(`Dunning escalation: ${escalated.length} contracts escalated`);
     return { escalated, timestamp: now };
+  }
+
+  /**
+   * T4-C2: approve the auto-escalator's proposal to flip a contract into
+   * FINAL_WARNING or LEGAL_ACTION. Restricted to OWNER/FINANCE_MANAGER since
+   * the downstream message is legally sensitive. Returns the updated contract
+   * so the caller can dispatch the actual notification.
+   */
+  async approveDunningEscalation(contractId: string, userId: string, userRole: string) {
+    const allowed = ['OWNER', 'FINANCE_MANAGER'];
+    if (!allowed.includes(userRole)) {
+      throw new ForbiddenException(
+        `สิทธิ์อนุมัติ dunning escalation เฉพาะ ${allowed.join(' / ')}`,
+      );
+    }
+
+    const contract = await this.prisma.contract.findFirst({
+      where: { id: contractId, deletedAt: null },
+      select: {
+        id: true,
+        contractNumber: true,
+        dunningStage: true,
+        pendingDunningStage: true,
+      },
+    });
+    if (!contract) throw new NotFoundException('ไม่พบสัญญา');
+    if (!contract.pendingDunningStage) {
+      throw new BadRequestException('สัญญานี้ไม่มี dunning escalation รออนุมัติ');
+    }
+
+    const now = new Date();
+    const target = contract.pendingDunningStage;
+
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.contract.update({
+        where: { id: contractId },
+        data: {
+          dunningStage: target,
+          dunningEscalatedAt: now,
+          dunningLastActionAt: now,
+          pendingDunningStage: null,
+          pendingDunningSince: null,
+        },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'DUNNING_ESCALATION_APPROVED',
+          entity: 'contract',
+          entityId: contractId,
+          oldValue: { dunningStage: contract.dunningStage, pendingDunningStage: target },
+          newValue: { dunningStage: target },
+        },
+      }),
+    ]);
+
+    return updated;
+  }
+
+  async rejectDunningEscalation(
+    contractId: string,
+    userId: string,
+    userRole: string,
+    reason: string,
+  ) {
+    const allowed = ['OWNER', 'FINANCE_MANAGER'];
+    if (!allowed.includes(userRole)) {
+      throw new ForbiddenException(
+        `สิทธิ์ปฏิเสธ dunning escalation เฉพาะ ${allowed.join(' / ')}`,
+      );
+    }
+    if (!reason || reason.trim().length < 5) {
+      throw new BadRequestException('ต้องระบุเหตุผลการปฏิเสธ (≥ 5 ตัวอักษร)');
+    }
+
+    const contract = await this.prisma.contract.findFirst({
+      where: { id: contractId, deletedAt: null },
+      select: { id: true, pendingDunningStage: true, dunningStage: true },
+    });
+    if (!contract) throw new NotFoundException('ไม่พบสัญญา');
+    if (!contract.pendingDunningStage) {
+      throw new BadRequestException('สัญญานี้ไม่มี dunning escalation รออนุมัติ');
+    }
+
+    await this.prisma.$transaction([
+      this.prisma.contract.update({
+        where: { id: contractId },
+        data: { pendingDunningStage: null, pendingDunningSince: null },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'DUNNING_ESCALATION_REJECTED',
+          entity: 'contract',
+          entityId: contractId,
+          oldValue: { pendingDunningStage: contract.pendingDunningStage },
+          newValue: { rejectedReason: reason.trim() },
+        },
+      }),
+    ]);
+    return { success: true };
+  }
+
+  async getPendingEscalations() {
+    return this.prisma.contract.findMany({
+      where: {
+        pendingDunningStage: { not: null },
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        contractNumber: true,
+        dunningStage: true,
+        pendingDunningStage: true,
+        pendingDunningSince: true,
+        customer: { select: { id: true, name: true, phone: true } },
+      },
+      orderBy: { pendingDunningSince: 'asc' },
+      take: 200,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
Auto-escalator flipped to LEGAL_ACTION without human review → PDPA + consumer-protection risk on disputed debts

## Changes
- Schema: Contract +pendingDunningStage/Since
- Cron: auto up to NOTICE; FINAL_WARNING/LEGAL_ACTION → park pending
- Service: approve / reject methods (OWNER/FM only)
- Controller: /pending-escalations, /contracts/:id/approve-escalation, /reject-escalation

## Test plan
- [x] +5 tests (27 overdue tests total)
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)