### PR TITLE
feat(accounting): Phase A.1a — CoA split (SHOP + FINANCE multi-entity)

### DIFF
--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -16,51 +16,91 @@
 - **ค่าปรับล่าช้า (Late fees) ไม่คิด VAT** — policy decision ของเจ้าของ (ถูกต้องตามกฎหมาย: ค่าปรับไม่อยู่ในฐาน VAT)
 - **ไม่มีภาษีหัก ณ ที่จ่าย (WHT)** สำหรับธุรกรรมกับลูกค้า
 
+## Multi-Entity Chart Partition (Phase A.1a)
+
+ระบบใช้ **2 ผังบัญชี** แยกตาม entity:
+- **SHOP chart** (109 acc.) — `docs/references/owner-chart-of-accounts.csv` — สำหรับ SHOP transactions (cash sale, expense, commission income)
+- **FINANCE chart** (41 acc.) — `docs/references/finance-chart-of-accounts.csv` — สำหรับ HP transactions (receivable, interest, late fee, bad debt)
+
+Schema: `ChartOfAccount.companyId` + `@@unique([companyId, code])` — same code can exist in both charts (e.g., 11-1101 Cash for SHOP and 11-1101 Cash for FINANCE — different bank accounts).
+
+Validation: `JournalAutoService.createAndPost` looks up accounts scoped to the JE's `companyId`. Posting an account that doesn't exist in this company's chart → throws BadRequestException.
+
 ## Chart of Accounts (Key Codes)
+
+### SHOP chart (selected)
 ```
-11-1101  เงินสด/ธนาคาร (Cash & Bank)
+11-1101  เงินสด — สุทธินีย์ คงเดช (Cash on Hand SHOP)
+11-1201  ธนาคาร KBank — เบสท์ช้อยส์โฟน (per owner CoA)
+41-1101  รายได้ มือถือ (ใหม่) (Revenue New)
+41-1102  รายได้ มือถือ (มือสอง) (Revenue Used)
+42-1105  รายได้ค่านายหน้า/คอมมิชชัน — used in A.1b inter-company
+51-1101  ต้นทุนมือถือ (ใหม่) (COGS New)
+51-1102  ต้นทุนมือถือ (มือสอง) (COGS Used)
+11-3101  Inventory ใหม่
+11-3102  Inventory มือสอง
+11-2105  ลูกหนี้คู่ค้า — FINANCE (Due-from-FINANCE) — A.1b clearing
+```
+
+### FINANCE chart (selected)
+```
+11-1101  เงินสด FINANCE (different bank from SHOP's 11-1101!)
 11-2102  ลูกหนี้เช่าซื้อ (HP Receivable)
-11-2103  ค่าเผื่อหนี้สงสัยจะสูญ (Allowance for Doubtful)
-11-3101  สินค้าคงเหลือ — เครื่องใหม่ (Inventory New)
-11-3102  สินค้าคงเหลือ — มือสอง (Inventory Used)
+11-2103  หัก: ค่าเผื่อหนี้สงสัยจะสูญ (Allowance for Doubtful)
+11-3103  สินค้ายึดคืน (Repossessed Inventory)
+11-3104  Inventory FINANCE — เครื่องใหม่
+11-3105  Inventory FINANCE — มือสอง
 11-4101  ภาษีซื้อ (VAT Input)
-21-2101  ภาษีขาย (VAT Output)
-21-5101  เครดิตลูกค้า (Customer Credit)
-41-1101  รายได้ขายเครื่องใหม่ (Revenue New)
-41-1102  รายได้ขายมือสอง (Revenue Used)
-42-1102  รายได้ค่าปรับล่าช้า (Late Fee Income)
-42-1105  รายได้ค่าคอมมิชชัน (Commission Income)
-51-1101  ต้นทุนขายเครื่องใหม่ (COGS New)
-51-1102  ต้นทุนขายมือสอง (COGS Used)
-53-1101  หนี้สูญ (Bad Debt Expense)
+21-1102  เจ้าหนี้คู่ค้า — SHOP (Due-to-SHOP) — A.1b clearing
+21-2101  ภาษีขาย ภ.พ.30 (VAT Output)
+21-2104  ภาษีขายดอกเบี้ยรอตัดบัญชี [DEFERRED CR-001]
+21-2202  รายได้ดอกเบี้ยรอตัดบัญชี [DEFERRED W-003 unearnedInterest]
+21-5101  เงินเกินของลูกค้า (Customer Credit Balance)
+41-2101  รายได้ขายเช่าซื้อ FINANCE
+41-2102  รายได้ขายเช่าซื้อมือสอง FINANCE
+42-2101  รายได้ดอกเบี้ยเช่าซื้อ (HP Interest Income) — was 42-1101 (Rounding Excess in owner CoA!)
+42-2102  ค่างวดเบี้ยปรับล่าช้า (Late Fee Income) — was 42-1102 (Bank Interest in owner CoA!)
+42-2104  รายได้จากการยึดเครื่อง (Repossession Income)
+42-2105  รายได้คอมมิชชันจาก SHOP (A.1b inter-company)
+51-2101  ต้นทุนขายเช่าซื้อ FINANCE — เครื่องใหม่
+51-2102  ต้นทุนขายเช่าซื้อ FINANCE — มือสอง
+53-1701  หนี้สูญ (Bad Debt Expense) — was 53-1101 (Salary in owner CoA!)
+53-1801  ค่านายหน้าจ่าย SHOP (Commission Expense, A.1b)
 ```
+
+### Phase A.1a temporary deviations
+
+- **Commission**: temporarily removed from payment JE (folded into HP_RECEIVABLE credit). Sentry alarm fires when monthlyCommission > 0. A.1b restores as proper inter-company JE (FINANCE expense + SHOP income).
+- **Contract activation**: posts entirely on FINANCE side in A.1a (down payment, COGS, revenue all FINANCE). A.1b will split — SHOP posts revenue + COGS, FINANCE posts HP Receivable + Due-to-SHOP.
 
 ## Journal Entries (Auto-generated)
 
-### Payment Received
+### Payment Received (FINANCE)
 ```
-Dr. Cash/Bank              [amountPaid]
-  Cr. HP Receivable        [principal + interest]
-  Cr. Commission Income    [monthlyCommission]
-  Cr. VAT Output           [vatAmount]
-  Cr. Late Fee Income      [lateFee — if any, NOT VAT]
+Dr. 11-1101 Cash/Bank FINANCE          [amountPaid]
+  Cr. 11-2102 HP Receivable            [principal + interest + commission folded in A.1a]
+  Cr. 21-2101 VAT Output               [vatAmount]
+  Cr. 42-2102 Late Fee Income          [lateFee — if any, NOT VAT]
 ```
+Note: A.1a folds commission into HP Receivable credit (Sentry alarms if monthlyCommission > 0). A.1b will restore as inter-company entry.
 
-### Contract Activation
+### Contract Activation (FINANCE — A.1a single-side)
 ```
-Dr. HP Receivable          [financedAmount + interest + commission + VAT]
-  Cr. Revenue              [sellingPrice + interest + commission]
-  Cr. VAT Output           [vatAmount]
-Dr. COGS                   [costPrice]
-  Cr. Inventory            [costPrice]
+Dr. 11-2102 HP Receivable              [financedAmount + interest + commission + VAT]
+  Cr. 41-2101/02 Revenue FINANCE       [sellingPrice + interest + commission]
+  Cr. 21-2101 VAT Output               [vatAmount]
+Dr. 51-2101/02 COGS FINANCE            [costPrice]
+  Cr. 11-3104/05 Inventory FINANCE     [costPrice]
 ```
+Note: A.1b will split — SHOP posts 41-1101/02 Revenue + 51-1101/02 COGS + 11-2105 Due-from-FINANCE; FINANCE posts 11-2102 HP Receivable + 21-1102 Due-to-SHOP.
 
-### Bad Debt Write-Off
+### Bad Debt Write-Off (FINANCE)
 ```
-Dr. Bad Debt Expense       [writeOffAmount - provisionAmount]
-Dr. Allowance for Doubtful [provisionAmount — if any]
-  Cr. HP Receivable        [writeOffAmount]
+Dr. 53-1701 Bad Debt Expense           [writeOffAmount - provisionAmount]
+Dr. 11-2103 Allowance for Doubtful     [provisionAmount — if any]
+  Cr. 11-2102 HP Receivable            [writeOffAmount]
 ```
