### PR TITLE
feat(menu): add พิมพ์สติกเกอร์ to side menu for all roles

### DIFF
--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -44,6 +44,7 @@ import {
   ClipboardCheck,
   PiggyBank,
   Star,
+  Tag,
 } from 'lucide-react';
 
 /* ── Types ─────────────────────────────────────────── */
@@ -104,6 +105,7 @@ const SALES_CONFIG: RoleMenuConfig = {
       icon: Warehouse,
       items: [
         { label: 'สต็อกสินค้า', path: '/stock', icon: Warehouse },
+        { label: 'พิมพ์สติกเกอร์', path: '/stickers', icon: Tag },
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
         { label: 'CRM Pipeline', path: '/crm', icon: Kanban },
         { label: 'รวมแชท', path: '/chat', icon: MessageSquareMore },
@@ -153,6 +155,7 @@ const BRANCH_MANAGER_CONFIG: RoleMenuConfig = {
       icon: Warehouse,
       items: [
         { label: 'สต็อกสินค้า', path: '/stock', icon: Warehouse },
+        { label: 'พิมพ์สติกเกอร์', path: '/stickers', icon: Tag },
         { label: 'สั่งซื้อ (PO)', path: '/purchase-orders', icon: ClipboardList },
         { label: 'ผู้ขาย', path: '/suppliers', icon: Building2 },
       ],
@@ -211,6 +214,7 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
         { label: 'สัญญาผ่อนชำระ', path: '/contracts', icon: FileCheck },
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
         { label: 'จัดการอุปกรณ์', path: '/mdm', icon: Smartphone },
+        { label: 'พิมพ์สติกเกอร์', path: '/stickers', icon: Tag },
       ],
     },
     {
@@ -267,6 +271,7 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
         { label: 'บันทึกรายจ่าย', path: '/expenses', icon: Receipt },
+        { label: 'พิมพ์สติกเกอร์', path: '/stickers', icon: Tag },
         { label: 'งานของทีม', path: '/todos', icon: CheckSquare },
       ],
     },
@@ -329,6 +334,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'สั่งซื้อ (PO)', path: '/purchase-orders', icon: ClipboardList },
         { label: 'รับซื้อมือสอง', path: '/trade-in', icon: Smartphone },
         { label: 'สต็อกสินค้า', path: '/stock', icon: Warehouse },
+        { label: 'พิมพ์สติกเกอร์', path: '/stickers', icon: Tag },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- เพิ่มเมนู "พิมพ์สติกเกอร์" (path: /stickers, icon: Tag) ใน side menu ของทุก role
- ก่อนหน้านี้ /stickers route มีอยู่แล้ว แต่เข้าได้แค่ผ่านปุ่มใน StockPage หรือ URL ตรง

## ตำแหน่งที่เพิ่ม
- **OWNER** — กลุ่ม "คลัง & จัดซื้อ" (ใต้ "สต็อกสินค้า")
- **BRANCH_MANAGER** — กลุ่ม "คลัง & จัดซื้อ" (ใต้ "สต็อกสินค้า")
- **FINANCE_MANAGER** — กลุ่ม "สัญญา & ชำระ" (ท้ายกลุ่ม)
- **ACCOUNTANT** — กลุ่ม "งานประจำวัน" (ใต้ "บันทึกรายจ่าย")
- **SALES** — กลุ่ม "เครื่องมือ" (ใต้ "สต็อกสินค้า")

## Test plan
- [ ] Login each role, open sidebar, verify "พิมพ์สติกเกอร์" appears
- [ ] Click → navigates to /stickers
- [ ] Existing flow ผ่านปุ่มใน Stock ยังทำงานได้

🤖 Generated with [Claude Code](https://claude.com/claude-code)