### PR TITLE
feat(collections): Plan 3/4 power features — Customer 360 + Bulk + Ad-hoc LINE + Inline Payment

### DIFF
--- a/apps/api/src/modules/overdue/bulk.service.spec.ts
+++ b/apps/api/src/modules/overdue/bulk.service.spec.ts
@@ -12,6 +12,7 @@ const mockPrisma = {
   },
   auditLog: { createMany: jest.fn() },
   dunningRule: { findUnique: jest.fn() },
+  $transaction: jest.fn(),
 };
 
 const mockMdmLock = {
@@ -36,13 +37,18 @@ describe('OverdueBulkService', () => {
       ],
     }).compile();
     service = module.get(OverdueBulkService);
+
+    // Default: auditLog.createMany resolves to a benign value so bulkSendLine
+    // audit-trail writes don't blow up in tests that don't assert on them.
+    mockPrisma.auditLog.createMany.mockResolvedValue({ count: 0 });
   });
 
   describe('bulkAssign', () => {
-    it('updates contracts and creates audit logs for each contractId', async () => {
+    it('updates contracts and creates audit logs atomically via $transaction', async () => {
       const contractIds = ['c1', 'c2', 'c3'];
-      mockPrisma.contract.updateMany.mockResolvedValueOnce({ count: 3 });
-      mockPrisma.auditLog.createMany.mockResolvedValueOnce({ count: 3 });
+      mockPrisma.contract.updateMany.mockReturnValueOnce({ count: 3 });
+      mockPrisma.auditLog.createMany.mockReturnValueOnce({ count: 3 });
+      mockPrisma.$transaction.mockResolvedValueOnce([{ count: 3 }, { count: 3 }]);
 
       const result = await service.bulkAssign(
         { contractIds, assignedToId: 'user-99' },
@@ -50,6 +56,7 @@ describe('OverdueBulkService', () => {
       );
 
       expect(result).toEqual({ updated: 3, requested: 3 });
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
 
       const updateArg = mockPrisma.contract.updateMany.mock.calls[0][0];
       expect(updateArg.where.id.in).toEqual(contractIds);

--- a/apps/api/src/modules/overdue/bulk.service.spec.ts
+++ b/apps/api/src/modules/overdue/bulk.service.spec.ts
@@ -1,0 +1,208 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MdmLockService } from './mdm-lock.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { OverdueBulkService } from './bulk.service';
+
+const mockPrisma = {
+  contract: {
+    updateMany: jest.fn(),
+    findMany: jest.fn(),
+  },
+  auditLog: { createMany: jest.fn() },
+  dunningRule: { findUnique: jest.fn() },
+};
+
+const mockMdmLock = {
+  proposeManual: jest.fn(),
+};
+
+const mockNotifications = {
+  send: jest.fn(),
+};
+
+describe('OverdueBulkService', () => {
+  let service: OverdueBulkService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OverdueBulkService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: MdmLockService, useValue: mockMdmLock },
+        { provide: NotificationsService, useValue: mockNotifications },
+      ],
+    }).compile();
+    service = module.get(OverdueBulkService);
+  });
+
+  describe('bulkAssign', () => {
+    it('updates contracts and creates audit logs for each contractId', async () => {
+      const contractIds = ['c1', 'c2', 'c3'];
+      mockPrisma.contract.updateMany.mockResolvedValueOnce({ count: 3 });
+      mockPrisma.auditLog.createMany.mockResolvedValueOnce({ count: 3 });
+
+      const result = await service.bulkAssign(
+        { contractIds, assignedToId: 'user-99' },
+        'actor-1',
+      );
+
+      expect(result).toEqual({ updated: 3, requested: 3 });
+
+      const updateArg = mockPrisma.contract.updateMany.mock.calls[0][0];
+      expect(updateArg.where.id.in).toEqual(contractIds);
+      expect(updateArg.data.assignedToId).toBe('user-99');
+
+      const auditArg = mockPrisma.auditLog.createMany.mock.calls[0][0];
+      expect(auditArg.data).toHaveLength(3);
+      expect(auditArg.data[0].action).toBe('BULK_ASSIGN');
+      expect(auditArg.data[0].userId).toBe('actor-1');
+    });
+  });
+
+  describe('bulkProposeLock', () => {
+    it('returns partial success when some proposeManual calls fail', async () => {
+      mockMdmLock.proposeManual
+        .mockResolvedValueOnce({ id: 'r1' })
+        .mockRejectedValueOnce(new Error('device missing'))
+        .mockResolvedValueOnce({ id: 'r3' });
+
+      const result = await service.bulkProposeLock(
+        { contractIds: ['c1', 'c2', 'c3'], reason: 'ลูกค้าไม่ตอบสนอง' },
+        'actor-1',
+      );
+
+      expect(result).toEqual({ proposed: 2, failed: 1, requested: 3 });
+    });
+
+    it('returns all proposed when all calls succeed', async () => {
+      mockMdmLock.proposeManual.mockResolvedValue({ id: 'r1' });
+
+      const result = await service.bulkProposeLock(
+        { contractIds: ['c1', 'c2'], reason: 'ลูกค้าไม่รับสาย 3 วัน' },
+        'actor-1',
+      );
+
+      expect(result).toEqual({ proposed: 2, failed: 0, requested: 2 });
+    });
+  });
+
+  describe('bulkSendLine', () => {
+    it('throws BadRequestException when neither templateId nor customMessage provided', async () => {
+      await expect(
+        service.bulkSendLine({ contractIds: ['c1'] }, 'actor-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('counts contracts without lineId as failed', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([
+        {
+          id: 'c1',
+          contractNumber: 'BC-001',
+          customer: { lineId: null, phone: '0812345678', name: 'ลูกค้า 1' },
+        },
+        {
+          id: 'c2',
+          contractNumber: 'BC-002',
+          customer: { lineId: 'U123', phone: '0812345679', name: 'ลูกค้า 2' },
+        },
+      ]);
+      mockNotifications.send.mockResolvedValueOnce({ id: 'n1', status: 'SENT' });
+
+      const result = await service.bulkSendLine(
+        { contractIds: ['c1', 'c2'], customMessage: 'กรุณาชำระเงินค้างชำระ' },
+        'actor-1',
+      );
+
+      expect(result).toEqual({ sent: 1, failed: 1, total: 2 });
+      expect(mockNotifications.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses customMessage verbatim when provided', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([
+        {
+          id: 'c1',
+          contractNumber: 'BC-001',
+          customer: { lineId: 'U999', phone: '0899999999', name: 'ทดสอบ' },
+        },
+      ]);
+      mockNotifications.send.mockResolvedValueOnce({ id: 'n1', status: 'SENT' });
+
+      await service.bulkSendLine(
+        { contractIds: ['c1'], customMessage: 'ข้อความทดสอบ 10 ตัวอักษร' },
+        'actor-1',
+      );
+
+      const sendArg = mockNotifications.send.mock.calls[0][0];
+      expect(sendArg.message).toBe('ข้อความทดสอบ 10 ตัวอักษร');
+      expect(sendArg.recipient).toBe('U999');
+      expect(sendArg.channel).toBe('LINE');
+    });
+
+    it('renders templateId message with customerName and contractNumber vars', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([
+        {
+          id: 'c1',
+          contractNumber: 'BC-2026-001',
+          customer: { lineId: 'U777', phone: '0811111111', name: 'สมชาย ใจดี' },
+        },
+      ]);
+      mockPrisma.dunningRule.findUnique.mockResolvedValueOnce({
+        id: 'rule-1',
+        messageTemplate: 'เรียน {{customerName}} สัญญา {{contractNumber}} มียอดค้างชำระ',
+      });
+      mockNotifications.send.mockResolvedValueOnce({ id: 'n1', status: 'SENT' });
+
+      const result = await service.bulkSendLine(
+        { contractIds: ['c1'], templateId: 'rule-1' },
+        'actor-1',
+      );
+
+      expect(result.sent).toBe(1);
+      const sendArg = mockNotifications.send.mock.calls[0][0];
+      expect(sendArg.message).toBe('เรียน สมชาย ใจดี สัญญา BC-2026-001 มียอดค้างชำระ');
+    });
+
+    it('throws BadRequestException when templateId does not exist', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([
+        {
+          id: 'c1',
+          contractNumber: 'BC-001',
+          customer: { lineId: 'U111', phone: '0800000000', name: 'ลูกค้า' },
+        },
+      ]);
+      mockPrisma.dunningRule.findUnique.mockResolvedValueOnce(null);
+
+      await expect(
+        service.bulkSendLine({ contractIds: ['c1'], templateId: 'no-such-template' }, 'actor-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('counts notification send failures as failed (does not throw)', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([
+        {
+          id: 'c1',
+          contractNumber: 'BC-001',
+          customer: { lineId: 'U100', phone: '0800000001', name: 'ผู้ทดสอบ' },
+        },
+        {
+          id: 'c2',
+          contractNumber: 'BC-002',
+          customer: { lineId: 'U200', phone: '0800000002', name: 'ผู้ทดสอบ 2' },
+        },
+      ]);
+      mockNotifications.send
+        .mockRejectedValueOnce(new Error('LINE API down'))
+        .mockResolvedValueOnce({ id: 'n2', status: 'SENT' });
+
+      const result = await service.bulkSendLine(
+        { contractIds: ['c1', 'c2'], customMessage: 'ข้อความทดสอบสำหรับการส่ง' },
+        'actor-1',
+      );
+
+      expect(result).toEqual({ sent: 1, failed: 1, total: 2 });
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/bulk.service.ts
+++ b/apps/api/src/modules/overdue/bulk.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { MdmLockService } from './mdm-lock.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -13,20 +14,21 @@ export class OverdueBulkService {
   ) {}
 
   async bulkAssign(dto: BulkAssignDto, actorId: string) {
-    const result = await this.prisma.contract.updateMany({
-      where: { id: { in: dto.contractIds }, deletedAt: null },
-      data: { assignedToId: dto.assignedToId },
-    });
-
-    await this.prisma.auditLog.createMany({
-      data: dto.contractIds.map((id) => ({
-        userId: actorId,
-        action: 'BULK_ASSIGN',
-        entity: 'contract',
-        entityId: id,
-        newValue: { assignedToId: dto.assignedToId },
-      })),
-    });
+    const [result] = await this.prisma.$transaction([
+      this.prisma.contract.updateMany({
+        where: { id: { in: dto.contractIds }, deletedAt: null },
+        data: { assignedToId: dto.assignedToId },
+      }),
+      this.prisma.auditLog.createMany({
+        data: dto.contractIds.map((id) => ({
+          userId: actorId,
+          action: 'BULK_ASSIGN',
+          entity: 'contract',
+          entityId: id,
+          newValue: { assignedToId: dto.assignedToId },
+        })),
+      }),
+    ]);
 
     return { updated: result.count, requested: dto.contractIds.length };
   }
@@ -39,7 +41,7 @@ export class OverdueBulkService {
     return { proposed, failed: results.length - proposed, requested: dto.contractIds.length };
   }
 
-  async bulkSendLine(dto: BulkSendLineDto, _actorId: string) {
+  async bulkSendLine(dto: BulkSendLineDto, actorId: string) {
     if (!dto.templateId && !dto.customMessage) {
       throw new BadRequestException('ต้องระบุ templateId หรือ customMessage');
     }
@@ -66,6 +68,7 @@ export class OverdueBulkService {
 
     let sent = 0;
     let failed = 0;
+    const auditEntries: Prisma.AuditLogCreateManyInput[] = [];
     for (const c of contracts) {
       if (!c.customer.lineId) {
         failed++;
@@ -91,9 +94,23 @@ export class OverdueBulkService {
           fallbackPhone: c.customer.phone ?? undefined,
         });
         sent++;
+        auditEntries.push({
+          userId: actorId,
+          action: 'BULK_SEND_LINE',
+          entity: 'contract',
+          entityId: c.id,
+          newValue: {
+            templateId: dto.templateId ?? null,
+            hasCustomMessage: Boolean(dto.customMessage),
+          },
+        });
       } catch {
         failed++;
       }
+    }
+
+    if (auditEntries.length > 0) {
+      await this.prisma.auditLog.createMany({ data: auditEntries });
     }
 
     return { sent, failed, total: contracts.length };

--- a/apps/api/src/modules/overdue/bulk.service.ts
+++ b/apps/api/src/modules/overdue/bulk.service.ts
@@ -1,0 +1,101 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MdmLockService } from './mdm-lock.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { BulkAssignDto, BulkProposeLockDto, BulkSendLineDto } from './dto/bulk.dto';
+
+@Injectable()
+export class OverdueBulkService {
+  constructor(
+    private prisma: PrismaService,
+    private mdmLockService: MdmLockService,
+    private notifications: NotificationsService,
+  ) {}
+
+  async bulkAssign(dto: BulkAssignDto, actorId: string) {
+    const result = await this.prisma.contract.updateMany({
+      where: { id: { in: dto.contractIds }, deletedAt: null },
+      data: { assignedToId: dto.assignedToId },
+    });
+
+    await this.prisma.auditLog.createMany({
+      data: dto.contractIds.map((id) => ({
+        userId: actorId,
+        action: 'BULK_ASSIGN',
+        entity: 'contract',
+        entityId: id,
+        newValue: { assignedToId: dto.assignedToId },
+      })),
+    });
+
+    return { updated: result.count, requested: dto.contractIds.length };
+  }
+
+  async bulkProposeLock(dto: BulkProposeLockDto, actorId: string) {
+    const results = await Promise.allSettled(
+      dto.contractIds.map((id) => this.mdmLockService.proposeManual(id, actorId, dto.reason)),
+    );
+    const proposed = results.filter((r) => r.status === 'fulfilled').length;
+    return { proposed, failed: results.length - proposed, requested: dto.contractIds.length };
+  }
+
+  async bulkSendLine(dto: BulkSendLineDto, _actorId: string) {
+    if (!dto.templateId && !dto.customMessage) {
+      throw new BadRequestException('ต้องระบุ templateId หรือ customMessage');
+    }
+
+    // Load contracts with customer LINE info
+    const contracts = await this.prisma.contract.findMany({
+      where: { id: { in: dto.contractIds }, deletedAt: null },
+      include: {
+        customer: { select: { lineId: true, phone: true, name: true } },
+      },
+    });
+
+    // Resolve template message if templateId provided
+    let templateMessage: string | null = null;
+    if (dto.templateId) {
+      const rule = await this.prisma.dunningRule.findUnique({
+        where: { id: dto.templateId },
+      });
+      if (!rule) {
+        throw new BadRequestException('ไม่พบ template');
+      }
+      templateMessage = rule.messageTemplate;
+    }
+
+    let sent = 0;
+    let failed = 0;
+    for (const c of contracts) {
+      if (!c.customer.lineId) {
+        failed++;
+        continue;
+      }
+
+      const message =
+        dto.customMessage ??
+        (templateMessage ?? '').replace(/\{\{(\w+)\}\}/g, (_match, key: string) => {
+          const vars: Record<string, string> = {
+            customerName: c.customer.name,
+            contractNumber: c.contractNumber,
+          };
+          return vars[key] ?? _match;
+        });
+
+      try {
+        await this.notifications.send({
+          channel: 'LINE',
+          recipient: c.customer.lineId,
+          message,
+          relatedId: c.id,
+          fallbackPhone: c.customer.phone ?? undefined,
+        });
+        sent++;
+      } catch {
+        failed++;
+      }
+    }
+
+    return { sent, failed, total: contracts.length };
+  }
+}

--- a/apps/api/src/modules/overdue/dto/bulk.dto.ts
+++ b/apps/api/src/modules/overdue/dto/bulk.dto.ts
@@ -1,0 +1,48 @@
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
+
+export class BulkAssignDto {
+  @IsArray()
+  @ArrayMinSize(1, { message: 'ต้องเลือกอย่างน้อย 1 รายการ' })
+  @ArrayMaxSize(100, { message: 'เลือกได้สูงสุด 100 รายการต่อครั้ง' })
+  @IsString({ each: true })
+  contractIds!: string[];
+
+  @IsString({ message: 'ต้องระบุผู้รับมอบหมาย' })
+  assignedToId!: string;
+}
+
+export class BulkSendLineDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
+  @IsString({ each: true })
+  contractIds!: string[];
+
+  @IsOptional()
+  @IsString()
+  templateId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(10, { message: 'ข้อความต้อง ≥ 10 ตัวอักษร' })
+  customMessage?: string;
+}
+
+export class BulkProposeLockDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
+  @IsString({ each: true })
+  contractIds!: string[];
+
+  @IsString()
+  @MinLength(5, { message: 'เหตุผล ≥ 5 ตัวอักษร' })
+  reason!: string;
+}

--- a/apps/api/src/modules/overdue/dto/bulk.dto.ts
+++ b/apps/api/src/modules/overdue/dto/bulk.dto.ts
@@ -19,30 +19,30 @@ export class BulkAssignDto {
 }
 
 export class BulkSendLineDto {
-  @IsArray()
-  @ArrayMinSize(1)
-  @ArrayMaxSize(100)
-  @IsString({ each: true })
+  @IsArray({ message: 'contractIds ต้องเป็น array' })
+  @ArrayMinSize(1, { message: 'ต้องเลือกอย่างน้อย 1 รายการ' })
+  @ArrayMaxSize(100, { message: 'เลือกได้สูงสุด 100 รายการต่อครั้ง' })
+  @IsString({ each: true, message: 'contractId ต้องเป็น string' })
   contractIds!: string[];
 
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'templateId ต้องเป็น string' })
   templateId?: string;
 
   @IsOptional()
-  @IsString()
+  @IsString({ message: 'customMessage ต้องเป็น string' })
   @MinLength(10, { message: 'ข้อความต้อง ≥ 10 ตัวอักษร' })
   customMessage?: string;
 }
 
 export class BulkProposeLockDto {
-  @IsArray()
-  @ArrayMinSize(1)
-  @ArrayMaxSize(100)
-  @IsString({ each: true })
+  @IsArray({ message: 'contractIds ต้องเป็น array' })
+  @ArrayMinSize(1, { message: 'ต้องเลือกอย่างน้อย 1 รายการ' })
+  @ArrayMaxSize(100, { message: 'เลือกได้สูงสุด 100 รายการต่อครั้ง' })
+  @IsString({ each: true, message: 'contractId ต้องเป็น string' })
   contractIds!: string[];
 
-  @IsString()
+  @IsString({ message: 'ต้องระบุเหตุผล' })
   @MinLength(5, { message: 'เหตุผล ≥ 5 ตัวอักษร' })
   reason!: string;
 }

