### PR TITLE
feat(accounting): Phase A.5c FINANCE deferred items (PPE depreciation, WHT, tax-disallowed)

### DIFF
--- a/apps/api/prisma/migrations/20260802000000_phase_a5c_asset_register/migration.sql
+++ b/apps/api/prisma/migrations/20260802000000_phase_a5c_asset_register/migration.sql
@@ -1,0 +1,40 @@
+-- Phase A.5c Wave 1 — PPE infrastructure
+-- Adds AssetCategory enum, WRITTEN_OFF to AssetStatus, extends FixedAsset,
+-- and creates DepreciationEntry idempotency table.
+
+-- CreateEnum
+CREATE TYPE "AssetCategory" AS ENUM ('OFFICE_EQUIPMENT', 'BUILDING_IMPROVEMENT', 'OFFICE_FURNITURE', 'VEHICLE');
+
+-- AlterEnum: add WRITTEN_OFF to AssetStatus
+ALTER TYPE "AssetStatus" ADD VALUE 'WRITTEN_OFF';
+
+-- AlterTable fixed_assets
+ALTER TABLE "fixed_assets"
+  ADD COLUMN "asset_category" "AssetCategory",
+  ADD COLUMN "disposal_proceeds" DECIMAL(12,2),
+  ADD COLUMN "last_depreciation_period" TEXT,
+  ADD COLUMN "useful_life_months" INTEGER;
+
+-- CreateTable depreciation_entries
+CREATE TABLE "depreciation_entries" (
+    "id" TEXT NOT NULL,
+    "asset_id" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "journal_entry_no" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "depreciation_entries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "depreciation_entries_period_idx" ON "depreciation_entries"("period");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "depreciation_entries_asset_id_period_key" ON "depreciation_entries"("asset_id", "period");
+
+-- CreateIndex
+CREATE INDEX "fixed_assets_asset_category_status_idx" ON "fixed_assets"("asset_category", "status");
+
+-- AddForeignKey
+ALTER TABLE "depreciation_entries" ADD CONSTRAINT "depreciation_entries_asset_id_fkey" FOREIGN KEY ("asset_id") REFERENCES "fixed_assets"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260802100000_phase_a5c_tax_disallowed_flag/migration.sql
+++ b/apps/api/prisma/migrations/20260802100000_phase_a5c_tax_disallowed_flag/migration.sql
@@ -1,0 +1,5 @@
+-- Phase A.5c: Add taxDisallowed flag and disallowedReason to Expense
+-- Migration: phase_a5c_tax_disallowed_flag
+
+ALTER TABLE "expenses" ADD COLUMN "tax_disallowed" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "expenses" ADD COLUMN "disallowed_reason" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3449,6 +3449,13 @@ model Expense {
   isRecurring  Boolean @default(false) @map("is_recurring")
   recurringDay Int?    @map("recurring_day")
 
+  // Tax-disallowed expense flag (Phase A.5c)
+  // When true, the expense routes to 54-XXXX accounts and cannot claim VAT input.
+  // Reasons: NO_RECEIPT (ไม่มีใบเสร็จ), PERSONAL_USE (ใช้ส่วนตัว),
+  //          PENALTY (เบี้ยปรับ), OTHER (อื่นๆ)
+  taxDisallowed    Boolean @default(false) @map("tax_disallowed")
+  disallowedReason String? @map("disallowed_reason")
+
   note String?
 
   createdAt DateTime  @default(now()) @map("created_at")

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3001,23 +3001,41 @@ enum AssetStatus {
   ACTIVE // ใช้งานอยู่
   FULLY_DEPRECIATED // หักค่าเสื่อมราคาครบแล้ว
   DISPOSED // จำหน่ายแล้ว
+  WRITTEN_OFF // ตัดบัญชีสินทรัพย์แล้ว (ไม่มีราคาขาย)
+}
+
+/// Phase A.5c — Typed category enum maps to specific Dr/Cr account codes
+enum AssetCategory {
+  OFFICE_EQUIPMENT     // Dr 53-1601 / Cr 12-2102
+  BUILDING_IMPROVEMENT // Dr 53-1602 / Cr 12-2104
+  OFFICE_FURNITURE     // Dr 53-1603 / Cr 12-2106
+  VEHICLE              // Dr 53-1604 / Cr 12-2108
 }
 
 model FixedAsset {
-  id               String      @id @default(uuid())
-  assetCode        String      @unique @map("asset_code") // รหัสสินทรัพย์ e.g. "PA-20241200002"
+  id               String        @id @default(uuid())
+  assetCode        String        @unique @map("asset_code") // รหัสสินทรัพย์ e.g. "PA-20241200002"
   name             String // ชื่อสินทรัพย์
   description      String?
-  category         String? // หมวดหมู่ (อุปกรณ์สำนักงาน, ส่วนปรับปรุงอาคาร, เครื่องตกแต่ง, ยานพาหนะ)
-  branchId         String?     @map("branch_id")
-  costValue        Decimal     @map("cost_value") @db.Decimal(12, 2) // ราคาทุนที่ซื้อมา
-  salvageValue     Decimal     @default(0) @map("salvage_value") @db.Decimal(12, 2) // ราคาซาก (ปกติ 1 บาท หรือ 0)
-  usefulLife       Int         @map("useful_life") // อายุการใช้งาน (จำนวนปี เช่น 5 ปี)
-  purchaseDate     DateTime    @map("purchase_date") // วันที่ซื้อ/เริ่มใช้งาน
-  accumulatedDepre Decimal     @default(0) @map("accumulated_depre") @db.Decimal(12, 2) // ค่าเสื่อมราคาสะสม
-  status           AssetStatus @default(ACTIVE)
-  disposedAt       DateTime?   @map("disposed_at")
-  disposalNote     String?     @map("disposal_note")
+  /// Free-form category string (legacy). Use assetCategory for A.5c depreciation journal routing.
+  category         String?       // หมวดหมู่ (อุปกรณ์สำนักงาน, ส่วนปรับปรุงอาคาร, เครื่องตกแต่ง, ยานพาหนะ)
+  /// Phase A.5c: typed category for precise account code routing
+  assetCategory    AssetCategory? @map("asset_category")
+  branchId         String?       @map("branch_id")
+  costValue        Decimal       @map("cost_value") @db.Decimal(12, 2) // ราคาทุนที่ซื้อมา
+  salvageValue     Decimal       @default(0) @map("salvage_value") @db.Decimal(12, 2) // ราคาซาก (ปกติ 1 บาท หรือ 0)
+  usefulLife       Int           @map("useful_life") // อายุการใช้งาน (จำนวนปี เช่น 5 ปี)
+  /// Phase A.5c: useful life in months (overrides usefulLife when set; takes precedence)
+  usefulLifeMonths Int?          @map("useful_life_months")
+  purchaseDate     DateTime      @map("purchase_date") // วันที่ซื้อ/เริ่มใช้งาน
+  accumulatedDepre Decimal       @default(0) @map("accumulated_depre") @db.Decimal(12, 2) // ค่าเสื่อมราคาสะสม
+  status           AssetStatus   @default(ACTIVE)
+  disposedAt       DateTime?     @map("disposed_at")
+  disposalNote     String?       @map("disposal_note")
+  /// Phase A.5c: disposal proceeds for gain/loss calculation
+  disposalProceeds Decimal?      @map("disposal_proceeds") @db.Decimal(12, 2)
+  /// Phase A.5c: period of last depreciation accrual e.g. "2026-04"; null = never depreciated
+  lastDepreciationPeriod String? @map("last_depreciation_period")
 
   // Account codes for journal entries
   depreciationAccountCode String @default("53-1601") @map("depreciation_account_code") // Dr: ค่าเสื่อมราคา (Expense)
@@ -3028,14 +3046,33 @@ model FixedAsset {
   updatedAt   DateTime  @updatedAt @map("updated_at")
   deletedAt   DateTime? @map("deleted_at")
 
-  branch    Branch? @relation(fields: [branchId], references: [id])
-  createdBy User?   @relation("AssetCreatedBy", fields: [createdById], references: [id])
+  branch               Branch?             @relation(fields: [branchId], references: [id])
+  createdBy            User?               @relation("AssetCreatedBy", fields: [createdById], references: [id])
+  depreciationEntries  DepreciationEntry[]
 
   @@index([branchId])
   @@index([status])
   @@index([category])
+  @@index([assetCategory, status])
   @@index([purchaseDate])
   @@map("fixed_assets")
+}
+
+/// Phase A.5c — Idempotency record: one depreciation JE per asset per period
+/// Immutable audit log — updatedAt/deletedAt intentionally omitted
+model DepreciationEntry {
+  id             String     @id @default(uuid())
+  assetId        String     @map("asset_id")
+  asset          FixedAsset @relation(fields: [assetId], references: [id], onDelete: Restrict)
+  period         String     // "2026-04"
+  amount         Decimal    @db.Decimal(12, 2)
+  journalEntryNo String?    @map("journal_entry_no") // JE-202604-00001
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([assetId, period])
+  @@index([period])
+  @@map("depreciation_entries")
 }
 
 // ============================================================

--- a/apps/api/src/modules/accounting/dto/expense.dto.ts
+++ b/apps/api/src/modules/accounting/dto/expense.dto.ts
@@ -5,6 +5,7 @@ import {
   IsEnum,
   IsDateString,
   IsBoolean,
+  IsIn,
   Min,
   Max,
   IsInt,
@@ -103,6 +104,15 @@ export class CreateExpenseDto {
   recurringDay?: number;
 
   @IsOptional()
+  @IsBoolean()
+  taxDisallowed?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['NO_RECEIPT', 'PERSONAL_USE', 'PENALTY', 'OTHER'])
+  disallowedReason?: string;
+
+  @IsOptional()
   @IsString()
   note?: string;
 }
@@ -170,6 +180,15 @@ export class UpdateExpenseDto {
   @IsOptional()
   @IsString()
   taxInvoiceNo?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  taxDisallowed?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['NO_RECEIPT', 'PERSONAL_USE', 'PENALTY', 'OTHER'])
+  disallowedReason?: string;
 
   @IsOptional()
   @IsString()

--- a/apps/api/src/modules/asset/asset.module.ts
+++ b/apps/api/src/modules/asset/asset.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AssetController } from './asset.controller';
 import { AssetService } from './asset.service';
+import { JournalModule } from '../journal/journal.module';
 
 @Module({
+  imports: [JournalModule],
   controllers: [AssetController],
   providers: [AssetService],
   exports: [AssetService],

--- a/apps/api/src/modules/asset/asset.service.ts
+++ b/apps/api/src/modules/asset/asset.service.ts
@@ -1,14 +1,19 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import * as Sentry from '@sentry/nestjs';
+import { Decimal } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateFixedAssetDto, UpdateFixedAssetDto, DisposeAssetDto } from './dto/asset.dto';
+import { AssetDisposalTemplate } from '../journal/cpa-templates/asset-disposal.template';
 
 @Injectable()
 export class AssetService {
   private readonly logger = new Logger(AssetService.name);
 
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private disposalTemplate: AssetDisposalTemplate,
+  ) {}
 
   /**
    * Generate asset code: PA-YYYYMMXXXX
@@ -36,10 +41,12 @@ export class AssetService {
         name: dto.name,
         description: dto.description,
         category: dto.category,
+        assetCategory: dto.assetCategory ?? null,
         branchId: dto.branchId,
         costValue: dto.costValue,
         salvageValue: dto.salvageValue ?? 0,
         usefulLife: dto.usefulLife,
+        usefulLifeMonths: dto.usefulLifeMonths ?? null,
         purchaseDate: new Date(dto.purchaseDate),
         depreciationAccountCode: dto.depreciationAccountCode ?? '53-1601',
         accumulatedAccountCode: dto.accumulatedAccountCode ?? '12-2102',
@@ -141,7 +148,8 @@ export class AssetService {
   }
 
   /**
-   * Dispose an asset (soft disposal)
+   * Dispose an asset — posts AssetDisposalTemplate JE (Phase A.5c).
+   * Updates asset status to DISPOSED and records disposal proceeds.
    */
   async dispose(id: string, dto: DisposeAssetDto) {
     const existing = await this.prisma.fixedAsset.findFirst({
@@ -151,14 +159,28 @@ export class AssetService {
       throw new NotFoundException('ไม่พบสินทรัพย์ที่ระบุ');
     }
 
-    return this.prisma.fixedAsset.update({
-      where: { id },
-      data: {
-        status: 'DISPOSED',
-        disposedAt: new Date(),
-        disposalNote: dto.disposalNote,
-      },
+    const result = await this.disposalTemplate.execute({
+      assetId: id,
+      disposalDate: new Date(),
+      disposalProceeds: new Decimal(dto.disposalProceeds?.toString() ?? '0'),
+      depositAccountCode: dto.depositAccountCode,
     });
+
+    // Add disposalNote if provided (template already sets a default)
+    if (dto.disposalNote) {
+      await this.prisma.fixedAsset.update({
+        where: { id },
+        data: { disposalNote: dto.disposalNote },
+      });
+    }
+
+    return {
+      ...(await this.prisma.fixedAsset.findFirst({
+        where: { id },
+        include: { branch: true },
+      })),
+      journalEntryNo: result.entryNo,
+    };
   }
 
   /**

--- a/apps/api/src/modules/asset/dto/asset.dto.ts
+++ b/apps/api/src/modules/asset/dto/asset.dto.ts
@@ -3,10 +3,18 @@ import {
   IsNotEmpty,
   IsOptional,
   IsNumber,
+  IsEnum,
   Min,
   IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+
+export enum AssetCategoryDto {
+  OFFICE_EQUIPMENT = 'OFFICE_EQUIPMENT',
+  BUILDING_IMPROVEMENT = 'BUILDING_IMPROVEMENT',
+  OFFICE_FURNITURE = 'OFFICE_FURNITURE',
+  VEHICLE = 'VEHICLE',
+}
 
 export class CreateFixedAssetDto {
   @IsString({ message: 'กรุณาระบุรหัสสินทรัพย์' })
@@ -24,6 +32,11 @@ export class CreateFixedAssetDto {
   @IsOptional()
   @IsString()
   category?: string;
+
+  /** Phase A.5c: typed category for precise account code routing */
+  @IsOptional()
+  @IsEnum(AssetCategoryDto, { message: 'ประเภทสินทรัพย์ไม่ถูกต้อง' })
+  assetCategory?: AssetCategoryDto;
 
   @IsOptional()
   @IsString()
@@ -44,6 +57,13 @@ export class CreateFixedAssetDto {
   @IsNumber({}, { message: 'กรุณาระบุอายุการใช้งาน (ปี)' })
   @Min(1, { message: 'อายุการใช้งานต้องอย่างน้อย 1 ปี' })
   usefulLife: number;
+
+  /** Phase A.5c: useful life in months (takes precedence over usefulLife when set) */
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({}, { message: 'อายุการใช้งาน (เดือน) ต้องเป็นตัวเลข' })
+  @Min(1, { message: 'อายุการใช้งาน (เดือน) ต้องอย่างน้อย 1 เดือน' })
+  usefulLifeMonths?: number;
 
   @IsDateString({}, { message: 'กรุณาระบุวันที่ซื้อ' })
   purchaseDate: string;
@@ -113,4 +133,16 @@ export class DisposeAssetDto {
   @IsOptional()
   @IsString()
   disposalNote?: string;
+
+  /** Phase A.5c: proceeds from asset sale (0 = write-off/no proceeds) */
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({}, { message: 'รายได้จากการจำหน่ายต้องเป็นตัวเลข' })
+  @Min(0, { message: 'รายได้จากการจำหน่ายต้องไม่ต่ำกว่า 0' })
+  disposalProceeds?: number = 0;
+
+  /** Phase A.5c: cash/bank account to receive proceeds; defaults to 11-1101 */
+  @IsOptional()
+  @IsString()
+  depositAccountCode?: string;
 }

--- a/apps/api/src/modules/journal/cpa-templates/asset-disposal.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/asset-disposal.template.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { seedFinanceCoa } from '../../../../prisma/seed-coa-finance';
+import { AssetDisposalTemplate } from './asset-disposal.template';
+import { JournalAutoService } from '../journal-auto.service';
+
+const prisma = new PrismaClient();
+
+async function ensureTestAsset(opts: {
+  assetCategory?: string;
+  costValue?: number;
+  salvageValue?: number;
+  accumulatedDepre?: number;
+  status?: string;
+}) {
+  const assetCode = `DIS-TEST-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  return prisma.fixedAsset.create({
+    data: {
+      assetCode,
+      name: `Disposal Test Asset ${assetCode}`,
+      category: opts.assetCategory ?? 'OFFICE_EQUIPMENT',
+      assetCategory: (opts.assetCategory ?? 'OFFICE_EQUIPMENT') as any,
+      costValue: new Decimal(opts.costValue ?? 100000),
+      salvageValue: new Decimal(opts.salvageValue ?? 0),
+      usefulLife: 5,
+      usefulLifeMonths: 60,
+      purchaseDate: new Date('2024-01-01'),
+      accumulatedDepre: new Decimal(opts.accumulatedDepre ?? 40000),
+      depreciationAccountCode: '53-1601',
+      accumulatedAccountCode: '12-2102',
+      status: (opts.status ?? 'ACTIVE') as any,
+    },
+  });
+}
+
+async function setup() {
+  await prisma.depreciationEntry.deleteMany({});
+  await prisma.journalLine.deleteMany({});
+  await prisma.journalEntry.deleteMany({});
+  await seedFinanceCoa(prisma);
+
+  const existing = await prisma.user.findFirst({ where: { email: 'admin@bestchoice.com' } });
+  if (!existing) {
+    await prisma.user.create({
+      data: { email: 'admin@bestchoice.com', password: 'x', name: 'admin', role: 'OWNER' },
+    });
+  }
+
+  return new JournalAutoService(prisma as any);
+}
+
+describe('AssetDisposalTemplate', () => {
+  let journal: JournalAutoService;
+
+  beforeAll(async () => {
+    journal = await setup();
+  });
+
+  it('loss case: NBV=60000, proceeds=50000 → Dr 53-1605 ขาดทุน 10000', async () => {
+    // cost=100000, accumulated=40000, NBV=60000, proceeds=50000, loss=10000
+    const asset = await ensureTestAsset({
+      assetCategory: 'OFFICE_EQUIPMENT',
+      costValue: 100000,
+      accumulatedDepre: 40000,
+    });
+
+    const tmpl = new AssetDisposalTemplate(journal, prisma as any);
+    const result = await tmpl.execute({
+      assetId: asset.id,
+      disposalDate: new Date('2026-04-30'),
+      disposalProceeds: 50000,
+      depositAccountCode: '11-1101',
+    });
+
+    expect(result.entryNo).toMatch(/^JE-/);
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { metadata: { path: ['assetId'], equals: asset.id } } as any,
+      include: { lines: true },
+    });
+
+    expect(je).toBeDefined();
+    expect(je!.status).toBe('POSTED');
+
+    // Balanced
+    const totalDr = je!.lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = je!.lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Dr accumulated dep 40000
+    const accLine = je!.lines.find((l) => l.accountCode === '12-2102');
+    expect(accLine).toBeDefined();
+    expect(new Decimal(accLine!.debit.toString()).toFixed(2)).toBe('40000.00');
+
+    // Dr cash 50000
+    const cashLine = je!.lines.find((l) => l.accountCode === '11-1101');
+    expect(cashLine).toBeDefined();
+    expect(new Decimal(cashLine!.debit.toString()).toFixed(2)).toBe('50000.00');
+
+    // Dr loss 10000
+    const lossLine = je!.lines.find((l) => l.accountCode === '53-1605');
+    expect(lossLine).toBeDefined();
+    expect(new Decimal(lossLine!.debit.toString()).toFixed(2)).toBe('10000.00');
+
+    // Cr asset cost 100000
+    const costLine = je!.lines.find((l) => l.accountCode === '12-2101');
+    expect(costLine).toBeDefined();
+    expect(new Decimal(costLine!.credit.toString()).toFixed(2)).toBe('100000.00');
+
+    // Asset status → DISPOSED
+    const updated = await prisma.fixedAsset.findFirst({ where: { id: asset.id } });
+    expect(updated!.status).toBe('DISPOSED');
+    expect(new Decimal(updated!.disposalProceeds!.toString()).toFixed(2)).toBe('50000.00');
+  });
+
+  it('gain case: NBV=20000, proceeds=30000 → Cr 41-1102 กำไร 10000', async () => {
+    // cost=100000, accumulated=80000, NBV=20000, proceeds=30000, gain=10000
+    const asset = await ensureTestAsset({
+      assetCategory: 'OFFICE_EQUIPMENT',
+      costValue: 100000,
+      accumulatedDepre: 80000,
+    });
+
+    const tmpl = new AssetDisposalTemplate(journal, prisma as any);
+    const result = await tmpl.execute({
+      assetId: asset.id,
+      disposalDate: new Date('2026-04-30'),
+      disposalProceeds: 30000,
+      depositAccountCode: '11-1101',
+    });
+
+    expect(result.entryNo).toMatch(/^JE-/);
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { metadata: { path: ['assetId'], equals: asset.id } } as any,
+      include: { lines: true },
+    });
+
+    // Balanced
+    const totalDr = je!.lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = je!.lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Cr gain 10000 (interim account 41-1102)
+    const gainLine = je!.lines.find((l) => l.accountCode === '41-1102');
+    expect(gainLine).toBeDefined();
+    expect(new Decimal(gainLine!.credit.toString()).toFixed(2)).toBe('10000.00');
+
+    // No loss line
+    const lossLine = je!.lines.find((l) => l.accountCode === '53-1605');
+    expect(lossLine).toBeUndefined();
+
+    const updated = await prisma.fixedAsset.findFirst({ where: { id: asset.id } });
+    expect(updated!.status).toBe('DISPOSED');
+  });
+
+  it('zero proceeds write-off: Dr 53-1605 = full NBV', async () => {
+    // cost=50000, accumulated=20000, NBV=30000, proceeds=0, loss=30000
+    const asset = await ensureTestAsset({
+      assetCategory: 'OFFICE_FURNITURE',
+      costValue: 50000,
+      accumulatedDepre: 20000,
+    });
+
+    const tmpl = new AssetDisposalTemplate(journal, prisma as any);
+    await tmpl.execute({
+      assetId: asset.id,
+      disposalDate: new Date(),
+      disposalProceeds: 0,
+    });
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { metadata: { path: ['assetId'], equals: asset.id } } as any,
+      include: { lines: true },
+    });
+
+    const lossLine = je!.lines.find((l) => l.accountCode === '53-1605');
+    expect(lossLine).toBeDefined();
+    expect(new Decimal(lossLine!.debit.toString()).toFixed(2)).toBe('30000.00');
+
+    // No cash line (proceeds=0)
+    const cashLine = je!.lines.find((l) => l.accountCode === '11-1101');
+    expect(cashLine).toBeUndefined();
+  });
+
+  it('throws if asset already DISPOSED', async () => {
+    const asset = await ensureTestAsset({ status: 'DISPOSED' });
+
+    const tmpl = new AssetDisposalTemplate(journal, prisma as any);
+    await expect(
+      tmpl.execute({ assetId: asset.id, disposalDate: new Date(), disposalProceeds: 0 }),
+    ).rejects.toThrow('ถูกจำหน่ายแล้ว');
+  });
+
+  it('uses VEHICLE account codes: 12-2107 / 12-2108', async () => {
+    const asset = await ensureTestAsset({
+      assetCategory: 'VEHICLE',
+      costValue: 500000,
+      accumulatedDepre: 200000,
+    });
+
+    const tmpl = new AssetDisposalTemplate(journal, prisma as any);
+    await tmpl.execute({
+      assetId: asset.id,
+      disposalDate: new Date(),
+      disposalProceeds: 250000,
+      depositAccountCode: '11-1101',
+    });
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { metadata: { path: ['assetId'], equals: asset.id } } as any,
+      include: { lines: true },
+    });
+
+    // Cr asset cost 12-2107
+    const costLine = je!.lines.find((l) => l.accountCode === '12-2107');
+    expect(costLine).toBeDefined();
+
+    // Dr accumulated 12-2108
+    const accLine = je!.lines.find((l) => l.accountCode === '12-2108');
+    expect(accLine).toBeDefined();
+  });
+});

--- a/apps/api/src/modules/journal/cpa-templates/asset-disposal.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/asset-disposal.template.ts
@@ -1,0 +1,192 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { JournalAutoService } from '../journal-auto.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/** Maps AssetCategory → [assetCostCode, accumulatedDepCode] */
+const CATEGORY_ASSET_CODE_MAP: Record<string, [string, string]> = {
+  OFFICE_EQUIPMENT: ['12-2101', '12-2102'],
+  BUILDING_IMPROVEMENT: ['12-2103', '12-2104'],
+  OFFICE_FURNITURE: ['12-2105', '12-2106'],
+  VEHICLE: ['12-2107', '12-2108'],
+};
+
+const LOSS_ON_DISPOSAL_CODE = '53-1605'; // ขาดทุนจากการจำหน่ายสินทรัพย์
+// TODO: Add dedicated gain-on-disposal income account (e.g. 41-1201 รายได้จากการจำหน่ายสินทรัพย์)
+// when owner requests it. For now, gains route to 41-1102 (รายได้จากการยึดสินค้า) as closest FINANCE income.
+const GAIN_ON_DISPOSAL_CODE = '41-1102'; // interim — see TODO above
+
+export interface AssetDisposalInput {
+  assetId: string;
+  disposalDate: Date;
+  disposalProceeds: Decimal | string | number;
+  /** Cash/bank account to receive proceeds, defaults to 11-1101 */
+  depositAccountCode?: string;
+}
+
+/**
+ * Template — Asset disposal (Phase A.5c).
+ *
+ * Loss case (NBV > proceeds):
+ *   Dr 12-210X+1 ค่าเสื่อมราคาสะสม       [accumulatedDepre]
+ *   Dr 11-1101   เงินสด/ธนาคาร            [disposalProceeds]
+ *   Dr 53-1605   ขาดทุนจากการจำหน่าย     [NBV - proceeds]
+ *     Cr 12-210X สินทรัพย์               [costValue]
+ *
+ * Gain case (proceeds > NBV):
+ *   Dr 12-210X+1 ค่าเสื่อมราคาสะสม       [accumulatedDepre]
+ *   Dr 11-1101   เงินสด/ธนาคาร            [disposalProceeds]
+ *     Cr 12-210X สินทรัพย์               [costValue]
+ *     Cr 41-1102 รายได้ (interim)        [proceeds - NBV]
+ *       ↑ TODO: replace with dedicated gain account when chart is extended
+ *
+ * Zero-proceeds write-off:
+ *   Dr 12-210X+1 ค่าเสื่อมราคาสะสม       [accumulatedDepre]
+ *   Dr 53-1605   ขาดทุนจากการจำหน่าย     [NBV]
+ *     Cr 12-210X สินทรัพย์               [costValue]
+ *
+ * After JE: asset.status → DISPOSED, disposalDate, disposalProceeds set.
+ */
+@Injectable()
+export class AssetDisposalTemplate {
+  private readonly logger = new Logger(AssetDisposalTemplate.name);
+
+  constructor(
+    private readonly journal: JournalAutoService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async execute(input: AssetDisposalInput): Promise<{ entryNo: string }> {
+    const { assetId, disposalDate, depositAccountCode = '11-1101' } = input;
+    const proceeds = new Decimal(input.disposalProceeds.toString());
+
+    if (proceeds.lt(0)) {
+      throw new BadRequestException('disposalProceeds ต้องมีค่าตั้งแต่ 0 ขึ้นไป');
+    }
+
+    const asset = await this.prisma.fixedAsset.findFirst({
+      where: { id: assetId, deletedAt: null },
+    });
+
+    if (!asset) {
+      throw new BadRequestException(`ไม่พบสินทรัพย์ id=${assetId}`);
+    }
+
+    if (asset.status === 'DISPOSED' || asset.status === 'WRITTEN_OFF') {
+      throw new BadRequestException(
+        `สินทรัพย์ ${asset.assetCode} ถูกจำหน่ายแล้ว (status=${asset.status})`,
+      );
+    }
+
+    // Resolve asset cost/accumulated account codes from assetCategory
+    let assetCostCode: string;
+    let accumulatedCode: string;
+
+    if (asset.assetCategory && CATEGORY_ASSET_CODE_MAP[asset.assetCategory]) {
+      [assetCostCode, accumulatedCode] = CATEGORY_ASSET_CODE_MAP[asset.assetCategory];
+    } else {
+      // Legacy: use stored accumulated code, derive cost code from accumulated (remove last digit + replace)
+      accumulatedCode = asset.accumulatedAccountCode;
+      // For legacy assets without assetCategory, use stored depreciation account's accumulated pair
+      // Best-effort: assume cost code is accumulated minus the +1 suffix
+      // e.g. "12-2102" → "12-2101"; "12-2104" → "12-2103"; "12-2106" → "12-2105"; "12-2108" → "12-2107"
+      const lastChar = accumulatedCode.slice(-1);
+      const lastDigit = parseInt(lastChar, 10);
+      assetCostCode = accumulatedCode.slice(0, -1) + (lastDigit - 1).toString();
+      this.logger.warn(
+        `[A.5c] AssetDisposalTemplate: asset ${asset.assetCode} has no assetCategory — derived cost code ${assetCostCode}`,
+      );
+    }
+
+    const costValue = new Decimal(asset.costValue.toString());
+    const accumulatedDepre = new Decimal(asset.accumulatedDepre.toString());
+    const nbv = costValue.minus(accumulatedDepre);
+    const zero = new Decimal(0);
+
+    const lines: { accountCode: string; dr: Decimal; cr: Decimal; description?: string }[] = [];
+
+    // Dr: derecognize accumulated depreciation
+    if (accumulatedDepre.gt(0)) {
+      lines.push({
+        accountCode: accumulatedCode,
+        dr: accumulatedDepre,
+        cr: zero,
+        description: `ตัดค่าเสื่อมราคาสะสม - ${asset.name}`,
+      });
+    }
+
+    // Dr: cash/bank proceeds (if any)
+    if (proceeds.gt(0)) {
+      lines.push({
+        accountCode: depositAccountCode,
+        dr: proceeds,
+        cr: zero,
+        description: `รับเงินจากจำหน่ายสินทรัพย์ - ${asset.name}`,
+      });
+    }
+
+    // Cr: derecognize asset cost
+    lines.push({
+      accountCode: assetCostCode,
+      dr: zero,
+      cr: costValue,
+      description: `ตัดบัญชีสินทรัพย์ - ${asset.name}`,
+    });
+
+    // Gain or loss
+    const gainOrLoss = proceeds.minus(nbv); // positive = gain, negative = loss
+
+    if (gainOrLoss.lt(0)) {
+      // Loss on disposal
+      lines.push({
+        accountCode: LOSS_ON_DISPOSAL_CODE,
+        dr: gainOrLoss.abs(),
+        cr: zero,
+        description: `ขาดทุนจากการจำหน่ายสินทรัพย์ - ${asset.name}`,
+      });
+    } else if (gainOrLoss.gt(0)) {
+      // Gain on disposal — TODO: replace 41-1102 with dedicated gain account
+      lines.push({
+        accountCode: GAIN_ON_DISPOSAL_CODE,
+        dr: zero,
+        cr: gainOrLoss,
+        description: `กำไรจากการจำหน่ายสินทรัพย์ - ${asset.name} [interim: 41-1102 — TODO add dedicated gain account]`,
+      });
+    }
+    // If gainOrLoss == 0: no extra line needed — already balanced
+
+    const result = await this.journal.createAndPost({
+      description: `จำหน่ายสินทรัพย์ ${asset.assetCode} - ${asset.name}`,
+      reference: `${assetId}:disposal`,
+      metadata: {
+        tag: 'ASSET_DISPOSAL',
+        flow: 'disposal',
+        assetId,
+        assetCode: asset.assetCode,
+        disposalDate: disposalDate.toISOString(),
+        disposalProceeds: proceeds.toFixed(2),
+        nbv: nbv.toFixed(2),
+        gainOrLoss: gainOrLoss.toFixed(2),
+      },
+      postedAt: disposalDate,
+      lines,
+    });
+
+    // Update asset status
+    await this.prisma.fixedAsset.update({
+      where: { id: assetId },
+      data: {
+        status: 'DISPOSED',
+        disposedAt: disposalDate,
+        disposalNote: `จำหน่ายสินทรัพย์ ณ ${disposalDate.toLocaleDateString('th-TH')}`,
+        disposalProceeds: proceeds,
+      },
+    });
+
+    this.logger.log(
+      `[A.5c] AssetDisposalTemplate: posted JE ${result.entryNumber} for asset ${asset.assetCode} proceeds=${proceeds.toFixed(2)} NBV=${nbv.toFixed(2)} gain/loss=${gainOrLoss.toFixed(2)}`,
+    );
+
+    return { entryNo: result.entryNumber };
+  }
+}

--- a/apps/api/src/modules/journal/cpa-templates/depreciation.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/depreciation.template.spec.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { seedFinanceCoa } from '../../../../prisma/seed-coa-finance';
+import { DepreciationTemplate } from './depreciation.template';
+import { JournalAutoService } from '../journal-auto.service';
+
+const prisma = new PrismaClient();
+
+async function ensureTestAsset(opts: {
+  assetCategory?: string;
+  costValue?: number;
+  salvageValue?: number;
+  usefulLifeMonths?: number;
+  usefulLife?: number;
+  accumulatedDepre?: number;
+}) {
+  const assetCode = `DEP-TEST-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  return prisma.fixedAsset.create({
+    data: {
+      assetCode,
+      name: `Test Asset ${assetCode}`,
+      category: opts.assetCategory ?? 'OFFICE_EQUIPMENT',
+      assetCategory: (opts.assetCategory ?? 'OFFICE_EQUIPMENT') as any,
+      costValue: new Decimal(opts.costValue ?? 60000),
+      salvageValue: new Decimal(opts.salvageValue ?? 0),
+      usefulLife: opts.usefulLife ?? 5,
+      usefulLifeMonths: opts.usefulLifeMonths ?? null,
+      purchaseDate: new Date('2026-01-01'),
+      accumulatedDepre: new Decimal(opts.accumulatedDepre ?? 0),
+      depreciationAccountCode: '53-1601',
+      accumulatedAccountCode: '12-2102',
+      status: 'ACTIVE',
+    },
+  });
+}
+
+async function setup() {
+  await prisma.depreciationEntry.deleteMany({});
+  await prisma.journalLine.deleteMany({});
+  await prisma.journalEntry.deleteMany({});
+  await seedFinanceCoa(prisma);
+
+  const existing = await prisma.user.findFirst({ where: { email: 'admin@bestchoice.com' } });
+  if (!existing) {
+    await prisma.user.create({
+      data: { email: 'admin@bestchoice.com', password: 'x', name: 'admin', role: 'OWNER' },
+    });
+  }
+
+  return new JournalAutoService(prisma as any);
+}
+
+describe('DepreciationTemplate', () => {
+  let journal: JournalAutoService;
+
+  beforeAll(async () => {
+    journal = await setup();
+  });
+
+  it('posts balanced JE for OFFICE_EQUIPMENT (Dr 53-1601 / Cr 12-2102)', async () => {
+    // 60,000 / 60 months = 1,000/month
+    const asset = await ensureTestAsset({
+      assetCategory: 'OFFICE_EQUIPMENT',
+      costValue: 60000,
+      salvageValue: 0,
+      usefulLifeMonths: 60,
+    });
+
+    const tmpl = new DepreciationTemplate(journal, prisma as any);
+    const result = await tmpl.execute({ assetId: asset.id, period: '2026-04' });
+
+    expect(result).not.toBeNull();
+    expect(result!.entryNo).toMatch(/^JE-/);
+
+    const je = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'monthly' } } as any,
+          { metadata: { path: ['assetId'], equals: asset.id } } as any,
+        ],
+      },
+      include: { lines: true },
+    });
+
+    expect(je).toBeDefined();
+    expect(je!.status).toBe('POSTED');
+
+    const lines = je!.lines;
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    const drLine = lines.find((l) => l.accountCode === '53-1601');
+    expect(drLine).toBeDefined();
+    expect(new Decimal(drLine!.debit.toString()).toFixed(2)).toBe('1000.00');
+
+    const crLine = lines.find((l) => l.accountCode === '12-2102');
+    expect(crLine).toBeDefined();
+    expect(new Decimal(crLine!.credit.toString()).toFixed(2)).toBe('1000.00');
+
+    // Asset updated
+    const updated = await prisma.fixedAsset.findFirst({ where: { id: asset.id } });
+    expect(new Decimal(updated!.accumulatedDepre.toString()).toFixed(2)).toBe('1000.00');
+    expect(updated!.lastDepreciationPeriod).toBe('2026-04');
+  });
+
+  it('posts correct accounts per category: VEHICLE → Dr 53-1604 / Cr 12-2108', async () => {
+    const asset = await ensureTestAsset({
+      assetCategory: 'VEHICLE',
+      costValue: 120000,
+      usefulLifeMonths: 60,
+    });
+
+    const tmpl = new DepreciationTemplate(journal, prisma as any);
+    const result = await tmpl.execute({ assetId: asset.id, period: '2026-04' });
+
+    expect(result).not.toBeNull();
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { metadata: { path: ['assetId'], equals: asset.id } } as any,
+      include: { lines: true },
+    });
+
+    const drLine = je!.lines.find((l) => l.accountCode === '53-1604');
+    expect(drLine).toBeDefined();
+    const crLine = je!.lines.find((l) => l.accountCode === '12-2108');
+    expect(crLine).toBeDefined();
+  });
+
+  it('is idempotent — second call for same period returns null', async () => {
+    const asset = await ensureTestAsset({ assetCategory: 'OFFICE_FURNITURE', usefulLifeMonths: 60 });
+
+    const tmpl = new DepreciationTemplate(journal, prisma as any);
+    const first = await tmpl.execute({ assetId: asset.id, period: '2026-05' });
+    const second = await tmpl.execute({ assetId: asset.id, period: '2026-05' });
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first!.entryNo).toBe(second!.entryNo);
+
+    const count = await prisma.depreciationEntry.count({
+      where: { assetId: asset.id, period: '2026-05' },
+    });
+    expect(count).toBe(1);
+  });
+
+  it('caps final partial month to remaining depreciable base', async () => {
+    // 60,000 over 60 months = 1,000/month. Start with 59,500 accumulated → remaining 500
+    const asset = await ensureTestAsset({
+      assetCategory: 'OFFICE_EQUIPMENT',
+      costValue: 60000,
+      salvageValue: 0,
+      usefulLifeMonths: 60,
+      accumulatedDepre: 59500,
+    });
+
+    const tmpl = new DepreciationTemplate(journal, prisma as any);
+    const result = await tmpl.execute({ assetId: asset.id, period: '2026-06' });
+
+    expect(result).not.toBeNull();
+
+    const entry = await prisma.depreciationEntry.findFirst({
+      where: { assetId: asset.id, period: '2026-06' },
+    });
+    // Should be capped at 500, not 1000
+    expect(new Decimal(entry!.amount.toString()).toFixed(2)).toBe('500.00');
+
+    const updated = await prisma.fixedAsset.findFirst({ where: { id: asset.id } });
+    expect(updated!.status).toBe('FULLY_DEPRECIATED');
+  });
+
+  it('skips fully depreciated asset', async () => {
+    const asset = await ensureTestAsset({
+      assetCategory: 'BUILDING_IMPROVEMENT',
+      costValue: 30000,
+      salvageValue: 0,
+      usefulLifeMonths: 60,
+      accumulatedDepre: 30000, // fully depreciated
+    });
+
+    const tmpl = new DepreciationTemplate(journal, prisma as any);
+    const result = await tmpl.execute({ assetId: asset.id, period: '2026-07' });
+
+    expect(result).toBeNull();
+  });
+
+  it('skips DISPOSED asset', async () => {
+    const asset = await ensureTestAsset({ assetCategory: 'VEHICLE', usefulLifeMonths: 60 });
+    await prisma.fixedAsset.update({ where: { id: asset.id }, data: { status: 'DISPOSED' } });
+
+    const tmpl = new DepreciationTemplate(journal, prisma as any);
+    const result = await tmpl.execute({ assetId: asset.id, period: '2026-08' });
+
+    expect(result).toBeNull();
+  });
+
+  it('uses usefulLifeMonths over usefulLife (years)', async () => {
+    // usefulLife=5 years would be 60 months → 1000/mo
+    // But usefulLifeMonths=12 → 5000/mo on 60000 cost
+    const asset = await ensureTestAsset({
+      assetCategory: 'OFFICE_EQUIPMENT',
+      costValue: 60000,
+      usefulLife: 5,
+      usefulLifeMonths: 12,
+    });
+
+    const tmpl = new DepreciationTemplate(journal, prisma as any);
+    await tmpl.execute({ assetId: asset.id, period: '2026-09' });
+
+    const entry = await prisma.depreciationEntry.findFirst({
+      where: { assetId: asset.id, period: '2026-09' },
+    });
+    expect(new Decimal(entry!.amount.toString()).toFixed(2)).toBe('5000.00');
+  });
+});

