### PR TITLE
fix(liff,paysolutions): close all installments on early-payoff + session cache

### DIFF
--- a/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
@@ -669,7 +669,11 @@ export class LineOaPaymentController {
           where: { contractId: linkContract.id, status: 'PAID' },
         });
         const totalInstallments = linkContract.totalMonths;
-        const amount = body.amount ? d(body.amount) : sumOutstanding(payment);
+        // Prefer body.amount from the LIFF form → fall back to link.amount
+        // (authoritative; honors early-payoff override). Avoid sumOutstanding
+        // on the linked installment because that returns the per-installment
+        // total for early-payoff links.
+        const amount = body.amount ? d(body.amount) : d(link.amount);
 
         const flex = this.lineOaService.buildPaymentSuccess({
           customerName: linkContract.customer.name,

--- a/apps/api/src/modules/paysolutions/paysolutions.module.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.module.ts
@@ -6,9 +6,16 @@ import { PaySolutionsController } from './paysolutions.controller';
 import { PaySolutionsService } from './paysolutions.service';
 import { LiffTokenGuard } from '../line-oa/guards/liff-token.guard';
 import { ShopOrdersModule } from '../shop-orders/shop-orders.module';
+import { ProductsModule } from '../products/products.module';
 
 @Module({
-  imports: [PrismaModule, LineOaModule, IntegrationsModule, forwardRef(() => ShopOrdersModule)],
+  imports: [
+    PrismaModule,
+    LineOaModule,
+    IntegrationsModule,
+    forwardRef(() => ShopOrdersModule),
+    ProductsModule,
+  ],
   controllers: [PaySolutionsController],
   providers: [PaySolutionsService, LiffTokenGuard],
   exports: [PaySolutionsService],

--- a/apps/api/src/modules/paysolutions/paysolutions.service.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.ts
@@ -21,8 +21,10 @@ import { Prisma, PaymentMethod } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { LineOaService } from '../line-oa/line-oa.service';
 import { buildPaymentSuccessFlex } from '../line-oa/flex-messages/payment-success.flex';
+import { buildEarlyPayoffSuccessFlex } from '../line-oa/flex-messages/early-payoff-success.flex';
 import { FlexMessagePayload } from '../line-oa/flex-messages/base-template';
 import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { ProductsService } from '../products/products.service';
 
 export interface PaymentIntentResult {
   paymentId: string;
@@ -53,6 +55,7 @@ export class PaySolutionsService {
     private integrationConfig: IntegrationConfigService,
     @Inject(forwardRef(() => OnlineOrderSaleAdapter))
     private saleAdapter: OnlineOrderSaleAdapter,
+    private productsService: ProductsService,
   ) {
     this.returnUrl = this.config.get<string>('PAYSOLUTIONS_RETURN_URL', '');
     this.apiBaseUrl = this.config.get<string>(
@@ -684,37 +687,159 @@ export class PaySolutionsService {
     const isSuccess = result_code === '00';
 
     if (isSuccess) {
-      // ชำระสำเร็จ
-      await this.prisma.$transaction(async (tx) => {
-        // อัปเดต PaymentLink
-        await tx.paymentLink.update({
-          where: { id: paymentLink.id },
-          data: { status: 'USED', usedAt: new Date() },
-        });
+      // Safely parse the webhook `total`. Falls back to the link's stored
+      // amount (authoritative for early-payoff links) when the wire value
+      // is malformed or absent.
+      let paidAmount: Prisma.Decimal;
+      try {
+        paidAmount =
+          total && !isNaN(Number(total)) && Number.isFinite(Number(total))
+            ? new Prisma.Decimal(total)
+            : paymentLink.amount;
+      } catch {
+        paidAmount = paymentLink.amount;
+      }
 
-        // อัปเดต Payment record ถ้ามี
-        if (paymentLink.paymentId) {
-          await tx.payment.update({
-            where: { id: paymentLink.paymentId },
-            data: {
-              status: 'PAID',
-              amountPaid: total && !isNaN(Number(total)) ? new Prisma.Decimal(total) : paymentLink.amount,
-              paidDate: new Date(),
-              paidAt: new Date(),
-              paymentMethod: PaymentMethod.ONLINE_GATEWAY,
-              gatewayRef: refno,
-              gatewayStatus: 'SUCCESS',
-              gatewayResponse: webhookData as object,
-              notes: `ชำระผ่าน Pay Solutions (${transaction_id || refno})`,
+      // ชำระสำเร็จ — distribute paid amount FIFO across unpaid installments.
+      // Early-payoff links carry amount = full payoff (with discount) and
+      // must close every pending installment, not just paymentLink.paymentId.
+      // Single-installment payments behave identically: one installment ends
+      // up fully paid, subsequent iterations stop at remaining <= 0.
+      //
+      // Serializable isolation matches contract-payment.earlyPayoff so two
+      // concurrent webhook retries cannot read stale amountPaid and
+      // double-credit an installment. The updateMany gate on `status: ACTIVE`
+      // is the belt-and-suspenders claim — only one transaction wins.
+      const result = await this.prisma.$transaction(
+        async (tx) => {
+          const claim = await tx.paymentLink.updateMany({
+            where: { id: paymentLink.id, status: 'ACTIVE' },
+            data: { status: 'USED', usedAt: new Date() },
+          });
+          if (claim.count === 0) {
+            return { alreadyClaimed: true as const };
+          }
+
+          const unpaidPayments = await tx.payment.findMany({
+            where: {
+              contractId: paymentLink.contractId!,
+              status: { not: 'PAID' },
+              deletedAt: null,
+            },
+            orderBy: { installmentNo: 'asc' },
+          });
+
+          let remaining = paidAmount;
+          const now = new Date();
+          let fullyPaidCount = 0;
+          for (const payment of unpaidPayments) {
+            if (remaining.lte(0)) break;
+            // lateFeeWaived=true sets lateFee=0 elsewhere, so reading lateFee
+            // directly is equivalent — we keep the guard explicit to be
+            // defensive against future model changes.
+            const lateFee = payment.lateFeeWaived
+              ? new Prisma.Decimal(0)
+              : payment.lateFee;
+            const owed = payment.amountDue.add(lateFee).sub(payment.amountPaid);
+            if (owed.lte(0)) continue;
+
+            const payThis = Prisma.Decimal.min(remaining, owed);
+            remaining = remaining.sub(payThis);
+            const newAmountPaid = payment.amountPaid.add(payThis).toDecimalPlaces(2);
+            const fullyPaid = newAmountPaid.gte(payment.amountDue.add(lateFee));
+
+            await tx.payment.update({
+              where: { id: payment.id },
+              data: {
+                amountPaid: newAmountPaid,
+                status: fullyPaid ? 'PAID' : 'PARTIALLY_PAID',
+                ...(fullyPaid ? { paidDate: now, paidAt: now } : {}),
+                paymentMethod: PaymentMethod.ONLINE_GATEWAY,
+                gatewayRef: refno,
+                gatewayStatus: 'SUCCESS',
+                gatewayResponse: webhookData as object,
+                notes: `ชำระผ่าน Pay Solutions (${transaction_id || refno})${
+                  unpaidPayments.length > 1 && fullyPaid ? ' [ปิดก่อนกำหนด]' : ''
+                }`,
+              },
+            });
+            if (fullyPaid) fullyPaidCount++;
+          }
+
+          // Close the contract when no installments remain. EARLY_PAYOFF
+          // only when a single webhook closed >1 installments at once (the
+          // discount-bearing LIFF flow). A normal last-installment payment
+          // that happens to zero the ledger gets COMPLETED instead — matches
+          // payments.service.checkContractCompletion semantics so dashboard
+          // queries (COMPLETED vs EARLY_PAYOFF) stay consistent.
+          const stillUnpaid = await tx.payment.count({
+            where: {
+              contractId: paymentLink.contractId!,
+              status: { not: 'PAID' },
+              deletedAt: null,
             },
           });
-        }
-      });
 
-      this.logger.log(`Payment SUCCESS: refno=${refno}, contractId=${paymentLink.contractId}`);
+          let contractStatus: 'EARLY_PAYOFF' | 'COMPLETED' | null = null;
+          if (stillUnpaid === 0) {
+            contractStatus = fullyPaidCount > 1 ? 'EARLY_PAYOFF' : 'COMPLETED';
+            const updated = await tx.contract.update({
+              where: { id: paymentLink.contractId! },
+              data: {
+                status: contractStatus,
+                ...(contractStatus === 'EARLY_PAYOFF' ? { creditBalance: 0 } : {}),
+              },
+              select: { productId: true },
+            });
+            if (updated.productId) {
+              try {
+                await this.productsService.transferOwnership(
+                  updated.productId,
+                  null,
+                  tx,
+                );
+              } catch (err) {
+                this.logger.error(
+                  `Failed to release product ownership for contract ${paymentLink.contractId}: ${err instanceof Error ? err.message : err}`,
+                );
+              }
+            }
+          }
 
-      // ส่ง LINE notification แจ้งลูกค้า
-      await this.sendPaymentSuccessNotification(paymentLink.contractId, paymentLink.paymentId);
+          return {
+            alreadyClaimed: false as const,
+            contractStatus,
+            fullyPaidCount,
+            totalUnpaidAtStart: unpaidPayments.length,
+          };
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+
+      if (result.alreadyClaimed) {
+        this.logger.log(
+          `Payment webhook refno=${refno}: link already claimed by prior retry — idempotent skip`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Payment SUCCESS: refno=${refno}, contractId=${paymentLink.contractId}, contractStatus=${result.contractStatus ?? 'ACTIVE'}, fullyPaid=${result.fullyPaidCount}/${result.totalUnpaidAtStart}`,
+      );
+
+      // Route notification: multi-installment close = early-payoff flex;
+      // everything else uses the existing single-installment flex.
+      if (result.contractStatus === 'EARLY_PAYOFF') {
+        await this.sendEarlyPayoffSuccessNotification(
+          paymentLink.contractId,
+          paidAmount,
+        );
+      } else {
+        await this.sendPaymentSuccessNotification(
+          paymentLink.contractId,
+          paymentLink.paymentId,
+        );
+      }
     } else {
       // ชำระไม่สำเร็จ
       if (paymentLink.paymentId) {
@@ -779,6 +904,51 @@ export class PaySolutionsService {
     } catch (err) {
       // ไม่ให้ notification error ทำให้ webhook fail
       this.logger.error(`Failed to send LINE notification: ${err}`);
+    }
+  }
+
+  /**
+   * ส่ง LINE flex message แจ้งลูกค้าว่าปิดยอดก่อนกำหนดสำเร็จ
+   * Used when a single PaySolutions payment closed multiple installments
+   * (via the 50%-discount LIFF early-payoff flow).
+   */
+  private async sendEarlyPayoffSuccessNotification(
+    contractId: string,
+    paidAmount: Prisma.Decimal,
+  ): Promise<void> {
+    try {
+      const contract = await this.prisma.contract.findUnique({
+        where: { id: contractId },
+        include: {
+          customer: { select: { name: true, lineId: true } },
+          payments: { where: { deletedAt: null } },
+        },
+      });
+      if (!contract?.customer.lineId) return;
+
+      // "Original amount" — what the customer would have paid without the
+      // early-payoff discount (sum of all installment totals incl. lateFee).
+      const originalAmount = contract.payments.reduce((acc, p) => {
+        const lateFee = p.lateFeeWaived ? new Prisma.Decimal(0) : p.lateFee;
+        return acc.add(p.amountDue).add(lateFee);
+      }, new Prisma.Decimal(0));
+      const savings = Prisma.Decimal.max(originalAmount.sub(paidAmount), new Prisma.Decimal(0));
+
+      const flex = buildEarlyPayoffSuccessFlex({
+        customerName: contract.customer.name,
+        contractNumber: contract.contractNumber,
+        amountPaid: Number(paidAmount),
+        originalAmount: Number(originalAmount),
+        savings: Number(savings),
+        payoffDate: formatDateLong(new Date()),
+      });
+
+      await this.lineOaService.sendFlexMessage(contract.customer.lineId, flex);
+      this.logger.log(
+        `Early-payoff notification sent for contract ${contract.contractNumber}`,
+      );
+    } catch (err) {
+      this.logger.error(`Failed to send early-payoff notification: ${err}`);
     }
   }
 

--- a/apps/web/src/hooks/useLiffInit.ts
+++ b/apps/web/src/hooks/useLiffInit.ts
@@ -17,13 +17,73 @@ interface UseLiffInitResult {
   error: string | null;
 }
 
+// Session cache — survives SPA navigation within the same tab so navigating
+// between LIFF pages (e.g. /liff/contract → /liff/early-payoff) does not
+// re-trigger LIFF SDK init or an OAuth round-trip. Cleared when the tab is
+// closed; also cleared by the axios 401 handler if the server rejects the
+// cached id_token (see lib/api.ts).
+//
+// A cachedAt timestamp bounds staleness on the client too — LIFF/OAuth
+// id_tokens are valid for ~1 hour so we treat entries older than 50 minutes
+// as expired and fall through to a fresh login.
+const SESSION_CACHE_KEY = 'bcp_liff_session_v1';
+const SESSION_CACHE_TTL_MS = 50 * 60 * 1000;
+
+interface SessionCache {
+  lineId: string;
+  idToken: string;
+  profile: LiffProfile;
+  cachedAt: number;
+}
+
+function readSessionCache(): SessionCache | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as SessionCache;
+    if (!parsed.lineId || !parsed.idToken || !parsed.profile || !parsed.cachedAt) return null;
+    if (Date.now() - parsed.cachedAt > SESSION_CACHE_TTL_MS) {
+      sessionStorage.removeItem(SESSION_CACHE_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionCache(cache: Omit<SessionCache, 'cachedAt'>): void {
+  try {
+    sessionStorage.setItem(
+      SESSION_CACHE_KEY,
+      JSON.stringify({ ...cache, cachedAt: Date.now() }),
+    );
+  } catch {
+    // sessionStorage unavailable — fall through; next page will just re-auth
+  }
+}
+
+/**
+ * Invalidate the LIFF session cache. Call from lib/api.ts on 401 so a stale
+ * id_token triggers a fresh OAuth round-trip on the next page mount instead
+ * of looping through failed API calls, and from future logout UI.
+ */
+export function clearLiffSessionCache(): void {
+  try {
+    sessionStorage.removeItem(SESSION_CACHE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 /**
  * Initialize LINE identity — works in both LIFF (LINE app) and regular browsers.
  *
  * Priority:
- * 1. LINE Login callback params (line_login=true in URL) — browser fallback
- * 2. LIFF SDK init — inside LINE app
- * 3. Redirect to LINE Login OAuth — browser fallback when LIFF fails
+ * 1. Session cache — reuse identity set by a prior page in the same tab
+ * 2. LINE Login callback params (line_login=true in URL) — browser fallback
+ * 3. LIFF SDK init — inside LINE app
+ * 4. Redirect to LINE Login OAuth — browser fallback when LIFF fails
  */
 export function useLiffInit(): UseLiffInitResult {
   const [lineId, setLineId] = useState('');
@@ -37,7 +97,19 @@ export function useLiffInit(): UseLiffInitResult {
 
     async function init() {
       try {
-        // ─── Check LINE Login callback params first ───
+        // ─── Session cache first — avoids re-auth when navigating between LIFF pages ───
+        const cached = readSessionCache();
+        if (cached) {
+          if (!cancelled) {
+            setLineId(cached.lineId);
+            setIdToken(cached.idToken);
+            setLiffIdToken(cached.idToken);
+            setProfile(cached.profile);
+          }
+          return;
+        }
+
+        // ─── Check LINE Login callback params ───
         const params = new URLSearchParams(window.location.search);
 
         if (params.get('login_error') === 'true') {
@@ -71,11 +143,18 @@ export function useLiffInit(): UseLiffInitResult {
               return;
             }
 
+            const profileValue: LiffProfile = {
+              userId,
+              displayName,
+              pictureUrl: pictureUrl || undefined,
+            };
+            writeSessionCache({ lineId: userId, idToken: lineIdToken, profile: profileValue });
+
             if (!cancelled) {
               setLineId(userId);
               setIdToken(lineIdToken);
               setLiffIdToken(lineIdToken);
-              setProfile({ userId, displayName, pictureUrl: pictureUrl || undefined });
+              setProfile(profileValue);
             }
             return;
           }
@@ -119,11 +198,18 @@ export function useLiffInit(): UseLiffInitResult {
             return;
           }
 
+          const profileValue: LiffProfile = {
+            userId: p.userId,
+            displayName: p.displayName,
+            pictureUrl: p.pictureUrl,
+          };
+          writeSessionCache({ lineId: p.userId, idToken: token, profile: profileValue });
+
           if (!cancelled) {
             setLineId(p.userId);
             setIdToken(token);
             setLiffIdToken(token);
-            setProfile({ userId: p.userId, displayName: p.displayName, pictureUrl: p.pictureUrl });
+            setProfile(profileValue);
           }
         } else {
           // Either LIFF_ID not configured, or current URL is not under the

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -186,6 +186,16 @@ liffApi.interceptors.response.use(
   },
   (error) => {
     const status = error?.response?.status;
+    // 401 from a LIFF endpoint means the cached id_token was rejected (expired
+    // or revoked). Clear the session cache so the next page mount bounces
+    // through a fresh OAuth instead of serving stale credentials forever.
+    if (status === 401) {
+      liffIdToken = null;
+      // Dynamic import avoids circular dependency with useLiffInit.
+      import('@/hooks/useLiffInit')
+        .then(({ clearLiffSessionCache }) => clearLiffSessionCache())
+        .catch(() => { /* module unavailable during dev HMR — ignore */ });
+    }
     if (status && status >= 500) {
       // Dynamically import Sentry to avoid bundling it if not configured
       import('@sentry/react').then((Sentry) => {


### PR DESCRIPTION
## Summary

Completes the LIFF early-payoff fix chain (after #675 / #676 / #677). Three related fixes:

### 1. PaySolutions webhook — close all installments on multi-installment payoff (CRITICAL)

Before: A ฿27,961 early-payoff payment arriving via webhook only marked installment 1 (฿2,729) as PAID — installments 2–12 stayed PENDING and the customer kept getting overdue notices despite having closed the contract. The webhook ignored `paymentLink.amount` and operated only on the single linked `payment.id`.

After: FIFO-distribute the paid amount across all unpaid installments, close the contract when zero remain.

- **Isolation**: `Prisma.TransactionIsolationLevel.Serializable` + `updateMany status=ACTIVE` gate prevents concurrent webhook retries from double-crediting.
- **Per-installment status**: writes `PARTIALLY_PAID` for short-pay edges (previously left PENDING with amountPaid > 0 — invisible to reports).
- **Contract status transition**: `EARLY_PAYOFF` when >1 installment closed in one payment; `COMPLETED` when it's just the final installment. Matches `contract-payment.earlyPayoff` and `payments.checkContractCompletion` semantics so dashboard/tier/PDPA queries stay consistent.
- **Product ownership release**: uses `productsService.transferOwnership(productId, null, tx)` for logging + NotFoundException guard (not raw `tx.product.update`).
- **Notification routing**: `buildEarlyPayoffSuccessFlex` when multi-installment close, existing `buildPaymentSuccessFlex` otherwise — customer sees the right savings total, not งวดที่ 1 wording.

### 2. Slip-upload notification — use link.amount

`apps/api/src/modules/line-oa/line-oa-payment.controller.ts:672` now falls back to `d(link.amount)` instead of `sumOutstanding(payment)`. Same pattern as #677 (resolvePaymentLink).

### 3. useLiffInit session cache

Stores `{lineId, idToken, profile, cachedAt}` in `sessionStorage` (TTL 50 min, under id_token's ~1-hour expiry). Subsequent LIFF page mounts in the same tab reuse the identity instead of round-tripping through OAuth every time. `clearLiffSessionCache()` is exported; the `liffApi` 401 interceptor calls it so a rejected id_token doesn't loop.

## Test plan

- [ ] Deploy
- [ ] Open /liff/early-payoff → pay ฿27,961.19 via PaySolutions → PaySolutions webhook fires → verify:
  - All 12 installments show PAID in admin
  - Contract status = EARLY_PAYOFF
  - Product ownedByCompanyId = null
  - Customer gets early-payoff flex (not งวดที่ 1 flex)
- [ ] Normal per-installment payment still works (single installment PAID, contract stays ACTIVE, no flex change)
- [ ] Paying the LAST installment normally closes contract as COMPLETED (not EARLY_PAYOFF)
- [ ] Navigate /liff/contract → /liff/early-payoff → /liff/history in LINE — verify no OAuth redirect between pages (session cache hit)

## Code review status

Code-reviewer agent flagged 6 Critical + 6 Warnings on the initial draft; all 6 Critical + W1 (safe Decimal parse) + W4 (cache TTL + 401 invalidation) + W5 (exported clearLiffSessionCache) are addressed in this PR. Lower-severity info (I1/I2/I3) and W2/W3/W6 deemed not worth the extra code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)