### PR TITLE
feat(infra): deploy web-shop to shop.bestchoicephone.app (Firebase multi-site)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,4 @@
+
+# Facebook Page (for historical chat extractor + live webhook)
+FACEBOOK_PAGE_ACCESS_TOKEN=
+FACEBOOK_PAGE_ID=

--- a/apps/api/prisma/migrations/20260601000000_chat_ai_hybrid_c/migration.sql
+++ b/apps/api/prisma/migrations/20260601000000_chat_ai_hybrid_c/migration.sql
@@ -1,0 +1,34 @@
+-- Chat AI Hybrid C: add aiPaused state on ChatRoom + singleton AiSettings table.
+-- Purely additive migration. No drops, no data backfill required (all new columns
+-- have safe defaults or are nullable).
+
+-- AlterTable: ChatRoom — AI pause state (staff take-over)
+ALTER TABLE "chat_rooms"
+  ADD COLUMN "ai_paused" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "ai_paused_at" TIMESTAMP(3),
+  ADD COLUMN "ai_paused_by_id" TEXT;
+
+-- AddForeignKey: ChatRoom.aiPausedBy -> User
+ALTER TABLE "chat_rooms"
+  ADD CONSTRAINT "chat_rooms_ai_paused_by_id_fkey"
+  FOREIGN KEY ("ai_paused_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- CreateTable: AiSettings (single-row, id = 'singleton')
+CREATE TABLE "ai_settings" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "sales_bot_mode" TEXT NOT NULL DEFAULT 'HYBRID',
+    "service_bot_mode" TEXT NOT NULL DEFAULT 'HYBRID',
+    "sales_bot_confidence_threshold" DOUBLE PRECISION NOT NULL DEFAULT 0.70,
+    "service_bot_confidence_threshold" DOUBLE PRECISION NOT NULL DEFAULT 0.75,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "updated_by_id" TEXT,
+
+    CONSTRAINT "ai_settings_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey: AiSettings.updatedBy -> User
+ALTER TABLE "ai_settings"
+  ADD CONSTRAINT "ai_settings_updated_by_id_fkey"
+  FOREIGN KEY ("updated_by_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -534,6 +534,8 @@ model User {
   crmLeadStageHistoryStagedBy CrmLeadStageHistory[]     @relation("CrmLeadStageHistoryStagedBy")
   paymentsWaived              Payment[]                 @relation("PaymentWaivedBy")
   paymentsWaivedApproved      Payment[]                 @relation("PaymentWaivedApprovedBy")
+  aiPausedRooms               ChatRoom[]                @relation("ChatRoomAiPausedBy")
+  aiSettingsUpdates           AiSettings[]              @relation("AiSettingsUpdatedBy")
 
   @@index([branchId])
   @@map("users")
@@ -3663,6 +3665,12 @@ model ChatRoom {
   totalMessages Int      @default(0) @map("total_messages")
   lastMessageAt DateTime @default(now()) @map("last_message_at")
 
+  // AI pause state (Hybrid C take-over)
+  aiPaused     Boolean   @default(false) @map("ai_paused")
+  aiPausedAt   DateTime? @map("ai_paused_at")
+  aiPausedById String?   @map("ai_paused_by_id")
+  aiPausedBy   User?     @relation("ChatRoomAiPausedBy", fields: [aiPausedById], references: [id])
+
   messages      ChatMessage[]
   feedbacks     ChatFeedback[]
   tags          ConversationTag[]
@@ -4766,4 +4774,20 @@ model KnownDevice {
   @@index([userId, lastSeenAt])
   @@index([fingerprint])
   @@map("known_devices")
+}
+
+/// Single-row settings for AI behavior (id = 'singleton').
+/// Controls per-bot mode (OFF | HYBRID | FULL) and confidence thresholds
+/// used by the draft orchestrator for Chat AI Hybrid C.
+model AiSettings {
+  id                            String   @id @default("singleton")
+  salesBotMode                  String   @default("HYBRID") @map("sales_bot_mode") // OFF | HYBRID | FULL
+  serviceBotMode                String   @default("HYBRID") @map("service_bot_mode") // OFF | HYBRID | FULL
+  salesBotConfidenceThreshold   Float    @default(0.70) @map("sales_bot_confidence_threshold")
+  serviceBotConfidenceThreshold Float    @default(0.75) @map("service_bot_confidence_threshold")
+  updatedAt                     DateTime @updatedAt @map("updated_at")
+  updatedById                   String?  @map("updated_by_id")
+  updatedBy                     User?    @relation("AiSettingsUpdatedBy", fields: [updatedById], references: [id])
+
+  @@map("ai_settings")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -71,6 +71,7 @@ import { FacebookDomainModule } from './modules/facebook-domain/facebook-domain.
 import { StaffChatModule } from './modules/staff-chat/staff-chat.module';
 import { ChatAnalyticsModule } from './modules/chat-analytics/chat-analytics.module';
 import { ChatHistoryExtractorModule } from './modules/chat-history-extractor/chat-history-extractor.module';
+import { ChatIntentRouterModule } from './modules/chat-intent-router/chat-intent-router.module';
 import { CsatModule } from './modules/csat/csat.module';
 import { AdsTrackingModule } from './modules/ads-tracking/ads-tracking.module';
 import { CrmModule } from './modules/crm/crm.module';
@@ -219,6 +220,8 @@ import { AppCacheModule } from './cache/cache.module';
     ChatAnalyticsModule,
     // Chat History Extractor — pull past LINE/FB conversations → AiTrainingPair (OWNER only)
     ChatHistoryExtractorModule,
+    // Chat Intent Router — classify inbound message to sales/service/handoff via Claude Haiku
+    ChatIntentRouterModule,
     // CSAT — customer satisfaction survey after chat resolution
     CsatModule,
     // Ads Attribution — campaign tracking + ROI

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -70,6 +70,7 @@ import { ChatAdaptersModule } from './modules/chat-adapters/chat-adapters.module
 import { FacebookDomainModule } from './modules/facebook-domain/facebook-domain.module';
 import { StaffChatModule } from './modules/staff-chat/staff-chat.module';
 import { ChatAnalyticsModule } from './modules/chat-analytics/chat-analytics.module';
+import { ChatHistoryExtractorModule } from './modules/chat-history-extractor/chat-history-extractor.module';
 import { CsatModule } from './modules/csat/csat.module';
 import { AdsTrackingModule } from './modules/ads-tracking/ads-tracking.module';
 import { CrmModule } from './modules/crm/crm.module';
@@ -216,6 +217,8 @@ import { AppCacheModule } from './cache/cache.module';
     StaffChatModule,
     // Chat Analytics — response time, resolution rate, channel volume
     ChatAnalyticsModule,
+    // Chat History Extractor — pull past LINE/FB conversations → AiTrainingPair (OWNER only)
+    ChatHistoryExtractorModule,
     // CSAT — customer satisfaction survey after chat resolution
     CsatModule,
     // Ads Attribution — campaign tracking + ROI

--- a/apps/api/src/modules/chat-history-extractor/chat-history-extractor.controller.ts
+++ b/apps/api/src/modules/chat-history-extractor/chat-history-extractor.controller.ts
@@ -3,15 +3,25 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { ChatHistoryExtractorService } from './chat-history-extractor.service';
+import { KnowledgeExtractorService } from './knowledge-extractor.service';
 
 @Controller('chat-history')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class ChatHistoryExtractorController {
-  constructor(private readonly svc: ChatHistoryExtractorService) {}
+  constructor(
+    private readonly svc: ChatHistoryExtractorService,
+    private readonly knowledgeSvc: KnowledgeExtractorService,
+  ) {}
 
   @Post('extract')
   @Roles('OWNER')
   async extract(@Body() body: { months?: number }) {
     return this.svc.extractAll(body.months ?? 12);
+  }
+
+  @Post('extract-knowledge')
+  @Roles('OWNER')
+  async extractKnowledge() {
+    return this.knowledgeSvc.extractAndSeed();
   }
 }

--- a/apps/api/src/modules/chat-history-extractor/chat-history-extractor.controller.ts
+++ b/apps/api/src/modules/chat-history-extractor/chat-history-extractor.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { ChatHistoryExtractorService } from './chat-history-extractor.service';
+
+@Controller('chat-history')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ChatHistoryExtractorController {
+  constructor(private readonly svc: ChatHistoryExtractorService) {}
+
+  @Post('extract')
+  @Roles('OWNER')
+  async extract(@Body() body: { months?: number }) {
+    return this.svc.extractAll(body.months ?? 12);
+  }
+}

--- a/apps/api/src/modules/chat-history-extractor/chat-history-extractor.module.ts
+++ b/apps/api/src/modules/chat-history-extractor/chat-history-extractor.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ChatHistoryExtractorService } from './chat-history-extractor.service';
+import { ChatHistoryExtractorController } from './chat-history-extractor.controller';
+import { LineExtractorSource } from './sources/line-extractor.source';
+import { FacebookExtractorSource } from './sources/facebook-extractor.source';
+
+@Module({
+  controllers: [ChatHistoryExtractorController],
+  providers: [ChatHistoryExtractorService, LineExtractorSource, FacebookExtractorSource],
+})
+export class ChatHistoryExtractorModule {}

--- a/apps/api/src/modules/chat-history-extractor/chat-history-extractor.module.ts
+++ b/apps/api/src/modules/chat-history-extractor/chat-history-extractor.module.ts
@@ -3,9 +3,15 @@ import { ChatHistoryExtractorService } from './chat-history-extractor.service';
 import { ChatHistoryExtractorController } from './chat-history-extractor.controller';
 import { LineExtractorSource } from './sources/line-extractor.source';
 import { FacebookExtractorSource } from './sources/facebook-extractor.source';
+import { KnowledgeExtractorService } from './knowledge-extractor.service';
 
 @Module({
   controllers: [ChatHistoryExtractorController],
-  providers: [ChatHistoryExtractorService, LineExtractorSource, FacebookExtractorSource],
+  providers: [
+    ChatHistoryExtractorService,
+    LineExtractorSource,
+    FacebookExtractorSource,
+    KnowledgeExtractorService,
+  ],
 })
 export class ChatHistoryExtractorModule {}

--- a/apps/api/src/modules/chat-history-extractor/chat-history-extractor.service.ts
+++ b/apps/api/src/modules/chat-history-extractor/chat-history-extractor.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LineExtractorSource, ExtractedMessage } from './sources/line-extractor.source';
+import { FacebookExtractorSource } from './sources/facebook-extractor.source';
+import { scrubPii } from './pii-scrubber.util';
+
+@Injectable()
+export class ChatHistoryExtractorService {
+  private readonly logger = new Logger(ChatHistoryExtractorService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly lineSrc: LineExtractorSource,
+    private readonly fbSrc: FacebookExtractorSource,
+  ) {}
+
+  async extractAll(
+    months: number,
+  ): Promise<{ lineCount: number; fbCount: number; pairsWritten: number }> {
+    const since = new Date();
+    since.setMonth(since.getMonth() - months);
+
+    this.logger.log(`Extracting from ${since.toISOString()} onward`);
+    const [lineMsgs, fbMsgs] = await Promise.all([
+      this.lineSrc.extract({ channel: 'LINE_FINANCE', since }),
+      this.fbSrc.extract({ since }),
+    ]);
+
+    const all = [...lineMsgs, ...fbMsgs].map((m) => ({ ...m, text: scrubPii(m.text) }));
+    const pairs = this.buildPairs(all);
+
+    const BATCH = 500;
+    let written = 0;
+    for (let i = 0; i < pairs.length; i += BATCH) {
+      const batch = pairs.slice(i, i + BATCH);
+      await this.prisma.aiTrainingPair.createMany({
+        data: batch.map((p) => ({
+          type: 'ACCEPT',
+          source: 'SYSTEM_EXTRACT',
+          roomId: null,
+          customerMessage: p.customerMessage,
+          aiDraft: null,
+          humanEdit: p.staffAnswer,
+          intent: null,
+          quality: null,
+        })),
+        skipDuplicates: true,
+      });
+      written += batch.length;
+    }
+
+    return { lineCount: lineMsgs.length, fbCount: fbMsgs.length, pairsWritten: written };
+  }
+
+  private buildPairs(
+    msgs: ExtractedMessage[],
+  ): { customerMessage: string; staffAnswer: string }[] {
+    const byRoom = new Map<string, ExtractedMessage[]>();
+    for (const m of msgs) {
+      const arr = byRoom.get(m.roomId) ?? [];
+      arr.push(m);
+      byRoom.set(m.roomId, arr);
+    }
+    const pairs: { customerMessage: string; staffAnswer: string }[] = [];
+    for (const arr of byRoom.values()) {
+      arr.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      for (let i = 0; i < arr.length; i++) {
+        if (arr[i].role !== 'CUSTOMER') continue;
+        const next = arr.slice(i + 1).find((m) => m.role === 'STAFF');
+        if (next) pairs.push({ customerMessage: arr[i].text, staffAnswer: next.text });
+      }
+    }
+    return pairs;
+  }
+}

--- a/apps/api/src/modules/chat-history-extractor/knowledge-extractor.service.spec.ts
+++ b/apps/api/src/modules/chat-history-extractor/knowledge-extractor.service.spec.ts
@@ -1,0 +1,52 @@
+import { Test } from '@nestjs/testing';
+import { KnowledgeExtractorService } from './knowledge-extractor.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import Anthropic from '@anthropic-ai/sdk';
+
+jest.mock('@anthropic-ai/sdk');
+
+describe('KnowledgeExtractorService', () => {
+  it('parses Claude response and upserts to ChatKnowledgeBase', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            faqs: [
+              {
+                intent: 'installment_rate',
+                triggerKeywords: ['ดอก', 'กี่เปอร์เซ็นต์'],
+                exampleQuestions: ['ดอกเบี้ยกี่เปอร์เซ็นต์'],
+                responseTemplate: 'ผ่อน 0% สูงสุด 12 งวดค่ะ',
+              },
+            ],
+            objections: [],
+          }),
+        },
+      ],
+    });
+    (Anthropic as unknown as jest.Mock).mockImplementation(() => ({
+      messages: { create: mockCreate },
+    }));
+
+    const prisma = {
+      aiTrainingPair: {
+        findMany: jest
+          .fn()
+          .mockResolvedValue([{ customerMessage: 'ดอกกี่เปอร์เซ็นต์', humanEdit: 'ผ่อน 0% ค่ะ' }]),
+      },
+      chatKnowledgeBase: {
+        upsert: jest.fn().mockResolvedValue({ id: 'kb1' }),
+      },
+    };
+
+    const mod = await Test.createTestingModule({
+      providers: [KnowledgeExtractorService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    const svc = mod.get(KnowledgeExtractorService);
+
+    const result = await svc.extractAndSeed();
+    expect(result.faqsSeeded).toBe(1);
+    expect(prisma.chatKnowledgeBase.upsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/modules/chat-history-extractor/knowledge-extractor.service.ts
+++ b/apps/api/src/modules/chat-history-extractor/knowledge-extractor.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import Anthropic from '@anthropic-ai/sdk';
+
+interface ExtractedFaq {
+  intent: string;
+  triggerKeywords: string[];
+  exampleQuestions: string[];
+  responseTemplate: string;
+}
+interface ExtractedObjection {
+  keyword: string;
+  bestResponse: string;
+}
+
+const SYSTEM_PROMPT = `You are extracting FAQ and sales-objection patterns from historical BESTCHOICE chat logs.
+Return ONLY valid JSON matching this schema:
+{
+  "faqs": [{ "intent": string, "triggerKeywords": string[], "exampleQuestions": string[], "responseTemplate": string }],
+  "objections": [{ "keyword": string, "bestResponse": string }]
+}
+Thai text is expected. Merge duplicate FAQs. Pick the BEST staff response as responseTemplate. Max 30 FAQs, 20 objections.`;
+
+@Injectable()
+export class KnowledgeExtractorService {
+  private readonly logger = new Logger(KnowledgeExtractorService.name);
+  private readonly client = new Anthropic();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async extractAndSeed(): Promise<{ faqsSeeded: number; objectionsSeeded: number }> {
+    const pairs = await this.prisma.aiTrainingPair.findMany({
+      where: { source: 'SYSTEM_EXTRACT' },
+      take: 2000,
+      orderBy: { createdAt: 'desc' },
+      select: { customerMessage: true, humanEdit: true },
+    });
+    if (pairs.length === 0) return { faqsSeeded: 0, objectionsSeeded: 0 };
+
+    const userContent =
+      'Here are the chat pairs (customer → staff):\n\n' +
+      pairs
+        .map((p, i) => `${i + 1}. C: ${p.customerMessage}\n   S: ${p.humanEdit}`)
+        .join('\n\n');
+
+    const resp = await this.client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 8000,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userContent }],
+    });
+    const textBlock = resp.content.find((c) => c.type === 'text');
+    if (!textBlock || textBlock.type !== 'text') throw new Error('Claude returned no text');
+
+    const parsed = JSON.parse(textBlock.text) as {
+      faqs: ExtractedFaq[];
+      objections: ExtractedObjection[];
+    };
+
+    for (const faq of parsed.faqs) {
+      await this.prisma.chatKnowledgeBase.upsert({
+        where: { id: `extracted:${faq.intent}` },
+        create: {
+          id: `extracted:${faq.intent}`,
+          channel: 'LINE_FINANCE',
+          category: 'EXTRACTED',
+          intent: faq.intent,
+          triggerKeywords: faq.triggerKeywords,
+          exampleQuestions: faq.exampleQuestions,
+          responseTemplate: faq.responseTemplate,
+          responseType: 'info',
+          requiresAuth: true,
+          requiresTools: [],
+          active: false,
+          priority: 0,
+        },
+        update: {
+          triggerKeywords: faq.triggerKeywords,
+          exampleQuestions: faq.exampleQuestions,
+          responseTemplate: faq.responseTemplate,
+        },
+      });
+    }
+
+    this.logger.log(
+      `Extracted ${parsed.faqs.length} FAQs and ${parsed.objections.length} objections from ${pairs.length} pairs`,
+    );
+
+    return { faqsSeeded: parsed.faqs.length, objectionsSeeded: parsed.objections.length };
+  }
+}

