### PR TITLE
fix(liff): LiffApiController channel SHOP → FINANCE (403 on /contracts)

### DIFF
--- a/apps/api/src/modules/line-oa/liff-api.controller.ts
+++ b/apps/api/src/modules/line-oa/liff-api.controller.ts
@@ -44,7 +44,10 @@ interface LiffPaymentLinkResult { url: string; token: string; totalPayoff?: numb
 @Controller('line-oa')
 @SkipCsrf()
 @UseGuards(LiffTokenGuard)
-@LiffChannel(LineChannelType.SHOP)
+// Installment customer LIFF — ทุก endpoint ใน controller นี้ (contracts,
+// history, profile, early-payoff, receipts, ฯลฯ) เป็น customer-facing
+// ของสาย FINANCE ไม่ใช่ SHOP online shop
+@LiffChannel(LineChannelType.FINANCE)
 export class LiffApiController {
   private readonly logger = new Logger(LiffApiController.name);
 


### PR DESCRIPTION
## Issue
หลัง PR #660 แก้ LINE Login token transfer → user เห็น **error ใหม่** "ไม่สามารถโหลดข้อมูลได้" แทน "ไม่สามารถรับ ID Token" — แปลว่า line-login PASS แล้วแต่ติด 403 ถัดมา

Cloud Run logs:
\`\`\`
403 /api/admin/line-oa/liff/contracts?lineId=Uc3b10124143e850b688de8b2d1251c2c
\`\`\`

## Root cause
\`LiffApiController\` ตั้ง \`@LiffChannel(SHOP)\`:
- \`LiffTokenGuard.enforceChannelBoundary\` check \`CustomerLineLink\` ของ verified lineUserId
- User link ผ่าน chatbot Finance → channel = **FINANCE**
- Expected (ตาม decorator) = **SHOP**
- Mismatch → \`ForbiddenException\` 403

แต่ controller นี้มี endpoints \`/liff/contracts\`, \`/liff/history\`, \`/liff/early-payoff\`, \`/liff/receipts\`, ฯลฯ — ทั้งหมดเป็น **customer installment** (FINANCE product) ไม่ใช่ online shop

(SHOP = \`shop.bestchoicephone.app\` app แยก)

## Fix
\`@LiffChannel(SHOP)\` → \`@LiffChannel(FINANCE)\` + comment

## Test plan
- [x] TypeScript pass
- [x] liff-api tests (60) pass
- [ ] หลัง deploy: user เปิด \`/liff/contract\` → เข้าหน้าสัญญาได้ (ไม่เห็น error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)