### PR TITLE
fix(payments): handle paginated response in PaymentHistorySheet

### DIFF
--- a/apps/web/src/components/payment/PaymentHistorySheet.tsx
+++ b/apps/web/src/components/payment/PaymentHistorySheet.tsx
@@ -69,8 +69,8 @@ export default function PaymentHistorySheet({ contractId, onClose }: PaymentHist
   const { data: payments = [], isLoading: loadingPayments } = useQuery<PaymentItem[]>({
     queryKey: ['contract-payments', contractId],
     queryFn: async () => {
-      const { data } = await api.get(`/payments/contract/${contractId}`);
-      return data;
+      const { data } = await api.get(`/payments/contract/${contractId}`, { params: { limit: 200 } });
+      return data.data;
     },
     enabled: !!contractId,
   });


### PR DESCRIPTION
## Summary
- กดปุ่ม **ประวัติ** ใน [/payments](https://bestchoicephone.app/payments) → error `f.reduce is not a function` → Sheet ไม่เปิด
- Root cause: `GET /payments/contract/:id` คืน paginated wrapper `{ data, total, page, limit, totalPages }` แต่ frontend type เป็น `PaymentItem[]` แล้วเรียก `.reduce()` บน object → throw
- Fix: extract `data.data` + ส่ง `limit=200` กัน totals ผิดถ้าสัญญายาว (default = 50)

## Test plan
- [ ] login เข้า /payments
- [ ] กดปุ่ม "ประวัติ" บน row ใดก็ได้
- [ ] Sheet ต้องเปิดแสดงงวดทั้งหมด + สรุป "ชำระแล้วรวม" / "ยอดคงค้าง" ถูกต้อง

🤖 Generated with [Claude Code](https://claude.com/claude-code)