### PR TITLE
feat(integrations): credential rotation staleness alarm + runbook (T6-C9)

### DIFF
--- a/apps/api/src/modules/integrations/credential-rotation.cron.spec.ts
+++ b/apps/api/src/modules/integrations/credential-rotation.cron.spec.ts
@@ -1,0 +1,123 @@
+import { Test } from '@nestjs/testing';
+import { CredentialRotationCron } from './credential-rotation.cron';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('CredentialRotationCron (T6-C9)', () => {
+  let cron: CredentialRotationCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const envBackup = process.env.INTEGRATION_ROTATION_THRESHOLD_DAYS;
+
+  beforeEach(async () => {
+    process.env.INTEGRATION_ROTATION_THRESHOLD_DAYS = '90';
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    prisma = {
+      systemConfig: {
+        findFirst: jest.fn(),
+      },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [CredentialRotationCron, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    cron = mod.get(CredentialRotationCron);
+  });
+
+  afterEach(() => {
+    process.env.INTEGRATION_ROTATION_THRESHOLD_DAYS = envBackup;
+  });
+
+  it('skips fields with no SystemConfig row (never configured)', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue(null);
+    const result = await cron.checkStale();
+    expect(result.stale).toBe(0);
+    expect(result.ok).toBe(0);
+    expect(result.skipped).toBeGreaterThan(0);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('counts recently-updated credentials as OK (< 90 days)', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({
+      value: 'encrypted-value',
+      updatedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    });
+    const result = await cron.checkStale();
+    expect(result.stale).toBe(0);
+    expect(result.ok).toBeGreaterThan(0);
+  });
+
+  it('flags stale credentials (> 90 days) and emits Sentry warning', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({
+      value: 'encrypted-value',
+      updatedAt: new Date(Date.now() - 120 * 24 * 60 * 60 * 1000),
+    });
+    const result = await cron.checkStale();
+    expect(result.stale).toBeGreaterThan(0);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('stale'),
+      expect.objectContaining({ level: 'warning' }),
+    );
+  });
+
+  it('uses env threshold when INTEGRATION_ROTATION_THRESHOLD_DAYS is set', async () => {
+    process.env.INTEGRATION_ROTATION_THRESHOLD_DAYS = '7';
+    // Re-create cron so constructor re-reads env
+    const mod = await Test.createTestingModule({
+      providers: [CredentialRotationCron, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const cron7d = mod.get(CredentialRotationCron);
+
+    prisma.systemConfig.findFirst.mockResolvedValue({
+      value: 'encrypted-value',
+      updatedAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000),
+    });
+    const result = await cron7d.checkStale();
+    expect(result.stale).toBeGreaterThan(0);
+  });
+
+  it('falls back to 90 days when env value is invalid', async () => {
+    process.env.INTEGRATION_ROTATION_THRESHOLD_DAYS = 'abc';
+    const mod = await Test.createTestingModule({
+      providers: [CredentialRotationCron, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const cronFallback = mod.get(CredentialRotationCron);
+
+    prisma.systemConfig.findFirst.mockResolvedValue({
+      value: 'x',
+      updatedAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+    });
+    const result = await cronFallback.checkStale();
+    expect(result.stale).toBe(0);
+  });
+
+  it('swallows DB exception + Sentry.captureException (cron never throws)', async () => {
+    prisma.systemConfig.findFirst.mockRejectedValue(new Error('db down'));
+    const result = await cron.checkStale();
+    expect(result).toEqual({ stale: 0, ok: 0, skipped: 0 });
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it('ignores non-sensitive fields (only iterates sensitive ones)', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({
+      value: 'x',
+      updatedAt: new Date(),
+    });
+    await cron.checkStale();
+    // Every findFirst call's key must include a sensitive field name
+    const keys = prisma.systemConfig.findFirst.mock.calls.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c: any) => c[0].where.key,
+    );
+    expect(keys.length).toBeGreaterThan(0);
+    // Non-sensitive keys like liff-id should not be queried
+    expect(keys.every((k: string) => !k.endsWith('.liffId'))).toBe(true);
+  });
+});

--- a/apps/api/src/modules/integrations/credential-rotation.cron.ts
+++ b/apps/api/src/modules/integrations/credential-rotation.cron.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+import { INTEGRATIONS } from './integration-registry';
+
+/**
+ * Weekly check for stale sensitive credentials (T6-C9).
+ *
+ * Loops through all integrations in the registry; for each field marked
+ * `sensitive: true`, looks up the SystemConfig row at
+ * `integration.<integrationKey>.<fieldKey>` and emits a Sentry warning if
+ * `updatedAt` is older than STALE_THRESHOLD_DAYS (default 90).
+ *
+ * The alarm is informational: it doesn't block the integration. It is the
+ * trigger for OWNER to run the rotation runbook — see
+ * `docs/guides/PEAK-CREDENTIALS-RUNBOOK.md`.
+ *
+ * Missing credentials (no SystemConfig row at all) are treated as "not
+ * configured" and skipped — we only flag credentials that were configured
+ * once and then left to rot.
+ */
+@Injectable()
+export class CredentialRotationCron {
+  private readonly logger = new Logger(CredentialRotationCron.name);
+
+  private readonly staleThresholdDays: number;
+
+  constructor(private readonly prisma: PrismaService) {
+    const envValue = process.env.INTEGRATION_ROTATION_THRESHOLD_DAYS;
+    const parsed = envValue ? parseInt(envValue, 10) : NaN;
+    this.staleThresholdDays = Number.isFinite(parsed) && parsed > 0 ? parsed : 90;
+  }
+
+  /** Every Monday 06:00 Asia/Bangkok. */
+  @Cron('0 6 * * 1', { timeZone: 'Asia/Bangkok' })
+  async checkStale(): Promise<{ stale: number; ok: number; skipped: number }> {
+    try {
+      const stale: Array<{ integration: string; field: string; ageDays: number }> = [];
+      let ok = 0;
+      let skipped = 0;
+
+      const now = Date.now();
+      const thresholdMs = this.staleThresholdDays * 24 * 60 * 60 * 1000;
+
+      for (const def of INTEGRATIONS) {
+        for (const field of def.fields) {
+          if (!field.sensitive) continue;
+
+          const row = await this.prisma.systemConfig.findFirst({
+            where: {
+              key: `integration.${def.key}.${field.key}`,
+              deletedAt: null,
+            },
+            select: { updatedAt: true, value: true },
+          });
+
+          if (!row || !row.value) {
+            skipped++;
+            continue;
+          }
+
+          const ageMs = now - row.updatedAt.getTime();
+          if (ageMs > thresholdMs) {
+            stale.push({
+              integration: def.key,
+              field: field.key,
+              ageDays: Math.floor(ageMs / (24 * 60 * 60 * 1000)),
+            });
+          } else {
+            ok++;
+          }
+        }
+      }
+
+      if (stale.length > 0) {
+        const sample = stale.slice(0, 10).map((s) => `${s.integration}.${s.field}=${s.ageDays}d`);
+        this.logger.warn(
+          `Stale credentials (>${this.staleThresholdDays}d): ${stale.length} — ${sample.join(', ')}`,
+        );
+        Sentry.captureMessage(
+          `Integration credentials stale: ${stale.length} field(s) > ${this.staleThresholdDays} days`,
+          {
+            level: 'warning',
+            tags: { kind: 'cron-job', cron: 'credential-rotation' },
+            extra: { stale, thresholdDays: this.staleThresholdDays },
+          },
+        );
+      } else {
+        this.logger.log(
+          `Credential rotation check: ${ok} fresh, ${skipped} not configured, 0 stale`,
+        );
+      }
+
+      return { stale: stale.length, ok, skipped };
+    } catch (err) {
+      this.logger.error(
+        `Credential rotation cron failed: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'credential-rotation' },
+      });
+      return { stale: 0, ok: 0, skipped: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/integrations/integrations.module.ts
+++ b/apps/api/src/modules/integrations/integrations.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { IntegrationsController } from './integrations.controller';
 import { IntegrationsService } from './integrations.service';
 import { IntegrationConfigService } from './integration-config.service';
+import { CredentialRotationCron } from './credential-rotation.cron';
 
 @Module({
   controllers: [IntegrationsController],
-  providers: [IntegrationsService, IntegrationConfigService],
+  providers: [IntegrationsService, IntegrationConfigService, CredentialRotationCron],
   exports: [IntegrationConfigService],
 })
 export class IntegrationsModule {}

--- a/docs/guides/PEAK-CREDENTIALS-RUNBOOK.md
+++ b/docs/guides/PEAK-CREDENTIALS-RUNBOOK.md
@@ -1,0 +1,110 @@
+# PEAK Credentials Runbook
+
+> **Owner:** OWNER role only (credentials grant production journal-write access)
+> **Cadence:** Quarterly rotation + on-demand after any suspected leak
+> **Related:** T6-C9 rotation alert, T6-C4 HMAC fix, T6-C5 idempotent sync
+> **Stale alarm:** `cron: credential-rotation` fires every Monday 06:00 Asia/Bangkok — Sentry warning if any sensitive credential > 90 days old
+
+## What PEAK credentials exist
+
+| Field | Stored at | Purpose | Sensitive |
+|-------|-----------|---------|-----------|
+| `peak.userToken` | `system_config` key `integration.peak.userToken` | Authenticates คน (OWNER) ที่สร้าง access | ✅ yes |
+| `peak.connectId` | `system_config` key `integration.peak.connectId` | Identifies ลูกค้า PEAK account | ⚠️ semi (public identifier) |
+| `peak.secretKey` | `system_config` key `integration.peak.secretKey` | **HMAC-SHA1 key** สำหรับ Time-Signature | 🔴 HIGH |
+| `peak.baseUrl` | `system_config` key `integration.peak.baseUrl` | API endpoint (defaults to prod) | low |
+
+ค่าที่ sensitive จะถูก encrypt ด้วย `INTEGRATION_ENCRYPTION_KEY` (env) ก่อนเก็บ ดู [integration-config.service.ts](../../apps/api/src/modules/integrations/integration-config.service.ts) `encryptPII()`
+
+## Who can read PEAK credentials
+
+- **OWNER role เท่านั้น** — ผ่าน `GET /integrations/peak` (`IntegrationsController`) แสดง masked (`••••xxxx`)
+- **Runtime code** — `PeakService.getConfig()` decrypt ด้วย `INTEGRATION_ENCRYPTION_KEY`
+- **DB admin access** — ถ้า DB ถูก compromise แต่ไม่มี key → เห็น ciphertext เท่านั้น
+
+Access จาก code path ใดๆก็ตามบันทึกใน `AuditLog` (global `AuditInterceptor` on mutation; read access ไม่ได้ log)
+
+## When to rotate
+
+**Required (immediate):**
+- Credentials leaked ใน git, Slack, email, logs, customer-facing
+- PEAK account compromised / suspicious journals appeared
+- OWNER departure (person who created them leaves role)
+- After T6-C4 fix deployed — เดิมเคย sign ด้วย connectId; ทีม PEAK ถ้ารู้ว่าเคย bug นี้อาจขอ rotate
+
+**Routine:**
+- Quarterly (mark in OWNER's calendar — 1 Jan / 1 Apr / 1 Jul / 1 Oct)
+- When Sentry alarm `cron: credential-rotation` fires (90-day staleness)
+
+## Rotation procedure
+
+### 1. Generate new credentials บน PEAK portal
+1. Login `https://app.peakaccount.com` ด้วย OWNER account
+2. Settings → API → Regenerate User Token (หรือ regenerate whole app)
+3. Copy new `UserToken`, `ConnectId`, `SecretKey` ไว้ในที่ปลอดภัย (password manager)
+
+### 2. เขียนค่าใหม่ลงระบบ
+- วิธี A (UI): OWNER login BESTCHOICE → `/settings/integrations` → card "PEAK" → "Edit" → paste ค่าใหม่ → "Save"
+- วิธี B (API): `POST /integrations/peak/config` body `{ userToken, connectId, secretKey }` with OWNER JWT
+
+### 3. Verify
+```bash
+# ทดสอบ connect (OWNER JWT)
+curl -X POST https://api.bestchoice.app/integrations/peak/test \
+  -H "Authorization: Bearer $OWNER_JWT"
+# expect: { "success": true, "message": "เชื่อมต่อ PEAK สำเร็จ (Client-Token ได้รับแล้ว)" }
+```
+
+### 4. Trigger manual sync เพื่อ flush backlog
+```bash
+curl -X POST https://api.bestchoice.app/peak/export \
+  -H "Authorization: Bearer $OWNER_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{ "startDate": "2026-04-01", "endDate": "2026-04-30" }'
+```
+
+### 5. Monitor
+- Sentry filter: `kind:peak-sync` — ไม่ควรมี error หลัง rotate
+- PEAK portal: Journal entries tab — verify entries ปรากฏถูก date
+- `cron: credential-rotation` Monday morning ต่อไปจะ reset
+
+## HMAC signature spec (T6-C4 reference)
+
+ระบบ sign ทุก request ด้วย:
+```
+Time-Signature = HMAC-SHA1(message=Time-Stamp, key=secretKey)
+```
+โดย `Time-Stamp` = yyyyMMddHHmmss (Asia/Bangkok local time)
+
+Fixture vector สำหรับ self-test:
+```
+timeStamp  = "20260419120000"
+secretKey  = "testSecret"
+signature  = "0c592fa5db6e3cb5b2c10f1a0d79c49b295761a6"  (hex, lowercase)
+```
+
+ถ้า sign output ไม่ตรง fixture นี้ = bug กลับมาใหม่
+
+**Legacy bug (ปิดแล้ว ใน PR T6-C4):** เคย sign ด้วย `connectId` แทน `secretKey` — ทำให้คนที่มี connectId (public identifier) forge signed requests ได้ ถ้า PEAK ฝั่ง server ไม่ strict validate
+
+## Encryption key (INTEGRATION_ENCRYPTION_KEY)
+
+- Separate lifecycle จาก PEAK credentials
+- ถ้า key หมุน (rotate) → ต้อง re-encrypt existing SystemConfig rows (ยังไม่มี migration script — ถ้า rotate ต้องเขียน migration ด้วย)
+- ห้าม commit ลง git; ห้าม log — `integration-config.service.ts` `onModuleInit()` แค่ warn ถ้า missing
+
+## Incident checklist (credentials leaked)
+
+- [ ] Rotate ทันที (section above)
+- [ ] ดู Sentry + audit logs — `AuditLog.action` ที่ mutate `integration.peak.*` หลัง leak timestamp
+- [ ] Check PEAK portal: Journal entries tab — entries ที่ไม่ได้ส่งจาก BESTCHOICE?
+- [ ] ถ้าพบ unauthorized entries → reverse ใน PEAK + Sentry report + filing report
+- [ ] Revoke OWNER JWT (logout all sessions) ถ้าสงสัย endpoint leak
+- [ ] Verify `INTEGRATION_ENCRYPTION_KEY` ไม่ leak เช่นกัน — ถ้า leak ต้อง rotate + re-encrypt ทุก integration credentials
+
+## Related files
+
+- [peak.service.ts](../../apps/api/src/modules/peak/peak.service.ts) — HMAC + export logic
+- [integration-config.service.ts](../../apps/api/src/modules/integrations/integration-config.service.ts) — encrypt/decrypt
+- [credential-rotation.cron.ts](../../apps/api/src/modules/integrations/credential-rotation.cron.ts) — weekly staleness alarm
+- [integration-registry.ts](../../apps/api/src/modules/integrations/integration-registry.ts) — `sensitive: true` flag per field


### PR DESCRIPTION
## Summary
ปิด T6-C9 จาก tier-8 heatmap ([#578](https://github.com/iamnaii/BESTCHOICE/pull/578)) — **credential rotation monitoring + PEAK-specific runbook**

### Cron: CredentialRotationCron
- รัน Monday 06:00 Asia/Bangkok (weekly)
- วน registry ทุก integration → scan เฉพาะ field ที่ `sensitive: true` (channelToken/secret, secretKey, apiKey, etc.)
- ถ้า \`SystemConfig.updatedAt\` > threshold (default 90 วัน, override ด้วย \`INTEGRATION_ROTATION_THRESHOLD_DAYS\`) → Sentry warning
- **Informational เท่านั้น** — ไม่ block integration เพราะการ block credentials ที่กำลัง work อยู่เสี่ยงกว่า

### Runbook: PEAK-CREDENTIALS-RUNBOOK.md
- Rotation procedure (generate → save → verify → sync backlog → monitor)
- HMAC fixture vector ผูกกับ T6-C4 fix ([#579](https://github.com/iamnaii/BESTCHOICE/pull/579))
- Incident checklist สำหรับ credentials leak
- Who can read what + encryption key lifecycle

## Test plan
- [x] +7 unit tests ครอบคลุม: empty DB, fresh creds, stale detection, env threshold override, invalid env fallback, DB error handling, sensitive-only iteration
- [x] Full API suite — 90 suites / 1202 tests passed
- [x] TypeScript 0 errors

## Coverage
| Integration | Sensitive fields monitored |
|------|---|
| line-shop / line-finance / line-staff | channelToken, channelSecret |
| sms | apiKey, apiSecret |
| facebook | pageAccessToken, appSecret |
| paysolutions | merchantId, ownerKey |
| peak | userToken, secretKey |
| mdm | apiKey |
| claude-ai | apiKey |

Depends on registry `sensitive: true` flags being accurate — ถ้ามี field ใหม่ต้อง mark `sensitive: true` ถึงจะถูก monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)