--- a/apps/api/src/modules/journal/cpa-templates/depreciation.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/depreciation.template.ts
@@ -1,0 +1,182 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { JournalAutoService } from '../journal-auto.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/** Maps AssetCategory → [Dr expenseCode, Cr accumulatedCode] */
+const CATEGORY_ACCOUNT_MAP: Record<string, [string, string]> = {
+  OFFICE_EQUIPMENT: ['53-1601', '12-2102'],
+  BUILDING_IMPROVEMENT: ['53-1602', '12-2104'],
+  OFFICE_FURNITURE: ['53-1603', '12-2106'],
+  VEHICLE: ['53-1604', '12-2108'],
+};
+
+const CATEGORY_LABEL: Record<string, string> = {
+  OFFICE_EQUIPMENT: 'อุปกรณ์สำนักงาน',
+  BUILDING_IMPROVEMENT: 'ส่วนปรับปรุงอาคาร',
+  OFFICE_FURNITURE: 'เครื่องตกแต่งสำนักงาน',
+  VEHICLE: 'ยานพาหนะ',
+};
+
+export interface DepreciationTemplateInput {
+  assetId: string;
+  /** Period in "YYYY-MM" format, e.g. "2026-04" */
+  period: string;
+}
+
+/**
+ * Template — Monthly straight-line depreciation (Phase A.5c).
+ *
+ * JE per asset:
+ *   Dr 53-160X ค่าเสื่อมราคา - <category>         [monthlyAmount]
+ *     Cr 12-210X ค่าเสื่อมราคาสะสม - <category>   [monthlyAmount]
+ *
+ * Category → account mapping:
+ *   OFFICE_EQUIPMENT:     Dr 53-1601 / Cr 12-2102
+ *   BUILDING_IMPROVEMENT: Dr 53-1602 / Cr 12-2104
+ *   OFFICE_FURNITURE:     Dr 53-1603 / Cr 12-2106
+ *   VEHICLE:              Dr 53-1604 / Cr 12-2108
+ *
+ * Idempotent: second call for same (assetId, period) returns null.
+ * Guards: ACTIVE status only, not fully depreciated.
+ */
+@Injectable()
+export class DepreciationTemplate {
+  private readonly logger = new Logger(DepreciationTemplate.name);
+
+  constructor(
+    private readonly journal: JournalAutoService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async execute(input: DepreciationTemplateInput): Promise<{ entryNo: string } | null> {
+    const { assetId, period } = input;
+
+    const asset = await this.prisma.fixedAsset.findFirst({
+      where: { id: assetId, deletedAt: null },
+    });
+
+    if (!asset) {
+      this.logger.warn(`[A.5c] DepreciationTemplate: asset ${assetId} not found`);
+      return null;
+    }
+
+    if (asset.status !== 'ACTIVE') {
+      this.logger.log(
+        `[A.5c] DepreciationTemplate: asset ${asset.assetCode} status=${asset.status} — skipping`,
+      );
+      return null;
+    }
+
+    // Idempotency: check DepreciationEntry
+    const existing = await this.prisma.depreciationEntry.findUnique({
+      where: { assetId_period: { assetId, period } },
+    });
+    if (existing) {
+      this.logger.log(
+        `[A.5c] DepreciationTemplate idempotency — entry already exists for asset ${asset.assetCode} period ${period}`,
+      );
+      return existing.journalEntryNo ? { entryNo: existing.journalEntryNo } : null;
+    }
+
+    // Resolve account codes: prefer explicit codes, fall back to assetCategory enum
+    let drCode: string;
+    let crCode: string;
+
+    if (asset.assetCategory && CATEGORY_ACCOUNT_MAP[asset.assetCategory]) {
+      [drCode, crCode] = CATEGORY_ACCOUNT_MAP[asset.assetCategory];
+    } else {
+      // Fall back to asset's stored account codes (legacy assets without assetCategory)
+      drCode = asset.depreciationAccountCode;
+      crCode = asset.accumulatedAccountCode;
+    }
+
+    // Compute monthly depreciation
+    const costValue = new Decimal(asset.costValue.toString());
+    const salvageValue = new Decimal(asset.salvageValue.toString());
+    const accumulatedDepre = new Decimal(asset.accumulatedDepre.toString());
+    const depreciableBase = costValue.minus(salvageValue);
+    const remainingBase = depreciableBase.minus(accumulatedDepre);
+
+    if (remainingBase.lte(0)) {
+      this.logger.log(
+        `[A.5c] DepreciationTemplate: asset ${asset.assetCode} fully depreciated — skipping`,
+      );
+      return null;
+    }
+
+    // usefulLifeMonths takes precedence over usefulLife (years)
+    const lifeMonths = asset.usefulLifeMonths ?? asset.usefulLife * 12;
+    if (lifeMonths <= 0) {
+      this.logger.warn(
+        `[A.5c] DepreciationTemplate: asset ${asset.assetCode} usefulLifeMonths=${lifeMonths} invalid — skipping`,
+      );
+      return null;
+    }
+
+    const monthlyAmount = depreciableBase.div(lifeMonths).toDecimalPlaces(2);
+    // Final partial month: cap to remaining
+    const actualAmount = monthlyAmount.gt(remainingBase) ? remainingBase : monthlyAmount;
+
+    const categoryLabel =
+      (asset.assetCategory && CATEGORY_LABEL[asset.assetCategory]) ?? 'สินทรัพย์';
+
+    const zero = new Decimal(0);
+
+    const result = await this.journal.createAndPost({
+      description: `ค่าเสื่อมราคา ${asset.name} (${categoryLabel}) ประจำงวด ${period}`,
+      reference: `${assetId}:depreciation:${period}`,
+      metadata: {
+        tag: 'DEPRECIATION',
+        flow: 'monthly',
+        assetId,
+        assetCode: asset.assetCode,
+        period,
+        category: asset.assetCategory ?? 'LEGACY',
+      },
+      lines: [
+        {
+          accountCode: drCode,
+          dr: actualAmount,
+          cr: zero,
+          description: `ค่าเสื่อมราคา - ${asset.name} (${period})`,
+        },
+        {
+          accountCode: crCode,
+          dr: zero,
+          cr: actualAmount,
+          description: `ค่าเสื่อมราคาสะสม - ${asset.name} (${period})`,
+        },
+      ],
+    });
+
+    // Record DepreciationEntry (idempotency guard)
+    await this.prisma.depreciationEntry.create({
+      data: {
+        assetId,
+        period,
+        amount: actualAmount,
+        journalEntryNo: result.entryNumber,
+      },
+    });
+
+    // Update asset accumulated depreciation + lastDepreciationPeriod
+    const newAccumulated = accumulatedDepre.plus(actualAmount);
+    const isFullyDepreciated = newAccumulated.gte(depreciableBase);
+
+    await this.prisma.fixedAsset.update({
+      where: { id: assetId },
+      data: {
+        accumulatedDepre: newAccumulated,
+        lastDepreciationPeriod: period,
+        status: isFullyDepreciated ? 'FULLY_DEPRECIATED' : 'ACTIVE',
+      },
+    });
+
+    this.logger.log(
+      `[A.5c] DepreciationTemplate: posted JE ${result.entryNumber} for asset ${asset.assetCode} period ${period} amount ${actualAmount.toFixed(2)}`,
+    );
+
+    return { entryNo: result.entryNumber };
+  }
+}

--- a/apps/api/src/modules/journal/cpa-templates/expense.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense.template.spec.ts
@@ -47,13 +47,15 @@ async function createTestExpense(
     category?: string;
     amount?: number;
     vatAmount?: number;
+    taxDisallowed?: boolean;
+    disallowedReason?: string;
   },
 ) {
   const category = (opts?.category ?? 'ADMIN_UTILITIES') as 'ADMIN_UTILITIES' | 'ADMIN_SALARY' | 'ADMIN_TELEPHONE';
   const amount = opts?.amount ?? 1000;
   const vatAmount = opts?.vatAmount ?? 70;
   const totalAmount = amount + vatAmount;
-  const expenseNumber = `EXP-TEST-${Date.now()}`;
+  const expenseNumber = `EXP-TEST-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
   return prisma.expense.create({
     data: {
@@ -68,7 +70,9 @@ async function createTestExpense(
       expenseDate: new Date(),
       status: 'PAID',
       createdById: userId,
-    },
+      taxDisallowed: opts?.taxDisallowed ?? false,
+      disallowedReason: opts?.disallowedReason ?? null,
+    } as any,
   });
 }
 
@@ -184,6 +188,101 @@ describe('ExpenseTemplate', () => {
     const apLine = je!.lines.find((l) => l.accountCode === '21-1104');
     expect(apLine).toBeDefined();
     expect(new Decimal(apLine!.credit.toString()).toFixed(2)).toBe('5000.00');
+  });
+
+  it('tax-disallowed: routes to 54-1101 (NO_RECEIPT) and skips VAT input', async () => {
+    const expense = await createTestExpense(prisma, branchId, userId, {
+      category: 'ADMIN_UTILITIES',
+      amount: 1000,
+      vatAmount: 70,
+      taxDisallowed: true,
+      disallowedReason: 'NO_RECEIPT',
+    });
+
+    const tmpl = new ExpenseTemplate(journal, prisma as any);
+    const result = await tmpl.execute({
+      expenseId: expense.id,
+      depositAccountCode: '11-1101',
+      isPaid: true,
+    });
+
+    expect(result).not.toBeNull();
+
+    const je = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'expense' } } as any,
+          { metadata: { path: ['expenseId'], equals: expense.id } } as any,
+        ],
+      },
+      include: { lines: true },
+    });
+
+    expect(je).toBeDefined();
+    const lines = je!.lines;
+
+    // Balanced
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Dr 54-1101 (tax-disallowed, full totalAmount including VAT — cannot claim VAT input)
+    const disallowedLine = lines.find((l) => l.accountCode === '54-1101');
+    expect(disallowedLine).toBeDefined();
+    expect(new Decimal(disallowedLine!.debit.toString()).toFixed(2)).toBe('1070.00');
+
+    // No 11-4101 VAT input (disallowed expenses cannot claim VAT)
+    const vatLine = lines.find((l) => l.accountCode === '11-4101');
+    expect(vatLine).toBeUndefined();
+
+    // Normal expense account (53-1302) should NOT appear
+    const normalLine = lines.find((l) => l.accountCode === '53-1302');
+    expect(normalLine).toBeUndefined();
+  });
+
+  it('tax-disallowed: routes to 54-1103 (PENALTY) and skips VAT input', async () => {
+    const expense = await createTestExpense(prisma, branchId, userId, {
+      category: 'ADMIN_UTILITIES',
+      amount: 500,
+      vatAmount: 35,
+      taxDisallowed: true,
+      disallowedReason: 'PENALTY',
+    });
+
+    const tmpl = new ExpenseTemplate(journal, prisma as any);
+    const result = await tmpl.execute({
+      expenseId: expense.id,
+      depositAccountCode: '11-1101',
+      isPaid: true,
+    });
+
+    expect(result).not.toBeNull();
+
+    const je = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'expense' } } as any,
+          { metadata: { path: ['expenseId'], equals: expense.id } } as any,
+        ],
+      },
+      include: { lines: true },
+    });
+
+    const lines = je!.lines;
+
+    // Balanced
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Dr 54-1103 (VAT penalty disallowed — full totalAmount = 500 + 35 = 535)
+    const disallowedLine = lines.find((l) => l.accountCode === '54-1103');
+    expect(disallowedLine).toBeDefined();
+    expect(new Decimal(disallowedLine!.debit.toString()).toFixed(2)).toBe('535.00');
+
+    // No VAT input
+    const vatLine = lines.find((l) => l.accountCode === '11-4101');
+    expect(vatLine).toBeUndefined();
   });
 
   it('is idempotent — second call returns same entry', async () => {

--- a/apps/api/src/modules/journal/cpa-templates/expense.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense.template.ts
@@ -31,6 +31,25 @@ const CATEGORY_CODE_MAP: Record<string, string> = {
 const VAT_INPUT_CODE = '11-4101'; // ภาษีซื้อ
 const AP_ACCRUED_CODE = '21-1104'; // เจ้าหนี้ค่าใช้จ่ายกิจการ (unpaid)
 
+/**
+ * Maps disallowedReason → 54-XXXX account code.
+ * Used when Expense.taxDisallowed = true to override the normal expense account.
+ *
+ * NO_RECEIPT_PND3  → 54-1101 (ภาษีออกแทนผู้รับ บุคคลธรรมดา)
+ * NO_RECEIPT_PND53 → 54-1102 (ภาษีออกแทนผู้รับ นิติบุคคล)
+ * NO_RECEIPT       → 54-1101 (default to PND3 when not specified)
+ * PERSONAL_USE     → 54-1104 (other disallowed)
+ * PENALTY_VAT      → 54-1103 (เบี้ยปรับ ภ.พ.30)
+ * PENALTY          → 54-1103 (VAT penalty)
+ * OTHER            → 54-1104
+ */
+const DISALLOWED_REASON_CODE: Record<string, string> = {
+  NO_RECEIPT: '54-1101',
+  PERSONAL_USE: '54-1104',
+  PENALTY: '54-1103',
+  OTHER: '54-1104',
+};
+
 export interface ExpenseTemplateInput {
   expenseId: string;
   /** Cash/bank account code when paid immediately (e.g. '11-1101', '11-1201') */
@@ -91,9 +110,28 @@ export class ExpenseTemplate {
     }
 
     // Resolve expense account code
-    const expenseAccountCode =
-      expense.accountCode ?? CATEGORY_CODE_MAP[expense.category];
-    if (!expenseAccountCode) {
+    let resolvedAccountCode = expense.accountCode ?? CATEGORY_CODE_MAP[expense.category];
+
+    // Tax-disallowed override: route to 54-XXXX when taxDisallowed = true.
+    // If the CATEGORY_CODE_MAP already routes to a 54-XXXX code (e.g. ADMIN_TAX_FEE, OTHER_FINE),
+    // we prefer the more specific 54-XXXX from disallowedReason when provided, otherwise keep the map code.
+    const isTaxDisallowed = (expense as any).taxDisallowed === true;
+    const disallowedReason = (expense as any).disallowedReason as string | null | undefined;
+
+    if (isTaxDisallowed) {
+      const reasonCode = disallowedReason
+        ? DISALLOWED_REASON_CODE[disallowedReason]
+        : undefined;
+      if (reasonCode) {
+        resolvedAccountCode = reasonCode;
+      } else if (!resolvedAccountCode?.startsWith('54-')) {
+        // Fallback: use 54-1104 (other disallowed) if no specific mapping
+        resolvedAccountCode = '54-1104';
+      }
+      // If already 54-XXXX from CATEGORY_CODE_MAP, keep it (no double-route).
+    }
+
+    if (!resolvedAccountCode) {
       throw new BadRequestException(
         `No account code mapping for expense category '${expense.category}' — expense ${expense.expenseNumber}. Add to CATEGORY_CODE_MAP or set accountCode on the Expense record.`,
       );
@@ -107,22 +145,36 @@ export class ExpenseTemplate {
     // Credit side: cash account or AP accrued
     const creditAccountCode = isPaid ? depositAccountCode : AP_ACCRUED_CODE;
 
-    const lines: { accountCode: string; dr: Decimal; cr: Decimal; description?: string }[] = [
-      {
-        accountCode: expenseAccountCode,
+    const lines: { accountCode: string; dr: Decimal; cr: Decimal; description?: string }[] = [];
+
+    if (isTaxDisallowed) {
+      // Tax-disallowed: the entire cash outflow (including VAT) is non-deductible.
+      // Book the full totalAmount to the 54-XXXX disallowed expense account.
+      // No VAT input claim (11-4101 is excluded).
+      // JE: Dr 54-XXXX [totalAmount] / Cr Cash [totalAmount]
+      lines.push({
+        accountCode: resolvedAccountCode,
+        dr: totalAmount,
+        cr: zero,
+        description: expense.description,
+      });
+    } else {
+      // Normal expense: Dr expense account [amount excl VAT]
+      lines.push({
+        accountCode: resolvedAccountCode,
         dr: amount,
         cr: zero,
         description: expense.description,
-      },
-    ];
-
-    if (vatAmount.gt(0)) {
-      lines.push({
-        accountCode: VAT_INPUT_CODE,
-        dr: vatAmount,
-        cr: zero,
-        description: 'ภาษีซื้อ',
       });
+
+      if (vatAmount.gt(0)) {
+        lines.push({
+          accountCode: VAT_INPUT_CODE,
+          dr: vatAmount,
+          cr: zero,
+          description: 'ภาษีซื้อ',
+        });
+      }
     }
 
     lines.push({
@@ -142,6 +194,8 @@ export class ExpenseTemplate {
         expenseNumber: expense.expenseNumber,
         category: expense.category,
         isPaid,
+        taxDisallowed: isTaxDisallowed,
+        disallowedReason: disallowedReason ?? null,
       },
       lines,
     });

--- a/apps/api/src/modules/journal/cpa-templates/wht-accrual.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/wht-accrual.template.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { seedFinanceCoa } from '../../../../prisma/seed-coa-finance';
+import { WhtAccrualTemplate } from './wht-accrual.template';
+import { JournalAutoService } from '../journal-auto.service';
+
+const prisma = new PrismaClient();
+
+async function setup() {
+  await prisma.journalLine.deleteMany({});
+  await prisma.journalEntry.deleteMany({});
+  await seedFinanceCoa(prisma);
+
+  const existing = await prisma.user.findFirst({ where: { email: 'admin@bestchoice.com' } });
+  if (!existing) {
+    await prisma.user.create({
+      data: { email: 'admin@bestchoice.com', password: 'x', name: 'admin', role: 'OWNER' },
+    });
+  }
+
+  return new JournalAutoService(prisma as any);
+}
+
+describe('WhtAccrualTemplate', () => {
+  let journal: JournalAutoService;
+
+  beforeAll(async () => {
+    journal = await setup();
+  });
+
+  it('posts a balanced JE with VAT — PND3 (individual contractor)', async () => {
+    const tmpl = new WhtAccrualTemplate(journal);
+
+    const grossAmount = new Decimal('10000.00'); // e.g. accounting fee
+    const vatAmount = new Decimal('700.00');       // 7% VAT
+    const whtAmount = new Decimal('300.00');        // 3% WHT
+    // net = 10000 + 700 - 300 = 10400
+
+    const result = await tmpl.execute({
+      expenseAccountCode: '53-1401', // accounting fees (must exist in CoA)
+      grossAmount,
+      vatAmount,
+      whtCategory: 'PND3',
+      whtAmount,
+      depositAccountCode: '11-1101',
+      vendorReference: 'TEST-PND3-001',
+    });
+
+    expect(result.entryNo).toMatch(/^JE-/);
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+
+    expect(je).toBeDefined();
+    expect(je!.status).toBe('POSTED');
+
+    const lines = je!.lines;
+
+    // Balanced
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Dr expense account
+    const expLine = lines.find((l) => l.accountCode === '53-1401');
+    expect(expLine).toBeDefined();
+    expect(new Decimal(expLine!.debit.toString()).toFixed(2)).toBe('10000.00');
+
+    // Dr 11-4101 ภาษีซื้อ
+    const vatLine = lines.find((l) => l.accountCode === '11-4101');
+    expect(vatLine).toBeDefined();
+    expect(new Decimal(vatLine!.debit.toString()).toFixed(2)).toBe('700.00');
+
+    // Cr 11-1101 cash (net)
+    const cashLine = lines.find((l) => l.accountCode === '11-1101');
+    expect(cashLine).toBeDefined();
+    expect(new Decimal(cashLine!.credit.toString()).toFixed(2)).toBe('10400.00');
+
+    // Cr 21-3102 ภ.ง.ด. 3 ค้างจ่าย
+    const whtLine = lines.find((l) => l.accountCode === '21-3102');
+    expect(whtLine).toBeDefined();
+    expect(new Decimal(whtLine!.credit.toString()).toFixed(2)).toBe('300.00');
+  });
+
+  it('omits 11-4101 line when vatAmount = 0', async () => {
+    const tmpl = new WhtAccrualTemplate(journal);
+
+    const result = await tmpl.execute({
+      expenseAccountCode: '53-1401',
+      grossAmount: new Decimal('5000.00'),
+      vatAmount: new Decimal('0.00'),
+      whtCategory: 'PND53',
+      whtAmount: new Decimal('150.00'),
+      depositAccountCode: '11-1101',
+      vendorReference: 'TEST-PND53-NOVAT',
+    });
+
+    expect(result.entryNo).toMatch(/^JE-/);
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+
+    const lines = je!.lines;
+
+    // No VAT line
+    const vatLine = lines.find((l) => l.accountCode === '11-4101');
+    expect(vatLine).toBeUndefined();
+
+    // Balanced
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Cr 21-3103 ภ.ง.ด. 53 ค้างจ่าย
+    const whtLine = lines.find((l) => l.accountCode === '21-3103');
+    expect(whtLine).toBeDefined();
+    expect(new Decimal(whtLine!.credit.toString()).toFixed(2)).toBe('150.00');
+
+    // Cr 11-1101 = 5000 - 150 = 4850
+    const cashLine = lines.find((l) => l.accountCode === '11-1101');
+    expect(cashLine).toBeDefined();
+    expect(new Decimal(cashLine!.credit.toString()).toFixed(2)).toBe('4850.00');
+  });
+
+  it('routes PND1 to 21-3101 (payroll WHT)', async () => {
+    const tmpl = new WhtAccrualTemplate(journal);
+
+    const result = await tmpl.execute({
+      expenseAccountCode: '53-1101',
+      grossAmount: new Decimal('20000.00'),
+      vatAmount: new Decimal('0.00'),
+      whtCategory: 'PND1',
+      whtAmount: new Decimal('400.00'),
+      depositAccountCode: '11-1101',
+      vendorReference: 'TEST-PND1-SALARY',
+    });
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+
+    const whtLine = je!.lines.find((l) => l.accountCode === '21-3101');
+    expect(whtLine).toBeDefined();
+    expect(new Decimal(whtLine!.credit.toString()).toFixed(2)).toBe('400.00');
+
+    // Balanced
+    const totalDr = je!.lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = je!.lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+  });
+
+  it('routes PND53 to 21-3103 (corporate vendor WHT)', async () => {
+    const tmpl = new WhtAccrualTemplate(journal);
+
+    const result = await tmpl.execute({
+      expenseAccountCode: '53-1401',
+      grossAmount: new Decimal('8000.00'),
+      vatAmount: new Decimal('560.00'),
+      whtCategory: 'PND53',
+      whtAmount: new Decimal('240.00'),
+      depositAccountCode: '11-1101',
+      vendorReference: 'TEST-PND53-CORP',
+    });
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+
+    const whtLine = je!.lines.find((l) => l.accountCode === '21-3103');
+    expect(whtLine).toBeDefined();
+    expect(new Decimal(whtLine!.credit.toString()).toFixed(2)).toBe('240.00');
+
+    // Balanced
+    const totalDr = je!.lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = je!.lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+  });
+});

--- a/apps/api/src/modules/journal/cpa-templates/wht-accrual.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/wht-accrual.template.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { JournalAutoService } from '../journal-auto.service';
+
+const VAT_INPUT_CODE = '11-4101'; // ภาษีซื้อ
+
+/** Maps whtCategory → WHT payable account code */
+const WHT_PAYABLE_CODE: Record<string, string> = {
+  PND1: '21-3101', // ภ.ง.ด. 1 ค้างจ่าย — payroll
+  PND3: '21-3102', // ภ.ง.ด. 3 ค้างจ่าย — individual contractor
+  PND53: '21-3103', // ภ.ง.ด. 53 ค้างจ่าย — corporate vendor
+};
+
+export interface WhtAccrualTemplateInput {
+  /** Expense account code, e.g. '53-1401' (accounting fees) */
+  expenseAccountCode: string;
+  /** Gross amount before WHT and before VAT */
+  grossAmount: Decimal;
+  /** VAT input on the expense (0 if exempt) */
+  vatAmount: Decimal;
+  /** PND category — determines WHT payable liability account */
+  whtCategory: 'PND1' | 'PND3' | 'PND53';
+  /** WHT amount (computed by caller, e.g. 3% × gross) */
+  whtAmount: Decimal;
+  /** Cash/bank account code paying the net amount */
+  depositAccountCode: string;
+  /** Optional vendor reference for traceability */
+  vendorReference?: string;
+}
+
+/**
+ * Template — Vendor payment with WHT withheld (Phase A.5c).
+ *
+ * Scenario: Company pays a vendor net-of-WHT and posts the WHT obligation.
+ *
+ * JE:
+ *   Dr <expenseAccountCode>    [grossAmount]
+ *   Dr 11-4101 ภาษีซื้อ        [vatAmount]   ← only if vatAmount > 0
+ *     Cr <depositAccountCode>  [grossAmount + vatAmount - whtAmount]   (net cash paid)
+ *     Cr 21-310X WHT payable   [whtAmount]   (PND1→21-3101, PND3→21-3102, PND53→21-3103)
+ *
+ * Not idempotent by default — caller should pass a stable vendorReference
+ * if retry safety is required (check reference before calling).
+ */
+@Injectable()
+export class WhtAccrualTemplate {
+  private readonly logger = new Logger(WhtAccrualTemplate.name);
+
+  constructor(private readonly journal: JournalAutoService) {}
+
+  async execute(input: WhtAccrualTemplateInput): Promise<{ entryNo: string }> {
+    const {
+      expenseAccountCode,
+      grossAmount,
+      vatAmount,
+      whtCategory,
+      whtAmount,
+      depositAccountCode,
+      vendorReference,
+    } = input;
+
+    const zero = new Decimal(0);
+    const whtPayableCode = WHT_PAYABLE_CODE[whtCategory];
+    // Net cash paid = gross + VAT - WHT
+    const netCash = grossAmount.plus(vatAmount).minus(whtAmount);
+
+    const lines: { accountCode: string; dr: Decimal; cr: Decimal; description?: string }[] = [
+      {
+        accountCode: expenseAccountCode,
+        dr: grossAmount,
+        cr: zero,
+        description: vendorReference ? `ค่าใช้จ่าย - ${vendorReference}` : 'ค่าใช้จ่าย',
+      },
+    ];
+
+    if (vatAmount.gt(zero)) {
+      lines.push({
+        accountCode: VAT_INPUT_CODE,
+        dr: vatAmount,
+        cr: zero,
+        description: 'ภาษีซื้อ',
+      });
+    }
+
+    lines.push(
+      {
+        accountCode: depositAccountCode,
+        dr: zero,
+        cr: netCash,
+        description: 'จ่ายเงินสุทธิ (หักภาษี ณ ที่จ่าย)',
+      },
+      {
+        accountCode: whtPayableCode,
+        dr: zero,
+        cr: whtAmount,
+        description: `ภาษีหัก ณ ที่จ่าย (${whtCategory})`,
+      },
+    );
+
+    const ref = `wht-accrual:${vendorReference ?? Date.now()}`;
+
+    const result = await this.journal.createAndPost({
+      description: `บันทึกภาษีหัก ณ ที่จ่าย (${whtCategory})${vendorReference ? ` — ${vendorReference}` : ''}`,
+      reference: ref,
+      metadata: {
+        tag: 'WHT',
+        flow: 'accrual',
+        whtCategory,
+        vendorReference: vendorReference ?? null,
+      },
+      lines,
+    });
+
+    this.logger.log(
+      `[A.5c] WhtAccrualTemplate: posted JE ${result.entryNumber} — ${whtCategory} wht=${whtAmount.toFixed(2)} ref=${ref}`,
+    );
+
+    return { entryNo: result.entryNumber };
+  }
+}

--- a/apps/api/src/modules/journal/cpa-templates/wht-remittance.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/wht-remittance.template.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { seedFinanceCoa } from '../../../../prisma/seed-coa-finance';
+import { WhtRemittanceTemplate } from './wht-remittance.template';
+import { JournalAutoService } from '../journal-auto.service';
+
+const prisma = new PrismaClient();
+
+async function setup() {
+  await prisma.journalLine.deleteMany({});
+  await prisma.journalEntry.deleteMany({});
+  await seedFinanceCoa(prisma);
+
+  const existing = await prisma.user.findFirst({ where: { email: 'admin@bestchoice.com' } });
+  if (!existing) {
+    await prisma.user.create({
+      data: { email: 'admin@bestchoice.com', password: 'x', name: 'admin', role: 'OWNER' },
+    });
+  }
+
+  return new JournalAutoService(prisma as any);
+}
+
+describe('WhtRemittanceTemplate', () => {
+  let journal: JournalAutoService;
+
+  beforeAll(async () => {
+    journal = await setup();
+  });
+
+  it('posts a balanced JE clearing PND3 payable to RD', async () => {
+    const tmpl = new WhtRemittanceTemplate(journal);
+    const remittanceDate = new Date('2026-05-15');
+
+    const result = await tmpl.execute({
+      whtCategory: 'PND3',
+      amount: new Decimal('300.00'),
+      remittanceDate,
+      depositAccountCode: '11-1101',
+      vendorReference: 'REM-2026-05-PND3',
+    });
+
+    expect(result.entryNo).toMatch(/^JE-/);
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+
+    expect(je).toBeDefined();
+    expect(je!.status).toBe('POSTED');
+
+    const lines = je!.lines;
+
+    // Balanced
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Dr 21-3102 ภ.ง.ด. 3 ค้างจ่าย (clears liability)
+    const whtLine = lines.find((l) => l.accountCode === '21-3102');
+    expect(whtLine).toBeDefined();
+    expect(new Decimal(whtLine!.debit.toString()).toFixed(2)).toBe('300.00');
+
+    // Cr 11-1101 cash
+    const cashLine = lines.find((l) => l.accountCode === '11-1101');
+    expect(cashLine).toBeDefined();
+    expect(new Decimal(cashLine!.credit.toString()).toFixed(2)).toBe('300.00');
+  });
+
+  it('clears PND1 payable (payroll) to RD', async () => {
+    const tmpl = new WhtRemittanceTemplate(journal);
+
+    const result = await tmpl.execute({
+      whtCategory: 'PND1',
+      amount: new Decimal('4000.00'),
+      remittanceDate: new Date('2026-05-15'),
+      depositAccountCode: '11-1101',
+      vendorReference: 'REM-2026-05-PND1',
+    });
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+
+    const lines = je!.lines;
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    const whtLine = lines.find((l) => l.accountCode === '21-3101');
+    expect(whtLine).toBeDefined();
+    expect(new Decimal(whtLine!.debit.toString()).toFixed(2)).toBe('4000.00');
+  });
+
+  it('clears PND53 payable (corporate) to RD', async () => {
+    const tmpl = new WhtRemittanceTemplate(journal);
+
+    const result = await tmpl.execute({
+      whtCategory: 'PND53',
+      amount: new Decimal('240.00'),
+      remittanceDate: new Date('2026-05-15'),
+      depositAccountCode: '11-1101',
+      vendorReference: 'REM-2026-05-PND53',
+    });
+
+    const je = await prisma.journalEntry.findFirst({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+
+    const lines = je!.lines;
+    const totalDr = lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+
+    // Dr 21-3103 (PND53 payable cleared)
+    const whtLine = lines.find((l) => l.accountCode === '21-3103');
+    expect(whtLine).toBeDefined();
+    expect(new Decimal(whtLine!.debit.toString()).toFixed(2)).toBe('240.00');
+  });
+});

--- a/apps/api/src/modules/journal/cpa-templates/wht-remittance.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/wht-remittance.template.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { JournalAutoService } from '../journal-auto.service';
+
+/** Maps whtCategory → WHT payable account code (same as accrual side) */
+const WHT_PAYABLE_CODE: Record<string, string> = {
+  PND1: '21-3101', // ภ.ง.ด. 1 ค้างจ่าย — payroll
+  PND3: '21-3102', // ภ.ง.ด. 3 ค้างจ่าย — individual contractor
+  PND53: '21-3103', // ภ.ง.ด. 53 ค้างจ่าย — corporate vendor
+};
+
+export interface WhtRemittanceTemplateInput {
+  whtCategory: 'PND1' | 'PND3' | 'PND53';
+  amount: Decimal;
+  remittanceDate: Date;
+  /** Cash/bank account code making the payment to RD */
+  depositAccountCode: string;
+  /** Optional reference (e.g. remittance batch ID or month) */
+  vendorReference?: string;
+}
+
+/**
+ * Template — Remit accrued WHT to Revenue Department (Phase A.5c).
+ *
+ * Scenario: End-of-month, pay the accumulated WHT balance to สรรพากร.
+ *
+ * JE:
+ *   Dr 21-310X WHT payable   [amount]   (clears the accrual liability)
+ *     Cr <depositAccountCode> [amount]
+ *
+ * Simplification note: For PND53, the full flow should be:
+ *   1. File ภ.ง.ด.53 form → move 21-3103 → 21-3202 (เจ้าหนี้สรรพากร ภ.ง.ด. 53 รอชำระ)
+ *   2. Pay 21-3202 → Cr cash
+ * This template does a single-step direct clearance (21-3103 → Cr cash) for simplicity.
+ * Upgrade to 2-step when filing-vs-payment date split becomes operationally relevant.
+ */
+@Injectable()
+export class WhtRemittanceTemplate {
+  private readonly logger = new Logger(WhtRemittanceTemplate.name);
+
+  constructor(private readonly journal: JournalAutoService) {}
+
+  async execute(input: WhtRemittanceTemplateInput): Promise<{ entryNo: string }> {
+    const { whtCategory, amount, remittanceDate, depositAccountCode, vendorReference } = input;
+
+    const zero = new Decimal(0);
+    const whtPayableCode = WHT_PAYABLE_CODE[whtCategory];
+
+    const dateStr = remittanceDate.toISOString().slice(0, 10);
+    const ref = `wht-remittance:${whtCategory}:${dateStr}:${vendorReference ?? Date.now()}`;
+
+    const result = await this.journal.createAndPost({
+      description: `นำส่งภาษีหัก ณ ที่จ่าย (${whtCategory}) วันที่ ${dateStr}${vendorReference ? ` — ${vendorReference}` : ''}`,
+      reference: ref,
+      metadata: {
+        tag: 'WHT',
+        flow: 'remittance',
+        whtCategory,
+        remittanceDate: dateStr,
+        vendorReference: vendorReference ?? null,
+      },
+      lines: [
+        {
+          accountCode: whtPayableCode,
+          dr: amount,
+          cr: zero,
+          description: `ล้างภาษีหัก ณ ที่จ่าย (${whtCategory})`,
+        },
+        {
+          accountCode: depositAccountCode,
+          dr: zero,
+          cr: amount,
+          description: `นำส่งสรรพากร (${whtCategory}) ${dateStr}`,
+        },
+      ],
+    });
+
+    this.logger.log(
+      `[A.5c] WhtRemittanceTemplate: posted JE ${result.entryNumber} — ${whtCategory} amount=${amount.toFixed(2)} date=${dateStr}`,
+    );
+
+    return { entryNo: result.entryNumber };
+  }
+}

--- a/apps/api/src/modules/journal/cron/depreciation.cron.ts
+++ b/apps/api/src/modules/journal/cron/depreciation.cron.ts
@@ -1,0 +1,76 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { DepreciationTemplate } from '../cpa-templates/depreciation.template';
+
+/**
+ * Phase A.5c — Monthly depreciation cron.
+ *
+ * Runs daily on days 28–31; guards that it only executes on the actual last day of the month
+ * (i.e. tomorrow is a different month). This avoids the complexity of computing "last day"
+ * ahead of time and handles all month lengths correctly (28/29/30/31).
+ *
+ * Schedule: '0 1 28-31 * *' — 01:00 Asia/Bangkok on days 28, 29, 30, 31.
+ */
+@Injectable()
+export class DepreciationCron {
+  private readonly logger = new Logger(DepreciationCron.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly template: DepreciationTemplate,
+  ) {}
+
+  @Cron('0 1 28-31 * *', { timeZone: 'Asia/Bangkok' })
+  async tick(): Promise<{ processed: number; skipped: number; failed: number }> {
+    // Guard: only run on the actual last day of the month
+    const now = new Date();
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (tomorrow.getMonth() === now.getMonth()) {
+      // Not the last day — exit silently
+      return { processed: 0, skipped: 0, failed: 0 };
+    }
+
+    const period = `${now.getFullYear()}-${(now.getMonth() + 1).toString().padStart(2, '0')}`;
+    this.logger.log(`[A.5c] DepreciationCron: running for period ${period}`);
+
+    const assets = await this.prisma.fixedAsset.findMany({
+      where: { status: 'ACTIVE', deletedAt: null },
+      select: { id: true, assetCode: true },
+    });
+
+    this.logger.log(`[A.5c] DepreciationCron: ${assets.length} active asset(s) to process`);
+
+    let processed = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (const asset of assets) {
+      try {
+        const result = await this.template.execute({ assetId: asset.id, period });
+        if (result !== null) {
+          processed++;
+        } else {
+          skipped++;
+        }
+      } catch (e) {
+        failed++;
+        Sentry.captureException(e, {
+          extra: { assetId: asset.id, assetCode: asset.assetCode, period },
+          tags: { kind: 'cron-job', cron: 'monthly-depreciation-a5c' },
+        });
+        this.logger.error(
+          `[A.5c] DepreciationCron: failed for asset ${asset.assetCode}: ${(e as Error).message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `[A.5c] DepreciationCron: period=${period} processed=${processed} skipped=${skipped} failed=${failed}`,
+    );
+
+    return { processed, skipped, failed };
+  }
+}