--- a/apps/api/src/modules/chat-history-extractor/pii-scrubber.util.spec.ts
+++ b/apps/api/src/modules/chat-history-extractor/pii-scrubber.util.spec.ts
@@ -1,0 +1,16 @@
+import { scrubPii } from './pii-scrubber.util';
+
+describe('scrubPii', () => {
+  it('redacts Thai 13-digit national ID', () => {
+    expect(scrubPii('เลขบัตร 1234567890123 ครับ')).toBe('เลขบัตร [REDACTED_ID] ครับ');
+  });
+  it('redacts full DOB dd/mm/yyyy', () => {
+    expect(scrubPii('เกิด 15/07/1990')).toBe('เกิด [REDACTED_DOB]');
+  });
+  it('preserves phone numbers', () => {
+    expect(scrubPii('โทร 0812345678')).toBe('โทร 0812345678');
+  });
+  it('preserves normal money numbers', () => {
+    expect(scrubPii('ราคา 15,900 บาท')).toBe('ราคา 15,900 บาท');
+  });
+});

--- a/apps/api/src/modules/chat-history-extractor/pii-scrubber.util.ts
+++ b/apps/api/src/modules/chat-history-extractor/pii-scrubber.util.ts
@@ -1,0 +1,6 @@
+const THAI_ID_RE = /\b\d{13}\b/g;
+const DOB_RE = /\b(0?[1-9]|[12]\d|3[01])\/(0?[1-9]|1[0-2])\/(19|20)\d{2}\b/g;
+
+export function scrubPii(text: string): string {
+  return text.replace(THAI_ID_RE, '[REDACTED_ID]').replace(DOB_RE, '[REDACTED_DOB]');
+}

