### PR TITLE
fix(company): make taxId optional when not VAT-registered

### DIFF
--- a/apps/api/src/modules/company/company.service.ts
+++ b/apps/api/src/modules/company/company.service.ts
@@ -51,7 +51,7 @@ export class CompanyService {
     }
 
     return this.prisma.companyInfo.create({
-      data: dto,
+      data: { ...dto, taxId: dto.taxId ?? '' },
       include: { branches: { where: { deletedAt: null } } },
     });
   }

--- a/apps/api/src/modules/company/dto/company.dto.ts
+++ b/apps/api/src/modules/company/dto/company.dto.ts
@@ -18,9 +18,9 @@ export class CreateCompanyDto {
   @IsString({ message: 'ชื่อบริษัท (อังกฤษ) ต้องเป็นข้อความ' })
   nameEn?: string;
 
+  @IsOptional()
   @IsString({ message: 'เลขประจำตัวผู้เสียภาษีต้องเป็นข้อความ' })
-  @IsNotEmpty({ message: 'กรุณาระบุเลขประจำตัวผู้เสียภาษี' })
-  taxId!: string;
+  taxId?: string;
 
   // companyCode is set once at creation and becomes the system identifier.
   // Only OWNER can assign it, and it's immutable afterward.

--- a/apps/web/src/pages/CompanySettingsPage.tsx
+++ b/apps/web/src/pages/CompanySettingsPage.tsx
@@ -453,13 +453,18 @@ function AddCompanyDialog({
             <div>
               <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
                 เลขทะเบียนภาษี
+                {!form.vatRegistered && (
+                  <span className="ml-1 text-muted-foreground/70 normal-case tracking-normal">
+                    (ไม่จำเป็น หากไม่จด VAT)
+                  </span>
+                )}
               </label>
               <input
                 className={inputClass}
                 value={form.taxId}
                 onChange={(e) => set('taxId', formatTaxId(e.target.value))}
                 placeholder="0-0000-00000-00-0"
-                required
+                required={form.vatRegistered}
               />
             </div>
             <div>


### PR DESCRIPTION
## Summary
- Form เพิ่มนิติบุคคลเดิมบังคับ **เลขทะเบียนภาษี** เสมอ ทำให้นิติบุคคลที่ไม่จด VAT (เช่น SHOP) สร้างไม่ได้ถ้าไม่มีเลขผู้เสียภาษี
- ทำให้ `taxId` กลายเป็น optional เมื่อ `vatRegistered = false` ทั้ง backend และ frontend

## Changes
- `CreateCompanyDto.taxId` → `@IsOptional()`
- `CompanyService.create()` → default `taxId` เป็น `''` (DB column ยังเป็น non-null `String`)
- `CompanySettingsPage` create form → `required` ผูกกับ `form.vatRegistered` + แสดง hint "(ไม่จำเป็น หากไม่จด VAT)"

## Test plan
- [ ] สร้างนิติบุคคลใหม่ **ไม่ติ๊ก** "จดทะเบียน VAT" และเว้นเลขทะเบียนภาษี → ต้องสร้างได้สำเร็จ
- [ ] สร้างนิติบุคคลใหม่ **ติ๊ก** "จดทะเบียน VAT" แต่เว้นเลขทะเบียนภาษี → ปุ่ม submit ต้อง trigger native required
- [ ] แก้ไขนิติบุคคลที่มีอยู่ — ฟังก์ชันเดิมยังทำงานได้ปกติ

🤖 Generated with [Claude Code](https://claude.com/claude-code)