### PR TITLE
feat(commission): daily clawback cron (T1-C6)

### DIFF
--- a/apps/api/src/modules/commission/commission-clawback.cron.spec.ts
+++ b/apps/api/src/modules/commission/commission-clawback.cron.spec.ts
@@ -1,0 +1,175 @@
+import { Test } from '@nestjs/testing';
+import { CommissionClawbackCron } from './commission-clawback.cron';
+import { CommissionService } from './commission.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('CommissionClawbackCron (T1-C6)', () => {
+  let cron: CommissionClawbackCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let commission: any;
+
+  beforeEach(async () => {
+    (Sentry.captureException as jest.Mock).mockClear();
+    prisma = {
+      contract: { findMany: jest.fn() },
+      payment: { count: jest.fn() },
+    };
+    commission = {
+      applyClawbackForContract: jest.fn(),
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        CommissionClawbackCron,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CommissionService, useValue: commission },
+      ],
+    }).compile();
+    cron = mod.get(CommissionClawbackCron);
+  });
+
+  it('returns zero-counts when no DEFAULT/CLOSED_BAD_DEBT contracts have pending clawback', async () => {
+    prisma.contract.findMany.mockResolvedValue([]);
+    const result = await cron.runDailyClawback();
+    expect(result).toEqual({ processed: 0, clawedBackCount: 0, errors: 0 });
+    expect(commission.applyClawbackForContract).not.toHaveBeenCalled();
+  });
+
+  it('queries only DEFAULT + CLOSED_BAD_DEBT contracts with unclawed commissions', async () => {
+    prisma.contract.findMany.mockResolvedValue([]);
+    await cron.runDailyClawback();
+    const call = prisma.contract.findMany.mock.calls[0][0];
+    expect(call.where.status).toEqual({ in: ['DEFAULT', 'CLOSED_BAD_DEBT'] });
+    expect(call.where.commissions).toEqual({
+      some: {
+        deletedAt: null,
+        status: { in: ['APPROVED', 'PAID'] },
+        clawbackAt: null,
+      },
+    });
+    expect(call.where.deletedAt).toBe(null);
+  });
+
+  it('counts PAID payments per contract and passes to applyClawbackForContract', async () => {
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 'c1', contractNumber: 'HP-0001', status: 'DEFAULT' },
+    ]);
+    prisma.payment.count.mockResolvedValue(3);
+    commission.applyClawbackForContract.mockResolvedValue({
+      clawedBackCount: 2,
+      totalAmount: '1500.00',
+      percent: 75,
+    });
+
+    const result = await cron.runDailyClawback();
+
+    expect(prisma.payment.count).toHaveBeenCalledWith({
+      where: { contractId: 'c1', status: 'PAID', deletedAt: null },
+    });
+    expect(commission.applyClawbackForContract).toHaveBeenCalledWith(
+      'c1',
+      3,
+      expect.stringContaining('DEFAULT'),
+    );
+    expect(result.processed).toBe(1);
+    expect(result.clawedBackCount).toBe(2);
+  });
+
+  it('sums clawedBackCount across multiple contracts', async () => {
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 'c1', contractNumber: 'HP-0001', status: 'DEFAULT' },
+      { id: 'c2', contractNumber: 'HP-0002', status: 'CLOSED_BAD_DEBT' },
+    ]);
+    prisma.payment.count.mockResolvedValueOnce(1).mockResolvedValueOnce(12);
+    commission.applyClawbackForContract
+      .mockResolvedValueOnce({ clawedBackCount: 1, totalAmount: '1000', percent: 100 })
+      .mockResolvedValueOnce({ clawedBackCount: 3, totalAmount: '750', percent: 25 });
+
+    const result = await cron.runDailyClawback();
+    expect(result.processed).toBe(2);
+    expect(result.clawedBackCount).toBe(4);
+    expect(result.errors).toBe(0);
+  });
+
+  it('continues processing remaining contracts when one throws + Sentry captures', async () => {
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 'c1', contractNumber: 'HP-BAD', status: 'DEFAULT' },
+      { id: 'c2', contractNumber: 'HP-OK', status: 'DEFAULT' },
+    ]);
+    prisma.payment.count.mockResolvedValue(5);
+    commission.applyClawbackForContract
+      .mockRejectedValueOnce(new Error('tx deadlock'))
+      .mockResolvedValueOnce({ clawedBackCount: 2, totalAmount: '500', percent: 50 });
+
+    const result = await cron.runDailyClawback();
+    expect(result.processed).toBe(1);
+    expect(result.clawedBackCount).toBe(2);
+    expect(result.errors).toBe(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ contractNumber: 'HP-BAD' }),
+      }),
+    );
+  });
+
+  it('uses idempotency via applyClawbackForContract (returns 0 on already-clawed)', async () => {
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 'c1', contractNumber: 'HP-0001', status: 'DEFAULT' },
+    ]);
+    prisma.payment.count.mockResolvedValue(4);
+    commission.applyClawbackForContract.mockResolvedValue({
+      clawedBackCount: 0,
+      totalAmount: '0',
+      percent: 50,
+    });
+
+    const result = await cron.runDailyClawback();
+    expect(result.processed).toBe(1);
+    expect(result.clawedBackCount).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it('caps batch at 500 contracts (safety limit)', async () => {
+    prisma.contract.findMany.mockResolvedValue([]);
+    await cron.runDailyClawback();
+    const call = prisma.contract.findMany.mock.calls[0][0];
+    expect(call.take).toBe(500);
+  });
+
+  it('swallows top-level DB failure + Sentry capture (cron never throws)', async () => {
+    prisma.contract.findMany.mockRejectedValue(new Error('db down'));
+    const result = await cron.runDailyClawback();
+    expect(result).toEqual({ processed: 0, clawedBackCount: 0, errors: 0 });
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ cron: 'commission-clawback' }),
+      }),
+    );
+  });
+
+  it('reason string includes triggering contract status (DEFAULT vs CLOSED_BAD_DEBT)', async () => {
+    prisma.contract.findMany.mockResolvedValue([
+      { id: 'c1', contractNumber: 'HP-1', status: 'CLOSED_BAD_DEBT' },
+    ]);
+    prisma.payment.count.mockResolvedValue(0);
+    commission.applyClawbackForContract.mockResolvedValue({
+      clawedBackCount: 1,
+      totalAmount: '1',
+      percent: 100,
+    });
+
+    await cron.runDailyClawback();
+    const [, , reason] = commission.applyClawbackForContract.mock.calls[0];
+    expect(reason).toContain('CLOSED_BAD_DEBT');
+  });
+});

