### PR TITLE
feat(audit): Merkle hash chain + nightly verify cron (T2-C4 ext)

### DIFF
--- a/apps/api/prisma/migrations/20260525100000_audit_log_merkle_chain/migration.sql
+++ b/apps/api/prisma/migrations/20260525100000_audit_log_merkle_chain/migration.sql
@@ -1,0 +1,35 @@
+-- T2-C4 ext: Merkle hash chain over AuditLog rows. Each row computes
+-- rowHash = SHA-256(sequenceNumber || id || userId || action || entity
+--                  || entityId || oldValue || newValue || createdAt
+--                  || prevRowHash)
+-- Tampering with any middle row breaks every row after it. A nightly cron
+-- walks the chain and Sentry-alerts on mismatch.
+--
+-- sequenceNumber is a dedicated bigint instead of createdAt-ordering because
+-- two inserts in the same ms would otherwise be ambiguous under ORDER BY
+-- createdAt. We use a Postgres sequence so it's monotonic + gap-free.
+
+ALTER TABLE "audit_logs"
+  ADD COLUMN "sequence_number" BIGINT,
+  ADD COLUMN "row_hash"        TEXT,
+  ADD COLUMN "prev_row_hash"   TEXT;
+
+CREATE INDEX "audit_logs_sequence_number_idx" ON "audit_logs"("sequence_number");
+
+-- Dedicated sequence (not SERIAL PK) — PK stays uuid for code compatibility.
+CREATE SEQUENCE IF NOT EXISTS "audit_logs_seq" START 1;
+
+-- Backfill existing rows: assign sequence in createdAt,id order. Hash is
+-- left NULL for historical rows — verification skips NULL hashes, so the
+-- chain is defined from the first row with a hash forward. New rows
+-- (written by AuditService after this migration) get both.
+UPDATE "audit_logs"
+SET "sequence_number" = subquery.seq
+FROM (
+  SELECT id, row_number() OVER (ORDER BY created_at ASC, id ASC) AS seq
+  FROM "audit_logs"
+) AS subquery
+WHERE "audit_logs".id = subquery.id;
+
+-- Advance the sequence to sit above backfilled rows.
+SELECT setval('audit_logs_seq', COALESCE((SELECT MAX(sequence_number) FROM "audit_logs"), 0) + 1, false);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1545,12 +1545,21 @@ model AuditLog {
   // rejects DELETE on this table regardless of path.
   archivedAt DateTime? @map("archived_at")
 
+  /// T2-C4 ext (Merkle chain): each row seals itself with a SHA-256 hash
+  /// over its own content + the previous row's rowHash. Tampering with any
+  /// row in the middle breaks every row after it. Verify via
+  /// audit.service.verifyChain() — runs as a nightly cron and on-demand.
+  sequenceNumber BigInt?  @map("sequence_number")
+  rowHash        String?  @map("row_hash") // hex-encoded SHA-256
+  prevRowHash    String?  @map("prev_row_hash")
+
   user User @relation(fields: [userId], references: [id])
 
   @@index([entity, entityId])
   @@index([userId])
   @@index([createdAt])
   @@index([archivedAt])
+  @@index([sequenceNumber])
   @@map("audit_logs")
 }
 

