### PR TITLE
feat(accounting): Phase A.3 (W-5) — Inter-company settlement JE + API

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -60,6 +60,7 @@ import { FinanceReceivableModule } from './modules/finance-receivable/finance-re
 import { AccountingModule } from './modules/accounting/accounting.module';
 import { CompanyModule } from './modules/company/company.module';
 import { InterCompanyModule } from './modules/inter-company/inter-company.module';
+import { IntercompanyModule } from './modules/intercompany/intercompany.module';
 import { JournalModule } from './modules/journal/journal.module';
 import { ChartOfAccountsModule } from './modules/chart-of-accounts/chart-of-accounts.module';
 import { TaxModule } from './modules/tax/tax.module';
@@ -210,6 +211,8 @@ import { AppCacheModule } from './cache/cache.module';
     CompanyModule,
     // Inter-Company (SHOP ↔ FINANCE)
     InterCompanyModule,
+    // Inter-company settlement (Phase A.3 W-5 — pays Due-to-SHOP)
+    IntercompanyModule,
     // Journal Entries (double-entry accounting)
     JournalModule,
     ChartOfAccountsModule,

--- a/apps/api/src/modules/intercompany/dto/settle-intercompany.dto.ts
+++ b/apps/api/src/modules/intercompany/dto/settle-intercompany.dto.ts
@@ -1,0 +1,20 @@
+import { IsString, IsOptional, IsNumber, IsPositive, MaxLength, IsDateString } from 'class-validator';
+
+export class SettleIntercompanyDto {
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'จำนวนเงินไม่ถูกต้อง' })
+  @IsPositive({ message: 'จำนวนเงินต้องมากกว่า 0' })
+  amount!: number;
+
+  @IsString({ message: 'กรุณาระบุเลขที่อ้างอิง' })
+  @MaxLength(50)
+  reference!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  notes?: string;
+
+  @IsOptional()
+  @IsDateString()
+  paidDate?: string;
+}

--- a/apps/api/src/modules/intercompany/intercompany.controller.ts
+++ b/apps/api/src/modules/intercompany/intercompany.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Post, Body, UseGuards, UsePipes, ValidationPipe } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { IntercompanyService } from './intercompany.service';
+import { SettleIntercompanyDto } from './dto/settle-intercompany.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+
+@ApiTags('Inter-company')
+@ApiBearerAuth('JWT')
+@Controller('accounting/intercompany')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@UsePipes(new ValidationPipe({ whitelist: true }))
+export class IntercompanyController {
+  constructor(private intercompany: IntercompanyService) {}
+
+  @Get('balance')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getBalance() {
+    return this.intercompany.getOutstandingBalance();
+  }
+
+  @Post('settle')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  settle(@Body() dto: SettleIntercompanyDto, @CurrentUser('id') userId: string) {
+    return this.intercompany.settle(dto, userId);
+  }
+}

--- a/apps/api/src/modules/intercompany/intercompany.module.ts
+++ b/apps/api/src/modules/intercompany/intercompany.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { IntercompanyController } from './intercompany.controller';
+import { IntercompanyService } from './intercompany.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { JournalModule } from '../journal/journal.module';
+
+@Module({
+  imports: [PrismaModule, JournalModule],
+  controllers: [IntercompanyController],
+  providers: [IntercompanyService],
+})
+export class IntercompanyModule {}

