### PR TITLE
feat(collections): Plan 5/4 hardening — runbook + priority score + OWNER alerts + workload + skip-tracing + LEGAL status + wallpaper + progress bar

### DIFF
--- a/apps/api/prisma/migrations/20260602000000_add_contract_status_legal/migration.sql
+++ b/apps/api/prisma/migrations/20260602000000_add_contract_status_legal/migration.sql
@@ -1,0 +1,3 @@
+-- AlterEnum: add LEGAL value to ContractStatus
+-- This is an additive-only change (no rows affected)
+ALTER TYPE "ContractStatus" ADD VALUE 'LEGAL';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -33,6 +33,7 @@ enum ContractStatus {
   ACTIVE
   OVERDUE
   DEFAULT
+  LEGAL // ดำเนินคดีทางกฎหมายแล้ว — 60d termination letter dispatched
   EARLY_PAYOFF
   COMPLETED
   EXCHANGED

--- a/apps/api/src/modules/overdue/contract-letter.service.spec.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.spec.ts
@@ -228,6 +228,47 @@ describe('ContractLetterService', () => {
       expect(terminatedCall).toBeUndefined();
     });
 
+    it('markDispatched sets contract.status=LEGAL for 60d termination letter (4 tx ops)', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'letter-t',
+        status: 'PDF_GENERATED',
+        contractId: 'c1',
+        letterType: 'CONTRACT_TERMINATION_60D',
+        letterNumber: 'ST-2026-00001',
+      });
+      mockPrisma.$transaction.mockResolvedValueOnce([
+        { id: 'letter-t', status: 'DISPATCHED' },
+        {},
+        {},
+        {},
+      ]);
+      mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
+
+      await service.markDispatched('letter-t', 'u1', { trackingNumber: 'EX123456' });
+
+      const txOps = mockPrisma.$transaction.mock.calls[0][0];
+      expect(Array.isArray(txOps)).toBe(true);
+      // 2 base ops + 2 legal-escalation ops for 60d letters
+      expect(txOps.length).toBe(4);
+    });
+
+    it('markDispatched does NOT set LEGAL for 45d return-device letter (2 tx ops)', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'letter-r',
+        status: 'PDF_GENERATED',
+        contractId: 'c1',
+        letterType: 'RETURN_DEVICE_45D',
+        letterNumber: 'ST-2026-00002',
+      });
+      mockPrisma.$transaction.mockResolvedValueOnce([{ id: 'letter-r', status: 'DISPATCHED' }, {}]);
+      mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
+
+      await service.markDispatched('letter-r', 'u1', { trackingNumber: 'EX777AB' });
+
+      const txOps = mockPrisma.$transaction.mock.calls[0][0];
+      expect(txOps.length).toBe(2); // only 2 base ops
+    });
+
     it('throws BadRequest when status is not PDF_GENERATED', async () => {
       mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
         id: 'l4',

--- a/apps/api/src/modules/overdue/contract-letter.service.spec.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.spec.ts
@@ -13,6 +13,7 @@ const mockPrisma = {
   },
   contract: {
     update: jest.fn(),
+    findUnique: jest.fn(),
   },
   auditLog: {
     create: jest.fn(),
@@ -202,6 +203,7 @@ describe('ContractLetterService', () => {
         ...pdfGeneratedLetter,
         letterType: 'CONTRACT_TERMINATION_60D',
       });
+      mockPrisma.contract.findUnique.mockResolvedValueOnce({ status: 'DEFAULT' });
       const dispatched = { id: 'l3', status: 'DISPATCHED' };
       mockPrisma.$transaction.mockResolvedValueOnce([dispatched, {}]);
       mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
@@ -236,6 +238,8 @@ describe('ContractLetterService', () => {
         letterType: 'CONTRACT_TERMINATION_60D',
         letterNumber: 'ST-2026-00001',
       });
+      // New: service now reads current contract status for audit `from` field
+      mockPrisma.contract.findUnique.mockResolvedValueOnce({ status: 'OVERDUE' });
       mockPrisma.$transaction.mockResolvedValueOnce([
         { id: 'letter-t', status: 'DISPATCHED' },
         {},
@@ -249,6 +253,38 @@ describe('ContractLetterService', () => {
       const txOps = mockPrisma.$transaction.mock.calls[0][0];
       expect(Array.isArray(txOps)).toBe(true);
       // 2 base ops + 2 legal-escalation ops for 60d letters
+      expect(txOps.length).toBe(4);
+    });
+
+    it('markDispatched audit log uses actual current contract status in `from` field', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'letter-t2',
+        status: 'PDF_GENERATED',
+        contractId: 'c-audit',
+        letterType: 'CONTRACT_TERMINATION_60D',
+        letterNumber: 'ST-2026-00007',
+      });
+      mockPrisma.contract.findUnique.mockResolvedValueOnce({ status: 'OVERDUE' });
+      // Capture auditLog.create calls to assert `from`
+      mockPrisma.auditLog.create.mockImplementation((args: any) => args);
+      mockPrisma.$transaction.mockResolvedValueOnce([
+        { id: 'letter-t2', status: 'DISPATCHED' },
+        {},
+        {},
+        {},
+      ]);
+      mockDunningEngine.executeEventTrigger.mockResolvedValue(undefined);
+
+      await service.markDispatched('letter-t2', 'u1', { trackingNumber: 'EX987654' });
+
+      // Find the CONTRACT_STATUS_LEGAL audit op inside the transaction payload
+      const txOps = mockPrisma.$transaction.mock.calls[0][0];
+      const legalAuditCall = mockPrisma.auditLog.create.mock.calls.find(
+        (call: any[]) => call[0]?.data?.action === 'CONTRACT_STATUS_LEGAL',
+      );
+      expect(legalAuditCall).toBeDefined();
+      expect(legalAuditCall?.[0]?.data?.newValue?.from).toBe('OVERDUE');
+      expect(legalAuditCall?.[0]?.data?.newValue?.to).toBe('LEGAL');
       expect(txOps.length).toBe(4);
     });
 

--- a/apps/api/src/modules/overdue/contract-letter.service.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.ts
@@ -130,7 +130,7 @@ export class ContractLetterService {
       throw new BadRequestException('เลข tracking EMS ต้อง ≥ 5 ตัวอักษร');
     }
 
-    const [updated] = await this.prisma.$transaction([
+    const transactionOps: Prisma.PrismaPromise<unknown>[] = [
       this.prisma.contractLetter.update({
         where: { id: letterId },
         data: {
@@ -153,7 +153,33 @@ export class ContractLetterService {
           },
         },
       }),
-    ]);
+    ];
+
+    if (letter.letterType === 'CONTRACT_TERMINATION_60D') {
+      transactionOps.push(
+        this.prisma.contract.update({
+          where: { id: letter.contractId },
+          data: { status: 'LEGAL' },
+        }),
+      );
+      transactionOps.push(
+        this.prisma.auditLog.create({
+          data: {
+            userId,
+            action: 'CONTRACT_STATUS_LEGAL',
+            entity: 'contract',
+            entityId: letter.contractId,
+            newValue: {
+              from: 'DEFAULT',
+              to: 'LEGAL',
+              reason: `60d termination letter dispatched: ${letter.letterNumber}`,
+            },
+          },
+        }),
+      );
+    }
+
+    const [updated] = await this.prisma.$transaction(transactionOps);
 
     // Fire LINE event — non-fatal
     try {

--- a/apps/api/src/modules/overdue/contract-letter.service.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.ts
@@ -156,6 +156,13 @@ export class ContractLetterService {
     ];
 
     if (letter.letterType === 'CONTRACT_TERMINATION_60D') {
+      // Read the actual current status so audit log reflects reality (contract
+      // may be OVERDUE, DEFAULT, etc. — not always DEFAULT).
+      const currentContract = await this.prisma.contract.findUnique({
+        where: { id: letter.contractId },
+        select: { status: true },
+      });
+      const fromStatus = currentContract?.status ?? 'UNKNOWN';
       transactionOps.push(
         this.prisma.contract.update({
           where: { id: letter.contractId },
@@ -170,7 +177,7 @@ export class ContractLetterService {
             entity: 'contract',
             entityId: letter.contractId,
             newValue: {
-              from: 'DEFAULT',
+              from: fromStatus,
               to: 'LEGAL',
               reason: `60d termination letter dispatched: ${letter.letterNumber}`,
             },

--- a/apps/api/src/modules/overdue/crons/broken-promise.cron.spec.ts
+++ b/apps/api/src/modules/overdue/crons/broken-promise.cron.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BrokenPromiseCron } from './broken-promise.cron';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { DunningEngineService } from '../dunning-engine.service';
 
 jest.mock('@sentry/nestjs', () => ({
   captureMessage: jest.fn(),
@@ -13,6 +14,7 @@ describe('BrokenPromiseCron.flagBrokenPromises', () => {
   let cron: BrokenPromiseCron;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let prisma: any;
+  let dunningEngine: { executeEventTrigger: jest.Mock };
 
   beforeEach(async () => {
     (Sentry.captureMessage as jest.Mock).mockClear();
@@ -24,11 +26,13 @@ describe('BrokenPromiseCron.flagBrokenPromises', () => {
         updateMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
     };
+    dunningEngine = { executeEventTrigger: jest.fn().mockResolvedValue(undefined) };
 
     const mod: TestingModule = await Test.createTestingModule({
       providers: [
         BrokenPromiseCron,
         { provide: PrismaService, useValue: prisma },
+        { provide: DunningEngineService, useValue: dunningEngine },
       ],
     }).compile();
     cron = mod.get(BrokenPromiseCron);
@@ -79,6 +83,37 @@ describe('BrokenPromiseCron.flagBrokenPromises', () => {
     expect(Sentry.captureException).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({ tags: expect.objectContaining({ cron: 'broken-promise' }) }),
+    );
+  });
+
+  it('fires BROKEN_PROMISE event for each unique contract', async () => {
+    prisma.callLog.findMany.mockResolvedValue([
+      { id: 'cl-1', contractId: 'c-1', settlementDate: new Date('2026-04-10') },
+      { id: 'cl-2', contractId: 'c-1', settlementDate: new Date('2026-04-12') },
+      { id: 'cl-3', contractId: 'c-2', settlementDate: new Date('2026-04-14') },
+    ]);
+
+    await cron.flagBrokenPromises();
+
+    // 3 call logs across 2 contracts → 2 event fires (dedup by contractId at cron level)
+    expect(dunningEngine.executeEventTrigger).toHaveBeenCalledTimes(2);
+    expect(dunningEngine.executeEventTrigger).toHaveBeenCalledWith('BROKEN_PROMISE', 'c-1', null, null);
+    expect(dunningEngine.executeEventTrigger).toHaveBeenCalledWith('BROKEN_PROMISE', 'c-2', null, null);
+  });
+
+  it('event trigger failure does NOT abort the flag — brokenAt still set', async () => {
+    prisma.callLog.findMany.mockResolvedValue([
+      { id: 'cl-1', contractId: 'c-1', settlementDate: new Date('2026-04-10') },
+    ]);
+    dunningEngine.executeEventTrigger.mockRejectedValueOnce(new Error('line api down'));
+
+    const result = await cron.flagBrokenPromises();
+
+    expect(result.flagged).toBe(1);
+    expect(prisma.callLog.updateMany).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: expect.objectContaining({ step: 'executeEventTrigger' }) }),
     );
   });
 });

--- a/apps/api/src/modules/overdue/crons/broken-promise.cron.ts
+++ b/apps/api/src/modules/overdue/crons/broken-promise.cron.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { DunningEngineService } from '../dunning-engine.service';
 
 /**
  * Broken-promise cron — flags promise-to-pay entries (CallLog.result='PROMISED')
@@ -19,7 +20,10 @@ import { PrismaService } from '../../../prisma/prisma.service';
 export class BrokenPromiseCron {
   private readonly logger = new Logger(BrokenPromiseCron.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly dunningEngine: DunningEngineService,
+  ) {}
 
   @Cron('0 * * * *', { timeZone: 'Asia/Bangkok' })
   async flagBrokenPromises(): Promise<{ flagged: number }> {
@@ -51,7 +55,23 @@ export class BrokenPromiseCron {
         data: { brokenAt: now },
       });
 
-      this.logger.warn(`Flagged ${candidates.length} broken promise(s)`);
+      // Fire BROKEN_PROMISE event per unique contract — customer gets a LINE nudge.
+      // Dedup window in executeEventTrigger (4h) prevents spam when multiple
+      // call logs for the same contract break at once. Non-fatal — flag stands
+      // even if LINE send fails.
+      const uniqueContractIds = Array.from(new Set(candidates.map((c) => c.contractId)));
+      for (const contractId of uniqueContractIds) {
+        try {
+          await this.dunningEngine.executeEventTrigger('BROKEN_PROMISE', contractId, null, null);
+        } catch (evErr) {
+          Sentry.captureException(evErr, {
+            tags: { cron: 'broken-promise', step: 'executeEventTrigger' },
+            extra: { contractId },
+          });
+        }
+      }
+
+      this.logger.warn(`Flagged ${candidates.length} broken promise(s) across ${uniqueContractIds.length} contract(s)`);
 
       Sentry.captureMessage(
         `Broken-promise cron flagged ${candidates.length} entries`,

--- a/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.spec.ts
+++ b/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { ContractLetterService } from '../contract-letter.service';
+import { OwnerAlertHelper } from '../owner-alert.helper';
 import { LetterAutoGenerateCron } from './letter-auto-generate.cron';
 
 const mockPrisma = {
@@ -12,16 +13,22 @@ const mockLetterService = {
   createIfNotExists: jest.fn(),
 };
 
+const mockOwnerAlert = {
+  sendToAllOwners: jest.fn().mockResolvedValue({ sent: 1, failed: 0 }),
+};
+
 describe('LetterAutoGenerateCron', () => {
   let cron: LetterAutoGenerateCron;
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockOwnerAlert.sendToAllOwners.mockResolvedValue({ sent: 1, failed: 0 });
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LetterAutoGenerateCron,
         { provide: PrismaService, useValue: mockPrisma },
         { provide: ContractLetterService, useValue: mockLetterService },
+        { provide: OwnerAlertHelper, useValue: mockOwnerAlert },
       ],
     }).compile();
     cron = module.get(LetterAutoGenerateCron);
@@ -113,5 +120,33 @@ describe('LetterAutoGenerateCron', () => {
 
     const result = await cron.run();
     expect(result).toEqual({ returnDevice: 0, termination: 0 });
+  });
+
+  it('sends OWNER alert when new letters were created', async () => {
+    mockPrisma.contract.findMany
+      .mockResolvedValueOnce([{ id: 'c1' }]) // returnCandidates
+      .mockResolvedValueOnce([{ id: 'c2' }, { id: 'c3' }]); // terminationCandidates
+
+    await cron.run();
+
+    expect(mockOwnerAlert.sendToAllOwners).toHaveBeenCalledWith(
+      expect.stringContaining('หนังสือทวงถาม'),
+      'letter-auto-generate',
+    );
+  });
+
+  it('skips OWNER alert when no letters were created', async () => {
+    // Both findMany return empty (defaults already set in beforeEach)
+    await cron.run();
+    expect(mockOwnerAlert.sendToAllOwners).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the cron when OWNER alert throws', async () => {
+    mockPrisma.contract.findMany
+      .mockResolvedValueOnce([{ id: 'c1' }])
+      .mockResolvedValueOnce([]);
+    mockOwnerAlert.sendToAllOwners.mockRejectedValueOnce(new Error('LINE down'));
+
+    await expect(cron.run()).resolves.toBeTruthy();
   });
 });

--- a/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts
+++ b/apps/api/src/modules/overdue/crons/letter-auto-generate.cron.ts
@@ -3,6 +3,7 @@ import { Cron } from '@nestjs/schedule';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { ContractLetterService } from '../contract-letter.service';
+import { OwnerAlertHelper } from '../owner-alert.helper';
 
 @Injectable()
 export class LetterAutoGenerateCron {
@@ -11,6 +12,7 @@ export class LetterAutoGenerateCron {
   constructor(
     private prisma: PrismaService,
     private letterService: ContractLetterService,
+    private ownerAlertHelper: OwnerAlertHelper,
   ) {}
 
   @Cron('15 9 * * *')
@@ -106,6 +108,20 @@ export class LetterAutoGenerateCron {
       this.logger.log(
         `Letter auto-generate: return_device=${returnDevice}, termination=${termination}`,
       );
+
+      // Alert OWNER when new letters were created
+      const totalCreated = returnDevice + termination;
+      if (totalCreated > 0) {
+        try {
+          const msg = `[ติดตามหนี้] มีหนังสือทวงถามใหม่ ${totalCreated} ใบรอสร้าง PDF (45 วัน ${returnDevice} / 60 วัน ${termination}) เปิด /collections แท็บ "อนุมัติ" เพื่อดำเนินการ`;
+          await this.ownerAlertHelper.sendToAllOwners(msg, 'letter-auto-generate');
+        } catch (err) {
+          Sentry.captureException(err, {
+            tags: { cron: 'letter-auto-generate', step: 'owner-alert' },
+          });
+        }
+      }
+
       return { returnDevice, termination };
     } catch (err) {
       Sentry.captureException(err, { tags: { cron: 'letter-auto-generate' } });

--- a/apps/api/src/modules/overdue/crons/mdm-auto-propose.cron.spec.ts
+++ b/apps/api/src/modules/overdue/crons/mdm-auto-propose.cron.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { MdmLockService } from '../mdm-lock.service';
+import { OwnerAlertHelper } from '../owner-alert.helper';
 import { MdmAutoProposeCron } from './mdm-auto-propose.cron';
 
 const mockPrisma = {
@@ -10,17 +11,22 @@ const mockPrisma = {
   $queryRaw: jest.fn(),
 };
 const mockMdmService = { proposeAuto: jest.fn() };
+const mockOwnerAlert = {
+  sendToAllOwners: jest.fn().mockResolvedValue({ sent: 1, failed: 0 }),
+};
 
 describe('MdmAutoProposeCron', () => {
   let cron: MdmAutoProposeCron;
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockOwnerAlert.sendToAllOwners.mockResolvedValue({ sent: 1, failed: 0 });
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MdmAutoProposeCron,
         { provide: PrismaService, useValue: mockPrisma },
         { provide: MdmLockService, useValue: mockMdmService },
+        { provide: OwnerAlertHelper, useValue: mockOwnerAlert },
       ],
     }).compile();
     cron = module.get(MdmAutoProposeCron);
@@ -88,6 +94,28 @@ describe('MdmAutoProposeCron', () => {
   it('does not throw when individual propose fails', async () => {
     mockPrisma.$queryRaw.mockResolvedValueOnce([{ contract_id: 'c1' }]);
     mockMdmService.proposeAuto.mockRejectedValueOnce(new Error('db down'));
+    await expect(cron.run()).resolves.toBeTruthy();
+  });
+
+  it('sends OWNER alert when new requests are proposed', async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ contract_id: 'c1' }]);
+    mockPrisma.contract.findMany.mockResolvedValueOnce([{ id: 'c2' }]);
+    await cron.run();
+    expect(mockOwnerAlert.sendToAllOwners).toHaveBeenCalledWith(
+      expect.stringContaining('คำขอล็อคเครื่อง'),
+      'mdm-auto-propose',
+    );
+  });
+
+  it('skips OWNER alert when nothing was proposed', async () => {
+    // $queryRaw returns empty, contract.findMany returns empty (defaults already set in beforeEach)
+    await cron.run();
+    expect(mockOwnerAlert.sendToAllOwners).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the cron when OWNER alert throws', async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ contract_id: 'c1' }]);
+    mockOwnerAlert.sendToAllOwners.mockRejectedValueOnce(new Error('LINE down'));
     await expect(cron.run()).resolves.toBeTruthy();
   });
 });

--- a/apps/api/src/modules/overdue/crons/mdm-auto-propose.cron.ts
+++ b/apps/api/src/modules/overdue/crons/mdm-auto-propose.cron.ts
@@ -3,6 +3,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { MdmLockService } from '../mdm-lock.service';
+import { OwnerAlertHelper } from '../owner-alert.helper';
 
 @Injectable()
 export class MdmAutoProposeCron {
@@ -11,6 +12,7 @@ export class MdmAutoProposeCron {
   constructor(
     private prisma: PrismaService,
     private mdmLockService: MdmLockService,
+    private ownerAlertHelper: OwnerAlertHelper,
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_9AM)
@@ -128,6 +130,18 @@ export class MdmAutoProposeCron {
       this.logger.log(
         `MDM auto-propose: uncontactable=${uncontactable.length}, no_promise=${noPromiseCount}`,
       );
+
+      // Alert OWNER if anything new was proposed
+      const totalProposed = uncontactable.length + noPromiseCount;
+      if (totalProposed > 0) {
+        try {
+          const msg = `[ติดตามหนี้] มีคำขอล็อคเครื่องใหม่ ${totalProposed} รายการรออนุมัติ (ติดต่อไม่ได้ ${uncontactable.length} / ไม่มีนัด ${noPromiseCount}) เปิด /collections แท็บ "อนุมัติ" เพื่อตรวจ`;
+          await this.ownerAlertHelper.sendToAllOwners(msg, 'mdm-auto-propose');
+        } catch (err) {
+          Sentry.captureException(err, { tags: { cron: 'mdm-auto-propose', step: 'owner-alert' } });
+        }
+      }
+
       return { uncontactable: uncontactable.length, noPromise: noPromiseCount };
     } catch (err) {
       Sentry.captureException(err, { tags: { cron: 'mdm-auto-propose' } });

--- a/apps/api/src/modules/overdue/kpi.service.spec.ts
+++ b/apps/api/src/modules/overdue/kpi.service.spec.ts
@@ -15,6 +15,9 @@ const mockPrisma = {
     count: jest.fn(),
     findMany: jest.fn(),
   },
+  user: {
+    findMany: jest.fn().mockResolvedValue([]),
+  },
 };
 
 function setupDefaultMocks() {
@@ -163,6 +166,10 @@ describe('OverdueKpiService', () => {
         { assignedToId: 'user-1', _count: { _all: 10 } },
         { assignedToId: 'user-2', _count: { _all: 20 } },
       ]);
+      mockPrisma.user.findMany.mockResolvedValueOnce([
+        { id: 'user-1', name: 'แนน' },
+        { id: 'user-2', name: 'กวาง' },
+      ]);
 
       const result = await service.getKpi({
         range: '7d',
@@ -171,6 +178,10 @@ describe('OverdueKpiService', () => {
       });
 
       expect(result.avgCollectorWorkload).toBe(15); // (10 + 20) / 2
+      expect(result.collectorWorkload).toEqual([
+        { userId: 'user-2', name: 'กวาง', count: 20 },
+        { userId: 'user-1', name: 'แนน', count: 10 },
+      ]);
     });
 
     it('promiseKeptRate7d is 0 when there are no promises in last 7d', async () => {

--- a/apps/api/src/modules/overdue/kpi.service.ts
+++ b/apps/api/src/modules/overdue/kpi.service.ts
@@ -123,6 +123,35 @@ export class OverdueKpiService {
           workloadBuckets.length
         : 0;
 
+    // Per-collector breakdown — only computed for OWNER to avoid over-fetching
+    const workloadWithNames =
+      params.userRole === 'OWNER' && workloadBuckets.length > 0
+        ? await this.prisma.user.findMany({
+            where: {
+              id: {
+                in: workloadBuckets
+                  .map((b: any) => b.assignedToId as string | null)
+                  .filter((id): id is string => id !== null),
+              },
+              deletedAt: null,
+            },
+            select: { id: true, name: true },
+          })
+        : [];
+
+    const collectorWorkload: Array<{ userId: string; name: string; count: number }> =
+      params.userRole === 'OWNER'
+        ? workloadBuckets
+            .filter((b: any) => b.assignedToId !== null)
+            .map((b: any) => ({
+              userId: b.assignedToId as string,
+              name:
+                workloadWithNames.find((u) => u.id === b.assignedToId)?.name ?? '(unknown)',
+              count: b._count._all,
+            }))
+            .sort((a: { count: number }, b: { count: number }) => b.count - a.count)
+        : [];
+
     const amountDue = new Prisma.Decimal(outstanding._sum.amountDue ?? 0);
     const amountPaid = new Prisma.Decimal(outstanding._sum.amountPaid ?? 0);
     const lateFees = new Prisma.Decimal(outstanding._sum.lateFee ?? 0);
@@ -135,6 +164,7 @@ export class OverdueKpiService {
       promisedCount: promised,
       promiseKeptRate7d: Math.round(promiseKeptRate7d * 100) / 100,
       avgCollectorWorkload: Math.round(avgCollectorWorkload),
+      collectorWorkload,
     };
   }
 }

--- a/apps/api/src/modules/overdue/kpi.service.ts
+++ b/apps/api/src/modules/overdue/kpi.service.ts
@@ -119,8 +119,7 @@ export class OverdueKpiService {
 
     const avgCollectorWorkload =
       workloadBuckets.length > 0
-        ? workloadBuckets.reduce((s: number, b: any) => s + b._count._all, 0) /
-          workloadBuckets.length
+        ? workloadBuckets.reduce((s, b) => s + b._count._all, 0) / workloadBuckets.length
         : 0;
 
     // Per-collector breakdown — only computed for OWNER to avoid over-fetching
@@ -130,7 +129,7 @@ export class OverdueKpiService {
             where: {
               id: {
                 in: workloadBuckets
-                  .map((b: any) => b.assignedToId as string | null)
+                  .map((b) => b.assignedToId)
                   .filter((id): id is string => id !== null),
               },
               deletedAt: null,
@@ -142,14 +141,13 @@ export class OverdueKpiService {
     const collectorWorkload: Array<{ userId: string; name: string; count: number }> =
       params.userRole === 'OWNER'
         ? workloadBuckets
-            .filter((b: any) => b.assignedToId !== null)
-            .map((b: any) => ({
-              userId: b.assignedToId as string,
-              name:
-                workloadWithNames.find((u) => u.id === b.assignedToId)?.name ?? '(unknown)',
+            .filter((b): b is typeof b & { assignedToId: string } => b.assignedToId !== null)
+            .map((b) => ({
+              userId: b.assignedToId,
+              name: workloadWithNames.find((u) => u.id === b.assignedToId)?.name ?? '(unknown)',
               count: b._count._all,
             }))
-            .sort((a: { count: number }, b: { count: number }) => b.count - a.count)
+            .sort((a, b) => b.count - a.count)
         : [];
 
     const amountDue = new Prisma.Decimal(outstanding._sum.amountDue ?? 0);

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -10,6 +10,7 @@ import { OverdueQueueService } from './queue.service';
 import { OverdueKpiService } from './kpi.service';
 import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
+import { OwnerAlertHelper } from './owner-alert.helper';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
 import { LetterAutoGenerateCron } from './crons/letter-auto-generate.cron';
@@ -31,6 +32,7 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     OverdueKpiService,
     OverdueTimelineService,
     OverdueBulkService,
+    OwnerAlertHelper,
     BrokenPromiseCron,
     MdmAutoProposeCron,
     LetterAutoGenerateCron,

--- a/apps/api/src/modules/overdue/owner-alert.helper.ts
+++ b/apps/api/src/modules/overdue/owner-alert.helper.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+
+/**
+ * Sends an internal LINE alert to all OWNER users who have lineId set.
+ * Used by collections crons to surface pending-approval counts so OWNER
+ * doesn't have to poll the approval tab.
+ *
+ * Silent no-op if no OWNER has lineId — logged but not an error. Individual
+ * send failures are swallowed at the caller level (Sentry capture there).
+ */
+@Injectable()
+export class OwnerAlertHelper {
+  private readonly logger = new Logger(OwnerAlertHelper.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private notifications: NotificationsService,
+  ) {}
+
+  async sendToAllOwners(
+    message: string,
+    relatedId?: string,
+  ): Promise<{ sent: number; failed: number }> {
+    const owners = await this.prisma.user.findMany({
+      where: {
+        role: 'OWNER',
+        isActive: true,
+        isSystemUser: false,
+        lineId: { not: null },
+        deletedAt: null,
+      },
+      select: { id: true, lineId: true, phone: true },
+    });
+
+    if (owners.length === 0) {
+      this.logger.log('No OWNER with lineId — skipping alert');
+      return { sent: 0, failed: 0 };
+    }
+
+    let sent = 0;
+    let failed = 0;
+    for (const owner of owners) {
+      try {
+        const result = await this.notifications.send({
+          channel: 'LINE',
+          recipient: owner.lineId!,
+          message,
+          relatedId: relatedId ?? 'collections-alert',
+          fallbackPhone: owner.phone ?? undefined,
+        });
+        if (result.status === 'SENT') sent++;
+        else failed++;
+      } catch {
+        failed++;
+      }
+    }
+    return { sent, failed };
+  }
+}

--- a/apps/api/src/modules/overdue/owner-alert.helper.ts
+++ b/apps/api/src/modules/overdue/owner-alert.helper.ts
@@ -47,6 +47,9 @@ export class OwnerAlertHelper {
           channel: 'LINE',
           recipient: owner.lineId!,
           message,
+          // relatedId is informational only (indexed but not unique) — it's
+          // stored on NotificationLog for filtering/forensics and is NOT used
+          // as a dedup key. Safe for repeat cron runs to reuse the same value.
           relatedId: relatedId ?? 'collections-alert',
           fallbackPhone: owner.phone ?? undefined,
         });

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -215,7 +215,7 @@ describe('OverdueQueueService', () => {
   });
 
   describe('pagination', () => {
-    it('caps limit at 100 when input exceeds 100', async () => {
+    it('caps response limit at 100 when input exceeds 100', async () => {
       mockPrisma.contract.findMany.mockResolvedValueOnce([]);
       mockPrisma.contract.count.mockResolvedValueOnce(0);
 
@@ -227,8 +227,10 @@ describe('OverdueQueueService', () => {
       });
 
       expect(result.limit).toBe(100);
+      // Prisma fetch caps at 500 (then sorts in memory by priority + paginates).
+      // Response `limit` field is still user-visible 100.
       const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
-      expect(callArg.take).toBe(100);
+      expect(callArg.take).toBe(500);
     });
 
     it('uses default limit of 50 when not specified', async () => {
@@ -242,6 +244,58 @@ describe('OverdueQueueService', () => {
       });
 
       expect(result.limit).toBe(50);
+    });
+  });
+
+  describe('priority score sort', () => {
+    const mkContract = (overrides: Record<string, unknown>) => ({
+      id: 'c-' + Math.random().toString(36).slice(2, 8),
+      contractNumber: 'CN-x',
+      status: 'OVERDUE',
+      dunningStage: 'NONE',
+      customer: { id: 'cu', name: 'x', phone: '0', lineId: null },
+      branch: { id: 'b', name: 'b' },
+      assignedTo: null,
+      noAnswerCount: 0,
+      needsSkipTracing: false,
+      deviceLocked: false,
+      payments: [
+        {
+          amountDue: '1000',
+          amountPaid: '0',
+          lateFee: '0',
+          dueDate: new Date(Date.now() - 10 * 86400000).toISOString(), // 10 days overdue
+        },
+      ],
+      callLogs: [],
+      _count: { callLogs: 0 },
+      ...overrides,
+    });
+
+    it('sorts by priority score desc so biggest+oldest+no-answer surfaces first', async () => {
+      const low = mkContract({
+        id: 'low',
+        payments: [{ amountDue: '500', amountPaid: '0', lateFee: '0', dueDate: new Date(Date.now() - 5 * 86400000).toISOString() }],
+      }); // 500 * 5 * 1 * 1 = 2500
+      const mid = mkContract({
+        id: 'mid',
+        payments: [{ amountDue: '2000', amountPaid: '0', lateFee: '0', dueDate: new Date(Date.now() - 20 * 86400000).toISOString() }],
+      }); // 2000 * 20 * 1 * 1 = 40000
+      const high = mkContract({
+        id: 'high',
+        noAnswerCount: 2,
+        _count: { callLogs: 3 }, // 3 broken promises
+        payments: [{ amountDue: '3000', amountPaid: '0', lateFee: '0', dueDate: new Date(Date.now() - 30 * 86400000).toISOString() }],
+      }); // 3000 * 30 * 3 * 7 = 1,890,000
+
+      mockPrisma.contract.findMany.mockResolvedValueOnce([low, mid, high]);
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const result = await service.getQueue({ tab: 'today', userRole: 'OWNER', userBranchId: null });
+
+      expect(result.data.map((r) => r.id)).toEqual(['high', 'mid', 'low']);
+      // __priorityScore should be stripped from response
+      expect((result.data[0] as any).__priorityScore).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -35,7 +35,11 @@ export class OverdueQueueService {
     // computed expression across payments + callLogs + counters). Acceptable
     // tradeoff: the overdue set is bounded by branch scope and status filter
     // to ~thousands at most in practice.
-    const [contracts, total] = await Promise.all([
+    // TODO: persist priorityScore to support >500 overdue cases (Wave 3 schema
+    // change). Until then we cap the fetch AND the reported total so that
+    // pagination doesn't hand out page numbers we can't serve.
+    const FETCH_CAP = 500;
+    const [contracts, dbCount] = await Promise.all([
       this.prisma.contract.findMany({
         where,
         include: {
@@ -58,7 +62,7 @@ export class OverdueQueueService {
             },
           },
         },
-        take: 500, // cap the fetch — priority sort + pagination happens in memory
+        take: FETCH_CAP, // cap the fetch — priority sort + pagination happens in memory
       }),
       this.prisma.contract.count({ where }),
     ]);
@@ -69,7 +73,13 @@ export class OverdueQueueService {
 
     const paged = rows.slice(skip, skip + limit).map(({ __priorityScore, ...rest }) => rest);
 
-    return { data: paged, total, page, limit };
+    // Cap the reported total so pagination never advertises pages we can't
+    // serve from our in-memory FETCH_CAP slice. Include a warning flag when
+    // the true DB count exceeds the cap so callers can surface it.
+    const total = Math.min(dbCount, FETCH_CAP);
+    const truncated = dbCount > FETCH_CAP;
+
+    return { data: paged, total, page, limit, truncated };
   }
 
   /**

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -30,6 +30,11 @@ export class OverdueQueueService {
 
     const where = this.buildWhere(params.tab, now, branchScope);
 
+    // Fetch all matching then sort by priority score in memory, then paginate.
+    // We can't express the priority formula as a Prisma orderBy (it involves a
+    // computed expression across payments + callLogs + counters). Acceptable
+    // tradeoff: the overdue set is bounded by branch scope and status filter
+    // to ~thousands at most in practice.
     const [contracts, total] = await Promise.all([
       this.prisma.contract.findMany({
         where,
@@ -46,17 +51,40 @@ export class OverdueQueueService {
             orderBy: { calledAt: 'desc' },
             take: 1,
           },
+          // For broken-promise multiplier in priority score
+          _count: {
+            select: {
+              callLogs: { where: { result: 'PROMISED', brokenAt: { not: null } } },
+            },
+          },
         },
-        orderBy: { updatedAt: 'desc' },
-        skip,
-        take: limit,
+        take: 500, // cap the fetch — priority sort + pagination happens in memory
       }),
       this.prisma.contract.count({ where }),
     ]);
 
-    const data = contracts.map((c) => this.toRow(c, now));
+    const rows = contracts
+      .map((c) => this.toRow(c, now))
+      .sort((a, b) => b.__priorityScore - a.__priorityScore);
 
-    return { data, total, page, limit };
+    const paged = rows.slice(skip, skip + limit).map(({ __priorityScore, ...rest }) => rest);
+
+    return { data: paged, total, page, limit };
+  }
+
+  /**
+   * Priority = outstanding × daysOverdue × (noAnswerCount+1) × brokenPromiseMultiplier.
+   * Larger score = higher urgency. Broken promises weigh 2× per occurrence to
+   * surface serial promise-breakers first.
+   */
+  private priorityScore(
+    outstanding: number,
+    daysOverdue: number,
+    noAnswerCount: number,
+    brokenPromiseCount: number,
+  ): number {
+    const brokenMul = 1 + brokenPromiseCount * 2;
+    return Math.max(0, outstanding) * Math.max(0, daysOverdue) * (noAnswerCount + 1) * brokenMul;
   }
 
   private buildWhere(
@@ -121,6 +149,8 @@ export class OverdueQueueService {
     const daysOverdue = payment
       ? Math.max(0, Math.floor((now.getTime() - new Date(payment.dueDate).getTime()) / 86400000))
       : 0;
+    const brokenPromiseCount = c._count?.callLogs ?? 0;
+    const __priorityScore = this.priorityScore(outstanding, daysOverdue, c.noAnswerCount ?? 0, brokenPromiseCount);
     return {
       id: c.id,
       contractNumber: c.contractNumber,
@@ -137,6 +167,7 @@ export class OverdueQueueService {
       settlementDate: callLog?.settlementDate ?? null,
       needsSkipTracing: c.needsSkipTracing,
       deviceLocked: c.deviceLocked,
+      __priorityScore,
     };
   }
 }

--- a/apps/api/src/modules/storage/shop-upload.controller.ts
+++ b/apps/api/src/modules/storage/shop-upload.controller.ts
@@ -13,6 +13,7 @@ export enum UploadKind {
   LETTER_EVIDENCE = 'LETTER_EVIDENCE',
   LETTER_SIGNATURE = 'LETTER_SIGNATURE',
   LETTER_LETTERHEAD = 'LETTER_LETTERHEAD',
+  MDM_WALLPAPER = 'MDM_WALLPAPER',
 }
 
 export class PresignedUploadDto {
@@ -39,7 +40,8 @@ export class ShopUploadController {
           : 'jpg';
     const date = new Date().toISOString().slice(0, 10);
     const isLetterKind = dto.kind.startsWith('LETTER_');
-    const basePath = isLetterKind ? 'letters' : 'shop';
+    const isMdmKind = dto.kind.startsWith('MDM_');
+    const basePath = isLetterKind ? 'letters' : isMdmKind ? 'mdm-assets' : 'shop';
     const key = `${basePath}/${dto.kind.toLowerCase()}/${date}/${randomUUID()}.${ext}`;
     const signed = await this.storage.getSignedUploadUrl(key, dto.contentType);
     return {

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
@@ -1,4 +1,6 @@
+import { Users } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { useAuth } from '@/contexts/AuthContext';
 import { useCollectionsKpi } from '../hooks/useCollectionsKpi';
 
 interface KpiCardProps {
@@ -36,7 +38,9 @@ function KpiCard({ label, value, subtitle, strip, loading }: KpiCardProps) {
 }
 
 export default function CollectionsKpiStrip() {
+  const { user } = useAuth();
   const { data, isLoading, isError, refetch } = useCollectionsKpi('7d');
+  const isOwner = user?.role === 'OWNER';
 
   if (isError) {
     return (
@@ -63,58 +67,84 @@ export default function CollectionsKpiStrip() {
     );
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 mb-6">
-      <KpiCard
-        label="ค้างรวม"
-        strip="bg-destructive"
-        loading={isLoading}
-        value={
-          <span>
-            {data?.totalOutstanding.toLocaleString() ?? '-'}{' '}
-            <span className="text-base font-medium">฿</span>
-          </span>
-        }
-        subtitle={
-          data ? (
+    <div className="mb-6 space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5">
+        <KpiCard
+          label="ค้างรวม"
+          strip="bg-destructive"
+          loading={isLoading}
+          value={
             <span>
-              + ค่าปรับ{' '}
-              <span className="tabular-nums text-destructive font-medium">
-                {data.totalLateFees.toLocaleString()}
-              </span>{' '}
-              ฿
+              {data?.totalOutstanding.toLocaleString() ?? '-'}{' '}
+              <span className="text-base font-medium">฿</span>
             </span>
-          ) : undefined
-        }
-      />
-      <KpiCard
-        label="คิววันนี้"
-        strip="bg-primary"
-        loading={isLoading}
-        value={<span className="text-primary">{data?.queueToday ?? '-'}</span>}
-        subtitle={trendEl}
-      />
-      <KpiCard
-        label="นัดชำระ"
-        strip="bg-warning"
-        loading={isLoading}
-        value={<span>{data?.promisedCount ?? '-'}</span>}
-        subtitle="รอชำระตามนัด"
-      />
-      <KpiCard
-        label="Promise-kept 7d"
-        strip="bg-success"
-        loading={isLoading}
-        value={
-          data ? (
-            <span className="text-success">
-              {(data.promiseKeptRate7d * 100).toFixed(0)}%
+          }
+          subtitle={
+            data ? (
+              <span>
+                + ค่าปรับ{' '}
+                <span className="tabular-nums text-destructive font-medium">
+                  {data.totalLateFees.toLocaleString()}
+                </span>{' '}
+                ฿
+              </span>
+            ) : undefined
+          }
+        />
+        <KpiCard
+          label="คิววันนี้"
+          strip="bg-primary"
+          loading={isLoading}
+          value={<span className="text-primary">{data?.queueToday ?? '-'}</span>}
+          subtitle={trendEl}
+        />
+        <KpiCard
+          label="นัดชำระ"
+          strip="bg-warning"
+          loading={isLoading}
+          value={<span>{data?.promisedCount ?? '-'}</span>}
+          subtitle="รอชำระตามนัด"
+        />
+        <KpiCard
+          label="Promise-kept 7d"
+          strip="bg-success"
+          loading={isLoading}
+          value={
+            data ? (
+              <span className="text-success">
+                {(data.promiseKeptRate7d * 100).toFixed(0)}%
+              </span>
+            ) : (
+              '-'
+            )
+          }
+          subtitle="ช่วง 7 วันล่าสุด"
+        />
+      </div>
+
+      {/* Collector workload breakdown — OWNER only */}
+      {isOwner && data?.collectorWorkload && data.collectorWorkload.length > 0 && (
+        <div className="rounded-xl border border-border/50 bg-card shadow-sm p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <Users className="size-4 text-primary" />
+            <div className="text-sm font-semibold">ผู้ติดตามหนี้</div>
+            <span className="text-xs text-muted-foreground leading-snug">
+              (ลูกค้าที่มอบหมาย ยังไม่ปิด)
             </span>
-          ) : (
-            '-'
-          )
-        }
-        subtitle="ช่วง 7 วันล่าสุด"
-      />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {data.collectorWorkload.map((w) => (
+              <div
+                key={w.userId}
+                className="inline-flex items-center gap-2 rounded-lg border border-border/50 bg-muted/30 px-3 py-1.5 text-xs"
+              >
+                <span className="font-medium">{w.name}</span>
+                <span className="tabular-nums text-muted-foreground">{w.count} ราย</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsKpiStrip.tsx
@@ -1,6 +1,7 @@
 import { Users } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useAuth } from '@/contexts/AuthContext';
+import { formatNumber } from '@/utils/formatters';
 import { useCollectionsKpi } from '../hooks/useCollectionsKpi';
 
 interface KpiCardProps {
@@ -75,7 +76,7 @@ export default function CollectionsKpiStrip() {
           loading={isLoading}
           value={
             <span>
-              {data?.totalOutstanding.toLocaleString() ?? '-'}{' '}
+              {data ? formatNumber(data.totalOutstanding) : '-'}{' '}
               <span className="text-base font-medium">฿</span>
             </span>
           }
@@ -84,7 +85,7 @@ export default function CollectionsKpiStrip() {
               <span>
                 + ค่าปรับ{' '}
                 <span className="tabular-nums text-destructive font-medium">
-                  {data.totalLateFees.toLocaleString()}
+                  {formatNumber(data.totalLateFees)}
                 </span>{' '}
                 ฿
               </span>

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
@@ -5,6 +5,7 @@ import { useCustomer360 } from '../hooks/useCustomer360';
 import Customer360Timeline from './Customer360Timeline';
 import Customer360Actions from './Customer360Actions';
 import type { ContractRow } from '../types';
+import { formatThaiDateShort } from '@/lib/date';
 
 interface Props {
   contract: ContractRow | null;
@@ -170,12 +171,7 @@ export default function Customer360Panel({ contract, onClose, onRequestSendLine 
                         <div className="text-xs text-muted-foreground leading-snug">
                           งวดถัดไป: งวด{' '}
                           <span className="tabular-nums font-medium">{nextDue.installmentNo}</span>{' '}
-                          ครบกำหนด{' '}
-                          {new Date(nextDue.dueDate).toLocaleDateString('th-TH', {
-                            day: 'numeric',
-                            month: 'short',
-                            year: 'numeric',
-                          })}
+                          ครบกำหนด {formatThaiDateShort(nextDue.dueDate)}
                         </div>
                       )}
                     </div>

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Panel.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { X, Phone, MessageCircle, MapPin, Loader2 } from 'lucide-react';
+import type { PaymentScheduleItem } from '../hooks/useCustomer360';
 import { useCustomer360 } from '../hooks/useCustomer360';
 import Customer360Timeline from './Customer360Timeline';
 import Customer360Actions from './Customer360Actions';
@@ -141,6 +142,45 @@ export default function Customer360Panel({ contract, onClose, onRequestSendLine 
                     </div>
                   </div>
                 </div>
+
+                {/* Installment progress bar */}
+                {data?.detail.payments && data.detail.payments.length > 0 && (() => {
+                  const payments = data.detail.payments as PaymentScheduleItem[];
+                  const paid = payments.filter((p) => p.status === 'PAID' || p.status === 'WAIVED').length;
+                  const total = payments.length;
+                  const percent = total > 0 ? Math.round((paid / total) * 100) : 0;
+                  const nextDue = payments.find((p) =>
+                    ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'].includes(p.status),
+                  );
+                  return (
+                    <div className="mt-4 space-y-2">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground leading-snug">ความคืบหน้าการผ่อน</span>
+                        <span className="tabular-nums font-medium">
+                          {paid} / {total} งวด ({percent}%)
+                        </span>
+                      </div>
+                      <div className="h-2 bg-muted rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-primary transition-all duration-500"
+                          style={{ width: `${percent}%` }}
+                        />
+                      </div>
+                      {nextDue && (
+                        <div className="text-xs text-muted-foreground leading-snug">
+                          งวดถัดไป: งวด{' '}
+                          <span className="tabular-nums font-medium">{nextDue.installmentNo}</span>{' '}
+                          ครบกำหนด{' '}
+                          {new Date(nextDue.dueDate).toLocaleDateString('th-TH', {
+                            day: 'numeric',
+                            month: 'short',
+                            year: 'numeric',
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
               </section>
 
               {/* Timeline */}

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsKpi.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsKpi.ts
@@ -9,6 +9,7 @@ export interface CollectionsKpi {
   promisedCount: number;
   promiseKeptRate7d: number;
   avgCollectorWorkload: number;
+  collectorWorkload?: Array<{ userId: string; name: string; count: number }>;
 }
 
 export function useCollectionsKpi(range: '7d' | '30d' = '7d') {

--- a/apps/web/src/pages/CollectionsPage/hooks/useCustomer360.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCustomer360.ts
@@ -10,6 +10,15 @@ export interface TimelineEvent {
   metadata?: Record<string, unknown>;
 }
 
+export interface PaymentScheduleItem {
+  id: string;
+  installmentNo: number;
+  dueDate: string;
+  status: 'PENDING' | 'PAID' | 'OVERDUE' | 'PARTIALLY_PAID' | 'WAIVED';
+  amountDue: number;
+  amountPaid: number;
+}
+
 export interface ContractDetail {
   id: string;
   contractNumber: string;
@@ -26,6 +35,7 @@ export interface ContractDetail {
   paidInstallments?: number;
   outstanding?: number;
   nextDueDate?: string | null;
+  payments?: PaymentScheduleItem[];
 }
 
 export function useCustomer360(contractId: string | null) {

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Search } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
@@ -33,6 +34,7 @@ interface Props {
 
 export default function FollowUpTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
   const [page, setPage] = useState(1);
+  const [showSkipTracing, setShowSkipTracing] = useState(false);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
 
@@ -49,7 +51,7 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
   const rows = q.data?.data ?? [];
 
   // Client-side search filter
-  const filtered = debouncedSearch
+  const searchFiltered = debouncedSearch
     ? rows.filter((r) => {
         const term = debouncedSearch.toLowerCase();
         return (
@@ -59,6 +61,11 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
         );
       })
     : rows;
+
+  // Skip-tracing filter applied on top of search filter
+  const filtered = showSkipTracing
+    ? searchFiltered.filter((c) => c.needsSkipTracing)
+    : searchFiltered;
 
   return (
     <QueryBoundary
@@ -74,24 +81,54 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
         </div>
       }
     >
+      {/* Skip-tracing toggle */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex-1" />
+        <button
+          onClick={() => setShowSkipTracing((v) => !v)}
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border transition-colors ${
+            showSkipTracing
+              ? 'border-destructive/30 bg-destructive/5 text-destructive'
+              : 'border-input hover:bg-muted text-muted-foreground'
+          }`}
+        >
+          <Search className="size-3.5" />
+          {showSkipTracing
+            ? `ต้องหาเบอร์ใหม่ (${filtered.length})`
+            : 'กรองที่ต้องหาเบอร์ใหม่'}
+        </button>
+      </div>
+
       {filtered.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-primary/30 bg-primary/5 p-10 text-center">
-          <div className="text-4xl mb-3">✅</div>
-          <div className="text-sm font-medium text-primary leading-snug">
-            ไม่มีใครที่ต้องตามต่อ
+        showSkipTracing ? (
+          <div className="rounded-xl border border-dashed border-border p-10 text-center">
+            <div className="text-sm font-medium text-muted-foreground leading-snug">
+              ไม่มีใครต้องหาเบอร์ใหม่
+            </div>
+            <div className="text-xs text-muted-foreground mt-1 leading-snug">
+              ทุกคนมีเบอร์ติดต่อที่ถูกต้องแล้ว
+            </div>
           </div>
-          <div className="text-xs text-muted-foreground mt-1 leading-snug">
-            ทุกคนติดต่อได้หมดแล้ว
+        ) : (
+          <div className="rounded-xl border border-dashed border-primary/30 bg-primary/5 p-10 text-center">
+            <div className="text-sm font-medium text-primary leading-snug">
+              ไม่มีใครที่ต้องตามต่อ
+            </div>
+            <div className="text-xs text-muted-foreground mt-1 leading-snug">
+              ทุกคนติดต่อได้หมดแล้ว
+            </div>
           </div>
-        </div>
+        )
       ) : (
         <>
           {/* Context banner */}
+          {!showSkipTracing && (
           <div className="mb-4 rounded-lg bg-warning/5 border border-warning/20 p-3 text-xs text-warning leading-snug">
             <strong>ตามต่อ:</strong>{' '}
             ลูกค้าที่เคยโทรไปแล้วแต่ไม่รับ — ถ้าไม่รับครั้งต่อไปครบ 3 ครั้ง
             ระบบจะเสนอล็อคเครื่องอัตโนมัติ
           </div>
+          )}
 
           <div className="space-y-2">
             {filtered.map((row) =>

--- a/apps/web/src/pages/DunningSettingsPage.tsx
+++ b/apps/web/src/pages/DunningSettingsPage.tsx
@@ -12,9 +12,10 @@ import {
   Link2,
   ToggleLeft,
   ToggleRight,
-  FileSignature,
+  Settings,
   Upload,
   Image as ImageIcon,
+  AlertTriangle,
 } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
@@ -108,7 +109,7 @@ function LetterAssetField({
   label: string;
   hint: string;
   currentUrl: string;
-  uploadKind: 'LETTER_SIGNATURE' | 'LETTER_LETTERHEAD';
+  uploadKind: 'LETTER_SIGNATURE' | 'LETTER_LETTERHEAD' | 'MDM_WALLPAPER';
   onSaved: (url: string) => void;
 }) {
   const [uploading, setUploading] = useState(false);
@@ -267,6 +268,12 @@ export default function DunningSettingsPage() {
 
   const signatureUrl = configs.find((s) => s.key === 'letter_signature_url')?.value ?? '';
   const letterheadUrl = configs.find((s) => s.key === 'letter_letterhead_url')?.value ?? '';
+  const wallpaperUrl = configs.find((s) => s.key === 'mdm_lock_wallpaper_url')?.value ?? '';
+
+  // Detect if auto-propose MDM is enabled (mdm_auto_propose_enabled = '1' or 'true')
+  const mdmAutoPropose =
+    (configs.find((s) => s.key === 'mdm_auto_propose_enabled')?.value ?? '') === '1' ||
+    (configs.find((s) => s.key === 'mdm_auto_propose_enabled')?.value ?? '') === 'true';
 
   const configMutation = useMutation({
     mutationFn: async (items: Array<{ key: string; value: string }>) =>
@@ -349,16 +356,15 @@ export default function DunningSettingsPage() {
         }
       />
 
-      {/* Letter Settings Card */}
+      {/* Document & MDM Assets Card */}
       <Card className="rounded-xl border border-border/50 bg-card shadow-sm mb-6">
         <CardContent className="p-5">
           <div className="flex items-center gap-2 mb-3">
-            <FileSignature className="size-4 text-primary" />
-            <div className="text-sm font-semibold">ตั้งค่าหนังสือทวงถาม</div>
+            <Settings className="size-4 text-primary" />
+            <div className="text-sm font-semibold">เอกสารและอุปกรณ์ติดตาม</div>
           </div>
           <p className="text-xs text-muted-foreground mb-4 leading-snug">
-            ตั้งค่าลายเซ็นและหัวกระดาษสำหรับหนังสือ 45 วัน และ 60 วัน —
-            PDF จะถูกสร้างโดยใช้ข้อมูลนี้
+            ลายเซ็นและหัวกระดาษสำหรับหนังสือทวงถาม · wallpaper เตือนบนเครื่องลูกค้าเมื่อถูกล็อค MDM
           </p>
 
           <div className="space-y-4">
@@ -376,11 +382,24 @@ export default function DunningSettingsPage() {
               uploadKind="LETTER_LETTERHEAD"
               onSaved={(url) => saveConfig('letter_letterhead_url', url)}
             />
+            <LetterAssetField
+              label="Wallpaper เตือนบนเครื่องลูกค้า"
+              hint="PNG 1080×1920px แนวตั้ง · แสดงบน lock screen เมื่อ MDM ล็อคเครื่อง"
+              currentUrl={wallpaperUrl}
+              uploadKind="MDM_WALLPAPER"
+              onSaved={(url) => saveConfig('mdm_lock_wallpaper_url', url)}
+            />
           </div>
 
           {!signatureUrl && (
             <div className="mt-4 rounded-lg bg-warning/5 border border-warning/20 p-3 text-xs text-warning leading-snug">
               ยังไม่ได้อัปโหลดลายเซ็น — PDF ที่สร้างจะไม่มีลายเซ็น โปรดอัปโหลดก่อนใช้งานจริง
+            </div>
+          )}
+          {!wallpaperUrl && mdmAutoPropose && (
+            <div className="mt-3 rounded-lg bg-destructive/5 border border-destructive/20 p-3 flex items-start gap-2 text-xs text-destructive leading-snug">
+              <AlertTriangle className="size-3.5 shrink-0 mt-0.5" />
+              <span>Wallpaper ยังไม่ตั้งค่า — MDM จะล็อคเครื่องโดยไม่เปลี่ยนรูป</span>
             </div>
           )}
         </CardContent>

--- a/docs/guides/COLLECTIONS-V2-DEPLOYMENT.md
+++ b/docs/guides/COLLECTIONS-V2-DEPLOYMENT.md
@@ -1,0 +1,258 @@
+# Collections Workflow Hub v2 — Deployment Runbook
+
+**Target release:** PRs #684 → #685 → #686 → #687 (stacked)
+**Last updated:** 2026-04-24
+
+---
+
+## Overview
+
+The Collections Workflow Hub is a 4-PR stacked redesign of the `/overdue` page. Each PR is individually deployable but depends on the previous PR's schema changes. Merge in order, run the seed step after Plan 1 merges, then incrementally enable feature flags as you're ready.
+
+Customer impact is **zero** on first merge — all new behavior is gated behind feature flags that default to off.
+
+---
+
+## Merge order
+
+```
+main
+├─ #684 feat/collections-foundation    ← merge first (schema + services)
+├─ #685 feat/collections-workflow-hub  ← merge after #684
+├─ #686 feat/collections-power-features ← merge after #685
+└─ #687 feat/collections-legal-letters ← merge after #686
+```
+
+Each PR triggers CI → `prisma migrate deploy` on prod. Schema changes are additive — no data loss.
+
+---
+
+## One-time seed on production (required after PR #684)
+
+The existing `prisma migrate deploy` handles schema but does NOT run seeds on production. You must manually invoke the production seed ONCE after PR #684 lands so the SYSTEM user, event-triggered dunning rules, and SystemConfig keys exist.
+
+**Without this step**, the `updateContractStatuses` cron will throw at 09:00 daily (the Plan 1 C2 bug fix requires SYSTEM user for audit trail).
+
+### Step-by-step (Cloud Run Job one-shot pattern)
+
+Memory precedent — the project uses ephemeral Cloud Run Jobs for prod DB scripts. Apply the same pattern:
+
+```bash
+# 1. Authenticate
+gcloud auth login
+gcloud config set project bestchoice-prod   # actual project id
+
+# 2. Get the deployed image URL (the same api container that's live)
+gcloud run services describe bestchoice-api --region asia-southeast1 --format 'value(spec.template.spec.containers[0].image)'
+# Example output: gcr.io/bestchoice-prod/bestchoice-api:abc123
+
+# 3. Run the seed as a one-shot job
+gcloud run jobs create bestchoice-seed-collections-foundation \
+  --image gcr.io/bestchoice-prod/bestchoice-api:abc123 \
+  --region asia-southeast1 \
+  --service-account bestchoice-api-sa@bestchoice-prod.iam.gserviceaccount.com \
+  --set-secrets 'DATABASE_URL=DATABASE_URL:latest' \
+  --command node \
+  --args -r,ts-node/register,prisma/seed-production.ts
+
+gcloud run jobs execute bestchoice-seed-collections-foundation --region asia-southeast1 --wait
+
+# 4. Verify in logs
+gcloud run jobs executions describe <execution-id> --region asia-southeast1
+# Look for: "Collections foundation: 1 system user, 8 event rules, 10 configs"
+
+# 5. Cleanup job
+gcloud run jobs delete bestchoice-seed-collections-foundation --region asia-southeast1 --quiet
+```
+
+**Idempotency:** safe to re-run. All operations are upsert-by-unique-key and preserve OWNER's manual `isActive` toggles on event rules.
+
+### Verify seed via Prisma Studio (optional)
+
+Open Cloud SQL Proxy and run `npx prisma studio` locally pointed at prod DATABASE_URL. Verify:
+- `User` table contains `system@bestchoice.internal` with `isSystemUser=true, isActive=false`
+- `DunningRule` table has 8 rows where `eventTrigger IS NOT NULL`; all `isActive=false` on first deploy
+- `SystemConfig` has 10 keys prefixed `collections_`, `mdm_`, or `letter_`
+
+---
+
+## Backfill `noAnswerCount` (optional — only if you want the UI to show historical counts)
+
+If you want the new "ตามต่อ" tab to surface contracts based on last-30-day call history from before this deploy:
+
+```bash
+# Same Cloud Run Job pattern, different script
+gcloud run jobs create bestchoice-backfill-no-answer \
+  --image gcr.io/bestchoice-prod/bestchoice-api:abc123 \
+  --region asia-southeast1 \
+  --service-account bestchoice-api-sa@bestchoice-prod.iam.gserviceaccount.com \
+  --set-secrets 'DATABASE_URL=DATABASE_URL:latest' \
+  --command npx \
+  --args tsx,scripts/backfill-no-answer-count.ts
+
+gcloud run jobs execute bestchoice-backfill-no-answer --region asia-southeast1 --wait
+gcloud run jobs delete bestchoice-backfill-no-answer --region asia-southeast1 --quiet
+```
+
+Safe to skip — new call logs start accumulating immediately on merge.
+
+---
+
+## Feature flag progression
+
+All flags live in `SystemConfig` and can be toggled via `PATCH /settings` (OWNER-only) or directly in DB.
+
+Start everything **OFF**, then enable in this order as UAT completes.
+
+| Flag | Default | What it enables | When to flip |
+|---|---|---|---|
+| `collections_v2_enabled` | `false` | Sidebar routes to `/collections`; otherwise `/overdue` | After #685 merges + smoke tests pass in staging |
+| `mdm_auto_propose_enabled` | `true` | Daily 09:00 cron creates `MdmLockRequest` for UNCONTACTABLE_3D / NO_PROMISE_3D | Already on — disable only if cron misbehaves |
+| `letter_auto_generate_enabled` | `false` | Daily 09:15 cron creates `ContractLetter` for 45d / 60d thresholds | **Only after legal review of PDF template output**; upload signature PNG first |
+| Individual `DunningRule.isActive` for event rules | `false` (prod seed) | LINE auto-send on call-log events (CALL_NO_ANSWER / CALL_ANSWERED_PROMISE / CALL_REFUSED / DEVICE_LOCKED / DEVICE_UNLOCKED / BROKEN_PROMISE / LETTER_DISPATCHED / CONTRACT_TERMINATED) | Per-rule OWNER decision via `/settings/dunning` |
+
+### Enable `collections_v2_enabled`
+
+```bash
+# Via app (OWNER only): /settings → Collections v2 → ON
+# Or via DB:
+UPDATE "system_config" SET value = 'true' WHERE key = 'collections_v2_enabled';
+```
+
+Effect: sidebar nav + mobile bottom nav swap `/overdue` → `/collections`. Existing `/overdue` still works via direct URL.
+
+### Enable event rules one at a time
+
+1. Login as OWNER, go to `/settings/dunning`
+2. Under "Event-triggered rules", review each rule's message template
+3. Edit template wording if needed (match your brand voice)
+4. Flip rule to active via the settings DB directly OR the toggle (if exposed in UI)
+5. Test by logging a NO_ANSWER call log on a test customer with `lineId` set — verify LINE arrives
+
+Suggested activation order (least to most aggressive):
+1. `dunning_on_no_answer` — soft reminder
+2. `dunning_confirm_promise` — positive confirmation
+3. `dunning_firm_warning` — firmer language
+4. `dunning_device_locked` + `dunning_device_unlocked` — only after MDM operational
+5. `dunning_broken_promise` — only after broken-promise cron tested
+6. `dunning_letter_dispatched` + `dunning_contract_terminated` — paired with legal letter rollout
+
+### Pre-activation checklist for `letter_auto_generate_enabled`
+
+Before flipping letter cron to `true`:
+
+- [ ] OWNER uploads signature PNG via `/settings/dunning` → Letter Settings card
+- [ ] OWNER uploads letterhead PNG (optional)
+- [ ] Company info verified in DB (`nameTh`, `taxId`, `address`, `directorName` must be accurate — letters are legal documents)
+- [ ] Generate a test PDF for a real contract via the `/collections` approval tab → download → inspect:
+  - Thai text renders correctly (not boxes)
+  - Letter number format `ST-YYYY-NNNNN`
+  - Company name + taxId at footer
+  - Signature image positioned correctly
+  - Paragraph flow reasonable
+- [ ] Legal review sign-off (recommended — letters are enforceable once dispatched)
+
+Only after all checked: flip `letter_auto_generate_enabled = 'true'`.
+
+---
+
+## Rollback plan
+
+### Quick rollback (feature flag off)
+
+If issues surface after enabling `collections_v2_enabled`:
+
+```sql
+UPDATE "system_config" SET value = 'false' WHERE key = 'collections_v2_enabled';
+```
+
+Sidebar immediately routes back to `/overdue`. Zero data loss; zero migration rollback needed.
+
+### Schema rollback (only if absolutely required)
+
+New columns have defaults; new tables are empty on first deploy. Reverting the migration would DROP the new tables — you'd lose any `MdmLockRequest` / `ContractLetter` rows created after deploy.
+
+Prefer: keep the schema, disable flags, investigate. Only drop tables if data integrity was compromised.
+
+---
+
+## Monitoring after go-live
+
+### Metrics to watch (first week)
+
+| Signal | Where | Red flag |
+|---|---|---|
+| `updateContractStatuses` cron success | Cloud Run logs / Sentry | Any "SYSTEM user not found" error |
+| `mdm-auto-propose` cron result | Cloud Run logs | Proposals count > 50/day → review threshold configs |
+| `letter-auto-generate` cron (when enabled) | Cloud Run logs | Any error |
+| `LETTER_DISPATCHED` event send rate | DunningAction table, status=SENT | LINE send failures surge |
+| Collector login → /collections load time | Analytics / RUM | > 2s p95 |
+| `executeEventTrigger` dedup skip rate | DunningAction table, status=SKIPPED | Unusually high (may indicate logic bug) |
+| User feedback from แนน / กวาง / ตุ๊กตา | Chat / ticket | Any workflow friction |
+
+### Sentry tags to filter on
+
+- `service: DunningEngineService`
+- `cron: mdm-auto-propose`
+- `cron: letter-auto-generate`
+- `method: executeEventTrigger.send`
+- `method: executeEventTrigger.paymentLink`
+
+---
+
+## Communication to ทีมติดตาม (แนน / กวาง / ตุ๊กตา)
+
+Before flipping `collections_v2_enabled`:
+
+> ทีมครับ พรุ่งนี้จะเปิดหน้าใหม่ `/collections` ให้ลอง UI เดิม `/overdue` ยังใช้ได้ถ้าอยากกลับไป ลองทำงาน 3 วัน แล้วมาบอกปัญหา/สิ่งที่ขาดกันได้เลย
+
+### Key changes to highlight
+
+1. **5 tabs ใหม่** แบ่งตาม workflow ประจำวัน: คิววันนี้ / ตามต่อ / นัดชำระ / อนุมัติ / ทั้งหมด
+2. **โทรแล้ว log ผลใน dialog เดียว** → ระบบส่ง LINE ถึงลูกค้าอัตโนมัติตามผลโทร (ถ้า OWNER เปิด event rules แล้ว)
+3. **Customer 360** เปิดจาก ▶ ที่การ์ด → ดูประวัติ+ชำระเงินได้โดยไม่ต้องออกจากหน้า
+4. **Bulk actions** เลือกหลายรายการแล้วมอบหมาย/ส่ง LINE/เสนอล็อคพร้อมกัน
+5. **MDM lock proposals** ระบบเสนออัตโนมัติเมื่อติดต่อไม่ได้ 3 วัน → OWNER อนุมัติในแท็บ "อนุมัติ"
+6. **หนังสือ 45/60 วัน** ระบบสร้างอัตโนมัติ OWNER generate PDF + ส่ง EMS + กรอก tracking กลับ
+
+### Rollback promise
+
+ถ้ารู้สึกว่า `/collections` ใหม่ยังไม่พร้อม บอก OWNER เพื่อปิด flag กลับไปใช้ `/overdue` เดิมได้ทันที
+
+---
+
+## FAQ
+
+**Q: ทำไมต้อง seed บน prod?**
+A: Plan 1 fix bug C2 — ถ้าไม่มี SYSTEM user, cron `updateContractStatuses` จะ throw (ตั้งใจ ป้องกัน audit log หายเงียบ ๆ)
+
+**Q: ถ้า OWNER ลืม upload signature แล้ว cron ส่ง letter?**
+A: `letter_auto_generate_enabled` default `false` → cron ไม่ฝัน. ถ้าเปิดโดยไม่ signature: PDF สร้างได้ (ไม่มีลายเซ็น) แต่หน้า generate dialog จะเตือนก่อนและขอ confirm
+
+**Q: ทำไมเลือก client-side PDF?**
+A: Matches existing project pattern (`jspdf` already in `apps/web` deps). ไม่ต้องเพิ่ม server-side PDF dep + Thai font handling fragile on Node. Client-side อาจช้ากว่าถ้า batch ใหญ่ แต่ MVP นี้ทำทีละใบ
+
+**Q: ถ้า LINE API down วันหนึ่ง จะทำอย่างไร?**
+A: `executeEventTrigger` จะ `status=FAILED` + Sentry alert. ข้อความไม่ไปถึงลูกค้า. Plan 6 (หลังจากนี้) จะเพิ่ม retry queue UI
+
+**Q: พนักงาน SALES ที่ไม่ใช่ตัวเองจะเห็นคิวคนอื่นไหม?**
+A: Branch-scoped — SALES/BRANCH_MANAGER เห็นเฉพาะสาขาตัวเอง. OWNER/FINANCE_MANAGER เห็นทุกสาขา
+
+**Q: ถ้า customer ไม่มี lineId จะส่ง LINE ไม่ได้ใช่ไหม?**
+A: ถูกต้อง. ContractCard มี chip "LINE" สีเขียวตอนที่ได้รับสาย lineId. Button "ส่ง LINE" ปุ่มจะ disabled + tooltip "ลูกค้าไม่มี LINE ID"
+
+---
+
+## Appendix: verify commands
+
+Copy-paste ready to run from laptop with `cloud_sql_proxy` running:
+
+```bash
+# Count seeds
+psql "$PROD_DATABASE_URL" -c "SELECT COUNT(*) FROM users WHERE is_system_user = true;"  # expect 1
+psql "$PROD_DATABASE_URL" -c "SELECT COUNT(*) FROM dunning_rules WHERE event_trigger IS NOT NULL;"  # expect 8
+psql "$PROD_DATABASE_URL" -c "SELECT COUNT(*) FROM system_config WHERE key LIKE 'collections_%' OR key LIKE 'mdm_%' OR key LIKE 'letter_%';"  # expect 10
+
+# Check feature flag state
+psql "$PROD_DATABASE_URL" -c "SELECT key, value FROM system_config WHERE key IN ('collections_v2_enabled','mdm_auto_propose_enabled','letter_auto_generate_enabled');"
+```


### PR DESCRIPTION
## Summary

Plan 5 closes the gaps identified after Plans 1-4: critical bugs, half-implemented spec items, and quality-of-life additions. Stacked on Plan 4.

**Base branch:** \`feat/collections-legal-letters\` (Plan 4) — merge #687 first.

## What's shipped

### Critical fixes
- **Deployment runbook** — `docs/guides/COLLECTIONS-V2-DEPLOYMENT.md` with merge order, Cloud Run Job seed commands, flag progression, rollback, monitoring
- **broken-promise cron wires BROKEN_PROMISE event** — previously flagged `brokenAt` silently; now fires LINE notification per unique contract (deduped at cron level + 4h engine dedup). Non-fatal if LINE down
- **ContractStatus.LEGAL** — schema enum value + migration. `markDispatched` on 60d termination letter sets contract.status=LEGAL (was leaving contracts as DEFAULT forever)

### Spec gaps closed
- **Priority score formula** — queue now sorts by `outstanding × daysOverdue × (noAnswerCount+1) × (1 + brokenPromiseCount×2)` instead of `updatedAt desc`. Collector sees biggest/oldest/most-delinquent first (spec §3)
- **OWNER LINE alerts** — new `OwnerAlertHelper` fires when mdm-auto-propose or letter-auto-generate creates N pending items → OWNER doesn't have to poll the approval tab
- **Wallpaper upload** — new field on Settings card saves `mdm_lock_wallpaper_url`. Warning banner if auto-propose enabled but wallpaper unset
- **Customer 360 installment progress bar** — spec §9 visual indicator with paid/total + percent + next-due date
- **Collector workload breakdown** — KPI strip (OWNER only) shows per-collector chip list with counts. Backs "แนน 45 / กวาง 12 → rebalance" visibility from spec
- **Skip-tracing filter** — toggle on FollowUpTab surfaces `needsSkipTracing=true` contracts (set by WRONG_NUMBER call result)

## Stats

- **10 commits** (on top of Plans 1-4)
- **+881 / -76 lines**
- **148 backend tests pass** (+35 from Plan 4)
- **0 TypeScript errors** (api + web)

## Customer impact on deploy

**Zero.** All changes either:
- Internal (runbook, priority sort logic, LEGAL status is dormant until 60d letter dispatches)
- Admin-only (wallpaper upload, workload chip, skip-tracing filter)
- OWNER alerts fire only when items are created (silent if no action)

## Test plan

- [ ] CI: 0 TS errors + all tests pass
- [ ] Staging: broken-promise cron fires BROKEN_PROMISE LINE event (log a PROMISED call with settlementDate=yesterday, run cron manually)
- [ ] Staging: queue sort order on a branch with known biggest-debtor matches expectation
- [ ] Staging: OWNER receives LINE alert after mdm auto-propose runs
- [ ] Staging: dispatch 60d letter → contract.status=LEGAL
- [ ] Staging: OWNER uploads wallpaper → URL saved in SystemConfig
- [ ] Staging: Customer 360 progress bar renders on a contract with payments
- [ ] Staging: OWNER sees per-collector breakdown on KPI strip

## Remaining backlog (deferred to future phases)

- Audit log viewer UI (DB has data, no UI)
- Analytics reports (collection rate by week, promise-kept trend)
- LINE API retry queue UI
- Bulk slip photo upload after mass letter dispatch
- Slip upload enforcement for non-cash payment methods
- Thailand Post Connect API integration
- PJ-Soft MDM API wire-up (still manual per current deferral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)