### PR TITLE
feat(webhook-security): wire anomaly log เข้า LINE Shop + Facebook webhooks (T6-C7)

### DIFF
--- a/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
+++ b/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
@@ -19,6 +19,7 @@ import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { ChatChannel, MessageType } from '@prisma/client';
 import { RawBodyRequest } from '../../common/types/raw-body-request';
+import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
 
 /**
  * Facebook Messenger Webhook Controller
@@ -42,6 +43,7 @@ export class FacebookWebhookController {
   constructor(
     private messageRouter: MessageRouterService,
     private configService: ConfigService,
+    private anomaly: WebhookAnomalyService,
   ) {}
 
   /**
@@ -87,6 +89,12 @@ export class FacebookWebhookController {
     const rawBody = (req as unknown as RawBodyRequest).rawBody;
     if (!this.verifySignature(rawBody, signature)) {
       this.logger.warn('[FB Webhook] Invalid signature — rejecting payload');
+      void this.anomaly.record({
+        provider: 'facebook',
+        reason: signature ? 'invalid_signature' : 'missing_signature',
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'] as string | undefined,
+      });
       throw new BadRequestException('Invalid signature');
     }
 

--- a/apps/api/src/modules/line-oa/line-webhook.guard.ts
+++ b/apps/api/src/modules/line-oa/line-webhook.guard.ts
@@ -3,6 +3,7 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import { Request } from 'express';
 import { RawBodyRequest } from '../../common/types/raw-body-request';
 import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
 
 /**
  * Guard for LINE Webhook signature verification
@@ -13,10 +14,15 @@ import { IntegrationConfigService } from '../integrations/integration-config.ser
 export class LineWebhookGuard implements CanActivate {
   private readonly logger = new Logger(LineWebhookGuard.name);
 
-  constructor(private integrationConfig: IntegrationConfigService) {}
+  constructor(
+    private integrationConfig: IntegrationConfigService,
+    private anomaly: WebhookAnomalyService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
+    const ipAddress = request.ip;
+    const userAgent = request.headers['user-agent'] as string | undefined;
 
     const channelSecret = (await this.integrationConfig.getValue('line-shop', 'channelSecret')) || '';
 
@@ -27,6 +33,7 @@ export class LineWebhookGuard implements CanActivate {
         return true;
       }
       this.logger.error('LINE_CHANNEL_SECRET missing in production — refusing webhook');
+      void this.anomaly.record({ provider: 'line-shop', reason: 'missing_secret', ipAddress, userAgent });
       throw new UnauthorizedException('Webhook signature verification not configured');
     }
 
@@ -34,6 +41,7 @@ export class LineWebhookGuard implements CanActivate {
 
     if (!signature) {
       this.logger.warn('Missing x-line-signature header');
+      void this.anomaly.record({ provider: 'line-shop', reason: 'missing_signature', ipAddress, userAgent });
       throw new UnauthorizedException('Missing LINE signature');
     }
 
@@ -48,6 +56,7 @@ export class LineWebhookGuard implements CanActivate {
     const expBuf = Buffer.from(expectedSignature, 'base64');
     if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
       this.logger.warn('Invalid LINE webhook signature');
+      void this.anomaly.record({ provider: 'line-shop', reason: 'invalid_signature', ipAddress, userAgent });
       throw new UnauthorizedException('Invalid LINE signature');
     }
 


### PR DESCRIPTION
## Summary
WebhookAnomaly infra (PR #539) wired เข้า 2 providers เพิ่ม — ครบ coverage: LINE Finance, LINE Shop, Facebook, PaySolutions

SMS + LINE Staff เหลือ — SMS provider ไม่มี HMAC, LINE Staff ไม่มี public endpoint

## Test plan
- [x] TS check passes
- [x] Existing guard tests ยังผ่าน

🤖 Generated with [Claude Code](https://claude.com/claude-code)