### PR TITLE
fix(line-login): cookie sameSite=none ให้ XHR cross-subdomain ทำงาน

### DIFF
--- a/apps/api/src/modules/line-oa/line-login.controller.ts
+++ b/apps/api/src/modules/line-oa/line-login.controller.ts
@@ -142,12 +142,18 @@ export class LineLoginController {
       // Set ID token in httpOnly cookie instead of URL (prevents leaking in browser history/Referrer)
       // COOKIE_DOMAIN (e.g. '.bestchoicephone.app') makes the cookie readable from
       // the root domain frontend, not only the api.* subdomain that served this callback.
+      //
+      // sameSite: 'none' (ไม่ใช่ 'lax') เพราะ frontend เรียก /id-token ผ่าน XHR
+      // ข้าม subdomain (bestchoicephone.app → api.bestchoicephone.app) — WebKit
+      // (Safari/LINE in-app WKWebView) ไม่ส่ง cookie sameSite=lax ใน XHR cross-
+      // origin แม้ว่าจะ same-site เดียวกันก็ตาม. maxAge ขยายจาก 60s → 300s
+      // เผื่อ network ช้าใน LINE WebView
       const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
       res.cookie('line_id_token', tokenData.id_token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production' || !!cookieDomain,
-        sameSite: 'lax',
-        maxAge: 60000, // 60 seconds — one-time use
+        secure: true, // required for sameSite: 'none'
+        sameSite: 'none',
+        maxAge: 300_000, // 5 minutes — one-time use, buffer for slow networks
         path: '/',
         ...(cookieDomain ? { domain: cookieDomain } : {}),
       });


### PR DESCRIPTION
## Issue
User คลิก \`/liff/contract\` จาก LINE chat (non-LIFF URL) → fallback ไป LINE Login OAuth → ได้ \`/id-token\` แล้ว 401 → UI เห็น "ไม่สามารถรับ ID Token" ติดค้าง

## Root cause
\`line_id_token\` cookie ตั้ง \`sameSite: 'lax'\`:
- WebKit (Safari + LINE WKWebView) **ไม่ส่ง cookie sameSite=lax ใน cross-origin XHR** แม้ว่า same-site เดียวกัน (\`bestchoicephone.app\` ↔ \`api.bestchoicephone.app\`)
- Frontend fetch \`/api/admin/line-oa/line-login/id-token\` → browser drop cookie → server เห็นเป็น request ที่ไม่มี cookie → 401

## Evidence
Cloud Run logs:
\`\`\`
2026-04-22T12:37:23Z  401 https://.../api/admin/line-oa/line-login/id-token
2026-04-22T12:37:23Z  [LineLogin] Success: Nai (Uc3b10124...)  ← OAuth ผ่าน + set cookie
\`\`\`

## Fix
- \`sameSite: 'lax'\` → \`'none'\`
- \`secure: true\` (บังคับคู่กับ sameSite=none)
- \`maxAge: 60s → 300s\` (buffer สำหรับ LINE WebView slow network)

## Test plan
- [x] TypeScript pass
- [ ] User เปิด \`/liff/contract\` ใน LINE WebView → login OAuth → /id-token คืน token (not 401) → useLiffInit set idToken → LiffContract โหลดสัญญา

Pattern เดียวกับ [PR #642](https://github.com/iamnaii/BESTCHOICE/pull/642) ที่แก้ refresh cookie path หลัง \`/api/admin\` middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)