### PR TITLE
fix(liff): handle liff.state on any pathname + /liff fallback route

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -158,6 +158,10 @@ function App() {
 
         {/* LIFF Pages (public, opened from LINE) */}
         <Route path="/pay/:token" element={<LiffPayment />} />
+        {/* Bare /liff and unknown /liff/* → redirect to primary LIFF page.
+            Guards against Endpoint URL mis-configs and catch-all "*→/" hijacking
+            LIFF traffic into ProtectedRoute. */}
+        <Route path="/liff" element={<Navigate to="/liff/contract" replace />} />
         <Route path="/liff/contract" element={<LiffContract />} />
         <Route path="/liff/register" element={<LiffRegister />} />
         <Route path="/liff/history" element={<LiffHistory />} />
@@ -174,6 +178,8 @@ function App() {
           <p>href: {window.location.href}</p>
           <p>time: {new Date().toISOString()}</p>
         </div>} />
+        {/* Unknown /liff/* sub-paths fall back to primary LIFF page (not catch-all "*→/"). */}
+        <Route path="/liff/*" element={<Navigate to="/liff/contract" replace />} />
 
         {/* 2FA Setup — authenticated, no main layout */}
         <Route

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -92,11 +92,12 @@ const queryClient = new QueryClient({
   },
 });
 
-// LIFF consent redirect: LINE redirects to /?liff.state={encodedPath}
-// Must handle BEFORE React renders to prevent ProtectedRoute catching "/"
+// LIFF consent redirect: LINE redirects to {endpoint}?liff.state={encodedPath}
+// Must handle BEFORE React renders — works for ANY endpoint URL (/, /liff, /liff/contract, etc.)
+// so the rich-menu URIs (https://liff.line.me/<id>/<path>) route correctly regardless of
+// which Endpoint URL the admin set in LINE Developers Console.
 const liffState = new URLSearchParams(window.location.search).get('liff.state');
-if (liffState && window.location.pathname === '/') {
-  // Replace URL to the actual LIFF path so React Router matches correctly
+if (liffState) {
   window.history.replaceState(null, '', liffState + window.location.search);
 }
 


### PR DESCRIPTION
## Summary
- LINE in-app browser แสดง "ไม่สามารถเปิดหน้านี้ได้" เมื่อ LIFF Endpoint URL ถูกตั้งเป็น `/liff` (หรือ path อื่นที่ไม่ใช่ `/`) — เพราะ handler ใน `main.tsx` รันเฉพาะ `pathname === '/'` ทำให้ `/liff?liff.state=...` ตกลง catch-all `*→/` → ProtectedRoute → ลูกค้าที่เข้าจาก LINE ไม่มี JWT → fail
- แก้ 2 จุดให้ robust ไม่ว่า admin จะตั้ง Endpoint URL เป็นอะไรใน LINE Developers Console

## Changes
- `apps/web/src/main.tsx` — rewrite URL จาก `liff.state` ทุก pathname (ลบ constraint `pathname === '/'`)
- `apps/web/src/App.tsx` — เพิ่ม 2 route fallback:
  - `/liff` → `Navigate to="/liff/contract"`
  - `/liff/*` (unknown sub-paths) → `Navigate to="/liff/contract"` (วางก่อน catch-all `*→/`)

## Test plan
- [ ] TypeScript check (`./tools/check-types.sh web`) — ผ่านแล้ว
- [ ] Deploy preview → ทดสอบ URL รูปแบบต่อไปนี้ใน LINE in-app browser:
  - [ ] `https://app.bestchoicephone.app/?liff.state=/liff/contract` → `/liff/contract`
  - [ ] `https://app.bestchoicephone.app/liff?liff.state=/liff/history` → `/liff/history`
  - [ ] `https://app.bestchoicephone.app/liff` (ไม่มี liff.state) → `/liff/contract`
  - [ ] `https://app.bestchoicephone.app/liff/unknown` → `/liff/contract`
- [ ] ตรวจ rich menu ทั้ง 6 ปุ่มเปิดหน้าตรงได้

## Config note (ไม่บังคับ — optional optimization)
หลัง merge แล้วตั้ง Endpoint URL ใน LINE Developers Console เป็น `https://app.bestchoicephone.app/liff/contract` จะลด redirect hop 1 ครั้ง (เดิมอาจ redirect 2 ครั้ง: `/liff` → `/liff/contract`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)