### PR TITLE
test(staff-chat): +15 AiMetrics + MediaContent tests (T4-C3 batch 5)

### DIFF
--- a/apps/api/src/modules/staff-chat/services/ai-metrics.service.spec.ts
+++ b/apps/api/src/modules/staff-chat/services/ai-metrics.service.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiMetricsService } from './ai-metrics.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+describe('AiMetricsService.getMetrics', () => {
+  let service: AiMetricsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      aiAutoReplyLog: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      aiTrainingPair: {
+        findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [AiMetricsService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(AiMetricsService);
+  });
+
+  it('returns all-zero metrics when no data', async () => {
+    const result = await service.getMetrics();
+    expect(result).toEqual({
+      autoReplyRate: 0,
+      handoffRate: 0,
+      acceptRate: 0,
+      editRate: 0,
+      rejectRate: 0,
+      avgConfidence: 0,
+      totalTrainingPairs: 0,
+      usableTrainingPairs: 0,
+    });
+  });
+
+  it('computes autoReplyRate + handoffRate from aiAutoReplyLog', async () => {
+    prisma.aiAutoReplyLog.findMany.mockResolvedValue([
+      { autoSent: true, confidence: 0.9 },
+      { autoSent: true, confidence: 0.85 },
+      { autoSent: false, confidence: 0.5 }, // handoff
+      { autoSent: false, confidence: 0.3 }, // handoff
+    ]);
+    const result = await service.getMetrics();
+    expect(result.autoReplyRate).toBe(50);
+    expect(result.handoffRate).toBe(50);
+  });
+
+  it('avgConfidence is percent (0-100), not 0-1', async () => {
+    prisma.aiAutoReplyLog.findMany.mockResolvedValue([
+      { autoSent: true, confidence: 0.9 },
+      { autoSent: true, confidence: 0.5 },
+    ]);
+    const result = await service.getMetrics();
+    expect(result.avgConfidence).toBe(70); // (0.9+0.5)/2 * 100
+  });
+
+  it('acceptRate / editRate / rejectRate computed from SUGGEST_FEEDBACK pairs', async () => {
+    prisma.aiTrainingPair.findMany.mockResolvedValue([
+      { type: 'ACCEPT' },
+      { type: 'ACCEPT' },
+      { type: 'EDIT' },
+      { type: 'REJECT' },
+    ]);
+    const result = await service.getMetrics();
+    expect(result.acceptRate).toBe(50);
+    expect(result.editRate).toBe(25);
+    expect(result.rejectRate).toBe(25);
+  });
+
+  it('totalTrainingPairs + usableTrainingPairs from count queries', async () => {
+    prisma.aiTrainingPair.count
+      .mockResolvedValueOnce(120) // total
+      .mockResolvedValueOnce(85); // usable (quality >= 0.7)
+    const result = await service.getMetrics();
+    expect(result.totalTrainingPairs).toBe(120);
+    expect(result.usableTrainingPairs).toBe(85);
+    // Verify quality filter on 2nd call
+    expect(prisma.aiTrainingPair.count.mock.calls[1][0].where.quality.gte).toBe(0.7);
+  });
+
+  it('applies date filter when from/to provided', async () => {
+    const from = new Date('2026-04-01');
+    const to = new Date('2026-04-30');
+    await service.getMetrics(from, to);
+    const autoArgs = prisma.aiAutoReplyLog.findMany.mock.calls[0][0];
+    expect(autoArgs.where.createdAt.gte).toBe(from);
+    expect(autoArgs.where.createdAt.lte).toBe(to);
+  });
+
+  it('no date filter when neither from nor to provided (empty where)', async () => {
+    await service.getMetrics();
+    expect(prisma.aiAutoReplyLog.findMany.mock.calls[0][0].where).toEqual({});
+  });
+
+  it('filters feedback by source=SUGGEST_FEEDBACK', async () => {
+    await service.getMetrics();
+    const where = prisma.aiTrainingPair.findMany.mock.calls[0][0].where;
+    expect(where.source).toBe('SUGGEST_FEEDBACK');
+  });
+});

