### PR TITLE
fix(web-shop): unwrap API envelope (blank-screen hotfix)

### DIFF
--- a/apps/web-shop/src/lib/api.ts
+++ b/apps/web-shop/src/lib/api.ts
@@ -21,6 +21,22 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// Response interceptor: unwrap API envelope { success, data, timestamp }
+// (matches apps/web/src/lib/api.ts so component code sees the payload
+// directly — otherwise `response.data` is the envelope and components
+// hit "data.map is not a function" on arrays).
+api.interceptors.response.use((response) => {
+  if (
+    response.data &&
+    typeof response.data === 'object' &&
+    'success' in response.data &&
+    'data' in response.data
+  ) {
+    response.data = response.data.data;
+  }
+  return response;
+});
+
 api.interceptors.response.use(
   (res) => res,
   (err) => {


### PR DESCRIPTION
## Bug
\`https://bestchoicephone-shop.web.app\` renders a blank screen. Playwright headless probe captured:

\`\`\`
TypeError: n.data.map is not a function
  at eN (index-Cua6riz2.js:124:5110)  // HomePage render
\`\`\`

## Cause
The API wraps every response in \`{ success, data, timestamp }\`. Admin web has an axios response interceptor that unwraps it ([apps/web/src/lib/api.ts:91-99](apps/web/src/lib/api.ts#L91-L99)), but web-shop never added the same interceptor — in dev the Vite proxy hit localhost API and no one saw the shape mismatch, and web-shop was never deployed to prod before today.

Effect: every web-shop \`useQuery\` received the full envelope into the component, so \`data.map(...)\` / \`data.planNumber\` / \`data.totalAmount\` etc. threw at render time.

## Fix
Port the same unwrap interceptor to web-shop. Single file, 16 lines added.

## Verification
- Reproduced locally with \`chromium.launch\` pointed at the deployed bundle → same stack trace
- After applying the fix + rebuild, the React tree renders the hero + featured-products section (\`#root\` populated)

No schema/route change; no other page touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)