### PR TITLE
feat(inbox): group recent payments by งวด with expandable partials

### DIFF
--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -884,24 +884,74 @@ export class CustomersService {
     // Verify customer exists
     await this.findOne(customerId);
 
-    // 1. Recent payments across all contracts (last 5)
-    const recentPayments = await this.prisma.payment.findMany({
+    // 1. Recent installments grouped from the last 5 distinct paymentIds with
+    //    a non-voided receipt. Returns each installment with all of its
+    //    non-voided receipts so the UI can show partial-payment breakdowns
+    //    (1 งวด → N partials).
+    const recentReceipts = await this.prisma.receipt.findMany({
       where: {
         contract: { customerId, deletedAt: null },
         deletedAt: null,
-        status: 'PAID',
+        isVoided: false,
+        paymentId: { not: null },
       },
       orderBy: { paidDate: 'desc' },
-      take: 5,
+      take: 30, // over-fetch so grouping yields up to 5 distinct installments
       select: {
         id: true,
-        installmentNo: true,
-        amountPaid: true,
+        receiptNumber: true,
+        amount: true,
         paidDate: true,
         paymentMethod: true,
+        installmentNo: true,
+        paymentId: true,
         contract: { select: { contractNumber: true } },
       },
     });
+
+    const paymentIds = Array.from(
+      new Set(recentReceipts.map((r) => r.paymentId).filter((id): id is string => !!id)),
+    ).slice(0, 5);
+
+    const payments = paymentIds.length
+      ? await this.prisma.payment.findMany({
+          where: { id: { in: paymentIds } },
+          select: {
+            id: true,
+            installmentNo: true,
+            amountDue: true,
+            amountPaid: true,
+            status: true,
+            contract: { select: { contractNumber: true } },
+          },
+        })
+      : [];
+    const paymentMap = new Map(payments.map((p) => [p.id, p]));
+
+    const recentPayments = paymentIds
+      .map((pid) => {
+        const p = paymentMap.get(pid);
+        if (!p) return null;
+        const partials = recentReceipts
+          .filter((r) => r.paymentId === pid)
+          .map((r) => ({
+            id: r.id,
+            receiptNumber: r.receiptNumber,
+            amount: r.amount,
+            paidDate: r.paidDate,
+            paymentMethod: r.paymentMethod,
+          }));
+        return {
+          id: p.id,
+          installmentNo: p.installmentNo,
+          amountDue: p.amountDue,
+          amountPaid: p.amountPaid,
+          status: p.status,
+          contract: p.contract,
+          partials,
+        };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
 
     // 2. Overdue summary
     const overduePayments = await this.prisma.payment.count({

--- a/apps/web/src/pages/UnifiedInboxPage/components/Customer360Panel.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/Customer360Panel.tsx
@@ -23,6 +23,10 @@ import {
   ExternalLink,
   Zap,
   Shield,
+  ChevronRight,
+  Banknote,
+  Landmark,
+  QrCode,
 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -47,12 +51,22 @@ interface ContractSummaryItem {
   shopWarrantyEndDate?: string;
 }
 
+interface PaymentPartial {
+  id: string;
+  receiptNumber: string;
+  amount: number | string;
+  paidDate: string;
+  paymentMethod: string | null;
+}
+
 interface PaymentSummaryItem {
   id: string;
   contract?: { contractNumber: string };
   installmentNo: number;
+  amountDue: number | string;
   amountPaid: number | string;
-  paidDate?: string;
+  status: string;
+  partials: PaymentPartial[];
 }
 
 interface ChatSessionItem {
@@ -600,22 +614,7 @@ export default function Customer360Panel({ customerId, activeRoomId, onSelectRoo
         {summary?.recentPayments?.length > 0 ? (
           <div className="space-y-1.5">
             {(summary.recentPayments as PaymentSummaryItem[]).map((p) => (
-              <div key={p.id} className="flex items-center justify-between text-xs">
-                <div>
-                  <span className="text-foreground/80">{p.contract?.contractNumber}</span>
-                  <span className="text-muted-foreground ml-1">งวด {p.installmentNo}</span>
-                </div>
-                <div className="text-right">
-                  <span className="font-medium text-success">
-                    {Number(p.amountPaid).toLocaleString()} บ.
-                  </span>
-                  {p.paidDate && (
-                    <p className="text-[10px] text-muted-foreground">
-                      {format(new Date(p.paidDate), 'dd/MM/yy')}
-                    </p>
-                  )}
-                </div>
-              </div>
+              <RecentPaymentGroup key={p.id} payment={p} />
             ))}
           </div>
         ) : (
@@ -1118,6 +1117,119 @@ function InternalNotesSection({ roomId, notes }: { roomId: string; notes: Intern
 }
 
 // ─── Sub-components ───────────────────────────────────────
+
+const paymentMethodMeta: Record<string, { label: string; icon: typeof Banknote; className: string }> = {
+  CASH:           { label: 'เงินสด', icon: Banknote,   className: 'bg-success/10 text-success' },
+  BANK_TRANSFER:  { label: 'โอน',    icon: Landmark,   className: 'bg-info/10 text-info' },
+  QR_EWALLET:     { label: 'QR',     icon: QrCode,     className: 'bg-primary/10 text-primary' },
+  ONLINE_GATEWAY: { label: 'ออนไลน์', icon: CreditCard, className: 'bg-accent text-accent-foreground' },
+};
+
+function PaymentMethodChip({ method }: { method: string | null | undefined }) {
+  if (!method) return <span className="text-[10px] text-muted-foreground">—</span>;
+  const meta = paymentMethodMeta[method];
+  if (!meta) {
+    return (
+      <span className="inline-flex items-center px-1 py-px rounded text-[9px] font-medium bg-muted text-muted-foreground">
+        {method}
+      </span>
+    );
+  }
+  const Icon = meta.icon;
+  return (
+    <span className={`inline-flex items-center gap-0.5 px-1 py-px rounded text-[9px] font-medium ${meta.className}`}>
+      <Icon className="w-2.5 h-2.5" />
+      {meta.label}
+    </span>
+  );
+}
+
+function RecentPaymentGroup({ payment }: { payment: PaymentSummaryItem }) {
+  const [open, setOpen] = useState(false);
+  const isPartial = payment.status === 'PARTIALLY_PAID';
+  const due = Number(payment.amountDue);
+  const paid = Number(payment.amountPaid);
+  const partialCount = payment.partials.length;
+  const expandable = partialCount > 1 || isPartial;
+
+  return (
+    <div className="rounded-md bg-muted/30 border border-border/50 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => expandable && setOpen((o) => !o)}
+        className={cn(
+          'w-full grid grid-cols-[12px_1fr_auto] items-center gap-2 px-2 py-1.5 text-left',
+          expandable ? 'cursor-pointer hover:bg-muted/50' : 'cursor-default',
+        )}
+      >
+        {expandable ? (
+          <ChevronRight
+            className={cn(
+              'w-3 h-3 text-muted-foreground transition-transform',
+              open && 'rotate-90',
+            )}
+          />
+        ) : (
+          <span />
+        )}
+        <div className="min-w-0">
+          <div className="text-[11px] text-foreground/90 truncate">
+            <span className="font-mono text-info">{payment.contract?.contractNumber}</span>
+            <span className="text-muted-foreground"> · งวด {payment.installmentNo}</span>
+          </div>
+          <div className="text-[9px] text-muted-foreground flex items-center gap-1.5 mt-0.5">
+            {partialCount > 1 && <span>{partialCount} ครั้ง</span>}
+            {partialCount > 1 && (isPartial || partialCount === 1) && <span>·</span>}
+            <span
+              className={cn(
+                'inline-flex items-center px-1 py-px rounded text-[9px] font-semibold',
+                isPartial
+                  ? 'bg-warning/10 text-warning'
+                  : 'bg-success/10 text-success',
+              )}
+            >
+              {isPartial ? 'ชำระบางส่วน' : 'ครบ'}
+            </span>
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <div className="text-xs font-semibold text-success tabular-nums">
+            {paid.toLocaleString()} บ.
+          </div>
+          {isPartial && (
+            <div className="text-[9px] text-warning tabular-nums">
+              / {due.toLocaleString()}
+            </div>
+          )}
+        </div>
+      </button>
+
+      {open && expandable && (
+        <div className="border-t border-border/50 bg-background/40">
+          {payment.partials.map((r, idx) => (
+            <div
+              key={r.id}
+              className="grid grid-cols-[16px_1fr_auto] items-center gap-2 pl-6 pr-2 py-1 text-[10px] border-t border-border/30 first:border-t-0"
+            >
+              <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-muted text-muted-foreground text-[9px] font-semibold tabular-nums">
+                {partialCount - idx}
+              </span>
+              <div className="flex items-center gap-1.5 min-w-0">
+                <PaymentMethodChip method={r.paymentMethod} />
+                <span className="text-muted-foreground truncate">
+                  {format(new Date(r.paidDate), 'dd/MM HH:mm')}
+                </span>
+              </div>
+              <span className="font-medium text-foreground tabular-nums">
+                {Number(r.amount).toLocaleString()}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function SectionHeader({ icon: Icon, label }: { icon: any; label: string }) {
   return (


### PR DESCRIPTION
## Summary
Customer 360 panel \"การชำระล่าสุด\" now groups payments by งวด and lets you expand each one to see partial-payment history (option A from `mockups/recent-payments-panel-v2.html`).

### API
- `customers.service.ts` queries the last 30 non-voided receipts (skipping `paymentId: null`), groups by `paymentId`, takes top 5 installments, and joins each to its Payment row for `amountDue` / `amountPaid` / `status`
- Each entry returns `partials[]` with `{id, receiptNumber, amount, paidDate, paymentMethod}`

### UI
- New `RecentPaymentGroup` component: 1 line per งวด by default; chevron + click to expand the partial breakdown
- Trigger shows partial count, \"ชำระบางส่วน\" / \"ครบ\" pill, paid total with running \"/ amountDue\" when partial
- Each partial row: sequence number bubble, method badge (Cash / Bank / QR / Online), date+time, amount

## Test plan
- [ ] Inbox → pick a customer with a งวด paid in multiple partials → row shows \"3 ครั้ง · ชำระบางส่วน\" + \"5,000 / 6,125.63\"
- [ ] Click row → 3 partial rows appear ordered newest-first, each with method chip + timestamp + amount
- [ ] Single-payment งวด stays collapsed (no chevron)
- [ ] Customer with zero receipts → shows \"ยังไม่มีการชำระ\" (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)