### PR TITLE
feat(metrics): Prometheus /metrics endpoint + SLO runbook (T7-C12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -53,6 +53,7 @@
     "nodemailer": "^8.0.5",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "prom-client": "^15.1.3",
     "puppeteer": "^24.40.0",
     "puppeteer-core": "^24.39.1",
     "qrcode": "^1.5.4",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -33,6 +33,7 @@ import { WebhookSecurityModule } from './modules/webhook-security/webhook-securi
 import { AiUsageModule } from './modules/ai-usage/ai-usage.module';
 import { RefundsModule } from './modules/refunds/refunds.module';
 import { ReceivableReconModule } from './modules/receivable-recon/receivable-recon.module';
+import { MetricsModule } from './modules/metrics/metrics.module';
 import { UsersModule } from './modules/users/users.module';
 import { SettingsModule } from './modules/settings/settings.module';
 import { InventoryModule } from './modules/inventory/inventory.module';
@@ -146,6 +147,7 @@ import { AppCacheModule } from './cache/cache.module';
     AiUsageModule,
     RefundsModule,
     ReceivableReconModule,
+    MetricsModule,
     // Legal Compliance & PDPA
     PDPAModule,
     KycModule,

--- a/apps/api/src/modules/metrics/metrics.controller.ts
+++ b/apps/api/src/modules/metrics/metrics.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Header, Headers, HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SkipThrottle } from '@nestjs/throttler';
+import { Public } from '../auth/decorators/public.decorator';
+import { MetricsService } from './metrics.service';
+
+/**
+ * /metrics — Prometheus scrape endpoint (T7-C12).
+ *
+ * Public (Prometheus scrapers don't send JWT) but gated by a shared-secret
+ * header `X-Metrics-Token` matching `METRICS_SCRAPE_TOKEN` env. Without the
+ * env set, endpoint returns 503 — prevents accidental exposure if the
+ * scrape token isn't configured.
+ *
+ * Rate-limited via SkipThrottle so Prometheus's every-15s scrape doesn't
+ * trip the global throttler.
+ */
+@Controller('metrics')
+@SkipThrottle()
+export class MetricsController {
+  constructor(
+    private readonly metrics: MetricsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Public()
+  @Get()
+  @Header('Content-Type', 'text/plain; version=0.0.4')
+  async scrape(@Headers('x-metrics-token') token?: string): Promise<string> {
+    const expected = this.config.get<string>('METRICS_SCRAPE_TOKEN');
+    if (!expected) {
+      throw new HttpException(
+        'metrics scrape not configured',
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
+    if (!token || token !== expected) {
+      throw new HttpException('forbidden', HttpStatus.FORBIDDEN);
+    }
+    return this.metrics.collect();
+  }
+}

--- a/apps/api/src/modules/metrics/metrics.module.ts
+++ b/apps/api/src/modules/metrics/metrics.module.ts
@@ -1,0 +1,15 @@
+import { Global, Module } from '@nestjs/common';
+import { MetricsService } from './metrics.service';
+import { MetricsController } from './metrics.controller';
+
+/**
+ * Global so any service that wants to increment a counter can inject
+ * MetricsService without a module import chain.
+ */
+@Global()
+@Module({
+  controllers: [MetricsController],
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
+export class MetricsModule {}

--- a/apps/api/src/modules/metrics/metrics.service.spec.ts
+++ b/apps/api/src/modules/metrics/metrics.service.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MetricsService } from './metrics.service';
+
+describe('MetricsService', () => {
+  let service: MetricsService;
+
+  beforeEach(async () => {
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [MetricsService],
+    }).compile();
+    service = mod.get(MetricsService);
+  });
+
+  it('exposes a prometheus registry with default metrics', async () => {
+    const output = await service.collect();
+    expect(output).toContain('process_cpu_user_seconds_total');
+    expect(output).toContain('nodejs_heap_size_used_bytes');
+  });
+
+  it('exposes custom BESTCHOICE counters', async () => {
+    service.paymentsRecorded.inc({ method: 'CASH', status: 'success' });
+    service.refundsRequested.inc({ status: 'REQUESTED' });
+    service.slipAutoApproved.inc();
+    const output = await service.collect();
+    expect(output).toContain('payments_recorded_total');
+    expect(output).toContain('refunds_requested_total');
+    expect(output).toContain('slip_auto_approved_total');
+  });
+
+  it('sets the app default label', async () => {
+    const output = await service.collect();
+    expect(output).toContain('app="bestchoice-api"');
+  });
+
+  it('http_request_duration_seconds uses histogram buckets 0.05..10', async () => {
+    service.httpDuration.observe({ method: 'GET', route: '/api/health', status_code: '200' }, 0.02);
+    const output = await service.collect();
+    expect(output).toContain('http_request_duration_seconds_bucket');
+    expect(output).toContain('le="0.05"');
+    expect(output).toContain('le="10"');
+  });
+});

--- a/apps/api/src/modules/metrics/metrics.service.ts
+++ b/apps/api/src/modules/metrics/metrics.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Counter, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+
+/**
+ * Prometheus metrics registry (T7-C12).
+ *
+ * Exposes:
+ *   - Node defaults (event loop lag, memory, GC, etc.)
+ *   - HTTP request duration histogram
+ *   - Business counters: payments recorded, refunds requested,
+ *     slip auto-approved, dunning escalated, AI calls
+ *
+ * Instrumented sparingly — new counters should have a named SLO attached or
+ * they become noise. See docs/guides/SLO-RUNBOOK.md for the target SLOs.
+ */
+@Injectable()
+export class MetricsService {
+  private readonly logger = new Logger(MetricsService.name);
+  readonly registry: Registry;
+
+  readonly httpDuration: Histogram<string>;
+  readonly paymentsRecorded: Counter<string>;
+  readonly refundsRequested: Counter<string>;
+  readonly slipAutoApproved: Counter<string>;
+  readonly dunningEscalated: Counter<string>;
+  readonly aiCalls: Counter<string>;
+  readonly webhookAnomalies: Counter<string>;
+
+  constructor() {
+    this.registry = new Registry();
+    this.registry.setDefaultLabels({ app: 'bestchoice-api' });
+    collectDefaultMetrics({ register: this.registry });
+
+    this.httpDuration = new Histogram({
+      name: 'http_request_duration_seconds',
+      help: 'HTTP request latency in seconds',
+      labelNames: ['method', 'route', 'status_code'],
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+      registers: [this.registry],
+    });
+
+    this.paymentsRecorded = new Counter({
+      name: 'payments_recorded_total',
+      help: 'Count of payments recorded (successful and idempotent re-records)',
+      labelNames: ['method', 'status'],
+      registers: [this.registry],
+    });
+
+    this.refundsRequested = new Counter({
+      name: 'refunds_requested_total',
+      help: 'Count of refund requests created',
+      labelNames: ['status'],
+      registers: [this.registry],
+    });
+
+    this.slipAutoApproved = new Counter({
+      name: 'slip_auto_approved_total',
+      help: 'Slip evidences auto-approved based on OCR confidence (T4-C9)',
+      registers: [this.registry],
+    });
+
+    this.dunningEscalated = new Counter({
+      name: 'dunning_escalated_total',
+      help: 'Dunning stage escalations',
+      labelNames: ['stage', 'source'], // source: 'auto' | 'manual_approval'
+      registers: [this.registry],
+    });
+
+    this.aiCalls = new Counter({
+      name: 'ai_calls_total',
+      help: 'Claude API calls by service',
+      labelNames: ['service', 'status'],
+      registers: [this.registry],
+    });
+
+    this.webhookAnomalies = new Counter({
+      name: 'webhook_anomalies_total',
+      help: 'Webhook signature anomalies captured by WebhookAnomalyService',
+      labelNames: ['provider', 'reason'],
+      registers: [this.registry],
+    });
+  }
+
+  async collect(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/docs/guides/SLO-RUNBOOK.md
+++ b/docs/guides/SLO-RUNBOOK.md
@@ -1,0 +1,161 @@
+# SLO Runbook (T7-C12)
+
+## Overview
+BESTCHOICE เปิด `/api/metrics` endpoint สำหรับ Prometheus scrape. Setup guide + target SLOs ด้านล่าง.
+
+## Endpoint
+
+```
+GET https://api.bestchoicephone.app/api/metrics
+Headers:
+  X-Metrics-Token: $METRICS_SCRAPE_TOKEN
+```
+
+- **Env required**: `METRICS_SCRAPE_TOKEN` (long random string, stored in Secret Manager)
+- Without env → 503 (fails closed)
+- Wrong token → 403
+- SkipThrottle (Prometheus scrape every 15s doesn't trip global rate limit)
+
+## Target SLOs
+
+### Availability
+| SLI | Target | Measurement |
+|-----|--------|-------------|
+| **API success rate** | 99.5% | 2xx+3xx / total, 7-day rolling |
+| **Health endpoint uptime** | 99.9% | `/api/health` 2xx, 30-day rolling |
+| **Deploy success rate** | 95% | GitHub Actions Deploy workflow conclusion, 30-day |
+
+### Latency
+| SLI | Target | Measurement |
+|-----|--------|-------------|
+| **p95 HTTP latency** | < 500ms | `http_request_duration_seconds` p95 per route |
+| **p99 HTTP latency** | < 2s | same, p99 |
+| **DB query p95** | < 200ms | (future — requires Prisma telemetry) |
+
+### Business correctness
+| SLI | Target | Measurement |
+|-----|--------|-------------|
+| **Payment recording success** | 99% | `payments_recorded_total{status="success"}` / total |
+| **Refund approval lag** | p95 < 24h | (future — compute from AuditLog timestamps) |
+| **Slip SLA (T4-C9)** | < 10 breaches/day | `data_audit_sla` cron output |
+| **Receivable recon breach** | < 1 branch/day | `receivable_recon_logs` where breached=true |
+
+## Counters exposed
+
+Current (as of this commit):
+
+| Metric | Labels | Purpose |
+|--------|--------|---------|
+| `http_request_duration_seconds` | method, route, status_code | Latency histogram |
+| `payments_recorded_total` | method, status | Payment ingestion success |
+| `refunds_requested_total` | status | Refund funnel |
+| `slip_auto_approved_total` | — | Auto-approve coverage |
+| `dunning_escalated_total` | stage, source | Collections pipeline |
+| `ai_calls_total` | service, status | AI cost/volume tracking |
+| `webhook_anomalies_total` | provider, reason | Security signal |
+
+Plus Node defaults (event loop lag, memory, GC).
+
+## Setup — Prometheus scraping
+
+### Cloud Monitoring (simplest)
+GCP Cloud Monitoring supports Prometheus-format scraping via "Managed Prometheus":
+
+1. Enable Managed Service for Prometheus on the GKE/GCE cluster (or use cloudrun+sidecar pattern)
+2. Add scrape config:
+   ```yaml
+   scrape_configs:
+     - job_name: bestchoice-api
+       scrape_interval: 30s
+       metrics_path: /api/metrics
+       scheme: https
+       static_configs:
+         - targets: ['api.bestchoicephone.app:443']
+       bearer_token_file: /var/run/secrets/metrics-token
+   ```
+
+### Self-hosted Prometheus + Grafana
+1. Deploy Prometheus container to a small VM (e1-micro works)
+2. Same scrape config as above
+3. Connect Grafana → Prometheus data source
+4. Import dashboard (see next section)
+
+## Grafana dashboard (initial)
+
+Panels to create:
+1. **Request rate** — `sum(rate(http_request_duration_seconds_count[5m])) by (route)`
+2. **Error rate %** — `sum(rate(http_request_duration_seconds_count{status_code=~"5.."}[5m])) / sum(rate(http_request_duration_seconds_count[5m])) * 100`
+3. **p95/p99 latency** — `histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route))`
+4. **Payments recorded/hr** — `sum(rate(payments_recorded_total[1h])) * 3600`
+5. **Refund funnel** — stacked by `status` label
+6. **Webhook anomalies** — table grouped by `provider, reason`
+7. **AI spend proxy** — `ai_calls_total` × known cost per call
+8. **Event loop lag** — `nodejs_eventloop_lag_seconds` (alert if >100ms)
+
+Save JSON to `docs/grafana/bestchoice-slo.json` once finalized.
+
+## Alerting rules
+
+```yaml
+groups:
+  - name: bestchoice-api
+    rules:
+      - alert: HighErrorRate
+        expr: sum(rate(http_request_duration_seconds_count{status_code=~"5.."}[5m])) / sum(rate(http_request_duration_seconds_count[5m])) > 0.01
+        for: 5m
+        annotations:
+          summary: "API error rate > 1% for 5 min"
+
+      - alert: SlowP95
+        expr: histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 0.5
+        for: 10m
+        annotations:
+          summary: "API p95 latency > 500ms for 10 min"
+
+      - alert: EventLoopStalled
+        expr: nodejs_eventloop_lag_seconds > 0.1
+        for: 2m
+        annotations:
+          summary: "Node event loop lag > 100ms"
+
+      - alert: WebhookAnomalySpike
+        expr: increase(webhook_anomalies_total[1h]) > 10
+        annotations:
+          summary: "Webhook anomalies > 10 in last hour — see WebhookAnomalyCron"
+```
+
+## Instrumentation guidelines
+
+### ✅ Good metric additions
+- Business events with a clear SLO target (waiver per hour, slip SLA)
+- Error categories that would page the on-call
+- Cost-driving signals (AI token count, SMS sends)
+
+### ❌ Bad metric additions
+- Debugging counters with no threshold
+- High-cardinality labels (userId, contractId — will explode storage)
+- Anything already captured in AuditLog (duplication)
+
+New counter additions: always attach an SLO/alert rule, or skip.
+
+## Cost estimate
+
+- Self-hosted Prometheus on `e1-micro`: ~฿100/month
+- Grafana Cloud free tier: 10k series, 50GB logs, 3 users — free
+- Managed Prometheus on GCP: $0.25/million samples ingested → BESTCHOICE @ 50 series × 15s → ~$1-2/mo
+
+## Rollback
+
+ถ้า `/metrics` ทำงานผิดปกติ:
+1. Set `METRICS_SCRAPE_TOKEN=` (empty) → endpoint returns 503 ไม่ครรลูก
+2. ลบ `MetricsModule` จาก `app.module.ts` → endpoint หายไป
+3. Deploy
+
+Prometheus scraper จะ timeout → alert ที่ Grafana แต่ api ยังทำงานปกติ
+
+## Emergency contacts
+| Role | Contact |
+|------|---------|
+| GCP owner | เจ้าของ (พี่นาย) |
+| Prometheus docs | https://prometheus.io/docs/ |
+| prom-client docs | https://github.com/siimon/prom-client |

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "nodemailer": "^8.0.5",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
+        "prom-client": "^15.1.3",
         "puppeteer": "^24.40.0",
         "puppeteer-core": "^24.39.1",
         "qrcode": "^1.5.4",
@@ -12588,6 +12589,12 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -20615,6 +20622,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -23046,6 +23066,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/teeny-request": {


### PR DESCRIPTION
## Summary
เปิด Prometheus scrape endpoint + SLO runbook สำหรับ observability

## Changes
- npm install prom-client
- MetricsService global + MetricsController `/api/metrics` token-gated
- Node defaults + 6 business counters
- docs/guides/SLO-RUNBOOK.md — targets, alerts, Grafana panels, cost

## Test plan
- [x] +4 metrics tests
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)