### PR TITLE
feat(tier-8): T1+T2 medium/low batch (C8+C9+C12-C16)

### DIFF
--- a/apps/api/prisma/migrations/20260527000000_refund_bank_reversal_lock/migration.sql
+++ b/apps/api/prisma/migrations/20260527000000_refund_bank_reversal_lock/migration.sql
@@ -1,0 +1,7 @@
+-- T1-C8: bank-reversal write-once lock. Once bankReversalRef is first
+-- written, this timestamp is set and the service layer blocks further
+-- mutations to bankReversalRef / bankReversalAt. Keeps a clean, frozen
+-- record of the bank evidence for audit.
+
+ALTER TABLE "refunds"
+  ADD COLUMN "bank_reversal_locked_at" TIMESTAMP(3);

--- a/apps/api/prisma/migrations/20260527100000_add_journal_post_audit_log/migration.sql
+++ b/apps/api/prisma/migrations/20260527100000_add_journal_post_audit_log/migration.sql
@@ -1,0 +1,26 @@
+-- T2-C14: Immutable audit log of every DRAFT→POSTED transition on a
+-- journal entry. Written in the same $transaction as the post() update
+-- so a failed audit insert rolls the post back.
+
+CREATE TABLE "journal_post_audit_logs" (
+  "id"               TEXT NOT NULL,
+  "journal_entry_id" TEXT NOT NULL,
+  "posted_by_id"     TEXT NOT NULL,
+  "posted_at"        TIMESTAMP(3) NOT NULL,
+  "ip_address"       TEXT,
+  "user_agent"       TEXT,
+  "created_at"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "journal_post_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "journal_post_audit_logs_journal_entry_id_idx"
+  ON "journal_post_audit_logs"("journal_entry_id");
+CREATE INDEX "journal_post_audit_logs_posted_by_id_idx"
+  ON "journal_post_audit_logs"("posted_by_id");
+CREATE INDEX "journal_post_audit_logs_posted_at_idx"
+  ON "journal_post_audit_logs"("posted_at");
+
+ALTER TABLE "journal_post_audit_logs"
+  ADD CONSTRAINT "journal_post_audit_logs_journal_entry_id_fkey"
+  FOREIGN KEY ("journal_entry_id") REFERENCES "journal_entries"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -809,6 +809,11 @@ model Refund {
   bankReversalRef String?     @map("bank_reversal_ref")
   bankReversalAt  DateTime?   @map("bank_reversal_at")
   bankReversalNotes String?   @map("bank_reversal_notes")
+  /// T1-C8: once bankReversalRef is first written, this row is frozen.
+  /// Any subsequent attempt to mutate bankReversalRef / bankReversalAt is
+  /// rejected in the service layer. Prevents staff from silently editing
+  /// the bank evidence after the fact (reg auditors care about this).
+  bankReversalLockedAt DateTime? @map("bank_reversal_locked_at")
   failureReason   String?     @map("failure_reason")
 
   createdAt DateTime  @default(now()) @map("created_at")
@@ -2440,6 +2445,7 @@ model JournalEntry {
   lines     JournalLine[]
   createdBy User          @relation("JournalCreatedBy", fields: [createdById], references: [id])
   postedBy  User?         @relation("JournalPostedBy", fields: [postedById], references: [id])
+  postAuditLogs JournalPostAuditLog[]
 
   @@index([companyId])
   @@index([entryDate])
@@ -2449,6 +2455,27 @@ model JournalEntry {
   @@map("journal_entries")
   // Partial unique index enforced via migration (CREATE UNIQUE INDEX ... WHERE reference_type IS NOT NULL)
   // Prisma cannot express partial @@unique; see migration 20260428010000_journal_entries_ref_unique
+}
+
+/// T2-C14: Immutable audit log of every DRAFT→POSTED transition on
+/// JournalEntry. Inserted in the SAME $transaction as the post() update so
+/// that a failed audit-log insert rolls the post back. updatedAt/deletedAt
+/// intentionally omitted (immutable audit log — append-only).
+model JournalPostAuditLog {
+  id             String   @id @default(uuid())
+  journalEntryId String   @map("journal_entry_id")
+  postedById     String   @map("posted_by_id")
+  postedAt       DateTime @map("posted_at")
+  ipAddress      String?  @map("ip_address")
+  userAgent      String?  @map("user_agent")
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  journalEntry JournalEntry @relation(fields: [journalEntryId], references: [id], onDelete: Restrict)
+
+  @@index([journalEntryId])
+  @@index([postedById])
+  @@index([postedAt])
+  @@map("journal_post_audit_logs")
 }
 
 model JournalLine {

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -909,4 +909,41 @@ describe('AccountingService', () => {
       expect(where.companyId).toBe('company-1');
     });
   });
+
+  // T2-C12 — once expense is PENDING_APPROVAL, money fields are frozen.
+  // Staff can still tweak description/notes/reference while the approver
+  // reviews (typos, vendor clarifications). Changing the amount after
+  // submission was the loophole.
+  describe('updateExpense — T2-C12 amount lock on PENDING_APPROVAL', () => {
+    const pendingExpense = {
+      id: 'exp-1',
+      status: 'PENDING_APPROVAL',
+      deletedAt: null,
+      amount: new Prisma.Decimal(1000),
+      vatAmount: new Prisma.Decimal(70),
+      totalAmount: new Prisma.Decimal(1070),
+      withholdingTax: new Prisma.Decimal(0),
+      accountCode: '51-1101',
+      description: 'old desc',
+    };
+
+    it('rejects amount edit when status is PENDING_APPROVAL', async () => {
+      prisma.expense.findFirst.mockResolvedValue(pendingExpense);
+      await expect(service.updateExpense('exp-1', { amount: 2000 })).rejects.toThrow(
+        /แก้ไขจำนวนเงิน/,
+      );
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+    });
+
+    it('allows description-only edit when status is PENDING_APPROVAL', async () => {
+      prisma.expense.findFirst.mockResolvedValue(pendingExpense);
+      prisma.expense.update.mockResolvedValue({ ...pendingExpense, description: 'fixed typo' });
+      await service.updateExpense('exp-1', { description: 'fixed typo', note: 'clarified vendor' });
+      expect(prisma.expense.update).toHaveBeenCalledTimes(1);
+      const data = prisma.expense.update.mock.calls[0][0].data;
+      expect(data.description).toBe('fixed typo');
+      expect(data.amount).toBeUndefined();
+      expect(data.vatAmount).toBeUndefined();
+    });
+  });
 });

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -270,6 +270,20 @@ export class AccountingService {
       throw new BadRequestException('ไม่สามารถแก้ไขรายจ่ายที่อนุมัติหรือจ่ายแล้ว');
     }
 
