### PR TITLE
feat(payments): overpay > 1฿ → 21-1103 advance (auto-consume FIFO)

### DIFF
--- a/apps/api/prisma/migrations/20260807000000_add_contract_advance_balance/migration.sql
+++ b/apps/api/prisma/migrations/20260807000000_add_contract_advance_balance/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "contracts" ADD COLUMN "advance_balance" DECIMAL(12,2) NOT NULL DEFAULT 0;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -852,6 +852,7 @@ model Contract {
   vatAmount        Decimal?       @map("vat_amount") @db.Decimal(12, 2)
   vatPct           Decimal?       @map("vat_pct") @db.Decimal(5, 4)
   monthlyPayment   Decimal        @map("monthly_payment") @db.Decimal(12, 2)
+  advanceBalance   Decimal        @default(0) @map("advance_balance") @db.Decimal(12, 2)
   status           ContractStatus @default(DRAFT)
   parentContractId String?        @map("parent_contract_id")
   notes            String?

--- a/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts
@@ -219,4 +219,136 @@ describe('PaymentReceipt2BTemplate', () => {
     });
     expect(entryReversal).toBeNull();
   });
+
+  describe('advance handling', () => {
+    it('overpay → advance: posts Cr 21-1103, no 53-1503 line', async () => {
+      // installmentTotal = 1,515.83 (standard 17K/12M fixture)
+      // Customer pays 1,600 — overpay = 84.17 → park to 21-1103
+      const { contract, inst, journal } = await setup();
+      const tmpl = new PaymentReceipt2BTemplate(journal, prisma as any);
+
+      const advanceCredit = new Decimal('84.17');
+      await tmpl.execute({
+        installmentScheduleId: inst.id,
+        amountReceived: new Decimal('1600.00'),
+        depositAccountCode: '11-1101',
+        advanceCredit,
+      });
+
+      const entry2B = await prisma.journalEntry.findFirstOrThrow({
+        where: { metadata: { path: ['tag'], equals: '2B' } } as any,
+        include: { lines: true },
+      });
+      const lines = entry2B.lines;
+
+      // Must have Cr 21-1103 with advanceCredit
+      const advance21_1103Cr = lines.find(
+        (l) => l.accountCode === '21-1103' && new Decimal(l.credit.toString()).eq(advanceCredit),
+      );
+      expect(advance21_1103Cr, 'Cr 21-1103 advance line missing').not.toBeUndefined();
+
+      // Must NOT have 53-1503 line (no rounding gain)
+      const rounding53 = lines.find((l) => l.accountCode === '53-1503');
+      expect(rounding53, '53-1503 should not appear').toBeUndefined();
+
+      // Journal must balance (total Dr = total Cr)
+      const totalDr = lines.reduce((acc, l) => acc.plus(l.debit.toString()), new Decimal(0));
+      const totalCr = lines.reduce((acc, l) => acc.plus(l.credit.toString()), new Decimal(0));
+      expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+    });
+
+    it('consume: posts Dr 21-1103, partial cash', async () => {
+      // installmentTotal = 1,515.83
+      // Customer has 200 advance → pays 1,315.83 cash + consume 200
+      const { contract, inst, journal } = await setup();
+      const tmpl = new PaymentReceipt2BTemplate(journal, prisma as any);
+
+      const advanceConsume = new Decimal('200.00');
+      const cashAmount = new Decimal('1315.83');
+      await tmpl.execute({
+        installmentScheduleId: inst.id,
+        amountReceived: cashAmount,
+        depositAccountCode: '11-1101',
+        advanceConsume,
+      });
+
+      const entry2B = await prisma.journalEntry.findFirstOrThrow({
+        where: { metadata: { path: ['tag'], equals: '2B' } } as any,
+        include: { lines: true },
+      });
+      const lines = entry2B.lines;
+
+      // Dr 21-1103 = advanceConsume
+      const advance21_1103Dr = lines.find(
+        (l) =>
+          l.accountCode === '21-1103' && new Decimal(l.debit.toString()).eq(advanceConsume),
+      );
+      expect(advance21_1103Dr, 'Dr 21-1103 consume line missing').not.toBeUndefined();
+
+      // Dr 11-1101 = cashAmount
+      const cashLine = lines.find(
+        (l) =>
+          l.accountCode === '11-1101' && new Decimal(l.debit.toString()).eq(cashAmount),
+      );
+      expect(cashLine, 'Dr 11-1101 cash line missing').not.toBeUndefined();
+
+      // Cr 11-2103 = installmentTotal (1,515.83)
+      const receivableLine = lines.find(
+        (l) =>
+          l.accountCode === '11-2103' &&
+          new Decimal(l.credit.toString()).eq(new Decimal('1515.83')),
+      );
+      expect(receivableLine, 'Cr 11-2103 = 1515.83 missing').not.toBeUndefined();
+
+      // Balanced
+      const totalDr = lines.reduce((acc, l) => acc.plus(l.debit.toString()), new Decimal(0));
+      const totalCr = lines.reduce((acc, l) => acc.plus(l.credit.toString()), new Decimal(0));
+      expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+    });
+
+    it('full-cover: 100% from advance, no Dr cash line', async () => {
+      // installmentTotal = 1,515.83
+      // Customer has 1,515.83 advance → pays 0 cash, fully covered by advance
+      const { contract, inst, journal } = await setup();
+      const tmpl = new PaymentReceipt2BTemplate(journal, prisma as any);
+
+      const advanceConsume = new Decimal('1515.83');
+      await tmpl.execute({
+        installmentScheduleId: inst.id,
+        amountReceived: new Decimal('0'),
+        depositAccountCode: '11-1101',
+        advanceConsume,
+      });
+
+      const entry2B = await prisma.journalEntry.findFirstOrThrow({
+        where: { metadata: { path: ['tag'], equals: '2B' } } as any,
+        include: { lines: true },
+      });
+      const lines = entry2B.lines;
+
+      // No Dr 11-1101 cash line
+      const cashLine = lines.find((l) => l.accountCode === '11-1101');
+      expect(cashLine, '11-1101 should not appear when amountReceived=0').toBeUndefined();
+
+      // Dr 21-1103 = 1,515.83
+      const advance21_1103Dr = lines.find(
+        (l) =>
+          l.accountCode === '21-1103' && new Decimal(l.debit.toString()).eq(advanceConsume),
+      );
+      expect(advance21_1103Dr, 'Dr 21-1103 = 1515.83 missing').not.toBeUndefined();
+
+      // Cr 11-2103 = 1,515.83
+      const receivableLine = lines.find(
+        (l) =>
+          l.accountCode === '11-2103' &&
+          new Decimal(l.credit.toString()).eq(new Decimal('1515.83')),
+      );
+      expect(receivableLine, 'Cr 11-2103 = 1515.83 missing').not.toBeUndefined();
+
+      // Balanced
+      const totalDr = lines.reduce((acc, l) => acc.plus(l.debit.toString()), new Decimal(0));
+      const totalCr = lines.reduce((acc, l) => acc.plus(l.credit.toString()), new Decimal(0));
+      expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+    });
+  });
 });

--- a/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts
@@ -19,6 +19,18 @@ export interface PaymentReceiptInput {
    * When omitted, the template creates its own Payment row (standalone use).
    */
   existingPaymentId?: string;
+  /**
+   * Overpay > 1฿ → post Cr 21-1103 (park excess as advance).
+   * Caller pre-computes: advanceCredit = amountReceived - installmentTotal.
+   * When provided, the overpay amount is removed from the tolerance check.
+   */
+  advanceCredit?: Decimal;
+  /**
+   * Consume existing 21-1103 advance balance → post Dr 21-1103.
+   * Caller pre-computes: advanceConsume = min(contract.advanceBalance, gap).
+   * When provided, this amount supplements amountReceived to cover installmentTotal.
+   */
+  advanceConsume?: Decimal;
 }
 
 /**
@@ -77,17 +89,27 @@ export class PaymentReceipt2BTemplate {
     const vatPerInst = vat.div(total).toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
     const installmentTotal = installmentExclVat.plus(vatPerInst); // 1,515.83
 
-    const diff = input.amountReceived.minus(installmentTotal); // + overpay, - underpay
+    const advCredit = input.advanceCredit ?? new Decimal(0);
+    const advConsume = input.advanceConsume ?? new Decimal(0);
+
+    // Effective rounding diff (subject to TOLERANCE):
+    //   amountReceived + advConsume - installmentTotal - advCredit
+    // Advance components are explicit by design; only the rounding remainder is
+    // checked against the 1฿ tolerance.
+    const roundingDiff = input.amountReceived
+      .plus(advConsume)
+      .minus(installmentTotal)
+      .minus(advCredit);
 
     // Validate tolerance (before entering TX — fast-fail on bad input)
-    if (diff.abs().gt(TOLERANCE)) {
+    if (roundingDiff.abs().gt(TOLERANCE)) {
       throw new BadRequestException(
-        `Payment difference ${diff.abs().toFixed(2)} exceeds tolerance 1.00`,
+        `Payment difference ${roundingDiff.abs().toFixed(2)} exceeds tolerance 1.00`,
       );
     }
 
     // Underpay requires approver
-    if (diff.lt(0) && !input.toleranceApproverId) {
+    if (roundingDiff.lt(0) && !input.toleranceApproverId) {
       throw new BadRequestException(
         'Underpay tolerance requires approver (toleranceApproverId)',
       );
@@ -128,50 +150,63 @@ export class PaymentReceipt2BTemplate {
         dr: Decimal;
         cr: Decimal;
         description?: string;
-      }[] = [
-        {
+      }[] = [];
+
+      // 1. Cash in (skip when 0 — full advance cover edge case)
+      if (input.amountReceived.gt(0)) {
+        lines.push({
           accountCode: input.depositAccountCode,
           dr: input.amountReceived,
           cr: zero,
           description: 'รับเงิน',
-        },
-      ];
+        });
+      }
 
-      if (diff.gt(0)) {
-        // Overpay — split credit between receivable + rounding gain
+      // 2. Consume existing advance
+      if (advConsume.gt(0)) {
         lines.push({
-          accountCode: '11-2103',
-          dr: zero,
-          cr: installmentTotal,
-          description: 'ล้างลูกหนี้ค้างชำระ',
+          accountCode: '21-1103',
+          dr: advConsume,
+          cr: zero,
+          description: 'หักเงินรับล่วงหน้า',
         });
-        lines.push({
-          accountCode: '53-1503',
-          dr: zero,
-          cr: diff,
-          description: 'กำไรปัดเศษ (Policy C)',
-        });
-      } else if (diff.lt(0)) {
-        // Underpay — add discount expense
+      }
+
+      // 3. Underpay rounding
+      if (roundingDiff.lt(0)) {
         lines.push({
           accountCode: '52-1104',
-          dr: diff.abs(),
+          dr: roundingDiff.abs(),
           cr: zero,
           description: 'ส่วนลดเศษสตางค์ (Policy C)',
         });
+      }
+
+      // 4. Clear receivable (always)
+      lines.push({
+        accountCode: '11-2103',
+        dr: zero,
+        cr: installmentTotal,
+        description: 'ล้างลูกหนี้ค้างชำระ',
+      });
+
+      // 5. Park new advance
+      if (advCredit.gt(0)) {
         lines.push({
-          accountCode: '11-2103',
+          accountCode: '21-1103',
           dr: zero,
-          cr: installmentTotal,
-          description: 'ล้างลูกหนี้ค้างชำระ',
+          cr: advCredit,
+          description: 'เงินรับล่วงหน้า',
         });
-      } else {
-        // Exact — simple credit
+      }
+
+      // 6. Overpay rounding
+      if (roundingDiff.gt(0)) {
         lines.push({
-          accountCode: '11-2103',
+          accountCode: '53-1503',
           dr: zero,
-          cr: installmentTotal,
-          description: 'ล้างลูกหนี้ค้างชำระ',
+          cr: roundingDiff,
+          description: 'กำไรปัดเศษ (Policy C)',
         });
       }
 

--- a/apps/api/src/modules/payments/dto/payment.dto.ts
+++ b/apps/api/src/modules/payments/dto/payment.dto.ts
@@ -4,7 +4,14 @@ import { IsString, IsNumber, IsOptional, Matches, Min, IsNotEmpty, MaxLength, Is
 const CASH_CODE_REGEX = /^11-(110[1-3]|120[1-3])$/;
 
 /** Payment case types for the wizard */
-export type PaymentCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'PARTIAL' | 'EARLY_PAYOFF' | 'RESCHEDULE';
+export type PaymentCase =
+  | 'NORMAL'
+  | 'OVERPAY'
+  | 'UNDERPAY'
+  | 'PARTIAL'
+  | 'EARLY_PAYOFF'
+  | 'RESCHEDULE'
+  | 'OVERPAY_ADVANCE';
 
 /** Payment channel/method enum */
 export type PaymentMethod = 'CASH' | 'TRANSFER' | 'QR' | 'PAYSOLUTIONS';