--- a/apps/api/src/modules/journal/journal.module.ts
+++ b/apps/api/src/modules/journal/journal.module.ts
@@ -20,6 +20,9 @@ import { BadDebtWriteOffTemplate } from './cpa-templates/bad-debt-writeoff.templ
 import { ExpenseTemplate } from './cpa-templates/expense.template';
 import { DefectExchangeReversalTemplate } from './cpa-templates/defect-exchange-reversal.template';
 import { ReceiptVoidReversalTemplate } from './cpa-templates/receipt-void-reversal.template';
+import { DepreciationTemplate } from './cpa-templates/depreciation.template';
+import { AssetDisposalTemplate } from './cpa-templates/asset-disposal.template';
+import { DepreciationCron } from './cron/depreciation.cron';
 
 @Module({
   imports: [PrismaModule],
@@ -44,6 +47,9 @@ import { ReceiptVoidReversalTemplate } from './cpa-templates/receipt-void-revers
     ExpenseTemplate,
     DefectExchangeReversalTemplate,
     ReceiptVoidReversalTemplate,
+    DepreciationTemplate,
+    AssetDisposalTemplate,
+    DepreciationCron,
   ],
   exports: [
     JournalService,
@@ -63,6 +69,8 @@ import { ReceiptVoidReversalTemplate } from './cpa-templates/receipt-void-revers
     ExpenseTemplate,
     DefectExchangeReversalTemplate,
     ReceiptVoidReversalTemplate,
+    DepreciationTemplate,
+    AssetDisposalTemplate,
   ],
 })
 export class JournalModule {}

