### PR TITLE
fix(ocr): bank-statement รับ PDF + หลายไฟล์

### DIFF
--- a/apps/api/src/modules/ocr/dto/ocr.dto.ts
+++ b/apps/api/src/modules/ocr/dto/ocr.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsArray, ArrayMinSize, ArrayMaxSize } from 'class-validator';
 
 export class OcrIdCardDto {
   @IsString()
@@ -36,10 +36,12 @@ export class OcrSalarySlipDto {
 }
 
 export class OcrBankStatementDto {
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(5_000_000)
-  imageBase64: string; // base64 data URL of the bank statement image
+  @IsArray({ message: 'ต้องส่งไฟล์เป็น array' })
+  @ArrayMinSize(1, { message: 'ต้องมีไฟล์อย่างน้อย 1 ไฟล์' })
+  @ArrayMaxSize(10, { message: 'อัปโหลดได้สูงสุด 10 ไฟล์' })
+  @IsString({ each: true })
+  @MaxLength(15_000_000, { each: true, message: 'ไฟล์ใหญ่เกินไป (เกิน 10MB)' })
+  filesBase64: string[]; // base64 data URLs of bank statement images or PDFs
 }
 
 export class OcrGenerateTemplateDto {

--- a/apps/api/src/modules/ocr/ocr.controller.ts
+++ b/apps/api/src/modules/ocr/ocr.controller.ts
@@ -60,6 +60,6 @@ export class OcrController {
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
   @Throttle({ short: { limit: 5, ttl: 60000 } })
   analyzeBankStatement(@Body() dto: OcrBankStatementDto) {
-    return this.ocrService.analyzeBankStatement(dto.imageBase64);
+    return this.ocrService.analyzeBankStatement(dto.filesBase64);
   }
 }

--- a/apps/api/src/modules/ocr/ocr.service.ts
+++ b/apps/api/src/modules/ocr/ocr.service.ts
@@ -308,6 +308,80 @@ export class OcrService {
     return bestResult;
   }
 
+  private async callClaudeOcrMultiFile(
+    files: Array<{ mediaType: string; base64Data: string; isDocument: boolean }>,
+    prompt: string,
+  ): Promise<Record<string, unknown>> {
+    const client = await this.ensureAnthropicReady();
+
+    const fileBlocks = files.map((f) =>
+      f.isDocument
+        ? {
+            type: 'document' as const,
+            source: {
+              type: 'base64' as const,
+              media_type: 'application/pdf' as const,
+              data: f.base64Data,
+            },
+          }
+        : {
+            type: 'image' as const,
+            source: {
+              type: 'base64' as const,
+              media_type: f.mediaType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+              data: f.base64Data,
+            },
+          },
+    );
+
+    const response = await client.messages.create({
+      model: OcrService.OCR_MODEL,
+      max_tokens: 2048,
+      temperature: 0,
+      system: OcrService.OCR_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: [...fileBlocks, { type: 'text', text: prompt }],
+        },
+      ],
+    });
+
+    const textContent = response.content.find((c) => c.type === 'text');
+    if (!textContent || textContent.type !== 'text') {
+      throw new InternalServerErrorException('No text response from Claude');
+    }
+
+    return this.parseJsonResponse(textContent.text) as Record<string, unknown>;
+  }
+
+  private async callClaudeOcrMultiFileWithRetry(
+    files: Array<{ mediaType: string; base64Data: string; isDocument: boolean }>,
+    prompt: string,
+    retryPrompt: string,
+  ): Promise<Record<string, unknown>> {
+    let bestResult = await this.callClaudeOcrMultiFile(files, prompt);
+    const confidence = Number(bestResult.confidence) || 0;
+
+    if (confidence < OcrService.LOW_CONFIDENCE_THRESHOLD) {
+      this.logger.warn(`Low confidence (${confidence.toFixed(2)}), retrying with enhanced prompt`);
+      for (let attempt = 0; attempt < OcrService.MAX_RETRIES; attempt++) {
+        try {
+          const retryResult = await this.callClaudeOcrMultiFile(files, retryPrompt);
+          const retryConfidence = Number(retryResult.confidence) || 0;
+          if (retryConfidence > confidence) {
+            bestResult = retryResult;
+            break;
+          }
+        } catch {
+          this.logger.warn(`Retry attempt ${attempt + 1} failed`);
+        }
+      }
+    }
+
+    return bestResult;
+  }
+
   // ─── 0. Generate Template HTML from File ───────────────
 
   private static readonly TEMPLATE_GENERATION_PROMPT = `คุณเป็นผู้เชี่ยวชาญด้านการสร้างเทมเพลต HTML สำหรับสัญญาผ่อนชำระสินค้า (ร้านขายมือถือในประเทศไทย)
@@ -862,14 +936,18 @@ ${basePrompt}`;
     'ดูรูปอีกครั้งอย่างละเอียด โดยเฉพาะยอดเงินเข้า เงินออก ยอดคงเหลือ และช่วงวันที่\n' +
     'ตอบเป็น JSON: { accountName, bankName, totalIncome, totalExpense, balance, transactionCount, dateRange, confidence }';
 
