### PR TITLE
feat(web-shop): Apple-minimal catalog redesign

### DIFF
--- a/apps/web-shop/src/components/catalog/ProductCard.tsx
+++ b/apps/web-shop/src/components/catalog/ProductCard.tsx
@@ -1,6 +1,4 @@
 import { Link } from 'react-router';
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
 export interface ProductGroup {
@@ -18,57 +16,95 @@ interface Props {
   product: ProductGroup;
 }
 
-function conditionVariant(g: string) {
-  return g === 'A' ? 'condition-a' : g === 'B' ? 'condition-b' : 'condition-c';
+function gradeChip(g: string) {
+  return (
+    <span
+      key={g}
+      aria-label={`เกรด ${g}`}
+      className="size-6 rounded-full bg-background/85 backdrop-blur-md border border-foreground/10 text-foreground text-[11px] font-semibold flex items-center justify-center leading-none"
+    >
+      {g}
+    </span>
+  );
 }
 
 export function ProductCard({ product: p }: Props) {
-  const to = `/products?brand=${p.brand}&model=${encodeURIComponent(p.model)}`;
+  const to = `/products?brand=${encodeURIComponent(p.brand)}&model=${encodeURIComponent(p.model)}`;
   const grades = p.conditionGrades ?? [];
+
   return (
-    <Card variant="interactive" className="flex flex-col">
-      <Link to={to} className="flex flex-col h-full">
-        <div className="relative bg-zinc-50 aspect-square flex items-center justify-center">
+    <article className="group text-center">
+      <Link to={to} className="block">
+        {/* Image plate — light surface, generous space, gentle hover scale.
+           Smaller radius on mobile (rounded-2xl) so dense 2-col grids breathe. */}
+        <div className="relative aspect-square bg-zinc-100 rounded-2xl md:rounded-3xl overflow-hidden flex items-center justify-center mb-3 md:mb-4">
           {p.thumbnailUrl ? (
             <img
               src={p.thumbnailUrl}
               alt={`${p.brand} ${p.model}`}
-              className="max-h-full max-w-full object-contain"
+              className="max-h-[78%] max-w-[78%] object-contain transition-transform duration-500 ease-out group-hover:scale-[1.04]"
               loading="lazy"
             />
           ) : (
-            <div className="text-zinc-400 text-sm leading-snug">ไม่มีรูป</div>
+            <div className="text-zinc-400 text-xs md:text-sm">ไม่มีรูป</div>
           )}
           {grades.length > 0 && (
-            <div className="absolute top-3 left-3 flex gap-1">
-              {grades.map((g) => (
-                <Badge key={g} variant={conditionVariant(g)} size="sm">
-                  {g}
-                </Badge>
-              ))}
+            <div className="absolute top-2 left-2 md:top-3 md:left-3 flex gap-1">
+              {grades.map(gradeChip)}
             </div>
           )}
         </div>
-        <div className="p-4 flex-1 flex flex-col gap-1 leading-snug">
-          <div className="font-semibold text-zinc-900">
-            {p.brand} {p.model}
-          </div>
-          <div className="text-emerald-600 font-bold text-lg">
-            เริ่มต้น ฿{p.minPrice.toLocaleString()}
-          </div>
-          <div className="text-xs text-muted-foreground">
-            ผ่อนเริ่ม ฿{p.monthlyPaymentFrom.toLocaleString()}/เดือน
-          </div>
-          <div
-            className={cn(
-              'text-xs mt-auto pt-2',
-              p.stock.tone === 'urgent' ? 'text-destructive' : 'text-muted-foreground',
-            )}
-          >
-            {p.stock.display}
-          </div>
+
+        {/* Caption block — Apple-style centered text. Tighter on mobile. */}
+        <div className="leading-snug space-y-0.5 md:space-y-1">
+          <p className="text-[10px] md:text-[11px] uppercase tracking-[0.14em] md:tracking-[0.16em] text-muted-foreground">
+            {p.brand}
+          </p>
+          <h3 className="font-display text-base md:text-xl lg:text-2xl font-semibold text-foreground tracking-tight line-clamp-1">
+            {p.model}
+          </h3>
+          <p className="num text-lg md:text-2xl font-semibold text-foreground pt-1 md:pt-2">
+            ฿{p.minPrice.toLocaleString()}
+          </p>
+          <p className="text-[11px] md:text-[13px] text-muted-foreground">
+            หรือ <span className="num">฿{p.monthlyPaymentFrom.toLocaleString()}</span>/ด.
+          </p>
         </div>
       </Link>
-    </Card>
+
+      {/* Stock chip — visible on every breakpoint */}
+      <div className="flex flex-col items-center gap-2 md:gap-3 mt-2 md:mt-4">
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 md:gap-1.5 text-[10px] md:text-[12px] px-2 md:px-2.5 py-0.5 md:py-1 rounded-full',
+            p.stock.tone === 'urgent'
+              ? 'text-amber-700 bg-amber-100/80'
+              : p.stock.tone === 'out'
+                ? 'text-muted-foreground bg-muted'
+                : 'text-emerald-700 bg-emerald-50',
+          )}
+        >
+          <span
+            className={cn(
+              'size-1 md:size-1.5 rounded-full',
+              p.stock.tone === 'urgent' ? 'bg-amber-500' : p.stock.tone === 'out' ? 'bg-muted-foreground' : 'bg-emerald-500',
+            )}
+          />
+          {p.stock.display}
+        </span>
+        {/* CTA button hidden on mobile — whole card is linkable.
+           Shown on md+ where grid is sparser and the action affordance helps.
+           aria-hidden + tabIndex=-1 because the parent block link already
+           handles navigation; this is a visual-only secondary cue. */}
+        <Link
+          to={to}
+          aria-hidden="true"
+          tabIndex={-1}
+          className="hidden md:inline-flex h-10 px-6 rounded-full bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 active:bg-primary/80 transition-colors items-center justify-center"
+        >
+          เลือกเครื่อง
+        </Link>
+      </div>
+    </article>
   );
 }