--- a/apps/api/src/modules/audit/audit-chain-verify.cron.ts
+++ b/apps/api/src/modules/audit/audit-chain-verify.cron.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { AuditService } from './audit.service';
+
+/**
+ * T2-C4 ext: nightly walk of the AuditLog Merkle chain. Any mismatch means
+ * someone (or some process) tampered with a row after insert. Sentry fires
+ * as `fatal` because this is an integrity incident, not a warning — it
+ * should page the on-call.
+ */
+@Injectable()
+export class AuditChainVerifyCron {
+  private readonly logger = new Logger(AuditChainVerifyCron.name);
+
+  constructor(private readonly audit: AuditService) {}
+
+  @Cron('45 3 * * *', { timeZone: 'Asia/Bangkok' })
+  async verify(): Promise<{ ok: boolean; rowsChecked: number }> {
+    try {
+      const result = await this.audit.verifyChain({ maxRows: 50_000 });
+      if (!result.ok) {
+        this.logger.error(
+          `AuditLog chain broken at seq=${result.firstMismatchSeq} id=${result.firstMismatchId}`,
+        );
+        Sentry.captureMessage(
+          `AuditLog Merkle chain mismatch — seq=${result.firstMismatchSeq} id=${result.firstMismatchId}`,
+          {
+            level: 'fatal',
+            tags: { kind: 'audit-chain', cron: 'audit-chain-verify' },
+            extra: {
+              rowsChecked: result.rowsChecked,
+              firstMismatchSeq: result.firstMismatchSeq?.toString() ?? null,
+              firstMismatchId: result.firstMismatchId,
+            },
+          },
+        );
+      } else {
+        this.logger.log(`AuditLog chain verified — ${result.rowsChecked} row(s) OK`);
+      }
+      return { ok: result.ok, rowsChecked: result.rowsChecked };
+    } catch (err) {
+      this.logger.error(`Audit chain verify failed: ${err instanceof Error ? err.message : err}`);
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'audit-chain-verify' },
+      });
+      return { ok: false, rowsChecked: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/audit/audit.controller.ts
+++ b/apps/api/src/modules/audit/audit.controller.ts
@@ -57,4 +57,20 @@ export class AuditController {
   getStats() {
     return this.auditService.getAuditStats();
   }
+
+  /**
+   * T2-C4 ext: walk the Merkle hash chain over AuditLog and return
+   * ok/first-mismatch. OWNER only — information leak potential.
+   */
+  @Get('verify-chain')
+  @Roles('OWNER')
+  async verifyChain() {
+    const result = await this.auditService.verifyChain({ maxRows: 50_000 });
+    return {
+      ok: result.ok,
+      rowsChecked: result.rowsChecked,
+      firstMismatchSeq: result.firstMismatchSeq?.toString() ?? null,
+      firstMismatchId: result.firstMismatchId,
+    };
+  }
 }

--- a/apps/api/src/modules/audit/audit.module.ts
+++ b/apps/api/src/modules/audit/audit.module.ts
@@ -2,11 +2,12 @@ import { Module, Global } from '@nestjs/common';
 import { AuditService } from './audit.service';
 import { AuditController } from './audit.controller';
 import { AuditInterceptor } from './audit.interceptor';
+import { AuditChainVerifyCron } from './audit-chain-verify.cron';
 
 @Global()
 @Module({
   controllers: [AuditController],
-  providers: [AuditService, AuditInterceptor],
+  providers: [AuditService, AuditInterceptor, AuditChainVerifyCron],
   exports: [AuditService, AuditInterceptor],
 })
 export class AuditModule {}

--- a/apps/api/src/modules/audit/audit.service.spec.ts
+++ b/apps/api/src/modules/audit/audit.service.spec.ts
@@ -1,0 +1,181 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createHash } from 'crypto';
+import { AuditService } from './audit.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('AuditService — Merkle hash chain (T2-C4 ext)', () => {
+  let service: AuditService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  // Helper to compute expected hash with same layout as service
+  const hash = (args: {
+    sequenceNumber: bigint;
+    id: string;
+    userId: string;
+    action: string;
+    entity: string;
+    entityId: string;
+    oldValue: unknown;
+    newValue: unknown;
+    createdAt: Date;
+    prevRowHash: string | null;
+  }): string => {
+    const payload = [
+      args.sequenceNumber.toString(),
+      args.id,
+      args.userId,
+      args.action,
+      args.entity,
+      args.entityId,
+      JSON.stringify(args.oldValue ?? null),
+      JSON.stringify(args.newValue ?? null),
+      args.createdAt.toISOString(),
+      args.prevRowHash ?? '',
+    ].join('|');
+    return createHash('sha256').update(payload).digest('hex');
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      auditLog: {
+        findMany: jest.fn(),
+      },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [AuditService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(AuditService);
+  });
+
+  describe('computeRowHash', () => {
+    it('produces identical output for identical input', () => {
+      const args = {
+        sequenceNumber: 1n,
+        id: 'aud-1',
+        userId: 'u-1',
+        action: 'CREATE',
+        entity: 'Contract',
+        entityId: 'c-1',
+        oldValue: null,
+        newValue: { status: 'ACTIVE' },
+        createdAt: new Date('2026-04-19T00:00:00Z'),
+        prevRowHash: null,
+      };
+      expect(service.computeRowHash(args)).toBe(service.computeRowHash(args));
+    });
+
+    it('produces different hash when any field changes', () => {
+      const base = {
+        sequenceNumber: 1n,
+        id: 'aud-1',
+        userId: 'u-1',
+        action: 'CREATE',
+        entity: 'Contract',
+        entityId: 'c-1',
+        oldValue: null,
+        newValue: { status: 'ACTIVE' },
+        createdAt: new Date('2026-04-19T00:00:00Z'),
+        prevRowHash: null,
+      };
+      const a = service.computeRowHash(base);
+      const b = service.computeRowHash({ ...base, action: 'UPDATE' });
+      expect(a).not.toBe(b);
+    });
+
+    it('prevRowHash propagates — changing prev changes current', () => {
+      const base = {
+        sequenceNumber: 2n,
+        id: 'aud-2',
+        userId: 'u-1',
+        action: 'CREATE',
+        entity: 'Contract',
+        entityId: 'c-1',
+        oldValue: null,
+        newValue: {},
+        createdAt: new Date(),
+        prevRowHash: 'aaa',
+      };
+      const a = service.computeRowHash(base);
+      const b = service.computeRowHash({ ...base, prevRowHash: 'bbb' });
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('verifyChain', () => {
+    const buildRow = (
+      seq: bigint,
+      prevHash: string | null,
+      overrides: Record<string, unknown> = {},
+    ) => {
+      const base = {
+        id: `aud-${seq}`,
+        userId: 'u-1',
+        action: 'CREATE',
+        entity: 'Contract',
+        entityId: `c-${seq}`,
+        oldValue: null,
+        newValue: { status: 'ACTIVE' },
+        createdAt: new Date(`2026-04-${String(seq + 10n).padStart(2, '0')}T00:00:00Z`),
+        sequenceNumber: seq,
+        prevRowHash: prevHash,
+        ...overrides,
+      };
+      const rowHash = hash({
+        sequenceNumber: base.sequenceNumber,
+        id: base.id,
+        userId: base.userId,
+        action: base.action,
+        entity: base.entity,
+        entityId: base.entityId,
+        oldValue: base.oldValue,
+        newValue: base.newValue,
+        createdAt: base.createdAt,
+        prevRowHash: base.prevRowHash,
+      });
+      return { ...base, rowHash };
+    };
+
+    it('returns ok=true for an intact chain of 3 rows', async () => {
+      const row1 = buildRow(1n, null);
+      const row2 = buildRow(2n, row1.rowHash);
+      const row3 = buildRow(3n, row2.rowHash);
+      prisma.auditLog.findMany.mockResolvedValue([row1, row2, row3]);
+
+      const result = await service.verifyChain();
+      expect(result.ok).toBe(true);
+      expect(result.rowsChecked).toBe(3);
+    });
+
+    it('detects tampered row — action changed after write', async () => {
+      const row1 = buildRow(1n, null);
+      const row2 = buildRow(2n, row1.rowHash);
+      const row3 = buildRow(3n, row2.rowHash);
+      // Attacker edits action on row2 without updating hash
+      const tampered = { ...row2, action: 'DELETE' };
+      prisma.auditLog.findMany.mockResolvedValue([row1, tampered, row3]);
+
+      const result = await service.verifyChain();
+      expect(result.ok).toBe(false);
+      expect(result.firstMismatchSeq).toBe(2n);
+    });
+
+    it('detects broken prev linkage', async () => {
+      const row1 = buildRow(1n, null);
+      const row2 = buildRow(2n, row1.rowHash);
+      const row3 = buildRow(3n, 'fake-hash'); // should be row2.rowHash
+      prisma.auditLog.findMany.mockResolvedValue([row1, row2, row3]);
+
+      const result = await service.verifyChain();
+      expect(result.ok).toBe(false);
+      expect(result.firstMismatchSeq).toBe(3n);
+    });
+
+    it('returns ok=true for empty chain', async () => {
+      prisma.auditLog.findMany.mockResolvedValue([]);
+      const result = await service.verifyChain();
+      expect(result.ok).toBe(true);
+      expect(result.rowsChecked).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/modules/audit/audit.service.ts
+++ b/apps/api/src/modules/audit/audit.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { createHash, randomUUID } from 'crypto';
 import { PrismaService } from '../../prisma/prisma.service';
 
 export interface AuditEntry {
@@ -20,26 +21,172 @@ export class AuditService {
 
   constructor(private prisma: PrismaService) {}
 
+  /**
+   * Canonical hash input string used to seal a row into the chain.
+   * Order matters — never reorder, never drop fields, or backfill breaks.
+   */
+  private buildHashPayload(args: {
+    sequenceNumber: bigint;
+    id: string;
+    userId: string;
+    action: string;
+    entity: string;
+    entityId: string;
+    oldValue: unknown;
+    newValue: unknown;
+    createdAt: Date;
+    prevRowHash: string | null;
+  }): string {
+    return [
+      args.sequenceNumber.toString(),
+      args.id,
+      args.userId,
+      args.action,
+      args.entity,
+      args.entityId,
+      JSON.stringify(args.oldValue ?? null),
+      JSON.stringify(args.newValue ?? null),
+      args.createdAt.toISOString(),
+      args.prevRowHash ?? '',
+    ].join('|');
+  }
+
+  computeRowHash(args: Parameters<AuditService['buildHashPayload']>[0]): string {
+    return createHash('sha256').update(this.buildHashPayload(args)).digest('hex');
+  }
+
   async log(entry: AuditEntry) {
     try {
       if (!entry.userId) return;
 
-      await this.prisma.auditLog.create({
-        data: {
-          userId: entry.userId,
+      // T2-C4 ext: hash chain. $transaction keeps nextval() + read-last-hash
+      // + insert atomic so two concurrent writers can't race to the same
+      // prevRowHash value.
+      await this.prisma.$transaction(async (tx) => {
+        const seqRow = await tx.$queryRaw<Array<{ nextval: bigint }>>`
+          SELECT nextval('audit_logs_seq') AS nextval
+        `;
+        const sequenceNumber = seqRow[0].nextval;
+
+        const prevRow = sequenceNumber > BigInt(1)
+          ? await tx.auditLog.findFirst({
+              where: { sequenceNumber: sequenceNumber - BigInt(1) },
+              select: { rowHash: true },
+            })
+          : null;
+
+        const id = randomUUID();
+        const createdAt = new Date();
+        const oldValue = (entry.oldValue as Prisma.InputJsonValue) ?? Prisma.JsonNull;
+        const newValue = (entry.newValue as Prisma.InputJsonValue) ?? Prisma.JsonNull;
+
+        const rowHash = this.computeRowHash({
+          sequenceNumber,
+          id,
+          userId: entry.userId!,
           action: entry.action,
           entity: entry.entity,
           entityId: entry.entityId || '',
-          oldValue: (entry.oldValue as Prisma.InputJsonValue) ?? Prisma.JsonNull,
-          newValue: (entry.newValue as Prisma.InputJsonValue) ?? Prisma.JsonNull,
-          ipAddress: entry.ipAddress || null,
-          userAgent: entry.userAgent || null,
-          duration: entry.duration || null,
-        },
+          oldValue: entry.oldValue ?? null,
+          newValue: entry.newValue ?? null,
+          createdAt,
+          prevRowHash: prevRow?.rowHash ?? null,
+        });
+
+        await tx.auditLog.create({
+          data: {
+            id,
+            userId: entry.userId!,
+            action: entry.action,
+            entity: entry.entity,
+            entityId: entry.entityId || '',
+            oldValue,
+            newValue,
+            ipAddress: entry.ipAddress || null,
+            userAgent: entry.userAgent || null,
+            duration: entry.duration || null,
+            createdAt,
+            sequenceNumber,
+            rowHash,
+            prevRowHash: prevRow?.rowHash ?? null,
+          },
+        });
       });
     } catch (err) {
       this.logger.error('Failed to write audit log', err);
     }
+  }
+
+  /**
+   * Walk the Merkle chain and return the first sequenceNumber where the
+   * recomputed hash doesn't match the stored hash (or prev linkage breaks).
+   * Null = chain intact through all rows with non-null hashes.
+   *
+   * Historical rows where rowHash IS NULL (backfill before this migration)
+   * are skipped — the chain is defined only for post-migration rows.
+   */
+  async verifyChain(options: { maxRows?: number } = {}): Promise<{
+    ok: boolean;
+    rowsChecked: number;
+    firstMismatchSeq: bigint | null;
+    firstMismatchId: string | null;
+  }> {
+    const take = options.maxRows ?? 10_000;
+    const rows = await this.prisma.auditLog.findMany({
+      where: { rowHash: { not: null }, sequenceNumber: { not: null } },
+      orderBy: { sequenceNumber: 'asc' },
+      select: {
+        id: true,
+        userId: true,
+        action: true,
+        entity: true,
+        entityId: true,
+        oldValue: true,
+        newValue: true,
+        createdAt: true,
+        sequenceNumber: true,
+        rowHash: true,
+        prevRowHash: true,
+      },
+      take,
+    });
+
+    let lastHash: string | null = null;
+    for (const r of rows) {
+      if (r.sequenceNumber === null || r.rowHash === null) continue;
+      // prev linkage check
+      if ((r.prevRowHash ?? null) !== lastHash && lastHash !== null) {
+        return {
+          ok: false,
+          rowsChecked: rows.indexOf(r),
+          firstMismatchSeq: r.sequenceNumber,
+          firstMismatchId: r.id,
+        };
+      }
+      const expected = this.computeRowHash({
+        sequenceNumber: r.sequenceNumber,
+        id: r.id,
+        userId: r.userId,
+        action: r.action,
+        entity: r.entity,
+        entityId: r.entityId,
+        oldValue: r.oldValue as unknown,
+        newValue: r.newValue as unknown,
+        createdAt: r.createdAt,
+        prevRowHash: r.prevRowHash ?? null,
+      });
+      if (expected !== r.rowHash) {
+        return {
+          ok: false,
+          rowsChecked: rows.indexOf(r),
+          firstMismatchSeq: r.sequenceNumber,
+          firstMismatchId: r.id,
+        };
+      }
+      lastHash = r.rowHash;
+    }
+
+    return { ok: true, rowsChecked: rows.length, firstMismatchSeq: null, firstMismatchId: null };
   }
 
   async getAuditLogs(filters: {


### PR DESCRIPTION
## Summary
AuditLog ปัจจุบันป้องกัน DELETE ผ่าน Postgres trigger แล้ว แต่ UPDATE ตรง DB ยังทำได้ → attacker ที่มี DB access แก้ row เก่าได้โดยไม่ทิ้งร่องรอย

Merkle chain: SHA-256(content|prevRowHash) — แก้ row ใดก็พัง hash ของทุก row ต่อ ๆ มา

## Changes
- Schema: sequenceNumber + rowHash + prevRowHash (+ audit_logs_seq SEQUENCE)
- Service: log() atomic seal, verifyChain() walk & compare
- GET /audit/verify-chain (OWNER)
- Nightly cron 03:45 → mismatch → Sentry fatal

## Test plan
- [x] +7 tests (computeRowHash + verifyChain)
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)