### PR TITLE
feat(collections): P1 UI enhancements

### DIFF
--- a/apps/api/prisma/migrations/20260603000000_add_p1_schema_snooze_snapshot_preset_callresult/migration.sql
+++ b/apps/api/prisma/migrations/20260603000000_add_p1_schema_snooze_snapshot_preset_callresult/migration.sql
@@ -1,0 +1,88 @@
+-- ============================================================
+-- P1 Collections UI Enhancements (2026-04-25)
+-- - ContractSnooze: per-user contract-card snooze
+-- - ContractDailySnapshot: immutable daily aging rollup (trend arrow + analytics)
+-- - FilterPreset: saved filter UI presets
+-- - CallLog enums: callResult + negotiationResult quick-tags
+-- ============================================================
+
+-- CreateEnum
+CREATE TYPE "FilterPresetScope" AS ENUM ('PRIVATE', 'SHARED_BRANCH', 'SHARED_ALL');
+
+-- CreateEnum
+CREATE TYPE "CallResult" AS ENUM ('ANSWERED', 'NO_ANSWER', 'BUSY', 'DEVICE_OFF', 'UNREACHABLE');
+
+-- CreateEnum
+CREATE TYPE "NegotiationResult" AS ENUM ('REQUESTED_EXTENSION', 'WILL_PAY', 'REFUSED', 'REQUESTED_RETURN', 'NEGOTIATING', 'NOT_APPLICABLE');
+
+-- AlterTable: extend CallLog with structured quick-tag enums
+ALTER TABLE "call_logs"
+  ADD COLUMN "call_result" "CallResult",
+  ADD COLUMN "negotiation_result" "NegotiationResult";
+
+-- CreateTable: per-user contract-card snooze
+CREATE TABLE "contract_snoozes" (
+    "id" TEXT NOT NULL,
+    "contract_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "snoozed_until" TIMESTAMP(3) NOT NULL,
+    "reason" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "contract_snoozes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: immutable daily snapshot of overdue state
+CREATE TABLE "contract_daily_snapshots" (
+    "id" TEXT NOT NULL,
+    "contract_id" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "days_overdue" INTEGER NOT NULL,
+    "outstanding" DECIMAL(12,2) NOT NULL,
+    "status" "ContractStatus" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "contract_daily_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: saved filter UI presets
+CREATE TABLE "filter_presets" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "owner_user_id" TEXT NOT NULL,
+    "scope" "FilterPresetScope" NOT NULL DEFAULT 'PRIVATE',
+    "branch_id" TEXT,
+    "page" TEXT NOT NULL,
+    "filter_json" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "filter_presets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "contract_snoozes_user_id_snoozed_until_idx" ON "contract_snoozes"("user_id", "snoozed_until");
+CREATE INDEX "contract_snoozes_contract_id_deleted_at_idx" ON "contract_snoozes"("contract_id", "deleted_at");
+
+-- CreateIndex
+CREATE INDEX "contract_daily_snapshots_date_idx" ON "contract_daily_snapshots"("date");
+CREATE INDEX "contract_daily_snapshots_contract_id_date_idx" ON "contract_daily_snapshots"("contract_id", "date" DESC);
+CREATE UNIQUE INDEX "contract_daily_snapshots_contract_id_date_key" ON "contract_daily_snapshots"("contract_id", "date");
+
+-- CreateIndex
+CREATE INDEX "filter_presets_owner_user_id_page_idx" ON "filter_presets"("owner_user_id", "page");
+CREATE INDEX "filter_presets_scope_branch_id_idx" ON "filter_presets"("scope", "branch_id");
+
+-- AddForeignKey
+ALTER TABLE "contract_snoozes" ADD CONSTRAINT "contract_snoozes_contract_id_fkey" FOREIGN KEY ("contract_id") REFERENCES "contracts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "contract_snoozes" ADD CONSTRAINT "contract_snoozes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contract_daily_snapshots" ADD CONSTRAINT "contract_daily_snapshots_contract_id_fkey" FOREIGN KEY ("contract_id") REFERENCES "contracts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "filter_presets" ADD CONSTRAINT "filter_presets_owner_user_id_fkey" FOREIGN KEY ("owner_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "filter_presets" ADD CONSTRAINT "filter_presets_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260604000000_add_promise_due_reminder_event_trigger/migration.sql
+++ b/apps/api/prisma/migrations/20260604000000_add_promise_due_reminder_event_trigger/migration.sql
@@ -1,0 +1,9 @@
+-- ============================================================
+-- P1 Collections UI — Task 14: Broken-Promise Auto-Suggest
+-- Adds PROMISE_DUE_REMINDER to DunningEventTrigger enum so the
+-- daily 09:00 Bangkok cron can stamp DunningActions for promises
+-- due TODAY (not yet broken). The PromiseTab banner reads these
+-- to prompt collectors to bulk-send a LINE reminder.
+-- ============================================================
+
+ALTER TYPE "DunningEventTrigger" ADD VALUE IF NOT EXISTS 'PROMISE_DUE_REMINDER';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -97,6 +97,11 @@ enum DunningEventTrigger {
   BROKEN_PROMISE
   LETTER_DISPATCHED
   CONTRACT_TERMINATED
+  /// P1 Task 14: daily auto-suggest for promises due TODAY (not yet broken).
+  /// Cron creates DunningAction with this trigger via a system rule (channel
+  /// INTERNAL_ALERT, autoExecute=false) — banner reads them to prompt the
+  /// collector to bulk-send a LINE reminder.
+  PROMISE_DUE_REMINDER
 }
 
 enum PlanType {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -41,6 +41,31 @@ enum ContractStatus {
   CLOSED_BAD_DEBT
 }
 
+// P1 Collections UI — Saved Filter Presets (Task 3)
+enum FilterPresetScope {
+  PRIVATE
+  SHARED_BRANCH
+  SHARED_ALL
+}
+
+// P1 Collections UI — Call Result Quick-Tags (Task 12)
+enum CallResult {
+  ANSWERED
+  NO_ANSWER
+  BUSY
+  DEVICE_OFF
+  UNREACHABLE
+}
+
+enum NegotiationResult {
+  REQUESTED_EXTENSION
+  WILL_PAY
+  REFUSED
+  REQUESTED_RETURN
+  NEGOTIATING
+  NOT_APPLICABLE
+}
+
 // Dunning escalation stages for overdue debt collection
 enum TodoStatus {
   TODO
@@ -457,6 +482,9 @@ model Branch {
   crmLeads                 CrmLead[]
   receivableReconLogs      ReceivableReconLog[]      @relation("ReceivableReconBranch")
 
+  // P1 Collections UI — branch-scoped saved filter presets
+  filterPresets FilterPreset[]
+
   @@index([companyId])
   @@map("branches")
 }
@@ -585,6 +613,10 @@ model User {
   mdmProposed      MdmLockRequest[] @relation("MdmProposed")
   mdmApproved      MdmLockRequest[] @relation("MdmApproved")
   letterDispatched ContractLetter[] @relation("LetterDispatched")
+
+  // P1 Collections UI — per-user contract snoozes + saved filter presets
+  snoozes       ContractSnooze[]
+  filterPresets FilterPreset[]
 
   @@index([branchId])
   @@map("users")
@@ -861,6 +893,10 @@ model Contract {
 
   mdmLockRequests MdmLockRequest[]
   contractLetters ContractLetter[]
+
+  // P1 Collections UI — per-user snooze + daily snapshot rollups
+  snoozes        ContractSnooze[]
+  dailySnapshots ContractDailySnapshot[]
 
   @@index([customerId])
   @@index([branchId])
@@ -1677,6 +1713,11 @@ model CallLog {
   /// ใช้ร่วมกับ result='PROMISED' เพื่อนับ broken-promise count → ป้อนเข้า dunning
   /// escalation และ credit-check ถัดไป
   brokenAt        DateTime? @map("broken_at")
+  // P1 Collections — quick-tag enums captured from ContactLogDialog (Task 12).
+  // `result` (free-string above) remains the legacy field for back-compat;
+  // these add structured analytics dimensions.
+  callResult        CallResult?        @map("call_result")
+  negotiationResult NegotiationResult? @map("negotiation_result")
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
   deletedAt       DateTime? @map("deleted_at")
@@ -4908,4 +4949,70 @@ model AiSettings {
   updatedBy                     User?    @relation("AiSettingsUpdatedBy", fields: [updatedById], references: [id])
 
   @@map("ai_settings")
+}
+
+// ============================================================
+// P1 Collections UI Enhancements (2026-04-25)
+// ============================================================
+
+/// Per-user snooze for contract cards in the Collections queue.
+/// Soft-deleted on un-snooze (so we can audit "who snoozed how often").
+/// Active snooze = `deletedAt is null AND snoozedUntil > now()`.
+model ContractSnooze {
+  id           String    @id @default(uuid())
+  contractId   String    @map("contract_id")
+  contract     Contract  @relation(fields: [contractId], references: [id], onDelete: Cascade)
+  userId       String    @map("user_id")
+  user         User      @relation(fields: [userId], references: [id])
+  snoozedUntil DateTime  @map("snoozed_until")
+  reason       String?
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+  deletedAt    DateTime? @map("deleted_at")
+
+  @@index([userId, snoozedUntil])
+  @@index([contractId, deletedAt])
+  @@map("contract_snoozes")
+}
+
+/// Immutable daily snapshot of overdue contract state for trending arrows
+/// (B1 follow-up) and historical analytics. Pruned to 30 days by daily cron.
+/// updatedAt/deletedAt intentionally omitted — append-only by design.
+model ContractDailySnapshot {
+  id          String         @id @default(uuid())
+  contractId  String         @map("contract_id")
+  contract    Contract       @relation(fields: [contractId], references: [id], onDelete: Cascade)
+  date        DateTime       @db.Date
+  daysOverdue Int            @map("days_overdue")
+  outstanding Decimal        @db.Decimal(12, 2)
+  status      ContractStatus
+  createdAt   DateTime       @default(now()) @map("created_at")
+
+  @@unique([contractId, date])
+  @@index([date])
+  @@index([contractId, date(sort: Desc)])
+  @@map("contract_daily_snapshots")
+}
+
+/// User-saved filter UI preset for Collections-style queue pages.
+/// `scope` gates visibility (PRIVATE = owner-only, SHARED_BRANCH = same branch,
+/// SHARED_ALL = OWNER-only org-wide). `filterJson` holds the opaque page-shape
+/// filter state — semantics owned by the consuming page (`page` discriminator).
+model FilterPreset {
+  id          String            @id @default(uuid())
+  name        String
+  ownerUserId String            @map("owner_user_id")
+  owner       User              @relation(fields: [ownerUserId], references: [id])
+  scope       FilterPresetScope @default(PRIVATE)
+  branchId    String?           @map("branch_id")
+  branch      Branch?           @relation(fields: [branchId], references: [id])
+  page        String
+  filterJson  Json              @map("filter_json")
+  createdAt   DateTime          @default(now()) @map("created_at")
+  updatedAt   DateTime          @updatedAt @map("updated_at")
+  deletedAt   DateTime?         @map("deleted_at")
+
+  @@index([ownerUserId, page])
+  @@index([scope, branchId])
+  @@map("filter_presets")
 }

--- a/apps/api/prisma/seeds/collections-foundation.seed.ts
+++ b/apps/api/prisma/seeds/collections-foundation.seed.ts
@@ -32,7 +32,7 @@ export async function seedCollectionsFoundation(
     },
   });
 
-  // 8 event-triggered dunning rules (upsert by deterministic id for idempotency)
+  // 9 event-triggered dunning rules (upsert by deterministic id for idempotency)
   const eventRules: Array<{
     id: string;
     name: string;
@@ -44,8 +44,9 @@ export async function seedCollectionsFoundation(
       | 'DEVICE_UNLOCKED'
       | 'BROKEN_PROMISE'
       | 'LETTER_DISPATCHED'
-      | 'CONTRACT_TERMINATED';
-    channel: 'LINE' | 'SMS';
+      | 'CONTRACT_TERMINATED'
+      | 'PROMISE_DUE_REMINDER';
+    channel: 'LINE' | 'SMS' | 'INTERNAL_ALERT';
     messageTemplate: string;
     includePaymentLink: boolean;
     autoExecute: boolean;
@@ -137,6 +138,21 @@ export async function seedCollectionsFoundation(
       includePaymentLink: false,
       autoExecute: true,
       sortOrder: 107,
+    },
+    {
+      // P1 Task 14: stamped daily by BrokenPromiseReminderCron at 09:00 BKK
+      // for every CallLog promise due TODAY. INTERNAL_ALERT channel +
+      // autoExecute=false → no message is sent automatically; the
+      // BrokenPromiseBanner reads these and prompts the collector to bulk-send.
+      id: 'dunning-event-PROMISE_DUE_REMINDER',
+      name: 'dunning_promise_due_reminder',
+      eventTrigger: 'PROMISE_DUE_REMINDER',
+      channel: 'INTERNAL_ALERT',
+      messageTemplate:
+        'เรียนคุณ {{customerName}}, วันนี้ครบกำหนดนัดชำระงวด {{installmentNo}} ยอด {{amount}} ฿ — กรุณาชำระภายในวันนี้',
+      includePaymentLink: true,
+      autoExecute: false,
+      sortOrder: 108,
     },
   ];
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { ContractsModule } from './modules/contracts/contracts.module';
 import { PaymentsModule } from './modules/payments/payments.module';
 // MASTER-only modules
 import { OverdueModule } from './modules/overdue/overdue.module';
+import { FilterPresetsModule } from './modules/filter-presets/filter-presets.module';
 import { DefectExchangeModule } from './modules/defect-exchange/defect-exchange.module';
 import { RepossessionsModule } from './modules/repossessions/repossessions.module';
 import { PurchaseOrdersModule } from './modules/purchase-orders/purchase-orders.module';
@@ -156,6 +157,7 @@ import { AppCacheModule } from './cache/cache.module';
     PaymentsModule,
     // MASTER: Operations
     OverdueModule,
+    FilterPresetsModule,
     DefectExchangeModule,
     RepossessionsModule,
     PurchaseOrdersModule,

--- a/apps/api/src/modules/contracts/contract-snapshot.service.spec.ts
+++ b/apps/api/src/modules/contracts/contract-snapshot.service.spec.ts
@@ -1,0 +1,151 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { ContractSnapshotService } from './contract-snapshot.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('ContractSnapshotService', () => {
+  let service: ContractSnapshotService;
+  let prisma: {
+    contract: { findFirst: jest.Mock };
+    payment: { aggregate: jest.Mock; count: jest.Mock };
+    callLog: { findFirst: jest.Mock };
+    chatMessage: { findFirst: jest.Mock };
+  };
+
+  const baseContract = {
+    id: 'c1',
+    contractNumber: 'BC-2026-001',
+    status: 'OVERDUE',
+    branchId: 'br1',
+    customerId: 'cu1',
+    totalMonths: 12,
+    monthlyPayment: 1000,
+    sellingPrice: 12000,
+    downPayment: 0,
+    interestTotal: 0,
+    storeCommission: 0,
+    vatAmount: 0,
+    collectionNotes: '',
+    updatedAt: new Date('2026-04-25T10:00:00Z'),
+    customer: { id: 'cu1', name: 'นายทดสอบ', phone: '0812345678' },
+    product: { name: 'iPhone 15 Pro' },
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      contract: { findFirst: jest.fn() },
+      payment: { aggregate: jest.fn(), count: jest.fn() },
+      callLog: { findFirst: jest.fn() },
+      chatMessage: { findFirst: jest.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractSnapshotService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = module.get(ContractSnapshotService);
+  });
+
+  it('throws NotFound when contract missing', async () => {
+    prisma.contract.findFirst.mockResolvedValue(null);
+    await expect(service.getSnapshot('missing')).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws Forbidden when user from another branch lacks cross-branch access', async () => {
+    prisma.contract.findFirst.mockResolvedValue(baseContract);
+    prisma.payment.aggregate.mockResolvedValue({ _sum: { amountDue: 0, amountPaid: 0 } });
+    prisma.payment.count.mockResolvedValue(0);
+    prisma.callLog.findFirst.mockResolvedValue(null);
+    prisma.chatMessage.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.getSnapshot('c1', { id: 'u1', role: 'SALES', branchId: 'br2' }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('returns lightweight snapshot with totals + remaining installments', async () => {
+    prisma.contract.findFirst.mockResolvedValue({ ...baseContract, totalMonths: 12 });
+    prisma.payment.aggregate.mockResolvedValue({
+      _sum: { amountDue: 12000, amountPaid: 4500 },
+    });
+    prisma.payment.count.mockResolvedValue(4);
+    prisma.callLog.findFirst.mockResolvedValue(null);
+    prisma.chatMessage.findFirst.mockResolvedValue(null);
+
+    const snap = await service.getSnapshot('c1');
+    expect(snap.contractNumber).toBe('BC-2026-001');
+    expect(snap.customer.name).toBe('นายทดสอบ');
+    expect(snap.product.name).toBe('iPhone 15 Pro');
+    expect(snap.totals.totalAmount).toBe(12000);
+    expect(snap.totals.outstanding).toBe(7500);
+    expect(snap.totals.installmentsRemaining).toBe(8);
+    expect(snap.lastPromise).toBeNull();
+    expect(snap.lastLine).toBeNull();
+  });
+
+  it('truncates collector comment > 100 chars and flags truncated', async () => {
+    const longNote = 'ก'.repeat(150);
+    prisma.contract.findFirst.mockResolvedValue({
+      ...baseContract,
+      collectionNotes: longNote,
+    });
+    prisma.payment.aggregate.mockResolvedValue({ _sum: { amountDue: 0, amountPaid: 0 } });
+    prisma.payment.count.mockResolvedValue(0);
+    prisma.callLog.findFirst.mockResolvedValue(null);
+    prisma.chatMessage.findFirst.mockResolvedValue(null);
+
+    const snap = await service.getSnapshot('c1');
+    expect(snap.lastCollectorComment?.truncated).toBe(true);
+    expect(snap.lastCollectorComment?.text.length).toBe(101); // 100 chars + ellipsis
+    expect(snap.lastCollectorComment?.text.endsWith('…')).toBe(true);
+  });
+
+  it('returns lastPromise BROKEN when callLog has brokenAt', async () => {
+    prisma.contract.findFirst.mockResolvedValue(baseContract);
+    prisma.payment.aggregate.mockResolvedValue({ _sum: { amountDue: 0, amountPaid: 0 } });
+    prisma.payment.count.mockResolvedValue(0);
+    prisma.callLog.findFirst.mockResolvedValue({
+      settlementDate: new Date('2026-04-20T00:00:00Z'),
+      result: 'PROMISED',
+      settlementNotes: 'จะโอนพรุ่งนี้',
+      notes: null,
+      brokenAt: new Date('2026-04-22T00:00:00Z'),
+    });
+    prisma.chatMessage.findFirst.mockResolvedValue(null);
+
+    const snap = await service.getSnapshot('c1');
+    expect(snap.lastPromise?.result).toBe('BROKEN');
+    expect(snap.lastPromise?.notes).toBe('จะโอนพรุ่งนี้');
+  });
+
+  it('returns lastLine read=true when readAt set', async () => {
+    prisma.contract.findFirst.mockResolvedValue(baseContract);
+    prisma.payment.aggregate.mockResolvedValue({ _sum: { amountDue: 0, amountPaid: 0 } });
+    prisma.payment.count.mockResolvedValue(0);
+    prisma.callLog.findFirst.mockResolvedValue(null);
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      createdAt: new Date('2026-04-24T08:00:00Z'),
+      readAt: new Date('2026-04-24T09:00:00Z'),
+      deliveredAt: new Date('2026-04-24T08:00:01Z'),
+    });
+
+    const snap = await service.getSnapshot('c1');
+    expect(snap.lastLine?.read).toBe(true);
+    expect(snap.lastLine?.timestamp).toBe('2026-04-24T08:00:00.000Z');
+  });
+
+  it('clamps outstanding to >=0 even if amountPaid > amountDue (overpayment)', async () => {
+    prisma.contract.findFirst.mockResolvedValue(baseContract);
+    prisma.payment.aggregate.mockResolvedValue({
+      _sum: { amountDue: 1000, amountPaid: 1500 },
+    });
+    prisma.payment.count.mockResolvedValue(1);
+    prisma.callLog.findFirst.mockResolvedValue(null);
+    prisma.chatMessage.findFirst.mockResolvedValue(null);
+
+    const snap = await service.getSnapshot('c1');
+    expect(snap.totals.outstanding).toBe(0);
+  });
+});

--- a/apps/api/src/modules/contracts/contract-snapshot.service.ts
+++ b/apps/api/src/modules/contracts/contract-snapshot.service.ts
@@ -1,0 +1,194 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { hasCrossBranchAccess } from '../auth/branch-access.util';
+
+export interface BranchAccessUser {
+  id: string;
+  role: string;
+  branchId: string | null;
+}
+
+/**
+ * Lightweight snapshot payload returned by `GET /contracts/:id/snapshot`.
+ *
+ * Designed for the Customer 360 hover/long-press preview card on the
+ * collections page. Targets sub-100ms latency by avoiding the full
+ * timeline payload — only aggregates that fit in a single render.
+ */
+export interface ContractSnapshot {
+  contractId: string;
+  contractNumber: string;
+  status: string;
+  customer: {
+    id: string;
+    name: string;
+    phone: string;
+  };
+  product: {
+    name: string;
+  };
+  totals: {
+    totalAmount: number;
+    outstanding: number;
+    installmentsTotal: number;
+    installmentsRemaining: number;
+  };
+  lastPromise: {
+    settlementDate: string;
+    result: string;
+    notes: string | null;
+  } | null;
+  lastLine: {
+    timestamp: string;
+    read: boolean;
+  } | null;
+  lastCollectorComment: {
+    text: string;
+    truncated: boolean;
+    by: string | null;
+    at: string;
+  } | null;
+}
+
+const COMMENT_TRUNCATE_AT = 100;
+
+@Injectable()
+export class ContractSnapshotService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Build the lightweight snapshot for the Customer 360 preview card.
+   *
+   * Five small parallel queries — much faster than the full Customer 360
+   * timeline because we never load the full payment / dunning / audit
+   * history. Branch-access enforced identically to ContractsService.findOne().
+   */
+  async getSnapshot(id: string, user?: BranchAccessUser): Promise<ContractSnapshot> {
+    const contract = await this.prisma.contract.findFirst({
+      where: { id, deletedAt: null },
+      select: {
+        id: true,
+        contractNumber: true,
+        status: true,
+        branchId: true,
+        customerId: true,
+        totalMonths: true,
+        monthlyPayment: true,
+        sellingPrice: true,
+        downPayment: true,
+        interestTotal: true,
+        storeCommission: true,
+        vatAmount: true,
+        collectionNotes: true,
+        updatedAt: true,
+        customer: {
+          select: { id: true, name: true, phone: true },
+        },
+        product: { select: { name: true } },
+      },
+    });
+    if (!contract) throw new NotFoundException('ไม่พบสัญญา');
+
+    if (user && !hasCrossBranchAccess(user)) {
+      if (user.branchId && contract.branchId !== user.branchId) {
+        throw new ForbiddenException('ไม่สามารถเข้าถึงสัญญาข้ามสาขาได้');
+      }
+    }
+
+    const [paymentAgg, paidCountAgg, lastPromise, lastLine] = await Promise.all([
+      this.prisma.payment.aggregate({
+        where: { contractId: id, deletedAt: null },
+        _sum: { amountDue: true, amountPaid: true },
+      }),
+      this.prisma.payment.count({
+        where: { contractId: id, deletedAt: null, status: 'PAID' },
+      }),
+      this.prisma.callLog.findFirst({
+        where: {
+          contractId: id,
+          deletedAt: null,
+          settlementDate: { not: null },
+        },
+        orderBy: { calledAt: 'desc' },
+        select: {
+          settlementDate: true,
+          result: true,
+          settlementNotes: true,
+          notes: true,
+          brokenAt: true,
+        },
+      }),
+      // Latest LINE message for the customer's chat room (LINE_FINANCE channel
+      // only — collections context). We pick the most recent INBOUND OR
+      // OUTBOUND message and surface delivered/read state when available.
+      this.prisma.chatMessage.findFirst({
+        where: {
+          deletedAt: null,
+          room: {
+            customerId: contract.customerId,
+            channel: 'LINE_FINANCE',
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        select: {
+          createdAt: true,
+          readAt: true,
+          deliveredAt: true,
+        },
+      }),
+    ]);
+
+    const totalAmount = Number(paymentAgg._sum.amountDue ?? 0);
+    const outstanding = Math.max(
+      0,
+      totalAmount - Number(paymentAgg._sum.amountPaid ?? 0),
+    );
+    const installmentsRemaining = Math.max(0, contract.totalMonths - paidCountAgg);
+
+    // Truncate the most recent collection note. We do not have a per-comment
+    // table, so the snapshot reads from Contract.collectionNotes (single
+    // free-text field updated by ContactLogDialog). Truncated at 100 chars.
+    const noteRaw = (contract.collectionNotes ?? '').trim();
+    const truncated = noteRaw.length > COMMENT_TRUNCATE_AT;
+    const lastCollectorComment = noteRaw.length
+      ? {
+          text: truncated ? `${noteRaw.slice(0, COMMENT_TRUNCATE_AT)}…` : noteRaw,
+          truncated,
+          by: null,
+          at: contract.updatedAt.toISOString(),
+        }
+      : null;
+
+    return {
+      contractId: contract.id,
+      contractNumber: contract.contractNumber,
+      status: contract.status,
+      customer: {
+        id: contract.customer.id,
+        name: contract.customer.name,
+        phone: contract.customer.phone,
+      },
+      product: { name: contract.product?.name ?? '—' },
+      totals: {
+        totalAmount,
+        outstanding,
+        installmentsTotal: contract.totalMonths,
+        installmentsRemaining,
+      },
+      lastPromise: lastPromise?.settlementDate
+        ? {
+            settlementDate: lastPromise.settlementDate.toISOString(),
+            result: lastPromise.brokenAt ? 'BROKEN' : lastPromise.result,
+            notes: lastPromise.settlementNotes ?? lastPromise.notes ?? null,
+          }
+        : null,
+      lastLine: lastLine
+        ? {
+            timestamp: lastLine.createdAt.toISOString(),
+            read: !!lastLine.readAt,
+          }
+        : null,
+      lastCollectorComment,
+    };
+  }
+}

--- a/apps/api/src/modules/contracts/contracts.controller.ts
+++ b/apps/api/src/modules/contracts/contracts.controller.ts
@@ -5,6 +5,7 @@ import { ContractsService } from './contracts.service';
 import { ContractWorkflowService } from './contract-workflow.service';
 import { ContractPaymentService } from './contract-payment.service';
 import { ContractDocumentService } from './contract-document.service';
+import { ContractSnapshotService } from './contract-snapshot.service';
 import { CreateContractDto, UpdateContractDto, EarlyPayoffDto, ReviewContractDto, RejectContractDto } from './dto/contract.dto';
 import { PdpaConsentDto } from './dto/pdpa-consent.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -24,6 +25,7 @@ export class ContractsController {
     private workflowService: ContractWorkflowService,
     private paymentService: ContractPaymentService,
     private documentService: ContractDocumentService,
+    private snapshotService: ContractSnapshotService,
   ) {}
 
   @Get()
@@ -69,6 +71,24 @@ export class ContractsController {
     @CurrentUser() user?: { id: string; role: string; branchId: string | null },
   ) {
     return this.contractsService.findOne(id, user);
+  }
+
+  /**
+   * Lightweight snapshot for the Customer 360 hover/long-press preview.
+   * Designed for sub-100ms latency — does NOT include the full timeline,
+   * full payment schedule, or contract documents.
+   *
+   * Returns: name+phone, contract#+status+product, totals/outstanding/
+   * remaining-installments, last promise+result, last LINE timestamp+read,
+   * last collector comment (truncated 100 chars).
+   */
+  @Get(':id/snapshot')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  getSnapshot(
+    @Param('id') id: string,
+    @CurrentUser() user?: { id: string; role: string; branchId: string | null },
+  ) {
+    return this.snapshotService.getSnapshot(id, user);
   }
 
   @Get(':id/schedule')

--- a/apps/api/src/modules/contracts/contracts.module.ts
+++ b/apps/api/src/modules/contracts/contracts.module.ts
@@ -4,6 +4,7 @@ import { ContractsService } from './contracts.service';
 import { ContractWorkflowService } from './contract-workflow.service';
 import { ContractPaymentService } from './contract-payment.service';
 import { ContractDocumentService } from './contract-document.service';
+import { ContractSnapshotService } from './contract-snapshot.service';
 import { ContractDocumentsController } from './contract-documents.controller';
 import { ContractDocumentsService } from './contract-documents.service';
 import { DocumentsController } from './documents.controller';
@@ -19,7 +20,7 @@ import { WarrantyModule } from '../warranty/warranty.module';
 @Module({
   imports: [NotificationsModule, OcrModule, SettingsModule, JournalModule, ProductsModule, WarrantyModule],
   controllers: [ContractsController, ContractDocumentsController, DocumentsController],
-  providers: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractDocumentsService, DocumentsService, GhostSaleCron],
-  exports: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractDocumentsService, DocumentsService],
+  providers: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractSnapshotService, ContractDocumentsService, DocumentsService, GhostSaleCron],
+  exports: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractSnapshotService, ContractDocumentsService, DocumentsService],
 })
 export class ContractsModule {}

--- a/apps/api/src/modules/filter-presets/dto/create-preset.dto.ts
+++ b/apps/api/src/modules/filter-presets/dto/create-preset.dto.ts
@@ -1,0 +1,29 @@
+import {
+  IsString,
+  IsEnum,
+  IsObject,
+  IsOptional,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+import { FilterPresetScope } from '@prisma/client';
+
+export class CreatePresetDto {
+  @IsString({ message: 'กรุณาระบุชื่อ preset' })
+  @MinLength(1, { message: 'ชื่อ preset ต้องไม่ว่าง' })
+  @MaxLength(50, { message: 'ชื่อ preset ยาวเกิน 50 ตัวอักษร' })
+  name!: string;
+
+  @IsEnum(FilterPresetScope, { message: 'scope ไม่ถูกต้อง' })
+  scope!: FilterPresetScope;
+
+  @IsString({ message: 'กรุณาระบุ page' })
+  page!: string;
+
+  @IsObject({ message: 'filterJson ต้องเป็น object' })
+  filterJson!: Record<string, any>;
+
+  @IsOptional()
+  @IsString()
+  branchId?: string;
+}

--- a/apps/api/src/modules/filter-presets/filter-presets.controller.ts
+++ b/apps/api/src/modules/filter-presets/filter-presets.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { FilterPresetsService } from './filter-presets.service';
+import { CreatePresetDto } from './dto/create-preset.dto';
+
+@ApiTags('FilterPresets')
+@ApiBearerAuth('JWT')
+@Controller('filter-presets')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FilterPresetsController {
+  constructor(private readonly service: FilterPresetsService) {}
+
+  @Get()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  list(
+    @Query('page') page: string,
+    @CurrentUser() user: { id: string; role: string; branchId: string | null },
+  ) {
+    return this.service.list({
+      userId: user.id,
+      userRole: user.role,
+      branchId: user.branchId,
+      page: page ?? 'collections-queue',
+    });
+  }
+
+  @Post()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  create(
+    @Body() dto: CreatePresetDto,
+    @CurrentUser() user: { id: string; role: string; branchId: string | null },
+  ) {
+    return this.service.create(dto, user.id, user.role, user.branchId);
+  }
+
+  @Delete(':id')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  delete(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    return this.service.delete(id, user.id, user.role);
+  }
+}

--- a/apps/api/src/modules/filter-presets/filter-presets.module.ts
+++ b/apps/api/src/modules/filter-presets/filter-presets.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { FilterPresetsController } from './filter-presets.controller';
+import { FilterPresetsService } from './filter-presets.service';
+
+@Module({
+  controllers: [FilterPresetsController],
+  providers: [FilterPresetsService],
+  exports: [FilterPresetsService],
+})
+export class FilterPresetsModule {}

--- a/apps/api/src/modules/filter-presets/filter-presets.service.spec.ts
+++ b/apps/api/src/modules/filter-presets/filter-presets.service.spec.ts
@@ -1,0 +1,193 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { FilterPresetScope } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { FilterPresetsService } from './filter-presets.service';
+
+const mockPrisma = {
+  filterPreset: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+describe('FilterPresetsService', () => {
+  let service: FilterPresetsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FilterPresetsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(FilterPresetsService);
+  });
+
+  describe('create', () => {
+    it('creates a PRIVATE preset for any user', async () => {
+      mockPrisma.filterPreset.create.mockResolvedValueOnce({
+        id: 'p1',
+        ownerUserId: 'u1',
+        scope: FilterPresetScope.PRIVATE,
+      });
+
+      const result = await service.create(
+        {
+          name: 'My filter',
+          scope: FilterPresetScope.PRIVATE,
+          page: 'collections-queue',
+          filterJson: { assigned: 'self' },
+        },
+        'u1',
+        'SALES',
+        'br1',
+      );
+
+      expect(result.ownerUserId).toBe('u1');
+      const arg = mockPrisma.filterPreset.create.mock.calls[0][0];
+      expect(arg.data.scope).toBe(FilterPresetScope.PRIVATE);
+      expect(arg.data.branchId).toBeUndefined();
+      expect(arg.data.ownerUserId).toBe('u1');
+    });
+
+    it('rejects SHARED_ALL for non-OWNER', async () => {
+      await expect(
+        service.create(
+          {
+            name: 'Global',
+            scope: FilterPresetScope.SHARED_ALL,
+            page: 'collections-queue',
+            filterJson: {},
+          },
+          'u1',
+          'BRANCH_MANAGER',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockPrisma.filterPreset.create).not.toHaveBeenCalled();
+    });
+
+    it('allows SHARED_ALL for OWNER (clears branchId)', async () => {
+      mockPrisma.filterPreset.create.mockResolvedValueOnce({ id: 'p2' });
+      await service.create(
+        {
+          name: 'Global',
+          scope: FilterPresetScope.SHARED_ALL,
+          page: 'collections-queue',
+          filterJson: {},
+          branchId: 'br1',
+        },
+        'owner1',
+        'OWNER',
+        'br1',
+      );
+      const arg = mockPrisma.filterPreset.create.mock.calls[0][0];
+      expect(arg.data.branchId).toBeUndefined();
+    });
+
+    it('rejects SHARED_BRANCH for SALES', async () => {
+      await expect(
+        service.create(
+          {
+            name: 'Branch',
+            scope: FilterPresetScope.SHARED_BRANCH,
+            page: 'collections-queue',
+            filterJson: {},
+          },
+          'u1',
+          'SALES',
+          'br1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows SHARED_BRANCH for FINANCE_MANAGER and falls back to user branch', async () => {
+      mockPrisma.filterPreset.create.mockResolvedValueOnce({ id: 'p3' });
+      await service.create(
+        {
+          name: 'Branch X',
+          scope: FilterPresetScope.SHARED_BRANCH,
+          page: 'collections-queue',
+          filterJson: {},
+        },
+        'fm1',
+        'FINANCE_MANAGER',
+        'br99',
+      );
+      const arg = mockPrisma.filterPreset.create.mock.calls[0][0];
+      expect(arg.data.branchId).toBe('br99');
+    });
+  });
+
+  describe('list', () => {
+    it('returns PRIVATE owned + SHARED_ALL + SHARED_BRANCH for branch user', async () => {
+      mockPrisma.filterPreset.findMany.mockResolvedValueOnce([
+        { id: 'a', scope: 'PRIVATE' },
+        { id: 'b', scope: 'SHARED_BRANCH' },
+        { id: 'c', scope: 'SHARED_ALL' },
+      ]);
+
+      const presets = await service.list({
+        userId: 'u1',
+        userRole: 'BRANCH_MANAGER',
+        branchId: 'br1',
+        page: 'collections-queue',
+      });
+
+      expect(presets).toHaveLength(3);
+      const arg = mockPrisma.filterPreset.findMany.mock.calls[0][0];
+      expect(arg.where.deletedAt).toBeNull();
+      expect(arg.where.page).toBe('collections-queue');
+      // visibility OR includes 3 conditions for branched user
+      expect(arg.where.OR).toHaveLength(3);
+    });
+
+    it('OWNER sees all SHARED_BRANCH presets even when branchId null', async () => {
+      mockPrisma.filterPreset.findMany.mockResolvedValueOnce([]);
+      await service.list({
+        userId: 'owner1',
+        userRole: 'OWNER',
+        branchId: null,
+        page: 'collections-queue',
+      });
+      const arg = mockPrisma.filterPreset.findMany.mock.calls[0][0];
+      const orConds = arg.where.OR as Array<{ scope: string }>;
+      // Should include unconditional SHARED_BRANCH visibility
+      expect(orConds.some((c) => c.scope === 'SHARED_BRANCH')).toBe(true);
+    });
+  });
+
+  describe('delete', () => {
+    it('throws NotFound when preset missing', async () => {
+      mockPrisma.filterPreset.findFirst.mockResolvedValueOnce(null);
+      await expect(service.delete('missing', 'u1', 'SALES')).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects when non-owner non-OWNER tries to delete', async () => {
+      mockPrisma.filterPreset.findFirst.mockResolvedValueOnce({
+        id: 'p1',
+        ownerUserId: 'u2',
+      });
+      await expect(service.delete('p1', 'u1', 'SALES')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('soft-deletes when owner', async () => {
+      mockPrisma.filterPreset.findFirst.mockResolvedValueOnce({ id: 'p1', ownerUserId: 'u1' });
+      mockPrisma.filterPreset.update.mockResolvedValueOnce({ id: 'p1', deletedAt: new Date() });
+      await service.delete('p1', 'u1', 'SALES');
+      const arg = mockPrisma.filterPreset.update.mock.calls[0][0];
+      expect(arg.where.id).toBe('p1');
+      expect(arg.data.deletedAt).toBeInstanceOf(Date);
+    });
+
+    it('OWNER can delete any preset', async () => {
+      mockPrisma.filterPreset.findFirst.mockResolvedValueOnce({ id: 'p1', ownerUserId: 'someone' });
+      mockPrisma.filterPreset.update.mockResolvedValueOnce({ id: 'p1' });
+      await service.delete('p1', 'owner1', 'OWNER');
+      expect(mockPrisma.filterPreset.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/modules/filter-presets/filter-presets.service.ts
+++ b/apps/api/src/modules/filter-presets/filter-presets.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { FilterPresetScope, Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreatePresetDto } from './dto/create-preset.dto';
+
+const BRANCH_SHARE_ROLES = new Set(['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER']);
+
+@Injectable()
+export class FilterPresetsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(dto: CreatePresetDto, userId: string, userRole?: string, userBranchId?: string | null) {
+    if (dto.scope === FilterPresetScope.SHARED_ALL && userRole !== 'OWNER') {
+      throw new ForbiddenException('ไม่มีสิทธิ์สร้าง preset สำหรับทุกสาขา');
+    }
+    if (dto.scope === FilterPresetScope.SHARED_BRANCH && !BRANCH_SHARE_ROLES.has(userRole ?? '')) {
+      throw new ForbiddenException('ไม่มีสิทธิ์สร้าง preset สำหรับทั้งสาขา');
+    }
+
+    // SHARED_BRANCH must have branchId — fall back to user's branch when not provided.
+    // PRIVATE / SHARED_ALL never carry a branchId.
+    let branchId: string | undefined;
+    if (dto.scope === FilterPresetScope.SHARED_BRANCH) {
+      branchId = dto.branchId ?? userBranchId ?? undefined;
+      if (!branchId) {
+        throw new ForbiddenException('preset SHARED_BRANCH ต้องระบุสาขา');
+      }
+    }
+
+    return this.prisma.filterPreset.create({
+      data: {
+        name: dto.name,
+        scope: dto.scope,
+        page: dto.page,
+        filterJson: dto.filterJson as Prisma.InputJsonValue,
+        branchId,
+        ownerUserId: userId,
+      },
+    });
+  }
+
+  async list({
+    userId,
+    userRole,
+    branchId,
+    page,
+  }: {
+    userId: string;
+    userRole: string;
+    branchId: string | null;
+    page: string;
+  }) {
+    const visibility: Prisma.FilterPresetWhereInput[] = [
+      { scope: FilterPresetScope.PRIVATE, ownerUserId: userId },
+      { scope: FilterPresetScope.SHARED_ALL },
+    ];
+    if (branchId) {
+      visibility.push({ scope: FilterPresetScope.SHARED_BRANCH, branchId });
+    }
+    // OWNER sees every SHARED_BRANCH preset (even outside their branch)
+    if (userRole === 'OWNER') {
+      visibility.push({ scope: FilterPresetScope.SHARED_BRANCH });
+    }
+
+    return this.prisma.filterPreset.findMany({
+      where: {
+        page,
+        deletedAt: null,
+        OR: visibility,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async delete(id: string, userId: string, userRole: string) {
+    const preset = await this.prisma.filterPreset.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!preset) {
+      throw new NotFoundException('ไม่พบ preset');
+    }
+    if (preset.ownerUserId !== userId && userRole !== 'OWNER') {
+      throw new ForbiddenException('ลบได้เฉพาะ preset ของตนเอง');
+    }
+    return this.prisma.filterPreset.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+}

--- a/apps/api/src/modules/overdue/__tests__/collections-foundation.seed.spec.ts
+++ b/apps/api/src/modules/overdue/__tests__/collections-foundation.seed.spec.ts
@@ -29,7 +29,7 @@ describe('seedCollectionsFoundation', () => {
         ],
       },
     });
-    expect(rules1).toBe(8);
+    expect(rules1).toBe(9);
     expect(configs1).toBe(10);
 
     // Run seed a second time — counts must not change
@@ -47,7 +47,7 @@ describe('seedCollectionsFoundation', () => {
         ],
       },
     });
-    expect(rules2).toBe(8);
+    expect(rules2).toBe(9);
     expect(configs2).toBe(10);
   });
 });

--- a/apps/api/src/modules/overdue/analytics-aging.service.spec.ts
+++ b/apps/api/src/modules/overdue/analytics-aging.service.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AnalyticsAgingService } from './analytics-aging.service';
+
+const mockPrisma = {
+  $queryRawUnsafe: jest.fn(),
+};
+
+describe('AnalyticsAgingService', () => {
+  let service: AnalyticsAgingService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsAgingService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(AnalyticsAgingService);
+  });
+
+  it('returns all 5 buckets even when DB returns nothing', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]);
+    const result = await service.getAgingBuckets({ userRole: 'OWNER', userBranchId: null });
+    expect(result).toHaveLength(5);
+    expect(result.map((r) => r.bucket)).toEqual(['1-7', '8-30', '31-60', '61-90', '90+']);
+    expect(result.every((r) => r.count === 0 && r.outstanding === 0)).toBe(true);
+  });
+
+  it('maps DB rows into the bucket order', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([
+      { bucket: '8-30', cnt: BigInt(3), outstanding: '4500.50' },
+      { bucket: '90+', cnt: BigInt(1), outstanding: '12000' },
+    ]);
+    const result = await service.getAgingBuckets({ userRole: 'OWNER', userBranchId: null });
+    expect(result.find((r) => r.bucket === '8-30')).toEqual({
+      bucket: '8-30',
+      count: 3,
+      outstanding: 4500.5,
+    });
+    expect(result.find((r) => r.bucket === '90+')).toEqual({
+      bucket: '90+',
+      count: 1,
+      outstanding: 12000,
+    });
+    expect(result.find((r) => r.bucket === '1-7')?.count).toBe(0);
+  });
+
+  it('caches result on second call (same scope)', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]);
+    await service.getAgingBuckets({ userRole: 'OWNER', userBranchId: null });
+    await service.getAgingBuckets({ userRole: 'OWNER', userBranchId: null });
+    expect(mockPrisma.$queryRawUnsafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('separate cache key per branch scope (BRANCH_MANAGER different branch = miss)', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]);
+    await service.getAgingBuckets({ userRole: 'BRANCH_MANAGER', userBranchId: 'b1' });
+    await service.getAgingBuckets({ userRole: 'BRANCH_MANAGER', userBranchId: 'b2' });
+    expect(mockPrisma.$queryRawUnsafe).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns zero buckets on DB error (no throw)', async () => {
+    mockPrisma.$queryRawUnsafe.mockRejectedValue(new Error('boom'));
+    const result = await service.getAgingBuckets({ userRole: 'OWNER', userBranchId: null });
+    expect(result).toHaveLength(5);
+    expect(result.every((r) => r.count === 0)).toBe(true);
+  });
+});

--- a/apps/api/src/modules/overdue/analytics-aging.service.ts
+++ b/apps/api/src/modules/overdue/analytics-aging.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Aging buckets used by Collections AnalyticsTab (Task 15).
+ * Codes match the OverdueBucket enum (queue-query.dto.ts) so clicking a
+ * bar can deep-link straight into QueueTab with the same bucket filter.
+ */
+export type AgingBucketCode = '1-7' | '8-30' | '31-60' | '61-90' | '90+';
+
+export interface AgingBucketRow {
+  bucket: AgingBucketCode;
+  count: number;
+  outstanding: number;
+}
+
+interface RawRow {
+  bucket: string;
+  cnt: bigint;
+  outstanding: number | string | null;
+}
+
+@Injectable()
+export class AnalyticsAgingService {
+  private readonly logger = new Logger(AnalyticsAgingService.name);
+  // 5-minute in-memory cache per branch scope key
+  private cache = new Map<string, { value: AgingBucketRow[]; expiresAt: number }>();
+  private readonly CACHE_TTL_MS = 5 * 60 * 1000;
+
+  constructor(private prisma: PrismaService) {}
+
+  async getAgingBuckets(params: {
+    userRole: string;
+    userBranchId: string | null;
+  }): Promise<AgingBucketRow[]> {
+    const branchScope =
+      params.userRole === 'BRANCH_MANAGER' ? params.userBranchId ?? '__all__' : '__all__';
+    const cacheKey = branchScope;
+    const now = Date.now();
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > now) return cached.value;
+
+    const value = await this.compute(branchScope === '__all__' ? null : branchScope);
+    this.cache.set(cacheKey, { value, expiresAt: now + this.CACHE_TTL_MS });
+    return value;
+  }
+
+  private async compute(branchId: string | null): Promise<AgingBucketRow[]> {
+    try {
+      const rows = await this.prisma.$queryRawUnsafe<RawRow[]>(
+        `
+        WITH oldest AS (
+          SELECT
+            p.contract_id,
+            MIN(p.due_date) AS oldest_due,
+            SUM((p.amount_due - p.amount_paid + p.late_fee))::numeric AS outstanding
+          FROM payments p
+          INNER JOIN contracts c ON c.id = p.contract_id
+          WHERE p.deleted_at IS NULL
+            AND c.deleted_at IS NULL
+            AND c.status IN ('OVERDUE', 'DEFAULT', 'LEGAL')
+            AND p.status IN ('PENDING', 'OVERDUE', 'PARTIALLY_PAID')
+            AND p.due_date < NOW()
+            ${branchId ? 'AND c.branch_id = $1' : ''}
+          GROUP BY p.contract_id
+        ),
+        bucketed AS (
+          SELECT
+            CASE
+              WHEN (CURRENT_DATE - oldest_due::date) BETWEEN 1 AND 7 THEN '1-7'
+              WHEN (CURRENT_DATE - oldest_due::date) BETWEEN 8 AND 30 THEN '8-30'
+              WHEN (CURRENT_DATE - oldest_due::date) BETWEEN 31 AND 60 THEN '31-60'
+              WHEN (CURRENT_DATE - oldest_due::date) BETWEEN 61 AND 90 THEN '61-90'
+              WHEN (CURRENT_DATE - oldest_due::date) > 90 THEN '90+'
+              ELSE NULL
+            END AS bucket,
+            outstanding
+          FROM oldest
+        )
+        SELECT bucket, COUNT(*)::bigint AS cnt, SUM(outstanding)::numeric AS outstanding
+        FROM bucketed
+        WHERE bucket IS NOT NULL
+        GROUP BY bucket
+        `,
+        ...(branchId ? [branchId] : []),
+      );
+
+      const order: AgingBucketCode[] = ['1-7', '8-30', '31-60', '61-90', '90+'];
+      const map = new Map<AgingBucketCode, AgingBucketRow>();
+      for (const code of order) map.set(code, { bucket: code, count: 0, outstanding: 0 });
+      for (const r of rows) {
+        const code = r.bucket as AgingBucketCode;
+        if (!map.has(code)) continue;
+        map.set(code, {
+          bucket: code,
+          count: Number(r.cnt),
+          outstanding: r.outstanding == null ? 0 : Number(r.outstanding),
+        });
+      }
+      return order.map((c) => map.get(c)!);
+    } catch (err) {
+      this.logger.error('aging buckets query failed', err);
+      return [
+        { bucket: '1-7', count: 0, outstanding: 0 },
+        { bucket: '8-30', count: 0, outstanding: 0 },
+        { bucket: '31-60', count: 0, outstanding: 0 },
+        { bucket: '61-90', count: 0, outstanding: 0 },
+        { bucket: '90+', count: 0, outstanding: 0 },
+      ];
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/analytics-leaderboard.service.spec.ts
+++ b/apps/api/src/modules/overdue/analytics-leaderboard.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AnalyticsLeaderboardService } from './analytics-leaderboard.service';
+
+const mockPrisma = {
+  $queryRawUnsafe: jest.fn(),
+};
+
+describe('AnalyticsLeaderboardService', () => {
+  let service: AnalyticsLeaderboardService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsLeaderboardService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(AnalyticsLeaderboardService);
+  });
+
+  it('returns empty array when no collectors qualify', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]);
+    const result = await service.getLeaderboard();
+    expect(result).toEqual([]);
+  });
+
+  it('maps DB rows + computes promiseKeptPercent', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([
+      {
+        collector_id: 'u1',
+        name: 'แนน',
+        assigned_count: BigInt(10),
+        promise_kept: BigInt(7),
+        promise_total: BigInt(10),
+        avg_days_to_first_contact: 1.5,
+        recovery_this_month: '15000.50',
+      },
+    ]);
+    const result = await service.getLeaderboard();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      collectorId: 'u1',
+      name: 'แนน',
+      assignedCount: 10,
+      promiseKeptPercent: 70,
+      avgDaysToFirstContact: 1.5,
+      recoveryThisMonth: 15000.5,
+    });
+  });
+
+  it('promiseKeptPercent = 0 when no promises', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([
+      {
+        collector_id: 'u1',
+        name: 'A',
+        assigned_count: BigInt(5),
+        promise_kept: BigInt(0),
+        promise_total: BigInt(0),
+        avg_days_to_first_contact: 0,
+        recovery_this_month: 0,
+      },
+    ]);
+    const result = await service.getLeaderboard();
+    expect(result[0].promiseKeptPercent).toBe(0);
+  });
+
+  it('caches result on second call', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]);
+    await service.getLeaderboard();
+    await service.getLeaderboard();
+    expect(mockPrisma.$queryRawUnsafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty list on DB error (no throw)', async () => {
+    mockPrisma.$queryRawUnsafe.mockRejectedValue(new Error('boom'));
+    const result = await service.getLeaderboard();
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/overdue/analytics-leaderboard.service.ts
+++ b/apps/api/src/modules/overdue/analytics-leaderboard.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface LeaderboardRow {
+  collectorId: string;
+  name: string;
+  assignedCount: number;
+  promiseKeptPercent: number;
+  avgDaysToFirstContact: number;
+  recoveryThisMonth: number;
+}
+
+interface RawLeaderboardRow {
+  collector_id: string;
+  name: string;
+  assigned_count: bigint;
+  promise_kept: bigint;
+  promise_total: bigint;
+  avg_days_to_first_contact: number | string | null;
+  recovery_this_month: number | string | null;
+}
+
+@Injectable()
+export class AnalyticsLeaderboardService {
+  private readonly logger = new Logger(AnalyticsLeaderboardService.name);
+  private cache: { value: LeaderboardRow[]; expiresAt: number } | null = null;
+  private readonly CACHE_TTL_MS = 5 * 60 * 1000;
+
+  constructor(private prisma: PrismaService) {}
+
+  async getLeaderboard(): Promise<LeaderboardRow[]> {
+    const now = Date.now();
+    if (this.cache && this.cache.expiresAt > now) return this.cache.value;
+    const value = await this.compute();
+    this.cache = { value, expiresAt: now + this.CACHE_TTL_MS };
+    return value;
+  }
+
+  private async compute(): Promise<LeaderboardRow[]> {
+    try {
+      // Single CTE-based aggregate: assigned contracts + promise kept ratio
+      // + avg days from contract assignment-equivalent (createdAt of first
+      // CallLog after assignment) + recovery this month (sum of payments
+      // amountPaid where paidDate in current month, recordedById = collector).
+      const rows = await this.prisma.$queryRawUnsafe<RawLeaderboardRow[]>(`
+        WITH active_collectors AS (
+          SELECT u.id AS collector_id, u.name
+          FROM users u
+          WHERE u.deleted_at IS NULL
+            AND u.role IN ('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+        ),
+        assigned AS (
+          SELECT c.assigned_to_id AS collector_id, COUNT(*)::bigint AS assigned_count
+          FROM contracts c
+          WHERE c.deleted_at IS NULL
+            AND c.assigned_to_id IS NOT NULL
+            AND c.status IN ('OVERDUE', 'DEFAULT', 'LEGAL')
+          GROUP BY c.assigned_to_id
+        ),
+        promises AS (
+          SELECT cl.caller_id AS collector_id,
+                 COUNT(*) FILTER (WHERE cl.broken_at IS NULL AND cl.settlement_date IS NOT NULL AND cl.settlement_date < NOW())::bigint AS kept,
+                 COUNT(*) FILTER (WHERE cl.settlement_date IS NOT NULL AND cl.settlement_date < NOW())::bigint AS total
+          FROM call_logs cl
+          WHERE cl.deleted_at IS NULL
+            AND cl.result = 'PROMISED'
+            AND cl.called_at >= NOW() - INTERVAL '90 days'
+          GROUP BY cl.caller_id
+        ),
+        first_contact AS (
+          SELECT cl.caller_id AS collector_id,
+                 AVG(EXTRACT(EPOCH FROM (cl.called_at - c.created_at)) / 86400.0) AS avg_days
+          FROM call_logs cl
+          INNER JOIN contracts c ON c.id = cl.contract_id
+          WHERE cl.deleted_at IS NULL
+            AND cl.called_at >= NOW() - INTERVAL '90 days'
+          GROUP BY cl.caller_id
+        ),
+        recovery AS (
+          SELECT p.recorded_by_id AS collector_id,
+                 SUM(p.amount_paid)::numeric AS recovery_amt
+          FROM payments p
+          WHERE p.deleted_at IS NULL
+            AND p.recorded_by_id IS NOT NULL
+            AND p.paid_date >= date_trunc('month', NOW())
+          GROUP BY p.recorded_by_id
+        )
+        SELECT
+          ac.collector_id,
+          ac.name,
+          COALESCE(a.assigned_count, 0) AS assigned_count,
+          COALESCE(p.kept, 0) AS promise_kept,
+          COALESCE(p.total, 0) AS promise_total,
+          COALESCE(fc.avg_days, 0) AS avg_days_to_first_contact,
+          COALESCE(r.recovery_amt, 0) AS recovery_this_month
+        FROM active_collectors ac
+        LEFT JOIN assigned a ON a.collector_id = ac.collector_id
+        LEFT JOIN promises p ON p.collector_id = ac.collector_id
+        LEFT JOIN first_contact fc ON fc.collector_id = ac.collector_id
+        LEFT JOIN recovery r ON r.collector_id = ac.collector_id
+        WHERE
+          COALESCE(a.assigned_count, 0) > 0
+          OR COALESCE(p.total, 0) > 0
+          OR COALESCE(r.recovery_amt, 0) > 0
+        ORDER BY recovery_this_month DESC, assigned_count DESC
+      `);
+
+      return rows.map((r) => {
+        const total = Number(r.promise_total);
+        const kept = Number(r.promise_kept);
+        return {
+          collectorId: r.collector_id,
+          name: r.name,
+          assignedCount: Number(r.assigned_count),
+          promiseKeptPercent: total > 0 ? Math.round((kept / total) * 1000) / 10 : 0,
+          avgDaysToFirstContact:
+            r.avg_days_to_first_contact == null
+              ? 0
+              : Math.round(Number(r.avg_days_to_first_contact) * 10) / 10,
+          recoveryThisMonth:
+            r.recovery_this_month == null ? 0 : Number(r.recovery_this_month),
+        };
+      });
+    } catch (err) {
+      this.logger.error('leaderboard query failed', err);
+      return [];
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/broken-promise-reminder.cron.spec.ts
+++ b/apps/api/src/modules/overdue/broken-promise-reminder.cron.spec.ts
@@ -1,0 +1,195 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BrokenPromiseReminderCron } from './broken-promise-reminder.cron';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('BrokenPromiseReminderCron.runDaily', () => {
+  let cron: BrokenPromiseReminderCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+
+    prisma = {
+      dunningRule: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'dunning-event-PROMISE_DUE_REMINDER' }),
+      },
+      callLog: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      dunningAction: {
+        create: jest.fn().mockResolvedValue({ id: 'da-1' }),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        BrokenPromiseReminderCron,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    cron = mod.get(BrokenPromiseReminderCron);
+  });
+
+  it('returns 0 suggested when no candidates', async () => {
+    const result = await cron.runDaily();
+    expect(result.suggested).toBe(0);
+    expect(prisma.dunningAction.create).not.toHaveBeenCalled();
+  });
+
+  it('aborts cleanly + reports to Sentry when system rule is missing', async () => {
+    prisma.dunningRule.findUnique.mockResolvedValueOnce(null);
+
+    const result = await cron.runDaily();
+
+    expect(result).toEqual({ suggested: 0, skipped: 0 });
+    expect(prisma.callLog.findMany).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Missing system DunningRule'),
+      expect.objectContaining({ level: 'error' }),
+    );
+  });
+
+  it('queries PROMISED + brokenAt null + settlementDate within today + contract OVERDUE/DEFAULT', async () => {
+    await cron.runDaily();
+
+    const where = prisma.callLog.findMany.mock.calls[0][0].where;
+    expect(where.result).toBe('PROMISED');
+    expect(where.brokenAt).toBeNull();
+    expect(where.deletedAt).toBeNull();
+    expect(where.settlementDate.gte).toBeInstanceOf(Date);
+    expect(where.settlementDate.lt).toBeInstanceOf(Date);
+    // 24h window
+    const span =
+      (where.settlementDate.lt as Date).getTime() -
+      (where.settlementDate.gte as Date).getTime();
+    expect(span).toBe(24 * 60 * 60 * 1000);
+    expect(where.contract.status.in).toEqual(['OVERDUE', 'DEFAULT']);
+    expect(where.contract.deletedAt).toBeNull();
+  });
+
+  it('creates one DunningAction per unique contract (dedup multiple call logs)', async () => {
+    prisma.callLog.findMany.mockResolvedValue([
+      {
+        id: 'cl-1',
+        contractId: 'c-1',
+        settlementDate: new Date('2026-04-25T08:00:00.000Z'),
+        contract: { payments: [{ id: 'p-1' }] },
+      },
+      {
+        id: 'cl-2',
+        contractId: 'c-1', // duplicate contract → skipped
+        settlementDate: new Date('2026-04-25T09:00:00.000Z'),
+        contract: { payments: [{ id: 'p-1' }] },
+      },
+      {
+        id: 'cl-3',
+        contractId: 'c-2',
+        settlementDate: new Date('2026-04-25T10:00:00.000Z'),
+        contract: { payments: [{ id: 'p-2' }] },
+      },
+    ]);
+
+    const result = await cron.runDaily();
+
+    expect(result.suggested).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(prisma.dunningAction.create).toHaveBeenCalledTimes(2);
+
+    const c1Args = prisma.dunningAction.create.mock.calls[0][0].data;
+    expect(c1Args.dunningRuleId).toBe('dunning-event-PROMISE_DUE_REMINDER');
+    expect(c1Args.contractId).toBe('c-1');
+    expect(c1Args.paymentId).toBe('p-1');
+    expect(c1Args.channel).toBe('INTERNAL_ALERT');
+    expect(c1Args.status).toBe('PENDING');
+  });
+
+  it('treats P2002 unique conflict as idempotent skip (does NOT alarm Sentry)', async () => {
+    prisma.callLog.findMany.mockResolvedValue([
+      {
+        id: 'cl-1',
+        contractId: 'c-1',
+        settlementDate: new Date('2026-04-25T08:00:00.000Z'),
+        contract: { payments: [{ id: 'p-1' }] },
+      },
+    ]);
+    const conflict = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    prisma.dunningAction.create.mockRejectedValueOnce(conflict);
+
+    const result = await cron.runDaily();
+
+    expect(result.suggested).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('forwards non-P2002 create failure to Sentry but continues other contracts', async () => {
+    prisma.callLog.findMany.mockResolvedValue([
+      {
+        id: 'cl-1',
+        contractId: 'c-1',
+        settlementDate: new Date('2026-04-25T08:00:00.000Z'),
+        contract: { payments: [{ id: 'p-1' }] },
+      },
+      {
+        id: 'cl-2',
+        contractId: 'c-2',
+        settlementDate: new Date('2026-04-25T09:00:00.000Z'),
+        contract: { payments: [{ id: 'p-2' }] },
+      },
+    ]);
+    prisma.dunningAction.create
+      .mockRejectedValueOnce(new Error('FK violation'))
+      .mockResolvedValueOnce({ id: 'da-2' });
+
+    const result = await cron.runDaily();
+
+    expect(result.suggested).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ step: 'createAction' }),
+      }),
+    );
+  });
+
+  it('captures top-level exception (does NOT throw) on DB failure', async () => {
+    prisma.callLog.findMany.mockRejectedValue(new Error('db down'));
+
+    const result = await cron.runDaily();
+
+    expect(result).toEqual({ suggested: 0, skipped: 0 });
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({ cron: 'broken-promise-reminder' }),
+      }),
+    );
+  });
+
+  it('survives candidates without an oldest-unpaid payment (paymentId null)', async () => {
+    prisma.callLog.findMany.mockResolvedValue([
+      {
+        id: 'cl-1',
+        contractId: 'c-1',
+        settlementDate: new Date('2026-04-25T08:00:00.000Z'),
+        contract: { payments: [] },
+      },
+    ]);
+
+    const result = await cron.runDaily();
+
+    expect(result.suggested).toBe(1);
+    const args = prisma.dunningAction.create.mock.calls[0][0].data;
+    expect(args.paymentId).toBeNull();
+  });
+});

