### PR TITLE
feat(tier-8): T4-C4 + T5-C12 + T5-C13 evidence + integrity

### DIFF
--- a/apps/api/prisma/migrations/20260525200000_product_imei_partial_unique/migration.sql
+++ b/apps/api/prisma/migrations/20260525200000_product_imei_partial_unique/migration.sql
@@ -1,0 +1,26 @@
+-- T5-C12: partial-unique IMEI constraint on products.
+--
+-- Before: `imei_serial` had a plain UNIQUE constraint, which meant a
+-- soft-deleted product permanently blocked the same IMEI from ever
+-- re-entering the system. This is wrong for trade-ins where the same
+-- physical phone legitimately comes back: write-off → customer brings in
+-- the same device months later → accept() needed to create a new Product
+-- row with the same IMEI.
+--
+-- After: the UNIQUE is enforced ONLY across active (non-soft-deleted)
+-- rows. Prisma cannot express partial unique indexes natively, so the
+-- constraint is maintained as a raw partial index. Prisma's
+-- `@unique` on the `imeiSerial` field is NOT removed from schema.prisma;
+-- that attribute keeps the generated TS type `imeiSerial?: string` but
+-- at the DB level the constraint is swapped for the partial index.
+--
+-- Service-layer uniqueness check in trade-in.service.ts accept() is
+-- updated in the same change to filter `deletedAt: null` — matching the
+-- DB behaviour.
+
+ALTER TABLE "products" DROP CONSTRAINT IF EXISTS "products_imei_serial_key";
+DROP INDEX IF EXISTS "products_imei_serial_key";
+
+CREATE UNIQUE INDEX "products_imei_serial_active_unique"
+  ON "products" ("imei_serial")
+  WHERE "deleted_at" IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -960,7 +960,14 @@ model Product {
   model              String
   color              String?
   storage            String?
-  imeiSerial         String?         @unique @map("imei_serial")
+  // T5-C12: uniqueness is enforced by a partial UNIQUE INDEX at the DB
+  // level (migration 20260525200000), not by Prisma `@unique`. Prisma
+  // cannot express `WHERE deleted_at IS NULL`, and keeping `@unique`
+  // here would make `prisma migrate dev` try to recreate a plain UNIQUE
+  // and clash with the partial index. The service layer in
+  // trade-in.service.ts `accept()` filters `deletedAt: null` when
+  // checking for collisions.
+  imeiSerial         String?         @map("imei_serial")
   serialNumber       String?         @map("serial_number")
   category           ProductCategory
   costPrice          Decimal         @map("cost_price") @db.Decimal(12, 2)

--- a/apps/api/src/modules/credit-check/credit-check.service.spec.ts
+++ b/apps/api/src/modules/credit-check/credit-check.service.spec.ts
@@ -27,6 +27,10 @@ describe('CreditCheckService override audit', () => {
         findUnique: jest.fn().mockResolvedValue(baseCheck),
         update: jest.fn((args) => Promise.resolve({ id: 'cc-1', ...args.data })),
       },
+      auditLog: {
+        create: jest.fn().mockResolvedValue({}),
+      },
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
     };
     integrationConfig = { getValue: jest.fn().mockResolvedValue(null) };
 
@@ -45,7 +49,7 @@ describe('CreditCheckService override audit', () => {
     await expect(
       service.override('con-missing', {
         status: 'APPROVED',
-        overrideReason: 'lorem ipsum valid',
+        overrideReason: 'lorem ipsum valid reason 30+ characters',
       }, 'u-1', 'OWNER'),
     ).rejects.toThrow(NotFoundException);
   });
@@ -104,7 +108,7 @@ describe('CreditCheckService override audit', () => {
     await expect(
       service.override('con-1', {
         status: 'APPROVED',
-        overrideReason: 'no-op change',
+        overrideReason: 'no-op change test 20+ characters',
       }, 'u-1', 'OWNER'),
     ).rejects.toThrow(BadRequestException);
   });
@@ -118,12 +122,108 @@ describe('CreditCheckService override audit', () => {
     });
     await service.override('con-1', {
       status: 'MANUAL_REVIEW',
-      overrideReason: 'reconsider on new info',
+      overrideReason: 'reconsider on new info from customer',
     }, 'u-owner', 'OWNER');
 
     const data = prisma.creditCheck.update.mock.calls[0][0].data;
     // Still REJECTED / 35 — we don't lose the AI's original verdict
     expect(data.originalStatus).toBe('REJECTED');
     expect(data.originalScore).toBe(35);
+  });
+
+  // ─── T4-C4: evidence gate on overrideById() ──────────────────────────────
+  describe('T4-C4 overrideById — evidence gate', () => {
+    const shortReason = 'too short'; // 9 chars
+    const validReason = 'customer produced additional salary slip evidence'; // > 20 chars
+
+    it('persists attachmentIds + reason in audit log on successful override', async () => {
+      prisma.creditCheck.findUnique.mockResolvedValue({
+        ...baseCheck,
+        id: 'cc-42',
+        status: 'MANUAL_REVIEW',
+      });
+
+      await service.overrideById(
+        'cc-42',
+        {
+          status: 'APPROVED',
+          overrideReason: validReason,
+          attachmentIds: ['att-1', 'att-2'],
+        },
+        'u-owner',
+        'OWNER',
+      );
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'CREDIT_CHECK_OVERRIDE',
+            entity: 'credit_check',
+            entityId: 'cc-42',
+            userId: 'u-owner',
+            newValue: expect.objectContaining({
+              overrideReason: validReason,
+              attachmentIds: ['att-1', 'att-2'],
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('allows empty attachmentIds (informational) but still writes audit log', async () => {
+      prisma.creditCheck.findUnique.mockResolvedValue({
+        ...baseCheck,
+        status: 'MANUAL_REVIEW',
+      });
+
+      await service.overrideById(
+        'cc-1',
+        {
+          status: 'APPROVED',
+          overrideReason: validReason,
+          attachmentIds: [],
+        },
+        'u-fm',
+        'FINANCE_MANAGER',
+      );
+
+      const audit = prisma.auditLog.create.mock.calls[0][0];
+      expect(audit.data.newValue.attachmentIds).toEqual([]);
+      expect(prisma.creditCheck.update).toHaveBeenCalled();
+    });
+
+    // Note: @MinLength(20) runs at the DTO-validation layer (ValidationPipe)
+    // before reaching the service. Service itself accepts short strings but
+    // the contract is enforced by class-validator — assert the decorator via
+    // metadata rather than calling the service with a short reason.
+    it('DTO rejects overrideReason with less than 20 chars via class-validator', async () => {
+      const { validate } = await import('class-validator');
+      const { OverrideCreditCheckDto } = await import('./dto/credit-check.dto');
+      const { plainToInstance } = await import('class-transformer');
+
+      const dto = plainToInstance(OverrideCreditCheckDto, {
+        status: 'APPROVED',
+        overrideReason: shortReason,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      const reasonError = errors.find((e) => e.property === 'overrideReason');
+      expect(reasonError).toBeDefined();
+      expect(JSON.stringify(reasonError?.constraints)).toContain('20 ตัวอักษร');
+    });
+
+    it('DTO accepts overrideReason >= 20 chars and attachmentIds array', async () => {
+      const { validate } = await import('class-validator');
+      const { OverrideCreditCheckDto } = await import('./dto/credit-check.dto');
+      const { plainToInstance } = await import('class-transformer');
+
+      const dto = plainToInstance(OverrideCreditCheckDto, {
+        status: 'APPROVED',
+        overrideReason: validReason,
+        attachmentIds: ['doc-123'],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
   });
 });

--- a/apps/api/src/modules/credit-check/credit-check.service.ts
+++ b/apps/api/src/modules/credit-check/credit-check.service.ts
@@ -226,26 +226,50 @@ export class CreditCheckService {
 
     this.enforceOverridePolicy(creditCheck.status, dto.status, userRole);
 
-    return this.prisma.creditCheck.update({
-      where: { id: creditCheckId },
-      data: {
-        status: dto.status as CreditCheckStatus,
-        reviewNotes: dto.reviewNotes,
-        checkedById: userId,
-        checkedAt: new Date(),
-        // Freeze the AI decision at the first override so future audits can
-        // compare final vs original. Don't overwrite on repeat overrides.
-        originalStatus: creditCheck.originalStatus ?? creditCheck.status,
-        originalScore: creditCheck.originalScore ?? creditCheck.aiScore,
-        overriddenAt: new Date(),
-        overriddenById: userId,
-        overrideReason: dto.overrideReason,
-      },
-      include: {
-        customer: { select: { id: true, name: true, phone: true, salary: true, occupation: true } },
-        checkedBy: { select: { id: true, name: true } },
-      },
-    });
+    // T4-C4: wrap update + audit-log write in one transaction so the
+    // evidence trail never drifts out of sync with the status change.
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.creditCheck.update({
+        where: { id: creditCheckId },
+        data: {
+          status: dto.status as CreditCheckStatus,
+          reviewNotes: dto.reviewNotes,
+          checkedById: userId,
+          checkedAt: new Date(),
+          // Freeze the AI decision at the first override so future audits can
+          // compare final vs original. Don't overwrite on repeat overrides.
+          originalStatus: creditCheck.originalStatus ?? creditCheck.status,
+          originalScore: creditCheck.originalScore ?? creditCheck.aiScore,
+          overriddenAt: new Date(),
+          overriddenById: userId,
+          overrideReason: dto.overrideReason,
+        },
+        include: {
+          customer: { select: { id: true, name: true, phone: true, salary: true, occupation: true } },
+          checkedBy: { select: { id: true, name: true } },
+        },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'CREDIT_CHECK_OVERRIDE',
+          entity: 'credit_check',
+          entityId: creditCheckId,
+          oldValue: {
+            status: creditCheck.status,
+            aiScore: creditCheck.aiScore,
+          },
+          newValue: {
+            status: dto.status,
+            overrideReason: dto.overrideReason,
+            attachmentIds: dto.attachmentIds ?? [],
+            userRole,
+          },
+        },
+      }),
+    ]);
+
+    return updated;
   }
 
   /**
@@ -399,24 +423,48 @@ export class CreditCheckService {
 
     this.enforceOverridePolicy(creditCheck.status, dto.status, userRole);
 
-    return this.prisma.creditCheck.update({
-      where: { contractId },
-      data: {
-        status: dto.status as CreditCheckStatus,
-        reviewNotes: dto.reviewNotes,
-        checkedById: userId,
-        checkedAt: new Date(),
-        originalStatus: creditCheck.originalStatus ?? creditCheck.status,
-        originalScore: creditCheck.originalScore ?? creditCheck.aiScore,
-        overriddenAt: new Date(),
-        overriddenById: userId,
-        overrideReason: dto.overrideReason,
-      },
-      include: {
-        customer: { select: { id: true, name: true, phone: true, salary: true, occupation: true } },
-        checkedBy: { select: { id: true, name: true } },
-      },
-    });
+    // T4-C4: atomic update + audit — same contract of evidence preservation
+    // as overrideById().
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.creditCheck.update({
+        where: { contractId },
+        data: {
+          status: dto.status as CreditCheckStatus,
+          reviewNotes: dto.reviewNotes,
+          checkedById: userId,
+          checkedAt: new Date(),
+          originalStatus: creditCheck.originalStatus ?? creditCheck.status,
+          originalScore: creditCheck.originalScore ?? creditCheck.aiScore,
+          overriddenAt: new Date(),
+          overriddenById: userId,
+          overrideReason: dto.overrideReason,
+        },
+        include: {
+          customer: { select: { id: true, name: true, phone: true, salary: true, occupation: true } },
+          checkedBy: { select: { id: true, name: true } },
+        },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'CREDIT_CHECK_OVERRIDE',
+          entity: 'credit_check',
+          entityId: creditCheck.id,
+          oldValue: {
+            status: creditCheck.status,
+            aiScore: creditCheck.aiScore,
+          },
+          newValue: {
+            status: dto.status,
+            overrideReason: dto.overrideReason,
+            attachmentIds: dto.attachmentIds ?? [],
+            userRole,
+          },
+        },
+      }),
+    ]);
+
+    return updated;
   }
 
   // === Customer History ===

--- a/apps/api/src/modules/credit-check/dto/credit-check.dto.ts
+++ b/apps/api/src/modules/credit-check/dto/credit-check.dto.ts
@@ -1,4 +1,14 @@
-import { IsString, IsOptional, IsArray, IsNumber, Matches, MaxLength, MinLength } from 'class-validator';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreateCreditCheckDto {
   @IsString()
@@ -16,13 +26,26 @@ export class CreateCreditCheckDto {
 
 export class OverrideCreditCheckDto {
   @IsString()
-  @Matches(/^(APPROVED|REJECTED|MANUAL_REVIEW)$/, { message: 'status ต้องเป็น APPROVED, REJECTED หรือ MANUAL_REVIEW' })
+  @Matches(/^(APPROVED|REJECTED|MANUAL_REVIEW)$/, {
+    message: 'status ต้องเป็น APPROVED, REJECTED หรือ MANUAL_REVIEW',
+  })
   status: string;
 
+  // T4-C4: evidence gate. Override ยกเลิกผล AI ต้องมีเหตุผลเชิงบรรยาย ≥ 20
+  // ตัวอักษร (ลดพื้นที่ของ "ok"/"approve" rubber-stamping) และแนบ attachmentIds
+  // (เอกสารที่อัปโหลดผ่านระบบ) เพื่อให้ตรวจย้อนหลังได้ นโยบายปัจจุบันยังยอม
+  // list ว่างได้ (informational) — deprecate เมื่อ business ตกลง mandate
   @IsString({ message: 'ต้องระบุเหตุผลการเปลี่ยนผลตรวจเครดิต' })
-  @MinLength(10, { message: 'เหตุผลต้องมีอย่างน้อย 10 ตัวอักษร' })
+  @IsNotEmpty({ message: 'ต้องระบุเหตุผลการเปลี่ยนผลตรวจเครดิต' })
+  @MinLength(20, { message: 'เหตุผลต้องมีอย่างน้อย 20 ตัวอักษร' })
   @MaxLength(2000, { message: 'เหตุผลต้องไม่เกิน 2000 ตัวอักษร' })
   overrideReason!: string;
+
+  @IsArray({ message: 'attachmentIds ต้องเป็น array' })
+  @ArrayMinSize(0)
+  @IsString({ each: true, message: 'attachmentIds ต้องเป็น array ของ string' })
+  @IsOptional()
+  attachmentIds?: string[];
 
   @IsString()
   @IsOptional()

--- a/apps/api/src/modules/trade-in/trade-in.service.spec.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.spec.ts
@@ -359,6 +359,56 @@ describe('TradeInService', () => {
         ),
       ).rejects.toThrow(BadRequestException);
     });
+
+    // ─── T5-C12: IMEI uniqueness ignores soft-deleted products ─────────────
+    describe('T5-C12 IMEI uniqueness — partial unique (deletedAt: null)', () => {
+      it('filters `deletedAt: null` in the uniqueness check (query shape)', async () => {
+        prisma.tradeIn.findUnique.mockResolvedValue(
+          makeTradeIn({ status: 'APPRAISED', imei: '123456789012345', offeredPrice: 5000 }),
+        );
+        prisma.product.findFirst.mockResolvedValue(null);
+        prisma.tradeIn.update.mockResolvedValue(makeTradeIn({ status: 'ACCEPTED' }));
+
+        await service.accept('ti-1', baseAcceptDto, 'user-1');
+
+        expect(prisma.product.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              imeiSerial: '123456789012345',
+              deletedAt: null,
+            }),
+          }),
+        );
+      });
+
+      it('rejects only when an ACTIVE product owns the IMEI', async () => {
+        prisma.tradeIn.findUnique.mockResolvedValue(
+          makeTradeIn({ status: 'APPRAISED', imei: '123456789012345', offeredPrice: 5000 }),
+        );
+        prisma.product.findFirst.mockResolvedValue({
+          id: 'prod-active',
+          name: 'iPhone 15 Pro',
+        });
+
+        await expect(
+          service.accept('ti-1', baseAcceptDto, 'user-1'),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('accepts when the only existing product owning the IMEI is soft-deleted (findFirst returns null)', async () => {
+        prisma.tradeIn.findUnique.mockResolvedValue(
+          makeTradeIn({ status: 'APPRAISED', imei: '123456789012345', offeredPrice: 5000 }),
+        );
+        // deletedAt: null filter means the soft-deleted row is invisible
+        prisma.product.findFirst.mockResolvedValue(null);
+        prisma.tradeIn.update.mockResolvedValue(makeTradeIn({ status: 'ACCEPTED' }));
+
+        await expect(
+          service.accept('ti-1', baseAcceptDto, 'user-1'),
+        ).resolves.toBeDefined();
+        expect(prisma.product.create).toHaveBeenCalled();
+      });
+    });
   });
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/apps/api/src/modules/trade-in/trade-in.service.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.ts
@@ -349,17 +349,17 @@ export class TradeInService {
         signatureBase64 = dto.sellerSignatureBase64;
       }
 
-      // IMEI uniqueness check — Product.imeiSerial เป็น @unique, ต้องไม่ชนกับสินค้าที่มีอยู่
-      // (รวม soft-deleted เพราะ DB constraint ไม่สนใจ deletedAt)
+      // T5-C12: IMEI uniqueness check — เฉพาะ active products (soft-deleted
+      // ถือว่าคืน IMEI กลับเข้า pool ได้) ตรงกับ partial unique index ใน DB
+      // (migration 20260525200000_product_imei_partial_unique).
       if (tradeIn.imei) {
         const existing = await tx.product.findFirst({
-          where: { imeiSerial: tradeIn.imei },
-          select: { id: true, name: true, deletedAt: true },
+          where: { imeiSerial: tradeIn.imei, deletedAt: null },
+          select: { id: true, name: true },
         });
         if (existing) {
-          const suffix = existing.deletedAt ? ' [ตัดจำหน่ายแล้ว]' : '';
           throw new BadRequestException(
-            `IMEI ${tradeIn.imei} มีอยู่ในระบบแล้ว: ${existing.name}${suffix}`,
+            `IMEI ${tradeIn.imei} มีอยู่ในระบบแล้ว: ${existing.name}`,
           );
         }
       }

--- a/apps/api/src/modules/warranty/warranty.service.spec.ts
+++ b/apps/api/src/modules/warranty/warranty.service.spec.ts
@@ -24,6 +24,7 @@ describe('WarrantyService.adjustShopWarranty', () => {
         update: jest.fn().mockResolvedValue({}),
       },
       warrantyAuditLog: { create: jest.fn().mockResolvedValue({}) },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
       $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
     };
 
@@ -64,10 +65,11 @@ describe('WarrantyService.adjustShopWarranty', () => {
     ).rejects.toThrow(ForbiddenException);
   });
 
-  it('BACKWARD allowed by OWNER — writes audit direction=BACKWARD', async () => {
+  it('BACKWARD allowed by OWNER — writes audit direction=BACKWARD (≤ 7 days, no co-approver needed)', async () => {
+    // Default mock: oldEnd = 2026-08-01. Shorten by 5 days = within single-approver threshold.
     await service.adjustShopWarranty(
       'c-1',
-      new Date('2026-07-01'),
+      new Date('2026-07-27'),
       'fix data-entry error from activation',
       'u-owner',
       'OWNER',
@@ -113,5 +115,100 @@ describe('WarrantyService.adjustShopWarranty', () => {
         'SALES',
       ),
     ).rejects.toThrow(ForbiddenException);
+  });
+
+  // ─── T5-C13: atomic audit + second approver on backward > 7 days ──────────
+  describe('T5-C13 — atomic audit + backward > 7 days co-approval', () => {
+    it('FORWARD one-person OK — update + single audit row inside one $transaction', async () => {
+      prisma.contract.findUnique.mockResolvedValue(contractWithWarranty(new Date('2026-08-01')));
+
+      await service.adjustShopWarranty(
+        'c-1',
+        new Date('2026-09-01'),
+        'extend warranty per customer agreement',
+        'u-bm',
+        'BRANCH_MANAGER',
+      );
+
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      // Transaction received an array of writes: contract.update + audit.create
+      const ops = prisma.$transaction.mock.calls[0][0];
+      expect(Array.isArray(ops)).toBe(true);
+      expect(prisma.warrantyAuditLog.create).toHaveBeenCalledTimes(1);
+      // No second-approver auditLog row needed
+      expect(prisma.auditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('BACKWARD ≤ 7 days one-person OK by OWNER — no second approver required', async () => {
+      // oldEnd = 2026-08-10, newEnd = 2026-08-05 → 5 days shortened
+      prisma.contract.findUnique.mockResolvedValue(contractWithWarranty(new Date('2026-08-10')));
+
+      await service.adjustShopWarranty(
+        'c-1',
+        new Date('2026-08-05'),
+        'customer swapped phones earlier than expected',
+        'u-owner',
+        'OWNER',
+      );
+
+      expect(prisma.warrantyAuditLog.create).toHaveBeenCalledTimes(1);
+      expect(prisma.auditLog.create).not.toHaveBeenCalled();
+      // audit row still gets direction=BACKWARD
+      const row = prisma.warrantyAuditLog.create.mock.calls[0][0];
+      expect(row.data.direction).toBe('BACKWARD');
+    });
+
+    it('BACKWARD > 7 days requires second approver — missing throws 400', async () => {
+      prisma.contract.findUnique.mockResolvedValue(contractWithWarranty(new Date('2026-08-30')));
+
+      await expect(
+        service.adjustShopWarranty(
+          'c-1',
+          new Date('2026-08-01'), // 29 days shortened
+          'major data-entry correction — reshipping warranty terms',
+          'u-owner',
+          'OWNER',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.warrantyAuditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('BACKWARD > 7 days with self-approval (same user) throws 400', async () => {
+      prisma.contract.findUnique.mockResolvedValue(contractWithWarranty(new Date('2026-08-30')));
+
+      await expect(
+        service.adjustShopWarranty(
+          'c-1',
+          new Date('2026-08-01'),
+          'ten-plus day correction — must have two-person signoff',
+          'u-owner',
+          'OWNER',
+          { secondApproverId: 'u-owner' },
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('BACKWARD > 7 days with different second approver writes co-approval audit row', async () => {
+      prisma.contract.findUnique.mockResolvedValue(contractWithWarranty(new Date('2026-08-30')));
+
+      await service.adjustShopWarranty(
+        'c-1',
+        new Date('2026-08-01'), // 29 days backward
+        'ten-plus day correction — two-person signoff required',
+        'u-owner',
+        'OWNER',
+        { secondApproverId: 'u-cfo' },
+      );
+
+      // Both writes inside ONE $transaction (atomicity)
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(prisma.warrantyAuditLog.create).toHaveBeenCalledTimes(1);
+      expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+
+      const coApproval = prisma.auditLog.create.mock.calls[0][0];
+      expect(coApproval.data.userId).toBe('u-cfo');
+      expect(coApproval.data.action).toBe('WARRANTY_BACKWARD_SECOND_APPROVAL');
+      expect(coApproval.data.newValue.primaryUserId).toBe('u-owner');
+    });
   });
 });

--- a/apps/api/src/modules/warranty/warranty.service.ts
+++ b/apps/api/src/modules/warranty/warranty.service.ts
@@ -132,15 +132,19 @@ export class WarrantyService {
   }
 
   /**
-   * Manual shop-warranty adjustment (T5-C6). The ONLY path allowed to mutate
-   * `shopWarrantyEndDate` after initial activation. Every call writes an
-   * immutable audit row.
+   * Manual shop-warranty adjustment (T5-C6 + T5-C13). The ONLY path allowed
+   * to mutate `shopWarrantyEndDate` after initial activation. Every call
+   * writes an immutable audit row in the SAME transaction as the update so
+   * an audit-write failure rolls back the mutation (T5-C13 atomicity).
    *
    * Policy:
    *   - reason is required (≥ 10 chars)
    *   - BACKWARD adjustment (newEnd < oldEnd) → OWNER only. This is the fraud
    *     vector: MANAGER shortens warranty so customer can't claim, then staff
    *     resells the faulty device.
+   *   - BACKWARD > 7 days → requires a SECOND approver (different user) —
+   *     two-person integrity check for material shortening of customer
+   *     coverage (T5-C13). Pass `secondApproverId` in the options arg.
    *   - FORWARD adjustment → OWNER / FINANCE_MANAGER / BRANCH_MANAGER
    */
   async adjustShopWarranty(
@@ -149,6 +153,7 @@ export class WarrantyService {
     reason: string,
     userId: string,
     userRole: string,
+    options?: { secondApproverId?: string },
   ): Promise<void> {
     if (!reason || reason.trim().length < 10) {
       throw new BadRequestException('ต้องระบุเหตุผลอย่างน้อย 10 ตัวอักษร');
@@ -180,6 +185,28 @@ export class WarrantyService {
       );
     }
 
+    // T5-C13: BACKWARD > 7 days needs a second approver (different user).
+    let secondApproverId: string | null = null;
+    if (isBackward && oldEnd) {
+      const daysShortened = Math.ceil(
+        (oldEnd.getTime() - newEndDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      if (daysShortened > 7) {
+        const approver = options?.secondApproverId?.trim();
+        if (!approver) {
+          throw new BadRequestException(
+            'การย่นวันสิ้นสุดประกันเกิน 7 วัน ต้องระบุผู้อนุมัติร่วม (second approver)',
+          );
+        }
+        if (approver === userId) {
+          throw new BadRequestException(
+            'ผู้อนุมัติร่วมต้องไม่ใช่ผู้ทำรายการคนเดียวกัน',
+          );
+        }
+        secondApproverId = approver;
+      }
+    }
+
     await this.prisma.$transaction([
       this.prisma.contract.update({
         where: { id: contractId },
@@ -195,10 +222,30 @@ export class WarrantyService {
           reason: reason.trim(),
         },
       }),
+      // T5-C13: second-approver trace on material shortening
+      ...(secondApproverId
+        ? [
+            this.prisma.auditLog.create({
+              data: {
+                userId: secondApproverId,
+                action: 'WARRANTY_BACKWARD_SECOND_APPROVAL',
+                entity: 'contract',
+                entityId: contractId,
+                oldValue: { shopWarrantyEndDate: oldEnd },
+                newValue: {
+                  shopWarrantyEndDate: newEndDate,
+                  reason: reason.trim(),
+                  primaryUserId: userId,
+                },
+              },
+            }),
+          ]
+        : []),
     ]);
 
     this.logger.log(
-      `Shop warranty adjusted for ${contractId}: ${direction} by ${userId}`,
+      `Shop warranty adjusted for ${contractId}: ${direction} by ${userId}` +
+        (secondApproverId ? ` (co-approved by ${secondApproverId})` : ''),
     );
   }
 


### PR DESCRIPTION
## Summary
3 items across credit-check / trade-in / warranty

### T4-C4 — Credit-check override evidence gate
- DTO: \`overrideReason\` += \`@IsNotEmpty + @MinLength(20)\` Thai message; \`attachmentIds: string[]\` with \`@ArrayMinSize(0)\` (policy informational)
- Service: \`override()\` + \`overrideById()\` wrap update + AuditLog ใน \`$transaction\` เดียว
- Audit captures old status/aiScore, new status, reason, attachmentIds, actor role (action=CREDIT_CHECK_OVERRIDE)

### T5-C12 — IMEI partial-unique index
- Migration: drop plain UNIQUE on \`products.imei_serial\` → install \`CREATE UNIQUE INDEX ... WHERE deleted_at IS NULL\`
- Schema: remove \`@unique\` from \`Product.imeiSerial\` (Prisma ไม่รองรับ partial; DB คือ source of truth)
- \`trade-in.service.accept()\` — IMEI check filters \`deletedAt: null\` ตรงกับ DB constraint

### T5-C13 — Warranty atomic audit + 2-person approval
- \`adjustShopWarranty\` signature += \`options?: { secondApproverId? }\`
- ถ้า BACKWARD > 7 days → ต้องมี \`secondApproverId\` (ต่างจาก \`userId\`)
- Contract update + warrantyAuditLog.create + co-approval AuditLog ทั้งหมดอยู่ใน \`prisma.$transaction\` เดียว — audit-write fail → rollback

## Test plan
- [x] +12 tests (4 credit-check + 3 trade-in + 5 warranty)
- [x] TypeScript API: 0 errors
- [x] Full API suite: 1188/1188 pass, 88 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)