### PR TITLE
chore(audit): security throttle + perf groupBy + compound indexes

### DIFF
--- a/apps/api/prisma/migrations/20260426131551_add_audit_compound_indexes/migration.sql
+++ b/apps/api/prisma/migrations/20260426131551_add_audit_compound_indexes/migration.sql
@@ -1,0 +1,15 @@
+-- Audit quick-wins: 3 compound indexes for hot cron paths.
+-- Idempotent (IF NOT EXISTS) so this can re-run on partially-migrated dev DBs.
+--
+-- NotificationLog: per-payment dedup probe in notifications.service.ts (queries by
+-- relatedId + subject + sentAt to skip already-sent reminders).
+CREATE INDEX IF NOT EXISTS "notification_logs_related_id_subject_sent_at_idx"
+  ON "notification_logs" ("related_id", "subject", "sent_at");
+
+-- Contract: */5min SLA cron scan filters by workflowStatus IN (...) AND updatedAt < threshold.
+CREATE INDEX IF NOT EXISTS "contracts_workflowStatus_updatedAt_idx"
+  ON "contracts" ("workflow_status", "updated_at");
+
+-- ChatRoom: */5min first-response SLA cron in chat-engine/chat-cron.service.ts.
+CREATE INDEX IF NOT EXISTS "chat_rooms_status_first_response_at_created_at_idx"
+  ON "chat_rooms" ("status", "first_response_at", "created_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -987,6 +987,8 @@ model Contract {
   @@index([deletedAt])
   @@index([status, deletedAt, branchId])
   @@index([workflowStatus])
+  // Speeds up the */5min SLA cron scan (workflowStatus IN (...) AND updatedAt < threshold)
+  @@index([workflowStatus, updatedAt])
   @@index([parentContractId])
   @@index([retentionStatus])
   @@index([noAnswerCount]) // H2: FollowUpTab filters on gte 1 lt 3 — index keeps it sub-ms at scale
@@ -1811,6 +1813,9 @@ model NotificationLog {
   @@index([status, channel])
   @@index([status, nextRetryAt])
   @@index([externalId])
+  // Speeds up the per-payment dedup probe in notifications.service.ts
+  // (queries by relatedId + subject + sentAt to skip already-sent reminders)
+  @@index([relatedId, subject, sentAt])
   @@map("notification_logs")
 }
 
@@ -4011,6 +4016,8 @@ model ChatRoom {
   @@index([status, priority])
   @@index([handoffMode, status])
   @@index([leadScore])
+  // Speeds up the */5min first-response SLA cron in chat-engine/chat-cron.service.ts
+  @@index([status, firstResponseAt, createdAt])
   @@map("chat_rooms")
 }
 

--- a/apps/api/src/modules/customers/customers.controller.ts
+++ b/apps/api/src/modules/customers/customers.controller.ts
@@ -127,7 +127,9 @@ export class CustomersController {
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
   @ApiOperation({ summary: 'Top referrers: ลูกค้าที่แนะนำมากที่สุด' })
   getReferralStats(@Query('limit') limit?: string) {
-    return this.customersService.getReferralStats(limit ? parseInt(limit) : 10);
+    return this.customersService.getReferralStats(
+      limit ? Math.min(parseInt(limit) || 10, 100) : 10,
+    );
   }
 
   @Get('watch-list')
@@ -137,7 +139,10 @@ export class CustomersController {
     @Query('branchId') branchId?: string,
     @Query('limit') limit?: string,
   ) {
-    return this.customersService.getWatchList(branchId, limit ? parseInt(limit) : 30);
+    return this.customersService.getWatchList(
+      branchId,
+      limit ? Math.min(parseInt(limit) || 30, 100) : 30,
+    );
   }
 
   @Get('upsell-candidates')
@@ -147,7 +152,10 @@ export class CustomersController {
     @Query('branchId') branchId?: string,
     @Query('limit') limit?: string,
   ) {
-    return this.customersService.getUpsellCandidates(branchId, limit ? parseInt(limit) : 20);
+    return this.customersService.getUpsellCandidates(
+      branchId,
+      limit ? Math.min(parseInt(limit) || 20, 100) : 20,
+    );
   }
 
   @Get('search')

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -625,40 +625,101 @@ export class DashboardService {
     const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     const branchFilter = branchId ? { branchId } : {};
 
-    // Sales metrics: contracts this month grouped by salesperson
-    const contracts = await this.prisma.contract.findMany({
-      where: { createdAt: { gte: monthStart, lt: monthEnd }, deletedAt: null, ...branchFilter },
-      include: {
-        salesperson: { select: { id: true, name: true } },
-        branch: { select: { name: true } },
-      },
-    });
+    // Sales metrics: contracts this month grouped by salesperson via Postgres groupBy
+    // (replaces former findMany + JS reduce — old path loaded full monthly contract
+    // set with deep includes; new path returns ~N rows where N = salesperson count).
+    const baseWhere = {
+      createdAt: { gte: monthStart, lt: monthEnd },
+      deletedAt: null,
+      ...branchFilter,
+    } as const;
 
-    const staffMap = new Map<string, {
-      name: string; branch: string; totalContracts: number;
-      totalSales: number; overdueCount: number;
-    }>();
+    const [aggregates, overdueAgg] = await Promise.all([
+      this.prisma.contract.groupBy({
+        by: ['salespersonId', 'branchId'],
+        where: baseWhere,
+        _count: { _all: true },
+        _sum: { sellingPrice: true },
+      }),
+      this.prisma.contract.groupBy({
+        by: ['salespersonId'],
+        where: { ...baseWhere, status: { in: ['OVERDUE', 'DEFAULT'] } },
+        _count: { _all: true },
+      }),
+    ]);
 
-    for (const c of contracts) {
-      const key = c.salespersonId;
-      const existing = staffMap.get(key) || {
-        name: c.salesperson.name, branch: c.branch.name,
-        totalContracts: 0, totalSales: 0, overdueCount: 0,
-      };
-      existing.totalContracts++;
-      existing.totalSales = new Prisma.Decimal(existing.totalSales)
-        .add(new Prisma.Decimal(c.sellingPrice ?? 0)).toNumber();
-      if (['OVERDUE', 'DEFAULT'].includes(c.status)) existing.overdueCount++;
-      staffMap.set(key, existing);
+    // Enrich names + branch names in two batched queries (vs N+1 in old loop).
+    const salespersonIds = Array.from(
+      new Set(aggregates.map((a) => a.salespersonId).filter((id): id is string => !!id)),
+    );
+    const branchIds = Array.from(
+      new Set(aggregates.map((a) => a.branchId).filter((id): id is string => !!id)),
+    );
+
+    const [users, branches] = await Promise.all([
+      salespersonIds.length
+        ? this.prisma.user.findMany({
+            where: { id: { in: salespersonIds } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([] as { id: string; name: string }[]),
+      branchIds.length
+        ? this.prisma.branch.findMany({
+            where: { id: { in: branchIds } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([] as { id: string; name: string }[]),
+    ]);
+
+    const userNameMap = new Map(users.map((u) => [u.id, u.name]));
+    const branchNameMap = new Map(branches.map((b) => [b.id, b.name]));
+    const overdueMap = new Map(
+      overdueAgg
+        .filter((o) => !!o.salespersonId)
+        .map((o) => [o.salespersonId as string, o._count._all]),
+    );
+
+    // Collapse [salespersonId, branchId] rows → one row per salesperson.
+    // Matches old semantics: first contract's branch wins for the salesperson.
+    type Bucket = {
+      name: string;
+      branch: string;
+      totalContracts: number;
+      totalSales: number;
+      overdueCount: number;
+    };
+    const staffMap = new Map<string, Bucket>();
+    for (const a of aggregates) {
+      if (!a.salespersonId) continue;
+      const key = a.salespersonId;
+      const existing = staffMap.get(key);
+      const sellingSum = new Prisma.Decimal(a._sum.sellingPrice ?? 0).toNumber();
+      if (existing) {
+        existing.totalContracts += a._count._all;
+        existing.totalSales = new Prisma.Decimal(existing.totalSales)
+          .add(new Prisma.Decimal(a._sum.sellingPrice ?? 0))
+          .toNumber();
+      } else {
+        staffMap.set(key, {
+          name: userNameMap.get(key) ?? '-',
+          branch: branchNameMap.get(a.branchId) ?? '-',
+          totalContracts: a._count._all,
+          totalSales: sellingSum,
+          overdueCount: overdueMap.get(key) ?? 0,
+        });
+      }
     }
 
-    const salesMetrics = Array.from(staffMap.entries()).map(([id, data]) => ({
-      salespersonId: id,
-      ...data,
-      overdueRate: data.totalContracts > 0
-        ? Number(((data.overdueCount / data.totalContracts) * 100).toFixed(1))
-        : 0,
-    })).sort((a, b) => b.totalSales - a.totalSales);
+    const salesMetrics = Array.from(staffMap.entries())
+      .map(([id, data]) => ({
+        salespersonId: id,
+        ...data,
+        overdueRate:
+          data.totalContracts > 0
+            ? Number(((data.overdueCount / data.totalContracts) * 100).toFixed(1))
+            : 0,
+      }))
+      .sort((a, b) => b.totalSales - a.totalSales);
 
     // Recent activity: contracts created + payments recorded in last 7 days
     const [recentContracts, recentPayments] = await Promise.all([

--- a/apps/api/src/modules/journal/journal.controller.ts
+++ b/apps/api/src/modules/journal/journal.controller.ts
@@ -64,7 +64,7 @@ export class JournalController {
       endDate,
       search,
       page: page ? parseInt(page) : undefined,
-      limit: limit ? parseInt(limit) : undefined,
+      limit: limit ? Math.min(parseInt(limit) || 50, 100) : undefined,
     });
   }
 

--- a/apps/api/src/modules/line-oa/broadcast.controller.ts
+++ b/apps/api/src/modules/line-oa/broadcast.controller.ts
@@ -11,6 +11,9 @@ import {
   UploadedFile,
   ParseIntPipe,
   DefaultValuePipe,
+  ParseFilePipe,
+  MaxFileSizeValidator,
+  FileTypeValidator,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiBearerAuth, ApiConsumes } from '@nestjs/swagger';
@@ -95,7 +98,17 @@ export class BroadcastController {
   @Roles('OWNER')
   @ApiConsumes('multipart/form-data')
   @UseInterceptors(FileInterceptor('file'))
-  async uploadImage(@UploadedFile() file: Express.Multer.File) {
+  async uploadImage(
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 10 * 1024 * 1024, message: 'ไฟล์มีขนาดเกิน 10MB' }),
+          new FileTypeValidator({ fileType: /^image\/(jpeg|png|gif|webp)$/ }),
+        ],
+      }),
+    )
+    file: Express.Multer.File,
+  ) {
     return this.broadcastService.uploadImage(file.buffer, file.originalname);
   }
 

--- a/apps/api/src/modules/line-oa/line-oa.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa.controller.ts
@@ -13,6 +13,9 @@ import {
   BadRequestException,
   UseInterceptors,
   UploadedFile,
+  ParseFilePipe,
+  MaxFileSizeValidator,
+  FileTypeValidator,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
@@ -551,7 +554,15 @@ export class LineOaController {
   @UseInterceptors(FileInterceptor('image'))
   async uploadRichMenuImage(
     @Param('id') id: string,
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 1 * 1024 * 1024, message: 'ไฟล์มีขนาดเกิน 1MB' }),
+          new FileTypeValidator({ fileType: /^image\/(jpeg|png)$/ }),
+        ],
+      }),
+    )
+    file: Express.Multer.File,
     @Query('channel') channel?: string,
   ) {
     if (!file) throw new BadRequestException('กรุณาอัปโหลดรูปภาพ');
@@ -565,7 +576,16 @@ export class LineOaController {
   @Roles('OWNER')
   @UseInterceptors(FileInterceptor('image'))
   async createWithImage(
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 1 * 1024 * 1024, message: 'ไฟล์มีขนาดเกิน 1MB' }),
+          new FileTypeValidator({ fileType: /^image\/(jpeg|png)$/ }),
+        ],
+        fileIsRequired: false,
+      }),
+    )
+    file: Express.Multer.File,
     @Body() body: any,
     @CurrentUser() user: { id: string },
   ) {

--- a/apps/api/src/modules/shop-auth-social/shop-auth-social.controller.ts
+++ b/apps/api/src/modules/shop-auth-social/shop-auth-social.controller.ts
@@ -1,12 +1,16 @@
-import { Body, Controller, HttpException, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, HttpException, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ShopAuthSocialService } from './shop-auth-social.service';
 import { LineLoginCallbackDto, FacebookLoginCallbackDto, BindPhoneDto } from './dto/social-login.dto';
+import { ShopBotDefenseGuard } from '../shop-bot-defense/shop-bot-defense.guard';
 
 @Controller('shop/auth')
+@UseGuards(ShopBotDefenseGuard)
 export class ShopAuthSocialController {
   constructor(private authService: ShopAuthSocialService) {}
 
   @Post('line/callback')
+  @Throttle({ short: { limit: 5, ttl: 60_000 } })
   async lineCallback(@Body() dto: LineLoginCallbackDto) {
     // Exchange code for LINE profile
     const profile = await this.exchangeLineCode(dto.code);
@@ -14,12 +18,14 @@ export class ShopAuthSocialController {
   }
 
   @Post('facebook/callback')
+  @Throttle({ short: { limit: 5, ttl: 60_000 } })
   async facebookCallback(@Body() dto: FacebookLoginCallbackDto) {
     const profile = await this.exchangeFacebookToken(dto.accessToken);
     return this.authService.handleFacebookLogin(profile);
   }
 
   @Post('bind-phone')
+  @Throttle({ short: { limit: 5, ttl: 60_000 } })
   async bindPhone(@Body() dto: BindPhoneDto) {
     return this.authService.bindPhoneToSocial(dto);
   }
@@ -35,12 +41,14 @@ export class ShopAuthSocialController {
         client_id: process.env.LINE_LOGIN_CHANNEL_ID || '',
         client_secret: process.env.LINE_LOGIN_CHANNEL_SECRET || '',
       }),
+      signal: AbortSignal.timeout(10_000),
     });
     if (!tokenRes.ok) throw new HttpException('LINE token exchange failed', HttpStatus.UNAUTHORIZED);
     const tokens = (await tokenRes.json()) as { access_token: string; id_token?: string };
 
     const profileRes = await fetch('https://api.line.me/v2/profile', {
       headers: { Authorization: `Bearer ${tokens.access_token}` },
+      signal: AbortSignal.timeout(10_000),
     });
     if (!profileRes.ok) throw new HttpException('LINE profile fetch failed', HttpStatus.UNAUTHORIZED);
     const profile = (await profileRes.json()) as {
@@ -59,6 +67,7 @@ export class ShopAuthSocialController {
   private async exchangeFacebookToken(accessToken: string) {
     const res = await fetch(
       `https://graph.facebook.com/me?fields=id,name,email&access_token=${encodeURIComponent(accessToken)}`,
+      { signal: AbortSignal.timeout(10_000) },
     );
     if (!res.ok) throw new HttpException('Facebook token verify failed', HttpStatus.UNAUTHORIZED);
     const data = (await res.json()) as { id: string; name: string; email?: string };

--- a/apps/api/src/modules/shop-installment-apply/shop-installment-apply.controller.ts
+++ b/apps/api/src/modules/shop-installment-apply/shop-installment-apply.controller.ts
@@ -1,7 +1,9 @@
 import { Body, Controller, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ShopInstallmentApplyService } from './shop-installment-apply.service';
 import { CreateApplicationDto } from './dto/create-application.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ShopBotDefenseGuard } from '../shop-bot-defense/shop-bot-defense.guard';
 
 /**
  * Customer-facing installment application endpoints.
@@ -13,10 +15,12 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
  * on `GET /:applicationNumber` use their session to scope results.
  */
 @Controller('shop/applications')
+@UseGuards(ShopBotDefenseGuard)
 export class ShopInstallmentApplyController {
   constructor(private service: ShopInstallmentApplyService) {}
 
   @Post()
+  @Throttle({ short: { limit: 5, ttl: 60_000 } })
   submit(@Body() dto: CreateApplicationDto, @Req() req: { user?: { sub?: string } }) {
     const customerId = req.user?.sub;
     return this.service.submit(dto, customerId);

--- a/apps/api/src/modules/shop-me/shop-me.controller.ts
+++ b/apps/api/src/modules/shop-me/shop-me.controller.ts
@@ -1,6 +1,9 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ShippingAddressDto } from '../shop-checkout/dto/place-order.dto';
+
+const MAX_SHIPPING_ADDRESSES = 20;
 
 @Controller('shop/me')
 @UseGuards(JwtAuthGuard)
@@ -14,9 +17,15 @@ export class ShopMeController {
   }
 
   @Post('addresses')
-  async addAddress(@Req() req: { user: { sub: string } }, @Body() addr: Record<string, unknown>) {
+  async addAddress(@Req() req: { user: { sub: string } }, @Body() addr: ShippingAddressDto) {
     const c = await this.prisma.customer.findUnique({ where: { id: req.user.sub } });
-    const next = [...(((c?.shippingAddresses as unknown[]) ?? [])), addr];
+    const existing = ((c?.shippingAddresses as unknown[]) ?? []);
+    if (existing.length >= MAX_SHIPPING_ADDRESSES) {
+      throw new BadRequestException(
+        `บันทึกที่อยู่จัดส่งได้สูงสุด ${MAX_SHIPPING_ADDRESSES} รายการ`,
+      );
+    }
+    const next = [...existing, addr];
     await this.prisma.customer.update({
       where: { id: req.user.sub },
       data: { shippingAddresses: next as any },

--- a/apps/api/src/modules/shop-reservation/shop-reservation.controller.ts
+++ b/apps/api/src/modules/shop-reservation/shop-reservation.controller.ts
@@ -1,8 +1,12 @@
-import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ShopReservationService } from './shop-reservation.service';
 import { CreateReservationDto } from './dto/create-reservation.dto';
+import { ShopBotDefenseGuard } from '../shop-bot-defense/shop-bot-defense.guard';
 
 @Controller('shop/reservations')
+@UseGuards(ShopBotDefenseGuard)
+@Throttle({ short: { limit: 30, ttl: 60_000 } })
 export class ShopReservationController {
   constructor(private reservationService: ShopReservationService) {}
 

--- a/apps/api/src/modules/shop-tracking/shop-tracking.controller.ts
+++ b/apps/api/src/modules/shop-tracking/shop-tracking.controller.ts
@@ -1,13 +1,17 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 import { ShopTrackingService } from './shop-tracking.service';
 import { TrackVisitDto } from './dto/track-visit.dto';
+import { ShopBotDefenseGuard } from '../shop-bot-defense/shop-bot-defense.guard';
 
 @Controller('shop')
+@UseGuards(ShopBotDefenseGuard)
 export class ShopTrackingController {
   constructor(private trackingService: ShopTrackingService) {}
 
   @Post('track')
+  @Throttle({ short: { limit: 30, ttl: 60_000 } })
   async track(@Body() dto: TrackVisitDto, @Req() req: Request): Promise<{ ok: true }> {
     const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.ip || '';
     const userAgent = req.headers['user-agent'] || '';

--- a/apps/api/src/modules/staff-chat/web-widget.controller.ts
+++ b/apps/api/src/modules/staff-chat/web-widget.controller.ts
@@ -7,10 +7,19 @@ import {
   Query,
   NotFoundException,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 import { ChatChannel } from '@prisma/client';
 import { v4 as uuidv4 } from 'uuid';
 import { SkipCsrf } from '../../guards/skip-csrf.decorator';
 import { RoomManagerService } from '../chat-engine/services/room-manager.service';
+
+class InitWidgetDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  visitorId?: string;
+}
 
 /**
  * WebWidgetController — REST endpoints for the web chat widget.
@@ -29,8 +38,9 @@ export class WebWidgetController {
    */
   @Post('init')
   @SkipCsrf()
+  @Throttle({ short: { limit: 30, ttl: 60_000 } })
   async initRoom(
-    @Body() body: { visitorId?: string },
+    @Body() body: InitWidgetDto,
   ): Promise<{ roomId: string; visitorId: string }> {
     const visitorId = body.visitorId || uuidv4();
 
@@ -51,6 +61,7 @@ export class WebWidgetController {
    */
   @Get('messages/:roomId')
   @SkipCsrf()
+  @Throttle({ short: { limit: 60, ttl: 60_000 } })
   async getMessages(
     @Param('roomId') roomId: string,
     @Query('limit') limit?: string,


### PR DESCRIPTION
## Summary

Quick wins from the codebase audit done after collections-guided-session merged. Two batches: security defense-in-depth + performance hot-path fixes.

### Security (commit \`b00d5ac5\`)

Public shop endpoints lacked throttle/bot defense — DoS / abuse openings:
- \`POST /api/shop/track\` — 30/min + ShopBotDefenseGuard
- \`POST /shop/applications\` — 5/min + ShopBotDefenseGuard
- \`POST /shop/auth/{line,facebook,bind-phone}/callback\` — 5/min + AbortSignal.timeout(10s) on outbound fetch
- \`POST /widget/init\` — 30/min + DTO with class-validator
- \`GET /widget/messages/:roomId\` — 60/min
- \`/shop/reservations/*\` — 30/min + ShopBotDefenseGuard

File-upload validators (ParseFilePipe + MaxFileSize + FileType):
- Broadcast image upload — 10MB image-only
- LINE rich-menu image — 1MB JPEG/PNG only

DTO replacements (was \`@Body() any\`):
- \`shop-me\` shipping address — reused existing \`ShippingAddressDto\` from shop-checkout (search-before-create)
- Widget init \`visitorId\` — \`@IsString()@MaxLength(64)\`

Pagination upper bounds:
- \`customers\` + \`journal\` controllers — \`Math.min(parseInt(limit) || N, 100)\`

Throttle bucket name: used \`short\` (matches existing ThrottlerModule.forRoot config — no \`default\` bucket exists).

### Performance (commit \`b42b7bb9\`)

**Dashboard staff metrics** — \`findMany + JS reduce\` → 2 parallel \`groupBy\` queries + 1 user/branch enrich. Old path loaded full monthly contract set with deep includes; new path returns ~N rows where N=salesperson count. Return shape preserved.

**3 new compound indexes:**
- \`NotificationLog [relatedId, subject, sentAt]\` — speeds payment-reminder cron dedup probe
- \`Contract [workflowStatus, updatedAt]\` — speeds */5min SLA cron scan
- \`ChatRoom [status, firstResponseAt, createdAt]\` — speeds */5min chat first-response cron

Migration \`20260426131551_add_audit_compound_indexes\` — idempotent (\`CREATE INDEX IF NOT EXISTS\`); fast on current volumes (no CONCURRENTLY needed).

## Test plan

- [x] \`./tools/check-types.sh all\` — API + Web both OK
- [x] All 238 API tests pass
- [x] Dashboard tests 6/6 pass
- [ ] Verify migration applies cleanly to prod (it's idempotent + small tables)
- [ ] Smoke test: hit each public endpoint with rapid-fire requests and confirm 429 after limit
- [ ] Smoke test: dashboard staff-metrics renders identical numbers as before

## Concerns

- Schema drift on dev DB persists (chat_messages/chat_rooms rename — pre-existing, unrelated). Migration was hand-applied to dev with \`prisma migrate resolve\`. Prod will run \`migrate deploy\` cleanly because prod doesn't have the drift.
- ShopBotDefenseGuard is \`@Global\` — no per-module imports needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)