### PR TITLE
feat(mdm): required reason + audit log บน unlock/lock (T6-C6)

### DIFF
--- a/apps/api/src/modules/mdm/dto/mdm.dto.ts
+++ b/apps/api/src/modules/mdm/dto/mdm.dto.ts
@@ -37,6 +37,14 @@ export class UnlockDeviceDto {
   @MaxLength(20, { message: 'หมายเลข IMEI ต้องไม่เกิน 20 ตัวอักษร' })
   imei: string;
 
+  /// T6-C6: reason required — prevents "quiet unlock" kickback. Callers
+  /// must describe why the phone is being released (paid in full, settlement
+  /// agreement, legal dispute, etc.)
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุเหตุผลในการปลดล็อค' })
+  @MaxLength(500, { message: 'เหตุผลต้องไม่เกิน 500 ตัวอักษร' })
+  reason!: string;
+
   @IsString()
   @IsOptional()
   @MaxLength(255)

--- a/apps/api/src/modules/mdm/mdm.controller.ts
+++ b/apps/api/src/modules/mdm/mdm.controller.ts
@@ -22,12 +22,17 @@ import {
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { AuditService } from '../audit/audit.service';
 
 @Controller('mdm')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
 export class MdmController {
-  constructor(private mdmService: MdmService) {}
+  constructor(
+    private mdmService: MdmService,
+    private audit: AuditService,
+  ) {}
 
   // ─── Status & Config ────────────────────────────────────
 
@@ -121,14 +126,36 @@ export class MdmController {
 
   @Post('lock')
   @Roles('OWNER', 'FINANCE_MANAGER')
-  lockDevice(@Body() dto: LockDeviceDto) {
-    return this.mdmService.lockDeviceByImei(dto.imei, dto.reason);
+  async lockDevice(
+    @Body() dto: LockDeviceDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    const result = await this.mdmService.lockDeviceByImei(dto.imei, dto.reason);
+    await this.audit.log({
+      userId: user.id,
+      action: 'MDM_LOCK',
+      entity: 'MDM',
+      entityId: dto.imei,
+      newValue: { imei: dto.imei, reason: dto.reason },
+    });
+    return result;
   }
 
   @Post('unlock')
   @Roles('OWNER', 'FINANCE_MANAGER')
-  unlockDevice(@Body() dto: UnlockDeviceDto) {
-    return this.mdmService.unlockDeviceByImei(dto.imei);
+  async unlockDevice(
+    @Body() dto: UnlockDeviceDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    const result = await this.mdmService.unlockDeviceByImei(dto.imei);
+    await this.audit.log({
+      userId: user.id,
+      action: 'MDM_UNLOCK',
+      entity: 'MDM',
+      entityId: dto.imei,
+      newValue: { imei: dto.imei, reason: dto.reason, note: dto.note ?? null },
+    });
+    return result;
   }
 
   // ─── Policies ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
MDM unlock ไม่มี required reason + ไม่มี AuditLog → "quiet unlock" kickback pattern

## Changes
- UnlockDeviceDto: `reason` required (เดิม optional note เท่านั้น)
- MdmController: lock/unlock → AuditService.log() พร้อม imei + reason
- AuditLog ผ่าน Merkle chain (PR #562) → tamper-evident

## Test plan
- [x] TS check passes
- [ ] MDM module ไม่มี spec เดิม — follow-up test coverage PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)