### PR TITLE
fix(liff-pay): drop installmentNo from create-intent for early-payoff

### DIFF
--- a/apps/web/src/pages/liff/LiffPayment.tsx
+++ b/apps/web/src/pages/liff/LiffPayment.tsx
@@ -169,7 +169,11 @@ export default function LiffPayment() {
         amount: Number(data.amount),
         description: `ชำระค่างวด สัญญา ${data.contract.contractNumber}`,
         lineId: queryLineId || undefined,
-        installmentNo: data.payment?.installmentNo,
+        // Only pass installmentNo for single-installment payments. Early-payoff
+        // links cover multiple installments — backend validates amount against
+        // the single linked installment's outstanding when installmentNo is
+        // present and would reject the full payoff as "ยอดไม่ตรง".
+        installmentNo: isMultiInstallment ? undefined : data.payment?.installmentNo,
       };
       const { data: result } = await liffApi.post<PaymentIntentResult>(
         '/paysolutions/create-intent',


### PR DESCRIPTION
## Summary

User reported 400 on "สแกนจ่าย ฿27,961.19" tap. Root cause: frontend was sending `installmentNo: 1` together with `amount: 27961.19`. Backend `paysolutions.service.ts:141-147` validates:

\`\`\`ts
if (installmentNo) {
  // ...
  const expectedAmount = dSub(dAdd(paymentRecord.amountDue, paymentRecord.lateFee), paymentRecord.amountPaid);
  if (!dClose(amount, expectedAmount)) {
    throw new BadRequestException('ยอดชำระไม่ตรง: ส่งมา ... แต่ยอดค้างจริง ...');
  }
}
\`\`\`

Installment 1's outstanding is ฿2,729, not the full ฿27,961 payoff → validation fails → 400.

Fix: send `installmentNo` only when `isMultiInstallment === false`. Backend then skips the per-installment check and creates the PaymentLink with `paymentId: null`, which the FIFO webhook handler from #678 processes correctly.

## Test plan

- [ ] Deploy
- [ ] Flow: /liff/early-payoff → tap ชำระเพื่อปิดสัญญา → /pay/{token} → tap สแกนจ่าย ฿27,961.19 → no 400 → redirects to Pay Solutions
- [ ] Normal single-installment flow still sends installmentNo and backend still validates amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)