### PR TITLE
fix(api): compile wipe-accounting CLI for prod image

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -6,7 +6,8 @@
     "deleteOutDir": true,
     "assets": [
       { "include": "modules/documents/templates/**/*.html", "outDir": "dist/src" },
-      { "include": "modules/contracts/templates/**/*.html", "outDir": "dist/src" }
+      { "include": "modules/contracts/templates/**/*.html", "outDir": "dist/src" },
+      { "include": "modules/journal/__tests__/fixtures/cpa-cases/*.csv", "outDir": "dist/src" }
     ]
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "prisma:studio": "prisma studio",
     "prisma:seed": "npx tsx prisma/seed.ts",
     "backfill:promise-slots": "tsx scripts/backfill-promise-slots.ts",
-    "wipe:accounting": "tsx src/cli/wipe-accounting.cli.ts",
+    "wipe:accounting": "node dist/src/cli/wipe-accounting.cli.js",
     "wipe:accounting:help": "echo 'Usage: CONFIRM_WIPE=YES_I_AM_SURE EXPECTED_DB_NAME=<db> [ALLOW_PROD_WIPE=YES_I_AM_SURE] npm run wipe:accounting'"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

The wipe-accounting Cloud Run Job (`wipe-prod-a4-once`) failed with `sh: tsx: not found` because the production image ran the CLI via `tsx src/cli/wipe-accounting.cli.ts` from a workspace where `tsx` isn't reliably on PATH. This blocked the Phase A.4 wipe and, transitively, every subsequent migration (Prisma `P3009` blocks A.5a/A.5c from applying — three consecutive prod deploys failed because of it).

This PR switches the script to run compiled JS:

- `apps/api/nest-cli.json` — include CPA-case CSV fixtures as build assets so `finance-coa.csv` lands at `dist/src/modules/journal/__tests__/fixtures/cpa-cases/`. The compiled `seed-coa-finance.js` resolves the CSV path via `__dirname → ../src/...` → that asset location.
- `apps/api/package.json` — `wipe:accounting` script now runs `node dist/src/cli/wipe-accounting.cli.js` (was `tsx ... .ts`). `nest build` already compiles `src/cli/*` by default; no tsconfig change needed.

## Test plan

- [x] `cd apps/api && npm run build` succeeds and produces:
  - `dist/src/cli/wipe-accounting.cli.js`
  - `dist/src/modules/journal/__tests__/fixtures/cpa-cases/finance-coa.csv` (plus 4 case CSVs)
- [x] `node dist/src/cli/wipe-accounting.cli.js` (no env vars) prints the help banner and exits 1 cleanly — guards still trigger
- [ ] CI lint+test green
- [ ] After merge, image rebuilds; then a new ephemeral wipe job pinned to the new image will be created — and only then run with owner approval

## Recovery sequence (post-merge, requires owner explicit go)

1. Verify new image tag (commit SHA) is in GAR after CI build
2. Update `wipe-prod-a4-once` job's image to the new tag (or create a fresh job — ephemeral)
3. Owner approves → run wipe (CONFIRM_WIPE + EXPECTED_DB_NAME=bestchoice + ALLOW_PROD_WIPE all set)
4. `bestchoice-migrate-resolve` job (with args updated to `--rolled-back 20260801100000_phase_a4_cpa_chart_schema`) unblocks Prisma state
5. Re-trigger Deploy workflow → A.4 / A.5a / A.5c apply on clean schema, API deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)