### PR TITLE
chore(ci): skip deploy workflow on docs-only changes

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -3,8 +3,18 @@ name: Deploy to GCP (Cloud Run + Firebase)
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'workflows/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'workflows/**'
 
 env:
   NODE_VERSION: '20'


### PR DESCRIPTION
## Why
GH Actions quota usage was high — every docs/spec/plan PR triggers full Lint+Test+Build+Deploy job (~12 min) even though no app code changed.

## What
Adds \`paths-ignore\` to deploy-gcp.yml workflow trigger:
- \`**.md\` — markdown anywhere
- \`docs/**\` — spec/plan files
- \`.claude/**\` — Claude config + skills
- \`workflows/**\` — project WAT workflow SOPs (not .github/workflows)

\`e2e-tests.yml\` already correctly filters via \`paths\` (only \`apps/web\` or \`apps/api\`).

## Effect
Docs-only PRs (most spec/plan commits) skip CI entirely → ~12 min saved per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)