### PR TITLE
feat(accounting): Phase A.2 — Deferred income (Unearned Interest + Unearned Commission + VAT Pending)

### DIFF
--- a/apps/api/prisma/migrations/20260616000000_add_unearned_income_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260616000000_add_unearned_income_fields/migration.sql
@@ -1,0 +1,25 @@
+-- Phase A.2 — Deferred income tracking on Contract.
+-- Stores the unrecognised portion of interest + commission per contract.
+-- Activation: unearnedInterest = interestTotal, unearnedCommission = storeCommission.
+-- Each payment moves the monthly slice from Unearned (Cr) to Earned (Cr Income).
+
+ALTER TABLE "contracts"
+  ADD COLUMN "unearned_interest"   DECIMAL(12, 2) NOT NULL DEFAULT 0,
+  ADD COLUMN "unearned_commission" DECIMAL(12, 2) NOT NULL DEFAULT 0;
+
+-- Backfill ACTIVE/OVERDUE/DEFAULT contracts: unearned = total - already-earned-portion.
+-- "Already earned" approximated as (paid_count / total_months) * total. Pre-Phase-A.2
+-- JEs were buggy (double-counted), so this is the cleanest heuristic for the new
+-- per-payment recognition to take over from. Fully PAID/COMPLETED contracts get 0.
+UPDATE "contracts" c
+SET
+  "unearned_interest"   = GREATEST(0, c."interest_total"   - COALESCE((
+    SELECT SUM(p."monthly_interest") FROM "payments" p
+    WHERE p."contract_id" = c."id" AND p."status" = 'PAID' AND p."deleted_at" IS NULL
+  ), 0)),
+  "unearned_commission" = GREATEST(0, COALESCE(c."store_commission", 0) - COALESCE((
+    SELECT SUM(p."monthly_commission") FROM "payments" p
+    WHERE p."contract_id" = c."id" AND p."status" = 'PAID' AND p."deleted_at" IS NULL
+  ), 0))
+WHERE c."status" IN ('ACTIVE', 'OVERDUE', 'DEFAULT')
+  AND c."deleted_at" IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -830,6 +830,13 @@ model Contract {
   interestTotal    Decimal        @map("interest_total") @db.Decimal(12, 2)
   financedAmount   Decimal        @map("financed_amount") @db.Decimal(12, 2)
   storeCommission  Decimal?       @map("store_commission") @db.Decimal(12, 2)
+  // Phase A.2 — Deferred income tracking. At activation: unearnedInterest =
+  // interestTotal, unearnedCommission = storeCommission. Each payment moves
+  // monthlyInterest/monthlyCommission from Unearned (Cr Unearned acct) to
+  // Earned (Cr Income acct). Recognises revenue cash-basis per TFRS for NPAEs
+  // instead of double-counting at activation + per payment.
+  unearnedInterest    Decimal @default(0) @map("unearned_interest") @db.Decimal(12, 2)
+  unearnedCommission  Decimal @default(0) @map("unearned_commission") @db.Decimal(12, 2)
   vatAmount        Decimal?       @map("vat_amount") @db.Decimal(12, 2)
   vatPct           Decimal?       @map("vat_pct") @db.Decimal(5, 4)
   monthlyPayment   Decimal        @map("monthly_payment") @db.Decimal(12, 2)

--- a/apps/api/prisma/seeds/chart-of-accounts.ts
+++ b/apps/api/prisma/seeds/chart-of-accounts.ts
@@ -96,7 +96,8 @@ export async function seedChartOfAccounts(prisma: PrismaClient): Promise<void> {
 
   await seedFinanceChartOfAccounts(prisma, financeCompany.id);
 
-  // SHOP-side accounts required by Phase A.1b inter-company JEs.
+  // SHOP-side accounts required by Phase A.1b inter-company JEs +
+  // Phase A.2 unearned commission deferred recognition.
   // Owner CSV does not include these — explicit upserts ensure they exist.
   const shopExtraAccounts: Array<{
     code: string;
@@ -118,6 +119,13 @@ export async function seedChartOfAccounts(prisma: PrismaClient): Promise<void> {
       nameEn: 'Commission Income from FINANCE',
       accountGroup: AccountGroup.REVENUE,
       parentCode: '42-11XX',
+    },
+    {
+      code: '21-2201',
+      nameTh: 'รายได้ค่านายหน้ารอตัดบัญชี (Unearned Commission)',
+      nameEn: 'Unearned Commission Income',
+      accountGroup: AccountGroup.LIABILITY,
+      parentCode: '21-22XX',
     },
   ];
 

--- a/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
@@ -166,11 +166,11 @@ describe('ContractWorkflowService', () => {
     it('activates a fully-approved DRAFT contract and writes the activation JE', async () => {
       await service.activate('contract-1');
 
-      // Contract status flipped to ACTIVE inside the tx
+      // Contract status flipped to ACTIVE + Phase A.2 unearned fields seeded
       expect(prisma.contract.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: 'contract-1' },
-          data: { status: 'ACTIVE' },
+          data: expect.objectContaining({ status: 'ACTIVE' }),
         }),
       );
       // JE was created

--- a/apps/api/src/modules/contracts/contract-workflow.service.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.ts
@@ -397,8 +397,17 @@ export class ContractWorkflowService {
       if (!prod || (prod.status !== 'RESERVED' && prod.status !== 'IN_STOCK')) {
         throw new BadRequestException('สินค้าไม่พร้อมสำหรับเปิดสัญญา (อาจถูกขายหรือลบไปแล้ว)');
       }
-      // Step 8: สถานะเปลี่ยนเป็น ACTIVE → เริ่มนับงวด
-      await tx.contract.update({ where: { id }, data: { status: 'ACTIVE' } });
+      // Step 8: สถานะเปลี่ยนเป็น ACTIVE → เริ่มนับงวด.
+      // Phase A.2: also seed unearnedInterest + unearnedCommission so payment
+      // JEs can drain them (deferred recognition cash-basis per TFRS NPAEs).
+      await tx.contract.update({
+        where: { id },
+        data: {
+          status: 'ACTIVE',
+          unearnedInterest: contract.interestTotal,
+          unearnedCommission: contract.storeCommission ?? 0,
+        },
+      });
       await tx.product.update({ where: { id: contract.productId }, data: { status: 'SOLD_INSTALLMENT' } });
 
       // Ownership transfer: SHOP → FINANCE.

--- a/apps/api/src/modules/data-audit/data-audit.service.ts
+++ b/apps/api/src/modules/data-audit/data-audit.service.ts
@@ -1180,6 +1180,7 @@ export class DataAuditService {
                   paidDate: payment.paidDate,
                 },
                 contract: {
+                  id: contract.id,
                   contractNumber: contract.contractNumber,
                   branchId: contract.branchId,
                 },

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -57,6 +57,8 @@ describe('JournalAutoService', () => {
           storeCommission: { toNumber: () => 300 },
           vatAmount: { toNumber: () => 700 },
         }),
+        // Phase A.2 — contract.unearnedInterest/Commission decrement after each JE
+        update: jest.fn().mockResolvedValue({ id: 'contract-1' }),
       },
       $transaction: jest.fn().mockImplementation(async (fn: unknown) => {
         if (typeof fn === 'function') {
@@ -93,24 +95,46 @@ describe('JournalAutoService', () => {
   }
 
   describe('createAndPost — balance validation', () => {
-    it('payment JE always balances by construction (Phase A.2: HP Receivable absorbs breakdown mismatch)', async () => {
-      // Phase A.2: payment JE drains HP Receivable by amountPaid - lateFee, so
-      // the JE is balanced regardless of whether breakdown components match
-      // amountPaid. Independent JE balance enforcement comes from createAndPost.
+    it('throws when payment breakdown drifts from amountPaid (Phase A.2 data-integrity guard)', async () => {
+      // breakdown sums to 5950 but amountPaid is 9999. Phase A.2 added an
+      // explicit drift check + Sentry alarm so corrupt upstream data doesn't
+      // silently over-drain HP Receivable.
+      const tx = prisma;
+      await expect(
+        service.createPaymentJournal(tx, {
+          payment: {
+            id: 'pay-1',
+            installmentNo: 1,
+            amountPaid: 9999,
+            monthlyPrincipal: 5000,
+            monthlyInterest: 500,
+            monthlyCommission: 100,
+            vatAmount: 300,
+            lateFee: 50,
+            lateFeeWaived: false,
+          },
+          contract: { contractNumber: 'BC-202601-0001', branchId: 'branch-1' },
+          userId: 'user-1',
+          companyId: 'company-1',
+        }),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('passes when breakdown sums to amountPaid (within 0.02 tolerance)', async () => {
       const tx = prisma;
       const result = await service.createPaymentJournal(tx, {
         payment: {
-          id: 'pay-1',
+          id: 'pay-2',
           installmentNo: 1,
-          amountPaid: 9999,
-          monthlyPrincipal: 5000,
-          monthlyInterest: 500,
-          monthlyCommission: 100,
-          vatAmount: 300,
-          lateFee: 50,
+          amountPaid: 1500,
+          monthlyPrincipal: 1000,
+          monthlyInterest: 100,
+          monthlyCommission: 300,
+          vatAmount: 100,
+          lateFee: 0,
           lateFeeWaived: false,
         },
-        contract: { contractNumber: 'BC-202601-0001', branchId: 'branch-1' },
+        contract: { contractNumber: 'BC-202601-0002', branchId: 'branch-1' },
         userId: 'user-1',
         companyId: 'company-1',
       });

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -93,29 +93,30 @@ describe('JournalAutoService', () => {
   }
 
   describe('createAndPost — balance validation', () => {
-    it('should throw InternalServerErrorException when Dr != Cr', async () => {
+    it('payment JE always balances by construction (Phase A.2: HP Receivable absorbs breakdown mismatch)', async () => {
+      // Phase A.2: payment JE drains HP Receivable by amountPaid - lateFee, so
+      // the JE is balanced regardless of whether breakdown components match
+      // amountPaid. Independent JE balance enforcement comes from createAndPost.
       const tx = prisma;
-
-      // amountPaid (Dr) = 9999, but Cr side = principal(5000) + interest(500) + commission(100) + vat(300) + lateFee(50) = 5950
-      // Mismatch → should throw
-      await expect(
-        service.createPaymentJournal(tx, {
-          payment: {
-            id: 'pay-1',
-            installmentNo: 1,
-            amountPaid: 9999,
-            monthlyPrincipal: 5000,
-            monthlyInterest: 500,
-            monthlyCommission: 100,
-            vatAmount: 300,
-            lateFee: 50,
-            lateFeeWaived: false,
-          },
-          contract: { contractNumber: 'BC-202601-0001', branchId: 'branch-1' },
-          userId: 'user-1',
-          companyId: 'company-1',
-        }),
-      ).rejects.toThrow(InternalServerErrorException);
+      const result = await service.createPaymentJournal(tx, {
+        payment: {
+          id: 'pay-1',
+          installmentNo: 1,
+          amountPaid: 9999,
+          monthlyPrincipal: 5000,
+          monthlyInterest: 500,
+          monthlyCommission: 100,
+          vatAmount: 300,
+          lateFee: 50,
+          lateFeeWaived: false,
+        },
+        contract: { contractNumber: 'BC-202601-0001', branchId: 'branch-1' },
+        userId: 'user-1',
+        companyId: 'company-1',
+      });
+      expect(result).toBeTruthy();
+      const lines = capturedLines();
+      expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
     });
 
     it('should return null when all lines are zero (no journal needed)', async () => {
@@ -346,7 +347,7 @@ describe('JournalAutoService', () => {
       expect(Number(hpLine?.debit)).toBeCloseTo(11600, 2);
     });
 
-    it('credits VAT_OUTPUT with vatAmount on FINANCE side', async () => {
+    it('credits VAT_OUTPUT_PENDING with vatAmount on FINANCE side (Phase A.2 deferred VAT)', async () => {
       prisma.companyInfo.findFirst = jest.fn().mockImplementation((args: any) => {
         if (args?.where?.companyCode === 'SHOP') return Promise.resolve({ id: 'co-SHOP' });
         if (args?.where?.companyCode === 'FINANCE') return Promise.resolve({ id: 'co-FINANCE' });
@@ -367,8 +368,11 @@ describe('JournalAutoService', () => {
         credit: number;
       }>;
 
-      const vatLine = lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT);
-      expect(Number(vatLine?.credit)).toBeCloseTo(1000, 2);
+      const vatPendingLine = lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT_PENDING);
+      expect(Number(vatPendingLine?.credit)).toBeCloseTo(1000, 2);
+      // VAT Output (PP.30) should NOT be credited at activation — only at payment.
+      const vatOutputLine = lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT);
+      expect(vatOutputLine).toBeUndefined();
     });
 
     it('always creates 2 paired entries (SHOP + FINANCE) regardless of cost', async () => {
@@ -536,7 +540,7 @@ describe('JournalAutoService', () => {
         expect(shopDueFrom).toBeCloseTo(10500, 2);
       });
 
-      it('SHOP entry contains revenue + commission + COGS lines', async () => {
+      it('SHOP entry contains revenue + Unearned Commission + COGS lines (Phase A.2)', async () => {
         await service.createContractActivationJournal(prisma, {
           contract: {
             id: 'c2',
@@ -560,12 +564,14 @@ describe('JournalAutoService', () => {
 
         expect(Number(lines.find((l) => l.accountCode === JournalAutoService.SHOP_ACC.CASH)?.debit)).toBeCloseTo(1000, 2);
         expect(Number(lines.find((l) => l.accountCode === JournalAutoService.SHOP_ACC.REVENUE_NEW)?.credit)).toBeCloseTo(11000, 2);
-        expect(Number(lines.find((l) => l.accountCode === JournalAutoService.SHOP_ACC.COMMISSION_INCOME)?.credit)).toBeCloseTo(500, 2);
+        // Phase A.2: commission deferred to Unearned, NOT recognised as Income at activation.
+        expect(Number(lines.find((l) => l.accountCode === JournalAutoService.SHOP_ACC.UNEARNED_COMMISSION)?.credit)).toBeCloseTo(500, 2);
+        expect(lines.find((l) => l.accountCode === JournalAutoService.SHOP_ACC.COMMISSION_INCOME)).toBeUndefined();
         expect(Number(lines.find((l) => l.accountCode === JournalAutoService.SHOP_ACC.COGS_NEW)?.debit)).toBeCloseTo(8000, 2);
         expect(Number(lines.find((l) => l.accountCode === JournalAutoService.SHOP_ACC.INVENTORY_NEW)?.credit)).toBeCloseTo(8000, 2);
       });
 
-      it('FINANCE entry contains HP receivable + interest + VAT lines (no cash, no revenue)', async () => {
+      it('FINANCE entry contains HP receivable + Unearned Interest + VAT Pending lines (Phase A.2)', async () => {
         await service.createContractActivationJournal(prisma, {
           contract: {
             id: 'c3',
@@ -588,8 +594,12 @@ describe('JournalAutoService', () => {
         const lines = financeEntry.lines.create as Array<{ accountCode: string; debit: unknown; credit: unknown }>;
 
         expect(Number(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.HP_RECEIVABLE)?.debit)).toBeCloseTo(12305, 2);
-        expect(Number(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.INTEREST_INCOME)?.credit)).toBeCloseTo(1000, 2);
-        expect(Number(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT)?.credit)).toBeCloseTo(805, 2);
+        // Phase A.2: interest deferred to Unearned, NOT recognised as Income at activation.
+        expect(Number(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.UNEARNED_INTEREST)?.credit)).toBeCloseTo(1000, 2);
+        expect(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.INTEREST_INCOME)).toBeUndefined();
+        // Phase A.2: VAT deferred to Pending, NOT VAT Output at activation.
+        expect(Number(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT_PENDING)?.credit)).toBeCloseTo(805, 2);
+        expect(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.VAT_OUTPUT)).toBeUndefined();
         // No cash on FINANCE side
         expect(lines.find((l) => l.accountCode === JournalAutoService.FINANCE_ACC.CASH)).toBeUndefined();
       });
@@ -641,7 +651,7 @@ describe('JournalAutoService', () => {
       });
     });
 
-    it('creates FINANCE payment entry + SHOP commission entry when commission > 0', async () => {
+    it('creates FINANCE payment entry + SHOP commission entry when commission > 0 (Phase A.2)', async () => {
       await service.createPaymentJournal(prisma, {
         payment: {
           id: 'p1',
@@ -665,19 +675,32 @@ describe('JournalAutoService', () => {
 
       const financeEntry = captured.find((e) => e.companyId === 'co-FINANCE');
       expect(financeEntry).toBeTruthy();
-      // Due-to-SHOP credit for commission
-      const dueToShopLine = financeEntry!.lines.find((l) => l.accountCode === '21-1102');
-      expect(dueToShopLine!.credit).toBeCloseTo(300, 2);
-      // HP Receivable credit = principal only (no commission fold)
+      // Phase A.2: HP Receivable credit = full installment (amountPaid - lateFee)
       const hpRecvLine = financeEntry!.lines.find((l) => l.accountCode === '11-2102');
-      expect(hpRecvLine!.credit).toBeCloseTo(1000, 2);
+      expect(hpRecvLine!.credit).toBeCloseTo(1500, 2);
+      // Phase A.2: Unearned Interest debited (recognised as earned)
+      const unearnedInterestLine = financeEntry!.lines.find((l) => l.accountCode === '21-2202');
+      expect(unearnedInterestLine!.debit).toBeCloseTo(100, 2);
+      const interestIncomeLine = financeEntry!.lines.find((l) => l.accountCode === '42-2101');
+      expect(interestIncomeLine!.credit).toBeCloseTo(100, 2);
+      // Phase A.2: VAT Pending debited, VAT Output credited
+      const vatPendingLine = financeEntry!.lines.find((l) => l.accountCode === '21-2102');
+      expect(vatPendingLine!.debit).toBeCloseTo(100, 2);
+      const vatOutputLine = financeEntry!.lines.find((l) => l.accountCode === '21-2101');
+      expect(vatOutputLine!.credit).toBeCloseTo(100, 2);
+      // Phase A.2: Due-to-SHOP NOT touched at payment (already accrued at activation)
+      const dueToShopLine = financeEntry!.lines.find((l) => l.accountCode === '21-1102');
+      expect(dueToShopLine).toBeUndefined();
 
       const shopEntry = captured.find((e) => e.companyId === 'co-SHOP');
       expect(shopEntry).toBeTruthy();
-      const dueFromFinanceLine = shopEntry!.lines.find((l) => l.accountCode === '11-2105');
-      expect(dueFromFinanceLine!.debit).toBeCloseTo(300, 2);
+      // Phase A.2: SHOP recognises commission via Unearned drain (not Due-from-FINANCE)
+      const unearnedCommissionLine = shopEntry!.lines.find((l) => l.accountCode === '21-2201');
+      expect(unearnedCommissionLine!.debit).toBeCloseTo(300, 2);
       const commissionLine = shopEntry!.lines.find((l) => l.accountCode === '42-1105');
       expect(commissionLine!.credit).toBeCloseTo(300, 2);
+      const dueFromFinanceLine = shopEntry!.lines.find((l) => l.accountCode === '11-2105');
+      expect(dueFromFinanceLine).toBeUndefined();
 
       // Both share IC prefix
       expect(financeEntry!.description).toMatch(/^\[IC-/);
@@ -889,17 +912,20 @@ describe('JournalAutoService', () => {
       const cashLine = financeEntry!.lines.find((l) => l.accountCode === '11-1101');
       expect(cashLine).toBeUndefined();
 
-      // HP Receivable credited for principal
+      // Phase A.2: HP Receivable credited for full installment (amountPaid - lateFee)
       const hpLine = financeEntry!.lines.find((l) => l.accountCode === '11-2102');
-      expect(hpLine!.credit).toBeCloseTo(1000, 2);
+      expect(hpLine!.credit).toBeCloseTo(1500, 2);
 
-      // SHOP entry created for commission
+      // SHOP entry: Unearned Commission drained (Phase A.2)
       const shopEntry = captured.find((e) => e.companyId === 'co-SHOP');
       expect(shopEntry).toBeTruthy();
-      const dueFromFinanceLine = shopEntry!.lines.find((l) => l.accountCode === '11-2105');
-      expect(dueFromFinanceLine!.debit).toBeCloseTo(300, 2);
+      const unearnedCommissionLine = shopEntry!.lines.find((l) => l.accountCode === '21-2201');
+      expect(unearnedCommissionLine!.debit).toBeCloseTo(300, 2);
       const commissionLine = shopEntry!.lines.find((l) => l.accountCode === '42-1105');
       expect(commissionLine!.credit).toBeCloseTo(300, 2);
+      // Phase A.2: no Due-from-FINANCE at payment (already established at activation)
+      const dueFromFinanceLine = shopEntry!.lines.find((l) => l.accountCode === '11-2105');
+      expect(dueFromFinanceLine).toBeUndefined();
 
       // Both share IC prefix
       expect(financeEntry!.description).toMatch(/^\[IC-/);
@@ -1489,7 +1515,7 @@ describe('JournalAutoService', () => {
       };
     }
 
-    it('balances when no discount (cash = sum of all components)', async () => {
+    it('balances when no discount (cash = sum of all components) — Phase A.2', async () => {
       const insts = [makeInst(), makeInst(), makeInst()]; // 3 × 1000 = 3000 owed
       await service.createEarlyPayoffJournal(prisma, {
         contractId: 'c-1', contractNumber: 'CNT-001',
@@ -1500,12 +1526,16 @@ describe('JournalAutoService', () => {
       expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
       const cashLine = lines.find((l) => l.accountCode === '11-1101');
       expect(Number(cashLine!.debit)).toBeCloseTo(3000, 2);
+      // Phase A.2: HP Receivable drains by full owed (sumPrincipal + interest + commission + VAT)
       const hpLine = lines.find((l) => l.accountCode === '11-2102');
-      expect(Number(hpLine!.credit)).toBeCloseTo(2400, 2); // 3 × 800
+      expect(Number(hpLine!.credit)).toBeCloseTo(3000, 2);
+      // Unearned Interest drained = sumInterestOrig (3 × 100 = 300)
+      const unearnedInterestLine = lines.find((l) => l.accountCode === '21-2202');
+      expect(Number(unearnedInterestLine!.debit)).toBeCloseTo(300, 2);
     });
 
-    it('balances when discount applied — principal in full, others scaled down', async () => {
-      const insts = [makeInst(), makeInst(), makeInst()]; // owed 3000, principal 2400
+    it('balances when discount applied — principal in full, others scaled down (Phase A.2)', async () => {
+      const insts = [makeInst(), makeInst(), makeInst()]; // owed 3000, principal 2400, others 600
       // 50% discount on grossProfit: discount=300 → totalPayoff=2700
       await service.createEarlyPayoffJournal(prisma, {
         contractId: 'c-1', contractNumber: 'CNT-001',
@@ -1516,13 +1546,16 @@ describe('JournalAutoService', () => {
       expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
       const cashLine = lines.find((l) => l.accountCode === '11-1101');
       expect(Number(cashLine!.debit)).toBeCloseTo(2700, 2);
-      // Principal MUST be settled in full
+      // Phase A.2: HP Receivable drains by full owed regardless of discount
       const hpLine = lines.find((l) => l.accountCode === '11-2102');
-      expect(Number(hpLine!.credit)).toBeCloseTo(2400, 2);
-      // Other 300 split proportionally across interest(300)+commission(150)+vat(150)=600
+      expect(Number(hpLine!.credit)).toBeCloseTo(3000, 2);
+      // Other 300 cash split proportionally across interest(300)+commission(150)+vat(150)=600
       // Scale = 300/600 = 0.5 → interest 150, commission 75, vat 75
       const interestLine = lines.find((l) => l.accountCode === '42-2101');
       expect(Number(interestLine!.credit)).toBeCloseTo(150, 2);
+      // Due-to-SHOP reduces by commission discount (75) — FINANCE owes SHOP less
+      const dueToShopLine = lines.find((l) => l.accountCode === '21-1102');
+      expect(Number(dueToShopLine!.debit)).toBeCloseTo(75, 2);
     });
 
     it('includes late fees in cash + as separate credit line', async () => {
@@ -1538,7 +1571,7 @@ describe('JournalAutoService', () => {
       expect(Number(lateFeeLine!.credit)).toBeCloseTo(200, 2);
     });
 
-    it('handles partial pre-existing pay by scaling remaining breakdown', async () => {
+    it('handles partial pre-existing pay by scaling remaining breakdown (Phase A.2)', async () => {
       // amountDue=1000, amountPaidBefore=400 → 60% remaining
       // Remaining: principal=480, interest=60, commission=30, vat=30 → total=600
       const insts = [makeInst({ amountPaidBefore: 400 })];
@@ -1549,8 +1582,9 @@ describe('JournalAutoService', () => {
       });
       const lines = capturedLines();
       expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
+      // Phase A.2: HP Receivable drains by full remaining owed = 600
       const hpLine = lines.find((l) => l.accountCode === '11-2102');
-      expect(Number(hpLine!.credit)).toBeCloseTo(480, 2);
+      expect(Number(hpLine!.credit)).toBeCloseTo(600, 2);
     });
 
     it('falls back to interest-only when breakdown is zero (legacy data)', async () => {
@@ -1599,6 +1633,146 @@ describe('JournalAutoService', () => {
       const icMatch = financeCall!.description.match(/\[IC-([0-9a-f-]+)\]/);
       expect(icMatch).not.toBeNull();
       expect(shopCall!.description).toContain(icMatch![0]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Phase A.2 — End-to-end deferred recognition lifecycle
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('Phase A.2 — Deferred recognition lifecycle invariants', () => {
+    let captured: Array<{
+      companyId: string;
+      lines: Array<{ accountCode: string; debit: number; credit: number }>;
+    }>;
+
+    beforeEach(() => {
+      captured = [];
+      prisma.journalEntry.create.mockImplementation((args: any) => {
+        const data = args.data;
+        captured.push({
+          companyId: data.companyId,
+          lines: (data.lines.create as Array<{ accountCode: string; debit: unknown; credit: unknown }>).map((l) => ({
+            accountCode: l.accountCode,
+            debit: Number(l.debit ?? 0),
+            credit: Number(l.credit ?? 0),
+          })),
+        });
+        return Promise.resolve({ id: `je-${captured.length}` });
+      });
+      prisma.companyInfo.findFirst = jest.fn().mockImplementation((args: any) => {
+        if (args?.where?.companyCode === 'SHOP') return Promise.resolve({ id: 'co-SHOP' });
+        if (args?.where?.companyCode === 'FINANCE') return Promise.resolve({ id: 'co-FINANCE' });
+        return Promise.resolve(null);
+      });
+    });
+
+    function netBalance(company: string, accountCode: string): number {
+      const lines = captured.filter((c) => c.companyId === company).flatMap((c) => c.lines);
+      return lines
+        .filter((l) => l.accountCode === accountCode)
+        .reduce((sum, l) => sum + (l.debit || 0) - (l.credit || 0), 0);
+    }
+
+    it('full contract: activation + 12 payments → all deferred accounts drain to 0', async () => {
+      const sellingPrice = 11000;
+      const downPayment = 1000;
+      const principal = sellingPrice - downPayment; // 10000
+      const interestTotal = 1200;
+      const storeCommission = 600;
+      const vatAmount = 0;
+      const financedAmount = principal + storeCommission + interestTotal + vatAmount; // 11800
+      const totalMonths = 12;
+      const monthlyPayment = financedAmount / totalMonths; // 983.33
+      const monthlyPrincipal = principal / totalMonths; // 833.33
+      const monthlyInterest = interestTotal / totalMonths; // 100
+      const monthlyCommission = storeCommission / totalMonths; // 50
+      const monthlyVat = vatAmount / totalMonths;
+
+      // Activation
+      await service.createContractActivationJournal(prisma, {
+        contract: {
+          id: 'c-lifecycle',
+          contractNumber: 'CT-LIFECYCLE',
+          sellingPrice,
+          downPayment,
+          financedAmount,
+          interestTotal,
+          storeCommission,
+          vatAmount,
+        },
+        product: { costPrice: 8000, category: 'NEW_PHONE' },
+        userId: 'u-1',
+        shopCompanyId: 'co-SHOP',
+        financeCompanyId: 'co-FINANCE',
+      });
+
+      // 12 payments
+      for (let i = 1; i <= totalMonths; i++) {
+        await service.createPaymentJournal(prisma, {
+          payment: {
+            id: `p-${i}`,
+            installmentNo: i,
+            amountPaid: monthlyPayment,
+            monthlyPrincipal,
+            monthlyInterest,
+            monthlyCommission,
+            vatAmount: monthlyVat,
+            lateFee: 0,
+            lateFeeWaived: false,
+            paidDate: new Date(),
+          },
+          contract: { contractNumber: 'CT-LIFECYCLE', branchId: 'b-1' },
+          userId: 'u-1',
+          shopCompanyId: 'co-SHOP',
+          financeCompanyId: 'co-FINANCE',
+        });
+      }
+
+      // FINANCE invariants:
+      expect(netBalance('co-FINANCE', '11-2102')).toBeCloseTo(0, 2); // HP Receivable drained
+      expect(netBalance('co-FINANCE', '21-2202')).toBeCloseTo(0, 2); // Unearned Interest drained
+      expect(netBalance('co-FINANCE', '21-2102')).toBeCloseTo(0, 2); // VAT Pending drained
+      expect(netBalance('co-FINANCE', '11-1101')).toBeCloseTo(financedAmount, 2); // Cash collected = full
+      expect(netBalance('co-FINANCE', '42-2101')).toBeCloseTo(-interestTotal, 2); // Interest Income = total (Cr is negative balance)
+
+      // Due-to-SHOP unchanged from activation (awaits W-5 settlement)
+      const expectedDueToShop = -(sellingPrice + storeCommission - downPayment); // Cr balance
+      expect(netBalance('co-FINANCE', '21-1102')).toBeCloseTo(expectedDueToShop, 2);
+
+      // SHOP invariants:
+      expect(netBalance('co-SHOP', '21-2201')).toBeCloseTo(0, 2); // Unearned Commission drained
+      expect(netBalance('co-SHOP', '42-1105')).toBeCloseTo(-storeCommission, 2); // Commission Income = total (Cr)
+
+      // Every JE must balance individually
+      for (const entry of captured) {
+        const dr = entry.lines.reduce((s, l) => s + (l.debit || 0), 0);
+        const cr = entry.lines.reduce((s, l) => s + (l.credit || 0), 0);
+        expect(Math.abs(dr - cr)).toBeLessThan(0.01);
+      }
+    });
+
+    it('inter-company invariant holds: SHOP Due-from-FINANCE == FINANCE Due-to-SHOP', async () => {
+      // Activation (SHOP debits Due-from, FINANCE credits Due-to)
+      await service.createContractActivationJournal(prisma, {
+        contract: {
+          id: 'c-ic',
+          contractNumber: 'CT-IC',
+          sellingPrice: 11000,
+          downPayment: 1000,
+          financedAmount: 11800,
+          interestTotal: 1200,
+          storeCommission: 600,
+          vatAmount: 0,
+        },
+        product: { costPrice: 8000, category: 'NEW_PHONE' },
+        userId: 'u-1',
+        shopCompanyId: 'co-SHOP',
+        financeCompanyId: 'co-FINANCE',
+      });
+
+      const shopDueFrom = netBalance('co-SHOP', '11-2105');     // Asset (Dr balance positive)
+      const financeDueTo = -netBalance('co-FINANCE', '21-1102'); // Liability (Cr balance flipped)
+      expect(Math.abs(shopDueFrom - financeDueTo)).toBeLessThan(0.01);
     });
   });
 

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -259,7 +259,7 @@ export class JournalAutoService {
         lateFeeWaived?: boolean;
         paidDate?: Date | null;
       };
-      contract: { contractNumber: string; branchId?: string | null };
+      contract: { id?: string; contractNumber: string; branchId?: string | null };
       userId: string;
       /** @deprecated Phase A.1b — use `financeCompanyId` instead. Accepted as alias. */
       companyId?: string | null;
@@ -313,9 +313,24 @@ export class JournalAutoService {
     // (principal + commission + interest + VAT) at activation. Each payment
     // drains the receivable by the installment portion of cash received
     // (= amountPaid - lateFee). Late fees are recognised as separate income.
-    const isZeroBreakdown =
-      principal.isZero() && interest.isZero() && commission.isZero() && vat.isZero() && lateFee.isZero();
-    const hpReceivableCredit = isZeroBreakdown ? amountPaid.sub(lateFee) : amountPaid.sub(lateFee);
+    const hpReceivableCredit = amountPaid.sub(lateFee);
+
+    // Data-integrity check: when a non-zero breakdown is supplied, it must
+    // sum to amountPaid (else upstream is corrupt — e.g. legacy import or a
+    // manual adjustment). The JE balances by construction, but we still
+    // throw + Sentry-alarm so the bad data doesn't drain HP Receivable
+    // incorrectly downstream. Tolerance 0.02 absorbs Decimal rounding.
+    const breakdownSum = principal.add(interest).add(commission).add(vat).add(lateFee);
+    const hasBreakdown = !breakdownSum.isZero();
+    if (hasBreakdown && breakdownSum.minus(amountPaid).abs().toNumber() > 0.02) {
+      const msg = `Payment breakdown drift for ${params.payment.id}: sum=${breakdownSum.toFixed(2)} ≠ amountPaid=${amountPaid.toFixed(2)}`;
+      this.logger.error(msg);
+      Sentry.captureException(new Error(msg), {
+        tags: { kind: 'payment-breakdown-drift' },
+        extra: { paymentId: params.payment.id, breakdownSum: breakdownSum.toFixed(2), amountPaid: amountPaid.toFixed(2) },
+      });
+      throw new InternalServerErrorException(msg);
+    }
 
     const intercompanyId = commission.gt(0) ? generateInterCompanyId() : null;
     const baseDesc = `รับชำระค่างวด งวดที่ ${params.payment.installmentNo} สัญญา ${params.contract.contractNumber}`;
@@ -365,35 +380,56 @@ export class JournalAutoService {
       });
     }
 
+    // Phase A.2: keep Contract.unearnedInterest / unearnedCommission in sync
+    // with the JE ledger. Caller can read these fields without a groupBy
+    // query (used by early-payoff calc + dashboard reporting).
+    if (params.contract.id && (interest.gt(0) || commission.gt(0))) {
+      await tx.contract.update({
+        where: { id: params.contract.id },
+        data: {
+          ...(interest.gt(0) ? { unearnedInterest: { decrement: interest } } : {}),
+          ...(commission.gt(0) ? { unearnedCommission: { decrement: commission } } : {}),
+        },
+      });
+    }
+
     return financeEntryId;
   }
 
   /**
-   * Phase A.1c — Early payoff JE (handles discount).
+   * Phase A.2 — Early payoff JE with deferred-recognition handling.
    *
    * When a customer closes their contract early with a discount, the
-   * collected cash is LESS than the sum of remaining installments. The
-   * principal must always be settled in full (otherwise HP Receivable
-   * stays inflated and the device remains on the FINANCE balance sheet).
-   * The discount is absorbed by reducing recognised interest, commission,
-   * and VAT proportionally.
+   * collected cash is LESS than the sum of remaining installments. HP
+   * Receivable was loaded in full at activation (principal + commission +
+   * interest + VAT) so we drain it by the full owed for the unpaid
+   * installments — irrespective of discount. The discount is absorbed by
+   * recognising LESS Interest Income / VAT Output than the full Unearned
+   * drain, plus reducing Due-to-SHOP for the commission discount portion.
    *
    * FINANCE entry:
    *   Dr. Cash (FINANCE)               [totalPayoff incl. late fees]
-   *     Cr. HP Receivable               [sum of remaining principal]
-   *     Cr. Interest Income             [scaled-down interest]
-   *     Cr. VAT Output                  [scaled-down VAT]
+   *   Dr. Unearned Interest            [sumInterestOrig — full deferred drain]
+   *   Dr. VAT Pending                  [sumVatOrig — full deferred drain]
+   *   Dr. Due-to-SHOP                  [commissionDiscount — only if > 0]
+   *     Cr. HP Receivable               [sumOwedExclLateFee — full installments]
+   *     Cr. Interest Income             [interestActual — earned portion only]
+   *     Cr. VAT Output (PP.30)          [vatActual — earned portion only]
    *     Cr. Late Fee Income             [unpaid late fees]
-   *     Cr. Due-to-SHOP                 [scaled-down commission, if > 0]
    *
-   * SHOP entry (only when commission > 0):
-   *   Dr. Due-from-FINANCE              [commission]
-   *     Cr. Commission Income           [commission]
+   * SHOP entry (only when sumCommissionOrig > 0):
+   *   Dr. Unearned Commission           [sumCommissionOrig — full deferred drain]
+   *     Cr. Commission Income            [commissionActual — earned portion]
+   *     Cr. Due-from-FINANCE             [commissionDiscount — mirrors FINANCE]
    *
-   * Linked via [IC-<uuid>] description prefix.
+   * The implicit interest discount = (Unearned drained – Income recognised) lives
+   * silently in the Cr/Dr asymmetry — no separate Discount Expense line. The
+   * commission discount flows through Due-to-SHOP / Due-from-FINANCE so the
+   * inter-company invariant remains intact after payoff.
    *
-   * Caller is responsible for updating Payment rows; this method only posts
-   * the aggregated JE for the whole payoff.
+   * Linked via [IC-<uuid>] description prefix when commission is non-zero.
+   * Caller is responsible for updating Payment rows + zeroing the contract's
+   * Unearned tracking fields; this method only posts the aggregated JE.
    */
   async createEarlyPayoffJournal(
     tx: Prisma.TransactionClient,
@@ -510,6 +546,21 @@ export class JournalAutoService {
     const financeDesc = intercompanyId
       ? formatInterCompanyDescription(intercompanyId, `${baseDesc} (FINANCE)`)
       : baseDesc;
+    const financeLines: Array<{ accountCode: string; description: string; debit: number; credit: number }> = [
+      { accountCode: FA.CASH, description: 'รับชำระปิดก่อนกำหนด', debit: cash.toNumber(), credit: 0 },
+      { accountCode: FA.UNEARNED_INTEREST, description: 'ตัดดอกเบี้ยรอตัดบัญชี', debit: sumInterestOrig.toNumber(), credit: 0 },
+      { accountCode: FA.VAT_OUTPUT_PENDING, description: 'ตัดภาษีขายรอเรียกเก็บ', debit: sumVatOrig.toNumber(), credit: 0 },
+      { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: sumOwedExclLateFee.toNumber() },
+      { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interestActual.toNumber() },
+      { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vatActual.toNumber() },
+      { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: sumLateFee.toNumber() },
+    ];
+    // Only emit Due-to-SHOP line when there's a commission discount to reduce.
+    // Avoids posting an empty Dr=0 line that adds noise to the JE.
+    if (commissionDiscount.gt(0)) {
+      financeLines.push({ accountCode: FA.DUE_TO_SHOP, description: 'ลดเจ้าหนี้ระหว่างบริษัท (ส่วนลดคอมมิชชัน)', debit: commissionDiscount.toNumber(), credit: 0 });
+    }
+
     const financeEntryId = await this.createAndPost(tx, {
       companyId: financeCompanyId,
       entryDate,
@@ -517,16 +568,7 @@ export class JournalAutoService {
       referenceType: 'EARLY_PAYOFF',
       referenceId: params.contractId,
       createdById: params.userId,
-      lines: [
-        { accountCode: FA.CASH, description: 'รับชำระปิดก่อนกำหนด', debit: cash.toNumber(), credit: 0 },
-        { accountCode: FA.UNEARNED_INTEREST, description: 'ตัดดอกเบี้ยรอตัดบัญชี', debit: sumInterestOrig.toNumber(), credit: 0 },
-        { accountCode: FA.VAT_OUTPUT_PENDING, description: 'ตัดภาษีขายรอเรียกเก็บ', debit: sumVatOrig.toNumber(), credit: 0 },
-        { accountCode: FA.DUE_TO_SHOP, description: 'ลดเจ้าหนี้ระหว่างบริษัท (ส่วนลดคอมมิชชัน)', debit: commissionDiscount.toNumber(), credit: 0 },
-        { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: sumOwedExclLateFee.toNumber() },
-        { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interestActual.toNumber() },
-        { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vatActual.toNumber() },
-        { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: sumLateFee.toNumber() },
-      ],
+      lines: financeLines,
     });
 
     // SHOP entry — Phase A.2:
@@ -548,6 +590,13 @@ export class JournalAutoService {
         ],
       });
     }
+
+    // Phase A.2: contract is closed — zero out remaining unearned tracking.
+    // (Equivalent to draining whatever Unearned balance was left.)
+    await tx.contract.update({
+      where: { id: params.contractId },
+      data: { unearnedInterest: 0, unearnedCommission: 0 },
+    });
 
     return financeEntryId;
   }
@@ -637,7 +686,7 @@ export class JournalAutoService {
         lateFeeWaived?: boolean;
         paidDate?: Date | null;
       };
-      contract: { contractNumber: string; branchId?: string | null };
+      contract: { id?: string; contractNumber: string; branchId?: string | null };
       userId: string;
       shopCompanyId?: string | null;
       financeCompanyId?: string | null;
@@ -721,6 +770,17 @@ export class JournalAutoService {
           { accountCode: SA.UNEARNED_COMMISSION, description: 'ตัดค่านายหน้ารอตัดบัญชี', debit: commission.toNumber(), credit: 0 },
           { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่านายหน้า', debit: 0, credit: commission.toNumber() },
         ],
+      });
+    }
+
+    // Phase A.2: keep Contract.unearned* in sync (same model as createPaymentJournal).
+    if (params.contract.id && (interest.gt(0) || commission.gt(0))) {
+      await tx.contract.update({
+        where: { id: params.contract.id },
+        data: {
+          ...(interest.gt(0) ? { unearnedInterest: { decrement: interest } } : {}),
+          ...(commission.gt(0) ? { unearnedCommission: { decrement: commission } } : {}),
+        },
       });
     }
 

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -39,6 +39,7 @@ export class JournalAutoService {
     COGS_USED: '51-1102',
     COMMISSION_INCOME: '42-1105',
     DUE_FROM_FINANCE: '11-2105',
+    UNEARNED_COMMISSION: '21-2201', // Phase A.2 — deferred commission income
   } as const;
 
   // FINANCE-side accounts (in FINANCE chart)
@@ -58,11 +59,13 @@ export class JournalAutoService {
     COGS_NEW: '51-2101',
     COGS_USED: '51-2102',
     VAT_OUTPUT: '21-2101',
+    VAT_OUTPUT_PENDING: '21-2102', // Phase A.2 — deferred output VAT (booked at activation, drained per payment)
     CUSTOMER_CREDIT: '21-5101',
     DUE_TO_SHOP: '21-1102',
     BAD_DEBT_EXPENSE: '53-1701',
     COMMISSION_EXPENSE: '53-1801',
     LOSS_ON_REPO_RESALE: '53-1804',
+    UNEARNED_INTEREST: '21-2202', // Phase A.2 — deferred interest income
   } as const;
 
   constructor(private prisma: PrismaService) {}
@@ -306,19 +309,23 @@ export class JournalAutoService {
       ? new Prisma.Decimal(0)
       : new Prisma.Decimal(params.payment.lateFee ?? 0);
 
-    // If breakdown is missing (legacy/manual payment), settle whole amount against receivable as fallback
+    // Phase A.2 model: HP Receivable was loaded with the full installment
+    // (principal + commission + interest + VAT) at activation. Each payment
+    // drains the receivable by the installment portion of cash received
+    // (= amountPaid - lateFee). Late fees are recognised as separate income.
     const isZeroBreakdown =
-      principal.isZero() &&
-      interest.isZero() &&
-      commission.isZero() &&
-      vat.isZero() &&
-      lateFee.isZero();
-    const hpReceivableCredit = isZeroBreakdown ? amountPaid.sub(lateFee) : principal;
+      principal.isZero() && interest.isZero() && commission.isZero() && vat.isZero() && lateFee.isZero();
+    const hpReceivableCredit = isZeroBreakdown ? amountPaid.sub(lateFee) : amountPaid.sub(lateFee);
 
     const intercompanyId = commission.gt(0) ? generateInterCompanyId() : null;
     const baseDesc = `รับชำระค่างวด งวดที่ ${params.payment.installmentNo} สัญญา ${params.contract.contractNumber}`;
 
-    // FINANCE entry (always)
+    // FINANCE entry (always).
+    // Phase A.2 deferred-recognition lines:
+    //   Dr Unearned Interest          → Cr Interest Income       (recognise interest as earned)
+    //   Dr Output VAT Pending         → Cr Output VAT (PP.30)    (recognise VAT as payable)
+    // Removed: Cr Due-to-SHOP (commission was already accrued in full at
+    // contract activation; per-payment Cr would double-create the liability).
     const financeDesc = intercompanyId
       ? formatInterCompanyDescription(intercompanyId, `${baseDesc} (FINANCE)`)
       : baseDesc;
@@ -331,15 +338,18 @@ export class JournalAutoService {
       createdById: params.userId,
       lines: [
         { accountCode: FA.CASH, description: 'รับชำระเงิน', debit: amountPaid.toNumber(), credit: 0 },
+        { accountCode: FA.UNEARNED_INTEREST, description: 'ตัดดอกเบี้ยรอตัดบัญชี', debit: interest.toNumber(), credit: 0 },
+        { accountCode: FA.VAT_OUTPUT_PENDING, description: 'ตัดภาษีขายรอเรียกเก็บ', debit: vat.toNumber(), credit: 0 },
         { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: hpReceivableCredit.toNumber() },
         { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interest.toNumber() },
         { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: lateFee.toNumber() },
         { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
-        { accountCode: FA.DUE_TO_SHOP, description: 'ค่าคอมมิชชันค้างจ่าย SHOP', debit: 0, credit: commission.toNumber() },
       ],
     });
 
-    // SHOP entry — only when commission > 0
+    // SHOP entry — only when commission > 0.
+    // Phase A.2: recognise commission as earned by draining Unearned Commission.
+    // Removed: Dr Due-from-FINANCE (receivable already established at activation).
     if (commission.gt(0) && shopCompanyId && intercompanyId) {
       await this.createAndPost(tx, {
         companyId: shopCompanyId,
@@ -349,8 +359,8 @@ export class JournalAutoService {
         referenceId: params.payment.id,
         createdById: params.userId,
         lines: [
-          { accountCode: SA.DUE_FROM_FINANCE, description: 'ค่าคอมมิชชันรับจาก FINANCE', debit: commission.toNumber(), credit: 0 },
-          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: commission.toNumber() },
+          { accountCode: SA.UNEARNED_COMMISSION, description: 'ตัดค่านายหน้ารอตัดบัญชี', debit: commission.toNumber(), credit: 0 },
+          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่านายหน้า', debit: 0, credit: commission.toNumber() },
         ],
       });
     }
@@ -446,15 +456,20 @@ export class JournalAutoService {
     }
 
     sumPrincipal = sumPrincipal.toDecimalPlaces(2);
+    sumInterestOrig = sumInterestOrig.toDecimalPlaces(2);
+    sumCommissionOrig = sumCommissionOrig.toDecimalPlaces(2);
+    sumVatOrig = sumVatOrig.toDecimalPlaces(2);
     sumLateFee = sumLateFee.toDecimalPlaces(2);
 
     const cash = new Prisma.Decimal(params.totalPayoff);
     const cashExclLateFee = cash.sub(sumLateFee);
     const sumOtherOrig = sumInterestOrig.add(sumCommissionOrig).add(sumVatOrig);
+    // Total receivable owed for the unpaid installments (= what HP Receivable
+    // must drain by — installments were loaded with full breakdown at activation).
+    const sumOwedExclLateFee = sumPrincipal.add(sumOtherOrig);
 
-    // Allocate non-principal cash proportionally (reduce interest/commission/vat
-    // by the discount). If breakdown is fully zero (legacy), assign whole non-
-    // principal to interest as fallback.
+    // Phase A.2: discount allocates proportionally across interest/commission/vat.
+    // Principal must always be settled in full (HP Receivable drain to zero).
     let interestActual = new Prisma.Decimal(0);
     let commissionActual = new Prisma.Decimal(0);
     let vatActual = new Prisma.Decimal(0);
@@ -475,10 +490,23 @@ export class JournalAutoService {
       interestActual = nonPrincipalActual.toDecimalPlaces(2);
     }
 
-    const intercompanyId = commissionActual.gt(0) ? generateInterCompanyId() : null;
+    // Discount portions per component (forfeited income).
+    const commissionDiscount = sumCommissionOrig.sub(commissionActual).toDecimalPlaces(2);
+
+    const intercompanyId = sumCommissionOrig.gt(0) ? generateInterCompanyId() : null;
     const baseDesc = `ปิดสัญญาก่อนกำหนด — สัญญา ${params.contractNumber}`;
     const entryDate = params.paidDate ?? new Date();
 
+    // FINANCE entry — Phase A.2:
+    //   Dr Cash                       totalPayoff
+    //   Dr Unearned Interest          sumInterestOrig                (drain full deferred)
+    //   Dr VAT Pending                sumVatOrig                      (drain full deferred)
+    //   Dr Due-to-SHOP                commissionDiscount              (FINANCE owes SHOP less)
+    //     Cr HP Receivable             sumOwedExclLateFee             (drain receivable)
+    //     Cr Interest Income           interestActual                  (recognize earned)
+    //     Cr VAT Output (PP.30)        vatActual                       (recognize VAT collected)
+    //     Cr Late Fee Income           sumLateFee
+    // The implicit interest/VAT discount = (Unearned drain - Income recognised).
     const financeDesc = intercompanyId
       ? formatInterCompanyDescription(intercompanyId, `${baseDesc} (FINANCE)`)
       : baseDesc;
@@ -491,15 +519,21 @@ export class JournalAutoService {
       createdById: params.userId,
       lines: [
         { accountCode: FA.CASH, description: 'รับชำระปิดก่อนกำหนด', debit: cash.toNumber(), credit: 0 },
-        { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: sumPrincipal.toNumber() },
+        { accountCode: FA.UNEARNED_INTEREST, description: 'ตัดดอกเบี้ยรอตัดบัญชี', debit: sumInterestOrig.toNumber(), credit: 0 },
+        { accountCode: FA.VAT_OUTPUT_PENDING, description: 'ตัดภาษีขายรอเรียกเก็บ', debit: sumVatOrig.toNumber(), credit: 0 },
+        { accountCode: FA.DUE_TO_SHOP, description: 'ลดเจ้าหนี้ระหว่างบริษัท (ส่วนลดคอมมิชชัน)', debit: commissionDiscount.toNumber(), credit: 0 },
+        { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: sumOwedExclLateFee.toNumber() },
         { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interestActual.toNumber() },
-        { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: sumLateFee.toNumber() },
         { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vatActual.toNumber() },
-        { accountCode: FA.DUE_TO_SHOP, description: 'ค่าคอมมิชชันค้างจ่าย SHOP', debit: 0, credit: commissionActual.toNumber() },
+        { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: sumLateFee.toNumber() },
       ],
     });
 
-    if (commissionActual.gt(0) && params.shopCompanyId && intercompanyId) {
+    // SHOP entry — Phase A.2:
+    //   Dr Unearned Commission         sumCommissionOrig             (drain full)
+    //     Cr Commission Income          commissionActual              (recognize earned)
+    //     Cr Due-from-FINANCE           commissionDiscount            (mirrors FINANCE Due-to-SHOP reduction)
+    if (sumCommissionOrig.gt(0) && params.shopCompanyId && intercompanyId) {
       await this.createAndPost(tx, {
         companyId: params.shopCompanyId,
         entryDate,
@@ -508,8 +542,9 @@ export class JournalAutoService {
         referenceId: params.contractId,
         createdById: params.userId,
         lines: [
-          { accountCode: SA.DUE_FROM_FINANCE, description: 'ค่าคอมมิชชันรับจาก FINANCE', debit: commissionActual.toNumber(), credit: 0 },
-          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: commissionActual.toNumber() },
+          { accountCode: SA.UNEARNED_COMMISSION, description: 'ตัดค่านายหน้ารอตัดบัญชี', debit: sumCommissionOrig.toNumber(), credit: 0 },
+          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่านายหน้า', debit: 0, credit: commissionActual.toNumber() },
+          { accountCode: SA.DUE_FROM_FINANCE, description: 'ลดลูกหนี้ระหว่างบริษัท (ส่วนลดคอมมิชชัน)', debit: 0, credit: commissionDiscount.toNumber() },
         ],
       });
     }
@@ -646,6 +681,12 @@ export class JournalAutoService {
     const intercompanyId = commission.gt(0) ? generateInterCompanyId() : null;
     const baseDesc = `ใช้เครดิตลูกค้าตัดงวด งวดที่ ${params.payment.installmentNo} สัญญา ${params.contract.contractNumber}`;
 
+    // Phase A.2: Same model as createPaymentJournal but Customer Credit replaces
+    // Cash on the FINANCE side. HP Receivable drains by amountAllocated - lateFee
+    // (= installment portion). Interest + VAT swap from deferred to recognised.
+    // Late fee is rare for credit allocation but handled symmetrically.
+    const hpReceivableCredit = amountAllocated.sub(effectiveLateFee);
+
     const financeDesc = intercompanyId
       ? formatInterCompanyDescription(intercompanyId, `${baseDesc} (FINANCE)`)
       : baseDesc;
@@ -658,11 +699,12 @@ export class JournalAutoService {
       createdById: params.userId,
       lines: [
         { accountCode: FA.CUSTOMER_CREDIT, description: 'ใช้เครดิตลูกค้า', debit: amountAllocated.toNumber(), credit: 0 },
-        { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: principal.toNumber() },
+        { accountCode: FA.UNEARNED_INTEREST, description: 'ตัดดอกเบี้ยรอตัดบัญชี', debit: interest.toNumber(), credit: 0 },
+        { accountCode: FA.VAT_OUTPUT_PENDING, description: 'ตัดภาษีขายรอเรียกเก็บ', debit: vat.toNumber(), credit: 0 },
+        { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: hpReceivableCredit.toNumber() },
         { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interest.toNumber() },
         { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: effectiveLateFee.toNumber() },
         { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vat.toNumber() },
-        { accountCode: FA.DUE_TO_SHOP, description: 'ค่าคอมมิชชันค้างจ่าย SHOP', debit: 0, credit: commission.toNumber() },
       ],
     });
 
@@ -676,8 +718,8 @@ export class JournalAutoService {
         referenceId: params.payment.id,
         createdById: params.userId,
         lines: [
-          { accountCode: SA.DUE_FROM_FINANCE, description: 'ค่าคอมมิชชันรับจาก FINANCE', debit: commission.toNumber(), credit: 0 },
-          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: commission.toNumber() },
+          { accountCode: SA.UNEARNED_COMMISSION, description: 'ตัดค่านายหน้ารอตัดบัญชี', debit: commission.toNumber(), credit: 0 },
+          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่านายหน้า', debit: 0, credit: commission.toNumber() },
         ],
       });
     }
@@ -858,7 +900,8 @@ export class JournalAutoService {
       shopLines.push({ accountCode: shopRevenueAcc, description: 'รายได้จากการขาย', debit: 0, credit: sellingPrice.toNumber() });
     }
     if (storeCommission.greaterThan(0)) {
-      shopLines.push({ accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่าคอมมิชชัน', debit: 0, credit: storeCommission.toNumber() });
+      // Phase A.2: defer commission income — recognised cash-basis per payment.
+      shopLines.push({ accountCode: SA.UNEARNED_COMMISSION, description: 'รายได้ค่านายหน้ารอตัดบัญชี', debit: 0, credit: storeCommission.toNumber() });
     }
     if (costPrice.greaterThan(0)) {
       shopLines.push({ accountCode: shopCogsAcc, description: 'ต้นทุนขาย', debit: costPrice.toNumber(), credit: 0 });
@@ -888,10 +931,14 @@ export class JournalAutoService {
       financeLines.push({ accountCode: FA.DUE_TO_SHOP, description: 'เจ้าหนี้ระหว่างบริษัท (SHOP)', debit: 0, credit: dueFromFinance.toNumber() });
     }
     if (interestTotal.greaterThan(0)) {
-      financeLines.push({ accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interestTotal.toNumber() });
+      // Phase A.2: defer interest — recognised cash-basis per payment via
+      // Dr Unearned Interest / Cr Interest Income in createPaymentJournal.
+      financeLines.push({ accountCode: FA.UNEARNED_INTEREST, description: 'รายได้ดอกเบี้ยรอตัดบัญชี', debit: 0, credit: interestTotal.toNumber() });
     }
     if (vatAmount.greaterThan(0)) {
-      financeLines.push({ accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vatAmount.toNumber() });
+      // Phase A.2: defer VAT — VAT becomes payable to the revenue dept as
+      // each installment's tax invoice is issued, not at activation.
+      financeLines.push({ accountCode: FA.VAT_OUTPUT_PENDING, description: 'ภาษีขายรอเรียกเก็บ', debit: 0, credit: vatAmount.toNumber() });
     }
 
     const financeEntryId = await this.createAndPost(tx, {

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -235,7 +235,7 @@ export class PaymentsService {
             lateFeeWaived: result.lateFeeWaived,
             paidDate: result.paidDate,
           },
-          contract: { contractNumber: contract.contractNumber, branchId: contract.branchId },
+          contract: { id: contract.id, contractNumber: contract.contractNumber, branchId: contract.branchId },
           userId: recordedById,
         });
       }
@@ -416,7 +416,7 @@ export class PaymentsService {
               lateFeeWaived: updated.lateFeeWaived,
               paidDate: updated.paidDate,
             },
-            contract: { contractNumber: contract.contractNumber, branchId: contract.branchId },
+            contract: { id: contract.id, contractNumber: contract.contractNumber, branchId: contract.branchId },
             userId: recordedById,
           });
         }
@@ -815,7 +815,7 @@ export class PaymentsService {
               lateFeeWaived: updated.lateFeeWaived,
               paidDate: updated.paidDate,
             },
-            contract: { contractNumber: contract.contractNumber, branchId: contract.branchId },
+            contract: { id: contract.id, contractNumber: contract.contractNumber, branchId: contract.branchId },
             userId: recordedById,
           });
         }

--- a/apps/api/src/modules/paysolutions/paysolutions.service.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.ts
@@ -720,7 +720,7 @@ export class PaySolutionsService {
       const shopCompanyId = shopCompany?.id ?? null;
       const contractForJe = await this.prisma.contract.findUnique({
         where: { id: paymentLink.contractId! },
-        select: { contractNumber: true, branchId: true },
+        select: { id: true, contractNumber: true, branchId: true },
       });
 
       // F-1-003 follow-up: resolve a real OWNER user.id for JournalEntry.createdById.
@@ -927,6 +927,7 @@ export class PaySolutionsService {
                   paidDate: snapshot.paidDate,
                 },
                 contract: {
+                  id: contractForJe.id,
                   contractNumber: contractForJe.contractNumber,
                   branchId: contractForJe.branchId,
                 },


### PR DESCRIPTION
## Summary

Fixes a critical pre-existing P0 bug where **interest, commission, and VAT were DOUBLE-COUNTED** across the contract lifecycle (post-Phase-A.1b discovery):

- Activation JE recognised the FULL interest+commission+VAT as Income/Output upfront
- Each payment JE ALSO credited those same accounts per installment
- After all 12 payments: Income = 2× actual; HP Receivable left with residual (only principal portion drained per payment)

For a 10M+ baht installment portfolio this was a **material misstatement risk** — overstated revenue → overpaid corporate tax → revenue dept audit exposure.

## Phase A.2 model — TFRS for NPAEs cash-basis

- **Activation**: defer to `Unearned Interest (21-2202)`, `Unearned Commission (21-2201)`, `VAT Pending (21-2102)`
- **Payment**: `Dr Unearned / Cr Income` (recognise as earned), `Dr VAT Pending / Cr Output VAT`
- **HP Receivable** drains by FULL installment (`amountPaid - lateFee`) — goes to zero when contract paid in full
- Payment JE no longer adds to `Due-to-SHOP` per installment (commission was already accrued in full at activation; per-payment add was double-counting)

## Schema changes

- `Contract.unearnedInterest Decimal(12,2) @default(0)`
- `Contract.unearnedCommission Decimal(12,2) @default(0)`
- Migration backfills ACTIVE/OVERDUE/DEFAULT contracts: `unearned = total - sum(paid_monthly_portion)`
- New SHOP account: `21-2201 รายได้ค่านายหน้ารอตัดบัญชี (Unearned Commission Income)`
- FINANCE accounts `21-2202` (Unearned Interest) + `21-2102` (VAT Pending) already in seed

## JE methods refactored

- `createContractActivationJournal` — SHOP commission Income → Unearned Commission; FINANCE Interest Income → Unearned Interest; FINANCE VAT Output → VAT Pending
- `createPaymentJournal` — HP Receivable Cr changes from `principal` → `amountPaid - lateFee`; add `Dr Unearned Interest + Dr VAT Pending`; remove `Cr Due-to-SHOP commission`
- `createCreditAllocationJournal` — same Phase A.2 pattern
- `createEarlyPayoffJournal` — drains Unearned Interest + VAT Pending fully; reduces Due-to-SHOP by commission discount; SHOP entry drains Unearned Commission and reduces Due-from-FINANCE matching

`contract-workflow.activate` now seeds `Contract.unearnedInterest + unearnedCommission` from contract values.

## Verification

- TypeScript: 0 errors (api + web)
- Jest: **2214 tests pass / 187 suites** (+2 new lifecycle invariant tests)
- Lifecycle test: simulates activation + 12 payments → all deferred accounts drain to 0, Cash collected = financedAmount, Interest Income = totalInterest exactly (no double count)
- IC invariant test: SHOP `11-2105` Due-from-FINANCE == FINANCE `21-1102` Due-to-SHOP across activation

## Production deploy plan

1. Merge → CI auto-runs migration `20260616000000_add_unearned_income_fields` (adds 2 columns + backfills test contracts)
2. New activations + payments use Phase A.2 model immediately
3. Existing test JEs in prod (from Phase A.1b/A.1c testing) are no longer aligned with new schema math — recommend regenerating via fresh activations after merge
4. No CPA review needed — data is test only (per owner instruction "ทุกอย่างทำเต็มระบบไปเลย เพราะข้อมูล ที่กระทบ ไม่ใช่ข้อมูลจริง")

## Test plan

- [ ] Run prod migration via CI deploy
- [ ] Verify `chartOfAccount` SHOP query returns `21-2201` (rerun seed if needed)
- [ ] Trigger one test contract activation in prod → verify activation JE has Unearned lines (not Income lines) on both SHOP+FINANCE
- [ ] Trigger one test payment → verify Unearned drain + Income recognition
- [ ] Trial balance after one full contract: HP Receivable=0, Unearned Interest=0, Unearned Commission=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)