### PR TITLE
feat(sales/inventory): damage→resale fraud block (T5-C8)

### DIFF
--- a/apps/api/prisma/migrations/20260525000000_product_damage_flag/migration.sql
+++ b/apps/api/prisma/migrations/20260525000000_product_damage_flag/migration.sql
@@ -1,0 +1,17 @@
+-- T5-C8 anti-fraud: track any product that ever passed through a terminal
+-- damage status (DAMAGED/LOST/WRITTEN_OFF). Once flagged, it stays flagged
+-- even if restored via FOUND — sales code uses this to force OWNER approval
+-- + explicit disclosure acknowledgement before resale.
+
+ALTER TABLE "products"
+  ADD COLUMN "was_previously_damaged" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "restored_from_terminal_at" TIMESTAMP(3);
+
+-- Backfill from existing stock_adjustments: any product that has a DAMAGED/
+-- LOST/WRITE_OFF adjustment row gets the flag on.
+UPDATE "products" p
+SET "was_previously_damaged" = true
+FROM "stock_adjustments" sa
+WHERE sa."product_id" = p.id
+  AND sa.reason IN ('DAMAGED', 'LOST', 'WRITE_OFF')
+  AND sa."deleted_at" IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -984,6 +984,18 @@ model Product {
   photos             String[]        @default([])
   stockInDate        DateTime?       @map("stock_in_date")
 
+  /// T5-C8: flagged to `true` the first time this product lands in a
+  /// terminal damage status (DAMAGED / LOST / WRITTEN_OFF). If a FOUND
+  /// adjustment later restores the row, this field stays `true` forever —
+  /// sales logic uses it to force OWNER approval + customer disclosure
+  /// before the phone can be resold, even though the current `status` is
+  /// IN_STOCK again.
+  wasPreviouslyDamaged Boolean   @default(false) @map("was_previously_damaged")
+  /// Timestamp of the last FOUND restoration from a terminal damage status.
+  /// Used by audit + Sentry to flag resale attempts within the suspicious
+  /// "damaged-then-resurrected" window.
+  restoredFromTerminalAt DateTime? @map("restored_from_terminal_at")
+
   // Legacy migration tracking (จากโปรแกรมเขียว)
   legacyProductCode String? @unique @map("legacy_product_code")
 

--- a/apps/api/src/modules/inventory/stock-adjustments.service.spec.ts
+++ b/apps/api/src/modules/inventory/stock-adjustments.service.spec.ts
@@ -118,4 +118,86 @@ describe('StockAdjustmentsService.create — T5-C3 4-eyes', () => {
       service.create({ ...baseDto, approverId: 'approver-owner' }, 'user-1'),
     ).resolves.toBeDefined();
   });