--- a/apps/api/src/modules/intercompany/intercompany.service.spec.ts
+++ b/apps/api/src/modules/intercompany/intercompany.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { IntercompanyService } from './intercompany.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+
+describe('IntercompanyService (Phase A.3 W-5)', () => {
+  let service: IntercompanyService;
+  let prisma: {
+    companyInfo: { findFirst: jest.Mock };
+    journalLine: { aggregate: jest.Mock };
+    $transaction: jest.Mock;
+  };
+  let journalAuto: { createInterCompanySettlementJournal: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      companyInfo: {
+        findFirst: jest.fn().mockImplementation(({ where }) => {
+          if (where?.companyCode === 'SHOP') return Promise.resolve({ id: 'co-SHOP' });
+          if (where?.companyCode === 'FINANCE') return Promise.resolve({ id: 'co-FINANCE' });
+          return Promise.resolve(null);
+        }),
+      },
+      journalLine: {
+        aggregate: jest.fn(),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
+    };
+    journalAuto = {
+      createInterCompanySettlementJournal: jest.fn().mockResolvedValue({
+        financeEntryId: 'je-finance',
+        shopEntryId: 'je-shop',
+      }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IntercompanyService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: JournalAutoService, useValue: journalAuto },
+      ],
+    }).compile();
+    service = module.get(IntercompanyService);
+  });
+
+  describe('getOutstandingBalance', () => {
+    it('returns matched balances when invariant holds', async () => {
+      prisma.journalLine.aggregate
+        .mockResolvedValueOnce({ _sum: { debit: 10600, credit: 0 } }) // SHOP 11-2105 Dr
+        .mockResolvedValueOnce({ _sum: { debit: 0, credit: 10600 } }); // FINANCE 21-1102 Cr
+
+      const result = await service.getOutstandingBalance();
+      expect(result.shopReceivableFromFinance).toBeCloseTo(10600, 2);
+      expect(result.financeOwesToShop).toBeCloseTo(10600, 2);
+      expect(result.balanced).toBe(true);
+      expect(result.drift).toBeCloseTo(0, 2);
+    });
+
+    it('detects drift when invariant breaks', async () => {
+      prisma.journalLine.aggregate
+        .mockResolvedValueOnce({ _sum: { debit: 10600, credit: 0 } })
+        .mockResolvedValueOnce({ _sum: { debit: 0, credit: 10500 } });
+
+      const result = await service.getOutstandingBalance();
+      expect(result.balanced).toBe(false);
+      expect(result.drift).toBeCloseTo(100, 2);
+    });
+
+    it('handles partially settled balance correctly (Dr offsets on FINANCE)', async () => {
+      // After 2,000 settlement: shop Dr 10600 Cr 2000, finance Cr 10600 Dr 2000 → balance 8600
+      prisma.journalLine.aggregate
+        .mockResolvedValueOnce({ _sum: { debit: 10600, credit: 2000 } })
+        .mockResolvedValueOnce({ _sum: { debit: 2000, credit: 10600 } });
+
+      const result = await service.getOutstandingBalance();
+      expect(result.shopReceivableFromFinance).toBeCloseTo(8600, 2);
+      expect(result.financeOwesToShop).toBeCloseTo(8600, 2);
+      expect(result.balanced).toBe(true);
+    });
+
+    it('throws when SHOP company not configured', async () => {
+      prisma.companyInfo.findFirst = jest.fn().mockResolvedValue(null);
+      await expect(service.getOutstandingBalance()).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('settle', () => {
+    beforeEach(() => {
+      prisma.journalLine.aggregate
+        .mockResolvedValueOnce({ _sum: { debit: 10600, credit: 0 } })
+        .mockResolvedValueOnce({ _sum: { debit: 0, credit: 10600 } });
+    });
+
+    it('posts settlement when amount within outstanding balance', async () => {
+      const result = await service.settle(
+        { amount: 5000, reference: 'TXN-2026-04-1' },
+        'user-1',
+      );
+      expect(journalAuto.createInterCompanySettlementJournal).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ amount: 5000, reference: 'TXN-2026-04-1', userId: 'user-1' }),
+      );
+      expect(result.amount).toBe(5000);
+      expect(result.remainingBalance).toBeCloseTo(5600, 2);
+      expect(result.financeEntryId).toBe('je-finance');
+      expect(result.shopEntryId).toBe('je-shop');
+    });
+
+    it('rejects when amount exceeds outstanding balance', async () => {
+      await expect(
+        service.settle({ amount: 11000, reference: 'TXN-OVER' }, 'user-1'),
+      ).rejects.toThrow(BadRequestException);
+      expect(journalAuto.createInterCompanySettlementJournal).not.toHaveBeenCalled();
+    });
+
+    it('allows settling exact outstanding balance', async () => {
+      const result = await service.settle(
+        { amount: 10600, reference: 'TXN-FULL' },
+        'user-1',
+      );
+      expect(result.remainingBalance).toBeCloseTo(0, 2);
+    });
+  });
+});

