### PR TITLE
feat(tier-8): T3+T4 medium batch (C11+C6+C9+C10+C11)

### DIFF
--- a/apps/api/prisma/migrations/20260527200000_tier8_medium_batch/migration.sql
+++ b/apps/api/prisma/migrations/20260527200000_tier8_medium_batch/migration.sql
@@ -1,0 +1,64 @@
+-- Tier-8 Medium batch migration — T3-C11 + T4-C6 + T4-C10
+--
+-- T3-C11: contracts.block_auto_escalation — manual hold on cron escalation
+-- T4-C10: sales_commissions.snapshot_salesperson_id — freeze earner at create
+-- T4-C6 : broadcast_approvals — immutable per-approver audit for large/risky
+--          broadcasts (>1000 audience OR trigger-word match)
+
+-- ──────────────────────────────────────────────────────────────
+-- T3-C11: Contract manual-hold on auto-escalation
+-- ──────────────────────────────────────────────────────────────
+ALTER TABLE "contracts"
+  ADD COLUMN "block_auto_escalation" TIMESTAMP(3);
+
+-- Partial index: only rows with an active hold are relevant to the cron
+CREATE INDEX "contracts_block_auto_escalation_idx"
+  ON "contracts"("block_auto_escalation")
+  WHERE "block_auto_escalation" IS NOT NULL;
+
+-- ──────────────────────────────────────────────────────────────
+-- T4-C10: SalesCommission snapshot salesperson
+-- ──────────────────────────────────────────────────────────────
+ALTER TABLE "sales_commissions"
+  ADD COLUMN "snapshot_salesperson_id" TEXT;
+
+-- Backfill: existing rows have no snapshot — use salesperson_id as
+-- source-of-truth for legacy commissions (they were never reassigned since
+-- the reassignment feature was introduced after this field).
+UPDATE "sales_commissions"
+  SET "snapshot_salesperson_id" = "salesperson_id"
+  WHERE "snapshot_salesperson_id" IS NULL;
+
+CREATE INDEX "sales_commissions_snapshot_salesperson_id_idx"
+  ON "sales_commissions"("snapshot_salesperson_id");
+
+-- ──────────────────────────────────────────────────────────────
+-- T4-C6: BroadcastApproval — immutable per-approver audit
+-- ──────────────────────────────────────────────────────────────
+CREATE TABLE "broadcast_approvals" (
+  "id" TEXT NOT NULL,
+  "broadcast_id" TEXT NOT NULL,
+  "approver_id" TEXT NOT NULL,
+  "reason" TEXT NOT NULL,
+  "trigger_matched" TEXT,
+  "audience_size" INTEGER NOT NULL,
+  "approved_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "broadcast_approvals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "broadcast_approvals_broadcast_id_approver_id_key"
+  ON "broadcast_approvals"("broadcast_id", "approver_id");
+CREATE INDEX "broadcast_approvals_broadcast_id_idx"
+  ON "broadcast_approvals"("broadcast_id");
+CREATE INDEX "broadcast_approvals_approver_id_idx"
+  ON "broadcast_approvals"("approver_id");
+
+ALTER TABLE "broadcast_approvals"
+  ADD CONSTRAINT "broadcast_approvals_broadcast_id_fkey"
+  FOREIGN KEY ("broadcast_id") REFERENCES "broadcast_messages"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "broadcast_approvals"
+  ADD CONSTRAINT "broadcast_approvals_approver_id_fkey"
+  FOREIGN KEY ("approver_id") REFERENCES "users"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -449,6 +449,7 @@ model User {
   broadcastMessages      BroadcastMessage[]   @relation("BroadcastCreatedBy")
   broadcastsApproved     BroadcastMessage[]   @relation("BroadcastApprovedBy")
   broadcastsRejected     BroadcastMessage[]   @relation("BroadcastRejectedBy")
+  broadcastApprovals     BroadcastApproval[]  @relation("BroadcastApprovalBy")
   refundsRequested       Refund[]             @relation("RefundRequestedBy")
   refundsApproved        Refund[]             @relation("RefundApprovedBy")
   refundsRejected        Refund[]             @relation("RefundRejectedBy")
@@ -633,6 +634,13 @@ model Contract {
   /// these fields.
   pendingDunningStage DunningStage? @map("pending_dunning_stage")
   pendingDunningSince DateTime?    @map("pending_dunning_since")
+
+  /// T3-C11: Manual hold on auto-escalation. When set to a future timestamp,
+  /// the cron (overdue.updateContractStatuses / escalateDunningStages) skips
+  /// this contract. Used when a BM/FM wants to give the customer more time
+  /// without tripping the escalator mid-conversation. Default hold duration
+  /// is 48h — long enough to resolve a promise-to-pay cycle.
+  blockAutoEscalation  DateTime? @map("block_auto_escalation")
 
   // Retention policy
   retentionStatus DocumentRetentionStatus @default(ACTIVE) @map("retention_status")
@@ -2794,6 +2802,13 @@ model CommissionRule {
 model SalesCommission {
   id               String           @id @default(uuid())
   salespersonId    String           @map("salesperson_id")
+  /// T4-C10: Snapshot of contract.salespersonId at the moment the commission
+  /// was created. If the contract is reassigned later via contracts admin,
+  /// the commission stays tied to whoever actually closed the deal. Read this
+  /// field (not salespersonId) when producing commission reports for payouts.
+  /// Nullable for legacy rows pre-migration — backfill to salespersonId in
+  /// that case.
+  snapshotSalespersonId String?     @map("snapshot_salesperson_id")
   contractId       String?          @map("contract_id")
   saleId           String?          @map("sale_id")
   commissionRuleId String?          @map("commission_rule_id")
@@ -2832,6 +2847,7 @@ model SalesCommission {
   approvedBy     User?           @relation("CommissionApprovedBy", fields: [approvedById], references: [id])
 
   @@index([salespersonId])
+  @@index([snapshotSalespersonId])
   @@index([contractId])
   @@index([saleId])
   @@index([period])
@@ -4181,9 +4197,38 @@ model BroadcastMessage {
   rejectedAt     DateTime? @map("rejected_at")
   rejectedReason String?   @map("rejected_reason")
 
+  approvals     BroadcastApproval[]
+
   @@index([status, scheduledAt])
   @@index([createdAt])
   @@index([approvedById])
   @@index([rejectedById])
   @@map("broadcast_messages")
+}
+
+/// T4-C6: Immutable per-approver audit row for broadcast approvals.
+/// Large-audience (>1000) or high-risk (legal/collection trigger words)
+/// broadcasts require TWO distinct OWNER approvers before dispatch. Each
+/// approval creates one row — the service counts them and only flips the
+/// BroadcastMessage to APPROVED once the threshold is met. Rows are never
+/// updated or deleted; retention is handled by audit cron (1yr).
+///
+/// Immutable append-only audit — updatedAt/deletedAt intentionally omitted.
+model BroadcastApproval {
+  id              String           @id @default(uuid())
+  broadcastId     String           @map("broadcast_id")
+  broadcast       BroadcastMessage @relation(fields: [broadcastId], references: [id], onDelete: Cascade)
+  approverId      String           @map("approver_id")
+  approver        User             @relation("BroadcastApprovalBy", fields: [approverId], references: [id])
+  /// Why the second approval was required (AUDIENCE_SIZE | TRIGGER_WORD).
+  reason          String
+  /// Matched trigger word (if reason = TRIGGER_WORD) — null otherwise.
+  triggerMatched  String?          @map("trigger_matched")
+  audienceSize    Int              @map("audience_size")
+  approvedAt      DateTime         @default(now()) @map("approved_at")
+
+  @@unique([broadcastId, approverId])
+  @@index([broadcastId])
+  @@index([approverId])
+  @@map("broadcast_approvals")
 }

--- a/apps/api/src/modules/broadcast/broadcast.controller.ts
+++ b/apps/api/src/modules/broadcast/broadcast.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Req, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, Param, Req, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { BroadcastService } from './broadcast.service';
 import { CreateBroadcastDto } from './dto/create-broadcast.dto';
@@ -17,5 +17,17 @@ export class BroadcastController {
   @Roles('OWNER')
   async send(@Body() dto: CreateBroadcastDto, @Req() req: any) {
     return this.broadcastService.sendBroadcast(dto, req.user.id);
+  }
+
+  // T4-C6: a SECOND OWNER (not the creator) must approve large-audience or
+  // trigger-word-containing broadcasts. Must be a distinct userId from the
+  // one who called /send.
+  @Post(':id/approve')
+  @Roles('OWNER')
+  async approve(
+    @Param('id') id: string,
+    @Req() req: any,
+  ) {
+    return this.broadcastService.approveBroadcast(id, req.user.id, req.user.role);
   }
 }

--- a/apps/api/src/modules/broadcast/broadcast.service.spec.ts
+++ b/apps/api/src/modules/broadcast/broadcast.service.spec.ts
@@ -1,0 +1,191 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { ChatChannel } from '@prisma/client';
+import { BroadcastService } from './broadcast.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LineOaService } from '../line-oa/line-oa.service';
+import { LineFinanceClientService } from '../chatbot-finance/services/line-finance-client.service';
+
+describe('BroadcastService (T4-C6: large-audience + trigger-word 2nd approval)', () => {
+  let service: BroadcastService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let lineOa: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let lineFinance: any;
+
+  beforeEach(async () => {
+    prisma = {
+      customerLineLink: { findMany: jest.fn().mockResolvedValue([]) },
+      chatRoom: { findMany: jest.fn().mockResolvedValue([]) },
+      notificationLog: { create: jest.fn().mockResolvedValue({}) },
+      broadcastMessage: {
+        create: jest.fn().mockResolvedValue({ id: 'bm-1' }),
+        findUnique: jest.fn(),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      broadcastApproval: {
+        create: jest.fn().mockImplementation(({ data }) =>
+          Promise.resolve({ id: 'ba-' + data.approverId, ...data }),
+        ),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
+    };
+    lineOa = { pushMessage: jest.fn().mockResolvedValue(undefined) };
+    lineFinance = { pushText: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BroadcastService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LineOaService, useValue: lineOa },
+        { provide: LineFinanceClientService, useValue: lineFinance },
+      ],
+    }).compile();
+
+    service = module.get<BroadcastService>(BroadcastService);
+  });
+
+  describe('evaluateApprovalRequirement (pure)', () => {
+    it('does NOT require approval for small benign broadcast', () => {
+      const v = service.evaluateApprovalRequirement('สวัสดีครับ', 10);
+      expect(v.required).toBe(false);
+    });
+
+    it('requires approval when audience > 1000', () => {
+      const v = service.evaluateApprovalRequirement('ข้อความธรรมดา', 1001);
+      expect(v.required).toBe(true);
+      expect(v.reason).toBe('AUDIENCE_SIZE');
+    });
+
+    it('requires approval on trigger word regardless of size', () => {
+      const v = service.evaluateApprovalRequirement(
+        'ถ้าไม่จ่ายจะยึดคืน',
+        5,
+      );
+      expect(v.required).toBe(true);
+      expect(v.reason).toBe('TRIGGER_WORD');
+      expect(v.triggerMatched).toBe('ยึด');
+    });
+  });
+
+  describe('sendBroadcast', () => {
+    // Helper to stub targets via customerLineLink
+    const stubTargets = (count: number) => {
+      const links = Array.from({ length: count }, (_, i) => ({
+        customerId: `cust-${i}`,
+        lineUserId: `U${i}`,
+        customer: { name: `ลูกค้า ${i}` },
+      }));
+      prisma.customerLineLink.findMany.mockResolvedValue(links);
+    };
+
+    it('small benign audience → sends without approval gate', async () => {
+      stubTargets(5);
+      const result = await service.sendBroadcast(
+        {
+          channel: ChatChannel.LINE_FINANCE,
+          message: 'สวัสดีครับ',
+        },
+        'owner-1',
+      );
+      expect(result.total).toBe(5);
+      expect(prisma.broadcastMessage.create).not.toHaveBeenCalled();
+      expect(lineFinance.pushText).toHaveBeenCalled();
+    });
+
+    it('audience > 1000 with 1 approver → ForbiddenException + queue row created', async () => {
+      stubTargets(1500);
+      await expect(
+        service.sendBroadcast(
+          {
+            channel: ChatChannel.LINE_FINANCE,
+            message: 'ข้อความธรรมดา',
+          },
+          'owner-1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.broadcastMessage.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'PENDING_APPROVAL',
+            audienceCount: 1500,
+            createdById: 'owner-1',
+          }),
+        }),
+      );
+      expect(lineFinance.pushText).not.toHaveBeenCalled();
+    });
+
+    it('trigger word triggers approval gate even when audience is small', async () => {
+      stubTargets(10);
+      await expect(
+        service.sendBroadcast(
+          {
+            channel: ChatChannel.LINE_FINANCE,
+            message: 'ถ้าไม่จ่ายจะดำเนินคดีตามกฎหมาย',
+          },
+          'owner-1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.broadcastMessage.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('approveBroadcast — 2-person SoD', () => {
+    it('rejects non-OWNER approver', async () => {
+      await expect(
+        service.approveBroadcast('bm-1', 'u-1', 'FINANCE_MANAGER'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects when approver is the creator (SoD)', async () => {
+      prisma.broadcastMessage.findUnique.mockResolvedValue({
+        id: 'bm-1',
+        createdById: 'owner-1',
+        audienceCount: 2000,
+        messages: [{ type: 'text', content: 'bulk' }],
+        approvals: [],
+      });
+      await expect(
+        service.approveBroadcast('bm-1', 'owner-1', 'OWNER'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('records 1st approval but does NOT flip status to APPROVED', async () => {
+      prisma.broadcastMessage.findUnique.mockResolvedValue({
+        id: 'bm-1',
+        createdById: 'owner-1',
+        audienceCount: 2000,
+        messages: [{ type: 'text', content: 'bulk' }],
+        approvals: [],
+      });
+      const result = await service.approveBroadcast('bm-1', 'owner-2', 'OWNER');
+      expect(result.cleared).toBe(false);
+      expect(result.totalApprovals).toBe(1);
+      expect(prisma.broadcastApproval.create).toHaveBeenCalled();
+      expect(prisma.broadcastMessage.update).not.toHaveBeenCalled();
+    });
+
+    it('2nd distinct approver flips status → APPROVED', async () => {
+      prisma.broadcastMessage.findUnique.mockResolvedValue({
+        id: 'bm-1',
+        createdById: 'owner-1',
+        audienceCount: 2000,
+        messages: [{ type: 'text', content: 'bulk' }],
+        approvals: [
+          { id: 'ba-1', approverId: 'owner-2' }, // one prior approval
+        ],
+      });
+      const result = await service.approveBroadcast('bm-1', 'owner-3', 'OWNER');
+      expect(result.cleared).toBe(true);
+      expect(result.totalApprovals).toBe(2);
+      expect(prisma.broadcastMessage.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'APPROVED' }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/modules/broadcast/broadcast.service.ts
+++ b/apps/api/src/modules/broadcast/broadcast.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { Injectable, Logger, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { LineOaService } from '../line-oa/line-oa.service';
 import { LineFinanceClientService } from '../chatbot-finance/services/line-finance-client.service';
@@ -9,6 +9,24 @@ interface BroadcastTarget {
   customerId: string;
   externalUserId: string; // lineUserId, FB PSID, etc.
   displayName: string;
+}
+
+/**
+ * T4-C6: broadcasts >1000 recipients or carrying legal/collection trigger
+ * words require a SECOND independent OWNER approval before dispatch. The
+ * first approval is the OWNER who calls send; the second must be a
+ * different OWNER who calls approveBroadcast(). Trigger words cover seizure
+ * / lawsuit / debt-collection language (ยึด/ฟ้อง/คดี/ทวง/ดำเนินคดี/ศาล)
+ * because a typo here that reaches 5000 customers has PDPA + reputational
+ * blast radius.
+ */
+const LARGE_AUDIENCE_THRESHOLD = 1000;
+const TRIGGER_WORDS = /(ยึด|ฟ้อง|คดี|ทวง|ดำเนินคดี|ศาล)/;
+
+interface ApprovalVerdict {
+  required: boolean;
+  reason: 'AUDIENCE_SIZE' | 'TRIGGER_WORD' | null;
+  triggerMatched: string | null;
 }
 
 @Injectable()
@@ -22,18 +40,154 @@ export class BroadcastService {
   ) {}
 
   /**
+   * Evaluate whether a broadcast needs a second-approver gate.
+   * Pure — no DB writes. Exposed for tests + UI preview.
+   */
+  evaluateApprovalRequirement(
+    message: string,
+    audienceSize: number,
+  ): ApprovalVerdict {
+    if (audienceSize > LARGE_AUDIENCE_THRESHOLD) {
+      return { required: true, reason: 'AUDIENCE_SIZE', triggerMatched: null };
+    }
+    const match = TRIGGER_WORDS.exec(message);
+    if (match) {
+      return { required: true, reason: 'TRIGGER_WORD', triggerMatched: match[0] };
+    }
+    return { required: false, reason: null, triggerMatched: null };
+  }
+
+  /**
+   * T4-C6: Record a second OWNER approval for a queued broadcast.
+   * Called by the endpoint that a SECOND OWNER (distinct from the one who
+   * called send) hits to clear the gate.
+   */
+  async approveBroadcast(
+    broadcastId: string,
+    approverId: string,
+    approverRole: string,
+  ) {
+    if (approverRole !== 'OWNER') {
+      throw new ForbiddenException('สิทธิ์อนุมัติ broadcast เฉพาะ OWNER');
+    }
+
+    const broadcast = await this.prisma.broadcastMessage.findUnique({
+      where: { id: broadcastId },
+      include: { approvals: true },
+    });
+    if (!broadcast) throw new BadRequestException('ไม่พบ broadcast นี้');
+
+    if (broadcast.approvals.some((a) => a.approverId === approverId)) {
+      throw new BadRequestException('ผู้ใช้งานคนนี้อนุมัติแล้ว');
+    }
+    if (broadcast.createdById === approverId) {
+      throw new ForbiddenException(
+        'ผู้อนุมัติรอบสองต้องไม่ใช่ผู้สร้าง (Segregation of Duties)',
+      );
+    }
+
+    const verdict = this.evaluateApprovalRequirement(
+      this.messageText(broadcast.messages),
+      broadcast.audienceCount,
+    );
+
+    const approval = await this.prisma.broadcastApproval.create({
+      data: {
+        broadcastId,
+        approverId,
+        reason: verdict.reason ?? 'AUDIENCE_SIZE',
+        triggerMatched: verdict.triggerMatched,
+        audienceSize: broadcast.audienceCount,
+      },
+    });
+
+    // Audit log for forensics — complements the immutable BroadcastApproval
+    await this.prisma.auditLog.create({
+      data: {
+        userId: approverId,
+        action: 'BROADCAST_APPROVAL_GRANTED',
+        entity: 'broadcast',
+        entityId: broadcastId,
+        newValue: {
+          reason: verdict.reason,
+          triggerMatched: verdict.triggerMatched,
+          audienceSize: broadcast.audienceCount,
+        },
+      },
+    });
+
+    const totalApprovals = broadcast.approvals.length + 1;
+    const cleared = totalApprovals >= 2;
+    if (cleared) {
+      await this.prisma.broadcastMessage.update({
+        where: { id: broadcastId },
+        data: { status: 'APPROVED', approvedById: approverId, approvedAt: new Date() },
+      });
+    }
+
+    return { approvalId: approval.id, totalApprovals, cleared };
+  }
+
+  private messageText(raw: unknown): string {
+    // BroadcastMessage.messages is Json[] — safely flatten for trigger scan
+    if (Array.isArray(raw)) {
+      return raw
+        .map((m) => (m && typeof m === 'object' && 'content' in (m as any)) ? String((m as any).content ?? '') : '')
+        .join(' ');
+    }
+    return typeof raw === 'string' ? raw : '';
+  }
+
+  /**
    * Send broadcast message to customers on the specified channel.
    * Returns summary of sent/failed counts.
    */
   async sendBroadcast(
     dto: CreateBroadcastDto,
     staffId: string,
-  ): Promise<{ total: number; sent: number; failed: number }> {
+  ): Promise<{ total: number; sent: number; failed: number; pendingApprovalId?: string }> {
     // 1. Resolve target customers
     const targets = await this.resolveTargets(dto);
 
     if (targets.length === 0) {
       throw new BadRequestException('ไม่พบลูกค้าที่ตรงกับเงื่อนไขที่กำหนด');
+    }
+
+    // T4-C6: large audience OR legal-risk message → require a second OWNER
+    // approver. Persist a PENDING_APPROVAL BroadcastMessage row; actual
+    // dispatch happens on the second approval via a separate code path.
+    const verdict = this.evaluateApprovalRequirement(dto.message, targets.length);
+    if (verdict.required) {
+      const queued = await this.prisma.broadcastMessage.create({
+        data: {
+          messages: [{ type: 'text', content: dto.message }],
+          audience: dto.filterTags?.join(',') ?? (dto.customerIds ? 'CUSTOM' : 'ALL'),
+          audienceCount: targets.length,
+          status: 'PENDING_APPROVAL',
+          createdById: staffId,
+        },
+      });
+      await this.prisma.auditLog.create({
+        data: {
+          userId: staffId,
+          action: 'BROADCAST_PENDING_SECOND_APPROVAL',
+          entity: 'broadcast',
+          entityId: queued.id,
+          newValue: {
+            reason: verdict.reason,
+            triggerMatched: verdict.triggerMatched,
+            audienceSize: targets.length,
+          },
+        },
+      });
+      this.logger.warn(
+        `[Broadcast] Blocked — second approval required: reason=${verdict.reason}, audience=${targets.length}, id=${queued.id}`,
+      );
+      throw new ForbiddenException(
+        verdict.reason === 'AUDIENCE_SIZE'
+          ? `Broadcast เกิน ${LARGE_AUDIENCE_THRESHOLD} รายต้องมี OWNER อนุมัติเพิ่มอีก 1 คน (broadcastId=${queued.id})`
+          : `ข้อความมีคำที่อ่อนไหวทางกฎหมาย (${verdict.triggerMatched}) ต้องมี OWNER อนุมัติเพิ่มอีก 1 คน (broadcastId=${queued.id})`,
+      );
     }
 
     this.logger.log(

--- a/apps/api/src/modules/chat-engine/services/assignment.service.spec.ts
+++ b/apps/api/src/modules/chat-engine/services/assignment.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { AssignmentService } from './assignment.service';
 import { PrismaService } from '../../../prisma/prisma.service';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ChatRoomStatus } from '@prisma/client';
 
 describe('AssignmentService', () => {
@@ -15,9 +15,15 @@ describe('AssignmentService', () => {
         update: jest.fn(),
         groupBy: jest.fn(),
       },
+      contract: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
       staffChatActivity: {
         create: jest.fn(),
         createMany: jest.fn(),
+      },
+      auditLog: {
+        create: jest.fn(),
       },
     };
 
@@ -73,6 +79,63 @@ describe('AssignmentService', () => {
           expect.objectContaining({ staffId: 'staff-B', action: 'transfer_in' }),
         ]),
       });
+    });
+
+    // T4-C11: commission hijack guard
+    it('allows handoff when customer has NO signed contract', async () => {
+      prisma.chatRoom.findUnique.mockResolvedValue({
+        id: 'room-1',
+        customerId: 'cust-1',
+      });
+      prisma.contract.findFirst.mockResolvedValue(null); // no signed contract
+      prisma.chatRoom.update.mockResolvedValue({});
+      prisma.staffChatActivity.createMany.mockResolvedValue({});
+
+      await expect(
+        service.transfer('room-1', 'staff-A', 'staff-B', 'BRANCH_MANAGER'),
+      ).resolves.toBeUndefined();
+      expect(prisma.chatRoom.update).toHaveBeenCalled();
+    });
+
+    it('T4-C11: rejects handoff after customer signed contract (non-OWNER)', async () => {
+      prisma.chatRoom.findUnique.mockResolvedValue({
+        id: 'room-1',
+        customerId: 'cust-1',
+      });
+      prisma.contract.findFirst.mockResolvedValue({
+        id: 'contract-99',
+        contractNumber: 'CT-2026-0099',
+      });
+
+      await expect(
+        service.transfer('room-1', 'staff-A', 'staff-B', 'BRANCH_MANAGER'),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.chatRoom.update).not.toHaveBeenCalled();
+    });
+
+    it('T4-C11: OWNER can override handoff post-signature with audit log', async () => {
+      prisma.chatRoom.findUnique.mockResolvedValue({
+        id: 'room-1',
+        customerId: 'cust-1',
+      });
+      prisma.contract.findFirst.mockResolvedValue({
+        id: 'contract-99',
+        contractNumber: 'CT-2026-0099',
+      });
+      prisma.chatRoom.update.mockResolvedValue({});
+      prisma.staffChatActivity.createMany.mockResolvedValue({});
+      prisma.auditLog.create.mockResolvedValue({});
+
+      await service.transfer('room-1', 'owner-1', 'staff-B', 'OWNER');
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'CHAT_HANDOFF_POST_SIGNATURE_OVERRIDE',
+          }),
+        }),
+      );
+      expect(prisma.chatRoom.update).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/chat-engine/services/assignment.service.ts
+++ b/apps/api/src/modules/chat-engine/services/assignment.service.ts
@@ -1,4 +1,11 @@
-import { Injectable, Logger, NotFoundException, Inject, Optional } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+  Inject,
+  Optional,
+} from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { ChatRoomStatus } from '@prisma/client';
 import { IChatGateway, CHAT_GATEWAY_TOKEN } from '../interfaces/chat-gateway.interface';
@@ -48,17 +55,77 @@ export class AssignmentService {
     this.gateway?.emitToStaff(staffId, 'chat:assigned', { roomId, assignedToId: staffId });
   }
 
-  /** Transfer a room from one staff to another */
+  /**
+   * Transfer a room from one staff to another.
+   *
+   * T4-C11 — commission-hijack guard: if the customer in this chat room
+   * has already SIGNED a contract (any contract the customer owns that is
+   * post-DRAFT / has a signature or has moved into ACTIVE workflow), the
+   * sale is effectively booked to the current owner of the chat. Allowing
+   * a transfer post-signature lets agent B inherit the chat ownership
+   * and claim the commission on agent A's deal via CRM attribution.
+   *
+   * Reject the transfer. OWNER may override (with audit trail) when a
+   * genuine escalation is needed — the override is the loud path so
+   * collusion leaves fingerprints.
+   */
   async transfer(
     roomId: string,
     fromStaffId: string,
     toStaffId: string,
+    actorRole?: string,
   ): Promise<void> {
     const room = await this.prisma.chatRoom.findUnique({
       where: { id: roomId },
-      select: { id: true, assignedToId: true },
+      select: { id: true, assignedToId: true, customerId: true },
     });
     if (!room) throw new NotFoundException('ไม่พบ room');
+
+    // T4-C11: block handoff if customer has a signed / active contract
+    if (room.customerId) {
+      const signedContract = await this.prisma.contract.findFirst({
+        where: {
+          customerId: room.customerId,
+          deletedAt: null,
+          OR: [
+            // Workflow-level: approved means contract is past signature gate
+            { workflowStatus: 'APPROVED' },
+            // Status-level: anything past DRAFT is "already signed" territory
+            { status: { in: ['ACTIVE', 'COMPLETED', 'OVERDUE', 'DEFAULT'] } },
+            // Belt-and-suspenders: any signature row on the contract
+            { signatures: { some: { deletedAt: null } } },
+          ],
+        },
+        select: { id: true, contractNumber: true },
+      });
+
+      if (signedContract) {
+        if (actorRole !== 'OWNER') {
+          throw new ForbiddenException(
+            `ลูกค้าเซ็นสัญญาแล้ว (${signedContract.contractNumber}) — ห้ามโอนห้องแชทเพื่อป้องกันการแย่งค่าคอมมิชชัน หากจำเป็น ให้ OWNER เป็นผู้โอน`,
+          );
+        }
+        // OWNER override — loud audit log
+        await this.prisma.auditLog.create({
+          data: {
+            userId: fromStaffId,
+            action: 'CHAT_HANDOFF_POST_SIGNATURE_OVERRIDE',
+            entity: 'chat_room',
+            entityId: roomId,
+            newValue: {
+              contractId: signedContract.id,
+              contractNumber: signedContract.contractNumber,
+              fromStaffId,
+              toStaffId,
+              overriddenBy: 'OWNER',
+            },
+          },
+        });
+        this.logger.warn(
+          `[Handoff] OWNER override — room ${roomId} transferred post-signature (${signedContract.contractNumber})`,
+        );
+      }
+    }
 
     await this.prisma.chatRoom.update({
       where: { id: roomId },

--- a/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
@@ -210,4 +210,74 @@ describe('VerificationService', () => {
       expect(result.linked).toBe(false);
     });
   });
+
+  // ─────────────────────────────────────────────────────────────
+  // T4-C9: per-lineUserId lookup rate limit
+  // ─────────────────────────────────────────────────────────────
+  describe('T4-C9 per-lineUserId lookup rate limit', () => {
+    beforeEach(() => {
+      service._resetLookupTrackerForTests();
+    });
+
+    it('allows 3 successful lookups in a row (counter clears on success)', async () => {
+      prisma.customer.findFirst.mockResolvedValue({
+        id: 'c1',
+        name: 'สมชาย',
+        phone: '0891234567',
+      });
+
+      for (let i = 0; i < 3; i++) {
+        await expect(
+          service.requestOtp({ lineUserId: 'U-success', phone: '0891234567' }),
+        ).resolves.toBeDefined();
+        // reset cooldown row so next iteration isn't blocked by it
+        prisma.chatbotOtpRequest.findUnique.mockResolvedValue(null);
+      }
+      expect(notifications.sendSmsFromQueue).toHaveBeenCalledTimes(3);
+    });
+
+    it('locks lineUserId after 3 failed lookups', async () => {
+      // Unknown phone — service throws on each call
+      prisma.customer.findFirst.mockResolvedValue(null);
+
+      // 3 failing lookups
+      for (let i = 0; i < 3; i++) {
+        await expect(
+          service.requestOtp({ lineUserId: 'U-bad', phone: '0810000000' }),
+        ).rejects.toThrow(BadRequestException);
+      }
+
+      // 4th attempt — locked message ("รออีก … วินาที")
+      await expect(
+        service.requestOtp({ lineUserId: 'U-bad', phone: '0810000000' }),
+      ).rejects.toThrow(/รออีก/);
+    });
+
+    it('lock expires after 30 minutes (jest fake timers)', async () => {
+      jest.useFakeTimers();
+      try {
+        prisma.customer.findFirst.mockResolvedValue(null);
+        for (let i = 0; i < 3; i++) {
+          await expect(
+            service.requestOtp({ lineUserId: 'U-exp', phone: '0810000000' }),
+          ).rejects.toThrow(BadRequestException);
+        }
+
+        // Immediately locked
+        await expect(
+          service.requestOtp({ lineUserId: 'U-exp', phone: '0810000000' }),
+        ).rejects.toThrow(/รออีก/);
+
+        // Advance 31 minutes — lock should be released
+        jest.advanceTimersByTime(31 * 60 * 1000);
+
+        // Now we're back to "normal not-found" behavior
+        await expect(
+          service.requestOtp({ lineUserId: 'U-exp', phone: '0810000000' }),
+        ).rejects.toThrow(/ไม่พบเบอร์โทรนี้ในระบบ/);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
 });

--- a/apps/api/src/modules/chatbot-finance/services/verification.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.ts
@@ -12,6 +12,16 @@ const OTP_MAX_ATTEMPTS = 3;
 const OTP_LENGTH = 6;
 const OTP_REQUEST_COOLDOWN_MS = 60 * 1000; // 1 นาที
 
+// T4-C9: per-lineUserId phone-lookup rate limit. LIFF-level throttle above
+// (5/min/IP) caps spam from a single client IP, but a single LINE user can
+// still rotate IPs (mobile network + wifi). Count failed lookups per
+// lineUserId and lock for 30 min after 3 fails inside a 30-min window.
+// In-memory Map is fine — single-process API; if we scale to multi-node we
+// lift this to Redis (TODO).
+const LOOKUP_FAIL_WINDOW_MS = 30 * 60 * 1000;
+const LOOKUP_FAIL_THRESHOLD = 3;
+const LOOKUP_LOCK_DURATION_MS = 30 * 60 * 1000;
+
 /**
  * Verification — DB-backed OTP store (works across multiple instances)
  *
@@ -28,10 +38,59 @@ const OTP_REQUEST_COOLDOWN_MS = 60 * 1000; // 1 นาที
 export class VerificationService {
   private readonly logger = new Logger(VerificationService.name);
 
+  // T4-C9: per-lineUserId failure timestamps + lock-until. Map key is
+  // lineUserId. Entry with `lockedUntil` set is fast-rejected until expiry.
+  private readonly lookupFailTracker = new Map<
+    string,
+    { fails: number[]; lockedUntil?: number }
+  >();
+
   constructor(
     private prisma: PrismaService,
     private notifications: NotificationsService,
   ) {}
+
+  /**
+   * T4-C9 helper: check if the caller is currently rate-limited AND record
+   * / clear fails. Exposed for tests via a single method so the lock state
+   * is observable + reset deterministically.
+   */
+  private checkLookupLock(lineUserId: string, now = Date.now()): void {
+    const entry = this.lookupFailTracker.get(lineUserId);
+    if (entry?.lockedUntil && entry.lockedUntil > now) {
+      const waitSec = Math.ceil((entry.lockedUntil - now) / 1000);
+      throw new BadRequestException(
+        `ค้นหาเบอร์ล้มเหลวหลายครั้ง กรุณารออีก ${waitSec} วินาที`,
+      );
+    }
+    if (entry?.lockedUntil && entry.lockedUntil <= now) {
+      // lock expired — reset
+      this.lookupFailTracker.delete(lineUserId);
+    }
+  }
+
+  private recordLookupFail(lineUserId: string, now = Date.now()): void {
+    const entry = this.lookupFailTracker.get(lineUserId) ?? { fails: [] };
+    // prune outside the window
+    entry.fails = entry.fails.filter((t) => now - t < LOOKUP_FAIL_WINDOW_MS);
+    entry.fails.push(now);
+    if (entry.fails.length >= LOOKUP_FAIL_THRESHOLD) {
+      entry.lockedUntil = now + LOOKUP_LOCK_DURATION_MS;
+      this.logger.warn(
+        `[Verify] lineUserId locked after ${entry.fails.length} failed lookups`,
+      );
+    }
+    this.lookupFailTracker.set(lineUserId, entry);
+  }
+
+  private clearLookupFails(lineUserId: string): void {
+    this.lookupFailTracker.delete(lineUserId);
+  }
+
+  /** T4-C9 test hook: reset the in-memory tracker between test cases. */
+  _resetLookupTrackerForTests(): void {
+    this.lookupFailTracker.clear();
+  }
 
   /**
    * Step 1: เริ่ม OTP flow
@@ -44,8 +103,12 @@ export class VerificationService {
     maskedPhone: string;
     expiresInSeconds: number;
   }> {
+    // T4-C9: per-lineUserId lock guard — fail fast before any DB work.
+    this.checkLookupLock(params.lineUserId);
+
     const phone = this.normalizePhone(params.phone);
     if (!phone) {
+      this.recordLookupFail(params.lineUserId);
       throw new BadRequestException('เบอร์โทรไม่ถูกต้อง');
     }
 
@@ -78,11 +141,16 @@ export class VerificationService {
     };
 
     if (!customer) {
+      // T4-C9: failed phone→customer lookup. Record fail and maybe lock.
+      this.recordLookupFail(params.lineUserId);
       this.logger.log(`[Verify] OTP requested for unknown phone`);
       throw new BadRequestException(
         'ไม่พบเบอร์โทรนี้ในระบบค่ะ กรุณาตรวจสอบเบอร์โทร หรือติดต่อสาขา 063-134-6356',
       );
     }
+
+    // T4-C9: successful lookup clears the fail counter
+    this.clearLookupFails(params.lineUserId);
 
     // Generate OTP + persist
     const otp = this.generateOtp();

--- a/apps/api/src/modules/commission/commission.service.spec.ts
+++ b/apps/api/src/modules/commission/commission.service.spec.ts
@@ -31,6 +31,10 @@ describe('CommissionService', () => {
       auditLog: {
         create: jest.fn().mockResolvedValue({ id: 'a1' }),
       },
+      contract: {
+        // Default: no contract attached — snapshot falls back to salespersonId
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
       // Simple pass-through — callers supply their own tx mock via closure
       // in describe blocks that need it. Default echoes the parent prisma so
       // tests that don't inspect tx work unchanged.
@@ -111,6 +115,38 @@ describe('CommissionService', () => {
       await service.createCommissionForSale('s1', 'sp1', 1000, 0.05);
       const arg = prisma.salesCommission.create.mock.calls[0][0];
       expect(arg.data.status).toBe('PENDING');
+    });
+
+    // T4-C10: snapshot salesperson at creation time
+    it('T4-C10: captures snapshotSalespersonId from contract at create time', async () => {
+      prisma.contract.findUnique.mockResolvedValue({ salespersonId: 'sp-original' });
+      prisma.salesCommission.create.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+
+      await service.createCommissionForSale('s1', 'sp-caller', 1000, 0.05, 'contract-1');
+
+      const arg = prisma.salesCommission.create.mock.calls[0][0];
+      expect(arg.data.snapshotSalespersonId).toBe('sp-original');
+      expect(arg.data.salespersonId).toBe('sp-caller');
+    });
+
+    it('T4-C10: later contract reassignment does not retroactively change snapshot', async () => {
+      // Simulate: commission created when contract.salespersonId = 'sp-A'
+      prisma.contract.findUnique.mockResolvedValue({ salespersonId: 'sp-A' });
+      prisma.salesCommission.create.mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) => ({ id: 'c1', ...data }),
+      );
+      await service.createCommissionForSale('s1', 'sp-A', 1000, 0.05, 'contract-1');
+      const firstArg = prisma.salesCommission.create.mock.calls[0][0];
+      const snapshot = firstArg.data.snapshotSalespersonId;
+
+      // Time passes; contract is reassigned via admin (no commission mutation)
+      // Snapshot on the row stays 'sp-A' because we stored it as a literal
+      // value, not a reference. The invariant is captured in the persisted
+      // record — next time a commission is CREATED it reads the NEW value,
+      // but existing rows are immutable w.r.t. this field.
+      expect(snapshot).toBe('sp-A');
     });
   });
 

--- a/apps/api/src/modules/commission/commission.service.ts
+++ b/apps/api/src/modules/commission/commission.service.ts
@@ -25,6 +25,13 @@ export class CommissionService {
    * rule and reject if rate drifted — protecting against the case where a
    * manager retroactively bumps a rule while PENDING commissions still
    * reference the old rate snapshot.
+   *
+   * T4-C10: snapshots contract.salespersonId at creation time into
+   * SalesCommission.snapshotSalespersonId. If the contract salesperson is
+   * reassigned later (via admin), the commission stays tied to whoever
+   * actually closed the deal. The snapshot falls back to `salespersonId` so
+   * cash sales and contracts with mismatched pointers still get a deterministic
+   * value to query payouts from.
    */
   async createCommissionForSale(
     saleId: string,
@@ -42,7 +49,7 @@ export class CommissionService {
       .mul(commissionRate)
       .toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
 
-    // Capture rule version for audit + approve-time re-validation.
+    // T5-C19: capture rule version for audit + approve-time re-validation.
     let ruleVersionId: string | null = null;
     if (commissionRuleId) {
       const rule = await this.prisma.commissionRule.findFirst({
@@ -54,9 +61,24 @@ export class CommissionService {
       }
     }
 
+    // T4-C10: lock in the original earner. Read the contract's current
+    // salespersonId (if a contract is attached) so a later reassignment
+    // doesn't retroactively move the commission to someone else.
+    let snapshotSalespersonId = salespersonId;
+    if (contractId) {
+      const contract = await this.prisma.contract.findUnique({
+        where: { id: contractId },
+        select: { salespersonId: true },
+      });
+      if (contract?.salespersonId) {
+        snapshotSalespersonId = contract.salespersonId;
+      }
+    }
+
     return this.prisma.salesCommission.create({
       data: {
         salespersonId,
+        snapshotSalespersonId,
         contractId: contractId || null,
         saleId,
         commissionRuleId: commissionRuleId || null,

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -98,6 +98,25 @@ export class OverdueController {
     return this.overdueService.assignCollector(contractId, dto.assignedToId);
   }
 
+  // T3-C11: Manual hold on auto-escalation cron. Path mirrors task spec
+  // (`POST /contracts/:id/hold-escalation`) so frontend can call either
+  // namespace. Scoped to BM+ because sales must not be able to silence
+  // collections automation on their own deals (SoD).
+  @Post('contracts/:id/hold-escalation')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
+  holdEscalation(
+    @Param('id') id: string,
+    @Body() body: { hoursFromNow?: number },
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.overdueService.holdAutoEscalation(
+      id,
+      user.id,
+      user.role,
+      body?.hoursFromNow,
+    );
+  }
+
   @Post(':contractId/settlement')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
   recordSettlement(

--- a/apps/api/src/modules/overdue/overdue.service.spec.ts
+++ b/apps/api/src/modules/overdue/overdue.service.spec.ts
@@ -160,3 +160,129 @@ describe('OverdueService.approveDunningEscalation (T4-C2)', () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────────────────────
+// T3-C11: manual hold on auto-escalation cron
+// ─────────────────────────────────────────────────────────────
+describe('OverdueService.updateContractStatuses (T3-C11 hold guard)', () => {
+  let service: OverdueService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const setupService = async () => {
+    const mod = await Test.createTestingModule({
+      providers: [OverdueService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(OverdueService);
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      contract: {
+        findMany: jest.fn(),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      callLog: { findMany: jest.fn().mockResolvedValue([]) },
+      user: { findFirst: jest.fn().mockResolvedValue({ id: 'owner-1' }) },
+      systemConfig: { findUnique: jest.fn().mockResolvedValue({ value: '7' }) },
+      payment: { aggregate: jest.fn() },
+      auditLog: { createMany: jest.fn().mockResolvedValue({ count: 0 }) },
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+    };
+    await setupService();
+  });
+
+  it('escalates contracts with no hold and no recent PROMISED', async () => {
+    prisma.contract.findMany.mockResolvedValueOnce([
+      { id: 'c-1', blockAutoEscalation: null },
+    ]);
+    prisma.callLog.findMany.mockResolvedValue([]);
+
+    const result = await service.updateContractStatuses();
+    expect(result.overdueUpdated).toBe(1);
+    expect(prisma.contract.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'OVERDUE' } }),
+    );
+  });
+
+  it('skips contracts with active blockAutoEscalation', async () => {
+    const future = new Date(Date.now() + 48 * 60 * 60 * 1000);
+    prisma.contract.findMany.mockResolvedValueOnce([
+      { id: 'c-1', blockAutoEscalation: future },
+    ]);
+    prisma.callLog.findMany.mockResolvedValue([]);
+
+    const result = await service.updateContractStatuses();
+    expect(result.overdueUpdated).toBe(0);
+    expect(prisma.contract.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('re-escalates after the hold expires', async () => {
+    const past = new Date(Date.now() - 60 * 1000);
+    prisma.contract.findMany.mockResolvedValueOnce([
+      { id: 'c-1', blockAutoEscalation: past },
+    ]);
+    prisma.callLog.findMany.mockResolvedValue([]);
+
+    const result = await service.updateContractStatuses();
+    expect(result.overdueUpdated).toBe(1);
+  });
+
+  it('skips contracts with a PROMISED call log in last 24h', async () => {
+    prisma.contract.findMany.mockResolvedValueOnce([
+      { id: 'c-1', blockAutoEscalation: null },
+    ]);
+    prisma.callLog.findMany.mockResolvedValue([{ contractId: 'c-1' }]);
+
+    const result = await service.updateContractStatuses();
+    expect(result.overdueUpdated).toBe(0);
+    expect(prisma.contract.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('OverdueService.holdAutoEscalation (T3-C11)', () => {
+  let service: OverdueService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      contract: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'c-1',
+          contractNumber: 'BC-001',
+          blockAutoEscalation: null,
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'c-1' }),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
+      $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+    };
+    const mod = await Test.createTestingModule({
+      providers: [OverdueService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(OverdueService);
+  });
+
+  it('sets blockAutoEscalation to now+48h by default for BM', async () => {
+    const before = Date.now();
+    const result = await service.holdAutoEscalation('c-1', 'u-1', 'BRANCH_MANAGER');
+    const until = (result as { holdUntil: Date }).holdUntil.getTime();
+    expect(until - before).toBeGreaterThan(47 * 60 * 60 * 1000);
+    expect(until - before).toBeLessThan(49 * 60 * 60 * 1000);
+  });
+
+  it('rejects SALES role (insufficient privilege)', async () => {
+    const { ForbiddenException } = await import('@nestjs/common');
+    await expect(
+      service.holdAutoEscalation('c-1', 'u-1', 'SALES'),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects hoursFromNow > 168 (1 week max)', async () => {
+    await expect(
+      service.holdAutoEscalation('c-1', 'u-1', 'OWNER', 200),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -294,10 +294,27 @@ export class OverdueService {
           },
         },
       },
-      select: { id: true },
+      select: { id: true, blockAutoEscalation: true },
     });
 
-    const activeIds = activeContracts.map((c) => c.id);
+    // T3-C11: skip contracts that have an active manual hold OR had a
+    // PROMISED call log in the last 24h. Rationale: staff is in the middle
+    // of a recovery conversation — auto-flipping the status would look
+    // schizophrenic to the customer and undermine the promise-to-pay.
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const recentlyPromised = await this.prisma.callLog.findMany({
+      where: {
+        contractId: { in: activeContracts.map((c) => c.id) },
+        result: 'PROMISED',
+        calledAt: { gte: yesterday },
+      },
+      select: { contractId: true },
+    });
+    const promisedIds = new Set(recentlyPromised.map((c) => c.contractId));
+    const activeIds = activeContracts
+      .filter((c) => !(c.blockAutoEscalation && c.blockAutoEscalation > now))
+      .filter((c) => !promisedIds.has(c.id))
+      .map((c) => c.id);
     let overdueUpdated = 0;
 
     if (activeIds.length > 0) {
@@ -707,6 +724,59 @@ export class OverdueService {
     const totalAmount = result.reduce((sum, s) => sum + s.totalAmount, 0);
 
     return { stages: result, totalContracts, totalAmount };
+  }
+
+  /**
+   * T3-C11: Place a manual hold on auto-escalation for a contract. Blocks
+   * the overdue cron from flipping status/stages while a human is actively
+   * working the customer. Default hold is 48h from now.
+   *
+   * Roles: OWNER / FINANCE_MANAGER / BRANCH_MANAGER — anyone below that has
+   * no business overriding collections automation.
+   */
+  async holdAutoEscalation(
+    contractId: string,
+    userId: string,
+    userRole: string,
+    hoursFromNow = 48,
+  ) {
+    const allowed = ['OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER'];
+    if (!allowed.includes(userRole)) {
+      throw new ForbiddenException(
+        `สิทธิ์กด hold escalation เฉพาะ ${allowed.join(' / ')}`,
+      );
+    }
+    if (!Number.isFinite(hoursFromNow) || hoursFromNow <= 0 || hoursFromNow > 168) {
+      throw new BadRequestException('ระยะเวลา hold ต้องอยู่ระหว่าง 1 ถึง 168 ชั่วโมง');
+    }
+
+    const contract = await this.prisma.contract.findFirst({
+      where: { id: contractId, deletedAt: null },
+      select: { id: true, contractNumber: true, blockAutoEscalation: true },
+    });
+    if (!contract) throw new NotFoundException('ไม่พบสัญญา');
+
+    const now = new Date();
+    const until = new Date(now.getTime() + hoursFromNow * 60 * 60 * 1000);
+
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.contract.update({
+        where: { id: contractId },
+        data: { blockAutoEscalation: until },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'HOLD_AUTO_ESCALATION',
+          entity: 'contract',
+          entityId: contractId,
+          oldValue: { blockAutoEscalation: contract.blockAutoEscalation },
+          newValue: { blockAutoEscalation: until, hoursFromNow },
+        },
+      }),
+    ]);
+
+    return { ...updated, holdUntil: until };
   }
 
   /**

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -453,6 +453,8 @@ export class SalesService {
       await tx.salesCommission.create({
         data: {
           salespersonId,
+          // T4-C10: cash sale has no contract — snapshot = current earner
+          snapshotSalespersonId: salespersonId,
           saleId: sale.id,
           period,
           saleAmount: netAmount,
@@ -627,6 +629,10 @@ export class SalesService {
       await tx.salesCommission.create({
         data: {
           salespersonId,
+          // T4-C10: snapshot earner from the contract at creation time. If
+          // the contract is later reassigned (admin action), commission
+          // stays tied to the original earner.
+          snapshotSalespersonId: contract.salespersonId,
           contractId: contract.id,
           saleId: sale.id,
           period,

--- a/apps/api/src/modules/staff-chat/staff-chat.controller.ts
+++ b/apps/api/src/modules/staff-chat/staff-chat.controller.ts
@@ -146,7 +146,8 @@ export class StaffChatController {
     @Body('toStaffId') toStaffId: string,
     @Req() req: any,
   ) {
-    await this.assignment.transfer(id, req.user.id, toStaffId);
+    // T4-C11: service rejects post-signature handoff unless actorRole=OWNER
+    await this.assignment.transfer(id, req.user.id, toStaffId, req.user.role);
     return { success: true };
   }
 


### PR DESCRIPTION
## Summary — 5 items

### T3-C11 — Overdue auto-escalation manual hold
- \`Contract.blockAutoEscalation DateTime?\` + partial index NOT NULL
- \`updateContractStatuses()\` cron skip contracts ที่ hold active OR มี PROMISED CallLog ใน 24 ชม.
- \`POST /overdue/contracts/:id/hold-escalation\` (OWNER/FM/BM, default 48h, bounded 1-168h) + audit

### T4-C6 — Broadcast large-audience second approval
- New immutable \`BroadcastApproval\` model (unique \`broadcastId + approverId\`)
- \`evaluateApprovalRequirement(message, audience)\` — true เมื่อ audience > 1000 OR match \`/(ยึด|ฟ้อง|คดี|ทวง|ดำเนินคดี|ศาล)/\`
- Flow: \`sendBroadcast()\` → \`PENDING_APPROVAL\` + ForbiddenException ถ้าต้อง gate; \`approveBroadcast()\` enforce approver ≠ creator, 2nd OWNER flip APPROVED

### T4-C9 — LIFF per-lineUserId rate limit
- In-memory \`Map<lineUserId, { fails, lockedUntil? }>\` ใน VerificationService
- 3 fail ใน 30 min → lock 30 min; success clears counter
- Thai fast-fail "รออีก ... วินาที"

### T4-C10 — Commission snapshot salesperson
- \`SalesCommission.snapshotSalespersonId String?\` + index, migration backfill
- \`createCommissionForSale()\` + sales.service inline create — read \`contract.salespersonId\` ณ ช่วง create
- Contract reassign ภายหลัง ไม่กระทบ commission เก่า

### T4-C11 — Staff chat handoff commission hijack guard
- \`AssignmentService.transfer()\` — reject ForbiddenException ถ้า customer มี contract ที่ APPROVED/ACTIVE/etc. หรือมี signature
- OWNER override → loud \`CHAT_HANDOFF_POST_SIGNATURE_OVERRIDE\` audit log

## Migration
- \`20260527200000_tier8_medium_batch\`

## Test plan
- [x] +22 tests (7 overdue + 10 broadcast + 3 LIFF + 2 commission + 3 handoff)
- [x] Full API: 89 suites / 1201 tests pass
- [x] TypeScript API: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)