### PR TITLE
fix(payment-link): fall back to FRONTEND_URL, not placeholder domain

### DIFF
--- a/apps/api/src/modules/line-oa/payment-links/payment-link.service.ts
+++ b/apps/api/src/modules/line-oa/payment-links/payment-link.service.ts
@@ -14,7 +14,13 @@ export class PaymentLinkService {
     private configService: ConfigService,
     private prisma: PrismaService,
   ) {
-    this.baseUrl = this.configService.get<string>('PAYMENT_LINK_BASE_URL') || 'https://bestchoice.example.com';
+    // Fall back to FRONTEND_URL (always set in prod) before the placeholder —
+    // missing PAYMENT_LINK_BASE_URL previously produced bestchoice.example.com
+    // links that LINE's in-app browser failed to resolve.
+    this.baseUrl =
+      this.configService.get<string>('PAYMENT_LINK_BASE_URL') ||
+      this.configService.get<string>('FRONTEND_URL') ||
+      'http://localhost:5173';
     this.expiryHours = 24; // Payment links expire in 24 hours
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #675. After LIFF early-payoff page loaded correctly, tapping "ชำระเพื่อปิดสัญญาทันที" still produced LINE's "cannot open page" — the button redirects to `result.url` from `POST /line-oa/liff/early-payoff`, which builds links as `${PAYMENT_LINK_BASE_URL}/pay/{token}`.

- `PAYMENT_LINK_BASE_URL` is not configured in Cloud Run env
- Fallback was hard-coded `'https://bestchoice.example.com'` — a placeholder domain that fails DNS
- LINE's WebView shows the generic network error when the link target can't resolve

`FRONTEND_URL` is already set to `https://bestchoicephone.app` in prod. Use it as the secondary fallback so links go to the real domain. Dev default moves to `http://localhost:5173` to match `.env.example`.

## Test plan

- [ ] Deploy to prod
- [ ] Open /liff/early-payoff in LINE → tap "ชำระเพื่อปิดสัญญาทันที" → `/pay/{token}` opens
- [ ] Payment page renders with correct amount + contract info

🤖 Generated with [Claude Code](https://claude.com/claude-code)