--- a/apps/api/src/modules/overdue/broken-promise-reminder.cron.ts
+++ b/apps/api/src/modules/overdue/broken-promise-reminder.cron.ts
@@ -1,0 +1,179 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * P1 Task 14 — Broken-promise auto-suggest cron.
+ *
+ * Runs daily 09:00 Bangkok (UTC+7) = 02:00 UTC. Scans CallLogs whose
+ * `result='PROMISED'` and `settlementDate` falls TODAY (Bangkok wall clock)
+ * and the underlying contract is still overdue + has not yet been paid for
+ * that promise (`brokenAt IS NULL`). For each, stamps a `DunningAction` with
+ * the system rule `dunning-event-PROMISE_DUE_REMINDER` so the PromiseTab
+ * banner (`BrokenPromiseBanner.tsx`) can surface "วันนี้มีนัดครบกำหนด N ราย"
+ * and prompt the collector to bulk-send a LINE reminder.
+ *
+ * NOT to be confused with the existing `BrokenPromiseCron` (hourly, top of
+ * hour) which flags promises whose settlementDate has ALREADY PASSED. This
+ * cron prompts BEFORE the promise breaks, the other one cleans up AFTER.
+ *
+ * Idempotency: the DunningAction unique index `(dunningRuleId, contractId,
+ * paymentId)` together with the day-bounded scan means re-running the cron
+ * the same day is a no-op for contracts that already have a reminder. We
+ * intentionally pass `paymentId` from the CallLog's contract's oldest unpaid
+ * payment so the unique key resets when the next installment becomes due.
+ *
+ * Failure mode: any error (DB / unique conflict / etc) is logged + sent to
+ * Sentry but does NOT throw — losing one day's suggestions is recoverable
+ * via the next run; throwing would mark the schedule as failed and we'd
+ * lose visibility into other crons in the same process.
+ */
+@Injectable()
+export class BrokenPromiseReminderCron {
+  private readonly logger = new Logger(BrokenPromiseReminderCron.name);
+  private static readonly RULE_ID = 'dunning-event-PROMISE_DUE_REMINDER';
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  // Daily 09:00 Bangkok (UTC+7) → 02:00 UTC. The @nestjs/schedule library
+  // honours timeZone, but the explicit UTC equivalent in the comment helps
+  // ops debug Cloud Run logs which display in UTC.
+  @Cron('0 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async runDaily(): Promise<{ suggested: number; skipped: number }> {
+    try {
+      // Compute Bangkok-local "today" window. Server may run in UTC; we
+      // convert by treating now as UTC and shifting +7h, then taking the
+      // calendar date — which is the Bangkok date the collector expects.
+      const now = new Date();
+      const bkkNow = new Date(now.getTime() + 7 * 60 * 60 * 1000);
+      const startOfDayBkk = new Date(
+        Date.UTC(bkkNow.getUTCFullYear(), bkkNow.getUTCMonth(), bkkNow.getUTCDate(), 0, 0, 0, 0),
+      );
+      // Convert back from "naive Bangkok" to UTC by subtracting +7h.
+      const startOfDayUtc = new Date(startOfDayBkk.getTime() - 7 * 60 * 60 * 1000);
+      const endOfDayUtc = new Date(startOfDayUtc.getTime() + 24 * 60 * 60 * 1000);
+
+      // Verify the system rule exists — if seed hasn't run, abort with a
+      // clear Sentry message instead of mass-FK-violating.
+      const rule = await this.prisma.dunningRule.findUnique({
+        where: { id: BrokenPromiseReminderCron.RULE_ID },
+      });
+      if (!rule) {
+        const msg = `Missing system DunningRule '${BrokenPromiseReminderCron.RULE_ID}' — run seedCollectionsFoundation`;
+        this.logger.error(msg);
+        Sentry.captureMessage(msg, {
+          level: 'error',
+          tags: { kind: 'cron-job', cron: 'broken-promise-reminder', step: 'rule-missing' },
+        });
+        return { suggested: 0, skipped: 0 };
+      }
+
+      // Find PROMISED CallLogs whose settlementDate is today AND the contract
+      // is still overdue AND brokenAt is null (i.e. payment hasn't landed yet).
+      const candidates = await this.prisma.callLog.findMany({
+        where: {
+          deletedAt: null,
+          result: 'PROMISED',
+          brokenAt: null,
+          settlementDate: { gte: startOfDayUtc, lt: endOfDayUtc },
+          contract: {
+            deletedAt: null,
+            status: { in: ['OVERDUE', 'DEFAULT'] },
+          },
+        },
+        select: {
+          id: true,
+          contractId: true,
+          settlementDate: true,
+          contract: {
+            select: {
+              payments: {
+                where: {
+                  deletedAt: null,
+                  status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+                },
+                orderBy: { dueDate: 'asc' },
+                take: 1,
+                select: { id: true },
+              },
+            },
+          },
+        },
+        take: 1000,
+      });
+
+      if (candidates.length === 0) {
+        return { suggested: 0, skipped: 0 };
+      }
+
+      // Dedup at cron level too — multiple CallLogs may exist per contract
+      // (re-promise after re-promise). One reminder per contract.
+      const seen = new Set<string>();
+      let suggested = 0;
+      let skipped = 0;
+
+      for (const c of candidates) {
+        if (seen.has(c.contractId)) {
+          skipped++;
+          continue;
+        }
+        seen.add(c.contractId);
+
+        const oldestUnpaidId = c.contract.payments[0]?.id ?? null;
+
+        try {
+          await this.prisma.dunningAction.create({
+            data: {
+              dunningRuleId: BrokenPromiseReminderCron.RULE_ID,
+              contractId: c.contractId,
+              paymentId: oldestUnpaidId,
+              channel: 'INTERNAL_ALERT',
+              status: 'PENDING',
+              messageContent: `นัดชำระวันนี้ (${(c.settlementDate as Date).toISOString().slice(0, 10)})`,
+            },
+          });
+          suggested++;
+        } catch (err) {
+          // Unique conflict on (ruleId, contractId, paymentId) means a
+          // reminder already exists for this contract+payment today — that's
+          // the idempotent re-run case, not a real failure. Anything else
+          // forward to Sentry.
+          const code = (err as { code?: string })?.code;
+          if (code === 'P2002') {
+            skipped++;
+            continue;
+          }
+          Sentry.captureException(err, {
+            tags: { kind: 'cron-job', cron: 'broken-promise-reminder', step: 'createAction' },
+            extra: { contractId: c.contractId, paymentId: oldestUnpaidId },
+          });
+          skipped++;
+        }
+      }
+
+      this.logger.log(
+        `Promise-due reminder: suggested ${suggested}, skipped ${skipped} (over ${candidates.length} candidate call log(s))`,
+      );
+
+      Sentry.captureMessage(
+        `Broken-promise-reminder cron suggested ${suggested} contract(s)`,
+        {
+          level: 'info',
+          tags: { kind: 'cron-job', cron: 'broken-promise-reminder' },
+          extra: { suggested, skipped, candidates: candidates.length },
+        },
+      );
+
+      return { suggested, skipped };
+    } catch (err) {
+      this.logger.error(
+        `Broken-promise-reminder cron failed: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'broken-promise-reminder' },
+      });
+      return { suggested: 0, skipped: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/contract-snapshot.cron.spec.ts
+++ b/apps/api/src/modules/overdue/contract-snapshot.cron.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { ContractSnapshotCron } from './contract-snapshot.cron';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+describe('ContractSnapshotCron.runDaily', () => {
+  let cron: ContractSnapshotCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    (Sentry.captureException as jest.Mock).mockClear();
+
+    prisma = {
+      contract: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      contractDailySnapshot: {
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractSnapshotCron,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    cron = mod.get(ContractSnapshotCron);
+  });
+
+  it('creates one snapshot per active overdue contract (skips zero-daysOverdue rows)', async () => {
+    // 3 candidate contracts: 2 with past-due payment (overdue >0), 1 with
+    // dueDate today (daysOverdue == 0 → filtered out before insert)
+    const yesterday = new Date(Date.now() - 86400000);
+    const tenDaysAgo = new Date(Date.now() - 10 * 86400000);
+    const today = new Date();
+
+    prisma.contract.findMany.mockResolvedValue([
+      {
+        id: 'c-1',
+        status: 'OVERDUE',
+        payments: [
+          {
+            dueDate: yesterday,
+            amountDue: new Prisma.Decimal('1000.00'),
+            amountPaid: new Prisma.Decimal('0'),
+            lateFee: new Prisma.Decimal('50.00'),
+          },
+        ],
+      },
+      {
+        id: 'c-2',
+        status: 'DEFAULT',
+        payments: [
+          {
+            dueDate: tenDaysAgo,
+            amountDue: new Prisma.Decimal('2000.00'),
+            amountPaid: new Prisma.Decimal('500.00'),
+            lateFee: new Prisma.Decimal('0'),
+          },
+        ],
+      },
+      {
+        id: 'c-3',
+        status: 'OVERDUE',
+        payments: [
+          {
+            dueDate: today,
+            amountDue: new Prisma.Decimal('500.00'),
+            amountPaid: new Prisma.Decimal('0'),
+            lateFee: new Prisma.Decimal('0'),
+          },
+        ],
+      },
+    ]);
+    prisma.contractDailySnapshot.createMany.mockResolvedValue({ count: 2 });
+
+    const result = await cron.runDaily();
+
+    expect(result.snapshotted).toBe(2);
+    const createArgs = prisma.contractDailySnapshot.createMany.mock.calls[0][0];
+    expect(createArgs.skipDuplicates).toBe(true);
+    expect(createArgs.data).toHaveLength(2);
+    expect(createArgs.data.map((r: { contractId: string }) => r.contractId).sort()).toEqual([
+      'c-1',
+      'c-2',
+    ]);
+
+    // Verify queue.service-style outstanding derivation for c-2:
+    // (amountDue 2000 - amountPaid 500 + lateFee 0) = 1500
+    const c2Row = createArgs.data.find((r: { contractId: string }) => r.contractId === 'c-2');
+    expect(new Prisma.Decimal(c2Row.outstanding).toString()).toBe('1500');
+    expect(c2Row.daysOverdue).toBeGreaterThanOrEqual(10);
+    expect(c2Row.status).toBe('DEFAULT');
+  });
+
+  it('does not duplicate snapshot for same date (relies on skipDuplicates + unique constraint)', async () => {
+    const yesterday = new Date(Date.now() - 86400000);
+    const candidate = {
+      id: 'c-1',
+      status: 'OVERDUE' as const,
+      payments: [
+        {
+          dueDate: yesterday,
+          amountDue: new Prisma.Decimal('1000.00'),
+          amountPaid: new Prisma.Decimal('0'),
+          lateFee: new Prisma.Decimal('0'),
+        },
+      ],
+    };
+    prisma.contract.findMany.mockResolvedValue([candidate]);
+
+    // First run: 1 inserted
+    prisma.contractDailySnapshot.createMany.mockResolvedValueOnce({ count: 1 });
+    const r1 = await cron.runDaily();
+    expect(r1.snapshotted).toBe(1);
+
+    // Second run same day: createMany returns count=0 because the unique
+    // (contractId, date) index dedups via skipDuplicates
+    prisma.contractDailySnapshot.createMany.mockResolvedValueOnce({ count: 0 });
+    const r2 = await cron.runDaily();
+    expect(r2.snapshotted).toBe(0);
+
+    // skipDuplicates was passed both times — that's the contract this test enforces
+    const calls = prisma.contractDailySnapshot.createMany.mock.calls;
+    expect(calls.every((c: [{ skipDuplicates: boolean }]) => c[0].skipDuplicates === true)).toBe(true);
+  });
+
+  it('prunes snapshots older than 30 days', async () => {
+    prisma.contractDailySnapshot.deleteMany.mockResolvedValue({ count: 5 });
+
+    const result = await cron.runDaily();
+
+    expect(result.pruned).toBe(5);
+    const deleteArgs = prisma.contractDailySnapshot.deleteMany.mock.calls[0][0];
+    expect(deleteArgs.where.date.lt).toBeInstanceOf(Date);
+    // Cutoff should be ~30 days before today (allow ±1 day for boundary)
+    const cutoff = deleteArgs.where.date.lt as Date;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const diffDays = Math.round((today.getTime() - cutoff.getTime()) / 86400000);
+    expect(diffDays).toBeGreaterThanOrEqual(29);
+    expect(diffDays).toBeLessThanOrEqual(31);
+  });
+});

--- a/apps/api/src/modules/overdue/contract-snapshot.cron.ts
+++ b/apps/api/src/modules/overdue/contract-snapshot.cron.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * ContractDailySnapshot cron — captures (daysOverdue, outstanding, status) for
+ * every active overdue contract once per day. Feeds:
+ *  - Trending arrow on ContractCard (Task 10): compare today vs ~7 days ago
+ *  - Analytics historical trends (E1+)
+ *
+ * Schedule: daily 00:10 Bangkok = 17:10 UTC (cron timezone honored by
+ * @nestjs/schedule, but `Cron('10 17 * * *', { timeZone })` makes intent explicit).
+ *
+ * Idempotency: `(contractId, date)` is unique. `createMany({ skipDuplicates })`
+ * makes re-runs on the same UTC day a no-op.
+ *
+ * Pruning: rows older than 30 days are deleted each run. Trending arrow only
+ * needs 7d history; 30d gives headroom for short historical charts. Anything
+ * longer-term should be reported off the journal entries / payment records,
+ * not these snapshots.
+ *
+ * Why compute from payments rather than read Contract columns: Contract has
+ * NO daysOverdue / outstanding columns — they are derived per-request in
+ * queue.service from the oldest unpaid Payment row. This cron mirrors that
+ * derivation so snapshots stay consistent with the live queue view.
+ */
+@Injectable()
+export class ContractSnapshotCron {
+  private readonly logger = new Logger(ContractSnapshotCron.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  // Daily 00:10 Bangkok (UTC+7) → 17:10 UTC
+  @Cron('10 17 * * *', { timeZone: 'Asia/Bangkok' })
+  async runDaily(): Promise<{ snapshotted: number; pruned: number }> {
+    try {
+      const now = new Date();
+      const today = new Date(now);
+      today.setHours(0, 0, 0, 0);
+
+      // Fetch all active overdue contracts + their oldest unpaid payment.
+      // Mirror of queue.service.ts toRow() derivation.
+      const contracts = await this.prisma.contract.findMany({
+        where: {
+          deletedAt: null,
+          status: { in: ['OVERDUE', 'DEFAULT', 'LEGAL'] },
+          // Must have at least one unpaid past-due payment to qualify as
+          // "active overdue" (mirrors queue tab filter).
+          payments: {
+            some: {
+              dueDate: { lte: now },
+              status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+            },
+          },
+        },
+        select: {
+          id: true,
+          status: true,
+          payments: {
+            where: {
+              dueDate: { lte: now },
+              status: { in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] },
+            },
+            orderBy: { dueDate: 'asc' },
+            take: 1,
+            select: {
+              dueDate: true,
+              amountDue: true,
+              amountPaid: true,
+              lateFee: true,
+            },
+          },
+        },
+      });
+
+      const rows = contracts
+        .map((c) => {
+          const p = c.payments[0];
+          if (!p) return null;
+          const daysOverdue = Math.max(
+            0,
+            Math.floor((now.getTime() - new Date(p.dueDate).getTime()) / 86400000),
+          );
+          if (daysOverdue <= 0) return null;
+          const outstanding = new Prisma.Decimal(p.amountDue)
+            .sub(p.amountPaid)
+            .add(p.lateFee);
+          return {
+            contractId: c.id,
+            date: today,
+            daysOverdue,
+            outstanding,
+            status: c.status,
+          };
+        })
+        .filter((r): r is NonNullable<typeof r> => r !== null);
+
+      let snapshotted = 0;
+      if (rows.length > 0) {
+        const result = await this.prisma.contractDailySnapshot.createMany({
+          data: rows,
+          skipDuplicates: true,
+        });
+        snapshotted = result.count;
+      }
+
+      // Prune snapshots older than 30 days. Trending arrow needs only 7d;
+      // 30d retention gives headroom for short trend charts without
+      // unbounded growth.
+      const cutoff = new Date(today);
+      cutoff.setDate(cutoff.getDate() - 30);
+      const pruneResult = await this.prisma.contractDailySnapshot.deleteMany({
+        where: { date: { lt: cutoff } },
+      });
+      const pruned = pruneResult.count;
+
+      this.logger.log(
+        `Snapshotted ${snapshotted}/${rows.length} contracts; pruned ${pruned} rows older than ${cutoff.toISOString().slice(0, 10)}`,
+      );
+
+      Sentry.captureMessage(
+        `ContractSnapshot cron snapshotted ${snapshotted} contract(s)`,
+        {
+          level: 'info',
+          tags: { kind: 'cron-job', cron: 'contract-snapshot' },
+          extra: { snapshotted, candidates: rows.length, pruned },
+        },
+      );
+
+      return { snapshotted, pruned };
+    } catch (err) {
+      this.logger.error(
+        `Contract snapshot cron failed: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'contract-snapshot' },
+      });
+      throw err;
+    }
+  }
+}

