### PR TITLE
fix(lint): remove eslint-disable for unregistered react-hooks rule

### DIFF
--- a/apps/web/src/pages/CollectionsPage/hooks/useMediaRecorder.ts
+++ b/apps/web/src/pages/CollectionsPage/hooks/useMediaRecorder.ts
@@ -84,7 +84,6 @@ export function useMediaRecorder(): UseMediaRecorderReturn {
   }, []);
 
   // Final cleanup on unmount only (intentional empty deps)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => () => cleanup(), []);
 
   const stopRecording = useCallback(() => {


### PR DESCRIPTION
## Summary
- ลบ comment \`eslint-disable-next-line react-hooks/exhaustive-deps\` ใน \`useMediaRecorder.ts\` — rule ไม่ได้ register ใน \`apps/web/eslint.config.mjs\` (ไม่มี eslint-plugin-react-hooks) → ESLint v9 flat config โยน hard error → CI lint fail → deploy ค้าง
- Unblock Deploy to GCP workflow ที่ fail ติดกัน 3 commits บน main (P2, P3, company-settings)

## Test plan
- [x] \`npx eslint . --quiet\` ผ่าน 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)