### PR TITLE
feat(customers): OWNER-only delete with active-contract block

### DIFF
--- a/apps/api/src/modules/customers/customers.controller.ts
+++ b/apps/api/src/modules/customers/customers.controller.ts
@@ -250,7 +250,7 @@ export class CustomersController {
   }
 
   @Delete(':id')
-  @Roles('OWNER', 'BRANCH_MANAGER')
+  @Roles('OWNER')
   remove(@Param('id') id: string) {
     return this.customersService.remove(id);
   }

--- a/apps/api/src/modules/customers/customers.service.spec.ts
+++ b/apps/api/src/modules/customers/customers.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConflictException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { CustomersService } from './customers.service';
 import { CustomerTierService } from './customer-tier.service';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -350,5 +350,52 @@ describe('PII read decryption (Phase 5)', () => {
     expect(
       (dedupCall![0] as { where: { nationalIdHash: string } }).where.nationalIdHash,
     ).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('CustomersService.remove — block if open contracts', () => {
+  let service: CustomersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    process.env.PII_HASH_SALT = 'b'.repeat(32);
+    prisma = {
+      customer: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'c1', deletedAt: null, references: null }),
+        update: jest.fn((args) => Promise.resolve({ id: 'c1', ...args.data })),
+      },
+      contract: { count: jest.fn() },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        CustomersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CustomerTierService, useValue: { getCustomerTier: jest.fn() } },
+      ],
+    }).compile();
+    service = mod.get(CustomersService);
+  });
+
+  afterEach(() => {
+    delete process.env.PII_HASH_SALT;
+  });
+
+  it('soft-deletes customer with no open contracts', async () => {
+    prisma.contract.count.mockResolvedValue(0);
+    await service.remove('c1');
+    const countArgs = prisma.contract.count.mock.calls[0][0];
+    expect(countArgs.where.customerId).toBe('c1');
+    expect(countArgs.where.status.in).toEqual(['ACTIVE', 'OVERDUE', 'DEFAULT']);
+    expect(prisma.customer.update).toHaveBeenCalledWith({
+      where: { id: 'c1' },
+      data: { deletedAt: expect.any(Date) },
+    });
+  });
+
+  it('throws BadRequestException if customer has open contracts', async () => {
+    prisma.contract.count.mockResolvedValue(2);
+    await expect(service.remove('c1')).rejects.toBeInstanceOf(BadRequestException);
+    expect(prisma.customer.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { paginatedResponse } from '../../common/helpers/pagination.helper';
@@ -614,6 +614,20 @@ export class CustomersService {
 
   async remove(id: string) {
     await this.findOne(id);
+
+    const activeContracts = await this.prisma.contract.count({
+      where: {
+        customerId: id,
+        deletedAt: null,
+        status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT'] },
+      },
+    });
+    if (activeContracts > 0) {
+      throw new BadRequestException(
+        `ไม่สามารถลบลูกค้าได้: มีสัญญาที่ยังเปิดอยู่ ${activeContracts} สัญญา`,
+      );
+    }
+
     return this.prisma.customer.update({
       where: { id },
       data: { deletedAt: new Date() },

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -23,7 +23,8 @@ import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import AddressForm, { AddressData, emptyAddress, serializeAddress } from '@/components/ui/AddressForm';
-import { Download, ChevronUp, ChevronDown, CreditCard, Camera, User, MapPin, Phone, Briefcase, Users, Copy } from 'lucide-react';
+import { Download, ChevronUp, ChevronDown, CreditCard, Camera, User, MapPin, Phone, Briefcase, Users, Copy, Trash2 } from 'lucide-react';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import {
   Select,
@@ -254,6 +255,20 @@ export default function CustomersPage() {
       toast.success('เพิ่มลูกค้าสำเร็จ');
       setIsModalOpen(false);
       navigate(`/customers/${res.data.id}`);
+    },
+    onError: (err: unknown) => {
+      toast.error(getErrorMessage(err));
+    },
+  });
+
+  const [deleteTarget, setDeleteTarget] = useState<Customer | null>(null);
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => api.delete(`/customers/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['customers'] });
+      toast.success('ลบลูกค้าสำเร็จ');
+      setDeleteTarget(null);
     },
     onError: (err: unknown) => {
       toast.error(getErrorMessage(err));
@@ -626,7 +641,22 @@ export default function CustomersPage() {
         <span className="text-xs text-muted-foreground whitespace-nowrap">{formatRelativeDate(c.createdAt)}</span>
       ),
     },
-  ], [canViewSalary, isOwnerOrManager, copyValue]);
+    ...(isOwner ? [{
+      key: 'actions',
+      label: '',
+      render: (c: Customer) => (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setDeleteTarget(c); }}
+          className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded transition-colors"
+          aria-label={`ลบลูกค้า ${c.name}`}
+          title="ลบลูกค้า"
+        >
+          <Trash2 className="size-4" strokeWidth={1.5} />
+        </button>
+      ),
+    }] : []),
+  ], [canViewSalary, isOwner, isOwnerOrManager, copyValue]);
 
   const inputClass = 'w-full px-3 py-2 border border-input rounded-lg text-sm outline-hidden focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background';
   const selectClass = `${inputClass}`;
@@ -1342,6 +1372,17 @@ export default function CustomersPage() {
         </div>
       </div>
       )}
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+        title="ลบลูกค้า"
+        description={deleteTarget ? `ต้องการลบลูกค้า "${deleteTarget.name}" ใช่หรือไม่? การลบจะไม่สามารถกู้คืนได้จากหน้าจอ หากลูกค้ามีสัญญาที่ยังเปิดอยู่จะไม่สามารถลบได้` : ''}
+        confirmLabel="ลบ"
+        variant="destructive"
+        loading={deleteMutation.isPending}
+        onConfirm={() => { if (deleteTarget) deleteMutation.mutate(deleteTarget.id); }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restrict `DELETE /customers/:id` to OWNER role (was OWNER + BRANCH_MANAGER)
- Block soft-delete if customer has ACTIVE / OVERDUE / DEFAULT contracts — throws `BadRequestException` with Thai message
- Add trash-icon action column to CustomersPage (OWNER only) with ConfirmDialog + toast error surfacing backend block message

## Test plan
- [x] Backend: 16/16 tests pass (added 2 for `remove()`)
- [x] `./tools/check-types.sh all` passes
- [ ] Manual: OWNER ลบลูกค้าไม่มีสัญญา → สำเร็จ
- [ ] Manual: OWNER ลบลูกค้ามีสัญญา ACTIVE → error message "ไม่สามารถลบลูกค้าได้: มีสัญญาที่ยังเปิดอยู่ N สัญญา"
- [ ] Manual: BRANCH_MANAGER / อื่นๆ ไม่เห็นปุ่มลบ + API ตอบ 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)