### PR TITLE
fix(web): rewrite ChartOfAccountsPage for Phase A.4 schema

### DIFF
--- a/apps/web/src/pages/ChartOfAccountsPage.tsx
+++ b/apps/web/src/pages/ChartOfAccountsPage.tsx
@@ -6,127 +6,158 @@ import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Badge } from '@/components/ui/badge';
-import { getStatusBadgeProps, accountGroupMap } from '@/lib/status-badges';
 
-type AccountGroup = 'ASSET' | 'LIABILITY' | 'EQUITY' | 'REVENUE' | 'EXPENSE';
-
-interface Company {
-  id: string;
-  companyCode: string;
-  nameTh?: string;
-}
+// removed in A.4 — single FINANCE chart, no companyId / multi-entity filter
 
 interface ChartOfAccount {
   id: string;
   code: string;
-  nameTh: string;
-  nameEn?: string | null;
-  accountGroup: AccountGroup;
-  parentCode?: string | null;
-  level: number;
-  isActive: boolean;
-  companyId: string | null;
-  peakAccountCode?: string | null;
-  peakAccountId?: string | null;
+  name: string;                 // Thai name (was nameTh + nameEn in old schema)
+  type: string;                 // สินทรัพย์ | สินทรัพย์ (Contra) | หนี้สิน | ทุน | รายได้ | ค่าใช้จ่าย
+  normalBalance: string;        // Dr | Cr | Dr/Cr
+  category?: string | null;
+  vatApplicable: boolean;
+  notes?: string | null;
+  status: string;               // ใช้งาน | ไม่ใช้งาน
 }
 
