### PR TITLE
feat(pii): Phase 2 schema — add nullable encrypted + hash columns

### DIFF
--- a/apps/api/prisma/migrations/20260528400000_add_pii_encrypted_columns/migration.sql
+++ b/apps/api/prisma/migrations/20260528400000_add_pii_encrypted_columns/migration.sql
@@ -1,0 +1,32 @@
+-- Phase 2: PII column-level encryption — additive schema migration
+-- Adds nullable encrypted + hash columns to Customer and TradeIn.
+-- All columns are NULL initially; Phase 3 dual-write + backfill populates them.
+-- Phase 6 drops the legacy plaintext columns.
+-- No existing columns are modified. No DROP statements.
+
+-- AlterTable: customers — add encrypted + hash columns
+ALTER TABLE "customers"
+  ADD COLUMN "national_id_encrypted"          TEXT,
+  ADD COLUMN "national_id_hash"               TEXT,
+  ADD COLUMN "phone_encrypted"                TEXT,
+  ADD COLUMN "phone_hash"                     TEXT,
+  ADD COLUMN "phone_secondary_encrypted"      TEXT,
+  ADD COLUMN "email_encrypted"                TEXT,
+  ADD COLUMN "address_id_card_encrypted"      TEXT,
+  ADD COLUMN "address_current_encrypted"      TEXT,
+  ADD COLUMN "address_work_encrypted"         TEXT,
+  ADD COLUMN "guardian_national_id_encrypted" TEXT,
+  ADD COLUMN "guardian_phone_encrypted"       TEXT,
+  ADD COLUMN "guardian_address_encrypted"     TEXT,
+  ADD COLUMN "references_encrypted"           JSONB;
+
+-- CreateIndex: national_id_hash UNIQUE (mirrors nationalId uniqueness for encrypted lookup)
+CREATE UNIQUE INDEX "customers_national_id_hash_key" ON "customers"("national_id_hash");
+
+-- CreateIndex: phone_hash (non-unique — customers may share a household phone)
+CREATE INDEX "customers_phone_hash_idx" ON "customers"("phone_hash");
+
+-- AlterTable: trade_ins — add encrypted columns for bank transfer PII
+ALTER TABLE "trade_ins"
+  ADD COLUMN "transfer_account_number_encrypted" TEXT,
+  ADD COLUMN "transfer_account_name_encrypted"   TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -495,6 +495,24 @@ model Customer {
   workplace          String?
   addressWork        String?   @map("address_work") // ที่อยู่ที่ทำงาน
   references         Json? // บุคคลอ้างอิง [{prefix, firstName, lastName, phone, relationship}]
+
+  // === PII encryption (Phase 6.5) — nullable during migration window ===
+  // All new columns are populated by dual-write in Phase 3 + backfilled.
+  // Phase 6 drops the legacy plaintext columns above.
+  nationalIdEncrypted         String? @map("national_id_encrypted")
+  nationalIdHash              String? @unique @map("national_id_hash")
+  phoneEncrypted              String? @map("phone_encrypted")
+  phoneHash                   String? @map("phone_hash")
+  phoneSecondaryEncrypted     String? @map("phone_secondary_encrypted")
+  emailEncrypted              String? @map("email_encrypted")
+  addressIdCardEncrypted      String? @map("address_id_card_encrypted")
+  addressCurrentEncrypted     String? @map("address_current_encrypted")
+  addressWorkEncrypted        String? @map("address_work_encrypted")
+  guardianNationalIdEncrypted String? @map("guardian_national_id_encrypted")
+  guardianPhoneEncrypted      String? @map("guardian_phone_encrypted")
+  guardianAddressEncrypted    String? @map("guardian_address_encrypted")
+  referencesEncrypted         Json?   @map("references_encrypted")
+
   documents          String[]  @default([]) // array of file URLs
 
   // Guardian (ผู้ปกครอง) — สำหรับลูกค้าอายุ 17-19
@@ -555,6 +573,7 @@ model Customer {
   @@index([createdAt])
   @@index([deletedAt])
   @@index([referredById])
+  @@index([phoneHash])
   @@map("customers")
 }
 
@@ -2987,6 +3006,10 @@ model TradeIn {
   transferBankName      String? @map("transfer_bank_name")
   transferAccountNumber String? @map("transfer_account_number")
   transferAccountName   String? @map("transfer_account_name")
+
+  // === PII encryption (Phase 6.5) ===
+  transferAccountNumberEncrypted String? @map("transfer_account_number_encrypted")
+  transferAccountNameEncrypted   String? @map("transfer_account_name_encrypted")
 
   // ─── ใบสำคัญจ่ายเงิน ───────────────────────────────────────────────
   voucherNumber String?   @unique @map("voucher_number") // EXP-YYYYMMNNNNN


### PR DESCRIPTION
## Summary
Phase 2 of CTO Roadmap 6.5 — PII column-level encryption. Pure schema addition, no behavior changes.

**Adds 13 new nullable columns to Customer + 2 to TradeIn** (all NULL during migration window). Phase 3 will dual-write into them, Phase 5 will switch reads, Phase 6 will drop the legacy plaintext columns.

## Migration SQL
\`\`\`sql
ALTER TABLE \"customers\" ADD COLUMN ... (13 encrypted/hash columns)
CREATE UNIQUE INDEX customers_national_id_hash_key ON customers(national_id_hash);
CREATE INDEX customers_phone_hash_idx ON customers(phone_hash);
ALTER TABLE \"trade_ins\" ADD COLUMN ... (2 encrypted columns)
\`\`\`

**No drops, no NOT NULLs, no ALTERs on existing columns** — fully backwards compatible.

## Verification
- [x] All new columns NULLABLE
- [x] UNIQUE index on national_id_hash + INDEX on phone_hash
- [x] No ALTER on existing PII columns
- [x] \`npx prisma generate\` succeeds
- [x] \`npx tsc --noEmit\` 0 errors

## Note on migration generation
\`prisma migrate dev --create-only\` blocked by pre-existing shadow DB issue (unrelated TodoStatus enum migration). Migration SQL was written manually after verifying exact output via \`prisma migrate diff\`.

**Plan doc:** [docs/superpowers/plans/2026-04-19-pii-column-encryption.md](docs/superpowers/plans/2026-04-19-pii-column-encryption.md)
**Predecessor:** #597 (Phase 1 foundation)

## Test plan
- [x] Prisma client regenerates without error
- [x] TypeScript check passes
- [ ] (After merge) prod migration applies cleanly via \`prisma migrate deploy\`
- [ ] (Phase 3 next) dual-write code populates these columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)