### PR TITLE
feat(collections): show date + amount on promise slot chips

### DIFF
--- a/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
+++ b/apps/web/src/pages/CollectionsPage/tabs/PromiseTab.tsx
@@ -143,7 +143,7 @@ function PromiseCycleView({ row }: { row: ContractRow }) {
                 className={`px-2 py-0.5 rounded text-xs font-medium leading-snug ${tone}`}
                 title={`งวดที่ ${s.slotIndex} — ${slotDate} · ${s.settlementAmount.toLocaleString()} ฿`}
               >
-                งวด {s.slotIndex}
+                งวด {s.slotIndex} · {slotDate} · {s.settlementAmount.toLocaleString()} ฿
               </div>
             );
           })}


### PR DESCRIPTION
## Summary
- Promise slot chips ในหน้า /collections (PromiseTab cycle view) แสดงวันที่ + ยอดบาทติดไปกับชื่องวด เช่น `งวด 1 · 29 เม.ย. 69 · 1,000 ฿`
- เดิมต้อง hover ดู tooltip ถึงจะเห็นวันที่/ยอด — เปลี่ยนเป็น inline เพื่อให้พนักงานทวงสแกนได้เร็ว
- Tooltip คงไว้เหมือนเดิม (สำหรับ screen reader / fallback)

## Test plan
- [ ] เปิด /collections → tab "นัดชำระ" → ดู chip งวดใต้การ์ด เห็น "งวด 1 · 29 เม.ย. 69 · 1,000 ฿"
- [ ] ตรวจ kept (เขียว) / broken (แดง) / pending (เทา) ทั้ง 3 สถานะ format ถูกต้อง
- [ ] ตรวจ chip ไม่ล้น layout เมื่อมี 3+ slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)