### PR TITLE
feat(chat-ai): Week 1 Hybrid C — unified inbox + dual AI bots + drafts

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -75,6 +75,7 @@ import { ChatHistoryExtractorModule } from './modules/chat-history-extractor/cha
 import { ChatIntentRouterModule } from './modules/chat-intent-router/chat-intent-router.module';
 import { SalesBotModule } from './modules/sales-bot/sales-bot.module';
 import { ChatAiDraftModule } from './modules/chat-ai-draft/chat-ai-draft.module';
+import { AiSettingsModule } from './modules/ai-settings/ai-settings.module';
 import { CsatModule } from './modules/csat/csat.module';
 import { AdsTrackingModule } from './modules/ads-tracking/ads-tracking.module';
 import { CrmModule } from './modules/crm/crm.module';
@@ -232,6 +233,8 @@ import { AppCacheModule } from './cache/cache.module';
     SalesBotModule,
     // Chat AI Draft orchestrator — router → bot → draft ChatMessage (Week 1 Hybrid C: staff approval required)
     ChatAiDraftModule,
+    // AI Settings — per-bot mode (OFF/HYBRID/FULL) + confidence thresholds (singleton row)
+    AiSettingsModule,
     // CSAT — customer satisfaction survey after chat resolution
     CsatModule,
     // Ads Attribution — campaign tracking + ROI

--- a/apps/api/src/modules/ai-settings/ai-settings.controller.ts
+++ b/apps/api/src/modules/ai-settings/ai-settings.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { AiSettingsService } from './ai-settings.service';
+
+type UpdateAiSettingsBody = {
+  salesBotMode?: string;
+  serviceBotMode?: string;
+  salesBotConfidenceThreshold?: number;
+  serviceBotConfidenceThreshold?: number;
+};
+
+@Controller('ai-settings')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AiSettingsController {
+  constructor(private readonly svc: AiSettingsService) {}
+
+  @Get()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  get() {
+    return this.svc.get();
+  }
+
+  @Patch()
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  update(@Body() body: UpdateAiSettingsBody, @Req() req: { user: { id: string } }) {
+    return this.svc.update(body, req.user.id);
+  }
+}

--- a/apps/api/src/modules/ai-settings/ai-settings.module.ts
+++ b/apps/api/src/modules/ai-settings/ai-settings.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AiSettingsService } from './ai-settings.service';
+import { AiSettingsController } from './ai-settings.controller';
+
+@Module({
+  controllers: [AiSettingsController],
+  providers: [AiSettingsService],
+  exports: [AiSettingsService],
+})
+export class AiSettingsModule {}

--- a/apps/api/src/modules/ai-settings/ai-settings.service.ts
+++ b/apps/api/src/modules/ai-settings/ai-settings.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+type AiSettingsUpdate = Partial<{
+  salesBotMode: string;
+  serviceBotMode: string;
+  salesBotConfidenceThreshold: number;
+  serviceBotConfidenceThreshold: number;
+}>;
+
+@Injectable()
+export class AiSettingsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async get() {
+    return this.prisma.aiSettings.upsert({
+      where: { id: 'singleton' },
+      create: { id: 'singleton' },
+      update: {},
+    });
+  }
+
+  async update(data: AiSettingsUpdate, userId: string) {
+    // Ensure singleton row exists before update
+    await this.prisma.aiSettings.upsert({
+      where: { id: 'singleton' },
+      create: { id: 'singleton' },
+      update: {},
+    });
+    return this.prisma.aiSettings.update({
+      where: { id: 'singleton' },
+      data: { ...data, updatedById: userId },
+    });
+  }
+}

--- a/apps/api/src/modules/customers/customers.controller.ts
+++ b/apps/api/src/modules/customers/customers.controller.ts
@@ -203,6 +203,15 @@ export class CustomersController {
     return this.customersService.getChatSummary(id);
   }
 
+  @Get(':id/summary')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  @ApiOperation({
+    summary: 'Compact summary for chat inbox sidebar (name, phone, active contracts, outstanding)',
+  })
+  getSummary(@Param('id') id: string) {
+    return this.customersService.getSummary(id);
+  }
+
   @Get(':id/risk-flag')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
   getRiskFlag(@Param('id') id: string) {

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -971,6 +971,56 @@ export class CustomersService {
     };
   }
 
