### PR TITLE
feat(credit-check): smart override — skip reason when staff agrees with AI

### DIFF
--- a/apps/web/src/components/credit-check/CreditCheckOverrideDialog.tsx
+++ b/apps/web/src/components/credit-check/CreditCheckOverrideDialog.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Sparkles, CheckCircle2, AlertTriangle } from 'lucide-react';
 
 interface Props {
   open: boolean;
   onClose: () => void;
+  aiDecision: string; // current CreditCheck.status — what AI decided
+  aiSummary: string | null;
   status: string;
   onStatusChange: (v: string) => void;
   reasonCategory: string;
@@ -18,58 +21,66 @@ interface Props {
 interface ReasonOption {
   value: string;
   label: string;
-  detailLabel: string;
-  detailPlaceholder: string;
+  /** If true, label alone is not enough — require textarea ≥ 10 chars */
+  requiresDetail: boolean;
+  detailLabel?: string;
+  detailPlaceholder?: string;
 }
 
 const REASON_OPTIONS: ReasonOption[] = [
   {
     value: 'EXISTING_CUSTOMER',
     label: 'ลูกค้าเก่าผ่อนจบแล้ว',
-    detailLabel: 'ระบุสัญญาเก่า',
-    detailPlaceholder: 'เช่น สัญญาเลขที่ BC-2024-00123 ผ่อน 12 งวดจบเมื่อ ธ.ค. 2568',
+    requiresDetail: true,
+    detailLabel: 'เลขสัญญาเก่า',
+    detailPlaceholder: 'เช่น BC-2024-00123',
   },
   {
     value: 'PERSONAL_VOUCH',
     label: 'พนักงาน/คนรู้จัก/ลูกหลาน',
-    detailLabel: 'ระบุชื่อ+ความสัมพันธ์',
-    detailPlaceholder: 'เช่น น้องสาวของ คุณสมชาย (พนักงานสาขาลาดพร้าว)',
+    requiresDetail: true,
+    detailLabel: 'ชื่อ + ความสัมพันธ์',
+    detailPlaceholder: 'เช่น น้องสาวคุณสมชาย (พนง.สาขาลาดพร้าว)',
   },
   {
     value: 'GUARANTOR',
     label: 'มีผู้ค้ำประกัน',
-    detailLabel: 'ระบุชื่อผู้ค้ำ+เอกสาร',
-    detailPlaceholder: 'เช่น บิดาค้ำ (นายสมบัติ ฯลฯ) แนบสำเนาบัตร+สลิปเงินเดือน',
+    requiresDetail: true,
+    detailLabel: 'ชื่อผู้ค้ำ + เอกสาร',
+    detailPlaceholder: 'เช่น บิดาค้ำ (นายสมบัติ) แนบสำเนาบัตร+สลิป',
   },
   {
     value: 'HIGH_DOWN',
-    label: 'ดาวน์สูง/จ่ายสดมาก (≥ 50%)',
-    detailLabel: 'ระบุยอดดาวน์',
-    detailPlaceholder: 'เช่น ดาวน์ 15,000 จากราคา 25,000 (60%)',
+    label: 'ดาวน์/จ่ายสด ≥ 50%',
+    requiresDetail: false,
   },
   {
     value: 'CASH_INCOME',
-    label: 'รายได้เป็นเงินสด/ไม่เข้าบัญชี',
-    detailLabel: 'ระบุอาชีพ+รายได้ประมาณ',
-    detailPlaceholder: 'เช่น ค้าขายในตลาด รายได้ประมาณ 25,000/เดือน',
+    label: 'รายได้เงินสด (AI อ่านไม่ครอบคลุม)',
+    requiresDetail: true,
+    detailLabel: 'อาชีพ + รายได้ประมาณ',
+    detailPlaceholder: 'เช่น ค้าขายตลาด รายได้ 25,000/เดือน',
   },
   {
     value: 'EXTRA_EVIDENCE',
     label: 'เอกสารรายได้เพิ่มเติม',
-    detailLabel: 'ระบุเอกสารที่ได้รับ',
-    detailPlaceholder: 'เช่น สลิปเงินเดือน 3 เดือน + หนังสือรับรองเงินเดือน',
+    requiresDetail: true,
+    detailLabel: 'ระบุเอกสาร',
+    detailPlaceholder: 'เช่น สลิปเงินเดือน 3 เดือน + ใบรับรองเงินเดือน',
   },
   {
     value: 'MGR_RISK',
     label: 'Manager/Owner รับความเสี่ยง',
-    detailLabel: 'เหตุผล + ผู้อนุมัติ',
-    detailPlaceholder: 'เช่น approve by exception โดยคุณ... (ความสัมพันธ์กับลูกค้า)',
+    requiresDetail: true,
+    detailLabel: 'ผู้อนุมัติ',
+    detailPlaceholder: 'เช่น approve โดยคุณ... (ระบุความสัมพันธ์)',
   },
   {
     value: 'OTHER',
     label: 'อื่นๆ',
+    requiresDetail: true,
     detailLabel: 'เหตุผล',
-    detailPlaceholder: 'กรุณาระบุเหตุผลให้ชัดเจน อย่างน้อย 20 ตัวอักษร',
+    detailPlaceholder: 'ระบุเหตุผลให้ชัดเจน',
   },
 ];
 
@@ -81,9 +92,18 @@ function compileReason(categoryValue: string, detail: string): string {
   return trimmed ? `${opt.label}: ${trimmed}` : opt.label;
 }
 
+function decisionLabel(decision: string): string {
+  if (decision === 'APPROVED') return 'อนุมัติ';
+  if (decision === 'REJECTED') return 'ปฏิเสธ';
+  if (decision === 'MANUAL_REVIEW') return 'ต้องตรวจเพิ่ม';
+  return decision;
+}
+
 export default function CreditCheckOverrideDialog({
   open,
   onClose,
+  aiDecision,
+  aiSummary,
   status,
   onStatusChange,
   reasonCategory,
@@ -93,11 +113,18 @@ export default function CreditCheckOverrideDialog({
   isPending,
   onConfirm,
 }: Props) {
+  const agreesWithAi = !!status && status === aiDecision;
   const currentOption = REASON_OPTIONS.find((o) => o.value === reasonCategory);
   const compiled = useMemo(() => compileReason(reasonCategory, notes), [reasonCategory, notes]);
-  const tooShort = compiled.trim().length < 20;
-  const tooLong = compiled.length > 2000;
-  const disabled = !status || !reasonCategory || tooShort || tooLong || isPending;
+
+  // Validation — only when disagreeing with AI
+  const needsReason = !!status && status !== aiDecision;
+  const reasonValid = agreesWithAi
+    ? true
+    : !!reasonCategory &&
+      (!currentOption?.requiresDetail || notes.trim().length >= 10) &&
+      compiled.length <= 2000;
+  const disabled = !status || !reasonValid || isPending;
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -106,6 +133,19 @@ export default function CreditCheckOverrideDialog({
           <DialogTitle>ปรับแก้สถานะเครดิตเช็ค</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
+          {/* AI context — read before deciding */}
+          {aiDecision && (
+            <div className="rounded-lg border border-border/60 bg-muted/30 p-3 space-y-1">
+              <div className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                <Sparkles className="size-3.5 text-primary" />
+                ผลจาก AI: <span className="text-primary">{decisionLabel(aiDecision)}</span>
+              </div>
+              {aiSummary && (
+                <div className="text-xs text-muted-foreground leading-snug">{aiSummary}</div>
+              )}
+            </div>
+          )}
+
           <div>
             <label className="block text-xs font-medium text-foreground mb-1.5">
               สถานะใหม่ <span className="text-destructive">*</span>
@@ -121,42 +161,78 @@ export default function CreditCheckOverrideDialog({
               <option value="MANUAL_REVIEW">ต้องตรวจเพิ่ม</option>
             </select>
           </div>
-          <div>
-            <label className="block text-xs font-medium text-foreground mb-1.5">
-              เหตุผล <span className="text-destructive">*</span>
-            </label>
-            <select
-              value={reasonCategory}
-              onChange={(e) => onReasonCategoryChange(e.target.value)}
-              className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm"
-            >
-              <option value="">-- เลือกเหตุผล --</option>
-              {REASON_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </div>
-          {currentOption && (
-            <div>
-              <label className="block text-xs font-medium text-foreground mb-1.5">
-                {currentOption.detailLabel} <span className="text-destructive">*</span>
-              </label>
-              <textarea
-                value={notes}
-                onChange={(e) => onNotesChange(e.target.value)}
-                rows={3}
-                placeholder={currentOption.detailPlaceholder}
-                className="w-full px-3 py-2 rounded-lg border border-input bg-background text-sm"
-              />
-              <div className="flex justify-between text-[11px] mt-1">
-                <span className={tooShort ? 'text-destructive' : 'text-muted-foreground'}>
-                  {tooShort
-                    ? `รวมต้อง ≥ 20 ตัวอักษร (ตอนนี้ ${compiled.trim().length})`
-                    : 'พอดีแล้ว'}
-                </span>
-                <span className="text-muted-foreground">{compiled.length}/2000</span>
+
+          {/* Agrees with AI → no reason needed */}
+          {agreesWithAi && (
+            <div className="rounded-lg border border-success/30 bg-success/5 p-3 flex items-start gap-2">
+              <CheckCircle2 className="size-4 text-success shrink-0 mt-0.5" />
+              <div className="text-xs text-foreground leading-snug">
+                เห็นด้วยกับ AI — ไม่ต้องใส่เหตุผลเพิ่ม กดยืนยันได้เลย
               </div>
             </div>
+          )}
+
+          {/* Disagrees with AI → require reason */}
+          {needsReason && (
+            <>
+              <div className="rounded-lg border border-warning/30 bg-warning/5 p-3 flex items-start gap-2">
+                <AlertTriangle className="size-4 text-warning shrink-0 mt-0.5" />
+                <div className="text-xs text-foreground leading-snug">
+                  คุณกำลัง override ผล AI — ต้องระบุเหตุผลเพื่อ audit
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5">
+                  เหตุผล <span className="text-destructive">*</span>
+                </label>
+                <select
+                  value={reasonCategory}
+                  onChange={(e) => onReasonCategoryChange(e.target.value)}
+                  className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm"
+                >
+                  <option value="">-- เลือกเหตุผล --</option>
+                  {REASON_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}{opt.requiresDetail ? '' : ' ✓'}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {currentOption?.requiresDetail && (
+                <div>
+                  <label className="block text-xs font-medium text-foreground mb-1.5">
+                    {currentOption.detailLabel} <span className="text-destructive">*</span>
+                  </label>
+                  <textarea
+                    value={notes}
+                    onChange={(e) => onNotesChange(e.target.value)}
+                    rows={3}
+                    placeholder={currentOption.detailPlaceholder}
+                    className="w-full px-3 py-2 rounded-lg border border-input bg-background text-sm"
+                  />
+                  <div className="flex justify-between text-[11px] mt-1">
+                    <span
+                      className={
+                        notes.trim().length < 10 ? 'text-destructive' : 'text-muted-foreground'
+                      }
+                    >
+                      {notes.trim().length < 10
+                        ? `ต้อง ≥ 10 ตัวอักษร (ตอนนี้ ${notes.trim().length})`
+                        : 'พอดีแล้ว'}
+                    </span>
+                    <span className="text-muted-foreground">{notes.length}/2000</span>
+                  </div>
+                </div>
+              )}
+
+              {currentOption && !currentOption.requiresDetail && (
+                <div className="text-[11px] text-muted-foreground px-1">
+                  ตัวเลือกนี้อธิบายในตัวเองแล้ว — ไม่ต้องใส่รายละเอียดเพิ่ม
+                </div>
+              )}
+            </>
           )}
         </div>
         <DialogFooter>

--- a/apps/web/src/pages/CustomerDetailPage.tsx
+++ b/apps/web/src/pages/CustomerDetailPage.tsx
@@ -131,6 +131,8 @@ export default function CustomerDetailPage() {
   const [activeTab, setActiveTab] = useState(initialTab);
   const [showCreditDialog, setShowCreditDialog] = useState(false);
   const [overrideId, setOverrideId] = useState<string | null>(null);
+  const [overrideAiDecision, setOverrideAiDecision] = useState<string>('');
+  const [overrideAiSummary, setOverrideAiSummary] = useState<string | null>(null);
   const [overrideStatus, setOverrideStatus] = useState('');
   const [overrideReasonCategory, setOverrideReasonCategory] = useState('');
   const [overrideNotes, setOverrideNotes] = useState('');
@@ -300,9 +302,15 @@ export default function CustomerDetailPage() {
   const overrideCreditMutation = useMutation({
     mutationFn: async () => {
       if (!overrideId) return;
+      // ถ้า staff เห็นด้วยกับ AI (status === AI decision) → ส่ง default reason
+      // ไม่ต้องบังคับให้พนักงานกรอก (เห็นด้วยไม่ใช่ override จริง)
+      const reason =
+        overrideStatus === overrideAiDecision
+          ? 'ยืนยันผล AI (staff เห็นด้วยกับคำแนะนำของระบบ)'
+          : compileReason(overrideReasonCategory, overrideNotes);
       const { data } = await api.post(`/customers/${id}/credit-check/${overrideId}/override`, {
         status: overrideStatus,
-        overrideReason: compileReason(overrideReasonCategory, overrideNotes),
+        overrideReason: reason,
       });
       return data;
     },
@@ -781,7 +789,10 @@ export default function CustomerDetailPage() {
                 onAnalyze={(ccId) => analyzeCreditMutation.mutate(ccId)}
                 onOverride={(ccId) => {
                   setOverrideId(ccId);
+                  setOverrideAiDecision(cc.status);
+                  setOverrideAiSummary(cc.aiSummary);
                   setOverrideStatus('');
+                  setOverrideReasonCategory('');
                   setOverrideNotes('');
                 }}
                 onViewStatement={(url) => window.open(url, '_blank', 'noopener,noreferrer')}
@@ -1270,6 +1281,8 @@ export default function CustomerDetailPage() {
           setOverrideReasonCategory('');
           setOverrideNotes('');
         }}
+        aiDecision={overrideAiDecision}
+        aiSummary={overrideAiSummary}
         status={overrideStatus}
         onStatusChange={setOverrideStatus}
         reasonCategory={overrideReasonCategory}


### PR DESCRIPTION
## Summary

ปรับ override dialog ให้ฉลาดขึ้น 3 จุดตามฟีดแบ็กเจ้าของ:

### 1. โชว์ผล AI ด้านบน (confront risk)
แสดง \`decision\` + \`aiSummary\` เพื่อให้ staff อ่านก่อนตัดสินใจ

### 2. เห็นด้วยกับ AI → ไม่ต้องใส่เหตุผล
ถ้า \`status === aiDecision\` → ซ่อน reason section, auto-fill "ยืนยันผล AI" — กดยืนยันได้เลย ไม่ใช่ override จริง

### 3. เหตุผลที่ชัดในตัวเอง → ไม่บังคับ textarea
เพิ่ม \`requiresDetail: boolean\` บนแต่ละ preset:

| Option | Requires detail? |
|--------|------------------|
| ลูกค้าเก่าผ่อนจบแล้ว | ✓ (เลขสัญญาเก่า) |
| พนักงาน/คนรู้จัก/ลูกหลาน | ✓ (ชื่อ+ความสัมพันธ์) |
| มีผู้ค้ำประกัน | ✓ (ชื่อ+เอกสาร) |
| **ดาวน์/จ่ายสด ≥ 50%** | **— (อธิบายในตัวเอง)** |
| รายได้เงินสด | ✓ (อาชีพ+รายได้) |
| เอกสารรายได้เพิ่มเติม | ✓ (ระบุเอกสาร) |
| Manager/Owner รับความเสี่ยง | ✓ (ผู้อนุมัติ) |
| อื่นๆ | ✓ (เหตุผล) |

Options ที่ self-explanatory มี ✓ ท้ายใน dropdown เพื่อสื่อว่าไม่ต้องกรอกต่อ

### เพิ่มเติม
- ลด min detail 20 → 10 ตัวอักษร
- ลบ compiled counter งงๆ (textarea ว่าง แต่โชว์ "27/2000") — ใช้ counter ของ textarea จริงแทน
- เตือนสี warning เมื่อจะ override ("คุณกำลัง override ผล AI — ต้องระบุเหตุผลเพื่อ audit")

## UX ผลลัพธ์

| Scenario | Click count |
|----------|-------------|
| Agree กับ AI | เลือกสถานะ + ยืนยัน = **2 คลิก** |
| Override (ดาวน์สูง) | สถานะ + เหตุผล + ยืนยัน = **3 คลิก** |
| Override (ค้ำประกัน) | สถานะ + เหตุผล + พิมพ์ชื่อ + ยืนยัน = ~30 วิ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)