### PR TITLE
docs(ops): backup drill + WAF runbooks (T7-C4, T7-C8)

### DIFF
--- a/docs/guides/BACKUP-RUNBOOK.md
+++ b/docs/guides/BACKUP-RUNBOOK.md
@@ -109,6 +109,75 @@ gcloud sql instances delete bestchoice-restore-drill --quiet
 - GCS exports: encrypted with `BACKUP_ENCRYPTION_KEY` (AES-256)
 - Key stored in Secret Manager — **never in .env or source code**
 
+## Quarterly Recovery Drill (T7-C4)
+
+เป้าหมาย: พิสูจน์ว่า restore ได้จริงภายใน RTO กำหนด — ไม่ใช่ "คิดว่าน่าจะได้"
+
+### RTO / RPO targets
+- **RTO** (Recovery Time Objective): 2 ชั่วโมง จาก incident ถึง system available
+- **RPO** (Recovery Point Objective): ≤ 5 นาที (Cloud SQL PITR มี granularity ~วินาที)
+
+### Drill schedule
+- **Q1 (Jan-Mar)**: วันศุกร์ที่ 2 ของเดือนมีนาคม
+- **Q2 (Apr-Jun)**: วันศุกร์ที่ 2 ของเดือนมิถุนายน
+- **Q3 (Jul-Sep)**: วันศุกร์ที่ 2 ของเดือนกันยายน
+- **Q4 (Oct-Dec)**: วันศุกร์ที่ 2 ของเดือนธันวาคม
+- เวลา: นอกเวลา business (หลัง 20:00 Asia/Bangkok)
+
+### Drill procedure (60-90 นาที)
+
+1. **Pre-flight** (10 นาที)
+   - [ ] ประกาศใน LINE OA internal ว่ากำลังทำ drill (dev environment)
+   - [ ] Snapshot prod state (count contracts, payments, users) เก็บไว้เทียบ
+   - [ ] บันทึกเวลาเริ่ม: `T0`
+
+2. **Create clone** (15-25 นาที)
+   - `gcloud sql instances clone bestchoice-prod bestchoice-drill-YYYYMMDD \
+       --point-in-time='YYYY-MM-DDTHH:MM:SSZ'`
+   - เลือก PITR timestamp ประมาณ 1 ชั่วโมงก่อน `T0`
+   - บันทึกเวลา clone เสร็จ: `T1` (ต้อง ≤ 45 นาที)
+
+3. **Verify data integrity** (15-25 นาที)
+   - Connect ไป clone instance
+   - รัน verification queries:
+     ```sql
+     SELECT COUNT(*) FROM contracts WHERE deleted_at IS NULL;
+     SELECT COUNT(*) FROM payments WHERE status = 'PAID';
+     SELECT COALESCE(SUM(amount_paid), 0) FROM payments WHERE paid_at > NOW() - INTERVAL '1 day';
+     ```
+   - ผลต้องตรงกับ snapshot ใน step 1 (tolerance ตามช่วง PITR gap)
+   - ตรวจ checksum ของ migrations: `\dt` show ทุก table ตามที่คาดหวัง
+
+4. **Application smoke test** (10-20 นาที)
+   - Deploy preview-API ชี้ไปที่ clone DB
+   - Login ด้วย test account
+   - ดึง contract 1 ใบ / ตรวจ payment history
+   - บันทึกเวลา app ready: `T2` (ต้อง ≤ 2 ชั่วโมง จาก `T0`)
+
+5. **Cleanup** (5 นาที)
+   - Delete clone instance: `gcloud sql instances delete bestchoice-drill-YYYYMMDD`
+   - ยืนยัน billing charge หยุด
+
+6. **Document** (10 นาที)
+   - บันทึก `T1-T0`, `T2-T0`, deviations ใน `docs/reports/backup-drills/YYYY-QN.md`
+   - ถ้า RTO miss → สร้าง issue + assign เจ้าของ
+   - Slack/LINE OA: "Drill YYYY-QN ผ่าน/ไม่ผ่าน, RTO=XXm"
+
+### Drill evidence checklist
+สิ่งที่ต้องมีเก็บในไฟล์ report:
+- [ ] Timestamps T0/T1/T2
+- [ ] Clone instance name + PITR target
+- [ ] Verification query results
+- [ ] App smoke test screenshot
+- [ ] Cleanup confirmation
+- [ ] Participant list
+
+### RTO miss escalation
+ถ้า drill fails RTO 2 ครั้งติดกัน:
+1. Root cause analysis ภายใน 7 วัน
+2. พิจารณา: warm standby, read replica, cross-region strategy
+3. ปรับ RTO target ถ้าจำเป็น + แจ้ง CPA เรื่อง business continuity
+
 ## Emergency Contacts
 
 | Role | Contact |

