### PR TITLE
feat(tier-8): T6 webhook hardening batch (C10 + C12 + C13 + C14)

### DIFF
--- a/apps/api/src/modules/chat-adapters/facebook-webhook.controller.spec.ts
+++ b/apps/api/src/modules/chat-adapters/facebook-webhook.controller.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as Sentry from '@sentry/nestjs';
+import { InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { FacebookWebhookController } from './facebook-webhook.controller';
+import { MessageRouterService } from '../chat-engine/services/message-router.service';
+import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('FacebookWebhookController.handleWebhook — rawBody SLO alert (T6-C14)', () => {
+  let controller: FacebookWebhookController;
+  let anomaly: { record: jest.Mock };
+
+  beforeEach(async () => {
+    const router = { routeInbound: jest.fn() };
+    anomaly = { record: jest.fn().mockResolvedValue(undefined) };
+    const config = {
+      get: jest.fn((key: string) => {
+        if (key === 'FB_APP_SECRET') return 'secret';
+        if (key === 'FB_VERIFY_TOKEN') return 'verify-token';
+        return undefined;
+      }),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      controllers: [FacebookWebhookController],
+      providers: [
+        { provide: MessageRouterService, useValue: router },
+        { provide: ConfigService, useValue: config },
+        { provide: WebhookAnomalyService, useValue: anomaly },
+      ],
+    }).compile();
+
+    controller = mod.get(FacebookWebhookController);
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  it('captures Sentry message + writes anomaly + throws 500 when rawBody is missing', async () => {
+    const req = {
+      ip: '31.13.64.1',
+      headers: { 'user-agent': 'facebookexternalua/1.0' },
+      // rawBody intentionally undefined — simulates middleware ordering bug
+    } as unknown as import('express').Request;
+
+    await expect(
+      controller.handleWebhook(req, { object: 'page', entry: [] }, 'sha256=deadbeef'),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Facebook webhook rawBody capture failed',
+      { level: 'error' },
+    );
+    expect(anomaly.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'facebook',
+        reason: 'other',
+        ipAddress: '31.13.64.1',
+        meta: expect.objectContaining({ note: 'missing_raw_body' }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
+++ b/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
@@ -8,10 +8,12 @@ import {
   HttpCode,
   Logger,
   BadRequestException,
+  InternalServerErrorException,
   Req,
   Res,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import * as Sentry from '@sentry/nestjs';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 import { MessageRouterService } from '../chat-engine/services/message-router.service';
 import { InboundMessage } from '../chat-engine/interfaces/channel-adapter.interface';
@@ -85,8 +87,29 @@ export class FacebookWebhookController {
     @Body() body: any,
     @Headers('x-hub-signature-256') signature: string,
   ): Promise<string> {
-    // 1. Verify HMAC-SHA256 signature against raw request bytes
     const rawBody = (req as unknown as RawBodyRequest).rawBody;
+
+    // 0. SLO alert — rawBody missing means the json() verify callback in
+    // main.ts never fired for this request. That's a middleware ordering /
+    // body parser regression and every FB event would silently fail HMAC
+    // verification. Escalate to Sentry + force Facebook to retry (500)
+    // rather than silently 200-ing a broken request.
+    if (!rawBody) {
+      this.logger.error(
+        '[FB Webhook] rawBody missing — json() verify callback did not capture bytes. Middleware ordering bug?',
+      );
+      Sentry.captureMessage('Facebook webhook rawBody capture failed', { level: 'error' });
+      void this.anomaly.record({
+        provider: 'facebook',
+        reason: 'other',
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'] as string | undefined,
+        meta: { note: 'missing_raw_body' },
+      });
+      throw new InternalServerErrorException('Webhook body capture failed');
+    }
+
+    // 1. Verify HMAC-SHA256 signature against raw request bytes
     if (!this.verifySignature(rawBody, signature)) {
       this.logger.warn('[FB Webhook] Invalid signature — rejecting payload');
       void this.anomaly.record({

--- a/apps/api/src/modules/integrations/integration-registry.spec.ts
+++ b/apps/api/src/modules/integrations/integration-registry.spec.ts
@@ -1,0 +1,34 @@
+import { INTEGRATIONS, getIntegrationDef } from './integration-registry';
+
+describe('integration-registry — MDM key rotation field (T6-C13)', () => {
+  it('defines the mdm integration', () => {
+    const mdm = getIntegrationDef('mdm');
+    expect(mdm).toBeDefined();
+    expect(mdm?.name).toBe('MDM PJ-Soft');
+  });
+
+  it('includes sensitive apiKeyPrevious field for zero-downtime rotation', () => {
+    const mdm = getIntegrationDef('mdm');
+    const prev = mdm?.fields.find((f) => f.key === 'apiKeyPrevious');
+    expect(prev).toBeDefined();
+    expect(prev?.sensitive).toBe(true);
+    expect(prev?.required).toBe(false);
+    expect(prev?.envVar).toBe('MDM_API_KEY_PREVIOUS');
+  });
+
+  it('keeps primary apiKey field untouched', () => {
+    const mdm = getIntegrationDef('mdm');
+    const primary = mdm?.fields.find((f) => f.key === 'apiKey');
+    expect(primary).toBeDefined();
+    expect(primary?.required).toBe(true);
+    expect(primary?.envVar).toBe('MDM_API_KEY');
+  });
+
+  it('has every sensitive field flagged correctly across the registry', () => {
+    // Sanity: registry entries must still have a key + at least one field
+    for (const def of INTEGRATIONS) {
+      expect(def.key).toBeTruthy();
+      expect(def.fields.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/api/src/modules/integrations/integration-registry.ts
+++ b/apps/api/src/modules/integrations/integration-registry.ts
@@ -293,6 +293,13 @@ export const INTEGRATIONS: IntegrationDef[] = [
         envVar: 'MDM_API_KEY',
       },
       {
+        key: 'apiKeyPrevious',
+        label: 'API Key (ก่อนหน้า) — ใช้ช่วง grace period หลัง rotate',
+        sensitive: true,
+        required: false,
+        envVar: 'MDM_API_KEY_PREVIOUS',
+      },
+      {
         key: 'baseUrl',
         label: 'Base URL',
         sensitive: false,

--- a/apps/api/src/modules/notifications/sms-webhook.controller.spec.ts
+++ b/apps/api/src/modules/notifications/sms-webhook.controller.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SmsWebhookController } from './sms-webhook.controller';
+import { NotificationsService } from './notifications.service';
+import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('SmsWebhookController — IP allow-list (T6-C10)', () => {
+  let controller: SmsWebhookController;
+  let notifications: { handleSmsDeliveryReport: jest.Mock };
+  let anomaly: { record: jest.Mock };
+  const originalEnv = process.env.SMS_WEBHOOK_ALLOWED_IPS;
+
+  const buildRes = () => {
+    const res: Record<string, jest.Mock> = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res as unknown as import('express').Response & { status: jest.Mock; json: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    notifications = { handleSmsDeliveryReport: jest.fn().mockResolvedValue({ ok: true }) };
+    anomaly = { record: jest.fn().mockResolvedValue(undefined) };
+    const mod: TestingModule = await Test.createTestingModule({
+      controllers: [SmsWebhookController],
+      providers: [
+        { provide: NotificationsService, useValue: notifications },
+        { provide: WebhookAnomalyService, useValue: anomaly },
+      ],
+    }).compile();
+    controller = mod.get(SmsWebhookController);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.SMS_WEBHOOK_ALLOWED_IPS;
+    else process.env.SMS_WEBHOOK_ALLOWED_IPS = originalEnv;
+  });
+
+  it('allows request when IP is in SMS_WEBHOOK_ALLOWED_IPS', async () => {
+    process.env.SMS_WEBHOOK_ALLOWED_IPS = '203.0.113.10,203.0.113.11';
+    const req = { ip: '203.0.113.10', headers: { 'user-agent': 'thaibulksms/1.0' } } as unknown as import('express').Request;
+    const res = buildRes();
+
+    await controller.handleDeliveryReportPost({ refno: 'abc', status: 'DELIVERED' }, req, res);
+
+    expect(notifications.handleSmsDeliveryReport).toHaveBeenCalledWith({ refno: 'abc', status: 'DELIVERED' });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(anomaly.record).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 + writes WebhookAnomaly when IP is not allow-listed', async () => {
+    process.env.SMS_WEBHOOK_ALLOWED_IPS = '203.0.113.10';
+    const req = { ip: '198.51.100.99', headers: { 'user-agent': 'curl/7.0' } } as unknown as import('express').Request;
+    const res = buildRes();
+
+    await controller.handleDeliveryReportPost({ refno: 'abc' }, req, res);
+
+    expect(notifications.handleSmsDeliveryReport).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(anomaly.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'sms',
+        reason: 'other',
+        ipAddress: '198.51.100.99',
+        meta: expect.objectContaining({ note: 'ip_not_allowed', method: 'POST' }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/notifications/sms-webhook.controller.ts
+++ b/apps/api/src/modules/notifications/sms-webhook.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Post, Get, Body, Query, Logger } from '@nestjs/common';
+import { Controller, Post, Get, Body, Query, Logger, Req, Res, HttpCode } from '@nestjs/common';
+import type { Request, Response } from 'express';
 import * as Sentry from '@sentry/nestjs';
 import { ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 import { NotificationsService } from './notifications.service';
+import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
 
 /**
  * Public webhook endpoint for ThaiBulkSMS delivery reports (DLR).
@@ -13,46 +15,122 @@ import { NotificationsService } from './notifications.service';
  * Mitigations:
  *   1. Strict per-IP rate limit (60/min) to prevent log flooding by
  *      arbitrary attackers crafting fake DLRs.
- *   2. handleSmsDeliveryReport upstream is idempotent: it looks up
+ *   2. Optional IP allow-list via SMS_WEBHOOK_ALLOWED_IPS env var —
+ *      comma-separated list of provider IPs. When set, only those IPs
+ *      can POST/GET the webhook; all others get 403 + WebhookAnomaly row.
+ *      When empty (dev), everything is allowed but a warning is logged so
+ *      the operator knows the allow-list is missing.
+ *   3. handleSmsDeliveryReport upstream is idempotent: it looks up
  *      a real notification log row by externalId and only updates
  *      its status. Unknown IDs are ignored, so a fake DLR cannot
  *      create new state — only modify a row that already exists.
  *
  * If ThaiBulkSMS adds HMAC support in the future, replace the
- * Throttle with an HMAC verification guard.
+ * allow-list with an HMAC verification guard.
  */
 @ApiTags('Notifications')
 @Controller('notifications')
 export class SmsWebhookController {
   private readonly logger = new Logger(SmsWebhookController.name);
+  private loggedMissingAllowList = false;
 
-  constructor(private notificationsService: NotificationsService) {}
+  constructor(
+    private notificationsService: NotificationsService,
+    private anomaly: WebhookAnomalyService,
+  ) {}
+
+  /**
+   * Return the parsed list of allowed IPs from env. Empty list means
+   * "allow all" (dev) — in that case we emit a one-time warning.
+   */
+  private getAllowedIps(): string[] {
+    const raw = process.env.SMS_WEBHOOK_ALLOWED_IPS ?? '';
+    return raw
+      .split(',')
+      .map((ip) => ip.trim())
+      .filter((ip) => ip.length > 0);
+  }
+
+  /**
+   * Decide whether the incoming request IP is allowed.
+   * Returns true if the env var is unset/empty (dev) OR the IP matches.
+   * Logs a one-time warning when the allow-list is missing.
+   */
+  private isIpAllowed(req: Request): boolean {
+    const allowed = this.getAllowedIps();
+    if (allowed.length === 0) {
+      if (!this.loggedMissingAllowList) {
+        this.logger.warn(
+          '[SMS-Webhook] SMS_WEBHOOK_ALLOWED_IPS is empty — allowing all IPs. Set this in production.',
+        );
+        this.loggedMissingAllowList = true;
+      }
+      return true;
+    }
+    const reqIp = req.ip ?? '';
+    return allowed.includes(reqIp);
+  }
+
+  /**
+   * Record anomaly + return a 403 response. Returns false so caller short-circuits.
+   */
+  private async denyIp(req: Request, res: Response, method: 'GET' | 'POST'): Promise<void> {
+    const reqIp = req.ip ?? 'unknown';
+    this.logger.warn(`[SMS-Webhook] Blocked IP ${reqIp} — not in SMS_WEBHOOK_ALLOWED_IPS (${method})`);
+    await this.anomaly.record({
+      provider: 'sms',
+      reason: 'other',
+      ipAddress: reqIp,
+      userAgent: req.headers['user-agent'] as string | undefined,
+      meta: { method, note: 'ip_not_allowed' },
+    });
+    res.status(403).json({ ok: false, error: 'ไม่อนุญาตให้เข้าถึง' });
+  }
 
   @Get('sms-webhook')
   @SkipCsrf()
   @Throttle({ default: { limit: 60, ttl: 60000 } })
-  async handleDeliveryReportGet(@Query() query: Record<string, unknown>) {
+  async handleDeliveryReportGet(
+    @Query() query: Record<string, unknown>,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    if (!this.isIpAllowed(req)) {
+      await this.denyIp(req, res, 'GET');
+      return;
+    }
     this.logger.log(`[SMS-Webhook] Delivery report received (GET)`);
     try {
-      return await this.notificationsService.handleSmsDeliveryReport(query);
+      const result = await this.notificationsService.handleSmsDeliveryReport(query);
+      res.status(200).json(result);
     } catch (err) {
       this.logger.error(`[SMS-Webhook] handler error: ${err instanceof Error ? err.message : err}`);
       Sentry.captureException(err, { tags: { module: 'sms-webhook', method: 'GET' } });
-      return { ok: false };
+      res.status(200).json({ ok: false });
     }
   }
 
   @Post('sms-webhook')
   @SkipCsrf()
+  @HttpCode(200)
   @Throttle({ default: { limit: 60, ttl: 60000 } })
-  async handleDeliveryReportPost(@Body() body: Record<string, unknown>) {
+  async handleDeliveryReportPost(
+    @Body() body: Record<string, unknown>,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    if (!this.isIpAllowed(req)) {
+      await this.denyIp(req, res, 'POST');
+      return;
+    }
     this.logger.log(`[SMS-Webhook] Delivery report received (POST)`);
     try {
-      return await this.notificationsService.handleSmsDeliveryReport(body);
+      const result = await this.notificationsService.handleSmsDeliveryReport(body);
+      res.status(200).json(result);
     } catch (err) {
       this.logger.error(`[SMS-Webhook] handler error: ${err instanceof Error ? err.message : err}`);
       Sentry.captureException(err, { tags: { module: 'sms-webhook', method: 'POST' } });
-      return { ok: false };
+      res.status(200).json({ ok: false });
     }
   }
 }

--- a/apps/api/src/modules/paysolutions/paysolutions.controller.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.controller.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createHmac } from 'crypto';
+import { PaySolutionsController } from './paysolutions.controller';
+import { PaySolutionsService } from './paysolutions.service';
+import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
+import { LiffTokenGuard } from '../line-oa/guards/liff-token.guard';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('PaySolutionsController.handleWebhook — HMAC (T6-C12)', () => {
+  let controller: PaySolutionsController;
+  let paySolutions: {
+    verifyWebhookMerchant: jest.Mock;
+    handlePaymentCallback: jest.Mock;
+  };
+  let anomaly: { record: jest.Mock };
+  const originalSecret = process.env.PAYSOLUTIONS_WEBHOOK_SECRET;
+
+  const buildReq = (rawBody: Buffer | undefined, ip = '203.0.113.5') => {
+    return {
+      ip,
+      rawBody,
+      headers: { 'user-agent': 'paysolutions-webhook/1.0' },
+    } as unknown as import('express').Request;
+  };
+
+  beforeEach(async () => {
+    paySolutions = {
+      verifyWebhookMerchant: jest.fn().mockResolvedValue(true),
+      handlePaymentCallback: jest.fn().mockResolvedValue(undefined),
+    };
+    anomaly = { record: jest.fn().mockResolvedValue(undefined) };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      controllers: [PaySolutionsController],
+      providers: [
+        { provide: PaySolutionsService, useValue: paySolutions },
+        { provide: WebhookAnomalyService, useValue: anomaly },
+      ],
+    })
+      .overrideGuard(LiffTokenGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = mod.get(PaySolutionsController);
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.PAYSOLUTIONS_WEBHOOK_SECRET;
+    else process.env.PAYSOLUTIONS_WEBHOOK_SECRET = originalSecret;
+  });
+
+  it('allows webhook when PAYSOLUTIONS_WEBHOOK_SECRET is not set (backward compat)', async () => {
+    delete process.env.PAYSOLUTIONS_WEBHOOK_SECRET;
+    const body = { merchantid: 'M123', refno: 'R1', result_code: '00' };
+    const req = buildReq(Buffer.from(JSON.stringify(body)));
+
+    const result = await controller.handleWebhook(body, req, undefined);
+
+    expect(paySolutions.handlePaymentCallback).toHaveBeenCalledWith(body);
+    expect(result).toEqual({ received: true, processed: true });
+    expect(anomaly.record).not.toHaveBeenCalled();
+  });
+
+  it('allows webhook when HMAC signature is correct', async () => {
+    process.env.PAYSOLUTIONS_WEBHOOK_SECRET = 's3cret-k3y';
+    const body = { merchantid: 'M123', refno: 'R1', result_code: '00' };
+    const rawBody = Buffer.from(JSON.stringify(body));
+    const signature = createHmac('sha256', 's3cret-k3y').update(rawBody).digest('hex');
+    const req = buildReq(rawBody);
+
+    const result = await controller.handleWebhook(body, req, signature);
+
+    expect(paySolutions.handlePaymentCallback).toHaveBeenCalledWith(body);
+    expect(result).toEqual({ received: true, processed: true });
+    expect(anomaly.record).not.toHaveBeenCalled();
+  });
+
+  it('rejects webhook + writes anomaly when HMAC signature mismatches', async () => {
+    process.env.PAYSOLUTIONS_WEBHOOK_SECRET = 's3cret-k3y';
+    const body = { merchantid: 'M123', refno: 'R1', result_code: '00' };
+    const rawBody = Buffer.from(JSON.stringify(body));
+    const badSig = createHmac('sha256', 'wrong-secret').update(rawBody).digest('hex');
+    const req = buildReq(rawBody);
+
+    const result = await controller.handleWebhook(body, req, badSig);
+
+    expect(result).toEqual({ received: true, processed: false });
+    expect(paySolutions.handlePaymentCallback).not.toHaveBeenCalled();
+    expect(anomaly.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'paysolutions',
+        reason: 'invalid_signature',
+        ipAddress: '203.0.113.5',
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/paysolutions/paysolutions.controller.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.controller.ts
@@ -9,16 +9,19 @@ import {
   BadRequestException,
   ParseUUIDPipe,
   Req,
+  Headers,
   UseGuards,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
+import { createHmac, timingSafeEqual } from 'crypto';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 import { PaySolutionsService } from './paysolutions.service';
 import { CreatePaymentIntentDto } from './dto';
 import { LiffTokenGuard } from '../line-oa/guards/liff-token.guard';
 import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
+import { RawBodyRequest } from '../../common/types/raw-body-request';
 
 /**
  * PaySolutions Payment Gateway Controller
@@ -74,12 +77,27 @@ export class PaySolutionsController {
   /**
    * POST /api/paysolutions/webhook
    * Webhook callback จาก Pay Solutions — ไม่มี auth guard
-   * Pay Solutions ส่ง form POST พร้อม parameters กลับมา ตรวจ merchantid แทน signature
+   *
+   * Defense-in-depth:
+   *   1. Throttle per merchantId (60/min) — prevents a single bad
+   *      merchant from drowning the endpoint
+   *   2. HMAC-SHA256 (optional) — if PAYSOLUTIONS_WEBHOOK_SECRET is set,
+   *      verify X-PaySolutions-Signature header using timingSafeEqual.
+   *      If not set, log a warning and fall through to merchantId check
+   *      (backward-compat with provider configs that haven't enabled
+   *      signing yet).
+   *   3. merchantId match — final gate; rejects webhooks with wrong
+   *      merchantId even when HMAC is off.
    */
   @Post('webhook')
   @SkipCsrf()
   @HttpCode(200)
-  async handleWebhook(@Body() body: Record<string, string>, @Req() req: Request) {
+  @Throttle({ default: { limit: 60, ttl: 60000 } })
+  async handleWebhook(
+    @Body() body: Record<string, string>,
+    @Req() req: Request,
+    @Headers('x-paysolutions-signature') signature: string | undefined,
+  ) {
     // PII-safe log: only fields needed to trace a webhook in support
     // tickets. Customer email/phone/name are NOT in the v2 webhook
     // payload but we still want a positive allow-list to prevent
@@ -93,11 +111,28 @@ export class PaySolutionsController {
     };
     this.logger.log(`Webhook received: ${JSON.stringify(safeFields)}`);
 
-    // NOTE: PaySolutions does not provide HMAC signature verification.
-    // merchantId match + HTTPS + throttle is the current defense-in-depth.
-    // If PaySolutions adds signing support in the future, implement it here.
+    // 1. HMAC-SHA256 verification (if secret configured)
+    const webhookSecret = process.env.PAYSOLUTIONS_WEBHOOK_SECRET;
+    if (webhookSecret) {
+      const rawBody = (req as unknown as RawBodyRequest).rawBody;
+      if (!this.verifyPaySolutionsSignature(rawBody, signature, webhookSecret)) {
+        this.logger.warn('[PaySolutions] HMAC signature mismatch — rejecting webhook');
+        void this.anomaly.record({
+          provider: 'paysolutions',
+          reason: signature ? 'invalid_signature' : 'missing_signature',
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'] as string | undefined,
+          meta: { refno: body.refno, order_no: body.order_no },
+        });
+        return { received: true, processed: false };
+      }
+    } else {
+      this.logger.warn(
+        '[PaySolutions] PAYSOLUTIONS_WEBHOOK_SECRET not set — skipping HMAC verification (backward compat)',
+      );
+    }
 
-    // Verify merchantid ตรงกับ config
+    // 2. Verify merchantid ตรงกับ config
     const isValid = await this.paySolutionsService.verifyWebhookMerchant(body.merchantid || '');
     if (!isValid) {
       this.logger.warn('Invalid webhook merchantid');
@@ -111,7 +146,7 @@ export class PaySolutionsController {
       return { received: true, processed: false };
     }
 
-    // Process payment callback
+    // 3. Process payment callback
     try {
       await this.paySolutionsService.handlePaymentCallback(body);
     } catch (error) {
@@ -120,6 +155,30 @@ export class PaySolutionsController {
     }
 
     return { received: true, processed: true };
+  }
+
+  /**
+   * Verify PaySolutions webhook HMAC-SHA256 signature using raw request bytes.
+   * PaySolutions' exact signing scheme is not published; we assume the common
+   * convention of HMAC-SHA256(rawBody, secret) returned as hex. The header
+   * may be prefixed with 'sha256=' — accept both shapes.
+   */
+  private verifyPaySolutionsSignature(
+    rawBody: Buffer | undefined,
+    signature: string | undefined,
+    secret: string,
+  ): boolean {
+    if (!rawBody || !signature) return false;
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+    const received = signature.startsWith('sha256=') ? signature.slice(7) : signature;
+    try {
+      const a = Buffer.from(expected, 'hex');
+      const b = Buffer.from(received, 'hex');
+      if (a.length !== b.length) return false;
+      return timingSafeEqual(a, b);
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/docs/guides/MDM-CREDENTIALS.md
+++ b/docs/guides/MDM-CREDENTIALS.md
@@ -1,0 +1,37 @@
+# MDM PJ-Soft Credentials Runbook
+
+ระบบเชื่อมกับ MDM PJ-Soft ผ่าน API Key สำหรับ remote lock/unlock เครื่องที่ขายผ่อน
+เอกสารนี้อธิบายวิธี rotate API key โดยไม่มี downtime.
+
+## Credential Fields
+
+| Integration key | Field key           | Env var                | ใช้เมื่อ                                 |
+|-----------------|---------------------|------------------------|------------------------------------------|
+| `mdm`           | `apiKey`            | `MDM_API_KEY`          | คีย์ใช้งานปัจจุบัน (primary)            |
+| `mdm`           | `apiKeyPrevious`    | `MDM_API_KEY_PREVIOUS` | คีย์เก่า — ใช้ fallback ช่วง grace period |
+| `mdm`           | `baseUrl`           | `MDM_BASE_URL`         | MDM API base URL (default mdm-th.com)    |
+
+ทั้ง `apiKey` และ `apiKeyPrevious` ถูก mark `sensitive: true` — UI จะ mask
+และ audit log จะไม่แสดงค่าจริง.
+
+## Rotation Flow (Zero-Downtime)
+
+**Goal**: rotate API key โดยที่ request ที่ลอยอยู่ใน flight ตอน rotate ไม่ล้มเหลว.
+
+1. **Generate new key** จาก MDM PJ-Soft dashboard (เก็บ old key ไว้ — อย่าเพิ่ง revoke).
+2. **Set previous-key slot**:
+   ```
+   MDM_API_KEY_PREVIOUS = <OLD_KEY>
+   MDM_API_KEY          = <NEW_KEY>
+   ```
+   Deploy ให้ env vars ทั้งสองตัวถูก apply พร้อมกัน.
+3. **Grace period 24 ชม.** — MDM service ลอง `apiKey` ก่อน, ถ้าได้ 401 จะ fallback เป็น `apiKeyPrevious`.
+   - ช่วงนี้ถ้า MDM provider cache คีย์เก่าอยู่ ระบบจะ degrade อย่างนุ่มนวลไม่ error ออกมา.
+4. **หลัง 24 ชม.** → revoke old key ที่ MDM dashboard + clear `MDM_API_KEY_PREVIOUS=''` (หรือลบ env var).
+5. **ตรวจสอบ log** — หาว่ามี fallback เกิดขึ้นกี่ครั้ง (grep `MDM fallback to previous key`). ถ้าเป็น 0 → rotation สำเร็จสะอาด.
+
+## Notes
+
+- PR ปัจจุบันเพิ่มแค่ **structural support** ใน registry (field `apiKeyPrevious`). Dual-key fallback logic ใน MDM service เป็นงานแยก (todo).
+- เมื่อ implement dual-key logic จริง ต้อง emit metric/log ทุกครั้งที่ fallback เกิดเพื่อ monitor grace period.
+- ห้าม commit API keys ลง git — set ผ่าน env var บน Cloud Run เท่านั้น.


### PR DESCRIPTION
## Summary
4 webhook security items bundle

### T6-C10 — SMS webhook IP allow-list
- Env \`SMS_WEBHOOK_ALLOWED_IPS\` (comma-separated)
- Empty = dev-permissive (warn once + allow all), set = reject non-matching with 403 + WebhookAnomaly
- Apply ทั้ง GET+POST, \`@Res()\` ให้ reject 403 ได้ภายใต้ \`@HttpCode(200)\` success path

### T6-C12 — PaySolutions HMAC verify
- HMAC-SHA256(rawBody, \`PAYSOLUTIONS_WEBHOOK_SECRET\`) เทียบกับ \`X-PaySolutions-Signature\` ด้วย \`timingSafeEqual\`
- Tolerate \`sha256=\` prefix
- ไม่มี secret → warn + fall through to merchantId check (backward compat)
- Mismatch → WebhookAnomaly (\`invalid_signature\` / \`missing_signature\`)
- \`@Throttle(60/60s)\` per-route

### T6-C13 — MDM API key versioning (structural)
- \`apiKeyPrevious\` optional field (\`sensitive: true\`, \`envVar: MDM_API_KEY_PREVIOUS\`) ใน integration registry
- \`docs/guides/MDM-CREDENTIALS.md\` — 5-step rotation runbook
- Dual-key fallback impl defer follow-up PR — structural only

### T6-C14 — Facebook rawBody SLO alert
- POST handler เริ่มด้วย check rawBody undefined → \`Sentry.captureMessage('Facebook webhook rawBody capture failed', error)\` + WebhookAnomaly + 500 InternalServerError
- FB จะ retry แทน silent 200 ตอน middleware order bug

## Test plan
- [x] +10 tests: 2 SMS + 3 PaySolutions + 4 registry + 1 Facebook
- [x] TypeScript API: 0 errors
- [x] jest affected modules: 17 tests / 6 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)