### PR TITLE
fix(inbox): send via HTTP + reserve space for MobileBottomNav

### DIFF
--- a/apps/api/src/modules/staff-chat/staff-chat.controller.ts
+++ b/apps/api/src/modules/staff-chat/staff-chat.controller.ts
@@ -117,11 +117,22 @@ export class StaffChatController {
     if (!text) {
       return { success: false, error: 'กรุณาพิมพ์ข้อความก่อนส่ง' };
     }
-    return this.messageRouter.sendStaffMessage({
+    const result = await this.messageRouter.sendStaffMessage({
       roomId: id,
       staffId: req.user.id,
       text,
     });
+
+    // Broadcast to staff viewing this room so the message appears in real-time
+    this.staffChatGateway.emitNewMessage(id, {
+      roomId: id,
+      role: 'STAFF',
+      staffId: req.user.id,
+      text,
+      createdAt: new Date().toISOString(),
+    });
+
+    return result;
   }
 
   // ─── Unread + Search ────────────────────────────────────

--- a/apps/web/src/pages/UnifiedInboxPage/index.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/index.tsx
@@ -70,7 +70,7 @@ export default function UnifiedInboxPage() {
   }, [activeRoomId]);
 
   // WebSocket for real-time updates
-  const { joinRoom, leaveRoom, sendMessage, viewRoom, isCustomerTyping } = useChatSocket({
+  const { joinRoom, leaveRoom, viewRoom, isCustomerTyping } = useChatSocket({
     onNewMessage: (data) => {
       queryClient.invalidateQueries({ queryKey: ['chat-messages', data.roomId] });
       queryClient.invalidateQueries({ queryKey: ['chat-rooms'] });
@@ -175,27 +175,39 @@ export default function UnifiedInboxPage() {
     [activeRoomId, joinRoom, leaveRoom],
   );
 
+  // Send via HTTP — WS is unreliable behind some proxies, so HTTP is the
+  // source of truth for sending. WS is still used to receive real-time updates.
+  const sendRoomMessage = async (text: string) => {
+    if (!activeRoomId) return;
+    try {
+      const { data } = await api.post<{ success: boolean; error?: string }>(
+        `/staff-chat/rooms/${activeRoomId}/messages`,
+        { text },
+      );
+      if (data && data.success === false) {
+        toast.error(`ส่งข้อความไม่สำเร็จ${data.error ? ` — ${data.error}` : ''}`);
+      }
+    } catch (err) {
+      const e = err as { response?: { data?: { error?: string; message?: string } } };
+      toast.error(e?.response?.data?.error ?? e?.response?.data?.message ?? 'ส่งข้อความไม่สำเร็จ');
+    }
+    queryClient.invalidateQueries({ queryKey: ['chat-messages', activeRoomId] });
+  };
+
   const handleSendMessage = useCallback(
     (text: string) => {
-      if (!activeRoomId) return;
-      sendMessage(activeRoomId, text);
-      // Optimistic: invalidate messages
-      setTimeout(() => {
-        queryClient.invalidateQueries({ queryKey: ['chat-messages', activeRoomId] });
-      }, 300);
+      void sendRoomMessage(text);
     },
-    [activeRoomId, sendMessage, queryClient],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeRoomId, queryClient],
   );
 
   const handleSendSticker = useCallback(
     ({ packageId, stickerId }: { packageId: number; stickerId: number }) => {
-      if (!activeRoomId) return;
-      sendMessage(activeRoomId, `[sticker:${packageId}:${stickerId}]`);
-      setTimeout(() => {
-        queryClient.invalidateQueries({ queryKey: ['chat-messages', activeRoomId] });
-      }, 300);
+      void sendRoomMessage(`[sticker:${packageId}:${stickerId}]`);
     },
-    [activeRoomId, sendMessage, queryClient],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeRoomId, queryClient],
   );
 
   const uploadFileMutation = useMutation({
@@ -229,7 +241,7 @@ export default function UnifiedInboxPage() {
   const customerId = sessionQuery.data?.customerId ?? null;
 
   return (
-    <div className="h-screen flex bg-card overflow-hidden">
+    <div className="h-screen flex bg-card overflow-hidden pb-[calc(56px+env(safe-area-inset-bottom))] lg:pb-0">
       {/* Left panel: Conversation list */}
       <div className={`w-80 flex-shrink-0 min-h-0 ${activeRoomId ? 'hidden lg:flex lg:flex-col' : 'flex flex-col w-full lg:w-80'}`}>
         <QueryBoundary


### PR DESCRIPTION
## Summary
- Switch chat send from WS-only emit to HTTP POST `/staff-chat/rooms/:id/messages` — emit on a disconnected socket was a silent no-op, so staff would type, see the input clear, and have nothing reach the customer
- Reserve space for `MobileBottomNav` in the inbox root so the textarea isn't hidden behind the fixed bottom nav on viewports below `lg` (full-bleed routes drop `TopBar` but didn't account for `MobileBottomNav`)
- Mirror commit ee3d8152 by emitting `chat:message:new` from the room HTTP endpoint so other staff still see new messages in real-time after the send-path move

## Test plan
- [ ] Desktop: open `/inbox`, pick a LINE room, type and send — message saves, appears in feed, customer LINE receives it
- [ ] Desktop: kill WS in DevTools (Network → block `socket.io`), send again — message still goes through (HTTP), toast on failure
- [ ] Narrow viewport (< 1024px or DevTools docked right): textarea visible above the bottom nav, typing works
- [ ] Two staff windows on the same room: send from window A → window B sees it within ~ms (WS broadcast still works)
- [ ] Sticker send: emoji picker → sticker still delivers via HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)