### PR TITLE
feat(collections): P0 UI enhancements

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -85,6 +85,7 @@ import { PeakModule } from './modules/peak/peak.module';
 import { MdmModule } from './modules/mdm/mdm.module';
 import { WebhooksModule } from './modules/webhooks/webhooks.module';
 import { AnalyticsModule } from './modules/analytics/analytics.module';
+import { SearchModule } from './modules/search/search.module';
 import { LoyaltyModule } from './modules/loyalty/loyalty.module';
 import { ShopTrackingModule } from './modules/shop-tracking/shop-tracking.module';
 import { ShopBotDefenseModule } from './modules/shop-bot-defense/shop-bot-defense.module';
@@ -293,6 +294,7 @@ import { AppCacheModule } from './cache/cache.module';
     SettingsModule,
     WebhooksModule,
     AnalyticsModule,
+    SearchModule,
     // Data Audit — automated DB health checks (OWNER only)
     DataAuditModule,
     // Two-Factor Authentication management (enroll, confirm, disable, backup codes)

--- a/apps/api/src/modules/overdue/dto/approve-mdm.dto.ts
+++ b/apps/api/src/modules/overdue/dto/approve-mdm.dto.ts
@@ -1,0 +1,15 @@
+import { IsBoolean, IsOptional } from 'class-validator';
+
+/**
+ * Body of POST /overdue/mdm-requests/:id/approve.
+ *
+ * - `includeWallpaper` is optional. When omitted the service falls back to
+ *   the proposer's choice stored on the MdmLockRequest row. When provided,
+ *   the approver's value overrides (approver has authority to decide at
+ *   approval time, not just at proposal time).
+ */
+export class ApproveMdmDto {
+  @IsOptional()
+  @IsBoolean({ message: 'ค่า includeWallpaper ต้องเป็น true/false' })
+  includeWallpaper?: boolean;
+}

--- a/apps/api/src/modules/overdue/dto/queue-query.dto.ts
+++ b/apps/api/src/modules/overdue/dto/queue-query.dto.ts
@@ -1,10 +1,71 @@
-import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
-import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { ContractStatus, ProductCategory } from '@prisma/client';
+
+// Overdue bucket codes (human-readable in URL query).
+export enum OverdueBucket {
+  B_1_7 = '1-7',
+  B_8_30 = '8-30',
+  B_31_60 = '31-60',
+  B_61_90 = '61-90',
+  B_90_PLUS = '90+',
+}
+
+// When was the customer last contacted via any channel.
+export enum LastContactedBucket {
+  TODAY = 'today',
+  THIS_WEEK = 'this_week',
+  NEVER = 'never',
+  OVER_7_DAYS = 'over_7_days',
+}
+
+// LINE delivery state — derived from dunning action result + customer.lineId.
+export enum LineResponseState {
+  RESPONDED = 'responded',
+  IGNORED = 'ignored',
+  BLOCKED = 'blocked',
+  NO_LINE = 'no_line',
+}
+
+// Coarse MDM lock state filter — maps to MdmLockStatus groups.
+export enum MdmStateFilter {
+  NOT_LOCKED = 'not_locked',
+  LOCKED = 'locked',
+  PENDING = 'pending',
+}
+
+// CSV or array → string[] (express parses repeated keys differently based on
+// query-parser; we accept both shapes).
+function splitCsv(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((v) => String(v));
+  if (value === undefined || value === null || value === '') return [];
+  return String(value)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function toBool(value: unknown): boolean | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'boolean') return value;
+  return value === 'true' || value === '1';
+}
 
 export class QueueQueryDto {
   @IsEnum(['today', 'followup', 'promise'], { message: 'tab ต้องเป็น today, followup, หรือ promise' })
   tab!: 'today' | 'followup' | 'promise';
 
+  // Existing
   @IsOptional()
   @IsString()
   branchId?: string;
@@ -21,4 +82,83 @@ export class QueueQueryDto {
   @Min(1)
   @Max(100)
   limit?: number;
+
+  // --- New filter fields ---
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsString()
+  assignedToId?: string; // 'self' | 'unassigned' | UUID
+
+  @IsOptional()
+  @Transform(({ value }) => toBool(value))
+  @IsBoolean()
+  showSkipTracing?: boolean;
+
+  @IsOptional()
+  @Transform(({ value }) => splitCsv(value))
+  @IsArray()
+  @IsEnum(OverdueBucket, { each: true, message: 'bucket ไม่ถูกต้อง' })
+  overdueBuckets?: OverdueBucket[];
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  minOutstanding?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  maxOutstanding?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => splitCsv(value))
+  @IsArray()
+  @IsEnum(ContractStatus, { each: true, message: 'status ไม่ถูกต้อง' })
+  contractStatuses?: ContractStatus[];
+
+  @IsOptional()
+  @Transform(({ value }) => splitCsv(value))
+  @IsArray()
+  @IsEnum(ProductCategory, { each: true, message: 'ประเภทสินค้าไม่ถูกต้อง' })
+  productTypes?: ProductCategory[];
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  minLetterCount?: number;
+
+  @IsOptional()
+  @IsEnum(LastContactedBucket)
+  lastContacted?: LastContactedBucket;
+
+  @IsOptional()
+  @IsEnum(LineResponseState)
+  lineResponse?: LineResponseState;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  minBrokenPromise?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => toBool(value))
+  @IsBoolean()
+  hasActivePromise?: boolean;
+
+  @IsOptional()
+  @IsEnum(MdmStateFilter)
+  mdmState?: MdmStateFilter;
+
+  @IsOptional()
+  @Transform(({ value }) => toBool(value))
+  @IsBoolean()
+  slipReviewPending?: boolean;
 }

--- a/apps/api/src/modules/overdue/mdm-lock.service.spec.ts
+++ b/apps/api/src/modules/overdue/mdm-lock.service.spec.ts
@@ -151,6 +151,79 @@ describe('MdmLockService', () => {
       const result = await service.approve('r1', 'owner1');
       expect(result.status).toBe('EXECUTED_MANUAL');
     });
+
+    it('approver can override wallpaper to TRUE even if proposer said false', async () => {
+      mockPrisma.user.findUnique.mockResolvedValueOnce({ role: 'OWNER' });
+      mockPrisma.mdmLockRequest.findUnique.mockResolvedValueOnce({
+        id: 'r1',
+        status: 'PENDING',
+        contractId: 'c1',
+        includeWallpaper: false,
+        trigger: 'MANUAL_COLLECTOR',
+      });
+      mockPrisma.systemConfig.findUnique.mockResolvedValueOnce({ value: 'https://s3/wall.png' });
+      mockPrisma.$transaction.mockResolvedValueOnce([{ id: 'r1', status: 'EXECUTED_MANUAL' }, {}, {}]);
+
+      await service.approve('r1', 'owner1', 'OWNER', { includeWallpaper: true });
+
+      // Request update payload includes the wallpaperUrlUsed when override=true
+      const reqUpdateArg = mockPrisma.mdmLockRequest.update.mock.calls.at(-1)![0];
+      expect(reqUpdateArg.data).toMatchObject({
+        status: 'EXECUTED_MANUAL',
+        wallpaperUrlUsed: 'https://s3/wall.png',
+      });
+      // Contract update marks wallpaperChanged=true
+      const contractUpdateArg = mockPrisma.contract.update.mock.calls.at(-1)![0];
+      expect(contractUpdateArg.data).toMatchObject({
+        deviceLocked: true,
+        wallpaperChanged: true,
+      });
+    });
+
+    it('approver can override wallpaper to FALSE even if proposer said true', async () => {
+      mockPrisma.user.findUnique.mockResolvedValueOnce({ role: 'OWNER' });
+      mockPrisma.mdmLockRequest.findUnique.mockResolvedValueOnce({
+        id: 'r1',
+        status: 'PENDING',
+        contractId: 'c1',
+        includeWallpaper: true,
+        trigger: 'MANUAL_COLLECTOR',
+      });
+      mockPrisma.$transaction.mockResolvedValueOnce([{ id: 'r1', status: 'EXECUTED_MANUAL' }, {}, {}]);
+
+      await service.approve('r1', 'owner1', 'OWNER', { includeWallpaper: false });
+
+      // systemConfig lookup should be skipped when override=false
+      expect(mockPrisma.systemConfig.findUnique).not.toHaveBeenCalled();
+
+      const reqUpdateArg = mockPrisma.mdmLockRequest.update.mock.calls.at(-1)![0];
+      expect(reqUpdateArg.data).toMatchObject({ wallpaperUrlUsed: null });
+      const contractUpdateArg = mockPrisma.contract.update.mock.calls.at(-1)![0];
+      expect(contractUpdateArg.data).toMatchObject({
+        deviceLocked: true,
+        wallpaperChanged: false,
+      });
+    });
+
+    it('falls back to proposer choice when approver does not supply override', async () => {
+      mockPrisma.user.findUnique.mockResolvedValueOnce({ role: 'OWNER' });
+      mockPrisma.mdmLockRequest.findUnique.mockResolvedValueOnce({
+        id: 'r1',
+        status: 'PENDING',
+        contractId: 'c1',
+        includeWallpaper: true,
+        trigger: 'MANUAL_COLLECTOR',
+      });
+      mockPrisma.systemConfig.findUnique.mockResolvedValueOnce({ value: 'https://s3/wall.png' });
+      mockPrisma.$transaction.mockResolvedValueOnce([{ id: 'r1', status: 'EXECUTED_MANUAL' }, {}, {}]);
+
+      await service.approve('r1', 'owner1');
+
+      const reqUpdateArg = mockPrisma.mdmLockRequest.update.mock.calls.at(-1)![0];
+      expect(reqUpdateArg.data).toMatchObject({
+        wallpaperUrlUsed: 'https://s3/wall.png',
+      });
+    });
   });
 
   describe('reject', () => {

--- a/apps/api/src/modules/overdue/mdm-lock.service.ts
+++ b/apps/api/src/modules/overdue/mdm-lock.service.ts
@@ -80,7 +80,22 @@ export class MdmLockService {
     });
   }
 