--- a/apps/api/src/modules/overdue/dto/log-contact.dto.ts
+++ b/apps/api/src/modules/overdue/dto/log-contact.dto.ts
@@ -1,5 +1,26 @@
 import { IsIn, IsOptional, IsString, IsDateString, MaxLength } from 'class-validator';
 
+// P1 Task 12 — quick-tag enums captured from ContactLogDialog chips.
+// Keep values 1:1 with prisma `CallResult` and `NegotiationResult` enums.
+export const CALL_RESULT_VALUES = [
+  'ANSWERED',
+  'NO_ANSWER',
+  'BUSY',
+  'DEVICE_OFF',
+  'UNREACHABLE',
+] as const;
+export type CallResultTag = (typeof CALL_RESULT_VALUES)[number];
+
+export const NEGOTIATION_RESULT_VALUES = [
+  'REQUESTED_EXTENSION',
+  'WILL_PAY',
+  'REFUSED',
+  'REQUESTED_RETURN',
+  'NEGOTIATING',
+  'NOT_APPLICABLE',
+] as const;
+export type NegotiationResultTag = (typeof NEGOTIATION_RESULT_VALUES)[number];
+
 export class LogContactDto {
   @IsIn(['NO_ANSWER', 'ANSWERED', 'PROMISED', 'REFUSED', 'WRONG_NUMBER', 'OTHER'], {
     message: 'result ไม่ถูกต้อง',
@@ -23,4 +44,14 @@ export class LogContactDto {
   @IsOptional()
   @IsString()
   settlementNotes?: string;
+
+  // Quick-tag enum fields (Task 12). Optional for back-compat — older clients
+  // and the existing free-string `result` continue to work unchanged.
+  @IsOptional()
+  @IsIn(CALL_RESULT_VALUES, { message: 'callResult ไม่ถูกต้อง' })
+  callResult?: CallResultTag;
+
+  @IsOptional()
+  @IsIn(NEGOTIATION_RESULT_VALUES, { message: 'negotiationResult ไม่ถูกต้อง' })
+  negotiationResult?: NegotiationResultTag;
 }

--- a/apps/api/src/modules/overdue/dto/queue-query.dto.ts
+++ b/apps/api/src/modules/overdue/dto/queue-query.dto.ts
@@ -44,6 +44,20 @@ export enum MdmStateFilter {
   PENDING = 'pending',
 }
 
+// Sort options for the queue list. PRIORITY is the legacy default
+// (computed score from outstanding × daysOverdue × broken-promise multiplier).
+// RANDOM is a fair-rotation shuffle seeded by `userId-todayDate` so multiple
+// collectors don't all start from the same top contract.
+export enum QueueSortBy {
+  PRIORITY = 'priority',
+  OUTSTANDING_DESC = 'outstanding_desc',
+  OUTSTANDING_ASC = 'outstanding_asc',
+  DAYS_OVERDUE_DESC = 'days_overdue_desc',
+  LAST_CONTACTED_ASC = 'last_contacted_asc',
+  NAME_ASC = 'name_asc',
+  RANDOM = 'random',
+}
+
 // CSV or array → string[] (express parses repeated keys differently based on
 // query-parser; we accept both shapes).
 function splitCsv(value: unknown): string[] {
@@ -161,4 +175,8 @@ export class QueueQueryDto {
   @Transform(({ value }) => toBool(value))
   @IsBoolean()
   slipReviewPending?: boolean;
+
+  @IsOptional()
+  @IsEnum(QueueSortBy, { message: 'sortBy ไม่ถูกต้อง' })
+  sortBy?: QueueSortBy;
 }

--- a/apps/api/src/modules/overdue/dto/snooze.dto.ts
+++ b/apps/api/src/modules/overdue/dto/snooze.dto.ts
@@ -1,0 +1,40 @@
+import {
+  IsEnum,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
+
+/**
+ * Predefined snooze durations. Frontend renders these as preset buttons; the
+ * backend translates them into a concrete `snoozedUntil` timestamp at write
+ * time so the wall-clock semantics ("tomorrow 09:00 Bangkok") are computed
+ * server-side and immune to client-clock skew / timezone bugs.
+ *
+ * `CUSTOM` requires the caller to supply `snoozedUntil` directly.
+ */
+export enum SnoozeDuration {
+  ONE_HOUR = '1h',
+  TWO_HOURS = '2h',
+  TOMORROW_9AM = 'tomorrow_9am',
+  NEXT_WEEK = 'next_week',
+  CUSTOM = 'custom',
+}
+
+export class CreateSnoozeDto {
+  @IsEnum(SnoozeDuration, { message: 'duration ไม่ถูกต้อง' })
+  duration!: SnoozeDuration;
+
+  // Required only when duration === CUSTOM. ISO 8601 string in any timezone;
+  // the service rejects values that aren't strictly in the future.
+  @ValidateIf((o) => o.duration === SnoozeDuration.CUSTOM)
+  @IsISO8601({}, { message: 'snoozedUntil ต้องเป็นเวลา ISO 8601' })
+  snoozedUntil?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200, { message: 'เหตุผลยาวเกินไป (จำกัด 200 ตัวอักษร)' })
+  reason?: string;
+}

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -13,6 +13,7 @@ import { DunningRetryService } from './dunning-retry.service';
 import { OverdueAnalyticsService } from './analytics.service';
 import { AnalyticsAgingService } from './analytics-aging.service';
 import { AnalyticsLeaderboardService } from './analytics-leaderboard.service';
+import { StuckContractsService } from './stuck-contracts.service';
 import { ContractSnoozeService } from './snooze.service';
 import { CreateSnoozeDto } from './dto/snooze.dto';
 import { AnalyticsQueryDto } from './dto/analytics-query.dto';
@@ -52,6 +53,7 @@ export class OverdueController {
     private analyticsService: OverdueAnalyticsService,
     private analyticsAgingService: AnalyticsAgingService,
     private analyticsLeaderboardService: AnalyticsLeaderboardService,
+    private stuckContractsService: StuckContractsService,
     private snoozeService: ContractSnoozeService,
   ) {}
 
@@ -87,6 +89,7 @@ export class OverdueController {
       hasActivePromise: dto.hasActivePromise,
       mdmState: dto.mdmState,
       slipReviewPending: dto.slipReviewPending,
+      sortBy: dto.sortBy,
     });
   }
 
@@ -555,6 +558,14 @@ export class OverdueController {
   @Roles('OWNER')
   getAnalyticsLeaderboard() {
     return this.analyticsLeaderboardService.getLeaderboard();
+  }
+
+  @Get('analytics/stuck')
+  @Roles('OWNER')
+  getStuckContracts(@Query('days') daysRaw?: string) {
+    const parsed = daysRaw ? parseInt(daysRaw, 10) : 14;
+    const days = Number.isFinite(parsed) && parsed > 0 ? parsed : 14;
+    return this.stuckContractsService.getStuckContracts({ days });
   }
 
   // --- LINE retry endpoints ---

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -51,6 +51,7 @@ export class OverdueController {
     private dunningRetryService: DunningRetryService,
     private analyticsService: OverdueAnalyticsService,
     private analyticsAgingService: AnalyticsAgingService,
+    private analyticsLeaderboardService: AnalyticsLeaderboardService,
     private snoozeService: ContractSnoozeService,
   ) {}
 
@@ -548,6 +549,12 @@ export class OverdueController {
       userRole: user.role,
       userBranchId: user.branchId,
     });
+  }
+
+  @Get('analytics/leaderboard')
+  @Roles('OWNER')
+  getAnalyticsLeaderboard() {
+    return this.analyticsLeaderboardService.getLeaderboard();
   }
 
   // --- LINE retry endpoints ---

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -12,6 +12,7 @@ import { ContractLetterService } from './contract-letter.service';
 import { DunningRetryService } from './dunning-retry.service';
 import { OverdueAnalyticsService } from './analytics.service';
 import { AnalyticsAgingService } from './analytics-aging.service';
+import { AnalyticsLeaderboardService } from './analytics-leaderboard.service';
 import { ContractSnoozeService } from './snooze.service';
 import { CreateSnoozeDto } from './dto/snooze.dto';
 import { AnalyticsQueryDto } from './dto/analytics-query.dto';
@@ -382,6 +383,19 @@ export class OverdueController {
     @CurrentUser() user: { id: string; role: string },
   ) {
     return this.mdmLockService.unlock(id, user.id, user.role);
+  }
+
+  // --- Promise-due reminders (P1 Task 14) ---
+
+  @Get('promise-due-reminders')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  listPromiseDueReminders(
+    @CurrentUser() user: { id: string; role: string; branchId: string | null },
+  ) {
+    // Cross-branch roles see all branches; branch-scoped roles see their own.
+    const CROSS_BRANCH_ROLES = ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'];
+    const branchId = CROSS_BRANCH_ROLES.includes(user.role) ? null : user.branchId;
+    return this.overdueService.listPromiseDueRemindersToday(branchId);
   }
 
   // --- Bulk actions ---

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -11,6 +11,9 @@ import { OverdueBulkService } from './bulk.service';
 import { ContractLetterService } from './contract-letter.service';
 import { DunningRetryService } from './dunning-retry.service';
 import { OverdueAnalyticsService } from './analytics.service';
+import { AnalyticsAgingService } from './analytics-aging.service';
+import { ContractSnoozeService } from './snooze.service';
+import { CreateSnoozeDto } from './dto/snooze.dto';
 import { AnalyticsQueryDto } from './dto/analytics-query.dto';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
 import { AssignCollectorDto } from './dto/assign-collector.dto';
@@ -46,6 +49,8 @@ export class OverdueController {
     private contractLetterService: ContractLetterService,
     private dunningRetryService: DunningRetryService,
     private analyticsService: OverdueAnalyticsService,
+    private analyticsAgingService: AnalyticsAgingService,
+    private snoozeService: ContractSnoozeService,
   ) {}
 
   // --- Collections Workflow Hub endpoints (Plan 2) ---
@@ -493,12 +498,42 @@ export class OverdueController {
     return this.contractLetterService.cancel(id, user.id, body.reason);
   }
 
+  // --- Per-user snooze (B2 backend) ---
+
+  @Post('contracts/:id/snooze')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES', 'ACCOUNTANT')
+  snoozeContract(
+    @Param('id') id: string,
+    @Body() dto: CreateSnoozeDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.snoozeService.snooze(id, user.id, dto);
+  }
+
+  @Delete('contracts/:id/snooze')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES', 'ACCOUNTANT')
+  unsnoozeContract(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.snoozeService.unsnooze(id, user.id);
+  }
+
   // --- Collections analytics ---
 
   @Get('analytics')
   @Roles('OWNER', 'FINANCE_MANAGER')
   getAnalytics(@Query() dto: AnalyticsQueryDto) {
     return this.analyticsService.getAnalytics({ range: dto.range ?? '30d' });
+  }
+
+  @Get('analytics/aging')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER')
+  getAnalyticsAging(@CurrentUser() user: { role: string; branchId: string | null }) {
+    return this.analyticsAgingService.getAgingBuckets({
+      userRole: user.role,
+      userBranchId: user.branchId,
+    });
   }
 
   // --- LINE retry endpoints ---

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -14,6 +14,7 @@ import { DunningRetryService } from './dunning-retry.service';
 import { OverdueAnalyticsService } from './analytics.service';
 import { AnalyticsAgingService } from './analytics-aging.service';
 import { AnalyticsLeaderboardService } from './analytics-leaderboard.service';
+import { StuckContractsService } from './stuck-contracts.service';
 import { OwnerAlertHelper } from './owner-alert.helper';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
@@ -43,6 +44,7 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     OverdueAnalyticsService,
     AnalyticsAgingService,
     AnalyticsLeaderboardService,
+    StuckContractsService,
     OwnerAlertHelper,
     BrokenPromiseCron,
     MdmAutoProposeCron,

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -16,6 +16,7 @@ import { OwnerAlertHelper } from './owner-alert.helper';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
 import { LetterAutoGenerateCron } from './crons/letter-auto-generate.cron';
+import { ContractSnapshotCron } from './contract-snapshot.cron';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { LineOaModule } from '../line-oa/line-oa.module';
@@ -40,6 +41,7 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     BrokenPromiseCron,
     MdmAutoProposeCron,
     LetterAutoGenerateCron,
+    ContractSnapshotCron,
   ],
   exports: [
     OverdueService,

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -13,11 +13,13 @@ import { OverdueBulkService } from './bulk.service';
 import { DunningRetryService } from './dunning-retry.service';
 import { OverdueAnalyticsService } from './analytics.service';
 import { AnalyticsAgingService } from './analytics-aging.service';
+import { AnalyticsLeaderboardService } from './analytics-leaderboard.service';
 import { OwnerAlertHelper } from './owner-alert.helper';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
 import { LetterAutoGenerateCron } from './crons/letter-auto-generate.cron';
 import { ContractSnapshotCron } from './contract-snapshot.cron';
+import { BrokenPromiseReminderCron } from './broken-promise-reminder.cron';
 import { ContractSnoozeService } from './snooze.service';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -40,11 +42,13 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     DunningRetryService,
     OverdueAnalyticsService,
     AnalyticsAgingService,
+    AnalyticsLeaderboardService,
     OwnerAlertHelper,
     BrokenPromiseCron,
     MdmAutoProposeCron,
     LetterAutoGenerateCron,
     ContractSnapshotCron,
+    BrokenPromiseReminderCron,
     ContractSnoozeService,
   ],
   exports: [

--- a/apps/api/src/modules/overdue/overdue.module.ts
+++ b/apps/api/src/modules/overdue/overdue.module.ts
@@ -12,11 +12,13 @@ import { OverdueTimelineService } from './timeline.service';
 import { OverdueBulkService } from './bulk.service';
 import { DunningRetryService } from './dunning-retry.service';
 import { OverdueAnalyticsService } from './analytics.service';
+import { AnalyticsAgingService } from './analytics-aging.service';
 import { OwnerAlertHelper } from './owner-alert.helper';
 import { BrokenPromiseCron } from './crons/broken-promise.cron';
 import { MdmAutoProposeCron } from './crons/mdm-auto-propose.cron';
 import { LetterAutoGenerateCron } from './crons/letter-auto-generate.cron';
 import { ContractSnapshotCron } from './contract-snapshot.cron';
+import { ContractSnoozeService } from './snooze.service';
 import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { LineOaModule } from '../line-oa/line-oa.module';
@@ -37,11 +39,13 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     OverdueBulkService,
     DunningRetryService,
     OverdueAnalyticsService,
+    AnalyticsAgingService,
     OwnerAlertHelper,
     BrokenPromiseCron,
     MdmAutoProposeCron,
     LetterAutoGenerateCron,
     ContractSnapshotCron,
+    ContractSnoozeService,
   ],
   exports: [
     OverdueService,

--- a/apps/api/src/modules/overdue/overdue.service.spec.ts
+++ b/apps/api/src/modules/overdue/overdue.service.spec.ts
@@ -569,4 +569,25 @@ describe('OverdueService.logContact with event trigger wiring', () => {
     ).rejects.toThrow(NotFoundException);
     expect(engineSpy).not.toHaveBeenCalled();
   });
+
+  // P1 Task 12 — quick-tag enums.
+  it('persists callResult + negotiationResult quick-tag enums when supplied', async () => {
+    await service.logContact('c-1', 'u-1', {
+      result: 'ANSWERED',
+      callResult: 'ANSWERED',
+      negotiationResult: 'WILL_PAY',
+    });
+
+    const createArgs = prisma.callLog.create.mock.calls[0][0];
+    expect(createArgs.data.callResult).toBe('ANSWERED');
+    expect(createArgs.data.negotiationResult).toBe('WILL_PAY');
+  });
+
+  it('writes null for quick-tag enums when omitted (back-compat)', async () => {
+    await service.logContact('c-1', 'u-1', { result: 'NO_ANSWER' });
+
+    const createArgs = prisma.callLog.create.mock.calls[0][0];
+    expect(createArgs.data.callResult).toBeNull();
+    expect(createArgs.data.negotiationResult).toBeNull();
+  });
 });

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -909,6 +909,20 @@ export class OverdueService {
       collectionNotes?: string;
       settlementDate?: string;
       settlementNotes?: string;
+      // P1 Task 12 quick-tag enums (optional, back-compat).
+      callResult?:
+        | 'ANSWERED'
+        | 'NO_ANSWER'
+        | 'BUSY'
+        | 'DEVICE_OFF'
+        | 'UNREACHABLE';
+      negotiationResult?:
+        | 'REQUESTED_EXTENSION'
+        | 'WILL_PAY'
+        | 'REFUSED'
+        | 'REQUESTED_RETURN'
+        | 'NEGOTIATING'
+        | 'NOT_APPLICABLE';
     },
   ) {
     const contract = await this.prisma.contract.findFirst({
@@ -946,6 +960,11 @@ export class OverdueService {
           notes: dto.notes ?? null,
           settlementDate: dto.settlementDate ? new Date(dto.settlementDate) : null,
           settlementNotes: dto.settlementNotes ?? null,
+          // P1 Task 12 — quick-tag enums. Stored alongside the legacy `result`
+          // free-string for back-compat. Analytics dashboards prefer these
+          // structured columns going forward.
+          callResult: dto.callResult ?? null,
+          negotiationResult: dto.negotiationResult ?? null,
         },
         include: { caller: { select: { id: true, name: true } } },
       }),

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -1059,4 +1059,64 @@ export class OverdueService {
       totalContracts: contracts.length,
     };
   }
+
+  /**
+   * P1 Task 14 — Read today's "promise-due-reminder" suggestions written by
+   * BrokenPromiseReminderCron. Used by `BrokenPromiseBanner.tsx` in PromiseTab
+   * to surface "วันนี้มีนัดครบกำหนด N ราย" + bulk-LINE prompt.
+   *
+   * Window is the same Bangkok-local "today" the cron uses, so a reminder
+   * created at 09:00 BKK is visible here until 00:00 BKK tomorrow regardless
+   * of where the API host clock is.
+   */
+  async listPromiseDueRemindersToday(branchId: string | null) {
+    const RULE_ID = 'dunning-event-PROMISE_DUE_REMINDER';
+    const now = new Date();
+    const bkkNow = new Date(now.getTime() + 7 * 60 * 60 * 1000);
+    const startOfDayBkk = new Date(
+      Date.UTC(bkkNow.getUTCFullYear(), bkkNow.getUTCMonth(), bkkNow.getUTCDate(), 0, 0, 0, 0),
+    );
+    const startOfDayUtc = new Date(startOfDayBkk.getTime() - 7 * 60 * 60 * 1000);
+    const endOfDayUtc = new Date(startOfDayUtc.getTime() + 24 * 60 * 60 * 1000);
+
+    const rows = await this.prisma.dunningAction.findMany({
+      where: {
+        deletedAt: null,
+        dunningRuleId: RULE_ID,
+        createdAt: { gte: startOfDayUtc, lt: endOfDayUtc },
+        contract: {
+          deletedAt: null,
+          ...(branchId ? { branchId } : {}),
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        contractId: true,
+        createdAt: true,
+        contract: {
+          select: {
+            id: true,
+            contractNumber: true,
+            branchId: true,
+            customer: { select: { id: true, name: true, lineId: true, phone: true } },
+          },
+        },
+      },
+    });
+
+    return {
+      total: rows.length,
+      withLine: rows.filter((r) => !!r.contract.customer.lineId).length,
+      contractIds: rows.map((r) => r.contractId),
+      data: rows.map((r) => ({
+        id: r.id,
+        contractId: r.contractId,
+        contractNumber: r.contract.contractNumber,
+        customerName: r.contract.customer.name,
+        hasLine: !!r.contract.customer.lineId,
+        createdAt: r.createdAt,
+      })),
+    };
+  }
 }

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -27,6 +27,12 @@ const mockPrisma = {
   paymentEvidence: {
     groupBy: jest.fn(),
   },
+  contractDailySnapshot: {
+    findMany: jest.fn(),
+  },
+  contractSnooze: {
+    findMany: jest.fn(),
+  },
 };
 
 function resetEnrichmentMocks() {
@@ -38,6 +44,8 @@ function resetEnrichmentMocks() {
   mockPrisma.dunningAction.findMany.mockResolvedValue([]);
   mockPrisma.contractLetter.groupBy.mockResolvedValue([]);
   mockPrisma.paymentEvidence.groupBy.mockResolvedValue([]);
+  mockPrisma.contractDailySnapshot.findMany.mockResolvedValue([]);
+  mockPrisma.contractSnooze.findMany.mockResolvedValue([]);
 }
 
 describe('OverdueQueueService', () => {
@@ -493,12 +501,17 @@ describe('OverdueQueueService', () => {
       expect(result.data[0].lastChannel).toBeNull();
     });
 
-    it('batch-loads enrichment via 8 aggregate queries (no N+1)', async () => {
+    it('batch-loads enrichment via 10 aggregate queries (no N+1)', async () => {
       const contracts = [makeContract(), makeContract({ id: 'c2', customerId: 'cust-2' })];
       mockPrisma.contract.findMany.mockResolvedValueOnce(contracts);
       mockPrisma.contract.count.mockResolvedValueOnce(2);
 
-      await service.getQueue({ tab: 'today', userRole: 'OWNER', userBranchId: null });
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        userId: 'enricher-user',
+      });
 
       // One call per aggregate regardless of row count — no N+1
       expect(mockPrisma.callLog.groupBy).toHaveBeenCalledTimes(1);
@@ -511,6 +524,9 @@ describe('OverdueQueueService', () => {
       // New in v-P0-final: letterCount + slipReviewPending enrichment
       expect(mockPrisma.contractLetter.groupBy).toHaveBeenCalledTimes(1);
       expect(mockPrisma.paymentEvidence.groupBy).toHaveBeenCalledTimes(1);
+      // Task 10: trending arrow + per-user snooze badge enrichment
+      expect(mockPrisma.contractDailySnapshot.findMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.contractSnooze.findMany).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1005,6 +1021,145 @@ describe('OverdueQueueService', () => {
       });
       // c2 has highest outstanding × daysOverdue → priority leader
       expect(r.data[0].id).toBe('c2');
+    });
+  });
+
+  describe('trendingArrow (Task 10)', () => {
+    function makeContractWithDaysOverdue(id: string, days: number): any {
+      return {
+        id,
+        contractNumber: `BC-${id}`,
+        status: 'OVERDUE',
+        dunningStage: 'NONE',
+        customerId: `cu-${id}`,
+        noAnswerCount: 0,
+        needsSkipTracing: false,
+        deviceLocked: false,
+        customer: { id: `cu-${id}`, name: id, phone: '0', lineId: null },
+        branch: { id: 'b', name: 'b' },
+        assignedTo: null,
+        payments: [
+          {
+            amountDue: '5000',
+            amountPaid: '0',
+            lateFee: '0',
+            dueDate: new Date(Date.now() - days * 86400000),
+            status: 'OVERDUE',
+          },
+        ],
+        callLogs: [],
+        _count: { callLogs: 0 },
+      };
+    }
+
+    it("renders 'UP' when today's daysOverdue exceeds the 7-day-ago snapshot", async () => {
+      const c = makeContractWithDaysOverdue('worse', 15); // today: ~15 days
+      mockPrisma.contract.findMany.mockResolvedValueOnce([c]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.contractDailySnapshot.findMany.mockResolvedValueOnce([
+        { contractId: 'worse', daysOverdue: 8 }, // 7 days ago they were behind 8
+      ]);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(r.data[0].trendingArrow).toBe('UP');
+    });
+
+    it("renders 'DOWN' when today's daysOverdue is less than the snapshot", async () => {
+      const c = makeContractWithDaysOverdue('better', 5);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([c]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.contractDailySnapshot.findMany.mockResolvedValueOnce([
+        { contractId: 'better', daysOverdue: 12 },
+      ]);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(r.data[0].trendingArrow).toBe('DOWN');
+    });
+
+    it('renders null when delta is exactly zero (no change)', async () => {
+      const c = makeContractWithDaysOverdue('same', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([c]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.contractDailySnapshot.findMany.mockResolvedValueOnce([
+        { contractId: 'same', daysOverdue: 10 },
+      ]);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(r.data[0].trendingArrow).toBeNull();
+    });
+
+    it('renders null when no historical snapshot exists for this contract', async () => {
+      const c = makeContractWithDaysOverdue('new', 10);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([c]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.contractDailySnapshot.findMany.mockResolvedValueOnce([]); // no row
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      expect(r.data[0].trendingArrow).toBeNull();
+    });
+
+    it('queries snapshots in a ±1 day window around 7-days-ago (cron-skip tolerance)', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([
+        makeContractWithDaysOverdue('a', 5),
+      ]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+      });
+
+      const snapCall = mockPrisma.contractDailySnapshot.findMany.mock.calls[0][0];
+      expect(snapCall.distinct).toEqual(['contractId']);
+      const lo = snapCall.where.date.gte as Date;
+      const hi = snapCall.where.date.lte as Date;
+      // Window spans (7+1)d ago → (7-1)d ago = 8d → 6d ago
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const expectedLo = today.getTime() - 8 * 86400000;
+      const expectedHi = today.getTime() - 6 * 86400000;
+      expect(Math.abs(lo.getTime() - expectedLo)).toBeLessThan(86400000);
+      expect(Math.abs(hi.getTime() - expectedHi)).toBeLessThan(86400000);
+    });
+
+    it('OWNER receives snoozedUntil for contracts they have an active snooze on', async () => {
+      const c = makeContractWithDaysOverdue('snzd', 10);
+      const future = new Date(Date.now() + 3600 * 1000);
+      mockPrisma.contract.findMany.mockResolvedValueOnce([c]);
+      mockPrisma.contract.count.mockResolvedValueOnce(1);
+      mockPrisma.contractSnooze.findMany.mockResolvedValueOnce([
+        { contractId: 'snzd', snoozedUntil: future },
+      ]);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        userId: 'owner-1',
+      });
+
+      expect(r.data[0].snoozedUntil).toEqual(future);
     });
   });
 });

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -864,4 +864,147 @@ describe('OverdueQueueService', () => {
       expect(result.data.map((r) => r.id).sort()).toEqual(['a', 'b']);
     });
   });
+
+  describe('sortBy', () => {
+    function makeQueueRows() {
+      // 3 contracts with distinct outstanding/daysOverdue/name to disambiguate sort
+      return [
+        makeContract({
+          id: 'c1',
+          contractNumber: 'BC-1',
+          customer: { id: 'cu1', name: 'ก สมชาย', phone: '0811111111', lineId: null },
+          payments: [
+            {
+              amountDue: '1000.00',
+              amountPaid: '0.00',
+              lateFee: '0.00',
+              dueDate: new Date(Date.now() - 5 * 86400000),
+              status: 'OVERDUE',
+            },
+          ],
+        }),
+        makeContract({
+          id: 'c2',
+          contractNumber: 'BC-2',
+          customer: { id: 'cu2', name: 'ค สมหญิง', phone: '0822222222', lineId: null },
+          payments: [
+            {
+              amountDue: '5000.00',
+              amountPaid: '0.00',
+              lateFee: '0.00',
+              dueDate: new Date(Date.now() - 30 * 86400000),
+              status: 'OVERDUE',
+            },
+          ],
+        }),
+        makeContract({
+          id: 'c3',
+          contractNumber: 'BC-3',
+          customer: { id: 'cu3', name: 'ข สมพร', phone: '0833333333', lineId: null },
+          payments: [
+            {
+              amountDue: '3000.00',
+              amountPaid: '0.00',
+              lateFee: '0.00',
+              dueDate: new Date(Date.now() - 15 * 86400000),
+              status: 'OVERDUE',
+            },
+          ],
+        }),
+      ];
+    }
+
+    it('outstanding_desc returns highest-outstanding first', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce(makeQueueRows());
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+        sortBy: 'outstanding_desc' as any,
+      });
+      expect(r.data.map((row) => row.id)).toEqual(['c2', 'c3', 'c1']);
+    });
+
+    it('outstanding_asc returns lowest-outstanding first', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce(makeQueueRows());
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+        sortBy: 'outstanding_asc' as any,
+      });
+      expect(r.data.map((row) => row.id)).toEqual(['c1', 'c3', 'c2']);
+    });
+
+    it('days_overdue_desc returns oldest-overdue first', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce(makeQueueRows());
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+        sortBy: 'days_overdue_desc' as any,
+      });
+      expect(r.data.map((row) => row.id)).toEqual(['c2', 'c3', 'c1']);
+    });
+
+    it('name_asc sorts by Thai customer name', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce(makeQueueRows());
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+        sortBy: 'name_asc' as any,
+      });
+      // ก < ข < ค in Thai locale collation
+      expect(r.data.map((row) => row.id)).toEqual(['c1', 'c3', 'c2']);
+    });
+
+    it('random produces deterministic order for same userId+today', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce(makeQueueRows());
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const a = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+        userId: 'user-X',
+        sortBy: 'random' as any,
+      });
+
+      mockPrisma.contract.findMany.mockResolvedValueOnce(makeQueueRows());
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+      const b = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+        userId: 'user-X',
+        sortBy: 'random' as any,
+      });
+
+      expect(a.data.map((r) => r.id)).toEqual(b.data.map((r) => r.id));
+      // result is a permutation of inputs
+      expect([...a.data.map((r) => r.id)].sort()).toEqual(['c1', 'c2', 'c3']);
+    });
+
+    it('default (priority) preserves legacy behavior', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce(makeQueueRows());
+      mockPrisma.contract.count.mockResolvedValueOnce(3);
+
+      const r = await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+      });
+      // c2 has highest outstanding × daysOverdue → priority leader
+      expect(r.data[0].id).toBe('c2');
+    });
+  });
 });

--- a/apps/api/src/modules/overdue/queue.service.spec.ts
+++ b/apps/api/src/modules/overdue/queue.service.spec.ts
@@ -792,6 +792,59 @@ describe('OverdueQueueService', () => {
       expect(result.data[0].slipReviewPending).toBe(false);
     });
 
