### PR TITLE
feat(invite): second-channel OTP + reduce validity to 24h (T7-C6)

### DIFF
--- a/apps/api/prisma/migrations/20260524800000_invite_token_otp/migration.sql
+++ b/apps/api/prisma/migrations/20260524800000_invite_token_otp/migration.sql
@@ -1,0 +1,10 @@
+-- T7-C6: invite flow hardening. Email carries only the link; a 6-digit OTP
+-- is sent to the invited user's phone via SMS. Completing signup requires
+-- both. If the email is forwarded or the mailbox is compromised, the
+-- attacker is still missing the phone-side OTP.
+
+ALTER TABLE "invite_tokens"
+  ADD COLUMN "otp_hash"        TEXT,
+  ADD COLUMN "otp_expires_at"  TIMESTAMP(3),
+  ADD COLUMN "otp_attempts"    INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "phone"           TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1904,6 +1904,14 @@ model InviteToken {
   invitedBy String    @map("invited_by")
   expiresAt DateTime  @map("expires_at")
   usedAt    DateTime? @map("used_at")
+  /// T7-C6: bcrypt hash of a 6-digit OTP sent through a second channel (SMS
+  /// to the invited user's phone). Email carries the link only — if the
+  /// email is forwarded or the mailbox is compromised, the attacker still
+  /// can't complete signup without the OTP from phone.
+  otpHash   String?   @map("otp_hash")
+  otpExpiresAt DateTime? @map("otp_expires_at")
+  otpAttempts  Int      @default(0) @map("otp_attempts")
+  phone     String? // invitee phone for SMS delivery
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime  @updatedAt @map("updated_at")
 

--- a/apps/api/src/modules/invite/dto/create-invite.dto.ts
+++ b/apps/api/src/modules/invite/dto/create-invite.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { IsEmail, IsEnum, IsOptional, IsUUID, Matches } from 'class-validator';
 import { UserRole } from '@prisma/client';
 
 export class CreateInviteDto {
@@ -11,4 +11,10 @@ export class CreateInviteDto {
   @IsOptional()
   @IsUUID('4', { message: 'รหัสสาขาไม่ถูกต้อง' })
   branchId?: string;
+
+  /// T7-C6: phone เพื่อส่ง OTP ผ่าน SMS คนละ channel กับ email — ทำให้
+  /// email compromise ไม่พอจะเข้ายึด invite ได้
+  @IsOptional()
+  @Matches(/^0[0-9]{9}$/, { message: 'เบอร์โทรต้องเป็นเลข 10 หลัก ขึ้นต้นด้วย 0' })
+  phone?: string;
 }

--- a/apps/api/src/modules/invite/dto/register-invite.dto.ts
+++ b/apps/api/src/modules/invite/dto/register-invite.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, MinLength, IsOptional } from 'class-validator';
+import { IsString, MinLength, IsOptional, Length } from 'class-validator';
 
 export class RegisterInviteDto {
   @IsString()
@@ -18,4 +18,12 @@ export class RegisterInviteDto {
   @IsOptional()
   @IsString()
   nickname?: string;
+
+  /// T7-C6: 6-digit OTP from SMS. Required when the invite was issued with
+  /// a phone number. Skipped when admin created invite without phone (older
+  /// flow — backwards compatible).
+  @IsOptional()
+  @IsString()
+  @Length(6, 6, { message: 'รหัส OTP ต้องเป็นตัวเลข 6 หลัก' })
+  otp?: string;
 }

--- a/apps/api/src/modules/invite/invite.service.spec.ts
+++ b/apps/api/src/modules/invite/invite.service.spec.ts
@@ -1,0 +1,158 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
+import { InviteService } from './invite.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EmailService } from '../email/email.service';
+import { ConfigService } from '@nestjs/config';
+
+describe('InviteService.register — T7-C6 OTP guard', () => {
+  let service: InviteService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const rawToken = 'a'.repeat(64);
+  const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+
+  const inviteRow = (overrides: Record<string, unknown> = {}) => ({
+    id: 'inv-1',
+    token: tokenHash,
+    email: 'new@test.com',
+    role: 'SALES',
+    branchId: null,
+    invitedBy: 'u-admin',
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    usedAt: null,
+    otpHash: null,
+    otpExpiresAt: null,
+    otpAttempts: 0,
+    phone: null,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      inviteToken: {
+        findUnique: jest.fn(),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      user: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn(),
+      },
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        InviteService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: EmailService, useValue: { sendInviteEmail: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+    service = mod.get(InviteService);
+  });
+
+  it('no-OTP invite still works (backward compat)', async () => {
+    prisma.inviteToken.findUnique.mockResolvedValue(inviteRow());
+    const result = await service.register({
+      token: rawToken,
+      password: 'password123',
+      name: 'New Staff',
+    });
+    expect(result.message).toContain('ลงทะเบียนสำเร็จ');
+  });
+
+  it('OTP invite without otp in dto → BadRequest', async () => {
+    prisma.inviteToken.findUnique.mockResolvedValue(
+      inviteRow({
+        otpHash: await bcrypt.hash('123456', 10),
+        otpExpiresAt: new Date(Date.now() + 10 * 60 * 1000),
+        phone: '0891234567',
+      }),
+    );
+    await expect(
+      service.register({
+        token: rawToken,
+        password: 'password123',
+        name: 'New Staff',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('OTP invite with wrong otp → increments attempts + BadRequest', async () => {
+    prisma.inviteToken.findUnique.mockResolvedValue(
+      inviteRow({
+        otpHash: await bcrypt.hash('123456', 10),
+        otpExpiresAt: new Date(Date.now() + 10 * 60 * 1000),
+        otpAttempts: 0,
+      }),
+    );
+    await expect(
+      service.register({
+        token: rawToken,
+        password: 'password123',
+        name: 'New Staff',
+        otp: '000000',
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.inviteToken.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ otpAttempts: 1 }),
+      }),
+    );
+  });
+
+  it('OTP invite with correct otp → registers', async () => {
+    const otp = '654321';
+    prisma.inviteToken.findUnique.mockResolvedValue(
+      inviteRow({
+        otpHash: await bcrypt.hash(otp, 10),
+        otpExpiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      }),
+    );
+    const result = await service.register({
+      token: rawToken,
+      password: 'password123',
+      name: 'New Staff',
+      otp,
+    });
+    expect(result.message).toContain('ลงทะเบียนสำเร็จ');
+  });
+
+  it('OTP invite with expired OTP → BadRequest', async () => {
+    prisma.inviteToken.findUnique.mockResolvedValue(
+      inviteRow({
+        otpHash: await bcrypt.hash('123456', 10),
+        otpExpiresAt: new Date(Date.now() - 60 * 1000), // expired 1 min ago
+      }),
+    );
+    await expect(
+      service.register({
+        token: rawToken,
+        password: 'password123',
+        name: 'New Staff',
+        otp: '123456',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('OTP invite after 3 failed attempts → BadRequest (burned)', async () => {
+    prisma.inviteToken.findUnique.mockResolvedValue(
+      inviteRow({
+        otpHash: await bcrypt.hash('123456', 10),
+        otpExpiresAt: new Date(Date.now() + 10 * 60 * 1000),
+        otpAttempts: 3,
+      }),
+    );
+    await expect(
+      service.register({
+        token: rawToken,
+        password: 'password123',
+        name: 'New Staff',
+        otp: '123456',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/invite/invite.service.ts
+++ b/apps/api/src/modules/invite/invite.service.ts
@@ -46,10 +46,26 @@ export class InviteService {
       throw new ConflictException('อีเมลนี้มีคำเชิญที่ยังไม่หมดอายุอยู่แล้ว');
     }
 
-    // Generate raw token and hash it
+    // Generate raw token (goes in email link)
     const rawToken = crypto.randomBytes(32).toString('hex');
     const hashedToken = this.hashToken(rawToken);
-    const expiresAt = new Date(Date.now() + 72 * 60 * 60 * 1000); // 72 hours
+    // T7-C6: reduce validity 72h → 24h. Email + OTP combo means an invite is
+    // two-channel; the longer the window open, the more chances a compromised
+    // mailbox has to intercept both channels.
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    // T7-C6: second channel OTP — 6 digits, 15 min validity, bcrypt-hashed.
+    // Sent via SMS to dto.phone (if provided). Older invites without phone
+    // fall back to email-only (best for existing integration tests and
+    // environments without SMS credentials).
+    let rawOtp: string | null = null;
+    let otpHash: string | null = null;
+    let otpExpiresAt: Date | null = null;
+    if (dto.phone) {
+      rawOtp = String(Math.floor(100000 + Math.random() * 900000)); // 6 digits
+      otpHash = await bcrypt.hash(rawOtp, 10);
+      otpExpiresAt = new Date(Date.now() + 15 * 60 * 1000);
+    }
 
     // Get inviter info for the email
     const inviter = await this.prisma.user.findUnique({
@@ -75,6 +91,9 @@ export class InviteService {
         branchId: dto.branchId || null,
         invitedBy,
         expiresAt,
+        otpHash,
+        otpExpiresAt,
+        phone: dto.phone ?? null,
       },
       select: {
         id: true,
@@ -83,6 +102,12 @@ export class InviteService {
         expiresAt: true,
       },
     });
+
+    // Consumed by controller: SMS the OTP separately (out of email channel).
+    // Not returned in the response — callers (the controller) will read
+    // `rawOtp` via a private field pattern if needed. For now we expose the
+    // raw OTP on a throwaway property so the controller can hand it to SMS.
+    (invite as typeof invite & { _rawOtp?: string })._rawOtp = rawOtp ?? undefined;
 
     // Build the invite URL with raw (unhashed) token
     const frontendUrl = this.configService.get<string>(
@@ -218,6 +243,28 @@ export class InviteService {
     }
     if (invite.expiresAt < new Date()) {
       throw new BadRequestException('ลิงก์หมดอายุแล้ว');
+    }
+
+    // T7-C6: when an OTP was issued at invite time, the invitee must supply
+    // it here alongside the link. 3 failed attempts → invite is burned.
+    if (invite.otpHash) {
+      if (!dto.otp) {
+        throw new BadRequestException('กรุณากรอกรหัส OTP ที่ส่งไปทาง SMS');
+      }
+      if (invite.otpExpiresAt && invite.otpExpiresAt < new Date()) {
+        throw new BadRequestException('รหัส OTP หมดอายุแล้ว กรุณาขอ invite ใหม่');
+      }
+      if (invite.otpAttempts >= 3) {
+        throw new BadRequestException('ผิด OTP เกิน 3 ครั้ง กรุณาขอ invite ใหม่');
+      }
+      const ok = await bcrypt.compare(dto.otp, invite.otpHash);
+      if (!ok) {
+        await this.prisma.inviteToken.update({
+          where: { id: invite.id },
+          data: { otpAttempts: invite.otpAttempts + 1 },
+        });
+        throw new BadRequestException('รหัส OTP ไม่ถูกต้อง');
+      }
     }
 
     // Check if email is already taken (race condition guard)


### PR DESCRIPTION
## Summary
ลด attack surface ของ invite link — email forward/compromise alone ไม่พอให้ attacker register ในยศที่ admin ตั้งใจ

## Changes
- DTO: `phone` (invite), `otp` (register)
- InviteToken schema: otpHash, otpExpiresAt, otpAttempts, phone
- Validity 72h → 24h
- Register flow: verify OTP (bcrypt compare), 3 failed attempts = burn
- Backward compat: ถ้า invite ไม่มี phone/otpHash → link-only เหมือนเดิม

## Test plan
- [x] +6 tests (no-OTP compat, missing, wrong+attempt, correct, expired, burned)
- [x] TS check passes

**Note**: SMS dispatch side follow-up (ต้อง wire SmsService ใน invite controller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)