@@ -35,7 +42,7 @@ export class PreviewJournalDto {
 
   @IsOptional()
   @IsString()
-  @IsIn(['NORMAL', 'OVERPAY', 'UNDERPAY', 'PARTIAL', 'EARLY_PAYOFF', 'RESCHEDULE'])
+  @IsIn(['NORMAL', 'OVERPAY', 'UNDERPAY', 'PARTIAL', 'EARLY_PAYOFF', 'RESCHEDULE', 'OVERPAY_ADVANCE'])
   case?: PaymentCase;
 
   @IsOptional()

--- a/apps/api/src/modules/payments/dto/payment.dto.ts
+++ b/apps/api/src/modules/payments/dto/payment.dto.ts
@@ -165,6 +165,12 @@ export class RecordPaymentDto {
   @IsString()
   @IsIn(['SINGLE', 'SPLIT'])
   splitMode?: RescheduleSplitMode;
+
+  /** กรณีการชำระ — ระบุเพื่อให้ service เลือก JE template ที่ถูกต้อง */
+  @IsOptional()
+  @IsString()
+  @IsIn(['NORMAL', 'OVERPAY', 'UNDERPAY', 'PARTIAL', 'EARLY_PAYOFF', 'RESCHEDULE', 'OVERPAY_ADVANCE'])
+  case?: PaymentCase;
 }
 
 export class BulkRecordPaymentDto {

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -160,6 +160,7 @@ export class PaymentsController {
       effectiveTransactionRef,
       dto.depositAccountCode,
       dto.toleranceApproverId,
+      dto.case,
     );
   }
 

--- a/apps/api/src/modules/payments/payments.service.advance.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.advance.spec.ts
@@ -1,0 +1,378 @@
+/**
+ * Task 4 — payments.service.advance.spec.ts
+ *
+ * Tests for OVERPAY_ADVANCE / auto-consume advance balance logic added to
+ * recordPayment. Uses mocked Prisma (unit style) — same pattern as payments.service.spec.ts.
+ *
+ * 4 test cases:
+ *   1. Overpay → advanceBalance increments by overage
+ *   2. Next installment auto-consumes advance, balance returns to 0
+ *   3. Multi-overpay accumulates correctly
+ *   4. Partial-cover: cash + advance fully clear installment
+ */
+
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+  SentryModule: class {},
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PaymentsService } from './payments.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ReceiptsService } from '../receipts/receipts.service';
+import { AuditService } from '../audit/audit.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { ProductsService } from '../products/products.service';
+import { LineOaService } from '../line-oa/line-oa.service';
+import { FlexTemplatesService } from '../line-oa/flex-templates.service';
+import { QuickReplyService } from '../line-oa/quick-reply.service';
+import { PromiseService } from '../overdue/promise.service';
+import { MdmLockService } from '../overdue/mdm-lock.service';
+import { PaymentReceipt2BTemplate } from '../journal/cpa-templates/payment-receipt-2b.template';
+
+const D = (n: number | string) => new Prisma.Decimal(n);
+
+// ── installmentTotal used across tests (whole-number for simple assertions) ──
+// financedAmount=10000, commission=0, interestTotal=2000, totalMonths=12, vatAmount=0
+// grossExclVat = 10000 + 0 + 2000 = 12000
+// installmentExclVat = floor(12000/12 * 100) / 100 = 1000.00 (ROUND_DOWN)
+// vatPerInst = round(0/12, 2, ROUND_HALF_UP) = 0.00
+// installmentTotal = 1000.00
+const INST_TOTAL = 1000;
+
+describe('PaymentsService — advance balance (Task 4)', () => {
+  let service: PaymentsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let receipt2BExecute: any;
+
+  // Mutable advance balance that persists across tests (simulates DB state)
+  let advanceBalance: number;
+
+  // Simulate the installment amountDue + prevPaid state
+  // Each test will override as needed
+  const makeContract = (overrides = {}) => ({
+    id: 'adv-contract-1',
+    contractNumber: 'BC-ADV-001',
+    status: 'ACTIVE',
+    deletedAt: null,
+    branchId: 'branch-1',
+    customerId: 'cust-1',
+    advanceBalance: D(advanceBalance),
+    ...overrides,
+  });
+
+  const makePayment = (installmentNo: number, overrides = {}) => ({
+    id: `adv-payment-${installmentNo}`,
+    contractId: 'adv-contract-1',
+    installmentNo,
+    amountDue: INST_TOTAL,
+    amountPaid: D(0),
+    lateFee: D(0),
+    lateFeeWaived: false,
+    dueDate: new Date('2027-01-01'), // future — no late fee
+    status: 'PENDING',
+    evidenceUrl: null,
+    notes: null,
+    depositAccountCode: null,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    advanceBalance = 0; // reset at start of each test
+
+    // We need fresh mocks per test so contract.advanceBalance reflects current state
+    const buildMockPrisma = () => ({
+      contract: {
+        findUnique: jest.fn().mockImplementation(() =>
+          Promise.resolve(makeContract({ advanceBalance: D(advanceBalance) })),
+        ),
+        update: jest.fn().mockImplementation(({ data }: { data: { advanceBalance?: { increment?: Prisma.Decimal } } }) => {
+          // Simulate the increment update in-memory
+          if (data.advanceBalance?.increment !== undefined) {
+            const delta = parseFloat(data.advanceBalance.increment.toString());
+            advanceBalance = parseFloat((advanceBalance + delta).toFixed(2));
+          }
+          return Promise.resolve(makeContract({ advanceBalance: D(advanceBalance) }));
+        }),
+      },
+      payment: {
+        findFirst: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockImplementation(({ data }: { data: { amountPaid?: Prisma.Decimal; status?: string; paidDate?: Date | null } }) => {
+          return Promise.resolve({
+            id: 'adv-payment-x',
+            contractId: 'adv-contract-1',
+            installmentNo: 1,
+            amountPaid: data.amountPaid ?? D(0),
+            amountDue: D(INST_TOTAL),
+            status: data.status ?? 'PENDING',
+            paidDate: data.paidDate ?? null,
+          });
+        }),
+        count: jest.fn().mockResolvedValue(1), // checkContractCompletion
+        aggregate: jest.fn().mockResolvedValue({ _sum: { amountPaid: INST_TOTAL, lateFee: 0 } }),
+      },
+      user: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'user-1', defaultCashAccountCode: null, deletedAt: null }),
+      },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
+      },
+      systemConfig: {
+        findUnique: jest.fn().mockResolvedValue(null), // no period lock, no late-fee config
+      },
+      installmentSchedule: {
+        findUnique: jest.fn().mockResolvedValue(null), // template call skipped (instSched=null)
+      },
+      callLog: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      auditLog: {
+        create: jest.fn().mockResolvedValue({ id: 'al-1' }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: jest.fn((cb: (tx: any) => Promise<any>) => cb(mockPrismaInst)),
+    });
+
+    // We need the mock instance to reference itself inside $transaction
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mockPrismaInst: any;
+    mockPrismaInst = buildMockPrisma();
+    prisma = mockPrismaInst;
+
+    receipt2BExecute = jest.fn().mockResolvedValue({ entryNo: 'JE-ADV' });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ReceiptsService, useValue: { generateReceipt: jest.fn().mockResolvedValue({ id: 'r-1' }) } },
+        {
+          provide: AuditService,
+          useValue: {
+            log: jest.fn().mockResolvedValue(undefined),
+            logPaymentEvent: jest.fn().mockResolvedValue(undefined),
+            logReceiptEvent: jest.fn().mockResolvedValue(undefined),
+            logContractFinancialEvent: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: JournalAutoService,
+          useValue: {
+            createPaymentJournal: jest.fn().mockResolvedValue('je-1'),
+            createExpenseJournal: jest.fn(),
+            createContractActivationJournal: jest.fn(),
+            createBadDebtWriteOffJournal: jest.fn(),
+            createCustomerCreditOverpaymentJournal: jest.fn().mockResolvedValue('je-2'),
+            createCreditAllocationJournal: jest.fn().mockResolvedValue({ financeEntryId: 'je-3', shopEntryId: 'je-4' }),
+          },
+        },
+        { provide: ProductsService, useValue: { transferOwnership: jest.fn() } },
+        {
+          provide: LineOaService,
+          useValue: { buildPaymentSuccess: jest.fn().mockReturnValue({}), sendFlexMessage: jest.fn() },
+        },
+        {
+          provide: FlexTemplatesService,
+          useValue: { paymentReceipt: jest.fn().mockReturnValue({ type: 'flex', altText: 'test', contents: {} }) },
+        },
+        {
+          provide: QuickReplyService,
+          useValue: { afterPayment: jest.fn().mockReturnValue([]) },
+        },
+        {
+          provide: PromiseService,
+          useValue: { findActivePromise: jest.fn().mockResolvedValue(null) },
+        },
+        {
+          provide: MdmLockService,
+          useValue: { autoUnlock: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: PaymentReceipt2BTemplate,
+          useValue: { execute: receipt2BExecute },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PaymentsService>(PaymentsService);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Test 1: Overpay → Cr 21-1103 + Contract.advanceBalance += overage
+  // ─────────────────────────────────────────────────────────────────────────────
+  it('overpay → Contract.advanceBalance increments by overage', async () => {
+    const overage = 50;
+    const cashAmount = INST_TOTAL + overage; // 1050
+
+    prisma.payment.findFirst.mockResolvedValue(makePayment(1));
+
+    await service.recordPayment(
+      'adv-contract-1',
+      1,
+      cashAmount,
+      'CASH',
+      'user-1',
+      'https://slip.test/1',
+      undefined,
+      'TEST-1',
+      '11-1101',
+      undefined,
+      'OVERPAY_ADVANCE',
+    );
+
+    // Contract.update should have been called with increment = +50
+    expect(prisma.contract.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'adv-contract-1' },
+        data: expect.objectContaining({
+          advanceBalance: expect.objectContaining({ increment: expect.anything() }),
+        }),
+      }),
+    );
+
+    // In-memory balance simulation: should now be 50
+    expect(advanceBalance).toBeCloseTo(50, 2);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Test 2: Next installment auto-consumes advance, balance returns to 0
+  // ─────────────────────────────────────────────────────────────────────────────
+  it('next installment auto-consumes advance → balance returns to 0', async () => {
+    // Pre-condition: advance = 50 (from test 1 scenario)
+    advanceBalance = 50;
+
+    // Pay งวด 2 with cash = installmentTotal - 50 = 950 → consume 50 from advance
+    const cashAmount = INST_TOTAL - 50; // 950
+
+    prisma.payment.findFirst.mockResolvedValue(makePayment(2));
+
+    const result = await service.recordPayment(
+      'adv-contract-1',
+      2,
+      cashAmount,
+      'CASH',
+      'user-1',
+      'https://slip.test/2',
+      undefined,
+      'TEST-2',
+      '11-1101',
+    );
+
+    // Contract.update called with decrement (increment = -50)
+    expect(prisma.contract.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          advanceBalance: expect.objectContaining({ increment: expect.anything() }),
+        }),
+      }),
+    );
+
+    // After consuming 50, balance should be 0
+    expect(advanceBalance).toBeCloseTo(0, 2);
+
+    // Payment should be marked PAID (recordedAmountPaid = cash + advanceConsume = 950+50 = 1000)
+    expect(result.status).toBe('PAID');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Test 3: Multi-overpay accumulates correctly
+  // ─────────────────────────────────────────────────────────────────────────────
+  it('multi-overpay accumulates advance balance correctly', async () => {
+    // First overpay +100
+    prisma.payment.findFirst.mockResolvedValue(makePayment(3));
+
+    await service.recordPayment(
+      'adv-contract-1',
+      3,
+      INST_TOTAL + 100,
+      'CASH',
+      'user-1',
+      'https://slip.test/3',
+      undefined,
+      'TEST-3',
+      '11-1101',
+      undefined,
+      'OVERPAY_ADVANCE',
+    );
+
+    expect(advanceBalance).toBeCloseTo(100, 2);
+
+    // Second overpay +200 (contract.findUnique will return advanceBalance=100 at this point)
+    prisma.payment.findFirst.mockResolvedValue(makePayment(4));
+
+    await service.recordPayment(
+      'adv-contract-1',
+      4,
+      INST_TOTAL + 200,
+      'CASH',
+      'user-1',
+      'https://slip.test/4',
+      undefined,
+      'TEST-4',
+      '11-1101',
+      undefined,
+      'OVERPAY_ADVANCE',
+    );
+
+    expect(advanceBalance).toBeCloseTo(300, 2);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Test 4: Partial-cover — cash + advance fully clears installment
+  // ─────────────────────────────────────────────────────────────────────────────
+  it('partial-cover: cash + advance fully clears installment, balance drops to 0', async () => {
+    // Pre-condition: advance = 300 (from test 3 scenario)
+    advanceBalance = 300;
+
+    // Pay งวด 5 with cash = 700 → consume 300 from advance → total = 1000 (paid in full)
+    const cashAmount = INST_TOTAL - 300; // 700
+
+    prisma.payment.findFirst.mockResolvedValue(makePayment(5));
+
+    const result = await service.recordPayment(
+      'adv-contract-1',
+      5,
+      cashAmount,
+      'CASH',
+      'user-1',
+      'https://slip.test/5',
+      undefined,
+      'TEST-5',
+      '11-1101',
+    );
+
+    // Balance should be drained to 0
+    expect(advanceBalance).toBeCloseTo(0, 2);
+
+    // Payment should be marked PAID
+    expect(result.status).toBe('PAID');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Regression: overpay without OVERPAY_ADVANCE case still throws
+  // ─────────────────────────────────────────────────────────────────────────────
+  it('overpay > 1฿ without OVERPAY_ADVANCE case throws BadRequestException (regression)', async () => {
+    prisma.payment.findFirst.mockResolvedValue(makePayment(6));
+
+    await expect(
+      service.recordPayment(
+        'adv-contract-1',
+        6,
+        INST_TOTAL + 50,
+        'CASH',
+        'user-1',
+        'https://slip.test/6',
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -238,8 +238,13 @@ export class PaymentsService {
           );
         }
         advanceCredit = overage;
-      } else if (d(amount).lt(remaining) && beforeAdvance.gt(0)) {
-        // Auto-consume FIFO when paying less than remaining but contract has advance
+      } else if (
+        d(amount).lt(remaining) &&
+        beforeAdvance.gt(0) &&
+        (paymentCase === undefined || paymentCase === 'NORMAL')
+      ) {
+        // Auto-consume FIFO ONLY for default/NORMAL case. PARTIAL/RESCHEDULE/EARLY_PAYOFF
+        // are explicit flows where the caller controls allocation directly.
         const gap = remaining.minus(d(amount));
         advanceConsume = Prisma.Decimal.min(beforeAdvance, gap);
       }
@@ -277,6 +282,24 @@ export class PaymentsService {
         await tx.contract.update({
           where: { id: contractId },
           data: { advanceBalance: { increment: advanceDelta } },
+        });
+        // Audit advance balance changes for forensics
+        await tx.auditLog.create({
+          data: {
+            action: 'OVERPAY_ADVANCE_RECORDED',
+            entity: 'contract',
+            entityId: contractId,
+            userId: recordedById,
+            newValue: {
+              paymentId: result.id,
+              installmentNo,
+              advanceCredit: advanceCredit.toString(),
+              advanceConsume: advanceConsume.toString(),
+              delta: advanceDelta.toString(),
+              beforeBalance: beforeAdvance.toString(),
+              afterBalance: beforeAdvance.plus(advanceDelta).toString(),
+            },
+          },
         });
       }
 
@@ -1554,7 +1577,35 @@ export class PaymentsService {
 
     // Dr: cash/bank received (installment total + late fee)
     const totalReceived = amountReceived.plus(lateFeeAmount);
-    rawLines.push({ code: input.depositAccountCode, dr: totalReceived, cr: zero, description: 'รับชำระ' });
+
+    // ── Advance balance split (mirror recordPayment §Task 4) ────────────────
+    // The wizard preview must match what the save actually does — including 21-1103 lines.
+    const advanceBalance = new Prisma.Decimal((c.advanceBalance ?? 0).toString());
+    const remaining = installmentTotal.plus(lateFeeAmount); // gross owed (no prevPaid in preview)
+    const overage = amountReceived.plus(lateFeeAmount).minus(remaining);
+    let previewAdvCredit = zero;
+    let previewAdvConsume = zero;
+
+    if (overage.gt(new Prisma.Decimal('1.00')) && input.case === 'OVERPAY_ADVANCE') {
+      previewAdvCredit = overage;
+    } else if (
+      amountReceived.plus(lateFeeAmount).lt(remaining) &&
+      advanceBalance.gt(zero) &&
+      (input.case === undefined || input.case === 'NORMAL')
+    ) {
+      const gap = remaining.minus(amountReceived.plus(lateFeeAmount));
+      previewAdvConsume = Prisma.Decimal.min(advanceBalance, gap);
+    }
+
+    // 1. Cash in (skip when 0 — full advance cover edge)
+    if (totalReceived.gt(zero)) {
+      rawLines.push({ code: input.depositAccountCode, dr: totalReceived, cr: zero, description: 'รับชำระ' });
+    }
+
+    // 2. Consume existing advance
+    if (previewAdvConsume.gt(zero)) {
+      rawLines.push({ code: '21-1103', dr: previewAdvConsume, cr: zero, description: 'หักเงินรับล่วงหน้า' });
+    }
 
     if (isConsolidated) {
       // CONSOLIDATED 2A+2B: Dr 21-2102 + 11-2106 to clear accrual side
@@ -1573,6 +1624,11 @@ export class PaymentsService {
     // Late fee: Cr 42-1103 if > 0
     if (lateFeeAmount.gt(zero)) {
       rawLines.push({ code: '42-1103', dr: zero, cr: lateFeeAmount, description: 'ค่าปรับชำระล่าช้า' });
+    }
+
+    // 5. Park new advance (overpay → 21-1103)
+    if (previewAdvCredit.gt(zero)) {
+      rawLines.push({ code: '21-1103', dr: zero, cr: previewAdvCredit, description: 'เงินรับล่วงหน้า' });
     }
 
     // Resolve account names from CoA

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -715,6 +715,7 @@ export class PaymentsService {
               contractNumber: true,
               totalMonths: true,
               monthlyPayment: true,
+              advanceBalance: true,
               customer: { select: { id: true, name: true, phone: true } },
               branch: { select: { id: true, name: true } },
             },

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -21,6 +21,7 @@ import { formatDateShort } from '../../utils/thai-date.util';
 import { MdmAutoService } from '../mdm/mdm-auto.service';
 import { PromiseService } from '../overdue/promise.service';
 import { MdmLockService } from '../overdue/mdm-lock.service';
+import { PaymentCase } from './dto/payment.dto';
 
 @Injectable()
 export class PaymentsService {
@@ -115,6 +116,7 @@ export class PaymentsService {
     transactionRef?: string,
     depositAccountCode?: string,
     toleranceApproverId?: string,
+    paymentCase?: PaymentCase,
   ) {
     if (!amount || amount <= 0) {
       throw new BadRequestException('จำนวนเงินต้องมากกว่า 0');
@@ -220,15 +222,35 @@ export class PaymentsService {
       const prevPaid = dRound(d(payment.amountPaid));
       const remaining = dRound(dSub(amountDue, prevPaid));
 
-      // Prevent overpayment: cap amount at what is owed for this installment
-      if (d(amount).gt(remaining)) {
-        throw new BadRequestException(
-          `จำนวนเงินเกินยอดค้างชำระ (ยอดค้าง ${remaining.toNumber().toLocaleString()} บาท, ชำระ ${amount.toLocaleString()} บาท) กรุณาใช้ระบบจัดสรรอัตโนมัติสำหรับการชำระหลายงวด`,
-        );
-      }
-      const totalPaid = dAdd(prevPaid, amount);
+      // Advance balance split logic (Task 4):
+      // - OVERPAY_ADVANCE: overage > 1฿ parked as advance (Cr 21-1103)
+      // - NORMAL/others: auto-consume existing advance to cover shortfall
+      const overage = d(amount).minus(remaining);
+      let advanceCredit = d(0);
+      let advanceConsume = d(0);
+      const beforeAdvance = d(contract.advanceBalance ?? 0);
 
-      const isPaidInFull = dGte(totalPaid, amountDue);
+      if (overage.gt(d('1.00'))) {
+        // Overpay > tolerance — must explicitly opt into advance posting
+        if (paymentCase !== 'OVERPAY_ADVANCE') {
+          throw new BadRequestException(
+            `จำนวนเงินเกินยอดค้างชำระ (ยอดค้าง ${remaining.toNumber().toLocaleString()} บาท, ชำระ ${amount.toLocaleString()} บาท) — ต้องเลือก case 'OVERPAY_ADVANCE' เพื่อบันทึกส่วนเกินเป็นเงินรับล่วงหน้า`,
+          );
+        }
+        advanceCredit = overage;
+      } else if (d(amount).lt(remaining) && beforeAdvance.gt(0)) {
+        // Auto-consume FIFO when paying less than remaining but contract has advance
+        const gap = remaining.minus(d(amount));
+        advanceConsume = Prisma.Decimal.min(beforeAdvance, gap);
+      }
+
+      // For OVERPAY_ADVANCE: amountPaid = installmentTotal (full clear via cash + advance posting).
+      // Otherwise: amountPaid = cash + consumed advance (may or may not fully clear).
+      const recordedAmountPaid =
+        paymentCase === 'OVERPAY_ADVANCE' ? remaining : dAdd(prevPaid, amount).plus(advanceConsume);
+
+      const isPaidInFull =
+        paymentCase === 'OVERPAY_ADVANCE' ? true : dGte(recordedAmountPaid, amountDue);
 
       // Append transactionRef to notes for idempotency tracking
       const updatedNotes = transactionRef
@@ -238,7 +260,7 @@ export class PaymentsService {
       const result = await tx.payment.update({
         where: { id: payment.id },
         data: {
-          amountPaid: totalPaid,
+          amountPaid: recordedAmountPaid,
           paidDate: isPaidInFull ? new Date() : null,
           paymentMethod: paymentMethod as PaymentMethod,
           status: isPaidInFull ? 'PAID' : 'PARTIALLY_PAID',
@@ -248,6 +270,15 @@ export class PaymentsService {
           depositAccountCode: resolvedDepositAccountCode,
         },
       });
+
+      // Update Contract.advanceBalance atomically with payment (Task 4.5)
+      const advanceDelta = advanceCredit.minus(advanceConsume);
+      if (!advanceDelta.eq(0)) {
+        await tx.contract.update({
+          where: { id: contractId },
+          data: { advanceBalance: { increment: advanceDelta } },
+        });
+      }
 
       // Check if all payments are completed → update contract status
       if (isPaidInFull) {
@@ -270,10 +301,12 @@ export class PaymentsService {
         if (instSched) {
           await this.paymentReceipt2BTemplate.execute({
             installmentScheduleId: instSched.id,
-            amountReceived: new Prisma.Decimal(result.amountPaid.toString()),
+            amountReceived: new Prisma.Decimal(amount.toString()),
             depositAccountCode: resolvedDepositAccountCode,
             toleranceApproverId: toleranceApproverId,
             existingPaymentId: result.id,
+            advanceCredit: advanceCredit.gt(0) ? advanceCredit : undefined,
+            advanceConsume: advanceConsume.gt(0) ? advanceConsume : undefined,
           });
         } else {
           this.logger.warn(

--- a/apps/web/src/pages/PaymentsPage/components/AdvanceBalanceBanner.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/AdvanceBalanceBanner.tsx
@@ -1,0 +1,37 @@
+import { Wallet } from 'lucide-react';
+import Decimal from 'decimal.js';
+
+interface Props {
+  amountDue: Decimal;
+  advanceBalance: Decimal;
+  onApply: (netDue: string) => void;
+}
+
+/**
+ * Shown when contract.advanceBalance > 0. Displays the auto-FIFO calculation
+ * and a one-tap "use this amount" button to set amountReceived = installment - advance.
+ */
+export function AdvanceBalanceBanner({ amountDue, advanceBalance, onApply }: Props) {
+  if (advanceBalance.lte(0)) return null;
+  const netDue = Decimal.max(new Decimal(0), amountDue.minus(advanceBalance));
+
+  return (
+    <div className="rounded-lg border border-success/40 bg-success/5 p-3 space-y-1">
+      <div className="flex items-center gap-2 text-sm font-medium text-success">
+        <Wallet className="size-4" />
+        <span>ลูกค้ามีเงินล่วงหน้า {advanceBalance.toFixed(2)} ฿</span>
+      </div>
+      <div className="text-xs text-muted-foreground leading-snug">
+        ค่างวด {amountDue.toFixed(2)} − ล่วงหน้า {advanceBalance.toFixed(2)} = ยอดที่ต้องเก็บ{' '}
+        {netDue.toFixed(2)} ฿
+      </div>
+      <button
+        type="button"
+        onClick={() => onApply(netDue.toFixed(2))}
+        className="text-xs underline text-primary hover:no-underline"
+      >
+        ใช้ยอดนี้
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
@@ -32,6 +32,7 @@ import { formatThaiDate } from '@/lib/date';
 import { useDebounce } from '@/hooks/useDebounce';
 import { toast } from 'sonner';
 import type { PendingPayment } from '../types';
+import { AdvanceBalanceBanner } from './AdvanceBalanceBanner';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -39,10 +40,10 @@ import type { PendingPayment } from '../types';
  * Auto-detected payment case (computed from amount diff client-side).
  * RESCHEDULE / EARLY_PAYOFF are handled in separate contract-detail pages, not here.
  */
-type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OUT_OF_RANGE';
+type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OVERPAY_ADVANCE' | 'OUT_OF_RANGE';
 
-/** Legacy type kept for API compatibility — backend accepts all 6 values */
-type PaymentCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'PARTIAL' | 'EARLY_PAYOFF' | 'RESCHEDULE';
+/** Legacy type kept for API compatibility — backend accepts all 7 values */
+type PaymentCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'PARTIAL' | 'EARLY_PAYOFF' | 'RESCHEDULE' | 'OVERPAY_ADVANCE';
 
 type WizardMethod = 'CASH' | 'TRANSFER' | 'QR' | 'PAYSOLUTIONS';
 
@@ -176,6 +177,17 @@ function CaseBadge({
         <AlertCircle className="size-4 text-warning shrink-0" />
         <span className="text-warning font-medium leading-snug">
           จ่ายขาด {absDiff} ฿ — Dr 52-1104 (ต้องอนุมัติ)
+        </span>
+      </div>
+    );
+  }
+
+  if (detectedCase === 'OVERPAY_ADVANCE') {
+    return (
+      <div className="flex items-center gap-1.5 rounded-lg border border-info/40 bg-info/5 px-3 py-2 text-sm">
+        <Info className="size-4 text-info shrink-0" />
+        <span className="text-info font-medium leading-snug">
+          เกิน {absDiff} ฿ — บันทึกเป็นเงินรับล่วงหน้า (หักงวดถัดไปอัตโนมัติ)
         </span>
       </div>
     );
@@ -332,19 +344,32 @@ function JePreviewPanel({
 
 // ─── Auto-detect case from amount diff ───────────────────────────────────────
 
-function detectCase(received: number, expectedTotal: Decimal): DetectedCase {
-  if (received <= 0) return 'OUT_OF_RANGE';
-  const diff = received - expectedTotal.toNumber();
+function detectCase(
+  received: number,
+  expectedTotal: Decimal,
+  advanceBalance: Decimal = new Decimal(0),
+): DetectedCase {
+  // Effective amount due = installment minus existing advance (FIFO consume).
+  // Cashier collects this — system splits internally on save.
+  const effectiveDue = Decimal.max(new Decimal(0), expectedTotal.minus(advanceBalance));
+
+  if (received <= 0) {
+    // Zero cash is OK iff advance fully covers the installment
+    return advanceBalance.gte(expectedTotal) ? 'NORMAL' : 'OUT_OF_RANGE';
+  }
+  const diff = received - effectiveDue.toNumber();
   if (Math.abs(diff) < 0.01) return 'NORMAL';
-  if (diff > 0 && diff <= 1) return 'OVERPAY';
-  if (diff < 0 && diff >= -1) return 'UNDERPAY';
-  return 'OUT_OF_RANGE';
+  if (diff > 0 && diff <= 1) return 'OVERPAY';            // rounding (gain)
+  if (diff < 0 && diff >= -1) return 'UNDERPAY';          // rounding (loss, requires approver)
+  if (diff > 1) return 'OVERPAY_ADVANCE';                 // pay > installment+1฿ → park excess
+  return 'OUT_OF_RANGE';                                  // diff < -1: still blocked → use แบ่งชำระ
 }
 
 /** Map auto-detected case to the API PaymentCase param (best fit) */
 function toApiCase(detected: DetectedCase): PaymentCase {
   if (detected === 'OVERPAY') return 'OVERPAY';
   if (detected === 'UNDERPAY') return 'UNDERPAY';
+  if (detected === 'OVERPAY_ADVANCE') return 'OVERPAY_ADVANCE';
   return 'NORMAL'; // OUT_OF_RANGE should never reach API (submit blocked)
 }
 
@@ -469,6 +494,12 @@ export function RecordPaymentWizard({
     return isNaN(v) ? new Decimal(0) : new Decimal(v);
   }, [lateFeeStr]);
 
+  // Advance balance from contract (Decimal, serialized as string from Prisma)
+  const advanceBalance = useMemo(
+    () => new Decimal(payment.contract.advanceBalance ?? 0),
+    [payment.contract.advanceBalance],
+  );
+
   // Auto-detect case
   const receivedNum = parseFloat(amountReceived) || 0;
   const expectedTotal = useMemo(
@@ -476,8 +507,8 @@ export function RecordPaymentWizard({
     [amountDueDecimal, currentLateFee],
   );
   const detectedCase = useMemo(
-    () => detectCase(receivedNum, expectedTotal),
-    [receivedNum, expectedTotal],
+    () => detectCase(receivedNum, expectedTotal, advanceBalance),
+    [receivedNum, expectedTotal, advanceBalance],
   );
   const amountDiff = useMemo(
     () => receivedNum - expectedTotal.toNumber(),
@@ -501,7 +532,8 @@ export function RecordPaymentWizard({
 
   const isPreviewReady: boolean =
     detectedCase !== 'OUT_OF_RANGE' &&
-    debouncedParams.amountReceived > 0 &&
+    // Allow 0 cash when advance fully covers installment (detectCase = NORMAL)
+    (debouncedParams.amountReceived > 0 || (detectedCase === 'NORMAL' && advanceBalance.gte(expectedTotal))) &&
     debouncedParams.depositAccountCode.length > 0;
 
   const { data: previewData, isFetching: previewLoading } = useQuery<JePreview, Error, JePreview>({
@@ -522,7 +554,8 @@ export function RecordPaymentWizard({
   const requiresSlip = method === 'TRANSFER' || method === 'QR';
 
   const canSubmit = (): boolean => {
-    if (receivedNum <= 0) return false;
+    // Allow zero-cash when advance fully covers the installment (detectCase returns NORMAL)
+    if (receivedNum <= 0 && detectedCase !== 'NORMAL') return false;
     if (!depositAccountCode) return false;
     if (detectedCase === 'OUT_OF_RANGE') return false;
     if (requiresRef && !referenceNumber.trim()) return false;
@@ -599,6 +632,18 @@ export function RecordPaymentWizard({
                   หากต้องการปิดยอดก่อนกำหนดหรือปรับดิว ใช้เมนูแยกในหน้าสัญญา
                 </p>
               </div>
+
+              {/* Advance balance banner — shown when contract has advance to consume */}
+              {advanceBalance.gt(0) && (
+                <AdvanceBalanceBanner
+                  amountDue={amountDueDecimal.add(currentLateFee).sub(amountPaidDecimal)}
+                  advanceBalance={advanceBalance}
+                  onApply={(netDue) => {
+                    setAmountReceived(netDue);
+                    setAmountManuallyEdited(true);
+                  }}
+                />
+              )}
 
               {/* Amount received */}
               <div>

--- a/apps/web/src/pages/PaymentsPage/types.ts
+++ b/apps/web/src/pages/PaymentsPage/types.ts
@@ -30,6 +30,7 @@ export interface PendingPayment {
     contractNumber: string;
     totalMonths: number;
     monthlyPayment: string;
+    advanceBalance: string;  // serialized Decimal from API — '0' for most contracts
     customer: { id: string; name: string; phone: string };
     branch: { id: string; name: string };
   };

--- a/docs/superpowers/plans/2026-05-06-payment-overpay-advance.md
+++ b/docs/superpowers/plans/2026-05-06-payment-overpay-advance.md
@@ -1,0 +1,1138 @@
+# Payment Overpay → Advance (21-1103) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend payment wizard + backend so customers can pay > installment + 1฿ tolerance, with the excess parked in `21-1103` (เงินรับล่วงหน้า) and auto-consumed FIFO on the next due installment.
+
+**Architecture:** Reuses existing `reschedule-jp6.template.ts` pattern (Cr 21-1103 → Dr 21-1103 next due). Adds 1 schema field (`Contract.advanceBalance`), 1 enum value (`OVERPAY_ADVANCE`), extends `PaymentReceipt2BTemplate` with optional `advanceCredit`/`advanceConsume` lines, extends `payments.service.recordPayment` to compute splits, adds `AdvanceBalanceBanner` UI component.
+
+**Tech Stack:** NestJS + Prisma + PostgreSQL + Decimal.js (api), React 18 + TypeScript + react-query (web)
+
+---
+
+## File Inventory
+
+### Backend
+- **Modify** `apps/api/prisma/schema.prisma` — add `Contract.advanceBalance Decimal @default(0)`
+- **Create** `apps/api/prisma/migrations/<ts>_add_contract_advance_balance/migration.sql`
+- **Modify** `apps/api/src/modules/payments/dto/payment.dto.ts` — extend `PaymentCase` enum
+- **Modify** `apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts` — accept `advanceCredit`/`advanceConsume` params, push corresponding JE lines, relax tolerance check for advance cases
+- **Modify** `apps/api/src/modules/payments/payments.service.ts` — `recordPayment()` computes `advanceCredit`/`advanceConsume`, updates `Contract.advanceBalance`
+- **Modify** `apps/api/src/modules/contracts/contracts.service.ts` (or wherever GET /contracts/:id lives) — include `advanceBalance` in response
+- **Test** `apps/api/src/modules/journal/cpa-templates/__tests__/payment-receipt-2b.template.spec.ts` — 3 new test cases (overpay→advance, consume, full-cover)
+- **Test** `apps/api/src/modules/payments/__tests__/payments.service.advance.spec.ts` — new file, 4 e2e cases against test DB
+
+### Frontend
+- **Create** `apps/web/src/pages/PaymentsPage/components/AdvanceBalanceBanner.tsx`
+- **Modify** `apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx` — extend `DetectedCase`, `detectCase()`, `CaseBadge`, JE preview, mount banner
+- **Modify** `apps/web/src/pages/PaymentsPage/types.ts` (or wherever Contract type lives) — add `advanceBalance: string`
+
+---
+
+## Phases
+
+1. **Foundation** — schema migration + enum (T1, T2)
+2. **Backend service layer** — extend 2B template (T3) → service splits (T4) → next-installment consume (T5)
+3. **Frontend types + API surface** — Contract.advanceBalance through to client (T6)
+4. **Frontend UX** — wizard detectCase, badge, banner, preview (T7, T8)
+5. **Integration + verification** — manual smoke + final TS check + PR prep (T9, T10)
+
+---
+
+## Phase 1: Foundation
+
+### Task 1: Schema + migration
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma:837` (Contract model)
+- Create: `apps/api/prisma/migrations/20260807000000_add_contract_advance_balance/migration.sql`
+
+- [ ] **Step 1.1: Add field to Contract model**
+
+Open `apps/api/prisma/schema.prisma`. Find `model Contract {` (around line 837). Add this line near the other Decimal fields (e.g. next to `financedAmount`):
+
+```prisma
+  advanceBalance     Decimal   @default(0) @db.Decimal(12, 2) @map("advance_balance")
+```
+
+- [ ] **Step 1.2: Generate migration SQL**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx prisma migrate dev --name add_contract_advance_balance --create-only
+```
+
+Expected: creates `prisma/migrations/<ts>_add_contract_advance_balance/migration.sql` containing:
+
+```sql
+ALTER TABLE "contracts" ADD COLUMN "advance_balance" DECIMAL(12,2) NOT NULL DEFAULT 0;
+```
+
+- [ ] **Step 1.3: Generate Prisma client**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx prisma generate
+```
+
+- [ ] **Step 1.4: Smoke check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && grep -n "advanceBalance" prisma/schema.prisma
+```
+
+Expected: shows the new field on `Contract`.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "feat(payments): add Contract.advanceBalance for overpay tracking"
+```
+
+---
+
+### Task 2: Extend PaymentCase enum
+
+**Files:**
+- Modify: `apps/api/src/modules/payments/dto/payment.dto.ts:7`
+
+- [ ] **Step 2.1: Read current enum**
+
+```bash
+grep -n "PaymentCase" apps/api/src/modules/payments/dto/payment.dto.ts
+```
+
+- [ ] **Step 2.2: Edit enum**
+
+In `apps/api/src/modules/payments/dto/payment.dto.ts`, find both occurrences (type alias + `@IsIn(...)`) and add `'OVERPAY_ADVANCE'`:
+
+```typescript
+export type PaymentCase =
+  | 'NORMAL'
+  | 'OVERPAY'
+  | 'UNDERPAY'
+  | 'PARTIAL'
+  | 'EARLY_PAYOFF'
+  | 'RESCHEDULE'
+  | 'OVERPAY_ADVANCE';
+```
+
+And:
+
+```typescript
+@IsIn(['NORMAL', 'OVERPAY', 'UNDERPAY', 'PARTIAL', 'EARLY_PAYOFF', 'RESCHEDULE', 'OVERPAY_ADVANCE'])
+```
+
+- [ ] **Step 2.3: Type-check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add apps/api/src/modules/payments/dto/payment.dto.ts
+git commit -m "feat(payments): extend PaymentCase enum with OVERPAY_ADVANCE"
+```
+
+---
+
+## Phase 2: Backend service layer
+
+### Task 3: Extend `PaymentReceipt2BTemplate` with advance params (TDD)
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts`
+- Test: `apps/api/src/modules/journal/cpa-templates/__tests__/payment-receipt-2b.template.spec.ts` (locate existing or create)
+
+- [ ] **Step 3.1: Locate existing 2B template tests**
+
+```bash
+find apps/api/src -name "payment-receipt-2b*" -type f
+```
+
+If a spec exists, append to it. If not, create at `apps/api/src/modules/journal/cpa-templates/__tests__/payment-receipt-2b.template.spec.ts`.
+
+- [ ] **Step 3.2: Write failing test — overpay → advance (10฿ excess)**
+
+Append to spec file:
+
+```typescript
+describe('PaymentReceipt2BTemplate — advance handling', () => {
+  let template: PaymentReceipt2BTemplate;
+  let prisma: PrismaService;
+  let contract: any;
+  let inst: any;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      providers: [PaymentReceipt2BTemplate, JournalAutoService, PrismaService],
+    }).compile();
+    template = module.get(PaymentReceipt2BTemplate);
+    prisma = module.get(PrismaService);
+    // Seed: 1 contract + 1 installment with installmentTotal = 1000 (clean numbers)
+    // (Use existing test helpers if available — pseudocode shown)
+    contract = await seedContract(prisma, { totalMonths: 12, financedAmount: 10000, interestTotal: 1000 });
+    inst = await seedInstallment(prisma, contract.id, 1, /* installmentTotal */ 1000);
+  });
+
+  it('overpay+advance: posts Cr 21-1103 + Cr 11-2103, no 53-1503 line', async () => {
+    const result = await template.execute({
+      installmentScheduleId: inst.id,
+      amountReceived: new Decimal(1010), // 10 over
+      depositAccountCode: '11-1101',
+      advanceCredit: new Decimal(10),
+    });
+    const je = await prisma.journalEntry.findUnique({
+      where: { entryNumber: result.entryNo },
+      include: { lines: { orderBy: { lineNo: 'asc' } } },
+    });
+    const codes = je!.lines.map(l => l.accountCode);
+    expect(codes).toContain('21-1103');
+    expect(codes).not.toContain('53-1503');
+    const advLine = je!.lines.find(l => l.accountCode === '21-1103')!;
+    expect(advLine.credit.toString()).toBe('10');
+    expect(advLine.debit.toString()).toBe('0');
+  });
+});
+```
+
+- [ ] **Step 3.3: Run failing test**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx jest src/modules/journal/cpa-templates/__tests__/payment-receipt-2b.template.spec.ts -t "advance handling"
+```
+
+Expected: FAIL — `advanceCredit` not a known property of `PaymentReceiptInput`.
+
+- [ ] **Step 3.4: Add params to interface**
+
+In `apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts`, extend `PaymentReceiptInput`:
+
+```typescript
+export interface PaymentReceiptInput {
+  installmentScheduleId: string;
+  amountReceived: Decimal;
+  depositAccountCode: string;
+  toleranceApproverId?: string;
+  existingPaymentId?: string;
+  /** Overpay > 1฿ → post Cr 21-1103. Caller pre-computed (received - installmentTotal). */
+  advanceCredit?: Decimal;
+  /** Use existing 21-1103 balance → post Dr 21-1103. Caller pre-computed (consume amount). */
+  advanceConsume?: Decimal;
+}
+```
+
+- [ ] **Step 3.5: Relax tolerance check + emit advance lines**
+
+Replace the tolerance + line-building block in `execute()`. Find the `if (diff.abs().gt(TOLERANCE))` and the line-building switch. Update to:
+
+```typescript
+    const advCredit = input.advanceCredit ?? new Decimal(0);
+    const advConsume = input.advanceConsume ?? new Decimal(0);
+    const isAdvanceCase = advCredit.gt(0) || advConsume.gt(0);
+
+    // Effective amount to clear from receivable:
+    //   cash + consume = installmentTotal + advanceCredit
+    //   so: rounding diff (subject to TOLERANCE) =
+    //       amountReceived + advConsume - installmentTotal - advCredit
+    const roundingDiff = input.amountReceived
+      .plus(advConsume)
+      .minus(installmentTotal)
+      .minus(advCredit);
+
+    // Validate rounding tolerance only (advance excess is allowed by design)
+    if (roundingDiff.abs().gt(TOLERANCE)) {
+      throw new BadRequestException(
+        `Payment difference ${roundingDiff.abs().toFixed(2)} exceeds tolerance 1.00`,
+      );
+    }
+
+    // Underpay rounding still requires approver
+    if (roundingDiff.lt(0) && !input.toleranceApproverId) {
+      throw new BadRequestException(
+        'Underpay tolerance requires approver (toleranceApproverId)',
+      );
+    }
+```
+
+In the line-building section, replace the existing if/else block (lines ~140-176) with:
+
+```typescript
+      // 1. Cash in (only if > 0)
+      if (input.amountReceived.gt(0)) {
+        lines.push({
+          accountCode: input.depositAccountCode,
+          dr: input.amountReceived,
+          cr: zero,
+          description: 'รับเงิน',
+        });
+      }
+
+      // 2. Consume existing advance (Dr 21-1103)
+      if (advConsume.gt(0)) {
+        lines.push({
+          accountCode: '21-1103',
+          dr: advConsume,
+          cr: zero,
+          description: 'หักเงินรับล่วงหน้า',
+        });
+      }
+
+      // 3. Underpay rounding adjustment
+      if (roundingDiff.lt(0)) {
+        lines.push({
+          accountCode: '52-1104',
+          dr: roundingDiff.abs(),
+          cr: zero,
+          description: 'ส่วนลดเศษสตางค์ (Policy C)',
+        });
+      }
+
+      // 4. Clear receivable (always)
+      lines.push({
+        accountCode: '11-2103',
+        dr: zero,
+        cr: installmentTotal,
+        description: 'ล้างลูกหนี้ค้างชำระ',
+      });
+
+      // 5. Park new advance (Cr 21-1103)
+      if (advCredit.gt(0)) {
+        lines.push({
+          accountCode: '21-1103',
+          dr: zero,
+          cr: advCredit,
+          description: 'เงินรับล่วงหน้า',
+        });
+      }
+
+      // 6. Overpay rounding adjustment
+      if (roundingDiff.gt(0)) {
+        lines.push({
+          accountCode: '53-1503',
+          dr: zero,
+          cr: roundingDiff,
+          description: 'กำไรปัดเศษ (Policy C)',
+        });
+      }
+```
+
+- [ ] **Step 3.6: Run test — verify pass**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx jest src/modules/journal/cpa-templates/__tests__/payment-receipt-2b.template.spec.ts -t "advance handling"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.7: Add 2 more test cases — consume + full-cover**
+
+Append to the same describe block:
+
+```typescript
+  it('consume: posts Dr 21-1103 + receives partial cash', async () => {
+    // installmentTotal = 1000, advance balance = 200, customer pays 800 cash
+    const result = await template.execute({
+      installmentScheduleId: inst.id,
+      amountReceived: new Decimal(800),
+      depositAccountCode: '11-1101',
+      advanceConsume: new Decimal(200),
+    });
+    const je = await prisma.journalEntry.findUnique({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+    const adv = je!.lines.find(l => l.accountCode === '21-1103')!;
+    expect(adv.debit.toString()).toBe('200');
+    expect(adv.credit.toString()).toBe('0');
+    const totalDr = je!.lines.reduce((s, l) => s.plus(l.debit), new Decimal(0));
+    const totalCr = je!.lines.reduce((s, l) => s.plus(l.credit), new Decimal(0));
+    expect(totalDr.eq(totalCr)).toBe(true);
+  });
+
+  it('full-cover: 100% from advance, no cash, no Dr cash line', async () => {
+    // installmentTotal = 1000, advance balance = 1000, customer pays 0
+    const result = await template.execute({
+      installmentScheduleId: inst.id,
+      amountReceived: new Decimal(0),
+      depositAccountCode: '11-1101',
+      advanceConsume: new Decimal(1000),
+    });
+    const je = await prisma.journalEntry.findUnique({
+      where: { entryNumber: result.entryNo },
+      include: { lines: true },
+    });
+    expect(je!.lines.find(l => l.accountCode === '11-1101')).toBeUndefined();
+    const adv = je!.lines.find(l => l.accountCode === '21-1103')!;
+    expect(adv.debit.toString()).toBe('1000');
+    const recv = je!.lines.find(l => l.accountCode === '11-2103')!;
+    expect(recv.credit.toString()).toBe('1000');
+  });
+```
+
+- [ ] **Step 3.8: Run all 3 advance tests**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx jest src/modules/journal/cpa-templates/__tests__/payment-receipt-2b.template.spec.ts
+```
+
+Expected: 3/3 pass + existing tests still pass (rounding tolerance regression check).
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add apps/api/src/modules/journal/cpa-templates/
+git commit -m "feat(payments): extend 2B template with advanceCredit/advanceConsume params
+
+- Cr 21-1103 when overpay > 1฿ (advanceCredit)
+- Dr 21-1103 when consuming existing balance (advanceConsume)
+- Skip Dr cash line when amountReceived = 0 (full-cover by advance)
+- Tolerance check now applies only to rounding diff (excludes advance excess)"
+```
+
+---
+
+### Task 4: `recordPayment` computes advance splits (TDD)
+
+**Files:**
+- Modify: `apps/api/src/modules/payments/payments.service.ts:107` (`recordPayment` method)
+- Modify: `apps/api/src/modules/payments/dto/payment.dto.ts` (DTO needs to accept `case` field if not already)
+- Test: `apps/api/src/modules/payments/__tests__/payments.service.advance.spec.ts` (new file)
+
+- [ ] **Step 4.1: Inspect existing recordPayment signature**
+
+```bash
+sed -n '107,225p' apps/api/src/modules/payments/payments.service.ts
+```
+
+Note: `recordPayment` currently throws if `amount > remaining`. We need to allow that when caller signals `case='OVERPAY_ADVANCE'`.
+
+- [ ] **Step 4.2: Add `case` parameter to recordPayment**
+
+Update signature:
+
+```typescript
+  async recordPayment(
+    contractId: string,
+    installmentNo: number,
+    amount: number,
+    paymentMethod: string,
+    recordedById: string,
+    evidenceUrl?: string,
+    notes?: string,
+    transactionRef?: string,
+    depositAccountCode?: string,
+    toleranceApproverId?: string,
+    paymentCase?: PaymentCase, // NEW
+  ) {
+```
+
+Add `import` at top:
+
+```typescript
+import { PaymentCase } from './dto/payment.dto';
+```
+
+- [ ] **Step 4.3: Replace overpay guard with split logic**
+
+Find the block (around line 224):
+
+```typescript
+      if (d(amount).gt(remaining)) {
+        throw new BadRequestException(
+          `จำนวนเงินเกินยอดค้างชำระ ...`,
+```
+
+Replace with:
+
+```typescript
+      const overage = d(amount).minus(remaining);
+      let advanceCredit = d(0);
+      let advanceConsume = d(0);
+      const beforeAdvance = d(contract.advanceBalance);
+
+      if (overage.gt(d('1.00'))) {
+        // Caller must explicitly opt into advance for amounts > tolerance
+        if (paymentCase !== 'OVERPAY_ADVANCE') {
+          throw new BadRequestException(
+            `จำนวนเงินเกินยอดค้างชำระ (ยอดค้าง ${remaining.toNumber().toLocaleString()} บาท, ชำระ ${amount.toLocaleString()} บาท) — ต้องเลือก case 'OVERPAY_ADVANCE' เพื่อบันทึกส่วนเกินเป็นเงินรับล่วงหน้า`,
+          );
+        }
+        advanceCredit = overage;
+      } else if (d(amount).lt(remaining) && beforeAdvance.gt(0)) {
+        // Auto-consume existing advance to cover gap
+        const gap = remaining.minus(d(amount));
+        advanceConsume = Prisma.Decimal.min(beforeAdvance, gap);
+      }
+```
+
+- [ ] **Step 4.4: Wire advanceCredit/advanceConsume into the 2B template call**
+
+Find where `recordPayment` calls `paymentReceipt2BTemplate.execute(...)` (search for "PaymentReceipt2BTemplate" or "execute({" inside recordPayment). The block typically constructs the input. Add the two fields:
+
+```typescript
+      const result = await this.paymentReceipt2BTemplate.execute({
+        installmentScheduleId: schedule.id,
+        amountReceived: d(amount),
+        depositAccountCode: resolvedDepositAccountCode,
+        toleranceApproverId,
+        existingPaymentId: payment.id,
+        advanceCredit: advanceCredit.gt(0) ? advanceCredit : undefined,
+        advanceConsume: advanceConsume.gt(0) ? advanceConsume : undefined,
+      });
+```
+
+- [ ] **Step 4.5: Update Contract.advanceBalance + Payment.amountPaid**
+
+After the JE call succeeds, update both rows. Find where `tx.payment.update({ ... amountPaid: ... })` is called inside `recordPayment`. Right before/after that, add:
+
+```typescript
+      // For OVERPAY_ADVANCE, Payment.amountPaid is just the installment total (not the cash received).
+      // The excess goes to Contract.advanceBalance.
+      const recordedAmountPaid = paymentCase === 'OVERPAY_ADVANCE' ? remaining : d(amount).plus(advanceConsume);
+
+      await tx.payment.update({
+        where: { id: payment.id },
+        data: {
+          amountPaid: recordedAmountPaid,
+          paidDate: new Date(),
+          paidAt: new Date(),
+          status: recordedAmountPaid.gte(amountDue) ? 'PAID' : 'PARTIALLY_PAID',
+          // ... preserve existing fields
+        },
+      });
+
+      // Update advance balance: +credit, -consume
+      const advanceDelta = advanceCredit.minus(advanceConsume);
+      if (!advanceDelta.eq(0)) {
+        await tx.contract.update({
+          where: { id: contractId },
+          data: { advanceBalance: { increment: advanceDelta } as any },
+        });
+      }
+```
+
+(If the codebase already has its own `tx.payment.update`, weave the recordedAmountPaid + advance delta logic without duplicating fields.)
+
+- [ ] **Step 4.6: Write failing tests**
+
+Create `apps/api/src/modules/payments/__tests__/payments.service.advance.spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { PaymentsService } from '../payments.service';
+import { Decimal } from '@prisma/client/runtime/library';
+
+describe('PaymentsService — advance balance', () => {
+  let service: PaymentsService;
+  let prisma: PrismaService;
+  let contractId: string;
+  let recordedById: string;
+
+  beforeAll(async () => {
+    // Bootstrap test app with full payments module wiring
+    // Use the same DATABASE_URL pattern as other-income.service.spec.ts
+    // Seed: contract with 12 monthly installments, installmentTotal=1000
+    // (Use existing fixtures or helpers — pseudocode shown)
+    const seeded = await seedContractWithPayments(prisma, {
+      totalMonths: 12,
+      financedAmount: 10000,
+      interestTotal: 1000,
+      installmentTotal: 1000,
+    });
+    contractId = seeded.contract.id;
+    recordedById = seeded.user.id;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('overpay → Cr 21-1103 + Contract.advanceBalance += 50', async () => {
+    await service.recordPayment(
+      contractId,
+      1, // installmentNo
+      1050, // amount
+      'CASH',
+      recordedById,
+      undefined,
+      undefined,
+      'TEST-1',
+      '11-1101',
+      undefined,
+      'OVERPAY_ADVANCE',
+    );
+    const c = await prisma.contract.findUnique({ where: { id: contractId } });
+    expect(c!.advanceBalance.toString()).toBe('50');
+  });
+
+  it('next installment auto-consumes advance, balance returns to 0', async () => {
+    // Pay งวด 2 with amount 950 (50 short of installmentTotal 1000) — should consume 50 from advance
+    await service.recordPayment(
+      contractId,
+      2,
+      950,
+      'CASH',
+      recordedById,
+      undefined,
+      undefined,
+      'TEST-2',
+      '11-1101',
+    );
+    const c = await prisma.contract.findUnique({ where: { id: contractId } });
+    expect(c!.advanceBalance.toString()).toBe('0');
+    const payment = await prisma.payment.findFirst({
+      where: { contractId, installmentNo: 2 },
+    });
+    expect(payment!.status).toBe('PAID');
+    expect(payment!.amountPaid.toString()).toBe('1000');
+  });
+
+  it('multi-overpay accumulates', async () => {
+    // Pay งวด 3 with 1100 (100 over) → balance = 100
+    await service.recordPayment(contractId, 3, 1100, 'CASH', recordedById, undefined, undefined, 'TEST-3', '11-1101', undefined, 'OVERPAY_ADVANCE');
+    let c = await prisma.contract.findUnique({ where: { id: contractId } });
+    expect(c!.advanceBalance.toString()).toBe('100');
+
+    // Pay งวด 4 with 1200 (200 over) → balance = 300
+    await service.recordPayment(contractId, 4, 1200, 'CASH', recordedById, undefined, undefined, 'TEST-4', '11-1101', undefined, 'OVERPAY_ADVANCE');
+    c = await prisma.contract.findUnique({ where: { id: contractId } });
+    expect(c!.advanceBalance.toString()).toBe('300');
+  });
+
+  it('full-cover: amount=0 with sufficient advance → installment paid, balance drained', async () => {
+    // From previous test, advance = 300. Pay งวด 5 with amount = 0 → consume only available 300, partial payment 700 outstanding? Actually plan says 100% covered if advance >= installment. Here installmentTotal = 1000 > advance 300, so this should NOT fully cover. Adjust expectation: advance drains to 0, payment = PARTIALLY_PAID with amountPaid = 300.
+    // For a true full-cover test, use a contract where advanceBalance >= installmentTotal.
+    // For now, test partial: pay 700 + consume 300
+    await service.recordPayment(contractId, 5, 700, 'CASH', recordedById, undefined, undefined, 'TEST-5', '11-1101');
+    const c = await prisma.contract.findUnique({ where: { id: contractId } });
+    expect(c!.advanceBalance.toString()).toBe('0');
+    const payment = await prisma.payment.findFirst({ where: { contractId, installmentNo: 5 } });
+    expect(payment!.status).toBe('PAID');
+    expect(payment!.amountPaid.toString()).toBe('1000'); // 700 cash + 300 advance
+  });
+});
+```
+
+- [ ] **Step 4.7: Run failing tests**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx jest src/modules/payments/__tests__/payments.service.advance.spec.ts
+```
+
+Expected: tests fail until Steps 4.2-4.5 land.
+
+- [ ] **Step 4.8: Iterate until 4/4 pass**
+
+Run repeatedly while fixing. Common failures:
+- `Contract.advanceBalance` field missing → re-run `npx prisma generate`
+- DTO validation rejects new case value → check `@IsIn` includes `'OVERPAY_ADVANCE'`
+- Recorded `amountPaid` mismatch → re-check Step 4.5 `recordedAmountPaid` formula
+
+- [ ] **Step 4.9: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4.10: Commit**
+
+```bash
+git add apps/api/src/modules/payments/
+git commit -m "feat(payments): recordPayment supports OVERPAY_ADVANCE + auto-consume
+
+- accepts paymentCase param, computes advanceCredit/Consume
+- updates Contract.advanceBalance atomically with JE post
+- amountPaid = installmentTotal (not cash) when advancing
+- 4 e2e tests cover overpay/consume/multi-accumulate/partial-cover"
+```
+
+---
+
+### Task 5: Update controller + caller paths
+
+**Files:**
+- Modify: `apps/api/src/modules/payments/payments.controller.ts`
+- Modify: `apps/api/src/modules/payments/dto/record-payment.dto.ts` (or wherever the request DTO for record endpoint lives)
+
+- [ ] **Step 5.1: Find the record-payment endpoint**
+
+```bash
+grep -rn "recordPayment\|@Post.*record\|@Post.*payment" apps/api/src/modules/payments/payments.controller.ts | head -10
+```
+
+- [ ] **Step 5.2: Add `case` to request DTO**
+
+Locate the DTO used by the record endpoint (likely `RecordPaymentDto` in `dto/`). Add:
+
+```typescript
+import { IsIn, IsOptional } from 'class-validator';
+import type { PaymentCase } from './payment.dto';
+
+export class RecordPaymentDto {
+  // ... existing fields ...
+
+  @IsOptional()
+  @IsIn(['NORMAL', 'OVERPAY', 'UNDERPAY', 'PARTIAL', 'EARLY_PAYOFF', 'RESCHEDULE', 'OVERPAY_ADVANCE'])
+  case?: PaymentCase;
+}
+```
+
+- [ ] **Step 5.3: Pass `case` through controller**
+
+Find the controller method calling `recordPayment(...)`. Append `dto.case` as the new last argument matching the service signature.
+
+- [ ] **Step 5.4: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add apps/api/src/modules/payments/
+git commit -m "feat(payments): pass paymentCase from controller through to service"
+```
+
+---
+
+### Task 6: Surface `Contract.advanceBalance` to client
+
+**Files:**
+- Modify: `apps/api/src/modules/contracts/contracts.service.ts` (find the GET /contracts/:id handler)
+
+- [ ] **Step 6.1: Locate findOne**
+
+```bash
+grep -n "findOne\|findById\|findUnique" apps/api/src/modules/contracts/contracts.service.ts | head -10
+```
+
+- [ ] **Step 6.2: Verify advanceBalance is already returned**
+
+Prisma `findUnique({ where: { id } })` returns all scalar fields by default (including the new `advanceBalance`). If the service uses an explicit `select: { ... }`, add `advanceBalance: true`.
+
+```bash
+grep -n "select:" apps/api/src/modules/contracts/contracts.service.ts | head -5
+```
+
+If you find `select: { ... }` in the contract findOne path, edit to include `advanceBalance: true`.
+
+- [ ] **Step 6.3: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+- [ ] **Step 6.4: Commit (only if Step 6.2 required an edit)**
+
+```bash
+git add apps/api/src/modules/contracts/
+git commit -m "feat(payments): include advanceBalance in GET /contracts/:id response"
+```
+
+(If no edit was needed because select wasn't used, skip this commit.)
+
+---
+
+## Phase 4: Frontend UX
+
+### Task 7: Wizard `detectCase` + badge
+
+**Files:**
+- Modify: `apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx:42` (DetectedCase type)
+- Modify: `apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx:335` (detectCase function)
+- Modify: `apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx:145-192` (CaseBadge component)
+
+- [ ] **Step 7.1: Extend DetectedCase type**
+
+In `RecordPaymentWizard.tsx`, line 42, change:
+
+```typescript
+type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OVERPAY_ADVANCE' | 'OUT_OF_RANGE';
+```
+
+- [ ] **Step 7.2: Update detectCase function**
+
+Find `function detectCase(received, expectedTotal)` (line 335) and replace with:
+
+```typescript
+function detectCase(
+  received: number,
+  expectedTotal: Decimal,
+  advanceBalance: Decimal = new Decimal(0),
+): DetectedCase {
+  // Effective amount due = installment minus advance (FIFO consume).
+  // Cashier collects this — system splits internally.
+  const effectiveDue = Decimal.max(new Decimal(0), expectedTotal.minus(advanceBalance));
+
+  if (received <= 0) {
+    // 0 cash is OK iff advance fully covers the installment
+    return advanceBalance.gte(expectedTotal) ? 'NORMAL' : 'OUT_OF_RANGE';
+  }
+  const diff = received - effectiveDue.toNumber();
+  if (Math.abs(diff) < 0.01) return 'NORMAL';
+  if (diff > 0 && diff <= 1) return 'OVERPAY';            // rounding (gain)
+  if (diff < 0 && diff >= -1) return 'UNDERPAY';          // rounding (loss, requires approver)
+  if (diff > 1) return 'OVERPAY_ADVANCE';                 // pay > installment+1฿ → park excess
+  return 'OUT_OF_RANGE';                                  // diff < -1: still blocked → use แบ่งชำระ
+}
+```
+
+- [ ] **Step 7.3: Update toApiCase mapping**
+
+Find `function toApiCase(detected)` (around line 345) and add the new mapping:
+
+```typescript
+function toApiCase(detected: DetectedCase): PaymentCase {
+  if (detected === 'OVERPAY') return 'OVERPAY';
+  if (detected === 'UNDERPAY') return 'UNDERPAY';
+  if (detected === 'OVERPAY_ADVANCE') return 'OVERPAY_ADVANCE';
+  return 'NORMAL';
+}
+```
+
+- [ ] **Step 7.4: Add CaseBadge branch**
+
+In `CaseBadge` component (around line 145), insert before the existing `OUT_OF_RANGE` branch:
+
+```tsx
+  if (detectedCase === 'OVERPAY_ADVANCE') {
+    return (
+      <div className="flex items-center gap-1.5 rounded-lg border border-info/40 bg-info/5 px-3 py-2 text-sm">
+        <Info className="size-4 text-info shrink-0" />
+        <span className="text-info font-medium leading-snug">
+          เกิน {absDiff} ฿ — บันทึกเป็นเงินรับล่วงหน้า (หักงวดถัดไปอัตโนมัติ)
+        </span>
+      </div>
+    );
+  }
+```
+
+Add `Info` to the lucide imports at the top of the file if not already present.
+
+- [ ] **Step 7.5: Unblock Save button + submit logic**
+
+Find:
+
+```typescript
+detectedCase !== 'OUT_OF_RANGE' &&
+```
+
+Verify: `OVERPAY_ADVANCE` is allowed because the condition only blocks `OUT_OF_RANGE`. No code change unless Save button uses an explicit allow-list — search for `'OVERPAY' &&` or `case === 'NORMAL' ||` patterns:
+
+```bash
+grep -n "submitDisabled\|'NORMAL'\|'OVERPAY'" apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx | head
+```
+
+If allow-list found (e.g. `if (detectedCase !== 'NORMAL' && detectedCase !== 'OVERPAY' && detectedCase !== 'UNDERPAY')`), add `&& detectedCase !== 'OVERPAY_ADVANCE'`.
+
+- [ ] **Step 7.6: Pass advanceBalance from contract**
+
+Find where `detectCase(...)` is called inside `useMemo` (around line 461). The contract data is queried via `useQuery`. Pass advance balance:
+
+```typescript
+  const detectedCase = useMemo(
+    () => detectCase(
+      Number(amountReceived) || 0,
+      amountDueDecimal.add(lateFeeDecimal).sub(amountPaidDecimal),
+      new Decimal(contract?.advanceBalance ?? 0),
+    ),
+    [amountReceived, amountDueDecimal, lateFeeDecimal, amountPaidDecimal, contract?.advanceBalance],
+  );
+```
+
+(The `contract` variable comes from useQuery — verify name.)
+
+- [ ] **Step 7.7: Update web Contract type**
+
+```bash
+grep -rn "interface Contract\b\|type Contract " apps/web/src/types apps/web/src/pages/PaymentsPage 2>/dev/null | head
+```
+
+In the Contract type definition, add:
+
+```typescript
+advanceBalance: string;  // serialized Decimal from API
+```
+
+- [ ] **Step 7.8: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+- [ ] **Step 7.9: Commit**
+
+```bash
+git add apps/web/src/pages/PaymentsPage/ apps/web/src/types/ 2>/dev/null || true
+git commit -m "feat(payments/web): wizard detects OVERPAY_ADVANCE case + new badge
+
+- detectCase considers contract.advanceBalance (effective due = installment - advance)
+- CaseBadge renders blue 'เกินจะบันทึกเป็นล่วงหน้า' for OVERPAY_ADVANCE
+- Save button enabled (no longer blocked by OUT_OF_RANGE)
+- Contract type extended with advanceBalance field"
+```
+
+---
+
+### Task 8: AdvanceBalanceBanner + JE preview line
+
+**Files:**
+- Create: `apps/web/src/pages/PaymentsPage/components/AdvanceBalanceBanner.tsx`
+- Modify: `apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx` (mount banner + extend JE preview)
+
+- [ ] **Step 8.1: Create AdvanceBalanceBanner**
+
+Create `apps/web/src/pages/PaymentsPage/components/AdvanceBalanceBanner.tsx`:
+
+```tsx
+import { Wallet } from 'lucide-react';
+import Decimal from 'decimal.js';
+
+interface Props {
+  amountDue: Decimal;
+  advanceBalance: Decimal;
+  onApply: (netDue: string) => void;
+}
+
+/**
+ * Shown when contract.advanceBalance > 0. Displays the auto-FIFO calculation
+ * and one-tap "use this amount" button to set amountReceived = installment - advance.
+ */
+export function AdvanceBalanceBanner({ amountDue, advanceBalance, onApply }: Props) {
+  if (advanceBalance.lte(0)) return null;
+  const netDue = Decimal.max(new Decimal(0), amountDue.minus(advanceBalance));
+
+  return (
+    <div className="rounded-lg border border-success/40 bg-success/5 p-3 space-y-1">
+      <div className="flex items-center gap-2 text-sm font-medium text-success">
+        <Wallet className="size-4" />
+        <span>ลูกค้ามีเงินล่วงหน้า {advanceBalance.toFixed(2)} ฿</span>
+      </div>
+      <div className="text-xs text-muted-foreground leading-snug">
+        ค่างวด {amountDue.toFixed(2)} − ล่วงหน้า {advanceBalance.toFixed(2)} = ยอดที่ต้องเก็บ {netDue.toFixed(2)} ฿
+      </div>
+      <button
+        type="button"
+        onClick={() => onApply(netDue.toFixed(2))}
+        className="text-xs underline text-primary hover:no-underline"
+      >
+        ใช้ยอดนี้
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8.2: Mount banner in wizard**
+
+In `RecordPaymentWizard.tsx`, find the section that renders the amount input (search for `amountReceived` JSX). Add the banner just above the input:
+
+```tsx
+import { AdvanceBalanceBanner } from './AdvanceBalanceBanner';
+
+// inside render, near amount input:
+{contract && new Decimal(contract.advanceBalance).gt(0) && (
+  <AdvanceBalanceBanner
+    amountDue={amountDueDecimal.add(lateFeeDecimal).sub(amountPaidDecimal)}
+    advanceBalance={new Decimal(contract.advanceBalance)}
+    onApply={(netDue) => setAmountReceived(netDue)}
+  />
+)}
+```
+
+- [ ] **Step 8.3: Extend JE preview to show 21-1103 lines**
+
+Find the JE preview block in the wizard (search for "Dr 11-2103" or "preview" or `previewLines`). Add lines for advance:
+
+```typescript
+// In the preview computation:
+const advanceCredit = detectedCase === 'OVERPAY_ADVANCE'
+  ? new Decimal(amountReceived).minus(amountDueDecimal.add(lateFeeDecimal).sub(amountPaidDecimal))
+  : new Decimal(0);
+
+const advanceConsume = (detectedCase === 'NORMAL' || detectedCase === 'UNDERPAY') &&
+  contract && new Decimal(contract.advanceBalance).gt(0) &&
+  new Decimal(amountReceived).lt(amountDueDecimal.add(lateFeeDecimal).sub(amountPaidDecimal))
+    ? Decimal.min(
+        new Decimal(contract.advanceBalance),
+        amountDueDecimal.add(lateFeeDecimal).sub(amountPaidDecimal).sub(new Decimal(amountReceived)),
+      )
+    : new Decimal(0);
+
+// Append preview lines:
+if (advanceCredit.gt(0)) {
+  previewLines.push({ accountCode: '21-1103', dr: 0, cr: advanceCredit.toNumber(), description: 'เงินรับล่วงหน้า' });
+}
+if (advanceConsume.gt(0)) {
+  previewLines.push({ accountCode: '21-1103', dr: advanceConsume.toNumber(), cr: 0, description: 'หักเงินรับล่วงหน้า' });
+}
+```
+
+(Adapt to existing variable names — the wizard's preview structure differs across versions.)
+
+- [ ] **Step 8.4: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add apps/web/src/pages/PaymentsPage/
+git commit -m "feat(payments/web): AdvanceBalanceBanner + 21-1103 in JE preview
+
+- Banner shown when contract.advanceBalance > 0 with one-tap apply
+- JE preview shows Cr 21-1103 (overpay) or Dr 21-1103 (consume)
+- Mirrors backend computation for cashier visibility"
+```
+
+---
+
+## Phase 5: Verification + PR
+
+### Task 9: Manual smoke test
+
+- [ ] **Step 9.1: Start dev servers**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && npm run dev
+```
+
+Wait until both API (3000) and Web (5173) are up.
+
+- [ ] **Step 9.2: Test scenario A — overpay**
+
+1. Login as `admin@bestchoice.com` / `admin1234`
+2. Open any active contract → `/payments` → pick งวด N
+3. In wizard: type `1600` for งวดที่ ค่างวด `1,515.83`
+4. Verify: blue banner "เกิน 84.17 ฿ — บันทึกเป็นเงินรับล่วงหน้า"
+5. Verify JE preview shows: Dr cash 1,600 / Cr 11-2103 1,515.83 / Cr 21-1103 84.17
+6. Click Save → success toast
+7. Reload contract detail → confirm `advanceBalance = 84.17`
+
+- [ ] **Step 9.3: Test scenario B — consume on next installment**
+
+1. Same contract, open งวด N+1 wizard
+2. Verify green banner: "ลูกค้ามีเงินล่วงหน้า 84.17 ฿ ... ยอดที่ต้องเก็บ 1,431.66 ฿"
+3. Click "ใช้ยอดนี้" → amountReceived field auto-fills `1431.66`
+4. Status badge: "NORMAL" / ตรงพอดี
+5. JE preview shows: Dr cash 1,431.66 / Dr 21-1103 84.17 / Cr 11-2103 1,515.83
+6. Save → success
+7. Reload → `advanceBalance = 0`
+
+- [ ] **Step 9.4: Test scenario C — underpay still blocked**
+
+1. Open งวด N+2, type `1400` (under by 115.83)
+2. Verify red badge "ห่างเกิน 1 ฿ — ใช้เมนูแบ่งชำระ/ปิดยอดแทน"
+3. Save button disabled
+
+- [ ] **Step 9.5: Stop dev servers**
+
+```bash
+# Ctrl+C the dev process or `pkill -f 'turbo|nest start'`
+```
+
+---
+
+### Task 10: Final TS + lint + PR
+
+- [ ] **Step 10.1: Full TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh all
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 10.2: Lint**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && npm run lint 2>&1 | tail -20
+```
+
+Fix any new errors introduced by this branch. Pre-existing warnings out of scope.
+
+- [ ] **Step 10.3: Run full payments test suite**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx jest src/modules/payments/ src/modules/journal/cpa-templates/ 2>&1 | tail -30
+```
+
+Expected: all pass (existing + new advance tests).
+
+- [ ] **Step 10.4: Push branch + create PR**
+
+```bash
+git push -u origin feat/payment-overpay-advance
+gh pr create --title "feat(payments): overpay > 1฿ → 21-1103 advance (auto-consume FIFO)" --body "$(cat <<'EOF'
+## Summary
+- Wizard accepts overpay > 1฿ tolerance (no longer blocked)
+- Excess parked in `21-1103 เงินรับล่วงหน้า` (per CSV plan)
+- Auto-consumed FIFO on next installment due
+- Reuses `reschedule-jp6` template pattern (Cr 21-1103 → Dr 21-1103)
+
+## Spec + Plan
+- Spec: \`docs/superpowers/specs/2026-05-06-payment-overpay-advance-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-06-payment-overpay-advance.md\`
+
+## Schema
+- Adds `Contract.advanceBalance Decimal @default(0)` (additive, safe migration)
+
+## Backend
+- `PaymentCase` enum extended with `OVERPAY_ADVANCE`
+- `PaymentReceipt2BTemplate` extended with `advanceCredit` / `advanceConsume` params
+- `recordPayment` computes split: overpay → balance += diff; underpay → balance -= consume
+- 3 new template tests + 4 new service tests
+
+## Frontend
+- `detectCase` considers `contract.advanceBalance` for effective due
+- New `OVERPAY_ADVANCE` badge (blue) — Save button enabled
+- New `AdvanceBalanceBanner` component with one-tap "use this amount"
+- JE preview shows 21-1103 line
+
+## Test plan
+- [ ] Login as admin → open contract → wizard
+- [ ] Type 1,600 for 1,515.83 installment → blue banner → save → contract.advanceBalance = 84.17
+- [ ] Open next installment → green banner → "ใช้ยอดนี้" → save → advance = 0
+- [ ] Underpay > 1฿ still blocked (regression check)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Note: per project memory (`feedback_no_auto_commit.md`), DO NOT push or open PR without explicit owner instruction. Wait for "push" / "create PR" before running this step.**
+
+---
+
+## Self-review
+
+- [ ] All 10 tasks completed with green checkmarks
+- [ ] `./tools/check-types.sh all` exits 0
+- [ ] All `apps/api` payment + template tests pass
+- [ ] Manual smoke (3 scenarios) passes
+- [ ] No `console.log` / `TODO` / `FIXME` markers introduced
+- [ ] No regression in existing rounding-tolerance behavior
+
+---
+
+## Out of scope (post-MVP)
+
+- Manual refund of advance (cash out)
+- Per-installment manual allocation (FIFO is automatic)
+- Customer-facing LIFF showing advance balance
+- Reports column "advance balance" on contracts list
+- Edge: contract closure with non-zero advance — current behavior is just leaves it; warning banner deferred
+
+---
+
+*End of plan.*

--- a/docs/superpowers/specs/2026-05-06-payment-overpay-advance-design.md
+++ b/docs/superpowers/specs/2026-05-06-payment-overpay-advance-design.md
@@ -1,0 +1,286 @@
+# Payment Overpay → Advance (21-1103) Design
+
+**Date:** 2026-05-06
+**Author:** owner + Claude
+**Status:** Design (approved sections 1-3, awaiting written-spec review)
+**Related:** Phase A.4 CPA Chart (PR #741), Reschedule JP6 template (existing pattern)
+
+## 1. Problem
+
+When a customer pays more than the installment amount + 1฿ tolerance, the wizard currently blocks save with a misleading message:
+
+> "ห่างเกิน 1 ฿ — ใช้เมนูแบ่งชำระ/ปิดยอดแทน"
+
+Real-world scenario (frequent for cash-paying customers): customer hands over 1,600฿ for an installment of 1,515.83฿ — they want to pay round numbers and have the extra credited toward the next installment.
+
+The CSV chart of accounts already plans for this case (see §3).
+
+## 2. CSV Plan (already in chart)
+
+| Code | Name | Purpose |
+|------|------|---------|
+| `21-1103` | เงินรับล่วงหน้า-ชำระก่อนครบกำหนด | "เงินที่ลูกค้าชำระล่วงหน้าก่อนถึงงวด **พักรอหักในงวดที่ถึงกำหนด**" |
+| `53-1503` | กำไร/ขาดทุนจากการปัดเศษ | Dr ขาด / Cr เกิน — **เฉพาะ ≤1฿ rounding** (existing tolerance, unchanged) |
+
+The plan is explicit: overpay > 1฿ is **not** rounding — it's a legitimate **advance payment** that posts to `21-1103` and gets consumed FIFO when the next installment comes due.
+
+The `reschedule-jp6.template.ts` already implements this exact pattern for reschedule fees:
+
+1. `recordFeeAdvance` — `Dr cash / Cr 21-1103` (park the advance)
+2. `consumeAdvanceOnFinalInstallment` — `Dr 21-1103 + Dr cash / Cr 11-2103` (drain when due)
+
+This design extends the same pattern to general overpayments.
+
+## 3. Architecture
+
+```
+PAYMENT (overpay):
+  Customer pays 1,600 for งวด 2 (ค่างวด 1,515.83)
+       ↓
+  Wizard detectCase → OVERPAY_ADVANCE (diff = +84.17)
+       ↓
+  POST /payments/:id { case: 'OVERPAY_ADVANCE', amountReceived: 1600 }
+       ↓
+  payments.service.recordPayment:
+    • Payment[งวด2].amountPaid = 1,515.83 (full installment)
+    • Payment[งวด2].status = 'PAID'
+    • Contract.advanceBalance += 84.17  ← denorm field (new)
+    • JE 2B (extended):
+        Dr 11-1101  1,600.00  (cash)
+        Cr 11-2101  1,515.83  (HP receivable)
+        Cr 21-1103     84.17  (advance — NEW LINE)
+
+NEXT INSTALLMENT (consume):
+  Open wizard for งวด 3
+       ↓
+  Banner shown: "ลูกค้ามีเงินล่วงหน้า 84.17 ฿"
+  Suggested amount: 1,515.83 - 84.17 = 1,431.66
+       ↓
+  Customer pays 1,431.66 → case = NORMAL (with auto-consume)
+       ↓
+  payments.service.recordPayment:
+    • Payment[งวด3].amountPaid = 1,515.83
+    • Contract.advanceBalance -= 84.17 → 0
+    • JE 2B (extended):
+        Dr 11-1101  1,431.66  (cash actually received)
+        Dr 21-1103     84.17  (consume advance — NEW LINE)
+        Cr 11-2101  1,515.83  (HP receivable cleared)
+```
+
+## 4. Components
+
+### 4.1 Schema change
+
+`apps/api/prisma/schema.prisma`:
+
+```prisma
+model Contract {
+  // ... existing fields ...
+  advanceBalance Decimal @default(0) @db.Decimal(12, 2)  // NEW
+}
+```
+
+Migration: `add_contract_advance_balance` — additive, default 0, safe for existing rows.
+
+### 4.2 Enum
+
+`apps/api/src/modules/payments/dto/payment.dto.ts`:
+
+```typescript
+export type PaymentCase =
+  | 'NORMAL'
+  | 'OVERPAY'           // ≤1฿ rounding — existing
+  | 'UNDERPAY'          // ≤1฿ rounding — existing
+  | 'PARTIAL'
+  | 'EARLY_PAYOFF'
+  | 'RESCHEDULE'
+  | 'OVERPAY_ADVANCE';  // NEW — overpay > 1฿
+```
+
+### 4.3 Service logic — `recordPayment`
+
+`apps/api/src/modules/payments/payments.service.ts`:
+
+```typescript
+async recordPayment(paymentId: string, dto: RecordPaymentDto, userId: string) {
+  return this.prisma.$transaction(async (tx) => {
+    const payment = await tx.payment.findUniqueOrThrow({ where: { id: paymentId }, include: { contract: true } });
+    const amountDue = new Decimal(payment.amountDue).plus(payment.lateFee).minus(payment.amountPaid);
+    const received = new Decimal(dto.amountReceived);
+    const advanceBalance = new Decimal(payment.contract.advanceBalance);
+
+    let advanceCredit = ZERO;   // post Cr 21-1103 (overpay → advance)
+    let advanceConsume = ZERO;  // post Dr 21-1103 (consume advance)
+    let cashAmount = received;
+
+    switch (dto.case) {
+      case 'OVERPAY_ADVANCE':
+        // Customer paid more than amountDue+1฿ → park excess
+        advanceCredit = received.minus(amountDue);
+        cashAmount = received;
+        // Update Payment: paid full amountDue
+        // Update Contract: advanceBalance += advanceCredit
+        break;
+
+      case 'NORMAL':
+      case 'OVERPAY':
+      case 'UNDERPAY':
+        // If contract has advance, consume FIFO
+        if (advanceBalance.gt(0) && received.lt(amountDue)) {
+          const gap = amountDue.minus(received);
+          advanceConsume = Decimal.min(advanceBalance, gap);
+          // Update Contract: advanceBalance -= advanceConsume
+        }
+        break;
+    }
+
+    // Update Payment row, Contract row
+    // Call PaymentReceipt2BTemplate with { advanceCredit, advanceConsume }
+  });
+}
+```
+
+### 4.4 Template extension
+
+`apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts`:
+
+```typescript
+export interface PaymentReceipt2BInput {
+  // ... existing fields ...
+  advanceCredit?: Decimal;   // Cr 21-1103 (overpay)
+  advanceConsume?: Decimal;  // Dr 21-1103 (use existing advance)
+}
+
+generate(input): JeLineInput[] {
+  const lines = [/* existing logic */];
+
+  if (input.advanceCredit?.gt(0)) {
+    lines.push({ accountCode: '21-1103', debit: ZERO, credit: input.advanceCredit, description: 'เงินรับล่วงหน้า' });
+  }
+  if (input.advanceConsume?.gt(0)) {
+    lines.push({ accountCode: '21-1103', debit: input.advanceConsume, credit: ZERO, description: 'หักเงินรับล่วงหน้า' });
+  }
+
+  // Edge: when 100% of installment is covered by advance, cashAmount=0 → skip Dr cash line
+  // (template's existing cash-line logic must already check `if (cashAmount.gt(0))`)
+
+  return lines;
+}
+```
+
+### 4.5 Frontend — wizard
+
+`apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx`:
+
+```typescript
+type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OVERPAY_ADVANCE' | 'OUT_OF_RANGE';
+
+function detectCase(
+  received: number,
+  expectedTotal: Decimal,
+  advanceBalance: Decimal = ZERO,
+): DetectedCase {
+  if (received <= 0 && advanceBalance.lt(expectedTotal)) return 'OUT_OF_RANGE';
+
+  // effective amount due = full installment minus advance available
+  // (advance auto-consumes FIFO, so cashier only collects the difference)
+  const effectiveDue = Decimal.max(ZERO, expectedTotal.minus(advanceBalance));
+  const diff = received - effectiveDue.toNumber();
+
+  if (received === 0 && advanceBalance.gte(expectedTotal)) return 'NORMAL'; // 100% from advance
+  if (Math.abs(diff) < 0.01) return 'NORMAL';
+  if (diff > 0 && diff <= 1) return 'OVERPAY';            // rounding
+  if (diff < 0 && diff >= -1) return 'UNDERPAY';          // rounding
+  if (diff > 1) return 'OVERPAY_ADVANCE';                 // overpay → grow advance
+  return 'OUT_OF_RANGE';                                  // diff < -1: still blocked
+}
+```
+
+`CaseBadge` component — add render branch for `OVERPAY_ADVANCE`:
+
+```tsx
+if (detectedCase === 'OVERPAY_ADVANCE') {
+  return (
+    <div className="rounded-lg border border-info/40 bg-info/5 px-3 py-2">
+      <span className="text-info font-medium">
+        เกิน {absDiff} ฿ — บันทึกเป็นเงินรับล่วงหน้า (หักงวดถัดไปอัตโนมัติ)
+      </span>
+    </div>
+  );
+}
+```
+
+Save button — enable for `OVERPAY_ADVANCE`:
+
+```typescript
+const submitDisabled =
+  detectedCase === 'OUT_OF_RANGE' ||
+  /* other existing conditions */;
+```
+
+JE preview — append `Cr 21-1103 {advanceCredit}` line when `OVERPAY_ADVANCE`.
+
+### 4.6 Frontend — AdvanceBalanceBanner
+
+New component, shown above amount field when `contract.advanceBalance > 0`:
+
+```tsx
+function AdvanceBalanceBanner({ amountDue, advanceBalance, onApply }: Props) {
+  const netDue = amountDue.minus(advanceBalance).toFixed(2);
+  return (
+    <div className="rounded-lg border border-success/40 bg-success/5 p-3">
+      <p className="text-sm font-medium">💰 ลูกค้ามีเงินล่วงหน้า {advanceBalance.toFixed(2)} ฿</p>
+      <p className="text-xs text-muted-foreground">ค่างวด {amountDue.toFixed(2)} − ล่วงหน้า {advanceBalance.toFixed(2)} = ยอดที่ต้องเก็บ {netDue}</p>
+      <button onClick={() => onApply(netDue)} className="text-xs underline mt-1">ใช้ยอดนี้</button>
+    </div>
+  );
+}
+```
+
+GET `/contracts/:id` response must include `advanceBalance: string`.
+
+## 5. Allocation strategy
+
+**FIFO** — advance is consumed against the **next earliest unpaid installment** automatically when that installment is recorded. No manual allocation in v1.
+
+Multi-installment overpay: if customer overpays งวด 2 by 2,000฿ (covering งวด 3 entirely + part of งวด 4):
+- v1 behavior: parks 2,000฿ in `21-1103`, consumes 1,515.83฿ from advance when งวด 3 recorded, leaves 484.17฿ for งวด 4
+- Wizard UX: cashier opens งวด 3 wizard, banner shows "ล่วงหน้า 2,000฿", suggests amountReceived = 0 (or 0.00 — fully covered by advance)
+- A purely-from-advance payment is a special edge case — ensure JE balances even when cashAmount = 0
+
+## 6. Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| Overpay covers entire next installment | Apply 100% from advance; cashAmount=0; Save button still works (no cash needed) |
+| Overpay > 1 future installment (e.g., 2 งวด) | Parks total; consumed FIFO across multiple ถัดไป |
+| Customer requests refund of advance | Manual journal — `Dr 21-1103 / Cr cash` (manager-approved, out of scope v1) |
+| Contract reposses/closes with advance > 0 | Manual handling at closure — flag in repossession flow (out of scope v1) |
+| Underpay > 1฿ | Still blocked — owner must use "แบ่งชำระ" flow (unchanged) |
+
+## 7. Acceptance criteria
+
+- [ ] `Contract.advanceBalance` field added via migration
+- [ ] PaymentCase enum extended with `OVERPAY_ADVANCE`
+- [ ] Wizard accepts overpay > 1฿ (Save button enabled)
+- [ ] Posting overpay creates `Cr 21-1103` line in JE
+- [ ] `Contract.advanceBalance` increments correctly
+- [ ] Next installment wizard shows AdvanceBalanceBanner with current balance
+- [ ] Recording next installment auto-consumes FIFO from advance
+- [ ] Posted JE balances (Dr = Cr) in all cases
+- [ ] `Contract.advanceBalance` decrements to 0 after full consume
+- [ ] Underpay > 1฿ still blocked (no regression)
+- [ ] All existing payment tests pass
+- [ ] 4 new tests: overpay, consume, multi-overpay, full-cover-by-advance
+
+## 8. Out of scope (v1)
+
+- Manual refund of advance balance (cash out)
+- Per-installment manual allocation (FIFO is automatic)
+- Advance display in customer-facing LIFF
+- Reporting (advance balance per contract on contracts list)
+- Edge: contract closure with non-zero advance (warn-only banner, manual ops)
+
+## 9. Open questions
+
+None — design follows existing patterns (reschedule-jp6) and CSV intent (`21-1103`).


### PR DESCRIPTION
## Summary
- Wizard accepts overpay > 1฿ tolerance (no longer blocked with "ใช้เมนูแบ่งชำระ/ปิดยอดแทน")
- Excess parked in `21-1103 เงินรับล่วงหน้า` (per CSV plan)
- Auto-consumed FIFO on next installment due
- Reuses `reschedule-jp6` template pattern (Cr 21-1103 → Dr 21-1103)

## Spec + Plan
- Spec: `docs/superpowers/specs/2026-05-06-payment-overpay-advance-design.md`
- Plan: `docs/superpowers/plans/2026-05-06-payment-overpay-advance.md`

## Schema
- Adds `Contract.advanceBalance Decimal @default(0)` (additive, safe migration)

## Backend
- `PaymentCase` enum extended with `OVERPAY_ADVANCE`
- `PaymentReceipt2BTemplate` extended with `advanceCredit` / `advanceConsume` params
- `recordPayment` computes split: overpay → balance += diff; underpay (NORMAL only) → balance -= consume
- `previewJournal` mirrors split logic so wizard preview matches save
- `AuditLog OVERPAY_ADVANCE_RECORDED` written on every advance-balance change
- 5 service tests + 3 template tests covering overpay/consume/multi-accumulate/full-cover

## Frontend
- `detectCase` considers `contract.advanceBalance` for effective due
- New blue `OVERPAY_ADVANCE` badge — Save button enabled
- New `AdvanceBalanceBanner` with one-tap "ใช้ยอดนี้"
- JE preview (server-fetched) shows 21-1103 line via mirrored backend logic

## Code review fixes (commit 720d3c99)
- [HIGH] Auto-consume gated on `paymentCase` (NORMAL/undefined only) — explicit flows skip
- [MED] `previewJournal` mirrors split logic
- [LOW] `AuditLog OVERPAY_ADVANCE_RECORDED` for forensics

## Test plan
- [ ] Login as admin → open contract → wizard
- [ ] Type 1,600 for 1,515.83 installment → blue badge → save → contract.advanceBalance = 84.17
- [ ] Open next installment → green banner → "ใช้ยอดนี้" → save → advance = 0
- [ ] Underpay > 1฿ still blocked (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)