--- a/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.spec.ts
+++ b/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.spec.ts
@@ -1,0 +1,53 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { FacebookExtractorSource } from './facebook-extractor.source';
+
+describe('FacebookExtractorSource', () => {
+  let source: FacebookExtractorSource;
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const mod = await Test.createTestingModule({
+      providers: [
+        FacebookExtractorSource,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (k: string) =>
+              ({ FACEBOOK_PAGE_ACCESS_TOKEN: 'tok', FACEBOOK_PAGE_ID: 'page123' }[k]),
+          },
+        },
+      ],
+    }).compile();
+    source = mod.get(FacebookExtractorSource);
+    fetchMock = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => fetchMock.mockRestore());
+
+  it('extracts messages from paginated conversations', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'conv1',
+            participants: { data: [{ id: 'user1', name: 'A' }, { id: 'page123', name: 'Page' }] },
+            messages: {
+              data: [
+                { id: 'm1', message: 'Hi', from: { id: 'user1' }, created_time: '2026-02-01T00:00:00+0000' },
+                { id: 'm2', message: 'Hello!', from: { id: 'page123' }, created_time: '2026-02-01T00:01:00+0000' },
+              ],
+            },
+          },
+        ],
+        paging: {},
+      }),
+    } as any);
+    const result = await source.extract({ since: new Date('2025-04-22') });
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe('CUSTOMER');
+    expect(result[1].role).toBe('STAFF');
+    expect(result[0].roomId).toBe('fb:conv1');
+  });
+});

