### PR TITLE
hotfix(test): unblock CI — repair customers controller/service specs

### DIFF
--- a/apps/api/src/modules/customers/customers.controller.spec.ts
+++ b/apps/api/src/modules/customers/customers.controller.spec.ts
@@ -103,6 +103,8 @@ describe('CustomersController PII (Phase 5)', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
+      undefined,
       reqOf('SALES'),
     );
     expect((result.data[0] as any).nationalId).toBe('12345-XXXXX-XX-3');

--- a/apps/api/src/modules/customers/customers.service.spec.ts
+++ b/apps/api/src/modules/customers/customers.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConflictException } from '@nestjs/common';
 import { CustomersService } from './customers.service';
+import { CustomerTierService } from './customer-tier.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { encryptPII } from '../../utils/crypto.util';
 
@@ -25,7 +26,11 @@ describe('CustomersService.create — NID normalization', () => {
       },
     };
     const mod: TestingModule = await Test.createTestingModule({
-      providers: [CustomersService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        CustomersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CustomerTierService, useValue: { getCustomerTier: jest.fn() } },
+      ],
     }).compile();
     service = mod.get(CustomersService);
   });
@@ -113,7 +118,11 @@ describe('CustomersService.create — T3-C9 phone + email dedup', () => {
       },
     };
     const mod: TestingModule = await Test.createTestingModule({
-      providers: [CustomersService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        CustomersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CustomerTierService, useValue: { getCustomerTier: jest.fn() } },
+      ],
     }).compile();
     service = mod.get(CustomersService);
   });
@@ -195,7 +204,11 @@ describe('PII dual-write (Phase 3)', () => {
       },
     };
     const mod: TestingModule = await Test.createTestingModule({
-      providers: [CustomersService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        CustomersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CustomerTierService, useValue: { getCustomerTier: jest.fn() } },
+      ],
     }).compile();
     service = mod.get(CustomersService);
 
@@ -271,7 +284,11 @@ describe('PII read decryption (Phase 5)', () => {
       },
     };
     const mod: TestingModule = await Test.createTestingModule({
-      providers: [CustomersService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        CustomersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CustomerTierService, useValue: { getCustomerTier: jest.fn() } },
+      ],
     }).compile();
     service = mod.get(CustomersService);
   });


### PR DESCRIPTION
## Summary

Pre-existing test failures blocking deploys (last 2 successful merges to main both failed deploy):

1. **customers.controller.spec.ts** — \`findAll\` test passed \`reqOf('SALES')\` as the 9th positional arg, but \`findAll\`'s signature added \`tier\` and \`creditCheckStatus\` params (#613, #614). Role landed in \`tier\` slot, \`req\` was undefined, masking skipped. Added 2 missing \`undefined\` args.

2. **customers.service.spec.ts** — All 14 PII Phase 5 tests failed with \"Nest can't resolve dependencies of CustomersService (PrismaService, ?)\" — \`CustomerTierService\` constructor dep added in #613 but test module never registered a stub. Added \`CustomerTierService\` mock to all 4 \`Test.createTestingModule\` calls.

## Test Results
- Before: 15 failures, 1579 passing
- After: 1594/1594 passing

## Risk
None — test-only changes that match current production code behavior. Will unblock the AdminPrefixMiddleware hotfix deploy (#619, already merged but failed to deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)