### PR TITLE
feat(chat-extractor): read FB credentials from Integration Hub

### DIFF
--- a/apps/api/src/modules/chat-history-extractor/chat-history-extractor.module.ts
+++ b/apps/api/src/modules/chat-history-extractor/chat-history-extractor.module.ts
@@ -4,8 +4,10 @@ import { ChatHistoryExtractorController } from './chat-history-extractor.control
 import { LineExtractorSource } from './sources/line-extractor.source';
 import { FacebookExtractorSource } from './sources/facebook-extractor.source';
 import { KnowledgeExtractorService } from './knowledge-extractor.service';
+import { IntegrationsModule } from '../integrations/integrations.module';
 
 @Module({
+  imports: [IntegrationsModule],
   controllers: [ChatHistoryExtractorController],
   providers: [
     ChatHistoryExtractorService,

--- a/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.spec.ts
+++ b/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.spec.ts
@@ -1,22 +1,20 @@
 import { Test } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
 import { FacebookExtractorSource } from './facebook-extractor.source';
+import { IntegrationConfigService } from '../../integrations/integration-config.service';
 
 describe('FacebookExtractorSource', () => {
   let source: FacebookExtractorSource;
   let fetchMock: jest.SpyInstance;
+  let integrationConfig: { getConfig: jest.Mock };
 
   beforeEach(async () => {
+    integrationConfig = {
+      getConfig: jest.fn().mockResolvedValue({ pageAccessToken: 'tok', pageId: 'page123' }),
+    };
     const mod = await Test.createTestingModule({
       providers: [
         FacebookExtractorSource,
-        {
-          provide: ConfigService,
-          useValue: {
-            get: (k: string) =>
-              ({ FACEBOOK_PAGE_ACCESS_TOKEN: 'tok', FACEBOOK_PAGE_ID: 'page123' }[k]),
-          },
-        },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
       ],
     }).compile();
     source = mod.get(FacebookExtractorSource);
@@ -25,7 +23,7 @@ describe('FacebookExtractorSource', () => {
 
   afterEach(() => fetchMock.mockRestore());
 
-  it('extracts messages from paginated conversations', async () => {
+  it('extracts messages from paginated conversations using Integration Hub credentials', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -45,9 +43,17 @@ describe('FacebookExtractorSource', () => {
       }),
     } as any);
     const result = await source.extract({ since: new Date('2025-04-22') });
+    expect(integrationConfig.getConfig).toHaveBeenCalledWith('facebook');
     expect(result).toHaveLength(2);
     expect(result[0].role).toBe('CUSTOMER');
     expect(result[1].role).toBe('STAFF');
     expect(result[0].roomId).toBe('fb:conv1');
+  });
+
+  it('skips gracefully when credentials are missing in Integration Hub', async () => {
+    integrationConfig.getConfig.mockResolvedValue({});
+    const result = await source.extract({ since: new Date('2025-04-22') });
+    expect(result).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.ts
+++ b/apps/api/src/modules/chat-history-extractor/sources/facebook-extractor.source.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { IntegrationConfigService } from '../../integrations/integration-config.service';
 import type { ExtractedMessage } from './line-extractor.source';
 
 interface FbMessage {
@@ -18,24 +18,34 @@ interface FbConversationsPage {
   paging?: { next?: string };
 }
 
+/**
+ * FacebookExtractorSource — pulls conversations from a FB Page via Graph API.
+ *
+ * Credentials read from Integration Hub ("facebook" integration):
+ * - pageAccessToken (long-lived Page Access Token)
+ * - pageId
+ *
+ * Managed at /integrations in the admin UI — no redeploy needed to rotate.
+ * Env var fallback is handled by IntegrationConfigService for dev/testing.
+ */
 @Injectable()
 export class FacebookExtractorSource {
   private readonly logger = new Logger(FacebookExtractorSource.name);
-  private readonly token: string;
-  private readonly pageId: string;
 
-  constructor(config: ConfigService) {
-    this.token = config.get<string>('FACEBOOK_PAGE_ACCESS_TOKEN') ?? '';
-    this.pageId = config.get<string>('FACEBOOK_PAGE_ID') ?? '';
-  }
+  constructor(private readonly integrationConfig: IntegrationConfigService) {}
 
   async extract(opts: { since: Date }): Promise<ExtractedMessage[]> {
-    if (!this.token || !this.pageId) {
-      this.logger.warn('Facebook extractor skipped — no token/pageId');
+    const cfg = await this.integrationConfig.getConfig('facebook');
+    const token = cfg.pageAccessToken || '';
+    const pageId = cfg.pageId || '';
+
+    if (!token || !pageId) {
+      this.logger.warn('Facebook extractor skipped — no pageAccessToken/pageId in Integration Hub');
       return [];
     }
+
     const out: ExtractedMessage[] = [];
-    let url: string | null = `https://graph.facebook.com/v19.0/${this.pageId}/conversations?fields=participants,messages{message,from,created_time}&limit=100&access_token=${this.token}`;
+    let url: string | null = `https://graph.facebook.com/v19.0/${pageId}/conversations?fields=participants,messages{message,from,created_time}&limit=100&access_token=${token}`;
     while (url) {
       const res: Response = await fetch(url);
       if (!res.ok) throw new Error(`FB Graph ${res.status}: ${await res.text()}`);
@@ -48,7 +58,7 @@ export class FacebookExtractorSource {
           out.push({
             roomId: `fb:${conv.id}`,
             channel: 'FACEBOOK',
-            role: m.from.id === this.pageId ? 'STAFF' : 'CUSTOMER',
+            role: m.from.id === pageId ? 'STAFF' : 'CUSTOMER',
             text: m.message,
             createdAt: created,
             externalMessageId: m.id,


### PR DESCRIPTION
## Summary

Switches `FacebookExtractorSource` from env vars to Integration Hub — same pattern as `facebook-app-review` (PR #639). Owner can now rotate FB Page tokens at `/integrations` without redeploying.

## Before / after

**Before** (merged in PR #643):
- `ConfigService.get('FACEBOOK_PAGE_ACCESS_TOKEN')` — required env var set in Cloud Run secrets
- Rotating token = redeploy

**After** (this PR):
- `IntegrationConfigService.getConfig('facebook')` → reads `pageAccessToken` + `pageId` from `IntegrationConfig` DB table (env var fallback preserved)
- Rotating token = update Integration Hub UI, cache invalidates automatically

## Changes

- `FacebookExtractorSource` constructor now injects `IntegrationConfigService` instead of `ConfigService`
- Async `getConfig('facebook')` in `extract()` before the API call
- Spec updated: mocks `IntegrationConfigService.getConfig` + added "skips when creds missing" test
- `ChatHistoryExtractorModule` imports `IntegrationsModule`

## Test plan

- [ ] Owner fills `pageAccessToken` + `pageId` in `/integrations` → facebook integration
- [ ] `POST /api/chat-history/extract` pulls conversations successfully
- [ ] Clear the fields in UI → extractor logs warn + returns 0 (no crash)

## Tests

- `facebook-extractor.source.spec.ts`: 2 tests (paginated extraction + graceful skip on missing creds) — both pass
- TS: API OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)