### PR TITLE
feat(tier-8): T2-C10 + T2-C11 + T5-C14 governance gates

### DIFF
--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -268,6 +268,11 @@ export class AccountingController {
   @Post('periods/reopen')
   @Roles('OWNER')
   reopenPeriod(@Body() dto: CloseMonthDto) {
-    return this.monthlyCloseService.reopenPeriod(dto.companyId, dto.year, dto.month);
+    return this.monthlyCloseService.reopenPeriod(
+      dto.companyId,
+      dto.year,
+      dto.month,
+      dto.boardResolutionId,
+    );
   }
 }

--- a/apps/api/src/modules/accounting/dto/monthly-close.dto.ts
+++ b/apps/api/src/modules/accounting/dto/monthly-close.dto.ts
@@ -16,4 +16,14 @@ export class CloseMonthDto {
   @IsString()
   @IsOptional()
   notes?: string;
+
+  /**
+   * T2-C10 — Required only when reopening a CLOSED period that is older than
+   * 90 days. Pass the ID / reference number of the board resolution that
+   * authorises the retroactive reopen. Ignored for fresh (< 90 days) reopens
+   * and for OPEN/REVIEW transitions.
+   */
+  @IsString()
+  @IsOptional()
+  boardResolutionId?: string;
 }

--- a/apps/api/src/modules/accounting/monthly-close.service.spec.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { MonthlyCloseService } from './monthly-close.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
@@ -262,6 +262,87 @@ describe('MonthlyCloseService', () => {
 
       await expect(service.syncToPeak('company-1', 2025, 3)).rejects.toThrow(BadRequestException);
       expect(peakService.exportJournalEntries).not.toHaveBeenCalled();
+    });
+  });
+
+  // T2-C10 — reopenPeriod 90-day lock
+  describe('reopenPeriod — T2-C10 90-day lock', () => {
+    const base = {
+      id: 'period-reopen-1',
+      companyId: 'company-1',
+      year: 2025,
+      month: 2,
+      reviewStartedAt: null,
+      reviewStartedById: null,
+      peakSyncedAt: null,
+      peakSyncResult: null,
+      reportSnapshot: null,
+      auditIssues: null,
+      notes: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('allows reopen of a fresh CLOSED period (closedAt < 90 days ago)', async () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+      prisma.accountingPeriod.findUnique.mockResolvedValue({
+        ...base,
+        status: 'CLOSED',
+        closedAt: tenDaysAgo,
+        closedById: 'user-1',
+      });
+      prisma.accountingPeriod.update.mockResolvedValue({
+        ...base,
+        status: 'OPEN',
+        closedAt: null,
+        closedById: null,
+      });
+
+      const result = await service.reopenPeriod('company-1', 2025, 2);
+
+      expect(result.status).toBe('OPEN');
+      expect(prisma.accountingPeriod.update).toHaveBeenCalled();
+    });
+
+    it('blocks reopen of a stale CLOSED period (closedAt > 90 days ago) without boardResolutionId', async () => {
+      const hundredDaysAgo = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+      prisma.accountingPeriod.findUnique.mockResolvedValue({
+        ...base,
+        status: 'CLOSED',
+        closedAt: hundredDaysAgo,
+        closedById: 'user-1',
+      });
+
+      await expect(service.reopenPeriod('company-1', 2025, 2)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(prisma.accountingPeriod.update).not.toHaveBeenCalled();
+    });
+
+    it('allows reopen of a stale CLOSED period when boardResolutionId is supplied', async () => {
+      const hundredDaysAgo = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+      prisma.accountingPeriod.findUnique.mockResolvedValue({
+        ...base,
+        status: 'CLOSED',
+        closedAt: hundredDaysAgo,
+        closedById: 'user-1',
+      });
+      prisma.accountingPeriod.update.mockResolvedValue({
+        ...base,
+        status: 'OPEN',
+        closedAt: null,
+        closedById: null,
+      });
+
+      const result = await service.reopenPeriod(
+        'company-1',
+        2025,
+        2,
+        'BOARD-RES-2026-04-19',
+      );
+
+      expect(result.status).toBe('OPEN');
+      expect(prisma.accountingPeriod.update).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { Injectable, BadRequestException, ForbiddenException, Logger } from '@nestjs/common';
 import { AccountingPeriodStatus, Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -242,11 +242,19 @@ export class MonthlyCloseService {
   /**
    * Reopen a period — resets to OPEN.
    * Cannot reopen a SYNCED period (data already exported to PEAK).
+   *
+   * T2-C10 — 90-day lock:
+   *   A CLOSED period older than 90 days (measured from `closedAt`) may only
+   *   be reopened with an explicit `boardResolutionId` string. Without it the
+   *   operation throws ForbiddenException — requires Board approval because
+   *   a stale reopen can rewrite reported P&L / tax filings after the fact.
+   *   OWNER-only is already enforced at the controller level.
    */
   async reopenPeriod(
     companyId: string,
     year: number,
     month: number,
+    boardResolutionId?: string,
   ): Promise<PeriodStatusResult> {
     const existing = await this.prisma.accountingPeriod.findUnique({
       where: { companyId_year_month: { companyId, year, month } },
@@ -263,6 +271,19 @@ export class MonthlyCloseService {
       );
     }
 
+    // T2-C10 — 90-day lock on stale CLOSED periods
+    if (existing.status === 'CLOSED' && existing.closedAt) {
+      const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+      const isStale = existing.closedAt < ninetyDaysAgo;
+      const hasBoardResolution =
+        typeof boardResolutionId === 'string' && boardResolutionId.trim().length > 0;
+      if (isStale && !hasBoardResolution) {
+        throw new ForbiddenException(
+          'งวดนี้ถูกปิดเกิน 90 วัน จึงล็อกอัตโนมัติ ต้องใช้มติบอร์ด (boardResolutionId) เพื่อเปิดงวดใหม่',
+        );
+      }
+    }
+
     const period = await this.prisma.accountingPeriod.update({
       where: { companyId_year_month: { companyId, year, month } },
       data: {
@@ -276,7 +297,12 @@ export class MonthlyCloseService {
       },
     });
 
-    this.logger.log(`Period ${year}/${month} (company ${companyId}) reopened to OPEN.`);
+    const logSuffix = boardResolutionId
+      ? ` (boardResolutionId=${boardResolutionId})`
+      : '';
+    this.logger.log(
+      `Period ${year}/${month} (company ${companyId}) reopened to OPEN.${logSuffix}`,
+    );
 
     return period as PeriodStatusResult;
   }

--- a/apps/api/src/modules/inventory/dto/create-stock-adjustment.dto.ts
+++ b/apps/api/src/modules/inventory/dto/create-stock-adjustment.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsArray, IsIn, IsNotEmpty } from 'class-validator';
+import { IsString, IsOptional, IsArray, IsIn, IsNotEmpty, ArrayMinSize } from 'class-validator';
 
 export class CreateStockAdjustmentDto {
   @IsString()
@@ -12,9 +12,13 @@ export class CreateStockAdjustmentDto {
   @IsOptional()
   notes?: string;
 
+  // T5-C14 — DAMAGED requires at least one photo as evidence. Enforced in the
+  // service layer (after reason is known); DTO-level validator keeps the type
+  // `string[]` when present so empty arrays are still shaped correctly.
   @IsArray()
   @IsString({ each: true })
   @IsOptional()
+  @ArrayMinSize(0)
   photos?: string[];
 
   // T5-C3 — every stock adjustment requires a second-person approver.

--- a/apps/api/src/modules/inventory/stock-adjustments.service.spec.ts
+++ b/apps/api/src/modules/inventory/stock-adjustments.service.spec.ts
@@ -187,7 +187,12 @@ describe('StockAdjustmentsService.create — T5-C3 4-eyes', () => {
         deletedAt: null,
       });
       await service.create(
-        { ...baseDto, reason: 'DAMAGED', approverId: 'approver-bm' },
+        {
+          ...baseDto,
+          reason: 'DAMAGED',
+          approverId: 'approver-bm',
+          photos: ['s3://photos/evidence.jpg'],
+        },
         'user-1',
       );
       expect(prisma.product.update).toHaveBeenCalledWith(
@@ -195,6 +200,97 @@ describe('StockAdjustmentsService.create — T5-C3 4-eyes', () => {
           data: expect.objectContaining({
             status: 'DAMAGED',
             wasPreviouslyDamaged: true,
+          }),
+        }),
+      );
+    });
+  });
+
+  // T2-C11 — > 500K THB requires OWNER approver
+  describe('T2-C11: high-value adjustments require OWNER', () => {
+    it('allows BRANCH_MANAGER approver for adjustment ≤ 500K THB', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'IN_STOCK',
+        branchId: 'branch-1',
+        deletedAt: null,
+        costPrice: '450000.00',
+      });
+      await expect(
+        service.create({ ...baseDto, approverId: 'approver-bm' }, 'user-1'),
+      ).resolves.toBeDefined();
+      expect(prisma.stockAdjustment.create).toHaveBeenCalled();
+    });
+
+    it('rejects BRANCH_MANAGER approver when value > 500K THB', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'IN_STOCK',
+        branchId: 'branch-1',
+        deletedAt: null,
+        costPrice: '650000.00',
+      });
+      await expect(
+        service.create({ ...baseDto, approverId: 'approver-bm' }, 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.stockAdjustment.create).not.toHaveBeenCalled();
+    });
+
+    it('allows OWNER approver when value > 500K THB', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'IN_STOCK',
+        branchId: 'branch-1',
+        deletedAt: null,
+        costPrice: '650000.00',
+      });
+      await expect(
+        service.create({ ...baseDto, approverId: 'approver-owner' }, 'user-1'),
+      ).resolves.toBeDefined();
+      expect(prisma.stockAdjustment.create).toHaveBeenCalled();
+    });
+  });
+
+  // T5-C14 — DAMAGED requires photos
+  describe('T5-C14: DAMAGED photo gate', () => {
+    const damagedBase = {
+      productId: 'p1',
+      reason: 'DAMAGED' as const,
+      approverId: 'approver-bm',
+      notes: 'screen cracked',
+    };
+
+    it('rejects DAMAGED without photos', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'IN_STOCK',
+        branchId: 'branch-1',
+        deletedAt: null,
+        costPrice: '10000.00',
+      });
+      await expect(service.create(damagedBase, 'user-1')).rejects.toThrow(BadRequestException);
+      expect(prisma.stockAdjustment.create).not.toHaveBeenCalled();
+    });
+
+    it('accepts DAMAGED with non-empty photos array', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: 'p1',
+        status: 'IN_STOCK',
+        branchId: 'branch-1',
+        deletedAt: null,
+        costPrice: '10000.00',
+      });
+      await expect(
+        service.create(
+          { ...damagedBase, photos: ['s3://photos/damage-1.jpg'] },
+          'user-1',
+        ),
+      ).resolves.toBeDefined();
+      expect(prisma.stockAdjustment.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            reason: 'DAMAGED',
+            photos: ['s3://photos/damage-1.jpg'],
           }),
         }),
       );

