### PR TITLE
feat(ui): sidebar reorder (OWNER) + customer intake flow refactor

### DIFF
--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -286,17 +286,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'Dashboard', path: '/', icon: Home },
         { label: 'งานของทีม', path: '/todos', icon: CheckSquare },
         { label: 'CRM Pipeline', path: '/crm', icon: Kanban },
-      ],
-    },
-    {
-      key: 'owner-sales',
-      label: 'ขาย',
-      icon: ShoppingCart,
-      items: [
-        { label: 'ขายของ (POS)', path: '/pos', icon: ShoppingCart },
-        { label: 'ลูกค้า', path: '/customers', icon: Users },
-        { label: 'เช็คเครดิตลูกค้าใหม่', path: '/customer-intake', icon: UserSearch },
-        { label: 'รับซื้อมือสอง', path: '/trade-in', icon: Smartphone },
+        { label: 'Finance Overview', path: '/finance-portfolio', icon: CircleDollarSign },
       ],
     },
     {
@@ -304,20 +294,20 @@ const OWNER_CONFIG: RoleMenuConfig = {
       label: 'คลัง & จัดซื้อ',
       icon: Warehouse,
       items: [
-        { label: 'สต็อกสินค้า', path: '/stock', icon: Warehouse },
-        { label: 'สั่งซื้อ (PO)', path: '/purchase-orders', icon: ClipboardList },
         { label: 'ผู้ขาย', path: '/suppliers', icon: Building2 },
+        { label: 'สั่งซื้อ (PO)', path: '/purchase-orders', icon: ClipboardList },
+        { label: 'รับซื้อมือสอง', path: '/trade-in', icon: Smartphone },
+        { label: 'สต็อกสินค้า', path: '/stock', icon: Warehouse },
       ],
     },
     {
-      key: 'owner-contracts',
-      label: 'สัญญา & ชำระ',
-      icon: FileCheck,
+      key: 'owner-sales',
+      label: 'ขาย',
+      icon: ShoppingCart,
       items: [
+        { label: 'ลูกค้า', path: '/customers', icon: Users },
+        { label: 'ขายของ (POS)', path: '/pos', icon: ShoppingCart },
         { label: 'สัญญาผ่อนชำระ', path: '/contracts', icon: FileCheck },
-        { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
-        { label: 'Finance Overview', path: '/finance-portfolio', icon: CircleDollarSign },
-        { label: 'จัดการอุปกรณ์', path: '/mdm', icon: Smartphone },
       ],
     },
     {
@@ -329,6 +319,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'เปลี่ยนเครื่อง', path: '/exchange', icon: RefreshCw },
         { label: 'เปลี่ยนเครื่องเสีย (7 วัน)', path: '/defect-exchange', icon: Wrench },
         { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
+        { label: 'จัดการอุปกรณ์', path: '/mdm', icon: Smartphone },
       ],
     },
     {
@@ -336,9 +327,10 @@ const OWNER_CONFIG: RoleMenuConfig = {
       label: 'บัญชี & รายงาน',
       icon: Calculator,
       items: [
+        { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
+        { label: 'รายจ่าย', path: '/expenses', icon: Receipt },
         { label: 'รายงาน', path: '/reports', icon: BarChart3 },
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
-        { label: 'รายจ่าย', path: '/expenses', icon: Receipt },
         { label: 'ภาษี', path: '/tax-reports', icon: Calculator },
         { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
       ],

--- a/apps/web/src/pages/CustomerIntakePage/components/PreCheckUploadStep.tsx
+++ b/apps/web/src/pages/CustomerIntakePage/components/PreCheckUploadStep.tsx
@@ -1,0 +1,85 @@
+import { useRef } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Upload, Loader2, ArrowLeft } from 'lucide-react';
+import type { QuickIntakeForm } from '../types';
+
+interface Props {
+  form: QuickIntakeForm;
+  onChange: (patch: Partial<QuickIntakeForm>) => void;
+  onSubmit: () => void;
+  onBack: () => void;
+  isSubmitting: boolean;
+}
+
+export default function PreCheckUploadStep({ form, onChange, onSubmit, onBack, isSubmitting }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const canSubmit = form.statementFiles.length > 0;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-5">
+      <div className="rounded-xl border border-border bg-card p-5 shadow-sm space-y-4">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Statement ธนาคาร 3 เดือน *</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            จำเป็นสำหรับการวิเคราะห์เครดิตด้วย AI
+          </p>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-foreground mb-1">ธนาคาร</label>
+          <Input
+            value={form.bankName || ''}
+            onChange={(e) => onChange({ bankName: e.target.value })}
+            placeholder="เช่น กสิกรไทย"
+          />
+        </div>
+
+        <div>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*,.pdf"
+            multiple
+            onChange={(e) => {
+              const files = e.target.files ? Array.from(e.target.files) : [];
+              onChange({ statementFiles: files });
+            }}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="w-full border-2 border-dashed border-border hover:border-primary/50 rounded-lg p-6 flex flex-col items-center gap-1 transition"
+          >
+            <Upload className="size-6 text-muted-foreground" />
+            <span className="text-sm text-foreground">
+              {form.statementFiles.length > 0
+                ? `เลือกแล้ว ${form.statementFiles.length} ไฟล์`
+                : 'ลากไฟล์หรือคลิกเลือก'}
+            </span>
+            <span className="text-xs text-muted-foreground">รูปภาพหรือ PDF หลายไฟล์ได้</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack} disabled={isSubmitting}>
+          <ArrowLeft className="size-4" />
+          กลับ
+        </Button>
+        <Button variant="primary" size="lg" onClick={onSubmit} disabled={!canSubmit || isSubmitting}>
+          {isSubmitting ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              กำลังวิเคราะห์...
+            </>
+          ) : (
+            'เริ่มเช็คเครดิต'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CustomerIntakePage/components/QuickIntakeStep.tsx
+++ b/apps/web/src/pages/CustomerIntakePage/components/QuickIntakeStep.tsx
@@ -1,20 +1,35 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Upload, CreditCard, Loader2 } from 'lucide-react';
+import { CreditCard, Loader2, ArrowRight } from 'lucide-react';
 import { checkCardReaderStatus, readSmartCard } from '@/lib/cardReader';
 import { toast } from 'sonner';
+import { THAI_NAME_PREFIXES } from '@/lib/constants';
 import type { QuickIntakeForm } from '../types';
+
+function formatNationalId(value: string): string {
+  const d = value.replace(/\D/g, '').slice(0, 13);
+  if (d.length <= 1) return d;
+  if (d.length <= 5) return `${d.slice(0, 1)}-${d.slice(1)}`;
+  if (d.length <= 10) return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5)}`;
+  if (d.length <= 12) return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5, 10)}-${d.slice(10)}`;
+  return `${d.slice(0, 1)}-${d.slice(1, 5)}-${d.slice(5, 10)}-${d.slice(10, 12)}-${d.slice(12)}`;
+}
+
+function formatPhone(value: string): string {
+  const d = value.replace(/\D/g, '').slice(0, 10);
+  if (d.length <= 3) return d;
+  if (d.length <= 6) return `${d.slice(0, 3)}-${d.slice(3)}`;
+  return `${d.slice(0, 3)}-${d.slice(3, 6)}-${d.slice(6)}`;
+}
 
 interface Props {
   form: QuickIntakeForm;
   onChange: (patch: Partial<QuickIntakeForm>) => void;
-  onSubmit: () => void;
-  isSubmitting: boolean;
+  onNext: () => void;
 }
 
-export default function QuickIntakeStep({ form, onChange, onSubmit, isSubmitting }: Props) {
-  const fileRef = useRef<HTMLInputElement>(null);
+export default function QuickIntakeStep({ form, onChange, onNext }: Props) {
   const [cardReaderLoading, setCardReaderLoading] = useState(false);
 
   const handleSmartCard = async () => {
@@ -40,12 +55,11 @@ export default function QuickIntakeStep({ form, onChange, onSubmit, isSubmitting
     }
   };
 
-  const canSubmit =
+  const canNext =
     /^\d{13}$/.test(form.nationalId) &&
     /^0\d{8,9}$/.test(form.phone) &&
     form.firstName.trim().length > 0 &&
-    form.lastName.trim().length > 0 &&
-    form.statementFiles.length > 0;
+    form.lastName.trim().length > 0;
 
   return (
     <div className="max-w-2xl mx-auto space-y-5">
@@ -61,11 +75,16 @@ export default function QuickIntakeStep({ form, onChange, onSubmit, isSubmitting
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
             <label className="block text-xs font-medium text-foreground mb-1">คำนำหน้า</label>
-            <Input
+            <select
               value={form.prefix || ''}
               onChange={(e) => onChange({ prefix: e.target.value })}
-              placeholder="นาย / นาง / น.ส."
-            />
+              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <option value="">-- เลือก --</option>
+              {THAI_NAME_PREFIXES.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
           </div>
           <div />
           <div>
@@ -85,80 +104,28 @@ export default function QuickIntakeStep({ form, onChange, onSubmit, isSubmitting
           <div>
             <label className="block text-xs font-medium text-foreground mb-1">เลขบัตรประชาชน *</label>
             <Input
-              value={form.nationalId}
+              value={formatNationalId(form.nationalId)}
               onChange={(e) => onChange({ nationalId: e.target.value.replace(/\D/g, '').slice(0, 13) })}
-              placeholder="1234567890123"
-              maxLength={13}
+              placeholder="1-2345-67890-12-3"
+              inputMode="numeric"
             />
           </div>
           <div>
             <label className="block text-xs font-medium text-foreground mb-1">เบอร์โทร *</label>
             <Input
-              value={form.phone}
+              value={formatPhone(form.phone)}
               onChange={(e) => onChange({ phone: e.target.value.replace(/\D/g, '').slice(0, 10) })}
-              placeholder="0812345678"
+              placeholder="081-234-5678"
+              inputMode="tel"
             />
           </div>
         </div>
       </div>
 
-      <div className="rounded-xl border border-border bg-card p-5 shadow-sm space-y-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-sm font-semibold text-foreground">Statement ธนาคาร 3 เดือน *</h3>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              จำเป็นสำหรับการวิเคราะห์เครดิตด้วย AI
-            </p>
-          </div>
-        </div>
-
-        <div>
-          <label className="block text-xs font-medium text-foreground mb-1">ธนาคาร</label>
-          <Input
-            value={form.bankName || ''}
-            onChange={(e) => onChange({ bankName: e.target.value })}
-            placeholder="เช่น กสิกรไทย"
-          />
-        </div>
-
-        <div>
-          <input
-            ref={fileRef}
-            type="file"
-            accept="image/*,.pdf"
-            multiple
-            onChange={(e) => {
-              const files = e.target.files ? Array.from(e.target.files) : [];
-              onChange({ statementFiles: files });
-            }}
-            className="hidden"
-          />
-          <button
-            type="button"
-            onClick={() => fileRef.current?.click()}
-            className="w-full border-2 border-dashed border-border hover:border-primary/50 rounded-lg p-6 flex flex-col items-center gap-1 transition"
-          >
-            <Upload className="size-6 text-muted-foreground" />
-            <span className="text-sm text-foreground">
-              {form.statementFiles.length > 0
-                ? `เลือกแล้ว ${form.statementFiles.length} ไฟล์`
-                : 'ลากไฟล์หรือคลิกเลือก'}
-            </span>
-            <span className="text-xs text-muted-foreground">รูปภาพหรือ PDF หลายไฟล์ได้</span>
-          </button>
-        </div>
-      </div>
-
       <div className="flex justify-end">
-        <Button variant="primary" size="lg" onClick={onSubmit} disabled={!canSubmit || isSubmitting}>
-          {isSubmitting ? (
-            <>
-              <Loader2 className="size-4 animate-spin" />
-              กำลังเช็คเครดิต...
-            </>
-          ) : (
-            'เช็คเครดิตเบื้องต้น'
-          )}
+        <Button variant="primary" size="lg" onClick={onNext} disabled={!canNext}>
+          ถัดไป: เช็คเครดิต
+          <ArrowRight className="size-4" />
         </Button>
       </div>
     </div>

--- a/apps/web/src/pages/CustomerIntakePage/hooks/useCustomerIntake.ts
+++ b/apps/web/src/pages/CustomerIntakePage/hooks/useCustomerIntake.ts
@@ -60,7 +60,7 @@ export function useCustomerIntake() {
       });
     },
     onSuccess: (result) => {
-      setState((prev) => ({ ...prev, preCheckResult: result, step: 'precheck' }));
+      setState((prev) => ({ ...prev, preCheckResult: result }));
       if (result.decision === 'PASS') {
         toast.success('ผ่านการตรวจเครดิตเบื้องต้น');
       } else if (result.decision === 'FAIL') {
@@ -73,6 +73,10 @@ export function useCustomerIntake() {
       toast.error(getErrorMessage(err));
     },
   });
+
+  const resetPreCheck = useCallback(() => {
+    setState((prev) => ({ ...prev, preCheckResult: null, step: 'quick' }));
+  }, []);
 
   const proceedToFull = useCallback(() => {
     if (!state.preCheckResult) return;
@@ -112,6 +116,7 @@ export function useCustomerIntake() {
     updateQuick,
     runPreCheck: () => preCheckMutation.mutate(),
     isPreChecking: preCheckMutation.isPending,
+    resetPreCheck,
     proceedToFull,
     reset,
   };

--- a/apps/web/src/pages/CustomerIntakePage/index.tsx
+++ b/apps/web/src/pages/CustomerIntakePage/index.tsx
@@ -6,6 +6,7 @@ import { CheckCircle2 } from 'lucide-react';
 import { useCustomerIntake } from './hooks/useCustomerIntake';
 import IntakeStepIndicator from './components/IntakeStepIndicator';
 import QuickIntakeStep from './components/QuickIntakeStep';
+import PreCheckUploadStep from './components/PreCheckUploadStep';
 import PreCheckResultStep from './components/PreCheckResultStep';
 import FullIntakeStep from './components/FullIntakeStep';
 
@@ -35,7 +36,16 @@ export default function CustomerIntakePage() {
         <QuickIntakeStep
           form={intake.state.quickForm}
           onChange={intake.updateQuick}
+          onNext={() => intake.goTo('precheck')}
+        />
+      )}
+
+      {intake.state.step === 'precheck' && !intake.state.preCheckResult && (
+        <PreCheckUploadStep
+          form={intake.state.quickForm}
+          onChange={intake.updateQuick}
           onSubmit={intake.runPreCheck}
+          onBack={() => intake.goTo('quick')}
           isSubmitting={intake.isPreChecking}
         />
       )}
@@ -44,7 +54,7 @@ export default function CustomerIntakePage() {
         <PreCheckResultStep
           result={intake.state.preCheckResult}
           onProceed={intake.proceedToFull}
-          onCancel={() => intake.goTo('quick')}
+          onCancel={intake.resetPreCheck}
         />
       )}
 


### PR DESCRIPTION
## Summary

Two UX improvements requested by owner:

### 1. Sidebar reorder (OWNER role only)

| Section | Change |
|---------|--------|
| ภาพรวม | + Finance Overview |
| คลัง & จัดซื้อ | + รับซื้อมือสอง, เรียงใหม่ ผู้ขาย→PO→รับซื้อ→สต็อก |
| ขาย | เหลือ ลูกค้า/POS/สัญญาผ่อน (ลบ trade-in, รวม customer entries) |
| ติดตามหนี้ | + จัดการอุปกรณ์ |
| บัญชี & รายงาน | + รับชำระค่างวด ขึ้นบนสุด |
| สัญญา & ชำระ | **ลบทั้ง section** (items กระจายไปยัง sections อื่นแทน) |

การตลาด / ตั้งค่า / เครื่องมือ — ไม่แตะ
SALES / BRANCH_MANAGER / FINANCE_MANAGER / ACCOUNTANT — ไม่แตะ

### 2. Customer Intake (/customer-intake)

- **คำนำหน้า**: Input → dropdown (\`นาย / นาง / นางสาว\`)
- **เลขบัตรประชาชน + เบอร์โทร**: auto-format with dashes while typing (\`1-2345-67890-12-3\`, \`081-234-5678\`). State stays digit-only for API.
- **Statement upload moved**: step 1 → step 2
  - Step 1 (ข้อมูลเบื้องต้น): light form (ชื่อ/id/เบอร์) → "ถัดไป"
  - Step 2 (เช็คเครดิต): two-phase — upload statement + bank → "เริ่มเช็คเครดิต" → AI analyzes → shows result
- New \`PreCheckUploadStep\` component
- New \`resetPreCheck\` hook action — clears stale result when user backs out from result screen

## Test Plan

- [ ] Sidebar OWNER: order matches spec, all links work
- [ ] /customer-intake step 1: dropdown works, dashes appear while typing ID/phone, "ถัดไป" disabled until valid
- [ ] /customer-intake step 2 phase 1: upload statement, "เริ่มเช็คเครดิต" disabled until file selected
- [ ] /customer-intake step 2 phase 2 (after API): result shows, "กรอกข้อมูลเต็ม" / "กลับ" work
- [ ] กลับ from result → step 1 (state reset, no stale result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)