### PR TITLE
fix(test): add customer.update to tx mock in verification.spec (hotfix deploy)

### DIFF
--- a/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
@@ -36,6 +36,7 @@ describe('VerificationService', () => {
         const tx = {
           customerLineLink: { upsert: jest.fn().mockResolvedValue({}) },
           chatRoom: { updateMany: jest.fn().mockResolvedValue({}) },
+          customer: { update: jest.fn().mockResolvedValue({}) },
         };
         return cb(tx);
       }),


### PR DESCRIPTION
## Hotfix
PR #657 break \`verification.service.spec.ts\` → CI fail on main → deploy blocked

\`bind()\` เรียก \`tx.customer.update()\` ใน transaction แต่ mock ของ \`tx\` ใน test ขาด field \`customer\` → \`TypeError: Cannot read properties of undefined (reading 'update')\`

## Fix
เพิ่ม \`customer: { update: jest.fn() }\` ใน tx mock

## Test plan
- [x] \`npx jest verification.service\` — 16 tests pass locally
- [ ] CI pipeline กลับมาเขียว → deploy ผ่าน → migration backfill + bind() sync ทำงาน

🤖 Generated with [Claude Code](https://claude.com/claude-code)