### PR TITLE
fix(payments): prefer-const on mockPrismaInst (unblock PR #762 deploy)

### DIFF
--- a/apps/api/src/modules/payments/payments.service.advance.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.advance.spec.ts
@@ -145,8 +145,7 @@ describe('PaymentsService — advance balance (Task 4)', () => {
 
     // We need the mock instance to reference itself inside $transaction
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let mockPrismaInst: any;
-    mockPrismaInst = buildMockPrisma();
+    const mockPrismaInst: any = buildMockPrisma();
     prisma = mockPrismaInst;
 
     receipt2BExecute = jest.fn().mockResolvedValue({ entryNo: 'JE-ADV' });


### PR DESCRIPTION
Lint error blocked PR #762 deploy. `mockPrismaInst` declared with `let` but never reassigned → ESLint `prefer-const` error.

Single-line fix: `let → const`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)