### PR TITLE
fix(liff): shorthand route redirects for rich-menu LIFF URIs

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -162,6 +162,11 @@ function App() {
             Guards against Endpoint URL mis-configs and catch-all "*→/" hijacking
             LIFF traffic into ProtectedRoute. */}
         <Route path="/liff" element={<Navigate to="/liff/contract" replace />} />
+        {/* Shorthand aliases for rich-menu LIFF URIs (https://liff.line.me/<id>/contract).
+            LINE rewrites them via liff.state so the landing pathname is the bare sub-path. */}
+        <Route path="/contract" element={<Navigate to="/liff/contract" replace />} />
+        <Route path="/history" element={<Navigate to="/liff/history" replace />} />
+        <Route path="/early-payoff" element={<Navigate to="/liff/early-payoff" replace />} />
         <Route path="/liff/contract" element={<LiffContract />} />
         <Route path="/liff/register" element={<LiffRegister />} />
         <Route path="/liff/history" element={<LiffHistory />} />

--- a/docs/designs/rich-menu/rich-menu-config.json
+++ b/docs/designs/rich-menu/rich-menu-config.json
@@ -1,0 +1,59 @@
+{
+  "size": {
+    "width": 2500,
+    "height": 1686
+  },
+  "selected": true,
+  "name": "BESTCHOICE Finance - Chromatic Shrine",
+  "chatBarText": "เมนู",
+  "areas": [
+    {
+      "bounds": { "x": 0, "y": 0, "width": 833, "height": 843 },
+      "action": {
+        "type": "uri",
+        "label": "สัญญาของฉัน",
+        "uri": "https://liff.line.me/REPLACE_LIFF_ID/liff/contract"
+      }
+    },
+    {
+      "bounds": { "x": 833, "y": 0, "width": 834, "height": 843 },
+      "action": {
+        "type": "uri",
+        "label": "ชำระค่างวด",
+        "uri": "https://liff.line.me/REPLACE_LIFF_ID/liff/contract"
+      }
+    },
+    {
+      "bounds": { "x": 1667, "y": 0, "width": 833, "height": 843 },
+      "action": {
+        "type": "uri",
+        "label": "ประวัติชำระ",
+        "uri": "https://liff.line.me/REPLACE_LIFF_ID/liff/history"
+      }
+    },
+    {
+      "bounds": { "x": 0, "y": 843, "width": 833, "height": 843 },
+      "action": {
+        "type": "uri",
+        "label": "ปิดยอดลด 50%",
+        "uri": "https://liff.line.me/REPLACE_LIFF_ID/liff/early-payoff"
+      }
+    },
+    {
+      "bounds": { "x": 833, "y": 843, "width": 834, "height": 843 },
+      "action": {
+        "type": "message",
+        "label": "ชวนเพื่อน",
+        "text": "ขอลิงก์ชวนเพื่อน"
+      }
+    },
+    {
+      "bounds": { "x": 1667, "y": 843, "width": 833, "height": 843 },
+      "action": {
+        "type": "message",
+        "label": "ติดต่อเรา",
+        "text": "สวัสดีค่ะ อยากสอบถามเกี่ยวกับสัญญาผ่อนชำระ"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Symptom
พอกด rich menu ปุ่ม 1-4 (สัญญาของฉัน / ชำระค่างวด / ประวัติชำระ / ปิดยอดลด 50%) ในมือถือลูกค้า → ขึ้นหน้า **Login admin** ("เข้าสู่ระบบ") แทนที่จะเป็นหน้า LIFF

## Root cause
Rich menu URI pattern: `https://liff.line.me/<id>/contract`
LINE rewrite: `?liff.state=/contract`
main.tsx handler → URL เป็น `/contract`
**ไม่มี route `/contract`** (มีแค่ `/liff/contract`) → catch-all `*→/` → ProtectedRoute → Login

(ก่อน PR #665 รอดเพราะ handler รันเฉพาะ `pathname === '/'` — endpoint path อื่นจะข้าม rewrite)

## Fix
- `App.tsx`: redirect `/contract`, `/history`, `/early-payoff` → `/liff/*` (รองรับ LIFF URI แบบ shorthand ที่ rich menu ใช้)
- `rich-menu-config.json`: เปลี่ยนเป็น pattern `/liff/<path>` สำหรับ rich menu upload ครั้งต่อไป (จะได้ไม่ต้อง redirect)

## Test plan
- [ ] Deploy → ลอง rich menu 4 ปุ่ม URI ต้องเปิดหน้า LIFF ไม่ใช่ login
- [ ] เปิด `/contract`, `/history`, `/early-payoff` ตรง ๆ → redirect ไป `/liff/*`
- [ ] `/liff/contract` ตรง ๆ ยังทำงาน

🤖 Generated with [Claude Code](https://claude.com/claude-code)