--- a/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.ts
+++ b/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { ExtractedMessage } from './line-extractor.source';
+
+interface FbMessage {
+  id: string;
+  message?: string;
+  from: { id: string; name?: string };
+  created_time: string;
+}
+interface FbConversation {
+  id: string;
+  participants: { data: { id: string; name?: string }[] };
+  messages: { data: FbMessage[]; paging?: { next?: string } };
+}
+interface FbConversationsPage {
+  data: FbConversation[];
+  paging?: { next?: string };
+}
+
+@Injectable()
+export class FacebookExtractorSource {
+  private readonly logger = new Logger(FacebookExtractorSource.name);
+  private readonly token: string;
+  private readonly pageId: string;
+
+  constructor(config: ConfigService) {
+    this.token = config.get<string>('FACEBOOK_PAGE_ACCESS_TOKEN') ?? '';
+    this.pageId = config.get<string>('FACEBOOK_PAGE_ID') ?? '';
+  }
+
+  async extract(opts: { since: Date }): Promise<ExtractedMessage[]> {
+    if (!this.token || !this.pageId) {
+      this.logger.warn('Facebook extractor skipped — no token/pageId');
+      return [];
+    }
+    const out: ExtractedMessage[] = [];
+    let url: string | null = `https://graph.facebook.com/v19.0/${this.pageId}/conversations?fields=participants,messages{message,from,created_time}&limit=100&access_token=${this.token}`;
+    while (url) {
+      const res: Response = await fetch(url);
+      if (!res.ok) throw new Error(`FB Graph ${res.status}: ${await res.text()}`);
+      const page = (await res.json()) as FbConversationsPage;
+      for (const conv of page.data) {
+        for (const m of conv.messages?.data ?? []) {
+          if (!m.message) continue;
+          const created = new Date(m.created_time);
+          if (created < opts.since) continue;
+          out.push({
+            roomId: `fb:${conv.id}`,
+            channel: 'FACEBOOK',
+            role: m.from.id === this.pageId ? 'STAFF' : 'CUSTOMER',
+            text: m.message,
+            createdAt: created,
+            externalMessageId: m.id,
+          });
+        }
+      }
+      url = page.paging?.next ?? null;
+    }
+    return out;
+  }
+}