-  async analyzeBankStatement(imageBase64: string): Promise<OcrBankStatementResult> {
+  async analyzeBankStatement(filesBase64: string[]): Promise<OcrBankStatementResult> {
     await this.ensureAnthropicReady();
-    const { mediaType, base64Data } = this.validateImageBase64(imageBase64);
+
+    if (!Array.isArray(filesBase64) || filesBase64.length === 0) {
+      throw new BadRequestException('กรุณาส่งไฟล์อย่างน้อย 1 ไฟล์');
+    }
+
+    const validatedFiles = filesBase64.map((b64) => this.validateFileBase64(b64));
 
     try {
-      const result = await this.callClaudeOcrWithRetry(
-        mediaType,
-        base64Data,
+      const result = await this.callClaudeOcrMultiFileWithRetry(
+        validatedFiles,
         OcrService.BANK_STATEMENT_PROMPT,
         OcrService.BANK_STATEMENT_RETRY_PROMPT,
       );

--- a/apps/web/e2e/customer-intake-pdf-upload.spec.ts
+++ b/apps/web/e2e/customer-intake-pdf-upload.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect, Route } from '@playwright/test';
+import { loginViaAPI } from './helpers/auth';
+import { gotoWithRetry } from './helpers/navigation';
+
+// Smallest valid PDF (~250 bytes) — "%PDF-1.1" + empty catalog
+const MINIMAL_PDF_BYTES = Buffer.from(
+  `%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 200]>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000052 00000 n
+0000000099 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+148
+%%EOF`,
+  'utf-8',
+);
+
+// 1x1 transparent PNG
+const TINY_PNG_BYTES = Buffer.from(
+  '89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D49444154789C626000000000050001A5F645400000000049454E44AE426082',
+  'hex',
+);
+
+test.describe('Customer Intake — PDF/image upload fix verification', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('uploading PDF triggers OCR with filesBase64 array (not imageBase64)', async ({ page }) => {
+    let capturedRequestBody: Record<string, unknown> | null = null;
+
+    // Intercept OCR endpoint — capture request body and return fake success
+    await page.route('**/ocr/bank-statement', async (route: Route) => {
+      const postData = route.request().postDataJSON();
+      capturedRequestBody = postData;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          accountName: 'Test User',
+          bankName: 'กสิกรไทย',
+          totalIncome: 50000,
+          totalExpense: 30000,
+          balance: 20000,
+          transactionCount: 50,
+          dateRange: '01/01/2026 - 31/03/2026',
+          confidence: 0.95,
+        }),
+      });
+    });
+
+    const ok = await gotoWithRetry(page, '/customer-intake');
+    if (!ok) test.skip();
+
+    // Step 1: fill quick intake form
+    await page.getByText(/ข้อมูลเบื้องต้น/).first().waitFor({ timeout: 15000 });
+    const inputs = page.locator('input');
+    // Based on QuickIntakeStep.tsx field order: firstName, lastName, nationalId, phone
+    await inputs.nth(0).fill('ทดสอบ');
+    await inputs.nth(1).fill('ทดสอบสกุล');
+    await inputs.nth(2).fill('1234567890123');
+    await inputs.nth(3).fill('0812345678');
+
+    await page.getByRole('button', { name: /ถัดไป.*เช็คเครดิต/ }).click();
+
+    // Step 2: upload a PDF file
+    await page.getByText(/Statement ธนาคาร/).waitFor({ timeout: 10000 });
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'statement.pdf',
+      mimeType: 'application/pdf',
+      buffer: MINIMAL_PDF_BYTES,
+    });
+
+    // Wait for OCR request to complete
+    await page.waitForResponse('**/ocr/bank-statement', { timeout: 10000 });
+
+    // VERIFY 1: Request body shape — must be filesBase64 array
+    expect(capturedRequestBody).not.toBeNull();
+    expect(capturedRequestBody).toHaveProperty('filesBase64');
+    expect(capturedRequestBody).not.toHaveProperty('imageBase64');
+    const body = capturedRequestBody as { filesBase64: string[] };
+    expect(Array.isArray(body.filesBase64)).toBe(true);
+    expect(body.filesBase64.length).toBe(1);
+
+    // VERIFY 2: PDF data URL prefix (not image — proves PDF is sent as-is)
+    expect(body.filesBase64[0]).toMatch(/^data:application\/pdf;base64,/);
+
+    // VERIFY 3: UI shows bankName from OCR result
+    const bankInput = page.getByPlaceholder(/จะแสดง|กำลังอ่าน|อ่านไม่ได้/);
+    await expect(bankInput).toHaveValue('กสิกรไทย', { timeout: 5000 });
+
+    // VERIFY 4: submit button is enabled
+    const submitBtn = page.getByRole('button', { name: /เริ่มเช็คเครดิต/ });
+    await expect(submitBtn).toBeEnabled();
+  });
+
+  test('uploading image triggers OCR with filesBase64 array (compressed JPEG)', async ({ page }) => {
+    let capturedRequestBody: Record<string, unknown> | null = null;
+
+    await page.route('**/ocr/bank-statement', async (route: Route) => {
+      capturedRequestBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          accountName: null,
+          bankName: 'ไทยพาณิชย์',
+          totalIncome: null,
+          totalExpense: null,
+          balance: null,
+          transactionCount: null,
+          dateRange: null,
+          confidence: 0.85,
+        }),
+      });
+    });
+
+    const ok = await gotoWithRetry(page, '/customer-intake');
+    if (!ok) test.skip();
+
+    await page.getByText(/ข้อมูลเบื้องต้น/).first().waitFor({ timeout: 15000 });
+    const inputs = page.locator('input');
+    await inputs.nth(0).fill('ทดสอบ');
+    await inputs.nth(1).fill('ทดสอบสกุล');
+    await inputs.nth(2).fill('1234567890123');
+    await inputs.nth(3).fill('0812345678');
+    await page.getByRole('button', { name: /ถัดไป.*เช็คเครดิต/ }).click();
+
+    await page.getByText(/Statement ธนาคาร/).waitFor({ timeout: 10000 });
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'statement.png',
+      mimeType: 'image/png',
+      buffer: TINY_PNG_BYTES,
+    });
+
+    await page.waitForResponse('**/ocr/bank-statement', { timeout: 10000 });
+
+    expect(capturedRequestBody).toHaveProperty('filesBase64');
+    const body = capturedRequestBody as { filesBase64: string[] };
+    expect(Array.isArray(body.filesBase64)).toBe(true);
+    // Image goes through compressImageForOcr → output is JPEG
+    expect(body.filesBase64[0]).toMatch(/^data:image\/(jpeg|png);base64,/);
+
+    const bankInput = page.getByPlaceholder(/จะแสดง|กำลังอ่าน|อ่านไม่ได้/);
+    await expect(bankInput).toHaveValue('ไทยพาณิชย์', { timeout: 5000 });
+  });
+
+  test('when OCR returns no bankName, input is editable so user can type', async ({ page }) => {
+    await page.route('**/ocr/bank-statement', async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          accountName: null,
+          bankName: null, // OCR failed to detect bank
+          totalIncome: null,
+          totalExpense: null,
+          balance: null,
+          transactionCount: null,
+          dateRange: null,
+          confidence: 0.3,
+        }),
+      });
+    });
+
+    const ok = await gotoWithRetry(page, '/customer-intake');
+    if (!ok) test.skip();
+
+    await page.getByText(/ข้อมูลเบื้องต้น/).first().waitFor({ timeout: 15000 });
+    const inputs = page.locator('input');
+    await inputs.nth(0).fill('ทดสอบ');
+    await inputs.nth(1).fill('ทดสอบสกุล');
+    await inputs.nth(2).fill('1234567890123');
+    await inputs.nth(3).fill('0812345678');
+    await page.getByRole('button', { name: /ถัดไป.*เช็คเครดิต/ }).click();
+
+    await page.getByText(/Statement ธนาคาร/).waitFor({ timeout: 10000 });
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'statement.pdf',
+      mimeType: 'application/pdf',
+      buffer: MINIMAL_PDF_BYTES,
+    });
+
+    await page.waitForResponse('**/ocr/bank-statement', { timeout: 10000 });
+
+    // Bank input should NOT be readOnly — user must be able to type
+    const bankInput = page.getByPlaceholder(/อ่านไม่ได้.*พิมพ์ชื่อธนาคาร/);
+    await expect(bankInput).toBeVisible({ timeout: 5000 });
+    await expect(bankInput).toBeEditable();
+
+    // Type manually
+    await bankInput.fill('กรุงเทพ');
+    await expect(bankInput).toHaveValue('กรุงเทพ');
+
+    // Submit should now be enabled
+    const submitBtn = page.getByRole('button', { name: /เริ่มเช็คเครดิต/ });
+    await expect(submitBtn).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/credit-check/useCreditCheckCreate.ts
+++ b/apps/web/src/components/credit-check/useCreditCheckCreate.ts
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
-import { compressImageForOcr } from '@/lib/compressImage';
+import { compressImageForOcr, fileToOcrBase64 } from '@/lib/compressImage';
 import { useDebounce } from '@/hooks/useDebounce';
 import {
   type Customer,
@@ -168,13 +168,24 @@ export function useCreditCheckCreate({ open, preselectedCustomer, onSuccess }: U
 
   const handleStatementOcr = async () => {
     if (statementFiles.length === 0) {
-      toast.error('กรุณาเลือกรูป Statement');
+      toast.error('กรุณาเลือกไฟล์ Statement');
+      return;
+    }
+    const supported = statementFiles.filter(
+      (f) => f.type.startsWith('image/') || f.type === 'application/pdf',
+    );
+    if (supported.length === 0) {
+      toast.error('กรุณาเลือกรูปภาพหรือ PDF');
       return;
     }
     setStatementLoading(true);
     try {
-      const imageBase64 = await compressImageForOcr(statementFiles[0]);
-      const { data } = await api.post<OcrBankStatementResult>('/ocr/bank-statement', { imageBase64 }, { timeout: 90000 });
+      const filesBase64 = await Promise.all(supported.map(fileToOcrBase64));
+      const { data } = await api.post<OcrBankStatementResult>(
+        '/ocr/bank-statement',
+        { filesBase64 },
+        { timeout: 120000 },
+      );
       setStatementResult(data);
       toast.success(`วิเคราะห์ Statement สำเร็จ (ความมั่นใจ ${(data.confidence * 100).toFixed(0)}%)`);
     } catch (err) {

--- a/apps/web/src/lib/compressImage.ts
+++ b/apps/web/src/lib/compressImage.ts
@@ -70,6 +70,35 @@ function applyOrientation(ctx: CanvasRenderingContext2D, orientation: number, w:
   }
 }
 
+/**
+ * Read a file as a base64 data URL (no transformation).
+ * Use for PDFs or files that shouldn't be re-encoded.
+ */
+export function fileToBase64DataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('ไม่สามารถอ่านไฟล์ได้'));
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Convert a File to a base64 data URL suitable for OCR.
+ * - Images: compressed to 1600px JPEG quality 0.8
+ * - PDFs: read as-is (backend handles them as document content blocks)
+ * - Other types: throws
+ */
+export async function fileToOcrBase64(file: File): Promise<string> {
+  if (file.type.startsWith('image/')) {
+    return compressImageForOcr(file);
+  }
+  if (file.type === 'application/pdf') {
+    return fileToBase64DataUrl(file);
+  }
+  throw new Error(`ไฟล์ประเภท ${file.type || 'ไม่รู้จัก'} ไม่รองรับ — กรุณาใช้รูปภาพหรือ PDF`);
+}
+
 export async function compressImageForOcr(
   file: File,
   maxWidth = 1600,

--- a/apps/web/src/pages/CustomerIntakePage/components/PreCheckUploadStep.tsx
+++ b/apps/web/src/pages/CustomerIntakePage/components/PreCheckUploadStep.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Upload, Loader2, ArrowLeft, Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '@/lib/api';
-import { compressImageForOcr } from '@/lib/compressImage';
+import { fileToOcrBase64 } from '@/lib/compressImage';
 import type { QuickIntakeForm } from '../types';
 
 interface Props {
@@ -18,22 +18,31 @@ interface Props {
 export default function PreCheckUploadStep({ form, onChange, onSubmit, onBack, isSubmitting }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
   const [ocrLoading, setOcrLoading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
 
   const canSubmit = form.statementFiles.length > 0 && !!form.bankName && !ocrLoading;
 
   const handleFiles = async (files: File[]) => {
-    onChange({ statementFiles: files });
+    onChange({ statementFiles: files, bankName: undefined });
 
-    const firstImage = files.find((f) => f.type.startsWith('image/'));
-    if (!firstImage) return;
+    const supported = files.filter(
+      (f) => f.type.startsWith('image/') || f.type === 'application/pdf',
+    );
+    if (supported.length === 0) {
+      toast.error('กรุณาเลือกรูปภาพหรือ PDF');
+      return;
+    }
+    if (supported.length !== files.length) {
+      toast.warning('บางไฟล์ไม่รองรับ — ใช้เฉพาะรูปภาพและ PDF');
+    }
 
     setOcrLoading(true);
     try {
-      const imageBase64 = await compressImageForOcr(firstImage);
+      const filesBase64 = await Promise.all(supported.map(fileToOcrBase64));
       const { data } = await api.post(
         '/ocr/bank-statement',
-        { imageBase64 },
-        { timeout: 90000 },
+        { filesBase64 },
+        { timeout: 120000 },
       );
       if (data?.bankName) {
         onChange({ bankName: data.bankName });
@@ -43,7 +52,6 @@ export default function PreCheckUploadStep({ form, onChange, onSubmit, onBack, i
       }
     } catch (err) {
       toast.error('อ่าน statement ไม่สำเร็จ — กรุณากรอกธนาคารเอง');
-      // Silent: OCR is best-effort. User can still type bank name manually.
       void err;
     } finally {
       setOcrLoading(false);
@@ -72,20 +80,55 @@ export default function PreCheckUploadStep({ form, onChange, onSubmit, onBack, i
             }}
             className="hidden"
           />
-          <button
-            type="button"
-            onClick={() => fileRef.current?.click()}
-            disabled={ocrLoading}
-            className="w-full border-2 border-dashed border-border hover:border-primary/50 rounded-lg p-6 flex flex-col items-center gap-1 transition disabled:opacity-50"
+          <div
+            role="button"
+            tabIndex={ocrLoading ? -1 : 0}
+            aria-disabled={ocrLoading}
+            onClick={() => !ocrLoading && fileRef.current?.click()}
+            onKeyDown={(e) => {
+              if (ocrLoading) return;
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                fileRef.current?.click();
+              }
+            }}
+            onDragOver={(e) => {
+              if (ocrLoading) return;
+              e.preventDefault();
+              e.stopPropagation();
+              setIsDragging(true);
+            }}
+            onDragLeave={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) setIsDragging(false);
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setIsDragging(false);
+              if (ocrLoading) return;
+              const dropped = e.dataTransfer.files ? Array.from(e.dataTransfer.files) : [];
+              if (dropped.length > 0) void handleFiles(dropped);
+            }}
+            className={`w-full border-2 border-dashed rounded-lg p-6 flex flex-col items-center gap-1 transition cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${
+              ocrLoading
+                ? 'opacity-50 cursor-not-allowed border-border'
+                : isDragging
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:border-primary/50'
+            }`}
           >
-            <Upload className="size-6 text-muted-foreground" />
+            <Upload className={`size-6 ${isDragging ? 'text-primary' : 'text-muted-foreground'}`} />
             <span className="text-sm text-foreground">
-              {form.statementFiles.length > 0
-                ? `เลือกแล้ว ${form.statementFiles.length} ไฟล์`
-                : 'ลากไฟล์หรือคลิกเลือก'}
+              {isDragging
+                ? 'วางไฟล์ที่นี่'
+                : form.statementFiles.length > 0
+                  ? `เลือกแล้ว ${form.statementFiles.length} ไฟล์`
+                  : 'ลากไฟล์มาวางหรือคลิกเลือก'}
             </span>
             <span className="text-xs text-muted-foreground">รูปภาพหรือ PDF หลายไฟล์ได้</span>
-          </button>
+          </div>
         </div>
 
         <div>
@@ -106,15 +149,15 @@ export default function PreCheckUploadStep({ form, onChange, onSubmit, onBack, i
           </label>
           <Input
             value={form.bankName || ''}
-            readOnly
+            onChange={(e) => onChange({ bankName: e.target.value })}
+            disabled={ocrLoading}
             placeholder={
               ocrLoading
                 ? 'กำลังอ่าน...'
                 : form.statementFiles.length === 0
                   ? 'จะแสดงหลัง upload statement'
-                  : 'ไม่สามารถอ่านได้ — กรุณา upload ใหม่'
+                  : 'อ่านไม่ได้ — พิมพ์ชื่อธนาคารเอง'
             }
-            className="bg-muted/50 cursor-not-allowed"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- แก้ bug หน้า `/customer-intake` step 2 ที่ upload PDF statement แล้ว bank field ติดค้าง "ไม่สามารถอ่านได้" ไปเรื่อยๆ (ไม่มี toast, ไม่มี network request) เพราะ code filter เฉพาะ `image/*` ทั้งที่ UI โชว์ว่ารับ PDF ได้
- รองรับ PDF + หลายไฟล์ทั้ง `/customer-intake` และ `/credit-checks` — Claude API รับ document content block ตรงๆ ส่งหลายไฟล์ใน request เดียว
- เจอ bug เสริมขณะแก้: input `readOnly` + toast บอก "กรุณากรอกเอง" = deadlock → เปลี่ยน input เป็น editable
- เพิ่ม drag & drop + keyboard access ที่ upload area

## Root cause
`PreCheckUploadStep.handleFiles` ใช้ `files.find(f => f.type.startsWith('image/'))` → ถ้า user upload PDF อย่างเดียว: \`return\` เงียบ ไม่เรียก OCR, ไม่ set loading, ไม่ toast — frontend เลยแสดง placeholder error ตามเงื่อนไข `statementFiles.length > 0 && !bankName`

## Changes

**Backend** (`apps/api/src/modules/ocr/`)
- `analyzeBankStatement(filesBase64: string[])` — รับ array แทน single base64
- ใช้ `validateFileBase64` (pattern เดียวกับ `generateTemplateHtml`) รองรับ image + PDF
- เพิ่ม `callClaudeOcrMultiFile[WithRetry]` ส่งหลายไฟล์ใน request เดียว
- `OcrBankStatementDto.filesBase64`: array 1-10 ไฟล์, 15MB/ไฟล์

**Frontend**
- `compressImage.ts` — helper `fileToOcrBase64` (image → compress, PDF → raw)
- `PreCheckUploadStep.tsx` — ส่ง array, drag & drop, input editable
- `useCreditCheckCreate.ts` (CreditChecksPage) — consistent flow

## Test plan
- [x] TypeScript check ผ่าน (API + web)
- [x] Existing OCR tests ผ่าน 52/52
- [x] Playwright E2E 3 tests ผ่าน (`customer-intake-pdf-upload.spec.ts`):
  - upload PDF → request shape ถูก + PDF data URL + bankName ขึ้น + submit enabled
  - upload image → compressed JPEG ถูก + bankName ขึ้น
  - OCR return null bankName → input editable + พิมพ์เองได้ + submit enabled
- [ ] Manual smoke test บน production หลัง deploy (upload PDF จริง + ภาพ statement จริง)

🤖 Generated with [Claude Code](https://claude.com/claude-code)