### PR TITLE
fix(tier-8): T7 medium refresh cookie + metrics rotation (C5+C9)

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.spec.ts
+++ b/apps/api/src/modules/auth/auth.controller.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { TwoFactorService } from './two-factor.service';
+
+/**
+ * T7-C5: Refresh endpoint is cookie-only. Body `refreshToken` is no longer
+ * honoured — CSRF exfil risk if SameSite drops. These tests pin the contract.
+ */
+describe('AuthController /auth/refresh (T7-C5 cookie-only)', () => {
+  let controller: AuthController;
+  let authService: jest.Mocked<Pick<AuthService, 'refreshToken'>>;
+
+  beforeEach(async () => {
+    authService = {
+      refreshToken: jest.fn().mockResolvedValue({
+        accessToken: 'new-access-token',
+        refreshToken: 'rotated-refresh-token',
+      }),
+    } as unknown as jest.Mocked<Pick<AuthService, 'refreshToken'>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: TwoFactorService, useValue: { isTwoFactorEnabled: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get(AuthController);
+  });
+
+  function makeReq(overrides: Partial<Request> = {}): Request {
+    return {
+      cookies: {},
+      headers: {},
+      ...overrides,
+    } as unknown as Request;
+  }
+
+  function makeRes(): Response {
+    const res = {
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    return res as unknown as Response;
+  }
+
+  it('accepts valid refresh token from cookie only', async () => {
+    const req = makeReq({ cookies: { refresh_token: 'cookie-token' } });
+    const res = makeRes();
+
+    const result = await controller.refresh(req, res);
+
+    expect(authService.refreshToken).toHaveBeenCalledTimes(1);
+    expect(authService.refreshToken).toHaveBeenCalledWith('cookie-token');
+    expect(result).toEqual({ accessToken: 'new-access-token' });
+    expect((res.cookie as jest.Mock)).toHaveBeenCalledWith(
+      'refresh_token',
+      'rotated-refresh-token',
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax' }),
+    );
+  });
+
+  it('rejects 401 when no cookie is present (body token not accepted)', async () => {
+    const req = makeReq({ cookies: {} });
+    const res = makeRes();
+
+    await expect(controller.refresh(req, res)).rejects.toThrow(UnauthorizedException);
+    await expect(controller.refresh(req, res)).rejects.toThrow(
+      'Refresh token ไม่ถูกต้องหรือหมดอายุ',
+    );
+    expect(authService.refreshToken).not.toHaveBeenCalled();
+  });
+
+  it('ignores body payload and uses cookie only when both present', async () => {
+    // Simulate a malicious caller sending a body token hoping we still honor it.
+    // The controller signature no longer binds @Body at all — body is invisible to the handler.
+    const req = makeReq({
+      cookies: { refresh_token: 'good-cookie-token' },
+      // body is set on the request object, but controller doesn't read it.
+      body: { refreshToken: 'attacker-supplied-token' },
+    } as Partial<Request>);
+    const res = makeRes();
+
+    await controller.refresh(req, res);
+
+    expect(authService.refreshToken).toHaveBeenCalledTimes(1);
+    expect(authService.refreshToken).toHaveBeenCalledWith('good-cookie-token');
+    expect(authService.refreshToken).not.toHaveBeenCalledWith('attacker-supplied-token');
+  });
+});

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -106,12 +106,15 @@ export class AuthController {
 
   @Post('refresh')
   @Throttle({ short: { ttl: 60000, limit: 10 } }) // 10 refresh attempts per minute
-  @ApiOperation({ summary: 'Refresh access token' })
-  async refresh(@Req() req: Request, @Body() body: { refreshToken?: string }, @Res({ passthrough: true }) res: Response) {
-    // Read from cookie first, fall back to body for backward compatibility
-    const token = req.cookies?.[REFRESH_COOKIE] || body.refreshToken;
+  @ApiOperation({ summary: 'Refresh access token (cookie-only)' })
+  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    // T7-C5: Cookie-only — body `refreshToken` no longer accepted.
+    // httpOnly cookie is not readable from JS and travels automatically; accepting
+    // the token in the body was a CSRF exfiltration risk if SameSite ever dropped.
+    // Web client already uses cookie (apps/web/src/lib/api.ts posts empty body).
+    const token = req.cookies?.[REFRESH_COOKIE];
     if (!token) {
-      return res.status(401).json({ message: 'Refresh token ไม่ถูกต้องหรือหมดอายุ' });
+      throw new UnauthorizedException('Refresh token ไม่ถูกต้องหรือหมดอายุ');
     }
     const result = await this.authService.refreshToken(token);
     setRefreshCookie(res, result.refreshToken);

--- a/apps/api/src/modules/metrics/metrics.controller.spec.ts
+++ b/apps/api/src/modules/metrics/metrics.controller.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
+
+/**
+ * T7-C9: Metrics endpoint supports dual tokens for zero-downtime rotation.
+ *   - Accepts METRICS_SCRAPE_TOKEN (current) and METRICS_SCRAPE_TOKEN_PREVIOUS (last rotated-out).
+ *   - Comparison is timing-safe.
+ *   - Matching PREVIOUS emits a Logger.warn so ops can see the old caller.
+ */
+describe('MetricsController (T7-C9 token rotation)', () => {
+  let controller: MetricsController;
+  let metrics: { collect: jest.Mock };
+  let config: { get: jest.Mock };
+
+  beforeEach(async () => {
+    metrics = { collect: jest.fn().mockResolvedValue('# HELP fake_metric\nfake_metric 1\n') };
+    config = { get: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MetricsController],
+      providers: [
+        { provide: MetricsService, useValue: metrics },
+        { provide: ConfigService, useValue: config },
+      ],
+    }).compile();
+
+    controller = module.get(MetricsController);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function configure(current?: string, previous?: string) {
+    config.get.mockImplementation((key: string) => {
+      if (key === 'METRICS_SCRAPE_TOKEN') return current;
+      if (key === 'METRICS_SCRAPE_TOKEN_PREVIOUS') return previous;
+      return undefined;
+    });
+  }
+
+  it('accepts the current token (no warning)', async () => {
+    configure('new-token-abc', 'old-token-xyz');
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    const out = await controller.scrape('new-token-abc');
+
+    expect(out).toContain('fake_metric');
+    expect(metrics.collect).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts the previous token and emits a rotation warning', async () => {
+    configure('new-token-abc', 'old-token-xyz');
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    const out = await controller.scrape('old-token-xyz');
+
+    expect(out).toContain('fake_metric');
+    expect(metrics.collect).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toMatch(/METRICS_SCRAPE_TOKEN_PREVIOUS/);
+    expect(msg).toMatch(/rotate/i);
+  });
+
+  it('rejects 403 when token matches neither current nor previous', async () => {
+    configure('new-token-abc', 'old-token-xyz');
+
+    await expect(controller.scrape('attacker-token')).rejects.toMatchObject({
+      status: HttpStatus.FORBIDDEN,
+    });
+    expect(metrics.collect).not.toHaveBeenCalled();
+  });
+
+  it('rejects 403 when no token is sent', async () => {
+    configure('new-token-abc');
+    await expect(controller.scrape(undefined)).rejects.toMatchObject({
+      status: HttpStatus.FORBIDDEN,
+    });
+  });
+
+  it('rejects 503 when METRICS_SCRAPE_TOKEN is not configured', async () => {
+    configure(undefined, 'old-token-xyz');
+    await expect(controller.scrape('any-token')).rejects.toBeInstanceOf(HttpException);
+    await expect(controller.scrape('any-token')).rejects.toMatchObject({
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+    });
+  });
+
+  it('does not leak comparison timing on mismatched lengths (smoke)', async () => {
+    configure('length-32-aaaaaaaaaaaaaaaaaaaaaaa', 'length-16-bbbbbbb');
+    // Short token: mismatched length against both — should cleanly 403.
+    await expect(controller.scrape('x')).rejects.toMatchObject({
+      status: HttpStatus.FORBIDDEN,
+    });
+    // Exact length as current but wrong content — timingSafeEqual path, still 403.
+    await expect(controller.scrape('length-32-bbbbbbbbbbbbbbbbbbbbbbb')).rejects.toMatchObject({
+      status: HttpStatus.FORBIDDEN,
+    });
+  });
+});

--- a/apps/api/src/modules/metrics/metrics.controller.ts
+++ b/apps/api/src/modules/metrics/metrics.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Header, Headers, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Header, Headers, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SkipThrottle } from '@nestjs/throttler';
+import { timingSafeEqual } from 'crypto';
 import { Public } from '../auth/decorators/public.decorator';
 import { MetricsService } from './metrics.service';
 
@@ -12,12 +13,21 @@ import { MetricsService } from './metrics.service';
  * env set, endpoint returns 503 — prevents accidental exposure if the
  * scrape token isn't configured.
  *
+ * T7-C9: Supports dual tokens for zero-downtime rotation:
+ *   - METRICS_SCRAPE_TOKEN — new/active token
+ *   - METRICS_SCRAPE_TOKEN_PREVIOUS — optional, last rotated-out token
+ * Both accepted; matches against PREVIOUS log a warning so ops can see the
+ * old caller is still in use and finish migrating scrapers. Comparisons use
+ * `timingSafeEqual` to avoid timing side-channels.
+ *
  * Rate-limited via SkipThrottle so Prometheus's every-15s scrape doesn't
  * trip the global throttler.
  */
 @Controller('metrics')
 @SkipThrottle()
 export class MetricsController {
+  private readonly logger = new Logger(MetricsController.name);
+
   constructor(
     private readonly metrics: MetricsService,
     private readonly config: ConfigService,
@@ -28,15 +38,39 @@ export class MetricsController {
   @Header('Content-Type', 'text/plain; version=0.0.4')
   async scrape(@Headers('x-metrics-token') token?: string): Promise<string> {
     const expected = this.config.get<string>('METRICS_SCRAPE_TOKEN');
+    const previous = this.config.get<string>('METRICS_SCRAPE_TOKEN_PREVIOUS');
+
     if (!expected) {
       throw new HttpException(
         'metrics scrape not configured',
         HttpStatus.SERVICE_UNAVAILABLE,
       );
     }
-    if (!token || token !== expected) {
+    if (!token) {
       throw new HttpException('forbidden', HttpStatus.FORBIDDEN);
     }
-    return this.metrics.collect();
+
+    if (safeCompare(token, expected)) {
+      return this.metrics.collect();
+    }
+    if (previous && safeCompare(token, previous)) {
+      this.logger.warn(
+        'metrics scrape authenticated via METRICS_SCRAPE_TOKEN_PREVIOUS — rotate the caller to the new token and remove PREVIOUS from env',
+      );
+      return this.metrics.collect();
+    }
+
+    throw new HttpException('forbidden', HttpStatus.FORBIDDEN);
   }
+}
+
+/**
+ * Constant-time string compare. Short-circuits on length mismatch (the length
+ * itself isn't secret; it's the same for all valid rotation pairs).
+ */
+function safeCompare(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
 }

--- a/docs/guides/SLO-RUNBOOK.md
+++ b/docs/guides/SLO-RUNBOOK.md
@@ -12,9 +12,23 @@ Headers:
 ```
 
 - **Env required**: `METRICS_SCRAPE_TOKEN` (long random string, stored in Secret Manager)
-- Without env → 503 (fails closed)
+- **Env optional**: `METRICS_SCRAPE_TOKEN_PREVIOUS` — used during zero-downtime rotation (T7-C9)
+- Without `METRICS_SCRAPE_TOKEN` → 503 (fails closed)
 - Wrong token → 403
+- Token compare uses `timingSafeEqual` (constant-time, resistant to timing attacks)
 - SkipThrottle (Prometheus scrape every 15s doesn't trip global rate limit)
+
+### Zero-downtime token rotation (T7-C9)
+
+```
+1. Generate new token N. Set METRICS_SCRAPE_TOKEN_PREVIOUS = current_token.
+2. Set METRICS_SCRAPE_TOKEN = N. Deploy.
+   Both old and new tokens are now accepted; requests matching PREVIOUS
+   emit a WARN log ("rotate the caller to the new token…").
+3. Update scrapers (Prometheus / Grafana Cloud / uptime check) to send N.
+4. Watch logs for 24h. Once WARN stops firing, unset
+   METRICS_SCRAPE_TOKEN_PREVIOUS and redeploy.
+```
 
 ## Target SLOs
 


### PR DESCRIPTION
## Summary

### T7-C5 — Refresh endpoint cookie-only
- \`auth.controller.refresh()\` — hard-remove body \`refreshToken\` acceptance; read from \`req.cookies[refresh_token]\` only
- Frontend (\`apps/web/src/lib/api.ts\`) ใช้ cookie + withCredentials อยู่แล้ว — ไม่ต้อง migrate
- ปิด CSRF exfil path ถ้า SameSite attribute อ่อนลงในอนาคต

### T7-C9 — Metrics token dual-value rotation
- \`/metrics\` endpoint — support \`METRICS_SCRAPE_TOKEN\` + optional \`METRICS_SCRAPE_TOKEN_PREVIOUS\`
- \`timingSafeEqual\` constant-time compare ทั้งคู่
- PREVIOUS match → Logger.warn ("rotate callers") ให้ ops เห็น stale caller
- \`docs/guides/SLO-RUNBOOK.md\` — 4-step zero-downtime rotation playbook

## Test plan
- [x] +9 tests (3 auth cookie-only + 6 metrics rotation)
- [x] Full auth + metrics suites: 56/56 pass
- [x] TypeScript API: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)