### PR TITLE
hotfix(admin): fix /api/admin/* 404 — register middleware at Express level

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -93,7 +93,6 @@ import { TwoFactorModule } from './modules/two-factor/two-factor.module';
 import { AuditInterceptor } from './modules/audit/audit.interceptor';
 import { SecurityMiddleware } from './modules/audit/security.middleware';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
-import { AdminPrefixMiddleware } from './common/middleware/admin-prefix.middleware';
 import { CsrfGuard } from './guards/csrf.guard';
 import { JwtAudienceGuard } from './modules/auth/guards/jwt-audience.guard';
 import { AppCacheModule } from './cache/cache.module';
@@ -272,9 +271,9 @@ import { AppCacheModule } from './cache/cache.module';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    // AdminPrefixMiddleware runs first: strip /api/admin/* prefix before any other middleware
-    // so that RequestIdMiddleware and SecurityMiddleware see the rewritten URL.
-    consumer.apply(AdminPrefixMiddleware).forRoutes('*');
+    // NOTE: AdminPrefixMiddleware is applied at Express level in main.ts
+    // (not here) because forRoutes('*') doesn't reliably run before the
+    // NestJS routing layer rejects unknown /api/admin/* paths with 404.
     // RequestIdMiddleware must run before SecurityMiddleware so Sentry scope is tagged first.
     consumer.apply(RequestIdMiddleware).forRoutes('*');
     consumer.apply(SecurityMiddleware).forRoutes('*');

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -17,6 +17,7 @@ import { AppModule } from './app.module';
 import { SentryExceptionFilter } from './filters/sentry-exception.filter';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import { validateEnv } from './utils/env-validation';
+import { AdminPrefixMiddleware } from './common/middleware/admin-prefix.middleware';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -25,6 +26,15 @@ async function bootstrap() {
   validateEnv();
 
   const app = await NestFactory.create(AppModule);
+
+  // AdminPrefixMiddleware MUST run at Express level (not via MiddlewareConsumer)
+  // so it executes before NestJS routing layer. Rewrites /api/admin/* → /api/*
+  // so existing controllers (mounted at /api/X via setGlobalPrefix) handle the
+  // request transparently. NestJS module-level middleware via forRoutes('*')
+  // is unreliable here because path-to-regexp matching can interact poorly
+  // with the global prefix; raw app.use() guarantees execution on every request.
+  const adminPrefix = new AdminPrefixMiddleware();
+  app.use((req, res, next) => adminPrefix.use(req, res, next));
 
   // Increase body size limit for base64 image uploads
   // `verify` callback captures raw body bytes for LINE webhook HMAC verification


### PR DESCRIPTION
## Summary

Production login broken: \`Cannot POST /api/admin/auth/login\` (404) after C3 (#611) deploy.

**Root cause:** NestJS module-level middleware via \`consumer.apply(AdminPrefixMiddleware).forRoutes('*')\` does not reliably run before the NestJS routing layer rejects unknown \`/api/admin/*\` paths with 404. The middleware was registered correctly but never executed for unmatched routes — so the rewrite \`/api/admin/X → /api/X\` never happened.

**Fix:** Apply \`AdminPrefixMiddleware\` via raw \`app.use()\` in [main.ts](apps/api/src/main.ts) — Express-level middleware runs on every request before any NestJS routing logic, guaranteeing the rewrite happens before route matching.

## Changes

- \`apps/api/src/main.ts\` — register \`AdminPrefixMiddleware\` via \`app.use()\` immediately after \`NestFactory.create()\`
- \`apps/api/src/app.module.ts\` — remove the \`consumer.apply(AdminPrefixMiddleware).forRoutes('*')\` registration (replaced by Express-level)

## Test Plan

- [x] Unit tests pass — \`AdminPrefixMiddleware\` (4/4 covering rewrite + non-matching paths)
- [x] TypeScript clean
- [ ] Smoke test after deploy: \`curl -X POST https://bestchoicephone.app/api/admin/auth/login -H "Content-Type: application/json" -d '{}'\` → expect 400 \`Bad Request\` (validation), NOT 404
- [ ] Smoke test admin login from browser
- [ ] Verify \`/api/health\` (no \`/admin\` prefix) still works
- [ ] Verify \`/api/shop/*\` still works (untouched by middleware)

## Risk

Low. The Express-level middleware is functionally identical to the module-level registration but runs at a stricter point in the request lifecycle. Unit tests cover the rewrite logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)