### PR TITLE
feat(notifications): kill-switch ปิด SMS แจ้งเตือนการชำระ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,11 @@ LINE_CHANNEL_SECRET=
 LINE_FINANCE_CHANNEL_ACCESS_TOKEN=
 LINE_FINANCE_CHANNEL_SECRET=
 
+# SMS payment-reminder kill-switch
+# true = block SMS แจ้งเตือนการชำระ (upcoming reminder, overdue notice, dunning SMS fallback)
+# OTP/KYC SMS, LINE push, broadcast, IN_APP ยังทำงานปกติ
+SMS_PAYMENT_REMINDER_DISABLED=false
+
 # LINE Messaging API — Staff OA (channel #3: BESTCHOICE Staff notifications)
 # Used to broadcast handoff alerts + slip review notifications to staff
 LINE_STAFF_CHANNEL_ACCESS_TOKEN=

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException, BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
 import { formatDateShort, formatDateTime } from '../../utils/thai-date.util';
 import { maskPhone } from '../../utils/mask.util';
+import { isSmsPaymentReminderDisabled } from '../../utils/sms-payment-reminder.util';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../prisma/prisma.service';
 import { SendNotificationDto, CreateNotificationTemplateDto, UpdateNotificationTemplateDto } from './dto/create-notification.dto';
@@ -880,18 +881,22 @@ export class NotificationsService {
             recipient: customer.lineId,
             message,
             relatedId: payment.id,
-            fallbackPhone: customer.phone || undefined,
+            fallbackPhone: isSmsPaymentReminderDisabled() ? undefined : (customer.phone || undefined),
           });
           sent++;
         }
       } else if (customer.phone) {
-        await this.send({
-          channel: 'SMS',
-          recipient: customer.phone,
-          message,
-          relatedId: payment.id,
-        });
-        sent++;
+        if (isSmsPaymentReminderDisabled()) {
+          this.logger.warn(`[SMS-REMINDER-OFF] Skipping payment reminder SMS for payment ${payment.id}`);
+        } else {
+          await this.send({
+            channel: 'SMS',
+            recipient: customer.phone,
+            message,
+            relatedId: payment.id,
+          });
+          sent++;
+        }
       }
     }
 
@@ -1005,18 +1010,22 @@ export class NotificationsService {
             recipient: customer.lineId,
             message,
             relatedId: payment.id,
-            fallbackPhone: customer.phone || undefined,
+            fallbackPhone: isSmsPaymentReminderDisabled() ? undefined : (customer.phone || undefined),
           });
           sent++;
         }
       } else if (customer.phone) {
-        await this.send({
-          channel: 'SMS',
-          recipient: customer.phone,
-          message,
-          relatedId: payment.id,
-        });
-        sent++;
+        if (isSmsPaymentReminderDisabled()) {
+          this.logger.warn(`[SMS-REMINDER-OFF] Skipping overdue notice SMS for payment ${payment.id}`);
+        } else {
+          await this.send({
+            channel: 'SMS',
+            recipient: customer.phone,
+            message,
+            relatedId: payment.id,
+          });
+          sent++;
+        }
       }
     }
 

--- a/apps/api/src/modules/notifications/scheduler.service.ts
+++ b/apps/api/src/modules/notifications/scheduler.service.ts
@@ -16,6 +16,7 @@ import { buildDailyReportFlex } from '../line-oa/flex-messages/daily-report.flex
 import { DashboardService } from '../dashboard/dashboard.service';
 import { PDPAService } from '../pdpa/pdpa.service';
 import { DunningEngineService } from '../overdue/dunning-engine.service';
+import { isSmsPaymentReminderDisabled } from '../../utils/sms-payment-reminder.util';
 
 @Injectable()
 export class SchedulerService {
@@ -255,7 +256,7 @@ export class SchedulerService {
               subject: `Dunning: ${esc.to}`,
               message,
               relatedId: esc.contractId,
-              fallbackPhone: contract.customer.phone || undefined,
+              fallbackPhone: isSmsPaymentReminderDisabled() ? undefined : (contract.customer.phone || undefined),
             });
             notified++;
           }

--- a/apps/api/src/utils/sms-payment-reminder.util.ts
+++ b/apps/api/src/utils/sms-payment-reminder.util.ts
@@ -1,0 +1,15 @@
+/**
+ * SMS payment-reminder kill-switch.
+ *
+ * Set env `SMS_PAYMENT_REMINDER_DISABLED=true` to block SMS that notifies
+ * customers about installment payments specifically:
+ *   - Upcoming-payment reminders (sendPaymentReminders)
+ *   - Overdue notices (sendOverdueNotices)
+ *   - Dunning escalation SMS fallback when LINE delivery fails
+ *
+ * Other SMS use cases keep working: OTP, KYC verification, contract
+ * activation, manual one-off sends. LINE/broadcast/IN_APP unaffected.
+ */
+export function isSmsPaymentReminderDisabled(): boolean {
+  return process.env.SMS_PAYMENT_REMINDER_DISABLED === 'true';
+}


### PR DESCRIPTION
## Summary
- เพิ่ม env `SMS_PAYMENT_REMINDER_DISABLED` ที่ block **เฉพาะ** SMS แจ้งเตือนเรื่องค่างวด (reminder + overdue + dunning SMS fallback)
- OTP/KYC SMS, LINE push, broadcast, contract activation SMS, IN_APP ยังทำงานปกติ
- จุดที่ gate:
  - `sendPaymentReminders` SMS branch + LINE→SMS fallback
  - `sendOverdueNotices` SMS branch + LINE→SMS fallback
  - Dunning escalation SMS fallback ใน `scheduler.service.ts`

## ⚠️ ต้องทำเพิ่มหลัง merge — workflow env

Production env `SMS_PAYMENT_REMINDER_DISABLED=true` **ยังไม่ได้อยู่ใน PR นี้** เพราะ token ที่ใช้ push ไม่มี workflow scope

ต้องไปแก้ `.github/workflows/deploy-gcp.yml` ผ่าน GitHub web UI เพิ่มบรรทัดใน `--set-env-vars` block (ประมาณบรรทัด 259):

```yaml
          API_BASE_URL=https://api.bestchoicephone.app,\
          LIFF_CHANNEL_ID=2009442540,\
          SMS_PAYMENT_REMINDER_DISABLED=true" \
```

ถ้าไม่เพิ่มบรรทัดนี้ → PR merge ไปก็ไม่มีผล เพราะ Cloud Run env ไม่ติด flag

## Test plan
- [x] TypeScript check ผ่าน 0 error
- [ ] หลัง merge + workflow update → ตรวจ Cloud Run revision ว่า env ติดหรือไม่
- [ ] ตรวจ log Cloud Run ว่ามี `[SMS-REMINDER-OFF]` warning เวลา cron ทำงาน
- [ ] ทดสอบ OTP SMS (chatbot-finance verification) ยังส่งได้ปกติ

🤖 Generated with [Claude Code](https://claude.com/claude-code)