### PR TITLE
fix(payments/test): align existing partial-payment tests with PR #764

### DIFF
--- a/apps/api/src/modules/payments/payments-financial.integration.spec.ts
+++ b/apps/api/src/modules/payments/payments-financial.integration.spec.ts
@@ -107,7 +107,7 @@ describe('PaymentsService — Financial Integration', () => {
     });
 
     it('should handle partial payment', async () => {
-      await service.recordPayment('c1', 1, 500, 'CASH', 'u1', 'https://s3.example.com/slip.jpg', undefined, 'TXN-2');
+      await service.recordPayment('c1', 1, 500, 'CASH', 'u1', 'https://s3.example.com/slip.jpg', undefined, 'TXN-2', undefined, undefined, 'PARTIAL');
       expect(payments[0].status).toBe('PARTIALLY_PAID');
       // amountPaid is now stored as Prisma.Decimal — compare numeric value
       expect(Number(payments[0].amountPaid)).toBe(500);

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -265,7 +265,7 @@ describe('PaymentsService', () => {
       const updatedPayment = { ...mockPayment, amountPaid: 1000, status: 'PARTIALLY_PAID', paidDate: null };
       prisma.payment.update.mockResolvedValue(updatedPayment);
 
-      const result = await service.recordPayment('contract-1', 1, 1000, 'CASH', 'user-1', 'http://slip.jpg');
+      const result = await service.recordPayment('contract-1', 1, 1000, 'CASH', 'user-1', 'http://slip.jpg', undefined, undefined, undefined, undefined, 'PARTIAL');
       expect(result.status).toBe('PARTIALLY_PAID');
     });
 
@@ -283,7 +283,7 @@ describe('PaymentsService', () => {
       const updatedPayment = { ...mockPayment, id: 'payment-1', amountPaid: 1000, status: 'PARTIALLY_PAID', paidDate: null };
       prisma.payment.update.mockResolvedValue(updatedPayment);
 
-      await service.recordPayment('contract-1', 1, 1000, 'CASH', 'user-1', 'http://slip.jpg');
+      await service.recordPayment('contract-1', 1, 1000, 'CASH', 'user-1', 'http://slip.jpg', undefined, undefined, undefined, undefined, 'PARTIAL');
       expect(receiptsService.generateReceipt).toHaveBeenCalledWith(
         'contract-1', 'payment-1', 'INSTALLMENT', 1000, 1, 'CASH', null, 'user-1',
       );


### PR DESCRIPTION
PR #764 added explicit `case='PARTIAL'` requirement for shortage > 1฿. 3 pre-existing tests called `recordPayment()` without the case param and now fail with BadRequestException. Adds `'PARTIAL'` to align with new design.

Verified: 59/59 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)