### PR TITLE
fix(topbar): notification bell click + reactive unread dot

### DIFF
--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -30,6 +30,9 @@ import {
 import { useCommandPalette } from '@/components/CommandPalette';
 import { ChatUnreadBadge } from './Sidebar';
 import { isChatVisibleForRole } from '@/config/menu';
+import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
+
+const NOTIFICATION_ROLES = ['OWNER', 'BRANCH_MANAGER'];
 
 /* ── Role display metadata ─────────────────────── */
 const roleLabels: Record<string, string> = {
@@ -141,6 +144,8 @@ export default function TopBar() {
   const { theme, setTheme } = useTheme();
   const { open: openCommandPalette } = useCommandPalette();
   const { pathname } = useLocation();
+  const unreadNotifications = useUnreadNotifications();
+  const canSeeNotifications = !!user && NOTIFICATION_ROLES.includes(user.role);
 
   const pageTitle = useMemo(() => {
     const map: Record<string, string> = {
@@ -224,19 +229,31 @@ export default function TopBar() {
         )}
 
         {/* Notifications bell */}
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="การแจ้งเตือน"
-          className="size-9 rounded-xl relative text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors duration-150"
-        >
-          <Bell className="size-[17px]" strokeWidth={1.75} />
-          {/* Active indicator dot */}
-          <span
-            className="absolute top-[9px] right-[9px] size-[7px] rounded-full bg-success ring-[1.5px] ring-background"
-            aria-hidden="true"
-          />
-        </Button>
+        {canSeeNotifications && (
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="size-9 rounded-xl relative text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors duration-150"
+          >
+            <Link
+              to="/notifications"
+              aria-label={
+                unreadNotifications > 0
+                  ? `การแจ้งเตือน (${unreadNotifications} รายการใหม่)`
+                  : 'การแจ้งเตือน'
+              }
+            >
+              <Bell className="size-[17px]" strokeWidth={1.75} />
+              {unreadNotifications > 0 && (
+                <span
+                  className="absolute top-[9px] right-[9px] size-[7px] rounded-full bg-destructive ring-[1.5px] ring-background"
+                  aria-hidden="true"
+                />
+              )}
+            </Link>
+          </Button>
+        )}
 
         {/* Dark/light mode toggle */}
         <Button

--- a/apps/web/src/hooks/useUnreadNotifications.ts
+++ b/apps/web/src/hooks/useUnreadNotifications.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+const ROLES_WITH_ACCESS = ['OWNER', 'BRANCH_MANAGER'] as const;
+
+type LogStats = { total: number; sent: number; failed: number; pending: number };
+
+export function useUnreadNotifications() {
+  const { user } = useAuth();
+  const hasAccess = !!user && ROLES_WITH_ACCESS.includes(user.role as (typeof ROLES_WITH_ACCESS)[number]);
+
+  const { data } = useQuery({
+    queryKey: ['notifications-log-stats'],
+    queryFn: () => api.get<LogStats>('/notifications/logs/stats').then((r) => r.data),
+    enabled: hasAccess,
+    refetchInterval: 30000,
+    staleTime: 10000,
+  });
+
+  return (data?.failed ?? 0) + (data?.pending ?? 0);
+}


### PR DESCRIPTION
## Summary

- Bell button in TopBar had no onClick/Link — clicking did nothing.
- Green indicator dot was hardcoded-on regardless of state.

## Changes

- Wrap Bell with `<Link to="/notifications">` via `asChild` (matches chat inbox button pattern).
- Gate button by role (OWNER/BRANCH_MANAGER) — `/notifications` page + `/notifications/logs/stats` endpoint are both restricted to those roles.
- New `useUnreadNotifications` hook polling `logs/stats` every 30s → returns `failed + pending` (deliveries needing attention).
- Dot now conditional (`unreadNotifications > 0`), color switched to `bg-destructive` — the dot signals "needs attention", green read as "all good".
- `aria-label` includes count when > 0 (e.g., "การแจ้งเตือน (3 รายการใหม่)").

## Test plan

- [ ] Login as OWNER — bell visible, clicks navigate to `/notifications`
- [ ] Login as OWNER when there are FAILED/PENDING notification logs — red dot appears
- [ ] Login as OWNER when all logs are SENT — no dot
- [ ] Login as SALES/ACCOUNTANT/FINANCE_MANAGER — bell hidden entirely (no 403 calls)
- [ ] `a11y`: aria-label reads correct count with screen reader

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>