### PR TITLE
feat(pii): Phase 1 foundation — utilities + env validation + audit service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,3 +123,11 @@ VITE_SENTRY_DSN=                     # Web: https://xxx@sentry.io/zzz
 # Frontend (Vite) — ใช้ในไฟล์ apps/web/.env
 VITE_API_URL=http://localhost:3000
 VITE_LIFF_ID=                        # จาก LINE Developers Console
+
+# PII Encryption (Phase 6.5)
+# Generate via: openssl rand -hex 32
+PII_ENCRYPTION_KEY=
+
+# PII Hash Salt (deterministic lookup for nationalId/phone)
+# Generate via: openssl rand -hex 32
+PII_HASH_SALT=

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { resolve } from 'path';
 import { AppController } from './app.controller';
 import { PrismaModule } from './prisma/prisma.module';
+import { PiiModule } from './modules/pii/pii.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { BranchesModule } from './modules/branches/branches.module';
 // Supplier Management (Phase 2 step-by-step modules)
@@ -111,6 +112,7 @@ import { AppCacheModule } from './cache/cache.module';
     AppCacheModule,
     StorageModule,
     PrismaModule,
+    PiiModule,
     AuthModule,
     BranchesModule,
     // Supplier Management (Phase 2 step-by-step modules)

--- a/apps/api/src/modules/pii/pii-audit.service.spec.ts
+++ b/apps/api/src/modules/pii/pii-audit.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test } from '@nestjs/testing';
+import { PiiAuditService } from './pii-audit.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PiiAuditService', () => {
+  let service: PiiAuditService;
+  let prisma: { auditLog: { create: jest.Mock } };
+
+  beforeEach(async () => {
+    prisma = { auditLog: { create: jest.fn().mockResolvedValue({}) } };
+    const module = await Test.createTestingModule({
+      providers: [
+        PiiAuditService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = module.get(PiiAuditService);
+  });
+
+  it('logs PII_DECRYPT_FULL action with all required fields', async () => {
+    await service.logDecryption({
+      userId: 'user-1',
+      customerId: 'cust-1',
+      fields: ['nationalId', 'phone'],
+      role: 'OWNER',
+      masked: false,
+      ipAddress: '1.2.3.4',
+      userAgent: 'Mozilla',
+    });
+
+    expect(prisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'user-1',
+        action: 'PII_DECRYPT_FULL',
+        entity: 'customer',
+        entityId: 'cust-1',
+        newValue: { fields: ['nationalId', 'phone'], role: 'OWNER' },
+        ipAddress: '1.2.3.4',
+        userAgent: 'Mozilla',
+      }),
+    });
+  });
+
+  it('logs PII_DECRYPT_MASKED when masked=true', async () => {
+    await service.logDecryption({
+      userId: 'user-2',
+      customerId: 'cust-2',
+      fields: ['nationalId'],
+      role: 'SALES',
+      masked: true,
+    });
+
+    expect(prisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'PII_DECRYPT_MASKED',
+        userId: 'user-2',
+      }),
+    });
+  });
+
+  it('does not throw if audit insert fails (logs to console)', async () => {
+    prisma.auditLog.create.mockRejectedValue(new Error('DB down'));
+    await expect(
+      service.logDecryption({
+        userId: 'u',
+        customerId: 'c',
+        fields: ['phone'],
+        role: 'OWNER',
+        masked: false,
+      }),
+    ).resolves.not.toThrow();
+  });
+});

