### PR TITLE
feat(tier-8): T4-C1 + T5-C2 + T5-C4 contract immutability

### DIFF
--- a/apps/api/src/modules/contracts/contracts.service.spec.ts
+++ b/apps/api/src/modules/contracts/contracts.service.spec.ts
@@ -705,4 +705,285 @@ describe('ContractsService', () => {
       expect(result).toEqual({ message: expect.stringContaining('soft delete') });
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // T5-C2 — softDelete immutability guard against drifted terminal statuses
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('T5-C2 — softDelete terminal-status immutability', () => {
+    const txAsArray = async (opsOrFn: unknown) => {
+      if (typeof opsOrFn === 'function') return (opsOrFn as (tx: unknown) => Promise<unknown>)(prisma);
+      return Promise.all(opsOrFn as Promise<unknown>[]);
+    };
+
+    it('DRAFT contract can still be soft-deleted (happy path)', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: 'DRAFT',
+        workflowStatus: 'CREATING',
+        signatures: [],
+      });
+      prisma.$transaction.mockImplementation(txAsArray);
+
+      const result = await service.softDelete('contract-1', 'user-1');
+      expect(result).toEqual({ message: expect.stringContaining('soft delete') });
+    });
+
+    it('ACTIVE contract is rejected with an immutability error (not the old generic error)', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: 'ACTIVE',
+        workflowStatus: 'APPROVED',
+        signatures: [],
+      });
+
+      await expect(service.softDelete('contract-1', 'user-1')).rejects.toThrow(
+        /สถานะ ACTIVE/,
+      );
+    });
+
+    it('CLOSED_BAD_DEBT contract is rejected even though workflow might still look CREATING', async () => {
+      // Edge case: status drifted to CLOSED_BAD_DEBT while workflow never
+      // updated — the explicit terminal-status guard catches this.
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: 'CLOSED_BAD_DEBT',
+        workflowStatus: 'CREATING',
+        signatures: [],
+      });
+
+      await expect(service.softDelete('contract-1', 'user-1')).rejects.toThrow(
+        /CLOSED_BAD_DEBT/,
+      );
+    });
+
+    it('DEFAULT contract is rejected with an immutability error', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: 'DEFAULT',
+        workflowStatus: 'APPROVED',
+        signatures: [],
+      });
+
+      await expect(service.softDelete('contract-1', 'user-1')).rejects.toThrow(
+        /สถานะ DEFAULT/,
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // T5-C4 — financial fields locked once any payment row exists (incl. PENDING)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('T5-C4 — update financials blocked when any payment rows exist', () => {
+    it('no payments yet → financial edit is allowed', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        salespersonId: 'user-1',
+        workflowStatus: 'CREATING',
+      });
+      prisma.user.findUnique.mockResolvedValue({ role: 'SALES' });
+
+      prisma.$transaction.mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txPrisma = {
+            ...prisma,
+            payment: {
+              // 1st call: existingPaymentCount, 2nd call: paidOrPartialCount, 3rd: overdueCount
+              count: jest.fn().mockResolvedValue(0),
+              updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+              createMany: jest.fn().mockResolvedValue({ count: 12 }),
+            },
+            contract: { update: jest.fn().mockResolvedValue({}) },
+          };
+          return fn(txPrisma);
+        },
+      );
+      prisma.contract.findUnique
+        .mockResolvedValueOnce({ ...mockContract, salespersonId: 'user-1', workflowStatus: 'CREATING' })
+        .mockResolvedValueOnce(mockContract);
+
+      await expect(
+        service.update('contract-1', { sellingPrice: 21000, downPayment: 3500, totalMonths: 12 }, 'user-1'),
+      ).resolves.toBeDefined();
+    });
+
+    it('one PENDING payment exists → changing sellingPrice is rejected', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        salespersonId: 'user-1',
+        workflowStatus: 'CREATING',
+      });
+      prisma.user.findUnique.mockResolvedValue({ role: 'SALES' });
+
+      prisma.$transaction.mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txPrisma = {
+            ...prisma,
+            payment: {
+              // existingPaymentCount: 1, paidOrPartialCount: 0
+              count: jest.fn()
+                .mockResolvedValueOnce(1)
+                .mockResolvedValueOnce(0),
+              updateMany: jest.fn(),
+              createMany: jest.fn(),
+            },
+            contract: { update: jest.fn().mockResolvedValue({}) },
+          };
+          return fn(txPrisma);
+        },
+      );
+
+      // sellingPrice=19000 → 15% min = 2850, existing downPayment=3000 satisfies the floor.
+      // This isolates the failure to the T5-C4 financial-change guard rather than
+      // the minDownPaymentPct validation.
+      await expect(
+        service.update('contract-1', { sellingPrice: 19000 }, 'user-1'),
+      ).rejects.toThrow(/ไม่สามารถแก้ไขเงื่อนไขทางการเงินได้/);
+    });
+
+    it('PENDING payment exists but only notes change → allowed', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        salespersonId: 'user-1',
+        workflowStatus: 'CREATING',
+      });
+      prisma.user.findUnique.mockResolvedValue({ role: 'SALES' });
+
+      prisma.$transaction.mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          const txPrisma = {
+            ...prisma,
+            payment: {
+              // existingPaymentCount: 1, paidOrPartialCount: 0 — no schedule recreation since existingPaymentCount>0
+              count: jest.fn()
+                .mockResolvedValueOnce(1)
+                .mockResolvedValueOnce(0),
+              updateMany: jest.fn(),
+              createMany: jest.fn(),
+            },
+            contract: { update: jest.fn().mockResolvedValue({}) },
+          };
+          return fn(txPrisma);
+        },
+      );
+      prisma.contract.findUnique
+        .mockResolvedValueOnce({ ...mockContract, salespersonId: 'user-1', workflowStatus: 'CREATING' })
+        .mockResolvedValueOnce(mockContract);
+
+      await expect(
+        service.update('contract-1', { notes: 'อัปเดตหมายเหตุ' }, 'user-1'),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // T4-C1 — salesperson reassignment guard
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('T4-C1 — updateSalesperson', () => {
+    beforeEach(() => {
+      prisma.auditLog = { create: jest.fn().mockResolvedValue({}) };
+      prisma.$transaction.mockImplementation(
+        async (fnOrArr: unknown) => {
+          if (typeof fnOrArr === 'function') return (fnOrArr as (tx: unknown) => Promise<unknown>)(prisma);
+          return Promise.all(fnOrArr as Promise<unknown>[]);
+        },
+      );
+      // user.findUnique is used both for the actor role check (update path) and
+      // new-salesperson lookup — return a generic active user by default.
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'user-new',
+        role: 'SALES',
+        deletedAt: null,
+      });
+    });
+
+    it('DRAFT contract → SALES user can reassign (no lock, still audit-logged)', async () => {
+      prisma.contract.findUnique
+        .mockResolvedValueOnce({
+          ...mockContract,
+          status: 'DRAFT',
+          workflowStatus: 'CREATING',
+          salespersonId: 'user-old',
+          signatures: [],
+        })
+        // second call: findOne() after update
+        .mockResolvedValueOnce({ ...mockContract, salespersonId: 'user-new' });
+
+      const result = await service.updateSalesperson('contract-1', 'user-new', {
+        id: 'manager-1',
+        role: 'BRANCH_MANAGER',
+      });
+
+      expect(result).toBeDefined();
+      expect(prisma.contract.update).toHaveBeenCalledWith({
+        where: { id: 'contract-1' },
+        data: { salespersonId: 'user-new' },
+      });
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'UPDATE_SALESPERSON',
+            entity: 'contract',
+            entityId: 'contract-1',
+          }),
+        }),
+      );
+    });
+
+    it('APPROVED contract + non-OWNER actor → ForbiddenException', async () => {
+      prisma.contract.findUnique.mockResolvedValueOnce({
+        ...mockContract,
+        status: 'ACTIVE',
+        workflowStatus: 'APPROVED',
+        salespersonId: 'user-old',
+        signatures: [],
+      });
+
+      await expect(
+        service.updateSalesperson('contract-1', 'user-new', {
+          id: 'manager-1',
+          role: 'BRANCH_MANAGER',
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(prisma.contract.update).not.toHaveBeenCalled();
+      expect(prisma.auditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('APPROVED contract + OWNER actor → allowed and audit entry records override', async () => {
+      prisma.contract.findUnique
+        .mockResolvedValueOnce({
+          ...mockContract,
+          status: 'ACTIVE',
+          workflowStatus: 'APPROVED',
+          salespersonId: 'user-old',
+          signatures: [{ id: 'sig-1' }],
+          contractNumber: 'BC-2026-001',
+        })
+        .mockResolvedValueOnce({ ...mockContract, salespersonId: 'user-new' });
+
+      const result = await service.updateSalesperson('contract-1', 'user-new', {
+        id: 'owner-1',
+        role: 'OWNER',
+      });
+
+      expect(result).toBeDefined();
+      expect(prisma.contract.update).toHaveBeenCalledWith({
+        where: { id: 'contract-1' },
+        data: { salespersonId: 'user-new' },
+      });
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'owner-1',
+            action: 'UPDATE_SALESPERSON',
+            newValue: expect.objectContaining({
+              overrideReason: 'OWNER_OVERRIDE_AFTER_LOCK',
+            }),
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -544,22 +544,33 @@ export class ContractsService {
 
     // Update contract + recreate payment schedule
     await this.prisma.$transaction(async (tx) => {
-      // Prevent schedule recalculation when any payments have been made
+      // T5-C4 — Any existing payment row (PAID/PARTIALLY_PAID/PENDING/OVERDUE)
+      // means the installment schedule is contractually locked in. Editing
+      // financial fields after that point would silently rewrite already-
+      // committed amounts/due-dates. Only non-financial fields (notes, etc.)
+      // remain mutable.
+      const existingPaymentCount = await tx.payment.count({
+        where: { contractId: id, deletedAt: null },
+      });
       const paidOrPartialCount = await tx.payment.count({
         where: { contractId: id, status: { in: ['PAID', 'PARTIALLY_PAID'] } },
       });
 
-      if (paidOrPartialCount > 0) {
-        // If payments exist, only allow updating notes/non-financial fields
+      if (existingPaymentCount > 0) {
+        const interestRateChanged =
+          dto.interestRate !== undefined &&
+          Number(dto.interestRate) !== Number(contract.interestRate);
         const financialsChanged =
           sellingPrice !== Number(contract.sellingPrice) ||
           downPayment !== Number(contract.downPayment) ||
-          totalMonths !== contract.totalMonths;
+          totalMonths !== contract.totalMonths ||
+          interestRateChanged;
 
         if (financialsChanged) {
           throw new BadRequestException(
-            'ไม่สามารถแก้ไขเงื่อนไขทางการเงินได้ เนื่องจากมีการชำระเงินแล้ว ' +
-            `(ชำระแล้ว ${paidOrPartialCount} งวด) กรุณาสร้างสัญญาใหม่แทน`,
+            'ไม่สามารถแก้ไขเงื่อนไขทางการเงินได้ เนื่องจากมีตารางผ่อนชำระแล้ว ' +
+            `(งวดทั้งหมด ${existingPaymentCount} งวด) ` +
+            'แก้ไขได้เฉพาะข้อมูลที่ไม่ใช่ตัวเงิน เช่น หมายเหตุ เท่านั้น กรุณาสร้างสัญญาใหม่แทน',
           );
         }
       }
@@ -579,8 +590,10 @@ export class ContractsService {
         },
       });
 
-      // Only recreate schedule if no payments have been made and none are overdue
-      if (paidOrPartialCount === 0) {
+      // Only recreate schedule if no payments have been made and none are overdue.
+      // T5-C4 — also skip recreation when no financial fields changed; there is
+      // no reason to wipe PENDING rows (and their IDs) if the math is identical.
+      if (paidOrPartialCount === 0 && existingPaymentCount === 0) {
         // Check for overdue payments — don't delete them as it would lose delinquency history
         const overdueCount = await tx.payment.count({
           where: { contractId: id, status: 'OVERDUE' },
@@ -611,12 +624,34 @@ export class ContractsService {
   async softDelete(id: string, userId: string) {
     const contract = await this.findOne(id);
 
-    // ห้ามลบสัญญาที่สถานะ ACTIVE ขึ้นไป (Immutable Contract)
-    if (!['DRAFT'].includes(contract.status) ||
+    // T5-C2 — Explicit terminal-status lockdown. Once a contract leaves DRAFT
+    // (activation, payoff, repossession, bad-debt close-out, etc.) it becomes
+    // a legal/financial record and MUST NOT be deletable — even if workflow
+    // drift left it in an unexpected state. Only DRAFT is mutable.
+    const immutableStatuses: string[] = [
+      'ACTIVE',
+      'OVERDUE',
+      'DEFAULT',
+      'EARLY_PAYOFF',
+      'COMPLETED',
+      'EXCHANGED',
+      'DEFECT_EXCHANGED',
+      'CLOSED_BAD_DEBT',
+    ];
+    if (immutableStatuses.includes(contract.status)) {
+      throw new BadRequestException(
+        `ไม่สามารถลบสัญญาที่อยู่ในสถานะ ${contract.status} ได้ — ` +
+        'สัญญาที่เปิดใช้งานหรือปิดรายการแล้วเป็นหลักฐานทางการเงินและทางกฎหมาย ห้ามลบเด็ดขาด',
+      );
+    }
+
+    // Beyond the terminal-status check, still require workflow to be
+    // CREATING/REJECTED (i.e. not already submitted/approved).
+    if (contract.status !== 'DRAFT' ||
         (contract.workflowStatus !== 'CREATING' && contract.workflowStatus !== 'REJECTED')) {
       throw new BadRequestException(
         'ลบได้เฉพาะสัญญาที่อยู่ในสถานะ DRAFT + กำลังสร้าง/ถูกปฏิเสธ เท่านั้น ' +
-        '(สัญญาที่ลงนามแล้วห้ามลบเด็ดขาด ใช้ soft delete เท่านั้น)'
+        '(สัญญาที่ลงนามแล้วห้ามลบเด็ดขาด ใช้ soft delete เท่านั้น)',
       );
     }
 
@@ -635,5 +670,105 @@ export class ContractsService {
     ]);
 
     return { message: 'ลบสัญญาเรียบร้อย (soft delete)' };
+  }
+
+  /**
+   * T4-C1 — Reassign salesperson after contract is created.
+   *
+   * Salesperson identity ties to commission payout and audit trail. Once a
+   * contract is APPROVED or has any `Signature` row, the salesperson
+   * attribution is effectively locked: changing it would rewrite a historical
+   * fact (who sold what, who gets the commission, whose signature witnessed
+   * the customer's). We therefore reject reassignment in those cases, with
+   * an OWNER-only override (logged to AuditLog, commission recalc must be
+   * scheduled separately).
+   *
+   * @param contractId      contract to update
+   * @param newSalespersonId  user id of the new salesperson
+   * @param actor           the user performing the change (with role)
+   */
+  async updateSalesperson(
+    contractId: string,
+    newSalespersonId: string,
+    actor: { id: string; role: string },
+  ) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+      include: { signatures: { select: { id: true } } },
+    });
+    if (!contract || contract.deletedAt) {
+      throw new NotFoundException('ไม่พบสัญญา');
+    }
+
+    // Verify the new salesperson exists and is active
+    const newSalesperson = await this.prisma.user.findUnique({
+      where: { id: newSalespersonId },
+      select: { id: true, role: true, deletedAt: true },
+    });
+    if (!newSalesperson || newSalesperson.deletedAt) {
+      throw new BadRequestException('ไม่พบพนักงานขายที่เลือก');
+    }
+
+    // No-op
+    if (contract.salespersonId === newSalespersonId) {
+      return { message: 'พนักงานขายเดิมอยู่แล้ว ไม่มีการเปลี่ยนแปลง', contractId };
+    }
+
+    const hasSignatures = (contract.signatures?.length ?? 0) > 0;
+    const isApproved = contract.workflowStatus === 'APPROVED';
+    const isLocked = isApproved || hasSignatures;
+
+    if (isLocked && actor.role !== 'OWNER') {
+      throw new ForbiddenException(
+        'ไม่สามารถเปลี่ยนพนักงานขายได้ เนื่องจากสัญญาถูกอนุมัติหรือลงนามแล้ว ' +
+        '(เฉพาะ OWNER เท่านั้นที่มีสิทธิ์แก้ไข)',
+      );
+    }
+
+    const previousSalespersonId = contract.salespersonId;
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.contract.update({
+        where: { id: contractId },
+        data: { salespersonId: newSalespersonId },
+      });
+
+      // Audit trail — required whenever a locked contract is overridden by OWNER,
+      // and cheap/useful even for the unlocked DRAFT path.
+      await tx.auditLog.create({
+        data: {
+          userId: actor.id,
+          action: 'UPDATE_SALESPERSON',
+          entity: 'contract',
+          entityId: contractId,
+          oldValue: { salespersonId: previousSalespersonId },
+          newValue: {
+            salespersonId: newSalespersonId,
+            overrideReason: isLocked ? 'OWNER_OVERRIDE_AFTER_LOCK' : 'PRE_APPROVAL_REASSIGN',
+            workflowStatus: contract.workflowStatus,
+            signatureCount: contract.signatures?.length ?? 0,
+          },
+        },
+      });
+    });
+
+    this.structuredLogger.log('contract.salesperson.reassigned', {
+      contractId,
+      contractNumber: contract.contractNumber,
+      previousSalespersonId,
+      newSalespersonId,
+      actorId: actor.id,
+      actorRole: actor.role,
+      wasLocked: isLocked,
+    });
+
+    // TODO(T4-C1): Commission recalculation is out of scope of this change.
+    // When a locked contract's salesperson is reassigned by OWNER, any
+    // already-posted commission attributions must be reversed on the
+    // previous salesperson and re-accrued to the new salesperson.
+    // Schedule this via CommissionService once the reconciliation flow is
+    // designed (see docs/ceo-review/tier-8-fraud-heatmap-master.md §T4-C1).
+
+    return this.findOne(contractId);
   }
 }


### PR DESCRIPTION
## Summary
3 items ที่ touch \`contracts.service.ts\` ทั้งหมด — bundle เพื่อกัน merge conflict

### T4-C1 — Salesperson reassign guard (NEW method)
- \`updateSalesperson(contractId, newSalespersonId, actor)\` — ไม่เคยมี method นี้ใน repo
- Verify salesperson active; no-op if unchanged
- Reject ForbiddenException ถ้า \`workflowStatus=APPROVED\` หรือมี Signature row แล้ว — **unless** actor.role=OWNER
- Write AuditLog (action=UPDATE_SALESPERSON) ใน \$transaction เดียวกับ contract update
- TODO: commission recalc out of scope

### T5-C2 — softDelete terminal-status lockdown
- Explicit reject list: ACTIVE / OVERDUE / DEFAULT / EARLY_PAYOFF / COMPLETED / EXCHANGED / DEFECT_EXCHANGED / CLOSED_BAD_DEBT
- ประเมินก่อน workflow check เดิม — status drift alone ก็ reject
- Thai error ระบุ status ที่ offending

### T5-C4 — Financial edits blocked when payments exist
- \`update()\` อ่าน \`existingPaymentCount\` (non-deleted payments) เพิ่มจาก \`paidOrPartialCount\`
- Block \`sellingPrice/downPayment/totalMonths/interestRate\` ถ้ามี payment row ใดๆ (รวม PENDING)
- Non-financial (notes/address) ยังแก้ได้
- Schedule recreation skip ถ้า \`existingPaymentCount > 0\` (กัน PENDING rows หาย)

## Test plan
- [x] +10 unit tests (4 T5-C2 + 3 T5-C4 + 3 T4-C1)
- [x] contracts.service.spec: 36 → 46 tests
- [x] TypeScript API: 0 errors
- [x] jest contracts: 159/159 pass, 6 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)