--- a/apps/api/src/modules/journal/journal.module.ts
+++ b/apps/api/src/modules/journal/journal.module.ts
@@ -23,6 +23,8 @@ import { ReceiptVoidReversalTemplate } from './cpa-templates/receipt-void-revers
 import { DepreciationTemplate } from './cpa-templates/depreciation.template';
 import { AssetDisposalTemplate } from './cpa-templates/asset-disposal.template';
 import { DepreciationCron } from './cron/depreciation.cron';
+import { WhtAccrualTemplate } from './cpa-templates/wht-accrual.template';
+import { WhtRemittanceTemplate } from './cpa-templates/wht-remittance.template';
 
 @Module({
   imports: [PrismaModule],
@@ -50,6 +52,8 @@ import { DepreciationCron } from './cron/depreciation.cron';
     DepreciationTemplate,
     AssetDisposalTemplate,
     DepreciationCron,
+    WhtAccrualTemplate,
+    WhtRemittanceTemplate,
   ],
   exports: [
     JournalService,
@@ -71,6 +75,8 @@ import { DepreciationCron } from './cron/depreciation.cron';
     ReceiptVoidReversalTemplate,
     DepreciationTemplate,
     AssetDisposalTemplate,
+    WhtAccrualTemplate,
+    WhtRemittanceTemplate,
   ],
 })
 export class JournalModule {}