--- a/apps/api/src/modules/chat-history-extractor/sources/line-extractor.source.spec.ts
+++ b/apps/api/src/modules/chat-history-extractor/sources/line-extractor.source.spec.ts
@@ -1,0 +1,66 @@
+import { Test } from '@nestjs/testing';
+import { LineExtractorSource } from './line-extractor.source';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+describe('LineExtractorSource', () => {
+  let source: LineExtractorSource;
+  let prisma: { chatMessage: { findMany: jest.Mock } };
+
+  beforeEach(async () => {
+    prisma = { chatMessage: { findMany: jest.fn() } };
+    const mod = await Test.createTestingModule({
+      providers: [LineExtractorSource, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    source = mod.get(LineExtractorSource);
+  });
+
+  it('extracts LINE messages grouped by room, oldest first', async () => {
+    prisma.chatMessage.findMany.mockResolvedValue([
+      { id: 'm1', roomId: 'r1', role: 'CUSTOMER', text: 'สวัสดี', createdAt: new Date('2026-01-01'), externalMessageId: null },
+      { id: 'm2', roomId: 'r1', role: 'STAFF', text: 'สวัสดีครับ', createdAt: new Date('2026-01-01T00:01:00'), externalMessageId: null },
+    ]);
+    const result = await source.extract({ channel: 'LINE_FINANCE', since: new Date('2025-04-22') });
+    expect(result).toHaveLength(2);
+    expect(result[0].roomId).toBe('r1');
+    expect(result[0].text).toBe('สวัสดี');
+    expect(result[0].role).toBe('CUSTOMER');
+    expect(result[1].role).toBe('STAFF');
+  });
+
+  it('maps BOT role to STAFF', async () => {
+    prisma.chatMessage.findMany.mockResolvedValue([
+      { id: 'm1', roomId: 'r1', role: 'BOT', text: 'ตอบอัตโนมัติ', createdAt: new Date('2026-01-01'), externalMessageId: 'ext1' },
+    ]);
+    const result = await source.extract({ channel: 'LINE_FINANCE', since: new Date('2025-04-22') });
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('STAFF');
+    expect(result[0].externalMessageId).toBe('ext1');
+  });
+
+  it('maps non-STAFF/BOT roles to CUSTOMER', async () => {
+    prisma.chatMessage.findMany.mockResolvedValue([
+      { id: 'm1', roomId: 'r1', role: 'SYSTEM', text: 'system msg', createdAt: new Date('2026-01-01'), externalMessageId: null },
+      { id: 'm2', roomId: 'r2', role: 'AUTO_TRIGGER', text: 'reminder', createdAt: new Date('2026-01-01'), externalMessageId: null },
+    ]);
+    const result = await source.extract({ channel: 'LINE_FINANCE', since: new Date('2025-04-22') });
+    expect(result[0].role).toBe('CUSTOMER');
+    expect(result[1].role).toBe('CUSTOMER');
+  });
+
+  it('passes the correct query filters to prisma', async () => {
+    prisma.chatMessage.findMany.mockResolvedValue([]);
+    const since = new Date('2025-04-22');
+    await source.extract({ channel: 'LINE_FINANCE', since });
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          room: { channel: 'LINE_FINANCE' },
+          createdAt: { gte: since },
+          deletedAt: null,
+          text: { not: null },
+        }),
+        orderBy: [{ roomId: 'asc' }, { createdAt: 'asc' }],
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/chat-history-extractor/sources/line-extractor.source.ts
+++ b/apps/api/src/modules/chat-history-extractor/sources/line-extractor.source.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+export interface ExtractedMessage {
+  roomId: string;
+  channel: 'LINE_FINANCE' | 'FACEBOOK';
+  role: 'CUSTOMER' | 'STAFF';
+  text: string;
+  createdAt: Date;
+  externalMessageId?: string;
+}
+
+@Injectable()
+export class LineExtractorSource {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async extract(opts: { channel: 'LINE_FINANCE'; since: Date }): Promise<ExtractedMessage[]> {
+    const rows = await this.prisma.chatMessage.findMany({
+      where: {
+        room: { channel: opts.channel },
+        createdAt: { gte: opts.since },
+        deletedAt: null,
+        text: { not: null },
+      },
+      orderBy: [{ roomId: 'asc' }, { createdAt: 'asc' }],
+      select: {
+        id: true,
+        roomId: true,
+        role: true,
+        text: true,
+        createdAt: true,
+        externalMessageId: true,
+      },
+    });
+
+    return rows
+      .filter((r): r is typeof r & { text: string } => r.text !== null)
+      .map((r) => ({
+        roomId: r.roomId,
+        channel: 'LINE_FINANCE' as const,
+        // MessageRole enum: CUSTOMER, BOT, STAFF, AUTO_TRIGGER, SYSTEM
+        // Treat BOT + STAFF as outgoing (STAFF side); everything else is inbound (CUSTOMER).
+        role: r.role === 'STAFF' || r.role === 'BOT' ? 'STAFF' : 'CUSTOMER',
+        text: r.text,
+        createdAt: r.createdAt,
+        externalMessageId: r.externalMessageId ?? undefined,
+      }));
+  }
+}

--- a/apps/api/src/modules/chat-intent-router/chat-intent-router.module.ts
+++ b/apps/api/src/modules/chat-intent-router/chat-intent-router.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ChatIntentRouterService } from './chat-intent-router.service';
+
+@Module({
+  providers: [ChatIntentRouterService],
+  exports: [ChatIntentRouterService],
+})
+export class ChatIntentRouterModule {}

--- a/apps/api/src/modules/chat-intent-router/chat-intent-router.service.spec.ts
+++ b/apps/api/src/modules/chat-intent-router/chat-intent-router.service.spec.ts
@@ -1,0 +1,57 @@
+import { Test } from '@nestjs/testing';
+import { ChatIntentRouterService } from './chat-intent-router.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import Anthropic from '@anthropic-ai/sdk';
+
+jest.mock('@anthropic-ai/sdk');
+
+describe('ChatIntentRouterService', () => {
+  let svc: ChatIntentRouterService;
+  let prisma: { customer: { findUnique: jest.Mock } };
+
+  beforeEach(async () => {
+    (Anthropic as unknown as jest.Mock).mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: '{"intent":"sales","confidence":0.92}' }],
+        }),
+      },
+    }));
+    prisma = { customer: { findUnique: jest.fn() } };
+    const mod = await Test.createTestingModule({
+      providers: [ChatIntentRouterService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    svc = mod.get(ChatIntentRouterService);
+  });
+
+  it('routes sales intent to sales bot', async () => {
+    const result = await svc.classify({ text: 'iPhone 15 กี่บาท', roomId: 'r1', customerId: null });
+    expect(result.routeTo).toBe('sales');
+    expect(result.confidence).toBeGreaterThan(0.9);
+  });
+
+  it('defaults greeting → service when customer has active contract', async () => {
+    (Anthropic as unknown as jest.Mock).mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: '{"intent":"greeting","confidence":0.85}' }],
+        }),
+      },
+    }));
+    prisma.customer.findUnique.mockResolvedValue({ id: 'c1', contracts: [{ status: 'ACTIVE' }] });
+    const result = await svc.classify({ text: 'สวัสดีครับ', roomId: 'r1', customerId: 'c1' });
+    expect(result.routeTo).toBe('service');
+  });
+
+  it('routes unknown + low confidence to handoff', async () => {
+    (Anthropic as unknown as jest.Mock).mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: '{"intent":"unknown","confidence":0.3}' }],
+        }),
+      },
+    }));
+    const result = await svc.classify({ text: '???', roomId: 'r1', customerId: null });
+    expect(result.routeTo).toBe('handoff');
+  });
+});