--- a/apps/api/src/modules/commission/commission-clawback.cron.ts
+++ b/apps/api/src/modules/commission/commission-clawback.cron.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CommissionService } from './commission.service';
+
+/**
+ * Daily commission clawback cron (T1-C6).
+ *
+ * T2-C6 shipped the clawback *policy* (`applyClawbackForContract`) but nothing
+ * was wired to call it. This cron finds every DEFAULT / CLOSED_BAD_DEBT
+ * contract that still has APPROVED or PAID commissions with `clawbackAt IS
+ * NULL`, computes `monthsPaid` from the count of PAID payments, and invokes
+ * the clawback service.
+ *
+ * The service itself is idempotent (rows already clawed back are filtered out
+ * by the `clawbackAt: null` predicate). A second cron pass on the same contract
+ * is a no-op.
+ *
+ * Sentry capture on per-contract exception — we do NOT rethrow, so one broken
+ * contract does not stop the entire batch.
+ */
+@Injectable()
+export class CommissionClawbackCron {
+  private readonly logger = new Logger(CommissionClawbackCron.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly commission: CommissionService,
+  ) {}
+
+  /** Runs 02:00 Asia/Bangkok — after billing + before morning ops. */
+  @Cron('0 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async runDailyClawback(): Promise<{
+    processed: number;
+    clawedBackCount: number;
+    errors: number;
+  }> {
+    try {
+      const contracts = await this.prisma.contract.findMany({
+        where: {
+          deletedAt: null,
+          status: { in: ['DEFAULT', 'CLOSED_BAD_DEBT'] },
+          commissions: {
+            some: {
+              deletedAt: null,
+              status: { in: ['APPROVED', 'PAID'] },
+              clawbackAt: null,
+            },
+          },
+        },
+        select: { id: true, contractNumber: true, status: true },
+        take: 500, // safety cap; re-run tomorrow if backlog
+      });
+
+      if (contracts.length === 0) {
+        this.logger.log('Commission clawback: no eligible contracts');
+        return { processed: 0, clawedBackCount: 0, errors: 0 };
+      }
+
+      let processed = 0;
+      let clawedBackCount = 0;
+      let errors = 0;
+
+      for (const contract of contracts) {
+        try {
+          const monthsPaid = await this.prisma.payment.count({
+            where: {
+              contractId: contract.id,
+              status: 'PAID',
+              deletedAt: null,
+            },
+          });
+
+          const reason = `Auto-clawback on contract.status=${contract.status}`;
+          const result = await this.commission.applyClawbackForContract(
+            contract.id,
+            monthsPaid,
+            reason,
+          );
+          processed++;
+          clawedBackCount += result.clawedBackCount;
+
+          if (result.clawedBackCount > 0) {
+            this.logger.log(
+              `Clawback ${contract.contractNumber}: ${result.clawedBackCount} commissions, ${result.percent}%, ฿${result.totalAmount}`,
+            );
+          }
+        } catch (err) {
+          errors++;
+          this.logger.error(
+            `Clawback failed for ${contract.contractNumber}: ${err instanceof Error ? err.message : err}`,
+          );
+          Sentry.captureException(err, {
+            tags: {
+              kind: 'cron-job',
+              cron: 'commission-clawback',
+              contractNumber: contract.contractNumber,
+            },
+          });
+        }
+      }
+
+      this.logger.log(
+        `Clawback cron: processed ${processed}/${contracts.length} contracts, ${clawedBackCount} commissions clawed back, ${errors} errors`,
+      );
+      return { processed, clawedBackCount, errors };
+    } catch (err) {
+      this.logger.error(
+        `Clawback cron failed at top level: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'commission-clawback' },
+      });
+      return { processed: 0, clawedBackCount: 0, errors: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/commission/commission.module.ts
+++ b/apps/api/src/modules/commission/commission.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { CommissionController } from './commission.controller';
 import { CommissionService } from './commission.service';
+import { CommissionClawbackCron } from './commission-clawback.cron';
 
 @Module({
   controllers: [CommissionController],
-  providers: [CommissionService],
+  providers: [CommissionService, CommissionClawbackCron],
   exports: [CommissionService],
 })
 export class CommissionModule {}


### PR DESCRIPTION
## Summary
ปิด T1-C6 — ต่อท่อให้ \`applyClawbackForContract\` (T2-C6 ชิปไว้ตั้งแต่แรก) ทำงานจริงในแต่ละวัน

## Problem
T2-C6 ชิป clawback policy (5-tier % ตาม monthsPaid) + schema แล้ว แต่ไม่มี caller — คืออยู่ในโค้ดเฉยๆ unused. ผลคือ salesperson ยังได้ commission เต็มแม้สัญญา default ตั้งแต่ FPD

## Fix
\`CommissionClawbackCron\` รัน 02:00 Asia/Bangkok:
1. Query contracts status=DEFAULT|CLOSED_BAD_DEBT ที่มี commission APPROVED/PAID กับ \`clawbackAt IS NULL\`
2. Count PAID payments → monthsPaid
3. Call \`applyClawbackForContract(contractId, monthsPaid, reason)\` — service idempotent อยู่แล้ว
4. Sentry capture per contract error + top-level error, cron ไม่ throw

Cap ที่ 500 contracts per batch (safety). Backlog spill ทำต่อวันพรุ่งนี้ — ดู memory ถ้าเคยเจอ

## Test plan
- [x] +9 cases (cron spec) — empty/query shape/payment count/multi-contract/mid-batch error/idempotency/500 cap/DB failure/reason format
- [x] Type check pass
- [x] Full API suite 1201 tests pass

## Impact
เดิม: 100% commission ถูกเก็บหมดแม้ default → estimate leak 5-15% ของ total commission spend (ยังไม่มี baseline data) 
หลัง merge: อัตโนมัติคืน 100% (FPD) / 75% (2-3 เดือน) / 50% (4-6) / 25% (7-12) / 0% (>12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)