### PR TITLE
fix(credit-check): override dialog sends overrideReason (required, ≥20 chars)

### DIFF
--- a/apps/web/src/components/credit-check/CreditCheckOverrideDialog.tsx
+++ b/apps/web/src/components/credit-check/CreditCheckOverrideDialog.tsx
@@ -43,21 +43,35 @@ export default function CreditCheckOverrideDialog({
             </select>
           </div>
           <div>
-            <label className="block text-xs font-medium text-foreground mb-1.5">หมายเหตุ</label>
+            <label className="block text-xs font-medium text-foreground mb-1.5">
+              เหตุผล <span className="text-destructive">*</span>
+            </label>
             <textarea
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
-              rows={3}
-              placeholder="เหตุผลที่ปรับแก้..."
+              rows={4}
+              placeholder="เหตุผลที่ปรับแก้ (อย่างน้อย 20 ตัวอักษร)"
               className="w-full px-3 py-2 rounded-lg border border-input bg-background text-sm"
             />
+            <div className="flex justify-between text-[11px] mt-1">
+              <span className={notes.trim().length < 20 ? 'text-destructive' : 'text-muted-foreground'}>
+                {notes.trim().length < 20
+                  ? `ต้องมีอย่างน้อย 20 ตัวอักษร (ตอนนี้ ${notes.trim().length})`
+                  : 'พอดีแล้ว'}
+              </span>
+              <span className="text-muted-foreground">{notes.length}/2000</span>
+            </div>
           </div>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>
             ยกเลิก
           </Button>
-          <Button variant="primary" onClick={onConfirm} disabled={!status || isPending}>
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            disabled={!status || notes.trim().length < 20 || notes.length > 2000 || isPending}
+          >
             {isPending ? 'กำลังบันทึก...' : 'ยืนยัน'}
           </Button>
         </DialogFooter>

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -301,7 +301,7 @@ export default function CustomerDetailPage() {
       if (!overrideId) return;
       const { data } = await api.post(`/customers/${id}/credit-check/${overrideId}/override`, {
         status: overrideStatus,
-        reviewNotes: overrideNotes || undefined,
+        overrideReason: overrideNotes,
       });
       return data;
     },


### PR DESCRIPTION
## Bug

Owner rายงาน: คลิก "ปรับแก้สถานะเครดิตเช็ค" + กรอก "III" → server reject ด้วย error **"เหตุผลต้องไม่เกิน 2000 ตัวอักษร"** (ซึ่งมั่ว เพราะ input แค่ 3 ตัว)

## Root Cause

Dialog ส่ง \`{ status, reviewNotes }\` แต่ server DTO (\`apps/api/src/modules/credit-check/dto/credit-check.dto.ts:38-42\`) ต้องการ \`overrideReason\` เป็นฟิลด์ required:

\`\`\`ts
@IsString() @IsNotEmpty()
@MinLength(20) @MaxLength(2000)
overrideReason!: string;
\`\`\`

\`overrideReason\` ไม่เคยถูกส่ง → class-validator บน undefined value ล้มเหลว + frontend (\`getErrorMessage\`) เอาข้อความแรกของ array มาโชว์ → user เจอ "ไม่เกิน 2000 ตัวอักษร" แทนข้อความจริง ("ต้องระบุเหตุผล..." / "ต้องมีอย่างน้อย 20 ตัวอักษร")

## Fix

- **Dialog:** rename field "หมายเหตุ" → "เหตุผล *", เพิ่ม live char counter (min 20 / max 2000), disable ปุ่มยืนยันจนกว่าจะ valid
- **Mutation:** ส่ง \`overrideReason: overrideNotes\` แทน \`reviewNotes: overrideNotes\`

## Test Plan

- [ ] Open override dialog: label เป็น "เหตุผล *" + counter แสดง "0/2000"
- [ ] พิมพ์ < 20 ตัวอักษร: counter แดง "ต้องมีอย่างน้อย 20 ตัวอักษร (ตอนนี้ X)" + ปุ่มยืนยัน disabled
- [ ] พิมพ์ ≥ 20 ตัวอักษร: counter ปกติ + ปุ่มยืนยัน enabled → submit สำเร็จ

🤖 Generated with [Claude Code](https://claude.com/claude-code)