### PR TITLE
fix(precheck): map decision → CreditCheckStatus to unblock contract creation

### DIFF
--- a/apps/api/src/modules/customers/customer-precheck.service.ts
+++ b/apps/api/src/modules/customers/customer-precheck.service.ts
@@ -126,8 +126,19 @@ export class CustomerPreCheckService {
 
     let creditCheckId: string | undefined;
     const aiScore: number | undefined = undefined;
+    const outcome = this.decideOutcome(tierResp.tier, aiScore);
 
     if (input.statementFiles && input.statementFiles.length > 0 && tierResp.tier !== 'BLACKLIST') {
+      // Map decision → CreditCheckStatus so contract creation can proceed:
+      //   PASS    → APPROVED      (auto-approved, can create contract immediately)
+      //   REVIEW  → MANUAL_REVIEW (manager must review before contract)
+      //   FAIL    → REJECTED      (no contract allowed)
+      const ccStatus =
+        outcome.decision === 'PASS'
+          ? 'APPROVED'
+          : outcome.decision === 'FAIL'
+            ? 'REJECTED'
+            : 'MANUAL_REVIEW';
       const cc = await this.prisma.creditCheck.create({
         data: {
           customerId: customer.id,
@@ -135,14 +146,12 @@ export class CustomerPreCheckService {
           statementFiles: input.statementFiles,
           statementMonths: 3,
           checkType: 'PRE',
-          status: 'PENDING',
+          status: ccStatus,
         },
         select: { id: true, aiScore: true },
       });
       creditCheckId = cc.id;
     }
-
-    const outcome = this.decideOutcome(tierResp.tier, aiScore);
 
     const nextStatus =
       outcome.decision === 'PASS'


### PR DESCRIPTION
## Bug

Owner reported on prod: customer \"เบญจวรรณ เจ๊กเรือง\" ผ่าน pre-check แล้ว (PASS, badge เขียว) แต่กดสร้างสัญญาขึ้น \"ลูกค้าต้องผ่านการตรวจเครดิตก่อนทำสัญญา\".

## Root Cause

\`customer-precheck.service.ts\` always created \`CreditCheck.status = 'PENDING'\` regardless of outcome. But \`contracts.service.ts:332-338\` requires:

\`\`\`ts
const approvedCreditCheck = await tx.creditCheck.findFirst({
  where: { customerId, status: 'APPROVED', contractId: null },
});
if (!approvedCreditCheck) throw new BadRequestException('ลูกค้าต้องผ่าน...');
\`\`\`

So PASS in UI never translated to APPROVED in DB.

## Fix

Map \`outcome.decision\` → \`CreditCheckStatus\` when creating the record:

| Decision | Status | Behavior |
|----------|--------|----------|
| PASS | APPROVED | Auto-approved → contract creation allowed |
| REVIEW | MANUAL_REVIEW | Manager must approve before contract |
| FAIL | REJECTED | No contract allowed |

## Test

- 11/11 \`customer-precheck.service.spec.ts\` pass
- TypeScript clean

## Risk

Low. Bug fix changes only the status value at write time. Existing PENDING records won't be migrated — affected customers can re-run pre-check (or admin can mass-update via SQL if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)