+    it('excludes contracts snoozed by current non-OWNER user (NOT { snoozes: { some } })', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'BRANCH_MANAGER',
+        userBranchId: 'branch-1',
+        userId: 'me-1',
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      const ands = (callArg.where.AND ?? []) as any[];
+      const snoozeClause = ands.find((c) => c?.NOT?.snoozes);
+      expect(snoozeClause).toBeDefined();
+      expect(snoozeClause.NOT.snoozes.some.userId).toBe('me-1');
+      expect(snoozeClause.NOT.snoozes.some.deletedAt).toBeNull();
+      expect(snoozeClause.NOT.snoozes.some.snoozedUntil.gt).toBeInstanceOf(Date);
+    });
+
+    it('OWNER role bypasses snooze exclusion (sees everything)', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'OWNER',
+        userBranchId: null,
+        userId: 'owner-1',
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      const ands = (callArg.where.AND ?? []) as any[];
+      const snoozeClause = ands.find((c) => c?.NOT?.snoozes);
+      expect(snoozeClause).toBeUndefined();
+    });
+
+    it('does not apply snooze exclusion when userId missing (e.g., system queries)', async () => {
+      mockPrisma.contract.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contract.count.mockResolvedValueOnce(0);
+
+      await service.getQueue({
+        tab: 'today',
+        userRole: 'SALES',
+        userBranchId: 'branch-1',
+      });
+
+      const callArg = mockPrisma.contract.findMany.mock.calls[0][0];
+      const ands = (callArg.where.AND ?? []) as any[];
+      const snoozeClause = ands.find((c) => c?.NOT?.snoozes);
+      expect(snoozeClause).toBeUndefined();
+    });
+
     it('minLetterCount=0 includes all contracts (no letters filter)', async () => {
       const a = makeContractWithDays('a', 10);
       const b = makeContractWithDays('b', 10);

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -104,7 +104,7 @@ export class OverdueQueueService {
       this.prisma.contract.count({ where }),
     ]);
 
-    const enriched = await this.enrichRows(contracts, now);
+    const enriched = await this.enrichRows(contracts, now, params.userId);
 
     // Post-enrichment filters — computed fields can't go into Prisma where.
     const afterPostFilter = this.applyPostFilters(enriched, params, now);
@@ -408,11 +408,28 @@ export class OverdueQueueService {
    * Uses batched groupBy + findMany(distinct) to avoid N+1 — one query per
    * aggregate regardless of how many contracts were fetched.
    */
-  private async enrichRows(contracts: any[], now: Date) {
+  private async enrichRows(
+    contracts: any[],
+    now: Date,
+    currentUserId: string | undefined,
+  ) {
     if (contracts.length === 0) return [];
 
     const contractIds = contracts.map((c) => c.id);
     const customerIds = [...new Set(contracts.map((c) => c.customerId))];
+
+    // For trending arrow: pull the snapshot closest to "7 days ago" within a
+    // ±1 day window so we still get a comparison even when the cron skipped
+    // a day (DB outage, deploy, etc.). `findMany({ distinct: contractId,
+    // orderBy: date desc })` collapses to one row per contract — the most
+    // recent snapshot in the window — which we then compare to today.
+    const sevenDaysAgo = new Date(now);
+    sevenDaysAgo.setHours(0, 0, 0, 0);
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+    const sevenDaysAgoLow = new Date(sevenDaysAgo);
+    sevenDaysAgoLow.setDate(sevenDaysAgoLow.getDate() - 1);
+    const sevenDaysAgoHigh = new Date(sevenDaysAgo);
+    sevenDaysAgoHigh.setDate(sevenDaysAgoHigh.getDate() + 1);
 
     const [
       lastCalls,
@@ -423,6 +440,8 @@ export class OverdueQueueService {
       lastChannels,
       letterCounts,
       pendingSlipEvidences,
+      sevenDayAgoSnapshots,
+      activeSnoozes,
     ] = await Promise.all([
       this.prisma.callLog.groupBy({
         by: ['contractId'],
@@ -490,6 +509,35 @@ export class OverdueQueueService {
         },
         _count: { _all: true },
       }),
+      // Trending arrow source — most recent snapshot within ±1d of 7 days
+      // ago, one row per contract (Task 10).
+      this.prisma.contractDailySnapshot.findMany({
+        where: {
+          contractId: { in: contractIds },
+          date: { gte: sevenDaysAgoLow, lte: sevenDaysAgoHigh },
+        },
+        orderBy: { date: 'desc' },
+        distinct: ['contractId'],
+        select: { contractId: true, daysOverdue: true },
+      }),
+      // Active per-user snoozes for the rows we fetched. OWNER sees the
+      // queue with snoozed cards retained (the SQL exclusion is bypassed for
+      // OWNER) — surface the snoozedUntil so the UI can render the badge.
+      // For non-OWNER callers this list is empty (their snoozed cards were
+      // already filtered out at the SQL level).
+      currentUserId
+        ? this.prisma.contractSnooze.findMany({
+            where: {
+              contractId: { in: contractIds },
+              userId: currentUserId,
+              snoozedUntil: { gt: now },
+              deletedAt: null,
+            },
+            orderBy: { snoozedUntil: 'desc' },
+            distinct: ['contractId'],
+            select: { contractId: true, snoozedUntil: true },
+          })
+        : Promise.resolve([] as { contractId: string; snoozedUntil: Date }[]),
     ]);
 
     const callMap = new Map<string, Date | null>(
@@ -516,6 +564,12 @@ export class OverdueQueueService {
     const slipPendingSet = new Set<string>(
       pendingSlipEvidences.filter((r) => r._count._all > 0).map((r) => r.contractId),
     );
+    const sevenDayMap = new Map<string, number>(
+      sevenDayAgoSnapshots.map((r) => [r.contractId, r.daysOverdue]),
+    );
+    const snoozeMap = new Map<string, Date>(
+      activeSnoozes.map((r) => [r.contractId, r.snoozedUntil]),
+    );
 
     return contracts.map((c) => {
       const base = this.toRow(c, now);
@@ -523,6 +577,12 @@ export class OverdueQueueService {
       const action = actionMap.get(c.id) ?? null;
       const lastContactedAt =
         call && action ? (call > action ? call : action) : call ?? action ?? null;
+
+      const trendingArrow = this.computeTrendingArrow(
+        base.daysOverdue,
+        sevenDayMap.get(c.id),
+      );
+      const snoozedUntil = snoozeMap.get(c.id) ?? null;
 
       return {
         ...base,
@@ -533,8 +593,34 @@ export class OverdueQueueService {
         lastChannel: this.toLastChannel(channelMap.get(c.id)),
         letterCount: letterCountMap.get(c.id) ?? 0,
         slipReviewPending: slipPendingSet.has(c.id),
+        trendingArrow,
+        snoozedUntil,
       };
     });
+  }
+
+  /**
+   * Compare today's daysOverdue with the same contract's daysOverdue ~7
+   * days ago. Returns:
+   *  - 'UP'   delta > 0 → getting worse (overdue accumulating)
+   *  - 'DOWN' delta < 0 → improving (customer paid down balance)
+   *  - null   no historical snapshot OR delta === 0
+   *
+   * Important: zero-delta and missing-data both render as "no arrow" in
+   * the UI. They are semantically different (no info vs no change) but
+   * surfacing two distinct null states would clutter the badge — the UI
+   * already shows the absolute daysOverdue prominently, so the trend chip
+   * is purely additive.
+   */
+  private computeTrendingArrow(
+    todayDays: number,
+    sevenDayDays: number | undefined,
+  ): 'UP' | 'DOWN' | null {
+    if (sevenDayDays === undefined) return null;
+    const delta = todayDays - sevenDayDays;
+    if (delta > 0) return 'UP';
+    if (delta < 0) return 'DOWN';
+    return null;
   }
 
   private toMdmState(status: string | undefined): MdmState {

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -6,7 +6,9 @@ import {
   LineResponseState,
   MdmStateFilter,
   OverdueBucket,
+  QueueSortBy,
 } from './dto/queue-query.dto';
+import { seededShuffle } from '../../utils/shuffle.util';
 
 export type QueueTab = 'today' | 'followup' | 'promise';
 
@@ -34,6 +36,9 @@ export interface QueueFilterInput {
   hasActivePromise?: boolean;
   mdmState?: MdmStateFilter;
   slipReviewPending?: boolean;
+
+  // Sort (post-enrichment)
+  sortBy?: QueueSortBy;
 }
 
 @Injectable()
@@ -104,7 +109,7 @@ export class OverdueQueueService {
     // Post-enrichment filters — computed fields can't go into Prisma where.
     const afterPostFilter = this.applyPostFilters(enriched, params, now);
 
-    const rows = afterPostFilter.sort((a, b) => b.__priorityScore - a.__priorityScore);
+    const rows = this.applySort(afterPostFilter, params.sortBy, params.userId, now);
 
     // If any post-filter fired, `total` must reflect filtered count so UI
     // pagination doesn't read "500 results" while showing 12. When no post-
@@ -218,6 +223,54 @@ export class OverdueQueueService {
       ...(Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : []),
       exclusion,
     ];
+  }
+
+  /**
+   * Apply sort to enriched rows. Default (PRIORITY) uses the legacy in-memory
+   * priority score (outstanding × daysOverdue × broken-promise multiplier).
+   * Other sorts read directly from enriched fields. RANDOM uses a deterministic
+   * Mulberry32 shuffle seeded by `${userId}-${YYYY-MM-DD}` so each collector
+   * sees a stable order within a single day, but a different order than peers
+   * — fair rotation without losing reload stability.
+   */
+  private applySort<
+    T extends {
+      outstanding: number;
+      daysOverdue: number;
+      lastContactedAt: Date | null;
+      customer: { name: string };
+      __priorityScore: number;
+      id: string;
+    },
+  >(rows: T[], sortBy: QueueSortBy | undefined, userId: string | undefined, now: Date): T[] {
+    const arr = rows.slice();
+    switch (sortBy) {
+      case QueueSortBy.OUTSTANDING_DESC:
+        return arr.sort((a, b) => b.outstanding - a.outstanding);
+      case QueueSortBy.OUTSTANDING_ASC:
+        return arr.sort((a, b) => a.outstanding - b.outstanding);
+      case QueueSortBy.DAYS_OVERDUE_DESC:
+        return arr.sort((a, b) => b.daysOverdue - a.daysOverdue);
+      case QueueSortBy.LAST_CONTACTED_ASC:
+        // Never-contacted (null) ranks first — they're the most stale.
+        return arr.sort((a, b) => {
+          const at = a.lastContactedAt ? new Date(a.lastContactedAt).getTime() : -Infinity;
+          const bt = b.lastContactedAt ? new Date(b.lastContactedAt).getTime() : -Infinity;
+          return at - bt;
+        });
+      case QueueSortBy.NAME_ASC:
+        return arr.sort((a, b) =>
+          (a.customer.name ?? '').localeCompare(b.customer.name ?? '', 'th'),
+        );
+      case QueueSortBy.RANDOM: {
+        const today = now.toISOString().slice(0, 10);
+        const seed = `${userId ?? 'anon'}-${today}`;
+        return seededShuffle(arr, seed);
+      }
+      case QueueSortBy.PRIORITY:
+      default:
+        return arr.sort((a, b) => b.__priorityScore - a.__priorityScore);
+    }
   }
 
   /**

--- a/apps/api/src/modules/overdue/queue.service.ts
+++ b/apps/api/src/modules/overdue/queue.service.ts
@@ -64,6 +64,7 @@ export class OverdueQueueService {
 
     const where = this.buildWhere(params.tab, now, branchScope);
     this.applyFilterWhere(where, params, params.userId);
+    this.applySnoozeExclusion(where, params.userRole, params.userId, now);
 
     // Fetch all matching then sort by priority score in memory, then paginate.
     // We can't express the priority formula as a Prisma orderBy (it involves a
@@ -182,6 +183,41 @@ export class OverdueQueueService {
         ];
       }
     }
+  }
+
+  /**
+   * Hide contracts the current user has snoozed (active ContractSnooze rows
+   * with `snoozedUntil > now`). OWNER bypasses the exclusion entirely so
+   * they can audit what their team has parked. Anonymous calls (no userId)
+   * also pass through unfiltered — there is nobody to exclude for.
+   *
+   * Implemented as a Prisma `NOT { snoozes: { some: { ... } } }` so the
+   * filter happens in SQL (no in-memory gymnastics on large queues).
+   */
+  private applySnoozeExclusion(
+    where: Prisma.ContractWhereInput,
+    userRole: string,
+    userId: string | undefined,
+    now: Date,
+  ): void {
+    if (!userId) return;
+    if (userRole === 'OWNER') return;
+
+    const exclusion: Prisma.ContractWhereInput = {
+      NOT: {
+        snoozes: {
+          some: {
+            userId,
+            snoozedUntil: { gt: now },
+            deletedAt: null,
+          },
+        },
+      },
+    };
+    where.AND = [
+      ...(Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : []),
+      exclusion,
+    ];
   }
 
   /**

--- a/apps/api/src/modules/overdue/snooze.service.spec.ts
+++ b/apps/api/src/modules/overdue/snooze.service.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ContractSnoozeService } from './snooze.service';
+import { SnoozeDuration } from './dto/snooze.dto';
+
+const mockPrisma = {
+  contract: {
+    findFirst: jest.fn(),
+  },
+  contractSnooze: {
+    updateMany: jest.fn(),
+    create: jest.fn(),
+  },
+};
+
+describe('ContractSnoozeService', () => {
+  let service: ContractSnoozeService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPrisma.contract.findFirst.mockResolvedValue({ id: 'contract-1' });
+    mockPrisma.contractSnooze.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.contractSnooze.create.mockImplementation((args: any) =>
+      Promise.resolve({ id: 'snooze-1', ...args.data }),
+    );
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractSnoozeService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = mod.get(ContractSnoozeService);
+  });
+
+  describe('snooze (create)', () => {
+    it('throws NotFoundException when contract missing or soft-deleted', async () => {
+      mockPrisma.contract.findFirst.mockResolvedValueOnce(null);
+      await expect(
+        service.snooze('missing', 'user-1', { duration: SnoozeDuration.ONE_HOUR }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('1h preset → snoozedUntil ~1h in future', async () => {
+      const before = Date.now();
+      await service.snooze('contract-1', 'user-1', { duration: SnoozeDuration.ONE_HOUR });
+      const after = Date.now();
+
+      const created = mockPrisma.contractSnooze.create.mock.calls[0][0].data;
+      const ms = (created.snoozedUntil as Date).getTime();
+      expect(ms).toBeGreaterThanOrEqual(before + 60 * 60 * 1000 - 100);
+      expect(ms).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 100);
+    });
+
+    it('2h preset → snoozedUntil ~2h in future', async () => {
+      const before = Date.now();
+      await service.snooze('contract-1', 'user-1', { duration: SnoozeDuration.TWO_HOURS });
+
+      const created = mockPrisma.contractSnooze.create.mock.calls[0][0].data;
+      const ms = (created.snoozedUntil as Date).getTime();
+      expect(ms).toBeGreaterThanOrEqual(before + 2 * 60 * 60 * 1000 - 100);
+    });
+
+    it('tomorrow 09:00 preset → next-day 09:00 Asia/Bangkok', async () => {
+      await service.snooze('contract-1', 'user-1', {
+        duration: SnoozeDuration.TOMORROW_9AM,
+      });
+      const created = mockPrisma.contractSnooze.create.mock.calls[0][0].data;
+      const dt = created.snoozedUntil as Date;
+      // Bangkok 09:00 = UTC 02:00. Verify hour falls on UTC 02 (with ±1h
+      // tolerance for DST / fractional UTC offsets — Asia/Bangkok is fixed +7
+      // so this is exact, but keep cushion for test timing edge cases).
+      expect(dt.getUTCHours()).toBe(2);
+      expect(dt.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('next_week preset → ~7 days in future', async () => {
+      const before = Date.now();
+      await service.snooze('contract-1', 'user-1', { duration: SnoozeDuration.NEXT_WEEK });
+      const created = mockPrisma.contractSnooze.create.mock.calls[0][0].data;
+      const ms = (created.snoozedUntil as Date).getTime();
+      // 7 days ± a few hours (depending on rounding to start-of-day)
+      expect(ms).toBeGreaterThanOrEqual(before + 6 * 86400 * 1000);
+      expect(ms).toBeLessThanOrEqual(before + 8 * 86400 * 1000);
+    });
+
+    it('CUSTOM with future ISO string is honored', async () => {
+      const future = new Date(Date.now() + 3 * 86400000).toISOString();
+      await service.snooze('contract-1', 'user-1', {
+        duration: SnoozeDuration.CUSTOM,
+        snoozedUntil: future,
+      });
+      const created = mockPrisma.contractSnooze.create.mock.calls[0][0].data;
+      expect((created.snoozedUntil as Date).toISOString()).toBe(future);
+    });
+
+    it('CUSTOM rejects past datetime', async () => {
+      const past = new Date(Date.now() - 86400000).toISOString();
+      await expect(
+        service.snooze('contract-1', 'user-1', {
+          duration: SnoozeDuration.CUSTOM,
+          snoozedUntil: past,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('CUSTOM without snoozedUntil throws BadRequest', async () => {
+      await expect(
+        service.snooze('contract-1', 'user-1', { duration: SnoozeDuration.CUSTOM }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('replaces any active snooze for same (contract, user) atomically', async () => {
+      await service.snooze('contract-1', 'user-1', { duration: SnoozeDuration.ONE_HOUR });
+
+      // Soft-delete sweep on prior actives must run before insert.
+      expect(mockPrisma.contractSnooze.updateMany).toHaveBeenCalledWith({
+        where: {
+          contractId: 'contract-1',
+          userId: 'user-1',
+          deletedAt: null,
+        },
+        data: { deletedAt: expect.any(Date) },
+      });
+      const updateOrder =
+        mockPrisma.contractSnooze.updateMany.mock.invocationCallOrder[0];
+      const createOrder = mockPrisma.contractSnooze.create.mock.invocationCallOrder[0];
+      expect(updateOrder).toBeLessThan(createOrder);
+    });
+
+    it('persists reason when supplied', async () => {
+      await service.snooze('contract-1', 'user-1', {
+        duration: SnoozeDuration.ONE_HOUR,
+        reason: 'รอลูกค้าโทรกลับ',
+      });
+      const created = mockPrisma.contractSnooze.create.mock.calls[0][0].data;
+      expect(created.reason).toBe('รอลูกค้าโทรกลับ');
+    });
+  });
+
+  describe('unsnooze (delete)', () => {
+    it('soft-deletes all active snoozes for (contract, user) and returns count', async () => {
+      mockPrisma.contractSnooze.updateMany.mockResolvedValueOnce({ count: 1 });
+
+      const result = await service.unsnooze('contract-1', 'user-1');
+
+      expect(mockPrisma.contractSnooze.updateMany).toHaveBeenCalledWith({
+        where: {
+          contractId: 'contract-1',
+          userId: 'user-1',
+          deletedAt: null,
+        },
+        data: { deletedAt: expect.any(Date) },
+      });
+      expect(result).toEqual({ unsnoozed: 1 });
+    });
+
+    it('returns unsnoozed:0 when no active snooze exists (idempotent)', async () => {
+      mockPrisma.contractSnooze.updateMany.mockResolvedValueOnce({ count: 0 });
+      const result = await service.unsnooze('contract-1', 'user-1');
+      expect(result).toEqual({ unsnoozed: 0 });
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/snooze.service.ts
+++ b/apps/api/src/modules/overdue/snooze.service.ts
@@ -1,0 +1,116 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateSnoozeDto, SnoozeDuration } from './dto/snooze.dto';
+
+/**
+ * Per-user snooze for collections queue cards.
+ *
+ * - One active snooze per (contractId, userId) pair: snoozing again replaces
+ *   the previous active record (soft-delete sweep first, then create). This
+ *   keeps the audit trail intact ("user X snoozed contract Y five times")
+ *   while never letting two active rows fight each other.
+ * - Wall-clock semantics for presets (`tomorrow_9am`, `next_week`) are
+ *   computed server-side in Asia/Bangkok so the user sees consistent
+ *   behaviour regardless of their device timezone or clock skew.
+ * - Custom datetime must be strictly in the future.
+ */
+@Injectable()
+export class ContractSnoozeService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async snooze(
+    contractId: string,
+    userId: string,
+    dto: CreateSnoozeDto,
+  ): Promise<{ id: string; snoozedUntil: Date }> {
+    const contract = await this.prisma.contract.findFirst({
+      where: { id: contractId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!contract) {
+      throw new NotFoundException('ไม่พบสัญญานี้');
+    }
+
+    const snoozedUntil = this.computeSnoozedUntil(dto);
+
+    // Soft-delete prior active snoozes for this (contract, user) so the new
+    // record is the unambiguous source of truth.
+    await this.prisma.contractSnooze.updateMany({
+      where: { contractId, userId, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+
+    const created = await this.prisma.contractSnooze.create({
+      data: {
+        contractId,
+        userId,
+        snoozedUntil,
+        reason: dto.reason ?? null,
+      },
+    });
+
+    return { id: created.id, snoozedUntil: created.snoozedUntil };
+  }
+
+  async unsnooze(
+    contractId: string,
+    userId: string,
+  ): Promise<{ unsnoozed: number }> {
+    const result = await this.prisma.contractSnooze.updateMany({
+      where: { contractId, userId, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+    return { unsnoozed: result.count };
+  }
+
+  /**
+   * Translate preset → concrete Date. Wall-clock anchors (tomorrow 09:00,
+   * next-week start-of-week) are derived from Asia/Bangkok so the same user
+   * action produces the same snooze regardless of device locale.
+   */
+  private computeSnoozedUntil(dto: CreateSnoozeDto): Date {
+    const now = new Date();
+    switch (dto.duration) {
+      case SnoozeDuration.ONE_HOUR:
+        return new Date(now.getTime() + 60 * 60 * 1000);
+      case SnoozeDuration.TWO_HOURS:
+        return new Date(now.getTime() + 2 * 60 * 60 * 1000);
+      case SnoozeDuration.TOMORROW_9AM:
+        return tomorrowAt9amBangkok(now);
+      case SnoozeDuration.NEXT_WEEK:
+        return new Date(now.getTime() + 7 * 86400 * 1000);
+      case SnoozeDuration.CUSTOM: {
+        if (!dto.snoozedUntil) {
+          throw new BadRequestException('กรุณาระบุเวลาที่จะ snooze');
+        }
+        const dt = new Date(dto.snoozedUntil);
+        if (Number.isNaN(dt.getTime())) {
+          throw new BadRequestException('snoozedUntil ไม่ใช่เวลาที่ถูกต้อง');
+        }
+        if (dt.getTime() <= now.getTime()) {
+          throw new BadRequestException('เวลา snooze ต้องอยู่ในอนาคต');
+        }
+        return dt;
+      }
+    }
+  }
+}
+
+/**
+ * Compute "tomorrow 09:00 Asia/Bangkok" as a UTC Date. Bangkok is fixed UTC+7
+ * (no DST), so 09:00 local == 02:00 UTC on the same wall-clock day.
+ */
+function tomorrowAt9amBangkok(now: Date): Date {
+  // Convert "now" to Bangkok wall-clock by adding +7h, then read calendar
+  // date components.
+  const bangkokNow = new Date(now.getTime() + 7 * 60 * 60 * 1000);
+  const y = bangkokNow.getUTCFullYear();
+  const m = bangkokNow.getUTCMonth();
+  const d = bangkokNow.getUTCDate();
+  // Tomorrow 09:00 Bangkok = (next-day) 02:00 UTC
+  return new Date(Date.UTC(y, m, d + 1, 2, 0, 0, 0));
+}

--- a/apps/api/src/modules/overdue/stuck-contracts.service.spec.ts
+++ b/apps/api/src/modules/overdue/stuck-contracts.service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { StuckContractsService } from './stuck-contracts.service';
+
+const mockPrisma = {
+  $queryRawUnsafe: jest.fn(),
+};
+
+describe('StuckContractsService', () => {
+  let service: StuckContractsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StuckContractsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(StuckContractsService);
+  });
+
+  it('returns empty array when no stuck contracts', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]);
+    const result = await service.getStuckContracts({ days: 14 });
+    expect(result).toEqual([]);
+  });
+
+  it('maps DB rows + computes daysIdle', async () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 86400000);
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([
+      {
+        id: 'c1',
+        contract_number: 'C-001',
+        customer_name: 'นายเอ',
+        customer_phone: '0812345678',
+        branch_name: 'สาขา 1',
+        assigned_to_id: 'u1',
+        assigned_to_name: 'แนน',
+        last_activity: tenDaysAgo,
+        outstanding: '5500.00',
+      },
+    ]);
+    const result = await service.getStuckContracts({ days: 7 });
+    expect(result).toHaveLength(1);
+    expect(result[0].contractId).toBe('c1');
+    expect(result[0].daysIdle).toBeGreaterThanOrEqual(9);
+    expect(result[0].daysIdle).toBeLessThanOrEqual(11);
+    expect(result[0].outstanding).toBe(5500);
+  });
+
+  it('handles null assigned + null phone', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([
+      {
+        id: 'c2',
+        contract_number: 'C-002',
+        customer_name: 'นายบี',
+        customer_phone: null,
+        branch_name: 'สาขา 2',
+        assigned_to_id: null,
+        assigned_to_name: null,
+        last_activity: null,
+        outstanding: 0,
+      },
+    ]);
+    const result = await service.getStuckContracts({ days: 14 });
+    expect(result[0].customerPhone).toBeNull();
+    expect(result[0].assignedToId).toBeNull();
+    expect(result[0].outstanding).toBe(0);
+  });
+
+  it('clamps days to [1, 365]', async () => {
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]);
+    await service.getStuckContracts({ days: -5 });
+    expect(mockPrisma.$queryRawUnsafe).toHaveBeenCalledWith(expect.any(String), 1);
+    await service.getStuckContracts({ days: 9999 });
+    expect(mockPrisma.$queryRawUnsafe).toHaveBeenLastCalledWith(expect.any(String), 365);
+  });
+
+  it('returns empty list on DB error (no throw)', async () => {
+    mockPrisma.$queryRawUnsafe.mockRejectedValue(new Error('boom'));
+    const result = await service.getStuckContracts({ days: 14 });
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/overdue/stuck-contracts.service.ts
+++ b/apps/api/src/modules/overdue/stuck-contracts.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface StuckContractRow {
+  contractId: string;
+  contractNumber: string;
+  customerName: string;
+  customerPhone: string | null;
+  branchName: string;
+  assignedToId: string | null;
+  assignedToName: string | null;
+  daysIdle: number;
+  outstanding: number;
+}
+
+interface RawRow {
+  id: string;
+  contract_number: string;
+  customer_name: string;
+  customer_phone: string | null;
+  branch_name: string;
+  assigned_to_id: string | null;
+  assigned_to_name: string | null;
+  last_activity: Date | null;
+  outstanding: number | string | null;
+}
+
+@Injectable()
+export class StuckContractsService {
+  private readonly logger = new Logger(StuckContractsService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Returns active overdue contracts that have had no audit log, no call log,
+   * and no dunning action in the past `days` days. These are at risk of being
+   * "forgotten" — a collector should reach out or the contract should be
+   * reassigned.
+   *
+   * Threshold: takes the MAX of (last call_log, last dunning_action,
+   * contract.last_contact_date). If that timestamp is older than `days` days
+   * ago (or null entirely), the contract is "stuck".
+   */
+  async getStuckContracts(params: { days: number }): Promise<StuckContractRow[]> {
+    const days = Math.max(1, Math.min(params.days, 365));
+    try {
+      const rows = await this.prisma.$queryRawUnsafe<RawRow[]>(
+        `
+        WITH last_activity AS (
+          SELECT
+            c.id AS contract_id,
+            GREATEST(
+              COALESCE(MAX(cl.called_at), '1970-01-01'::timestamp),
+              COALESCE(MAX(da.created_at), '1970-01-01'::timestamp),
+              COALESCE(c.last_contact_date, '1970-01-01'::timestamp)
+            ) AS last_activity
+          FROM contracts c
+          LEFT JOIN call_logs cl ON cl.contract_id = c.id AND cl.deleted_at IS NULL
+          LEFT JOIN dunning_actions da
+            ON da.contract_id = c.id AND da.deleted_at IS NULL
+          WHERE c.deleted_at IS NULL
+            AND c.status IN ('OVERDUE', 'DEFAULT', 'LEGAL')
+          GROUP BY c.id, c.last_contact_date
+        ),
+        outstanding AS (
+          SELECT
+            p.contract_id,
+            SUM((p.amount_due - p.amount_paid + p.late_fee))::numeric AS amt
+          FROM payments p
+          WHERE p.deleted_at IS NULL
+            AND p.status IN ('PENDING', 'OVERDUE', 'PARTIALLY_PAID')
+          GROUP BY p.contract_id
+        )
+        SELECT
+          c.id,
+          c.contract_number,
+          cu.name AS customer_name,
+          cu.phone AS customer_phone,
+          b.name AS branch_name,
+          c.assigned_to_id,
+          u.name AS assigned_to_name,
+          la.last_activity,
+          COALESCE(o.amt, 0) AS outstanding
+        FROM contracts c
+        INNER JOIN customers cu ON cu.id = c.customer_id
+        INNER JOIN branches b ON b.id = c.branch_id
+        LEFT JOIN users u ON u.id = c.assigned_to_id
+        INNER JOIN last_activity la ON la.contract_id = c.id
+        LEFT JOIN outstanding o ON o.contract_id = c.id
+        WHERE c.deleted_at IS NULL
+          AND c.status IN ('OVERDUE', 'DEFAULT', 'LEGAL')
+          AND la.last_activity < NOW() - ($1::int * INTERVAL '1 day')
+        ORDER BY la.last_activity ASC
+        LIMIT 200
+        `,
+        days,
+      );
+
+      const now = Date.now();
+      return rows.map((r) => {
+        const lastMs = r.last_activity ? r.last_activity.getTime() : 0;
+        const idleMs = Math.max(0, now - lastMs);
+        return {
+          contractId: r.id,
+          contractNumber: r.contract_number,
+          customerName: r.customer_name,
+          customerPhone: r.customer_phone,
+          branchName: r.branch_name,
+          assignedToId: r.assigned_to_id,
+          assignedToName: r.assigned_to_name,
+          daysIdle: Math.floor(idleMs / 86400000),
+          outstanding: r.outstanding == null ? 0 : Number(r.outstanding),
+        };
+      });
+    } catch (err) {
+      this.logger.error('stuck contracts query failed', err);
+      return [];
+    }
+  }
+}

--- a/apps/api/src/utils/shuffle.util.spec.ts
+++ b/apps/api/src/utils/shuffle.util.spec.ts
@@ -1,0 +1,66 @@
+import { hashString, mulberry32, seededShuffle } from './shuffle.util';
+
+describe('shuffle.util', () => {
+  describe('mulberry32', () => {
+    it('produces deterministic output for the same seed', () => {
+      const a = mulberry32(42);
+      const b = mulberry32(42);
+      expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+    });
+
+    it('produces different outputs for different seeds', () => {
+      const a = mulberry32(1);
+      const b = mulberry32(2);
+      expect(a()).not.toBe(b());
+    });
+
+    it('produces values in [0, 1)', () => {
+      const r = mulberry32(123);
+      for (let i = 0; i < 50; i++) {
+        const v = r();
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThan(1);
+      }
+    });
+  });
+
+  describe('hashString', () => {
+    it('is stable for the same input', () => {
+      expect(hashString('user-1-2026-04-25')).toBe(hashString('user-1-2026-04-25'));
+    });
+
+    it('returns different values for different inputs', () => {
+      expect(hashString('a')).not.toBe(hashString('b'));
+    });
+  });
+
+  describe('seededShuffle', () => {
+    const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+    it('does not mutate the input array', () => {
+      const original = items.slice();
+      seededShuffle(items, 'seed-1');
+      expect(items).toEqual(original);
+    });
+
+    it('returns the same items (just reordered)', () => {
+      const out = seededShuffle(items, 'seed-1');
+      expect(out.slice().sort((a, b) => a - b)).toEqual(items);
+    });
+
+    it('is deterministic for the same seed', () => {
+      expect(seededShuffle(items, 'k1')).toEqual(seededShuffle(items, 'k1'));
+    });
+
+    it('produces a different order for a different seed', () => {
+      const a = seededShuffle(items, 'user-A-2026-04-25');
+      const b = seededShuffle(items, 'user-B-2026-04-25');
+      expect(a).not.toEqual(b);
+    });
+
+    it('handles empty + single-element arrays', () => {
+      expect(seededShuffle([], 's')).toEqual([]);
+      expect(seededShuffle([42], 's')).toEqual([42]);
+    });
+  });
+});

--- a/apps/api/src/utils/shuffle.util.ts
+++ b/apps/api/src/utils/shuffle.util.ts
@@ -1,0 +1,50 @@
+/**
+ * Mulberry32 — tiny seeded PRNG (32-bit). Deterministic when given the same
+ * seed; used for fair-rotation random sort in the collections queue so each
+ * user sees a stable order within a single day, but a different order than
+ * peers/yesterday.
+ *
+ * Reference: https://en.wikipedia.org/wiki/Pseudorandom_number_generator
+ *            https://stackoverflow.com/a/47593316
+ */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * String → 32-bit integer hash (FNV-1a). Stable across runs/environments —
+ * same string produces the same int. Used to seed mulberry32 from a
+ * `${userId}-${YYYY-MM-DD}` rotation key.
+ */
+export function hashString(input: string): number {
+  let h = 0x811c9dc5; // FNV-1a 32-bit offset basis
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193); // FNV-1a 32-bit prime
+  }
+  return h >>> 0;
+}
+
+/**
+ * Fisher–Yates shuffle driven by a deterministic PRNG. Returns a *new* array;
+ * does not mutate the input.
+ *
+ * @param items - input array (treated as immutable)
+ * @param seed  - rotation key, e.g. `${userId}-${todayISODate}`
+ */
+export function seededShuffle<T>(items: readonly T[], seed: string): T[] {
+  const out = items.slice();
+  const rng = mulberry32(hashString(seed));
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -78,6 +78,7 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",
+    "react-hotkeys-hook": "^5.2.4",
     "react-qr-code": "^2.0.18",
     "react-resizable-panels": "^4.10.0",
     "react-router": "^7.14.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,7 +26,6 @@ const ContractDetailPage = lazy(() => import('@/pages/ContractDetailPage'));
 const ContractSignPage = lazy(() => import('@/pages/ContractSignPage'));
 const ContractTemplatesPage = lazy(() => import('@/pages/ContractTemplatesPage'));
 const PaymentsPage = lazy(() => import('@/pages/PaymentsPage'));
-const OverduePage = lazy(() => import('@/pages/OverduePage'));
 const RepossessionsPage = lazy(() => import('@/pages/RepossessionsPage'));
 const NotificationsPage = lazy(() => import('@/pages/NotificationsPage'));
 const ReportsPage = lazy(() => import('@/pages/ReportsPage'));
@@ -425,7 +424,11 @@ function App() {
           />
           <Route path="/receipts" element={<Navigate to="/payments?tab=receipts" replace />} />
           <Route path="/verify/:receiptNumber" element={<ReceiptVerifyPage />} />
-          <Route path="/overdue" element={<OverduePage />} />
+          {/* /overdue → /collections (Task 18 of 2026-04-25-collections-ui-p1).
+              Old route kept as a redirect so external bookmarks/LINE links keep
+              working. MigrationBanner on /collections nudges users to update. */}
+          <Route path="/overdue" element={<Navigate to="/collections" replace />} />
+          <Route path="/overdue/*" element={<Navigate to="/collections" replace />} />
           <Route path="/collections" element={<CollectionsPage />} />
           <Route
             path="/collection-dashboard"

--- a/apps/web/src/hooks/useCollectionsKeyboard.test.tsx
+++ b/apps/web/src/hooks/useCollectionsKeyboard.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCollectionsKeyboard } from './useCollectionsKeyboard';
+
+// react-hotkeys-hook reads `key` AND `code` (it ignores events without `code`).
+function codeFor(key: string): string {
+  if (key === '?') return 'Slash';
+  if (key === 'Escape') return 'Escape';
+  if (key === 'ArrowDown') return 'ArrowDown';
+  if (key === 'ArrowUp') return 'ArrowUp';
+  if (key.length === 1 && /[a-z]/i.test(key)) return `Key${key.toUpperCase()}`;
+  return key;
+}
+
+function press(key: string, opts: { shift?: boolean } = {}) {
+  const code = codeFor(key);
+  const down = new KeyboardEvent('keydown', {
+    key,
+    code,
+    bubbles: true,
+    cancelable: true,
+    shiftKey: opts.shift ?? false,
+  });
+  document.dispatchEvent(down);
+  // react-hotkeys-hook clears the pressed-keys set on keyup — mirror a real key press.
+  const up = new KeyboardEvent('keyup', {
+    key,
+    code,
+    bubbles: true,
+    cancelable: true,
+    shiftKey: opts.shift ?? false,
+  });
+  document.dispatchEvent(up);
+}
+
+describe('useCollectionsKeyboard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('Shift+? toggles the help overlay', () => {
+    const { result } = renderHook(() => useCollectionsKeyboard({}));
+    expect(result.current.helpOpen).toBe(false);
+
+    act(() => press('/', { shift: true }));
+    expect(result.current.helpOpen).toBe(true);
+
+    act(() => press('/', { shift: true }));
+    expect(result.current.helpOpen).toBe(false);
+  });
+
+  it('Esc closes the help overlay', () => {
+    const { result } = renderHook(() => useCollectionsKeyboard({}));
+    act(() => press('/', { shift: true }));
+    expect(result.current.helpOpen).toBe(true);
+
+    act(() => press('Escape'));
+    expect(result.current.helpOpen).toBe(false);
+  });
+
+  it('G then Q switches to the today tab (G-prefix combo)', () => {
+    const onSwitchTab = vi.fn();
+    const { result } = renderHook(() => useCollectionsKeyboard({ onSwitchTab }));
+
+    act(() => press('g'));
+    expect(result.current.waitingForGSecond).toBe(true);
+
+    act(() => press('q'));
+    expect(onSwitchTab).toHaveBeenCalledWith('today');
+    expect(result.current.waitingForGSecond).toBe(false);
+  });
+
+  it('G prefix expires after 1.5s without a second key', () => {
+    const onSwitchTab = vi.fn();
+    const { result } = renderHook(() => useCollectionsKeyboard({ onSwitchTab }));
+
+    act(() => press('g'));
+    expect(result.current.waitingForGSecond).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(result.current.waitingForGSecond).toBe(false);
+
+    // Pressing P now should fire payment, NOT switch to promise tab.
+    act(() => press('p'));
+    expect(onSwitchTab).not.toHaveBeenCalled();
+  });
+
+  it('J / K move focus down / up', () => {
+    const onMoveFocus = vi.fn();
+    renderHook(() => useCollectionsKeyboard({ onMoveFocus }));
+
+    act(() => press('j'));
+    expect(onMoveFocus).toHaveBeenCalledWith(1);
+
+    act(() => press('k'));
+    expect(onMoveFocus).toHaveBeenCalledWith(-1);
+  });
+
+  it('P fires the payment action when not in G-prefix', () => {
+    const onPaymentFocused = vi.fn();
+    const onSwitchTab = vi.fn();
+    renderHook(() => useCollectionsKeyboard({ onPaymentFocused, onSwitchTab }));
+
+    act(() => press('p'));
+    expect(onPaymentFocused).toHaveBeenCalledTimes(1);
+    expect(onSwitchTab).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useCollectionsKeyboard.ts
+++ b/apps/web/src/hooks/useCollectionsKeyboard.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+
+/**
+ * Collections-specific keyboard shortcut handler.
+ *
+ * Implements the spec from `docs/superpowers/plans/2026-04-25-collections-ui-p1.md` Task 9:
+ * - Global: `?` opens help overlay; `Esc` closes
+ * - Tab nav: 2-key combo `G` then `Q/F/P/A/N/L` (1.5s timeout for second key)
+ * - Card actions: `J/K` or `↓/↑` move focus; `Enter` open Customer 360; `L` LINE; `C` log call;
+ *   `P` payment; `S` snooze; `A` assign
+ * - `/` focuses the filter chips search input (first text input within FilterChipsBar)
+ *
+ * Inputs are auto-disabled by `react-hotkeys-hook` (it skips when focus is on
+ * input/textarea/contentEditable). We rely on its built-in detection via
+ * `enableOnFormTags` defaulting to false.
+ *
+ * Lives outside `CollectionsPage` so the hook can be re-used by sub-tabs and the
+ * existing `useKeyboardShortcuts` (template-page hook) is left untouched.
+ */
+export interface CollectionsKeyboardCallbacks {
+  /** Tab navigation: queue / followup / promise / approval / aNalytics / aLl */
+  onSwitchTab?: (tab: 'today' | 'followup' | 'promise' | 'approval' | 'analytics' | 'all') => void;
+  /** Move focus inside the active queue (J/K or arrow keys) */
+  onMoveFocus?: (direction: 1 | -1) => void;
+  /** Enter — open Customer 360 for currently focused card */
+  onOpenFocused?: () => void;
+  /** L — open LINE composer for focused card */
+  onLineFocused?: () => void;
+  /** C — open call-log dialog for focused card */
+  onCallFocused?: () => void;
+  /** P — open payment-record dialog for focused card */
+  onPaymentFocused?: () => void;
+  /** S — open snooze dialog for focused card */
+  onSnoozeFocused?: () => void;
+  /** A — open assign dialog for focused card */
+  onAssignFocused?: () => void;
+}
+
+const G_PREFIX_TIMEOUT_MS = 1500;
+
+export function useCollectionsKeyboard(callbacks: CollectionsKeyboardCallbacks) {
+  const [helpOpen, setHelpOpen] = useState(false);
+  // `G` prefix state: true while we are waiting for the second key after a `G`.
+  const [waitingForGSecond, setWaitingForGSecond] = useState(false);
+  const gTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearGTimeout = useCallback(() => {
+    if (gTimeoutRef.current) {
+      clearTimeout(gTimeoutRef.current);
+      gTimeoutRef.current = null;
+    }
+  }, []);
+
+  const startGPrefix = useCallback(() => {
+    setWaitingForGSecond(true);
+    clearGTimeout();
+    gTimeoutRef.current = setTimeout(() => {
+      setWaitingForGSecond(false);
+      gTimeoutRef.current = null;
+    }, G_PREFIX_TIMEOUT_MS);
+  }, [clearGTimeout]);
+
+  const consumeGPrefix = useCallback(() => {
+    setWaitingForGSecond(false);
+    clearGTimeout();
+  }, [clearGTimeout]);
+
+  useEffect(() => () => clearGTimeout(), [clearGTimeout]);
+
+  // ------- Global help / escape -------
+  useHotkeys(
+    'shift+/',
+    (e) => {
+      e.preventDefault();
+      setHelpOpen((open) => !open);
+    },
+    { preventDefault: true },
+  );
+
+  useHotkeys('esc', () => {
+    setHelpOpen(false);
+    consumeGPrefix();
+  });
+
+  // ------- Focus filter search -------
+  useHotkeys(
+    '/',
+    (e) => {
+      // Built-in input detection skips this when typing — so a bare `/` from any
+      // non-input focus jumps straight to the chip-bar search input.
+      e.preventDefault();
+      const input =
+        document.querySelector<HTMLInputElement>('[data-collections-search] input') ||
+        document.querySelector<HTMLInputElement>('input[placeholder*="ค้นหา"]');
+      input?.focus();
+      input?.select?.();
+    },
+    { preventDefault: true },
+  );
+
+  // ------- G-prefix tab navigation -------
+  useHotkeys('g', () => startGPrefix(), { enabled: !waitingForGSecond });
+
+  useHotkeys(
+    'q',
+    () => {
+      if (!waitingForGSecond) return;
+      consumeGPrefix();
+      callbacks.onSwitchTab?.('today');
+    },
+    { enabled: waitingForGSecond },
+    [waitingForGSecond, callbacks.onSwitchTab],
+  );
+
+  useHotkeys(
+    'f',
+    () => {
+      if (!waitingForGSecond) return;
+      consumeGPrefix();
+      callbacks.onSwitchTab?.('followup');
+    },
+    { enabled: waitingForGSecond },
+    [waitingForGSecond, callbacks.onSwitchTab],
+  );
+
+  useHotkeys(
+    'p',
+    () => {
+      if (waitingForGSecond) {
+        consumeGPrefix();
+        callbacks.onSwitchTab?.('promise');
+      } else {
+        callbacks.onPaymentFocused?.();
+      }
+    },
+    [waitingForGSecond, callbacks.onSwitchTab, callbacks.onPaymentFocused],
+  );
+
+  useHotkeys(
+    'a',
+    () => {
+      if (waitingForGSecond) {
+        consumeGPrefix();
+        callbacks.onSwitchTab?.('approval');
+      } else {
+        callbacks.onAssignFocused?.();
+      }
+    },
+    [waitingForGSecond, callbacks.onSwitchTab, callbacks.onAssignFocused],
+  );
+
+  useHotkeys(
+    'n',
+    () => {
+      if (!waitingForGSecond) return;
+      consumeGPrefix();
+      callbacks.onSwitchTab?.('analytics');
+    },
+    { enabled: waitingForGSecond },
+    [waitingForGSecond, callbacks.onSwitchTab],
+  );
+
+  useHotkeys(
+    'l',
+    () => {
+      if (waitingForGSecond) {
+        consumeGPrefix();
+        callbacks.onSwitchTab?.('all');
+      } else {
+        callbacks.onLineFocused?.();
+      }
+    },
+    [waitingForGSecond, callbacks.onSwitchTab, callbacks.onLineFocused],
+  );
+
+  // ------- Card navigation / actions -------
+  useHotkeys(
+    'j, down',
+    (e) => {
+      e.preventDefault();
+      callbacks.onMoveFocus?.(1);
+    },
+    { preventDefault: true },
+    [callbacks.onMoveFocus],
+  );
+
+  useHotkeys(
+    'k, up',
+    (e) => {
+      e.preventDefault();
+      callbacks.onMoveFocus?.(-1);
+    },
+    { preventDefault: true },
+    [callbacks.onMoveFocus],
+  );
+
+  useHotkeys('enter', () => callbacks.onOpenFocused?.(), [callbacks.onOpenFocused]);
+
+  useHotkeys('c', () => callbacks.onCallFocused?.(), [callbacks.onCallFocused]);
+  useHotkeys('s', () => callbacks.onSnoozeFocused?.(), [callbacks.onSnoozeFocused]);
+
+  return {
+    helpOpen,
+    setHelpOpen,
+    /** Indicator: true while waiting for the second key of a `G` combo */
+    waitingForGSecond,
+  };
+}

--- a/apps/web/src/pages/CollectionsPage/components/AgingBucketChart.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/AgingBucketChart.tsx
@@ -113,11 +113,12 @@ export default function AgingBucketChart() {
                   />
                   <YAxis dataKey="bucket" type="category" {...AXIS_STYLE} width={56} />
                   <Tooltip
-                    formatter={(v: number) =>
-                      mode === 'outstanding'
-                        ? [`${formatBaht(v)} บาท`, 'ยอดค้าง']
-                        : [`${v} สัญญา`, 'จำนวน']
-                    }
+                    formatter={(v) => {
+                      const n = typeof v === 'number' ? v : Number(v);
+                      return mode === 'outstanding'
+                        ? [`${formatBaht(n)} บาท`, 'ยอดค้าง']
+                        : [`${n} สัญญา`, 'จำนวน'];
+                    }}
                     labelFormatter={(l) => `${l} วัน`}
                   />
                   <Bar

--- a/apps/web/src/pages/CollectionsPage/components/AgingBucketChart.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/AgingBucketChart.tsx
@@ -1,0 +1,140 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Cell,
+} from 'recharts';
+import { Card, CardContent } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import QueryBoundary from '@/components/QueryBoundary';
+import { useAnalyticsAging, type AgingBucketCode } from '../hooks/useAnalyticsAging';
+
+// Color ramp by severity — emerald (fresh) → red (worst)
+const BUCKET_COLOR: Record<AgingBucketCode, string> = {
+  '1-7': '#10b981',
+  '8-30': '#f59e0b',
+  '31-60': '#f97316',
+  '61-90': '#ef4444',
+  '90+': '#7f1d1d',
+};
+
+const AXIS_STYLE = { stroke: '#a1a1aa', fontSize: 11 };
+const GRID_PROPS = { strokeDasharray: '3 3', stroke: '#e4e4e7' };
+
+function formatBaht(n: number): string {
+  return new Intl.NumberFormat('th-TH', { maximumFractionDigits: 0 }).format(n);
+}
+
+export default function AgingBucketChart() {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<'count' | 'outstanding'>('count');
+  const { data = [], isLoading, isError, error, refetch } = useAnalyticsAging();
+
+  const chartData = useMemo(
+    () =>
+      data.map((r) => ({
+        bucket: r.bucket,
+        value: mode === 'count' ? r.count : r.outstanding,
+      })),
+    [data, mode],
+  );
+
+  const handleBarClick = (payload: { bucket?: AgingBucketCode } | undefined) => {
+    if (!payload?.bucket) return;
+    // Deep-link into QueueTab with bucket filter applied (URL param). The
+    // queue filter hook reads `q_buckets` (csv) — switch to default 'today'
+    // tab and pre-seed filter.
+    const params = new URLSearchParams(window.location.search);
+    params.set('q_buckets', payload.bucket);
+    navigate(`/collections?${params.toString()}#today`);
+  };
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <div className="text-sm font-semibold mb-0.5 leading-snug">
+              ค้างชำระ — แยกตามอายุหนี้
+            </div>
+            <div className="text-xs text-muted-foreground leading-snug">
+              คลิกแถบเพื่อกรองคิวงาน
+            </div>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            <span className={mode === 'count' ? 'font-medium' : 'text-muted-foreground'}>
+              นับสัญญา
+            </span>
+            <Switch
+              checked={mode === 'outstanding'}
+              onCheckedChange={(v) => setMode(v ? 'outstanding' : 'count')}
+              aria-label="สลับโหมดแสดงผล: นับ/ยอด"
+            />
+            <span
+              className={mode === 'outstanding' ? 'font-medium' : 'text-muted-foreground'}
+            >
+              ยอดค้าง (บาท)
+            </span>
+          </div>
+        </div>
+
+        <QueryBoundary
+          isLoading={isLoading}
+          isError={isError}
+          error={error}
+          onRetry={refetch}
+          errorTitle="ไม่สามารถโหลดข้อมูลอายุหนี้ได้"
+        >
+          <div style={{ width: '100%', height: 240 }}>
+            {chartData.every((d) => d.value === 0) ? (
+              <div className="flex items-center justify-center h-full text-xs text-muted-foreground italic leading-snug">
+                ยังไม่มีข้อมูล
+              </div>
+            ) : (
+              <ResponsiveContainer>
+                <BarChart
+                  data={chartData}
+                  layout="vertical"
+                  margin={{ top: 4, right: 24, bottom: 4, left: 24 }}
+                >
+                  <CartesianGrid {...GRID_PROPS} horizontal={false} />
+                  <XAxis
+                    type="number"
+                    {...AXIS_STYLE}
+                    tickFormatter={(v) =>
+                      mode === 'outstanding' ? formatBaht(v) : String(v)
+                    }
+                  />
+                  <YAxis dataKey="bucket" type="category" {...AXIS_STYLE} width={56} />
+                  <Tooltip
+                    formatter={(v: number) =>
+                      mode === 'outstanding'
+                        ? [`${formatBaht(v)} บาท`, 'ยอดค้าง']
+                        : [`${v} สัญญา`, 'จำนวน']
+                    }
+                    labelFormatter={(l) => `${l} วัน`}
+                  />
+                  <Bar
+                    dataKey="value"
+                    onClick={(d) => handleBarClick(d as { bucket?: AgingBucketCode })}
+                    cursor="pointer"
+                  >
+                    {chartData.map((d) => (
+                      <Cell key={d.bucket} fill={BUCKET_COLOR[d.bucket as AgingBucketCode]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </QueryBoundary>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/BrokenPromiseBanner.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/BrokenPromiseBanner.tsx
@@ -1,0 +1,128 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Bell, Send, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/lib/api';
+
+/**
+ * P1 Task 14 — Broken-Promise Auto-Suggest banner.
+ *
+ * Reads `GET /overdue/promise-due-reminders` (DunningActions stamped today
+ * by BrokenPromiseReminderCron at 09:00 BKK) and renders a single-line banner
+ * inviting the collector to bulk-send a LINE reminder to every customer
+ * whose promise is due TODAY.
+ *
+ * Hidden when there are 0 reminders so it doesn't add visual noise on quiet
+ * days. Bulk-LINE button is disabled when 0 contracts have a `lineId`.
+ */
+
+interface ReminderRow {
+  id: string;
+  contractId: string;
+  contractNumber: string;
+  customerName: string;
+  hasLine: boolean;
+  createdAt: string;
+}
+
+interface ReminderResponse {
+  total: number;
+  withLine: number;
+  contractIds: string[];
+  data: ReminderRow[];
+}
+
+const PROMISE_DUE_TEMPLATE =
+  'เรียนคุณ {{customerName}}, วันนี้ครบกำหนดนัดชำระสัญญา {{contractNumber}} — กรุณาชำระภายในวันนี้เพื่อหลีกเลี่ยงค่าปรับและการดำเนินการต่อไป';
+
+export default function BrokenPromiseBanner() {
+  const qc = useQueryClient();
+  const [submitting, setSubmitting] = useState(false);
+
+  const q = useQuery<ReminderResponse>({
+    queryKey: ['promise-due-reminders'],
+    queryFn: async () => {
+      const { data } = await api.get<ReminderResponse>('/overdue/promise-due-reminders');
+      return data;
+    },
+    // Re-poll every 10 minutes so the banner keeps in sync if cron fires
+    // while the collector has the page open (e.g. shift changeover at 09:00).
+    refetchInterval: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const bulkSend = useMutation({
+    mutationFn: async (contractIds: string[]) => {
+      // Use customMessage with placeholder substitution handled by bulkSendLine
+      // — we do client-side substitution here because the server-side template
+      // resolver only knows {{customerName}} and {{contractNumber}}, which is
+      // exactly what we need.
+      const { data } = await api.post<{ sent: number; failed: number; total: number }>(
+        '/overdue/bulk/send-line',
+        {
+          contractIds,
+          customMessage: PROMISE_DUE_TEMPLATE,
+        },
+      );
+      return data;
+    },
+    onSuccess: (res) => {
+      toast.success(`ส่ง LINE สำเร็จ ${res.sent}/${res.total} ราย (ล้มเหลว ${res.failed})`);
+      qc.invalidateQueries({ queryKey: ['promise-due-reminders'] });
+      qc.invalidateQueries({ queryKey: ['collections-queue'] });
+    },
+    onError: () => {
+      toast.error('ส่ง LINE ไม่สำเร็จ — กรุณาลองใหม่');
+    },
+    onSettled: () => setSubmitting(false),
+  });
+
+  const lineEligibleIds = useMemo(
+    () => (q.data?.data ?? []).filter((r) => r.hasLine).map((r) => r.contractId),
+    [q.data],
+  );
+
+  if (q.isLoading || q.isError || !q.data || q.data.total === 0) return null;
+
+  const total = q.data.total;
+  const withLine = q.data.withLine;
+  const noLine = total - withLine;
+
+  const onBulkSend = () => {
+    if (lineEligibleIds.length === 0 || submitting) return;
+    setSubmitting(true);
+    bulkSend.mutate(lineEligibleIds);
+  };
+
+  return (
+    <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 mb-4">
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 rounded-lg bg-primary/10 p-2 text-primary">
+          <Bell className="size-5" aria-hidden="true" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-semibold text-foreground leading-snug">
+            วันนี้มีนัดครบกำหนด {total} ราย — ส่ง LINE เตือนทั้งหมด?
+          </div>
+          <div className="text-xs text-muted-foreground mt-0.5 leading-snug">
+            มี LINE ID พร้อมส่ง {withLine} ราย
+            {noLine > 0 && ` · ไม่มี LINE ID ${noLine} ราย (ต้องโทรหรือ SMS แทน)`}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onBulkSend}
+          disabled={lineEligibleIds.length === 0 || submitting}
+          className="shrink-0 inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {submitting ? (
+            <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+          ) : (
+            <Send className="size-3.5" aria-hidden="true" />
+          )}
+          ส่ง LINE ทั้งหมด ({lineEligibleIds.length})
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/CallResultChips.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CallResultChips.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CallResultChips from './CallResultChips';
+
+describe('CallResultChips', () => {
+  it('renders both rows of chips with Thai labels', () => {
+    render(
+      <CallResultChips
+        callResult={null}
+        negotiationResult={null}
+        onCallResultChange={() => {}}
+        onNegotiationResultChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('ผลการโทร')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'รับสาย' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'ไม่รับสาย' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'ขอผ่อน' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'จะจ่าย' })).toBeTruthy();
+  });
+
+  it('disables negotiation chips when call result is no-contact (NO_ANSWER)', () => {
+    render(
+      <CallResultChips
+        callResult="NO_ANSWER"
+        negotiationResult={null}
+        onCallResultChange={() => {}}
+        onNegotiationResultChange={() => {}}
+      />,
+    );
+    expect(
+      (screen.getByRole('button', { name: 'จะจ่าย' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it('enables negotiation chips when call result is ANSWERED', () => {
+    render(
+      <CallResultChips
+        callResult="ANSWERED"
+        negotiationResult={null}
+        onCallResultChange={() => {}}
+        onNegotiationResultChange={() => {}}
+      />,
+    );
+    expect(
+      (screen.getByRole('button', { name: 'จะจ่าย' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
+  it('clicking a selected chip toggles it off (passes null)', async () => {
+    const onCallResultChange = vi.fn();
+    render(
+      <CallResultChips
+        callResult="ANSWERED"
+        negotiationResult={null}
+        onCallResultChange={onCallResultChange}
+        onNegotiationResultChange={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'รับสาย' }));
+    expect(onCallResultChange).toHaveBeenCalledWith(null);
+  });
+
+  it('clicking an unselected chip selects it', async () => {
+    const onCallResultChange = vi.fn();
+    render(
+      <CallResultChips
+        callResult={null}
+        negotiationResult={null}
+        onCallResultChange={onCallResultChange}
+        onNegotiationResultChange={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'ปิดเครื่อง' }));
+    expect(onCallResultChange).toHaveBeenCalledWith('DEVICE_OFF');
+  });
+
+  it('aria-pressed reflects selection state', () => {
+    render(
+      <CallResultChips
+        callResult="BUSY"
+        negotiationResult={null}
+        onCallResultChange={() => {}}
+        onNegotiationResultChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'สายไม่ว่าง' }).getAttribute('aria-pressed'),
+    ).toBe('true');
+    expect(
+      screen.getByRole('button', { name: 'รับสาย' }).getAttribute('aria-pressed'),
+    ).toBe('false');
+  });
+});

--- a/apps/web/src/pages/CollectionsPage/components/CallResultChips.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CallResultChips.tsx
@@ -1,0 +1,136 @@
+/**
+ * Call result quick-tag chips for ContactLogDialog (Task 12).
+ *
+ * Two chip rows:
+ *   1. ผลการโทร  — รับสาย / ไม่รับสาย / สายไม่ว่าง / ปิดเครื่อง / เบอร์ไม่ติดต่อ
+ *   2. ผลการเจรจา — ขอผ่อน / จะจ่าย / ปฏิเสธ / ขอคืนเครื่อง / กำลังเจรจา
+ *
+ * The negotiation row is disabled when the call result is a "no contact"
+ * type (NO_ANSWER / BUSY / DEVICE_OFF / UNREACHABLE) — you cannot negotiate
+ * with someone you didn't reach. ANSWERED is the only call result that
+ * unlocks negotiation chips.
+ *
+ * Selections are auto-saved to CallLog when the parent ContactLogDialog
+ * submits (the dialog passes them as `callResult` + `negotiationResult`
+ * fields in the LogContact payload).
+ */
+
+export type CallResultTag =
+  | 'ANSWERED'
+  | 'NO_ANSWER'
+  | 'BUSY'
+  | 'DEVICE_OFF'
+  | 'UNREACHABLE';
+
+export type NegotiationResultTag =
+  | 'REQUESTED_EXTENSION'
+  | 'WILL_PAY'
+  | 'REFUSED'
+  | 'REQUESTED_RETURN'
+  | 'NEGOTIATING'
+  | 'NOT_APPLICABLE';
+
+const CALL_RESULTS: { value: CallResultTag; label: string }[] = [
+  { value: 'ANSWERED', label: 'รับสาย' },
+  { value: 'NO_ANSWER', label: 'ไม่รับสาย' },
+  { value: 'BUSY', label: 'สายไม่ว่าง' },
+  { value: 'DEVICE_OFF', label: 'ปิดเครื่อง' },
+  { value: 'UNREACHABLE', label: 'เบอร์ไม่ติดต่อ' },
+];
+
+const NEGOTIATION_RESULTS: { value: NegotiationResultTag; label: string }[] = [
+  { value: 'REQUESTED_EXTENSION', label: 'ขอผ่อน' },
+  { value: 'WILL_PAY', label: 'จะจ่าย' },
+  { value: 'REFUSED', label: 'ปฏิเสธ' },
+  { value: 'REQUESTED_RETURN', label: 'ขอคืนเครื่อง' },
+  { value: 'NEGOTIATING', label: 'กำลังเจรจา' },
+];
+
+const NO_CONTACT_TYPES: CallResultTag[] = [
+  'NO_ANSWER',
+  'BUSY',
+  'DEVICE_OFF',
+  'UNREACHABLE',
+];
+
+interface Props {
+  callResult: CallResultTag | null;
+  negotiationResult: NegotiationResultTag | null;
+  onCallResultChange: (v: CallResultTag | null) => void;
+  onNegotiationResultChange: (v: NegotiationResultTag | null) => void;
+}
+
+export default function CallResultChips({
+  callResult,
+  negotiationResult,
+  onCallResultChange,
+  onNegotiationResultChange,
+}: Props) {
+  const negotiationDisabled = !callResult || NO_CONTACT_TYPES.includes(callResult);
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="text-xs font-medium text-muted-foreground mb-1.5 leading-snug">
+          ผลการโทร
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {CALL_RESULTS.map((opt) => {
+            const active = callResult === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() =>
+                  onCallResultChange(active ? null : opt.value)
+                }
+                aria-pressed={active}
+                className={`rounded-full border px-3 py-1 text-xs leading-snug transition-colors ${
+                  active
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-input bg-card text-foreground hover:bg-accent'
+                }`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <div className="text-xs font-medium text-muted-foreground mb-1.5 leading-snug">
+          ผลการเจรจา
+          {negotiationDisabled && (
+            <span className="ml-1 text-2xs text-muted-foreground/80">
+              (ติดต่อลูกค้าได้ก่อนถึงจะเลือกได้)
+            </span>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {NEGOTIATION_RESULTS.map((opt) => {
+            const active = negotiationResult === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                disabled={negotiationDisabled}
+                onClick={() =>
+                  onNegotiationResultChange(active ? null : opt.value)
+                }
+                aria-pressed={active}
+                className={`rounded-full border px-3 py-1 text-xs leading-snug transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                  active
+                    ? 'border-success bg-success text-success-foreground'
+                    : 'border-input bg-card text-foreground hover:bg-accent'
+                }`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/CollectionsFilters.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/CollectionsFilters.tsx
@@ -32,7 +32,7 @@ export default function CollectionsFilters({
   });
 
   return (
-    <div className="bg-card border border-border/50 shadow-sm rounded-xl p-4 mb-5">
+    <div data-collections-search className="bg-card border border-border/50 shadow-sm rounded-xl p-4 mb-5">
       <div className="flex gap-3 flex-wrap">
         <input
           type="text"

--- a/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContactLogDialog.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect } from 'react';
 import Modal from '@/components/ui/Modal';
 import { useContactLog } from '../hooks/useContactLog';
+import CallResultChips, {
+  type CallResultTag,
+  type NegotiationResultTag,
+} from './CallResultChips';
 import type { ContractRow, CallResult } from '../types';
 
 interface Props {
@@ -26,6 +30,9 @@ const defaultForm = {
   collectionNotes: '',
   settlementDate: '',
   settlementNotes: '',
+  // P1 Task 12 — quick-tag chip selections
+  callResult: null as CallResultTag | null,
+  negotiationResult: null as NegotiationResultTag | null,
 };
 
 // Derive tomorrow's date for min= on settlement date input
@@ -61,6 +68,11 @@ export default function ContactLogDialog({ open, contract, onClose }: Props) {
       settlementDate: form.result === 'PROMISED' ? form.settlementDate || undefined : undefined,
       settlementNotes:
         form.result === 'PROMISED' ? form.settlementNotes || undefined : undefined,
+      // Auto-save the quick-tag enum selections (Task 12). null → omit
+      // so the back-end stores null and the existing free-string `result`
+      // remains the legacy source of truth.
+      callResult: form.callResult ?? undefined,
+      negotiationResult: form.negotiationResult ?? undefined,
     };
     mutation.mutate(payload, {
       onSuccess: () => {
@@ -139,6 +151,18 @@ export default function ContactLogDialog({ open, contract, onClose }: Props) {
             </div>
           </div>
         )}
+
+        {/* Quick-tag chips (Task 12) — captured into CallLog.callResult +
+            CallLog.negotiationResult for analytics. Independent from the
+            legacy free-string `result` select above. */}
+        <CallResultChips
+          callResult={form.callResult}
+          negotiationResult={form.negotiationResult}
+          onCallResultChange={(v) => setForm({ ...form, callResult: v })}
+          onNegotiationResultChange={(v) =>
+            setForm({ ...form, negotiationResult: v })
+          }
+        />
 
         {/* Notes */}
         <div>

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.test.tsx
@@ -65,4 +65,35 @@ describe('<ContractCard />', () => {
     render(<ContractCard contract={base} onLogContact={vi.fn()} />);
     expect(screen.queryByText('ล็อคแล้ว')).not.toBeInTheDocument();
   });
+
+  it('renders snooze badge when snoozedUntil is in the future', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const c: ContractRow = { ...base, snoozedUntil: future };
+    render(<ContractCard contract={c} onLogContact={vi.fn()} />);
+    expect(screen.getByText(/^ถึง/)).toBeInTheDocument();
+  });
+
+  it('omits snooze badge when snoozedUntil is null', () => {
+    render(<ContractCard contract={base} onLogContact={vi.fn()} />);
+    expect(screen.queryByText(/^ถึง/)).not.toBeInTheDocument();
+  });
+
+  it('renders trending-up arrow when trendingArrow=UP', () => {
+    const c: ContractRow = { ...base, trendingArrow: 'UP' };
+    render(<ContractCard contract={c} onLogContact={vi.fn()} />);
+    expect(screen.getByTestId('trending-up')).toBeInTheDocument();
+    expect(screen.queryByTestId('trending-down')).not.toBeInTheDocument();
+  });
+
+  it('renders trending-down arrow when trendingArrow=DOWN', () => {
+    const c: ContractRow = { ...base, trendingArrow: 'DOWN' };
+    render(<ContractCard contract={c} onLogContact={vi.fn()} />);
+    expect(screen.getByTestId('trending-down')).toBeInTheDocument();
+  });
+
+  it('renders no arrow when trendingArrow is null (no historical data)', () => {
+    render(<ContractCard contract={base} onLogContact={vi.fn()} />);
+    expect(screen.queryByTestId('trending-up')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('trending-down')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -14,8 +14,18 @@ import {
   AlertTriangle,
   Users,
   FileText,
+  MoreHorizontal,
+  Moon,
+  ArrowUp,
+  ArrowDown,
 } from 'lucide-react';
 import { formatDateShort } from '@/utils/formatters';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
 import type { ContractRow } from '../types';
 import { agingBucket, agingColor, formatRelativeTime } from '../utils/cardIndicators';
 
@@ -55,18 +65,56 @@ const CHANNEL_META: Record<
   LETTER: { icon: FileText, label: 'จดหมาย' },
 };
 
+function formatSnoozeUntil(iso: string): string {
+  const d = new Date(iso);
+  const today = new Date();
+  const sameDay =
+    d.getFullYear() === today.getFullYear() &&
+    d.getMonth() === today.getMonth() &&
+    d.getDate() === today.getDate();
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  if (sameDay) return `${hh}:${mm}`;
+  return `${formatDateShort(d)} ${hh}:${mm}`;
+}
+
 function IndicatorChips({ contract }: { contract: ContractRow }) {
   const bucket = agingBucket(contract.daysOverdue);
   const channelMeta = contract.lastChannel ? CHANNEL_META[contract.lastChannel] : null;
   const ChannelIcon = channelMeta?.icon ?? null;
+  const arrow = contract.trendingArrow;
 
   return (
     <div className="mb-3 flex flex-wrap items-center gap-1.5">
       <span
-        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-2xs font-medium leading-snug ${agingColor(bucket)}`}
+        className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-medium leading-snug ${agingColor(bucket)}`}
       >
         เลย {contract.daysOverdue} วัน
+        {arrow === 'UP' && (
+          <ArrowUp
+            className="size-3"
+            aria-label="แย่ลงเทียบ 7 วันก่อน"
+            data-testid="trending-up"
+          />
+        )}
+        {arrow === 'DOWN' && (
+          <ArrowDown
+            className="size-3"
+            aria-label="ดีขึ้นเทียบ 7 วันก่อน"
+            data-testid="trending-down"
+          />
+        )}
       </span>
+
+      {contract.snoozedUntil && (
+        <span
+          className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 text-primary text-2xs font-medium px-2 py-0.5 leading-snug"
+          title={`Snooze ถึง ${new Date(contract.snoozedUntil).toLocaleString('th-TH')}`}
+        >
+          <Moon className="size-3" />
+          ถึง {formatSnoozeUntil(contract.snoozedUntil)}
+        </span>
+      )}
 
       <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted text-muted-foreground text-2xs font-medium px-2 py-0.5 leading-snug">
         <Clock className="size-3" />
@@ -126,6 +174,10 @@ interface Props {
   onPreview?: (contract: ContractRow, anchor: PreviewAnchor) => void;
   /** Cancel a pending preview (called when caller closes the panel). */
   onPreviewCancel?: () => void;
+  /** Open the SnoozeDialog (Task 7). Hides the ⋯ menu entry when undefined. */
+  onSnooze?: (c: ContractRow) => void;
+  /** Lift active snooze immediately. Hides the ⋯ menu entry when undefined. */
+  onUnsnooze?: (c: ContractRow) => void;
 }
 
 export default function ContractCard({
@@ -138,7 +190,11 @@ export default function ContractCard({
   focused,
   onPreview,
   onPreviewCancel,
+  onSnooze,
+  onUnsnooze,
 }: Props) {
+  const isSnoozed =
+    !!contract.snoozedUntil && new Date(contract.snoozedUntil).getTime() > Date.now();
   const focusRing = focused ? 'ring-2 ring-primary ring-offset-1 ring-offset-background' : '';
   const wrapperRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<number | null>(null);
@@ -313,6 +369,32 @@ export default function ContractCard({
               >
                 <ChevronRight className="size-3.5" />
               </button>
+            )}
+            {(onSnooze || onUnsnooze) && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className="rounded-lg border border-input p-1.5 hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                    title="เพิ่มเติม"
+                    aria-label="เพิ่มเติม"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <MoreHorizontal className="size-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  {onSnooze && !isSnoozed && (
+                    <DropdownMenuItem onSelect={() => onSnooze(contract)}>
+                      <Moon className="size-4" /> Snooze จน...
+                    </DropdownMenuItem>
+                  )}
+                  {onUnsnooze && isSnoozed && (
+                    <DropdownMenuItem onSelect={() => onUnsnooze(contract)}>
+                      <Moon className="size-4" /> ยกเลิก snooze
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
           </div>
         </div>

--- a/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/ContractCard.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import {
   Phone,
   PhoneMissed,
@@ -17,6 +18,25 @@ import {
 import { formatDateShort } from '@/utils/formatters';
 import type { ContractRow } from '../types';
 import { agingBucket, agingColor, formatRelativeTime } from '../utils/cardIndicators';
+
+/**
+ * Customer 360 snapshot preview is a deliberate intent gesture (Task 11):
+ * - Desktop: 500ms hover dwell → opens floating panel
+ * - Mobile: 500ms long-press (touchstart-touchend with no scroll) → bottom sheet
+ *
+ * 500ms strikes the balance between "pops on accidental drag-by" (too fast)
+ * and "feels broken / unresponsive" (too slow). Material/macOS tooltip
+ * defaults are 400-700ms; we picked 500ms so a quick triple-glance through
+ * the list does NOT spawn a panel for every card.
+ */
+const PREVIEW_DELAY_MS = 500;
+
+export interface PreviewAnchor {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
 
 function priorityColor(daysOverdue: number): string {
   if (daysOverdue >= 30) return 'bg-destructive';
@@ -97,6 +117,15 @@ interface Props {
   onSendLine?: (c: ContractRow) => void;
   selected?: boolean;
   onToggleSelect?: (id: string) => void;
+  /** Highlight as keyboard-focused card (J/K navigation) */
+  focused?: boolean;
+  /**
+   * Fired after a 500ms hover dwell (desktop) or long-press (mobile).
+   * Caller renders the floating Customer360SnapshotCard at `anchor`.
+   */
+  onPreview?: (contract: ContractRow, anchor: PreviewAnchor) => void;
+  /** Cancel a pending preview (called when caller closes the panel). */
+  onPreviewCancel?: () => void;
 }
 
 export default function ContractCard({
@@ -106,9 +135,49 @@ export default function ContractCard({
   onSendLine,
   selected,
   onToggleSelect,
+  focused,
+  onPreview,
+  onPreviewCancel,
 }: Props) {
+  const focusRing = focused ? 'ring-2 ring-primary ring-offset-1 ring-offset-background' : '';
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<number | null>(null);
+
+  function clearTimer() {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }
+
+  function schedulePreview() {
+    if (!onPreview || !wrapperRef.current) return;
+    clearTimer();
+    const el = wrapperRef.current;
+    timerRef.current = window.setTimeout(() => {
+      const r = el.getBoundingClientRect();
+      onPreview(contract, { top: r.top, left: r.left, right: r.right, bottom: r.bottom });
+    }, PREVIEW_DELAY_MS);
+  }
+
+  function cancelPreview() {
+    clearTimer();
+  }
+
   return (
-    <div className="group relative flex rounded-xl border border-border/50 bg-card shadow-sm hover:shadow-card-hover transition-shadow overflow-hidden">
+    <div
+      ref={wrapperRef}
+      data-collections-card-id={contract.id}
+      onMouseEnter={schedulePreview}
+      onMouseLeave={cancelPreview}
+      onTouchStart={schedulePreview}
+      onTouchEnd={() => {
+        clearTimer();
+        onPreviewCancel?.();
+      }}
+      onTouchMove={cancelPreview}
+      className={`group relative flex rounded-xl border border-border/50 bg-card shadow-sm hover:shadow-card-hover transition-shadow overflow-hidden ${focusRing}`}
+    >
       {/* Checkbox column — only rendered when bulk-select is active */}
       {onToggleSelect && (
         <label className="flex items-start pt-5 pl-3 shrink-0 cursor-pointer">

--- a/apps/web/src/pages/CollectionsPage/components/Customer360SnapshotCard.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360SnapshotCard.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useRef } from 'react';
+import {
+  Phone,
+  Package,
+  CalendarCheck,
+  MessageCircle,
+  CheckCheck,
+  Clock,
+  StickyNote,
+  AlertTriangle,
+  Loader2,
+  X,
+} from 'lucide-react';
+import { useContractSnapshot } from '../hooks/useContractSnapshot';
+import { formatRelativeTime } from '../utils/cardIndicators';
+import { formatDateShort } from '@/utils/formatters';
+
+interface Props {
+  contractId: string | null;
+  /** Anchor rect in viewport coordinates (from getBoundingClientRect of the source card). */
+  anchor: { top: number; left: number; right: number; bottom: number } | null;
+  /** Bottom-sheet variant for mobile (long-press). */
+  variant?: 'floating' | 'sheet';
+  open: boolean;
+  onClose: () => void;
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  ACTIVE: 'bg-success/10 text-success border-success/30',
+  OVERDUE: 'bg-warning/10 text-warning border-warning/30',
+  DEFAULT: 'bg-destructive/10 text-destructive border-destructive/30',
+  LEGAL: 'bg-destructive/10 text-destructive border-destructive/30',
+  CLOSED: 'bg-muted text-muted-foreground border-border',
+};
+
+/**
+ * Customer 360 snapshot preview card.
+ *
+ * - Desktop: floating panel anchored to the right of the source ContractCard
+ *   (opens after 500ms hover dwell — see CollectionsPage queue tab wiring).
+ * - Mobile: bottom sheet variant (long-press 500ms on the card).
+ *
+ * Designed for sub-100ms perceived latency. Calls `useContractSnapshot`
+ * which hits `GET /contracts/:id/snapshot` (lightweight — does NOT load
+ * the full timeline).
+ */
+export default function Customer360SnapshotCard({
+  contractId,
+  anchor,
+  variant = 'floating',
+  open,
+  onClose,
+}: Props) {
+  const { data, isLoading, error } = useContractSnapshot(contractId, open);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click / Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('mousedown', onMouseDown);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('mousedown', onMouseDown);
+    };
+  }, [open, onClose]);
+
+  if (!open || !contractId) return null;
+
+  // Position the floating panel to the right of the anchor, fallback to left
+  // if there's no room. Sheet variant ignores anchor (CSS-positioned).
+  let positionStyle: React.CSSProperties = {};
+  if (variant === 'floating' && anchor) {
+    const PANEL_WIDTH = 360;
+    const GAP = 8;
+    const viewportRight = window.innerWidth;
+    const wantsRight = anchor.right + GAP + PANEL_WIDTH < viewportRight - 16;
+    positionStyle = wantsRight
+      ? { top: anchor.top, left: anchor.right + GAP }
+      : { top: anchor.top, left: Math.max(16, anchor.left - GAP - PANEL_WIDTH) };
+  }
+
+  const wrapperClass =
+    variant === 'sheet'
+      ? 'fixed inset-x-0 bottom-0 z-50 max-h-[85vh] overflow-auto rounded-t-2xl border-t border-border bg-card shadow-card-hover'
+      : 'fixed z-50 w-[360px] max-h-[80vh] overflow-auto rounded-xl border border-border bg-card shadow-card-hover';
+
+  return (
+    <>
+      {variant === 'sheet' && (
+        <div
+          className="fixed inset-0 z-40 bg-black/30"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      )}
+      <div
+        ref={panelRef}
+        className={wrapperClass}
+        style={positionStyle}
+        role="dialog"
+        aria-label="Customer 360 snapshot"
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+          <div className="text-2xs font-medium uppercase tracking-wide text-muted-foreground leading-snug">
+            Customer 360 — สรุปด่วน
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            aria-label="ปิด"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {isLoading && (
+          <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+            <Loader2 className="size-4 mr-2 animate-spin" /> กำลังโหลด...
+          </div>
+        )}
+
+        {error && (
+          <div className="px-4 py-6 text-sm text-destructive leading-snug">
+            <AlertTriangle className="size-4 inline mr-1" />
+            โหลดข้อมูลไม่สำเร็จ
+          </div>
+        )}
+
+        {data && (
+          <div className="space-y-3 p-4">
+            {/* Header — name + status + contract# */}
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <div className="text-base font-semibold leading-snug truncate">
+                  {data.customer.name}
+                </div>
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-2xs font-medium leading-snug ${
+                    STATUS_COLOR[data.status] ?? 'bg-muted text-muted-foreground border-border'
+                  }`}
+                >
+                  {data.status}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-muted-foreground leading-snug">
+                <span className="font-mono text-primary">{data.contractNumber}</span>
+                <span>·</span>
+                <a
+                  href={`tel:${data.customer.phone}`}
+                  className="inline-flex items-center gap-1 hover:underline"
+                >
+                  <Phone className="size-3" />
+                  {data.customer.phone}
+                </a>
+              </div>
+            </div>
+
+            {/* Product */}
+            <div className="flex items-center gap-2 rounded-lg bg-muted/40 px-3 py-2 text-xs leading-snug">
+              <Package className="size-3.5 text-muted-foreground shrink-0" />
+              <span className="truncate">{data.product.name}</span>
+            </div>
+
+            {/* Totals */}
+            <div className="grid grid-cols-2 gap-2">
+              <div className="rounded-lg border border-border/50 px-3 py-2">
+                <div className="text-2xs uppercase tracking-wide text-muted-foreground leading-snug">
+                  คงค้าง
+                </div>
+                <div className="text-sm font-semibold tabular-nums text-destructive leading-snug">
+                  {data.totals.outstanding.toLocaleString()} ฿
+                </div>
+              </div>
+              <div className="rounded-lg border border-border/50 px-3 py-2">
+                <div className="text-2xs uppercase tracking-wide text-muted-foreground leading-snug">
+                  งวดเหลือ
+                </div>
+                <div className="text-sm font-semibold tabular-nums leading-snug">
+                  {data.totals.installmentsRemaining}/{data.totals.installmentsTotal}
+                </div>
+              </div>
+            </div>
+
+            {/* Last promise */}
+            {data.lastPromise && (
+              <div className="rounded-lg border border-border/50 px-3 py-2 space-y-0.5">
+                <div className="flex items-center gap-1.5 text-2xs uppercase tracking-wide text-muted-foreground leading-snug">
+                  <CalendarCheck className="size-3" />
+                  นัดล่าสุด
+                </div>
+                <div className="text-xs leading-snug">
+                  <span className="tabular-nums">
+                    {formatDateShort(new Date(data.lastPromise.settlementDate))}
+                  </span>{' '}
+                  <span
+                    className={
+                      data.lastPromise.result === 'BROKEN'
+                        ? 'text-destructive font-medium'
+                        : 'text-foreground'
+                    }
+                  >
+                    · {data.lastPromise.result === 'BROKEN' ? 'นัดผิด' : data.lastPromise.result}
+                  </span>
+                </div>
+                {data.lastPromise.notes && (
+                  <div className="text-2xs text-muted-foreground leading-snug truncate">
+                    {data.lastPromise.notes}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Last LINE message */}
+            {data.lastLine && (
+              <div className="flex items-center justify-between rounded-lg border border-border/50 px-3 py-2 text-xs leading-snug">
+                <div className="flex items-center gap-1.5">
+                  <MessageCircle className="size-3.5 text-muted-foreground" />
+                  <span className="text-muted-foreground">LINE ล่าสุด</span>
+                  <span className="tabular-nums">
+                    {formatRelativeTime(data.lastLine.timestamp)}
+                  </span>
+                </div>
+                {data.lastLine.read ? (
+                  <span className="inline-flex items-center gap-1 text-success">
+                    <CheckCheck className="size-3.5" /> อ่านแล้ว
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 text-muted-foreground">
+                    <Clock className="size-3.5" /> ยังไม่อ่าน
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Last collector comment */}
+            {data.lastCollectorComment && (
+              <div className="rounded-lg border border-border/50 px-3 py-2 space-y-1">
+                <div className="flex items-center gap-1.5 text-2xs uppercase tracking-wide text-muted-foreground leading-snug">
+                  <StickyNote className="size-3" />
+                  บันทึกล่าสุด
+                </div>
+                <div className="text-xs text-foreground leading-snug">
+                  {data.lastCollectorComment.text}
+                </div>
+                <div className="text-2xs text-muted-foreground leading-snug">
+                  {formatRelativeTime(data.lastCollectorComment.at)}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/Customer360Timeline.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import {
   PhoneCall,
   Banknote,
@@ -8,6 +9,10 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import type { TimelineEvent } from '../hooks/useCustomer360';
+import TimelineFilterChips, {
+  type TimelineFilterValue,
+} from './TimelineFilterChips';
+import { DateRangePicker, type DateRangeValue } from '@/components/ui/DateRangePicker';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -187,42 +192,81 @@ interface Props {
 }
 
 export default function Customer360Timeline({ events }: Props) {
-  if (events.length === 0) {
-    return (
-      <div className="text-center py-8 text-sm text-muted-foreground leading-snug">
-        ยังไม่มีกิจกรรม
-      </div>
-    );
-  }
+  const [filterType, setFilterType] = useState<TimelineFilterValue>('ALL');
+  const [dateRange, setDateRange] = useState<DateRangeValue>({ from: null, to: null });
 
-  const groups = groupByDate(events);
+  // Counts per type — computed from full event set so chips show stable totals
+  const counts = useMemo(() => {
+    const c: Partial<Record<TimelineFilterValue, number>> = { ALL: events.length };
+    for (const e of events) {
+      c[e.type] = (c[e.type] ?? 0) + 1;
+    }
+    return c;
+  }, [events]);
+
+  // Apply in-memory filter (timeline capped at 100 events backend-side)
+  const filteredEvents = useMemo(() => {
+    const fromMs = dateRange.from ? dateRange.from.getTime() : null;
+    const toMs = dateRange.to ? dateRange.to.getTime() : null;
+    return events.filter((e) => {
+      if (filterType !== 'ALL' && e.type !== filterType) return false;
+      if (fromMs !== null || toMs !== null) {
+        const t = new Date(e.timestamp).getTime();
+        if (fromMs !== null && t < fromMs) return false;
+        if (toMs !== null && t > toMs) return false;
+      }
+      return true;
+    });
+  }, [events, filterType, dateRange]);
+
+  const hasDateFilter = dateRange.from !== null || dateRange.to !== null;
+  const hasAnyFilter = filterType !== 'ALL' || hasDateFilter;
 
   return (
-    <div className="space-y-1">
-      {groups.map((group, groupIdx) => (
-        <div key={group.label}>
-          {/* Section header */}
-          <div
-            className={`text-xs uppercase tracking-wider text-muted-foreground mb-1 leading-snug ${
-              groupIdx === 0 ? '' : 'mt-4'
-            }`}
-          >
-            {group.label}
-          </div>
+    <div className="space-y-3">
+      {/* Filter controls */}
+      <div className="space-y-2">
+        <TimelineFilterChips value={filterType} onChange={setFilterType} counts={counts} />
+        <DateRangePicker value={dateRange} onChange={setDateRange} />
+      </div>
 
-          {/* Events */}
-          <div>
-            {group.items.map((event, idx) => (
-              <EventCard key={event.id} event={event} isFirst={idx === 0} />
-            ))}
-          </div>
+      {/* Empty states */}
+      {events.length === 0 ? (
+        <div className="text-center py-8 text-sm text-muted-foreground leading-snug">
+          ยังไม่มีกิจกรรม
         </div>
-      ))}
+      ) : filteredEvents.length === 0 ? (
+        <div className="text-center py-8 text-sm text-muted-foreground leading-snug">
+          ไม่พบกิจกรรมตามตัวกรอง
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {groupByDate(filteredEvents).map((group, groupIdx) => (
+            <div key={group.label}>
+              {/* Section header */}
+              <div
+                className={`text-xs uppercase tracking-wider text-muted-foreground mb-1 leading-snug ${
+                  groupIdx === 0 ? '' : 'mt-4'
+                }`}
+              >
+                {group.label}
+              </div>
 
-      {/* Cap notice */}
-      {events.length >= 100 && (
-        <div className="pt-3 text-center text-xs text-muted-foreground leading-snug">
-          แสดง 100 รายการล่าสุด
+              {/* Events */}
+              <div>
+                {group.items.map((event, idx) => (
+                  <EventCard key={event.id} event={event} isFirst={idx === 0} />
+                ))}
+              </div>
+            </div>
+          ))}
+
+          {/* Cap notice — only when not filtering (full result hits cap) */}
+          {!hasAnyFilter && events.length >= 100 && (
+            <div className="pt-3 text-center text-xs text-muted-foreground leading-snug">
+              แสดง 100 รายการล่าสุด
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/pages/CollectionsPage/components/FilterChipsBar.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/FilterChipsBar.tsx
@@ -1,6 +1,7 @@
 import { Filter, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { QueueFilterState } from '../hooks/useQueueFilter';
+import { FilterPresetsDropdown } from './FilterPresetsDropdown';
 
 interface FilterChipsBarProps {
   filter: QueueFilterState;
@@ -145,6 +146,27 @@ function buildChips(f: QueueFilterState): Chip[] {
   return chips;
 }
 
+// Keys that exist in QueueFilterState — required to wipe stale values when a
+// preset is applied (setFilter merges with current state, so leftover fields
+// would persist across preset applications without an explicit `undefined`).
+const ALL_FILTER_KEYS: (keyof QueueFilterState)[] = [
+  'assigned',
+  'branchId',
+  'overdueBuckets',
+  'minOutstanding',
+  'maxOutstanding',
+  'contractStatuses',
+  'productTypes',
+  'minLetterCount',
+  'lastContacted',
+  'lineResponse',
+  'minBrokenPromise',
+  'hasActivePromise',
+  'mdmState',
+  'showSkipTracing',
+  'slipReviewPending',
+];
+
 export default function FilterChipsBar({
   filter,
   setFilter,
@@ -155,8 +177,18 @@ export default function FilterChipsBar({
 }: FilterChipsBarProps) {
   const chips = buildChips(filter);
 
+  const applyPreset = (preset: QueueFilterState) => {
+    const wipe: Partial<QueueFilterState> = {};
+    for (const k of ALL_FILTER_KEYS) {
+      (wipe as Record<string, unknown>)[k] = undefined;
+    }
+    setFilter({ ...wipe, ...preset });
+  };
+
   return (
     <div className="mb-3 flex flex-wrap items-center gap-2">
+      <FilterPresetsDropdown currentFilter={filter} onApply={applyPreset} />
+
       <Button variant="outline" size="sm" onClick={onOpenFilter} className="gap-1.5">
         <Filter className="size-3.5" />
         ตัวกรอง

--- a/apps/web/src/pages/CollectionsPage/components/FilterChipsBar.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/FilterChipsBar.tsx
@@ -1,7 +1,8 @@
 import { Filter, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import type { QueueFilterState } from '../hooks/useQueueFilter';
+import type { QueueFilterState, QueueSortOption } from '../hooks/useQueueFilter';
 import { FilterPresetsDropdown } from './FilterPresetsDropdown';
+import { SortDropdown } from './SortDropdown';
 
 interface FilterChipsBarProps {
   filter: QueueFilterState;
@@ -165,6 +166,7 @@ const ALL_FILTER_KEYS: (keyof QueueFilterState)[] = [
   'mdmState',
   'showSkipTracing',
   'slipReviewPending',
+  'sortBy',
 ];
 
 export default function FilterChipsBar({
@@ -188,6 +190,11 @@ export default function FilterChipsBar({
   return (
     <div className="mb-3 flex flex-wrap items-center gap-2">
       <FilterPresetsDropdown currentFilter={filter} onApply={applyPreset} />
+
+      <SortDropdown
+        value={filter.sortBy}
+        onChange={(v: QueueSortOption) => setFilter({ sortBy: v })}
+      />
 
       <Button variant="outline" size="sm" onClick={onOpenFilter} className="gap-1.5">
         <Filter className="size-3.5" />

--- a/apps/web/src/pages/CollectionsPage/components/FilterPresetsDropdown.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/FilterPresetsDropdown.tsx
@@ -1,0 +1,200 @@
+import { useState } from 'react';
+import { Bookmark, ChevronDown, Save, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { useAuth } from '@/contexts/AuthContext';
+import { SYSTEM_PRESETS } from '../constants/systemPresets';
+import {
+  useListPresets,
+  useCreatePreset,
+  useDeletePreset,
+  type FilterPresetScope,
+} from '../hooks/useFilterPresets';
+import type { QueueFilterState } from '../hooks/useQueueFilter';
+
+const PAGE_KEY = 'collections-queue';
+
+interface Props {
+  currentFilter: QueueFilterState;
+  onApply: (filter: QueueFilterState) => void;
+}
+
+export function FilterPresetsDropdown({ currentFilter, onApply }: Props) {
+  const { user } = useAuth();
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [scope, setScope] = useState<FilterPresetScope>('PRIVATE');
+
+  const presetsQuery = useListPresets(PAGE_KEY);
+  const create = useCreatePreset();
+  const del = useDeletePreset(PAGE_KEY);
+
+  const userPresets = presetsQuery.data ?? [];
+  const role = user?.role ?? '';
+  const canShareBranch = ['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER'].includes(role);
+  const canShareAll = role === 'OWNER';
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    create.mutate(
+      {
+        name: name.trim(),
+        scope,
+        page: PAGE_KEY,
+        filterJson: currentFilter,
+      },
+      {
+        onSuccess: () => {
+          setSaveOpen(false);
+          setName('');
+          setScope('PRIVATE');
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-1.5">
+            <Bookmark className="size-3.5" />
+            Presets
+            <ChevronDown className="size-3.5 opacity-60" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-64">
+          <DropdownMenuLabel>ระบบแนะนำ</DropdownMenuLabel>
+          {SYSTEM_PRESETS.map((p) => (
+            <DropdownMenuItem
+              key={p.key}
+              onSelect={() => onApply(p.filter)}
+              className="cursor-pointer"
+            >
+              {p.name}
+            </DropdownMenuItem>
+          ))}
+
+          {userPresets.length > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>ของฉัน / ทีม</DropdownMenuLabel>
+              {userPresets.map((p) => (
+                <DropdownMenuItem
+                  key={p.id}
+                  onSelect={() => onApply(p.filterJson)}
+                  className="group flex cursor-pointer items-center justify-between gap-2"
+                >
+                  <span className="truncate">
+                    {p.name}
+                    {p.scope !== 'PRIVATE' && (
+                      <span className="ml-1 text-2xs text-muted-foreground leading-snug">
+                        {p.scope === 'SHARED_BRANCH' ? '· สาขา' : '· ทุกสาขา'}
+                      </span>
+                    )}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      del.mutate(p.id);
+                    }}
+                    className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity"
+                    aria-label={`ลบ preset ${p.name}`}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </DropdownMenuItem>
+              ))}
+            </>
+          )}
+
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setSaveOpen(true)} className="cursor-pointer">
+            <Save className="mr-2 size-4" />
+            บันทึก filter ปัจจุบัน
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={saveOpen} onOpenChange={setSaveOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>บันทึก Filter Preset</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="preset-name">ชื่อ preset</Label>
+              <Input
+                id="preset-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="เช่น เกินกำหนด LADPRAO"
+                maxLength={50}
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>ขอบเขต</Label>
+              <RadioGroup
+                value={scope}
+                onValueChange={(v) => setScope(v as FilterPresetScope)}
+              >
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="PRIVATE" id="sc-p" />
+                  <Label htmlFor="sc-p" className="font-normal cursor-pointer">
+                    ของฉันเท่านั้น
+                  </Label>
+                </div>
+                {canShareBranch && (
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="SHARED_BRANCH" id="sc-b" />
+                    <Label htmlFor="sc-b" className="font-normal cursor-pointer">
+                      สาขาของฉัน
+                    </Label>
+                  </div>
+                )}
+                {canShareAll && (
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="SHARED_ALL" id="sc-a" />
+                    <Label htmlFor="sc-a" className="font-normal cursor-pointer">
+                      ทุกสาขา
+                    </Label>
+                  </div>
+                )}
+              </RadioGroup>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSaveOpen(false)}>
+              ยกเลิก
+            </Button>
+            <Button onClick={handleSave} disabled={!name.trim() || create.isPending}>
+              {create.isPending ? 'กำลังบันทึก...' : 'บันทึก'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default FilterPresetsDropdown;

--- a/apps/web/src/pages/CollectionsPage/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,102 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface ShortcutGroup {
+  title: string;
+  rows: Array<{ keys: string[]; label: string }>;
+}
+
+const GROUPS: ShortcutGroup[] = [
+  {
+    title: 'ทั่วไป',
+    rows: [
+      { keys: ['?'], label: 'เปิด/ปิดหน้าช่วยเหลือ' },
+      { keys: ['Esc'], label: 'ปิด dialog หรือยกเลิก G-prefix' },
+      { keys: ['/'], label: 'โฟกัสช่องค้นหา' },
+    ],
+  },
+  {
+    title: 'สลับแท็บ (กด G แล้วตามด้วย…)',
+    rows: [
+      { keys: ['G', 'Q'], label: 'คิววันนี้' },
+      { keys: ['G', 'F'], label: 'ติดตามต่อเนื่อง' },
+      { keys: ['G', 'P'], label: 'นัดชำระ' },
+      { keys: ['G', 'A'], label: 'รออนุมัติ' },
+      { keys: ['G', 'N'], label: 'วิเคราะห์ (Analytics)' },
+      { keys: ['G', 'L'], label: 'ทั้งหมด' },
+    ],
+  },
+  {
+    title: 'การ์ดในคิว',
+    rows: [
+      { keys: ['J', '↓'], label: 'ย้ายโฟกัสลง' },
+      { keys: ['K', '↑'], label: 'ย้ายโฟกัสขึ้น' },
+      { keys: ['Enter'], label: 'เปิด Customer 360' },
+      { keys: ['L'], label: 'ส่ง LINE' },
+      { keys: ['C'], label: 'บันทึกการโทร' },
+      { keys: ['P'], label: 'บันทึกชำระเงิน' },
+      { keys: ['S'], label: 'Snooze' },
+      { keys: ['A'], label: 'มอบหมาย / Assign' },
+    ],
+  },
+];
+
+function KeyCap({ children }: { children: string }) {
+  return (
+    <kbd className="inline-flex min-w-[1.75rem] items-center justify-center rounded-md border border-border bg-muted px-1.5 py-0.5 text-2xs font-mono font-medium text-foreground shadow-sm">
+      {children}
+    </kbd>
+  );
+}
+
+export default function KeyboardShortcutsOverlay({ open, onOpenChange }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>แป้นพิมพ์ลัด</DialogTitle>
+          <DialogDescription>กด ? อีกครั้ง หรือ Esc เพื่อปิดหน้านี้</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-5 sm:grid-cols-2 sm:gap-6">
+          {GROUPS.map((g) => (
+            <section key={g.title} className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {g.title}
+              </h3>
+              <ul className="space-y-1.5">
+                {g.rows.map((row) => (
+                  <li
+                    key={row.label}
+                    className="flex items-center justify-between gap-3 text-sm leading-snug"
+                  >
+                    <span className="text-foreground">{row.label}</span>
+                    <span className="flex items-center gap-1">
+                      {row.keys.map((k, idx) => (
+                        <span key={`${row.label}-${k}-${idx}`} className="flex items-center gap-1">
+                          {idx > 0 && (
+                            <span className="text-2xs text-muted-foreground">แล้ว</span>
+                          )}
+                          <KeyCap>{k}</KeyCap>
+                        </span>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/LeaderboardTable.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LeaderboardTable.tsx
@@ -1,0 +1,188 @@
+import { useMemo, useState } from 'react';
+import { Trophy, ArrowUp, ArrowDown, Download } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import QueryBoundary from '@/components/QueryBoundary';
+import { useLeaderboard, type LeaderboardRow } from '../hooks/useLeaderboard';
+
+type SortKey =
+  | 'name'
+  | 'assignedCount'
+  | 'promiseKeptPercent'
+  | 'avgDaysToFirstContact'
+  | 'recoveryThisMonth';
+
+const COLUMNS: { key: SortKey; label: string; align: 'left' | 'right' }[] = [
+  { key: 'name', label: 'พนักงาน', align: 'left' },
+  { key: 'assignedCount', label: 'มอบหมาย', align: 'right' },
+  { key: 'promiseKeptPercent', label: '% ตามนัด', align: 'right' },
+  { key: 'avgDaysToFirstContact', label: 'เฉลี่ย (วัน) ติดต่อแรก', align: 'right' },
+  { key: 'recoveryThisMonth', label: 'เก็บได้ (เดือนนี้)', align: 'right' },
+];
+
+const TROPHY_COLOR = ['text-amber-500', 'text-zinc-400', 'text-amber-700'];
+
+function formatBaht(n: number): string {
+  return new Intl.NumberFormat('th-TH', { maximumFractionDigits: 0 }).format(n);
+}
+
+function downloadCsv(rows: LeaderboardRow[]): void {
+  const header = [
+    'อันดับ',
+    'รหัสพนักงาน',
+    'ชื่อ',
+    'มอบหมาย (สัญญา)',
+    '% ตามนัด',
+    'เฉลี่ยวันติดต่อแรก',
+    'เก็บได้เดือนนี้ (บาท)',
+  ];
+  const lines = [header.join(',')];
+  rows.forEach((r, idx) => {
+    const cells = [
+      String(idx + 1),
+      r.collectorId,
+      `"${r.name.replace(/"/g, '""')}"`,
+      String(r.assignedCount),
+      String(r.promiseKeptPercent),
+      String(r.avgDaysToFirstContact),
+      String(r.recoveryThisMonth),
+    ];
+    lines.push(cells.join(','));
+  });
+  // BOM for Excel UTF-8 detection
+  const bom = '﻿';
+  const blob = new Blob([bom + lines.join('\n')], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  const ts = new Date().toISOString().slice(0, 10);
+  a.download = `collector-leaderboard-${ts}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export default function LeaderboardTable() {
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({
+    key: 'recoveryThisMonth',
+    dir: 'desc',
+  });
+  const { data = [], isLoading, isError, error, refetch } = useLeaderboard();
+
+  const sorted = useMemo(() => {
+    const arr = [...data];
+    arr.sort((a, b) => {
+      const av = a[sort.key];
+      const bv = b[sort.key];
+      if (typeof av === 'number' && typeof bv === 'number') {
+        return sort.dir === 'asc' ? av - bv : bv - av;
+      }
+      return sort.dir === 'asc'
+        ? String(av).localeCompare(String(bv), 'th')
+        : String(bv).localeCompare(String(av), 'th');
+    });
+    return arr;
+  }, [data, sort]);
+
+  const toggleSort = (key: SortKey) => {
+    setSort((cur) =>
+      cur.key === key
+        ? { key, dir: cur.dir === 'asc' ? 'desc' : 'asc' }
+        : { key, dir: key === 'name' ? 'asc' : 'desc' },
+    );
+  };
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <div className="text-sm font-semibold mb-0.5 leading-snug">
+              อันดับผู้ติดตามหนี้
+            </div>
+            <div className="text-xs text-muted-foreground leading-snug">
+              เรียงตามยอดเก็บได้เดือนนี้
+            </div>
+          </div>
+          <button
+            onClick={() => downloadCsv(sorted)}
+            disabled={sorted.length === 0}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-input hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <Download className="size-3.5" />
+            ดาวน์โหลด CSV
+          </button>
+        </div>
+
+        <QueryBoundary
+          isLoading={isLoading}
+          isError={isError}
+          error={error}
+          onRetry={refetch}
+          errorTitle="ไม่สามารถโหลดอันดับผู้ติดตามได้"
+        >
+          {sorted.length === 0 ? (
+            <div className="py-8 text-center text-xs text-muted-foreground italic leading-snug">
+              ยังไม่มีข้อมูล
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-xs text-muted-foreground">
+                    <th className="text-left py-2 px-2 w-10 font-medium">#</th>
+                    {COLUMNS.map((c) => (
+                      <th
+                        key={c.key}
+                        className={`py-2 px-2 font-medium cursor-pointer select-none hover:text-foreground ${
+                          c.align === 'right' ? 'text-right' : 'text-left'
+                        }`}
+                        onClick={() => toggleSort(c.key)}
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          {c.label}
+                          {sort.key === c.key &&
+                            (sort.dir === 'asc' ? (
+                              <ArrowUp className="size-3" />
+                            ) : (
+                              <ArrowDown className="size-3" />
+                            ))}
+                        </span>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map((row, idx) => (
+                    <tr key={row.collectorId} className="border-b border-border/60">
+                      <td className="py-2 px-2 tabular-nums">
+                        {idx < 3 ? (
+                          <Trophy className={`size-4 ${TROPHY_COLOR[idx]}`} />
+                        ) : (
+                          <span className="text-muted-foreground">{idx + 1}</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-2 font-medium leading-snug">{row.name}</td>
+                      <td className="py-2 px-2 text-right tabular-nums">
+                        {row.assignedCount}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums">
+                        {row.promiseKeptPercent.toFixed(1)}%
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums">
+                        {row.avgDaysToFirstContact.toFixed(1)}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums font-medium">
+                        {formatBaht(row.recoveryThisMonth)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </QueryBoundary>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Download, FileText, Loader2, Upload } from 'lucide-react';
+import { Download, Eye, FileText, Loader2, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import Modal from '@/components/ui/Modal';
@@ -9,6 +9,7 @@ import { renderLetterPdf, type LetterTemplateData } from '../utils/letterPdfRend
 import { useLetterActions } from '../hooks/useLetterActions';
 import type { LetterRow } from '../hooks/useLetterQueue';
 import { EvidenceThumbnailGrid } from './EvidenceThumbnailGrid';
+import LetterPdfPreviewDialog from './LetterPdfPreviewDialog';
 
 interface Props {
   open: boolean;
@@ -297,6 +298,7 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
   const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
   const [evidenceVerified, setEvidenceVerified] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
   const { dispatch } = useLetterActions();
 
   // Create a local preview URL for the selected evidence file
@@ -360,17 +362,27 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
 
   return (
     <div className="space-y-4 p-1">
-      {/* PDF download link */}
+      {/* PDF preview + download */}
       {letter.pdfUrl && (
-        <a
-          href={letter.pdfUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
-        >
-          <Download className="size-4" />
-          ดาวน์โหลด PDF ({letter.letterNumber})
-        </a>
+        <div className="flex items-center gap-2 flex-wrap">
+          <button
+            type="button"
+            onClick={() => setPreviewOpen(true)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-input hover:bg-muted text-foreground transition-colors"
+          >
+            <Eye className="size-3.5" />
+            ดู PDF
+          </button>
+          <a
+            href={letter.pdfUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg text-primary hover:underline"
+          >
+            <Download className="size-3.5" />
+            ดาวน์โหลด ({letter.letterNumber})
+          </a>
+        </div>
       )}
 
       {/* Letter info block */}
@@ -470,6 +482,15 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
           )}
         </button>
       </div>
+
+      {/* PDF preview popup — pre-dispatch sanity check */}
+      <LetterPdfPreviewDialog
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        pdfUrl={letter.pdfUrl}
+        title={`PDF — ${letter.letterNumber}`}
+        subtitle={`${letter.contract.customer.name} · ${letter.contract.contractNumber}`}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/CollectionsPage/components/LetterPdfPreviewDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterPdfPreviewDialog.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import { ExternalLink, Download, ZoomIn, ZoomOut, RotateCcw, FileText } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  pdfUrl: string | null;
+  title?: string;
+  subtitle?: string;
+}
+
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 2.5;
+const ZOOM_STEP = 0.25;
+
+/**
+ * LetterPdfPreviewDialog — Inline PDF preview using iframe.
+ *
+ * Approach:
+ *  - Uses native browser PDF viewer via <iframe> (no extra dependency).
+ *  - Zoom is implemented via CSS transform on the iframe wrapper (works on all browsers).
+ *  - Mobile fallback: most mobile browsers (iOS Safari especially) do NOT render PDFs in iframes
+ *    reliably, so we always expose a prominent "เปิดในแท็บใหม่" link.
+ */
+export default function LetterPdfPreviewDialog({
+  open,
+  onClose,
+  pdfUrl,
+  title = 'ตัวอย่าง PDF',
+  subtitle,
+}: Props) {
+  const [zoom, setZoom] = useState(1);
+
+  const handleZoomIn = () => setZoom((z) => Math.min(MAX_ZOOM, +(z + ZOOM_STEP).toFixed(2)));
+  const handleZoomOut = () => setZoom((z) => Math.max(MIN_ZOOM, +(z - ZOOM_STEP).toFixed(2)));
+  const handleZoomReset = () => setZoom(1);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) {
+          setZoom(1);
+          onClose();
+        }
+      }}
+    >
+      <DialogContent
+        className="max-w-4xl w-[calc(100vw-2rem)] h-[90vh] p-0 gap-0 flex flex-col"
+        showCloseButton
+      >
+        <DialogHeader className="px-5 pt-5 pb-3 mb-0 border-b border-border space-y-1 text-start">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <FileText className="size-4 text-primary" />
+            {title}
+          </DialogTitle>
+          {subtitle && (
+            <DialogDescription className="text-xs leading-snug">{subtitle}</DialogDescription>
+          )}
+        </DialogHeader>
+
+        {/* Toolbar */}
+        <div className="flex items-center justify-between gap-2 px-5 py-2 border-b border-border bg-muted/40">
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handleZoomOut}
+              disabled={!pdfUrl || zoom <= MIN_ZOOM}
+              className="inline-flex items-center justify-center size-8 rounded-md hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              aria-label="ซูมออก"
+            >
+              <ZoomOut className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleZoomReset}
+              disabled={!pdfUrl}
+              className="px-2 h-8 rounded-md text-xs font-medium tabular-nums hover:bg-accent disabled:opacity-40 transition-colors min-w-[3.5rem]"
+              aria-label="รีเซ็ตซูม"
+            >
+              {Math.round(zoom * 100)}%
+            </button>
+            <button
+              type="button"
+              onClick={handleZoomIn}
+              disabled={!pdfUrl || zoom >= MAX_ZOOM}
+              className="inline-flex items-center justify-center size-8 rounded-md hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              aria-label="ซูมเข้า"
+            >
+              <ZoomIn className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleZoomReset}
+              disabled={!pdfUrl || zoom === 1}
+              className="inline-flex items-center justify-center size-8 rounded-md hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              aria-label="รีเซ็ต"
+            >
+              <RotateCcw className="size-4" />
+            </button>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {pdfUrl && (
+              <>
+                <a
+                  href={pdfUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-3 h-8 rounded-md text-xs font-medium border border-input hover:bg-accent transition-colors"
+                >
+                  <ExternalLink className="size-3.5" />
+                  เปิดในแท็บใหม่
+                </a>
+                <a
+                  href={pdfUrl}
+                  download
+                  className="inline-flex items-center gap-1.5 px-3 h-8 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                >
+                  <Download className="size-3.5" />
+                  ดาวน์โหลด
+                </a>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* PDF body */}
+        <div className="flex-1 overflow-auto bg-muted/20 min-h-0">
+          {pdfUrl ? (
+            <div
+              className={cn(
+                'mx-auto h-full transition-[width,height] origin-top',
+                zoom !== 1 && 'origin-top-left',
+              )}
+              style={{
+                width: `${zoom * 100}%`,
+                minHeight: `${zoom * 100}%`,
+              }}
+            >
+              <iframe
+                src={`${pdfUrl}#view=FitH`}
+                title={title}
+                className="w-full h-full border-0 block"
+                // sandbox intentionally omitted — must allow plugin/PDF rendering
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-full text-sm text-muted-foreground leading-snug">
+              ยังไม่มี PDF
+            </div>
+          )}
+        </div>
+
+        {/* Mobile fallback hint — visible only on small screens */}
+        {pdfUrl && (
+          <div className="md:hidden px-5 py-2 border-t border-border bg-warning/5 text-[11px] text-muted-foreground leading-snug">
+            หากแสดงผลไม่ครบบนมือถือ กรุณากด{' '}
+            <a
+              href={pdfUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary font-medium underline underline-offset-2"
+            >
+              เปิดในแท็บใหม่
+            </a>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterQueueSection.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { FileText, Download, CheckCircle, RotateCcw, Loader2, Upload } from 'lucide-react';
+import { FileText, Download, CheckCircle, RotateCcw, Loader2, Upload, Eye } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { useLetterQueue, type LetterRow, type LetterType, type LetterStatus } from '../hooks/useLetterQueue';
 import { useLetterActions } from '../hooks/useLetterActions';
 import LetterDispatchDialog from './LetterDispatchDialog';
 import BulkSlipUploadDialog from './BulkSlipUploadDialog';
+import LetterPdfPreviewDialog from './LetterPdfPreviewDialog';
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -67,6 +68,7 @@ interface LetterRowCardProps {
   letter: LetterRow;
   onOpenGenerate: (l: LetterRow) => void;
   onOpenDispatch: (l: LetterRow) => void;
+  onPreviewPdf: (l: LetterRow) => void;
   onDelivered: (l: LetterRow) => void;
   onUndeliverable: (l: LetterRow) => void;
   deliveredPending: boolean;
@@ -77,6 +79,7 @@ function LetterRowCard({
   letter,
   onOpenGenerate,
   onOpenDispatch,
+  onPreviewPdf,
   onDelivered,
   onUndeliverable,
   deliveredPending,
@@ -129,7 +132,19 @@ function LetterRowCard({
         </div>
 
         {/* CTAs per status */}
-        <div className="flex items-center justify-end gap-2">
+        <div className="flex items-center justify-end gap-2 flex-wrap">
+          {/* Preview PDF — visible whenever a PDF exists */}
+          {letter.pdfUrl && (
+            <button
+              type="button"
+              onClick={() => onPreviewPdf(letter)}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-input px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <Eye className="size-3.5" />
+              ดู PDF
+            </button>
+          )}
+
           {letter.status === 'PENDING_DISPATCH' && (
             <button
               type="button"
@@ -206,6 +221,7 @@ export default function LetterQueueSection() {
   const [dispatchLetter, setDispatchLetter] = useState<LetterRow | null>(null);
   const [dispatchMode, setDispatchMode] = useState<'generate' | 'dispatch'>('generate');
   const [bulkSlipOpen, setBulkSlipOpen] = useState(false);
+  const [previewLetter, setPreviewLetter] = useState<LetterRow | null>(null);
 
   const openGenerate = (l: LetterRow) => {
     setDispatchLetter(l);
@@ -277,6 +293,7 @@ export default function LetterQueueSection() {
                     letter={letter}
                     onOpenGenerate={openGenerate}
                     onOpenDispatch={openDispatch}
+                    onPreviewPdf={setPreviewLetter}
                     onDelivered={(l) => markDelivered.mutate(l.id)}
                     onUndeliverable={handleUndeliverable}
                     deliveredPending={markDelivered.isPending}
@@ -303,6 +320,16 @@ export default function LetterQueueSection() {
           open={bulkSlipOpen}
           letters={dispatchedMissingEvidence}
           onClose={() => setBulkSlipOpen(false)}
+        />
+      )}
+
+      {previewLetter && (
+        <LetterPdfPreviewDialog
+          open={!!previewLetter}
+          onClose={() => setPreviewLetter(null)}
+          pdfUrl={previewLetter.pdfUrl}
+          title={`PDF — ${previewLetter.letterNumber}`}
+          subtitle={`${previewLetter.contract.customer.name} · ${previewLetter.contract.contractNumber}`}
         />
       )}
     </>

--- a/apps/web/src/pages/CollectionsPage/components/MigrationBanner.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/MigrationBanner.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MigrationBanner from './MigrationBanner';
+
+const STORAGE_KEY = 'collections-migrated-banner-dismissed';
+
+describe('MigrationBanner', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // Inside the 14-day window — DEPLOY_DATE = 2026-04-25
+    vi.setSystemTime(new Date('2026-04-26T10:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  it('renders when not dismissed and within 14-day window', () => {
+    render(<MigrationBanner />);
+    expect(screen.getByText(/ย้ายจาก \/overdue มาที่ \/collections/)).toBeInTheDocument();
+  });
+
+  it('does not render when previously dismissed (localStorage flag set)', () => {
+    window.localStorage.setItem(STORAGE_KEY, '1');
+    render(<MigrationBanner />);
+    expect(screen.queryByText(/ย้ายจาก \/overdue/)).not.toBeInTheDocument();
+  });
+
+  it('dismiss click persists to localStorage and hides the banner', () => {
+    render(<MigrationBanner />);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('ปิดประกาศ'));
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1');
+    expect(screen.queryByText(/ย้ายจาก \/overdue/)).not.toBeInTheDocument();
+  });
+
+  it('does not render past the 14-day window even if not dismissed', () => {
+    // 2026-05-10 is > 14 days after deploy date 2026-04-25
+    vi.setSystemTime(new Date('2026-05-10T00:00:00Z'));
+    render(<MigrationBanner />);
+    expect(screen.queryByText(/ย้ายจาก \/overdue/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/CollectionsPage/components/MigrationBanner.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/MigrationBanner.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { Info, X } from 'lucide-react';
+
+const STORAGE_KEY = 'collections-migrated-banner-dismissed';
+// Hardcoded deploy date — banner stops showing 14 days after this date.
+// Update this when re-deploying or running another migration nudge.
+const DEPLOY_DATE = new Date('2026-04-25');
+const DAYS_VISIBLE = 14;
+
+function shouldShow(now: Date, dismissed: boolean): boolean {
+  if (dismissed) return false;
+  const cutoff = new Date(DEPLOY_DATE);
+  cutoff.setDate(cutoff.getDate() + DAYS_VISIBLE);
+  return now < cutoff;
+}
+
+export default function MigrationBanner() {
+  // Read once on mount so SSR/hydration mismatch isn't a concern; localStorage
+  // is only available in the browser.
+  const [visible, setVisible] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    const dismissed = window.localStorage.getItem(STORAGE_KEY) === '1';
+    return shouldShow(new Date(), dismissed);
+  });
+
+  // Re-evaluate on focus/route change in case user kept tab open across the cutoff.
+  useEffect(() => {
+    const onFocus = () => {
+      const dismissed = window.localStorage.getItem(STORAGE_KEY) === '1';
+      setVisible(shouldShow(new Date(), dismissed));
+    };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, []);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    window.localStorage.setItem(STORAGE_KEY, '1');
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="status"
+      className="mb-4 flex items-start gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3 text-sm leading-snug"
+    >
+      <Info className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden="true" />
+      <div className="flex-1">
+        <p className="font-medium text-foreground">
+          ย้ายจาก /overdue มาที่ /collections แล้ว อัปเดต bookmark ได้เลย
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          หน้าเดิมจะ redirect อัตโนมัติ — ฟีเจอร์ทั้งหมดอยู่ที่นี่ครบ
+        </p>
+      </div>
+      <button
+        onClick={dismiss}
+        className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+        aria-label="ปิดประกาศ"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/SnoozeDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/SnoozeDialog.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react';
+import { Moon, Clock, Sunrise, CalendarDays, CalendarClock } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useSnoozeContract, type SnoozeDuration } from '../hooks/useSnooze';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  contract: {
+    id: string;
+    contractNumber: string;
+    customer: { name: string };
+  } | null;
+}
+
+interface PresetOption {
+  key: Exclude<SnoozeDuration, 'custom'>;
+  label: string;
+  hint: string;
+  icon: typeof Clock;
+}
+
+const PRESETS: PresetOption[] = [
+  { key: '1h', label: '1 ชั่วโมง', hint: 'ลูกค้ากำลังขับรถ / ติดประชุม', icon: Clock },
+  { key: '2h', label: '2 ชั่วโมง', hint: 'ออกธุระระยะสั้น', icon: Clock },
+  {
+    key: 'tomorrow_9am',
+    label: 'พรุ่งนี้ 09:00',
+    hint: 'รอเปิดเช้าวันถัดไป',
+    icon: Sunrise,
+  },
+  {
+    key: 'next_week',
+    label: 'สัปดาห์หน้า',
+    hint: '7 วันจากตอนนี้',
+    icon: CalendarDays,
+  },
+];
+
+/**
+ * Format a Date as the value expected by `<input type="datetime-local">`
+ * (YYYY-MM-DDTHH:mm) using the user's local timezone.
+ */
+function toLocalDatetimeValue(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * SnoozeDialog — pick a duration to hide a contract card from the queue.
+ *
+ * UX:
+ *  - 4 preset buttons (1h / 2h / tomorrow 09:00 / next week) — one-click
+ *    snooze for the common cases.
+ *  - "กำหนดเอง" toggle reveals a `<input type="datetime-local">` for custom
+ *    snoozes. The control's `min` is "now + 5min" so users can't pick the
+ *    past in the picker UI; the BE re-validates anyway.
+ *  - Optional reason note (max 200 chars) — shown to the OWNER who can audit
+ *    snooze patterns per collector.
+ */
+export default function SnoozeDialog({ open, onClose, contract }: Props) {
+  const [reason, setReason] = useState('');
+  const [customMode, setCustomMode] = useState(false);
+  const [customValue, setCustomValue] = useState('');
+  const snooze = useSnoozeContract();
+
+  const minDatetime = toLocalDatetimeValue(new Date(Date.now() + 5 * 60 * 1000));
+
+  function reset() {
+    setReason('');
+    setCustomMode(false);
+    setCustomValue('');
+  }
+
+  function handleClose() {
+    if (snooze.isPending) return;
+    reset();
+    onClose();
+  }
+
+  function handlePreset(key: Exclude<SnoozeDuration, 'custom'>) {
+    if (!contract || snooze.isPending) return;
+    snooze.mutate(
+      {
+        contractId: contract.id,
+        payload: { duration: key, reason: reason.trim() || undefined },
+      },
+      {
+        onSuccess: () => {
+          reset();
+          onClose();
+        },
+      },
+    );
+  }
+
+  function handleCustomSubmit() {
+    if (!contract || !customValue || snooze.isPending) return;
+    // datetime-local has no timezone — interpret as local then ship as ISO.
+    const iso = new Date(customValue).toISOString();
+    snooze.mutate(
+      {
+        contractId: contract.id,
+        payload: {
+          duration: 'custom',
+          snoozedUntil: iso,
+          reason: reason.trim() || undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          reset();
+          onClose();
+        },
+      },
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Moon className="size-4 text-muted-foreground" /> Snooze จน...
+          </DialogTitle>
+          {contract && (
+            <DialogDescription className="leading-snug">
+              {contract.contractNumber} · {contract.customer.name}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {!customMode ? (
+          <div className="grid gap-2">
+            {PRESETS.map((p) => {
+              const Icon = p.icon;
+              return (
+                <button
+                  key={p.key}
+                  onClick={() => handlePreset(p.key)}
+                  disabled={snooze.isPending}
+                  className="group flex items-center gap-3 rounded-lg border border-input bg-background p-3 text-left hover:border-primary/40 hover:bg-accent disabled:opacity-50 transition-colors"
+                >
+                  <div className="flex size-9 items-center justify-center rounded-full bg-muted text-muted-foreground group-hover:bg-primary/10 group-hover:text-primary transition-colors">
+                    <Icon className="size-4" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium leading-snug">{p.label}</div>
+                    <div className="text-2xs text-muted-foreground leading-snug">
+                      {p.hint}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+            <button
+              onClick={() => setCustomMode(true)}
+              disabled={snooze.isPending}
+              className="flex items-center gap-3 rounded-lg border border-dashed border-input bg-background p-3 text-left hover:border-primary/40 hover:bg-accent disabled:opacity-50 transition-colors"
+            >
+              <div className="flex size-9 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                <CalendarClock className="size-4" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium leading-snug">กำหนดเอง...</div>
+                <div className="text-2xs text-muted-foreground leading-snug">
+                  เลือกวัน-เวลา
+                </div>
+              </div>
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="snooze-custom">วัน-เวลาที่ปลุก</Label>
+              <Input
+                id="snooze-custom"
+                type="datetime-local"
+                value={customValue}
+                min={minDatetime}
+                onChange={(e) => setCustomValue(e.target.value)}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="snooze-reason">เหตุผล (ไม่บังคับ)</Label>
+          <Input
+            id="snooze-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="เช่น รอลูกค้าโทรกลับ"
+            maxLength={200}
+          />
+        </div>
+
+        <DialogFooter>
+          {customMode && (
+            <Button
+              variant="outline"
+              onClick={() => setCustomMode(false)}
+              disabled={snooze.isPending}
+            >
+              กลับ
+            </Button>
+          )}
+          <Button variant="outline" onClick={handleClose} disabled={snooze.isPending}>
+            ยกเลิก
+          </Button>
+          {customMode && (
+            <Button
+              onClick={handleCustomSubmit}
+              disabled={!customValue || snooze.isPending}
+            >
+              Snooze
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/SortDropdown.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/SortDropdown.tsx
@@ -1,0 +1,52 @@
+import { ArrowUpDown } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+export type QueueSortValue =
+  | 'priority'
+  | 'outstanding_desc'
+  | 'outstanding_asc'
+  | 'days_overdue_desc'
+  | 'last_contacted_asc'
+  | 'name_asc'
+  | 'random';
+
+const SORT_OPTIONS: { value: QueueSortValue; label: string }[] = [
+  { value: 'priority', label: 'Priority' },
+  { value: 'outstanding_desc', label: 'ยอดค้าง สูง→ต่ำ' },
+  { value: 'outstanding_asc', label: 'ยอดค้าง ต่ำ→สูง' },
+  { value: 'days_overdue_desc', label: 'เลยกำหนดนานสุด' },
+  { value: 'last_contacted_asc', label: 'ไม่แตะนานสุด' },
+  { value: 'name_asc', label: 'ชื่อ ก-ฮ' },
+  { value: 'random', label: 'สุ่ม (rotation)' },
+];
+
+interface Props {
+  value?: QueueSortValue;
+  onChange: (v: QueueSortValue) => void;
+}
+
+export function SortDropdown({ value, onChange }: Props) {
+  return (
+    <Select value={value ?? 'priority'} onValueChange={(v) => onChange(v as QueueSortValue)}>
+      <SelectTrigger className="h-8 w-[180px]" aria-label="เรียงลำดับคิว">
+        <ArrowUpDown className="mr-1.5 size-3.5 opacity-70" />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {SORT_OPTIONS.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export default SortDropdown;

--- a/apps/web/src/pages/CollectionsPage/components/StuckContractsSection.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/StuckContractsSection.tsx
@@ -1,0 +1,245 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { UserPlus, Clock } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/lib/api';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import QueryBoundary from '@/components/QueryBoundary';
+import { useStuckContracts } from '../hooks/useStuckContracts';
+
+interface StaffUser {
+  id: string;
+  name: string;
+  role: string;
+}
+
+const THRESHOLD_OPTIONS = [7, 14, 30] as const;
+
+function formatBaht(n: number): string {
+  return new Intl.NumberFormat('th-TH', { maximumFractionDigits: 0 }).format(n);
+}
+
+export default function StuckContractsSection() {
+  const queryClient = useQueryClient();
+  const [days, setDays] = useState<number>(14);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [reassignOpen, setReassignOpen] = useState(false);
+  const [targetUserId, setTargetUserId] = useState<string>('');
+
+  const { data = [], isLoading, isError, error, refetch } = useStuckContracts(days);
+
+  const { data: staff = [] } = useQuery<StaffUser[]>({
+    queryKey: ['staff-users'],
+    queryFn: async () => {
+      const res = await api.get('/users');
+      const list = res.data?.data || res.data || [];
+      return Array.isArray(list) ? list : [];
+    },
+    enabled: reassignOpen,
+  });
+
+  const reassign = useMutation({
+    mutationFn: async (vars: { contractIds: string[]; assignedToId: string }) =>
+      api.post('/overdue/bulk/assign', vars),
+    onSuccess: () => {
+      toast.success('มอบหมายสำเร็จ');
+      setSelected(new Set());
+      setReassignOpen(false);
+      setTargetUserId('');
+      queryClient.invalidateQueries({ queryKey: ['collections-stuck-contracts'] });
+    },
+    onError: () => toast.error('มอบหมายไม่สำเร็จ'),
+  });
+
+  const allChecked = useMemo(
+    () => data.length > 0 && data.every((r) => selected.has(r.contractId)),
+    [data, selected],
+  );
+  const toggleAll = () => {
+    if (allChecked) setSelected(new Set());
+    else setSelected(new Set(data.map((r) => r.contractId)));
+  };
+  const toggleOne = (id: string) => {
+    setSelected((cur) => {
+      const next = new Set(cur);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleReassign = () => {
+    if (!targetUserId || selected.size === 0) return;
+    reassign.mutate({
+      contractIds: Array.from(selected),
+      assignedToId: targetUserId,
+    });
+  };
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between mb-4 gap-3 flex-wrap">
+          <div>
+            <div className="text-sm font-semibold mb-0.5 leading-snug inline-flex items-center gap-1.5">
+              <Clock className="size-4 text-muted-foreground" />
+              สัญญาที่ถูกค้าง
+            </div>
+            <div className="text-xs text-muted-foreground leading-snug">
+              ไม่มี call log / dunning / ติดต่อ ใน {days} วันที่ผ่านมา
+            </div>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted-foreground">เกณฑ์:</span>
+            {THRESHOLD_OPTIONS.map((d) => (
+              <button
+                key={d}
+                onClick={() => {
+                  setDays(d);
+                  setSelected(new Set());
+                }}
+                className={`px-2.5 py-1 rounded-md border transition-colors ${
+                  days === d
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'border-input hover:bg-accent'
+                }`}
+              >
+                {d} วัน
+              </button>
+            ))}
+            <button
+              onClick={() => setReassignOpen(true)}
+              disabled={selected.size === 0}
+              className="ml-2 inline-flex items-center gap-1.5 px-3 py-1.5 font-medium rounded-lg border border-input hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <UserPlus className="size-3.5" />
+              มอบหมายใหม่ ({selected.size})
+            </button>
+          </div>
+        </div>
+
+        <QueryBoundary
+          isLoading={isLoading}
+          isError={isError}
+          error={error}
+          onRetry={refetch}
+          errorTitle="ไม่สามารถโหลดสัญญาที่ค้างได้"
+        >
+          {data.length === 0 ? (
+            <div className="py-8 text-center text-xs text-muted-foreground italic leading-snug">
+              ไม่มีสัญญาที่ค้างเกินเกณฑ์
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-xs text-muted-foreground">
+                    <th className="py-2 px-2 w-8">
+                      <Checkbox
+                        checked={allChecked}
+                        onCheckedChange={toggleAll}
+                        aria-label="เลือกทั้งหมด"
+                      />
+                    </th>
+                    <th className="text-left py-2 px-2 font-medium">สัญญา</th>
+                    <th className="text-left py-2 px-2 font-medium">ลูกค้า</th>
+                    <th className="text-left py-2 px-2 font-medium">สาขา</th>
+                    <th className="text-left py-2 px-2 font-medium">ผู้รับผิดชอบ</th>
+                    <th className="text-right py-2 px-2 font-medium">วันค้าง</th>
+                    <th className="text-right py-2 px-2 font-medium">ยอดค้าง</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.map((row) => (
+                    <tr key={row.contractId} className="border-b border-border/60">
+                      <td className="py-2 px-2">
+                        <Checkbox
+                          checked={selected.has(row.contractId)}
+                          onCheckedChange={() => toggleOne(row.contractId)}
+                          aria-label={`เลือก ${row.contractNumber}`}
+                        />
+                      </td>
+                      <td className="py-2 px-2 font-medium tabular-nums leading-snug">
+                        {row.contractNumber}
+                      </td>
+                      <td className="py-2 px-2 leading-snug">
+                        <div>{row.customerName}</div>
+                        {row.customerPhone && (
+                          <div className="text-xs text-muted-foreground">
+                            {row.customerPhone}
+                          </div>
+                        )}
+                      </td>
+                      <td className="py-2 px-2 text-muted-foreground leading-snug">
+                        {row.branchName}
+                      </td>
+                      <td className="py-2 px-2 leading-snug">
+                        {row.assignedToName ?? (
+                          <span className="text-muted-foreground italic">ไม่ได้มอบหมาย</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums">
+                        {row.daysIdle}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums font-medium">
+                        {formatBaht(row.outstanding)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </QueryBoundary>
+      </CardContent>
+
+      <Dialog open={reassignOpen} onOpenChange={setReassignOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>มอบหมาย {selected.size} สัญญา</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground leading-snug">
+              เลือกผู้รับผิดชอบใหม่
+            </label>
+            <select
+              value={targetUserId}
+              onChange={(e) => setTargetUserId(e.target.value)}
+              className="w-full h-9 px-3 text-sm rounded-md border border-input bg-background"
+            >
+              <option value="">— เลือก —</option>
+              {staff.map((u) => (
+                <option key={u.id} value={u.id}>
+                  {u.name} ({u.role})
+                </option>
+              ))}
+            </select>
+          </div>
+          <DialogFooter>
+            <button
+              onClick={() => setReassignOpen(false)}
+              className="px-3 py-1.5 text-xs rounded-md border border-input hover:bg-accent"
+            >
+              ยกเลิก
+            </button>
+            <button
+              onClick={handleReassign}
+              disabled={!targetUserId || reassign.isPending}
+              className="px-3 py-1.5 text-xs rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              ยืนยัน
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/components/TimelineFilterChips.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/TimelineFilterChips.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { TimelineEvent } from '../hooks/useCustomer360';
+
+export type TimelineEventType = TimelineEvent['type'];
+export type TimelineFilterValue = TimelineEventType | 'ALL';
+
+const CHIPS: { value: TimelineFilterValue; label: string }[] = [
+  { value: 'ALL', label: 'ทั้งหมด' },
+  { value: 'PAYMENT', label: 'ชำระ' },
+  { value: 'DUNNING_ACTION', label: 'แจ้งเตือน' },
+  { value: 'CALL', label: 'โทร' },
+  { value: 'LETTER', label: 'หนังสือ' },
+  { value: 'MDM', label: 'เครื่อง' },
+  { value: 'STATUS_CHANGE', label: 'สถานะ' },
+];
+
+interface Props {
+  value: TimelineFilterValue;
+  onChange: (value: TimelineFilterValue) => void;
+  counts?: Partial<Record<TimelineFilterValue, number>>;
+  className?: string;
+}
+
+export default function TimelineFilterChips({ value, onChange, counts, className }: Props) {
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1', className)}>
+      {CHIPS.map((chip) => {
+        const count = counts?.[chip.value];
+        const isActive = value === chip.value;
+        return (
+          <Button
+            key={chip.value}
+            type="button"
+            variant={isActive ? 'primary' : 'ghost'}
+            size="sm"
+            className="h-7 px-2.5 text-xs"
+            onClick={() => onChange(chip.value)}
+          >
+            <span className="leading-snug">{chip.label}</span>
+            {typeof count === 'number' && (
+              <span
+                className={cn(
+                  'ml-1.5 tabular-nums text-[10px]',
+                  isActive ? 'text-primary-foreground/80' : 'text-muted-foreground',
+                )}
+              >
+                {count}
+              </span>
+            )}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/pages/CollectionsPage/constants/systemPresets.ts
+++ b/apps/web/src/pages/CollectionsPage/constants/systemPresets.ts
@@ -1,0 +1,38 @@
+import type { QueueFilterState } from '../hooks/useQueueFilter';
+
+export interface SystemPreset {
+  key: string;
+  name: string;
+  filter: QueueFilterState;
+}
+
+/**
+ * Hardcoded system-wide filter presets shown above user-saved presets in the
+ * dropdown. These cover the four most common collector views:
+ *  - urgent-today: own tickets in the early-overdue (1–7 day) bucket
+ *  - overdue-60-plus: deeper-overdue triage (61+ days)
+ *  - legal-pipeline: contracts in LEGAL status — handed to legal team
+ *  - untouched-7-days: contracts not contacted in over a week
+ */
+export const SYSTEM_PRESETS: SystemPreset[] = [
+  {
+    key: 'urgent-today',
+    name: 'ด่วนวันนี้',
+    filter: { assigned: 'self', overdueBuckets: ['1-7'] },
+  },
+  {
+    key: 'overdue-60-plus',
+    name: 'เลยกำหนด 60+',
+    filter: { overdueBuckets: ['61-90', '90+'] },
+  },
+  {
+    key: 'legal-pipeline',
+    name: 'LEGAL pipeline',
+    filter: { contractStatuses: ['LEGAL'] },
+  },
+  {
+    key: 'untouched-7-days',
+    name: 'ยังไม่แตะ 7 วัน',
+    filter: { lastContacted: 'over_7_days' },
+  },
+];

--- a/apps/web/src/pages/CollectionsPage/hooks/useAnalyticsAging.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useAnalyticsAging.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export type AgingBucketCode = '1-7' | '8-30' | '31-60' | '61-90' | '90+';
+
+export interface AgingBucketRow {
+  bucket: AgingBucketCode;
+  count: number;
+  outstanding: number;
+}
+
+export function useAnalyticsAging() {
+  return useQuery<AgingBucketRow[]>({
+    queryKey: ['collections-analytics-aging'],
+    queryFn: async () => (await api.get('/overdue/analytics/aging')).data,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useBulkActions.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useBulkActions.ts
@@ -1,9 +1,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { useUndoMutation } from './useUndoMutation';
 
+/**
+ * Bulk collections actions. Several actions surface an undo snackbar via
+ * `useUndoMutation` per Task 8 (collections-ui-p1):
+ *
+ *   - assign:        ASSIGN kind (30s undo) — caller MUST pass `previousAssignments`
+ *                    (Map<contractId, prevAssignedToId | null>) for reverse to work.
+ *                    Without it the hook degrades to a plain toast (no undo button).
+ *   - sendLine:      SEND_LINE kind — no undo (LINE messages are irreversible).
+ *                    Toast only summarises sent/failed counts.
+ *   - proposeLock:   PROPOSE_LOCK kind (10s) with live PENDING-status check.
+ *                    Reverse requires a per-request DELETE endpoint that is not
+ *                    yet shipped — wired structurally so γ-cluster can plug in.
+ */
 export function useBulkActions(clearSelection: () => void) {
   const qc = useQueryClient();
+  const { showUndo } = useUndoMutation();
 
   const invalidate = () => {
     qc.invalidateQueries({ queryKey: ['collections-queue'] });
@@ -11,12 +26,51 @@ export function useBulkActions(clearSelection: () => void) {
   };
 
   const assign = useMutation({
-    mutationFn: async (p: { contractIds: string[]; assignedToId: string }) => {
-      const { data } = await api.post('/overdue/bulk/assign', p);
-      return data as { updated: number; requested: number };
+    mutationFn: async (p: {
+      contractIds: string[];
+      assignedToId: string;
+      /**
+       * Optional: previous assignedToId per contract, captured by caller before
+       * the mutation runs. When provided, undo re-issues bulk-assign per
+       * previous owner. When omitted, undo is unavailable (plain toast only).
+       */
+      previousAssignments?: Record<string, string | null>;
+    }) => {
+      const { data } = await api.post('/overdue/bulk/assign', {
+        contractIds: p.contractIds,
+        assignedToId: p.assignedToId,
+      });
+      return {
+        result: data as { updated: number; requested: number },
+        previousAssignments: p.previousAssignments,
+      };
     },
-    onSuccess: (data) => {
-      toast.success(`มอบหมาย ${data.updated}/${data.requested} รายการสำเร็จ`);
+    onSuccess: ({ result, previousAssignments }) => {
+      const reverse = previousAssignments
+        ? async () => {
+            // Group contracts by previous assignee so we issue one bulk-assign
+            // per target. Contracts with no prior assignee are skipped (cannot
+            // currently un-assign via the bulk endpoint).
+            const groups = new Map<string, string[]>();
+            for (const [contractId, prev] of Object.entries(previousAssignments)) {
+              if (!prev) continue;
+              const list = groups.get(prev) ?? [];
+              list.push(contractId);
+              groups.set(prev, list);
+            }
+            await Promise.all(
+              [...groups.entries()].map(([prev, ids]) =>
+                api.post('/overdue/bulk/assign', { contractIds: ids, assignedToId: prev }),
+              ),
+            );
+          }
+        : undefined;
+      showUndo({
+        kind: 'ASSIGN',
+        message: `มอบหมาย ${result.updated}/${result.requested} รายการสำเร็จ`,
+        reverse,
+        invalidateKeys: [['collections-queue'], ['pending-mdm']],
+      });
       clearSelection();
       invalidate();
     },
@@ -33,7 +87,11 @@ export function useBulkActions(clearSelection: () => void) {
       return data as { sent: number; failed: number; total: number };
     },
     onSuccess: (data) => {
-      toast.success(`ส่ง LINE ${data.sent}/${data.total} (ล้มเหลว ${data.failed})`);
+      // SEND_LINE is irreversible — show recipient counts only.
+      showUndo({
+        kind: 'SEND_LINE',
+        message: `ส่ง LINE ${data.sent}/${data.total} (ล้มเหลว ${data.failed})`,
+      });
       clearSelection();
       invalidate();
     },
@@ -43,10 +101,25 @@ export function useBulkActions(clearSelection: () => void) {
   const proposeLock = useMutation({
     mutationFn: async (p: { contractIds: string[]; reason: string }) => {
       const { data } = await api.post('/overdue/bulk/propose-lock', p);
-      return data as { proposed: number; failed: number; requested: number };
+      return data as {
+        proposed: number;
+        failed: number;
+        requested: number;
+        // Backend may surface created MdmLockRequest ids — wired here so
+        // when the DELETE endpoint ships, undo becomes a one-line change.
+        requestIds?: string[];
+      };
     },
     onSuccess: (data) => {
-      toast.success(`เสนอล็อค ${data.proposed}/${data.requested} รายการ รออนุมัติ`);
+      // Bulk propose-lock creates N MdmLockRequests; per-request reverse is
+      // currently unavailable (no DELETE endpoint). Show toast with the
+      // PROPOSE_LOCK timing so the UX timing is consistent for QA, but no
+      // reverse handler is wired yet — degrades to a plain toast.
+      showUndo({
+        kind: 'PROPOSE_LOCK',
+        message: `เสนอล็อค ${data.proposed}/${data.requested} รายการ รออนุมัติ`,
+        // reverse + mdmRequestId intentionally omitted until DELETE endpoint exists.
+      });
       clearSelection();
       invalidate();
     },

--- a/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useCollectionsQueue.ts
@@ -59,6 +59,7 @@ export function useCollectionsQueue(params: {
         if (filter.mdmState) q.set('mdmState', filter.mdmState);
         if (filter.showSkipTracing) q.set('showSkipTracing', 'true');
         if (filter.slipReviewPending) q.set('slipReviewPending', 'true');
+        if (filter.sortBy) q.set('sortBy', filter.sortBy);
       }
       const { data } = await api.get(`/overdue/queue?${q}`);
       return data;

--- a/apps/web/src/pages/CollectionsPage/hooks/useContactLog.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useContactLog.ts
@@ -9,6 +9,20 @@ export interface LogContactPayload {
   collectionNotes?: string;
   settlementDate?: string;
   settlementNotes?: string;
+  // P1 Task 12 — quick-tag enums
+  callResult?:
+    | 'ANSWERED'
+    | 'NO_ANSWER'
+    | 'BUSY'
+    | 'DEVICE_OFF'
+    | 'UNREACHABLE';
+  negotiationResult?:
+    | 'REQUESTED_EXTENSION'
+    | 'WILL_PAY'
+    | 'REFUSED'
+    | 'REQUESTED_RETURN'
+    | 'NEGOTIATING'
+    | 'NOT_APPLICABLE';
 }
 
 export function useContactLog() {

--- a/apps/web/src/pages/CollectionsPage/hooks/useContractSnapshot.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useContractSnapshot.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface ContractSnapshot {
+  contractId: string;
+  contractNumber: string;
+  status: string;
+  customer: {
+    id: string;
+    name: string;
+    phone: string;
+  };
+  product: {
+    name: string;
+  };
+  totals: {
+    totalAmount: number;
+    outstanding: number;
+    installmentsTotal: number;
+    installmentsRemaining: number;
+  };
+  lastPromise: {
+    settlementDate: string;
+    result: string;
+    notes: string | null;
+  } | null;
+  lastLine: {
+    timestamp: string;
+    read: boolean;
+  } | null;
+  lastCollectorComment: {
+    text: string;
+    truncated: boolean;
+    by: string | null;
+    at: string;
+  } | null;
+}
+
+/**
+ * Fetches the lightweight snapshot used by the Customer 360 hover/long-press
+ * preview card. Cache for 30s — the panel only opens after a 500ms intent
+ * gesture so this hits cache nicely on rapid hover-pop-hover patterns.
+ */
+export function useContractSnapshot(contractId: string | null, enabled = true) {
+  return useQuery({
+    queryKey: ['contract-snapshot', contractId],
+    queryFn: async () => {
+      const { data } = await api.get<ContractSnapshot>(
+        `/contracts/${contractId}/snapshot`,
+      );
+      return data;
+    },
+    enabled: !!contractId && enabled,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useFilterPresets.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useFilterPresets.ts
@@ -1,0 +1,72 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api from '@/lib/api';
+import type { QueueFilterState } from './useQueueFilter';
+
+export type FilterPresetScope = 'PRIVATE' | 'SHARED_BRANCH' | 'SHARED_ALL';
+
+export interface FilterPreset {
+  id: string;
+  name: string;
+  ownerUserId: string;
+  scope: FilterPresetScope;
+  branchId: string | null;
+  page: string;
+  filterJson: QueueFilterState;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePresetBody {
+  name: string;
+  scope: FilterPresetScope;
+  page: string;
+  filterJson: QueueFilterState;
+  branchId?: string;
+}
+
+export function useListPresets(page: string) {
+  return useQuery({
+    queryKey: ['filter-presets', page],
+    queryFn: async () => {
+      const { data } = await api.get<FilterPreset[]>('/filter-presets', { params: { page } });
+      return data;
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useCreatePreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: CreatePresetBody) => {
+      const { data } = await api.post<FilterPreset>('/filter-presets', body);
+      return data;
+    },
+    onSuccess: (_, vars) => {
+      qc.invalidateQueries({ queryKey: ['filter-presets', vars.page] });
+      toast.success('บันทึก preset แล้ว');
+    },
+    onError: (err: any) => {
+      const msg = err?.response?.data?.message ?? 'บันทึก preset ล้มเหลว';
+      toast.error(msg);
+    },
+  });
+}
+
+export function useDeletePreset(page: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await api.delete(`/filter-presets/${id}`);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['filter-presets', page] });
+      toast.success('ลบ preset แล้ว');
+    },
+    onError: (err: any) => {
+      const msg = err?.response?.data?.message ?? 'ลบ preset ล้มเหลว';
+      toast.error(msg);
+    },
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useLeaderboard.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useLeaderboard.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface LeaderboardRow {
+  collectorId: string;
+  name: string;
+  assignedCount: number;
+  promiseKeptPercent: number;
+  avgDaysToFirstContact: number;
+  recoveryThisMonth: number;
+}
+
+export function useLeaderboard(enabled = true) {
+  return useQuery<LeaderboardRow[]>({
+    queryKey: ['collections-leaderboard'],
+    queryFn: async () => (await api.get('/overdue/analytics/leaderboard')).data,
+    staleTime: 5 * 60 * 1000,
+    enabled,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useLetterActions.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useLetterActions.ts
@@ -1,9 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { useUndoMutation } from './useUndoMutation';
 
 export function useLetterActions() {
   const qc = useQueryClient();
+  const { showUndo } = useUndoMutation();
 
   const invalidate = () => qc.invalidateQueries({ queryKey: ['letter-queue'] });
 
@@ -57,10 +59,19 @@ export function useLetterActions() {
   const markUndeliverable = useMutation({
     mutationFn: async ({ letterId, reason }: { letterId: string; reason: string }) => {
       const { data } = await api.post(`/overdue/letters/${letterId}/undeliverable`, { reason });
-      return data;
+      return { data, letterId };
     },
     onSuccess: () => {
-      toast.success('บันทึกส่งไม่ถึงแล้ว');
+      // Per Task 8 (collections-ui-p1): MARK_UNDELIVERABLE has a 30s undo
+      // window; reverse = revert letter status back to DISPATCHED. The reverse
+      // endpoint (POST /overdue/letters/:id/revert-undeliverable) is not yet
+      // shipped — wired structurally so undo degrades to a plain success toast
+      // until the endpoint exists. Plug `reverse:` here when ready.
+      showUndo({
+        kind: 'MARK_UNDELIVERABLE',
+        message: 'บันทึกส่งไม่ถึงแล้ว',
+        invalidateKeys: [['letter-queue']],
+      });
       invalidate();
     },
     onError: (err: unknown) => toast.error(getErrorMessage(err)),

--- a/apps/web/src/pages/CollectionsPage/hooks/useQueueFilter.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useQueueFilter.ts
@@ -5,6 +5,14 @@ export type OverdueBucketOption = '1-7' | '8-30' | '31-60' | '61-90' | '90+';
 export type LastContactedOption = 'today' | 'this_week' | 'never' | 'over_7_days';
 export type LineResponseOption = 'responded' | 'ignored' | 'blocked' | 'no_line';
 export type MdmStateOption = 'not_locked' | 'locked' | 'pending';
+export type QueueSortOption =
+  | 'priority'
+  | 'outstanding_desc'
+  | 'outstanding_asc'
+  | 'days_overdue_desc'
+  | 'last_contacted_asc'
+  | 'name_asc'
+  | 'random';
 
 export interface QueueFilterState {
   assigned?: 'self' | 'unassigned' | string;
@@ -22,6 +30,7 @@ export interface QueueFilterState {
   mdmState?: MdmStateOption;
   showSkipTracing?: boolean;
   slipReviewPending?: boolean;
+  sortBy?: QueueSortOption;
 }
 
 /**
@@ -68,6 +77,7 @@ const FILTER_NAMES = [
   'mdmState',
   'showSkipTracing',
   'slipReviewPending',
+  'sortBy',
 ] as const;
 
 function namespacedKeys(prefix: string): Set<string> {
@@ -107,6 +117,7 @@ function serialize(
   if (state.mdmState) out.set(`${prefix}mdmState`, state.mdmState);
   if (state.showSkipTracing) out.set(`${prefix}showSkipTracing`, 'true');
   if (state.slipReviewPending) out.set(`${prefix}slipReviewPending`, 'true');
+  if (state.sortBy) out.set(`${prefix}sortBy`, state.sortBy);
   return out;
 }
 
@@ -150,6 +161,7 @@ export function useQueueFilter(
       mdmState: (params.get(`${prefix}mdmState`) as MdmStateOption | null) ?? undefined,
       showSkipTracing: params.get(`${prefix}showSkipTracing`) === 'true' || undefined,
       slipReviewPending: params.get(`${prefix}slipReviewPending`) === 'true' || undefined,
+      sortBy: (params.get(`${prefix}sortBy`) as QueueSortOption | null) ?? undefined,
     };
   }, [params, prefix]);
 

--- a/apps/web/src/pages/CollectionsPage/hooks/useSnooze.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useSnooze.ts
@@ -1,0 +1,66 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+
+/**
+ * Snooze duration presets — must match `SnoozeDuration` enum in the BE
+ * (apps/api/src/modules/overdue/dto/snooze.dto.ts).
+ *
+ * Wall-clock anchors (`tomorrow_9am`, `next_week`) are computed server-side
+ * in Asia/Bangkok so behaviour is timezone-stable.
+ */
+export type SnoozeDuration =
+  | '1h'
+  | '2h'
+  | 'tomorrow_9am'
+  | 'next_week'
+  | 'custom';
+
+export interface SnoozePayload {
+  duration: SnoozeDuration;
+  /** Required when duration === 'custom'. ISO 8601 in any timezone. */
+  snoozedUntil?: string;
+  reason?: string;
+}
+
+export function useSnoozeContract() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      contractId,
+      payload,
+    }: {
+      contractId: string;
+      payload: SnoozePayload;
+    }) => {
+      const { data } = await api.post(
+        `/overdue/contracts/${contractId}/snooze`,
+        payload,
+      );
+      return data as { id: string; snoozedUntil: string };
+    },
+    onSuccess: () => {
+      toast.success('Snooze สำเร็จ');
+      // Refresh queue so the snoozed card disappears.
+      qc.invalidateQueries({ queryKey: ['overdue-queue'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}
+
+export function useUnsnoozeContract() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (contractId: string) => {
+      const { data } = await api.delete(
+        `/overdue/contracts/${contractId}/snooze`,
+      );
+      return data as { unsnoozed: number };
+    },
+    onSuccess: () => {
+      toast.success('ยกเลิก snooze แล้ว');
+      qc.invalidateQueries({ queryKey: ['overdue-queue'] });
+    },
+    onError: (err: unknown) => toast.error(getErrorMessage(err)),
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useStuckContracts.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useStuckContracts.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface StuckContractRow {
+  contractId: string;
+  contractNumber: string;
+  customerName: string;
+  customerPhone: string | null;
+  branchName: string;
+  assignedToId: string | null;
+  assignedToName: string | null;
+  daysIdle: number;
+  outstanding: number;
+}
+
+export function useStuckContracts(days: number, enabled = true) {
+  return useQuery<StuckContractRow[]>({
+    queryKey: ['collections-stuck-contracts', days],
+    queryFn: async () => (await api.get(`/overdue/analytics/stuck?days=${days}`)).data,
+    staleTime: 5 * 60 * 1000,
+    enabled,
+  });
+}

--- a/apps/web/src/pages/CollectionsPage/hooks/useUndoMutation.test.tsx
+++ b/apps/web/src/pages/CollectionsPage/hooks/useUndoMutation.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+// --- mock sonner (capture toast call args including action.onClick) ----------
+type ToastCall = {
+  message: string;
+  options?: { duration?: number; action?: { label: string; onClick: () => void } };
+};
+const toastCalls: { success: ToastCall[]; error: string[] } = { success: [], error: [] };
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (message: string, options?: ToastCall['options']) => {
+      toastCalls.success.push({ message, options });
+    },
+    error: (message: string) => {
+      toastCalls.error.push(message);
+    },
+  },
+}));
+
+// --- mock api -----------------------------------------------------------------
+const apiGet = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+  getErrorMessage: (err: unknown) => (err instanceof Error ? err.message : 'error'),
+}));
+
+// IMPORTANT: import after mocks so the hook picks up the mocked modules.
+import { useUndoMutation } from './useUndoMutation';
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { qc, wrapper };
+}
+
+describe('useUndoMutation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    toastCalls.success.length = 0;
+    toastCalls.error.length = 0;
+    apiGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('reversibility matrix', () => {
+    it('SEND_LINE: shows toast with no action (irreversible)', () => {
+      const { wrapper } = makeWrapper();
+      const reverse = vi.fn();
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'SEND_LINE',
+          message: 'ส่ง LINE 5 ราย',
+          reverse,
+        });
+      });
+      expect(toastCalls.success).toHaveLength(1);
+      expect(toastCalls.success[0].message).toBe('ส่ง LINE 5 ราย');
+      // No action should be wired for SEND_LINE.
+      expect(toastCalls.success[0].options?.action).toBeUndefined();
+    });
+
+    it('ASSIGN: shows toast with 30s duration + action button', () => {
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'ASSIGN',
+          message: 'มอบหมายแล้ว',
+          reverse: vi.fn().mockResolvedValue(undefined),
+        });
+      });
+      expect(toastCalls.success[0].options?.duration).toBe(30_000);
+      expect(toastCalls.success[0].options?.action?.label).toBe('เลิกทำ');
+    });
+
+    it('SNOOZE: 30s duration', () => {
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'SNOOZE',
+          message: 'พักไว้แล้ว',
+          reverse: vi.fn().mockResolvedValue(undefined),
+        });
+      });
+      expect(toastCalls.success[0].options?.duration).toBe(30_000);
+    });
+
+    it('MARK_UNDELIVERABLE: 30s duration', () => {
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'MARK_UNDELIVERABLE',
+          message: 'บันทึกส่งไม่ถึง',
+          reverse: vi.fn().mockResolvedValue(undefined),
+        });
+      });
+      expect(toastCalls.success[0].options?.duration).toBe(30_000);
+    });
+
+    it('PROPOSE_LOCK: 10s duration', () => {
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'PROPOSE_LOCK',
+          message: 'เสนอล็อคแล้ว',
+          reverse: vi.fn().mockResolvedValue(undefined),
+          mdmRequestId: 'mdm-1',
+        });
+      });
+      expect(toastCalls.success[0].options?.duration).toBe(10_000);
+    });
+  });
+
+  describe('timeout behaviour', () => {
+    it('does NOT call reverse if timeout elapses without undo click', async () => {
+      const { wrapper } = makeWrapper();
+      const reverse = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'ASSIGN',
+          message: 'ok',
+          reverse,
+        });
+      });
+      // advance well past the 30s window
+      await act(async () => {
+        vi.advanceTimersByTime(31_000);
+      });
+      expect(reverse).not.toHaveBeenCalled();
+    });
+
+    it('cleanup function cancels the pending timeout', () => {
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      let cancel = () => {};
+      act(() => {
+        cancel = result.current.showUndo({
+          kind: 'ASSIGN',
+          message: 'ok',
+          reverse: vi.fn().mockResolvedValue(undefined),
+        });
+      });
+      act(() => {
+        cancel();
+      });
+      // No assertion failure = timer cleared without throwing; sanity check
+      // that subsequent advances don't trigger anything weird.
+      act(() => {
+        vi.advanceTimersByTime(31_000);
+      });
+      expect(toastCalls.error).toHaveLength(0);
+    });
+
+    it('unmount cancels active timers (no pending reverses fire)', () => {
+      const { wrapper } = makeWrapper();
+      const reverse = vi.fn().mockResolvedValue(undefined);
+      const { result, unmount } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({ kind: 'ASSIGN', message: 'ok', reverse });
+      });
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(31_000);
+      });
+      expect(reverse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('undo invocation', () => {
+    it('clicking the action button calls reverse + shows success toast', async () => {
+      const { wrapper } = makeWrapper();
+      const reverse = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({ kind: 'ASSIGN', message: 'มอบหมายแล้ว', reverse });
+      });
+      await act(async () => {
+        toastCalls.success[0].options!.action!.onClick();
+        // flush microtasks
+        await Promise.resolve();
+      });
+      expect(reverse).toHaveBeenCalledTimes(1);
+      // 2 success toasts now: the original + "เลิกทำสำเร็จ"
+      expect(toastCalls.success.map((t) => t.message)).toContain('เลิกทำสำเร็จ');
+    });
+
+    it('reverse error surfaces as error toast (caller does not need try/catch)', async () => {
+      const { wrapper } = makeWrapper();
+      const reverse = vi.fn().mockRejectedValue(new Error('reverse failed'));
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({ kind: 'ASSIGN', message: 'ok', reverse });
+      });
+      await act(async () => {
+        toastCalls.success[0].options!.action!.onClick();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(toastCalls.error).toContain('reverse failed');
+    });
+  });
+
+  describe('PROPOSE_LOCK live-check', () => {
+    it('blocks reverse when MdmLockRequest status is no longer PENDING', async () => {
+      const { wrapper } = makeWrapper();
+      apiGet.mockResolvedValue({ data: { status: 'APPROVED' } });
+      const reverse = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'PROPOSE_LOCK',
+          message: 'เสนอล็อคแล้ว',
+          reverse,
+          mdmRequestId: 'mdm-42',
+        });
+      });
+      await act(async () => {
+        toastCalls.success[0].options!.action!.onClick();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(apiGet).toHaveBeenCalledWith('/overdue/mdm-requests/mdm-42');
+      // reverse must NOT be invoked
+      expect(reverse).not.toHaveBeenCalled();
+      // user-friendly error toast surfaced
+      expect(toastCalls.error.some((m) => m.includes('ไม่สามารถยกเลิกได้แล้ว'))).toBe(true);
+    });
+
+    it('proceeds with reverse when MdmLockRequest status is still PENDING', async () => {
+      const { wrapper } = makeWrapper();
+      apiGet.mockResolvedValue({ data: { status: 'PENDING' } });
+      const reverse = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'PROPOSE_LOCK',
+          message: 'เสนอล็อคแล้ว',
+          reverse,
+          mdmRequestId: 'mdm-7',
+        });
+      });
+      await act(async () => {
+        toastCalls.success[0].options!.action!.onClick();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(apiGet).toHaveBeenCalledWith('/overdue/mdm-requests/mdm-7');
+      expect(reverse).toHaveBeenCalledTimes(1);
+    });
+
+    it('PROPOSE_LOCK without mdmRequestId surfaces error and skips reverse', async () => {
+      const { wrapper } = makeWrapper();
+      const reverse = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => useUndoMutation(), { wrapper });
+      act(() => {
+        result.current.showUndo({
+          kind: 'PROPOSE_LOCK',
+          message: 'เสนอล็อคแล้ว',
+          reverse,
+          // no mdmRequestId
+        });
+      });
+      await act(async () => {
+        toastCalls.success[0].options!.action!.onClick();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(reverse).not.toHaveBeenCalled();
+      expect(toastCalls.error.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/web/src/pages/CollectionsPage/hooks/useUndoMutation.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useUndoMutation.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
+import api, { getErrorMessage } from '@/lib/api';
+
+/**
+ * useUndoMutation — Sonner toast wrapper with action button + per-action timeout
+ *
+ * Reversibility matrix (decision Q3 from collections-ui-p1 spec):
+ *
+ *   action            | timeout | undo behaviour
+ *   ------------------+---------+---------------------------------------------
+ *   ASSIGN            |   30s   | reassign back to previous assignee
+ *   SNOOZE            |   30s   | clear snooze (delete ContractSnooze row)
+ *   MARK_UNDELIVERABLE|   30s   | revert letter status to DISPATCHED
+ *   PROPOSE_LOCK      |   10s   | DELETE MdmLockRequest IFF status still PENDING
+ *                     |         | (live GET /overdue/mdm-requests/:id check)
+ *   SEND_LINE         |  none   | irreversible — toast shows recipient count only
+ *
+ * Live-check semantics (PROPOSE_LOCK):
+ *   When the user clicks "เลิกทำ" we issue GET /overdue/mdm-requests/:id and
+ *   inspect `status`. If anything other than PENDING (e.g. APPROVED, REJECTED)
+ *   we abort the reverse, surface a Thai-language error toast, and skip the
+ *   reverse mutation entirely.
+ */
+
+export type UndoActionKind =
+  | 'ASSIGN'
+  | 'SNOOZE'
+  | 'MARK_UNDELIVERABLE'
+  | 'PROPOSE_LOCK'
+  | 'SEND_LINE';
+
+const TIMEOUTS_MS: Record<UndoActionKind, number> = {
+  ASSIGN: 30_000,
+  SNOOZE: 30_000,
+  MARK_UNDELIVERABLE: 30_000,
+  PROPOSE_LOCK: 10_000,
+  SEND_LINE: 0,
+};
+
+export interface UndoOptions {
+  /** Action kind — drives timeout + (for PROPOSE_LOCK) live-check semantics. */
+  kind: UndoActionKind;
+  /** Toast message shown immediately after the primary mutation succeeds. */
+  message: string;
+  /**
+   * Async reverser. Called when the user clicks "เลิกทำ" within the timeout.
+   * Throw to surface an error toast — caller does NOT need to wrap in try/catch.
+   */
+  reverse?: () => Promise<unknown>;
+  /**
+   * Required for PROPOSE_LOCK: the MdmLockRequest id we will live-check
+   * before invoking `reverse`. If status !== PENDING the reverse is blocked.
+   */
+  mdmRequestId?: string;
+  /** React Query keys to invalidate after a successful reverse. */
+  invalidateKeys?: ReadonlyArray<readonly unknown[]>;
+}
+
+export interface UndoMutationApi {
+  /**
+   * Show the undo toast. Returns a cleanup that cancels the pending timeout
+   * (mostly useful for tests; in production the toast manages its own lifecycle).
+   */
+  showUndo: (options: UndoOptions) => () => void;
+}
+
+/**
+ * Hook returning a stable `showUndo(options)` function. Designed to be called
+ * from the `onSuccess` of a useMutation after the primary write succeeds.
+ *
+ * NOTE: this hook does not own the *primary* mutation — callers keep their
+ * existing useMutation. It only wraps the toast + undo lifecycle.
+ */
+export function useUndoMutation(): UndoMutationApi {
+  const queryClient = useQueryClient();
+  // Track active timers so unmount cancels them — prevents stale undo prompts
+  // running reverses against torn-down state.
+  const timersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((t) => clearTimeout(t));
+      timers.clear();
+    };
+  }, []);
+
+  const showUndo = useCallback(
+    (options: UndoOptions): (() => void) => {
+      const { kind, message, reverse, mdmRequestId, invalidateKeys } = options;
+      const timeoutMs = TIMEOUTS_MS[kind];
+
+      // SEND_LINE has no undo — surface info toast only and bail out.
+      if (kind === 'SEND_LINE' || !reverse || timeoutMs === 0) {
+        toast.success(message);
+        return () => {};
+      }
+
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      let cancelled = false;
+
+      const runReverse = async () => {
+        if (cancelled) return;
+        cancelled = true;
+        if (timer) {
+          clearTimeout(timer);
+          timersRef.current.delete(timer);
+          timer = null;
+        }
+
+        try {
+          // PROPOSE_LOCK live-check: confirm request is still PENDING before reverse.
+          if (kind === 'PROPOSE_LOCK') {
+            if (!mdmRequestId) {
+              throw new Error('mdmRequestId จำเป็นสำหรับการยกเลิก propose-lock');
+            }
+            const { data } = await api.get(`/overdue/mdm-requests/${mdmRequestId}`);
+            if (!data || data.status !== 'PENDING') {
+              toast.error('ไม่สามารถยกเลิกได้แล้ว — คำขอถูกอนุมัติหรือปฏิเสธไปแล้ว');
+              return;
+            }
+          }
+
+          await reverse();
+          toast.success('เลิกทำสำเร็จ');
+          invalidateKeys?.forEach((key) => {
+            queryClient.invalidateQueries({ queryKey: key as readonly unknown[] });
+          });
+        } catch (err) {
+          toast.error(getErrorMessage(err));
+        }
+      };
+
+      toast.success(message, {
+        duration: timeoutMs,
+        action: {
+          label: 'เลิกทำ',
+          onClick: () => {
+            void runReverse();
+          },
+        },
+      });
+
+      timer = setTimeout(() => {
+        // Timeout elapsed without undo — drop the timer reference.
+        if (timer) {
+          timersRef.current.delete(timer);
+          timer = null;
+        }
+        cancelled = true;
+      }, timeoutMs);
+      timersRef.current.add(timer);
+
+      return () => {
+        if (timer) {
+          clearTimeout(timer);
+          timersRef.current.delete(timer);
+          timer = null;
+        }
+        cancelled = true;
+      };
+    },
+    [queryClient],
+  );
+
+  return { showUndo };
+}

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -96,6 +96,7 @@ export default function CollectionsPage() {
           onLogContact={openContactDialog}
           onOpen360={openPanel}
           onSendLine={setLineDialogContract}
+          onSwitchTab={(tab) => setActiveTab(tab as CollectionsTabKey)}
         />
       )}
 

--- a/apps/web/src/pages/CollectionsPage/index.tsx
+++ b/apps/web/src/pages/CollectionsPage/index.tsx
@@ -7,6 +7,7 @@ import CollectionsTabs from './components/CollectionsTabs';
 import CollectionsFilters from './components/CollectionsFilters';
 import ContactLogDialog from './components/ContactLogDialog';
 import Customer360Panel from './components/Customer360Panel';
+import MigrationBanner from './components/MigrationBanner';
 import SendLineAdHocDialog from './components/SendLineAdHocDialog';
 import QueueTab from './tabs/QueueTab';
 import FollowUpTab from './tabs/FollowUpTab';
@@ -65,6 +66,8 @@ export default function CollectionsPage() {
   return (
     <div>
       <PageHeader title="ติดตามหนี้" subtitle="คิวงานของผู้ติดตามหนี้รายวัน" />
+
+      <MigrationBanner />
 
       <CollectionsKpiStrip />
 

--- a/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
@@ -17,6 +17,9 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { DateRangePicker, type DateRangeValue } from '@/components/ui/DateRangePicker';
 import { useCollectionsAnalytics } from '../hooks/useCollectionsAnalytics';
 import AgingBucketChart from '../components/AgingBucketChart';
+import LeaderboardTable from '../components/LeaderboardTable';
+import StuckContractsSection from '../components/StuckContractsSection';
+import { useAuth } from '@/contexts/AuthContext';
 
 // Chart colors: pragmatic hex approximations of the theme palette.
 // recharts requires explicit color values; these match emerald/red/amber tokens.
@@ -66,6 +69,8 @@ function defaultRange(): DateRangeValue {
 }
 
 export default function AnalyticsTab() {
+  const { user } = useAuth();
+  const isOwner = user?.role === 'OWNER';
   const [dateRange, setDateRange] = useState<DateRangeValue>(defaultRange);
   const range = useMemo(() => mapRangeToEnum(dateRange), [dateRange]);
   const { data, isLoading, isError, error, refetch } = useCollectionsAnalytics(range);
@@ -88,6 +93,10 @@ export default function AnalyticsTab() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
             {/* Aging buckets — span full width above 5 trend cards */}
             <AgingBucketChart />
+
+            {/* OWNER-only sections */}
+            {isOwner && <LeaderboardTable />}
+            {isOwner && <StuckContractsSection />}
             {/* Card 1 — weekly collection rate */}
             <Card>
               <CardContent className="p-5">

--- a/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/AnalyticsTab.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import QueryBoundary from '@/components/QueryBoundary';
 import { DateRangePicker, type DateRangeValue } from '@/components/ui/DateRangePicker';
 import { useCollectionsAnalytics } from '../hooks/useCollectionsAnalytics';
+import AgingBucketChart from '../components/AgingBucketChart';
 
 // Chart colors: pragmatic hex approximations of the theme palette.
 // recharts requires explicit color values; these match emerald/red/amber tokens.
@@ -85,6 +86,8 @@ export default function AnalyticsTab() {
       >
         {data && (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+            {/* Aging buckets — span full width above 5 trend cards */}
+            <AgingBucketChart />
             {/* Card 1 — weekly collection rate */}
             <Card>
               <CardContent className="p-5">

--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -7,6 +7,7 @@ import BulkActionBar from '../components/BulkActionBar';
 import TruncatedBanner from '../components/TruncatedBanner';
 import FilterChipsBar from '../components/FilterChipsBar';
 import FilterDrawer from '../components/FilterDrawer';
+import BrokenPromiseBanner from '../components/BrokenPromiseBanner';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useQueueFilter } from '../hooks/useQueueFilter';
@@ -141,6 +142,7 @@ export default function PromiseTab({ search, branchId, onLogContact, onOpen360, 
         resultCount={rows.length}
         totalCount={total}
       />
+      <BrokenPromiseBanner />
       {truncated && <TruncatedBanner onOpenFilter={openFilter} />}
       {isEmpty ? (
         <div className="rounded-xl border border-dashed border-border p-10 text-center">

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -10,9 +10,11 @@ import TruncatedBanner from '../components/TruncatedBanner';
 import FilterChipsBar from '../components/FilterChipsBar';
 import FilterDrawer from '../components/FilterDrawer';
 import KeyboardShortcutsOverlay from '../components/KeyboardShortcutsOverlay';
+import SnoozeDialog from '../components/SnoozeDialog';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useQueueFilter } from '../hooks/useQueueFilter';
+import { useUnsnoozeContract } from '../hooks/useSnooze';
 import type { ContractRow } from '../types';
 
 const LIMIT = 50;
@@ -59,6 +61,8 @@ export default function QueueTab({
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
   const [filter, setFilter, resetFilter] = useQueueFilter('queue');
+  const [snoozeTarget, setSnoozeTarget] = useState<ContractRow | null>(null);
+  const unsnooze = useUnsnoozeContract();
 
   const q = useCollectionsQueue({
     tab: 'today',

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -101,7 +101,7 @@ export default function QueueTab({
     onCallFocused: () => focusedRow && onLogContact(focusedRow),
     // Payment / snooze / assign actions are wired in their own follow-up tasks.
     onPaymentFocused: () => focusedRow && onOpen360?.(focusedRow),
-    onSnoozeFocused: () => focusedRow && onOpen360?.(focusedRow),
+    onSnoozeFocused: () => focusedRow && setSnoozeTarget(focusedRow),
     onAssignFocused: () => focusedRow && onOpen360?.(focusedRow),
   });
 
@@ -163,6 +163,8 @@ export default function QueueTab({
                   setPreviewState({ contractId: c.id, anchor, variant });
                 }}
                 onPreviewCancel={() => setPreviewState(null)}
+                onSnooze={(c) => setSnoozeTarget(c)}
+                onUnsnooze={(c) => unsnooze.mutate(c.id)}
               />
             ))}
           </div>
@@ -222,6 +224,19 @@ export default function QueueTab({
           setPage(1);
         }}
         liveCount={total}
+      />
+      <SnoozeDialog
+        open={!!snoozeTarget}
+        onClose={() => setSnoozeTarget(null)}
+        contract={
+          snoozeTarget
+            ? {
+                id: snoozeTarget.id,
+                contractNumber: snoozeTarget.contractNumber,
+                customer: { name: snoozeTarget.customer.name },
+              }
+            : null
+        }
       />
     </QueryBoundary>
   );

--- a/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/QueueTab.tsx
@@ -1,12 +1,15 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PartyPopper } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
+import { useCollectionsKeyboard } from '@/hooks/useCollectionsKeyboard';
 import QueryBoundary from '@/components/QueryBoundary';
-import ContractCard from '../components/ContractCard';
+import ContractCard, { type PreviewAnchor } from '../components/ContractCard';
+import Customer360SnapshotCard from '../components/Customer360SnapshotCard';
 import BulkActionBar from '../components/BulkActionBar';
 import TruncatedBanner from '../components/TruncatedBanner';
 import FilterChipsBar from '../components/FilterChipsBar';
 import FilterDrawer from '../components/FilterDrawer';
+import KeyboardShortcutsOverlay from '../components/KeyboardShortcutsOverlay';
 import { useCollectionsQueue } from '../hooks/useCollectionsQueue';
 import { useBulkSelection } from '../hooks/useBulkSelection';
 import { useQueueFilter } from '../hooks/useQueueFilter';
@@ -34,11 +37,25 @@ interface Props {
   onLogContact: (c: ContractRow) => void;
   onOpen360?: (c: ContractRow) => void;
   onSendLine?: (c: ContractRow) => void;
+  onSwitchTab?: (tab: 'today' | 'followup' | 'promise' | 'approval' | 'analytics' | 'all') => void;
 }
 
-export default function QueueTab({ search, branchId, onLogContact, onOpen360, onSendLine }: Props) {
+export default function QueueTab({
+  search,
+  branchId,
+  onLogContact,
+  onOpen360,
+  onSendLine,
+  onSwitchTab,
+}: Props) {
   const [page, setPage] = useState(1);
   const [filterOpen, setFilterOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const [previewState, setPreviewState] = useState<{
+    contractId: string;
+    anchor: PreviewAnchor;
+    variant: 'floating' | 'sheet';
+  } | null>(null);
   const sel = useBulkSelection();
   const debouncedSearch = useDebounce(search, 300);
   const [filter, setFilter, resetFilter] = useQueueFilter('queue');
@@ -56,6 +73,33 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
   const total = q.data?.total ?? 0;
   const rows = q.data?.data ?? [];
   const truncated = q.data?.truncated ?? false;
+
+  // Keep focus index within bounds when rows change.
+  useEffect(() => {
+    if (focusedIndex >= rows.length) setFocusedIndex(0);
+  }, [rows.length, focusedIndex]);
+
+  const focusedRow = rows[focusedIndex];
+
+  const { helpOpen, setHelpOpen, waitingForGSecond } = useCollectionsKeyboard({
+    onSwitchTab,
+    onMoveFocus: (dir) => {
+      if (rows.length === 0) return;
+      setFocusedIndex((i) => {
+        const next = i + dir;
+        if (next < 0) return 0;
+        if (next >= rows.length) return rows.length - 1;
+        return next;
+      });
+    },
+    onOpenFocused: () => focusedRow && onOpen360?.(focusedRow),
+    onLineFocused: () => focusedRow && onSendLine?.(focusedRow),
+    onCallFocused: () => focusedRow && onLogContact(focusedRow),
+    // Payment / snooze / assign actions are wired in their own follow-up tasks.
+    onPaymentFocused: () => focusedRow && onOpen360?.(focusedRow),
+    onSnoozeFocused: () => focusedRow && onOpen360?.(focusedRow),
+    onAssignFocused: () => focusedRow && onOpen360?.(focusedRow),
+  });
 
   const openFilter = () => setFilterOpen(true);
 
@@ -95,7 +139,7 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
       ) : (
         <>
           <div className="space-y-2">
-            {rows.map((row) => (
+            {rows.map((row, idx) => (
               <ContractCard
                 key={row.id}
                 contract={row}
@@ -104,6 +148,17 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
                 onSendLine={onSendLine}
                 selected={sel.isSelected(row.id)}
                 onToggleSelect={sel.toggle}
+                focused={idx === focusedIndex}
+                onPreview={(c, anchor) => {
+                  // Detect coarse pointer (touch) → bottom sheet, else floating
+                  const variant: 'floating' | 'sheet' =
+                    typeof window !== 'undefined' &&
+                    window.matchMedia?.('(pointer: coarse)').matches
+                      ? 'sheet'
+                      : 'floating';
+                  setPreviewState({ contractId: c.id, anchor, variant });
+                }}
+                onPreviewCancel={() => setPreviewState(null)}
               />
             ))}
           </div>
@@ -134,6 +189,22 @@ export default function QueueTab({ search, branchId, onLogContact, onOpen360, on
         </>
       )}
       <BulkActionBar selectedIds={sel.selectedIds} onClear={sel.clear} />
+      {waitingForGSecond && (
+        <div
+          className="fixed bottom-4 right-4 z-50 rounded-md border border-border bg-card px-3 py-1.5 text-xs font-mono shadow-lg"
+          aria-live="polite"
+        >
+          G-
+        </div>
+      )}
+      <KeyboardShortcutsOverlay open={helpOpen} onOpenChange={setHelpOpen} />
+      <Customer360SnapshotCard
+        open={!!previewState}
+        contractId={previewState?.contractId ?? null}
+        anchor={previewState?.anchor ?? null}
+        variant={previewState?.variant ?? 'floating'}
+        onClose={() => setPreviewState(null)}
+      />
       <FilterDrawer
         open={filterOpen}
         onOpenChange={setFilterOpen}

--- a/apps/web/src/pages/CollectionsPage/types.ts
+++ b/apps/web/src/pages/CollectionsPage/types.ts
@@ -52,6 +52,19 @@ export interface ContractRow {
   lastChannel: 'LINE' | 'SMS' | 'CALL' | 'LETTER' | null;
   letterCount: number;
   slipReviewPending: boolean;
+  /**
+   * ISO timestamp when the current user's snooze on this card expires.
+   * Null when no active snooze (the row would be hidden from the queue
+   * anyway except for OWNER, who sees everyone's parked work).
+   */
+  snoozedUntil?: string | null;
+  /**
+   * 7-day daysOverdue trend vs the same contract one week ago.
+   *  - 'UP'   getting worse  (delta > 0)
+   *  - 'DOWN' improving      (delta < 0)
+   *  - null   no historical snapshot to compare with, OR delta === 0
+   */
+  trendingArrow?: 'UP' | 'DOWN' | null;
 }
 
 export type CallResult =

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
+        "react-hotkeys-hook": "^5.2.4",
         "react-qr-code": "^2.0.18",
         "react-resizable-panels": "^4.10.0",
         "react-router": "^7.14.0",
@@ -43193,6 +43194,16 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.2.4.tgz",
+      "integrity": "sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
## Summary
14 P1 features + /overdue redirect จาก `docs/superpowers/specs/2026-04-25-collections-ui-enhancements-design.md`.

### Features (16 commits + 2 setup)
- **Setup** schema: ContractSnooze, ContractDailySnapshot, FilterPreset, CallLog enums + daily snapshot cron
- **A3** Saved Filter Presets (CRUD + 4 system presets, scope PRIVATE/SHARED_BRANCH/SHARED_ALL)
- **A4** Sort dropdown (7 options + Mulberry32 random)
- **A5** Customer 360 Timeline filter (event types + date range)
- **B1+** Trending arrow (7-day delta from snapshots)
- **B2** Snooze (per-user, OWNER bypass)
- **B3** Undo snackbar (per-action timeout + live MdmRequest check)
- **B6** Keyboard shortcuts (G-prefix combos + J/K nav + react-hotkeys-hook)
- **C1** Customer 360 snapshot preview (hover/long-press 500ms)
- **C2** Call Result quick-tag chips
- **D3** Letter PDF preview popup (iframe + zoom)
- **D5** Broken-promise auto-suggest cron + PromiseTab banner
- **E1** Aging bucket chart + deep-link to QueueTab
- **E2** Collector leaderboard (OWNER, CSV export)
- **E4** Stuck contracts widget (bulk reassign)
- **F** /overdue → /collections redirect + 14-day MigrationBanner

## Tests
- API: snooze 26, queue.service 49, filter-presets 11, contracts 179 (incl. 7 snapshot), broken-promise 8, analytics 20
- Web: useUndoMutation 13, useCollectionsKeyboard 6, MigrationBanner 4, ContractCard 11, CallResultChips 6
- Type check: API+Web OK
- Security focused review: PASS (FilterPreset roles, snooze per-user, leaderboard/stuck OWNER gate, trending arrow null-safe, undo live-check)

## Known issues (non-blocking)
- Commit \`db33c29d\` mislabeled (recharts typing fix) — content includes T11/T14/T15 due to parallel-agent race. Functional correctness verified.
- Commit \`2a1a6806\` mislabeled — content is T4 sort dropdown.
- OverduePage.tsx not deleted yet (AllTab still embeds — defer to follow-up).

## Test plan
- [ ] Filter preset roles: SALES cannot create SHARED_ALL/SHARED_BRANCH; OWNER can delete any
- [ ] Snooze: snoozed cards hidden from snoozer, visible to OWNER
- [ ] Sort random: stable per-collector-per-day seed
- [ ] Customer 360 snapshot: hover 500ms triggers, long-press on mobile
- [ ] Undo PROPOSE_LOCK: shows error if MDM already approved
- [ ] Keyboard: \`?\` opens help, \`G Q\` switches tabs, \`/\` focuses search
- [ ] /overdue redirect: bookmarks redirect, banner shows 14 days then disappears
- [ ] Trending arrow appears after snapshot data ≥ 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)