### PR TITLE
feat(collections): Plan 2/4 workflow hub — 5-tab UI + backend queue/KPI/MDM endpoints

### DIFF
--- a/apps/api/prisma/seeds/collections-foundation.seed.ts
+++ b/apps/api/prisma/seeds/collections-foundation.seed.ts
@@ -167,8 +167,13 @@ export async function seedCollectionsFoundation(
     });
   }
 
-  // 9 SystemConfig keys for MDM + letter settings
+  // 10 SystemConfig keys: collections flag + MDM + letter settings
   const mdmLetterConfigs: Array<{ key: string; value: string; label: string }> = [
+    {
+      key: 'collections_v2_enabled',
+      value: 'false',
+      label: 'เปิดใช้งานหน้า /collections (Workflow Hub ใหม่) — Plan 2',
+    },
     {
       key: 'mdm_auto_propose_enabled',
       value: 'true',

--- a/apps/api/src/modules/overdue/__tests__/collections-foundation.seed.spec.ts
+++ b/apps/api/src/modules/overdue/__tests__/collections-foundation.seed.spec.ts
@@ -21,10 +21,16 @@ describe('seedCollectionsFoundation', () => {
       where: { eventTrigger: { not: null } },
     });
     const configs1 = await prisma.systemConfig.count({
-      where: { OR: [{ key: { startsWith: 'mdm_' } }, { key: { startsWith: 'letter_' } }] },
+      where: {
+        OR: [
+          { key: 'collections_v2_enabled' },
+          { key: { startsWith: 'mdm_' } },
+          { key: { startsWith: 'letter_' } },
+        ],
+      },
     });
     expect(rules1).toBe(8);
-    expect(configs1).toBe(9);
+    expect(configs1).toBe(10);
 
     // Run seed a second time — counts must not change
     await seedCollectionsFoundation(prisma);
@@ -33,9 +39,15 @@ describe('seedCollectionsFoundation', () => {
       where: { eventTrigger: { not: null } },
     });
     const configs2 = await prisma.systemConfig.count({
-      where: { OR: [{ key: { startsWith: 'mdm_' } }, { key: { startsWith: 'letter_' } }] },
+      where: {
+        OR: [
+          { key: 'collections_v2_enabled' },
+          { key: { startsWith: 'mdm_' } },
+          { key: { startsWith: 'letter_' } },
+        ],
+      },
     });
     expect(rules2).toBe(8);
-    expect(configs2).toBe(9);
+    expect(configs2).toBe(10);
   });
 });

--- a/apps/api/src/modules/overdue/dto/kpi-query.dto.ts
+++ b/apps/api/src/modules/overdue/dto/kpi-query.dto.ts
@@ -1,0 +1,7 @@
+import { IsIn, IsOptional } from 'class-validator';
+
+export class KpiQueryDto {
+  @IsOptional()
+  @IsIn(['7d', '30d'], { message: 'range ต้องเป็น 7d หรือ 30d' })
+  range?: '7d' | '30d';
+}