+
+  describe('T5-C8: FOUND restoration gates', () => {
+    const foundDto = { ...baseDto, reason: 'FOUND' as const };
+
+    it('rejects BRANCH_MANAGER approving FOUND on a DAMAGED product', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'DAMAGED',
+        branchId: 'branch-1',
+        deletedAt: new Date(),
+      });
+      await expect(
+        service.create({ ...foundDto, approverId: 'approver-bm' }, 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects FINANCE_MANAGER approving FOUND on WRITTEN_OFF product', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'WRITTEN_OFF',
+        branchId: 'branch-1',
+        deletedAt: new Date(),
+      });
+      await expect(
+        service.create({ ...foundDto, approverId: 'approver-fm' }, 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows OWNER to approve FOUND on DAMAGED', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'DAMAGED',
+        branchId: 'branch-1',
+        deletedAt: new Date(),
+      });
+      await expect(
+        service.create({ ...foundDto, approverId: 'approver-owner' }, 'user-1'),
+      ).resolves.toBeDefined();
+      // Restoration stamp applied
+      expect(prisma.product.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'IN_STOCK',
+            restoredFromTerminalAt: expect.any(Date),
+          }),
+        }),
+      );
+    });
+
+    it('allows BRANCH_MANAGER to approve FOUND on LOST (not damage fraud pattern)', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'LOST',
+        branchId: 'branch-1',
+        deletedAt: new Date(),
+      });
+      await expect(
+        service.create({ ...foundDto, approverId: 'approver-bm' }, 'user-1'),
+      ).resolves.toBeDefined();
+    });
+
+    it('DAMAGED adjustment flips wasPreviouslyDamaged=true', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'IN_STOCK',
+        branchId: 'branch-1',
+        deletedAt: null,
+      });
+      await service.create(
+        { ...baseDto, reason: 'DAMAGED', approverId: 'approver-bm' },
+        'user-1',
+      );
+      expect(prisma.product.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'DAMAGED',
+            wasPreviouslyDamaged: true,
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/inventory/stock-adjustments.service.ts
+++ b/apps/api/src/modules/inventory/stock-adjustments.service.ts
@@ -51,6 +51,19 @@ export class StockAdjustmentsService {
         if (!product.deletedAt && product.status === 'IN_STOCK') {
           throw new BadRequestException('สินค้านี้อยู่ในสต๊อคอยู่แล้ว ไม่สามารถใช้เหตุผล "พบคืน" ได้');
         }
+        // T5-C8: restoring from DAMAGED/WRITTEN_OFF requires OWNER approver.
+        // The generic 4-eyes allows BRANCH_MANAGER to approve — that's fine
+        // for LOST→FOUND (missing phone reappears), but DAMAGED→FOUND is the
+        // classic fraud vector (manager flags damage, sells to accomplice as
+        // scrap, then resurrects for a clean retail resale). OWNER sign-off
+        // raises that bar.
+        const isDamageResurrection =
+          product.status === 'DAMAGED' || product.status === 'WRITTEN_OFF';
+        if (isDamageResurrection && approver.role !== 'OWNER') {
+          throw new ForbiddenException(
+            'การกู้คืนสินค้าจากสถานะ DAMAGED/WRITTEN_OFF ต้องให้ OWNER อนุมัติเท่านั้น (ไม่ใช่ BRANCH_MANAGER/FINANCE_MANAGER)',
+          );
+        }
       } else {
         // DAMAGED, LOST, WRITE_OFF, CORRECTION, OTHER: product must exist and be in stock
         if (!product || product.deletedAt) {
@@ -87,16 +100,31 @@ export class StockAdjustmentsService {
 
       // Update product status based on reason
       if (dto.reason === 'FOUND') {
+        const wasDamageRestore =
+          product.status === 'DAMAGED' || product.status === 'WRITTEN_OFF';
         await tx.product.update({
           where: { id: dto.productId },
-          data: { status: 'IN_STOCK', deletedAt: null, stockInDate: new Date() },
+          data: {
+            status: 'IN_STOCK',
+            deletedAt: null,
+            stockInDate: new Date(),
+            // T5-C8: stamp the restoration so sales can detect a recent
+            // damage-then-resurrect pattern. wasPreviouslyDamaged is already
+            // set from the prior DAMAGED adjustment — never flip it back.
+            restoredFromTerminalAt: wasDamageRestore ? new Date() : undefined,
+          },
         });
       } else if (['DAMAGED', 'LOST', 'WRITE_OFF'].includes(dto.reason)) {
         // DAMAGED, LOST, WRITE_OFF → update status and soft delete
         const statusMap: Record<string, 'DAMAGED' | 'LOST' | 'WRITTEN_OFF'> = { DAMAGED: 'DAMAGED', LOST: 'LOST', WRITE_OFF: 'WRITTEN_OFF' };
         await tx.product.update({
           where: { id: dto.productId },
-          data: { status: statusMap[dto.reason] || dto.reason, deletedAt: new Date() },
+          data: {
+            status: statusMap[dto.reason] || dto.reason,
+            deletedAt: new Date(),
+            // T5-C8: sticky flag — stays true even if FOUND later resurrects.
+            wasPreviouslyDamaged: true,
+          },
         });
       }
       // CORRECTION, OTHER → record only, no status/deletion change

--- a/apps/api/src/modules/sales/dto/sale.dto.ts
+++ b/apps/api/src/modules/sales/dto/sale.dto.ts
@@ -38,6 +38,12 @@ export class CreateSaleDto {
   @Min(0, { message: 'loyaltyPointsRedeemed ต้องเป็น 0 หรือมากกว่า' })
   loyaltyPointsRedeemed?: number;
 
+  // T5-C8 — required when product.wasPreviouslyDamaged=true. Attest that the
+  // customer was told the phone has a damage history. Sale is also restricted
+  // to OWNER / FINANCE_MANAGER in that case.
+  @IsOptional()
+  previouslyDamagedAcknowledged?: boolean;
+
   // Payment method (all sale types)
   @IsIn(['CASH', 'BANK_TRANSFER', 'QR_EWALLET'], { message: 'กรุณาระบุวิธีชำระเงิน' })
   @IsOptional()

--- a/apps/api/src/modules/sales/sales.service.spec.ts
+++ b/apps/api/src/modules/sales/sales.service.spec.ts
@@ -781,4 +781,64 @@ describe('SalesService', () => {
       ).rejects.not.toThrow(/เกินขีดจำกัด|ต่ำกว่าขั้นต่ำ|ต้องมีผู้อนุมัติ/);
     });
   });
+
+  describe('create — wasPreviouslyDamaged guard (T5-C8)', () => {
+    const cashDto = (overrides: Record<string, unknown> = {}) => ({
+      saleType: 'CASH' as const,
+      productId: 'p1',
+      sellingPrice: 20000,
+      discount: 0,
+      paymentMethod: 'CASH',
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      // Product has damage history flag set
+      prisma.product.findUnique = jest.fn().mockResolvedValue({
+        costPrice: 18000,
+        wasPreviouslyDamaged: true,
+        deletedAt: null,
+      });
+    });
+
+    it('rejects sale when acknowledgement flag missing', async () => {
+      await expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        service.create(cashDto() as any, 'owner-1', 'OWNER'),
+      ).rejects.toThrow(/previouslyDamagedAcknowledged/);
+    });
+
+    it('rejects SALES even with acknowledgement', async () => {
+      await expect(
+        service.create(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cashDto({ previouslyDamagedAcknowledged: true }) as any,
+          'sp-1',
+          'SALES',
+        ),
+      ).rejects.toThrow(/OWNER \/ FINANCE_MANAGER/);
+    });
+
+    it('rejects BRANCH_MANAGER even with acknowledgement', async () => {
+      await expect(
+        service.create(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cashDto({ previouslyDamagedAcknowledged: true }) as any,
+          'bm-1',
+          'BRANCH_MANAGER',
+        ),
+      ).rejects.toThrow(/OWNER \/ FINANCE_MANAGER/);
+    });
+
+    it('OWNER + acknowledgement passes the T5-C8 guard (fails later on unrelated stock check, not on T5-C8)', async () => {
+      await expect(
+        service.create(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cashDto({ previouslyDamagedAcknowledged: true }) as any,
+          'owner-1',
+          'OWNER',
+        ),
+      ).rejects.not.toThrow(/previouslyDamagedAcknowledged|OWNER \/ FINANCE_MANAGER/);
+    });
+  });
 });

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { PaymentMethod, PlanType, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateSaleDto } from './dto/sale.dto';
@@ -245,6 +250,31 @@ export class SalesService {
     const discount = baseDiscount + loyaltyPoints;
     const netAmount = dto.sellingPrice - discount;
 
+    // T5-C8 pre-check (before sub-methods' own verifyProductInStock which
+    // only validates stock state). We resolve wasPreviouslyDamaged upfront
+    // so we can fail fast with the right Thai error before touching the
+    // tx, and so the downstream verifyProductInStock inside the tx just
+    // needs to re-confirm in-stock — not duplicate role checks.
+    if (dto.productId) {
+      const productFlags = await this.prisma.product.findUnique({
+        where: { id: dto.productId },
+        select: { wasPreviouslyDamaged: true, deletedAt: true },
+      });
+      if (productFlags?.wasPreviouslyDamaged && !productFlags.deletedAt) {
+        if (!dto.previouslyDamagedAcknowledged) {
+          throw new BadRequestException(
+            'สินค้านี้เคยมีสถานะ DAMAGED/LOST/WRITTEN_OFF — ต้องยืนยัน previouslyDamagedAcknowledged=true และต้องได้รับอนุมัติจาก OWNER/FINANCE_MANAGER',
+          );
+        }
+        const allowedRoles = ['OWNER', 'FINANCE_MANAGER'];
+        if (!allowedRoles.includes(userRole)) {
+          throw new ForbiddenException(
+            `ขายสินค้าที่เคย DAMAGED ต้องทำโดย ${allowedRoles.join(' / ')} เท่านั้น`,
+          );
+        }
+      }
+    }
+
     // Look up product cost so the service can enforce a cost floor.
     let costPrice: number | null = null;
     if (dto.productId) {
@@ -309,11 +339,41 @@ export class SalesService {
     return sale;
   }
 
-  /** Check product availability inside transaction to prevent race conditions */
-  private async verifyProductInStock(tx: Parameters<Parameters<typeof this.prisma.$transaction>[0]>[0], productId: string) {
+  /**
+   * Check product availability inside transaction to prevent race conditions.
+   *
+   * T5-C8: products that were ever flagged DAMAGED/LOST/WRITTEN_OFF keep
+   * `wasPreviouslyDamaged=true` permanently. Selling such a phone is
+   * allowed only when the caller (a) passes `previouslyDamagedAcknowledged`
+   * in the DTO — proof that the customer was told the phone has a damage
+   * history — and (b) is OWNER/FINANCE_MANAGER. BRANCH_MANAGER/SALES can't
+   * push these through alone.
+   */
+  private async verifyProductInStock(
+    tx: Parameters<Parameters<typeof this.prisma.$transaction>[0]>[0],
+    productId: string,
+    opts?: {
+      userRole?: string;
+      acknowledged?: boolean;
+    },
+  ) {
     const product = await tx.product.findUnique({ where: { id: productId } });
     if (!product || product.deletedAt || product.status !== 'IN_STOCK') {
       throw new BadRequestException('สินค้าไม่พร้อมขาย หรือถูกขายไปแล้ว');
+    }
+    if (product.wasPreviouslyDamaged) {
+      const allowedRoles = ['OWNER', 'FINANCE_MANAGER'];
+      if (!opts?.acknowledged) {
+        throw new BadRequestException(
+          'สินค้านี้เคยมีสถานะ DAMAGED/LOST/WRITTEN_OFF — ต้องยืนยันว่าได้แจ้งลูกค้าแล้ว ' +
+            '(previouslyDamagedAcknowledged=true) และได้รับอนุมัติจาก OWNER/FINANCE_MANAGER',
+        );
+      }
+      if (opts.userRole && !allowedRoles.includes(opts.userRole)) {
+        throw new ForbiddenException(
+          `ขายสินค้าที่เคย DAMAGED ต้องทำโดย ${allowedRoles.join(' / ')} เท่านั้น`,
+        );
+      }
     }
     return product;
   }


### PR DESCRIPTION
## Summary
ปิด fraud pattern: manager flag DAMAGED → ขาย scrap → FOUND → resell retail

## Changes
- Product: +wasPreviouslyDamaged (sticky), +restoredFromTerminalAt
- Stock adjust: DAMAGED→WRITTEN_OFF FOUND ต้อง OWNER (LOST ยัง 4-eyes)
- Sales: wasPreviouslyDamaged → require acknowledgement + OWNER/FM only

## Test plan
- [x] +9 tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)