### PR TITLE
ci: activate SMS kill-switch env (follow-up #558)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -256,7 +256,8 @@ jobs:
           PAYSOLUTIONS_TERMINAL_ID=TID00001,\
           GCS_BUCKET=bestchoice-documents,\
           API_BASE_URL=https://api.bestchoicephone.app,\
-          LIFF_CHANNEL_ID=2009442540" \
+          LIFF_CHANNEL_ID=2009442540,\
+          SMS_PAYMENT_REMINDER_DISABLED=true" \
             --set-cloudsql-instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME }} \
             --allow-unauthenticated
 


### PR DESCRIPTION
## Summary
PR #558 squash merge commit มี diff ว่างเปล่า เพราะ kill-switch code เข้า main แล้วผ่าน squash ของ PR #559 (carry-over) — workflow env change เป็น follow-up ที่ไม่ได้ landed

**Fix:** เพิ่ม `SMS_PAYMENT_REMINDER_DISABLED=true` ใน `--set-env-vars` ของ Deploy step → deploy ครั้งถัดไป env จะ set ใน prod Cloud Run

**Active ทันที:** kill-switch util (`sms-payment-reminder.util.ts`) อ่าน env var นี้ → block:
- Payment reminder SMS (T-5/T-3/T-1/T)
- Overdue notice SMS (T+1/T+3)
- Dunning escalation SMS fallback

ยังทำงานปกติ: LINE push, OTP/KYC SMS, contract activation SMS, broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)