### PR TITLE
feat(collections): Plan 4/4 legal letters — PDF generator + dispatch queue + evidence chain

### DIFF
--- a/apps/api/src/modules/overdue/contract-letter.service.spec.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.spec.ts
@@ -6,6 +6,7 @@ import { ContractLetterService } from './contract-letter.service';
 const mockPrisma = {
   contractLetter: {
     findUnique: jest.fn(),
+    findFirst: jest.fn(),
     findMany: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
@@ -65,20 +66,34 @@ describe('ContractLetterService', () => {
 
   describe('cancel', () => {
     it('cancels when in PENDING_DISPATCH', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'letter-3',
         status: 'PENDING_DISPATCH',
       });
-      mockPrisma.contractLetter.update.mockResolvedValueOnce({ id: 'letter-3', status: 'CANCELLED' });
+      const cancelled = { id: 'letter-3', status: 'CANCELLED', cancelReason: 'ลูกค้าชำระครบแล้ว' };
+      mockPrisma.$transaction.mockResolvedValueOnce([cancelled, {}]);
 
       const result = await service.cancel('letter-3', 'u1', 'ลูกค้าชำระครบแล้ว');
-      expect(result.status).toBe('CANCELLED');
-      const updateArg = mockPrisma.contractLetter.update.mock.calls[0][0];
-      expect(updateArg.data.cancelReason).toBe('ลูกค้าชำระครบแล้ว');
+      expect(result).toBe(cancelled);
+      // Ensure soft-delete guard present
+      const findArg = mockPrisma.contractLetter.findFirst.mock.calls[0][0];
+      expect(findArg.where.deletedAt).toBeNull();
+    });
+
+    it('creates audit log with CANCEL_LETTER action', async () => {
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
+        id: 'letter-3b',
+        status: 'PENDING_DISPATCH',
+      });
+      mockPrisma.$transaction.mockResolvedValueOnce([{ id: 'letter-3b' }, {}]);
+      await service.cancel('letter-3b', 'user-42', 'เหตุผลยกเลิก');
+      const txArg = mockPrisma.$transaction.mock.calls[0][0];
+      expect(Array.isArray(txArg)).toBe(true);
+      expect(txArg).toHaveLength(2);
     });
 
     it('throws when letter is DISPATCHED', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'letter-4',
         status: 'DISPATCHED',
       });
@@ -86,7 +101,7 @@ describe('ContractLetterService', () => {
     });
 
     it('requires reason length ≥ 5', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'letter-5',
         status: 'PENDING_DISPATCH',
       });
@@ -94,7 +109,7 @@ describe('ContractLetterService', () => {
     });
 
     it('throws NotFound when letter missing', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(null);
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce(null);
       await expect(service.cancel('nope', 'u1', 'abcde')).rejects.toThrow(/ไม่พบหนังสือ/);
     });
   });
@@ -139,7 +154,7 @@ describe('ContractLetterService', () => {
 
   describe('markPdfGenerated', () => {
     it('transitions PENDING_DISPATCH -> PDF_GENERATED and records URL', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'l1',
         status: 'PENDING_DISPATCH',
         contractId: 'c1',
@@ -152,7 +167,7 @@ describe('ContractLetterService', () => {
     });
 
     it('throws BadRequest when status is not PENDING_DISPATCH', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'l2',
         status: 'PDF_GENERATED',
       });
@@ -160,7 +175,7 @@ describe('ContractLetterService', () => {
     });
 
     it('throws NotFound for unknown letter', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(null);
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce(null);
       await expect(service.markPdfGenerated('nope', 'url', 'u1')).rejects.toThrow(/ไม่พบหนังสือ/);
     });
   });
@@ -174,14 +189,14 @@ describe('ContractLetterService', () => {
     };
 
     it('validates tracking number length ≥ 5', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(pdfGeneratedLetter);
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce(pdfGeneratedLetter);
       await expect(
         service.markDispatched('l3', 'u1', { trackingNumber: 'AB1' }),
       ).rejects.toThrow(/tracking/);
     });
 
     it('transitions PDF_GENERATED -> DISPATCHED and fires LETTER_DISPATCHED event', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(pdfGeneratedLetter);
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce(pdfGeneratedLetter);
       const dispatched = { id: 'l3', status: 'DISPATCHED', trackingNumber: 'EMS12345' };
       mockPrisma.$transaction.mockResolvedValueOnce([dispatched, {}]);
       mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
@@ -198,7 +213,7 @@ describe('ContractLetterService', () => {
     });
 
     it('fires CONTRACT_TERMINATED event for CONTRACT_TERMINATION_60D letter type', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         ...pdfGeneratedLetter,
         letterType: 'CONTRACT_TERMINATION_60D',
       });
@@ -217,7 +232,7 @@ describe('ContractLetterService', () => {
     });
 
     it('does not fire CONTRACT_TERMINATED for RETURN_DEVICE_45D letter type', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(pdfGeneratedLetter);
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce(pdfGeneratedLetter);
       mockPrisma.$transaction.mockResolvedValueOnce([{ id: 'l3', status: 'DISPATCHED' }, {}]);
       mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
 
@@ -229,7 +244,7 @@ describe('ContractLetterService', () => {
     });
 
     it('throws BadRequest when status is not PDF_GENERATED', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'l4',
         status: 'PENDING_DISPATCH',
         contractId: 'c4',
@@ -243,7 +258,7 @@ describe('ContractLetterService', () => {
 
   describe('markDelivered', () => {
     it('transitions DISPATCHED -> DELIVERED', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'l5',
         status: 'DISPATCHED',
         contractId: 'c5',
@@ -256,7 +271,7 @@ describe('ContractLetterService', () => {
     });
 
     it('throws BadRequest when status is not DISPATCHED', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'l6',
         status: 'PDF_GENERATED',
       });
@@ -264,7 +279,7 @@ describe('ContractLetterService', () => {
     });
 
     it('throws NotFound when letter missing', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(null);
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce(null);
       await expect(service.markDelivered('nope', 'u1')).rejects.toThrow(/ไม่พบหนังสือ/);
     });
   });
@@ -283,7 +298,7 @@ describe('ContractLetterService', () => {
     });
 
     it('flips contract.needsSkipTracing = true and marks UNDELIVERABLE', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(dispatchedLetter);
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce(dispatchedLetter);
       const undeliverable = { id: 'l7', status: 'UNDELIVERABLE' };
       mockPrisma.$transaction.mockResolvedValueOnce([undeliverable, {}, {}]);
 
@@ -297,7 +312,7 @@ describe('ContractLetterService', () => {
     });
 
     it('throws BadRequest when status is not DISPATCHED', async () => {
-      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+      mockPrisma.contractLetter.findFirst.mockResolvedValueOnce({
         id: 'l8',
         status: 'DELIVERED',
       });

--- a/apps/api/src/modules/overdue/contract-letter.service.spec.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.spec.ts
@@ -1,14 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../prisma/prisma.service';
+import { DunningEngineService } from './dunning-engine.service';
 import { ContractLetterService } from './contract-letter.service';
 
 const mockPrisma = {
   contractLetter: {
     findUnique: jest.fn(),
+    findMany: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
     count: jest.fn(),
   },
+  contract: {
+    update: jest.fn(),
+  },
+  auditLog: {
+    create: jest.fn(),
+  },
+  $transaction: jest.fn(),
+};
+
+const mockDunningEngine = {
+  executeEventTrigger: jest.fn(),
 };
 
 describe('ContractLetterService', () => {
@@ -20,6 +33,7 @@ describe('ContractLetterService', () => {
       providers: [
         ContractLetterService,
         { provide: PrismaService, useValue: mockPrisma },
+        { provide: DunningEngineService, useValue: mockDunningEngine },
       ],
     }).compile();
     service = module.get(ContractLetterService);
@@ -52,7 +66,8 @@ describe('ContractLetterService', () => {
   describe('cancel', () => {
     it('cancels when in PENDING_DISPATCH', async () => {
       mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
-        id: 'letter-3', status: 'PENDING_DISPATCH',
+        id: 'letter-3',
+        status: 'PENDING_DISPATCH',
       });
       mockPrisma.contractLetter.update.mockResolvedValueOnce({ id: 'letter-3', status: 'CANCELLED' });
 
@@ -64,14 +79,16 @@ describe('ContractLetterService', () => {
 
     it('throws when letter is DISPATCHED', async () => {
       mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
-        id: 'letter-4', status: 'DISPATCHED',
+        id: 'letter-4',
+        status: 'DISPATCHED',
       });
       await expect(service.cancel('letter-4', 'u1', 'ลูกค้าชำระครบแล้ว')).rejects.toThrow(/ยกเลิก/);
     });
 
     it('requires reason length ≥ 5', async () => {
       mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
-        id: 'letter-5', status: 'PENDING_DISPATCH',
+        id: 'letter-5',
+        status: 'PENDING_DISPATCH',
       });
       await expect(service.cancel('letter-5', 'u1', 'no')).rejects.toThrow(/เหตุผล/);
     });
@@ -79,6 +96,214 @@ describe('ContractLetterService', () => {
     it('throws NotFound when letter missing', async () => {
       mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(null);
       await expect(service.cancel('nope', 'u1', 'abcde')).rejects.toThrow(/ไม่พบหนังสือ/);
+    });
+  });
+
+  // ---------- New tests for extended methods ----------
+
+  describe('list', () => {
+    const mockLetters = [
+      { id: 'l1', status: 'PENDING_DISPATCH', letterType: 'RETURN_DEVICE_45D' },
+      { id: 'l2', status: 'PDF_GENERATED', letterType: 'CONTRACT_TERMINATION_60D' },
+    ];
+
+    it('returns letters without filter', async () => {
+      mockPrisma.contractLetter.findMany.mockResolvedValueOnce(mockLetters);
+      const result = await service.list({});
+      expect(result).toBe(mockLetters);
+      const findArg = mockPrisma.contractLetter.findMany.mock.calls[0][0];
+      expect(findArg.where.deletedAt).toBeNull();
+    });
+
+    it('filters by status', async () => {
+      mockPrisma.contractLetter.findMany.mockResolvedValueOnce([mockLetters[0]]);
+      await service.list({ status: 'PENDING_DISPATCH' });
+      const findArg = mockPrisma.contractLetter.findMany.mock.calls[0][0];
+      expect(findArg.where.status).toBe('PENDING_DISPATCH');
+    });
+
+    it('filters by letterType', async () => {
+      mockPrisma.contractLetter.findMany.mockResolvedValueOnce([mockLetters[1]]);
+      await service.list({ letterType: 'CONTRACT_TERMINATION_60D' });
+      const findArg = mockPrisma.contractLetter.findMany.mock.calls[0][0];
+      expect(findArg.where.letterType).toBe('CONTRACT_TERMINATION_60D');
+    });
+
+    it('filters by branchId via contract relation', async () => {
+      mockPrisma.contractLetter.findMany.mockResolvedValueOnce([]);
+      await service.list({ branchId: 'branch-1' });
+      const findArg = mockPrisma.contractLetter.findMany.mock.calls[0][0];
+      expect(findArg.where.contract).toEqual({ branchId: 'branch-1' });
+    });
+  });
+
+  describe('markPdfGenerated', () => {
+    it('transitions PENDING_DISPATCH -> PDF_GENERATED and records URL', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l1',
+        status: 'PENDING_DISPATCH',
+        contractId: 'c1',
+      });
+      const updatedLetter = { id: 'l1', status: 'PDF_GENERATED', pdfUrl: 'https://s3.../letter.pdf' };
+      mockPrisma.$transaction.mockResolvedValueOnce([updatedLetter, {}]);
+
+      const result = await service.markPdfGenerated('l1', 'https://s3.../letter.pdf', 'u1');
+      expect(result).toBe(updatedLetter);
+    });
+
+    it('throws BadRequest when status is not PENDING_DISPATCH', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l2',
+        status: 'PDF_GENERATED',
+      });
+      await expect(service.markPdfGenerated('l2', 'url', 'u1')).rejects.toThrow(/PENDING_DISPATCH/);
+    });
+
+    it('throws NotFound for unknown letter', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(null);
+      await expect(service.markPdfGenerated('nope', 'url', 'u1')).rejects.toThrow(/ไม่พบหนังสือ/);
+    });
+  });
+
+  describe('markDispatched', () => {
+    const pdfGeneratedLetter = {
+      id: 'l3',
+      status: 'PDF_GENERATED',
+      contractId: 'c3',
+      letterType: 'RETURN_DEVICE_45D',
+    };
+
+    it('validates tracking number length ≥ 5', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(pdfGeneratedLetter);
+      await expect(
+        service.markDispatched('l3', 'u1', { trackingNumber: 'AB1' }),
+      ).rejects.toThrow(/tracking/);
+    });
+
+    it('transitions PDF_GENERATED -> DISPATCHED and fires LETTER_DISPATCHED event', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(pdfGeneratedLetter);
+      const dispatched = { id: 'l3', status: 'DISPATCHED', trackingNumber: 'EMS12345' };
+      mockPrisma.$transaction.mockResolvedValueOnce([dispatched, {}]);
+      mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
+
+      const result = await service.markDispatched('l3', 'u1', { trackingNumber: 'EMS12345' });
+      expect(result).toBe(dispatched);
+      expect(mockDunningEngine.executeEventTrigger).toHaveBeenCalledWith(
+        'LETTER_DISPATCHED',
+        'c3',
+        null,
+        null,
+        expect.any(Object),
+      );
+    });
+
+    it('fires CONTRACT_TERMINATED event for CONTRACT_TERMINATION_60D letter type', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        ...pdfGeneratedLetter,
+        letterType: 'CONTRACT_TERMINATION_60D',
+      });
+      const dispatched = { id: 'l3', status: 'DISPATCHED' };
+      mockPrisma.$transaction.mockResolvedValueOnce([dispatched, {}]);
+      mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
+
+      await service.markDispatched('l3', 'u1', { trackingNumber: 'EMS99999' });
+
+      expect(mockDunningEngine.executeEventTrigger).toHaveBeenCalledWith(
+        'CONTRACT_TERMINATED',
+        'c3',
+        null,
+        null,
+      );
+    });
+
+    it('does not fire CONTRACT_TERMINATED for RETURN_DEVICE_45D letter type', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(pdfGeneratedLetter);
+      mockPrisma.$transaction.mockResolvedValueOnce([{ id: 'l3', status: 'DISPATCHED' }, {}]);
+      mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
+
+      await service.markDispatched('l3', 'u1', { trackingNumber: 'EMS54321' });
+
+      const calls = mockDunningEngine.executeEventTrigger.mock.calls;
+      const terminatedCall = calls.find((c: string[]) => c[0] === 'CONTRACT_TERMINATED');
+      expect(terminatedCall).toBeUndefined();
+    });
+
+    it('throws BadRequest when status is not PDF_GENERATED', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l4',
+        status: 'PENDING_DISPATCH',
+        contractId: 'c4',
+        letterType: 'RETURN_DEVICE_45D',
+      });
+      await expect(
+        service.markDispatched('l4', 'u1', { trackingNumber: 'EMS00001' }),
+      ).rejects.toThrow(/PDF_GENERATED/);
+    });
+  });
+
+  describe('markDelivered', () => {
+    it('transitions DISPATCHED -> DELIVERED', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l5',
+        status: 'DISPATCHED',
+        contractId: 'c5',
+      });
+      const delivered = { id: 'l5', status: 'DELIVERED' };
+      mockPrisma.$transaction.mockResolvedValueOnce([delivered, {}]);
+
+      const result = await service.markDelivered('l5', 'u1');
+      expect(result).toBe(delivered);
+    });
+
+    it('throws BadRequest when status is not DISPATCHED', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l6',
+        status: 'PDF_GENERATED',
+      });
+      await expect(service.markDelivered('l6', 'u1')).rejects.toThrow(/DISPATCHED/);
+    });
+
+    it('throws NotFound when letter missing', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(null);
+      await expect(service.markDelivered('nope', 'u1')).rejects.toThrow(/ไม่พบหนังสือ/);
+    });
+  });
+
+  describe('markUndeliverable', () => {
+    const dispatchedLetter = {
+      id: 'l7',
+      status: 'DISPATCHED',
+      contractId: 'c7',
+    };
+
+    it('requires reason length ≥ 5', async () => {
+      await expect(
+        service.markUndeliverable('l7', 'u1', 'abc'),
+      ).rejects.toThrow(/เหตุผล/);
+    });
+
+    it('flips contract.needsSkipTracing = true and marks UNDELIVERABLE', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(dispatchedLetter);
+      const undeliverable = { id: 'l7', status: 'UNDELIVERABLE' };
+      mockPrisma.$transaction.mockResolvedValueOnce([undeliverable, {}, {}]);
+
+      const result = await service.markUndeliverable('l7', 'u1', 'ที่อยู่ไม่ถูกต้อง');
+      expect(result).toBe(undeliverable);
+
+      // Verify transaction includes contract.update for needsSkipTracing
+      const txArg = mockPrisma.$transaction.mock.calls[0][0];
+      expect(Array.isArray(txArg)).toBe(true);
+      expect(txArg).toHaveLength(3);
+    });
+
+    it('throws BadRequest when status is not DISPATCHED', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l8',
+        status: 'DELIVERED',
+      });
+      await expect(
+        service.markUndeliverable('l8', 'u1', 'ที่อยู่ไม่ถูกต้อง'),
+      ).rejects.toThrow(/สถานะ/);
     });
   });
 });