### PR DESCRIPTION
## Summary
FINANCE-only deferred items from A.4 backlog (SHOP-side intentionally not addressed — awaiting CPA CSV).

### Wave 1 — PPE
- AssetRegister + DepreciationEntry models
- AssetService CRUD + dispose endpoint
- DepreciationTemplate (per category: 12-2101/02/05/07 → 53-1601..04 + accumulated 12-2102/04/06/08)
- Monthly DepreciationCron (last-day-of-month, Asia/Bangkok)
- AssetDisposalTemplate (loss path 53-1605 / gain path interim 41-1102 with TODO)

### Wave 2 — WHT + Tax-Disallowed
- WhtAccrualTemplate (vendor net-of-WHT payment, PND1/3/53 → 21-3101/02/03)
- WhtRemittanceTemplate (RD payment to clear WHT payable; PND53 single-step, see code comment)
- Expense.taxDisallowed flag + disallowedReason field (migration 20260802100000)
- ExpenseTemplate 54-XXXX routing: NO_RECEIPT→54-1101, PENALTY→54-1103, PERSONAL_USE/OTHER→54-1104
- Full totalAmount (incl. VAT) booked to disallowed account; 11-4101 VAT input skipped

## Still deferred to A.5b (waiting for CPA SHOP CSV)
- SHOP chart of accounts
- Paired SHOP+FINANCE JEs
- Inter-company settlement
- Repossession resale (SHOP-side)

## Test plan
- wht-accrual.template.spec.ts: 4 tests pass (PND3+VAT, PND53 no-VAT, PND1 routing, PND53 routing)
- wht-remittance.template.spec.ts: 3 tests pass (PND3, PND1, PND53 routing)
- expense.template.spec.ts: 5 tests pass (3 existing + 2 new tax-disallowed)
- TSC: API OK, Web OK