--- a/apps/api/src/modules/overdue/dto/send-line-adhoc.dto.ts
+++ b/apps/api/src/modules/overdue/dto/send-line-adhoc.dto.ts
@@ -1,0 +1,12 @@
+import { IsOptional, IsString, MinLength } from 'class-validator';
+
+export class SendLineAdHocDto {
+  @IsOptional()
+  @IsString()
+  templateId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(10, { message: 'ข้อความต้อง ≥ 10 ตัวอักษร' })
+  customMessage?: string;
+}

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -6,6 +6,8 @@ import { DunningEngineService } from './dunning-engine.service';
 import { OverdueQueueService } from './queue.service';
 import { OverdueKpiService } from './kpi.service';
 import { MdmLockService } from './mdm-lock.service';
+import { OverdueTimelineService } from './timeline.service';
+import { OverdueBulkService } from './bulk.service';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { AssignCollectorDto } from './dto/assign-collector.dto';
 import { RecordSettlementDto } from './dto/record-settlement.dto';
@@ -13,6 +15,8 @@ import { LogContactDto } from './dto/log-contact.dto';
 import { CreateDunningRuleDto, UpdateDunningRuleDto } from './dto/dunning-rule.dto';
 import { QueueQueryDto } from './dto/queue-query.dto';
 import { KpiQueryDto } from './dto/kpi-query.dto';
+import { BulkAssignDto, BulkProposeLockDto, BulkSendLineDto } from './dto/bulk.dto';
+import { SendLineAdHocDto } from './dto/send-line-adhoc.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -31,6 +35,8 @@ export class OverdueController {
     private queueService: OverdueQueueService,
     private kpiService: OverdueKpiService,
     private mdmLockService: MdmLockService,
+    private timelineService: OverdueTimelineService,
+    private bulkService: OverdueBulkService,
   ) {}
 
   // --- Collections Workflow Hub endpoints (Plan 2) ---
@@ -113,6 +119,12 @@ export class OverdueController {
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
   getTimeline(@Param('id') id: string) {
     return this.overdueService.getContractTimeline(id);
+  }
+
+  @Get('contracts/:id/full-timeline')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getFullTimeline(@Param('id') contractId: string) {
+    return this.timelineService.getFullTimeline(contractId);
   }
 
   @Get('contracts/:id/call-logs')
@@ -336,5 +348,44 @@ export class OverdueController {
     @CurrentUser() user: { id: string; role: string },
   ) {
     return this.mdmLockService.unlock(id, user.id, user.role);
+  }
+
+  // --- Bulk actions ---
+
+  @Post('bulk/assign')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  bulkAssign(@Body() dto: BulkAssignDto, @CurrentUser() user: { id: string }) {
+    return this.bulkService.bulkAssign(dto, user.id);
+  }
+
+  @Post('bulk/propose-lock')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+  bulkProposeLock(@Body() dto: BulkProposeLockDto, @CurrentUser() user: { id: string }) {
+    return this.bulkService.bulkProposeLock(dto, user.id);
+  }
+
+  @Post('bulk/send-line')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+  bulkSendLine(@Body() dto: BulkSendLineDto, @CurrentUser() user: { id: string }) {
+    return this.bulkService.bulkSendLine(dto, user.id);
+  }
+
+  // --- Ad-hoc single contract LINE send ---
+
+  @Post(':contractId/send-line-adhoc')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+  async sendLineAdhoc(
+    @Param('contractId') contractId: string,
+    @Body() dto: SendLineAdHocDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.bulkService.bulkSendLine(
+      {
+        contractIds: [contractId],
+        templateId: dto.templateId,
+        customMessage: dto.customMessage,
+      },
+      user.id,
+    );
   }
 }

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -8,6 +8,8 @@ import { DunningEngineService } from './dunning-engine.service';
 import { MdmLockService } from './mdm-lock.service';
 import { OverdueQueueService } from './queue.service';
 import { OverdueKpiService } from './kpi.service';
+import { OverdueTimelineService } from './timeline.service';
+import { OverdueBulkService } from './bulk.service';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
@@ -26,6 +28,8 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     MdmLockService,
     OverdueQueueService,
     OverdueKpiService,
+    OverdueTimelineService,
+    OverdueBulkService,
     BrokenPromiseCron,
     MdmAutoProposeCron,
   ],
@@ -37,6 +41,8 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     MdmLockService,
     OverdueQueueService,
     OverdueKpiService,
+    OverdueTimelineService,
+    OverdueBulkService,
   ],
 })
 export class OverdueModule {}