--- a/apps/api/src/modules/chat-intent-router/chat-intent-router.service.ts
+++ b/apps/api/src/modules/chat-intent-router/chat-intent-router.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Anthropic from '@anthropic-ai/sdk';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export type Intent = 'sales' | 'service' | 'greeting' | 'complaint' | 'unknown';
+export type RouteTo = 'sales' | 'service' | 'handoff';
+
+export interface IntentResult {
+  intent: Intent;
+  confidence: number;
+  routeTo: RouteTo;
+}
+
+const SYSTEM_PROMPT = `You classify a BESTCHOICE customer chat message into one of:
+- sales: asking about product, price, installment, promotion, trade-in
+- service: asking about existing contract, payment, due date, balance, receipt
+- greeting: hi/hello with no topic yet
+- complaint: angry, threatening, mentions legal action or consumer rights
+- unknown: unclear
+
+Return ONLY JSON: {"intent": "...", "confidence": 0.0-1.0}`;
+
+@Injectable()
+export class ChatIntentRouterService {
+  private readonly logger = new Logger(ChatIntentRouterService.name);
+  private _client: Anthropic | null = null;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  private get client(): Anthropic {
+    if (!this._client) {
+      this._client = new Anthropic();
+    }
+    return this._client;
+  }
+
+  async classify(input: {
+    text: string;
+    roomId: string;
+    customerId: string | null;
+    priorMessages?: { role: 'CUSTOMER' | 'STAFF'; text: string }[];
+  }): Promise<IntentResult> {
+    const userContent = [
+      ...(input.priorMessages ?? []).map((m) => `${m.role}: ${m.text}`),
+      `CUSTOMER: ${input.text}`,
+    ].join('\n');
+
+    const resp = await this.client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 100,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userContent }],
+    });
+    const textBlock = resp.content.find((c) => c.type === 'text');
+    if (!textBlock || textBlock.type !== 'text') {
+      return { intent: 'unknown', confidence: 0, routeTo: 'handoff' };
+    }
+
+    let parsed: { intent: Intent; confidence: number };
+    try {
+      parsed = JSON.parse(textBlock.text);
+    } catch {
+      return { intent: 'unknown', confidence: 0, routeTo: 'handoff' };
+    }
+
+    const routeTo = await this.route(parsed, input.customerId);
+    return { ...parsed, routeTo };
+  }
+
+  private async route(
+    parsed: { intent: Intent; confidence: number },
+    customerId: string | null,
+  ): Promise<RouteTo> {
+    if (parsed.intent === 'complaint') return 'handoff';
+    if (parsed.intent === 'unknown' && parsed.confidence < 0.5) return 'handoff';
+    if (parsed.intent === 'sales') return 'sales';
+    if (parsed.intent === 'service') return 'service';
+    if (parsed.intent === 'greeting') {
+      if (customerId) {
+        const customer = await this.prisma.customer.findUnique({
+          where: { id: customerId },
+          include: {
+            contracts: {
+              where: { status: 'ACTIVE', deletedAt: null },
+              take: 1,
+            },
+          },
+        });
+        if (customer?.contracts?.length) return 'service';
+      }
+      return 'sales';
+    }
+    return 'handoff';
+  }
+}