--- a/apps/api/src/modules/overdue/contract-letter.service.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.ts
@@ -1,10 +1,14 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
-import { LetterType } from '@prisma/client';
+import { LetterType, LetterStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { DunningEngineService } from './dunning-engine.service';
 
 @Injectable()
 export class ContractLetterService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private dunningEngine: DunningEngineService,
+  ) {}
 
   /**
    * Create a letter for the given contract + type if one doesn't already exist.
@@ -51,6 +55,190 @@ export class ContractLetterService {
         cancelReason: reason.trim(),
       },
     });
+  }
+
+  /**
+   * List letters matching a status filter, newest-triggered first.
+   * Includes contract + customer for display in OWNER queue.
+   */
+  async list(params: {
+    status?: LetterStatus;
+    letterType?: LetterType;
+    branchId?: string;
+    limit?: number;
+  }) {
+    const where: Prisma.ContractLetterWhereInput = {
+      deletedAt: null,
+      ...(params.status && { status: params.status }),
+      ...(params.letterType && { letterType: params.letterType }),
+      ...(params.branchId && { contract: { branchId: params.branchId } }),
+    };
+    return this.prisma.contractLetter.findMany({
+      where,
+      include: {
+        contract: {
+          select: {
+            id: true,
+            contractNumber: true,
+            customer: { select: { id: true, name: true, phone: true, addressCurrent: true } },
+            branch: { select: { id: true, name: true } },
+          },
+        },
+      },
+      orderBy: { triggeredAt: 'desc' },
+      take: params.limit ?? 100,
+    });
+  }
+
+  /** After client generates PDF and uploads to S3, backend records the URL. */
+  async markPdfGenerated(letterId: string, pdfUrl: string, userId: string) {
+    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+    if (letter.status !== 'PENDING_DISPATCH') {
+      throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ PENDING_DISPATCH');
+    }
+    return this.prisma
+      .$transaction([
+        this.prisma.contractLetter.update({
+          where: { id: letterId },
+          data: { status: 'PDF_GENERATED', pdfUrl, pdfGeneratedAt: new Date() },
+        }),
+        this.prisma.auditLog.create({
+          data: {
+            userId,
+            action: 'LETTER_PDF_GENERATED',
+            entity: 'contract_letter',
+            entityId: letterId,
+            newValue: { pdfUrl },
+          },
+        }),
+      ])
+      .then(([l]) => l);
+  }
+
+  async markDispatched(
+    letterId: string,
+    userId: string,
+    params: { trackingNumber: string; evidencePhotoUrl?: string },
+  ) {
+    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+    if (letter.status !== 'PDF_GENERATED') {
+      throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ PDF_GENERATED');
+    }
+    if (!params.trackingNumber || params.trackingNumber.trim().length < 5) {
+      throw new BadRequestException('เลข tracking EMS ต้อง ≥ 5 ตัวอักษร');
+    }
+
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.contractLetter.update({
+        where: { id: letterId },
+        data: {
+          status: 'DISPATCHED',
+          dispatchedAt: new Date(),
+          dispatchedById: userId,
+          trackingNumber: params.trackingNumber.trim(),
+          evidencePhotoUrl: params.evidencePhotoUrl ?? null,
+        },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'LETTER_DISPATCHED',
+          entity: 'contract_letter',
+          entityId: letterId,
+          newValue: {
+            trackingNumber: params.trackingNumber,
+            evidencePhotoUrl: params.evidencePhotoUrl ?? null,
+          },
+        },
+      }),
+    ]);
+
+    // Fire LINE event — non-fatal
+    try {
+      await this.dunningEngine.executeEventTrigger(
+        'LETTER_DISPATCHED',
+        letter.contractId,
+        null,
+        null,
+        { trackingNumber: params.trackingNumber } as any,
+      );
+    } catch {
+      // already logged by engine
+    }
+
+    // If CONTRACT_TERMINATION_60D, also fire CONTRACT_TERMINATED event
+    if (letter.letterType === 'CONTRACT_TERMINATION_60D') {
+      try {
+        await this.dunningEngine.executeEventTrigger(
+          'CONTRACT_TERMINATED',
+          letter.contractId,
+          null,
+          null,
+        );
+      } catch {
+        /* non-fatal */
+      }
+    }
+
+    return updated;
+  }
+
+  async markDelivered(letterId: string, userId: string) {
+    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+    if (letter.status !== 'DISPATCHED') {
+      throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ DISPATCHED');
+    }
+    return this.prisma
+      .$transaction([
+        this.prisma.contractLetter.update({
+          where: { id: letterId },
+          data: { status: 'DELIVERED', deliveredAt: new Date() },
+        }),
+        this.prisma.auditLog.create({
+          data: {
+            userId,
+            action: 'LETTER_DELIVERED',
+            entity: 'contract_letter',
+            entityId: letterId,
+          },
+        }),
+      ])
+      .then(([l]) => l);
+  }
+
+  async markUndeliverable(letterId: string, userId: string, reason: string) {
+    if (!reason || reason.trim().length < 5) {
+      throw new BadRequestException('เหตุผลต้อง ≥ 5 ตัวอักษร');
+    }
+    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+    if (letter.status !== 'DISPATCHED') {
+      throw new BadRequestException('สถานะไม่ถูกต้อง');
+    }
+    return this.prisma
+      .$transaction([
+        this.prisma.contractLetter.update({
+          where: { id: letterId },
+          data: { status: 'UNDELIVERABLE', cancelReason: reason.trim(), cancelledAt: new Date() },
+        }),
+        this.prisma.contract.update({
+          where: { id: letter.contractId },
+          data: { needsSkipTracing: true },
+        }),
+        this.prisma.auditLog.create({
+          data: {
+            userId,
+            action: 'LETTER_UNDELIVERABLE',
+            entity: 'contract_letter',
+            entityId: letterId,
+            newValue: { reason },
+          },
+        }),
+      ])
+      .then(([l]) => l);
   }
 
   private async nextSequence(year: number): Promise<number> {

--- a/apps/api/src/modules/overdue/contract-letter.service.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.ts
@@ -37,8 +37,10 @@ export class ContractLetterService {
    * the paper trail is legally load-bearing and cancellation is not allowed —
    * the proper action is to issue a follow-up or mark UNDELIVERABLE post-hoc.
    */
-  async cancel(letterId: string, _userId: string, reason: string) {
-    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+  async cancel(letterId: string, userId: string, reason: string) {
+    const letter = await this.prisma.contractLetter.findFirst({
+      where: { id: letterId, deletedAt: null },
+    });
     if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
     if (!['PENDING_DISPATCH', 'PDF_GENERATED'].includes(letter.status)) {
       throw new BadRequestException('ไม่สามารถยกเลิกหนังสือที่ส่งไปแล้ว');
@@ -47,14 +49,26 @@ export class ContractLetterService {
       throw new BadRequestException('ต้องระบุเหตุผลการยกเลิก (≥ 5 ตัวอักษร)');
     }
 
-    return this.prisma.contractLetter.update({
-      where: { id: letterId },
-      data: {
-        status: 'CANCELLED',
-        cancelledAt: new Date(),
-        cancelReason: reason.trim(),
-      },
-    });
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.contractLetter.update({
+        where: { id: letterId },
+        data: {
+          status: 'CANCELLED',
+          cancelledAt: new Date(),
+          cancelReason: reason.trim(),
+        },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'CANCEL_LETTER',
+          entity: 'contract_letter',
+          entityId: letterId,
+          newValue: { reason: reason.trim() },
+        },
+      }),
+    ]);
+    return updated;
   }
 
   /**
@@ -92,7 +106,9 @@ export class ContractLetterService {
 
   /** After client generates PDF and uploads to S3, backend records the URL. */
   async markPdfGenerated(letterId: string, pdfUrl: string, userId: string) {
-    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    const letter = await this.prisma.contractLetter.findFirst({
+      where: { id: letterId, deletedAt: null },
+    });
     if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
     if (letter.status !== 'PENDING_DISPATCH') {
       throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ PENDING_DISPATCH');
@@ -121,7 +137,9 @@ export class ContractLetterService {
     userId: string,
     params: { trackingNumber: string; evidencePhotoUrl?: string },
   ) {
-    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    const letter = await this.prisma.contractLetter.findFirst({
+      where: { id: letterId, deletedAt: null },
+    });
     if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
     if (letter.status !== 'PDF_GENERATED') {
       throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ PDF_GENERATED');
@@ -162,7 +180,7 @@ export class ContractLetterService {
         letter.contractId,
         null,
         null,
-        { trackingNumber: params.trackingNumber } as any,
+        { trackingNumber: params.trackingNumber },
       );
     } catch {
       // already logged by engine
@@ -186,7 +204,9 @@ export class ContractLetterService {
   }
 
   async markDelivered(letterId: string, userId: string) {
-    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    const letter = await this.prisma.contractLetter.findFirst({
+      where: { id: letterId, deletedAt: null },
+    });
     if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
     if (letter.status !== 'DISPATCHED') {
       throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ DISPATCHED');
@@ -213,7 +233,9 @@ export class ContractLetterService {
     if (!reason || reason.trim().length < 5) {
       throw new BadRequestException('เหตุผลต้อง ≥ 5 ตัวอักษร');
     }
-    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    const letter = await this.prisma.contractLetter.findFirst({
+      where: { id: letterId, deletedAt: null },
+    });
     if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
     if (letter.status !== 'DISPATCHED') {
       throw new BadRequestException('สถานะไม่ถูกต้อง');

--- a/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.spec.ts
+++ b/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ContractLetterService } from '../contract-letter.service';
+import { LetterAutoGenerateCron } from './letter-auto-generate.cron';
+
+const mockPrisma = {
+  systemConfig: { findUnique: jest.fn() },
+  contract: { findMany: jest.fn() },
+};
+
+const mockLetterService = {
+  createIfNotExists: jest.fn(),
+};
+
+describe('LetterAutoGenerateCron', () => {
+  let cron: LetterAutoGenerateCron;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LetterAutoGenerateCron,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: ContractLetterService, useValue: mockLetterService },
+      ],
+    }).compile();
+    cron = module.get(LetterAutoGenerateCron);
+
+    // Default: enabled + default thresholds
+    mockPrisma.systemConfig.findUnique.mockImplementation(
+      ({ where: { key } }: { where: { key: string } }) => {
+        if (key === 'letter_auto_generate_enabled') return Promise.resolve({ value: 'true' });
+        if (key === 'letter_return_device_days') return Promise.resolve({ value: '45' });
+        if (key === 'letter_termination_days') return Promise.resolve({ value: '60' });
+        return Promise.resolve(null);
+      },
+    );
+    mockPrisma.contract.findMany.mockResolvedValue([]);
+    mockLetterService.createIfNotExists.mockResolvedValue({ id: 'letter-new' });
+  });
+
+  it('skips all processing when letter_auto_generate_enabled=false', async () => {
+    mockPrisma.systemConfig.findUnique.mockImplementationOnce(() =>
+      Promise.resolve({ value: 'false' }),
+    );
+    const result = await cron.run();
+    expect(result).toEqual({ returnDevice: 0, termination: 0 });
+    expect(mockPrisma.contract.findMany).not.toHaveBeenCalled();
+    expect(mockLetterService.createIfNotExists).not.toHaveBeenCalled();
+  });
+
+  it('creates RETURN_DEVICE_45D for matching contracts', async () => {
+    mockPrisma.contract.findMany
+      .mockResolvedValueOnce([{ id: 'c1' }, { id: 'c2' }]) // returnCandidates
+      .mockResolvedValueOnce([]); // terminationCandidates
+
+    const result = await cron.run();
+    expect(result.returnDevice).toBe(2);
+    expect(result.termination).toBe(0);
+    expect(mockLetterService.createIfNotExists).toHaveBeenCalledTimes(2);
+    expect(mockLetterService.createIfNotExists).toHaveBeenCalledWith('c1', 'RETURN_DEVICE_45D');
+    expect(mockLetterService.createIfNotExists).toHaveBeenCalledWith('c2', 'RETURN_DEVICE_45D');
+  });
+
+  it('creates CONTRACT_TERMINATION_60D for matching contracts', async () => {
+    mockPrisma.contract.findMany
+      .mockResolvedValueOnce([]) // returnCandidates
+      .mockResolvedValueOnce([{ id: 'c3' }, { id: 'c4' }, { id: 'c5' }]); // terminationCandidates
+
+    const result = await cron.run();
+    expect(result.returnDevice).toBe(0);
+    expect(result.termination).toBe(3);
+    expect(mockLetterService.createIfNotExists).toHaveBeenCalledTimes(3);
+    expect(mockLetterService.createIfNotExists).toHaveBeenCalledWith('c3', 'CONTRACT_TERMINATION_60D');
+  });
+
+  it('does not abort the cron when individual createIfNotExists throws', async () => {
+    mockPrisma.contract.findMany
+      .mockResolvedValueOnce([{ id: 'c6' }, { id: 'c7' }]) // returnCandidates
+      .mockResolvedValueOnce([]); // terminationCandidates
+
+    mockLetterService.createIfNotExists
+      .mockRejectedValueOnce(new Error('DB error'))
+      .mockResolvedValueOnce({ id: 'letter-ok' });
+
+    const result = await cron.run();
+    // c6 failed, c7 succeeded → returnDevice = 1
+    expect(result.returnDevice).toBe(1);
+    expect(result.termination).toBe(0);
+  });
+
+  it('respects custom threshold config values when querying candidates', async () => {
+    mockPrisma.systemConfig.findUnique.mockImplementation(
+      ({ where: { key } }: { where: { key: string } }) => {
+        if (key === 'letter_auto_generate_enabled') return Promise.resolve({ value: 'true' });
+        if (key === 'letter_return_device_days') return Promise.resolve({ value: '30' });
+        if (key === 'letter_termination_days') return Promise.resolve({ value: '45' });
+        return Promise.resolve(null);
+      },
+    );
+    mockPrisma.contract.findMany.mockResolvedValue([]);
+
+    await cron.run();
+
+    // Verify findMany was called twice (return + termination queries)
+    expect(mockPrisma.contract.findMany).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles outer catch block and returns zeros on catastrophic error', async () => {
+    mockPrisma.systemConfig.findUnique
+      .mockResolvedValueOnce({ value: 'true' }) // enabled check passes
+      .mockRejectedValueOnce(new Error('config read failed')); // subsequent read fails
+
+    const result = await cron.run();
+    expect(result).toEqual({ returnDevice: 0, termination: 0 });
+  });
+});

--- a/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts
+++ b/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ContractLetterService } from '../contract-letter.service';
+
+@Injectable()
+export class LetterAutoGenerateCron {
+  private readonly logger = new Logger(LetterAutoGenerateCron.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private letterService: ContractLetterService,
+  ) {}
+
+  @Cron('15 9 * * *')
+  async run(): Promise<{ returnDevice: number; termination: number }> {
+    try {
+      const enabled = await this.prisma.systemConfig.findUnique({
+        where: { key: 'letter_auto_generate_enabled' },
+      });
+      if (enabled?.value !== 'true') {
+        this.logger.log('letter_auto_generate_enabled=false — skipping');
+        return { returnDevice: 0, termination: 0 };
+      }
+
+      const returnDays = Number(
+        (
+          await this.prisma.systemConfig.findUnique({
+            where: { key: 'letter_return_device_days' },
+          })
+        )?.value ?? 45,
+      );
+      const terminationDays = Number(
+        (
+          await this.prisma.systemConfig.findUnique({
+            where: { key: 'letter_termination_days' },
+          })
+        )?.value ?? 60,
+      );
+
+      const now = new Date();
+      const returnThreshold = new Date(now.getTime() - returnDays * 86400000);
+      const terminationThreshold = new Date(now.getTime() - terminationDays * 86400000);
+
+      const returnCandidates = await this.prisma.contract.findMany({
+        where: {
+          status: { in: ['OVERDUE', 'DEFAULT'] },
+          deletedAt: null,
+          payments: {
+            some: {
+              dueDate: { lt: returnThreshold },
+              status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+            },
+          },
+          contractLetters: {
+            none: { letterType: 'RETURN_DEVICE_45D', deletedAt: null },
+          },
+        },
+        select: { id: true },
+      });
+
+      let returnDevice = 0;
+      for (const { id } of returnCandidates) {
+        try {
+          await this.letterService.createIfNotExists(id, 'RETURN_DEVICE_45D');
+          returnDevice++;
+        } catch (err) {
+          Sentry.captureException(err, {
+            tags: { cron: 'letter-auto-generate', letterType: 'RETURN_DEVICE_45D' },
+            extra: { contractId: id },
+          });
+        }
+      }
+
+      const terminationCandidates = await this.prisma.contract.findMany({
+        where: {
+          status: { in: ['OVERDUE', 'DEFAULT'] },
+          deletedAt: null,
+          payments: {
+            some: {
+              dueDate: { lt: terminationThreshold },
+              status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+            },
+          },
+          contractLetters: {
+            none: { letterType: 'CONTRACT_TERMINATION_60D', deletedAt: null },
+          },
+        },
+        select: { id: true },
+      });
+
+      let termination = 0;
+      for (const { id } of terminationCandidates) {
+        try {
+          await this.letterService.createIfNotExists(id, 'CONTRACT_TERMINATION_60D');
+          termination++;
+        } catch (err) {
+          Sentry.captureException(err, {
+            tags: { cron: 'letter-auto-generate', letterType: 'CONTRACT_TERMINATION_60D' },
+            extra: { contractId: id },
+          });
+        }
+      }
+
+      this.logger.log(
+        `Letter auto-generate: return_device=${returnDevice}, termination=${termination}`,
+      );
+      return { returnDevice, termination };
+    } catch (err) {
+      Sentry.captureException(err, { tags: { cron: 'letter-auto-generate' } });
+      this.logger.error(
+        `letter-auto-generate failed: ${err instanceof Error ? err.message : err}`,
+      );
+      return { returnDevice: 0, termination: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts
+++ b/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts
@@ -16,28 +16,27 @@ export class LetterAutoGenerateCron {
   @Cron('15 9 * * *')
   async run(): Promise<{ returnDevice: number; termination: number }> {
     try {
-      const enabled = await this.prisma.systemConfig.findUnique({
-        where: { key: 'letter_auto_generate_enabled' },
+      // Batch-fetch all 3 config keys in a single query (was 3 sequential findUnique calls).
+      const configs = await this.prisma.systemConfig.findMany({
+        where: {
+          key: {
+            in: [
+              'letter_auto_generate_enabled',
+              'letter_return_device_days',
+              'letter_termination_days',
+            ],
+          },
+        },
       });
-      if (enabled?.value !== 'true') {
+      const configMap = new Map(configs.map((c) => [c.key, c.value]));
+
+      if (configMap.get('letter_auto_generate_enabled') !== 'true') {
         this.logger.log('letter_auto_generate_enabled=false — skipping');
         return { returnDevice: 0, termination: 0 };
       }
 
-      const returnDays = Number(
-        (
-          await this.prisma.systemConfig.findUnique({
-            where: { key: 'letter_return_device_days' },
-          })
-        )?.value ?? 45,
-      );
-      const terminationDays = Number(
-        (
-          await this.prisma.systemConfig.findUnique({
-            where: { key: 'letter_termination_days' },
-          })
-        )?.value ?? 60,
-      );
+      const returnDays = Number(configMap.get('letter_return_device_days') ?? 45);
+      const terminationDays = Number(configMap.get('letter_termination_days') ?? 60);
 
       const now = new Date();
       const returnThreshold = new Date(now.getTime() - returnDays * 86400000);

--- a/apps/api/src/modules/overdue/dunning-engine.service.ts
+++ b/apps/api/src/modules/overdue/dunning-engine.service.ts
@@ -14,6 +14,7 @@ export interface TemplateVars {
   dueDate: string;
   daysOverdue: string;
   installmentNo: string;
+  trackingNumber?: string;
 }
 
 @Injectable()

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -8,6 +8,7 @@ import { OverdueKpiService } from './kpi.service';
 import { MdmLockService } from './mdm-lock.service';
 import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
+import { ContractLetterService } from './contract-letter.service';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { AssignCollectorDto } from './dto/assign-collector.dto';
 import { RecordSettlementDto } from './dto/record-settlement.dto';
@@ -37,6 +38,7 @@ export class OverdueController {
     private mdmLockService: MdmLockService,
     private timelineService: OverdueTimelineService,
     private bulkService: OverdueBulkService,
+    private contractLetterService: ContractLetterService,
   ) {}
 
   // --- Collections Workflow Hub endpoints (Plan 2) ---
@@ -387,5 +389,70 @@ export class OverdueController {
       },
       user.id,
     );
+  }
+
+  // --- Contract letters ---
+
+  @Get('letters')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
+  listLetters(
+    @Query('status') status?: string,
+    @Query('letterType') letterType?: string,
+    @CurrentUser() user?: { role: string; branchId: string | null },
+  ) {
+    return this.contractLetterService.list({
+      status: status as any,
+      letterType: letterType as any,
+      branchId: user?.role === 'BRANCH_MANAGER' ? user.branchId ?? undefined : undefined,
+    });
+  }
+
+  @Post('letters/:id/pdf-generated')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markPdfGenerated(
+    @Param('id') id: string,
+    @Body() body: { pdfUrl: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markPdfGenerated(id, body.pdfUrl, user.id);
+  }
+
+  @Post('letters/:id/dispatch')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  dispatchLetter(
+    @Param('id') id: string,
+    @Body() body: { trackingNumber: string; evidencePhotoUrl?: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markDispatched(id, user.id, body);
+  }
+
+  @Post('letters/:id/delivered')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markLetterDelivered(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markDelivered(id, user.id);
+  }
+
+  @Post('letters/:id/undeliverable')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markLetterUndeliverable(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markUndeliverable(id, user.id, body.reason);
+  }
+
+  @Post('letters/:id/cancel')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  cancelLetter(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.cancel(id, user.id, body.reason);
   }
 }

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -12,6 +12,7 @@ import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
+import { LetterAutoGenerateCron } from './crons/letter-auto-generate.cron';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { LineOaModule } from '../line-oa/line-oa.module';
@@ -32,6 +33,7 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     OverdueBulkService,
     BrokenPromiseCron,
     MdmAutoProposeCron,
+    LetterAutoGenerateCron,
   ],
   exports: [
     OverdueService,

--- a/apps/api/src/modules/storage/shop-upload.controller.spec.ts
+++ b/apps/api/src/modules/storage/shop-upload.controller.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ShopUploadController, UploadKind } from './shop-upload.controller';
 import { StorageService } from './storage.service';
@@ -92,6 +93,43 @@ describe('ShopUploadController', () => {
         contentType: 'image/png',
       });
       expect(result.key).toMatch(/^shop\/trade_in_photo\/.+\.png$/);
+    });
+  });
+
+  describe('MIME whitelist enforcement', () => {
+    it('rejects LETTER_PDF with non-PDF content type', async () => {
+      await expect(
+        controller.presign({
+          kind: UploadKind.LETTER_PDF,
+          contentType: 'image/jpeg',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects LETTER_EVIDENCE with video/mp4', async () => {
+      await expect(
+        controller.presign({
+          kind: UploadKind.LETTER_EVIDENCE,
+          contentType: 'video/mp4',
+        }),
+      ).rejects.toThrow(/ประเภทไฟล์ไม่ถูกต้อง/);
+    });
+
+    it('accepts LETTER_EVIDENCE with application/pdf', async () => {
+      const result = await controller.presign({
+        kind: UploadKind.LETTER_EVIDENCE,
+        contentType: 'application/pdf',
+      });
+      expect(result.key).toMatch(/^letters\/letter_evidence\/.+\.pdf$/);
+    });
+
+    it('rejects LETTER_SIGNATURE with application/pdf', async () => {
+      await expect(
+        controller.presign({
+          kind: UploadKind.LETTER_SIGNATURE,
+          contentType: 'application/pdf',
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/apps/api/src/modules/storage/shop-upload.controller.spec.ts
+++ b/apps/api/src/modules/storage/shop-upload.controller.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ShopUploadController, UploadKind } from './shop-upload.controller';
+import { StorageService } from './storage.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+const mockStorageService = {
+  getSignedUploadUrl: jest.fn().mockResolvedValue({
+    url: 'https://storage.example.com/signed-url',
+    method: 'PUT',
+  }),
+  getPublicUrl: jest.fn((key: string) => `https://cdn.example.com/${key}`),
+};
+
+describe('ShopUploadController', () => {
+  let controller: ShopUploadController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ShopUploadController],
+      providers: [{ provide: StorageService, useValue: mockStorageService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ShopUploadController>(ShopUploadController);
+    jest.clearAllMocks();
+    mockStorageService.getSignedUploadUrl.mockResolvedValue({
+      url: 'https://storage.example.com/signed-url',
+      method: 'PUT',
+    });
+    mockStorageService.getPublicUrl.mockImplementation(
+      (key: string) => `https://cdn.example.com/${key}`,
+    );
+  });
+
+  describe('LETTER_PDF with application/pdf content type', () => {
+    it('returns a key under letters/ prefix with .pdf extension', async () => {
+      const result = await controller.presign({
+        kind: UploadKind.LETTER_PDF,
+        contentType: 'application/pdf',
+      });
+      expect(result.key).toMatch(/^letters\/letter_pdf\/.+\.pdf$/);
+      expect(result.publicUrl).toContain('letters/letter_pdf/');
+    });
+  });
+
+  describe('LETTER_EVIDENCE with image/jpeg content type', () => {
+    it('returns a key under letters/ prefix with .jpg extension', async () => {
+      const result = await controller.presign({
+        kind: UploadKind.LETTER_EVIDENCE,
+        contentType: 'image/jpeg',
+      });
+      expect(result.key).toMatch(/^letters\/letter_evidence\/.+\.jpg$/);
+    });
+  });
+
+  describe('LETTER_SIGNATURE with image/png content type', () => {
+    it('returns a key under letters/ prefix with .png extension', async () => {
+      const result = await controller.presign({
+        kind: UploadKind.LETTER_SIGNATURE,
+        contentType: 'image/png',
+      });
+      expect(result.key).toMatch(/^letters\/letter_signature\/.+\.png$/);
+    });
+  });
+
+  describe('LETTER_LETTERHEAD with image/png content type', () => {
+    it('returns a key under letters/ prefix with .png extension', async () => {
+      const result = await controller.presign({
+        kind: UploadKind.LETTER_LETTERHEAD,
+        contentType: 'image/png',
+      });
+      expect(result.key).toMatch(/^letters\/letter_letterhead\/.+\.png$/);
+    });
+  });
+
+  describe('non-letter kind (regression: BANK_SLIP)', () => {
+    it('still routes to shop/ prefix', async () => {
+      const result = await controller.presign({
+        kind: UploadKind.BANK_SLIP,
+        contentType: 'image/jpeg',
+      });
+      expect(result.key).toMatch(/^shop\/bank_slip\/.+\.jpg$/);
+    });
+  });
+
+  describe('non-letter kind with PNG (regression: TRADE_IN_PHOTO)', () => {
+    it('still routes to shop/ prefix with .png extension', async () => {
+      const result = await controller.presign({
+        kind: UploadKind.TRADE_IN_PHOTO,
+        contentType: 'image/png',
+      });
+      expect(result.key).toMatch(/^shop\/trade_in_photo\/.+\.png$/);
+    });
+  });
+});

--- a/apps/api/src/modules/storage/shop-upload.controller.ts
+++ b/apps/api/src/modules/storage/shop-upload.controller.ts
@@ -9,6 +9,10 @@ export enum UploadKind {
   BUYBACK_PHOTO = 'BUYBACK_PHOTO',
   BANK_SLIP = 'BANK_SLIP',
   REVIEW_PHOTO = 'REVIEW_PHOTO',
+  LETTER_PDF = 'LETTER_PDF',
+  LETTER_EVIDENCE = 'LETTER_EVIDENCE',
+  LETTER_SIGNATURE = 'LETTER_SIGNATURE',
+  LETTER_LETTERHEAD = 'LETTER_LETTERHEAD',
 }
 
 export class PresignedUploadDto {
@@ -27,9 +31,16 @@ export class ShopUploadController {
 
   @Post('signed-url')
   async presign(@Body() dto: PresignedUploadDto) {
-    const ext = dto.contentType === 'image/png' ? 'png' : 'jpg';
+    const ext =
+      dto.contentType === 'application/pdf'
+        ? 'pdf'
+        : dto.contentType === 'image/png'
+          ? 'png'
+          : 'jpg';
     const date = new Date().toISOString().slice(0, 10);
-    const key = `shop/${dto.kind.toLowerCase()}/${date}/${randomUUID()}.${ext}`;
+    const isLetterKind = dto.kind.startsWith('LETTER_');
+    const basePath = isLetterKind ? 'letters' : 'shop';
+    const key = `${basePath}/${dto.kind.toLowerCase()}/${date}/${randomUUID()}.${ext}`;
     const signed = await this.storage.getSignedUploadUrl(key, dto.contentType);
     return {
       uploadUrl: signed.url,

--- a/apps/api/src/modules/storage/shop-upload.controller.ts
+++ b/apps/api/src/modules/storage/shop-upload.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
 import { randomUUID } from 'crypto';
 import { StorageService } from './storage.service';
@@ -24,6 +24,20 @@ export class PresignedUploadDto {
   contentType!: string;
 }
 
+// Per-kind MIME whitelists. Client's `contentType` is untrusted — server must
+// verify against the allowed set for the requested upload kind. A mismatch is
+// a 400 BadRequest (Thai message) rather than a signed URL handed to the client.
+const ALLOWED_MIME_BY_KIND: Record<UploadKind, readonly string[]> = {
+  [UploadKind.TRADE_IN_PHOTO]: ['image/jpeg', 'image/png', 'image/webp'],
+  [UploadKind.BUYBACK_PHOTO]: ['image/jpeg', 'image/png', 'image/webp'],
+  [UploadKind.BANK_SLIP]: ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'],
+  [UploadKind.REVIEW_PHOTO]: ['image/jpeg', 'image/png', 'image/webp'],
+  [UploadKind.LETTER_PDF]: ['application/pdf'],
+  [UploadKind.LETTER_EVIDENCE]: ['image/jpeg', 'image/png', 'application/pdf'],
+  [UploadKind.LETTER_SIGNATURE]: ['image/png', 'image/jpeg'],
+  [UploadKind.LETTER_LETTERHEAD]: ['image/png', 'image/jpeg'],
+};
+
 @Controller('shop/upload')
 @UseGuards(JwtAuthGuard)
 export class ShopUploadController {
@@ -31,12 +45,19 @@ export class ShopUploadController {
 
   @Post('signed-url')
   async presign(@Body() dto: PresignedUploadDto) {
+    const allowed = ALLOWED_MIME_BY_KIND[dto.kind];
+    if (!allowed || !allowed.includes(dto.contentType)) {
+      throw new BadRequestException('ประเภทไฟล์ไม่ถูกต้อง');
+    }
+
     const ext =
       dto.contentType === 'application/pdf'
         ? 'pdf'
         : dto.contentType === 'image/png'
           ? 'png'
-          : 'jpg';
+          : dto.contentType === 'image/webp'
+            ? 'webp'
+            : 'jpg';
     const date = new Date().toISOString().slice(0, 10);
     const isLetterKind = dto.kind.startsWith('LETTER_');
     const basePath = isLetterKind ? 'letters' : 'shop';

--- a/apps/web/e2e/collections-smoke.spec.ts
+++ b/apps/web/e2e/collections-smoke.spec.ts
@@ -137,4 +137,10 @@ test.describe('/collections power features', () => {
     // Close
     await page.getByRole('button', { name: /ยกเลิก/ }).first().click();
   });
+
+  test('OWNER: approval tab shows Letter queue section header', async ({ page }) => {
+    if (await hasErrorBoundary(page)) return;
+    await page.getByRole('button', { name: /อนุมัติ/ }).first().click();
+    await expect(page.getByText(/หนังสือทวงถาม/).first()).toBeVisible({ timeout: 5000 });
+  });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,6 +66,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "decimal.js": "^10.6.0",
     "dompurify": "^3.3.3",
     "exceljs": "^4.4.0",
     "html2pdf.js": "^0.14.0",

--- a/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
@@ -1,0 +1,437 @@
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Download, FileText, Loader2, Upload } from 'lucide-react';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import Modal from '@/components/ui/Modal';
+import { renderLetterPdf, type LetterTemplateData } from '../utils/letterPdfRenderer';
+import { useLetterActions } from '../hooks/useLetterActions';
+import type { LetterRow } from '../hooks/useLetterQueue';
+
+interface Props {
+  open: boolean;
+  letter: LetterRow;
+  initialMode: 'generate' | 'dispatch';
+  onClose: () => void;
+}
+
+export default function LetterDispatchDialog({ open, letter, initialMode, onClose }: Props) {
+  const [mode, setMode] = useState<'generate' | 'dispatch'>(initialMode);
+
+  // Reset mode when letter changes or initialMode changes
+  useEffect(() => {
+    setMode(initialMode);
+  }, [initialMode, letter.id]);
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      title={mode === 'generate' ? 'สร้าง PDF หนังสือ' : 'บันทึกการส่งหนังสือ'}
+    >
+      {mode === 'generate' ? (
+        <GenerateSection letter={letter} onGenerated={() => setMode('dispatch')} onClose={onClose} />
+      ) : (
+        <DispatchSection letter={letter} onClose={onClose} />
+      )}
+    </Modal>
+  );
+}
+
+// ── GenerateSection ────────────────────────────────────────────────────────────
+
+interface GenerateSectionProps {
+  letter: LetterRow;
+  onGenerated: () => void;
+  onClose: () => void;
+}
+
+function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps) {
+  const [busy, setBusy] = useState(false);
+  const { markPdfGenerated } = useLetterActions();
+
+  // Prefetch company info (OWNER role required — if request fails we catch gracefully)
+  const companiesQuery = useQuery({
+    queryKey: ['companies-for-letter'],
+    queryFn: async () => {
+      const { data } = await api.get('/companies');
+      return data as Array<{
+        id: string;
+        companyCode: string | null;
+        nameTh: string;
+        taxId: string;
+        address: string;
+        phone: string | null;
+        directorName: string;
+        directorPosition: string | null;
+        logoUrl: string | null;
+      }>;
+    },
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+
+  const settingsQuery = useQuery({
+    queryKey: ['settings-for-letter'],
+    queryFn: async () => {
+      const { data } = await api.get('/settings');
+      return data as Array<{ key: string; value: string | null }>;
+    },
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+
+  const handleGenerate = async () => {
+    setBusy(true);
+    try {
+      // 1. Gather company, contract data, and settings
+      const [contractRes] = await Promise.all([
+        api.get(`/contracts/${letter.contractId}`).then((r) => r.data),
+      ]);
+
+      // Pick FINANCE company (the HP financer signing the letter)
+      const companies = companiesQuery.data ?? [];
+      const company =
+        companies.find((c) => c.companyCode === 'FINANCE') ?? companies[0] ?? null;
+
+      if (!company) {
+        throw new Error('ไม่พบข้อมูลบริษัท (FINANCE) — โปรดตั้งค่า CompanyInfo ก่อน');
+      }
+
+      // Settings: letter_signature_url + letter_letterhead_url
+      const settings = settingsQuery.data ?? [];
+      const findConfig = (key: string): string | null =>
+        settings.find((s) => s.key === key)?.value ?? null;
+
+      const signatureUrl = findConfig('letter_signature_url');
+      const letterheadUrl = findConfig('letter_letterhead_url');
+
+      if (!signatureUrl) {
+        const proceed = window.confirm(
+          'ยังไม่มีลายเซ็นในระบบ — สร้าง PDF ต่อโดยไม่มีลายเซ็น?',
+        );
+        if (!proceed) {
+          setBusy(false);
+          return;
+        }
+      }
+
+      // Compute outstanding + days overdue from payments
+      const payments: Array<{
+        status: string;
+        amountDue: string;
+        amountPaid: string;
+        lateFee: string | null;
+        dueDate: string;
+      }> = (contractRes.payments ?? []).filter((p: { status: string }) =>
+        ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'].includes(p.status),
+      );
+
+      const outstanding = payments.reduce((sum, p) => {
+        return (
+          sum +
+          (parseFloat(p.amountDue) - parseFloat(p.amountPaid) + parseFloat(p.lateFee ?? '0'))
+        );
+      }, 0);
+
+      const now = new Date();
+      const oldest = payments
+        .map((p) => new Date(p.dueDate))
+        .sort((a, b) => a.getTime() - b.getTime())[0];
+      const daysOverdue = oldest
+        ? Math.max(0, Math.floor((now.getTime() - oldest.getTime()) / 86400000))
+        : 0;
+
+      const data: LetterTemplateData = {
+        letterType: letter.letterType,
+        letterNumber: letter.letterNumber,
+        letterDate: new Date(),
+        company: {
+          nameTh: company.nameTh,
+          taxId: company.taxId,
+          address: company.address,
+          phone: company.phone ?? undefined,
+          directorName: company.directorName,
+          directorPosition: company.directorPosition ?? undefined,
+          // Use letterhead as logo if available, otherwise fall back to company logo
+          logoUrl: letterheadUrl ?? company.logoUrl ?? undefined,
+          signatureUrl: signatureUrl ?? undefined,
+        },
+        customer: {
+          name: letter.contract.customer.name,
+          address: letter.contract.customer.addressCurrent ?? null,
+        },
+        contract: {
+          contractNumber: letter.contract.contractNumber,
+          contractDate: contractRes.createdAt ? new Date(contractRes.createdAt) : null,
+          outstanding,
+          daysOverdue,
+        },
+      };
+
+      // 2. Render PDF
+      const blob = await renderLetterPdf(data);
+
+      // 3. Presign upload URL
+      const { data: presigned } = await api.post('/shop/upload/signed-url', {
+        kind: 'LETTER_PDF',
+        contentType: 'application/pdf',
+      });
+
+      // 4. PUT blob to S3
+      const uploadRes = await fetch(presigned.uploadUrl, {
+        method: presigned.method ?? 'PUT',
+        body: blob,
+        headers: { 'Content-Type': 'application/pdf' },
+      });
+      if (!uploadRes.ok) {
+        throw new Error(`อัปโหลดไม่สำเร็จ (HTTP ${uploadRes.status})`);
+      }
+
+      // 5. Mark generated on backend
+      await markPdfGenerated.mutateAsync({ letterId: letter.id, pdfUrl: presigned.publicUrl });
+
+      toast.success('สร้าง PDF สำเร็จ');
+      onGenerated();
+    } catch (err) {
+      toast.error(
+        `สร้าง PDF ไม่สำเร็จ: ${err instanceof Error ? err.message : getErrorMessage(err)}`,
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const isLoadingDeps = companiesQuery.isLoading || settingsQuery.isLoading;
+
+  return (
+    <div className="space-y-4 p-1">
+      {/* Letter summary block */}
+      <div className="rounded-lg bg-muted/40 border border-border p-3 text-sm space-y-1.5">
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground leading-snug">เลขที่หนังสือ</span>
+          <span className="font-mono text-xs tabular-nums">{letter.letterNumber}</span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground leading-snug">ลูกค้า</span>
+          <span className="font-semibold leading-snug text-right">
+            {letter.contract.customer.name}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground leading-snug">สัญญา</span>
+          <span className="font-mono text-xs text-primary tabular-nums">
+            {letter.contract.contractNumber}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground leading-snug">ประเภท</span>
+          <span
+            className={
+              letter.letterType === 'CONTRACT_TERMINATION_60D'
+                ? 'text-destructive font-medium leading-snug text-right'
+                : 'text-warning font-medium leading-snug text-right'
+            }
+          >
+            {letter.letterType === 'RETURN_DEVICE_45D'
+              ? 'หนังสือทวงถามและเรียกเครื่องคืน 45 วัน'
+              : 'หนังสือบอกเลิกสัญญา 60 วัน'}
+          </span>
+        </div>
+      </div>
+
+      <div className="text-xs text-muted-foreground leading-snug">
+        ระบบจะสร้าง PDF ภาษาไทย A4 พร้อมลายเซ็นจากการตั้งค่าและอัปโหลดไปที่ S3
+        จากนั้นท่านสามารถดาวน์โหลดเพื่อพิมพ์และนำไปส่งไปรษณีย์ EMS
+      </div>
+
+      {isLoadingDeps && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          กำลังโหลดข้อมูลบริษัท...
+        </div>
+      )}
+
+      <div className="flex gap-2 justify-end pt-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-sm rounded-lg border border-input hover:bg-muted transition-colors"
+        >
+          ยกเลิก
+        </button>
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={busy || isLoadingDeps}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {busy ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              กำลังสร้าง...
+            </>
+          ) : (
+            <>
+              <FileText className="size-4" />
+              สร้าง PDF
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── DispatchSection ────────────────────────────────────────────────────────────
+
+interface DispatchSectionProps {
+  letter: LetterRow;
+  onClose: () => void;
+}
+
+function DispatchSection({ letter, onClose }: DispatchSectionProps) {
+  const [tracking, setTracking] = useState('');
+  const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+  const { dispatch } = useLetterActions();
+
+  const handleSubmit = async () => {
+    if (tracking.trim().length < 5) {
+      toast.error('เลข tracking ต้อง ≥ 5 ตัวอักษร');
+      return;
+    }
+    setBusy(true);
+    try {
+      let evidencePhotoUrl: string | undefined;
+
+      if (evidenceFile) {
+        const { data: presigned } = await api.post('/shop/upload/signed-url', {
+          kind: 'LETTER_EVIDENCE',
+          contentType: evidenceFile.type,
+        });
+        const up = await fetch(presigned.uploadUrl, {
+          method: presigned.method ?? 'PUT',
+          body: evidenceFile,
+          headers: { 'Content-Type': evidenceFile.type },
+        });
+        if (!up.ok) throw new Error(`อัปโหลดรูปไม่สำเร็จ (HTTP ${up.status})`);
+        evidencePhotoUrl = presigned.publicUrl;
+      }
+
+      await dispatch.mutateAsync({
+        letterId: letter.id,
+        trackingNumber: tracking.trim(),
+        evidencePhotoUrl,
+      });
+
+      onClose();
+    } catch (err) {
+      toast.error(getErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const trackingValid = tracking.trim().length >= 5;
+
+  return (
+    <div className="space-y-4 p-1">
+      {/* PDF download link */}
+      {letter.pdfUrl && (
+        <a
+          href={letter.pdfUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
+        >
+          <Download className="size-4" />
+          ดาวน์โหลด PDF ({letter.letterNumber})
+        </a>
+      )}
+
+      {/* Letter info block */}
+      <div className="rounded-lg bg-muted/40 border border-border p-3 text-xs space-y-1">
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground leading-snug">ลูกค้า</span>
+          <span className="font-semibold leading-snug text-right">
+            {letter.contract.customer.name}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="text-muted-foreground leading-snug">สัญญา</span>
+          <span className="font-mono text-primary tabular-nums">
+            {letter.contract.contractNumber}
+          </span>
+        </div>
+      </div>
+
+      {/* Tracking number input */}
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
+          เลข EMS tracking *
+        </label>
+        <input
+          type="text"
+          value={tracking}
+          onChange={(e) => setTracking(e.target.value)}
+          placeholder="เช่น EX123456789TH"
+          className="w-full px-3 py-2 border border-input rounded-lg text-sm font-mono tabular-nums bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+          autoFocus
+        />
+        {tracking.length > 0 && !trackingValid && (
+          <p className="text-[10px] text-destructive mt-1 leading-snug">
+            ต้องกรอกอย่างน้อย 5 ตัวอักษร
+          </p>
+        )}
+      </div>
+
+      {/* Evidence photo upload */}
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
+          รูปใบรับส่งไปรษณีย์ (ไม่บังคับ)
+        </label>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setEvidenceFile(e.target.files?.[0] ?? null)}
+          className="text-sm text-muted-foreground file:mr-3 file:rounded-lg file:border file:border-input file:bg-muted file:px-3 file:py-1 file:text-xs file:font-medium file:text-foreground hover:file:bg-accent cursor-pointer"
+        />
+        {evidenceFile && (
+          <p className="mt-1 text-[10px] text-muted-foreground leading-snug">
+            {evidenceFile.name} ({(evidenceFile.size / 1024).toFixed(0)} KB)
+          </p>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-2 justify-end pt-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-sm rounded-lg border border-input hover:bg-muted transition-colors"
+        >
+          ยกเลิก
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={busy || !trackingValid}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {busy ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              กำลังบันทึก...
+            </>
+          ) : (
+            <>
+              <Upload className="size-4" />
+              บันทึกส่งแล้ว
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Download, FileText, Loader2, Upload } from 'lucide-react';
+import { AlertTriangle, Download, FileText, Loader2, Upload } from 'lucide-react';
 import { toast } from 'sonner';
+import Decimal from 'decimal.js';
 import api, { getErrorMessage } from '@/lib/api';
 import Modal from '@/components/ui/Modal';
 import { renderLetterPdf, type LetterTemplateData } from '../utils/letterPdfRenderer';
@@ -48,6 +49,10 @@ interface GenerateSectionProps {
 
 function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps) {
   const [busy, setBusy] = useState(false);
+  // When signature is missing, user must explicitly acknowledge before
+  // the PDF can be generated. `proceedWithoutSignature` flips to true only
+  // after the "สร้างต่อโดยไม่มีลายเซ็น" button is clicked.
+  const [proceedWithoutSignature, setProceedWithoutSignature] = useState(false);
   const { markPdfGenerated } = useLetterActions();
 
   // Prefetch company info (OWNER role required — if request fails we catch gracefully)
@@ -81,10 +86,25 @@ function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps)
     retry: 1,
   });
 
+  // Compute config synchronously from already-loaded queries so the
+  // "missing signature" warning can render inline (no `window.confirm`).
+  const settings = settingsQuery.data ?? [];
+  const findConfig = (key: string): string | null =>
+    settings.find((s) => s.key === key)?.value ?? null;
+  const signatureUrl = findConfig('letter_signature_url');
+  const letterheadUrl = findConfig('letter_letterhead_url');
+
+  const hasSignature = !!signatureUrl;
+  const isLoadingDeps = companiesQuery.isLoading || settingsQuery.isLoading;
+
+  // The generate button is blocked when signature is missing AND user has
+  // not explicitly acknowledged via the "สร้างต่อโดยไม่มีลายเซ็น" button.
+  const signatureCheckBlocked = !isLoadingDeps && !hasSignature && !proceedWithoutSignature;
+
   const handleGenerate = async () => {
     setBusy(true);
     try {
-      // 1. Gather company, contract data, and settings
+      // 1. Gather company + contract data
       const [contractRes] = await Promise.all([
         api.get(`/contracts/${letter.contractId}`).then((r) => r.data),
       ]);
@@ -98,25 +118,8 @@ function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps)
         throw new Error('ไม่พบข้อมูลบริษัท (FINANCE) — โปรดตั้งค่า CompanyInfo ก่อน');
       }
 
-      // Settings: letter_signature_url + letter_letterhead_url
-      const settings = settingsQuery.data ?? [];
-      const findConfig = (key: string): string | null =>
-        settings.find((s) => s.key === key)?.value ?? null;
-
-      const signatureUrl = findConfig('letter_signature_url');
-      const letterheadUrl = findConfig('letter_letterhead_url');
-
-      if (!signatureUrl) {
-        const proceed = window.confirm(
-          'ยังไม่มีลายเซ็นในระบบ — สร้าง PDF ต่อโดยไม่มีลายเซ็น?',
-        );
-        if (!proceed) {
-          setBusy(false);
-          return;
-        }
-      }
-
-      // Compute outstanding + days overdue from payments
+      // Compute outstanding using Decimal (money arithmetic MUST NOT use
+      // parseFloat — this balance appears on a court-submitted letter).
       const payments: Array<{
         status: string;
         amountDue: string;
@@ -127,12 +130,16 @@ function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps)
         ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'].includes(p.status),
       );
 
-      const outstanding = payments.reduce((sum, p) => {
-        return (
-          sum +
-          (parseFloat(p.amountDue) - parseFloat(p.amountPaid) + parseFloat(p.lateFee ?? '0'))
-        );
-      }, 0);
+      const outstandingDec = payments.reduce(
+        (sum, p) =>
+          sum
+            .plus(new Decimal(p.amountDue ?? '0'))
+            .minus(new Decimal(p.amountPaid ?? '0'))
+            .plus(new Decimal(p.lateFee ?? '0')),
+        new Decimal(0),
+      );
+      // renderLetterPdf expects a number — convert only at the very edge.
+      const outstanding = outstandingDec.toNumber();
 
       const now = new Date();
       const oldest = payments
@@ -202,8 +209,6 @@ function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps)
     }
   };
 
-  const isLoadingDeps = companiesQuery.isLoading || settingsQuery.isLoading;
-
   return (
     <div className="space-y-4 p-1">
       {/* Letter summary block */}
@@ -252,6 +257,37 @@ function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps)
         </div>
       )}
 
+      {/* Inline warning — replaces window.confirm so the missing-signature
+          decision is explicit, keyboard-accessible, and visible in the dialog */}
+      {!isLoadingDeps && !hasSignature && (
+        <div
+          role="alert"
+          className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-xs space-y-2"
+        >
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="size-4 text-warning shrink-0 mt-0.5" />
+            <div className="leading-snug">
+              <div className="font-semibold text-warning">ยังไม่มีลายเซ็นในระบบ</div>
+              <div className="text-muted-foreground mt-0.5">
+                PDF ที่สร้างจะไม่มีลายเซ็น — แนะนำให้อัปโหลดลายเซ็นในการตั้งค่าก่อน
+                หรือกดปุ่มด้านล่างเพื่อสร้างต่อโดยไม่มีลายเซ็น
+              </div>
+            </div>
+          </div>
+          {!proceedWithoutSignature && (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => setProceedWithoutSignature(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-warning/50 bg-background px-3 py-1.5 text-xs font-medium text-warning hover:bg-warning/10 transition-colors"
+              >
+                สร้างต่อโดยไม่มีลายเซ็น
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="flex gap-2 justify-end pt-2">
         <button
           type="button"
@@ -263,7 +299,7 @@ function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps)
         <button
           type="button"
           onClick={handleGenerate}
-          disabled={busy || isLoadingDeps}
+          disabled={busy || isLoadingDeps || signatureCheckBlocked}
           className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
           {busy ? (

--- a/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
@@ -76,8 +76,11 @@ function GenerateSection({ letter, onGenerated, onClose }: GenerateSectionProps)
     retry: 1,
   });
 
+  // Must share queryKey with DunningSettingsPage so that when OWNER uploads
+  // a signature, this dialog sees fresh data. `['settings']` is the source-of-
+  // truth key used by DunningSettingsPage / InterestConfigPage / SettingsPage.
   const settingsQuery = useQuery({
-    queryKey: ['settings-for-letter'],
+    queryKey: ['settings'],
     queryFn: async () => {
       const { data } = await api.get('/settings');
       return data as Array<{ key: string; value: string | null }>;

--- a/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { FileText, Download, CheckCircle, RotateCcw, Loader2 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import Modal from '@/components/ui/Modal';
 import { cn } from '@/lib/utils';
 import { useLetterQueue, type LetterRow, type LetterType, type LetterStatus } from '../hooks/useLetterQueue';
 import { useLetterActions } from '../hooks/useLetterActions';
@@ -205,6 +206,12 @@ export default function LetterQueueSection() {
   const [dispatchLetter, setDispatchLetter] = useState<LetterRow | null>(null);
   const [dispatchMode, setDispatchMode] = useState<'generate' | 'dispatch'>('generate');
 
+  // Undeliverable reason dialog — replaces window.prompt
+  const [undeliverableLetter, setUndeliverableLetter] = useState<LetterRow | null>(null);
+  const [undeliverableReason, setUndeliverableReason] = useState<string>(
+    'ย้ายที่อยู่ไม่ทราบที่อยู่ใหม่',
+  );
+
   const openGenerate = (l: LetterRow) => {
     setDispatchLetter(l);
     setDispatchMode('generate');
@@ -216,13 +223,23 @@ export default function LetterQueueSection() {
   };
 
   const handleUndeliverable = (letter: LetterRow) => {
-    const reason = window.prompt(
-      'เหตุผลที่ส่งไม่ถึง (≥ 5 ตัวอักษร):',
-      'ย้ายที่อยู่ไม่ทราบที่อยู่ใหม่',
-    );
-    if (!reason || reason.length < 5) return;
-    markUndeliverable.mutate({ letterId: letter.id, reason });
+    setUndeliverableLetter(letter);
+    setUndeliverableReason('ย้ายที่อยู่ไม่ทราบที่อยู่ใหม่');
   };
+
+  const closeUndeliverable = () => setUndeliverableLetter(null);
+
+  const submitUndeliverable = () => {
+    if (!undeliverableLetter) return;
+    const trimmed = undeliverableReason.trim();
+    if (trimmed.length < 5) return;
+    markUndeliverable.mutate(
+      { letterId: undeliverableLetter.id, reason: trimmed },
+      { onSettled: () => closeUndeliverable() },
+    );
+  };
+
+  const undeliverableValid = undeliverableReason.trim().length >= 5;
 
   const count = data?.length ?? 0;
 
@@ -278,6 +295,79 @@ export default function LetterQueueSection() {
           onClose={() => setDispatchLetter(null)}
         />
       )}
+
+      {/* Undeliverable reason — replaces window.prompt */}
+      <Modal
+        isOpen={!!undeliverableLetter}
+        onClose={closeUndeliverable}
+        title="บันทึกเหตุผลที่ส่งไม่ถึง"
+      >
+        {undeliverableLetter && (
+          <div className="space-y-4 p-1">
+            <div className="rounded-lg bg-muted/40 border border-border p-3 text-xs space-y-1">
+              <div className="flex justify-between gap-4">
+                <span className="text-muted-foreground leading-snug">ลูกค้า</span>
+                <span className="font-semibold leading-snug text-right">
+                  {undeliverableLetter.contract.customer.name}
+                </span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span className="text-muted-foreground leading-snug">สัญญา</span>
+                <span className="font-mono text-primary tabular-nums">
+                  {undeliverableLetter.contract.contractNumber}
+                </span>
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor="undeliverable-reason"
+                className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug"
+              >
+                เหตุผลที่ส่งไม่ถึง (≥ 5 ตัวอักษร) *
+              </label>
+              <textarea
+                id="undeliverable-reason"
+                value={undeliverableReason}
+                onChange={(e) => setUndeliverableReason(e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring leading-snug"
+                autoFocus
+              />
+              {undeliverableReason.length > 0 && !undeliverableValid && (
+                <p className="text-[10px] text-destructive mt-1 leading-snug">
+                  ต้องกรอกอย่างน้อย 5 ตัวอักษร
+                </p>
+              )}
+            </div>
+
+            <div className="flex gap-2 justify-end pt-2">
+              <button
+                type="button"
+                onClick={closeUndeliverable}
+                className="px-4 py-2 text-sm rounded-lg border border-input hover:bg-muted transition-colors"
+              >
+                ยกเลิก
+              </button>
+              <button
+                type="button"
+                onClick={submitUndeliverable}
+                disabled={!undeliverableValid || markUndeliverable.isPending}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+              >
+                {markUndeliverable.isPending ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    กำลังบันทึก...
+                  </>
+                ) : (
+                  'บันทึก'
+                )}
+              </button>
+            </div>
+          </div>
+        )}
+      </Modal>
     </>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react';
+import { FileText, Download, CheckCircle, RotateCcw, Loader2 } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { useLetterQueue, type LetterRow, type LetterType, type LetterStatus } from '../hooks/useLetterQueue';
+import { useLetterActions } from '../hooks/useLetterActions';
+import LetterDispatchDialog from './LetterDispatchDialog';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function letterTypeLabel(t: LetterType): string {
+  return t === 'RETURN_DEVICE_45D' ? 'ทวงถาม 45 วัน' : 'บอกเลิก 60 วัน';
+}
+
+function letterTypeStyle(t: LetterType): string {
+  return t === 'CONTRACT_TERMINATION_60D'
+    ? 'bg-destructive/10 text-destructive'
+    : 'bg-warning/10 text-warning';
+}
+
+function letterStatusLabel(s: LetterStatus): string {
+  const map: Record<LetterStatus, string> = {
+    PENDING_DISPATCH: 'รอสร้าง PDF',
+    PDF_GENERATED: 'รอส่งไปรษณีย์',
+    DISPATCHED: 'ส่งแล้ว · รอรับ',
+    DELIVERED: 'รับแล้ว',
+    UNDELIVERABLE: 'ส่งไม่ถึง',
+    CANCELLED: 'ยกเลิก',
+  };
+  return map[s];
+}
+
+function letterStatusDot(s: LetterStatus): string {
+  const map: Record<LetterStatus, string> = {
+    PENDING_DISPATCH: 'bg-muted-foreground',
+    PDF_GENERATED: 'bg-warning',
+    DISPATCHED: 'bg-primary',
+    DELIVERED: 'bg-success',
+    UNDELIVERABLE: 'bg-destructive',
+    CANCELLED: 'bg-muted-foreground',
+  };
+  return map[s];
+}
+
+function daysAgoLabel(iso: string): string {
+  const days = Math.floor((Date.now() - new Date(iso).getTime()) / 86400000);
+  return days === 0 ? 'วันนี้' : `${days} วันที่แล้ว`;
+}
+
+function urgencyStrip(letter: LetterRow): string {
+  const days = Math.floor((Date.now() - new Date(letter.triggeredAt).getTime()) / 86400000);
+  if (days >= 5) return 'bg-destructive';
+  if (days >= 2) return 'bg-warning';
+  return 'bg-primary';
+}
+
+// ── Row Skeleton ───────────────────────────────────────────────────────────────
+
+function RowSkeleton() {
+  return <div className="bg-muted animate-pulse h-24 rounded-lg" />;
+}
+
+// ── Letter Row ─────────────────────────────────────────────────────────────────
+
+interface LetterRowCardProps {
+  letter: LetterRow;
+  onOpenGenerate: (l: LetterRow) => void;
+  onOpenDispatch: (l: LetterRow) => void;
+  onDelivered: (l: LetterRow) => void;
+  onUndeliverable: (l: LetterRow) => void;
+  deliveredPending: boolean;
+  undeliverablePending: boolean;
+}
+
+function LetterRowCard({
+  letter,
+  onOpenGenerate,
+  onOpenDispatch,
+  onDelivered,
+  onUndeliverable,
+  deliveredPending,
+  undeliverablePending,
+}: LetterRowCardProps) {
+  return (
+    <div className="relative flex rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+      {/* Urgency heat strip */}
+      <div className={cn('w-1 shrink-0', urgencyStrip(letter))} />
+
+      <div className="flex-1 p-4 min-w-0">
+        {/* Header row: badges + age */}
+        <div className="flex items-start justify-between gap-3 mb-1.5">
+          <div className="flex items-center gap-1.5 flex-wrap min-w-0">
+            <span
+              className={cn(
+                'inline-flex items-center rounded-full text-[10px] font-semibold px-2 py-0.5 leading-snug',
+                letterTypeStyle(letter.letterType),
+              )}
+            >
+              {letterTypeLabel(letter.letterType)}
+            </span>
+            <span className="inline-flex items-center gap-1 rounded-full text-[10px] font-medium px-2 py-0.5 leading-snug bg-muted text-muted-foreground">
+              <span
+                className={cn('inline-block size-1.5 rounded-full', letterStatusDot(letter.status))}
+              />
+              {letterStatusLabel(letter.status)}
+            </span>
+          </div>
+          <div className="shrink-0 text-[10px] text-muted-foreground leading-snug whitespace-nowrap tabular-nums">
+            {daysAgoLabel(letter.triggeredAt)}
+          </div>
+        </div>
+
+        {/* Contract # + Customer */}
+        <div className="font-mono text-xs text-primary font-medium mb-0.5">
+          {letter.contract.contractNumber}
+        </div>
+        <div className="text-sm font-semibold leading-snug truncate mb-0.5">
+          {letter.contract.customer.name}
+        </div>
+        <div className="text-[10px] text-muted-foreground leading-snug mb-3">
+          {letter.letterNumber}
+          {letter.trackingNumber && (
+            <>
+              {' · '}
+              <span className="font-mono tabular-nums">{letter.trackingNumber}</span>
+            </>
+          )}
+        </div>
+
+        {/* CTAs per status */}
+        <div className="flex items-center justify-end gap-2">
+          {letter.status === 'PENDING_DISPATCH' && (
+            <button
+              type="button"
+              onClick={() => onOpenGenerate(letter)}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              <FileText className="size-3.5" />
+              สร้าง PDF
+            </button>
+          )}
+
+          {letter.status === 'PDF_GENERATED' && (
+            <>
+              {letter.pdfUrl && (
+                <a
+                  href={letter.pdfUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                >
+                  <Download className="size-3.5" />
+                  ดาวน์โหลด
+                </a>
+              )}
+              <button
+                type="button"
+                onClick={() => onOpenDispatch(letter)}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                <CheckCircle className="size-3.5" />
+                บันทึกส่งแล้ว
+              </button>
+            </>
+          )}
+
+          {letter.status === 'DISPATCHED' && (
+            <>
+              <button
+                type="button"
+                onClick={() => onUndeliverable(letter)}
+                disabled={undeliverablePending}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50 transition-colors"
+              >
+                <RotateCcw className="size-3.5" />
+                คืน
+              </button>
+              <button
+                type="button"
+                onClick={() => onDelivered(letter)}
+                disabled={deliveredPending}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+              >
+                {deliveredPending ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <CheckCircle className="size-3.5" />
+                )}
+                รับแล้ว
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── LetterQueueSection ────────────────────────────────────────────────────────
+
+export default function LetterQueueSection() {
+  const { data, isLoading } = useLetterQueue();
+  const { markDelivered, markUndeliverable } = useLetterActions();
+
+  const [dispatchLetter, setDispatchLetter] = useState<LetterRow | null>(null);
+  const [dispatchMode, setDispatchMode] = useState<'generate' | 'dispatch'>('generate');
+
+  const openGenerate = (l: LetterRow) => {
+    setDispatchLetter(l);
+    setDispatchMode('generate');
+  };
+
+  const openDispatch = (l: LetterRow) => {
+    setDispatchLetter(l);
+    setDispatchMode('dispatch');
+  };
+
+  const handleUndeliverable = (letter: LetterRow) => {
+    const reason = window.prompt(
+      'เหตุผลที่ส่งไม่ถึง (≥ 5 ตัวอักษร):',
+      'ย้ายที่อยู่ไม่ทราบที่อยู่ใหม่',
+    );
+    if (!reason || reason.length < 5) return;
+    markUndeliverable.mutate({ letterId: letter.id, reason });
+  };
+
+  const count = data?.length ?? 0;
+
+  return (
+    <>
+      <Card className="rounded-xl border border-border/50 bg-card shadow-sm">
+        <CardContent className="p-5">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <FileText className="size-4 text-primary" />
+              <h3 className="text-sm font-semibold leading-snug">หนังสือทวงถาม / บอกเลิก</h3>
+            </div>
+            <span className="text-xs tabular-nums bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+              {count}
+            </span>
+          </div>
+
+          {isLoading ? (
+            <div className="space-y-2">
+              <RowSkeleton />
+              <RowSkeleton />
+            </div>
+          ) : count === 0 ? (
+            <div className="rounded-lg border border-dashed border-success/30 bg-success/5 py-8 text-center">
+              <div className="text-sm font-medium text-success leading-snug">
+                ไม่มีหนังสือรอดำเนินการ
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {data!.map((letter) => (
+                <LetterRowCard
+                  key={letter.id}
+                  letter={letter}
+                  onOpenGenerate={openGenerate}
+                  onOpenDispatch={openDispatch}
+                  onDelivered={(l) => markDelivered.mutate(l.id)}
+                  onUndeliverable={handleUndeliverable}
+                  deliveredPending={markDelivered.isPending}
+                  undeliverablePending={markUndeliverable.isPending}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {dispatchLetter && (
+        <LetterDispatchDialog
+          open={!!dispatchLetter}
+          letter={dispatchLetter}
+          initialMode={dispatchMode}
+          onClose={() => setDispatchLetter(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useLetterActions.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useLetterActions.ts
@@ -1,0 +1,82 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export function useLetterActions() {
+  const qc = useQueryClient();
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['letter-queue'] });
+
+  const markPdfGenerated = useMutation({
+    mutationFn: async ({ letterId, pdfUrl }: { letterId: string; pdfUrl: string }) => {
+      const { data } = await api.post(`/overdue/letters/${letterId}/pdf-generated`, { pdfUrl });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('บันทึก PDF สำเร็จ');
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const dispatch = useMutation({
+    mutationFn: async ({
+      letterId,
+      trackingNumber,
+      evidencePhotoUrl,
+    }: {
+      letterId: string;
+      trackingNumber: string;
+      evidencePhotoUrl?: string;
+    }) => {
+      const { data } = await api.post(`/overdue/letters/${letterId}/dispatch`, {
+        trackingNumber,
+        ...(evidencePhotoUrl && { evidencePhotoUrl }),
+      });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('บันทึกการส่งหนังสือสำเร็จ');
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const markDelivered = useMutation({
+    mutationFn: async (letterId: string) => {
+      const { data } = await api.post(`/overdue/letters/${letterId}/delivered`);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('บันทึกรับหนังสือแล้ว');
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const markUndeliverable = useMutation({
+    mutationFn: async ({ letterId, reason }: { letterId: string; reason: string }) => {
+      const { data } = await api.post(`/overdue/letters/${letterId}/undeliverable`, { reason });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('บันทึกส่งไม่ถึงแล้ว');
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const cancel = useMutation({
+    mutationFn: async ({ letterId, reason }: { letterId: string; reason: string }) => {
+      const { data } = await api.post(`/overdue/letters/${letterId}/cancel`, { reason });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('ยกเลิกหนังสือแล้ว');
+      invalidate();
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  return { markPdfGenerated, dispatch, markDelivered, markUndeliverable, cancel };
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useLetterQueue.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useLetterQueue.ts
@@ -1,0 +1,66 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export type LetterType = 'RETURN_DEVICE_45D' | 'CONTRACT_TERMINATION_60D';
+
+export type LetterStatus =
+  | 'PENDING_DISPATCH'
+  | 'PDF_GENERATED'
+  | 'DISPATCHED'
+  | 'DELIVERED'
+  | 'UNDELIVERABLE'
+  | 'CANCELLED';
+
+export interface LetterRow {
+  id: string;
+  contractId: string;
+  letterType: LetterType;
+  letterNumber: string;
+  status: LetterStatus;
+  triggeredAt: string;
+  pdfUrl: string | null;
+  pdfGeneratedAt: string | null;
+  dispatchedAt: string | null;
+  trackingNumber: string | null;
+  evidencePhotoUrl: string | null;
+  deliveredAt: string | null;
+  cancelledAt: string | null;
+  cancelReason: string | null;
+  contract: {
+    id: string;
+    contractNumber: string;
+    customer: {
+      id: string;
+      name: string;
+      phone: string;
+      addressCurrent: string | null;
+    };
+    branch: { id: string; name: string };
+  };
+}
+
+const ACTIVE_STATUSES: LetterStatus[] = ['PENDING_DISPATCH', 'PDF_GENERATED', 'DISPATCHED'];
+
+async function fetchLettersByStatus(status: LetterStatus): Promise<LetterRow[]> {
+  const { data } = await api.get<LetterRow[]>('/overdue/letters', { params: { status } });
+  return data;
+}
+
+/**
+ * Fetches letters in all 3 active statuses in parallel and merges into a
+ * single sorted list (newest triggeredAt first).
+ */
+export function useLetterQueue() {
+  return useQuery<LetterRow[]>({
+    queryKey: ['letter-queue'],
+    queryFn: async () => {
+      const results = await Promise.all(ACTIVE_STATUSES.map(fetchLettersByStatus));
+      const merged = results.flat();
+      merged.sort(
+        (a, b) => new Date(b.triggeredAt).getTime() - new Date(a.triggeredAt).getTime(),
+      );
+      return merged;
+    },
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
@@ -9,6 +9,7 @@ import {
   useRejectMdm,
 } from '../hooks/useApprovalQueues';
 import { EscalationRow, MdmRow } from '../components/ApprovalPendingRow';
+import LetterQueueSection from '../components/LetterQueueSection';
 
 function RowSkeleton() {
   return <div className="bg-muted animate-pulse h-20 rounded-lg" />;
@@ -108,6 +109,9 @@ export default function ApprovalTab() {
           )}
         </CardContent>
       </Card>
+
+      {/* Letter queue — generate PDF → dispatch → track delivery */}
+      <LetterQueueSection />
     </div>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/utils/letterPdfRenderer.ts
+++ b/apps/web/src/pages/CollectionsPage/utils/letterPdfRenderer.ts
@@ -1,0 +1,461 @@
+/**
+ * letterPdfRenderer.ts
+ *
+ * Client-side A4 PDF renderer for legal collection letters.
+ * Supports two templates:
+ *   - RETURN_DEVICE_45D  — demand notice + device return ultimatum
+ *   - CONTRACT_TERMINATION_60D — contract termination + legal action notice
+ *
+ * Thai text is rendered using the THSarabunPSK font (loaded from /fonts/).
+ * Font loading is shared with the existing template-editor pdfGenerator.
+ */
+
+import { jsPDF } from 'jspdf';
+
+// ── Page geometry (A4 portrait, mm) ───────────────────────────────────────────
+const PAGE_W = 210;
+const PAGE_H = 297;
+const MARGIN = 25;
+const CONTENT_W = PAGE_W - MARGIN * 2;
+
+// ── Font constants (must match names registered by loadThaiFont) ───────────────
+const PDF_FONT_FAMILY = 'THSarabunPSK';
+const REQUIRED_FONTS = ['THSarabunPSK-Regular', 'THSarabunPSK-Bold'] as const;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type LetterTemplateData = {
+  letterType: 'RETURN_DEVICE_45D' | 'CONTRACT_TERMINATION_60D';
+  letterNumber: string;
+  letterDate: Date;
+  company: {
+    nameTh: string;
+    taxId: string;
+    address: string;
+    phone?: string | null;
+    directorName: string;
+    directorPosition?: string | null;
+    logoUrl?: string | null;
+    signatureUrl?: string | null;
+  };
+  customer: {
+    name: string;
+    address?: string | null;
+  };
+  contract: {
+    contractNumber: string;
+    contractDate?: Date | null;
+    outstanding: number;
+    daysOverdue: number;
+  };
+};
+
+// ── Font loader ───────────────────────────────────────────────────────────────
+// Module-level cache so font data is loaded only once per page session.
+const _fontCache: Record<string, string> = {};
+
+async function _ensureFont(fontName: string): Promise<void> {
+  if (_fontCache[fontName]) return;
+  try {
+    const response = await fetch(`/fonts/${fontName}.ttf`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const buffer = await response.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    // Convert in 8 KB chunks to avoid call-stack overflow on large font files
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 8192) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+    }
+    _fontCache[fontName] = btoa(binary);
+  } catch (err) {
+    console.warn(`[letterPdfRenderer] Failed to load font ${fontName}:`, err);
+  }
+}
+
+async function loadThaiFont(doc: jsPDF): Promise<void> {
+  await Promise.all(REQUIRED_FONTS.map((f) => _ensureFont(f)));
+
+  const styles: Record<string, string> = {
+    'THSarabunPSK-Regular': 'normal',
+    'THSarabunPSK-Bold': 'bold',
+  };
+
+  for (const fontName of REQUIRED_FONTS) {
+    const base64 = _fontCache[fontName];
+    if (!base64) continue; // graceful fallback if fetch failed
+    doc.addFileToVFS(`${fontName}.ttf`, base64);
+    doc.addFont(`${fontName}.ttf`, PDF_FONT_FAMILY, styles[fontName] ?? 'normal');
+  }
+}
+
+// ── Image helper ──────────────────────────────────────────────────────────────
+
+async function loadImageAsDataUrl(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const blob = await res.blob();
+    return await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return null;
+  }
+}
+
+// ── Date formatter ────────────────────────────────────────────────────────────
+
+function formatThaiDate(d: Date): string {
+  return d.toLocaleDateString('th-TH', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+// ── Number formatter ──────────────────────────────────────────────────────────
+
+function formatMoney(n: number): string {
+  return n.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+// ── Section renderers ─────────────────────────────────────────────────────────
+
+/**
+ * Renders the top-of-page header:
+ *   • Optional company logo top-left
+ *   • Letter number + date top-right
+ *   • Thin rule beneath
+ */
+function headerBlock(
+  doc: jsPDF,
+  data: LetterTemplateData,
+  logoDataUrl: string | null,
+): void {
+  const topY = MARGIN;
+
+  // Logo (30mm × 20mm)
+  if (logoDataUrl) {
+    try {
+      doc.addImage(logoDataUrl, 'PNG', MARGIN, topY, 30, 20);
+    } catch {
+      // Ignore — logo rendering is best-effort
+    }
+  }
+
+  // Letter reference block, right-aligned
+  doc.setFontSize(11);
+  doc.setFont(PDF_FONT_FAMILY, 'normal');
+  doc.setTextColor(0);
+  doc.text(`เลขที่ ${data.letterNumber}`, PAGE_W - MARGIN, topY + 5, { align: 'right' });
+  doc.text(
+    `วันที่ ${formatThaiDate(data.letterDate)}`,
+    PAGE_W - MARGIN,
+    topY + 11,
+    { align: 'right' },
+  );
+
+  // Company name beneath logo area (or left-aligned if no logo)
+  doc.setFontSize(13);
+  doc.setFont(PDF_FONT_FAMILY, 'bold');
+  doc.text(data.company.nameTh, MARGIN, topY + 6);
+
+  // Rule
+  doc.setDrawColor(180);
+  doc.setLineWidth(0.4);
+  doc.line(MARGIN, topY + 22, PAGE_W - MARGIN, topY + 22);
+
+  doc.setFont(PDF_FONT_FAMILY, 'normal');
+}
+
+/**
+ * Renders the centred letter title.
+ * Returns the Y position after the title.
+ */
+function titleBlock(doc: jsPDF, title: string, yStart: number): number {
+  doc.setFontSize(16);
+  doc.setFont(PDF_FONT_FAMILY, 'bold');
+  doc.text(title, PAGE_W / 2, yStart, { align: 'center' });
+  doc.setFont(PDF_FONT_FAMILY, 'normal');
+  return yStart + 14;
+}
+
+/**
+ * Renders the "เรียน / อ้างถึง" address block.
+ * Returns the Y position after the block.
+ */
+function addressBlock(doc: jsPDF, data: LetterTemplateData, yStart: number): number {
+  doc.setFontSize(14);
+  let y = yStart;
+
+  doc.text(`เรียน  ${data.customer.name}`, MARGIN, y);
+  y += 7;
+
+  if (data.customer.address) {
+    doc.setTextColor(60);
+    const addressLines = doc.splitTextToSize(
+      `ที่อยู่  ${data.customer.address}`,
+      CONTENT_W - 8,
+    );
+    doc.text(addressLines, MARGIN + 8, y);
+    y += addressLines.length * 7;
+    doc.setTextColor(0);
+  }
+
+  y += 3;
+
+  doc.text(
+    `อ้างถึง  สัญญาเช่าซื้อเลขที่ ${data.contract.contractNumber}`,
+    MARGIN,
+    y,
+  );
+  y += 7;
+
+  if (data.contract.contractDate) {
+    doc.text(
+      `              ลงวันที่ ${formatThaiDate(data.contract.contractDate)}`,
+      MARGIN,
+      y,
+    );
+    y += 7;
+  }
+
+  // Thin separator
+  doc.setDrawColor(210);
+  doc.setLineWidth(0.2);
+  doc.line(MARGIN, y + 1, PAGE_W - MARGIN, y + 1);
+
+  return y + 6;
+}
+
+/**
+ * RETURN_DEVICE_45D body — demand letter + device-return ultimatum.
+ */
+function bodyReturnDevice45D(
+  doc: jsPDF,
+  data: LetterTemplateData,
+  yStart: number,
+): number {
+  doc.setFontSize(14);
+  let y = yStart;
+  const lineH = 7.5;
+
+  // Paragraph 1 — facts
+  const p1 =
+    `     ด้วยท่านได้ทำสัญญาเช่าซื้อกับ ${data.company.nameTh} ` +
+    `และมีภาระค้างชำระเป็นเวลา ${data.contract.daysOverdue} วัน ` +
+    `รวมเป็นจำนวนเงินทั้งสิ้น ${formatMoney(data.contract.outstanding)} บาท ` +
+    `บริษัทฯ ได้ดำเนินการติดตามทวงถามซ้ำหลายครั้งแล้ว แต่ไม่สามารถ` +
+    `ติดต่อหรือได้รับการชำระจากท่านแต่อย่างใด`;
+  const p1Lines = doc.splitTextToSize(p1, CONTENT_W);
+  doc.text(p1Lines, MARGIN, y);
+  y += p1Lines.length * lineH + 4;
+
+  // Paragraph 2 — ultimatum intro
+  const p2 =
+    `     บัดนี้ บริษัทฯ จึงขอบอกกล่าวและกำหนดให้ท่านดำเนินการ` +
+    `อย่างใดอย่างหนึ่งดังต่อไปนี้ ภายใน 15 วัน นับแต่วันที่ได้รับ` +
+    `หนังสือฉบับนี้`;
+  const p2Lines = doc.splitTextToSize(p2, CONTENT_W);
+  doc.text(p2Lines, MARGIN, y);
+  y += p2Lines.length * lineH + 3;
+
+  // Option A
+  doc.text(
+    `     1.  ชำระยอดค้างชำระทั้งหมด ${formatMoney(data.contract.outstanding)} บาท พร้อมค่าธรรมเนียมล่าช้าที่เกิดขึ้น`,
+    MARGIN,
+    y,
+  );
+  y += lineH;
+
+  // Option B
+  doc.text(
+    `     2.  ส่งมอบทรัพย์สินที่เช่าซื้อ (โทรศัพท์มือถือ) คืนแก่บริษัทฯ ใน` +
+      `สภาพที่สมบูรณ์`,
+    MARGIN,
+    y,
+  );
+  y += lineH + 4;
+
+  // Warning
+  doc.setFont(PDF_FONT_FAMILY, 'bold');
+  const warn =
+    `     หากท่านไม่ดำเนินการใดภายในกำหนดเวลาดังกล่าว บริษัทฯ ` +
+    `จำเป็นต้องดำเนินการตามกระบวนการทางกฎหมายต่อไป โดยไม่จำเป็น` +
+    `ต้องแจ้งให้ทราบล่วงหน้าอีก`;
+  const warnLines = doc.splitTextToSize(warn, CONTENT_W);
+  doc.text(warnLines, MARGIN, y);
+  doc.setFont(PDF_FONT_FAMILY, 'normal');
+  return y + warnLines.length * lineH + 6;
+}
+
+/**
+ * CONTRACT_TERMINATION_60D body — termination notice + legal action.
+ */
+function bodyContractTermination60D(
+  doc: jsPDF,
+  data: LetterTemplateData,
+  yStart: number,
+): number {
+  doc.setFontSize(14);
+  let y = yStart;
+  const lineH = 7.5;
+
+  // Paragraph 1 — recite prior notice
+  const p1 =
+    `     ตามที่ท่านได้ผิดนัดชำระค่างวดเป็นเวลา ${data.contract.daysOverdue} วัน ` +
+    `ยอดค้างชำระรวม ${formatMoney(data.contract.outstanding)} บาท บริษัทฯ ` +
+    `ได้มีหนังสือแจ้งเตือนและให้โอกาสท่านชำระหนี้หรือส่งมอบเครื่องคืน` +
+    `แล้ว แต่ท่านมิได้ดำเนินการใด ๆ ภายในระยะเวลาที่กำหนด`;
+  const p1Lines = doc.splitTextToSize(p1, CONTENT_W);
+  doc.text(p1Lines, MARGIN, y);
+  y += p1Lines.length * lineH + 4;
+
+  // Paragraph 2 — termination declaration
+  doc.setFont(PDF_FONT_FAMILY, 'bold');
+  const p2 =
+    `     บริษัทฯ จึงขอบอกเลิกสัญญาเช่าซื้อฉบับดังกล่าวโดยมีผลทันทีนับ` +
+    `แต่วันที่ท่านได้รับหนังสือนี้`;
+  const p2Lines = doc.splitTextToSize(p2, CONTENT_W);
+  doc.text(p2Lines, MARGIN, y);
+  doc.setFont(PDF_FONT_FAMILY, 'normal');
+  y += p2Lines.length * lineH + 4;
+
+  // Paragraph 3 — legal action notice
+  const p3 =
+    `     นับแต่นี้ บริษัทฯ จะมอบหมายให้ทนายความดำเนินคดีทางแพ่งและ` +
+    `ทางอาญาเพื่อเรียกคืนทรัพย์สินและค่าเสียหายทั้งปวงตามกฎหมาย รวมถึง` +
+    `ดำเนินการผ่านระบบ MDM เพื่อระงับการใช้งานอุปกรณ์ดังกล่าวโดยทันที`;
+  const p3Lines = doc.splitTextToSize(p3, CONTENT_W);
+  doc.text(p3Lines, MARGIN, y);
+  y += p3Lines.length * lineH + 4;
+
+  // Paragraph 4 — settlement invitation
+  const p4 =
+    `     อย่างไรก็ตาม หากท่านประสงค์จะเจรจาประนอมหนี้ กรุณาติดต่อ` +
+    `บริษัทฯ ภายใน 7 วันนับแต่วันที่ได้รับหนังสือฉบับนี้`;
+  const p4Lines = doc.splitTextToSize(p4, CONTENT_W);
+  doc.text(p4Lines, MARGIN, y);
+  return y + p4Lines.length * lineH + 6;
+}
+
+/**
+ * Renders the closing "ขอแสดงความนับถือ" + signature block.
+ * Signature image floats above the printed name.
+ */
+function signatureBlock(
+  doc: jsPDF,
+  data: LetterTemplateData,
+  yStart: number,
+  signatureDataUrl: string | null,
+): void {
+  const rightX = PAGE_W - MARGIN - 65;
+  let y = yStart;
+
+  doc.setFontSize(14);
+  doc.setFont(PDF_FONT_FAMILY, 'normal');
+  doc.text('ขอแสดงความนับถือ', rightX, y);
+  y += 6;
+
+  if (signatureDataUrl) {
+    try {
+      doc.addImage(signatureDataUrl, 'PNG', rightX, y, 50, 20);
+    } catch {
+      // Signature image is best-effort
+    }
+    y += 22;
+  } else {
+    // Blank signature line
+    doc.setDrawColor(150);
+    doc.setLineWidth(0.3);
+    doc.line(rightX, y + 12, rightX + 60, y + 12);
+    y += 18;
+  }
+
+  doc.setFont(PDF_FONT_FAMILY, 'bold');
+  doc.text(`(${data.company.directorName})`, rightX, y);
+  y += 6;
+  doc.setFont(PDF_FONT_FAMILY, 'normal');
+  doc.setFontSize(12);
+  if (data.company.directorPosition) {
+    doc.text(data.company.directorPosition, rightX, y);
+    y += 6;
+  }
+  doc.text(data.company.nameTh, rightX, y);
+}
+
+/**
+ * Renders the small footer at the very bottom of the page:
+ * company taxId + address + phone in muted text.
+ */
+function footerBlock(doc: jsPDF, data: LetterTemplateData): void {
+  doc.setFontSize(9);
+  doc.setTextColor(130);
+  const parts = [
+    data.company.nameTh,
+    `เลขประจำตัวผู้เสียภาษี ${data.company.taxId}`,
+    data.company.address,
+    data.company.phone ? `โทร ${data.company.phone}` : null,
+  ]
+    .filter(Boolean)
+    .join('  ·  ');
+  const lines = doc.splitTextToSize(parts, CONTENT_W);
+  doc.text(lines, MARGIN, PAGE_H - MARGIN + 3);
+  doc.setTextColor(0);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Renders a legal letter PDF and returns it as a Blob.
+ *
+ * @example
+ * const blob = await renderLetterPdf(data);
+ * const url = URL.createObjectURL(blob);
+ * window.open(url);
+ */
+export async function renderLetterPdf(data: LetterTemplateData): Promise<Blob> {
+  const doc = new jsPDF({ unit: 'mm', format: 'a4', orientation: 'portrait' });
+
+  // Load Thai font — uses module-level cache so subsequent calls are instant
+  await loadThaiFont(doc);
+
+  // Activate font; fall back to helvetica if font loading failed entirely
+  if (_fontCache['THSarabunPSK-Regular']) {
+    doc.setFont(PDF_FONT_FAMILY, 'normal');
+  } else {
+    doc.setFont('helvetica', 'normal');
+  }
+
+  // Fetch optional images in parallel
+  const [logoDataUrl, signatureDataUrl] = await Promise.all([
+    data.company.logoUrl ? loadImageAsDataUrl(data.company.logoUrl) : Promise.resolve(null),
+    data.company.signatureUrl
+      ? loadImageAsDataUrl(data.company.signatureUrl)
+      : Promise.resolve(null),
+  ]);
+
+  // ── Render sections ──────────────────────────────────────────────────────
+  headerBlock(doc, data, logoDataUrl);
+
+  const titleMap: Record<LetterTemplateData['letterType'], string> = {
+    RETURN_DEVICE_45D: 'หนังสือทวงถามและเรียกให้ส่งมอบเครื่องคืน',
+    CONTRACT_TERMINATION_60D: 'หนังสือบอกเลิกสัญญาและแจ้งดำเนินคดีทางกฎหมาย',
+  };
+
+  let y = titleBlock(doc, titleMap[data.letterType], MARGIN + 32);
+  y = addressBlock(doc, data, y);
+
+  y =
+    data.letterType === 'RETURN_DEVICE_45D'
+      ? bodyReturnDevice45D(doc, data, y)
+      : bodyContractTermination60D(doc, data, y);
+
+  signatureBlock(doc, data, y + 8, signatureDataUrl);
+  footerBlock(doc, data);
+
+  return doc.output('blob');
+}

--- a/apps/web/src/pages/CollectionsPage/utils/letterPdfRenderer.ts
+++ b/apps/web/src/pages/CollectionsPage/utils/letterPdfRenderer.ts
@@ -11,6 +11,8 @@
  */
 
 import { jsPDF } from 'jspdf';
+import { formatThaiDateLong } from '@/lib/date';
+import { formatNumberDecimal } from '@/utils/formatters';
 
 // ── Page geometry (A4 portrait, mm) ───────────────────────────────────────────
 const PAGE_W = 210;
@@ -106,21 +108,19 @@ async function loadImageAsDataUrl(url: string): Promise<string | null> {
   }
 }
 
-// ── Date formatter ────────────────────────────────────────────────────────────
+// ── Date & money formatters ───────────────────────────────────────────────────
+//
+// Legal letters are court-submitted documents — dates MUST render in พ.ศ.
+// (Thai Buddhist Era) consistently. We use the shared `formatThaiDateLong`
+// helper from `@/lib/date` (e.g. "8 เมษายน 2569") instead of
+// `toLocaleDateString('th-TH', ...)` whose output varies by browser/ICU
+// version (some environments render ค.ศ. or drop the พ.ศ. offset entirely).
+//
+// Money is formatted via the shared `formatNumberDecimal` (th-TH locale,
+// 2 decimal places) — keeps PDF output identical to on-screen displays.
 
-function formatThaiDate(d: Date): string {
-  return d.toLocaleDateString('th-TH', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
-}
-
-// ── Number formatter ──────────────────────────────────────────────────────────
-
-function formatMoney(n: number): string {
-  return n.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-}
+const formatThaiDate = (d: Date): string => formatThaiDateLong(d);
+const formatMoney = (n: number): string => formatNumberDecimal(n, 2);
 
 // ── Section renderers ─────────────────────────────────────────────────────────
 

--- a/apps/web/src/pages/DunningSettingsPage.tsx
+++ b/apps/web/src/pages/DunningSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -12,6 +12,9 @@ import {
   Link2,
   ToggleLeft,
   ToggleRight,
+  FileSignature,
+  Upload,
+  Image as ImageIcon,
 } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
@@ -19,6 +22,7 @@ import Modal from '@/components/ui/Modal';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import QueryBoundary from '@/components/QueryBoundary';
 import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import { getStatusBadgeProps, dunningChannelMap } from '@/lib/status-badges';
 
 interface DunningRule {
@@ -87,6 +91,98 @@ function getTriggerBadgeCls(day: number): string {
   if (day <= 7) return 'bg-warning/30 text-warning border border-warning/40';
   if (day <= 30) return 'bg-destructive/20 text-destructive border border-destructive/30';
   return 'bg-destructive/30 text-destructive border border-destructive/40';
+}
+
+interface ConfigItem {
+  key: string;
+  value: string;
+}
+
+function LetterAssetField({
+  label,
+  hint,
+  currentUrl,
+  uploadKind,
+  onSaved,
+}: {
+  label: string;
+  hint: string;
+  currentUrl: string;
+  uploadKind: 'LETTER_SIGNATURE' | 'LETTER_LETTERHEAD';
+  onSaved: (url: string) => void;
+}) {
+  const [uploading, setUploading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = async (file: File) => {
+    setUploading(true);
+    try {
+      const { data: presigned } = await api.post('/shop/upload/signed-url', {
+        kind: uploadKind,
+        contentType: file.type,
+      });
+      const up = await fetch(presigned.uploadUrl, {
+        method: presigned.method ?? 'PUT',
+        body: file,
+        headers: { 'Content-Type': file.type },
+      });
+      if (!up.ok) throw new Error('Upload failed');
+      onSaved(presigned.publicUrl);
+      toast.success('อัปโหลดสำเร็จ');
+    } catch (err) {
+      toast.error(getErrorMessage(err));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="text-xs font-medium mb-1">{label}</div>
+      <div className="text-xs text-muted-foreground mb-2">{hint}</div>
+      <div className="flex items-center gap-3">
+        {currentUrl ? (
+          <div className="shrink-0 size-16 rounded-lg border border-border bg-muted/30 p-1 flex items-center justify-center overflow-hidden">
+            <img src={currentUrl} alt={label} className="max-w-full max-h-full object-contain" />
+          </div>
+        ) : (
+          <div className="shrink-0 size-16 rounded-lg border border-dashed border-border bg-muted/20 flex items-center justify-center">
+            <ImageIcon className="size-5 text-muted-foreground" />
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/png,image/jpeg"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleChange(f);
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            disabled={uploading}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border border-input hover:bg-muted disabled:opacity-50"
+          >
+            <Upload className="size-3.5" />{' '}
+            {uploading ? 'กำลังอัปโหลด...' : currentUrl ? 'เปลี่ยนรูป' : 'อัปโหลด'}
+          </button>
+          {currentUrl && (
+            <button
+              type="button"
+              onClick={() => onSaved('')}
+              className="ml-2 text-xs text-muted-foreground hover:text-destructive"
+            >
+              ลบ
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function DunningSettingsPage() {
@@ -164,6 +260,23 @@ export default function DunningSettingsPage() {
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });
 
+  const { data: configs = [] } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  const signatureUrl = configs.find((s) => s.key === 'letter_signature_url')?.value ?? '';
+  const letterheadUrl = configs.find((s) => s.key === 'letter_letterhead_url')?.value ?? '';
+
+  const configMutation = useMutation({
+    mutationFn: async (items: Array<{ key: string; value: string }>) =>
+      (await api.patch('/settings', { items })).data,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['settings'] }),
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+
+  const saveConfig = (key: string, value: string) => configMutation.mutate([{ key, value }]);
+
   const openCreate = () => {
     setEditId(null);
     setForm(defaultForm);
@@ -235,6 +348,43 @@ export default function DunningSettingsPage() {
           </button>
         }
       />
+
+      {/* Letter Settings Card */}
+      <Card className="rounded-xl border border-border/50 bg-card shadow-sm mb-6">
+        <CardContent className="p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <FileSignature className="size-4 text-primary" />
+            <div className="text-sm font-semibold">ตั้งค่าหนังสือทวงถาม</div>
+          </div>
+          <p className="text-xs text-muted-foreground mb-4 leading-snug">
+            ตั้งค่าลายเซ็นและหัวกระดาษสำหรับหนังสือ 45 วัน และ 60 วัน —
+            PDF จะถูกสร้างโดยใช้ข้อมูลนี้
+          </p>
+
+          <div className="space-y-4">
+            <LetterAssetField
+              label="ลายเซ็นต์ผู้มีอำนาจ *"
+              hint="PNG 200×80px พื้นหลังโปร่งใส"
+              currentUrl={signatureUrl}
+              uploadKind="LETTER_SIGNATURE"
+              onSaved={(url) => saveConfig('letter_signature_url', url)}
+            />
+            <LetterAssetField
+              label="หัวกระดาษ (ไม่บังคับ)"
+              hint="PNG 600×100px แนวนอน"
+              currentUrl={letterheadUrl}
+              uploadKind="LETTER_LETTERHEAD"
+              onSaved={(url) => saveConfig('letter_letterhead_url', url)}
+            />
+          </div>
+
+          {!signatureUrl && (
+            <div className="mt-4 rounded-lg bg-warning/5 border border-warning/20 p-3 text-xs text-warning leading-snug">
+              ยังไม่ได้อัปโหลดลายเซ็น — PDF ที่สร้างจะไม่มีลายเซ็น โปรดอัปโหลดก่อนใช้งานจริง
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Event-triggered rules — read-only (Plan 2+ will add editing) */}
       {eventRules.length > 0 && (

--- a/docs/superpowers/plans/2026-04-24-collections-legal-letters-plan.md
+++ b/docs/superpowers/plans/2026-04-24-collections-legal-letters-plan.md
@@ -1,0 +1,1008 @@
+# Collections Workflow Hub — Plan 4/4: Legal Letters
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. UI tasks MUST invoke `frontend-design` skill before coding.
+
+**Goal:** Ship the legal-notice infrastructure that closes the `LEGAL_ACTION` workflow gap: 45-day "return device" and 60-day "contract termination + legal action" registered letters. Manual-dispatch MVP — OWNER generates PDF in browser, prints, mails via EMS, returns to enter tracking#. Evidence chain (PDF snapshot + tracking + dispatch receipt photo) satisfies Thai court requirements.
+
+**Architecture:** Client-side PDF via jsPDF (matches existing project pattern; no new npm deps). Backend manages ContractLetter state machine + auto-generate cron. OWNER queue lives in existing ApprovalTab. Thailand Post Connect API deferred to Phase B.
+
+**Tech Stack:** NestJS + Prisma (backend state machine + cron) + React + jsPDF 4 + jspdf-autotable (already in web deps) + StorageService (existing S3/GCS abstraction).
+
+**Spec:** [docs/superpowers/specs/2026-04-24-collections-workflow-hub-design.md](../specs/2026-04-24-collections-workflow-hub-design.md) §6.
+
+**Depends on:** Plan 3 branch `feat/collections-power-features`. Plan 1 already created `ContractLetter` model + `ContractLetterService` skeleton (createIfNotExists + cancel) + 5 SystemConfig keys.
+
+---
+
+## File Map
+
+### Create — Backend
+
+- `apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts` + `.spec.ts`
+- `apps/api/src/modules/overdue/dto/letter-dispatch.dto.ts`
+
+### Modify — Backend
+
+- `apps/api/src/modules/overdue/contract-letter.service.ts` — add `list`, `markPdfGenerated`, `markDispatched`, `markDelivered`
+- `apps/api/src/modules/overdue/contract-letter.service.spec.ts` — extend
+- `apps/api/src/modules/overdue/overdue.controller.ts` — 6 new endpoints
+- `apps/api/src/modules/overdue/overdue.module.ts` — register cron
+
+### Create — Frontend
+
+```
+apps/web/src/pages/CollectionsPage/
+  components/
+    LetterQueueSection.tsx            # inside ApprovalTab
+    LetterDispatchDialog.tsx          # generate PDF + print + enter tracking#
+    LetterSettingsCard.tsx            # small card on DunningSettingsPage (Plan 4)
+  hooks/
+    useLetterQueue.ts
+    useLetterActions.ts
+  utils/
+    letterPdfRenderer.ts              # client-side jsPDF builder, 2 templates
+```
+
+### Modify — Frontend
+
+- `apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx` — add `<LetterQueueSection />` as 3rd section
+- `apps/web/src/pages/DunningSettingsPage.tsx` — add signature + letterhead upload card
+
+---
+
+## Design brief — "Courthouse-grade paper, screen-calm UI"
+
+The letter itself is the hero — black ink on white, serif-ish for authority, exact legal wording. The UI around it stays Operations Room.
+
+**PDF design (jsPDF):**
+- A4 portrait. Margins 25mm top/bottom/left/right.
+- Header: company letterhead image (if configured) at top-left, letter number + date at top-right. Black rule line below.
+- Body: Thai text with Sarabun or IBM Plex Sans Thai (embed via jsPDF `addFileToVFS`). 14pt body, 1.5 line-height.
+- Footer: director's printed name + "(ลายมือชื่อ)" block, signature image (if configured). Company name + taxId + address in small gray text at very bottom.
+- No color except letterhead/signature. Black/white only. **Tabular-nums** on amount and contract#.
+
+**UI screen-side:**
+- Queue section in ApprovalTab shows PENDING + PDF_GENERATED letters only.
+- Each row: letter number + contract# + letter type chip + days-since-triggered + status chip + CTA button.
+- Status-specific CTAs:
+  - PENDING_DISPATCH → [สร้าง PDF] (opens dialog → generates + uploads → flips to PDF_GENERATED)
+  - PDF_GENERATED → [ดาวน์โหลด PDF] + [บันทึกส่งแล้ว] (opens dispatch dialog for tracking + evidence)
+  - DISPATCHED → [ทำเครื่องหมายรับ] (mark delivered) or [คืน] (mark undeliverable)
+- Cancel option behind a small trash icon for PENDING_DISPATCH/PDF_GENERATED only.
+
+---
+
+## Task 1: Extend ContractLetterService
+
+### Files
+- Modify: `apps/api/src/modules/overdue/contract-letter.service.ts`
+- Modify: `apps/api/src/modules/overdue/contract-letter.service.spec.ts`
+
+### New methods
+
+```typescript
+/**
+ * List letters matching a status filter, newest-triggered first.
+ * Includes contract + customer for display in OWNER queue.
+ */
+async list(params: {
+  status?: LetterStatus;
+  letterType?: LetterType;
+  branchId?: string;
+  limit?: number;
+}) {
+  const where: Prisma.ContractLetterWhereInput = {
+    deletedAt: null,
+    ...(params.status && { status: params.status }),
+    ...(params.letterType && { letterType: params.letterType }),
+    ...(params.branchId && { contract: { branchId: params.branchId } }),
+  };
+  return this.prisma.contractLetter.findMany({
+    where,
+    include: {
+      contract: {
+        select: {
+          id: true,
+          contractNumber: true,
+          customer: { select: { id: true, name: true, phone: true, address: true } },
+          branch: { select: { id: true, name: true } },
+        },
+      },
+    },
+    orderBy: { triggeredAt: 'desc' },
+    take: params.limit ?? 100,
+  });
+}
+
+/** After client generates PDF and uploads to S3, backend records the URL. */
+async markPdfGenerated(letterId: string, pdfUrl: string, userId: string) {
+  const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+  if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+  if (letter.status !== 'PENDING_DISPATCH') {
+    throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ PENDING_DISPATCH');
+  }
+  return this.prisma.$transaction([
+    this.prisma.contractLetter.update({
+      where: { id: letterId },
+      data: { status: 'PDF_GENERATED', pdfUrl, pdfGeneratedAt: new Date() },
+    }),
+    this.prisma.auditLog.create({
+      data: { userId, action: 'LETTER_PDF_GENERATED', entity: 'contract_letter', entityId: letterId, newValue: { pdfUrl } },
+    }),
+  ]).then(([l]) => l);
+}
+
+async markDispatched(
+  letterId: string,
+  userId: string,
+  params: { trackingNumber: string; evidencePhotoUrl?: string },
+) {
+  const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+  if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+  if (letter.status !== 'PDF_GENERATED') {
+    throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ PDF_GENERATED');
+  }
+  if (!params.trackingNumber || params.trackingNumber.trim().length < 5) {
+    throw new BadRequestException('เลข tracking EMS ต้อง ≥ 5 ตัวอักษร');
+  }
+
+  const [updated] = await this.prisma.$transaction([
+    this.prisma.contractLetter.update({
+      where: { id: letterId },
+      data: {
+        status: 'DISPATCHED',
+        dispatchedAt: new Date(),
+        dispatchedById: userId,
+        trackingNumber: params.trackingNumber.trim(),
+        evidencePhotoUrl: params.evidencePhotoUrl ?? null,
+      },
+    }),
+    this.prisma.auditLog.create({
+      data: {
+        userId,
+        action: 'LETTER_DISPATCHED',
+        entity: 'contract_letter',
+        entityId: letterId,
+        newValue: { trackingNumber: params.trackingNumber, evidencePhotoUrl: params.evidencePhotoUrl ?? null },
+      },
+    }),
+  ]);
+
+  // Fire LINE event — non-fatal
+  try {
+    await this.dunningEngine.executeEventTrigger(
+      'LETTER_DISPATCHED',
+      letter.contractId,
+      null,
+      null,
+      { trackingNumber: params.trackingNumber },
+    );
+  } catch {
+    // already logged by engine
+  }
+
+  // If CONTRACT_TERMINATION_60D, also fire CONTRACT_TERMINATED event
+  if (letter.letterType === 'CONTRACT_TERMINATION_60D') {
+    try {
+      await this.dunningEngine.executeEventTrigger('CONTRACT_TERMINATED', letter.contractId, null, null);
+    } catch { /* non-fatal */ }
+  }
+
+  return updated;
+}
+
+async markDelivered(letterId: string, userId: string) {
+  const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+  if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+  if (letter.status !== 'DISPATCHED') {
+    throw new BadRequestException('สถานะไม่ถูกต้อง — ต้องอยู่ในสถานะ DISPATCHED');
+  }
+  return this.prisma.$transaction([
+    this.prisma.contractLetter.update({
+      where: { id: letterId },
+      data: { status: 'DELIVERED', deliveredAt: new Date() },
+    }),
+    this.prisma.auditLog.create({
+      data: { userId, action: 'LETTER_DELIVERED', entity: 'contract_letter', entityId: letterId },
+    }),
+  ]).then(([l]) => l);
+}
+
+async markUndeliverable(letterId: string, userId: string, reason: string) {
+  if (!reason || reason.trim().length < 5) {
+    throw new BadRequestException('เหตุผลต้อง ≥ 5 ตัวอักษร');
+  }
+  const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+  if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+  if (letter.status !== 'DISPATCHED') {
+    throw new BadRequestException('สถานะไม่ถูกต้อง');
+  }
+  return this.prisma.$transaction([
+    this.prisma.contractLetter.update({
+      where: { id: letterId },
+      data: { status: 'UNDELIVERABLE', cancelReason: reason.trim(), cancelledAt: new Date() },
+    }),
+    this.prisma.contract.update({
+      where: { id: letter.contractId },
+      data: { needsSkipTracing: true },
+    }),
+    this.prisma.auditLog.create({
+      data: { userId, action: 'LETTER_UNDELIVERABLE', entity: 'contract_letter', entityId: letterId, newValue: { reason } },
+    }),
+  ]).then(([l]) => l);
+}
+```
+
+Also: inject `DunningEngineService` into the constructor so `executeEventTrigger` is callable.
+
+### Tests
+
+Extend existing spec with 10+ new tests:
+- list filters by status/type/branch
+- markPdfGenerated: only PENDING_DISPATCH → PDF_GENERATED; records URL + timestamp
+- markPdfGenerated rejects non-PENDING
+- markDispatched validates tracking length ≥ 5
+- markDispatched fires LETTER_DISPATCHED event
+- markDispatched fires CONTRACT_TERMINATED for 60D letter type
+- markDelivered: DISPATCHED → DELIVERED
+- markUndeliverable flips contract.needsSkipTracing = true
+- markUndeliverable requires reason
+
+### Commit
+`feat(overdue): ContractLetterService full state machine (list/pdf/dispatch/delivered/undeliverable)`
+
+---
+
+## Task 2: letter-auto-generate cron
+
+### Files
+- Create: `apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts` + `.spec.ts`
+- Modify: `apps/api/src/modules/overdue/overdue.module.ts`
+
+### Behavior
+
+Daily 09:15 (after mdm-auto-propose at 09:00 to avoid load spikes). Respects `letter_auto_generate_enabled` flag (default false — OWNER must review templates before first auto-run).
+
+Scan contracts:
+- For `RETURN_DEVICE_45D`: OVERDUE ≥ `letter_return_device_days` (45) days, has overdue payments, no existing letter of this type
+- For `CONTRACT_TERMINATION_60D`: OVERDUE ≥ `letter_termination_days` (60) days, no existing letter of this type
+
+Create via `ContractLetterService.createIfNotExists` (already idempotent). Notify OWNER via LINE (single "N letters pending" message) — optional, skip if no LINE for OWNER user.
+
+```typescript
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ContractLetterService } from '../contract-letter.service';
+
+@Injectable()
+export class LetterAutoGenerateCron {
+  private readonly logger = new Logger(LetterAutoGenerateCron.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private letterService: ContractLetterService,
+  ) {}
+
+  @Cron('15 9 * * *')
+  async run(): Promise<{ returnDevice: number; termination: number }> {
+    try {
+      const enabled = await this.prisma.systemConfig.findUnique({
+        where: { key: 'letter_auto_generate_enabled' },
+      });
+      if (enabled?.value !== 'true') {
+        this.logger.log('letter_auto_generate_enabled=false — skipping');
+        return { returnDevice: 0, termination: 0 };
+      }
+
+      const returnDays = Number(
+        (await this.prisma.systemConfig.findUnique({ where: { key: 'letter_return_device_days' } }))?.value ?? 45,
+      );
+      const terminationDays = Number(
+        (await this.prisma.systemConfig.findUnique({ where: { key: 'letter_termination_days' } }))?.value ?? 60,
+      );
+
+      const now = new Date();
+      const returnThreshold = new Date(now.getTime() - returnDays * 86400000);
+      const terminationThreshold = new Date(now.getTime() - terminationDays * 86400000);
+
+      const returnCandidates = await this.prisma.contract.findMany({
+        where: {
+          status: { in: ['OVERDUE', 'DEFAULT'] },
+          deletedAt: null,
+          payments: {
+            some: {
+              dueDate: { lt: returnThreshold },
+              status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+            },
+          },
+          contractLetters: {
+            none: { letterType: 'RETURN_DEVICE_45D', deletedAt: null },
+          },
+        },
+        select: { id: true },
+      });
+
+      let returnDevice = 0;
+      for (const { id } of returnCandidates) {
+        try {
+          await this.letterService.createIfNotExists(id, 'RETURN_DEVICE_45D');
+          returnDevice++;
+        } catch (err) {
+          Sentry.captureException(err, { tags: { cron: 'letter-auto-generate', letterType: 'RETURN_DEVICE_45D' }, extra: { contractId: id } });
+        }
+      }
+
+      const terminationCandidates = await this.prisma.contract.findMany({
+        where: {
+          status: { in: ['OVERDUE', 'DEFAULT'] },
+          deletedAt: null,
+          payments: {
+            some: {
+              dueDate: { lt: terminationThreshold },
+              status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+            },
+          },
+          contractLetters: {
+            none: { letterType: 'CONTRACT_TERMINATION_60D', deletedAt: null },
+          },
+        },
+        select: { id: true },
+      });
+
+      let termination = 0;
+      for (const { id } of terminationCandidates) {
+        try {
+          await this.letterService.createIfNotExists(id, 'CONTRACT_TERMINATION_60D');
+          termination++;
+        } catch (err) {
+          Sentry.captureException(err, { tags: { cron: 'letter-auto-generate', letterType: 'CONTRACT_TERMINATION_60D' }, extra: { contractId: id } });
+        }
+      }
+
+      this.logger.log(`Letter auto-generate: return_device=${returnDevice}, termination=${termination}`);
+      return { returnDevice, termination };
+    } catch (err) {
+      Sentry.captureException(err, { tags: { cron: 'letter-auto-generate' } });
+      this.logger.error(`letter-auto-generate failed: ${err instanceof Error ? err.message : err}`);
+      return { returnDevice: 0, termination: 0 };
+    }
+  }
+}
+```
+
+### Tests (mock-based)
+
+5+ tests:
+- Skips when flag disabled
+- Creates RETURN_DEVICE_45D for matching contracts
+- Creates CONTRACT_TERMINATION_60D for matching contracts
+- Deduplicates (existing letter prevents re-creation — verified via unique constraint)
+- Does not throw when individual create fails
+
+### Register in module
+
+Add `LetterAutoGenerateCron` to providers.
+
+### Commit
+`feat(overdue): letter-auto-generate cron (daily 09:15, flag-gated)`
+
+---
+
+## Task 3: Backend endpoints
+
+### File
+- Modify: `apps/api/src/modules/overdue/overdue.controller.ts`
+
+### Routes
+
+```typescript
+  @Get('letters')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
+  listLetters(
+    @Query('status') status?: string,
+    @Query('letterType') letterType?: string,
+    @CurrentUser() user?: { role: string; branchId: string | null },
+  ) {
+    return this.contractLetterService.list({
+      status: status as any,
+      letterType: letterType as any,
+      branchId: user?.role === 'BRANCH_MANAGER' ? user.branchId ?? undefined : undefined,
+    });
+  }
+
+  @Post('letters/:id/pdf-generated')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markPdfGenerated(
+    @Param('id') id: string,
+    @Body() body: { pdfUrl: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markPdfGenerated(id, body.pdfUrl, user.id);
+  }
+
+  @Post('letters/:id/dispatch')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  dispatchLetter(
+    @Param('id') id: string,
+    @Body() body: { trackingNumber: string; evidencePhotoUrl?: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markDispatched(id, user.id, body);
+  }
+
+  @Post('letters/:id/delivered')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markLetterDelivered(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markDelivered(id, user.id);
+  }
+
+  @Post('letters/:id/undeliverable')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  markLetterUndeliverable(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.markUndeliverable(id, user.id, body.reason);
+  }
+
+  @Post('letters/:id/cancel')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  cancelLetter(
+    @Param('id') id: string,
+    @Body() body: { reason: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.cancel(id, user.id, body.reason);
+  }
+```
+
+Inject `ContractLetterService` in controller constructor.
+
+### Commit
+`feat(overdue): contract-letter endpoints (list/pdf/dispatch/delivered/undeliverable/cancel)`
+
+---
+
+## Task 4: Frontend — letterPdfRenderer utility
+
+Invoke `frontend-design` skill first. Design brief above (PDF section).
+
+### File
+- Create: `apps/web/src/pages/CollectionsPage/utils/letterPdfRenderer.ts`
+
+### Responsibilities
+
+1. Render an A4 Thai PDF (jsPDF + Sarabun font OR fall back to system default if font not loaded — Thai glyphs may look ugly without the embed, but not fatal for MVP)
+2. Accept contract + letter + company info data object
+3. Return `Blob` for upload
+
+### Font handling
+
+This is the trickiest bit. Existing `apps/web/src/components/template-editor/pdf/pdfGenerator.ts:16` has `loadThaiFont(doc: jsPDF)` — copy or import that function. Reuse the pattern.
+
+### Two templates
+
+```typescript
+export type LetterTemplateData = {
+  letterType: 'RETURN_DEVICE_45D' | 'CONTRACT_TERMINATION_60D';
+  letterNumber: string;
+  letterDate: Date;
+  company: {
+    nameTh: string;
+    taxId: string;
+    address: string;
+    phone?: string;
+    directorName: string;
+    directorPosition?: string;
+    logoUrl?: string | null;
+    signatureUrl?: string | null;
+  };
+  customer: {
+    name: string;
+    address?: string | null;
+  };
+  contract: {
+    contractNumber: string;
+    contractDate?: Date;
+    outstanding: number;
+    daysOverdue: number;
+  };
+};
+
+export async function renderLetterPdf(data: LetterTemplateData): Promise<Blob> {
+  // See template below
+}
+```
+
+### Template content — RETURN_DEVICE_45D
+
+Rough structure (Thai):
+
+```
+[logo]                                                      [letterNumber]
+                                                            [date]
+
+                                   หนังสือทวงถามและเรียกให้ส่งมอบเครื่องคืน
+
+เรียน [customer.name]
+      [customer.address]
+
+อ้างถึง สัญญาเช่าซื้อเลขที่ [contract.contractNumber]
+       ลงวันที่ [contract.contractDate]
+
+ด้วยท่านได้ทำสัญญาเช่าซื้อกับ [company.nameTh] และมีภาระค้างชำระเป็นเวลา
+[daysOverdue] วัน เป็นจำนวนเงินรวมทั้งสิ้น [outstanding] บาท บริษัทฯ
+ได้ดำเนินการติดตามทวงถามแล้วแต่ไม่สามารถติดต่อท่านได้
+
+บัดนี้ บริษัทฯ จึงขอบอกกล่าวให้ท่านดำเนินการอย่างใดอย่างหนึ่งดังนี้ ภายใน
+15 วัน นับแต่วันที่ได้รับหนังสือฉบับนี้:
+   1. ชำระยอดค้างทั้งหมด [outstanding] บาท
+   2. ส่งมอบเครื่องที่เช่าซื้อคืนแก่บริษัทฯ
+
+หากท่านไม่ดำเนินการภายในกำหนดเวลาดังกล่าว บริษัทฯ จะดำเนินการตาม
+กระบวนการทางกฎหมายต่อไป
+
+                                  ขอแสดงความนับถือ
+
+
+                                  ([company.directorName])
+                                  [company.directorPosition]
+                                  [company.nameTh]
+
+[small footer: nameTh · taxId · address · phone]
+```
+
+### Template content — CONTRACT_TERMINATION_60D
+
+Stronger language:
+
+```
+                            หนังสือบอกเลิกสัญญาและแจ้งดำเนินคดีทางกฎหมาย
+
+เรียน [name]
+
+อ้างถึง สัญญาเช่าซื้อเลขที่ [contract.contractNumber]
+       ลงวันที่ [contract.contractDate]
+       หนังสือทวงถามครั้งก่อน เลขที่ ... (ถ้ามี)
+
+ด้วยท่านได้ผิดนัดชำระเป็นเวลา [daysOverdue] วัน ยอดค้างรวม [outstanding] บาท
+บริษัทฯ ได้มีหนังสือทวงถามให้ท่านชำระหนี้หรือส่งคืนเครื่องแล้ว แต่ท่านมิได้
+ดำเนินการใด ๆ
+
+บริษัทฯ จึงขอบอกเลิกสัญญาเช่าซื้อฉบับดังกล่าว มีผลทันที และจะส่งเรื่องให้
+ทนายความดำเนินคดีทางแพ่ง/อาญา เพื่อเรียกคืนเครื่องและค่าเสียหายต่อไป
+
+หากท่านต้องการเจรจาประนอมหนี้ กรุณาติดต่อบริษัทฯ ภายใน 7 วันนับแต่ได้รับ
+หนังสือนี้
+
+                                  ขอแสดงความนับถือ
+                                  ([company.directorName])
+```
+
+### Implementation hints
+
+- Use `doc.text(line, x, y, { maxWidth })` for word wrapping
+- Reuse layout for shared sections (header, footer, signature block)
+- Keep it functional, not clever — the text matters, not the code elegance
+- Return `doc.output('blob')` at end
+
+### Tests
+
+Optional. Visual tests are hard. Skip unit tests for the renderer — manual inspection of the generated PDF is the real test.
+
+### Commit
+`feat(collections): letter PDF renderer (client-side jsPDF with Thai font) — 2 templates`
+
+---
+
+## Task 5: Frontend — LetterQueueSection + useLetterQueue + useLetterActions
+
+Invoke `frontend-design` skill.
+
+### Files
+- Create: `apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx`
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useLetterQueue.ts`
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useLetterActions.ts`
+- Modify: `apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx` — add section
+
+### Hook: useLetterQueue
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface LetterRow {
+  id: string;
+  contractId: string;
+  letterType: 'RETURN_DEVICE_45D' | 'CONTRACT_TERMINATION_60D';
+  letterNumber: string;
+  status: 'PENDING_DISPATCH' | 'PDF_GENERATED' | 'DISPATCHED' | 'DELIVERED' | 'UNDELIVERABLE' | 'CANCELLED';
+  triggeredAt: string;
+  pdfUrl?: string | null;
+  pdfGeneratedAt?: string | null;
+  dispatchedAt?: string | null;
+  trackingNumber?: string | null;
+  contract: {
+    id: string;
+    contractNumber: string;
+    customer: { id: string; name: string; phone: string; address?: string | null };
+    branch: { id: string; name: string };
+  };
+}
+
+export function useLetterQueue() {
+  return useQuery<LetterRow[]>({
+    queryKey: ['letter-queue'],
+    queryFn: async () => {
+      // Only show actionable statuses in queue: PENDING_DISPATCH + PDF_GENERATED + DISPATCHED
+      const [pending, generated, dispatched] = await Promise.all([
+        api.get('/overdue/letters?status=PENDING_DISPATCH'),
+        api.get('/overdue/letters?status=PDF_GENERATED'),
+        api.get('/overdue/letters?status=DISPATCHED'),
+      ]);
+      return [...pending.data, ...generated.data, ...dispatched.data];
+    },
+  });
+}
+```
+
+### Hook: useLetterActions
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export function useLetterActions() {
+  const qc = useQueryClient();
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['letter-queue'] });
+
+  return {
+    markPdfGenerated: useMutation({
+      mutationFn: async (p: { letterId: string; pdfUrl: string }) =>
+        (await api.post(`/overdue/letters/${p.letterId}/pdf-generated`, { pdfUrl: p.pdfUrl })).data,
+      onSuccess: () => { toast.success('บันทึก PDF แล้ว'); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+    dispatch: useMutation({
+      mutationFn: async (p: { letterId: string; trackingNumber: string; evidencePhotoUrl?: string }) =>
+        (await api.post(`/overdue/letters/${p.letterId}/dispatch`, { trackingNumber: p.trackingNumber, evidencePhotoUrl: p.evidencePhotoUrl })).data,
+      onSuccess: () => { toast.success('บันทึกการส่งหนังสือแล้ว'); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+    markDelivered: useMutation({
+      mutationFn: async (letterId: string) =>
+        (await api.post(`/overdue/letters/${letterId}/delivered`)).data,
+      onSuccess: () => { toast.success('ทำเครื่องหมายรับแล้ว'); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+    markUndeliverable: useMutation({
+      mutationFn: async (p: { letterId: string; reason: string }) =>
+        (await api.post(`/overdue/letters/${p.letterId}/undeliverable`, { reason: p.reason })).data,
+      onSuccess: () => { toast.success('ทำเครื่องหมายส่งไม่ถึง'); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+    cancel: useMutation({
+      mutationFn: async (p: { letterId: string; reason: string }) =>
+        (await api.post(`/overdue/letters/${p.letterId}/cancel`, { reason: p.reason })).data,
+      onSuccess: () => { toast.success('ยกเลิกหนังสือแล้ว'); invalidate(); },
+      onError: (e) => toast.error(getErrorMessage(e)),
+    }),
+  };
+}
+```
+
+### LetterQueueSection
+
+Card with header (count pill + lucide `FileText` icon). List of `LetterRow` rendered as rows similar to `ApprovalPendingRow` pattern from Plan 2 Task 12. Each row has the CTAs described in the design brief above.
+
+Layout:
+```tsx
+<Card className="rounded-xl border border-border/50 bg-card shadow-sm">
+  <CardContent className="p-5">
+    <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center gap-2">
+        <FileText className="size-4 text-warning" />
+        <h3 className="text-sm font-semibold">หนังสือทวงถาม (รอดำเนินการ)</h3>
+      </div>
+      <span className="text-xs tabular-nums bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+        {letters?.length ?? 0}
+      </span>
+    </div>
+    {/* list or empty */}
+  </CardContent>
+</Card>
+```
+
+Each letter row (inline component or extract to `LetterQueueRow`):
+```tsx
+<div className="relative flex items-start gap-3 rounded-lg border border-border/50 p-3 bg-background hover:bg-muted/20 transition-colors">
+  <div className="shrink-0 size-10 rounded-lg bg-warning/10 text-warning flex items-center justify-center">
+    <FileText className="size-5" />
+  </div>
+
+  <div className="flex-1 min-w-0">
+    <div className="flex flex-wrap items-baseline gap-2 mb-1">
+      <span className="font-mono text-xs text-primary font-medium">{letter.letterNumber}</span>
+      <span className="text-sm font-semibold leading-snug">{letter.contract.customer.name}</span>
+      <span className="text-xs text-muted-foreground">({letter.contract.contractNumber})</span>
+    </div>
+    <div className="flex flex-wrap gap-1.5 text-2xs">
+      <span className={`rounded-full px-2 py-0.5 ${letterTypeStyle(letter.letterType)}`}>
+        {letterTypeLabel(letter.letterType)}
+      </span>
+      <span className="rounded-full px-2 py-0.5 bg-muted text-muted-foreground">
+        {letterStatusLabel(letter.status)}
+      </span>
+      <span className="text-muted-foreground">
+        สร้างเมื่อ {daysAgoLabel(letter.triggeredAt)}
+      </span>
+    </div>
+  </div>
+
+  <div className="flex flex-col gap-1.5 shrink-0">
+    {letter.status === 'PENDING_DISPATCH' && (
+      <button onClick={() => openDispatchDialog(letter, 'generate')} className={ctaBtn('primary')}>
+        สร้าง PDF
+      </button>
+    )}
+    {letter.status === 'PDF_GENERATED' && (
+      <>
+        <a href={letter.pdfUrl ?? '#'} target="_blank" rel="noopener" className={ctaBtn('secondary')}>
+          ดาวน์โหลด
+        </a>
+        <button onClick={() => openDispatchDialog(letter, 'dispatch')} className={ctaBtn('primary')}>
+          บันทึกส่งแล้ว
+        </button>
+      </>
+    )}
+    {letter.status === 'DISPATCHED' && (
+      <>
+        <button onClick={() => markDelivered.mutate(letter.id)} className={ctaBtn('secondary')}>
+          รับแล้ว
+        </button>
+        <button onClick={() => openUndeliverable(letter)} className={ctaBtn('destructive-outline')}>
+          คืน
+        </button>
+      </>
+    )}
+  </div>
+</div>
+```
+
+Helper functions for label + style — keep them top-of-file.
+
+Empty state: "ไม่มีหนังสือรอดำเนินการ 🎉"
+
+### Integrate into ApprovalTab
+
+Add `<LetterQueueSection />` as a third Card section after the existing dunning + MDM sections.
+
+### TS + commit
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && git add apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx apps/web/src/pages/CollectionsPage/hooks/useLetterQueue.ts apps/web/src/pages/CollectionsPage/hooks/useLetterActions.ts apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx && git commit -m "feat(collections): LetterQueueSection in ApprovalTab — list + actions per status"
+```
+
+---
+
+## Task 6: Frontend — LetterDispatchDialog
+
+Invoke `frontend-design` skill.
+
+### File
+- Create: `apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx`
+
+### Two modes
+
+1. `mode = 'generate'`: show a "สร้าง PDF" button — runs renderer → uploads via signed URL → calls markPdfGenerated → switches dialog to `dispatch` mode
+2. `mode = 'dispatch'`: show tracking# input + slip photo upload + "บันทึกส่งแล้ว" submit
+
+Props:
+```typescript
+interface Props {
+  open: boolean;
+  letter: LetterRow | null;
+  initialMode: 'generate' | 'dispatch';
+  onClose: () => void;
+}
+```
+
+### Generate mode UI
+
+```
+┌──────────────────────────────────────────────┐
+│ สร้าง PDF หนังสือ                              │
+├──────────────────────────────────────────────┤
+│ ลูกค้า: [customer.name]                        │
+│ เลขที่หนังสือ: [letterNumber]                   │
+│ ประเภท: [letterType label]                     │
+│                                                │
+│ [สร้าง PDF] [ยกเลิก]                            │
+└──────────────────────────────────────────────┘
+```
+
+Click "สร้าง PDF":
+1. Fetch company info (`GET /settings/company` or similar — check what endpoint exists; if not, use a fallback with hardcoded values from CompanyInfo.companyCode='FINANCE')
+2. Fetch full contract detail (for contractDate, outstanding, etc.)
+3. Call `renderLetterPdf({...})` → Blob
+4. POST blob to signed URL upload endpoint: check existing pattern — look at `apps/web/src/pages/` for S3 upload patterns. Often `POST /storage/signed-url` to get URL, then PUT blob to that URL.
+5. Call `markPdfGenerated.mutate({ letterId, pdfUrl })`
+6. Switch dialog to `dispatch` mode and populate.
+
+Pseudo-code:
+```typescript
+async function handleGenerate() {
+  setBusy(true);
+  try {
+    // 1. Load data
+    const [company, contract] = await Promise.all([
+      api.get('/settings/company/FINANCE').then((r) => r.data).catch(() => null),  // fallback
+      api.get(`/contracts/${letter.contractId}`).then((r) => r.data),
+    ]);
+
+    // 2. Load signature/letterhead URLs from SystemConfig
+    const [sigCfg, lhCfg] = await Promise.all([
+      api.get('/settings').then((r) => r.data).catch(() => []),
+      // or a single-key endpoint if available
+    ]);
+
+    // 3. Render
+    const blob = await renderLetterPdf({
+      letterType: letter.letterType,
+      letterNumber: letter.letterNumber,
+      letterDate: new Date(),
+      company: { ...company, signatureUrl: sigCfg.find((c) => c.key === 'letter_signature_url')?.value },
+      customer: contract.customer,
+      contract: { contractNumber: contract.contractNumber, outstanding: ..., daysOverdue: ... },
+    });
+
+    // 4. Upload via signed URL
+    const key = `letters/${letter.id}/${letter.letterNumber}.pdf`;
+    const { uploadUrl, publicUrl } = await api.post('/storage/signed-url', { key, contentType: 'application/pdf' }).then((r) => r.data);
+    await fetch(uploadUrl, { method: 'PUT', body: blob, headers: { 'Content-Type': 'application/pdf' } });
+
+    // 5. Mark generated
+    await markPdfGenerated.mutateAsync({ letterId: letter.id, pdfUrl: publicUrl });
+
+    // 6. Switch mode
+    setMode('dispatch');
+    toast.success('สร้าง PDF สำเร็จ');
+  } catch (err) {
+    toast.error(`สร้าง PDF ไม่สำเร็จ: ${err instanceof Error ? err.message : err}`);
+  } finally {
+    setBusy(false);
+  }
+}
+```
+
+**NOTE:** The exact signed-url endpoint + response shape depends on what exists in the project. BEFORE coding, run `grep -rn "signed-url\|getSignedUrl\|presigned" apps/api/src/modules/storage/` to find the endpoint and adapt.
+
+If no signed-url endpoint exists yet, fallback option: POST `multipart/form-data` to a new `POST /overdue/letters/:id/upload-pdf` endpoint that the backend accepts via `@UseInterceptors(FileInterceptor)`. But that requires backend work — prefer reusing existing infra if it exists.
+
+### Dispatch mode UI
+
+```
+┌──────────────────────────────────────────────┐
+│ บันทึกการส่งหนังสือ                             │
+├──────────────────────────────────────────────┤
+│ เลข EMS tracking *                            │
+│ [_____________________________]                │
+│                                                │
+│ รูปใบรับส่ง (สลิปไปรษณีย์) ไม่บังคับ             │
+│ [เลือกไฟล์]                                     │
+│                                                │
+│ [บันทึกส่งแล้ว] [ยกเลิก]                         │
+└──────────────────────────────────────────────┘
+```
+
+Upload photo same way as PDF — via signed URL to `letters/:id/receipt-photo.jpg`.
+
+### Commit
+`feat(collections): LetterDispatchDialog — generate PDF + enter tracking#`
+
+---
+
+## Task 7: Frontend — Letter settings (signature + letterhead upload)
+
+Invoke `frontend-design` skill.
+
+### File
+- Modify: `apps/web/src/pages/DunningSettingsPage.tsx` — add a new Card section
+
+### Behavior
+
+OWNER uploads signature PNG + optional letterhead PNG. Saves as SystemConfig keys `letter_signature_url` + `letter_letterhead_url` (Plan 1 already seeded empty defaults).
+
+A small status note below: "ก่อนใช้งานหนังสือทวงถาม โปรดอัปโหลดลายเซ็นต์ผู้มีอำนาจ"
+
+### Upload helper
+
+Use the same signed-url pattern. If file input selected → upload → save URL to SystemConfig via `PATCH /settings` (existing bulk update endpoint).
+
+Layout:
+```tsx
+<Card className="rounded-xl border border-border/50 bg-card shadow-sm mb-6">
+  <CardContent className="p-5">
+    <div className="flex items-center gap-2 mb-3">
+      <FileSignature className="size-4 text-primary" />
+      <div className="text-sm font-semibold">ตั้งค่าหนังสือทวงถาม</div>
+    </div>
+    <p className="text-xs text-muted-foreground mb-4">
+      ตั้งค่าลายเซ็นและหัวกระดาษสำหรับหนังสือ RETURN_DEVICE_45D และ CONTRACT_TERMINATION_60D
+    </p>
+
+    <div className="space-y-4">
+      <UploadField
+        label="ลายเซ็นต์ผู้มีอำนาจ *"
+        description="PNG 200×80px พื้นหลังโปร่งใส"
+        currentUrl={signatureUrl}
+        onUpload={(url) => saveConfig('letter_signature_url', url)}
+      />
+      <UploadField
+        label="หัวกระดาษ (ไม่บังคับ)"
+        description="PNG 600×100px แนวนอน"
+        currentUrl={letterheadUrl}
+        onUpload={(url) => saveConfig('letter_letterhead_url', url)}
+      />
+    </div>
+  </CardContent>
+</Card>
+```
+
+`UploadField` is a small inline component: file input + preview (if URL set) + "ลบ" button.
+
+### Commit
+`feat(dunning-settings): letter signature + letterhead upload card`
+
+---
+
+## Task 8: E2E smoke + full sweep
+
+### Files
+- Modify: `apps/web/e2e/collections-smoke.spec.ts` — add letter queue visibility test
+
+Add test:
+- Login OWNER → /collections → click อนุมัติ → "หนังสือทวงถาม" card visible
+
+### Sweep
+
+```bash
+./tools/check-types.sh all                    # 0
+cd apps/api && npm test                       # all pass
+cd apps/web && npm test -- --run               # all pass
+```
+
+### Commit
+`test(collections): e2e for letter queue visibility`
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+| Spec § | Task |
+|---|---|
+| §6.1 Letter types + triggers | 2 (cron) |
+| §6.2 Letter flow diagram | 1 (service) + 3 (endpoints) + 5 (UI) + 6 (dispatch) |
+| §6.3 PDF template | 4 (renderer) |
+| §6.4 Evidence chain | 1 (service) + 6 (tracking + slip upload) |
+| §6.5 Integration with dunning | 1 (fire LETTER_DISPATCHED + CONTRACT_TERMINATED events) |
+
+**Out of scope (respected):**
+- Thailand Post Connect API (manual dispatch MVP only)
+- OCR of dispatch slip
+- Courier alternatives (EMS only)
+- Multi-language letters
+- Automated legal packet bundle
+
+**Placeholder scan:** all tasks have complete code / exact commands / acceptance criteria. The only DYNAMIC part is the signed-url endpoint location — Task 6 explicitly instructs subagent to grep before coding.
+
+**Type consistency:** `LetterRow` / `LetterTemplateData` / `LetterStatus` / `LetterType` — single definitions in types.ts or hook files. Endpoint paths `/overdue/letters/*` consistent across backend + frontend.


### PR DESCRIPTION
## Summary

Plan 4/4 of the **Collections Workflow Hub** redesign. Ships the legal-notice infrastructure: RETURN_DEVICE_45D and CONTRACT_TERMINATION_60D registered letters. Manual-dispatch MVP — OWNER generates PDF in browser via jsPDF, prints, mails via EMS, returns to enter tracking#. Evidence chain (pdfUrl + trackingNumber + slip photo + audit trail) satisfies Thai hire-purchase court requirements.

**Base branch:** `feat/collections-power-features` (Plan 3) — merge Plan 3 first.

## What's shipped

### Backend
- ContractLetterService full state machine: `list` / `markPdfGenerated` / `markDispatched` / `markDelivered` / `markUndeliverable` — DunningEngine wired so LETTER_DISPATCHED + CONTRACT_TERMINATED LINE events fire on dispatch
- `letter-auto-generate.cron.ts` — daily 09:15, flag-gated via `letter_auto_generate_enabled` (default false)
- 6 controller endpoints under `/overdue/letters/*`
- Storage upload: extended UploadKind with LETTER_PDF / LETTER_EVIDENCE / LETTER_SIGNATURE / LETTER_LETTERHEAD + accept `application/pdf` content type

### Frontend
- `letterPdfRenderer.ts` — client-side jsPDF A4 Thai-font rendering for 2 letter templates (reuses existing template-editor font infrastructure)
- `LetterQueueSection` in ApprovalTab — urgency heat strip + per-status CTAs (สร้าง PDF / ดาวน์โหลด / บันทึกส่งแล้ว / รับแล้ว / คืน)
- `LetterDispatchDialog` — two-mode (generate → dispatch auto-transition): generate fetches company+contract+settings → renders PDF → presigned upload → marks generated; dispatch accepts tracking# + optional slip photo
- DunningSettingsPage — new card for signature + letterhead upload

## Customer impact on deploy

**Still zero.** `letter_auto_generate_enabled` default `false` — cron won't fire until OWNER flips it. Existing features unchanged.

When OWNER eventually enables auto-generate + dispatches the first letter, customers receive:
1. Physical registered letter via EMS
2. LINE notification "บริษัทได้จัดส่งหนังสือถึงท่าน ทางไปรษณีย์ลงทะเบียน (EMS: XXX)"
3. For 60d letter: additional LINE "สัญญาของท่านได้ถูกบอกเลิกและอยู่ระหว่างดำเนินคดี"

## Test plan

- [ ] CI: type-check + unit tests green
- [ ] Staging (flag=true + letter_auto_generate_enabled=true): run cron manually, verify letters created for aging contracts
- [ ] Staging: OWNER uploads signature via /settings/dunning
- [ ] Staging: OWNER generates PDF from queue → downloads → checks Thai rendering + layout
- [ ] Staging: OWNER enters tracking# → LETTER_DISPATCHED LINE event fires
- [ ] Staging: OWNER marks undeliverable → contract.needsSkipTracing flips true

## Out of scope (future phase)

- Thailand Post Connect API integration (manual dispatch only for MVP)
- OCR of dispatch slip
- Letter template editing via UI (templates are code-based for legal review)
- Multi-language letters (Thai only)
- Automated legal packet bundle (contract + call log + payment history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)