### PR TITLE
fix(inbox): drop eslint-disable for unregistered react-hooks rule

### DIFF
--- a/apps/web/src/pages/UnifiedInboxPage/index.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/index.tsx
@@ -198,7 +198,6 @@ export default function UnifiedInboxPage() {
     (text: string) => {
       void sendRoomMessage(text);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeRoomId, queryClient],
   );
 
@@ -206,7 +205,6 @@ export default function UnifiedInboxPage() {
     ({ packageId, stickerId }: { packageId: number; stickerId: number }) => {
       void sendRoomMessage(`[sticker:${packageId}:${stickerId}]`);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeRoomId, queryClient],
   );
 


### PR DESCRIPTION
## Summary
- Follow-up to #706 — its CI lint failed because the eslint config doesn't load the `react-hooks` plugin, so the two `// eslint-disable-next-line react-hooks/exhaustive-deps` comments referenced an undefined rule and were promoted to errors
- Removing the comments is sufficient: the closures already capture the right deps (activeRoomId, queryClient)

## Test plan
- [x] `npx eslint src/pages/UnifiedInboxPage/index.tsx` — 0 errors
- [ ] CI lint job passes
- [ ] GCP deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)