### PR TITLE
fix(accounting): Phase A.1c — JE bug fixes (early payoff + trial balance + entry number)

### DIFF
--- a/apps/api/src/modules/contracts/contract-payment.service.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.ts
@@ -183,7 +183,23 @@ export class ContractPaymentService {
           orderBy: { installmentNo: 'asc' },
         });
 
-        // Distribute totalPayoff across unpaid installments (FIFO)
+        // Distribute totalPayoff across unpaid installments (FIFO).
+        // We update each Payment row individually but post ONE aggregated JE
+        // at the end via createEarlyPayoffJournal — per-installment JEs were
+        // unbalanced when discount > 0 (cash partial vs full breakdown).
+        // Snapshot the breakdown BEFORE any updates so the JE math reflects
+        // the as-of-payoff state, not the post-update partial payment.
+        const installmentSnapshots = unpaidPayments.map((p) => ({
+          amountDue: p.amountDue,
+          amountPaidBefore: p.amountPaid,
+          monthlyPrincipal: p.monthlyPrincipal,
+          monthlyInterest: p.monthlyInterest,
+          monthlyCommission: p.monthlyCommission,
+          vatAmount: p.vatAmount,
+          lateFee: p.lateFee,
+          lateFeeWaived: p.lateFeeWaived,
+        }));
+
         let remainingPayoff = d(quote.totalPayoff);
         for (const payment of unpaidPayments) {
           const lateFee = payment.lateFeeWaived ? d(0) : d(payment.lateFee);
@@ -196,7 +212,7 @@ export class ContractPaymentService {
           const payAmount = d(payAmountNum);
           remainingPayoff = dSub(remainingPayoff, payAmount);
 
-          const updatedPayment = await tx.payment.update({
+          await tx.payment.update({
             where: { id: payment.id },
             data: {
               status: 'PAID',
@@ -211,32 +227,21 @@ export class ContractPaymentService {
                 : '[ปิดก่อนกำหนด]',
             },
           });
-
-          // Auto journal entry for each installment closed by the payoff.
-          // (Audit finding J3: closes the journal coverage gap on early
-          // payoff. Errors propagate so the whole tx rolls back.)
-          await this.journalAutoService.createPaymentJournal(tx, {
-            shopCompanyId,
-            financeCompanyId,
-            payment: {
-              id: updatedPayment.id,
-              installmentNo: updatedPayment.installmentNo,
-              amountPaid: updatedPayment.amountPaid,
-              monthlyPrincipal: updatedPayment.monthlyPrincipal,
-              monthlyInterest: updatedPayment.monthlyInterest,
-              monthlyCommission: updatedPayment.monthlyCommission,
-              vatAmount: updatedPayment.vatAmount,
-              lateFee: updatedPayment.lateFee,
-              lateFeeWaived: updatedPayment.lateFeeWaived,
-              paidDate: updatedPayment.paidDate,
-            },
-            contract: {
-              contractNumber: freshContract.contractNumber,
-              branchId: freshContract.branchId,
-            },
-            userId,
-          });
         }
+
+        // One aggregated JE for the whole payoff. Discount is absorbed by
+        // proportionally reducing interest / commission / VAT (principal
+        // must always be settled in full so HP Receivable stays correct).
+        await this.journalAutoService.createEarlyPayoffJournal(tx, {
+          contractId: id,
+          contractNumber: freshContract.contractNumber,
+          installments: installmentSnapshots,
+          totalPayoff: quote.totalPayoff,
+          userId,
+          shopCompanyId,
+          financeCompanyId,
+          paidDate,
+        });
 
         // Reset credit balance (used up by the early payoff)
         const updated = await tx.contract.update({

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -64,6 +64,8 @@ describe('JournalAutoService', () => {
         }
         return Promise.all(fn as Promise<unknown>[]);
       }),
+      // generateEntryNumber uses $queryRaw with FOR UPDATE for collision-free seq
+      $queryRaw: jest.fn().mockResolvedValue([]),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -1434,6 +1436,7 @@ describe('JournalAutoService', () => {
           count: jest.fn().mockResolvedValue(0),
           create: jest.fn().mockResolvedValue({ id: 'entry1' }),
         },
+        $queryRaw: jest.fn().mockResolvedValue([]),
       };
       await expect(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1592,6 +1595,7 @@ describe('JournalAutoService', () => {
             .fn()
             .mockImplementation(({ data }) => Promise.resolve({ id: 'e1', _captured: data })),
         },
+        $queryRaw: jest.fn().mockResolvedValue([]),
       };
       (Sentry.captureMessage as jest.Mock).mockClear();
       const originalDate = new Date('2025-03-15T00:00:00Z');

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -1465,6 +1465,144 @@ describe('JournalAutoService', () => {
   });
 
   // ──────────────────────────────────────────────────────────────────────────
+  // createEarlyPayoffJournal (Phase A.1c — C-2 fix)
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('createEarlyPayoffJournal (Phase A.1c)', () => {
+    const userId = 'u-1';
+
+    beforeEach(() => {
+      prisma.companyInfo.findFirst.mockResolvedValue({ id: 'co-FINANCE' });
+    });
+
+    function makeInst(overrides: Partial<{
+      amountDue: number; amountPaidBefore: number;
+      monthlyPrincipal: number; monthlyInterest: number;
+      monthlyCommission: number; vatAmount: number;
+      lateFee: number; lateFeeWaived: boolean;
+    }> = {}) {
+      return {
+        amountDue: 1000, amountPaidBefore: 0,
+        monthlyPrincipal: 800, monthlyInterest: 100,
+        monthlyCommission: 50, vatAmount: 50,
+        lateFee: 0, lateFeeWaived: false,
+        ...overrides,
+      };
+    }
+
+    it('balances when no discount (cash = sum of all components)', async () => {
+      const insts = [makeInst(), makeInst(), makeInst()]; // 3 × 1000 = 3000 owed
+      await service.createEarlyPayoffJournal(prisma, {
+        contractId: 'c-1', contractNumber: 'CNT-001',
+        installments: insts, totalPayoff: 3000,
+        userId, shopCompanyId: 'co-SHOP', financeCompanyId: 'co-FINANCE',
+      });
+      const lines = capturedLines();
+      expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
+      const cashLine = lines.find((l) => l.accountCode === '11-1101');
+      expect(Number(cashLine!.debit)).toBeCloseTo(3000, 2);
+      const hpLine = lines.find((l) => l.accountCode === '11-2102');
+      expect(Number(hpLine!.credit)).toBeCloseTo(2400, 2); // 3 × 800
+    });
+
+    it('balances when discount applied — principal in full, others scaled down', async () => {
+      const insts = [makeInst(), makeInst(), makeInst()]; // owed 3000, principal 2400
+      // 50% discount on grossProfit: discount=300 → totalPayoff=2700
+      await service.createEarlyPayoffJournal(prisma, {
+        contractId: 'c-1', contractNumber: 'CNT-001',
+        installments: insts, totalPayoff: 2700,
+        userId, shopCompanyId: 'co-SHOP', financeCompanyId: 'co-FINANCE',
+      });
+      const lines = capturedLines();
+      expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
+      const cashLine = lines.find((l) => l.accountCode === '11-1101');
+      expect(Number(cashLine!.debit)).toBeCloseTo(2700, 2);
+      // Principal MUST be settled in full
+      const hpLine = lines.find((l) => l.accountCode === '11-2102');
+      expect(Number(hpLine!.credit)).toBeCloseTo(2400, 2);
+      // Other 300 split proportionally across interest(300)+commission(150)+vat(150)=600
+      // Scale = 300/600 = 0.5 → interest 150, commission 75, vat 75
+      const interestLine = lines.find((l) => l.accountCode === '42-2101');
+      expect(Number(interestLine!.credit)).toBeCloseTo(150, 2);
+    });
+
+    it('includes late fees in cash + as separate credit line', async () => {
+      const insts = [makeInst({ lateFee: 200 })];
+      await service.createEarlyPayoffJournal(prisma, {
+        contractId: 'c-1', contractNumber: 'CNT-001',
+        installments: insts, totalPayoff: 1200, // 1000 owed + 200 late fee
+        userId, shopCompanyId: 'co-SHOP', financeCompanyId: 'co-FINANCE',
+      });
+      const lines = capturedLines();
+      expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
+      const lateFeeLine = lines.find((l) => l.accountCode === '42-2102');
+      expect(Number(lateFeeLine!.credit)).toBeCloseTo(200, 2);
+    });
+
+    it('handles partial pre-existing pay by scaling remaining breakdown', async () => {
+      // amountDue=1000, amountPaidBefore=400 → 60% remaining
+      // Remaining: principal=480, interest=60, commission=30, vat=30 → total=600
+      const insts = [makeInst({ amountPaidBefore: 400 })];
+      await service.createEarlyPayoffJournal(prisma, {
+        contractId: 'c-1', contractNumber: 'CNT-001',
+        installments: insts, totalPayoff: 600,
+        userId, shopCompanyId: 'co-SHOP', financeCompanyId: 'co-FINANCE',
+      });
+      const lines = capturedLines();
+      expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
+      const hpLine = lines.find((l) => l.accountCode === '11-2102');
+      expect(Number(hpLine!.credit)).toBeCloseTo(480, 2);
+    });
+
+    it('falls back to interest-only when breakdown is zero (legacy data)', async () => {
+      const insts = [makeInst({
+        monthlyPrincipal: 0, monthlyInterest: 0,
+        monthlyCommission: 0, vatAmount: 0,
+        amountDue: 1000,
+      })];
+      await service.createEarlyPayoffJournal(prisma, {
+        contractId: 'c-1', contractNumber: 'CNT-001',
+        installments: insts, totalPayoff: 1000,
+        userId, shopCompanyId: 'co-SHOP', financeCompanyId: 'co-FINANCE',
+      });
+      const lines = capturedLines();
+      expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
+      // Whole non-principal cash → interest line
+      const interestLine = lines.find((l) => l.accountCode === '42-2101');
+      expect(Number(interestLine!.credit)).toBeCloseTo(1000, 2);
+    });
+
+    it('skips SHOP entry when commission is zero', async () => {
+      const insts = [makeInst({ monthlyCommission: 0, monthlyPrincipal: 850 })];
+      await service.createEarlyPayoffJournal(prisma, {
+        contractId: 'c-1', contractNumber: 'CNT-001',
+        installments: insts, totalPayoff: 1000,
+        userId, shopCompanyId: 'co-SHOP', financeCompanyId: 'co-FINANCE',
+      });
+      // Only one entry created (FINANCE side)
+      expect(prisma.journalEntry.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('posts paired SHOP entry when commission > 0 with matching IC prefix', async () => {
+      const insts = [makeInst()]; // commission 50
+      await service.createEarlyPayoffJournal(prisma, {
+        contractId: 'c-1', contractNumber: 'CNT-001',
+        installments: insts, totalPayoff: 1000,
+        userId, shopCompanyId: 'co-SHOP', financeCompanyId: 'co-FINANCE',
+      });
+      expect(prisma.journalEntry.create).toHaveBeenCalledTimes(2);
+      const calls = prisma.journalEntry.create.mock.calls.map((c: unknown[]) => (c[0] as { data: { description: string; companyId: string } }).data);
+      const financeCall = calls.find((c) => c.companyId === 'co-FINANCE');
+      const shopCall = calls.find((c) => c.companyId === 'co-SHOP');
+      expect(financeCall).toBeDefined();
+      expect(shopCall).toBeDefined();
+      // Both descriptions carry the same [IC-<uuid>] prefix
+      const icMatch = financeCall!.description.match(/\[IC-([0-9a-f-]+)\]/);
+      expect(icMatch).not.toBeNull();
+      expect(shopCall!.description).toContain(icMatch![0]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
   // createRepossessionResaleJournal (Phase A.1b)
   // ──────────────────────────────────────────────────────────────────────────
   describe('createRepossessionResaleJournal (Phase A.1b)', () => {

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -71,10 +71,28 @@ export class JournalAutoService {
     const now = new Date();
     const ym = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
     const prefix = `JE-${ym}`;
-    const count = await tx.journalEntry.count({
-      where: { entryNumber: { startsWith: prefix } },
-    });
-    return `${prefix}-${String(count + 1).padStart(4, '0')}`;
+
+    // SELECT ... FOR UPDATE serialises concurrent inserts in the same month-prefix.
+    // count()-based generation race-conditions when two transactions read the same
+    // count and produce identical entry numbers — Phase A.1b doubled the surface
+    // by posting paired SHOP+FINANCE entries per business operation. Same pattern
+    // as receipts.service.generateReceiptNumber (verified working).
+    const result = await (tx as unknown as { $queryRaw: typeof PrismaService.prototype.$queryRaw }).$queryRaw<
+      Array<{ entryNumber: string }>
+    >`
+      SELECT entry_number AS "entryNumber" FROM journal_entries
+      WHERE entry_number LIKE ${prefix + '%'}
+      ORDER BY entry_number DESC
+      LIMIT 1
+      FOR UPDATE
+    `;
+
+    let seq = 1;
+    if (result.length > 0) {
+      const lastSeq = parseInt(result[0].entryNumber.replace(`${prefix}-`, ''), 10);
+      if (!Number.isNaN(lastSeq)) seq = lastSeq + 1;
+    }
+    return `${prefix}-${String(seq).padStart(4, '0')}`;
   }
 
   /** Resolve company id (defaults to first active company if not provided) */
@@ -1069,43 +1087,41 @@ export class JournalAutoService {
       },
     };
 
-    const lines = await this.prisma.journalLine.findMany({
+    // Aggregate at the DB level — full table scan into memory was OOM-prone at scale.
+    const grouped = await this.prisma.journalLine.groupBy({
+      by: ['accountCode'],
       where,
-      select: { accountCode: true, debit: true, credit: true },
+      _sum: { debit: true, credit: true },
     });
 
-    const accountMap = new Map<string, { totalDebit: Prisma.Decimal; totalCredit: Prisma.Decimal }>();
-    for (const line of lines) {
-      const acc = accountMap.get(line.accountCode) || {
-        totalDebit: new Prisma.Decimal(0),
-        totalCredit: new Prisma.Decimal(0),
-      };
-      acc.totalDebit = acc.totalDebit.add(new Prisma.Decimal(line.debit ?? 0));
-      acc.totalCredit = acc.totalCredit.add(new Prisma.Decimal(line.credit ?? 0));
-      accountMap.set(line.accountCode, acc);
-    }
-
-    const codes = Array.from(accountMap.keys());
+    const codes = grouped.map((g) => g.accountCode);
+    // Scope chart lookup by companyId — same code (e.g. 11-1101 Cash) can exist in
+    // both SHOP and FINANCE charts with different names. Without the scope, names
+    // would be silently mislabelled when one entity's row overwrites the other's.
     const chartAccounts = codes.length > 0
       ? await this.prisma.chartOfAccount.findMany({
-          where: { code: { in: codes } },
+          where: {
+            code: { in: codes },
+            ...(filters.companyId ? { companyId: filters.companyId } : {}),
+          },
           select: { code: true, nameTh: true, accountGroup: true },
         })
       : [];
 
     const chartMap = new Map(chartAccounts.map((a) => [a.code, a]));
 
-    const accounts = codes
-      .map((code) => {
-        const sums = accountMap.get(code)!;
-        const chart = chartMap.get(code);
+    const accounts = grouped
+      .map((g) => {
+        const totalDebit = new Prisma.Decimal(g._sum.debit ?? 0);
+        const totalCredit = new Prisma.Decimal(g._sum.credit ?? 0);
+        const chart = chartMap.get(g.accountCode);
         return {
-          code,
+          code: g.accountCode,
           nameTh: chart?.nameTh || '(ไม่พบในผังบัญชี)',
           accountGroup: chart?.accountGroup || 'UNKNOWN',
-          totalDebit: sums.totalDebit.toDecimalPlaces(2).toNumber(),
-          totalCredit: sums.totalCredit.toDecimalPlaces(2).toNumber(),
-          balance: sums.totalDebit.sub(sums.totalCredit).toDecimalPlaces(2).toNumber(),
+          totalDebit: totalDebit.toDecimalPlaces(2).toNumber(),
+          totalCredit: totalCredit.toDecimalPlaces(2).toNumber(),
+          balance: totalDebit.sub(totalCredit).toDecimalPlaces(2).toNumber(),
         };
       })
       .sort((a, b) => a.code.localeCompare(b.code));

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -359,6 +359,165 @@ export class JournalAutoService {
   }
 
   /**
+   * Phase A.1c — Early payoff JE (handles discount).
+   *
+   * When a customer closes their contract early with a discount, the
+   * collected cash is LESS than the sum of remaining installments. The
+   * principal must always be settled in full (otherwise HP Receivable
+   * stays inflated and the device remains on the FINANCE balance sheet).
+   * The discount is absorbed by reducing recognised interest, commission,
+   * and VAT proportionally.
+   *
+   * FINANCE entry:
+   *   Dr. Cash (FINANCE)               [totalPayoff incl. late fees]
+   *     Cr. HP Receivable               [sum of remaining principal]
+   *     Cr. Interest Income             [scaled-down interest]
+   *     Cr. VAT Output                  [scaled-down VAT]
+   *     Cr. Late Fee Income             [unpaid late fees]
+   *     Cr. Due-to-SHOP                 [scaled-down commission, if > 0]
+   *
+   * SHOP entry (only when commission > 0):
+   *   Dr. Due-from-FINANCE              [commission]
+   *     Cr. Commission Income           [commission]
+   *
+   * Linked via [IC-<uuid>] description prefix.
+   *
+   * Caller is responsible for updating Payment rows; this method only posts
+   * the aggregated JE for the whole payoff.
+   */
+  async createEarlyPayoffJournal(
+    tx: Prisma.TransactionClient,
+    params: {
+      contractId: string;
+      contractNumber: string;
+      installments: Array<{
+        amountDue: Decimal | number | null;
+        amountPaidBefore: Decimal | number | null;
+        monthlyPrincipal: Decimal | number | null;
+        monthlyInterest: Decimal | number | null;
+        monthlyCommission: Decimal | number | null;
+        vatAmount: Decimal | number | null;
+        lateFee: Decimal | number | null;
+        lateFeeWaived: boolean;
+      }>;
+      totalPayoff: Decimal | number; // cash debit, includes late fees
+      userId: string;
+      shopCompanyId?: string | null;
+      financeCompanyId?: string | null;
+      paidDate?: Date | null;
+    },
+  ): Promise<string | null> {
+    const FA = JournalAutoService.FINANCE_ACC;
+    const SA = JournalAutoService.SHOP_ACC;
+
+    const financeCompanyId =
+      params.financeCompanyId ??
+      (
+        await tx.companyInfo.findFirst({
+          where: { companyCode: 'FINANCE', deletedAt: null },
+          select: { id: true },
+        })
+      )?.id ??
+      null;
+    if (!financeCompanyId) {
+      throw new InternalServerErrorException('FINANCE company required for early payoff JE');
+    }
+
+    // Per-installment remaining breakdown — scale by (1 - amountPaidBefore/amountDue).
+    let sumPrincipal = new Prisma.Decimal(0);
+    let sumInterestOrig = new Prisma.Decimal(0);
+    let sumCommissionOrig = new Prisma.Decimal(0);
+    let sumVatOrig = new Prisma.Decimal(0);
+    let sumLateFee = new Prisma.Decimal(0);
+
+    for (const inst of params.installments) {
+      const amountDue = new Prisma.Decimal(inst.amountDue ?? 0);
+      const amountPaidBefore = new Prisma.Decimal(inst.amountPaidBefore ?? 0);
+      const ratioRemaining = amountDue.gt(0)
+        ? Prisma.Decimal.max(0, new Prisma.Decimal(1).sub(amountPaidBefore.div(amountDue)))
+        : new Prisma.Decimal(1);
+      sumPrincipal = sumPrincipal.add(new Prisma.Decimal(inst.monthlyPrincipal ?? 0).mul(ratioRemaining));
+      sumInterestOrig = sumInterestOrig.add(new Prisma.Decimal(inst.monthlyInterest ?? 0).mul(ratioRemaining));
+      sumCommissionOrig = sumCommissionOrig.add(new Prisma.Decimal(inst.monthlyCommission ?? 0).mul(ratioRemaining));
+      sumVatOrig = sumVatOrig.add(new Prisma.Decimal(inst.vatAmount ?? 0).mul(ratioRemaining));
+      if (!inst.lateFeeWaived) {
+        sumLateFee = sumLateFee.add(new Prisma.Decimal(inst.lateFee ?? 0));
+      }
+    }
+
+    sumPrincipal = sumPrincipal.toDecimalPlaces(2);
+    sumLateFee = sumLateFee.toDecimalPlaces(2);
+
+    const cash = new Prisma.Decimal(params.totalPayoff);
+    const cashExclLateFee = cash.sub(sumLateFee);
+    const sumOtherOrig = sumInterestOrig.add(sumCommissionOrig).add(sumVatOrig);
+
+    // Allocate non-principal cash proportionally (reduce interest/commission/vat
+    // by the discount). If breakdown is fully zero (legacy), assign whole non-
+    // principal to interest as fallback.
+    let interestActual = new Prisma.Decimal(0);
+    let commissionActual = new Prisma.Decimal(0);
+    let vatActual = new Prisma.Decimal(0);
+    const nonPrincipalActual = cashExclLateFee.sub(sumPrincipal);
+
+    if (sumOtherOrig.gt(0)) {
+      const scale = nonPrincipalActual.div(sumOtherOrig);
+      interestActual = sumInterestOrig.mul(scale).toDecimalPlaces(2);
+      commissionActual = sumCommissionOrig.mul(scale).toDecimalPlaces(2);
+      vatActual = sumVatOrig.mul(scale).toDecimalPlaces(2);
+      // Absorb rounding residual into interest so the entry balances exactly.
+      const allocated = interestActual.add(commissionActual).add(vatActual);
+      const residual = nonPrincipalActual.sub(allocated);
+      if (!residual.isZero()) {
+        interestActual = interestActual.add(residual).toDecimalPlaces(2);
+      }
+    } else {
+      interestActual = nonPrincipalActual.toDecimalPlaces(2);
+    }
+
+    const intercompanyId = commissionActual.gt(0) ? generateInterCompanyId() : null;
+    const baseDesc = `ปิดสัญญาก่อนกำหนด — สัญญา ${params.contractNumber}`;
+    const entryDate = params.paidDate ?? new Date();
+
+    const financeDesc = intercompanyId
+      ? formatInterCompanyDescription(intercompanyId, `${baseDesc} (FINANCE)`)
+      : baseDesc;
+    const financeEntryId = await this.createAndPost(tx, {
+      companyId: financeCompanyId,
+      entryDate,
+      description: financeDesc,
+      referenceType: 'EARLY_PAYOFF',
+      referenceId: params.contractId,
+      createdById: params.userId,
+      lines: [
+        { accountCode: FA.CASH, description: 'รับชำระปิดก่อนกำหนด', debit: cash.toNumber(), credit: 0 },
+        { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: sumPrincipal.toNumber() },
+        { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interestActual.toNumber() },
+        { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: sumLateFee.toNumber() },
+        { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vatActual.toNumber() },
+        { accountCode: FA.DUE_TO_SHOP, description: 'ค่าคอมมิชชันค้างจ่าย SHOP', debit: 0, credit: commissionActual.toNumber() },
+      ],
+    });
+
+    if (commissionActual.gt(0) && params.shopCompanyId && intercompanyId) {
+      await this.createAndPost(tx, {
+        companyId: params.shopCompanyId,
+        entryDate,
+        description: formatInterCompanyDescription(intercompanyId, `${baseDesc} (SHOP commission)`),
+        referenceType: 'EARLY_PAYOFF',
+        referenceId: params.contractId,
+        createdById: params.userId,
+        lines: [
+          { accountCode: SA.DUE_FROM_FINANCE, description: 'ค่าคอมมิชชันรับจาก FINANCE', debit: commissionActual.toNumber(), credit: 0 },
+          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: commissionActual.toNumber() },
+        ],
+      });
+    }
+
+    return financeEntryId;
+  }
+
+  /**
    * Phase A.1b — Customer Credit overpayment.
    *
    * When a customer pays MORE than amount due, the excess is parked as a


### PR DESCRIPTION
## Summary
4 bug fixes from Phase A.1b post-review (3 commits):

- **C-2** (`bc26c666`): Early payoff JE unbalanced when discount > 0 — customers couldn't close contracts early via discounted payoff
- **C-3** (`546f201f`): Trial balance loaded all journal_lines into memory → OOM at scale
- **C-4** (`546f201f`): Trial balance chart name lookup ignored companyId → name collision when same code exists in both SHOP+FINANCE charts
- **W-3** (`546f201f`): generateEntryNumber count() race-condition under concurrent inserts → duplicate entry_number P2002

## Changes
- New `createEarlyPayoffJournal` posts ONE aggregated JE per payoff. Principal always settled in full (HP Receivable correctness), discount absorbed by proportionally reducing interest+commission+VAT. Paired SHOP commission entry (IC prefix) when commission > 0.
- `contract-payment.service.earlyPayoff`: snapshots breakdowns BEFORE per-row updates, posts new JE once after the loop (replaces N per-installment unbalanced JEs).
- `getTrialBalance`: switched to Prisma `groupBy + _sum` (DB-side aggregation), scoped chart name lookup by companyId.
- `generateEntryNumber`: switched to `SELECT ... FOR UPDATE` pattern (same as receipts.service.generateReceiptNumber) — concurrent generations serialise on last-row lock.

## Verification
- TypeScript: 0 errors (api + web)
- Jest: **2212 tests pass / 187 suites** (+7 new for createEarlyPayoffJournal)
- Lint: clean

## Test plan
- [ ] Production: trigger one real early payoff with discount → verify JE balances + Payment rows updated
- [ ] Production: query journal_entries trial-balance API → confirm groupBy returns correct sums
- [ ] Optional smoke: 2 concurrent JE creates in same minute should produce different entry_numbers (manual test in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)