### PR TITLE
feat(customer): Intake Integration (Phase 4)

### DIFF
--- a/apps/api/src/modules/customers/customers.controller.ts
+++ b/apps/api/src/modules/customers/customers.controller.ts
@@ -79,6 +79,7 @@ export class CustomersController {
     @Query('sortBy') sortBy?: string,
     @Query('sortOrder') sortOrder?: string,
     @Query('tier') tier?: string,
+    @Query('creditCheckStatus') creditCheckStatus?: string,
     @Req() req?: AuthRequest,
   ) {
     const result = await this.customersService.findAll(
@@ -92,6 +93,7 @@ export class CustomersController {
       sortBy,
       sortOrder,
       tier,
+      creditCheckStatus,
     );
 
     const role = req?.user?.role || 'UNKNOWN';

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -25,6 +25,7 @@ export class CustomersService {
     sortBy?: string,
     sortOrder?: string,
     tier?: string,
+    creditCheckStatus?: string,
   ) {
     const where: Record<string, unknown> = { deletedAt: null };
 
@@ -45,9 +46,14 @@ export class CustomersService {
       where.contracts = { some: { branchId, deletedAt: null } };
     }
 
-    // Credit status filter
+    // Credit status filter (on CreditCheck relation)
     if (creditStatus) {
       where.creditChecks = { some: { status: creditStatus } };
+    }
+
+    // Phase 3 credit check status filter (on Customer.creditCheckStatus field)
+    if (creditCheckStatus) {
+      where.creditCheckStatus = creditCheckStatus;
     }
 
     // Determine sort order

--- a/apps/web/e2e/customer-intake-full-flow.spec.ts
+++ b/apps/web/e2e/customer-intake-full-flow.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI } from './helpers/auth';
+import { gotoWithRetry, hasErrorBoundary } from './helpers/navigation';
+
+test.describe('Customer Intake — full flow smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('clicking "+ เพิ่มลูกค้าใหม่" navigates to /customer-intake', async ({ page }) => {
+    const ok = await gotoWithRetry(page, '/customers');
+    if (!ok) return;
+    const btn = page.getByRole('button', { name: /เพิ่มลูกค้า/ }).first();
+    if (!(await btn.isVisible({ timeout: 5000 }).catch(() => false))) return;
+    await btn.click();
+    await page.waitForURL(/\/customer-intake$/, { timeout: 10000 });
+    expect(await hasErrorBoundary(page)).toBe(false);
+  });
+
+  test('contracts/create accepts ?customerId= param', async ({ page }) => {
+    // First, find an existing customer id
+    await gotoWithRetry(page, '/customers');
+    const firstRow = page.locator('table tbody tr').first();
+    if (!(await firstRow.isVisible({ timeout: 5000 }).catch(() => false))) return;
+    await firstRow.click();
+    await page.waitForURL(/\/customers\/[^/]+$/, { timeout: 10000 });
+    const url = page.url();
+    const customerId = url.split('/').pop()?.split('?')[0];
+    if (!customerId) return;
+
+    await gotoWithRetry(page, `/contracts/create?customerId=${customerId}`);
+    // Page should load without error
+    expect(await hasErrorBoundary(page)).toBe(false);
+  });
+
+  test('credit status filter chip exists on /customers', async ({ page }) => {
+    const ok = await gotoWithRetry(page, '/customers');
+    if (!ok) return;
+    await expect(page.getByText(/ทุกสถานะเครดิต|รอผู้จัดการตรวจ/).first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts
+++ b/apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api, { getErrorMessage } from '@/lib/api';
 import { serializeAddress, AddressData, emptyAddress } from '@/components/ui/AddressForm';
@@ -11,6 +11,8 @@ import { useDraftStorage } from '@/hooks/useDraftStorage';
 export function useContractCreateData() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const preselectedCustomerId = searchParams.get('customerId');
   const [step, setStep] = useState(0);
   const draft = useDraftStorage();
 
@@ -159,6 +161,18 @@ export function useContractCreateData() {
       return data.data || [];
     },
     enabled: step >= 1,
+  });
+
+  // Pre-select customer from URL param ?customerId= (Phase 4 integration)
+  useQuery<Customer | null>({
+    queryKey: ['preselect-customer', preselectedCustomerId],
+    queryFn: async () => {
+      if (!preselectedCustomerId) return null;
+      const { data } = await api.get(`/customers/${preselectedCustomerId}`);
+      if (data) setSelectedCustomer(data);
+      return data;
+    },
+    enabled: !!preselectedCustomerId && !selectedCustomer,
   });
 
   const { data: latestCreditCheck } = useQuery<{ id: string; status: string; aiScore: number | null } | null>({

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -191,7 +191,7 @@ export default function CustomersPage() {
       if (debouncedSearch) params.search = debouncedSearch;
       if (contractStatusFilter) params.contractStatus = contractStatusFilter;
       if (hasOverdueFilter) params.hasOverdue = 'true';
-      if (creditStatusFilter) params.creditStatus = creditStatusFilter;
+      if (creditStatusFilter) params.creditCheckStatus = creditStatusFilter;
       if (branchFilter) params.branchId = branchFilter;
       if (tierFilter) params.tier = tierFilter;
       if (sortBy) params.sortBy = sortBy;
@@ -446,7 +446,7 @@ export default function CustomersPage() {
       if (debouncedSearch) params.search = debouncedSearch;
       if (contractStatusFilter) params.contractStatus = contractStatusFilter;
       if (hasOverdueFilter) params.hasOverdue = 'true';
-      if (creditStatusFilter) params.creditStatus = creditStatusFilter;
+      if (creditStatusFilter) params.creditCheckStatus = creditStatusFilter;
       if (branchFilter) params.branchId = branchFilter;
       params.limit = '10000';
       const { data: allData } = await api.get<CustomersResponse>('/customers', { params });
@@ -647,8 +647,8 @@ export default function CustomersPage() {
               <Download className="w-4 h-4" />
               ส่งออก Excel
             </button>
-            <button onClick={() => { resetForm(); setIsModalOpen(true); }} className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90">
-              + เพิ่มลูกค้า
+            <button onClick={() => navigate('/customer-intake')} className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90">
+              + เพิ่มลูกค้าใหม่
             </button>
           </div>
         }
@@ -732,6 +732,9 @@ export default function CustomersPage() {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="ALL">ทุกสถานะเครดิต</SelectItem>
+              <SelectItem value="UNDER_REVIEW">รอผู้จัดการตรวจ</SelectItem>
+              <SelectItem value="PRE_CHECK_PASSED">ผ่าน pre-check</SelectItem>
+              <SelectItem value="FULL_CHECK_PASSED">ผ่านเต็ม</SelectItem>
               <SelectItem value="APPROVED">ผ่าน</SelectItem>
               <SelectItem value="REJECTED">ไม่ผ่าน</SelectItem>
               <SelectItem value="PENDING">รอตรวจ</SelectItem>

--- a/docs/superpowers/plans/2026-04-20-customer-intake-integration-phase4.md
+++ b/docs/superpowers/plans/2026-04-20-customer-intake-integration-phase4.md
@@ -1,0 +1,306 @@
+# Customer Intake Integration (Phase 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Wire the Customer Intake Wizard (Phase 3) into the rest of the app — `/contracts/create` reads `?customerId=` to pre-select, `/customers` list redirects to the wizard for new customers, manager review queue accessible via filter.
+
+**Architecture:** Pure integration — no new backend logic. Add URL-param handling to existing hook, redirect button to new page, new filter chip. Reuses Phase 1-3 pieces.
+
+**Tech Stack:** React Router URL params, existing hooks.
+
+**Spec reference:** [docs/superpowers/specs/2026-04-20-customer-intake-credit-check-redesign-design.md](../specs/2026-04-20-customer-intake-credit-check-redesign-design.md) section 5 (flow), section 12 Phase 4.
+
+---
+
+## File Structure
+
+### Modified
+- `apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts` — accept preselected customer from URL
+- `apps/web/src/pages/ContractCreatePage/index.tsx` — skip step 1 (customer select) when preselected
+- `apps/web/src/pages/CustomersPage.tsx` — "+ เพิ่มลูกค้า" button → `/customer-intake`, add review-queue filter
+- `apps/web/e2e/customer-intake-full-flow.spec.ts` — new E2E for full happy path
+
+---
+
+## Task 1: ContractCreatePage — accept `?customerId=` pre-select
+
+**Files:**
+- Modify: `apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts`
+- Modify: `apps/web/src/pages/ContractCreatePage/index.tsx`
+
+- [ ] **Step 1: Read searchParams in hook**
+
+In `useContractCreateData.ts`, add import at top:
+```typescript
+import { useSearchParams } from 'react-router';
+```
+
+Near the top of the hook (after `useNavigate()`):
+```typescript
+const [searchParams] = useSearchParams();
+const preselectedCustomerId = searchParams.get('customerId');
+```
+
+After the existing `useState` for `selectedCustomer`, add a query to fetch the preselected customer (only if param present):
+```typescript
+useQuery({
+  queryKey: ['preselect-customer', preselectedCustomerId],
+  queryFn: async () => {
+    if (!preselectedCustomerId) return null;
+    const { data } = await api.get(`/customers/${preselectedCustomerId}`);
+    if (data && !selectedCustomer) {
+      setSelectedCustomer(data);
+      setStep((s) => (s === 0 ? 1 : s)); // skip customer select step if on step 0 → jump to plan
+    }
+    return data;
+  },
+  enabled: !!preselectedCustomerId && !selectedCustomer,
+});
+```
+
+Wait — current wizard has 3 steps (product → customer → plan). If customerId pre-set, user should skip to plan step. But they still need to pick product first. So:
+- Step 0 (product select) — stay
+- Step 1 (customer select) — SKIP if pre-selected, auto-select and jump forward
+- Step 2 (plan) — final
+
+Modify the logic: when preselectedCustomer loads, set selectedCustomer AND set step=1 only after product is also selected. Actually simpler: don't auto-jump, just pre-select. The wizard's `canNext()` logic will let user proceed naturally.
+
+Simplified implementation — just auto-set selectedCustomer:
+```typescript
+useQuery({
+  queryKey: ['preselect-customer', preselectedCustomerId],
+  queryFn: async () => {
+    if (!preselectedCustomerId) return null;
+    const { data } = await api.get(`/customers/${preselectedCustomerId}`);
+    return data;
+  },
+  enabled: !!preselectedCustomerId && !selectedCustomer,
+});
+```
+
+Then in a separate `useEffect`:
+```typescript
+useEffect(() => {
+  // Auto-advance to customer step if product is already selected and customer just loaded
+  if (preselectedCustomerId && selectedCustomer && step === 0 && selectedProduct) {
+    setStep(2); // skip customer-select, go directly to plan
+  }
+}, [preselectedCustomerId, selectedCustomer, selectedProduct, step]);
+```
+
+But the subsequent issue: we need the query data to flow to selectedCustomer. Let me use queryClient to seed + setState:
+
+Final clean version:
+```typescript
+useQuery<Customer | null>({
+  queryKey: ['preselect-customer', preselectedCustomerId],
+  queryFn: async () => {
+    if (!preselectedCustomerId) return null;
+    const { data } = await api.get(`/customers/${preselectedCustomerId}`);
+    return data;
+  },
+  enabled: !!preselectedCustomerId,
+});
+
+useEffect(() => {
+  if (!preselectedCustomerId || selectedCustomer) return;
+  // Fetch + set imperatively via queryClient cache
+  const cached = queryClient.getQueryData<Customer>(['preselect-customer', preselectedCustomerId]);
+  if (cached) setSelectedCustomer(cached);
+}, [preselectedCustomerId, selectedCustomer, queryClient]);
+```
+
+Simpler — just put the setter inside queryFn:
+
+```typescript
+const { data: _preselected } = useQuery({
+  queryKey: ['preselect-customer', preselectedCustomerId],
+  queryFn: async () => {
+    if (!preselectedCustomerId) return null;
+    const { data } = await api.get(`/customers/${preselectedCustomerId}`);
+    if (data) setSelectedCustomer(data);
+    return data;
+  },
+  enabled: !!preselectedCustomerId && !selectedCustomer,
+});
+```
+
+(Side-effect in queryFn is OK here — it's idempotent + gated.)
+
+- [ ] **Step 2: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/pages/ContractCreatePage/hooks/useContractCreateData.ts
+git commit -m "feat(contract-create): support ?customerId= URL param to preselect customer
+
+Wired to Phase 3 intake wizard which redirects here with the param."
+```
+
+---
+
+## Task 2: CustomersPage — redirect "+ เพิ่มลูกค้า" + review-queue filter
+
+**Files:**
+- Modify: `apps/web/src/pages/CustomersPage.tsx`
+
+- [ ] **Step 1: Change button to redirect**
+
+Find the `+ เพิ่มลูกค้า` button handler. If it opens a modal, REPLACE with navigation:
+
+```tsx
+<Button
+  variant="primary"
+  onClick={() => navigate('/customer-intake')}
+>
+  + เพิ่มลูกค้าใหม่
+</Button>
+```
+
+Remove any `showCreateModal` state + `CustomerCreateModal` rendering if they were only used for new-customer creation from this page. (If the same modal is used for OTHER features, leave it.)
+
+Check: does `CustomersPage.tsx` render a `CustomerCreateModal`? Look for imports and JSX. If yes, assess if it's only for "+ เพิ่มลูกค้า" — if so, remove.
+
+- [ ] **Step 2: Add creditCheckStatus filter for review queue**
+
+In the filter bar, add a new select beside existing filters:
+```tsx
+<select
+  value={creditStatusFilter}
+  onChange={(e) => setCreditStatusFilter(e.target.value)}
+  className="h-10 px-3 rounded-lg border border-input bg-background text-sm"
+>
+  <option value="">ทุกสถานะเครดิต</option>
+  <option value="UNDER_REVIEW">รอผู้จัดการตรวจ</option>
+  <option value="PRE_CHECK_PASSED">ผ่าน pre-check</option>
+  <option value="FULL_CHECK_PASSED">ผ่านเต็ม</option>
+  <option value="REJECTED">ไม่ผ่าน</option>
+</select>
+```
+
+State:
+```typescript
+const [creditStatusFilter, setCreditStatusFilter] = useState('');
+```
+
+Thread into query key + params:
+```typescript
+if (creditStatusFilter) params.set('creditCheckStatus', creditStatusFilter);
+```
+
+Page reset effect should include this new filter:
+```typescript
+useEffect(() => setPage(1), [debouncedSearch, statusFilter, creditFilter, tierFilter, branchFilter, creditStatusFilter]);
+```
+
+- [ ] **Step 3: Backend — accept `creditCheckStatus` query param**
+
+Open `apps/api/src/modules/customers/customers.controller.ts`. Add query param:
+```typescript
+@Query('creditCheckStatus') creditCheckStatus?: string,
+```
+Pass to service.
+
+In `customers.service.ts` `findAll()`, accept the new param and add to `where` clause:
+```typescript
+if (creditCheckStatus) where.creditCheckStatus = creditCheckStatus;
+```
+
+- [ ] **Step 4: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh all
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/CustomersPage.tsx apps/api/src/modules/customers/customers.controller.ts apps/api/src/modules/customers/customers.service.ts
+git commit -m "feat(customer): redirect create button + credit status filter
+
+- '+ เพิ่มลูกค้าใหม่' ไป /customer-intake (full wizard)
+- เพิ่ม filter สถานะเครดิต (UNDER_REVIEW, PRE/FULL_CHECK_PASSED, REJECTED)
+- Backend accepts creditCheckStatus query param on /customers list
+
+Manager review queue = /customers?creditCheckStatus=UNDER_REVIEW"
+```
+
+---
+
+## Task 3: E2E full-flow smoke test
+
+**Files:**
+- Create: `apps/web/e2e/customer-intake-full-flow.spec.ts`
+
+- [ ] **Step 1: E2E**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { loginViaAPI } from './helpers/auth';
+import { gotoWithRetry, hasErrorBoundary } from './helpers/navigation';
+
+test.describe('Customer Intake — full flow smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('clicking "+ เพิ่มลูกค้าใหม่" navigates to /customer-intake', async ({ page }) => {
+    const ok = await gotoWithRetry(page, '/customers');
+    if (!ok) return;
+    const btn = page.getByRole('button', { name: /เพิ่มลูกค้า/ }).first();
+    if (!(await btn.isVisible({ timeout: 5000 }).catch(() => false))) return;
+    await btn.click();
+    await page.waitForURL(/\/customer-intake$/);
+    expect(await hasErrorBoundary(page)).toBe(false);
+  });
+
+  test('contracts/create accepts ?customerId= param', async ({ page }) => {
+    // First, find an existing customer id
+    await gotoWithRetry(page, '/customers');
+    const firstRow = page.locator('table tbody tr').first();
+    if (!(await firstRow.isVisible({ timeout: 5000 }).catch(() => false))) return;
+    await firstRow.click();
+    await page.waitForURL(/\/customers\/[^/]+$/, { timeout: 10000 });
+    const url = page.url();
+    const customerId = url.split('/').pop()?.split('?')[0];
+    if (!customerId) return;
+
+    await gotoWithRetry(page, `/contracts/create?customerId=${customerId}`);
+    // Page should load without error
+    expect(await hasErrorBoundary(page)).toBe(false);
+  });
+
+  test('credit status filter chip exists on /customers', async ({ page }) => {
+    const ok = await gotoWithRetry(page, '/customers');
+    if (!ok) return;
+    await expect(page.getByText(/ทุกสถานะเครดิต|รอผู้จัดการตรวจ/).first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Commit + push + PR**
+
+```bash
+git add apps/web/e2e/customer-intake-full-flow.spec.ts
+git commit -m "test(customer-intake): E2E full flow smoke"
+git push -u origin feat/customer-intake-integration-phase4
+gh pr create --base main --title "feat(customer): Intake Integration (Phase 4)" --body "..."
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+- Section 12 Phase 4: all items delivered (pre-select, redirect, review queue filter, E2E)
+
+No placeholders. Types consistent.
+
+Scope tight — only integration; no logic duplicated.


### PR DESCRIPTION
## Summary
Phase 4 ปิดวงจร Customer Intake redesign — wire Phase 3 wizard เข้ากับส่วนอื่นของ app

### 3 จุด integration
1. **`/contracts/create?customerId=`** — pre-select customer (สำหรับ wizard → create contract redirect)
2. **`/customers` "+ เพิ่มลูกค้า" button** → redirect ไป `/customer-intake` (Phase 3 wizard)
3. **`/customers?creditCheckStatus=UNDER_REVIEW`** — manager review queue filter (ใหม่)

## Commits (4)
1. `e8d95c1a` — plan doc
2. `2200244a` — ContractCreatePage accepts `?customerId=` param
3. `70e54001` — CustomersPage redirect + credit status filter + backend param
4. `dfdbcf3e` — E2E full flow smoke

## Manager Review Queue
```
/customers?creditCheckStatus=UNDER_REVIEW
```
→ filter ลูกค้าที่ pre-check บอก REVIEW → manager override → PRE_CHECK_PASSED หรือ REJECTED

## Dependencies
- Phase 1 (merged) — `Customer.creditCheckStatus` field ✓
- Phase 2 (PR #614) — sets the status during pre-check — ควร merge ก่อน Phase 4 เพื่อให้ filter มีข้อมูลจริง
- Phase 3 (PR #615) — wizard ที่ redirect target — ควร merge ก่อน Phase 4 เพื่อให้ button ไปถึงหน้าถูก

**Merge order: #614 → #615 → #616 (this)**

## Test plan
- [x] 3 E2E smoke tests
- [ ] Manual: click "+ เพิ่มลูกค้าใหม่" → ไป /customer-intake (รอ Phase 3 merge)
- [ ] Manual: /contracts/create?customerId=<id> → customer pre-selected
- [ ] Manual: filter manager queue → เห็นเฉพาะ UNDER_REVIEW

🤖 Generated with [Claude Code](https://claude.com/claude-code)