--- a/docs/superpowers/plans/2026-04-22-chat-ai-week1-hybrid-c.md
+++ b/docs/superpowers/plans/2026-04-22-chat-ai-week1-hybrid-c.md
@@ -260,7 +260,7 @@ export class LineExtractorSource {
       .map((r) => ({
         roomId: r.roomId,
         channel: 'LINE_FINANCE',
-        role: r.role === 'STAFF' || r.role === 'AI' ? 'STAFF' : 'CUSTOMER',
+        role: r.role === 'STAFF' || r.role === 'BOT' ? 'STAFF' : 'CUSTOMER',
         text: r.text,
         createdAt: r.createdAt,
         externalMessageId: r.externalMessageId ?? undefined,
@@ -1557,7 +1557,7 @@ private async loadHistory(roomId: string, maxMessages = 10): Promise<{ role: 'us
     .reverse()
     .filter((r): r is typeof r & { text: string } => r.text !== null)
     .map((r) => ({
-      role: r.role === 'STAFF' || r.role === 'AI' ? ('assistant' as const) : ('user' as const),
+      role: r.role === 'STAFF' || r.role === 'BOT' ? ('assistant' as const) : ('user' as const),
       content: r.text,
     }));
   // Truncate oldest if combined content too large
@@ -1623,7 +1623,7 @@ git commit -m "feat(chatbot-finance): inject full conversation history into Clau
 - Create: `apps/api/src/modules/chat-ai-draft/dto/approve-draft.dto.ts`
 - Modify: `apps/api/src/app.module.ts`
 
-**Context:** On every inbound `ChatMessage` with role=CUSTOMER, orchestrator runs router → bot, then writes a `ChatMessage` row with `role='AI'` and a `status` indicating DRAFT (we piggyback on `deliveredAt`=null + a new metadata flag in `toolsUsed` or use a lightweight approach: mark drafts with intent prefix `"DRAFT:"`. Simpler — add a `status` enum field later; for Week 1 we use `intent` field to flag `'DRAFT:<original-intent>'` and filter on it). Staff approves → we update the same message (strip DRAFT prefix, set deliveredAt, send to LINE/FB).
+**Context:** On every inbound `ChatMessage` with role=CUSTOMER, orchestrator runs router → bot, then writes a `ChatMessage` row with `role='BOT'` and a `status` indicating DRAFT (we piggyback on `deliveredAt`=null + a new metadata flag in `toolsUsed` or use a lightweight approach: mark drafts with intent prefix `"DRAFT:"`. Simpler — add a `status` enum field later; for Week 1 we use `intent` field to flag `'DRAFT:<original-intent>'` and filter on it). Staff approves → we update the same message (strip DRAFT prefix, set deliveredAt, send to LINE/FB).
 
 For Week 1, we keep it simple — the orchestrator does NOT actually send the draft yet. It just creates the draft row. Sending happens in Task 11 (Hybrid C approve-and-send endpoint).
 
@@ -1735,7 +1735,7 @@ export class ChatAiDraftService {
     const draft = await this.prisma.chatMessage.create({
       data: {
         roomId: inbound.roomId,
-        role: 'AI',
+        role: 'BOT',
         type: 'TEXT',
         text: reply,
         intent: `DRAFT:${routed.intent}`,
@@ -1808,7 +1808,7 @@ export class ChatAiDraftService {
       select: { role: true, text: true },
     });
     return rows.reverse().map((r) => ({
-      role: r.role === 'STAFF' || r.role === 'AI' ? ('STAFF' as const) : ('CUSTOMER' as const),
+      role: r.role === 'STAFF' || r.role === 'BOT' ? ('STAFF' as const) : ('CUSTOMER' as const),
       text: r.text ?? '',
     }));
   }
@@ -1946,7 +1946,7 @@ describe('ChatAiDraftService', () => {
     expect(result.draftMessageId).toBe('d1');
     expect(prisma.chatMessage.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ role: 'AI', intent: 'DRAFT:sales' }),
+        data: expect.objectContaining({ role: 'BOT', intent: 'DRAFT:sales' }),
       }),
     );
   });
@@ -2022,7 +2022,7 @@ Same pattern inside Facebook webhook handler after persisting inbound message.
 ./tools/check-types.sh api
 cd apps/api && npm run start:dev
 # In another terminal, simulate a LINE webhook POST or use existing seed script to trigger inbound.
-# Then check DB: SELECT id, intent FROM chat_messages WHERE role = 'AI' ORDER BY created_at DESC LIMIT 5;
+# Then check DB: SELECT id, intent FROM chat_messages WHERE role = 'BOT' ORDER BY created_at DESC LIMIT 5;
 ```
 Expected: new AI draft rows appear with `intent LIKE 'DRAFT:%'`.
 
@@ -2353,7 +2353,7 @@ import { Badge } from '@/components/ui/badge';
 
 export interface Message {
   id: string;
-  role: 'CUSTOMER' | 'STAFF' | 'AI';
+  role: 'CUSTOMER' | 'STAFF' | 'BOT';
   text: string;
   createdAt: string;
   intent?: string | null;
@@ -2374,7 +2374,7 @@ export function MessageBubble({ message }: { message: Message }) {
         )}
       >
         {message.text}
-        {message.role === 'AI' && (
+        {message.role === 'BOT' && (
           <div className="mt-1 flex items-center gap-1 text-[10px] opacity-70">
             <span>AI</span>
             {isDraft && <Badge variant="outline" className="h-4 text-[9px]">Draft</Badge>}
@@ -2526,7 +2526,7 @@ export function useLatestDraft(roomId: string | null) {
       const messages = (await fetchMessages(roomId)) as Message[];
       const latest = [...messages]
         .reverse()
-        .find((m) => m.role === 'AI' && m.intent?.startsWith('DRAFT:'));
+        .find((m) => m.role === 'BOT' && m.intent?.startsWith('DRAFT:'));
       return latest ?? null;
     },
     enabled: !!roomId,


### PR DESCRIPTION
## Problem
The Phase 3 web-shop ships cart, apply, trade-in, saving plan, reviews, and buyback — but it was never plumbed into the deploy workflow. \`bestchoicephone.app\` has been serving **\`apps/web\` (the admin dashboard)**, and \`apps/web-shop\` has no production URL. Customers have no way to reach the shop today.

## Fix
Wire \`apps/web-shop\` to a second Firebase Hosting site (\`bestchoice-shop\`) exposed at **\`shop.bestchoicephone.app\`**, while keeping the admin deploy unchanged.

## Changes
- **firebase.json** — convert \`hosting\` to a 2-target array (\`admin\` + \`shop\`). Shop reuses the same \`/api/**\` rewrite to the \`bestchoice-api\` Cloud Run service, so every customer request is same-origin.
- **.firebaserc** — add target map: \`admin → bestchoice-prod\`, \`shop → bestchoice-shop\`.
- **.github/workflows/deploy-gcp.yml** — \`deploy-web\` job now builds both apps, authenticates to GCP, and runs \`firebase deploy\` once per target. Shop step has \`continue-on-error: true\` so an unconfigured shop site can't break admin deploys during rollout.
- **apps/web-shop/src/lib/api.ts** — drop the hardcoded \`https://bestchoicephone.app\` baseURL (was pointing the shop at the admin domain). Use relative URLs; Vite proxy handles dev, Firebase rewrite handles prod.
- **docs/guides/SHOP-SUBDOMAIN-SETUP.md** — owner runbook: create the hosting site, attach custom domain, DNS, sanity check, rollback.

## Owner one-off setup (after merge)
1. \`firebase hosting:sites:create bestchoice-shop --project bestchoice-prod\`
2. Firebase Console → site \`bestchoice-shop\` → **Add custom domain** → \`shop.bestchoicephone.app\`
3. Add the TXT + A records Firebase shows at the DNS registrar
4. Wait for TLS provisioning (5 min – few hrs)
5. Push anything to main → \`Deploy shop hosting\` step now passes
6. Verify: \`curl -sI https://shop.bestchoicephone.app\` → 200

Full steps in [SHOP-SUBDOMAIN-SETUP.md](docs/guides/SHOP-SUBDOMAIN-SETUP.md).

## Verification
- \`npm run build --workspace=apps/web-shop\` — OK (\~572 KB / 168 KB gzip)
- \`firebase.json\` lint clean (schema validates)
- Admin deploy unchanged — \`hosting:admin\` target points at the same \`bestchoice-prod\` site it always did
- Shop deploy independent — if \`bestchoice-shop\` site isn't ready yet, step fails cleanly and admin still deploys

## Rollback
Revert this PR or flip \`continue-on-error\` + \`if: false\` on the shop step. Admin is isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)