### PR TITLE
fix(liff): skip liff.state rewrite when state is "/"

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -93,11 +93,11 @@ const queryClient = new QueryClient({
 });
 
 // LIFF consent redirect: LINE redirects to {endpoint}?liff.state={encodedPath}
-// Must handle BEFORE React renders — works for ANY endpoint URL (/, /liff, /liff/contract, etc.)
-// so the rich-menu URIs (https://liff.line.me/<id>/<path>) route correctly regardless of
-// which Endpoint URL the admin set in LINE Developers Console.
+// Must handle BEFORE React renders — works for ANY endpoint URL (/, /liff, /liff/contract, etc.).
+// Skip rewrite when liff.state is empty or "/" (bare rich-menu URI without sub-path) —
+// otherwise we'd rewrite a valid LIFF endpoint pathname down to "/" and hit ProtectedRoute.
 const liffState = new URLSearchParams(window.location.search).get('liff.state');
-if (liffState) {
+if (liffState && liffState !== '/') {
   window.history.replaceState(null, '', liffState + window.location.search);
 }
 


### PR DESCRIPTION
## Symptom
กดปุ่ม rich menu → ยังขึ้นหน้า Login admin (เหมือนเดิม) แม้ PR #666 merge แล้ว

## Root cause (regression ที่ PR #665 สร้าง)
ถ้า rich menu URI เป็นแบบ bare (`https://liff.line.me/<id>` ไม่มี sub-path):
- LINE ส่ง `?liff.state=/`
- main.tsx handler จาก PR #665 rewrite URL ทุกครั้งที่มี liff.state
- ผลลัพธ์: endpoint pathname ที่ valid อยู่แล้ว (เช่น `/liff/contract`) ถูก rewrite ให้เป็น `/` → ProtectedRoute → Login

## Fix
Skip rewrite เมื่อ `liff.state === '/'` — ปล่อยให้ endpoint pathname เดิมทำงาน

## หลัง merge + deploy
ตั้ง Endpoint URL ใน LINE Console เป็น:
```
https://bestchoicephone.app/liff/contract
```
แล้ว rich menu แบบ bare URI จะเปิดหน้า LIFF Contract ตรงๆ ไม่ drop ไป `/`

## Test plan
- [ ] Deploy → กด rich menu → หน้า LIFF Contract เปิดได้ (ไม่ใช่ login)
- [ ] Rich menu URI ที่มี sub-path (/contract, /history) ยังทำงานผ่าน PR #666 redirect routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)