### PR TITLE
fix(customer-intake, contract-docs): UX correctness + cache propagation

### DIFF
--- a/apps/api/src/modules/customers/customer-precheck.service.spec.ts
+++ b/apps/api/src/modules/customers/customer-precheck.service.spec.ts
@@ -50,6 +50,20 @@ describe('CustomerPreCheckService — decideOutcome (pure)', () => {
   it('NEW without AI REVIEW', () => {
     expect(service.decideOutcome('NEW', undefined).decision).toBe('REVIEW');
   });
+  it('NEW without AI + no statement → "ยังไม่มี statement" reason', () => {
+    const result = service.decideOutcome('NEW', undefined, false);
+    expect(result.decision).toBe('REVIEW');
+    expect(result.reasons[0].code).toBe('NEW_NO_DATA');
+    expect(result.reasons[0].message).toContain('ยังไม่มี statement');
+  });
+  it('NEW without AI + has statement → "แนบ statement แล้ว" reason (no contradiction)', () => {
+    const result = service.decideOutcome('NEW', undefined, true);
+    expect(result.decision).toBe('REVIEW');
+    expect(result.reasons[0].code).toBe('NEW_PENDING_REVIEW');
+    expect(result.reasons[0].message).toContain('แนบ statement แล้ว');
+    // Must NOT claim "no statement" when one was uploaded.
+    expect(result.reasons[0].message).not.toContain('ยังไม่มี statement');
+  });
 });
 
 describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
@@ -207,6 +221,77 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
     expect(findFirstCall.where.checkType).toBe('PRE');
     expect(findFirstCall.where.bankName).toBe('SCB');
     expect(findFirstCall.where.deletedAt).toBeNull();