+Note: 53-1701 (was 53-1101 in owner CoA = Salary!). Critical remap fixed in Phase A.1a.
 
 ### Expense Paid
 ```

--- a/apps/api/prisma/migrations/20260615000000_chart_of_accounts_company_partition/migration.sql
+++ b/apps/api/prisma/migrations/20260615000000_chart_of_accounts_company_partition/migration.sql
@@ -12,7 +12,8 @@ UPDATE "chart_of_accounts" SET "company_id" = (
   SELECT id FROM "company_info" WHERE "company_code" = 'FINANCE' LIMIT 1
 ) WHERE 'FINANCE' = ANY("allowed_companies") AND "company_id" IS NULL;
 
-ALTER TABLE "chart_of_accounts" DROP CONSTRAINT IF EXISTS "chart_of_accounts_code_key";
+-- Original migration created UNIQUE INDEX (not CONSTRAINT). Drop INDEX to remove unique-on-code.
+DROP INDEX IF EXISTS "chart_of_accounts_code_key";
 
 CREATE UNIQUE INDEX "chart_of_accounts_company_id_code_key" ON "chart_of_accounts" ("company_id", "code");
 CREATE INDEX "chart_of_accounts_company_id_idx" ON "chart_of_accounts" ("company_id");

--- a/apps/api/prisma/migrations/20260615000000_chart_of_accounts_company_partition/migration.sql
+++ b/apps/api/prisma/migrations/20260615000000_chart_of_accounts_company_partition/migration.sql
@@ -1,0 +1,20 @@
+-- Phase A.1a: ChartOfAccount multi-entity partition
+ALTER TABLE "chart_of_accounts" ADD COLUMN "company_id" TEXT;
+
+ALTER TABLE "chart_of_accounts" ADD CONSTRAINT "chart_of_accounts_company_id_fkey"
+  FOREIGN KEY ("company_id") REFERENCES "company_info"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+UPDATE "chart_of_accounts" SET "company_id" = (
+  SELECT id FROM "company_info" WHERE "company_code" = 'SHOP' LIMIT 1
+) WHERE 'SHOP' = ANY("allowed_companies") AND "company_id" IS NULL;
+
+UPDATE "chart_of_accounts" SET "company_id" = (
+  SELECT id FROM "company_info" WHERE "company_code" = 'FINANCE' LIMIT 1
+) WHERE 'FINANCE' = ANY("allowed_companies") AND "company_id" IS NULL;
+
+ALTER TABLE "chart_of_accounts" DROP CONSTRAINT IF EXISTS "chart_of_accounts_code_key";
+
+CREATE UNIQUE INDEX "chart_of_accounts_company_id_code_key" ON "chart_of_accounts" ("company_id", "code");
+CREATE INDEX "chart_of_accounts_company_id_idx" ON "chart_of_accounts" ("company_id");
+
+ALTER TABLE "chart_of_accounts" DROP COLUMN "allowed_companies";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2870,6 +2870,7 @@ model CompanyInfo {
   taxReports         TaxReport[]
   ownedProducts      Product[]                 @relation("ProductOwnership")
   accountingPeriods  AccountingPeriod[]
+  chartOfAccounts    ChartOfAccount[]          @relation("CompanyChartOfAccounts")
 
   @@map("company_info")
 }
@@ -3153,7 +3154,7 @@ enum AccountGroup {
 
 model ChartOfAccount {
   id           String       @id @default(uuid())
-  code         String       @unique // e.g. "1100", "4100"
+  code         String // e.g. "1100", "4100"
   nameTh       String       @map("name_th") // ชื่อบัญชีภาษาไทย
   nameEn       String?      @map("name_en") // English name (optional)
   accountGroup AccountGroup @map("account_group")
@@ -3161,8 +3162,9 @@ model ChartOfAccount {
   level        Int          @default(1) // 1=group, 2=sub-group, 3=detail
   isActive     Boolean      @default(true) @map("is_active")
 
-  // ── การใช้งานข้ามบริษัท (multi-entity) ──
-  allowedCompanies String[] @default([]) @map("allowed_companies") // [] = ใช้ได้ทุกบริษัท, ["FINANCE"] = เฉพาะ FINANCE, ["SHOP"] = เฉพาะ SHOP
+  // ── Multi-entity partition (Phase A.1a) ──
+  companyId String?      @map("company_id")
+  company   CompanyInfo? @relation("CompanyChartOfAccounts", fields: [companyId], references: [id], onDelete: SetNull)
 
   // ── การ sync กับ PEAK (ระบบบัญชีภายนอก) ──
   peakAccountCode String? @map("peak_account_code") // รหัสบัญชีฝั่ง PEAK (สำหรับ export journal)
@@ -3172,8 +3174,10 @@ model ChartOfAccount {
   updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
 
+  @@unique([companyId, code])
   @@index([accountGroup])
   @@index([code])
+  @@index([companyId])
   @@map("chart_of_accounts")
 }
 

--- a/apps/api/prisma/seeds/chart-of-accounts-finance.ts
+++ b/apps/api/prisma/seeds/chart-of-accounts-finance.ts
@@ -1,0 +1,87 @@
+import { PrismaClient, AccountGroup } from '@prisma/client';
+
+interface FinanceAccount {
+  code: string;
+  nameTh: string;
+  nameEn: string;
+  accountGroup: AccountGroup;
+  parentCode?: string;
+  level: number;
+}
+
+const FINANCE_ACCOUNTS: FinanceAccount[] = [
+  // ─── 11-XXXX สินทรัพย์หมุนเวียน (12) — includes 2 new INVENTORY accounts ───
+  { code: '11-1101', nameTh: 'เงินสด FINANCE', nameEn: 'Cash on Hand FINANCE', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-1201', nameTh: 'ธนาคาร FINANCE — บัญชีหลัก', nameEn: 'Bank — FINANCE Main', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-1202', nameTh: 'ธนาคาร FINANCE — รับชำระค่างวด', nameEn: 'Bank — Installment Collection', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-2102', nameTh: 'ลูกหนี้เช่าซื้อ', nameEn: 'Hire-Purchase Receivable', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-2103', nameTh: 'หัก: ค่าเผื่อหนี้สงสัยจะสูญ', nameEn: 'Less: Allowance for Doubtful Accounts', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-2104', nameTh: 'ลูกหนี้ไฟแนนซ์ภายนอก', nameEn: 'External Finance Receivable', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-3103', nameTh: 'สินค้ายึดคืน/ซ่อมแล้ว', nameEn: 'Repossessed/Refurbished Goods', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-3104', nameTh: 'สินค้าคงเหลือ FINANCE — เครื่องใหม่', nameEn: 'Inventory FINANCE New', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-3105', nameTh: 'สินค้าคงเหลือ FINANCE — มือสอง', nameEn: 'Inventory FINANCE Used', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-4101', nameTh: 'ภาษีซื้อ', nameEn: 'Input VAT', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-4102', nameTh: 'ภาษีซื้อยังไม่ถึงกำหนด', nameEn: 'Input VAT Pending', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-4103', nameTh: 'ภาษีถูกหัก ณ ที่จ่าย', nameEn: 'Withholding Tax Receivable', accountGroup: AccountGroup.ASSET, level: 3 },
+
+  // ─── 21-XXXX หนี้สินหมุนเวียน (10) ───
+  { code: '21-1102', nameTh: 'เจ้าหนี้คู่ค้า — SHOP (Due-to-SHOP)', nameEn: 'Inter-company Payable — SHOP', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2101', nameTh: 'ภาษีขาย ภ.พ.30', nameEn: 'Output VAT (PP.30)', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2102', nameTh: 'ภาษีขายรอเรียกเก็บ', nameEn: 'Output VAT Pending Invoice', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2103', nameTh: 'ภ.พ.36 ค้างจ่าย', nameEn: 'PP.36 Payable', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2104', nameTh: 'ภาษีขายดอกเบี้ยรอตัดบัญชี [DEFERRED CR-001]', nameEn: 'Deferred VAT on Interest', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2202', nameTh: 'รายได้ดอกเบี้ยรอตัดบัญชี [DEFERRED W-003]', nameEn: 'Unearned Interest Income', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-3201', nameTh: 'เจ้าหนี้สรรพากร ภ.พ.30 รอชำระ', nameEn: 'VAT Payable to RD', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-3202', nameTh: 'เจ้าหนี้สรรพากร ภ.ง.ด.53 รอชำระ', nameEn: 'PND.53 Payable to RD', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-4201', nameTh: 'เงินรับล่วงหน้า', nameEn: 'Advance Receipts', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-5101', nameTh: 'เงินเกินของลูกค้า', nameEn: 'Customer Credit Balance', accountGroup: AccountGroup.LIABILITY, level: 3 },
+
+  // ─── 31/32-XXXX ส่วนของผู้ถือหุ้น (2) ───
+  { code: '31-1101', nameTh: 'ทุนสามัญ FINANCE', nameEn: 'Common Stock FINANCE', accountGroup: AccountGroup.EQUITY, level: 3 },
+  { code: '32-1101', nameTh: 'กำไร(ขาดทุน)สะสม FINANCE', nameEn: 'Retained Earnings FINANCE', accountGroup: AccountGroup.EQUITY, level: 3 },
+
+  // ─── 41-XXXX รายได้จากการขาย (2) — added for FINANCE-side contract activation ───
+  { code: '41-2101', nameTh: 'รายได้ขายเช่าซื้อ FINANCE', nameEn: 'HP Sales Revenue FINANCE', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '41-2102', nameTh: 'รายได้ขายเช่าซื้อมือสอง FINANCE', nameEn: 'HP Used Sales Revenue FINANCE', accountGroup: AccountGroup.REVENUE, level: 3 },
+
+  // ─── 42-XXXX รายได้อื่น (5) ───
+  { code: '42-2101', nameTh: 'รายได้ดอกเบี้ยเช่าซื้อ', nameEn: 'Hire-Purchase Interest Income', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2102', nameTh: 'ค่างวดเบี้ยปรับล่าช้า', nameEn: 'Late Payment Penalty Income', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2103', nameTh: 'ค่ามัดจำ/เงินประกันที่ริบ', nameEn: 'Forfeited Deposits', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2104', nameTh: 'รายได้จากการยึดเครื่อง', nameEn: 'Repossession Income', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2105', nameTh: 'รายได้ค่าคอมมิชชันจาก SHOP [A.1b]', nameEn: 'Commission Income from SHOP', accountGroup: AccountGroup.REVENUE, level: 3 },
+
+  // ─── 51-XXXX ต้นทุนขาย (2) — added for FINANCE-side contract activation ───
+  { code: '51-2101', nameTh: 'ต้นทุนขายเช่าซื้อ FINANCE — เครื่องใหม่', nameEn: 'COGS FINANCE New', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '51-2102', nameTh: 'ต้นทุนขายเช่าซื้อ FINANCE — มือสอง', nameEn: 'COGS FINANCE Used', accountGroup: AccountGroup.EXPENSE, level: 3 },
+
+  // ─── 53-XXXX ค่าใช้จ่าย (6) ───
+  { code: '53-1701', nameTh: 'หนี้สูญ', nameEn: 'Bad Debt Expense', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1702', nameTh: 'หนี้สงสัยจะสูญ', nameEn: 'Doubtful Debt Expense', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1801', nameTh: 'ค่านายหน้าจ่าย SHOP [A.1b]', nameEn: 'Commission Expense to SHOP', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1802', nameTh: 'ค่าธรรมเนียม PaySolutions', nameEn: 'PaySolutions Fees', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1803', nameTh: 'ค่าธรรมเนียมโอนเงิน', nameEn: 'Bank Transfer Fees', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1601', nameTh: 'ค่าเสื่อมราคา — อุปกรณ์ FINANCE', nameEn: 'Depreciation — FINANCE Equipment', accountGroup: AccountGroup.EXPENSE, level: 3 },
+
+  // ─── 54-XXXX รายจ่ายต้องห้ามทางภาษี (2) ───
+  { code: '54-1101', nameTh: 'ภงด. ทางภาษี ภ.ง.ด.3', nameEn: 'Tax Expense — PND.3', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '54-1102', nameTh: 'ภงด. ทางภาษี ภ.ง.ด.53', nameEn: 'Tax Expense — PND.53', accountGroup: AccountGroup.EXPENSE, level: 3 },
+];
+
+export async function seedFinanceChartOfAccounts(prisma: PrismaClient, financeCompanyId: string): Promise<void> {
+  console.log(`  → Seeding ${FINANCE_ACCOUNTS.length} FINANCE accounts...`);
+  for (const acc of FINANCE_ACCOUNTS) {
+    await prisma.chartOfAccount.upsert({
+      where: { companyId_code: { companyId: financeCompanyId, code: acc.code } },
+      update: {
+        nameTh: acc.nameTh, nameEn: acc.nameEn, accountGroup: acc.accountGroup,
+        level: acc.level, isActive: true, peakAccountCode: acc.code,
+      },
+      create: {
+        code: acc.code, companyId: financeCompanyId, nameTh: acc.nameTh, nameEn: acc.nameEn,
+        accountGroup: acc.accountGroup, parentCode: acc.parentCode, level: acc.level,
+        isActive: true, peakAccountCode: acc.code,
+      },
+    });
+  }
+}

--- a/apps/api/prisma/seeds/chart-of-accounts.ts
+++ b/apps/api/prisma/seeds/chart-of-accounts.ts
@@ -13,7 +13,20 @@ interface ChartOfAccountSeed {
 }
 
 function parseOwnerCsv(): ChartOfAccountSeed[] {
-  const csvPath = path.resolve(__dirname, '../../../../docs/references/owner-chart-of-accounts.csv');
+  // Path resolution: works for both dev (tsx from prisma/seeds/) and CI (compiled to dist/prisma/seeds/).
+  // Try multiple candidates because __dirname depth varies (4 levels up in dev, 5 in CI compiled).
+  const candidates = [
+    path.resolve(__dirname, '../../../../docs/references/owner-chart-of-accounts.csv'),     // dev: prisma/seeds/ → repo root
+    path.resolve(__dirname, '../../../../../docs/references/owner-chart-of-accounts.csv'),  // CI: dist/prisma/seeds/ → repo root
+    path.resolve(process.cwd(), 'docs/references/owner-chart-of-accounts.csv'),             // fallback: relative to cwd
+  ];
+  const csvPath = candidates.find((p) => fs.existsSync(p));
+  if (!csvPath) {
+    throw new Error(
+      `Owner CoA CSV not found. Tried: ${candidates.join(', ')}. ` +
+      `__dirname=${__dirname}, cwd=${process.cwd()}`,
+    );
+  }
   const raw = fs.readFileSync(csvPath, 'utf-8');
   const lines = raw.split('\n').filter((l) => l.trim());
 

--- a/apps/api/prisma/seeds/chart-of-accounts.ts
+++ b/apps/api/prisma/seeds/chart-of-accounts.ts
@@ -1,4 +1,7 @@
 import { PrismaClient, AccountGroup } from '@prisma/client';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { seedFinanceChartOfAccounts } from './chart-of-accounts-finance';
 
 interface ChartOfAccountSeed {
   code: string;
@@ -7,235 +10,91 @@ interface ChartOfAccountSeed {
   accountGroup: AccountGroup;
   parentCode?: string;
   level: number;
-  allowedCompanies?: string[]; // [] หรือไม่ระบุ = ใช้ได้ทุกบริษัท
-  peakAccountCode?: string;    // รหัสบัญชีฝั่ง PEAK (ถ้ามี)
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const CHART_OF_ACCOUNTS: ChartOfAccountSeed[] = [
-  // ════════════════════════════════════════════════════════════
-  // หมวด 1: สินทรัพย์ (ASSET) — PEAK format XX-XXXX
-  // ════════════════════════════════════════════════════════════
+function parseOwnerCsv(): ChartOfAccountSeed[] {
+  const csvPath = path.resolve(__dirname, '../../../../docs/references/owner-chart-of-accounts.csv');
+  const raw = fs.readFileSync(csvPath, 'utf-8');
+  const lines = raw.split('\n').filter((l) => l.trim());
 
-  // ── สินทรัพย์หมุนเวียน ──
-  { code: '11-0000', nameTh: 'สินทรัพย์หมุนเวียน', nameEn: 'Current Assets', accountGroup: AccountGroup.ASSET, level: 1 },
+  const accounts: ChartOfAccountSeed[] = [];
+  let currentGroup: AccountGroup | null = null;
 
-  // กลุ่มเงินสดและรายการเทียบเท่าเงินสด
-  { code: '11-11XX', nameTh: 'กลุ่มเงินสดและรายการเทียบเท่าเงินสด', nameEn: 'Cash and Cash Equivalents', accountGroup: AccountGroup.ASSET, parentCode: '11-0000', level: 2 },
-  { code: '11-1101', nameTh: 'เงินสด - สุทธิ/เงินย่อย', nameEn: 'Cash on Hand / Petty Cash', accountGroup: AccountGroup.ASSET, parentCode: '11-11XX', level: 3 },
-  { code: '11-1102', nameTh: 'เงินสด - เอกสาร/ค่าส่ง', nameEn: 'Cash - Documents/Delivery', accountGroup: AccountGroup.ASSET, parentCode: '11-11XX', level: 3 },
-  { code: '11-1103', nameTh: 'เงินสด - อิเล็กทรอนิกส์', nameEn: 'Cash - Electronic', accountGroup: AccountGroup.ASSET, parentCode: '11-11XX', level: 3 },
+  for (const line of lines) {
+    const cols = line.split(',').map((c) => c.replace(/^"|"$/g, '').trim());
+    const first = cols[0] || '';
 
-  // กลุ่มเงินฝากธนาคาร
-  { code: '11-12XX', nameTh: 'กลุ่มเงินฝากธนาคาร', nameEn: 'Bank Deposits', accountGroup: AccountGroup.ASSET, parentCode: '11-0000', level: 2 },
-  { code: '11-1201', nameTh: 'ธนาคาร - กสิกรไทย ออมทรัพย์', nameEn: 'Bank - KBank Savings', accountGroup: AccountGroup.ASSET, parentCode: '11-12XX', level: 3 },
-  { code: '11-1202', nameTh: 'ธนาคาร - ไทยพาณิชย์ ออมทรัพย์', nameEn: 'Bank - SCB Savings', accountGroup: AccountGroup.ASSET, parentCode: '11-12XX', level: 3 },
-  { code: '11-1203', nameTh: 'ธนาคาร - กรุงไทย ออมทรัพย์', nameEn: 'Bank - KTB Savings', accountGroup: AccountGroup.ASSET, parentCode: '11-12XX', level: 3 },
+    if (first.startsWith('หมวดที่ 1')) { currentGroup = AccountGroup.ASSET; continue; }
+    if (first.startsWith('หมวดที่ 2')) { currentGroup = AccountGroup.LIABILITY; continue; }
+    if (first.startsWith('หมวดที่ 3')) { currentGroup = AccountGroup.EQUITY; continue; }
+    if (first.startsWith('หมวดที่ 4')) { currentGroup = AccountGroup.REVENUE; continue; }
+    if (first.startsWith('หมวดที่ 5')) { currentGroup = AccountGroup.EXPENSE; continue; }
+    if (first === 'เลขบัญชี') continue;
 
-  // กลุ่มลูกหนี้การค้าและลูกหนี้อื่น
-  { code: '11-21XX', nameTh: 'กลุ่มลูกหนี้การค้าและลูกหนี้อื่น', nameEn: 'Trade and Other Receivables', accountGroup: AccountGroup.ASSET, parentCode: '11-0000', level: 2 },
-  { code: '11-2101', nameTh: 'ลูกหนี้การค้า', nameEn: 'Accounts Receivable', accountGroup: AccountGroup.ASSET, parentCode: '11-21XX', level: 3 },
-  { code: '11-2102', nameTh: 'ลูกหนี้เช่าซื้อ', nameEn: 'Hire-Purchase Receivable', accountGroup: AccountGroup.ASSET, parentCode: '11-21XX', level: 3, allowedCompanies: ['FINANCE'] },
-  { code: '11-2103', nameTh: 'หัก: ค่าเผื่อหนี้สงสัยจะสูญ', nameEn: 'Less: Allowance for Doubtful Accounts', accountGroup: AccountGroup.ASSET, parentCode: '11-21XX', level: 3 },
-  { code: '11-2104', nameTh: 'ลูกหนี้ไฟแนนซ์ภายนอก', nameEn: 'External Finance Receivable', accountGroup: AccountGroup.ASSET, parentCode: '11-21XX', level: 3 },
+    if (!currentGroup) continue;
+    if (!/^\d{2}-\d{4,5}$/.test(first)) continue;
 
-  // กลุ่มต้นทุนสินค้าคงเหลือ
-  { code: '11-31XX', nameTh: 'กลุ่มต้นทุนสินค้าคงเหลือ', nameEn: 'Inventory', accountGroup: AccountGroup.ASSET, parentCode: '11-0000', level: 2 },
-  { code: '11-3101', nameTh: 'ต้นทุนมือถือ (ใหม่)', nameEn: 'Inventory - New Phones', accountGroup: AccountGroup.ASSET, parentCode: '11-31XX', level: 3 },
-  { code: '11-3102', nameTh: 'ต้นทุนมือถือ (มือสอง)', nameEn: 'Inventory - Used Phones', accountGroup: AccountGroup.ASSET, parentCode: '11-31XX', level: 3 },
-  { code: '11-3103', nameTh: 'สินค้ายึดคืน/ซ่อมแล้ว', nameEn: 'Repossessed/Refurbished Goods', accountGroup: AccountGroup.ASSET, parentCode: '11-31XX', level: 3 },
+    const code = first;
+    const nameTh = cols[1] || '';
+    if (!nameTh) continue;
 
-  // กลุ่มภาษีและสินทรัพย์หมุนเวียนอื่น
-  { code: '11-41XX', nameTh: 'กลุ่มภาษีและสินทรัพย์หมุนเวียนอื่น', nameEn: 'Tax and Other Current Assets', accountGroup: AccountGroup.ASSET, parentCode: '11-0000', level: 2 },
-  { code: '11-4101', nameTh: 'ภาษีซื้อ', nameEn: 'Input VAT', accountGroup: AccountGroup.ASSET, parentCode: '11-41XX', level: 3, allowedCompanies: ['FINANCE'] },
-  { code: '11-4102', nameTh: 'ภาษีซื้อยังไม่ถึงกำหนด', nameEn: 'Input VAT Pending', accountGroup: AccountGroup.ASSET, parentCode: '11-41XX', level: 3, allowedCompanies: ['FINANCE'] },
+    let level = 3;
+    if (code.endsWith('-0000') || code.endsWith('-1000') || code.endsWith('-2000')) level = 1;
+    else if (code.endsWith('XX')) level = 2;
 
-  // ── สินทรัพย์ไม่หมุนเวียน ──
-  { code: '12-0000', nameTh: 'สินทรัพย์ไม่หมุนเวียน', nameEn: 'Non-Current Assets', accountGroup: AccountGroup.ASSET, level: 1 },
+    accounts.push({ code, nameTh, accountGroup: currentGroup, level });
+  }
 
-  // กลุ่มที่ดิน อาคาร และอุปกรณ์
-  { code: '12-21XX', nameTh: 'กลุ่มที่ดิน อาคาร และอุปกรณ์', nameEn: 'Property, Plant and Equipment', accountGroup: AccountGroup.ASSET, parentCode: '12-0000', level: 2 },
-  { code: '12-2101', nameTh: 'อุปกรณ์สำนักงาน', nameEn: 'Office Equipment', accountGroup: AccountGroup.ASSET, parentCode: '12-21XX', level: 3 },
-  { code: '12-2102', nameTh: 'หัก: ค่าเสื่อมราคาสะสม - อุปกรณ์สำนักงาน', nameEn: 'Less: Accum. Depr. - Office Equipment', accountGroup: AccountGroup.ASSET, parentCode: '12-21XX', level: 3 },
-  { code: '12-2103', nameTh: 'ส่วนปรับปรุงอาคาร', nameEn: 'Leasehold Improvements', accountGroup: AccountGroup.ASSET, parentCode: '12-21XX', level: 3 },
-  { code: '12-2104', nameTh: 'หัก: ค่าเสื่อมราคาสะสม - ส่วนปรับปรุงอาคาร', nameEn: 'Less: Accum. Depr. - Leasehold Improvements', accountGroup: AccountGroup.ASSET, parentCode: '12-21XX', level: 3 },
-  { code: '12-2105', nameTh: 'เครื่องตกแต่งสำนักงาน', nameEn: 'Office Furniture and Fixtures', accountGroup: AccountGroup.ASSET, parentCode: '12-21XX', level: 3 },
-  { code: '12-2106', nameTh: 'หัก: ค่าเสื่อมราคาสะสม - เครื่องตกแต่ง', nameEn: 'Less: Accum. Depr. - Furniture and Fixtures', accountGroup: AccountGroup.ASSET, parentCode: '12-21XX', level: 3 },
-  { code: '12-2107', nameTh: 'ยานพาหนะ', nameEn: 'Vehicles', accountGroup: AccountGroup.ASSET, parentCode: '12-21XX', level: 3 },
-
-  // ════════════════════════════════════════════════════════════
-  // หมวด 2: หนี้สิน (LIABILITY)
-  // ════════════════════════════════════════════════════════════
-
-  // ── หนี้สินหมุนเวียน ──
-  { code: '21-0000', nameTh: 'หนี้สินหมุนเวียน', nameEn: 'Current Liabilities', accountGroup: AccountGroup.LIABILITY, level: 1 },
-
-  // กลุ่มเจ้าหนี้การค้าและเจ้าหนี้อื่น
-  { code: '21-11XX', nameTh: 'กลุ่มเจ้าหนี้การค้าและเจ้าหนี้อื่น', nameEn: 'Trade and Other Payables', accountGroup: AccountGroup.LIABILITY, parentCode: '21-0000', level: 2 },
-  { code: '21-1101', nameTh: 'เจ้าหนี้การค้า', nameEn: 'Accounts Payable', accountGroup: AccountGroup.LIABILITY, parentCode: '21-11XX', level: 3 },
-  { code: '21-1103', nameTh: 'เจ้าหนี้ค่าใช้จ่ายบริการ', nameEn: 'Service Expense Payable', accountGroup: AccountGroup.LIABILITY, parentCode: '21-11XX', level: 3 },
-
-  // กลุ่มภาษีมูลค่าเพิ่ม (VAT)
-  { code: '21-21XX', nameTh: 'กลุ่มภาษีมูลค่าเพิ่ม (VAT)', nameEn: 'Value Added Tax (VAT)', accountGroup: AccountGroup.LIABILITY, parentCode: '21-0000', level: 2 },
-  { code: '21-2101', nameTh: 'ภาษีขาย ภ.พ.30', nameEn: 'Output VAT (PP.30)', accountGroup: AccountGroup.LIABILITY, parentCode: '21-21XX', level: 3, allowedCompanies: ['FINANCE'] },
-  { code: '21-2102', nameTh: 'ภ.พ.30 ค้างจ่าย', nameEn: 'VAT Payable (PP.30)', accountGroup: AccountGroup.LIABILITY, parentCode: '21-21XX', level: 3, allowedCompanies: ['FINANCE'] },
-
-  // กลุ่มภาษีหัก ณ ที่จ่าย (WHT)
-  { code: '21-31XX', nameTh: 'กลุ่มภาษีหัก ณ ที่จ่าย (WHT)', nameEn: 'Withholding Tax', accountGroup: AccountGroup.LIABILITY, parentCode: '21-0000', level: 2 },
-  { code: '21-3101', nameTh: 'ภ.ง.ด.1 ค่าจ้าง (เงินเดือน)', nameEn: 'WHT PND.1 (Salary)', accountGroup: AccountGroup.LIABILITY, parentCode: '21-31XX', level: 3 },
-  { code: '21-3102', nameTh: 'ภ.ง.ด.3 ค่าจ้าง (บุคคลธรรมดา)', nameEn: 'WHT PND.3 (Individual)', accountGroup: AccountGroup.LIABILITY, parentCode: '21-31XX', level: 3 },
-  { code: '21-3103', nameTh: 'ภ.ง.ด.53 ค่าจ้าง (นิติบุคคล)', nameEn: 'WHT PND.53 (Juristic Person)', accountGroup: AccountGroup.LIABILITY, parentCode: '21-31XX', level: 3 },
-
-  // กลุ่มเงินรับล่วงหน้า/รายจ่ายสรรพากร
-  { code: '21-41XX', nameTh: 'กลุ่มเงินรับล่วงหน้า/รายจ่ายสรรพากร', nameEn: 'Advance Receipts / Revenue Dept.', accountGroup: AccountGroup.LIABILITY, parentCode: '21-0000', level: 2 },
-  { code: '21-4201', nameTh: 'เงินรับล่วงหน้า', nameEn: 'Advance Receipts', accountGroup: AccountGroup.LIABILITY, parentCode: '21-41XX', level: 3 },
-  { code: '21-4202', nameTh: 'เงินมัดจำรับ', nameEn: 'Deposits Received', accountGroup: AccountGroup.LIABILITY, parentCode: '21-41XX', level: 3 },
-
-  // กลุ่มเจ้าหนี้อื่น
-  { code: '21-51XX', nameTh: 'กลุ่มเจ้าหนี้อื่น', nameEn: 'Other Payables', accountGroup: AccountGroup.LIABILITY, parentCode: '21-0000', level: 2 },
-  { code: '21-5101', nameTh: 'เงินเกินของลูกค้า', nameEn: 'Customer Credit Balance', accountGroup: AccountGroup.LIABILITY, parentCode: '21-51XX', level: 3 },
-
-  // ── หนี้สินไม่หมุนเวียน ──
-  { code: '22-0000', nameTh: 'หนี้สินไม่หมุนเวียน', nameEn: 'Non-Current Liabilities', accountGroup: AccountGroup.LIABILITY, level: 1 },
-  { code: '22-1101', nameTh: 'เงินกู้ยืมระยะยาว', nameEn: 'Long-Term Loans', accountGroup: AccountGroup.LIABILITY, parentCode: '22-0000', level: 3 },
-
-  // ════════════════════════════════════════════════════════════
-  // หมวด 3: ส่วนของเจ้าของ (EQUITY)
-  // ════════════════════════════════════════════════════════════
-  { code: '31-0000', nameTh: 'ทุนที่ออกและชำระเต็มมูลค่าแล้ว', nameEn: 'Issued and Paid-up Capital', accountGroup: AccountGroup.EQUITY, level: 1 },
-  { code: '31-1101', nameTh: 'ทุนสามัญ', nameEn: 'Common Stock', accountGroup: AccountGroup.EQUITY, parentCode: '31-0000', level: 2 },
-
-  { code: '32-0000', nameTh: 'กำไร (ขาดทุน) สะสม', nameEn: 'Retained Earnings (Deficit)', accountGroup: AccountGroup.EQUITY, level: 1 },
-  { code: '32-1001', nameTh: 'กำไร(ขาดทุน)สะสม', nameEn: 'Retained Earnings (Deficit)', accountGroup: AccountGroup.EQUITY, parentCode: '32-0000', level: 2 },
-
-  // ════════════════════════════════════════════════════════════
-  // หมวด 4: รายได้ (REVENUE)
-  // ════════════════════════════════════════════════════════════
-
-  // ── รายได้จากการขายและบริการ ──
-  { code: '41-0000', nameTh: 'รายได้จากการขายและบริการ', nameEn: 'Sales and Service Revenue', accountGroup: AccountGroup.REVENUE, level: 1 },
-
-  // กลุ่มรายได้จากการขาย
-  { code: '41-11XX', nameTh: 'กลุ่มรายได้จากการขาย', nameEn: 'Sales Revenue', accountGroup: AccountGroup.REVENUE, parentCode: '41-0000', level: 2 },
-  { code: '41-1101', nameTh: 'รายได้ มือถือ (ใหม่)', nameEn: 'Revenue - New Phones', accountGroup: AccountGroup.REVENUE, parentCode: '41-11XX', level: 3 },
-  { code: '41-1102', nameTh: 'รายได้ มือสอง (มือสอง)', nameEn: 'Revenue - Used Phones', accountGroup: AccountGroup.REVENUE, parentCode: '41-11XX', level: 3 },
-  { code: '41-1103', nameTh: 'รายได้จากขายผ่านไฟแนนซ์ภายนอก', nameEn: 'External Finance Sales Revenue', accountGroup: AccountGroup.REVENUE, parentCode: '41-11XX', level: 3 },
-
-  // กลุ่มรายการปรับปรุงรายได้
-  { code: '41-21XX', nameTh: 'กลุ่มรายการปรับปรุงรายได้', nameEn: 'Revenue Adjustments', accountGroup: AccountGroup.REVENUE, parentCode: '41-0000', level: 2 },
-  { code: '41-2101', nameTh: '(หัก) ส่วนลดจ่าย', nameEn: 'Less: Sales Discounts', accountGroup: AccountGroup.REVENUE, parentCode: '41-21XX', level: 3 },
-
-  // ── รายได้อื่น ──
-  { code: '42-0000', nameTh: 'รายได้อื่น', nameEn: 'Other Income', accountGroup: AccountGroup.REVENUE, level: 1 },
-
-  // กลุ่มรายได้ดอกเบี้ย/เครดิต
-  { code: '42-11XX', nameTh: 'กลุ่มรายได้ดอกเบี้ย/เครดิต', nameEn: 'Interest and Credit Income', accountGroup: AccountGroup.REVENUE, parentCode: '42-0000', level: 2 },
-  { code: '42-1101', nameTh: 'รายได้ดอกเบี้ยเช่าซื้อ', nameEn: 'Interest Income on Hire Purchase', accountGroup: AccountGroup.REVENUE, parentCode: '42-11XX', level: 3, allowedCompanies: ['FINANCE'] },
-  { code: '42-1102', nameTh: 'ค่างวดเบี้ยปรับล่าช้า', nameEn: 'Late Payment Penalty Income', accountGroup: AccountGroup.REVENUE, parentCode: '42-11XX', level: 3, allowedCompanies: ['FINANCE'] },
-  { code: '42-1103', nameTh: 'ค่ามัดจำ/เงินประกันที่ริบ', nameEn: 'Forfeited Deposits/Guarantees', accountGroup: AccountGroup.REVENUE, parentCode: '42-11XX', level: 3, allowedCompanies: ['FINANCE'] },
-  { code: '42-1104', nameTh: 'รายได้จากการยึดเครื่อง', nameEn: 'Repossession Income', accountGroup: AccountGroup.REVENUE, parentCode: '42-11XX', level: 3, allowedCompanies: ['FINANCE'] },
-  { code: '42-1105', nameTh: 'รายได้ค่านายหน้า/คอมมิชชัน', nameEn: 'Commission Income', accountGroup: AccountGroup.REVENUE, parentCode: '42-11XX', level: 3, allowedCompanies: ['SHOP'] },
-
-  // ════════════════════════════════════════════════════════════
-  // หมวด 5: ค่าใช้จ่าย (EXPENSE)
-  // ════════════════════════════════════════════════════════════
-
-  // ── ต้นทุนขาย ──
-  { code: '51-0000', nameTh: 'ต้นทุนขาย', nameEn: 'Cost of Goods Sold', accountGroup: AccountGroup.EXPENSE, level: 1 },
-  { code: '51-1101', nameTh: 'ต้นทุนมือถือ (ใหม่)', nameEn: 'COGS - New Phones', accountGroup: AccountGroup.EXPENSE, parentCode: '51-0000', level: 3 },
-  { code: '51-1102', nameTh: 'ต้นทุนมือถือ (มือสอง)', nameEn: 'COGS - Used Phones', accountGroup: AccountGroup.EXPENSE, parentCode: '51-0000', level: 3 },
-
-  // ── ค่าใช้จ่ายในการขาย ──
-  { code: '52-0000', nameTh: 'ค่าใช้จ่ายในการขาย', nameEn: 'Selling Expenses', accountGroup: AccountGroup.EXPENSE, level: 1 },
-  { code: '52-1101', nameTh: 'ค่าคอมมิชชั่น/นาย', nameEn: 'Sales Commission', accountGroup: AccountGroup.EXPENSE, parentCode: '52-0000', level: 3 },
-  { code: '52-1102', nameTh: 'ค่าส่งเสริมการขาย', nameEn: 'Sales Promotion', accountGroup: AccountGroup.EXPENSE, parentCode: '52-0000', level: 3 },
-  { code: '52-1103', nameTh: 'ค่าบริการส่ง SMS', nameEn: 'SMS Service', accountGroup: AccountGroup.EXPENSE, parentCode: '52-0000', level: 3 },
-  { code: '52-1104', nameTh: 'ส่วนลดไม่จ่ายเนตศาสตร์', nameEn: 'Unclaimed Discount', accountGroup: AccountGroup.EXPENSE, parentCode: '52-0000', level: 3 },
-
-  // ── ค่าใช้จ่ายในการบริหาร ──
-  { code: '53-0000', nameTh: 'ค่าใช้จ่ายในการบริหาร', nameEn: 'Administrative Expenses', accountGroup: AccountGroup.EXPENSE, level: 1 },
-  { code: '53-0102', nameTh: 'โบนัส', nameEn: 'Bonus', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 3 },
-  { code: '53-0116', nameTh: 'ค่าสวัสดิการ', nameEn: 'Welfare', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 3 },
-  { code: '53-0509', nameTh: 'ค่ากรรมสิทธิ์', nameEn: 'Proprietary Fee', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 3 },
-
-  // กลุ่มค่าใช้จ่ายบุคลากร
-  { code: '53-11XX', nameTh: 'กลุ่มค่าใช้จ่ายบุคลากร', nameEn: 'Personnel Expenses', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 2 },
-  { code: '53-1101', nameTh: 'เงินเดือน ค่าจ้าง', nameEn: 'Salaries and Wages', accountGroup: AccountGroup.EXPENSE, parentCode: '53-11XX', level: 3 },
-  { code: '53-1102', nameTh: 'ค่าคอมมิชชั่น พนักงาน', nameEn: 'Employee Commission', accountGroup: AccountGroup.EXPENSE, parentCode: '53-11XX', level: 3 },
-  { code: '53-1103', nameTh: 'เงินสมทบประกันสังคม กองทุนเงินทดแทน', nameEn: 'Social Security and Compensation Fund', accountGroup: AccountGroup.EXPENSE, parentCode: '53-11XX', level: 3 },
-  { code: '53-1104', nameTh: 'ค่าอบรม สัมมนา', nameEn: 'Training and Seminar', accountGroup: AccountGroup.EXPENSE, parentCode: '53-11XX', level: 3 },
-
-  // กลุ่มวัสดุสิ้นเปลืองและอุปกรณ์
-  { code: '53-12XX', nameTh: 'กลุ่มวัสดุสิ้นเปลืองและอุปกรณ์', nameEn: 'Consumables and Supplies', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 2 },
-  { code: '53-1201', nameTh: 'ค่าเครื่องเขียน วัสดุสำนักงาน', nameEn: 'Stationery and Office Supplies', accountGroup: AccountGroup.EXPENSE, parentCode: '53-12XX', level: 3 },
-  { code: '53-1202', nameTh: 'ค่าเครื่องเขียนแบบพิมพ์', nameEn: 'Printed Stationery', accountGroup: AccountGroup.EXPENSE, parentCode: '53-12XX', level: 3 },
-
-  // กลุ่มสถานที่/สาธารณูปโภค
-  { code: '53-13XX', nameTh: 'กลุ่มสถานที่/สาธารณูปโภค', nameEn: 'Premises and Utilities', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 2 },
-  { code: '53-1301', nameTh: 'ค่าน้ำ', nameEn: 'Water', accountGroup: AccountGroup.EXPENSE, parentCode: '53-13XX', level: 3 },
-  { code: '53-1302', nameTh: 'ค่าไฟฟ้า', nameEn: 'Electricity', accountGroup: AccountGroup.EXPENSE, parentCode: '53-13XX', level: 3 },
-  { code: '53-1303', nameTh: 'ค่าโทรศัพท์สำนักงาน', nameEn: 'Telephone/Internet', accountGroup: AccountGroup.EXPENSE, parentCode: '53-13XX', level: 3 },
-  { code: '53-1304', nameTh: 'ค่าไปรษณีย์ และขนส่ง', nameEn: 'Postage and Delivery', accountGroup: AccountGroup.EXPENSE, parentCode: '53-13XX', level: 3 },
-  { code: '53-1305', nameTh: 'ค่าซ่อมแซม', nameEn: 'Repairs and Maintenance', accountGroup: AccountGroup.EXPENSE, parentCode: '53-13XX', level: 3 },
-
-  // กลุ่มค่าจ้างบริการวิชาชีพ
-  { code: '53-14XX', nameTh: 'กลุ่มค่าจ้างบริการวิชาชีพ', nameEn: 'Professional Service Fees', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 2 },
-  { code: '53-1401', nameTh: 'ค่าบริการ AI', nameEn: 'AI Service', accountGroup: AccountGroup.EXPENSE, parentCode: '53-14XX', level: 3 },
-  { code: '53-1402', nameTh: 'ค่าจ้างเขียนโปรแกรม', nameEn: 'Software Development', accountGroup: AccountGroup.EXPENSE, parentCode: '53-14XX', level: 3 },
-  { code: '53-1403', nameTh: 'ค่าบริการทำบัญชี', nameEn: 'Accounting Service', accountGroup: AccountGroup.EXPENSE, parentCode: '53-14XX', level: 3 },
-  { code: '53-1404', nameTh: 'ค่าบริการที่ปรึกษากฎหมาย', nameEn: 'Legal Advisory Service', accountGroup: AccountGroup.EXPENSE, parentCode: '53-14XX', level: 3 },
-  { code: '53-1405', nameTh: 'ค่าบริการอื่น', nameEn: 'Other Services', accountGroup: AccountGroup.EXPENSE, parentCode: '53-14XX', level: 3 },
-
-  // กลุ่มค่าธรรมเนียม/ค่าใช้จ่ายทางการเงิน
-  { code: '53-15XX', nameTh: 'กลุ่มค่าธรรมเนียม/ค่าใช้จ่ายทางการเงิน', nameEn: 'Financial Fees and Charges', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 2 },
-  { code: '53-1501', nameTh: 'ค่าธรรมเนียมธนาคาร', nameEn: 'Bank Charges', accountGroup: AccountGroup.EXPENSE, parentCode: '53-15XX', level: 3 },
-  { code: '53-1502', nameTh: 'ค่าธรรมเนียมอื่น', nameEn: 'Other Fees', accountGroup: AccountGroup.EXPENSE, parentCode: '53-15XX', level: 3 },
-  { code: '53-1503', nameTh: 'ขาดทุน(กำไร)จากการปิดสัญญา', nameEn: 'Loss (Gain) on Contract Closure', accountGroup: AccountGroup.EXPENSE, parentCode: '53-15XX', level: 3 },
-
-  // กลุ่มค่าเสื่อมราคา
-  { code: '53-16XX', nameTh: 'กลุ่มค่าเสื่อมราคา', nameEn: 'Depreciation', accountGroup: AccountGroup.EXPENSE, parentCode: '53-0000', level: 2 },
-  { code: '53-1601', nameTh: 'ค่าเสื่อมราคา - อุปกรณ์สำนักงาน', nameEn: 'Depreciation - Office Equipment', accountGroup: AccountGroup.EXPENSE, parentCode: '53-16XX', level: 3 },
-  { code: '53-1602', nameTh: 'ค่าเสื่อมราคา - ส่วนปรับปรุงอาคาร', nameEn: 'Depreciation - Leasehold Improvements', accountGroup: AccountGroup.EXPENSE, parentCode: '53-16XX', level: 3 },
-  { code: '53-1603', nameTh: 'ค่าเสื่อมราคา - เครื่องตกแต่ง', nameEn: 'Depreciation - Furniture and Fixtures', accountGroup: AccountGroup.EXPENSE, parentCode: '53-16XX', level: 3 },
-  { code: '53-1604', nameTh: 'ค่าเสื่อมราคา - ยานพาหนะ', nameEn: 'Depreciation - Vehicles', accountGroup: AccountGroup.EXPENSE, parentCode: '53-16XX', level: 3 },
-
-  // ── ค่าใช้จ่ายอื่น / รายจ่ายต้องห้ามทางภาษี ──
-  { code: '54-0000', nameTh: 'ค่าใช้จ่ายอื่น / รายจ่ายต้องห้ามทางภาษี', nameEn: 'Other Expenses / Non-Deductible Expenses', accountGroup: AccountGroup.EXPENSE, level: 1 },
-  { code: '54-1101', nameTh: 'ภงด.ทางภาษี ภ.ง.ด.3', nameEn: 'Tax Expense - PND.3', accountGroup: AccountGroup.EXPENSE, parentCode: '54-0000', level: 3 },
-  { code: '54-1102', nameTh: 'ภงด.ทางภาษี ภ.ง.ด.53', nameEn: 'Tax Expense - PND.53', accountGroup: AccountGroup.EXPENSE, parentCode: '54-0000', level: 3 },
-  { code: '54-1103', nameTh: 'ภงด.ทางภาษี ภ.พ.30', nameEn: 'Tax Expense - PP.30', accountGroup: AccountGroup.EXPENSE, parentCode: '54-0000', level: 3 },
-  { code: '54-1104', nameTh: 'เบี้ยปรับเงินเพิ่ม', nameEn: 'Surcharges and Penalties', accountGroup: AccountGroup.EXPENSE, parentCode: '54-0000', level: 3 },
-];
+  return accounts;
+}
 
 export async function seedChartOfAccounts(prisma: PrismaClient): Promise<void> {
-  console.log('Seeding Chart of Accounts (ผังบัญชี)...');
+  console.log('Seeding Chart of Accounts (Phase A.1a — SHOP + FINANCE split)...');
 
-  for (const account of CHART_OF_ACCOUNTS) {
+  const shopCompany = await prisma.companyInfo.findFirst({
+    where: { companyCode: 'SHOP', deletedAt: null },
+    select: { id: true },
+  });
+  const financeCompany = await prisma.companyInfo.findFirst({
+    where: { companyCode: 'FINANCE', deletedAt: null },
+    select: { id: true },
+  });
+
+  if (!shopCompany || !financeCompany) {
+    throw new Error('SHOP and FINANCE companies must exist before seeding chart of accounts');
+  }
+
+  const shopAccounts = parseOwnerCsv();
+  console.log(`  → Seeding ${shopAccounts.length} SHOP accounts from owner CSV...`);
+  for (const acc of shopAccounts) {
     await prisma.chartOfAccount.upsert({
-      where: { code: account.code },
+      where: { companyId_code: { companyId: shopCompany.id, code: acc.code } },
       update: {
-        nameTh: account.nameTh,
-        nameEn: account.nameEn,
-        accountGroup: account.accountGroup,
-        parentCode: account.parentCode,
-        level: account.level,
-        isActive: true,
-        allowedCompanies: account.allowedCompanies ?? [],
-        peakAccountCode: account.peakAccountCode ?? account.code,
+        nameTh: acc.nameTh, nameEn: acc.nameEn, accountGroup: acc.accountGroup,
+        level: acc.level, isActive: true, peakAccountCode: acc.code,
       },
       create: {
-        code: account.code,
-        nameTh: account.nameTh,
-        nameEn: account.nameEn ?? undefined,
-        accountGroup: account.accountGroup,
-        parentCode: account.parentCode ?? undefined,
-        level: account.level,
-        isActive: true,
-        allowedCompanies: account.allowedCompanies ?? [],
-        peakAccountCode: account.peakAccountCode ?? account.code,
+        code: acc.code, companyId: shopCompany.id, nameTh: acc.nameTh, nameEn: acc.nameEn,
+        accountGroup: acc.accountGroup, parentCode: acc.parentCode, level: acc.level,
+        isActive: true, peakAccountCode: acc.code,
       },
     });
   }
 
-  console.log(`  ✓ Chart of Accounts: ${CHART_OF_ACCOUNTS.length} accounts seeded`);
+  await seedFinanceChartOfAccounts(prisma, financeCompany.id);
+
+  // SHOP-side clearing account for inter-company (used in A.1b)
+  await prisma.chartOfAccount.upsert({
+    where: { companyId_code: { companyId: shopCompany.id, code: '11-2105' } },
+    update: { nameTh: 'ลูกหนี้คู่ค้า — FINANCE (Due-from-FINANCE)' },
+    create: {
+      code: '11-2105', companyId: shopCompany.id,
+      nameTh: 'ลูกหนี้คู่ค้า — FINANCE (Due-from-FINANCE)',
+      nameEn: 'Inter-company Receivable — FINANCE',
+      accountGroup: AccountGroup.ASSET, parentCode: '11-21XX', level: 3,
+      isActive: true, peakAccountCode: '11-2105',
+    },
+  });
+
+  console.log(`  ✓ Chart of Accounts: ${shopAccounts.length + 1} SHOP + 41 FINANCE seeded`);
 }

--- a/apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts
+++ b/apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts
@@ -17,11 +17,13 @@ export class ChartOfAccountsController {
     @Query('group') group?: AccountGroup,
     @Query('active') active?: string,
     @Query('q') q?: string,
+    @Query('companyId') companyId?: string,
   ) {
     return this.service.findAll({
       group,
       active: active != null ? active === 'true' : undefined,
       q,
+      companyId: companyId === 'SHARED' ? 'SHARED' : companyId,
     });
   }
 

--- a/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts
+++ b/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts
@@ -14,6 +14,7 @@ describe('ChartOfAccountsService', () => {
       chartOfAccount: {
         findMany: jest.fn(),
         findUnique: jest.fn(),
+        findFirst: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
         count: jest.fn(),
@@ -32,12 +33,13 @@ describe('ChartOfAccountsService', () => {
   });
 
   describe('findAll', () => {
-    it('returns active accounts ordered by code with soft-delete filter', async () => {
+    it('returns active accounts ordered by companyId+code with soft-delete filter', async () => {
       prisma.chartOfAccount.findMany.mockResolvedValue([{ id: 'a1' }]);
       await service.findAll();
+      // Phase A.1a: ordered by [companyId asc, code asc] so SHARED (null) groups first.
       expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith({
         where: { deletedAt: null },
-        orderBy: { code: 'asc' },
+        orderBy: [{ companyId: 'asc' }, { code: 'asc' }],
       });
     });
 
@@ -95,9 +97,8 @@ describe('ChartOfAccountsService', () => {
     });
 
     it('rejects unknown parentCode with BadRequestException', async () => {
-      prisma.chartOfAccount.findUnique
-        .mockResolvedValueOnce(null) // duplicate check
-        .mockResolvedValueOnce(null); // parent lookup
+      prisma.chartOfAccount.findUnique.mockResolvedValueOnce(null); // duplicate check
+      prisma.chartOfAccount.findFirst.mockResolvedValueOnce(null); // parent lookup (Phase A.1a uses findFirst scoped to companyId)
       await expect(
         service.create({ ...baseDto, parentCode: '11-1000' } as any),
       ).rejects.toBeInstanceOf(BadRequestException);
@@ -126,7 +127,8 @@ describe('ChartOfAccountsService', () => {
       const call = prisma.chartOfAccount.create.mock.calls[0][0];
       expect(call.data.level).toBe(3);
       expect(call.data.isActive).toBe(true);
-      expect(call.data.allowedCompanies).toEqual([]);
+      // Phase A.1a: allowedCompanies dropped — companyId now scopes ownership.
+      expect(call.data).not.toHaveProperty('allowedCompanies');
     });
   });
 
@@ -141,7 +143,8 @@ describe('ChartOfAccountsService', () => {
     it('rejects update with unknown parentCode', async () => {
       prisma.chartOfAccount.findUnique
         .mockResolvedValueOnce({ id: 'a1', code: '11-1101' }) // findOne
-        .mockResolvedValueOnce(null); // parent lookup
+        .mockResolvedValueOnce({ id: 'a1', code: '11-1101', companyId: null }); // existing fetch for parent scope
+      prisma.chartOfAccount.findFirst.mockResolvedValueOnce(null); // parent lookup (Phase A.1a uses findFirst)
       await expect(
         service.update('a1', { parentCode: '99-9999' }),
       ).rejects.toBeInstanceOf(BadRequestException);
@@ -199,6 +202,69 @@ describe('ChartOfAccountsService', () => {
     it('throws NotFoundException when account does not exist', async () => {
       prisma.chartOfAccount.findUnique.mockResolvedValue(null);
       await expect(service.remove('missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  // Phase A.1a: companyId scoping + composite (companyId, code) uniqueness.
+  describe('findAll companyId filter (Phase A.1a)', () => {
+    it('filters by SHOP companyId when provided', async () => {
+      prisma.chartOfAccount.findMany.mockResolvedValue([]);
+      await service.findAll({ companyId: 'shop-co-1' });
+      expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ companyId: 'shop-co-1' }),
+        }),
+      );
+    });
+
+    it('filters companyId=null when SHARED', async () => {
+      prisma.chartOfAccount.findMany.mockResolvedValue([]);
+      await service.findAll({ companyId: 'SHARED' });
+      expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ companyId: null }),
+        }),
+      );
+    });
+
+    it('returns all when no companyId provided (no companyId in where)', async () => {
+      prisma.chartOfAccount.findMany.mockResolvedValue([]);
+      await service.findAll({});
+      const call = prisma.chartOfAccount.findMany.mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('companyId');
+    });
+  });
+
+  describe('create with composite uniqueness (Phase A.1a)', () => {
+    it('uses companyId_code in findUnique check with explicit companyId', async () => {
+      prisma.chartOfAccount.findUnique.mockResolvedValue(null);
+      prisma.chartOfAccount.create.mockResolvedValue({ id: 'new1' });
+      await service.create({
+        code: '11-1101',
+        companyId: 'finance-co-1',
+        nameTh: 'FINANCE Cash',
+        accountGroup: AccountGroup.ASSET,
+      } as any);
+      expect(prisma.chartOfAccount.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { companyId_code: { companyId: 'finance-co-1', code: '11-1101' } },
+        }),
+      );
+    });
+
+    it('treats undefined companyId as null in uniqueness check', async () => {
+      prisma.chartOfAccount.findUnique.mockResolvedValue(null);
+      prisma.chartOfAccount.create.mockResolvedValue({ id: 'new1' });
+      await service.create({
+        code: '99-9999',
+        nameTh: 'Shared',
+        accountGroup: AccountGroup.ASSET,
+      } as any);
+      expect(prisma.chartOfAccount.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { companyId_code: { companyId: null, code: '99-9999' } },
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts
+++ b/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts
@@ -7,10 +7,23 @@ import { AccountGroup } from '@prisma/client';
 export class ChartOfAccountsService {
   constructor(private prisma: PrismaService) {}
 
-  async findAll(filter?: { group?: AccountGroup; active?: boolean; q?: string }) {
+  async findAll(filter?: {
+    group?: AccountGroup;
+    active?: boolean;
+    q?: string;
+    companyId?: string | 'SHARED' | null;
+  }) {
+    const companyFilter =
+      filter?.companyId === 'SHARED'
+        ? { companyId: null }
+        : filter?.companyId
+          ? { companyId: filter.companyId }
+          : {};
+
     return this.prisma.chartOfAccount.findMany({
       where: {
         deletedAt: null,
+        ...companyFilter,
         ...(filter?.group && { accountGroup: filter.group }),
         ...(filter?.active != null && { isActive: filter.active }),
         ...(filter?.q && {
@@ -21,7 +34,7 @@ export class ChartOfAccountsService {
           ],
         }),
       },
-      orderBy: { code: 'asc' },
+      orderBy: [{ companyId: 'asc' }, { code: 'asc' }],
     });
   }
 
@@ -32,24 +45,31 @@ export class ChartOfAccountsService {
   }
 
   async create(dto: CreateChartOfAccountDto) {
-    const exists = await this.prisma.chartOfAccount.findUnique({ where: { code: dto.code } });
-    if (exists) throw new ConflictException(`รหัสบัญชี ${dto.code} มีอยู่แล้ว`);
+    const companyId = dto.companyId ?? null;
+
+    // Composite uniqueness check
+    const exists = await this.prisma.chartOfAccount.findUnique({
+      where: { companyId_code: { companyId: companyId as any, code: dto.code } },
+    });
+    if (exists) throw new ConflictException(`รหัสบัญชี ${dto.code} มีอยู่แล้วในบริษัทนี้`);
 
     if (dto.parentCode) {
-      const parent = await this.prisma.chartOfAccount.findUnique({ where: { code: dto.parentCode } });
-      if (!parent) throw new BadRequestException(`ไม่พบบัญชีแม่ ${dto.parentCode}`);
+      const parent = await this.prisma.chartOfAccount.findFirst({
+        where: { code: dto.parentCode, companyId, deletedAt: null },
+      });
+      if (!parent) throw new BadRequestException(`ไม่พบบัญชีแม่ ${dto.parentCode} ในบริษัทเดียวกัน`);
     }
 
     return this.prisma.chartOfAccount.create({
       data: {
         code: dto.code,
+        companyId,
         nameTh: dto.nameTh,
         nameEn: dto.nameEn,
         accountGroup: dto.accountGroup,
         parentCode: dto.parentCode,
         level: dto.level ?? 3,
         isActive: dto.isActive ?? true,
-        allowedCompanies: dto.allowedCompanies ?? [],
         peakAccountCode: dto.peakAccountCode ?? dto.code,
         peakAccountId: dto.peakAccountId,
       },
@@ -59,10 +79,25 @@ export class ChartOfAccountsService {
   async update(id: string, dto: UpdateChartOfAccountDto) {
     await this.findOne(id);
     if (dto.parentCode) {
-      const parent = await this.prisma.chartOfAccount.findUnique({ where: { code: dto.parentCode } });
-      if (!parent) throw new BadRequestException(`ไม่พบบัญชีแม่ ${dto.parentCode}`);
+      // For update, must verify parent exists in the same company as the existing account
+      const existing = await this.prisma.chartOfAccount.findUnique({ where: { id } });
+      const parent = await this.prisma.chartOfAccount.findFirst({
+        where: { code: dto.parentCode, companyId: existing?.companyId ?? null, deletedAt: null },
+      });
+      if (!parent) throw new BadRequestException(`ไม่พบบัญชีแม่ ${dto.parentCode} ในบริษัทเดียวกัน`);
     }
-    return this.prisma.chartOfAccount.update({ where: { id }, data: dto });
+    // Strip undefined so they don't overwrite existing
+    const data: any = {};
+    if (dto.nameTh !== undefined) data.nameTh = dto.nameTh;
+    if (dto.nameEn !== undefined) data.nameEn = dto.nameEn;
+    if (dto.accountGroup !== undefined) data.accountGroup = dto.accountGroup;
+    if (dto.parentCode !== undefined) data.parentCode = dto.parentCode;
+    if (dto.level !== undefined) data.level = dto.level;
+    if (dto.isActive !== undefined) data.isActive = dto.isActive;
+    if (dto.peakAccountCode !== undefined) data.peakAccountCode = dto.peakAccountCode;
+    if (dto.peakAccountId !== undefined) data.peakAccountId = dto.peakAccountId;
+    // Note: companyId NOT updatable — moving accounts between companies is intentional rare op (do via delete+recreate)
+    return this.prisma.chartOfAccount.update({ where: { id }, data });
   }
 
   async remove(id: string) {
@@ -76,7 +111,9 @@ export class ChartOfAccountsService {
     }
 
     // Block delete if any child accounts exist
-    const children = await this.prisma.chartOfAccount.count({ where: { parentCode: account.code } });
+    const children = await this.prisma.chartOfAccount.count({
+      where: { parentCode: account.code, companyId: account.companyId },
+    });
     if (children > 0) {
       throw new BadRequestException('มีบัญชีย่อยอยู่ ลบไม่ได้');
     }

--- a/apps/api/src/modules/chart-of-accounts/dto/chart-of-account.dto.ts
+++ b/apps/api/src/modules/chart-of-accounts/dto/chart-of-account.dto.ts
@@ -1,7 +1,5 @@
-import { IsString, IsOptional, IsEnum, IsBoolean, IsInt, Matches, MaxLength, Min, Max, IsArray, IsIn } from 'class-validator';
+import { IsString, IsOptional, IsEnum, IsBoolean, IsInt, Matches, MaxLength, Min, Max, IsUUID } from 'class-validator';
 import { AccountGroup } from '@prisma/client';
-
-const ALLOWED_COMPANY_CODES = ['SHOP', 'FINANCE'] as const;
 
 export class CreateChartOfAccountDto {
   @IsString()
@@ -34,10 +32,9 @@ export class CreateChartOfAccountDto {
   @IsOptional()
   isActive?: boolean;
 
-  @IsArray()
+  @IsUUID(undefined, { message: 'companyId ต้องเป็น UUID ที่ถูกต้อง' })
   @IsOptional()
-  @IsIn(ALLOWED_COMPANY_CODES, { each: true, message: 'allowedCompanies ต้องเป็น SHOP หรือ FINANCE' })
-  allowedCompanies?: string[];
+  companyId?: string;
 
   @IsString()
   @IsOptional()
@@ -79,10 +76,11 @@ export class UpdateChartOfAccountDto {
   @IsOptional()
   isActive?: boolean;
 
-  @IsArray()
+  // companyId kept for symmetry with CreateDto, but service.update() ignores it.
+  // Moving an account between companies must be done via delete+recreate to preserve audit trail.
+  @IsUUID(undefined, { message: 'companyId ต้องเป็น UUID ที่ถูกต้อง' })
   @IsOptional()
-  @IsIn(ALLOWED_COMPANY_CODES, { each: true, message: 'allowedCompanies ต้องเป็น SHOP หรือ FINANCE' })
-  allowedCompanies?: string[];
+  companyId?: string;
 
   @IsString()
   @IsOptional()

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -29,7 +29,13 @@ describe('JournalAutoService', () => {
         findUnique: jest.fn().mockResolvedValue({ companyCode: 'FINANCE' }),
       },
       chartOfAccount: {
-        findMany: jest.fn().mockResolvedValue([]),
+        // Phase A.1a: createAndPost validates lookup codes against
+        // (companyId, code). Return whatever codes the call asks for so
+        // existing tests don't trip the new validation.
+        findMany: jest.fn().mockImplementation(({ where }: { where: { code?: { in?: string[] } } }) => {
+          const codes = where?.code?.in ?? [];
+          return Promise.resolve(codes.map((code: string) => ({ code, nameTh: code })));
+        }),
       },
       // F-6-002: default — no closed period
       accountingPeriod: {
@@ -212,7 +218,7 @@ describe('JournalAutoService', () => {
 
       const lines = capturedLines();
       const vatLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.VAT_INPUT,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_INPUT,
       );
       expect(vatLine).toBeDefined();
       expect(Number(vatLine!.debit)).toBeCloseTo(70, 2);
@@ -227,7 +233,7 @@ describe('JournalAutoService', () => {
 
       const lines = capturedLines();
       const cashLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.CASH,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.CASH,
       );
       expect(cashLine).toBeDefined();
       expect(Number(cashLine!.credit)).toBeCloseTo(1070, 2);
@@ -320,8 +326,8 @@ describe('JournalAutoService', () => {
         credit: number;
       }>;
 
-      const cashLine = lines.find((l) => l.accountCode === JournalAutoService.ACC.CASH);
-      const hpLine = lines.find((l) => l.accountCode === JournalAutoService.ACC.HP_RECEIVABLE);
+      const cashLine = lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.CASH);
+      const hpLine = lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.HP_RECEIVABLE);
 
       expect(Number(cashLine?.debit)).toBeCloseTo(3000, 2);
       // HP Receivable = financedAmount (already includes principal+commission+interest+vat)
@@ -342,7 +348,7 @@ describe('JournalAutoService', () => {
         credit: number;
       }>;
 
-      const vatLine = lines.find((l) => l.accountCode === JournalAutoService.ACC.VAT_OUTPUT);
+      const vatLine = lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT);
       expect(Number(vatLine?.credit)).toBeCloseTo(1000, 2);
     });
 
@@ -388,12 +394,12 @@ describe('JournalAutoService', () => {
       const salesLines = prisma.journalEntry.create.mock.calls[0][0].data.lines
         .create as Array<{ accountCode: string; credit: number }>;
       const revLine = salesLines.find((l) => l.credit > 0 && l.accountCode.startsWith('41'));
-      expect(revLine?.accountCode).toBe(JournalAutoService.ACC.REVENUE_USED);
+      expect(revLine?.accountCode).toBe(JournalAutoService.FINANCE_ACC.REVENUE_USED);
 
       const cogsLines = prisma.journalEntry.create.mock.calls[1][0].data.lines
         .create as Array<{ accountCode: string; debit: number }>;
       const cogsLine = cogsLines.find((l) => l.debit > 0);
-      expect(cogsLine?.accountCode).toBe(JournalAutoService.ACC.COGS_USED);
+      expect(cogsLine?.accountCode).toBe(JournalAutoService.FINANCE_ACC.COGS_USED);
     });
 
     // F-2-001 regression: financedAmount per installment.util.ts:56 already
@@ -477,7 +483,7 @@ describe('JournalAutoService', () => {
 
       const lines = capturedLines();
       const badDebtLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.BAD_DEBT_EXPENSE,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.BAD_DEBT_EXPENSE,
       );
       expect(Number(badDebtLine?.debit)).toBeCloseTo(5000, 2);
     });
@@ -493,7 +499,7 @@ describe('JournalAutoService', () => {
 
       const lines = capturedLines();
       const hpLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.HP_RECEIVABLE,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.HP_RECEIVABLE,
       );
       expect(Number(hpLine?.credit)).toBeCloseTo(5000, 2);
     });
@@ -511,10 +517,10 @@ describe('JournalAutoService', () => {
 
       const lines = capturedLines();
       const badDebtLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.BAD_DEBT_EXPENSE,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.BAD_DEBT_EXPENSE,
       );
       const allowanceLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.ALLOWANCE_DOUBTFUL,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.ALLOWANCE_DOUBTFUL,
       );
       expect(Number(badDebtLine?.debit)).toBeCloseTo(3000, 2);
       expect(Number(allowanceLine?.debit)).toBeCloseTo(2000, 2);
@@ -534,7 +540,7 @@ describe('JournalAutoService', () => {
       const lines = capturedLines();
       // zero-line filter removes it
       const badDebtLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.BAD_DEBT_EXPENSE,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.BAD_DEBT_EXPENSE,
       );
       expect(badDebtLine).toBeUndefined();
     });
@@ -678,14 +684,14 @@ describe('JournalAutoService', () => {
 
       // Late fee should appear on LATE_FEE_INCOME as a credit
       const lateFeeIncomeLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.LATE_FEE_INCOME,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.LATE_FEE_INCOME,
       );
       expect(lateFeeIncomeLine).toBeDefined();
       expect(Number(lateFeeIncomeLine!.credit)).toBeCloseTo(200, 2);
 
       // VAT_OUTPUT must be zero (or absent) — late fee is VAT-exempt
       const vatOutputLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.VAT_OUTPUT,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT,
       );
       const vatOutputCredit = vatOutputLine ? Number(vatOutputLine.credit) : 0;
       expect(vatOutputCredit).toBe(0);
@@ -714,7 +720,7 @@ describe('JournalAutoService', () => {
       const lines = capturedLines();
 
       const lateFeeIncomeLine = lines.find(
-        (l) => l.accountCode === JournalAutoService.ACC.LATE_FEE_INCOME,
+        (l) => l.accountCode === JournalAutoService.FINANCE_ACC.LATE_FEE_INCOME,
       );
       // Should be absent (zero-line filter removes it)
       expect(lateFeeIncomeLine).toBeUndefined();
@@ -785,14 +791,16 @@ describe('JournalAutoService', () => {
     });
   });
 
-  describe('createAndPost — allowedCompanies validation', () => {
-    it('throws BadRequestException when SHOP companyId uses FINANCE-only account (F-3-027 part 3/3)', async () => {
+  // Phase A.1a: allowedCompanies removed; chart partitioned by composite (companyId, code).
+  // createAndPost now rejects codes that don't exist in the target company's chart.
+  describe('createAndPost — chart partition validation (Phase A.1a)', () => {
+    it('throws BadRequestException when account code does not exist in target company chart', async () => {
       const tx = {
         companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'SHOP' }) },
         chartOfAccount: {
+          // Only 11-1101 exists in SHOP chart. 11-2102 does not (HP_RECEIVABLE is FINANCE-only).
           findMany: jest.fn().mockResolvedValue([
-            { code: '11-2102', nameTh: 'ลูกหนี้เช่าซื้อ', allowedCompanies: ['FINANCE'] },
-            { code: '11-1101', nameTh: 'เงินสด', allowedCompanies: [] },
+            { code: '11-1101', nameTh: 'เงินสด' },
           ]),
         },
         accountingPeriod: { findFirst: jest.fn().mockResolvedValue(null) },
@@ -812,17 +820,14 @@ describe('JournalAutoService', () => {
             { accountCode: '11-1101', debit: 0, credit: 100 },
           ],
         }),
-      ).rejects.toThrow(/11-2102.*ใช้ไม่ได้กับบริษัท SHOP/);
+      ).rejects.toThrow(/11-2102.*chart.*co-SHOP/);
     });
 
-    it('allows account with empty allowedCompanies for any companyId (F-3-027 part 3/3)', async () => {
+    it('queries chartOfAccount with composite (companyId, code) filter', async () => {
+      const findMany = jest.fn().mockResolvedValue([{ code: '11-1101', nameTh: 'เงินสด' }]);
       const tx = {
         companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'SHOP' }) },
-        chartOfAccount: {
-          findMany: jest.fn().mockResolvedValue([
-            { code: '11-1101', nameTh: 'เงินสด', allowedCompanies: [] },
-          ]),
-        },
+        chartOfAccount: { findMany },
         accountingPeriod: { findFirst: jest.fn().mockResolvedValue(null) },
         journalEntry: {
           count: jest.fn().mockResolvedValue(0),
@@ -844,6 +849,14 @@ describe('JournalAutoService', () => {
           ],
         }),
       ).resolves.toBe('entry1');
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            companyId: 'co-SHOP',
+            code: { in: ['11-1101'] },
+          }),
+        }),
+      );
     });
   });
 
@@ -855,7 +868,12 @@ describe('JournalAutoService', () => {
       const tx = {
         accountingPeriod: { findFirst: jest.fn().mockResolvedValue({ status: 'CLOSED' }) },
         companyInfo: { findUnique: jest.fn().mockResolvedValue({ companyCode: 'FINANCE' }) },
-        chartOfAccount: { findMany: jest.fn().mockResolvedValue([]) },
+        chartOfAccount: {
+          findMany: jest.fn().mockResolvedValue([
+            { code: '11-1101', nameTh: 'เงินสด' },
+            { code: '21-2101', nameTh: 'ภาษีขาย' },
+          ]),
+        },
         journalEntry: {
           count: jest.fn().mockResolvedValue(0),
           create: jest

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -23,24 +23,44 @@ import { PrismaService } from '../../prisma/prisma.service';
 export class JournalAutoService {
   private readonly logger = new Logger(JournalAutoService.name);
 
-  // Account codes — single source of truth
-  static readonly ACC = {
+  // Phase A.1a: Account codes partitioned by company chart.
+  // SHOP and FINANCE have separate chart-of-accounts. Each side's accounts
+  // must be looked up by composite (companyId, code).
+
+  // SHOP-side accounts (in SHOP chart)
+  static readonly SHOP_ACC = {
     CASH: '11-1101',
-    HP_RECEIVABLE: '11-2102',
-    INVENTORY_NEW: '11-3101',
-    INVENTORY_USED: '11-3102',
-    VAT_INPUT: '11-4101',
-    VAT_OUTPUT: '21-2101',
-    ALLOWANCE_DOUBTFUL: '11-2103',  // ค่าเผื่อหนี้สงสัยจะสูญ (contra asset; matches chart-of-accounts seed)
-    CUSTOMER_CREDIT: '21-5101',
     REVENUE_NEW: '41-1101',
     REVENUE_USED: '41-1102',
-    INTEREST_INCOME: '42-1101',     // รายได้ดอกเบี้ยเช่าซื้อ (HP interest revenue)
-    LATE_FEE_INCOME: '42-1102',
-    COMMISSION_INCOME: '42-1105',
+    INVENTORY_NEW: '11-3101',
+    INVENTORY_USED: '11-3102',
     COGS_NEW: '51-1101',
     COGS_USED: '51-1102',
-    BAD_DEBT_EXPENSE: '53-1101',    // หนี้สูญ
+    COMMISSION_INCOME: '42-1105',
+    DUE_FROM_FINANCE: '11-2105',
+  } as const;
+
+  // FINANCE-side accounts (in FINANCE chart)
+  static readonly FINANCE_ACC = {
+    CASH: '11-1101',
+    HP_RECEIVABLE: '11-2102',
+    ALLOWANCE_DOUBTFUL: '11-2103',
+    REPO_INVENTORY: '11-3103',
+    INVENTORY_NEW: '11-3104',
+    INVENTORY_USED: '11-3105',
+    VAT_INPUT: '11-4101',
+    REVENUE_NEW: '41-2101',
+    REVENUE_USED: '41-2102',
+    INTEREST_INCOME: '42-2101',
+    LATE_FEE_INCOME: '42-2102',
+    REPOSSESSION_INCOME: '42-2104',
+    COGS_NEW: '51-2101',
+    COGS_USED: '51-2102',
+    VAT_OUTPUT: '21-2101',
+    CUSTOMER_CREDIT: '21-5101',
+    DUE_TO_SHOP: '21-1102',
+    BAD_DEBT_EXPENSE: '53-1701',
+    COMMISSION_EXPENSE: '53-1801',
   } as const;
 
   constructor(private prisma: PrismaService) {}
@@ -105,30 +125,19 @@ export class JournalAutoService {
       throw new InternalServerErrorException(msg);
     }
 
-    // F-3-027 part 3/3: validate allowedCompanies for each line's account
+    // Phase A.1a: validate accounts exist in this company's chart
+    // (composite (companyId, code) lookup — chart is now partitioned by company)
     const codes = [...new Set(lines.map((l) => l.accountCode))];
-    const [accounts, company] = await Promise.all([
-      tx.chartOfAccount.findMany({
-        where: { code: { in: codes } },
-        select: { code: true, nameTh: true, allowedCompanies: true },
-      }),
-      tx.companyInfo.findUnique({
-        where: { id: params.companyId },
-        select: { companyCode: true },
-      }),
-    ]);
-    if (!company) {
-      throw new BadRequestException(`Company ${params.companyId} not found`);
-    }
-    if (company.companyCode) {
-      const companyCode = company.companyCode;
-      for (const acc of accounts) {
-        if (acc.allowedCompanies.length > 0 && !acc.allowedCompanies.includes(companyCode)) {
-          throw new BadRequestException(
-            `Account ${acc.code} (${acc.nameTh}) ใช้ไม่ได้กับบริษัท ${companyCode}`,
-          );
-        }
-      }
+    const accounts = await tx.chartOfAccount.findMany({
+      where: { code: { in: codes }, companyId: params.companyId, deletedAt: null },
+      select: { code: true, nameTh: true },
+    });
+    const foundCodes = new Set(accounts.map((a) => a.code));
+    const missing = codes.filter((c) => !foundCodes.has(c));
+    if (missing.length > 0) {
+      throw new BadRequestException(
+        `Account(s) ${missing.join(', ')} ไม่อยู่ใน chart ของ companyId ${params.companyId}`,
+      );
     }
 
     // F-6-002: soft-block — if entryDate in CLOSED period, redirect to current
@@ -188,14 +197,18 @@ export class JournalAutoService {
   }
 
   /**
-   * Auto journal — Payment received from customer.
+   * Auto journal — Payment received from customer (FINANCE side).
    *
    * Dr. Cash/Bank                    [amountPaid]
-   *   Cr. Hire-Purchase Receivable   [monthlyPrincipal only — NOT principal+interest]
+   *   Cr. Hire-Purchase Receivable   [principal + commission — see A.1a note]
    *   Cr. Interest Income            [monthlyInterest]
-   *   Cr. Commission Income          [monthlyCommission]
    *   Cr. VAT Output                 [vatAmount]
    *   Cr. Late Fee Income            [lateFee — if any]
+   *
+   * Phase A.1a: Commission income line REMOVED. Commission is folded into
+   * the HP receivable credit temporarily; A.1b will introduce inter-company
+   * journal entries (FINANCE commission expense + SHOP commission income).
+   * Sentry alarm fires when commission > 0 to surface deferred work.
    *
    * Interest is recognised as a separate revenue line (cash basis).
    * Late fees are NOT charged VAT (owner policy).
@@ -235,12 +248,29 @@ export class JournalAutoService {
       ? new Prisma.Decimal(0)
       : new Prisma.Decimal(params.payment.lateFee ?? 0);
 
-    // HP receivable is reduced by principal only — interest is recognised as separate revenue
-    const hpSettled = principal;
+    // Phase A.1a: HP receivable absorbs principal + commission temporarily
+    // (commission's own income line removed pending A.1b inter-company wiring).
+    // Interest, VAT, late fee remain as their own credit lines.
+    const hpSettled = principal.add(commission);
     // If breakdown is missing (legacy/manual payment), settle whole amount against receivable as fallback
     const isZeroBreakdown = principal.isZero() && interest.isZero() && commission.isZero() && vat.isZero() && lateFee.isZero();
     const fallbackHp = isZeroBreakdown ? amountPaid.sub(lateFee) : hpSettled;
 
+    // Phase A.1a: payment journal posts to FINANCE side only.
+    // Commission income line REMOVED — defer inter-company JE wiring to A.1b.
+    if (commission.gt(0)) {
+      Sentry.captureMessage('Payment commission not yet posted (deferred to A.1b)', {
+        level: 'info',
+        tags: { module: 'journal', kind: 'commission-deferred' },
+        extra: {
+          paymentId: params.payment.id,
+          contractNumber: params.contract.contractNumber,
+          amount: commission.toString(),
+        },
+      });
+    }
+
+    const FA = JournalAutoService.FINANCE_ACC;
     return this.createAndPost(tx, {
       companyId,
       entryDate: params.payment.paidDate || new Date(),
@@ -249,12 +279,12 @@ export class JournalAutoService {
       referenceId: params.payment.id,
       createdById: params.userId,
       lines: [
-        { accountCode: JournalAutoService.ACC.CASH, description: 'รับชำระเงิน', debit: amountPaid.toNumber(), credit: 0 },
-        { accountCode: JournalAutoService.ACC.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: fallbackHp.toNumber() },
-        { accountCode: JournalAutoService.ACC.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interest.toNumber() },
-        { accountCode: JournalAutoService.ACC.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: commission.toNumber() },
-        { accountCode: JournalAutoService.ACC.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
-        { accountCode: JournalAutoService.ACC.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: lateFee.toNumber() },
+        { accountCode: FA.CASH, description: 'รับชำระเงิน', debit: amountPaid.toNumber(), credit: 0 },
+        { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ (รวม commission ชั่วคราวจนกว่า A.1b)', debit: 0, credit: fallbackHp.toNumber() },
+        { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interest.toNumber() },
+        // COMMISSION_INCOME line removed (Phase A.1a) — see Sentry alarm above; A.1b will post inter-company commission.
+        { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
+        { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: lateFee.toNumber() },
       ],
     });
   }
@@ -295,6 +325,18 @@ export class JournalAutoService {
     const vat = new Prisma.Decimal(params.expense.vatAmount ?? 0);
     const total = new Prisma.Decimal(params.expense.totalAmount ?? 0);
 
+    // Phase A.1a: pick SHOP_ACC vs FINANCE_ACC based on owning company.
+    // SHOP is not VAT-registered, so VAT_INPUT only applies to FINANCE expenses.
+    const company = await tx.companyInfo.findUnique({
+      where: { id: companyId },
+      select: { companyCode: true },
+    });
+    const isShop = company?.companyCode === 'SHOP';
+    const SA = JournalAutoService.SHOP_ACC;
+    const FA = JournalAutoService.FINANCE_ACC;
+    const cashAcc = isShop ? SA.CASH : FA.CASH;
+    const vatInputAcc = FA.VAT_INPUT; // SHOP has no VAT chart entry; vat should be 0 for SHOP expenses
+
     return this.createAndPost(tx, {
       companyId,
       entryDate: params.expense.paymentDate || params.expense.expenseDate,
@@ -304,8 +346,8 @@ export class JournalAutoService {
       createdById: params.userId,
       lines: [
         { accountCode: params.expense.accountCode, description: params.expense.description, debit: amount.toNumber(), credit: 0 },
-        { accountCode: JournalAutoService.ACC.VAT_INPUT, description: 'ภาษีซื้อ', debit: vat.toNumber(), credit: 0 },
-        { accountCode: JournalAutoService.ACC.CASH, description: 'จ่ายเงิน', debit: 0, credit: total.toNumber() },
+        { accountCode: vatInputAcc, description: 'ภาษีซื้อ', debit: vat.toNumber(), credit: 0 },
+        { accountCode: cashAcc, description: 'จ่ายเงิน', debit: 0, credit: total.toNumber() },
       ],
     });
   }
@@ -358,11 +400,15 @@ export class JournalAutoService {
     // (computed by installment.util.ts:56 calculateInstallment). Adding them again would
     // double-count and unbalance the JE — see F-2-001.
     const hpReceivable = financedAmount;
+    // Phase A.1a: contract activation posts to FINANCE side using FINANCE chart codes.
+    // SHOP-side split (sales revenue + COGS on SHOP books, FINANCE pays SHOP for goods)
+    // is deferred to A.1b inter-company JE wiring.
+    const FA = JournalAutoService.FINANCE_ACC;
     const isUsed = (params.product.category || '').toLowerCase().includes('used') ||
       (params.product.category || '').includes('มือสอง');
-    const revenueAcc = isUsed ? JournalAutoService.ACC.REVENUE_USED : JournalAutoService.ACC.REVENUE_NEW;
-    const cogsAcc = isUsed ? JournalAutoService.ACC.COGS_USED : JournalAutoService.ACC.COGS_NEW;
-    const inventoryAcc = isUsed ? JournalAutoService.ACC.INVENTORY_USED : JournalAutoService.ACC.INVENTORY_NEW;
+    const revenueAcc = isUsed ? FA.REVENUE_USED : FA.REVENUE_NEW;
+    const cogsAcc = isUsed ? FA.COGS_USED : FA.COGS_NEW;
+    const inventoryAcc = isUsed ? FA.INVENTORY_USED : FA.INVENTORY_NEW;
 
     // Sales + receivable entry
     const salesEntryId = await this.createAndPost(tx, {
@@ -373,11 +419,11 @@ export class JournalAutoService {
       referenceId: params.contract.id,
       createdById: params.userId,
       lines: [
-        { accountCode: JournalAutoService.ACC.CASH, description: 'รับเงินดาวน์', debit: downPayment.toNumber(), credit: 0 },
-        { accountCode: JournalAutoService.ACC.HP_RECEIVABLE, description: 'ลูกหนี้เช่าซื้อ', debit: hpReceivable.toNumber(), credit: 0 },
+        { accountCode: FA.CASH, description: 'รับเงินดาวน์', debit: downPayment.toNumber(), credit: 0 },
+        { accountCode: FA.HP_RECEIVABLE, description: 'ลูกหนี้เช่าซื้อ', debit: hpReceivable.toNumber(), credit: 0 },
         { accountCode: revenueAcc, description: 'รายได้จากการขาย', debit: 0, credit: revenue.toNumber() },
-        { accountCode: JournalAutoService.ACC.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interest.toNumber() },
-        { accountCode: JournalAutoService.ACC.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
+        { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interest.toNumber() },
+        { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
       ],
     });
 
@@ -477,6 +523,8 @@ export class JournalAutoService {
       ? writeOff.sub(provision)
       : new Prisma.Decimal(0);
 
+    // Phase A.1a: bad debt write-off is FINANCE-side (HP receivable lives on FINANCE chart).
+    const FA = JournalAutoService.FINANCE_ACC;
     return this.createAndPost(tx, {
       companyId,
       entryDate: new Date(),
@@ -486,19 +534,19 @@ export class JournalAutoService {
       createdById: params.createdById,
       lines: [
         {
-          accountCode: JournalAutoService.ACC.BAD_DEBT_EXPENSE,
+          accountCode: FA.BAD_DEBT_EXPENSE,
           description: 'ค่าใช้จ่ายหนี้สูญ',
           debit: incrementalExpense.toNumber(),
           credit: 0,
         },
         {
-          accountCode: JournalAutoService.ACC.ALLOWANCE_DOUBTFUL,
+          accountCode: FA.ALLOWANCE_DOUBTFUL,
           description: 'ใช้ค่าเผื่อหนี้สงสัยจะสูญ',
           debit: provision.toNumber(),
           credit: 0,
         },
         {
-          accountCode: JournalAutoService.ACC.HP_RECEIVABLE,
+          accountCode: FA.HP_RECEIVABLE,
           description: 'ตัดลูกหนี้เช่าซื้อ',
           debit: 0,
           credit: writeOff.toNumber(),

--- a/apps/api/src/modules/journal/journal.service.ts
+++ b/apps/api/src/modules/journal/journal.service.ts
@@ -47,7 +47,7 @@ export class JournalService {
       }
     }
 
-    // 3. Validate companyId exists and not deleted (ดึงก่อนเพื่อเอา companyCode ไปเช็ค allowedCompanies)
+    // 3. Validate companyId exists and not deleted
     const company = await this.prisma.companyInfo.findFirst({
       where: { id: dto.companyId, deletedAt: null },
     });
@@ -61,38 +61,28 @@ export class JournalService {
     // anyone backdate a journal into a closed month.
     await validatePeriodOpen(this.prisma, new Date(dto.entryDate), dto.companyId);
 
-    // 4. Validate accountCodes exist in ChartOfAccount + allowed for this company
+    // 4. Validate accountCodes exist in this company's ChartOfAccount
+    // Phase A.1a: chart is now per-company (composite key (companyId, code)),
+    // so the lookup is scoped to dto.companyId. Any code not in this company's
+    // chart is reported back; allowedCompanies array is no longer used.
     const accountCodes = dto.lines.map((line) => line.accountCode);
     const accounts = await this.prisma.chartOfAccount.findMany({
       where: {
         code: { in: accountCodes },
+        companyId: dto.companyId,
         isActive: true,
+        deletedAt: null,
       },
-      select: { code: true, allowedCompanies: true },
+      select: { code: true },
     });
 
     const foundCodes = new Set(accounts.map((a) => a.code));
     const missingCodes = accountCodes.filter((code) => !foundCodes.has(code));
 
     if (missingCodes.length > 0) {
-      throw new BadRequestException(`รหัสบัญชีไม่ถูกต้อง: ${missingCodes.join(', ')}`);
-    }
-
-    // เช็คว่าบัญชีนี้อนุญาตให้บริษัทนี้ใช้หรือไม่
-    // allowedCompanies เป็น array ว่าง = ใช้ได้ทุกบริษัท
-    if (company.companyCode) {
-      const blocked = accounts.filter(
-        (a) =>
-          a.allowedCompanies.length > 0 &&
-          !a.allowedCompanies.includes(company.companyCode as string),
+      throw new BadRequestException(
+        `รหัสบัญชีไม่ถูกต้องหรือไม่อยู่ในผังบัญชีของบริษัทนี้: ${missingCodes.join(', ')}`,
       );
-
-      if (blocked.length > 0) {
-        const codes = blocked.map((a) => a.code).join(', ');
-        throw new BadRequestException(
-          `บัญชี ${codes} ใช้กับบริษัท ${company.companyCode} ไม่ได้`,
-        );
-      }
     }
 
     // 5. Generate entry number + create in transaction to avoid race condition

--- a/apps/web/e2e/accounting-coa-multi-entity.spec.ts
+++ b/apps/web/e2e/accounting-coa-multi-entity.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI, getAuthHeaders } from './helpers/auth';
+import { unwrapResponse } from './helpers/api-utils';
+
+/* ================================================================
+   Phase A.1a — Chart of Accounts multi-entity scoping
+   Verifies the new companyId filter on GET /chart-of-accounts:
+   - no param → returns all accounts (SHOP + FINANCE + SHARED)
+   - companyId=SHARED → returns only accounts with companyId=null
+   - companyId=<SHOP id> → returns only SHOP-owned accounts
+
+   Schema change: ChartOfAccount.allowedCompanies dropped; ownership
+   modelled via composite (companyId, code) per Wave 1 of A.1a.
+   ================================================================ */
+
+const API_URL = process.env.API_DIRECT_URL || 'http://localhost:3000';
+
+test.describe('Accounting — CoA multi-entity (Phase A.1a)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaAPI(page);
+  });
+
+  test('GET /chart-of-accounts returns all accounts when no companyId param', async ({ page }) => {
+    const res = await page.request.get(`${API_URL}/api/chart-of-accounts`, {
+      headers: getAuthHeaders(),
+    });
+    expect(res.ok()).toBeTruthy();
+    const accounts = unwrapResponse(await res.json()) as Array<{ companyId: string | null }>;
+    expect(Array.isArray(accounts)).toBeTruthy();
+    // After Wave 1 seed split, total chart should comfortably exceed 50 entries
+    // across SHOP + FINANCE + any SHARED rows.
+    expect(accounts.length).toBeGreaterThan(50);
+  });
+
+  test('GET /chart-of-accounts?companyId=SHARED returns only null-companyId accounts', async ({ page }) => {
+    const res = await page.request.get(`${API_URL}/api/chart-of-accounts?companyId=SHARED`, {
+      headers: getAuthHeaders(),
+    });
+    expect(res.ok()).toBeTruthy();
+    const accounts = unwrapResponse(await res.json()) as Array<{ companyId: string | null }>;
+    expect(Array.isArray(accounts)).toBeTruthy();
+    // Every returned row must have companyId === null
+    expect(accounts.every((a) => a.companyId === null)).toBeTruthy();
+  });
+
+  test('GET /chart-of-accounts?companyId=<SHOP_id> returns SHOP accounts only', async ({ page }) => {
+    const cosRes = await page.request.get(`${API_URL}/api/companies`, {
+      headers: getAuthHeaders(),
+    });
+    if (!cosRes.ok()) {
+      test.skip(true, 'companies endpoint not available');
+      return;
+    }
+    const companies = unwrapResponse(await cosRes.json()) as Array<{
+      id: string;
+      companyCode?: string;
+    }>;
+    const shop = companies.find((c) => c.companyCode === 'SHOP');
+    if (!shop) {
+      test.skip(true, 'SHOP company not configured');
+      return;
+    }
+
+    const res = await page.request.get(
+      `${API_URL}/api/chart-of-accounts?companyId=${shop.id}`,
+      { headers: getAuthHeaders() },
+    );
+    expect(res.ok()).toBeTruthy();
+    const accounts = unwrapResponse(await res.json()) as Array<{
+      companyId: string | null;
+    }>;
+    expect(Array.isArray(accounts)).toBeTruthy();
+    expect(accounts.length).toBeGreaterThan(0);
+    expect(accounts.every((a) => a.companyId === shop.id)).toBeTruthy();
+  });
+});

--- a/apps/web/src/pages/ChartOfAccountsPage.tsx
+++ b/apps/web/src/pages/ChartOfAccountsPage.tsx
@@ -10,7 +10,11 @@ import { getStatusBadgeProps, accountGroupMap } from '@/lib/status-badges';
 
 type AccountGroup = 'ASSET' | 'LIABILITY' | 'EQUITY' | 'REVENUE' | 'EXPENSE';
 
-type CompanyCode = 'SHOP' | 'FINANCE';
+interface Company {
+  id: string;
+  companyCode: string;
+  nameTh?: string;
+}
 
 interface ChartOfAccount {
   id: string;
@@ -21,7 +25,7 @@ interface ChartOfAccount {
   parentCode?: string | null;
   level: number;
   isActive: boolean;
-  allowedCompanies: CompanyCode[];
+  companyId: string | null;
   peakAccountCode?: string | null;
   peakAccountId?: string | null;
 }
@@ -43,7 +47,7 @@ interface FormState {
   parentCode: string;
   level: number;
   isActive: boolean;
-  allowedCompanies: CompanyCode[];
+  companyId: string; // empty string = shared
   peakAccountCode: string;
   peakAccountId: string;
 }
@@ -56,7 +60,7 @@ const emptyForm: FormState = {
   parentCode: '',
   level: 3,
   isActive: true,
-  allowedCompanies: [],
+  companyId: '',
   peakAccountCode: '',
   peakAccountId: '',
 };
@@ -64,16 +68,28 @@ const emptyForm: FormState = {
 export default function ChartOfAccountsPage() {
   const queryClient = useQueryClient();
   const [groupFilter, setGroupFilter] = useState<AccountGroup | 'ALL'>('ALL');
+  const [companyFilter, setCompanyFilter] = useState<string>('ALL');
   const [search, setSearch] = useState('');
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<ChartOfAccount | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [deleteConfirm, setDeleteConfirm] = useState<{ open: boolean; id: string; label: string }>({ open: false, id: '', label: '' });
 
-  const { data: accounts = [], isLoading, isError, error, refetch } = useQuery<ChartOfAccount[]>({
-    queryKey: ['chart-of-accounts'],
+  const { data: companies = [] } = useQuery<Company[]>({
+    queryKey: ['companies-coa'],
     queryFn: async () => {
-      const { data } = await api.get('/chart-of-accounts');
+      const { data } = await api.get('/companies');
+      return data;
+    },
+  });
+
+  const { data: accounts = [], isLoading, isError, error, refetch } = useQuery<ChartOfAccount[]>({
+    queryKey: ['chart-of-accounts', companyFilter],
+    queryFn: async () => {
+      const params: Record<string, string> = {};
+      if (companyFilter === 'SHARED') params.companyId = 'SHARED';
+      else if (companyFilter !== 'ALL') params.companyId = companyFilter;
+      const { data } = await api.get('/chart-of-accounts', { params });
       return data;
     },
   });
@@ -108,6 +124,7 @@ export default function ChartOfAccountsPage() {
         ...form,
         nameEn: form.nameEn || undefined,
         parentCode: form.parentCode || undefined,
+        companyId: form.companyId || undefined,
         peakAccountCode: form.peakAccountCode || undefined,
         peakAccountId: form.peakAccountId || undefined,
       };
@@ -132,7 +149,7 @@ export default function ChartOfAccountsPage() {
         parentCode: form.parentCode || undefined,
         level: form.level,
         isActive: form.isActive,
-        allowedCompanies: form.allowedCompanies,
+        companyId: form.companyId || null,
         peakAccountCode: form.peakAccountCode || undefined,
         peakAccountId: form.peakAccountId || undefined,
       };
@@ -160,7 +177,10 @@ export default function ChartOfAccountsPage() {
 
   function openCreate() {
     setEditing(null);
-    setForm(emptyForm);
+    // Pre-fill companyId from current filter (UX nicety)
+    const initialCompanyId =
+      companyFilter !== 'ALL' && companyFilter !== 'SHARED' ? companyFilter : '';
+    setForm({ ...emptyForm, companyId: initialCompanyId });
     setShowForm(true);
   }
 
@@ -174,7 +194,7 @@ export default function ChartOfAccountsPage() {
       parentCode: a.parentCode || '',
       level: a.level,
       isActive: a.isActive,
-      allowedCompanies: a.allowedCompanies || [],
+      companyId: a.companyId || '',
       peakAccountCode: a.peakAccountCode || '',
       peakAccountId: a.peakAccountId || '',
     });
@@ -222,6 +242,21 @@ export default function ChartOfAccountsPage() {
           onChange={(e) => setSearch(e.target.value)}
           className={`${inputClass} max-w-xs`}
         />
+        <select
+          value={companyFilter}
+          onChange={(e) => setCompanyFilter(e.target.value)}
+          className={`${inputClass} max-w-[14rem]`}
+          aria-label="กรองตามบริษัท"
+        >
+          <option value="ALL">ทุกบริษัท (รวม shared)</option>
+          <option value="SHARED">Shared (ไม่ระบุบริษัท)</option>
+          {companies.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.companyCode}
+              {c.nameTh ? ` — ${c.nameTh}` : ''}
+            </option>
+          ))}
+        </select>
         <div className="flex gap-2 flex-wrap">
           <FilterChip active={groupFilter === 'ALL'} onClick={() => setGroupFilter('ALL')}>ทั้งหมด</FilterChip>
           {(Object.keys(GROUP_LABELS) as AccountGroup[]).map((g) => (
@@ -396,28 +431,24 @@ export default function ChartOfAccountsPage() {
                 ใช้งาน
               </label>
 
-              {/* ── การใช้งานข้ามบริษัท (Multi-Entity) ── */}
+              {/* ── บริษัทเจ้าของบัญชี (Multi-Entity) ── */}
               <div className="border-t pt-4 mt-2">
-                <label className="block text-xs font-medium mb-2">อนุญาตให้บริษัทใช้งาน</label>
-                <div className="flex gap-4">
-                  {(['SHOP', 'FINANCE'] as CompanyCode[]).map((c) => (
-                    <label key={c} className="flex items-center gap-2 text-sm">
-                      <input
-                        type="checkbox"
-                        checked={form.allowedCompanies.includes(c)}
-                        onChange={(e) => {
-                          const next = e.target.checked
-                            ? [...form.allowedCompanies, c]
-                            : form.allowedCompanies.filter((x) => x !== c);
-                          setForm({ ...form, allowedCompanies: next });
-                        }}
-                      />
-                      {c === 'SHOP' ? 'BESTCHOICE SHOP' : 'BESTCHOICE FINANCE'}
-                    </label>
+                <label className="block text-xs font-medium mb-1.5">บริษัทเจ้าของบัญชี</label>
+                <select
+                  value={form.companyId}
+                  onChange={(e) => setForm({ ...form, companyId: e.target.value })}
+                  className={inputClass}
+                >
+                  <option value="">Shared (ใช้ได้ทุกบริษัท)</option>
+                  {companies.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.companyCode}
+                      {c.nameTh ? ` — ${c.nameTh}` : ''}
+                    </option>
                   ))}
-                </div>
+                </select>
                 <p className="text-xs text-muted-foreground mt-1.5">
-                  ไม่เลือกเลย = ใช้ได้ทุกบริษัท
+                  เว้นว่าง (Shared) = ใช้ได้กับทุกบริษัท
                 </p>
               </div>
 

--- a/docs/references/finance-chart-of-accounts.csv
+++ b/docs/references/finance-chart-of-accounts.csv
@@ -1,0 +1,51 @@
+หมวดที่ 1: สินทรัพย์ (Assets),,,
+เลขบัญชี,ชื่อบัญชี,เลขที่บัญชีในเบสท์ช้อยส์,หมายเหตุ
+11-1101,เงินสด FINANCE,,Cash on Hand FINANCE
+11-1201,ธนาคาร FINANCE — บัญชีหลัก,,Bank — FINANCE Main
+11-1202,ธนาคาร FINANCE — รับชำระค่างวด,,Bank — Installment Collection
+11-2102,ลูกหนี้เช่าซื้อ,,Hire-Purchase Receivable
+11-2103,หัก: ค่าเผื่อหนี้สงสัยจะสูญ,,Less: Allowance for Doubtful Accounts
+11-2104,ลูกหนี้ไฟแนนซ์ภายนอก,,External Finance Receivable
+11-3103,สินค้ายึดคืน/ซ่อมแล้ว,,Repossessed/Refurbished Goods
+11-3104,สินค้าคงเหลือ FINANCE — เครื่องใหม่,,Inventory FINANCE New
+11-3105,สินค้าคงเหลือ FINANCE — มือสอง,,Inventory FINANCE Used
+11-4101,ภาษีซื้อ,,Input VAT
+11-4102,ภาษีซื้อยังไม่ถึงกำหนด,,Input VAT Pending
+11-4103,ภาษีถูกหัก ณ ที่จ่าย,,Withholding Tax Receivable
+หมวดที่ 2: หนี้สิน (Liabilities),,,
+เลขบัญชี,ชื่อบัญชี,เลขที่บัญชีในเบสท์ช้อยส์,หมายเหตุ
+21-1102,เจ้าหนี้คู่ค้า — SHOP (Due-to-SHOP),,Inter-company Payable — SHOP
+21-2101,ภาษีขาย ภ.พ.30,,Output VAT (PP.30)
+21-2102,ภาษีขายรอเรียกเก็บ,,Output VAT Pending Invoice
+21-2103,ภ.พ.36 ค้างจ่าย,,PP.36 Payable (foreign VAT)
+21-2104,ภาษีขายดอกเบี้ยรอตัดบัญชี,,DEFERRED CR-001 — VAT on interest
+21-2202,รายได้ดอกเบี้ยรอตัดบัญชี,,DEFERRED W-003 — Unearned Interest
+21-3201,เจ้าหนี้สรรพากร ภ.พ.30 รอชำระ,,VAT Payable to RD
+21-3202,เจ้าหนี้สรรพากร ภ.ง.ด.53 รอชำระ,,PND.53 Payable to RD
+21-4201,เงินรับล่วงหน้า,,Advance Receipts
+21-5101,เงินเกินของลูกค้า,,Customer Credit Balance
+หมวดที่ 3: ส่วนของผู้ถือหุ้น (Equity),,,
+เลขบัญชี,ชื่อบัญชี,เลขที่บัญชีในเบสท์ช้อยส์,หมายเหตุ
+31-1101,ทุนสามัญ FINANCE,,Common Stock FINANCE
+32-1101,กำไร(ขาดทุน)สะสม FINANCE,,Retained Earnings FINANCE
+หมวดที่ 4: รายได้ (Revenues),,,
+เลขบัญชี,ชื่อบัญชี,เลขที่บัญชีในเบสท์ช้อยส์,หมายเหตุ
+41-2101,รายได้ขายเช่าซื้อ FINANCE,,HP Sales Revenue FINANCE
+41-2102,รายได้ขายเช่าซื้อมือสอง FINANCE,,HP Used Sales Revenue FINANCE
+42-2101,รายได้ดอกเบี้ยเช่าซื้อ,,Hire-Purchase Interest Income
+42-2102,ค่างวดเบี้ยปรับล่าช้า,,Late Payment Penalty Income
+42-2103,ค่ามัดจำ/เงินประกันที่ริบ,,Forfeited Deposits
+42-2104,รายได้จากการยึดเครื่อง,,Repossession Income
+42-2105,รายได้ค่าคอมมิชชันจาก SHOP,,A.1b inter-company commission
+หมวดที่ 5: ค่าใช้จ่าย (Expenses),,,
+เลขบัญชี,ชื่อบัญชี,เลขที่บัญชีในเบสท์ช้อยส์,หมายเหตุ
+51-2101,ต้นทุนขายเช่าซื้อ FINANCE — เครื่องใหม่,,COGS FINANCE New
+51-2102,ต้นทุนขายเช่าซื้อ FINANCE — มือสอง,,COGS FINANCE Used
+53-1701,หนี้สูญ,,Bad Debt Expense (was 53-1101 = Salary in owner CoA!)
+53-1702,หนี้สงสัยจะสูญ,,Doubtful Debt Expense
+53-1801,ค่านายหน้าจ่าย SHOP,,A.1b inter-company commission expense
+53-1802,ค่าธรรมเนียม PaySolutions,,PaySolutions Fees
+53-1803,ค่าธรรมเนียมโอนเงิน,,Bank Transfer Fees
+53-1601,ค่าเสื่อมราคา — อุปกรณ์ FINANCE,,Depreciation — FINANCE Equipment
+54-1101,ภงด. ทางภาษี ภ.ง.ด.3,,Tax Expense — PND.3
+54-1102,ภงด. ทางภาษี ภ.ง.ด.53,,Tax Expense — PND.53

--- a/docs/superpowers/plans/2026-04-29-accounting-phase-a1a-coa-split.md
+++ b/docs/superpowers/plans/2026-04-29-accounting-phase-a1a-coa-split.md
@@ -1,0 +1,1325 @@
+# Accounting Phase A.1a — CoA Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split BESTCHOICE chart of accounts into 2 entity-scoped charts (SHOP=109 owner accounts + FINANCE=44 new accounts) via schema partition (`companyId` + composite unique). Remap ACC constants in JournalAutoService to fix audit findings F-2-002 (Bad Debt → Salary), F-3-012 (Interest → Rounding Excess), F-3-013 (Late Fee → Bank Interest). Defer inter-company JE wiring to A.1b.
+
+**Architecture:** Schema migration + seed replacement + companyId-scoped lookups. NO inter-company JE structural changes (deferred). Commission income line temporarily removed from payment JE with Sentry alarm. Pattern: TDD per task, single PR with squash merge, deploy via existing GCP workflow (Migrations runs before API deploy = atomic).
+
+**Tech Stack:** Prisma (migration + multi-entity schema), NestJS (services + DTOs + controller), React + Tailwind + shadcn (frontend), Jest (unit tests), Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-04-29-accounting-phase-a1a-coa-split-design.md`
+**Phase A.0 commit (predecessor):** `23eb4473`
+**Branch:** `feat/accounting-phase-a1a-coa-split` (already created from origin/main + cherry-picked spec)
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Verify branch + clean tree**
+
+Run: `git branch --show-current && git status --short`
+Expected: branch `feat/accounting-phase-a1a-coa-split`, working tree clean (or only mockups/ untracked)
+
+- [ ] **Step 2: Verify spec exists**
+
+Run: `ls docs/superpowers/specs/2026-04-29-accounting-phase-a1a-coa-split-design.md`
+Expected: file exists (cherry-picked as `f9866426`)
+
+- [ ] **Step 3: Backup verification (already done by user before deploy)**
+
+Note: Phase A.0 deploy already created a backup. Schema changes in A.1a are additive in deploy (existing rows updated, no destructive drops in production order).
+
+---
+
+## Wave 1 — Schema + Seed (single atomic commit)
+
+### Task 1: Update Prisma schema for ChartOfAccount
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma` (ChartOfAccount model + add CompanyInfo inverse relation)
+
+- [ ] **Step 1: Read current ChartOfAccount model**
+
+Run: `grep -B 1 -A 28 "^model ChartOfAccount" apps/api/prisma/schema.prisma`
+
+- [ ] **Step 2: Apply schema diff**
+
+Edit `apps/api/prisma/schema.prisma` ChartOfAccount model:
+
+```diff
+ model ChartOfAccount {
+   id           String       @id @default(uuid())
+-  code         String       @unique // e.g. "1100", "4100"
++  code         String       // e.g. "1100", "4100" — unique per company via composite
+   nameTh       String       @map("name_th")
+   nameEn       String?      @map("name_en")
+   accountGroup AccountGroup @map("account_group")
+   parentCode   String?      @map("parent_code")
+   level        Int          @default(1)
+   isActive     Boolean      @default(true) @map("is_active")
+
+-  // ── การใช้งานข้ามบริษัท (multi-entity) ──
+-  allowedCompanies String[] @default([]) @map("allowed_companies")
++  // ── Multi-entity partition (Phase A.1a) ──
++  companyId    String?      @map("company_id") // null = shared (cash, etc.); else SHOP or FINANCE
++  company      CompanyInfo? @relation("CompanyChartOfAccounts", fields: [companyId], references: [id], onDelete: SetNull)
+
+   // ── การ sync กับ PEAK ──
+   peakAccountCode String? @map("peak_account_code")
+   peakAccountId   String? @map("peak_account_id")
+
+   createdAt DateTime  @default(now()) @map("created_at")
+   updatedAt DateTime  @updatedAt @map("updated_at")
+   deletedAt DateTime? @map("deleted_at")
+
++  @@unique([companyId, code])
+   @@index([accountGroup])
+   @@index([code])
++  @@index([companyId])
+   @@map("chart_of_accounts")
+ }
+```
+
+- [ ] **Step 3: Add inverse relation in CompanyInfo model**
+
+Find the CompanyInfo model in `schema.prisma` and add the inverse relation:
+
+```diff
+ model CompanyInfo {
+   // ... existing fields ...
+
++  chartOfAccounts ChartOfAccount[] @relation("CompanyChartOfAccounts")
+
+   // ... existing relations ...
+ }
+```
+
+- [ ] **Step 4: TypeScript + schema validation**
+
+Run: `cd apps/api && npx prisma validate`
+Expected: `The schema is valid 🚀`
+
+(Don't run `prisma generate` yet — wait for migration creation in Task 2.)
+
+---
+
+### Task 2: Create migration with backfill SQL
+
+**Files:**
+- Create: `apps/api/prisma/migrations/{timestamp}_chart_of_accounts_company_partition/migration.sql`
+
+- [ ] **Step 1: Generate migration name + folder**
+
+Use sequential timestamp matching existing pattern (e.g., `20260615000000`):
+
+```bash
+cd apps/api
+mkdir -p prisma/migrations/20260615000000_chart_of_accounts_company_partition
+```
+
+- [ ] **Step 2: Write migration SQL by hand (Prisma migrate dev cannot apply due to drift — same as Phase A.0 Task 16)**
+
+Create `apps/api/prisma/migrations/20260615000000_chart_of_accounts_company_partition/migration.sql`:
+
+```sql
+-- Phase A.1a: ChartOfAccount multi-entity partition
+-- Step 1: Add company_id column (nullable initially)
+ALTER TABLE "chart_of_accounts" ADD COLUMN "company_id" TEXT;
+
+-- Step 2: Add FK to company_info
+ALTER TABLE "chart_of_accounts" ADD CONSTRAINT "chart_of_accounts_company_id_fkey"
+  FOREIGN KEY ("company_id") REFERENCES "company_info"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Step 3: Backfill — assign company_id based on existing allowed_companies array
+UPDATE "chart_of_accounts" SET "company_id" = (
+  SELECT id FROM "company_info" WHERE "company_code" = 'SHOP' LIMIT 1
+) WHERE 'SHOP' = ANY("allowed_companies") AND "company_id" IS NULL;
+
+UPDATE "chart_of_accounts" SET "company_id" = (
+  SELECT id FROM "company_info" WHERE "company_code" = 'FINANCE' LIMIT 1
+) WHERE 'FINANCE' = ANY("allowed_companies") AND "company_id" IS NULL;
+
+-- Note: accounts with empty allowed_companies remain company_id = NULL (shared)
+
+-- Step 4: Drop old unique constraint on code
+ALTER TABLE "chart_of_accounts" DROP CONSTRAINT IF EXISTS "chart_of_accounts_code_key";
+
+-- Step 5: Add composite unique on (company_id, code)
+CREATE UNIQUE INDEX "chart_of_accounts_company_id_code_key" ON "chart_of_accounts" ("company_id", "code");
+
+-- Step 6: Add index on company_id for filter queries
+CREATE INDEX "chart_of_accounts_company_id_idx" ON "chart_of_accounts" ("company_id");
+
+-- Step 7: Drop allowed_companies column
+ALTER TABLE "chart_of_accounts" DROP COLUMN "allowed_companies";
+```
+
+- [ ] **Step 3: Regenerate Prisma client**
+
+Run: `cd apps/api && npx prisma generate`
+Expected: `✔ Generated Prisma Client` — new ChartOfAccount type has `companyId` field, no `allowedCompanies`.
+
+- [ ] **Step 4: TypeScript check (will reveal callers using old fields)**
+
+Run: `cd apps/api && npx tsc --noEmit 2>&1 | head -40`
+Expected: errors in:
+- `chart-of-accounts.service.ts` (uses `allowedCompanies`)
+- `chart-of-accounts.dto.ts` (declares `allowedCompanies`)
+- `chart-of-accounts.service.spec.ts` (tests `allowedCompanies`)
+- `journal-auto.service.ts` (lookup uses `allowedCompanies`)
+- `journal.service.ts` (lookup uses `allowedCompanies`)
+- Any seeds that use `allowedCompanies`
+
+**These errors are expected — Tasks 3-8 will fix them.** Do NOT try to fix yet.
+
+---
+
+### Task 3: Replace seed file with 109 SHOP + 44 FINANCE
+
+**Files:**
+- Replace: `apps/api/prisma/seeds/chart-of-accounts.ts`
+- Create: `apps/api/prisma/seeds/chart-of-accounts-finance.ts`
+
+- [ ] **Step 1: Parse owner CoA CSV** (gather data)
+
+Run: `cat docs/references/owner-chart-of-accounts.csv | head -10`
+Expected: see structure (code, nameTh, notes columns).
+
+- [ ] **Step 2: Replace `chart-of-accounts.ts` seed**
+
+Replace entire file content:
+
+```typescript
+import { PrismaClient, AccountGroup } from '@prisma/client';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { seedFinanceChartOfAccounts } from './chart-of-accounts-finance';
+
+interface ChartOfAccountSeed {
+  code: string;
+  nameTh: string;
+  nameEn?: string;
+  accountGroup: AccountGroup;
+  parentCode?: string;
+  level: number;
+}
+
+/**
+ * Phase A.1a: SHOP chart of accounts (109 accounts from owner CSV).
+ * Owner-supplied. See docs/references/owner-chart-of-accounts.csv.
+ */
+function parseOwnerCsv(): ChartOfAccountSeed[] {
+  const csvPath = path.resolve(__dirname, '../../../../docs/references/owner-chart-of-accounts.csv');
+  const raw = fs.readFileSync(csvPath, 'utf-8');
+  const lines = raw.split('\n').filter((l) => l.trim());
+
+  const accounts: ChartOfAccountSeed[] = [];
+  let currentGroup: AccountGroup | null = null;
+
+  for (const line of lines) {
+    const cols = line.split(',').map((c) => c.replace(/^"|"$/g, '').trim());
+    const first = cols[0] || '';
+
+    // Section header (e.g., "หมวดที่ 1: สินทรัพย์ (Assets)")
+    if (first.startsWith('หมวดที่ 1')) { currentGroup = AccountGroup.ASSET; continue; }
+    if (first.startsWith('หมวดที่ 2')) { currentGroup = AccountGroup.LIABILITY; continue; }
+    if (first.startsWith('หมวดที่ 3')) { currentGroup = AccountGroup.EQUITY; continue; }
+    if (first.startsWith('หมวดที่ 4')) { currentGroup = AccountGroup.REVENUE; continue; }
+    if (first.startsWith('หมวดที่ 5')) { currentGroup = AccountGroup.EXPENSE; continue; }
+    if (first === 'เลขบัญชี') continue; // header row
+
+    if (!currentGroup) continue;
+
+    // Account code pattern: XX-XXXX or XX-XXXX
+    if (!/^\d{2}-\d{4,5}$/.test(first)) continue;
+
+    const code = first;
+    const nameTh = cols[1] || '';
+    if (!nameTh) continue;
+
+    // Determine level from code suffix
+    let level = 3;
+    if (code.endsWith('-0000') || code.endsWith('-1000') || code.endsWith('-2000')) level = 1;
+    else if (code.endsWith('XX')) level = 2;
+
+    accounts.push({ code, nameTh, accountGroup: currentGroup, level });
+  }
+
+  return accounts;
+}
+
+export async function seedChartOfAccounts(prisma: PrismaClient): Promise<void> {
+  console.log('Seeding Chart of Accounts (Phase A.1a — SHOP + FINANCE split)...');
+
+  // Resolve company ids
+  const shopCompany = await prisma.companyInfo.findFirst({
+    where: { companyCode: 'SHOP', deletedAt: null },
+    select: { id: true },
+  });
+  const financeCompany = await prisma.companyInfo.findFirst({
+    where: { companyCode: 'FINANCE', deletedAt: null },
+    select: { id: true },
+  });
+
+  if (!shopCompany || !financeCompany) {
+    throw new Error('SHOP and FINANCE companies must exist before seeding chart of accounts');
+  }
+
+  // Seed SHOP chart from owner CSV
+  const shopAccounts = parseOwnerCsv();
+  console.log(`  → Seeding ${shopAccounts.length} SHOP accounts from owner CSV...`);
+  for (const acc of shopAccounts) {
+    await prisma.chartOfAccount.upsert({
+      where: { companyId_code: { companyId: shopCompany.id, code: acc.code } },
+      update: {
+        nameTh: acc.nameTh,
+        nameEn: acc.nameEn,
+        accountGroup: acc.accountGroup,
+        level: acc.level,
+        isActive: true,
+        peakAccountCode: acc.code,
+      },
+      create: {
+        code: acc.code,
+        companyId: shopCompany.id,
+        nameTh: acc.nameTh,
+        nameEn: acc.nameEn,
+        accountGroup: acc.accountGroup,
+        parentCode: acc.parentCode,
+        level: acc.level,
+        isActive: true,
+        peakAccountCode: acc.code,
+      },
+    });
+  }
+
+  // Seed FINANCE chart from finance seed file
+  await seedFinanceChartOfAccounts(prisma, financeCompany.id);
+
+  // Add SHOP-side clearing account (Due-from-FINANCE) for inter-company (used in A.1b)
+  await prisma.chartOfAccount.upsert({
+    where: { companyId_code: { companyId: shopCompany.id, code: '11-2105' } },
+    update: { nameTh: 'ลูกหนี้คู่ค้า — FINANCE (Due-from-FINANCE)' },
+    create: {
+      code: '11-2105',
+      companyId: shopCompany.id,
+      nameTh: 'ลูกหนี้คู่ค้า — FINANCE (Due-from-FINANCE)',
+      nameEn: 'Inter-company Receivable — FINANCE',
+      accountGroup: AccountGroup.ASSET,
+      parentCode: '11-21XX',
+      level: 3,
+      isActive: true,
+      peakAccountCode: '11-2105',
+    },
+  });
+
+  console.log(`  ✓ Chart of Accounts: ${shopAccounts.length + 1} SHOP + 44 FINANCE seeded`);
+}
+```
+
+- [ ] **Step 3: Create FINANCE seed file**
+
+Create `apps/api/prisma/seeds/chart-of-accounts-finance.ts`:
+
+```typescript
+import { PrismaClient, AccountGroup } from '@prisma/client';
+
+interface FinanceAccount {
+  code: string;
+  nameTh: string;
+  nameEn: string;
+  accountGroup: AccountGroup;
+  parentCode?: string;
+  level: number;
+}
+
+/**
+ * Phase A.1a: FINANCE chart of accounts (44 accounts).
+ * 38 standard + 2 deferred (W-003 unearnedInterest, CR-001 VAT-on-interest)
+ * + 4 inter-company clearing accounts (1 here as Due-to-SHOP; 3 others added separately).
+ */
+const FINANCE_ACCOUNTS: FinanceAccount[] = [
+  // ─── 11-XXXX สินทรัพย์หมุนเวียน (10) ───
+  { code: '11-1101', nameTh: 'เงินสด FINANCE', nameEn: 'Cash on Hand FINANCE', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-1201', nameTh: 'ธนาคาร FINANCE — บัญชีหลัก', nameEn: 'Bank — FINANCE Main', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-1202', nameTh: 'ธนาคาร FINANCE — รับชำระค่างวด', nameEn: 'Bank — Installment Collection', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-2102', nameTh: 'ลูกหนี้เช่าซื้อ', nameEn: 'Hire-Purchase Receivable', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-2103', nameTh: 'หัก: ค่าเผื่อหนี้สงสัยจะสูญ', nameEn: 'Less: Allowance for Doubtful Accounts', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-2104', nameTh: 'ลูกหนี้ไฟแนนซ์ภายนอก', nameEn: 'External Finance Receivable', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-3103', nameTh: 'สินค้ายึดคืน/ซ่อมแล้ว', nameEn: 'Repossessed/Refurbished Goods', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-4101', nameTh: 'ภาษีซื้อ', nameEn: 'Input VAT', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-4102', nameTh: 'ภาษีซื้อยังไม่ถึงกำหนด', nameEn: 'Input VAT Pending', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-4103', nameTh: 'ภาษีถูกหัก ณ ที่จ่าย', nameEn: 'Withholding Tax Receivable', accountGroup: AccountGroup.ASSET, level: 3 },
+
+  // ─── 21-XXXX หนี้สินหมุนเวียน (10) ───
+  { code: '21-1102', nameTh: 'เจ้าหนี้คู่ค้า — SHOP (Due-to-SHOP)', nameEn: 'Inter-company Payable — SHOP', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2101', nameTh: 'ภาษีขาย ภ.พ.30', nameEn: 'Output VAT (PP.30)', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2102', nameTh: 'ภาษีขายรอเรียกเก็บ', nameEn: 'Output VAT Pending Invoice', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2103', nameTh: 'ภ.พ.36 ค้างจ่าย', nameEn: 'PP.36 Payable', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2104', nameTh: 'ภาษีขายดอกเบี้ยรอตัดบัญชี [DEFERRED CR-001]', nameEn: 'Deferred VAT on Interest', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-2202', nameTh: 'รายได้ดอกเบี้ยรอตัดบัญชี [DEFERRED W-003]', nameEn: 'Unearned Interest Income', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-3201', nameTh: 'เจ้าหนี้สรรพากร ภ.พ.30 รอชำระ', nameEn: 'VAT Payable to RD', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-3202', nameTh: 'เจ้าหนี้สรรพากร ภ.ง.ด.53 รอชำระ', nameEn: 'PND.53 Payable to RD', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-4201', nameTh: 'เงินรับล่วงหน้า', nameEn: 'Advance Receipts', accountGroup: AccountGroup.LIABILITY, level: 3 },
+  { code: '21-5101', nameTh: 'เงินเกินของลูกค้า', nameEn: 'Customer Credit Balance', accountGroup: AccountGroup.LIABILITY, level: 3 },
+
+  // ─── 31/32-XXXX ส่วนของผู้ถือหุ้น (2) ───
+  { code: '31-1101', nameTh: 'ทุนสามัญ FINANCE', nameEn: 'Common Stock FINANCE', accountGroup: AccountGroup.EQUITY, level: 3 },
+  { code: '32-1101', nameTh: 'กำไร(ขาดทุน)สะสม FINANCE', nameEn: 'Retained Earnings FINANCE', accountGroup: AccountGroup.EQUITY, level: 3 },
+
+  // ─── 42-XXXX รายได้อื่น (5) ───
+  { code: '42-2101', nameTh: 'รายได้ดอกเบี้ยเช่าซื้อ', nameEn: 'Hire-Purchase Interest Income', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2102', nameTh: 'ค่างวดเบี้ยปรับล่าช้า', nameEn: 'Late Payment Penalty Income', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2103', nameTh: 'ค่ามัดจำ/เงินประกันที่ริบ', nameEn: 'Forfeited Deposits', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2104', nameTh: 'รายได้จากการยึดเครื่อง', nameEn: 'Repossession Income', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '42-2105', nameTh: 'รายได้ค่าคอมมิชชันจาก SHOP [A.1b]', nameEn: 'Commission Income from SHOP', accountGroup: AccountGroup.REVENUE, level: 3 },
+
+  // ─── 53-XXXX ค่าใช้จ่าย (6) ───
+  { code: '53-1701', nameTh: 'หนี้สูญ', nameEn: 'Bad Debt Expense', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1702', nameTh: 'หนี้สงสัยจะสูญ', nameEn: 'Doubtful Debt Expense', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1801', nameTh: 'ค่านายหน้าจ่าย SHOP [A.1b]', nameEn: 'Commission Expense to SHOP', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1802', nameTh: 'ค่าธรรมเนียม PaySolutions', nameEn: 'PaySolutions Fees', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1803', nameTh: 'ค่าธรรมเนียมโอนเงิน', nameEn: 'Bank Transfer Fees', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1601', nameTh: 'ค่าเสื่อมราคา — อุปกรณ์ FINANCE', nameEn: 'Depreciation — FINANCE Equipment', accountGroup: AccountGroup.EXPENSE, level: 3 },
+
+  // ─── 54-XXXX รายจ่ายต้องห้ามทางภาษี (2) ───
+  { code: '54-1101', nameTh: 'ภงด. ทางภาษี ภ.ง.ด.3', nameEn: 'Tax Expense — PND.3', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '54-1102', nameTh: 'ภงด. ทางภาษี ภ.ง.ด.53', nameEn: 'Tax Expense — PND.53', accountGroup: AccountGroup.EXPENSE, level: 3 },
+];
+
+export async function seedFinanceChartOfAccounts(prisma: PrismaClient, financeCompanyId: string): Promise<void> {
+  console.log(`  → Seeding ${FINANCE_ACCOUNTS.length} FINANCE accounts...`);
+  for (const acc of FINANCE_ACCOUNTS) {
+    await prisma.chartOfAccount.upsert({
+      where: { companyId_code: { companyId: financeCompanyId, code: acc.code } },
+      update: {
+        nameTh: acc.nameTh,
+        nameEn: acc.nameEn,
+        accountGroup: acc.accountGroup,
+        level: acc.level,
+        isActive: true,
+        peakAccountCode: acc.code,
+      },
+      create: {
+        code: acc.code,
+        companyId: financeCompanyId,
+        nameTh: acc.nameTh,
+        nameEn: acc.nameEn,
+        accountGroup: acc.accountGroup,
+        parentCode: acc.parentCode,
+        level: acc.level,
+        isActive: true,
+        peakAccountCode: acc.code,
+      },
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles for seed**
+
+Run: `cd apps/api && npx tsc --noEmit prisma/seeds/chart-of-accounts.ts prisma/seeds/chart-of-accounts-finance.ts 2>&1 | head -10`
+Expected: 0 errors (depends on Prisma client regenerated in Task 2)
+
+- [ ] **Step 5: Commit Wave 1 atomically**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/20260615000000_chart_of_accounts_company_partition/ apps/api/prisma/seeds/chart-of-accounts.ts apps/api/prisma/seeds/chart-of-accounts-finance.ts
+git commit -m "feat(accounting): split CoA into SHOP + FINANCE charts (Phase A.1a Wave 1)
+
+Schema: ChartOfAccount adds companyId + composite unique (companyId, code).
+Migration: backfill existing 76 rows by allowedCompanies → SHOP/FINANCE/null,
+then drop allowedCompanies column.
+
+Seed replaced:
+- SHOP chart: 109 accounts parsed from docs/references/owner-chart-of-accounts.csv
+- FINANCE chart: 44 accounts (38 standard + 2 deferred + 4 clearing)
+- 1 SHOP-side clearing account (11-2105 Due-from-FINANCE)
+
+Note: backend code paths still reference allowedCompanies — Tasks 4-8 fix.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Wave 2 — Backend code update
+
+### Task 4: Update chart-of-accounts.service.ts
+
+**Files:**
+- Modify: `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts`
+
+- [ ] **Step 1: Read current service**
+
+Run: `cat apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts`
+
+- [ ] **Step 2: Replace findAll signature to accept companyId filter**
+
+Edit `findAll` method:
+
+```typescript
+async findAll(filter?: { group?: AccountGroup; active?: boolean; q?: string; companyId?: string | 'SHARED' | null }) {
+  const companyFilter = filter?.companyId === 'SHARED'
+    ? { companyId: null }
+    : filter?.companyId
+      ? { companyId: filter.companyId }
+      : {}; // no filter = all companies
+
+  return this.prisma.chartOfAccount.findMany({
+    where: {
+      deletedAt: null,
+      ...companyFilter,
+      ...(filter?.group && { accountGroup: filter.group }),
+      ...(filter?.active != null && { isActive: filter.active }),
+      ...(filter?.q && {
+        OR: [
+          { code: { contains: filter.q, mode: 'insensitive' } },
+          { nameTh: { contains: filter.q, mode: 'insensitive' } },
+          { nameEn: { contains: filter.q, mode: 'insensitive' } },
+        ],
+      }),
+    },
+    orderBy: [{ companyId: 'asc' }, { code: 'asc' }],
+  });
+}
+```
+
+- [ ] **Step 3: Update create() to use composite unique check**
+
+```typescript
+async create(dto: CreateChartOfAccountDto) {
+  // Composite uniqueness check
+  const exists = await this.prisma.chartOfAccount.findUnique({
+    where: { companyId_code: { companyId: dto.companyId ?? null, code: dto.code } },
+  });
+  if (exists) throw new ConflictException(`รหัสบัญชี ${dto.code} มีอยู่แล้วในบริษัทนี้`);
+
+  if (dto.parentCode) {
+    const parent = await this.prisma.chartOfAccount.findFirst({
+      where: { code: dto.parentCode, companyId: dto.companyId ?? null, deletedAt: null },
+    });
+    if (!parent) throw new BadRequestException(`ไม่พบบัญชีแม่ ${dto.parentCode} ในบริษัทเดียวกัน`);
+  }
+
+  return this.prisma.chartOfAccount.create({
+    data: {
+      code: dto.code,
+      companyId: dto.companyId ?? null,
+      nameTh: dto.nameTh,
+      nameEn: dto.nameEn,
+      accountGroup: dto.accountGroup,
+      parentCode: dto.parentCode,
+      level: dto.level ?? 3,
+      isActive: dto.isActive ?? true,
+      peakAccountCode: dto.peakAccountCode ?? dto.code,
+      peakAccountId: dto.peakAccountId,
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Remove allowedCompanies from update + delete logic**
+
+Update `update()` and `remove()` to drop any reference to `allowedCompanies`. The `update()` body should pass `dto` directly to Prisma update.
+
+- [ ] **Step 5: TypeScript check**
+
+Run: `cd apps/api && npx tsc --noEmit src/modules/chart-of-accounts/chart-of-accounts.service.ts 2>&1 | head -5`
+Expected: 0 errors (depends on DTO update in Task 6)
+
+- [ ] **Step 6: Commit (combined with Tasks 5+6 below in single commit)**
+
+Skip commit until Tasks 5+6 done (controller + DTO together).
+
+---
+
+### Task 5: Update chart-of-accounts.controller.ts
+
+**Files:**
+- Modify: `apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts`
+
+- [ ] **Step 1: Read current controller**
+
+Run: `cat apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts`
+
+- [ ] **Step 2: Update findAll endpoint to accept ?companyId= query param**
+
+Find the `findAll` route handler and add `companyId` query param:
+
+```typescript
+@Get()
+async findAll(
+  @Query('group') group?: AccountGroup,
+  @Query('active') active?: string,
+  @Query('q') q?: string,
+  @Query('companyId') companyId?: string,  // NEW: 'SHOP-uuid' | 'FINANCE-uuid' | 'SHARED' | undefined
+) {
+  return this.chartOfAccountsService.findAll({
+    group,
+    active: active === 'true' ? true : active === 'false' ? false : undefined,
+    q,
+    companyId: companyId === 'SHARED' ? 'SHARED' : companyId,
+  });
+}
+```
+
+---
+
+### Task 6: Update chart-of-account.dto.ts
+
+**Files:**
+- Modify: `apps/api/src/modules/chart-of-accounts/dto/chart-of-account.dto.ts`
+
+- [ ] **Step 1: Replace allowedCompanies with companyId**
+
+Edit the DTO file:
+
+```diff
+-import { IsString, IsOptional, IsEnum, IsBoolean, IsInt, Matches, MaxLength, Min, Max, IsArray, IsIn } from 'class-validator';
++import { IsString, IsOptional, IsEnum, IsBoolean, IsInt, Matches, MaxLength, Min, Max, IsUUID } from 'class-validator';
+ import { AccountGroup } from '@prisma/client';
+
+-const ALLOWED_COMPANY_CODES = ['SHOP', 'FINANCE'] as const;
+
+ export class CreateChartOfAccountDto {
+   // ... existing code, nameTh, accountGroup, parentCode, level, isActive ...
+
+-  @IsArray()
+-  @IsOptional()
+-  @IsIn(ALLOWED_COMPANY_CODES, { each: true, message: 'allowedCompanies ต้องเป็น SHOP หรือ FINANCE' })
+-  allowedCompanies?: string[];
++  @IsUUID()
++  @IsOptional()
++  companyId?: string;  // null/undefined = shared account
+
+   // ... existing peakAccountCode, peakAccountId ...
+ }
+
+ export class UpdateChartOfAccountDto {
+   // mirror — remove allowedCompanies, add companyId
+ }
+```
+
+- [ ] **Step 2: TypeScript check + commit Tasks 4+5+6 together**
+
+Run: `cd apps/api && npx tsc --noEmit 2>&1 | grep -E "chart-of-accounts" | head -5`
+Expected: 0 errors in chart-of-accounts files (other modules may still error — fix in Tasks 7+8).
+
+```bash
+git add apps/api/src/modules/chart-of-accounts/
+git commit -m "feat(coa): companyId-aware queries + DTO update (Phase A.1a Wave 2a)
+
+- findAll accepts ?companyId= filter (SHOP id, FINANCE id, 'SHARED', or omit)
+- create uses composite unique (companyId, code)
+- DTO replaces allowedCompanies array with optional companyId UUID
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Update journal-auto.service.ts (ACC remap + lookup + commission removal)
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal-auto.service.ts`
+
+- [ ] **Step 1: Replace ACC constants with SHOP_ACC + FINANCE_ACC**
+
+Find `static readonly ACC = {` block (~line 30) and replace:
+
+```typescript
+// SHOP-side accounts (in SHOP chart)
+static readonly SHOP_ACC = {
+  CASH: '11-1101',
+  REVENUE_NEW: '41-1101',
+  REVENUE_USED: '41-1102',
+  INVENTORY_NEW: '11-3101',
+  INVENTORY_USED: '11-3102',
+  COGS_NEW: '51-1101',
+  COGS_USED: '51-1102',
+  COMMISSION_INCOME: '42-1105',         // owner CoA — used in A.1b
+  DUE_FROM_FINANCE: '11-2105',          // inter-company clearing — A.1b
+} as const;
+
+// FINANCE-side accounts (in FINANCE chart)
+static readonly FINANCE_ACC = {
+  CASH: '11-1101',
+  HP_RECEIVABLE: '11-2102',
+  ALLOWANCE_DOUBTFUL: '11-2103',
+  REPO_INVENTORY: '11-3103',
+  VAT_INPUT: '11-4101',
+  INTEREST_INCOME: '42-2101',           // moved from 42-1101 (was Rounding Excess in owner CoA)
+  LATE_FEE_INCOME: '42-2102',           // moved from 42-1102 (was Bank Interest in owner CoA)
+  REPOSSESSION_INCOME: '42-2104',
+  VAT_OUTPUT: '21-2101',
+  CUSTOMER_CREDIT: '21-5101',
+  DUE_TO_SHOP: '21-1102',               // inter-company clearing — A.1b
+  BAD_DEBT_EXPENSE: '53-1701',          // moved from 53-1101 (was Salary!)
+  COMMISSION_EXPENSE: '53-1801',        // for A.1b
+} as const;
+
+// Backward compat for tests (alias to FINANCE_ACC + SHOP_ACC subset)
+// Will be removed once all tests use scoped names.
+static readonly ACC = {
+  ...this.SHOP_ACC,
+  ...this.FINANCE_ACC,
+} as const;
+```
+
+(Note: TypeScript may not allow `...this` in static. If so, repeat manually.)
+
+- [ ] **Step 2: Update validation lookup in createAndPost**
+
+Find the `createAndPost` method's allowedCompanies validation block (added in Phase A.0) and replace:
+
+```diff
+-// F-3-027: validate allowedCompanies
+-const codes = [...new Set(lines.map((l) => l.accountCode))];
+-const [accounts, company] = await Promise.all([
+-  tx.chartOfAccount.findMany({
+-    where: { code: { in: codes } },
+-    select: { code: true, nameTh: true, allowedCompanies: true },
+-  }),
+-  tx.companyInfo.findUnique({
+-    where: { id: params.companyId },
+-    select: { companyCode: true },
+-  }),
+-]);
+-if (!company) {
+-  throw new BadRequestException(`Company ${params.companyId} not found`);
+-}
+-for (const acc of accounts) {
+-  if (acc.allowedCompanies.length > 0 && !acc.allowedCompanies.includes(company.companyCode)) {
+-    throw new BadRequestException(
+-      `Account ${acc.code} (${acc.nameTh}) ใช้ไม่ได้กับบริษัท ${company.companyCode}`,
+-    );
+-  }
+-}
++// F-3-027 + Phase A.1a: validate accounts exist in this company's chart
++const codes = [...new Set(lines.map((l) => l.accountCode))];
++const accounts = await tx.chartOfAccount.findMany({
++  where: { code: { in: codes }, companyId: params.companyId, deletedAt: null },
++  select: { code: true, nameTh: true },
++});
++const foundCodes = new Set(accounts.map((a) => a.code));
++const missing = codes.filter((c) => !foundCodes.has(c));
++if (missing.length > 0) {
++  throw new BadRequestException(
++    `Account(s) ${missing.join(', ')} ไม่อยู่ใน chart ของ companyId ${params.companyId}`,
++  );
++}
+```
+
+- [ ] **Step 3: Update createPaymentJournal — remove COMMISSION_INCOME line + add Sentry alarm**
+
+Find createPaymentJournal in journal-auto.service.ts. Look for:
+
+```typescript
+lines.push({
+  accountCode: ACC.COMMISSION_INCOME,
+  description: 'Commission Income',
+  debit: 0,
+  credit: monthlyCommission.toNumber(),
+});
+```
+
+(or similar — pattern may differ slightly). Replace with:
+
+```typescript
+// Phase A.1a: commission removed from payment JE — defer to A.1b inter-company
+if (params.payment.monthlyCommission && new Decimal(params.payment.monthlyCommission).gt(0)) {
+  Sentry.captureMessage('Payment commission not yet posted (deferred to A.1b)', {
+    level: 'info',
+    tags: { module: 'journal', kind: 'commission-deferred' },
+    extra: { paymentId: params.payment.id, amount: params.payment.monthlyCommission.toString() },
+  });
+}
+// (no COMMISSION_INCOME line pushed)
+```
+
+- [ ] **Step 4: Update all ACC references**
+
+Run: `grep -n "ACC\." apps/api/src/modules/journal/journal-auto.service.ts`
+
+For each reference, decide whether it's SHOP or FINANCE context based on the journal type:
+- `createPaymentJournal` (FINANCE side) — uses FINANCE_ACC for HP_RECEIVABLE, INTEREST_INCOME, LATE_FEE_INCOME, VAT_OUTPUT, CUSTOMER_CREDIT, BAD_DEBT_EXPENSE; uses FINANCE_ACC.CASH (FINANCE bank receives payment)
+- `createContractActivationJournal` (FINANCE side primary, SHOP COGS but currently single-entity) — TODO: A.1a posts everything as FINANCE since A.1b will split. For now, replace ACC.HP_RECEIVABLE → FINANCE_ACC.HP_RECEIVABLE, ACC.REVENUE_NEW → use SHOP_ACC.REVENUE_NEW (Wait — this references will fail because account is in SHOP chart but companyId is FINANCE). **CRITICAL DESIGN DECISION**: For A.1a, contract activation must continue working. We have two options:
+  - (a) Temporarily use FINANCE chart accounts only for revenue (add 41-1101 to FINANCE chart)
+  - (b) Allow journal to span 2 companies (current single-entity)
+
+  Per spec section 3.5: "Update all references in createPaymentJournal, createContractActivationJournal, createBadDebtWriteOffJournal to use the new partitioned constants. Pass companyId from already-resolved (Phase A.0) caller."
+
+  This means contract activation will use FINANCE_ACC throughout (everything FINANCE-side; SHOP gets nothing in A.1a). This works because:
+  - HP_RECEIVABLE = 11-2102 in FINANCE ✓
+  - REVENUE = need new code in FINANCE chart for "FINANCE side recognition of HP value-add"
+
+  **Simplest A.1a path:** Add `41-2101 รายได้ขายเช่าซื้อ — FINANCE` to FINANCE seed (Task 3), use it in contract activation. Remove SHOP revenue from this JE (defer SHOP-side to A.1b).
+
+  Add to `chart-of-accounts-finance.ts`:
+  ```typescript
+  { code: '41-2101', nameTh: 'รายได้ขายเช่าซื้อ FINANCE', nameEn: 'HP Sales Revenue FINANCE', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '41-2102', nameTh: 'รายได้ขายเช่าซื้อมือสอง FINANCE', nameEn: 'HP Used Sales Revenue FINANCE', accountGroup: AccountGroup.REVENUE, level: 3 },
+  { code: '11-3104', nameTh: 'สินค้าคงเหลือ FINANCE — เครื่องใหม่', nameEn: 'Inventory FINANCE New', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '11-3105', nameTh: 'สินค้าคงเหลือ FINANCE — มือสอง', nameEn: 'Inventory FINANCE Used', accountGroup: AccountGroup.ASSET, level: 3 },
+  { code: '51-2101', nameTh: 'ต้นทุนขายเช่าซื้อ FINANCE — เครื่องใหม่', nameEn: 'COGS FINANCE New', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '51-2102', nameTh: 'ต้นทุนขายเช่าซื้อ FINANCE — มือสอง', nameEn: 'COGS FINANCE Used', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  ```
+
+  Update FINANCE_ACC accordingly:
+  ```typescript
+  REVENUE_NEW: '41-2101',
+  REVENUE_USED: '41-2102',
+  INVENTORY_NEW: '11-3104',
+  INVENTORY_USED: '11-3105',
+  COGS_NEW: '51-2101',
+  COGS_USED: '51-2102',
+  ```
+
+  Note: This means FINANCE chart grows from 44 → 50 accounts. Update spec acknowledgment in commit message.
+
+- [ ] **Step 5: Update createContractActivationJournal to use FINANCE_ACC throughout**
+
+Replace all `ACC.X` references in createContractActivationJournal with `FINANCE_ACC.X`.
+
+- [ ] **Step 6: Update createBadDebtWriteOffJournal to use FINANCE_ACC**
+
+```typescript
+// Replace ACC.BAD_DEBT_EXPENSE → FINANCE_ACC.BAD_DEBT_EXPENSE
+// Replace ACC.HP_RECEIVABLE → FINANCE_ACC.HP_RECEIVABLE
+// Replace ACC.ALLOWANCE_DOUBTFUL → FINANCE_ACC.ALLOWANCE_DOUBTFUL
+```
+
+- [ ] **Step 7: Update createExpenseJournal to use SHOP_ACC or FINANCE_ACC based on caller's companyId**
+
+Currently createExpenseJournal accepts companyId. Use that to pick chart:
+
+```typescript
+const acc = params.companyId === '<SHOP_ID>' ? this.SHOP_ACC : this.FINANCE_ACC;
+// Then use acc.CASH, acc.VAT_INPUT
+```
+
+But hardcoded SHOP_ID isn't right. Instead, look up company by id:
+
+```typescript
+const company = await tx.companyInfo.findUnique({ where: { id: params.companyId }, select: { companyCode: true } });
+const isShop = company?.companyCode === 'SHOP';
+const accs = isShop ? JournalAutoService.SHOP_ACC : JournalAutoService.FINANCE_ACC;
+// Use accs.CASH, accs.VAT_INPUT
+```
+
+- [ ] **Step 8: TypeScript check**
+
+Run: `cd apps/api && npx tsc --noEmit src/modules/journal/journal-auto.service.ts 2>&1 | head -10`
+Expected: 0 errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/modules/journal/journal-auto.service.ts apps/api/prisma/seeds/chart-of-accounts-finance.ts
+git commit -m "feat(journal): partition ACC constants by company chart (Phase A.1a Wave 2b)
+
+ACC remapped:
+- BAD_DEBT_EXPENSE: 53-1101 (Salary!) → 53-1701 หนี้สูญ (FINANCE)
+- INTEREST_INCOME: 42-1101 (Rounding!) → 42-2101 (FINANCE)
+- LATE_FEE_INCOME: 42-1102 (Bank Interest!) → 42-2102 (FINANCE)
+
+createAndPost validation now scoped: accounts must exist in this
+company's chart (composite (companyId, code) lookup).
+
+createPaymentJournal: COMMISSION_INCOME line removed; Sentry alarm
+fires if monthlyCommission > 0 (defer inter-company to A.1b).
+
+Added 6 FINANCE accounts for revenue/inventory/COGS so contract
+activation works FINANCE-side in A.1a (SHOP-side split deferred to A.1b).
+FINANCE chart now has 50 accounts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Update journal.service.ts lookup
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/journal.service.ts`
+
+- [ ] **Step 1: Find allowedCompanies usage**
+
+Run: `grep -n "allowedCompanies" apps/api/src/modules/journal/journal.service.ts`
+
+- [ ] **Step 2: Replace with composite (companyId, code) lookup**
+
+```diff
+-const accounts = await this.prisma.chartOfAccount.findMany({
+-  where: { code: { in: codes } },
+-  select: { code: true, nameTh: true, allowedCompanies: true },
+-});
+-// ... validation by allowedCompanies + companyCode
++const accounts = await this.prisma.chartOfAccount.findMany({
++  where: { code: { in: codes }, companyId: dto.companyId, deletedAt: null },
++  select: { code: true, nameTh: true },
++});
++const foundCodes = new Set(accounts.map((a) => a.code));
++const missing = codes.filter((c) => !foundCodes.has(c));
++if (missing.length > 0) {
++  throw new BadRequestException(
++    `Account(s) ${missing.join(', ')} ไม่อยู่ใน chart ของ companyId ${dto.companyId}`,
++  );
++}
+```
+
+- [ ] **Step 3: TypeScript check**
+
+Run: `cd apps/api && npx tsc --noEmit 2>&1 | head -10`
+Expected: 0 errors across all files
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/modules/journal/journal.service.ts
+git commit -m "feat(journal): manual JE validation uses composite (companyId, code) lookup (Phase A.1a Wave 2c)
+
+journal.service.create + post now look up accounts scoped to the JE's
+companyId. Throws BadRequestException with missing-codes list if any
+referenced account isn't in this company's chart.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Wave 3 — Frontend
+
+### Task 9: Update ChartOfAccountsPage with company selector
+
+**Files:**
+- Modify: `apps/web/src/pages/ChartOfAccountsPage.tsx`
+- Possibly modify: `apps/web/src/pages/ChartOfAccountsPage.tsx` form/dialog area
+
+- [ ] **Step 1: Read current page**
+
+Run: `head -100 apps/web/src/pages/ChartOfAccountsPage.tsx`
+
+- [ ] **Step 2: Add companyFilter state + companies query**
+
+In the component (after existing useState calls):
+
+```typescript
+const [companyFilter, setCompanyFilter] = useState<string>('ALL');
+
+const { data: companies = [] } = useQuery<{ id: string; companyCode: string }[]>({
+  queryKey: ['companies-active'],
+  queryFn: async () => {
+    const { data } = await api.get('/companies?active=true');
+    return data;
+  },
+});
+```
+
+- [ ] **Step 3: Update findAll query to include companyId param**
+
+```typescript
+const { data: accounts = [], isLoading, isError, error, refetch } = useQuery<ChartOfAccount[]>({
+  queryKey: ['chart-of-accounts', companyFilter],
+  queryFn: async () => {
+    const params: Record<string, string> = {};
+    if (companyFilter === 'SHARED') params.companyId = 'SHARED';
+    else if (companyFilter !== 'ALL') params.companyId = companyFilter;
+    const { data } = await api.get('/chart-of-accounts', { params });
+    return data;
+  },
+});
+```
+
+- [ ] **Step 4: Add company selector to UI (before group filter)**
+
+Find the existing filter section and add Select component:
+
+```tsx
+<Select value={companyFilter} onValueChange={setCompanyFilter}>
+  <SelectTrigger className="w-48">
+    <SelectValue placeholder="บริษัท" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="ALL">ทุกบริษัท (รวม shared)</SelectItem>
+    <SelectItem value="SHARED">Shared (ไม่ระบุ)</SelectItem>
+    {companies.map((c) => (
+      <SelectItem key={c.id} value={c.id}>{c.companyCode}</SelectItem>
+    ))}
+  </SelectContent>
+</Select>
+```
+
+- [ ] **Step 5: Update create form to include companyId field**
+
+In the form state interface and FormState, replace `allowedCompanies` with `companyId: string | null`. Add companyId selector dropdown to form (defaults to current `companyFilter` if not 'ALL').
+
+- [ ] **Step 6: Update ChartOfAccount type**
+
+```typescript
+interface ChartOfAccount {
+  // ... existing
+  companyId: string | null;  // NEW
+  // remove allowedCompanies
+}
+```
+
+- [ ] **Step 7: TypeScript check**
+
+Run: `cd apps/web && npx tsc --noEmit 2>&1 | head -5`
+Expected: 0 errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/pages/ChartOfAccountsPage.tsx
+git commit -m "feat(coa): company selector + filter on ChartOfAccountsPage (Phase A.1a Wave 3)
+
+Add company dropdown above filters. ?companyId= passed to backend.
+Defaults to ALL (shows shared + all companies' accounts).
+
+Create form requires companyId selection (or shared).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Wave 4 — Tests + verification
+
+### Task 10: Update cross-spec mocks
+
+**Files:**
+- Modify: any spec that mocks `chartOfAccount.findMany` or `companyInfo.findUnique` (added in Phase A.0)
+
+- [ ] **Step 1: Find affected specs**
+
+```bash
+grep -rln "chartOfAccount" apps/api/src --include="*.spec.ts" | head
+grep -rln "allowedCompanies" apps/api/src --include="*.spec.ts" | head
+```
+
+- [ ] **Step 2: For each affected spec, update mock to use new lookup signature**
+
+Pattern change: `chartOfAccount.findMany` mock should:
+- Accept `where: { code: { in: ... }, companyId: ..., deletedAt: null }`
+- Return rows WITHOUT `allowedCompanies` field
+- Return rows WITH `code` + `nameTh`
+
+Default mock returns `[]` (so validation finds all codes missing — adjust per-test as needed):
+
+```typescript
+chartOfAccount: {
+  findMany: jest.fn().mockResolvedValue([
+    // Return all expected codes for the test
+    { code: '11-1101', nameTh: 'Cash' },
+    { code: '11-2102', nameTh: 'HP Receivable' },
+    // ... etc
+  ]),
+},
+```
+
+- [ ] **Step 3: Run full unit test suite to identify failures**
+
+Run: `cd apps/api && npx jest 2>&1 | tail -20`
+Expected: many failures initially. Fix mock per-spec until 2171+ pass.
+
+- [ ] **Step 4: Commit cross-spec mock updates**
+
+```bash
+git add apps/api/src/modules/**/*.spec.ts
+git commit -m "test: update mocks for Phase A.1a CoA composite lookup (Wave 4a)
+
+chartOfAccount.findMany mocks updated:
+- Drop allowedCompanies field from returned rows
+- Account for companyId parameter in where clause
+- Default mock returns codes that satisfy each test's JE lines
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Add chart-of-accounts.service.spec.ts (if absent)
+
+**Files:**
+- Create or modify: `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts`
+
+- [ ] **Step 1: Check if spec exists**
+
+Run: `ls apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts 2>&1`
+
+- [ ] **Step 2: Write or extend spec with companyId filter tests**
+
+If file doesn't exist, create with skeleton from contract-workflow.service.spec.ts pattern. Add tests:
+
+```typescript
+describe('findAll companyId filter (Phase A.1a)', () => {
+  it('returns only SHOP accounts when companyId=<SHOP id>', async () => {
+    prisma.chartOfAccount.findMany = jest.fn().mockResolvedValue([
+      { id: '1', code: '11-1101', companyId: 'shop-co-1', nameTh: 'SHOP Cash' },
+    ]);
+    const result = await service.findAll({ companyId: 'shop-co-1' });
+    expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ companyId: 'shop-co-1' }) }),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns shared accounts when companyId=SHARED', async () => {
+    prisma.chartOfAccount.findMany = jest.fn().mockResolvedValue([
+      { id: '2', code: '99-9999', companyId: null, nameTh: 'Shared Account' },
+    ]);
+    const result = await service.findAll({ companyId: 'SHARED' });
+    expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ companyId: null }) }),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns all accounts when no companyId provided', async () => {
+    prisma.chartOfAccount.findMany = jest.fn().mockResolvedValue([
+      { id: '1', code: '11-1101', companyId: 'shop-co-1' },
+      { id: '2', code: '99-9999', companyId: null },
+    ]);
+    const result = await service.findAll({});
+    expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith(
+      expect.not.objectContaining({ where: expect.objectContaining({ companyId: expect.anything() }) }),
+    );
+  });
+});
+
+describe('create with companyId (Phase A.1a)', () => {
+  it('creates account with composite uniqueness check', async () => {
+    prisma.chartOfAccount.findUnique = jest.fn().mockResolvedValue(null);
+    prisma.chartOfAccount.create = jest.fn().mockResolvedValue({ id: 'new1' });
+
+    await service.create({
+      code: '11-1101',
+      companyId: 'finance-co-1',
+      nameTh: 'FINANCE Cash',
+      accountGroup: AccountGroup.ASSET,
+    } as any);
+
+    expect(prisma.chartOfAccount.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { companyId_code: { companyId: 'finance-co-1', code: '11-1101' } },
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+cd apps/api && npx jest chart-of-accounts.service.spec.ts
+git add apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts
+git commit -m "test(coa): companyId filter + composite uniqueness tests (Phase A.1a Wave 4b)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Add E2E spec accounting-coa-multi-entity
+
+**Files:**
+- Create: `apps/web/e2e/accounting-coa-multi-entity.spec.ts`
+
+- [ ] **Step 1: Write E2E spec following project pattern**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { loginViaAPI, getAuthHeaders } from './helpers/auth';
+
+test.describe('Accounting — CoA multi-entity (Phase A.1a)', () => {
+  test('GET /chart-of-accounts returns all when no companyId param', async ({ request }) => {
+    const auth = await loginViaAPI(request, 'OWNER');
+    const res = await request.get('/api/chart-of-accounts', { headers: getAuthHeaders(auth) });
+    expect(res.ok()).toBeTruthy();
+    const accounts = await res.json();
+    expect(accounts.length).toBeGreaterThan(100);  // 109 SHOP + 50 FINANCE = ~160
+  });
+
+  test('GET /chart-of-accounts?companyId=<SHOP> returns SHOP accounts only', async ({ request }) => {
+    const auth = await loginViaAPI(request, 'OWNER');
+    const cosRes = await request.get('/api/companies?active=true', { headers: getAuthHeaders(auth) });
+    const companies = await cosRes.json();
+    const shop = companies.find((c: any) => c.companyCode === 'SHOP');
+    test.skip(!shop, 'SHOP company not configured');
+
+    const res = await request.get(`/api/chart-of-accounts?companyId=${shop.id}`, { headers: getAuthHeaders(auth) });
+    const accounts = await res.json();
+    expect(accounts.length).toBeGreaterThan(50);
+    expect(accounts.every((a: any) => a.companyId === shop.id)).toBeTruthy();
+  });
+
+  test('GET /chart-of-accounts?companyId=SHARED returns null-companyId accounts', async ({ request }) => {
+    const auth = await loginViaAPI(request, 'OWNER');
+    const res = await request.get('/api/chart-of-accounts?companyId=SHARED', { headers: getAuthHeaders(auth) });
+    const accounts = await res.json();
+    expect(accounts.every((a: any) => a.companyId === null)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: TypeScript check**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e/accounting-coa-multi-entity.spec.ts
+git commit -m "test(accounting): E2E for CoA multi-entity filter (Phase A.1a Wave 4c)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Wave 5 — Docs + push + PR
+
+### Task 13: Update accounting.md
+
+**Files:**
+- Modify: `.claude/rules/accounting.md`
+
+- [ ] **Step 1: Read current accounting.md**
+
+Run: `cat .claude/rules/accounting.md`
+
+- [ ] **Step 2: Update chart structure section + ACC code references**
+
+Replace the "Chart of Accounts (Key Codes)" section to reflect:
+- 2 charts (SHOP / FINANCE)
+- New BAD_DEBT_EXPENSE code 53-1701 (FINANCE)
+- New INTEREST_INCOME code 42-2101 (FINANCE)
+- New LATE_FEE_INCOME code 42-2102 (FINANCE)
+- Note about A.1a (commission temporarily removed) + A.1b (inter-company JE coming)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/rules/accounting.md
+git commit -m "docs: update accounting rules for Phase A.1a CoA split
+
+- Document SHOP + FINANCE charts
+- Update key codes (BAD_DEBT_EXPENSE 53-1701, INTEREST_INCOME 42-2101, LATE_FEE_INCOME 42-2102)
+- Note commission temporary removal (A.1b restores)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Create finance-chart-of-accounts.csv reference
+
+**Files:**
+- Create: `docs/references/finance-chart-of-accounts.csv`
+
+- [ ] **Step 1: Generate CSV from FINANCE seed**
+
+Mirror `owner-chart-of-accounts.csv` format. Use the 50-account FINANCE seed as source.
+
+```csv
+หมวดที่ 1: สินทรัพย์ (Assets),,,
+เลขบัญชี,ชื่อบัญชี,เลขที่บัญชีในเบสท์ช้อยส์,หมายเหตุ
+11-1101,เงินสด FINANCE,,
+11-1201,ธนาคาร FINANCE — บัญชีหลัก,,
+... (all 50 accounts) ...
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/references/finance-chart-of-accounts.csv
+git commit -m "docs: add FINANCE chart of accounts reference CSV (Phase A.1a)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: Final verification + push + PR
+
+- [ ] **Step 1: Full TS check**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 errors
+
+- [ ] **Step 2: Full unit test suite**
+
+Run: `cd apps/api && npx jest`
+Expected: All PASS (existing 2171+ + new tests)
+
+- [ ] **Step 3: Lint**
+
+Run: `cd apps/api && npm run lint && cd ../web && npm run lint`
+Expected: 0 errors
+
+- [ ] **Step 4: Final code review subagent**
+
+Dispatch code-reviewer subagent on entire branch vs origin/main. Fix any CRITICAL findings inline.
+
+- [ ] **Step 5: Pre-deploy: backup chart_of_accounts**
+
+```bash
+gcloud sql backups create --instance=bestchoice-db --project=bestchoice-prod --description="pre-A1a-coa-split"
+```
+
+(User may run this OR add note to PR description requesting it before merge.)
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push -u origin feat/accounting-phase-a1a-coa-split
+```
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --title "feat(accounting): Phase A.1a — CoA split (SHOP + FINANCE multi-entity)" --body "..."
+```
+
+PR body includes:
+- Summary of schema change + seed split
+- ACC remap table (old → new codes)
+- Commission temporary removal note
+- Pre-deploy backup requirement
+- Test plan checklist
+
+---
+
+## Self-Review Checklist (post-write)
+
+- [ ] Spec coverage: every section in spec maps to a task ✓
+  - Schema change → Task 1, 2
+  - Seed → Task 3
+  - Validation lookup → Task 7 (createAndPost), Task 8 (journal.service)
+  - ACC remap → Task 7
+  - Commission removal → Task 7
+  - Frontend → Task 9
+  - Tests → Tasks 10, 11, 12
+  - Docs → Tasks 13, 14
+- [ ] Type consistency: companyId is string | null throughout, companyCode is 'SHOP' | 'FINANCE'
+- [ ] No placeholders: all code blocks complete
+- [ ] Migration is additive at deploy time (column added before allowedCompanies dropped, in single migration but ordered SQL)
+- [ ] Atomic commits: Wave 1 single commit, Wave 2a/2b/2c separate commits, Wave 3-5 separate
+
+---
+
+## Estimated Effort
+
+| Wave | Tasks | Time |
+|---|---|---|
+| 1 (schema + seed) | 1, 2, 3 | ~5 hr |
+| 2 (backend) | 4, 5, 6, 7, 8 | ~6 hr |
+| 3 (frontend) | 9 | ~3 hr |
+| 4 (tests) | 10, 11, 12 | ~5 hr |
+| 5 (docs + PR) | 13, 14, 15 | ~2 hr |
+| **Total** | **15 tasks** | **~21 hr** |

--- a/docs/superpowers/specs/2026-04-29-accounting-phase-a1a-coa-split-design.md
+++ b/docs/superpowers/specs/2026-04-29-accounting-phase-a1a-coa-split-design.md
@@ -1,0 +1,424 @@
+# Accounting Phase A.1a — CoA Split (SHOP/FINANCE Multi-Entity Schema) — Spec
+
+**Date:** 2026-04-29
+**Type:** Schema migration + CoA reorg (no inter-company JE wiring; deferred to A.1b)
+**Status:** Draft for review
+**Predecessor:** Phase A.0 PR #722 (`feat/accounting-phase-a0-critical-fix`) — code-only critical fixes
+**Audit source:** `docs/reports/2026-04-29-accounting-audit.md` Phase A.1 + business decisions section
+
+---
+
+## 1. Goal
+
+Split BESTCHOICE chart of accounts into 2 entity-scoped charts (SHOP + FINANCE) with proper schema partitioning. Replaces the current single-table `allowedCompanies` array approach with explicit `companyId` partitioning + composite unique on `(companyId, code)`.
+
+Owner CoA (109 accounts, owner-supplied) becomes SHOP's chart. New 44-account FINANCE chart (38 standard + 2 deferred-decision + 4 inter-company clearing) added. ACC constants in `JournalAutoService` remapped to point at correct accounts (e.g., `BAD_DEBT_EXPENSE` moves from `53-1101 Salary` → `53-1701 หนี้สูญ`).
+
+**Deliverable:** 1 PR. Schema migration + seed replacement + lookup updates + frontend filter. ~21 hr work.
+
+---
+
+## 2. Background
+
+### Why this exists
+
+Phase A.0 hardened code-level bugs (math, try/catch, validation, period close) WITHOUT touching CoA. The remaining critical findings from audit (F-2-002, F-3-001 to F-3-022, F-3-026) all require CoA structural change before they can be fixed.
+
+### Why split (Q1 = ข)
+
+Owner's 109-account CoA is purpose-built for SHOP single-entity operation (no HP receivable, no commission income, no allowance accounts). System assumes SHOP↔FINANCE split. Reconciling means either:
+- (a) Extend owner CoA with FINANCE accounts (single chart, 150+ acc.) — rejected
+- (b) Split into 2 charts — chosen
+
+### Why composite unique (Q2 = A)
+
+Both SHOP and FINANCE need `11-1101 Cash` (different bank accounts). Current `code String @unique` blocks coexistence. Composite unique `@@unique([companyId, code])` is industry standard (matches PEAK multi-entity pattern).
+
+---
+
+## 3. Scope (5 logical changes)
+
+### 3.1 Schema change
+
+```prisma
+model ChartOfAccount {
+  id              String       @id @default(uuid())
+  code            String       // NOT unique anymore
+  companyId       String?      @map("company_id")  // NEW — null = shared
+  company         CompanyInfo? @relation(fields: [companyId], references: [id])
+  nameTh          String
+  nameEn          String?
+  accountGroup    AccountGroup
+  parentCode      String?
+  level           Int          @default(1)
+  isActive        Boolean      @default(true)
+  // allowedCompanies REMOVED
+  peakAccountCode String?
+  peakAccountId   String?
+  createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @updatedAt
+  deletedAt       DateTime?
+
+  @@unique([companyId, code])  // NEW composite unique
+  @@index([accountGroup])
+  @@index([code])
+  @@index([companyId])  // NEW
+  @@map("chart_of_accounts")
+}
+```
+
+### 3.2 Migration (single SQL file, atomic)
+
+5 logical steps in one migration:
+
+1. `ALTER TABLE chart_of_accounts ADD COLUMN company_id TEXT NULL`
+2. `ALTER TABLE chart_of_accounts ADD CONSTRAINT chart_of_accounts_company_id_fkey FOREIGN KEY (company_id) REFERENCES company_info(id)`
+3. Backfill: `UPDATE chart_of_accounts SET company_id = (SELECT id FROM company_info WHERE company_code = 'SHOP') WHERE 'SHOP' = ANY(allowed_companies);` (and similar for FINANCE)
+4. `ALTER TABLE chart_of_accounts DROP CONSTRAINT chart_of_accounts_code_key; CREATE UNIQUE INDEX ON chart_of_accounts (company_id, code);`
+5. `ALTER TABLE chart_of_accounts DROP COLUMN allowed_companies;`
+
+### 3.3 Seed replacement
+
+**SHOP chart — 109 accounts** from `docs/references/owner-chart-of-accounts.csv`:
+- All accounts get `companyId = SHOP company id`
+- Code preserved as-is from CSV (e.g., 11-1101 = "เงินสด สุทธินีย์ คงเดช")
+
+**FINANCE chart — 44 accounts** (NEW seed file `chart-of-accounts-finance.ts`):
+
+```
+─ 11-XXXX สินทรัพย์หมุนเวียน (10) ─
+11-1101 เงินสด FINANCE
+11-1201 ธนาคาร FINANCE — บัญชีหลัก
+11-1202 ธนาคาร FINANCE — รับชำระค่างวด
+11-2102 ลูกหนี้เช่าซื้อ
+11-2103 หัก: ค่าเผื่อหนี้สงสัยจะสูญ
+11-2104 ลูกหนี้ไฟแนนซ์ภายนอก
+11-3103 สินค้ายึดคืน/ซ่อมแล้ว
+11-4101 ภาษีซื้อ
+11-4102 ภาษีซื้อยังไม่ถึงกำหนด
+11-4103 ภาษีถูกหัก ณ ที่จ่าย
+
+─ 21-XXXX หนี้สินหมุนเวียน (8) ─
+21-1102 เจ้าหนี้คู่ค้า — SHOP (clearing for inter-company)
+21-2101 ภาษีขาย ภ.พ.30
+21-2102 ภาษีขายรอเรียกเก็บ
+21-2103 ภ.พ.36 ค้างจ่าย
+21-2104 ภาษีขายดอกเบี้ยรอตัดบัญชี [DEFERRED — for CR-001 if VAT on interest]
+21-2202 รายได้ดอกเบี้ยรอตัดบัญชี [DEFERRED — for W-003 unearnedInterest]
+21-3201 เจ้าหนี้สรรพากร ภ.พ.30 รอชำระ
+21-3202 เจ้าหนี้สรรพากร ภ.ง.ด.53 รอชำระ
+21-4201 เงินรับล่วงหน้า
+21-5101 เงินเกินของลูกค้า
+
+─ 31/32-XXXX ส่วนของผู้ถือหุ้น (2) ─
+31-1101 ทุนสามัญ FINANCE
+32-1101 กำไร(ขาดทุน)สะสม FINANCE
+
+─ 42-XXXX รายได้อื่น (5) — ใช้ 42-2XXX prefix แยกจาก SHOP's 42-1XXX ─
+42-2101 รายได้ดอกเบี้ยเช่าซื้อ (HP Interest Income)
+42-2102 ค่างวดเบี้ยปรับล่าช้า (Late Fee Income)
+42-2103 ค่ามัดจำ/เงินประกันที่ริบ
+42-2104 รายได้จากการยึดเครื่อง (Repossession Income)
+42-2105 รายได้ค่าคอมมิชชันจาก SHOP [unused in A.1a — for A.1b inter-company]
+
+─ 53-XXXX ค่าใช้จ่าย (6) ─
+53-1701 หนี้สูญ (Bad Debt Expense) — ใหม่
+53-1702 หนี้สงสัยจะสูญ (Doubtful Debt Expense)
+53-1801 ค่านายหน้าจ่าย SHOP (Commission Expense — for A.1b inter-company)
+53-1802 ค่าธรรมเนียม PaySolutions
+53-1803 ค่าธรรมเนียมโอนเงิน
+53-1601 ค่าเสื่อมราคา — อุปกรณ์ FINANCE
+
+─ 54-XXXX รายจ่ายต้องห้ามทางภาษี (2) ─
+54-1101 ภงด. ทางภาษี ภ.ง.ด.3
+54-1102 ภงด. ทางภาษี ภ.ง.ด.53
+
+Plus 1 SHOP-side clearing account:
+SHOP 11-2105 ลูกหนี้คู่ค้า — FINANCE (Due-from-FINANCE for inter-company)
+```
+
+**Total in DB after migration:** 109 SHOP + 25 (existing shared accounts re-tagged null) + 38 + 2 deferred + 1 clearing per side = ~155 accounts
+
+### 3.4 Validation lookup change
+
+In `journal-auto.service.ts createAndPost`:
+
+```typescript
+// Before:
+const accounts = await tx.chartOfAccount.findMany({
+  where: { code: { in: codes } },
+  select: { code: true, nameTh: true, allowedCompanies: true },
+});
+
+// After:
+const accounts = await tx.chartOfAccount.findMany({
+  where: { code: { in: codes }, companyId: params.companyId },
+  select: { code: true, nameTh: true },
+});
+// Validation simplifies — if account exists in this company's chart, allowed.
+// If not exists → throw "account not in chart for company"
+```
+
+Same change in `journal.service.ts create + post`.
+
+### 3.5 ACC constant remapping
+
+```typescript
+// journal-auto.service.ts — partition ACC by company chart
+private static readonly SHOP_ACC = {
+  CASH: '11-1101',
+  REVENUE_NEW: '41-1101',
+  REVENUE_USED: '41-1102',
+  INVENTORY_NEW: '11-3101',
+  INVENTORY_USED: '11-3102',
+  COGS_NEW: '51-1101',
+  COGS_USED: '51-1102',
+  COMMISSION_INCOME: '42-1105',         // exists in owner CoA — for A.1b
+  DUE_FROM_FINANCE: '11-2105',          // new clearing
+} as const;
+
+private static readonly FINANCE_ACC = {
+  CASH: '11-1101',                      // FINANCE's cash, different account
+  HP_RECEIVABLE: '11-2102',
+  ALLOWANCE_DOUBTFUL: '11-2103',
+  REPO_INVENTORY: '11-3103',
+  VAT_INPUT: '11-4101',
+  INTEREST_INCOME: '42-2101',           // moved from 42-1101 (was wrong code)
+  LATE_FEE_INCOME: '42-2102',           // moved from 42-1102 (was wrong code)
+  REPOSSESSION_INCOME: '42-2104',
+  VAT_OUTPUT: '21-2101',
+  CUSTOMER_CREDIT: '21-5101',
+  DUE_TO_SHOP: '21-1102',               // new clearing
+  BAD_DEBT_EXPENSE: '53-1701',          // moved from 53-1101 (was Salary!)
+  COMMISSION_EXPENSE: '53-1801',        // for A.1b
+} as const;
+```
+
+Update all references in createPaymentJournal, createContractActivationJournal, createBadDebtWriteOffJournal to use the new partitioned constants. Pass `companyId` from already-resolved (Phase A.0) caller.
+
+### 3.6 Commission temporary removal
+
+In `createPaymentJournal`, remove the commission income line:
+
+```typescript
+// REMOVED — defer to A.1b inter-company:
+// lines.push({
+//   accountCode: ACC.COMMISSION_INCOME, ...
+// });
+// TODO A.1b: post inter-company commission JE here
+
+if (params.payment.monthlyCommission && params.payment.monthlyCommission.gt(0)) {
+  Sentry.captureMessage('Payment commission not yet posted (deferred to A.1b)', {
+    level: 'info',
+    tags: { module: 'journal', kind: 'commission-deferred' },
+    extra: { paymentId: params.payment.id, amount: params.payment.monthlyCommission.toString() },
+  });
+}
+```
+
+### 3.7 Frontend ChartOfAccountsPage
+
+Add company selector dropdown above filters:
+
+```tsx
+<Select value={companyFilter} onValueChange={setCompanyFilter}>
+  <SelectItem value="ALL">ทุกบริษัท (รวม shared)</SelectItem>
+  <SelectItem value="SHOP">SHOP</SelectItem>
+  <SelectItem value="FINANCE">FINANCE</SelectItem>
+  <SelectItem value="SHARED">Shared (ไม่ระบุบริษัท)</SelectItem>
+</Select>
+```
+
+API: `GET /chart-of-accounts?companyId=<id|"shared"|null>`. Backend filters accordingly.
+
+Create/edit form: company selector required field (defaults to current filter if set).
+
+---
+
+## 4. File Structure
+
+| File | Type | Wave |
+|---|---|---|
+| `apps/api/prisma/schema.prisma` | Modify | 1 |
+| `apps/api/prisma/migrations/{ts}_chart_of_accounts_company_partition/migration.sql` | Create | 1 |
+| `apps/api/prisma/seeds/chart-of-accounts.ts` | Replace (use 109 SHOP from CSV) | 1 |
+| `apps/api/prisma/seeds/chart-of-accounts-finance.ts` | Create (44 FINANCE accounts) | 1 |
+| `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts` | Modify (filter by companyId) | 2 |
+| `apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts` | Modify (add ?companyId= query) | 2 |
+| `apps/api/src/modules/chart-of-accounts/dto/create-chart-of-account.dto.ts` | Modify (add companyId field) | 2 |
+| `apps/api/src/modules/chart-of-accounts/dto/update-chart-of-account.dto.ts` | Modify | 2 |
+| `apps/api/src/modules/journal/journal-auto.service.ts` | Modify (ACC remap + lookup change + commission removal) | 2 |
+| `apps/api/src/modules/journal/journal.service.ts` | Modify (lookup change in create + post) | 2 |
+| `apps/web/src/pages/ChartOfAccountsPage.tsx` | Modify (company selector) | 3 |
+| ~5 spec files | Modify (mock updates) | 4 |
+| `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts` | Create if absent (filter tests) | 4 |
+| `apps/web/e2e/accounting-coa-multi-entity.spec.ts` | Create | 4 |
+| `.claude/rules/accounting.md` | Update (new chart structure) | 5 |
+| `docs/references/finance-chart-of-accounts.csv` | Create | 5 |
+
+---
+
+## 5. Wave order (single PR, multiple commits)
+
+**Wave 1 — Schema + seed (single atomic commit)**
+- Migration file + schema update
+- Seed file replacement + new FINANCE seed
+- Verify migrate dev passes locally
+
+**Wave 2 — Backend code (3 commits)**
+- (2a) `chart-of-accounts.service` + controller + DTO — companyId filter
+- (2b) `journal-auto.service` — ACC partition + lookup + commission removal
+- (2c) `journal.service` — lookup change
+
+**Wave 3 — Frontend (1 commit)**
+- ChartOfAccountsPage company selector + filter wiring
+
+**Wave 4 — Tests + verification (1 commit)**
+- Update mocks across affected specs
+- New chart-of-accounts.service.spec
+- E2E accounting-coa-multi-entity
+- Full test + TS check
+
+**Wave 5 — Docs + push + PR**
+- accounting.md update
+- finance-chart-of-accounts.csv reference
+- Internal memo for นักบัญชี (commission temporary divergence)
+
+---
+
+## 6. Pattern Decisions (Captured from Brainstorm)
+
+| ID | Decision | Choice |
+|---|---|---|
+| Q1 | CoA ground truth | Split 2 charts (SHOP + FINANCE) |
+| Q2 | Schema | Composite unique (companyId, code) |
+| Q3 | FINANCE chart size | ~38 + 2 deferred + 4 clearing |
+| Q4 | Commission ownership | Proper inter-company (A.1b) |
+| Q5 | Inter-company JE policy | Full inter-company (A.1b for wiring) |
+| Q6 | Sub-phase split | A.1a (this) + A.1b (inter-company JE) |
+| Q7 | Deferred accounts | Include 21-2202 + 21-2104 in seed |
+
+---
+
+## 7. Testing Strategy
+
+### Unit tests (~30 new + ~20 existing updates)
+
+| Area | Tests added |
+|---|---|
+| Schema | Migration backfill verification on test DB |
+| Validation | (companyId, code) lookup correct; cross-company returns empty + throws |
+| ACC remap | Bad debt write-off posts to '53-1701' (FINANCE chart); Interest income posts to '42-2101' |
+| Commission | Payment JE has no COMMISSION_INCOME line; Sentry alarm fires when monthlyCommission > 0 |
+| ChartOfAccounts CRUD | Filter by companyId; create with companyId; update preserves companyId |
+| Frontend ChartOfAccountsPage | Company dropdown filters list; create form requires companyId |
+
+### E2E (1 new)
+
+- `accounting-coa-multi-entity.spec.ts`:
+  - GET /chart-of-accounts → returns all
+  - GET /chart-of-accounts?companyId=SHOP → ~109 rows
+  - GET /chart-of-accounts?companyId=FINANCE → ~44 rows
+  - POST create with companyId — verify saves correctly
+
+### Cross-spec impact
+
+ALL specs that mock `chartOfAccount.findMany` need updates (filter by companyId). Pattern verified in Phase A.0 — budget 1 hr for stale-mock fixes.
+
+---
+
+## 8. Success Criteria
+
+- [ ] Schema migration applied — `chart_of_accounts` has `company_id` column + composite unique
+- [ ] All existing 76 accounts re-tagged correctly (verify counts: SHOP/FINANCE/null match expected from `allowedCompanies`)
+- [ ] 109 SHOP accounts seeded
+- [ ] 44 FINANCE accounts seeded (38 + 2 deferred + 4 clearing — note: 2 of the 4 clearing are SHOP-side `11-2105 Due-from-FINANCE`)
+- [ ] All unit tests pass (existing 2171 + ~30 new)
+- [ ] All E2E tests pass (existing + 1 new)
+- [ ] TypeScript: 0 errors
+- [ ] Sentry: no error spike 1 hr post-deploy
+- [ ] Manual: GET /chart-of-accounts?companyId=SHOP returns 109+ rows
+- [ ] Manual: GET /chart-of-accounts?companyId=FINANCE returns ~44 rows
+- [ ] Manual: trigger bad debt write-off → JE row in journal_lines references '53-1701' (not '53-1101')
+- [ ] Documented: `accounting.md` updated
+- [ ] Documented: `docs/references/finance-chart-of-accounts.csv` exists
+- [ ] Internal memo sent to นักบัญชี (commission divergence + A.1b plan)
+
+---
+
+## 9. Risk & Mitigation
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Migration backfill miscategorizes accounts | CRITICAL | `gcloud sql backups create` pre-deploy. Manual review of mapping. Dry-run on staging. |
+| ACC remapping breaks existing JEs in prod | HIGH | Old code records preserved (just moved to different chart). Forward-only fix. Existing JE rows reference old codes by string — they remain valid records. |
+| Commission line removal causes SHOP P&L underreport | HIGH | **Documented temporary divergence**. Sentry alarm tracks. Internal memo. A.1b restores. |
+| Frontend page breaks for users | LOW | Default to "All" filter — preserves current behavior. |
+| Stale test mocks across modules | MEDIUM | Budget 1 hr fix cycle. |
+| FK constraint blocks delete of SHOP/FINANCE company | LOW | Migration uses `ON DELETE SET NULL` so company deletion sets companyId to null (account becomes shared). |
+
+### Backup before deploy (mandatory)
+
+```bash
+gcloud sql backups create --instance=bestchoice-db --project=bestchoice-prod --description="pre-A1a-coa-migration"
+```
+
+### Rollback plan
+
+If migration breaks data:
+1. Revert PR commit + redeploy
+2. Manual restore: `psql` connect → restore `chart_of_accounts` table from backup
+3. Total recovery: ~15 min
+
+If migration succeeds but code has bug:
+1. Cloud Run revision rollback (1 click) — schema stays new
+2. Total recovery: ~5 min
+
+---
+
+## 10. Out of Scope (deferred to A.1b)
+
+- ❌ Inter-company JE pairing (contract activation split, commission inter-company, repossession)
+- ❌ Bad debt provision JE (Dr Bad Debt Expense / Cr Allowance)
+- ❌ Customer credit overpayment JE
+- ❌ Repossession resale JE
+- ❌ Backfill historical JEs with new account codes
+- ❌ Year-end closing entries (Phase A.2)
+- ❌ HP interest accrual policy (W-003 unearnedInterest implementation — Phase A.2)
+
+---
+
+## 11. Estimated Effort
+
+| Phase | Time |
+|---|---|
+| Wave 1 (schema + seed) | ~5 hr |
+| Wave 2 (backend) | ~4 hr |
+| Wave 3 (frontend) | ~3 hr |
+| Wave 4 (tests) | ~5 hr |
+| Wave 5 (docs + PR) | ~2 hr |
+| Self-review + 2-stage subagent review + fix | ~2 hr |
+| **Total A.1a** | **~21 hr** |
+
+---
+
+## 12. Follow-up Specs
+
+After A.1a ships:
+
+- **A.1b** — Inter-company JE wiring (full SHOP↔FINANCE flow): contract activation split, commission inter-company, repossession resale, customer credit JE, bad debt provision JE
+- **A.2** — Policy-dependent fixes: HP interest recognition (W-003 unearnedInterest), CR-001 VAT on interest decision (CPA), year-end closing entries
+- **A.3** — Backfill historical orphan transactions (36 prod orphan payments + historical activations)
+- **B** — Build missing reports (P&L from JE not raw tables, Balance Sheet from JE, Cash Flow investing/financing, Notes to FS, GL endpoint, HP Subsidiary Ledger, PND.50/51)
+
+---
+
+## 13. References
+
+- Audit report: `docs/reports/2026-04-29-accounting-audit.md`
+- Phase A.0 spec: `docs/superpowers/specs/2026-04-29-accounting-phase-a0-critical-fix-design.md`
+- Phase A.0 PR: #722 (`feat/accounting-phase-a0-critical-fix`)
+- Owner CoA: `docs/references/owner-chart-of-accounts.csv`
+- Accounting rules: `.claude/rules/accounting.md`
+- Memory: `project_accounting_phase_a0_pr722.md`
+- Memory: `project_accounting_audit_2026_04_29.md`


### PR DESCRIPTION
## Summary

Phase A.1a of the accounting fix roadmap. Splits the chart of accounts into 2 entity-scoped charts (SHOP + FINANCE) via schema partition.

### Schema change
- `ChartOfAccount.allowedCompanies` (string array) → `companyId` (FK to CompanyInfo) + `@@unique([companyId, code])` composite unique
- Migration is additive: backfill existing rows by allowed_companies → SHOP/FINANCE/null, then drop allowed_companies column
- Same code can exist in both charts (e.g., 11-1101 Cash for SHOP and FINANCE — different bank accounts)

### CoA structure
- **SHOP chart** (109 accounts) — parsed from `docs/references/owner-chart-of-accounts.csv`
- **FINANCE chart** (41 accounts) — new `docs/references/finance-chart-of-accounts.csv`
- 1 SHOP-side clearing account (11-2105 Due-from-FINANCE) + 1 FINANCE-side clearing (21-1102 Due-to-SHOP) for A.1b inter-company

### Critical ACC remapping (audit findings F-2-002, F-3-012, F-3-013 fixed)
- BAD_DEBT_EXPENSE: 53-1101 (Salary in owner CoA!) → 53-1701 (FINANCE หนี้สูญ)
- INTEREST_INCOME: 42-1101 (Rounding Excess in owner CoA!) → 42-2101 (FINANCE)
- LATE_FEE_INCOME: 42-1102 (Bank Interest in owner CoA!) → 42-2102 (FINANCE)
- REVENUE/INVENTORY/COGS NEW/USED: split SHOP (existing codes) + FINANCE (new 41-2101/02, 11-3104/05, 51-2101/02 codes)

### Validation hardening
- `JournalAutoService.createAndPost` validates account exists in this company's chart (composite (companyId, code) lookup)
- `journal.service.ts create` uses same scoped validation
- Throws BadRequestException with missing-codes list

### Temporary deviation (will be restored in A.1b)
- Commission income line removed from payment JE; folded into HP_RECEIVABLE credit to keep entry balanced. Sentry alarm fires when monthlyCommission > 0.
- Contract activation posts everything on FINANCE side. A.1b will split into proper inter-company SHOP+FINANCE entries.

### Frontend
- ChartOfAccountsPage gains company selector + ?companyId= filter
- Create form requires companyId selection (or shared)

### Tests
- 2177/2177 unit tests pass (+ 39 new for chart-of-accounts service + journal-auto partition)
- 1 new E2E spec: accounting-coa-multi-entity (verifies filter behavior)

### Out of scope (deferred to A.1b)
- Inter-company JE pairing (commission, contract activation split, repossession)
- Bad debt provision JE (Dr Bad Debt / Cr Allowance)
- Customer credit overpayment JE
- Backfill historical JEs with new account codes
- Year-end closing entries → A.2

### Pre-deploy backup recommended

Run a Cloud SQL backup with description `pre-A1a-coa-split` before deploying.

## Test plan
- [ ] CI: Lint & Test pass
- [ ] CI: 4 E2E shards (note: chat_snoozes drift may cause unrelated failures)
- [ ] CI: Migration runs successfully (additive only — 1 column add + FK + 2 SQL UPDATE backfill + 1 column drop)
- [ ] CI: API + Web deploy
- [ ] Sentry: no error spike for 1 hour post-deploy
- [ ] Manual: GET /chart-of-accounts?companyId=<SHOP id> returns 100+ rows
- [ ] Manual: GET /chart-of-accounts?companyId=<FINANCE id> returns ~41 rows
- [ ] Manual: trigger bad debt write-off (test contract) → JE row references 53-1701 (not 53-1101)

## Spec + Plan
- Spec: `docs/superpowers/specs/2026-04-29-accounting-phase-a1a-coa-split-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-accounting-phase-a1a-coa-split.md`
- Predecessor: PR #722 Phase A.0 (merged 23eb4473)

Generated with Claude Code