### PR TITLE
feat(collections): Plan 6/N backlog closeout — slip enforcement + retry queue + analytics + audit filter + bulk slip

### DIFF
--- a/apps/api/src/modules/audit/audit.controller.ts
+++ b/apps/api/src/modules/audit/audit.controller.ts
@@ -32,6 +32,7 @@ export class AuditController {
     @Query('userId') userId?: string,
     @Query('entity') entity?: string,
     @Query('action') action?: string,
+    @Query('actions') actions?: string | string[],
     @Query('from') from?: string,
     @Query('to') to?: string,
     @Query('page') page?: string,
@@ -39,10 +40,18 @@ export class AuditController {
     @Query('search') search?: string,
     @Query('entityId') entityId?: string,
   ) {
+    // Accept ?actions=A&actions=B (array) or ?actions=A,B (CSV)
+    let actionsList: string[] | undefined;
+    if (Array.isArray(actions)) {
+      actionsList = actions.filter((a) => typeof a === 'string' && a.length > 0);
+    } else if (typeof actions === 'string' && actions.length > 0) {
+      actionsList = actions.split(',').map((s) => s.trim()).filter(Boolean);
+    }
     return this.auditService.getAuditLogs({
       userId,
       entity,
       action,
+      actions: actionsList && actionsList.length > 0 ? actionsList : undefined,
       from,
       to,
       page: page ? parseInt(page) : undefined,

--- a/apps/api/src/modules/audit/audit.service.ts
+++ b/apps/api/src/modules/audit/audit.service.ts
@@ -193,6 +193,7 @@ export class AuditService {
     userId?: string;
     entity?: string;
     action?: string;
+    actions?: string[];
     from?: string;
     to?: string;
     page?: number;
@@ -206,7 +207,12 @@ export class AuditService {
     const where: Prisma.AuditLogWhereInput = {};
     if (filters.userId) where.userId = filters.userId;
     if (filters.entity) where.entity = { contains: filters.entity, mode: 'insensitive' };
-    if (filters.action) where.action = { contains: filters.action, mode: 'insensitive' };
+    // `actions` (array of exact matches) takes precedence over `action` (substring match)
+    if (filters.actions && filters.actions.length > 0) {
+      where.action = { in: filters.actions };
+    } else if (filters.action) {
+      where.action = { contains: filters.action, mode: 'insensitive' };
+    }
     if (filters.entityId) where.entityId = filters.entityId;
     if (filters.from || filters.to) {
       where.createdAt = {

--- a/apps/api/src/modules/overdue/analytics.service.spec.ts
+++ b/apps/api/src/modules/overdue/analytics.service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { OverdueAnalyticsService } from './analytics.service';
+
+const mockPrisma = {
+  $queryRaw: jest.fn(),
+};
+
+const emptyResult = {
+  weeklyCollectionRate: [],
+  promiseKeptTrend: [],
+  dunningActionVolume: [],
+  letterDispatchByType: [],
+  mdmLockVolume: [],
+};
+
+describe('OverdueAnalyticsService', () => {
+  let service: OverdueAnalyticsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OverdueAnalyticsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(OverdueAnalyticsService);
+  });
+
+  describe('getAnalytics', () => {
+    beforeEach(() => {
+      // Each call to $queryRaw returns empty arrays by default
+      mockPrisma.$queryRaw.mockResolvedValue([]);
+    });
+
+    it('returns all 5 metric arrays in the response shape', async () => {
+      const result = await service.getAnalytics({ range: '30d' });
+      expect(result.range).toBe('30d');
+      expect(Array.isArray(result.weeklyCollectionRate)).toBe(true);
+      expect(Array.isArray(result.promiseKeptTrend)).toBe(true);
+      expect(Array.isArray(result.dunningActionVolume)).toBe(true);
+      expect(Array.isArray(result.letterDispatchByType)).toBe(true);
+      expect(Array.isArray(result.mdmLockVolume)).toBe(true);
+    });
+
+    it('returns empty arrays (not null) when DB has no data', async () => {
+      mockPrisma.$queryRaw.mockResolvedValue([]);
+      const result = await service.getAnalytics({ range: '30d' });
+      expect(result).toMatchObject({
+        ...emptyResult,
+        range: '30d',
+      });
+    });
+
+    it('caches the result on second call (same range)', async () => {
+      await service.getAnalytics({ range: '30d' });
+      await service.getAnalytics({ range: '30d' });
+      // $queryRaw called 5 times for each metric on first call, 0 on cache hit
+      expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(5);
+    });
+
+    it('different range triggers a separate DB query (different cache key)', async () => {
+      await service.getAnalytics({ range: '30d' });
+      await service.getAnalytics({ range: '90d' });
+      // 5 calls for 30d + 5 calls for 90d = 10
+      expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(10);
+    });
+
+    it('maps DB rows correctly for weeklyCollectionRate', async () => {
+      const weekStart = new Date('2026-04-14T00:00:00.000Z');
+      mockPrisma.$queryRaw
+        .mockResolvedValueOnce([
+          { week_start: weekStart, paid_count: BigInt(8), due_count: BigInt(10) },
+        ]) // weeklyCollectionRate
+        .mockResolvedValue([]); // rest
+
+      const result = await service.getAnalytics({ range: '30d' });
+      expect(result.weeklyCollectionRate).toHaveLength(1);
+      expect(result.weeklyCollectionRate[0].paidCount).toBe(8);
+      expect(result.weeklyCollectionRate[0].dueCount).toBe(10);
+      expect(result.weeklyCollectionRate[0].rate).toBeCloseTo(0.8);
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/analytics.service.ts
+++ b/apps/api/src/modules/overdue/analytics.service.ts
@@ -1,0 +1,219 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface AnalyticsResult {
+  range: '30d' | '90d';
+  weeklyCollectionRate: Array<{ weekStart: string; paidCount: number; dueCount: number; rate: number }>;
+  promiseKeptTrend: Array<{ weekStart: string; kept: number; broken: number }>;
+  dunningActionVolume: Array<{ date: string; sent: number; failed: number }>;
+  letterDispatchByType: Array<{ type: string; month: string; count: number }>;
+  mdmLockVolume: Array<{ date: string; proposed: number; approved: number }>;
+}
+
+type WeeklyCollectionRow = { week_start: Date; paid_count: bigint; due_count: bigint };
+type PromiseKeptRow = { week_start: Date; kept: bigint; broken: bigint };
+type DunningVolumeRow = { day: Date; sent: bigint; failed: bigint };
+type LetterDispatchRow = { letter_type: string; month: Date; cnt: bigint };
+type MdmVolumeRow = { day: Date; proposed: bigint; approved: bigint };
+
+@Injectable()
+export class OverdueAnalyticsService {
+  private readonly logger = new Logger(OverdueAnalyticsService.name);
+  // 5-minute in-memory cache per range
+  private cache = new Map<string, { value: AnalyticsResult; expiresAt: number }>();
+  private readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+  constructor(private prisma: PrismaService) {}
+
+  async getAnalytics(params: { range: '30d' | '90d' }): Promise<AnalyticsResult> {
+    const cacheKey = params.range;
+    const now = Date.now();
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > now) return cached.value;
+
+    const value = await this.compute(params.range);
+    this.cache.set(cacheKey, { value, expiresAt: now + this.CACHE_TTL_MS });
+    return value;
+  }
+
+  private async compute(range: '30d' | '90d'): Promise<AnalyticsResult> {
+    const days = range === '30d' ? 30 : 90;
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    const [
+      weeklyCollectionRate,
+      promiseKeptTrend,
+      dunningActionVolume,
+      letterDispatchByType,
+      mdmLockVolume,
+    ] = await Promise.all([
+      this.weeklyCollectionRate(since),
+      this.promiseKeptTrend(since),
+      this.dunningActionVolume(since),
+      this.letterDispatchByType(since),
+      this.mdmLockVolume(since),
+    ]);
+
+    return {
+      range,
+      weeklyCollectionRate,
+      promiseKeptTrend,
+      dunningActionVolume,
+      letterDispatchByType,
+      mdmLockVolume,
+    };
+  }
+
+  /**
+   * Count paid payments vs due payments bucketed by ISO week start.
+   * A payment is "due" if its dueDate falls in the week;
+   * "paid" if its paidDate falls in the week.
+   */
+  private async weeklyCollectionRate(
+    since: Date,
+  ): Promise<AnalyticsResult['weeklyCollectionRate']> {
+    try {
+      const rows = await this.prisma.$queryRaw<WeeklyCollectionRow[]>`
+        SELECT
+          date_trunc('week', p.paid_date)::date  AS week_start,
+          COUNT(*) FILTER (WHERE p.status = 'PAID') AS paid_count,
+          COUNT(*) AS due_count
+        FROM payments p
+        WHERE p.deleted_at IS NULL
+          AND p.paid_date >= ${since}
+        GROUP BY date_trunc('week', p.paid_date)
+        ORDER BY week_start ASC
+      `;
+      return rows.map((r) => ({
+        weekStart: r.week_start.toISOString().split('T')[0],
+        paidCount: Number(r.paid_count),
+        dueCount: Number(r.due_count),
+        rate: Number(r.due_count) > 0 ? Number(r.paid_count) / Number(r.due_count) : 0,
+      }));
+    } catch (err) {
+      this.logger.error('weeklyCollectionRate query failed', err);
+      return [];
+    }
+  }
+
+  /**
+   * Promises kept vs broken per week, from CallLog with result='PROMISED'.
+   * A promise is "broken" if brokenAt is set in the week range;
+   * "kept" if settlementDate is in the week range and brokenAt IS NULL.
+   */
+  private async promiseKeptTrend(
+    since: Date,
+  ): Promise<AnalyticsResult['promiseKeptTrend']> {
+    try {
+      const rows = await this.prisma.$queryRaw<PromiseKeptRow[]>`
+        SELECT
+          date_trunc('week', COALESCE(broken_at, settlement_date))::date AS week_start,
+          COUNT(*) FILTER (WHERE broken_at IS NULL AND settlement_date IS NOT NULL) AS kept,
+          COUNT(*) FILTER (WHERE broken_at IS NOT NULL) AS broken
+        FROM call_logs
+        WHERE deleted_at IS NULL
+          AND result = 'PROMISED'
+          AND COALESCE(broken_at, settlement_date) >= ${since}
+          AND COALESCE(broken_at, settlement_date) IS NOT NULL
+        GROUP BY date_trunc('week', COALESCE(broken_at, settlement_date))
+        ORDER BY week_start ASC
+      `;
+      return rows.map((r) => ({
+        weekStart: r.week_start.toISOString().split('T')[0],
+        kept: Number(r.kept),
+        broken: Number(r.broken),
+      }));
+    } catch (err) {
+      this.logger.error('promiseKeptTrend query failed', err);
+      return [];
+    }
+  }
+
+  /**
+   * DunningActions by day — count SENT vs FAILED.
+   */
+  private async dunningActionVolume(
+    since: Date,
+  ): Promise<AnalyticsResult['dunningActionVolume']> {
+    try {
+      const rows = await this.prisma.$queryRaw<DunningVolumeRow[]>`
+        SELECT
+          date_trunc('day', created_at)::date AS day,
+          COUNT(*) FILTER (WHERE status = 'SENT') AS sent,
+          COUNT(*) FILTER (WHERE status = 'FAILED') AS failed
+        FROM dunning_actions
+        WHERE deleted_at IS NULL
+          AND created_at >= ${since}
+        GROUP BY date_trunc('day', created_at)
+        ORDER BY day ASC
+      `;
+      return rows.map((r) => ({
+        date: r.day.toISOString().split('T')[0],
+        sent: Number(r.sent),
+        failed: Number(r.failed),
+      }));
+    } catch (err) {
+      this.logger.error('dunningActionVolume query failed', err);
+      return [];
+    }
+  }
+
+  /**
+   * ContractLetters dispatched, grouped by type and month.
+   */
+  private async letterDispatchByType(
+    since: Date,
+  ): Promise<AnalyticsResult['letterDispatchByType']> {
+    try {
+      const rows = await this.prisma.$queryRaw<LetterDispatchRow[]>`
+        SELECT
+          letter_type,
+          date_trunc('month', dispatched_at)::date AS month,
+          COUNT(*) AS cnt
+        FROM contract_letters
+        WHERE deleted_at IS NULL
+          AND dispatched_at IS NOT NULL
+          AND dispatched_at >= ${since}
+        GROUP BY letter_type, date_trunc('month', dispatched_at)
+        ORDER BY month ASC, letter_type ASC
+      `;
+      return rows.map((r) => ({
+        type: r.letter_type,
+        month: r.month.toISOString().split('T')[0].substring(0, 7), // YYYY-MM
+        count: Number(r.cnt),
+      }));
+    } catch (err) {
+      this.logger.error('letterDispatchByType query failed', err);
+      return [];
+    }
+  }
+
+  /**
+   * MdmLockRequests by day — proposed count + approved count.
+   */
+  private async mdmLockVolume(
+    since: Date,
+  ): Promise<AnalyticsResult['mdmLockVolume']> {
+    try {
+      const rows = await this.prisma.$queryRaw<MdmVolumeRow[]>`
+        SELECT
+          date_trunc('day', proposed_at)::date AS day,
+          COUNT(*) AS proposed,
+          COUNT(*) FILTER (WHERE status = 'APPROVED') AS approved
+        FROM mdm_lock_requests
+        WHERE deleted_at IS NULL
+          AND proposed_at >= ${since}
+        GROUP BY date_trunc('day', proposed_at)
+        ORDER BY day ASC
+      `;
+      return rows.map((r) => ({
+        date: r.day.toISOString().split('T')[0],
+        proposed: Number(r.proposed),
+        approved: Number(r.approved),
+      }));
+    } catch (err) {
+      this.logger.error('mdmLockVolume query failed', err);
+      return [];
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/analytics.service.ts
+++ b/apps/api/src/modules/overdue/analytics.service.ts
@@ -36,9 +36,29 @@ export class OverdueAnalyticsService {
     return value;
   }
 
+  /**
+   * Return the UTC Date representing midnight of the current day in
+   * Asia/Bangkok (UTC+7, no DST), minus N days. This keeps day-boundary
+   * buckets aligned with the local business day rather than UTC midnight.
+   */
+  private bangkokMidnightDaysAgo(days: number): Date {
+    const BKK_OFFSET_MS = 7 * 60 * 60 * 1000;
+    // Convert "now" into Bangkok-local clock, floor to start-of-day there,
+    // then convert back to UTC by subtracting the offset.
+    const nowUtc = Date.now();
+    const bkkNow = new Date(nowUtc + BKK_OFFSET_MS);
+    const bkkMidnightUtc = Date.UTC(
+      bkkNow.getUTCFullYear(),
+      bkkNow.getUTCMonth(),
+      bkkNow.getUTCDate(),
+    );
+    const sinceUtcMs = bkkMidnightUtc - BKK_OFFSET_MS - days * 24 * 60 * 60 * 1000;
+    return new Date(sinceUtcMs);
+  }
+
   private async compute(range: '30d' | '90d'): Promise<AnalyticsResult> {
     const days = range === '30d' ? 30 : 90;
-    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const since = this.bangkokMidnightDaysAgo(days);
 
     const [
       weeklyCollectionRate,

--- a/apps/api/src/modules/overdue/contract-letter.service.spec.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.spec.ts
@@ -347,4 +347,53 @@ describe('ContractLetterService', () => {
       ).rejects.toThrow(/สถานะ/);
     });
   });
+
+  describe('updateEvidence', () => {
+    it('updates evidencePhotoUrl and creates audit log for DISPATCHED letter', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l9',
+        status: 'DISPATCHED',
+        contractId: 'c9',
+      });
+      const updatedLetter = { id: 'l9', status: 'DISPATCHED', evidencePhotoUrl: 'https://s3.example.com/slip.jpg' };
+      mockPrisma.$transaction.mockResolvedValueOnce([updatedLetter, {}]);
+
+      const result = await service.updateEvidence('l9', 'https://s3.example.com/slip.jpg', 'u1');
+      expect(result).toBe(updatedLetter);
+    });
+
+    it('updates evidencePhotoUrl for DELIVERED letter', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l10',
+        status: 'DELIVERED',
+        contractId: 'c10',
+      });
+      const updatedLetter = { id: 'l10', status: 'DELIVERED', evidencePhotoUrl: 'https://s3.example.com/slip2.jpg' };
+      mockPrisma.$transaction.mockResolvedValueOnce([updatedLetter, {}]);
+
+      const result = await service.updateEvidence('l10', 'https://s3.example.com/slip2.jpg', 'u1');
+      expect(result).toBe(updatedLetter);
+    });
+
+    it('throws NotFound when letter missing', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce(null);
+      await expect(service.updateEvidence('nope', 'https://example.com/a.jpg', 'u1')).rejects.toThrow(/ไม่พบหนังสือ/);
+    });
+
+    it('throws BadRequest when status is PENDING_DISPATCH (not yet dispatched)', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l11',
+        status: 'PENDING_DISPATCH',
+      });
+      await expect(service.updateEvidence('l11', 'https://example.com/a.jpg', 'u1')).rejects.toThrow(/ส่งแล้ว/);
+    });
+
+    it('throws BadRequest when evidencePhotoUrl is empty string', async () => {
+      mockPrisma.contractLetter.findUnique.mockResolvedValueOnce({
+        id: 'l12',
+        status: 'DISPATCHED',
+      });
+      await expect(service.updateEvidence('l12', '   ', 'u1')).rejects.toThrow(/อัปโหลด/);
+    });
+  });
 });

--- a/apps/api/src/modules/overdue/contract-letter.service.ts
+++ b/apps/api/src/modules/overdue/contract-letter.service.ts
@@ -267,6 +267,37 @@ export class ContractLetterService {
       .then(([l]) => l);
   }
 
+  /**
+   * Update the evidence photo URL for a letter that has already been dispatched or delivered.
+   * Creates an audit trail entry alongside the update.
+   */
+  async updateEvidence(letterId: string, evidencePhotoUrl: string, userId: string) {
+    const letter = await this.prisma.contractLetter.findUnique({ where: { id: letterId } });
+    if (!letter) throw new NotFoundException('ไม่พบหนังสือ');
+    if (!['DISPATCHED', 'DELIVERED'].includes(letter.status)) {
+      throw new BadRequestException('สามารถเพิ่มสลิปได้เฉพาะหนังสือที่ส่งแล้ว');
+    }
+    if (!evidencePhotoUrl || !evidencePhotoUrl.trim()) {
+      throw new BadRequestException('กรุณาอัปโหลดสลิป');
+    }
+    const [updated] = await this.prisma.$transaction([
+      this.prisma.contractLetter.update({
+        where: { id: letterId },
+        data: { evidencePhotoUrl: evidencePhotoUrl.trim() },
+      }),
+      this.prisma.auditLog.create({
+        data: {
+          userId,
+          action: 'LETTER_EVIDENCE_UPDATED',
+          entity: 'contract_letter',
+          entityId: letterId,
+          newValue: { evidencePhotoUrl },
+        },
+      }),
+    ]);
+    return updated;
+  }
+
   private async nextSequence(year: number): Promise<number> {
     const count = await this.prisma.contractLetter.count({
       where: { letterNumber: { startsWith: `ST-${year}-` } },

--- a/apps/api/src/modules/overdue/dto/analytics-query.dto.ts
+++ b/apps/api/src/modules/overdue/dto/analytics-query.dto.ts
@@ -1,0 +1,7 @@
+import { IsIn, IsOptional } from 'class-validator';
+
+export class AnalyticsQueryDto {
+  @IsOptional()
+  @IsIn(['30d', '90d'], { message: 'range ต้องเป็น 30d หรือ 90d' })
+  range?: '30d' | '90d';
+}

--- a/apps/api/src/modules/overdue/dto/update-letter-evidence.dto.spec.ts
+++ b/apps/api/src/modules/overdue/dto/update-letter-evidence.dto.spec.ts
@@ -1,0 +1,150 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import {
+  UpdateLetterEvidenceDto,
+  isPrivateOrLoopbackHost,
+} from './update-letter-evidence.dto';
+
+async function expectInvalid(url: string) {
+  const dto = plainToInstance(UpdateLetterEvidenceDto, { evidencePhotoUrl: url });
+  const errors = await validate(dto);
+  expect(errors.length).toBeGreaterThan(0);
+}
+
+async function expectValid(url: string) {
+  const dto = plainToInstance(UpdateLetterEvidenceDto, { evidencePhotoUrl: url });
+  const errors = await validate(dto);
+  expect(errors).toHaveLength(0);
+}
+
+describe('UpdateLetterEvidenceDto — SSRF defenses', () => {
+  const ORIGINAL_S3_ENDPOINT = process.env.S3_ENDPOINT;
+
+  afterEach(() => {
+    if (ORIGINAL_S3_ENDPOINT === undefined) delete process.env.S3_ENDPOINT;
+    else process.env.S3_ENDPOINT = ORIGINAL_S3_ENDPOINT;
+  });
+
+  describe('rejects internal / loopback / private hosts', () => {
+    it('rejects loopback IPv4 (127.0.0.1)', async () => {
+      await expectInvalid('https://127.0.0.1/x');
+    });
+
+    it('rejects cloud metadata IMDS (169.254.169.254)', async () => {
+      await expectInvalid('https://169.254.169.254/x');
+    });
+
+    it('rejects RFC1918 10.x', async () => {
+      await expectInvalid('https://10.0.0.1/x');
+    });
+
+    it('rejects RFC1918 192.168.x', async () => {
+      await expectInvalid('https://192.168.1.1/x');
+    });
+
+    it('rejects RFC1918 172.16-31.x', async () => {
+      await expectInvalid('https://172.20.0.5/x');
+    });
+
+    it('rejects 0.0.0.0', async () => {
+      await expectInvalid('https://0.0.0.0/x');
+    });
+
+    it('rejects IPv6 loopback [::1]', async () => {
+      await expectInvalid('https://[::1]/x');
+    });
+
+    it('rejects "localhost" hostname', async () => {
+      await expectInvalid('https://localhost/x');
+    });
+
+    it('rejects subdomain of .localhost', async () => {
+      await expectInvalid('https://api.localhost/x');
+    });
+  });
+
+  describe('rejects non-https schemes', () => {
+    it('rejects http://example.com (not https)', async () => {
+      await expectInvalid('http://example.com/x');
+    });
+
+    it('rejects ftp scheme', async () => {
+      await expectInvalid('ftp://storage.googleapis.com/bucket/x');
+    });
+
+    it('rejects javascript: scheme', async () => {
+      await expectInvalid('javascript:alert(1)');
+    });
+  });
+
+  describe('rejects unknown public hosts (allowlist enforcement)', () => {
+    it('rejects evil.com even with valid https', async () => {
+      delete process.env.S3_ENDPOINT;
+      await expectInvalid('https://evil.com/x');
+    });
+
+    it('rejects look-alike host that contains storage.googleapis.com as path', async () => {
+      delete process.env.S3_ENDPOINT;
+      await expectInvalid('https://attacker.com/storage.googleapis.com/bucket/x');
+    });
+
+    it('rejects empty / malformed URLs', async () => {
+      await expectInvalid('');
+      await expectInvalid('not a url');
+      await expectInvalid('https://');
+    });
+  });
+
+  describe('accepts configured public storage hosts', () => {
+    it('accepts GCS public URL (storage.googleapis.com)', async () => {
+      delete process.env.S3_ENDPOINT;
+      await expectValid('https://storage.googleapis.com/bestchoice-documents/letters/x.pdf');
+    });
+
+    it('accepts URL whose host matches S3_ENDPOINT', async () => {
+      process.env.S3_ENDPOINT = 'https://minio.example.com';
+      await expectValid('https://minio.example.com/bucket/x.jpg');
+    });
+
+    it('still accepts GCS even when S3_ENDPOINT is set', async () => {
+      process.env.S3_ENDPOINT = 'https://minio.example.com';
+      await expectValid('https://storage.googleapis.com/bucket/x.jpg');
+    });
+
+    it('rejects host that does not match S3_ENDPOINT', async () => {
+      process.env.S3_ENDPOINT = 'https://minio.example.com';
+      await expectInvalid('https://other.example.com/bucket/x.jpg');
+    });
+  });
+
+  describe('isPrivateOrLoopbackHost — unit', () => {
+    it.each([
+      'localhost',
+      '127.0.0.1',
+      '10.255.255.255',
+      '169.254.169.254',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.0.1',
+      '0.0.0.0',
+      '100.64.0.1',
+      '::1',
+      'fe80::1',
+    ])('flags %s as private', (h) => {
+      expect(isPrivateOrLoopbackHost(h)).toBe(true);
+    });
+
+    it.each(['storage.googleapis.com', 'example.com', 'minio.example.com'])(
+      'leaves %s alone (not private)',
+      (h) => {
+        expect(isPrivateOrLoopbackHost(h)).toBe(false);
+      },
+    );
+
+    it('flags 172.15.x.x as private (any IPv4 literal rejected)', () => {
+      // outside RFC1918 172.16-31 but still an IP literal — reject by default
+      expect(isPrivateOrLoopbackHost('172.15.0.1')).toBe(true);
+      expect(isPrivateOrLoopbackHost('8.8.8.8')).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/dto/update-letter-evidence.dto.ts
+++ b/apps/api/src/modules/overdue/dto/update-letter-evidence.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsUrl } from 'class-validator';
+
+export class UpdateLetterEvidenceDto {
+  @IsString({ message: 'กรุณาระบุ URL' })
+  @IsUrl(
+    { protocols: ['https'], require_protocol: true },
+    { message: 'URL ต้องเป็น https' },
+  )
+  evidencePhotoUrl: string;
+}

--- a/apps/api/src/modules/overdue/dto/update-letter-evidence.dto.ts
+++ b/apps/api/src/modules/overdue/dto/update-letter-evidence.dto.ts
@@ -1,10 +1,114 @@
-import { IsString, IsUrl } from 'class-validator';
+import {
+  IsString,
+  Validate,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+/**
+ * IsPublicHttpsUrl — strict URL validator that defends against SSRF.
+ *
+ * Approach: **allowlist**. We only accept https URLs whose host matches a
+ * known storage backend (GCS public host, optional custom S3 endpoint host).
+ * This is preferred over a deny-list because storage backends are a closed,
+ * predictable set — no need to enumerate private IP ranges.
+ *
+ * **Defense-in-depth fallback**: even when the host doesn't match the allowlist
+ * (e.g. tests without env), we still reject IP literals, localhost, and
+ * RFC1918 / link-local ranges so the DTO is safe by default.
+ *
+ * Allowed hosts (resolved at validation time from env):
+ *  - `storage.googleapis.com` (GCS — always allowed)
+ *  - host extracted from `S3_ENDPOINT` (if set — for MinIO / R2 / dev)
+ */
+@ValidatorConstraint({ name: 'isPublicHttpsUrl', async: false })
+export class IsPublicHttpsUrlConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string' || value.length === 0) return false;
+
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      return false;
+    }
+
+    if (url.protocol !== 'https:') return false;
+
+    const host = url.hostname.toLowerCase();
+    if (!host) return false;
+
+    // Always reject obviously-internal hosts (defense in depth)
+    if (isPrivateOrLoopbackHost(host)) return false;
+
+    // Allowlist: GCS public host
+    if (host === 'storage.googleapis.com') return true;
+
+    // Allowlist: configured S3 endpoint (MinIO / R2 / etc.)
+    const s3Endpoint = process.env.S3_ENDPOINT;
+    if (s3Endpoint) {
+      try {
+        const s3Host = new URL(s3Endpoint).hostname.toLowerCase();
+        if (s3Host && host === s3Host) return true;
+      } catch {
+        // malformed S3_ENDPOINT — ignore and fall through to reject
+      }
+    }
+
+    return false;
+  }
+
+  defaultMessage(_args: ValidationArguments): string {
+    return 'URL ต้องเป็น https สาธารณะเท่านั้น';
+  }
+}
+
+/**
+ * Returns true if the host is an IP literal, loopback, or RFC1918 / link-local
+ * address that must never be reachable from server-side fetches.
+ */
+export function isPrivateOrLoopbackHost(host: string): boolean {
+  const h = host.toLowerCase();
+
+  // Hostname denylist
+  if (h === 'localhost' || h === 'localhost.localdomain') return true;
+  if (h.endsWith('.localhost')) return true;
+
+  // IPv6 literal — URL.hostname strips brackets, so "::1" / "0::1" appear raw.
+  // Any host containing ":" is an IPv6 literal in this context.
+  if (h.includes(':')) return true;
+
+  // IPv4 dotted literal? (4 numeric octets)
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+
+  const o = m.slice(1, 5).map((n) => Number(n));
+  if (o.some((n) => n < 0 || n > 255)) return true; // malformed IP — reject
+
+  const [a, b] = o;
+
+  // 0.0.0.0/8 — "this network" / unspecified
+  if (a === 0) return true;
+  // 10.0.0.0/8 — RFC1918
+  if (a === 10) return true;
+  // 127.0.0.0/8 — loopback
+  if (a === 127) return true;
+  // 169.254.0.0/16 — link-local (incl. cloud metadata 169.254.169.254)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12 — RFC1918
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16 — RFC1918
+  if (a === 192 && b === 168) return true;
+  // 100.64.0.0/10 — CGNAT
+  if (a === 100 && b >= 64 && b <= 127) return true;
+
+  // Any other IPv4 literal — still reject (we want hostnames only for public URLs)
+  return true;
+}
 
 export class UpdateLetterEvidenceDto {
   @IsString({ message: 'กรุณาระบุ URL' })
-  @IsUrl(
-    { protocols: ['https'], require_protocol: true },
-    { message: 'URL ต้องเป็น https' },
-  )
-  evidencePhotoUrl: string;
+  @Validate(IsPublicHttpsUrlConstraint)
+  evidencePhotoUrl!: string;
 }

--- a/apps/api/src/modules/overdue/dunning-retry.service.spec.ts
+++ b/apps/api/src/modules/overdue/dunning-retry.service.spec.ts
@@ -1,0 +1,120 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { DunningRetryService } from './dunning-retry.service';
+
+const mockPrisma = {
+  dunningAction: {
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+const mockNotifications = {
+  send: jest.fn(),
+};
+
+const baseAction = {
+  id: 'action-1',
+  status: 'FAILED',
+  deletedAt: null,
+  messageContent: 'กรุณาชำระค่างวด',
+  contractId: 'contract-1',
+  dunningRule: { id: 'rule-1', name: 'LINE Reminder', channel: 'LINE' },
+  contract: {
+    id: 'contract-1',
+    contractNumber: 'BC-2026-001',
+    customer: { id: 'cust-1', name: 'สมชาย ใจดี', phone: '0812345678', lineId: 'Uabc123' },
+  },
+};
+
+describe('DunningRetryService', () => {
+  let service: DunningRetryService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DunningRetryService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: NotificationsService, useValue: mockNotifications },
+      ],
+    }).compile();
+    service = module.get(DunningRetryService);
+  });
+
+  describe('listFailed', () => {
+    it('queries status=FAILED ordered by createdAt desc', async () => {
+      mockPrisma.dunningAction.findMany.mockResolvedValueOnce([baseAction]);
+      const result = await service.listFailed(50);
+      expect(result).toEqual([baseAction]);
+      const arg = mockPrisma.dunningAction.findMany.mock.calls[0][0];
+      expect(arg.where.status).toBe('FAILED');
+      expect(arg.where.deletedAt).toBeNull();
+      expect(arg.orderBy).toEqual({ createdAt: 'desc' });
+      expect(arg.take).toBe(50);
+    });
+
+    it('uses default limit 100 when not specified', async () => {
+      mockPrisma.dunningAction.findMany.mockResolvedValueOnce([]);
+      await service.listFailed();
+      const arg = mockPrisma.dunningAction.findMany.mock.calls[0][0];
+      expect(arg.take).toBe(100);
+    });
+  });
+
+  describe('retry', () => {
+    it('throws NotFoundException if action not found', async () => {
+      mockPrisma.dunningAction.findUnique.mockResolvedValueOnce(null);
+      await expect(service.retry('nope', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequest if action status is not FAILED', async () => {
+      mockPrisma.dunningAction.findUnique.mockResolvedValueOnce({
+        ...baseAction,
+        status: 'SENT',
+      });
+      await expect(service.retry('action-1', 'user-1')).rejects.toThrow(BadRequestException);
+      expect(mockNotifications.send).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequest if no recipient for channel', async () => {
+      mockPrisma.dunningAction.findUnique.mockResolvedValueOnce({
+        ...baseAction,
+        dunningRule: { id: 'rule-1', name: 'LINE Reminder', channel: 'LINE' },
+        contract: {
+          ...baseAction.contract,
+          customer: { ...baseAction.contract.customer, lineId: null },
+        },
+      });
+      await expect(service.retry('action-1', 'user-1')).rejects.toThrow(/ไม่พบผู้รับ/);
+      expect(mockNotifications.send).not.toHaveBeenCalled();
+    });
+
+    it('updates status=SENT and sets executedById on success', async () => {
+      mockPrisma.dunningAction.findUnique.mockResolvedValueOnce(baseAction);
+      mockNotifications.send.mockResolvedValueOnce({ id: 'notif-1', status: 'SENT' });
+      const updatedAction = { ...baseAction, status: 'SENT', executedById: 'user-1' };
+      mockPrisma.dunningAction.update.mockResolvedValueOnce(updatedAction);
+
+      const result = await service.retry('action-1', 'user-1');
+      expect(result.status).toBe('SENT');
+      const updateArg = mockPrisma.dunningAction.update.mock.calls[0][0];
+      expect(updateArg.data.status).toBe('SENT');
+      expect(updateArg.data.executedById).toBe('user-1');
+      expect(updateArg.data.result).toContain('manual retry OK');
+    });
+
+    it('keeps FAILED and throws BadRequest when send returns FAILED', async () => {
+      mockPrisma.dunningAction.findUnique.mockResolvedValueOnce(baseAction);
+      mockNotifications.send.mockResolvedValueOnce({ id: 'notif-2', status: 'FAILED', errorMsg: 'LINE token invalid' });
+      mockPrisma.dunningAction.update.mockResolvedValueOnce({ ...baseAction });
+
+      await expect(service.retry('action-1', 'user-1')).rejects.toThrow(BadRequestException);
+      const updateArg = mockPrisma.dunningAction.update.mock.calls[0][0];
+      expect(updateArg.data.result).toContain('manual retry failed');
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/dunning-retry.service.ts
+++ b/apps/api/src/modules/overdue/dunning-retry.service.ts
@@ -1,0 +1,133 @@
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+
+@Injectable()
+export class DunningRetryService {
+  private readonly logger = new Logger(DunningRetryService.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private notificationsService: NotificationsService,
+  ) {}
+
+  /**
+   * List DunningActions with status=FAILED, newest first.
+   * Includes contract.customer (for display) and dunningRule (for channel info).
+   */
+  async listFailed(limit = 100) {
+    return this.prisma.dunningAction.findMany({
+      where: { status: 'FAILED', deletedAt: null },
+      include: {
+        contract: {
+          select: {
+            id: true,
+            contractNumber: true,
+            customer: { select: { id: true, name: true, phone: true, lineId: true } },
+          },
+        },
+        dunningRule: {
+          select: { id: true, name: true, channel: true, messageTemplate: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  }
+
+  /**
+   * Retry a single failed DunningAction.
+   * Re-sends via NotificationsService using stored messageContent + recipient from contract.customer.
+   * - On success: updates status=SENT
+   * - On failure: keeps status=FAILED and updates result text
+   */
+  async retry(actionId: string, userId: string) {
+    const action = await this.prisma.dunningAction.findUnique({
+      where: { id: actionId },
+      include: {
+        contract: {
+          select: {
+            id: true,
+            contractNumber: true,
+            customer: { select: { id: true, name: true, phone: true, lineId: true } },
+          },
+        },
+        dunningRule: {
+          select: { id: true, name: true, channel: true },
+        },
+      },
+    });
+
+    if (!action || action.deletedAt) {
+      throw new NotFoundException('ไม่พบ DunningAction');
+    }
+
+    if (action.status !== 'FAILED') {
+      throw new BadRequestException('สามารถ retry ได้เฉพาะ DunningAction ที่มีสถานะ FAILED เท่านั้น');
+    }
+
+    const customer = action.contract.customer;
+    const channel = action.dunningRule.channel;
+
+    // Resolve recipient based on channel
+    const recipient =
+      channel === 'LINE' ? customer.lineId : customer.phone;
+
+    if (!recipient) {
+      throw new BadRequestException(
+        `ไม่พบผู้รับสำหรับช่องทาง ${channel} (ลูกค้า: ${customer.name})`,
+      );
+    }
+
+    const message = action.messageContent ?? action.dunningRule.channel;
+
+    try {
+      const sendResult = await this.notificationsService.send({
+        channel: channel as 'LINE' | 'SMS',
+        recipient,
+        message,
+        relatedId: action.contractId,
+        subject: `Dunning retry: ${action.dunningRule.name}`,
+        noRetry: true, // manual retry — don't re-enqueue on failure
+      });
+
+      if (sendResult.status === 'SENT') {
+        const updated = await this.prisma.dunningAction.update({
+          where: { id: actionId },
+          data: {
+            status: 'SENT',
+            executedAt: new Date(),
+            executedById: userId,
+            result: `manual retry OK — notif ${sendResult.id}`,
+          },
+        });
+        this.logger.log(`[DunningRetry] action ${actionId} retry succeeded by user ${userId}`);
+        return updated;
+      } else {
+        // send returned FAILED without throwing
+        await this.prisma.dunningAction.update({
+          where: { id: actionId },
+          data: {
+            result: `manual retry failed: ${sendResult.errorMsg ?? 'unknown'}`,
+            updatedAt: new Date(),
+          },
+        });
+        throw new BadRequestException(
+          `ส่ง ${channel} ไม่สำเร็จ: ${sendResult.errorMsg ?? 'unknown'}`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException || err instanceof NotFoundException) throw err;
+
+      const errMsg = err instanceof Error ? err.message : String(err);
+      await this.prisma.dunningAction.update({
+        where: { id: actionId },
+        data: {
+          result: `manual retry exception: ${errMsg}`,
+          updatedAt: new Date(),
+        },
+      });
+      throw new BadRequestException(`ส่ง ${channel} ไม่สำเร็จ: ${errMsg}`);
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -10,6 +10,8 @@ import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
 import { ContractLetterService } from './contract-letter.service';
 import { DunningRetryService } from './dunning-retry.service';
+import { OverdueAnalyticsService } from './analytics.service';
+import { AnalyticsQueryDto } from './dto/analytics-query.dto';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { AssignCollectorDto } from './dto/assign-collector.dto';
 import { RecordSettlementDto } from './dto/record-settlement.dto';
@@ -41,6 +43,7 @@ export class OverdueController {
     private bulkService: OverdueBulkService,
     private contractLetterService: ContractLetterService,
     private dunningRetryService: DunningRetryService,
+    private analyticsService: OverdueAnalyticsService,
   ) {}
 
   // --- Collections Workflow Hub endpoints (Plan 2) ---
@@ -466,6 +469,14 @@ export class OverdueController {
     @CurrentUser() user: { id: string },
   ) {
     return this.contractLetterService.cancel(id, user.id, body.reason);
+  }
+
+  // --- Collections analytics ---
+
+  @Get('analytics')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  getAnalytics(@Query() dto: AnalyticsQueryDto) {
+    return this.analyticsService.getAnalytics({ range: dto.range ?? '30d' });
   }
 
   // --- LINE retry endpoints ---

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -438,6 +438,16 @@ export class OverdueController {
     return this.contractLetterService.markDelivered(id, user.id);
   }
 
+  @Patch('letters/:id/evidence')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  updateLetterEvidence(
+    @Param('id') id: string,
+    @Body() body: { evidencePhotoUrl: string },
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractLetterService.updateEvidence(id, body.evidencePhotoUrl, user.id);
+  }
+
   @Post('letters/:id/undeliverable')
   @Roles('OWNER', 'FINANCE_MANAGER')
   markLetterUndeliverable(

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -9,6 +9,7 @@ import { MdmLockService } from './mdm-lock.service';
 import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
 import { ContractLetterService } from './contract-letter.service';
+import { DunningRetryService } from './dunning-retry.service';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { AssignCollectorDto } from './dto/assign-collector.dto';
 import { RecordSettlementDto } from './dto/record-settlement.dto';
@@ -39,6 +40,7 @@ export class OverdueController {
     private timelineService: OverdueTimelineService,
     private bulkService: OverdueBulkService,
     private contractLetterService: ContractLetterService,
+    private dunningRetryService: DunningRetryService,
   ) {}
 
   // --- Collections Workflow Hub endpoints (Plan 2) ---
@@ -454,5 +456,19 @@ export class OverdueController {
     @CurrentUser() user: { id: string },
   ) {
     return this.contractLetterService.cancel(id, user.id, body.reason);
+  }
+
+  // --- LINE retry endpoints ---
+
+  @Get('line-retries')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
+  listFailed(@Query('limit') limit?: string) {
+    return this.dunningRetryService.listFailed(limit ? parseInt(limit, 10) : 100);
+  }
+
+  @Post('line-retries/:id/retry')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  retryLine(@Param('id') id: string, @CurrentUser() user: { id: string }) {
+    return this.dunningRetryService.retry(id, user.id);
   }
 }

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -21,6 +21,7 @@ import { QueueQueryDto } from './dto/queue-query.dto';
 import { KpiQueryDto } from './dto/kpi-query.dto';
 import { BulkAssignDto, BulkProposeLockDto, BulkSendLineDto } from './dto/bulk.dto';
 import { SendLineAdHocDto } from './dto/send-line-adhoc.dto';
+import { UpdateLetterEvidenceDto } from './dto/update-letter-evidence.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -445,10 +446,10 @@ export class OverdueController {
   @Roles('OWNER', 'FINANCE_MANAGER')
   updateLetterEvidence(
     @Param('id') id: string,
-    @Body() body: { evidencePhotoUrl: string },
+    @Body() dto: UpdateLetterEvidenceDto,
     @CurrentUser() user: { id: string },
   ) {
-    return this.contractLetterService.updateEvidence(id, body.evidencePhotoUrl, user.id);
+    return this.contractLetterService.updateEvidence(id, dto.evidencePhotoUrl, user.id);
   }
 
   @Post('letters/:id/undeliverable')
@@ -484,7 +485,11 @@ export class OverdueController {
   @Get('line-retries')
   @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
   listFailed(@Query('limit') limit?: string) {
-    return this.dunningRetryService.listFailed(limit ? parseInt(limit, 10) : 100);
+    const parsedLimit = Math.min(
+      Math.max(parseInt(limit ?? '', 10) || 100, 1),
+      500,
+    );
+    return this.dunningRetryService.listFailed(parsedLimit);
   }
 
   @Post('line-retries/:id/retry')

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -11,6 +11,7 @@ import { OverdueKpiService } from './kpi.service';
 import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
 import { DunningRetryService } from './dunning-retry.service';
+import { OverdueAnalyticsService } from './analytics.service';
 import { OwnerAlertHelper } from './owner-alert.helper';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
@@ -34,6 +35,7 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     OverdueTimelineService,
     OverdueBulkService,
     DunningRetryService,
+    OverdueAnalyticsService,
     OwnerAlertHelper,
     BrokenPromiseCron,
     MdmAutoProposeCron,

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -10,6 +10,7 @@ import { OverdueQueueService } from './queue.service';
 import { OverdueKpiService } from './kpi.service';
 import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
+import { DunningRetryService } from './dunning-retry.service';
 import { OwnerAlertHelper } from './owner-alert.helper';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
@@ -32,6 +33,7 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     OverdueKpiService,
     OverdueTimelineService,
     OverdueBulkService,
+    DunningRetryService,
     OwnerAlertHelper,
     BrokenPromiseCron,
     MdmAutoProposeCron,

--- a/apps/api/src/modules/payments/dto/payment.dto.ts
+++ b/apps/api/src/modules/payments/dto/payment.dto.ts
@@ -45,6 +45,12 @@ export class BulkRecordPaymentDto {
 
   @IsString()
   @IsOptional()
+  @MaxLength(2048)
+  @Matches(/^https:\/\/.+/, { message: 'evidenceUrl ต้องเป็น HTTPS URL' })
+  evidenceUrl?: string; // สลิปโอนเงิน / หลักฐานการชำระ (ติดไว้กับงวดแรกที่สร้าง)
+
+  @IsString()
+  @IsOptional()
   notes?: string;
 }
 

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -127,6 +127,7 @@ export class PaymentsController {
       dto.paymentMethod,
       user.id,
       dto.notes,
+      dto.evidenceUrl,
     );
   }
 

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -295,6 +295,26 @@ describe('PaymentsService', () => {
       expect(result.totalAllocated).toBe(5000);
       expect(result.overpayment).toBe(0);
     });
+
+    it('should attach evidenceUrl to the first payment only', async () => {
+      const payments = [
+        { ...mockPayment, id: 'p-1', installmentNo: 1, amountDue: 3000, amountPaid: 0, lateFee: 0, status: 'PENDING' },
+        { ...mockPayment, id: 'p-2', installmentNo: 2, amountDue: 3000, amountPaid: 0, lateFee: 0, status: 'PENDING' },
+      ];
+      prisma.contract.findUnique.mockResolvedValue({ ...mockContract, payments });
+      prisma.payment.update
+        .mockResolvedValueOnce({ ...payments[0], amountPaid: 3000, status: 'PAID', paidDate: new Date() })
+        .mockResolvedValueOnce({ ...payments[1], amountPaid: 2000, status: 'PARTIALLY_PAID', paidDate: null });
+
+      await service.autoAllocatePayment(
+        'contract-1', 5000, 'BANK_TRANSFER', 'user-1', undefined, 'https://slip.example.com/transfer.jpg',
+      );
+
+      const firstCall = prisma.payment.update.mock.calls[0][0];
+      const secondCall = prisma.payment.update.mock.calls[1][0];
+      expect(firstCall.data.evidenceUrl).toBe('https://slip.example.com/transfer.jpg');
+      expect(secondCall.data.evidenceUrl).toBeUndefined();
+    });
   });
 
   describe('getContractPayments', () => {

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -282,6 +282,7 @@ export class PaymentsService {
     paymentMethod: string,
     recordedById: string,
     notes?: string,
+    evidenceUrl?: string,
   ) {
     if (!amount || amount <= 0) {
       throw new BadRequestException('จำนวนเงินต้องมากกว่า 0');
@@ -305,13 +306,16 @@ export class PaymentsService {
       const unpaid = contract.payments.filter((p) => p.status !== 'PAID');
       if (unpaid.length === 0) throw new BadRequestException('ไม่มีงวดค้างชำระ');
 
-      for (const payment of unpaid) {
+      for (const [idx, payment] of unpaid.entries()) {
         if (remaining.lte(0)) break;
 
         const amountDue = dRound(dSub(dAdd(payment.amountDue, payment.lateFee), payment.amountPaid));
         const payAmount = dRound(Prisma.Decimal.min(remaining, amountDue));
         const totalPaid = dRound(dAdd(payment.amountPaid, payAmount));
         const isPaidInFull = dGte(totalPaid, dRound(dAdd(payment.amountDue, payment.lateFee)));
+
+        // Attach evidenceUrl to the FIRST payment only (represents the transfer slip)
+        const isFirstPayment = idx === 0;
 
         const updated = await tx.payment.update({
           where: { id: payment.id },
@@ -322,6 +326,7 @@ export class PaymentsService {
             status: isPaidInFull ? 'PAID' : 'PARTIALLY_PAID',
             recordedById,
             notes: notes || payment.notes,
+            ...(isFirstPayment && evidenceUrl ? { evidenceUrl } : {}),
           },
         });
 

--- a/apps/web/src/pages/AuditLogsPage.tsx
+++ b/apps/web/src/pages/AuditLogsPage.tsx
@@ -67,6 +67,58 @@ const entityLabels: Record<string, string> = {
   notifications: 'แจ้งเตือน',
 };
 
+// ── Collections quick-filter presets ────────────────────────────────────────
+const COLLECTION_PRESET_ACTIONS: Record<string, string[]> = {
+  all: [
+    'STATUS_CHANGE',
+    'DUNNING_ESCALATION_PENDING',
+    'DUNNING_ESCALATION_APPROVED',
+    'DUNNING_ESCALATION_REJECTED',
+    'MDM_LOCK_APPROVED',
+    'MDM_UNLOCK',
+    'HOLD_AUTO_ESCALATION',
+    'LETTER_PDF_GENERATED',
+    'LETTER_DISPATCHED',
+    'LETTER_DELIVERED',
+    'LETTER_UNDELIVERABLE',
+    'LETTER_EVIDENCE_UPDATED',
+    'CONTRACT_STATUS_LEGAL',
+    'BULK_ASSIGN',
+    'CREATE_CALL_LOG',
+  ],
+  mdm: ['MDM_LOCK_APPROVED', 'MDM_UNLOCK', 'HOLD_AUTO_ESCALATION'],
+  letters: [
+    'LETTER_PDF_GENERATED',
+    'LETTER_DISPATCHED',
+    'LETTER_DELIVERED',
+    'LETTER_UNDELIVERABLE',
+    'LETTER_EVIDENCE_UPDATED',
+    'CONTRACT_STATUS_LEGAL',
+  ],
+  dunning: [
+    'DUNNING_ESCALATION_PENDING',
+    'DUNNING_ESCALATION_APPROVED',
+    'DUNNING_ESCALATION_REJECTED',
+  ],
+};
+
+type CollectionPreset = keyof typeof COLLECTION_PRESET_ACTIONS | null;
+
+const PRESET_LABELS: Record<string, string> = {
+  all: 'ทั้งหมด (Collections)',
+  mdm: 'MDM',
+  letters: 'หนังสือ',
+  dunning: 'Dunning escalation',
+};
+
+function presetBtnClass(active: boolean) {
+  return `px-2.5 py-1 text-[10px] font-medium rounded-full border transition-colors ${
+    active
+      ? 'bg-primary/10 border-primary/40 text-primary'
+      : 'border-input text-muted-foreground hover:text-foreground hover:bg-muted'
+  }`;
+}
+
 export default function AuditLogsPage() {
   useDocumentTitle('ประวัติการใช้งาน');
   const [entity, setEntity] = useState('');
@@ -75,6 +127,9 @@ export default function AuditLogsPage() {
   const [dateTo, setDateTo] = useState('');
   const [page, setPage] = useState(1);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [collectionPreset, setCollectionPreset] = useState<CollectionPreset>(null);
+  // Client-side filter for preset actions (multi-action filter)
+  const [presetActions, setPresetActions] = useState<string[]>([]);
   const limit = 25;
 
   const debouncedEntity = useDebounce(entity, 300);
@@ -104,8 +159,29 @@ export default function AuditLogsPage() {
     },
   });
 
-  const logs = result?.data || [];
+  // When a preset is active, filter the fetched page client-side by preset actions.
+  // The server filters by a single `action` param; for multi-action presets we
+  // fetch without an action filter and filter in-memory.
+  const rawLogs = result?.data || [];
+  const logs =
+    presetActions.length > 0
+      ? rawLogs.filter((l) => presetActions.includes(l.action))
+      : rawLogs;
   const totalPages = result?.totalPages || 1;
+
+  function applyPreset(key: string) {
+    setCollectionPreset(key as CollectionPreset);
+    setPresetActions(COLLECTION_PRESET_ACTIONS[key] ?? []);
+    // Clear the manual action select so server doesn't double-filter
+    setAction('');
+    setPage(1);
+  }
+
+  function clearPreset() {
+    setCollectionPreset(null);
+    setPresetActions([]);
+    setPage(1);
+  }
 
   return (
     <div>
@@ -180,6 +256,28 @@ export default function AuditLogsPage() {
           </div>
         </div>
       )}
+
+      {/* Collections quick-filter presets */}
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <span className="text-[10px] font-medium text-muted-foreground">Collections:</span>
+        {Object.keys(COLLECTION_PRESET_ACTIONS).map((key) => (
+          <button
+            key={key}
+            onClick={() => applyPreset(key)}
+            className={presetBtnClass(collectionPreset === key)}
+          >
+            {PRESET_LABELS[key] ?? key}
+          </button>
+        ))}
+        {collectionPreset && (
+          <button
+            onClick={clearPreset}
+            className="text-[10px] text-muted-foreground underline hover:text-foreground transition-colors"
+          >
+            เคลียร์
+          </button>
+        )}
+      </div>
 
       {/* Filters */}
       <div className="rounded-xl border border-border/50 bg-card shadow-sm p-5 mb-6">

--- a/apps/web/src/pages/AuditLogsPage.tsx
+++ b/apps/web/src/pages/AuditLogsPage.tsx
@@ -128,7 +128,7 @@ export default function AuditLogsPage() {
   const [page, setPage] = useState(1);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [collectionPreset, setCollectionPreset] = useState<CollectionPreset>(null);
-  // Client-side filter for preset actions (multi-action filter)
+  // Server-side filter for preset actions (multi-action filter, sent as `actions` query param)
   const [presetActions, setPresetActions] = useState<string[]>([]);
   const limit = 25;
 
@@ -139,34 +139,34 @@ export default function AuditLogsPage() {
     queryFn: async () => (await api.get('/audit/stats')).data,
   });
 
+  const presetActionsKey = presetActions.join(',');
+
   const { data: result, isLoading, isError, error, refetch } = useQuery<{
     data: AuditLog[];
     total: number;
     page: number;
     totalPages: number;
   }>({
-    queryKey: ['audit-logs', debouncedEntity, action, dateFrom, dateTo, page],
+    queryKey: ['audit-logs', debouncedEntity, action, dateFrom, dateTo, page, presetActionsKey],
     queryFn: async () => {
-      const params: Record<string, string> = {
+      const params: Record<string, string | string[]> = {
         page: String(page),
         limit: String(limit),
       };
       if (debouncedEntity) params.entity = debouncedEntity;
-      if (action) params.action = action;
+      // `actions` (multi) takes precedence over `action` (single) — matches backend
+      if (presetActions.length > 0) {
+        params.actions = presetActions;
+      } else if (action) {
+        params.action = action;
+      }
       if (dateFrom) params.from = dateFrom;
       if (dateTo) params.to = dateTo;
       return (await api.get('/audit/logs', { params })).data;
     },
   });
 
-  // When a preset is active, filter the fetched page client-side by preset actions.
-  // The server filters by a single `action` param; for multi-action presets we
-  // fetch without an action filter and filter in-memory.
-  const rawLogs = result?.data || [];
-  const logs =
-    presetActions.length > 0
-      ? rawLogs.filter((l) => presetActions.includes(l.action))
-      : rawLogs;
+  const logs = result?.data || [];
   const totalPages = result?.totalPages || 1;
 
   function applyPreset(key: string) {

--- a/apps/web/src/pages/CollectionsPage/components/BulkSlipUploadDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/BulkSlipUploadDialog.tsx
@@ -14,12 +14,14 @@ interface Props {
 
 export default function BulkSlipUploadDialog({ open, letters, onClose }: Props) {
   const [files, setFiles] = useState<Record<string, File | null>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
   const qc = useQueryClient();
 
   function handleClose() {
     if (busy) return;
     setFiles({});
+    setErrors({});
     onClose();
   }
 
@@ -34,6 +36,8 @@ export default function BulkSlipUploadDialog({ open, letters, onClose }: Props) 
     }
 
     setBusy(true);
+    setErrors({});
+    const rowErrors: Record<string, string> = {};
     let ok = 0;
     let fail = 0;
     for (const { letter, file } of pairs) {
@@ -47,7 +51,7 @@ export default function BulkSlipUploadDialog({ open, letters, onClose }: Props) 
           body: file,
           headers: { 'Content-Type': file.type },
         });
-        if (!up.ok) throw new Error('Upload failed');
+        if (!up.ok) throw new Error('อัปโหลดไฟล์ไปยัง storage ไม่สำเร็จ');
 
         await api.patch(`/overdue/letters/${letter.id}/evidence`, {
           evidencePhotoUrl: presigned.publicUrl,
@@ -55,17 +59,21 @@ export default function BulkSlipUploadDialog({ open, letters, onClose }: Props) 
         ok++;
       } catch (err) {
         fail++;
-        console.error(`Letter ${letter.letterNumber}:`, err);
+        rowErrors[letter.id] = getErrorMessage(err);
       }
     }
 
+    setErrors(rowErrors);
     qc.invalidateQueries({ queryKey: ['letter-queue'] });
-    toast.success(
-      `อัปโหลดสำเร็จ ${ok}/${pairs.length}${fail ? ` (ล้มเหลว ${fail})` : ''}`,
-    );
+    if (fail === 0) {
+      toast.success(`อัปโหลดสำเร็จ ${ok}/${pairs.length}`);
+      setBusy(false);
+      setFiles({});
+      onClose();
+      return;
+    }
+    toast.error(`อัปโหลดสำเร็จ ${ok}/${pairs.length} (ล้มเหลว ${fail})`);
     setBusy(false);
-    setFiles({});
-    onClose();
   };
 
   const selectedCount = Object.values(files).filter(Boolean).length;
@@ -80,6 +88,7 @@ export default function BulkSlipUploadDialog({ open, letters, onClose }: Props) 
         <div className="max-h-96 overflow-y-auto space-y-px border border-border/50 rounded-lg divide-y divide-border/30">
           {letters.map((l) => {
             const f = files[l.id];
+            const rowError = errors[l.id];
             return (
               <div key={l.id} className="flex items-center gap-3 px-3 py-2.5 bg-background">
                 <div className="flex-1 min-w-0">
@@ -98,6 +107,11 @@ export default function BulkSlipUploadDialog({ open, letters, onClose }: Props) 
                   {f && (
                     <div className="text-[10px] text-success leading-snug mt-0.5 truncate">
                       {f.name} ({(f.size / 1024).toFixed(0)} KB)
+                    </div>
+                  )}
+                  {rowError && (
+                    <div className="text-[10px] text-destructive leading-snug mt-0.5">
+                      {rowError}
                     </div>
                   )}
                 </div>

--- a/apps/web/src/pages/CollectionsPage/components/BulkSlipUploadDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/BulkSlipUploadDialog.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import { Loader2, Upload } from 'lucide-react';
+import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
+import api, { getErrorMessage } from '@/lib/api';
+import Modal from '@/components/ui/Modal';
+import type { LetterRow } from '../hooks/useLetterQueue';
+
+interface Props {
+  open: boolean;
+  letters: LetterRow[];
+  onClose: () => void;
+}
+
+export default function BulkSlipUploadDialog({ open, letters, onClose }: Props) {
+  const [files, setFiles] = useState<Record<string, File | null>>({});
+  const [busy, setBusy] = useState(false);
+  const qc = useQueryClient();
+
+  function handleClose() {
+    if (busy) return;
+    setFiles({});
+    onClose();
+  }
+
+  const handleSubmit = async () => {
+    const pairs = letters
+      .map((l) => ({ letter: l, file: files[l.id] }))
+      .filter((p): p is { letter: LetterRow; file: File } => !!p.file);
+
+    if (pairs.length === 0) {
+      toast.error('กรุณาเลือกไฟล์อย่างน้อย 1 รายการ');
+      return;
+    }
+
+    setBusy(true);
+    let ok = 0;
+    let fail = 0;
+    for (const { letter, file } of pairs) {
+      try {
+        const { data: presigned } = await api.post('/shop/upload/signed-url', {
+          kind: 'LETTER_EVIDENCE',
+          contentType: file.type,
+        });
+        const up = await fetch(presigned.uploadUrl, {
+          method: presigned.method ?? 'PUT',
+          body: file,
+          headers: { 'Content-Type': file.type },
+        });
+        if (!up.ok) throw new Error('Upload failed');
+
+        await api.patch(`/overdue/letters/${letter.id}/evidence`, {
+          evidencePhotoUrl: presigned.publicUrl,
+        });
+        ok++;
+      } catch (err) {
+        fail++;
+        console.error(`Letter ${letter.letterNumber}:`, err);
+      }
+    }
+
+    qc.invalidateQueries({ queryKey: ['letter-queue'] });
+    toast.success(
+      `อัปโหลดสำเร็จ ${ok}/${pairs.length}${fail ? ` (ล้มเหลว ${fail})` : ''}`,
+    );
+    setBusy(false);
+    setFiles({});
+    onClose();
+  };
+
+  const selectedCount = Object.values(files).filter(Boolean).length;
+
+  return (
+    <Modal isOpen={open} onClose={handleClose} title="อัปโหลดสลิปชุด">
+      <div className="space-y-3 p-1">
+        <div className="text-xs text-muted-foreground leading-snug">
+          เลือกรูปสลิปไปรษณีย์สำหรับแต่ละหนังสือ — สามารถข้ามได้ถ้ายังไม่มี
+        </div>
+
+        <div className="max-h-96 overflow-y-auto space-y-px border border-border/50 rounded-lg divide-y divide-border/30">
+          {letters.map((l) => {
+            const f = files[l.id];
+            return (
+              <div key={l.id} className="flex items-center gap-3 px-3 py-2.5 bg-background">
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium leading-snug truncate">
+                    {l.contract.customer.name}
+                  </div>
+                  <div className="text-[10px] text-muted-foreground leading-snug tabular-nums">
+                    {l.letterNumber}
+                    {l.trackingNumber && (
+                      <>
+                        {' · EMS: '}
+                        <span className="font-mono">{l.trackingNumber}</span>
+                      </>
+                    )}
+                  </div>
+                  {f && (
+                    <div className="text-[10px] text-success leading-snug mt-0.5 truncate">
+                      {f.name} ({(f.size / 1024).toFixed(0)} KB)
+                    </div>
+                  )}
+                </div>
+                <label className="shrink-0 cursor-pointer">
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="sr-only"
+                    disabled={busy}
+                    onChange={(e) => {
+                      const picked = e.target.files?.[0] ?? null;
+                      setFiles((prev) => ({ ...prev, [l.id]: picked }));
+                    }}
+                  />
+                  <span
+                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-[10px] font-medium rounded-lg border transition-colors ${
+                      f
+                        ? 'border-success/40 bg-success/5 text-success'
+                        : 'border-input text-muted-foreground hover:bg-muted hover:text-foreground'
+                    }`}
+                  >
+                    <Upload className="size-3" />
+                    {f ? 'เปลี่ยน' : 'เลือก'}
+                  </span>
+                </label>
+              </div>
+            );
+          })}
+        </div>
+
+        {selectedCount > 0 && (
+          <div className="text-xs text-muted-foreground leading-snug tabular-nums">
+            เลือกแล้ว {selectedCount} / {letters.length} รายการ
+          </div>
+        )}
+
+        <div className="flex gap-2 justify-end pt-2">
+          <button
+            onClick={handleClose}
+            disabled={busy}
+            className="px-4 py-2 text-sm rounded-lg border border-input hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={busy || selectedCount === 0}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {busy ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                กำลังอัปโหลด...
+              </>
+            ) : (
+              <>
+                <Upload className="size-4" />
+                อัปโหลดทั้งหมด{selectedCount > 0 ? ` (${selectedCount})` : ''}
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsTabs.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsTabs.tsx
@@ -1,4 +1,4 @@
-import { Phone, Clock, Calendar, ClipboardCheck, List } from 'lucide-react';
+import { Phone, Clock, Calendar, ClipboardCheck, List, BarChart3 } from 'lucide-react';
 import type { CollectionsTabKey } from '../index';
 
 interface Props {
@@ -18,11 +18,12 @@ const TAB_CONFIG: Array<{
   { key: 'promise', label: 'นัดชำระ', Icon: Calendar },
   { key: 'approval', label: 'อนุมัติ', Icon: ClipboardCheck },
   { key: 'all', label: 'ทั้งหมด', Icon: List },
+  { key: 'analytics', label: 'วิเคราะห์', Icon: BarChart3 },
 ];
 
 export default function CollectionsTabs({ active, onChange, canSeeApproval, counts }: Props) {
   const visibleTabs = TAB_CONFIG.filter(
-    (t) => t.key !== 'approval' || canSeeApproval,
+    (t) => (t.key !== 'approval' && t.key !== 'analytics') || canSeeApproval,
   );
 
   return (

--- a/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { FileText, Download, CheckCircle, RotateCcw, Loader2 } from 'lucide-react';
+import { FileText, Download, CheckCircle, RotateCcw, Loader2, Upload } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { useLetterQueue, type LetterRow, type LetterType, type LetterStatus } from '../hooks/useLetterQueue';
 import { useLetterActions } from '../hooks/useLetterActions';
 import LetterDispatchDialog from './LetterDispatchDialog';
+import BulkSlipUploadDialog from './BulkSlipUploadDialog';
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -204,6 +205,7 @@ export default function LetterQueueSection() {
 
   const [dispatchLetter, setDispatchLetter] = useState<LetterRow | null>(null);
   const [dispatchMode, setDispatchMode] = useState<'generate' | 'dispatch'>('generate');
+  const [bulkSlipOpen, setBulkSlipOpen] = useState(false);
 
   const openGenerate = (l: LetterRow) => {
     setDispatchLetter(l);
@@ -225,6 +227,9 @@ export default function LetterQueueSection() {
   };
 
   const count = data?.length ?? 0;
+  const dispatchedMissingEvidence = (data ?? []).filter(
+    (l) => l.status === 'DISPATCHED' && !l.evidencePhotoUrl,
+  );
 
   return (
     <>
@@ -252,20 +257,34 @@ export default function LetterQueueSection() {
               </div>
             </div>
           ) : (
-            <div className="space-y-2">
-              {data!.map((letter) => (
-                <LetterRowCard
-                  key={letter.id}
-                  letter={letter}
-                  onOpenGenerate={openGenerate}
-                  onOpenDispatch={openDispatch}
-                  onDelivered={(l) => markDelivered.mutate(l.id)}
-                  onUndeliverable={handleUndeliverable}
-                  deliveredPending={markDelivered.isPending}
-                  undeliverablePending={markUndeliverable.isPending}
-                />
-              ))}
-            </div>
+            <>
+              {/* Bulk slip upload trigger — show when 2+ dispatched letters missing evidence */}
+              {dispatchedMissingEvidence.length >= 2 && (
+                <div className="mb-3 flex justify-end">
+                  <button
+                    onClick={() => setBulkSlipOpen(true)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-input hover:bg-muted text-muted-foreground transition-colors"
+                  >
+                    <Upload className="size-3.5" />
+                    อัปโหลดสลิปชุด ({dispatchedMissingEvidence.length})
+                  </button>
+                </div>
+              )}
+              <div className="space-y-2">
+                {data!.map((letter) => (
+                  <LetterRowCard
+                    key={letter.id}
+                    letter={letter}
+                    onOpenGenerate={openGenerate}
+                    onOpenDispatch={openDispatch}
+                    onDelivered={(l) => markDelivered.mutate(l.id)}
+                    onUndeliverable={handleUndeliverable}
+                    deliveredPending={markDelivered.isPending}
+                    undeliverablePending={markUndeliverable.isPending}
+                  />
+                ))}
+              </div>
+            </>
           )}
         </CardContent>
       </Card>
@@ -276,6 +295,14 @@ export default function LetterQueueSection() {
           letter={dispatchLetter}
           initialMode={dispatchMode}
           onClose={() => setDispatchLetter(null)}
+        />
+      )}
+
+      {bulkSlipOpen && (
+        <BulkSlipUploadDialog
+          open={bulkSlipOpen}
+          letters={dispatchedMissingEvidence}
+          onClose={() => setBulkSlipOpen(false)}
         />
       )}
     </>

--- a/apps/web/src/pages/CollectionsPage/components/LineRetryQueueSection.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LineRetryQueueSection.tsx
@@ -34,49 +34,52 @@ export default function LineRetryQueueSection() {
           </div>
         ) : (
           <div className="space-y-2">
-            {actions.map((a) => (
-              <div
-                key={a.id}
-                className="flex items-start gap-3 rounded-lg border border-border/50 p-3 bg-background"
-              >
-                <div className="shrink-0 size-8 rounded-full bg-destructive/10 text-destructive flex items-center justify-center">
-                  <AlertTriangle className="size-4" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex flex-wrap items-baseline gap-2 mb-0.5">
-                    <span className="text-sm font-semibold leading-snug truncate">
-                      {a.contract.customer.name}
-                    </span>
-                    <span className="font-mono text-[10px] text-primary">
-                      {a.contract.contractNumber}
-                    </span>
-                    <span className="text-[10px] text-muted-foreground">
-                      · {a.dunningRule.name}
-                    </span>
-                  </div>
-                  <div className="text-[10px] text-muted-foreground leading-snug line-clamp-2">
-                    {a.messageContent?.substring(0, 120)}
-                    {(a.messageContent?.length ?? 0) > 120 ? '…' : ''}
-                  </div>
-                  {a.result && (
-                    <div className="text-[10px] text-destructive mt-1 leading-snug">
-                      Error: {a.result}
-                    </div>
-                  )}
-                  <div className="text-[10px] text-muted-foreground mt-1 tabular-nums">
-                    ครั้งแรก: {formatDateShort(new Date(a.createdAt))}
-                  </div>
-                </div>
-                <button
-                  onClick={() => retry.mutate(a.id)}
-                  disabled={retry.isPending}
-                  className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            {actions.map((a) => {
+              const isThisRetrying = retry.isPending && retry.variables === a.id;
+              return (
+                <div
+                  key={a.id}
+                  className="flex items-start gap-3 rounded-lg border border-border/50 p-3 bg-background"
                 >
-                  <RefreshCw className={`size-3.5 ${retry.isPending ? 'animate-spin' : ''}`} />
-                  ลองอีกครั้ง
-                </button>
-              </div>
-            ))}
+                  <div className="shrink-0 size-8 rounded-full bg-destructive/10 text-destructive flex items-center justify-center">
+                    <AlertTriangle className="size-4" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-wrap items-baseline gap-2 mb-0.5">
+                      <span className="text-sm font-semibold leading-snug truncate">
+                        {a.contract.customer.name}
+                      </span>
+                      <span className="font-mono text-[10px] text-primary">
+                        {a.contract.contractNumber}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground">
+                        · {a.dunningRule.name}
+                      </span>
+                    </div>
+                    <div className="text-[10px] text-muted-foreground leading-snug line-clamp-2">
+                      {a.messageContent?.substring(0, 120)}
+                      {(a.messageContent?.length ?? 0) > 120 ? '…' : ''}
+                    </div>
+                    {a.result && (
+                      <div className="text-[10px] text-destructive mt-1 leading-snug">
+                        Error: {a.result}
+                      </div>
+                    )}
+                    <div className="text-[10px] text-muted-foreground mt-1 tabular-nums">
+                      ครั้งแรก: {formatDateShort(new Date(a.createdAt))}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => retry.mutate(a.id)}
+                    disabled={isThisRetrying}
+                    className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                  >
+                    <RefreshCw className={`size-3.5 ${isThisRetrying ? 'animate-spin' : ''}`} />
+                    ลองอีกครั้ง
+                  </button>
+                </div>
+              );
+            })}
           </div>
         )}
       </CardContent>

--- a/apps/web/src/pages/CollectionsPage/components/LineRetryQueueSection.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LineRetryQueueSection.tsx
@@ -1,0 +1,85 @@
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { useFailedActions, useRetryAction } from '../hooks/useLineRetry';
+import { formatDateShort } from '@/utils/formatters';
+
+export default function LineRetryQueueSection() {
+  const { data: actions = [], isLoading } = useFailedActions();
+  const retry = useRetryAction();
+
+  return (
+    <Card className="rounded-xl border border-border/50 bg-card shadow-sm">
+      <CardContent className="p-5">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="size-4 text-destructive" />
+            <h3 className="text-sm font-semibold leading-snug">ส่งไม่สำเร็จ รอลองใหม่</h3>
+          </div>
+          <span className="text-xs tabular-nums bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+            {actions.length}
+          </span>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2">
+            {[0, 1].map((i) => (
+              <div key={i} className="h-16 bg-muted animate-pulse rounded-lg" />
+            ))}
+          </div>
+        ) : actions.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-success/30 bg-success/5 py-8 text-center">
+            <div className="text-sm font-medium text-success leading-snug">
+              ไม่มีรายการที่ส่งไม่สำเร็จ
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {actions.map((a) => (
+              <div
+                key={a.id}
+                className="flex items-start gap-3 rounded-lg border border-border/50 p-3 bg-background"
+              >
+                <div className="shrink-0 size-8 rounded-full bg-destructive/10 text-destructive flex items-center justify-center">
+                  <AlertTriangle className="size-4" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-baseline gap-2 mb-0.5">
+                    <span className="text-sm font-semibold leading-snug truncate">
+                      {a.contract.customer.name}
+                    </span>
+                    <span className="font-mono text-[10px] text-primary">
+                      {a.contract.contractNumber}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground">
+                      · {a.dunningRule.name}
+                    </span>
+                  </div>
+                  <div className="text-[10px] text-muted-foreground leading-snug line-clamp-2">
+                    {a.messageContent?.substring(0, 120)}
+                    {(a.messageContent?.length ?? 0) > 120 ? '…' : ''}
+                  </div>
+                  {a.result && (
+                    <div className="text-[10px] text-destructive mt-1 leading-snug">
+                      Error: {a.result}
+                    </div>
+                  )}
+                  <div className="text-[10px] text-muted-foreground mt-1 tabular-nums">
+                    ครั้งแรก: {formatDateShort(new Date(a.createdAt))}
+                  </div>
+                </div>
+                <button
+                  onClick={() => retry.mutate(a.id)}
+                  disabled={retry.isPending}
+                  className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                >
+                  <RefreshCw className={`size-3.5 ${retry.isPending ? 'animate-spin' : ''}`} />
+                  ลองอีกครั้ง
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
@@ -3,6 +3,7 @@ import { Banknote, Landmark, QrCode, ImageUp, CircleCheck } from 'lucide-react';
 import { toast } from 'sonner';
 import Modal from '@/components/ui/Modal';
 import api, { getErrorMessage } from '@/lib/api';
+import { formatNumber } from '@/utils/formatters';
 import { useRecordPayment } from '../hooks/useRecordPayment';
 import type { PaymentMethod } from '../hooks/useRecordPayment';
 import type { ContractRow } from '../types';
@@ -259,7 +260,7 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
               ? 'กำลังบันทึก...'
               : uploadingSlip
                 ? 'กำลังอัปโหลดสลิป...'
-                : `บันทึกชำระ${validAmount ? ` ${amountNum.toLocaleString()} ฿` : ''}`}
+                : `บันทึกชำระ${validAmount ? ` ${formatNumber(amountNum)} ฿` : ''}`}
           </button>
         </div>
       </div>

--- a/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
@@ -117,7 +117,7 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
             <div className="text-right">
               <div className="text-xs text-muted-foreground leading-snug">ค้างชำระ</div>
               <div className="text-lg font-bold tabular-nums text-destructive">
-                {contract.outstanding.toLocaleString()} ฿
+                {formatNumber(contract.outstanding)} ฿
               </div>
             </div>
           </div>
@@ -145,7 +145,7 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
                 onClick={() => setAmount(contract.outstanding.toString())}
                 className="hover:text-foreground underline transition-colors"
               >
-                ใช้ยอดค้าง {contract.outstanding.toLocaleString()} ฿
+                ใช้ยอดค้าง {formatNumber(contract.outstanding)} ฿
               </button>
             )}
           </div>

--- a/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
-import { Banknote, Landmark, QrCode } from 'lucide-react';
+import { Banknote, Landmark, QrCode, ImageUp, CircleCheck } from 'lucide-react';
+import { toast } from 'sonner';
 import Modal from '@/components/ui/Modal';
+import api, { getErrorMessage } from '@/lib/api';
 import { useRecordPayment } from '../hooks/useRecordPayment';
 import type { PaymentMethod } from '../hooks/useRecordPayment';
 import type { ContractRow } from '../types';
@@ -22,7 +24,14 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
   const [method, setMethod] = useState<PaymentMethod>('CASH');
   const [notes, setNotes] = useState('');
 
+  // Slip upload state
+  const [slipFile, setSlipFile] = useState<File | null>(null);
+  const [slipUrl, setSlipUrl] = useState<string>('');
+  const [uploadingSlip, setUploadingSlip] = useState(false);
+
   const mutation = useRecordPayment();
+
+  const requiresSlip = method === 'BANK_TRANSFER' || method === 'QR_EWALLET';
 
   // Pre-fill amount from outstanding on open
   useEffect(() => {
@@ -30,26 +39,65 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
       setAmount(contract.outstanding > 0 ? contract.outstanding.toString() : '');
       setMethod('CASH');
       setNotes('');
+      setSlipFile(null);
+      setSlipUrl('');
     }
   }, [open, contract?.id]);
 
+  // Reset slip when method changes away from transfer types
+  useEffect(() => {
+    if (!requiresSlip) {
+      setSlipFile(null);
+      setSlipUrl('');
+    }
+  }, [requiresSlip]);
+
+  const handleSlipChange = async (file: File) => {
+    setSlipFile(file);
+    setUploadingSlip(true);
+    setSlipUrl('');
+    try {
+      const { data: presigned } = await api.post('/shop/upload/signed-url', {
+        kind: 'BANK_SLIP',
+        contentType: file.type,
+      });
+      const up = await fetch(presigned.uploadUrl, {
+        method: presigned.method ?? 'PUT',
+        body: file,
+        headers: { 'Content-Type': file.type },
+      });
+      if (!up.ok) throw new Error('Upload failed');
+      setSlipUrl(presigned.publicUrl);
+      toast.success('อัปโหลดสลิปสำเร็จ');
+    } catch (err) {
+      toast.error(getErrorMessage(err));
+      setSlipFile(null);
+    } finally {
+      setUploadingSlip(false);
+    }
+  };
+
   const amountNum = parseFloat(amount);
   const validAmount = !isNaN(amountNum) && amountNum > 0;
+  const canSubmit = validAmount && !mutation.isPending && !uploadingSlip && (!requiresSlip || !!slipUrl);
 
   function handleSubmit() {
-    if (!contract || !validAmount) return;
+    if (!contract || !canSubmit) return;
     mutation.mutate(
       {
         contractId: contract.id,
         amount: amountNum,
         paymentMethod: method,
         notes: notes || undefined,
+        evidenceUrl: slipUrl || undefined,
       },
       {
         onSuccess: () => {
           onClose();
           setAmount('');
           setNotes('');
+          setSlipFile(null);
+          setSlipUrl('');
         },
       },
     );
@@ -126,6 +174,57 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
           </div>
         </div>
 
+        {/* Slip upload — shown only for non-cash methods */}
+        {requiresSlip && (
+          <div>
+            <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
+              สลิปการโอน{' '}
+              <span className="text-destructive">*</span>
+            </label>
+            <label
+              className={`flex items-center gap-3 rounded-lg border-2 border-dashed px-4 py-3 cursor-pointer transition-colors ${
+                slipUrl
+                  ? 'border-success/40 bg-success/5'
+                  : 'border-input hover:border-primary/40 hover:bg-muted/50'
+              }`}
+            >
+              <input
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                disabled={uploadingSlip}
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) handleSlipChange(f);
+                }}
+              />
+              {slipUrl ? (
+                <CircleCheck className="size-5 text-success shrink-0" />
+              ) : (
+                <ImageUp className="size-5 text-muted-foreground shrink-0" />
+              )}
+              <div className="flex-1 min-w-0">
+                {slipFile ? (
+                  <div className="text-xs leading-snug">
+                    <div className="font-medium text-foreground truncate">{slipFile.name}</div>
+                    <div className="text-muted-foreground tabular-nums">
+                      {(slipFile.size / 1024).toFixed(0)} KB
+                      {uploadingSlip && ' · กำลังอัปโหลด...'}
+                      {slipUrl && !uploadingSlip && (
+                        <span className="text-success"> · อัปโหลดแล้ว</span>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground leading-snug">
+                    คลิกเพื่อเลือกรูปสลิป (บังคับสำหรับโอน/QR)
+                  </div>
+                )}
+              </div>
+            </label>
+          </div>
+        )}
+
         {/* Notes */}
         <div>
           <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
@@ -153,12 +252,14 @@ export default function PaymentRecordDialog({ open, contract, onClose }: Props) 
           <button
             type="button"
             onClick={handleSubmit}
-            disabled={!validAmount || mutation.isPending}
+            disabled={!canSubmit}
             className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
           >
             {mutation.isPending
               ? 'กำลังบันทึก...'
-              : `บันทึกชำระ${validAmount ? ` ${amountNum.toLocaleString()} ฿` : ''}`}
+              : uploadingSlip
+                ? 'กำลังอัปโหลดสลิป...'
+                : `บันทึกชำระ${validAmount ? ` ${amountNum.toLocaleString()} ฿` : ''}`}
           </button>
         </div>
       </div>

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsAnalytics.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsAnalytics.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface CollectionsAnalytics {
+  range: '30d' | '90d';
+  weeklyCollectionRate: Array<{
+    weekStart: string;
+    paidCount: number;
+    dueCount: number;
+    rate: number;
+  }>;
+  promiseKeptTrend: Array<{ weekStart: string; kept: number; broken: number }>;
+  dunningActionVolume: Array<{ date: string; sent: number; failed: number }>;
+  letterDispatchByType: Array<{ type: string; month: string; count: number }>;
+  mdmLockVolume: Array<{ date: string; proposed: number; approved: number }>;
+}
+
+export function useCollectionsAnalytics(range: '30d' | '90d') {
+  return useQuery<CollectionsAnalytics>({
+    queryKey: ['collections-analytics', range],
+    queryFn: async () => (await api.get(`/overdue/analytics?range=${range}`)).data,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useLineRetry.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useLineRetry.ts
@@ -1,0 +1,41 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+export interface FailedAction {
+  id: string;
+  contractId: string;
+  channel: string;
+  status: string;
+  messageContent: string | null;
+  result: string | null;
+  createdAt: string;
+  dunningRule: { name: string };
+  contract: {
+    id: string;
+    contractNumber: string;
+    customer: { id: string; name: string; phone: string; lineId: string | null };
+  };
+}
+
+export function useFailedActions() {
+  return useQuery<FailedAction[]>({
+    queryKey: ['line-retries'],
+    queryFn: async () => (await api.get('/overdue/line-retries?limit=100')).data,
+    staleTime: 60_000,
+  });
+}
+
+export function useRetryAction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (actionId: string) =>
+      (await api.post(`/overdue/line-retries/${actionId}/retry`)).data,
+    onSuccess: (data) => {
+      if (data.status === 'SENT') toast.success('ส่งสำเร็จ');
+      else toast.warning('ยังส่งไม่สำเร็จ จะลองใหม่ได้');
+      qc.invalidateQueries({ queryKey: ['line-retries'] });
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts
@@ -9,6 +9,7 @@ export interface RecordPaymentPayload {
   amount: number;
   paymentMethod: PaymentMethod;
   notes?: string;
+  evidenceUrl?: string;
 }
 
 /**
@@ -16,8 +17,8 @@ export interface RecordPaymentPayload {
  * allocates across next-due installments. Collector doesn't need to pick
  * installmentNo; just enter the amount customer paid.
  *
- * Out of scope (MVP): slip upload / evidenceUrl enforcement. Backend accepts
- * evidenceUrl but auto-allocate doesn't require it.
+ * Slip upload is enforced client-side for BANK_TRANSFER and QR_EWALLET methods.
+ * evidenceUrl is passed through to backend when provided.
  */
 export function useRecordPayment() {
   const qc = useQueryClient();

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -13,9 +13,10 @@ import FollowUpTab from './tabs/FollowUpTab';
 import PromiseTab from './tabs/PromiseTab';
 import AllTab from './tabs/AllTab';
 import ApprovalTab from './tabs/ApprovalTab';
+import AnalyticsTab from './tabs/AnalyticsTab';
 import type { ContractRow } from './types';
 
-export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all';
+export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all' | 'analytics';
 
 export default function CollectionsPage() {
   useDocumentTitle('ติดตามหนี้');
@@ -95,6 +96,8 @@ export default function CollectionsPage() {
       {activeTab === 'approval' && canSeeApproval && <ApprovalTab />}
 
       {activeTab === 'all' && <AllTab />}
+
+      {activeTab === 'analytics' && canSeeApproval && <AnalyticsTab />}
 
       <ContactLogDialog
         open={!!dialogContract}

--- a/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
@@ -1,0 +1,296 @@
+import { useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+import { Card, CardContent } from '@/components/ui/card';
+import QueryBoundary from '@/components/QueryBoundary';
+import { useCollectionsAnalytics } from '../hooks/useCollectionsAnalytics';
+
+// Chart colors: pragmatic hex approximations of the theme palette.
+// recharts requires explicit color values; these match emerald/red/amber tokens.
+const CHART_COLORS = {
+  success: '#10b981', // emerald-500 — matches theme primary
+  destructive: '#ef4444', // red-500
+  warning: '#f59e0b', // amber-500
+  muted: '#a1a1aa', // zinc-400
+};
+
+const AXIS_STYLE = { stroke: '#a1a1aa', fontSize: 11 };
+const GRID_PROPS = { strokeDasharray: '3 3', stroke: '#e4e4e7' };
+
+function Empty() {
+  return (
+    <div className="flex items-center justify-center h-full text-xs text-muted-foreground italic leading-snug">
+      ยังไม่มีข้อมูล
+    </div>
+  );
+}
+
+// Pivot letter dispatch rows into per-month objects keyed by type
+function pivotLetters(
+  items: Array<{ type: string; month: string; count: number }>,
+): Array<Record<string, string | number>> {
+  const months = Array.from(new Set(items.map((i) => i.month))).sort();
+  return months.map((m) => {
+    const row: Record<string, string | number> = { month: m.slice(0, 7) };
+    for (const item of items.filter((i) => i.month === m)) {
+      row[item.type] = item.count;
+    }
+    return row;
+  });
+}
+
+export default function AnalyticsTab() {
+  const [range, setRange] = useState<'30d' | '90d'>('30d');
+  const { data, isLoading, isError, error, refetch } = useCollectionsAnalytics(range);
+
+  return (
+    <div>
+      {/* Range toggle */}
+      <div className="flex justify-end mb-4">
+        <div className="inline-flex rounded-lg border border-input overflow-hidden">
+          {(['30d', '90d'] as const).map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                range === r
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-background text-muted-foreground hover:bg-muted'
+              }`}
+            >
+              {r === '30d' ? '30 วัน' : '90 วัน'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <QueryBoundary
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        errorTitle="ไม่สามารถโหลดข้อมูลวิเคราะห์ได้"
+      >
+        {data && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+            {/* Card 1 — weekly collection rate */}
+            <Card>
+              <CardContent className="p-5">
+                <div className="text-sm font-semibold mb-0.5 leading-snug">
+                  อัตราการเก็บเงินรายสัปดาห์
+                </div>
+                <div className="text-xs text-muted-foreground mb-4 leading-snug">
+                  % งวดที่ชำระในแต่ละสัปดาห์
+                </div>
+                <div style={{ width: '100%', height: 220 }}>
+                  {data.weeklyCollectionRate.length === 0 ? (
+                    <Empty />
+                  ) : (
+                    <ResponsiveContainer>
+                      <LineChart
+                        data={data.weeklyCollectionRate.map((w) => ({
+                          week: w.weekStart.slice(5, 10),
+                          rate: Math.round(w.rate * 100),
+                        }))}
+                      >
+                        <CartesianGrid {...GRID_PROPS} />
+                        <XAxis dataKey="week" {...AXIS_STYLE} />
+                        <YAxis
+                          {...AXIS_STYLE}
+                          domain={[0, 100]}
+                          tickFormatter={(v) => `${v}%`}
+                        />
+                        <Tooltip
+                          formatter={(v) => [`${v}%`, 'อัตราชำระ']}
+                          labelFormatter={(l) => `สัปดาห์ ${l}`}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey="rate"
+                          stroke={CHART_COLORS.success}
+                          strokeWidth={2}
+                          dot={{ r: 3, fill: CHART_COLORS.success }}
+                          name="อัตราชำระ"
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Card 2 — promise kept vs broken */}
+            <Card>
+              <CardContent className="p-5">
+                <div className="text-sm font-semibold mb-0.5 leading-snug">
+                  นัดชำระ: ได้ตามนัด vs ผิดนัด
+                </div>
+                <div className="text-xs text-muted-foreground mb-4 leading-snug">รายสัปดาห์</div>
+                <div style={{ width: '100%', height: 220 }}>
+                  {data.promiseKeptTrend.length === 0 ? (
+                    <Empty />
+                  ) : (
+                    <ResponsiveContainer>
+                      <BarChart
+                        data={data.promiseKeptTrend.map((w) => ({
+                          week: w.weekStart.slice(5, 10),
+                          ตามนัด: w.kept,
+                          ผิดนัด: w.broken,
+                        }))}
+                      >
+                        <CartesianGrid {...GRID_PROPS} />
+                        <XAxis dataKey="week" {...AXIS_STYLE} />
+                        <YAxis {...AXIS_STYLE} />
+                        <Tooltip />
+                        <Legend wrapperStyle={{ fontSize: 11 }} />
+                        <Bar dataKey="ตามนัด" stackId="p" fill={CHART_COLORS.success} />
+                        <Bar dataKey="ผิดนัด" stackId="p" fill={CHART_COLORS.destructive} />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Card 3 — dunning action volume */}
+            <Card>
+              <CardContent className="p-5">
+                <div className="text-sm font-semibold mb-0.5 leading-snug">
+                  การแจ้งเตือน LINE/SMS
+                </div>
+                <div className="text-xs text-muted-foreground mb-4 leading-snug">
+                  สำเร็จ vs ล้มเหลว รายวัน
+                </div>
+                <div style={{ width: '100%', height: 220 }}>
+                  {data.dunningActionVolume.length === 0 ? (
+                    <Empty />
+                  ) : (
+                    <ResponsiveContainer>
+                      <LineChart
+                        data={data.dunningActionVolume.map((d) => ({
+                          day: d.date.slice(5, 10),
+                          สำเร็จ: d.sent,
+                          ล้มเหลว: d.failed,
+                        }))}
+                      >
+                        <CartesianGrid {...GRID_PROPS} />
+                        <XAxis dataKey="day" {...AXIS_STYLE} />
+                        <YAxis {...AXIS_STYLE} />
+                        <Tooltip />
+                        <Legend wrapperStyle={{ fontSize: 11 }} />
+                        <Line
+                          type="monotone"
+                          dataKey="สำเร็จ"
+                          stroke={CHART_COLORS.success}
+                          strokeWidth={2}
+                          dot={false}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey="ล้มเหลว"
+                          stroke={CHART_COLORS.destructive}
+                          strokeWidth={2}
+                          dot={false}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Card 4 — letter dispatch by type */}
+            <Card>
+              <CardContent className="p-5">
+                <div className="text-sm font-semibold mb-0.5 leading-snug">หนังสือที่ส่ง</div>
+                <div className="text-xs text-muted-foreground mb-4 leading-snug">
+                  รายเดือน · แยกประเภท
+                </div>
+                <div style={{ width: '100%', height: 220 }}>
+                  {data.letterDispatchByType.length === 0 ? (
+                    <Empty />
+                  ) : (
+                    <ResponsiveContainer>
+                      <BarChart data={pivotLetters(data.letterDispatchByType)}>
+                        <CartesianGrid {...GRID_PROPS} />
+                        <XAxis dataKey="month" {...AXIS_STYLE} />
+                        <YAxis {...AXIS_STYLE} />
+                        <Tooltip />
+                        <Legend wrapperStyle={{ fontSize: 11 }} />
+                        <Bar
+                          dataKey="RETURN_DEVICE_45D"
+                          fill={CHART_COLORS.warning}
+                          name="ทวงถาม 45 วัน"
+                        />
+                        <Bar
+                          dataKey="CONTRACT_TERMINATION_60D"
+                          fill={CHART_COLORS.destructive}
+                          name="บอกเลิก 60 วัน"
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Card 5 — MDM lock volume (full width) */}
+            <Card className="lg:col-span-2">
+              <CardContent className="p-5">
+                <div className="text-sm font-semibold mb-0.5 leading-snug">
+                  การเสนอและอนุมัติล็อคเครื่อง
+                </div>
+                <div className="text-xs text-muted-foreground mb-4 leading-snug">รายวัน</div>
+                <div style={{ width: '100%', height: 220 }}>
+                  {data.mdmLockVolume.length === 0 ? (
+                    <Empty />
+                  ) : (
+                    <ResponsiveContainer>
+                      <LineChart
+                        data={data.mdmLockVolume.map((d) => ({
+                          day: d.date.slice(5, 10),
+                          เสนอ: d.proposed,
+                          อนุมัติ: d.approved,
+                        }))}
+                      >
+                        <CartesianGrid {...GRID_PROPS} />
+                        <XAxis dataKey="day" {...AXIS_STYLE} />
+                        <YAxis {...AXIS_STYLE} />
+                        <Tooltip />
+                        <Legend wrapperStyle={{ fontSize: 11 }} />
+                        <Line
+                          type="monotone"
+                          dataKey="เสนอ"
+                          stroke={CHART_COLORS.warning}
+                          strokeWidth={2}
+                          dot={false}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey="อนุมัติ"
+                          stroke={CHART_COLORS.success}
+                          strokeWidth={2}
+                          dot={false}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '../hooks/useApprovalQueues';
 import { EscalationRow, MdmRow } from '../components/ApprovalPendingRow';
 import LetterQueueSection from '../components/LetterQueueSection';
+import LineRetryQueueSection from '../components/LineRetryQueueSection';
 
 function RowSkeleton() {
   return <div className="bg-muted animate-pulse h-20 rounded-lg" />;
@@ -112,6 +113,9 @@ export default function ApprovalTab() {
 
       {/* Letter queue — generate PDF → dispatch → track delivery */}
       <LetterQueueSection />
+
+      {/* LINE/SMS retry queue — failed DunningActions */}
+      <LineRetryQueueSection />
     </div>
   );
 }

--- a/docs/superpowers/plans/2026-04-24-collections-backlog-plan.md
+++ b/docs/superpowers/plans/2026-04-24-collections-backlog-plan.md
@@ -1,0 +1,188 @@
+# Collections — Plan 6/N: Remaining Backlog
+
+> Close the 5 deferred backlog items from Plan 5 audit. UI tasks invoke `frontend-design` skill.
+
+**Depends on:** Plan 5 branch `feat/collections-hardening`.
+
+## Tasks
+
+### Task 1: Slip upload enforcement on PaymentRecordDialog
+**Why:** PaymentRecordDialog auto-allocate path accepts notes but not slip. Non-cash (BANK_TRANSFER / QR_EWALLET) should require slip for evidence + compliance.
+
+**Files:**
+- Modify: `apps/web/src/pages/CollectionsPage/components/PaymentRecordDialog.tsx`
+- Modify: `apps/web/src/pages/CollectionsPage/hooks/useRecordPayment.ts`
+
+**Behavior:**
+- Add `evidenceUrl?: string` to payload.
+- When method is `BANK_TRANSFER` or `QR_EWALLET`, show slip upload field (reuse `LETTER_EVIDENCE` UploadKind or add `PAYMENT_SLIP`).
+- Submit button disabled until slip uploaded when method requires it.
+- Backend `/payments/auto-allocate` may not accept evidenceUrl — check. If not, use `/payments/record` with installmentNo picked from `contract.payments[0]` (oldest unpaid).
+
+**Approach:** Inspect `BulkRecordPaymentDto` (used by auto-allocate) — if it has `evidenceUrl`, great. If not, pass `evidenceUrl` inline via mutation anyway and let backend ignore, OR route non-cash through `/payments/record`. Simplest for MVP: extend `BulkRecordPaymentDto` server-side to accept optional `evidenceUrl` and have service persist it on the first allocated payment.
+
+Actually cleanest: since slip is per-payment (one slip, one physical transfer), we can just pass it through auto-allocate and have the service attach it to the first created Payment row. Small backend change.
+
+**Commit:** `feat(collections): slip upload enforcement on non-cash payments`
+
+---
+
+### Task 2: LINE retry queue UI + backend retry endpoint
+**Why:** If LINE API is down when `executeEventTrigger` runs, the `DunningAction` row persists with `status=FAILED`. No UI surfaces these; admin has no visible recovery path except DB query.
+
+**Files:**
+- Modify: `apps/api/src/modules/overdue/overdue.controller.ts` — add 2 endpoints
+- Create: `apps/api/src/modules/overdue/dunning-retry.service.ts` — retry logic
+- Create: `apps/web/src/pages/CollectionsPage/components/LineRetryQueueSection.tsx` — UI in ApprovalTab
+- Create: `apps/web/src/pages/CollectionsPage/hooks/useLineRetry.ts`
+
+**Backend endpoints:**
+- `GET /overdue/line-retries?limit=100` — lists DunningAction where status=FAILED ordered by createdAt desc (roles: OWNER / FM / BM)
+- `POST /overdue/line-retries/:id/retry` — retry send; reuse NotificationsService.send with the same message + recipient (OWNER / FM)
+
+**Retry service logic:**
+```typescript
+async retry(actionId: string, userId: string) {
+  const action = await prisma.dunningAction.findUnique({
+    where: { id: actionId },
+    include: { contract: { include: { customer: true } } },
+  });
+  if (!action) throw NotFoundException;
+  if (action.status !== 'FAILED') throw BadRequestException('Action ไม่ได้อยู่สถานะ FAILED');
+
+  const recipient = action.channel === 'LINE'
+    ? action.contract.customer.lineId
+    : action.contract.customer.phone;
+  if (!recipient) throw BadRequestException('ไม่พบช่องทางติดต่อ');
+
+  try {
+    const result = await this.notifications.send({
+      channel: action.channel, recipient,
+      message: action.messageContent ?? '', relatedId: action.contractId,
+    });
+    return prisma.dunningAction.update({
+      where: { id: actionId },
+      data: {
+        status: result.status === 'SENT' ? 'SENT' : 'FAILED',
+        result: `retry by ${userId}: notificationId:${result.id}`,
+        executedAt: result.status === 'SENT' ? new Date() : null,
+      },
+    });
+  } catch (err) {
+    // Log retry attempt but keep FAILED
+    return prisma.dunningAction.update({
+      where: { id: actionId },
+      data: { result: `retry failed: ${err instanceof Error ? err.message : err}` },
+    });
+  }
+}
+```
+
+**Frontend:**
+- Section in ApprovalTab (4th card): title "ส่งไม่สำเร็จ รอลองใหม่", FileText/AlertTriangle icon, list of failed actions
+- Each row: customer name + channel + message preview + [ลองอีกครั้ง] button
+- Success toast after retry, list refetches
+
+**Commit:** `feat(collections): LINE retry queue UI + backend retry endpoint`
+
+---
+
+### Task 3: Collections analytics (charts)
+**Why:** OWNER needs trend visibility — "Is our collection rate improving? Are promises being kept more?"
+
+**Files:**
+- Modify: `apps/api/src/modules/overdue/kpi.service.ts` — add `getAnalytics(params: { range: '30d'|'90d' })` method
+- Modify: controller — add `GET /overdue/analytics`
+- Create: `apps/web/src/pages/CollectionsPage/components/CollectionsAnalyticsSection.tsx` (renders inside AllTab or separately)
+
+**Backend analytics response shape:**
+```typescript
+{
+  range: '30d' | '90d';
+  weeklyCollectionRate: Array<{ weekStart: string; paidCount: number; dueCount: number; rate: number }>;
+  promiseKeptTrend: Array<{ weekStart: string; kept: number; broken: number }>;
+  dunningActionVolume: Array<{ date: string; sent: number; failed: number }>;
+  letterDispatchByType: Array<{ type: 'RETURN_DEVICE_45D' | 'CONTRACT_TERMINATION_60D'; month: string; count: number }>;
+  mdmLockVolume: Array<{ date: string; proposed: number; approved: number }>;
+}
+```
+
+Each series aggregated server-side from existing tables (Payment, CallLog, DunningAction, ContractLetter, MdmLockRequest). Cache 5min.
+
+**Frontend:**
+- Recharts already in deps — use `LineChart`, `BarChart` components
+- New tab on CollectionsPage? Or a section in AllTab? → Add as 6th tab **📊 วิเคราะห์** visible OWNER + FM only
+- 5 chart cards, 2-col grid on desktop
+
+**Commit:** `feat(collections): analytics tab with weekly collection/promise/dunning/letter/MDM trends`
+
+---
+
+### Task 4: Audit log filter for collections actions
+**Why:** AuditLogsPage exists but user has to filter manually through all audit logs. Add collections quick-filter.
+
+**Files:**
+- Modify: `apps/web/src/pages/AuditLogsPage.tsx`
+
+**Behavior:**
+- Add a quick-filter dropdown "Collections" with presets: all collections actions, MDM only, letters only, dunning escalations only
+- Filter actions: `STATUS_CHANGE` (contract), `DUNNING_ESCALATION_*`, `MDM_LOCK_*`, `MDM_UNLOCK`, `LETTER_*`, `CONTRACT_STATUS_LEGAL`, `BULK_ASSIGN`, `CREATE_CALL_LOG`
+- Use existing filter infra if possible; add as preset button row above the table
+
+**Commit:** `feat(audit): quick-filter presets for collections-related audit actions`
+
+---
+
+### Task 5: Bulk slip upload for dispatched letters
+**Why:** If OWNER mails 10 letters in one batch, they have 10 tracking slips to match back. Current flow requires opening each letter's dialog one at a time.
+
+**Files:**
+- Create: `apps/web/src/pages/CollectionsPage/components/BulkSlipUploadDialog.tsx`
+- Modify: `LetterQueueSection.tsx` — add "อัปโหลดสลิปชุด" button when ≥2 DISPATCHED letters present
+
+**Behavior:**
+- Dialog shows list of DISPATCHED letters missing `evidencePhotoUrl`
+- For each row: letter number + tracking# + file input
+- Upload all files in parallel via existing LETTER_EVIDENCE presigned URL endpoint, then PATCH each letter with its evidence URL
+
+**Note:** No new backend — reuses existing `/overdue/letters/:id/dispatch` to re-set evidencePhotoUrl (actually dispatch locks status to DISPATCHED; need a dedicated `PATCH /overdue/letters/:id/evidence` endpoint that only updates the photo URL post-dispatch).
+
+Add small backend endpoint:
+```typescript
+@Patch('letters/:id/evidence')
+@Roles('OWNER', 'FINANCE_MANAGER')
+updateLetterEvidence(
+  @Param('id') id: string,
+  @Body() body: { evidencePhotoUrl: string },
+  @CurrentUser() user: { id: string },
+) {
+  return this.contractLetterService.updateEvidence(id, body.evidencePhotoUrl, user.id);
+}
+```
+
+With service method:
+```typescript
+async updateEvidence(letterId: string, evidencePhotoUrl: string, userId: string) {
+  const letter = await prisma.contractLetter.findUnique({ where: { id: letterId } });
+  if (!letter) throw NotFoundException;
+  if (!['DISPATCHED','DELIVERED'].includes(letter.status)) throw BadRequestException;
+  return prisma.$transaction([
+    prisma.contractLetter.update({ where: { id: letterId }, data: { evidencePhotoUrl } }),
+    prisma.auditLog.create({ data: { userId, action: 'LETTER_EVIDENCE_UPDATED', entity: 'contract_letter', entityId: letterId, newValue: { evidencePhotoUrl } } }),
+  ]).then(([l]) => l);
+}
+```
+
+**Commit:** `feat(collections): bulk slip upload for dispatched letters`
+
+---
+
+### Task 6: Final sweep + PR
+
+```bash
+./tools/check-types.sh all
+cd apps/api && npx jest --testPathPattern='overdue|dunning|mdm-lock|contract-letter|collections|queue|kpi|timeline|bulk|letter|broken-promise|retry'
+cd apps/web && npm test -- --run
+```
+
+Then push + PR stacked on `feat/collections-hardening`.


### PR DESCRIPTION
## Summary

Plan 6 closes the 5 deferred items from Plan 5 audit. Stacked on Plan 5.

**Base branch:** \`feat/collections-hardening\` (Plan 5) — merge #688 first.

## What's shipped

### Backend (4 new endpoints)
- \`POST /payments/auto-allocate\` — now accepts optional \`evidenceUrl\` (attached to first Payment for non-cash slips)
- \`GET /overdue/line-retries?limit=100\` — list FAILED DunningActions (OWNER/FM/BM)
- \`POST /overdue/line-retries/:id/retry\` — resend via NotificationsService (OWNER/FM)
- \`PATCH /overdue/letters/:id/evidence\` — update slip photo post-dispatch (OWNER/FM)
- \`GET /overdue/analytics?range=30d|90d\` — 5 trend metric arrays, 5-min cache (OWNER/FM)

### Frontend (5 UI additions)
- **Slip upload enforcement** — PaymentRecordDialog shows required slip field for BANK_TRANSFER / QR_EWALLET, uploads via BANK_SLIP presigned URL, submit gated until slip resolves
- **LINE retry queue** — 4th section in ApprovalTab listing failed sends with per-row retry button
- **Analytics tab** — new 6th tab 📊 วิเคราะห์ (OWNER/FM) with 5 recharts:
  - Weekly collection rate (line)
  - Promise kept vs broken (stacked bar)
  - Dunning action volume sent/failed (line)
  - Letter dispatch by type per month (grouped bar)
  - MDM lock proposed vs approved per day (line)
  + 30d/90d range toggle
- **Audit log presets** — quick-filter buttons on AuditLogsPage for Collections / MDM / Letters / Dunning actions
- **Bulk slip upload** — dialog in LetterQueueSection surfaces when ≥2 DISPATCHED letters missing evidence; upload all at once with per-row file input

## Stats

- **10 commits**
- **+1,800 lines** (estimate)
- **222 backend tests pass** (+74 from Plan 5)
- **0 TypeScript errors** (api + web)

## Customer impact on deploy

**Still zero** — all features are OWNER/FM admin tools. No new cron firing on customers. Slip upload enforcement applies only when collector manually triggers PaymentRecordDialog with non-cash method.

## Test plan

- [ ] CI: 0 TS + all tests pass
- [ ] Staging: Payment with BANK_TRANSFER requires slip; upload succeeds; Payment.evidenceUrl populated
- [ ] Staging: force a DunningAction to FAILED (e.g., customer without lineId + LINE template active) → appears in retry queue → retry button works
- [ ] Staging: OWNER opens Analytics tab → 5 charts render without crash (even on empty data)
- [ ] Staging: AuditLogs page preset "หนังสือ" filters to LETTER_* actions
- [ ] Staging: dispatch 3 letters → bulk slip upload dialog appears → upload 2 slips → each letter gets evidencePhotoUrl

## What's fully done now across all 6 plans

### Collections Workflow Hub — complete feature set
- Schema + migrations (6 enums, 2 new tables, 8+ new columns)
- Event-driven dunning engine + 8 seeded rules
- MDM lock service + auto-propose cron + wallpaper upload
- Legal letters (45d + 60d) with full state machine, PDF generator, dispatch flow, evidence chain
- 6 tabs: คิววันนี้ / ตามต่อ / นัดชำระ / อนุมัติ / ทั้งหมด / วิเคราะห์
- ContractCard with priority heat strip + operations-room aesthetic
- Customer 360 slide-over with timeline + installment progress bar + actions
- Bulk actions (assign, send LINE, propose lock, slip upload)
- Inline payment recording with slip enforcement
- OWNER notifications via LINE for pending approval items
- LINE retry queue for failed sends
- Audit log quick-filter
- Analytics with 5 metric trends
- Deployment runbook

## Still deferred (out of scope — external vendor work)

- Thailand Post Connect API auto-dispatch
- PJ-Soft MDM API integration (physical device lock remains manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)