### PR TITLE
feat(accounting): Phase A.0 critical fix — math + try/catch + webhook + period close

### DIFF
--- a/apps/api/prisma/migrations/20260612000001_add_period_reopen_audit_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260612000001_add_period_reopen_audit_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "accounting_periods" ADD COLUMN     "reopened_at" TIMESTAMP(3),
+ADD COLUMN     "reopened_by_id" TEXT,
+ADD COLUMN     "board_resolution_id" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "accounting_periods" ADD CONSTRAINT "accounting_periods_reopened_by_id_fkey" FOREIGN KEY ("reopened_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -635,6 +635,7 @@ model User {
   dunningActionsExecuted      DunningAction[]           @relation("DunningActionExecutor")
   periodsReviewStarted        AccountingPeriod[]        @relation("PeriodReviewStartedBy")
   periodsClosed               AccountingPeriod[]        @relation("PeriodClosedBy")
+  periodsReopened             AccountingPeriod[]        @relation("PeriodReopenedBy")
   broadcastMessages           BroadcastMessage[]        @relation("BroadcastCreatedBy")
   broadcastsApproved          BroadcastMessage[]        @relation("BroadcastApprovedBy")
   broadcastsRejected          BroadcastMessage[]        @relation("BroadcastRejectedBy")
@@ -4692,6 +4693,10 @@ model AccountingPeriod {
   closedAt          DateTime? @map("closed_at")
   closedById        String?   @map("closed_by_id")
   closedBy          User?     @relation("PeriodClosedBy", fields: [closedById], references: [id])
+  reopenedAt        DateTime? @map("reopened_at")
+  reopenedById      String?   @map("reopened_by_id")
+  reopenedBy        User?     @relation("PeriodReopenedBy", fields: [reopenedById], references: [id])
+  boardResolutionId String?   @map("board_resolution_id")
 
   peakSyncedAt   DateTime? @map("peak_synced_at")
   peakSyncResult Json?     @map("peak_sync_result")

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -249,7 +249,7 @@ export class AccountingController {
   @Roles('OWNER', 'FINANCE_MANAGER')
   closeMonthlyPeriod(
     @Body() dto: CloseMonthDto,
-    @Request() req: { user: { id: string } },
+    @Request() req: { user: { id: string; role: string } },
   ) {
     return this.monthlyCloseService.closePeriod(
       dto.companyId,
@@ -258,6 +258,7 @@ export class AccountingController {
       req.user.id,
       dto.notes,
       dto.forceCloseReason,
+      req.user.role,
     );
   }
 

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -256,6 +256,7 @@ export class AccountingController {
       dto.month,
       req.user.id,
       dto.notes,
+      dto.forceCloseReason,
     );
   }
 

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -15,6 +15,7 @@ import { BadDebtService } from './bad-debt.service';
 import { MonthlyCloseService } from './monthly-close.service';
 import { CreateExpenseDto, UpdateExpenseDto, RejectExpenseDto } from './dto/expense.dto';
 import { CloseMonthDto } from './dto/monthly-close.dto';
+import { ReopenPeriodDto } from './dto/reopen-period.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -268,12 +269,10 @@ export class AccountingController {
 
   @Post('periods/reopen')
   @Roles('OWNER')
-  reopenPeriod(@Body() dto: CloseMonthDto) {
-    return this.monthlyCloseService.reopenPeriod(
-      dto.companyId,
-      dto.year,
-      dto.month,
-      dto.boardResolutionId,
-    );
+  reopenPeriod(
+    @Body() dto: ReopenPeriodDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.monthlyCloseService.reopenPeriod(dto, req.user.id);
   }
 }

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -946,4 +946,73 @@ describe('AccountingService', () => {
       expect(data.vatAmount).toBeUndefined();
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // markExpensePaid — F-3-027 part 2/3: pass branch.companyId to JE
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('markExpensePaid (F-3-027 part 2/3)', () => {
+    it('passes branch.companyId to expense JE on markPaid', async () => {
+      const approvedExpense = {
+        id: 'exp-1',
+        expenseNumber: 'EX-001',
+        status: 'APPROVED',
+        deletedAt: null,
+        createdById: 'user-1',
+        accountCode: '51-1101',
+        amount: new Prisma.Decimal(1000),
+        vatAmount: new Prisma.Decimal(70),
+        totalAmount: new Prisma.Decimal(1070),
+        description: 'rent',
+        expenseDate: new Date('2026-04-01'),
+        paymentDate: null,
+        branch: { companyId: 'co-SHOP' },
+      };
+      prisma.expense.findFirst.mockResolvedValue(approvedExpense);
+      prisma.expense.update.mockResolvedValue({
+        ...approvedExpense,
+        status: 'PAID',
+        paymentDate: new Date('2026-04-15'),
+      });
+
+      await service.markExpensePaid('exp-1', '2026-04-15');
+
+      expect(journalAutoService.createExpenseJournal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ companyId: 'co-SHOP' }),
+      );
+    });
+
+    it('passes null companyId when branch has no companyId (legacy branch)', async () => {
+      const approvedExpense = {
+        id: 'exp-2',
+        expenseNumber: 'EX-002',
+        status: 'APPROVED',
+        deletedAt: null,
+        createdById: 'user-1',
+        accountCode: '51-1101',
+        amount: new Prisma.Decimal(500),
+        vatAmount: new Prisma.Decimal(0),
+        totalAmount: new Prisma.Decimal(500),
+        description: 'misc',
+        expenseDate: new Date('2026-04-01'),
+        paymentDate: null,
+        branch: { companyId: null },
+      };
+      prisma.expense.findFirst.mockResolvedValue(approvedExpense);
+      prisma.expense.update.mockResolvedValue({
+        ...approvedExpense,
+        status: 'PAID',
+        paymentDate: new Date('2026-04-15'),
+      });
+
+      await service.markExpensePaid('exp-2');
+
+      // null lets JournalAutoService.resolveCompanyId fall through (legacy fallback)
+      expect(journalAutoService.createExpenseJournal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ companyId: null }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -1014,5 +1014,38 @@ describe('AccountingService', () => {
         expect.objectContaining({ companyId: null }),
       );
     });
+
+    it('rolls back expense markPaid if JE creation throws (F-1-016)', async () => {
+      const approvedExpense = {
+        id: 'exp-3',
+        expenseNumber: 'EX-003',
+        status: 'APPROVED',
+        deletedAt: null,
+        createdById: 'user-1',
+        accountCode: '51-1101',
+        amount: new Prisma.Decimal(1000),
+        vatAmount: new Prisma.Decimal(70),
+        totalAmount: new Prisma.Decimal(1070),
+        description: 'rent',
+        expenseDate: new Date('2026-04-01'),
+        paymentDate: null,
+        branch: { companyId: 'co-SHOP' },
+      };
+      prisma.expense.findFirst.mockResolvedValue(approvedExpense);
+      prisma.expense.update.mockResolvedValue({
+        ...approvedExpense,
+        status: 'PAID',
+        paymentDate: new Date('2026-04-15'),
+      });
+      journalAutoService.createExpenseJournal.mockRejectedValueOnce(new Error('JE failed'));
+
+      await expect(service.markExpensePaid('exp-3', '2026-04-15')).rejects.toThrow('JE failed');
+
+      // The expense.update was called inside the $transaction (which now rolls back),
+      // but in our mock environment the rollback isn't simulated. The contract here is:
+      // the error must propagate out so $transaction rejects atomically. Pre-fix, the
+      // try/catch swallowed it and markExpensePaid resolved successfully — leaving the
+      // ledger out of sync with the expense.status='PAID' write.
+    });
   });
 });

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -360,7 +360,10 @@ export class AccountingService {
 
   async markExpensePaid(id: string, paymentDate?: string) {
     return this.prisma.$transaction(async (tx) => {
-      const expense = await tx.expense.findFirst({ where: { id, deletedAt: null } });
+      const expense = await tx.expense.findFirst({
+        where: { id, deletedAt: null },
+        include: { branch: { select: { companyId: true } } },
+      });
       if (!expense) throw new NotFoundException('ไม่พบรายจ่าย');
       if (expense.status !== 'APPROVED') {
         throw new BadRequestException('ต้องอนุมัติก่อนถึงจะบันทึกจ่ายได้');
@@ -371,8 +374,12 @@ export class AccountingService {
       });
 
       // Auto journal entry — record expense payment
+      // F-3-027 part 2/3: pass branch.companyId so SHOP expenses post under SHOP,
+      // FINANCE expenses under FINANCE — instead of falling back to non-deterministic
+      // resolveCompanyId in JournalAutoService.
       try {
         await this.journalAutoService.createExpenseJournal(tx, {
+          companyId: expense.branch?.companyId ?? null,
           expense: {
             id: updated.id,
             expenseNumber: updated.expenseNumber,

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -377,25 +377,23 @@ export class AccountingService {
       // F-3-027 part 2/3: pass branch.companyId so SHOP expenses post under SHOP,
       // FINANCE expenses under FINANCE — instead of falling back to non-deterministic
       // resolveCompanyId in JournalAutoService.
-      try {
-        await this.journalAutoService.createExpenseJournal(tx, {
-          companyId: expense.branch?.companyId ?? null,
-          expense: {
-            id: updated.id,
-            expenseNumber: updated.expenseNumber,
-            accountCode: updated.accountCode,
-            amount: updated.amount,
-            vatAmount: updated.vatAmount,
-            totalAmount: updated.totalAmount,
-            description: updated.description,
-            expenseDate: updated.expenseDate,
-            paymentDate: updated.paymentDate,
-          },
-          userId: expense.createdById,
-        });
-      } catch (err) {
-        this.logger.error(`Auto-journal failed for expense ${updated.id}: ${err}`);
-      }
+      // F-1-016: atomic with expense payment — if JE fails, $transaction rolls back.
+      // Pre-v4 try/catch caused silent ledger divergence (audit F-1-016 / F-2-008).
+      await this.journalAutoService.createExpenseJournal(tx, {
+        companyId: expense.branch?.companyId ?? null,
+        expense: {
+          id: updated.id,
+          expenseNumber: updated.expenseNumber,
+          accountCode: updated.accountCode,
+          amount: updated.amount,
+          vatAmount: updated.vatAmount,
+          totalAmount: updated.totalAmount,
+          description: updated.description,
+          expenseDate: updated.expenseDate,
+          paymentDate: updated.paymentDate,
+        },
+        userId: expense.createdById,
+      });
 
       return updated;
     });

--- a/apps/api/src/modules/accounting/dto/monthly-close.dto.ts
+++ b/apps/api/src/modules/accounting/dto/monthly-close.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, Min, Max, IsOptional, IsString } from 'class-validator';
+import { IsInt, Min, Max, IsOptional, IsString, MinLength } from 'class-validator';
 
 export class CloseMonthDto {
   @IsInt({ message: 'ปีต้องเป็นจำนวนเต็ม' })
@@ -26,4 +26,15 @@ export class CloseMonthDto {
   @IsString()
   @IsOptional()
   boardResolutionId?: string;
+
+  /**
+   * F-6-003 — OWNER override required when closing a REVIEW period whose
+   * `auditIssues.hasIssues=true`. Must be ≥50 characters explaining the
+   * acknowledged issues and rationale. Force close creates an AuditLog
+   * with action=`PERIOD_FORCE_CLOSE` for traceability.
+   */
+  @IsOptional()
+  @IsString()
+  @MinLength(50, { message: 'forceCloseReason ต้อง ≥50 ตัวอักษร' })
+  forceCloseReason?: string;
 }

--- a/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
+++ b/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
@@ -1,0 +1,32 @@
+import { IsInt, IsString, Max, Min, MinLength } from 'class-validator';
+
+/**
+ * F-6-004 — Reopening a closed period rewrites filed financial statements,
+ * so we require:
+ *   - boardResolutionId  (mandatory — reference to the board minute that
+ *     authorised the reopen; logged in AuditLog for traceability)
+ *   - reason             (≥20 chars — short narrative captured in AuditLog)
+ *
+ * Caller must be OWNER (enforced at controller level).
+ */
+export class ReopenPeriodDto {
+  @IsString({ message: 'companyId ต้องเป็น string' })
+  companyId!: string;
+
+  @IsInt({ message: 'ปีต้องเป็นจำนวนเต็ม' })
+  @Min(2020)
+  year!: number;
+
+  @IsInt({ message: 'เดือนต้องเป็น 1-12' })
+  @Min(1)
+  @Max(12)
+  month!: number;
+
+  @IsString({ message: 'boardResolutionId ต้องเป็น string' })
+  @MinLength(1, { message: 'กรุณาระบุ boardResolutionId' })
+  boardResolutionId!: string;
+
+  @IsString({ message: 'reason ต้องเป็น string' })
+  @MinLength(20, { message: 'reason ต้อง ≥20 ตัวอักษร' })
+  reason!: string;
+}

--- a/apps/api/src/modules/accounting/monthly-close.service.spec.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.spec.ts
@@ -334,6 +334,7 @@ describe('MonthlyCloseService', () => {
         'user-1',
         undefined,
         reason,
+        'OWNER',
       );
 
       expect(result.status).toBe('CLOSED');
@@ -351,6 +352,39 @@ describe('MonthlyCloseService', () => {
           }),
         }),
       );
+    });
+
+    it('blocks forceCloseReason if user role is not OWNER (F-6-003 hardening)', async () => {
+      prisma.accountingPeriod.findUnique.mockResolvedValue({
+        id: 'period-f6003-non-owner',
+        companyId: 'company-1',
+        year: 2026,
+        month: 4,
+        status: 'REVIEW',
+        auditIssues: {
+          totalJournals: 12,
+          unbalancedJournals: 2,
+          paymentsWithoutBreakdown: 0,
+          hasIssues: true,
+        },
+      });
+
+      const reason = 'a'.repeat(60); // valid length
+
+      await expect(
+        service.closePeriod(
+          'company-1',
+          2026,
+          4,
+          'user-1',
+          undefined,
+          reason,
+          'FINANCE_MANAGER',
+        ),
+      ).rejects.toThrow(/OWNER เท่านั้น/);
+
+      expect(prisma.accountingPeriod.update).not.toHaveBeenCalled();
+      expect(prisma.auditLog.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/accounting/monthly-close.service.spec.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.spec.ts
@@ -389,6 +389,9 @@ describe('MonthlyCloseService', () => {
       updatedAt: new Date(),
     };
 
+    const reasonText =
+      'Material misstatement found in March, restating per CPA recommendation';
+
     it('allows reopen of a fresh CLOSED period (closedAt < 90 days ago)', async () => {
       const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
       prisma.accountingPeriod.findUnique.mockResolvedValue({
@@ -404,7 +407,16 @@ describe('MonthlyCloseService', () => {
         closedById: null,
       });
 
-      const result = await service.reopenPeriod('company-1', 2025, 2);
+      const result = await service.reopenPeriod(
+        {
+          companyId: 'company-1',
+          year: 2025,
+          month: 2,
+          boardResolutionId: 'BR-FRESH-1',
+          reason: reasonText,
+        },
+        'user-OWNER-1',
+      );
 
       expect(result.status).toBe('OPEN');
       expect(prisma.accountingPeriod.update).toHaveBeenCalled();
@@ -419,9 +431,18 @@ describe('MonthlyCloseService', () => {
         closedById: 'user-1',
       });
 
-      await expect(service.reopenPeriod('company-1', 2025, 2)).rejects.toThrow(
-        ForbiddenException,
-      );
+      await expect(
+        service.reopenPeriod(
+          {
+            companyId: 'company-1',
+            year: 2025,
+            month: 2,
+            boardResolutionId: '',
+            reason: reasonText,
+          },
+          'user-OWNER-1',
+        ),
+      ).rejects.toThrow(ForbiddenException);
       expect(prisma.accountingPeriod.update).not.toHaveBeenCalled();
     });
 
@@ -441,14 +462,78 @@ describe('MonthlyCloseService', () => {
       });
 
       const result = await service.reopenPeriod(
-        'company-1',
-        2025,
-        2,
-        'BOARD-RES-2026-04-19',
+        {
+          companyId: 'company-1',
+          year: 2025,
+          month: 2,
+          boardResolutionId: 'BOARD-RES-2026-04-19',
+          reason: reasonText,
+        },
+        'user-OWNER-1',
       );
 
       expect(result.status).toBe('OPEN');
       expect(prisma.accountingPeriod.update).toHaveBeenCalled();
+    });
+
+    // F-6-004 — persists audit fields + creates AuditLog
+    it('reopenPeriod creates AuditLog with userId + persists boardResolutionId (F-6-004)', async () => {
+      const period = {
+        ...base,
+        id: 'period-f6004-1',
+        year: 2026,
+        month: 3,
+        status: 'CLOSED',
+        closedAt: new Date(),
+        closedById: 'user-CLOSER',
+      };
+      prisma.accountingPeriod.findUnique.mockResolvedValue(period);
+      prisma.accountingPeriod.update.mockResolvedValue({
+        ...period,
+        status: 'OPEN',
+        closedAt: null,
+        closedById: null,
+      });
+
+      await service.reopenPeriod(
+        {
+          companyId: 'company-1',
+          year: 2026,
+          month: 3,
+          boardResolutionId: 'BR-2026-001',
+          reason: reasonText,
+        },
+        'user-OWNER-1',
+      );
+
+      // Verify period update includes new audit fields
+      expect(prisma.accountingPeriod.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'OPEN',
+            reopenedAt: expect.any(Date),
+            reopenedById: 'user-OWNER-1',
+            boardResolutionId: 'BR-2026-001',
+          }),
+        }),
+      );
+
+      // Verify AuditLog created
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'user-OWNER-1',
+            action: 'PERIOD_REOPEN',
+            entity: 'accounting_period',
+            entityId: 'period-f6004-1',
+            newValue: expect.objectContaining({
+              boardResolutionId: 'BR-2026-001',
+              reason: reasonText,
+              period: '2026-03',
+            }),
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/modules/accounting/monthly-close.service.spec.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.spec.ts
@@ -9,22 +9,29 @@ import { PeakService } from '../peak/peak.service';
 
 // ─── Minimal mock factories ────────────────────────────────────────────────
 
-const makePrisma = () => ({
-  accountingPeriod: {
-    findUnique: jest.fn(),
-    upsert: jest.fn(),
-    update: jest.fn(),
-    findMany: jest.fn(),
-    count: jest.fn(),
-  },
-  journalEntry: {
-    count: jest.fn(),
-    findMany: jest.fn(),
-  },
-  payment: {
-    count: jest.fn(),
-  },
-});
+const makePrisma = () => {
+  const prisma: any = {
+    accountingPeriod: {
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    journalEntry: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+    payment: {
+      count: jest.fn(),
+    },
+    auditLog: {
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(async (cb: (tx: any) => Promise<unknown>) => cb(prisma)),
+  };
+  return prisma;
+};
 
 const makeJournalAutoService = () => ({
   getTrialBalance: jest.fn(),
@@ -244,6 +251,105 @@ describe('MonthlyCloseService', () => {
 
       await expect(service.closePeriod('company-1', 2025, 5, 'user-1')).rejects.toThrow(
         BadRequestException,
+      );
+    });
+
+    // F-6-003 — auditIssues hard-block + OWNER override via forceCloseReason
+    it('blocks closePeriod when auditIssues.hasIssues=true and no forceCloseReason (F-6-003)', async () => {
+      prisma.accountingPeriod.findUnique.mockResolvedValue({
+        id: 'period-f6003-block',
+        companyId: 'company-1',
+        year: 2026,
+        month: 4,
+        status: 'REVIEW',
+        auditIssues: {
+          totalJournals: 12,
+          unbalancedJournals: 2,
+          paymentsWithoutBreakdown: 0,
+          hasIssues: true,
+        },
+      });
+
+      await expect(
+        service.closePeriod('company-1', 2026, 4, 'user-1'),
+      ).rejects.toThrow(/issue|hasIssues/i);
+
+      expect(prisma.accountingPeriod.update).not.toHaveBeenCalled();
+      expect(prisma.auditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('allows closePeriod with forceCloseReason ≥50 chars + creates AuditLog (F-6-003)', async () => {
+      prisma.accountingPeriod.findUnique.mockResolvedValue({
+        id: 'period-f6003-force',
+        companyId: 'company-1',
+        year: 2026,
+        month: 4,
+        status: 'REVIEW',
+        auditIssues: {
+          totalJournals: 12,
+          unbalancedJournals: 2,
+          paymentsWithoutBreakdown: 0,
+          hasIssues: true,
+        },
+      });
+
+      accountingService.getBranchIdsForCompany.mockResolvedValue(['branch-1']);
+      journalAutoService.getTrialBalance.mockResolvedValue({
+        asOfDate: '2026-04-30',
+        accounts: [],
+        totalDebit: 0,
+        totalCredit: 0,
+        balanced: true,
+      });
+      accountingService.getProfitLossReport.mockResolvedValue({ totalRevenue: 0 });
+      accountingService.getBalanceSheet.mockResolvedValue({ totalAssets: 0 });
+      taxService.previewPP30.mockResolvedValue({ totalVatOutput: 0, netVat: 0 });
+
+      prisma.accountingPeriod.update.mockResolvedValue({
+        id: 'period-f6003-force',
+        companyId: 'company-1',
+        year: 2026,
+        month: 4,
+        status: 'CLOSED',
+        closedAt: new Date(),
+        closedById: 'user-1',
+        reportSnapshot: { generatedAt: new Date().toISOString() },
+        reviewStartedAt: null,
+        reviewStartedById: null,
+        peakSyncedAt: null,
+        peakSyncResult: null,
+        auditIssues: { hasIssues: true, unbalancedJournals: 2 },
+        notes: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const reason =
+        'Issues acknowledged: unbalanced JEs traced to test data, will be cleaned in next sprint, force-closing for owner sign-off';
+
+      const result = await service.closePeriod(
+        'company-1',
+        2026,
+        4,
+        'user-1',
+        undefined,
+        reason,
+      );
+
+      expect(result.status).toBe('CLOSED');
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'PERIOD_FORCE_CLOSE',
+            entity: 'accounting_period',
+            entityId: 'period-f6003-force',
+            userId: 'user-1',
+            newValue: expect.objectContaining({
+              reason,
+              period: '2026-04',
+            }),
+          }),
+        }),
       );
     });
   });

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -289,19 +289,24 @@ export class MonthlyCloseService {
    *   operation throws ForbiddenException — requires Board approval because
    *   a stale reopen can rewrite reported P&L / tax filings after the fact.
    *   OWNER-only is already enforced at the controller level.
+   *
+   * F-6-004 — Persists `reopenedAt`, `reopenedById`, `boardResolutionId`
+   * on the AccountingPeriod row and creates an AuditLog `PERIOD_REOPEN`
+   * record capturing reason + board resolution. DTO requires both
+   * `boardResolutionId` and `reason` (≥20 chars).
    */
   async reopenPeriod(
-    companyId: string,
-    year: number,
-    month: number,
-    boardResolutionId?: string,
+    dto: { companyId: string; year: number; month: number; boardResolutionId: string; reason: string },
+    userId: string,
   ): Promise<PeriodStatusResult> {
+    const { companyId, year, month, boardResolutionId, reason } = dto;
+
     const existing = await this.prisma.accountingPeriod.findUnique({
       where: { companyId_year_month: { companyId, year, month } },
     });
 
     if (!existing) {
-      // Already effectively OPEN (no record exists)
+      // Already effectively OPEN (no record exists) — nothing to reopen.
       return this.getPeriodStatus(companyId, year, month);
     }
 
@@ -311,7 +316,10 @@ export class MonthlyCloseService {
       );
     }
 
-    // T2-C10 — 90-day lock on stale CLOSED periods
+    // T2-C10 — 90-day lock on stale CLOSED periods. boardResolutionId is now
+    // always required by DTO, but we still keep the explicit check for clarity
+    // (and to surface the Forbidden message rather than a generic validation
+    // error if the DTO is bypassed by an internal caller).
     if (existing.status === 'CLOSED' && existing.closedAt) {
       const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
       const isStale = existing.closedAt < ninetyDaysAgo;
@@ -324,24 +332,44 @@ export class MonthlyCloseService {
       }
     }
 
-    const period = await this.prisma.accountingPeriod.update({
-      where: { companyId_year_month: { companyId, year, month } },
-      data: {
-        status: 'OPEN',
-        reviewStartedAt: null,
-        reviewStartedById: null,
-        closedAt: null,
-        closedById: null,
-        auditIssues: Prisma.JsonNull,
-        reportSnapshot: Prisma.JsonNull,
-      },
+    const period = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.accountingPeriod.update({
+        where: { companyId_year_month: { companyId, year, month } },
+        data: {
+          status: 'OPEN',
+          reviewStartedAt: null,
+          reviewStartedById: null,
+          closedAt: null,
+          closedById: null,
+          auditIssues: Prisma.JsonNull,
+          reportSnapshot: Prisma.JsonNull,
+          reopenedAt: new Date(),
+          reopenedById: userId,
+          boardResolutionId,
+        },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId,
+          action: 'PERIOD_REOPEN',
+          entity: 'accounting_period',
+          entityId: existing.id,
+          newValue: {
+            boardResolutionId,
+            reason,
+            period: `${existing.year}-${String(existing.month).padStart(2, '0')}`,
+            previousStatus: existing.status,
+          } as unknown as import('@prisma/client').Prisma.JsonObject,
+        },
+      });
+
+      return updated;
     });
 
-    const logSuffix = boardResolutionId
-      ? ` (boardResolutionId=${boardResolutionId})`
-      : '';
     this.logger.log(
-      `Period ${year}/${month} (company ${companyId}) reopened to OPEN.${logSuffix}`,
+      `Period ${year}/${month} (company ${companyId}) reopened to OPEN by ${userId} ` +
+        `(boardResolutionId=${boardResolutionId}).`,
     );
 
     return period as PeriodStatusResult;

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -150,6 +150,11 @@ export class MonthlyCloseService {
   /**
    * REVIEW → CLOSED.
    * Generates report snapshots: trial balance, P&L, balance sheet, VAT summary.
+   *
+   * F-6-003 — Hard-blocks close when `existing.auditIssues.hasIssues=true`
+   * unless OWNER supplies `forceCloseReason` (≥50 chars, validated by DTO).
+   * Force close writes an AuditLog `PERIOD_FORCE_CLOSE` capturing the
+   * reason + the issues acknowledged at the time of close.
    */
   async closePeriod(
     companyId: string,
@@ -157,6 +162,7 @@ export class MonthlyCloseService {
     month: number,
     userId: string,
     notes?: string,
+    forceCloseReason?: string,
   ): Promise<PeriodStatusResult> {
     const existing = await this.prisma.accountingPeriod.findUnique({
       where: { companyId_year_month: { companyId, year, month } },
@@ -169,21 +175,55 @@ export class MonthlyCloseService {
       );
     }
 
+    // F-6-003 — enforce auditIssues unless OWNER provides forceCloseReason
+    const issues = (existing.auditIssues as { hasIssues?: boolean } | null) ?? null;
+    const hasIssues = issues?.hasIssues === true;
+    if (hasIssues && !forceCloseReason) {
+      throw new BadRequestException({
+        message:
+          'พบ issue ในงวดนี้ ต้องแก้ก่อนปิด หรือใส่ forceCloseReason (≥50 ตัวอักษร) เพื่อ override (OWNER เท่านั้น)',
+        issues,
+      });
+    }
+
     // Generate report snapshots
     const reportSnapshot = await this.generateReportSnapshots(companyId, year, month);
 
-    const period = await this.prisma.accountingPeriod.update({
-      where: { companyId_year_month: { companyId, year, month } },
-      data: {
-        status: 'CLOSED',
-        closedAt: new Date(),
-        closedById: userId,
-        reportSnapshot: reportSnapshot as unknown as import('@prisma/client').Prisma.JsonObject,
-        ...(notes !== undefined ? { notes } : {}),
-      },
+    const period = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.accountingPeriod.update({
+        where: { companyId_year_month: { companyId, year, month } },
+        data: {
+          status: 'CLOSED',
+          closedAt: new Date(),
+          closedById: userId,
+          reportSnapshot: reportSnapshot as unknown as import('@prisma/client').Prisma.JsonObject,
+          ...(notes !== undefined ? { notes } : {}),
+        },
+      });
+
+      if (forceCloseReason) {
+        await tx.auditLog.create({
+          data: {
+            userId,
+            action: 'PERIOD_FORCE_CLOSE',
+            entity: 'accounting_period',
+            entityId: existing.id,
+            newValue: {
+              reason: forceCloseReason,
+              issues: existing.auditIssues,
+              period: `${existing.year}-${String(existing.month).padStart(2, '0')}`,
+            } as unknown as import('@prisma/client').Prisma.JsonObject,
+          },
+        });
+      }
+
+      return updated;
     });
 
-    this.logger.log(`Period ${year}/${month} (company ${companyId}) CLOSED by ${userId}.`);
+    this.logger.log(
+      `Period ${year}/${month} (company ${companyId}) CLOSED by ${userId}.` +
+        (forceCloseReason ? ' [FORCE_CLOSE]' : ''),
+    );
 
     return period as PeriodStatusResult;
   }

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -163,6 +163,7 @@ export class MonthlyCloseService {
     userId: string,
     notes?: string,
     forceCloseReason?: string,
+    userRole?: string,
   ): Promise<PeriodStatusResult> {
     const existing = await this.prisma.accountingPeriod.findUnique({
       where: { companyId_year_month: { companyId, year, month } },
@@ -184,6 +185,15 @@ export class MonthlyCloseService {
           'พบ issue ในงวดนี้ ต้องแก้ก่อนปิด หรือใส่ forceCloseReason (≥50 ตัวอักษร) เพื่อ override (OWNER เท่านั้น)',
         issues,
       });
+    }
+
+    // F-6-003 hardening — forceCloseReason override is OWNER-only.
+    // Controller @Roles allows FINANCE_MANAGER for normal close, but the
+    // override path that bypasses auditIssues must be restricted to OWNER.
+    if (forceCloseReason && userRole !== 'OWNER') {
+      throw new ForbiddenException(
+        'เฉพาะ OWNER เท่านั้นที่ใช้ forceCloseReason override ได้',
+      );
     }
 
     // Generate report snapshots

--- a/apps/api/src/modules/contracts/contract-payment.service.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException, InternalServerErrorException } from '@nestjs/common';
 import { PaymentMethod, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ProductsService } from '../products/products.service';
@@ -15,6 +15,23 @@ export class ContractPaymentService {
     private productsService: ProductsService,
     private journalAutoService: JournalAutoService,
   ) {}
+
+  /**
+   * F-3-027 part 2/3 follow-up: Resolve FINANCE companyId for HP installment
+   * journal entries triggered by early payoff. Mirrors PaymentsService helper —
+   * payments on installment contracts post to FINANCE-side accounts and must
+   * pass companyId explicitly (Task 9 will validate via allowedCompanies).
+   */
+  private async resolveFinanceCompanyId(): Promise<string> {
+    const financeCompany = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+      select: { id: true },
+    });
+    if (!financeCompany) {
+      throw new InternalServerErrorException('FINANCE company not configured');
+    }
+    return financeCompany.id;
+  }
 
   async getSchedule(id: string) {
     await this.findOne(id);
@@ -130,6 +147,11 @@ export class ContractPaymentService {
     // into a closed accounting period.
     await validatePeriodOpen(this.prisma, paidDate);
 
+    // F-3-027 part 2/3 follow-up: resolve FINANCE companyId once BEFORE the
+    // transaction (and BEFORE the per-installment loop) so the early-payoff
+    // JE callers pass companyId explicitly to JournalAutoService.
+    const financeCompanyId = await this.resolveFinanceCompanyId();
+
     await this.prisma.$transaction(
       async (tx) => {
         const freshContract = await tx.contract.findUnique({
@@ -178,6 +200,7 @@ export class ContractPaymentService {
           // (Audit finding J3: closes the journal coverage gap on early
           // payoff. Errors propagate so the whole tx rolls back.)
           await this.journalAutoService.createPaymentJournal(tx, {
+            companyId: financeCompanyId,
             payment: {
               id: updatedPayment.id,
               installmentNo: updatedPayment.installmentNo,

--- a/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
+++ b/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
@@ -179,6 +179,9 @@ describe('Contract Signing & Workflow', () => {
         findMany: jest.fn().mockResolvedValue([]),
         findUnique: jest.fn().mockResolvedValue(null),
       },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
+      },
       $transaction: jest.fn((cb) => cb(txMock)),
     };
 

--- a/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
@@ -1,0 +1,200 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { ContractWorkflowService } from './contract-workflow.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { ProductsService } from '../products/products.service';
+
+/**
+ * ContractWorkflowService unit tests.
+ *
+ * Initial coverage focuses on the activate() path and the F-1-002 / F-2-003
+ * audit finding: a try/catch around createContractActivationJournal used to
+ * swallow JE failures, leaving the contract ACTIVE without any ledger entry.
+ * The fix removes that try/catch so the entire $transaction rolls back when
+ * the JE fails — atomic with contract activation.
+ */
+
+jest.mock('../../utils/sequence.util', () => ({
+  generateSaleNumber: jest.fn().mockResolvedValue('SL000001'),
+}));
+
+jest.mock('../../utils/validation.util', () => ({
+  checkAgeEligibility: jest.fn().mockReturnValue({ eligible: true, requiresGuardian: false }),
+  checkRequiredContractFields: jest.fn().mockReturnValue([]),
+  checkRequiredDocuments: jest.fn().mockReturnValue({ complete: true, checklist: [] }),
+  checkRequiredSignatures: jest.fn().mockReturnValue({ complete: true, checklist: [] }),
+}));
+
+jest.mock('../../utils/thai-date.util', () => ({
+  formatDateShort: jest.fn().mockReturnValue('1 พ.ค. 2026'),
+}));
+
+describe('ContractWorkflowService', () => {
+  let service: ContractWorkflowService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let journalAutoMock: { createContractActivationJournal: jest.Mock };
+  let productsMock: { transferOwnership: jest.Mock };
+  let notificationsMock: { send: jest.Mock };
+
+  const mockProduct = {
+    id: 'product-1',
+    name: 'iPhone 15',
+    brand: 'Apple',
+    model: 'iPhone 15',
+    category: 'SMARTPHONE',
+    status: 'RESERVED',
+    imeiSerial: '123456789012345',
+    costPrice: new Prisma.Decimal(20000),
+    deletedAt: null,
+    prices: [],
+  };
+
+  const mockCustomer = {
+    id: 'customer-1',
+    name: 'สมชาย ใจดี',
+    phone: '0891234567',
+    nationalId: '1234567890123',
+    lineId: null,
+    birthDate: null,
+    deletedAt: null,
+    references: [],
+  };
+
+  // Approved DRAFT contract with full signature set + PDPA consent.
+  const mockContract = {
+    id: 'contract-1',
+    contractNumber: 'BC-2026-001',
+    customerId: 'customer-1',
+    productId: 'product-1',
+    branchId: 'branch-1',
+    salespersonId: 'user-1',
+    status: 'DRAFT',
+    workflowStatus: 'APPROVED',
+    sellingPrice: new Prisma.Decimal(20000),
+    downPayment: new Prisma.Decimal(3000),
+    totalMonths: 12,
+    interestRate: new Prisma.Decimal(0.08),
+    interestTotal: new Prisma.Decimal(1728),
+    financedAmount: new Prisma.Decimal(21754.08),
+    storeCommission: new Prisma.Decimal(1800),
+    vatAmount: new Prisma.Decimal(226.08),
+    vatPct: new Prisma.Decimal(0.07),
+    monthlyPayment: new Prisma.Decimal(1813),
+    paymentDueDay: 5,
+    notes: null,
+    deletedAt: null,
+    pdpaConsentId: 'pdpa-1',
+    contractHash: null, // legacy contract — verifyContractHash short-circuits
+    customer: mockCustomer,
+    product: { ...mockProduct, prices: [] },
+    branch: { id: 'branch-1', name: 'สาขาลาดพร้าว' },
+    salesperson: { id: 'user-1', name: 'พนักงาน 1' },
+    reviewedBy: null,
+    interestConfig: null,
+    payments: [],
+    signatures: [
+      { id: 's1', signerType: 'CUSTOMER', signedAt: new Date(), staffUserId: null, deletedAt: null },
+      { id: 's2', signerType: 'COMPANY', signedAt: new Date(), staffUserId: 'user-1', deletedAt: null },
+      { id: 's3', signerType: 'WITNESS_1', signedAt: new Date(), staffUserId: 'user-1', deletedAt: null },
+      { id: 's4', signerType: 'WITNESS_2', signedAt: new Date(), staffUserId: 'user-1', deletedAt: null },
+    ],
+    eDocuments: [],
+    contractDocuments: [],
+    creditCheck: { id: 'cc-1', status: 'APPROVED' },
+  };
+
+  // Tx mock — runs the callback with prisma itself.
+  // Critically: if the callback throws, $transaction re-throws (real Prisma
+  // behavior), so the test can assert that errors propagate out of activate().
+  const makeTxMock = () =>
+    jest.fn().mockImplementation(async (fnOrArray: unknown) => {
+      if (typeof fnOrArray === 'function') {
+        return (fnOrArray as (tx: unknown) => Promise<unknown>)(prisma);
+      }
+      return Promise.all(fnOrArray as Promise<unknown>[]);
+    });
+
+  beforeEach(async () => {
+    prisma = {
+      contract: {
+        findUnique: jest.fn().mockResolvedValue(mockContract),
+        update: jest.fn().mockResolvedValue({ ...mockContract, status: 'ACTIVE' }),
+      },
+      product: {
+        findUnique: jest.fn().mockResolvedValue(mockProduct),
+        update: jest.fn().mockResolvedValue({ ...mockProduct, status: 'SOLD_INSTALLMENT' }),
+      },
+      sale: {
+        create: jest.fn().mockResolvedValue({ id: 'sale-1' }),
+      },
+      payment: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'finance-co-1' }),
+      },
+      $transaction: makeTxMock(),
+    };
+
+    journalAutoMock = {
+      createContractActivationJournal: jest.fn().mockResolvedValue(undefined),
+    };
+    productsMock = {
+      transferOwnership: jest.fn().mockResolvedValue(undefined),
+    };
+    notificationsMock = {
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractWorkflowService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: NotificationsService, useValue: notificationsMock },
+        { provide: JournalAutoService, useValue: journalAutoMock },
+        { provide: ProductsService, useValue: productsMock },
+      ],
+    }).compile();
+
+    service = module.get<ContractWorkflowService>(ContractWorkflowService);
+  });
+
+  describe('activate', () => {
+    it('activates a fully-approved DRAFT contract and writes the activation JE', async () => {
+      await service.activate('contract-1');
+
+      // Contract status flipped to ACTIVE inside the tx
+      expect(prisma.contract.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'contract-1' },
+          data: { status: 'ACTIVE' },
+        }),
+      );
+      // JE was created
+      expect(journalAutoMock.createContractActivationJournal).toHaveBeenCalledTimes(1);
+    });
+
+    it('rolls back contract activation if journal creation throws (F-1-002 / F-2-003)', async () => {
+      journalAutoMock.createContractActivationJournal.mockRejectedValueOnce(
+        new Error('JE failed for atomic rollback test'),
+      );
+
+      // Activation must surface the JE failure (no silent swallow).
+      await expect(service.activate('contract-1')).rejects.toThrow(
+        'JE failed for atomic rollback test',
+      );
+
+      // The JE was attempted (we threw from inside it, not before it).
+      expect(journalAutoMock.createContractActivationJournal).toHaveBeenCalledTimes(1);
+
+      // Atomic guarantee: the throw propagates out of the $transaction callback,
+      // so Prisma rolls back contract.update + product.update + sale.create.
+      // Our mock cannot model rollback semantics — the load-bearing assertion is
+      // the rejects.toThrow above. This test guarantees the v4 fix property:
+      // ledger and contract state cannot diverge on JE failure.
+    });
+  });
+});

--- a/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
@@ -177,6 +177,22 @@ describe('ContractWorkflowService', () => {
       expect(journalAutoMock.createContractActivationJournal).toHaveBeenCalledTimes(1);
     });
 
+    it('passes FINANCE companyId to JournalAutoService on activation (F-3-027 part 2/3)', async () => {
+      // HP receivable + interest income are FINANCE-side, so activation must
+      // resolve FINANCE companyId explicitly (not rely on resolveCompanyId fallback).
+      prisma.companyInfo.findFirst = jest.fn().mockImplementation((args: any) => {
+        if (args?.where?.companyCode === 'FINANCE') return Promise.resolve({ id: 'co-FINANCE' });
+        return Promise.resolve(null);
+      });
+
+      await service.activate('contract-1');
+
+      expect(journalAutoMock.createContractActivationJournal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ companyId: 'co-FINANCE' }),
+      );
+    });
+
     it('rolls back contract activation if journal creation throws (F-1-002 / F-2-003)', async () => {
       journalAutoMock.createContractActivationJournal.mockRejectedValueOnce(
         new Error('JE failed for atomic rollback test'),

--- a/apps/api/src/modules/contracts/contract-workflow.service.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.ts
@@ -424,25 +424,26 @@ export class ContractWorkflowService {
         },
       });
 
-      // Auto journal entry — record contract activation (sales + COGS)
-      try {
-        await this.journalAutoService.createContractActivationJournal(tx, {
-          contract: {
-            id: contract.id,
-            contractNumber: contract.contractNumber,
-            sellingPrice: contract.sellingPrice,
-            downPayment: contract.downPayment,
-            financedAmount: contract.financedAmount,
-            interestTotal: contract.interestTotal,
-            storeCommission: contract.storeCommission ?? 0,
-            vatAmount: contract.vatAmount ?? 0,
-          },
-          product: { costPrice: prod.costPrice, category: prod.category },
-          userId: contract.salespersonId,
-        });
-      } catch (err) {
-        this.logger.error(`Auto-journal failed for contract activation ${contract.id}: ${err}`);
-      }
+      // Auto journal entry — record contract activation (sales + COGS).
+      // Atomic with contract activation: if JE fails, the entire $transaction
+      // rolls back. The pre-v4 try/catch silently swallowed JE failures,
+      // leaving the contract ACTIVE without any ledger entry — defeating
+      // the v4 unbalanced-throw guard (audit findings F-1-002 / F-2-003).
+      // NestJS' global exception filter logs the propagated error.
+      await this.journalAutoService.createContractActivationJournal(tx, {
+        contract: {
+          id: contract.id,
+          contractNumber: contract.contractNumber,
+          sellingPrice: contract.sellingPrice,
+          downPayment: contract.downPayment,
+          financedAmount: contract.financedAmount,
+          interestTotal: contract.interestTotal,
+          storeCommission: contract.storeCommission ?? 0,
+          vatAmount: contract.vatAmount ?? 0,
+        },
+        product: { costPrice: prod.costPrice, category: prod.category },
+        userId: contract.salespersonId,
+      });
     });
 
     // Send LINE notification to customer (non-blocking)

--- a/apps/api/src/modules/contracts/contract-workflow.service.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { formatDateShort } from '../../utils/thai-date.util';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -370,6 +370,18 @@ export class ContractWorkflowService {
       throw new BadRequestException('สินค้าไม่พร้อมสำหรับเปิดสัญญา (อาจถูกขายหรือลบไปแล้ว)');
     }
 
+    // F-3-027 part 2/3: HP receivable + interest income are FINANCE-side accounts.
+    // Resolve FINANCE companyId BEFORE the transaction so it can be passed
+    // explicitly to the activation JE (instead of relying on the non-deterministic
+    // resolveCompanyId fallback). Also reused below for product ownership transfer.
+    const financeCompany = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+      select: { id: true },
+    });
+    if (!financeCompany) {
+      throw new InternalServerErrorException('FINANCE company not configured');
+    }
+
     await this.prisma.$transaction(async (tx) => {
       // Re-check product status inside transaction to prevent race condition
       const prod = await tx.product.findUnique({ where: { id: contract.productId } });
@@ -383,24 +395,14 @@ export class ContractWorkflowService {
       // Ownership transfer: SHOP → FINANCE.
       // Per CLAUDE.md business rule: "กรรมสิทธิ์สินค้าย้ายจาก SHOP → FINANCE
       // (จนลูกค้าผ่อนครบ)". Runs inside the activation transaction so
-      // ownership can never drift from contract status.
-      const financeCompany = await tx.companyInfo.findFirst({
-        where: { companyCode: 'FINANCE', deletedAt: null },
-        select: { id: true },
-      });
-      if (financeCompany) {
-        await this.productsService.transferOwnership(
-          contract.productId,
-          financeCompany.id,
-          tx,
-        );
-      } else {
-        // If FINANCE entity is missing we still activate, but the ops team
-        // needs to know — ownership will fall back to the branch's company.
-        this.logger.warn(
-          `FINANCE company not found while activating contract ${contract.contractNumber} — product ownership NOT transferred`,
-        );
-      }
+      // ownership can never drift from contract status. Reuses financeCompany
+      // resolved before the tx (F-3-027 part 2/3) — missing FINANCE entity
+      // is now a hard error rather than a silent warn-and-continue.
+      await this.productsService.transferOwnership(
+        contract.productId,
+        financeCompany.id,
+        tx,
+      );
 
       // Auto-create Sale record for this contract activation
       const saleNumber = await generateSaleNumber(tx);
@@ -431,6 +433,7 @@ export class ContractWorkflowService {
       // the v4 unbalanced-throw guard (audit findings F-1-002 / F-2-003).
       // NestJS' global exception filter logs the propagated error.
       await this.journalAutoService.createContractActivationJournal(tx, {
+        companyId: financeCompany.id,
         contract: {
           id: contract.id,
           contractNumber: contract.contractNumber,

--- a/apps/api/src/modules/data-audit/data-audit.service.ts
+++ b/apps/api/src/modules/data-audit/data-audit.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, InternalServerErrorException } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
@@ -1028,6 +1028,19 @@ export class DataAuditService {
       throw new NotFoundException('ไม่พบผู้ใช้ OWNER สำหรับ backfill');
     }
 
+    // F-3-027 part 2/3 follow-up: resolve FINANCE companyId once for all
+    // payment-journal backfills. HP installment receipts post to FINANCE-side
+    // accounts and must pass companyId explicitly (Task 9 will validate via
+    // allowedCompanies). Hoisted here so we don't query per payment.
+    const financeCompany = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+      select: { id: true },
+    });
+    if (!financeCompany) {
+      throw new InternalServerErrorException('FINANCE company not configured');
+    }
+    const financeCompanyId = financeCompany.id;
+
     // 1. Find orphan contracts (any non-DRAFT status without CONTRACT journal)
     const orphanContracts = await this.prisma.$queryRaw<{ id: string }[]>`
       SELECT c.id
@@ -1143,6 +1156,7 @@ export class DataAuditService {
           try {
             await this.prisma.$transaction(async (tx) => {
               await this.journalAutoService.createPaymentJournal(tx, {
+                companyId: financeCompanyId,
                 payment: {
                   id: payment.id,
                   installmentNo: payment.installmentNo,

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -752,4 +752,22 @@ describe('JournalAutoService', () => {
       })).resolves.toBeTruthy();
     });
   });
+
+  describe('resolveCompanyId determinism', () => {
+    it('resolveCompanyId returns deterministic company across calls (F-3-027 part 1/3)', async () => {
+      const tx = {
+        companyInfo: {
+          findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (service as any).resolveCompanyId(tx);
+      expect(tx.companyInfo.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'asc' },
+        })
+      );
+      expect(result).toBe('co-FINANCE');
+    });
+  });
 });

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -20,6 +20,10 @@ describe('JournalAutoService', () => {
     prisma = {
       companyInfo: {
         findFirst: jest.fn().mockResolvedValue({ id: 'company-1' }),
+        findUnique: jest.fn().mockResolvedValue({ companyCode: 'FINANCE' }),
+      },
+      chartOfAccount: {
+        findMany: jest.fn().mockResolvedValue([]),
       },
       journalEntry: {
         count: jest.fn().mockResolvedValue(0),
@@ -768,6 +772,66 @@ describe('JournalAutoService', () => {
         })
       );
       expect(result).toBe('co-FINANCE');
+    });
+  });
+
+  describe('createAndPost — allowedCompanies validation', () => {
+    it('throws BadRequestException when SHOP companyId uses FINANCE-only account (F-3-027 part 3/3)', async () => {
+      const tx = {
+        companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'SHOP' }) },
+        chartOfAccount: {
+          findMany: jest.fn().mockResolvedValue([
+            { code: '11-2102', nameTh: 'ลูกหนี้เช่าซื้อ', allowedCompanies: ['FINANCE'] },
+            { code: '11-1101', nameTh: 'เงินสด', allowedCompanies: [] },
+          ]),
+        },
+        journalEntry: { count: jest.fn(), create: jest.fn() },
+      };
+      await expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).createAndPost(tx, {
+          companyId: 'co-SHOP',
+          entryDate: new Date(),
+          description: 'test',
+          referenceType: 'TEST',
+          referenceId: 'test',
+          createdById: 'u1',
+          lines: [
+            { accountCode: '11-2102', debit: 100, credit: 0 },
+            { accountCode: '11-1101', debit: 0, credit: 100 },
+          ],
+        }),
+      ).rejects.toThrow(/11-2102.*ใช้ไม่ได้กับบริษัท SHOP/);
+    });
+
+    it('allows account with empty allowedCompanies for any companyId (F-3-027 part 3/3)', async () => {
+      const tx = {
+        companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'SHOP' }) },
+        chartOfAccount: {
+          findMany: jest.fn().mockResolvedValue([
+            { code: '11-1101', nameTh: 'เงินสด', allowedCompanies: [] },
+          ]),
+        },
+        journalEntry: {
+          count: jest.fn().mockResolvedValue(0),
+          create: jest.fn().mockResolvedValue({ id: 'entry1' }),
+        },
+      };
+      await expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).createAndPost(tx, {
+          companyId: 'co-SHOP',
+          entryDate: new Date(),
+          description: 'test',
+          referenceType: 'TEST',
+          referenceId: 'test',
+          createdById: 'u1',
+          lines: [
+            { accountCode: '11-1101', debit: 100, credit: 0 },
+            { accountCode: '11-1101', debit: 0, credit: 100 },
+          ],
+        }),
+      ).resolves.toBe('entry1');
     });
   });
 });

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -1,8 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { InternalServerErrorException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/nestjs';
 import { JournalAutoService } from './journal-auto.service';
 import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 
 /**
  * JournalAutoService tests — validates the double-entry bookkeeping engine.
@@ -24,6 +30,10 @@ describe('JournalAutoService', () => {
       },
       chartOfAccount: {
         findMany: jest.fn().mockResolvedValue([]),
+      },
+      // F-6-002: default — no closed period
+      accountingPeriod: {
+        findFirst: jest.fn().mockResolvedValue(null),
       },
       journalEntry: {
         count: jest.fn().mockResolvedValue(0),
@@ -785,6 +795,7 @@ describe('JournalAutoService', () => {
             { code: '11-1101', nameTh: 'เงินสด', allowedCompanies: [] },
           ]),
         },
+        accountingPeriod: { findFirst: jest.fn().mockResolvedValue(null) },
         journalEntry: { count: jest.fn(), create: jest.fn() },
       };
       await expect(
@@ -812,6 +823,7 @@ describe('JournalAutoService', () => {
             { code: '11-1101', nameTh: 'เงินสด', allowedCompanies: [] },
           ]),
         },
+        accountingPeriod: { findFirst: jest.fn().mockResolvedValue(null) },
         journalEntry: {
           count: jest.fn().mockResolvedValue(0),
           create: jest.fn().mockResolvedValue({ id: 'entry1' }),
@@ -832,6 +844,47 @@ describe('JournalAutoService', () => {
           ],
         }),
       ).resolves.toBe('entry1');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // F-6-002: createAndPost — soft-block CLOSED period
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('createAndPost — soft-block CLOSED period (F-6-002)', () => {
+    it('redirects entryDate to current period if originally in CLOSED period (F-6-002)', async () => {
+      const tx = {
+        accountingPeriod: { findFirst: jest.fn().mockResolvedValue({ status: 'CLOSED' }) },
+        companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'FINANCE' }) },
+        chartOfAccount: { findMany: jest.fn().mockResolvedValue([]) },
+        journalEntry: {
+          count: jest.fn().mockResolvedValue(0),
+          create: jest
+            .fn()
+            .mockImplementation(({ data }) => Promise.resolve({ id: 'e1', _captured: data })),
+        },
+      };
+      (Sentry.captureMessage as jest.Mock).mockClear();
+      const originalDate = new Date('2025-03-15T00:00:00Z');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (service as any).createAndPost(tx, {
+        companyId: 'co1',
+        entryDate: originalDate,
+        description: 'Original description',
+        referenceType: 'TEST',
+        referenceId: 'test-redirect',
+        createdById: 'u1',
+        lines: [
+          { accountCode: '11-1101', debit: 100, credit: 0 },
+          { accountCode: '21-2101', debit: 0, credit: 100 },
+        ],
+      });
+
+      // The captured create call should have a current-period entryDate (year matches now)
+      const created = tx.journalEntry.create.mock.calls[0][0].data;
+      expect(created.entryDate.getFullYear()).toBe(new Date().getFullYear());
+      expect(created.description).toMatch(/^\[Originally for 2025-03\]/);
+      expect(Sentry.captureMessage).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -731,4 +731,25 @@ describe('JournalAutoService', () => {
       expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
     });
   });
+
+  describe('createAndPost — Decimal precision (F-2-010)', () => {
+    it('balance check uses Decimal precision (no floating-point drift) (F-2-010)', async () => {
+      // Construct many lines that sum to identical totals via Decimal
+      // but might drift in JS Number addition (e.g. 0.1 + 0.1 + ... = 3.0000000000000004).
+      const tx = prisma;
+      const lines: Array<{ accountCode: string; debit: number; credit: number }> = [];
+      for (let i = 0; i < 30; i++) lines.push({ accountCode: '11-1101', debit: 0.1, credit: 0 });
+      for (let i = 0; i < 30; i++) lines.push({ accountCode: '21-2101', debit: 0, credit: 0.1 });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await expect((service as any).createAndPost(tx, {
+        companyId: 'co1',
+        entryDate: new Date(),
+        description: 'Decimal precision test',
+        referenceType: 'TEST',
+        referenceId: 'test-decimal',
+        createdById: 'u1',
+        lines,
+      })).resolves.toBeTruthy();
+    });
+  });
 });

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { InternalServerErrorException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { JournalAutoService } from './journal-auto.service';
 import { PrismaService } from '../../prisma/prisma.service';
 
@@ -246,15 +247,19 @@ describe('JournalAutoService', () => {
   // createContractActivationJournal
   // ──────────────────────────────────────────────────────────────────────────
   describe('createContractActivationJournal', () => {
-    // Balance rule: Dr(downPayment + financedAmount) = Cr(revenue + vatAmount)
-    // revenue = sellingPrice + interestTotal + storeCommission
-    // 3000 + 9300 = (10000 + 800 + 500) + 1000  →  12300 = 12300  ✓
+    // Production formula (installment.util.ts:56):
+    //   principal      = sellingPrice - downPayment        = 12300 - 3000 = 9300
+    //   financedAmount = principal + commission + interest + vat
+    //                  = 9300 + 500 + 800 + 1000           = 11600
+    // Activation JE balance:
+    //   Dr cash(downPayment 3000) + hpReceivable(financedAmount 11600)            = 14600
+    //   Cr revenue(sellingPrice+commission 12800) + interest(800) + vat(1000)     = 14600  ✓
     const baseContract = {
       id: 'contract-1',
       contractNumber: 'BC-202601-0001',
       sellingPrice: 12300,
       downPayment: 3000,
-      financedAmount: 9300,
+      financedAmount: 11600,
       interestTotal: 800,
       storeCommission: 500,
       vatAmount: 1000,
@@ -305,7 +310,7 @@ describe('JournalAutoService', () => {
       const hpLine = lines.find((l) => l.accountCode === JournalAutoService.ACC.HP_RECEIVABLE);
 
       expect(Number(cashLine?.debit)).toBeCloseTo(3000, 2);
-      // HP Receivable = financedAmount + interest + commission + VAT = 9300+800+500+1000
+      // HP Receivable = financedAmount (already includes principal+commission+interest+vat)
       expect(Number(hpLine?.debit)).toBeCloseTo(11600, 2);
     });
 
@@ -375,6 +380,45 @@ describe('JournalAutoService', () => {
         .create as Array<{ accountCode: string; debit: number }>;
       const cogsLine = cogsLines.find((l) => l.debit > 0);
       expect(cogsLine?.accountCode).toBe(JournalAutoService.ACC.COGS_USED);
+    });
+
+    // F-2-001 regression: financedAmount per installment.util.ts:56 already
+    // includes principal + commission + interest + vat. The previous code
+    // added them again, causing the JE to be unbalanced and createAndPost to
+    // throw on every contract activation.
+    it('produces balanced JE when financedAmount already includes interest+commission+vat', async () => {
+      const principal = new Prisma.Decimal('10000');
+      const commission = new Prisma.Decimal('500');
+      const interest = new Prisma.Decimal('1000');
+      const vat = new Prisma.Decimal('805');
+      // Production formula (installment.util.ts:56)
+      const financedAmount = principal.plus(commission).plus(interest).plus(vat); // 12305
+      // sellingPrice = principal + downPayment (per installment.util.ts:52)
+      const downPayment = new Prisma.Decimal('1000');
+      const sellingPrice = principal.plus(downPayment); // 11000
+
+      await service.createContractActivationJournal(prisma, {
+        contract: {
+          id: 'c-fixture',
+          contractNumber: 'CT-FIXTURE',
+          sellingPrice,
+          downPayment,
+          financedAmount,
+          interestTotal: interest,
+          storeCommission: commission,
+          vatAmount: vat,
+        },
+        product: { costPrice: new Prisma.Decimal('8000'), category: 'มือถือใหม่' },
+        userId: 'user-1',
+        companyId: 'company-1',
+      });
+
+      // First call = sales entry
+      const salesEntry = prisma.journalEntry.create.mock.calls[0][0];
+      const lines = salesEntry.data.lines.create as Array<{ debit: number; credit: number }>;
+      const totalDr = sumDebits(lines);
+      const totalCr = sumCredits(lines);
+      expect(Math.abs(totalDr - totalCr)).toBeLessThan(0.01);
     });
   });
 
@@ -514,17 +558,16 @@ describe('JournalAutoService', () => {
       });
 
       // ── 1. Contract Activation journal ──────────────────────────────────
-      // Dr HP Receivable (9 300) + Dr Cash/Down (3 000) / Cr Revenue (10 000) + Cr VAT (800) + Cr Commission (500)
-      // Dr COGS (8 000) / Cr Inventory (8 000)
-      // Balance: Dr = 3000+9300+8000 = 20300  |  Cr = 10000+800+500+8000+1000 = ...
-      // We use the same numbers as the existing tests so we know they balance.
+      // financedAmount = principal(9300) + commission(500) + interest(800) + vat(1000) = 11600
+      // Sales JE  : Dr cash(3000) + hpReceivable(11600) = Cr revenue(12800) + interest(800) + vat(1000) = 14600
+      // COGS JE   : Dr COGS(8000) = Cr Inventory(8000)
       await service.createContractActivationJournal(prisma, {
         contract: {
           id: 'contract-tb',
           contractNumber: 'BC-TB-0001',
           sellingPrice: 12300,
           downPayment: 3000,
-          financedAmount: 9300,
+          financedAmount: 11600,
           interestTotal: 800,
           storeCommission: 500,
           vatAmount: 1000,

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
@@ -103,6 +103,32 @@ export class JournalAutoService {
         },
       });
       throw new InternalServerErrorException(msg);
+    }
+
+    // F-3-027 part 3/3: validate allowedCompanies for each line's account
+    const codes = [...new Set(lines.map((l) => l.accountCode))];
+    const [accounts, company] = await Promise.all([
+      tx.chartOfAccount.findMany({
+        where: { code: { in: codes } },
+        select: { code: true, nameTh: true, allowedCompanies: true },
+      }),
+      tx.companyInfo.findUnique({
+        where: { id: params.companyId },
+        select: { companyCode: true },
+      }),
+    ]);
+    if (!company) {
+      throw new BadRequestException(`Company ${params.companyId} not found`);
+    }
+    if (company.companyCode) {
+      const companyCode = company.companyCode;
+      for (const acc of accounts) {
+        if (acc.allowedCompanies.length > 0 && !acc.allowedCompanies.includes(companyCode)) {
+          throw new BadRequestException(
+            `Account ${acc.code} (${acc.nameTh}) ใช้ไม่ได้กับบริษัท ${companyCode}`,
+          );
+        }
+      }
     }
 
     const entryNumber = await this.generateEntryNumber(tx);

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -88,14 +88,18 @@ export class JournalAutoService {
     const lines = params.lines.filter((l) => l.debit > 0 || l.credit > 0);
     if (lines.length === 0) return null;
 
-    const totalDebit = lines.reduce((s, l) => s + l.debit, 0);
-    const totalCredit = lines.reduce((s, l) => s + l.credit, 0);
-    if (Math.abs(totalDebit - totalCredit) > 0.001) {
+    const totalDebit = lines.reduce((s, l) => s.plus(new Decimal(l.debit)), new Decimal(0));
+    const totalCredit = lines.reduce((s, l) => s.plus(new Decimal(l.credit)), new Decimal(0));
+    if (totalDebit.minus(totalCredit).abs().gt(new Decimal('0.01'))) {
       const msg = `Journal not balanced for ${params.referenceType} ${params.referenceId}: Dr ${totalDebit} ≠ Cr ${totalCredit}`;
       this.logger.error(msg);
       Sentry.captureException(new Error(msg), {
         tags: { kind: 'journal', referenceType: params.referenceType },
-        extra: { referenceId: params.referenceId, totalDebit, totalCredit },
+        extra: {
+          referenceId: params.referenceId,
+          totalDebit: totalDebit.toString(),
+          totalCredit: totalCredit.toString(),
+        },
       });
       throw new InternalServerErrorException(msg);
     }

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -131,13 +131,43 @@ export class JournalAutoService {
       }
     }
 
+    // F-6-002: soft-block — if entryDate in CLOSED period, redirect to current
+    let entryDate = params.entryDate;
+    let description = params.description;
+    const period = await tx.accountingPeriod.findFirst({
+      where: {
+        companyId: params.companyId,
+        year: entryDate.getFullYear(),
+        month: entryDate.getMonth() + 1,
+        status: { in: ['CLOSED', 'SYNCED'] },
+      },
+      select: { status: true },
+    });
+    if (period) {
+      const originalYM = `${entryDate.getFullYear()}-${String(entryDate.getMonth() + 1).padStart(2, '0')}`;
+      this.logger.warn(
+        `Auto-JE redirected from ${period.status} period ${originalYM} to current period`,
+      );
+      Sentry.captureMessage(`Auto-JE redirect: ${originalYM} → current`, {
+        level: 'warning',
+        tags: { kind: 'journal', referenceType: params.referenceType },
+        extra: {
+          referenceId: params.referenceId,
+          originalYM,
+          periodStatus: period.status,
+        },
+      });
+      description = `[Originally for ${originalYM}] ${description}`;
+      entryDate = new Date();
+    }
+
     const entryNumber = await this.generateEntryNumber(tx);
     const entry = await tx.journalEntry.create({
       data: {
         entryNumber,
         companyId: params.companyId,
-        entryDate: params.entryDate,
-        description: params.description,
+        entryDate,
+        description,
         status: 'POSTED',
         postedAt: new Date(),
         postedById: params.createdById,

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -63,6 +63,7 @@ export class JournalAutoService {
     if (companyId) return companyId;
     const company = await tx.companyInfo.findFirst({
       where: { isActive: true, deletedAt: null },
+      orderBy: { createdAt: 'asc' },
       select: { id: true },
     });
     return company?.id || null;

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -293,8 +293,10 @@ export class JournalAutoService {
 
     // Sales revenue = sellingPrice + commission only — interest is a separate revenue line
     const revenue = sellingPrice.add(commission);
-    // HP Receivable = total owed after down payment (principal + interest + commission + VAT)
-    const hpReceivable = financedAmount.add(interest).add(commission).add(vat);
+    // HP Receivable = financedAmount which already includes principal + commission + interest + vat
+    // (computed by installment.util.ts:56 calculateInstallment). Adding them again would
+    // double-count and unbalance the JE — see F-2-001.
+    const hpReceivable = financedAmount;
     const isUsed = (params.product.category || '').toLowerCase().includes('used') ||
       (params.product.category || '').includes('มือสอง');
     const revenueAcc = isUsed ? JournalAutoService.ACC.REVENUE_USED : JournalAutoService.ACC.REVENUE_NEW;

--- a/apps/api/src/modules/journal/journal.service.spec.ts
+++ b/apps/api/src/modules/journal/journal.service.spec.ts
@@ -119,6 +119,8 @@ describe('JournalService.post — SoD enforcement', () => {
     id: 'je-1',
     status: 'DRAFT',
     createdById,
+    companyId: 'company-1',
+    entryDate: new Date('2026-04-10'),
     lines: [
       { id: 'jl-1', debit: 100, credit: 0 },
       { id: 'jl-2', debit: 0, credit: 100 },
@@ -133,6 +135,12 @@ describe('JournalService.post — SoD enforcement', () => {
       },
       journalPostAuditLog: {
         create: jest.fn().mockResolvedValue({ id: 'jpal-1' }),
+      },
+      accountingPeriod: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      systemConfig: {
+        findUnique: jest.fn().mockResolvedValue(null),
       },
       // post() now wraps update + audit insert in a $transaction so a
       // failed audit row rolls the post back.
@@ -196,6 +204,24 @@ describe('JournalService.post — SoD enforcement', () => {
     prisma.journalPostAuditLog.create.mockRejectedValue(new Error('audit insert failed'));
     // Simulate transactional rollback: $transaction propagates the throw.
     await expect(service.post('je-1', 'u-reviewer')).rejects.toThrow(/audit insert failed/);
+  });
+
+  // F-6-001: post() (DRAFT→POSTED) must validate that the entry's period is
+  // open. A DRAFT entry created before period close could otherwise be
+  // posted after close, retroactively altering the closed period's TB.
+  it('blocks post() if entryDate is in CLOSED period (F-6-001)', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
+
+    await expect(service.post('je-1', 'u-reviewer')).rejects.toThrow(/CLOSED|ปิด/i);
+    expect(prisma.journalEntry.update).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('blocks post() if entryDate is in SYNCED period (F-6-001)', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'SYNCED' });
+
+    await expect(service.post('je-1', 'u-reviewer')).rejects.toThrow(BadRequestException);
+    expect(prisma.journalEntry.update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/modules/journal/journal.service.ts
+++ b/apps/api/src/modules/journal/journal.service.ts
@@ -208,6 +208,12 @@ export class JournalService {
       throw new BadRequestException('สถานะไม่ถูกต้อง');
     }
 
+    // F-6-001: prevent posting a DRAFT into a CLOSED/SYNCED period.
+    // create() already validates at draft time, but a draft created while
+    // the period was open could otherwise be posted after period close,
+    // retroactively altering the closed period's trial balance.
+    await validatePeriodOpen(this.prisma, entry.entryDate, entry.companyId);
+
     // T2-C2: Segregation of Duties — the accountant who drafted a journal
     // entry must not be the same person who posts it to the ledger. System-
     // generated entries (journal-auto.service) have createdById = null and

--- a/apps/api/src/modules/payments/payments-financial.integration.spec.ts
+++ b/apps/api/src/modules/payments/payments-financial.integration.spec.ts
@@ -79,7 +79,7 @@ describe('PaymentsService — Financial Integration', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PaymentsService,
-        { provide: PrismaService, useValue: { $transaction: jest.fn(fn => fn(tx)), systemConfig: { findUnique: jest.fn().mockResolvedValue(null) } } },
+        { provide: PrismaService, useValue: { $transaction: jest.fn(fn => fn(tx)), systemConfig: { findUnique: jest.fn().mockResolvedValue(null) }, companyInfo: { findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }) } } },
         { provide: ReceiptsService, useValue: { generateReceipt: jest.fn().mockResolvedValue({}) } },
         { provide: AuditService, useValue: { logPaymentEvent: jest.fn().mockResolvedValue(undefined) } },
         { provide: JournalAutoService, useValue: { createPaymentJournal: jest.fn().mockResolvedValue('je-1'), createExpenseJournal: jest.fn(), createContractActivationJournal: jest.fn(), createBadDebtWriteOffJournal: jest.fn() } },

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -84,6 +84,12 @@ describe('PaymentsService', () => {
       callLog: {
         updateMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
+      // F-3-027 part 2/3: payment paths resolve FINANCE companyId for the JE.
+      // Default mock returns a FINANCE company so existing tests pass; specific
+      // tests can override to assert the lookup happened.
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
+      },
       $transaction: jest.fn((cb) => cb(mockPrisma)),
     };
 
@@ -275,6 +281,31 @@ describe('PaymentsService', () => {
       await service.recordPayment('contract-1', 1, 1000, 'CASH', 'user-1', 'http://slip.jpg');
       expect(receiptsService.generateReceipt).toHaveBeenCalledWith(
         'contract-1', 'payment-1', 'INSTALLMENT', 1000, 1, 'CASH', null, 'user-1',
+      );
+    });
+
+    it('passes FINANCE companyId to createPaymentJournal on full payment (F-3-027 part 2/3)', async () => {
+      // HP installment receipts are FINANCE-side, so the JE companyId must be
+      // resolved via companyInfo.findFirst({companyCode:'FINANCE'}) and passed
+      // explicitly (not left to resolveCompanyId fallback). Asserts both that
+      // the lookup ran with the right filter AND that the value flowed to the JE.
+      prisma.companyInfo.findFirst.mockImplementation((args: any) => {
+        if (args?.where?.companyCode === 'FINANCE') return Promise.resolve({ id: 'co-FINANCE' });
+        return Promise.resolve(null);
+      });
+      const updatedPayment = { ...mockPayment, id: 'payment-1', amountPaid: 3000, status: 'PAID', paidDate: new Date() };
+      prisma.payment.update.mockResolvedValue(updatedPayment);
+
+      const journalAutoMock = (service as unknown as { journalAutoService: { createPaymentJournal: jest.Mock } }).journalAutoService;
+
+      await service.recordPayment('contract-1', 1, 3000, 'CASH', 'user-1', 'http://slip.jpg');
+
+      expect(prisma.companyInfo.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ companyCode: 'FINANCE' }) }),
+      );
+      expect(journalAutoMock.createPaymentJournal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ companyId: 'co-FINANCE' }),
       );
     });
   });

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, BadRequestException, ForbiddenException, Logger, Optional, Inject, forwardRef } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, ForbiddenException, InternalServerErrorException, Logger, Optional, Inject, forwardRef } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import { StructuredLoggerService } from '../../common/logger';
 import { Prisma, PaymentMethod } from '@prisma/client';
@@ -40,6 +40,25 @@ export class PaymentsService {
     @Optional() private mdmLockService?: MdmLockService,
   ) {}
 
+  /**
+   * F-3-027 part 2/3: Resolve FINANCE companyId for HP installment journal entries.
+   * Payments on installment contracts post to FINANCE-side accounts (HP Receivable,
+   * Interest Income, VAT Output) — must be passed explicitly to JournalAutoService
+   * instead of relying on the non-deterministic resolveCompanyId fallback.
+   * Hoisted out of the per-installment loop so autoAllocate / applyCreditBalance
+   * resolve it once per call rather than once per installment.
+   */
+  private async resolveFinanceCompanyId(): Promise<string> {
+    const financeCompany = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+      select: { id: true },
+    });
+    if (!financeCompany) {
+      throw new InternalServerErrorException('FINANCE company not configured');
+    }
+    return financeCompany.id;
+  }
+
   /** Enforce branch-level access: SALES/BRANCH_MANAGER can only operate on their own branch */
   async validateBranchAccess(
     contractId: string,
@@ -78,6 +97,11 @@ export class PaymentsService {
 
     // CR-7: Validate payment date is not in a closed accounting period
     await validatePeriodOpen(this.prisma, new Date());
+
+    // F-3-027 part 2/3: resolve FINANCE companyId BEFORE the transaction so
+    // it can be passed explicitly to the payment JE (HP installment receipts
+    // are FINANCE-side activity).
+    const financeCompanyId = await this.resolveFinanceCompanyId();
 
     // Capture dueDate for loyalty points check (on-time = paidDate <= dueDate)
     let capturedDueDate: Date | null = null;
@@ -182,6 +206,7 @@ export class PaymentsService {
       // ledger and cash never diverge. (Audit finding J5.)
       if (isPaidInFull) {
         await this.journalAutoService.createPaymentJournal(tx, {
+          companyId: financeCompanyId,
           payment: {
             id: result.id,
             installmentNo: result.installmentNo,
@@ -302,6 +327,10 @@ export class PaymentsService {
       throw new BadRequestException('จำนวนเงินต้องมากกว่า 0');
     }
 
+    // F-3-027 part 2/3: resolve FINANCE companyId once before the tx so the
+    // per-installment JE calls below use it (instead of resolveCompanyId fallback).
+    const financeCompanyId = await this.resolveFinanceCompanyId();
+
     // Wrap entire allocation in a serializable transaction to prevent double-payment
     const allocationResult = await this.prisma.$transaction(async (tx) => {
       const contract = await tx.contract.findUnique({
@@ -356,6 +385,7 @@ export class PaymentsService {
           // (Audit finding J1: closes the journal coverage gap on the
           // multi-installment auto-allocate path.)
           await this.journalAutoService.createPaymentJournal(tx, {
+            companyId: financeCompanyId,
             payment: {
               id: updated.id,
               installmentNo: updated.installmentNo,
@@ -679,6 +709,10 @@ export class PaymentsService {
 
   // ─── Apply credit balance to next pending installment ─
   async applyCreditBalance(contractId: string, recordedById: string) {
+    // F-3-027 part 2/3: resolve FINANCE companyId once before the tx so the
+    // per-installment JE calls below use it (instead of resolveCompanyId fallback).
+    const financeCompanyId = await this.resolveFinanceCompanyId();
+
     return this.prisma.$transaction(async (tx) => {
       const contract = await tx.contract.findUnique({
         where: { id: contractId },
@@ -730,6 +764,7 @@ export class PaymentsService {
           // (Audit finding J2: closes the journal coverage gap on the
           // credit-balance allocation path.)
           await this.journalAutoService.createPaymentJournal(tx, {
+            companyId: financeCompanyId,
             payment: {
               id: updated.id,
               installmentNo: updated.installmentNo,

--- a/apps/api/src/modules/paysolutions/paysolutions.module.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.module.ts
@@ -7,6 +7,7 @@ import { PaySolutionsService } from './paysolutions.service';
 import { LiffTokenGuard } from '../line-oa/guards/liff-token.guard';
 import { ShopOrdersModule } from '../shop-orders/shop-orders.module';
 import { ProductsModule } from '../products/products.module';
+import { JournalModule } from '../journal/journal.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { ProductsModule } from '../products/products.module';
     IntegrationsModule,
     forwardRef(() => ShopOrdersModule),
     ProductsModule,
+    JournalModule,
   ],
   controllers: [PaySolutionsController],
   providers: [PaySolutionsService, LiffTokenGuard],

--- a/apps/api/src/modules/paysolutions/paysolutions.service.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.spec.ts
@@ -26,8 +26,9 @@ describe('PaySolutionsService.handlePaymentCallback — payment JE (F-1-003)', (
   const linkId = 'link-1';
 
   beforeEach(async () => {
-    // Reset shared Sentry mock so assertions in one test don't leak.
+    // Reset shared Sentry mocks so assertions in one test don't leak.
     (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
 
     // Tx mock surface used inside the $transaction callback. It must mirror
     // the Prisma client surface used in the production path: paymentLink
@@ -89,12 +90,19 @@ describe('PaySolutionsService.handlePaymentCallback — payment JE (F-1-003)', (
       companyInfo: {
         findFirst: jest.fn().mockResolvedValue({ id: 'co-finance' }),
       },
+      // F-1-003 follow-up: real OWNER user resolution for JE.createdById FK.
+      user: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'user-system-1' }),
+      },
       contract: {
         findUnique: jest.fn().mockResolvedValue({
           contractNumber: 'CT-2026-0001',
           branchId: 'br-1',
         }),
       },
+      // Both the main tx and the post-tx JE-only tx invoke the same callback
+      // signature — txMock works for both since JE only needs a Prisma client
+      // surface (the real JournalAutoService is mocked).
       $transaction: jest.fn().mockImplementation(async (cb: any) => cb(txMock)),
       __tx: txMock,
     };
@@ -157,8 +165,64 @@ describe('PaySolutionsService.handlePaymentCallback — payment JE (F-1-003)', (
           contractNumber: 'CT-2026-0001',
           branchId: 'br-1',
         }),
-        userId: 'paysolutions-webhook',
+        // Real OWNER user.id, not the literal 'paysolutions-webhook' string
+        // (FK-violation fix — see data-audit.service.ts:1023 reference pattern)
+        userId: 'user-system-1',
       }),
+    );
+  });
+
+  it('JE failure does not roll back payment.update — tx-poisoning prevention (F-1-003 follow-up)', async () => {
+    // The JE call lives in a SEPARATE $transaction posted AFTER the main tx
+    // commits. A JE rejection must therefore be unable to undo Payment.update
+    // to PAID — this is the whole point of the post-tx restructuring.
+    journalAuto.createPaymentJournal.mockRejectedValueOnce(
+      new Error('JE failed'),
+    );
+
+    await service.handlePaymentCallback({
+      refno: 'refno-1',
+      result_code: '00',
+      order_no: 'order-1',
+      transaction_id: 'tx-1',
+      total: '1000',
+    });
+
+    // Payment was committed to PAID despite the JE rejection.
+    expect(prisma.__tx.payment.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'PAID' }),
+      }),
+    );
+    // And there are at least two distinct $transaction invocations now —
+    // the main payment tx and one JE tx per fully-paid installment.
+    expect((prisma.$transaction as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('skips JE entirely when no OWNER user is present (FK-violation guard)', async () => {
+    (prisma.user.findFirst as jest.Mock).mockResolvedValueOnce(null);
+
+    await service.handlePaymentCallback({
+      refno: 'refno-1',
+      result_code: '00',
+      order_no: 'order-1',
+      transaction_id: 'tx-1',
+      total: '1000',
+    });
+
+    // No JE was attempted — guard prevents FK violation that would otherwise
+    // be swallowed by the inner try/catch.
+    expect(journalAuto.createPaymentJournal).not.toHaveBeenCalled();
+    // But payment was still committed (P2 — webhook MUST acknowledge).
+    expect(prisma.__tx.payment.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'PAID' }),
+      }),
+    );
+    // And Sentry was alerted via captureMessage (different from captureException).
+    expect(Sentry.captureMessage as jest.Mock).toHaveBeenCalledWith(
+      expect.stringContaining('no OWNER user'),
+      expect.objectContaining({ level: 'error' }),
     );
   });
 

--- a/apps/api/src/modules/paysolutions/paysolutions.service.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.spec.ts
@@ -1,0 +1,199 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/nestjs';
+import { PaySolutionsService } from './paysolutions.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ConfigService } from '@nestjs/config';
+import { LineOaService } from '../line-oa/line-oa.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { OnlineOrderSaleAdapter } from '../shop-orders/online-order-sale.adapter';
+import { ProductsService } from '../products/products.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+
+// We don't care about the underlying Sentry transport during unit tests —
+// captureException is spied on directly in the JE-failure test.
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('PaySolutionsService.handlePaymentCallback — payment JE (F-1-003)', () => {
+  let service: PaySolutionsService;
+  let prisma: any;
+  let journalAuto: { createPaymentJournal: jest.Mock };
+  const paymentId = 'pay-1';
+  const contractId = 'ct-1';
+  const linkId = 'link-1';
+
+  beforeEach(async () => {
+    // Reset shared Sentry mock so assertions in one test don't leak.
+    (Sentry.captureException as jest.Mock).mockClear();
+
+    // Tx mock surface used inside the $transaction callback. It must mirror
+    // the Prisma client surface used in the production path: paymentLink
+    // updateMany, payment findMany/update.
+    const txMock = {
+      paymentLink: {
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      payment: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: paymentId,
+            contractId,
+            installmentNo: 1,
+            amountDue: new Prisma.Decimal(1000),
+            amountPaid: new Prisma.Decimal(0),
+            lateFee: new Prisma.Decimal(0),
+            lateFeeWaived: false,
+            monthlyPrincipal: new Prisma.Decimal(800),
+            monthlyInterest: new Prisma.Decimal(150),
+            monthlyCommission: new Prisma.Decimal(50),
+            vatAmount: new Prisma.Decimal(0),
+          },
+        ]),
+        update: jest.fn().mockResolvedValue({
+          id: paymentId,
+          installmentNo: 1,
+          amountPaid: new Prisma.Decimal(1000),
+          monthlyPrincipal: new Prisma.Decimal(800),
+          monthlyInterest: new Prisma.Decimal(150),
+          monthlyCommission: new Prisma.Decimal(50),
+          vatAmount: new Prisma.Decimal(0),
+          lateFee: new Prisma.Decimal(0),
+          lateFeeWaived: false,
+          paidDate: new Date(),
+          status: 'PAID',
+        }),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      contract: {
+        update: jest.fn().mockResolvedValue({ productId: null }),
+      },
+    };
+
+    prisma = {
+      paymentLink: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: linkId,
+          token: 'refno-1',
+          status: 'ACTIVE',
+          contractId,
+          paymentId,
+          amount: new Prisma.Decimal(1000),
+          savingPlanId: null,
+          payment: { id: paymentId },
+        }),
+        update: jest.fn(),
+      },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'co-finance' }),
+      },
+      contract: {
+        findUnique: jest.fn().mockResolvedValue({
+          contractNumber: 'CT-2026-0001',
+          branchId: 'br-1',
+        }),
+      },
+      $transaction: jest.fn().mockImplementation(async (cb: any) => cb(txMock)),
+      __tx: txMock,
+    };
+
+    journalAuto = {
+      createPaymentJournal: jest.fn().mockResolvedValue('je-1'),
+    };
+
+    const lineOa = {} as Partial<LineOaService>;
+    const integrationConfig = {
+      getValue: jest.fn().mockResolvedValue(''),
+    } as Partial<IntegrationConfigService>;
+    const config = {
+      get: jest.fn().mockImplementation((_k: string, def?: string) => def ?? ''),
+    } as Partial<ConfigService>;
+    const saleAdapter = {} as Partial<OnlineOrderSaleAdapter>;
+    const products = {
+      transferOwnership: jest.fn().mockResolvedValue(undefined),
+    } as Partial<ProductsService>;
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaySolutionsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: config },
+        { provide: LineOaService, useValue: lineOa },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
+        { provide: OnlineOrderSaleAdapter, useValue: saleAdapter },
+        { provide: ProductsService, useValue: products },
+        { provide: JournalAutoService, useValue: journalAuto },
+      ],
+    }).compile();
+
+    service = mod.get<PaySolutionsService>(PaySolutionsService);
+    // Suppress notification-side-effect logs/throws — we don't test those here.
+    jest
+      .spyOn<any, any>(service as any, 'sendPaymentSuccessNotification')
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn<any, any>(service as any, 'sendEarlyPayoffSuccessNotification')
+      .mockResolvedValue(undefined);
+  });
+
+  it('posts payment JE on successful webhook callback (F-1-003)', async () => {
+    await service.handlePaymentCallback({
+      refno: 'refno-1',
+      result_code: '00',
+      order_no: 'order-1',
+      transaction_id: 'tx-1',
+      total: '1000',
+    });
+
+    expect(journalAuto.createPaymentJournal).toHaveBeenCalledTimes(1);
+    expect(journalAuto.createPaymentJournal).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        companyId: 'co-finance',
+        payment: expect.objectContaining({ id: paymentId, installmentNo: 1 }),
+        contract: expect.objectContaining({
+          contractNumber: 'CT-2026-0001',
+          branchId: 'br-1',
+        }),
+        userId: 'paysolutions-webhook',
+      }),
+    );
+  });
+
+  it('does not block payment processing if JE creation fails (F-1-003 P2 pattern)', async () => {
+    journalAuto.createPaymentJournal.mockRejectedValueOnce(
+      new Error('JE post failed'),
+    );
+
+    await expect(
+      service.handlePaymentCallback({
+        refno: 'refno-1',
+        result_code: '00',
+        order_no: 'order-1',
+        transaction_id: 'tx-1',
+        total: '1000',
+      }),
+    ).resolves.not.toThrow();
+
+    // Payment.update was still called with PAID status — the JE failure
+    // must NOT cause the webhook to abort. Customer paid real money via QR;
+    // we acknowledge and reconcile the JE manually from Sentry alert.
+    expect(prisma.__tx.payment.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'PAID' }),
+      }),
+    );
+
+    expect(Sentry.captureException as jest.Mock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          module: 'paysolutions',
+          event: 'webhook-je-failure',
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/paysolutions/paysolutions.service.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.ts
@@ -25,6 +25,7 @@ import { buildEarlyPayoffSuccessFlex } from '../line-oa/flex-messages/early-payo
 import { FlexMessagePayload } from '../line-oa/flex-messages/base-template';
 import { IntegrationConfigService } from '../integrations/integration-config.service';
 import { ProductsService } from '../products/products.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
 
 export interface PaymentIntentResult {
   paymentId: string;
@@ -56,6 +57,7 @@ export class PaySolutionsService {
     @Inject(forwardRef(() => OnlineOrderSaleAdapter))
     private saleAdapter: OnlineOrderSaleAdapter,
     private productsService: ProductsService,
+    private journalAutoService: JournalAutoService,
   ) {
     this.returnUrl = this.config.get<string>('PAYSOLUTIONS_RETURN_URL', '');
     this.apiBaseUrl = this.config.get<string>(
@@ -700,6 +702,20 @@ export class PaySolutionsService {
         paidAmount = paymentLink.amount;
       }
 
+      // F-1-003: Resolve FINANCE companyId + load contract metadata BEFORE the
+      // transaction so the payment JE can be posted with explicit company
+      // (HP receivable is FINANCE-side activity). Matches PaymentsService
+      // pattern (resolveFinanceCompanyId hoisted out of $transaction).
+      const financeCompany = await this.prisma.companyInfo.findFirst({
+        where: { companyCode: 'FINANCE', deletedAt: null },
+        select: { id: true },
+      });
+      const financeCompanyId = financeCompany?.id ?? null;
+      const contractForJe = await this.prisma.contract.findUnique({
+        where: { id: paymentLink.contractId! },
+        select: { contractNumber: true, branchId: true },
+      });
+
       // ชำระสำเร็จ — distribute paid amount FIFO across unpaid installments.
       // Early-payoff links carry amount = full payoff (with discount) and
       // must close every pending installment, not just paymentLink.paymentId.
@@ -748,7 +764,7 @@ export class PaySolutionsService {
             const newAmountPaid = payment.amountPaid.add(payThis).toDecimalPlaces(2);
             const fullyPaid = newAmountPaid.gte(payment.amountDue.add(lateFee));
 
-            await tx.payment.update({
+            const paymentUpdated = await tx.payment.update({
               where: { id: payment.id },
               data: {
                 amountPaid: newAmountPaid,
@@ -763,7 +779,57 @@ export class PaySolutionsService {
                 }`,
               },
             });
-            if (fullyPaid) fullyPaidCount++;
+            if (fullyPaid) {
+              fullyPaidCount++;
+
+              // F-1-003: Post payment JE — Sentry+log+continue pattern (P2).
+              // Webhook MUST NOT block payment if JE fails (customer paid via
+              // QR — gateway already moved real money). Manual reconciliation
+              // is triggered from the Sentry alert. This contrasts with sync
+              // user-initiated payment paths (PaymentsService.recordPayment)
+              // which DO rethrow because the user can retry.
+              if (contractForJe) {
+                try {
+                  await this.journalAutoService.createPaymentJournal(tx, {
+                    companyId: financeCompanyId,
+                    payment: {
+                      id: paymentUpdated.id,
+                      installmentNo: paymentUpdated.installmentNo,
+                      amountPaid: paymentUpdated.amountPaid,
+                      monthlyPrincipal: paymentUpdated.monthlyPrincipal,
+                      monthlyInterest: paymentUpdated.monthlyInterest,
+                      monthlyCommission: paymentUpdated.monthlyCommission,
+                      vatAmount: paymentUpdated.vatAmount,
+                      lateFee: paymentUpdated.lateFee,
+                      lateFeeWaived: paymentUpdated.lateFeeWaived,
+                      paidDate: paymentUpdated.paidDate,
+                    },
+                    contract: {
+                      contractNumber: contractForJe.contractNumber,
+                      branchId: contractForJe.branchId,
+                    },
+                    userId: 'paysolutions-webhook',
+                  });
+                } catch (jeErr) {
+                  Sentry.captureException(jeErr, {
+                    tags: {
+                      module: 'paysolutions',
+                      event: 'webhook-je-failure',
+                    },
+                    extra: {
+                      paymentId: paymentUpdated.id,
+                      contractId: paymentLink.contractId,
+                      refno,
+                      error: String(jeErr),
+                    },
+                  });
+                  this.logger.error(
+                    `Webhook JE failed for payment ${paymentUpdated.id}: ${jeErr instanceof Error ? jeErr.message : jeErr}`,
+                  );
+                  // DO NOT rethrow — Pattern P2 — payment must be acknowledged
+                }
+              }
+            }
           }
 
           // Close the contract when no installments remain. EARLY_PAYOFF

--- a/apps/api/src/modules/paysolutions/paysolutions.service.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.ts
@@ -716,6 +716,25 @@ export class PaySolutionsService {
         select: { contractNumber: true, branchId: true },
       });
 
+      // F-1-003 follow-up: resolve a real OWNER user.id for JournalEntry.createdById.
+      // The previous fix passed the literal string 'paysolutions-webhook' which
+      // would always violate the FK to User.id in production. Pattern matches
+      // data-audit.service.ts:1023 (system user lookup for backfill operations).
+      const systemUser = await this.prisma.user.findFirst({
+        where: { role: 'OWNER', deletedAt: null },
+        select: { id: true },
+        orderBy: { createdAt: 'asc' },
+      });
+      const systemUserId = systemUser?.id ?? null;
+      if (!systemUserId) {
+        // No OWNER user found — skip JE entirely and alert. Webhook still
+        // proceeds (P2: payment must commit; JE is reconciled manually).
+        Sentry.captureMessage(
+          'PaySolutions webhook: no OWNER user found for JE creation',
+          { level: 'error', tags: { module: 'paysolutions' } },
+        );
+      }
+
       // ชำระสำเร็จ — distribute paid amount FIFO across unpaid installments.
       // Early-payoff links carry amount = full payoff (with discount) and
       // must close every pending installment, not just paymentLink.paymentId.
@@ -748,6 +767,22 @@ export class PaySolutionsService {
           let remaining = paidAmount;
           const now = new Date();
           let fullyPaidCount = 0;
+          // F-1-003 follow-up: collect snapshots of fully-paid payments for
+          // post-tx JE posting. JE must NOT run inside this $transaction —
+          // PostgreSQL Serializable would abort the tx on JE failure
+          // (tx-poisoning) and roll back the Payment.update to PAID.
+          const fullyPaidSnapshots: Array<{
+            id: string;
+            installmentNo: number;
+            amountPaid: Prisma.Decimal;
+            monthlyPrincipal: Prisma.Decimal | null;
+            monthlyInterest: Prisma.Decimal | null;
+            monthlyCommission: Prisma.Decimal | null;
+            vatAmount: Prisma.Decimal | null;
+            lateFee: Prisma.Decimal;
+            lateFeeWaived: boolean;
+            paidDate: Date | null;
+          }> = [];
           for (const payment of unpaidPayments) {
             if (remaining.lte(0)) break;
             // lateFeeWaived=true sets lateFee=0 elsewhere, so reading lateFee
@@ -781,54 +816,20 @@ export class PaySolutionsService {
             });
             if (fullyPaid) {
               fullyPaidCount++;
-
-              // F-1-003: Post payment JE — Sentry+log+continue pattern (P2).
-              // Webhook MUST NOT block payment if JE fails (customer paid via
-              // QR — gateway already moved real money). Manual reconciliation
-              // is triggered from the Sentry alert. This contrasts with sync
-              // user-initiated payment paths (PaymentsService.recordPayment)
-              // which DO rethrow because the user can retry.
-              if (contractForJe) {
-                try {
-                  await this.journalAutoService.createPaymentJournal(tx, {
-                    companyId: financeCompanyId,
-                    payment: {
-                      id: paymentUpdated.id,
-                      installmentNo: paymentUpdated.installmentNo,
-                      amountPaid: paymentUpdated.amountPaid,
-                      monthlyPrincipal: paymentUpdated.monthlyPrincipal,
-                      monthlyInterest: paymentUpdated.monthlyInterest,
-                      monthlyCommission: paymentUpdated.monthlyCommission,
-                      vatAmount: paymentUpdated.vatAmount,
-                      lateFee: paymentUpdated.lateFee,
-                      lateFeeWaived: paymentUpdated.lateFeeWaived,
-                      paidDate: paymentUpdated.paidDate,
-                    },
-                    contract: {
-                      contractNumber: contractForJe.contractNumber,
-                      branchId: contractForJe.branchId,
-                    },
-                    userId: 'paysolutions-webhook',
-                  });
-                } catch (jeErr) {
-                  Sentry.captureException(jeErr, {
-                    tags: {
-                      module: 'paysolutions',
-                      event: 'webhook-je-failure',
-                    },
-                    extra: {
-                      paymentId: paymentUpdated.id,
-                      contractId: paymentLink.contractId,
-                      refno,
-                      error: String(jeErr),
-                    },
-                  });
-                  this.logger.error(
-                    `Webhook JE failed for payment ${paymentUpdated.id}: ${jeErr instanceof Error ? jeErr.message : jeErr}`,
-                  );
-                  // DO NOT rethrow — Pattern P2 — payment must be acknowledged
-                }
-              }
+              // Capture snapshot for post-tx JE — see fullyPaidSnapshots
+              // declaration above for tx-poisoning rationale.
+              fullyPaidSnapshots.push({
+                id: paymentUpdated.id,
+                installmentNo: paymentUpdated.installmentNo,
+                amountPaid: paymentUpdated.amountPaid,
+                monthlyPrincipal: paymentUpdated.monthlyPrincipal,
+                monthlyInterest: paymentUpdated.monthlyInterest,
+                monthlyCommission: paymentUpdated.monthlyCommission,
+                vatAmount: paymentUpdated.vatAmount,
+                lateFee: paymentUpdated.lateFee,
+                lateFeeWaived: paymentUpdated.lateFeeWaived,
+                paidDate: paymentUpdated.paidDate,
+              });
             }
           }
 
@@ -877,6 +878,7 @@ export class PaySolutionsService {
             contractStatus,
             fullyPaidCount,
             totalUnpaidAtStart: unpaidPayments.length,
+            fullyPaidSnapshots,
           };
         },
         { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
@@ -892,6 +894,57 @@ export class PaySolutionsService {
       this.logger.log(
         `Payment SUCCESS: refno=${refno}, contractId=${paymentLink.contractId}, contractStatus=${result.contractStatus ?? 'ACTIVE'}, fullyPaid=${result.fullyPaidCount}/${result.totalUnpaidAtStart}`,
       );
+
+      // F-1-003 follow-up: Post payment JE OUTSIDE the main $transaction.
+      // Each JE runs in its own $transaction so a failure cannot poison the
+      // already-committed Payment.update. This preserves the P2 guarantee:
+      // payment is acknowledged regardless of JE success. JE errors go to
+      // Sentry for manual reconciliation.
+      if (contractForJe && systemUserId) {
+        for (const snapshot of result.fullyPaidSnapshots) {
+          try {
+            await this.prisma.$transaction(async (tx2) => {
+              await this.journalAutoService.createPaymentJournal(tx2, {
+                companyId: financeCompanyId,
+                payment: {
+                  id: snapshot.id,
+                  installmentNo: snapshot.installmentNo,
+                  amountPaid: snapshot.amountPaid,
+                  monthlyPrincipal: snapshot.monthlyPrincipal,
+                  monthlyInterest: snapshot.monthlyInterest,
+                  monthlyCommission: snapshot.monthlyCommission,
+                  vatAmount: snapshot.vatAmount,
+                  lateFee: snapshot.lateFee,
+                  lateFeeWaived: snapshot.lateFeeWaived,
+                  paidDate: snapshot.paidDate,
+                },
+                contract: {
+                  contractNumber: contractForJe.contractNumber,
+                  branchId: contractForJe.branchId,
+                },
+                userId: systemUserId,
+              });
+            });
+          } catch (jeErr) {
+            Sentry.captureException(jeErr, {
+              tags: {
+                module: 'paysolutions',
+                event: 'webhook-je-failure',
+              },
+              extra: {
+                paymentId: snapshot.id,
+                contractId: paymentLink.contractId,
+                refno,
+                error: String(jeErr),
+              },
+            });
+            this.logger.error(
+              `Webhook JE failed for payment ${snapshot.id}: ${jeErr instanceof Error ? jeErr.message : jeErr}`,
+            );
+            // DO NOT rethrow — Pattern P2 — payment was already committed.
+          }
+        }
+      }
 
       // Route notification: multi-installment close = early-payoff flex;
       // everything else uses the existing single-installment flex.

--- a/apps/api/src/modules/receipts/receipts.service.spec.ts
+++ b/apps/api/src/modules/receipts/receipts.service.spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReceiptsService } from './receipts.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { LineOaService } from '../line-oa/line-oa.service';
+
+// Mock the period-lock util so the test isn't blocked by closed-period validation.
+jest.mock('../../utils/period-lock.util', () => ({
+  validatePeriodOpen: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('ReceiptsService', () => {
+  let service: ReceiptsService;
+  let prisma: any;
+  let journalAutoService: any;
+
+  const receiptId = 'rcpt-1';
+  const userId = 'user-1';
+  const approverId = 'user-2';
+
+  beforeEach(async () => {
+    // Build a tx mock that exposes the same surface as PrismaService used inside
+    // voidReceipt's $transaction callback.
+    const txMock = {
+      receipt: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      journalEntry: {
+        findFirst: jest.fn(),
+      },
+      $queryRaw: jest.fn().mockResolvedValue([]),
+    };
+
+    prisma = {
+      receipt: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      $transaction: jest.fn().mockImplementation(async (cb: any) => cb(txMock)),
+      __tx: txMock,
+    };
+
+    journalAutoService = {
+      createReversalJournal: jest.fn(),
+    };
+
+    const lineOaService = {} as Partial<LineOaService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReceiptsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: JournalAutoService, useValue: journalAutoService },
+        { provide: LineOaService, useValue: lineOaService },
+      ],
+    }).compile();
+
+    service = module.get<ReceiptsService>(ReceiptsService);
+  });
+
+  describe('voidReceipt', () => {
+    it('rolls back receipt void if reversal JE throws (F-1-017)', async () => {
+      const tx = prisma.__tx;
+
+      // Existing receipt that can be voided (issued recently, has paymentId).
+      tx.receipt.findUnique.mockResolvedValue({
+        id: receiptId,
+        receiptNumber: 'RC-2026-04-00001',
+        contractId: 'ct-1',
+        paymentId: 'pay-1',
+        payerName: 'Customer A',
+        receiverName: 'Cashier',
+        amount: 1000,
+        installmentNo: 1,
+        paymentMethod: 'CASH',
+        isVoided: false,
+        deletedAt: null,
+        createdAt: new Date(), // today → within 30-day limit
+      });
+
+      tx.receipt.create.mockResolvedValue({
+        id: 'cn-1',
+        receiptNumber: 'RC-2026-04-00002',
+        receiptType: 'CREDIT_NOTE',
+      });
+      tx.receipt.update.mockResolvedValue({ id: receiptId, isVoided: true });
+
+      // Original posted journal entry exists.
+      tx.journalEntry.findFirst.mockResolvedValue({
+        id: 'je-1',
+        referenceType: 'PAYMENT',
+        referenceId: 'pay-1',
+        status: 'POSTED',
+      });
+
+      // Reversal JE creation throws.
+      journalAutoService.createReversalJournal.mockRejectedValueOnce(
+        new Error('JE reversal failed'),
+      );
+
+      await expect(
+        service.voidReceipt(receiptId, 'wrong amount', userId, approverId),
+      ).rejects.toThrow('JE reversal failed');
+
+      // The error must propagate out of $transaction so Prisma rolls back the
+      // receipt.update({ isVoided: true }) write. Pre-fix, a try/catch swallowed
+      // the error and the void was committed without a reversal JE — silent
+      // ledger divergence (audit F-1-017).
+      expect(journalAutoService.createReversalJournal).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/modules/receipts/receipts.service.ts
+++ b/apps/api/src/modules/receipts/receipts.service.ts
@@ -402,27 +402,25 @@ export class ReceiptsService {
         },
       });
 
-      // Auto journal — create reversal entry for the original payment
+      // Auto journal — create reversal entry for the original payment.
+      // Atomic with receipt void: if reversal JE fails, $transaction rolls back
+      // so the receipt stays in its original (un-voided) state.
+      // Pre-v4 try/catch swallowed errors → silent ledger divergence (audit F-1-017).
       if (receipt.paymentId) {
-        try {
-          // Find the original journal entry by payment reference
-          const originalEntry = await tx.journalEntry.findFirst({
-            where: {
-              referenceType: 'PAYMENT',
-              referenceId: receipt.paymentId,
-              status: 'POSTED',
-              deletedAt: null,
-            },
+        const originalEntry = await tx.journalEntry.findFirst({
+          where: {
+            referenceType: 'PAYMENT',
+            referenceId: receipt.paymentId,
+            status: 'POSTED',
+            deletedAt: null,
+          },
+        });
+        if (originalEntry) {
+          await this.journalAutoService.createReversalJournal(tx, {
+            originalEntryId: originalEntry.id,
+            reason: reason.trim(),
+            userId: issuedById,
           });
-          if (originalEntry) {
-            await this.journalAutoService.createReversalJournal(tx, {
-              originalEntryId: originalEntry.id,
-              reason: reason.trim(),
-              userId: issuedById,
-            });
-          }
-        } catch (err) {
-          this.logger.error(`Auto-reversal failed for receipt ${id}: ${err}`);
         }
       }
 

--- a/apps/web/e2e/accounting-contract-activation.spec.ts
+++ b/apps/web/e2e/accounting-contract-activation.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI, getAuthHeaders } from './helpers/auth';
+import { unwrapResponse } from './helpers/api-utils';
+
+/* ================================================================
+   Phase A.0 — F-2-001 + F-1-002
+   Verify that contract activation creates a balanced JournalEntry.
+
+   Strategy (smoke-level):
+   - We do NOT seed a fresh contract (full POS → activate flow needs
+     product, customer, signatures, downpayment — too brittle for E2E).
+   - Instead, we check for the EXISTENCE and BALANCE of recent
+     activation-type JournalEntries in the system. If the dev DB has
+     any activated contract, at least one CONTRACT-referenced JE must
+     exist and every JE in the system must be balanced (debit = credit).
+   - This catches the bug where contract activation silently failed to
+     post a JE, and the bug where unbalanced JEs were silently swallowed.
+   ================================================================ */
+
+const API_URL = process.env.API_DIRECT_URL || 'http://localhost:3000';
+
+test.describe('Accounting — Contract Activation creates JE (Phase A.0)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('all recent JournalEntries are balanced (F-1-002 — no silent unbalanced post)', async ({ page }) => {
+    const res = await page.request.get(`${API_URL}/api/journal-entries?limit=100`, {
+      headers: getAuthHeaders(),
+    });
+
+    expect(res.ok()).toBeTruthy();
+    const body = unwrapResponse(await res.json()) as {
+      data: Array<{
+        id: string;
+        entryNumber: string;
+        lines: Array<{ debit: string | number; credit: string | number }>;
+      }>;
+    };
+
+    expect(Array.isArray(body.data)).toBeTruthy();
+
+    // For every entry in the recent window, debit-sum must equal credit-sum.
+    // Even one unbalanced entry = F-1-002 regression.
+    for (const entry of body.data) {
+      const debitSum = entry.lines.reduce((s, l) => s + Number(l.debit || 0), 0);
+      const creditSum = entry.lines.reduce((s, l) => s + Number(l.credit || 0), 0);
+      // Allow 0.01 rounding tolerance for Decimal serialization
+      expect(
+        Math.abs(debitSum - creditSum),
+        `Entry ${entry.entryNumber} unbalanced: Dr=${debitSum} Cr=${creditSum}`,
+      ).toBeLessThan(0.01);
+    }
+  });
+
+  test('activated contracts each have at least one related JournalEntry (F-2-001)', async ({ page }) => {
+    // Fetch a small window of contracts in ACTIVE status
+    const cRes = await page.request.get(`${API_URL}/api/contracts?status=ACTIVE&limit=5`, {
+      headers: getAuthHeaders(),
+    });
+
+    if (!cRes.ok()) {
+      test.skip(true, 'requires fixture: no ACTIVE contracts endpoint accessible');
+      return;
+    }
+
+    const cBody = unwrapResponse(await cRes.json()) as {
+      data: Array<{ id: string; contractNumber: string }>;
+    };
+
+    if (!cBody.data || cBody.data.length === 0) {
+      test.skip(true, 'requires fixture: no ACTIVE contracts in dev DB to verify against');
+      return;
+    }
+
+    // Fetch JEs and search by contract number in description (the auto-JE
+    // service writes contract number into the description field). This is a
+    // weaker check than referenceId filtering (not supported by API yet) but
+    // catches the bug where activation produces zero JEs.
+    const jeRes = await page.request.get(`${API_URL}/api/journal-entries?limit=200`, {
+      headers: getAuthHeaders(),
+    });
+    expect(jeRes.ok()).toBeTruthy();
+    const jeBody = unwrapResponse(await jeRes.json()) as {
+      data: Array<{ description?: string | null; lines: Array<{ debit: string | number; credit: string | number }> }>;
+    };
+
+    // At least one of the recent contracts should appear in some JE
+    // description. If none do, F-2-001 may have regressed.
+    const contractNumbers = cBody.data.map((c) => c.contractNumber);
+    const matched = jeBody.data.filter((je) =>
+      contractNumbers.some((cn) => je.description?.includes(cn)),
+    );
+
+    // Soft assertion: warn rather than fail when dev DB has activated
+    // contracts older than the JE window.
+    if (matched.length === 0) {
+      test.skip(
+        true,
+        'requires fixture: ACTIVE contracts found but none referenced in last 200 JEs (likely older than JE window)',
+      );
+      return;
+    }
+
+    // Each matched JE must itself be balanced
+    for (const je of matched) {
+      const debitSum = je.lines.reduce((s, l) => s + Number(l.debit || 0), 0);
+      const creditSum = je.lines.reduce((s, l) => s + Number(l.credit || 0), 0);
+      expect(Math.abs(debitSum - creditSum)).toBeLessThan(0.01);
+    }
+  });
+});

--- a/apps/web/e2e/accounting-paysolutions-webhook.spec.ts
+++ b/apps/web/e2e/accounting-paysolutions-webhook.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI, getAuthHeaders } from './helpers/auth';
+import { unwrapResponse } from './helpers/api-utils';
+
+/* ================================================================
+   Phase A.0 — F-1-003
+   Verify that PaySolutions webhook callbacks create a Payment + JE.
+
+   Strategy (smoke-level):
+   - The PaySolutions webhook requires HMAC-SHA256 signature using
+     PAYSOLUTIONS_WEBHOOK_SECRET — we cannot fake a webhook in E2E
+     without leaking that secret into the test code. Skipping the
+     full callback flow.
+   - Instead we (a) verify the webhook endpoint exists and rejects
+     unsigned requests (security regression check) and (b) verify
+     that any recent PAID Payment has a matching JournalEntry
+     (F-1-003 — webhook-created payments must post a JE).
+   ================================================================ */
+
+const API_URL = process.env.API_DIRECT_URL || 'http://localhost:3000';
+
+test.describe('Accounting — PaySolutions webhook creates JE (F-1-003)', () => {
+  test('webhook endpoint exists and rejects unsigned/invalid payloads', async ({ request }) => {
+    // Send an empty/invalid body — webhook should NOT 404 (proves endpoint
+    // is mounted) and SHOULD reject (4xx or processing-error response).
+    const res = await request.post(`${API_URL}/api/paysolutions/webhook`, {
+      data: { invalid: 'payload' },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    // Accept any non-404 status — endpoint exists. The webhook handler
+    // intentionally returns 200 even on processing failure (ack-then-log
+    // pattern) to prevent retries; what matters here is "endpoint is up".
+    expect(res.status()).not.toBe(404);
+  });
+
+  test('recent PAID payments via gateway have matching JournalEntry (F-1-003)', async ({ page }) => {
+    await loginViaAPI(page);
+
+    // Look up recent payments — gateway-collected ones should each have
+    // a JE in the system. We can't filter by paymentChannel directly via
+    // every API, so we just ensure SOME paid payments exist with related JE.
+    const pRes = await page.request.get(`${API_URL}/api/payments?status=PAID&limit=20`, {
+      headers: getAuthHeaders(),
+    });
+
+    if (!pRes.ok()) {
+      test.skip(true, `requires fixture: payments endpoint returned ${pRes.status()}`);
+      return;
+    }
+
+    const pBody = unwrapResponse(await pRes.json()) as {
+      data?: Array<{ id: string; paymentNumber?: string; amount?: string | number }>;
+    };
+
+    if (!pBody.data || pBody.data.length === 0) {
+      test.skip(true, 'requires fixture: no PAID payments in dev DB to verify against');
+      return;
+    }
+
+    // Fetch recent JEs; each PAID payment should appear in some JE's
+    // description. (Cannot filter by referenceId on /journal-entries yet.)
+    const jeRes = await page.request.get(`${API_URL}/api/journal-entries?limit=200`, {
+      headers: getAuthHeaders(),
+    });
+    expect(jeRes.ok()).toBeTruthy();
+    const jeBody = unwrapResponse(await jeRes.json()) as {
+      data: Array<{
+        description?: string | null;
+        lines: Array<{ debit: string | number; credit: string | number }>;
+      }>;
+    };
+
+    const paymentNumbers = pBody.data
+      .map((p) => p.paymentNumber)
+      .filter((n): n is string => Boolean(n));
+
+    if (paymentNumbers.length === 0) {
+      test.skip(true, 'requires fixture: payments lack paymentNumber field — cannot match by description');
+      return;
+    }
+
+    const matched = jeBody.data.filter((je) =>
+      paymentNumbers.some((pn) => je.description?.includes(pn)),
+    );
+
+    if (matched.length === 0) {
+      test.skip(
+        true,
+        'requires fixture: PAID payments found but none referenced in last 200 JEs (likely older than JE window)',
+      );
+      return;
+    }
+
+    // Every matched JE must be balanced
+    for (const je of matched) {
+      const debitSum = je.lines.reduce((s, l) => s + Number(l.debit || 0), 0);
+      const creditSum = je.lines.reduce((s, l) => s + Number(l.credit || 0), 0);
+      expect(Math.abs(debitSum - creditSum)).toBeLessThan(0.01);
+    }
+  });
+});

--- a/apps/web/e2e/accounting-period-close.spec.ts
+++ b/apps/web/e2e/accounting-period-close.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI, getAuthHeaders } from './helpers/auth';
+import { unwrapResponse } from './helpers/api-utils';
+
+/* ================================================================
+   Phase A.0 — F-6-003
+   Verify period-close hardening:
+   - Closing a REVIEW period with hasIssues=true MUST be blocked
+     (400) when no forceCloseReason provided.
+   - Closing same period with forceCloseReason ≥50 chars MUST succeed
+     and create an AuditLog with action=PERIOD_FORCE_CLOSE.
+
+   Strategy:
+   - We cannot fabricate an audit-issues period state without a test
+     fixture endpoint. Instead we exercise the validation layer:
+   - Send POST with too-short forceCloseReason → expect 400 (hits the
+     @MinLength(50) DTO validator).
+   - This proves the contract is wired (the bug we fixed was the
+     handler ignoring forceCloseReason entirely).
+   ================================================================ */
+
+const API_URL = process.env.API_DIRECT_URL || 'http://localhost:3000';
+
+test.describe('Accounting — Period Close hardening (F-6-003)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('rejects close with forceCloseReason shorter than 50 chars (DTO validation)', async ({ page }) => {
+    const res = await page.request.post(`${API_URL}/api/expenses/periods/close`, {
+      headers: getAuthHeaders(),
+      data: {
+        companyId: 'nonexistent-id-for-validation-test',
+        year: 2026,
+        month: 1,
+        forceCloseReason: 'too short', // 9 chars — must be rejected by @MinLength(50)
+      },
+    });
+
+    expect(res.status()).toBe(400);
+    const body = await res.json().catch(() => ({}));
+    const message = JSON.stringify(body);
+    // Thai validation message from CloseMonthDto
+    expect(message).toMatch(/forceCloseReason|50 ตัวอักษร/);
+  });
+
+  test('accepts payload shape with valid forceCloseReason ≥50 chars (no DTO error)', async ({ page }) => {
+    const longReason =
+      'ทดสอบ E2E สำหรับ F-6-003 — รับทราบและยอมรับปัญหา audit ทั้งหมดที่ระบบรายงาน เพื่อปิดงวดสำหรับ smoke test ของ Phase A.0';
+    expect(longReason.length).toBeGreaterThanOrEqual(50);
+
+    const res = await page.request.post(`${API_URL}/api/expenses/periods/close`, {
+      headers: getAuthHeaders(),
+      data: {
+        companyId: 'nonexistent-id-for-validation-test',
+        year: 2026,
+        month: 1,
+        forceCloseReason: longReason,
+      },
+    });
+
+    // Either 404 (period not found) or 400 (other business rule) or 200 (closed) — but NOT
+    // a 400 "forceCloseReason ต้อง ≥50 ตัวอักษร" DTO violation. That proves the field is
+    // accepted by the DTO and reaches the service layer.
+    const body = await res.json().catch(() => ({}));
+    const message = JSON.stringify(body);
+    expect(message).not.toMatch(/forceCloseReason ต้อง ≥50 ตัวอักษร/);
+  });
+
+  test('closing endpoint exists and requires auth', async ({ request }) => {
+    // Fresh request with no auth — must be 401 not 404.
+    const res = await request.post(`${API_URL}/api/expenses/periods/close`, {
+      data: { companyId: 'x', year: 2026, month: 1 },
+      headers: { 'Content-Type': 'application/json' },
+    });
+    // Should be unauthorized (401) — endpoint mounted, guard active.
+    // Some setups respond 403 for missing CSRF — accept either.
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test.skip('full close-with-audit-issues flow', async () => {
+    // requires fixture: needs a REVIEW-status period with auditIssues.hasIssues=true
+    // pre-seeded via test endpoint. Currently no such fixture exists.
+    // Once available, verify:
+    //  1. POST without forceCloseReason → 400 with "audit issues" message
+    //  2. POST with valid forceCloseReason → 200 + AuditLog row exists
+    //     where action=PERIOD_FORCE_CLOSE and entity points to the period
+    expect(true).toBe(false);
+  });
+});
+
+test.describe('Accounting — Period reopen (F-6-004)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('reopen endpoint exists and rejects unauth', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/expenses/periods/reopen`, {
+      data: { companyId: 'x', year: 2026, month: 1, reason: 'test' },
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect([401, 403]).toContain(res.status());
+  });
+});

--- a/docs/superpowers/plans/2026-04-29-accounting-phase-a0-critical-fix.md
+++ b/docs/superpowers/plans/2026-04-29-accounting-phase-a0-critical-fix.md
@@ -1,0 +1,1794 @@
+# Accounting Phase A.0 — Critical Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 11 critical accounting bugs (5 waves) without changing chart of accounts or accounting policy. After deploy, new contract activations + PaySolutions webhook payments will produce correct journal entries; period close will be properly hardened.
+
+**Architecture:** Surgical edits to existing services (no new files for app code). One Prisma migration adds 3 optional audit fields to `accounting_periods`. Pattern is TDD per fix: write failing test → minimal implementation → verify pass → commit. Single PR with squash merge; 5 logical waves committed in dependency order.
+
+**Tech Stack:** NestJS, Prisma, TypeScript, Jest (unit + integration), Playwright (E2E), Sentry (error capture).
+
+**Spec:** `docs/superpowers/specs/2026-04-29-accounting-phase-a0-critical-fix-design.md`
+**Audit predecessor:** `docs/reports/2026-04-29-accounting-audit.md`
+
+---
+
+## Pre-flight: Setup branch
+
+- [ ] **Step 1: Verify on main + clean working tree**
+
+Run: `git status`
+Expected: `On branch main` + `nothing to commit, working tree clean` (untracked mockups OK)
+
+- [ ] **Step 2: Pull latest**
+
+Run: `git pull origin main`
+Expected: `Already up to date.` (or fast-forward succeeds)
+
+- [ ] **Step 3: Create feature branch**
+
+Run: `git checkout -b feat/accounting-phase-a0-critical-fix`
+Expected: `Switched to a new branch 'feat/accounting-phase-a0-critical-fix'`
+
+---
+
+## Wave 1 — Foundation (Tasks 1-4)
+
+**Goal:** Fix the math bug + Decimal precision + try/catch on contract activation. Three changes ship as a logical unit because removing try/catch without math fix would break every contract activation in prod.
+
+### Task 1: Fix `hpReceivable` double-counting
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal-auto.service.ts:296`
+- Test: `apps/api/src/modules/journal/journal-auto.service.spec.ts`
+
+- [ ] **Step 1: Read current implementation to confirm context**
+
+Run: `grep -n "hpReceivable" apps/api/src/modules/journal/journal-auto.service.ts`
+Expected output includes line 296 with the double-counting expression.
+
+- [ ] **Step 2: Add failing test for balanced activation JE**
+
+Open `apps/api/src/modules/journal/journal-auto.service.spec.ts` and add test inside the `describe('createContractActivationJournal')` block (or create the block if absent):
+
+```typescript
+it('produces balanced JE when financedAmount already includes interest+commission+vat', async () => {
+  // financedAmount = principal + commission + interest + vat (per installment.util.ts:56)
+  const principal = new Decimal('10000');
+  const commission = new Decimal('500');
+  const interest = new Decimal('1000');
+  const vat = new Decimal('805');
+  const financedAmount = principal.plus(commission).plus(interest).plus(vat); // 12305
+
+  const tx = makeFakeTx();  // helper that captures createAndPost calls
+  await service.createContractActivationJournal(tx, {
+    contract: {
+      id: 'c1', contractNumber: 'CT-001',
+      sellingPrice: new Decimal('11000'),  // principal + commission
+      downPayment: new Decimal('1000'),
+      financedAmount,
+      interestTotal: interest,
+      storeCommission: commission,
+      vatAmount: vat,
+    },
+    product: { costPrice: new Decimal('8000'), category: 'มือถือใหม่' },
+    userId: 'u1',
+  });
+
+  // Inspect captured lines from the salesEntry
+  const salesCall = tx.captured[0];
+  const totalDr = salesCall.lines.reduce((s, l) => s + l.debit, 0);
+  const totalCr = salesCall.lines.reduce((s, l) => s + l.credit, 0);
+  expect(Math.abs(totalDr - totalCr)).toBeLessThan(0.01);
+});
+```
+
+If `makeFakeTx` does not exist in the spec, add this helper at top of file:
+
+```typescript
+function makeFakeTx() {
+  const captured: any[] = [];
+  return {
+    captured,
+    journalEntry: {
+      count: jest.fn().mockResolvedValue(0),
+      create: jest.fn().mockImplementation(({ data }) => {
+        captured.push({ lines: data.lines.create });
+        return Promise.resolve({ id: `entry-${captured.length}` });
+      }),
+    },
+    companyInfo: { findFirst: jest.fn().mockResolvedValue({ id: 'co1' }) },
+  };
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "produces balanced JE when financedAmount"`
+Expected: FAIL with `Journal not balanced for CONTRACT c1: Dr ... ≠ Cr ...`
+
+- [ ] **Step 4: Fix the bug**
+
+Edit `apps/api/src/modules/journal/journal-auto.service.ts` line 296:
+
+```diff
+-    const hpReceivable = financedAmount.add(interest).add(commission).add(vat);
++    // financedAmount already includes principal + commission + interest + vat
++    // (computed by installment.util.ts:56 calculateInstallment)
++    const hpReceivable = financedAmount;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "produces balanced JE when financedAmount"`
+Expected: PASS
+
+- [ ] **Step 6: Run full spec to verify no regression**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts`
+Expected: All existing tests still PASS (test fixtures using `financedAmount = sellingPrice - downPayment` may need updating — fix them to use `financedAmount = principal + commission + interest + vat` since that matches production)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/modules/journal/journal-auto.service.ts apps/api/src/modules/journal/journal-auto.service.spec.ts
+git commit -m "fix(journal): hpReceivable no longer double-counts i+c+v (F-2-001)
+
+financedAmount already includes principal + commission + interest + vat
+per installment.util.ts:56. Adding them again caused createAndPost to throw
+on every contract activation. Combined with the try/catch at
+contract-workflow.service.ts:443, this resulted in zero contract activation
+JEs being posted in production (only 1 JE total in prod history).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Decimal precision in balance check
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal-auto.service.ts:91-93`
+- Test: `apps/api/src/modules/journal/journal-auto.service.spec.ts`
+
+- [ ] **Step 1: Add failing test for fractional satang precision**
+
+Add to spec file:
+
+```typescript
+it('balance check uses Decimal precision (no floating-point false-pass)', async () => {
+  // Construct 100 lines of 0.01 each on Dr side, 99 lines of 0.01 + 1 line of 0.011 on Cr side
+  // Total: Dr=1.00, Cr=1.001 → diff=0.001. Old Number-based check tolerates ±0.001 → false-pass.
+  // Decimal check tolerates 0.01 → still false-pass for this input. Use harder case:
+  // Dr=1.00, Cr=1.011 → diff=0.011 → old false-pass (>0.001 but <0.012 threshold... actually 0.011 > 0.001 so old throws). Use:
+  // Dr 100 lines of 0.01 = 1.00; Cr 100 lines of 0.01 = 1.00 plus 1 line of 0.005 = 1.005
+  // diff = 0.005 → old check: 0.005 > 0.001 → throws. Use 0.0009 difference (under old threshold):
+  // Dr 1.00 vs Cr 1.0009 → diff 0.0009 → old PASSES (false), Decimal check FAILS (0.0009 > 0.01? No, 0.0009 < 0.01 → also passes). 
+  // Better test: use exact-arithmetic breakage. JS floats:
+  //   0.1 + 0.2 = 0.30000000000000004 (rounding error)
+  // Construct 30 lines of 0.1 vs 30 lines of 0.1 → totals identical in Decimal but may drift in Number.
+  // Simpler: assert createAndPost doesn't throw for clearly balanced Decimal sums that JS floats miscompute.
+  const tx = makeFakeTx();
+  const lines = [];
+  for (let i = 0; i < 30; i++) lines.push({ accountCode: '11-1101', debit: 0.1, credit: 0 });
+  for (let i = 0; i < 30; i++) lines.push({ accountCode: '21-2101', debit: 0, credit: 0.1 });
+  // (createAndPost is private; call via a public method that uses it — use createPaymentJournal as proxy isn't trivial.
+  //  Instead, expose createAndPost for test via casting):
+  await expect((service as any).createAndPost(tx, {
+    companyId: 'co1', entryDate: new Date(), description: 'test',
+    referenceType: 'TEST', referenceId: 'test', createdById: 'u1',
+    lines,
+  })).resolves.not.toThrow();
+});
+```
+
+- [ ] **Step 2: Run test to verify behavior baseline**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "balance check uses Decimal"`
+Expected: May PASS already (depends on floating-point evaluation order). If passes, the test is too weak — proceed anyway since the change is purely defensive.
+
+- [ ] **Step 3: Switch balance check to Decimal**
+
+Edit `journal-auto.service.ts:91-93`:
+
+```diff
+-    const totalDebit = lines.reduce((s, l) => s + l.debit, 0);
+-    const totalCredit = lines.reduce((s, l) => s + l.credit, 0);
+-    if (Math.abs(totalDebit - totalCredit) > 0.001) {
++    const totalDebit = lines.reduce((s, l) => s.plus(new Decimal(l.debit)), new Decimal(0));
++    const totalCredit = lines.reduce((s, l) => s.plus(new Decimal(l.credit)), new Decimal(0));
++    if (totalDebit.minus(totalCredit).abs().gt(new Decimal('0.01'))) {
+       const msg = `Journal not balanced for ${params.referenceType} ${params.referenceId}: Dr ${totalDebit} ≠ Cr ${totalCredit}`;
+```
+
+Update the Sentry extras to call `.toString()` on the Decimal values:
+
+```diff
+       Sentry.captureException(new Error(msg), {
+         tags: { kind: 'journal', referenceType: params.referenceType },
+-        extra: { referenceId: params.referenceId, totalDebit, totalCredit },
++        extra: { referenceId: params.referenceId, totalDebit: totalDebit.toString(), totalCredit: totalCredit.toString() },
+       });
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "balance check uses Decimal"`
+Expected: PASS
+
+- [ ] **Step 5: Run full spec**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/journal/journal-auto.service.ts apps/api/src/modules/journal/journal-auto.service.spec.ts
+git commit -m "fix(journal): balance check uses Decimal not floating-point (F-2-010)
+
+JS Number sums accumulate floating-point error across many lines.
+Switch totalDebit/totalCredit to Prisma.Decimal arithmetic with 0.01
+satang tolerance.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Remove try/catch on contract activation
+
+**Files:**
+- Modify: `apps/api/src/modules/contracts/contract-workflow.service.ts:425-447`
+- Test: `apps/api/src/modules/contracts/contract-workflow.service.spec.ts` (or create `contract-workflow.service.spec.ts` if absent)
+
+- [ ] **Step 1: Locate exact lines**
+
+Run: `grep -nB 2 -A 18 "Auto journal entry — record contract activation" apps/api/src/modules/contracts/contract-workflow.service.ts`
+Expected output: the try/catch block
+
+- [ ] **Step 2: Find or create the contract-workflow spec**
+
+Run: `ls apps/api/src/modules/contracts/contract-workflow*.spec.ts 2>&1 || echo "NEW"`
+
+If NEW: create skeleton at `apps/api/src/modules/contracts/contract-workflow.service.spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { ContractWorkflowService } from './contract-workflow.service';
+// ... (mirror dependency injection from existing spec patterns; copy from contract-payment.service.spec.ts as reference)
+```
+
+- [ ] **Step 3: Add failing test for atomic rollback**
+
+```typescript
+it('rolls back contract activation if journal creation throws (F-1-002)', async () => {
+  const journalAutoMock = {
+    createContractActivationJournal: jest.fn().mockRejectedValue(new Error('JE failed')),
+  };
+  const service = new ContractWorkflowService(prisma, journalAutoMock as any /* other deps */);
+
+  const contract = await prisma.contract.create({ data: { /* DRAFT contract fixture */ } });
+
+  await expect(service.activate(contract.id, 'user1')).rejects.toThrow('JE failed');
+
+  const after = await prisma.contract.findUnique({ where: { id: contract.id } });
+  expect(after.status).toBe('DRAFT'); // rollback verified
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails (current code swallows)**
+
+Run: `cd apps/api && npx jest contract-workflow.service.spec.ts -t "rolls back contract activation"`
+Expected: FAIL — test expects throw but current code swallows error so `activate` resolves successfully
+
+- [ ] **Step 5: Remove try/catch wrapper**
+
+Edit `contract-workflow.service.ts:425-447`:
+
+```diff
+       });
+
+       // Auto journal entry — record contract activation (sales + COGS)
+-      try {
+-        await this.journalAutoService.createContractActivationJournal(tx, {
+-          contract: {
+-            id: contract.id,
+-            contractNumber: contract.contractNumber,
+-            sellingPrice: contract.sellingPrice,
+-            downPayment: contract.downPayment,
+-            financedAmount: contract.financedAmount,
+-            interestTotal: contract.interestTotal,
+-            storeCommission: contract.storeCommission ?? 0,
+-            vatAmount: contract.vatAmount ?? 0,
+-          },
+-          product: { costPrice: prod.costPrice, category: prod.category },
+-          userId: contract.salespersonId,
+-        });
+-      } catch (err) {
+-        this.logger.error(`Auto-journal failed for contract activation ${contract.id}: ${err}`);
+-      }
++      // Atomic with contract activation: if JE fails, the entire transaction rolls back.
++      // Pre-v4 try/catch caused silent ledger divergence (audit F-1-002 / F-2-003).
++      await this.journalAutoService.createContractActivationJournal(tx, {
++        contract: {
++          id: contract.id,
++          contractNumber: contract.contractNumber,
++          sellingPrice: contract.sellingPrice,
++          downPayment: contract.downPayment,
++          financedAmount: contract.financedAmount,
++          interestTotal: contract.interestTotal,
++          storeCommission: contract.storeCommission ?? 0,
++          vatAmount: contract.vatAmount ?? 0,
++        },
++        product: { costPrice: prod.costPrice, category: prod.category },
++        userId: contract.salespersonId,
++      });
+     });
+```
+
+- [ ] **Step 6: Run test to verify pass**
+
+Run: `cd apps/api && npx jest contract-workflow.service.spec.ts -t "rolls back contract activation"`
+Expected: PASS
+
+- [ ] **Step 7: Run full contract-workflow spec**
+
+Run: `cd apps/api && npx jest contract-workflow`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/modules/contracts/contract-workflow.service.ts apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+git commit -m "fix(contracts): remove try/catch on activation JE (F-1-002 / F-2-003)
+
+The try/catch around createContractActivationJournal was swallowing
+the InternalServerErrorException thrown by createAndPost. This caused
+contract activation to succeed in DB but produced no ledger entry,
+defeating the v4 unbalanced-throw guard. Now propagates so the
+\$transaction rolls back atomically.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Run Wave 1 verification
+
+- [ ] **Step 1: TypeScript check**
+
+Run: `./tools/check-types.sh api`
+Expected: 0 errors
+
+- [ ] **Step 2: Full unit test suite for journal + contracts**
+
+Run: `cd apps/api && npx jest journal contracts/contract-workflow`
+Expected: All PASS, no new failures
+
+- [ ] **Step 3: Stop and review with user**
+
+User checkpoint — Wave 1 complete. Proceed to Wave 2?
+
+---
+
+## Wave 2 — Company Validation (Tasks 5-9)
+
+**Goal:** `resolveCompanyId` deterministic; callers pass explicit companyId; `createAndPost` enforces `allowedCompanies`. Order matters: resolve fix → callers updated → validation added.
+
+### Task 5: Make `resolveCompanyId` deterministic
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal-auto.service.ts:64-69`
+- Test: `apps/api/src/modules/journal/journal-auto.service.spec.ts`
+
+- [ ] **Step 1: Add failing test**
+
+```typescript
+it('resolveCompanyId returns deterministic company across calls', async () => {
+  const tx = {
+    companyInfo: {
+      findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
+    },
+  };
+  const result = await (service as any).resolveCompanyId(tx);
+  expect(tx.companyInfo.findFirst).toHaveBeenCalledWith(
+    expect.objectContaining({
+      orderBy: { createdAt: 'asc' },
+    })
+  );
+  expect(result).toBe('co-FINANCE');
+});
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "resolveCompanyId returns deterministic"`
+Expected: FAIL — assertion on `orderBy` field absent
+
+- [ ] **Step 3: Add ORDER BY**
+
+Edit `journal-auto.service.ts:64-69`:
+
+```diff
+     if (companyId) return companyId;
+     const company = await tx.companyInfo.findFirst({
+       where: { isActive: true, deletedAt: null },
++      orderBy: { createdAt: 'asc' },
+       select: { id: true },
+     });
+     return company?.id || null;
+   }
+```
+
+- [ ] **Step 4: Verify pass**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "resolveCompanyId returns deterministic"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/journal/journal-auto.service.ts apps/api/src/modules/journal/journal-auto.service.spec.ts
+git commit -m "fix(journal): resolveCompanyId deterministic via createdAt asc (F-3-027 part 1/3)
+
+findFirst without orderBy returns non-deterministic results in multi-company
+setups, risking FINANCE-only accounts being posted under SHOP companyId.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Pass explicit companyId from contract-workflow
+
+**Files:**
+- Modify: `apps/api/src/modules/contracts/contract-workflow.service.ts` (activation block from Task 3)
+- Modify: `apps/api/src/modules/journal/journal-auto.service.ts:265-283` (createContractActivationJournal accepts companyId)
+
+- [ ] **Step 1: Verify createContractActivationJournal already accepts companyId**
+
+Run: `grep -nB 2 -A 20 "async createContractActivationJournal" apps/api/src/modules/journal/journal-auto.service.ts | head -30`
+Expected: signature shows `params.companyId?: string | null` (it already does — passed to resolveCompanyId)
+
+- [ ] **Step 2: Add failing test on contract-workflow**
+
+In `contract-workflow.service.spec.ts`:
+
+```typescript
+it('passes FINANCE companyId to JournalAutoService on activation (F-3-027 part 2)', async () => {
+  // FINANCE company seeded as 'co-FINANCE'
+  const journalAutoMock = { createContractActivationJournal: jest.fn().mockResolvedValue(['e1']) };
+  const service = new ContractWorkflowService(prisma, journalAutoMock as any);
+  const contract = await prisma.contract.create({ data: { /* DRAFT */ } });
+
+  await service.activate(contract.id, 'user1');
+
+  expect(journalAutoMock.createContractActivationJournal).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ companyId: 'co-FINANCE' })
+  );
+});
+```
+
+- [ ] **Step 3: Verify fails**
+
+Run: `cd apps/api && npx jest contract-workflow.service.spec.ts -t "passes FINANCE companyId"`
+Expected: FAIL — current code doesn't pass companyId
+
+- [ ] **Step 4: Add FINANCE company lookup + pass companyId**
+
+In `contract-workflow.service.ts`, before the activation tx block, add:
+
+```typescript
+// Resolve FINANCE company id (HP receivable + interest income are FINANCE-side)
+const financeCompany = await this.prisma.companyInfo.findFirst({
+  where: { companyCode: 'FINANCE', deletedAt: null },
+  select: { id: true },
+});
+if (!financeCompany) throw new InternalServerErrorException('FINANCE company not configured');
+```
+
+In the `createContractActivationJournal` call, add the param:
+
+```diff
+       await this.journalAutoService.createContractActivationJournal(tx, {
++        companyId: financeCompany.id,
+         contract: {
+           id: contract.id,
+           ...
+         },
+         ...
+       });
+```
+
+- [ ] **Step 5: Verify pass**
+
+Run: `cd apps/api && npx jest contract-workflow.service.spec.ts -t "passes FINANCE companyId"`
+Expected: PASS
+
+- [ ] **Step 6: Run full contract spec**
+
+Run: `cd apps/api && npx jest contracts/contract-workflow`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/modules/contracts/contract-workflow.service.ts apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+git commit -m "fix(contracts): pass FINANCE companyId to activation JE (F-3-027 part 2)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Pass explicit companyId from payments
+
+**Files:**
+- Modify: `apps/api/src/modules/payments/payments.service.ts:184-200` (recordPayment) + similar at lines ~358 (autoAllocate) + ~732 (creditAlloc)
+- Test: `apps/api/src/modules/payments/payments.service.spec.ts`
+
+- [ ] **Step 1: Inspect Payment.companyId field**
+
+Run: `grep -E "companyId" apps/api/prisma/schema.prisma | grep -B 1 -A 1 "model Payment"`
+Confirm: Payment has `companyId String @map("company_id")`.
+
+- [ ] **Step 2: Add failing test**
+
+```typescript
+it('passes payment.companyId to JournalAutoService on full payment (F-3-027 part 2)', async () => {
+  const journalAutoMock = { createPaymentJournal: jest.fn().mockResolvedValue('e1') };
+  // ... setup payment fixture with companyId='co-FINANCE'
+  await service.recordPayment(payment.id, /*...*/);
+  expect(journalAutoMock.createPaymentJournal).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ companyId: 'co-FINANCE' })
+  );
+});
+```
+
+- [ ] **Step 3: Verify fails**
+
+Run: `cd apps/api && npx jest payments.service.spec.ts -t "passes payment.companyId"`
+Expected: FAIL
+
+- [ ] **Step 4: Add `companyId: result.companyId` to all 3 createPaymentJournal call sites**
+
+Search for `createPaymentJournal` calls in `payments.service.ts`:
+
+Run: `grep -n "createPaymentJournal" apps/api/src/modules/payments/payments.service.ts`
+
+For each call (3 sites), add the field — example:
+
+```diff
+       await this.journalAutoService.createPaymentJournal(tx, {
++        companyId: result.companyId,
+         payment: { ... },
+         contract: { ... },
+         userId: recordedById,
+       });
+```
+
+For `autoAllocatePayment` and `allocateCreditBalance`, the `companyId` may need to come from the contract loaded earlier in the function. If the existing code loads `contract: { ..., companyId: ... }`, pass that. If not, add `companyId` to the contract select.
+
+- [ ] **Step 5: Verify pass + run full payments spec**
+
+Run: `cd apps/api && npx jest payments.service`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/payments/payments.service.ts apps/api/src/modules/payments/payments.service.spec.ts
+git commit -m "fix(payments): pass payment.companyId to JE callers (F-3-027 part 2)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Pass explicit companyId from accounting (expense)
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/accounting.service.ts:374-391` (markExpensePaid)
+
+- [ ] **Step 1: Inspect Expense → Branch → companyId path**
+
+Run: `grep -B 2 -A 10 "createExpenseJournal" apps/api/src/modules/accounting/accounting.service.ts`
+
+- [ ] **Step 2: Add failing test in `accounting.service.spec.ts`**
+
+```typescript
+it('passes branch.companyId to expense JE (F-3-027 part 2)', async () => {
+  const journalAutoMock = { createExpenseJournal: jest.fn().mockResolvedValue('e1') };
+  // expense in branch with companyId='co-SHOP'
+  await service.markExpensePaid(expense.id, /*...*/);
+  expect(journalAutoMock.createExpenseJournal).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ companyId: 'co-SHOP' })
+  );
+});
+```
+
+- [ ] **Step 3: Verify fails + load branch.companyId in markExpensePaid**
+
+In the existing query that loads the expense for journal creation, add:
+
+```diff
+       const expense = await tx.expense.findUnique({
+         where: { id },
+-        select: { /* ... existing fields */ },
++        select: { /* ... existing fields */, branch: { select: { companyId: true } } },
+       });
+```
+
+Then pass:
+
+```diff
+       await this.journalAutoService.createExpenseJournal(tx, {
++        companyId: expense.branch.companyId,
+         expense: { ... },
+         userId,
+       });
+```
+
+- [ ] **Step 4: Verify pass + run full accounting spec**
+
+Run: `cd apps/api && npx jest accounting.service`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/accounting/accounting.service.ts apps/api/src/modules/accounting/accounting.service.spec.ts
+git commit -m "fix(accounting): pass branch.companyId to expense JE (F-3-027 part 2)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Add `allowedCompanies` validation in `createAndPost`
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal-auto.service.ts:75-127`
+- Test: `apps/api/src/modules/journal/journal-auto.service.spec.ts`
+
+- [ ] **Step 1: Add failing test for FINANCE-only account on SHOP companyId**
+
+```typescript
+it('throws BadRequestException when SHOP companyId uses FINANCE-only account (F-3-027 part 3)', async () => {
+  const tx = {
+    companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'SHOP' }) },
+    chartOfAccount: { findMany: jest.fn().mockResolvedValue([
+      { code: '11-2102', nameTh: 'ลูกหนี้เช่าซื้อ', allowedCompanies: ['FINANCE'] },
+    ]) },
+    journalEntry: { count: jest.fn(), create: jest.fn() },
+  };
+  await expect((service as any).createAndPost(tx, {
+    companyId: 'co-SHOP',
+    entryDate: new Date(),
+    description: 'test',
+    referenceType: 'TEST', referenceId: 'test', createdById: 'u1',
+    lines: [
+      { accountCode: '11-2102', debit: 100, credit: 0 },
+      { accountCode: '11-1101', debit: 0, credit: 100 },
+    ],
+  })).rejects.toThrow(/11-2102.*ใช้ไม่ได้กับบริษัท SHOP/);
+});
+
+it('allows account with empty allowedCompanies for any companyId', async () => {
+  const tx = {
+    companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'SHOP' }) },
+    chartOfAccount: { findMany: jest.fn().mockResolvedValue([
+      { code: '11-1101', nameTh: 'เงินสด', allowedCompanies: [] },
+    ]) },
+    journalEntry: {
+      count: jest.fn().mockResolvedValue(0),
+      create: jest.fn().mockResolvedValue({ id: 'entry1' }),
+    },
+  };
+  await expect((service as any).createAndPost(tx, {
+    companyId: 'co-SHOP',
+    entryDate: new Date(),
+    description: 'test',
+    referenceType: 'TEST', referenceId: 'test', createdById: 'u1',
+    lines: [
+      { accountCode: '11-1101', debit: 100, credit: 0 },
+      { accountCode: '11-1101', debit: 0, credit: 100 },
+    ],
+  })).resolves.toBe('entry1');
+});
+```
+
+- [ ] **Step 2: Verify fails**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "throws BadRequestException when SHOP"`
+Expected: FAIL — current code doesn't validate
+
+- [ ] **Step 3: Add validation in createAndPost**
+
+In `journal-auto.service.ts createAndPost`, after the balance check (around line 100, before `generateEntryNumber`):
+
+```typescript
+// Validate allowedCompanies (F-3-027 part 3)
+const codes = [...new Set(lines.map(l => l.accountCode))];
+const [accounts, company] = await Promise.all([
+  tx.chartOfAccount.findMany({
+    where: { code: { in: codes } },
+    select: { code: true, nameTh: true, allowedCompanies: true },
+  }),
+  tx.companyInfo.findUnique({
+    where: { id: params.companyId },
+    select: { companyCode: true },
+  }),
+]);
+if (!company) {
+  throw new BadRequestException(`Company ${params.companyId} not found`);
+}
+for (const acc of accounts) {
+  if (acc.allowedCompanies.length > 0 && !acc.allowedCompanies.includes(company.companyCode)) {
+    throw new BadRequestException(
+      `Account ${acc.code} (${acc.nameTh}) ใช้ไม่ได้กับบริษัท ${company.companyCode}`
+    );
+  }
+}
+```
+
+Add the import at top of file:
+
+```typescript
+import { BadRequestException, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+```
+
+(BadRequestException may already be imported — check.)
+
+- [ ] **Step 4: Verify pass**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "throws BadRequestException when SHOP"`
+Expected: PASS
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "allows account with empty allowedCompanies"`
+Expected: PASS
+
+- [ ] **Step 5: Run full journal-auto spec + verify no regression**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts`
+Expected: All PASS. Some existing tests may need to mock `chartOfAccount.findMany` and `companyInfo.findUnique` — add stubs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/journal/journal-auto.service.ts apps/api/src/modules/journal/journal-auto.service.spec.ts
+git commit -m "fix(journal): validate allowedCompanies in createAndPost (F-3-027 part 3)
+
+Throws BadRequestException if any account in the JE has allowedCompanies
+that excludes the entry's companyCode. Closes the gap where
+journal-auto.service.ts was bypassing the validation that
+journal.service.ts already enforced for manual entries.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Wave 2 verification + checkpoint
+
+- [ ] **Step 1: TypeScript check**
+
+Run: `./tools/check-types.sh api`
+Expected: 0 errors
+
+- [ ] **Step 2: Run all journal + payments + contracts + accounting specs**
+
+Run: `cd apps/api && npx jest journal payments contracts/contract-workflow accounting`
+Expected: All PASS
+
+- [ ] **Step 3: User checkpoint**
+
+Wave 2 complete. Proceed to Wave 3?
+
+---
+
+## Wave 3 — Other try/catch removals (Tasks 11-12)
+
+### Task 11: Remove try/catch on expense JE
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/accounting.service.ts:374-391`
+
+- [ ] **Step 1: Add failing test for atomic expense rollback**
+
+In `accounting.service.spec.ts`:
+
+```typescript
+it('rolls back expense markPaid if JE creation throws (F-1-016)', async () => {
+  const journalAutoMock = {
+    createExpenseJournal: jest.fn().mockRejectedValue(new Error('JE failed')),
+  };
+  // ...
+  await expect(service.markExpensePaid(expense.id, /*...*/)).rejects.toThrow('JE failed');
+  const after = await prisma.expense.findUnique({ where: { id: expense.id } });
+  expect(after.status).not.toBe('PAID');
+});
+```
+
+- [ ] **Step 2: Verify fails**
+
+Run: `cd apps/api && npx jest accounting.service.spec.ts -t "rolls back expense markPaid"`
+Expected: FAIL
+
+- [ ] **Step 3: Remove try/catch around createExpenseJournal**
+
+Edit `accounting.service.ts:374-391`:
+
+```diff
+-      try {
+-        await this.journalAutoService.createExpenseJournal(tx, { /* ... */ });
+-      } catch (err) {
+-        this.logger.error(`Auto-journal failed for expense ${updated.id}: ${err}`);
+-      }
++      // Atomic with expense payment: if JE fails, transaction rolls back.
++      await this.journalAutoService.createExpenseJournal(tx, { /* ... */ });
+```
+
+- [ ] **Step 4: Verify pass + commit**
+
+Run: `cd apps/api && npx jest accounting.service`
+Expected: All PASS
+
+```bash
+git add apps/api/src/modules/accounting/accounting.service.ts apps/api/src/modules/accounting/accounting.service.spec.ts
+git commit -m "fix(accounting): remove try/catch on expense JE (F-1-016)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Remove try/catch on receipt VOID
+
+**Files:**
+- Modify: `apps/api/src/modules/receipts/receipts.service.ts:407-426`
+
+- [ ] **Step 1: Add failing test in receipts.service.spec.ts**
+
+```typescript
+it('rolls back receipt void if reversal JE throws (F-1-017)', async () => {
+  const journalAutoMock = {
+    createReversalJournal: jest.fn().mockRejectedValue(new Error('JE failed')),
+  };
+  // ...
+  await expect(service.voidReceipt(receipt.id, /*...*/)).rejects.toThrow('JE failed');
+  const after = await prisma.receipt.findUnique({ where: { id: receipt.id } });
+  expect(after.status).not.toBe('VOIDED');
+});
+```
+
+- [ ] **Step 2: Verify fails**
+
+Run: `cd apps/api && npx jest receipts.service.spec.ts -t "rolls back receipt void"`
+Expected: FAIL
+
+- [ ] **Step 3: Remove try/catch**
+
+Edit `receipts.service.ts:407-426`:
+
+```diff
+-      try {
+-        await this.journalAutoService.createReversalJournal(tx, { /* ... */ });
+-      } catch (err) {
+-        this.logger.error(`Auto-reversal failed for receipt ${id}: ${err}`);
+-      }
++      // Atomic with receipt void: if reversal JE fails, transaction rolls back.
++      await this.journalAutoService.createReversalJournal(tx, { /* ... */ });
+```
+
+- [ ] **Step 4: Verify pass + commit**
+
+Run: `cd apps/api && npx jest receipts.service`
+Expected: All PASS
+
+```bash
+git add apps/api/src/modules/receipts/receipts.service.ts apps/api/src/modules/receipts/receipts.service.spec.ts
+git commit -m "fix(receipts): remove try/catch on void reversal JE (F-1-017)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Wave 4 — PaySolutions Webhook (Tasks 13-15)
+
+### Task 13: Import JournalModule in PaySolutionsModule
+
+**Files:**
+- Modify: `apps/api/src/modules/paysolutions/paysolutions.module.ts`
+
+- [ ] **Step 1: Read current module imports**
+
+Run: `cat apps/api/src/modules/paysolutions/paysolutions.module.ts`
+
+- [ ] **Step 2: Add JournalModule import**
+
+```diff
+ import { Module } from '@nestjs/common';
++import { JournalModule } from '../journal/journal.module';
+ ...
+
+ @Module({
+-  imports: [ /* existing */ ],
++  imports: [ /* existing */, JournalModule ],
+   ...
+ })
+ export class PaySolutionsModule {}
+```
+
+- [ ] **Step 3: Verify JournalAutoService is exported from JournalModule**
+
+Run: `grep -E "exports|JournalAutoService" apps/api/src/modules/journal/journal.module.ts`
+Expected: `exports: [JournalService, JournalAutoService]` (if not, add to exports)
+
+- [ ] **Step 4: TypeScript check**
+
+Run: `./tools/check-types.sh api`
+Expected: 0 errors
+
+(No commit yet — combine with Task 14 in single commit since module change is meaningless without service usage.)
+
+---
+
+### Task 14: Inject + use JournalAutoService in PaySolutionsService
+
+**Files:**
+- Modify: `apps/api/src/modules/paysolutions/paysolutions.service.ts:713-816`
+- Test: `apps/api/src/modules/paysolutions/paysolutions.service.spec.ts`
+
+- [ ] **Step 1: Add failing test for webhook posts JE**
+
+```typescript
+it('posts payment JE on successful webhook callback (F-1-003)', async () => {
+  const journalAutoMock = {
+    createPaymentJournal: jest.fn().mockResolvedValue('je-1'),
+  };
+  const service = new PaySolutionsService(prisma, /*...other deps*/, journalAutoMock as any);
+
+  // setup: a Payment row in PENDING + a successful webhook payload
+  const payment = await prisma.payment.create({ data: { /* ... */ } });
+  await service.handlePaymentCallback({ /* webhook payload */ });
+
+  expect(journalAutoMock.createPaymentJournal).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      companyId: payment.companyId,
+      payment: expect.objectContaining({ id: payment.id }),
+    })
+  );
+});
+
+it('does not block payment processing if JE creation fails (F-1-003 P2 pattern)', async () => {
+  const journalAutoMock = {
+    createPaymentJournal: jest.fn().mockRejectedValue(new Error('JE failed')),
+  };
+  const sentryMock = jest.spyOn(Sentry, 'captureException').mockImplementation(() => 'eid');
+  // ... setup
+  await expect(service.handlePaymentCallback({ /* payload */ })).resolves.not.toThrow();
+  const after = await prisma.payment.findUnique({ where: { id: payment.id } });
+  expect(after.status).toBe('PAID'); // Payment processing succeeded despite JE failure
+  expect(sentryMock).toHaveBeenCalledWith(
+    expect.any(Error),
+    expect.objectContaining({ tags: expect.objectContaining({ module: 'paysolutions' }) })
+  );
+});
+```
+
+- [ ] **Step 2: Verify both fail**
+
+Run: `cd apps/api && npx jest paysolutions.service.spec.ts -t "F-1-003"`
+Expected: FAIL on both
+
+- [ ] **Step 3: Add JournalAutoService injection**
+
+In `paysolutions.service.ts` constructor:
+
+```diff
++import { JournalAutoService } from '../journal/journal-auto.service';
++import * as Sentry from '@sentry/node';
+ ...
+   constructor(
+     private prisma: PrismaService,
+     // ... existing
++    private journalAutoService: JournalAutoService,
+   ) {}
+```
+
+- [ ] **Step 4: Add JE creation in webhook handler**
+
+Inside `handlePaymentCallback` `$transaction`, after the Payment.update to PAID and after determining `wasFullyPaid`:
+
+```typescript
+// Auto journal entry — Sentry+log+continue pattern (P2): webhook MUST NOT block payment
+if (paymentUpdated.status === 'PAID') {
+  try {
+    await this.journalAutoService.createPaymentJournal(tx, {
+      companyId: paymentUpdated.companyId,
+      payment: {
+        id: paymentUpdated.id,
+        installmentNo: paymentUpdated.installmentNo,
+        amountPaid: paymentUpdated.amountPaid,
+        monthlyPrincipal: paymentUpdated.monthlyPrincipal,
+        monthlyInterest: paymentUpdated.monthlyInterest,
+        monthlyCommission: paymentUpdated.monthlyCommission,
+        vatAmount: paymentUpdated.vatAmount,
+        lateFee: paymentUpdated.lateFee,
+        lateFeeWaived: paymentUpdated.lateFeeWaived,
+        paidDate: paymentUpdated.paidDate,
+      },
+      contract: {
+        contractNumber: contract.contractNumber,
+        branchId: contract.branchId,
+      },
+      userId: 'paysolutions-webhook',  // system user for webhook-originated entries
+    });
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { module: 'paysolutions', event: 'webhook-je-failure' },
+      extra: { paymentId: paymentUpdated.id, contractId: contract.id, error: String(err) },
+    });
+    this.logger.error(`Webhook JE failed for payment ${paymentUpdated.id}: ${err}`);
+    // DO NOT rethrow — let payment processing continue
+  }
+}
+```
+
+- [ ] **Step 5: Verify both tests pass**
+
+Run: `cd apps/api && npx jest paysolutions.service.spec.ts -t "F-1-003"`
+Expected: PASS on both
+
+- [ ] **Step 6: Run full paysolutions spec**
+
+Run: `cd apps/api && npx jest paysolutions`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/modules/paysolutions/paysolutions.module.ts apps/api/src/modules/paysolutions/paysolutions.service.ts apps/api/src/modules/paysolutions/paysolutions.service.spec.ts
+git commit -m "fix(paysolutions): post payment JE in webhook callback (F-1-003)
+
+Inject JournalAutoService into PaySolutionsService. After Payment.update
+to PAID inside the webhook \$transaction, call createPaymentJournal.
+
+Pattern P2 (Sentry+log+continue): if JE creation throws, log + Sentry
+alert but DO NOT rethrow — webhook must not block payment processing.
+Customer paid via QR; manual reconciliation from Sentry alert.
+
+Closes the source of 36 orphan payments observed in production audit
+(Layer 4 finding F-4-001).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: Wave 4 verification + checkpoint
+
+- [ ] **Step 1: TypeScript check**
+
+Run: `./tools/check-types.sh api`
+Expected: 0 errors
+
+- [ ] **Step 2: Run all changed module specs**
+
+Run: `cd apps/api && npx jest journal payments contracts accounting receipts paysolutions`
+Expected: All PASS
+
+- [ ] **Step 3: User checkpoint**
+
+Wave 4 complete. Proceed to Wave 5?
+
+---
+
+## Wave 5 — Period Close Hardening (Tasks 16-21)
+
+### Task 16: Migration for AccountingPeriod reopen audit fields
+
+**Files:**
+- Create: `apps/api/prisma/migrations/{timestamp}_add_period_reopen_audit_fields/migration.sql`
+- Modify: `apps/api/prisma/schema.prisma` (AccountingPeriod model)
+
+- [ ] **Step 1: Update schema**
+
+Edit `apps/api/prisma/schema.prisma` AccountingPeriod model — add 3 fields after existing `closedById`:
+
+```diff
+   closedAt          DateTime? @map("closed_at")
+   closedById        String?   @map("closed_by_id")
+   closedBy          User?     @relation("PeriodClosedBy", fields: [closedById], references: [id])
+
++  reopenedAt        DateTime? @map("reopened_at")
++  reopenedById      String?   @map("reopened_by_id")
++  reopenedBy        User?     @relation("PeriodReopenedBy", fields: [reopenedById], references: [id])
++  boardResolutionId String?   @map("board_resolution_id")
++
+   peakSyncedAt   DateTime? @map("peak_synced_at")
+```
+
+(Also add `PeriodReopenedBy User[] @relation("PeriodReopenedBy")` to the User model.)
+
+- [ ] **Step 2: Generate migration**
+
+Run: `cd apps/api && npx prisma migrate dev --name add_period_reopen_audit_fields --create-only`
+Expected: New migration folder created. Verify SQL only adds 3 nullable columns + new FK.
+
+- [ ] **Step 3: Apply migration to dev DB + regenerate client**
+
+Run: `cd apps/api && npx prisma migrate deploy && npx prisma generate`
+Expected: Migration applies cleanly.
+
+- [ ] **Step 4: TypeScript check**
+
+Run: `./tools/check-types.sh api`
+Expected: 0 errors (the new fields will be required by tests, not by existing code)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "feat(accounting): add reopen audit fields to AccountingPeriod (F-6-004)
+
+reopenedAt + reopenedById + boardResolutionId — 3 optional fields to
+persist who/when/why for period reopen actions. Adding nullable so
+existing rows are unaffected.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 17: `JournalService.post()` validatePeriodOpen
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal.service.ts:200`
+- Test: `apps/api/src/modules/journal/journal.service.spec.ts`
+
+- [ ] **Step 1: Add failing test**
+
+```typescript
+it('blocks post() if entryDate is in CLOSED period (F-6-001)', async () => {
+  // Setup: AccountingPeriod for 2025-03 with status=CLOSED
+  await prisma.accountingPeriod.create({ data: { companyId: 'co1', year: 2025, month: 3, status: 'CLOSED', closedAt: new Date() } });
+  // Setup: DRAFT JE with entryDate=2025-03-15
+  const entry = await prisma.journalEntry.create({ data: { /* DRAFT, entryDate: 2025-03-15, companyId: co1 */ } });
+
+  await expect(service.post(entry.id, 'user1')).rejects.toThrow(/CLOSED|locked/i);
+});
+```
+
+- [ ] **Step 2: Verify fails**
+
+Run: `cd apps/api && npx jest journal.service.spec.ts -t "blocks post"`
+Expected: FAIL
+
+- [ ] **Step 3: Add validatePeriodOpen call**
+
+Edit `journal.service.ts post()`:
+
+```typescript
+import { validatePeriodOpen } from '../../utils/period-lock.util';
+// ... in post() at start:
+async post(id: string, userId: string, meta?: any) {
+  const entry = await this.findOne(id);
+  if (entry.status !== 'DRAFT') throw new BadRequestException('Only DRAFT entries can be posted');
+  // F-6-001: prevent posting into CLOSED period
+  await validatePeriodOpen(this.prisma, entry.entryDate, entry.companyId);
+  // ... existing balance re-check + transaction
+}
+```
+
+- [ ] **Step 4: Verify pass + commit**
+
+Run: `cd apps/api && npx jest journal.service.spec.ts`
+Expected: All PASS
+
+```bash
+git add apps/api/src/modules/journal/journal.service.ts apps/api/src/modules/journal/journal.service.spec.ts
+git commit -m "fix(journal): post() validates period open (F-6-001)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 18: `JournalAutoService.createAndPost` soft-block CLOSED period
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal-auto.service.ts createAndPost`
+- Test: `apps/api/src/modules/journal/journal-auto.service.spec.ts`
+
+- [ ] **Step 1: Add failing test**
+
+```typescript
+it('redirects entryDate to current period if originally in CLOSED period (F-6-002)', async () => {
+  const tx = {
+    accountingPeriod: { findFirst: jest.fn().mockResolvedValue({ status: 'CLOSED' }) },
+    companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'FINANCE' }) },
+    chartOfAccount: { findMany: jest.fn().mockResolvedValue([]) },
+    journalEntry: {
+      count: jest.fn().mockResolvedValue(0),
+      create: jest.fn().mockImplementation(({ data }) => Promise.resolve({ id: 'e1', _captured: data })),
+    },
+  };
+  const sentrySpy = jest.spyOn(Sentry, 'captureMessage').mockImplementation(() => 'eid');
+  const originalDate = new Date('2025-03-15');
+
+  await (service as any).createAndPost(tx, {
+    companyId: 'co1', entryDate: originalDate, description: 'Original',
+    referenceType: 'TEST', referenceId: 'test', createdById: 'u1',
+    lines: [
+      { accountCode: '11-1101', debit: 100, credit: 0 },
+      { accountCode: '21-2101', debit: 0, credit: 100 },
+    ],
+  });
+
+  const created = tx.journalEntry.create.mock.calls[0][0].data;
+  expect(created.entryDate.getFullYear()).toBe(new Date().getFullYear());
+  expect(created.description).toMatch(/^\[Originally for 2025-03\]/);
+  expect(sentrySpy).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Verify fails**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts -t "redirects entryDate"`
+Expected: FAIL
+
+- [ ] **Step 3: Add soft-block logic in createAndPost**
+
+After balance check + allowedCompanies check, add:
+
+```typescript
+// F-6-002: soft-block — if entryDate falls in CLOSED period, redirect to current period
+let entryDate = params.entryDate;
+let description = params.description;
+const period = await tx.accountingPeriod.findFirst({
+  where: {
+    companyId: params.companyId,
+    year: entryDate.getFullYear(),
+    month: entryDate.getMonth() + 1,
+    status: { in: ['CLOSED', 'SYNCED'] },
+  },
+  select: { status: true },
+});
+if (period) {
+  const originalYM = `${entryDate.getFullYear()}-${String(entryDate.getMonth() + 1).padStart(2, '0')}`;
+  this.logger.warn(`Auto-JE redirected from CLOSED ${originalYM} to current period`);
+  Sentry.captureMessage(`Auto-JE redirect: ${originalYM} → current`, {
+    level: 'warning',
+    tags: { kind: 'journal', referenceType: params.referenceType },
+    extra: { referenceId: params.referenceId, originalYM },
+  });
+  description = `[Originally for ${originalYM}] ${description}`;
+  entryDate = new Date();
+}
+```
+
+Then use `entryDate` and `description` (local vars) instead of `params.entryDate` / `params.description` in the `journalEntry.create` data block.
+
+- [ ] **Step 4: Verify pass + commit**
+
+Run: `cd apps/api && npx jest journal-auto.service.spec.ts`
+Expected: All PASS (existing tests may need to mock `accountingPeriod.findFirst` returning null)
+
+```bash
+git add apps/api/src/modules/journal/journal-auto.service.ts apps/api/src/modules/journal/journal-auto.service.spec.ts
+git commit -m "fix(journal): auto-JE soft-blocks CLOSED period (F-6-002)
+
+If entryDate falls in CLOSED/SYNCED period, redirect to current period
++ prepend '[Originally for YYYY-MM]' to description + Sentry warning.
+Webhook payments must not fail just because period is closed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 19: `closePeriod` enforce auditIssues with OWNER override
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/monthly-close.service.ts:154`
+- Modify: `apps/api/src/modules/accounting/dto/close-month.dto.ts` (add `forceCloseReason` field)
+- Test: `apps/api/src/modules/accounting/monthly-close.service.spec.ts`
+
+- [ ] **Step 1: Add field to DTO**
+
+Edit `close-month.dto.ts`:
+
+```diff
++import { IsOptional, IsString, MinLength } from 'class-validator';
+ export class CloseMonthDto {
+   /* existing fields */
++  @IsOptional()
++  @IsString()
++  @MinLength(50, { message: 'forceCloseReason ต้อง ≥50 ตัวอักษร' })
++  forceCloseReason?: string;
+ }
+```
+
+- [ ] **Step 2: Add failing tests**
+
+```typescript
+it('blocks closePeriod when auditIssues.hasIssues=true and no forceCloseReason (F-6-003)', async () => {
+  const period = await prisma.accountingPeriod.create({ data: {
+    companyId: 'co1', year: 2026, month: 4, status: 'REVIEW',
+    auditIssues: { hasIssues: true, unbalancedJournals: 2 } as any,
+  }});
+  await expect(service.closePeriod({ companyId: 'co1', year: 2026, month: 4 } as any, 'user1')).rejects.toThrow(/issue/i);
+});
+
+it('allows closePeriod with forceCloseReason ≥50 chars + creates AuditLog (F-6-003)', async () => {
+  const period = await prisma.accountingPeriod.create({ data: {
+    companyId: 'co1', year: 2026, month: 4, status: 'REVIEW',
+    auditIssues: { hasIssues: true, unbalancedJournals: 2 } as any,
+  }});
+  const reason = 'Issues acknowledged: unbalanced JEs traced to test data, will be cleaned in next sprint, force-closing for owner sign-off';
+  await service.closePeriod({ companyId: 'co1', year: 2026, month: 4, forceCloseReason: reason } as any, 'user1');
+  const auditLog = await prisma.auditLog.findFirst({ where: { action: 'PERIOD_FORCE_CLOSE' } });
+  expect(auditLog).not.toBeNull();
+  expect(auditLog?.userId).toBe('user1');
+});
+```
+
+- [ ] **Step 3: Verify fails**
+
+Run: `cd apps/api && npx jest monthly-close.service.spec.ts -t "F-6-003"`
+Expected: FAIL on both
+
+- [ ] **Step 4: Add enforcement in closePeriod**
+
+In `monthly-close.service.ts closePeriod()`, after the `existing.status !== 'REVIEW'` check, add:
+
+```typescript
+// F-6-003: enforce auditIssues unless OWNER provides forceCloseReason
+const hasIssues = (existing.auditIssues as any)?.hasIssues === true;
+if (hasIssues && !dto.forceCloseReason) {
+  throw new BadRequestException({
+    message: 'พบ issue ในงวดนี้ ต้องแก้ก่อนปิด หรือใส่ forceCloseReason (≥50 ตัวอักษร)',
+    issues: existing.auditIssues,
+  });
+}
+```
+
+Inside the `$transaction`, before/alongside the period.update to CLOSED, add:
+
+```typescript
+if (dto.forceCloseReason) {
+  await tx.auditLog.create({
+    data: {
+      userId,
+      action: 'PERIOD_FORCE_CLOSE',
+      entity: 'accounting_period',
+      entityId: existing.id,
+      details: {
+        reason: dto.forceCloseReason,
+        issues: existing.auditIssues,
+        period: `${existing.year}-${String(existing.month).padStart(2, '0')}`,
+      } as any,
+    },
+  });
+}
+```
+
+- [ ] **Step 5: Verify pass + commit**
+
+Run: `cd apps/api && npx jest monthly-close.service.spec.ts`
+Expected: All PASS
+
+```bash
+git add apps/api/src/modules/accounting/monthly-close.service.ts apps/api/src/modules/accounting/dto/close-month.dto.ts apps/api/src/modules/accounting/monthly-close.service.spec.ts
+git commit -m "fix(accounting): closePeriod enforces auditIssues with OWNER override (F-6-003)
+
+If auditIssues.hasIssues=true, throw BadRequestException unless
+forceCloseReason (≥50 chars) provided. Force close creates AuditLog
+PERIOD_FORCE_CLOSE for traceability.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 20: `reopenPeriod` audit trail + persistent fields
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/accounting.controller.ts:268`
+- Modify: `apps/api/src/modules/accounting/monthly-close.service.ts:253`
+- Modify: `apps/api/src/modules/accounting/dto/reopen-period.dto.ts` (or create if absent)
+
+- [ ] **Step 1: Update DTO**
+
+Edit `reopen-period.dto.ts` (create if absent):
+
+```typescript
+import { IsString, MinLength } from 'class-validator';
+
+export class ReopenPeriodDto {
+  @IsString() companyId!: string;
+  @IsString() @MinLength(1) boardResolutionId!: string;
+  @IsString() @MinLength(20, { message: 'reason ต้อง ≥20 ตัวอักษร' }) reason!: string;
+  year!: number;
+  month!: number;
+}
+```
+
+- [ ] **Step 2: Add failing test**
+
+```typescript
+it('reopenPeriod creates AuditLog with userId + boardResolutionId (F-6-004)', async () => {
+  const period = await prisma.accountingPeriod.create({ data: {
+    companyId: 'co1', year: 2026, month: 3, status: 'CLOSED', closedAt: new Date(),
+  }});
+  await service.reopenPeriod({
+    companyId: 'co1', year: 2026, month: 3,
+    boardResolutionId: 'BR-2026-001',
+    reason: 'Material misstatement found in March, restating per CPA recommendation',
+  }, 'user-OWNER-1');
+  const after = await prisma.accountingPeriod.findUnique({ where: { id: period.id } });
+  expect(after?.status).toBe('OPEN');
+  expect(after?.reopenedById).toBe('user-OWNER-1');
+  expect(after?.boardResolutionId).toBe('BR-2026-001');
+  const auditLog = await prisma.auditLog.findFirst({ where: { action: 'PERIOD_REOPEN' } });
+  expect(auditLog).not.toBeNull();
+  expect(auditLog?.userId).toBe('user-OWNER-1');
+});
+```
+
+- [ ] **Step 3: Verify fails**
+
+Run: `cd apps/api && npx jest monthly-close.service.spec.ts -t "F-6-004"`
+Expected: FAIL
+
+- [ ] **Step 4: Update controller to capture userId**
+
+Edit `accounting.controller.ts:268`:
+
+```diff
+   @Post('periods/reopen')
+   @Roles('OWNER')
+-  async reopenPeriod(@Body() dto: ReopenPeriodDto) {
+-    return this.monthlyCloseService.reopenPeriod(dto);
++  async reopenPeriod(@Body() dto: ReopenPeriodDto, @Request() req: any) {
++    return this.monthlyCloseService.reopenPeriod(dto, req.user.id);
+   }
+```
+
+Add `import { Request } from '@nestjs/common';` if absent.
+
+- [ ] **Step 5: Update service to persist + audit**
+
+Edit `monthly-close.service.ts reopenPeriod`:
+
+```diff
+-  async reopenPeriod(dto: ReopenPeriodDto) {
++  async reopenPeriod(dto: ReopenPeriodDto, userId: string) {
+     // ... existing existence/status checks
+     return this.prisma.$transaction(async (tx) => {
+       const updated = await tx.accountingPeriod.update({
+         where: { id: existing.id },
+         data: {
+           status: 'OPEN',
+           closedAt: null,
+           closedById: null,
+           auditIssues: undefined,
+           reportSnapshot: undefined,
++          reopenedAt: new Date(),
++          reopenedById: userId,
++          boardResolutionId: dto.boardResolutionId,
+         },
+       });
++      await tx.auditLog.create({
++        data: {
++          userId,
++          action: 'PERIOD_REOPEN',
++          entity: 'accounting_period',
++          entityId: existing.id,
++          details: {
++            boardResolutionId: dto.boardResolutionId,
++            reason: dto.reason,
++            period: `${existing.year}-${String(existing.month).padStart(2, '0')}`,
++          } as any,
++        },
++      });
+       return updated;
+     });
+   }
+```
+
+- [ ] **Step 6: Verify pass + commit**
+
+Run: `cd apps/api && npx jest monthly-close.service.spec.ts`
+Expected: All PASS
+
+```bash
+git add apps/api/src/modules/accounting/accounting.controller.ts apps/api/src/modules/accounting/monthly-close.service.ts apps/api/src/modules/accounting/dto/reopen-period.dto.ts apps/api/src/modules/accounting/monthly-close.service.spec.ts
+git commit -m "fix(accounting): reopenPeriod persists audit fields + creates AuditLog (F-6-004)
+
+Controller captures req.user.id and passes to service.
+Service persists reopenedAt/reopenedById/boardResolutionId on the period
++ creates AuditLog PERIOD_REOPEN with reason + board resolution.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 21: Wave 5 verification + checkpoint
+
+- [ ] **Step 1: Full TypeScript + test run**
+
+Run: `./tools/check-types.sh all && cd apps/api && npx jest`
+Expected: 0 type errors + all tests pass
+
+- [ ] **Step 2: Migration verification**
+
+Run: `cd apps/api && npx prisma migrate status`
+Expected: All migrations applied, no drift
+
+- [ ] **Step 3: User checkpoint**
+
+Wave 5 complete. Proceed to E2E + final verification?
+
+---
+
+## E2E Tests (Task 22)
+
+### Task 22: 3 new E2E tests
+
+**Files:**
+- Create: `apps/web/e2e/accounting-contract-activation.spec.ts`
+- Create: `apps/web/e2e/accounting-paysolutions-webhook.spec.ts`
+- Create: `apps/web/e2e/accounting-period-close.spec.ts`
+
+- [ ] **Step 1: Read existing E2E spec for pattern reference**
+
+Run: `ls apps/web/e2e/*.spec.ts | head -5 && head -30 apps/web/e2e/$(ls apps/web/e2e/*.spec.ts | head -1 | xargs basename)`
+
+- [ ] **Step 2: Create contract activation E2E**
+
+Write `apps/web/e2e/accounting-contract-activation.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { loginAsOwner } from './helpers/auth';
+
+test.describe('Accounting — Contract Activation creates JE', () => {
+  test('activated contract has matching JournalEntry (F-2-001 + F-1-002 verification)', async ({ page, request }) => {
+    await loginAsOwner(page);
+
+    // Create + activate contract via UI (or API for speed)
+    const created = await request.post('/api/contracts', { data: { /* fixture */ } });
+    const { id, contractNumber } = await created.json();
+    await request.post(`/api/contracts/${id}/activate`);
+
+    // Verify JE exists + balanced
+    const jeRes = await request.get(`/api/journal-entries?referenceType=CONTRACT&referenceId=${id}`);
+    const jes = await jeRes.json();
+    expect(jes.data).toHaveLength(2); // sales + COGS entries
+    for (const je of jes.data) {
+      const totalDr = je.lines.reduce((s: number, l: any) => s + Number(l.debit), 0);
+      const totalCr = je.lines.reduce((s: number, l: any) => s + Number(l.credit), 0);
+      expect(Math.abs(totalDr - totalCr)).toBeLessThan(0.01);
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Create PaySolutions webhook E2E**
+
+Write `apps/web/e2e/accounting-paysolutions-webhook.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Accounting — PaySolutions webhook creates JE', () => {
+  test('webhook callback creates Payment + JournalEntry (F-1-003 verification)', async ({ request }) => {
+    // Setup: create a test contract + payment in PENDING via API
+    // ... fixture setup
+
+    // Mock webhook call
+    const webhookRes = await request.post('/api/paysolutions/webhook', {
+      data: { /* payload matching PaySolutions format */ },
+      headers: { /* required signature/auth */ },
+    });
+    expect(webhookRes.ok()).toBe(true);
+
+    // Verify Payment is PAID
+    const paymentRes = await request.get(`/api/payments/${paymentId}`);
+    const payment = await paymentRes.json();
+    expect(payment.status).toBe('PAID');
+
+    // Verify JE was created
+    const jeRes = await request.get(`/api/journal-entries?referenceType=PAYMENT&referenceId=${paymentId}`);
+    const jes = await jeRes.json();
+    expect(jes.data.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 4: Create period close E2E**
+
+Write `apps/web/e2e/accounting-period-close.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { loginAsOwner } from './helpers/auth';
+
+test.describe('Accounting — Period Close hardening', () => {
+  test('blocks close when auditIssues.hasIssues; allows with forceCloseReason (F-6-003)', async ({ page, request }) => {
+    await loginAsOwner(page);
+
+    // Setup: period with hasIssues=true via test fixture endpoint
+    const setup = await request.post('/api/test-fixtures/period-with-issues', {
+      data: { companyId: '...', year: 2026, month: 4 },
+    });
+
+    // Without forceCloseReason
+    const reject = await request.post('/api/expenses/periods/close', {
+      data: { companyId: '...', year: 2026, month: 4 },
+    });
+    expect(reject.status()).toBe(400);
+
+    // With forceCloseReason
+    const accept = await request.post('/api/expenses/periods/close', {
+      data: {
+        companyId: '...', year: 2026, month: 4,
+        forceCloseReason: 'Issues acknowledged: traced to test data, will be cleaned in next sprint, force-closing per owner sign-off',
+      },
+    });
+    expect(accept.ok()).toBe(true);
+
+    // Verify AuditLog
+    const audit = await request.get('/api/audit-logs?action=PERIOD_FORCE_CLOSE');
+    const logs = await audit.json();
+    expect(logs.data.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 5: Run E2E locally**
+
+Run: `cd apps/web && npx playwright test accounting-`
+Expected: All 3 PASS
+
+If failures relate to chat_snoozes drift (memory `project_chat_snoozes_migration_drift.md`), document but proceed — that's a separate pre-existing issue.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/e2e/accounting-*.spec.ts
+git commit -m "test(accounting): add E2E for activation JE, webhook JE, period close (Phase A.0)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final Verification + PR (Task 23)
+
+### Task 23: Comprehensive check + push + open PR
+
+- [ ] **Step 1: Full TypeScript check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors
+
+- [ ] **Step 2: Full unit test suite**
+
+Run: `cd apps/api && npx jest`
+Expected: All PASS (existing 577 + ~20 new)
+
+- [ ] **Step 3: Lint check**
+
+Run: `cd apps/api && npm run lint && cd ../web && npm run lint`
+Expected: 0 errors
+
+- [ ] **Step 4: Local E2E smoke**
+
+Run: `cd apps/web && npx playwright test --grep="accounting"`
+Expected: All PASS (3 new + any related existing)
+
+- [ ] **Step 5: Run /review subagent before push**
+
+Use the code-reviewer subagent on all changed files in this branch:
+
+```
+diff --stat origin/main...HEAD
+```
+
+Dispatch code-reviewer with: "Review all changes in branch feat/accounting-phase-a0-critical-fix vs main. Spec: docs/superpowers/specs/2026-04-29-accounting-phase-a0-critical-fix-design.md. Check: spec coverage, missing tests, type consistency, severity of any new issues. Output finding list."
+
+Fix any CRITICAL or WARNING findings inline.
+
+- [ ] **Step 6: Push branch**
+
+Run: `git push -u origin feat/accounting-phase-a0-critical-fix`
+Expected: branch pushed
+
+- [ ] **Step 7: Open PR via gh**
+
+```bash
+gh pr create --title "feat(accounting): Phase A.0 critical fix — math + try/catch + webhook + period close" --body "$(cat <<'EOF'
+## Summary
+
+Phase A.0 of the accounting fix plan from the 2026-04-29 audit. Code-only fixes (no CoA changes, no policy decisions). 11 fixes in 5 waves.
+
+### Critical chain fixed
+- **F-2-001**: hpReceivable double-counting math bug (1 line)
+- **F-1-002**: try/catch swallowing activation JE failures (3 sites)
+- **F-1-003**: PaySolutions webhook now posts payment JE (was source of 36 orphan payments in prod)
+- **F-3-027**: allowedCompanies validation in createAndPost + deterministic resolveCompanyId
+
+### Period close hardened
+- **F-6-001**: JournalService.post() validates period not CLOSED
+- **F-6-002**: JournalAutoService soft-blocks CLOSED period (redirects to current)
+- **F-6-003**: closePeriod enforces auditIssues with OWNER forceCloseReason override
+- **F-6-004**: reopenPeriod persists audit trail + AuditLog
+
+### Out of scope (future phases)
+- CoA reconciliation → A.1 (blocked on owner business decision)
+- Policy fixes (interest, commission, VAT, inter-company) → A.2 (CPA pending)
+- Backfill 36 orphan payments + historical activations → A.3 (after A.0 + A.1 deployed)
+
+## Test plan
+- [ ] All unit tests pass (existing 577 + ~20 new)
+- [ ] All E2E tests pass (3 new + existing)
+- [ ] Sentry no error spike for 1 hour post-deploy
+- [ ] Manual: 1 contract activation → JE exists + balanced
+- [ ] Manual: 1 PaySolutions test webhook → JE exists
+- [ ] Layer 4 prod re-run after 24h → no NEW orphan payments
+
+Spec: \`docs/superpowers/specs/2026-04-29-accounting-phase-a0-critical-fix-design.md\`
+Plan: \`docs/superpowers/plans/2026-04-29-accounting-phase-a0-critical-fix.md\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8: Monitor CI**
+
+Run: `gh pr checks` after creation
+Wait for: Lint pass + 4 E2E shards (note: chat_snoozes drift may cause unrelated E2E failures — document, don't block on those)
+
+- [ ] **Step 9: Report PR URL to user + await merge approval**
+
+Report PR # and URL. Wait for user to merge (admin override may be needed if E2E fails on unrelated chat_snoozes drift).
+
+---
+
+## Self-Review Checklist (run before declaring plan complete)
+
+- [ ] Spec coverage: every fix in spec section 3 has at least one task ✓ (11 fixes → Tasks 1, 3, 5, 6, 7, 8, 9, 11, 12, 13-14, 17, 18, 19, 20)
+- [ ] Test coverage: each fix has at least one failing-then-passing test ✓
+- [ ] No placeholder text (TBD/TODO/XXX) — verify with grep
+- [ ] Type consistency: parameter names match across tasks (companyId, forceCloseReason, boardResolutionId)
+- [ ] Migration is additive only (3 nullable columns)
+- [ ] Commit messages reference finding IDs
+- [ ] All 5 waves have a verification + checkpoint step
+- [ ] Final task includes PR creation with proper body
+
+---
+
+## Estimated Effort
+
+| Wave | Tasks | Time |
+|---|---|---|
+| 1 (Foundation) | 1-4 | ~1 hr |
+| 2 (Company validation) | 5-10 | ~3 hr |
+| 3 (try/catch) | 11-12 | ~30 min |
+| 4 (PaySolutions webhook) | 13-15 | ~2 hr |
+| 5 (Period close) | 16-21 | ~3 hr |
+| E2E | 22 | ~2 hr |
+| Final + PR | 23 | ~1.5 hr |
+| **Total** | **23 tasks** | **~13 hr** |

--- a/docs/superpowers/specs/2026-04-29-accounting-phase-a0-critical-fix-design.md
+++ b/docs/superpowers/specs/2026-04-29-accounting-phase-a0-critical-fix-design.md
@@ -1,0 +1,284 @@
+# Accounting Phase A.0 — Critical Fix (Code-Only) — Spec
+
+**Date:** 2026-04-29
+**Type:** Code fix sprint (no CoA changes, no policy decisions)
+**Status:** Draft for review
+**Predecessor:** `docs/reports/2026-04-29-accounting-audit.md` (audit found 41 critical findings, 79 total)
+
+---
+
+## 1. Goal
+
+แก้ critical bugs ในระบบ accounting/journal ที่**ไม่ต้องรอ business decision** เพื่อหยุด orphan transactions ใหม่ + ปิด silent failure paths ก่อนทำ CoA reconciliation (A.1) และ policy work (A.2-A.3) ในเฟสถัดไป
+
+**Deliverable:** 1 PR with 11 fixes (5 logical waves), 20+ unit tests, 3 E2E tests, 1 migration. Ship to prod in 1 day.
+
+**ไม่ทำใน spec นี้:**
+- เปลี่ยน account code / เพิ่มบัญชี / re-align block ใน CoA
+- เพิ่ม JE สำหรับ event ที่ต้องตัดสิน policy (commission ownership, inter-company, year-end closing, customer credit)
+- Stock JEs (trade-in, PO receipt, write-off)
+- Backfill historical orphan transactions
+- Build missing reports (P&L, BS, CF)
+
+---
+
+## 2. Background
+
+จาก audit `docs/reports/2026-04-29-accounting-audit.md`:
+
+**Critical chain ใน prod (Layer 4 prod data):**
+- มี JournalEntry **1 row total** ตลอดประวัติ prod (April 2026 ฿6,125.63)
+- มี **36 orphan PAID payments** ตั้งแต่ 2025-11-24 (ลูกค้าจ่ายจริง ไม่มี ledger record)
+
+**Root cause chain:**
+1. F-2-001: `journal-auto.service.ts:296` — `hpReceivable = financedAmount + i+c+v` แต่ `financedAmount` มี i+c+v อยู่แล้ว → double-count → throw ทุก contract activation
+2. F-1-002: `contract-workflow.service.ts:443` try/catch กลืน throw → activation succeeds in DB แต่ไม่มี JE
+3. F-1-003: `paysolutions.service.ts:713` webhook ไม่มี JournalAutoService injection → 36 orphan payments
+4. F-3-027: `createAndPost` ไม่ validate `allowedCompanies` + `resolveCompanyId` non-deterministic
+5. F-1-016 / F-1-017: try/catch ใน expense + receipt void → silent JE failure
+6. F-6-001 ถึง F-6-004: period close ไม่ validate / ไม่ block / ไม่มี audit trail
+
+---
+
+## 3. Scope — 11 Fixes ใน 5 Waves
+
+### Wave 1 — Foundation (3 fixes ต้องอยู่ commit เดียว)
+
+**ทำไมต้องรวม:** ถ้า #1 ไม่มี #2 → JE สร้างได้แต่ try/catch ยังมี (ใช้ครึ่งทาง). ถ้า #2 ไม่มี #1 → contract activation ทุกตัว fail (math throws).
+
+| # | ID | Change |
+|---|---|---|
+| 1 | F-2-001 | `journal-auto.service.ts:296` `hpReceivable = financedAmount.add(...)` → `hpReceivable = financedAmount` |
+| 2 | F-1-002 / F-2-003 | `contract-workflow.service.ts:443` ลบ try/catch รอบ `createContractActivationJournal` — ให้ propagate |
+| 3 | F-2-010 | `journal-auto.service.ts:91-93` balance check ใช้ `Prisma.Decimal` แทน `Number()`; tolerance 0.01 |
+
+### Wave 2 — Company Validation (3 changes)
+
+**Order matters:** 5a → 5c → 5b (validation last, after callers updated)
+
+| # | Change |
+|---|---|
+| 5a | `journal-auto.service.ts:64` `resolveCompanyId` add `orderBy: { createdAt: 'asc' }` |
+| 5c | Pass explicit `companyId` from 3 callers: `contract-workflow.service.ts` (use `contract.companyId`), `payments.service.ts` (use `contract.companyId`), `accounting.service.ts` (use `expense.branch.companyId`) |
+| 5b | `journal-auto.service.ts createAndPost` add: query `chartOfAccount` for accountCodes in lines, query `companyInfo`, throw `BadRequestException` if any account.allowedCompanies excludes companyCode |
+
+### Wave 3 — Other try/catch removals
+
+| # | ID | Change |
+|---|---|---|
+| 3 | F-1-016 / F-2-008 | `accounting.service.ts:374-391` ลบ try/catch รอบ `createExpenseJournal` |
+| 4 | F-1-017 | `receipts.service.ts:407-426` ลบ try/catch รอบ `createReversalJournal` |
+
+### Wave 4 — PaySolutions Webhook
+
+| # | ID | Change |
+|---|---|---|
+| 7 | F-1-003 | `paysolutions.service.ts` inject `JournalAutoService` (also update `paysolutions.module.ts` to import `JournalModule`). After Payment.update to PAID inside webhook tx, call `createPaymentJournal`. **Pattern: Sentry+log+continue** — do NOT rethrow (webhook must not block payment) |
+
+### Wave 5 — Period Close Hardening (5 changes + 1 migration)
+
+| # | ID | Change |
+|---|---|---|
+| 8 | F-6-001 | `journal.service.ts:200` `post()` add `validatePeriodOpen(prisma, entry.entryDate, entry.companyId)` at start |
+| 9 | F-6-002 | `journal-auto.service.ts createAndPost` check if `entryDate` in CLOSED period; if yes: redirect entryDate to current period + prepend `[Originally for YYYY-MM]` to description + Sentry warning |
+| 10 | F-6-003 | `monthly-close.service.ts:154` `closePeriod` check `existing.auditIssues.hasIssues`; throw if true unless `forceCloseReason` provided (≥50 chars) → AuditLog `PERIOD_FORCE_CLOSE` |
+| 11 | F-6-004 | `accounting.controller.ts:268` add `@Request() req`. `monthly-close.service.ts:253` `reopenPeriod(dto, userId)`: create AuditLog `PERIOD_REOPEN` with boardResolutionId + reason. New migration adds `reopenedAt`, `reopenedById`, `boardResolutionId` to `accounting_periods` |
+| — | DTO changes | `close-month.dto.ts` add optional `forceCloseReason: string @MinLength(50)`. `reopen-period.dto.ts` make `boardResolutionId` + `reason` required |
+
+---
+
+## 4. Pattern Decisions (Made — overrideable)
+
+### P1 — Sync user/staff actions: rethrow on JE failure
+Sites: contract activation (#2), expense pay (#3), receipt VOID (#4)
+
+**Behavior:** JE fails → `$transaction` rollback → operation fails → user sees error → retry
+**Rationale:** silent divergence is worse than "operation failed, please retry"
+
+### P2 — Async webhook: Sentry+log+continue
+Sites: PaySolutions webhook (#7)
+
+**Behavior:** JE fails → Sentry capture + log error + continue payment processing
+**Rationale:** Customer paid via QR — payment must complete; manual reconciliation from Sentry alert
+
+### P3 — JournalAutoService in CLOSED period: soft-block (redirect)
+Sites: #9
+
+**Behavior:** entryDate in CLOSED period → redirect to current OPEN period + add `[Originally for YYYY-MM]` to description
+**Rationale:** webhook payments shouldn't fail just because period closed; accounting team reconciles via description note
+
+### P4 — closePeriod with auditIssues: hard-block + OWNER override
+Sites: #10
+
+**Behavior:** `hasIssues=true` → throw BadRequestException unless `forceCloseReason` (≥50 chars) provided → AuditLog
+**Rationale:** known issues shouldn't lock-in unintentionally; OWNER has documented escape hatch
+
+### P5 — Customer Credit overpayment JE (21-5101)
+**Decision:** Defer to A.1 — 21-5101 not in owner CoA (F-3-010); avoid pre-committing accounts
+
+---
+
+## 5. File Structure
+
+### Modified files (10)
+
+| File | Wave | Changes |
+|---|---|---|
+| `apps/api/src/modules/journal/journal-auto.service.ts` | 1, 2, 5 | math fix, validation, Decimal balance, soft-block period |
+| `apps/api/src/modules/journal/journal.service.ts` | 5 | validatePeriodOpen in post() |
+| `apps/api/src/modules/contracts/contract-workflow.service.ts` | 1, 2 | remove try/catch, pass companyId |
+| `apps/api/src/modules/payments/payments.service.ts` | 2 | pass companyId |
+| `apps/api/src/modules/accounting/accounting.service.ts` | 2, 3 | pass companyId, remove try/catch |
+| `apps/api/src/modules/receipts/receipts.service.ts` | 3 | remove try/catch |
+| `apps/api/src/modules/paysolutions/paysolutions.service.ts` | 4 | inject + post payment JE |
+| `apps/api/src/modules/paysolutions/paysolutions.module.ts` | 4 | import JournalModule |
+| `apps/api/src/modules/accounting/monthly-close.service.ts` | 5 | enforce auditIssues, audit reopen |
+| `apps/api/src/modules/accounting/accounting.controller.ts` | 5 | add @Request() to reopenPeriod |
+
+### DTO changes (2)
+- `apps/api/src/modules/accounting/dto/close-month.dto.ts` — add optional `forceCloseReason`
+- `apps/api/src/modules/accounting/dto/reopen-period.dto.ts` — make `boardResolutionId` + `reason` required
+
+### New migration (1)
+- `apps/api/prisma/migrations/{timestamp}_add_period_reopen_audit_fields/migration.sql`
+- Add `reopened_at TIMESTAMPTZ`, `reopened_by_id TEXT`, `board_resolution_id TEXT` to `accounting_periods`
+- Update `apps/api/prisma/schema.prisma` AccountingPeriod model
+
+### Test files (5 modified, 0 new)
+- `journal-auto.service.spec.ts` — add tests for #1, #5b, #6, #9
+- `contract-workflow.service.spec.ts` — add atomic rollback test (#2)
+- `paysolutions.service.spec.ts` — add #7 tests (post JE, JE failure doesn't block payment, Sentry called)
+- `monthly-close.service.spec.ts` — add #10 + #11 tests
+- `journal.service.spec.ts` — add #8 test
+
+### New E2E tests (3)
+- `apps/web/e2e/accounting-contract-activation.spec.ts` — full flow → verify JE created + balanced
+- `apps/web/e2e/accounting-paysolutions-webhook.spec.ts` — simulate webhook → verify Payment + JE
+- `apps/web/e2e/accounting-period-close.spec.ts` — close with mock issues → verify hard block; with forceCloseReason → verify AuditLog + status=CLOSED
+
+---
+
+## 6. Commit Order (within single PR)
+
+PR uses **squash merge** (project default) so commits below are for review traceability — main gets 1 squash commit at end.
+
+| Commit | Wave | Files | Notes |
+|---|---|---|---|
+| (a) | 1 | journal-auto.service.ts + spec, contract-workflow.service.ts + spec | math + Decimal + try/catch removal |
+| (b) | 2 | journal-auto.service.ts (+5a, +5b), 3 callers + spec | resolveCompanyId ORDER BY → callers pass companyId → validation |
+| (c) | 3 | accounting.service.ts, receipts.service.ts + specs | other try/catch removals |
+| (d) | 4 | paysolutions.service.ts + module + spec, paysolutions.module.ts | webhook JE with Sentry pattern |
+| (e) | 5 | migration + schema, journal.service.ts + spec, monthly-close.service.ts + spec, accounting.controller.ts, 2 DTOs | period close + reopen audit |
+| (f) | E2E | 3 new E2E specs | end-to-end verification |
+
+---
+
+## 7. Testing Strategy
+
+### Unit tests (~20 new)
+
+| Wave | Tests added |
+|---|---|
+| 1 | (i) JE balanced after math fix; (ii) balance check rejects unbalanced; (iii) Decimal precision 100 lines fractional satang; (iv) contract rollback on JE failure; (v) JE created on successful activation |
+| 2 | (i) resolveCompanyId returns same row across calls; (ii) caller passes companyId not fallback; (iii) FINANCE-only account thrown when SHOP companyId; (iv) accounts with empty allowedCompanies allowed for any company |
+| 3 | (i) expense rollback on JE failure; (ii) receipt void rollback; (iii) error message propagated to user; (iv) original receipt JE not reversed if reversal fails |
+| 4 | (i) webhook posts JE on PAID; (ii) JE failure doesn't block Payment.update; (iii) Sentry.captureException called with correct tags |
+| 5 | (i) post() throws if entryDate in CLOSED; (ii) auto-JE redirected when CLOSED; (iii) closePeriod throws on hasIssues; (iv) reopenPeriod creates AuditLog with userId |
+
+### E2E tests (3 new)
+
+1. **`accounting-contract-activation.spec.ts`** — login OWNER → POS → activate contract → query GET /journal-entries?referenceType=CONTRACT&referenceId=$id → assert exists + balanced
+2. **`accounting-paysolutions-webhook.spec.ts`** — mock POST /paysolutions/webhook with success payload → assert Payment.status=PAID + JournalEntry created with referenceType=PAYMENT
+3. **`accounting-period-close.spec.ts`** — create period with hasIssues=true via test fixture → POST /expenses/periods/close → expect 400; retry with `forceCloseReason: "..."` 50 chars → expect 200 + AuditLog row exists
+
+### Manual verification (post-deploy)
+
+1. Run `apps/api/scripts/audit-trial-balance.ts` against prod → record orphan payment count baseline
+2. Make 1 test contract end-to-end → verify JournalEntry table has matching row + balanced
+3. Trigger 1 PaySolutions test webhook → verify JournalEntry row appears
+4. Re-run audit script after 24h → orphan payment count should NOT grow (existing 36 stay until A.3 backfill)
+
+---
+
+## 8. Success Criteria
+
+- [ ] All unit tests pass (existing 577 + ~20 new)
+- [ ] All E2E tests pass (existing 35+ + 3 new) — note: chat_snoozes drift unrelated to this PR may still cause unrelated E2E failures
+- [ ] TypeScript check clean (`./tools/check-types.sh all`)
+- [ ] CI deploy success (Lint + 4 E2E shards + Build + Migrations + Cloud Run + Firebase)
+- [ ] Sentry **no error spike** in 1 hour post-deploy
+- [ ] Layer 4 prod re-run after 24h: **new** orphan payment count = 0 (old 36 await A.3 backfill)
+- [ ] 1 manual contract activation → JournalEntry exists + balanced
+- [ ] 1 manual PaySolutions webhook test → JournalEntry exists
+
+---
+
+## 9. Risk & Mitigation
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Wave 1 deploy breaks contract activation in prod | Activation fails for users until rollback | Deploy at low traffic; monitor Sentry 30 min post-deploy; rollback ready (~10 min revert) |
+| Wave 2 caller misses companyId, validation throws | Operations fail in prod | grep all call sites + add caller-specific unit tests + E2E covers contract path |
+| Wave 4 webhook JE failure rate spikes | Sentry alert flood; orphan payments resume | Sentry alert threshold tuned; manual reconcile process documented; option to roll back Wave 4 only |
+| Wave 5 migration on prod | 0 risk (3 optional NULL fields, no data movement) | N/A |
+| F-2-001 makes existing JE "look weird" | None — Layer 4 confirmed prod has 1 JE total | Clean slate; backfill in A.3 |
+| F-3-027 validation throws on existing manual JE | Manual JE may have wrong companyId | journal.service.ts already has manual validation (this fix only adds to auto path) |
+
+### Rollback plan
+- All changes are in single PR with squash merge → `git revert <merge-sha>` + push → trigger deploy → ~10 min total
+- Migration is additive (3 optional fields) → no data migration to reverse
+
+---
+
+## 10. Out of Scope (deferred)
+
+- ❌ All findings dependent on owner CoA decision (F-2-002, F-3-001 to F-3-022 except F-3-027) → A.1
+- ❌ All findings dependent on policy decision (F-2-005 interest, F-2-007/F-3-028 commission, F-1-011 inter-company, CR-001 VAT) → A.2
+- ❌ Stock JEs (F-1-005 trade-in, F-1-006 PO, F-1-007 write-off) → A.1 (after stock-related accounts confirmed)
+- ❌ Year-end closing entries (F-1-013 / F-6-007) → A.2 (depends on retained earnings code from A.1)
+- ❌ Bad debt provision JE (F-1-009) → A.1 (depends on Bad Debt Expense + Allowance accounts from A.1)
+- ❌ Repossession resale JE (F-1-018) → A.1
+- ❌ Backfill 36 orphan payments + historical activations → A.3 (depends on A.0 + A.1 deployed + CPA sign-off)
+- ❌ Build missing reports (P&L, BS, CF, Notes, GL, PND.50/51, subsidiary ledger) → Phase B
+- ❌ Customer Credit overpayment JE (F-2-006) → A.1 (uses 21-5101 not in owner CoA)
+- ❌ Late fee waiver JE (F-1-020) → A.2 (depends on accrual policy)
+
+---
+
+## 11. Estimated Effort
+
+| Phase | Time |
+|---|---|
+| Wave 1 implementation | ~1 hr |
+| Wave 2 implementation | ~2 hr |
+| Wave 3 implementation | ~30 min |
+| Wave 4 implementation | ~2 hr |
+| Wave 5 implementation | ~3 hr |
+| Unit tests (~20) | ~3 hr |
+| E2E tests (3) | ~2 hr |
+| Self-review + /review subagent + fix | ~1 hr |
+| Deploy + monitor | ~1 hr |
+| **Total** | **~15 hr** |
+
+---
+
+## 12. Follow-up Specs (Anticipated)
+
+After this spec ships:
+
+- **A.1 — CoA Reconciliation Fix** — depends on owner business decision #1 (CoA ground truth). Adds new accounts, re-aligns blocks, fixes BAD_DEBT_EXPENSE mapping, enables F-1-001/005/006/007/009 stock + sales + provision JEs, F-2-006 customer credit JE.
+- **A.2 — Policy-Dependent Fixes** — depends on CPA decisions (interest, commission, VAT, inter-company). Year-end closing entries.
+- **A.3 — Historical Backfill** — depends on A.0 + A.1 deployed + CPA sign-off. Backfill 36 orphan payments + historical contract activations.
+- **B — Build Missing Reports** — General Ledger, Balance Sheet (from JE), Cash Flow investing/financing, Notes to FS, HP Subsidiary Ledger, PND.50/51.
+
+---
+
+## 13. References
+
+- Audit report: `docs/reports/2026-04-29-accounting-audit.md`
+- Audit raw outputs: `docs/reports/audit-2026-04-29-raw/`
+- Audit script: `apps/api/scripts/audit-trial-balance.ts`
+- Owner CoA: `docs/references/owner-chart-of-accounts.csv`
+- Accounting rules: `.claude/rules/accounting.md`
+- Memory: `project_accounting_audit_2026_04_29.md`
+- Memory: `project_interest_recognition_policy.md` (W-003 / N-005 deferred)


### PR DESCRIPTION
## Summary

Phase A.0 of the accounting fix plan from the [2026-04-29 audit](docs/reports/2026-04-29-accounting-audit.md). **Code-only fixes** (no CoA changes, no policy decisions). 11 fixes in 5 waves + 1 critical hardening fix.

### Critical chain fixed (verified by final review)

- **F-2-001**: hpReceivable double-counting math bug (1 line fix, was throwing on every contract activation)
- **F-1-002 / F-2-003**: try/catch swallowing activation JE failures (silent ledger divergence)
- **F-1-003**: PaySolutions webhook now posts payment JE — was the source of **36 orphan payments** in production (Layer 4 audit data)
- **F-3-027**: allowedCompanies validation in createAndPost + deterministic resolveCompanyId + all 5 callers pass explicit companyId
- **F-1-016 / F-1-017**: try/catch removed on expense + receipt VOID JE (atomic with operation)

### Period close hardened
- **F-6-001**: JournalService.post() validates period not CLOSED
- **F-6-002**: JournalAutoService soft-blocks CLOSED period (redirects to current + Sentry)
- **F-6-003**: closePeriod enforces auditIssues.hasIssues with **OWNER-only** forceCloseReason override + AuditLog
- **F-6-004**: reopenPeriod persists audit trail (reopenedAt/By/boardResolutionId) + AuditLog

### PaySolutions webhook hardening (after final review caught 2 critical bugs)
- Real OWNER User.id resolved for `createdById` FK (was hardcoded string → would FK violate)
- JE posted in **separate $transaction AFTER** main webhook tx commits (prevents tx poisoning that would roll back Payment.update to PAID)

### Pattern decisions
- **Sync user actions** (contract activation, expense pay, receipt void): rethrow on JE failure → atomic rollback
- **Async webhook** (PaySolutions): Sentry+log+continue → payment must complete; manual reconcile from alert
- **Auto-JE in CLOSED period**: soft-block → redirect entryDate to current + `[Originally for YYYY-MM]` description
- **closePeriod auditIssues**: hard-block + OWNER override (≥50 char reason → AuditLog)

### Out of scope (deferred to future phases)
- ❌ CoA reconciliation → A.1 (blocked on owner business decision)
- ❌ Policy fixes (interest, commission, VAT, inter-company) → A.2 (CPA pending)
- ❌ Backfill 36 orphan payments + historical activations → A.3 (after A.0 + A.1 deployed + CPA sign-off)
- ❌ Build missing reports (P&L, BS, CF) → Phase B

## What's in this PR

- **23 commits** in dependency order (squash merge will collapse to 1)
- **2171/2171 unit tests pass** (186 suites)
- **0 TypeScript errors**
- **1 Prisma migration** (additive only — 3 nullable columns + 1 FK)
- **3 new E2E specs** (smoke-level; some `test.skip()` for fixture-dependent paths)
- **2 reviews per task** + **1 final code review** (all approved after 3 fix loops for caught issues)

## Test plan

- [ ] CI: Lint & Test pass
- [ ] CI: 4 E2E shards pass (note: pre-existing chat_snoozes drift may cause unrelated failures per memory `project_chat_snoozes_migration_drift.md`)
- [ ] CI: Build, Migrations, Cloud Run, Firebase deploys
- [ ] Sentry: no error spike for 1 hour post-deploy
- [ ] Manual: 1 contract activation → JournalEntry exists + balanced
- [ ] Manual: 1 PaySolutions test webhook → JournalEntry exists
- [ ] Layer 4 prod audit re-run after 24h → **new** orphan payment count = 0 (existing 36 await A.3 backfill)

## Known limitations / requires prod attention

1. **Behavior tightening**: contract activation now throws if FINANCE company is not seeded (was silent warn-and-continue). Production has FINANCE seeded — verified.
2. **closePeriod auditIssues hard-block**: existing periods with `hasIssues=true` will need to either fix the issues OR provide forceCloseReason on next close attempt.
3. **Out-of-scope `createPaymentJournal` callers** (contract-payment.service.ts, data-audit.service.ts) were updated as Task 7b after review found them missed.

Spec: `docs/superpowers/specs/2026-04-29-accounting-phase-a0-critical-fix-design.md`
Plan: `docs/superpowers/plans/2026-04-29-accounting-phase-a0-critical-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)