--- a/apps/api/src/modules/staff-chat/services/media-content.service.spec.ts
+++ b/apps/api/src/modules/staff-chat/services/media-content.service.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { MediaContentService } from './media-content.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { LineFinanceClientService } from '../../chatbot-finance/services/line-finance-client.service';
+import { StorageService } from '../../storage/storage.service';
+
+describe('MediaContentService.getAudioUrl', () => {
+  let service: MediaContentService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let line: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let storage: any;
+
+  beforeEach(async () => {
+    prisma = {
+      chatMessage: {
+        findUnique: jest.fn(),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    };
+    line = {
+      getMessageContent: jest.fn().mockResolvedValue(Buffer.from('audio')),
+    };
+    storage = {
+      upload: jest.fn().mockResolvedValue(undefined),
+      getSignedDownloadUrl: jest.fn().mockResolvedValue('https://signed.example/audio.m4a'),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaContentService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LineFinanceClientService, useValue: line },
+        { provide: StorageService, useValue: storage },
+      ],
+    }).compile();
+    service = mod.get(MediaContentService);
+  });
+
+  it('throws NotFound when message missing', async () => {
+    prisma.chatMessage.findUnique.mockResolvedValue(null);
+    await expect(service.getAudioUrl('msg-1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws BadRequest when message type is not AUDIO', async () => {
+    prisma.chatMessage.findUnique.mockResolvedValue({ id: 'msg-1', type: 'TEXT' });
+    await expect(service.getAudioUrl('msg-1')).rejects.toThrow(BadRequestException);
+  });
+
+  it('returns signed URL directly when mediaUrl is already cached (non-line://)', async () => {
+    prisma.chatMessage.findUnique.mockResolvedValue({
+      id: 'msg-1',
+      type: 'AUDIO',
+      mediaUrl: 'chat-audio/msg-1.m4a',
+    });
+    const result = await service.getAudioUrl('msg-1');
+    expect(result.url).toBe('https://signed.example/audio.m4a');
+    expect(line.getMessageContent).not.toHaveBeenCalled();
+    expect(storage.upload).not.toHaveBeenCalled();
+  });
+
+  it('throws BadRequest when LINE download needed but externalMessageId missing', async () => {
+    prisma.chatMessage.findUnique.mockResolvedValue({
+      id: 'msg-1',
+      type: 'AUDIO',
+      mediaUrl: null,
+      externalMessageId: null,
+    });
+    await expect(service.getAudioUrl('msg-1')).rejects.toThrow(BadRequestException);
+  });
+
+  it('downloads from LINE, uploads to storage, updates DB, returns signed URL', async () => {
+    prisma.chatMessage.findUnique.mockResolvedValue({
+      id: 'msg-1',
+      type: 'AUDIO',
+      mediaUrl: null,
+      externalMessageId: 'line-ext-123',
+    });
+    const result = await service.getAudioUrl('msg-1');
+    expect(line.getMessageContent).toHaveBeenCalledWith('line-ext-123');
+    expect(storage.upload).toHaveBeenCalledWith(
+      'chat-audio/msg-1.m4a',
+      expect.any(Buffer),
+      'audio/mp4',
+    );
+    expect(prisma.chatMessage.update).toHaveBeenCalledWith({
+      where: { id: 'msg-1' },
+      data: { mediaUrl: 'chat-audio/msg-1.m4a' },
+    });
+    expect(result.url).toContain('https://');
+  });
+
+  it('downloads from LINE when mediaUrl starts with line:// (not yet migrated)', async () => {
+    prisma.chatMessage.findUnique.mockResolvedValue({
+      id: 'msg-1',
+      type: 'AUDIO',
+      mediaUrl: 'line://placeholder',
+      externalMessageId: 'line-ext-123',
+    });
+    await service.getAudioUrl('msg-1');
+    expect(line.getMessageContent).toHaveBeenCalled();
+  });
+
+  it('wraps LINE download failure in friendly Thai BadRequest', async () => {
+    prisma.chatMessage.findUnique.mockResolvedValue({
+      id: 'msg-1',
+      type: 'AUDIO',
+      mediaUrl: null,
+      externalMessageId: 'line-ext-123',
+    });
+    line.getMessageContent.mockRejectedValue(new Error('LINE API down'));
+    await expect(service.getAudioUrl('msg-1')).rejects.toThrow(
+      /ไม่สามารถดาวน์โหลดไฟล์เสียงได้/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Batch 5 — AI performance KPIs + voice message media path

Cumulative T4-C3: 68 tests

## Test plan
- [x] +15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)