+    // T2-C12: once a staff member submits the expense for approval, the
+    // monetary fields (amount, vatAmount, withholdingTax) are frozen. Only
+    // description-like metadata may still be edited. Prevents silently
+    // bumping a number between submission and approval. (APPROVED / PAID
+    // are already fully blocked above — this catches PENDING_APPROVAL.)
+    if (
+      expense.status === 'PENDING_APPROVAL' &&
+      (dto.amount !== undefined || dto.vatAmount !== undefined || dto.withholdingTax !== undefined)
+    ) {
+      throw new BadRequestException(
+        'แก้ไขจำนวนเงิน / VAT / ภาษีหัก ณ ที่จ่าย ไม่ได้เมื่อรายจ่ายอยู่ในสถานะรออนุมัติ — ยกเลิกการส่งอนุมัติก่อน',
+      );
+    }
+
     const data: Prisma.ExpenseUpdateInput = {};
     if (dto.accountType !== undefined) data.accountType = dto.accountType;
     if (dto.category !== undefined) {

--- a/apps/api/src/modules/audit/audit-retention.cron.spec.ts
+++ b/apps/api/src/modules/audit/audit-retention.cron.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditRetentionCron } from './audit-retention.cron';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('AuditRetentionCron.archiveOldEntries', () => {
+  let cron: AuditRetentionCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  const originalEnv = process.env.AUDIT_LOG_RETENTION_DAYS;
+
+  beforeEach(async () => {
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    delete process.env.AUDIT_LOG_RETENTION_DAYS;
+    prisma = {
+      auditLog: { updateMany: jest.fn().mockResolvedValue({ count: 0 }) },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [AuditRetentionCron, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    cron = mod.get(AuditRetentionCron);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.AUDIT_LOG_RETENTION_DAYS;
+    } else {
+      process.env.AUDIT_LOG_RETENTION_DAYS = originalEnv;
+    }
+  });
+
+  it('returns archived=0 when there are no old rows (and does not page Sentry)', async () => {
+    prisma.auditLog.updateMany.mockResolvedValue({ count: 0 });
+    const result = await cron.archiveOldEntries();
+    expect(result.archived).toBe(0);
+    expect(result.retentionDays).toBe(AuditRetentionCron.DEFAULT_RETENTION_DAYS);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('soft-archives rows older than retention (archivedAt set via updateMany, not delete)', async () => {
+    prisma.auditLog.updateMany.mockResolvedValue({ count: 42 });
+    const result = await cron.archiveOldEntries();
+    expect(result.archived).toBe(42);
+
+    // Verify we used UPDATE (not DELETE — the trigger would reject that).
+    const call = prisma.auditLog.updateMany.mock.calls[0][0];
+    expect(call.data.archivedAt).toBeInstanceOf(Date);
+    expect(call.where.archivedAt).toBeNull();
+    expect(call.where.createdAt.lt).toBeInstanceOf(Date);
+
+    // Default cutoff should be ~180d ago
+    const ageDays = (Date.now() - (call.where.createdAt.lt as Date).getTime()) / (24 * 60 * 60 * 1000);
+    expect(ageDays).toBeGreaterThan(179.9);
+    expect(ageDays).toBeLessThan(180.1);
+
+    // Sentry info when rows were actually archived
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('archived 42'),
+      expect.objectContaining({ level: 'info' }),
+    );
+  });
+
+  it('honours AUDIT_LOG_RETENTION_DAYS env override', async () => {
+    process.env.AUDIT_LOG_RETENTION_DAYS = '30';
+    prisma.auditLog.updateMany.mockResolvedValue({ count: 0 });
+    const result = await cron.archiveOldEntries();
+    expect(result.retentionDays).toBe(30);
+
+    const where = prisma.auditLog.updateMany.mock.calls[0][0].where;
+    const ageDays = (Date.now() - (where.createdAt.lt as Date).getTime()) / (24 * 60 * 60 * 1000);
+    expect(ageDays).toBeGreaterThan(29.9);
+    expect(ageDays).toBeLessThan(30.1);
+  });
+});

--- a/apps/api/src/modules/audit/audit-retention.cron.ts
+++ b/apps/api/src/modules/audit/audit-retention.cron.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * T2-C13 — weekly sweep of the main AuditLog.
+ *
+ * The AuditLog table carries the legal audit trail (who did what, when).
+ * The BEFORE DELETE trigger installed by 20260520300000_audit_log_archive_immutable
+ * refuses physical DELETEs, so we *archive* instead: set archived_at on any
+ * row older than AUDIT_LOG_RETENTION_DAYS.
+ *
+ * Archived rows remain queryable for forensics but fall outside the hot
+ * reporting set. A separate purge path (not this cron) can later hard-cull
+ * archived rows beyond the 7-year legal retention.
+ *
+ * Schedule: Sunday 03:00 Asia/Bangkok. Lines up after the audit-chain-verify
+ * cron at 03:45 on other days, avoiding lock contention.
+ */
+@Injectable()
+export class AuditRetentionCron {
+  private readonly logger = new Logger(AuditRetentionCron.name);
+  static readonly DEFAULT_RETENTION_DAYS = 180;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  private getRetentionDays(): number {
+    const raw = process.env.AUDIT_LOG_RETENTION_DAYS;
+    if (!raw) return AuditRetentionCron.DEFAULT_RETENTION_DAYS;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n <= 0) return AuditRetentionCron.DEFAULT_RETENTION_DAYS;
+    return n;
+  }
+
+  @Cron('0 3 * * 0', { timeZone: 'Asia/Bangkok' })
+  async archiveOldEntries(): Promise<{ archived: number; retentionDays: number }> {
+    const retentionDays = this.getRetentionDays();
+    try {
+      const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+      // Soft-archive only: the BEFORE DELETE trigger (T2-C4 ext) refuses
+      // physical deletes on audit_logs. UPDATE archived_at is the policy-
+      // compliant path.
+      const result = await this.prisma.auditLog.updateMany({
+        where: {
+          createdAt: { lt: cutoff },
+          archivedAt: null,
+        },
+        data: { archivedAt: new Date() },
+      });
+
+      if (result.count > 0) {
+        this.logger.log(
+          `AuditLog retention: archived ${result.count} row(s) older than ${retentionDays}d`,
+        );
+        Sentry.captureMessage(`AuditLog retention archived ${result.count} row(s)`, {
+          level: 'info',
+          tags: { kind: 'cron-job', cron: 'audit-retention' },
+          extra: { archived: result.count, retentionDays },
+        });
+      } else {
+        this.logger.log(`AuditLog retention: nothing older than ${retentionDays}d`);
+      }
+      return { archived: result.count, retentionDays };
+    } catch (err) {
+      this.logger.error(
+        `Audit retention failed: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'audit-retention' },
+      });
+      return { archived: 0, retentionDays };
+    }
+  }
+}

--- a/apps/api/src/modules/audit/audit.interceptor.spec.ts
+++ b/apps/api/src/modules/audit/audit.interceptor.spec.ts
@@ -1,0 +1,90 @@
+import { AuditInterceptor } from './audit.interceptor';
+import { AuditService } from './audit.service';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of, lastValueFrom } from 'rxjs';
+
+/**
+ * T2-C15: extend SENSITIVE_FIELDS redaction to cover integration secrets
+ * (bank API keys, PEAK secret, MDM key, webhook secret, SMS API secret)
+ * plus a regex catch-all for `*secret*` / `*apikey*` / `*token*` so the
+ * audit log never stores the plaintext value.
+ */
+describe('AuditInterceptor — T2-C15 SENSITIVE_FIELDS redaction', () => {
+  let audit: { log: jest.Mock };
+  let interceptor: AuditInterceptor;
+
+  const buildContext = (body: Record<string, unknown>) => {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          method: 'POST',
+          url: '/api/settings/system-config',
+          body,
+          user: { id: 'user-1' },
+          headers: {},
+          ip: '127.0.0.1',
+        }),
+      }),
+    } as unknown as ExecutionContext;
+    const handler = { handle: () => of({ id: 'cfg-1' }) } as unknown as CallHandler;
+    return { ctx, handler };
+  };
+
+  beforeEach(() => {
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+    interceptor = new AuditInterceptor(audit as unknown as AuditService);
+  });
+
+  it('redacts explicit integration secret keys (peakSecretKey, mdmApiKey, webhookSecret, smsApiSecret)', async () => {
+    const { ctx, handler } = buildContext({
+      peakSecretKey: 'PEAK-xxxx-plaintext',
+      mdmApiKey: 'mdm-yyyy',
+      webhookSecret: 'wh_zzz',
+      smsApiSecret: 'sms_aaa',
+      // non-sensitive passes through
+      displayName: 'SHOP settings',
+    });
+    await lastValueFrom(interceptor.intercept(ctx, handler));
+    expect(audit.log).toHaveBeenCalledTimes(1);
+    const arg = audit.log.mock.calls[0][0];
+    expect(arg.newValue).toMatchObject({
+      peakSecretKey: '[REDACTED]',
+      mdmApiKey: '[REDACTED]',
+      webhookSecret: '[REDACTED]',
+      smsApiSecret: '[REDACTED]',
+      displayName: 'SHOP settings',
+    });
+  });
+
+  it('preserves non-sensitive keys exactly', async () => {
+    const { ctx, handler } = buildContext({
+      companyCode: 'SHOP',
+      branchName: 'Ladprao',
+      nationalId: '1234567890123', // PII list (existing)
+    });
+    await lastValueFrom(interceptor.intercept(ctx, handler));
+    const arg = audit.log.mock.calls[0][0];
+    expect(arg.newValue.companyCode).toBe('SHOP');
+    expect(arg.newValue.branchName).toBe('Ladprao');
+    // nationalId is PII — still redacted by pre-existing rule
+    expect(arg.newValue.nationalId).toBe('[REDACTED]');
+  });
+
+  it('regex redacts unlisted *secret* / *apikey* / *token* shaped keys', async () => {
+    const { ctx, handler } = buildContext({
+      lineChannelSecret: 'xxxx',
+      chatConeApiKey: 'yyyy',
+      xeroAccessToken: 'zzzz',
+      // pattern must be case-insensitive
+      MY_SECRET: 'aaaa',
+      publicId: 'keep',
+    });
+    await lastValueFrom(interceptor.intercept(ctx, handler));
+    const arg = audit.log.mock.calls[0][0];
+    expect(arg.newValue.lineChannelSecret).toBe('[REDACTED]');
+    expect(arg.newValue.chatConeApiKey).toBe('[REDACTED]');
+    expect(arg.newValue.xeroAccessToken).toBe('[REDACTED]');
+    expect(arg.newValue.MY_SECRET).toBe('[REDACTED]');
+    expect(arg.newValue.publicId).toBe('keep');
+  });
+});

--- a/apps/api/src/modules/audit/audit.interceptor.ts
+++ b/apps/api/src/modules/audit/audit.interceptor.ts
@@ -21,7 +21,30 @@ export class AuditInterceptor implements NestInterceptor {
     'email', 'lineId', 'lineUserId',
     'address', 'currentAddress', 'registeredAddress',
     'bankAccount', 'bankAccountNumber', 'accountNumber',
+    // T2-C15: integration secrets stored under SystemConfig or passed in
+    // third-party webhook payloads. These leak through the audit log as
+    // "newValue" otherwise.
+    'bankApiKey', 'paymentGateway', 'peakSecretKey', 'mdmApiKey',
+    'connectId', 'userToken', 'appSecret', 'webhookSecret',
+    'secretKey', 'smsApiSecret',
   ];
+
+  /**
+   * T2-C15: pattern-match catch-all for secret-shaped keys we haven't
+   * listed explicitly (e.g. `xyzApiKey`, `someSecret`, `myToken`). Keeps
+   * us safe when new fields are added to SystemConfig without touching
+   * this file.
+   */
+  private static readonly SENSITIVE_FIELD_PATTERNS: RegExp[] = [
+    /secret/i,
+    /apikey/i,
+    /token/i,
+  ];
+
+  private static isSensitiveKey(key: string): boolean {
+    if (AuditInterceptor.SENSITIVE_FIELDS.includes(key)) return true;
+    return AuditInterceptor.SENSITIVE_FIELD_PATTERNS.some((re) => re.test(key));
+  }
 
   constructor(private auditService: AuditService) {}
 
@@ -122,12 +145,16 @@ export class AuditInterceptor implements NestInterceptor {
   private sanitizeBody(body: Record<string, unknown>): Record<string, unknown> | undefined {
     if (!body || typeof body !== 'object' || Object.keys(body).length === 0) return undefined;
     const sanitized = { ...body };
-    for (const field of AuditInterceptor.SENSITIVE_FIELDS) {
-      if (field in sanitized) {
-        sanitized[field] = '[REDACTED]';
+    // T2-C15: redact by exact name OR by regex match (e.g. xyzApiKey,
+    // someSecret). Covers the SystemConfig integration-secrets surface
+    // without having to enumerate every possible key.
+    for (const key of Object.keys(sanitized)) {
+      if (AuditInterceptor.isSensitiveKey(key)) {
+        sanitized[key] = '[REDACTED]';
       }
     }
     for (const [key, value] of Object.entries(sanitized)) {
+      if (sanitized[key] === '[REDACTED]') continue;
       if (typeof value === 'string' && value.startsWith('data:image/')) {
         sanitized[key] = '[IMAGE_DATA]';
       } else if (Array.isArray(value)) {

--- a/apps/api/src/modules/audit/audit.module.ts
+++ b/apps/api/src/modules/audit/audit.module.ts
@@ -3,11 +3,12 @@ import { AuditService } from './audit.service';
 import { AuditController } from './audit.controller';
 import { AuditInterceptor } from './audit.interceptor';
 import { AuditChainVerifyCron } from './audit-chain-verify.cron';
+import { AuditRetentionCron } from './audit-retention.cron';
 
 @Global()
 @Module({
   controllers: [AuditController],
-  providers: [AuditService, AuditInterceptor, AuditChainVerifyCron],
+  providers: [AuditService, AuditInterceptor, AuditChainVerifyCron, AuditRetentionCron],
   exports: [AuditService, AuditInterceptor],
 })
 export class AuditModule {}

--- a/apps/api/src/modules/commission/commission.controller.ts
+++ b/apps/api/src/modules/commission/commission.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Query,
+  Headers,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { CommissionService } from './commission.service';
 import { CreateCommissionRuleDto, UpdateCommissionRuleDto } from './dto/commission.dto';
@@ -78,9 +88,16 @@ export class CommissionController {
   updateRule(
     @Param('id') id: string,
     @Body() dto: UpdateCommissionRuleDto,
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string; role: string },
+    @Headers('x-retroactive-approval') retroactiveApproval?: string,
   ) {
-    return this.commissionService.updateRule(id, dto, user.id);
+    // T2-C16 — retroactive rate change requires OWNER + explicit
+    // X-Retroactive-Approval: true header. Any other truthy value is
+    // rejected too, so a sloppy "yes" or "1" in the header won't bypass.
+    return this.commissionService.updateRule(id, dto, user.id, {
+      role: user.role,
+      retroactiveApproval: retroactiveApproval?.toLowerCase() === 'true',
+    });
   }
 
   // ============================================================

--- a/apps/api/src/modules/commission/commission.service.spec.ts
+++ b/apps/api/src/modules/commission/commission.service.spec.ts
@@ -28,6 +28,9 @@ describe('CommissionService', () => {
         findFirst: jest.fn(),
         update: jest.fn(),
       },
+      auditLog: {
+        create: jest.fn().mockResolvedValue({ id: 'a1' }),
+      },
       // Simple pass-through — callers supply their own tx mock via closure
       // in describe blocks that need it. Default echoes the parent prisma so
       // tests that don't inspect tx work unchanged.
@@ -442,6 +445,70 @@ describe('CommissionService', () => {
       prisma.salesCommission.count.mockResolvedValue(999);
 
       await expect(service.updateRule('rule-1', { rate: 0.03 })).resolves.toBeDefined();
+    });
+  });
+
+  // T2-C16 — retroactive-change block. APPROVED-but-unpaid commissions
+  // carry a rate snapshot; letting the master rate change silently after
+  // approval reads to an auditor as retroactive re-pricing. Only OWNER +
+  // explicit X-Retroactive-Approval header overrides.
+  describe('updateRule — T2-C16 retroactive approval guard', () => {
+    const rule = () => ({
+      id: 'rule-1',
+      name: 'default-rule',
+      ruleType: 'PERCENTAGE',
+      rate: new Prisma.Decimal('0.03'),
+      fixedAmount: null,
+      minSaleAmount: null,
+      maxSaleAmount: null,
+    });
+    const updatedRule = (newRate = '0.05') => ({
+      ...rule(),
+      rate: new Prisma.Decimal(newRate),
+    });
+
+    it('allows rate change when no APPROVED-unpaid commissions exist', async () => {
+      prisma.commissionRule.findFirst.mockResolvedValue(rule());
+      prisma.commissionRule.update.mockResolvedValue(updatedRule());
+      // PENDING count = 0, APPROVED (unpaid) count = 0
+      prisma.salesCommission.count.mockResolvedValue(0);
+
+      await expect(
+        service.updateRule('rule-1', { rate: 0.05 }, 'u-owner', { role: 'OWNER' }),
+      ).resolves.toBeDefined();
+      expect(prisma.commissionRule.update).toHaveBeenCalled();
+    });
+
+    it('rejects rate change when APPROVED-unpaid commissions exist and header missing', async () => {
+      prisma.commissionRule.findFirst.mockResolvedValue(rule());
+      // first count = PENDING (0), second count = APPROVED-unpaid (3)
+      prisma.salesCommission.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(3);
+
+      await expect(
+        service.updateRule('rule-1', { rate: 0.05 }, 'u-owner', {
+          role: 'OWNER',
+          retroactiveApproval: false,
+        }),
+      ).rejects.toThrow(/X-Retroactive-Approval/);
+      expect(prisma.commissionRule.update).not.toHaveBeenCalled();
+    });
+
+    it('allows rate change when OWNER + X-Retroactive-Approval: true', async () => {
+      prisma.commissionRule.findFirst.mockResolvedValue(rule());
+      prisma.commissionRule.update.mockResolvedValue(updatedRule());
+      prisma.salesCommission.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(3);
+
+      await expect(
+        service.updateRule('rule-1', { rate: 0.05 }, 'u-owner', {
+          role: 'OWNER',
+          retroactiveApproval: true,
+        }),
+      ).resolves.toBeDefined();
+      expect(prisma.commissionRule.update).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/commission/commission.service.ts
+++ b/apps/api/src/modules/commission/commission.service.ts
@@ -317,7 +317,12 @@ export class CommissionService {
    *    this audit log is the source of truth for _why_ that snapshot is
    *    what it is.
    */
-  async updateRule(id: string, dto: UpdateCommissionRuleDto, userId?: string) {
+  async updateRule(
+    id: string,
+    dto: UpdateCommissionRuleDto,
+    userId?: string,
+    actor: { role?: string; retroactiveApproval?: boolean } = {},
+  ) {
     const rule = await this.prisma.commissionRule.findFirst({
       where: { id, deletedAt: null },
     });
@@ -326,6 +331,8 @@ export class CommissionService {
     if (dto.rate !== undefined && !rule.rate.equals(new Prisma.Decimal(dto.rate))) {
       const now = new Date();
       const currentPeriod = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+      // T2-C5 — block rate changes while PENDING commissions exist for the
+      // current period (snapshot invariant on SalesCommission).
       const pending = await this.prisma.salesCommission.count({
         where: {
           commissionRuleId: id,
@@ -338,6 +345,28 @@ export class CommissionService {
         throw new ConflictException(
           `เปลี่ยนอัตราไม่ได้ — มี commission ที่รอดำเนินการ ${pending} รายการใน period ${currentPeriod} ปิด period ก่อนหรือรอเดือนหน้า`,
         );
+      }
+
+      // T2-C16 — block rate changes while APPROVED-but-not-PAID commissions
+      // exist for the rule. APPROVED rows carry a rate snapshot, but a rate
+      // change could be read as retroactive re-pricing by an auditor. Only
+      // OWNER with an explicit X-Retroactive-Approval header may proceed.
+      const unpaid = await this.prisma.salesCommission.count({
+        where: {
+          commissionRuleId: id,
+          status: 'APPROVED',
+          deletedAt: null,
+        },
+      });
+      if (unpaid > 0) {
+        const isOwner = actor.role === 'OWNER';
+        const retroApproved = actor.retroactiveApproval === true;
+        if (!(isOwner && retroApproved)) {
+          throw new ForbiddenException(
+            `เปลี่ยนอัตราไม่ได้ — มี commission อนุมัติแล้วแต่ยังไม่จ่าย ${unpaid} รายการ. ` +
+              `ต้องให้ OWNER ส่ง header X-Retroactive-Approval: true เพื่อยืนยันการเปลี่ยนย้อนหลัง`,
+          );
+        }
       }
     }
 

--- a/apps/api/src/modules/journal/journal.controller.ts
+++ b/apps/api/src/modules/journal/journal.controller.ts
@@ -5,11 +5,13 @@ import {
   Param,
   Body,
   Query,
+  Req,
   UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import type { Request } from 'express';
 import { JournalService } from './journal.service';
 import { JournalAutoService } from './journal-auto.service';
 import { CreateJournalEntryDto } from './dto/journal.dto';
@@ -74,8 +76,19 @@ export class JournalController {
 
   @Post(':id/post')
   @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
-  post(@Param('id') id: string, @CurrentUser('id') userId: string) {
-    return this.journalService.post(id, userId);
+  post(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+    @Req() req: Request,
+  ) {
+    // T2-C14 — capture ip + UA at the controller edge. JournalPostAuditLog
+    // is the "who POSTED what, from where" legal-retention trail.
+    const ipAddress =
+      (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ||
+      req.ip ||
+      undefined;
+    const userAgent = req.headers['user-agent'] ?? undefined;
+    return this.journalService.post(id, userId, { ipAddress, userAgent });
   }
 
   @Post(':id/void')

--- a/apps/api/src/modules/journal/journal.service.spec.ts
+++ b/apps/api/src/modules/journal/journal.service.spec.ts
@@ -131,6 +131,13 @@ describe('JournalService.post — SoD enforcement', () => {
         findFirst: jest.fn().mockResolvedValue(balancedEntry('u-author')),
         update: jest.fn((args) => Promise.resolve({ ...balancedEntry('u-author'), ...args.data })),
       },
+      journalPostAuditLog: {
+        create: jest.fn().mockResolvedValue({ id: 'jpal-1' }),
+      },
+      // post() now wraps update + audit insert in a $transaction so a
+      // failed audit row rolls the post back.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: jest.fn(async (cb: (tx: any) => Promise<unknown>) => cb(prisma)),
     };
     const mod: TestingModule = await Test.createTestingModule({
       providers: [JournalService, { provide: PrismaService, useValue: prisma }],
@@ -162,5 +169,32 @@ describe('JournalService.post — SoD enforcement', () => {
       status: 'POSTED',
     });
     await expect(service.post('je-1', 'u-reviewer')).rejects.toThrow(BadRequestException);
+  });
+
+  // T2-C14 — post() writes an immutable JournalPostAuditLog row in the
+  // same $transaction. Failure of that insert rolls the post back.
+  it('writes JournalPostAuditLog row in the same $transaction as the post', async () => {
+    await service.post('je-1', 'u-reviewer', {
+      ipAddress: '10.0.0.1',
+      userAgent: 'jest',
+    });
+    expect(prisma.journalPostAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          journalEntryId: 'je-1',
+          postedById: 'u-reviewer',
+          ipAddress: '10.0.0.1',
+          userAgent: 'jest',
+        }),
+      }),
+    );
+    // audit + update must share a transaction (both inside the $transaction cb)
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls the post back if JournalPostAuditLog insert fails', async () => {
+    prisma.journalPostAuditLog.create.mockRejectedValue(new Error('audit insert failed'));
+    // Simulate transactional rollback: $transaction propagates the throw.
+    await expect(service.post('je-1', 'u-reviewer')).rejects.toThrow(/audit insert failed/);
   });
 });

--- a/apps/api/src/modules/journal/journal.service.ts
+++ b/apps/api/src/modules/journal/journal.service.ts
@@ -197,7 +197,11 @@ export class JournalService {
     return entry;
   }
 
-  async post(id: string, userId: string) {
+  async post(
+    id: string,
+    userId: string,
+    meta: { ipAddress?: string; userAgent?: string } = {},
+  ) {
     const entry = await this.findOne(id);
 
     if (entry.status !== 'DRAFT') {
@@ -228,14 +232,34 @@ export class JournalService {
       throw new BadRequestException('ยอดเดบิตและเครดิตไม่สมดุล');
     }
 
-    return this.prisma.journalEntry.update({
-      where: { id },
-      data: {
-        status: 'POSTED',
-        postedAt: new Date(),
-        postedById: userId,
-      },
-      include: { lines: true },
+    // T2-C14: write the immutable JournalPostAuditLog row inside the same
+    // $transaction as the post. If the audit insert fails for any reason
+    // (FK breakage, trigger rejection, DB outage mid-call) the post() is
+    // rolled back so we never end up with a POSTED entry that has no
+    // corresponding audit row.
+    const postedAt = new Date();
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.journalEntry.update({
+        where: { id },
+        data: {
+          status: 'POSTED',
+          postedAt,
+          postedById: userId,
+        },
+        include: { lines: true },
+      });
+
+      await tx.journalPostAuditLog.create({
+        data: {
+          journalEntryId: id,
+          postedById: userId,
+          postedAt,
+          ipAddress: meta.ipAddress ?? null,
+          userAgent: meta.userAgent ?? null,
+        },
+      });
+
+      return updated;
     });
   }
 

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -1,3 +1,13 @@
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+  SentryModule: class {},
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { PaymentsService } from './payments.service';
@@ -10,6 +20,7 @@ import { LineOaService } from '../line-oa/line-oa.service';
 import { FlexTemplatesService } from '../line-oa/flex-templates.service';
 import { QuickReplyService } from '../line-oa/quick-reply.service';
 import { WarrantyService } from '../warranty/warranty.service';
+import * as Sentry from '@sentry/node';
 
 describe('PaymentsService', () => {
   let service: PaymentsService;
@@ -401,6 +412,64 @@ describe('PaymentsService', () => {
       );
       expect(res.lateFeeWaived).toBe(true);
       expect(prisma.payment.update).toHaveBeenCalled();
+    });
+  });
+
+  // T1-C9 — large waiver Sentry alarm. A 200-baht goodwill waiver is
+  // routine; a 6,000-baht waiver probably deserves a second set of eyes
+  // from finance. Sentry fires at the >5,000 THB threshold so waves of
+  // abuse show up before they drain margin.
+  describe('waiveLateFee — T1-C9 large-amount Sentry alarm', () => {
+    beforeEach(() => {
+      (Sentry.captureMessage as jest.Mock).mockClear();
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'approver-1',
+        role: 'FINANCE_MANAGER',
+        isActive: true,
+        deletedAt: null,
+      });
+    });
+
+    it('does NOT call Sentry.captureMessage when waivedAmount ≤ 5,000', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...mockPayment,
+        lateFee: 5000, // exactly at threshold — not >
+        lateFeeWaived: false,
+      });
+      prisma.payment.update.mockResolvedValue({
+        ...mockPayment,
+        lateFee: 0,
+        lateFeeWaived: true,
+      });
+
+      await service.waiveLateFee('payment-1', 'goodwill', 'user-1', 'approver-1');
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('calls Sentry.captureMessage with level=warning when waivedAmount > 5,000', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...mockPayment,
+        contractId: 'contract-1',
+        lateFee: 7500,
+        lateFeeWaived: false,
+      });
+      prisma.payment.update.mockResolvedValue({
+        ...mockPayment,
+        lateFee: 0,
+        lateFeeWaived: true,
+      });
+
+      await service.waiveLateFee('payment-1', 'goodwill', 'user-1', 'approver-1');
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+      const [message, opts] = (Sentry.captureMessage as jest.Mock).mock.calls[0];
+      expect(message).toBe('Large late-fee waiver');
+      expect(opts.level).toBe('warning');
+      expect(opts.tags).toMatchObject({ kind: 'finance' });
+      expect(opts.extra).toMatchObject({
+        waivedBy: 'user-1',
+        contractId: 'contract-1',
+        amount: 7500,
+      });
     });
   });
 });

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -844,6 +844,23 @@ export class PaymentsService {
       approverId,
     });
 
+    // T1-C9 — unusual-waiver alarm. Most waivers are a few hundred baht
+    // (goodwill, one-off late days). Anything above 5,000 THB is worth a
+    // human eyeball on Sentry so finance can spot pattern abuse early.
+    if (result.originalLateFee > 5000) {
+      Sentry.captureMessage('Large late-fee waiver', {
+        level: 'warning',
+        tags: { kind: 'finance' },
+        extra: {
+          waivedBy: userId,
+          contractId: result.contractId,
+          amount: result.originalLateFee,
+          paymentId,
+          approverId,
+        },
+      });
+    }
+
     // Financial audit trail (outside transaction — audit failure shouldn't roll back waiver)
     await this.auditService.logPaymentEvent({
       userId,

--- a/apps/api/src/modules/refunds/refunds.service.spec.ts
+++ b/apps/api/src/modules/refunds/refunds.service.spec.ts
@@ -191,6 +191,59 @@ describe('RefundsService', () => {
     });
   });
 
+  // T1-C8 — bankReversalRef / bankReversalAt are write-once. First write
+  // sets bankReversalLockedAt; any subsequent markReversed attempt must
+  // reject with a Thai error.
+  describe('markReversed — T1-C8 bank reversal lock', () => {
+    it('first write sets bankReversalLockedAt', async () => {
+      prisma.refund.findUnique.mockResolvedValue(
+        refundRecord({ status: 'APPROVED', bankReversalLockedAt: null, bankReversalRef: null }),
+      );
+      await service.markReversed(
+        'rf-1',
+        { bankReversalRef: 'SCB-00001', notes: 'first write' },
+        'u-owner',
+        'OWNER',
+      );
+      const data = prisma.refund.update.mock.calls[0][0].data;
+      expect(data.bankReversalRef).toBe('SCB-00001');
+      expect(data.bankReversalLockedAt).toBeInstanceOf(Date);
+    });
+
+    it('rejects a second write once bankReversalLockedAt is set', async () => {
+      prisma.refund.findUnique.mockResolvedValue(
+        refundRecord({
+          status: 'APPROVED',
+          bankReversalRef: 'SCB-00001',
+          bankReversalAt: new Date('2026-04-01'),
+          bankReversalLockedAt: new Date('2026-04-01'),
+        }),
+      );
+      await expect(
+        service.markReversed(
+          'rf-1',
+          { bankReversalRef: 'SCB-99999', notes: 'try to overwrite' },
+          'u-owner',
+          'OWNER',
+        ),
+      ).rejects.toThrow(/ถูกล็อคแล้ว/);
+      expect(prisma.refund.update).not.toHaveBeenCalled();
+    });
+
+    it('reading still works after lock is set (findOne)', async () => {
+      const frozen = refundRecord({
+        status: 'PROCESSED',
+        bankReversalRef: 'SCB-00001',
+        bankReversalAt: new Date('2026-04-01'),
+        bankReversalLockedAt: new Date('2026-04-01'),
+      });
+      prisma.refund.findUnique.mockResolvedValue(frozen);
+      const result = await service.findOne('rf-1');
+      expect(result.bankReversalRef).toBe('SCB-00001');
+      expect(result.bankReversalLockedAt).toBeInstanceOf(Date);
+    });
+  });
+
   describe('markFailed', () => {
     it('sets FAILED with reason when bank declined', async () => {
       prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));

--- a/apps/api/src/modules/refunds/refunds.service.ts
+++ b/apps/api/src/modules/refunds/refunds.service.ts
@@ -192,14 +192,25 @@ export class RefundsService {
         `สิทธิ์บันทึก bank reversal เฉพาะ ${RefundsService.APPROVER_ROLES.join(' / ')}`,
       );
     }
+    // T1-C8: bank reversal is write-once. If bankReversalRef is already set
+    // (or the lock timestamp exists), reject further writes outright so staff
+    // can't silently edit the bank evidence after the fact.
+    if (refund.bankReversalLockedAt || refund.bankReversalRef) {
+      throw new BadRequestException(
+        'ข้อมูล bank reversal ถูกล็อคแล้วหลังจากบันทึกครั้งแรก — แก้ไขไม่ได้',
+      );
+    }
 
+    const now = new Date();
     const updated = await this.prisma.refund.update({
       where: { id: refundId },
       data: {
         status: 'PROCESSED',
         bankReversalRef: dto.bankReversalRef,
-        bankReversalAt: new Date(),
+        bankReversalAt: now,
         bankReversalNotes: dto.notes,
+        // T1-C8 — freeze bankReversalRef / bankReversalAt on first write.
+        bankReversalLockedAt: now,
       },
     });
 


### PR DESCRIPTION
## Summary — 7 items

### T1-C8 — Refund bank reversal timestamp lock
- \`Refund.bankReversalLockedAt\` column + migration
- \`markReversed()\` set lock ครั้งแรก, reject re-write ด้วย Thai error

### T1-C9 — Large waiver Sentry alert
- \`waiveLateFee()\` → Sentry warning ถ้า originalLateFee > 5000, tags kind=finance, extra = waivedBy/contract/amount

### T2-C12 — Expense PENDING_APPROVAL lock
- \`updateExpense()\` block amount/vatAmount/withholdingTax แก้ เมื่อ status = PENDING_APPROVAL; description/notes ยัง edit ได้

### T2-C13 — AuditLog retention cron
- Sunday 03:00 Asia/Bangkok — \`AUDIT_LOG_RETENTION_DAYS\` (default 180)
- ใช้ \`updateMany({ archivedAt })\` — ไม่ DELETE (เพราะ BEFORE DELETE trigger ของ T2-C4 ext)

### T2-C14 — JournalPostAuditLog immutable
- Model + migration \`20260527100000_add_journal_post_audit_log\`
- \`JournalService.post()\` รับ \`meta: { ipAddress, userAgent }\` — update + audit ใน \`$transaction\` เดียว, audit fail → rollback

### T2-C15 — SystemConfig SENSITIVE_FIELDS extension
- เพิ่ม bankApiKey, paymentGateway*, peakSecretKey, mdmApiKey, ฯลฯ
- Regex catch-all \`/secret|apikey|token/i\` ใน \`AuditInterceptor.sanitizeBody\`

### T2-C16 — CommissionRule retroactive block
- \`updateRule()\` รับ \`actor: { role, retroactiveApproval }\`
- APPROVED-unpaid count > 0 → block ยกเว้น \`OWNER + X-Retroactive-Approval: true\` header

## Test plan
- [x] +18 new cases
- [x] Full API: 90 suites / 1194 tests pass
- [x] TypeScript API: 0 errors
- [x] 2 migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)