### PR TITLE
ci(deploy): add PII secrets to Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -235,7 +235,9 @@ jobs:
           PAYSOLUTIONS_API_KEY=PAYSOLUTIONS_API_KEY:latest,\
           LINE_FINANCE_CHANNEL_SECRET=LINE_FINANCE_CHANNEL_SECRET:latest,\
           LINE_FINANCE_CHANNEL_ACCESS_TOKEN=LINE_FINANCE_CHANNEL_ACCESS_TOKEN:latest,\
-          LINE_LOGIN_CHANNEL_SECRET=LINE_LOGIN_CHANNEL_SECRET:latest" \
+          LINE_LOGIN_CHANNEL_SECRET=LINE_LOGIN_CHANNEL_SECRET:latest,\
+          PII_ENCRYPTION_KEY=pii-encryption-key:latest,\
+          PII_HASH_SALT=pii-hash-salt:latest" \
             --set-env-vars="\
           TZ=Asia/Bangkok,\
           NODE_ENV=production,\


### PR DESCRIPTION
## Summary
Phase 6.5 made PII_ENCRYPTION_KEY + PII_HASH_SALT required in production. CI \`--set-secrets\` was wiping them on every deploy. This adds them to the workflow.

## Root cause
PR #600 merged → CI deploy started → \`gcloud run deploy --set-secrets=...\` REPLACED all secrets (including manually-mounted PII secrets) → new revision failed startup probe → container exited with \`PII_ENCRYPTION_KEY required\`.

Old revision (00306) still serving 100% traffic. API healthy.

## Fix
Add 2 lines to deploy-gcp.yml \`--set-secrets\` block.

## Verify after merge
- New CI run completes successfully
- Cloud Run revision 00308+ takes traffic
- API still healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)