### PR TITLE
fix(liff-pay): use link.amount so early-payoff shows full payoff total

### DIFF
--- a/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
@@ -523,7 +523,11 @@ export class LineOaPaymentController {
 
     const payment = link.payment!;
     const contract = link.contract;
-    const amount = sumOutstanding(payment);
+    // Use link.amount (authoritative) — createPaymentLink honors the
+    // overrideAmount for early-payoff links. Recomputing from the linked
+    // installment would return the single-installment total, not the full
+    // payoff amount.
+    const amount = d(link.amount);
 
     // Generate PromptPay QR as data URL for the LIFF page
     let qrDataUrl: string | null = null;


### PR DESCRIPTION
## Summary

Follow-up to #676. After fixing the payment link domain, tapping "ชำระเพื่อปิดสัญญา" opened the PayPage but showed ฿2,729 (first installment) instead of ฿27,961.19 (full early-payoff with 50% discount).

`resolvePaymentLink` was calling `sumOutstanding(payment)` on the linked installment, ignoring `link.amount` — which `createPaymentLink` stores honoring the `overrideAmount` passed by the early-payoff flow. Fix: read `link.amount` directly.

Affects: displayed amount on /pay/{token}, PromptPay QR value, "ชำระเงิน {amount} บาท" button.

## Test plan

- [ ] Deploy to prod
- [ ] Open /liff/early-payoff → confirm payoff quote ฿27,961.19
- [ ] Tap "ชำระเพื่อปิดสัญญาทันที" → `/pay/{token}` should show ฿27,961.19
- [ ] PromptPay QR should encode ฿27,961.19
- [ ] Per-installment payment flow (non-early-payoff) still shows correct installment amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)