### PR TITLE
fix(ocr): update model to claude-sonnet-4-6 (404 not_found_error)

### DIFF
--- a/apps/api/src/modules/ocr/ocr.service.ts
+++ b/apps/api/src/modules/ocr/ocr.service.ts
@@ -27,7 +27,7 @@ export class OcrService {
     'ถ้าตัวอักษรไม่ชัด ให้ใช้บริบทรอบข้างช่วยในการตีความ เช่น รูปแบบเลขบัตรประชาชน 13 หลัก หรือชื่อธนาคารที่คุ้นเคย ' +
     'ตอบเป็น JSON เท่านั้น ห้ามมี markdown code block หรือข้อความอื่นใดนอกเหนือจาก JSON';
 
-  private static readonly OCR_MODEL = 'claude-sonnet-4-5-20250514';
+  private static readonly OCR_MODEL = 'claude-sonnet-4-6';
   private static readonly LOW_CONFIDENCE_THRESHOLD = 0.7;
   private static readonly MAX_RETRIES = 2;
 


### PR DESCRIPTION
## Hotfix
Anthropic ตอบ 404 ทุก OCR request บน production:

\`\`\`
Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-5-20250514"}
\`\`\`

\`OCR_MODEL\` ใน [ocr.service.ts:30](apps/api/src/modules/ocr/ocr.service.ts#L30) เป็น \`claude-sonnet-4-5-20250514\` ซึ่ง **ไม่มีอยู่จริงในปัจจุบัน** (เม.ย. 2026) → OCR ทุก endpoint fail (id-card, payment-slip, book-bank, salary-slip, bank-statement)

ค้นพบหลัง deploy [PR #648](https://github.com/iamnaii/BESTCHOICE/pull/648) ที่ปรับ logger ให้ log error detail — Cloud Run logs เห็น stack trace จริง

## Fix
\`OCR_MODEL\` → \`claude-sonnet-4-6\` (current latest Sonnet, vision support ครบ, สมเหตุสมผลสำหรับ OCR เอกสารไทย)

## Followup (out of scope)
- \`/system-status\` ยังเขียวเพราะ \`checkAiStatus\` ใช้ \`countTokens\` ที่ดูจะ accept invalid model — leak issue ผ่าน health check ควร fix แยก

## Test plan
- [x] TypeScript passed
- [ ] หลัง merge + deploy: ลูกค้าลอง upload PDF/รูป → bankName ขึ้น

🤖 Generated with [Claude Code](https://claude.com/claude-code)