### PR TITLE
feat(payments): underpay > 1฿ → PARTIAL (multi-receipt per installment)

### DIFF
--- a/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts
@@ -351,4 +351,34 @@ describe('PaymentReceipt2BTemplate', () => {
       expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
     });
   });
+
+  describe('partial clear', () => {
+    it('partial: posts only Dr cash + Cr 11-2103 (amount), no tolerance check', async () => {
+      const { inst, journal } = await setup();
+      const tmpl = new PaymentReceipt2BTemplate(journal, prisma as any);
+
+      const result = await tmpl.execute({
+        installmentScheduleId: inst.id,
+        amountReceived: new Decimal('800'),
+        depositAccountCode: '11-1101',
+        partialClear: true,
+      });
+      const je = await prisma.journalEntry.findFirstOrThrow({
+        where: { entryNumber: result.entryNo },
+        include: { lines: { orderBy: { createdAt: 'asc' } } },
+      });
+      expect(je.lines).toHaveLength(2);
+      const cash = je.lines.find((l) => l.accountCode === '11-1101')!;
+      expect(cash.debit.toString()).toBe('800');
+      expect(cash.credit.toString()).toBe('0');
+      const recv = je.lines.find((l) => l.accountCode === '11-2103')!;
+      expect(recv.debit.toString()).toBe('0');
+      expect(recv.credit.toString()).toBe('800');
+      expect(je.lines.find((l) => l.accountCode === '53-1503')).toBeUndefined();
+      expect(je.lines.find((l) => l.accountCode === '52-1104')).toBeUndefined();
+      const totalDr = je.lines.reduce((s, l) => s.plus(l.debit.toString()), new Decimal(0));
+      const totalCr = je.lines.reduce((s, l) => s.plus(l.credit.toString()), new Decimal(0));
+      expect(totalDr.eq(totalCr)).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts
@@ -31,6 +31,12 @@ export interface PaymentReceiptInput {
    * When provided, this amount supplements amountReceived to cover installmentTotal.
    */
   advanceConsume?: Decimal;
+  /**
+   * Customer pays less than the full installment intentionally.
+   * Skip tolerance check; emit only Dr cash X / Cr 11-2103 X (partial clear).
+   * Per CSV case-3-split-payment.csv pattern.
+   */
+  partialClear?: boolean;
 }
 
 /**
@@ -91,28 +97,31 @@ export class PaymentReceipt2BTemplate {
 
     const advCredit = input.advanceCredit ?? new Decimal(0);
     const advConsume = input.advanceConsume ?? new Decimal(0);
+    let roundingDiff = new Decimal(0);
 
-    // Effective rounding diff (subject to TOLERANCE):
-    //   amountReceived + advConsume - installmentTotal - advCredit
-    // Advance components are explicit by design; only the rounding remainder is
-    // checked against the 1฿ tolerance.
-    const roundingDiff = input.amountReceived
-      .plus(advConsume)
-      .minus(installmentTotal)
-      .minus(advCredit);
+    if (!input.partialClear) {
+      // Effective rounding diff (subject to TOLERANCE):
+      //   amountReceived + advConsume - installmentTotal - advCredit
+      // Advance components are explicit by design; only the rounding remainder is
+      // checked against the 1฿ tolerance.
+      roundingDiff = input.amountReceived
+        .plus(advConsume)
+        .minus(installmentTotal)
+        .minus(advCredit);
 
-    // Validate tolerance (before entering TX — fast-fail on bad input)
-    if (roundingDiff.abs().gt(TOLERANCE)) {
-      throw new BadRequestException(
-        `Payment difference ${roundingDiff.abs().toFixed(2)} exceeds tolerance 1.00`,
-      );
-    }
+      // Validate tolerance (before entering TX — fast-fail on bad input)
+      if (roundingDiff.abs().gt(TOLERANCE)) {
+        throw new BadRequestException(
+          `Payment difference ${roundingDiff.abs().toFixed(2)} exceeds tolerance 1.00`,
+        );
+      }
 
-    // Underpay requires approver
-    if (roundingDiff.lt(0) && !input.toleranceApproverId) {
-      throw new BadRequestException(
-        'Underpay tolerance requires approver (toleranceApproverId)',
-      );
+      // Underpay requires approver
+      if (roundingDiff.lt(0) && !input.toleranceApproverId) {
+        throw new BadRequestException(
+          'Underpay tolerance requires approver (toleranceApproverId)',
+        );
+      }
     }
 
     // Wrap Payment.create (if needed) + JE post + reversal in a single atomic transaction.
@@ -152,62 +161,78 @@ export class PaymentReceipt2BTemplate {
         description?: string;
       }[] = [];
 
-      // 1. Cash in (skip when 0 — full advance cover edge case)
-      if (input.amountReceived.gt(0)) {
+      if (input.partialClear) {
+        // CSV case-3 pattern: Dr cash + Cr 11-2103 = amount (partial clear)
         lines.push({
           accountCode: input.depositAccountCode,
           dr: input.amountReceived,
           cr: zero,
-          description: 'รับเงิน',
+          description: 'รับชำระบางส่วน',
         });
-      }
-
-      // 2. Consume existing advance
-      if (advConsume.gt(0)) {
         lines.push({
-          accountCode: '21-1103',
-          dr: advConsume,
-          cr: zero,
-          description: 'หักเงินรับล่วงหน้า',
-        });
-      }
-
-      // 3. Underpay rounding
-      if (roundingDiff.lt(0)) {
-        lines.push({
-          accountCode: '52-1104',
-          dr: roundingDiff.abs(),
-          cr: zero,
-          description: 'ส่วนลดเศษสตางค์ (Policy C)',
-        });
-      }
-
-      // 4. Clear receivable (always)
-      lines.push({
-        accountCode: '11-2103',
-        dr: zero,
-        cr: installmentTotal,
-        description: 'ล้างลูกหนี้ค้างชำระ',
-      });
-
-      // 5. Park new advance
-      if (advCredit.gt(0)) {
-        lines.push({
-          accountCode: '21-1103',
+          accountCode: '11-2103',
           dr: zero,
-          cr: advCredit,
-          description: 'เงินรับล่วงหน้า',
+          cr: input.amountReceived, // partial — NOT installmentTotal
+          description: 'ล้างลูกหนี้ค้างชำระ (บางส่วน)',
         });
-      }
+      } else {
+        // 1. Cash in (skip when 0 — full advance cover edge case)
+        if (input.amountReceived.gt(0)) {
+          lines.push({
+            accountCode: input.depositAccountCode,
+            dr: input.amountReceived,
+            cr: zero,
+            description: 'รับเงิน',
+          });
+        }
 
-      // 6. Overpay rounding
-      if (roundingDiff.gt(0)) {
+        // 2. Consume existing advance
+        if (advConsume.gt(0)) {
+          lines.push({
+            accountCode: '21-1103',
+            dr: advConsume,
+            cr: zero,
+            description: 'หักเงินรับล่วงหน้า',
+          });
+        }
+
+        // 3. Underpay rounding
+        if (roundingDiff.lt(0)) {
+          lines.push({
+            accountCode: '52-1104',
+            dr: roundingDiff.abs(),
+            cr: zero,
+            description: 'ส่วนลดเศษสตางค์ (Policy C)',
+          });
+        }
+
+        // 4. Clear receivable (always)
         lines.push({
-          accountCode: '53-1503',
+          accountCode: '11-2103',
           dr: zero,
-          cr: roundingDiff,
-          description: 'กำไรปัดเศษ (Policy C)',
+          cr: installmentTotal,
+          description: 'ล้างลูกหนี้ค้างชำระ',
         });
+
+        // 5. Park new advance
+        if (advCredit.gt(0)) {
+          lines.push({
+            accountCode: '21-1103',
+            dr: zero,
+            cr: advCredit,
+            description: 'เงินรับล่วงหน้า',
+          });
+        }
+
+        // 6. Overpay rounding
+        if (roundingDiff.gt(0)) {
+          lines.push({
+            accountCode: '53-1503',
+            dr: zero,
+            cr: roundingDiff,
+            description: 'กำไรปัดเศษ (Policy C)',
+          });
+        }
       }
 
       const result = await this.journal.createAndPost(

--- a/apps/api/src/modules/payments/payments.service.advance.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.advance.spec.ts
@@ -374,4 +374,89 @@ describe('PaymentsService — advance balance (Task 4)', () => {
       ),
     ).rejects.toThrow(BadRequestException);
   });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // PARTIAL case tests (Task 2)
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('PARTIAL case', () => {
+    it('partial 800 of 1000 → status PARTIALLY_PAID, partialClear flag passed to template', async () => {
+      // Return an installmentSchedule so the template is actually called
+      prisma.installmentSchedule.findUnique.mockResolvedValueOnce({ id: 'sch-partial-1' });
+      prisma.payment.findFirst.mockResolvedValueOnce(makePayment(7));
+
+      await service.recordPayment(
+        'adv-contract-1',
+        7,
+        800, // 200 shortage → requires PARTIAL
+        'CASH',
+        'user-1',
+        undefined,
+        undefined,
+        'TEST-P1',
+        '11-1101',
+        undefined,
+        'PARTIAL',
+      );
+
+      expect(receipt2BExecute).toHaveBeenCalledWith(
+        expect.objectContaining({ partialClear: true }),
+      );
+
+      expect(prisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'PARTIALLY_PAID' }),
+        }),
+      );
+    });
+
+    it('shortage > 1฿ without case=PARTIAL throws BadRequestException', async () => {
+      prisma.payment.findFirst.mockResolvedValueOnce(makePayment(8));
+
+      await expect(
+        service.recordPayment(
+          'adv-contract-1',
+          8,
+          800, // 200 shortage — no explicit PARTIAL case
+          'CASH',
+          'user-1',
+          undefined,
+          undefined,
+          'TEST-P2',
+          '11-1101',
+        ),
+      ).rejects.toThrow(/PARTIAL/);
+    });
+
+    it('re-pay full remainder after partial → status PAID, partialClear NOT passed', async () => {
+      // Simulate installment 9 with prevPaid = 800 (PARTIALLY_PAID)
+      prisma.payment.findFirst.mockResolvedValueOnce(
+        makePayment(9, { amountPaid: D(800), status: 'PARTIALLY_PAID' }),
+      );
+      // Return an installmentSchedule for the template call
+      prisma.installmentSchedule.findUnique.mockResolvedValueOnce({ id: 'sch-partial-3' });
+
+      await service.recordPayment(
+        'adv-contract-1',
+        9,
+        200, // 800 prevPaid + 200 cash = 1000 = PAID in full
+        'CASH',
+        'user-1',
+        undefined,
+        undefined,
+        'TEST-P3',
+        '11-1101',
+      );
+
+      // partialClear should NOT be set (shortage = 0)
+      expect(receipt2BExecute).toHaveBeenCalledWith(
+        expect.not.objectContaining({ partialClear: true }),
+      );
+
+      expect(prisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'PAID' }),
+        }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -229,6 +229,7 @@ export class PaymentsService {
       let advanceCredit = d(0);
       let advanceConsume = d(0);
       const beforeAdvance = d(contract.advanceBalance ?? 0);
+      let isPartialClear = false;
 
       if (overage.gt(d('1.00'))) {
         // Overpay > tolerance — must explicitly opt into advance posting
@@ -247,6 +248,18 @@ export class PaymentsService {
         // are explicit flows where the caller controls allocation directly.
         const gap = remaining.minus(d(amount));
         advanceConsume = Prisma.Decimal.min(beforeAdvance, gap);
+      }
+
+      // NEW: shortage > 1฿ requires explicit case='PARTIAL'.
+      // Compute shortage AFTER advanceConsume (advance covers part of the gap).
+      const shortage = remaining.minus(d(amount)).minus(advanceConsume);
+      if (shortage.gt(d('1.00'))) {
+        if (paymentCase !== 'PARTIAL') {
+          throw new BadRequestException(
+            `จำนวนเงินน้อยกว่ายอดที่ต้องชำระ (ยอดที่ต้องชำระ ${remaining.toNumber().toLocaleString()} บาท, ชำระ ${amount.toLocaleString()} บาท) — เลือก case 'PARTIAL' เพื่อบันทึกเป็นจ่ายบางส่วน`,
+          );
+        }
+        isPartialClear = true;
       }
 
       // For OVERPAY_ADVANCE: amountPaid = installmentTotal (full clear via cash + advance posting).
@@ -309,9 +322,10 @@ export class PaymentsService {
       }
 
       // Phase A.4b: replaced createPaymentJournal (old stub) with PaymentReceipt2BTemplate.
-      // Template is called only on full payment. It runs inside the same $transaction so
-      // a JE failure rolls back the Payment.update — no orphan ledger entries.
-      if (isPaidInFull) {
+      // Template is called on full payment OR partial payment (isPartialClear).
+      // It runs inside the same $transaction so a JE failure rolls back the
+      // Payment.update — no orphan ledger entries.
+      if (isPaidInFull || isPartialClear) {
         const instSched = await tx.installmentSchedule.findUnique({
           where: {
             contractId_installmentNo: {
@@ -330,6 +344,7 @@ export class PaymentsService {
             existingPaymentId: result.id,
             advanceCredit: advanceCredit.gt(0) ? advanceCredit : undefined,
             advanceConsume: advanceConsume.gt(0) ? advanceConsume : undefined,
+            partialClear: isPartialClear ? true : undefined,
           });
         } else {
           this.logger.warn(
@@ -1571,7 +1586,39 @@ export class PaymentsService {
       };
     }
 
-    // ── Normal / Overpay / Underpay / Partial / EarlyPayoff ─────────────────
+    // ── PARTIAL case: minimal partial-clear preview ─────────────────────────
+    if (input.case === 'PARTIAL') {
+      const amountReceived = new Prisma.Decimal(input.amountReceived.toString());
+      rawLines.push({ code: input.depositAccountCode, dr: amountReceived, cr: zero, description: 'รับชำระบางส่วน' });
+      rawLines.push({ code: '11-2103', dr: zero, cr: amountReceived, description: 'ล้างลูกหนี้ค้างชำระ (บางส่วน)' });
+
+      const codes = [...new Set(rawLines.map((l) => l.code))];
+      const coaRows = await this.prisma.chartOfAccount.findMany({
+        where: { code: { in: codes } },
+        select: { code: true, name: true },
+      });
+      const nameMap = new Map(coaRows.map((r) => [r.code, r.name]));
+      let totalDebit = zero;
+      let totalCredit = zero;
+      for (const l of rawLines) {
+        totalDebit = totalDebit.plus(l.dr);
+        totalCredit = totalCredit.plus(l.cr);
+      }
+      return {
+        lines: rawLines.map((l) => ({
+          accountCode: l.code,
+          accountName: nameMap.get(l.code) ?? l.code,
+          debit: l.dr.toFixed(2),
+          credit: l.cr.toFixed(2),
+          description: l.description,
+        })),
+        totalDebit: totalDebit.toFixed(2),
+        totalCredit: totalCredit.toFixed(2),
+        isBalanced: totalDebit.toFixed(2) === totalCredit.toFixed(2),
+      };
+    }
+
+    // ── Normal / Overpay / Underpay / EarlyPayoff (existing logic continues) ─
     const amountReceived = new Prisma.Decimal(input.amountReceived.toString());
     const isConsolidated = !inst.accrualJournalEntryId; // 2A not yet run
 

--- a/apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx
@@ -90,6 +90,14 @@ export default function PaymentTable({
       key: 'status',
       label: 'สถานะ',
       render: (p: PendingPayment) => {
+        if (p.status === 'PARTIALLY_PAID') {
+          const owed = (parseFloat(p.amountDue) + parseFloat(p.lateFee)) - parseFloat(p.amountPaid);
+          return (
+            <Badge variant="warning" appearance="default" size="md">
+              ค้าง {owed.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿
+            </Badge>
+          );
+        }
         const cfg = getStatusBadgeProps(p.status, paymentStatusMap);
         return <Badge variant={cfg.variant} appearance={cfg.appearance} size="sm">{cfg.label}</Badge>;
       },

--- a/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+++ b/apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import Decimal from 'decimal.js';
 import {
@@ -40,7 +41,7 @@ import { AdvanceBalanceBanner } from './AdvanceBalanceBanner';
  * Auto-detected payment case (computed from amount diff client-side).
  * RESCHEDULE / EARLY_PAYOFF are handled in separate contract-detail pages, not here.
  */
-type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OVERPAY_ADVANCE' | 'OUT_OF_RANGE';
+type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OVERPAY_ADVANCE' | 'PARTIAL' | 'OUT_OF_RANGE';
 
 /** Legacy type kept for API compatibility — backend accepts all 7 values */
 type PaymentCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'PARTIAL' | 'EARLY_PAYOFF' | 'RESCHEDULE' | 'OVERPAY_ADVANCE';
@@ -110,12 +111,30 @@ function ContractInfoPanel({
           `${lateFee.toNumber().toLocaleString('th-TH', { minimumFractionDigits: 2 })} ฿`,
           true,
         )}
+      {amountPaid.gt(0) && (
+        <>
+          {row(
+            'จ่ายแล้ว',
+            <span className="text-muted-foreground font-mono">
+              {amountPaid.toNumber().toLocaleString('th-TH', { minimumFractionDigits: 2 })} ฿
+            </span>,
+          )}
+          <div className="flex justify-between text-sm py-1 border-b border-border/50 border-t mt-1 pt-1">
+            <span className="text-warning font-bold leading-snug">ยอดเหลือ</span>
+            <span className="text-warning font-bold font-mono leading-snug">
+              {totalDue.toNumber().toLocaleString('th-TH', { minimumFractionDigits: 2 })} ฿
+            </span>
+          </div>
+        </>
+      )}
+      {amountPaid.lte(0) && (
       <div className="flex justify-between text-sm pt-2 font-bold">
         <span className="leading-snug">ยอดรวมต้องชำระ</span>
         <span className="text-primary leading-snug">
           {totalDue.toNumber().toLocaleString('th-TH', { minimumFractionDigits: 2 })} ฿
         </span>
       </div>
+      )}
       <div className="pt-2 mt-1 border-t border-border">
         <div className="flex justify-between text-xs text-muted-foreground">
           <span className="leading-snug">Net Exposure</span>
@@ -188,6 +207,17 @@ function CaseBadge({
         <Info className="size-4 text-info shrink-0" />
         <span className="text-info font-medium leading-snug">
           เกิน {absDiff} ฿ — บันทึกเป็นเงินรับล่วงหน้า (หักงวดถัดไปอัตโนมัติ)
+        </span>
+      </div>
+    );
+  }
+
+  if (detectedCase === 'PARTIAL') {
+    return (
+      <div className="flex items-center gap-1.5 rounded-lg border border-warning/40 bg-warning/5 px-3 py-2 text-sm">
+        <AlertCircle className="size-4 text-warning shrink-0" />
+        <span className="text-warning font-medium leading-snug">
+          จ่ายขาด {absDiff} ฿ — บันทึกบางส่วน ลูกค้าค้าง {absDiff} ฿ ต่อ
         </span>
       </div>
     );
@@ -362,7 +392,8 @@ function detectCase(
   if (diff > 0 && diff <= 1) return 'OVERPAY';            // rounding (gain)
   if (diff < 0 && diff >= -1) return 'UNDERPAY';          // rounding (loss, requires approver)
   if (diff > 1) return 'OVERPAY_ADVANCE';                 // pay > installment+1฿ → park excess
-  return 'OUT_OF_RANGE';                                  // diff < -1: still blocked → use แบ่งชำระ
+  if (diff < -1) return 'PARTIAL';                        // paid something but not enough → partial payment
+  return 'OUT_OF_RANGE';                                  // only reached when received <= 0 edge cases
 }
 
 /** Map auto-detected case to the API PaymentCase param (best fit) */
@@ -370,6 +401,7 @@ function toApiCase(detected: DetectedCase): PaymentCase {
   if (detected === 'OVERPAY') return 'OVERPAY';
   if (detected === 'UNDERPAY') return 'UNDERPAY';
   if (detected === 'OVERPAY_ADVANCE') return 'OVERPAY_ADVANCE';
+  if (detected === 'PARTIAL') return 'PARTIAL';
   return 'NORMAL'; // OUT_OF_RANGE should never reach API (submit blocked)
 }
 
@@ -406,6 +438,7 @@ export function RecordPaymentWizard({
   defaultDepositAccountCode = '11-1101',
 }: RecordPaymentWizardProps) {
   const [depositAccountCode, setDepositAccountCode] = useState(defaultDepositAccountCode);
+  const [showPartialConfirm, setShowPartialConfirm] = useState(false);
 
   // Amount fields
   const lateFeeDecimal = useMemo(() => new Decimal(payment.lateFee), [payment.lateFee]);
@@ -530,6 +563,7 @@ export function RecordPaymentWizard({
   );
   const debouncedParams = useDebounce(previewParams, 300);
 
+  // PARTIAL is now a valid case that can be submitted — treat same as other valid cases
   const isPreviewReady: boolean =
     detectedCase !== 'OUT_OF_RANGE' &&
     // Allow 0 cash when advance fully covers installment (detectCase = NORMAL)
@@ -564,7 +598,8 @@ export function RecordPaymentWizard({
     return true;
   };
 
-  const handleSubmit = () => {
+  const actuallySubmit = () => {
+    setShowPartialConfirm(false);
     onSubmit({
       contractId: payment.contract.id,
       installmentNo: payment.installmentNo,
@@ -583,6 +618,14 @@ export function RecordPaymentWizard({
       slipUrl: slipUrl || undefined,
       memo: memo || undefined,
     });
+  };
+
+  const handleSubmit = () => {
+    if (detectedCase === 'PARTIAL') {
+      setShowPartialConfirm(true);
+      return;
+    }
+    actuallySubmit();
   };
 
   const handleOpenChange = (isOpen: boolean) => {
@@ -879,6 +922,17 @@ export function RecordPaymentWizard({
           </Button>
         </DialogFooter>
       </DialogContent>
+
+      {/* Partial payment confirmation gate */}
+      <ConfirmDialog
+        open={showPartialConfirm}
+        onOpenChange={setShowPartialConfirm}
+        title="ยืนยันบันทึกบางส่วน"
+        description={`ค่างวด ${expectedTotal.toFixed(2)} ฿ • ลูกค้าจ่าย ${(receivedNum).toFixed(2)} ฿ • ค้าง ${Math.abs(amountDiff).toFixed(2)} ฿. ลูกค้าจะค้างยอดนี้จนกว่าจะจ่ายเพิ่ม.`}
+        confirmLabel="ยืนยันบันทึก"
+        cancelLabel="ยกเลิก"
+        onConfirm={actuallySubmit}
+      />
     </Dialog>
   );
 }

--- a/docs/superpowers/plans/2026-05-07-payment-partial.md
+++ b/docs/superpowers/plans/2026-05-07-payment-partial.md
@@ -1,0 +1,785 @@
+# Payment Partial (Underpay > 1฿) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend wizard + backend to handle underpay > 1฿ as `case='PARTIAL'`. Cashier confirms via dialog → `Payment.amountPaid` accumulates → status `PARTIALLY_PAID` until total reaches `amountDue`. Re-payment uses the same wizard re-opening; list row shows "ค้าง XXX ฿" chip.
+
+**Architecture:** Mirror PR #762 OVERPAY_ADVANCE pattern. Add `partialClear?: boolean` flag to `PaymentReceipt2BTemplate`; when set, skip tolerance + emit only `Dr cash X / Cr 11-2103 X` (per CSV `case-3-split-payment.csv`). Service detects shortage > 1฿ + requires `paymentCase='PARTIAL'`. No schema change, no enum change.
+
+**Tech Stack:** NestJS + Prisma (api), React 18 + TypeScript + Decimal.js (web)
+
+---
+
+## File Inventory
+
+### Backend
+- **Modify** `apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts` — add `partialClear?: boolean` input, when set → skip tolerance check + emit minimal partial JE
+- **Modify** `apps/api/src/modules/payments/payments.service.ts` — `recordPayment` shortage check + pass `partialClear` to template; `previewJournal` PARTIAL branch
+- **Test** `apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts` — append 1 new test (partial clear)
+- **Test** `apps/api/src/modules/payments/payments.service.advance.spec.ts` — append 3 new tests (partial / re-pay / multi-receipt)
+
+### Frontend
+- **Modify** `apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx` — extend `DetectedCase`, `detectCase()`, `CaseBadge`; add ConfirmDialog gate before submit
+- **Modify** `apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx` — replace small status badge with prominent "ค้าง XXX ฿" chip when status=PARTIALLY_PAID
+
+---
+
+## Phases
+
+1. **Backend — template** (T1)
+2. **Backend — service + preview** (T2)
+3. **Frontend — wizard + dialog** (T3)
+4. **Frontend — list chip** (T4)
+5. **Verification** (T5)
+
+---
+
+## Phase 1: Backend template
+
+### Task 1: Extend `PaymentReceipt2BTemplate` with `partialClear` flag (TDD)
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts`
+- Test: `apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts`
+
+- [ ] **Step 1.1: Add input field**
+
+In `payment-receipt-2b.template.ts`, extend `PaymentReceiptInput`:
+
+```typescript
+export interface PaymentReceiptInput {
+  installmentScheduleId: string;
+  amountReceived: Decimal;
+  depositAccountCode: string;
+  toleranceApproverId?: string;
+  existingPaymentId?: string;
+  advanceCredit?: Decimal;
+  advanceConsume?: Decimal;
+  /**
+   * Customer pays less than the full installment intentionally.
+   * Skip tolerance check; emit only Dr cash X / Cr 11-2103 X (partial clear).
+   * Per CSV case-3-split-payment.csv pattern.
+   */
+  partialClear?: boolean;
+}
+```
+
+- [ ] **Step 1.2: Write failing test**
+
+Append to `payment-receipt-2b.template.spec.ts` inside the existing describe block (just before the closing brace):
+
+```typescript
+  describe('partial clear', () => {
+    it('partial: posts only Dr cash + Cr 11-2103 (amount), no tolerance check', async () => {
+      // installmentTotal = 1515.83, customer pays 800
+      const result = await template.execute({
+        installmentScheduleId: inst.id,
+        amountReceived: new Decimal('800'),
+        depositAccountCode: '11-1101',
+        partialClear: true,
+      });
+      const je = await prisma.journalEntry.findUnique({
+        where: { entryNumber: result.entryNo },
+        include: { lines: { orderBy: { lineNo: 'asc' } } },
+      });
+      expect(je!.lines).toHaveLength(2);
+      const cash = je!.lines.find((l) => l.accountCode === '11-1101')!;
+      expect(cash.debit.toString()).toBe('800');
+      expect(cash.credit.toString()).toBe('0');
+      const recv = je!.lines.find((l) => l.accountCode === '11-2103')!;
+      expect(recv.debit.toString()).toBe('0');
+      expect(recv.credit.toString()).toBe('800'); // partial — NOT installmentTotal
+      // No 53-1503 / 52-1104 lines
+      expect(je!.lines.find((l) => l.accountCode === '53-1503')).toBeUndefined();
+      expect(je!.lines.find((l) => l.accountCode === '52-1104')).toBeUndefined();
+      // Balanced
+      const totalDr = je!.lines.reduce((s, l) => s.plus(l.debit), new Decimal(0));
+      const totalCr = je!.lines.reduce((s, l) => s.plus(l.credit), new Decimal(0));
+      expect(totalDr.eq(totalCr)).toBe(true);
+    });
+  });
+```
+
+- [ ] **Step 1.3: Run failing test**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && DATABASE_URL=postgresql://localhost:5432/bestchoice_oi_test npx vitest run src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts -t "partial"
+```
+
+Expected: FAIL — `partialClear` field unknown OR template throws tolerance error.
+
+- [ ] **Step 1.4: Implement partial branch in `execute()`**
+
+In `payment-receipt-2b.template.ts`, find the start of the line-building block (after the rounding diff check, around the `lines: { ... }[] = []` declaration). Add a partialClear branch BEFORE the existing logic:
+
+```typescript
+      const lines: {
+        accountCode: string;
+        dr: Decimal;
+        cr: Decimal;
+        description?: string;
+      }[] = [];
+
+      // Partial clear: skip tolerance + advance + rounding logic.
+      // Emit only Dr cash + Cr 11-2103 (per CSV case-3 pattern).
+      if (input.partialClear) {
+        lines.push({
+          accountCode: input.depositAccountCode,
+          dr: input.amountReceived,
+          cr: zero,
+          description: 'รับชำระบางส่วน',
+        });
+        lines.push({
+          accountCode: '11-2103',
+          dr: zero,
+          cr: input.amountReceived, // partial — NOT installmentTotal
+          description: 'ล้างลูกหนี้ค้างชำระ (บางส่วน)',
+        });
+      } else {
+        // ... existing 6-step logic (cash, advance consume, underpay, clear, advance credit, overpay) ...
+      }
+```
+
+Wrap the existing 6-step line-building (cash/advConsume/underpayRounding/clearReceivable/advCredit/overpayRounding) inside the `else` branch.
+
+Also wrap the **tolerance check** (`if (roundingDiff.abs().gt(TOLERANCE))`) and **underpay-requires-approver check** in a `if (!input.partialClear)` guard so they don't fire on partial:
+
+```typescript
+    const advCredit = input.advanceCredit ?? new Decimal(0);
+    const advConsume = input.advanceConsume ?? new Decimal(0);
+
+    if (!input.partialClear) {
+      const roundingDiff = input.amountReceived
+        .plus(advConsume)
+        .minus(installmentTotal)
+        .minus(advCredit);
+
+      if (roundingDiff.abs().gt(TOLERANCE)) {
+        throw new BadRequestException(
+          `Payment difference ${roundingDiff.abs().toFixed(2)} exceeds tolerance 1.00`,
+        );
+      }
+
+      if (roundingDiff.lt(0) && !input.toleranceApproverId) {
+        throw new BadRequestException(
+          'Underpay tolerance requires approver (toleranceApproverId)',
+        );
+      }
+    }
+```
+
+For the `roundingDiff` variable used later inside the line-builder (in the `else` branch), keep it scoped or recompute inside the branch. Simplest: declare `roundingDiff` outside the `if`, default to `new Decimal(0)` when partial:
+
+```typescript
+    let roundingDiff = new Decimal(0);
+    if (!input.partialClear) {
+      roundingDiff = input.amountReceived
+        .plus(advConsume)
+        .minus(installmentTotal)
+        .minus(advCredit);
+      // ... validation as above ...
+    }
+```
+
+- [ ] **Step 1.5: Run test to pass**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && DATABASE_URL=postgresql://localhost:5432/bestchoice_oi_test npx vitest run src/modules/journal/cpa-templates/payment-receipt-2b.template.spec.ts
+```
+
+Expected: 10/10 pass (9 existing + 1 new partial).
+
+- [ ] **Step 1.6: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add apps/api/src/modules/journal/cpa-templates/
+git commit -m "$(cat <<'EOF'
+feat(payments): extend 2B template with partialClear flag
+
+- Cr 11-2103 = amount (partial clear, NOT installmentTotal)
+- Skip tolerance + underpay-approver checks when partialClear=true
+- No advance / VAT / WHT / rounding lines on partial path
+- Mirrors CSV case-3-split-payment pattern (multi-receipt per installment)
+- 1 new TDD test covers partial clear
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2: Backend service + preview
+
+### Task 2: `recordPayment` shortage check + `previewJournal` PARTIAL branch (TDD)
+
+**Files:**
+- Modify: `apps/api/src/modules/payments/payments.service.ts`
+- Test: `apps/api/src/modules/payments/payments.service.advance.spec.ts`
+
+- [ ] **Step 2.1: Add shortage check to `recordPayment`**
+
+In `payments.service.ts:107` (`recordPayment`), find the existing OVERPAY_ADVANCE block (around line 224-260, the `if (overage.gt(d('1.00')))` block). Add the mirror shortage block right after it:
+
+```typescript
+      const overage = d(amount).minus(remaining);
+      let advanceCredit = d(0);
+      let advanceConsume = d(0);
+      const beforeAdvance = d(contract.advanceBalance ?? 0);
+      let isPartialClear = false;
+
+      if (overage.gt(d('1.00'))) {
+        if (paymentCase !== 'OVERPAY_ADVANCE') {
+          throw new BadRequestException(
+            `จำนวนเงินเกินยอดค้างชำระ (ยอดค้าง ${remaining.toNumber().toLocaleString()} บาท, ชำระ ${amount.toLocaleString()} บาท) — ต้องเลือก case 'OVERPAY_ADVANCE' เพื่อบันทึกส่วนเกินเป็นเงินรับล่วงหน้า`,
+          );
+        }
+        advanceCredit = overage;
+      } else if (
+        d(amount).lt(remaining) &&
+        beforeAdvance.gt(0) &&
+        (paymentCase === undefined || paymentCase === 'NORMAL')
+      ) {
+        const gap = remaining.minus(d(amount));
+        advanceConsume = Prisma.Decimal.min(beforeAdvance, gap);
+      }
+
+      // NEW: shortage > 1฿ requires explicit PARTIAL flag
+      const shortage = remaining.minus(d(amount)).minus(advanceConsume);
+      if (shortage.gt(d('1.00'))) {
+        if (paymentCase !== 'PARTIAL') {
+          throw new BadRequestException(
+            `จำนวนเงินน้อยกว่ายอดที่ต้องชำระ (ยอดที่ต้องชำระ ${remaining.toNumber().toLocaleString()} บาท, ชำระ ${amount.toLocaleString()} บาท) — เลือก case 'PARTIAL' เพื่อบันทึกเป็นจ่ายบางส่วน`,
+          );
+        }
+        isPartialClear = true;
+      }
+```
+
+- [ ] **Step 2.2: Update `recordedAmountPaid` + status**
+
+Find the existing block:
+```typescript
+      const recordedAmountPaid =
+        paymentCase === 'OVERPAY_ADVANCE' ? remaining : dAdd(prevPaid, amount).plus(advanceConsume);
+
+      const isPaidInFull =
+        paymentCase === 'OVERPAY_ADVANCE' ? true : dGte(recordedAmountPaid, amountDue);
+```
+
+No change needed — `dGte(recordedAmountPaid, amountDue)` already returns `false` for partial (where `prevPaid + amount + 0 < amountDue`), and the existing `status: isPaidInFull ? 'PAID' : 'PARTIALLY_PAID'` handles it correctly.
+
+- [ ] **Step 2.3: Pass `partialClear` to template**
+
+Find the existing `paymentReceipt2BTemplate.execute({...})` call. Add `partialClear`:
+
+```typescript
+          await this.paymentReceipt2BTemplate.execute({
+            installmentScheduleId: instSched.id,
+            amountReceived: new Prisma.Decimal(amount.toString()),
+            depositAccountCode: resolvedDepositAccountCode,
+            toleranceApproverId: toleranceApproverId,
+            existingPaymentId: result.id,
+            advanceCredit: advanceCredit.gt(0) ? advanceCredit : undefined,
+            advanceConsume: advanceConsume.gt(0) ? advanceConsume : undefined,
+            partialClear: isPartialClear ? true : undefined,
+          });
+```
+
+- [ ] **Step 2.4: Add PARTIAL branch to `previewJournal`**
+
+In `previewJournal` (around line 1442), find the "Normal / Overpay / Underpay / Partial / EarlyPayoff" branch (around line 1551). At the top of that branch (right after the existing RESCHEDULE early-return), add:
+
+```typescript
+    // ── PARTIAL case: minimal partial-clear preview ─────────────────────────
+    if (input.case === 'PARTIAL') {
+      const amountReceived = new Prisma.Decimal(input.amountReceived.toString());
+      rawLines.push({ code: input.depositAccountCode, dr: amountReceived, cr: zero, description: 'รับชำระบางส่วน' });
+      rawLines.push({ code: '11-2103', dr: zero, cr: amountReceived, description: 'ล้างลูกหนี้ค้างชำระ (บางส่วน)' });
+
+      // Resolve names + return balanced
+      const codes = [...new Set(rawLines.map((l) => l.code))];
+      const coaRows = await this.prisma.chartOfAccount.findMany({
+        where: { code: { in: codes } },
+        select: { code: true, name: true },
+      });
+      const nameMap = new Map(coaRows.map((r) => [r.code, r.name]));
+      let totalDebit = zero;
+      let totalCredit = zero;
+      for (const l of rawLines) {
+        totalDebit = totalDebit.plus(l.dr);
+        totalCredit = totalCredit.plus(l.cr);
+      }
+      return {
+        lines: rawLines.map((l) => ({
+          accountCode: l.code,
+          accountName: nameMap.get(l.code) ?? l.code,
+          debit: l.dr.toFixed(2),
+          credit: l.cr.toFixed(2),
+          description: l.description,
+        })),
+        totalDebit: totalDebit.toFixed(2),
+        totalCredit: totalCredit.toFixed(2),
+        isBalanced: totalDebit.toFixed(2) === totalCredit.toFixed(2),
+      };
+    }
+
+    // ── Normal / Overpay / Underpay / EarlyPayoff (existing logic continues) ─
+```
+
+- [ ] **Step 2.5: Write failing service tests**
+
+Append to `apps/api/src/modules/payments/payments.service.advance.spec.ts` inside the existing describe block:
+
+```typescript
+  describe('PARTIAL case', () => {
+    it('partial 800 of 1000 → status PARTIALLY_PAID, amountPaid=800', async () => {
+      // Use existing buildMockPrisma + service from outer setup
+      // Seed payment row with amountDue=1000, amountPaid=0, lateFee=0
+      mockPrismaInst.payment.findFirst.mockResolvedValueOnce({
+        id: 'p-partial-1', contractId: 'c-1', installmentNo: 1,
+        amountDue: new Decimal(1000), amountPaid: new Decimal(0), lateFee: new Decimal(0),
+        status: 'PENDING', dueDate: new Date(), notes: '',
+      });
+
+      const updated = { id: 'p-partial-1', status: 'PARTIALLY_PAID', amountPaid: new Decimal(800) };
+      mockPrismaInst.payment.update.mockResolvedValueOnce(updated);
+
+      const result = await service.recordPayment(
+        'c-1', 1, 800, 'CASH', 'u-1',
+        undefined, undefined, 'TEST-P1', '11-1101', undefined,
+        'PARTIAL',
+      );
+
+      expect(mockPrismaInst.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            amountPaid: expect.any(Object), // Decimal(800)
+            status: 'PARTIALLY_PAID',
+          }),
+        }),
+      );
+      // partialClear should be passed to template
+      expect(receipt2BExecute).toHaveBeenCalledWith(expect.objectContaining({ partialClear: true }));
+    });
+
+    it('rejects shortage > 1฿ when paymentCase !== PARTIAL', async () => {
+      mockPrismaInst.payment.findFirst.mockResolvedValueOnce({
+        id: 'p-partial-2', contractId: 'c-1', installmentNo: 2,
+        amountDue: new Decimal(1000), amountPaid: new Decimal(0), lateFee: new Decimal(0),
+        status: 'PENDING', dueDate: new Date(), notes: '',
+      });
+
+      await expect(
+        service.recordPayment('c-1', 2, 800, 'CASH', 'u-1', undefined, undefined, 'TEST-P2', '11-1101'),
+      ).rejects.toThrow(/PARTIAL/);
+    });
+
+    it('re-pay remainder after partial → status PAID', async () => {
+      // Simulate prevPaid=800, customer now pays 200 (full clear)
+      mockPrismaInst.payment.findFirst.mockResolvedValueOnce({
+        id: 'p-partial-3', contractId: 'c-1', installmentNo: 3,
+        amountDue: new Decimal(1000), amountPaid: new Decimal(800), lateFee: new Decimal(0),
+        status: 'PARTIALLY_PAID', dueDate: new Date(), notes: '',
+      });
+
+      const updated = { id: 'p-partial-3', status: 'PAID', amountPaid: new Decimal(1000) };
+      mockPrismaInst.payment.update.mockResolvedValueOnce(updated);
+
+      await service.recordPayment(
+        'c-1', 3, 200, 'CASH', 'u-1',
+        undefined, undefined, 'TEST-P3', '11-1101',
+      );
+
+      expect(mockPrismaInst.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            amountPaid: expect.any(Object), // Decimal(1000) cumulative
+            status: 'PAID',
+          }),
+        }),
+      );
+      // No partialClear — case is undefined and shortage <= 1
+      expect(receipt2BExecute).toHaveBeenCalledWith(expect.not.objectContaining({ partialClear: true }));
+    });
+  });
+```
+
+- [ ] **Step 2.6: Run failing tests**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx jest src/modules/payments/payments.service.advance.spec.ts
+```
+
+Expected: tests fail until Steps 2.1-2.3 land.
+
+- [ ] **Step 2.7: Iterate to green**
+
+Common adjustments:
+- If `mockPrismaInst.payment.findFirst` not aware of new test, copy existing test's mock setup pattern
+- If `receipt2BExecute` doesn't capture `partialClear`, verify Step 2.3 call signature
+
+- [ ] **Step 2.8: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api
+```
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add apps/api/src/modules/payments/
+git commit -m "$(cat <<'EOF'
+feat(payments): recordPayment supports PARTIAL + previewJournal mirror
+
+- shortage > 1฿ requires explicit case='PARTIAL' (mirror OVERPAY_ADVANCE)
+- recordedAmountPaid accumulates; status='PARTIALLY_PAID' until full
+- partialClear flag passed to 2B template (skip tolerance, partial JE)
+- previewJournal PARTIAL branch shows Dr cash / Cr 11-2103 = amount
+- 3 new mocked-Prisma tests cover partial / reject / re-pay-to-PAID
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3: Frontend wizard + dialog
+
+### Task 3: Wizard `detectCase` + PARTIAL badge + ConfirmDialog
+
+**Files:**
+- Modify: `apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx`
+
+- [ ] **Step 3.1: Extend `DetectedCase`**
+
+Around line 42, change:
+```typescript
+type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OVERPAY_ADVANCE' | 'PARTIAL' | 'OUT_OF_RANGE';
+```
+
+- [ ] **Step 3.2: Update `detectCase` function**
+
+Find `function detectCase(received, expectedTotal, advanceBalance)` (around line 347). Replace the `diff < -1` branch:
+
+```typescript
+  if (diff > 0 && diff <= 1) return 'OVERPAY';
+  if (diff < 0 && diff >= -1) return 'UNDERPAY';
+  if (diff > 1) return 'OVERPAY_ADVANCE';
+  if (diff < -1) return 'PARTIAL';   // ← NEW: was OUT_OF_RANGE
+  return 'OUT_OF_RANGE';              // only when received <= 0
+```
+
+- [ ] **Step 3.3: Update `toApiCase`**
+
+Add the new branch:
+```typescript
+function toApiCase(detected: DetectedCase): PaymentCase {
+  if (detected === 'OVERPAY') return 'OVERPAY';
+  if (detected === 'UNDERPAY') return 'UNDERPAY';
+  if (detected === 'OVERPAY_ADVANCE') return 'OVERPAY_ADVANCE';
+  if (detected === 'PARTIAL') return 'PARTIAL';
+  return 'NORMAL';
+}
+```
+
+- [ ] **Step 3.4: Add CaseBadge branch**
+
+In `CaseBadge` component (around line 145), add before the existing `OUT_OF_RANGE` branch:
+
+```tsx
+  if (detectedCase === 'PARTIAL') {
+    return (
+      <div className="flex items-center gap-1.5 rounded-lg border border-warning/40 bg-warning/5 px-3 py-2 text-sm">
+        <AlertCircle className="size-4 text-warning shrink-0" />
+        <span className="text-warning font-medium leading-snug">
+          จ่ายขาด {absDiff} ฿ — บันทึกบางส่วน ลูกค้าค้าง {absDiff} ฿ ต่อ
+        </span>
+      </div>
+    );
+  }
+```
+
+- [ ] **Step 3.5: Allow Save when PARTIAL**
+
+Find `canSubmit()` (around line 555). The condition `if (detectedCase === 'OUT_OF_RANGE') return false;` already allows PARTIAL. Verify by reading the function — no change needed if only OUT_OF_RANGE is blocked. If a different allow-list pattern is found, add `&& detectedCase !== 'PARTIAL'` to allow PARTIAL.
+
+- [ ] **Step 3.6: Add ConfirmDialog state + import**
+
+At the top of RecordPaymentWizard.tsx, add:
+
+```typescript
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+```
+
+In the component body (around the other useState calls, ~line 408):
+
+```typescript
+  const [showPartialConfirm, setShowPartialConfirm] = useState(false);
+```
+
+- [ ] **Step 3.7: Gate submit on PARTIAL**
+
+Find the `handleSubmit` / submit mutation logic (search for `mutate(` or `onSubmit`). Wrap the submit call:
+
+```typescript
+  const handleSubmitClick = () => {
+    if (detectedCase === 'PARTIAL') {
+      setShowPartialConfirm(true);
+    } else {
+      actuallySubmit();
+    }
+  };
+
+  const actuallySubmit = () => {
+    setShowPartialConfirm(false);
+    // ... existing submit logic (mutation.mutate(...) or similar)
+  };
+```
+
+Replace the Save button's `onClick` with `handleSubmitClick`.
+
+- [ ] **Step 3.8: Render the ConfirmDialog**
+
+Near the bottom of the JSX (just before the closing element), add:
+
+```tsx
+      <ConfirmDialog
+        open={showPartialConfirm}
+        onOpenChange={setShowPartialConfirm}
+        title="ยืนยันบันทึกบางส่วน"
+        description={`ค่างวด ${expectedTotal.toFixed(2)} ฿\nลูกค้าจ่าย ${parseFloat(amountReceived).toFixed(2)} ฿\nค้าง ${Math.abs(amountDiff).toFixed(2)} ฿\n\nลูกค้าจะค้างยอดนี้ จนกว่าจะจ่ายเพิ่ม`}
+        confirmLabel="ยืนยันบันทึก"
+        cancelLabel="ยกเลิก"
+        onConfirm={actuallySubmit}
+      />
+```
+
+(If the existing `ConfirmDialog` doesn't render `\n` correctly, replace `description` with a custom `<DialogDescription>` block; or use the existing pattern from `MdmDeviceWidget.tsx` where the dialog renders multi-line by passing JSX.)
+
+- [ ] **Step 3.9: Add paid breakdown to left panel**
+
+Find the left panel block (around line 600-640, look for "ค่างวด" labels). Add a "จ่ายแล้ว" / "ยอดเหลือ" group when `amountPaidDecimal.gt(0)`:
+
+```tsx
+{amountPaidDecimal.gt(0) && (
+  <>
+    <div className="flex justify-between text-sm">
+      <span className="text-muted-foreground">จ่ายแล้ว</span>
+      <span className="text-muted-foreground font-mono">{amountPaidDecimal.toFixed(2)} ฿</span>
+    </div>
+    <hr className="border-border my-1" />
+    <div className="flex justify-between">
+      <span className="text-warning font-bold">ยอดเหลือ</span>
+      <span className="text-warning font-bold font-mono text-lg">
+        {amountDueDecimal.add(currentLateFee).sub(amountPaidDecimal).toFixed(2)} ฿
+      </span>
+    </div>
+  </>
+)}
+```
+
+(Match exact tailwind classes used by adjacent rows.)
+
+- [ ] **Step 3.10: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+- [ ] **Step 3.11: Commit**
+
+```bash
+git add apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx
+git commit -m "$(cat <<'EOF'
+feat(payments/web): wizard supports PARTIAL with confirm dialog
+
+- detectCase: diff < -1 → PARTIAL (was OUT_OF_RANGE)
+- CaseBadge yellow 'จ่ายขาด N ฿ — บันทึกบางส่วน'
+- ConfirmDialog gates save on PARTIAL with breakdown display
+- Left panel shows 'จ่ายแล้ว' / 'ยอดเหลือ' when amountPaid > 0
+- Pre-fill formula already correct (amountDue + lateFee - amountPaid)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4: List row chip
+
+### Task 4: Replace status badge with prominent "ค้าง" chip on PARTIALLY_PAID rows
+
+**Files:**
+- Modify: `apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx`
+
+- [ ] **Step 4.1: Update status column render**
+
+In `PaymentTable.tsx`, find the `status` column render (around line 89-95). Replace:
+
+```tsx
+      {
+        key: 'status',
+        label: 'สถานะ',
+        render: (p: PendingPayment) => {
+          if (p.status === 'PARTIALLY_PAID') {
+            const owed = (parseFloat(p.amountDue) + parseFloat(p.lateFee)) - parseFloat(p.amountPaid);
+            return (
+              <Badge variant="warning" appearance="solid" size="md">
+                ค้าง {owed.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ฿
+              </Badge>
+            );
+          }
+          const cfg = getStatusBadgeProps(p.status, paymentStatusMap);
+          return <Badge variant={cfg.variant} appearance={cfg.appearance} size="sm">{cfg.label}</Badge>;
+        },
+      },
+```
+
+- [ ] **Step 4.2: TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web
+```
+
+If `Badge variant="warning"` doesn't exist, check available variants in the Badge component and use the closest "warning" tone (e.g., `variant="default"` with custom className, or `variant="warning"` if defined).
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add apps/web/src/pages/PaymentsPage/components/PaymentTable.tsx
+git commit -m "$(cat <<'EOF'
+feat(payments/web): prominent 'ค้าง XXX ฿' chip on PARTIALLY_PAID rows
+
+- Replaces small status badge with size-md warning chip
+- Cashier can scan outstanding amount without opening wizard
+- Other statuses (PENDING/OVERDUE/PAID) unchanged
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5: Verification
+
+### Task 5: Final TS + manual smoke + PR prep
+
+- [ ] **Step 5.1: Full TS check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh all
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5.2: Run all OI + payment tests**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api && npx jest src/modules/payments/__tests__/ src/modules/payments/payments.service.advance.spec.ts 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5.3: Lint**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && npm run lint 2>&1 | tail -20 || true
+```
+
+Note any NEW errors introduced by this branch (the previous `prefer-const` fixed; we should not regress on warnings).
+
+- [ ] **Step 5.4: Manual smoke (owner runs)**
+
+1. Login as `admin@bestchoice.com` / `admin1234`
+2. Open contract → /payments → pick installment with full balance owing
+3. Type `800` for installment of `1,515.83` (or whatever the actual installment is) — verify:
+   - Yellow PARTIAL badge appears
+   - Save → confirm dialog shows breakdown
+   - Confirm → success
+   - Contract page shows `amountPaid = 800`, `status = PARTIALLY_PAID`
+4. Back at /payments list → verify row shows `ค้าง 715.83 ฿` chip
+5. Click that row again → wizard opens with:
+   - Left panel: ค่างวด 1,515.83 / จ่ายแล้ว 800 / ยอดเหลือ 715.83
+   - amountReceived pre-fill = 715.83
+6. Type 715.83 → no badge (NORMAL) → Save → success → status PAID
+
+- [ ] **Step 5.5: Push + PR (await owner instruction)**
+
+```bash
+git push -u origin feat/payment-partial
+gh pr create --title "feat(payments): underpay > 1฿ → PARTIAL (multi-receipt per installment)" --body "$(cat <<'EOF'
+## Summary
+- Wizard accepts underpay > 1฿ (no longer blocked with dead 'เมนูแบ่งชำระ' reference)
+- Customer can pay partial amount; remaining accumulates in same installment row
+- Per CSV case-3-split-payment.csv pattern (multiple 2B JE per installment)
+- ConfirmDialog gate prevents typo accidents
+
+## Spec + Plan
+- Spec: \`docs/superpowers/specs/2026-05-07-payment-partial-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-07-payment-partial.md\`
+
+## Schema
+- None (reuses Payment.amountPaid + status enum existing)
+
+## Backend
+- \`PaymentReceipt2BTemplate.partialClear?: boolean\` flag
+- \`recordPayment\` shortage > 1฿ requires explicit \`case='PARTIAL'\`
+- \`previewJournal\` PARTIAL branch
+- 1 template test + 3 service tests
+
+## Frontend
+- Wizard \`detectCase\` returns PARTIAL for diff < -1 (was OUT_OF_RANGE)
+- New yellow PARTIAL badge + ConfirmDialog gate before save
+- Left panel shows 'จ่ายแล้ว / ยอดเหลือ' when amountPaid > 0
+- /payments list shows 'ค้าง XXX ฿' chip on PARTIALLY_PAID rows
+- Pre-fill formula unchanged (already returns remaining)
+
+## Test plan
+- [ ] Type 800 for 1,515.83 installment → PARTIAL badge → Save → confirm dialog → submit → status=PARTIALLY_PAID
+- [ ] List shows 'ค้าง 715.83 ฿' chip
+- [ ] Re-open same row → pre-fill = 715.83 → Save → status=PAID
+- [ ] Underpay <1฿ still UNDERPAY (rounding tolerance, regression check)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Note: per project memory, do NOT push until owner says "push" / "create PR".**
+
+---
+
+## Self-review
+
+- [ ] All 5 tasks completed
+- [ ] `./tools/check-types.sh all` exits 0
+- [ ] All payment tests pass
+- [ ] Manual smoke (5 steps) passes
+- [ ] No `console.log` / `TODO` introduced
+- [ ] No regression in NORMAL/OVERPAY/UNDERPAY/OVERPAY_ADVANCE behavior
+
+---
+
+## Out of scope (post-MVP)
+
+- Per-receipt history view (audit trail of all 2B receipts on one installment)
+- Customer-facing partial-pay reminder (LIFF push)
+- Auto-reminder cron for stale PARTIAL
+- Reports column "outstanding partial" on contracts list
+- Late fee on partial-paid installment (currently inherited from existing lateFee logic — may need follow-up if cashier wants to defer late fee until full clear)
+
+---
+
+*End of plan.*

--- a/docs/superpowers/specs/2026-05-07-payment-partial-design.md
+++ b/docs/superpowers/specs/2026-05-07-payment-partial-design.md
@@ -1,0 +1,319 @@
+# Payment Partial (Underpay > 1฿) Design
+
+**Date:** 2026-05-07
+**Author:** owner + Claude
+**Status:** Design (sections 1-3 approved, awaiting written-spec review)
+**Related:** PR #762 OVERPAY_ADVANCE (mirror pattern), CSV `case-3-split-payment.csv`
+
+## 1. Problem
+
+Payment wizard currently blocks underpay > 1฿ with a misleading message:
+
+> "ห่างเกิน 1 ฿ — ใช้เมนูแบ่งชำระ/ปิดยอดแทน"
+
+**Two issues:**
+1. The "เมนูแบ่งชำระ" referenced does not exist anywhere in the UI — it's a dead reference
+2. Real-world cashier needs to record partial payments (customer pays 1,500 of 1,515.83 cash, planning to pay the rest later, or split between cash + transfer)
+
+The CSV chart explicitly designs for this case at `case-3-split-payment.csv` — multiple `2B` JE entries per installment, each clearing partial of `11-2103`.
+
+## 2. CSV Plan (already in chart)
+
+Per `case-3-split-payment.csv`:
+
+```
+2A (accrual on due date — once per installment):
+  Dr 11-2103  1,515.83  (open the receivable)
+
+2B receipt #1 (customer pays 800):
+  Dr 11-1101    800.00  (cash)
+  Cr 11-2103    800.00  (partial clear) → remaining 715.83
+
+2B receipt #2 (customer pays 715.83):
+  Dr 11-1101    715.83
+  Cr 11-2103    715.83  (remaining clear)
+```
+
+Key insight: `11-2103 ลูกหนี้ค้างชำระ` accumulates partial reductions until 0. **No new account, no new template, no installmentTotal check on 2B receipts.**
+
+This design extends the existing `PaymentReceipt2BTemplate` to skip the tolerance check and post `Cr 11-2103 = amount` (not full installment) when `case='PARTIAL'`.
+
+## 3. Architecture
+
+```
+PAYMENT (partial — first receipt):
+  Customer pays 800 for งวด 2 (ค่างวด 1,515.83)
+       ↓
+  Wizard detectCase → PARTIAL (diff = -715.83)
+       ↓
+  Confirm dialog: "ลูกค้าจ่าย 800 ฿ (ขาด 715.83). บันทึกเป็นจ่ายบางส่วน?"
+       ↓
+  POST /payments/:id { case: 'PARTIAL', amountReceived: 800 }
+       ↓
+  payments.service.recordPayment:
+    • Payment[งวด2].amountPaid = 800
+    • Payment[งวด2].status = 'PARTIALLY_PAID'
+    • JE 2B (extended):
+        Dr 11-1101  800.00  (cash)
+        Cr 11-2103  800.00  (partial clear, NOT installmentTotal)
+
+LIST DISPLAY:
+  /payments table row shows: 🟡 ค้าง 715.83 ฿ (chip on row)
+
+NEXT RECEIPT (later — same wizard, same installment):
+  Cashier clicks the same row → wizard re-opens งวด 2
+  Left panel: ค่างวด 1,515.83 / จ่ายแล้ว 800 / ยอดเหลือ 715.83
+  amountReceived pre-filled = 715.83
+       ↓
+  Customer pays 715.83 → case = NORMAL (within ±1฿ of remaining)
+       ↓
+  payments.service.recordPayment:
+    • Payment[งวด2].amountPaid = 800 + 715.83 = 1,515.83
+    • Payment[งวด2].status = 'PAID'
+    • JE 2B:
+        Dr 11-1101  715.83
+        Cr 11-2103  715.83  (remaining clear)
+```
+
+**Mixed-method (C-case)** is just two PARTIAL receipts on the same day with different `depositAccountCode` (cash 800 / 11-1101, transfer 715.83 / 11-1201) — no new logic.
+
+## 4. Components
+
+### 4.1 Schema change
+
+**None.** Reuses `Payment.amountPaid` (Decimal, cumulative) + `PaymentStatus` enum (`PAID`, `PARTIALLY_PAID`, `PENDING`, `OVERDUE`).
+
+### 4.2 Enum
+
+**None.** `PaymentCase.PARTIAL` already exists in `apps/api/src/modules/payments/dto/payment.dto.ts`.
+
+### 4.3 Service logic — `recordPayment`
+
+`apps/api/src/modules/payments/payments.service.ts`:
+
+```typescript
+async recordPayment(/* existing params */, paymentCase?: PaymentCase) {
+  // ... existing setup ...
+
+  const remaining = dRound(dSub(amountDue, prevPaid));
+  const overage = d(amount).minus(remaining);
+  const shortage = remaining.minus(d(amount));
+
+  // Existing OVERPAY_ADVANCE logic — unchanged
+  if (overage.gt(d('1.00'))) { /* require OVERPAY_ADVANCE */ }
+
+  // NEW: shortage > 1฿ requires explicit PARTIAL
+  if (shortage.gt(d('1.00')) && paymentCase !== 'PARTIAL') {
+    throw new BadRequestException(
+      `จำนวนเงินน้อยกว่ายอดที่ต้องชำระ (ยอดที่ต้องชำระ ${remaining}, จ่าย ${amount}) — ` +
+      `เลือก case 'PARTIAL' เพื่อบันทึกเป็นจ่ายบางส่วน`,
+    );
+  }
+
+  // ... advance auto-consume (existing) ...
+
+  const recordedAmountPaid = d(amount).plus(advanceConsume).plus(prevPaid);
+  // (no special branch for PARTIAL — amountPaid is just cumulative)
+
+  const isPaidInFull = dGte(recordedAmountPaid, amountDue);
+  const status = isPaidInFull ? 'PAID' : 'PARTIALLY_PAID';
+
+  // ... call template with new partialClear flag ...
+}
+```
+
+### 4.4 Template extension
+
+`apps/api/src/modules/journal/cpa-templates/payment-receipt-2b.template.ts`:
+
+```typescript
+export interface PaymentReceiptInput {
+  // ... existing fields ...
+  /** Skip tolerance check + clear receivable by amount only (not installmentTotal). */
+  partialClear?: boolean;
+}
+
+// In execute():
+if (input.partialClear) {
+  // Skip tolerance + skip rounding lines (53-1503/52-1104)
+  // Build minimal JE:
+  lines.push({
+    accountCode: input.depositAccountCode,
+    dr: input.amountReceived,
+    cr: zero,
+    description: 'รับชำระบางส่วน',
+  });
+  lines.push({
+    accountCode: '11-2103',
+    dr: zero,
+    cr: input.amountReceived, // partial clear = amount, NOT installmentTotal
+    description: 'ล้างลูกหนี้ค้างชำระ (บางส่วน)',
+  });
+  // No advance / VAT / WHT lines — partial is the simplest case
+}
+```
+
+When `partialClear=true`, advance handling and rounding tolerance both bypassed. The template is intentionally minimal — partial pay = "just record the cash + reduce the receivable by that amount."
+
+### 4.5 `previewJournal` mirror
+
+Mirror the same `partialClear` branch in `previewJournal`:
+
+```typescript
+if (input.case === 'PARTIAL') {
+  // Skip the existing 2A+2B consolidated / 2B-only logic
+  rawLines.push({ code: input.depositAccountCode, dr: amountReceived, cr: zero, description: 'รับชำระบางส่วน' });
+  rawLines.push({ code: '11-2103', dr: zero, cr: amountReceived, description: 'ล้างลูกหนี้ค้างชำระ (บางส่วน)' });
+  // Skip: late fee, advance, VAT, WHT
+  return /* balanced result */;
+}
+```
+
+### 4.6 Wizard `detectCase`
+
+`apps/web/src/pages/PaymentsPage/components/RecordPaymentWizard.tsx`:
+
+```typescript
+type DetectedCase = 'NORMAL' | 'OVERPAY' | 'UNDERPAY' | 'OVERPAY_ADVANCE' | 'PARTIAL' | 'OUT_OF_RANGE';
+
+function detectCase(received, expectedTotal, advanceBalance) {
+  // ... existing logic ...
+  if (diff > 1) return 'OVERPAY_ADVANCE';
+  if (diff < -1) return 'PARTIAL';   // ← NEW: was OUT_OF_RANGE
+  return 'OUT_OF_RANGE';              // ← only if received <= 0 (zero/negative)
+}
+```
+
+### 4.7 CaseBadge — PARTIAL render
+
+```tsx
+if (detectedCase === 'PARTIAL') {
+  return (
+    <div className="rounded-lg border border-warning/40 bg-warning/5 ...">
+      <AlertCircle className="text-warning" />
+      <span className="text-warning font-medium">
+        จ่ายขาด {absDiff} ฿ — บันทึกบางส่วน ลูกค้าค้าง {absDiff} ฿ ต่อ
+      </span>
+    </div>
+  );
+}
+```
+
+### 4.8 Confirm dialog (D-case guard)
+
+When `detectedCase === 'PARTIAL'` and user clicks Save, show modal:
+
+```tsx
+<ConfirmDialog
+  title="ยืนยันบันทึกบางส่วน"
+  body={
+    <div>
+      <p>ค่างวด: {expectedTotal.toFixed(2)} ฿</p>
+      <p>ลูกค้าจ่าย: {received.toFixed(2)} ฿</p>
+      <p className="font-bold">ค้าง: {absDiff.toFixed(2)} ฿</p>
+      <p className="text-xs text-muted-foreground mt-2">
+        ลูกค้าจะค้างยอดนี้ จนกว่าจะจ่ายเพิ่ม
+      </p>
+    </div>
+  }
+  cancelLabel="ยกเลิก"
+  confirmLabel="ยืนยันบันทึก"
+  onConfirm={() => actuallySubmit()}
+/>
+```
+
+Reuse the existing `ConfirmDialog` component from `apps/web/src/components/`.
+
+### 4.9 Wizard left panel — paid breakdown
+
+Add when `payment.amountPaid > 0`:
+
+```tsx
+<div className="space-y-1 text-sm">
+  <Row label="ค่างวด" value={amountDue.toFixed(2)} />
+  {amountPaid.gt(0) && (
+    <Row label="จ่ายแล้ว" value={amountPaid.toFixed(2)} className="text-muted-foreground" />
+  )}
+  <hr />
+  <Row
+    label="ยอดเหลือ"
+    value={remaining.toFixed(2)}
+    className={remaining.gt(0) ? "text-warning font-bold text-lg" : "text-success font-bold"}
+  />
+</div>
+```
+
+### 4.10 amountReceived pre-fill
+
+When opening wizard for `payment.status === 'PARTIALLY_PAID'`:
+
+```typescript
+// instead of `defaultAmount = amountDue + lateFee - amountPaid`
+// it's already correct — just verify behavior:
+const defaultAmount = amountDueDecimal.add(lateFeeDecimal).sub(amountPaidDecimal);
+// = (1515.83 + 0) - 800 = 715.83 ✓
+```
+
+The existing pre-fill formula already handles this correctly because `amountPaid` is cumulative. **No code change needed for pre-fill.**
+
+### 4.11 /payments list row — outstanding chip
+
+`apps/web/src/pages/PaymentsPage/components/PendingTab.tsx` (or list table):
+
+When `payment.status === 'PARTIALLY_PAID'`, replace the small badge with a prominent chip:
+
+```tsx
+{payment.status === 'PARTIALLY_PAID' && (
+  <Chip variant="warning" size="lg">
+    🟡 ค้าง {(amountDue - amountPaid).toFixed(2)} ฿
+  </Chip>
+)}
+```
+
+## 5. Re-payment flow (multi-day partial)
+
+1. Customer pays 800 today → wizard records PARTIAL → `Payment.status = PARTIALLY_PAID`, `amountPaid = 800`
+2. Cashier sees row in list with chip "ค้าง 715.83 ฿"
+3. Days/weeks later, customer comes back with 715.83
+4. Cashier clicks the same row → wizard re-opens
+5. Left panel auto-shows "ยอดเหลือ 715.83 ฿"
+6. `amountReceived` pre-filled = 715.83 (existing formula)
+7. Cashier confirms → `case='NORMAL'` (within ±1฿ tolerance)
+8. JE: `Dr cash 715.83 / Cr 11-2103 715.83` → `status = PAID`
+
+**Mixed-method (C-case)** = step 1 with cash, step 4-7 with transfer on the same day. Just two PARTIAL receipts, different `depositAccountCode`.
+
+## 6. Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| Customer overpays the remainder (e.g. pays 720 of 715.83) | Existing rounding tolerance handles ±1฿. > 1฿ would be OVERPAY_ADVANCE on the remainder. |
+| Customer pays into already-PAID installment | Service rejects (`status === 'PAID'` guard exists) |
+| Late fee on partial-paid installment | LateFee accrues normally based on dueDate. When PARTIAL receipt happens after dueDate, lateFee included in `remaining` calc. Customer must clear lateFee + remaining principal — existing pattern. |
+| Repeated partial (3+ receipts) | All accumulate in `amountPaid`. Each is a fresh JE 2B receipt. |
+| User cancels confirm dialog | Wizard stays open, no save. |
+| Underpay > 1฿ but `paymentCase !== 'PARTIAL'` | Service rejects with explicit error (mirror OVERPAY_ADVANCE pattern). |
+
+## 7. Acceptance criteria
+
+- [ ] Wizard accepts underpay > 1฿ when user confirms (case='PARTIAL')
+- [ ] Confirm dialog appears before save with breakdown
+- [ ] JE posts `Dr cash X / Cr 11-2103 X` (no full installmentTotal clear, no rounding lines)
+- [ ] `Payment.amountPaid` accumulates across receipts
+- [ ] `Payment.status = PARTIALLY_PAID` after first receipt, `PAID` after total reaches `amountDue`
+- [ ] Re-opening wizard for PARTIALLY_PAID installment shows "ยอดเหลือ" + pre-fills `remaining`
+- [ ] /payments list row shows "ค้าง XXX ฿" chip on PARTIALLY_PAID rows
+- [ ] previewJournal mirrors PARTIAL JE
+- [ ] Existing tests pass (no regression)
+- [ ] 4 new tests: partial receipt, re-pay, multi-receipt, overpay-on-remainder
+
+## 8. Out of scope (post-MVP)
+
+- Per-receipt history view (audit trail of all 2B receipts on one installment) — exists implicitly via JournalEntry but no dedicated UI
+- Customer-facing partial-pay reminder (LIFF push notification when PARTIALLY_PAID)
+- Auto-reminder cron for stale PARTIAL (e.g., 7 days unpaid → call cron)
+- Reports column "outstanding partial" on contracts list
+
+## 9. Open questions
+
+None — design follows existing CSV pattern (case-3) and mirrors the OVERPAY_ADVANCE PR #762 pattern.


### PR DESCRIPTION
## Summary
- Wizard accepts underpay > 1฿ (no longer blocked with dead 'เมนูแบ่งชำระ' reference)
- Customer can pay partial; remaining accumulates in same installment
- Per CSV `case-3-split-payment.csv` pattern (multiple 2B JE per installment)
- ConfirmDialog gates save to prevent typo accidents

## Spec + Plan
- Spec: `docs/superpowers/specs/2026-05-07-payment-partial-design.md`
- Plan: `docs/superpowers/plans/2026-05-07-payment-partial.md`

## Schema
- None (reuses `Payment.amountPaid` + `PaymentStatus` enum)

## Backend
- `PaymentReceipt2BTemplate.partialClear?: boolean` flag → emits only `Dr cash X / Cr 11-2103 X` (skip tolerance + advance + rounding)
- `recordPayment` shortage > 1฿ requires `case='PARTIAL'`; passes `partialClear` to template
- `previewJournal` PARTIAL branch mirrors save logic
- 1 template test + 3 service tests (8 total in advance.spec.ts)

## Frontend
- Wizard `detectCase` returns `PARTIAL` for `diff < -1` (was `OUT_OF_RANGE`)
- Yellow PARTIAL badge "จ่ายขาด N ฿ — บันทึกบางส่วน"
- ConfirmDialog gate before save with breakdown
- Left panel shows "จ่ายแล้ว / ยอดเหลือ" when `amountPaid > 0`
- /payments list shows prominent "ค้าง XXX ฿" chip on PARTIALLY_PAID rows
- Pre-fill formula unchanged (already returns remaining via `amountDue + lateFee - amountPaid`)

## Status
- TS: 0 errors (api + web)
- Tests: 8/8 pass in `payments.service.advance.spec.ts` (5 OVERPAY_ADVANCE + 3 PARTIAL)
- 4 commits via subagent-driven workflow

## Test plan
- [ ] Type 800 for 1,515.83 installment → yellow PARTIAL badge → Save → confirm dialog
- [ ] Confirm → status=PARTIALLY_PAID, JE: Dr cash 800 / Cr 11-2103 800
- [ ] /payments list shows "ค้าง 715.83 ฿" chip
- [ ] Re-open same row → pre-fill = 715.83 → Save → status=PAID
- [ ] Underpay <1฿ still UNDERPAY (rounding tolerance, regression)
- [ ] OVERPAY_ADVANCE still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)