### PR TITLE
fix(contract-docs): remove SIGNED_CONTRACT จาก manual upload list

### DIFF
--- a/apps/web/src/components/contract/DocumentUpload.tsx
+++ b/apps/web/src/components/contract/DocumentUpload.tsx
@@ -19,12 +19,13 @@ interface ContractDocument {
   uploadedBy: { id: string; name: string };
 }
 
+// SIGNED_CONTRACT + PDPA_CONSENT ไม่รวมในรายการนี้ — backend สร้าง
+// auto หลังเซ็น e-Signature (contract-documents.service.ts:77,82)
 const DOCUMENT_TYPES = [
   { value: 'ID_CARD_COPY', label: 'สำเนาบัตรประชาชน (หน้า)', required: true },
   { value: 'KYC_SELFIE', label: 'รูปถ่ายลูกค้าถือบัตรประชาชน', required: true },
   { value: 'DEVICE_PHOTO', label: 'รูปถ่ายสินค้า', required: true },
   { value: 'DEVICE_IMEI_PHOTO', label: 'รูปถ่าย IMEI สินค้า', required: true },
-  { value: 'SIGNED_CONTRACT', label: 'PDF สัญญาที่เซ็นแล้ว (อัตโนมัติจากระบบ)', required: true },
   { value: 'FACEBOOK_PROFILE', label: 'Profile Facebook', required: true },
   { value: 'FACEBOOK_POST', label: 'Post Facebook ล่าสุด (ไม่เกิน 1 เดือน)', required: true },
   { value: 'LINE_PROFILE', label: 'Profile LINE', required: true },


### PR DESCRIPTION
## Why
หน้า DocumentUpload แสดง card "PDF สัญญาที่เซ็นแล้ว (อัตโนมัติจากระบบ)" เป็น **required upload** — ขัดกับ label ที่บอกว่าระบบสร้างอัตโนมัติ

Backend [contract-documents.service.ts:77](apps/api/src/modules/contracts/contract-documents.service.ts#L77) ตั้ง \`autoGenerate: true\` สำหรับ SIGNED_CONTRACT — ระบบสร้าง PDF หลัง e-Signature ครบ, user ไม่ต้อง upload เอง

## Fix
ลบ \`SIGNED_CONTRACT\` ออกจาก \`DOCUMENT_TYPES\` ใน \`DocumentUpload.tsx\` — UI จะตรงกับ backend auto-generation logic

## Test plan
- [x] TypeScript pass
- [ ] Manual: เปิดหน้า contract documents → ไม่เห็น card "PDF สัญญาที่เซ็นแล้ว" อีกแล้ว (ระบบ generate ให้เอง)

## Followup (out of scope)
- PDPA_CONSENT ก็มี \`autoGenerate: true\` แต่ไม่ได้แสดงใน DocumentUpload อยู่แล้ว — OK
- DOWN_PAYMENT_RECEIPT, GUARDIAN_DOC อยู่ใน backend required แต่ไม่มีใน frontend list — อาจต้องเพิ่มภายหลังถ้าเจอ bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)