### PR TITLE
fix(auth): cookie path /api/admin/auth — fix login bounce loop

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -34,7 +34,7 @@ function setRefreshCookie(res: Response, token: string) {
     secure: isProduction || !!cookieDomain,
     sameSite: 'lax',
     maxAge: COOKIE_MAX_AGE,
-    path: '/api/auth',
+    path: '/api/admin/auth',
     ...(cookieDomain ? { domain: cookieDomain } : {}),
   });
 }
@@ -42,7 +42,7 @@ function setRefreshCookie(res: Response, token: string) {
 function clearRefreshCookie(res: Response) {
   const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
   res.clearCookie(REFRESH_COOKIE, {
-    path: '/api/auth',
+    path: '/api/admin/auth',
     ...(cookieDomain ? { domain: cookieDomain } : {}),
   });
 }


### PR DESCRIPTION
## Summary
**Hotfix** สำหรับ regression จาก #611 (admin namespace) — refresh cookie path ไม่ตรงกับ URL ที่ frontend เรียก ทำให้ผู้ใช้ทุกคน**เด้งกลับหน้า login ทุก 15 นาที** (ทันทีที่ access token หมดอายุ)

## Root cause
- Frontend (`apps/web/src/lib/env.ts`) ตั้ง `API_URL = '/api/admin'`
- เรียก `POST /api/admin/auth/refresh`
- `AdminPrefixMiddleware` rewrite \`/api/admin/*\` → \`/api/*\` server-side
- แต่ cookie ตั้งด้วย `path: '/api/auth'`
- Browser เห็น URL `/api/admin/auth/refresh` → ไม่ตรง path `/api/auth` → ไม่ส่ง cookie → 401

ยืนยันด้วย Cloud Run logs:
```
2026-04-22T07:09:18 POST /api/admin/auth/refresh 401
2026-04-22T07:09:17 GET  /api/admin/auth/me      401
```

## Fix
เปลี่ยน cookie path ทั้ง `setRefreshCookie` และ `clearRefreshCookie`:
`/api/auth` → `/api/admin/auth`

ตรงกับ URL ที่ browser เห็น ไม่ใช่ URL หลัง middleware rewrite

## Test plan
- [x] `auth.controller.spec.ts` — 3/3 passed
- [ ] หลัง deploy: เปิด `/settings/integrations` ในแท็บใหม่ → ไม่ถูกเด้งกลับ login
- [ ] รอ 15 นาที (access token expiry) → refresh page → ยัง logged in
- [ ] ทดสอบ logout → cookie ถูก clear (Application tab → Cookies → ไม่มี refresh_token)

## Impact
ผู้ใช้ทุกคนเด้งกลับ login ทุก 15 นาทีตั้งแต่ #611 merged — ต้อง merge ด่วน

🤖 Generated with [Claude Code](https://claude.com/claude-code)