### PR TITLE
fix(menu): show ผังบัญชี + ตรวจสอบบัญชี in OWNER sidebar

### DIFF
--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -358,6 +358,8 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
         { label: 'ภาษี', path: '/tax-reports', icon: Calculator },
         { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
+        { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
+        { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
       ],
     },
     {


### PR DESCRIPTION
Both pages existed and OWNER had route access, but the menu entries lived only in ACCOUNTANT_CONFIG — OWNER had to type the URL by hand. Adds them under OWNER's 'บัญชี & รายงาน' group, next to 'ปิดบัญชีรายเดือน'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)