### PR TITLE
fix(other-income): 12 bugs from deep-verification

### DIFF
--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -499,10 +499,16 @@ describe('OtherIncomeService — post + reverse + copy', () => {
     expect(sheet.summary.docCount).toBeGreaterThanOrEqual(1);
     expect(new Prisma.Decimal(sheet.summary.incomeGross.toString()).gte(1000)).toBe(true);
 
-    // byAccount should have 42-1102
-    expect(sheet.byAccount.has('42-1102')).toBe(true);
+    // byAccount should be an array (B1 fix) containing 42-1102
+    expect(Array.isArray(sheet.byAccount)).toBe(true);
+    expect(sheet.byAccount.some((r) => r.code === '42-1102')).toBe(true);
 
-    // byPayment should have 11-1201
-    expect(sheet.byPayment.has('11-1201')).toBe(true);
+    // byPayment should be an array (B1 fix) containing 11-1201
+    expect(Array.isArray(sheet.byPayment)).toBe(true);
+    expect(sheet.byPayment.some((r) => r.code === '11-1201')).toBe(true);
+
+    // summary should use vat/wht keys (B2 fix)
+    expect(sheet.summary).toHaveProperty('vat');
+    expect(sheet.summary).toHaveProperty('wht');
   }, 30_000);
 });

--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -7,6 +7,13 @@ import { ValidationService } from '../services/validation.service';
 import { AutoJournalService } from '../services/auto-journal.service';
 import { OtherIncomeTemplate } from '../templates/other-income.template';
 import { JournalAutoService } from '../../journal/journal-auto.service';
+import { StorageService } from '../../storage/storage.service';
+
+const stubStorage = {
+  upload: async () => undefined,
+  delete: async () => undefined,
+  getSignedUrl: async () => 'https://stub/url',
+};
 
 const D = (n: number | string) => new Prisma.Decimal(n);
 
@@ -30,6 +37,7 @@ describe('OtherIncomeService — CRUD', () => {
         AutoJournalService,
         PrismaService,
         { provide: OtherIncomeTemplate, useValue: stubTemplate },
+        { provide: StorageService, useValue: stubStorage },
       ],
     }).compile();
     await module.init();