-  async approve(requestId: string, approverId: string, approverRole?: string) {
+  /**
+   * Approve a pending MDM lock request and execute it.
+   *
+   * @param options.includeWallpaper — Optional approver override. When
+   *   provided, this takes precedence over the proposer's `includeWallpaper`
+   *   field on the request. When omitted, falls back to the proposer's
+   *   choice. This lets OWNER/FINANCE_MANAGER decide at approve-time whether
+   *   the wallpaper ships, instead of being locked into the proposer's
+   *   decision (D2 UX).
+   */
+  async approve(
+    requestId: string,
+    approverId: string,
+    approverRole?: string,
+    options: { includeWallpaper?: boolean } = {},
+  ) {
     const role = await this.resolveRole(approverId, approverRole);
     if (!(APPROVE_ROLES as readonly string[]).includes(role)) {
       throw new ForbiddenException(`สิทธิ์อนุมัติล็อคเครื่องเฉพาะ ${APPROVE_ROLES.join(' / ')}`);
@@ -92,7 +107,11 @@ export class MdmLockService {
       throw new BadRequestException('คำขอนี้ไม่อยู่ในสถานะรออนุมัติ');
     }
 
-    const wallpaperUrl = req.includeWallpaper
+    // Approver override takes precedence; otherwise use proposer's choice.
+    const effectiveIncludeWallpaper =
+      options.includeWallpaper !== undefined ? options.includeWallpaper : req.includeWallpaper;
+
+    const wallpaperUrl = effectiveIncludeWallpaper
       ? (
           await this.prisma.systemConfig.findUnique({ where: { key: 'mdm_lock_wallpaper_url' } })
         )?.value ?? null
@@ -114,8 +133,8 @@ export class MdmLockService {
         data: {
           deviceLocked: true,
           deviceLockedAt: now,
-          wallpaperChanged: req.includeWallpaper,
-          wallpaperChangedAt: req.includeWallpaper ? now : null,
+          wallpaperChanged: effectiveIncludeWallpaper,
+          wallpaperChangedAt: effectiveIncludeWallpaper ? now : null,
         },
       }),
       this.prisma.auditLog.create({
@@ -124,7 +143,11 @@ export class MdmLockService {
           action: 'MDM_LOCK_APPROVED',
           entity: 'mdm_lock_request',
           entityId: requestId,
-          newValue: { trigger: req.trigger, includeWallpaper: req.includeWallpaper },
+          newValue: {
+            trigger: req.trigger,
+            includeWallpaper: effectiveIncludeWallpaper,
+            proposerIncludeWallpaper: req.includeWallpaper,
+          },
         },
       }),
     ]);

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -53,15 +53,32 @@ export class OverdueController {
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES', 'FINANCE_MANAGER', 'ACCOUNTANT')
   getQueue(
     @Query() dto: QueueQueryDto,
-    @CurrentUser() user: { role: string; branchId: string | null },
+    @CurrentUser() user: { id: string; role: string; branchId: string | null },
   ) {
     return this.queueService.getQueue({
       tab: dto.tab,
       branchId: dto.branchId,
       page: dto.page,
       limit: dto.limit,
+      userId: user.id,
       userRole: user.role,
       userBranchId: user.branchId,
+      // Filter fields
+      search: dto.search,
+      assignedToId: dto.assignedToId,
+      showSkipTracing: dto.showSkipTracing,
+      overdueBuckets: dto.overdueBuckets,
+      minOutstanding: dto.minOutstanding,
+      maxOutstanding: dto.maxOutstanding,
+      contractStatuses: dto.contractStatuses,
+      productTypes: dto.productTypes,
+      minLetterCount: dto.minLetterCount,
+      lastContacted: dto.lastContacted,
+      lineResponse: dto.lineResponse,
+      minBrokenPromise: dto.minBrokenPromise,
+      hasActivePromise: dto.hasActivePromise,
+      mdmState: dto.mdmState,
+      slipReviewPending: dto.slipReviewPending,
     });
   }
 

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -21,6 +21,7 @@ import { QueueQueryDto } from './dto/queue-query.dto';
 import { KpiQueryDto } from './dto/kpi-query.dto';
 import { BulkAssignDto, BulkProposeLockDto, BulkSendLineDto } from './dto/bulk.dto';
 import { SendLineAdHocDto } from './dto/send-line-adhoc.dto';
+import { ApproveMdmDto } from './dto/approve-mdm.dto';
 import { UpdateLetterEvidenceDto } from './dto/update-letter-evidence.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -351,9 +352,12 @@ export class OverdueController {
   @Roles('OWNER', 'FINANCE_MANAGER')
   approveMdmLock(
     @Param('id') id: string,
+    @Body() body: ApproveMdmDto,
     @CurrentUser() user: { id: string; role: string },
   ) {
-    return this.mdmLockService.approve(id, user.id, user.role);
+    return this.mdmLockService.approve(id, user.id, user.role, {
+      includeWallpaper: body.includeWallpaper,
+    });
   }
 
   @Post('mdm-requests/:id/reject')

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -6,14 +6,38 @@ const mockPrisma = {
   contract: {
     findMany: jest.fn(),
     count: jest.fn(),
+    groupBy: jest.fn(),
+  },
+  callLog: {
+    groupBy: jest.fn(),
+  },
+  dunningAction: {
+    groupBy: jest.fn(),
+    findMany: jest.fn(),
+  },
+  auditLog: {
+    groupBy: jest.fn(),
+  },
+  mdmLockRequest: {
+    findMany: jest.fn(),
   },
 };
+
+function resetEnrichmentMocks() {
+  mockPrisma.callLog.groupBy.mockResolvedValue([]);
+  mockPrisma.dunningAction.groupBy.mockResolvedValue([]);
+  mockPrisma.auditLog.groupBy.mockResolvedValue([]);
+  mockPrisma.mdmLockRequest.findMany.mockResolvedValue([]);
+  mockPrisma.contract.groupBy.mockResolvedValue([]);
+  mockPrisma.dunningAction.findMany.mockResolvedValue([]);
+}
 
 describe('OverdueQueueService', () => {
   let service: OverdueQueueService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    resetEnrichmentMocks();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OverdueQueueService,
@@ -29,6 +53,7 @@ describe('OverdueQueueService', () => {
       contractNumber: 'BC-2024-001',
       status: 'OVERDUE',
       dunningStage: 'STAGE_1',
+      customerId: 'cust-1',
       noAnswerCount: 0,
       needsSkipTracing: false,
       deviceLocked: false,
@@ -82,6 +107,12 @@ describe('OverdueQueueService', () => {
       expect(row).toHaveProperty('settlementDate');
       expect(row).toHaveProperty('needsSkipTracing');
       expect(row).toHaveProperty('deviceLocked');
+      // New enrichment fields
+      expect(row).toHaveProperty('lastContactedAt');
+      expect(row).toHaveProperty('brokenPromiseCount');
+      expect(row).toHaveProperty('mdmState');
+      expect(row).toHaveProperty('relatedContractsCount');
+      expect(row).toHaveProperty('lastChannel');
 
       // Verify computed fields
       expect(row.outstanding).toBe(5150); // 5000 - 0 + 150
@@ -253,6 +284,7 @@ describe('OverdueQueueService', () => {
       contractNumber: 'CN-x',
       status: 'OVERDUE',
       dunningStage: 'NONE',
+      customerId: 'cu',
       customer: { id: 'cu', name: 'x', phone: '0', lineId: null },
       branch: { id: 'b', name: 'b' },
       assignedTo: null,
@@ -296,6 +328,178 @@ describe('OverdueQueueService', () => {
       expect(result.data.map((r) => r.id)).toEqual(['high', 'mid', 'low']);
       // __priorityScore should be stripped from response
       expect((result.data[0] as any).__priorityScore).toBeUndefined();
+    });
+  });
+
+  describe('card indicators enrichment', () => {
+    it('computes lastContactedAt as max of CallLog.createdAt and DunningAction.executedAt', async () => {
+      const contract = makeContract();
+      const callTs = new Date(Date.now() - 3 * 3600 * 1000); // 3h ago
+      const actionTs = new Date(Date.now() - 1 * 3600 * 1000); // 1h ago (more recent)
+
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.callLog.groupBy.mockResolvedValueOnce([
+        { contractId: 'contract-1', _max: { createdAt: callTs } },
+      ]);
+      mockPrisma.dunningAction.groupBy.mockResolvedValueOnce([
+        { contractId: 'contract-1', _max: { executedAt: actionTs } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].lastContactedAt).toEqual(actionTs);
+    });
+
+    it('falls back to CallLog.createdAt if no DunningAction', async () => {
+      const contract = makeContract();
+      const callTs = new Date(Date.now() - 3600 * 1000);
+
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.callLog.groupBy.mockResolvedValueOnce([
+        { contractId: 'contract-1', _max: { createdAt: callTs } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].lastContactedAt).toEqual(callTs);
+    });
+
+    it('returns null lastContactedAt when no contacts exist', async () => {
+      const contract = makeContract();
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].lastContactedAt).toBeNull();
+    });
+
+    it('includes brokenPromiseCount from BROKEN_PROMISE audit events', async () => {
+      const contract = makeContract();
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.auditLog.groupBy.mockResolvedValueOnce([
+        { entityId: 'contract-1', _count: { _all: 2 } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].brokenPromiseCount).toBe(2);
+    });
+
+    it('maps MdmLockRequest status to mdmState — PENDING/LOCKED/UNLOCKED/NONE', async () => {
+      const contract = makeContract();
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.mdmLockRequest.findMany.mockResolvedValueOnce([
+        { contractId: 'contract-1', status: 'EXECUTED_API' },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].mdmState).toBe('LOCKED');
+    });
+
+    it('returns NONE mdmState when no MdmLockRequest exists', async () => {
+      const contract = makeContract();
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].mdmState).toBe('NONE');
+    });
+
+    it('computes relatedContractsCount as other active contracts for customer', async () => {
+      const contract = makeContract();
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.contract.groupBy.mockResolvedValueOnce([
+        { customerId: 'cust-1', _count: { _all: 3 } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      // 3 total active → 2 others
+      expect(result.data[0].relatedContractsCount).toBe(2);
+    });
+
+    it('maps latest DunningAction channel to lastChannel (LINE/SMS/CALL)', async () => {
+      const contract = makeContract();
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.dunningAction.findMany.mockResolvedValueOnce([
+        { contractId: 'contract-1', channel: 'LINE' },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].lastChannel).toBe('LINE');
+    });
+
+    it('returns null lastChannel when no DunningAction exists', async () => {
+      const contract = makeContract();
+      mockPrisma.contract.findMany.mockResolvedValueOnce([contract]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.data[0].lastChannel).toBeNull();
+    });
+
+    it('batch-loads enrichment via 6 aggregate queries (no N+1)', async () => {
+      const contracts = [makeContract(), makeContract({ id: 'c2', customerId: 'cust-2' })];
+      mockPrisma.contract.findMany.mockResolvedValueOnce(contracts);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+
+      await service.getQueue({ tab: 'today', userRole: 'OWNER', userBranchId: null });
+
+      // One call per aggregate regardless of row count — no N+1
+      expect(mockPrisma.callLog.groupBy).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.dunningAction.groupBy).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.auditLog.groupBy).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.mdmLockRequest.findMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.contract.groupBy).toHaveBeenCalledTimes(1);
+      // 2 dunningAction.findMany calls total allowed (one for lastChannel)
+      expect(mockPrisma.dunningAction.findMany).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -21,6 +21,12 @@ const mockPrisma = {
   mdmLockRequest: {
     findMany: jest.fn(),
   },
+  contractLetter: {
+    groupBy: jest.fn(),
+  },
+  paymentEvidence: {
+    groupBy: jest.fn(),
+  },
 };
 
 function resetEnrichmentMocks() {
@@ -30,6 +36,8 @@ function resetEnrichmentMocks() {
   mockPrisma.mdmLockRequest.findMany.mockResolvedValue([]);
   mockPrisma.contract.groupBy.mockResolvedValue([]);
   mockPrisma.dunningAction.findMany.mockResolvedValue([]);
+  mockPrisma.contractLetter.groupBy.mockResolvedValue([]);
+  mockPrisma.paymentEvidence.groupBy.mockResolvedValue([]);
 }
 
 describe('OverdueQueueService', () => {
@@ -485,7 +493,7 @@ describe('OverdueQueueService', () => {
       expect(result.data[0].lastChannel).toBeNull();
     });
 
-    it('batch-loads enrichment via 6 aggregate queries (no N+1)', async () => {
+    it('batch-loads enrichment via 8 aggregate queries (no N+1)', async () => {
       const contracts = [makeContract(), makeContract({ id: 'c2', customerId: 'cust-2' })];
       mockPrisma.contract.findMany.mockResolvedValueOnce(contracts);
       mockPrisma.contract.count.mockResolvedValueOnce(2);
@@ -500,6 +508,9 @@ describe('OverdueQueueService', () => {
       expect(mockPrisma.contract.groupBy).toHaveBeenCalledTimes(1);
       // 2 dunningAction.findMany calls total allowed (one for lastChannel)
       expect(mockPrisma.dunningAction.findMany).toHaveBeenCalledTimes(1);
+      // New in v-P0-final: letterCount + slipReviewPending enrichment
+      expect(mockPrisma.contractLetter.groupBy).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.paymentEvidence.groupBy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -713,6 +724,91 @@ describe('OverdueQueueService', () => {
       });
 
       expect(result.truncated).toBe(false);
+    });
+
+    it('filters by minLetterCount using ContractLetter groupBy count', async () => {
+      const a = makeContractWithDays('a', 10);
+      const b = makeContractWithDays('b', 10);
+      const c = makeContractWithDays('c', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([a, b, c]);
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+      mockPrisma.contractLetter.groupBy.mockResolvedValueOnce([
+        { contractId: 'a', _count: { _all: 3 } },
+        { contractId: 'b', _count: { _all: 1 } },
+        // c has no letters → 0 from the default
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        minLetterCount: 2,
+      });
+
+      expect(result.data.map((r) => r.id)).toEqual(['a']);
+      expect(result.data[0].letterCount).toBe(3);
+      // total reflects post-filter count, not raw SQL count
+      expect(result.total).toBe(1);
+    });
+
+    it('filters by slipReviewPending=true (only rows with pending PaymentEvidence)', async () => {
+      const a = makeContractWithDays('a', 10);
+      const b = makeContractWithDays('b', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([a, b]);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+      mockPrisma.paymentEvidence.groupBy.mockResolvedValueOnce([
+        { contractId: 'a', _count: { _all: 2 } },
+        // b has none
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        slipReviewPending: true,
+      });
+
+      expect(result.data.map((r) => r.id)).toEqual(['a']);
+      expect(result.data[0].slipReviewPending).toBe(true);
+    });
+
+    it('slipReviewPending=false excludes contracts with pending slips', async () => {
+      const a = makeContractWithDays('a', 10);
+      const b = makeContractWithDays('b', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([a, b]);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+      mockPrisma.paymentEvidence.groupBy.mockResolvedValueOnce([
+        { contractId: 'a', _count: { _all: 1 } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        slipReviewPending: false,
+      });
+
+      expect(result.data.map((r) => r.id)).toEqual(['b']);
+      expect(result.data[0].slipReviewPending).toBe(false);
+    });
+
+    it('minLetterCount=0 includes all contracts (no letters filter)', async () => {
+      const a = makeContractWithDays('a', 10);
+      const b = makeContractWithDays('b', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([a, b]);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+      mockPrisma.contractLetter.groupBy.mockResolvedValueOnce([
+        { contractId: 'a', _count: { _all: 0 } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        minLetterCount: 0,
+      });
+
+      expect(result.data.map((r) => r.id).sort()).toEqual(['a', 'b']);
     });
   });
 });

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -502,4 +502,217 @@ describe('OverdueQueueService', () => {
       expect(mockPrisma.dunningAction.findMany).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('filters', () => {
+    function makeContractWithDays(id: string, days: number): any {
+      return {
+        id,
+        contractNumber: `BC-${id}`,
+        status: 'OVERDUE',
+        dunningStage: 'NONE',
+        customerId: `cust-${id}`,
+        noAnswerCount: 0,
+        needsSkipTracing: false,
+        deviceLocked: false,
+        customer: { id: `cust-${id}`, name: `ลูกค้า ${id}`, phone: '0800000000', lineId: null },
+        branch: { id: 'branch-1', name: 'สาขา 1' },
+        assignedTo: null,
+        payments: [
+          {
+            amountDue: '5000.00',
+            amountPaid: '0.00',
+            lateFee: '0',
+            dueDate: new Date(Date.now() - days * 86400000),
+            status: 'OVERDUE',
+          },
+        ],
+        callLogs: [],
+        _count: { callLogs: 0 },
+      };
+    }
+
+    it('filters by overdueBuckets (8-30 and 31-60 range)', async () => {
+      const contracts = [
+        makeContractWithDays('a', 3), // 1-7
+        makeContractWithDays('b', 15), // 8-30
+        makeContractWithDays('c', 45), // 31-60
+        makeContractWithDays('d', 75), // 61-90
+        makeContractWithDays('e', 120), // 90+
+      ];
+      mockPrisma.contract.findMany.mockResolvedValueOnce(contracts);
+      mockPrisma.contract.count.mockResolvedValueOnce(5);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        overdueBuckets: ['8-30', '31-60'] as any,
+      });
+
+      const ids = result.data.map((r) => r.id).sort();
+      expect(ids).toEqual(['b', 'c']);
+    });
+
+    it('filters by outstanding range (min/max)', async () => {
+      const small = { ...makeContractWithDays('small', 10) };
+      small.payments = [
+        { amountDue: '1000', amountPaid: '0', lateFee: '0', dueDate: new Date(Date.now() - 10 * 86400000) },
+      ];
+      const mid = { ...makeContractWithDays('mid', 10) };
+      mid.payments = [
+        { amountDue: '10000', amountPaid: '0', lateFee: '0', dueDate: new Date(Date.now() - 10 * 86400000) },
+      ];
+      const large = { ...makeContractWithDays('large', 10) };
+      large.payments = [
+        { amountDue: '50000', amountPaid: '0', lateFee: '0', dueDate: new Date(Date.now() - 10 * 86400000) },
+      ];
+      mockPrisma.contract.findMany.mockResolvedValueOnce([small, mid, large]);
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        minOutstanding: 5000,
+        maxOutstanding: 20000,
+      });
+
+      expect(result.data.map((r) => r.id)).toEqual(['mid']);
+    });
+
+    it('filters by minBrokenPromise using enriched count', async () => {
+      const a = makeContractWithDays('a', 10);
+      const b = makeContractWithDays('b', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([a, b]);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+      mockPrisma.auditLog.groupBy.mockResolvedValueOnce([
+        { entityId: 'a', _count: { _all: 2 } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        minBrokenPromise: 1,
+      });
+
+      expect(result.data.map((r) => r.id)).toEqual(['a']);
+      expect(result.data[0].brokenPromiseCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('filters by lastContacted=never (rows with no call or dunning action)', async () => {
+      const a = makeContractWithDays('a', 10);
+      const b = makeContractWithDays('b', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([a, b]);
+      mockPrisma.contract.count.mockResolvedValueOnce(2);
+      mockPrisma.callLog.groupBy.mockResolvedValueOnce([
+        { contractId: 'a', _max: { createdAt: new Date() } },
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        lastContacted: 'never' as any,
+      });
+
+      expect(result.data.map((r) => r.id)).toEqual(['b']);
+      expect(result.data[0].lastContactedAt).toBeNull();
+    });
+
+    it('filters by mdmState=not_locked (excludes LOCKED/PENDING)', async () => {
+      const a = makeContractWithDays('a', 10);
+      const b = makeContractWithDays('b', 10);
+      const c = makeContractWithDays('c', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([a, b, c]);
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+      mockPrisma.mdmLockRequest.findMany.mockResolvedValueOnce([
+        { contractId: 'a', status: 'EXECUTED_API' }, // LOCKED
+        { contractId: 'b', status: 'PENDING' }, // PENDING
+      ]);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        mdmState: 'not_locked' as any,
+      });
+
+      expect(result.data.map((r) => r.id)).toEqual(['c']);
+    });
+
+    it('applies assignedToId=self via user id on where clause', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        userId: 'me-user-123',
+        assignedToId: 'self',
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      expect(callArg.where.assignedToId).toBe('me-user-123');
+    });
+
+    it('applies contractStatuses filter in Prisma where', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        contractStatuses: ['DEFAULT', 'LEGAL'] as any,
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      expect(callArg.where.status).toEqual({ in: ['DEFAULT', 'LEGAL'] });
+    });
+
+    it('applies productTypes filter via Product relation', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        productTypes: ['PHONE_USED'] as any,
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      expect(callArg.where.product).toEqual({ category: { in: ['PHONE_USED'] } });
+    });
+
+    it('returns truncated=true when fetch hits FETCH_CAP', async () => {
+      const many = Array.from({ length: 500 }, (_, i) => makeContractWithDays(`c${i}`, 10));
+      mockPrisma.contract.findMany.mockResolvedValueOnce(many);
+      mockPrisma.contract.count.mockResolvedValueOnce(1200);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.truncated).toBe(true);
+    });
+
+    it('returns truncated=false when fetch under FETCH_CAP', async () => {
+      const few = [makeContractWithDays('only', 10)];
+      mockPrisma.contract.findMany.mockResolvedValueOnce(few);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+
+      const result = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(result.truncated).toBe(false);
+    });
+  });
 });

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -1,27 +1,58 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { ContractStatus, Prisma, ProductCategory } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import {
+  LastContactedBucket,
+  LineResponseState,
+  MdmStateFilter,
+  OverdueBucket,
+} from './dto/queue-query.dto';
 
 export type QueueTab = 'today' | 'followup' | 'promise';
 
 export type MdmState = 'NONE' | 'PENDING' | 'LOCKED' | 'UNLOCKED';
 export type LastChannel = 'LINE' | 'SMS' | 'CALL' | 'LETTER' | null;
 
+const FETCH_CAP = 500;
+
+export interface QueueFilterInput {
+  // Pre-SQL filters
+  search?: string;
+  assignedToId?: string; // 'self' | 'unassigned' | UUID
+  showSkipTracing?: boolean;
+  overdueBuckets?: OverdueBucket[];
+  minOutstanding?: number;
+  maxOutstanding?: number;
+  contractStatuses?: ContractStatus[];
+  productTypes?: ProductCategory[];
+  minLetterCount?: number;
+
+  // Post-enrichment filters (apply to computed fields after fetch)
+  lastContacted?: LastContactedBucket;
+  lineResponse?: LineResponseState;
+  minBrokenPromise?: number;
+  hasActivePromise?: boolean;
+  mdmState?: MdmStateFilter;
+  slipReviewPending?: boolean;
+}
+
 @Injectable()
 export class OverdueQueueService {
   constructor(private prisma: PrismaService) {}
 
-  async getQueue(params: {
-    tab: QueueTab;
-    userRole: string;
-    userBranchId: string | null;
-    branchId?: string;
-    page?: number;
-    limit?: number;
-  }) {
+  async getQueue(
+    params: {
+      tab: QueueTab;
+      userRole: string;
+      userBranchId: string | null;
+      userId?: string;
+      branchId?: string;
+      page?: number;
+      limit?: number;
+    } & QueueFilterInput,
+  ) {
     const page = params.page ?? 1;
     const limit = Math.min(params.limit ?? 50, 100);
-    const skip = (page - 1) * limit;
     const now = new Date();
 
     const branchScope: Prisma.ContractWhereInput =
@@ -32,6 +63,7 @@ export class OverdueQueueService {
         : {};
 
     const where = this.buildWhere(params.tab, now, branchScope);
+    this.applyFilterWhere(where, params, params.userId);
 
     // Fetch all matching then sort by priority score in memory, then paginate.
     // We can't express the priority formula as a Prisma orderBy (it involves a
@@ -61,18 +93,203 @@ export class OverdueQueueService {
             },
           },
         },
-        take: 500, // cap the fetch — priority sort + pagination happens in memory
+        take: FETCH_CAP, // cap the fetch — priority sort + pagination happens in memory
       }),
       this.prisma.contract.count({ where }),
     ]);
 
     const enriched = await this.enrichRows(contracts, now);
 
-    const rows = enriched.sort((a, b) => b.__priorityScore - a.__priorityScore);
+    // Post-enrichment filters — computed fields can't go into Prisma where.
+    const afterPostFilter = this.applyPostFilters(enriched, params, now);
 
+    const rows = afterPostFilter.sort((a, b) => b.__priorityScore - a.__priorityScore);
+
+    // If any post-filter fired, `total` must reflect filtered count so UI
+    // pagination doesn't read "500 results" while showing 12. When no post-
+    // filter active, fall back to the raw SQL count (authoritative for large sets).
+    const hasPostFilter =
+      params.lastContacted !== undefined ||
+      params.lineResponse !== undefined ||
+      params.minBrokenPromise !== undefined ||
+      params.hasActivePromise !== undefined ||
+      params.mdmState !== undefined ||
+      params.slipReviewPending !== undefined;
+
+    const effectiveTotal = hasPostFilter ? afterPostFilter.length : total;
+
+    const skip = (page - 1) * limit;
     const paged = rows.slice(skip, skip + limit).map(({ __priorityScore, ...rest }) => rest);
 
-    return { data: paged, total, page, limit };
+    const truncated = contracts.length >= FETCH_CAP;
+
+    return { data: paged, total: effectiveTotal, page, limit, truncated };
+  }
+
+  /**
+   * Mutate `where` to apply SQL-level filter constraints (branch overrides,
+   * assignee, overdue buckets, outstanding range, contract/product type, skip
+   * tracing, search). Callers pass the already-built tab-specific where.
+   */
+  private applyFilterWhere(
+    where: Prisma.ContractWhereInput,
+    f: QueueFilterInput,
+    userId?: string,
+  ): void {
+    // Assignee override
+    if (f.assignedToId === 'self') {
+      where.assignedToId = userId ?? undefined;
+    } else if (f.assignedToId === 'unassigned') {
+      where.assignedToId = null;
+    } else if (f.assignedToId) {
+      where.assignedToId = f.assignedToId;
+    }
+
+    // Skip tracing
+    if (f.showSkipTracing) {
+      where.needsSkipTracing = true;
+    }
+
+    // Contract statuses — if provided, overrides any tab-defined status filter
+    if (f.contractStatuses?.length) {
+      where.status = { in: f.contractStatuses };
+    }
+
+    // Product types (via join)
+    if (f.productTypes?.length) {
+      where.product = { category: { in: f.productTypes } };
+    }
+
+    // Outstanding range — applied as a nested payment filter. We can't filter
+    // directly on (amountDue - amountPaid + lateFee), so approximate with
+    // amountDue; post-filter will tighten exact range on computed outstanding.
+    // (Outstanding post-filter below handles exact bounds.)
+    // No-op at SQL level — handled in applyPostFilters.
+
+    // Search: customer name, contract#, phone
+    if (f.search) {
+      const q = f.search.trim();
+      if (q) {
+        const searchOr: Prisma.ContractWhereInput[] = [
+          { contractNumber: { contains: q, mode: 'insensitive' } },
+          { customer: { name: { contains: q, mode: 'insensitive' } } },
+          { customer: { phone: { contains: q.replace(/\D/g, '') } } },
+        ];
+        where.AND = [
+          ...(Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : []),
+          { OR: searchOr },
+        ];
+      }
+    }
+  }
+
+  /**
+   * Apply filters that depend on enriched/computed fields. Runs after fetch,
+   * so `rows` is bounded by FETCH_CAP.
+   */
+  private applyPostFilters<
+    T extends {
+      daysOverdue: number;
+      outstanding: number;
+      lastContactedAt: Date | null;
+      brokenPromiseCount: number;
+      mdmState: MdmState;
+      settlementDate: Date | string | null;
+      customer: { lineId: string | null };
+    },
+  >(rows: T[], f: QueueFilterInput, now: Date): T[] {
+    let filtered = rows;
+
+    // Overdue buckets (computed on `daysOverdue`)
+    if (f.overdueBuckets?.length) {
+      const matchesBucket = (days: number, bucket: OverdueBucket) => {
+        switch (bucket) {
+          case OverdueBucket.B_1_7:
+            return days >= 1 && days <= 7;
+          case OverdueBucket.B_8_30:
+            return days >= 8 && days <= 30;
+          case OverdueBucket.B_31_60:
+            return days >= 31 && days <= 60;
+          case OverdueBucket.B_61_90:
+            return days >= 61 && days <= 90;
+          case OverdueBucket.B_90_PLUS:
+            return days >= 91;
+        }
+      };
+      filtered = filtered.filter((r) =>
+        (f.overdueBuckets as OverdueBucket[]).some((b) => matchesBucket(r.daysOverdue, b)),
+      );
+    }
+
+    // Outstanding range (exact)
+    if (f.minOutstanding !== undefined) {
+      filtered = filtered.filter((r) => r.outstanding >= (f.minOutstanding as number));
+    }
+    if (f.maxOutstanding !== undefined) {
+      filtered = filtered.filter((r) => r.outstanding <= (f.maxOutstanding as number));
+    }
+
+    // Last contacted bucket
+    if (f.lastContacted) {
+      const nowMs = now.getTime();
+      filtered = filtered.filter((r) => {
+        const last = r.lastContactedAt ? new Date(r.lastContactedAt).getTime() : null;
+        switch (f.lastContacted) {
+          case LastContactedBucket.TODAY:
+            return last !== null && nowMs - last < 86400000;
+          case LastContactedBucket.THIS_WEEK:
+            return last !== null && nowMs - last < 7 * 86400000;
+          case LastContactedBucket.NEVER:
+            return last === null;
+          case LastContactedBucket.OVER_7_DAYS:
+            return last === null || nowMs - last > 7 * 86400000;
+          default:
+            return true;
+        }
+      });
+    }
+
+    // Minimum broken-promise count
+    if (f.minBrokenPromise !== undefined) {
+      filtered = filtered.filter((r) => r.brokenPromiseCount >= (f.minBrokenPromise as number));
+    }
+
+    // MDM state
+    if (f.mdmState) {
+      filtered = filtered.filter((r) => {
+        switch (f.mdmState) {
+          case MdmStateFilter.NOT_LOCKED:
+            return r.mdmState === 'NONE' || r.mdmState === 'UNLOCKED';
+          case MdmStateFilter.LOCKED:
+            return r.mdmState === 'LOCKED';
+          case MdmStateFilter.PENDING:
+            return r.mdmState === 'PENDING';
+          default:
+            return true;
+        }
+      });
+    }
+
+    // Has active promise — defined as settlementDate present and in the future
+    // or within the last 3 days (aligns with promise-tab window).
+    if (f.hasActivePromise !== undefined) {
+      filtered = filtered.filter((r) => {
+        if (!r.settlementDate) return !f.hasActivePromise;
+        const sms = new Date(r.settlementDate).getTime();
+        const active = sms >= now.getTime() - 3 * 86400000;
+        return f.hasActivePromise ? active : !active;
+      });
+    }
+
+    // LINE response (heuristic based on lastCallResult + customer.lineId).
+    // Server-side data doesn't include LINE delivery state yet — BLOCKED is
+    // inferred only from explicit flag when available; NO_LINE from missing
+    // customer.lineId. RESPONDED/IGNORED deferred (W-011 — ต้อง schema change).
+    if (f.lineResponse === LineResponseState.NO_LINE) {
+      filtered = filtered.filter((r) => !r.customer.lineId);
+    }
+
+    return filtered;
   }
 
   /**

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -114,7 +114,8 @@ export class OverdueQueueService {
       params.minBrokenPromise !== undefined ||
       params.hasActivePromise !== undefined ||
       params.mdmState !== undefined ||
-      params.slipReviewPending !== undefined;
+      params.slipReviewPending !== undefined ||
+      params.minLetterCount !== undefined;
 
     const effectiveTotal = hasPostFilter ? afterPostFilter.length : total;
 
@@ -196,6 +197,8 @@ export class OverdueQueueService {
       mdmState: MdmState;
       settlementDate: Date | string | null;
       customer: { lineId: string | null };
+      letterCount: number;
+      slipReviewPending: boolean;
     },
   >(rows: T[], f: QueueFilterInput, now: Date): T[] {
     let filtered = rows;
@@ -281,6 +284,19 @@ export class OverdueQueueService {
       });
     }
 
+    // Minimum letter count — count of ContractLetter rows per contract.
+    if (f.minLetterCount !== undefined) {
+      filtered = filtered.filter((r) => r.letterCount >= (f.minLetterCount as number));
+    }
+
+    // Slip review pending — rows with at least one PaymentEvidence in
+    // PENDING_REVIEW. Useful for finance to clear pending-slip backlog.
+    if (f.slipReviewPending !== undefined) {
+      filtered = filtered.filter((r) =>
+        f.slipReviewPending ? r.slipReviewPending : !r.slipReviewPending,
+      );
+    }
+
     // LINE response (heuristic based on lastCallResult + customer.lineId).
     // Server-side data doesn't include LINE delivery state yet — BLOCKED is
     // inferred only from explicit flag when available; NO_LINE from missing
@@ -316,6 +332,8 @@ export class OverdueQueueService {
       latestMdms,
       customerContractCounts,
       lastChannels,
+      letterCounts,
+      pendingSlipEvidences,
     ] = await Promise.all([
       this.prisma.callLog.groupBy({
         by: ['contractId'],
@@ -365,6 +383,24 @@ export class OverdueQueueService {
         distinct: ['contractId'],
         select: { contractId: true, channel: true },
       }),
+      // Letters dispatched per contract — used by minLetterCount filter.
+      this.prisma.contractLetter.groupBy({
+        by: ['contractId'],
+        where: { contractId: { in: contractIds }, deletedAt: null },
+        _count: { _all: true },
+      }),
+      // Pending slip evidence per contract — used by slipReviewPending filter.
+      // PaymentEvidence.status='PENDING_REVIEW' is the source of truth for
+      // slips awaiting finance review (see slip-review module).
+      this.prisma.paymentEvidence.groupBy({
+        by: ['contractId'],
+        where: {
+          contractId: { in: contractIds },
+          deletedAt: null,
+          status: 'PENDING_REVIEW',
+        },
+        _count: { _all: true },
+      }),
     ]);
 
     const callMap = new Map<string, Date | null>(
@@ -385,6 +421,12 @@ export class OverdueQueueService {
     const channelMap = new Map<string, string>(
       lastChannels.map((r) => [r.contractId, r.channel]),
     );
+    const letterCountMap = new Map<string, number>(
+      letterCounts.map((r) => [r.contractId, r._count._all]),
+    );
+    const slipPendingSet = new Set<string>(
+      pendingSlipEvidences.filter((r) => r._count._all > 0).map((r) => r.contractId),
+    );
 
     return contracts.map((c) => {
       const base = this.toRow(c, now);
@@ -400,6 +442,8 @@ export class OverdueQueueService {
         mdmState: this.toMdmState(mdmMap.get(c.id)),
         relatedContractsCount: Math.max(0, (customerCountMap.get(c.customerId) ?? 1) - 1),
         lastChannel: this.toLastChannel(channelMap.get(c.id)),
+        letterCount: letterCountMap.get(c.id) ?? 0,
+        slipReviewPending: slipPendingSet.has(c.id),
       };
     });
   }

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -4,6 +4,9 @@ import { PrismaService } from '../../prisma/prisma.service';
 
 export type QueueTab = 'today' | 'followup' | 'promise';
 
+export type MdmState = 'NONE' | 'PENDING' | 'LOCKED' | 'UNLOCKED';
+export type LastChannel = 'LINE' | 'SMS' | 'CALL' | 'LETTER' | null;
+
 @Injectable()
 export class OverdueQueueService {
   constructor(private prisma: PrismaService) {}
@@ -63,13 +66,153 @@ export class OverdueQueueService {
       this.prisma.contract.count({ where }),
     ]);
 
-    const rows = contracts
-      .map((c) => this.toRow(c, now))
-      .sort((a, b) => b.__priorityScore - a.__priorityScore);
+    const enriched = await this.enrichRows(contracts, now);
+
+    const rows = enriched.sort((a, b) => b.__priorityScore - a.__priorityScore);
 
     const paged = rows.slice(skip, skip + limit).map(({ __priorityScore, ...rest }) => rest);
 
     return { data: paged, total, page, limit };
+  }
+
+  /**
+   * Enrich contracts with card indicator fields:
+   * - lastContactedAt: max(CallLog.createdAt, DunningAction.executedAt)
+   * - brokenPromiseCount: count of BROKEN_PROMISE audit events
+   * - mdmState: NONE | PENDING | LOCKED | UNLOCKED (latest MdmLockRequest)
+   * - relatedContractsCount: other active contracts for same customer
+   * - lastChannel: channel of most recent DunningAction
+   *
+   * Uses batched groupBy + findMany(distinct) to avoid N+1 — one query per
+   * aggregate regardless of how many contracts were fetched.
+   */
+  private async enrichRows(contracts: any[], now: Date) {
+    if (contracts.length === 0) return [];
+
+    const contractIds = contracts.map((c) => c.id);
+    const customerIds = [...new Set(contracts.map((c) => c.customerId))];
+
+    const [
+      lastCalls,
+      lastActions,
+      brokenPromises,
+      latestMdms,
+      customerContractCounts,
+      lastChannels,
+    ] = await Promise.all([
+      this.prisma.callLog.groupBy({
+        by: ['contractId'],
+        where: { contractId: { in: contractIds }, deletedAt: null },
+        _max: { createdAt: true },
+      }),
+      this.prisma.dunningAction.groupBy({
+        by: ['contractId'],
+        where: {
+          contractId: { in: contractIds },
+          deletedAt: null,
+          executedAt: { not: null },
+        },
+        _max: { executedAt: true },
+      }),
+      this.prisma.auditLog.groupBy({
+        by: ['entityId'],
+        where: {
+          entityId: { in: contractIds },
+          entity: 'Contract',
+          action: 'BROKEN_PROMISE',
+        },
+        _count: { _all: true },
+      }),
+      this.prisma.mdmLockRequest.findMany({
+        where: { contractId: { in: contractIds }, deletedAt: null },
+        orderBy: { createdAt: 'desc' },
+        distinct: ['contractId'],
+        select: { contractId: true, status: true },
+      }),
+      this.prisma.contract.groupBy({
+        by: ['customerId'],
+        where: {
+          customerId: { in: customerIds },
+          status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT', 'LEGAL'] },
+          deletedAt: null,
+        },
+        _count: { _all: true },
+      }),
+      this.prisma.dunningAction.findMany({
+        where: {
+          contractId: { in: contractIds },
+          deletedAt: null,
+          executedAt: { not: null },
+        },
+        orderBy: { executedAt: 'desc' },
+        distinct: ['contractId'],
+        select: { contractId: true, channel: true },
+      }),
+    ]);
+
+    const callMap = new Map<string, Date | null>(
+      lastCalls.map((r) => [r.contractId, r._max.createdAt ?? null]),
+    );
+    const actionMap = new Map<string, Date | null>(
+      lastActions.map((r) => [r.contractId, r._max.executedAt ?? null]),
+    );
+    const brokenMap = new Map<string, number>(
+      brokenPromises.map((r) => [r.entityId, r._count._all]),
+    );
+    const mdmMap = new Map<string, string>(
+      latestMdms.map((r) => [r.contractId, r.status]),
+    );
+    const customerCountMap = new Map<string, number>(
+      customerContractCounts.map((r) => [r.customerId, r._count._all]),
+    );
+    const channelMap = new Map<string, string>(
+      lastChannels.map((r) => [r.contractId, r.channel]),
+    );
+
+    return contracts.map((c) => {
+      const base = this.toRow(c, now);
+      const call = callMap.get(c.id) ?? null;
+      const action = actionMap.get(c.id) ?? null;
+      const lastContactedAt =
+        call && action ? (call > action ? call : action) : call ?? action ?? null;
+
+      return {
+        ...base,
+        lastContactedAt,
+        brokenPromiseCount: brokenMap.get(c.id) ?? 0,
+        mdmState: this.toMdmState(mdmMap.get(c.id)),
+        relatedContractsCount: Math.max(0, (customerCountMap.get(c.customerId) ?? 1) - 1),
+        lastChannel: this.toLastChannel(channelMap.get(c.id)),
+      };
+    });
+  }
+
+  private toMdmState(status: string | undefined): MdmState {
+    if (!status) return 'NONE';
+    if (status === 'PENDING') return 'PENDING';
+    if (status === 'UNLOCKED') return 'UNLOCKED';
+    if (
+      status === 'APPROVED' ||
+      status === 'EXECUTED_MANUAL' ||
+      status === 'EXECUTED_API'
+    ) {
+      return 'LOCKED';
+    }
+    // REJECTED / FAILED → treat as no active lock
+    return 'NONE';
+  }
+
+  private toLastChannel(channel: string | undefined): LastChannel {
+    switch (channel) {
+      case 'LINE':
+        return 'LINE';
+      case 'SMS':
+        return 'SMS';
+      case 'CALL_TASK':
+        return 'CALL';
+      default:
+        return null;
+    }
   }
 
   /**

--- a/apps/api/src/modules/search/dto/search-query.dto.ts
+++ b/apps/api/src/modules/search/dto/search-query.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, MinLength, MaxLength } from 'class-validator';
+
+export class SearchQueryDto {
+  @IsString({ message: 'กรุณาระบุคำค้น' })
+  @MinLength(2, { message: 'คำค้นต้องมีอย่างน้อย 2 ตัวอักษร' })
+  @MaxLength(100, { message: 'คำค้นยาวเกินไป' })
+  q!: string;
+}

--- a/apps/api/src/modules/search/search.controller.ts
+++ b/apps/api/src/modules/search/search.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Query, UseGuards, Req } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import type { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { SearchService } from './search.service';
+import { SearchQueryDto } from './dto/search-query.dto';
+
+type AuthRequest = Request & {
+  user?: { id: string; role: string; branchId?: string };
+};
+
+@ApiTags('Search')
+@ApiBearerAuth('JWT')
+@Controller('search')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class SearchController {
+  constructor(private service: SearchService) {}
+
+  @Get('union')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  @ApiOperation({
+    summary: 'Union search across contracts, customers, letters, IMEIs',
+  })
+  async unionSearch(@Query() dto: SearchQueryDto, @Req() req: AuthRequest) {
+    return this.service.unionSearch({
+      q: dto.q,
+      userId: req.user?.id ?? '',
+      userRole: req.user?.role ?? '',
+      branchId: req.user?.branchId,
+    });
+  }
+}

--- a/apps/api/src/modules/search/search.module.ts
+++ b/apps/api/src/modules/search/search.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+
+@Module({
+  controllers: [SearchController],
+  providers: [SearchService],
+  exports: [SearchService],
+})
+export class SearchModule {}

--- a/apps/api/src/modules/search/search.service.spec.ts
+++ b/apps/api/src/modules/search/search.service.spec.ts
@@ -1,0 +1,170 @@
+import { Test } from '@nestjs/testing';
+import { SearchService } from './search.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+function mockPrisma() {
+  return {
+    contract: { findMany: jest.fn().mockResolvedValue([]) },
+    customer: { findMany: jest.fn().mockResolvedValue([]) },
+    contractLetter: { findMany: jest.fn().mockResolvedValue([]) },
+    product: { findMany: jest.fn().mockResolvedValue([]) },
+  } as unknown as PrismaService;
+}
+
+describe('SearchService', () => {
+  let service: SearchService;
+  let prisma: PrismaService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        SearchService,
+        { provide: PrismaService, useValue: mockPrisma() },
+      ],
+    }).compile();
+    service = module.get(SearchService);
+    prisma = module.get(PrismaService);
+  });
+
+  it('normalizes phone queries (strips non-digits, preserves +66)', () => {
+    expect(service.normalizePhone('082-123-4567')).toBe('0821234567');
+    expect(service.normalizePhone('+66 82 123 4567')).toBe('+66821234567');
+    expect(service.normalizePhone('  (082) 123-4567  ')).toBe('0821234567');
+  });
+
+  it('returns empty groups when query shorter than 2 chars', async () => {
+    const result = await service.unionSearch({
+      q: 'a',
+      userId: 'u1',
+      userRole: 'OWNER',
+    });
+    expect(result).toEqual({
+      contracts: [],
+      customers: [],
+      imeis: [],
+      letterTrackings: [],
+    });
+    expect(prisma.contract.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns grouped results (contracts, customers, IMEIs, tracking)', async () => {
+    jest.spyOn(prisma.contract, 'findMany').mockResolvedValue([
+      {
+        id: 'c1',
+        contractNumber: 'CT001',
+        status: 'ACTIVE',
+        customer: { name: 'นายทดสอบ' },
+      } as any,
+    ]);
+    jest.spyOn(prisma.customer, 'findMany').mockResolvedValue([
+      {
+        id: 'cu1',
+        name: 'นายทดสอบ',
+        phone: '0821234567',
+      } as any,
+    ]);
+    jest.spyOn(prisma.contractLetter, 'findMany').mockResolvedValue([
+      {
+        id: 'l1',
+        trackingNumber: 'TH123',
+        contractId: 'c1',
+        contract: { contractNumber: 'CT001' },
+      } as any,
+    ]);
+    jest.spyOn(prisma.product, 'findMany').mockResolvedValue([
+      {
+        imeiSerial: '356938035643809',
+        contracts: [
+          {
+            id: 'c1',
+            contractNumber: 'CT001',
+            customer: { name: 'นายทดสอบ' },
+          },
+        ],
+      } as any,
+    ]);
+
+    const result = await service.unionSearch({
+      q: 'ทดสอบ',
+      userId: 'u1',
+      userRole: 'OWNER',
+    });
+
+    expect(result.contracts).toHaveLength(1);
+    expect(result.contracts[0]).toMatchObject({
+      id: 'c1',
+      contractNumber: 'CT001',
+      customerName: 'นายทดสอบ',
+      status: 'ACTIVE',
+    });
+    expect(result.customers).toHaveLength(1);
+    expect(result.letterTrackings).toHaveLength(1);
+    expect(result.letterTrackings[0].trackingNumber).toBe('TH123');
+    expect(result.imeis).toHaveLength(1);
+    expect(result.imeis[0]).toMatchObject({
+      contractId: 'c1',
+      imei: '356938035643809',
+      contractNumber: 'CT001',
+    });
+  });
+
+  it('respects branch scope for SALES on contracts', async () => {
+    jest.spyOn(prisma.contract, 'findMany').mockResolvedValue([]);
+    await service.unionSearch({
+      q: 'anything',
+      userId: 'u1',
+      userRole: 'SALES',
+      branchId: 'br1',
+    });
+
+    expect(prisma.contract.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ branchId: 'br1' }),
+      }),
+    );
+  });
+
+  it('does NOT branch-scope customers (customers are global)', async () => {
+    jest.spyOn(prisma.customer, 'findMany').mockResolvedValue([]);
+    await service.unionSearch({
+      q: 'anything',
+      userId: 'u1',
+      userRole: 'SALES',
+      branchId: 'br1',
+    });
+
+    const call = (prisma.customer.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).not.toHaveProperty('branchId');
+  });
+
+  it('scopes letters by contract.branchId when SALES', async () => {
+    jest.spyOn(prisma.contractLetter, 'findMany').mockResolvedValue([]);
+    await service.unionSearch({
+      q: 'TH99',
+      userId: 'u1',
+      userRole: 'SALES',
+      branchId: 'br1',
+    });
+
+    expect(prisma.contractLetter.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          contract: { branchId: 'br1' },
+        }),
+      }),
+    );
+  });
+
+  it('OWNER role not branch-scoped', async () => {
+    jest.spyOn(prisma.contract, 'findMany').mockResolvedValue([]);
+    await service.unionSearch({
+      q: 'anything',
+      userId: 'u1',
+      userRole: 'OWNER',
+      branchId: 'br1',
+    });
+
+    const call = (prisma.contract.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).not.toHaveProperty('branchId');
+  });
+});

--- a/apps/api/src/modules/search/search.service.ts
+++ b/apps/api/src/modules/search/search.service.ts
@@ -91,6 +91,15 @@ export class SearchService {
       this.prisma.customer.findMany({
         where: {
           deletedAt: null,
+          // SALES scope: Customer has no direct branchId, so scope via any
+          // contract owned by the user's branch. Mirrors CustomersService.findAll
+          // which scopes SALES-visible customers by `contracts.some.branchId`
+          // (see customers.service.ts:45 — `where.contracts = { some: { branchId, deletedAt: null } }`).
+          // OWNER / BRANCH_MANAGER / FINANCE_MANAGER / ACCOUNTANT keep
+          // cross-branch visibility in union search.
+          ...(isSales && branchId
+            ? { contracts: { some: { branchId, deletedAt: null } } }
+            : {}),
           OR: [
             { name: { contains: query, mode: 'insensitive' } },
             { phone: { contains: phoneNormalized } },

--- a/apps/api/src/modules/search/search.service.ts
+++ b/apps/api/src/modules/search/search.service.ts
@@ -1,0 +1,174 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface SearchResult {
+  contracts: {
+    id: string;
+    contractNumber: string;
+    customerName: string;
+    status: string;
+  }[];
+  customers: {
+    id: string;
+    name: string;
+    phone: string | null;
+  }[];
+  imeis: {
+    contractId: string;
+    imei: string;
+    contractNumber: string;
+    customerName: string;
+  }[];
+  letterTrackings: {
+    letterId: string;
+    trackingNumber: string;
+    contractId: string;
+    contractNumber: string;
+  }[];
+}
+
+interface UnionSearchParams {
+  q: string;
+  userId: string;
+  userRole: string;
+  branchId?: string;
+}
+
+@Injectable()
+export class SearchService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Normalize a phone-like query:
+   * - preserve leading `+` (country code such as +66)
+   * - strip all non-digit characters elsewhere
+   */
+  normalizePhone(phone: string): string {
+    const trimmed = phone.trim();
+    const hasPlus = trimmed.startsWith('+');
+    const digits = trimmed.replace(/\D/g, '');
+    return hasPlus ? `+${digits}` : digits;
+  }
+
+  async unionSearch({
+    q,
+    userRole,
+    branchId,
+  }: UnionSearchParams): Promise<SearchResult> {
+    const query = q.trim();
+    if (query.length < 2) {
+      return { contracts: [], customers: [], imeis: [], letterTrackings: [] };
+    }
+
+    const phoneNormalized = this.normalizePhone(query);
+    const isSales = userRole === 'SALES';
+    const branchFilter = isSales && branchId ? { branchId } : {};
+
+    const [contracts, customers, letters, imeiProducts] = await Promise.all([
+      this.prisma.contract.findMany({
+        where: {
+          deletedAt: null,
+          ...branchFilter,
+          OR: [
+            { contractNumber: { contains: query, mode: 'insensitive' } },
+            {
+              customer: {
+                name: { contains: query, mode: 'insensitive' },
+              },
+            },
+            { customer: { phone: { contains: phoneNormalized } } },
+          ],
+        },
+        select: {
+          id: true,
+          contractNumber: true,
+          status: true,
+          customer: { select: { name: true } },
+        },
+        take: 10,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.customer.findMany({
+        where: {
+          deletedAt: null,
+          OR: [
+            { name: { contains: query, mode: 'insensitive' } },
+            { phone: { contains: phoneNormalized } },
+          ],
+        },
+        select: { id: true, name: true, phone: true },
+        take: 10,
+      }),
+      this.prisma.contractLetter.findMany({
+        where: {
+          deletedAt: null,
+          trackingNumber: { contains: query, mode: 'insensitive' },
+          ...(isSales && branchId ? { contract: { branchId } } : {}),
+        },
+        select: {
+          id: true,
+          trackingNumber: true,
+          contractId: true,
+          contract: { select: { contractNumber: true } },
+        },
+        take: 10,
+      }),
+      // IMEI search via Product.imeiSerial (joined to its active contract)
+      this.prisma.product.findMany({
+        where: {
+          deletedAt: null,
+          imeiSerial: { contains: query, mode: 'insensitive' },
+          ...(isSales && branchId ? { branchId } : {}),
+          contracts: { some: { deletedAt: null } },
+        },
+        select: {
+          imeiSerial: true,
+          contracts: {
+            where: { deletedAt: null },
+            select: {
+              id: true,
+              contractNumber: true,
+              customer: { select: { name: true } },
+            },
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+          },
+        },
+        take: 10,
+      }),
+    ]);
+
+    const imeis: SearchResult['imeis'] = imeiProducts
+      .filter((p) => p.imeiSerial && p.contracts.length > 0)
+      .map((p) => {
+        const c = p.contracts[0];
+        return {
+          contractId: c.id,
+          imei: p.imeiSerial as string,
+          contractNumber: c.contractNumber,
+          customerName: c.customer?.name ?? '',
+        };
+      });
+
+    return {
+      contracts: contracts.map((c) => ({
+        id: c.id,
+        contractNumber: c.contractNumber,
+        customerName: c.customer?.name ?? '',
+        status: c.status,
+      })),
+      customers: customers.map((c) => ({
+        id: c.id,
+        name: c.name,
+        phone: c.phone,
+      })),
+      imeis,
+      letterTrackings: letters.map((l) => ({
+        letterId: l.id,
+        trackingNumber: l.trackingNumber ?? '',
+        contractId: l.contractId,
+        contractNumber: l.contract?.contractNumber ?? '',
+      })),
+    };
+  }
+}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -28,9 +28,15 @@ import {
   FileText,
   Search,
   Plus,
+  User as UserIcon,
+  Mail,
+  Smartphone,
+  Clock,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useDebounce } from '@/hooks/useDebounce';
+import { useUnionSearch } from '@/pages/CollectionsPage/hooks/useUnionSearch';
 
 /* ─── Navigation Items ─── */
 
@@ -71,12 +77,46 @@ const quickActions: NavEntry[] = [
   { label: 'บันทึกชำระเงิน', path: '/payments', icon: DollarSign, keywords: 'record payment บันทึก ชำระ' },
 ];
 
+/* ─── Recent Searches (localStorage) ─── */
+
+const RECENT_KEY = 'cmdk-recent-searches';
+const RECENT_MAX = 10;
+
+function loadRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(q: string) {
+  const trimmed = q.trim();
+  if (trimmed.length < 2) return;
+  try {
+    const list = loadRecent().filter((x) => x !== trimmed);
+    list.unshift(trimmed);
+    localStorage.setItem(RECENT_KEY, JSON.stringify(list.slice(0, RECENT_MAX)));
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
 /* ─── Component ─── */
 
 export default function CommandPalette() {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query, 200);
   const navigate = useNavigate();
   const { user } = useAuth();
+  const [recent, setRecent] = useState<string[]>(() => loadRecent());
+
+  const { data: searchData, isLoading: isSearching } =
+    useUnionSearch(debouncedQuery);
 
   // Ctrl+K / Cmd+K to open
   useEffect(() => {
@@ -90,12 +130,25 @@ export default function CommandPalette() {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, []);
 
+  // Refresh recent when opening
+  useEffect(() => {
+    if (open) {
+      setRecent(loadRecent());
+    } else {
+      // Clear query when closing to reset state next open
+      setQuery('');
+    }
+  }, [open]);
+
   const handleSelect = useCallback(
-    (path: string) => {
+    (path: string, persistQuery = true) => {
+      if (persistQuery && debouncedQuery) {
+        saveRecent(debouncedQuery);
+      }
       setOpen(false);
       navigate(path);
     },
-    [navigate],
+    [navigate, debouncedQuery],
   );
 
   const filterByRole = useCallback(
@@ -105,6 +158,9 @@ export default function CommandPalette() {
   );
 
   if (!open) return null;
+
+  const hasQuery = debouncedQuery.trim().length >= 2;
+  const showRecent = !query && recent.length > 0;
 
   return (
     <div className="fixed inset-0 z-50">
@@ -119,15 +175,133 @@ export default function CommandPalette() {
         <Command
           className="rounded-xl border border-border bg-popover shadow-2xl"
           loop
+          // cmdk's built-in filter hides non-matching items. We want server
+          // search results to always show, so disable client-side filtering
+          // whenever the user has typed a query.
+          shouldFilter={!hasQuery}
         >
-          <CommandInput placeholder="ค้นหาหน้า, สัญญา, ลูกค้า..." />
+          <CommandInput
+            placeholder="ค้นหาหน้า, contract#, ชื่อ, เบอร์, IMEI, tracking#..."
+            value={query}
+            onValueChange={setQuery}
+          />
           <CommandList>
             <CommandEmpty>
               <div className="flex flex-col items-center gap-2">
                 <Search className="size-8 text-muted-foreground/40" />
-                <span>ไม่พบผลลัพธ์</span>
+                <span>
+                  {isSearching ? 'กำลังค้นหา...' : 'ไม่พบผลลัพธ์'}
+                </span>
               </div>
             </CommandEmpty>
+
+            {/* Recent searches (shown only when input is empty) */}
+            {showRecent && (
+              <>
+                <CommandGroup heading="ค้นล่าสุด">
+                  {recent.map((q) => (
+                    <CommandItem
+                      key={q}
+                      value={`recent-${q}`}
+                      onSelect={() => setQuery(q)}
+                    >
+                      <Clock />
+                      <span>{q}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            )}
+
+            {/* Server search results (when user typed ≥2 chars) */}
+            {hasQuery && searchData && (
+              <>
+                {searchData.contracts.length > 0 && (
+                  <CommandGroup heading={`สัญญา (${searchData.contracts.length})`}>
+                    {searchData.contracts.map((c) => (
+                      <CommandItem
+                        key={`contract-${c.id}`}
+                        value={`contract-${c.id}`}
+                        onSelect={() => handleSelect(`/contracts/${c.id}`)}
+                      >
+                        <FileCheck />
+                        <div className="flex flex-col">
+                          <span className="leading-snug">
+                            {c.contractNumber} — {c.customerName}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {c.status}
+                          </span>
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+
+                {searchData.customers.length > 0 && (
+                  <CommandGroup heading={`ลูกค้า (${searchData.customers.length})`}>
+                    {searchData.customers.map((c) => (
+                      <CommandItem
+                        key={`customer-${c.id}`}
+                        value={`customer-${c.id}`}
+                        onSelect={() => handleSelect(`/customers/${c.id}`)}
+                      >
+                        <UserIcon />
+                        <span>
+                          {c.name}
+                          {c.phone ? ` · ${c.phone}` : ''}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+
+                {searchData.imeis.length > 0 && (
+                  <CommandGroup heading={`IMEI (${searchData.imeis.length})`}>
+                    {searchData.imeis.map((im) => (
+                      <CommandItem
+                        key={`imei-${im.contractId}-${im.imei}`}
+                        value={`imei-${im.contractId}-${im.imei}`}
+                        onSelect={() => handleSelect(`/contracts/${im.contractId}`)}
+                      >
+                        <Smartphone />
+                        <div className="flex flex-col">
+                          <span className="leading-snug font-mono text-xs">
+                            {im.imei}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {im.contractNumber} — {im.customerName}
+                          </span>
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+
+                {searchData.letterTrackings.length > 0 && (
+                  <CommandGroup heading={`Tracking (${searchData.letterTrackings.length})`}>
+                    {searchData.letterTrackings.map((l) => (
+                      <CommandItem
+                        key={`letter-${l.letterId}`}
+                        value={`letter-${l.letterId}`}
+                        onSelect={() => handleSelect(`/contracts/${l.contractId}`)}
+                      >
+                        <Mail />
+                        <span>
+                          {l.trackingNumber} → {l.contractNumber}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+
+                {(searchData.contracts.length > 0 ||
+                  searchData.customers.length > 0 ||
+                  searchData.imeis.length > 0 ||
+                  searchData.letterTrackings.length > 0) && <CommandSeparator />}
+              </>
+            )}
 
             {/* Quick Actions */}
             <CommandGroup heading="ดำเนินการด่วน">
@@ -135,7 +309,7 @@ export default function CommandPalette() {
                 <CommandItem
                   key={item.path}
                   value={`${item.label} ${item.keywords || ''}`}
-                  onSelect={() => handleSelect(item.path)}
+                  onSelect={() => handleSelect(item.path, false)}
                 >
                   <item.icon />
                   <span>{item.label}</span>
@@ -151,7 +325,7 @@ export default function CommandPalette() {
                 <CommandItem
                   key={item.path}
                   value={`${item.label} ${item.keywords || ''}`}
-                  onSelect={() => handleSelect(item.path)}
+                  onSelect={() => handleSelect(item.path, false)}
                 >
                   <item.icon />
                   <span>{item.label}</span>

--- a/apps/web/src/components/ui/DateRangePicker.tsx
+++ b/apps/web/src/components/ui/DateRangePicker.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { CalendarIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { formatThaiDate } from '@/lib/date';
+import { startOfDay, endOfDay, subDays, startOfMonth, endOfMonth, subMonths } from 'date-fns';
+import type { DateRange } from 'react-day-picker';
+
+export type DateRangeValue = { from: Date | null; to: Date | null };
+
+export interface DateRangePickerProps {
+  value: DateRangeValue;
+  onChange: (value: DateRangeValue) => void;
+  className?: string;
+  disabled?: boolean;
+}
+
+type PresetKey = 'today' | '7d' | '30d' | 'thisMonth' | 'lastMonth' | '3m' | 'custom';
+
+const PRESETS: { key: PresetKey; label: string; compute: () => DateRangeValue }[] = [
+  {
+    key: 'today',
+    label: 'วันนี้',
+    compute: () => {
+      const now = new Date();
+      return { from: startOfDay(now), to: endOfDay(now) };
+    },
+  },
+  {
+    key: '7d',
+    label: '7 วัน',
+    compute: () => {
+      const now = new Date();
+      return { from: startOfDay(subDays(now, 6)), to: endOfDay(now) };
+    },
+  },
+  {
+    key: '30d',
+    label: '30 วัน',
+    compute: () => {
+      const now = new Date();
+      return { from: startOfDay(subDays(now, 29)), to: endOfDay(now) };
+    },
+  },
+  {
+    key: 'thisMonth',
+    label: 'เดือนนี้',
+    compute: () => {
+      const now = new Date();
+      return { from: startOfMonth(now), to: endOfMonth(now) };
+    },
+  },
+  {
+    key: 'lastMonth',
+    label: 'เดือนที่แล้ว',
+    compute: () => {
+      const last = subMonths(new Date(), 1);
+      return { from: startOfMonth(last), to: endOfMonth(last) };
+    },
+  },
+  {
+    key: '3m',
+    label: '3 เดือน',
+    compute: () => {
+      const now = new Date();
+      return { from: startOfDay(subMonths(now, 3)), to: endOfDay(now) };
+    },
+  },
+];
+
+export function DateRangePicker({ value, onChange, className, disabled }: DateRangePickerProps) {
+  const [selected, setSelected] = useState<PresetKey>('custom');
+
+  function handlePreset(key: PresetKey) {
+    const preset = PRESETS.find((p) => p.key === key);
+    if (preset) {
+      setSelected(key);
+      onChange(preset.compute());
+    }
+  }
+
+  function handleCalendar(range: DateRange | undefined) {
+    setSelected('custom');
+    onChange({ from: range?.from ?? null, to: range?.to ?? null });
+  }
+
+  const displayLabel =
+    value.from && value.to
+      ? `${formatThaiDate(value.from)} – ${formatThaiDate(value.to)}`
+      : 'เลือกช่วงวันที่';
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+      {/* Preset shortcuts — always visible for quick access */}
+      <div className="flex flex-wrap items-center gap-1">
+        {PRESETS.map((p) => (
+          <Button
+            key={p.key}
+            variant={selected === p.key ? 'primary' : 'ghost'}
+            size="sm"
+            onClick={() => handlePreset(p.key)}
+            disabled={disabled}
+            type="button"
+          >
+            {p.label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Custom range via popover calendar */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" disabled={disabled} type="button">
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {displayLabel}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-auto p-0">
+          <Calendar
+            mode="range"
+            selected={value.from && value.to ? { from: value.from, to: value.to } : undefined}
+            onSelect={handleCalendar}
+            numberOfMonths={2}
+            autoFocus
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/__tests__/DateRangePicker.test.tsx
+++ b/apps/web/src/components/ui/__tests__/DateRangePicker.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DateRangePicker } from '../DateRangePicker';
+
+describe('DateRangePicker', () => {
+  it('renders preset buttons', () => {
+    render(<DateRangePicker value={{ from: null, to: null }} onChange={() => {}} />);
+    expect(screen.getByText('วันนี้')).toBeInTheDocument();
+    expect(screen.getByText('7 วัน')).toBeInTheDocument();
+    expect(screen.getByText('30 วัน')).toBeInTheDocument();
+  });
+
+  it('calls onChange when preset clicked', () => {
+    const onChange = vi.fn();
+    render(<DateRangePicker value={{ from: null, to: null }} onChange={onChange} />);
+    fireEvent.click(screen.getByText('7 วัน'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: expect.any(Date),
+        to: expect.any(Date),
+      }),
+    );
+  });
+
+  it('displays Thai Buddhist year (พ.ศ.)', () => {
+    const from = new Date(2026, 3, 25); // April 25, 2026 CE = 2569 BE
+    render(<DateRangePicker value={{ from, to: from }} onChange={() => {}} />);
+    expect(screen.getByText(/2569/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/CollectionsPage/__tests__/tabVisibility.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/__tests__/tabVisibility.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CollectionsPage from '../index';
+
+// Mock auth context
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+// Mock hooks that fire network requests so the page renders without errors
+vi.mock('../hooks/useCollectionsKpi', () => ({
+  useCollectionsKpi: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock('../hooks/useCollectionsQueue', () => ({
+  useCollectionsQueue: () => ({
+    data: { data: [], total: 0, page: 1, limit: 50, truncated: false },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useApprovalQueues', () => ({
+  useApprovalQueues: () => ({ data: null, isLoading: false }),
+  usePendingMdm: () => ({ data: [], isLoading: false }),
+  usePendingLetters: () => ({ data: [], isLoading: false }),
+  usePendingExchanges: () => ({ data: [], isLoading: false }),
+  usePendingRepossessions: () => ({ data: [], isLoading: false }),
+  usePendingWriteOffs: () => ({ data: [], isLoading: false }),
+  useApproveMdm: () => ({ mutate: vi.fn(), isPending: false }),
+  useRejectMdm: () => ({ mutate: vi.fn(), isPending: false }),
+  useUnlockMdm: () => ({ mutate: vi.fn(), isPending: false }),
+  useApproveLetter: () => ({ mutate: vi.fn(), isPending: false }),
+  useRejectLetter: () => ({ mutate: vi.fn(), isPending: false }),
+  useApproveExchange: () => ({ mutate: vi.fn(), isPending: false }),
+  useRejectExchange: () => ({ mutate: vi.fn(), isPending: false }),
+  useApproveRepossession: () => ({ mutate: vi.fn(), isPending: false }),
+  useRejectRepossession: () => ({ mutate: vi.fn(), isPending: false }),
+  useApproveWriteOff: () => ({ mutate: vi.fn(), isPending: false }),
+  useRejectWriteOff: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../hooks/useCollectionsAnalytics', () => ({
+  useCollectionsAnalytics: () => ({ data: null, isLoading: false }),
+}));
+
+import { useAuth } from '@/contexts/AuthContext';
+
+function renderWith(role: string) {
+  (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    user: { id: 'u1', email: 'x@y.com', name: 'T', role, branchId: null },
+  });
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <CollectionsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/** helper: get tab buttons from the CollectionsTabs bar (buttons with border-b-2) */
+function getTabLabels(): string[] {
+  return Array.from(document.querySelectorAll('button.border-b-2')).map(
+    (btn) => btn.textContent?.trim() ?? '',
+  );
+}
+
+describe('CollectionsPage tab visibility by role', () => {
+  it('OWNER sees all 6 tabs including อนุมัติ + วิเคราะห์', () => {
+    renderWith('OWNER');
+    const labels = getTabLabels();
+    expect(labels).toEqual(
+      expect.arrayContaining(['คิววันนี้', 'ตามต่อ', 'นัดชำระ', 'อนุมัติ', 'ทั้งหมด', 'วิเคราะห์']),
+    );
+    expect(labels).toHaveLength(6);
+  });
+
+  it('FINANCE_MANAGER sees approval and analytics', () => {
+    renderWith('FINANCE_MANAGER');
+    const labels = getTabLabels();
+    expect(labels).toEqual(
+      expect.arrayContaining(['อนุมัติ', 'วิเคราะห์']),
+    );
+  });
+
+  it('BRANCH_MANAGER sees approval but NOT analytics', () => {
+    renderWith('BRANCH_MANAGER');
+    const labels = getTabLabels();
+    expect(labels).toContain('อนุมัติ');
+    expect(labels).not.toContain('วิเคราะห์');
+  });
+
+  it('SALES sees 4 tabs (no approval, no analytics)', () => {
+    renderWith('SALES');
+    const labels = getTabLabels();
+    expect(labels).toEqual(['คิววันนี้', 'ตามต่อ', 'นัดชำระ', 'ทั้งหมด']);
+    expect(labels).not.toContain('อนุมัติ');
+    expect(labels).not.toContain('วิเคราะห์');
+  });
+
+  it('ACCOUNTANT sees 4 tabs (no approval, no analytics)', () => {
+    renderWith('ACCOUNTANT');
+    const labels = getTabLabels();
+    expect(labels).not.toContain('อนุมัติ');
+    expect(labels).not.toContain('วิเคราะห์');
+    expect(labels).toHaveLength(4);
+  });
+});

--- a/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 import { CheckCircle, XCircle, Unlock } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
+import api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUnlockMdm } from '../hooks/useApprovalQueues';
+import { WallpaperPreview } from './WallpaperPreview';
 import type { PendingEscalation, PendingMdmRequest } from '../types';
 
 /* ── helpers ─────────────────────────────────────────────────── */
@@ -216,21 +219,48 @@ function UnlockDialog({
 
 interface MdmRowProps {
   item: PendingMdmRequest;
-  onApprove: (requestId: string) => void;
+  /**
+   * Approver action. `opts.includeWallpaper` (optional) overrides the
+   * proposer's choice. When omitted backend falls back to proposer's value.
+   */
+  onApprove: (requestId: string, opts?: { includeWallpaper?: boolean }) => void;
   onReject: (requestId: string, reason: string) => void;
   approvePending: boolean;
   rejectPending: boolean;
 }
 
+/**
+ * Fetches the MDM wallpaper URL from SystemConfig for the approve dialog
+ * preview. Returns null when the setting is not yet configured. Cached for
+ * 5 minutes — the URL changes rarely.
+ *
+ * Uses the shared `/settings` endpoint (same source DunningSettingsPage writes
+ * to) so preview matches what the OWNER configured.
+ */
+function useWallpaperUrl(enabled: boolean): string | null {
+  const { data } = useQuery<Array<{ key: string; value: string | null }>>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data ?? [],
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+  const entry = data?.find((s) => s.key === 'mdm_lock_wallpaper_url');
+  return entry?.value && entry.value.length > 0 ? entry.value : null;
+}
+
 export function MdmRow({ item, onApprove, onReject, approvePending, rejectPending }: MdmRowProps) {
   const [showReject, setShowReject] = useState(false);
   const [showUnlockConfirm, setShowUnlockConfirm] = useState(false);
+  const [showApproveDialog, setShowApproveDialog] = useState(false);
+  const [includeWallpaper, setIncludeWallpaper] = useState<boolean>(item.includeWallpaper);
 
   const { user } = useAuth();
   const isOwner = user?.role === 'OWNER';
   const isLocked = item.status === 'EXECUTED_MANUAL' || item.status === 'EXECUTED_API' || item.status === 'LOCKED';
   const canUnlock = isOwner && isLocked;
   const unlock = useUnlockMdm();
+
+  const wallpaperUrl = useWallpaperUrl(showApproveDialog);
 
   const actionLabel =
     'เสนอล็อคเครื่อง' + (item.includeWallpaper ? ' + wallpaper' : '');
@@ -281,7 +311,10 @@ export function MdmRow({ item, onApprove, onReject, approvePending, rejectPendin
                   <XCircle className="size-3.5" /> ปฏิเสธ
                 </button>
                 <button
-                  onClick={() => onApprove(item.id)}
+                  onClick={() => {
+                    setIncludeWallpaper(item.includeWallpaper);
+                    setShowApproveDialog(true);
+                  }}
                   disabled={approvePending}
                   className="inline-flex items-center gap-1.5 rounded-lg bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
                 >
@@ -324,6 +357,46 @@ export function MdmRow({ item, onApprove, onReject, approvePending, rejectPendin
           setShowUnlockConfirm(false);
         }}
       />
+
+      {showApproveDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="w-full max-w-md rounded-xl border border-border bg-card shadow-xl p-6 mx-4">
+            <h3 className="text-sm font-semibold mb-1 leading-snug">อนุมัติล็อคเครื่อง</h3>
+            <p className="text-xs text-muted-foreground leading-snug mb-4">
+              สัญญา {item.contract.contractNumber} • ลูกค้า{' '}
+              <span className="text-foreground">{item.contract.customer.name}</span>
+            </p>
+
+            <div className="mb-4">
+              <WallpaperPreview
+                wallpaperUrl={wallpaperUrl}
+                checked={includeWallpaper && !!wallpaperUrl}
+                onChange={setIncludeWallpaper}
+              />
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setShowApproveDialog(false)}
+                className="rounded-lg border border-input px-4 py-1.5 text-sm hover:bg-muted transition-colors"
+              >
+                ยกเลิก
+              </button>
+              <button
+                disabled={approvePending}
+                onClick={() => {
+                  const effective = includeWallpaper && !!wallpaperUrl;
+                  onApprove(item.id, { includeWallpaper: effective });
+                  setShowApproveDialog(false);
+                }}
+                className="rounded-lg bg-destructive px-4 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+              >
+                {approvePending ? 'กำลังอนุมัติ...' : 'ยืนยันอนุมัติ'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
@@ -255,9 +255,14 @@ export function MdmRow({ item, onApprove, onReject, approvePending, rejectPendin
   const [includeWallpaper, setIncludeWallpaper] = useState<boolean>(item.includeWallpaper);
 
   const { user } = useAuth();
-  const isOwner = user?.role === 'OWNER';
-  const isLocked = item.status === 'EXECUTED_MANUAL' || item.status === 'EXECUTED_API' || item.status === 'LOCKED';
-  const canUnlock = isOwner && isLocked;
+  // MDM is considered "locked on device" when the request has been executed
+  // (either manually or via API). Matches backend policy in mdm-lock.service.ts
+  // (`unlock()` requires status ∈ {EXECUTED_MANUAL, EXECUTED_API}).
+  const isLocked =
+    item.status === 'EXECUTED_MANUAL' || item.status === 'EXECUTED_API';
+  // Unlock endpoint is `@Roles('OWNER', 'FINANCE_MANAGER')` — mirror that here.
+  const canUnlock =
+    (user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER') && isLocked;
   const unlock = useUnlockMdm();
 
   const wallpaperUrl = useWallpaperUrl(showApproveDialog);

--- a/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ApprovalPendingRow.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
-import { CheckCircle, XCircle } from 'lucide-react';
+import { CheckCircle, XCircle, Unlock } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useAuth } from '@/contexts/AuthContext';
+import { useUnlockMdm } from '../hooks/useApprovalQueues';
 import type { PendingEscalation, PendingMdmRequest } from '../types';
 
 /* ── helpers ─────────────────────────────────────────────────── */
@@ -162,6 +164,54 @@ export function EscalationRow({
   );
 }
 
+/* ── Unlock confirm dialog ───────────────────────────────────── */
+
+interface UnlockDialogProps {
+  open: boolean;
+  customerName: string;
+  contractNumber: string;
+  pending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function UnlockDialog({
+  open,
+  customerName,
+  contractNumber,
+  pending,
+  onConfirm,
+  onCancel,
+}: UnlockDialogProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-xl border border-border bg-card shadow-xl p-6 mx-4">
+        <h3 className="text-sm font-semibold mb-2 leading-snug">ยืนยันปลดล็อคเครื่อง?</h3>
+        <p className="text-xs text-muted-foreground leading-snug mb-4">
+          ลูกค้า <span className="text-foreground font-medium">{customerName}</span>{' '}
+          (สัญญา {contractNumber}) จะใช้เครื่องได้ทันที
+        </p>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onCancel}
+            className="rounded-lg border border-input px-4 py-1.5 text-sm hover:bg-muted transition-colors"
+          >
+            ยกเลิก
+          </button>
+          <button
+            disabled={pending}
+            onClick={onConfirm}
+            className="rounded-lg bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {pending ? 'กำลังปลดล็อค...' : 'ยืนยันปลดล็อค'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /* ── MDM Row ─────────────────────────────────────────────────── */
 
 interface MdmRowProps {
@@ -174,6 +224,13 @@ interface MdmRowProps {
 
 export function MdmRow({ item, onApprove, onReject, approvePending, rejectPending }: MdmRowProps) {
   const [showReject, setShowReject] = useState(false);
+  const [showUnlockConfirm, setShowUnlockConfirm] = useState(false);
+
+  const { user } = useAuth();
+  const isOwner = user?.role === 'OWNER';
+  const isLocked = item.status === 'EXECUTED_MANUAL' || item.status === 'EXECUTED_API' || item.status === 'LOCKED';
+  const canUnlock = isOwner && isLocked;
+  const unlock = useUnlockMdm();
 
   const actionLabel =
     'เสนอล็อคเครื่อง' + (item.includeWallpaper ? ' + wallpaper' : '');
@@ -214,20 +271,34 @@ export function MdmRow({ item, onApprove, onReject, approvePending, rejectPendin
 
           {/* Actions */}
           <div className="flex items-center justify-end gap-2">
-            <button
-              onClick={() => setShowReject(true)}
-              disabled={rejectPending}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium hover:bg-muted text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors"
-            >
-              <XCircle className="size-3.5" /> ปฏิเสธ
-            </button>
-            <button
-              onClick={() => onApprove(item.id)}
-              disabled={approvePending}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
-            >
-              <CheckCircle className="size-3.5" /> อนุมัติล็อค
-            </button>
+            {!isLocked && (
+              <>
+                <button
+                  onClick={() => setShowReject(true)}
+                  disabled={rejectPending}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium hover:bg-muted text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors"
+                >
+                  <XCircle className="size-3.5" /> ปฏิเสธ
+                </button>
+                <button
+                  onClick={() => onApprove(item.id)}
+                  disabled={approvePending}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+                >
+                  <CheckCircle className="size-3.5" /> อนุมัติล็อค
+                </button>
+              </>
+            )}
+            {canUnlock && (
+              <button
+                onClick={() => setShowUnlockConfirm(true)}
+                disabled={unlock.isPending}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium hover:bg-muted text-foreground disabled:opacity-50 transition-colors"
+              >
+                <Unlock className="size-3.5" />
+                {unlock.isPending ? 'กำลังปลดล็อค...' : 'ปลดล็อค'}
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -239,6 +310,18 @@ export function MdmRow({ item, onApprove, onReject, approvePending, rejectPendin
         onConfirm={(reason) => {
           onReject(item.id, reason);
           setShowReject(false);
+        }}
+      />
+
+      <UnlockDialog
+        open={showUnlockConfirm}
+        customerName={item.contract.customer.name}
+        contractNumber={item.contract.contractNumber}
+        pending={unlock.isPending}
+        onCancel={() => setShowUnlockConfirm(false)}
+        onConfirm={() => {
+          unlock.mutate(item.id);
+          setShowUnlockConfirm(false);
         }}
       />
     </>

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsTabs.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsTabs.tsx
@@ -5,6 +5,7 @@ interface Props {
   active: CollectionsTabKey;
   onChange: (key: CollectionsTabKey) => void;
   canSeeApproval: boolean;
+  canSeeAnalytics?: boolean;
   counts?: Partial<Record<CollectionsTabKey, number>>;
 }
 
@@ -21,10 +22,18 @@ const TAB_CONFIG: Array<{
   { key: 'analytics', label: 'วิเคราะห์', Icon: BarChart3 },
 ];
 
-export default function CollectionsTabs({ active, onChange, canSeeApproval, counts }: Props) {
-  const visibleTabs = TAB_CONFIG.filter(
-    (t) => (t.key !== 'approval' && t.key !== 'analytics') || canSeeApproval,
-  );
+export default function CollectionsTabs({
+  active,
+  onChange,
+  canSeeApproval,
+  canSeeAnalytics = canSeeApproval,
+  counts,
+}: Props) {
+  const visibleTabs = TAB_CONFIG.filter((t) => {
+    if (t.key === 'approval') return canSeeApproval;
+    if (t.key === 'analytics') return canSeeAnalytics;
+    return true;
+  });
 
   return (
     <div className="flex gap-0 border-b border-border mb-4 overflow-x-auto">

--- a/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.test.tsx
@@ -28,6 +28,11 @@ const contract: ContractRow = {
   settlementDate: null,
   needsSkipTracing: false,
   deviceLocked: false,
+  lastContactedAt: null,
+  brokenPromiseCount: 0,
+  mdmState: 'NONE',
+  relatedContractsCount: 0,
+  lastChannel: null,
 };
 
 describe('<ContactLogDialog />', () => {

--- a/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.test.tsx
@@ -33,6 +33,8 @@ const contract: ContractRow = {
   mdmState: 'NONE',
   relatedContractsCount: 0,
   lastChannel: null,
+  letterCount: 0,
+  slipReviewPending: false,
 };
 
 describe('<ContactLogDialog />', () => {

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
@@ -24,6 +24,11 @@ const base: ContractRow = {
   settlementDate: null,
   needsSkipTracing: false,
   deviceLocked: false,
+  lastContactedAt: null,
+  brokenPromiseCount: 0,
+  mdmState: 'NONE',
+  relatedContractsCount: 0,
+  lastChannel: null,
 };
 
 describe('<ContractCard />', () => {

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
@@ -29,6 +29,8 @@ const base: ContractRow = {
   mdmState: 'NONE',
   relatedContractsCount: 0,
   lastChannel: null,
+  letterCount: 0,
+  slipReviewPending: false,
 };
 
 describe('<ContractCard />', () => {

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -9,15 +9,85 @@ import {
   UserCircle,
   NotebookPen,
   ChevronRight,
+  Clock,
+  AlertTriangle,
+  Users,
+  FileText,
 } from 'lucide-react';
 import { formatDateShort } from '@/utils/formatters';
 import type { ContractRow } from '../types';
+import { agingBucket, agingColor, formatRelativeTime } from '../utils/cardIndicators';
 
 function priorityColor(daysOverdue: number): string {
   if (daysOverdue >= 30) return 'bg-destructive';
   if (daysOverdue >= 8) return 'bg-warning';
   if (daysOverdue >= 1) return 'bg-primary';
   return 'bg-muted';
+}
+
+const CHANNEL_META: Record<
+  NonNullable<ContractRow['lastChannel']>,
+  { icon: typeof Phone; label: string }
+> = {
+  LINE: { icon: MessageCircle, label: 'LINE' },
+  SMS: { icon: MessageCircle, label: 'SMS' },
+  CALL: { icon: Phone, label: 'โทร' },
+  LETTER: { icon: FileText, label: 'จดหมาย' },
+};
+
+function IndicatorChips({ contract }: { contract: ContractRow }) {
+  const bucket = agingBucket(contract.daysOverdue);
+  const channelMeta = contract.lastChannel ? CHANNEL_META[contract.lastChannel] : null;
+  const ChannelIcon = channelMeta?.icon ?? null;
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-1.5">
+      <span
+        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-2xs font-medium leading-snug ${agingColor(bucket)}`}
+      >
+        เลย {contract.daysOverdue} วัน
+      </span>
+
+      <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted text-muted-foreground text-2xs font-medium px-2 py-0.5 leading-snug">
+        <Clock className="size-3" />
+        {formatRelativeTime(contract.lastContactedAt)}
+      </span>
+
+      {contract.brokenPromiseCount > 0 && (
+        <span className="inline-flex items-center gap-1 rounded-full border border-destructive/30 bg-destructive/10 text-destructive text-2xs font-medium px-2 py-0.5 leading-snug">
+          <AlertTriangle className="size-3" />
+          นัดผิด {contract.brokenPromiseCount} ครั้ง
+        </span>
+      )}
+
+      {ChannelIcon && channelMeta && (
+        <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted text-muted-foreground text-2xs font-medium px-2 py-0.5 leading-snug">
+          <ChannelIcon className="size-3" />
+          {channelMeta.label}
+        </span>
+      )}
+
+      {contract.mdmState === 'PENDING' && (
+        <span className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 text-warning text-2xs font-medium px-2 py-0.5 leading-snug">
+          <Lock className="size-3" />
+          รอ OWNER อนุมัติ
+        </span>
+      )}
+      {contract.mdmState === 'LOCKED' && (
+        <span className="inline-flex items-center gap-1 rounded-full border border-destructive/30 bg-destructive/10 text-destructive text-2xs font-medium px-2 py-0.5 leading-snug">
+          <Lock className="size-3" />
+          ล็อคแล้ว
+        </span>
+      )}
+
+      {contract.relatedContractsCount > 0 && (
+        <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted text-muted-foreground text-2xs font-medium px-2 py-0.5 leading-snug">
+          <Users className="size-3" />
+          +{contract.relatedContractsCount} สัญญา
+        </span>
+      )}
+    </div>
+  );
 }
 
 interface Props {
@@ -93,6 +163,9 @@ export default function ContractCard({
           </span>{' '}
           ฿
         </div>
+
+        {/* Enrichment indicator chips: aging / last contacted / broken promise / channel / MDM / related */}
+        <IndicatorChips contract={contract} />
 
         {/* Status chip cluster */}
         <div className="flex flex-wrap gap-1.5 mb-3">

--- a/apps/web/src/pages/CollectionsPage/components/EvidenceThumbnailGrid.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/EvidenceThumbnailGrid.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { X, ZoomIn } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+
+interface EvidenceThumbnailGridProps {
+  urls: string[];
+  onRemove?: (index: number) => void;
+  maxPreview?: number;
+}
+
+export function EvidenceThumbnailGrid({ urls, onRemove, maxPreview = 3 }: EvidenceThumbnailGridProps) {
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+
+  if (urls.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground leading-snug">
+        ยังไม่ได้อัปโหลดหลักฐาน
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-2">
+        {urls.slice(0, maxPreview).map((url, i) => (
+          <div key={`${url}-${i}`} className="relative aspect-square overflow-hidden rounded border border-border">
+            <img
+              src={url}
+              alt={`หลักฐาน ${i + 1}`}
+              className="h-full w-full cursor-zoom-in object-cover"
+              onClick={() => setLightboxUrl(url)}
+            />
+            <div className="absolute right-1 top-1 flex gap-1">
+              <Button
+                size="icon"
+                variant="secondary"
+                className="h-6 w-6"
+                onClick={() => setLightboxUrl(url)}
+                type="button"
+                aria-label="ขยาย"
+              >
+                <ZoomIn className="h-3 w-3" />
+              </Button>
+              {onRemove && (
+                <Button
+                  size="icon"
+                  variant="destructive"
+                  className="h-6 w-6"
+                  onClick={() => onRemove(i)}
+                  type="button"
+                  aria-label="ลบ"
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      {urls.length > maxPreview && (
+        <p className="mt-1 text-xs text-muted-foreground">+{urls.length - maxPreview} รูปเพิ่มเติม</p>
+      )}
+
+      <Dialog open={!!lightboxUrl} onOpenChange={(o) => !o && setLightboxUrl(null)}>
+        <DialogContent className="max-w-3xl p-0">
+          {lightboxUrl && (
+            <img src={lightboxUrl} alt="หลักฐาน (ขยาย)" className="w-full rounded" />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/FilterChipsBar.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/FilterChipsBar.tsx
@@ -1,0 +1,192 @@
+import { Filter, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { QueueFilterState } from '../hooks/useQueueFilter';
+
+interface FilterChipsBarProps {
+  filter: QueueFilterState;
+  setFilter: (patch: Partial<QueueFilterState>) => void;
+  reset: () => void;
+  onOpenFilter: () => void;
+  resultCount?: number;
+  totalCount?: number;
+}
+
+interface Chip {
+  key: string;
+  label: string;
+  clear: Partial<QueueFilterState>;
+}
+
+function buildChips(f: QueueFilterState): Chip[] {
+  const chips: Chip[] = [];
+
+  if (f.assigned === 'self') {
+    chips.push({ key: 'assigned-self', label: 'ของฉัน', clear: { assigned: undefined } });
+  } else if (f.assigned === 'unassigned') {
+    chips.push({
+      key: 'assigned-unassigned',
+      label: 'ยังไม่ assign',
+      clear: { assigned: undefined },
+    });
+  }
+
+  f.overdueBuckets?.forEach((b) =>
+    chips.push({
+      key: `bucket-${b}`,
+      label: `เลย ${b} วัน`,
+      clear: { overdueBuckets: f.overdueBuckets!.filter((x) => x !== b) },
+    }),
+  );
+
+  if (f.minOutstanding !== undefined || f.maxOutstanding !== undefined) {
+    chips.push({
+      key: 'outstanding-range',
+      label: `ยอด ${(f.minOutstanding ?? 0).toLocaleString()}–${
+        f.maxOutstanding !== undefined ? f.maxOutstanding.toLocaleString() : '∞'
+      }`,
+      clear: { minOutstanding: undefined, maxOutstanding: undefined },
+    });
+  }
+
+  f.contractStatuses?.forEach((s) =>
+    chips.push({
+      key: `status-${s}`,
+      label: s,
+      clear: { contractStatuses: f.contractStatuses!.filter((x) => x !== s) },
+    }),
+  );
+
+  f.productTypes?.forEach((p) =>
+    chips.push({
+      key: `product-${p}`,
+      label: p,
+      clear: { productTypes: f.productTypes!.filter((x) => x !== p) },
+    }),
+  );
+
+  if (f.minLetterCount !== undefined) {
+    chips.push({
+      key: 'min-letter',
+      label: `จดหมาย ≥${f.minLetterCount}`,
+      clear: { minLetterCount: undefined },
+    });
+  }
+
+  if (f.lastContacted === 'today')
+    chips.push({ key: 'lc-today', label: 'ติดต่อวันนี้', clear: { lastContacted: undefined } });
+  if (f.lastContacted === 'this_week')
+    chips.push({
+      key: 'lc-week',
+      label: 'ติดต่อสัปดาห์นี้',
+      clear: { lastContacted: undefined },
+    });
+  if (f.lastContacted === 'never')
+    chips.push({ key: 'lc-never', label: 'ไม่เคยแตะ', clear: { lastContacted: undefined } });
+  if (f.lastContacted === 'over_7_days')
+    chips.push({
+      key: 'lc-over7',
+      label: 'ไม่แตะ >7 วัน',
+      clear: { lastContacted: undefined },
+    });
+
+  if (f.lineResponse === 'no_line')
+    chips.push({ key: 'lr-none', label: 'ไม่มี LINE', clear: { lineResponse: undefined } });
+
+  if (f.minBrokenPromise !== undefined) {
+    chips.push({
+      key: 'min-broken',
+      label: `นัดผิด ≥${f.minBrokenPromise}`,
+      clear: { minBrokenPromise: undefined },
+    });
+  }
+
+  if (f.hasActivePromise === true)
+    chips.push({
+      key: 'has-promise',
+      label: 'มีนัดชำระ',
+      clear: { hasActivePromise: undefined },
+    });
+  if (f.hasActivePromise === false)
+    chips.push({
+      key: 'no-promise',
+      label: 'ไม่มีนัดชำระ',
+      clear: { hasActivePromise: undefined },
+    });
+
+  if (f.mdmState === 'locked')
+    chips.push({ key: 'mdm-locked', label: 'MDM ล็อค', clear: { mdmState: undefined } });
+  if (f.mdmState === 'pending')
+    chips.push({
+      key: 'mdm-pending',
+      label: 'MDM รออนุมัติ',
+      clear: { mdmState: undefined },
+    });
+  if (f.mdmState === 'not_locked')
+    chips.push({
+      key: 'mdm-not-locked',
+      label: 'MDM ยังไม่ล็อค',
+      clear: { mdmState: undefined },
+    });
+
+  if (f.showSkipTracing)
+    chips.push({
+      key: 'skip-tracing',
+      label: 'ต้องหาเบอร์ใหม่',
+      clear: { showSkipTracing: false },
+    });
+
+  if (f.slipReviewPending)
+    chips.push({
+      key: 'slip-review',
+      label: 'รอยืนยันสลิป',
+      clear: { slipReviewPending: false },
+    });
+
+  return chips;
+}
+
+export default function FilterChipsBar({
+  filter,
+  setFilter,
+  reset,
+  onOpenFilter,
+  resultCount,
+  totalCount,
+}: FilterChipsBarProps) {
+  const chips = buildChips(filter);
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-2">
+      <Button variant="outline" size="sm" onClick={onOpenFilter} className="gap-1.5">
+        <Filter className="size-3.5" />
+        ตัวกรอง
+        {chips.length > 0 && <span className="ml-0.5 text-primary">({chips.length})</span>}
+      </Button>
+
+      {chips.map((chip) => (
+        <button
+          key={chip.key}
+          type="button"
+          onClick={() => setFilter(chip.clear)}
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-2xs leading-snug hover:bg-accent transition-colors"
+          aria-label={`ลบตัวกรอง ${chip.label}`}
+        >
+          {chip.label}
+          <X className="size-3" />
+        </button>
+      ))}
+
+      {chips.length > 0 && (
+        <Button variant="ghost" size="sm" onClick={reset} className="text-2xs">
+          ล้างทั้งหมด
+        </Button>
+      )}
+
+      {resultCount !== undefined && totalCount !== undefined && totalCount > resultCount && (
+        <span className="ml-auto text-2xs text-muted-foreground leading-snug">
+          แสดง {resultCount.toLocaleString()} จาก {totalCount.toLocaleString()}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/FilterDrawer.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/FilterDrawer.tsx
@@ -1,0 +1,460 @@
+import { useEffect, useState } from 'react';
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Slider, SliderThumb } from '@/components/ui/slider';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/contexts/AuthContext';
+import type {
+  LastContactedOption,
+  LineResponseOption,
+  MdmStateOption,
+  OverdueBucketOption,
+  QueueFilterState,
+} from '../hooks/useQueueFilter';
+
+interface FilterDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  filter: QueueFilterState;
+  onApply: (next: QueueFilterState) => void;
+  onReset: () => void;
+  liveCount?: number;
+}
+
+const BUCKETS: OverdueBucketOption[] = ['1-7', '8-30', '31-60', '61-90', '90+'];
+const STATUSES: Array<{ value: string; label: string }> = [
+  { value: 'ACTIVE', label: 'ACTIVE' },
+  { value: 'OVERDUE', label: 'OVERDUE' },
+  { value: 'DEFAULT', label: 'DEFAULT' },
+  { value: 'LEGAL', label: 'LEGAL' },
+];
+const PRODUCTS: Array<{ value: string; label: string }> = [
+  { value: 'PHONE_NEW', label: 'มือถือใหม่' },
+  { value: 'PHONE_USED', label: 'มือถือมือสอง' },
+  { value: 'TABLET', label: 'แท็บเล็ต' },
+  { value: 'ACCESSORY', label: 'อุปกรณ์เสริม' },
+];
+
+const LAST_CONTACTED: Array<{ value: LastContactedOption | 'any'; label: string }> = [
+  { value: 'any', label: 'ทั้งหมด' },
+  { value: 'today', label: 'วันนี้' },
+  { value: 'this_week', label: 'ภายใน 7 วัน' },
+  { value: 'never', label: 'ไม่เคยแตะ' },
+  { value: 'over_7_days', label: 'ไม่แตะ >7 วัน' },
+];
+
+const LINE_RESPONSE: Array<{ value: LineResponseOption | 'any'; label: string }> = [
+  { value: 'any', label: 'ทั้งหมด' },
+  { value: 'no_line', label: 'ไม่มี LINE' },
+  { value: 'responded', label: 'ตอบ' },
+  { value: 'ignored', label: 'เพิกเฉย' },
+  { value: 'blocked', label: 'ถูกบล็อก' },
+];
+
+const MDM_OPTIONS: Array<{ value: MdmStateOption | 'any'; label: string }> = [
+  { value: 'any', label: 'ทั้งหมด' },
+  { value: 'not_locked', label: 'ยังไม่ล็อค' },
+  { value: 'pending', label: 'รออนุมัติ' },
+  { value: 'locked', label: 'ล็อคแล้ว' },
+];
+
+const OUTSTANDING_MIN = 0;
+const OUTSTANDING_MAX = 100000;
+const OUTSTANDING_STEP = 500;
+
+export default function FilterDrawer({
+  open,
+  onOpenChange,
+  filter,
+  onApply,
+  onReset,
+  liveCount,
+}: FilterDrawerProps) {
+  const { user } = useAuth();
+  const canPickBranch = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
+
+  const [draft, setDraft] = useState<QueueFilterState>(filter);
+
+  // Reset draft whenever the drawer is (re)opened or external filter changes
+  useEffect(() => {
+    if (open) setDraft(filter);
+  }, [open, filter]);
+
+  const toggleArrayValue = <K extends keyof QueueFilterState>(key: K, value: string) => {
+    const current = (draft[key] as unknown as string[] | undefined) ?? [];
+    const next = current.includes(value)
+      ? current.filter((x) => x !== value)
+      : [...current, value];
+    setDraft({ ...draft, [key]: next.length ? (next as any) : undefined });
+  };
+
+  const minOut = draft.minOutstanding ?? OUTSTANDING_MIN;
+  const maxOut = draft.maxOutstanding ?? OUTSTANDING_MAX;
+
+  const handleApply = () => {
+    onApply(draft);
+    onOpenChange(false);
+  };
+
+  const handleLocalReset = () => {
+    setDraft({});
+    onReset();
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-md flex flex-col p-0"
+        aria-describedby={undefined}
+      >
+        <SheetHeader>
+          <SheetTitle>ตัวกรอง</SheetTitle>
+        </SheetHeader>
+
+        <SheetBody className="flex-1 overflow-y-auto px-6">
+          <Accordion type="multiple" defaultValue={['who', 'state', 'activity']}>
+            {/* Section 1: WHO */}
+            <AccordionItem value="who">
+              <AccordionTrigger>ผู้ดูแล</AccordionTrigger>
+              <AccordionContent className="space-y-4 pb-4">
+                <RadioGroup
+                  value={draft.assigned ?? 'any'}
+                  onValueChange={(v) =>
+                    setDraft({
+                      ...draft,
+                      assigned: v === 'any' ? undefined : (v as 'self' | 'unassigned'),
+                    })
+                  }
+                  className="space-y-1.5"
+                >
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="any" id="assigned-any" />
+                    <Label htmlFor="assigned-any" className="cursor-pointer">
+                      ทั้งหมด
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="self" id="assigned-self" />
+                    <Label htmlFor="assigned-self" className="cursor-pointer">
+                      ของฉัน
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="unassigned" id="assigned-unassigned" />
+                    <Label htmlFor="assigned-unassigned" className="cursor-pointer">
+                      ยังไม่ assign
+                    </Label>
+                  </div>
+                </RadioGroup>
+
+                {canPickBranch && (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="branchId">สาขา (ID)</Label>
+                    <input
+                      id="branchId"
+                      type="text"
+                      value={draft.branchId ?? ''}
+                      onChange={(e) =>
+                        setDraft({ ...draft, branchId: e.target.value || undefined })
+                      }
+                      placeholder="ว่าง = ทุกสาขา"
+                      className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                    />
+                  </div>
+                )}
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* Section 2: CONTRACT STATE */}
+            <AccordionItem value="state">
+              <AccordionTrigger>สถานะสัญญา</AccordionTrigger>
+              <AccordionContent className="space-y-4 pb-4">
+                <div>
+                  <Label>ช่วงวันค้างชำระ</Label>
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {BUCKETS.map((b) => {
+                      const active = draft.overdueBuckets?.includes(b) ?? false;
+                      return (
+                        <button
+                          key={b}
+                          type="button"
+                          onClick={() => toggleArrayValue('overdueBuckets', b)}
+                          className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                            active
+                              ? 'border-primary bg-primary text-primary-foreground'
+                              : 'border-border bg-muted text-muted-foreground hover:bg-accent'
+                          }`}
+                        >
+                          {b} วัน
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div>
+                  <div className="flex items-center justify-between">
+                    <Label>ยอดค้าง (฿)</Label>
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {minOut.toLocaleString()} – {maxOut === OUTSTANDING_MAX ? '100,000+' : maxOut.toLocaleString()}
+                    </span>
+                  </div>
+                  <Slider
+                    className="mt-3"
+                    min={OUTSTANDING_MIN}
+                    max={OUTSTANDING_MAX}
+                    step={OUTSTANDING_STEP}
+                    value={[minOut, maxOut]}
+                    onValueChange={(v) => {
+                      const [lo, hi] = v;
+                      setDraft({
+                        ...draft,
+                        minOutstanding: lo === OUTSTANDING_MIN ? undefined : lo,
+                        maxOutstanding: hi === OUTSTANDING_MAX ? undefined : hi,
+                      });
+                    }}
+                  >
+                    <SliderThumb aria-label="ยอดค้างต่ำสุด" />
+                    <SliderThumb aria-label="ยอดค้างสูงสุด" />
+                  </Slider>
+                </div>
+
+                <div>
+                  <Label>สถานะ</Label>
+                  <div className="mt-2 space-y-1.5">
+                    {STATUSES.map((s) => {
+                      const active = draft.contractStatuses?.includes(s.value) ?? false;
+                      return (
+                        <div key={s.value} className="flex items-center gap-2">
+                          <Checkbox
+                            id={`status-${s.value}`}
+                            checked={active}
+                            onCheckedChange={() => toggleArrayValue('contractStatuses', s.value)}
+                          />
+                          <Label htmlFor={`status-${s.value}`} className="cursor-pointer">
+                            {s.label}
+                          </Label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div>
+                  <Label>ประเภทสินค้า</Label>
+                  <div className="mt-2 space-y-1.5">
+                    {PRODUCTS.map((p) => {
+                      const active = draft.productTypes?.includes(p.value) ?? false;
+                      return (
+                        <div key={p.value} className="flex items-center gap-2">
+                          <Checkbox
+                            id={`product-${p.value}`}
+                            checked={active}
+                            onCheckedChange={() => toggleArrayValue('productTypes', p.value)}
+                          />
+                          <Label htmlFor={`product-${p.value}`} className="cursor-pointer">
+                            {p.label}
+                          </Label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="minLetterCount">จดหมายที่ส่งขั้นต่ำ</Label>
+                  <input
+                    id="minLetterCount"
+                    type="number"
+                    min={0}
+                    value={draft.minLetterCount ?? ''}
+                    onChange={(e) =>
+                      setDraft({
+                        ...draft,
+                        minLetterCount: e.target.value === '' ? undefined : Number(e.target.value),
+                      })
+                    }
+                    placeholder="ว่าง = ไม่กรอง"
+                    className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                  />
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* Section 3: ACTIVITY & RISK */}
+            <AccordionItem value="activity">
+              <AccordionTrigger>กิจกรรม & ความเสี่ยง</AccordionTrigger>
+              <AccordionContent className="space-y-4 pb-4">
+                <div>
+                  <Label>ติดต่อล่าสุด</Label>
+                  <RadioGroup
+                    className="mt-2 space-y-1.5"
+                    value={draft.lastContacted ?? 'any'}
+                    onValueChange={(v) =>
+                      setDraft({
+                        ...draft,
+                        lastContacted:
+                          v === 'any' ? undefined : (v as LastContactedOption),
+                      })
+                    }
+                  >
+                    {LAST_CONTACTED.map((opt) => (
+                      <div key={opt.value} className="flex items-center gap-2">
+                        <RadioGroupItem value={opt.value} id={`lc-${opt.value}`} />
+                        <Label htmlFor={`lc-${opt.value}`} className="cursor-pointer">
+                          {opt.label}
+                        </Label>
+                      </div>
+                    ))}
+                  </RadioGroup>
+                </div>
+
+                <div>
+                  <Label>การตอบรับ LINE</Label>
+                  <RadioGroup
+                    className="mt-2 space-y-1.5"
+                    value={draft.lineResponse ?? 'any'}
+                    onValueChange={(v) =>
+                      setDraft({
+                        ...draft,
+                        lineResponse:
+                          v === 'any' ? undefined : (v as LineResponseOption),
+                      })
+                    }
+                  >
+                    {LINE_RESPONSE.map((opt) => (
+                      <div key={opt.value} className="flex items-center gap-2">
+                        <RadioGroupItem value={opt.value} id={`lr-${opt.value}`} />
+                        <Label htmlFor={`lr-${opt.value}`} className="cursor-pointer">
+                          {opt.label}
+                        </Label>
+                      </div>
+                    ))}
+                  </RadioGroup>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="minBrokenPromise">นัดผิดขั้นต่ำ</Label>
+                  <input
+                    id="minBrokenPromise"
+                    type="number"
+                    min={0}
+                    value={draft.minBrokenPromise ?? ''}
+                    onChange={(e) =>
+                      setDraft({
+                        ...draft,
+                        minBrokenPromise:
+                          e.target.value === '' ? undefined : Number(e.target.value),
+                      })
+                    }
+                    placeholder="ว่าง = ไม่กรอง"
+                    className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                  />
+                </div>
+
+                <div>
+                  <Label>สถานะ MDM</Label>
+                  <RadioGroup
+                    className="mt-2 space-y-1.5"
+                    value={draft.mdmState ?? 'any'}
+                    onValueChange={(v) =>
+                      setDraft({
+                        ...draft,
+                        mdmState: v === 'any' ? undefined : (v as MdmStateOption),
+                      })
+                    }
+                  >
+                    {MDM_OPTIONS.map((opt) => (
+                      <div key={opt.value} className="flex items-center gap-2">
+                        <RadioGroupItem value={opt.value} id={`mdm-${opt.value}`} />
+                        <Label htmlFor={`mdm-${opt.value}`} className="cursor-pointer">
+                          {opt.label}
+                        </Label>
+                      </div>
+                    ))}
+                  </RadioGroup>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id="hasActivePromise"
+                      checked={draft.hasActivePromise === true}
+                      onCheckedChange={(checked) =>
+                        setDraft({
+                          ...draft,
+                          hasActivePromise: checked ? true : undefined,
+                        })
+                      }
+                    />
+                    <Label htmlFor="hasActivePromise" className="cursor-pointer">
+                      มีนัดชำระที่ยังไม่หมดอายุ
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id="showSkipTracing"
+                      checked={!!draft.showSkipTracing}
+                      onCheckedChange={(checked) =>
+                        setDraft({
+                          ...draft,
+                          showSkipTracing: checked ? true : undefined,
+                        })
+                      }
+                    />
+                    <Label htmlFor="showSkipTracing" className="cursor-pointer">
+                      ต้องหาเบอร์ใหม่เท่านั้น
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id="slipReviewPending"
+                      checked={!!draft.slipReviewPending}
+                      onCheckedChange={(checked) =>
+                        setDraft({
+                          ...draft,
+                          slipReviewPending: checked ? true : undefined,
+                        })
+                      }
+                    />
+                    <Label htmlFor="slipReviewPending" className="cursor-pointer">
+                      รอยืนยันสลิป
+                    </Label>
+                  </div>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </SheetBody>
+
+        <SheetFooter className="gap-2">
+          <Button variant="outline" onClick={handleLocalReset} className="flex-1 sm:flex-none">
+            ล้าง
+          </Button>
+          <div className="flex-1 text-center text-xs text-muted-foreground leading-snug">
+            {liveCount !== undefined ? `ปัจจุบันแสดง ${liveCount.toLocaleString()} แถว` : ''}
+          </div>
+          <Button onClick={handleApply} className="flex-1 sm:flex-none">
+            ใช้ตัวกรอง
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Download, FileText, Loader2, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import Modal from '@/components/ui/Modal';
+import { Checkbox } from '@/components/ui/checkbox';
 import { renderLetterPdf, type LetterTemplateData } from '../utils/letterPdfRenderer';
 import { useLetterActions } from '../hooks/useLetterActions';
 import type { LetterRow } from '../hooks/useLetterQueue';
+import { EvidenceThumbnailGrid } from './EvidenceThumbnailGrid';
 
 interface Props {
   open: boolean;
@@ -293,8 +295,29 @@ interface DispatchSectionProps {
 function DispatchSection({ letter, onClose }: DispatchSectionProps) {
   const [tracking, setTracking] = useState('');
   const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
+  const [evidenceVerified, setEvidenceVerified] = useState(false);
   const [busy, setBusy] = useState(false);
   const { dispatch } = useLetterActions();
+
+  // Create a local preview URL for the selected evidence file
+  const evidencePreviewUrl = useMemo(
+    () => (evidenceFile ? URL.createObjectURL(evidenceFile) : null),
+    [evidenceFile],
+  );
+
+  // Revoke object URL when file changes or component unmounts
+  useEffect(() => {
+    return () => {
+      if (evidencePreviewUrl) URL.revokeObjectURL(evidencePreviewUrl);
+    };
+  }, [evidencePreviewUrl]);
+
+  // Reset verification whenever file changes — user must re-verify
+  useEffect(() => {
+    setEvidenceVerified(false);
+  }, [evidenceFile]);
+
+  const evidenceUrls = evidencePreviewUrl ? [evidencePreviewUrl] : [];
 
   const handleSubmit = async () => {
     if (tracking.trim().length < 5) {
@@ -386,11 +409,17 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
         )}
       </div>
 
-      {/* Evidence photo upload */}
-      <div>
-        <label className="text-xs font-medium text-muted-foreground mb-1.5 block leading-snug">
+      {/* Evidence photo upload + preview */}
+      <div className="space-y-2">
+        <label className="text-xs font-medium text-muted-foreground block leading-snug">
           รูปใบรับส่งไปรษณีย์ (ไม่บังคับ)
         </label>
+
+        <EvidenceThumbnailGrid
+          urls={evidenceUrls}
+          onRemove={() => setEvidenceFile(null)}
+        />
+
         <input
           type="file"
           accept="image/*"
@@ -398,10 +427,19 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
           className="text-sm text-muted-foreground file:mr-3 file:rounded-lg file:border file:border-input file:bg-muted file:px-3 file:py-1 file:text-xs file:font-medium file:text-foreground hover:file:bg-accent cursor-pointer"
         />
         {evidenceFile && (
-          <p className="mt-1 text-[10px] text-muted-foreground leading-snug">
+          <p className="text-[10px] text-muted-foreground leading-snug">
             {evidenceFile.name} ({(evidenceFile.size / 1024).toFixed(0)} KB)
           </p>
         )}
+
+        <label className="flex items-start gap-2 text-sm pt-1 cursor-pointer">
+          <Checkbox
+            checked={evidenceVerified}
+            onCheckedChange={(v) => setEvidenceVerified(v === true)}
+            className="mt-0.5"
+          />
+          <span className="leading-snug text-foreground">ตรวจสอบหลักฐานการส่งถูกต้องแล้ว</span>
+        </label>
       </div>
 
       {/* Actions */}
@@ -416,7 +454,7 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={busy || !trackingValid}
+          disabled={busy || !trackingValid || !evidenceVerified}
           className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
           {busy ? (
@@ -427,7 +465,7 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
           ) : (
             <>
               <Upload className="size-4" />
-              บันทึกส่งแล้ว
+              ยืนยันส่ง
             </>
           )}
         </button>

--- a/apps/web/src/pages/CollectionsPage/components/TruncatedBanner.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/TruncatedBanner.tsx
@@ -1,0 +1,35 @@
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface TruncatedBannerProps {
+  /**
+   * Callback to open the filter drawer. Task 10 will wire this to a real
+   * drawer; during P0 this may be a no-op or a stub toast.
+   */
+  onOpenFilter: () => void;
+}
+
+/**
+ * Amber banner shown when backend queue capped results at 500 rows.
+ * Nudges the user to narrow filter before the UI silently hides tail rows.
+ */
+export function TruncatedBanner({ onOpenFilter }: TruncatedBannerProps) {
+  return (
+    <div
+      role="alert"
+      className="mb-3 flex items-center justify-between rounded-md border border-warning/40 bg-warning/10 px-4 py-2.5 text-sm"
+    >
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 text-warning" aria-hidden="true" />
+        <span className="text-foreground leading-snug">
+          แสดง 500 แถวแรก — ปรับ filter ให้แคบลงเพื่อเห็นทั้งหมด
+        </span>
+      </div>
+      <Button variant="ghost" size="sm" onClick={onOpenFilter}>
+        เปิด filter
+      </Button>
+    </div>
+  );
+}
+
+export default TruncatedBanner;

--- a/apps/web/src/pages/CollectionsPage/components/WallpaperPreview.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/WallpaperPreview.tsx
@@ -1,0 +1,48 @@
+import { Checkbox } from '@/components/ui/checkbox';
+
+interface WallpaperPreviewProps {
+  wallpaperUrl: string | null;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+/**
+ * Shown inside the MDM approve dialog. Lets the approver decide at
+ * approve-time whether to attach the configured wallpaper to the lock.
+ *
+ * When the OWNER hasn't configured a wallpaper URL yet, the component
+ * renders a hint linking to settings instead of a broken image.
+ */
+export function WallpaperPreview({ wallpaperUrl, checked, onChange }: WallpaperPreviewProps) {
+  if (!wallpaperUrl) {
+    return (
+      <p className="text-xs text-muted-foreground leading-snug">
+        ยังไม่ตั้ง wallpaper MDM —{' '}
+        <a href="/settings" className="underline underline-offset-2">
+          ไปตั้งค่าที่หน้า Dunning
+        </a>
+      </p>
+    );
+  }
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-border bg-muted/30 p-3">
+      <img
+        src={wallpaperUrl}
+        alt="MDM wallpaper preview"
+        className="h-16 w-16 rounded object-cover"
+      />
+      <div className="flex-1">
+        <label className="flex items-start gap-2 text-sm leading-snug cursor-pointer">
+          <Checkbox
+            checked={checked}
+            onCheckedChange={(v) => onChange(!!v)}
+            className="mt-0.5"
+          />
+          <span>แนบภาพพื้นหลังนี้ให้เครื่องพร้อมล็อค</span>
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export default WallpaperPreview;

--- a/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
@@ -85,3 +85,23 @@ export function useRejectMdm() {
     onError: (err: unknown) => toast.error(getErrorMessage(err)),
   });
 }
+
+/**
+ * Unlock an already-executed MDM lock. Backend restricts to OWNER/FINANCE_MANAGER.
+ * Invalidates the approval queue + contract queue so UI reflects deviceLocked=false.
+ */
+export function useUnlockMdm() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      const { data } = await api.post(`/overdue/mdm-requests/${requestId}/unlock`);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success('ปลดล็อคเครื่องแล้ว');
+      qc.invalidateQueries({ queryKey: ['pending-mdm'] });
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useApprovalQueues.ts
@@ -55,11 +55,26 @@ export function useRejectEscalation() {
   });
 }
 
+/**
+ * Approve a pending MDM lock request.
+ *
+ * Accepts either a plain requestId string (back-compat) or an object with
+ * an explicit `includeWallpaper` override. The object form lets the approve
+ * dialog surface a wallpaper preview + checkbox so the OWNER decides at
+ * approve-time whether the wallpaper is shipped.
+ */
 export function useApproveMdm() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (requestId: string) => {
-      const { data } = await api.post(`/overdue/mdm-requests/${requestId}/approve`);
+    mutationFn: async (
+      arg: string | { id: string; includeWallpaper?: boolean },
+    ) => {
+      const id = typeof arg === 'string' ? arg : arg.id;
+      const body =
+        typeof arg === 'string' || arg.includeWallpaper === undefined
+          ? undefined
+          : { includeWallpaper: arg.includeWallpaper };
+      const { data } = await api.post(`/overdue/mdm-requests/${id}/approve`, body);
       return data;
     },
     onSuccess: () => {

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import type { ContractRow } from '../types';
+import type { QueueFilterState } from './useQueueFilter';
 
 export interface QueueResponse {
   data: ContractRow[];
@@ -23,13 +24,42 @@ export function useCollectionsQueue(params: {
   page: number;
   limit: number;
   enabled: boolean;
+  filter?: QueueFilterState;
 }) {
-  const { tab, search, branchId, page, limit, enabled } = params;
+  const { tab, search, branchId, page, limit, enabled, filter } = params;
+
+  // Stable serialized key fragment for the filter so React Query invalidates
+  // precisely when filter state changes.
+  const filterKey = filter ? JSON.stringify(filter) : '';
+
   return useQuery<QueueResponse, Error, QueueResponse>({
-    queryKey: ['collections-queue', tab, search, branchId, page, limit],
+    queryKey: ['collections-queue', tab, search, branchId, page, limit, filterKey],
     queryFn: async () => {
       const q = new URLSearchParams({ tab, page: String(page), limit: String(limit) });
       if (branchId) q.set('branchId', branchId);
+      if (search) q.set('search', search);
+      if (filter) {
+        if (filter.assigned) q.set('assignedToId', filter.assigned);
+        if (filter.overdueBuckets?.length) q.set('overdueBuckets', filter.overdueBuckets.join(','));
+        if (filter.minOutstanding !== undefined)
+          q.set('minOutstanding', String(filter.minOutstanding));
+        if (filter.maxOutstanding !== undefined)
+          q.set('maxOutstanding', String(filter.maxOutstanding));
+        if (filter.contractStatuses?.length)
+          q.set('contractStatuses', filter.contractStatuses.join(','));
+        if (filter.productTypes?.length) q.set('productTypes', filter.productTypes.join(','));
+        if (filter.minLetterCount !== undefined)
+          q.set('minLetterCount', String(filter.minLetterCount));
+        if (filter.lastContacted) q.set('lastContacted', filter.lastContacted);
+        if (filter.lineResponse) q.set('lineResponse', filter.lineResponse);
+        if (filter.minBrokenPromise !== undefined)
+          q.set('minBrokenPromise', String(filter.minBrokenPromise));
+        if (filter.hasActivePromise !== undefined)
+          q.set('hasActivePromise', String(filter.hasActivePromise));
+        if (filter.mdmState) q.set('mdmState', filter.mdmState);
+        if (filter.showSkipTracing) q.set('showSkipTracing', 'true');
+        if (filter.slipReviewPending) q.set('slipReviewPending', 'true');
+      }
       const { data } = await api.get(`/overdue/queue?${q}`);
       return data;
     },

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
@@ -7,6 +7,11 @@ export interface QueueResponse {
   total: number;
   page: number;
   limit: number;
+  /**
+   * True when backend hit the hard row cap (500) — filter should be narrowed.
+   * Backend omits this when under cap, so we default to false in `select`.
+   */
+  truncated: boolean;
 }
 
 export type QueueTab = 'today' | 'followup' | 'promise';
@@ -20,7 +25,7 @@ export function useCollectionsQueue(params: {
   enabled: boolean;
 }) {
   const { tab, search, branchId, page, limit, enabled } = params;
-  return useQuery<QueueResponse>({
+  return useQuery<QueueResponse, Error, QueueResponse>({
     queryKey: ['collections-queue', tab, search, branchId, page, limit],
     queryFn: async () => {
       const q = new URLSearchParams({ tab, page: String(page), limit: String(limit) });
@@ -30,5 +35,6 @@ export function useCollectionsQueue(params: {
     },
     enabled,
     placeholderData: (prev) => prev,
+    select: (res) => ({ ...res, truncated: res.truncated ?? false }),
   });
 }

--- a/apps/web/src/pages/CollectionsPage/hooks/useQueueFilter.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useQueueFilter.ts
@@ -1,0 +1,159 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
+
+export type OverdueBucketOption = '1-7' | '8-30' | '31-60' | '61-90' | '90+';
+export type LastContactedOption = 'today' | 'this_week' | 'never' | 'over_7_days';
+export type LineResponseOption = 'responded' | 'ignored' | 'blocked' | 'no_line';
+export type MdmStateOption = 'not_locked' | 'locked' | 'pending';
+
+export interface QueueFilterState {
+  assigned?: 'self' | 'unassigned' | string;
+  branchId?: string;
+  overdueBuckets?: OverdueBucketOption[];
+  minOutstanding?: number;
+  maxOutstanding?: number;
+  contractStatuses?: string[];
+  productTypes?: string[];
+  minLetterCount?: number;
+  lastContacted?: LastContactedOption;
+  lineResponse?: LineResponseOption;
+  minBrokenPromise?: number;
+  hasActivePromise?: boolean;
+  mdmState?: MdmStateOption;
+  showSkipTracing?: boolean;
+  slipReviewPending?: boolean;
+}
+
+const boolParam = (v: string | null): boolean | undefined => {
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  return undefined;
+};
+
+const numParam = (v: string | null): number | undefined => {
+  if (v === null || v === '') return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+function serialize(state: QueueFilterState, baseParams: URLSearchParams): URLSearchParams {
+  const out = new URLSearchParams();
+  // preserve non-filter params (e.g. ?view=incoming)
+  baseParams.forEach((value: string, key: string) => {
+    if (!FILTER_KEYS.has(key)) out.set(key, value);
+  });
+  if (state.assigned) out.set('assigned', state.assigned);
+  if (state.branchId) out.set('branchId', state.branchId);
+  if (state.overdueBuckets?.length) out.set('buckets', state.overdueBuckets.join(','));
+  if (state.minOutstanding !== undefined) out.set('minOutstanding', String(state.minOutstanding));
+  if (state.maxOutstanding !== undefined) out.set('maxOutstanding', String(state.maxOutstanding));
+  if (state.contractStatuses?.length) out.set('statuses', state.contractStatuses.join(','));
+  if (state.productTypes?.length) out.set('products', state.productTypes.join(','));
+  if (state.minLetterCount !== undefined) out.set('minLetterCount', String(state.minLetterCount));
+  if (state.lastContacted) out.set('lastContacted', state.lastContacted);
+  if (state.lineResponse) out.set('lineResponse', state.lineResponse);
+  if (state.minBrokenPromise !== undefined)
+    out.set('minBrokenPromise', String(state.minBrokenPromise));
+  if (state.hasActivePromise !== undefined)
+    out.set('hasActivePromise', String(state.hasActivePromise));
+  if (state.mdmState) out.set('mdmState', state.mdmState);
+  if (state.showSkipTracing) out.set('showSkipTracing', 'true');
+  if (state.slipReviewPending) out.set('slipReviewPending', 'true');
+  return out;
+}
+
+const FILTER_KEYS = new Set([
+  'assigned',
+  'branchId',
+  'buckets',
+  'minOutstanding',
+  'maxOutstanding',
+  'statuses',
+  'products',
+  'minLetterCount',
+  'lastContacted',
+  'lineResponse',
+  'minBrokenPromise',
+  'hasActivePromise',
+  'mdmState',
+  'showSkipTracing',
+  'slipReviewPending',
+]);
+
+export function useQueueFilter(): [
+  QueueFilterState,
+  (patch: Partial<QueueFilterState>) => void,
+  () => void,
+] {
+  const [params, setParams] = useSearchParams();
+
+  const state: QueueFilterState = useMemo(() => {
+    const assignedRaw = params.get('assigned');
+    const minOut = numParam(params.get('minOutstanding'));
+    const maxOut = numParam(params.get('maxOutstanding'));
+    const minLetter = numParam(params.get('minLetterCount'));
+    const minBroken = numParam(params.get('minBrokenPromise'));
+    return {
+      assigned: assignedRaw ?? undefined,
+      branchId: params.get('branchId') ?? undefined,
+      overdueBuckets: (params.get('buckets')?.split(',').filter(Boolean) as OverdueBucketOption[]) ??
+        undefined,
+      minOutstanding: minOut,
+      maxOutstanding: maxOut,
+      contractStatuses: params.get('statuses')?.split(',').filter(Boolean),
+      productTypes: params.get('products')?.split(',').filter(Boolean),
+      minLetterCount: minLetter,
+      lastContacted: (params.get('lastContacted') as LastContactedOption | null) ?? undefined,
+      lineResponse: (params.get('lineResponse') as LineResponseOption | null) ?? undefined,
+      minBrokenPromise: minBroken,
+      hasActivePromise: boolParam(params.get('hasActivePromise')),
+      mdmState: (params.get('mdmState') as MdmStateOption | null) ?? undefined,
+      showSkipTracing: params.get('showSkipTracing') === 'true' || undefined,
+      slipReviewPending: params.get('slipReviewPending') === 'true' || undefined,
+    };
+  }, [params]);
+
+  const setFilter = useCallback(
+    (patch: Partial<QueueFilterState>) => {
+      const next: QueueFilterState = { ...state, ...patch };
+      // Strip undefined/empty values
+      (Object.keys(next) as (keyof QueueFilterState)[]).forEach((k) => {
+        const v = next[k];
+        if (v === undefined || v === '' || (Array.isArray(v) && v.length === 0)) {
+          delete next[k];
+        }
+      });
+      setParams(serialize(next, params), { replace: true });
+    },
+    [state, params, setParams],
+  );
+
+  const reset = useCallback(() => {
+    const next = new URLSearchParams();
+    params.forEach((value: string, key: string) => {
+      if (!FILTER_KEYS.has(key)) next.set(key, value);
+    });
+    setParams(next, { replace: true });
+  }, [params, setParams]);
+
+  return [state, setFilter, reset];
+}
+
+export function countActiveFilters(f: QueueFilterState): number {
+  let n = 0;
+  if (f.assigned) n++;
+  if (f.branchId) n++;
+  if (f.overdueBuckets?.length) n++;
+  if (f.minOutstanding !== undefined || f.maxOutstanding !== undefined) n++;
+  if (f.contractStatuses?.length) n++;
+  if (f.productTypes?.length) n++;
+  if (f.minLetterCount !== undefined) n++;
+  if (f.lastContacted) n++;
+  if (f.lineResponse) n++;
+  if (f.minBrokenPromise !== undefined) n++;
+  if (f.hasActivePromise !== undefined) n++;
+  if (f.mdmState) n++;
+  if (f.showSkipTracing) n++;
+  if (f.slipReviewPending) n++;
+  return n;
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useQueueFilter.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useQueueFilter.ts
@@ -24,6 +24,21 @@ export interface QueueFilterState {
   slipReviewPending?: boolean;
 }
 
+/**
+ * Tab identifier — used to namespace URL query params so that filter state on
+ * one tab doesn't leak to another when the user switches tabs. Each tab's
+ * filter params are prefixed with a unique 2-char key so the 4 tabs can
+ * coexist in the same URL without collision.
+ */
+export type QueueFilterTab = 'queue' | 'follow-up' | 'promise' | 'all';
+
+const TAB_PREFIX: Record<QueueFilterTab, string> = {
+  queue: 'q_',
+  'follow-up': 'f_',
+  promise: 'p_',
+  all: 'a_',
+};
+
 const boolParam = (v: string | null): boolean | undefined => {
   if (v === 'true') return true;
   if (v === 'false') return false;
@@ -36,33 +51,8 @@ const numParam = (v: string | null): number | undefined => {
   return Number.isFinite(n) ? n : undefined;
 };
 
-function serialize(state: QueueFilterState, baseParams: URLSearchParams): URLSearchParams {
-  const out = new URLSearchParams();
-  // preserve non-filter params (e.g. ?view=incoming)
-  baseParams.forEach((value: string, key: string) => {
-    if (!FILTER_KEYS.has(key)) out.set(key, value);
-  });
-  if (state.assigned) out.set('assigned', state.assigned);
-  if (state.branchId) out.set('branchId', state.branchId);
-  if (state.overdueBuckets?.length) out.set('buckets', state.overdueBuckets.join(','));
-  if (state.minOutstanding !== undefined) out.set('minOutstanding', String(state.minOutstanding));
-  if (state.maxOutstanding !== undefined) out.set('maxOutstanding', String(state.maxOutstanding));
-  if (state.contractStatuses?.length) out.set('statuses', state.contractStatuses.join(','));
-  if (state.productTypes?.length) out.set('products', state.productTypes.join(','));
-  if (state.minLetterCount !== undefined) out.set('minLetterCount', String(state.minLetterCount));
-  if (state.lastContacted) out.set('lastContacted', state.lastContacted);
-  if (state.lineResponse) out.set('lineResponse', state.lineResponse);
-  if (state.minBrokenPromise !== undefined)
-    out.set('minBrokenPromise', String(state.minBrokenPromise));
-  if (state.hasActivePromise !== undefined)
-    out.set('hasActivePromise', String(state.hasActivePromise));
-  if (state.mdmState) out.set('mdmState', state.mdmState);
-  if (state.showSkipTracing) out.set('showSkipTracing', 'true');
-  if (state.slipReviewPending) out.set('slipReviewPending', 'true');
-  return out;
-}
-
-const FILTER_KEYS = new Set([
+// Canonical filter key names (suffix — real URL key is `<prefix><name>`).
+const FILTER_NAMES = [
   'assigned',
   'branchId',
   'buckets',
@@ -78,40 +68,90 @@ const FILTER_KEYS = new Set([
   'mdmState',
   'showSkipTracing',
   'slipReviewPending',
-]);
+] as const;
 
-export function useQueueFilter(): [
-  QueueFilterState,
-  (patch: Partial<QueueFilterState>) => void,
-  () => void,
-] {
+function namespacedKeys(prefix: string): Set<string> {
+  return new Set(FILTER_NAMES.map((n) => `${prefix}${n}`));
+}
+
+function serialize(
+  state: QueueFilterState,
+  baseParams: URLSearchParams,
+  prefix: string,
+): URLSearchParams {
+  const out = new URLSearchParams();
+  const ownKeys = namespacedKeys(prefix);
+  // preserve params that don't belong to this tab (other tabs' namespaced
+  // filter state + non-filter params like ?view=incoming or other tabs' URLs)
+  baseParams.forEach((value: string, key: string) => {
+    if (!ownKeys.has(key)) out.set(key, value);
+  });
+  if (state.assigned) out.set(`${prefix}assigned`, state.assigned);
+  if (state.branchId) out.set(`${prefix}branchId`, state.branchId);
+  if (state.overdueBuckets?.length) out.set(`${prefix}buckets`, state.overdueBuckets.join(','));
+  if (state.minOutstanding !== undefined)
+    out.set(`${prefix}minOutstanding`, String(state.minOutstanding));
+  if (state.maxOutstanding !== undefined)
+    out.set(`${prefix}maxOutstanding`, String(state.maxOutstanding));
+  if (state.contractStatuses?.length)
+    out.set(`${prefix}statuses`, state.contractStatuses.join(','));
+  if (state.productTypes?.length) out.set(`${prefix}products`, state.productTypes.join(','));
+  if (state.minLetterCount !== undefined)
+    out.set(`${prefix}minLetterCount`, String(state.minLetterCount));
+  if (state.lastContacted) out.set(`${prefix}lastContacted`, state.lastContacted);
+  if (state.lineResponse) out.set(`${prefix}lineResponse`, state.lineResponse);
+  if (state.minBrokenPromise !== undefined)
+    out.set(`${prefix}minBrokenPromise`, String(state.minBrokenPromise));
+  if (state.hasActivePromise !== undefined)
+    out.set(`${prefix}hasActivePromise`, String(state.hasActivePromise));
+  if (state.mdmState) out.set(`${prefix}mdmState`, state.mdmState);
+  if (state.showSkipTracing) out.set(`${prefix}showSkipTracing`, 'true');
+  if (state.slipReviewPending) out.set(`${prefix}slipReviewPending`, 'true');
+  return out;
+}
+
+/**
+ * Per-tab filter state hook. Each tab (queue/follow-up/promise/all) holds its
+ * own filter state in URL params, namespaced with a 2-char prefix so switching
+ * tabs doesn't leak filter state between them.
+ *
+ * Backward-compatible: calling without a tab arg defaults to 'queue' to keep
+ * existing consumers working during the refactor.
+ */
+export function useQueueFilter(
+  tab: QueueFilterTab = 'queue',
+): [QueueFilterState, (patch: Partial<QueueFilterState>) => void, () => void] {
   const [params, setParams] = useSearchParams();
+  const prefix = TAB_PREFIX[tab];
 
   const state: QueueFilterState = useMemo(() => {
-    const assignedRaw = params.get('assigned');
-    const minOut = numParam(params.get('minOutstanding'));
-    const maxOut = numParam(params.get('maxOutstanding'));
-    const minLetter = numParam(params.get('minLetterCount'));
-    const minBroken = numParam(params.get('minBrokenPromise'));
+    const assignedRaw = params.get(`${prefix}assigned`);
+    const minOut = numParam(params.get(`${prefix}minOutstanding`));
+    const maxOut = numParam(params.get(`${prefix}maxOutstanding`));
+    const minLetter = numParam(params.get(`${prefix}minLetterCount`));
+    const minBroken = numParam(params.get(`${prefix}minBrokenPromise`));
     return {
       assigned: assignedRaw ?? undefined,
-      branchId: params.get('branchId') ?? undefined,
-      overdueBuckets: (params.get('buckets')?.split(',').filter(Boolean) as OverdueBucketOption[]) ??
+      branchId: params.get(`${prefix}branchId`) ?? undefined,
+      overdueBuckets:
+        (params.get(`${prefix}buckets`)?.split(',').filter(Boolean) as OverdueBucketOption[]) ??
         undefined,
       minOutstanding: minOut,
       maxOutstanding: maxOut,
-      contractStatuses: params.get('statuses')?.split(',').filter(Boolean),
-      productTypes: params.get('products')?.split(',').filter(Boolean),
+      contractStatuses: params.get(`${prefix}statuses`)?.split(',').filter(Boolean),
+      productTypes: params.get(`${prefix}products`)?.split(',').filter(Boolean),
       minLetterCount: minLetter,
-      lastContacted: (params.get('lastContacted') as LastContactedOption | null) ?? undefined,
-      lineResponse: (params.get('lineResponse') as LineResponseOption | null) ?? undefined,
+      lastContacted:
+        (params.get(`${prefix}lastContacted`) as LastContactedOption | null) ?? undefined,
+      lineResponse:
+        (params.get(`${prefix}lineResponse`) as LineResponseOption | null) ?? undefined,
       minBrokenPromise: minBroken,
-      hasActivePromise: boolParam(params.get('hasActivePromise')),
-      mdmState: (params.get('mdmState') as MdmStateOption | null) ?? undefined,
-      showSkipTracing: params.get('showSkipTracing') === 'true' || undefined,
-      slipReviewPending: params.get('slipReviewPending') === 'true' || undefined,
+      hasActivePromise: boolParam(params.get(`${prefix}hasActivePromise`)),
+      mdmState: (params.get(`${prefix}mdmState`) as MdmStateOption | null) ?? undefined,
+      showSkipTracing: params.get(`${prefix}showSkipTracing`) === 'true' || undefined,
+      slipReviewPending: params.get(`${prefix}slipReviewPending`) === 'true' || undefined,
     };
-  }, [params]);
+  }, [params, prefix]);
 
   const setFilter = useCallback(
     (patch: Partial<QueueFilterState>) => {
@@ -123,18 +163,19 @@ export function useQueueFilter(): [
           delete next[k];
         }
       });
-      setParams(serialize(next, params), { replace: true });
+      setParams(serialize(next, params, prefix), { replace: true });
     },
-    [state, params, setParams],
+    [state, params, setParams, prefix],
   );
 
   const reset = useCallback(() => {
     const next = new URLSearchParams();
+    const ownKeys = namespacedKeys(prefix);
     params.forEach((value: string, key: string) => {
-      if (!FILTER_KEYS.has(key)) next.set(key, value);
+      if (!ownKeys.has(key)) next.set(key, value);
     });
     setParams(next, { replace: true });
-  }, [params, setParams]);
+  }, [params, setParams, prefix]);
 
   return [state, setFilter, reset];
 }

--- a/apps/web/src/pages/CollectionsPage/hooks/useUnionSearch.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useUnionSearch.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface SearchResult {
+  contracts: {
+    id: string;
+    contractNumber: string;
+    customerName: string;
+    status: string;
+  }[];
+  customers: {
+    id: string;
+    name: string;
+    phone: string | null;
+  }[];
+  imeis: {
+    contractId: string;
+    imei: string;
+    contractNumber: string;
+    customerName: string;
+  }[];
+  letterTrackings: {
+    letterId: string;
+    trackingNumber: string;
+    contractId: string;
+    contractNumber: string;
+  }[];
+}
+
+/**
+ * Debounced union search across contracts, customers, letter tracking
+ * numbers, and IMEIs. Returns grouped results for CommandPalette.
+ *
+ * The caller is expected to debounce `q` (see `useDebounce` in
+ * CommandPalette). Server enforces min 2 chars — we mirror that with
+ * `enabled` to avoid firing requests for single-char queries.
+ */
+export function useUnionSearch(q: string) {
+  return useQuery<SearchResult>({
+    queryKey: ['search-union', q],
+    queryFn: async () => {
+      const res = await api.get<SearchResult>('/search/union', {
+        params: { q },
+      });
+      return res.data;
+    },
+    enabled: q.trim().length >= 2,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -18,6 +18,26 @@ import type { ContractRow } from './types';
 
 export type CollectionsTabKey = 'today' | 'followup' | 'promise' | 'approval' | 'all' | 'analytics';
 
+/**
+ * Role-based access for tabs. Empty array = all authenticated roles.
+ * Previously SALES/ACCOUNTANT could click Approval/Analytics and get silent
+ * 403s — now gated at the tab bar so the tab never renders.
+ */
+const TAB_ROLE_ACCESS: Record<CollectionsTabKey, string[]> = {
+  today: [],
+  followup: [],
+  promise: [],
+  all: [],
+  approval: ['OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER'],
+  analytics: ['OWNER', 'FINANCE_MANAGER'],
+};
+
+function canAccessTab(key: CollectionsTabKey, role: string | undefined): boolean {
+  const allowed = TAB_ROLE_ACCESS[key];
+  if (!allowed || allowed.length === 0) return true;
+  return !!role && allowed.includes(role);
+}
+
 export default function CollectionsPage() {
   useDocumentTitle('ติดตามหนี้');
   const { user } = useAuth();
@@ -28,10 +48,15 @@ export default function CollectionsPage() {
   const [panelContract, setPanelContract] = useState<ContractRow | null>(null);
   const [lineDialogContract, setLineDialogContract] = useState<ContractRow | null>(null);
 
-  const canSeeApproval = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
+  const canSeeApproval = canAccessTab('approval', user?.role);
+  const canSeeAnalytics = canAccessTab('analytics', user?.role);
   const showBranchFilter = user?.role === 'OWNER' || user?.role === 'FINANCE_MANAGER';
 
-  const showFilters = activeTab === 'today' || activeTab === 'followup' || activeTab === 'promise';
+  // Safety net: if the active tab is role-gated and user lost access mid-session,
+  // fall back to the default tab instead of rendering nothing.
+  const effectiveTab: CollectionsTabKey = canAccessTab(activeTab, user?.role) ? activeTab : 'today';
+
+  const showFilters = effectiveTab === 'today' || effectiveTab === 'followup' || effectiveTab === 'promise';
 
   const openContactDialog = (c: ContractRow) => setDialogContract(c);
   const openPanel = (c: ContractRow) => setPanelContract(c);
@@ -44,13 +69,14 @@ export default function CollectionsPage() {
       <CollectionsKpiStrip />
 
       <CollectionsTabs
-        active={activeTab}
+        active={effectiveTab}
         onChange={(key) => {
           setActiveTab(key);
           setSearch('');
           setBranchId('');
         }}
         canSeeApproval={canSeeApproval}
+        canSeeAnalytics={canSeeAnalytics}
       />
 
       {showFilters && (
@@ -63,7 +89,7 @@ export default function CollectionsPage() {
         />
       )}
 
-      {activeTab === 'today' && (
+      {effectiveTab === 'today' && (
         <QueueTab
           search={search}
           branchId={branchId}
@@ -73,7 +99,7 @@ export default function CollectionsPage() {
         />
       )}
 
-      {activeTab === 'followup' && (
+      {effectiveTab === 'followup' && (
         <FollowUpTab
           search={search}
           branchId={branchId}
@@ -83,7 +109,7 @@ export default function CollectionsPage() {
         />
       )}
 
-      {activeTab === 'promise' && (
+      {effectiveTab === 'promise' && (
         <PromiseTab
           search={search}
           branchId={branchId}
@@ -93,11 +119,11 @@ export default function CollectionsPage() {
         />
       )}
 
-      {activeTab === 'approval' && canSeeApproval && <ApprovalTab />}
+      {effectiveTab === 'approval' && canSeeApproval && <ApprovalTab />}
 
-      {activeTab === 'all' && <AllTab />}
+      {effectiveTab === 'all' && <AllTab />}
 
-      {activeTab === 'analytics' && canSeeApproval && <AnalyticsTab />}
+      {effectiveTab === 'analytics' && canSeeAnalytics && <AnalyticsTab />}
 
       <ContactLogDialog
         open={!!dialogContract}

--- a/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -11,8 +11,10 @@ import {
   CartesianGrid,
   Legend,
 } from 'recharts';
+import { subDays, startOfDay, endOfDay } from 'date-fns';
 import { Card, CardContent } from '@/components/ui/card';
 import QueryBoundary from '@/components/QueryBoundary';
+import { DateRangePicker, type DateRangeValue } from '@/components/ui/DateRangePicker';
 import { useCollectionsAnalytics } from '../hooks/useCollectionsAnalytics';
 
 // Chart colors: pragmatic hex approximations of the theme palette.
@@ -49,29 +51,29 @@ function pivotLetters(
   });
 }
 
+// Map custom date range -> backend range enum (P0: avoid backend change).
+// Rule: diff days ≤ 45 → '30d', otherwise → '90d'.
+function mapRangeToEnum(value: DateRangeValue): '30d' | '90d' {
+  if (!value.from || !value.to) return '30d';
+  const days = Math.round((value.to.getTime() - value.from.getTime()) / 86400000);
+  return days <= 45 ? '30d' : '90d';
+}
+
+function defaultRange(): DateRangeValue {
+  const now = new Date();
+  return { from: startOfDay(subDays(now, 29)), to: endOfDay(now) };
+}
+
 export default function AnalyticsTab() {
-  const [range, setRange] = useState<'30d' | '90d'>('30d');
+  const [dateRange, setDateRange] = useState<DateRangeValue>(defaultRange);
+  const range = useMemo(() => mapRangeToEnum(dateRange), [dateRange]);
   const { data, isLoading, isError, error, refetch } = useCollectionsAnalytics(range);
 
   return (
     <div>
-      {/* Range toggle */}
+      {/* Date range picker */}
       <div className="flex justify-end mb-4">
-        <div className="inline-flex rounded-lg border border-input overflow-hidden">
-          {(['30d', '90d'] as const).map((r) => (
-            <button
-              key={r}
-              onClick={() => setRange(r)}
-              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                range === r
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-background text-muted-foreground hover:bg-muted'
-              }`}
-            >
-              {r === '30d' ? '30 วัน' : '90 วัน'}
-            </button>
-          ))}
-        </div>
+        <DateRangePicker value={dateRange} onChange={setDateRange} />
       </div>
 
       <QueryBoundary

--- a/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/ApprovalTab.tsx
@@ -100,7 +100,9 @@ export default function ApprovalTab() {
                 <MdmRow
                   key={item.id}
                   item={item}
-                  onApprove={(requestId) => approveMdm.mutate(requestId)}
+                  onApprove={(requestId, opts) =>
+                    approveMdm.mutate({ id: requestId, includeWallpaper: opts?.includeWallpaper })
+                  }
                   onReject={(requestId, reason) => rejectMdm.mutate({ requestId, reason })}
                   approvePending={approveMdm.isPending}
                   rejectPending={rejectMdm.isPending}

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -40,7 +40,7 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
   const [filterOpen, setFilterOpen] = useState(false);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
-  const [filter, setFilter, resetFilter] = useQueueFilter();
+  const [filter, setFilter, resetFilter] = useQueueFilter('follow-up');
 
   const q = useCollectionsQueue({
     tab: 'followup',

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -4,6 +4,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
 import BulkActionBar from '../components/BulkActionBar';
+import TruncatedBanner from '../components/TruncatedBanner';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
 import type { ContractRow } from '../types';
@@ -49,6 +50,10 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
 
   const total = q.data?.total ?? 0;
   const rows = q.data?.data ?? [];
+  const truncated = q.data?.truncated ?? false;
+
+  // Task 10 will wire this to a real filter drawer; stub for now.
+  const openFilter = () => {};
 
   // Client-side search filter
   const searchFiltered = debouncedSearch
@@ -81,6 +86,7 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
         </div>
       }
     >
+      {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
       {/* Skip-tracing toggle */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex-1" />

--- a/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/FollowUpTab.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
-import { Search } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
 import BulkActionBar from '../components/BulkActionBar';
 import TruncatedBanner from '../components/TruncatedBanner';
+import FilterChipsBar from '../components/FilterChipsBar';
+import FilterDrawer from '../components/FilterDrawer';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
+import { useQueueFilter } from '../hooks/useQueueFilter';
 import type { ContractRow } from '../types';
 
 const LIMIT = 50;
@@ -35,9 +37,10 @@ interface Props {
 
 export default function FollowUpTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
   const [page, setPage] = useState(1);
-  const [showSkipTracing, setShowSkipTracing] = useState(false);
+  const [filterOpen, setFilterOpen] = useState(false);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
+  const [filter, setFilter, resetFilter] = useQueueFilter();
 
   const q = useCollectionsQueue({
     tab: 'followup',
@@ -46,31 +49,15 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
     page,
     limit: LIMIT,
     enabled: true,
+    filter,
   });
 
   const total = q.data?.total ?? 0;
   const rows = q.data?.data ?? [];
   const truncated = q.data?.truncated ?? false;
 
-  // Task 10 will wire this to a real filter drawer; stub for now.
-  const openFilter = () => {};
-
-  // Client-side search filter
-  const searchFiltered = debouncedSearch
-    ? rows.filter((r) => {
-        const term = debouncedSearch.toLowerCase();
-        return (
-          r.customer.name.toLowerCase().includes(term) ||
-          r.contractNumber.toLowerCase().includes(term) ||
-          r.customer.phone.toLowerCase().includes(term)
-        );
-      })
-    : rows;
-
-  // Skip-tracing filter applied on top of search filter
-  const filtered = showSkipTracing
-    ? searchFiltered.filter((c) => c.needsSkipTracing)
-    : searchFiltered;
+  const openFilter = () => setFilterOpen(true);
+  const filtered = rows;
 
   return (
     <QueryBoundary
@@ -86,27 +73,18 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
         </div>
       }
     >
+      <FilterChipsBar
+        filter={filter}
+        setFilter={setFilter}
+        reset={resetFilter}
+        onOpenFilter={openFilter}
+        resultCount={rows.length}
+        totalCount={total}
+      />
       {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
-      {/* Skip-tracing toggle */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex-1" />
-        <button
-          onClick={() => setShowSkipTracing((v) => !v)}
-          className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border transition-colors ${
-            showSkipTracing
-              ? 'border-destructive/30 bg-destructive/5 text-destructive'
-              : 'border-input hover:bg-muted text-muted-foreground'
-          }`}
-        >
-          <Search className="size-3.5" />
-          {showSkipTracing
-            ? `ต้องหาเบอร์ใหม่ (${filtered.length})`
-            : 'กรองที่ต้องหาเบอร์ใหม่'}
-        </button>
-      </div>
 
       {filtered.length === 0 ? (
-        showSkipTracing ? (
+        filter.showSkipTracing ? (
           <div className="rounded-xl border border-dashed border-border p-10 text-center">
             <div className="text-sm font-medium text-muted-foreground leading-snug">
               ไม่มีใครต้องหาเบอร์ใหม่
@@ -128,7 +106,7 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
       ) : (
         <>
           {/* Context banner */}
-          {!showSkipTracing && (
+          {!filter.showSkipTracing && (
           <div className="mb-4 rounded-lg bg-warning/5 border border-warning/20 p-3 text-xs text-warning leading-snug">
             <strong>ตามต่อ:</strong>{' '}
             ลูกค้าที่เคยโทรไปแล้วแต่ไม่รับ — ถ้าไม่รับครั้งต่อไปครบ 3 ครั้ง
@@ -189,6 +167,20 @@ export default function FollowUpTab({ search, branchId, onLogContact, onOpen360,
         </>
       )}
       <BulkActionBar selectedIds={sel.selectedIds} onClear={sel.clear} />
+      <FilterDrawer
+        open={filterOpen}
+        onOpenChange={setFilterOpen}
+        filter={filter}
+        onApply={(next) => {
+          setFilter(next);
+          setPage(1);
+        }}
+        onReset={() => {
+          resetFilter();
+          setPage(1);
+        }}
+        liveCount={total}
+      />
     </QueryBoundary>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Calendar } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
@@ -98,7 +98,7 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
   const [filterOpen, setFilterOpen] = useState(false);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
-  const [filter, setFilter, resetFilter] = useQueueFilter();
+  const [filter, setFilter, resetFilter] = useQueueFilter('promise');
 
   const q = useCollectionsQueue({
     tab: 'promise',
@@ -144,7 +144,7 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
       {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
       {isEmpty ? (
         <div className="rounded-xl border border-dashed border-border p-10 text-center">
-          <div className="text-4xl mb-3">📅</div>
+          <Calendar className="mx-auto mb-3 size-10 text-muted-foreground" />
           <div className="text-sm font-medium text-foreground leading-snug">
             ไม่มีนัดชำระในช่วงนี้
           </div>

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -4,6 +4,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
 import BulkActionBar from '../components/BulkActionBar';
+import TruncatedBanner from '../components/TruncatedBanner';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
 import type { ContractRow } from '../types';
@@ -105,6 +106,10 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
 
   const total = q.data?.total ?? 0;
   const rows = q.data?.data ?? [];
+  const truncated = q.data?.truncated ?? false;
+
+  // Task 10 will wire this to a real filter drawer; stub for now.
+  const openFilter = () => {};
 
   // Client-side search filter
   const filtered = debouncedSearch
@@ -135,6 +140,7 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
         </div>
       }
     >
+      {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
       {isEmpty ? (
         <div className="rounded-xl border border-dashed border-border p-10 text-center">
           <div className="text-4xl mb-3">📅</div>

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -5,8 +5,11 @@ import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
 import BulkActionBar from '../components/BulkActionBar';
 import TruncatedBanner from '../components/TruncatedBanner';
+import FilterChipsBar from '../components/FilterChipsBar';
+import FilterDrawer from '../components/FilterDrawer';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
+import { useQueueFilter } from '../hooks/useQueueFilter';
 import type { ContractRow } from '../types';
 
 const LIMIT = 50;
@@ -92,8 +95,10 @@ interface Props {
 
 export default function PromiseTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
   const [page, setPage] = useState(1);
+  const [filterOpen, setFilterOpen] = useState(false);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
+  const [filter, setFilter, resetFilter] = useQueueFilter();
 
   const q = useCollectionsQueue({
     tab: 'promise',
@@ -102,29 +107,17 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
     page,
     limit: LIMIT,
     enabled: true,
+    filter,
   });
 
   const total = q.data?.total ?? 0;
   const rows = q.data?.data ?? [];
   const truncated = q.data?.truncated ?? false;
 
-  // Task 10 will wire this to a real filter drawer; stub for now.
-  const openFilter = () => {};
+  const openFilter = () => setFilterOpen(true);
 
-  // Client-side search filter
-  const filtered = debouncedSearch
-    ? rows.filter((r) => {
-        const term = debouncedSearch.toLowerCase();
-        return (
-          r.customer.name.toLowerCase().includes(term) ||
-          r.contractNumber.toLowerCase().includes(term) ||
-          r.customer.phone.toLowerCase().includes(term)
-        );
-      })
-    : rows;
-
-  const groups = groupRows(filtered);
-  const isEmpty = filtered.length === 0;
+  const groups = groupRows(rows);
+  const isEmpty = rows.length === 0;
 
   return (
     <QueryBoundary
@@ -140,6 +133,14 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
         </div>
       }
     >
+      <FilterChipsBar
+        filter={filter}
+        setFilter={setFilter}
+        reset={resetFilter}
+        onOpenFilter={openFilter}
+        resultCount={rows.length}
+        totalCount={total}
+      />
       {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
       {isEmpty ? (
         <div className="rounded-xl border border-dashed border-border p-10 text-center">
@@ -249,6 +250,20 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
         </>
       )}
       <BulkActionBar selectedIds={sel.selectedIds} onClear={sel.clear} />
+      <FilterDrawer
+        open={filterOpen}
+        onOpenChange={setFilterOpen}
+        filter={filter}
+        onApply={(next) => {
+          setFilter(next);
+          setPage(1);
+        }}
+        onReset={() => {
+          resetFilter();
+          setPage(1);
+        }}
+        liveCount={total}
+      />
     </QueryBoundary>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -4,8 +4,11 @@ import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
 import BulkActionBar from '../components/BulkActionBar';
 import TruncatedBanner from '../components/TruncatedBanner';
+import FilterChipsBar from '../components/FilterChipsBar';
+import FilterDrawer from '../components/FilterDrawer';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
+import { useQueueFilter } from '../hooks/useQueueFilter';
 import type { ContractRow } from '../types';
 
 const LIMIT = 50;
@@ -34,8 +37,10 @@ interface Props {
 
 export default function QueueTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
   const [page, setPage] = useState(1);
+  const [filterOpen, setFilterOpen] = useState(false);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
+  const [filter, setFilter, resetFilter] = useQueueFilter();
 
   const q = useCollectionsQueue({
     tab: 'today',
@@ -44,26 +49,14 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
     page,
     limit: LIMIT,
     enabled: true,
+    filter,
   });
 
   const total = q.data?.total ?? 0;
   const rows = q.data?.data ?? [];
   const truncated = q.data?.truncated ?? false;
 
-  // Task 10 will wire this to a real filter drawer; stub for now.
-  const openFilter = () => {};
-
-  // Client-side search filter
-  const filtered = debouncedSearch
-    ? rows.filter((r) => {
-        const term = debouncedSearch.toLowerCase();
-        return (
-          r.customer.name.toLowerCase().includes(term) ||
-          r.contractNumber.toLowerCase().includes(term) ||
-          r.customer.phone.toLowerCase().includes(term)
-        );
-      })
-    : rows;
+  const openFilter = () => setFilterOpen(true);
 
   return (
     <QueryBoundary
@@ -79,8 +72,16 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
         </div>
       }
     >
+      <FilterChipsBar
+        filter={filter}
+        setFilter={setFilter}
+        reset={resetFilter}
+        onOpenFilter={openFilter}
+        resultCount={rows.length}
+        totalCount={total}
+      />
       {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
-      {filtered.length === 0 ? (
+      {rows.length === 0 ? (
         <div className="rounded-xl border border-dashed border-success/30 bg-success/5 p-10 text-center">
           <div className="text-4xl mb-3">🎉</div>
           <div className="text-sm font-medium text-success leading-snug">
@@ -93,7 +94,7 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
       ) : (
         <>
           <div className="space-y-2">
-            {filtered.map((row) => (
+            {rows.map((row) => (
               <ContractCard
                 key={row.id}
                 contract={row}
@@ -132,6 +133,20 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
         </>
       )}
       <BulkActionBar selectedIds={sel.selectedIds} onClear={sel.clear} />
+      <FilterDrawer
+        open={filterOpen}
+        onOpenChange={setFilterOpen}
+        filter={filter}
+        onApply={(next) => {
+          setFilter(next);
+          setPage(1);
+        }}
+        onReset={() => {
+          resetFilter();
+          setPage(1);
+        }}
+        liveCount={total}
+      />
     </QueryBoundary>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -3,6 +3,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
 import BulkActionBar from '../components/BulkActionBar';
+import TruncatedBanner from '../components/TruncatedBanner';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
 import type { ContractRow } from '../types';
@@ -47,6 +48,10 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
 
   const total = q.data?.total ?? 0;
   const rows = q.data?.data ?? [];
+  const truncated = q.data?.truncated ?? false;
+
+  // Task 10 will wire this to a real filter drawer; stub for now.
+  const openFilter = () => {};
 
   // Client-side search filter
   const filtered = debouncedSearch
@@ -74,6 +79,7 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
         </div>
       }
     >
+      {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
       {filtered.length === 0 ? (
         <div className="rounded-xl border border-dashed border-success/30 bg-success/5 p-10 text-center">
           <div className="text-4xl mb-3">🎉</div>

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { PartyPopper } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import QueryBoundary from '@/components/QueryBoundary';
 import ContractCard from '../components/ContractCard';
@@ -40,7 +41,7 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
   const [filterOpen, setFilterOpen] = useState(false);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
-  const [filter, setFilter, resetFilter] = useQueueFilter();
+  const [filter, setFilter, resetFilter] = useQueueFilter('queue');
 
   const q = useCollectionsQueue({
     tab: 'today',
@@ -83,7 +84,7 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
       {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
       {rows.length === 0 ? (
         <div className="rounded-xl border border-dashed border-success/30 bg-success/5 p-10 text-center">
-          <div className="text-4xl mb-3">🎉</div>
+          <PartyPopper className="mx-auto mb-3 size-10 text-success" />
           <div className="text-sm font-medium text-success leading-snug">
             ไม่มีคิวติดตามวันนี้
           </div>

--- a/apps/web/src/pages/CollectionsPage/types.ts
+++ b/apps/web/src/pages/CollectionsPage/types.ts
@@ -38,6 +38,12 @@ export interface ContractRow {
   settlementDate: string | null;
   needsSkipTracing: boolean;
   deviceLocked: boolean;
+  // Card indicator fields (enriched server-side)
+  lastContactedAt: string | null;
+  brokenPromiseCount: number;
+  mdmState: 'NONE' | 'PENDING' | 'LOCKED' | 'UNLOCKED';
+  relatedContractsCount: number;
+  lastChannel: 'LINE' | 'SMS' | 'CALL' | 'LETTER' | null;
 }
 
 export type CallResult =

--- a/apps/web/src/pages/CollectionsPage/types.ts
+++ b/apps/web/src/pages/CollectionsPage/types.ts
@@ -13,6 +13,12 @@ export interface PendingMdmRequest {
   includeWallpaper: boolean;
   reason: string;
   proposedAt: string;
+  /**
+   * Optional — when present and set to EXECUTED_MANUAL / EXECUTED_API, the
+   * approval row renders an Unlock button (OWNER only). Absent for raw
+   * PENDING requests (which is the common case in the approval queue).
+   */
+  status?: 'PENDING' | 'EXECUTED_MANUAL' | 'EXECUTED_API' | 'REJECTED' | 'UNLOCKED' | 'LOCKED';
   contract: {
     id: string;
     contractNumber: string;

--- a/apps/web/src/pages/CollectionsPage/types.ts
+++ b/apps/web/src/pages/CollectionsPage/types.ts
@@ -18,7 +18,7 @@ export interface PendingMdmRequest {
    * approval row renders an Unlock button (OWNER only). Absent for raw
    * PENDING requests (which is the common case in the approval queue).
    */
-  status?: 'PENDING' | 'EXECUTED_MANUAL' | 'EXECUTED_API' | 'REJECTED' | 'UNLOCKED' | 'LOCKED';
+  status?: 'PENDING' | 'APPROVED' | 'EXECUTED_MANUAL' | 'EXECUTED_API' | 'FAILED' | 'REJECTED' | 'UNLOCKED';
   contract: {
     id: string;
     contractNumber: string;
@@ -50,6 +50,8 @@ export interface ContractRow {
   mdmState: 'NONE' | 'PENDING' | 'LOCKED' | 'UNLOCKED';
   relatedContractsCount: number;
   lastChannel: 'LINE' | 'SMS' | 'CALL' | 'LETTER' | null;
+  letterCount: number;
+  slipReviewPending: boolean;
 }
 
 export type CallResult =

--- a/apps/web/src/pages/CollectionsPage/utils/cardIndicators.ts
+++ b/apps/web/src/pages/CollectionsPage/utils/cardIndicators.ts
@@ -1,0 +1,37 @@
+export type AgingBucket = '1-7' | '8-30' | '31-60' | '61-90' | '90+';
+
+export function agingBucket(daysOverdue: number): AgingBucket {
+  if (daysOverdue <= 7) return '1-7';
+  if (daysOverdue <= 30) return '8-30';
+  if (daysOverdue <= 60) return '31-60';
+  if (daysOverdue <= 90) return '61-90';
+  return '90+';
+}
+
+export function agingColor(bucket: AgingBucket): string {
+  switch (bucket) {
+    case '1-7':
+      return 'bg-emerald-500/15 text-emerald-700 border-emerald-500/30';
+    case '8-30':
+      return 'bg-amber-500/15 text-amber-700 border-amber-500/30';
+    case '31-60':
+      return 'bg-orange-500/15 text-orange-700 border-orange-500/30';
+    case '61-90':
+      return 'bg-red-500/15 text-red-700 border-red-500/30';
+    case '90+':
+      return 'bg-purple-500/15 text-purple-700 border-purple-500/30';
+  }
+}
+
+export function formatRelativeTime(date: Date | string | null): string {
+  if (!date) return 'ไม่เคย';
+  const ts = typeof date === 'string' ? new Date(date) : date;
+  const diffMs = Date.now() - ts.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'เมื่อสักครู่';
+  if (diffMin < 60) return `${diffMin} นาที`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr} ชม.`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay} วัน`;
+}


### PR DESCRIPTION
## Summary
9 P0 features จาก `docs/superpowers/specs/2026-04-25-collections-ui-enhancements-design.md`:

- **A1** ⌘K command palette (union search: contracts/customers/phone/IMEI/tracking#)
- **A2** Queue filter drawer + chips bar + URL sync (10+ filter fields)
- **A6** DateRangePicker shared component (Thai presets + พ.ศ.)
- **B1** ContractCard indicator chips (aging/last-contact/broken-promise/channel/MDM/related)
- **B7** Truncated banner สำหรับ queue >500 rows
- **D1** MDM unlock button (OWNER + FINANCE_MANAGER)
- **D2** Wallpaper attach on MDM approve
- **D4** Letter evidence thumbnail + mandatory verification
- **D9** ApprovalTab role gate (SALES/ACCOUNTANT hidden)

Plus post-review fixes: SALES customer search branch-scoped, `PendingMdmRequest.status` enum cleanup, `minLetterCount`/`slipReviewPending` implementation, tab-namespaced URL keys, emoji→lucide icons.

## Test plan
- [ ] Tab visibility per role (OWNER all 6 / FINANCE_MANAGER same / BRANCH_MANAGER: no analytics / SALES+ACCOUNTANT: no approval+analytics)
- [ ] Queue filter combinations (outstanding range slider, overdue buckets multi, brokenPromise, MDM state, slipReviewPending, letter count)
- [ ] URL filter round-trip survives refresh
- [ ] ContractCard shows all 8 indicator types correctly
- [ ] MDM unlock button OWNER + FINANCE_MANAGER only
- [ ] Wallpaper checkbox pre-checked when URL set in DunningSettings
- [ ] Letter dispatch disabled until verification checkbox ticked
- [ ] ⌘K palette opens, debounce 200ms, recent searches persist
- [ ] Truncated banner shows when queue > 500
- [ ] SALES command palette cannot find cross-branch customers

## Tests run
- API: 34/34 queue.service.spec (10 existing + 10 enrichment + 10 filter + 4 minLetterCount/slipReviewPending)
- Web: 15/15 CollectionsPage (tab visibility + DateRangePicker)
- Type check: API OK, Web OK

## Post-ship follow-up (deferred)
- Hardcoded Tailwind colors → semantic tokens (W2)
- \`any[]\` type in enrichRows (W3)
- \`as any\` in FilterDrawer (W6)
- lineResponse RESPONDED/IGNORED/BLOCKED filter (W8 — needs LINE delivery state schema)
- BRANCH_MANAGER backend policy alignment w/ UI (W1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)