### PR TITLE
fix(trade-in): resolve branchId from user when not in payload

### DIFF
--- a/apps/api/src/modules/trade-in/trade-in.controller.ts
+++ b/apps/api/src/modules/trade-in/trade-in.controller.ts
@@ -124,8 +124,12 @@ export class TradeInController {
   // Quick Buy — 1-shot create + appraise + accept + voucher allocate
   @Post('quick-buy')
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
-  quickBuy(@Body() dto: QuickBuyTradeInDto, @CurrentUser('id') userId: string) {
-    return this.tradeInService.quickBuy(dto, userId);
+  quickBuy(
+    @Body() dto: QuickBuyTradeInDto,
+    @CurrentUser('id') userId: string,
+    @CurrentUser('branchId') userBranchId: string | null,
+  ) {
+    return this.tradeInService.quickBuy(dto, userId, userBranchId);
   }
 
   // Seller history (auto-fill + repeat warning)

--- a/apps/api/src/modules/trade-in/trade-in.service.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.ts
@@ -582,11 +582,25 @@ export class TradeInService {
    *  - ถ้า fail กลางทาง → record ค้างใน intermediate state (PENDING/APPRAISED)
    *    ซึ่งสามารถกู้คืนได้ผ่าน legacy modals (appraise/accept ทีละขั้น)
    */
-  async quickBuy(dto: QuickBuyTradeInDto, userId: string) {
+  async quickBuy(
+    dto: QuickBuyTradeInDto,
+    userId: string,
+    userBranchId?: string | null,
+  ) {
+    // Resolve branch — prefer DTO (explicit pick), fall back to user's home branch.
+    // OWNER/cross-branch users have no default branch, so they must pass branchId
+    // explicitly; surface a clear error instead of letting accept() fail later.
+    const branchId = dto.branchId ?? userBranchId ?? null;
+    if (!branchId) {
+      throw new BadRequestException(
+        'กรุณาเลือกสาขาที่รับซื้อก่อน — บัญชีของคุณไม่ได้ผูกกับสาขาเริ่มต้น',
+      );
+    }
+
     // ─── Stage 1: Create (PENDING_APPRAISAL) ───
     // ใช้ create() เดิม — validation seller/IMEI dup/ID card upload เกิดที่นี่
     const created = await this.create({
-      branchId: dto.branchId,
+      branchId,
       deviceBrand: dto.deviceBrand,
       deviceModel: dto.deviceModel,
       deviceStorage: dto.deviceStorage,

--- a/apps/web/src/components/trade-in/QuickBuyModal.tsx
+++ b/apps/web/src/components/trade-in/QuickBuyModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
 import { readSmartCard } from '@/lib/cardReader';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -43,6 +44,7 @@ const conditionOptions = [
 ];
 
 export default function QuickBuyModal({ open, onClose, onSuccess }: QuickBuyModalProps) {
+  const { user } = useAuth();
   const [step, setStep] = useState(1);
   const [imeiCheckResult, setImeiCheckResult] = useState<{ result: 'clean' | 'duplicate'; count: number } | null>(null);
   const [sellerHistory, setSellerHistory] = useState<SellerHistoryResponse | null>(null);
@@ -96,6 +98,7 @@ export default function QuickBuyModal({ open, onClose, onSuccess }: QuickBuyModa
   const quickBuyMutation = useMutation({
     mutationFn: async () => {
       const payload = {
+        branchId: user?.branchId ?? undefined,
         sellerName: form.sellerName,
         sellerPhone: form.sellerPhone || undefined,
         sellerIdCardNumber: form.sellerIdCardNumber || undefined,


### PR DESCRIPTION
## Summary
- `QuickBuyModal` didn't send `branchId`, so the trade-in record stored `branchId=null` and the accept stage later failed with `รายการเทรดอินไม่มีข้อมูลสาขา — ไม่สามารถรับเข้าสต๊อคได้`
- Frontend now sends `user.branchId` from `AuthContext`; backend controller forwards `@CurrentUser('branchId')`; service prefers `dto.branchId`, falls back to `userBranchId`, and throws a clear error up front when both are missing (OWNER with no default branch)

## Test plan
- [ ] Sign in as `manager.ladprao@bestchoice.com` (BRANCH_MANAGER) → /trade-in → quick buy flow → submit → record created with branchId set, voucher issued
- [ ] Sign in as `admin@bestchoice.com` (OWNER, no default branch) → quick buy → expect `กรุณาเลือกสาขาที่รับซื้อก่อน — บัญชีของคุณไม่ได้ผูกกับสาขาเริ่มต้น` toast at submit (instead of silent record + failure later)
- [ ] Existing trade-ins with `branchId=null` still surface the original receive-into-stock error (no regression)

## Follow-up
- Add a branch picker in `QuickBuyModal` for OWNER — out of scope for this hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)