### PR TITLE
fix(inbox): unread count + quick actions popup

### DIFF
--- a/apps/api/src/modules/chat-engine/services/room-manager.service.spec.ts
+++ b/apps/api/src/modules/chat-engine/services/room-manager.service.spec.ts
@@ -151,6 +151,31 @@ describe('RoomManagerService', () => {
       });
     });
 
+    it('should increment unreadCount on inbound CUSTOMER messages', async () => {
+      prisma.chatMessage.create.mockResolvedValue({ id: 'm', createdAt: new Date() });
+      prisma.chatRoom.update.mockResolvedValue({});
+
+      await service.saveMessage({ roomId: 'room-1', role: MessageRole.CUSTOMER, text: 'hi' });
+
+      expect(prisma.chatRoom.update).toHaveBeenCalledWith({
+        where: { id: 'room-1' },
+        data: expect.objectContaining({ unreadCount: { increment: 1 } }),
+      });
+    });
+
+    it('should NOT increment unreadCount on STAFF or BOT messages', async () => {
+      prisma.chatMessage.create.mockResolvedValue({ id: 'm', createdAt: new Date() });
+      prisma.chatRoom.findUnique.mockResolvedValue({ firstResponseAt: null });
+      prisma.chatRoom.update.mockResolvedValue({});
+
+      await service.saveMessage({ roomId: 'room-1', role: MessageRole.STAFF, text: 'reply' });
+
+      expect(prisma.chatRoom.update).toHaveBeenCalledWith({
+        where: { id: 'room-1' },
+        data: expect.not.objectContaining({ unreadCount: expect.anything() }),
+      });
+    });
+
     it('should set firstResponseAt for first BOT reply', async () => {
       prisma.chatMessage.create.mockResolvedValue({ id: 'msg-2', createdAt: new Date() });
       prisma.chatRoom.findUnique.mockResolvedValue({ firstResponseAt: null });

--- a/apps/api/src/modules/chat-engine/services/room-manager.service.ts
+++ b/apps/api/src/modules/chat-engine/services/room-manager.service.ts
@@ -237,7 +237,10 @@ export class RoomManagerService {
       lastMessageAt: new Date(),
     };
 
-    if (params.role === MessageRole.STAFF || params.role === MessageRole.BOT) {
+    if (params.role === MessageRole.CUSTOMER) {
+      // Inbound message — increment unread until staff opens the room (markAsRead resets it).
+      updateData.unreadCount = { increment: 1 };
+    } else if (params.role === MessageRole.STAFF || params.role === MessageRole.BOT) {
       // Set firstResponseAt if not already set (SLA metric)
       const room = await this.prisma.chatRoom.findUnique({
         where: { id: params.roomId },

--- a/apps/api/src/modules/chatbot-finance/services/chat-room.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/chat-room.service.ts
@@ -109,6 +109,9 @@ export class ChatRoomService {
       data: {
         totalMessages: { increment: 1 },
         lastMessageAt: new Date(),
+        ...(params.role === MessageRole.CUSTOMER
+          ? { unreadCount: { increment: 1 } }
+          : {}),
       },
     });
 

--- a/apps/web/src/pages/UnifiedInboxPage/components/Customer360Panel.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/Customer360Panel.tsx
@@ -16,9 +16,12 @@ import {
   Smartphone,
   ExternalLink,
   Link2,
+  QrCode,
+  Zap,
   Send,
   Shield,
 } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { format, isPast, differenceInDays } from 'date-fns';
 import { th } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
@@ -506,28 +509,51 @@ export default function Customer360Panel({ customerId, activeRoomId, onSelectRoo
 
       {/* ─── 7. Quick Actions ────────────────────────────── */}
       <div className="p-4">
-        <SectionHeader icon={Send} label="ดำเนินการ" />
-        <div className="grid grid-cols-2 gap-2">
-          <QuickActionBtn
-            icon={<Link2 className="w-3.5 h-3.5" />}
-            label="ส่งลิงก์ชำระ"
-            onClick={() => toast.info('เลือกสัญญาก่อนส่งลิงก์')}
-          />
-          <QuickActionBtn
-            icon={<FileText className="w-3.5 h-3.5" />}
-            label="สร้างสัญญา"
-            onClick={() => window.open(`/contracts/create`, '_blank')}
-          />
-          <QuickActionBtn
-            icon={<ExternalLink className="w-3.5 h-3.5" />}
-            label="ดูข้อมูลลูกค้า"
-            onClick={() => window.open(`/customers/${customerId}`, '_blank')}
-          />
-          <QuickActionBtn
-            icon={<Clock className="w-3.5 h-3.5" />}
-            label="ประวัติชำระ"
-            onClick={() => window.open(`/payments?search=${customer?.phone}`, '_blank')}
-          />
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-1.5">
+            <Send className="w-3.5 h-3.5 text-muted-foreground" />
+            <h4 className="text-[11px] font-semibold text-foreground/70 uppercase tracking-wide">ดำเนินการ</h4>
+          </div>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                className="w-6 h-6 rounded-full bg-primary flex items-center justify-center text-primary-foreground hover:bg-primary/90 transition-colors"
+                title="ดำเนินการ"
+              >
+                <Zap className="w-3.5 h-3.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="end" side="top" className="w-56 p-2">
+              <div className="grid grid-cols-2 gap-1.5">
+                <QuickActionBtn
+                  icon={<Link2 className="w-3.5 h-3.5 flex-shrink-0" />}
+                  label="ส่งลิงก์ชำระ"
+                  onClick={() => toast.info('เลือกสัญญาก่อนส่งลิงก์')}
+                />
+                <QuickActionBtn
+                  icon={<QrCode className="w-3.5 h-3.5 flex-shrink-0" />}
+                  label="ส่ง QR ชำระ"
+                  onClick={() => toast.info('เลือกสัญญาก่อนส่ง QR')}
+                />
+                <QuickActionBtn
+                  icon={<FileText className="w-3.5 h-3.5 flex-shrink-0" />}
+                  label="ดูสัญญา"
+                  onClick={() => window.open(`/contracts?customerId=${customerId}`, '_blank')}
+                />
+                <QuickActionBtn
+                  icon={<Clock className="w-3.5 h-3.5 flex-shrink-0" />}
+                  label="ประวัติชำระ"
+                  onClick={() => window.open(`/payments?search=${customer?.phone}`, '_blank')}
+                />
+                <QuickActionBtn
+                  icon={<ExternalLink className="w-3.5 h-3.5 flex-shrink-0" />}
+                  label="ดูข้อมูลลูกค้า"
+                  onClick={() => window.open(`/customers/${customerId}`, '_blank')}
+                  className="col-span-2"
+                />
+              </div>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
       </div>{/* end scrollable */}
@@ -701,15 +727,20 @@ function QuickActionBtn({
   icon,
   label,
   onClick,
+  className,
 }: {
   icon: ReactNode;
   label: string;
   onClick: () => void;
+  className?: string;
 }) {
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-1.5 px-2 py-2 text-[11px] bg-muted hover:bg-accent rounded-lg text-foreground/70 transition-colors"
+      className={cn(
+        'flex items-center gap-1.5 px-2 py-2 text-[11px] bg-muted hover:bg-accent rounded-lg text-foreground/70 transition-colors',
+        className,
+      )}
     >
       {icon}
       {label}


### PR DESCRIPTION
## Summary
- แก้ bug unread count ไม่เคย increment เมื่อลูกค้าส่งข้อความ → inbox ไม่รู้ว่าแชทไหนยังไม่อ่าน
- เปลี่ยน "ดำเนินการ" จาก 4 ปุ่ม always-visible เป็น FAB + popup 5 actions

## Changes

**Backend — unread count**
- `room-manager.service.ts`: increment `unreadCount` เมื่อ `role === CUSTOMER`
- `chat-room.service.ts` (chatbot-finance): เพิ่มเช่นเดียวกัน
- `room-manager.service.spec.ts`: +2 tests ครอบคลุม increment + ไม่ increment สำหรับ STAFF/BOT

**Frontend — quick actions popup**
- แทนที่ grid 4 ปุ่มด้วย Zap FAB button + Radix Popover
- 5 actions (icon ซ้าย label ขวา, 2 คอลัมน์): ส่งลิงก์ชำระ / ส่ง QR ชำระ / ดูสัญญา / ประวัติชำระ / ดูข้อมูลลูกค้า

## Test plan
- [ ] ลูกค้าส่งข้อความเข้า inbox → ชื่อตัวหนา + badge ตัวเลขปรากฏ
- [ ] Staff เปิดอ่านแชท → badge หายไป
- [ ] Tab "ยังไม่อ่าน" filter ได้ถูกต้อง
- [ ] กด Zap button → popup แสดง 5 actions
- [ ] กด action แต่ละอัน → ทำงานถูกต้อง
- [ ] click outside popup → ปิด

🤖 Generated with [Claude Code](https://claude.com/claude-code)