### PR TITLE
fix(liff): auto-retry logout+login ถ้า getIDToken ค่า null

### DIFF
--- a/apps/web/src/hooks/useLiffInit.ts
+++ b/apps/web/src/hooks/useLiffInit.ts
@@ -107,13 +107,32 @@ export function useLiffInit(): UseLiffInitResult {
           const p = await liff.getProfile();
           const token = liff.getIDToken();
 
-          // No ID token = LIFF channel missing 'openid' scope OR token expired.
-          // Without ID token, server can't verify identity — surface a clear error
-          // instead of silently letting downstream API calls 401.
+          // No ID token = LIFF channel missing 'openid' scope OR cached token
+          // from a prior login without openid. Try ONCE to force fresh login
+          // (clears cached token) — use sessionStorage flag to prevent loop.
           if (!token) {
-            if (!cancelled) setError('ไม่สามารถรับ ID Token จาก LINE กรุณาปิดหน้านี้แล้วเปิดใหม่จาก LINE OA');
+            const RETRY_KEY = 'liff_idtoken_retry';
+            const alreadyRetried = sessionStorage.getItem(RETRY_KEY) === '1';
+            if (!alreadyRetried && liff.isInClient()) {
+              sessionStorage.setItem(RETRY_KEY, '1');
+              try {
+                liff.logout();
+              } catch {
+                // ignore logout errors
+              }
+              liff.login({ redirectUri: window.location.href });
+              return;
+            }
+            sessionStorage.removeItem(RETRY_KEY);
+            if (!cancelled)
+              setError(
+                'ไม่สามารถรับ ID Token จาก LINE — LIFF channel อาจยังไม่เปิด openid scope กรุณาแจ้งแอดมินเพื่อตรวจสอบ LINE Developers Console',
+              );
             return;
           }
+
+          // Success — clear retry flag
+          sessionStorage.removeItem('liff_idtoken_retry');
 
           if (!cancelled) {
             setLineId(p.userId);


### PR DESCRIPTION
## Issue
User เปิด LIFF จาก LINE OA → เห็น error "ไม่สามารถรับ ID Token จาก LINE" dead-end ใช้งานต่อไม่ได้

## Root causes
1. **LIFF channel ไม่เปิด openid scope** (config issue) — ต้องแก้ที่ LINE Developers Console
2. **Cached token ไม่มี openid scope** — user login LIFF ก่อน scope ถูกเปิด → token เก่าไม่มี openid ทำให้ \`getIDToken()\` คืน null ตลอด

PR นี้แก้ case 2 ได้ (case 1 ต้อง config ฝั่ง admin)

## Fix
ถ้า \`getIDToken()\` คืน null + อยู่ใน LINE client → auto-retry 1 ครั้ง:
- \`liff.logout()\` → clear cached session
- \`liff.login({ redirectUri })\` → fresh OAuth flow, ขอ openid scope ใหม่
- \`sessionStorage\` flag กัน infinite loop
- Success → clear flag
- Retry แล้วยัง null → แสดง error ใหม่ที่ชี้ไปที่แอดมินให้ตรวจ LIFF channel

## Test plan
- [x] TypeScript pass
- [ ] Manual: เปิด LIFF บน LINE app → ถ้าได้ token ปกติ ไม่เห็น action retry
- [ ] Manual: User ที่เคยเจอ error → เปิดใหม่ → ระบบ auto logout+login → ได้ token → เข้าระบบได้

## Followup (admin action, out of scope code)
ตรวจ **LINE Developers Console → Provider → LIFF channel → Scopes** ว่าเปิด \`openid\` ไหม — ถ้าไม่เปิด code fix นี้ก็ไม่ช่วย (infinite retry จะถูก block ที่รอบ 2, error จะแสดงพร้อมคำแนะนำ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)