### PR TITLE
feat(tier-8): T3 payment hygiene batch (C2+C3+C4+C5+C9)

### DIFF
--- a/apps/api/prisma/migrations/20260526000000_add_tier8_fraud_slip_waiver/migration.sql
+++ b/apps/api/prisma/migrations/20260526000000_add_tier8_fraud_slip_waiver/migration.sql
@@ -1,0 +1,41 @@
+-- Tier-8 fraud heatmap — T3 batch
+-- T3-C2: SlipFingerprint — cross-contract slip reuse detection.
+-- T3-C4: FeeWaiverApproval — immutable approval evidence for late-fee waivers.
+--
+-- Both tables are append-only (no updated_at / deleted_at). A slip
+-- fingerprint MUST NOT be mutated or erased, otherwise a fraudster could
+-- reuse a receipt across contracts and delete the evidence afterwards. The
+-- waiver approval row is the legal proof that a manager clicked "approve"
+-- at a specific moment from a specific IP — destroying it would leave no
+-- trace of the 4-eyes ceremony enforced in payments.service.waiveLateFee().
+
+-- ─── T3-C2: SlipFingerprint ─────────────────────────────────────────────
+CREATE TABLE "slip_fingerprints" (
+  "id"          TEXT        NOT NULL,
+  "hash"        TEXT        NOT NULL,
+  "contract_id" TEXT        NOT NULL,
+  "payment_id"  TEXT,
+  "created_at"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "slip_fingerprints_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "slip_fingerprints_hash_key"       ON "slip_fingerprints"("hash");
+CREATE INDEX        "slip_fingerprints_contract_id_idx" ON "slip_fingerprints"("contract_id");
+CREATE INDEX        "slip_fingerprints_created_at_idx"  ON "slip_fingerprints"("created_at");
+
+-- ─── T3-C4: FeeWaiverApproval ────────────────────────────────────────────
+CREATE TABLE "fee_waiver_approvals" (
+  "id"                TEXT        NOT NULL,
+  "waiver_payment_id" TEXT        NOT NULL,
+  "approver_id"       TEXT        NOT NULL,
+  "approved_at"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "ip_address"        TEXT,
+  "user_agent"        TEXT,
+
+  CONSTRAINT "fee_waiver_approvals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "fee_waiver_approvals_waiver_payment_id_idx" ON "fee_waiver_approvals"("waiver_payment_id");
+CREATE INDEX "fee_waiver_approvals_approver_id_idx"       ON "fee_waiver_approvals"("approver_id");
+CREATE INDEX "fee_waiver_approvals_approved_at_idx"       ON "fee_waiver_approvals"("approved_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2321,6 +2321,45 @@ model PaymentEvidence {
   @@map("payment_evidences")
 }
 
+/// T3-C2: Slip fingerprint for cross-contract reuse detection.
+/// Immutable by design — updatedAt/deletedAt intentionally omitted because
+/// a fingerprint is a hash-based evidence of a specific slip upload event.
+/// Rows are append-only: once a slip hash is recorded, it must NOT be
+/// mutated or soft-deleted (doing so would let a fraudster erase evidence
+/// that the same slip was already used on another contract). Retention of
+/// older rows is handled by a dedicated cron if needed.
+model SlipFingerprint {
+  id         String   @id @default(uuid())
+  hash       String   @unique // sha256(refNo|amount|bank|date) OR sha256(imageUrl)
+  contractId String   @map("contract_id")
+  paymentId  String?  @map("payment_id")
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@index([contractId])
+  @@index([createdAt])
+  @@map("slip_fingerprints")
+}
+
+/// T3-C4: Late fee waiver approval evidence.
+/// Immutable by design — updatedAt/deletedAt intentionally omitted because
+/// each row represents the *act* of approving a waiver at a specific moment.
+/// Deleting or mutating this record would destroy the audit trail proving
+/// who clicked "approve" and from which IP/user-agent. Retention handled by
+/// the existing AuditLog retention cron if ever needed.
+model FeeWaiverApproval {
+  id               String   @id @default(uuid())
+  waiverPaymentId  String   @map("waiver_payment_id")
+  approverId       String   @map("approver_id")
+  approvedAt       DateTime @default(now()) @map("approved_at")
+  ipAddress        String?  @map("ip_address")
+  userAgent        String?  @map("user_agent") @db.Text
+
+  @@index([waiverPaymentId])
+  @@index([approverId])
+  @@index([approvedAt])
+  @@map("fee_waiver_approvals")
+}
+
 // ============================================================
 // FINANCE RECEIVABLE (เงินรับจากไฟแนนซ์)
 // ============================================================

--- a/apps/api/src/modules/chatbot-finance/services/slip-processing.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/slip-processing.service.spec.ts
@@ -34,6 +34,13 @@ describe('SlipProcessingService', () => {
   };
 
   beforeEach(async () => {
+    // Build a Prisma mock where `$transaction(cb)` invokes cb with the
+    // same surface (paymentEvidence.create, slipFingerprint.createMany)
+    // that the service expects inside the tx.
+    const paymentEvidenceCreate = jest.fn().mockResolvedValue({ id: 'ev-1' });
+    const slipFingerprintCreateMany = jest.fn().mockResolvedValue({ count: 1 });
+    const slipFingerprintFindUnique = jest.fn().mockResolvedValue(null);
+
     prisma = {
       contract: {
         findFirst: jest.fn().mockResolvedValue(contract),
@@ -46,8 +53,18 @@ describe('SlipProcessingService', () => {
         }),
       },
       paymentEvidence: {
-        create: jest.fn().mockResolvedValue({ id: 'ev-1' }),
+        create: paymentEvidenceCreate,
       },
+      slipFingerprint: {
+        findUnique: slipFingerprintFindUnique,
+        createMany: slipFingerprintCreateMany,
+      },
+      $transaction: jest.fn((cb: (tx: unknown) => Promise<unknown>) =>
+        cb({
+          paymentEvidence: { create: paymentEvidenceCreate },
+          slipFingerprint: { createMany: slipFingerprintCreateMany },
+        }),
+      ),
     };
     storage = {
       upload: jest.fn().mockResolvedValue('https://s3/slip.jpg'),
@@ -255,6 +272,66 @@ describe('SlipProcessingService', () => {
 
       const createdPayload = prisma.paymentEvidence.create.mock.calls[0][0].data;
       expect(createdPayload.status).toBe('PENDING_REVIEW');
+    });
+  });
+
+  // T3-C2: The same slip (refNo + amount + bank + date) must never be used on
+  // two different contracts. Same-contract re-upload is still allowed because
+  // customers legitimately resubmit when they lose the ack message.
+  describe('cross-contract slip reuse (T3-C2)', () => {
+    beforeEach(() => {
+      vision.extractSlip.mockResolvedValue({
+        isSlip: true,
+        amount: 3500,
+        toAccount: '203-1-16520-5',
+        bankName: 'KBank',
+        date: '2026-04-19',
+        refNo: 'TXN-REUSED-001',
+        confidence: 0.95,
+      });
+    });
+
+    it('accepts first upload and records a fingerprint', async () => {
+      prisma.slipFingerprint.findUnique.mockResolvedValue(null);
+
+      const result = await service.processSlip(defaultParams);
+
+      expect(result.ok).toBe(true);
+      expect(prisma.slipFingerprint.createMany).toHaveBeenCalledTimes(1);
+      const payload = prisma.slipFingerprint.createMany.mock.calls[0][0];
+      expect(payload.data[0].contractId).toBe('con-1');
+      expect(typeof payload.data[0].hash).toBe('string');
+      expect(payload.data[0].hash.length).toBe(64); // sha256 hex
+      expect(payload.skipDuplicates).toBe(true);
+    });
+
+    it('allows re-upload on the SAME contract (idempotent)', async () => {
+      // Existing fingerprint was for the SAME contract — should NOT be treated as reuse.
+      prisma.slipFingerprint.findUnique.mockResolvedValue({
+        contractId: 'con-1',
+        createdAt: new Date(),
+      });
+
+      const result = await service.processSlip(defaultParams);
+
+      expect(result.ok).toBe(true);
+      // skipDuplicates prevents insert explosion on retry — call still fires
+      expect(prisma.slipFingerprint.createMany).toHaveBeenCalled();
+    });
+
+    it('rejects when same hash was used on a DIFFERENT contract within 30d', async () => {
+      prisma.slipFingerprint.findUnique.mockResolvedValue({
+        contractId: 'con-OTHER',
+        createdAt: new Date(),
+      });
+
+      const result = await service.processSlip(defaultParams);
+
+      expect(result.ok).toBe(false);
+      expect(result.reply).toContain('สลิปนี้ถูกใช้กับสัญญาอื่นแล้ว');
+      // Must NOT create evidence OR fingerprint on reuse rejection
+      expect(prisma.paymentEvidence.create).not.toHaveBeenCalled();
+      expect(prisma.slipFingerprint.createMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/modules/chatbot-finance/services/slip-processing.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/slip-processing.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import * as crypto from 'crypto';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { StorageService } from '../../storage/storage.service';
@@ -8,6 +9,15 @@ import { StaffNotificationService } from './staff-notification.service';
 import { FinanceConfigService } from './finance-config.service';
 
 const AMOUNT_TOLERANCE = 0.5; // ±0.50 บาท
+
+/**
+ * T3-C2: Look back this many days when checking whether a slip hash has
+ * already been used on a DIFFERENT contract. 30 days is long enough to catch
+ * "forward a friend's slip"-style reuse, short enough to survive legitimate
+ * re-uploads (e.g. customer uploads same slip to the chatbot twice after
+ * losing the success message).
+ */
+const SLIP_REUSE_LOOKBACK_DAYS = 30;
 
 /**
  * OCR confidence threshold for auto-approving a slip.
@@ -98,6 +108,35 @@ export class SlipProcessingService {
       };
     }
 
+    // 3.5 T3-C2: cross-contract slip reuse guard. Reject if the SAME slip
+    // (same OCR refNo+amount+bank+date, or same image URL when OCR can't
+    // identify it) has been used on a DIFFERENT contract within the last
+    // 30 days. Same-contract re-upload is still allowed (customers commonly
+    // resubmit when they don't see the ack reply).
+    const slipHash = this.computeSlipHash(extracted, imageUrl);
+    const reusedOn = await this.findRecentSlipReuse(slipHash, contract.id);
+    if (reusedOn) {
+      this.logger.warn(
+        `[Slip] Reuse detected: hash=${slipHash.slice(0, 12)}… prev contract=${reusedOn.contractId} current=${contract.id}`,
+      );
+      Sentry.captureMessage('slip_reuse_detected', {
+        level: 'warning',
+        tags: { module: 'chatbot-finance', action: 'slip_reuse' },
+        extra: {
+          hashPrefix: slipHash.slice(0, 12),
+          currentContractId: contract.id,
+          previousContractId: reusedOn.contractId,
+          previousSeenAt: reusedOn.createdAt,
+        },
+      });
+      return {
+        ok: false,
+        reply:
+          'สลิปนี้ถูกใช้กับสัญญาอื่นแล้วค่ะ 🙏\n' +
+          'กรุณาส่งสลิปใหม่ของงวดนี้ หรือติดต่อแอดมิน 063-134-6356 นะคะ',
+      };
+    }
+
     // 4. Match บัญชี (exact digits-only match against current SystemConfig)
     const wrongAccount =
       extracted.toAccount && !this.financeConfig.isCompanyBankAccount(extracted.toAccount);
@@ -108,6 +147,7 @@ export class SlipProcessingService {
         imageUrl,
         amount: extracted.amount,
         note: `โอนผิดบัญชี: ${extracted.toAccount}`,
+        slipHash,
       });
       // Notify staff (fire-and-forget with error capture)
       this.staffNotify.notifySlipReview({
@@ -171,6 +211,7 @@ export class SlipProcessingService {
       amount: slipAmount,
       note: this.buildExtractedNote(extracted, canAutoApprove),
       autoApprove: canAutoApprove,
+      slipHash,
     });
 
     // 7. Reply
@@ -253,19 +294,85 @@ export class SlipProcessingService {
     amount?: number;
     note: string;
     autoApprove?: boolean;
+    slipHash?: string;
   }) {
-    return this.prisma.paymentEvidence.create({
-      data: {
-        contractId: params.contractId,
-        paymentId: params.paymentId,
-        lineUserId: params.lineUserId,
-        imageUrl: params.imageUrl,
-        amount: params.amount,
-        status: params.autoApprove ? 'APPROVED' : 'PENDING_REVIEW',
-        reviewedById: params.autoApprove ? null : undefined,
-        reviewedAt: params.autoApprove ? new Date() : undefined,
-        reviewNote: params.note,
-      },
+    // Write PaymentEvidence + SlipFingerprint atomically. The fingerprint
+    // insert uses `createMany({ skipDuplicates: true })` so a same-contract
+    // re-upload (which we explicitly allow) doesn't blow up the unique hash
+    // constraint — it just no-ops the second fingerprint write.
+    return this.prisma.$transaction(async (tx) => {
+      const evidence = await tx.paymentEvidence.create({
+        data: {
+          contractId: params.contractId,
+          paymentId: params.paymentId,
+          lineUserId: params.lineUserId,
+          imageUrl: params.imageUrl,
+          amount: params.amount,
+          status: params.autoApprove ? 'APPROVED' : 'PENDING_REVIEW',
+          reviewedById: params.autoApprove ? null : undefined,
+          reviewedAt: params.autoApprove ? new Date() : undefined,
+          reviewNote: params.note,
+        },
+      });
+
+      if (params.slipHash) {
+        await tx.slipFingerprint.createMany({
+          data: [
+            {
+              hash: params.slipHash,
+              contractId: params.contractId,
+              paymentId: params.paymentId ?? null,
+            },
+          ],
+          skipDuplicates: true,
+        });
+      }
+
+      return evidence;
     });
+  }
+
+  /**
+   * T3-C2: Compute a stable fingerprint for a slip.
+   * Prefer OCR-derived fields (refNo + amount + bankName + date) since the
+   * same transfer from two phones produces two different image URLs but the
+   * same ref number. Fallback to hashing the image URL when OCR can't
+   * extract a ref — better than no fingerprint at all.
+   */
+  private computeSlipHash(extracted: SlipExtraction, imageUrl: string): string {
+    const hasher = crypto.createHash('sha256');
+    if (extracted.refNo) {
+      hasher.update(
+        [
+          extracted.refNo.trim(),
+          extracted.amount?.toFixed(2) ?? '',
+          (extracted.bankName ?? '').trim().toUpperCase(),
+          (extracted.date ?? '').trim(),
+        ].join('|'),
+      );
+    } else {
+      hasher.update(`url:${imageUrl}`);
+    }
+    return hasher.digest('hex');
+  }
+
+  /**
+   * T3-C2: Returns the previous fingerprint row if the same hash has been
+   * used on a DIFFERENT contract within the lookback window. Same-contract
+   * re-uploads are allowed (null returned). `null` also for "first seen".
+   */
+  private async findRecentSlipReuse(
+    hash: string,
+    currentContractId: string,
+  ): Promise<{ contractId: string; createdAt: Date } | null> {
+    const cutoff = new Date(Date.now() - SLIP_REUSE_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+    const existing = await this.prisma.slipFingerprint.findUnique({
+      where: { hash },
+      select: { contractId: true, createdAt: true },
+    });
+    if (!existing) return null;
+    if (existing.contractId === currentContractId) return null; // same-contract re-upload — OK
+    if (existing.createdAt < cutoff) return null; // stale fingerprint, ignore
+    return existing;
   }
 }

--- a/apps/api/src/modules/customers/customers.service.spec.ts
+++ b/apps/api/src/modules/customers/customers.service.spec.ts
@@ -80,3 +80,86 @@ describe('CustomersService.create — NID normalization', () => {
     await expect(service.create(baseDto('1123456789001'))).resolves.toBeDefined();
   });
 });
+
+/**
+ * T3-C9: phone + email dedup at application level (no DB @unique because
+ * legacy rows have duplicates we cannot auto-resolve). Normalization
+ * strips dashes/spaces and optional +66 prefix from phones; lowercases
+ * and trims emails.
+ */
+describe('CustomersService.create — T3-C9 phone + email dedup', () => {
+  let service: CustomersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      customer: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn((args) => Promise.resolve({ id: 'cust-new', ...args.data })),
+        update: jest.fn((args) => Promise.resolve({ id: args.where.id, ...args.data })),
+      },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [CustomersService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(CustomersService);
+  });
+
+  const baseDto = (overrides: Record<string, unknown> = {}) => ({
+    name: 'Test',
+    nationalId: '1123456789001',
+    isForeigner: true, // skip checksum
+    phone: '0812345678',
+    ...overrides,
+  }) as unknown as Parameters<CustomersService['create']>[0];
+
+  it('normalizes phone (dashes, spaces, +66) and rejects dedup collision', async () => {
+    // Existing customer has the normalized form "0812345678"
+    prisma.customer.findFirst.mockImplementation(
+      (args: { where: { phone?: string } }) => {
+        if (args.where?.phone === '0812345678') {
+          return Promise.resolve({ id: 'cust-existing', name: 'Previous' });
+        }
+        return Promise.resolve(null);
+      },
+    );
+
+    // DTO uses dashed format — should still collide after normalization.
+    await expect(
+      service.create(baseDto({ phone: '081-234-5678' })),
+    ).rejects.toThrow(ConflictException);
+
+    // +66 prefix also normalizes to the same 10-digit 0-prefixed form.
+    await expect(
+      service.create(baseDto({ phone: '+66812345678' })),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('rejects duplicate email case-insensitively and writes lowercased form', async () => {
+    // Collision on email (case-insensitive)
+    prisma.customer.findFirst.mockImplementation(
+      (args: { where: { email?: unknown } }) => {
+        if (
+          args.where?.email &&
+          typeof args.where.email === 'object' &&
+          (args.where.email as { equals?: string }).equals === 'foo@example.com'
+        ) {
+          return Promise.resolve({ id: 'cust-existing', name: 'Prev' });
+        }
+        return Promise.resolve(null);
+      },
+    );
+
+    await expect(
+      service.create(baseDto({ email: '  FOO@Example.COM  ' })),
+    ).rejects.toThrow(ConflictException);
+
+    // No collision case — email must be written lowercased + trimmed
+    prisma.customer.findFirst.mockResolvedValue(null);
+    await service.create(baseDto({ email: '  Bar@Example.COM ' }));
+    const createArgs = prisma.customer.create.mock.calls[0][0];
+    expect(createArgs.data.email).toBe('bar@example.com');
+  });
+});

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -271,8 +271,90 @@ export class CustomersService {
     return raw.replace(/[\s-]/g, '').toUpperCase();
   }
 
+  /**
+   * T3-C9: Normalize a Thai mobile phone for application-level dedup. We do
+   * NOT add a DB `@unique` constraint because existing data contains legacy
+   * duplicates we can't auto-resolve; instead we block NEW writes from
+   * creating more. Strips spaces, dashes, parentheses, and optional +66
+   * country prefix, always returning a leading zero. Examples:
+   *   "081-234 5678"   → "0812345678"
+   *   "+66812345678"   → "0812345678"
+   *   "(081) 234 5678" → "0812345678"
+   */
+  private normalizePhone(raw: string | null | undefined): string | null {
+    if (!raw) return null;
+    const trimmed = raw.replace(/[\s()\-]/g, '');
+    if (trimmed.startsWith('+66')) return '0' + trimmed.slice(3);
+    if (trimmed.startsWith('66') && trimmed.length === 11) return '0' + trimmed.slice(2);
+    return trimmed;
+  }
+
+  /**
+   * T3-C9: Normalize email for case-insensitive dedup. Lowercases and trims
+   * outer whitespace. We keep it simple — no local-part sub-address parsing
+   * (foo+bar@...) because owners sometimes legitimately share a single
+   * family inbox with sub-addresses.
+   */
+  private normalizeEmail(raw: string | null | undefined): string | null {
+    if (!raw) return null;
+    return raw.trim().toLowerCase();
+  }
+
+  /**
+   * T3-C9: application-level dedup for phone + email. Throws ConflictException
+   * on collision with a non-soft-deleted record. `ignoreCustomerId` excludes
+   * the customer being updated from the search (so update-in-place doesn't
+   * collide with itself).
+   */
+  private async assertContactNotDuplicate(
+    phone: string | null,
+    email: string | null,
+    ignoreCustomerId?: string,
+  ): Promise<void> {
+    if (phone) {
+      const dupPhone = await this.prisma.customer.findFirst({
+        where: {
+          phone,
+          deletedAt: null,
+          ...(ignoreCustomerId ? { NOT: { id: ignoreCustomerId } } : {}),
+        },
+        select: { id: true, name: true },
+      });
+      if (dupPhone) {
+        throw new ConflictException({
+          message: 'ลูกค้าที่มีเบอร์โทรนี้มีอยู่แล้ว',
+          existingCustomer: dupPhone,
+        });
+      }
+    }
+    if (email) {
+      // Postgres default collation is case-sensitive, so a literal `where:
+      // { email }` wouldn't catch "Foo@x.com" vs "foo@x.com". We rely on
+      // normalization at write-time; the dedup lookup uses Prisma's
+      // `mode: 'insensitive'` too, for belt-and-braces against any legacy
+      // row that slipped through un-normalized.
+      const dupEmail = await this.prisma.customer.findFirst({
+        where: {
+          email: { equals: email, mode: 'insensitive' },
+          deletedAt: null,
+          ...(ignoreCustomerId ? { NOT: { id: ignoreCustomerId } } : {}),
+        },
+        select: { id: true, name: true },
+      });
+      if (dupEmail) {
+        throw new ConflictException({
+          message: 'ลูกค้าที่มีอีเมลนี้มีอยู่แล้ว',
+          existingCustomer: dupEmail,
+        });
+      }
+    }
+  }
+
   async create(dto: CreateCustomerDto) {
     const normalizedNid = this.normalizeNationalId(dto.nationalId);
+    const normalizedPhone = this.normalizePhone(dto.phone);
+    const normalizedPhoneSecondary = this.normalizePhone(dto.phoneSecondary);
+    const normalizedEmail = this.normalizeEmail(dto.email);
 
     // Check duplicate national ID (normalized — so format variations still collide)
     const existing = await this.prisma.customer.findUnique({
@@ -290,9 +372,15 @@ export class CustomersService {
       throw new ConflictException('เลขบัตรประชาชนไม่ถูกต้อง');
     }
 
+    // T3-C9: reject duplicate phone / email at application level.
+    await this.assertContactNotDuplicate(normalizedPhone, normalizedEmail);
+
     const data: Prisma.CustomerCreateInput = {
       ...dto,
       nationalId: normalizedNid,
+      phone: normalizedPhone ?? dto.phone,
+      phoneSecondary: normalizedPhoneSecondary ?? dto.phoneSecondary ?? null,
+      email: normalizedEmail ?? dto.email ?? null,
       references: dto.references !== undefined
         ? (dto.references as Prisma.InputJsonValue)
         : undefined,
@@ -305,8 +393,26 @@ export class CustomersService {
     // NID is intentionally not in UpdateCustomerDto — customers can't change
     // their ID through this endpoint. If NID needs correction, create a
     // dedicated admin-only flow that writes to an audit log.
+
+    // T3-C9: normalize + dedup phone/email when either is being changed.
+    const normalizedPhone = dto.phone !== undefined ? this.normalizePhone(dto.phone) : undefined;
+    const normalizedPhoneSecondary =
+      dto.phoneSecondary !== undefined ? this.normalizePhone(dto.phoneSecondary) : undefined;
+    const normalizedEmail = dto.email !== undefined ? this.normalizeEmail(dto.email) : undefined;
+
+    await this.assertContactNotDuplicate(
+      normalizedPhone ?? null,
+      normalizedEmail ?? null,
+      id,
+    );
+
     const data: Prisma.CustomerUpdateInput = {
       ...dto,
+      ...(normalizedPhone !== undefined ? { phone: normalizedPhone ?? dto.phone } : {}),
+      ...(normalizedPhoneSecondary !== undefined
+        ? { phoneSecondary: normalizedPhoneSecondary }
+        : {}),
+      ...(normalizedEmail !== undefined ? { email: normalizedEmail } : {}),
       references: dto.references !== undefined
         ? (dto.references as Prisma.InputJsonValue)
         : undefined,

--- a/apps/api/src/modules/loyalty/dto/loyalty.dto.ts
+++ b/apps/api/src/modules/loyalty/dto/loyalty.dto.ts
@@ -42,6 +42,25 @@ export class RedeemPointsDto {
   @IsString()
   @IsOptional()
   contractId?: string;
+
+  /**
+   * T3-C3: Anti-fraud linkage to a concrete POS transaction. Without this,
+   * staff could redeem points freely against "ghost" customer lookups. A
+   * redemption must always reference a sale/contract/manual-POS event so
+   * there's a paper trail back to who bought what.
+   */
+  @IsString({ message: 'กรุณาระบุเลขที่ธุรกรรม POS' })
+  @MaxLength(255)
+  posTransactionId: string;
+
+  /**
+   * T3-C3: OWNER override required when redeeming > 10,000 points in one
+   * call. Service layer verifies the approver actually has OWNER role.
+   */
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  approverId?: string;
 }
 
 export class PointHistoryQueryDto {

--- a/apps/api/src/modules/loyalty/loyalty.controller.ts
+++ b/apps/api/src/modules/loyalty/loyalty.controller.ts
@@ -48,7 +48,9 @@ export class LoyaltyController {
       customerId,
       dto.amount,
       dto.description,
+      dto.posTransactionId,
       dto.contractId,
+      dto.approverId,
     );
   }
 

--- a/apps/api/src/modules/loyalty/loyalty.service.spec.ts
+++ b/apps/api/src/modules/loyalty/loyalty.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { LoyaltyService } from './loyalty.service';
 import { PrismaService } from '../../prisma/prisma.service';
 
@@ -123,5 +124,100 @@ describe('LoyaltyService.awardReferralPoints — race-safe idempotency', () => {
     await service.awardReferralPoints('referred-1');
 
     expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+// ─── T3-C3: Redemption anti-fraud guards ─────────────────────────────────
+// 1. Daily cap (5,000 pts per customer)
+// 2. Owner override for >10,000 pts in a single call
+// 3. posTransactionId required (audit linkage)
+describe('LoyaltyService.redeemPoints — T3-C3 anti-fraud', () => {
+  let service: LoyaltyService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      customer: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'cust-1',
+          loyaltyBalance: 50000,
+          deletedAt: null,
+        }),
+        update: jest.fn().mockResolvedValue({ loyaltyBalance: 45000 }),
+      },
+      user: {
+        findUnique: jest.fn(),
+      },
+      loyaltyRedemption: {
+        aggregate: jest.fn().mockResolvedValue({ _sum: { points: 0 } }),
+        create: jest.fn(),
+      },
+      $transaction: jest.fn(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async (cb: (tx: any) => Promise<unknown>) =>
+          cb({
+            loyaltyRedemption: { create: jest.fn() },
+            customer: { update: jest.fn().mockResolvedValue({ loyaltyBalance: 45000 }) },
+          }),
+      ),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [LoyaltyService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(LoyaltyService);
+  });
+
+  it('allows redemption under the daily cap with posTransactionId', async () => {
+    prisma.loyaltyRedemption.aggregate.mockResolvedValue({ _sum: { points: 2000 } });
+
+    const res = await service.redeemPoints('cust-1', 1000, 'ส่วนลดงวด', 'POS-123');
+    expect(res.redeemedPoints).toBe(1000);
+    expect(res.newBalance).toBe(45000);
+  });
+
+  it('rejects when today + requested exceeds REDEMPTION_DAILY_CAP (5,000)', async () => {
+    // Already redeemed 4,000 today — another 2,000 would push to 6,000.
+    prisma.loyaltyRedemption.aggregate.mockResolvedValue({ _sum: { points: 4000 } });
+
+    await expect(
+      service.redeemPoints('cust-1', 2000, 'ส่วนลดงวด', 'POS-124'),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects >10,000 pts redemption without an OWNER approverId', async () => {
+    await expect(
+      service.redeemPoints('cust-1', 12000, 'ส่วนลดใหญ่', 'POS-125'),
+    ).rejects.toThrow(ForbiddenException);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects >10,000 pts when approver is not OWNER', async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'mgr-1',
+      role: 'FINANCE_MANAGER',
+      isActive: true,
+      deletedAt: null,
+    });
+
+    await expect(
+      service.redeemPoints('cust-1', 12000, 'ส่วนลดใหญ่', 'POS-125', undefined, 'mgr-1'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects when posTransactionId is missing (internal caller bypass defense)', async () => {
+    await expect(
+      service.redeemPoints('cust-1', 500, 'ส่วนลด', ''),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects when approver does not exist for high-value redemption', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.redeemPoints('cust-1', 12000, 'ส่วนลดใหญ่', 'POS-125', undefined, 'ghost'),
+    ).rejects.toThrow(NotFoundException);
   });
 });

--- a/apps/api/src/modules/loyalty/loyalty.service.ts
+++ b/apps/api/src/modules/loyalty/loyalty.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
   Logger,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -14,6 +15,20 @@ const POINTS_PER_BAHT = 0.01;
 const REFERRAL_POINTS = 500;
 /** Points expire after 1 year (ms) */
 const POINTS_EXPIRY_DAYS = 365;
+
+/**
+ * T3-C3: Per-customer daily redemption cap. Prevents a compromised account
+ * or a colluding staff member from draining a loyalty balance in one go.
+ * 5,000 points = 5,000 baht discount, which is ~1 full-month installment.
+ */
+const REDEMPTION_DAILY_CAP = 5000;
+
+/**
+ * T3-C3: High-value redemption threshold. Any single call above this requires
+ * an OWNER to co-sign via `approverId`. 10,000 points = 10,000 baht — well
+ * above a normal goodwill discount, so a manager override is appropriate.
+ */
+const REDEMPTION_OWNER_OVERRIDE_THRESHOLD = 10000;
 
 @Injectable()
 export class LoyaltyService {
@@ -144,11 +159,25 @@ export class LoyaltyService {
 
   // ─── Redeem points ────────────────────────────────────────────────────────
 
+  /**
+   * T3-C3: Redeem points with anti-fraud guards.
+   *
+   * Guards:
+   *   (1) `posTransactionId` is required — every redemption must point to a
+   *       concrete POS/sale/contract event for audit.
+   *   (2) Cumulative redemptions for a customer in the current day cannot
+   *       exceed REDEMPTION_DAILY_CAP (5,000 pts). Protects against
+   *       drain-in-one-go attacks.
+   *   (3) A single call above REDEMPTION_OWNER_OVERRIDE_THRESHOLD (10,000
+   *       pts) requires an `approverId` that belongs to an OWNER.
+   */
   async redeemPoints(
     customerId: string,
     amount: number,
     description: string,
+    posTransactionId: string,
     contractId?: string,
+    approverId?: string,
   ): Promise<{
     redeemedPoints: number;
     discountAmount: number;
@@ -156,6 +185,32 @@ export class LoyaltyService {
   }> {
     if (amount <= 0) {
       throw new BadRequestException('จำนวนแต้มที่แลกต้องมากกว่า 0');
+    }
+    // (1) posTransactionId is mandatory — validated at DTO level too, but
+    // defense-in-depth for internal callers bypassing the controller.
+    if (!posTransactionId || !posTransactionId.trim()) {
+      throw new BadRequestException('กรุณาระบุเลขที่ธุรกรรม POS');
+    }
+
+    // (3) OWNER override for high-value redemptions.
+    if (amount > REDEMPTION_OWNER_OVERRIDE_THRESHOLD) {
+      if (!approverId) {
+        throw new ForbiddenException(
+          `การแลกแต้มเกิน ${REDEMPTION_OWNER_OVERRIDE_THRESHOLD.toLocaleString()} แต้ม ต้องมีผู้อนุมัติระดับ OWNER`,
+        );
+      }
+      const approver = await this.prisma.user.findUnique({
+        where: { id: approverId },
+        select: { id: true, role: true, isActive: true, deletedAt: true },
+      });
+      if (!approver || !approver.isActive || approver.deletedAt) {
+        throw new NotFoundException('ไม่พบผู้อนุมัติ หรือผู้อนุมัติถูกปิดการใช้งาน');
+      }
+      if (approver.role !== 'OWNER') {
+        throw new ForbiddenException(
+          `ผู้อนุมัติต้องมีสิทธิ์ OWNER (role ปัจจุบัน: ${approver.role})`,
+        );
+      }
     }
 
     const customer = await this.prisma.customer.findUnique({
@@ -171,15 +226,41 @@ export class LoyaltyService {
       );
     }
 
+    // (2) Daily cap — sum redemptions since start-of-day (local server time).
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const dayAgg = await this.prisma.loyaltyRedemption.aggregate({
+      where: {
+        customerId,
+        deletedAt: null,
+        createdAt: { gte: startOfDay },
+      },
+      _sum: { points: true },
+    });
+    const alreadyRedeemedToday = dayAgg._sum.points ?? 0;
+    if (alreadyRedeemedToday + amount > REDEMPTION_DAILY_CAP) {
+      throw new BadRequestException(
+        `เกินโควต้าแลกแต้มต่อวัน (ใช้ไปแล้ว ${alreadyRedeemedToday.toLocaleString()} แต้ม, ` +
+          `สูงสุด ${REDEMPTION_DAILY_CAP.toLocaleString()} แต้ม/วัน)`,
+      );
+    }
+
     // 1 point = 1 baht discount
     const discountAmount = new Prisma.Decimal(amount);
+
+    // Persist posTransactionId + approver (when present) in `reason` for
+    // audit without touching the schema. Format is easy to grep for and
+    // compatible with existing dashboards.
+    const reasonParts = [description, `pos:${posTransactionId}`];
+    if (approverId) reasonParts.push(`approver:${approverId}`);
+    const reasonWithRefs = reasonParts.join(' | ');
 
     const result = await this.prisma.$transaction(async (tx) => {
       await tx.loyaltyRedemption.create({
         data: {
           customerId,
           points: amount,
-          reason: description,
+          reason: reasonWithRefs,
           discountAmount,
           contractId: contractId ?? null,
         },
@@ -192,7 +273,10 @@ export class LoyaltyService {
       return updated;
     });
 
-    this.logger.log(`redeemPoints: -${amount} pts for customer ${customerId}`);
+    this.logger.log(
+      `redeemPoints: -${amount} pts for customer ${customerId} ` +
+        `pos=${posTransactionId}${approverId ? ` approver=${approverId}` : ''}`,
+    );
     return {
       redeemedPoints: amount,
       discountAmount: Number(discountAmount),

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards, Req } from '@nestjs/common';
+import type { Request } from 'express';
 import { ApiTags, ApiBearerAuth , ApiOperation} from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { PaymentsService } from './payments.service';
@@ -166,8 +167,28 @@ export class PaymentsController {
     @Param('paymentId') paymentId: string,
     @Body() dto: WaiveLateFeeDto,
     @CurrentUser() user: { id: string },
+    @Req() req: Request,
   ) {
-    return this.paymentsService.waiveLateFee(paymentId, dto.reason, user.id, dto.approverId);
+    // T3-C4: capture IP + UA of the APPROVER for the immutable audit row.
+    // Trust proxy forwarding is already configured at the app bootstrap
+    // level (req.ip honours X-Forwarded-For); user-agent comes straight
+    // from the browser. Both are optional — null is acceptable if unset.
+    const forwarded = req.headers['x-forwarded-for'];
+    const ipAddress =
+      (typeof forwarded === 'string' ? forwarded.split(',')[0].trim() : undefined) ||
+      req.ip ||
+      null;
+    const userAgentHeader = req.headers['user-agent'];
+    const userAgent =
+      typeof userAgentHeader === 'string' ? userAgentHeader : null;
+
+    return this.paymentsService.waiveLateFee(
+      paymentId,
+      dto.reason,
+      user.id,
+      dto.approverId,
+      { ipAddress, userAgent },
+    );
   }
 
   /** Force branch filtering for non-global roles */

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -63,6 +63,10 @@ describe('PaymentsService', () => {
       systemConfig: {
         findUnique: jest.fn().mockResolvedValue(null), // CR-7: period lock check
       },
+      // T3-C4: immutable approval audit row written alongside the waiver
+      feeWaiverApproval: {
+        create: jest.fn().mockResolvedValue({ id: 'waiver-approval-1' }),
+      },
       $transaction: jest.fn((cb) => cb(mockPrisma)),
     };
 
@@ -401,6 +405,69 @@ describe('PaymentsService', () => {
       );
       expect(res.lateFeeWaived).toBe(true);
       expect(prisma.payment.update).toHaveBeenCalled();
+    });
+
+    // T3-C4: FeeWaiverApproval immutable row MUST be written for every
+    // approved waiver, so auditors have a log independent of the mutable
+    // Payment.waived* columns. IP + UA are passed through from the
+    // controller @Req() so we can detect anomalies later.
+    it('writes a FeeWaiverApproval audit row with ip + userAgent', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'approver-1',
+        role: 'FINANCE_MANAGER',
+        isActive: true,
+        deletedAt: null,
+      });
+      prisma.payment.update.mockResolvedValue({
+        ...payableWithFee,
+        lateFee: 0,
+        lateFeeWaived: true,
+      });
+
+      await service.waiveLateFee(
+        'payment-1',
+        'customer hardship',
+        'user-1',
+        'approver-1',
+        { ipAddress: '10.0.0.42', userAgent: 'Mozilla/5.0 Test' },
+      );
+
+      expect(prisma.feeWaiverApproval.create).toHaveBeenCalledWith({
+        data: {
+          waiverPaymentId: 'payment-1',
+          approverId: 'approver-1',
+          ipAddress: '10.0.0.42',
+          userAgent: 'Mozilla/5.0 Test',
+        },
+      });
+    });
+
+    it('does NOT write the approval row when the waiver is rejected upstream', async () => {
+      // Self-approval — rejection happens before the tx even starts.
+      await expect(
+        service.waiveLateFee('payment-1', 'reason', 'user-1', 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.feeWaiverApproval.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // T3-C5: Preventive rule — no direct mutation of Payment.amountPaid and
+  // friends. The method exists specifically to raise on any future caller
+  // that tries to hot-patch a financial field instead of writing a reversal.
+  describe('updatePayment — T3-C5 immutability guard', () => {
+    it('rejects direct mutation of amountPaid with a clear Thai reversal hint', async () => {
+      await expect(
+        service.updatePayment('payment-1', { amountPaid: 9999 }),
+      ).rejects.toThrow(ForbiddenException);
+
+      try {
+        await service.updatePayment('payment-1', { amountPaid: 9999 });
+      } catch (err) {
+        // Message must reference reversePayment so the offending dev knows
+        // the correct remediation path.
+        expect((err as Error).message).toContain('reversePayment');
+        expect((err as Error).message).toContain('amountPaid');
+      }
     });
   });
 });

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -768,6 +768,7 @@ export class PaymentsService {
     reason: string,
     userId: string,
     approverId: string,
+    context?: { ipAddress?: string | null; userAgent?: string | null },
   ) {
     // T1-C2 — 4-eyes (Segregation of Duties): requester ≠ approver, and
     // approver must be a manager-tier user. Waiver bypass previously let a
@@ -824,6 +825,20 @@ export class PaymentsService {
         },
       });
 
+      // T3-C4: immutable approval evidence. Columns on Payment (waivedApprovedById,
+      // waivedAt) are convenient for queries, but we ALSO persist a separate
+      // FeeWaiverApproval row so that any future mutation of the Payment
+      // columns leaves the approval audit trail intact. IP + UA help detect
+      // "someone else logged in as the manager" attacks.
+      await tx.feeWaiverApproval.create({
+        data: {
+          waiverPaymentId: paymentId,
+          approverId,
+          ipAddress: context?.ipAddress ?? null,
+          userAgent: context?.userAgent ?? null,
+        },
+      });
+
       // Check contract completion inside transaction
       if (isNowFullyPaid && payment.status !== 'PAID') {
         await this.checkContractCompletion(payment.contractId, tx);
@@ -861,6 +876,56 @@ export class PaymentsService {
     });
 
     return { ...result.updated, originalLateFee: result.originalLateFee };
+  }
+
+  // ─── T3-C5: Preventive immutability guard ───────────────
+  /**
+   * T3-C5: PREVENTIVE RULE.
+   *
+   * `Payment.amountPaid` is a financial fact — once money has been recorded
+   * against an installment, the correct remediation for an error is to
+   * REVERSE the bad entry (create a negative/offsetting record) and book a
+   * NEW payment with the correct amount. Silently mutating `amountPaid`
+   * would erase the audit trail used by accountants to reconcile bank
+   * statements against Payment rows.
+   *
+   * Today no endpoint calls this method — it exists specifically to trap
+   * future code that tries to patch Payment fields directly. If you find
+   * yourself wanting to bypass it, stop and write a reversal instead.
+   *
+   * Forbidden fields (will throw):
+   *   - amountPaid
+   *   - amountDue
+   *   - status (use recordPayment / waiveLateFee / reversePayment instead)
+   *   - paidDate
+   *   - monthlyPrincipal / monthlyInterest / monthlyCommission / vatAmount
+   *
+   * Safe fields (`notes`, `evidenceUrl`) are routed through dedicated
+   * helpers elsewhere — this method does NOT write them.
+   */
+  async updatePayment(
+    _paymentId: string,
+    patch: Record<string, unknown>,
+  ): Promise<never> {
+    const FORBIDDEN_FIELDS = new Set([
+      'amountPaid',
+      'amountDue',
+      'status',
+      'paidDate',
+      'monthlyPrincipal',
+      'monthlyInterest',
+      'monthlyCommission',
+      'vatAmount',
+      'lateFee',
+    ]);
+    const violated = Object.keys(patch).filter((k) => FORBIDDEN_FIELDS.has(k));
+    const violationMsg =
+      violated.length > 0
+        ? `ห้ามแก้ไข field การเงินของ Payment โดยตรง (${violated.join(', ')}) ` +
+          'กรุณาใช้ reversePayment() + บันทึกรายการชำระใหม่แทน'
+        : 'ห้ามแก้ไข Payment ผ่าน updatePayment() — กรุณาใช้ recordPayment() / ' +
+          'waiveLateFee() / reversePayment() ตามกรณี';
+    throw new ForbiddenException(violationMsg);
   }
 
   // ─── Award loyalty points for on-time payment ──────────


### PR DESCRIPTION
## Summary
5 items ครอบคลุม slip/loyalty/payment/customer hygiene

### T3-C2 — Slip cross-contract reuse
- New immutable \`SlipFingerprint\` model (sha256 of ref+amount+bank+date, fallback image URL; unique index on hash)
- \`SlipProcessingService\` compute hash ก่อน \`createEvidence\` → reject ถ้าเจอ hash เดิมบน contract อื่นใน 30 วัน
- Same-contract re-upload ยัง OK
- Sentry warning on detection

### T3-C3 — Loyalty redemption cap
- \`redeemPoints()\` 3 guards: (1) daily cap 5,000 pts/customer (aggregated since midnight), (2) OWNER approver required ถ้า > 10,000 pts/call, (3) \`posTransactionId\` mandatory
- Thai errors

### T3-C4 — Fee waiver approval signature
- New immutable \`FeeWaiverApproval\` model (\`waiverPaymentId\`, \`approverId\`, \`approvedAt\`, \`ipAddress?\`, \`userAgent?\`)
- \`waiveLateFee()\` write approval row ใน \`$transaction\` เดียวกับ Payment update
- Controller capture ip (X-Forwarded-For aware) + UA ผ่าน \`@Req()\`

### T3-C5 — Payment immutability (preventive)
- \`updatePayment()\` throw ForbiddenException ถ้าพยายาม mutate: amountPaid/amountDue/status/paidDate/monthlyPrincipal/Interest/Commission/vatAmount/lateFee
- ชี้ caller ไปใช้ \`reversePayment()\` แทน

### T3-C9 — Phone/email dedup
- \`normalizePhone\` (strip dash/space/paren, collapse +66/66 → leading 0)
- \`normalizeEmail\` (lowercase+trim)
- Application-level \`assertContactNotDuplicate\` on create/update — email match \`mode: insensitive\`
- No DB \`@unique\` (legacy dupes)

## Test plan
- [x] +14 tests (3 slip + 6 loyalty + 2 waiver + 1 payment + 2 customer)
- [x] Migration \`20260526000000_add_tier8_fraud_slip_waiver\` creates both tables
- [x] TypeScript API: 0 errors
- [x] Full API suite: 1190/1190 pass, 88 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)