--- a/apps/api/src/modules/pii/pii-audit.service.ts
+++ b/apps/api/src/modules/pii/pii-audit.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface LogDecryptionInput {
+  userId: string;
+  customerId: string;
+  fields: string[];
+  role: string;
+  masked: boolean;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+@Injectable()
+export class PiiAuditService {
+  private readonly logger = new Logger(PiiAuditService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  async logDecryption(input: LogDecryptionInput): Promise<void> {
+    try {
+      await this.prisma.auditLog.create({
+        data: {
+          userId: input.userId,
+          action: input.masked ? 'PII_DECRYPT_MASKED' : 'PII_DECRYPT_FULL',
+          entity: 'customer',
+          entityId: input.customerId,
+          newValue: { fields: input.fields, role: input.role },
+          ipAddress: input.ipAddress,
+          userAgent: input.userAgent,
+        },
+      });
+    } catch (err) {
+      // Never let audit failure block PII access — audit is best-effort
+      this.logger.error(`PII audit log failed: ${(err as Error).message}`);
+    }
+  }
+}

--- a/apps/api/src/modules/pii/pii.module.ts
+++ b/apps/api/src/modules/pii/pii.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { PiiAuditService } from './pii-audit.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+
+@Global()
+@Module({
+  imports: [PrismaModule],
+  providers: [PiiAuditService],
+  exports: [PiiAuditService],
+})
+export class PiiModule {}

--- a/apps/api/src/utils/env-validation.spec.ts
+++ b/apps/api/src/utils/env-validation.spec.ts
@@ -1,0 +1,73 @@
+import { validateEnv } from './env-validation';
+
+describe('env-validation', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('production PII requirements', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+      process.env.DATABASE_URL = 'postgres://x';
+      process.env.JWT_SECRET = 'x';
+      process.env.JWT_REFRESH_SECRET = 'x';
+    });
+
+    it('throws if PII_ENCRYPTION_KEY missing in prod', () => {
+      delete process.env.PII_ENCRYPTION_KEY;
+      delete process.env.PII_HASH_SALT;
+      expect(() => validateEnv()).toThrow(/PII_ENCRYPTION_KEY required/);
+    });
+
+    it('throws if PII_ENCRYPTION_KEY wrong length', () => {
+      process.env.PII_ENCRYPTION_KEY = 'short';
+      process.env.PII_HASH_SALT = 'a'.repeat(32);
+      expect(() => validateEnv()).toThrow(/64 hex chars/);
+    });
+
+    it('throws if PII_ENCRYPTION_KEY not hex', () => {
+      process.env.PII_ENCRYPTION_KEY = 'z'.repeat(64);
+      process.env.PII_HASH_SALT = 'a'.repeat(32);
+      expect(() => validateEnv()).toThrow(/64 hex chars/);
+    });
+
+    it('throws if PII_HASH_SALT missing in prod', () => {
+      process.env.PII_ENCRYPTION_KEY = 'a'.repeat(64);
+      delete process.env.PII_HASH_SALT;
+      expect(() => validateEnv()).toThrow(/PII_HASH_SALT required/);
+    });
+
+    it('throws if PII_HASH_SALT too short', () => {
+      process.env.PII_ENCRYPTION_KEY = 'a'.repeat(64);
+      process.env.PII_HASH_SALT = 'short';
+      expect(() => validateEnv()).toThrow(/>= 32 chars/);
+    });
+
+    it('passes when both env vars valid', () => {
+      process.env.PII_ENCRYPTION_KEY = 'a'.repeat(64);
+      process.env.PII_HASH_SALT = 'b'.repeat(32);
+      expect(() => validateEnv()).not.toThrow();
+    });
+  });
+
+  describe('development mode', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+      process.env.DATABASE_URL = 'postgres://x';
+      process.env.JWT_SECRET = 'x';
+      process.env.JWT_REFRESH_SECRET = 'x';
+    });
+
+    it('does not require PII vars in dev', () => {
+      delete process.env.PII_ENCRYPTION_KEY;
+      delete process.env.PII_HASH_SALT;
+      expect(() => validateEnv()).not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/utils/env-validation.ts
+++ b/apps/api/src/utils/env-validation.ts
@@ -1,6 +1,6 @@
 /**
  * Validates required environment variables at application startup
- * Fails fast with clear error messages if critical vars are missing
+ * Fails fast with clear error messages if critical vars are missing or malformed
  */
 
 interface EnvVar {
@@ -35,5 +35,34 @@ export function validateEnv(): void {
       'Please set these in your .env file or environment.',
     ].join('\n');
     throw new Error(message);
+  }
+
+  // Production-only PII encryption requirements (Phase 6.5)
+  if (process.env.NODE_ENV === 'production') {
+    validatePiiEncryptionEnv();
+  }
+}
+
+function validatePiiEncryptionEnv(): void {
+  const piiKey = process.env.PII_ENCRYPTION_KEY;
+  if (!piiKey) {
+    throw new Error(
+      'PII_ENCRYPTION_KEY required in production. Generate via: openssl rand -hex 32'
+    );
+  }
+  if (piiKey.length !== 64 || !/^[0-9a-f]+$/i.test(piiKey)) {
+    throw new Error(
+      'PII_ENCRYPTION_KEY must be 64 hex chars (32 bytes for AES-256)'
+    );
+  }
+
+  const piiSalt = process.env.PII_HASH_SALT;
+  if (!piiSalt) {
+    throw new Error(
+      'PII_HASH_SALT required in production. Generate via: openssl rand -hex 32'
+    );
+  }
+  if (piiSalt.length < 32) {
+    throw new Error('PII_HASH_SALT must be >= 32 chars');
   }
 }

--- a/apps/api/src/utils/pii.util.spec.ts
+++ b/apps/api/src/utils/pii.util.spec.ts
@@ -1,0 +1,73 @@
+import { hashPII, maskNationalId, maskPhone, maskBankAccount, maskEmail } from './pii.util';
+
+describe('pii.util', () => {
+  const salt = 'test-salt-32-chars-minimum-needed-here';
+
+  describe('hashPII', () => {
+    it('returns deterministic hash for same input', () => {
+      expect(hashPII('1234567890123', salt)).toBe(hashPII('1234567890123', salt));
+    });
+
+    it('returns different hashes for different inputs', () => {
+      expect(hashPII('1234567890123', salt)).not.toBe(hashPII('1234567890124', salt));
+    });
+
+    it('returns 64-char hex string', () => {
+      const hash = hashPII('test', salt);
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(hashPII('', salt)).toBe('');
+    });
+
+    it('throws if salt is missing or too short', () => {
+      expect(() => hashPII('test', '')).toThrow('PII_HASH_SALT required');
+      expect(() => hashPII('test', 'short')).toThrow('PII_HASH_SALT must be >= 32 chars');
+    });
+  });
+
+  describe('maskNationalId', () => {
+    it('shows 5 first + 1 last char', () => {
+      expect(maskNationalId('1234567890123')).toBe('12345-XXXXX-XX-3');
+    });
+
+    it('returns empty for empty input', () => {
+      expect(maskNationalId('')).toBe('');
+    });
+
+    it('returns input as-is if not 13 chars', () => {
+      expect(maskNationalId('123')).toBe('123');
+    });
+  });
+
+  describe('maskPhone', () => {
+    it('shows prefix + last 2 chars', () => {
+      expect(maskPhone('0812345678')).toBe('081-XXX-XX78');
+    });
+
+    it('returns input as-is if shorter than 10', () => {
+      expect(maskPhone('12345')).toBe('12345');
+    });
+  });
+
+  describe('maskBankAccount', () => {
+    it('shows last 2 chars only', () => {
+      expect(maskBankAccount('1234567890')).toBe('XXXXXXXX90');
+    });
+
+    it('returns empty for empty input', () => {
+      expect(maskBankAccount('')).toBe('');
+    });
+  });
+
+  describe('maskEmail', () => {
+    it('masks local part except first char', () => {
+      expect(maskEmail('john.doe@example.com')).toBe('j*******@example.com');
+    });
+
+    it('returns input as-is if no @', () => {
+      expect(maskEmail('not-an-email')).toBe('not-an-email');
+    });
+  });
+});

--- a/apps/api/src/utils/pii.util.ts
+++ b/apps/api/src/utils/pii.util.ts
@@ -1,0 +1,54 @@
+import { createHmac } from 'crypto';
+
+/**
+ * Deterministic hash for PII lookup. Uses HMAC-SHA-256 with PII_HASH_SALT.
+ * Same input + salt → same hash, enabling unique constraint + lookup queries.
+ * Cannot be reversed; attacker needs plaintext to test.
+ */
+export function hashPII(plaintext: string, salt: string): string {
+  if (!salt) throw new Error('PII_HASH_SALT required');
+  if (salt.length < 32) throw new Error('PII_HASH_SALT must be >= 32 chars');
+  if (!plaintext) return '';
+  return createHmac('sha256', salt).update(plaintext).digest('hex');
+}
+
+/**
+ * Mask 13-digit Thai national ID: show 5 first + 1 last.
+ * Example: "1234567890123" → "12345-XXXXX-XX-3"
+ */
+export function maskNationalId(value: string): string {
+  if (!value) return '';
+  if (value.length !== 13) return value;
+  return `${value.slice(0, 5)}-XXXXX-XX-${value.slice(-1)}`;
+}
+
+/**
+ * Mask Thai mobile phone: show 3-char prefix + last 2.
+ * Example: "0812345678" → "081-XXX-XX78"
+ */
+export function maskPhone(value: string): string {
+  if (!value) return '';
+  const digits = value.replace(/\D/g, '');
+  if (digits.length < 10) return value;
+  return `${digits.slice(0, 3)}-XXX-XX${digits.slice(-2)}`;
+}
+
+/**
+ * Mask bank account: show last 2 chars only.
+ */
+export function maskBankAccount(value: string): string {
+  if (!value) return '';
+  if (value.length <= 2) return value;
+  return 'X'.repeat(value.length - 2) + value.slice(-2);
+}
+
+/**
+ * Mask email local-part: show first char only.
+ * Example: "john.doe@example.com" → "j*******@example.com"
+ */
+export function maskEmail(value: string): string {
+  if (!value || !value.includes('@')) return value;
+  const [local, domain] = value.split('@');
+  if (local.length <= 1) return value;
+  return `${local[0]}${'*'.repeat(local.length - 1)}@${domain}`;
+}


### PR DESCRIPTION
## Summary
Phase 1 of CTO Roadmap 6.5 — PII column-level encryption. Pure foundation, no schema or behavior changes yet.

**Decisions locked in (Q1-Q4 brainstorm 2026-04-19):**
- Q1: encrypt Customer.{nationalId, phone, address, email, guardian*, references} + TradeIn.{transferAccountNumber}
- Q2: hash columns = nationalIdHash + phoneHash only
- Q3: 2-step migration (4 PRs total — this is PR 1/4)
- Q4: backend-side role-based mask, SALES sees masked nationalId

**This PR delivers:**
- `apps/api/src/utils/pii.util.ts` — hashPII (HMAC-SHA-256) + maskNationalId/Phone/BankAccount/Email
- `apps/api/src/utils/env-validation.ts` — require PII_ENCRYPTION_KEY (64 hex) + PII_HASH_SALT (>=32 chars) in production
- `apps/api/src/modules/pii/pii-audit.service.ts` — log PII_DECRYPT_FULL / PII_DECRYPT_MASKED to AuditLog
- `apps/api/src/modules/pii/pii.module.ts` — global module exporting PiiAuditService
- `.env.example` — documents new vars + openssl generation

**Tests:** +24 unit tests (14 pii.util + 7 env-validation + 3 pii-audit), all green

**Plan doc:** [docs/superpowers/plans/2026-04-19-pii-column-encryption.md](docs/superpowers/plans/2026-04-19-pii-column-encryption.md)

## Test plan
- [x] new tests pass (npx jest pii)
- [x] env-validation blocks startup in prod when PII vars missing/malformed
- [x] dev server starts without PII env vars
- [ ] PR 2 (next): schema migration adds nullable encrypted + hash columns

## Pre-prod action items (before PR 4 = backfill)
Set Cloud Run env vars from Secret Manager:
- \`PII_ENCRYPTION_KEY\` = \`openssl rand -hex 32\`
- \`PII_HASH_SALT\` = \`openssl rand -hex 32\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)