--- a/apps/api/src/modules/overdue/timeline.service.spec.ts
+++ b/apps/api/src/modules/overdue/timeline.service.spec.ts
@@ -1,0 +1,196 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { OverdueTimelineService } from './timeline.service';
+
+const mockPrisma = {
+  contract: { findFirst: jest.fn() },
+  callLog: { findMany: jest.fn() },
+  payment: { findMany: jest.fn() },
+  dunningAction: { findMany: jest.fn() },
+  auditLog: { findMany: jest.fn() },
+  contractLetter: { findMany: jest.fn() },
+};
+
+const emptyAll = () => {
+  mockPrisma.callLog.findMany.mockResolvedValue([]);
+  mockPrisma.payment.findMany.mockResolvedValue([]);
+  mockPrisma.dunningAction.findMany.mockResolvedValue([]);
+  mockPrisma.auditLog.findMany.mockResolvedValue([]);
+  mockPrisma.contractLetter.findMany.mockResolvedValue([]);
+};
+
+describe('OverdueTimelineService', () => {
+  let service: OverdueTimelineService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OverdueTimelineService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(OverdueTimelineService);
+  });
+
+  describe('getFullTimeline', () => {
+    it('throws NotFoundException when contract is missing', async () => {
+      mockPrisma.contract.findFirst.mockResolvedValueOnce(null);
+      emptyAll();
+      await expect(service.getFullTimeline('no-such-id')).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns empty array when all sources return empty', async () => {
+      mockPrisma.contract.findFirst.mockResolvedValueOnce({ id: 'c1' });
+      emptyAll();
+      const result = await service.getFullTimeline('c1');
+      expect(result).toEqual([]);
+    });
+
+    it('merges call + payment + dunningAction events and sorts DESC by timestamp', async () => {
+      mockPrisma.contract.findFirst.mockResolvedValueOnce({ id: 'c1' });
+
+      // call at T2 (later)
+      mockPrisma.callLog.findMany.mockResolvedValueOnce([
+        {
+          id: 'call1',
+          calledAt: new Date('2026-01-15T10:00:00Z'),
+          result: 'PROMISED',
+          notes: null,
+          settlementDate: null,
+          caller: { id: 'u1', name: 'แนน' },
+        },
+      ]);
+
+      // payment at T1 (earlier)
+      mockPrisma.payment.findMany.mockResolvedValueOnce([
+        {
+          id: 'pay1',
+          updatedAt: new Date('2026-01-10T08:00:00Z'),
+          amountPaid: { toNumber: () => 1500 },
+          installmentNo: 3,
+          paymentMethod: 'TRANSFER',
+        },
+      ]);
+
+      // dunning at T3 (latest)
+      mockPrisma.dunningAction.findMany.mockResolvedValueOnce([
+        {
+          id: 'da1',
+          createdAt: new Date('2026-01-20T12:00:00Z'),
+          channel: 'LINE',
+          messageContent: 'แจ้งเตือนค้างชำระ',
+          status: 'SENT',
+          dunningRule: { name: 'เตือนงวดค้าง', channel: 'LINE' },
+        },
+      ]);
+
+      mockPrisma.auditLog.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contractLetter.findMany.mockResolvedValueOnce([]);
+
+      const result = await service.getFullTimeline('c1');
+
+      expect(result).toHaveLength(3);
+      // Should be sorted DESC: dunning (T3) → call (T2) → payment (T1)
+      expect(result[0].id).toBe('dunning-da1');
+      expect(result[0].type).toBe('DUNNING_ACTION');
+      expect(result[1].id).toBe('call-call1');
+      expect(result[1].type).toBe('CALL');
+      expect(result[1].title).toBe('นัดชำระ');
+      expect(result[1].subtitle).toBe('แนน');
+      expect(result[2].id).toBe('payment-pay1');
+      expect(result[2].type).toBe('PAYMENT');
+    });
+
+    it('caps result at 100 events when total exceeds 100', async () => {
+      mockPrisma.contract.findFirst.mockResolvedValueOnce({ id: 'c1' });
+
+      // Generate 60 call events + 60 payment events = 120 total
+      // Use a base timestamp and offset by minutes to avoid invalid dates
+      const baseCall = new Date('2026-01-01T10:00:00Z');
+      const calls = Array.from({ length: 60 }, (_, i) => ({
+        id: `call${i}`,
+        calledAt: new Date(baseCall.getTime() + i * 60000),
+        result: 'ANSWERED',
+        notes: null,
+        settlementDate: null,
+        caller: { id: 'u1', name: 'ผู้โทร' },
+      }));
+
+      const basePay = new Date('2026-02-01T10:00:00Z');
+      const payments = Array.from({ length: 60 }, (_, i) => ({
+        id: `pay${i}`,
+        updatedAt: new Date(basePay.getTime() + i * 60000),
+        amountPaid: { toNumber: () => 1000 },
+        installmentNo: i + 1,
+        paymentMethod: null,
+      }));
+
+      mockPrisma.callLog.findMany.mockResolvedValueOnce(calls);
+      mockPrisma.payment.findMany.mockResolvedValueOnce(payments);
+      mockPrisma.dunningAction.findMany.mockResolvedValueOnce([]);
+      mockPrisma.auditLog.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contractLetter.findMany.mockResolvedValueOnce([]);
+
+      const result = await service.getFullTimeline('c1');
+      expect(result).toHaveLength(100);
+    });
+
+    it('maps audit MDM events to MDM type and STATUS_CHANGE to STATUS_CHANGE type', async () => {
+      mockPrisma.contract.findFirst.mockResolvedValueOnce({ id: 'c1' });
+      emptyAll();
+
+      mockPrisma.auditLog.findMany.mockResolvedValueOnce([
+        {
+          id: 'a1',
+          createdAt: new Date('2026-01-12T09:00:00Z'),
+          action: 'MDM_LOCK_APPROVED',
+          newValue: null,
+          entity: 'contract',
+        },
+        {
+          id: 'a2',
+          createdAt: new Date('2026-01-11T09:00:00Z'),
+          action: 'STATUS_CHANGE',
+          newValue: { from: 'ACTIVE', to: 'OVERDUE' },
+          entity: 'contract',
+        },
+      ]);
+
+      const result = await service.getFullTimeline('c1');
+      expect(result).toHaveLength(2);
+      const mdmEvent = result.find((e) => e.id === 'audit-a1');
+      const statusEvent = result.find((e) => e.id === 'audit-a2');
+      expect(mdmEvent?.type).toBe('MDM');
+      expect(mdmEvent?.title).toBe('ล็อคเครื่องแล้ว');
+      expect(statusEvent?.type).toBe('STATUS_CHANGE');
+      expect(statusEvent?.title).toBe('สถานะสัญญาเปลี่ยน: ACTIVE → OVERDUE');
+    });
+
+    it('maps letter events correctly with LETTER type', async () => {
+      mockPrisma.contract.findFirst.mockResolvedValueOnce({ id: 'c1' });
+      emptyAll();
+
+      const dispatchedAt = new Date('2026-01-18T14:00:00Z');
+      mockPrisma.contractLetter.findMany.mockResolvedValueOnce([
+        {
+          id: 'l1',
+          createdAt: new Date('2026-01-17T10:00:00Z'),
+          dispatchedAt,
+          letterType: 'WARNING_1',
+          letterNumber: 'LT-0001',
+          trackingNumber: 'TH123456789',
+          status: 'DISPATCHED',
+        },
+      ]);
+
+      const result = await service.getFullTimeline('c1');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('letter-l1');
+      expect(result[0].type).toBe('LETTER');
+      expect(result[0].timestamp).toBe(dispatchedAt.toISOString());
+      expect(result[0].title).toContain('TH123456789');
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/timeline.service.ts
+++ b/apps/api/src/modules/overdue/timeline.service.ts
@@ -102,8 +102,8 @@ export class OverdueTimelineService {
         id: `payment-${p.id}`,
         type: 'PAYMENT',
         timestamp: p.updatedAt.toISOString(),
-        title: `ชำระ ${p.amountPaid.toNumber().toLocaleString('th-TH')} ฿ (งวด ${p.installmentNo})`,
-        metadata: { amount: p.amountPaid.toNumber(), method: p.paymentMethod ?? undefined },
+        title: `ชำระ ${Number(p.amountPaid.toFixed(2)).toLocaleString('th-TH')} ฿ (งวด ${p.installmentNo})`,
+        metadata: { amount: p.amountPaid.toString(), method: p.paymentMethod ?? undefined },
       });
     }
 

--- a/apps/api/src/modules/overdue/timeline.service.ts
+++ b/apps/api/src/modules/overdue/timeline.service.ts
@@ -1,0 +1,166 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export type TimelineEventType =
+  | 'CALL'
+  | 'PAYMENT'
+  | 'DUNNING_ACTION'
+  | 'STATUS_CHANGE'
+  | 'MDM'
+  | 'LETTER';
+
+export interface TimelineEvent {
+  id: string;
+  type: TimelineEventType;
+  timestamp: string;
+  title: string;
+  subtitle?: string;
+  metadata?: Record<string, unknown>;
+}
+
+const CALL_RESULT_LABELS: Record<string, string> = {
+  NO_ANSWER: 'ไม่รับสาย',
+  ANSWERED: 'รับสาย',
+  PROMISED: 'นัดชำระ',
+  REFUSED: 'ปฏิเสธ',
+  WRONG_NUMBER: 'เบอร์ผิด',
+  OTHER: 'อื่น ๆ',
+};
+
+@Injectable()
+export class OverdueTimelineService {
+  constructor(private prisma: PrismaService) {}
+
+  async getFullTimeline(contractId: string): Promise<TimelineEvent[]> {
+    // Verify contract exists (avoid leaking other tenants' data via guessed IDs)
+    const contract = await this.prisma.contract.findFirst({
+      where: { id: contractId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!contract) throw new NotFoundException('ไม่พบสัญญา');
+
+    const [calls, payments, dunningActions, audits, letters] = await Promise.all([
+      this.prisma.callLog.findMany({
+        where: { contractId },
+        include: { caller: { select: { id: true, name: true } } },
+        orderBy: { calledAt: 'desc' },
+        take: 50,
+      }),
+      this.prisma.payment.findMany({
+        where: { contractId, status: 'PAID' },
+        orderBy: { updatedAt: 'desc' },
+        take: 50,
+      }),
+      this.prisma.dunningAction.findMany({
+        where: { contractId, deletedAt: null },
+        include: { dunningRule: { select: { name: true, channel: true } } },
+        orderBy: { createdAt: 'desc' },
+        take: 50,
+      }),
+      this.prisma.auditLog.findMany({
+        where: {
+          entity: { in: ['contract', 'mdm_lock_request'] },
+          entityId: contractId,
+          action: {
+            in: [
+              'STATUS_CHANGE',
+              'DUNNING_ESCALATION_APPROVED',
+              'MDM_LOCK_APPROVED',
+              'MDM_UNLOCK',
+            ],
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 50,
+      }),
+      this.prisma.contractLetter.findMany({
+        where: { contractId, deletedAt: null, status: { in: ['DISPATCHED', 'DELIVERED'] } },
+        orderBy: { dispatchedAt: 'desc' },
+        take: 50,
+      }),
+    ]);
+
+    const events: TimelineEvent[] = [];
+
+    for (const c of calls) {
+      events.push({
+        id: `call-${c.id}`,
+        type: 'CALL',
+        timestamp: c.calledAt.toISOString(),
+        title: CALL_RESULT_LABELS[c.result] ?? c.result,
+        subtitle: c.caller?.name ?? undefined,
+        metadata: {
+          result: c.result,
+          notes: c.notes ?? undefined,
+          settlementDate: c.settlementDate ?? undefined,
+        },
+      });
+    }
+
+    for (const p of payments) {
+      events.push({
+        id: `payment-${p.id}`,
+        type: 'PAYMENT',
+        timestamp: p.updatedAt.toISOString(),
+        title: `ชำระ ${p.amountPaid.toNumber().toLocaleString('th-TH')} ฿ (งวด ${p.installmentNo})`,
+        metadata: { amount: p.amountPaid.toNumber(), method: p.paymentMethod ?? undefined },
+      });
+    }
+
+    for (const d of dunningActions) {
+      events.push({
+        id: `dunning-${d.id}`,
+        type: 'DUNNING_ACTION',
+        timestamp: d.createdAt.toISOString(),
+        title: `ส่ง ${d.channel}: ${d.dunningRule.name}`,
+        subtitle:
+          d.messageContent
+            ? d.messageContent.substring(0, 80) + (d.messageContent.length > 80 ? '…' : '')
+            : undefined,
+        metadata: { status: d.status, channel: d.channel },
+      });
+    }
+
+    for (const a of audits) {
+      const isMdm = a.action.startsWith('MDM_');
+      events.push({
+        id: `audit-${a.id}`,
+        type: isMdm ? 'MDM' : 'STATUS_CHANGE',
+        timestamp: a.createdAt.toISOString(),
+        title: this.formatAuditTitle(a.action, a.newValue as Record<string, unknown> | null),
+        metadata: { action: a.action, newValue: a.newValue ?? undefined },
+      });
+    }
+
+    for (const l of letters) {
+      events.push({
+        id: `letter-${l.id}`,
+        type: 'LETTER',
+        timestamp: (l.dispatchedAt ?? l.createdAt).toISOString(),
+        title: `ส่งหนังสือ: ${l.letterType} (EMS: ${l.trackingNumber ?? '—'})`,
+        metadata: { status: l.status, letterNumber: l.letterNumber },
+      });
+    }
+
+    events.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    return events.slice(0, 100);
+  }
+
+  private formatAuditTitle(
+    action: string,
+    newValue: Record<string, unknown> | null,
+  ): string {
+    switch (action) {
+      case 'STATUS_CHANGE':
+        return `สถานะสัญญาเปลี่ยน: ${newValue?.from ?? '?'} → ${newValue?.to ?? '?'}`;
+      case 'DUNNING_ESCALATION_APPROVED':
+        return `อนุมัติเลื่อนระดับเตือน: ${newValue?.dunningStage ?? '?'}`;
+      case 'MDM_LOCK_APPROVED':
+        return 'ล็อคเครื่องแล้ว';
+      case 'MDM_UNLOCK':
+        return 'ปลดล็อคเครื่องแล้ว';
+      default:
+        return action;
+    }
+  }
+}

--- a/apps/web/e2e/collections-smoke.spec.ts
+++ b/apps/web/e2e/collections-smoke.spec.ts
@@ -70,3 +70,71 @@ test.describe('/overdue backward compat', () => {
     await expect(page.getByText(/ค้างชำระ|ค่าปรับ/).first()).toBeVisible({ timeout: 15000 });
   });
 });
+
+/* ================================================================
+   Plan 3 Power Features — Customer 360 / Bulk / Ad-hoc LINE
+   ================================================================ */
+test.describe('/collections power features', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+    await gotoWithRetry(page, '/collections');
+  });
+
+  test('no crash on tab switching through all 5 tabs', async ({ page }) => {
+    if (await hasErrorBoundary(page)) return;
+    for (const label of ['ตามต่อ', 'นัดชำระ', 'อนุมัติ', 'ทั้งหมด', 'คิววันนี้']) {
+      await page.getByRole('button', { name: new RegExp(label) }).first().click();
+      await expect(page.locator('body')).not.toContainText(/เกิดข้อผิดพลาด/);
+    }
+  });
+
+  test('Customer 360 panel opens + closes without error', async ({ page }) => {
+    if (await hasErrorBoundary(page)) return;
+
+    // Look for the 360 button (ChevronRight) on any contract card. Skip if none.
+    const openBtn = page.locator('[title="เปิด Customer 360"]').first();
+    if (!(await openBtn.isVisible({ timeout: 3000 }).catch(() => false))) {
+      return; // No contracts to test with — environment has no data
+    }
+
+    await openBtn.click();
+    await expect(page.getByRole('dialog', { name: /ข้อมูลลูกค้า 360/ })).toBeVisible({ timeout: 5000 });
+
+    // Close via close button
+    await page.getByRole('button', { name: /ปิด/ }).click();
+    await expect(page.getByRole('dialog', { name: /ข้อมูลลูกค้า 360/ })).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('BulkActionBar appears when row selected', async ({ page }) => {
+    if (await hasErrorBoundary(page)) return;
+
+    const checkbox = page.locator('input[type="checkbox"]').first();
+    if (!(await checkbox.isVisible({ timeout: 3000 }).catch(() => false))) {
+      return; // No contracts
+    }
+
+    await checkbox.check();
+    await expect(page.getByText(/เลือก\s*\d+\s*รายการ/)).toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('button', { name: /มอบหมาย/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /ส่ง LINE/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /เสนอล็อค/ })).toBeVisible();
+  });
+
+  test('ad-hoc LINE dialog opens from contract card', async ({ page }) => {
+    if (await hasErrorBoundary(page)) return;
+
+    // Find an enabled LINE send button (not the disabled ones for customers without lineId)
+    const sendBtn = page.locator('[title="ส่ง LINE"]').first();
+    if (!(await sendBtn.isVisible({ timeout: 3000 }).catch(() => false))) {
+      return;
+    }
+
+    const disabled = await sendBtn.isDisabled().catch(() => true);
+    if (disabled) return;
+
+    await sendBtn.click();
+    await expect(page.getByText(/ส่ง LINE ถึง/)).toBeVisible({ timeout: 3000 });
+    // Close
+    await page.getByRole('button', { name: /ยกเลิก/ }).first().click();
+  });
+});

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -86,6 +86,15 @@ export function formatThaiDateTime(input: DateInput): string {
 }
 
 /**
+ * HH:mm (24-hour) — e.g. "14:30"
+ */
+export function formatThaiTime(input: DateInput): string {
+  const d = toDate(input);
+  if (!d) return '-';
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
  * Convert a พ.ศ. year to ค.ศ. (for parsing user input).
  */
 export function beToAd(yearBE: number): number {

--- a/apps/web/src/pages/CollectionsPage/components/BulkActionBar.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/BulkActionBar.tsx
@@ -1,0 +1,306 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { X, UserPlus, MessageSquare, Lock } from 'lucide-react';
+import api from '@/lib/api';
+import { useBulkActions } from '../hooks/useBulkActions';
+
+interface Props {
+  selectedIds: Set<string>;
+  onClear: () => void;
+}
+
+interface StaffUser {
+  id: string;
+  name: string;
+  role: string;
+}
+
+export default function BulkActionBar({ selectedIds, onClear }: Props) {
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [lineMessage, setLineMessage] = useState('');
+  const [lineOpen, setLineOpen] = useState(false);
+  const [lockReason, setLockReason] = useState('');
+  const [lockOpen, setLockOpen] = useState(false);
+
+  const { assign, sendLine, proposeLock } = useBulkActions(onClear);
+
+  const { data: staffUsers = [] } = useQuery<StaffUser[]>({
+    queryKey: ['staff-users'],
+    queryFn: async () => {
+      const { data } = await api.get('/users');
+      const list = data.data || data || [];
+      return Array.isArray(list) ? list : [];
+    },
+    enabled: assignOpen,
+  });
+
+  const ids = Array.from(selectedIds);
+  const show = ids.length > 0;
+
+  return (
+    <>
+      {/* Sticky bottom bar */}
+      <div
+        className={`fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-card/95 backdrop-blur-sm shadow-[0_-4px_20px_rgba(0,0,0,0.04)] transform transition-transform duration-200 ${
+          show ? 'translate-y-0' : 'translate-y-full'
+        }`}
+      >
+        <div className="max-w-screen-2xl mx-auto px-4 py-3 flex items-center justify-between gap-3 flex-wrap">
+          <div className="text-sm font-medium tabular-nums leading-snug">
+            เลือก <span className="text-primary">{ids.length}</span> รายการ
+          </div>
+
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              onClick={() => setAssignOpen(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-input hover:bg-muted transition-colors"
+            >
+              <UserPlus className="size-3.5" />
+              มอบหมาย
+            </button>
+            <button
+              onClick={() => setLineOpen(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-input hover:bg-muted transition-colors"
+            >
+              <MessageSquare className="size-3.5" />
+              ส่ง LINE
+            </button>
+            <button
+              onClick={() => setLockOpen(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-input hover:bg-muted transition-colors"
+            >
+              <Lock className="size-3.5" />
+              เสนอล็อค
+            </button>
+            <button
+              onClick={onClear}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            >
+              <X className="size-3.5" />
+              ยกเลิก
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Assign modal */}
+      {assignOpen && (
+        <InlineAssignModal
+          staffUsers={staffUsers}
+          pending={assign.isPending}
+          onClose={() => setAssignOpen(false)}
+          onConfirm={(assignedToId) => {
+            assign.mutate({ contractIds: ids, assignedToId });
+            setAssignOpen(false);
+          }}
+        />
+      )}
+
+      {/* Send LINE modal */}
+      {lineOpen && (
+        <InlineLineModal
+          value={lineMessage}
+          onChange={setLineMessage}
+          pending={sendLine.isPending}
+          onClose={() => {
+            setLineOpen(false);
+            setLineMessage('');
+          }}
+          onSubmit={() => {
+            sendLine.mutate({ contractIds: ids, customMessage: lineMessage });
+            setLineOpen(false);
+            setLineMessage('');
+          }}
+        />
+      )}
+
+      {/* Propose lock modal */}
+      {lockOpen && (
+        <InlineLockModal
+          value={lockReason}
+          onChange={setLockReason}
+          pending={proposeLock.isPending}
+          onClose={() => {
+            setLockOpen(false);
+            setLockReason('');
+          }}
+          onSubmit={() => {
+            proposeLock.mutate({ contractIds: ids, reason: lockReason });
+            setLockOpen(false);
+            setLockReason('');
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline mini-modal helpers — keep file self-contained
+// ---------------------------------------------------------------------------
+
+function ModalOverlay({
+  children,
+  onClose,
+}: {
+  children: React.ReactNode;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-background/60 backdrop-blur-sm" />
+      <div
+        className="relative bg-card rounded-xl shadow-2xl w-full max-w-sm mx-4 p-5 border border-border"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function InlineAssignModal({
+  staffUsers,
+  pending,
+  onClose,
+  onConfirm,
+}: {
+  staffUsers: StaffUser[];
+  pending: boolean;
+  onClose: () => void;
+  onConfirm: (id: string) => void;
+}) {
+  const [picked, setPicked] = useState('');
+  return (
+    <ModalOverlay onClose={onClose}>
+      <div className="text-sm font-semibold mb-3 leading-snug">มอบหมายผู้ติดตาม</div>
+      <select
+        value={picked}
+        onChange={(e) => setPicked(e.target.value)}
+        className="w-full px-3 py-2 border border-input rounded-lg text-sm mb-4 leading-snug"
+      >
+        <option value="">— เลือกพนักงาน —</option>
+        {staffUsers.map((u) => (
+          <option key={u.id} value={u.id}>
+            {u.name} ({u.role})
+          </option>
+        ))}
+      </select>
+      <div className="flex gap-2 justify-end">
+        <button
+          onClick={onClose}
+          className="px-3 py-1.5 text-xs rounded-lg border border-input hover:bg-muted transition-colors"
+        >
+          ยกเลิก
+        </button>
+        <button
+          onClick={() => picked && onConfirm(picked)}
+          disabled={!picked || pending}
+          className="px-3 py-1.5 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {pending ? 'กำลังมอบหมาย...' : 'มอบหมาย'}
+        </button>
+      </div>
+    </ModalOverlay>
+  );
+}
+
+function InlineLineModal({
+  value,
+  onChange,
+  pending,
+  onClose,
+  onSubmit,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  pending: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}) {
+  const valid = value.trim().length >= 10;
+  return (
+    <ModalOverlay onClose={onClose}>
+      <div className="text-sm font-semibold mb-3 leading-snug">ส่ง LINE แบบพิมพ์เอง</div>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={4}
+        placeholder="พิมพ์ข้อความที่จะส่งถึงลูกค้าที่เลือก..."
+        className="w-full px-3 py-2 border border-input rounded-lg text-sm mb-2 resize-none leading-snug"
+        autoFocus
+      />
+      <div className="text-xs text-muted-foreground mb-4 leading-snug">
+        {value.length} ตัวอักษร (ขั้นต่ำ 10)
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button
+          onClick={onClose}
+          className="px-3 py-1.5 text-xs rounded-lg border border-input hover:bg-muted transition-colors"
+        >
+          ยกเลิก
+        </button>
+        <button
+          onClick={onSubmit}
+          disabled={!valid || pending}
+          className="px-3 py-1.5 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {pending ? 'กำลังส่ง...' : 'ส่ง LINE'}
+        </button>
+      </div>
+    </ModalOverlay>
+  );
+}
+
+function InlineLockModal({
+  value,
+  onChange,
+  pending,
+  onClose,
+  onSubmit,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  pending: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}) {
+  const valid = value.trim().length >= 5;
+  return (
+    <ModalOverlay onClose={onClose}>
+      <div className="text-sm font-semibold mb-1 leading-snug">เสนอล็อคเครื่อง</div>
+      <div className="text-xs text-muted-foreground mb-3 leading-snug">
+        เหตุผลจะบันทึกใน audit log และ OWNER จะเห็นในแท็บ &quot;อนุมัติ&quot;
+      </div>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={3}
+        placeholder="เช่น ลูกค้าติดต่อไม่ได้ 4 วัน โทรไป 5 ครั้งไม่รับ..."
+        className="w-full px-3 py-2 border border-input rounded-lg text-sm mb-2 resize-none leading-snug"
+        autoFocus
+      />
+      <div className="text-xs text-muted-foreground mb-4 leading-snug">
+        {value.length} ตัวอักษร (ขั้นต่ำ 5)
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button
+          onClick={onClose}
+          className="px-3 py-1.5 text-xs rounded-lg border border-input hover:bg-muted transition-colors"
+        >
+          ยกเลิก
+        </button>
+        <button
+          onClick={onSubmit}
+          disabled={!valid || pending}
+          className="px-3 py-1.5 text-xs font-medium rounded-lg bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+        >
+          {pending ? 'กำลังเสนอ...' : 'เสนอล็อค'}
+        </button>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -2,6 +2,7 @@ import {
   Phone,
   PhoneMissed,
   MessageCircle,
+  MessageSquare,
   Lock,
   Search,
   CalendarCheck,
@@ -23,11 +24,35 @@ interface Props {
   contract: ContractRow;
   onLogContact: (c: ContractRow) => void;
   onOpen360?: (c: ContractRow) => void;
+  onSendLine?: (c: ContractRow) => void;
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
 }
 
-export default function ContractCard({ contract, onLogContact, onOpen360 }: Props) {
+export default function ContractCard({
+  contract,
+  onLogContact,
+  onOpen360,
+  onSendLine,
+  selected,
+  onToggleSelect,
+}: Props) {
   return (
     <div className="group relative flex rounded-xl border border-border/50 bg-card shadow-sm hover:shadow-card-hover transition-shadow overflow-hidden">
+      {/* Checkbox column — only rendered when bulk-select is active */}
+      {onToggleSelect && (
+        <label className="flex items-start pt-5 pl-3 shrink-0 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={!!selected}
+            onChange={() => onToggleSelect(contract.id)}
+            onClick={(e) => e.stopPropagation()}
+            className="size-4 rounded border-input accent-primary focus:ring-2 focus:ring-ring/30"
+            aria-label={`เลือกสัญญา ${contract.contractNumber}`}
+          />
+        </label>
+      )}
+
       {/* Priority heat strip */}
       <div className={`w-1 shrink-0 ${priorityColor(contract.daysOverdue)}`} />
 
@@ -127,6 +152,15 @@ export default function ContractCard({ contract, onLogContact, onOpen360 }: Prop
               aria-label="บันทึกผลการโทร"
             >
               <NotebookPen className="size-3.5" />
+            </button>
+            <button
+              onClick={() => onSendLine?.(contract)}
+              disabled={!contract.customer.lineId}
+              className="rounded-lg border border-input p-1.5 hover:bg-accent text-muted-foreground hover:text-foreground disabled:opacity-40 transition-colors"
+              title={contract.customer.lineId ? 'ส่ง LINE' : 'ลูกค้าไม่มี LINE ID'}
+              aria-label="ส่ง LINE"
+            >
+              <MessageSquare className="size-3.5" />
             </button>
             {onOpen360 && (
               <button

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -7,6 +7,7 @@ import {
   CalendarCheck,
   UserCircle,
   NotebookPen,
+  ChevronRight,
 } from 'lucide-react';
 import { formatDateShort } from '@/utils/formatters';
 import type { ContractRow } from '../types';
@@ -127,6 +128,16 @@ export default function ContractCard({ contract, onLogContact, onOpen360 }: Prop
             >
               <NotebookPen className="size-3.5" />
             </button>
+            {onOpen360 && (
+              <button
+                onClick={() => onOpen360(contract)}
+                className="rounded-lg border border-input p-1.5 hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                title="เปิด Customer 360"
+                aria-label="เปิด Customer 360"
+              >
+                <ChevronRight className="size-3.5" />
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Actions.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Actions.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Banknote, MessageSquare, Lock, ExternalLink } from 'lucide-react';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import PaymentRecordDialog from './PaymentRecordDialog';
+import type { ContractRow } from '../types';
+
+interface Props {
+  contract: ContractRow;
+  onSendLine?: () => void; // wired in Task 8
+  onProposeLock?: () => void; // optional inline fallback if Task 7 caller doesn't override
+}
+
+export default function Customer360Actions({ contract, onSendLine, onProposeLock }: Props) {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const [paymentOpen, setPaymentOpen] = useState(false);
+
+  // Inline propose-lock mutation (used when caller doesn't provide onProposeLock)
+  const proposeMutation = useMutation({
+    mutationFn: async () => {
+      const reason = window.prompt('ระบุเหตุผลการเสนอล็อคเครื่อง (≥ 5 ตัวอักษร):');
+      if (!reason || reason.trim().length < 5) {
+        throw new Error('กรุณาระบุเหตุผลอย่างน้อย 5 ตัวอักษร');
+      }
+      const { data } = await api.post('/overdue/bulk/propose-lock', {
+        contractIds: [contract.id],
+        reason: reason.trim(),
+      });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('เสนอล็อคเครื่องแล้ว รออนุมัติจาก OWNER');
+      qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+      qc.invalidateQueries({ queryKey: ['customer-360', contract.id] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const handleProposeLock = onProposeLock ?? (() => proposeMutation.mutate());
+
+  const canRecordPayment = contract.outstanding > 0;
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          onClick={() => setPaymentOpen(true)}
+          disabled={!canRecordPayment}
+          className="flex flex-col items-center gap-1.5 py-3 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <Banknote className="size-5" />
+          <span className="text-xs font-medium leading-snug">บันทึกจ่าย</span>
+        </button>
+
+        <button
+          onClick={onSendLine}
+          disabled={!contract.customer.lineId || !onSendLine}
+          className="flex flex-col items-center gap-1.5 py-3 rounded-lg border border-input hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          title={!contract.customer.lineId ? 'ลูกค้าไม่มี LINE ID' : undefined}
+        >
+          <MessageSquare className="size-5" />
+          <span className="text-xs font-medium leading-snug">ส่ง LINE</span>
+        </button>
+
+        <button
+          onClick={handleProposeLock}
+          disabled={contract.deviceLocked || proposeMutation.isPending}
+          className="flex flex-col items-center gap-1.5 py-3 rounded-lg border border-input hover:bg-muted disabled:opacity-50 transition-colors"
+          title={contract.deviceLocked ? 'ล็อคเครื่องแล้ว' : 'เสนอล็อคเครื่อง'}
+        >
+          <Lock className="size-5" />
+          <span className="text-xs font-medium leading-snug">
+            {contract.deviceLocked ? 'ล็อคแล้ว' : proposeMutation.isPending ? 'กำลังเสนอ...' : 'เสนอล็อค'}
+          </span>
+        </button>
+
+        <button
+          onClick={() => navigate(`/contracts/${contract.id}`)}
+          className="flex flex-col items-center gap-1.5 py-3 rounded-lg border border-input hover:bg-muted transition-colors"
+        >
+          <ExternalLink className="size-5" />
+          <span className="text-xs font-medium leading-snug">ดูสัญญาเต็ม</span>
+        </button>
+      </div>
+
+      <PaymentRecordDialog
+        open={paymentOpen}
+        contract={contract}
+        onClose={() => setPaymentOpen(false)}
+      />
+    </>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Actions.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Actions.tsx
@@ -10,21 +10,20 @@ import type { ContractRow } from '../types';
 interface Props {
   contract: ContractRow;
   onSendLine?: () => void; // wired in Task 8
-  onProposeLock?: () => void; // optional inline fallback if Task 7 caller doesn't override
+  onProposeLock?: () => void; // optional — parent may override with its own modal flow
 }
 
 export default function Customer360Actions({ contract, onSendLine, onProposeLock }: Props) {
   const navigate = useNavigate();
   const qc = useQueryClient();
   const [paymentOpen, setPaymentOpen] = useState(false);
+  const [lockOpen, setLockOpen] = useState(false);
+  const [lockReason, setLockReason] = useState('');
 
-  // Inline propose-lock mutation (used when caller doesn't provide onProposeLock)
+  // Inline propose-lock mutation (used when caller doesn't provide onProposeLock).
+  // Uses a local modal (matches BulkActionBar's InlineLockModal pattern) — no window.prompt().
   const proposeMutation = useMutation({
-    mutationFn: async () => {
-      const reason = window.prompt('ระบุเหตุผลการเสนอล็อคเครื่อง (≥ 5 ตัวอักษร):');
-      if (!reason || reason.trim().length < 5) {
-        throw new Error('กรุณาระบุเหตุผลอย่างน้อย 5 ตัวอักษร');
-      }
+    mutationFn: async (reason: string) => {
       const { data } = await api.post('/overdue/bulk/propose-lock', {
         contractIds: [contract.id],
         reason: reason.trim(),
@@ -35,11 +34,13 @@ export default function Customer360Actions({ contract, onSendLine, onProposeLock
       toast.success('เสนอล็อคเครื่องแล้ว รออนุมัติจาก OWNER');
       qc.invalidateQueries({ queryKey: ['pending-mdm'] });
       qc.invalidateQueries({ queryKey: ['customer-360', contract.id] });
+      setLockOpen(false);
+      setLockReason('');
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });
 
-  const handleProposeLock = onProposeLock ?? (() => proposeMutation.mutate());
+  const handleProposeLock = onProposeLock ?? (() => setLockOpen(true));
 
   const canRecordPayment = contract.outstanding > 0;
 
@@ -91,6 +92,83 @@ export default function Customer360Actions({ contract, onSendLine, onProposeLock
         contract={contract}
         onClose={() => setPaymentOpen(false)}
       />
+
+      {lockOpen && (
+        <InlineLockModal
+          value={lockReason}
+          onChange={setLockReason}
+          pending={proposeMutation.isPending}
+          onClose={() => {
+            setLockOpen(false);
+            setLockReason('');
+          }}
+          onSubmit={() => proposeMutation.mutate(lockReason)}
+        />
+      )}
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// InlineLockModal — mirrors the pattern in BulkActionBar so the UX is identical
+// between bulk action bar and Customer 360 actions. No window.prompt().
+// ---------------------------------------------------------------------------
+
+function InlineLockModal({
+  value,
+  onChange,
+  pending,
+  onClose,
+  onSubmit,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  pending: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}) {
+  const valid = value.trim().length >= 5;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-background/60 backdrop-blur-sm" />
+      <div
+        className="relative bg-card rounded-xl shadow-2xl w-full max-w-sm mx-4 p-5 border border-border"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-sm font-semibold mb-1 leading-snug">เสนอล็อคเครื่อง</div>
+        <div className="text-xs text-muted-foreground mb-3 leading-snug">
+          เหตุผลจะบันทึกใน audit log และ OWNER จะเห็นในแท็บ &quot;อนุมัติ&quot;
+        </div>
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={3}
+          placeholder="เช่น ลูกค้าติดต่อไม่ได้ 4 วัน โทรไป 5 ครั้งไม่รับ..."
+          className="w-full px-3 py-2 border border-input rounded-lg text-sm mb-2 resize-none leading-snug"
+          autoFocus
+        />
+        <div className="text-xs text-muted-foreground mb-4 leading-snug">
+          {value.length} ตัวอักษร (ขั้นต่ำ 5)
+        </div>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded-lg border border-input hover:bg-muted transition-colors"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={!valid || pending}
+            className="px-3 py-1.5 text-xs font-medium rounded-lg bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+          >
+            {pending ? 'กำลังเสนอ...' : 'เสนอล็อค'}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
@@ -1,0 +1,167 @@
+import { useEffect } from 'react';
+import { X, Phone, MessageCircle, MapPin, Loader2 } from 'lucide-react';
+import { useCustomer360 } from '../hooks/useCustomer360';
+import Customer360Timeline from './Customer360Timeline';
+import type { ContractRow } from '../types';
+
+interface Props {
+  contract: ContractRow | null;
+  onClose: () => void;
+}
+
+export default function Customer360Panel({ contract, onClose }: Props) {
+  const { data, isLoading, isError } = useCustomer360(contract?.id ?? null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!contract) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [contract, onClose]);
+
+  // Block body scroll while open
+  useEffect(() => {
+    if (!contract) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [contract]);
+
+  const open = !!contract;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        className={`fixed inset-0 z-40 bg-background/60 backdrop-blur-sm transition-opacity duration-200 ${
+          open ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-hidden="true"
+      />
+
+      {/* Slide-over */}
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="ข้อมูลลูกค้า 360"
+        className={`fixed inset-y-0 right-0 z-50 w-full md:w-[480px] bg-card border-l border-border shadow-2xl transform transition-transform duration-200 flex flex-col ${
+          open ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        {/* Header */}
+        <div className="sticky top-0 flex items-center justify-between px-5 py-4 border-b border-border bg-card z-10">
+          <div>
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">
+              Customer 360
+            </div>
+            <div className="text-sm font-mono tabular-nums text-primary">
+              {contract?.contractNumber}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="ปิด"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+
+        {/* Body (scrollable) */}
+        <div className="flex-1 overflow-y-auto">
+          {!contract ? null : isLoading ? (
+            <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+              <Loader2 className="size-6 animate-spin mb-2" />
+              <div className="text-sm leading-snug">กำลังโหลด...</div>
+            </div>
+          ) : isError ? (
+            <div className="p-5 text-sm text-destructive leading-snug">
+              ไม่สามารถโหลดข้อมูลลูกค้าได้
+            </div>
+          ) : (
+            <>
+              {/* Customer header */}
+              <section className="p-5 border-b border-border">
+                <div className="text-lg font-semibold leading-snug mb-1">
+                  {data?.detail.customer.name ?? contract.customer.name}
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                  {contract.customer.phone && (
+                    <a
+                      href={`tel:${contract.customer.phone}`}
+                      className="inline-flex items-center gap-1 font-mono tabular-nums text-primary hover:underline"
+                    >
+                      <Phone className="size-3" />
+                      {contract.customer.phone}
+                    </a>
+                  )}
+                  {(data?.detail.customer.lineId ?? contract.customer.lineId) && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-success/10 text-success px-2 py-0.5">
+                      <MessageCircle className="size-3" />
+                      LINE
+                    </span>
+                  )}
+                  {data?.detail.customer.address && (
+                    <span className="inline-flex items-center gap-1 max-w-full">
+                      <MapPin className="size-3 shrink-0" />
+                      <span className="truncate leading-snug">{data.detail.customer.address}</span>
+                    </span>
+                  )}
+                </div>
+                <div className="mt-2 text-xs text-muted-foreground leading-snug">
+                  สาขา {contract.branch.name}
+                </div>
+              </section>
+
+              {/* Contract summary */}
+              <section className="p-5 border-b border-border">
+                <div className="text-xs uppercase tracking-wider text-muted-foreground mb-3">
+                  สัญญา
+                </div>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <div className="text-xs text-muted-foreground mb-1 leading-snug">ค้างชำระ</div>
+                    <div className="text-xl font-bold tabular-nums text-destructive">
+                      {contract.outstanding.toLocaleString()} ฿
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-muted-foreground mb-1 leading-snug">เลยกำหนด</div>
+                    <div className="text-xl font-bold tabular-nums">
+                      {contract.daysOverdue}{' '}
+                      <span className="text-xs text-muted-foreground font-normal">วัน</span>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              {/* Timeline */}
+              <section className="p-5 border-b border-border">
+                <div className="text-xs uppercase tracking-wider text-muted-foreground mb-3">
+                  กิจกรรม
+                </div>
+                <Customer360Timeline events={data?.timeline ?? []} />
+              </section>
+
+              {/* Actions placeholder — Task 6 replaces */}
+              <section className="p-5">
+                <div className="text-xs uppercase tracking-wider text-muted-foreground mb-3">
+                  การดำเนินการ
+                </div>
+                <div className="text-xs text-muted-foreground italic leading-snug">
+                  Quick actions (Task 6)
+                </div>
+              </section>
+            </>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
@@ -2,14 +2,16 @@ import { useEffect } from 'react';
 import { X, Phone, MessageCircle, MapPin, Loader2 } from 'lucide-react';
 import { useCustomer360 } from '../hooks/useCustomer360';
 import Customer360Timeline from './Customer360Timeline';
+import Customer360Actions from './Customer360Actions';
 import type { ContractRow } from '../types';
 
 interface Props {
   contract: ContractRow | null;
   onClose: () => void;
+  onRequestSendLine?: (c: ContractRow) => void; // Task 8 wires this
 }
 
-export default function Customer360Panel({ contract, onClose }: Props) {
+export default function Customer360Panel({ contract, onClose, onRequestSendLine }: Props) {
   const { data, isLoading, isError } = useCustomer360(contract?.id ?? null);
 
   // Close on Escape
@@ -149,14 +151,17 @@ export default function Customer360Panel({ contract, onClose }: Props) {
                 <Customer360Timeline events={data?.timeline ?? []} />
               </section>
 
-              {/* Actions placeholder — Task 6 replaces */}
+              {/* Actions */}
               <section className="p-5">
                 <div className="text-xs uppercase tracking-wider text-muted-foreground mb-3">
                   การดำเนินการ
                 </div>
-                <div className="text-xs text-muted-foreground italic leading-snug">
-                  Quick actions (Task 6)
-                </div>
+                <Customer360Actions
+                  contract={contract}
+                  onSendLine={
+                    onRequestSendLine ? () => onRequestSendLine(contract) : undefined
+                  }
+                />
               </section>
             </>
           )}

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   type LucideIcon,
 } from 'lucide-react';
+import { formatThaiDateShort, formatThaiTime } from '@/lib/date';
 import type { TimelineEvent } from '../hooks/useCustomer360';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -27,11 +28,7 @@ function groupByDate(events: TimelineEvent[]): Array<{ label: string; items: Tim
     } else if (d.getTime() === yesterday.getTime()) {
       label = 'เมื่อวาน';
     } else {
-      label = d.toLocaleDateString('th-TH', {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric',
-      });
+      label = formatThaiDateShort(d);
     }
 
     if (!groups.has(label)) {
@@ -52,11 +49,7 @@ function timeLabel(iso: string): string {
   if (mins < 60) return `${mins} นาทีที่แล้ว`;
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs} ชม.ที่แล้ว`;
-  return new Date(iso).toLocaleTimeString('th-TH', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
+  return formatThaiTime(iso);
 }
 
 // ─── icon/color config ───────────────────────────────────────────────────────

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
@@ -137,16 +137,12 @@ function getEventStyle(event: TimelineEvent): EventStyle {
 
 // ─── sub-components ──────────────────────────────────────────────────────────
 
-function EventCard({ event, isFirst }: { event: TimelineEvent; isFirst: boolean }) {
+function EventCard({ event }: { event: TimelineEvent }) {
   const { Icon, iconBg, iconText, typeLabel } = getEventStyle(event);
   const label = timeLabel(event.timestamp);
 
   return (
-    <div
-      className={`flex gap-3 px-1 py-2.5 rounded-lg hover:bg-muted/40 transition-colors ${
-        isFirst ? '' : ''
-      }`}
-    >
+    <div className="flex gap-3 px-1 py-2.5 rounded-lg hover:bg-muted/40 transition-colors">
       {/* Icon circle */}
       <div
         className={`shrink-0 mt-0.5 size-8 rounded-full flex items-center justify-center ${iconBg}`}
@@ -205,8 +201,8 @@ export default function Customer360Timeline({ events }: Props) {
 
           {/* Events */}
           <div>
-            {group.items.map((event, idx) => (
-              <EventCard key={event.id} event={event} isFirst={idx === 0} />
+            {group.items.map((event) => (
+              <EventCard key={event.id} event={event} />
             ))}
           </div>
         </div>

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
@@ -1,0 +1,230 @@
+import {
+  PhoneCall,
+  Banknote,
+  MessageCircle,
+  Activity,
+  Lock,
+  FileText,
+  type LucideIcon,
+} from 'lucide-react';
+import type { TimelineEvent } from '../hooks/useCustomer360';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function groupByDate(events: TimelineEvent[]): Array<{ label: string; items: TimelineEvent[] }> {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const yesterday = new Date(today.getTime() - 86_400_000);
+  const groups = new Map<string, TimelineEvent[]>();
+  const order: string[] = [];
+
+  for (const e of events) {
+    const d = new Date(e.timestamp);
+    d.setHours(0, 0, 0, 0);
+    let label: string;
+    if (d.getTime() === today.getTime()) {
+      label = 'วันนี้';
+    } else if (d.getTime() === yesterday.getTime()) {
+      label = 'เมื่อวาน';
+    } else {
+      label = d.toLocaleDateString('th-TH', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      });
+    }
+
+    if (!groups.has(label)) {
+      groups.set(label, []);
+      order.push(label);
+    }
+    groups.get(label)!.push(e);
+  }
+
+  return order.map((label) => ({ label, items: groups.get(label)! }));
+}
+
+function timeLabel(iso: string): string {
+  const t = new Date(iso).getTime();
+  const now = Date.now();
+  const mins = Math.floor((now - t) / 60_000);
+  if (mins < 1) return 'ตอนนี้';
+  if (mins < 60) return `${mins} นาทีที่แล้ว`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs} ชม.ที่แล้ว`;
+  return new Date(iso).toLocaleTimeString('th-TH', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+// ─── icon/color config ───────────────────────────────────────────────────────
+
+interface EventStyle {
+  Icon: LucideIcon;
+  iconBg: string;
+  iconText: string;
+  typeLabel: string;
+}
+
+function getEventStyle(event: TimelineEvent): EventStyle {
+  // CALL: override based on result metadata
+  if (event.type === 'CALL') {
+    const result = event.metadata?.result as string | undefined;
+    if (result === 'PROMISED') {
+      return {
+        Icon: PhoneCall,
+        iconBg: 'bg-success/10',
+        iconText: 'text-success',
+        typeLabel: 'โทร',
+      };
+    }
+    if (result === 'REFUSED') {
+      return {
+        Icon: PhoneCall,
+        iconBg: 'bg-destructive/10',
+        iconText: 'text-destructive',
+        typeLabel: 'โทร',
+      };
+    }
+    return {
+      Icon: PhoneCall,
+      iconBg: 'bg-primary/10',
+      iconText: 'text-primary',
+      typeLabel: 'โทร',
+    };
+  }
+
+  switch (event.type) {
+    case 'PAYMENT':
+      return {
+        Icon: Banknote,
+        iconBg: 'bg-success/10',
+        iconText: 'text-success',
+        typeLabel: 'ชำระ',
+      };
+    case 'DUNNING_ACTION':
+      return {
+        Icon: MessageCircle,
+        iconBg: 'bg-primary/10',
+        iconText: 'text-primary',
+        typeLabel: 'แจ้งเตือน',
+      };
+    case 'STATUS_CHANGE':
+      return {
+        Icon: Activity,
+        iconBg: 'bg-muted',
+        iconText: 'text-muted-foreground',
+        typeLabel: 'สถานะ',
+      };
+    case 'MDM':
+      return {
+        Icon: Lock,
+        iconBg: 'bg-destructive/10',
+        iconText: 'text-destructive',
+        typeLabel: 'เครื่อง',
+      };
+    case 'LETTER':
+      return {
+        Icon: FileText,
+        iconBg: 'bg-warning/10',
+        iconText: 'text-warning',
+        typeLabel: 'หนังสือ',
+      };
+    default:
+      return {
+        Icon: Activity,
+        iconBg: 'bg-muted',
+        iconText: 'text-muted-foreground',
+        typeLabel: event.type,
+      };
+  }
+}
+
+// ─── sub-components ──────────────────────────────────────────────────────────
+
+function EventCard({ event, isFirst }: { event: TimelineEvent; isFirst: boolean }) {
+  const { Icon, iconBg, iconText, typeLabel } = getEventStyle(event);
+  const label = timeLabel(event.timestamp);
+
+  return (
+    <div
+      className={`flex gap-3 px-1 py-2.5 rounded-lg hover:bg-muted/40 transition-colors ${
+        isFirst ? '' : ''
+      }`}
+    >
+      {/* Icon circle */}
+      <div
+        className={`shrink-0 mt-0.5 size-8 rounded-full flex items-center justify-center ${iconBg}`}
+      >
+        <Icon className={`size-4 ${iconText}`} />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-2 text-xs text-muted-foreground mb-0.5">
+          <span className="tabular-nums leading-snug">{label}</span>
+          <span className="text-[10px] uppercase tracking-wider leading-snug shrink-0">
+            {typeLabel}
+          </span>
+        </div>
+        <div className="text-sm font-medium leading-snug truncate">{event.title}</div>
+        {event.subtitle && (
+          <div className="text-xs text-muted-foreground mt-0.5 truncate leading-snug">
+            {event.subtitle}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── main component ──────────────────────────────────────────────────────────
+
+interface Props {
+  events: TimelineEvent[];
+}
+
+export default function Customer360Timeline({ events }: Props) {
+  if (events.length === 0) {
+    return (
+      <div className="text-center py-8 text-sm text-muted-foreground leading-snug">
+        ยังไม่มีกิจกรรม
+      </div>
+    );
+  }
+
+  const groups = groupByDate(events);
+
+  return (
+    <div className="space-y-1">
+      {groups.map((group, groupIdx) => (
+        <div key={group.label}>
+          {/* Section header */}
+          <div
+            className={`text-xs uppercase tracking-wider text-muted-foreground mb-1 leading-snug ${
+              groupIdx === 0 ? '' : 'mt-4'
+            }`}
+          >
+            {group.label}
+          </div>
+
+          {/* Events */}
+          <div>
+            {group.items.map((event, idx) => (
+              <EventCard key={event.id} event={event} isFirst={idx === 0} />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {/* Cap notice */}
+      {events.length >= 100 && (
+        <div className="pt-3 text-center text-xs text-muted-foreground leading-snug">
+          แสดง 100 รายการล่าสุด
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
@@ -1,9 +1,20 @@
 import { useState, useEffect } from 'react';
 import { Banknote, Landmark, QrCode } from 'lucide-react';
 import Modal from '@/components/ui/Modal';
+import { formatNumber } from '@/utils/formatters';
 import { useRecordPayment } from '../hooks/useRecordPayment';
 import type { PaymentMethod } from '../hooks/useRecordPayment';
 import type { ContractRow } from '../types';
+
+// Money string validator: non-empty, digits with optional single decimal (up to 2 places), > 0.
+// Avoids parseFloat() precision issues on money input — works purely on the raw string.
+const MONEY_PATTERN = /^\d+(\.\d{1,2})?$/;
+function isValidMoneyString(s: string): boolean {
+  const trimmed = s.trim();
+  if (!MONEY_PATTERN.test(trimmed)) return false;
+  // Reject "0" and "0.00" etc without relying on parseFloat
+  return /[1-9]/.test(trimmed);
+}
 
 interface Props {
   open: boolean;
@@ -33,15 +44,15 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
     }
   }, [open, contract?.id]);
 
-  const amountNum = parseFloat(amount);
-  const validAmount = !isNaN(amountNum) && amountNum > 0;
+  const validAmount = isValidMoneyString(amount);
 
   function handleSubmit() {
     if (!contract || !validAmount) return;
+    // Conversion happens once at submit boundary — backend is the authoritative validator.
     mutation.mutate(
       {
         contractId: contract.id,
-        amount: amountNum,
+        amount: Number(amount.trim()),
         paymentMethod: method,
         notes: notes || undefined,
       },
@@ -158,7 +169,7 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
           >
             {mutation.isPending
               ? 'กำลังบันทึก...'
-              : `บันทึกชำระ${validAmount ? ` ${amountNum.toLocaleString()} ฿` : ''}`}
+              : `บันทึกชำระ${validAmount ? ` ${formatNumber(amount.trim())} ฿` : ''}`}
           </button>
         </div>
       </div>

--- a/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect } from 'react';
+import { Banknote, Landmark, QrCode } from 'lucide-react';
+import Modal from '@/components/ui/Modal';
+import { useRecordPayment } from '../hooks/useRecordPayment';
+import type { PaymentMethod } from '../hooks/useRecordPayment';
+import type { ContractRow } from '../types';
+
+interface Props {
+  open: boolean;
+  contract: ContractRow | null;
+  onClose: () => void;
+}
+
+const METHOD_OPTIONS: { key: PaymentMethod; label: string; icon: React.ReactNode }[] = [
+  { key: 'CASH', label: 'เงินสด', icon: <Banknote className="size-5" /> },
+  { key: 'BANK_TRANSFER', label: 'โอน', icon: <Landmark className="size-5" /> },
+  { key: 'QR_EWALLET', label: 'QR', icon: <QrCode className="size-5" /> },
+];
+
+export default function PaymentRecordDialog({ open, contract, onClose }: Props) {
+  const [amount, setAmount] = useState<string>('');
+  const [method, setMethod] = useState<PaymentMethod>('CASH');
+  const [notes, setNotes] = useState('');
+
+  const mutation = useRecordPayment();
+
+  // Pre-fill amount from outstanding on open
+  useEffect(() => {
+    if (open && contract) {
+      setAmount(contract.outstanding > 0 ? contract.outstanding.toString() : '');
+      setMethod('CASH');
+      setNotes('');
+    }
+  }, [open, contract?.id]);
+
+  const amountNum = parseFloat(amount);
+  const validAmount = !isNaN(amountNum) && amountNum > 0;
+
+  function handleSubmit() {
+    if (!contract || !validAmount) return;
+    mutation.mutate(
+      {
+        contractId: contract.id,
+        amount: amountNum,
+        paymentMethod: method,
+        notes: notes || undefined,
+      },
+      {
+        onSuccess: () => {
+          onClose();
+          setAmount('');
+          setNotes('');
+        },
+      },
+    );
+  }
+
+  return (
+    <Modal isOpen={open} onClose={onClose} title="บันทึกการชำระเงิน" size="md">
+      <div className="space-y-5 p-1">
+        {/* Customer summary */}
+        {contract && (
+          <div className="flex items-center justify-between text-sm border-b border-border pb-3">
+            <div>
+              <div className="font-semibold leading-snug">{contract.customer.name}</div>
+              <div className="font-mono text-xs text-primary">{contract.contractNumber}</div>
+            </div>
+            <div className="text-right">
+              <div className="text-xs text-muted-foreground leading-snug">ค้างชำระ</div>
+              <div className="text-lg font-bold tabular-nums text-destructive">
+                {contract.outstanding.toLocaleString()} ฿
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Amount (hero) */}
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
+            จำนวนเงิน (บาท)
+          </label>
+          <input
+            type="number"
+            inputMode="decimal"
+            step="0.01"
+            min="0.01"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="w-full px-4 py-3 border border-input rounded-lg text-2xl font-bold tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus:border-transparent"
+            autoFocus
+          />
+          <div className="mt-1 text-xs text-muted-foreground leading-snug">
+            {contract && contract.outstanding > 0 && (
+              <button
+                type="button"
+                onClick={() => setAmount(contract.outstanding.toString())}
+                className="hover:text-foreground underline transition-colors"
+              >
+                ใช้ยอดค้าง {contract.outstanding.toLocaleString()} ฿
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Payment method — radio tiles */}
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
+            วิธีชำระ
+          </label>
+          <div className="grid grid-cols-3 gap-2">
+            {METHOD_OPTIONS.map((opt) => (
+              <button
+                key={opt.key}
+                type="button"
+                onClick={() => setMethod(opt.key)}
+                className={`flex flex-col items-center gap-1 py-3 rounded-lg border transition-colors ${
+                  method === opt.key
+                    ? 'border-primary bg-primary/5 text-primary'
+                    : 'border-input text-muted-foreground hover:text-foreground hover:bg-muted'
+                }`}
+              >
+                {opt.icon}
+                <span className="text-xs font-medium leading-snug">{opt.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Notes */}
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
+            หมายเหตุ (ไม่บังคับ)
+          </label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={2}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm resize-none leading-snug"
+            placeholder="เช่น จ่ายผ่านโอน KBank อ้างอิง XXX"
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 justify-end pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={mutation.isPending}
+            className="px-4 py-2 text-sm rounded-lg border border-input hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            ยกเลิก
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!validAmount || mutation.isPending}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {mutation.isPending
+              ? 'กำลังบันทึก...'
+              : `บันทึกชำระ${validAmount ? ` ${amountNum.toLocaleString()} ฿` : ''}`}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/SendLineAdHocDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/SendLineAdHocDialog.tsx
@@ -1,0 +1,179 @@
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Modal from '@/components/ui/Modal';
+import api from '@/lib/api';
+import { useAdHocLine } from '../hooks/useAdHocLine';
+import type { ContractRow } from '../types';
+
+interface Props {
+  open: boolean;
+  contract: ContractRow | null;
+  onClose: () => void;
+}
+
+interface DunningRule {
+  id: string;
+  name: string;
+  messageTemplate: string;
+}
+
+type Mode = 'template' | 'custom';
+
+function modeBtn(active: boolean): string {
+  return `px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors ${
+    active
+      ? 'border-primary bg-primary/5 text-primary'
+      : 'border-input hover:bg-muted text-muted-foreground'
+  }`;
+}
+
+/**
+ * Substitutes known contract placeholders with actual values for preview.
+ * Unknown {{vars}} are replaced with ··· so collector can spot them.
+ */
+function substituteTemplate(template: string, contract: ContractRow): string {
+  return template
+    .replace(/\{\{customerName\}\}/g, contract.customer.name)
+    .replace(/\{\{contractNumber\}\}/g, contract.contractNumber)
+    .replace(/\{\{amount\}\}/g, contract.outstanding.toLocaleString())
+    .replace(/\{\{daysOverdue\}\}/g, String(contract.daysOverdue))
+    .replace(/\{\{(\w+)\}\}/g, '···');
+}
+
+export default function SendLineAdHocDialog({ open, contract, onClose }: Props) {
+  const [mode, setMode] = useState<Mode>('template');
+  const [templateId, setTemplateId] = useState('');
+  const [customMessage, setCustomMessage] = useState('');
+
+  const mutation = useAdHocLine();
+
+  // Fetch dunning rules (event-trigger pool) when dialog opens
+  const { data: rules = [] } = useQuery<DunningRule[]>({
+    queryKey: ['dunning-rules'],
+    queryFn: async () => {
+      const { data } = await api.get('/overdue/dunning-rules');
+      const list = Array.isArray(data) ? data : data?.data ?? [];
+      return list as DunningRule[];
+    },
+    enabled: open,
+  });
+
+  // Reset state when dialog opens for a new contract
+  useEffect(() => {
+    if (open) {
+      setMode('template');
+      setTemplateId('');
+      setCustomMessage('');
+    }
+  }, [open, contract?.id]);
+
+  const selectedRule = rules.find((r) => r.id === templateId);
+
+  const canSubmit =
+    (mode === 'template' && !!templateId) ||
+    (mode === 'custom' && customMessage.trim().length >= 10);
+
+  function handleSubmit() {
+    if (!contract || !canSubmit) return;
+    mutation.mutate(
+      {
+        contractId: contract.id,
+        templateId: mode === 'template' ? templateId : undefined,
+        customMessage: mode === 'custom' ? customMessage.trim() : undefined,
+      },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+      },
+    );
+  }
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      title={`ส่ง LINE ถึง ${contract?.customer.name ?? ''}`}
+      size="md"
+    >
+      <div className="space-y-4">
+        {/* Mode toggle */}
+        <div className="flex gap-2">
+          <button onClick={() => setMode('template')} className={modeBtn(mode === 'template')}>
+            ใช้ template
+          </button>
+          <button onClick={() => setMode('custom')} className={modeBtn(mode === 'custom')}>
+            พิมพ์เอง
+          </button>
+        </div>
+
+        {mode === 'template' ? (
+          <div className="space-y-3">
+            <select
+              value={templateId}
+              onChange={(e) => setTemplateId(e.target.value)}
+              className="w-full px-3 py-2 border border-input rounded-lg text-sm leading-snug"
+            >
+              <option value="">— เลือก template —</option>
+              {rules.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
+            </select>
+
+            {/* Message preview with substituted vars */}
+            {selectedRule && contract && (
+              <div className="rounded-lg bg-muted/50 border border-border p-3">
+                <div className="text-xs text-muted-foreground mb-1.5 leading-snug">
+                  ตัวอย่างข้อความ
+                </div>
+                <div className="text-sm whitespace-pre-wrap leading-snug">
+                  {substituteTemplate(selectedRule.messageTemplate, contract)}
+                </div>
+              </div>
+            )}
+
+            {rules.length === 0 && (
+              <div className="text-xs text-muted-foreground italic leading-snug">
+                ยังไม่มี dunning rules — สร้างในหน้าตั้งค่าก่อน
+              </div>
+            )}
+          </div>
+        ) : (
+          <div>
+            <textarea
+              value={customMessage}
+              onChange={(e) => setCustomMessage(e.target.value)}
+              rows={5}
+              placeholder="พิมพ์ข้อความถึงลูกค้า..."
+              className="w-full px-3 py-2 border border-input rounded-lg text-sm resize-none leading-snug"
+              autoFocus
+            />
+            <div className="mt-1 text-xs text-muted-foreground leading-snug">
+              {customMessage.length} ตัวอักษร (ขั้นต่ำ 10)
+            </div>
+          </div>
+        )}
+
+        {/* Submit */}
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            onClick={onClose}
+            disabled={mutation.isPending}
+            className="px-4 py-2 text-sm rounded-lg border border-input hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit || mutation.isPending}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {mutation.isPending ? 'กำลังส่ง...' : 'ส่ง LINE'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useAdHocLine.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useAdHocLine.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export interface SendLineAdHocPayload {
+  contractId: string;
+  templateId?: string;
+  customMessage?: string;
+}
+
+export function useAdHocLine() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ contractId, ...body }: SendLineAdHocPayload) => {
+      const { data } = await api.post(`/overdue/${contractId}/send-line-adhoc`, body);
+      return data as { sent: number; failed: number; total: number };
+    },
+    onSuccess: (data, vars) => {
+      if (data.sent > 0) {
+        toast.success('ส่ง LINE สำเร็จ');
+      } else {
+        toast.error('ส่ง LINE ไม่สำเร็จ — อาจไม่มี lineId');
+      }
+      qc.invalidateQueries({ queryKey: ['customer-360', vars.contractId] });
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useBulkActions.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useBulkActions.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export function useBulkActions(clearSelection: () => void) {
+  const qc = useQueryClient();
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['collections-queue'] });
+    qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+  };
+
+  const assign = useMutation({
+    mutationFn: async (p: { contractIds: string[]; assignedToId: string }) => {
+      const { data } = await api.post('/overdue/bulk/assign', p);
+      return data as { updated: number; requested: number };
+    },
+    onSuccess: (data) => {
+      toast.success(`มอบหมาย ${data.updated}/${data.requested} รายการสำเร็จ`);
+      clearSelection();
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const sendLine = useMutation({
+    mutationFn: async (p: {
+      contractIds: string[];
+      customMessage?: string;
+      templateId?: string;
+    }) => {
+      const { data } = await api.post('/overdue/bulk/send-line', p);
+      return data as { sent: number; failed: number; total: number };
+    },
+    onSuccess: (data) => {
+      toast.success(`ส่ง LINE ${data.sent}/${data.total} (ล้มเหลว ${data.failed})`);
+      clearSelection();
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const proposeLock = useMutation({
+    mutationFn: async (p: { contractIds: string[]; reason: string }) => {
+      const { data } = await api.post('/overdue/bulk/propose-lock', p);
+      return data as { proposed: number; failed: number; requested: number };
+    },
+    onSuccess: (data) => {
+      toast.success(`เสนอล็อค ${data.proposed}/${data.requested} รายการ รออนุมัติ`);
+      clearSelection();
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  return { assign, sendLine, proposeLock };
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useBulkSelection.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useBulkSelection.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export function useBulkSelection() {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const toggleAll = (ids: string[]) =>
+    setSelected((prev) => {
+      const allSelected = ids.length > 0 && ids.every((id) => prev.has(id));
+      return allSelected ? new Set<string>() : new Set(ids);
+    });
+
+  const clear = () => setSelected(new Set<string>());
+
+  return {
+    selectedIds: selected,
+    isSelected: (id: string) => selected.has(id),
+    toggle,
+    toggleAll,
+    clear,
+    count: selected.size,
+  };
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useCustomer360.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCustomer360.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface TimelineEvent {
+  id: string;
+  type: 'CALL' | 'PAYMENT' | 'DUNNING_ACTION' | 'STATUS_CHANGE' | 'MDM' | 'LETTER';
+  timestamp: string;
+  title: string;
+  subtitle?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ContractDetail {
+  id: string;
+  contractNumber: string;
+  status: string;
+  customer: {
+    id: string;
+    name: string;
+    phone: string;
+    lineId?: string | null;
+    address?: string | null;
+  };
+  branch: { id: string; name: string };
+  installmentCount: number;
+  paidInstallments?: number;
+  outstanding?: number;
+  nextDueDate?: string | null;
+}
+
+export function useCustomer360(contractId: string | null) {
+  return useQuery({
+    queryKey: ['customer-360', contractId],
+    queryFn: async () => {
+      const [detailRes, timelineRes] = await Promise.all([
+        api.get(`/contracts/${contractId}`),
+        api.get(`/overdue/contracts/${contractId}/full-timeline`),
+      ]);
+      return {
+        detail: detailRes.data as ContractDetail,
+        timeline: timelineRes.data as TimelineEvent[],
+      };
+    },
+    enabled: !!contractId,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { formatNumber } from '@/utils/formatters';
 
 export type PaymentMethod = 'CASH' | 'BANK_TRANSFER' | 'QR_EWALLET';
 
@@ -27,7 +28,7 @@ export function useRecordPayment() {
       return data;
     },
     onSuccess: (_, vars) => {
-      toast.success(`บันทึกชำระ ${vars.amount.toLocaleString()} ฿ สำเร็จ`);
+      toast.success(`บันทึกชำระ ${formatNumber(vars.amount)} ฿ สำเร็จ`);
       qc.invalidateQueries({ queryKey: ['collections-queue'] });
       qc.invalidateQueries({ queryKey: ['collections-kpi'] });
       qc.invalidateQueries({ queryKey: ['customer-360', vars.contractId] });

--- a/apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export type PaymentMethod = 'CASH' | 'BANK_TRANSFER' | 'QR_EWALLET';
+
+export interface RecordPaymentPayload {
+  contractId: string;
+  amount: number;
+  paymentMethod: PaymentMethod;
+  notes?: string;
+}
+
+/**
+ * Records a payment via /payments/auto-allocate — server automatically
+ * allocates across next-due installments. Collector doesn't need to pick
+ * installmentNo; just enter the amount customer paid.
+ *
+ * Out of scope (MVP): slip upload / evidenceUrl enforcement. Backend accepts
+ * evidenceUrl but auto-allocate doesn't require it.
+ */
+export function useRecordPayment() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: RecordPaymentPayload) => {
+      const { data } = await api.post('/payments/auto-allocate', payload);
+      return data;
+    },
+    onSuccess: (_, vars) => {
+      toast.success(`บันทึกชำระ ${vars.amount.toLocaleString()} ฿ สำเร็จ`);
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
+      qc.invalidateQueries({ queryKey: ['collections-kpi'] });
+      qc.invalidateQueries({ queryKey: ['customer-360', vars.contractId] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -7,6 +7,7 @@ import CollectionsTabs from './components/CollectionsTabs';
 import CollectionsFilters from './components/CollectionsFilters';
 import ContactLogDialog from './components/ContactLogDialog';
 import Customer360Panel from './components/Customer360Panel';
+import SendLineAdHocDialog from './components/SendLineAdHocDialog';
 import QueueTab from './tabs/QueueTab';
 import FollowUpTab from './tabs/FollowUpTab';
 import PromiseTab from './tabs/PromiseTab';
@@ -24,6 +25,7 @@ export default function CollectionsPage() {
   const [branchId, setBranchId] = useState('');
   const [dialogContract, setDialogContract] = useState<ContractRow | null>(null);
   const [panelContract, setPanelContract] = useState<ContractRow | null>(null);
+  const [lineDialogContract, setLineDialogContract] = useState<ContractRow | null>(null);
 
   const canSeeApproval = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
   const showBranchFilter = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
@@ -66,6 +68,7 @@ export default function CollectionsPage() {
           branchId={branchId}
           onLogContact={openContactDialog}
           onOpen360={openPanel}
+          onSendLine={setLineDialogContract}
         />
       )}
 
@@ -75,6 +78,7 @@ export default function CollectionsPage() {
           branchId={branchId}
           onLogContact={openContactDialog}
           onOpen360={openPanel}
+          onSendLine={setLineDialogContract}
         />
       )}
 
@@ -84,6 +88,7 @@ export default function CollectionsPage() {
           branchId={branchId}
           onLogContact={openContactDialog}
           onOpen360={openPanel}
+          onSendLine={setLineDialogContract}
         />
       )}
 
@@ -97,7 +102,17 @@ export default function CollectionsPage() {
         onClose={() => setDialogContract(null)}
       />
 
-      <Customer360Panel contract={panelContract} onClose={closePanel} />
+      <SendLineAdHocDialog
+        open={!!lineDialogContract}
+        contract={lineDialogContract}
+        onClose={() => setLineDialogContract(null)}
+      />
+
+      <Customer360Panel
+        contract={panelContract}
+        onClose={closePanel}
+        onRequestSendLine={setLineDialogContract}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -6,6 +6,7 @@ import CollectionsKpiStrip from './components/CollectionsKpiStrip';
 import CollectionsTabs from './components/CollectionsTabs';
 import CollectionsFilters from './components/CollectionsFilters';
 import ContactLogDialog from './components/ContactLogDialog';
+import Customer360Panel from './components/Customer360Panel';
 import QueueTab from './tabs/QueueTab';
 import FollowUpTab from './tabs/FollowUpTab';
 import PromiseTab from './tabs/PromiseTab';
@@ -22,6 +23,7 @@ export default function CollectionsPage() {
   const [search, setSearch] = useState('');
   const [branchId, setBranchId] = useState('');
   const [dialogContract, setDialogContract] = useState<ContractRow | null>(null);
+  const [panelContract, setPanelContract] = useState<ContractRow | null>(null);
 
   const canSeeApproval = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
   const showBranchFilter = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
@@ -29,6 +31,8 @@ export default function CollectionsPage() {
   const showFilters = activeTab === 'today' || activeTab === 'followup' || activeTab === 'promise';
 
   const openContactDialog = (c: ContractRow) => setDialogContract(c);
+  const openPanel = (c: ContractRow) => setPanelContract(c);
+  const closePanel = () => setPanelContract(null);
 
   return (
     <div>
@@ -57,15 +61,30 @@ export default function CollectionsPage() {
       )}
 
       {activeTab === 'today' && (
-        <QueueTab search={search} branchId={branchId} onLogContact={openContactDialog} />
+        <QueueTab
+          search={search}
+          branchId={branchId}
+          onLogContact={openContactDialog}
+          onOpen360={openPanel}
+        />
       )}
 
       {activeTab === 'followup' && (
-        <FollowUpTab search={search} branchId={branchId} onLogContact={openContactDialog} />
+        <FollowUpTab
+          search={search}
+          branchId={branchId}
+          onLogContact={openContactDialog}
+          onOpen360={openPanel}
+        />
       )}
 
       {activeTab === 'promise' && (
-        <PromiseTab search={search} branchId={branchId} onLogContact={openContactDialog} />
+        <PromiseTab
+          search={search}
+          branchId={branchId}
+          onLogContact={openContactDialog}
+          onOpen360={openPanel}
+        />
       )}
 
       {activeTab === 'approval' && canSeeApproval && <ApprovalTab />}
@@ -77,6 +96,8 @@ export default function CollectionsPage() {
         contract={dialogContract}
         onClose={() => setDialogContract(null)}
       />
+
+      <Customer360Panel contract={panelContract} onClose={closePanel} />
     </div>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -25,9 +25,10 @@ interface Props {
   search: string;
   branchId: string;
   onLogContact: (c: ContractRow) => void;
+  onOpen360?: (c: ContractRow) => void;
 }
 
-export default function FollowUpTab({ search, branchId, onLogContact }: Props) {
+export default function FollowUpTab({ search, branchId, onLogContact, onOpen360 }: Props) {
   const [page, setPage] = useState(1);
   const debouncedSearch = useDebounce(search, 300);
 
@@ -92,10 +93,15 @@ export default function FollowUpTab({ search, branchId, onLogContact }: Props) {
             {filtered.map((row) =>
               row.noAnswerCount === 2 ? (
                 <div key={row.id} className="ring-2 ring-destructive/40 rounded-xl">
-                  <ContractCard contract={row} onLogContact={onLogContact} />
+                  <ContractCard contract={row} onLogContact={onLogContact} onOpen360={onOpen360} />
                 </div>
               ) : (
-                <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+                <ContractCard
+                  key={row.id}
+                  contract={row}
+                  onLogContact={onLogContact}
+                  onOpen360={onOpen360}
+                />
               ),
             )}
           </div>

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
+import BulkActionBar from '../components/BulkActionBar';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
+import { useBulkSelection } from '../hooks/useBulkSelection';
 import type { ContractRow } from '../types';
 
 const LIMIT = 50;
@@ -26,10 +28,12 @@ interface Props {
   branchId: string;
   onLogContact: (c: ContractRow) => void;
   onOpen360?: (c: ContractRow) => void;
+  onSendLine?: (c: ContractRow) => void;
 }
 
-export default function FollowUpTab({ search, branchId, onLogContact, onOpen360 }: Props) {
+export default function FollowUpTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
   const [page, setPage] = useState(1);
+  const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
 
   const q = useCollectionsQueue({
@@ -93,7 +97,14 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360 
             {filtered.map((row) =>
               row.noAnswerCount === 2 ? (
                 <div key={row.id} className="ring-2 ring-destructive/40 rounded-xl">
-                  <ContractCard contract={row} onLogContact={onLogContact} onOpen360={onOpen360} />
+                  <ContractCard
+                    contract={row}
+                    onLogContact={onLogContact}
+                    onOpen360={onOpen360}
+                    onSendLine={onSendLine}
+                    selected={sel.isSelected(row.id)}
+                    onToggleSelect={sel.toggle}
+                  />
                 </div>
               ) : (
                 <ContractCard
@@ -101,6 +112,9 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360 
                   contract={row}
                   onLogContact={onLogContact}
                   onOpen360={onOpen360}
+                  onSendLine={onSendLine}
+                  selected={sel.isSelected(row.id)}
+                  onToggleSelect={sel.toggle}
                 />
               ),
             )}
@@ -131,6 +145,7 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360 
           )}
         </>
       )}
+      <BulkActionBar selectedIds={sel.selectedIds} onClear={sel.clear} />
     </QueryBoundary>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -83,9 +83,10 @@ interface Props {
   search: string;
   branchId: string;
   onLogContact: (c: ContractRow) => void;
+  onOpen360?: (c: ContractRow) => void;
 }
 
-export default function PromiseTab({ search, branchId, onLogContact }: Props) {
+export default function PromiseTab({ search, branchId, onLogContact, onOpen360 }: Props) {
   const [page, setPage] = useState(1);
   const debouncedSearch = useDebounce(search, 300);
 
@@ -153,7 +154,11 @@ export default function PromiseTab({ search, branchId, onLogContact }: Props) {
                 <div className="space-y-2">
                   {groups.broken.map((row) => (
                     <div key={row.id} className="ring-2 ring-destructive/50 rounded-xl">
-                      <ContractCard contract={row} onLogContact={onLogContact} />
+                      <ContractCard
+                        contract={row}
+                        onLogContact={onLogContact}
+                        onOpen360={onOpen360}
+                      />
                     </div>
                   ))}
                 </div>
@@ -168,7 +173,12 @@ export default function PromiseTab({ search, branchId, onLogContact }: Props) {
                 </h3>
                 <div className="space-y-2">
                   {groups.today.map((row) => (
-                    <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+                    <ContractCard
+                      key={row.id}
+                      contract={row}
+                      onLogContact={onLogContact}
+                      onOpen360={onOpen360}
+                    />
                   ))}
                 </div>
               </section>
@@ -182,7 +192,12 @@ export default function PromiseTab({ search, branchId, onLogContact }: Props) {
                 </h3>
                 <div className="space-y-2">
                   {groups.upcoming.map((row) => (
-                    <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+                    <ContractCard
+                      key={row.id}
+                      contract={row}
+                      onLogContact={onLogContact}
+                      onOpen360={onOpen360}
+                    />
                   ))}
                 </div>
               </section>

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -3,7 +3,9 @@ import { AlertTriangle } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
+import BulkActionBar from '../components/BulkActionBar';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
+import { useBulkSelection } from '../hooks/useBulkSelection';
 import type { ContractRow } from '../types';
 
 const LIMIT = 50;
@@ -84,10 +86,12 @@ interface Props {
   branchId: string;
   onLogContact: (c: ContractRow) => void;
   onOpen360?: (c: ContractRow) => void;
+  onSendLine?: (c: ContractRow) => void;
 }
 
-export default function PromiseTab({ search, branchId, onLogContact, onOpen360 }: Props) {
+export default function PromiseTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
   const [page, setPage] = useState(1);
+  const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
 
   const q = useCollectionsQueue({
@@ -158,6 +162,9 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360 }
                         contract={row}
                         onLogContact={onLogContact}
                         onOpen360={onOpen360}
+                        onSendLine={onSendLine}
+                        selected={sel.isSelected(row.id)}
+                        onToggleSelect={sel.toggle}
                       />
                     </div>
                   ))}
@@ -178,6 +185,9 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360 }
                       contract={row}
                       onLogContact={onLogContact}
                       onOpen360={onOpen360}
+                      onSendLine={onSendLine}
+                      selected={sel.isSelected(row.id)}
+                      onToggleSelect={sel.toggle}
                     />
                   ))}
                 </div>
@@ -197,6 +207,9 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360 }
                       contract={row}
                       onLogContact={onLogContact}
                       onOpen360={onOpen360}
+                      onSendLine={onSendLine}
+                      selected={sel.isSelected(row.id)}
+                      onToggleSelect={sel.toggle}
                     />
                   ))}
                 </div>
@@ -229,6 +242,7 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360 }
           )}
         </>
       )}
+      <BulkActionBar selectedIds={sel.selectedIds} onClear={sel.clear} />
     </QueryBoundary>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
+import BulkActionBar from '../components/BulkActionBar';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
+import { useBulkSelection } from '../hooks/useBulkSelection';
 import type { ContractRow } from '../types';
 
 const LIMIT = 50;
@@ -26,10 +28,12 @@ interface Props {
   branchId: string;
   onLogContact: (c: ContractRow) => void;
   onOpen360?: (c: ContractRow) => void;
+  onSendLine?: (c: ContractRow) => void;
 }
 
-export default function QueueTab({ search, branchId, onLogContact, onOpen360 }: Props) {
+export default function QueueTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
   const [page, setPage] = useState(1);
+  const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
 
   const q = useCollectionsQueue({
@@ -89,6 +93,9 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360 }: 
                 contract={row}
                 onLogContact={onLogContact}
                 onOpen360={onOpen360}
+                onSendLine={onSendLine}
+                selected={sel.isSelected(row.id)}
+                onToggleSelect={sel.toggle}
               />
             ))}
           </div>
@@ -118,6 +125,7 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360 }: 
           )}
         </>
       )}
+      <BulkActionBar selectedIds={sel.selectedIds} onClear={sel.clear} />
     </QueryBoundary>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -25,9 +25,10 @@ interface Props {
   search: string;
   branchId: string;
   onLogContact: (c: ContractRow) => void;
+  onOpen360?: (c: ContractRow) => void;
 }
 
-export default function QueueTab({ search, branchId, onLogContact }: Props) {
+export default function QueueTab({ search, branchId, onLogContact, onOpen360 }: Props) {
   const [page, setPage] = useState(1);
   const debouncedSearch = useDebounce(search, 300);
 
@@ -83,7 +84,12 @@ export default function QueueTab({ search, branchId, onLogContact }: Props) {
         <>
           <div className="space-y-2">
             {filtered.map((row) => (
-              <ContractCard key={row.id} contract={row} onLogContact={onLogContact} />
+              <ContractCard
+                key={row.id}
+                contract={row}
+                onLogContact={onLogContact}
+                onOpen360={onOpen360}
+              />
             ))}
           </div>
 

--- a/docs/superpowers/plans/2026-04-24-collections-power-features-plan.md
+++ b/docs/superpowers/plans/2026-04-24-collections-power-features-plan.md
@@ -1,0 +1,679 @@
+# Collections Workflow Hub — Plan 3/4: Power Features
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. UI tasks MUST invoke `frontend-design` skill before building components.
+
+**Goal:** Ship Customer 360 slide-over, bulk actions, inline payment recording, and ad-hoc LINE send. Turns `/collections` from "view + log" to "act + recover" without leaving the page.
+
+**Architecture:** A right-side slide-over (`Customer360Panel`) reused across all tabs. Bulk selection is local state on each tab, with a sticky `BulkActionBar`. New backend endpoints: `/overdue/contracts/:id/full-timeline`, `/overdue/bulk/*`, `/overdue/:id/send-line-adhoc`.
+
+**Tech Stack:** Same as Plan 2 (NestJS + React + Tailwind + shadcn/ui + lucide-react + tanstack/react-query).
+
+**Spec:** [docs/superpowers/specs/2026-04-24-collections-workflow-hub-design.md](../specs/2026-04-24-collections-workflow-hub-design.md) §7 (bulk), §9 (Customer 360), §10 (inline payment).
+
+**Depends on:** Plan 2 branch `feat/collections-workflow-hub`.
+
+---
+
+## File Map
+
+### Create — Backend
+
+- `apps/api/src/modules/overdue/timeline.service.ts` + `.spec.ts`
+- `apps/api/src/modules/overdue/bulk.service.ts` + `.spec.ts`
+- `apps/api/src/modules/overdue/dto/bulk.dto.ts`
+- `apps/api/src/modules/overdue/dto/send-line-adhoc.dto.ts`
+
+### Modify — Backend
+
+- `apps/api/src/modules/overdue/overdue.controller.ts` — add 5 endpoints
+- `apps/api/src/modules/overdue/overdue.module.ts` — register new services
+
+### Create — Frontend
+
+```
+apps/web/src/pages/CollectionsPage/
+  components/
+    Customer360Panel.tsx            # slide-over shell
+    Customer360Header.tsx           # name + phone + LINE status chips
+    Customer360Timeline.tsx         # merged event feed
+    Customer360Actions.tsx          # quick action buttons
+    PaymentRecordDialog.tsx
+    BulkActionBar.tsx
+    SendLineAdHocDialog.tsx
+  hooks/
+    useCustomer360.ts               # queries timeline + contract detail
+    useBulkSelection.ts             # selection state + helpers
+    useBulkActions.ts               # mutations for bulk ops
+    useAdHocLine.ts                 # single ad-hoc send mutation
+    useRecordPayment.ts             # POST /payments wrapper
+```
+
+### Modify — Frontend
+
+- `apps/web/src/pages/CollectionsPage/components/ContractCard.tsx` — add checkbox + "▶" 360 button
+- `apps/web/src/pages/CollectionsPage/index.tsx` — render `<Customer360Panel />`, manage slide-over state + bulk selection context
+- Tab files (QueueTab / FollowUpTab / PromiseTab) — consume bulk state via props
+
+---
+
+## Design brief — still "Operations Room"
+
+- **Customer 360** = ปีกทำงานด้านขวา (width 480px desktop, full screen mobile). Animates in from right (`translate-x-full` → `translate-x-0` + opacity backdrop).
+- **Timeline** = chronological feed with icon per event type: phone, LINE, payment, status change, MDM, letter. Newest on top. Infinite scroll NOT needed for MVP; show last 50 with "load more" button.
+- **BulkActionBar** = sticky bar at bottom of viewport when any rows selected. Shows count + 4 action buttons. Similar to Gmail's multi-select. No floating — always at bottom edge.
+- **PaymentRecordDialog** = reuses existing POS-style dialog if present (check `@/components/ui/` first). Amount input has `tabular-nums`, payment method radio row, optional slip upload.
+
+**Semantic tokens only.** Thai labels. `leading-snug`. `tabular-nums`.
+
+---
+
+## Ground Rules
+
+1. Stacked branch: base `feat/collections-workflow-hub`, new `feat/collections-power-features`.
+2. Every UI subagent invokes `frontend-design` skill before coding.
+3. TDD backend; component tests where feasible.
+4. `./tools/check-types.sh all` green before each commit.
+5. Commit per task. No dep additions.
+6. Reuse existing `Payment` creation endpoint — do not duplicate.
+
+---
+
+## Task 1: Backend — `GET /overdue/contracts/:id/full-timeline`
+
+### Files
+- Create: `apps/api/src/modules/overdue/timeline.service.ts` + `.spec.ts`
+- Modify: controller + module
+
+### Behavior
+
+Returns merged event feed for a single contract, sorted DESC by timestamp:
+
+```typescript
+interface TimelineEvent {
+  id: string;                 // source id prefixed by type ("call-xxx", "payment-yyy")
+  type: 'CALL' | 'PAYMENT' | 'DUNNING_ACTION' | 'STATUS_CHANGE' | 'MDM' | 'LETTER';
+  timestamp: string;          // ISO
+  title: string;              // Thai label
+  subtitle?: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+Sources to merge:
+- `callLogs` (type=CALL; title from `result` + notes; subtitle = caller.name)
+- `payments` where `status=PAID` (type=PAYMENT; title "ชำระ X ฿ งวด Y")
+- `dunningActions` (type=DUNNING_ACTION; title "ส่ง {channel}: {ruleName}"; subtitle = messageContent truncated)
+- `auditLogs` where `entity IN ('contract', 'mdm_lock_request')` AND `action IN ('STATUS_CHANGE','DUNNING_ESCALATION_APPROVED','MDM_LOCK_APPROVED','MDM_UNLOCK')` (type=STATUS_CHANGE or MDM)
+- `contractLetters` where status in (DISPATCHED, DELIVERED) (type=LETTER; title "ส่งหนังสือ: RETURN_DEVICE_45D" — Plan 4 will populate, empty for now)
+
+Cap at 100 events. Service fetches each source then merges + sorts in memory. Simple and correct; performance OK for < 100s events per contract.
+
+### Controller route
+
+```typescript
+@Get('contracts/:id/full-timeline')
+@Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
+getFullTimeline(@Param('id') contractId: string) {
+  return this.timelineService.getFullTimeline(contractId);
+}
+```
+
+### Tests
+
+Mock-based. 4 tests:
+- Returns events from all 4 current sources (call, payment, dunning action, audit)
+- Sorted DESC by timestamp
+- Caps at 100
+- Returns `[]` when contract has nothing
+
+### Commit
+`feat(overdue): full-timeline endpoint for Customer 360 panel`
+
+---
+
+## Task 2: Backend — `/overdue/bulk/*`
+
+### Files
+- Create: `apps/api/src/modules/overdue/bulk.service.ts` + `.spec.ts`
+- Create: `apps/api/src/modules/overdue/dto/bulk.dto.ts`
+
+### DTOs
+
+```typescript
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsString, IsOptional, MinLength } from 'class-validator';
+
+export class BulkAssignDto {
+  @IsArray() @ArrayMinSize(1) @ArrayMaxSize(100) @IsString({ each: true })
+  contractIds!: string[];
+
+  @IsString({ message: 'ต้องระบุผู้รับมอบหมาย' })
+  assignedToId!: string;
+}
+
+export class BulkSendLineDto {
+  @IsArray() @ArrayMinSize(1) @ArrayMaxSize(100) @IsString({ each: true })
+  contractIds!: string[];
+
+  @IsOptional() @IsString()
+  templateId?: string;   // DunningRule id (eventTrigger=null AND triggerDay=null ad-hoc pool)
+
+  @IsOptional() @IsString() @MinLength(10, { message: 'ข้อความต้อง ≥ 10 ตัวอักษร' })
+  customMessage?: string;
+}
+
+export class BulkProposeLockDto {
+  @IsArray() @ArrayMinSize(1) @ArrayMaxSize(100) @IsString({ each: true })
+  contractIds!: string[];
+
+  @IsString() @MinLength(5, { message: 'เหตุผล ≥ 5 ตัวอักษร' })
+  reason!: string;
+}
+```
+
+### Service
+
+```typescript
+@Injectable()
+export class OverdueBulkService {
+  constructor(
+    private prisma: PrismaService,
+    private mdmLockService: MdmLockService,
+    private dunningEngine: DunningEngineService,
+    private notifications: NotificationsService,
+  ) {}
+
+  async bulkAssign(dto: BulkAssignDto, actorId: string) {
+    const result = await this.prisma.contract.updateMany({
+      where: { id: { in: dto.contractIds }, deletedAt: null },
+      data: { assignedToId: dto.assignedToId },
+    });
+    // Audit per contract
+    await this.prisma.auditLog.createMany({
+      data: dto.contractIds.map((id) => ({
+        userId: actorId,
+        action: 'BULK_ASSIGN',
+        entity: 'contract',
+        entityId: id,
+        newValue: { assignedToId: dto.assignedToId },
+      })),
+    });
+    return { updated: result.count };
+  }
+
+  async bulkProposeLock(dto: BulkProposeLockDto, actorId: string) {
+    const results = await Promise.allSettled(
+      dto.contractIds.map((id) => this.mdmLockService.proposeManual(id, actorId, dto.reason)),
+    );
+    const ok = results.filter((r) => r.status === 'fulfilled').length;
+    const failed = results.length - ok;
+    return { proposed: ok, failed };
+  }
+
+  async bulkSendLine(dto: BulkSendLineDto, actorId: string) {
+    // Simple for MVP: iterate, send per contract, collect results.
+    // If templateId — render rule's message. If customMessage — send as-is.
+    if (!dto.templateId && !dto.customMessage) {
+      throw new BadRequestException('ต้องระบุ templateId หรือ customMessage');
+    }
+
+    const contracts = await this.prisma.contract.findMany({
+      where: { id: { in: dto.contractIds }, deletedAt: null },
+      include: { customer: { select: { lineId: true, phone: true, name: true } } },
+    });
+
+    let sent = 0;
+    let failed = 0;
+    for (const c of contracts) {
+      if (!c.customer.lineId) { failed++; continue; }
+      try {
+        await this.notifications.send({
+          channel: 'LINE',
+          recipient: c.customer.lineId,
+          message: dto.customMessage ?? 'Template rendering requires executeEventTrigger helper',
+          relatedId: c.id,
+          fallbackPhone: c.customer.phone,
+        });
+        sent++;
+      } catch { failed++; }
+    }
+    return { sent, failed, total: contracts.length };
+  }
+}
+```
+
+### Controller
+
+```typescript
+  @Post('bulk/assign')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  bulkAssign(@Body() dto: BulkAssignDto, @CurrentUser() user: { id: string }) {
+    return this.bulkService.bulkAssign(dto, user.id);
+  }
+
+  @Post('bulk/propose-lock')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+  bulkProposeLock(@Body() dto: BulkProposeLockDto, @CurrentUser() user: { id: string }) {
+    return this.bulkService.bulkProposeLock(dto, user.id);
+  }
+
+  @Post('bulk/send-line')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+  bulkSendLine(@Body() dto: BulkSendLineDto, @CurrentUser() user: { id: string }) {
+    return this.bulkService.bulkSendLine(dto, user.id);
+  }
+```
+
+### Tests
+
+Minimum 6 tests (2 per method). Mock prisma + mdmLockService + notifications.
+
+### Commit
+`feat(overdue): bulk assign/propose-lock/send-line endpoints with 100-item cap`
+
+---
+
+## Task 3: Backend — `POST /overdue/:contractId/send-line-adhoc`
+
+Single-contract ad-hoc LINE send (different from bulk).
+
+### DTO
+```typescript
+// send-line-adhoc.dto.ts
+import { IsOptional, IsString, MinLength } from 'class-validator';
+
+export class SendLineAdHocDto {
+  @IsOptional() @IsString()
+  templateId?: string;
+
+  @IsOptional() @IsString() @MinLength(10)
+  customMessage?: string;
+}
+```
+
+### Controller
+
+```typescript
+@Post(':contractId/send-line-adhoc')
+@Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+async sendLineAdhoc(
+  @Param('contractId') contractId: string,
+  @Body() dto: SendLineAdHocDto,
+  @CurrentUser() user: { id: string },
+) {
+  // Reuse bulk path for consistency
+  return this.bulkService.bulkSendLine(
+    { contractIds: [contractId], templateId: dto.templateId, customMessage: dto.customMessage },
+    user.id,
+  );
+}
+```
+
+### Commit
+`feat(overdue): ad-hoc LINE send endpoint for single contract`
+
+---
+
+## Task 4: Frontend — Customer360Panel slide-over shell
+
+Invoke `frontend-design` skill first.
+
+### Files
+- Create: `apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx`
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useCustomer360.ts`
+- Modify: `apps/web/src/pages/CollectionsPage/index.tsx` — render + state
+
+### Design
+
+Right-side panel, 480px width on desktop, full-screen on mobile. Enter: translate-x + backdrop fade. Exit: reverse.
+
+Structure:
+```
+┌─────────────────────────────┐
+│ [×]     Customer 360         │  (header bar, sticky)
+├─────────────────────────────┤
+│ Customer info (name, phone,  │
+│  LINE chip, address)         │
+├─────────────────────────────┤
+│ Contract summary             │
+│  (installment progress bar,  │
+│   outstanding, next due)     │
+├─────────────────────────────┤
+│ Timeline (TASK 5)            │
+│  (scrollable feed)           │
+├─────────────────────────────┤
+│ Quick actions (TASK 6)       │
+│  (payment, LINE, lock, open) │
+└─────────────────────────────┘
+```
+
+Panel controlled by parent: `panel={contract: ContractRow | null; onClose: () => void}`. Parent manages open/closed state.
+
+### Hook
+
+```typescript
+export function useCustomer360(contractId: string | null) {
+  return useQuery({
+    queryKey: ['customer-360', contractId],
+    queryFn: async () => {
+      const [detail, timeline] = await Promise.all([
+        api.get(`/contracts/${contractId}`).then((r) => r.data),
+        api.get(`/overdue/contracts/${contractId}/full-timeline`).then((r) => r.data),
+      ]);
+      return { detail, timeline };
+    },
+    enabled: !!contractId,
+  });
+}
+```
+
+### Stub for Tasks 5 + 6
+
+For this task, render the shell with placeholders for Timeline + Actions. Tasks 5 + 6 replace them.
+
+### Wire ContractCard
+
+Add `onOpen360` prop to `ContractCard`. Parent passes setter that opens the panel. Render a `▶` button in the card's action cluster.
+
+### Commit
+`feat(collections): Customer360Panel shell + slide-over state`
+
+---
+
+## Task 5: Frontend — Customer360Timeline
+
+Invoke `frontend-design` skill.
+
+### File
+- Create: `apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx`
+
+### Design
+
+Vertical feed. Each event:
+
+```
+┌──────────────────────────────────────┐
+│ [icon] [ time-ago label ]     [type chip] │
+│        [ title ]                          │
+│        [ subtitle in muted ]              │
+└──────────────────────────────────────┘
+```
+
+Group events by date — small sticky date header ("วันนี้", "เมื่อวาน", "22 เม.ย. 2026") separating groups.
+
+Icons by type:
+- CALL → `PhoneCall` (color based on result: PROMISED=success, NO_ANSWER=warning, REFUSED=destructive)
+- PAYMENT → `Banknote` (success)
+- DUNNING_ACTION → `MessageCircle` (primary)
+- STATUS_CHANGE → `Activity` (muted)
+- MDM → `Lock`/`Unlock` (destructive/success)
+- LETTER → `FileText` (warning)
+
+Show last 50 by default with "โหลดเพิ่ม" button if len === 50.
+
+Empty state: "ยังไม่มีกิจกรรม" neutral.
+
+### Integrate into Customer360Panel
+
+Replace Timeline placeholder with `<Customer360Timeline events={data.timeline ?? []} />`.
+
+### Commit
+`feat(collections): Customer360Timeline — grouped event feed`
+
+---
+
+## Task 6: Frontend — Customer360Actions + PaymentRecordDialog
+
+Invoke `frontend-design` skill for PaymentRecordDialog.
+
+### Files
+- Create: `apps/web/src/pages/CollectionsPage/components/Customer360Actions.tsx`
+- Create: `apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx`
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts`
+
+### Actions row in Customer360
+
+4 action buttons (icon + label):
+- **บันทึกจ่าย** — opens PaymentRecordDialog (primary button)
+- **ส่ง LINE** — opens SendLineAdHocDialog (Task 8)
+- **เสนอล็อคเครื่อง** — opens existing MDM propose flow (inline small modal reusing `mdm-lock-propose` logic)
+- **ดูสัญญาเต็ม** — `navigate('/contracts/:id')`
+
+Use outline button style for secondary actions; primary filled for "บันทึกจ่าย".
+
+Disable "บันทึกจ่าย" when outstanding === 0.
+
+### PaymentRecordDialog
+
+Modal form:
+- **ยอดเงิน** (default = outstanding; `tabular-nums`; allows partial)
+- **วิธีชำระ** radio row: เงินสด / โอน / QR
+- **slip upload** (shown if method !== เงินสด) — reuse existing upload component from `/payments/new` or similar
+- **หมายเหตุ** textarea
+
+Submit → `POST /payments` (existing endpoint) → on success invalidate `collections-queue`, `collections-kpi`, `customer-360:<id>`.
+
+### useRecordPayment hook
+
+```typescript
+export function useRecordPayment(contractId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: {
+      amount: number;
+      method: 'CASH' | 'TRANSFER' | 'QR';
+      slipUrl?: string;
+      notes?: string;
+    }) => {
+      const { data } = await api.post('/payments', { contractId, ...body });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('บันทึกการชำระสำเร็จ');
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
+      qc.invalidateQueries({ queryKey: ['collections-kpi'] });
+      qc.invalidateQueries({ queryKey: ['customer-360', contractId] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+}
+```
+
+Shape of `/payments` body must match existing API — inspect `apps/api/src/modules/payments/payments.controller.ts` for exact DTO. Adapt as needed.
+
+### Integrate into Customer360Panel
+
+Replace Actions placeholder with `<Customer360Actions contract={...} onClose={onClose} />`.
+
+### Commit
+`feat(collections): Customer360 actions + PaymentRecordDialog for inline payment`
+
+---
+
+## Task 7: Frontend — BulkActionBar + useBulkSelection
+
+Invoke `frontend-design` skill.
+
+### Files
+- Create: `apps/web/src/pages/CollectionsPage/components/BulkActionBar.tsx`
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useBulkSelection.ts`
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useBulkActions.ts`
+- Modify: `ContractCard.tsx` — add checkbox + `selected` + `onToggleSelect` props
+- Modify: Queue/FollowUp/Promise tab files — wire selection state
+
+### useBulkSelection
+
+```typescript
+export function useBulkSelection() {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const toggle = (id: string) => setSelected((s) => {
+    const next = new Set(s);
+    next.has(id) ? next.delete(id) : next.add(id);
+    return next;
+  });
+  const toggleAll = (ids: string[]) => setSelected((s) => {
+    const allSelected = ids.every((id) => s.has(id));
+    return allSelected ? new Set() : new Set(ids);
+  });
+  const clear = () => setSelected(new Set());
+  return { selected, toggle, toggleAll, clear, count: selected.size };
+}
+```
+
+### BulkActionBar
+
+Sticky bottom, only visible when `selected.size > 0`. Layout:
+```
+[ n รายการถูกเลือก ]  [มอบหมาย ▾] [ส่ง LINE] [เสนอล็อค] [ยกเลิก]
+```
+
+"มอบหมาย" = dropdown with staff user list (reuse `/users` query). On select → calls bulk assign → on success clears selection.
+"ส่ง LINE" = opens modal (reuse SendLineAdHocDialog from Task 8 but with N contracts).
+"เสนอล็อค" = opens prompt for reason → bulk propose.
+"ยกเลิก" = `clear()`.
+
+Use `fixed bottom-0 left-0 right-0 border-t border-border bg-card shadow-lg z-40`. `p-3`. Mobile responsive.
+
+### useBulkActions hook
+
+```typescript
+export function useBulkActions(clearSelection: () => void) {
+  const qc = useQueryClient();
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['collections-queue'] });
+    qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+  };
+
+  return {
+    assign: useMutation({
+      mutationFn: (p: { contractIds: string[]; assignedToId: string }) =>
+        api.post('/overdue/bulk/assign', p).then((r) => r.data),
+      onSuccess: (data) => { toast.success(`มอบหมาย ${data.updated} รายการสำเร็จ`); clearSelection(); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+    sendLine: useMutation({
+      mutationFn: (p: { contractIds: string[]; customMessage?: string; templateId?: string }) =>
+        api.post('/overdue/bulk/send-line', p).then((r) => r.data),
+      onSuccess: (data) => { toast.success(`ส่ง LINE ${data.sent}/${data.total} สำเร็จ`); clearSelection(); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+    proposeLock: useMutation({
+      mutationFn: (p: { contractIds: string[]; reason: string }) =>
+        api.post('/overdue/bulk/propose-lock', p).then((r) => r.data),
+      onSuccess: (data) => { toast.success(`เสนอล็อค ${data.proposed} รายการ`); clearSelection(); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+  };
+}
+```
+
+### ContractCard update
+
+Add props `selected?: boolean` + `onToggleSelect?: () => void`. Render checkbox left of the priority strip (or inside the strip area). Use existing `Checkbox` from `@/components/ui/checkbox` if present.
+
+### Wire into Queue/FollowUp/Promise tabs
+
+Each tab uses `useBulkSelection`. Pass `selected`, `onToggleSelect` to each `<ContractCard />`. Render `<BulkActionBar ... />` at root of tab (or lift to CollectionsPage — acceptable either way).
+
+Recommended: lift selection state to CollectionsPage so it persists across tab switches... actually no — clear on tab change to avoid confusion. Per-tab is fine.
+
+### Commit
+`feat(collections): bulk selection + BulkActionBar with assign/send-line/propose-lock`
+
+---
+
+## Task 8: Frontend — SendLineAdHocDialog + single-contract ad-hoc send
+
+Invoke `frontend-design` skill.
+
+### Files
+- Create: `apps/web/src/pages/CollectionsPage/components/SendLineAdHocDialog.tsx`
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useAdHocLine.ts`
+- Modify: `ContractCard.tsx` — add "ส่ง LINE" button that opens dialog
+
+### Design
+
+Modal:
+- **Mode:** radio "ใช้ template" / "พิมพ์เอง"
+- **If template:** dropdown of DunningRule options (eventTrigger=null AND triggerDay=null — ad-hoc pool). Show preview of rendered message.
+- **If custom:** textarea (min 10 chars). Show remaining character count.
+- **Preview card** shows final message with `{{placeholders}}` replaced using dummy contract vars.
+- **Submit button:** ส่ง LINE (disabled until valid)
+
+### useAdHocLine hook
+
+```typescript
+export function useAdHocLine() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ contractId, ...body }: {
+      contractId: string;
+      templateId?: string;
+      customMessage?: string;
+    }) => {
+      const { data } = await api.post(`/overdue/${contractId}/send-line-adhoc`, body);
+      return data;
+    },
+    onSuccess: (data) => {
+      toast.success(`ส่ง LINE ${data.sent}/${data.total}`);
+      qc.invalidateQueries({ queryKey: ['customer-360'] });
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+}
+```
+
+### Wire into ContractCard
+
+Enable the "💬 ส่งไลน์" button (was stub in Plan 2). On click, open dialog.
+
+### Wire into Customer360Actions
+
+"ส่ง LINE" action also opens this dialog.
+
+### Commit
+`feat(collections): ad-hoc LINE send dialog + single-contract endpoint consumer`
+
+---
+
+## Task 9: E2E smoke + full type-check sweep
+
+### Files
+- Modify: `apps/web/e2e/collections-smoke.spec.ts` — add Plan 3 tests
+
+Add:
+- Click card ▶ → Customer360Panel slides open, timeline header visible
+- Close panel → panel gone
+- Select 2 rows in queue → BulkActionBar appears with count=2
+- Ad-hoc LINE dialog opens from a card button (skip actual send — just open/close)
+
+### Sweep
+
+```bash
+./tools/check-types.sh all      # 0 errors
+cd apps/api && npm test         # all pass
+cd apps/web && npm test -- --run
+```
+
+- [ ] Commit: `test(collections): e2e smoke for Customer 360 + bulk + ad-hoc LINE`
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+| Spec § | Task |
+|---|---|
+| §7 Bulk actions | 2, 7 |
+| §9 Customer 360 | 1, 4, 5, 6 |
+| §10 Inline payment | 6 |
+| §4 Ad-hoc LINE send | 3, 8 |
+
+**Out of scope (Plan 4):**
+- Legal letters (PDF + dispatch + OWNER queue UI)
+- MDM unlock UI action (has endpoint; surface in approval tab or customer 360 only)
+- Drag-drop kanban
+- Thailand Post Connect API
+
+**Placeholder scan:** no TBD. All code snippets present.
+
+**Type consistency:** `ContractRow`, `PendingMdmRequest`, `TimelineEvent` types shared from `types.ts`. Endpoint paths consistent across backend + frontend.


### PR DESCRIPTION
## Summary

Plan 3/4 of the **Collections Workflow Hub** redesign. Turns `/collections` from view-only into a recovery tool: collectors can now record payments, send LINE ad-hoc, bulk assign/notify/propose-lock, and open full customer context (Customer 360 slide-over) without leaving the page.

**Base branch:** \`feat/collections-workflow-hub\` (Plan 2) — merge Plan 2 first.

## What's shipped

### Backend (3 endpoints)
- \`GET /overdue/contracts/:id/full-timeline\` — merged event feed (call logs + payments + dunning actions + audit + letters), DESC sorted, capped at 100
- \`POST /overdue/bulk/assign | /bulk/propose-lock | /bulk/send-line\` — 100-item cap, partial-success reporting, per-contract audit
- \`POST /overdue/:contractId/send-line-adhoc\` — single-contract wrapper (delegates to bulkSendLine)

### Frontend (Customer 360 slide-over + power features)
- **Customer360Panel** — 480px slide-over (right edge), 200ms translate-x + backdrop blur, Escape key + body-scroll lock
- **Customer360Timeline** — grouped event feed (วันนี้ / เมื่อวาน / date), per-type icon + color, relative time labels, 100-item cap notice
- **Customer360Actions** — 2x2 quick actions (บันทึกจ่าย / ส่ง LINE / เสนอล็อค / ดูสัญญาเต็ม)
- **PaymentRecordDialog** — hero amount input + 3-tile method radio (CASH/BANK_TRANSFER/QR_EWALLET), auto-allocate to next-due installments, "ใช้ยอดค้าง" quick-fill
- **BulkActionBar** — sticky bottom bar when selection > 0, 3 inline mini-modals for assign/send-line/propose-lock
- **SendLineAdHocDialog** — mode toggle (template / พิมพ์เอง), live preview with placeholder substitution
- **ContractCard** updates: checkbox column (when \`onToggleSelect\` provided), ChevronRight 360 button, LINE button re-enabled

### Wiring
- Shared \`useBulkSelection\` hook per tab (auto-clears on tab switch via component unmount)
- \`useRecordPayment\` / \`useAdHocLine\` / \`useBulkActions\` query-invalidation discipline
- Customer360Actions propagates via parent setters so same dialogs open from card row AND from panel

## Customer impact on deploy

**Still zero** — feature flag \`collections_v2_enabled\` from Plan 2 still default \`false\`. Payment recording hits existing \`/payments/auto-allocate\` which is the same endpoint collectors would use elsewhere; no change to customer-visible billing.

LINE ad-hoc: same event rule infrastructure from Plan 1. If collector uses this feature, customer gets a LINE. That's the intended behavior.

## Stats

- **10 commits** (on top of Plan 2's 14 + Plan 1's 18)
- **+3043 / -13 lines**
- **113 backend tests pass** (+15 from Plan 2)
- **0 TypeScript errors**
- **4 new E2E smoke tests** (tab switching, Customer 360 open/close, bulk bar appearance, LINE dialog open)

## Design notes

Operations Room aesthetic continued. Customer 360 is deliberately Linear-drawer calm: fast, structured, no decoration. Timeline groups by date (วันนี้/เมื่อวาน/absolute) with per-type icon colors (PROMISED calls show success green, REFUSED show destructive red). PaymentRecordDialog emphasizes the amount — hero \`text-2xl\` tabular input.

Bulk bar uses \`backdrop-blur-sm\` + \`border-t\` for elevation, slides up from bottom via transform. 3 inline mini-modals for action confirmations instead of dropdown menus — clearer intent, fewer clicks for mobile.

## Test plan

- [ ] CI: \`npm test\` + \`./tools/check-types.sh all\` green
- [ ] Staging with flag=true:
  - Open \`/collections\` → click a contract card's ▶ → Customer 360 slides in
  - Record payment on an overdue contract → contract.outstanding drops
  - Select 2-3 rows → BulkActionBar shows count → mass-assign to collector
  - Click LINE button on a card with lineId → ad-hoc dialog opens, template preview renders
- [ ] Staging smoke: broken-promise highlight still works on PromiseTab (regression)
- [ ] Staging smoke: approval tab still lists pending MDM + dunning escalations (regression)

## Out of scope (Plan 4/4)

- Legal letters (PDF generator + dispatch queue + OWNER approval for mass send)
- MDM unlock UI action button (endpoint exists; approval tab could surface it — defer)
- Skip-tracing workflow (flag exists, no UI prompt yet)
- Drag-drop kanban
- Thailand Post Connect API

🤖 Generated with [Claude Code](https://claude.com/claude-code)