--- a/docs/guides/WAF-RUNBOOK.md
+++ b/docs/guides/WAF-RUNBOOK.md
@@ -1,0 +1,98 @@
+# Cloud Armor WAF Runbook (T7-C8)
+
+## Overview
+BESTCHOICE API อยู่บน Cloud Run with `--allow-unauthenticated` (ต้องเป็น public เพื่อรับ webhook จาก LINE/PaySolutions/SMS). ป้องกันระดับ network = Cloud Armor edge policy ต้องเปิดใช้.
+
+ปัจจุบัน (pre-T7-C8): ไม่มี Cloud Armor — defense in depth เหลือแต่ app-level auth + NestJS rate limiter. DDoS / credential stuffing / geo-probe เข้าถึง app ได้ตรง.
+
+## Target policy
+
+### Rate limits
+| Path | Unauth limit | Auth limit | Action |
+|------|--------------|------------|--------|
+| `/api/auth/login` | 30/min per IP | — | throttle 429 |
+| `/api/auth/login/2fa` | 15/min per IP | — | throttle 429 |
+| `/api/paysolutions/webhook` | 120/min per IP | — | throttle 429 |
+| `/api/line-oa/webhook` | 300/min per IP | — | throttle 429 |
+| `/api/*` (catchall) | 300/min per IP | 1200/min per user | throttle 429 |
+
+### Geo restrictions
+- Allow: Thailand (TH) + บริษัท VPN egress IPs
+- Block + alert: China (CN), Russia (RU), North Korea (KP)
+- Log only: everywhere else — collect 30 days data, decide if need broader block
+
+### Bot detection
+- reCAPTCHA integration บน `/api/auth/login` (score < 0.3 = block)
+- Known bot headers (scrapers) → block
+- Missing `Accept-Language` header on `/api/auth/*` → challenge
+
+## Setup checklist
+
+1. **GCP Console → Security → Cloud Armor**
+   - Create security policy `bestchoice-api-edge`
+   - Adaptive protection: layer 7 DDoS enabled
+   - Log sampling: 100% (log everything เริ่มต้น 30 วัน แล้วลดลง 10%)
+
+2. **Attach to backend**
+   - `gcloud compute backend-services update bestchoice-api-backend \
+       --security-policy=bestchoice-api-edge`
+
+3. **Rules priority order** (ต่ำ = เลือกก่อน)
+   ```
+   1000 - allowlist (internal IPs) → allow
+   2000 - denylist (known bad IPs) → deny(403)
+   3000 - geo restrictions → deny(403)
+   4000 - rate limits per path → throttle
+   5000 - bot detection → challenge
+   9000 - default → allow
+   ```
+
+4. **Logging → BigQuery**
+   - Export `compute.googleapis.com/security_policy_blocks` → `bestchoice-ops.waf_logs`
+   - Dashboard ใน Grafana/Metabase: top blocked IPs, top rate-limited paths
+
+## Monitoring
+
+### Alerts (Sentry / PagerDuty)
+- > 1000 blocks/hour per IP → page on-call
+- > 100 rate-limit hits/hour on auth endpoints → Sentry warning
+- Geo-block spike > 50/hour → Sentry info
+
+### Daily review (manual 5 min)
+- GCP Console → Cloud Armor → Policy → Logs
+- Look for: new blocked IP ranges, unusual path patterns, 429 spike
+
+## Incident playbook
+
+### Suspected DDoS (429 rate > 10k/min)
+1. Enable Adaptive Protection response action (if not already)
+2. Manually add `block-all-non-TH` rule priority 500 (temporary)
+3. Notify customer via LINE OA broadcast: "ระบบรัก busy ขอเวลา 10-30 นาที"
+4. Post-incident: review blocked ranges, update denylist permanently
+
+### Legitimate customer blocked
+1. Customer contacts sales with 403 error
+2. Get their IP (send `curl ifconfig.me`)
+3. Check logs → confirm geo or rate-limit block
+4. Temporary allowlist entry priority 900
+5. If recurring: review geo policy
+
+## Cost estimate
+- Cloud Armor standard: $5/month fixed + $1/policy/month × rules (~15 rules = $15)
+- Adaptive Protection: $1/million requests evaluated
+- Expected BESTCHOICE volume: 2-5M req/mo → ~$25-45/mo total
+
+## Rollback
+ถ้า WAF block legit traffic มากเกินไป:
+```
+gcloud compute backend-services update bestchoice-api-backend \
+    --no-security-policy
+```
+แล้ว debug logs หาว่า rule ไหน match → แก้ rule แล้ว re-attach
+
+## Emergency Contacts
+| Role | Contact |
+|------|---------|
+| GCP owner | เจ้าของ (พี่นาย) |
+| Cloud Armor docs | https://cloud.google.com/armor/docs |
+| Related: rate limit at app-level | `apps/api/src/guards/user-throttler.guard.ts` |


### PR DESCRIPTION
## Summary
Ops-level items ใน Phase 2 master — documentation-first เพราะต้อง GCP console + business approval ก่อน execute

- **BACKUP-RUNBOOK**: +quarterly drill procedure (60-90 min, RTO 2h / RPO 5min)
- **WAF-RUNBOOK**: ใหม่ — rate limits/geo/bot rules + setup + incident playbook

## Test plan
- [x] Markdown formatted
- [x] Cost estimate included
- [ ] Quarterly drill scheduled + run (ops follow-up)
- [ ] WAF enabled in GCP + first 30d logs observed (ops follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)