### PR TITLE
fix(liff): early-payoff field mapping + document download 401

### DIFF
--- a/apps/api/src/modules/line-oa/guards/liff-token.guard.ts
+++ b/apps/api/src/modules/line-oa/guards/liff-token.guard.ts
@@ -56,7 +56,11 @@ export class LiffTokenGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
-    const idToken = request.headers['x-liff-id-token'] as string | undefined;
+    // Accept token from header (XHR) OR ?idToken= query param
+    // (browser navigation / <a href> — PDF downloads, file links).
+    const idToken =
+      (request.headers['x-liff-id-token'] as string | undefined) ||
+      (request.query?.idToken as string | undefined);
 
     if (!idToken) {
       throw new UnauthorizedException('กรุณาเปิดผ่าน LINE');

--- a/apps/api/src/modules/line-oa/liff-api.controller.spec.ts
+++ b/apps/api/src/modules/line-oa/liff-api.controller.spec.ts
@@ -232,19 +232,45 @@ describe('LiffApiController', () => {
   // ─── getLiffEarlyPayoffQuote ─────────────────────────
 
   describe('getLiffEarlyPayoffQuote', () => {
-    it('returns quote for active contract', async () => {
+    it('returns quote for active contract with mapped fields', async () => {
       liffService.findCustomerByLineId.mockResolvedValue({ id: 'cust1', name: 'สมชาย' });
       liffService.findContractForCustomer.mockResolvedValue({
         id: 'con1', contractNumber: 'BC-001', status: 'ACTIVE',
       });
       contractPaymentService.getEarlyPayoffQuote.mockResolvedValue({
-        totalPayoff: 8500, remainingMonths: 4,
+        totalPayoff: 8500,
+        remainingMonths: 4,
+        remainingCost: 6000,
+        grossProfit: 2000,
+        discountAmount: 1000,
+        advancePayment: 500,
+        unpaidLateFees: 100,
       });
 
       const result = await controller.getLiffEarlyPayoffQuote(mockReq('U_line'), 'con1');
       expect(result.totalPayoff).toBe(8500);
       expect(result.contractNumber).toBe('BC-001');
       expect(result.customerName).toBe('สมชาย');
+      expect(result.remainingPrincipal).toBe(6000);
+      expect(result.remainingInterest).toBe(2000);
+      expect(result.discount).toBe(1000);
+      expect(result.partiallyPaidCredit).toBe(500);
+      expect(result.unpaidLateFees).toBe(100);
+    });
+
+    it('clamps negative grossProfit to 0 for remainingInterest (loss case)', async () => {
+      liffService.findCustomerByLineId.mockResolvedValue({ id: 'cust1', name: 'สมชาย' });
+      liffService.findContractForCustomer.mockResolvedValue({
+        id: 'con1', contractNumber: 'BC-001', status: 'ACTIVE',
+      });
+      contractPaymentService.getEarlyPayoffQuote.mockResolvedValue({
+        totalPayoff: 5000, remainingMonths: 2,
+        remainingCost: 4000, grossProfit: -500,
+        discountAmount: 0, advancePayment: 0, unpaidLateFees: 0,
+      });
+
+      const result = await controller.getLiffEarlyPayoffQuote(mockReq('U_line'), 'con1');
+      expect(result.remainingInterest).toBe(0);
     });
 
     it('throws BadRequestException if no contractId', async () => {

--- a/apps/api/src/modules/line-oa/liff-api.controller.ts
+++ b/apps/api/src/modules/line-oa/liff-api.controller.ts
@@ -223,8 +223,18 @@ export class LiffApiController {
     }
 
     const quote = await this.contractPaymentService.getEarlyPayoffQuote(contractId);
+    // Map service field names → LiffEarlyPayoffQuote (shared/liff-types.ts).
+    // The admin endpoint (/contracts/:id/early-payoff-quote) keeps the raw service
+    // shape; LIFF wants the customer-facing breakdown (principal / interest /
+    // discount / credit) without exposing internal cost/profit terminology.
     return {
-      ...quote,
+      remainingMonths: quote.remainingMonths,
+      remainingPrincipal: quote.remainingCost,
+      remainingInterest: Math.max(0, quote.grossProfit),
+      discount: quote.discountAmount,
+      partiallyPaidCredit: quote.advancePayment,
+      unpaidLateFees: quote.unpaidLateFees,
+      totalPayoff: quote.totalPayoff,
       contractNumber: contract.contractNumber,
       customerName: customer.name,
     };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -153,6 +153,20 @@ let liffIdToken: string | null = null;
 export function setLiffIdToken(token: string | null) {
   liffIdToken = token;
 }
+/** Read the current LIFF id_token — used to build document/file download
+ * links that can't attach the X-Liff-Id-Token header (plain <a href>). */
+export function getLiffIdToken(): string | null {
+  return liffIdToken;
+}
+/** Append idToken query param to a download URL so LiffTokenGuard can
+ * authenticate browser-navigation requests (new tab / target=_blank),
+ * which don't carry the X-Liff-Id-Token header. */
+export function withLiffToken(url: string): string {
+  const token = liffIdToken;
+  if (!token) return url;
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}idToken=${encodeURIComponent(token)}`;
+}
 
 // Attach X-Liff-Id-Token header on all liffApi requests
 liffApi.interceptors.request.use((config) => {

--- a/apps/web/src/pages/liff/LiffContract.tsx
+++ b/apps/web/src/pages/liff/LiffContract.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useLiffInit } from '@/hooks/useLiffInit';
-import { liffApi } from '@/lib/api';
+import { liffApi, withLiffToken } from '@/lib/api';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -565,7 +565,7 @@ export default function LiffContract() {
         {/* Action row: PDF + early payoff */}
         <section className="relative z-[1] mt-3 px-5 grid grid-cols-[1fr_1.2fr] gap-2.5">
           <a
-            href={`/api/line-oa/liff/contracts/${contract.id}/document`}
+            href={withLiffToken(`/api/line-oa/liff/contracts/${contract.id}/document`)}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center gap-2 rounded-2xl border border-border/50 bg-card px-3 py-3.5 text-[13px] font-medium text-foreground active:scale-[0.98] transition-transform shadow-sm leading-snug"

--- a/apps/web/src/pages/liff/LiffReceipts.tsx
+++ b/apps/web/src/pages/liff/LiffReceipts.tsx
@@ -1,5 +1,5 @@
 import { useLiffInit } from '@/hooks/useLiffInit';
-import { liffApi } from '@/lib/api';
+import { liffApi, withLiffToken } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
 import { formatDateMedium } from '@/utils/formatters';
 import { FileText, Download } from 'lucide-react';
@@ -132,7 +132,7 @@ export default function LiffReceipts() {
                       asChild
                     >
                       <a
-                        href={`/api/line-oa/liff/receipts/${r.id}/download`}
+                        href={withLiffToken(`/api/line-oa/liff/receipts/${r.id}/download`)}
                         target="_blank"
                         rel="noopener noreferrer"
                       >


### PR DESCRIPTION
## 2 bugs fixed ที่เจอตอนลุย LIFF

### Bug 1 — ปิดยอด crash: `undefined is not an object (evaluating 'h.remainingPrincipal.toLocaleString')`
Field-name mismatch:
| Frontend expect | Service returns |
|---|---|
| `remainingPrincipal` | `remainingCost` |
| `remainingInterest` | `grossProfit` |
| `discount` | `discountAmount` |
| `partiallyPaidCredit` | `advancePayment` |

Map ใน LIFF controller + clamp `grossProfit` ติดลบเป็น 0

### Bug 2 — กด PDF สัญญา/ใบเสร็จ = 401 "กรุณาเปิดผ่าน LINE"
`<a href="/api/.../document" target="_blank">` เป็น browser navigation → ไม่ส่ง `X-Liff-Id-Token` header → LiffTokenGuard reject 401 → JSON response ในหน้าเปล่า

Fix:
- `LiffTokenGuard`: accept `?idToken=` query param เป็น fallback
- `lib/api.ts`: `withLiffToken(url)` helper แนบ token เข้า URL
- `LiffContract.tsx` + `LiffReceipts.tsx`: wrap download hrefs

Token short-lived (~นาที) — exposure จำกัด

## Test
- [x] type check: API + Web ผ่าน
- [x] 30/30 liff-api.controller.spec ผ่าน (2 test ใหม่: mapped fields + loss case)
- [x] 4/4 liff-token.guard.spec ผ่าน
- [ ] Deploy → กดปิดยอดต้องเห็นยอดครบ + กด PDF ต้องดาวน์โหลดได้

🤖 Generated with [Claude Code](https://claude.com/claude-code)