### PR TITLE
fix(tier-8): T7-C2 + T7-C3 password rate limit + health leak

### DIFF
--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -8,6 +8,8 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
 import { LoginAuditService } from './login-audit.service';
 
+const mockEmailSender = { sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined) };
+
 describe('AuthService', () => {
   let service: AuthService;
   let prisma: PrismaService;
@@ -30,6 +32,7 @@ describe('AuthService', () => {
   });
 
   beforeEach(async () => {
+    mockEmailSender.sendPasswordResetEmail.mockClear();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
@@ -47,6 +50,10 @@ describe('AuthService', () => {
               update: jest.fn().mockResolvedValue({}),
               updateMany: jest.fn().mockResolvedValue({ count: 1 }),
               deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+            },
+            passwordResetToken: {
+              create: jest.fn().mockResolvedValue({ id: 'prt-1' }),
+              updateMany: jest.fn().mockResolvedValue({ count: 0 }),
             },
             $transaction: jest.fn().mockImplementation((args) => {
               // Batch transaction: execute all promises in the array
@@ -78,9 +85,7 @@ describe('AuthService', () => {
         },
         {
           provide: EmailService,
-          useValue: {
-            sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
-          },
+          useValue: mockEmailSender,
         },
         {
           provide: LoginAuditService,
@@ -263,6 +268,58 @@ describe('AuthService', () => {
         where: { userId: 'user-123', isRevoked: false },
         data: { isRevoked: true, revokedAt: expect.any(Date) },
       });
+    });
+  });
+
+  describe('forgotPassword (T7-C2 per-email rate limit)', () => {
+    const existingUser = {
+      id: 'user-42',
+      name: 'User 42',
+      email: 'ratelimit@test.com',
+      isActive: true,
+      deletedAt: null,
+    };
+
+    it('sends email for the first 3 requests in the window', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(existingUser);
+
+      for (let i = 0; i < 3; i++) {
+        const res = await service.forgotPassword({ email: 'ratelimit@test.com' });
+        expect(res).toEqual({ message: expect.any(String) });
+      }
+
+      expect(mockEmailSender.sendPasswordResetEmail).toHaveBeenCalledTimes(3);
+    });
+
+    it('silently suppresses the 4th request within the window (still 200, no email)', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(existingUser);
+
+      // Burn through the 3 allowed requests
+      await service.forgotPassword({ email: 'ratelimit@test.com' });
+      await service.forgotPassword({ email: 'ratelimit@test.com' });
+      await service.forgotPassword({ email: 'ratelimit@test.com' });
+      expect(mockEmailSender.sendPasswordResetEmail).toHaveBeenCalledTimes(3);
+
+      // 4th hit: must still resolve with a generic success message
+      // (no exception — enumeration-resistance) but must NOT send email
+      const res = await service.forgotPassword({ email: 'ratelimit@test.com' });
+      expect(res).toEqual({ message: expect.any(String) });
+      expect(mockEmailSender.sendPasswordResetEmail).toHaveBeenCalledTimes(3);
+
+      // Must NOT create a DB token either — saves writes on abusive input
+      expect(prisma.passwordResetToken.create).toHaveBeenCalledTimes(3);
+    });
+
+    it('treats email as case-insensitive for the rate limit', async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(existingUser);
+
+      await service.forgotPassword({ email: 'Case@Test.Com' });
+      await service.forgotPassword({ email: 'case@test.com' });
+      await service.forgotPassword({ email: 'CASE@TEST.COM' });
+
+      // 4th should be suppressed regardless of casing
+      await service.forgotPassword({ email: 'case@test.com' });
+      expect(mockEmailSender.sendPasswordResetEmail).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -18,6 +18,17 @@ import { LoginAuditService, LoginFailureKind } from './login-audit.service';
 const LOCKOUT_THRESHOLD = 5; // failures before lock
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15 minutes
 
+// Password reset per-email rate limit (T7-C2).
+// Prevents an attacker from spamming 1000s of reset emails to a target inbox
+// and also reduces email-enumeration signal via bounce timing.
+// Kept lightweight (in-memory Map) because:
+//   - throttler is per-IP, not per-email
+//   - DB-backed counter = extra write on a public endpoint
+// Process-local is acceptable: attacker would still hit the per-IP throttle
+// on the controller, and bypassing both would need many IPs AND many replicas.
+const PASSWORD_RESET_MAX_PER_WINDOW = 3;
+const PASSWORD_RESET_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
 export interface AuthMeta {
   ipAddress?: string;
   userAgent?: string;
@@ -27,6 +38,13 @@ export interface AuthMeta {
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
 
+  /**
+   * Per-email password reset request timestamps (T7-C2).
+   * Map<lowercased email, number[] of request timestamps in ms>.
+   * Cleaned up lazily inside `isPasswordResetRateLimited`.
+   */
+  private readonly passwordResetAttempts = new Map<string, number[]>();
+
   constructor(
     private prisma: PrismaService,
     private jwtService: JwtService,
@@ -34,6 +52,37 @@ export class AuthService {
     private emailService: EmailService,
     private loginAudit: LoginAuditService,
   ) {}
+
+  /**
+   * T7-C2: Returns true if this email has exceeded the allowed number of
+   * password reset requests within the rolling window.
+   *
+   * Side-effect: records the new timestamp when under the limit. This means
+   * a single call both checks and increments — callers should invoke it
+   * exactly once per forgotPassword request.
+   *
+   * Intentionally silent (no exception). Caller returns the generic
+   * "if this email exists…" message to preserve enumeration resistance —
+   * an attacker must not be able to distinguish "rate-limited" from
+   * "email not on file" via response shape or status code.
+   */
+  private isPasswordResetRateLimited(email: string): boolean {
+    const key = email.toLowerCase();
+    const now = Date.now();
+    const cutoff = now - PASSWORD_RESET_WINDOW_MS;
+    const existing = this.passwordResetAttempts.get(key) ?? [];
+    const recent = existing.filter((t) => t > cutoff);
+
+    if (recent.length >= PASSWORD_RESET_MAX_PER_WINDOW) {
+      // Keep the trimmed list so stale entries don't grow unbounded.
+      this.passwordResetAttempts.set(key, recent);
+      return true;
+    }
+
+    recent.push(now);
+    this.passwordResetAttempts.set(key, recent);
+    return false;
+  }
 
   private async auditLogin(
     emailTried: string,
@@ -296,13 +345,23 @@ export class AuthService {
    * Always returns success to prevent email enumeration.
    */
   async forgotPassword(dto: ForgotPasswordDto): Promise<{ message: string }> {
+    // Always return success to prevent email enumeration attacks
+    const successMessage = 'หากอีเมลนี้มีอยู่ในระบบ คุณจะได้รับลิงก์รีเซ็ตรหัสผ่าน';
+
+    // T7-C2: Per-email rate limit (max 3 / hour). Silently suppress email send
+    // when exceeded — still return the generic success message so an attacker
+    // can't distinguish "rate-limited" from "no such account" via response.
+    if (this.isPasswordResetRateLimited(dto.email)) {
+      this.logger.warn(
+        `Password reset rate limit hit for email (hashed): ${this.hashToken(dto.email.toLowerCase()).slice(0, 12)}`,
+      );
+      return { message: successMessage };
+    }
+
     const user = await this.prisma.user.findUnique({
       where: { email: dto.email },
       select: { id: true, name: true, email: true, isActive: true, deletedAt: true },
     });
-
-    // Always return success to prevent email enumeration attacks
-    const successMessage = 'หากอีเมลนี้มีอยู่ในระบบ คุณจะได้รับลิงก์รีเซ็ตรหัสผ่าน';
 
     if (!user || user.deletedAt || !user.isActive) {
       return { message: successMessage };

--- a/apps/api/src/modules/health/health.controller.spec.ts
+++ b/apps/api/src/modules/health/health.controller.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('HealthController', () => {
+  let controller: HealthController;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let configGet: jest.Mock<any, any>;
+
+  beforeEach(async () => {
+    configGet = jest.fn((key: string) => {
+      // Simulate storage misconfiguration: all S3_* env vars missing
+      const missing = ['S3_ENDPOINT', 'S3_ACCESS_KEY', 'S3_SECRET_KEY', 'S3_BUCKET'];
+      if (missing.includes(key)) return undefined;
+      return 'configured';
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        {
+          provide: PrismaService,
+          useValue: {
+            // Simulate DB unreachable so that `checkDatabase` also exercises
+            // the error branch — both checks should emit generic messages.
+            $queryRaw: jest.fn().mockRejectedValue(
+              new Error('password authentication failed for user "postgres"'),
+            ),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: configGet },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  describe('GET /health/detailed (T7-C3: no env var leak)', () => {
+    // Regex of env-var prefixes commonly used across integrations. If any
+    // appears in the 503 body we have leaked integration topology.
+    const ENV_VAR_LEAK_REGEX = /\b(S3_|DB_|REDIS_|AI_|SMS_|LINE_|PAY_|SENTRY_|JWT_)/;
+
+    it('returns 503 with generic messages — no env var names in body', async () => {
+      let caught: HttpException | null = null;
+      try {
+        await controller.checkDetailed();
+      } catch (err) {
+        caught = err as HttpException;
+      }
+
+      expect(caught).toBeInstanceOf(HttpException);
+      expect(caught!.getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
+
+      const body = caught!.getResponse();
+      const serialized = JSON.stringify(body);
+
+      // Must NOT contain any env var names — `S3_ACCESS_KEY`, `DB_HOST`, etc.
+      expect(serialized).not.toMatch(ENV_VAR_LEAK_REGEX);
+
+      // Must also not surface the raw DB driver error ("password authentication…")
+      expect(serialized).not.toMatch(/password authentication failed/i);
+      expect(serialized).not.toMatch(/postgres/i);
+
+      // Sanity: generic messages still present for ops to recognize the failure
+      expect(serialized.toLowerCase()).toContain('storage misconfigured');
+      expect(serialized.toLowerCase()).toContain('database unavailable');
+    });
+  });
+});

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -4,9 +4,11 @@ import {
   HttpCode,
   HttpException,
   HttpStatus,
+  Logger,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import * as Sentry from '@sentry/nestjs';
 import { Public } from '../auth/decorators/public.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -37,13 +39,19 @@ interface DetailedHealthResponse extends PublicHealthResponse {
  * GET /api/health           — public liveness probe (minimal response so we
  *                             don't leak which backends are deployed or why a
  *                             check failed).
- * GET /api/health/detailed  — OWNER / FINANCE_MANAGER only. Returns per-check
- *                             messages (env var names, DB errors) that are
- *                             useful for ops but should not be public.
+ * GET /api/health/detailed  — OWNER / FINANCE_MANAGER only. Returns generic
+ *                             per-check messages (no env var names, no raw
+ *                             DB errors). Specific diagnostics — including
+ *                             the list of missing env vars — are forwarded
+ *                             to Sentry so ops can see them without leaking
+ *                             integration topology to authenticated users
+ *                             whose account might be compromised (T7-C3).
  */
 @ApiTags('Health')
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
@@ -102,9 +110,17 @@ export class HealthController {
       await this.prisma.$queryRaw`SELECT 1`;
       return { status: 'ok' };
     } catch (err) {
+      // Do not surface raw DB error to the client — it can reveal driver,
+      // schema, or network topology. Keep the message generic and forward
+      // specifics to Sentry + server logs for ops (T7-C3).
+      const detail = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Health: database check failed — ${detail}`);
+      Sentry.captureException(err instanceof Error ? err : new Error(detail), {
+        tags: { healthCheck: 'database' },
+      });
       return {
         status: 'error',
-        message: err instanceof Error ? err.message : 'database unreachable',
+        message: 'Database unavailable',
       };
     }
   }
@@ -113,9 +129,20 @@ export class HealthController {
     const required = ['S3_ENDPOINT', 'S3_ACCESS_KEY', 'S3_SECRET_KEY', 'S3_BUCKET'];
     const missing = required.filter((key) => !this.configService.get<string>(key));
     if (missing.length > 0) {
+      // Do NOT echo env var names in the HTTP response — this lets attackers
+      // map which integrations are deployed (S3 vs GCS, etc). Forward the
+      // specifics to Sentry + server logs for ops visibility only (T7-C3).
+      this.logger.error(
+        `Health: storage misconfigured — missing env vars: ${missing.join(', ')}`,
+      );
+      Sentry.captureMessage('Health: storage misconfigured', {
+        level: 'error',
+        tags: { healthCheck: 'storage' },
+        extra: { missingEnvVars: missing },
+      });
       return {
         status: 'error',
-        message: `missing env vars: ${missing.join(', ')}`,
+        message: 'Storage misconfigured',
       };
     }
     return { status: 'ok' };


### PR DESCRIPTION
## Summary
2 T7 security quick wins

### T7-C2 — Password reset per-email rate limit (3/hour)
- \`auth.service.isPasswordResetRateLimited()\` — in-memory \`Map<email, timestamps[]>\`
- Over-limit requests return generic success message (preserve enumeration resistance) — no email sent, no DB token
- In-memory vs DB: avoid write amplification on public endpoint; per-IP \`@Throttle 5/min\` ยังเป็น first line

### T7-C3 — /health/detailed env var name leak
- Replace \`"missing env vars: S3_ACCESS_KEY..."\` → \`"Storage misconfigured"\`, \`"Database unavailable"\`
- Specifics → Sentry.captureMessage / Logger.error for ops

## Test plan
- [x] +3 auth tests: first 3 send email, 4th suppressed, case-insensitive match
- [x] +1 health test: response body ไม่มี env var names (regex \`/S3_|DB_|REDIS_|AI_|SMS_|LINE_|PAY_|SENTRY_|JWT_/\`)
- [x] Full API: 1180/1180 pass, 89 suites
- [x] TypeScript API: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)