--- a/apps/api/src/modules/inventory/stock-adjustments.service.ts
+++ b/apps/api/src/modules/inventory/stock-adjustments.service.ts
@@ -8,6 +8,11 @@ import { Prisma, StockAdjustmentReason } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateStockAdjustmentDto } from './dto/create-stock-adjustment.dto';
 
+// T2-C11 — stock adjustments whose product cost exceeds this threshold must
+// be approved by an OWNER. Managers (BRANCH_MANAGER / FINANCE_MANAGER) cannot
+// rubber-stamp a write-off of a flagship-tier device.
+const OWNER_ONLY_ADJUSTMENT_THRESHOLD_THB = 500_000;
+
 @Injectable()
 export class StockAdjustmentsService {
   constructor(private prisma: PrismaService) {}
@@ -34,6 +39,18 @@ export class StockAdjustmentsService {
       throw new ForbiddenException(
         `ผู้อนุมัติต้องเป็น ${approverAllowed.join(' / ')} (role ปัจจุบัน: ${approver.role})`,
       );
+    }
+
+    // T5-C14 — DAMAGED stock adjustments must carry at least one photo as
+    // evidence (paralleling the DEFECT exchange gate from T5-C10). The DTO
+    // lets `photos` be optional at the type level; enforce per-reason here.
+    if (dto.reason === 'DAMAGED') {
+      const photos = dto.photos ?? [];
+      if (!Array.isArray(photos) || photos.length === 0) {
+        throw new BadRequestException(
+          'การปรับสต๊อคเหตุผล DAMAGED ต้องแนบรูปภาพอย่างน้อย 1 รูปเป็นหลักฐาน',
+        );
+      }
     }
 
     return this.prisma.$transaction(async (tx) => {
@@ -77,6 +94,18 @@ export class StockAdjustmentsService {
         }
       }
 
+      // T2-C11 — high-value adjustments (> 500K THB cost) require OWNER.
+      // BRANCH_MANAGER / FINANCE_MANAGER approval is insufficient for flagship
+      // devices because the write-off blast-radius is too large for a mid-tier
+      // sign-off. Comparison uses Prisma.Decimal to avoid float drift.
+      const adjustmentValue = new Prisma.Decimal(product?.costPrice ?? 0);
+      const threshold = new Prisma.Decimal(OWNER_ONLY_ADJUSTMENT_THRESHOLD_THB);
+      if (adjustmentValue.greaterThan(threshold) && approver.role !== 'OWNER') {
+        throw new ForbiddenException(
+          'การปรับสต็อกเกิน 500,000 บาท ต้องได้รับอนุมัติจาก OWNER เท่านั้น',
+        );
+      }
+
       // Create adjustment record (with 4-eyes approver captured)
       const adjustment = await tx.stockAdjustment.create({
         data: {
@@ -85,7 +114,12 @@ export class StockAdjustmentsService {
           reason: dto.reason as StockAdjustmentReason,
           previousStatus: product.status,
           notes: dto.notes,
-          photos: dto.photos || [],
+          // T5-C14 — photos are write-once: captured at create time from the
+          // validated DTO and never mutated afterwards (no update route
+          // exists for stock adjustments; service deliberately has no
+          // update() method). Cloning the array prevents caller-side
+          // aliasing from altering the stored evidence set.
+          photos: [...(dto.photos ?? [])],
           adjustedById: userId,
           approvedById: dto.approverId,
           approvedAt: new Date(),


### PR DESCRIPTION
## Summary
3 tier-8 High-severity items bundled — ครอบคลุม accounting period lock + stock adjustment gates

### T2-C10 — Period reopen 90-day lock
- \`monthly-close.service.reopenPeriod()\` — ถ้า \`status=CLOSED && closedAt < now-90d\` throw ForbiddenException
- Override ได้ด้วย \`boardResolutionId\` parameter (optional) — เก็บใน log ไม่ใช่ persist ใน AccountingPeriod
- Rationale: 90 วัน ให้ปิดเร็วไว คอม reopen ได้ง่ายพอ; หลังนั้นต้อง board resolution

### T2-C11 — Stock adjustment OWNER gate > 500K
- \`stock-adjustments.service.ts\` — ถ้า total adjustment > 500,000 THB ต้อง OWNER เท่านั้นอนุมัติ (ไม่ใช่ BM/FM)
- ใช้ \`Prisma.Decimal\` เทียบให้ตรงกับ v4 hardening

### T5-C14 — DAMAGED photo gate + write-once immutability
- DTO: \`photos: string[]\` (ArrayMinSize(0) — DTO ไม่รู้ reason แต่ service enforce)
- Service: ถ้า \`reason=DAMAGED\` ต้องมี photos.length >= 1
- Structural immutability: ไม่มี update() method, controller ไม่ expose, photos array cloned เพื่อกัน caller mutation หลัง write

## Test plan
- [x] +8 unit tests (3 T2-C10 + 3 T2-C11 + 2 T5-C14)
- [x] monthly-close: 8→11 tests, stock-adjustments: 12→17 tests
- [x] \`./tools/check-types.sh api\` 0 errors
- [x] jest accounting + inventory: 163/163 pass across 8 suites

## Follow-ups
- \`boardResolutionId\` persistence — ถ้าต้องเก็บใน AccountingPeriod model ทำ migration แยก
- tier-8 master doc sync — update entries move to Completed (separate commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)