### PR TITLE
hotfix(lint): unblock deploy — invalid eslint-disable in PaymentsPage

### DIFF
--- a/apps/web/src/pages/PaymentsPage/index.tsx
+++ b/apps/web/src/pages/PaymentsPage/index.tsx
@@ -34,8 +34,10 @@ export default function PaymentsPage() {
 
   // Redirect SALES users away from receipts tab (no permission)
   useEffect(() => {
-    if (tab === 'receipts' && !canSeeReceipts) setTab('pending');
-  }, [tab, canSeeReceipts]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (tab === 'receipts' && !canSeeReceipts) {
+      setSearchParams({ tab: 'pending' });
+    }
+  }, [tab, canSeeReceipts, setSearchParams]);
 
   const [statusFilter, setStatusFilter] = useState('');
   const [branchFilter, setBranchFilter] = useState('');


### PR DESCRIPTION
Deploy failing 3 times in a row because ESLint found 1 error: 'Definition for rule react-hooks/exhaustive-deps was not found'. That rule requires eslint-plugin-react-hooks which isn't loaded in this project's config.

Fix: remove the `eslint-disable-line react-hooks/exhaustive-deps` comment added in PR #617, inline the setSearchParams call, add setSearchParams to deps array.

**Urgent — production has been stuck on commit `f9e75791` (Phase 2 #614) since 11:22.**