### PR TITLE
test(staff-chat): +22 Snooze + CollisionDetection tests (T4-C3 batch 1)

### DIFF
--- a/apps/api/src/modules/staff-chat/services/collision-detection.service.spec.ts
+++ b/apps/api/src/modules/staff-chat/services/collision-detection.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CollisionDetectionService } from './collision-detection.service';
+
+describe('CollisionDetectionService', () => {
+  let service: CollisionDetectionService;
+
+  beforeEach(async () => {
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [CollisionDetectionService],
+    }).compile();
+    service = mod.get(CollisionDetectionService);
+  });
+
+  describe('addViewer / getViewers', () => {
+    it('tracks a single viewer with name + since timestamp', () => {
+      service.addViewer('s-1', 'u-1', 'Staff A');
+      const viewers = service.getViewers('s-1');
+      expect(viewers).toHaveLength(1);
+      expect(viewers[0]).toMatchObject({ userId: 'u-1', userName: 'Staff A' });
+      expect(viewers[0].since).toBeInstanceOf(Date);
+    });
+
+    it('returns empty array for unknown session', () => {
+      expect(service.getViewers('nowhere')).toEqual([]);
+    });
+
+    it('tracks multiple viewers on same session', () => {
+      service.addViewer('s-1', 'u-1', 'Staff A');
+      service.addViewer('s-1', 'u-2', 'Staff B');
+      expect(service.getViewers('s-1')).toHaveLength(2);
+    });
+
+    it('idempotent — re-adding same user does not duplicate or refresh since', async () => {
+      service.addViewer('s-1', 'u-1', 'Staff A');
+      const first = service.getViewers('s-1')[0].since;
+      await new Promise((r) => setTimeout(r, 10));
+      service.addViewer('s-1', 'u-1', 'Staff A (rename ignored)');
+      const second = service.getViewers('s-1')[0];
+      expect(second.since).toEqual(first);
+      expect(service.getViewers('s-1')).toHaveLength(1);
+    });
+  });
+
+  describe('removeViewer', () => {
+    it('removes a single viewer', () => {
+      service.addViewer('s-1', 'u-1', 'A');
+      service.addViewer('s-1', 'u-2', 'B');
+      service.removeViewer('s-1', 'u-1');
+      expect(service.getViewers('s-1').map((v) => v.userId)).toEqual(['u-2']);
+    });
+
+    it('cleans up empty session map', () => {
+      service.addViewer('s-1', 'u-1', 'A');
+      service.removeViewer('s-1', 'u-1');
+      expect(service.getViewers('s-1')).toEqual([]);
+    });
+
+    it('is a no-op for unknown session', () => {
+      expect(() => service.removeViewer('nowhere', 'u-1')).not.toThrow();
+    });
+  });
+
+  describe('removeViewerFromAll', () => {
+    it('removes user from every session', () => {
+      service.addViewer('s-1', 'u-1', 'A');
+      service.addViewer('s-2', 'u-1', 'A');
+      service.addViewer('s-2', 'u-2', 'B');
+      service.removeViewerFromAll('u-1');
+      expect(service.getViewers('s-1')).toEqual([]);
+      expect(service.getViewers('s-2').map((v) => v.userId)).toEqual(['u-2']);
+    });
+  });
+
+  describe('isCollision', () => {
+    it('false when no one is viewing', () => {
+      expect(service.isCollision('s-1', 'u-1')).toBe(false);
+    });
+
+    it('false when only the excluded user is viewing', () => {
+      service.addViewer('s-1', 'u-1', 'A');
+      expect(service.isCollision('s-1', 'u-1')).toBe(false);
+    });
+
+    it('true when another user is viewing', () => {
+      service.addViewer('s-1', 'u-1', 'A');
+      service.addViewer('s-1', 'u-2', 'B');
+      expect(service.isCollision('s-1', 'u-1')).toBe(true);
+    });
+
+    it('true when OTHER is viewing but excludedUser is not in session', () => {
+      service.addViewer('s-1', 'u-2', 'B');
+      expect(service.isCollision('s-1', 'u-1')).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/staff-chat/services/snooze.service.spec.ts
+++ b/apps/api/src/modules/staff-chat/services/snooze.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { SnoozeService } from './snooze.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+describe('SnoozeService', () => {
+  let service: SnoozeService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      chatRoom: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'room-1', deletedAt: null }),
+      },
+      chatSnooze: {
+        create: jest.fn((args) => Promise.resolve({ id: 'snooze-1', ...args.data })),
+        findUnique: jest.fn(),
+        update: jest.fn().mockResolvedValue({}),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [SnoozeService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(SnoozeService);
+  });
+
+  describe('createSnooze', () => {
+    it('creates snooze when room exists', async () => {
+      const remindAt = new Date(Date.now() + 2 * 60 * 60 * 1000);
+      await service.createSnooze('room-1', 'u-1', remindAt, 'follow up');
+      const args = prisma.chatSnooze.create.mock.calls[0][0];
+      expect(args.data.roomId).toBe('room-1');
+      expect(args.data.staffId).toBe('u-1');
+      expect(args.data.remindAt).toBe(remindAt);
+      expect(args.data.note).toBe('follow up');
+    });
+
+    it('throws NotFound when room missing', async () => {
+      prisma.chatRoom.findFirst.mockResolvedValue(null);
+      await expect(
+        service.createSnooze('missing', 'u-1', new Date()),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFound when room soft-deleted (deletedAt filter)', async () => {
+      // findFirst with deletedAt: null returns null when soft-deleted
+      prisma.chatRoom.findFirst.mockResolvedValue(null);
+      await expect(
+        service.createSnooze('deleted-room', 'u-1', new Date()),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('stores null note when undefined', async () => {
+      await service.createSnooze('room-1', 'u-1', new Date());
+      expect(prisma.chatSnooze.create.mock.calls[0][0].data.note).toBeNull();
+    });
+  });
+
+  describe('cancelSnooze', () => {
+    it('marks completed=true when found', async () => {
+      prisma.chatSnooze.findUnique.mockResolvedValue({ id: 'snooze-1' });
+      await service.cancelSnooze('snooze-1');
+      expect(prisma.chatSnooze.update).toHaveBeenCalledWith({
+        where: { id: 'snooze-1' },
+        data: { completed: true },
+      });
+    });
+
+    it('throws NotFound when snooze missing', async () => {
+      prisma.chatSnooze.findUnique.mockResolvedValue(null);
+      await expect(service.cancelSnooze('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getActiveSnoozes', () => {
+    it('filters by staffId + completed=false', async () => {
+      await service.getActiveSnoozes('u-1');
+      const where = prisma.chatSnooze.findMany.mock.calls[0][0].where;
+      expect(where.staffId).toBe('u-1');
+      expect(where.completed).toBe(false);
+    });
+
+    it('orders by remindAt asc (next-due first)', async () => {
+      await service.getActiveSnoozes('u-1');
+      expect(prisma.chatSnooze.findMany.mock.calls[0][0].orderBy).toEqual({
+        remindAt: 'asc',
+      });
+    });
+  });
+
+  describe('getRoomSnoozes', () => {
+    it('filters by roomId + includes staff name', async () => {
+      await service.getRoomSnoozes('room-1');
+      const args = prisma.chatSnooze.findMany.mock.calls[0][0];
+      expect(args.where.roomId).toBe('room-1');
+      expect(args.include.staff.select).toEqual({ id: true, name: true });
+    });
+
+    it('orders by createdAt desc (most recent first)', async () => {
+      await service.getRoomSnoozes('room-1');
+      expect(prisma.chatSnooze.findMany.mock.calls[0][0].orderBy).toEqual({
+        createdAt: 'desc',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
T4-C3 — staff-chat module (19 services, 0 tests). Batch 1 = 2 smallest services

## Coverage
- SnoozeService: create/cancel/getActive/getRoom (10 tests)
- CollisionDetectionService: viewer tracking + isCollision (12 tests)

## Test plan
- [x] +22 tests pass
- [x] TS check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)