--- a/apps/api/src/modules/intercompany/intercompany.service.ts
+++ b/apps/api/src/modules/intercompany/intercompany.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { SettleIntercompanyDto } from './dto/settle-intercompany.dto';
+
+@Injectable()
+export class IntercompanyService {
+  constructor(
+    private prisma: PrismaService,
+    private journalAuto: JournalAutoService,
+  ) {}
+
+  /**
+   * Compute current outstanding inter-company balance.
+   * - financeOwesToShop: net Cr balance on FINANCE 21-1102 (Due-to-SHOP)
+   * - shopReceivableFromFinance: net Dr balance on SHOP 11-2105 (Due-from-FINANCE)
+   *
+   * The two should always match (IC invariant). Returns both for cross-check.
+   */
+  async getOutstandingBalance(): Promise<{
+    financeOwesToShop: number;
+    shopReceivableFromFinance: number;
+    balanced: boolean;
+    drift: number;
+  }> {
+    const [shop, finance] = await Promise.all([
+      this.prisma.companyInfo.findFirst({ where: { companyCode: 'SHOP', deletedAt: null }, select: { id: true } }),
+      this.prisma.companyInfo.findFirst({ where: { companyCode: 'FINANCE', deletedAt: null }, select: { id: true } }),
+    ]);
+    if (!shop || !finance) {
+      throw new InternalServerErrorException('SHOP or FINANCE company not configured');
+    }
+
+    const [shopAgg, financeAgg] = await Promise.all([
+      this.prisma.journalLine.aggregate({
+        where: {
+          deletedAt: null,
+          accountCode: '11-2105',
+          journalEntry: { companyId: shop.id, status: 'POSTED', deletedAt: null },
+        },
+        _sum: { debit: true, credit: true },
+      }),
+      this.prisma.journalLine.aggregate({
+        where: {
+          deletedAt: null,
+          accountCode: '21-1102',
+          journalEntry: { companyId: finance.id, status: 'POSTED', deletedAt: null },
+        },
+        _sum: { debit: true, credit: true },
+      }),
+    ]);
+
+    const shopReceivableFromFinance = new Prisma.Decimal(shopAgg._sum.debit ?? 0)
+      .sub(shopAgg._sum.credit ?? 0)
+      .toDecimalPlaces(2)
+      .toNumber();
+    const financeOwesToShop = new Prisma.Decimal(financeAgg._sum.credit ?? 0)
+      .sub(financeAgg._sum.debit ?? 0)
+      .toDecimalPlaces(2)
+      .toNumber();
+
+    const drift = Math.round((shopReceivableFromFinance - financeOwesToShop) * 100) / 100;
+
+    return {
+      financeOwesToShop,
+      shopReceivableFromFinance,
+      balanced: Math.abs(drift) < 0.01,
+      drift,
+    };
+  }
+
+  /**
+   * Record an inter-company settlement (FINANCE pays SHOP).
+   * Posts paired SHOP+FINANCE JEs in a single transaction.
+   */
+  async settle(dto: SettleIntercompanyDto, userId: string) {
+    // Pre-flight: settlement amount cannot exceed current outstanding.
+    const balance = await this.getOutstandingBalance();
+    if (dto.amount > balance.financeOwesToShop + 0.01) {
+      throw new BadRequestException(
+        `จำนวนชำระเกินยอดที่ค้าง (ค้าง ${balance.financeOwesToShop.toLocaleString('th-TH', { minimumFractionDigits: 2 })} บาท)`,
+      );
+    }
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      return this.journalAuto.createInterCompanySettlementJournal(tx, {
+        amount: dto.amount,
+        reference: dto.reference,
+        notes: dto.notes,
+        paidDate: dto.paidDate ? new Date(dto.paidDate) : null,
+        userId,
+      });
+    });
+
+    return {
+      ...result,
+      amount: dto.amount,
+      reference: dto.reference,
+      remainingBalance: Math.round((balance.financeOwesToShop - dto.amount) * 100) / 100,
+    };
+  }
+}

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -1661,6 +1661,98 @@ describe('JournalAutoService', () => {
   });
 
   // ──────────────────────────────────────────────────────────────────────────
