### PR TITLE
fix(ocr): log bank-statement error detail (diagnose prod 500)

### DIFF
--- a/apps/api/src/modules/ocr/ocr.service.ts
+++ b/apps/api/src/modules/ocr/ocr.service.ts
@@ -969,11 +969,18 @@ ${basePrompt}`;
       };
     } catch (error) {
       if (error instanceof BadRequestException) throw error;
+      const err = error as Error & { status?: number };
       if (error instanceof SyntaxError) {
-        this.logger.error('Failed to parse bank statement OCR response as JSON');
+        this.logger.error(
+          `Failed to parse bank statement OCR response as JSON: ${err.message}`,
+          err.stack,
+        );
         throw new BadRequestException('ไม่สามารถอ่านข้อมูลจาก Statement ธนาคารได้ กรุณาลองใช้รูปที่ชัดเจนกว่านี้');
       }
-      this.logger.error('OCR bank statement extraction failed');
+      this.logger.error(
+        `OCR bank statement extraction failed (status=${err.status ?? 'n/a'}): ${err.message}`,
+        err.stack,
+      );
       throw new InternalServerErrorException('ระบบ OCR ขัดข้อง กรุณาลองใหม่อีกครั้ง');
     }
   }


### PR DESCRIPTION
## Why
หลัง PR #645 deploy ลูกค้า upload PDF บน production แล้วยังได้ 500 — แต่ log ใน Cloud Run บอกแค่ \`OCR bank statement extraction failed\` ไม่มี root cause (Anthropic 4xx/5xx? timeout? invalid PDF?) เพราะ \`logger.error\` เดิมไม่ pass error detail + \`SentryExceptionFilter\` mask message ใน production

## What
เพิ่ม \`error.message\`, \`status\`, \`stack\` เข้า log ใน catch block ของ \`analyzeBankStatement\` — Cloud Run logs จะเห็น root cause จริง (Sentry ก็เก็บ original exception ครบอยู่แล้ว แต่ Cloud Run เป็น primary triage path)

## Test plan
- [x] TypeScript check passed
- [ ] หลัง merge + deploy ลูกค้าลอง upload PDF ซ้ำ → query \`gcloud logging read ... textPayload:"OCR bank statement"\` → เห็น root cause message

🤖 Generated with [Claude Code](https://claude.com/claude-code)