### PR TITLE
feat(liff-early-payoff): skip /pay/{token} landing, jump to PaySolutions

### DIFF
--- a/apps/web/src/pages/liff/LiffEarlyPayoff.tsx
+++ b/apps/web/src/pages/liff/LiffEarlyPayoff.tsx
@@ -67,11 +67,27 @@ export default function LiffEarlyPayoff() {
 
   const payoffMutation = useMutation({
     mutationFn: async () => {
-      const { data: result } = await liffApi.post('/line-oa/liff/early-payoff', { lineId, contractId });
-      return result as { url: string; token: string; totalPayoff: number };
+      if (!quote) throw new Error('ไม่พบข้อมูลยอดปิดสัญญา');
+      // Skip the intermediate /pay/{token} landing page and the old
+      // /line-oa/liff/early-payoff hop (which only minted a PaymentLink
+      // shell). Call PaySolutions directly — the hosted QR is the real
+      // terminal step anyway. installmentNo is intentionally omitted so
+      // backend skips per-installment amount validation (the payoff
+      // amount intentionally exceeds any single installment).
+      const { data: intent } = await liffApi.post('/paysolutions/create-intent', {
+        contractId,
+        amount: Number(quote.totalPayoff),
+        description: `ปิดยอดก่อนกำหนด สัญญา ${quote.contractNumber}`,
+        lineId,
+      });
+      return intent as { success: boolean; paymentId: string; paymentUrl: string; gatewayRef: string };
     },
     onSuccess: (result) => {
-      window.location.href = result.url;
+      if (result.paymentUrl) {
+        window.location.href = result.paymentUrl;
+      } else {
+        toast.error('ไม่สามารถสร้างลิงก์ชำระเงินได้ กรุณาลองใหม่');
+      }
     },
     onError: (err: Error) => {
       toast.error(err.message);


### PR DESCRIPTION
## Summary

User requested shortening the early-payoff flow. Old sequence:

\`\`\`
/liff/early-payoff
  → POST /line-oa/liff/early-payoff (creates PaymentLink shell)
  → /pay/{token} (shows summary + scan-to-pay CTA)
  → tap "สแกนจ่าย"
  → POST /paysolutions/create-intent (creates real gateway intent)
  → PaySolutions hosted QR
\`\`\`

New sequence:

\`\`\`
/liff/early-payoff
  → POST /paysolutions/create-intent (with quote.totalPayoff)
  → PaySolutions hosted QR
\`\`\`

The `/line-oa/liff/early-payoff` endpoint's only job was minting a PaymentLink shell — `create-intent` creates its own PaymentLink atomically, so the middle hop is dead weight. One fewer round-trip, one fewer page render.

`installmentNo` is intentionally omitted so the backend skips per-installment amount validation (payoff amount exceeds any single installment by design, same reason as #680).

## Test plan

- [ ] Deploy
- [ ] Open /liff/early-payoff → tap "ชำระเพื่อปิดสัญญาทันที" → goes straight to Pay Solutions QR (no intermediate /pay page)
- [ ] Complete payment → webhook closes all installments + sets contract EARLY_PAYOFF
- [ ] Customer receives "ปิดยอดสำเร็จ" flex

🤖 Generated with [Claude Code](https://claude.com/claude-code)