@@ -230,6 +238,7 @@ describe('OtherIncomeService — post + reverse + copy', () => {
         OtherIncomeTemplate,
         JournalAutoService,
         PrismaService,
+        { provide: StorageService, useValue: stubStorage },
       ],
     }).compile();
     await module.init();

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -9,13 +9,19 @@ import {
   Post,
   Query,
   Request,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
+  ParseFilePipe,
+  MaxFileSizeValidator,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { OtherIncomeService } from './other-income.service';
+import { StorageService } from '../storage/storage.service';
 import { CreateOtherIncomeDto } from './dto/create-other-income.dto';
 import { UpdateOtherIncomeDto } from './dto/update-other-income.dto';
 import { PostOtherIncomeDto } from './dto/post-other-income.dto';
@@ -27,7 +33,10 @@ import { DailySheetQueryDto } from './dto/daily-sheet-query.dto';
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
 export class OtherIncomeController {
-  constructor(private readonly service: OtherIncomeService) {}
+  constructor(
+    private readonly service: OtherIncomeService,
+    private readonly storage: StorageService,
+  ) {}
 
   // CRITICAL: declare daily-sheet BEFORE :id so the literal string
   // doesn't get parsed as a UUID by ParseUUIDPipe on the :id routes.
@@ -98,5 +107,27 @@ export class OtherIncomeController {
     @CurrentUser('id') userId: string,
   ) {
     return this.service.copy(id, userId);
+  }
+
+  @Post(':id/attachments')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAttachment(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @CurrentUser('id') userId: string,
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({
+            maxSize: 20 * 1024 * 1024, // 20 MB
+            message: 'ไฟล์มีขนาดเกิน 20MB',
+          }),
+        ],
+        fileIsRequired: true,
+        errorHttpStatusCode: 400,
+      }),
+    )
+    file: Express.Multer.File,
+  ) {
+    return this.service.uploadAttachment(id, file, userId, this.storage);
   }
 }

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -14,6 +14,7 @@ import {
   UseInterceptors,
   ParseFilePipe,
   MaxFileSizeValidator,
+  FileTypeValidator,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -21,7 +22,6 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { OtherIncomeService } from './other-income.service';
-import { StorageService } from '../storage/storage.service';
 import { CreateOtherIncomeDto } from './dto/create-other-income.dto';
 import { UpdateOtherIncomeDto } from './dto/update-other-income.dto';
 import { PostOtherIncomeDto } from './dto/post-other-income.dto';
@@ -33,16 +33,18 @@ import { DailySheetQueryDto } from './dto/daily-sheet-query.dto';
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
 export class OtherIncomeController {
-  constructor(
-    private readonly service: OtherIncomeService,
-    private readonly storage: StorageService,
-  ) {}
+  constructor(private readonly service: OtherIncomeService) {}
 
   // CRITICAL: declare daily-sheet BEFORE :id so the literal string
   // doesn't get parsed as a UUID by ParseUUIDPipe on the :id routes.
   @Get('daily-sheet')
   dailySheet(@Query() q: DailySheetQueryDto) {
     return this.service.dailySheet(q.date);
+  }
+
+  @Get('config/attachment-threshold')
+  async attachmentThreshold() {
+    return { threshold: await this.service.getAttachmentThreshold() };
   }
 
   @Get()
@@ -118,8 +120,11 @@ export class OtherIncomeController {
       new ParseFilePipe({
         validators: [
           new MaxFileSizeValidator({
-            maxSize: 20 * 1024 * 1024, // 20 MB
-            message: 'ไฟล์มีขนาดเกิน 20MB',
+            maxSize: 5 * 1024 * 1024,
+            message: 'ไฟล์มีขนาดเกิน 5MB',
+          }),
+          new FileTypeValidator({
+            fileType: /^(application\/pdf|image\/(jpeg|png|webp))$/,
           }),
         ],
         fileIsRequired: true,
@@ -128,6 +133,6 @@ export class OtherIncomeController {
     )
     file: Express.Multer.File,
   ) {
-    return this.service.uploadAttachment(id, file, userId, this.storage);
+    return this.service.uploadAttachment(id, file, userId);
   }
 }

--- a/apps/api/src/modules/other-income/other-income.module.ts
+++ b/apps/api/src/modules/other-income/other-income.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { JournalModule } from '../journal/journal.module';
+import { StorageModule } from '../storage/storage.module';
 import { OtherIncomeService } from './other-income.service';
 import { OtherIncomeController } from './other-income.controller';
 import { DocNumberService } from './services/doc-number.service';
@@ -10,7 +11,7 @@ import { OtherIncomeTemplate } from './templates/other-income.template';
 // PrismaService is provided globally via PrismaModule (@Global) — no import needed.
 
 @Module({
-  imports: [JournalModule],
+  imports: [JournalModule, StorageModule],
   controllers: [OtherIncomeController],
   providers: [
     OtherIncomeService,

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -31,6 +31,7 @@ export class OtherIncomeService {
     private readonly validation: ValidationService,
     private readonly autoJournal: AutoJournalService,
     private readonly template: OtherIncomeTemplate,
+    private readonly storage: StorageService,
   ) {}
 
   async create(dto: CreateOtherIncomeDto, userId: string) {
@@ -730,33 +731,35 @@ export class OtherIncomeService {
   // uploadAttachment(): store file in S3/GCS + create OtherIncomeAttachment row
   // -------------------------------------------------------------------------
 
-  async uploadAttachment(
-    id: string,
-    file: Express.Multer.File,
-    userId: string,
-    storage: StorageService,
-  ) {
-    // Verify doc exists
-    await this.findOneOrFail(id);
+  async uploadAttachment(id: string, file: Express.Multer.File, userId: string) {
+    const doc = await this.findOneOrFail(id);
 
-    // Sanitize filename
+    if (doc.status === OtherIncomeStatus.REVERSED) {
+      throw new BadRequestException('ไม่สามารถแนบไฟล์เอกสารที่ถูกกลับรายการ');
+    }
+
     const decodedName = Buffer.from(file.originalname, 'latin1').toString('utf8');
     // eslint-disable-next-line no-control-regex
-    const safeName = decodedName.replace(/[<>:"/\\|?* -]/g, '_');
+    const safeName = decodedName.replace(/[<>:"/\\|?* -\s]/g, '_');
     const key = `other-income/${id}/${Date.now()}-${randomUUID()}-${safeName}`;
 
-    await storage.upload(key, file.buffer, file.mimetype);
+    await this.storage.upload(key, file.buffer, file.mimetype);
 
-    return this.prisma.otherIncomeAttachment.create({
-      data: {
-        otherIncomeId: id,
-        s3Key: key,
-        filename: decodedName,
-        size: file.size,
-        mimeType: file.mimetype,
-        uploadedById: userId,
-      },
-    });
+    try {
+      return await this.prisma.otherIncomeAttachment.create({
+        data: {
+          otherIncomeId: id,
+          s3Key: key,
+          filename: decodedName,
+          size: file.size,
+          mimeType: file.mimetype,
+          uploadedById: userId,
+        },
+      });
+    } catch (err) {
+      await this.storage.delete(key).catch(() => undefined);
+      throw err;
+    }
   }
 
   // findOneOrFail()
@@ -794,7 +797,7 @@ export class OtherIncomeService {
   }
 
   /** Read OTHER_INCOME_ATTACHMENT_THRESHOLD from SystemConfig. Falls back to 50_000. */
-  private async getAttachmentThreshold(): Promise<number> {
+  async getAttachmentThreshold(): Promise<number> {
     try {
       const row = await this.prisma.systemConfig.findUnique({
         where: { key: 'OTHER_INCOME_ATTACHMENT_THRESHOLD' },

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -5,7 +5,9 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { OtherIncomeStatus, Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
 import { PrismaService } from '../../prisma/prisma.service';
+import { StorageService } from '../storage/storage.service';
 import { DocNumberService } from './services/doc-number.service';
 import { ValidationService } from './services/validation.service';
 import { AutoJournalService } from './services/auto-journal.service';
@@ -592,22 +594,64 @@ export class OtherIncomeService {
       byPaymentMap.set(doc.paymentAccountCode, prevPay.plus(doc.amountReceived.toString()));
     }
 
-    // Sort maps by account code
-    const byAccount = new Map(
-      [...byAccountMap.entries()].sort(([a], [b]) => a.localeCompare(b)),
-    );
-    const byPayment = new Map(
-      [...byPaymentMap.entries()].sort(([a], [b]) => a.localeCompare(b)),
-    );
+    // B1: convert Maps to sorted arrays (Maps serialize to {} via JSON.stringify)
+    // B3: include name + count per byAccount item
+    // B4: include count per byPayment item
+
+    // Gather account names from ChartOfAccount for B3
+    const allAccountCodes = [...byAccountMap.keys()];
+    const coaRows = allAccountCodes.length > 0
+      ? await this.prisma.chartOfAccount.findMany({
+          where: { code: { in: allAccountCodes } },
+          select: { code: true, name: true },
+        })
+      : [];
+    const nameByCode = Object.fromEntries(coaRows.map((r) => [r.code, r.name]));
+
+    // Count per account code (number of distinct docs contributing to each)
+    const byAccountCountMap = new Map<string, number>();
+    for (const doc of docs) {
+      const codesInDoc = new Set(doc.items.map((it) => it.accountCode));
+      for (const code of codesInDoc) {
+        byAccountCountMap.set(code, (byAccountCountMap.get(code) ?? 0) + 1);
+      }
+    }
+
+    // Count per payment account code (number of docs per payment channel)
+    const byPaymentCountMap = new Map<string, number>();
+    for (const doc of docs) {
+      byPaymentCountMap.set(
+        doc.paymentAccountCode,
+        (byPaymentCountMap.get(doc.paymentAccountCode) ?? 0) + 1,
+      );
+    }
+
+    const byAccount = [...byAccountMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([code, total]) => ({
+        code,
+        name: nameByCode[code] ?? code,
+        total: total.toFixed(2),
+        count: byAccountCountMap.get(code) ?? 0,
+      }));
+
+    const byPayment = [...byPaymentMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([code, total]) => ({
+        code,
+        total: total.toFixed(2),
+        count: byPaymentCountMap.get(code) ?? 0,
+      }));
 
     return {
       date,
       summary: {
         docCount: docs.length,
-        incomeGross,
-        vatAmount: vat,
-        whtAmount: wht,
-        netReceived: net,
+        incomeGross: incomeGross.toFixed(2),
+        // B2: rename to vat/wht to match frontend DailySheet type
+        vat: vat.toFixed(2),
+        wht: wht.toFixed(2),
+        netReceived: net.toFixed(2),
       },
       docs,
       byAccount,
@@ -678,6 +722,39 @@ export class OtherIncomeService {
       take: 50,
       include: {
         user: { select: { id: true, name: true, email: true } },
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // uploadAttachment(): store file in S3/GCS + create OtherIncomeAttachment row
+  // -------------------------------------------------------------------------
+
+  async uploadAttachment(
+    id: string,
+    file: Express.Multer.File,
+    userId: string,
+    storage: StorageService,
+  ) {
+    // Verify doc exists
+    await this.findOneOrFail(id);
+
+    // Sanitize filename
+    const decodedName = Buffer.from(file.originalname, 'latin1').toString('utf8');
+    // eslint-disable-next-line no-control-regex
+    const safeName = decodedName.replace(/[<>:"/\\|?* -]/g, '_');
+    const key = `other-income/${id}/${Date.now()}-${randomUUID()}-${safeName}`;
+
+    await storage.upload(key, file.buffer, file.mimetype);
+
+    return this.prisma.otherIncomeAttachment.create({
+      data: {
+        otherIncomeId: id,
+        s3Key: key,
+        filename: decodedName,
+        size: file.size,
+        mimeType: file.mimetype,
+        uploadedById: userId,
       },
     });
   }

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -68,9 +68,12 @@ export const otherIncomeApi = {
     const formData = new FormData();
     formData.append('file', file);
     return api
-      .post<OtherIncomeAttachment>(`/other-income/${id}/attachments`, formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      })
+      .post<OtherIncomeAttachment>(`/other-income/${id}/attachments`, formData)
       .then((r) => r.data);
   },
+
+  getAttachmentThreshold: () =>
+    api
+      .get<{ threshold: number }>('/other-income/config/attachment-threshold')
+      .then((r) => r.data.threshold),
 };

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -2,6 +2,7 @@ import api from './api';
 import type {
   AuditLogEntry,
   OtherIncome,
+  OtherIncomeAttachment,
   ListResponse,
   DailySheet,
   OtherIncomeStatus,
@@ -62,4 +63,14 @@ export const otherIncomeApi = {
 
   getAuditTrail: (id: string) =>
     api.get<AuditLogEntry[]>(`/other-income/${id}/audit`).then((r) => r.data),
+
+  uploadAttachment: (id: string, file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    return api
+      .post<OtherIncomeAttachment>(`/other-income/${id}/attachments`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      .then((r) => r.data);
+  },
 };

--- a/apps/web/src/pages/other-income/OtherIncomeDailySheetPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeDailySheetPage.tsx
@@ -67,7 +67,7 @@ export default function OtherIncomeDailySheetPage() {
         Number(d.incomeGross).toFixed(2),
         Number(d.vatAmount).toFixed(2),
         Number(d.whtAmount).toFixed(2),
-        Number(d.amountReceived).toFixed(2),
+        Number(d.netReceived).toFixed(2),
         d.paymentAccountCode,
       ]);
     });
@@ -236,7 +236,7 @@ export default function OtherIncomeDailySheetPage() {
                             {Number(d.whtAmount).toFixed(2)}
                           </td>
                           <td className="px-2 py-2 text-right font-mono font-bold">
-                            {Number(d.amountReceived).toFixed(2)}
+                            {Number(d.netReceived).toFixed(2)}
                           </td>
                         </tr>
                       ))}

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -15,8 +15,8 @@ import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { PaymentCompareCard } from './components/PaymentCompareCard';
 import { CounterpartyPicker } from './components/CounterpartyPicker';
 
-// Threshold above which attachment is required (matches backend SystemConfig default)
-const ATTACHMENT_THRESHOLD = 50_000;
+// Fallback while config is loading; live value comes from /other-income/config/attachment-threshold
+const ATTACHMENT_THRESHOLD_FALLBACK = 50_000;
 
 // ------------------------------------------------------------------
 // JE preview computation — mirrors AutoJournalService on the backend
@@ -85,13 +85,13 @@ function computeJePreview(values: OtherIncomeFormValues): JeLine[] {
     });
   }
 
-  // Dr WHT payable (21-3101) if any
+  // Dr WHT receivable (11-4103) if any
   if (totalWht > 0) {
     lines.push({
-      accountCode: '21-3101',
-      debit: 0,
-      credit: +totalWht.toFixed(2),
-      description: 'ภาษีหัก ณ ที่จ่าย',
+      accountCode: '11-4103',
+      debit: +totalWht.toFixed(2),
+      credit: 0,
+      description: 'ภาษีหัก ณ ที่จ่าย (รอเรียกคืน)',
     });
   }
 
@@ -313,9 +313,16 @@ export default function OtherIncomeEntryPage() {
     onError: () => toast.error('ไม่สามารถแนบไฟล์ได้'),
   });
 
+  const thresholdQuery = useQuery({
+    queryKey: ['other-income-attachment-threshold'],
+    queryFn: () => otherIncomeApi.getAttachmentThreshold(),
+    staleTime: 5 * 60_000,
+  });
+  const attachmentThreshold = thresholdQuery.data ?? ATTACHMENT_THRESHOLD_FALLBACK;
+
   const currentAttachments = loadQuery.data?.attachments ?? [];
   const amountReceived = Number(values.amountReceived) || 0;
-  const needsAttachment = amountReceived >= ATTACHMENT_THRESHOLD && currentAttachments.length === 0;
+  const needsAttachment = amountReceived >= attachmentThreshold && currentAttachments.length === 0;
 
   return (
     <div className="pb-32">
@@ -544,7 +551,7 @@ export default function OtherIncomeEntryPage() {
                 {needsAttachment && (
                   <div className="flex items-start gap-2 text-xs text-warning">
                     <AlertTriangle size={14} className="shrink-0 mt-0.5" />
-                    <span>ยอดรับ ≥ {ATTACHMENT_THRESHOLD.toLocaleString()} ฿ — ต้องแนบไฟล์ประกอบเพื่อ POST</span>
+                    <span>ยอดรับ ≥ {attachmentThreshold.toLocaleString()} ฿ — ต้องแนบไฟล์ประกอบเพื่อ POST</span>
                   </div>
                 )}
                 {/* Existing attachments */}
@@ -566,11 +573,19 @@ export default function OtherIncomeEntryPage() {
                   <input
                     ref={fileInputRef}
                     type="file"
+                    aria-hidden="true"
+                    tabIndex={-1}
                     className="hidden"
-                    accept=".pdf,.jpg,.jpeg,.png,.doc,.docx"
+                    accept="application/pdf,image/jpeg,image/png,image/webp"
                     onChange={(e) => {
                       const file = e.target.files?.[0];
-                      if (file) uploadAttachmentMutation.mutate(file);
+                      if (file) {
+                        if (file.size > 5 * 1024 * 1024) {
+                          toast.error('ไฟล์มีขนาดเกิน 5 MB');
+                        } else {
+                          uploadAttachmentMutation.mutate(file);
+                        }
+                      }
                       if (fileInputRef.current) fileInputRef.current.value = '';
                     }}
                   />
@@ -584,7 +599,7 @@ export default function OtherIncomeEntryPage() {
                     {uploadAttachmentMutation.isPending ? 'กำลังอัปโหลด...' : 'แนบไฟล์'}
                   </button>
                   <p className="text-xs text-muted-foreground mt-1">
-                    รองรับ PDF, รูปภาพ, Word — ขนาดสูงสุด 20 MB
+                    รองรับ PDF, JPG, PNG, WebP — ขนาดสูงสุด 5 MB
                   </p>
                 </div>
               </div>
@@ -631,8 +646,8 @@ export default function OtherIncomeEntryPage() {
                   <span className="text-muted-foreground">WHT</span>
                   <span>
                     -{jeLines
-                      .filter((l) => l.accountCode === '21-3101')
-                      .reduce((s, l) => s + l.credit, 0)
+                      .filter((l) => l.accountCode === '11-4103')
+                      .reduce((s, l) => s + l.debit, 0)
                       .toFixed(2)}{' '}
                     ฿
                   </span>
@@ -686,13 +701,15 @@ export default function OtherIncomeEntryPage() {
               const errors = form.formState.errors;
               const errorKeys = Object.keys(errors);
               const hasErrors = errorKeys.length > 0;
-              const tooltipMsg = hasErrors
-                ? `ฟิลด์ที่ยังไม่ผ่าน: ${errorKeys.join(', ')}`
-                : undefined;
+              const tooltipMsg = needsAttachment
+                ? `ต้องแนบเอกสารเมื่อยอดรับ ≥ ${attachmentThreshold.toLocaleString()} ฿`
+                : hasErrors
+                  ? `ฟิลด์ที่ยังไม่ผ่าน: ${errorKeys.join(', ')}`
+                  : undefined;
               return (
                 <button
                   type="button"
-                  disabled={isSubmitting || hasErrors}
+                  disabled={isSubmitting || hasErrors || needsAttachment}
                   title={tooltipMsg}
                   onClick={() => {
                     const raw = form.getValues();

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -1,10 +1,10 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Save, Send, ArrowLeft, Receipt } from 'lucide-react';
+import { Save, Send, ArrowLeft, Receipt, FileText, Paperclip, AlertTriangle } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { otherIncomeApi } from '@/lib/otherIncome';
@@ -14,6 +14,9 @@ import { AdjustmentTable } from './components/AdjustmentTable';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { PaymentCompareCard } from './components/PaymentCompareCard';
 import { CounterpartyPicker } from './components/CounterpartyPicker';
+
+// Threshold above which attachment is required (matches backend SystemConfig default)
+const ATTACHMENT_THRESHOLD = 50_000;
 
 // ------------------------------------------------------------------
 // JE preview computation — mirrors AutoJournalService on the backend
@@ -299,6 +302,21 @@ export default function OtherIncomeEntryPage() {
 
   const isSubmitting = saveDraftMutation.isPending || saveAndPostMutation.isPending;
 
+  // B7: Attachment uploader (only available after doc is saved and has an id)
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadAttachmentMutation = useMutation({
+    mutationFn: (file: File) => otherIncomeApi.uploadAttachment(id!, file),
+    onSuccess: () => {
+      toast.success('แนบไฟล์เรียบร้อยแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income', id] });
+    },
+    onError: () => toast.error('ไม่สามารถแนบไฟล์ได้'),
+  });
+
+  const currentAttachments = loadQuery.data?.attachments ?? [];
+  const amountReceived = Number(values.amountReceived) || 0;
+  const needsAttachment = amountReceived >= ATTACHMENT_THRESHOLD && currentAttachments.length === 0;
+
   return (
     <div className="pb-32">
       <div className="p-6 max-w-7xl mx-auto">
@@ -513,6 +531,64 @@ export default function OtherIncomeEntryPage() {
                 className="w-full border rounded-md px-3 py-2 text-sm bg-background"
               />
             </div>
+
+            {/* --- B7: Attachment section (visible in edit mode when doc exists) --- */}
+            {isEdit && (
+              <div className={`rounded-xl border p-5 space-y-3 ${needsAttachment ? 'border-warning bg-warning/5' : 'bg-card'}`}>
+                <div className="flex items-center gap-2">
+                  <Paperclip size={16} className={needsAttachment ? 'text-warning' : 'text-muted-foreground'} />
+                  <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                    เอกสารแนบ
+                  </h2>
+                </div>
+                {needsAttachment && (
+                  <div className="flex items-start gap-2 text-xs text-warning">
+                    <AlertTriangle size={14} className="shrink-0 mt-0.5" />
+                    <span>ยอดรับ ≥ {ATTACHMENT_THRESHOLD.toLocaleString()} ฿ — ต้องแนบไฟล์ประกอบเพื่อ POST</span>
+                  </div>
+                )}
+                {/* Existing attachments */}
+                {currentAttachments.length > 0 && (
+                  <ul className="space-y-1">
+                    {currentAttachments.map((att) => (
+                      <li key={att.id} className="flex items-center gap-2 text-xs">
+                        <FileText size={12} className="text-muted-foreground shrink-0" />
+                        <span className="flex-1 truncate">{att.filename}</span>
+                        <span className="text-muted-foreground">
+                          {(att.size / 1024).toFixed(1)} KB
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {/* Upload button */}
+                <div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    className="hidden"
+                    accept=".pdf,.jpg,.jpeg,.png,.doc,.docx"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) uploadAttachmentMutation.mutate(file);
+                      if (fileInputRef.current) fileInputRef.current.value = '';
+                    }}
+                  />
+                  <button
+                    type="button"
+                    disabled={uploadAttachmentMutation.isPending}
+                    onClick={() => fileInputRef.current?.click()}
+                    className="inline-flex items-center gap-2 px-3 py-2 text-xs font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
+                  >
+                    <Paperclip size={12} />
+                    {uploadAttachmentMutation.isPending ? 'กำลังอัปโหลด...' : 'แนบไฟล์'}
+                  </button>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    รองรับ PDF, รูปภาพ, Word — ขนาดสูงสุด 20 MB
+                  </p>
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Right column — JE Preview */}
@@ -606,23 +682,34 @@ export default function OtherIncomeEntryPage() {
               <Save size={16} />
               {saveDraftMutation.isPending ? 'กำลังบันทึก...' : 'บันทึกร่าง'}
             </button>
-            <button
-              type="button"
-              disabled={isSubmitting}
-              onClick={() => {
-                const raw = form.getValues();
-                const result = otherIncomeFormSchema.safeParse(raw);
-                if (!result.success) {
-                  toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
-                  return;
-                }
-                saveAndPostMutation.mutate(result.data);
-              }}
-              className="inline-flex items-center gap-2 px-5 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
-            >
-              <Send size={16} />
-              {saveAndPostMutation.isPending ? 'กำลัง POST...' : 'บันทึก & POST'}
-            </button>
+            {(() => {
+              const errors = form.formState.errors;
+              const errorKeys = Object.keys(errors);
+              const hasErrors = errorKeys.length > 0;
+              const tooltipMsg = hasErrors
+                ? `ฟิลด์ที่ยังไม่ผ่าน: ${errorKeys.join(', ')}`
+                : undefined;
+              return (
+                <button
+                  type="button"
+                  disabled={isSubmitting || hasErrors}
+                  title={tooltipMsg}
+                  onClick={() => {
+                    const raw = form.getValues();
+                    const result = otherIncomeFormSchema.safeParse(raw);
+                    if (!result.success) {
+                      toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+                      return;
+                    }
+                    saveAndPostMutation.mutate(result.data);
+                  }}
+                  className="inline-flex items-center gap-2 px-5 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                >
+                  <Send size={16} />
+                  {saveAndPostMutation.isPending ? 'กำลัง POST...' : 'บันทึก & POST'}
+                </button>
+              );
+            })()}
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/other-income/OtherIncomeReceiptPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeReceiptPage.tsx
@@ -222,7 +222,7 @@ export default function OtherIncomeReceiptPage() {
 
             {/* B11: 4 signature blocks per spec §3.5 + QR code */}
             <div className="mt-6">
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center text-xs text-muted-foreground">
+              <div className="grid grid-cols-2 md:grid-cols-4 print:grid-cols-4 gap-6 text-center text-xs text-muted-foreground">
                 {/* 1: ผู้ออกเอกสาร */}
                 <div>
                   <div className="border-b border-border mb-2 h-14"></div>

--- a/apps/web/src/pages/other-income/OtherIncomeReceiptPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeReceiptPage.tsx
@@ -220,20 +220,41 @@ export default function OtherIncomeReceiptPage() {
               </div>
             </div>
 
-            {/* Signature block + QR code */}
-            <div className="grid grid-cols-3 gap-8 mt-4 text-center text-xs text-muted-foreground items-end">
-              <div>
-                <div className="border-b border-border mb-2 h-12"></div>
-                <p>ผู้ออกเอกสาร / ผู้รับเงิน</p>
+            {/* B11: 4 signature blocks per spec §3.5 + QR code */}
+            <div className="mt-6">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center text-xs text-muted-foreground">
+                {/* 1: ผู้ออกเอกสาร */}
+                <div>
+                  <div className="border-b border-border mb-2 h-14"></div>
+                  <p className="font-medium">ผู้ออกเอกสาร</p>
+                  <p className="text-muted-foreground">ลายเซ็น / วันที่</p>
+                </div>
+                {/* 2: ตราประทับผู้ขาย */}
+                <div>
+                  <div className="border border-dashed border-border mb-2 h-14 flex items-center justify-center rounded">
+                    <span className="text-muted-foreground/50">ตราประทับ</span>
+                  </div>
+                  <p className="font-medium">ตราประทับ (ผู้ขาย)</p>
+                </div>
+                {/* 3: ผู้รับเอกสาร */}
+                <div>
+                  <div className="border-b border-border mb-2 h-14"></div>
+                  <p className="font-medium">ผู้รับเอกสาร</p>
+                  <p className="text-muted-foreground">ลายเซ็น / วันที่</p>
+                </div>
+                {/* 4: ตราประทับลูกค้า */}
+                <div>
+                  <div className="border border-dashed border-border mb-2 h-14 flex items-center justify-center rounded">
+                    <span className="text-muted-foreground/50">ตราประทับ</span>
+                  </div>
+                  <p className="font-medium">ตราประทับ (ลูกค้า)</p>
+                </div>
               </div>
-              <div>
-                <div className="border-b border-border mb-2 h-12"></div>
-                <p>ผู้รับเอกสาร / ลูกค้า</p>
-              </div>
-              <div className="flex flex-col items-center gap-1">
+              {/* QR code below signature row */}
+              <div className="flex flex-col items-center gap-1 mt-4">
                 <QRCodeSVG
                   value={`${window.location.origin}/other-income/${docQuery.data.id}`}
-                  size={80}
+                  size={72}
                   level="M"
                 />
                 <p className="text-xs text-muted-foreground mt-1">

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -87,9 +87,10 @@ function buildJeFromDoc(doc: OtherIncome): JeLine[] {
     lines.push({ accountCode: '21-2101', debit: 0, credit: totalVat, description: 'ภาษีขาย' });
   }
 
+  // B6: WHT is Dr 11-4103 (WHT receivable) per AutoJournalService — not Cr 21-3101
   const totalWht = parseFloat(doc.whtAmount) || 0;
   if (totalWht > 0) {
-    lines.push({ accountCode: '21-3101', debit: 0, credit: totalWht, description: 'ภาษีหัก ณ ที่จ่าย' });
+    lines.push({ accountCode: '11-4103', debit: totalWht, credit: 0, description: 'ภาษีหัก ณ ที่จ่าย' });
   }
 
   for (const adj of doc.adjustments) {
@@ -120,7 +121,8 @@ function buildJeFromDoc(doc: OtherIncome): JeLine[] {
 }
 
 // Roles that can reverse a POSTED document
-const REVERSE_ROLES = ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'];
+// B9: ACCOUNTANT removed — backend @Roles only allows OWNER/FINANCE_MANAGER on POST :id/reverse
+const REVERSE_ROLES = ['OWNER', 'FINANCE_MANAGER'];
 
 // ------------------------------------------------------------------
 // Main component
@@ -251,7 +253,7 @@ export default function OtherIncomeViewPage() {
               {doc.customerId && (
                 <button
                   onClick={() => navigate(`/other-income/${doc.id}/receipt`)}
-                  className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-bold bg-primary text-primary-foreground rounded-md"
+                  className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-bold bg-primary text-primary-foreground rounded-md animate-pulse"
                 >
                   <Printer size={16} /> พิมพ์ใบเสร็จ
                 </button>

--- a/apps/web/src/pages/other-income/components/ItemsTable.tsx
+++ b/apps/web/src/pages/other-income/components/ItemsTable.tsx
@@ -111,9 +111,15 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
               </select>
             </div>
             <div className="col-span-1">
-              <label className="text-muted-foreground">WHT%</label>
+              <label
+                className="text-muted-foreground"
+                title="แนะนำ: ดอกเบี้ย 15% / ค่าบริการ 3% / ค่าเช่า 5% / นิติบุคคล 1%"
+              >
+                WHT%
+              </label>
               <select
                 {...register(`items.${idx}.whtPct`)}
+                title="แนะนำ: ดอกเบี้ย 15% / ค่าบริการ 3% / ค่าเช่า 5% / นิติบุคคล 1%"
                 className="w-full border rounded px-1 py-1 text-xs font-mono"
               >
                 {[0, 1, 2, 3, 5, 7, 10, 15].map((p) => (


### PR DESCRIPTION
## Summary

Deep-verification of PR #761 against the original PDF spec found 12 bugs. This PR fixes all 12.

## HIGH severity (production-blocking)
- **B1+B2+B3+B4**: Daily Sheet was broken — byAccount/byPayment were Maps that JSON-serialize to {}; summary keys mismatched between API (vatAmount/whtAmount) and frontend (vat/wht); missing fields name (byAccount) and count (both)
- **B7**: Entry page had no attachment uploader, but V11 enforces requirement at backend for amount >= 50,000 THB. Added POST /other-income/:id/attachments endpoint + StorageModule wiring + frontend attachment section with threshold warning

## MEDIUM
- **B5**: Daily Sheet Table 1 column showed amountReceived instead of netReceived
- **B6**: ViewPage JE preview showed WHT as Cr 21-3101 but real JE posts Dr 11-4103 (WHT receivable)
- **B9**: ViewPage REVERSE_ROLES included ACCOUNTANT but backend @Roles only allows OWNER/FINANCE_MANAGER

## LOW (cosmetic/polish)
- **B8**: POST button now pre-flight-disabled when form has validation errors + title tooltip listing which fields fail
- **B10**: Post-POST print button has animate-pulse per spec §3.4
- **B11**: Receipt now has 4 signature blocks per spec §3.5 (ผู้ออก / ตราประทับผู้ขาย / ผู้รับ / ตราประทับลูกค้า)
- **B12**: ItemsTable WHT% select has suggestion tooltip

## Test plan
- [ ] CI Lint & Type check green (confirmed locally: API OK, Web OK)
- [ ] Backend dailySheet test passes (confirmed: 10/10 pass)
- [ ] Daily Sheet UI: VAT/WHT summary boxes show numbers (not NaN), Tables 2+3 populated with code/name/count
- [ ] Entry page edit mode: attachment section visible; large amounts show warning; file upload works
- [ ] ViewPage: ACCOUNTANT does not see Reverse button
- [ ] ViewPage JE preview: WHT entry shows Dr 11-4103 not Cr 21-3101
- [ ] Receipt print: 4 signature blocks visible

Fixes bugs found in PR #761.

Generated with [Claude Code](https://claude.com/claude-code)