### PR TITLE
fix(hosting): no-cache on SPA HTML so deploys take effect immediately

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -37,7 +37,8 @@
             { "key": "X-Content-Type-Options", "value": "nosniff" },
             { "key": "X-XSS-Protection", "value": "1; mode=block" },
             { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-            { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+            { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
           ]
         }
       ]
@@ -79,7 +80,8 @@
             { "key": "X-Content-Type-Options", "value": "nosniff" },
             { "key": "X-XSS-Protection", "value": "1; mode=block" },
             { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-            { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+            { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+            { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
           ]
         }
       ]


### PR DESCRIPTION
## Summary

Firebase Hosting defaults to \`max-age=3600\` when no Cache-Control is set. The generic \`**\` rule set security headers but no Cache-Control, so every SPA route (\`/\`, \`/liff/*\`, \`/pay/*\`) was cached for 1 hour in LINE's in-app WebView and the Fastly edge. The #681 direct-to-PaySolutions redesign was deployed correctly but users hitting the app within the hour got the cached old HTML still pointing at the previous LiffEarlyPayoff chunk.

Adds \`Cache-Control: no-cache, no-store, must-revalidate\` to the default \`**\` rule on both admin and shop hosting targets. JS/CSS/images keep their immutable max-age=2592000 from the asset-specific rules — hash-stamped filenames make that safe.

## Test plan

- [ ] Deploy
- [ ] Verify \`curl -sI https://bestchoicephone.app/liff/early-payoff\` shows \`cache-control: no-cache, no-store, must-revalidate\`
- [ ] \`/assets/*.js\` still shows \`cache-control: public, max-age=2592000, immutable\`
- [ ] Re-test #681 early-payoff flow — should bypass /pay/{token} on first tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)