--- a/apps/web-shop/src/index.css
+++ b/apps/web-shop/src/index.css
@@ -2,6 +2,11 @@
 @import "./styles/tokens.css";
 @import "./styles/motion.css";
 
+/* Inter for English display + tabular numbers — paired with IBM Plex Sans Thai
+   for Thai text. Thai body text uses Plex; English headlines + numbers use
+   Inter at tighter tracking for an Apple-minimal feel. */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap");
+
 @layer base {
   body {
     font-family: "IBM Plex Sans Thai", Inter, sans-serif;
@@ -9,5 +14,19 @@
   }
   * {
     line-height: 1.375; /* snug — Thai text safe */
+  }
+}
+
+@layer utilities {
+  /* Display = Inter with tight tracking for English headlines */
+  .font-display {
+    font-family: "Inter", "IBM Plex Sans Thai", sans-serif;
+    letter-spacing: -0.03em;
+  }
+  /* Tabular numbers in Inter — for prices, counts, money */
+  .num {
+    font-family: "Inter", sans-serif;
+    font-feature-settings: "tnum";
+    letter-spacing: -0.01em;
   }
 }

--- a/apps/web-shop/src/pages/CatalogPage.tsx
+++ b/apps/web-shop/src/pages/CatalogPage.tsx
@@ -1,25 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Search, SlidersHorizontal } from 'lucide-react';
+import { Link } from 'react-router';
+import { Search, SlidersHorizontal, ChevronRight, ChevronDown } from 'lucide-react';
 import ShopLayout from '@/components/layout/ShopLayout';
 import { FilterSidebar, type CatalogFilters } from '@/components/catalog/FilterSidebar';
-import { SortDropdown } from '@/components/catalog/SortDropdown';
 import {
   Container,
-  CategoryHero,
-  StatefulList,
-  ProductCard,
-  Button,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  StatefulList,
+  ProductCard,
   type ProductGroup,
 } from '@/components';
 import { api } from '@/lib/api';
 import { copy } from '@/lib/copy';
 import { useTrackEvent } from '@/hooks/useTrackEvent';