+  /**
+   * Compact summary for chat inbox assistant sidebar.
+   * Returns name, phone, and lightweight counts (active contracts,
+   * overdue installments, total outstanding). Cheaper than
+   * `getChatSummary`, which pulls full payment/call/chat history.
+   */
+  async getSummary(customerId: string) {
+    const customer = await this.prisma.customer.findFirst({
+      where: { id: customerId, deletedAt: null },
+      select: { id: true, name: true, phone: true },
+    });
+    if (!customer) {
+      throw new NotFoundException('ไม่พบข้อมูลลูกค้า');
+    }
+
+    const activeContracts = await this.prisma.contract.count({
+      where: {
+        customerId,
+        deletedAt: null,
+        status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT'] },
+      },
+    });
+
+    const overdueCount = await this.prisma.payment.count({
+      where: {
+        contract: { customerId, deletedAt: null },
+        deletedAt: null,
+        status: 'OVERDUE',
+      },
+    });
+
+    const outstanding = await this.prisma.payment.aggregate({
+      where: {
+        contract: { customerId, deletedAt: null },
+        deletedAt: null,
+        status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+      },
+      _sum: { amountDue: true },
+    });
+
+    return {
+      id: customer.id,
+      name: customer.name,
+      phone: customer.phone ?? null,
+      activeContracts,
+      overdueCount,
+      totalOutstandingThb: Number(outstanding._sum.amountDue ?? 0),
+    };
+  }
+
   private validateNationalId(id: string): boolean {
     if (!/^\d{13}$/.test(id)) return false;
     let sum = 0;

--- a/apps/api/src/modules/staff-chat/staff-chat.controller.ts
+++ b/apps/api/src/modules/staff-chat/staff-chat.controller.ts
@@ -103,6 +103,24 @@ export class StaffChatController {
     return this.roomManager.getRecentMessages(id, limit ? parseInt(limit, 10) : 50);
   }
 
+  @Post('rooms/:id/messages')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  async sendRoomMessage(
+    @Param('id') id: string,
+    @Body() body: { text: string },
+    @Req() req: { user: { id: string } },
+  ) {
+    const text = (body?.text ?? '').trim();
+    if (!text) {
+      return { success: false, error: 'กรุณาพิมพ์ข้อความก่อนส่ง' };
+    }
+    return this.messageRouter.sendStaffMessage({
+      roomId: id,
+      staffId: req.user.id,
+      text,
+    });
+  }
+
   // ─── Unread + Search ────────────────────────────────────
 
   @Get('unread-count')

--- a/apps/web/e2e/chat-inbox.spec.ts
+++ b/apps/web/e2e/chat-inbox.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI } from './helpers/auth';
+
+test.describe('Chat Inbox (/chat)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Use cached API login — avoids rate-limiting the /auth/login endpoint
+    // when running alongside other specs in the same worker.
+    await loginViaAPI(page);
+  });
+
+  test('loads /chat page with header', async ({ page }) => {
+    await page.goto('/chat', { waitUntil: 'domcontentloaded' });
+
+    // Page header renders
+    await expect(page.getByRole('heading', { name: 'รวมแชท' })).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('renders room filter tabs', async ({ page }) => {
+    await page.goto('/chat', { waitUntil: 'domcontentloaded' });
+
+    // Filter tabs (Radix TabsTrigger has role="tab")
+    await expect(page.getByRole('tab', { name: 'ทั้งหมด' })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByRole('tab', { name: 'LINE' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Facebook' })).toBeVisible();
+  });
+
+  test('shows empty conversation panel when no room selected', async ({ page }) => {
+    await page.goto('/chat', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByText('เลือกห้องจากด้านซ้ายเพื่อดูการสนทนา'),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  // Happy-path AI draft approval flow.
+  //
+  // Intentionally skipped for Week 1 smoke suite — seeding an inbound chat
+  // message + an AI-generated draft deterministically requires:
+  //   1. A chat room with a customer + channel config (LINE/FB)
+  //   2. A fresh inbound ChatMessage from the customer
+  //   3. The AI draft worker to process the inbound and produce an AiDraft
+  //
+  // That seed infra is planned for Week 2 (shadow-mode smoke seed). This
+  // skipped test pins the expected shape so we can re-enable it by simply
+  // removing `.skip` once seeding is in place.
+  test.skip('staff approves AI draft (requires seed infra — re-enable Week 2)', async ({
+    page,
+  }) => {
+    await page.goto('/chat', { waitUntil: 'domcontentloaded' });
+
+    // Pick the first room in the list
+    await page.locator('[data-testid="room-list-item"]').first().click({ timeout: 10000 });
+
+    // AI draft card should surface on the right sidebar
+    const draftCard = page.getByText('AI แนะนำคำตอบ');
+    await draftCard.waitFor({ state: 'visible', timeout: 30000 });
+
+    // Approve & send
+    await page.getByRole('button', { name: /ส่ง/ }).click();
+
+    // Toast confirms send
+    await expect(page.locator('[data-sonner-toast]').first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -82,6 +82,7 @@ const AssetManagementPage = lazy(() => import('@/pages/AssetManagementPage'));
 const ChartOfAccountsPage = lazy(() => import('@/pages/ChartOfAccountsPage'));
 const TodosPage = lazy(() => import('@/pages/TodosPage'));
 const UnifiedInboxPage = lazy(() => import('@/pages/UnifiedInboxPage'));
+const ChatInboxPage = lazy(() => import('@/pages/chat/ChatInboxPage'));
 const CrmPipelinePage = lazy(() => import('@/pages/CrmPipelinePage'));
 const AdsTrackingPage = lazy(() => import('@/pages/AdsTrackingPage'));
 const ChannelSettingsPage = lazy(() => import('@/pages/ChannelSettingsPage'));
@@ -323,6 +324,7 @@ function App() {
           <Route path="/sales" element={<SalesHistoryPage />} />
           <Route path="/todos" element={<TodosPage />} />
           <Route path="/inbox" element={<ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}><UnifiedInboxPage /></ProtectedRoute>} />
+          <Route path="/chat" element={<ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}><ChatInboxPage /></ProtectedRoute>} />
           <Route path="/crm" element={<ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}><CrmPipelinePage /></ProtectedRoute>} />
           <Route path="/ads" element={<ProtectedRoute roles={['OWNER']}><AdsTrackingPage /></ProtectedRoute>} />
           <Route path="/settings/channels" element={<ProtectedRoute roles={['OWNER']}><ChannelSettingsPage /></ProtectedRoute>} />

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -42,7 +42,7 @@ function MobileSidebar() {
 
 /* ── Main Content Area ────────────────────────────── */
 /* ── Full-bleed routes (no TopBar, no container padding) ── */
-const FULL_BLEED_ROUTES = ['/inbox'];
+const FULL_BLEED_ROUTES = ['/inbox', '/chat'];
 
 function MainContent() {
   const isMobile = useIsMobile();

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -106,6 +106,7 @@ const SALES_CONFIG: RoleMenuConfig = {
         { label: 'สต็อกสินค้า', path: '/stock', icon: Warehouse },
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
         { label: 'CRM Pipeline', path: '/crm', icon: Kanban },
+        { label: 'รวมแชท', path: '/chat', icon: MessageSquareMore },
         { label: 'งานของทีม', path: '/todos', icon: CheckSquare },
       ],
     },
@@ -163,6 +164,7 @@ const BRANCH_MANAGER_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'ค้างชำระ', path: '/overdue', icon: AlertTriangle },
         { label: 'CRM Pipeline', path: '/crm', icon: Kanban },
+        { label: 'รวมแชท', path: '/chat', icon: MessageSquareMore },
         { label: 'รายงาน', path: '/reports', icon: BarChart3 },
       ],
     },
@@ -219,6 +221,7 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
         { label: 'ติดตามหนี้', path: '/overdue', icon: AlertTriangle },
         { label: 'เปลี่ยนเครื่องเสีย (7 วัน)', path: '/defect-exchange', icon: Wrench },
         { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
+        { label: 'รวมแชท', path: '/chat', icon: MessageSquareMore },
       ],
     },
     {
@@ -399,6 +402,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'AI Admin', path: '/settings/ai-admin', icon: Sparkles },
         { label: 'AI Assistant', path: '/settings/ai-chat', icon: Sparkles },
+        { label: 'รวมแชท', path: '/chat', icon: MessageSquareMore },
         { label: 'การเชื่อมต่อ', path: '/settings/integrations', icon: Plug },
         { label: 'LINE OA', path: '/settings/rich-menu', icon: MessageSquareMore },
         { label: 'Dunning', path: '/settings/dunning', icon: Bell },

--- a/apps/web/src/pages/AiSettingsPage.tsx
+++ b/apps/web/src/pages/AiSettingsPage.tsx
@@ -9,7 +9,15 @@ import { Switch } from '@/components/ui/switch';
 import { Slider } from '@/components/ui/slider';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Sparkles } from 'lucide-react';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { Sparkles, Bot } from 'lucide-react';
 
 const CHANNELS = [
   { value: 'LINE_FINANCE', label: 'LINE Finance' },
@@ -170,6 +178,98 @@ function AiSettingsForm({ initial }: { initial: AiSettings }) {
   );
 }
 
+interface PerBotSettings {
+  salesBotMode: string;
+  serviceBotMode: string;
+  salesBotConfidenceThreshold: number;
+  serviceBotConfidenceThreshold: number;
+}
+
+function PerBotModeCard() {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<PerBotSettings>({
+    queryKey: ['ai-settings-per-bot'],
+    queryFn: () =>
+      api.get('/ai-settings').then((r: any) => {
+        const d = r.data?.data ?? r.data;
+        return {
+          salesBotMode: d.salesBotMode ?? 'HYBRID',
+          serviceBotMode: d.serviceBotMode ?? 'HYBRID',
+          salesBotConfidenceThreshold: d.salesBotConfidenceThreshold ?? 0.7,
+          serviceBotConfidenceThreshold: d.serviceBotConfidenceThreshold ?? 0.75,
+        };
+      }),
+  });
+
+  const update = useMutation({
+    mutationFn: (body: Partial<PerBotSettings>) => api.patch('/ai-settings', body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ai-settings-per-bot'] });
+      toast.success('บันทึกการตั้งค่าแล้ว');
+    },
+    onError: () => toast.error('บันทึกไม่สำเร็จ'),
+  });
+
+  const settings = query.data;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2 leading-snug">
+          <Bot className="w-4 h-4 text-muted-foreground" />
+          โหมด AI ต่อบอท (Week 1 Hybrid C)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {settings ? (
+          <>
+            <div className="flex items-center justify-between gap-2">
+              <Label className="leading-snug">บอทขาย (Sales Bot)</Label>
+              <Select
+                value={settings.salesBotMode}
+                onValueChange={(v) => update.mutate({ salesBotMode: v })}
+                disabled={update.isPending}
+              >
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="OFF">OFF (ปิด)</SelectItem>
+                  <SelectItem value="HYBRID">HYBRID (แนะนำ)</SelectItem>
+                  <SelectItem value="FULL">FULL (Week 2)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <Label className="leading-snug">น้องเบส (Service Bot)</Label>
+              <Select
+                value={settings.serviceBotMode}
+                onValueChange={(v) => update.mutate({ serviceBotMode: v })}
+                disabled={update.isPending}
+              >
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="OFF">OFF (ปิด)</SelectItem>
+                  <SelectItem value="HYBRID">HYBRID (แนะนำ)</SelectItem>
+                  <SelectItem value="FULL">FULL (Week 2)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <p className="text-xs text-muted-foreground leading-snug">
+              HYBRID: AI สร้าง draft ให้พนักงานตรวจก่อนส่ง · FULL: AI ส่งเองทันที (Week 2) · OFF: ไม่สร้าง draft
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground leading-snug">กำลังโหลดการตั้งค่า...</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function AiSettingsPage() {
   const settingsQuery = useQuery<AiSettings>({
     queryKey: ['ai-settings'],
@@ -194,7 +294,8 @@ export default function AiSettingsPage() {
   return (
     <div>
       <PageHeader title="AI Settings" subtitle="ตั้งค่า AI Auto Mode สำหรับตอบแชทอัตโนมัติ" />
-      <div className="max-w-2xl">
+      <div className="max-w-2xl space-y-6">
+        <PerBotModeCard />
         <QueryBoundary
           isLoading={settingsQuery.isLoading}
           isError={settingsQuery.isError}

--- a/apps/web/src/pages/chat/ChatInboxPage.tsx
+++ b/apps/web/src/pages/chat/ChatInboxPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { RoomList } from './components/RoomList';
+import { AssistantSidebar } from './components/AssistantSidebar';
 import { ConversationPanel } from './components/ConversationPanel';
+import { RoomList } from './components/RoomList';
 
 export default function ChatInboxPage() {
   const [activeRoomId, setActiveRoomId] = useState<string | null>(null);
@@ -16,7 +17,7 @@ export default function ChatInboxPage() {
       <div className="grid flex-1 grid-cols-[320px_1fr_360px] overflow-hidden">
         <RoomList activeRoomId={activeRoomId} onSelect={setActiveRoomId} />
         <ConversationPanel roomId={activeRoomId} />
-        <aside className="border-l border-border bg-card p-4" aria-label="แผงรายละเอียด" />
+        <AssistantSidebar roomId={activeRoomId} />
       </div>
     </div>
   );

--- a/apps/web/src/pages/chat/ChatInboxPage.tsx
+++ b/apps/web/src/pages/chat/ChatInboxPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RoomList } from './components/RoomList';
+import { ConversationPanel } from './components/ConversationPanel';
 
 export default function ChatInboxPage() {
   const [activeRoomId, setActiveRoomId] = useState<string | null>(null);
@@ -14,11 +15,7 @@ export default function ChatInboxPage() {
       </header>
       <div className="grid flex-1 grid-cols-[320px_1fr_360px] overflow-hidden">
         <RoomList activeRoomId={activeRoomId} onSelect={setActiveRoomId} />
-        <div className="flex items-center justify-center bg-background p-4">
-          <p className="text-sm leading-snug text-muted-foreground">
-            เลือกห้องจากด้านซ้ายเพื่อดูการสนทนา
-          </p>
-        </div>
+        <ConversationPanel roomId={activeRoomId} />
         <aside className="border-l border-border bg-card p-4" aria-label="แผงรายละเอียด" />
       </div>
     </div>

--- a/apps/web/src/pages/chat/ChatInboxPage.tsx
+++ b/apps/web/src/pages/chat/ChatInboxPage.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { RoomList } from './components/RoomList';
+
+export default function ChatInboxPage() {
+  const [activeRoomId, setActiveRoomId] = useState<string | null>(null);
+
+  return (
+    <div className="flex h-[calc(100vh-4rem)] flex-col bg-background">
+      <header className="border-b border-border bg-background px-4 py-3">
+        <h1 className="text-xl font-semibold leading-snug text-foreground">รวมแชท</h1>
+        <p className="text-sm leading-snug text-muted-foreground">
+          ดูทุกห้องจาก LINE + Facebook ที่เดียว — AI ช่วยแนะนำคำตอบ
+        </p>
+      </header>
+      <div className="grid flex-1 grid-cols-[320px_1fr_360px] overflow-hidden">
+        <RoomList activeRoomId={activeRoomId} onSelect={setActiveRoomId} />
+        <div className="flex items-center justify-center bg-background p-4">
+          <p className="text-sm leading-snug text-muted-foreground">
+            เลือกห้องจากด้านซ้ายเพื่อดูการสนทนา
+          </p>
+        </div>
+        <aside className="border-l border-border bg-card p-4" aria-label="แผงรายละเอียด" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/components/AiDraftCard.tsx
+++ b/apps/web/src/pages/chat/components/AiDraftCard.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { Check, Pencil, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import type { Message } from './MessageBubble';
+import { useApproveDraft, useSkipDraft } from '../hooks/useAiDraft';
+
+/**
+ * AiDraftCard — surfaces a pending AI draft reply with Approve / Edit / Skip.
+ *
+ * Approve: sends the (possibly edited) text as the room's next staff reply
+ * and marks the draft as delivered.
+ * Edit: toggles an inline textarea; approve then uses the edited copy.
+ * Skip: discards the draft — AI will generate a new one on the next inbound.
+ */
+export function AiDraftCard({ draft, roomId }: { draft: Message; roomId: string }) {
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(draft.text ?? '');
+  const approve = useApproveDraft();
+  const skip = useSkipDraft();
+
+  // Reset local edit state when the underlying draft changes.
+  useEffect(() => {
+    setText(draft.text ?? '');
+    setEditing(false);
+  }, [draft.id, draft.text]);
+
+  const handleApprove = () => {
+    const edited = editing ? text.trim() : undefined;
+    if (editing && !edited) {
+      toast.error('ข้อความว่างเปล่า');
+      return;
+    }
+    approve.mutate(
+      { draftMessageId: draft.id, editedText: edited, roomId },
+      {
+        onSuccess: () => {
+          toast.success('ส่งให้ลูกค้าแล้ว');
+          setEditing(false);
+        },
+        onError: () => toast.error('ส่งไม่สำเร็จ'),
+      },
+    );
+  };
+
+  const handleSkip = () => {
+    skip.mutate(
+      { draftMessageId: draft.id, roomId },
+      {
+        onSuccess: () => toast.success('ข้ามร่างนี้แล้ว'),
+        onError: () => toast.error('ข้ามไม่สำเร็จ'),
+      },
+    );
+  };
+
+  const intentLabel = draft.intent?.startsWith('DRAFT:')
+    ? draft.intent.slice('DRAFT:'.length)
+    : draft.intent;
+
+  return (
+    <Card className="border-l-4 border-l-emerald-500">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm leading-snug">
+          <span>AI แนะนำคำตอบ</span>
+          {intentLabel && (
+            <Badge variant="outline" className="text-[10px] leading-snug">
+              {intentLabel}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {editing ? (
+          <Textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            className="min-h-[90px] text-sm leading-snug"
+            aria-label="แก้ไขข้อความก่อนส่ง"
+          />
+        ) : (
+          <div className="whitespace-pre-wrap break-words text-sm leading-snug text-foreground">
+            {draft.text ?? ''}
+          </div>
+        )}
+        <div className="text-xs leading-snug text-muted-foreground">
+          {draft.toolsUsed && draft.toolsUsed.length > 0
+            ? `Tools: ${draft.toolsUsed.join(', ')}`
+            : 'ไม่ได้เรียก tool'}
+          {typeof draft.confidence === 'number' && (
+            <span> · ความมั่นใจ {(draft.confidence * 100).toFixed(0)}%</span>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2 pt-1">
+          <Button
+            size="sm"
+            onClick={handleApprove}
+            disabled={approve.isPending || skip.isPending}
+          >
+            <Check className="mr-1 h-3 w-3" />
+            ส่ง
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setEditing((prev) => !prev)}
+            disabled={approve.isPending || skip.isPending}
+          >
+            <Pencil className="mr-1 h-3 w-3" />
+            {editing ? 'ยกเลิกแก้' : 'แก้ก่อนส่ง'}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleSkip}
+            disabled={approve.isPending || skip.isPending}
+          >
+            <X className="mr-1 h-3 w-3" />
+            ข้าม
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/chat/components/AssistantSidebar.tsx
+++ b/apps/web/src/pages/chat/components/AssistantSidebar.tsx
@@ -1,0 +1,94 @@
+import { useQuery } from '@tanstack/react-query';
+import { Hand } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { AiDraftCard } from './AiDraftCard';
+import { CustomerCard } from './CustomerCard';
+import { useLatestDraft, useTakeOver } from '../hooks/useAiDraft';
+import { fetchRoom } from '../lib/chat-api';
+
+/**
+ * AssistantSidebar — right column of the /chat inbox page.
+ *
+ * Composes three blocks:
+ *   1. CustomerCard — if the room is linked to a customer.
+ *   2. AiDraftCard  — if there's a pending AI draft (polled every 5s).
+ *   3. Take-Over button — pauses AI for the room (sets `aiPaused=true`).
+ *
+ * Week 1 intentionally omits the "Suggested actions" block (Week 2 scope).
+ */
+export function AssistantSidebar({ roomId }: { roomId: string | null }) {
+  const { data: draft } = useLatestDraft(roomId);
+  const takeOver = useTakeOver();
+
+  const { data: room } = useQuery({
+    queryKey: ['chat-room', roomId],
+    queryFn: () => (roomId ? fetchRoom(roomId) : Promise.resolve(null)),
+    enabled: !!roomId,
+    refetchInterval: 5000,
+  });
+
+  if (!roomId) {
+    return (
+      <aside
+        className="flex h-full flex-col items-center justify-center border-l border-border bg-card p-4 text-sm leading-snug text-muted-foreground"
+        aria-label="แผงรายละเอียด"
+      >
+        เลือกห้องเพื่อดูรายละเอียด
+      </aside>
+    );
+  }
+
+  const handleTakeOver = () => {
+    takeOver.mutate(roomId, {
+      onSuccess: () => toast.success('ถือห้องแล้ว AI จะหยุดตอบ'),
+      onError: () => toast.error('ถือห้องไม่สำเร็จ'),
+    });
+  };
+
+  return (
+    <aside
+      className="flex h-full flex-col gap-3 overflow-y-auto border-l border-border bg-card p-3"
+      aria-label="แผงรายละเอียด"
+    >
+      {room?.customerId ? (
+        <CustomerCard customerId={room.customerId} />
+      ) : (
+        <Card>
+          <CardContent className="p-3">
+            <div className="text-xs leading-snug text-muted-foreground">
+              ยังไม่ได้จับคู่กับลูกค้าในระบบ
+            </div>
+            {room?.displayName && (
+              <div className="mt-1 text-sm leading-snug text-foreground">{room.displayName}</div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {draft ? (
+        <AiDraftCard draft={draft} roomId={roomId} />
+      ) : (
+        <Card>
+          <CardContent className="p-3">
+            <div className="text-xs leading-snug text-muted-foreground">
+              ไม่มีข้อความร่างจาก AI ในขณะนี้
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleTakeOver}
+        disabled={takeOver.isPending || room?.aiPaused === true}
+        className="mt-auto"
+      >
+        <Hand className="mr-1 h-3 w-3" />
+        {room?.aiPaused ? 'กำลังถือห้องอยู่' : 'ถือห้อง (หยุด AI)'}
+      </Button>
+    </aside>
+  );
+}

--- a/apps/web/src/pages/chat/components/ComposeBox.tsx
+++ b/apps/web/src/pages/chat/components/ComposeBox.tsx
@@ -1,0 +1,75 @@
+import { useState, type KeyboardEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Send } from 'lucide-react';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { sendStaffMessage } from '../lib/chat-api';
+import { useInvalidateRoomMessages } from '../hooks/useRoomMessages';
+
+/**
+ * ComposeBox — lets the staff type and send a message to the customer.
+ *
+ * POSTs to `/staff-chat/rooms/:id/messages`, which routes through
+ * `MessageRouterService.sendStaffMessage` (saves ChatMessage + pushes via
+ * the channel adapter). Enter submits, Shift+Enter inserts a newline.
+ */
+export function ComposeBox({ roomId }: { roomId: string }) {
+  const [text, setText] = useState('');
+  const invalidate = useInvalidateRoomMessages();
+
+  const mutation = useMutation({
+    mutationFn: (body: { roomId: string; text: string }) =>
+      sendStaffMessage(body.roomId, body.text),
+    onSuccess: (res: any) => {
+      // Backend returns { success, error? } so surface delivery failures even
+      // when the HTTP call itself succeeded (e.g. LINE push quota exhausted).
+      const payload = res?.data ?? res;
+      if (payload && payload.success === false) {
+        toast.error(payload.error ?? 'ส่งข้อความไม่สำเร็จ');
+        return;
+      }
+      setText('');
+      invalidate(roomId);
+      toast.success('ส่งข้อความแล้ว');
+    },
+    onError: (e: any) => {
+      toast.error(e?.response?.data?.message ?? 'ส่งข้อความไม่สำเร็จ');
+    },
+  });
+
+  const handleSend = () => {
+    const trimmed = text.trim();
+    if (!trimmed || mutation.isPending) return;
+    mutation.mutate({ roomId, text: trimmed });
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="border-t border-border bg-card p-3">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="พิมพ์ข้อความส่งเป็นพนักงาน... (Enter ส่ง, Shift+Enter ขึ้นบรรทัดใหม่)"
+        className="min-h-[64px] resize-none leading-snug"
+        aria-label="พิมพ์ข้อความตอบลูกค้า"
+      />
+      <div className="mt-2 flex items-center justify-between">
+        <span className="text-xs leading-snug text-muted-foreground">
+          ข้อความจะส่งในชื่อคุณ ไม่ใช่ AI
+        </span>
+        <Button onClick={handleSend} disabled={!text.trim() || mutation.isPending} size="sm">
+          <Send className="mr-2 h-4 w-4" aria-hidden="true" />
+          ส่ง
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/components/ConversationPanel.tsx
+++ b/apps/web/src/pages/chat/components/ConversationPanel.tsx
@@ -1,0 +1,47 @@
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { MessageBubble, type Message } from './MessageBubble';
+import { ComposeBox } from './ComposeBox';
+import { useRoomMessages } from '../hooks/useRoomMessages';
+
+/**
+ * ConversationPanel — the center column of the inbox.
+ *
+ * Renders the message stream for the selected room and a compose box so
+ * staff can send replies as themselves (bypassing the AI draft flow).
+ */
+export function ConversationPanel({ roomId }: { roomId: string | null }) {
+  const { data, isLoading, isError } = useRoomMessages(roomId);
+  const messages = (data ?? []) as Message[];
+
+  if (!roomId) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background p-4">
+        <p className="text-sm leading-snug text-muted-foreground">
+          เลือกห้องจากด้านซ้ายเพื่อดูการสนทนา
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-background">
+      <ScrollArea className="flex-1">
+        <div className="flex flex-col gap-2 p-4">
+          {isLoading && (
+            <div className="text-sm leading-snug text-muted-foreground">กำลังโหลด...</div>
+          )}
+          {isError && !isLoading && (
+            <div className="text-sm leading-snug text-destructive">โหลดข้อความไม่สำเร็จ</div>
+          )}
+          {!isLoading && !isError && messages.length === 0 && (
+            <div className="text-sm leading-snug text-muted-foreground">ยังไม่มีข้อความในห้องนี้</div>
+          )}
+          {messages.map((m) => (
+            <MessageBubble key={m.id} message={m} />
+          ))}
+        </div>
+      </ScrollArea>
+      <ComposeBox roomId={roomId} />
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/components/CustomerCard.tsx
+++ b/apps/web/src/pages/chat/components/CustomerCard.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { fetchCustomerSummary } from '../lib/chat-api';
+
+/**
+ * CustomerCard — compact customer info for the chat assistant sidebar.
+ * Fetches `/customers/:id/summary` (cheap projection: name, phone,
+ * active-contract count, overdue count, total outstanding).
+ * Staff click the name to deep-link into the full customer detail page.
+ */
+export function CustomerCard({ customerId }: { customerId: string }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['customer-summary', customerId],
+    queryFn: () => fetchCustomerSummary(customerId),
+    enabled: !!customerId,
+  });
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-3">
+          <div className="text-xs leading-snug text-muted-foreground">กำลังโหลด...</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm leading-snug">
+          <Link
+            to={`/customers/${data.id}`}
+            className="text-primary hover:underline"
+          >
+            {data.name}
+          </Link>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 text-xs leading-snug text-muted-foreground">
+        <div>โทร: {data.phone ?? '-'}</div>
+        <div className="flex flex-wrap gap-1">
+          <Badge variant="secondary">{data.activeContracts} สัญญา</Badge>
+          {data.overdueCount > 0 && (
+            <Badge variant="destructive">ค้าง {data.overdueCount} งวด</Badge>
+          )}
+        </div>
+        <div>
+          คงค้าง:{' '}
+          <span className="font-medium text-foreground">
+            {data.totalOutstandingThb.toLocaleString('th-TH', {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 2,
+            })}
+          </span>{' '}
+          บาท
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/chat/components/MessageBubble.tsx
+++ b/apps/web/src/pages/chat/components/MessageBubble.tsx
@@ -1,0 +1,67 @@
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+
+export interface Message {
+  id: string;
+  role: 'CUSTOMER' | 'STAFF' | 'BOT' | 'AUTO_TRIGGER' | 'SYSTEM';
+  text: string | null;
+  createdAt: string;
+  intent?: string | null;
+  confidence?: number | null;
+  toolsUsed?: string[];
+  deliveredAt?: string | null;
+}
+
+/**
+ * MessageBubble — one row in the conversation panel.
+ *
+ * - CUSTOMER messages render on the left with a muted background.
+ * - STAFF/BOT/SYSTEM messages render on the right.
+ * - BOT messages flagged as AI drafts (intent starts with `DRAFT:` and not yet
+ *   delivered) are visually distinguished with an emerald left border so
+ *   reviewers can quickly spot pending-approval replies.
+ */
+export function MessageBubble({ message }: { message: Message }) {
+  const isCustomer = message.role === 'CUSTOMER';
+  const isSystem = message.role === 'SYSTEM' || message.role === 'AUTO_TRIGGER';
+  const isDraft = !!message.intent?.startsWith('DRAFT:') && !message.deliveredAt;
+
+  if (isSystem) {
+    return (
+      <div className="flex justify-center">
+        <span className="rounded-full bg-muted px-3 py-1 text-xs leading-snug text-muted-foreground">
+          {message.text ?? ''}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('flex', isCustomer ? 'justify-start' : 'justify-end')}>
+      <div
+        className={cn(
+          'max-w-[75%] rounded-lg px-3 py-2 text-sm leading-snug whitespace-pre-wrap break-words',
+          isCustomer
+            ? 'bg-muted text-foreground'
+            : 'bg-primary text-primary-foreground',
+          isDraft && 'border-l-4 border-emerald-500 bg-card text-foreground',
+        )}
+      >
+        <div>{message.text ?? ''}</div>
+        {message.role === 'BOT' && (
+          <div className="mt-1 flex items-center gap-1 text-[10px] leading-snug opacity-70">
+            <span>AI</span>
+            {isDraft && (
+              <Badge variant="outline" className="h-4 px-1 text-[9px]">
+                Draft
+              </Badge>
+            )}
+            {typeof message.confidence === 'number' && (
+              <span>· {(message.confidence * 100).toFixed(0)}%</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/components/RoomFilters.tsx
+++ b/apps/web/src/pages/chat/components/RoomFilters.tsx
@@ -1,0 +1,54 @@
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Search } from 'lucide-react';
+import type { ChannelFilter, RoomFilter } from '../lib/chat-api';
+
+export function RoomFilters({
+  filter,
+  onFilterChange,
+  channel,
+  onChannelChange,
+  search,
+  onSearchChange,
+}: {
+  filter: RoomFilter;
+  onFilterChange: (f: RoomFilter) => void;
+  channel: ChannelFilter;
+  onChannelChange: (c: ChannelFilter) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2 border-b border-border p-2">
+      <div className="relative">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden
+        />
+        <Input
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="ค้นหาชื่อ/เบอร์โทร"
+          className="pl-9 leading-snug"
+          aria-label="ค้นหาห้องแชท"
+        />
+      </div>
+      <Tabs value={filter} onValueChange={(v) => onFilterChange(v as RoomFilter)}>
+        <TabsList className="w-full">
+          <TabsTrigger value="all" className="flex-1 leading-snug">ทั้งหมด</TabsTrigger>
+          <TabsTrigger value="sales" className="flex-1 leading-snug">ขาย</TabsTrigger>
+          <TabsTrigger value="service" className="flex-1 leading-snug">บริการ</TabsTrigger>
+          <TabsTrigger value="handoff" className="flex-1 leading-snug">Handoff</TabsTrigger>
+          <TabsTrigger value="sla_breach" className="flex-1 leading-snug">SLA</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      <Tabs value={channel} onValueChange={(v) => onChannelChange(v as ChannelFilter)}>
+        <TabsList className="w-full">
+          <TabsTrigger value="all" className="flex-1 leading-snug">ทุกช่องทาง</TabsTrigger>
+          <TabsTrigger value="LINE_FINANCE" className="flex-1 leading-snug">LINE</TabsTrigger>
+          <TabsTrigger value="FACEBOOK" className="flex-1 leading-snug">Facebook</TabsTrigger>
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/components/RoomList.tsx
+++ b/apps/web/src/pages/chat/components/RoomList.tsx
@@ -1,0 +1,55 @@
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useDebounce } from '@/hooks/useDebounce';
+import { useState } from 'react';
+import { useRooms } from '../hooks/useRooms';
+import type { ChannelFilter, RoomFilter } from '../lib/chat-api';
+import { RoomFilters } from './RoomFilters';
+import { RoomListItem } from './RoomListItem';
+
+export function RoomList({
+  activeRoomId,
+  onSelect,
+}: {
+  activeRoomId: string | null;
+  onSelect: (roomId: string) => void;
+}) {
+  const [filter, setFilter] = useState<RoomFilter>('all');
+  const [channel, setChannel] = useState<ChannelFilter>('all');
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 300);
+  const { data = [], isLoading, isError } = useRooms(filter, channel, debouncedSearch || undefined);
+
+  return (
+    <div className="flex h-full flex-col border-r border-border bg-card">
+      <RoomFilters
+        filter={filter}
+        onFilterChange={setFilter}
+        channel={channel}
+        onChannelChange={setChannel}
+        search={search}
+        onSearchChange={setSearch}
+      />
+      <ScrollArea className="flex-1">
+        {isLoading && (
+          <div className="p-4 text-sm leading-snug text-muted-foreground">กำลังโหลด...</div>
+        )}
+        {isError && !isLoading && (
+          <div className="p-4 text-sm leading-snug text-destructive">โหลดห้องแชทไม่สำเร็จ</div>
+        )}
+        {!isLoading && !isError && data.length === 0 && (
+          <div className="p-4 text-sm leading-snug text-muted-foreground">ไม่มีห้องแชท</div>
+        )}
+        <div className="flex flex-col gap-1 p-1">
+          {data.map((room) => (
+            <RoomListItem
+              key={room.id}
+              room={room}
+              active={room.id === activeRoomId}
+              onClick={() => onSelect(room.id)}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/components/RoomListItem.tsx
+++ b/apps/web/src/pages/chat/components/RoomListItem.tsx
@@ -1,0 +1,54 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { MessageCircle, MessageSquare } from 'lucide-react';
+import { computeSlaBreach } from '../hooks/useRooms';
+import type { ChatRoomSummary } from '../lib/chat-api';
+
+export function RoomListItem({
+  room,
+  active,
+  onClick,
+}: {
+  room: ChatRoomSummary;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const ChannelIcon = room.channel === 'FACEBOOK' ? MessageCircle : MessageSquare;
+  const name = room.customer?.name ?? room.displayName ?? 'ไม่ระบุชื่อ';
+  const initial = name.trim().charAt(0) || '?';
+  const lastMessage = room.messages?.[0]?.text ?? null;
+  const slaBreach = computeSlaBreach(room);
+
+  return (
+    <button
+      type="button"
+      data-testid="room-list-item"
+      onClick={onClick}
+      className={cn(
+        'flex w-full gap-3 rounded-md p-3 text-left transition-colors hover:bg-accent',
+        active && 'bg-accent',
+      )}
+    >
+      <Avatar className="h-10 w-10 shrink-0">
+        {room.pictureUrl && <AvatarImage src={room.pictureUrl} alt={name} />}
+        <AvatarFallback>{initial}</AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate font-medium leading-snug text-foreground">{name}</span>
+          <ChannelIcon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        </div>
+        <div className="truncate text-xs leading-snug text-muted-foreground">
+          {lastMessage ?? '...'}
+        </div>
+        <div className="mt-1 flex flex-wrap gap-1">
+          {room.unreadCount > 0 && <Badge variant="primary">{room.unreadCount}</Badge>}
+          {room.handoffMode && <Badge variant="destructive">Handoff</Badge>}
+          {room.aiPaused && <Badge variant="secondary">รับช่วง</Badge>}
+          {slaBreach && <Badge variant="destructive">SLA</Badge>}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/pages/chat/hooks/useAiDraft.ts
+++ b/apps/web/src/pages/chat/hooks/useAiDraft.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { approveDraft, fetchMessages, skipDraft, takeOver } from '../lib/chat-api';
+import type { Message } from '../components/MessageBubble';
+
+/**
+ * useLatestDraft — polls the room messages every 5s and returns the most
+ * recent BOT message flagged as a pending draft. Used by the assistant
+ * sidebar to surface AI-suggested replies awaiting staff approval.
+ *
+ * A draft = role BOT + intent starts with `DRAFT:` + not yet delivered.
+ */
+export function useLatestDraft(roomId: string | null) {
+  return useQuery<Message | null>({
+    queryKey: ['chat-latest-draft', roomId],
+    queryFn: async () => {
+      if (!roomId) return null;
+      const messages = (await fetchMessages(roomId)) as Message[];
+      // Scan newest → oldest and pick the first undelivered BOT draft.
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const m = messages[i];
+        if (
+          m.role === 'BOT' &&
+          m.intent &&
+          m.intent.startsWith('DRAFT:') &&
+          !m.deliveredAt
+        ) {
+          return m;
+        }
+      }
+      return null;
+    },
+    enabled: !!roomId,
+    refetchInterval: 5000,
+  });
+}
+
+export function useApproveDraft() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { draftMessageId: string; editedText?: string; roomId: string }) =>
+      approveDraft(args.draftMessageId, args.editedText),
+    onSuccess: (_data, args) => {
+      qc.invalidateQueries({ queryKey: ['chat-messages', args.roomId] });
+      qc.invalidateQueries({ queryKey: ['chat-latest-draft', args.roomId] });
+      qc.invalidateQueries({ queryKey: ['chat-rooms'] });
+    },
+  });
+}
+
+export function useSkipDraft() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { draftMessageId: string; roomId: string }) =>
+      skipDraft(args.draftMessageId),
+    onSuccess: (_data, args) => {
+      qc.invalidateQueries({ queryKey: ['chat-messages', args.roomId] });
+      qc.invalidateQueries({ queryKey: ['chat-latest-draft', args.roomId] });
+    },
+  });
+}
+
+export function useTakeOver() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (roomId: string) => takeOver(roomId),
+    onSuccess: (_data, roomId) => {
+      qc.invalidateQueries({ queryKey: ['chat-rooms'] });
+      qc.invalidateQueries({ queryKey: ['chat-room', roomId] });
+      qc.invalidateQueries({ queryKey: ['chat-latest-draft', roomId] });
+    },
+  });
+}

--- a/apps/web/src/pages/chat/hooks/useRoomMessages.ts
+++ b/apps/web/src/pages/chat/hooks/useRoomMessages.ts
@@ -1,0 +1,23 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchMessages } from '../lib/chat-api';
+
+/**
+ * useRoomMessages — fetch messages for a specific chat room.
+ *
+ * Auto-refetches every 5s so AI drafts + inbound customer messages surface
+ * promptly without needing the Socket.IO gateway wired up yet. When the
+ * gateway ships (later task) this interval can be relaxed.
+ */
+export function useRoomMessages(roomId: string | null) {
+  return useQuery({
+    queryKey: ['chat-messages', roomId],
+    queryFn: () => (roomId ? fetchMessages(roomId) : Promise.resolve([])),
+    enabled: !!roomId,
+    refetchInterval: 5000,
+  });
+}
+
+export function useInvalidateRoomMessages() {
+  const qc = useQueryClient();
+  return (roomId: string) => qc.invalidateQueries({ queryKey: ['chat-messages', roomId] });
+}

--- a/apps/web/src/pages/chat/hooks/useRooms.ts
+++ b/apps/web/src/pages/chat/hooks/useRooms.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchRooms, type ChannelFilter, type ChatRoomSummary, type RoomFilter } from '../lib/chat-api';
+
+/**
+ * SLA breach threshold: 5 minutes of no staff response to an active handoff.
+ * Temporary client-side check — Task 11 doesn't add a server-side field yet.
+ */
+const SLA_BREACH_MS = 5 * 60 * 1000;
+
+function computeSlaBreach(room: ChatRoomSummary): boolean {
+  if (!room.handoffMode) return false;
+  if (room.firstResponseAt) return false;
+  const lastAt = new Date(room.lastMessageAt).getTime();
+  return Number.isFinite(lastAt) && Date.now() - lastAt > SLA_BREACH_MS;
+}
+
+function applyClientFilter(rooms: ChatRoomSummary[], filter: RoomFilter): ChatRoomSummary[] {
+  switch (filter) {
+    case 'handoff':
+      return rooms.filter((r) => r.handoffMode);
+    case 'sla_breach':
+      return rooms.filter(computeSlaBreach);
+    case 'sales':
+    case 'service':
+      // Intent routing (sales vs service) lands in a later task — fall through for now.
+      return rooms;
+    case 'all':
+    default:
+      return rooms;
+  }
+}
+
+export function useRooms(filter: RoomFilter, channel: ChannelFilter, q?: string) {
+  return useQuery({
+    queryKey: ['chat-rooms', filter, channel, q ?? ''],
+    queryFn: () => fetchRooms({ filter, channel, q }),
+    refetchInterval: 10_000,
+    select: (response) => applyClientFilter(response.data, filter),
+  });
+}
+
+export { computeSlaBreach };

--- a/apps/web/src/pages/chat/lib/chat-api.ts
+++ b/apps/web/src/pages/chat/lib/chat-api.ts
@@ -1,0 +1,79 @@
+import api from '@/lib/api';
+
+export type ChatChannelValue = 'LINE_FINANCE' | 'LINE_SHOP' | 'FACEBOOK' | 'TIKTOK' | 'WEB';
+
+/**
+ * ChatRoomSummary — projection of ChatRoom used in the unified inbox list.
+ * Matches the include shape returned by `GET /staff-chat/rooms`
+ * (`RoomManagerService.listRooms`). Most fields come from the ChatRoom row
+ * directly; `customer`, `assignedTo`, `messages` are nested via Prisma include.
+ */
+export interface ChatRoomSummary {
+  id: string;
+  customerId: string | null;
+  lineUserId: string | null;
+  externalUserId: string | null;
+  displayName: string | null;
+  pictureUrl: string | null;
+  channel: ChatChannelValue;
+  status: 'ACTIVE' | 'IDLE';
+  priority: 'LOW' | 'NORMAL' | 'HIGH' | 'CRITICAL';
+  handoffMode: boolean;
+  handoffReason: string | null;
+  aiPaused: boolean;
+  firstResponseAt: string | null;
+  unreadCount: number;
+  lastMessageAt: string;
+  customer: { id: string; name: string | null; phone: string | null } | null;
+  assignedTo: { id: string; name: string | null; avatarUrl: string | null } | null;
+  messages: Array<{ text: string | null; role: string; createdAt: string }>;
+}
+
+export interface ChatRoomListResponse {
+  data: ChatRoomSummary[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export type RoomFilter = 'all' | 'sales' | 'service' | 'handoff' | 'sla_breach';
+export type ChannelFilter = 'all' | 'LINE_FINANCE' | 'FACEBOOK';
+
+/**
+ * Fetch rooms for the unified inbox.
+ * The `filter` prop is client-side only for now — Task 11 keeps server params
+ * minimal (channel + search). SLA/handoff filtering is applied client-side
+ * in `useRooms` until a server-side index is added.
+ */
+export async function fetchRooms(params: {
+  filter: RoomFilter;
+  channel: ChannelFilter;
+  q?: string;
+}): Promise<ChatRoomListResponse> {
+  const query: Record<string, string> = {};
+  if (params.channel !== 'all') query.channel = params.channel;
+  if (params.q) query.search = params.q;
+  const res = await api.get<ChatRoomListResponse>('/staff-chat/rooms', { params: query });
+  return res.data;
+}
+
+export async function fetchMessages(roomId: string) {
+  const res = await api.get(`/staff-chat/rooms/${roomId}/messages`);
+  return res.data;
+}
+
+export async function approveDraft(draftMessageId: string, editedText?: string) {
+  return api.post('/chat-ai/approve', { draftMessageId, editedText });
+}
+
+export async function skipDraft(draftMessageId: string) {
+  return api.post(`/chat-ai/skip/${draftMessageId}`);
+}
+
+export async function takeOver(roomId: string) {
+  return api.post(`/chat-ai/take-over/${roomId}`);
+}
+
+export async function sendStaffMessage(roomId: string, text: string) {
+  return api.post(`/staff-chat/rooms/${roomId}/messages`, { text });
+}

--- a/apps/web/src/pages/chat/lib/chat-api.ts
+++ b/apps/web/src/pages/chat/lib/chat-api.ts
@@ -77,3 +77,41 @@ export async function takeOver(roomId: string) {
 export async function sendStaffMessage(roomId: string, text: string) {
   return api.post(`/staff-chat/rooms/${roomId}/messages`, { text });
 }
+
+/**
+ * ChatRoomDetail — shape returned by `GET /staff-chat/rooms/:id`
+ * (`RoomManagerService.findById`). Includes full room flags
+ * (`aiPaused`, `handoffMode`, `customerId`) needed by the assistant
+ * sidebar's Take-Over button + customer card.
+ */
+export interface ChatRoomDetail {
+  id: string;
+  customerId: string | null;
+  channel: ChatChannelValue;
+  status: 'ACTIVE' | 'IDLE';
+  aiPaused: boolean;
+  handoffMode: boolean;
+  handoffReason: string | null;
+  displayName: string | null;
+  pictureUrl: string | null;
+  customer: { id: string; name: string | null; phone: string | null } | null;
+}
+
+export async function fetchRoom(roomId: string): Promise<ChatRoomDetail> {
+  const res = await api.get<ChatRoomDetail>(`/staff-chat/rooms/${roomId}`);
+  return res.data;
+}
+
+export interface CustomerSummary {
+  id: string;
+  name: string;
+  phone: string | null;
+  activeContracts: number;
+  overdueCount: number;
+  totalOutstandingThb: number;
+}
+
+export async function fetchCustomerSummary(customerId: string): Promise<CustomerSummary> {
+  const res = await api.get<CustomerSummary>(`/customers/${customerId}/summary`);
+  return res.data;
+}


### PR DESCRIPTION
## Summary

Ships Week 1 Hybrid C of the Chat + AI initiative ([design spec](docs/superpowers/specs/2026-04-22-chat-ai-unified-inbox-design.md), [implementation plan](docs/superpowers/plans/2026-04-22-chat-ai-week1-hybrid-c.md)) — staff now get a `/chat` unified inbox with AI assistant that drafts replies for every inbound LINE/Facebook customer message, with human approve/edit/skip/take-over.

**Week 2 (next plan)**: RAG + Full A autonomous mode + guardrails + rollout.

## What's new

**Backend (16 new files + 6 modified):**
- `chat-history-extractor/` — pull 12mo LINE (from existing `ChatMessage`) + Facebook Graph API → PII scrub → `AiTrainingPair` → Claude Haiku batch → seed `ChatKnowledgeBase`
- `chat-intent-router/` — Claude Haiku classifier: sales / service / greeting / complaint / unknown → routeTo decision
- `sales-bot/` — Claude **Sonnet 4.6** tool-use loop + 4 tools: `search_products`, `calculate_installment`, `list_promotions`, `handoff_to_human`
- `chat-ai-draft/` — orchestrator (router → bot → draft `ChatMessage` with `intent='DRAFT:*'`) + approve/skip/take-over endpoints
- `chatbot-finance/finance-ai.service` upgrade — Haiku → Sonnet 4.6 + full conversation-history window (last 10 msgs, 20k char budget)
- Webhook wiring — inbound `ChatMessage` (CUSTOMER role) triggers `generateDraft()` fire-and-forget on LINE + Facebook + all MessageRouter adapters
- `ai-settings/` — `/ai-settings` GET + PATCH for per-bot mode (`OFF | HYBRID | FULL`) + confidence thresholds
- `/customers/:id/summary` thin endpoint (name, phone, active contracts, overdue count, outstanding)
- `POST /staff-chat/rooms/:id/messages` — staff compose endpoint (delegates to existing `MessageRouterService.sendStaffMessage`)

**Frontend (`/chat` page):**
- 3-column layout: room list + conversation + AI assistant sidebar
- Room list with filter tabs (ทั้งหมด / ขาย / บริการ / Handoff / SLA) + channel tabs (LINE / Facebook)
- Conversation panel with MessageBubble (AI drafts get emerald-border + Draft badge) + ComposeBox
- AI Assistant sidebar: CustomerCard + AiDraftCard (Send / แก้ก่อนส่ง / ข้าม) + Take-Over button
- `AiSettingsPage` — per-bot mode dropdown (OFF/HYBRID/FULL)
- E2E smoke spec (`chat-inbox.spec.ts`) — 3 active, 1 skipped (draft approval — needs seed infra for Week 2)

**Schema:**
- `ChatRoom.aiPaused` + `aiPausedAt` + `aiPausedById` + `aiPausedBy` (for take-over)
- `AiSettings` singleton table (sales/service bot mode + confidence thresholds)

## Model policy

- `claude-sonnet-4-6` → customer-facing (Sales Bot + น้องเบส reply)
- `claude-haiku-4-5-20251001` → internal only (Intent Router, Knowledge Extractor batch)

## Test status

- **API**: 115 tests pass across 17 suites (chat-history-extractor + chat-intent-router + sales-bot + chat-ai-draft + chatbot-finance + staff-chat)
- **TypeScript**: API OK + Web OK (0 errors)
- **E2E**: 3 active smoke tests + 1 skipped (draft approval flow — requires seed infra deferred to Week 2)

## Test plan (manual, post-merge)

- [ ] Staff opens `/chat` → sees room list from LINE Finance OA
- [ ] Staff selects a room → conversation panel loads messages
- [ ] Customer sends LINE message → AI draft appears in sidebar within 30s
- [ ] Staff clicks "ส่ง" → message delivered via LINE push; draft marked `deliveredAt`
- [ ] Staff clicks "แก้ก่อนส่ง" → edits textarea → approve → edited text delivered
- [ ] Staff clicks "ข้าม" → draft soft-deleted, no send
- [ ] Staff clicks "ถือห้อง" → `room.aiPaused=true`, next inbound does NOT generate new draft
- [ ] Owner toggles `/ai-settings` salesBotMode=OFF → next inbound SALES message doesn't generate draft
- [ ] OWNER hits `POST /api/chat-history/extract` → `AiTrainingPair` populated from 12mo
- [ ] OWNER hits `POST /api/chat-history/extract-knowledge` → `ChatKnowledgeBase` seeded with `active=false` entries
- [ ] Verify intent router routes Thai messages correctly (iPhone 15 question → sales, "ยอดคงเหลือ" → service)

## Pre-deploy requirements

1. Set prod env vars: `FACEBOOK_PAGE_ACCESS_TOKEN`, `FACEBOOK_PAGE_ID`
2. Confirm `ANTHROPIC_API_KEY` is live (used by existing chatbot-finance)
3. Run migration via pipeline (`20260601000000_chat_ai_hybrid_c`) — purely additive, no drops

## Known issues / deferred

- **`Product.costPrice` as customer-facing price** — pre-existing codebase pattern (shop-catalog does the same). Sales bot inherits this bug. Fix proposed for Week 2: switch to `ProductPrice` (default) or `PricingTemplate.cashPrice`.
- **AI draft cost**: Sonnet reply costs ~3x Haiku. Monitor `AiAutoReplyLog.costUsd` after rollout; consider bumping to Haiku for service bot if volume spikes.
- **RAG retrieval** — Week 2 scope. Current bot has no memory of past successful replies across rooms.
- **Guardrails 2-7** (no-go list, hallucination guard, rate limit, shadow-mode A/B) — Week 2 scope.
- **E2E draft approval happy path** — test skipped until seed infra lands in Week 2.

## Commits

Squash merge candidate. 12 atomic commits listed below + 1 merge from main (PRs #637-#640 absorbed):

- T1: `ChatRoom.aiPaused` + `AiSettings` singleton table
- T2-T5: Chat history extractor (LINE + FB + PII + orchestrator + Claude knowledge seeder)
- T6: Intent Router
- T7: Sales Bot module + 4 tools
- T8: น้องเบส Sonnet upgrade + full conversation history
- T9: Draft orchestrator + approve/skip/take-over endpoints
- T10: Webhook wiring (LINE + FB + all adapters)
- T11-T13: `/chat` unified inbox UI (rooms + conversation + assistant sidebar)
- T14: `AiSettings` per-bot mode toggle
- T15: E2E smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)