### PR TITLE
fix(cli): backfill status filter — use ContractStatus enum

### DIFF
--- a/apps/api/src/cli/backfill-installment-schedules.cli.ts
+++ b/apps/api/src/cli/backfill-installment-schedules.cli.ts
@@ -33,7 +33,7 @@ async function main(): Promise<void> {
 
   const candidates = await prisma.contract.findMany({
     where: {
-      workflowStatus: 'ACTIVE' as any,
+      status: { in: ['ACTIVE', 'OVERDUE', 'DEFAULT', 'LEGAL'] as any },
       deletedAt: null,
     },
     select: {


### PR DESCRIPTION
Was filtering by wrong enum field. Backfill job exited 1 with no rows affected. This 1-line fix unblocks.