+import { cn } from '@/lib/utils';
 
 interface CatalogResponse {
   data: ProductGroup[];
@@ -28,14 +27,69 @@ interface CatalogResponse {
   limit: number;
 }
 
+const BRANDS = ['ทั้งหมด', 'Apple', 'Samsung', 'OPPO', 'Xiaomi'] as const;
+
+const GRADES: Array<{ v: string; label: string }> = [
+  { v: '', label: 'ทุกเกรด' },
+  { v: 'A', label: 'A' },
+  { v: 'B', label: 'B' },
+  { v: 'C', label: 'C' },
+];
+
+const SORTS: Array<{ v: string; label: string }> = [
+  { v: 'popular', label: 'ยอดนิยม' },
+  { v: 'newest', label: 'ใหม่ล่าสุด' },
+  { v: 'price_asc', label: 'ราคา ต่ำ → สูง' },
+  { v: 'price_desc', label: 'ราคา สูง → ต่ำ' },
+];
+
+interface PillProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function Pill({ active, onClick, children }: PillProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        'px-4 py-1.5 text-[13px] rounded-full border transition-colors leading-snug whitespace-nowrap',
+        active
+          ? 'bg-foreground text-background border-foreground'
+          : 'bg-background text-foreground border-border hover:border-foreground/60',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 export default function CatalogPage() {
   const [filters, setFilters] = useState<CatalogFilters>({});
   const [sort, setSort] = useState<string>('popular');
+  const [sortOpen, setSortOpen] = useState(false);
+  const sortBtnRef = useRef<HTMLButtonElement>(null);
   const track = useTrackEvent();
 
   useEffect(() => {
     track('ViewContent', { content_type: 'catalog' });
   }, [track]);
+
+  // Close sort menu on Escape; return focus to the trigger.
+  useEffect(() => {
+    if (!sortOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setSortOpen(false);
+        sortBtnRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [sortOpen]);
 
   const { data, isLoading, isError, refetch } = useQuery<CatalogResponse>({
     queryKey: ['shop', 'catalog', filters, sort],
@@ -50,60 +104,201 @@ export default function CatalogPage() {
     },
   });
 
+  const total = data?.total ?? 0;
+  const activeBrand = filters.brand ?? 'ทั้งหมด';
+  const activeGrade = filters.conditionGrade ?? '';
+  const activeSortLabel = SORTS.find((s) => s.v === sort)?.label ?? '';
+
+  // Hero headline noun follows the brand filter — Apple-style single-noun
+  // headline must reflect what's actually being shown.
+  const heroNoun =
+    activeBrand === 'Samsung' ? 'Galaxy'
+    : activeBrand === 'OPPO' ? 'OPPO'
+    : activeBrand === 'Xiaomi' ? 'Xiaomi'
+    : 'iPhone';
+
   return (
     <ShopLayout>
-      <CategoryHero
-        title={copy.catalog.pageTitle}
-        breadcrumbs={[{ label: 'หน้าแรก', to: '/' }, { label: copy.catalog.pageTitle }]}
-      />
+      {/* Apple-minimal hero — center-aligned, generous breathing room */}
+      <section className="pt-16 md:pt-24 pb-12 md:pb-16 text-center">
+        <Container>
+          <p className="text-sm text-muted-foreground tracking-wide mb-3">
+            สินค้าทั้งหมด · พร้อมจัด {total > 0 && `${total} รุ่น`}
+          </p>
+          {/* Two spans so each language gets safe leading: tight (~0.92) for
+             the English noun + period, snug for Thai so สระบน/ไม้เอก are not
+             clipped. */}
+          <h1 className="font-display text-5xl sm:text-6xl md:text-7xl font-semibold tracking-tight text-foreground">
+            <span className="block leading-[0.92]">{heroNoun}.</span>
+            <span className="block text-primary leading-tight pt-1 md:pt-1.5">
+              ผ่อนได้บัตรเดียว.
+            </span>
+          </h1>
+          <p className="font-display text-xl md:text-2xl font-medium text-muted-foreground mt-5 md:mt-6 max-w-2xl mx-auto leading-tight">
+            เครื่องผ่านตรวจ 30 จุด รับประกันร้าน 30 วัน
+          </p>
+          <div className="flex flex-wrap justify-center gap-x-6 gap-y-3 mt-8 text-[15px]">
+            <a
+              href="#catalog"
+              className="text-primary hover:underline underline-offset-4 inline-flex items-center gap-1.5"
+            >
+              เริ่มเลือกเครื่อง
+              <ChevronRight className="size-4" aria-hidden />
+            </a>
+            <Link
+              to="/how-it-works"
+              className="text-foreground hover:underline underline-offset-4 inline-flex items-center gap-1.5"
+            >
+              ดูวิธีผ่อน
+              <ChevronRight className="size-4" aria-hidden />
+            </Link>
+          </div>
+        </Container>
+      </section>
 
-      <Container className="py-6 md:py-8">
-        <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-6">
-          <aside className="hidden md:block">
-            <FilterSidebar filters={filters} onChange={setFilters} />
-          </aside>
-
-          <div className="space-y-4 leading-snug">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <p className="text-sm text-muted-foreground">
-                {isLoading ? copy.common.loading : `${data?.total ?? 0} รุ่น`}
-              </p>
-              <div className="flex items-center gap-2">
-                <div className="md:hidden">
-                  <Dialog>
-                    <DialogTrigger asChild>
-                      <Button variant="outline" size="md">
-                        <SlidersHorizontal className="size-4" />
-                        ตัวกรอง
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>ตัวกรอง</DialogTitle>
-                      </DialogHeader>
-                      <FilterSidebar filters={filters} onChange={setFilters} />
-                    </DialogContent>
-                  </Dialog>
-                </div>
-                <SortDropdown value={sort} onChange={setSort} />
-              </div>
+      {/* Sticky filter toolbar — Apple subtle bar */}
+      <div
+        id="catalog"
+        className="sticky top-[57px] z-20 bg-muted/70 backdrop-blur-md border-y border-border"
+      >
+        <Container>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 py-3">
+            <div className="flex flex-wrap gap-2">
+              {BRANDS.map((b) => (
+                <Pill
+                  key={b}
+                  active={activeBrand === b}
+                  onClick={() =>
+                    setFilters({
+                      ...filters,
+                      brand: b === 'ทั้งหมด' ? undefined : b,
+                    })
+                  }
+                >
+                  {b}
+                </Pill>
+              ))}
             </div>
 
-            <StatefulList<ProductGroup>
-              isLoading={isLoading}
-              isError={isError}
-              data={data?.data}
-              loadingVariant="card-grid"
-              onRetry={() => refetch()}
-              emptyState={{
-                icon: <Search className="size-12" />,
-                title: copy.catalog.emptyTitle,
-                description: copy.catalog.emptyDescription,
-              }}
-              wrapperClassName="grid grid-cols-2 md:grid-cols-3 gap-4"
-              renderItem={(p) => <ProductCard key={`${p.brand}-${p.model}`} product={p} />}
-            />
+            <span className="hidden md:inline-block w-px h-5 bg-border mx-1" />
+
+            <div className="flex flex-wrap gap-2">
+              {GRADES.map((g) => (
+                <Pill
+                  key={g.v || 'all'}
+                  active={activeGrade === g.v}
+                  onClick={() =>
+                    setFilters({ ...filters, conditionGrade: g.v || undefined })
+                  }
+                >
+                  {g.label}
+                </Pill>
+              ))}
+            </div>
+
+            <div className="flex-1" />
+
+            {/* More filters */}
+            <Dialog>
+              <DialogTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 px-3.5 py-1.5 text-[13px] border border-border rounded-full hover:border-foreground/60 transition-colors text-foreground bg-background leading-snug"
+                >
+                  <SlidersHorizontal className="size-3.5" />
+                  ตัวกรอง
+                </button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>ตัวกรองเพิ่มเติม</DialogTitle>
+                </DialogHeader>
+                <FilterSidebar filters={filters} onChange={setFilters} />
+              </DialogContent>
+            </Dialog>
+
+            {/* Sort dropdown — listbox semantics for screen readers + ESC to
+               close (handled by effect). Outside-click closes via overlay. */}
+            <div className="relative">
+              <button
+                ref={sortBtnRef}
+                type="button"
+                aria-haspopup="listbox"
+                aria-expanded={sortOpen}
+                onClick={() => setSortOpen((o) => !o)}
+                className="flex items-center gap-1.5 px-3.5 py-1.5 text-[13px] border border-border rounded-full hover:border-foreground/60 transition-colors text-foreground bg-background leading-snug"
+              >
+                <span className="text-muted-foreground">เรียง:</span>
+                <span>{activeSortLabel}</span>
+                <ChevronDown className="size-3.5 text-muted-foreground" />
+              </button>
+              {sortOpen && (
+                <>
+                  <button
+                    type="button"
+                    aria-label="ปิดเมนูเรียง"
+                    tabIndex={-1}
+                    className="fixed inset-0 z-10"
+                    onClick={() => setSortOpen(false)}
+                  />
+                  <ul
+                    role="listbox"
+                    aria-label="เรียงโดย"
+                    className="absolute right-0 mt-2 w-52 bg-background border border-border rounded-xl shadow-lg z-20 py-1.5 overflow-hidden"
+                  >
+                    {SORTS.map((s) => {
+                      const selected = sort === s.v;
+                      return (
+                        <li key={s.v}>
+                          <button
+                            type="button"
+                            role="option"
+                            aria-selected={selected}
+                            onClick={() => {
+                              setSort(s.v);
+                              setSortOpen(false);
+                              sortBtnRef.current?.focus();
+                            }}
+                            className={cn(
+                              'block w-full text-left px-3.5 py-2 text-[13px] leading-snug',
+                              selected
+                                ? 'text-primary font-medium bg-primary/5'
+                                : 'text-foreground hover:bg-muted',
+                            )}
+                          >
+                            {s.label}
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </>
+              )}
+            </div>
           </div>
+        </Container>
+      </div>
+
+      {/* Product grid — Apple-style 3-col / mobile 2-col.
+         No <main> wrapper here: ShopLayout already provides one. */}
+      <Container>
+        <div className="py-12 md:py-16">
+          <StatefulList<ProductGroup>
+            isLoading={isLoading}
+            isError={isError}
+            data={data?.data}
+            loadingVariant="card-grid"
+            onRetry={() => refetch()}
+            emptyState={{
+              icon: <Search className="size-12" />,
+              title: copy.catalog.emptyTitle,
+              description: copy.catalog.emptyDescription,
+            }}
+            wrapperClassName="grid grid-cols-2 lg:grid-cols-3 gap-x-3 gap-y-6 md:gap-x-6 md:gap-y-10 lg:gap-x-8 lg:gap-y-12"
+            renderItem={(p) => (
+              <ProductCard key={`${p.brand}-${p.model}`} product={p} />
+            )}
+          />
         </div>
       </Container>
     </ShopLayout>


### PR DESCRIPTION
## Summary

- Redesign customer-facing catalog page (`/products`) in the storefront app with an Apple-style aesthetic — center-aligned hero, sticky pill filter toolbar, responsive grid (mobile 2-col / desktop 3-col), and centered Apple-style product cards
- Brand-aware hero noun (Apple → "iPhone.", Samsung → "Galaxy.", etc.) keeps the headline coherent when the brand filter changes
- Mobile dense grid (Shopee/Lazada-style): CTA pill hidden on mobile, whole card is linkable; desktop keeps the visible "เลือกเครื่อง" emerald pill as a secondary visual cue (`aria-hidden` so it's not a duplicate link for screen readers)

## Code review fixes addressed before commit

- Removed nested `<main>` (ShopLayout already supplies one)
- Split English/Thai spans in the headline so Thai สระบน/tone marks aren't clipped (English `leading-[0.92]`, Thai `leading-tight`)
- Sort dropdown made keyboard-accessible: `aria-haspopup="listbox"` + `aria-expanded`, ESC-to-close with focus return, `role="option"` + `aria-selected`, `<ul>/<li>` semantics
- Filter pills got `aria-pressed`
- Product card brand value `encodeURIComponent`'d in the catalog query string
- Removed dead `.pill-cta` utility

## Files

- `apps/web-shop/src/index.css` — Inter font import + `.font-display`/`.num` utilities
- `apps/web-shop/src/components/catalog/ProductCard.tsx` — centered Apple card, mobile-responsive sizing, line-clamp model name, desktop-only CTA pill (`aria-hidden`)
- `apps/web-shop/src/pages/CatalogPage.tsx` — hero + sticky pill toolbar + accessible sort listbox + responsive grid

## Test plan

- [ ] `cd apps/web-shop && npm run dev` opens fine at `http://localhost:5174/products`
- [ ] Desktop (≥ 1024px): hero centered, 3-col grid, "เลือกเครื่อง" emerald pill visible per card
- [ ] Mobile (< 768px): 2-col grid, no CTA pill, whole card tappable
- [ ] Brand filter pill changes hero noun (Samsung → "Galaxy.")
- [ ] Tab into sort dropdown → Enter opens → Esc closes → focus returns to trigger
- [ ] Screen reader announces filter pills with "pressed/not pressed" state
- [ ] No nested `<main>` warning in dev tools accessibility tree
- [ ] Thai vowels (`เ`, `ื`) and tone marks (`่`) on `ผ่อนได้บัตรเดียว` are not clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)