### PR TITLE
feat(peak): daily sync cron at 23:30 (T6-C8)

### DIFF
--- a/apps/api/src/modules/peak/peak-sync.cron.spec.ts
+++ b/apps/api/src/modules/peak/peak-sync.cron.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PeakSyncCron } from './peak-sync.cron';
+import { PeakService } from './peak.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('PeakSyncCron.dailySync', () => {
+  let cron: PeakSyncCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let peak: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    peak = {
+      isConfigured: jest.fn().mockResolvedValue(true),
+      exportJournalEntries: jest.fn().mockResolvedValue({ exported: 0, errors: [] }),
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [PeakSyncCron, { provide: PeakService, useValue: peak }],
+    }).compile();
+    cron = mod.get(PeakSyncCron);
+  });
+
+  it('skips silently when PEAK is not configured', async () => {
+    peak.isConfigured.mockResolvedValue(false);
+    const result = await cron.dailySync();
+    expect(result).toEqual({ exported: 0, errors: 0 });
+    expect(peak.exportJournalEntries).not.toHaveBeenCalled();
+  });
+
+  it('exports yesterday-to-now window', async () => {
+    await cron.dailySync();
+    const [start, end] = peak.exportJournalEntries.mock.calls[0];
+    const dayDiff = (end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000);
+    expect(dayDiff).toBeGreaterThan(0.9);
+    expect(dayDiff).toBeLessThan(2);
+  });
+
+  it('reports exported count when success', async () => {
+    peak.exportJournalEntries.mockResolvedValue({ exported: 7, errors: [] });
+    const result = await cron.dailySync();
+    expect(result.exported).toBe(7);
+    expect(result.errors).toBe(0);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('Sentry warning when errors present', async () => {
+    peak.exportJournalEntries.mockResolvedValue({
+      exported: 5,
+      errors: ['JE-001: timeout', 'JE-002: resCode=500'],
+    });
+    const result = await cron.dailySync();
+    expect(result.errors).toBe(2);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('2 errors'),
+      expect.objectContaining({ level: 'warning' }),
+    );
+  });
+
+  it('swallows exception + Sentry capture (no throw)', async () => {
+    peak.exportJournalEntries.mockRejectedValue(new Error('peak down'));
+    const result = await cron.dailySync();
+    expect(result).toEqual({ exported: 0, errors: 0 });
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/peak/peak-sync.cron.ts
+++ b/apps/api/src/modules/peak/peak-sync.cron.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PeakService } from './peak.service';
+
+/**
+ * Daily PEAK sync (T6-C8). Exports all POSTED journal entries from yesterday
+ * into PEAK accounting system. Runs at 23:30 Asia/Bangkok — after business
+ * hours but before midnight so entries for "today" aren't pulled into
+ * tomorrow's batch.
+ *
+ * Idempotency: `exportJournalEntries` already filters `peakSyncedAt = null`,
+ * so re-running the same window is safe.
+ */
+@Injectable()
+export class PeakSyncCron {
+  private readonly logger = new Logger(PeakSyncCron.name);
+
+  constructor(private readonly peak: PeakService) {}
+
+  @Cron('30 23 * * *', { timeZone: 'Asia/Bangkok' })
+  async dailySync(): Promise<{ exported: number; errors: number }> {
+    try {
+      if (!(await this.peak.isConfigured())) {
+        this.logger.log('PEAK not configured — skipping daily sync');
+        return { exported: 0, errors: 0 };
+      }
+
+      // Range: yesterday 00:00 through today 23:30 (today window to catch
+      // same-day posts up to now). PEAK syncedAt filter prevents duplicate
+      // export — we can be generous with the range.
+      const start = new Date();
+      start.setDate(start.getDate() - 1);
+      start.setHours(0, 0, 0, 0);
+      const end = new Date();
+
+      const result = await this.peak.exportJournalEntries(start, end);
+      this.logger.log(
+        `PEAK daily sync: ${result.exported} exported, ${result.errors.length} errors`,
+      );
+
+      if (result.errors.length > 0) {
+        Sentry.captureMessage(
+          `PEAK daily sync had ${result.errors.length} errors (exported ${result.exported})`,
+          {
+            level: 'warning',
+            tags: { kind: 'cron-job', cron: 'peak-sync' },
+            extra: { errors: result.errors.slice(0, 20), exported: result.exported },
+          },
+        );
+      }
+
+      return { exported: result.exported, errors: result.errors.length };
+    } catch (err) {
+      this.logger.error(`PEAK sync cron failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'peak-sync' } });
+      return { exported: 0, errors: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/peak/peak.module.ts
+++ b/apps/api/src/modules/peak/peak.module.ts
@@ -4,11 +4,12 @@ import { JournalModule } from '../journal/journal.module';
 import { IntegrationsModule } from '../integrations/integrations.module';
 import { PeakController } from './peak.controller';
 import { PeakService } from './peak.service';
+import { PeakSyncCron } from './peak-sync.cron';
 
 @Module({
   imports: [PrismaModule, JournalModule, IntegrationsModule],
   controllers: [PeakController],
-  providers: [PeakService],
+  providers: [PeakService, PeakSyncCron],
   exports: [PeakService],
 })
 export class PeakModule {}


### PR DESCRIPTION
## Summary
PEAK export service + manual trigger มีอยู่แล้ว — เพิ่ม cron รันอัตโนมัติทุกคืน 23:30 Asia/Bangkok เพื่อไม่ต้องพึ่งพา accountant กดเอง

## Behavior
- Skip silently เมื่อ PEAK config ว่าง
- Sentry warning เมื่อมี error + breakdown top 20
- Exception swallow เพื่อ cron ไม่พัง

## Test plan
- [x] +5 tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)