### PR TITLE
fix(peak): HMAC key + idempotent sync (T6-C4 + T6-C5)

### DIFF
--- a/apps/api/src/modules/integrations/integrations.service.ts
+++ b/apps/api/src/modules/integrations/integrations.service.ts
@@ -267,9 +267,9 @@ export class IntegrationsService {
         String(now.getSeconds()).padStart(2, '0'),
       ].join('');
 
-      // HMAC-SHA1(timeStamp, connectId) using connectId as key
+      // HMAC-SHA1(message=timeStamp, key=secretKey) — must match PeakService.generateTimeSignature
       const timeSignature = crypto
-        .createHmac('sha1', connectId)
+        .createHmac('sha1', secretKey)
         .update(timeStamp)
         .digest('hex');
 

--- a/apps/api/src/modules/peak/peak.service.spec.ts
+++ b/apps/api/src/modules/peak/peak.service.spec.ts
@@ -1,0 +1,330 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { createHmac } from 'crypto';
+import { PeakService } from './peak.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('PeakService', () => {
+  let service: PeakService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let integrationConfig: any;
+
+  beforeEach(async () => {
+    prisma = {
+      journalEntry: {
+        findMany: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+      },
+    };
+    integrationConfig = {
+      getValue: jest.fn(async (_ns: string, key: string) => {
+        switch (key) {
+          case 'baseUrl':
+            return 'https://api.peakaccount.com/api/v1';
+          case 'userToken':
+            return 'testUserToken';
+          case 'connectId':
+            return 'testConnectId';
+          case 'secretKey':
+            return 'testSecret';
+          default:
+            return '';
+        }
+      }),
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        PeakService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: { get: () => '' } },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
+      ],
+    }).compile();
+    service = mod.get(PeakService);
+  });
+
+  describe('generateTimeSignature (T6-C4)', () => {
+    it('signs the time-stamp with secretKey as HMAC key (not connectId)', () => {
+      const config = {
+        baseUrl: '',
+        userToken: '',
+        connectId: 'testConnectId',
+        secretKey: 'testSecret',
+      };
+      const timeStamp = '20260419120000';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sig = (service as any).generateTimeSignature(timeStamp, config);
+
+      const expectedWithSecret = createHmac('sha1', 'testSecret').update(timeStamp).digest('hex');
+      const legacyBugWithConnectId = createHmac('sha1', 'testConnectId')
+        .update(timeStamp)
+        .digest('hex');
+
+      expect(sig).toBe(expectedWithSecret);
+      expect(sig).not.toBe(legacyBugWithConnectId);
+    });
+
+    it('fixture vector: (timeStamp=20260419120000, secretKey=testSecret) → 0c592fa5db6e3cb5b2c10f1a0d79c49b295761a6', () => {
+      const config = {
+        baseUrl: '',
+        userToken: '',
+        connectId: 'anyConnectId',
+        secretKey: 'testSecret',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sig = (service as any).generateTimeSignature('20260419120000', config);
+      expect(sig).toBe('0c592fa5db6e3cb5b2c10f1a0d79c49b295761a6');
+    });
+
+    it('signature is independent of connectId (proves key is secretKey)', () => {
+      const configA = {
+        baseUrl: '',
+        userToken: '',
+        connectId: 'connectA',
+        secretKey: 'samesecret',
+      };
+      const configB = {
+        baseUrl: '',
+        userToken: '',
+        connectId: 'connectB',
+        secretKey: 'samesecret',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const s = service as any;
+      expect(s.generateTimeSignature('20260101000000', configA)).toBe(
+        s.generateTimeSignature('20260101000000', configB),
+      );
+    });
+
+    it('signature changes when secretKey changes', () => {
+      const config1 = {
+        baseUrl: '',
+        userToken: '',
+        connectId: 'c',
+        secretKey: 'secret1',
+      };
+      const config2 = {
+        baseUrl: '',
+        userToken: '',
+        connectId: 'c',
+        secretKey: 'secret2',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const s = service as any;
+      expect(s.generateTimeSignature('20260101000000', config1)).not.toBe(
+        s.generateTimeSignature('20260101000000', config2),
+      );
+    });
+  });
+
+  describe('isConfigured', () => {
+    it('returns true when all three credentials present', async () => {
+      await expect(service.isConfigured()).resolves.toBe(true);
+    });
+
+    it('returns false when secretKey missing', async () => {
+      integrationConfig.getValue.mockImplementation(async (_ns: string, key: string) => {
+        if (key === 'secretKey') return '';
+        return 'x';
+      });
+      await expect(service.isConfigured()).resolves.toBe(false);
+    });
+  });
+
+  describe('exportJournalEntries — T6-C5 idempotency', () => {
+    beforeEach(() => {
+      globalThis.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      (globalThis.fetch as jest.Mock).mockReset();
+    });
+
+    const mockPeakHeaders = () => {
+      // First call: ClientToken, second+: DailyJournals POST
+      (globalThis.fetch as jest.Mock).mockImplementation((url: string) => {
+        if (url.endsWith('/ClientToken')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ clientToken: 'ct-test' }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ resCode: '200', resDesc: 'OK' }),
+        });
+      });
+    };
+
+    it('skips gracefully when PEAK not configured', async () => {
+      integrationConfig.getValue.mockResolvedValue('');
+      const result = await service.exportJournalEntries(new Date(), new Date());
+      expect(result).toEqual({ exported: 0, skipped: 0, errors: ['PEAK ยังไม่ได้ตั้งค่า'] });
+    });
+
+    it('returns empty result when no unsynced entries in window', async () => {
+      mockPeakHeaders();
+      prisma.journalEntry.findMany.mockResolvedValue([]);
+      const result = await service.exportJournalEntries(new Date(), new Date());
+      expect(result).toEqual({ exported: 0, skipped: 0, errors: [] });
+    });
+
+    it('only marks peakSyncedAt when update affects 1 row (race protection)', async () => {
+      mockPeakHeaders();
+      const entry = {
+        id: 'je-1',
+        entryNumber: 'JE-001',
+        entryDate: new Date('2026-04-18'),
+        description: 'Test',
+        lines: [
+          {
+            accountCode: '11-1101',
+            description: null,
+            debit: { toString: () => '100' },
+            credit: { toString: () => '0' },
+          },
+        ],
+      };
+      prisma.journalEntry.findMany.mockResolvedValue([entry]);
+      prisma.journalEntry.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.exportJournalEntries(new Date(), new Date());
+
+      expect(prisma.journalEntry.updateMany).toHaveBeenCalledWith({
+        where: { id: 'je-1', peakSyncedAt: null },
+        data: { peakSyncedAt: expect.any(Date) },
+      });
+      expect(result.exported).toBe(1);
+    });
+
+    it('treats concurrent double-sync as no-op (updateMany returns count=0)', async () => {
+      mockPeakHeaders();
+      prisma.journalEntry.findMany.mockResolvedValue([
+        {
+          id: 'je-1',
+          entryNumber: 'JE-001',
+          entryDate: new Date('2026-04-18'),
+          description: 'Test',
+          lines: [
+            {
+              accountCode: '11-1101',
+              description: null,
+              debit: { toString: () => '100' },
+              credit: { toString: () => '0' },
+            },
+          ],
+        },
+      ]);
+      prisma.journalEntry.updateMany.mockResolvedValue({ count: 0 });
+
+      const result = await service.exportJournalEntries(new Date(), new Date());
+
+      expect(result.exported).toBe(0);
+      expect(result.skipped).toBe(1);
+    });
+
+    it('continues processing remaining entries when one throws', async () => {
+      const entries = [
+        {
+          id: 'je-1',
+          entryNumber: 'JE-001',
+          entryDate: new Date('2026-04-18'),
+          description: 'A',
+          lines: [
+            {
+              accountCode: '11-1101',
+              description: null,
+              debit: { toString: () => '10' },
+              credit: { toString: () => '0' },
+            },
+          ],
+        },
+        {
+          id: 'je-2',
+          entryNumber: 'JE-002',
+          entryDate: new Date('2026-04-18'),
+          description: 'B',
+          lines: [
+            {
+              accountCode: '11-1101',
+              description: null,
+              debit: { toString: () => '20' },
+              credit: { toString: () => '0' },
+            },
+          ],
+        },
+      ];
+      prisma.journalEntry.findMany.mockResolvedValue(entries);
+      prisma.journalEntry.updateMany.mockResolvedValue({ count: 1 });
+
+      let call = 0;
+      (globalThis.fetch as jest.Mock).mockImplementation((url: string) => {
+        if (url.endsWith('/ClientToken')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ clientToken: 'ct-test' }),
+          });
+        }
+        call++;
+        if (call === 1) {
+          return Promise.reject(new Error('network'));
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ resCode: '200' }),
+        });
+      });
+
+      const result = await service.exportJournalEntries(new Date(), new Date());
+      expect(result.exported).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('JE-001');
+    });
+
+    it('does not mark peakSyncedAt when PEAK returns non-200 resCode', async () => {
+      (globalThis.fetch as jest.Mock).mockImplementation((url: string) => {
+        if (url.endsWith('/ClientToken')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ clientToken: 'ct-test' }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ resCode: '500', resDesc: 'server fail' }),
+        });
+      });
+      prisma.journalEntry.findMany.mockResolvedValue([
+        {
+          id: 'je-1',
+          entryNumber: 'JE-001',
+          entryDate: new Date('2026-04-18'),
+          description: 'X',
+          lines: [
+            {
+              accountCode: '11-1101',
+              description: null,
+              debit: { toString: () => '1' },
+              credit: { toString: () => '0' },
+            },
+          ],
+        },
+      ]);
+
+      const result = await service.exportJournalEntries(new Date(), new Date());
+      expect(prisma.journalEntry.updateMany).not.toHaveBeenCalled();
+      expect(result.exported).toBe(0);
+      expect(result.errors[0]).toContain('server fail');
+    });
+  });
+});

