### PR TITLE
feat(bad-debt): BadDebtWriteOffAuditLog immutable audit (T1-C7)

### DIFF
--- a/apps/api/prisma/migrations/20260519000000_bad_debt_writeoff_audit_log/migration.sql
+++ b/apps/api/prisma/migrations/20260519000000_bad_debt_writeoff_audit_log/migration.sql
@@ -1,0 +1,52 @@
+-- T1-C7: Immutable audit trail for bad-debt write-offs.
+-- The global AuditInterceptor already logs write-offs but rotates on 180-day
+-- retention. Thai Revenue Code requires write-off evidence retained 7+ years.
+-- Dedicated table + BEFORE DELETE trigger = append-only forensic record.
+
+CREATE TABLE "bad_debt_write_off_audit_logs" (
+    "id" TEXT NOT NULL,
+    "contract_id" TEXT NOT NULL,
+    "contract_number" TEXT NOT NULL,
+    "outstanding_amount" DECIMAL(12,2) NOT NULL,
+    "provision_amount" DECIMAL(12,2) NOT NULL,
+    "written_off_by_id" TEXT NOT NULL,
+    "written_off_by_role" TEXT NOT NULL,
+    "approved_by_id" TEXT NOT NULL,
+    "approved_by_role" TEXT NOT NULL,
+    "notes" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "bad_debt_write_off_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "bad_debt_write_off_audit_logs_contract_id_idx" ON "bad_debt_write_off_audit_logs"("contract_id");
+CREATE INDEX "bad_debt_write_off_audit_logs_written_off_by_id_created_at_idx" ON "bad_debt_write_off_audit_logs"("written_off_by_id", "created_at");
+CREATE INDEX "bad_debt_write_off_audit_logs_approved_by_id_created_at_idx" ON "bad_debt_write_off_audit_logs"("approved_by_id", "created_at");
+CREATE INDEX "bad_debt_write_off_audit_logs_created_at_idx" ON "bad_debt_write_off_audit_logs"("created_at");
+
+ALTER TABLE "bad_debt_write_off_audit_logs"
+  ADD CONSTRAINT "bad_debt_write_off_audit_logs_contract_id_fkey"
+  FOREIGN KEY ("contract_id") REFERENCES "contracts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "bad_debt_write_off_audit_logs"
+  ADD CONSTRAINT "bad_debt_write_off_audit_logs_written_off_by_id_fkey"
+  FOREIGN KEY ("written_off_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "bad_debt_write_off_audit_logs"
+  ADD CONSTRAINT "bad_debt_write_off_audit_logs_approved_by_id_fkey"
+  FOREIGN KEY ("approved_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Block physical DELETE at the DB level. Matches the pattern used for
+-- audit_logs (see migration 20260520300000_audit_log_archive_immutable).
+-- Any code path (ORM, raw SQL, migration) that attempts DELETE will raise.
+CREATE OR REPLACE FUNCTION bad_debt_write_off_audit_logs_block_delete()
+  RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'DELETE forbidden on bad_debt_write_off_audit_logs — immutable audit trail (T1-C7)';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER bad_debt_write_off_audit_logs_no_delete
+  BEFORE DELETE ON "bad_debt_write_off_audit_logs"
+  FOR EACH ROW
+  EXECUTE FUNCTION bad_debt_write_off_audit_logs_block_delete();

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -455,6 +455,8 @@ model User {
   loginAudits            LoginAuditLog[]      @relation("LoginAudits")
   dataAuditAcknowledgements DataAuditLog[]    @relation("DataAuditAcknowledgedBy")
   warrantyAudits         WarrantyAuditLog[]   @relation("WarrantyAuditUser")
+  badDebtWriteOffsWritten  BadDebtWriteOffAuditLog[] @relation("BadDebtWriteOffWriter")
+  badDebtWriteOffsApproved BadDebtWriteOffAuditLog[] @relation("BadDebtWriteOffApprover")
   crmLeadAssignFromHistory CrmLeadAssignment[] @relation("CrmLeadAssignFrom")
   crmLeadAssignToHistory   CrmLeadAssignment[] @relation("CrmLeadAssignTo")
   crmLeadAssignChangedBy   CrmLeadAssignment[] @relation("CrmLeadAssignChangedBy")
@@ -682,6 +684,7 @@ model Contract {
   deviceReceivedAt DateTime? @map("device_received_at")
 
   warrantyAudits WarrantyAuditLog[] @relation("WarrantyAuditContract")
+  badDebtWriteOffAudits BadDebtWriteOffAuditLog[] @relation("BadDebtWriteOffContract")
 
   @@index([customerId])
   @@index([branchId])
@@ -3941,6 +3944,44 @@ model LoginAuditLog {
   @@index([success, createdAt])
   @@index([createdAt])
   @@map("login_audit_logs")
+}
+
+/// Immutable audit trail for every bad-debt write-off (T1-C7). The global
+/// AuditInterceptor already logs mutating requests, but that log rotates on a
+/// 180-day retention cron (T2-C13 — pending); by law (Thai Revenue Code)
+/// write-offs must be traceable for 7+ years. This dedicated table is
+/// append-only, trigger-protected against DELETE, and outlives interceptor
+/// rotation.
+///
+/// Written synchronously inside the writeOffBadDebt transaction so it can't
+/// be skipped by accident.
+///
+/// Immutable — updatedAt/deletedAt intentionally omitted (no row will ever
+/// be edited; delete blocked by BEFORE DELETE trigger — see migration).
+model BadDebtWriteOffAuditLog {
+  id                String   @id @default(uuid())
+  contractId        String   @map("contract_id")
+  contractNumber    String   @map("contract_number")
+  /// Total outstanding principal + unpaid late fees at write-off time
+  outstandingAmount Decimal  @map("outstanding_amount") @db.Decimal(12, 2)
+  /// Sum of ACTIVE BadDebtProvision rows already reserved before write-off
+  provisionAmount   Decimal  @map("provision_amount") @db.Decimal(12, 2)
+  writtenOffById    String   @map("written_off_by_id")
+  writtenOffByRole  String   @map("written_off_by_role")
+  approvedById      String   @map("approved_by_id")
+  approvedByRole    String   @map("approved_by_role")
+  notes             String?
+  createdAt         DateTime @default(now()) @map("created_at")
+
+  contract     Contract @relation("BadDebtWriteOffContract", fields: [contractId], references: [id], onDelete: Restrict)
+  writtenOffBy User     @relation("BadDebtWriteOffWriter", fields: [writtenOffById], references: [id], onDelete: Restrict)
+  approvedBy   User     @relation("BadDebtWriteOffApprover", fields: [approvedById], references: [id], onDelete: Restrict)
+
+  @@index([contractId])
+  @@index([writtenOffById, createdAt])
+  @@index([approvedById, createdAt])
+  @@index([createdAt])
+  @@map("bad_debt_write_off_audit_logs")
 }
 
 /// Append-only log of Claude API calls: one row per request. Used by the

--- a/apps/api/src/modules/accounting/bad-debt.service.spec.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.spec.ts
@@ -40,6 +40,9 @@ describe('BadDebtService', () => {
         updateMany: jest.fn().mockResolvedValue({ count: 0 }),
         createMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
+      badDebtWriteOffAuditLog: {
+        create: jest.fn().mockResolvedValue({ id: 'wo-audit-1' }),
+      },
       user: {
         findUnique: jest.fn().mockImplementation(({ where: { id } }) =>
           Promise.resolve({
@@ -467,6 +470,78 @@ describe('BadDebtService', () => {
       await expect(
         service.writeOffBadDebt('c1', 'bm-1', 'fm-1'),
       ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    // ── T1-C7: immutable write-off audit log ─────────────────────────────
+    describe('T1-C7: BadDebtWriteOffAuditLog', () => {
+      beforeEach(() => {
+        prisma.contract.findFirst.mockResolvedValue({
+          id: 'c1',
+          contractNumber: 'HP-001',
+          status: 'OVERDUE',
+        });
+        prisma.contract.update.mockResolvedValue({});
+        prisma.badDebtProvision.updateMany.mockResolvedValue({ count: 1 });
+        prisma.badDebtProvision.findMany.mockResolvedValue([]);
+        prisma.payment.findMany.mockResolvedValue(mkUnpaid(15_000));
+      });
+
+      it('writes an audit log row inside the same transaction as the write-off', async () => {
+        await service.writeOffBadDebt('c1', 'bm-1', 'fm-1', 'court order');
+        expect(prisma.badDebtWriteOffAuditLog.create).toHaveBeenCalledTimes(1);
+      });
+
+      it('snapshots contractNumber + writer/approver IDs + roles at write-off time', async () => {
+        await service.writeOffBadDebt('c1', 'bm-1', 'fm-1', 'court order');
+        const data = prisma.badDebtWriteOffAuditLog.create.mock.calls[0][0].data;
+        expect(data).toMatchObject({
+          contractId: 'c1',
+          contractNumber: 'HP-001',
+          writtenOffById: 'bm-1',
+          writtenOffByRole: 'BRANCH_MANAGER',
+          approvedById: 'fm-1',
+          approvedByRole: 'FINANCE_MANAGER',
+          notes: 'court order',
+        });
+      });
+
+      it('records outstandingAmount computed from unpaid payments', async () => {
+        prisma.payment.findMany.mockResolvedValue(mkUnpaid(25_000));
+        await service.writeOffBadDebt('c1', 'bm-1', 'fm-1');
+        const data = prisma.badDebtWriteOffAuditLog.create.mock.calls[0][0].data;
+        expect(Number(data.outstandingAmount)).toBe(25_000);
+      });
+
+      it('records provisionAmount from existing ACTIVE provisions', async () => {
+        prisma.badDebtProvision.findMany.mockResolvedValue([
+          { provisionAmount: new Prisma.Decimal(1_000) },
+          { provisionAmount: new Prisma.Decimal(500) },
+        ]);
+        await service.writeOffBadDebt('c1', 'bm-1', 'fm-1');
+        const data = prisma.badDebtWriteOffAuditLog.create.mock.calls[0][0].data;
+        expect(Number(data.provisionAmount)).toBe(1_500);
+      });
+
+      it('does not write audit log if tier rule rejects the write-off', async () => {
+        // 25k outstanding with BM-only approver → tier rule fails (needs FM+)
+        prisma.payment.findMany.mockResolvedValue(mkUnpaid(25_000));
+        await expect(
+          service.writeOffBadDebt('c1', 'bm-1', 'bm-2'),
+        ).rejects.toBeDefined();
+        expect(prisma.badDebtWriteOffAuditLog.create).not.toHaveBeenCalled();
+      });
+
+      it('does not write audit log if contract is already CLOSED_BAD_DEBT', async () => {
+        prisma.contract.findFirst.mockResolvedValue({
+          id: 'c1',
+          contractNumber: 'HP-001',
+          status: 'CLOSED_BAD_DEBT',
+        });
+        await expect(
+          service.writeOffBadDebt('c1', 'bm-1', 'fm-1'),
+        ).rejects.toBeDefined();
+        expect(prisma.badDebtWriteOffAuditLog.create).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/api/src/modules/accounting/bad-debt.service.ts
+++ b/apps/api/src/modules/accounting/bad-debt.service.ts
@@ -345,6 +345,23 @@ export class BadDebtService {
         createdById: approvedById,
       });
 
+      // T1-C7: Immutable audit log inside the same transaction. Captures
+      // both parties' roles at write-off time (role can change later, the
+      // snapshot cannot). Insertion failure = whole write-off rolls back.
+      await tx.badDebtWriteOffAuditLog.create({
+        data: {
+          contractId: contract.id,
+          contractNumber: contract.contractNumber,
+          outstandingAmount,
+          provisionAmount: existingProvisionAmount,
+          writtenOffById,
+          writtenOffByRole: writer.role,
+          approvedById,
+          approvedByRole: approver.role,
+          notes,
+        },
+      });
+
       return { contractId, status: 'CLOSED_BAD_DEBT', writtenOffAt: new Date() };
     });
   }


### PR DESCRIPTION
## Summary
ปิด T1-C7 — dedicated immutable audit table สำหรับ bad-debt write-offs

## Problem
Global AuditInterceptor log ทุก mutation แต่จะ rotate ที่ 180 วัน (T2-C13 pending). Thai Revenue Code ต้องการ evidence ของ bad-debt write-off ที่เก็บ 7+ ปี → interceptor rotation จะลบหลักฐานก่อนเวลาอันควร

## Fix
- **Model** \`BadDebtWriteOffAuditLog\`: contract+amounts+writer/approver ids & roles + notes + createdAt. ไม่มี updatedAt/deletedAt (immutable by design)
- **Migration**: BEFORE DELETE trigger raise exception — pattern เดียวกับ audit_logs (PR #524)
- **Service integration**: เขียน audit row ใน \`\$transaction\` เดียวกับ write-off — ถ้า audit insert fail → write-off ทั้งหมด rollback
- **Snapshot roles**: เก็บ role ณ ช่วง write-off (roles เปลี่ยนได้ หลัง แต่ record เปลี่ยนไม่ได้)

## Test plan
- [x] +6 cases T1-C7 describe block — audit row written, field snapshot, outstanding amount, provision sum, tier rule rejects no audit, already-closed contract no audit
- [x] Type check pass, Prisma generate pass
- [x] Full API suite passes

## Related
- Depends on schema change + migration — ใช้ \`prisma migrate deploy\` ใน CI ตามปกติ
- Future: T2-C13 (AuditLog main retention cron) ยังต้องทำ — doc-only table นี้ครอบคลุมกรณี bad-debt แต่ mutation อื่นๆ ยังอาศัย interceptor

🤖 Generated with [Claude Code](https://claude.com/claude-code)