--- a/apps/api/src/modules/overdue/dto/queue-query.dto.ts
+++ b/apps/api/src/modules/overdue/dto/queue-query.dto.ts
@@ -1,0 +1,24 @@
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueueQueryDto {
+  @IsEnum(['today', 'followup', 'promise'], { message: 'tab ต้องเป็น today, followup, หรือ promise' })
+  tab!: 'today' | 'followup' | 'promise';
+
+  @IsOptional()
+  @IsString()
+  branchId?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/apps/api/src/modules/overdue/dto/queue-query.dto.ts
+++ b/apps/api/src/modules/overdue/dto/queue-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class QueueQueryDto {
@@ -8,6 +8,12 @@ export class QueueQueryDto {
   @IsOptional()
   @IsString()
   branchId?: string;
+
+  /** C1: server-side search by customer name / contractNumber / phone */
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  search?: string;
 
   @IsOptional()
   @Type(() => Number)

--- a/apps/api/src/modules/overdue/dto/reject-mdm.dto.ts
+++ b/apps/api/src/modules/overdue/dto/reject-mdm.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class RejectMdmDto {
+  @IsString({ message: 'กรุณาระบุเหตุผล' })
+  @IsNotEmpty({ message: 'กรุณาระบุเหตุผล' })
+  @MinLength(5, { message: 'เหตุผลต้องมีอย่างน้อย 5 ตัวอักษร' })
+  reason!: string;
+}

--- a/apps/api/src/modules/overdue/kpi.service.spec.ts
+++ b/apps/api/src/modules/overdue/kpi.service.spec.ts
@@ -1,0 +1,228 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { OverdueKpiService } from './kpi.service';
+
+const mockPrisma = {
+  payment: {
+    aggregate: jest.fn(),
+    findFirst: jest.fn(),
+  },
+  contract: {
+    count: jest.fn(),
+    groupBy: jest.fn(),
+  },
+  callLog: {
+    count: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+function setupDefaultMocks() {
+  mockPrisma.payment.aggregate.mockResolvedValue({
+    _sum: { amountDue: '1000000.00', amountPaid: '200000.00', lateFee: '45000.00' },
+  });
+  mockPrisma.contract.count.mockResolvedValue(34);
+  mockPrisma.callLog.count
+    .mockResolvedValueOnce(12) // promisedCount (future)
+    .mockResolvedValueOnce(5); // totalPromised (last 7d)
+  mockPrisma.callLog.findMany.mockResolvedValue([]); // no candidates → keptCount = 0
+  mockPrisma.contract.groupBy.mockResolvedValue([]);
+}
+
+describe('OverdueKpiService', () => {
+  let service: OverdueKpiService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OverdueKpiService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(OverdueKpiService);
+  });
+
+  describe('getKpi', () => {
+    it('returns all 7 required fields with correct types', async () => {
+      setupDefaultMocks();
+
+      const result = await service.getKpi({
+        range: '7d',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result).toHaveProperty('totalOutstanding');
+      expect(result).toHaveProperty('totalLateFees');
+      expect(result).toHaveProperty('queueToday');
+      expect(result).toHaveProperty('queueTodayTrend');
+      expect(result).toHaveProperty('promisedCount');
+      expect(result).toHaveProperty('promiseKeptRate7d');
+      expect(result).toHaveProperty('avgCollectorWorkload');
+
+      expect(typeof result.totalOutstanding).toBe('number');
+      expect(typeof result.totalLateFees).toBe('number');
+      expect(typeof result.queueToday).toBe('number');
+      expect(typeof result.queueTodayTrend).toBe('number');
+      expect(typeof result.promisedCount).toBe('number');
+      expect(typeof result.promiseKeptRate7d).toBe('number');
+      expect(typeof result.avgCollectorWorkload).toBe('number');
+
+      // Verify computed values
+      expect(result.totalOutstanding).toBe(800000); // 1000000 - 200000
+      expect(result.totalLateFees).toBe(45000);
+      expect(result.queueToday).toBe(34);
+      expect(result.queueTodayTrend).toBe(0); // placeholder
+      expect(result.promisedCount).toBe(12);
+    });
+
+    it('returns cached result on second call within 60s', async () => {
+      setupDefaultMocks();
+
+      const result1 = await service.getKpi({
+        range: '7d',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      // Second call — mocks should NOT be called again
+      const result2 = await service.getKpi({
+        range: '7d',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result1).toBe(result2); // same object reference (cached)
+      // payment.aggregate was called only once (not twice)
+      expect(mockPrisma.payment.aggregate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT use cache for different range (different cache key)', async () => {
+      setupDefaultMocks();
+      // Setup for second call
+      mockPrisma.payment.aggregate.mockResolvedValue({
+        _sum: { amountDue: '500000.00', amountPaid: '100000.00', lateFee: '20000.00' },
+      });
+      mockPrisma.contract.count.mockResolvedValue(20);
+      mockPrisma.callLog.count
+        .mockResolvedValueOnce(6)
+        .mockResolvedValueOnce(3);
+      mockPrisma.callLog.findMany.mockResolvedValue([]);
+      mockPrisma.contract.groupBy.mockResolvedValue([]);
+
+      await service.getKpi({ range: '7d', userRole: 'OWNER', userBranchId: null });
+      await service.getKpi({ range: '30d', userRole: 'OWNER', userBranchId: null });
+
+      // Both calls hit DB (different cache keys)
+      expect(mockPrisma.payment.aggregate).toHaveBeenCalledTimes(2);
+    });
+
+    it('SALES users get branch-scoped query — branchId filter applied', async () => {
+      setupDefaultMocks();
+
+      await service.getKpi({
+        range: '7d',
+        userRole: 'SALES',
+        userBranchId: 'branch-sales-1',
+      });
+
+      // Verify payment.aggregate was called with branchId in contract scope
+      const aggregateCall = mockPrisma.payment.aggregate.mock.calls[0][0];
+      expect(aggregateCall.where.contract.branchId).toBe('branch-sales-1');
+
+      // Verify contract.count was called with branchId
+      const countCall = mockPrisma.contract.count.mock.calls[0][0];
+      expect(countCall.where.branchId).toBe('branch-sales-1');
+    });
+
+    it('avgCollectorWorkload is 0 for non-OWNER roles (no groupBy query)', async () => {
+      setupDefaultMocks();
+
+      const result = await service.getKpi({
+        range: '7d',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+      });
+
+      expect(result.avgCollectorWorkload).toBe(0);
+      // groupBy should NOT have been called for BRANCH_MANAGER
+      expect(mockPrisma.contract.groupBy).not.toHaveBeenCalled();
+    });
+
+    it('avgCollectorWorkload computes correctly for OWNER with assigned contracts', async () => {
+      mockPrisma.payment.aggregate.mockResolvedValue({
+        _sum: { amountDue: '0', amountPaid: '0', lateFee: '0' },
+      });
+      mockPrisma.contract.count.mockResolvedValue(0);
+      mockPrisma.callLog.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0);
+      mockPrisma.callLog.findMany.mockResolvedValue([]);
+      mockPrisma.contract.groupBy.mockResolvedValue([
+        { assignedToId: 'user-1', _count: { _all: 10 } },
+        { assignedToId: 'user-2', _count: { _all: 20 } },
+      ]);
+
+      const result = await service.getKpi({
+        range: '7d',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.avgCollectorWorkload).toBe(15); // (10 + 20) / 2
+    });
+
+    it('promiseKeptRate7d is 0 when there are no promises in last 7d', async () => {
+      mockPrisma.payment.aggregate.mockResolvedValue({
+        _sum: { amountDue: '0', amountPaid: '0', lateFee: '0' },
+      });
+      mockPrisma.contract.count.mockResolvedValue(0);
+      mockPrisma.callLog.count
+        .mockResolvedValueOnce(0) // future promised
+        .mockResolvedValueOnce(0); // past 7d total = 0
+      mockPrisma.callLog.findMany.mockResolvedValue([]); // no candidates
+      mockPrisma.contract.groupBy.mockResolvedValue([]);
+
+      const result = await service.getKpi({
+        range: '7d',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.promiseKeptRate7d).toBe(0);
+    });
+
+    it('promiseKeptRate7d rounds to 2 decimal places', async () => {
+      const candidateDate = new Date(Date.now() - 2 * 86400000);
+      mockPrisma.payment.aggregate.mockResolvedValue({
+        _sum: { amountDue: '0', amountPaid: '0', lateFee: '0' },
+      });
+      mockPrisma.contract.count.mockResolvedValue(0);
+      mockPrisma.callLog.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(3); // 3 total promises
+      // 1 candidate (keptCandidates)
+      mockPrisma.callLog.findMany.mockResolvedValue([
+        { contractId: 'c1', settlementDate: candidateDate },
+        { contractId: 'c2', settlementDate: candidateDate },
+        { contractId: 'c3', settlementDate: candidateDate },
+      ]);
+      // 1 of 3 paid
+      mockPrisma.payment.findFirst
+        .mockResolvedValueOnce({ id: 'p1', status: 'PAID' }) // c1 paid
+        .mockResolvedValueOnce(null) // c2 not paid
+        .mockResolvedValueOnce(null); // c3 not paid
+      mockPrisma.contract.groupBy.mockResolvedValue([]);
+
+      const result = await service.getKpi({
+        range: '7d',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      // 1/3 = 0.333... → rounds to 0.33
+      expect(result.promiseKeptRate7d).toBe(0.33);
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/kpi.service.spec.ts
+++ b/apps/api/src/modules/overdue/kpi.service.spec.ts
@@ -6,6 +6,8 @@ const mockPrisma = {
   payment: {
     aggregate: jest.fn(),
     findFirst: jest.fn(),
+    // C3 fix: batched promise-kept lookup uses findMany instead of N+1 findFirst
+    findMany: jest.fn().mockResolvedValue([]),
   },
   contract: {
     count: jest.fn(),
@@ -202,17 +204,17 @@ describe('OverdueKpiService', () => {
       mockPrisma.callLog.count
         .mockResolvedValueOnce(0)
         .mockResolvedValueOnce(3); // 3 total promises
-      // 1 candidate (keptCandidates)
+      // 3 candidates (keptCandidates)
       mockPrisma.callLog.findMany.mockResolvedValue([
         { contractId: 'c1', settlementDate: candidateDate },
         { contractId: 'c2', settlementDate: candidateDate },
         { contractId: 'c3', settlementDate: candidateDate },
       ]);
-      // 1 of 3 paid
-      mockPrisma.payment.findFirst
-        .mockResolvedValueOnce({ id: 'p1', status: 'PAID' }) // c1 paid
-        .mockResolvedValueOnce(null) // c2 not paid
-        .mockResolvedValueOnce(null); // c3 not paid
+      // C3 fix: single findMany returns paid payments for all 3 contracts.
+      // Only c1 has a payment paid on/after settlementDate (kept); c2/c3 absent → broken.
+      mockPrisma.payment.findMany.mockResolvedValueOnce([
+        { contractId: 'c1', updatedAt: new Date(candidateDate.getTime() + 86400000) },
+      ]);
       mockPrisma.contract.groupBy.mockResolvedValue([]);
 
       const result = await service.getKpi({

--- a/apps/api/src/modules/overdue/kpi.service.ts
+++ b/apps/api/src/modules/overdue/kpi.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { bangkokStartOfDay } from '../../utils/date.util';
 
 export interface KpiResult {
   totalOutstanding: number;
@@ -61,8 +62,10 @@ export class OverdueKpiService {
   }) {
     const nowDate = new Date();
     const sevenDaysAgo = new Date(nowDate.getTime() - 7 * 86400000);
-    const today = new Date(nowDate);
-    today.setHours(0, 0, 0, 0);
+    // Use Bangkok-local midnight, not server-TZ midnight. On Cloud Run (UTC),
+    // setHours(0,0,0,0) flips the "today" boundary at 07:00 ICT — collectors
+    // would see yesterday's queue all morning.
+    const today = bangkokStartOfDay(nowDate);
 
     const branchScope: Prisma.ContractWhereInput =
       params.userRole === 'SALES' || params.userRole === 'BRANCH_MANAGER'
@@ -170,8 +173,10 @@ export class OverdueKpiService {
 
     const avgCollectorWorkload =
       workloadBuckets.length > 0
-        ? workloadBuckets.reduce((s: number, b: any) => s + b._count._all, 0) /
-          workloadBuckets.length
+        ? workloadBuckets.reduce(
+            (s: number, b: { _count: { _all: number } }) => s + b._count._all,
+            0,
+          ) / workloadBuckets.length
         : 0;
 
     const amountDue = new Prisma.Decimal(outstanding._sum.amountDue ?? 0);

--- a/apps/api/src/modules/overdue/kpi.service.ts
+++ b/apps/api/src/modules/overdue/kpi.service.ts
@@ -2,18 +2,52 @@ import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 
+export interface KpiResult {
+  totalOutstanding: number;
+  totalLateFees: number;
+  queueToday: number;
+  queueTodayTrend: number;
+  promisedCount: number;
+  promiseKeptRate7d: number;
+  avgCollectorWorkload: number;
+}
+
 @Injectable()
 export class OverdueKpiService {
-  private cache = new Map<string, { value: any; expiresAt: number }>();
-  private CACHE_TTL_MS = 60_000;
+  // H2 fix: bounded TTL cache with capacity cap + explicit invalidate().
+  // Previously the Map grew unbounded and had no write-side invalidation — a
+  // freshly-recorded payment didn't show up for 60s. Now callers (payment
+  // recording, log-contact) can invalidate when state changes, and the cache
+  // self-bounds to avoid memory creep.
+  private cache = new Map<string, { value: KpiResult; expiresAt: number }>();
+  private readonly CACHE_TTL_MS = 60_000;
+  private readonly CACHE_MAX_ENTRIES = 200;
 
   constructor(private prisma: PrismaService) {}
 
-  async getKpi(params: { range: '7d' | '30d'; userRole: string; userBranchId: string | null }) {
+  /**
+   * Call from services that mutate collection-visible state (payment recorded,
+   * contact logged, MDM approved, etc.) to drop stale KPI snapshots.
+   */
+  invalidate(): void {
+    this.cache.clear();
+  }
+
+  async getKpi(params: {
+    range: '7d' | '30d';
+    userRole: string;
+    userBranchId: string | null;
+  }): Promise<KpiResult> {
     const cacheKey = `${params.userRole}:${params.userBranchId ?? 'any'}:${params.range}`;
     const now = Date.now();
     const cached = this.cache.get(cacheKey);
     if (cached && cached.expiresAt > now) return cached.value;
+
+    // Cap memory — evict oldest if we hit the ceiling before adding.
+    if (this.cache.size >= this.CACHE_MAX_ENTRIES) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey) this.cache.delete(oldestKey);
+    }
 
     const value = await this.compute(params);
     this.cache.set(cacheKey, { value, expiresAt: now + this.CACHE_TTL_MS });
@@ -103,17 +137,34 @@ export class OverdueKpiService {
           : Promise.resolve([] as Array<{ assignedToId: string | null; _count: { _all: number } }>),
       ]);
 
-    // Promise-kept resolution: check if a payment was made on or after the settlementDate
+    // C3 fix: promise-kept resolution in ONE query instead of N+1.
+    // Previously: for each candidate, findFirst(paid after settlementDate).
+    // Now: pull all PAID payments for these contracts since the earliest
+    // settlementDate, match in-memory. O(N+M) instead of O(N×M) roundtrips.
     let keptCount = 0;
-    for (const c of keptCandidates) {
-      const paid = await this.prisma.payment.findFirst({
+    if (keptCandidates.length > 0) {
+      const earliest = keptCandidates.reduce(
+        (min, c) => ((c.settlementDate as Date) < min ? (c.settlementDate as Date) : min),
+        keptCandidates[0].settlementDate as Date,
+      );
+      const paidPayments = await this.prisma.payment.findMany({
         where: {
-          contractId: c.contractId,
+          contractId: { in: keptCandidates.map((c) => c.contractId) },
           status: 'PAID',
-          updatedAt: { gte: c.settlementDate as Date },
+          updatedAt: { gte: earliest },
         },
+        select: { contractId: true, updatedAt: true },
       });
-      if (paid) keptCount++;
+      const paidByContract = new Map<string, Date[]>();
+      for (const p of paidPayments) {
+        const list = paidByContract.get(p.contractId) ?? [];
+        list.push(p.updatedAt);
+        paidByContract.set(p.contractId, list);
+      }
+      for (const c of keptCandidates) {
+        const dates = paidByContract.get(c.contractId) ?? [];
+        if (dates.some((d) => d >= (c.settlementDate as Date))) keptCount++;
+      }
     }
     const promiseKeptRate7d = totalPromised > 0 ? keptCount / totalPromised : 0;
 

--- a/apps/api/src/modules/overdue/kpi.service.ts
+++ b/apps/api/src/modules/overdue/kpi.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable()
+export class OverdueKpiService {
+  private cache = new Map<string, { value: any; expiresAt: number }>();
+  private CACHE_TTL_MS = 60_000;
+
+  constructor(private prisma: PrismaService) {}
+
+  async getKpi(params: { range: '7d' | '30d'; userRole: string; userBranchId: string | null }) {
+    const cacheKey = `${params.userRole}:${params.userBranchId ?? 'any'}:${params.range}`;
+    const now = Date.now();
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > now) return cached.value;
+
+    const value = await this.compute(params);
+    this.cache.set(cacheKey, { value, expiresAt: now + this.CACHE_TTL_MS });
+    return value;
+  }
+
+  private async compute(params: {
+    range: '7d' | '30d';
+    userRole: string;
+    userBranchId: string | null;
+  }) {
+    const nowDate = new Date();
+    const sevenDaysAgo = new Date(nowDate.getTime() - 7 * 86400000);
+    const today = new Date(nowDate);
+    today.setHours(0, 0, 0, 0);
+
+    const branchScope: Prisma.ContractWhereInput =
+      params.userRole === 'SALES' || params.userRole === 'BRANCH_MANAGER'
+        ? { branchId: params.userBranchId ?? undefined }
+        : {};
+
+    const [outstanding, queueToday, promised, keptCandidates, totalPromised, workloadBuckets] =
+      await Promise.all([
+        this.prisma.payment.aggregate({
+          where: {
+            status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+            dueDate: { lt: nowDate },
+            contract: {
+              status: { in: ['OVERDUE', 'DEFAULT'] },
+              deletedAt: null,
+              ...branchScope,
+            },
+          },
+          _sum: { amountDue: true, amountPaid: true, lateFee: true },
+        }),
+        this.prisma.contract.count({
+          where: {
+            ...branchScope,
+            status: { in: ['ACTIVE', 'OVERDUE'] },
+            deletedAt: null,
+            OR: [{ blockAutoEscalation: null }, { blockAutoEscalation: { lt: nowDate } }],
+            payments: {
+              some: {
+                dueDate: { lte: nowDate },
+                status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+              },
+            },
+            callLogs: { none: { calledAt: { gte: today } } },
+          },
+        }),
+        this.prisma.callLog.count({
+          where: {
+            result: 'PROMISED',
+            settlementDate: { gte: nowDate },
+            contract: branchScope,
+          },
+        }),
+        // Candidates for promise-kept rate (last 7d promises)
+        this.prisma.callLog.findMany({
+          where: {
+            result: 'PROMISED',
+            settlementDate: { gte: sevenDaysAgo, lte: nowDate },
+            contract: branchScope,
+          },
+          select: {
+            contractId: true,
+            settlementDate: true,
+          },
+        }),
+        this.prisma.callLog.count({
+          where: {
+            result: 'PROMISED',
+            settlementDate: { gte: sevenDaysAgo, lte: nowDate },
+            contract: branchScope,
+          },
+        }),
+        params.userRole === 'OWNER'
+          ? this.prisma.contract.groupBy({
+              by: ['assignedToId'],
+              where: {
+                status: { in: ['OVERDUE', 'DEFAULT'] },
+                deletedAt: null,
+                assignedToId: { not: null },
+              },
+              _count: { _all: true },
+            })
+          : Promise.resolve([] as Array<{ assignedToId: string | null; _count: { _all: number } }>),
+      ]);
+
+    // Promise-kept resolution: check if a payment was made on or after the settlementDate
+    let keptCount = 0;
+    for (const c of keptCandidates) {
+      const paid = await this.prisma.payment.findFirst({
+        where: {
+          contractId: c.contractId,
+          status: 'PAID',
+          updatedAt: { gte: c.settlementDate as Date },
+        },
+      });
+      if (paid) keptCount++;
+    }
+    const promiseKeptRate7d = totalPromised > 0 ? keptCount / totalPromised : 0;
+
+    const avgCollectorWorkload =
+      workloadBuckets.length > 0
+        ? workloadBuckets.reduce((s: number, b: any) => s + b._count._all, 0) /
+          workloadBuckets.length
+        : 0;
+
+    const amountDue = new Prisma.Decimal(outstanding._sum.amountDue ?? 0);
+    const amountPaid = new Prisma.Decimal(outstanding._sum.amountPaid ?? 0);
+    const lateFees = new Prisma.Decimal(outstanding._sum.lateFee ?? 0);
+
+    return {
+      totalOutstanding: amountDue.sub(amountPaid).toNumber(),
+      totalLateFees: lateFees.toNumber(),
+      queueToday,
+      queueTodayTrend: 0, // placeholder — no cache history yet
+      promisedCount: promised,
+      promiseKeptRate7d: Math.round(promiseKeptRate7d * 100) / 100,
+      avgCollectorWorkload: Math.round(avgCollectorWorkload),
+    };
+  }
+}

--- a/apps/api/src/modules/overdue/mdm-lock.service.spec.ts
+++ b/apps/api/src/modules/overdue/mdm-lock.service.spec.ts
@@ -195,4 +195,20 @@ describe('MdmLockService', () => {
       );
     });
   });
+
+  describe('getPendingByRole', () => {
+    it('filters by branch for BRANCH_MANAGER', async () => {
+      mockPrisma.mdmLockRequest.findMany.mockResolvedValueOnce([]);
+      await service.getPendingByRole('BRANCH_MANAGER', 'branch-1');
+      const arg = mockPrisma.mdmLockRequest.findMany.mock.calls[0][0];
+      expect(arg.where.contract).toEqual({ branchId: 'branch-1' });
+    });
+
+    it('does not filter by branch for OWNER', async () => {
+      mockPrisma.mdmLockRequest.findMany.mockResolvedValueOnce([]);
+      await service.getPendingByRole('OWNER');
+      const arg = mockPrisma.mdmLockRequest.findMany.mock.calls[0][0];
+      expect(arg.where.contract).toBeUndefined();
+    });
+  });
 });

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -3,11 +3,16 @@ import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { OverdueService } from './overdue.service';
 import { DunningRuleService } from './dunning-rule.service';
 import { DunningEngineService } from './dunning-engine.service';
+import { OverdueQueueService } from './queue.service';
+import { OverdueKpiService } from './kpi.service';
+import { MdmLockService } from './mdm-lock.service';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { AssignCollectorDto } from './dto/assign-collector.dto';
 import { RecordSettlementDto } from './dto/record-settlement.dto';
 import { LogContactDto } from './dto/log-contact.dto';
 import { CreateDunningRuleDto, UpdateDunningRuleDto } from './dto/dunning-rule.dto';
+import { QueueQueryDto } from './dto/queue-query.dto';
+import { KpiQueryDto } from './dto/kpi-query.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -23,7 +28,47 @@ export class OverdueController {
     private overdueService: OverdueService,
     private dunningRuleService: DunningRuleService,
     private dunningEngineService: DunningEngineService,
+    private queueService: OverdueQueueService,
+    private kpiService: OverdueKpiService,
+    private mdmLockService: MdmLockService,
   ) {}
+
+  // --- Collections Workflow Hub endpoints (Plan 2) ---
+
+  @Get('queue')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getQueue(
+    @Query() dto: QueueQueryDto,
+    @CurrentUser() user: { role: string; branchId: string | null },
+  ) {
+    return this.queueService.getQueue({
+      tab: dto.tab,
+      branchId: dto.branchId,
+      page: dto.page,
+      limit: dto.limit,
+      userRole: user.role,
+      userBranchId: user.branchId,
+    });
+  }
+
+  @Get('kpi')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getKpi(
+    @Query() dto: KpiQueryDto,
+    @CurrentUser() user: { role: string; branchId: string | null },
+  ) {
+    return this.kpiService.getKpi({
+      range: dto.range ?? '7d',
+      userRole: user.role,
+      userBranchId: user.branchId,
+    });
+  }
+
+  @Get('mdm-pending')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
+  getMdmPending(@CurrentUser() user: { role: string; branchId: string | null }) {
+    return this.mdmLockService.getPendingByRole(user.role, user.branchId ?? undefined);
+  }
 
   @Get()
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -13,6 +13,7 @@ import { LogContactDto } from './dto/log-contact.dto';
 import { CreateDunningRuleDto, UpdateDunningRuleDto } from './dto/dunning-rule.dto';
 import { QueueQueryDto } from './dto/queue-query.dto';
 import { KpiQueryDto } from './dto/kpi-query.dto';
+import { RejectMdmDto } from './dto/reject-mdm.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -324,7 +325,7 @@ export class OverdueController {
   @Roles('OWNER', 'FINANCE_MANAGER')
   rejectMdmLock(
     @Param('id') id: string,
-    @Body() body: { reason: string },
+    @Body() body: RejectMdmDto,
     @CurrentUser() user: { id: string; role: string },
   ) {
     return this.mdmLockService.reject(id, user.id, body.reason, user.role);

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -307,4 +307,34 @@ export class OverdueController {
       body.reason,
     );
   }
+
+  // --- MDM lock/unlock approvals (OWNER/FM only) ---
+
+  @Post('mdm-requests/:id/approve')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  approveMdmLock(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.mdmLockService.approve(id, user.id, user.role);
+  }
+
+  @Post('mdm-requests/:id/reject')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  rejectMdmLock(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.mdmLockService.reject(id, user.id, body.reason, user.role);
+  }
+
+  @Post('mdm-requests/:id/unlock')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  unlockMdm(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.mdmLockService.unlock(id, user.id, user.role);
+  }
 }

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -44,6 +44,7 @@ export class OverdueController {
     return this.queueService.getQueue({
       tab: dto.tab,
       branchId: dto.branchId,
+      search: dto.search,
       page: dto.page,
       limit: dto.limit,
       userRole: user.role,

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -70,6 +70,12 @@ export class OverdueController {
     return this.mdmLockService.getPendingByRole(user.role, user.branchId ?? undefined);
   }
 
+  @Get('collections-flag')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  async getCollectionsFlag() {
+    return { enabled: await this.overdueService.getCollectionsFlag() };
+  }
+
   @Get()
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
   findOverdue(

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -6,6 +6,8 @@ import { ContractLetterService } from './contract-letter.service';
 import { DunningRuleService } from './dunning-rule.service';
 import { DunningEngineService } from './dunning-engine.service';
 import { MdmLockService } from './mdm-lock.service';
+import { OverdueQueueService } from './queue.service';
+import { OverdueKpiService } from './kpi.service';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
@@ -22,6 +24,8 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     DunningRuleService,
     DunningEngineService,
     MdmLockService,
+    OverdueQueueService,
+    OverdueKpiService,
     BrokenPromiseCron,
     MdmAutoProposeCron,
   ],
@@ -31,6 +35,8 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     DunningRuleService,
     DunningEngineService,
     MdmLockService,
+    OverdueQueueService,
+    OverdueKpiService,
   ],
 })
 export class OverdueModule {}

--- a/apps/api/src/modules/overdue/overdue.service.spec.ts
+++ b/apps/api/src/modules/overdue/overdue.service.spec.ts
@@ -422,6 +422,45 @@ describe('OverdueService (C2: throw if no SYSTEM user)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
+// getCollectionsFlag: feature flag reader
+// ─────────────────────────────────────────────────────────────
+describe('OverdueService.getCollectionsFlag', () => {
+  let service: OverdueService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    prisma = {
+      systemConfig: { findUnique: jest.fn() },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        OverdueService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: DunningEngineService, useValue: mockDunningEngine },
+      ],
+    }).compile();
+    service = mod.get(OverdueService);
+  });
+
+  it('returns true when flag value is "true"', async () => {
+    prisma.systemConfig.findUnique.mockResolvedValue({ key: 'collections_v2_enabled', value: 'true' });
+    await expect(service.getCollectionsFlag()).resolves.toBe(true);
+  });
+
+  it('returns false when flag value is "false"', async () => {
+    prisma.systemConfig.findUnique.mockResolvedValue({ key: 'collections_v2_enabled', value: 'false' });
+    await expect(service.getCollectionsFlag()).resolves.toBe(false);
+  });
+
+  it('returns false when flag key does not exist (null)', async () => {
+    prisma.systemConfig.findUnique.mockResolvedValue(null);
+    await expect(service.getCollectionsFlag()).resolves.toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
 // logContact: event trigger wiring + noAnswerCount maintenance
 // ─────────────────────────────────────────────────────────────
 describe('OverdueService.logContact with event trigger wiring', () => {

--- a/apps/api/src/modules/overdue/overdue.service.spec.ts
+++ b/apps/api/src/modules/overdue/overdue.service.spec.ts
@@ -3,10 +3,15 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { OverdueService } from './overdue.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { DunningEngineService } from './dunning-engine.service';
+import { OverdueKpiService } from './kpi.service';
 
 // Shared no-op mock for DunningEngineService — tests that care can spy on it
 const mockDunningEngine = {
   executeEventTrigger: jest.fn().mockResolvedValue(undefined),
+};
+// Shared no-op KpiService mock — only its invalidate() is called from OverdueService
+const mockKpiService = {
+  invalidate: jest.fn(),
 };
 
 describe('OverdueService.recordSettlement', () => {
@@ -33,6 +38,7 @@ describe('OverdueService.recordSettlement', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);
@@ -120,6 +126,7 @@ describe('OverdueService.approveDunningEscalation (T4-C2)', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);
@@ -188,6 +195,7 @@ describe('OverdueService.updateContractStatuses (T3-C11 hold guard)', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);
@@ -286,6 +294,7 @@ describe('OverdueService.holdAutoEscalation (T3-C11)', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);
@@ -340,6 +349,7 @@ describe('OverdueService.updateContractStatuses (C3: atomic flip)', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);
@@ -404,6 +414,7 @@ describe('OverdueService (C2: throw if no SYSTEM user)', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);
@@ -439,6 +450,7 @@ describe('OverdueService.getCollectionsFlag', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);
@@ -504,6 +516,7 @@ describe('OverdueService.logContact with event trigger wiring', () => {
         OverdueService,
         { provide: PrismaService, useValue: prisma },
         { provide: DunningEngineService, useValue: dunningEngineMock },
+        { provide: OverdueKpiService, useValue: mockKpiService },
       ],
     }).compile();
     service = mod.get(OverdueService);

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -11,6 +11,7 @@ import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { Prisma, DunningStage } from '@prisma/client';
 import { BUSINESS_RULES } from '../../utils/config.util';
 import { DunningEngineService } from './dunning-engine.service';
+import { OverdueKpiService } from './kpi.service';
 
 @Injectable()
 export class OverdueService {
@@ -19,6 +20,7 @@ export class OverdueService {
   constructor(
     private prisma: PrismaService,
     private dunningEngine: DunningEngineService,
+    private kpiService: OverdueKpiService,
   ) {}
 
   private async getSystemUserIdOrThrow(): Promise<string> {
@@ -974,6 +976,10 @@ export class OverdueService {
         );
       }
     }
+
+    // H2: drop stale KPI snapshots — logContact mutates counters that feed
+    // queueToday, noAnswerCount-based filters, and promise-kept calcs.
+    this.kpiService.invalidate();
 
     return callLog;
   }

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -861,6 +861,17 @@ export class OverdueService {
   }
 
   /**
+   * Read the collections_v2_enabled feature flag from SystemConfig.
+   * Returns false when the key is absent or set to anything other than 'true'.
+   */
+  async getCollectionsFlag(): Promise<boolean> {
+    const cfg = await this.prisma.systemConfig.findUnique({
+      where: { key: 'collections_v2_enabled' },
+    });
+    return cfg?.value === 'true';
+  }
+
+  /**
    * Reset dunning stage when a contract is no longer overdue
    * (e.g., after a payment brings it back to ACTIVE)
    */

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -1,0 +1,247 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { OverdueQueueService } from './queue.service';
+
+const mockPrisma = {
+  contract: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+};
+
+describe('OverdueQueueService', () => {
+  let service: OverdueQueueService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OverdueQueueService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(OverdueQueueService);
+  });
+
+  function makeContract(overrides: Partial<any> = {}) {
+    return {
+      id: 'contract-1',
+      contractNumber: 'BC-2024-001',
+      status: 'OVERDUE',
+      dunningStage: 'STAGE_1',
+      noAnswerCount: 0,
+      needsSkipTracing: false,
+      deviceLocked: false,
+      customer: { id: 'cust-1', name: 'สมชาย ใจดี', phone: '0812345678', lineId: 'line123' },
+      branch: { id: 'branch-1', name: 'สาขาลาดพร้าว' },
+      assignedTo: { id: 'user-1', name: 'นักติดตาม 1' },
+      payments: [
+        {
+          amountDue: '5000.00',
+          amountPaid: '0.00',
+          lateFee: '150.00',
+          dueDate: new Date(Date.now() - 10 * 86400000), // 10 days ago
+          status: 'OVERDUE',
+        },
+      ],
+      callLogs: [],
+      ...overrides,
+    };
+  }
+
+  describe('getQueue — today tab', () => {
+    it('returns correct ContractRow shape for today tab', async () => {
+      const contract = makeContract({
+        callLogs: [{ result: 'NO_ANSWER', calledAt: new Date(Date.now() - 86400000), settlementDate: null }],
+      });
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+      });
+
+      expect(result.data).toHaveLength(1);
+      const row = result.data[0];
+
+      // Verify all ContractRow fields present
+      expect(row).toHaveProperty('id');
+      expect(row).toHaveProperty('contractNumber');
+      expect(row).toHaveProperty('status');
+      expect(row).toHaveProperty('dunningStage');
+      expect(row).toHaveProperty('customer');
+      expect(row).toHaveProperty('branch');
+      expect(row).toHaveProperty('assignedTo');
+      expect(row).toHaveProperty('outstanding');
+      expect(row).toHaveProperty('daysOverdue');
+      expect(row).toHaveProperty('lastCallResult');
+      expect(row).toHaveProperty('lastCallAt');
+      expect(row).toHaveProperty('noAnswerCount');
+      expect(row).toHaveProperty('settlementDate');
+      expect(row).toHaveProperty('needsSkipTracing');
+      expect(row).toHaveProperty('deviceLocked');
+
+      // Verify computed fields
+      expect(row.outstanding).toBe(5150); // 5000 - 0 + 150
+      expect(row.daysOverdue).toBe(10);
+      expect(row.lastCallResult).toBe('NO_ANSWER');
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(50);
+    });
+  });
+
+  describe('SALES branch scoping', () => {
+    it('forces SALES user to their own branchId in query', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'SALES',
+        userBranchId: 'branch-sales',
+        branchId: 'branch-other', // should be ignored
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      expect(callArg.where.branchId).toBe('branch-sales');
+    });
+
+    it('OWNER with branchId filter uses provided branchId', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        branchId: 'branch-filtered',
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      expect(callArg.where.branchId).toBe('branch-filtered');
+    });
+  });
+
+  describe('followup tab', () => {
+    it('query filter uses noAnswerCount gte 1 lt 3 (excludes >= 3)', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'followup',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      expect(callArg.where.noAnswerCount).toEqual({ gte: 1, lt: 3 });
+    });
+
+    it('followup returns only contracts with noAnswerCount 1-2 from mock', async () => {
+      const c1 = makeContract({ noAnswerCount: 1, status: 'OVERDUE' });
+      const c2 = makeContract({ id: 'contract-2', noAnswerCount: 2, status: 'DEFAULT' });
+      mockPrisma.contract.findMany.mockResolvedValueOnce([c1, c2]);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+
+      const result = await service.getQueue({
+        tab: 'followup',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+  });
+
+  describe('promise tab', () => {
+    it('promise tab query includes settlementDate window (today-3 to today+30)', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      const before = Date.now();
+      await service.getQueue({
+        tab: 'promise',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+      const after = Date.now();
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      const settlementFilter = callArg.where.callLogs.some.settlementDate;
+
+      expect(settlementFilter.gte.getTime()).toBeGreaterThanOrEqual(before - 3 * 86400000 - 100);
+      expect(settlementFilter.gte.getTime()).toBeLessThanOrEqual(after - 3 * 86400000 + 100);
+      expect(settlementFilter.lte.getTime()).toBeGreaterThanOrEqual(before + 30 * 86400000 - 100);
+      expect(settlementFilter.lte.getTime()).toBeLessThanOrEqual(after + 30 * 86400000 + 100);
+    });
+
+    it('includes future-dated and recently-passed settlements in result', async () => {
+      const futureDated = makeContract({
+        callLogs: [
+          {
+            result: 'PROMISED',
+            calledAt: new Date(),
+            settlementDate: new Date(Date.now() + 5 * 86400000), // 5 days in future
+          },
+        ],
+      });
+      const recentlyPassed = makeContract({
+        id: 'contract-past',
+        callLogs: [
+          {
+            result: 'PROMISED',
+            calledAt: new Date(),
+            settlementDate: new Date(Date.now() - 2 * 86400000), // 2 days ago (within 3d)
+          },
+        ],
+      });
+      mockPrisma.contract.findMany.mockResolvedValueOnce([futureDated, recentlyPassed]);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+
+      const result = await service.getQueue({
+        tab: 'promise',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].settlementDate).toBeDefined();
+      expect(result.data[1].settlementDate).toBeDefined();
+    });
+  });
+
+  describe('pagination', () => {
+    it('caps limit at 100 when input exceeds 100', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        limit: 200, // should be capped
+      });
+
+      expect(result.limit).toBe(100);
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      expect(callArg.take).toBe(100);
+    });
+
+    it('uses default limit of 50 when not specified', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.limit).toBe(50);
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -13,6 +13,7 @@ export class OverdueQueueService {
     userRole: string;
     userBranchId: string | null;
     branchId?: string;
+    search?: string;
     page?: number;
     limit?: number;
   }) {
@@ -28,7 +29,26 @@ export class OverdueQueueService {
         ? { branchId: params.branchId }
         : {};
 
-    const where = this.buildWhere(params.tab, now, branchScope);
+    const baseWhere = this.buildWhere(params.tab, now, branchScope);
+
+    // C1 fix: server-side search across contractNumber / customer name / phone.
+    // Previously the filter was applied client-side on the current page only, so
+    // matches outside the first N rows were invisible to the collector.
+    const search = params.search?.trim();
+    const where: Prisma.ContractWhereInput = search
+      ? {
+          AND: [
+            baseWhere,
+            {
+              OR: [
+                { contractNumber: { contains: search, mode: 'insensitive' } },
+                { customer: { name: { contains: search, mode: 'insensitive' } } },
+                { customer: { phone: { contains: search } } },
+              ],
+            },
+          ],
+        }
+      : baseWhere;
 
     const [contracts, total] = await Promise.all([
       this.prisma.contract.findMany({
@@ -95,6 +115,9 @@ export class OverdueQueueService {
     }
 
     // promise
+    // H4 fix: scope to PROMISED-only with an explicit settlementDate window.
+    // Previously ANSWERED was also matched, which leaked answered-but-not-promised
+    // calls into the promise tab if their row happened to have a stray settlementDate.
     const todayMinus3 = new Date(now.getTime() - 3 * 86400000);
     const todayPlus30 = new Date(now.getTime() + 30 * 86400000);
     return {
@@ -102,8 +125,9 @@ export class OverdueQueueService {
       deletedAt: null,
       callLogs: {
         some: {
-          result: { in: ['PROMISED', 'ANSWERED'] },
+          result: 'PROMISED',
           settlementDate: { gte: todayMinus3, lte: todayPlus30 },
+          brokenAt: null, // un-broken promises — broken ones belong elsewhere
         },
       },
     };

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -1,0 +1,142 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export type QueueTab = 'today' | 'followup' | 'promise';
+
+@Injectable()
+export class OverdueQueueService {
+  constructor(private prisma: PrismaService) {}
+
+  async getQueue(params: {
+    tab: QueueTab;
+    userRole: string;
+    userBranchId: string | null;
+    branchId?: string;
+    page?: number;
+    limit?: number;
+  }) {
+    const page = params.page ?? 1;
+    const limit = Math.min(params.limit ?? 50, 100);
+    const skip = (page - 1) * limit;
+    const now = new Date();
+
+    const branchScope: Prisma.ContractWhereInput =
+      params.userRole === 'SALES' || params.userRole === 'BRANCH_MANAGER'
+        ? { branchId: params.userBranchId ?? undefined }
+        : params.branchId
+        ? { branchId: params.branchId }
+        : {};
+
+    const where = this.buildWhere(params.tab, now, branchScope);
+
+    const [contracts, total] = await Promise.all([
+      this.prisma.contract.findMany({
+        where,
+        include: {
+          customer: { select: { id: true, name: true, phone: true, lineId: true } },
+          branch: { select: { id: true, name: true } },
+          assignedTo: { select: { id: true, name: true } },
+          payments: {
+            where: { status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] } },
+            orderBy: { dueDate: 'asc' },
+            take: 1,
+          },
+          callLogs: {
+            orderBy: { calledAt: 'desc' },
+            take: 1,
+          },
+        },
+        orderBy: { updatedAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.contract.count({ where }),
+    ]);
+
+    const data = contracts.map((c) => this.toRow(c, now));
+
+    return { data, total, page, limit };
+  }
+
+  private buildWhere(
+    tab: QueueTab,
+    now: Date,
+    branchScope: Prisma.ContractWhereInput,
+  ): Prisma.ContractWhereInput {
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    if (tab === 'today') {
+      return {
+        ...branchScope,
+        status: { in: ['ACTIVE', 'OVERDUE'] },
+        deletedAt: null,
+        OR: [{ blockAutoEscalation: null }, { blockAutoEscalation: { lt: now } }],
+        payments: {
+          some: {
+            dueDate: { lte: now },
+            status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+          },
+        },
+        callLogs: {
+          none: { calledAt: { gte: startOfDay } },
+        },
+      };
+    }
+
+    if (tab === 'followup') {
+      return {
+        ...branchScope,
+        status: { in: ['OVERDUE', 'DEFAULT'] },
+        deletedAt: null,
+        noAnswerCount: { gte: 1, lt: 3 },
+      };
+    }
+
+    // promise
+    const todayMinus3 = new Date(now.getTime() - 3 * 86400000);
+    const todayPlus30 = new Date(now.getTime() + 30 * 86400000);
+    return {
+      ...branchScope,
+      deletedAt: null,
+      callLogs: {
+        some: {
+          result: { in: ['PROMISED', 'ANSWERED'] },
+          settlementDate: { gte: todayMinus3, lte: todayPlus30 },
+        },
+      },
+    };
+  }
+
+  private toRow(c: any, now: Date) {
+    const payment = c.payments[0];
+    const callLog = c.callLogs[0];
+    const outstanding = payment
+      ? new Prisma.Decimal(payment.amountDue)
+          .sub(payment.amountPaid)
+          .add(payment.lateFee)
+          .toNumber()
+      : 0;
+    const daysOverdue = payment
+      ? Math.max(0, Math.floor((now.getTime() - new Date(payment.dueDate).getTime()) / 86400000))
+      : 0;
+    return {
+      id: c.id,
+      contractNumber: c.contractNumber,
+      status: c.status,
+      dunningStage: c.dunningStage,
+      customer: c.customer,
+      branch: c.branch,
+      assignedTo: c.assignedTo,
+      outstanding,
+      daysOverdue,
+      lastCallResult: callLog?.result ?? null,
+      lastCallAt: callLog?.calledAt ?? null,
+      noAnswerCount: c.noAnswerCount,
+      settlementDate: callLog?.settlementDate ?? null,
+      needsSkipTracing: c.needsSkipTracing,
+      deviceLocked: c.deviceLocked,
+    };
+  }
+}

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { bangkokStartOfDay } from '../../utils/date.util';
 
 export type QueueTab = 'today' | 'followup' | 'promise';
 
@@ -84,8 +85,9 @@ export class OverdueQueueService {
     now: Date,
     branchScope: Prisma.ContractWhereInput,
   ): Prisma.ContractWhereInput {
-    const startOfDay = new Date(now);
-    startOfDay.setHours(0, 0, 0, 0);
+    // Bangkok-local midnight — server TZ on Cloud Run is UTC, so naive
+    // setHours(0,0,0,0) would shift the "today" boundary by 7 hours.
+    const startOfDay = bangkokStartOfDay(now);
 
     if (tab === 'today') {
       return {

--- a/apps/api/src/utils/date.util.ts
+++ b/apps/api/src/utils/date.util.ts
@@ -23,3 +23,17 @@ export function calculateAgeInYears(birthDate: Date | string, now: Date = new Da
   const birth = typeof birthDate === 'string' ? new Date(birthDate) : birthDate;
   return Math.floor((now.getTime() - birth.getTime()) / (365.25 * 24 * 60 * 60 * 1000));
 }
+
+/**
+ * Bangkok timezone is fixed UTC+7 (Thailand has no DST).
+ * Returns the UTC instant that corresponds to 00:00 Bangkok-local on the day
+ * that contains `now` in Bangkok. Use this anywhere business-day boundaries
+ * matter (queue "today" filters, KPI snapshots, etc.) — server TZ on Cloud Run
+ * is UTC, so naive `setHours(0,0,0,0)` rolls over 7 hours early.
+ */
+const BANGKOK_OFFSET_MS = 7 * 60 * 60 * 1000;
+export function bangkokStartOfDay(now: Date = new Date()): Date {
+  const bangkokNowMs = now.getTime() + BANGKOK_OFFSET_MS;
+  const bangkokMidnightMs = Math.floor(bangkokNowMs / 86_400_000) * 86_400_000;
+  return new Date(bangkokMidnightMs - BANGKOK_OFFSET_MS);
+}

--- a/apps/web/e2e/collections-smoke.spec.ts
+++ b/apps/web/e2e/collections-smoke.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI } from './helpers/auth';
+import { gotoWithRetry, hasErrorBoundary } from './helpers/navigation';
+
+/* ================================================================
+   Collections Workflow Hub (/collections) — smoke tests
+   ================================================================ */
+test.describe('/collections workflow hub', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('OWNER: loads page with 5 tabs visible (including อนุมัติ)', async ({ page }) => {
+    await gotoWithRetry(page, '/collections');
+    if (await hasErrorBoundary(page)) return;
+
+    await expect(page.getByRole('heading', { name: /ติดตามหนี้/ }).first()).toBeVisible({ timeout: 15000 });
+
+    for (const label of ['คิววันนี้', 'ตามต่อ', 'นัดชำระ', 'อนุมัติ', 'ทั้งหมด']) {
+      await expect(page.getByRole('button', { name: new RegExp(label) }).first()).toBeVisible({ timeout: 5000 });
+    }
+  });
+
+  test('OWNER: switching to ตามต่อ shows the warning banner', async ({ page }) => {
+    await gotoWithRetry(page, '/collections');
+    if (await hasErrorBoundary(page)) return;
+
+    await page.getByRole('button', { name: /ตามต่อ/ }).first().click();
+    await expect(page.getByText(/ตามต่อ.*เคยโทร/i).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('OWNER: switching to นัดชำระ loads the promise queue', async ({ page }) => {
+    await gotoWithRetry(page, '/collections');
+    if (await hasErrorBoundary(page)) return;
+
+    await page.getByRole('button', { name: /นัดชำระ/ }).first().click();
+    // Either rendered content or empty state — should not crash
+    await expect(page.locator('body')).not.toContainText(/เกิดข้อผิดพลาด/);
+  });
+
+  test('OWNER: approval tab loads both pending sections', async ({ page }) => {
+    await gotoWithRetry(page, '/collections');
+    if (await hasErrorBoundary(page)) return;
+
+    await page.getByRole('button', { name: /อนุมัติ/ }).first().click();
+
+    await expect(page.getByText(/รออนุมัติเลื่อนระดับเตือน/).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/รออนุมัติล็อคเครื่อง/).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('OWNER: ทั้งหมด tab renders existing overdue content', async ({ page }) => {
+    await gotoWithRetry(page, '/collections');
+    if (await hasErrorBoundary(page)) return;
+
+    await page.getByRole('button', { name: /ทั้งหมด/ }).first().click();
+    // AllTab wraps OverduePage — its own PageHeader renders "ค่าปรับ & ค้างชำระ"
+    await expect(page.getByText(/ค่าปรับ|ค้างชำระ/).first()).toBeVisible({ timeout: 10000 });
+  });
+});
+
+/* ================================================================
+   /overdue still works (flag off by default) — no redirect
+   ================================================================ */
+test.describe('/overdue backward compat', () => {
+  test('existing /overdue still loads when flag is off (default)', async ({ page }) => {
+    await loginViaAPI(page);
+    await gotoWithRetry(page, '/overdue');
+    if (await hasErrorBoundary(page)) return;
+
+    await expect(page.getByText(/ค้างชำระ|ค่าปรับ/).first()).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -95,6 +95,7 @@ const WebhooksPage = lazy(() => import('@/pages/WebhooksPage'));
 const ChatAnalyticsPage = lazy(() => import('@/pages/ChatAnalyticsPage'));
 const CannedResponseAdminPage = lazy(() => import('@/pages/CannedResponseAdminPage'));
 const CollectionDashboardPage = lazy(() => import('@/pages/CollectionDashboardPage'));
+const CollectionsPage = lazy(() => import('@/pages/CollectionsPage'));
 const DunningSettingsPage = lazy(() => import('@/pages/DunningSettingsPage'));
 const MonthlyClosePage = lazy(() => import('@/pages/MonthlyClosePage'));
 const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
@@ -425,6 +426,7 @@ function App() {
           <Route path="/receipts" element={<Navigate to="/payments?tab=receipts" replace />} />
           <Route path="/verify/:receiptNumber" element={<ReceiptVerifyPage />} />
           <Route path="/overdue" element={<OverduePage />} />
+          <Route path="/collections" element={<CollectionsPage />} />
           <Route
             path="/collection-dashboard"
             element={

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -426,7 +426,16 @@ function App() {
           <Route path="/receipts" element={<Navigate to="/payments?tab=receipts" replace />} />
           <Route path="/verify/:receiptNumber" element={<ReceiptVerifyPage />} />
           <Route path="/overdue" element={<OverduePage />} />
-          <Route path="/collections" element={<CollectionsPage />} />
+          <Route
+            path="/collections"
+            element={
+              <ProtectedRoute
+                roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES']}
+              >
+                <CollectionsPage />
+              </ProtectedRoute>
+            }
+          />
           <Route
             path="/collection-dashboard"
             element={

--- a/apps/web/src/components/layout/MobileBottomNav.tsx
+++ b/apps/web/src/components/layout/MobileBottomNav.tsx
@@ -6,16 +6,21 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useUnreadChat } from '@/hooks/useUnreadChat';
 import { getMenuConfig } from '@/config/menu';
 import type { BottomNavItem } from '@/config/menu';
+import { useCollectionsFlag } from '@/pages/CollectionsPage/hooks/useCollectionsFlag';
 
 function MobileBottomNav() {
   const { pathname } = useLocation();
   const { setMobileSidebarOpen } = useLayout();
   const { user } = useAuth();
 
-  const tabs = useMemo(
-    () => getMenuConfig(user?.role ?? '').bottomNav,
-    [user?.role],
-  );
+  const { enabled: collectionsEnabled } = useCollectionsFlag();
+  const tabs = useMemo<BottomNavItem[]>(() => {
+    const rawTabs = getMenuConfig(user?.role ?? '').bottomNav;
+    if (!collectionsEnabled) return rawTabs;
+    return rawTabs.map((tab) =>
+      tab.path === '/overdue' ? { ...tab, path: '/collections' } : tab,
+    );
+  }, [user?.role, collectionsEnabled]);
 
   const isActive = (path: string) => {
     if (path === '/') return pathname === '/';

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -33,6 +33,7 @@ import {
 import { useLayout } from './LayoutContext';
 import { getMenuConfig } from '@/config/menu';
 import type { MenuSection } from '@/config/menu';
+import { useCollectionsFlag } from '@/pages/CollectionsPage/hooks/useCollectionsFlag';
 
 /* ── Role label map ─────────────────────────────── */
 const roleBadgeMap: Record<string, { label: string; cls: string }> = {
@@ -69,7 +70,18 @@ const expandedMenuClassNames: AccordionMenuClassNames = {
 
 /* ─── useRoleMenu ───────────────────────────────── */
 function useRoleMenu(role: string): MenuSection[] {
-  return useMemo(() => getMenuConfig(role).sidebar, [role]);
+  const { enabled: collectionsEnabled } = useCollectionsFlag();
+  return useMemo(() => {
+    const sections = getMenuConfig(role).sidebar;
+    if (!collectionsEnabled) return sections;
+    // Swap /overdue → /collections when the flag is on
+    return sections.map((section) => ({
+      ...section,
+      items: section.items.map((item) =>
+        item.path === '/overdue' ? { ...item, path: '/collections' } : item,
+      ),
+    }));
+  }, [role, collectionsEnabled]);
 }
 
 /* ─── Collapsed Icon Rail (70px wide) ────────────── */

--- a/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
@@ -1,0 +1,246 @@
+import { useState } from 'react';
+import { CheckCircle, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { PendingEscalation, PendingMdmRequest } from '../types';
+
+/* ── helpers ─────────────────────────────────────────────────── */
+
+function daysSince(iso: string): number {
+  const diff = Date.now() - new Date(iso).getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+function heatStrip(proposedAt: string): string {
+  const d = daysSince(proposedAt);
+  if (d >= 2) return 'bg-destructive';
+  if (d >= 1) return 'bg-warning';
+  return 'bg-primary';
+}
+
+function staleLabel(iso: string): string {
+  const d = daysSince(iso);
+  if (d === 0) return 'วันนี้';
+  if (d === 1) return 'เมื่อวาน';
+  return `${d} วันที่แล้ว`;
+}
+
+/* ── Reject reason modal ─────────────────────────────────────── */
+
+interface RejectDialogProps {
+  open: boolean;
+  onConfirm: (reason: string) => void;
+  onCancel: () => void;
+  pending: boolean;
+}
+
+function RejectDialog({ open, onConfirm, onCancel, pending }: RejectDialogProps) {
+  const [reason, setReason] = useState('');
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-xl border border-border bg-card shadow-xl p-6 mx-4">
+        <h3 className="text-sm font-semibold mb-3 leading-snug">ระบุเหตุผลการปฏิเสธ</h3>
+        <textarea
+          className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring leading-snug"
+          rows={3}
+          placeholder="เหตุผลอย่างน้อย 5 ตัวอักษร..."
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          autoFocus
+        />
+        <div className="flex gap-2 mt-3 justify-end">
+          <button
+            onClick={onCancel}
+            className="rounded-lg border border-input px-4 py-1.5 text-sm hover:bg-muted transition-colors"
+          >
+            ยกเลิก
+          </button>
+          <button
+            disabled={reason.trim().length < 5 || pending}
+            onClick={() => onConfirm(reason.trim())}
+            className="rounded-lg bg-destructive px-4 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+          >
+            {pending ? 'กำลังส่ง...' : 'ยืนยันปฏิเสธ'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Escalation Row ─────────────────────────────────────────── */
+
+interface EscalationRowProps {
+  item: PendingEscalation;
+  onApprove: (contractId: string) => void;
+  onReject: (contractId: string, reason: string) => void;
+  approvePending: boolean;
+  rejectPending: boolean;
+}
+
+export function EscalationRow({
+  item,
+  onApprove,
+  onReject,
+  approvePending,
+  rejectPending,
+}: EscalationRowProps) {
+  const [showReject, setShowReject] = useState(false);
+
+  const stageLabelMap: Record<string, string> = {
+    FINAL_WARNING: 'อนุมัติเตือนครั้งสุดท้าย',
+    LEGAL_ACTION: 'อนุมัติดำเนินคดี',
+  };
+  const stageLabel = stageLabelMap[item.pendingDunningStage] ?? item.pendingDunningStage;
+  const chipVariant =
+    item.pendingDunningStage === 'LEGAL_ACTION'
+      ? 'bg-destructive/10 text-destructive'
+      : 'bg-warning/10 text-warning';
+
+  return (
+    <>
+      <div className="relative flex rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+        <div className={cn('w-1 shrink-0', heatStrip(item.pendingDunningSince))} />
+        <div className="flex-1 p-4 min-w-0">
+          {/* action chip + contract# */}
+          <div className="flex items-start justify-between gap-3 mb-1.5">
+            <div className="min-w-0">
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full text-2xs font-semibold px-2 py-0.5 leading-snug mb-1',
+                  chipVariant,
+                )}
+              >
+                {stageLabel}
+              </span>
+              <div className="font-mono text-xs text-primary font-medium">
+                {item.contractNumber}
+              </div>
+              <div className="text-sm font-semibold leading-snug truncate">{item.customer.name}</div>
+            </div>
+            <div className="text-right shrink-0 text-2xs text-muted-foreground leading-snug whitespace-nowrap">
+              {staleLabel(item.pendingDunningSince)}
+            </div>
+          </div>
+
+          {/* Stage transition */}
+          <div className="text-2xs text-muted-foreground leading-snug mb-3">
+            {item.dunningStage} <span className="mx-1">→</span>{' '}
+            <span className="font-semibold text-foreground">{item.pendingDunningStage}</span>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={() => setShowReject(true)}
+              disabled={rejectPending}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium hover:bg-muted text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors"
+            >
+              <XCircle className="size-3.5" /> ปฏิเสธ
+            </button>
+            <button
+              onClick={() => onApprove(item.id)}
+              disabled={approvePending}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            >
+              <CheckCircle className="size-3.5" /> อนุมัติ
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <RejectDialog
+        open={showReject}
+        pending={rejectPending}
+        onCancel={() => setShowReject(false)}
+        onConfirm={(reason) => {
+          onReject(item.id, reason);
+          setShowReject(false);
+        }}
+      />
+    </>
+  );
+}
+
+/* ── MDM Row ─────────────────────────────────────────────────── */
+
+interface MdmRowProps {
+  item: PendingMdmRequest;
+  onApprove: (requestId: string) => void;
+  onReject: (requestId: string, reason: string) => void;
+  approvePending: boolean;
+  rejectPending: boolean;
+}
+
+export function MdmRow({ item, onApprove, onReject, approvePending, rejectPending }: MdmRowProps) {
+  const [showReject, setShowReject] = useState(false);
+
+  const actionLabel =
+    'เสนอล็อคเครื่อง' + (item.includeWallpaper ? ' + wallpaper' : '');
+
+  return (
+    <>
+      <div className="relative flex rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+        <div className={cn('w-1 shrink-0', heatStrip(item.proposedAt))} />
+        <div className="flex-1 p-4 min-w-0">
+          {/* action chip + contract# */}
+          <div className="flex items-start justify-between gap-3 mb-1.5">
+            <div className="min-w-0">
+              <span className="inline-flex items-center rounded-full text-2xs font-semibold px-2 py-0.5 leading-snug mb-1 bg-destructive/10 text-destructive">
+                {actionLabel}
+              </span>
+              <div className="font-mono text-xs text-primary font-medium">
+                {item.contract.contractNumber}
+              </div>
+              <div className="text-sm font-semibold leading-snug truncate">
+                {item.contract.customer.name}
+              </div>
+            </div>
+            <div className="text-right shrink-0 text-2xs text-muted-foreground leading-snug whitespace-nowrap">
+              {staleLabel(item.proposedAt)}
+            </div>
+          </div>
+
+          {/* reason + proposer */}
+          <div className="text-2xs text-muted-foreground leading-snug mb-1 line-clamp-2">
+            {item.reason}
+          </div>
+          <div className="text-2xs text-muted-foreground leading-snug mb-3">
+            เสนอโดย{' '}
+            <span className="font-medium text-foreground">{item.proposedBy.name}</span>
+            {' · '}
+            {item.contract.branch.name}
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={() => setShowReject(true)}
+              disabled={rejectPending}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium hover:bg-muted text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors"
+            >
+              <XCircle className="size-3.5" /> ปฏิเสธ
+            </button>
+            <button
+              onClick={() => onApprove(item.id)}
+              disabled={approvePending}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+            >
+              <CheckCircle className="size-3.5" /> อนุมัติล็อค
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <RejectDialog
+        open={showReject}
+        pending={rejectPending}
+        onCancel={() => setShowReject(false)}
+        onConfirm={(reason) => {
+          onReject(item.id, reason);
+          setShowReject(false);
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsFilters.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsFilters.tsx
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+interface Branch {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  search: string;
+  onSearchChange: (v: string) => void;
+  branchId: string;
+  onBranchChange: (v: string) => void;
+  showBranchFilter: boolean;
+}
+
+export default function CollectionsFilters({
+  search,
+  onSearchChange,
+  branchId,
+  onBranchChange,
+  showBranchFilter,
+}: Props) {
+  const { data: branches = [] } = useQuery<Branch[]>({
+    queryKey: ['branches'],
+    queryFn: async () => {
+      const { data } = await api.get('/branches');
+      return data?.data ?? data ?? [];
+    },
+    enabled: showBranchFilter,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return (
+    <div className="bg-card border border-border/50 shadow-sm rounded-xl p-4 mb-5">
+      <div className="flex gap-3 flex-wrap">
+        <input
+          type="text"
+          placeholder="ค้นหาเลขสัญญา, ชื่อลูกค้า, เบอร์โทร..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="px-3 py-2 border border-input rounded-lg text-sm min-w-[260px] focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background focus:border-transparent leading-snug"
+        />
+        {showBranchFilter && (
+          <select
+            value={branchId}
+            onChange={(e) => onBranchChange(e.target.value)}
+            className="px-3 py-2 border border-input rounded-lg text-sm min-w-[160px] leading-snug"
+          >
+            <option value="">ทุกสาขา</option>
+            {branches.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
@@ -1,0 +1,120 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { useCollectionsKpi } from '../hooks/useCollectionsKpi';
+
+interface KpiCardProps {
+  label: string;
+  value: React.ReactNode;
+  subtitle?: React.ReactNode;
+  strip: string;
+  loading?: boolean;
+}
+
+function KpiCard({ label, value, subtitle, strip, loading }: KpiCardProps) {
+  return (
+    <Card className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden hover:shadow-card-hover transition-all">
+      <div className="flex h-full">
+        <div className={`w-1 shrink-0 ${strip}`} />
+        <CardContent className="p-5 flex-1">
+          <div className="text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2 leading-snug">
+            {label}
+          </div>
+          {loading ? (
+            <div className="bg-muted animate-pulse h-7 rounded w-24 mb-1" />
+          ) : (
+            <div className="text-2xl font-bold tabular-nums leading-snug">{value}</div>
+          )}
+          {subtitle && !loading && (
+            <div className="text-xs text-muted-foreground mt-1 leading-snug">{subtitle}</div>
+          )}
+          {loading && (
+            <div className="bg-muted animate-pulse h-3 rounded w-32 mt-2 opacity-60" />
+          )}
+        </CardContent>
+      </div>
+    </Card>
+  );
+}
+
+export default function CollectionsKpiStrip() {
+  const { data, isLoading, isError, refetch } = useCollectionsKpi('7d');
+
+  if (isError) {
+    return (
+      <div className="mb-6 rounded-xl border border-destructive/30 bg-destructive/5 p-4 flex items-center justify-between">
+        <span className="text-sm text-destructive leading-snug">ไม่สามารถโหลด KPI ได้</span>
+        <button
+          onClick={() => refetch()}
+          className="px-3 py-1.5 text-xs border border-destructive/30 rounded-lg text-destructive hover:bg-destructive/10 transition-colors"
+        >
+          ลองใหม่
+        </button>
+      </div>
+    );
+  }
+
+  const trend = data?.queueTodayTrend ?? 0;
+  const trendEl =
+    trend !== 0 ? (
+      <span className={trend > 0 ? 'text-destructive' : 'text-success'}>
+        {trend > 0 ? '↑' : '↓'} {Math.abs(trend).toFixed(0)}%
+      </span>
+    ) : (
+      <span>วันนี้</span>
+    );
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 mb-6">
+      <KpiCard
+        label="ค้างรวม"
+        strip="bg-destructive"
+        loading={isLoading}
+        value={
+          <span>
+            {data?.totalOutstanding.toLocaleString() ?? '-'}{' '}
+            <span className="text-base font-medium">฿</span>
+          </span>
+        }
+        subtitle={
+          data ? (
+            <span>
+              + ค่าปรับ{' '}
+              <span className="tabular-nums text-destructive font-medium">
+                {data.totalLateFees.toLocaleString()}
+              </span>{' '}
+              ฿
+            </span>
+          ) : undefined
+        }
+      />
+      <KpiCard
+        label="คิววันนี้"
+        strip="bg-primary"
+        loading={isLoading}
+        value={<span className="text-primary">{data?.queueToday ?? '-'}</span>}
+        subtitle={trendEl}
+      />
+      <KpiCard
+        label="นัดชำระ"
+        strip="bg-warning"
+        loading={isLoading}
+        value={<span>{data?.promisedCount ?? '-'}</span>}
+        subtitle="รอชำระตามนัด"
+      />
+      <KpiCard
+        label="Promise-kept 7d"
+        strip="bg-success"
+        loading={isLoading}
+        value={
+          data ? (
+            <span className="text-success">
+              {(data.promiseKeptRate7d * 100).toFixed(0)}%
+            </span>
+          ) : (
+            '-'
+          )
+        }
+        subtitle="ช่วง 7 วันล่าสุด"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from '@/components/ui/card';
+import { formatNumber } from '@/utils/formatters';
 import { useCollectionsKpi } from '../hooks/useCollectionsKpi';
 
 interface KpiCardProps {
@@ -70,7 +71,7 @@ export default function CollectionsKpiStrip() {
         loading={isLoading}
         value={
           <span>
-            {data?.totalOutstanding.toLocaleString() ?? '-'}{' '}
+            {data ? formatNumber(data.totalOutstanding) : '-'}{' '}
             <span className="text-base font-medium">฿</span>
           </span>
         }
@@ -79,7 +80,7 @@ export default function CollectionsKpiStrip() {
             <span>
               + ค่าปรับ{' '}
               <span className="tabular-nums text-destructive font-medium">
-                {data.totalLateFees.toLocaleString()}
+                {formatNumber(data.totalLateFees)}
               </span>{' '}
               ฿
             </span>

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsTabs.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsTabs.tsx
@@ -1,0 +1,55 @@
+import { Phone, Clock, Calendar, ClipboardCheck, List } from 'lucide-react';
+import type { CollectionsTabKey } from '../index';
+
+interface Props {
+  active: CollectionsTabKey;
+  onChange: (key: CollectionsTabKey) => void;
+  canSeeApproval: boolean;
+  counts?: Partial<Record<CollectionsTabKey, number>>;
+}
+
+const TAB_CONFIG: Array<{
+  key: CollectionsTabKey;
+  label: string;
+  Icon: React.ElementType;
+}> = [
+  { key: 'today', label: 'คิววันนี้', Icon: Phone },
+  { key: 'followup', label: 'ตามต่อ', Icon: Clock },
+  { key: 'promise', label: 'นัดชำระ', Icon: Calendar },
+  { key: 'approval', label: 'อนุมัติ', Icon: ClipboardCheck },
+  { key: 'all', label: 'ทั้งหมด', Icon: List },
+];
+
+export default function CollectionsTabs({ active, onChange, canSeeApproval, counts }: Props) {
+  const visibleTabs = TAB_CONFIG.filter(
+    (t) => t.key !== 'approval' || canSeeApproval,
+  );
+
+  return (
+    <div className="flex gap-0 border-b border-border mb-4 overflow-x-auto">
+      {visibleTabs.map(({ key, label, Icon }) => {
+        const count = counts?.[key];
+        const isActive = active === key;
+        return (
+          <button
+            key={key}
+            onClick={() => onChange(key)}
+            className={`inline-flex items-center gap-1.5 px-4 py-2.5 text-sm border-b-2 transition-colors whitespace-nowrap ${
+              isActive
+                ? 'border-primary text-primary font-medium'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <Icon className="size-4 shrink-0" />
+            {label}
+            {count != null && count > 0 && (
+              <span className="bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 text-2xs tabular-nums leading-none">
+                {count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContactLogDialog from './ContactLogDialog';
+import type { ContractRow } from '../types';
+
+// Mock the hook so it doesn't require a real QueryClient
+vi.mock('../hooks/useContactLog', () => ({
+  useContactLog: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+const contract: ContractRow = {
+  id: 'ctr-1',
+  contractNumber: 'BC-2026-0001',
+  status: 'OVERDUE',
+  dunningStage: 'NOTICE',
+  customer: { id: 'cus-1', name: 'สมชาย ใจดี', phone: '0812345678', lineId: null },
+  branch: { id: 'br-1', name: 'สาขาลาดพร้าว' },
+  assignedTo: null,
+  outstanding: 5500,
+  daysOverdue: 12,
+  lastCallResult: null,
+  lastCallAt: null,
+  noAnswerCount: 0,
+  settlementDate: null,
+  needsSkipTracing: false,
+  deviceLocked: false,
+};
+
+describe('<ContactLogDialog />', () => {
+  it('renders when open', () => {
+    render(<ContactLogDialog open={true} contract={contract} onClose={vi.fn()} />);
+    expect(screen.getByText('ผลการติดต่อ')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(<ContactLogDialog open={false} contract={contract} onClose={vi.fn()} />);
+    expect(screen.queryByText('ผลการติดต่อ')).not.toBeInTheDocument();
+  });
+
+  it('reveals settlement section when result is PROMISED', async () => {
+    const user = userEvent.setup();
+    render(<ContactLogDialog open={true} contract={contract} onClose={vi.fn()} />);
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'PROMISED');
+
+    // Settlement section label appears
+    expect(screen.getByText(/วันที่นัดชำระ/)).toBeInTheDocument();
+  });
+
+  it('hides settlement section when result is NO_ANSWER', async () => {
+    const user = userEvent.setup();
+    render(<ContactLogDialog open={true} contract={contract} onClose={vi.fn()} />);
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'NO_ANSWER');
+
+    expect(screen.queryByText(/วันที่นัดชำระ/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect } from 'react';
+import Modal from '@/components/ui/Modal';
+import { useContactLog } from '../hooks/useContactLog';
+import type { ContractRow, CallResult } from '../types';
+
+interface Props {
+  open: boolean;
+  contract: ContractRow | null;
+  onClose: () => void;
+}
+
+const CALL_RESULT_LABELS: Record<CallResult, string> = {
+  NO_ANSWER: 'ไม่รับสาย',
+  ANSWERED: 'รับสาย',
+  PROMISED: 'นัดชำระ',
+  REFUSED: 'ปฏิเสธ',
+  WRONG_NUMBER: 'เบอร์ผิด',
+  OTHER: 'อื่น ๆ',
+};
+
+const LINE_NOTIFY_RESULTS: CallResult[] = ['NO_ANSWER', 'PROMISED', 'REFUSED'];
+
+const defaultForm = {
+  result: 'NO_ANSWER' as CallResult,
+  notes: '',
+  collectionNotes: '',
+  settlementDate: '',
+  settlementNotes: '',
+};
+
+// Derive tomorrow's date for min= on settlement date input
+function getTomorrow(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().split('T')[0];
+}
+
+export default function ContactLogDialog({ open, contract, onClose }: Props) {
+  const [form, setForm] = useState(defaultForm);
+  const mutation = useContactLog();
+
+  // Reset form whenever dialog opens for a new contract
+  useEffect(() => {
+    if (open) {
+      setForm(defaultForm);
+    }
+  }, [open, contract?.id]);
+
+  function handleClose() {
+    if (mutation.isPending) return;
+    onClose();
+  }
+
+  function handleSubmit() {
+    if (!contract) return;
+    const payload = {
+      contractId: contract.id,
+      result: form.result,
+      notes: form.notes || undefined,
+      collectionNotes: form.collectionNotes || undefined,
+      settlementDate: form.result === 'PROMISED' ? form.settlementDate || undefined : undefined,
+      settlementNotes:
+        form.result === 'PROMISED' ? form.settlementNotes || undefined : undefined,
+    };
+    mutation.mutate(payload, {
+      onSuccess: () => {
+        handleClose();
+      },
+    });
+  }
+
+  const showLineNotify = LINE_NOTIFY_RESULTS.includes(form.result as CallResult);
+  const showSettlement = form.result === 'PROMISED';
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={handleClose}
+      title={`บันทึกการติดต่อ — ${contract?.customer.name ?? ''}`}
+      size="md"
+    >
+      <div className="space-y-4">
+        {/* Contract summary */}
+        {contract && (
+          <div className="rounded-lg bg-muted/40 px-3 py-2 text-xs text-muted-foreground leading-snug">
+            <span className="font-mono text-primary font-medium">{contract.contractNumber}</span>
+            {' · '}ค้าง{' '}
+            <span className="tabular-nums font-medium text-destructive">
+              {contract.outstanding.toLocaleString()}
+            </span>{' '}
+            ฿ · {contract.daysOverdue} วัน
+          </div>
+        )}
+
+        {/* Result select */}
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1 block leading-snug">
+            ผลการติดต่อ <span className="text-destructive">*</span>
+          </label>
+          <select
+            value={form.result}
+            onChange={(e) => setForm({ ...form, result: e.target.value as CallResult })}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm leading-snug"
+          >
+            {(Object.keys(CALL_RESULT_LABELS) as CallResult[]).map((k) => (
+              <option key={k} value={k}>
+                {CALL_RESULT_LABELS[k]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Settlement fields (shown only for PROMISED) */}
+        {showSettlement && (
+          <div className="space-y-3 rounded-lg border border-border/50 bg-card p-3">
+            <div>
+              <label className="text-xs font-medium text-muted-foreground mb-1 block leading-snug">
+                วันที่นัดชำระ <span className="text-destructive">*</span>
+              </label>
+              <input
+                type="date"
+                min={getTomorrow()}
+                value={form.settlementDate}
+                onChange={(e) => setForm({ ...form, settlementDate: e.target.value })}
+                className="w-full px-3 py-2 border border-input rounded-lg text-sm leading-snug"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground mb-1 block leading-snug">
+                รายละเอียดการนัด
+              </label>
+              <textarea
+                value={form.settlementNotes}
+                onChange={(e) => setForm({ ...form, settlementNotes: e.target.value })}
+                placeholder="ระบุจำนวนเงินที่นัดจ่าย, ช่องทางการชำระ..."
+                rows={2}
+                className="w-full px-3 py-2 border border-input rounded-lg text-sm resize-none leading-snug"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Notes */}
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1 block leading-snug">
+            หมายเหตุการโทร
+          </label>
+          <textarea
+            value={form.notes}
+            onChange={(e) => setForm({ ...form, notes: e.target.value })}
+            placeholder="รายละเอียดการสนทนา..."
+            rows={2}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm resize-none leading-snug"
+          />
+        </div>
+
+        {/* Collection notes */}
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1 block leading-snug">
+            บันทึกผู้ติดตาม (อัปเดตบนสัญญา)
+          </label>
+          <textarea
+            value={form.collectionNotes}
+            onChange={(e) => setForm({ ...form, collectionNotes: e.target.value })}
+            placeholder="บันทึกสถานะการติดตาม..."
+            rows={2}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm resize-none leading-snug"
+          />
+        </div>
+
+        {/* LINE notify banner */}
+        {showLineNotify && (
+          <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-primary leading-snug">
+            แจ้งเตือน: ระบบจะส่ง LINE ทันทีหลังบันทึก
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-2 justify-end pt-1">
+          <button
+            onClick={handleClose}
+            disabled={mutation.isPending}
+            className="px-4 py-2 text-sm border border-input rounded-lg hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={
+              mutation.isPending ||
+              (showSettlement && !form.settlementDate)
+            }
+            className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+          >
+            {mutation.isPending ? 'กำลังบันทึก...' : 'บันทึก'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import Modal from '@/components/ui/Modal';
+import { formatNumber } from '@/utils/formatters';
 import { useContactLog } from '../hooks/useContactLog';
 import type { ContractRow, CallResult } from '../types';
 
@@ -86,7 +87,7 @@ export default function ContactLogDialog({ open, contract, onClose }: Props) {
             <span className="font-mono text-primary font-medium">{contract.contractNumber}</span>
             {' · '}ค้าง{' '}
             <span className="tabular-nums font-medium text-destructive">
-              {contract.outstanding.toLocaleString()}
+              {formatNumber(contract.outstanding)}
             </span>{' '}
             ฿ · {contract.daysOverdue} วัน
           </div>

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ContractCard from './ContractCard';
+import type { ContractRow } from '../types';
+
+// formatDateShort calls Intl under the hood — mock it so JSDOM doesn't vary
+vi.mock('@/utils/formatters', () => ({
+  formatDateShort: (d: Date) => d.toISOString().split('T')[0],
+}));
+
+const base: ContractRow = {
+  id: 'ctr-1',
+  contractNumber: 'BC-2026-0001',
+  status: 'OVERDUE',
+  dunningStage: 'NOTICE',
+  customer: { id: 'cus-1', name: 'สมชาย ใจดี', phone: '0812345678', lineId: null },
+  branch: { id: 'br-1', name: 'สาขาลาดพร้าว' },
+  assignedTo: null,
+  outstanding: 5500,
+  daysOverdue: 12,
+  lastCallResult: null,
+  lastCallAt: null,
+  noAnswerCount: 0,
+  settlementDate: null,
+  needsSkipTracing: false,
+  deviceLocked: false,
+};
+
+describe('<ContractCard />', () => {
+  it('renders the contract number', () => {
+    render(<ContractCard contract={base} onLogContact={vi.fn()} />);
+    expect(screen.getByText('BC-2026-0001')).toBeInTheDocument();
+  });
+
+  it('renders the days-overdue hero number', () => {
+    render(<ContractCard contract={base} onLogContact={vi.fn()} />);
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('shows "ยังไม่มอบหมาย" when assignedTo is null', () => {
+    render(<ContractCard contract={base} onLogContact={vi.fn()} />);
+    expect(screen.getByText('ยังไม่มอบหมาย')).toBeInTheDocument();
+  });
+
+  it('shows assignee name when assignedTo is set', () => {
+    const c: ContractRow = { ...base, assignedTo: { id: 'u1', name: 'นางสาวแนน' } };
+    render(<ContractCard contract={c} onLogContact={vi.fn()} />);
+    expect(screen.getByText('นางสาวแนน')).toBeInTheDocument();
+  });
+
+  it('shows "ล็อคแล้ว" chip when deviceLocked is true', () => {
+    const c: ContractRow = { ...base, deviceLocked: true };
+    render(<ContractCard contract={c} onLogContact={vi.fn()} />);
+    expect(screen.getByText('ล็อคแล้ว')).toBeInTheDocument();
+  });
+
+  it('does not show "ล็อคแล้ว" chip when deviceLocked is false', () => {
+    render(<ContractCard contract={base} onLogContact={vi.fn()} />);
+    expect(screen.queryByText('ล็อคแล้ว')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -8,7 +8,7 @@ import {
   UserCircle,
   NotebookPen,
 } from 'lucide-react';
-import { formatDateShort } from '@/utils/formatters';
+import { formatDateShort, formatNumber } from '@/utils/formatters';
 import type { ContractRow } from '../types';
 
 function priorityColor(daysOverdue: number): string {
@@ -71,7 +71,7 @@ export default function ContractCard({ contract, onLogContact, onOpen360 }: Prop
         <div className="text-sm font-medium tabular-nums mb-3 leading-snug">
           ค้าง{' '}
           <span className="text-destructive">
-            {contract.outstanding.toLocaleString()}
+            {formatNumber(contract.outstanding)}
           </span>{' '}
           ฿
         </div>

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -34,12 +34,20 @@ export default function ContractCard({ contract, onLogContact, onOpen360 }: Prop
         {/* Top row: contract# + name + branch | days-overdue hero */}
         <div className="flex items-start justify-between gap-3 mb-2 min-w-0">
           <div className="min-w-0">
-            <div
-              className="font-mono text-xs text-primary font-medium cursor-pointer hover:underline"
-              onClick={() => onOpen360?.(contract)}
-            >
-              {contract.contractNumber}
-            </div>
+            {onOpen360 ? (
+              <button
+                type="button"
+                onClick={() => onOpen360(contract)}
+                className="font-mono text-xs text-primary font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 rounded text-left"
+                aria-label={`เปิด Customer 360 ของสัญญา ${contract.contractNumber}`}
+              >
+                {contract.contractNumber}
+              </button>
+            ) : (
+              <div className="font-mono text-xs text-primary font-medium">
+                {contract.contractNumber}
+              </div>
+            )}
             <div className="text-sm font-semibold leading-snug truncate">
               {contract.customer.name}
             </div>

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -1,0 +1,135 @@
+import {
+  Phone,
+  PhoneMissed,
+  MessageCircle,
+  Lock,
+  Search,
+  CalendarCheck,
+  UserCircle,
+  NotebookPen,
+} from 'lucide-react';
+import { formatDateShort } from '@/utils/formatters';
+import type { ContractRow } from '../types';
+
+function priorityColor(daysOverdue: number): string {
+  if (daysOverdue >= 30) return 'bg-destructive';
+  if (daysOverdue >= 8) return 'bg-warning';
+  if (daysOverdue >= 1) return 'bg-primary';
+  return 'bg-muted';
+}
+
+interface Props {
+  contract: ContractRow;
+  onLogContact: (c: ContractRow) => void;
+  onOpen360?: (c: ContractRow) => void;
+}
+
+export default function ContractCard({ contract, onLogContact, onOpen360 }: Props) {
+  return (
+    <div className="group relative flex rounded-xl border border-border/50 bg-card shadow-sm hover:shadow-card-hover transition-shadow overflow-hidden">
+      {/* Priority heat strip */}
+      <div className={`w-1 shrink-0 ${priorityColor(contract.daysOverdue)}`} />
+
+      <div className="flex-1 p-4 min-w-0">
+        {/* Top row: contract# + name + branch | days-overdue hero */}
+        <div className="flex items-start justify-between gap-3 mb-2 min-w-0">
+          <div className="min-w-0">
+            <div
+              className="font-mono text-xs text-primary font-medium cursor-pointer hover:underline"
+              onClick={() => onOpen360?.(contract)}
+            >
+              {contract.contractNumber}
+            </div>
+            <div className="text-sm font-semibold leading-snug truncate">
+              {contract.customer.name}
+            </div>
+            <div className="text-2xs text-muted-foreground leading-snug">
+              {contract.branch.name}
+            </div>
+          </div>
+
+          {/* Days-overdue hero */}
+          <div className="text-right shrink-0">
+            <div className="text-3xl font-bold tabular-nums leading-none">
+              {contract.daysOverdue}
+            </div>
+            <div className="text-2xs text-muted-foreground uppercase tracking-wide leading-snug">
+              วัน
+            </div>
+          </div>
+        </div>
+
+        {/* Outstanding amount (secondary) */}
+        <div className="text-sm font-medium tabular-nums mb-3 leading-snug">
+          ค้าง{' '}
+          <span className="text-destructive">
+            {contract.outstanding.toLocaleString()}
+          </span>{' '}
+          ฿
+        </div>
+
+        {/* Status chip cluster */}
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {contract.noAnswerCount > 0 && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-warning/10 text-warning text-2xs font-medium px-2 py-0.5 leading-snug">
+              <PhoneMissed className="size-3" />
+              ไม่รับ {contract.noAnswerCount} ครั้ง
+            </span>
+          )}
+          {contract.customer.lineId && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-success/10 text-success text-2xs font-medium px-2 py-0.5 leading-snug">
+              <MessageCircle className="size-3" /> LINE
+            </span>
+          )}
+          {contract.deviceLocked && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-destructive/10 text-destructive text-2xs font-medium px-2 py-0.5 leading-snug">
+              <Lock className="size-3" /> ล็อคแล้ว
+            </span>
+          )}
+          {contract.needsSkipTracing && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-muted text-muted-foreground text-2xs font-medium px-2 py-0.5 leading-snug">
+              <Search className="size-3" /> หาเบอร์ใหม่
+            </span>
+          )}
+          {contract.settlementDate && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 text-primary text-2xs font-medium px-2 py-0.5 leading-snug">
+              <CalendarCheck className="size-3" /> นัด{' '}
+              {formatDateShort(new Date(contract.settlementDate))}
+            </span>
+          )}
+        </div>
+
+        {/* Bottom row: assignee + CTAs */}
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-2xs text-muted-foreground truncate leading-snug">
+            {contract.assignedTo ? (
+              <span className="inline-flex items-center gap-1">
+                <UserCircle className="size-3" />
+                {contract.assignedTo.name}
+              </span>
+            ) : (
+              <span className="italic">ยังไม่มอบหมาย</span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <a
+              href={`tel:${contract.customer.phone}`}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 tabular-nums transition-colors"
+            >
+              <Phone className="size-3.5" /> {contract.customer.phone}
+            </a>
+            <button
+              onClick={() => onLogContact(contract)}
+              className="rounded-lg border border-input p-1.5 hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+              title="บันทึกผลการโทร"
+              aria-label="บันทึกผลการโทร"
+            >
+              <NotebookPen className="size-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
@@ -81,6 +81,23 @@ export function useRejectMdm() {
     onSuccess: () => {
       toast.success('ปฏิเสธคำขอ');
       qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}
+
+export function useUnlockMdm() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      const { data } = await api.post(`/overdue/mdm-requests/${requestId}/unlock`);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('ปลดล็อคเครื่องสำเร็จ');
+      qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });

--- a/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
@@ -1,0 +1,87 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import type { PendingEscalation, PendingMdmRequest } from '../types';
+
+export function usePendingEscalations() {
+  return useQuery<PendingEscalation[]>({
+    queryKey: ['pending-escalations'],
+    queryFn: async () => {
+      const { data } = await api.get('/overdue/pending-escalations');
+      return data;
+    },
+  });
+}
+
+export function usePendingMdm() {
+  return useQuery<PendingMdmRequest[]>({
+    queryKey: ['pending-mdm'],
+    queryFn: async () => {
+      const { data } = await api.get('/overdue/mdm-pending');
+      return data;
+    },
+  });
+}
+
+export function useApproveEscalation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (contractId: string) => {
+      const { data } = await api.post(`/overdue/contracts/${contractId}/approve-escalation`);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('อนุมัติ dunning escalation สำเร็จ');
+      qc.invalidateQueries({ queryKey: ['pending-escalations'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}
+
+export function useRejectEscalation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ contractId, reason }: { contractId: string; reason: string }) => {
+      const { data } = await api.post(`/overdue/contracts/${contractId}/reject-escalation`, {
+        reason,
+      });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('ปฏิเสธแล้ว');
+      qc.invalidateQueries({ queryKey: ['pending-escalations'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}
+
+export function useApproveMdm() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      const { data } = await api.post(`/overdue/mdm-requests/${requestId}/approve`);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('อนุมัติล็อคเครื่อง');
+      qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}
+
+export function useRejectMdm() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ requestId, reason }: { requestId: string; reason: string }) => {
+      const { data } = await api.post(`/overdue/mdm-requests/${requestId}/reject`, { reason });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('ปฏิเสธคำขอ');
+      qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsFlag.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsFlag.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+/**
+ * Reads the collections_v2_enabled feature flag from the backend. Cached 5 min.
+ * When enabled=true, the app should route /overdue -> /collections.
+ */
+export function useCollectionsFlag() {
+  const { data, isLoading } = useQuery<{ enabled: boolean }>({
+    queryKey: ['collections-flag'],
+    queryFn: async () => {
+      const { data } = await api.get('/overdue/collections-flag');
+      return data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+  return { enabled: data?.enabled ?? false, isLoading };
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsKpi.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsKpi.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface CollectionsKpi {
+  totalOutstanding: number;
+  totalLateFees: number;
+  queueToday: number;
+  queueTodayTrend: number;
+  promisedCount: number;
+  promiseKeptRate7d: number;
+  avgCollectorWorkload: number;
+}
+
+export function useCollectionsKpi(range: '7d' | '30d' = '7d') {
+  return useQuery<CollectionsKpi>({
+    queryKey: ['collections-kpi', range],
+    queryFn: async () => {
+      const { data } = await api.get(`/overdue/kpi?range=${range}`);
+      return data;
+    },
+    refetchOnWindowFocus: true,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import type { ContractRow } from '../types';
+
+export interface QueueResponse {
+  data: ContractRow[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export type QueueTab = 'today' | 'followup' | 'promise';
+
+export function useCollectionsQueue(params: {
+  tab: QueueTab;
+  search: string;
+  branchId: string;
+  page: number;
+  limit: number;
+  enabled: boolean;
+}) {
+  const { tab, search, branchId, page, limit, enabled } = params;
+  return useQuery<QueueResponse>({
+    queryKey: ['collections-queue', tab, search, branchId, page, limit],
+    queryFn: async () => {
+      const q = new URLSearchParams({ tab, page: String(page), limit: String(limit) });
+      if (branchId) q.set('branchId', branchId);
+      const { data } = await api.get(`/overdue/queue?${q}`);
+      return data;
+    },
+    enabled,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
@@ -25,6 +25,8 @@ export function useCollectionsQueue(params: {
     queryFn: async () => {
       const q = new URLSearchParams({ tab, page: String(page), limit: String(limit) });
       if (branchId) q.set('branchId', branchId);
+      // C1 fix: push search to server so matches outside the first page are visible
+      if (search.trim()) q.set('search', search.trim());
       const { data } = await api.get(`/overdue/queue?${q}`);
       return data;
     },

--- a/apps/web/src/pages/CollectionsPage/hooks/useContactLog.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useContactLog.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export interface LogContactPayload {
+  contractId: string;
+  result: string;
+  notes?: string;
+  collectionNotes?: string;
+  settlementDate?: string;
+  settlementNotes?: string;
+}
+
+export function useContactLog() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ contractId, ...body }: LogContactPayload) => {
+      const { data } = await api.patch(`/overdue/${contractId}/contact-log`, body);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('บันทึกการติดต่อสำเร็จ');
+      queryClient.invalidateQueries({ queryKey: ['collections-queue'] });
+      queryClient.invalidateQueries({ queryKey: ['collections-kpi'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -5,6 +5,12 @@ import PageHeader from '@/components/ui/PageHeader';
 import CollectionsKpiStrip from './components/CollectionsKpiStrip';
 import CollectionsTabs from './components/CollectionsTabs';
 import CollectionsFilters from './components/CollectionsFilters';
+import ContactLogDialog from './components/ContactLogDialog';
+import QueueTab from './tabs/QueueTab';
+import FollowUpTab from './tabs/FollowUpTab';
+import PromiseTab from './tabs/PromiseTab';
+import AllTab from './tabs/AllTab';
+import type { ContractRow } from './types';
 
 export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all';
 
@@ -14,11 +20,14 @@ export default function CollectionsPage() {
   const [activeTab, setActiveTab] = useState<CollectionsTabKey>('today');
   const [search, setSearch] = useState('');
   const [branchId, setBranchId] = useState('');
+  const [dialogContract, setDialogContract] = useState<ContractRow | null>(null);
 
   const canSeeApproval = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
   const showBranchFilter = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
 
   const showFilters = activeTab === 'today' || activeTab === 'followup' || activeTab === 'promise';
+
+  const openContactDialog = (c: ContractRow) => setDialogContract(c);
 
   return (
     <div>
@@ -46,17 +55,32 @@ export default function CollectionsPage() {
         />
       )}
 
-      {/* Tab content placeholder — later tasks replace */}
-      <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
-        <div className="mb-2 font-medium text-foreground">
-          {activeTab === 'today' && 'คิววันนี้'}
-          {activeTab === 'followup' && 'ตามต่อ'}
-          {activeTab === 'promise' && 'นัดชำระ'}
-          {activeTab === 'approval' && 'อนุมัติ'}
-          {activeTab === 'all' && 'ทั้งหมด'}
+      {activeTab === 'today' && (
+        <QueueTab search={search} branchId={branchId} onLogContact={openContactDialog} />
+      )}
+
+      {activeTab === 'followup' && (
+        <FollowUpTab search={search} branchId={branchId} onLogContact={openContactDialog} />
+      )}
+
+      {activeTab === 'promise' && (
+        <PromiseTab search={search} branchId={branchId} onLogContact={openContactDialog} />
+      )}
+
+      {activeTab === 'approval' && (
+        <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
+          <div className="mb-2 font-medium text-foreground">อนุมัติ</div>
+          <div>Tab content จะถูกเพิ่มใน Task 12-13</div>
         </div>
-        <div>Tab content จะถูกเพิ่มใน Task 9-14</div>
-      </div>
+      )}
+
+      {activeTab === 'all' && <AllTab />}
+
+      <ContactLogDialog
+        open={!!dialogContract}
+        contract={dialogContract}
+        onClose={() => setDialogContract(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -3,6 +3,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import PageHeader from '@/components/ui/PageHeader';
 import CollectionsKpiStrip from './components/CollectionsKpiStrip';
+import CollectionsTabs from './components/CollectionsTabs';
+import CollectionsFilters from './components/CollectionsFilters';
 
 export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all';
 
@@ -10,16 +12,13 @@ export default function CollectionsPage() {
   useDocumentTitle('ติดตามหนี้');
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState<CollectionsTabKey>('today');
+  const [search, setSearch] = useState('');
+  const [branchId, setBranchId] = useState('');
 
   const canSeeApproval = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
+  const showBranchFilter = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
 
-  const tabs: Array<{ key: CollectionsTabKey; label: string; visible: boolean }> = [
-    { key: 'today', label: 'คิววันนี้', visible: true },
-    { key: 'followup', label: 'ตามต่อ', visible: true },
-    { key: 'promise', label: 'นัดชำระ', visible: true },
-    { key: 'approval', label: 'อนุมัติ', visible: canSeeApproval },
-    { key: 'all', label: 'ทั้งหมด', visible: true },
-  ];
+  const showFilters = activeTab === 'today' || activeTab === 'followup' || activeTab === 'promise';
 
   return (
     <div>
@@ -27,29 +26,34 @@ export default function CollectionsPage() {
 
       <CollectionsKpiStrip />
 
-      {/* Tabs */}
-      <div className="flex gap-1 border-b border-border mb-4 overflow-x-auto">
-        {tabs
-          .filter((t) => t.visible)
-          .map((t) => (
-            <button
-              key={t.key}
-              onClick={() => setActiveTab(t.key)}
-              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
-                activeTab === t.key
-                  ? 'border-primary text-primary'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {t.label}
-            </button>
-          ))}
-      </div>
+      <CollectionsTabs
+        active={activeTab}
+        onChange={(key) => {
+          setActiveTab(key);
+          setSearch('');
+          setBranchId('');
+        }}
+        canSeeApproval={canSeeApproval}
+      />
+
+      {showFilters && (
+        <CollectionsFilters
+          search={search}
+          onSearchChange={setSearch}
+          branchId={branchId}
+          onBranchChange={setBranchId}
+          showBranchFilter={showBranchFilter}
+        />
+      )}
 
       {/* Tab content placeholder — later tasks replace */}
       <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
         <div className="mb-2 font-medium text-foreground">
-          {tabs.find((t) => t.key === activeTab)?.label}
+          {activeTab === 'today' && 'คิววันนี้'}
+          {activeTab === 'followup' && 'ตามต่อ'}
+          {activeTab === 'promise' && 'นัดชำระ'}
+          {activeTab === 'approval' && 'อนุมัติ'}
+          {activeTab === 'all' && 'ทั้งหมด'}
         </div>
         <div>Tab content จะถูกเพิ่มใน Task 9-14</div>
       </div>

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import PageHeader from '@/components/ui/PageHeader';
+import CollectionsKpiStrip from './components/CollectionsKpiStrip';
 
 export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all';
 
@@ -24,10 +25,7 @@ export default function CollectionsPage() {
     <div>
       <PageHeader title="ติดตามหนี้" subtitle="คิวงานของผู้ติดตามหนี้รายวัน" />
 
-      {/* KPI strip placeholder — Task 6 replaces with CollectionsKpiStrip */}
-      <div className="mb-6 rounded-xl border border-border/50 bg-muted/30 p-5 text-sm text-muted-foreground">
-        KPI strip จะอยู่ที่นี่ (Task 6)
-      </div>
+      <CollectionsKpiStrip />
 
       {/* Tabs */}
       <div className="flex gap-1 border-b border-border mb-4 overflow-x-auto">

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -10,6 +10,7 @@ import QueueTab from './tabs/QueueTab';
 import FollowUpTab from './tabs/FollowUpTab';
 import PromiseTab from './tabs/PromiseTab';
 import AllTab from './tabs/AllTab';
+import ApprovalTab from './tabs/ApprovalTab';
 import type { ContractRow } from './types';
 
 export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all';
@@ -67,12 +68,7 @@ export default function CollectionsPage() {
         <PromiseTab search={search} branchId={branchId} onLogContact={openContactDialog} />
       )}
 
-      {activeTab === 'approval' && (
-        <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
-          <div className="mb-2 font-medium text-foreground">อนุมัติ</div>
-          <div>Tab content จะถูกเพิ่มใน Task 12-13</div>
-        </div>
-      )}
+      {activeTab === 'approval' && canSeeApproval && <ApprovalTab />}
 
       {activeTab === 'all' && <AllTab />}
 

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+
+export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all';
+
+export default function CollectionsPage() {
+  useDocumentTitle('ติดตามหนี้');
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<CollectionsTabKey>('today');
+
+  const canSeeApproval = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
+
+  const tabs: Array<{ key: CollectionsTabKey; label: string; visible: boolean }> = [
+    { key: 'today', label: 'คิววันนี้', visible: true },
+    { key: 'followup', label: 'ตามต่อ', visible: true },
+    { key: 'promise', label: 'นัดชำระ', visible: true },
+    { key: 'approval', label: 'อนุมัติ', visible: canSeeApproval },
+    { key: 'all', label: 'ทั้งหมด', visible: true },
+  ];
+
+  return (
+    <div>
+      <PageHeader title="ติดตามหนี้" subtitle="คิวงานของผู้ติดตามหนี้รายวัน" />
+
+      {/* KPI strip placeholder — Task 6 replaces with CollectionsKpiStrip */}
+      <div className="mb-6 rounded-xl border border-border/50 bg-muted/30 p-5 text-sm text-muted-foreground">
+        KPI strip จะอยู่ที่นี่ (Task 6)
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-border mb-4 overflow-x-auto">
+        {tabs
+          .filter((t) => t.visible)
+          .map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setActiveTab(t.key)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                activeTab === t.key
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+      </div>
+
+      {/* Tab content placeholder — later tasks replace */}
+      <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
+        <div className="mb-2 font-medium text-foreground">
+          {tabs.find((t) => t.key === activeTab)?.label}
+        </div>
+        <div>Tab content จะถูกเพิ่มใน Task 9-14</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/AllTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/AllTab.tsx
@@ -1,0 +1,14 @@
+import OverduePage from '@/pages/OverduePage';
+
+/**
+ * AllTab wraps the existing /overdue page for audit/admin use. Provides backward
+ * compatibility — the original table + kanban + all modals are preserved verbatim
+ * while collectors shift to the new workflow tabs.
+ *
+ * The original OverduePage includes its own PageHeader — appearing under the
+ * CollectionsPage PageHeader. Accepted as a temporary migration artifact;
+ * Plan 3 refactors OverduePage to be embeddable without its own header.
+ */
+export default function AllTab() {
+  return <OverduePage />;
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
@@ -1,0 +1,113 @@
+import { ShieldAlert, Lock } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  usePendingEscalations,
+  usePendingMdm,
+  useApproveEscalation,
+  useRejectEscalation,
+  useApproveMdm,
+  useRejectMdm,
+} from '../hooks/useApprovalQueues';
+import { EscalationRow, MdmRow } from '../components/ApprovalPendingRow';
+
+function RowSkeleton() {
+  return <div className="bg-muted animate-pulse h-20 rounded-lg" />;
+}
+
+export default function ApprovalTab() {
+  const escalations = usePendingEscalations();
+  const mdm = usePendingMdm();
+
+  const approveEscalation = useApproveEscalation();
+  const rejectEscalation = useRejectEscalation();
+  const approveMdm = useApproveMdm();
+  const rejectMdm = useRejectMdm();
+
+  return (
+    <div className="space-y-6">
+      {/* Dunning escalations queue */}
+      <Card className="rounded-xl border border-border/50 bg-card shadow-sm">
+        <CardContent className="p-5">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="size-4 text-warning" />
+              <h3 className="text-sm font-semibold leading-snug">รออนุมัติเลื่อนระดับเตือน</h3>
+            </div>
+            <span className="text-xs tabular-nums bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+              {escalations.data?.length ?? 0}
+            </span>
+          </div>
+
+          {escalations.isLoading ? (
+            <div className="space-y-2">
+              <RowSkeleton />
+              <RowSkeleton />
+            </div>
+          ) : !escalations.data || escalations.data.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-success/30 bg-success/5 py-8 text-center">
+              <div className="text-sm font-medium text-success leading-snug">
+                ไม่มีรายการรออนุมัติ
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {escalations.data.map((item) => (
+                <EscalationRow
+                  key={item.id}
+                  item={item}
+                  onApprove={(contractId) => approveEscalation.mutate(contractId)}
+                  onReject={(contractId, reason) =>
+                    rejectEscalation.mutate({ contractId, reason })
+                  }
+                  approvePending={approveEscalation.isPending}
+                  rejectPending={rejectEscalation.isPending}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* MDM lock queue */}
+      <Card className="rounded-xl border border-border/50 bg-card shadow-sm">
+        <CardContent className="p-5">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <Lock className="size-4 text-destructive" />
+              <h3 className="text-sm font-semibold leading-snug">รออนุมัติล็อคเครื่อง</h3>
+            </div>
+            <span className="text-xs tabular-nums bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+              {mdm.data?.length ?? 0}
+            </span>
+          </div>
+
+          {mdm.isLoading ? (
+            <div className="space-y-2">
+              <RowSkeleton />
+              <RowSkeleton />
+            </div>
+          ) : !mdm.data || mdm.data.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-success/30 bg-success/5 py-8 text-center">
+              <div className="text-sm font-medium text-success leading-snug">
+                ไม่มีรายการรออนุมัติ
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {mdm.data.map((item) => (
+                <MdmRow
+                  key={item.id}
+                  item={item}
+                  onApprove={(requestId) => approveMdm.mutate(requestId)}
+                  onReject={(requestId, reason) => rejectMdm.mutate({ requestId, reason })}
+                  approvePending={approveMdm.isPending}
+                  rejectPending={rejectMdm.isPending}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -41,19 +41,8 @@ export default function FollowUpTab({ search, branchId, onLogContact }: Props) {
   });
 
   const total = q.data?.total ?? 0;
-  const rows = q.data?.data ?? [];
-
-  // Client-side search filter
-  const filtered = debouncedSearch
-    ? rows.filter((r) => {
-        const term = debouncedSearch.toLowerCase();
-        return (
-          r.customer.name.toLowerCase().includes(term) ||
-          r.contractNumber.toLowerCase().includes(term) ||
-          r.customer.phone.toLowerCase().includes(term)
-        );
-      })
-    : rows;
+  // C1 fix: search is now server-side via useCollectionsQueue → /overdue/queue
+  const filtered = q.data?.data ?? [];
 
   return (
     <QueryBoundary

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { useDebounce } from '@/hooks/useDebounce';
+import QueryBoundary from '@/components/QueryBoundary';
+import ContractCard from '../components/ContractCard';
+import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
+import type { ContractRow } from '../types';
+
+const LIMIT = 50;
+
+function CardSkeleton() {
+  return (
+    <div className="flex rounded-xl border border-border/50 bg-card overflow-hidden h-[148px] animate-pulse">
+      <div className="w-1 shrink-0 bg-muted" />
+      <div className="flex-1 p-4 space-y-2">
+        <div className="h-3 w-24 rounded bg-muted" />
+        <div className="h-4 w-40 rounded bg-muted" />
+        <div className="h-3 w-20 rounded bg-muted" />
+        <div className="mt-3 h-3 w-32 rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  search: string;
+  branchId: string;
+  onLogContact: (c: ContractRow) => void;
+}
+
+export default function FollowUpTab({ search, branchId, onLogContact }: Props) {
+  const [page, setPage] = useState(1);
+  const debouncedSearch = useDebounce(search, 300);
+
+  const q = useCollectionsQueue({
+    tab: 'followup',
+    search: debouncedSearch,
+    branchId,
+    page,
+    limit: LIMIT,
+    enabled: true,
+  });
+
+  const total = q.data?.total ?? 0;
+  const rows = q.data?.data ?? [];
+
+  // Client-side search filter
+  const filtered = debouncedSearch
+    ? rows.filter((r) => {
+        const term = debouncedSearch.toLowerCase();
+        return (
+          r.customer.name.toLowerCase().includes(term) ||
+          r.contractNumber.toLowerCase().includes(term) ||
+          r.customer.phone.toLowerCase().includes(term)
+        );
+      })
+    : rows;
+
+  return (
+    <QueryBoundary
+      isLoading={q.isLoading}
+      isError={q.isError}
+      error={q.error}
+      onRetry={q.refetch}
+      loadingFallback={
+        <div className="space-y-2">
+          <CardSkeleton />
+          <CardSkeleton />
+          <CardSkeleton />
+        </div>
+      }
+    >
+      {filtered.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-primary/30 bg-primary/5 p-10 text-center">
+          <div className="text-4xl mb-3">✅</div>
+          <div className="text-sm font-medium text-primary leading-snug">
+            ไม่มีใครที่ต้องตามต่อ
+          </div>
+          <div className="text-xs text-muted-foreground mt-1 leading-snug">
+            ทุกคนติดต่อได้หมดแล้ว
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Context banner */}
+          <div className="mb-4 rounded-lg bg-warning/5 border border-warning/20 p-3 text-xs text-warning leading-snug">
+            <strong>ตามต่อ:</strong>{' '}
+            ลูกค้าที่เคยโทรไปแล้วแต่ไม่รับ — ถ้าไม่รับครั้งต่อไปครบ 3 ครั้ง
+            ระบบจะเสนอล็อคเครื่องอัตโนมัติ
+          </div>
+
+          <div className="space-y-2">
+            {filtered.map((row) =>
+              row.noAnswerCount === 2 ? (
+                <div key={row.id} className="ring-2 ring-destructive/40 rounded-xl">
+                  <ContractCard contract={row} onLogContact={onLogContact} />
+                </div>
+              ) : (
+                <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+              ),
+            )}
+          </div>
+
+          {total > LIMIT && (
+            <div className="mt-5 flex items-center justify-between text-xs text-muted-foreground">
+              <span className="leading-snug">
+                หน้า {page}/{Math.ceil(total / LIMIT)} · ทั้งหมด {total} รายการ
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  className="px-3 py-1 rounded border border-input hover:bg-muted disabled:opacity-50 transition-colors"
+                >
+                  ก่อนหน้า
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={page * LIMIT >= total}
+                  className="px-3 py-1 rounded border border-input hover:bg-muted disabled:opacity-50 transition-colors"
+                >
+                  ถัดไป
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </QueryBoundary>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { CheckCircle2 } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
@@ -60,7 +61,7 @@ export default function FollowUpTab({ search, branchId, onLogContact }: Props) {
     >
       {filtered.length === 0 ? (
         <div className="rounded-xl border border-dashed border-primary/30 bg-primary/5 p-10 text-center">
-          <div className="text-4xl mb-3">✅</div>
+          <CheckCircle2 className="size-10 mx-auto mb-3 text-primary" />
           <div className="text-sm font-medium text-primary leading-snug">
             ไม่มีใครที่ต้องตามต่อ
           </div>

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -99,19 +99,8 @@ export default function PromiseTab({ search, branchId, onLogContact }: Props) {
   });
 
   const total = q.data?.total ?? 0;
-  const rows = q.data?.data ?? [];
-
-  // Client-side search filter
-  const filtered = debouncedSearch
-    ? rows.filter((r) => {
-        const term = debouncedSearch.toLowerCase();
-        return (
-          r.customer.name.toLowerCase().includes(term) ||
-          r.contractNumber.toLowerCase().includes(term) ||
-          r.customer.phone.toLowerCase().includes(term)
-        );
-      })
-    : rows;
+  // C1 fix: search is now server-side via useCollectionsQueue → /overdue/queue
+  const filtered = q.data?.data ?? [];
 
   const groups = groupRows(filtered);
   const isEmpty = filtered.length === 0;

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Calendar } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
@@ -100,10 +100,10 @@ export default function PromiseTab({ search, branchId, onLogContact }: Props) {
 
   const total = q.data?.total ?? 0;
   // C1 fix: search is now server-side via useCollectionsQueue → /overdue/queue
-  const filtered = q.data?.data ?? [];
+  const rows = q.data?.data ?? [];
 
-  const groups = groupRows(filtered);
-  const isEmpty = filtered.length === 0;
+  const groups = groupRows(rows);
+  const isEmpty = rows.length === 0;
 
   return (
     <QueryBoundary
@@ -121,7 +121,7 @@ export default function PromiseTab({ search, branchId, onLogContact }: Props) {
     >
       {isEmpty ? (
         <div className="rounded-xl border border-dashed border-border p-10 text-center">
-          <div className="text-4xl mb-3">📅</div>
+          <Calendar className="size-10 mx-auto mb-3 text-muted-foreground" />
           <div className="text-sm font-medium text-foreground leading-snug">
             ไม่มีนัดชำระในช่วงนี้
           </div>

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -1,0 +1,219 @@
+import { useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { useDebounce } from '@/hooks/useDebounce';
+import QueryBoundary from '@/components/QueryBoundary';
+import ContractCard from '../components/ContractCard';
+import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
+import type { ContractRow } from '../types';
+
+const LIMIT = 50;
+
+function CardSkeleton() {
+  return (
+    <div className="flex rounded-xl border border-border/50 bg-card overflow-hidden h-[148px] animate-pulse">
+      <div className="w-1 shrink-0 bg-muted" />
+      <div className="flex-1 p-4 space-y-2">
+        <div className="h-3 w-24 rounded bg-muted" />
+        <div className="h-4 w-40 rounded bg-muted" />
+        <div className="h-3 w-20 rounded bg-muted" />
+        <div className="mt-3 h-3 w-32 rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+function todayDateString(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+function tomorrowDateString(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().split('T')[0];
+}
+
+function thirtyDaysFromNow(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 30);
+  return d.toISOString().split('T')[0];
+}
+
+interface GroupedRows {
+  today: ContractRow[];
+  broken: ContractRow[];
+  upcoming: ContractRow[];
+}
+
+function groupRows(rows: ContractRow[]): GroupedRows {
+  const todayStr = todayDateString();
+  const tomorrowStr = tomorrowDateString();
+  const limitStr = thirtyDaysFromNow();
+
+  const sorted = [...rows].sort((a, b) => {
+    if (!a.settlementDate) return 1;
+    if (!b.settlementDate) return -1;
+    return a.settlementDate.localeCompare(b.settlementDate);
+  });
+
+  const today: ContractRow[] = [];
+  const broken: ContractRow[] = [];
+  const upcoming: ContractRow[] = [];
+
+  for (const row of sorted) {
+    if (!row.settlementDate) {
+      upcoming.push(row);
+      continue;
+    }
+    const d = row.settlementDate.split('T')[0];
+    if (d < todayStr) {
+      broken.push(row);
+    } else if (d === todayStr) {
+      today.push(row);
+    } else if (d >= tomorrowStr && d <= limitStr) {
+      upcoming.push(row);
+    } else {
+      upcoming.push(row);
+    }
+  }
+
+  return { today, broken, upcoming };
+}
+
+interface Props {
+  search: string;
+  branchId: string;
+  onLogContact: (c: ContractRow) => void;
+}
+
+export default function PromiseTab({ search, branchId, onLogContact }: Props) {
+  const [page, setPage] = useState(1);
+  const debouncedSearch = useDebounce(search, 300);
+
+  const q = useCollectionsQueue({
+    tab: 'promise',
+    search: debouncedSearch,
+    branchId,
+    page,
+    limit: LIMIT,
+    enabled: true,
+  });
+
+  const total = q.data?.total ?? 0;
+  const rows = q.data?.data ?? [];
+
+  // Client-side search filter
+  const filtered = debouncedSearch
+    ? rows.filter((r) => {
+        const term = debouncedSearch.toLowerCase();
+        return (
+          r.customer.name.toLowerCase().includes(term) ||
+          r.contractNumber.toLowerCase().includes(term) ||
+          r.customer.phone.toLowerCase().includes(term)
+        );
+      })
+    : rows;
+
+  const groups = groupRows(filtered);
+  const isEmpty = filtered.length === 0;
+
+  return (
+    <QueryBoundary
+      isLoading={q.isLoading}
+      isError={q.isError}
+      error={q.error}
+      onRetry={q.refetch}
+      loadingFallback={
+        <div className="space-y-2">
+          <CardSkeleton />
+          <CardSkeleton />
+          <CardSkeleton />
+        </div>
+      }
+    >
+      {isEmpty ? (
+        <div className="rounded-xl border border-dashed border-border p-10 text-center">
+          <div className="text-4xl mb-3">📅</div>
+          <div className="text-sm font-medium text-foreground leading-snug">
+            ไม่มีนัดชำระในช่วงนี้
+          </div>
+          <div className="text-xs text-muted-foreground mt-1 leading-snug">
+            ลูกค้าที่นัดชำระไว้จะปรากฏที่นี่
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-6">
+            {/* เลยนัดแล้ว */}
+            {groups.broken.length > 0 && (
+              <section>
+                <h3 className="text-xs uppercase tracking-wider text-destructive font-semibold mb-2 flex items-center gap-2 leading-snug">
+                  <AlertTriangle className="size-3.5" />
+                  เลยนัดแล้ว — ต้องตามทันที
+                </h3>
+                <div className="space-y-2">
+                  {groups.broken.map((row) => (
+                    <div key={row.id} className="ring-2 ring-destructive/50 rounded-xl">
+                      <ContractCard contract={row} onLogContact={onLogContact} />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* วันนี้ครบกำหนดนัด */}
+            {groups.today.length > 0 && (
+              <section>
+                <h3 className="text-xs uppercase tracking-wider text-muted-foreground mb-2 leading-snug">
+                  วันนี้ครบกำหนดนัด
+                </h3>
+                <div className="space-y-2">
+                  {groups.today.map((row) => (
+                    <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* กำลังจะถึง */}
+            {groups.upcoming.length > 0 && (
+              <section>
+                <h3 className="text-xs uppercase tracking-wider text-muted-foreground mb-2 leading-snug">
+                  กำลังจะถึง
+                </h3>
+                <div className="space-y-2">
+                  {groups.upcoming.map((row) => (
+                    <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+
+          {total > LIMIT && (
+            <div className="mt-5 flex items-center justify-between text-xs text-muted-foreground">
+              <span className="leading-snug">
+                หน้า {page}/{Math.ceil(total / LIMIT)} · ทั้งหมด {total} รายการ
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  className="px-3 py-1 rounded border border-input hover:bg-muted disabled:opacity-50 transition-colors"
+                >
+                  ก่อนหน้า
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={page * LIMIT >= total}
+                  className="px-3 py-1 rounded border border-input hover:bg-muted disabled:opacity-50 transition-colors"
+                >
+                  ถัดไป
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </QueryBoundary>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { useDebounce } from '@/hooks/useDebounce';
+import QueryBoundary from '@/components/QueryBoundary';
+import ContractCard from '../components/ContractCard';
+import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
+import type { ContractRow } from '../types';
+
+const LIMIT = 50;
+
+function CardSkeleton() {
+  return (
+    <div className="flex rounded-xl border border-border/50 bg-card overflow-hidden h-[148px] animate-pulse">
+      <div className="w-1 shrink-0 bg-muted" />
+      <div className="flex-1 p-4 space-y-2">
+        <div className="h-3 w-24 rounded bg-muted" />
+        <div className="h-4 w-40 rounded bg-muted" />
+        <div className="h-3 w-20 rounded bg-muted" />
+        <div className="mt-3 h-3 w-32 rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  search: string;
+  branchId: string;
+  onLogContact: (c: ContractRow) => void;
+}
+
+export default function QueueTab({ search, branchId, onLogContact }: Props) {
+  const [page, setPage] = useState(1);
+  const debouncedSearch = useDebounce(search, 300);
+
+  const q = useCollectionsQueue({
+    tab: 'today',
+    search: debouncedSearch,
+    branchId,
+    page,
+    limit: LIMIT,
+    enabled: true,
+  });
+
+  const total = q.data?.total ?? 0;
+  const rows = q.data?.data ?? [];
+
+  // Client-side search filter
+  const filtered = debouncedSearch
+    ? rows.filter((r) => {
+        const term = debouncedSearch.toLowerCase();
+        return (
+          r.customer.name.toLowerCase().includes(term) ||
+          r.contractNumber.toLowerCase().includes(term) ||
+          r.customer.phone.toLowerCase().includes(term)
+        );
+      })
+    : rows;
+
+  return (
+    <QueryBoundary
+      isLoading={q.isLoading}
+      isError={q.isError}
+      error={q.error}
+      onRetry={q.refetch}
+      loadingFallback={
+        <div className="space-y-2">
+          <CardSkeleton />
+          <CardSkeleton />
+          <CardSkeleton />
+        </div>
+      }
+    >
+      {filtered.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-success/30 bg-success/5 p-10 text-center">
+          <div className="text-4xl mb-3">🎉</div>
+          <div className="text-sm font-medium text-success leading-snug">
+            ไม่มีคิวติดตามวันนี้
+          </div>
+          <div className="text-xs text-muted-foreground mt-1 leading-snug">
+            กลับมาพรุ่งนี้เช้า
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2">
+            {filtered.map((row) => (
+              <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+            ))}
+          </div>
+
+          {total > LIMIT && (
+            <div className="mt-5 flex items-center justify-between text-xs text-muted-foreground">
+              <span className="leading-snug">
+                หน้า {page}/{Math.ceil(total / LIMIT)} · ทั้งหมด {total} รายการ
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  className="px-3 py-1 rounded border border-input hover:bg-muted disabled:opacity-50 transition-colors"
+                >
+                  ก่อนหน้า
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={page * LIMIT >= total}
+                  className="px-3 py-1 rounded border border-input hover:bg-muted disabled:opacity-50 transition-colors"
+                >
+                  ถัดไป
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </QueryBoundary>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -41,19 +41,10 @@ export default function QueueTab({ search, branchId, onLogContact }: Props) {
   });
 
   const total = q.data?.total ?? 0;
-  const rows = q.data?.data ?? [];
-
-  // Client-side search filter
-  const filtered = debouncedSearch
-    ? rows.filter((r) => {
-        const term = debouncedSearch.toLowerCase();
-        return (
-          r.customer.name.toLowerCase().includes(term) ||
-          r.contractNumber.toLowerCase().includes(term) ||
-          r.customer.phone.toLowerCase().includes(term)
-        );
-      })
-    : rows;
+  // C1 fix: search is now server-side via useCollectionsQueue → /overdue/queue
+  // so the returned page is already filtered. No client-side narrowing needed;
+  // previously the filter only matched the current page, missing hits past it.
+  const filtered = q.data?.data ?? [];
 
   return (
     <QueryBoundary

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { CheckCircle2 } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
@@ -62,7 +63,7 @@ export default function QueueTab({ search, branchId, onLogContact }: Props) {
     >
       {filtered.length === 0 ? (
         <div className="rounded-xl border border-dashed border-success/30 bg-success/5 p-10 text-center">
-          <div className="text-4xl mb-3">🎉</div>
+          <CheckCircle2 className="size-10 mx-auto mb-3 text-success" />
           <div className="text-sm font-medium text-success leading-snug">
             ไม่มีคิวติดตามวันนี้
           </div>

--- a/apps/web/src/pages/CollectionsPage/types.ts
+++ b/apps/web/src/pages/CollectionsPage/types.ts
@@ -1,3 +1,27 @@
+export interface PendingEscalation {
+  id: string;
+  contractNumber: string;
+  dunningStage: string;
+  pendingDunningStage: string;
+  pendingDunningSince: string;
+  customer: { id: string; name: string; phone: string };
+}
+
+export interface PendingMdmRequest {
+  id: string;
+  trigger: string;
+  includeWallpaper: boolean;
+  reason: string;
+  proposedAt: string;
+  contract: {
+    id: string;
+    contractNumber: string;
+    customer: { id: string; name: string; phone: string };
+    branch: { id: string; name: string };
+  };
+  proposedBy: { id: string; name: string };
+}
+
 export interface ContractRow {
   id: string;
   contractNumber: string;

--- a/apps/web/src/pages/CollectionsPage/types.ts
+++ b/apps/web/src/pages/CollectionsPage/types.ts
@@ -1,0 +1,25 @@
+export interface ContractRow {
+  id: string;
+  contractNumber: string;
+  status: string;
+  dunningStage: string;
+  customer: { id: string; name: string; phone: string; lineId: string | null };
+  branch: { id: string; name: string };
+  assignedTo: { id: string; name: string } | null;
+  outstanding: number;
+  daysOverdue: number;
+  lastCallResult: string | null;
+  lastCallAt: string | null;
+  noAnswerCount: number;
+  settlementDate: string | null;
+  needsSkipTracing: boolean;
+  deviceLocked: boolean;
+}
+
+export type CallResult =
+  | 'NO_ANSWER'
+  | 'ANSWERED'
+  | 'PROMISED'
+  | 'REFUSED'
+  | 'WRONG_NUMBER'
+  | 'OTHER';

--- a/docs/superpowers/plans/2026-04-24-collections-workflow-hub-plan.md
+++ b/docs/superpowers/plans/2026-04-24-collections-workflow-hub-plan.md
@@ -1,0 +1,740 @@
+# Collections Workflow Hub — Plan 2/4: Frontend Workflow Hub
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recommended) or superpowers:executing-plans.
+
+**Goal:** Ship the new `/collections` page with 5 tabs + ContractCard + KPI strip. Behind a SystemConfig feature flag so OWNER controls rollout. Old `/overdue` redirects to `/collections` when flag is on; otherwise falls through.
+
+**Architecture:** New React page tree at `apps/web/src/pages/CollectionsPage/` with tabs for daily workflow (คิววันนี้ / ตามต่อ / นัดชำระ / อนุมัติ / ทั้งหมด). Backend adds queue + KPI endpoints. Existing `/overdue` logic preserved inside the AllTab for audit/backup.
+
+**Tech Stack:** NestJS (api), React 18 + Vite + Tailwind + shadcn/ui (web), @tanstack/react-query.
+
+**Spec:** [docs/superpowers/specs/2026-04-24-collections-workflow-hub-design.md](../specs/2026-04-24-collections-workflow-hub-design.md) §3, §8, §11.
+
+**Depends on:** Plan 1 foundation (schema, event engine, MdmLockService). Branch off `feat/collections-foundation`.
+
+---
+
+## File Map
+
+### Create — Backend
+
+- `apps/api/src/modules/overdue/queue.service.ts` + `.spec.ts` — tabbed queries
+- `apps/api/src/modules/overdue/kpi.service.ts` + `.spec.ts` — KPI aggregation
+- `apps/api/src/modules/overdue/dto/queue-query.dto.ts`
+
+### Modify — Backend
+
+- `apps/api/src/modules/overdue/overdue.controller.ts` — add `/queue`, `/kpi`, `/mdm-pending`
+- `apps/api/src/modules/overdue/overdue.module.ts` — register QueueService + KpiService
+- `apps/api/src/modules/overdue/mdm-lock.service.ts` — expose `getPendingByRole` via controller (already implemented)
+
+### Create — Frontend
+
+```
+apps/web/src/pages/CollectionsPage/
+  index.tsx                        # shell: tabs + route guard
+  hooks/
+    useCollectionsQueue.ts         # tab-specific queries
+    useCollectionsKpi.ts
+    useContactLog.ts               # shared mutation used by multiple tabs
+    useCollectionsFlag.ts          # reads feature flag
+  components/
+    CollectionsKpiStrip.tsx
+    CollectionsTabs.tsx
+    CollectionsFilters.tsx
+    ContractCard.tsx
+    ContactLogDialog.tsx
+    AssignCollectorInlineDialog.tsx
+    ApprovalPendingRow.tsx
+  tabs/
+    QueueTab.tsx                   # คิววันนี้
+    FollowUpTab.tsx                # ตามต่อ (NO_ANSWER)
+    PromiseTab.tsx                 # นัดชำระ
+    ApprovalTab.tsx                # อนุมัติ (dunning escalations + mdm)
+    AllTab.tsx                     # existing /overdue moved here
+```
+
+### Modify — Frontend
+
+- `apps/web/src/App.tsx` — add `/collections` route + redirect logic from `/overdue`
+- `apps/web/src/components/layout/MainLayout.tsx` — sidebar nav link (if it has one for /overdue, swap to /collections when flag on)
+- `apps/web/src/pages/OverduePage.tsx` → moved to `CollectionsPage/tabs/AllTab.tsx` (keep exports)
+
+### System config
+
+- Seed `collections_v2_enabled` (string: "true"|"false") — Task 1 of this plan
+
+---
+
+## Ground Rules
+
+1. **Feature flag first.** Everything user-facing hides behind `collections_v2_enabled`. Default: `true` in dev, `false` in prod (owner toggles via settings).
+2. **TDD for services** (backend). For UI, prefer vitest unit tests on hooks + RTL component tests.
+3. **Commit per task.** Push frequently.
+4. **Type-check + existing test suite** green before commit.
+5. **No new deps.** Use existing shadcn/ui + Tailwind.
+6. **Thai UI copy.** Collectors are Thai-speaking staff.
+7. **Reuse Plan 1 infra.** Don't re-implement logContact / event triggers — just call the existing endpoints.
+
+---
+
+## Task 1: Seed feature flag + backend KPI endpoint skeleton
+
+**Files:**
+- Modify: `apps/api/prisma/seeds/collections-foundation.seed.ts` — add `collections_v2_enabled` key
+- Modify: `apps/api/prisma/seed-production.ts` — no change (already calls foundation seed)
+
+- [ ] Add new SystemConfig key in the `configs` array of `seedCollectionsFoundation`:
+
+```typescript
+{ key: 'collections_v2_enabled', value: 'false', description: 'Enable /collections workflow hub page (Plan 2)' },
+```
+
+Place before the `mdm_*` block for alphabetical ordering.
+
+- [ ] Re-run idempotent seed: `cd apps/api && npx jest collections-foundation`
+- [ ] Commit: `feat(seed): add collections_v2_enabled feature flag (default false)`
+
+---
+
+## Task 2: Backend — OverdueQueueService
+
+**Files:**
+- Create: `apps/api/src/modules/overdue/queue.service.ts`
+- Create: `apps/api/src/modules/overdue/queue.service.spec.ts`
+- Create: `apps/api/src/modules/overdue/dto/queue-query.dto.ts`
+- Modify: `apps/api/src/modules/overdue/overdue.controller.ts`
+- Modify: `apps/api/src/modules/overdue/overdue.module.ts`
+
+### Behavior
+
+`GET /overdue/queue?tab=today|followup|promise&branchId=&page=&limit=` returns `{ data: ContractRow[], total, page, limit }`.
+
+**Tab filters:**
+| tab | filter |
+|---|---|
+| `today` | `status IN (ACTIVE, OVERDUE)` + oldest overdue payment ≤ today + no callLog.calledAt today + `blockAutoEscalation` null or expired |
+| `followup` | latest callLog.result = NO_ANSWER + `noAnswerCount < 3` |
+| `promise` | exists callLog with `settlementDate BETWEEN today-3 AND today+30` AND `result IN (PROMISED, ANSWERED)` |
+
+**ContractRow shape:**
+```typescript
+{
+  id: string;
+  contractNumber: string;
+  status: string;
+  dunningStage: string;
+  customer: { id: string; name: string; phone: string; lineId: string | null };
+  branch: { id: string; name: string };
+  assignedTo: { id: string; name: string } | null;
+  outstanding: number;
+  daysOverdue: number;
+  lastCallResult: string | null;
+  lastCallAt: string | null;
+  noAnswerCount: number;
+  settlementDate: string | null;
+  needsSkipTracing: boolean;
+  deviceLocked: boolean;
+}
+```
+
+### Steps
+
+- [ ] Write failing tests (mock-based, mirror `mdm-lock.service.spec.ts` style):
+  - Returns correct shape
+  - `today` filter respects branch scoping for SALES
+  - `followup` excludes contracts with noAnswerCount >= 3
+  - `promise` includes future-dated + recently-passed nudges
+  - Pagination caps limit at 100
+
+- [ ] Implement `QueueService`:
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export type QueueTab = 'today' | 'followup' | 'promise';
+
+@Injectable()
+export class OverdueQueueService {
+  constructor(private prisma: PrismaService) {}
+
+  async getQueue(params: {
+    tab: QueueTab;
+    userRole: string;
+    userBranchId: string | null;
+    branchId?: string;
+    page?: number;
+    limit?: number;
+  }) {
+    const page = params.page ?? 1;
+    const limit = Math.min(params.limit ?? 50, 100);
+    const skip = (page - 1) * limit;
+    const now = new Date();
+
+    const branchScope: Prisma.ContractWhereInput =
+      params.userRole === 'SALES' || params.userRole === 'BRANCH_MANAGER'
+        ? { branchId: params.userBranchId ?? undefined }
+        : params.branchId
+        ? { branchId: params.branchId }
+        : {};
+
+    const where = this.buildWhere(params.tab, now, branchScope);
+
+    const [contracts, total] = await Promise.all([
+      this.prisma.contract.findMany({
+        where,
+        include: {
+          customer: { select: { id: true, name: true, phone: true, lineId: true } },
+          branch: { select: { id: true, name: true } },
+          assignedTo: { select: { id: true, name: true } },
+          payments: {
+            where: { status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] } },
+            orderBy: { dueDate: 'asc' },
+            take: 1,
+          },
+          callLogs: {
+            orderBy: { calledAt: 'desc' },
+            take: 1,
+          },
+        },
+        orderBy: { updatedAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.contract.count({ where }),
+    ]);
+
+    const data = contracts.map((c) => this.toRow(c, now));
+
+    return { data, total, page, limit };
+  }
+
+  private buildWhere(tab: QueueTab, now: Date, branchScope: Prisma.ContractWhereInput): Prisma.ContractWhereInput {
+    const startOfDay = new Date(now); startOfDay.setHours(0, 0, 0, 0);
+
+    if (tab === 'today') {
+      return {
+        ...branchScope,
+        status: { in: ['ACTIVE', 'OVERDUE'] },
+        deletedAt: null,
+        OR: [{ blockAutoEscalation: null }, { blockAutoEscalation: { lt: now } }],
+        payments: {
+          some: {
+            dueDate: { lte: now },
+            status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+          },
+        },
+        callLogs: {
+          none: { calledAt: { gte: startOfDay } },
+        },
+      };
+    }
+
+    if (tab === 'followup') {
+      // We'll filter lastCallResult client-side (easier than nested aggregate)
+      return {
+        ...branchScope,
+        status: { in: ['OVERDUE', 'DEFAULT'] },
+        deletedAt: null,
+        noAnswerCount: { gte: 1, lt: 3 },
+      };
+    }
+
+    // promise
+    const todayMinus3 = new Date(now.getTime() - 3 * 86400000);
+    const todayPlus30 = new Date(now.getTime() + 30 * 86400000);
+    return {
+      ...branchScope,
+      deletedAt: null,
+      callLogs: {
+        some: {
+          result: { in: ['PROMISED', 'ANSWERED'] },
+          settlementDate: { gte: todayMinus3, lte: todayPlus30 },
+        },
+      },
+    };
+  }
+
+  private toRow(c: any, now: Date) {
+    const payment = c.payments[0];
+    const callLog = c.callLogs[0];
+    const outstanding = payment
+      ? new Prisma.Decimal(payment.amountDue).sub(payment.amountPaid).add(payment.lateFee).toNumber()
+      : 0;
+    const daysOverdue = payment
+      ? Math.max(0, Math.floor((now.getTime() - new Date(payment.dueDate).getTime()) / 86400000))
+      : 0;
+    return {
+      id: c.id,
+      contractNumber: c.contractNumber,
+      status: c.status,
+      dunningStage: c.dunningStage,
+      customer: c.customer,
+      branch: c.branch,
+      assignedTo: c.assignedTo,
+      outstanding,
+      daysOverdue,
+      lastCallResult: callLog?.result ?? null,
+      lastCallAt: callLog?.calledAt ?? null,
+      noAnswerCount: c.noAnswerCount,
+      settlementDate: callLog?.settlementDate ?? null,
+      needsSkipTracing: c.needsSkipTracing,
+      deviceLocked: c.deviceLocked,
+    };
+  }
+}
+```
+
+- [ ] DTO `queue-query.dto.ts`:
+
+```typescript
+import { IsEnum, IsInt, IsOptional, IsString, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueueQueryDto {
+  @IsEnum(['today','followup','promise'], { message: 'tab ต้องเป็น today, followup, หรือ promise' })
+  tab!: 'today' | 'followup' | 'promise';
+
+  @IsOptional() @IsString()
+  branchId?: string;
+
+  @IsOptional() @Type(() => Number) @IsInt() @Min(1)
+  page?: number;
+
+  @IsOptional() @Type(() => Number) @IsInt() @Min(1) @Max(100)
+  limit?: number;
+}
+```
+
+- [ ] Controller route:
+
+```typescript
+  @Get('queue')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getQueue(
+    @Query() dto: QueueQueryDto,
+    @CurrentUser() user: { role: string; branchId: string | null },
+  ) {
+    return this.queueService.getQueue({
+      tab: dto.tab,
+      branchId: dto.branchId,
+      page: dto.page,
+      limit: dto.limit,
+      userRole: user.role,
+      userBranchId: user.branchId,
+    });
+  }
+```
+
+Inject `OverdueQueueService` in constructor.
+
+- [ ] Register in module (providers + exports).
+
+- [ ] TS + test + commit: `feat(overdue): queue endpoint for tabbed collections view`
+
+---
+
+## Task 3: Backend — OverdueKpiService
+
+**Files:**
+- Create: `apps/api/src/modules/overdue/kpi.service.ts`
+- Create: `apps/api/src/modules/overdue/kpi.service.spec.ts`
+- Modify: controller + module
+
+### Behavior
+
+`GET /overdue/kpi?range=7d|30d` returns:
+```json
+{
+  "totalOutstanding": 1250000.00,
+  "totalLateFees": 45000.00,
+  "queueToday": 34,
+  "queueTodayTrend": -0.08,
+  "promisedCount": 12,
+  "promiseKeptRate7d": 0.72,
+  "avgCollectorWorkload": 28
+}
+```
+
+- `totalOutstanding`: sum of (amountDue - amountPaid) for all overdue payments in branch scope
+- `totalLateFees`: sum of lateFee
+- `queueToday`: contract count in today tab right now
+- `queueTodayTrend`: ratio vs 24h ago (placeholder: 0 for now — implement later if cache data exists)
+- `promisedCount`: callLogs with future settlementDate, result PROMISED
+- `promiseKeptRate7d`: (promises in last 7d that were kept by payment) / (promises in last 7d) — 0 if zero promises
+- `avgCollectorWorkload`: for OWNER only; contracts-per-assigned-user
+
+Cache 60s via simple in-memory map (service member) keyed by `${userRole}:${branchId}:${range}`.
+
+### Steps
+
+- [ ] Write tests (mock prisma.aggregate + count)
+- [ ] Implement service
+- [ ] Add controller route + role guard
+- [ ] Commit: `feat(overdue): kpi endpoint for collections dashboard`
+
+---
+
+## Task 4: Backend — MDM pending endpoint
+
+**File:** modify `apps/api/src/modules/overdue/overdue.controller.ts`
+
+- [ ] Add endpoint:
+
+```typescript
+  @Get('mdm-pending')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
+  getMdmPending(@CurrentUser() user: { role: string; branchId: string | null }) {
+    return this.mdmLockService.getPendingByRole(user.role, user.branchId ?? undefined);
+  }
+```
+
+Inject `MdmLockService` in constructor. Import existing service.
+
+- [ ] Add controller test for role gating.
+- [ ] Commit: `feat(overdue): mdm-pending endpoint for approval tab`
+
+---
+
+## Task 5: Frontend — feature flag hook + collections page shell
+
+**Files:**
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useCollectionsFlag.ts`
+- Create: `apps/web/src/pages/CollectionsPage/index.tsx`
+- Modify: `apps/web/src/App.tsx`
+
+### useCollectionsFlag
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export function useCollectionsFlag() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['system-config', 'collections_v2_enabled'],
+    queryFn: async () => {
+      const { data } = await api.get('/system-config/collections_v2_enabled');
+      return data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+  return { enabled: data?.value === 'true', isLoading };
+}
+```
+
+If `/system-config/:key` endpoint doesn't exist, check existing routes and either reuse or add a public read-only one. Fallback: hardcode flag via env var during development.
+
+### index.tsx
+
+Shell component: renders tabs + slide-over placeholder (no Customer 360 yet — Plan 3).
+
+```tsx
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+import CollectionsTabs from './components/CollectionsTabs';
+import CollectionsKpiStrip from './components/CollectionsKpiStrip';
+import QueueTab from './tabs/QueueTab';
+import FollowUpTab from './tabs/FollowUpTab';
+import PromiseTab from './tabs/PromiseTab';
+import ApprovalTab from './tabs/ApprovalTab';
+import AllTab from './tabs/AllTab';
+
+export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all';
+
+export default function CollectionsPage() {
+  useDocumentTitle('ติดตามหนี้');
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<CollectionsTabKey>('today');
+
+  const canSeeApproval = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
+
+  return (
+    <div>
+      <PageHeader title="ติดตามหนี้" subtitle="คิวงานของผู้ติดตามหนี้รายวัน" />
+      <CollectionsKpiStrip />
+      <CollectionsTabs active={activeTab} onChange={setActiveTab} canSeeApproval={canSeeApproval} />
+      <div className="mt-4">
+        {activeTab === 'today' && <QueueTab />}
+        {activeTab === 'followup' && <FollowUpTab />}
+        {activeTab === 'promise' && <PromiseTab />}
+        {activeTab === 'approval' && canSeeApproval && <ApprovalTab />}
+        {activeTab === 'all' && <AllTab />}
+      </div>
+    </div>
+  );
+}
+```
+
+### App.tsx route + redirect
+
+- Add:
+```tsx
+const CollectionsPage = lazy(() => import('@/pages/CollectionsPage'));
+```
+- Add route inside protected routes area:
+```tsx
+<Route path="/collections" element={<CollectionsPage />} />
+```
+- Handle `/overdue` — keep existing route but add logic: the existing `OverduePage` can stay as-is; redirect happens via `AllTab.tsx` importing the existing component. Users still hit `/overdue` → gets old page (no flag coupling needed for Plan 2 since `/collections` is additive).
+
+Actually simpler: add feature-flag-based redirect component:
+
+```tsx
+function OverdueRouteResolver() {
+  const { enabled } = useCollectionsFlag();
+  if (enabled) return <Navigate to="/collections" replace />;
+  const OverduePage = lazy(() => import('@/pages/OverduePage'));
+  return <Suspense fallback={null}><OverduePage /></Suspense>;
+}
+```
+
+- Replace existing `<Route path="/overdue" ...>` with `<Route path="/overdue" element={<OverdueRouteResolver />} />`.
+
+- [ ] TS + web build + commit: `feat(collections): page shell + /overdue feature-flag redirect`
+
+---
+
+## Task 6: Frontend — CollectionsKpiStrip
+
+**File:** `apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx`
+
+Fetches `/overdue/kpi?range=7d` and renders 4 cards: ค้างรวม / คิววันนี้ / นัดแล้ว / Promise-kept 7d.
+
+Use existing Card styling from OverduePage (currency formatting, accent color stripes). Follow `bg-card`, `text-muted-foreground` tokens per project rules.
+
+- [ ] Create component + hook `useCollectionsKpi.ts`
+- [ ] Handle loading (skeleton) + error (QueryBoundary)
+- [ ] Commit: `feat(collections): KPI strip component`
+
+---
+
+## Task 7: Frontend — CollectionsTabs + CollectionsFilters
+
+**Files:** respective components
+
+- `CollectionsTabs`: renders 5 buttons (today/followup/promise/approval/all). Approval only shown if `canSeeApproval`. Active tab has primary bg.
+- `CollectionsFilters`: search input (debounced), branch select (OWNER only). Shared across Queue/FollowUp/Promise tabs.
+
+Pattern: both emit onChange callbacks; parent state lifted to CollectionsPage.
+
+- [ ] Create components + tests
+- [ ] Commit: `feat(collections): tabs + filters components`
+
+---
+
+## Task 8: Frontend — ContractCard + ContactLogDialog
+
+**Files:**
+- `components/ContractCard.tsx` — the atomic row
+- `components/ContactLogDialog.tsx` — unified modal for NO_ANSWER / PROMISED / REFUSED / WRONG_NUMBER / OTHER
+- `hooks/useContactLog.ts` — wraps `PATCH /overdue/:contractId/contact-log`
+
+### ContractCard spec
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ ☐  [contract#] · [customer name] · [phone]                 │
+│ ครบกำหนด [dueDate] · เลย [N] วัน · งวด [x]/[total]          │
+│ ค้าง [X] + ปรับ [Y] = [Z] ฿                                │
+│ 📊 โทร: [result] [N] ครั้ง · LINE ส่งไป [M] ครั้ง           │
+│ ผู้ติดตาม: [name] or "ยังไม่มอบหมาย"                        │
+│ [📞 โทร] [📝 บันทึกผล] [💬 ส่งไลน์] [▶ 360]                 │
+└───────────────────────────────────────────────────────────┘
+```
+
+Buttons:
+- 📞 โทร — `<a href="tel:...">` wrap
+- 📝 บันทึกผล — opens ContactLogDialog
+- 💬 ส่งไลน์ — disabled in Plan 2 (Plan 3), show tooltip "เร็ว ๆ นี้"
+- ▶ 360 — disabled in Plan 2 (Plan 3)
+
+### ContactLogDialog
+
+Form fields: result (select), notes (optional), collectionNotes (optional), settlementDate + settlementNotes (only when result=PROMISED).
+
+Submit → `PATCH /overdue/:contractId/contact-log` → invalidate `['collections-queue']` + `['collections-kpi']` → close + toast.
+
+- [ ] TDD: write tests for ContactLogDialog (result change toggles settlement fields; submit calls mutation)
+- [ ] TDD: ContractCard renders all states (assigned/unassigned, locked/not, skipTracing flag)
+- [ ] Commit: `feat(collections): ContractCard + ContactLogDialog`
+
+---
+
+## Task 9: Frontend — QueueTab
+
+**File:** `apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx`
+
+Fetch `/overdue/queue?tab=today` paginated. Render list of ContractCards. Empty state: "ไม่มีคิวติดตามวันนี้ 🎉".
+
+- [ ] Test: renders cards from mock query
+- [ ] Test: shows empty state
+- [ ] Test: paginates on scroll (or button) — use "Load more" button for simplicity
+- [ ] Commit: `feat(collections): QueueTab (คิววันนี้)`
+
+---
+
+## Task 10: Frontend — FollowUpTab
+
+Same as QueueTab but `tab=followup`. Additional: show "โทรไปแล้ว X ครั้ง" in card. Red badge if `noAnswerCount === 2` (next call = lock trigger).
+
+- [ ] Commit: `feat(collections): FollowUpTab (ตามต่อ)`
+
+---
+
+## Task 11: Frontend — PromiseTab
+
+Same pattern, `tab=promise`. Sort rows by `settlementDate asc`. Highlight broken promises (settlementDate passed + still not paid) in destructive color.
+
+- [ ] Commit: `feat(collections): PromiseTab (นัดชำระ)`
+
+---
+
+## Task 12: Frontend — ApprovalTab
+
+**Two sections:**
+1. Dunning escalation pending — fetch `/overdue/pending-escalations` (existing endpoint)
+2. MDM lock pending — fetch `/overdue/mdm-pending` (new endpoint from Task 4)
+
+Each row: "ขอยึดเครื่อง: สัญญา XX / ลูกค้า YY / trigger=UNCONTACTABLE_3D / เสนอเมื่อ 2 วันที่แล้ว" with [อนุมัติ] [ปฏิเสธ] buttons.
+
+Approve MDM → `POST /overdue/:id/approve-mdm-lock` (endpoint not yet wired — see Task 13).
+Approve dunning → existing `POST /overdue/contracts/:id/approve-escalation`.
+
+- [ ] Commit: `feat(collections): ApprovalTab (dunning + mdm pending)`
+
+---
+
+## Task 13: Backend — MDM approve/reject/unlock endpoints
+
+**File:** `apps/api/src/modules/overdue/overdue.controller.ts`
+
+Plan 1 created `MdmLockService.approve/reject/unlock` but did not wire endpoints. Add:
+
+```typescript
+  @Post(':contractId/approve-mdm-lock')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  approveMdmLock(
+    @Param('contractId') contractId: string, // note: this is actually the mdmLockRequest ID; adjust if needed
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    // Accept mdmLockRequest ID via path — rename param
+    return this.mdmLockService.approve(contractId, user.id, user.role);
+  }
+
+  @Post(':requestId/reject-mdm-lock')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  rejectMdmLock(
+    @Param('requestId') requestId: string,
+    @Body() body: { reason: string },
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.mdmLockService.reject(requestId, user.id, body.reason, user.role);
+  }
+
+  @Post(':requestId/unlock-mdm-device')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  unlockMdm(
+    @Param('requestId') requestId: string,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.mdmLockService.unlock(requestId, user.id, user.role);
+  }
+```
+
+Use unambiguous route params (e.g., `:mdmRequestId`) to avoid collision with `:contractId` elsewhere. Prefer new top-level path: `POST /overdue/mdm-requests/:id/approve`.
+
+- [ ] Rework to avoid path collision:
+  ```typescript
+  @Post('mdm-requests/:id/approve')
+  @Post('mdm-requests/:id/reject')
+  @Post('mdm-requests/:id/unlock')
+  ```
+
+- [ ] Controller tests for role gating
+- [ ] Commit: `feat(overdue): mdm-requests approve/reject/unlock endpoints`
+
+---
+
+## Task 14: Frontend — AllTab (migrate existing OverduePage)
+
+**File:** `apps/web/src/pages/CollectionsPage/tabs/AllTab.tsx`
+
+Import the existing `OverduePage` default export and render it. No changes to the existing page. This preserves all table/kanban/existing features for admin audit.
+
+```tsx
+import OverduePage from '@/pages/OverduePage';
+export default function AllTab() { return <OverduePage />; }
+```
+
+If `OverduePage` has its own `PageHeader`, that's fine — collectors who use AllTab see a double header but that's acceptable as a migration step. Plan 3 can refactor.
+
+- [ ] Commit: `feat(collections): AllTab wraps existing /overdue page`
+
+---
+
+## Task 15: Sidebar nav update
+
+**File:** `apps/web/src/components/layout/MainLayout.tsx` (or wherever nav is defined)
+
+If there's a sidebar link pointing to `/overdue`, swap to `/collections` when feature flag is enabled. Otherwise keep `/overdue`.
+
+- [ ] Check if flag-aware routing is needed or the redirect component handles it
+- [ ] If sidebar exists, gate the link
+- [ ] Commit: `feat(collections): sidebar routes to /collections when flag on`
+
+---
+
+## Task 16: Vitest + E2E smoke
+
+**Files:**
+- Create: `apps/web/e2e/collections-smoke.spec.ts` (Playwright)
+
+Tests:
+- OWNER with flag=true → `/overdue` redirects to `/collections`, 5 tabs visible
+- SALES with flag=true → `/collections` loads, no Approval tab
+- Flag=false → `/overdue` still loads existing page
+
+- [ ] Run E2E: `cd apps/web && npx playwright test collections-smoke`
+- [ ] Commit: `test(collections): e2e smoke test for flag + tab visibility`
+
+---
+
+## Task 17: Full type-check + test sweep
+
+- [ ] `./tools/check-types.sh all` — 0 errors
+- [ ] `cd apps/api && npm test`
+- [ ] `cd apps/web && npm test -- --run`
+- [ ] Commit any trailing fixes
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+| Spec § | Task |
+|---|---|
+| §3 Page layout — 5 tabs | 5, 7, 9–12, 14 |
+| §3 KPI strip | 3, 6 |
+| §3 ContractCard layout | 8 |
+| §3 Tab semantics | 2 (backend), 9–12 (UI) |
+| §11 Feature flag | 1, 5 |
+| §11 queue endpoint | 2 |
+| §11 kpi endpoint | 3 |
+| §11 mdm-pending endpoint | 4 |
+| §11 approve-mdm-lock endpoint | 13 |
+
+**Out of scope (Plan 3+):**
+- Customer 360 slide-over
+- Bulk actions
+- Inline payment recording
+- LINE ad-hoc send button (placeholder stub only)
+- Priority score formula
+- Full KPI (trend + workload) — stubbed to 0 in Task 3
+
+**Placeholder scan:** no TBD / TODO / vague instructions. Every task has file paths + acceptance criteria.
+
+**Type consistency:** `QueueTab` keys (`today`/`followup`/`promise`/`approval`/`all`) identical across types, backend enum, and URL params. `MDM approve path = /overdue/mdm-requests/:id/approve` consistent in Tasks 4 + 12 + 13.


### PR DESCRIPTION
## Summary

Plan 2/4 of the **Collections Workflow Hub** redesign. Ships the new `/collections` page: 5 date-driven tabs (คิววันนี้ / ตามต่อ / นัดชำระ / อนุมัติ / ทั้งหมด), KPI strip, ContractCard (operations-room aesthetic), ContactLogDialog, and approval queue for dunning escalations + MDM lock requests.

Behind feature flag `collections_v2_enabled` (default `false`). Old `/overdue` page still fully functional — the AllTab wraps it verbatim.

**Base branch:** `feat/collections-foundation` (Plan 1) — merge Plan 1 first.
**Spec:** [2026-04-24-collections-workflow-hub-design.md](../blob/feat/collections-workflow-hub/docs/superpowers/specs/2026-04-24-collections-workflow-hub-design.md)
**Plan:** [2026-04-24-collections-workflow-hub-plan.md](../blob/feat/collections-workflow-hub/docs/superpowers/plans/2026-04-24-collections-workflow-hub-plan.md)

## What's shipped

### Backend
- `GET /overdue/queue?tab=today|followup|promise&branchId=&page=&limit=` — tabbed ContractRow lists with branch scoping
- `GET /overdue/kpi?range=7d|30d` — 7-field KPI bundle (outstanding, queueToday, promisedCount, promiseKeptRate7d, etc.) with 60s in-memory cache
- `GET /overdue/mdm-pending` — MDM lock requests for approval tab
- `GET /overdue/collections-flag` — feature-flag readable by all authenticated roles
- `POST /overdue/mdm-requests/:id/{approve,reject,unlock}` — OWNER/FM only

### Frontend (operations-room aesthetic)
- `/collections` route with 5 tabs, shell in `CollectionsPage/index.tsx`
- KPI strip with 4 cards (days-overdue hero + priority heat strips)
- ContractCard — priority heat strip, `text-3xl tabular-nums` days counter, status chip row, prominent tel: CTA
- ContactLogDialog — result-aware form (reveals settlement fields on PROMISED)
- QueueTab / FollowUpTab / PromiseTab — all built on ContractCard, with celebratory empty states
- PromiseTab groups by date status (เลยนัดแล้ว / วันนี้ / กำลังจะถึง) with destructive highlights on broken promises
- FollowUpTab highlights rows where \`noAnswerCount === 2\` with a ring border (next call triggers auto-lock)
- ApprovalTab — two cards (dunning escalations + MDM) with inline reject-reason modal
- AllTab wraps existing `/overdue` verbatim

### Design system compliance
- Semantic tokens only (no hardcoded hex, no gray-*)
- IBM Plex Sans Thai with \`leading-snug\` everywhere
- \`tabular-nums\` on all numeric displays
- \`lucide-react\` icons only
- Reuses existing \`Card\` / \`Badge\` / \`Modal\` / \`QueryBoundary\` components

### Sidebar
Flag-gated: sidebar nav + mobile bottom nav auto-route to `/collections` when flag is on, fall back to `/overdue` when off.

## Customer impact on deploy

**Zero.** Flag default `false`. Even if a user manually navigates to `/collections`, they see the new UI consuming existing data — no writes to customer-visible systems that weren't already in Plan 1.

## Stats

- **14 commits** (on top of Plan 1's 18)
- **+3656 / -10 lines**
- **98 backend tests pass** (+22 from Plan 1)
- **0 TypeScript errors**
- **5 new E2E smoke tests** (tabs visibility, warning banners, approval sections)

## Test plan

- [ ] CI: \`npm test\` + \`./tools/check-types.sh all\`
- [ ] Staging: OWNER enables flag via \`UPDATE system_config SET value='true' WHERE key='collections_v2_enabled';\`
- [ ] Staging smoke: sidebar "ติดตามหนี้" navigates to \`/collections\`, 5 tabs visible
- [ ] Staging smoke: log NO_ANSWER on a contract → LINE event rule fires (if any active) → DunningAction created
- [ ] Staging smoke: OWNER approves MDM pending → contract.deviceLocked=true
- [ ] Staging smoke: OWNER disables flag → sidebar returns to \`/overdue\` path

## Out of scope (Plan 3/4)

- Customer 360 slide-over
- Bulk actions (multi-select assign/LINE/lock)
- Inline payment recording
- LINE ad-hoc send button (ContactCard has placeholder)
- Full promise-kept trend (currently simple %)
- Legal letter PDF generator (Plan 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)