--- a/apps/api/src/modules/peak/peak.service.ts
+++ b/apps/api/src/modules/peak/peak.service.ts
@@ -26,8 +26,8 @@ interface PeakConfig {
  *
  * Authentication flow:
  * 1. Create Time-Stamp (yyyyMMddHHmmss)
- * 2. HMAC-SHA1(Time-Stamp, connectId) using secretKey → Time-Signature
- * 3. POST /ClientToken → get Client-Token
+ * 2. Time-Signature = HMAC-SHA1(message=Time-Stamp, key=secretKey)
+ * 3. POST /ClientToken (with connectId as a body/header identifier) → get Client-Token
  * 4. Include all 4 headers on every request
  *
  * Key endpoint: POST /DailyJournals — create journal entries
@@ -91,6 +91,7 @@ export class PeakService {
     }
 
     let exported = 0;
+    let skipped = 0;
     const errors: string[] = [];
 
     for (const entry of entries) {
@@ -99,11 +100,23 @@ export class PeakService {
         const result = await this.postToPeak('/DailyJournals', peakPayload);
 
         if (result.resCode === '200') {
-          await this.prisma.journalEntry.update({
-            where: { id: entry.id },
+          // T6-C5: idempotent mark — only update if still unsynced. If a
+          // concurrent cron run already marked it, `count` is 0 and we skip
+          // without double-counting. Protects against the case where two
+          // workers pick up the same entry between findMany and update.
+          const marked = await this.prisma.journalEntry.updateMany({
+            where: { id: entry.id, peakSyncedAt: null },
             data: { peakSyncedAt: new Date() },
           });
-          exported++;
+          if (marked.count === 1) {
+            exported++;
+          } else {
+            skipped++;
+            Sentry.captureMessage(
+              `PEAK: duplicate sync attempt for ${entry.entryNumber} — entry already marked`,
+              { level: 'info', tags: { kind: 'peak-sync', entryNumber: entry.entryNumber } },
+            );
+          }
         } else {
           errors.push(`${entry.entryNumber}: ${result.resDesc || 'Unknown PEAK error'}`);
         }
@@ -116,8 +129,10 @@ export class PeakService {
       }
     }
 
-    this.logger.log(`PEAK export: ${exported} exported, ${errors.length} errors out of ${entries.length}`);
-    return { exported, skipped: entries.length - exported - errors.length, errors };
+    this.logger.log(
+      `PEAK export: ${exported} exported, ${skipped} skipped (already synced), ${errors.length} errors out of ${entries.length}`,
+    );
+    return { exported, skipped, errors };
   }
 
   /** Fetch chart of accounts from PEAK */
@@ -149,9 +164,15 @@ export class PeakService {
     return `${y}${M}${d}${h}${m}${s}`;
   }
 
-  /** HMAC-SHA1(timeStamp, connectId) using secretKey → Time-Signature */
+  /**
+   * Time-Signature = HMAC-SHA1(message=timeStamp, key=secretKey).
+   *
+   * T6-C4 fix: earlier versions signed with `connectId` (public identifier) as
+   * the HMAC key, which would have let anyone with the connectId forge signed
+   * requests. The spec requires secretKey as the key.
+   */
   private generateTimeSignature(timeStamp: string, config: PeakConfig): string {
-    return createHmac('sha1', config.connectId)
+    return createHmac('sha1', config.secretKey)
       .update(timeStamp)
       .digest('hex');
   }


### PR DESCRIPTION
## Summary
Bundle 2 critical PEAK integration fixes from tier-8 heatmap (PR [#578](https://github.com/iamnaii/BESTCHOICE/pull/578)):

### T6-C4 — HMAC key mix-up (security)
`PeakService.generateTimeSignature()` + `IntegrationsService.testPeak()` signed with `connectId` (public identifier) instead of `secretKey`. Fixed to match the header comment spec:
```
Time-Signature = HMAC-SHA1(message=Time-Stamp, key=secretKey)
```
**Impact:** ถ้า PEAK ฝั่ง server ไม่ strict validate การ signature verification จะอ่อนแอเพราะ connectId = public identifier (ถูก embed ใน request ทุกอัน) ใครก็ forge ได้ SecretKey มีเฉพาะเจ้าของ account

### T6-C5 — Partial-sync race
เดิม `journalEntry.update({ where: { id }, ... })` เขียน peakSyncedAt ทับ ถ้า 2 workers ประมวลผล entry เดียวกัน → double-count exported + PEAK ได้ journal 2 ครั้ง. Fix ใช้ `updateMany({ where: { id, peakSyncedAt: null } })` — second worker จะได้ count=0 → increment `skipped` + Sentry info log แทน

## Fixture vector (locked in test)
```
timeStamp  = "20260419120000"
secretKey  = "testSecret"
signature  = "0c592fa5db6e3cb5b2c10f1a0d79c49b295761a6"
```
ถ้า future refactor break this → test fails + PEAK sync จะ fail ใน prod ทันที

## Test plan
- [x] `./tools/check-types.sh api` → 0 errors
- [x] `npx jest src/modules/peak` → 3 suites / 18 tests passed
- [x] Full API suite → 90 suites / 1195 tests (baseline unchanged)
- [ ] Manual: OWNER → \`/settings/integrations\` → PEAK card → Test → expect success (หลัง PR merge + rotate creds ถ้าต้องการ verify)

## Breaking changes
- **เชิง technical**: Signature ที่ send ไป PEAK จะเปลี่ยน. ถ้า prod เคย work ด้วย connectId = bug ที่ PEAK server ฝั่งรับ (weak validation) → หลัง merge ยัง work ได้เหมือนเดิม. ถ้า PEAK strict validate → ควรใช้ secretKey อยู่แล้วตาม spec
- ทีม PEAK แนะนำให้ rotate credentials หลัง deploy — ดู [PEAK-CREDENTIALS-RUNBOOK.md](docs/guides/PEAK-CREDENTIALS-RUNBOOK.md) (ใน PR แยก T6-C9)

## Follow-up
- PR T6-C9: credential rotation cron + runbook (separate, coming next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)