### PR TITLE
feat(accounting): W-2 (entry# concurrency) + W-4 (explicit discount) + frontend settlement

### DIFF
--- a/apps/api/prisma/seeds/chart-of-accounts-finance.ts
+++ b/apps/api/prisma/seeds/chart-of-accounts-finance.ts
@@ -62,6 +62,7 @@ const FINANCE_ACCOUNTS: FinanceAccount[] = [
   { code: '53-1802', nameTh: 'ค่าธรรมเนียม PaySolutions', nameEn: 'PaySolutions Fees', accountGroup: AccountGroup.EXPENSE, level: 3 },
   { code: '53-1803', nameTh: 'ค่าธรรมเนียมโอนเงิน', nameEn: 'Bank Transfer Fees', accountGroup: AccountGroup.EXPENSE, level: 3 },
   { code: '53-1804', nameTh: 'ขาดทุนจากการขายสินค้ายึดคืน', nameEn: 'Loss on Repossession Resale', accountGroup: AccountGroup.EXPENSE, level: 3 },
+  { code: '53-1805', nameTh: 'ส่วนลดให้ลูกค้า — ดอกเบี้ย', nameEn: 'Sales Discount on Interest', accountGroup: AccountGroup.EXPENSE, level: 3 },
   { code: '53-1601', nameTh: 'ค่าเสื่อมราคา — อุปกรณ์ FINANCE', nameEn: 'Depreciation — FINANCE Equipment', accountGroup: AccountGroup.EXPENSE, level: 3 },
 
   // ─── 54-XXXX รายจ่ายต้องห้ามทางภาษี (2) ───

--- a/apps/api/prisma/seeds/chart-of-accounts.ts
+++ b/apps/api/prisma/seeds/chart-of-accounts.ts
@@ -127,6 +127,13 @@ export async function seedChartOfAccounts(prisma: PrismaClient): Promise<void> {
       accountGroup: AccountGroup.LIABILITY,
       parentCode: '21-22XX',
     },
+    {
+      code: '53-1801',
+      nameTh: 'ส่วนลดให้ลูกค้า — คอมมิชชัน',
+      nameEn: 'Sales Discount on Commission',
+      accountGroup: AccountGroup.EXPENSE,
+      parentCode: '53-18XX',
+    },
   ];
 
   for (const acc of shopExtraAccounts) {

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -1558,8 +1558,8 @@ describe('JournalAutoService', () => {
       expect(Number(unearnedInterestLine!.debit)).toBeCloseTo(300, 2);
     });
 
-    it('balances when discount applied — principal in full, others scaled down (Phase A.2)', async () => {
-      const insts = [makeInst(), makeInst(), makeInst()]; // owed 3000, principal 2400, others 600
+    it('balances when discount applied — principal in full, others as full + explicit discount (Phase W-4)', async () => {
+      const insts = [makeInst(), makeInst(), makeInst()]; // owed 3000, principal 2400, interest 300, commission 150, vat 150
       // 50% discount on grossProfit: discount=300 → totalPayoff=2700
       await service.createEarlyPayoffJournal(prisma, {
         contractId: 'c-1', contractNumber: 'CNT-001',
@@ -1573,10 +1573,12 @@ describe('JournalAutoService', () => {
       // Phase A.2: HP Receivable drains by full owed regardless of discount
       const hpLine = lines.find((l) => l.accountCode === '11-2102');
       expect(Number(hpLine!.credit)).toBeCloseTo(3000, 2);
-      // Other 300 cash split proportionally across interest(300)+commission(150)+vat(150)=600
-      // Scale = 300/600 = 0.5 → interest 150, commission 75, vat 75
+      // Phase W-4: Interest Income credited at FULL (300), not actual (150)
       const interestLine = lines.find((l) => l.accountCode === '42-2101');
-      expect(Number(interestLine!.credit)).toBeCloseTo(150, 2);
+      expect(Number(interestLine!.credit)).toBeCloseTo(300, 2);
+      // Phase W-4: Sales Discount Interest expense visible (interest discount 150 + vat discount 75)
+      const discountLine = lines.find((l) => l.accountCode === '53-1805');
+      expect(Number(discountLine!.debit)).toBeCloseTo(225, 2);
       // Due-to-SHOP reduces by commission discount (75) — FINANCE owes SHOP less
       const dueToShopLine = lines.find((l) => l.accountCode === '21-1102');
       expect(Number(dueToShopLine!.debit)).toBeCloseTo(75, 2);
@@ -1611,7 +1613,7 @@ describe('JournalAutoService', () => {
       expect(Number(hpLine!.credit)).toBeCloseTo(600, 2);
     });
 
-    it('falls back to interest-only when breakdown is zero (legacy data)', async () => {
+    it('legacy zero-breakdown: flat HP Receivable drain, no interest/VAT recognition (Phase W-4)', async () => {
       const insts = [makeInst({
         monthlyPrincipal: 0, monthlyInterest: 0,
         monthlyCommission: 0, vatAmount: 0,
@@ -1624,9 +1626,12 @@ describe('JournalAutoService', () => {
       });
       const lines = capturedLines();
       expect(sumDebits(lines)).toBeCloseTo(sumCredits(lines), 2);
-      // Whole non-principal cash → interest line
+      // HP Receivable drains by full amountDue (matches activation Dr)
+      const hpLine = lines.find((l) => l.accountCode === '11-2102');
+      expect(Number(hpLine!.credit)).toBeCloseTo(1000, 2);
+      // No interest income recognised (no breakdown to allocate from)
       const interestLine = lines.find((l) => l.accountCode === '42-2101');
-      expect(Number(interestLine!.credit)).toBeCloseTo(1000, 2);
+      expect(interestLine === undefined || Number(interestLine.credit) === 0).toBe(true);
     });
 
     it('skips SHOP entry when commission is zero', async () => {

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -40,6 +40,7 @@ export class JournalAutoService {
     COMMISSION_INCOME: '42-1105',
     DUE_FROM_FINANCE: '11-2105',
     UNEARNED_COMMISSION: '21-2201', // Phase A.2 — deferred commission income
+    SALES_DISCOUNT_COMMISSION: '53-1801', // Phase W-4 — explicit discount expense (commission portion)
   } as const;
 
   // FINANCE-side accounts (in FINANCE chart)
@@ -65,6 +66,7 @@ export class JournalAutoService {
     BAD_DEBT_EXPENSE: '53-1701',
     COMMISSION_EXPENSE: '53-1801',
     LOSS_ON_REPO_RESALE: '53-1804',
+    SALES_DISCOUNT_INTEREST: '53-1805', // Phase W-4 — explicit discount expense (interest portion)
     UNEARNED_INTEREST: '21-2202', // Phase A.2 — deferred interest income
   } as const;
 
@@ -75,19 +77,21 @@ export class JournalAutoService {
     const ym = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
     const prefix = `JE-${ym}`;
 
-    // SELECT ... FOR UPDATE serialises concurrent inserts in the same month-prefix.
-    // count()-based generation race-conditions when two transactions read the same
-    // count and produce identical entry numbers — Phase A.1b doubled the surface
-    // by posting paired SHOP+FINANCE entries per business operation. Same pattern
-    // as receipts.service.generateReceiptNumber (verified working).
-    const result = await (tx as unknown as { $queryRaw: typeof PrismaService.prototype.$queryRaw }).$queryRaw<
-      Array<{ entryNumber: string }>
-    >`
+    // Phase W-2: pg_advisory_xact_lock serialises concurrent generation within
+    // the same month, even when no rows yet exist for that prefix. The previous
+    // SELECT ... FOR UPDATE only locked existing rows — first JE of a new month
+    // still race-conditioned (two callers both saw empty, both wrote -0001).
+    // Lock key = numeric YYYYMM (e.g. 202604) — small, stable, scoped per month.
+    // Auto-released at tx commit/rollback (xact_lock variant).
+    const txRaw = tx as unknown as { $queryRaw: typeof PrismaService.prototype.$queryRaw };
+    const lockKey = parseInt(ym, 10);
+    await txRaw.$queryRaw`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`;
+
+    const result = await txRaw.$queryRaw<Array<{ entryNumber: string }>>`
       SELECT entry_number AS "entryNumber" FROM journal_entries
       WHERE entry_number LIKE ${prefix + '%'}
       ORDER BY entry_number DESC
       LIMIT 1
-      FOR UPDATE
     `;
 
     let seq = 1;
@@ -566,6 +570,8 @@ export class JournalAutoService {
     let sumCommissionOrig = new Prisma.Decimal(0);
     let sumVatOrig = new Prisma.Decimal(0);
     let sumLateFee = new Prisma.Decimal(0);
+    // Total remaining amountDue (used as HP Receivable drain when breakdown is zero).
+    let sumRemainingDue = new Prisma.Decimal(0);
 
     for (const inst of params.installments) {
       const amountDue = new Prisma.Decimal(inst.amountDue ?? 0);
@@ -577,10 +583,12 @@ export class JournalAutoService {
       sumInterestOrig = sumInterestOrig.add(new Prisma.Decimal(inst.monthlyInterest ?? 0).mul(ratioRemaining));
       sumCommissionOrig = sumCommissionOrig.add(new Prisma.Decimal(inst.monthlyCommission ?? 0).mul(ratioRemaining));
       sumVatOrig = sumVatOrig.add(new Prisma.Decimal(inst.vatAmount ?? 0).mul(ratioRemaining));
+      sumRemainingDue = sumRemainingDue.add(amountDue.sub(amountPaidBefore));
       if (!inst.lateFeeWaived) {
         sumLateFee = sumLateFee.add(new Prisma.Decimal(inst.lateFee ?? 0));
       }
     }
+    sumRemainingDue = sumRemainingDue.toDecimalPlaces(2);
 
     sumPrincipal = sumPrincipal.toDecimalPlaces(2);
     sumInterestOrig = sumInterestOrig.toDecimalPlaces(2);
@@ -618,36 +626,74 @@ export class JournalAutoService {
     }
 
     // Discount portions per component (forfeited income).
+    const interestDiscount = sumInterestOrig.sub(interestActual).toDecimalPlaces(2);
     const commissionDiscount = sumCommissionOrig.sub(commissionActual).toDecimalPlaces(2);
+    const vatDiscount = sumVatOrig.sub(vatActual).toDecimalPlaces(2);
 
     const intercompanyId = sumCommissionOrig.gt(0) ? generateInterCompanyId() : null;
     const baseDesc = `ปิดสัญญาก่อนกำหนด — สัญญา ${params.contractNumber}`;
     const entryDate = params.paidDate ?? new Date();
 
-    // FINANCE entry — Phase A.2:
+    // FINANCE entry — Phase W-4 (explicit discount expense):
     //   Dr Cash                       totalPayoff
     //   Dr Unearned Interest          sumInterestOrig                (drain full deferred)
     //   Dr VAT Pending                sumVatOrig                      (drain full deferred)
+    //   Dr Sales Discount Interest    interestDiscount + vatDiscount  (visible in P&L as expense)
     //   Dr Due-to-SHOP                commissionDiscount              (FINANCE owes SHOP less)
     //     Cr HP Receivable             sumOwedExclLateFee             (drain receivable)
-    //     Cr Interest Income           interestActual                  (recognize earned)
-    //     Cr VAT Output (PP.30)        vatActual                       (recognize VAT collected)
+    //     Cr Interest Income           sumInterestOrig                 (recognize FULL — discount as separate expense)
+    //     Cr VAT Output (PP.30)        sumVatOrig                      (recognize FULL — discount as separate expense)
     //     Cr Late Fee Income           sumLateFee
-    // The implicit interest/VAT discount = (Unearned drain - Income recognised).
+    // Phase W-4 makes the discount visible as an explicit P&L line item
+    // ("ส่วนลดให้ลูกค้า") instead of hidden in income asymmetry — matches CPA
     const financeDesc = intercompanyId
       ? formatInterCompanyDescription(intercompanyId, `${baseDesc} (FINANCE)`)
       : baseDesc;
+    // Phase W-4: Cr Income lines post the FULL Unearned drain (not the
+    // discounted amount). The discount is broken out as an explicit
+    // Dr Sales Discount Interest expense — visible in P&L for CPA reporting.
+    // VAT discount also flows through the same Discount Interest account.
+    //
+    // Legacy zero-breakdown fallback: when sumOtherOrig=0, there's no Unearned
+    // balance to drain so we credit Interest Income for the whole nonPrincipal
+    // and post no discount expense (no original interest to discount from).
+    const isLegacyFallback = sumOtherOrig.isZero() && interestActual.gt(0);
+    const interestIncomeCredit = isLegacyFallback ? interestActual : sumInterestOrig;
+    const vatOutputCredit = sumVatOrig; // 0 in legacy fallback
+    const interestDiscountTotal = interestDiscount.add(vatDiscount).toDecimalPlaces(2);
+
     const financeLines: Array<{ accountCode: string; description: string; debit: number; credit: number }> = [
       { accountCode: FA.CASH, description: 'รับชำระปิดก่อนกำหนด', debit: cash.toNumber(), credit: 0 },
       { accountCode: FA.UNEARNED_INTEREST, description: 'ตัดดอกเบี้ยรอตัดบัญชี', debit: sumInterestOrig.toNumber(), credit: 0 },
       { accountCode: FA.VAT_OUTPUT_PENDING, description: 'ตัดภาษีขายรอเรียกเก็บ', debit: sumVatOrig.toNumber(), credit: 0 },
       { accountCode: FA.HP_RECEIVABLE, description: 'ตัดลูกหนี้เช่าซื้อ', debit: 0, credit: sumOwedExclLateFee.toNumber() },
-      { accountCode: FA.INTEREST_INCOME, description: 'รายได้ดอกเบี้ยเช่าซื้อ', debit: 0, credit: interestActual.toNumber() },
-      { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vatActual.toNumber() },
+      { accountCode: FA.INTEREST_INCOME, description: isLegacyFallback ? 'รายได้ดอกเบี้ยเช่าซื้อ' : 'รายได้ดอกเบี้ยเช่าซื้อ (เต็ม)', debit: 0, credit: interestIncomeCredit.toNumber() },
+      { accountCode: FA.VAT_OUTPUT, description: 'ภาษีขาย', debit: 0, credit: vatOutputCredit.toNumber() },
       { accountCode: FA.LATE_FEE_INCOME, description: 'ค่าปรับล่าช้า', debit: 0, credit: sumLateFee.toNumber() },
     ];
+    // Legacy fallback case: zero breakdown means we cannot allocate cash to
+    // interest/VAT/commission portions. Settle as a flat receivable drain:
+    //   Dr Cash + Dr Discount (if cash < amountDue)
+    //     Cr HP Receivable (= sumRemainingDue, matches activation Dr)
+    // Skip Interest Income / VAT Output entirely — no breakdown to recognise.
+    if (isLegacyFallback) {
+      const hpLine = financeLines.find((l) => l.accountCode === FA.HP_RECEIVABLE)!;
+      hpLine.credit = sumRemainingDue.toNumber();
+      const interestLine = financeLines.find((l) => l.accountCode === FA.INTEREST_INCOME)!;
+      interestLine.credit = 0;
+      const vatLine = financeLines.find((l) => l.accountCode === FA.VAT_OUTPUT)!;
+      vatLine.credit = 0;
+      // Implicit discount = sumRemainingDue - cashExclLateFee. Post as expense.
+      const legacyDiscount = sumRemainingDue.sub(cashExclLateFee).toDecimalPlaces(2);
+      if (legacyDiscount.gt(0)) {
+        financeLines.push({ accountCode: FA.SALES_DISCOUNT_INTEREST, description: 'ส่วนลดให้ลูกค้า — ปิดก่อนกำหนด (legacy)', debit: legacyDiscount.toNumber(), credit: 0 });
+      }
+    }
+    // Explicit discount expense (only when discount > 0 and breakdown was provided).
+    if (interestDiscountTotal.gt(0) && !isLegacyFallback) {
+      financeLines.push({ accountCode: FA.SALES_DISCOUNT_INTEREST, description: 'ส่วนลดให้ลูกค้า — ดอกเบี้ย/VAT', debit: interestDiscountTotal.toNumber(), credit: 0 });
+    }
     // Only emit Due-to-SHOP line when there's a commission discount to reduce.
-    // Avoids posting an empty Dr=0 line that adds noise to the JE.
     if (commissionDiscount.gt(0)) {
       financeLines.push({ accountCode: FA.DUE_TO_SHOP, description: 'ลดเจ้าหนี้ระหว่างบริษัท (ส่วนลดคอมมิชชัน)', debit: commissionDiscount.toNumber(), credit: 0 });
     }
@@ -662,11 +708,20 @@ export class JournalAutoService {
       lines: financeLines,
     });
 
-    // SHOP entry — Phase A.2:
-    //   Dr Unearned Commission         sumCommissionOrig             (drain full)
-    //     Cr Commission Income          commissionActual              (recognize earned)
+    // SHOP entry — Phase W-4 (explicit discount expense):
+    //   Dr Unearned Commission         sumCommissionOrig             (drain full deferred)
+    //   Dr Sales Discount Commission   commissionDiscount            (visible in P&L)
+    //     Cr Commission Income          sumCommissionOrig             (recognize FULL — discount as separate expense)
     //     Cr Due-from-FINANCE           commissionDiscount            (mirrors FINANCE Due-to-SHOP reduction)
     if (sumCommissionOrig.gt(0) && params.shopCompanyId && intercompanyId) {
+      const shopLines: Array<{ accountCode: string; description: string; debit: number; credit: number }> = [
+        { accountCode: SA.UNEARNED_COMMISSION, description: 'ตัดค่านายหน้ารอตัดบัญชี', debit: sumCommissionOrig.toNumber(), credit: 0 },
+        { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่านายหน้า (เต็ม)', debit: 0, credit: sumCommissionOrig.toNumber() },
+      ];
+      if (commissionDiscount.gt(0)) {
+        shopLines.push({ accountCode: SA.SALES_DISCOUNT_COMMISSION, description: 'ส่วนลดให้ลูกค้า — คอมมิชชัน', debit: commissionDiscount.toNumber(), credit: 0 });
+        shopLines.push({ accountCode: SA.DUE_FROM_FINANCE, description: 'ลดลูกหนี้ระหว่างบริษัท (ส่วนลดคอมมิชชัน)', debit: 0, credit: commissionDiscount.toNumber() });
+      }
       await this.createAndPost(tx, {
         companyId: params.shopCompanyId,
         entryDate,
@@ -674,11 +729,7 @@ export class JournalAutoService {
         referenceType: 'EARLY_PAYOFF',
         referenceId: params.contractId,
         createdById: params.userId,
-        lines: [
-          { accountCode: SA.UNEARNED_COMMISSION, description: 'ตัดค่านายหน้ารอตัดบัญชี', debit: sumCommissionOrig.toNumber(), credit: 0 },
-          { accountCode: SA.COMMISSION_INCOME, description: 'รายได้ค่านายหน้า', debit: 0, credit: commissionActual.toNumber() },
-          { accountCode: SA.DUE_FROM_FINANCE, description: 'ลดลูกหนี้ระหว่างบริษัท (ส่วนลดคอมมิชชัน)', debit: 0, credit: commissionDiscount.toNumber() },
-        ],
+        lines: shopLines,
       });
     }
 

--- a/apps/api/src/modules/receipts/receipts.service.ts
+++ b/apps/api/src/modules/receipts/receipts.service.ts
@@ -25,7 +25,14 @@ export class ReceiptsService {
 
   /**
    * Generate receipt number: RC-YYYY-MM-NNNNN
-   * Uses SELECT FOR UPDATE to prevent race conditions with concurrent payments.
+   *
+   * Phase W-2: pg_advisory_xact_lock serialises concurrent generation within
+   * the same month, even when no rows yet exist for that prefix. The previous
+   * SELECT ... FOR UPDATE only locked existing rows — first receipt of a new
+   * month still race-conditioned (two callers both saw empty, both wrote -00001).
+   * Lock key = numeric YYYYMM with a +1 prefix (1<YYYYMM>) to namespace separate
+   * from journal entries which use the same lock space (raw YYYYMM).
+   * Auto-released at tx commit/rollback.
    */
   private async generateReceiptNumber(tx?: Prisma.TransactionClient): Promise<string> {
     const db = tx || this.prisma;
@@ -34,15 +41,14 @@ export class ReceiptsService {
     const month = String(now.getMonth() + 1).padStart(2, '0');
     const prefix = `RC-${year}-${month}-`;
 
-    // Use raw query with FOR UPDATE to lock the row and prevent concurrent reads
-    // from getting the same sequence number.
-    // Schema maps Receipt → "receipts" with column "receipt_number" (snake_case).
+    const lockKey = parseInt(`1${year}${month}`, 10);
+    await db.$queryRaw`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`;
+
     const result = await db.$queryRaw<Array<{ receiptNumber: string }>>`
       SELECT receipt_number AS "receiptNumber" FROM receipts
       WHERE receipt_number LIKE ${prefix + '%'}
       ORDER BY receipt_number DESC
       LIMIT 1
-      FOR UPDATE
     `;
 
     let seq = 1;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -98,6 +98,7 @@ const CollectionsPage = lazy(() => import('@/pages/CollectionsPage'));
 const DunningSettingsPage = lazy(() => import('@/pages/DunningSettingsPage'));
 const SmsTemplatesPage = lazy(() => import('@/pages/SmsTemplatesPage'));
 const MonthlyClosePage = lazy(() => import('@/pages/MonthlyClosePage'));
+const IntercompanySettlementPage = lazy(() => import('@/pages/IntercompanySettlementPage'));
 const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
 const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
 const AiTrainingPage = lazy(() => import('@/pages/AiTrainingPage'));
@@ -543,6 +544,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <MonthlyClosePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/accounting/intercompany"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <IntercompanySettlementPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -285,6 +285,7 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
       icon: CalendarDays,
       items: [
         { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
+        { label: 'ชำระเงินระหว่างบริษัท', path: '/accounting/intercompany', icon: ClipboardList },
         { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
         { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
         { label: 'PEAK Sync', path: '/settings/peak-sync', icon: Plug },
@@ -358,6 +359,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
         { label: 'ภาษี', path: '/tax-reports', icon: Calculator },
         { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
+        { label: 'ชำระเงินระหว่างบริษัท', path: '/accounting/intercompany', icon: ClipboardList },
         { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
         { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
       ],

--- a/apps/web/src/pages/IntercompanySettlementPage.tsx
+++ b/apps/web/src/pages/IntercompanySettlementPage.tsx
@@ -1,0 +1,287 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Loader2, ArrowRightLeft, AlertTriangle, CheckCircle2, History } from 'lucide-react';
+import api, { getErrorMessage } from '@/lib/api';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { formatThaiDateShort } from '@/lib/date';
+
+interface BalanceResponse {
+  financeOwesToShop: number;
+  shopReceivableFromFinance: number;
+  balanced: boolean;
+  drift: number;
+}
+
+interface SettlementHistory {
+  id: string;
+  entryNumber: string;
+  entryDate: string;
+  description: string;
+  referenceId: string;
+  lines: Array<{
+    accountCode: string;
+    debit: string | number;
+    credit: string | number;
+  }>;
+}
+
+const fmtBaht = (n: number) =>
+  n.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+export default function IntercompanySettlementPage() {
+  const qc = useQueryClient();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [amount, setAmount] = useState('');
+  const [reference, setReference] = useState('');
+  const [notes, setNotes] = useState('');
+  const [paidDate, setPaidDate] = useState(new Date().toISOString().slice(0, 10));
+
+  const balanceQ = useQuery<BalanceResponse>({
+    queryKey: ['intercompany-balance'],
+    queryFn: async () => (await api.get('/accounting/intercompany/balance')).data,
+    staleTime: 30_000,
+  });
+
+  const historyQ = useQuery<{ data: SettlementHistory[] }>({
+    queryKey: ['intercompany-history'],
+    queryFn: async () =>
+      (
+        await api.get('/journal-entries', {
+          params: { search: 'IC_SETTLEMENT', limit: 50 },
+        })
+      ).data,
+    staleTime: 30_000,
+  });
+
+  const settleMut = useMutation({
+    mutationFn: async () =>
+      (
+        await api.post('/accounting/intercompany/settle', {
+          amount: parseFloat(amount),
+          reference,
+          notes: notes || undefined,
+          paidDate: paidDate ? new Date(paidDate).toISOString() : undefined,
+        })
+      ).data,
+    onSuccess: () => {
+      toast.success('บันทึกการชำระเงินระหว่างบริษัทเรียบร้อย');
+      qc.invalidateQueries({ queryKey: ['intercompany-balance'] });
+      qc.invalidateQueries({ queryKey: ['intercompany-history'] });
+      setDialogOpen(false);
+      setAmount('');
+      setReference('');
+      setNotes('');
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const balance = balanceQ.data;
+  const settlementHistory = (historyQ.data?.data ?? []).filter(
+    (e) => e.description?.includes('IC-') && e.description?.includes('ชำระเงินระหว่างบริษัท'),
+  );
+
+  const handleSubmit = () => {
+    const amt = parseFloat(amount);
+    if (!amt || amt <= 0) {
+      toast.error('กรอกจำนวนเงินให้ถูกต้อง');
+      return;
+    }
+    if (balance && amt > balance.financeOwesToShop + 0.01) {
+      toast.error(`จำนวนเกินยอดค้าง (สูงสุด ${fmtBaht(balance.financeOwesToShop)} บาท)`);
+      return;
+    }
+    if (!reference.trim()) {
+      toast.error('กรอกเลขที่อ้างอิง');
+      return;
+    }
+    settleMut.mutate();
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="ชำระเงินระหว่างบริษัท (FINANCE → SHOP)"
+        subtitle="ตรวจสอบยอด FINANCE ค้างจ่าย SHOP และบันทึกการโอนเงินจริง"
+      />
+
+      <QueryBoundary isLoading={balanceQ.isLoading} isError={balanceQ.isError} error={balanceQ.error} onRetry={() => balanceQ.refetch()}>
+        {balance && (
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold flex items-center gap-2">
+                <ArrowRightLeft className="h-5 w-5 text-primary" />
+                ยอดค้างจ่ายปัจจุบัน
+              </h2>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="rounded-lg border border-border bg-muted p-4">
+                  <p className="text-sm text-muted-foreground">FINANCE ค้างจ่าย SHOP</p>
+                  <p className="text-3xl font-bold mt-1 leading-snug">
+                    ฿{fmtBaht(balance.financeOwesToShop)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-border bg-muted p-4">
+                  <p className="text-sm text-muted-foreground">SHOP ลูกหนี้ FINANCE</p>
+                  <p className="text-3xl font-bold mt-1 leading-snug">
+                    ฿{fmtBaht(balance.shopReceivableFromFinance)}
+                  </p>
+                </div>
+              </div>
+
+              {balance.balanced ? (
+                <div className="flex items-center gap-2 text-sm text-primary">
+                  <CheckCircle2 className="h-4 w-4" />
+                  ยอดสองฝั่งตรงกัน (Inter-company invariant ✓)
+                </div>
+              ) : (
+                <div className="flex items-start gap-2 rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+                  <AlertTriangle className="h-4 w-4 mt-0.5" />
+                  <div>
+                    <strong>ยอดสองฝั่งไม่ตรงกัน</strong> — ส่วนต่าง ฿{fmtBaht(Math.abs(balance.drift))}.
+                    ตรวจสอบ JE ที่ผ่านมา หรือแจ้งฝ่าย dev ทันที
+                  </div>
+                </div>
+              )}
+
+              <Button
+                onClick={() => setDialogOpen(true)}
+                disabled={balance.financeOwesToShop <= 0}
+                className="w-full md:w-auto"
+              >
+                บันทึกการชำระเงิน
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </QueryBoundary>
+
+      <QueryBoundary isLoading={historyQ.isLoading} isError={historyQ.isError} error={historyQ.error} onRetry={() => historyQ.refetch()}>
+        <Card>
+          <CardHeader>
+            <h2 className="text-lg font-semibold flex items-center gap-2">
+              <History className="h-5 w-5 text-muted-foreground" />
+              ประวัติการชำระล่าสุด
+            </h2>
+          </CardHeader>
+          <CardContent>
+            {settlementHistory.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-8">
+                ยังไม่มีรายการชำระระหว่างบริษัท
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {settlementHistory.slice(0, 20).map((entry) => {
+                  const cashLine = entry.lines.find(
+                    (l) => l.accountCode === '11-1101' && Number(l.debit) > 0,
+                  );
+                  const amt = cashLine ? Number(cashLine.debit) : 0;
+                  const isShopSide = entry.description.includes('(SHOP)');
+                  return (
+                    <div
+                      key={entry.id}
+                      className="flex items-center justify-between rounded-md border border-border bg-card p-3"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">
+                          {entry.referenceId}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatThaiDateShort(new Date(entry.entryDate))} •{' '}
+                          {isShopSide ? 'SHOP' : 'FINANCE'}
+                        </p>
+                      </div>
+                      <p className="text-sm font-semibold tabular-nums">
+                        ฿{fmtBaht(amt)}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </QueryBoundary>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>บันทึกการชำระเงิน FINANCE → SHOP</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="amount">จำนวนเงิน (บาท)</Label>
+              <Input
+                id="amount"
+                type="number"
+                step="0.01"
+                min="0"
+                max={balance?.financeOwesToShop}
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="0.00"
+              />
+              {balance && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  สูงสุด ฿{fmtBaht(balance.financeOwesToShop)}
+                </p>
+              )}
+            </div>
+            <div>
+              <Label htmlFor="reference">เลขที่อ้างอิง (Bank ref / เลขที่โอน)</Label>
+              <Input
+                id="reference"
+                value={reference}
+                onChange={(e) => setReference(e.target.value)}
+                placeholder="เช่น TXN-2026-04-001"
+                maxLength={50}
+              />
+            </div>
+            <div>
+              <Label htmlFor="paidDate">วันที่ชำระ</Label>
+              <Input
+                id="paidDate"
+                type="date"
+                value={paidDate}
+                onChange={(e) => setPaidDate(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="notes">หมายเหตุ (ถ้ามี)</Label>
+              <Textarea
+                id="notes"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={2}
+                maxLength={500}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+              ยกเลิก
+            </Button>
+            <Button onClick={handleSubmit} disabled={settleMut.isPending}>
+              {settleMut.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              บันทึก
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes 3 follow-ups from Phase A.3:

- **W-2** — `generateEntryNumber` + `generateReceiptNumber` race condition on first JE/receipt of new month
- **W-4** — Explicit `Sales Discount` expense in early payoff (CPA-friendly P&L)
- **Frontend** — `/accounting/intercompany` page with live balance + settlement form + history

## W-2 detail
Both functions previously used `SELECT ... FOR UPDATE` which only locks existing rows. First-of-month had no row to lock → 2 concurrent callers both saw empty → both wrote `-0001` → P2002 collision → tx rollback (lost contract activation / payment).

Switched to `pg_advisory_xact_lock(YYYYMM::bigint)` (and `1<YYYYMM>` for receipts to namespace separately). Lock auto-releases at commit/rollback.

## W-4 detail
Discount on early payoff was implicit in Cr/Dr asymmetry (Cr Interest Income only for collected amount). Now broken out explicitly:
- Cr Income at FULL Unearned drain
- Dr `53-1805 ส่วนลดให้ลูกค้า — ดอกเบี้ย/VAT` (FINANCE) for interest+VAT discount
- Dr `53-1801 ส่วนลดให้ลูกค้า — คอมมิชชัน` (SHOP) for commission discount

Visible as P&L line item per Thai accounting practice (ส่วนลดจ่าย).

## Frontend detail
New page at `/accounting/intercompany`:
- Balance card with both side amounts + IC invariant drift detection
- Settlement dialog (amount/ref/date/notes, validates ≤ outstanding)
- History of recent IC settlements

Wired into menu under "ปิดบัญชี" group (OWNER, FM, ACCT).

## Verification
- Jest: **2226/188 pass**
- TypeScript: 0 errors
- Lint: 0 errors

## Test plan
- [ ] Run prod seed for new accounts (53-1805 FINANCE + 53-1801 SHOP) via Cloud Run Job
- [ ] Visit `/accounting/intercompany` after deploy → balance shows correctly
- [ ] Test settlement: enter amount + ref → verify both JEs posted + balance reduced
- [ ] Trigger one early payoff with discount on prod → verify Sales Discount expense visible in trial balance

## Deferred (won't block this PR)
- Settlement cron job for monthly auto-settle — owner-decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)