### PR TITLE
feat(credit-check): override dialog uses preset reason categories

### DIFF
--- a/apps/web/src/components/credit-check/CreditCheckOverrideDialog.tsx
+++ b/apps/web/src/components/credit-check/CreditCheckOverrideDialog.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 
@@ -6,10 +7,78 @@ interface Props {
   onClose: () => void;
   status: string;
   onStatusChange: (v: string) => void;
+  reasonCategory: string;
+  onReasonCategoryChange: (v: string) => void;
   notes: string;
   onNotesChange: (v: string) => void;
   isPending: boolean;
   onConfirm: () => void;
+}
+
+interface ReasonOption {
+  value: string;
+  label: string;
+  detailLabel: string;
+  detailPlaceholder: string;
+}
+
+const REASON_OPTIONS: ReasonOption[] = [
+  {
+    value: 'EXISTING_CUSTOMER',
+    label: 'ลูกค้าเก่าผ่อนจบแล้ว',
+    detailLabel: 'ระบุสัญญาเก่า',
+    detailPlaceholder: 'เช่น สัญญาเลขที่ BC-2024-00123 ผ่อน 12 งวดจบเมื่อ ธ.ค. 2568',
+  },
+  {
+    value: 'PERSONAL_VOUCH',
+    label: 'พนักงาน/คนรู้จัก/ลูกหลาน',
+    detailLabel: 'ระบุชื่อ+ความสัมพันธ์',
+    detailPlaceholder: 'เช่น น้องสาวของ คุณสมชาย (พนักงานสาขาลาดพร้าว)',
+  },
+  {
+    value: 'GUARANTOR',
+    label: 'มีผู้ค้ำประกัน',
+    detailLabel: 'ระบุชื่อผู้ค้ำ+เอกสาร',
+    detailPlaceholder: 'เช่น บิดาค้ำ (นายสมบัติ ฯลฯ) แนบสำเนาบัตร+สลิปเงินเดือน',
+  },
+  {
+    value: 'HIGH_DOWN',
+    label: 'ดาวน์สูง/จ่ายสดมาก (≥ 50%)',
+    detailLabel: 'ระบุยอดดาวน์',
+    detailPlaceholder: 'เช่น ดาวน์ 15,000 จากราคา 25,000 (60%)',
+  },
+  {
+    value: 'CASH_INCOME',
+    label: 'รายได้เป็นเงินสด/ไม่เข้าบัญชี',
+    detailLabel: 'ระบุอาชีพ+รายได้ประมาณ',
+    detailPlaceholder: 'เช่น ค้าขายในตลาด รายได้ประมาณ 25,000/เดือน',
+  },
+  {
+    value: 'EXTRA_EVIDENCE',
+    label: 'เอกสารรายได้เพิ่มเติม',
+    detailLabel: 'ระบุเอกสารที่ได้รับ',
+    detailPlaceholder: 'เช่น สลิปเงินเดือน 3 เดือน + หนังสือรับรองเงินเดือน',
+  },
+  {
+    value: 'MGR_RISK',
+    label: 'Manager/Owner รับความเสี่ยง',
+    detailLabel: 'เหตุผล + ผู้อนุมัติ',
+    detailPlaceholder: 'เช่น approve by exception โดยคุณ... (ความสัมพันธ์กับลูกค้า)',
+  },
+  {
+    value: 'OTHER',
+    label: 'อื่นๆ',
+    detailLabel: 'เหตุผล',
+    detailPlaceholder: 'กรุณาระบุเหตุผลให้ชัดเจน อย่างน้อย 20 ตัวอักษร',
+  },
+];
+
+function compileReason(categoryValue: string, detail: string): string {
+  const opt = REASON_OPTIONS.find((o) => o.value === categoryValue);
+  const trimmed = detail.trim();
+  if (!opt) return trimmed;
+  if (opt.value === 'OTHER') return trimmed;
+  return trimmed ? `${opt.label}: ${trimmed}` : opt.label;
 }
 
 export default function CreditCheckOverrideDialog({
@@ -17,11 +86,19 @@ export default function CreditCheckOverrideDialog({
   onClose,
   status,
   onStatusChange,
+  reasonCategory,
+  onReasonCategoryChange,
   notes,
   onNotesChange,
   isPending,
   onConfirm,
 }: Props) {
+  const currentOption = REASON_OPTIONS.find((o) => o.value === reasonCategory);
+  const compiled = useMemo(() => compileReason(reasonCategory, notes), [reasonCategory, notes]);
+  const tooShort = compiled.trim().length < 20;
+  const tooLong = compiled.length > 2000;
+  const disabled = !status || !reasonCategory || tooShort || tooLong || isPending;
+
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-md">
@@ -30,7 +107,9 @@ export default function CreditCheckOverrideDialog({
         </DialogHeader>
         <div className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-foreground mb-1.5">สถานะใหม่</label>
+            <label className="block text-xs font-medium text-foreground mb-1.5">
+              สถานะใหม่ <span className="text-destructive">*</span>
+            </label>
             <select
               value={status}
               onChange={(e) => onStatusChange(e.target.value)}
@@ -46,32 +125,45 @@ export default function CreditCheckOverrideDialog({
             <label className="block text-xs font-medium text-foreground mb-1.5">
               เหตุผล <span className="text-destructive">*</span>
             </label>
-            <textarea
-              value={notes}
-              onChange={(e) => onNotesChange(e.target.value)}
-              rows={4}
-              placeholder="เหตุผลที่ปรับแก้ (อย่างน้อย 20 ตัวอักษร)"
-              className="w-full px-3 py-2 rounded-lg border border-input bg-background text-sm"
-            />
-            <div className="flex justify-between text-[11px] mt-1">
-              <span className={notes.trim().length < 20 ? 'text-destructive' : 'text-muted-foreground'}>
-                {notes.trim().length < 20
-                  ? `ต้องมีอย่างน้อย 20 ตัวอักษร (ตอนนี้ ${notes.trim().length})`
-                  : 'พอดีแล้ว'}
-              </span>
-              <span className="text-muted-foreground">{notes.length}/2000</span>
-            </div>
+            <select
+              value={reasonCategory}
+              onChange={(e) => onReasonCategoryChange(e.target.value)}
+              className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm"
+            >
+              <option value="">-- เลือกเหตุผล --</option>
+              {REASON_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
           </div>
+          {currentOption && (
+            <div>
+              <label className="block text-xs font-medium text-foreground mb-1.5">
+                {currentOption.detailLabel} <span className="text-destructive">*</span>
+              </label>
+              <textarea
+                value={notes}
+                onChange={(e) => onNotesChange(e.target.value)}
+                rows={3}
+                placeholder={currentOption.detailPlaceholder}
+                className="w-full px-3 py-2 rounded-lg border border-input bg-background text-sm"
+              />
+              <div className="flex justify-between text-[11px] mt-1">
+                <span className={tooShort ? 'text-destructive' : 'text-muted-foreground'}>
+                  {tooShort
+                    ? `รวมต้อง ≥ 20 ตัวอักษร (ตอนนี้ ${compiled.trim().length})`
+                    : 'พอดีแล้ว'}
+                </span>
+                <span className="text-muted-foreground">{compiled.length}/2000</span>
+              </div>
+            </div>
+          )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>
             ยกเลิก
           </Button>
-          <Button
-            variant="primary"
-            onClick={onConfirm}
-            disabled={!status || notes.trim().length < 20 || notes.length > 2000 || isPending}
-          >
+          <Button variant="primary" onClick={onConfirm} disabled={disabled}>
             {isPending ? 'กำลังบันทึก...' : 'ยืนยัน'}
           </Button>
         </DialogFooter>
@@ -79,3 +171,5 @@ export default function CreditCheckOverrideDialog({
     </Dialog>
   );
 }
+
+export { compileReason, REASON_OPTIONS };

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useParams, useNavigate, Link, useSearchParams } from 'react-router';
 import CreditCheckCreateDialog from '@/components/credit-check/CreditCheckCreateDialog';
 import CreditCheckCard from '@/components/credit-check/CreditCheckCard';
-import CreditCheckOverrideDialog from '@/components/credit-check/CreditCheckOverrideDialog';
+import CreditCheckOverrideDialog, { compileReason } from '@/components/credit-check/CreditCheckOverrideDialog';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import api, { getErrorMessage } from '@/lib/api';
@@ -132,6 +132,7 @@ export default function CustomerDetailPage() {
   const [showCreditDialog, setShowCreditDialog] = useState(false);
   const [overrideId, setOverrideId] = useState<string | null>(null);
   const [overrideStatus, setOverrideStatus] = useState('');
+  const [overrideReasonCategory, setOverrideReasonCategory] = useState('');
   const [overrideNotes, setOverrideNotes] = useState('');
 
   useEffect(() => {
@@ -301,7 +302,7 @@ export default function CustomerDetailPage() {
       if (!overrideId) return;
       const { data } = await api.post(`/customers/${id}/credit-check/${overrideId}/override`, {
         status: overrideStatus,
-        overrideReason: overrideNotes,
+        overrideReason: compileReason(overrideReasonCategory, overrideNotes),
       });
       return data;
     },
@@ -310,6 +311,7 @@ export default function CustomerDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['customer-credit-checks', id] });
       setOverrideId(null);
       setOverrideStatus('');
+      setOverrideReasonCategory('');
       setOverrideNotes('');
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
@@ -1262,9 +1264,16 @@ export default function CustomerDetailPage() {
 
       <CreditCheckOverrideDialog
         open={!!overrideId}
-        onClose={() => setOverrideId(null)}
+        onClose={() => {
+          setOverrideId(null);
+          setOverrideStatus('');
+          setOverrideReasonCategory('');
+          setOverrideNotes('');
+        }}
         status={overrideStatus}
         onStatusChange={setOverrideStatus}
+        reasonCategory={overrideReasonCategory}
+        onReasonCategoryChange={setOverrideReasonCategory}
         notes={overrideNotes}
         onNotesChange={setOverrideNotes}
         isPending={overrideCreditMutation.isPending}


### PR DESCRIPTION
## Summary

ปรับ dialog "ปรับแก้สถานะเครดิตเช็ค" จาก free-text → **dropdown 8 preset + detail textarea** เพื่อ standardize audit trail + เร็วในการกรอก

## Preset categories

| # | Category | Use case |
|---|----------|----------|
| 1 | ลูกค้าเก่าผ่อนจบแล้ว | track record |
| 2 | พนักงาน/คนรู้จัก/ลูกหลาน | personal vouch |
| 3 | มีผู้ค้ำประกัน | secondary liability |
| 4 | ดาวน์สูง/จ่ายสดมาก (≥ 50%) | skin in the game |
| 5 | รายได้เป็นเงินสด/ไม่เข้าบัญชี | AI miss |
| 6 | เอกสารรายได้เพิ่มเติม | supplementary evidence |
| 7 | Manager/Owner รับความเสี่ยง | approve by exception |
| 8 | อื่นๆ | free text |

แต่ละ preset มี placeholder แนะนำรูปแบบ detail ที่เหมาะสม

## Submission

ส่ง \`overrideReason\` = \`\"<Category label>: <detail>\"\` (compiled via \`compileReason()\`)
\- Option "อื่นๆ" ส่งเฉพาะ detail
- Server รับเหมือนเดิม — ยังคง validate min 20 / max 2000

## Risk

Low — frontend-only change. Server contract unchanged. All existing CreditCheck records unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)