+  // createInterCompanySettlementJournal (Phase A.3 W-5)
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('createInterCompanySettlementJournal (Phase A.3)', () => {
+    let captured: Array<{ companyId: string; lines: Array<{ accountCode: string; debit: number; credit: number }>; description: string }>;
+
+    beforeEach(() => {
+      captured = [];
+      prisma.journalEntry.create.mockImplementation((args: any) => {
+        const data = args.data;
+        captured.push({
+          companyId: data.companyId,
+          description: data.description,
+          lines: (data.lines.create as Array<{ accountCode: string; debit: unknown; credit: unknown }>).map((l) => ({
+            accountCode: l.accountCode,
+            debit: Number(l.debit ?? 0),
+            credit: Number(l.credit ?? 0),
+          })),
+        });
+        return Promise.resolve({ id: `je-${captured.length}` });
+      });
+      prisma.companyInfo.findFirst = jest.fn().mockImplementation((args: any) => {
+        if (args?.where?.companyCode === 'SHOP') return Promise.resolve({ id: 'co-SHOP' });
+        if (args?.where?.companyCode === 'FINANCE') return Promise.resolve({ id: 'co-FINANCE' });
+        return Promise.resolve(null);
+      });
+    });
+
+    it('posts paired SHOP+FINANCE entries that reduce IC clearing accounts symmetrically', async () => {
+      await service.createInterCompanySettlementJournal(prisma, {
+        amount: 5000,
+        reference: 'TXN-2026-04',
+        userId: 'u1',
+        shopCompanyId: 'co-SHOP',
+        financeCompanyId: 'co-FINANCE',
+      });
+
+      expect(captured).toHaveLength(2);
+
+      const finance = captured.find((c) => c.companyId === 'co-FINANCE')!;
+      const dueToShopLine = finance.lines.find((l) => l.accountCode === '21-1102');
+      expect(dueToShopLine!.debit).toBeCloseTo(5000, 2);
+      const cashFinanceLine = finance.lines.find((l) => l.accountCode === '11-1101');
+      expect(cashFinanceLine!.credit).toBeCloseTo(5000, 2);
+
+      const shop = captured.find((c) => c.companyId === 'co-SHOP')!;
+      const cashShopLine = shop.lines.find((l) => l.accountCode === '11-1101');
+      expect(cashShopLine!.debit).toBeCloseTo(5000, 2);
+      const dueFromFinanceLine = shop.lines.find((l) => l.accountCode === '11-2105');
+      expect(dueFromFinanceLine!.credit).toBeCloseTo(5000, 2);
+    });
+
+    it('both entries share IC prefix', async () => {
+      await service.createInterCompanySettlementJournal(prisma, {
+        amount: 100,
+        reference: 'TXN-IC',
+        userId: 'u1',
+        shopCompanyId: 'co-SHOP',
+        financeCompanyId: 'co-FINANCE',
+      });
+
+      const finance = captured.find((c) => c.companyId === 'co-FINANCE')!;
+      const shop = captured.find((c) => c.companyId === 'co-SHOP')!;
+      const icMatch = finance.description.match(/\[IC-([0-9a-f-]+)\]/);
+      expect(icMatch).not.toBeNull();
+      expect(shop.description).toContain(icMatch![0]);
+    });
+
+    it('throws when amount is zero', async () => {
+      await expect(
+        service.createInterCompanySettlementJournal(prisma, {
+          amount: 0,
+          reference: 'TXN-ZERO',
+          userId: 'u1',
+          shopCompanyId: 'co-SHOP',
+          financeCompanyId: 'co-FINANCE',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('throws when SHOP or FINANCE missing', async () => {
+      prisma.companyInfo.findFirst = jest.fn().mockResolvedValue(null);
+      await expect(
+        service.createInterCompanySettlementJournal(prisma, {
+          amount: 100,
+          reference: 'TXN-NO-CO',
+          userId: 'u1',
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
   // Phase A.2 — End-to-end deferred recognition lifecycle
   // ──────────────────────────────────────────────────────────────────────────
   describe('Phase A.2 — Deferred recognition lifecycle invariants', () => {

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -397,6 +397,97 @@ export class JournalAutoService {
   }
 
   /**
+   * Phase A.3 (W-5) — Inter-company settlement JE.
+   *
+   * FINANCE pays SHOP to settle the accumulated `Due-to-SHOP` balance from
+   * contract activations. Posts paired entries:
+   *
+   * FINANCE entry:
+   *   Dr. Due-to-SHOP (21-1102)        [settlement amount]
+   *     Cr. Cash (FINANCE)              [settlement amount]
+   *
+   * SHOP entry:
+   *   Dr. Cash (SHOP)                   [settlement amount]
+   *     Cr. Due-from-FINANCE (11-2105)  [settlement amount]
+   *
+   * Linked via [IC-<uuid>] description prefix. Each settlement reduces both
+   * sides of the inter-company clearing pair symmetrically — the IC invariant
+   * (SHOP Due-from = FINANCE Due-to) holds before and after.
+   *
+   * Caller must verify the settlement amount does not exceed the current
+   * outstanding (Due-to-SHOP balance on FINANCE).
+   */
+  async createInterCompanySettlementJournal(
+    tx: Prisma.TransactionClient,
+    params: {
+      amount: Decimal | number;
+      paidDate?: Date | null;
+      reference: string; // e.g., bank transfer ref or "MONTHLY-2026-04"
+      notes?: string;
+      userId: string;
+      shopCompanyId?: string | null;
+      financeCompanyId?: string | null;
+    },
+  ): Promise<{ financeEntryId: string | null; shopEntryId: string | null }> {
+    const FA = JournalAutoService.FINANCE_ACC;
+    const SA = JournalAutoService.SHOP_ACC;
+
+    const financeCompanyId =
+      params.financeCompanyId ??
+      (await tx.companyInfo.findFirst({ where: { companyCode: 'FINANCE', deletedAt: null }, select: { id: true } }))?.id ??
+      null;
+    const shopCompanyId =
+      params.shopCompanyId ??
+      (await tx.companyInfo.findFirst({ where: { companyCode: 'SHOP', deletedAt: null }, select: { id: true } }))?.id ??
+      null;
+
+    if (!financeCompanyId || !shopCompanyId) {
+      throw new InternalServerErrorException('SHOP and FINANCE companies must be configured for inter-company settlement JE');
+    }
+
+    const amount = new Prisma.Decimal(params.amount);
+    if (!amount.gt(0)) {
+      throw new InternalServerErrorException('Settlement amount must be positive');
+    }
+
+    const intercompanyId = generateInterCompanyId();
+    const entryDate = params.paidDate ?? new Date();
+    const baseDesc = params.notes
+      ? `ชำระเงินระหว่างบริษัท ${params.reference} — ${params.notes}`
+      : `ชำระเงินระหว่างบริษัท ${params.reference}`;
+
+    // FINANCE side: pay SHOP, reduce Due-to-SHOP liability + reduce Cash
+    const financeEntryId = await this.createAndPost(tx, {
+      companyId: financeCompanyId,
+      entryDate,
+      description: formatInterCompanyDescription(intercompanyId, `${baseDesc} (FINANCE)`),
+      referenceType: 'IC_SETTLEMENT',
+      referenceId: params.reference,
+      createdById: params.userId,
+      lines: [
+        { accountCode: FA.DUE_TO_SHOP, description: 'ชำระเจ้าหนี้ระหว่างบริษัท SHOP', debit: amount.toNumber(), credit: 0 },
+        { accountCode: FA.CASH, description: 'จ่ายเงินให้ SHOP', debit: 0, credit: amount.toNumber() },
+      ],
+    });
+
+    // SHOP side: receive cash, reduce Due-from-FINANCE asset
+    const shopEntryId = await this.createAndPost(tx, {
+      companyId: shopCompanyId,
+      entryDate,
+      description: formatInterCompanyDescription(intercompanyId, `${baseDesc} (SHOP)`),
+      referenceType: 'IC_SETTLEMENT',
+      referenceId: params.reference,
+      createdById: params.userId,
+      lines: [
+        { accountCode: SA.CASH, description: 'รับเงินจาก FINANCE', debit: amount.toNumber(), credit: 0 },
+        { accountCode: SA.DUE_FROM_FINANCE, description: 'ตัดลูกหนี้ระหว่างบริษัท FINANCE', debit: 0, credit: amount.toNumber() },
+      ],
+    });
+
+    return { financeEntryId, shopEntryId };
+  }
+
+  /**
    * Phase A.2 — Early payoff JE with deferred-recognition handling.
    *
    * When a customer closes their contract early with a discount, the


### PR DESCRIPTION
## Summary

Closes the Phase A.1b/A.2 W-5 follow-up. Without this, FINANCE Due-to-SHOP / SHOP Due-from-FINANCE accumulate forever — FINANCE can never close monthly because liability never drains.

## Changes

- **`createInterCompanySettlementJournal`**: posts paired SHOP+FINANCE JE with `[IC-<uuid>]` prefix
  - FINANCE: `Dr Due-to-SHOP / Cr Cash`
  - SHOP: `Dr Cash / Cr Due-from-FINANCE`
- **New `intercompany` module** (separate from legacy `inter-company` which tracks `InterCompanyTransaction` table)
  - `GET /accounting/intercompany/balance` — returns current outstanding + IC invariant drift detection
  - `POST /accounting/intercompany/settle` (OWNER, FM) — pre-flight validates amount ≤ outstanding, posts JE atomically

## Tests

- **2226 tests pass / 188 suites** (+12 new: 4 JE-method + 7 service + lifecycle re-verify)
- TypeScript: 0 errors
- IC invariant: SHOP `11-2105` debit balance always equals FINANCE `21-1102` credit balance after activation, payment, and settlement

## Test plan

- [ ] Run `GET /accounting/intercompany/balance` on prod → returns current outstanding (= sum of activations × `sellingPrice + commission - downPayment`, minus partial payoffs commission discounts)
- [ ] Run `POST /accounting/intercompany/settle` with small test amount → both JEs posted, balance reduces
- [ ] Trial balance: FINANCE Cash decreases, FINANCE Due-to-SHOP decreases by same amount; SHOP Cash increases, SHOP Due-from-FINANCE decreases by same amount
- [ ] No new chart-of-accounts to seed (uses existing 21-1102, 11-2105, 11-1101)

## Deferred (not in this PR)

- Frontend UI for settlement (cron monthly auto-settle?) — owner-decision, can come later
- W-2 (generateEntryNumber FOR UPDATE concurrency) — pre-existing
- W-4 (VAT discount + ใบลดหนี้ compliance) — needs CPA discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)