### PR TITLE
fix(liff): sync customer.lineId ใน bind() + backfill migration

### DIFF
--- a/apps/api/prisma/migrations/20260422090000_backfill_customer_lineid_from_link/migration.sql
+++ b/apps/api/prisma/migrations/20260422090000_backfill_customer_lineid_from_link/migration.sql
@@ -1,0 +1,16 @@
+-- Backfill customers.line_id from customer_line_links (FINANCE channel)
+-- Reason: verification.service.ts:bind() เดิม sync แค่ CustomerLineLink +
+-- chatRoom.customerId แต่ไม่ update customer.line_id ทำให้ LIFF หน้า
+-- /liff/contract หาสัญญาไม่เจอ (ขึ้น "ไม่มีสัญญา") แม้ customer ผูก LINE
+-- ผ่าน chatbot Finance แล้ว
+--
+-- ตั้งแต่ commit นี้เป็นต้นไป bind() จะ sync customers.line_id ด้วย —
+-- migration นี้ sync ย้อนหลังสำหรับ links ที่มีอยู่
+
+UPDATE customers c
+SET line_id = l.line_user_id
+FROM customer_line_links l
+WHERE l.customer_id = c.id
+  AND l.channel = 'FINANCE'
+  AND l.unlinked_at IS NULL
+  AND (c.line_id IS NULL OR c.line_id = '');

--- a/apps/api/src/modules/chatbot-finance/services/verification.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.ts
@@ -318,6 +318,14 @@ export class VerificationService {
           verificationAttempts: 0,
         },
       });
+
+      // Sync canonical customer.lineId — LIFF pages (LiffContract etc.)
+      // lookup customer ด้วย field นี้ตรงๆ ถ้าไม่ update จะ "ไม่มีสัญญา"
+      // ทั้งที่ chatbot/CustomerLineLink link เรียบร้อยแล้ว
+      await tx.customer.update({
+        where: { id: customerId },
+        data: { lineId: lineUserId },
+      });
     });
     this.logger.log(`[Verify] Bound ${lineUserId.slice(0, 8)}... → customer ${customerId.slice(0, 8)}...`);
   }


### PR DESCRIPTION
## Issue
User verify ผ่าน chatbot Finance แล้ว → เปิด LIFF \`/liff/contract\` เห็น **"ไม่มีสัญญา"** ทั้งที่ chatbot ตอบข้อมูลสัญญาได้ปกติ

## Root cause
2 ระบบ match customer กับ LINE user ด้วย field ต่างกัน:

| System | Field |
|---|---|
| chatbot Finance | \`CustomerLineLink\` (composite key: lineUserId + channel) |
| LIFF Contract | \`customer.lineId\` (direct field) |

\`verification.service.ts:bind()\` sync CustomerLineLink + chatRoom.customerId แต่ **ไม่ update \`customer.lineId\`** → LIFF lookup ล้มเหลว

## Fix
**1. [verification.service.ts:303](apps/api/src/modules/chatbot-finance/services/verification.service.ts#L303)** — เพิ่ม \`tx.customer.update({ lineId })\` ใน transaction เดียวกันกับ CustomerLineLink upsert

**2. [migration 20260422090000_backfill_customer_lineid_from_link](apps/api/prisma/migrations/20260422090000_backfill_customer_lineid_from_link/migration.sql)** — backfill \`customers.line_id\` สำหรับ links ที่มีอยู่:
\`\`\`sql
UPDATE customers c SET line_id = l.line_user_id
FROM customer_line_links l
WHERE l.customer_id = c.id
  AND l.channel = 'FINANCE' AND l.unlinked_at IS NULL
  AND (c.line_id IS NULL OR c.line_id = '');
\`\`\`

## Test plan
- [x] TypeScript pass
- [ ] หลัง deploy: เจ้าของเปิด LIFF \`/liff/contract\` → เห็นสัญญา (ไม่ใช่ "ไม่มีสัญญา")
- [ ] Verify migration: ใน Cloud SQL ตรวจ \`customers.line_id\` หลัง migrate มี value ตรงกับ \`customer_line_links.line_user_id\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)