### PR TITLE
chore(scripts): add seed/cleanup for collections test data

### DIFF
--- a/scripts/cleanup-collections-test-data.ts
+++ b/scripts/cleanup-collections-test-data.ts
@@ -1,0 +1,162 @@
+/**
+ * Cleanup Collections Test Data — soft-delete ทุก record ที่ marker matched
+ *
+ * ใช้:
+ *   # Dry-run (preview)
+ *   npx tsx scripts/cleanup-collections-test-data.ts
+ *
+ *   # ลบจริง (soft-delete + scramble unique fields เพื่อให้ re-seed ได้)
+ *   npx tsx scripts/cleanup-collections-test-data.ts --commit
+ *
+ * Markers:
+ *   - Customer.legacyMemberCode startsWith `__SEED_2026_04_25__`
+ *   - Contract.notes = `__SEED_2026_04_25__`
+ *
+ * What this does (soft-delete per project rule — `database.md` ห้าม hard delete):
+ *   - Customer/Contract/Payment.deletedAt = now()
+ *   - Customer.legacyMemberCode → null  (free unique constraint for re-seed)
+ *   - Customer.nationalId → `__DELETED_<uuid>` (free @unique constraint)
+ *   - Customer.phone → `__DELETED_<uuid>` (free unique-ish lookup)
+ *
+ * Safety guards:
+ *   - Customer must have name prefix `[TEST] ` (double-check)
+ *   - Customer's contracts must ALL match marker (else skip — likely real data)
+ *   - Refuse if > 25 records match (anti-blast)
+ */
+import { PrismaClient } from '@prisma/client';
+
+const MARKER = '__SEED_2026_04_25__';
+const NAME_PREFIX = '[TEST] ';
+const MAX_DELETE_LIMIT = 25;
+
+const COMMIT = process.argv.includes('--commit');
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log(`\n=== Cleanup Collections Test Data ===`);
+  console.log(`Mode: ${COMMIT ? '🔥 COMMIT (soft-delete)' : '🧪 DRY-RUN'}`);
+  console.log(`Marker: ${MARKER}\n`);
+
+  // 1. Find marker-tagged contracts (active only — already-cleaned ones we leave alone)
+  const contracts = await prisma.contract.findMany({
+    where: { notes: MARKER, deletedAt: null },
+    select: {
+      id: true,
+      contractNumber: true,
+      customerId: true,
+      customer: { select: { id: true, name: true, legacyMemberCode: true } },
+      _count: { select: { payments: { where: { deletedAt: null } } } },
+    },
+  });
+  console.log(`🔎 Found ${contracts.length} active contracts with marker`);
+
+  const safeContracts = contracts.filter(
+    (c) => c.customer.name.startsWith(NAME_PREFIX) && c.customer.legacyMemberCode?.startsWith(MARKER),
+  );
+  if (safeContracts.length !== contracts.length) {
+    console.log(`⚠️  ${contracts.length - safeContracts.length} contracts skipped — customer doesn't match TEST pattern`);
+  }
+  if (safeContracts.length > MAX_DELETE_LIMIT) {
+    console.error(`❌ Too many matches (${safeContracts.length} > ${MAX_DELETE_LIMIT}) — aborting`);
+    process.exit(1);
+  }
+
+  // 2. Find marker-tagged customers (active only)
+  const customers = await prisma.customer.findMany({
+    where: { legacyMemberCode: { startsWith: MARKER }, deletedAt: null },
+    select: {
+      id: true,
+      name: true,
+      contracts: { where: { deletedAt: null }, select: { id: true, notes: true } },
+    },
+  });
+  console.log(`🔎 Found ${customers.length} active customers with marker`);
+
+  const safeCustomers = customers.filter((c) => {
+    if (!c.name.startsWith(NAME_PREFIX)) return false;
+    if (c.contracts.length === 0) return true;
+    return c.contracts.every((ct) => ct.notes === MARKER);
+  });
+  if (safeCustomers.length !== customers.length) {
+    console.log(
+      `⚠️  ${customers.length - safeCustomers.length} customers skipped — name doesn't match TEST or contracts include non-marker rows`,
+    );
+  }
+  if (safeCustomers.length > MAX_DELETE_LIMIT) {
+    console.error(`❌ Too many customer matches (${safeCustomers.length} > ${MAX_DELETE_LIMIT}) — aborting`);
+    process.exit(1);
+  }
+
+  if (safeContracts.length > 0) {
+    console.log(`\n📋 Contracts to soft-delete:`);
+    safeContracts.forEach((c) =>
+      console.log(`  - ${c.contractNumber} (${c.customer.name}) — ${c._count.payments} payments`),
+    );
+  }
+  if (safeCustomers.length > 0) {
+    console.log(`\n👤 Customers to soft-delete:`);
+    safeCustomers.forEach((c) => console.log(`  - ${c.name} [${c.contracts.length} contracts]`));
+  }
+
+  if (safeContracts.length === 0 && safeCustomers.length === 0) {
+    console.log(`\n✋ ไม่มีอะไรต้องลบ`);
+    return;
+  }
+
+  if (!COMMIT) {
+    console.log(`\n✋ Dry-run — เพิ่ม --commit เพื่อ soft-delete จริง\n`);
+    return;
+  }
+
+  console.log(`\n🗑️  Soft-deleting...`);
+  const now = new Date();
+
+  // 3. Soft-delete payments first (so a stale active payment doesn't surface
+  //    in cron/queries after parents are gone). Order doesn't really matter
+  //    for soft-delete but keeps things tidy.
+  let totalPayments = 0;
+  for (const c of safeContracts) {
+    const r = await prisma.payment.updateMany({
+      where: { contractId: c.id, deletedAt: null },
+      data: { deletedAt: now },
+    });
+    totalPayments += r.count;
+  }
+  console.log(`  ${totalPayments} payments soft-deleted`);
+
+  // 4. Soft-delete contracts
+  if (safeContracts.length > 0) {
+    const cr = await prisma.contract.updateMany({
+      where: { id: { in: safeContracts.map((c) => c.id) } },
+      data: { deletedAt: now },
+    });
+    console.log(`  ${cr.count} contracts soft-deleted`);
+  }
+
+  // 5. Soft-delete customers + scramble unique fields so re-seed can reuse markers/NIDs/phones
+  for (const c of safeCustomers) {
+    await prisma.customer.update({
+      where: { id: c.id },
+      data: {
+        deletedAt: now,
+        legacyMemberCode: null,
+        nationalId: `__DELETED_${c.id}`,
+        nationalIdHash: null,
+        nationalIdEncrypted: null,
+        phone: `__DELETED_${c.id}`,
+        phoneHash: null,
+        phoneEncrypted: null,
+      },
+    });
+  }
+  console.log(`  ${safeCustomers.length} customers soft-deleted + unique fields cleared`);
+
+  console.log(`\n✅ Cleanup เสร็จ — re-seed ได้ทันที (idempotency guard ตรวจ deletedAt: null เท่านั้น)\n`);
+}
+
+main()
+  .catch((err) => {
+    console.error('\n❌ Failed:', err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/cleanup-collections-test-data.ts
+++ b/scripts/cleanup-collections-test-data.ts
@@ -32,6 +32,13 @@ const MAX_DELETE_LIMIT = 25;
 const COMMIT = process.argv.includes('--commit');
 const prisma = new PrismaClient();
 
+/** Disconnect Prisma then exit with code 1. Ensures connection is closed on early-exit. */
+async function bail(msg: string): Promise<never> {
+  console.error(msg);
+  await prisma.$disconnect();
+  process.exit(1);
+}
+
 async function main() {
   console.log(`\n=== Cleanup Collections Test Data ===`);
   console.log(`Mode: ${COMMIT ? '🔥 COMMIT (soft-delete)' : '🧪 DRY-RUN'}`);
@@ -57,8 +64,7 @@ async function main() {
     console.log(`⚠️  ${contracts.length - safeContracts.length} contracts skipped — customer doesn't match TEST pattern`);
   }
   if (safeContracts.length > MAX_DELETE_LIMIT) {
-    console.error(`❌ Too many matches (${safeContracts.length} > ${MAX_DELETE_LIMIT}) — aborting`);
-    process.exit(1);
+    await bail(`❌ Too many matches (${safeContracts.length} > ${MAX_DELETE_LIMIT}) — aborting`);
   }
 
   // 2. Find marker-tagged customers (active only)
@@ -83,8 +89,7 @@ async function main() {
     );
   }
   if (safeCustomers.length > MAX_DELETE_LIMIT) {
-    console.error(`❌ Too many customer matches (${safeCustomers.length} > ${MAX_DELETE_LIMIT}) — aborting`);
-    process.exit(1);
+    await bail(`❌ Too many customer matches (${safeCustomers.length} > ${MAX_DELETE_LIMIT}) — aborting`);
   }
 
   if (safeContracts.length > 0) {
@@ -157,6 +162,6 @@ async function main() {
 main()
   .catch((err) => {
     console.error('\n❌ Failed:', err);
-    process.exit(1);
+    process.exitCode = 1; // set exit code without skipping .finally()
   })
   .finally(() => prisma.$disconnect());

--- a/scripts/seed-collections-test-data.ts
+++ b/scripts/seed-collections-test-data.ts
@@ -25,6 +25,8 @@
  *   - ~240 Payments (12 งวด × 20) — กระจายอายุหนี้ 5 buckets
  *
  * ⚠️ One-off — ห้ามรันซ้ำ. มี idempotency guard เช็ค marker ก่อน
+ * ⚠️ ทดสอบ end-to-end ได้บน prod เท่านั้น — dev DB อาจขาด migration บางตัว
+ *    ให้รัน dry-run บน dev เพื่อตรวจ lookups แล้วรัน --commit บน prod
  */
 import { PrismaClient, Prisma, type ContractStatus, type PaymentStatus } from '@prisma/client';
 import { encryptPII } from '../apps/api/src/utils/crypto.util';
@@ -40,6 +42,13 @@ const SALT = process.env.PII_HASH_SALT || '';
 const COMMIT = process.argv.includes('--commit');
 
 const prisma = new PrismaClient();
+
+/** Disconnect Prisma then exit with code 1. Ensures connection is closed on early-exit. */
+async function bail(msg: string): Promise<never> {
+  console.error(msg);
+  await prisma.$disconnect();
+  process.exit(1);
+}
 
 const FAKE_PEOPLE: Array<{ prefix: string; first: string; last: string; nickname: string; salary: number; occupation: string }> = [
   { prefix: 'นาย', first: 'ทดสอบหนึ่ง', last: 'นามสมมติ', nickname: 'หนึ่ง', salary: 18000, occupation: 'พนักงานบริษัท' },
@@ -72,10 +81,10 @@ interface OverdueBucket {
 }
 
 const OVERDUE_BUCKETS: OverdueBucket[] = [
-  { label: 'current', daysOverdue: 0, paidInstallments: 3, contractStatus: 'ACTIVE' },
-  { label: '1-30',    daysOverdue: 15, paidInstallments: 2, contractStatus: 'OVERDUE' },
-  { label: '31-60',   daysOverdue: 45, paidInstallments: 2, contractStatus: 'OVERDUE' },
-  { label: '61-90',   daysOverdue: 75, paidInstallments: 1, contractStatus: 'OVERDUE' },
+  { label: 'current', daysOverdue: 0,   paidInstallments: 3, contractStatus: 'ACTIVE' },
+  { label: '1-30',    daysOverdue: 15,  paidInstallments: 2, contractStatus: 'OVERDUE' },
+  { label: '31-60',   daysOverdue: 45,  paidInstallments: 2, contractStatus: 'OVERDUE' },
+  { label: '61-90',   daysOverdue: 75,  paidInstallments: 1, contractStatus: 'OVERDUE' },
   { label: '90+',     daysOverdue: 120, paidInstallments: 1, contractStatus: 'OVERDUE' },
 ];
 
@@ -84,7 +93,7 @@ const fakePhone = (idx: number) => `${PHONE_PREFIX}${String(idx).padStart(5, '0'
 function generateContractNumber(idx: number): string {
   const now = new Date();
   const yymm = `${String(now.getFullYear() + 543).slice(2)}${String(now.getMonth() + 1).padStart(2, '0')}`;
-  return `BCP-TEST-${yymm}-${String(idx).padStart(5, '0')}`;
+  return `BC-TEST-${yymm}-${String(idx).padStart(5, '0')}`;
 }
 
 async function main() {
@@ -97,8 +106,7 @@ async function main() {
   const hasEncryption = !!KEY && KEY.length >= 32 && !!SALT && SALT.length >= 32;
   if (COMMIT) {
     if (!hasEncryption && (KEY || SALT)) {
-      console.error('❌ PII_ENCRYPTION_KEY และ PII_HASH_SALT ต้องตั้งทั้งคู่ และยาว ≥32 ตัวอักษร');
-      process.exit(1);
+      await bail('❌ PII_ENCRYPTION_KEY และ PII_HASH_SALT ต้องตั้งทั้งคู่ และยาว ≥32 ตัวอักษร');
     }
     if (!hasEncryption) {
       console.log('⚠️  ไม่มี PII keys — จะ seed แบบ dev (ไม่ encrypt) — อย่ารันแบบนี้บน prod');
@@ -114,8 +122,7 @@ async function main() {
         orderBy: { createdAt: 'asc' },
       });
   if (!branch) {
-    console.error('❌ ไม่พบ branch — ระบุ BRANCH_ID หรือเช็คว่ามี non-warehouse branch ใน DB');
-    process.exit(1);
+    await bail('❌ ไม่พบ branch — ระบุ BRANCH_ID หรือเช็คว่ามี non-warehouse branch ใน DB');
   }
   console.log(`📍 Branch: ${branch.id} — ${branch.name}`);
 
@@ -125,19 +132,18 @@ async function main() {
     (await prisma.user.findFirst({ where: { role: 'SALES', deletedAt: null } })) ||
     (await prisma.user.findFirst({ where: { role: 'OWNER' } }));
   if (!salesperson) {
-    console.error('❌ ไม่พบ user สำหรับเป็น salesperson');
-    process.exit(1);
+    await bail('❌ ไม่พบ user สำหรับเป็น salesperson');
   }
   console.log(`👤 Salesperson: ${salesperson.id} — ${salesperson.name} (${salesperson.role})`);
 
-  // 3. Pick existing product (don't create — keep cleanup simple)
-  const product = await prisma.product.findFirst({
-    where: { branchId: branch.id, deletedAt: null },
-    orderBy: { createdAt: 'asc' },
-  }) || await prisma.product.findFirst({ where: { deletedAt: null }, orderBy: { createdAt: 'asc' } });
+  // 3. Pick existing product (don't create — keep cleanup simple).
+  //    Script reuses the same product for all 20 contracts to avoid SKU pollution.
+  //    If this product is later deleted, contracts remain valid (FK is to productId which allows soft-deleted products).
+  const product =
+    (await prisma.product.findFirst({ where: { branchId: branch.id, deletedAt: null }, orderBy: { createdAt: 'asc' } })) ||
+    (await prisma.product.findFirst({ where: { deletedAt: null }, orderBy: { createdAt: 'asc' } }));
   if (!product) {
-    console.error('❌ ไม่พบ Product ใน DB — ต้องมี product อย่างน้อย 1 ตัว');
-    process.exit(1);
+    await bail('❌ ไม่พบ Product ใน DB — ต้องมี product อย่างน้อย 1 ตัว');
   }
   console.log(`📦 Product: ${product.id} — ${product.brand} ${product.model}`);
 
@@ -146,9 +152,10 @@ async function main() {
     where: { legacyMemberCode: { startsWith: MARKER }, deletedAt: null },
   });
   if (existing > 0) {
-    console.error(`\n❌ พบ ${existing} customer ที่มี marker เดียวกันแล้ว — รัน cleanup ก่อน:`);
-    console.error(`   npx tsx scripts/cleanup-collections-test-data.ts --commit`);
-    process.exit(1);
+    await bail(
+      `\n❌ พบ ${existing} customer ที่มี marker เดียวกันแล้ว — รัน cleanup ก่อน:\n` +
+      `   npx tsx scripts/cleanup-collections-test-data.ts --commit`,
+    );
   }
 
   console.log(`\n📋 Plan: 20 customers + 20 contracts + 240 payments (12 งวด × 20 สัญญา)`);
@@ -159,7 +166,8 @@ async function main() {
     return;
   }
 
-  // 5. Create
+  // 5. Create — each customer+contract+payments in a single transaction so a mid-loop
+  //    crash doesn't leave orphan contracts without payments.
   let cIdx = 0;
   for (let bucketIdx = 0; bucketIdx < OVERDUE_BUCKETS.length; bucketIdx++) {
     const bucket = OVERDUE_BUCKETS[bucketIdx];
@@ -170,89 +178,93 @@ async function main() {
       const phone = fakePhone(cIdx);
       const fullName = `${NAME_PREFIX}${person.first} ${person.last}`;
 
-      const customer = await prisma.customer.create({
-        data: {
-          nationalId: nid,
-          nationalIdEncrypted: hasEncryption ? encryptPII(nid, KEY) : null,
-          nationalIdHash: hasEncryption ? hashPII(nid, SALT) : null,
-          phone,
-          phoneEncrypted: hasEncryption ? encryptPII(phone, KEY) : null,
-          phoneHash: hasEncryption ? hashPII(phone, SALT) : null,
-          prefix: person.prefix,
-          name: fullName,
-          nickname: person.nickname,
-          occupation: person.occupation,
-          salary: new Prisma.Decimal(person.salary),
-          creditCheckStatus: 'FULL_CHECK_PASSED',
-          status: 'ACTIVE',
-          legacyMemberCode: `${MARKER}-${cIdx}`, // marker ผ่าน unique field
-        },
-      });
-
-      // Contract — 12-month plan, 8% flat interest
+      // Contract financials — 12-month plan, 8% flat interest
       const sellingPrice = new Prisma.Decimal(15000);
       const downPayment = new Prisma.Decimal(3000);
       const financedAmount = new Prisma.Decimal(12000);
       const interestRate = new Prisma.Decimal('0.0800');
       const totalMonths = 12;
       const interestTotal = financedAmount.mul(interestRate); // 960
-      const totalDue = financedAmount.add(interestTotal); // 12960
+      const totalDue = financedAmount.add(interestTotal);    // 12960
       const monthlyPayment = totalDue.div(totalMonths).toDecimalPlaces(2); // 1080
 
-      // Backdate contract creation to land payments in the right aging bucket
+      // Backdate contract creation so payments land in the right aging bucket.
+      // Uses 30-day months — close enough for test data.
       const monthsBack = bucket.paidInstallments + (bucket.daysOverdue > 0 ? 1 : 0);
       const contractCreatedAt = new Date(Date.now() - (monthsBack * 30 + bucket.daysOverdue) * 86400000);
 
-      const contract = await prisma.contract.create({
-        data: {
-          contractNumber: generateContractNumber(cIdx),
-          customerId: customer.id,
-          productId: product.id,
-          branchId: branch.id,
-          salespersonId: salesperson.id,
-          planType: 'STORE_WITH_INTEREST',
-          sellingPrice,
-          downPayment,
-          interestRate,
-          totalMonths,
-          interestTotal,
-          financedAmount,
-          monthlyPayment,
-          status: bucket.contractStatus,
-          paymentDueDay: 5,
-          workflowStatus: 'APPROVED',
-          createdAt: contractCreatedAt,
-          notes: MARKER,
-        },
-      });
-
-      // Payments — 12 งวด
-      const payments: Prisma.PaymentCreateManyInput[] = [];
-      for (let i = 1; i <= totalMonths; i++) {
-        const dueDate = new Date(contractCreatedAt.getTime() + i * 30 * 86400000);
-        let status: PaymentStatus = 'PENDING';
-        let amountPaid = new Prisma.Decimal(0);
-        let paidAt: Date | null = null;
-
-        if (i <= bucket.paidInstallments) {
-          status = 'PAID';
-          amountPaid = monthlyPayment;
-          paidAt = new Date(dueDate.getTime() - 2 * 86400000);
-        } else if (i === bucket.paidInstallments + 1 && bucket.daysOverdue > 0) {
-          status = 'OVERDUE';
-        }
-
-        payments.push({
-          contractId: contract.id,
-          installmentNo: i,
-          dueDate,
-          amountDue: monthlyPayment,
-          amountPaid,
-          paidAt,
-          status,
+      const { customer, contract } = await prisma.$transaction(async (tx) => {
+        const customer = await tx.customer.create({
+          data: {
+            nationalId: nid,
+            nationalIdEncrypted: hasEncryption ? encryptPII(nid, KEY) : null,
+            nationalIdHash: hasEncryption ? hashPII(nid, SALT) : null,
+            phone,
+            phoneEncrypted: hasEncryption ? encryptPII(phone, KEY) : null,
+            phoneHash: hasEncryption ? hashPII(phone, SALT) : null,
+            prefix: person.prefix,
+            name: fullName,
+            nickname: person.nickname,
+            occupation: person.occupation,
+            salary: new Prisma.Decimal(person.salary),
+            creditCheckStatus: 'FULL_CHECK_PASSED',
+            status: 'ACTIVE',
+            legacyMemberCode: `${MARKER}-${cIdx}`, // marker ผ่าน unique field
+          },
         });
-      }
-      await prisma.payment.createMany({ data: payments });
+
+        const contract = await tx.contract.create({
+          data: {
+            contractNumber: generateContractNumber(cIdx),
+            customerId: customer.id,
+            productId: product.id,
+            branchId: branch.id,
+            salespersonId: salesperson.id,
+            planType: 'STORE_WITH_INTEREST',
+            sellingPrice,
+            downPayment,
+            interestRate,
+            totalMonths,
+            interestTotal,
+            financedAmount,
+            monthlyPayment,
+            status: bucket.contractStatus,
+            paymentDueDay: 5,
+            workflowStatus: 'APPROVED',
+            createdAt: contractCreatedAt,
+            notes: MARKER,
+          },
+        });
+
+        const payments: Prisma.PaymentCreateManyInput[] = [];
+        for (let i = 1; i <= totalMonths; i++) {
+          const dueDate = new Date(contractCreatedAt.getTime() + i * 30 * 86400000);
+          let status: PaymentStatus = 'PENDING';
+          let amountPaid = new Prisma.Decimal(0);
+          let paidAt: Date | null = null;
+
+          if (i <= bucket.paidInstallments) {
+            status = 'PAID';
+            amountPaid = monthlyPayment;
+            paidAt = new Date(dueDate.getTime() - 2 * 86400000);
+          } else if (i === bucket.paidInstallments + 1 && bucket.daysOverdue > 0) {
+            status = 'OVERDUE';
+          }
+
+          payments.push({
+            contractId: contract.id,
+            installmentNo: i,
+            dueDate,
+            amountDue: monthlyPayment,
+            amountPaid,
+            paidAt,
+            status,
+          });
+        }
+        await tx.payment.createMany({ data: payments });
+
+        return { customer, contract };
+      });
 
       console.log(
         `  [${bucket.label.padEnd(7)}] ${customer.id.slice(0, 8)}.. ${fullName.padEnd(40)} ${contract.contractNumber} → ${bucket.paidInstallments}/${totalMonths} paid${bucket.daysOverdue > 0 ? `, ${bucket.daysOverdue}d overdue` : ''}`,
@@ -268,6 +280,6 @@ async function main() {
 main()
   .catch((err) => {
     console.error('\n❌ Failed:', err);
-    process.exit(1);
+    process.exitCode = 1; // set exit code without skipping .finally()
   })
   .finally(() => prisma.$disconnect());

--- a/scripts/seed-collections-test-data.ts
+++ b/scripts/seed-collections-test-data.ts
@@ -1,0 +1,273 @@
+/**
+ * Seed Collections Test Data — สร้างลูกค้าทดสอบ + สัญญา + การชำระเงิน
+ * เพื่อทดสอบหน้า /collections บน production
+ *
+ * ใช้:
+ *   # Dry-run (แสดงสิ่งที่จะสร้าง ไม่บันทึก DB)
+ *   npx tsx scripts/seed-collections-test-data.ts
+ *
+ *   # Commit จริง (เขียน DB)
+ *   npx tsx scripts/seed-collections-test-data.ts --commit
+ *
+ *   # ระบุ branch (default: branch แรกที่ไม่ใช่ warehouse)
+ *   BRANCH_ID=<id> npx tsx scripts/seed-collections-test-data.ts --commit
+ *
+ * ต้องมี env: DATABASE_URL, PII_ENCRYPTION_KEY (32+ chars), PII_HASH_SALT (32+ chars)
+ *
+ * Markers (สำหรับ cleanup):
+ *   - Customer.legacyMemberCode = `__SEED_2026_04_25__-N` (N = 1..20)
+ *   - Contract.notes = `__SEED_2026_04_25__`
+ *   ใช้ scripts/cleanup-collections-test-data.ts ลบทิ้ง
+ *
+ * จะสร้าง:
+ *   - 20 Test Customers (name prefix "[TEST] ", phone "099-99-XXXXX", NID "9999XXXXXXXXX")
+ *   - 20 Contracts ACTIVE/OVERDUE (1 ต่อ 1 customer) — ใช้ existing product (ไม่สร้างใหม่)
+ *   - ~240 Payments (12 งวด × 20) — กระจายอายุหนี้ 5 buckets
+ *
+ * ⚠️ One-off — ห้ามรันซ้ำ. มี idempotency guard เช็ค marker ก่อน
+ */
+import { PrismaClient, Prisma, type ContractStatus, type PaymentStatus } from '@prisma/client';
+import { encryptPII } from '../apps/api/src/utils/crypto.util';
+import { hashPII } from '../apps/api/src/utils/pii.util';
+
+const MARKER = '__SEED_2026_04_25__';
+const NAME_PREFIX = '[TEST] ';
+const NID_PREFIX = '9999'; // Real Thai NIDs start with 1-8
+const PHONE_PREFIX = '09999'; // 099-99-XXXXX is rare/unused
+
+const KEY = process.env.PII_ENCRYPTION_KEY || '';
+const SALT = process.env.PII_HASH_SALT || '';
+const COMMIT = process.argv.includes('--commit');
+
+const prisma = new PrismaClient();
+
+const FAKE_PEOPLE: Array<{ prefix: string; first: string; last: string; nickname: string; salary: number; occupation: string }> = [
+  { prefix: 'นาย', first: 'ทดสอบหนึ่ง', last: 'นามสมมติ', nickname: 'หนึ่ง', salary: 18000, occupation: 'พนักงานบริษัท' },
+  { prefix: 'นางสาว', first: 'ทดสอบสอง', last: 'นามสมมติ', nickname: 'สอง', salary: 22000, occupation: 'รับจ้างทั่วไป' },
+  { prefix: 'นาย', first: 'ทดสอบสาม', last: 'นามสมมติ', nickname: 'สาม', salary: 16000, occupation: 'ค้าขาย' },
+  { prefix: 'นางสาว', first: 'ทดสอบสี่', last: 'นามสมมติ', nickname: 'สี่', salary: 25000, occupation: 'พนักงานโรงงาน' },
+  { prefix: 'นาย', first: 'ทดสอบห้า', last: 'นามสมมติ', nickname: 'ห้า', salary: 20000, occupation: 'ขับรถส่งของ' },
+  { prefix: 'นางสาว', first: 'ทดสอบหก', last: 'นามสมมติ', nickname: 'หก', salary: 17000, occupation: 'พนักงานบริษัท' },
+  { prefix: 'นาย', first: 'ทดสอบเจ็ด', last: 'นามสมมติ', nickname: 'เจ็ด', salary: 19000, occupation: 'ช่างซ่อม' },
+  { prefix: 'นางสาว', first: 'ทดสอบแปด', last: 'นามสมมติ', nickname: 'แปด', salary: 23000, occupation: 'พนักงานบริษัท' },
+  { prefix: 'นาย', first: 'ทดสอบเก้า', last: 'นามสมมติ', nickname: 'เก้า', salary: 21000, occupation: 'รับจ้างทั่วไป' },
+  { prefix: 'นางสาว', first: 'ทดสอบสิบ', last: 'นามสมมติ', nickname: 'สิบ', salary: 24000, occupation: 'ค้าขาย' },
+  { prefix: 'นาย', first: 'ทดสอบสิบเอ็ด', last: 'นามสมมติ', nickname: 'เอ็ด', salary: 18500, occupation: 'พนักงานโรงงาน' },
+  { prefix: 'นางสาว', first: 'ทดสอบสิบสอง', last: 'นามสมมติ', nickname: 'สอบ', salary: 22500, occupation: 'พนักงานบริษัท' },
+  { prefix: 'นาย', first: 'ทดสอบสิบสาม', last: 'นามสมมติ', nickname: 'สาม-สาม', salary: 16500, occupation: 'ขับรถส่งของ' },
+  { prefix: 'นางสาว', first: 'ทดสอบสิบสี่', last: 'นามสมมติ', nickname: 'สี่-สี่', salary: 25500, occupation: 'พนักงานบริษัท' },
+  { prefix: 'นาย', first: 'ทดสอบสิบห้า', last: 'นามสมมติ', nickname: 'ห้า-ห้า', salary: 20500, occupation: 'รับจ้างทั่วไป' },
+  { prefix: 'นางสาว', first: 'ทดสอบสิบหก', last: 'นามสมมติ', nickname: 'หก-หก', salary: 17500, occupation: 'ค้าขาย' },
+  { prefix: 'นาย', first: 'ทดสอบสิบเจ็ด', last: 'นามสมมติ', nickname: 'เจ็ด-เจ็ด', salary: 19500, occupation: 'ช่างซ่อม' },
+  { prefix: 'นางสาว', first: 'ทดสอบสิบแปด', last: 'นามสมมติ', nickname: 'แปด-แปด', salary: 23500, occupation: 'พนักงานบริษัท' },
+  { prefix: 'นาย', first: 'ทดสอบสิบเก้า', last: 'นามสมมติ', nickname: 'เก้า-เก้า', salary: 21500, occupation: 'พนักงานโรงงาน' },
+  { prefix: 'นางสาว', first: 'ทดสอบยี่สิบ', last: 'นามสมมติ', nickname: 'ยี่สิบ', salary: 24500, occupation: 'พนักงานบริษัท' },
+];
+
+interface OverdueBucket {
+  label: string;
+  daysOverdue: number;
+  paidInstallments: number;
+  contractStatus: ContractStatus;
+}
+
+const OVERDUE_BUCKETS: OverdueBucket[] = [
+  { label: 'current', daysOverdue: 0, paidInstallments: 3, contractStatus: 'ACTIVE' },
+  { label: '1-30',    daysOverdue: 15, paidInstallments: 2, contractStatus: 'OVERDUE' },
+  { label: '31-60',   daysOverdue: 45, paidInstallments: 2, contractStatus: 'OVERDUE' },
+  { label: '61-90',   daysOverdue: 75, paidInstallments: 1, contractStatus: 'OVERDUE' },
+  { label: '90+',     daysOverdue: 120, paidInstallments: 1, contractStatus: 'OVERDUE' },
+];
+
+const fakeNationalId = (idx: number) => `${NID_PREFIX}${String(idx).padStart(9, '0')}`;
+const fakePhone = (idx: number) => `${PHONE_PREFIX}${String(idx).padStart(5, '0')}`;
+function generateContractNumber(idx: number): string {
+  const now = new Date();
+  const yymm = `${String(now.getFullYear() + 543).slice(2)}${String(now.getMonth() + 1).padStart(2, '0')}`;
+  return `BCP-TEST-${yymm}-${String(idx).padStart(5, '0')}`;
+}
+
+async function main() {
+  console.log(`\n=== Seed Collections Test Data ===`);
+  console.log(`Mode: ${COMMIT ? '🔥 COMMIT' : '🧪 DRY-RUN'}`);
+  console.log(`Marker: ${MARKER}\n`);
+
+  // Dev path: PII keys missing → skip encryption (mirrors customers.service.ts behavior).
+  // Prod path: keys must be ≥32 chars (validated by encryptPII / hashPII themselves).
+  const hasEncryption = !!KEY && KEY.length >= 32 && !!SALT && SALT.length >= 32;
+  if (COMMIT) {
+    if (!hasEncryption && (KEY || SALT)) {
+      console.error('❌ PII_ENCRYPTION_KEY และ PII_HASH_SALT ต้องตั้งทั้งคู่ และยาว ≥32 ตัวอักษร');
+      process.exit(1);
+    }
+    if (!hasEncryption) {
+      console.log('⚠️  ไม่มี PII keys — จะ seed แบบ dev (ไม่ encrypt) — อย่ารันแบบนี้บน prod');
+    }
+  }
+
+  // 1. Pick branch
+  const requestedBranchId = process.env.BRANCH_ID;
+  const branch = requestedBranchId
+    ? await prisma.branch.findFirst({ where: { id: requestedBranchId, deletedAt: null } })
+    : await prisma.branch.findFirst({
+        where: { deletedAt: null, isMainWarehouse: false },
+        orderBy: { createdAt: 'asc' },
+      });
+  if (!branch) {
+    console.error('❌ ไม่พบ branch — ระบุ BRANCH_ID หรือเช็คว่ามี non-warehouse branch ใน DB');
+    process.exit(1);
+  }
+  console.log(`📍 Branch: ${branch.id} — ${branch.name}`);
+
+  // 2. Pick salesperson
+  const salesperson =
+    (await prisma.user.findFirst({ where: { branchId: branch.id, role: 'SALES', deletedAt: null } })) ||
+    (await prisma.user.findFirst({ where: { role: 'SALES', deletedAt: null } })) ||
+    (await prisma.user.findFirst({ where: { role: 'OWNER' } }));
+  if (!salesperson) {
+    console.error('❌ ไม่พบ user สำหรับเป็น salesperson');
+    process.exit(1);
+  }
+  console.log(`👤 Salesperson: ${salesperson.id} — ${salesperson.name} (${salesperson.role})`);
+
+  // 3. Pick existing product (don't create — keep cleanup simple)
+  const product = await prisma.product.findFirst({
+    where: { branchId: branch.id, deletedAt: null },
+    orderBy: { createdAt: 'asc' },
+  }) || await prisma.product.findFirst({ where: { deletedAt: null }, orderBy: { createdAt: 'asc' } });
+  if (!product) {
+    console.error('❌ ไม่พบ Product ใน DB — ต้องมี product อย่างน้อย 1 ตัว');
+    process.exit(1);
+  }
+  console.log(`📦 Product: ${product.id} — ${product.brand} ${product.model}`);
+
+  // 4. Idempotency guard (active rows only — soft-deleted re-runs are fine)
+  const existing = await prisma.customer.count({
+    where: { legacyMemberCode: { startsWith: MARKER }, deletedAt: null },
+  });
+  if (existing > 0) {
+    console.error(`\n❌ พบ ${existing} customer ที่มี marker เดียวกันแล้ว — รัน cleanup ก่อน:`);
+    console.error(`   npx tsx scripts/cleanup-collections-test-data.ts --commit`);
+    process.exit(1);
+  }
+
+  console.log(`\n📋 Plan: 20 customers + 20 contracts + 240 payments (12 งวด × 20 สัญญา)`);
+  console.log(`   Aging: 4 current + 4×(1-30d) + 4×(31-60d) + 4×(61-90d) + 4×(90+d)`);
+
+  if (!COMMIT) {
+    console.log(`\n✋ Dry-run — เพิ่ม --commit เพื่อเขียน DB จริง\n`);
+    return;
+  }
+
+  // 5. Create
+  let cIdx = 0;
+  for (let bucketIdx = 0; bucketIdx < OVERDUE_BUCKETS.length; bucketIdx++) {
+    const bucket = OVERDUE_BUCKETS[bucketIdx];
+    for (let inBucket = 0; inBucket < 4; inBucket++) {
+      cIdx++;
+      const person = FAKE_PEOPLE[cIdx - 1];
+      const nid = fakeNationalId(cIdx);
+      const phone = fakePhone(cIdx);
+      const fullName = `${NAME_PREFIX}${person.first} ${person.last}`;
+
+      const customer = await prisma.customer.create({
+        data: {
+          nationalId: nid,
+          nationalIdEncrypted: hasEncryption ? encryptPII(nid, KEY) : null,
+          nationalIdHash: hasEncryption ? hashPII(nid, SALT) : null,
+          phone,
+          phoneEncrypted: hasEncryption ? encryptPII(phone, KEY) : null,
+          phoneHash: hasEncryption ? hashPII(phone, SALT) : null,
+          prefix: person.prefix,
+          name: fullName,
+          nickname: person.nickname,
+          occupation: person.occupation,
+          salary: new Prisma.Decimal(person.salary),
+          creditCheckStatus: 'FULL_CHECK_PASSED',
+          status: 'ACTIVE',
+          legacyMemberCode: `${MARKER}-${cIdx}`, // marker ผ่าน unique field
+        },
+      });
+
+      // Contract — 12-month plan, 8% flat interest
+      const sellingPrice = new Prisma.Decimal(15000);
+      const downPayment = new Prisma.Decimal(3000);
+      const financedAmount = new Prisma.Decimal(12000);
+      const interestRate = new Prisma.Decimal('0.0800');
+      const totalMonths = 12;
+      const interestTotal = financedAmount.mul(interestRate); // 960
+      const totalDue = financedAmount.add(interestTotal); // 12960
+      const monthlyPayment = totalDue.div(totalMonths).toDecimalPlaces(2); // 1080
+
+      // Backdate contract creation to land payments in the right aging bucket
+      const monthsBack = bucket.paidInstallments + (bucket.daysOverdue > 0 ? 1 : 0);
+      const contractCreatedAt = new Date(Date.now() - (monthsBack * 30 + bucket.daysOverdue) * 86400000);
+
+      const contract = await prisma.contract.create({
+        data: {
+          contractNumber: generateContractNumber(cIdx),
+          customerId: customer.id,
+          productId: product.id,
+          branchId: branch.id,
+          salespersonId: salesperson.id,
+          planType: 'STORE_WITH_INTEREST',
+          sellingPrice,
+          downPayment,
+          interestRate,
+          totalMonths,
+          interestTotal,
+          financedAmount,
+          monthlyPayment,
+          status: bucket.contractStatus,
+          paymentDueDay: 5,
+          workflowStatus: 'APPROVED',
+          createdAt: contractCreatedAt,
+          notes: MARKER,
+        },
+      });
+
+      // Payments — 12 งวด
+      const payments: Prisma.PaymentCreateManyInput[] = [];
+      for (let i = 1; i <= totalMonths; i++) {
+        const dueDate = new Date(contractCreatedAt.getTime() + i * 30 * 86400000);
+        let status: PaymentStatus = 'PENDING';
+        let amountPaid = new Prisma.Decimal(0);
+        let paidAt: Date | null = null;
+
+        if (i <= bucket.paidInstallments) {
+          status = 'PAID';
+          amountPaid = monthlyPayment;
+          paidAt = new Date(dueDate.getTime() - 2 * 86400000);
+        } else if (i === bucket.paidInstallments + 1 && bucket.daysOverdue > 0) {
+          status = 'OVERDUE';
+        }
+
+        payments.push({
+          contractId: contract.id,
+          installmentNo: i,
+          dueDate,
+          amountDue: monthlyPayment,
+          amountPaid,
+          paidAt,
+          status,
+        });
+      }
+      await prisma.payment.createMany({ data: payments });
+
+      console.log(
+        `  [${bucket.label.padEnd(7)}] ${customer.id.slice(0, 8)}.. ${fullName.padEnd(40)} ${contract.contractNumber} → ${bucket.paidInstallments}/${totalMonths} paid${bucket.daysOverdue > 0 ? `, ${bucket.daysOverdue}d overdue` : ''}`,
+      );
+    }
+  }
+
+  console.log(`\n✅ เสร็จ — ${cIdx} customer + ${cIdx} contract + ${cIdx * 12} payments`);
+  console.log(`\n🔍 ตรวจที่: /collections — กรองสาขา "${branch.name}"`);
+  console.log(`🧹 Cleanup: npx tsx scripts/cleanup-collections-test-data.ts --commit\n`);
+}
+
+main()
+  .catch((err) => {
+    console.error('\n❌ Failed:', err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Adds two one-off scripts under `scripts/` so we can stand up realistic test data on `/collections` (active + overdue across 5 aging buckets) and tear it down cleanly.

## What gets seeded

- **20 customers** named `[TEST] ทดสอบ<N> นามสมมติ`, NID `9999XXXXXXXXX`, phone `099-99-XXXXX`
- **20 contracts** (STORE_WITH_INTEREST, 12-month, ฿15k selling price, ฿3k down)
- **~240 payments** backdated so each contract lands in the right bucket:
  - 4 × current
  - 4 × 1-30 days overdue
  - 4 × 31-60 days
  - 4 × 61-90 days
  - 4 × 90+ days
- Reuses an existing Product (no new SKU pollution)

## Markers (for cleanup)
- `Customer.legacyMemberCode` startsWith `__SEED_2026_04_25__` (unique field, perfect filter)
- `Contract.notes` = `__SEED_2026_04_25__`

## Safety
- **Dry-run by default** — `--commit` required to write
- **PII**: encrypts `nationalId`/`phone` when `PII_ENCRYPTION_KEY`+`PII_HASH_SALT` are set (≥32 chars); skips encryption in dev
- **Idempotency guard** in seed: refuses if active marker rows already exist
- **Cleanup is soft-delete only** (project rule in `.claude/rules/database.md` forbids hard delete) — sets `deletedAt`, nulls `legacyMemberCode`, scrambles NID/phone so re-seed works
- **Triple guard** in cleanup: marker + `[TEST] ` name prefix + every contract on the customer must also be marker-tagged
- **Anti-blast**: refuse if >25 rows would be touched

## Run

```bash
# 1. Export prod secrets (need gcloud auth)
export DATABASE_URL=$(gcloud secrets versions access latest --secret=database-url)
export PII_ENCRYPTION_KEY=$(gcloud secrets versions access latest --secret=pii-encryption-key)
export PII_HASH_SALT=$(gcloud secrets versions access latest --secret=pii-hash-salt)

# 2. Dry-run first
npx tsx scripts/seed-collections-test-data.ts

# 3. Commit
npx tsx scripts/seed-collections-test-data.ts --commit

# 4. Cleanup later (dry-run, then commit)
npx tsx scripts/cleanup-collections-test-data.ts
npx tsx scripts/cleanup-collections-test-data.ts --commit
```

Override target branch: `BRANCH_ID=<id> npx tsx ...`

## Test plan
- [x] TypeScript check (against current schema)
- [x] Dry-run on dev (lookups for branch/salesperson/product all resolve)
- [ ] (blocked locally — dev DB is missing the `assigned_at` column from migration `20260606000000_add_p3_assigned_at_voice_memo_restore_expires`; prod has it)
- [ ] After merge: run on prod, verify `/collections` shows 20 new contracts with the expected aging distribution