### PR TITLE
feat(inbox): render payment Flex Card as preview bubble + fix URL overflow

### DIFF
--- a/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
+++ b/apps/api/src/modules/line-oa/line-oa-payment.controller.ts
@@ -798,20 +798,26 @@ export class LineOaPaymentController {
     // Create payment link
     const linkResult = await this.paymentLinkService.createPaymentLink(body.contractId);
 
-    // Build flex
+    // Build flex + capture meta for inbox preview
+    const totalInstallments = await this.prisma.payment.count({
+      where: { contractId: contract.id, deletedAt: null },
+    });
+    const lateFeeTotal = overduePayments.reduce((sum, p) => sum + d(p.lateFee), 0);
+    const firstPayment = contract.payments[0];
+
     const flex = isOverdue
       ? this.flexTemplates.overdueNotice({
           contractNumber: contract.contractNumber,
           overdueInstallments: overduePayments.length,
           totalAmount: linkResult.amount,
-          lateFee: overduePayments.reduce((sum, p) => sum + d(p.lateFee), 0),
+          lateFee: lateFeeTotal,
           paymentUrl: linkResult.url,
         })
       : this.flexTemplates.paymentReminder({
           contractNumber: contract.contractNumber,
-          installmentNo: contract.payments[0].installmentNo,
+          installmentNo: firstPayment.installmentNo,
           amount: linkResult.amount,
-          dueDate: formatDateShort(contract.payments[0].dueDate),
+          dueDate: formatDateShort(firstPayment.dueDate),
           paymentUrl: linkResult.url,
         });
 
@@ -835,12 +841,29 @@ export class LineOaPaymentController {
     });
 
     if (room) {
+      // Pipe-encoded meta so inbox can render a preview card matching the LINE Flex
+      // Format (reminder): [flex:payment-reminder|<contractNo>|<installmentNo>/<total>|<amount>|<dueDate>|<daysUntilDue>] <url>
+      // Format (overdue):  [flex:overdue-notice|<contractNo>|<overdueCount>|<amount>|<lateFee>|<oldestDueDate>] <url>
+      const metaText = isOverdue
+        ? (() => {
+            const oldest = overduePayments[0];
+            const oldestDue = oldest?.dueDate ? formatDateShort(oldest.dueDate) : '';
+            return `[flex:overdue-notice|${contract.contractNumber}|${overduePayments.length}|${linkResult.amount}|${lateFeeTotal}|${oldestDue}] ${linkResult.url}`;
+          })()
+        : (() => {
+            const dueDateStr = formatDateShort(firstPayment.dueDate);
+            const daysUntilDue = firstPayment.dueDate
+              ? Math.ceil((new Date(firstPayment.dueDate).getTime() - now.getTime()) / 86400000)
+              : 0;
+            return `[flex:payment-reminder|${contract.contractNumber}|${firstPayment.installmentNo}/${totalInstallments}|${linkResult.amount}|${dueDateStr}|${daysUntilDue}] ${linkResult.url}`;
+          })();
+
       await this.prisma.chatMessage.create({
         data: {
           roomId: room.id,
           role: MessageRole.STAFF,
           type: MessageType.TEXT,
-          text: `[${isOverdue ? 'แจ้งค้างชำระ' : 'แจ้งเตือนค่างวด'} - Flex Card] ${linkResult.url}`,
+          text: metaText,
           staffId: req.user.id,
         },
       });

--- a/apps/web/src/pages/UnifiedInboxPage/components/ConversationItem.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/ConversationItem.tsx
@@ -6,6 +6,17 @@ import { Badge } from '@/components/ui/badge';
 import { getStatusBadgeProps, sessionPriorityMap } from '@/lib/status-badges';
 import { useState } from 'react';
 
+/** Map sentinel-prefixed message bodies to a human-friendly preview. */
+function formatMessagePreview(text: string | null | undefined): string {
+  if (!text) return '(ข้อความสื่อ)';
+  if (text.startsWith('[flex:payment-reminder')) return '📋 แจ้งเตือนค่างวด (Flex Card)';
+  if (text.startsWith('[flex:overdue-notice')) return '⚠️ แจ้งค้างชำระ (Flex Card)';
+  if (text === '[flex:verify]') return '🔐 ยืนยันตัวตน (Flex Card)';
+  if (text.startsWith('[gif:')) return '(GIF)';
+  if (text.match(/^\[sticker:\d+:\d+\]$/)) return '(สติกเกอร์)';
+  return text;
+}
+
 interface ConversationItemProps {
   session: {
     id: string;
@@ -126,7 +137,7 @@ export default function ConversationItem({ session, isActive, onClick, onPin }: 
           )}>
             {lastMessage?.role === 'STAFF' && <span className="text-primary font-medium">คุณ: </span>}
             {lastMessage?.role === 'BOT' && <span className="text-muted-foreground font-medium">Bot: </span>}
-            {lastMessage?.text ?? '(ข้อความสื่อ)'}
+            {formatMessagePreview(lastMessage?.text)}
           </p>
           {hasUnread && (
             <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-primary text-primary-foreground text-[10px] font-bold leading-snug flex-shrink-0">

--- a/apps/web/src/pages/UnifiedInboxPage/components/MessageBubble.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils';
 import { format } from 'date-fns';
+import { PaymentFlexPreview, parsePaymentFlex } from './PaymentFlexPreview';
 
 interface MessageBubbleProps {
   message: {
@@ -60,6 +61,33 @@ export default function MessageBubble({ message, customerAvatar, customerInitial
             </span>
             {isStaff && (
               <span className={cn('text-[10px] ml-1', message.readAt ? 'text-info' : 'text-muted-foreground')}>
+                {message.readAt ? '✓✓' : '✓'}
+              </span>
+            )}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Payment Flex Card — preview the bubble customer received in LINE
+  const paymentFlex = parsePaymentFlex(message.text);
+  if (paymentFlex) {
+    return (
+      <div className={cn('flex gap-2 mb-3', isCustomer ? 'justify-start' : 'justify-end')}>
+        <div className="flex flex-col max-w-[75%] items-end">
+          {(isBot || isStaff) && (
+            <span className="text-[10px] text-muted-foreground mb-0.5 px-1">
+              {isBot ? 'Bot' : message.staff?.name ?? 'พนักงาน'}
+            </span>
+          )}
+          <PaymentFlexPreview data={paymentFlex} />
+          <span className="flex items-center mt-0.5 px-1">
+            <span className="text-[10px] text-muted-foreground">
+              {format(new Date(message.createdAt), 'HH:mm')}
+            </span>
+            {isStaff && (
+              <span className={cn('text-[10px] ml-1', message.readAt ? 'text-primary' : 'text-muted-foreground')}>
                 {message.readAt ? '✓✓' : '✓'}
               </span>
             )}
@@ -177,7 +205,7 @@ export default function MessageBubble({ message, customerAvatar, customerInitial
         {/* Bubble */}
         <div
           className={cn(
-            'px-3.5 py-2 rounded-2xl text-sm leading-relaxed',
+            'max-w-full min-w-0 px-3.5 py-2 rounded-2xl text-sm leading-relaxed [overflow-wrap:anywhere]',
             isCustomer
               ? 'bg-muted text-foreground rounded-bl-md'
               : isBot
@@ -196,7 +224,7 @@ export default function MessageBubble({ message, customerAvatar, customerInitial
           )}
 
           {/* Text */}
-          {message.text && <p className="whitespace-pre-wrap break-words">{message.text}</p>}
+          {message.text && <p className="whitespace-pre-wrap">{message.text}</p>}
         </div>
 
         {/* Timestamp + Read receipt */}

--- a/apps/web/src/pages/UnifiedInboxPage/components/PaymentFlexPreview.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/PaymentFlexPreview.tsx
@@ -1,0 +1,179 @@
+import { CreditCard, AlertTriangle, ExternalLink } from 'lucide-react';
+
+/**
+ * Compact preview card shown in the inbox when staff sends a payment Flex Card
+ * via LINE Finance. Mimics the bubble customers see in LINE so staff have
+ * visual confirmation without parsing raw URLs.
+ *
+ * Encoded by line-oa-payment.controller.ts as:
+ *   [flex:payment-reminder|<contractNo>|<inst>/<total>|<amount>|<dueDate>|<daysUntilDue>] <url>
+ *   [flex:overdue-notice|<contractNo>|<overdueCount>|<amount>|<lateFee>|<oldestDueDate>] <url>
+ */
+
+const FLEX_REGEX = /^\[flex:(payment-reminder|overdue-notice)\|([^\]]+)\]\s+(https?:\/\/\S+)/;
+
+export interface ParsedPaymentFlex {
+  kind: 'payment-reminder' | 'overdue-notice';
+  contractNumber: string;
+  amount: number;
+  url: string;
+  // reminder-only
+  installmentLabel?: string;
+  dueDate?: string;
+  daysUntilDue?: number;
+  // overdue-only
+  overdueCount?: number;
+  lateFee?: number;
+  oldestDueDate?: string;
+}
+
+export function parsePaymentFlex(text: string | null | undefined): ParsedPaymentFlex | null {
+  if (!text) return null;
+  const m = text.match(FLEX_REGEX);
+  if (!m) return null;
+  const [, kind, payload, url] = m;
+  const parts = payload.split('|');
+
+  if (kind === 'payment-reminder') {
+    const [contractNumber, installmentLabel, amountStr, dueDate, daysStr] = parts;
+    const amount = Number(amountStr);
+    if (!Number.isFinite(amount)) return null;
+    return {
+      kind: 'payment-reminder',
+      contractNumber,
+      installmentLabel,
+      amount,
+      dueDate,
+      daysUntilDue: Number(daysStr),
+      url,
+    };
+  }
+
+  // overdue-notice
+  const [contractNumber, overdueCountStr, amountStr, lateFeeStr, oldestDueDate] = parts;
+  const amount = Number(amountStr);
+  if (!Number.isFinite(amount)) return null;
+  return {
+    kind: 'overdue-notice',
+    contractNumber,
+    amount,
+    overdueCount: Number(overdueCountStr),
+    lateFee: Number(lateFeeStr),
+    oldestDueDate,
+    url,
+  };
+}
+
+const formatBaht = (n: number) =>
+  n.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+export function PaymentFlexPreview({ data }: { data: ParsedPaymentFlex }) {
+  if (data.kind === 'overdue-notice') {
+    return (
+      <div className="w-[260px] rounded-2xl overflow-hidden border border-border bg-card shadow-sm">
+        <div className="px-3.5 py-2.5 text-white bg-gradient-to-br from-red-500 to-red-700">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="text-[10px] opacity-90 leading-snug">BESTCHOICE FINANCE</div>
+              <div className="text-sm font-semibold leading-snug mt-0.5 flex items-center gap-1.5">
+                <AlertTriangle className="size-3.5" />
+                แจ้งค้างชำระ
+              </div>
+            </div>
+            <span className="text-[10px] px-2 py-0.5 rounded-full bg-white/25 font-semibold whitespace-nowrap">
+              {data.overdueCount} งวด
+            </span>
+          </div>
+        </div>
+        <div className="px-3.5 py-3">
+          <div className="rounded-lg p-3 mb-2.5 bg-red-50 border border-red-100">
+            <div className="text-[10px] text-muted-foreground">ยอดค้างชำระ</div>
+            <div className="text-xl font-bold text-red-600 leading-tight my-1">
+              ฿{formatBaht(data.amount)}
+            </div>
+            {data.oldestDueDate && (
+              <div className="text-[11px] text-muted-foreground">
+                ครบกำหนดเมื่อ {data.oldestDueDate}
+              </div>
+            )}
+          </div>
+          <div className="flex justify-between text-xs py-1">
+            <span className="text-muted-foreground">สัญญา</span>
+            <span className="font-semibold">{data.contractNumber}</span>
+          </div>
+          {!!data.lateFee && data.lateFee > 0 && (
+            <div className="flex justify-between text-xs py-1">
+              <span className="text-muted-foreground">ค่าปรับล่าช้า</span>
+              <span className="font-semibold text-red-600">฿{formatBaht(data.lateFee)}</span>
+            </div>
+          )}
+        </div>
+        <FlexFooter url={data.url} />
+      </div>
+    );
+  }
+
+  // payment-reminder
+  const days = data.daysUntilDue ?? 0;
+  const isUrgent = days <= 1;
+  const headerClass = isUrgent
+    ? 'bg-gradient-to-br from-amber-500 to-orange-600'
+    : 'bg-gradient-to-br from-emerald-500 to-emerald-700';
+  const badgeText = days === 0 ? 'วันนี้' : days === 1 ? 'พรุ่งนี้' : `อีก ${days} วัน`;
+  const amountClass = isUrgent ? 'text-orange-600' : 'text-emerald-600';
+  const cardBg = isUrgent ? 'bg-orange-50 border-orange-100' : 'bg-emerald-50 border-emerald-100';
+
+  return (
+    <div className="w-[260px] rounded-2xl overflow-hidden border border-border bg-card shadow-sm">
+      <div className={`px-3.5 py-2.5 text-white ${headerClass}`}>
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="text-[10px] opacity-90 leading-snug">BESTCHOICE FINANCE</div>
+            <div className="text-sm font-semibold leading-snug mt-0.5 flex items-center gap-1.5">
+              <CreditCard className="size-3.5" />
+              แจ้งเตือนค่างวด
+            </div>
+          </div>
+          <span className="text-[10px] px-2 py-0.5 rounded-full bg-white/25 font-semibold whitespace-nowrap">
+            {badgeText}
+          </span>
+        </div>
+      </div>
+      <div className="px-3.5 py-3">
+        <div className={`rounded-lg p-3 mb-2.5 border ${cardBg}`}>
+          <div className="text-[10px] text-muted-foreground">
+            ยอดชำระ {data.installmentLabel ? `· งวด ${data.installmentLabel}` : ''}
+          </div>
+          <div className={`text-xl font-bold leading-tight my-1 ${amountClass}`}>
+            ฿{formatBaht(data.amount)}
+          </div>
+          {data.dueDate && (
+            <div className="text-[11px] text-muted-foreground">ครบกำหนด {data.dueDate}</div>
+          )}
+        </div>
+        <div className="flex justify-between text-xs py-1">
+          <span className="text-muted-foreground">สัญญา</span>
+          <span className="font-semibold">{data.contractNumber}</span>
+        </div>
+      </div>
+      <FlexFooter url={data.url} />
+    </div>
+  );
+}
+
+function FlexFooter({ url }: { url: string }) {
+  return (
+    <div className="px-3.5 py-1.5 bg-muted/50 border-t border-border flex items-center justify-between">
+      <span className="text-[9px] text-muted-foreground">Flex Card · ส่งให้ลูกค้าใน LINE แล้ว</span>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-[9px] text-info hover:underline inline-flex items-center gap-0.5"
+      >
+        เปิดลิงก์
+        <ExternalLink className="size-2.5" />
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/components/MessageBubble.tsx
+++ b/apps/web/src/pages/chat/components/MessageBubble.tsx
@@ -40,7 +40,7 @@ export function MessageBubble({ message }: { message: Message }) {
     <div className={cn('flex', isCustomer ? 'justify-start' : 'justify-end')}>
       <div
         className={cn(
-          'max-w-[75%] rounded-lg px-3 py-2 text-sm leading-snug whitespace-pre-wrap break-words',
+          'max-w-[75%] min-w-0 rounded-lg px-3 py-2 text-sm leading-snug whitespace-pre-wrap [overflow-wrap:anywhere]',
           isCustomer
             ? 'bg-muted text-foreground'
             : 'bg-primary text-primary-foreground',


### PR DESCRIPTION
## Summary
- Inbox `/inbox` แสดง Flex Card ที่ส่งให้ลูกค้าใน LINE เป็น preview bubble (เลียน Style C ของ flex-templates) แทนการโชว์ URL ดิบยาวๆ
- รองรับ 2 ประเภท: payment-reminder (เขียว/ส้ม ตาม urgency) และ overdue-notice (แดง)
- แก้ bug URL ยาวทะลุขอบ chat bubble — สลับ break-words → overflow-wrap:anywhere + เพิ่ม min-w-0

## Changes
- line-oa-payment.controller.ts — encode meta ใน ChatMessage text เป็น [flex:payment-reminder|...] / [flex:overdue-notice|...] แทนข้อความเดิม
- PaymentFlexPreview.tsx (ใหม่) — preview card component + parser
- MessageBubble.tsx (UnifiedInbox + chat) — wire renderer + แก้ overflow URL
- ConversationItem.tsx — list preview แสดง label สั้นๆ แทน raw URL
- mockups/inbox-flex-card-preview.html — design reference

## Backwards compat
ข้อความเก่าที่บันทึกแบบ "[แจ้งเตือนค่างวด - Flex Card] URL" จะแสดงเป็น text bubble ปกติ (ไม่ render เป็น card) แต่ URL ไม่ทะลุขอบแล้ว ไม่ต้อง backfill

## Test plan
- [ ] เปิด /inbox เลือกห้องที่มี payment Flex Card (ใหม่) → เห็น preview card สวยงาม
- [ ] กดปุ่ม "เปิดลิงก์" → เปิด payment URL ใน tab ใหม่
- [ ] ห้องที่มีข้อความเก่า → URL ไม่ทะลุขอบ
- [ ] ConversationList preview แสดง label สั้นๆ สำหรับห้องที่ส่ง flex ล่าสุด

🤖 Generated with [Claude Code](https://claude.com/claude-code)