### PR TITLE
fix(liff): history test broken by PR #669 receipt join (CI hotfix)

### DIFF
--- a/apps/api/src/modules/line-oa/liff-api.service.spec.ts
+++ b/apps/api/src/modules/line-oa/liff-api.service.spec.ts
@@ -24,6 +24,9 @@ describe('LiffApiService', () => {
       contract: {
         findFirst: jest.fn(),
       },
+      receipt: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -267,18 +270,23 @@ describe('LiffApiService', () => {
           {
             contractNumber: 'BC-001',
             payments: [
-              { installmentNo: 1, amountPaid: new Prisma.Decimal('2000'), paidDate: new Date('2026-02-01'), paymentMethod: 'CASH', lateFee: new Prisma.Decimal('0') },
-              { installmentNo: 2, amountPaid: new Prisma.Decimal('2000'), paidDate: new Date('2026-03-01'), paymentMethod: 'BANK_TRANSFER', lateFee: new Prisma.Decimal('50') },
+              { id: 'pay-1', installmentNo: 1, amountPaid: new Prisma.Decimal('2000'), paidDate: new Date('2026-02-01'), paymentMethod: 'CASH', lateFee: new Prisma.Decimal('0') },
+              { id: 'pay-2', installmentNo: 2, amountPaid: new Prisma.Decimal('2000'), paidDate: new Date('2026-03-01'), paymentMethod: 'BANK_TRANSFER', lateFee: new Prisma.Decimal('50') },
             ],
           },
           {
             contractNumber: 'BC-002',
             payments: [
-              { installmentNo: 1, amountPaid: new Prisma.Decimal('1500'), paidDate: new Date('2026-02-15'), paymentMethod: 'PROMPTPAY', lateFee: new Prisma.Decimal('0') },
+              { id: 'pay-3', installmentNo: 1, amountPaid: new Prisma.Decimal('1500'), paidDate: new Date('2026-02-15'), paymentMethod: 'PROMPTPAY', lateFee: new Prisma.Decimal('0') },
             ],
           },
         ],
       });
+      // Receipts issued for pay-1 and pay-3 only
+      prisma.receipt.findMany.mockResolvedValue([
+        { id: 'rc-a', paymentId: 'pay-1' },
+        { id: 'rc-c', paymentId: 'pay-3' },
+      ]);
 
       const result = await service.findCustomerPaymentHistory('U_line');
       expect(result).not.toBeNull();
@@ -291,6 +299,10 @@ describe('LiffApiService', () => {
       // Decimal → number conversion
       expect(result!.payments[2].amountPaid).toBe(2000);
       expect(result!.payments[0].lateFee).toBe(50);
+      // Receipt IDs joined: pay-1 → rc-a, pay-3 → rc-c, pay-2 → null (no receipt)
+      expect(result!.payments[0].receiptId).toBeNull(); // pay-2 (Mar 1)
+      expect(result!.payments[1].receiptId).toBe('rc-c'); // pay-3 (Feb 15)
+      expect(result!.payments[2].receiptId).toBe('rc-a'); // pay-1 (Feb 1)
     });
   });
 

--- a/apps/api/src/modules/line-oa/liff-api.service.ts
+++ b/apps/api/src/modules/line-oa/liff-api.service.ts
@@ -7,7 +7,7 @@ import { maskThaiName } from '../../utils/mask-name.util';
 interface LiffPaymentItem { installmentNo: number; dueDate: string; amountDue: number; amountPaid: number; lateFee: number; status: string; paidDate: string | null; paymentMethod: string | null; }
 interface LiffContractItem { id: string; contractNumber: string; status: string; dunningStage: string; daysOverdue: number; product: string; sellingPrice: number; downPayment: number; monthlyPayment: number; totalMonths: number; paidInstallments: number; totalOutstanding: number; createdAt: string; payments: LiffPaymentItem[]; }
 interface LiffContractResponse { customer: { name: string }; contracts: LiffContractItem[]; }
-interface LiffHistoryPayment { contractNumber: string; installmentNo: number; amountPaid: number; paidDate: string | null; paymentMethod: string | null; lateFee: number; }
+interface LiffHistoryPayment { contractNumber: string; installmentNo: number; amountPaid: number; paidDate: string | null; paymentMethod: string | null; lateFee: number; receiptId: string | null; }
 interface LiffHistoryResponse { customer: { name: string }; payments: LiffHistoryPayment[]; }
 interface LiffProfileResponse { name: string; phone: string; lineDisplayName: string; contractCount: number; totalPoints: number; }
 interface LiffRegisterLookupResponse { customerId: string; maskedName: string; }


### PR DESCRIPTION
## Symptom
PR #669 deploy run \`24797223268\` **failed** on Lint & Test:
\`\`\`
FAIL src/modules/line-oa/liff-api.service.spec.ts
  ● LiffApiService › findCustomerPaymentHistory › returns sorted payment history across contracts
Tests: 1 failed, 1641 passed, 1642 total
\`\`\`
→ CI กลับมาแดงบน main

## Root cause
2 gaps จาก PR #669:

1. **Local type mirror drift** — \`liff-api.service.ts\` line 10 มี local \`LiffHistoryPayment\` interface mirror ที่ **ไม่ได้เพิ่ม \`receiptId\`** ตอนเพิ่มใน shared/\`liff-types.ts\`. Service compile ผ่านเพราะ excess property allowed แต่ test อ่าน \`result!.payments[i].receiptId\` ไม่เห็น field

2. **Mock missing** — \`liff-api.service.spec.ts\` ไม่มี \`prisma.receipt.findMany\` stub และ payment fixtures ไม่มี \`id\` → service เรียก \`findMany\` ได้ \`undefined\` → receiptByPaymentId Map พัง

## Fix
- Add \`receiptId: string | null\` ที่ local mirror ใน \`liff-api.service.ts\`
- \`prisma.receipt.findMany: jest.fn().mockResolvedValue([])\` default + ต่อเติมใน test case ด้วย \`mockResolvedValue([{id,paymentId}])\`
- ใส่ \`id\` ใน payment fixtures + assert receiptId mapping (pay-1→rc-a, pay-3→rc-c, pay-2→null)

## Test
- [x] type check API ผ่าน
- [x] 31/31 tests ใน liff-api.service.spec ผ่าน (เพิ่ม receipt join assertion)

⚡ **priority: high** — unblock CI + deploy pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)