### PR TITLE
fix(line-login): ส่ง id_token ผ่าน URL fragment แทน cookie

### DIFF
--- a/apps/api/src/modules/line-oa/line-login.controller.ts
+++ b/apps/api/src/modules/line-oa/line-login.controller.ts
@@ -2,13 +2,12 @@ import {
   Controller,
   Get,
   Query,
-  Req,
   Res,
   Logger,
   BadRequestException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import * as Sentry from '@sentry/nestjs';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 
@@ -130,8 +129,12 @@ export class LineLoginController {
 
       this.logger.log(`[LineLogin] Success: ${profile.displayName} (${profile.userId})`);
 
-      // Redirect back to frontend with LINE data as query params
-      // Frontend will pick these up and store in memory
+      // Pass ID token via URL fragment (hash), not cookie:
+      // - WebKit ITP + LINE WKWebView block cross-subdomain cookies แม้ว่า
+      //   sameSite=none + secure + domain ตรง (confirmed 401 ใน Cloud Run logs)
+      // - URL fragment (#) ไม่ถูกส่งไปที่ server (client-only) — ไม่ leak
+      //   ใน referrer header หรือ server access logs
+      // - Frontend อ่าน location.hash → clear hash ทันที → keep ใน memory
       const redirectUrl = new URL(`${this.frontendBaseUrl}${returnPath}`);
       redirectUrl.searchParams.set('line_login', 'true');
       redirectUrl.searchParams.set('line_user_id', profile.userId);
@@ -139,24 +142,7 @@ export class LineLoginController {
       if (profile.pictureUrl) {
         redirectUrl.searchParams.set('line_picture', profile.pictureUrl);
       }
-      // Set ID token in httpOnly cookie instead of URL (prevents leaking in browser history/Referrer)
-      // COOKIE_DOMAIN (e.g. '.bestchoicephone.app') makes the cookie readable from
-      // the root domain frontend, not only the api.* subdomain that served this callback.
-      //
-      // sameSite: 'none' (ไม่ใช่ 'lax') เพราะ frontend เรียก /id-token ผ่าน XHR
-      // ข้าม subdomain (bestchoicephone.app → api.bestchoicephone.app) — WebKit
-      // (Safari/LINE in-app WKWebView) ไม่ส่ง cookie sameSite=lax ใน XHR cross-
-      // origin แม้ว่าจะ same-site เดียวกันก็ตาม. maxAge ขยายจาก 60s → 300s
-      // เผื่อ network ช้าใน LINE WebView
-      const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
-      res.cookie('line_id_token', tokenData.id_token, {
-        httpOnly: true,
-        secure: true, // required for sameSite: 'none'
-        sameSite: 'none',
-        maxAge: 300_000, // 5 minutes — one-time use, buffer for slow networks
-        path: '/',
-        ...(cookieDomain ? { domain: cookieDomain } : {}),
-      });
+      redirectUrl.hash = `id_token=${encodeURIComponent(tokenData.id_token)}`;
 
       res.redirect(redirectUrl.toString());
     } catch (err) {
@@ -173,22 +159,4 @@ export class LineLoginController {
     }
   }
 
-  /**
-   * One-shot endpoint — returns id_token from httpOnly cookie then clears it.
-   * Frontend calls this right after the /callback redirect to pick up the token
-   * the callback stored. Token is then kept in JS memory for LIFF API headers.
-   */
-  @Get('id-token')
-  getIdToken(@Req() req: Request, @Res() res: Response) {
-    const token = (req.cookies as Record<string, string> | undefined)?.line_id_token;
-    const cookieDomain = process.env.COOKIE_DOMAIN || undefined;
-    res.clearCookie('line_id_token', {
-      path: '/',
-      ...(cookieDomain ? { domain: cookieDomain } : {}),
-    });
-    if (!token) {
-      return res.status(401).json({ error: 'No id_token cookie' });
-    }
-    return res.json({ token });
-  }
 }

--- a/apps/web/src/hooks/useLiffInit.ts
+++ b/apps/web/src/hooks/useLiffInit.ts
@@ -50,31 +50,24 @@ export function useLiffInit(): UseLiffInitResult {
           const displayName = params.get('line_display_name');
           const pictureUrl = params.get('line_picture');
 
+          // Read id_token from URL fragment (backend puts it there to avoid
+          // WebKit ITP cross-subdomain cookie blocking). Fragment is not sent
+          // to server in any HTTP request = no leak in access logs/referrer.
+          const hashParams = new URLSearchParams(window.location.hash.slice(1));
+          const lineIdToken = hashParams.get('id_token');
+
           if (userId && displayName) {
-            // Clean URL — remove login params
+            // Clean URL — remove login query params AND fragment
             const cleanUrl = new URL(window.location.href);
             ['line_login', 'line_user_id', 'line_display_name', 'line_picture'].forEach(
               (k) => cleanUrl.searchParams.delete(k),
             );
+            cleanUrl.hash = '';
             window.history.replaceState({}, '', cleanUrl.toString());
 
-            // Fetch id_token from one-shot cookie endpoint (httpOnly, not readable from JS)
-            let lineIdToken: string | null = null;
-            try {
-              const base = API_URL.startsWith('http') ? API_URL : `${window.location.origin}${API_URL}`;
-              const tokenRes = await fetch(`${base}/line-oa/line-login/id-token`, {
-                credentials: 'include',
-              });
-              if (tokenRes.ok) {
-                const body = (await tokenRes.json()) as { token?: string };
-                lineIdToken = body.token ?? null;
-              }
-            } catch {
-              // Cookie missing or network error
-            }
-
             if (!lineIdToken) {
-              if (!cancelled) setError('ไม่สามารถรับ ID Token จาก LINE กรุณาปิดหน้านี้แล้วเปิดใหม่จาก LINE OA');
+              if (!cancelled)
+                setError('ไม่สามารถรับ ID Token จาก LINE กรุณาปิดหน้านี้แล้วเปิดใหม่จาก LINE OA');
               return;
             }
 


### PR DESCRIPTION
## Issue
PR #659 (sameSite=none) ยังไม่แก้ปัญหา — Cloud Run logs ยังเห็น 401 จาก \`/id-token\` หลัง deploy:
\`\`\`
2026-04-22T12:56:04Z  401 /api/admin/line-oa/line-login/id-token
2026-04-22T12:56:03Z  [LineLogin] Success: Nai (Uc3b10124...)
\`\`\`

WebKit ITP + LINE WKWebView block cross-subdomain cookies แม้ sameSite=none + secure + domain ตรง — ไม่ใช่ issue ที่แก้ที่ cookie attributes ได้

## Fix
เปลี่ยน transport mechanism: **URL fragment (hash) แทน cookie**

**Backend** (\`line-login.controller.ts\`):
- Callback redirect ใช้ \`redirectUrl.hash = 'id_token=xxx'\` แทน \`res.cookie()\`
- ลบ \`GET /id-token\` endpoint (ไม่ใช้แล้ว)

**Frontend** (\`useLiffInit.ts\`):
- อ่าน \`window.location.hash\` → parse \`id_token\`
- Clear hash ทันทีด้วย \`history.replaceState\` (ไม่เหลือใน history)
- Keep token in-memory (JS variable) เหมือนเดิม

## Security
- URL fragment (\`#\`) ไม่ถูกส่งใน HTTP requests (ไม่อยู่ใน server access logs, referrer headers, analytics tracking)
- Frontend clear hash หลังอ่าน → ไม่เหลือใน browser history
- Token keep in JS memory เหมือนเดิม — XSS safe pattern

## Test plan
- [x] TypeScript pass
- [x] ไม่มีใครเรียก \`/id-token\` endpoint แล้ว (grep confirmed)
- [ ] User เปิด LIFF ใน LINE → LINE Login fallback → frontend ได้ id_token → LiffContract โหลดสัญญาได้

🤖 Generated with [Claude Code](https://claude.com/claude-code)