### PR TITLE
feat(accounting): Phase A.6 dynamic CoA architecture

### DIFF
--- a/apps/api/prisma/migrations/20260803000000_phase_a6_expense_category_string/migration.sql
+++ b/apps/api/prisma/migrations/20260803000000_phase_a6_expense_category_string/migration.sql
@@ -1,0 +1,9 @@
+-- Phase A.6: Expense.category enum → String
+-- Allows the column to store either legacy ExpenseCategory enum values
+-- (e.g. ADMIN_SALARY) OR CoA codes (e.g. 53-1101) sent by the updated UI.
+--
+-- PostgreSQL cannot alter an enum-backed column to TEXT directly.
+-- The USING clause casts the existing enum values to text preserving all data.
+
+ALTER TABLE "expenses"
+  ALTER COLUMN "category" TYPE TEXT USING "category"::TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3416,7 +3416,7 @@ model Expense {
   expenseNumber  String             @unique @map("expense_number")
   branchId       String             @map("branch_id")
   accountType    ExpenseAccountType @map("account_type")
-  category       ExpenseCategory
+  category       String          // Phase A.6: was ExpenseCategory enum; now stores CoA code OR legacy enum string
   accountCode    String?            @map("account_code")
   description    String
   amount         Decimal            @db.Decimal(12, 2)

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -21,7 +21,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { ExpenseAccountType, ExpenseCategory, ExpenseStatus } from '@prisma/client';
+import { ExpenseAccountType, ExpenseStatus } from '@prisma/client';
 
 @ApiTags('Expenses')
 @ApiBearerAuth('JWT')
@@ -48,7 +48,7 @@ export class AccountingController {
   findAll(
     @Query('branchId') branchId?: string,
     @Query('accountType') accountType?: ExpenseAccountType,
-    @Query('category') category?: ExpenseCategory,
+    @Query('category') category?: string,
     @Query('status') status?: ExpenseStatus,
     @Query('search') search?: string,
     @Query('startDate') startDate?: string,

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -87,6 +87,9 @@ describe('AccountingService', () => {
       accountingPeriod: {
         findUnique: jest.fn().mockResolvedValue(null),
       },
+      chartOfAccount: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
       $transaction: jest.fn().mockImplementation(async (fn) => {
         if (typeof fn === 'function') {
           return fn(prisma);
@@ -1315,6 +1318,32 @@ describe('AccountingService', () => {
 
       const result = await service.markExpensePaid('exp-3', '2026-04-15');
       expect(result.status).toBe('PAID');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CATEGORY_CODE_MAP boot validator (Phase A.6)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('CATEGORY_CODE_MAP boot validator', () => {
+    it('throws when any mapped code missing from CoA', async () => {
+      // Only return one code — rest are "missing"
+      prisma.chartOfAccount = {
+        ...prisma.chartOfAccount,
+        findMany: jest.fn().mockResolvedValue([{ code: '52-1101' }]),
+      };
+      await expect(service.onModuleInit()).rejects.toThrow(/missing CoA codes/);
+    });
+
+    it('passes when all mapped codes exist', async () => {
+      prisma.chartOfAccount = {
+        ...prisma.chartOfAccount,
+        findMany: jest.fn().mockImplementation(({ where }: { where: { code: { in: string[] } } }) => {
+          const requested = where.code.in;
+          return Promise.resolve(requested.map((code: string) => ({ code })));
+        }),
+      };
+      await expect(service.onModuleInit()).resolves.not.toThrow();
     });
   });
 });

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -3,10 +3,11 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { StructuredLoggerService } from '../../common/logger';
-import { ExpenseAccountType, ExpenseCategory, ExpenseStatus, Prisma, WhtIncomeType } from '@prisma/client';
+import { ExpenseAccountType, ExpenseStatus, Prisma, WhtIncomeType } from '@prisma/client';
 import { CreateExpenseDto, UpdateExpenseDto } from './dto/expense.dto';
 import { validatePeriodOpen as validatePeriodOpenUtil } from '../../utils/period-lock.util';
 import { JournalAutoService } from '../journal/journal-auto.service';
@@ -47,36 +48,42 @@ const CATEGORY_ACCOUNT_MAP: Record<string, ExpenseAccountType> = {
 };
 
 // Map category → account code (PEAK format XX-XXXX)
-// C3 FIX (Phase A.4 PR #741 review): audited against finance-coa.csv new chart.
-// FINANCE entity has NO COGS accounts — COGS is booked on SHOP side (deferred to A.5).
-// ADMIN_SOCIAL_SECURITY and ADMIN_INSURANCE share 53-1102 (เงินสมทบประกันสังคม) — confirmed.
-// ADMIN_DEPRECIATION 53-1601 does NOT exist in new chart — commented out.
-// All other codes verified present and semantically correct.
+// Phase A.6: audited against 105-account finance-coa.csv.
+// FINANCE entity has NO COGS accounts — COGS is booked on SHOP side (deferred to A.5b).
+// COGS_PRODUCT, COGS_REPAIR_PARTS — deprecated; FINANCE has no COGS. UI hides these.
 const CATEGORY_CODE_MAP: Record<string, string> = {
-  // TODO A.5: remap COGS_PRODUCT + COGS_REPAIR_PARTS when SHOP chart is re-introduced.
-  // FINANCE entity does NOT book COGS — these categories must not be used for FINANCE JEs.
-  // COGS_PRODUCT: '51-1101',      // REMOVED — 51-1101 in new chart = "ค่าใช้จ่าย VAT ลูกหนี้ไม่ชำระ" (Finance Cost, not COGS)
-  // COGS_REPAIR_PARTS: '51-1102', // REMOVED — 51-1102 in new chart = "หนี้สูญ/ขาดทุนจากยึดเครื่อง" (Finance Cost, not COGS)
-  SELL_COMMISSION: '52-1101',     // ค่าคอมฯ พนักงาน — verified
-  SELL_ADVERTISING: '52-1102',    // ค่าส่งเสริมการขาย — verified
-  SELL_TRANSPORT: '53-1304',      // ค่าไปรษณีย์ และขนส่ง — verified
-  SELL_PACKAGING: '52-1102',      // ค่าส่งเสริมการขาย (บรรจุภัณฑ์ — nearest match) — verified
-  ADMIN_SALARY: '53-1101',        // เงินเดือน ค่าจ้าง — verified
-  ADMIN_SOCIAL_SECURITY: '53-1102', // เงินสมทบประกันสังคม — verified (was 53-1103 ค่าล่วงเวลา, corrected)
-  ADMIN_RENT: '53-1301',          // ค่าน้ำ group — NOTE: no dedicated rent account in chart; 53-1301=ค่าน้ำ. TODO A.5: add 53-13XX rent account
-  ADMIN_UTILITIES: '53-1302',     // ค่าไฟฟ้า — verified
-  ADMIN_OFFICE_SUPPLIES: '53-1201', // ค่าเครื่องเขียน วัสดุสำนักงาน — verified
-  // ADMIN_DEPRECIATION: '53-1601', // REMOVED — 53-1601 does NOT exist in new chart. TODO A.5: add depreciation account
-  ADMIN_INSURANCE: '53-1103',     // ค่าล่วงเวลา — closest existing; TODO A.5: add dedicated insurance account
-  ADMIN_TAX_FEE: '54-1103',       // เบี้ยปรับ-ภ.พ.30 (รายจ่ายต้องห้าม) — verified
-  ADMIN_MAINTENANCE: '53-1305',   // ค่าซ่อมแซมฯ — verified
-  ADMIN_TRAVEL: '53-1304',        // ค่าไปรษณีย์ และขนส่ง — verified (nearest travel/transport)
-  ADMIN_TELEPHONE: '53-1303',     // ค่าโทรศัพท์สำนักงาน — verified
-  OTHER_INTEREST: '53-1501',      // ค่าธรรมเนียมธนาคาร — verified (finance charge bucket)
-  OTHER_LOSS: '53-1503',          // กำไร(ขาดทุน)สุทธิจากการปัดเศษ — verified (Dr when loss)
-  OTHER_FINE: '54-1104',          // เบี้ยปรับเงินเพิ่ม (อื่นๆ) — verified
-  OTHER_MISC: '53-1502',          // ค่าธรรมเนียมราชการ — verified (misc fees bucket)
+  SELL_COMMISSION: '52-1101',       // ค่าคอมฯ พนักงาน
+  SELL_ADVERTISING: '52-1102',      // ค่าส่งเสริมการขาย
+  SELL_TRANSPORT: '53-1304',        // ค่าไปรษณีย์ และขนส่ง
+  SELL_PACKAGING: '52-1102',        // nearest match (CSV lacks dedicated packaging)
+  ADMIN_SALARY: '53-1101',          // เงินเดือน ค่าจ้าง
+  ADMIN_SOCIAL_SECURITY: '53-1102', // เงินสมทบประกันสังคม (corrected from 53-1103 ค่าล่วงเวลา per audit)
+  ADMIN_RENT: '53-1502',            // ค่าธรรมเนียมราชการ — TEMP placeholder; CSV needs dedicated rent (defer A.7)
+  ADMIN_UTILITIES: '53-1302',       // ค่าไฟฟ้า
+  ADMIN_OFFICE_SUPPLIES: '53-1201', // ค่าเครื่องเขียน วัสดุสำนักงาน
+  ADMIN_DEPRECIATION: '53-1601',    // ค่าเสื่อมราคา-อุปกรณ์ (now exists in 105-CSV)
+  ADMIN_INSURANCE: '53-1502',       // ค่าธรรมเนียมราชการ — TEMP; CSV needs dedicated insurance
+  ADMIN_TAX_FEE: '54-1103',         // เบี้ยปรับ-ภ.พ.30 (รายจ่ายต้องห้าม)
+  ADMIN_MAINTENANCE: '53-1305',     // ค่าซ่อมแซมฯ
+  ADMIN_TRAVEL: '53-1304',          // ค่าไปรษณีย์ และขนส่ง
+  ADMIN_TELEPHONE: '53-1303',       // ค่าโทรศัพท์สำนักงาน
+  OTHER_INTEREST: '53-1501',        // ค่าธรรมเนียมธนาคาร
+  OTHER_LOSS: '53-1503',            // กำไร(ขาดทุน) สุทธิจากการปัดเศษ
+  OTHER_FINE: '54-1104',            // เบี้ยปรับเงินเพิ่ม (อื่นๆ)
+  OTHER_MISC: '53-1502',            // ค่าธรรมเนียมราชการ
 };
+
+/**
+ * Resolve a category string to a CoA account code.
+ * Phase A.6: category column is now String (was enum), so we handle two cases:
+ *  1. If it looks like a CoA code already (XX-XXXX), return as-is.
+ *  2. Otherwise, treat as legacy enum key and look up in CATEGORY_CODE_MAP.
+ * Returns null if not resolvable — caller should log warn + skip JE post.
+ */
+function resolveAccountCode(category: string): string | null {
+  if (/^\d{2}-\d{4}$/.test(category)) return category;
+  return CATEGORY_CODE_MAP[category] ?? null;
+}
 
 async function generateExpenseNumber(tx: Prisma.TransactionClient): Promise<string> {
   const now = new Date();
@@ -115,7 +122,7 @@ async function generateExpenseNumber(tx: Prisma.TransactionClient): Promise<stri
  *    - สินค้าแต่ละชิ้นมี costPrice เฉพาะ (IMEI-level tracking)
  */
 @Injectable()
-export class AccountingService {
+export class AccountingService implements OnModuleInit {
   private readonly logger = new Logger(AccountingService.name);
   private readonly structuredLogger = new StructuredLoggerService(AccountingService.name);
   constructor(
@@ -123,6 +130,27 @@ export class AccountingService {
     private journalAutoService: JournalAutoService,
     private expenseTemplate: ExpenseTemplate,
   ) {}
+
+  /**
+   * Phase A.6 boot validator — verifies every code in CATEGORY_CODE_MAP exists
+   * in the chart_of_accounts table. Throws on startup if any code is missing
+   * so misconfiguration is caught immediately rather than at JE-post time.
+   */
+  async onModuleInit() {
+    const codes = [...new Set(Object.values(CATEGORY_CODE_MAP))];
+    const found = await this.prisma.chartOfAccount.findMany({
+      where: { code: { in: codes }, deletedAt: null },
+      select: { code: true },
+    });
+    const foundSet = new Set(found.map((f) => f.code));
+    const missing = codes.filter((c) => !foundSet.has(c));
+    if (missing.length > 0) {
+      const msg = `[Phase A.6] CATEGORY_CODE_MAP references missing CoA codes: ${missing.join(', ')}. Update CATEGORY_CODE_MAP or seed missing codes.`;
+      this.logger.error(msg);
+      throw new Error(msg);
+    }
+    this.logger.log(`CATEGORY_CODE_MAP validated: all ${codes.length} codes exist in CoA.`);
+  }
 
   /**
    * Resolve companyId to an array of branchIds belonging to that company.
@@ -167,7 +195,7 @@ export class AccountingService {
     const whtIncomeType = (dto.whtIncomeType as WhtIncomeType) || null;
     const totalAmount = dRound(dAdd(dto.amount, vatAmount)).toNumber();
     const netPayment = dRound(dSub(totalAmount, withholdingTax)).toNumber();
-    const accountCode = dto.accountCode || CATEGORY_CODE_MAP[dto.category] || null;
+    const accountCode = dto.accountCode || resolveAccountCode(dto.category) || null;
 
     const expense = await this.prisma.$transaction(async (tx) => {
       const expenseNumber = await generateExpenseNumber(tx);
@@ -177,7 +205,8 @@ export class AccountingService {
           expenseNumber,
           branchId: dto.branchId,
           accountType: dto.accountType,
-          category: dto.category,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          category: dto.category as any, // Phase A.6: String after migration; cast until Prisma client regenerates
           accountCode,
           description: dto.description,
           amount: dto.amount,
@@ -221,7 +250,7 @@ export class AccountingService {
   async findAllExpenses(filters: {
     branchId?: string;
     accountType?: ExpenseAccountType;
-    category?: ExpenseCategory;
+    category?: string;
     status?: ExpenseStatus;
     search?: string;
     startDate?: string;
@@ -236,7 +265,8 @@ export class AccountingService {
     const where: Prisma.ExpenseWhereInput = { deletedAt: null };
     if (branchId) where.branchId = branchId;
     if (accountType) where.accountType = accountType;
-    if (category) where.category = category;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (category) where.category = category as any; // Phase A.6: String after migration; cast until Prisma client regenerates
     if (status) where.status = status;
     if (startDate || endDate) {
       where.expenseDate = {};
@@ -311,8 +341,9 @@ export class AccountingService {
     const data: Prisma.ExpenseUpdateInput = {};
     if (dto.accountType !== undefined) data.accountType = dto.accountType;
     if (dto.category !== undefined) {
-      data.category = dto.category;
-      data.accountCode = CATEGORY_CODE_MAP[dto.category] || expense.accountCode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.category = dto.category as any; // Phase A.6: String after migration; cast until Prisma client regenerates
+      data.accountCode = resolveAccountCode(dto.category) || expense.accountCode;
     }
     if (dto.accountCode !== undefined) data.accountCode = dto.accountCode;
     if (dto.description !== undefined) data.description = dto.description;

--- a/apps/api/src/modules/accounting/dto/expense.dto.ts
+++ b/apps/api/src/modules/accounting/dto/expense.dto.ts
@@ -6,13 +6,13 @@ import {
   IsDateString,
   IsBoolean,
   IsIn,
+  IsNotEmpty,
   Min,
   Max,
   IsInt,
 } from 'class-validator';
 import {
   ExpenseAccountType,
-  ExpenseCategory,
   ExpenseStatus,
   PaymentMethod,
 } from '@prisma/client';
@@ -24,8 +24,9 @@ export class CreateExpenseDto {
   @IsEnum(ExpenseAccountType)
   accountType: ExpenseAccountType;
 
-  @IsEnum(ExpenseCategory)
-  category: ExpenseCategory;
+  @IsString()
+  @IsNotEmpty()
+  category: string; // Phase A.6: was ExpenseCategory enum; now stores CoA code OR legacy enum string
 
   @IsOptional()
   @IsString()
@@ -123,8 +124,8 @@ export class UpdateExpenseDto {
   accountType?: ExpenseAccountType;
 
   @IsOptional()
-  @IsEnum(ExpenseCategory)
-  category?: ExpenseCategory;
+  @IsString()
+  category?: string; // Phase A.6: was ExpenseCategory enum; now stores CoA code OR legacy enum string
 
   @IsOptional()
   @IsString()

--- a/apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts
+++ b/apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts
@@ -4,6 +4,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { ChartOfAccountsService } from './chart-of-accounts.service';
 import { CreateChartOfAccountDto, UpdateChartOfAccountDto } from './dto/chart-of-account.dto';
+import { CoaGroupedQueryDto, CoaGroupedResponse } from './dto/coa-grouped.dto';
 
 @Controller('chart-of-accounts')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -28,6 +29,12 @@ export class ChartOfAccountsController {
     const codeList = codes.split(',').map((c) => c.trim()).filter(Boolean);
     if (codeList.length > 20) throw new BadRequestException('codes ต้องไม่เกิน 20 รายการ');
     return this.service.findByCodes(codeList);
+  }
+
+  @Get('grouped')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  grouped(@Query() query: CoaGroupedQueryDto): Promise<CoaGroupedResponse> {
+    return this.service.findGrouped(query);
   }
 
   @Get(':id')

--- a/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts
+++ b/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChartOfAccountsService } from './chart-of-accounts.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('ChartOfAccountsService.findGrouped', () => {
+  let service: ChartOfAccountsService;
+  let prisma: { chartOfAccount: { findMany: jest.Mock } };
+
+  beforeEach(async () => {
+    prisma = { chartOfAccount: { findMany: jest.fn() } };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChartOfAccountsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = module.get<ChartOfAccountsService>(ChartOfAccountsService);
+  });
+
+  it('groups accounts by category, sorted by code', async () => {
+    prisma.chartOfAccount.findMany.mockResolvedValue([
+      { code: '53-1101', name: 'เงินเดือน', normalBalance: 'Dr', category: 'OpEx-บุคลากร', vatApplicable: false, notes: null },
+      { code: '53-1102', name: 'ประกันสังคม', normalBalance: 'Dr', category: 'OpEx-บุคลากร', vatApplicable: false, notes: null },
+      { code: '53-1201', name: 'วัสดุสำนักงาน', normalBalance: 'Dr', category: 'OpEx-วัสดุ', vatApplicable: false, notes: null },
+    ]);
+
+    const result = await service.findGrouped({ type: 'ค่าใช้จ่าย' });
+
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups[0].category).toBe('OpEx-บุคลากร');
+    expect(result.groups[0].accounts).toHaveLength(2);
+    expect(result.groups[0].accounts[0].code).toBe('53-1101');
+    expect(result.groups[1].category).toBe('OpEx-วัสดุ');
+  });
+
+  it('filters by codePrefix', async () => {
+    prisma.chartOfAccount.findMany.mockResolvedValue([
+      { code: '12-2101', name: 'อุปกรณ์สำนักงาน', normalBalance: 'Dr', category: 'สินทรัพย์ถาวร', vatApplicable: false, notes: null },
+    ]);
+
+    await service.findGrouped({ codePrefix: '12-21' });
+
+    expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ code: { startsWith: '12-21' } }),
+      }),
+    );
+  });
+
+  it('groups uncategorized accounts under "อื่นๆ"', async () => {
+    prisma.chartOfAccount.findMany.mockResolvedValue([
+      { code: '99-9999', name: 'test', normalBalance: 'Dr', category: null, vatApplicable: false, notes: null },
+    ]);
+
+    const result = await service.findGrouped({});
+
+    expect(result.groups[0].category).toBe('อื่นๆ');
+  });
+});

--- a/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts
+++ b/apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateChartOfAccountDto, UpdateChartOfAccountDto } from './dto/chart-of-account.dto';
+import { CoaAccountRow, CoaGroupedResponse } from './dto/coa-grouped.dto';
 
 @Injectable()
 export class ChartOfAccountsService {
@@ -35,6 +37,41 @@ export class ChartOfAccountsService {
       select: { code: true, name: true },
       orderBy: { code: 'asc' },
     });
+  }
+
+  async findGrouped(query: { type?: string; codePrefix?: string; category?: string }): Promise<CoaGroupedResponse> {
+    const where: Prisma.ChartOfAccountWhereInput = { deletedAt: null, status: 'ใช้งาน' };
+    if (query.type) where.type = query.type;
+    if (query.codePrefix) where.code = { startsWith: query.codePrefix };
+    if (query.category) where.category = query.category;
+
+    const rows = await this.prisma.chartOfAccount.findMany({
+      where,
+      orderBy: { code: 'asc' },
+      select: {
+        code: true,
+        name: true,
+        normalBalance: true,
+        category: true,
+        vatApplicable: true,
+        notes: true,
+      },
+    });
+
+    const map = new Map<string, CoaAccountRow[]>();
+    for (const r of rows) {
+      const cat = r.category ?? 'อื่นๆ';
+      const arr = map.get(cat) ?? [];
+      arr.push({
+        code: r.code,
+        name: r.name,
+        normalBalance: r.normalBalance,
+        vatApplicable: r.vatApplicable,
+        notes: r.notes,
+      });
+      map.set(cat, arr);
+    }
+    return { groups: Array.from(map, ([category, accounts]) => ({ category, accounts })) };
   }
 
   async findOne(id: string) {

--- a/apps/api/src/modules/chart-of-accounts/dto/coa-grouped.dto.ts
+++ b/apps/api/src/modules/chart-of-accounts/dto/coa-grouped.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsString, Matches } from 'class-validator';
+
+export class CoaGroupedQueryDto {
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{2}(-\d{0,4})?$/, { message: 'codePrefix must match XX or XX-XXXX' })
+  codePrefix?: string;
+
+  @IsOptional()
+  @IsString()
+  category?: string;
+}
+
+export interface CoaAccountRow {
+  code: string;
+  name: string;
+  normalBalance: string;
+  vatApplicable: boolean;
+  notes: string | null;
+}
+
+export interface CoaGroup {
+  category: string;
+  accounts: CoaAccountRow[];
+}
+
+export interface CoaGroupedResponse {
+  groups: CoaGroup[];
+}

--- a/apps/web/src/hooks/useCoa.ts
+++ b/apps/web/src/hooks/useCoa.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+export interface CoaAccountRow {
+  code: string;
+  name: string;
+  normalBalance: string;
+  vatApplicable: boolean;
+  notes: string | null;
+}
+
+export interface CoaGroup {
+  category: string;
+  accounts: CoaAccountRow[];
+}
+
+export interface CoaGroupedResponse {
+  groups: CoaGroup[];
+}
+
+export interface CoaByCodesRow {
+  code: string;
+  name: string;
+}
+
+export interface CoaGroupedFilter {
+  type?: string;
+  codePrefix?: string;
+  category?: string;
+}
+
+export function useCoaGroups(filter: CoaGroupedFilter) {
+  return useQuery<CoaGroupedResponse>({
+    queryKey: ['coa', 'grouped', filter],
+    queryFn: async () => {
+      const { data } = await api.get<CoaGroupedResponse>('/chart-of-accounts/grouped', {
+        params: filter,
+      });
+      return data;
+    },
+    staleTime: Infinity,
+  });
+}
+
+export function useCoaByCodes(codes: string[]) {
+  const sortedKey = [...codes].sort().join(',');
+  return useQuery<CoaByCodesRow[]>({
+    queryKey: ['coa', 'by-codes', sortedKey],
+    queryFn: async () => {
+      const { data } = await api.get<CoaByCodesRow[]>('/chart-of-accounts/by-codes', {
+        params: { codes: codes.join(',') },
+      });
+      return data;
+    },
+    staleTime: Infinity,
+    enabled: codes.length > 0,
+  });
+}

--- a/apps/web/src/pages/AssetManagementPage/components/AssetForm.tsx
+++ b/apps/web/src/pages/AssetManagementPage/components/AssetForm.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { Asset, Branch, categoryOptions, inputClass, fmt, AssetForm as AssetFormType } from '../types';
+import { useCoaGroups } from '@/hooks/useCoa';
 
 interface AssetFormProps {
   editingAsset: Asset | null;
@@ -32,6 +33,14 @@ export default function AssetForm({
   setField,
 }: AssetFormProps) {
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const { data: assetCoa } = useCoaGroups({ codePrefix: '12-21' });
+  const { data: depCoa } = useCoaGroups({ codePrefix: '53-16' });
+
+  const allAssets = assetCoa?.groups.flatMap((g) => g.accounts) ?? [];
+  const costAccounts = allAssets.filter((a) => a.normalBalance === 'Dr');
+  const accumAccounts = allAssets.filter((a) => a.normalBalance === 'Cr');
+  const depAccounts = depCoa?.groups.flatMap((g) => g.accounts) ?? [];
 
   return (
     <div className="fixed inset-0 z-50 bg-foreground/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8">
@@ -299,18 +308,11 @@ export default function AssetForm({
                     onChange={(e) => setField('assetAccountCode', e.target.value)}
                   >
                     <option value="">-- เลือก --</option>
-                    <optgroup label="อุปกรณ์สำนักงาน">
-                      <option value="12-2101">12-2101 อุปกรณ์สำนักงาน</option>
-                    </optgroup>
-                    <optgroup label="ส่วนปรับปรุงอาคาร">
-                      <option value="12-2103">12-2103 ส่วนปรับปรุงอาคาร</option>
-                    </optgroup>
-                    <optgroup label="เครื่องตกแต่ง">
-                      <option value="12-2105">12-2105 เครื่องตกแต่งสำนักงาน</option>
-                    </optgroup>
-                    <optgroup label="ยานพาหนะ">
-                      <option value="12-2107">12-2107 ยานพาหนะ</option>
-                    </optgroup>
+                    {costAccounts.map((a) => (
+                      <option key={a.code} value={a.code}>
+                        {a.code} {a.name}
+                      </option>
+                    ))}
                   </select>
                 </div>
                 <div>
@@ -323,10 +325,11 @@ export default function AssetForm({
                     onChange={(e) => setField('depreciationAccountCode', e.target.value)}
                   >
                     <option value="">-- เลือก --</option>
-                    <option value="53-1601">53-1601 ค่าเสื่อมราคา - อุปกรณ์สำนักงาน</option>
-                    <option value="53-1602">53-1602 ค่าเสื่อมราคา - ส่วนปรับปรุงอาคาร</option>
-                    <option value="53-1603">53-1603 ค่าเสื่อมราคา - เครื่องตกแต่ง</option>
-                    <option value="53-1604">53-1604 ค่าเสื่อมราคา - ยานพาหนะ</option>
+                    {depAccounts.map((a) => (
+                      <option key={a.code} value={a.code}>
+                        {a.code} {a.name}
+                      </option>
+                    ))}
                   </select>
                 </div>
                 <div>
@@ -339,9 +342,11 @@ export default function AssetForm({
                     onChange={(e) => setField('accumulatedDepreAccountCode', e.target.value)}
                   >
                     <option value="">-- เลือก --</option>
-                    <option value="12-2102">12-2102 ค่าเสื่อมสะสม - อุปกรณ์สำนักงาน</option>
-                    <option value="12-2104">12-2104 ค่าเสื่อมสะสม - ส่วนปรับปรุงอาคาร</option>
-                    <option value="12-2106">12-2106 ค่าเสื่อมสะสม - เครื่องตกแต่ง</option>
+                    {accumAccounts.map((a) => (
+                      <option key={a.code} value={a.code}>
+                        {a.code} {a.name}
+                      </option>
+                    ))}
                   </select>
                 </div>
               </div>

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import { useDebounce } from '@/hooks/useDebounce';
+import { useCoaGroups } from '@/hooks/useCoa';
 import PageHeader from '@/components/ui/PageHeader';
 import DataTable from '@/components/ui/DataTable';
 import QueryBoundary from '@/components/QueryBoundary';
@@ -39,24 +40,6 @@ interface Summary {
 }
 
 // ─── Constants ───
-const accountTypeLabels: Record<string, string> = {
-  COST_OF_SALES: '51 ต้นทุนขาย', SELLING_EXPENSE: '52 ค่าใช้จ่ายในการขาย',
-  ADMINISTRATIVE_EXPENSE: '53 ค่าใช้จ่ายในการบริหาร', OTHER_EXPENSE: '54 ค่าใช้จ่ายอื่น',
-};
-
-const categoryLabels: Record<string, string> = {
-  COGS_PRODUCT: 'ต้นทุนสินค้า', COGS_REPAIR_PARTS: 'อะไหล่/ซ่อม',
-  SELL_COMMISSION: 'ค่าคอมมิชชั่น', SELL_ADVERTISING: 'ค่าโฆษณา/การตลาด',
-  SELL_TRANSPORT: 'ค่าขนส่ง', SELL_PACKAGING: 'ค่าบรรจุภัณฑ์',
-  ADMIN_SALARY: 'เงินเดือน/ค่าจ้าง', ADMIN_SOCIAL_SECURITY: 'ประกันสังคม',
-  ADMIN_RENT: 'ค่าเช่าสถานที่', ADMIN_UTILITIES: 'ค่าน้ำ/ไฟ/เน็ต',
-  ADMIN_OFFICE_SUPPLIES: 'วัสดุสำนักงาน', ADMIN_DEPRECIATION: 'ค่าเสื่อมราคา',
-  ADMIN_INSURANCE: 'ค่าประกันภัย', ADMIN_TAX_FEE: 'ภาษี/ค่าธรรมเนียม',
-  ADMIN_MAINTENANCE: 'ค่าซ่อมบำรุง', ADMIN_TRAVEL: 'ค่าเดินทาง',
-  ADMIN_TELEPHONE: 'ค่าโทรศัพท์',
-  OTHER_INTEREST: 'ดอกเบี้ยจ่าย', OTHER_LOSS: 'ขาดทุนจำหน่ายสินทรัพย์',
-  OTHER_FINE: 'ค่าปรับ', OTHER_MISC: 'เบ็ดเตล็ด',
-};
 
 const statusLabels: Record<string, string> = {
   DRAFT: 'ร่าง', PENDING_APPROVAL: 'รออนุมัติ', APPROVED: 'อนุมัติแล้ว',
@@ -68,38 +51,6 @@ const paymentMethodLabels: Record<string, string> = {
   CASH: 'เงินสด', BANK_TRANSFER: 'โอนเงิน', QR_EWALLET: 'QR/e-Wallet',
 };
 
-const categoryGroups: Record<string, { value: string; label: string }[]> = {
-  COST_OF_SALES: [
-    { value: 'COGS_PRODUCT', label: '51-1101 ต้นทุนมือถือ (ใหม่)' },
-    { value: 'COGS_REPAIR_PARTS', label: '51-1102 ต้นทุนมือถือ (มือสอง)' },
-  ],
-  SELLING_EXPENSE: [
-    { value: 'SELL_COMMISSION', label: '52-1101 ค่าคอมมิชชั่น' },
-    { value: 'SELL_ADVERTISING', label: '52-1102 ค่าส่งเสริมการขาย' },
-    { value: 'SELL_TRANSPORT', label: '53-1304 ค่าขนส่ง' },
-    { value: 'SELL_PACKAGING', label: '52-1103 ค่าบริการส่ง SMS' },
-  ],
-  ADMINISTRATIVE_EXPENSE: [
-    { value: 'ADMIN_SALARY', label: '53-1101 เงินเดือน/ค่าจ้าง' },
-    { value: 'ADMIN_SOCIAL_SECURITY', label: '53-1103 ประกันสังคม/กองทุน' },
-    { value: 'ADMIN_RENT', label: '53-1301 ค่าเช่าสถานที่' },
-    { value: 'ADMIN_UTILITIES', label: '53-1302 ค่าน้ำ/ไฟฟ้า' },
-    { value: 'ADMIN_OFFICE_SUPPLIES', label: '53-1201 วัสดุสำนักงาน' },
-    { value: 'ADMIN_DEPRECIATION', label: '53-1601 ค่าเสื่อมราคา' },
-    { value: 'ADMIN_INSURANCE', label: '53-1103 ค่าประกันภัย' },
-    { value: 'ADMIN_TAX_FEE', label: '54-1103 ภาษี/ค่าธรรมเนียม' },
-    { value: 'ADMIN_MAINTENANCE', label: '53-1305 ค่าซ่อมบำรุง' },
-    { value: 'ADMIN_TRAVEL', label: '53-1304 ค่าเดินทาง/ขนส่ง' },
-    { value: 'ADMIN_TELEPHONE', label: '53-1303 ค่าโทรศัพท์' },
-  ],
-  OTHER_EXPENSE: [
-    { value: 'OTHER_INTEREST', label: '53-1501 ค่าธรรมเนียมธนาคาร' },
-    { value: 'OTHER_LOSS', label: '53-1503 ขาดทุนจากการปิดสัญญา' },
-    { value: 'OTHER_FINE', label: '54-1104 เบี้ยปรับเงินเพิ่ม' },
-    { value: 'OTHER_MISC', label: '53-1502 ค่าธรรมเนียมอื่น' },
-  ],
-};
-
 const inputClass = 'w-full px-3 py-2 border border-input rounded-lg focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
 
 function fmt(n: string | number | null | undefined): string {
@@ -108,7 +59,7 @@ function fmt(n: string | number | null | undefined): string {
 }
 
 const emptyForm = {
-  branchId: '', accountType: 'ADMINISTRATIVE_EXPENSE', category: 'ADMIN_UTILITIES',
+  branchId: '', category: '',
   description: '', amount: '', vatAmount: '0', withholdingTax: '0',
   expenseDate: new Date().toISOString().split('T')[0], paymentMethod: '',
   vendorName: '', vendorTaxId: '', reference: '', taxInvoiceNo: '', note: '',
@@ -126,10 +77,13 @@ function ExpenseFormPanel({ editingExpense, branches, onClose, onSaved }: {
   const [includeVat, setIncludeVat] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
 
+  const { data: coaData } = useCoaGroups({ type: 'ค่าใช้จ่าย' });
+  const groups = coaData?.groups ?? [];
+
   useEffect(() => {
     if (editingExpense) {
       setForm({
-        branchId: editingExpense.branch.id, accountType: editingExpense.accountType,
+        branchId: editingExpense.branch.id,
         category: editingExpense.category, description: editingExpense.description,
         amount: editingExpense.amount, vatAmount: editingExpense.vatAmount,
         withholdingTax: editingExpense.withholdingTax, expenseDate: editingExpense.expenseDate.slice(0, 10),
@@ -145,6 +99,13 @@ function ExpenseFormPanel({ editingExpense, branches, onClose, onSaved }: {
       setIncludeVat(false);
     }
   }, [editingExpense, branches]);
+
+  // Set initial category once CoA groups load (new form only)
+  useEffect(() => {
+    if (groups.length > 0 && !form.category && !editingExpense) {
+      setForm((f) => ({ ...f, category: groups[0].accounts[0]?.code ?? '' }));
+    }
+  }, [groups, form.category, editingExpense]);
 
   useEffect(() => {
     if (includeVat) {
@@ -189,7 +150,7 @@ function ExpenseFormPanel({ editingExpense, branches, onClose, onSaved }: {
     const withholdingTax = parseFloat(form.withholdingTax) || 0;
     saveMutation.mutate({
       data: {
-        branchId: form.branchId || branches[0]?.id, accountType: form.accountType,
+        branchId: form.branchId || branches[0]?.id,
         category: form.category, description: form.description, amount, vatAmount,
         withholdingTax, includeVat, expenseDate: form.expenseDate,
         paymentMethod: form.paymentMethod || undefined, vendorName: form.vendorName || undefined,
@@ -202,8 +163,6 @@ function ExpenseFormPanel({ editingExpense, branches, onClose, onSaved }: {
       andSubmit,
     });
   };
-
-  const availableCategories = categoryGroups[form.accountType] || [];
   const amt = parseFloat(form.amount || '0');
   const vat = parseFloat(form.vatAmount || '0');
   const wht = parseFloat(form.withholdingTax || '0');
@@ -289,19 +248,17 @@ function ExpenseFormPanel({ editingExpense, branches, onClose, onSaved }: {
               </div>
             </div>
             <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">หมวดบัญชี <span className="text-destructive">*</span></label>
-                  <select value={form.accountType} onChange={(e) => { const t = e.target.value; setForm({ ...form, accountType: t, category: categoryGroups[t]?.[0]?.value || '' }); }} className={inputClass}>
-                    {Object.entries(accountTypeLabels).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-xs font-medium text-foreground mb-1.5">หมวดย่อย <span className="text-destructive">*</span></label>
-                  <select value={form.category} onChange={(e) => setForm({ ...form, category: e.target.value })} className={inputClass}>
-                    {availableCategories.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
-                  </select>
-                </div>
+              <div>
+                <label className="block text-xs font-medium text-foreground mb-1.5">หมวดบัญชี <span className="text-destructive">*</span></label>
+                <select value={form.category} onChange={(e) => setForm({ ...form, category: e.target.value })} className={inputClass}>
+                  {groups.map((g) => (
+                    <optgroup key={g.category} label={g.category}>
+                      {g.accounts.map((a) => (
+                        <option key={a.code} value={a.code}>{a.code} {a.name}</option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </select>
               </div>
               <div>
                 <label className="block text-xs font-medium text-foreground mb-1.5">รายละเอียด <span className="text-destructive">*</span></label>
@@ -467,7 +424,6 @@ export default function ExpensesPage() {
   const isOwner = currentUser?.role === 'OWNER';
   const [searchParams, setSearchParams] = useSearchParams();
   const statusFilter = searchParams.get('status') || '';
-  const accountTypeFilter = searchParams.get('accountType') || '';
   const categoryFilter = searchParams.get('category') || '';
   const branchFilter = searchParams.get('branch') || '';
   const startDate = searchParams.get('startDate') || '';
@@ -499,6 +455,14 @@ export default function ExpensesPage() {
 
   const { data: branches = [] } = useQuery<{ id: string; name: string }[]>({ queryKey: ['branches'], queryFn: async () => (await api.get('/branches')).data });
 
+  const { data: coaData } = useCoaGroups({ type: 'ค่าใช้จ่าย' });
+  const coaGroups = coaData?.groups ?? [];
+  const codeToName = useMemo(() => {
+    const m = new Map<string, string>();
+    coaGroups.forEach((g) => g.accounts.forEach((a) => m.set(a.code, a.name)));
+    return m;
+  }, [coaGroups]);
+
   const { data: summary } = useQuery<Summary>({
     queryKey: ['expenses-summary', branchFilter, startDate, endDate],
     queryFn: async () => { const p = new URLSearchParams(); if (branchFilter) p.set('branchId', branchFilter); if (startDate) p.set('startDate', startDate); if (endDate) p.set('endDate', endDate); return (await api.get(`/expenses/summary?${p}`)).data; },
@@ -511,11 +475,10 @@ export default function ExpensesPage() {
     error,
     refetch,
   } = useQuery<{ data: Expense[]; total: number }>({
-    queryKey: ['expenses', statusFilter, accountTypeFilter, categoryFilter, branchFilter, startDate, endDate, debouncedSearch, page],
+    queryKey: ['expenses', statusFilter, categoryFilter, branchFilter, startDate, endDate, debouncedSearch, page],
     queryFn: async () => {
       const p = new URLSearchParams({ limit: '20', page: String(page) });
       if (statusFilter) p.set('status', statusFilter);
-      if (accountTypeFilter) p.set('accountType', accountTypeFilter);
       if (categoryFilter) p.set('category', categoryFilter);
       if (branchFilter) p.set('branchId', branchFilter);
       if (startDate) p.set('startDate', startDate);
@@ -561,7 +524,7 @@ export default function ExpensesPage() {
     },
     {
       key: 'description', label: 'รายละเอียด',
-      render: (e: Expense) => (<div className="min-w-0"><div className="font-medium truncate">{e.description}</div><div className="text-xs text-muted-foreground">{categoryLabels[e.category] || e.category}</div></div>),
+      render: (e: Expense) => (<div className="min-w-0"><div className="font-medium truncate">{e.description}</div><div className="text-xs text-muted-foreground">{codeToName.get(e.category) || e.category}</div></div>),
     },
     { key: 'branch', label: 'สาขา', render: (e: Expense) => e.branch.name },
     { key: 'vendorName', label: 'ผู้รับเงิน', render: (e: Expense) => e.vendorName || '-' },
@@ -658,17 +621,14 @@ export default function ExpensesPage() {
         </div>
         <div>
           <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">หมวดบัญชี</label>
-          <select value={accountTypeFilter} onChange={(e) => { setFilter('accountType', e.target.value); setFilter('category', ''); }} className={`${inputClass} w-auto min-w-[160px]`}>
-            <option value="">ทั้งหมด</option>
-            {Object.entries(accountTypeLabels).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
-          </select>
-        </div>
-        <div>
-          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">หมวดย่อย</label>
           <select value={categoryFilter} onChange={(e) => setFilter('category', e.target.value)} className={`${inputClass} w-auto min-w-[180px]`}>
             <option value="">ทั้งหมด</option>
-            {Object.entries(categoryGroups).filter(([key]) => !accountTypeFilter || key === accountTypeFilter).map(([groupKey, cats]) => (
-              <optgroup key={groupKey} label={accountTypeLabels[groupKey]}>{cats.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}</optgroup>
+            {coaGroups.map((g) => (
+              <optgroup key={g.category} label={g.category}>
+                {g.accounts.map((a) => (
+                  <option key={a.code} value={a.code}>{a.code} {a.name}</option>
+                ))}
+              </optgroup>
             ))}
           </select>
         </div>

--- a/docs/superpowers/plans/2026-05-06-coa-dynamic-architecture.md
+++ b/docs/superpowers/plans/2026-05-06-coa-dynamic-architecture.md
@@ -1,0 +1,699 @@
+# Phase A.6 Dynamic CoA Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ~20 drift-prone hardcoded XX-XXXX account codes in UI + backend with dynamic CoA-driven lookups so future CSV updates require zero code change.
+
+**Architecture:** New `GET /accounting/coa-grouped` endpoint returns accounts grouped by `category` field (already populated from CSV in Phase A.4). Frontend hooks `useCoaGroups` + `useCoaByCodes` cache responses (`staleTime: Infinity`). `CATEGORY_CODE_MAP` in accounting.service gets boot validator that throws if any mapped code missing from CoA.
+
+**Tech Stack:** NestJS + Prisma + React Query + shadcn/ui
+
+**Spec:** [docs/superpowers/specs/2026-05-06-coa-dynamic-architecture-design.md](../specs/2026-05-06-coa-dynamic-architecture-design.md)
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|------|----------------|--------|
+| `apps/api/src/modules/chart-of-accounts/dto/coa-grouped.dto.ts` | Query DTO + response shape | Create |
+| `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts` | Add `findGrouped()` method | Modify |
+| `apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts` | Add `GET /chart-of-accounts/grouped` | Modify |
+| `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts` | Test `findGrouped()` | Create |
+| `apps/api/src/modules/accounting/accounting.service.ts` | Fix `CATEGORY_CODE_MAP` + add `onModuleInit` validator | Modify |
+| `apps/api/src/modules/accounting/accounting.service.spec.ts` | Test boot validator behavior | Modify |
+| `apps/web/src/hooks/useCoa.ts` | `useCoaGroups` + `useCoaByCodes` hooks | Create |
+| `apps/web/src/pages/ExpensesPage.tsx` | Replace hardcoded `categoryGroups` with hook | Modify |
+| `apps/web/src/pages/AssetManagementPage/components/AssetForm.tsx` | Replace 4 hardcoded `<option>` blocks | Modify |
+| `apps/web/src/pages/IntercompanySettlementPage.tsx` | Optional: replace `'11-1101'` filter | Modify (optional) |
+
+---
+
+## Dependency Graph
+
+```
+T1 endpoint (api)
+    ↓
+T2 hook (web) ─────────────────┐
+    ↓                          ↓
+T3 ExpensesPage refactor   T4 AssetForm refactor
+                               ↓
+T5 fix CATEGORY_CODE_MAP + boot validator (api accounting service)
+    ↓
+T6 verification + commit + PR
+```
+
+T1 must complete before T2. T3 + T4 parallel after T2. T5 independent. T6 last.
+
+---
+
+## Task 1: Backend — `GET /chart-of-accounts/grouped` endpoint
+
+**Files:**
+- Create: `apps/api/src/modules/chart-of-accounts/dto/coa-grouped.dto.ts`
+- Modify: `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts`
+- Modify: `apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts`
+- Modify: `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts`
+
+- [ ] **Step 1.1: Write DTO**
+
+Create `apps/api/src/modules/chart-of-accounts/dto/coa-grouped.dto.ts`:
+
+```typescript
+import { IsOptional, IsString, Matches } from 'class-validator';
+
+export class CoaGroupedQueryDto {
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{2}(-\d{0,4})?$/, { message: 'codePrefix must match XX or XX-XXXX' })
+  codePrefix?: string;
+
+  @IsOptional()
+  @IsString()
+  category?: string;
+}
+
+export interface CoaAccountRow {
+  code: string;
+  name: string;
+  normalBalance: string;
+  vatApplicable: boolean;
+  notes: string | null;
+}
+
+export interface CoaGroup {
+  category: string;
+  accounts: CoaAccountRow[];
+}
+
+export interface CoaGroupedResponse {
+  groups: CoaGroup[];
+}
+```
+
+- [ ] **Step 1.2: Write service test (TDD)**
+
+In `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts` (create if missing — note: per memory T3 deleted earlier spec; rebuild minimal version):
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChartOfAccountsService } from './chart-of-accounts.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('ChartOfAccountsService.findGrouped', () => {
+  let service: ChartOfAccountsService;
+  let prisma: { chartOfAccount: { findMany: jest.Mock } };
+
+  beforeEach(async () => {
+    prisma = { chartOfAccount: { findMany: jest.fn() } };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChartOfAccountsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = module.get<ChartOfAccountsService>(ChartOfAccountsService);
+  });
+
+  it('groups accounts by category, sorted by code', async () => {
+    prisma.chartOfAccount.findMany.mockResolvedValue([
+      { code: '53-1101', name: 'เงินเดือน', type: 'ค่าใช้จ่าย', normalBalance: 'Dr', category: 'OpEx-บุคลากร', vatApplicable: false, notes: null },
+      { code: '53-1102', name: 'ประกันสังคม', type: 'ค่าใช้จ่าย', normalBalance: 'Dr', category: 'OpEx-บุคลากร', vatApplicable: false, notes: null },
+      { code: '53-1201', name: 'วัสดุสำนักงาน', type: 'ค่าใช้จ่าย', normalBalance: 'Dr', category: 'OpEx-วัสดุ', vatApplicable: false, notes: null },
+    ]);
+
+    const result = await service.findGrouped({ type: 'ค่าใช้จ่าย' });
+
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups[0].category).toBe('OpEx-บุคลากร');
+    expect(result.groups[0].accounts).toHaveLength(2);
+    expect(result.groups[0].accounts[0].code).toBe('53-1101');
+    expect(result.groups[1].category).toBe('OpEx-วัสดุ');
+  });
+
+  it('filters by codePrefix', async () => {
+    prisma.chartOfAccount.findMany.mockResolvedValue([
+      { code: '12-2101', name: 'อุปกรณ์สำนักงาน', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'สินทรัพย์ถาวร', vatApplicable: false, notes: null },
+    ]);
+
+    await service.findGrouped({ codePrefix: '12-21' });
+
+    expect(prisma.chartOfAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ code: { startsWith: '12-21' } }),
+      }),
+    );
+  });
+
+  it('groups uncategorized accounts under "อื่นๆ"', async () => {
+    prisma.chartOfAccount.findMany.mockResolvedValue([
+      { code: '99-9999', name: 'test', type: 'ค่าใช้จ่าย', normalBalance: 'Dr', category: null, vatApplicable: false, notes: null },
+    ]);
+
+    const result = await service.findGrouped({});
+
+    expect(result.groups[0].category).toBe('อื่นๆ');
+  });
+});
+```
+
+- [ ] **Step 1.3: Run test, expect failure**
+
+```bash
+cd apps/api && npx jest src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts
+```
+
+Expected: FAIL — `findGrouped is not a function`
+
+- [ ] **Step 1.4: Implement service method**
+
+In `apps/api/src/modules/chart-of-accounts/chart-of-accounts.service.ts`, add:
+
+```typescript
+async findGrouped(query: { type?: string; codePrefix?: string; category?: string }): Promise<CoaGroupedResponse> {
+  const where: Prisma.ChartOfAccountWhereInput = { deletedAt: null, status: 'ใช้งาน' };
+  if (query.type) where.type = query.type;
+  if (query.codePrefix) where.code = { startsWith: query.codePrefix };
+  if (query.category) where.category = query.category;
+
+  const rows = await this.prisma.chartOfAccount.findMany({
+    where,
+    orderBy: { code: 'asc' },
+    select: {
+      code: true,
+      name: true,
+      normalBalance: true,
+      category: true,
+      vatApplicable: true,
+      notes: true,
+    },
+  });
+
+  const map = new Map<string, CoaAccountRow[]>();
+  for (const r of rows) {
+    const cat = r.category ?? 'อื่นๆ';
+    const arr = map.get(cat) ?? [];
+    arr.push({
+      code: r.code,
+      name: r.name,
+      normalBalance: r.normalBalance,
+      vatApplicable: r.vatApplicable,
+      notes: r.notes,
+    });
+    map.set(cat, arr);
+  }
+  return { groups: Array.from(map, ([category, accounts]) => ({ category, accounts })) };
+}
+```
+
+Add imports at top:
+```typescript
+import { CoaAccountRow, CoaGroupedResponse } from './dto/coa-grouped.dto';
+```
+
+- [ ] **Step 1.5: Run test, expect pass**
+
+```bash
+cd apps/api && npx jest src/modules/chart-of-accounts/chart-of-accounts.service.spec.ts
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 1.6: Add controller endpoint**
+
+In `apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts`, add after `by-codes` endpoint:
+
+```typescript
+@Get('grouped')
+@Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+async grouped(@Query() query: CoaGroupedQueryDto): Promise<CoaGroupedResponse> {
+  return this.service.findGrouped(query);
+}
+```
+
+Add imports:
+```typescript
+import { CoaGroupedQueryDto, CoaGroupedResponse } from './dto/coa-grouped.dto';
+```
+
+- [ ] **Step 1.7: TSC + commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+git add apps/api/src/modules/chart-of-accounts/
+git commit -m "feat(coa): add GET /chart-of-accounts/grouped endpoint
+
+Returns accounts grouped by category for dynamic UI dropdowns.
+Filters: type, codePrefix, category."
+```
+
+---
+
+## Task 2: Frontend — `useCoa` hooks
+
+**Files:**
+- Create: `apps/web/src/hooks/useCoa.ts`
+
+- [ ] **Step 2.1: Write hooks**
+
+Create `apps/web/src/hooks/useCoa.ts`:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface CoaAccountRow {
+  code: string;
+  name: string;
+  normalBalance: string;
+  vatApplicable: boolean;
+  notes: string | null;
+}
+
+export interface CoaGroup {
+  category: string;
+  accounts: CoaAccountRow[];
+}
+
+export interface CoaGroupedResponse {
+  groups: CoaGroup[];
+}
+
+export interface CoaByCodesRow {
+  code: string;
+  name: string;
+}
+
+export interface CoaGroupedFilter {
+  type?: string;
+  codePrefix?: string;
+  category?: string;
+}
+
+export function useCoaGroups(filter: CoaGroupedFilter) {
+  return useQuery<CoaGroupedResponse>({
+    queryKey: ['coa', 'grouped', filter],
+    queryFn: async () => {
+      const { data } = await api.get<CoaGroupedResponse>('/chart-of-accounts/grouped', { params: filter });
+      return data;
+    },
+    staleTime: Infinity,
+  });
+}
+
+export function useCoaByCodes(codes: string[]) {
+  const sortedKey = [...codes].sort().join(',');
+  return useQuery<CoaByCodesRow[]>({
+    queryKey: ['coa', 'by-codes', sortedKey],
+    queryFn: async () => {
+      const { data } = await api.get<CoaByCodesRow[]>('/chart-of-accounts/by-codes', {
+        params: { codes: codes.join(',') },
+      });
+      return data;
+    },
+    staleTime: Infinity,
+    enabled: codes.length > 0,
+  });
+}
+```
+
+- [ ] **Step 2.2: TSC check + commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+git add apps/web/src/hooks/useCoa.ts
+git commit -m "feat(web): add useCoaGroups + useCoaByCodes hooks
+
+Wraps GET /chart-of-accounts/grouped + /by-codes with React Query
+(staleTime Infinity since CoA only changes on seed)."
+```
+
+---
+
+## Task 3: Refactor ExpensesPage to use `useCoaGroups`
+
+**Files:**
+- Modify: `apps/web/src/pages/ExpensesPage.tsx`
+
+- [ ] **Step 3.1: Read existing structure**
+
+Open `apps/web/src/pages/ExpensesPage.tsx` and identify:
+- Lines 47-59: `categoryLabels` const (used for table display)
+- Lines 71-101: `categoryGroups` const (used for dropdowns)
+- Line 110-111: `emptyForm` defaults — references `accountType: 'ADMINISTRATIVE_EXPENSE'`, `category: 'ADMIN_UTILITIES'`
+- Line 206: `availableCategories = categoryGroups[form.accountType]`
+- Lines 294-302: dropdowns rendering categoryGroups + availableCategories
+- Lines 660-668: filter controls
+
+- [ ] **Step 3.2: Replace hardcoded constants with hook usage**
+
+Remove `categoryLabels` and `categoryGroups` constants. Replace with:
+
+```typescript
+import { useCoaGroups, type CoaAccountRow } from '@/hooks/useCoa';
+
+// Inside component:
+const { data: coaData } = useCoaGroups({ type: 'ค่าใช้จ่าย' });
+const groups = coaData?.groups ?? [];
+
+// Build flat lookup: code → name (for table display)
+const codeToName = new Map<string, string>();
+groups.forEach(g => g.accounts.forEach(a => codeToName.set(a.code, a.name)));
+
+// Replace categoryLabels[e.category] usage with codeToName.get(e.category)
+```
+
+Form simplification — remove `accountType` field; user picks one expense category directly:
+
+```typescript
+// emptyForm — drop accountType, default category to first available
+const emptyForm = {
+  branchId: '',
+  category: '',  // will be set when groups load
+  description: '',
+  ...
+};
+
+// Effect: when groups load, set initial category
+useEffect(() => {
+  if (groups.length > 0 && !form.category) {
+    setForm(f => ({ ...f, category: groups[0].accounts[0]?.code ?? '' }));
+  }
+}, [groups, form.category]);
+```
+
+The `category` field now stores the actual CoA code (e.g., `'53-1101'`) instead of enum (`'ADMIN_SALARY'`). The backend's `Expense.category` field stays a string column accepting both enum strings and CoA codes — see Task 5 migration for backwards compat.
+
+Render dropdown grouped by category:
+
+```tsx
+<select value={form.category} onChange={e => setForm({ ...form, category: e.target.value })} className={inputClass}>
+  {groups.map(g => (
+    <optgroup key={g.category} label={g.category}>
+      {g.accounts.map(a => (
+        <option key={a.code} value={a.code}>{a.code} {a.name}</option>
+      ))}
+    </optgroup>
+  ))}
+</select>
+```
+
+Filter dropdown — same `<optgroup>` pattern, plus "ทั้งหมด" empty option.
+
+- [ ] **Step 3.3: Update API payload**
+
+In the create/update mutation, send `category` (now CoA code string) directly. Drop `accountType` from payload.
+
+The backend `expenses.service.ts` already accepts `category` as string. Just verify it doesn't validate against the old enum. If it does, relax that check in Task 5.
+
+- [ ] **Step 3.4: Verify locally**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add apps/web/src/pages/ExpensesPage.tsx
+git commit -m "refactor(expenses): use useCoaGroups for dynamic categories
+
+Removes hardcoded categoryGroups + categoryLabels (drift-prone, had wrong
+codes per Phase A.4 audit). Dropdown now loads from CoA via API. Single
+category dropdown grouped by CoA category column.
+
+Existing Expense.category enum values stored in DB still display via
+codeToName fallback."
+```
+
+---
+
+## Task 4: Refactor AssetForm to use `useCoaGroups`
+
+**Files:**
+- Modify: `apps/web/src/pages/AssetManagementPage/components/AssetForm.tsx`
+
+- [ ] **Step 4.1: Identify hardcoded blocks**
+
+Lines 303-312, 326-329, 342-344 contain 4 dropdowns with hardcoded `<option>` for:
+- Asset cost accounts (12-2101/03/05/07)
+- Depreciation expense (53-1601..04)
+- Accumulated depreciation (12-2102/04/06/08)
+
+- [ ] **Step 4.2: Add hook usage**
+
+At top of component:
+
+```typescript
+import { useCoaGroups } from '@/hooks/useCoa';
+
+// Inside component:
+const { data: assetCoa } = useCoaGroups({ codePrefix: '12-21' });
+const { data: depCoa } = useCoaGroups({ codePrefix: '53-16' });
+
+// Split asset accounts into cost (Dr-normal) vs accumulated (Cr-normal)
+const allAssets = assetCoa?.groups.flatMap(g => g.accounts) ?? [];
+const costAccounts = allAssets.filter(a => a.normalBalance === 'Dr');
+const accumAccounts = allAssets.filter(a => a.normalBalance === 'Cr');
+const depAccounts = depCoa?.groups.flatMap(g => g.accounts) ?? [];
+```
+
+- [ ] **Step 4.3: Replace dropdowns**
+
+Replace each hardcoded `<select>` with:
+
+```tsx
+{/* Asset cost dropdown */}
+<select value={form.assetAccountCode} onChange={...}>
+  <option value="">เลือก...</option>
+  {costAccounts.map(a => (
+    <option key={a.code} value={a.code}>{a.code} {a.name}</option>
+  ))}
+</select>
+
+{/* Depreciation expense dropdown */}
+<select value={form.depreciationAccountCode} onChange={...}>
+  <option value="">เลือก...</option>
+  {depAccounts.map(a => (
+    <option key={a.code} value={a.code}>{a.code} {a.name}</option>
+  ))}
+</select>
+
+{/* Accumulated depreciation dropdown */}
+<select value={form.accumulatedAccountCode} onChange={...}>
+  <option value="">เลือก...</option>
+  {accumAccounts.map(a => (
+    <option key={a.code} value={a.code}>{a.code} {a.name}</option>
+  ))}
+</select>
+```
+
+- [ ] **Step 4.4: TSC + commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+git add apps/web/src/pages/AssetManagementPage/components/AssetForm.tsx
+git commit -m "refactor(assets): AssetForm dropdowns from useCoaGroups
+
+Replaces 4 hardcoded <option> blocks (12-2101..07, 53-1601..04, 12-2102..08)
+with dynamic CoA lookup. New CSV codes auto-appear; renamed accounts auto-update."
+```
+
+---
+
+## Task 5: Fix CATEGORY_CODE_MAP + boot validator
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/accounting.service.ts`
+- Modify: `apps/api/src/modules/accounting/accounting.service.spec.ts`
+
+- [ ] **Step 5.1: Update map per audit findings**
+
+Open `apps/api/src/modules/accounting/accounting.service.ts:46-79`. Current map has correct comments — convert TODOs to actual fixes:
+
+```typescript
+// Current top of file uses Record<string, string>. Change comments to reflect Phase A.6 audit.
+const CATEGORY_CODE_MAP: Record<string, string> = {
+  // FINANCE chart only (SHOP-side defer to A.5b/A.7)
+  // COGS_PRODUCT — deprecated; FINANCE has no COGS. UI hides this category.
+  // COGS_REPAIR_PARTS — same as COGS_PRODUCT.
+  SELL_COMMISSION: '52-1101',     // ค่าคอมฯ พนักงาน
+  SELL_ADVERTISING: '52-1102',    // ค่าส่งเสริมการขาย
+  SELL_TRANSPORT: '53-1304',      // ค่าไปรษณีย์ และขนส่ง
+  SELL_PACKAGING: '52-1102',      // nearest match (CSV lacks dedicated packaging)
+  ADMIN_SALARY: '53-1101',        // เงินเดือน ค่าจ้าง
+  ADMIN_SOCIAL_SECURITY: '53-1102', // เงินสมทบประกันสังคม (corrected from 53-1103 ค่าล่วงเวลา)
+  ADMIN_RENT: '53-1502',          // ค่าธรรมเนียมราชการ — TEMP placeholder; CSV needs dedicated rent (defer A.7)
+  ADMIN_UTILITIES: '53-1302',     // ค่าไฟฟ้า
+  ADMIN_OFFICE_SUPPLIES: '53-1201', // ค่าเครื่องเขียน วัสดุสำนักงาน
+  ADMIN_DEPRECIATION: '53-1601',  // ค่าเสื่อมราคา-อุปกรณ์ (now exists in 105-CSV; was REMOVED before update)
+  ADMIN_INSURANCE: '53-1502',     // ค่าธรรมเนียมราชการ — TEMP; CSV needs dedicated insurance
+  ADMIN_TAX_FEE: '54-1103',       // เบี้ยปรับ-ภ.พ.30 (รายจ่ายต้องห้าม)
+  ADMIN_MAINTENANCE: '53-1305',   // ค่าซ่อมแซมฯ
+  ADMIN_TRAVEL: '53-1304',        // ค่าไปรษณีย์ และขนส่ง
+  ADMIN_TELEPHONE: '53-1303',     // ค่าโทรศัพท์สำนักงาน
+  OTHER_INTEREST: '53-1501',      // ค่าธรรมเนียมธนาคาร
+  OTHER_LOSS: '53-1503',          // กำไร(ขาดทุน) สุทธิจากการปัดเศษ
+  OTHER_FINE: '54-1104',          // เบี้ยปรับเงินเพิ่ม (อื่นๆ)
+  OTHER_MISC: '53-1502',          // ค่าธรรมเนียมราชการ
+};
+```
+
+- [ ] **Step 5.2: Implement boot validator**
+
+In `AccountingService` class, add `OnModuleInit`:
+
+```typescript
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+
+@Injectable()
+export class AccountingService implements OnModuleInit {
+  private readonly logger = new Logger(AccountingService.name);
+  // ... existing code ...
+
+  async onModuleInit() {
+    const codes = [...new Set(Object.values(CATEGORY_CODE_MAP))];
+    const found = await this.prisma.chartOfAccount.findMany({
+      where: { code: { in: codes }, deletedAt: null },
+      select: { code: true },
+    });
+    const foundSet = new Set(found.map(f => f.code));
+    const missing = codes.filter(c => !foundSet.has(c));
+    if (missing.length > 0) {
+      const msg = `[Phase A.6] CATEGORY_CODE_MAP references missing CoA codes: ${missing.join(', ')}. Update CATEGORY_CODE_MAP or seed missing codes.`;
+      this.logger.error(msg);
+      throw new Error(msg);
+    }
+    this.logger.log(`CATEGORY_CODE_MAP validated: all ${codes.length} codes exist in CoA.`);
+  }
+}
+```
+
+- [ ] **Step 5.3: Spec test for validator**
+
+In `apps/api/src/modules/accounting/accounting.service.spec.ts`, add test (use the existing test setup pattern):
+
+```typescript
+describe('CATEGORY_CODE_MAP boot validator', () => {
+  it('throws when any mapped code missing from CoA', async () => {
+    prisma.chartOfAccount.findMany = jest.fn().mockResolvedValue([
+      { code: '52-1101' }, // only 1 of N
+    ]);
+    await expect(service.onModuleInit()).rejects.toThrow(/missing CoA codes/);
+  });
+
+  it('passes when all mapped codes exist', async () => {
+    // mock find to return all codes from CATEGORY_CODE_MAP
+    prisma.chartOfAccount.findMany = jest.fn().mockImplementation(({ where }: any) => {
+      const requested = where.code.in as string[];
+      return Promise.resolve(requested.map(code => ({ code })));
+    });
+    await expect(service.onModuleInit()).resolves.not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 5.4: Run tests + TSC + commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+cd apps/api && npx jest src/modules/accounting/accounting.service.spec.ts -t "CATEGORY_CODE_MAP"
+```
+
+Expected: 2 new tests pass + existing tests still pass.
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE
+git add apps/api/src/modules/accounting/accounting.service.ts apps/api/src/modules/accounting/accounting.service.spec.ts
+git commit -m "fix(accounting): CATEGORY_CODE_MAP corrected + boot validator
+
+Fixes mapping drift caught in Phase A.6 audit:
+- ADMIN_SOCIAL_SECURITY: 53-1103 (ค่าล่วงเวลา) → 53-1102 (ประกันสังคม)
+- ADMIN_DEPRECIATION: re-added → 53-1601 (now exists in 105-CSV)
+- ADMIN_RENT, ADMIN_INSURANCE: temp placeholder 53-1502 (CSV lacks dedicated)
+
+Adds onModuleInit validator that throws if any mapped code missing from
+seeded CoA — fails fast at boot instead of NotFoundException at runtime."
+```
+
+---
+
+## Task 6: Verify + push + PR
+
+- [ ] **Step 6.1: Run all relevant tests**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE
+./tools/check-types.sh all
+cd apps/api && npx jest src/modules/chart-of-accounts src/modules/accounting
+cd apps/web && npm run build
+```
+
+Expected: TSC clean, all jest specs pass, web build succeeds.
+
+- [ ] **Step 6.2: Push + PR**
+
+```bash
+git push -u origin <feature-branch>
+gh pr create --title "feat(accounting): Phase A.6 dynamic CoA architecture" --body "$(cat <<'EOF'
+Eliminates ~20 drift-prone hardcoded XX-XXXX codes per Phase A.6 audit.
+
+## Changes
+- API: GET /chart-of-accounts/grouped (filter by type/codePrefix/category)
+- Web: useCoaGroups + useCoaByCodes hooks (staleTime Infinity)
+- ExpensesPage: removes 70 lines of hardcoded categoryGroups
+- AssetForm: removes 4 hardcoded option blocks
+- accounting.service: CATEGORY_CODE_MAP corrections + onModuleInit validator (fails fast on drift)
+
+## Effect
+CSV updates now reflect immediately in UI dropdowns after seed:coa job.
+Boot fails fast if a mapped code goes missing from chart.
+
+## Spec
+docs/superpowers/specs/2026-05-06-coa-dynamic-architecture-design.md
+
+## Test plan
+- [ ] Existing Expense rows still display category labels (codeToName fallback)
+- [ ] New expenses use CoA code as category value
+- [ ] Asset form loads correct dropdowns after image deploy
+EOF
+)" --base main
+```
+
+Don't auto-merge — owner reviews.
+
+---
+
+## Self-Review
+
+### Spec coverage check
+- [x] §4.1 New endpoint → Task 1
+- [x] §4.2 Existing by-codes endpoint → reused
+- [x] §4.3 Frontend hooks → Task 2
+- [x] §4.4 ExpensesPage refactor → Task 3
+- [x] §4.5 AssetForm refactor → Task 4
+- [x] §4.6 IntercompanySettlementPage → noted optional, not in critical path
+- [x] §4.7 Backend CATEGORY_CODE_MAP fix + validator → Task 5
+- [x] §5 Migration steps → covered T1-T6
+- [x] §6 Backwards compat → handled in Task 3 step 3.2 (codeToName fallback)
+- [x] §8 Acceptance Criteria → met if T1-T6 pass
+
+### Spec §9 Open Questions resolution
+1. **ADMIN_INSURANCE / ADMIN_RENT** — temp placeholder `53-1502` (defer A.7 dedicated CSV row)
+2. **COGS_PRODUCT/REPAIR_PARTS** — keep DEPRECATED (commented out); UI hides
+3. **ExpenseCategory enum** — keep enum on existing rows; new rows store CoA code (string column accepts both)
+
+### Placeholder scan
+- No "TBD" or "implement later" in tasks
+- All code blocks are concrete and complete
+- File paths exact
+
+### Type consistency
+- `CoaAccountRow`, `CoaGroup`, `CoaGroupedResponse` defined consistently in DTO + hook
+- `findGrouped` signature matches in service + spec + controller

--- a/docs/superpowers/specs/2026-05-06-coa-dynamic-architecture-design.md
+++ b/docs/superpowers/specs/2026-05-06-coa-dynamic-architecture-design.md
@@ -1,0 +1,217 @@
+# Dynamic Chart-of-Accounts Architecture
+
+**Date:** 2026-05-06
+**Author:** owner + Claude
+**Status:** Design (approved)
+**Phase:** A.6 (post Phase A.4-A.5c)
+
+## 1. Goal
+
+Eliminate drift between hardcoded account codes/category mappings and the canonical CSV. After this work, updating `finance-coa.csv` requires zero code changes — UI dropdowns, backend mappings, and category groupings sync automatically from the seeded `ChartOfAccount` table.
+
+## 2. Problem
+
+Audit (2026-05-06) found ~100 hardcoded XX-XXXX references in api+web, of which:
+- **~20 are DRIFT** — wrong codes (e.g., `ADMIN_RENT: '53-1301'` actually = ค่าน้ำ in CSV; `ADMIN_INSURANCE: '53-1103'` = ค่าล่วงเวลา)
+- **~10 are stale UI dropdowns** in ExpensesPage + AssetForm + IntercompanySettlementPage that hardcoded subset of codes from old chart
+- **~70 are intentional** template/JE references aligned with CSV (Phase A.4 design)
+
+Each CSV update (99→105 just happened, more coming for SHOP/PEAK) requires manual sync of ~30 hardcoded sites. Drift inevitable.
+
+## 3. Architecture
+
+```
+CSV (finance-coa.csv)         ←── single source of truth
+        │
+        │ npm run seed:coa  (idempotent upsert)
+        ▼
+ChartOfAccount table (105 rows, category column populated)
+        │
+        │ GET /accounting/coa-grouped?type=ค่าใช้จ่าย
+        │ GET /accounting/coa-by-codes?codes=12-2101,12-2103
+        ▼
+┌────────────────────────────────────────────────────────────┐
+│ React Query (staleTime: Infinity, cache key by query)      │
+└────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌──────────────┬───────────────┬──────────────┬─────────────┐
+│ ExpensesPage │   AssetForm   │ CashAccount  │ Intercompany│
+│              │               │  (existing)  │ Settlement  │
+└──────────────┴───────────────┴──────────────┴─────────────┘
+```
+
+## 4. Components
+
+### 4.1 New API endpoint — `GET /accounting/coa-grouped`
+
+**Location:** extend `apps/api/src/modules/chart-of-accounts/chart-of-accounts.controller.ts`
+
+**Query params:**
+- `type` — filter by `ChartOfAccount.type` (e.g., `ค่าใช้จ่าย`, `สินทรัพย์`, `หนี้สิน`, `รายได้`, `ทุน`)
+- `codePrefix` (optional) — filter by code prefix `12-21` (matches `12-21XX`)
+- `category` (optional) — filter by `ChartOfAccount.category` (e.g., `เงินสด`, `OpEx-บุคลากร`)
+
+**Response shape:**
+```typescript
+{
+  groups: Array<{
+    category: string;          // CSV "หมวดหมู่" column
+    accounts: Array<{
+      code: string;            // "53-1101"
+      name: string;            // "เงินเดือน ค่าจ้าง"
+      normalBalance: 'Dr' | 'Cr' | 'Dr/Cr';
+      vatApplicable: boolean;
+      notes: string | null;
+    }>;
+  }>;
+}
+```
+
+Auth: `JwtAuthGuard, RolesGuard`. Roles: all logged-in users (read-only data).
+
+### 4.2 Existing endpoint reuse — `GET /accounting/coa-by-codes`
+
+Already exists from Phase A.4. Used by callers that need a specific known set (e.g., `CashAccountSelect` 6 codes, IntercompanySettlement 2 codes).
+
+### 4.3 Frontend — `useCoaGroups` hook
+
+**Location:** `apps/web/src/hooks/useCoa.ts` (new file)
+
+```typescript
+export function useCoaGroups(filter: { type?: string; codePrefix?: string; category?: string }) {
+  return useQuery({
+    queryKey: ['coa-grouped', filter],
+    queryFn: () => api.get<CoaGroupedResponse>('/accounting/coa-grouped', { params: filter }).then(r => r.data),
+    staleTime: Infinity, // CoA changes only on seed
+  });
+}
+
+export function useCoaByCodes(codes: string[]) {
+  return useQuery({
+    queryKey: ['coa-by-codes', codes.sort().join(',')],
+    queryFn: () => api.get<CoaRow[]>('/accounting/coa-by-codes', { params: { codes: codes.join(',') } }).then(r => r.data),
+    staleTime: Infinity,
+    enabled: codes.length > 0,
+  });
+}
+```
+
+### 4.4 ExpensesPage refactor
+
+Replace hardcoded `categoryGroups` + `categoryLabels`:
+
+```typescript
+// BEFORE: 70+ lines of hardcoded categoryGroups + categoryLabels
+
+// AFTER:
+const { data: coa } = useCoaGroups({ type: 'ค่าใช้จ่าย' });
+// renders dropdown groups directly from coa.groups
+// label = `${account.code} ${account.name}`
+```
+
+Removes `accountType` field — type is implicit (always `ค่าใช้จ่าย`). Single dropdown grouped by category.
+
+`categoryLabels` lookup still needed for filter chips/table display → derive from CoA name.
+
+### 4.5 AssetForm refactor
+
+Replace 4 hardcoded `<option>` blocks with:
+
+```typescript
+const { data: assetGroups } = useCoaGroups({ codePrefix: '12-21' });    // for asset cost
+const { data: depGroups } = useCoaGroups({ codePrefix: '53-16' });      // for depreciation expense
+const { data: accumGroups } = useCoaGroups({ codePrefix: '12-21' });    // accumulated dep — Contra Asset rows only
+```
+
+Filter by `normalBalance` to separate cost (Dr) from accumulated (Cr).
+
+### 4.6 IntercompanySettlementPage refactor
+
+Replace `l.accountCode === '11-1101'` with looking up from CoA. Or keep hardcoded since this is for filtering JE lines, not for display.
+
+### 4.7 Backend `CATEGORY_CODE_MAP` refactor
+
+`apps/api/src/modules/accounting/accounting.service.ts:46-79`
+
+Two options:
+
+**A. Replace hardcoded map with DB lookup at runtime:**
+```typescript
+async getCodeForCategory(category: string): Promise<string> {
+  // Map ExpenseCategory enum → CoA code via category alias table
+  // Need new schema: ExpenseCategoryMapping(category, accountCode)
+}
+```
+
+**B. Keep central TS map but auto-validate at startup:**
+```typescript
+async onModuleInit() {
+  const codes = Object.values(CATEGORY_CODE_MAP);
+  const found = await this.prisma.chartOfAccount.findMany({ where: { code: { in: codes } } });
+  const missing = codes.filter(c => !found.some(f => f.code === c));
+  if (missing.length > 0) throw new Error(`CATEGORY_CODE_MAP references missing CoA codes: ${missing.join(', ')}`);
+}
+```
+
+**Recommendation: B** — simpler, cheaper, fails fast. Only requires fixing the existing wrong mappings + adding boot validator.
+
+### 4.8 Drop ExpenseCategory enum from DB?
+
+Currently `ExpenseCategory` is an enum on `Expense.category` field. Keep it (categories are user-meaningful labels), just ensure each enum value maps to a real CoA code via validated `CATEGORY_CODE_MAP`.
+
+## 5. Migration Steps
+
+| # | Step | Touches | Risk |
+|---|------|---------|------|
+| 1 | Add `GET /accounting/coa-grouped` endpoint + service method | api/chart-of-accounts | Low — additive |
+| 2 | Add `useCoaGroups` + `useCoaByCodes` hooks | web/hooks | Low — additive |
+| 3 | Refactor ExpensesPage to use hook (remove hardcoded categoryGroups) | web/pages | Medium — visible UI change |
+| 4 | Refactor AssetForm to use hook | web/pages/AssetManagementPage | Low |
+| 5 | Fix CATEGORY_CODE_MAP (correct wrong codes per audit) + add `onModuleInit` validator | api/accounting | Medium — boot fails if map wrong |
+| 6 | Remove old hardcoded mappings (keep cpa-templates intentional) | many files | Low — cleanup |
+| 7 | Verify tests pass + smoke test | api+web | — |
+
+## 6. Backwards compatibility
+
+`Expense` records already in DB have `category` enum values (ADMIN_SALARY, etc.). Mapping these to current CSV codes:
+
+| Old enum | Old code (drift) | New code (correct) | Action |
+|----------|------------------|---------------------|--------|
+| ADMIN_SOCIAL_SECURITY | 53-1103 (ค่าล่วงเวลา) | 53-1102 (ประกันสังคม) | Update map |
+| ADMIN_INSURANCE | 53-1103 (ค่าล่วงเวลา) | TBD — owner decides (53-1502 misc?) | Update map after owner picks |
+| ADMIN_RENT | 53-1301 (ค่าน้ำ) | TBD — CSV lacks dedicated rent | Update map after owner picks OR add CSV row |
+| ADMIN_DEPRECIATION | (REMOVED) | 53-1601 (now exists in updated 105 CSV!) | Re-add, point to 53-1601 |
+| COGS_PRODUCT | (REMOVED) | TBD — no COGS in FINANCE chart | Mark deprecated, add SHOP-side later |
+| COGS_REPAIR_PARTS | (REMOVED) | TBD | same |
+| SELL_PACKAGING | 52-1102 (ส่งเสริมการขาย) | TBD — wrong, packaging not present | Map to 53-1502 misc OR add CSV |
+
+Existing Expense rows with deprecated categories → rerender with old labels via fallback. New expenses can't pick deprecated categories.
+
+## 7. Out of scope
+
+- SHOP-side accounting (Phase A.5b — waits CSV from CPA)
+- PEAK code mapping integration
+- Auto-conversion of historical Expense.category to new categories (will rerender labels but not data-migrate)
+
+## 8. Acceptance Criteria
+
+- [ ] `GET /accounting/coa-grouped` returns expected shape and data for type=ค่าใช้จ่าย
+- [ ] ExpensesPage dropdown shows ~30 actual CSV expense accounts (not 21 hardcoded)
+- [ ] AssetForm dropdowns load from CoA (no hardcoded options)
+- [ ] `CATEGORY_CODE_MAP` boot validator passes (or throws at startup if drift detected)
+- [ ] Updating `finance-coa.csv` then running `seed:coa` immediately reflects in UI dropdowns (no code change)
+- [ ] All existing Expense.category values still map to a valid CoA code
+- [ ] TSC clean (api + web)
+- [ ] Tests pass
+
+## 9. Open Questions
+
+1. **ADMIN_INSURANCE / ADMIN_RENT** — CSV has no dedicated accounts. Owner decides:
+   - Add CSV rows (53-1306 ค่าเช่า, 53-1107 ค่าประกันภัย)
+   - Map to nearest existing (53-1502 misc)
+   - Mark as deprecated, hide from UI
+2. **COGS_PRODUCT / COGS_REPAIR_PARTS** — FINANCE chart has no COGS. Defer to SHOP A.5b? Or remove from UI now?
+3. **ExpenseCategory enum** — keep as DB enum, or drop and just store CoA code on Expense.category (string)?
+
+These can be resolved during implementation or by follow-up CSV update from CPA.


### PR DESCRIPTION
Eliminates ~20 drift-prone hardcoded XX-XXXX codes per Phase A.6 audit.

## Changes
- API: `GET /chart-of-accounts/grouped` (filter by type/codePrefix/category)
- Web: `useCoaGroups` + `useCoaByCodes` hooks (staleTime Infinity)
- ExpensesPage: removes ~70 lines of hardcoded categoryGroups + categoryLabels
- AssetForm: removes 3 hardcoded option blocks (12-21XX cost, 53-16XX dep, accumulated)
- accounting.service: CATEGORY_CODE_MAP corrections (SOCIAL_SECURITY 53-1103→53-1102, RENT/INSURANCE temp 53-1502, DEPRECIATION re-added 53-1601) + onModuleInit validator (fails fast on drift)
- Prisma: Expense.category enum → String (accepts CoA codes or legacy enum) + migration

## Effect
CSV updates now reflect immediately in UI dropdowns after seed:coa job.
Boot fails fast if a mapped code goes missing from chart.

## Spec + Plan
- Spec: docs/superpowers/specs/2026-05-06-coa-dynamic-architecture-design.md
- Plan: docs/superpowers/plans/2026-05-06-coa-dynamic-architecture.md

## Open items
- ADMIN_RENT, ADMIN_INSURANCE temp mapped to 53-1502 — CPA needs dedicated CSV rows (Phase A.7)
- COGS_PRODUCT, COGS_REPAIR_PARTS deprecated comments — wait Phase A.5b SHOP chart