+  });
+
+  // ─── abandonPreCheck — refuse to delete real customer rows ──────────────
+  it('abandons a placeholder customer with no contracts', async () => {
+    prisma.customer.findFirst.mockResolvedValue({
+      id: 'cust-placeholder',
+      name: 'ลูกค้าใหม่ (Pre-check)',
+      creditCheckStatus: 'UNDER_REVIEW',
+      _count: { contracts: 0 },
+    });
+
+    const result = await service.abandonPreCheck('cust-placeholder');
+
+    expect(result.deleted).toBe(true);
+    expect(prisma.customer.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'cust-placeholder' },
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it('refuses to abandon if name was changed (full intake completed)', async () => {
+    prisma.customer.findFirst.mockResolvedValue({
+      id: 'cust-real',
+      name: 'สมชาย ใจดี',
+      creditCheckStatus: 'UNDER_REVIEW',
+      _count: { contracts: 0 },
+    });
+
+    const result = await service.abandonPreCheck('cust-real');
+
+    expect(result.deleted).toBe(false);
+    expect(prisma.customer.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to abandon if any contracts exist', async () => {
+    prisma.customer.findFirst.mockResolvedValue({
+      id: 'cust-with-contract',
+      name: 'ลูกค้าใหม่ (Pre-check)',
+      creditCheckStatus: 'UNDER_REVIEW',
+      _count: { contracts: 1 },
+    });
+
+    const result = await service.abandonPreCheck('cust-with-contract');
+
+    expect(result.deleted).toBe(false);
+    expect(prisma.customer.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to abandon if creditCheckStatus is no longer UNDER_REVIEW', async () => {
+    prisma.customer.findFirst.mockResolvedValue({
+      id: 'cust-approved',
+      name: 'ลูกค้าใหม่ (Pre-check)',
+      creditCheckStatus: 'APPROVED',
+      _count: { contracts: 0 },
+    });
+
+    const result = await service.abandonPreCheck('cust-approved');
+
+    expect(result.deleted).toBe(false);
+    expect(prisma.customer.update).not.toHaveBeenCalled();
+  });
+
+  it('returns {deleted:false} silently if customer does not exist (already removed)', async () => {
+    prisma.customer.findFirst.mockResolvedValue(null);
+
+    const result = await service.abandonPreCheck('cust-gone');
+
+    expect(result.deleted).toBe(false);
+    expect(prisma.customer.update).not.toHaveBeenCalled();
   });
 
   it('wraps creditCheck create + customer.creditCheckStatus update in one $transaction (no drift on failure)', async () => {

--- a/apps/api/src/modules/customers/customer-precheck.service.ts
+++ b/apps/api/src/modules/customers/customer-precheck.service.ts
@@ -27,6 +27,7 @@ export class CustomerPreCheckService {
   decideOutcome(
     tier: CustomerTier,
     aiScore: number | undefined,
+    hasStatement = false,
   ): { decision: PreCheckDecision; reasons: { code: string; message: string }[] } {
     const reasons: { code: string; message: string }[] = [];
 
@@ -61,12 +62,22 @@ export class CustomerPreCheckService {
       reasons.push({ code: 'AI_FAIL_OVERRIDE', message: `ประวัติดี แต่ AI ${aiScore} ต่ำเกิน` });
       return { decision: 'FAIL', reasons };
     }
-    // NEW
+    // NEW — no scoring engine yet, so the only path that produces a verdict
+    // for new customers is "manager review". Differentiate the message by
+    // whether the user actually attached a statement, so the result step
+    // doesn't lie to a user who just uploaded one.
     if (aiScore === undefined) {
-      reasons.push({
-        code: 'NEW_NO_DATA',
-        message: 'ลูกค้าใหม่ยังไม่มี statement — ต้องตรวจเพิ่ม',
-      });
+      if (hasStatement) {
+        reasons.push({
+          code: 'NEW_PENDING_REVIEW',
+          message: 'แนบ statement แล้ว — รอผู้จัดการพิจารณา',
+        });
+      } else {
+        reasons.push({
+          code: 'NEW_NO_DATA',
+          message: 'ลูกค้าใหม่ยังไม่มี statement — ต้องตรวจเพิ่ม',
+        });
+      }
       return { decision: 'REVIEW', reasons };
     }
     if (aiScore >= PASS_THRESHOLD) {
@@ -146,7 +157,8 @@ export class CustomerPreCheckService {
 
     let creditCheckId: string | undefined;
     const aiScore: number | undefined = undefined;
-    const outcome = this.decideOutcome(tierResp.tier, aiScore);
+    const hasStatement = !!input.statementFiles && input.statementFiles.length > 0;
+    const outcome = this.decideOutcome(tierResp.tier, aiScore, hasStatement);
 
     const nextStatus =
       outcome.decision === 'PASS'
@@ -223,5 +235,49 @@ export class CustomerPreCheckService {
 
     this.cache.set(key, { result, expires: Date.now() + CACHE_TTL_MS });
     return result;
+  }
+
+  /**
+   * Abandon a pre-check session and soft-delete the placeholder customer that
+   * `runPreCheck` created on first contact.
+   *
+   * Safety guards (refuse to delete if any are violated):
+   *   - customer must still be on the placeholder name `ลูกค้าใหม่ (Pre-check)`
+   *     (sentinel proving the user never advanced to FullIntakeStep — the
+   *     full-intake form rewrites `name` from firstName+lastName)
+   *   - must have no contracts (active or historical)
+   *   - must still be in UNDER_REVIEW status
+   *
+   * Any of those failing means the row is real customer data — never delete.
+   */
+  async abandonPreCheck(customerId: string): Promise<{ deleted: boolean }> {
+    const customer = await this.prisma.customer.findFirst({
+      where: { id: customerId, deletedAt: null },
+      select: {
+        id: true,
+        name: true,
+        creditCheckStatus: true,
+        _count: { select: { contracts: true } },
+      },
+    });
+    if (!customer) return { deleted: false };
+
+    const isPlaceholder = customer.name === 'ลูกค้าใหม่ (Pre-check)';
+    const hasNoContracts = customer._count.contracts === 0;
+    const isUnderReview = customer.creditCheckStatus === 'UNDER_REVIEW';
+
+    if (!isPlaceholder || !hasNoContracts || !isUnderReview) {
+      this.logger.warn(
+        `[pre-check] refuse abandon ${customerId}: placeholder=${isPlaceholder} noContracts=${hasNoContracts} underReview=${isUnderReview}`,
+      );
+      return { deleted: false };
+    }
+
+    await this.prisma.customer.update({
+      where: { id: customerId },
+      data: { deletedAt: new Date() },
+    });
+    this.logger.log(`[pre-check] abandoned placeholder customer ${customerId}`);
+    return { deleted: true };
   }
 }

--- a/apps/api/src/modules/customers/customers.controller.ts
+++ b/apps/api/src/modules/customers/customers.controller.ts
@@ -256,6 +256,16 @@ export class CustomersController {
     return this.preCheckService.runPreCheck(body);
   }
 
+  @Post('pre-check/:customerId/abandon')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  @ApiOperation({
+    summary:
+      'Abandon a pre-check session — soft-delete the placeholder customer so a half-finished intake does not leave garbage rows. No-op if the row already has real data.',
+  })
+  abandonPreCheck(@Param('customerId') customerId: string) {
+    return this.preCheckService.abandonPreCheck(customerId);
+  }
+
   @Post()
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
   create(@Body() dto: CreateCustomerDto) {

--- a/apps/web/src/components/contract/CreditCheckPanel.tsx
+++ b/apps/web/src/components/contract/CreditCheckPanel.tsx
@@ -43,6 +43,26 @@ export default function CreditCheckPanel({ contractId }: { contractId: string })
     },
   });
 
+  // The statement file list also feeds the documents-tab "Statement" card via
+  // the DocumentUpload component, which keeps its own queries
+  // (['contract-credit-check-statement'] / ['customer-credit-check-latest-statement'])
+  // and is read by ContractCreatePage as ['customer-latest-credit'].
+  // Invalidate all of them after any credit-check mutation so every consumer
+  // refetches without needing a page refresh. The parent contract row carries
+  // the stepper state (`contractDocuments.length`) so refresh it too.
+  const customerId = creditCheck?.customer.id;
+  const refetchCreditCheckEverywhere = () => {
+    queryClient.invalidateQueries({ queryKey: ['credit-check', contractId] });
+    queryClient.invalidateQueries({ queryKey: ['contract-credit-check-statement', contractId] });
+    queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
+    if (customerId) {
+      queryClient.invalidateQueries({ queryKey: ['customer-latest-credit', customerId] });
+      queryClient.invalidateQueries({
+        queryKey: ['customer-credit-check-latest-statement', customerId],
+      });
+    }
+  };
+
   const uploadMutation = useMutation({
     mutationFn: async (files: FileList) => {
       const fileUrls: string[] = [];
@@ -65,7 +85,7 @@ export default function CreditCheckPanel({ contractId }: { contractId: string })
     },
     onSuccess: () => {
       toast.success('อัปโหลด Statement สำเร็จ');
-      queryClient.invalidateQueries({ queryKey: ['credit-check', contractId] });
+      refetchCreditCheckEverywhere();
       if (fileInputRef.current) fileInputRef.current.value = '';
     },
     onError: (err: unknown) => {
@@ -80,7 +100,7 @@ export default function CreditCheckPanel({ contractId }: { contractId: string })
     },
     onSuccess: () => {
       toast.success('วิเคราะห์เครดิตเสร็จสิ้น');
-      queryClient.invalidateQueries({ queryKey: ['credit-check', contractId] });
+      refetchCreditCheckEverywhere();
     },
     onError: (err: unknown) => {
       toast.error(getErrorMessage(err));
@@ -97,7 +117,7 @@ export default function CreditCheckPanel({ contractId }: { contractId: string })
     },
     onSuccess: () => {
       toast.success('อัปเดตสถานะเครดิตเช็คแล้ว');
-      queryClient.invalidateQueries({ queryKey: ['credit-check', contractId] });
+      refetchCreditCheckEverywhere();
       setOverrideStatus('');
       setOverrideNotes('');
     },

--- a/apps/web/src/components/contract/DocumentUpload.tsx
+++ b/apps/web/src/components/contract/DocumentUpload.tsx
@@ -89,6 +89,17 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
   const customerFiles = customerCreditCheck?.statementFiles ?? [];
   const statementFiles = contractFiles.length > 0 ? contractFiles : customerFiles;
 
+  // ContractDetailPage's stepper reads `contract.contractDocuments.length`
+  // from the ['contract', id] query — invalidating only ['contract-documents']
+  // updates this list but leaves the parent stepper stale until a manual
+  // page refresh. Refresh both keys so the step-2 → step-3 transition lights
+  // up immediately on upload/delete.
+  const refetchDocLists = () => {
+    queryClient.invalidateQueries({ queryKey: ['contract-documents', contractId] });
+    queryClient.invalidateQueries({ queryKey: ['contract', contractId] });
+    queryClient.invalidateQueries({ queryKey: ['contract-doc-checklist', contractId] });
+  };
+
   const uploadMutation = useMutation({
     mutationFn: async ({ file, documentType }: { file: File; documentType: string }) => {
       const reader = new FileReader();
@@ -108,7 +119,7 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
     },
     onSuccess: () => {
       toast.success('อัปโหลดเอกสารสำเร็จ');
-      queryClient.invalidateQueries({ queryKey: ['contract-documents', contractId] });
+      refetchDocLists();
     },
     onError: (err: unknown) => {
       toast.error(getErrorMessage(err));
@@ -124,7 +135,7 @@ export default function DocumentUpload({ contractId, customerId }: { contractId:
     },
     onSuccess: () => {
       toast.success('ลบเอกสารแล้ว');
-      queryClient.invalidateQueries({ queryKey: ['contract-documents', contractId] });
+      refetchDocLists();
     },
     onError: (err: unknown) => {
       toast.error(getErrorMessage(err));

--- a/apps/web/src/components/credit-check/useCreditCheckCreate.ts
+++ b/apps/web/src/components/credit-check/useCreditCheckCreate.ts
@@ -243,10 +243,21 @@ export function useCreditCheckCreate({ open, preselectedCustomer, onSuccess }: U
       });
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (_data, _vars, _ctx) => {
       toast.success('สร้างรายการตรวจเครดิตสำเร็จ');
+      // ContractCreatePage + DocumentUpload's statement card both read the
+      // customer's latest credit check via separate query keys — invalidate
+      // them so a freshly uploaded statement appears without page refresh.
       queryClient.invalidateQueries({ queryKey: ['credit-checks'] });
       queryClient.invalidateQueries({ queryKey: ['customer-credit-checks'] });
+      if (selectedCustomer) {
+        queryClient.invalidateQueries({
+          queryKey: ['customer-latest-credit', selectedCustomer.id],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['customer-credit-check-latest-statement', selectedCustomer.id],
+        });
+      }
       reset();
       onSuccess?.();
     },
@@ -263,13 +274,19 @@ export function useCreditCheckCreate({ open, preselectedCustomer, onSuccess }: U
       });
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (_data, vars) => {
       // New record starts as PENDING; auto-score runs in background. Final
       // APPROVED/REJECTED must go through the override dialog (enforces
       // ≥20-char reason + audit log + role check) — not a one-click action.
       toast.success('บันทึกตรวจเครดิตสำเร็จ — รอผลวิเคราะห์');
       queryClient.invalidateQueries({ queryKey: ['credit-checks'] });
       queryClient.invalidateQueries({ queryKey: ['customer-credit-checks'] });
+      queryClient.invalidateQueries({
+        queryKey: ['customer-latest-credit', vars.customerId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['customer-credit-check-latest-statement', vars.customerId],
+      });
       reset();
       onSuccess?.();
     },

--- a/apps/web/src/pages/CustomerIntakePage/components/PreCheckUploadStep.tsx
+++ b/apps/web/src/pages/CustomerIntakePage/components/PreCheckUploadStep.tsx
@@ -64,7 +64,7 @@ export default function PreCheckUploadStep({ form, onChange, onSubmit, onBack, i
         <div>
           <h3 className="text-sm font-semibold text-foreground">Statement ธนาคาร 3 เดือน *</h3>
           <p className="text-xs text-muted-foreground mt-0.5">
-            จำเป็นสำหรับการวิเคราะห์เครดิตด้วย AI
+            จำเป็นสำหรับการพิจารณาเครดิตของผู้จัดการ
           </p>
         </div>
 
@@ -171,7 +171,7 @@ export default function PreCheckUploadStep({ form, onChange, onSubmit, onBack, i
           {isSubmitting ? (
             <>
               <Loader2 className="size-4 animate-spin" />
-              กำลังวิเคราะห์...
+              กำลังประมวลผล...
             </>
           ) : (
             'เริ่มเช็คเครดิต'

--- a/apps/web/src/pages/CustomerIntakePage/hooks/useCustomerIntake.ts
+++ b/apps/web/src/pages/CustomerIntakePage/hooks/useCustomerIntake.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { getErrorMessage } from '@/lib/api';
+import api, { getErrorMessage } from '@/lib/api';
 import { postPreCheck, type PreCheckResponse } from '@/lib/api/customer-precheck';
 import type { IntakeStep, QuickIntakeForm, WizardState } from '../types';
 
@@ -60,22 +60,36 @@ export function useCustomerIntake() {
       });
     },
     onSuccess: (result) => {
+      // Result is shown by PreCheckResultStep — no toast (it duplicates the banner).
       setState((prev) => ({ ...prev, preCheckResult: result }));
-      if (result.decision === 'PASS') {
-        toast.success('ผ่านการตรวจเครดิตเบื้องต้น');
-      } else if (result.decision === 'FAIL') {
-        toast.error('ไม่ผ่านการตรวจเครดิต');
-      } else {
-        toast.warning('ต้องให้ผู้จัดการตรวจเพิ่ม');
-      }
     },
     onError: (err) => {
       toast.error(getErrorMessage(err));
     },
   });
 
+  // If pre-check just minted a placeholder customer and the user backs out
+  // before filling the full form, ask the API to soft-delete it so the DB
+  // doesn't accumulate "ลูกค้าใหม่ (Pre-check)" rows. Fire-and-forget — the
+  // endpoint is idempotent and refuses to delete anything that has grown
+  // into a real customer (contracts, name changed, etc).
+  const abandonPlaceholder = (result: PreCheckResponse | null) => {
+    if (!result?.isNewCustomer || !result.customerId) return;
+    void api.post(`/customers/pre-check/${result.customerId}/abandon`).catch(() => {});
+  };
+
   const resetPreCheck = useCallback(() => {
-    setState((prev) => ({ ...prev, preCheckResult: null, step: 'quick' }));
+    setState((prev) => {
+      abandonPlaceholder(prev.preCheckResult);
+      return { ...prev, preCheckResult: null, step: 'quick' };
+    });
+  }, []);
+
+  const cancelIntake = useCallback(() => {
+    setState((prev) => {
+      abandonPlaceholder(prev.preCheckResult);
+      return prev;
+    });
   }, []);
 
   const proceedToFull = useCallback(() => {
@@ -117,6 +131,7 @@ export function useCustomerIntake() {
     runPreCheck: () => preCheckMutation.mutate(),
     isPreChecking: preCheckMutation.isPending,
     resetPreCheck,
+    cancelIntake,
     proceedToFull,
     reset,
   };

--- a/apps/web/src/pages/CustomerIntakePage/index.tsx
+++ b/apps/web/src/pages/CustomerIntakePage/index.tsx
@@ -22,7 +22,10 @@ export default function CustomerIntakePage() {
         subtitle="scan บัตร → อัพ statement → เช็คเครดิต → กรอกข้อมูลเต็ม"
         action={
           <button
-            onClick={() => navigate('/customers')}
+            onClick={() => {
+              intake.cancelIntake();
+              navigate('/customers');
+            }}
             className="px-4 py-2 text-sm text-muted-foreground border border-input rounded-lg"
           >
             ยกเลิก


### PR DESCRIPTION
## Summary

Bundle of 4 fixes from a debug session on `/customer-intake` and the contract documents tab.

### Customer intake (`/customer-intake`)
- **AI-scoring fiction removed** — UI no longer claims "วิเคราะห์เครดิตด้วย AI" / "กำลังวิเคราะห์..." since the scorer doesn't exist; statement is supplementary data for the manager
- **Self-contradicting reason fixed** — when a user actually uploads a statement, the result no longer says "ยังไม่มี statement". `decideOutcome` now takes `hasStatement` and emits `NEW_PENDING_REVIEW` ("แนบ statement แล้ว — รอผู้จัดการพิจารณา") in that case
- **Redundant toast removed** — result step already shows the decision banner; no more duplicate "ต้องให้ผู้จัดการตรวจเพิ่ม" toast
- **Garbage customer cleanup** — new `POST /customers/pre-check/:id/abandon` soft-deletes the placeholder row that pre-check mints, but only if the row is still untouched (`name === 'ลูกค้าใหม่ (Pre-check)'`, no contracts, status still `UNDER_REVIEW`). Wired to both the result-step "กลับ" button and the page-header "ยกเลิก"

### Contract documents tab (step 2 → 3 transition)
- `DocumentUpload` mutations now invalidate `['contract', contractId]` so the parent stepper updates immediately on upload — previously needed a page refresh because the stepper reads `contract.contractDocuments.length` from a different query than DocumentUpload's own list

### Contract credit-check statement card
- Same root cause as above but with more keys: `CreditCheckPanel`, `useCreditCheckCreate`, `DocumentUpload`, and `ContractCreatePage` all hit the same endpoints with **different query keys**. Upload mutations now invalidate every consumer's key so the documents-tab statement card refreshes without page refresh

## Test plan
- [x] API typecheck
- [x] Web typecheck
- [x] `customer-precheck.service.spec.ts` — 24 → 31 tests (added 5 abandon guards + 2 hasStatement variants)
- [x] `customers.controller.spec.ts` passes
- [ ] Manual: pre-check NEW customer with statement → reason says "แนบ statement แล้ว"
- [ ] Manual: contract DRAFT → upload doc → step 2 turns ✓ without refresh
- [ ] Manual: contract → ตรวจเครดิต tab → upload statement → documents tab statement card shows files without refresh
- [ ] Manual: pre-check then click "กลับ"/"ยกเลิก" → placeholder customer not visible in `/customers`