-const GROUP_LABELS: Record<AccountGroup, string> = {
-  ASSET: 'สินทรัพย์',
-  LIABILITY: 'หนี้สิน',
-  EQUITY: 'ส่วนของเจ้าของ',
-  REVENUE: 'รายได้',
-  EXPENSE: 'ค่าใช้จ่าย',
+// Filter types — UI labels map to type field values
+type TypeFilter = 'ALL' | 'สินทรัพย์' | 'หนี้สิน' | 'ทุน' | 'รายได้' | 'ค่าใช้จ่าย';
+
+const TYPE_FILTER_LABELS: { value: TypeFilter; label: string }[] = [
+  { value: 'ALL', label: 'ทั้งหมด' },
+  { value: 'สินทรัพย์', label: 'สินทรัพย์' },
+  { value: 'หนี้สิน', label: 'หนี้สิน' },
+  { value: 'ทุน', label: 'ส่วนของเจ้าของ' },
+  { value: 'รายได้', label: 'รายได้' },
+  { value: 'ค่าใช้จ่าย', label: 'ค่าใช้จ่าย' },
+];
+
+// Type select options for the form
+const TYPE_OPTIONS = [
+  'สินทรัพย์',
+  'สินทรัพย์ (Contra)',
+  'หนี้สิน',
+  'ทุน',
+  'รายได้',
+  'ค่าใช้จ่าย',
+];
+
+// Section headers by 2-digit code prefix (matching CSV structure)
+const CODE_PREFIX_LABELS: Record<string, string> = {
+  '11': 'สินทรัพย์หมุนเวียน',
+  '12': 'สินทรัพย์ไม่หมุนเวียน',
+  '21': 'หนี้สินหมุนเวียน',
+  '22': 'หนี้สินไม่หมุนเวียน',
+  '31': 'ทุนเรือนหุ้น / ส่วนของเจ้าของ',
+  '32': 'กำไรสะสม',
+  '33': 'กำไรประจำปี',
+  '39': 'บัญชีปิดงบ (Closing Accounts)',
+  '41': 'รายได้จากการขาย',
+  '42': 'รายได้อื่น',
+  '51': 'ต้นทุนขาย',
+  '52': 'ค่าใช้จ่ายในการขาย',
+  '53': 'ค่าใช้จ่ายในการบริหาร',
+  '54': 'ค่าใช้จ่ายทางการเงิน',
+  '55': 'ค่าใช้จ่ายอื่น',
 };
 
+// Derive section label from code — fallback to raw prefix
+function getSectionLabel(prefix: string): string {
+  return CODE_PREFIX_LABELS[prefix] ?? `หมวด ${prefix}`;
+}
+
+// Extract 2-digit prefix from code like "11-1101" → "11"
+function codePrefix(code: string): string {
+  const dash = code.indexOf('-');
+  if (dash >= 2) return code.slice(0, 2);
+  return code.slice(0, 2);
+}
 
 interface FormState {
   code: string;
-  nameTh: string;
-  nameEn: string;
-  accountGroup: AccountGroup;
-  parentCode: string;
-  level: number;
-  isActive: boolean;
-  companyId: string; // empty string = shared
-  peakAccountCode: string;
-  peakAccountId: string;
+  name: string;
+  type: string;
+  normalBalance: string;
+  category: string;
+  vatApplicable: boolean;
+  notes: string;
+  status: string;
 }
 
 const emptyForm: FormState = {
   code: '',
-  nameTh: '',
-  nameEn: '',
-  accountGroup: 'ASSET',
-  parentCode: '',
-  level: 3,
-  isActive: true,
-  companyId: '',
-  peakAccountCode: '',
-  peakAccountId: '',
+  name: '',
+  type: 'สินทรัพย์',
+  normalBalance: 'Dr',
+  category: '',
+  vatApplicable: false,
+  notes: '',
+  status: 'ใช้งาน',
 };
 
 export default function ChartOfAccountsPage() {
   const queryClient = useQueryClient();
-  const [groupFilter, setGroupFilter] = useState<AccountGroup | 'ALL'>('ALL');
-  const [companyFilter, setCompanyFilter] = useState<string>('ALL');
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('ALL');
   const [search, setSearch] = useState('');
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<ChartOfAccount | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
-  const [deleteConfirm, setDeleteConfirm] = useState<{ open: boolean; id: string; label: string }>({ open: false, id: '', label: '' });
+  const [deleteConfirm, setDeleteConfirm] = useState<{ open: boolean; id: string; label: string }>({
+    open: false,
+    id: '',
+    label: '',
+  });
 
-  const { data: companies = [] } = useQuery<Company[]>({
-    queryKey: ['companies-coa'],
+  const {
+    data: accounts = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<ChartOfAccount[]>({
+    queryKey: ['chart-of-accounts'],
     queryFn: async () => {
-      const { data } = await api.get('/companies');
+      const { data } = await api.get('/chart-of-accounts');
       return data;
     },
   });
 
-  const { data: accounts = [], isLoading, isError, error, refetch } = useQuery<ChartOfAccount[]>({
-    queryKey: ['chart-of-accounts', companyFilter],
-    queryFn: async () => {
-      const params: Record<string, string> = {};
-      if (companyFilter === 'SHARED') params.companyId = 'SHARED';
-      else if (companyFilter !== 'ALL') params.companyId = companyFilter;
-      const { data } = await api.get('/chart-of-accounts', { params });
-      return data;
-    },
-  });
-
+  // Client-side filter: type + search
   const filtered = useMemo(() => {
     return accounts.filter((a) => {
-      if (groupFilter !== 'ALL' && a.accountGroup !== groupFilter) return false;
+      // Type filter — "สินทรัพย์" matches both "สินทรัพย์" and "สินทรัพย์ (Contra)"
+      if (typeFilter !== 'ALL' && !a.type.startsWith(typeFilter)) return false;
       if (search) {
         const q = search.toLowerCase();
-        return (
-          a.code.toLowerCase().includes(q) ||
-          a.nameTh.toLowerCase().includes(q) ||
-          (a.nameEn || '').toLowerCase().includes(q)
-        );
+        return a.code.toLowerCase().includes(q) || a.name.toLowerCase().includes(q);
       }
       return true;
     });
-  }, [accounts, groupFilter, search]);
+  }, [accounts, typeFilter, search]);
 
-  const grouped = useMemo(() => {
-    const map = new Map<AccountGroup, ChartOfAccount[]>();
+  // Group by 2-digit code prefix, preserving sort order (accounts are already sorted by code asc)
+  const sections = useMemo(() => {
+    const map = new Map<string, ChartOfAccount[]>();
     for (const a of filtered) {
-      if (!map.has(a.accountGroup)) map.set(a.accountGroup, []);
-      map.get(a.accountGroup)!.push(a);
+      const prefix = codePrefix(a.code);
+      if (!map.has(prefix)) map.set(prefix, []);
+      map.get(prefix)!.push(a);
     }
-    return map;
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
   }, [filtered]);
 
   const createMutation = useMutation({
     mutationFn: async () => {
       const payload = {
-        ...form,
-        nameEn: form.nameEn || undefined,
-        parentCode: form.parentCode || undefined,
-        companyId: form.companyId || undefined,
-        peakAccountCode: form.peakAccountCode || undefined,
-        peakAccountId: form.peakAccountId || undefined,
+        code: form.code,
+        name: form.name,
+        type: form.type,
+        normalBalance: form.normalBalance,
+        category: form.category || undefined,
+        vatApplicable: form.vatApplicable,
+        notes: form.notes || undefined,
+        status: form.status,
       };
       const { data } = await api.post('/chart-of-accounts', payload);
       return data;
@@ -143,15 +174,13 @@ export default function ChartOfAccountsPage() {
     mutationFn: async () => {
       if (!editing) return;
       const payload = {
-        nameTh: form.nameTh,
-        nameEn: form.nameEn || undefined,
-        accountGroup: form.accountGroup,
-        parentCode: form.parentCode || undefined,
-        level: form.level,
-        isActive: form.isActive,
-        companyId: form.companyId || null,
-        peakAccountCode: form.peakAccountCode || undefined,
-        peakAccountId: form.peakAccountId || undefined,
+        name: form.name,
+        type: form.type,
+        normalBalance: form.normalBalance,
+        category: form.category || undefined,
+        vatApplicable: form.vatApplicable,
+        notes: form.notes || undefined,
+        status: form.status,
       };
       const { data } = await api.patch(`/chart-of-accounts/${editing.id}`, payload);
       return data;
@@ -177,10 +206,7 @@ export default function ChartOfAccountsPage() {
 
   function openCreate() {
     setEditing(null);
-    // Pre-fill companyId from current filter (UX nicety)
-    const initialCompanyId =
-      companyFilter !== 'ALL' && companyFilter !== 'SHARED' ? companyFilter : '';
-    setForm({ ...emptyForm, companyId: initialCompanyId });
+    setForm(emptyForm);
     setShowForm(true);
   }
 
@@ -188,15 +214,13 @@ export default function ChartOfAccountsPage() {
     setEditing(a);
     setForm({
       code: a.code,
-      nameTh: a.nameTh,
-      nameEn: a.nameEn || '',
-      accountGroup: a.accountGroup,
-      parentCode: a.parentCode || '',
-      level: a.level,
-      isActive: a.isActive,
-      companyId: a.companyId || '',
-      peakAccountCode: a.peakAccountCode || '',
-      peakAccountId: a.peakAccountId || '',
+      name: a.name,
+      type: a.type,
+      normalBalance: a.normalBalance,
+      category: a.category ?? '',
+      vatApplicable: a.vatApplicable,
+      notes: a.notes ?? '',
+      status: a.status,
     });
     setShowForm(true);
   }
@@ -208,7 +232,7 @@ export default function ChartOfAccountsPage() {
   }
 
   function handleSubmit() {
-    if (!form.code.trim() || !form.nameTh.trim()) {
+    if (!form.code.trim() || !form.name.trim()) {
       toast.error('กรุณากรอกรหัสและชื่อบัญชี');
       return;
     }
@@ -216,13 +240,14 @@ export default function ChartOfAccountsPage() {
     else createMutation.mutate();
   }
 
-  const inputClass = 'w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden';
+  const inputClass =
+    'w-full px-3 py-2 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden bg-background text-foreground';
 
   return (
     <div>
       <PageHeader
         title="ผังบัญชี"
-        subtitle="จัดการรหัสบัญชี (Chart of Accounts) สำหรับระบบบัญชี"
+        subtitle="จัดการรหัสบัญชี (Chart of Accounts) — BESTCHOICE FINANCE"
         action={
           <button
             onClick={openCreate}
@@ -241,33 +266,21 @@ export default function ChartOfAccountsPage() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className={`${inputClass} max-w-xs`}
+          aria-label="ค้นหาบัญชี"
         />
-        <select
-          value={companyFilter}
-          onChange={(e) => setCompanyFilter(e.target.value)}
-          className={`${inputClass} max-w-[14rem]`}
-          aria-label="กรองตามบริษัท"
-        >
-          <option value="ALL">ทุกบริษัท (รวม shared)</option>
-          <option value="SHARED">Shared (ไม่ระบุบริษัท)</option>
-          {companies.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.companyCode}
-              {c.nameTh ? ` — ${c.nameTh}` : ''}
-            </option>
-          ))}
-        </select>
         <div className="flex gap-2 flex-wrap">
-          <FilterChip active={groupFilter === 'ALL'} onClick={() => setGroupFilter('ALL')}>ทั้งหมด</FilterChip>
-          {(Object.keys(GROUP_LABELS) as AccountGroup[]).map((g) => (
-            <FilterChip key={g} active={groupFilter === g} onClick={() => setGroupFilter(g)}>
-              {GROUP_LABELS[g]}
+          {TYPE_FILTER_LABELS.map(({ value, label }) => (
+            <FilterChip key={value} active={typeFilter === value} onClick={() => setTypeFilter(value)}>
+              {label}
             </FilterChip>
           ))}
         </div>
+        <span className="text-xs text-muted-foreground leading-snug">
+          {filtered.length} รายการ
+        </span>
       </div>
 
-      {/* List */}
+      {/* Account list grouped by code prefix */}
       <QueryBoundary
         isLoading={isLoading && accounts.length === 0}
         isError={isError}
@@ -275,87 +288,111 @@ export default function ChartOfAccountsPage() {
         onRetry={refetch}
         errorTitle="ไม่สามารถโหลดผังบัญชีได้"
       >
-      {filtered.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">ไม่พบบัญชี</div>
-      ) : (
-        <div className="space-y-6">
-          {(Object.keys(GROUP_LABELS) as AccountGroup[]).map((g) => {
-            const list = grouped.get(g);
-            if (!list || list.length === 0) return null;
-            return (
-              <div key={g} className="rounded-xl border border-border bg-card overflow-hidden">
-                <div className="px-4 py-2.5 border-b border-border bg-muted/40 font-semibold text-sm flex items-center gap-2">
-                  {(() => {
-                    const cfg = getStatusBadgeProps(g, accountGroupMap);
-                    return <Badge variant={cfg.variant} appearance={cfg.appearance} size="sm">{cfg.label}</Badge>;
-                  })()}
+        {filtered.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground leading-snug">ไม่พบบัญชี</div>
+        ) : (
+          <div className="space-y-4">
+            {sections.map(([prefix, list]) => (
+              <div key={prefix} className="rounded-xl border border-border bg-card overflow-hidden">
+                {/* Section header */}
+                <div className="px-4 py-2.5 border-b border-border bg-muted/40 flex items-center gap-2">
+                  <span className="font-mono text-xs font-semibold text-muted-foreground">{prefix}</span>
+                  <span className="font-semibold text-sm leading-snug">{getSectionLabel(prefix)}</span>
                   <span className="text-muted-foreground font-normal text-xs">({list.length})</span>
                 </div>
                 <table className="w-full text-sm">
                   <thead className="bg-muted/50 text-xs text-muted-foreground">
                     <tr>
-                      <th className="text-left px-4 py-2 font-medium w-32">รหัส</th>
-                      <th className="text-left px-4 py-2 font-medium">ชื่อบัญชี (ไทย)</th>
-                      <th className="text-left px-4 py-2 font-medium">ชื่อบัญชี (อังกฤษ)</th>
-                      <th className="text-left px-4 py-2 font-medium w-24">บัญชีแม่</th>
-                      <th className="text-left px-4 py-2 font-medium w-20">ระดับ</th>
-                      <th className="text-left px-4 py-2 font-medium w-24">สถานะ</th>
+                      <th className="text-left px-4 py-2 font-medium w-28">รหัส</th>
+                      <th className="text-left px-4 py-2 font-medium">ชื่อบัญชี</th>
+                      <th className="text-left px-4 py-2 font-medium w-44">ประเภท</th>
+                      <th className="text-left px-4 py-2 font-medium w-20">ยอดปกติ</th>
+                      <th className="text-left px-4 py-2 font-medium w-20">สถานะ</th>
                       <th className="text-right px-4 py-2 font-medium w-32">การกระทำ</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {list.map((a) => (
-                      <tr key={a.id} className="border-t border-border hover:bg-muted/30">
-                        <td className="px-4 py-2 font-mono font-medium">{a.code}</td>
-                        <td className="px-4 py-2">{a.nameTh}</td>
-                        <td className="px-4 py-2 text-muted-foreground">{a.nameEn || '-'}</td>
-                        <td className="px-4 py-2 font-mono text-muted-foreground">{a.parentCode || '-'}</td>
-                        <td className="px-4 py-2">{a.level}</td>
-                        <td className="px-4 py-2">
-                          {a.isActive ? (
-                            <Badge variant="success" appearance="light">ใช้งาน</Badge>
-                          ) : (
-                            <Badge variant="secondary">ปิด</Badge>
-                          )}
-                        </td>
-                        <td className="px-4 py-2 text-right space-x-2">
-                          <button
-                            onClick={() => openEdit(a)}
-                            className="text-xs px-2 py-1 text-primary hover:underline"
-                          >
-                            แก้ไข
-                          </button>
-                          <button
-                            onClick={() => setDeleteConfirm({ open: true, id: a.id, label: `${a.code} ${a.nameTh}` })}
-                            className="text-xs px-2 py-1 text-destructive hover:underline"
-                          >
-                            ลบ
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
+                    {list.map((a) => {
+                      const isContra = a.type.includes('Contra');
+                      return (
+                        <tr key={a.id} className="border-t border-border hover:bg-muted/30">
+                          <td className="px-4 py-2 font-mono font-medium text-foreground">{a.code}</td>
+                          <td className="px-4 py-2 leading-snug">
+                            <span className="text-foreground">{a.name}</span>
+                            {a.category && (
+                              <span className="ml-2 text-xs text-muted-foreground">{a.category}</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-2">
+                            <div className="flex items-center gap-1.5 flex-wrap">
+                              <span className="text-muted-foreground leading-snug">{a.type}</span>
+                              {isContra && (
+                                <Badge variant="warning" appearance="light" size="sm">
+                                  Contra
+                                </Badge>
+                              )}
+                              {a.vatApplicable && (
+                                <Badge variant="info" appearance="light" size="sm">
+                                  VAT
+                                </Badge>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-4 py-2 font-mono text-xs text-muted-foreground">{a.normalBalance}</td>
+                          <td className="px-4 py-2">
+                            {a.status === 'ใช้งาน' ? (
+                              <Badge variant="success" appearance="light" size="sm">ใช้งาน</Badge>
+                            ) : (
+                              <Badge variant="secondary" size="sm">{a.status}</Badge>
+                            )}
+                          </td>
+                          <td className="px-4 py-2 text-right space-x-2">
+                            <button
+                              onClick={() => openEdit(a)}
+                              className="text-xs px-2 py-1 text-primary hover:underline"
+                            >
+                              แก้ไข
+                            </button>
+                            <button
+                              onClick={() =>
+                                setDeleteConfirm({ open: true, id: a.id, label: `${a.code} ${a.name}` })
+                              }
+                              className="text-xs px-2 py-1 text-destructive hover:underline"
+                            >
+                              ลบ
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>
-            );
-          })}
-        </div>
-      )}
+            ))}
+          </div>
+        )}
       </QueryBoundary>
 
-      {/* Form overlay */}
+      {/* Add / Edit form overlay */}
       {showForm && (
         <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8">
           <div className="w-full max-w-xl bg-background rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100vh-4rem)]">
-            <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b px-6 py-4 flex items-center justify-between">
-              <button onClick={closeForm} className="text-sm text-muted-foreground hover:text-foreground">← กลับ</button>
-              <h2 className="text-lg font-semibold">{editing ? 'แก้ไขบัญชี' : 'เพิ่มบัญชีใหม่'}</h2>
+            <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-xs border-b border-border px-6 py-4 flex items-center justify-between">
+              <button onClick={closeForm} className="text-sm text-muted-foreground hover:text-foreground">
+                ← กลับ
+              </button>
+              <h2 className="text-lg font-semibold leading-snug">
+                {editing ? 'แก้ไขบัญชี' : 'เพิ่มบัญชีใหม่'}
+              </h2>
               <div className="w-12" />
             </div>
             <div className="p-6 space-y-4">
+              {/* Code + Type */}
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-xs font-medium mb-1.5">รหัสบัญชี <span className="text-destructive">*</span></label>
+                  <label className="block text-xs font-medium mb-1.5 leading-snug">
+                    รหัสบัญชี <span className="text-destructive">*</span>
+                  </label>
                   <input
                     type="text"
                     value={form.code}
@@ -366,129 +403,118 @@ export default function ChartOfAccountsPage() {
                   />
                 </div>
                 <div>
-                  <label className="block text-xs font-medium mb-1.5">หมวดบัญชี <span className="text-destructive">*</span></label>
+                  <label className="block text-xs font-medium mb-1.5 leading-snug">
+                    ประเภทบัญชี <span className="text-destructive">*</span>
+                  </label>
                   <select
-                    value={form.accountGroup}
-                    onChange={(e) => setForm({ ...form, accountGroup: e.target.value as AccountGroup })}
+                    value={form.type}
+                    onChange={(e) => setForm({ ...form, type: e.target.value })}
                     className={inputClass}
+                    aria-label="ประเภทบัญชี"
                   >
-                    {(Object.keys(GROUP_LABELS) as AccountGroup[]).map((g) => (
-                      <option key={g} value={g}>{GROUP_LABELS[g]}</option>
+                    {TYPE_OPTIONS.map((t) => (
+                      <option key={t} value={t}>{t}</option>
                     ))}
                   </select>
                 </div>
               </div>
+
+              {/* Name */}
               <div>
-                <label className="block text-xs font-medium mb-1.5">ชื่อบัญชี (ไทย) <span className="text-destructive">*</span></label>
+                <label className="block text-xs font-medium mb-1.5 leading-snug">
+                  ชื่อบัญชี (ภาษาไทย) <span className="text-destructive">*</span>
+                </label>
                 <input
                   type="text"
-                  value={form.nameTh}
-                  onChange={(e) => setForm({ ...form, nameTh: e.target.value })}
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
                   className={inputClass}
-                  placeholder="เช่น เงินสด - เงินสดย่อย"
+                  placeholder="เช่น เงินสด"
                 />
               </div>
-              <div>
-                <label className="block text-xs font-medium mb-1.5">ชื่อบัญชี (อังกฤษ)</label>
-                <input
-                  type="text"
-                  value={form.nameEn}
-                  onChange={(e) => setForm({ ...form, nameEn: e.target.value })}
-                  className={inputClass}
-                  placeholder="เช่น Petty Cash"
-                />
-              </div>
+
+              {/* Normal Balance + Category */}
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-xs font-medium mb-1.5">รหัสบัญชีแม่ (ถ้ามี)</label>
-                  <input
-                    type="text"
-                    value={form.parentCode}
-                    onChange={(e) => setForm({ ...form, parentCode: e.target.value })}
-                    className={inputClass}
-                    placeholder="เช่น 11-1100"
-                  />
-                </div>
-                <div>
-                  <label className="block text-xs font-medium mb-1.5">ระดับ (1=กลุ่ม, 3=รายละเอียด)</label>
+                  <label className="block text-xs font-medium mb-1.5 leading-snug">ยอดปกติ</label>
                   <select
-                    value={form.level}
-                    onChange={(e) => setForm({ ...form, level: Number(e.target.value) })}
+                    value={form.normalBalance}
+                    onChange={(e) => setForm({ ...form, normalBalance: e.target.value })}
                     className={inputClass}
+                    aria-label="ยอดปกติ"
                   >
-                    <option value={1}>1 - กลุ่มหลัก</option>
-                    <option value={2}>2 - กลุ่มย่อย</option>
-                    <option value={3}>3 - รายละเอียด</option>
+                    <option value="Dr">Dr (เดบิต)</option>
+                    <option value="Cr">Cr (เครดิต)</option>
+                    <option value="Dr/Cr">Dr/Cr (ทั้งสองด้าน)</option>
                   </select>
                 </div>
-              </div>
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={form.isActive}
-                  onChange={(e) => setForm({ ...form, isActive: e.target.checked })}
-                />
-                ใช้งาน
-              </label>
-
-              {/* ── บริษัทเจ้าของบัญชี (Multi-Entity) ── */}
-              <div className="border-t pt-4 mt-2">
-                <label className="block text-xs font-medium mb-1.5">บริษัทเจ้าของบัญชี</label>
-                <select
-                  value={form.companyId}
-                  onChange={(e) => setForm({ ...form, companyId: e.target.value })}
-                  className={inputClass}
-                >
-                  <option value="">Shared (ใช้ได้ทุกบริษัท)</option>
-                  {companies.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.companyCode}
-                      {c.nameTh ? ` — ${c.nameTh}` : ''}
-                    </option>
-                  ))}
-                </select>
-                <p className="text-xs text-muted-foreground mt-1.5">
-                  เว้นว่าง (Shared) = ใช้ได้กับทุกบริษัท
-                </p>
-              </div>
-
-              {/* ── การ sync กับ PEAK ── */}
-              <div className="border-t pt-4 mt-2">
-                <label className="block text-xs font-medium mb-2 text-muted-foreground">
-                  การเชื่อมต่อกับ PEAK (ระบบบัญชีภายนอก)
-                </label>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-xs font-medium mb-1.5">รหัสบัญชี PEAK</label>
-                    <input
-                      type="text"
-                      value={form.peakAccountCode}
-                      onChange={(e) => setForm({ ...form, peakAccountCode: e.target.value })}
-                      className={inputClass}
-                      placeholder="เช่น 11-1101"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium mb-1.5">PEAK Account ID</label>
-                    <input
-                      type="text"
-                      value={form.peakAccountId}
-                      onChange={(e) => setForm({ ...form, peakAccountId: e.target.value })}
-                      className={inputClass}
-                      placeholder="UUID จาก PEAK API"
-                    />
-                  </div>
+                <div>
+                  <label className="block text-xs font-medium mb-1.5 leading-snug">หมวดหมู่ (ถ้ามี)</label>
+                  <input
+                    type="text"
+                    value={form.category}
+                    onChange={(e) => setForm({ ...form, category: e.target.value })}
+                    className={inputClass}
+                    placeholder="เช่น เงินสด, ลูกหนี้, VAT"
+                  />
                 </div>
               </div>
+
+              {/* VAT applicable */}
+              <label className="flex items-center gap-2 text-sm leading-snug cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={form.vatApplicable}
+                  onChange={(e) => setForm({ ...form, vatApplicable: e.target.checked })}
+                  className="rounded"
+                />
+                มี VAT (vatApplicable)
+              </label>
+
+              {/* Notes */}
+              <div>
+                <label className="block text-xs font-medium mb-1.5 leading-snug">หมายเหตุ</label>
+                <textarea
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  className={`${inputClass} resize-none`}
+                  rows={3}
+                  placeholder="หมายเหตุเพิ่มเติม (ถ้ามี)"
+                />
+              </div>
+
+              {/* Status */}
+              <div>
+                <label className="block text-xs font-medium mb-1.5 leading-snug">สถานะ</label>
+                <select
+                  value={form.status}
+                  onChange={(e) => setForm({ ...form, status: e.target.value })}
+                  className={inputClass}
+                  aria-label="สถานะ"
+                >
+                  <option value="ใช้งาน">ใช้งาน</option>
+                  <option value="ไม่ใช้งาน">ไม่ใช้งาน</option>
+                </select>
+              </div>
             </div>
-            <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t px-6 py-4 flex justify-end gap-3">
-              <button onClick={closeForm} className="px-6 py-2.5 text-sm border border-input rounded-lg hover:bg-muted">ยกเลิก</button>
+
+            <div className="sticky bottom-0 bg-background/95 backdrop-blur-xs border-t border-border px-6 py-4 flex justify-end gap-3">
+              <button
+                onClick={closeForm}
+                className="px-6 py-2.5 text-sm border border-input rounded-lg hover:bg-muted"
+              >
+                ยกเลิก
+              </button>
               <button
                 onClick={handleSubmit}
                 disabled={createMutation.isPending || updateMutation.isPending}
                 className="px-6 py-2.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 font-semibold"
               >
-                {createMutation.isPending || updateMutation.isPending ? 'กำลังบันทึก...' : editing ? 'บันทึกการแก้ไข' : 'เพิ่มบัญชี'}
+                {createMutation.isPending || updateMutation.isPending
+                  ? 'กำลังบันทึก...'
+                  : editing
+                  ? 'บันทึกการแก้ไข'
+                  : 'เพิ่มบัญชี'}
               </button>
             </div>
           </div>
@@ -506,13 +532,23 @@ export default function ChartOfAccountsPage() {
   );
 }
 
-function FilterChip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+function FilterChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
-        active ? 'bg-primary text-primary-foreground border-primary' : 'bg-background border-input hover:bg-muted'
+      className={`px-3 py-1.5 text-sm rounded-lg border transition-colors leading-snug ${
+        active
+          ? 'bg-primary text-primary-foreground border-primary'
+          : 'bg-background border-input hover:bg-muted text-foreground'
       }`}
     >
       {children}


### PR DESCRIPTION
## Summary

- Page rendered blank in prod after Phase A.4 migration removed `nameTh`, `nameEn`, `accountGroup`, `companyId`, `isActive`, `parentCode` from `ChartOfAccount`
- Rewritten to match new schema: `code`, `name`, `type`, `normalBalance`, `category`, `vatApplicable`, `notes`, `status`
- Removed company filter dropdown (removed in A.4 — single FINANCE chart)
- Replaced enum-based group filter with Thai `type` field filter pills (`สินทรัพย์` matches both `สินทรัพย์` and `สินทรัพย์ (Contra)`)
- Groups accounts by 2-digit code prefix (11=สินทรัพย์หมุนเวียน, 21=หนี้สินหมุนเวียน, 41/42=รายได้, 51-55=ค่าใช้จ่าย, etc.)
- Shows Contra badge when `type` includes "Contra", VAT badge when `vatApplicable=true`
- Simplified Add/Edit form: code, name, type (select), normalBalance (Dr/Cr/Dr/Cr), category, vatApplicable (checkbox), notes, status
- Search by code OR name (removed nameEn)

## Test plan

- [ ] TypeScript: `./tools/check-types.sh web` — 0 errors (confirmed)
- [ ] Build: `npm run build` — passes (confirmed)
- [ ] Verify page loads in prod with 105 accounts grouped correctly
- [ ] Verify filter pills work (สินทรัพย์ includes Contra rows)
- [ ] Verify Add/Edit form saves with new fields