### PR TITLE
design(stickers): catalog picker + redesigned 50×30mm thermal label

### DIFF
--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -5,19 +5,21 @@ import {
   Printer,
   Plus,
   X,
-  ScanBarcode,
-  CornerDownLeft,
+  Search,
+  ScanLine,
+  Check,
+  Smartphone,
+  Package,
   CheckCircle2,
   CircleAlert,
   Loader2,
-  Layers,
-  Ruler,
   Trash2,
 } from 'lucide-react';
 import api from '@/lib/api';
 import { formatGregorianDate } from '@/lib/date';
 import QueryBoundary from '@/components/QueryBoundary';
 
+/* ─── types ─────────────────────────────────────────── */
 interface StickerRate {
   downPayment: number;
   monthlyPrice: number;
@@ -39,20 +41,46 @@ interface StickerData {
   shopLogoUrl: string | null;
 }
 
+interface StockProduct {
+  id: string;
+  brand: string;
+  model: string;
+  color: string | null;
+  storage: string | null;
+  imeiSerial: string | null;
+  photos: string[];
+  branch: { id: string; name: string } | null;
+  prices: Array<{ price: string }>;
+}
+
 interface PrintItem {
   productId: string;
   qty: number;
 }
 
+/* ─── constants ────────────────────────────────────── */
 const RECENT_KEY = 'sticker-print:recent';
-const MAX_RECENT = 6;
+const MAX_RECENT = 8;
+const TAPE_PER_STICKER_MM = 52;
+
+const BRAND_TINTS: Record<string, string> = {
+  Apple: 'from-zinc-900 to-zinc-700',
+  Samsung: 'from-blue-900 to-blue-700',
+  OPPO: 'from-emerald-900 to-emerald-700',
+  Vivo: 'from-violet-900 to-violet-700',
+  Xiaomi: 'from-orange-900 to-orange-700',
+  Huawei: 'from-rose-900 to-rose-700',
+  Realme: 'from-yellow-900 to-amber-700',
+  Honor: 'from-sky-900 to-sky-700',
+};
+
+function brandTint(brand: string): string {
+  return BRAND_TINTS[brand] ?? 'from-slate-800 to-slate-600';
+}
 
 function formatBaht(n: number): string {
   return n.toLocaleString('th-TH');
 }
-
-// 50mm sticker + ~2mm gap between labels on a continuous roll
-const TAPE_PER_STICKER_MM = 52;
 
 function loadRecent(): string[] {
   try {
@@ -74,7 +102,7 @@ function saveRecent(ids: string[]) {
   }
 }
 
-// Physical-size sticker (50×30mm) — used for both screen preview AND print.
+/* ─── 50×30mm sticker (used for both print & preview) ─ */
 function StickerCard({ data }: { data: StickerData }) {
   const specParts = [
     data.color,
@@ -133,61 +161,146 @@ function StickerCard({ data }: { data: StickerData }) {
   );
 }
 
-// Wraps a StickerCard inside crop-mark frame for on-screen preview only.
-function DielineFrame({ children, label }: { children: React.ReactNode; label?: string }) {
-  return (
-    <div className="dieline-frame">
-      <div className="dieline-marks" aria-hidden="true">
-        <span className="mark mark-tl" />
-        <span className="mark mark-tr" />
-        <span className="mark mark-bl" />
-        <span className="mark mark-br" />
-      </div>
-      {children}
-      {label && <div className="dieline-label font-mono">{label}</div>}
-    </div>
-  );
-}
-
-function StatusBadge({
-  state,
+/* ─── product card (catalog picker) ──────────────── */
+function ProductCard({
+  product,
+  selected,
+  qty,
+  onAdd,
+  onInc,
+  onDec,
+  onRemove,
 }: {
-  state: 'ready' | 'loading' | 'missing' | 'pending';
+  product: StockProduct;
+  selected: boolean;
+  qty: number;
+  onAdd: () => void;
+  onInc: () => void;
+  onDec: () => void;
+  onRemove: () => void;
 }) {
-  if (state === 'ready')
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-primary">
-        <CheckCircle2 className="size-3" /> ready
-      </span>
-    );
-  if (state === 'loading')
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-muted-foreground">
-        <Loader2 className="size-3 animate-spin" /> lookup
-      </span>
-    );
-  if (state === 'missing')
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-warning">
-        <CircleAlert className="size-3" /> not found
-      </span>
-    );
+  const photo = product.photos?.[0];
+  const cash = product.prices?.[0]?.price ? parseFloat(product.prices[0].price) : null;
+  const tint = brandTint(product.brand);
+
   return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-muted-foreground/60">
-      <span className="size-1.5 rounded-full bg-muted-foreground/40" /> queued
-    </span>
+    <article
+      className={`product-card group relative ${selected ? 'is-selected' : ''}`}
+      onClick={() => {
+        if (!selected) onAdd();
+      }}
+    >
+      {/* Media */}
+      <div className={`product-media bg-gradient-to-br ${tint}`}>
+        {photo ? (
+          <img src={photo} alt="" loading="lazy" className="size-full object-cover" />
+        ) : (
+          <div className="flex size-full items-center justify-center">
+            <Smartphone className="size-12 text-white/30" strokeWidth={1.2} />
+          </div>
+        )}
+        {selected && (
+          <div className="product-check">
+            <Check className="size-3.5" strokeWidth={3} />
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="product-body">
+        <div className="flex items-start justify-between gap-2 min-w-0">
+          <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+              {product.brand}
+            </div>
+            <h3 className="font-semibold text-[15px] leading-tight truncate mt-0.5">
+              {product.model}
+            </h3>
+          </div>
+          {cash !== null && (
+            <div className="text-right shrink-0">
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                ราคา
+              </div>
+              <div className="font-mono font-semibold text-[15px] tabular-nums leading-tight">
+                {formatBaht(cash)}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5 mt-2.5">
+          {product.color && <span className="spec-pill">{product.color}</span>}
+          {product.storage && <span className="spec-pill">{product.storage}</span>}
+          {product.imeiSerial && (
+            <span className="spec-pill spec-pill-mono" title={product.imeiSerial}>
+              …{product.imeiSerial.slice(-6)}
+            </span>
+          )}
+        </div>
+
+        {/* Action footer */}
+        <div className="product-action">
+          {selected ? (
+            <div className="qty-control" onClick={(e) => e.stopPropagation()}>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (qty <= 1) onRemove();
+                  else onDec();
+                }}
+                aria-label={qty <= 1 ? 'ลบรายการ' : 'ลด'}
+              >
+                {qty <= 1 ? <Trash2 className="size-3.5" /> : '−'}
+              </button>
+              <span className="qty-num font-mono tabular-nums">{qty}</span>
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground mr-2">
+                ดวง
+              </span>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onInc();
+                }}
+                aria-label="เพิ่ม"
+              >
+                +
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAdd();
+              }}
+              className="add-btn"
+            >
+              <Plus className="size-3.5" />
+              เพิ่มเข้าคิว
+            </button>
+          )}
+        </div>
+      </div>
+    </article>
   );
 }
 
+/* ─── main page ───────────────────────────────────── */
 export default function StickerPrintPage() {
   const [searchParams] = useSearchParams();
   const idsFromUrl = searchParams.get('productIds');
 
   const [items, setItems] = useState<PrintItem[]>([]);
-  const [manualInput, setManualInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [activeBrand, setActiveBrand] = useState<string>('ทั้งหมด');
+  const [scanInput, setScanInput] = useState('');
+  const [scanOpen, setScanOpen] = useState(false);
   const [recent, setRecent] = useState<string[]>(() => loadRecent());
-  const [now, setNow] = useState(() => new Date());
-  const inputRef = useRef<HTMLInputElement>(null);
+  const scanRef = useRef<HTMLInputElement>(null);
 
   // Initialize from URL once on mount
   useEffect(() => {
@@ -199,27 +312,51 @@ export default function StickerPrintPage() {
         .map((id) => ({ productId: id, qty: 1 }));
       setItems(initial);
     }
-    inputRef.current?.focus();
   }, [idsFromUrl]);
 
-  // Live clock for the operator strip — refreshes once a minute
+  // Debounce search
   useEffect(() => {
-    const t = setInterval(() => setNow(new Date()), 60_000);
-    return () => clearInterval(t);
-  }, []);
+    const t = setTimeout(() => setDebouncedSearch(search), 200);
+    return () => clearTimeout(t);
+  }, [search]);
 
+  // Focus scanner when opened
+  useEffect(() => {
+    if (scanOpen) scanRef.current?.focus();
+  }, [scanOpen]);
+
+  /* ─── data: stock products ────────────────────── */
+  const stockQuery = useQuery({
+    queryKey: ['sticker-stock', debouncedSearch, activeBrand],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        status: 'IN_STOCK',
+        limit: '60',
+        page: '1',
+      });
+      if (debouncedSearch) params.set('search', debouncedSearch);
+      if (activeBrand && activeBrand !== 'ทั้งหมด') params.set('brand', activeBrand);
+      const res = await api.get(`/products/stock?${params.toString()}`);
+      return res.data as { products: StockProduct[]; total: number };
+    },
+  });
+
+  /* ─── data: brand list ────────────────────────── */
+  const brandsQuery = useQuery({
+    queryKey: ['sticker-brands'],
+    queryFn: async () => {
+      const res = await api.get('/products/brands');
+      return Array.isArray(res.data) ? (res.data as string[]) : [];
+    },
+  });
+
+  /* ─── data: sticker preview data ──────────────── */
   const productIdsKey = useMemo(
     () => items.map((i) => i.productId).sort().join(','),
     [items],
   );
 
-  const {
-    data: stickerData = [],
-    isFetching,
-    isError,
-    error,
-    refetch,
-  } = useQuery<StickerData[]>({
+  const previewQuery = useQuery<StickerData[]>({
     queryKey: ['sticker-data', productIdsKey],
     queryFn: async () => {
       if (items.length === 0) return [];
@@ -233,11 +370,10 @@ export default function StickerPrintPage() {
   });
 
   const dataMap = useMemo(
-    () => new Map(stickerData.map((d) => [d.productId, d])),
-    [stickerData],
+    () => new Map((previewQuery.data ?? []).map((d) => [d.productId, d])),
+    [previewQuery.data],
   );
 
-  // Build flat list expanded by qty, in user's input order
   const expandedStickers = useMemo(() => {
     const out: StickerData[] = [];
     for (const item of items) {
@@ -250,243 +386,290 @@ export default function StickerPrintPage() {
 
   const totalSheets = expandedStickers.length;
   const totalItems = items.length;
-  const readyCount = items.filter((i) => dataMap.has(i.productId)).length;
-  const tapeCm = (totalSheets * TAPE_PER_STICKER_MM) / 10; // mm → cm
+  const tapeCm = (totalSheets * TAPE_PER_STICKER_MM) / 10;
 
-  const addManual = (raw?: string) => {
-    const value = raw ?? manualInput;
-    const ids = value
+  /* ─── actions ────────────────────────────────── */
+  const addProduct = (productId: string) => {
+    setItems((prev) => {
+      if (prev.some((p) => p.productId === productId)) return prev;
+      return [...prev, { productId, qty: 1 }];
+    });
+    saveRecent([productId]);
+    setRecent(loadRecent());
+  };
+
+  const incQty = (productId: string) =>
+    setItems(items.map((i) => (i.productId === productId ? { ...i, qty: i.qty + 1 } : i)));
+  const decQty = (productId: string) =>
+    setItems(
+      items.map((i) =>
+        i.productId === productId ? { ...i, qty: Math.max(1, i.qty - 1) } : i,
+      ),
+    );
+  const removeItem = (productId: string) =>
+    setItems(items.filter((i) => i.productId !== productId));
+  const clearAll = () => setItems([]);
+
+  const handleScan = () => {
+    const ids = scanInput
       .split(/[\s,]+/)
       .map((s) => s.trim())
       .filter(Boolean);
     if (ids.length === 0) return;
-
     setItems((prev) => {
       const seen = new Set(prev.map((p) => p.productId));
       const next = [...prev];
       for (const id of ids) {
-        if (!seen.has(id)) {
-          next.push({ productId: id, qty: 1 });
-          seen.add(id);
-        }
+        if (!seen.has(id)) next.push({ productId: id, qty: 1 });
       }
       return next;
     });
     saveRecent(ids);
     setRecent(loadRecent());
-    setManualInput('');
-    inputRef.current?.focus();
-  };
-
-  const updateQty = (productId: string, qty: number) => {
-    setItems(items.map((i) => (i.productId === productId ? { ...i, qty: Math.max(1, qty) } : i)));
-  };
-
-  const removeItem = (productId: string) => {
-    setItems(items.filter((i) => i.productId !== productId));
-  };
-
-  const clearAll = () => {
-    setItems([]);
-    inputRef.current?.focus();
+    setScanInput('');
+    scanRef.current?.focus();
   };
 
   const handlePrint = () => window.print();
 
-  const dateLabel = now.toLocaleDateString('th-TH', {
-    weekday: 'short',
-    day: '2-digit',
-    month: 'short',
-  });
-  const timeLabel = now.toLocaleTimeString('th-TH', { hour: '2-digit', minute: '2-digit' });
+  const products = stockQuery.data?.products ?? [];
+  const brandPills = ['ทั้งหมด', ...(brandsQuery.data ?? [])];
+  const itemMap = new Map(items.map((i) => [i.productId, i]));
 
   return (
     <div>
-      {/* ─── PRINT-HIDDEN OPERATOR CONSOLE ──────────────────────────── */}
       <div className="print:hidden">
-        <header className="sticker-header">
-          <div className="flex items-baseline gap-3 min-w-0">
-            <div className="font-mono text-xs uppercase tracking-[0.18em] text-primary">
-              <span className="inline-block size-1.5 rounded-full bg-primary mr-2 animate-pulse" />
-              station / labels
+        {/* ─── HERO ────────────────────────────────────── */}
+        <header className="hero">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-primary mb-1">
+              <span className="inline-block size-1.5 rounded-full bg-primary mr-2 align-middle animate-pulse" />
+              thermal label · 50 × 30 mm
             </div>
-            <h1 className="text-lg font-semibold tracking-tight truncate">เครื่องพิมพ์สติกเกอร์</h1>
-            <span className="text-xs text-muted-foreground hidden sm:inline">
-              สติกเกอร์ติดเครื่อง 50 × 30 mm · thermal roll
-            </span>
+            <h1 className="text-[28px] sm:text-[32px] font-bold tracking-tight leading-none">
+              พิมพ์สติกเกอร์
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1.5">
+              เลือกหลายเครื่องจากสต็อกพร้อมขาย เพิ่มเข้าคิว แล้วสั่งพิมพ์ทีเดียว
+            </p>
           </div>
-          <div className="hidden md:flex items-center gap-4 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
-            <span>{dateLabel}</span>
-            <span className="text-foreground tabular-nums">{timeLabel}</span>
+          <div className="hero-stats">
+            <div>
+              <div className="hero-stat-num tabular-nums">{totalItems}</div>
+              <div className="hero-stat-label">รายการ</div>
+            </div>
+            <div className="hero-divider" />
+            <div>
+              <div className="hero-stat-num tabular-nums">{totalSheets}</div>
+              <div className="hero-stat-label">ดวง</div>
+            </div>
+            <div className="hero-divider" />
+            <div>
+              <div className="hero-stat-num tabular-nums">{tapeCm.toFixed(0)}</div>
+              <div className="hero-stat-label">ซม.เทป</div>
+            </div>
           </div>
         </header>
 
-        <div className="sticker-grid">
-          {/* ─── LEFT: SCANNER + QUEUE ─────────────────────────── */}
-          <section className="sticker-panel">
-            {/* Scanner input */}
-            <div className="scanner">
-              <ScanBarcode className={`scanner-icon ${manualInput ? 'is-active' : ''}`} />
-              <input
-                ref={inputRef}
-                type="text"
-                value={manualInput}
-                onChange={(e) => setManualInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    addManual();
-                  }
-                }}
-                placeholder="สแกน หรือ วาง Product ID / IMEI"
-                className="scanner-input font-mono"
-                spellCheck={false}
-                autoComplete="off"
-              />
-              <kbd className="scanner-hint">
-                <CornerDownLeft className="size-3" />
-                <span>Enter</span>
-              </kbd>
+        {/* ─── MAIN GRID ────────────────────────────────── */}
+        <div className="main-grid">
+          {/* LEFT: Picker */}
+          <section className="picker">
+            {/* Toolbar */}
+            <div className="toolbar">
+              <div className="search-box">
+                <Search className="size-4 text-muted-foreground shrink-0" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="ค้นหาแบรนด์ / รุ่น / IMEI ในสต็อก…"
+                  className="search-input"
+                  spellCheck={false}
+                />
+                {search && (
+                  <button type="button" onClick={() => setSearch('')} className="search-clear" aria-label="ล้าง">
+                    <X className="size-3.5" />
+                  </button>
+                )}
+              </div>
               <button
                 type="button"
-                onClick={() => addManual()}
-                disabled={!manualInput.trim()}
-                className="scanner-add"
+                onClick={() => setScanOpen((v) => !v)}
+                className={`scan-toggle ${scanOpen ? 'is-open' : ''}`}
               >
-                <Plus className="size-3.5" />
-                เพิ่ม
+                <ScanLine className="size-4" />
+                <span className="hidden sm:inline">สแกน / วาง ID</span>
               </button>
             </div>
 
-            {/* Stats strip */}
-            <dl className="stats-strip">
-              <div>
-                <dt>รายการ</dt>
-                <dd className="tabular-nums">
-                  <span className="text-foreground font-semibold">{totalItems}</span>
-                  <span className="text-muted-foreground/60 text-[11px] ml-1">/ {readyCount} พร้อม</span>
-                </dd>
-              </div>
-              <div>
-                <dt>ดวงทั้งหมด</dt>
-                <dd className="tabular-nums">
-                  <Layers className="size-3 inline-block mr-1 text-muted-foreground/70" />
-                  <span className="text-foreground font-semibold">{totalSheets}</span>
-                </dd>
-              </div>
-              <div>
-                <dt>เทปประมาณ</dt>
-                <dd className="tabular-nums">
-                  <Ruler className="size-3 inline-block mr-1 text-muted-foreground/70" />
-                  <span className="text-foreground font-semibold">
-                    {tapeCm > 0 ? tapeCm.toFixed(1) : '—'}
-                  </span>
-                  <span className="text-muted-foreground/60 text-[11px] ml-1">cm</span>
-                </dd>
-              </div>
-            </dl>
-
-            {/* Recent chips */}
-            {recent.length > 0 && (
-              <div className="recent">
-                <span className="recent-label">ใช้ล่าสุด</span>
-                <div className="recent-chips">
-                  {recent.map((id) => (
-                    <button
-                      key={id}
-                      type="button"
-                      onClick={() => addManual(id)}
-                      className="recent-chip font-mono"
-                      disabled={items.some((i) => i.productId === id)}
-                      title={`เพิ่ม ${id}`}
-                    >
-                      <Plus className="size-3 opacity-60" />
-                      {id.length > 14 ? `…${id.slice(-12)}` : id}
-                    </button>
-                  ))}
+            {/* Scanner panel (collapsed) */}
+            {scanOpen && (
+              <div className="scan-panel">
+                <div className="scan-row">
+                  <input
+                    ref={scanRef}
+                    type="text"
+                    value={scanInput}
+                    onChange={(e) => setScanInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleScan();
+                      }
+                    }}
+                    placeholder="วาง Product ID หรือ IMEI หลายๆ ตัว คั่นด้วยช่องว่าง / comma"
+                    className="scan-input font-mono"
+                    spellCheck={false}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleScan}
+                    disabled={!scanInput.trim()}
+                    className="scan-add"
+                  >
+                    <Plus className="size-4" />
+                    เพิ่ม
+                  </button>
                 </div>
+                {recent.length > 0 && (
+                  <div className="recent-row">
+                    <span className="recent-label">ใช้ล่าสุด</span>
+                    {recent.map((id) => (
+                      <button
+                        key={id}
+                        type="button"
+                        onClick={() => addProduct(id)}
+                        disabled={items.some((i) => i.productId === id)}
+                        className="recent-pill font-mono"
+                      >
+                        {id.length > 14 ? `…${id.slice(-12)}` : id}
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
             )}
 
-            {/* Queue */}
-            <div className="queue">
-              <div className="queue-head">
-                <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                  คิวพิมพ์
-                </span>
+            {/* Brand chips */}
+            {brandPills.length > 1 && (
+              <div className="brand-chips">
+                {brandPills.map((b) => (
+                  <button
+                    key={b}
+                    type="button"
+                    onClick={() => setActiveBrand(b)}
+                    className={`brand-chip ${activeBrand === b ? 'is-active' : ''}`}
+                  >
+                    {b}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* Product grid */}
+            <QueryBoundary
+              isLoading={stockQuery.isLoading}
+              isError={stockQuery.isError}
+              error={stockQuery.error}
+              onRetry={stockQuery.refetch}
+              errorTitle="โหลดสต็อกไม่สำเร็จ"
+            >
+              {products.length === 0 ? (
+                <div className="empty-grid">
+                  <Package className="size-10 text-muted-foreground/40 mb-2" strokeWidth={1.2} />
+                  <p className="text-sm text-muted-foreground">
+                    {debouncedSearch || activeBrand !== 'ทั้งหมด'
+                      ? 'ไม่พบสินค้าตามเงื่อนไข — ลองเปลี่ยนคำค้นหรือแบรนด์'
+                      : 'ไม่มีสินค้าพร้อมขายในสต็อก'}
+                  </p>
+                </div>
+              ) : (
+                <div className="product-grid">
+                  {products.map((p) => {
+                    const item = itemMap.get(p.id);
+                    return (
+                      <ProductCard
+                        key={p.id}
+                        product={p}
+                        selected={!!item}
+                        qty={item?.qty ?? 0}
+                        onAdd={() => addProduct(p.id)}
+                        onInc={() => incQty(p.id)}
+                        onDec={() => decQty(p.id)}
+                        onRemove={() => removeItem(p.id)}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </QueryBoundary>
+          </section>
+
+          {/* RIGHT: Print queue + preview */}
+          <aside className="queue-side">
+            <div className="queue-card">
+              <div className="queue-card-head">
+                <h2 className="text-[15px] font-semibold leading-tight">คิวพิมพ์</h2>
                 {items.length > 0 && (
                   <button type="button" onClick={clearAll} className="queue-clear">
                     <Trash2 className="size-3" />
-                    ล้างทั้งหมด
+                    ล้าง
                   </button>
                 )}
               </div>
 
               {items.length === 0 ? (
                 <div className="queue-empty">
-                  <p className="text-sm text-muted-foreground">
-                    คิวยังว่าง — สแกน barcode, วาง ID,
-                    <br />
-                    หรือเปิดจากหน้า "สต็อกสินค้า" → "พิมพ์สติกเกอร์"
+                  <div className="ghost-stack">
+                    <div className="ghost-paper" />
+                    <div className="ghost-paper" />
+                    <div className="ghost-paper top">
+                      <div className="text-[8pt] font-mono uppercase tracking-[0.2em] text-black/30">
+                        sticker preview
+                      </div>
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground text-center mt-3 max-w-[24ch]">
+                    เลือกเครื่องจากด้านซ้าย เพื่อเริ่มสร้างคิวพิมพ์
                   </p>
                 </div>
               ) : (
                 <ul className="queue-list">
                   {items.map((item, idx) => {
                     const data = dataMap.get(item.productId);
-                    const state: 'ready' | 'loading' | 'missing' | 'pending' = data
+                    const state = data
                       ? 'ready'
-                      : isFetching
+                      : previewQuery.isFetching
                         ? 'loading'
                         : 'missing';
                     return (
-                      <li key={item.productId} className="queue-row">
-                        <span className="queue-num font-mono">
-                          {String(idx + 1).padStart(2, '0')}
-                        </span>
+                      <li key={item.productId} className="queue-item">
+                        <div className="queue-marker">
+                          {state === 'ready' && <CheckCircle2 className="size-4 text-primary" />}
+                          {state === 'loading' && <Loader2 className="size-4 text-muted-foreground animate-spin" />}
+                          {state === 'missing' && <CircleAlert className="size-4 text-warning" />}
+                        </div>
                         <div className="min-w-0 flex-1">
-                          <div className="font-mono text-xs text-foreground/90 truncate">
-                            {item.productId}
-                          </div>
-                          <div className="text-[11px] text-muted-foreground truncate">
-                            {data ? (
-                              <>
-                                {data.brand} {data.model}
-                                {data.cashPrice !== null && (
-                                  <span className="ml-2 tabular-nums text-foreground/70">
-                                    ฿ {formatBaht(data.cashPrice)}
-                                  </span>
-                                )}
-                              </>
-                            ) : (
-                              <StatusBadge state={state} />
+                          <div className="text-[13px] font-medium truncate">
+                            {data ? `${data.brand} ${data.model}` : (
+                              <span className="text-muted-foreground">ไม่พบสินค้า</span>
                             )}
                           </div>
+                          <div className="text-[11px] font-mono text-muted-foreground/80 truncate">
+                            #{idx + 1} · {item.productId.slice(0, 12)}
+                            {item.productId.length > 12 ? '…' : ''}
+                          </div>
                         </div>
-                        {data && <StatusBadge state="ready" />}
-                        <div className="qty-stepper">
-                          <button
-                            type="button"
-                            onClick={() => updateQty(item.productId, item.qty - 1)}
-                            disabled={item.qty <= 1}
-                            aria-label="ลด"
-                          >
-                            −
-                          </button>
-                          <span className="font-mono tabular-nums">{item.qty}</span>
-                          <button
-                            type="button"
-                            onClick={() => updateQty(item.productId, item.qty + 1)}
-                            aria-label="เพิ่ม"
-                          >
-                            +
-                          </button>
+                        <div className="queue-qty">
+                          <span className="font-mono font-semibold tabular-nums">{item.qty}</span>
+                          <span className="text-[10px] text-muted-foreground ml-0.5">ดวง</span>
                         </div>
                         <button
                           type="button"
                           onClick={() => removeItem(item.productId)}
-                          className="queue-remove"
-                          aria-label="ลบรายการ"
+                          className="queue-x"
+                          aria-label="ลบ"
                         >
                           <X className="size-3.5" />
                         </button>
@@ -496,79 +679,60 @@ export default function StickerPrintPage() {
                 </ul>
               )}
             </div>
-          </section>
 
-          {/* ─── RIGHT: PREVIEW DECK ────────────────────────────── */}
-          <section className="sticker-deck">
-            <div className="deck-head">
-              <div className="flex items-center gap-2">
-                <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                  preview deck
-                </span>
-                <span className="text-xs text-muted-foreground">· แสดงผลตามจริง 1 : 1</span>
+            {/* Preview deck */}
+            {expandedStickers.length > 0 && (
+              <div className="preview-card">
+                <div className="preview-head">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                    preview
+                  </span>
+                  <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground tabular-nums">
+                    {totalSheets} ดวง · {tapeCm.toFixed(1)} cm
+                  </span>
+                </div>
+                <div className="preview-stack">
+                  {expandedStickers.slice(0, 8).map((data, idx) => (
+                    <div key={`${data.productId}-${idx}`} className="dieline">
+                      <span className="mark mark-tl" />
+                      <span className="mark mark-tr" />
+                      <span className="mark mark-bl" />
+                      <span className="mark mark-br" />
+                      <StickerCard data={data} />
+                    </div>
+                  ))}
+                  {expandedStickers.length > 8 && (
+                    <div className="preview-more font-mono">
+                      + อีก {expandedStickers.length - 8} ดวง
+                    </div>
+                  )}
+                </div>
               </div>
-              <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground tabular-nums">
-                {totalSheets} / {totalSheets} ดวง
-              </div>
-            </div>
+            )}
 
-            <QueryBoundary
-              isLoading={false}
-              isError={isError}
-              error={error}
-              onRetry={refetch}
-              errorTitle="โหลดข้อมูลสติกเกอร์ไม่สำเร็จ"
+            {/* PRINT button */}
+            <button
+              type="button"
+              onClick={handlePrint}
+              disabled={totalSheets === 0}
+              className="print-cta"
             >
-              <div className="deck-surface">
-                {expandedStickers.length === 0 ? (
-                  <div className="deck-empty">
-                    <DielineFrame label="50 × 30 mm">
-                      <div className="ghost-sticker">
-                        <div className="text-[7pt] uppercase tracking-[0.2em] text-black/30 font-mono">
-                          awaiting input
-                        </div>
-                        <div className="text-[10pt] text-black/40 mt-2">
-                          รอข้อมูลแรก…
-                        </div>
-                      </div>
-                    </DielineFrame>
-                    <p className="text-xs text-muted-foreground text-center max-w-[28ch]">
-                      ตัวอย่างจะปรากฏที่นี่ทันทีหลังเพิ่ม Product ID จากช่องสแกนทางซ้าย
-                    </p>
-                  </div>
-                ) : (
-                  <div className="deck-grid">
-                    {expandedStickers.map((data, idx) => (
-                      <DielineFrame
-                        key={`${data.productId}-${idx}`}
-                        label={`#${String(idx + 1).padStart(3, '0')}`}
-                      >
-                        <StickerCard data={data} />
-                      </DielineFrame>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </QueryBoundary>
-          </section>
-        </div>
-
-        {/* Sticky action bar */}
-        {totalSheets > 0 && (
-          <div className="print-bar">
-            <div className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
-              {totalSheets} ดวง · {tapeCm.toFixed(1)} cm tape
-            </div>
-            <button type="button" onClick={handlePrint} className="print-btn">
-              <Printer className="size-4" />
-              <span>พิมพ์</span>
-              <span className="font-mono tabular-nums opacity-80">({totalSheets})</span>
+              <Printer className="size-5" />
+              <span className="flex-1 text-left">
+                <span className="block text-[15px] font-semibold leading-tight">พิมพ์สติกเกอร์</span>
+                <span className="block text-[11px] opacity-80 leading-tight tabular-nums">
+                  {totalSheets > 0 ? `${totalSheets} ดวง · ใช้เทป ~${tapeCm.toFixed(1)} ซม.` : 'ยังไม่มีรายการในคิว'}
+                </span>
+              </span>
+              <span className="font-mono text-[14px] tabular-nums opacity-90">
+                {totalSheets}
+              </span>
             </button>
-          </div>
-        )}
+          </aside>
+        </div>
       </div>
 
-      {/* ─── PRINT-ONLY AREA ───────────────────────────────────────── */}
+      {/* ─── PRINT-ONLY ─────────────────────────────────── */}
       <div className="print-stickers hidden print:block">
         {expandedStickers.map((data, idx) => (
           <StickerCard key={`p-${data.productId}-${idx}`} data={data} />
@@ -576,7 +740,7 @@ export default function StickerPrintPage() {
       </div>
 
       <style>{`
-        /* ─── physical 50×30mm sticker ─────────────────────── */
+        /* ─── Physical sticker ──────────────────────────── */
         .sticker {
           width: 50mm;
           height: 30mm;
@@ -585,226 +749,423 @@ export default function StickerPrintPage() {
           box-sizing: border-box;
         }
 
-        /* ─── operator console layout ──────────────────────── */
-        .sticker-header {
+        /* ─── Hero ──────────────────────────────────────── */
+        .hero {
           display: flex;
-          align-items: center;
+          align-items: flex-end;
           justify-content: space-between;
-          gap: 1rem;
-          padding: 1rem 1.25rem;
-          margin-bottom: 1rem;
-          background: hsl(var(--card));
+          gap: 1.5rem;
+          padding: 1.25rem 1.5rem;
+          margin-bottom: 1.25rem;
+          background: linear-gradient(
+            135deg,
+            hsl(var(--card)) 0%,
+            hsl(var(--card)) 60%,
+            hsl(var(--primary) / 0.06) 100%
+          );
           border: 1px solid hsl(var(--border));
-          border-radius: 8px;
+          border-radius: 14px;
           position: relative;
           overflow: hidden;
         }
-        .sticker-header::before {
+        .hero::before {
           content: '';
           position: absolute;
-          left: 0; right: 0; bottom: 0;
-          height: 2px;
-          background: repeating-linear-gradient(
-            90deg,
-            hsl(var(--primary)) 0 8px,
-            transparent 8px 16px
-          );
-          opacity: 0.6;
+          inset: 0;
+          background-image:
+            radial-gradient(circle at 1px 1px, hsl(var(--primary) / 0.06) 1px, transparent 0);
+          background-size: 22px 22px;
+          mask-image: linear-gradient(to right, transparent 30%, black 100%);
+          pointer-events: none;
+        }
+        .hero-stats {
+          display: flex;
+          align-items: center;
+          gap: 1rem;
+          padding: 0.75rem 1.25rem;
+          background: hsl(var(--background));
+          border: 1px solid hsl(var(--border));
+          border-radius: 10px;
+          z-index: 1;
+        }
+        .hero-stat-num {
+          font-size: 24px;
+          font-weight: 700;
+          line-height: 1;
+          color: hsl(var(--foreground));
+        }
+        .hero-stat-label {
+          font-size: 10px;
+          text-transform: uppercase;
+          letter-spacing: 0.16em;
+          color: hsl(var(--muted-foreground));
+          margin-top: 4px;
+        }
+        .hero-divider {
+          width: 1px;
+          height: 32px;
+          background: hsl(var(--border));
+        }
+        @media (max-width: 640px) {
+          .hero { flex-direction: column; align-items: flex-start; }
         }
 
-        .sticker-grid {
+        /* ─── Layout ────────────────────────────────────── */
+        .main-grid {
           display: grid;
-          grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
-          gap: 1rem;
+          grid-template-columns: minmax(0, 1fr) 360px;
+          gap: 1.25rem;
           align-items: start;
         }
-        @media (max-width: 1024px) {
-          .sticker-grid { grid-template-columns: 1fr; }
+        @media (max-width: 1100px) {
+          .main-grid { grid-template-columns: 1fr; }
         }
 
-        .sticker-panel,
-        .sticker-deck {
+        /* ─── Picker ────────────────────────────────────── */
+        .picker {
           background: hsl(var(--card));
           border: 1px solid hsl(var(--border));
-          border-radius: 8px;
+          border-radius: 14px;
           padding: 1rem;
         }
 
-        /* ─── scanner input ────────────────────────────────── */
-        .scanner {
-          position: relative;
+        .toolbar {
+          display: flex;
+          gap: 0.5rem;
+        }
+        .search-box {
+          flex: 1;
           display: flex;
           align-items: center;
-          gap: 0.5rem;
-          padding: 0.625rem 0.75rem;
+          gap: 0.625rem;
+          padding: 0 0.875rem;
           background: hsl(var(--background));
           border: 1px solid hsl(var(--border));
-          border-radius: 6px;
+          border-radius: 10px;
+          height: 42px;
           transition: border-color 200ms, box-shadow 200ms;
         }
-        .scanner:focus-within {
+        .search-box:focus-within {
           border-color: hsl(var(--primary));
           box-shadow: 0 0 0 3px hsl(var(--primary) / 0.12);
         }
-        .scanner::after {
-          content: '';
-          position: absolute;
-          left: 2.25rem;
-          right: 8rem;
-          bottom: -1px;
-          height: 1px;
-          background: linear-gradient(
-            90deg,
-            transparent 0%,
-            hsl(var(--primary)) 50%,
-            transparent 100%
-          );
-          opacity: 0;
-          transition: opacity 200ms;
-        }
-        .scanner:focus-within::after { opacity: 0.4; animation: scan-line 1.6s ease-in-out infinite; }
-        @keyframes scan-line {
-          0%   { transform: translateX(-30%); opacity: 0; }
-          50%  { opacity: 0.6; }
-          100% { transform: translateX(30%); opacity: 0; }
-        }
-        .scanner-icon {
-          color: hsl(var(--muted-foreground));
-          flex-shrink: 0;
-          width: 1.125rem;
-          height: 1.125rem;
-        }
-        .scanner-icon.is-active { color: hsl(var(--primary)); }
-        .scanner-input {
+        .search-input {
           flex: 1;
           background: transparent;
           border: 0;
           outline: 0;
-          font-size: 0.95rem;
-          letter-spacing: 0.02em;
+          font-size: 14px;
           min-width: 0;
         }
-        .scanner-input::placeholder { color: hsl(var(--muted-foreground) / 0.7); letter-spacing: 0; }
-        .scanner-hint {
+        .search-input::placeholder { color: hsl(var(--muted-foreground) / 0.7); }
+        .search-clear {
           display: inline-flex;
           align-items: center;
-          gap: 0.25rem;
-          padding: 0.125rem 0.4rem;
-          font-family: var(--font-mono);
-          font-size: 10px;
-          text-transform: uppercase;
-          letter-spacing: 0.08em;
+          justify-content: center;
+          width: 22px;
+          height: 22px;
           color: hsl(var(--muted-foreground));
-          background: hsl(var(--muted));
-          border: 1px solid hsl(var(--border));
-          border-radius: 4px;
-        }
-        .scanner-add {
-          display: inline-flex;
-          align-items: center;
-          gap: 0.25rem;
-          padding: 0.375rem 0.75rem;
-          font-size: 0.8rem;
-          font-weight: 600;
-          color: hsl(var(--foreground));
-          background: hsl(var(--muted));
-          border: 1px solid hsl(var(--border));
+          background: transparent;
+          border: 0;
           border-radius: 4px;
           cursor: pointer;
-          transition: background 150ms;
         }
-        .scanner-add:hover:not(:disabled) { background: hsl(var(--accent)); }
-        .scanner-add:disabled { opacity: 0.4; cursor: not-allowed; }
+        .search-clear:hover { background: hsl(var(--accent)); color: hsl(var(--foreground)); }
 
-        /* ─── stats strip ─────────────────────────────────── */
-        .stats-strip {
-          display: grid;
-          grid-template-columns: repeat(3, 1fr);
-          gap: 0;
-          margin: 0.875rem 0;
-          padding: 0;
-          border-top: 1px dashed hsl(var(--border));
-          border-bottom: 1px dashed hsl(var(--border));
-        }
-        .stats-strip > div {
-          padding: 0.625rem 0.75rem;
-          border-right: 1px dashed hsl(var(--border));
-        }
-        .stats-strip > div:last-child { border-right: 0; }
-        .stats-strip dt {
-          font-family: var(--font-mono);
-          font-size: 10px;
-          text-transform: uppercase;
-          letter-spacing: 0.16em;
-          color: hsl(var(--muted-foreground));
-          margin-bottom: 0.125rem;
-        }
-        .stats-strip dd {
-          font-size: 0.95rem;
-          margin: 0;
-        }
-
-        /* ─── recent chips ────────────────────────────────── */
-        .recent {
-          display: flex;
-          align-items: flex-start;
-          gap: 0.625rem;
-          margin-bottom: 0.875rem;
-        }
-        .recent-label {
-          flex-shrink: 0;
-          padding-top: 0.3rem;
-          font-family: var(--font-mono);
-          font-size: 10px;
-          text-transform: uppercase;
-          letter-spacing: 0.16em;
-          color: hsl(var(--muted-foreground));
-        }
-        .recent-chips {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 0.3rem;
-          min-width: 0;
-        }
-        .recent-chip {
+        .scan-toggle {
           display: inline-flex;
           align-items: center;
-          gap: 0.25rem;
-          padding: 0.25rem 0.5rem;
-          font-size: 11px;
+          gap: 0.5rem;
+          padding: 0 0.875rem;
+          height: 42px;
+          font-size: 13px;
+          font-weight: 500;
           color: hsl(var(--foreground));
           background: hsl(var(--background));
           border: 1px solid hsl(var(--border));
-          border-radius: 4px;
+          border-radius: 10px;
           cursor: pointer;
-          transition: all 120ms;
+          transition: all 150ms;
         }
-        .recent-chip:hover:not(:disabled) {
+        .scan-toggle:hover { border-color: hsl(var(--primary) / 0.5); }
+        .scan-toggle.is-open {
+          background: hsl(var(--primary) / 0.1);
           border-color: hsl(var(--primary));
           color: hsl(var(--primary));
         }
-        .recent-chip:disabled { opacity: 0.35; cursor: not-allowed; }
 
-        /* ─── queue list ──────────────────────────────────── */
-        .queue-head {
+        /* Scan panel */
+        .scan-panel {
+          margin-top: 0.625rem;
+          padding: 0.875rem;
+          background: hsl(var(--background));
+          border: 1px solid hsl(var(--border));
+          border-radius: 10px;
+          animation: panel-in 200ms ease-out;
+        }
+        @keyframes panel-in {
+          from { opacity: 0; transform: translateY(-4px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .scan-row { display: flex; gap: 0.5rem; }
+        .scan-input {
+          flex: 1;
+          padding: 0.5rem 0.75rem;
+          background: hsl(var(--card));
+          border: 1px solid hsl(var(--border));
+          border-radius: 8px;
+          font-size: 13px;
+          outline: 0;
+        }
+        .scan-input:focus {
+          border-color: hsl(var(--primary));
+          box-shadow: 0 0 0 3px hsl(var(--primary) / 0.12);
+        }
+        .scan-add {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+          padding: 0 0.875rem;
+          font-size: 13px;
+          font-weight: 600;
+          color: hsl(var(--primary-foreground));
+          background: hsl(var(--primary));
+          border: 0;
+          border-radius: 8px;
+          cursor: pointer;
+        }
+        .scan-add:disabled { opacity: 0.4; cursor: not-allowed; }
+        .recent-row {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 0.375rem;
+          margin-top: 0.625rem;
+        }
+        .recent-label {
+          font-size: 10px;
+          text-transform: uppercase;
+          letter-spacing: 0.16em;
+          color: hsl(var(--muted-foreground));
+          margin-right: 0.25rem;
+        }
+        .recent-pill {
+          padding: 0.2rem 0.5rem;
+          font-size: 11px;
+          color: hsl(var(--foreground));
+          background: hsl(var(--card));
+          border: 1px solid hsl(var(--border));
+          border-radius: 999px;
+          cursor: pointer;
+          transition: all 120ms;
+        }
+        .recent-pill:hover:not(:disabled) {
+          border-color: hsl(var(--primary));
+          color: hsl(var(--primary));
+        }
+        .recent-pill:disabled { opacity: 0.3; cursor: not-allowed; }
+
+        /* Brand chips */
+        .brand-chips {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.375rem;
+          margin: 1rem 0 0.875rem;
+          padding-bottom: 0.875rem;
+          border-bottom: 1px dashed hsl(var(--border));
+        }
+        .brand-chip {
+          padding: 0.375rem 0.875rem;
+          font-size: 12px;
+          font-weight: 500;
+          color: hsl(var(--muted-foreground));
+          background: hsl(var(--background));
+          border: 1px solid hsl(var(--border));
+          border-radius: 999px;
+          cursor: pointer;
+          transition: all 150ms;
+        }
+        .brand-chip:hover { color: hsl(var(--foreground)); border-color: hsl(var(--primary) / 0.4); }
+        .brand-chip.is-active {
+          background: hsl(var(--primary));
+          color: hsl(var(--primary-foreground));
+          border-color: hsl(var(--primary));
+          box-shadow: 0 4px 12px -4px hsl(var(--primary) / 0.5);
+        }
+
+        /* ─── Product grid ──────────────────────────────── */
+        .product-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+          gap: 0.875rem;
+        }
+        .product-card {
+          position: relative;
+          display: flex;
+          flex-direction: column;
+          background: hsl(var(--card));
+          border: 1px solid hsl(var(--border));
+          border-radius: 12px;
+          overflow: hidden;
+          cursor: pointer;
+          transition: transform 200ms, border-color 200ms, box-shadow 200ms;
+        }
+        .product-card:hover {
+          transform: translateY(-2px);
+          border-color: hsl(var(--primary) / 0.5);
+          box-shadow: 0 12px 28px -16px hsl(0 0% 0% / 0.35);
+        }
+        .product-card.is-selected {
+          border-color: hsl(var(--primary));
+          box-shadow:
+            0 0 0 1px hsl(var(--primary)),
+            0 12px 28px -12px hsl(var(--primary) / 0.4);
+        }
+        .product-media {
+          position: relative;
+          aspect-ratio: 16 / 10;
+          overflow: hidden;
+        }
+        .product-check {
+          position: absolute;
+          top: 8px;
+          right: 8px;
+          width: 24px;
+          height: 24px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: white;
+          background: hsl(var(--primary));
+          border-radius: 999px;
+          box-shadow: 0 4px 10px hsl(var(--primary) / 0.5);
+          animation: check-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        @keyframes check-in {
+          from { transform: scale(0.4); opacity: 0; }
+          to   { transform: scale(1); opacity: 1; }
+        }
+        .product-body {
+          padding: 0.75rem 0.875rem;
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+        }
+        .spec-pill {
+          padding: 0.125rem 0.5rem;
+          font-size: 10px;
+          color: hsl(var(--muted-foreground));
+          background: hsl(var(--muted));
+          border-radius: 4px;
+        }
+        .spec-pill-mono { font-family: var(--font-mono); }
+
+        .product-action {
+          margin-top: 0.75rem;
+          padding-top: 0.625rem;
+          border-top: 1px dashed hsl(var(--border));
+        }
+        .add-btn {
+          width: 100%;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.375rem;
+          padding: 0.4rem 0.75rem;
+          font-size: 12px;
+          font-weight: 600;
+          color: hsl(var(--foreground));
+          background: hsl(var(--background));
+          border: 1px solid hsl(var(--border));
+          border-radius: 8px;
+          cursor: pointer;
+          transition: all 150ms;
+        }
+        .add-btn:hover {
+          color: hsl(var(--primary));
+          border-color: hsl(var(--primary));
+          background: hsl(var(--primary) / 0.06);
+        }
+        .qty-control {
           display: flex;
           align-items: center;
           justify-content: space-between;
-          padding: 0.5rem 0.25rem 0.625rem;
+          gap: 0.25rem;
+          padding: 0.25rem;
+          background: hsl(var(--primary) / 0.08);
+          border: 1px solid hsl(var(--primary) / 0.3);
+          border-radius: 8px;
+        }
+        .qty-control button {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 26px;
+          height: 26px;
+          font-size: 14px;
+          font-weight: 600;
+          color: hsl(var(--primary));
+          background: transparent;
+          border: 0;
+          border-radius: 6px;
+          cursor: pointer;
+          transition: background 150ms;
+        }
+        .qty-control button:hover { background: hsl(var(--primary) / 0.15); }
+        .qty-num {
+          flex: 1;
+          text-align: center;
+          font-size: 14px;
+          font-weight: 700;
+          color: hsl(var(--primary));
+        }
+
+        .empty-grid {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          padding: 3rem 1rem;
+          background: hsl(var(--background));
+          border: 1px dashed hsl(var(--border));
+          border-radius: 10px;
+        }
+
+        /* ─── Queue side ────────────────────────────────── */
+        .queue-side {
+          position: sticky;
+          top: 1rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.875rem;
+        }
+        .queue-card,
+        .preview-card {
+          background: hsl(var(--card));
+          border: 1px solid hsl(var(--border));
+          border-radius: 14px;
+          padding: 0.875rem 1rem;
+        }
+        .queue-card-head,
+        .preview-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding-bottom: 0.625rem;
+          margin-bottom: 0.5rem;
           border-bottom: 1px solid hsl(var(--border));
         }
         .queue-clear {
           display: inline-flex;
           align-items: center;
           gap: 0.25rem;
+          padding: 0.25rem 0.5rem;
           font-size: 11px;
           color: hsl(var(--muted-foreground));
-          cursor: pointer;
-          background: none;
+          background: transparent;
           border: 0;
-          padding: 0.25rem 0.5rem;
           border-radius: 4px;
-          transition: color 150ms, background 150ms;
+          cursor: pointer;
         }
         .queue-clear:hover { color: hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); }
 
@@ -812,62 +1173,38 @@ export default function StickerPrintPage() {
           list-style: none;
           padding: 0;
           margin: 0;
-          max-height: 50vh;
+          max-height: 260px;
           overflow-y: auto;
         }
-        .queue-row {
+        .queue-item {
           display: flex;
           align-items: center;
           gap: 0.625rem;
-          padding: 0.625rem 0.25rem;
+          padding: 0.5rem 0;
           border-bottom: 1px dashed hsl(var(--border));
-          animation: queue-in 220ms ease-out;
+          animation: row-in 200ms ease-out;
         }
-        .queue-row:last-child { border-bottom: 0; }
-        @keyframes queue-in {
+        .queue-item:last-child { border-bottom: 0; }
+        @keyframes row-in {
           from { opacity: 0; transform: translateX(-4px); }
           to   { opacity: 1; transform: translateX(0); }
         }
-        .queue-num {
-          font-size: 10px;
-          color: hsl(var(--muted-foreground) / 0.7);
-          min-width: 1.5ch;
-          text-align: right;
+        .queue-marker {
+          flex-shrink: 0;
+          width: 20px;
+          display: flex;
+          justify-content: center;
         }
-
-        .qty-stepper {
-          display: inline-flex;
-          align-items: center;
-          border: 1px solid hsl(var(--border));
-          border-radius: 4px;
-          overflow: hidden;
-          background: hsl(var(--background));
-        }
-        .qty-stepper button {
-          width: 1.5rem;
-          height: 1.5rem;
-          font-size: 14px;
-          line-height: 1;
-          color: hsl(var(--foreground));
-          background: transparent;
-          border: 0;
-          cursor: pointer;
-          transition: background 120ms;
-        }
-        .qty-stepper button:hover:not(:disabled) { background: hsl(var(--accent)); }
-        .qty-stepper button:disabled { opacity: 0.3; cursor: not-allowed; }
-        .qty-stepper span {
-          min-width: 1.75rem;
-          text-align: center;
+        .queue-qty {
+          flex-shrink: 0;
+          padding: 0.25rem 0.5rem;
+          background: hsl(var(--muted));
+          border-radius: 6px;
           font-size: 12px;
-          padding: 0 0.25rem;
-          border-left: 1px solid hsl(var(--border));
-          border-right: 1px solid hsl(var(--border));
         }
-
-        .queue-remove {
-          width: 1.5rem;
-          height: 1.5rem;
+        .queue-x {
+          width: 22px;
+          height: 22px;
           display: inline-flex;
           align-items: center;
           justify-content: center;
@@ -876,143 +1213,121 @@ export default function StickerPrintPage() {
           border: 0;
           border-radius: 4px;
           cursor: pointer;
-          transition: color 150ms, background 150ms;
         }
-        .queue-remove:hover { color: hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); }
+        .queue-x:hover { color: hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); }
 
         .queue-empty {
-          padding: 2rem 1rem;
-          text-align: center;
-          background: repeating-linear-gradient(
-            -45deg,
-            hsl(var(--muted) / 0.4) 0 6px,
-            transparent 6px 12px
-          );
-          border-radius: 6px;
-          margin-top: 0.625rem;
-        }
-
-        /* ─── preview deck ────────────────────────────────── */
-        .deck-head {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          padding-bottom: 0.625rem;
-          margin-bottom: 0.875rem;
-          border-bottom: 1px solid hsl(var(--border));
-        }
-        .deck-surface {
-          background:
-            radial-gradient(circle at 1px 1px, hsl(var(--muted-foreground) / 0.18) 1px, transparent 0)
-            0 0 / 16px 16px,
-            hsl(var(--muted) / 0.4);
-          border: 1px solid hsl(var(--border));
-          border-radius: 6px;
-          min-height: 320px;
-          padding: 1.5rem;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
-        .deck-grid {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 1.5rem;
-          justify-content: center;
-          width: 100%;
-        }
-        .deck-empty {
           display: flex;
           flex-direction: column;
           align-items: center;
-          gap: 1rem;
+          padding: 1rem 0.5rem 0.5rem;
+        }
+        .ghost-stack {
+          position: relative;
+          width: 110px;
+          height: 70px;
+        }
+        .ghost-paper {
+          position: absolute;
+          inset: 0;
+          background: hsl(var(--background));
+          border: 1px dashed hsl(var(--border));
+          border-radius: 4px;
+        }
+        .ghost-paper:nth-child(1) { transform: rotate(-6deg) translate(-6px, 4px); opacity: 0.5; }
+        .ghost-paper:nth-child(2) { transform: rotate(3deg) translate(2px, 2px); opacity: 0.7; }
+        .ghost-paper.top {
+          background: white;
+          border-style: dashed;
+          border-color: hsl(var(--border));
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 6px;
+          color: black;
+          box-shadow: 0 4px 12px -4px hsl(0 0% 0% / 0.15);
         }
 
-        /* ─── dieline frame (crop marks around sticker) ─── */
-        .dieline-frame {
+        /* Preview deck */
+        .preview-stack {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          align-items: center;
+          max-height: 360px;
+          overflow-y: auto;
+          padding: 0.5rem;
+          background:
+            radial-gradient(circle at 1px 1px, hsl(var(--muted-foreground) / 0.15) 1px, transparent 0)
+            0 0 / 14px 14px,
+            hsl(var(--background));
+          border-radius: 8px;
+        }
+        .dieline {
           position: relative;
-          padding: 8px;
+          padding: 6px;
           background: white;
           box-shadow:
             0 1px 0 hsl(var(--border)),
-            0 8px 20px -8px hsl(0 0% 0% / 0.18);
-          animation: dieline-in 260ms ease-out;
+            0 6px 16px -8px hsl(0 0% 0% / 0.2);
+          animation: dieline-in 240ms ease-out;
         }
         @keyframes dieline-in {
           from { opacity: 0; transform: translateY(4px); }
           to   { opacity: 1; transform: translateY(0); }
         }
-        .dieline-marks .mark {
+        .dieline .mark {
           position: absolute;
-          width: 8px;
-          height: 8px;
+          width: 7px;
+          height: 7px;
           border-color: hsl(var(--primary) / 0.65);
           border-style: solid;
           border-width: 0;
         }
-        .dieline-marks .mark-tl { top: -2px; left: -2px; border-top-width: 1.5px; border-left-width: 1.5px; }
-        .dieline-marks .mark-tr { top: -2px; right: -2px; border-top-width: 1.5px; border-right-width: 1.5px; }
-        .dieline-marks .mark-bl { bottom: -2px; left: -2px; border-bottom-width: 1.5px; border-left-width: 1.5px; }
-        .dieline-marks .mark-br { bottom: -2px; right: -2px; border-bottom-width: 1.5px; border-right-width: 1.5px; }
-        .dieline-label {
-          position: absolute;
-          right: 0;
-          top: -1.1rem;
-          font-size: 9px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
+        .dieline .mark-tl { top: -2px; left: -2px; border-top-width: 1.5px; border-left-width: 1.5px; }
+        .dieline .mark-tr { top: -2px; right: -2px; border-top-width: 1.5px; border-right-width: 1.5px; }
+        .dieline .mark-bl { bottom: -2px; left: -2px; border-bottom-width: 1.5px; border-left-width: 1.5px; }
+        .dieline .mark-br { bottom: -2px; right: -2px; border-bottom-width: 1.5px; border-right-width: 1.5px; }
+
+        .preview-more {
+          width: 100%;
+          padding: 0.5rem;
+          text-align: center;
+          font-size: 11px;
           color: hsl(var(--muted-foreground));
-        }
-
-        .ghost-sticker {
-          width: 50mm;
-          height: 30mm;
-          background: white;
-          border: 1px dashed hsl(var(--border));
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          padding: 1mm;
-        }
-
-        /* ─── sticky print bar ────────────────────────────── */
-        .print-bar {
-          position: fixed;
-          right: 1.5rem;
-          bottom: 1.5rem;
-          display: flex;
-          align-items: center;
-          gap: 1rem;
-          padding: 0.5rem 0.5rem 0.5rem 1rem;
           background: hsl(var(--card));
-          border: 1px solid hsl(var(--border));
-          border-radius: 999px;
-          box-shadow: 0 12px 32px -8px hsl(0 0% 0% / 0.25);
-          z-index: 30;
-          animation: bar-in 240ms cubic-bezier(0.16, 1, 0.3, 1);
+          border: 1px dashed hsl(var(--border));
+          border-radius: 6px;
         }
-        @keyframes bar-in {
-          from { opacity: 0; transform: translateY(8px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-        .print-btn {
-          display: inline-flex;
-          align-items: center;
-          gap: 0.5rem;
-          padding: 0.5rem 1rem;
-          font-weight: 600;
-          color: hsl(var(--primary-foreground));
-          background: hsl(var(--primary));
-          border: 0;
-          border-radius: 999px;
-          cursor: pointer;
-          transition: filter 150ms, transform 150ms;
-        }
-        .print-btn:hover { filter: brightness(1.1); transform: translateY(-1px); }
-        .print-btn:active { transform: translateY(0); }
 
-        /* ─── print rules ─────────────────────────────────── */
+        /* PRINT cta */
+        .print-cta {
+          display: flex;
+          align-items: center;
+          gap: 0.75rem;
+          padding: 0.875rem 1rem;
+          color: hsl(var(--primary-foreground));
+          background:
+            linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.85) 100%);
+          border: 0;
+          border-radius: 14px;
+          cursor: pointer;
+          transition: transform 200ms, box-shadow 200ms, filter 200ms;
+          box-shadow: 0 8px 24px -8px hsl(var(--primary) / 0.6);
+        }
+        .print-cta:not(:disabled):hover {
+          transform: translateY(-1px);
+          filter: brightness(1.05);
+          box-shadow: 0 12px 28px -8px hsl(var(--primary) / 0.7);
+        }
+        .print-cta:disabled {
+          background: hsl(var(--muted));
+          color: hsl(var(--muted-foreground));
+          cursor: not-allowed;
+          box-shadow: none;
+        }
+
+        /* ─── Print rules ────────────────────────────────── */
         @media print {
           @page { size: 50mm 30mm; margin: 0; }
           body { margin: 0; padding: 0; background: white; }

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -163,8 +163,8 @@ function StickerCard({ data }: { data: StickerData }) {
   );
 }
 
-/* ─── product card (catalog picker) ──────────────── */
-function ProductCard({
+/* ─── product row (catalog picker, list mode) ────── */
+function ProductRow({
   product,
   selected,
   qty,
@@ -186,52 +186,37 @@ function ProductCard({
   const tint = brandTint(product.brand);
 
   return (
-    <article
-      className={`product-card group relative ${selected ? 'is-selected' : ''}`}
+    <div
+      className={`product-row ${selected ? 'is-selected' : ''}`}
       onClick={() => {
         if (!selected) onAdd();
       }}
     >
-      {/* Media */}
-      <div className={`product-media bg-gradient-to-br ${tint}`}>
+      {/* Thumbnail */}
+      <div className={`row-thumb bg-gradient-to-br ${tint}`}>
         {photo ? (
           <img src={photo} alt="" loading="lazy" className="size-full object-cover" />
         ) : (
-          <div className="flex size-full items-center justify-center">
-            <Smartphone className="size-12 text-white/30" strokeWidth={1.2} />
-          </div>
+          <Smartphone className="size-5 text-white/40" strokeWidth={1.4} />
         )}
         {selected && (
-          <div className="product-check">
-            <Check className="size-3.5" strokeWidth={3} />
+          <div className="row-check">
+            <Check className="size-2.5" strokeWidth={3.5} />
           </div>
         )}
       </div>
 
       {/* Body */}
-      <div className="product-body">
-        <div className="flex items-start justify-between gap-2 min-w-0">
-          <div className="min-w-0">
-            <div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-              {product.brand}
-            </div>
-            <h3 className="font-semibold text-[15px] leading-tight truncate mt-0.5">
-              {product.model}
-            </h3>
-          </div>
-          {cash !== null && (
-            <div className="text-right shrink-0">
-              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                ราคา
-              </div>
-              <div className="font-mono font-semibold text-[15px] tabular-nums leading-tight">
-                {formatBaht(cash)}
-              </div>
-            </div>
-          )}
+      <div className="row-body min-w-0 flex-1">
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground shrink-0">
+            {product.brand}
+          </span>
+          <h3 className="font-semibold text-[14px] leading-tight truncate">
+            {product.model}
+          </h3>
         </div>
-
-        <div className="flex flex-wrap gap-1.5 mt-2.5">
+        <div className="flex flex-wrap items-center gap-1.5 mt-1">
           {product.color && <span className="spec-pill">{product.color}</span>}
           {product.storage && <span className="spec-pill">{product.storage}</span>}
           {product.imeiSerial && (
@@ -239,54 +224,41 @@ function ProductCard({
               …{product.imeiSerial.slice(-6)}
             </span>
           )}
-        </div>
-
-        {/* Action footer */}
-        <div className="product-action">
-          {selected ? (
-            <div className="qty-control" onClick={(e) => e.stopPropagation()}>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (qty <= 1) onRemove();
-                  else onDec();
-                }}
-                aria-label={qty <= 1 ? 'ลบรายการ' : 'ลด'}
-              >
-                {qty <= 1 ? <Trash2 className="size-3.5" /> : '−'}
-              </button>
-              <span className="qty-num font-mono tabular-nums">{qty}</span>
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground mr-2">
-                ดวง
-              </span>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onInc();
-                }}
-                aria-label="เพิ่ม"
-              >
-                +
-              </button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onAdd();
-              }}
-              className="add-btn"
-            >
-              <Plus className="size-3.5" />
-              เพิ่มเข้าคิว
-            </button>
+          {product.branch?.name && (
+            <span className="text-[10px] text-muted-foreground/80">· {product.branch.name}</span>
           )}
         </div>
       </div>
-    </article>
+
+      {/* Price */}
+      {cash !== null && (
+        <div className="row-price font-mono tabular-nums">
+          ฿ {formatBaht(cash)}
+        </div>
+      )}
+
+      {/* Action */}
+      <div className="row-action" onClick={(e) => e.stopPropagation()}>
+        {selected ? (
+          <div className="qty-control">
+            <button
+              type="button"
+              onClick={() => (qty <= 1 ? onRemove() : onDec())}
+              aria-label={qty <= 1 ? 'ลบ' : 'ลด'}
+            >
+              {qty <= 1 ? <Trash2 className="size-3.5" /> : '−'}
+            </button>
+            <span className="qty-num font-mono tabular-nums">{qty}</span>
+            <button type="button" onClick={onInc} aria-label="เพิ่ม">+</button>
+          </div>
+        ) : (
+          <button type="button" onClick={onAdd} className="add-btn-row">
+            <Plus className="size-3.5" />
+            เพิ่ม
+          </button>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -579,11 +551,11 @@ export default function StickerPrintPage() {
                   </p>
                 </div>
               ) : (
-                <div className="product-grid">
+                <div className="product-list">
                   {products.map((p) => {
                     const item = itemMap.get(p.id);
                     return (
-                      <ProductCard
+                      <ProductRow
                         key={p.id}
                         product={p}
                         selected={!!item}
@@ -926,85 +898,93 @@ export default function StickerPrintPage() {
           box-shadow: 0 4px 12px -4px hsl(var(--primary) / 0.5);
         }
 
-        /* ─── Product grid ──────────────────────────────── */
-        .product-grid {
-          display: grid;
-          grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-          gap: 0.875rem;
-        }
-        .product-card {
-          position: relative;
+        /* ─── Product list (rows) ───────────────────────── */
+        .product-list {
           display: flex;
           flex-direction: column;
+          gap: 0.375rem;
+        }
+        .product-row {
+          display: flex;
+          align-items: center;
+          gap: 0.875rem;
+          padding: 0.625rem 0.875rem;
           background: hsl(var(--card));
           border: 1px solid hsl(var(--border));
-          border-radius: 12px;
-          overflow: hidden;
+          border-radius: 10px;
           cursor: pointer;
-          transition: transform 200ms, border-color 200ms, box-shadow 200ms;
+          transition: border-color 150ms, background 150ms, transform 150ms;
         }
-        .product-card:hover {
-          transform: translateY(-2px);
+        .product-row:hover {
           border-color: hsl(var(--primary) / 0.5);
-          box-shadow: 0 12px 28px -16px hsl(0 0% 0% / 0.35);
+          background: hsl(var(--accent) / 0.4);
         }
-        .product-card.is-selected {
+        .product-row.is-selected {
           border-color: hsl(var(--primary));
-          box-shadow:
-            0 0 0 1px hsl(var(--primary)),
-            0 12px 28px -12px hsl(var(--primary) / 0.4);
+          background: hsl(var(--primary) / 0.06);
+          box-shadow: inset 3px 0 0 hsl(var(--primary));
         }
-        .product-media {
+        .row-thumb {
           position: relative;
-          aspect-ratio: 16 / 10;
+          width: 44px;
+          height: 44px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 8px;
           overflow: hidden;
+          flex-shrink: 0;
         }
-        .product-check {
+        .row-check {
           position: absolute;
-          top: 8px;
-          right: 8px;
-          width: 24px;
-          height: 24px;
+          top: -3px;
+          right: -3px;
+          width: 16px;
+          height: 16px;
           display: flex;
           align-items: center;
           justify-content: center;
           color: white;
           background: hsl(var(--primary));
+          border: 2px solid hsl(var(--card));
           border-radius: 999px;
-          box-shadow: 0 4px 10px hsl(var(--primary) / 0.5);
-          animation: check-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
+          animation: check-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
         }
         @keyframes check-in {
-          from { transform: scale(0.4); opacity: 0; }
+          from { transform: scale(0.3); opacity: 0; }
           to   { transform: scale(1); opacity: 1; }
         }
-        .product-body {
-          padding: 0.75rem 0.875rem;
+        .row-body {
           display: flex;
           flex-direction: column;
-          flex: 1;
+          gap: 0.125rem;
         }
+        .row-price {
+          font-size: 14px;
+          font-weight: 600;
+          color: hsl(var(--foreground));
+          flex-shrink: 0;
+          padding: 0 0.625rem;
+          border-left: 1px dashed hsl(var(--border));
+          line-height: 1;
+        }
+        .row-action { flex-shrink: 0; }
+
         .spec-pill {
-          padding: 0.125rem 0.5rem;
+          padding: 0.1rem 0.4rem;
           font-size: 10px;
           color: hsl(var(--muted-foreground));
           background: hsl(var(--muted));
-          border-radius: 4px;
+          border-radius: 3px;
+          line-height: 1.4;
         }
         .spec-pill-mono { font-family: var(--font-mono); }
 
-        .product-action {
-          margin-top: 0.75rem;
-          padding-top: 0.625rem;
-          border-top: 1px dashed hsl(var(--border));
-        }
-        .add-btn {
-          width: 100%;
+        .add-btn-row {
           display: inline-flex;
           align-items: center;
-          justify-content: center;
-          gap: 0.375rem;
-          padding: 0.4rem 0.75rem;
+          gap: 0.25rem;
+          padding: 0.375rem 0.75rem;
           font-size: 12px;
           font-weight: 600;
           color: hsl(var(--foreground));
@@ -1014,43 +994,45 @@ export default function StickerPrintPage() {
           cursor: pointer;
           transition: all 150ms;
         }
-        .add-btn:hover {
+        .add-btn-row:hover {
           color: hsl(var(--primary));
           border-color: hsl(var(--primary));
           background: hsl(var(--primary) / 0.06);
         }
         .qty-control {
-          display: flex;
+          display: inline-flex;
           align-items: center;
-          justify-content: space-between;
-          gap: 0.25rem;
-          padding: 0.25rem;
+          gap: 0;
+          padding: 0;
           background: hsl(var(--primary) / 0.08);
-          border: 1px solid hsl(var(--primary) / 0.3);
+          border: 1px solid hsl(var(--primary) / 0.4);
           border-radius: 8px;
+          overflow: hidden;
         }
         .qty-control button {
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          width: 26px;
-          height: 26px;
+          width: 28px;
+          height: 28px;
           font-size: 14px;
           font-weight: 600;
           color: hsl(var(--primary));
           background: transparent;
           border: 0;
-          border-radius: 6px;
           cursor: pointer;
           transition: background 150ms;
         }
         .qty-control button:hover { background: hsl(var(--primary) / 0.15); }
         .qty-num {
-          flex: 1;
+          min-width: 2rem;
           text-align: center;
-          font-size: 14px;
+          font-size: 13px;
           font-weight: 700;
           color: hsl(var(--primary));
+          padding: 0 0.25rem;
+          border-left: 1px solid hsl(var(--primary) / 0.25);
+          border-right: 1px solid hsl(var(--primary) / 0.25);
         }
 
         .empty-grid {

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -14,9 +14,11 @@ import {
   CircleAlert,
   Loader2,
   Trash2,
+  Tag,
 } from 'lucide-react';
 import api from '@/lib/api';
 import { formatGregorianDate } from '@/lib/date';
+import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 
 /* ─── types ─────────────────────────────────────────── */
@@ -439,37 +441,29 @@ export default function StickerPrintPage() {
   return (
     <div>
       <div className="print:hidden">
-        {/* ─── HERO ────────────────────────────────────── */}
-        <header className="hero">
-          <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-primary mb-1">
-              <span className="inline-block size-1.5 rounded-full bg-primary mr-2 align-middle animate-pulse" />
-              thermal label · 50 × 30 mm
+        <PageHeader
+          icon={<Tag className="size-4" strokeWidth={1.75} />}
+          title="พิมพ์สติกเกอร์"
+          subtitle="เลือกหลายเครื่องจากสต็อกพร้อมขาย เพิ่มเข้าคิว แล้วสั่งพิมพ์ทีเดียว · thermal 50 × 30 mm"
+          action={
+            <div className="hidden sm:flex items-center gap-3 px-3.5 py-1.5 rounded-md border border-border bg-card text-[12px]">
+              <div className="flex items-baseline gap-1">
+                <span className="font-semibold tabular-nums">{totalItems}</span>
+                <span className="text-muted-foreground">รายการ</span>
+              </div>
+              <span className="text-border">·</span>
+              <div className="flex items-baseline gap-1">
+                <span className="font-semibold tabular-nums">{totalSheets}</span>
+                <span className="text-muted-foreground">ดวง</span>
+              </div>
+              <span className="text-border">·</span>
+              <div className="flex items-baseline gap-1">
+                <span className="font-semibold tabular-nums">{tapeCm.toFixed(0)}</span>
+                <span className="text-muted-foreground">ซม.เทป</span>
+              </div>
             </div>
-            <h1 className="text-[28px] sm:text-[32px] font-bold tracking-tight leading-none">
-              พิมพ์สติกเกอร์
-            </h1>
-            <p className="text-sm text-muted-foreground mt-1.5">
-              เลือกหลายเครื่องจากสต็อกพร้อมขาย เพิ่มเข้าคิว แล้วสั่งพิมพ์ทีเดียว
-            </p>
-          </div>
-          <div className="hero-stats">
-            <div>
-              <div className="hero-stat-num tabular-nums">{totalItems}</div>
-              <div className="hero-stat-label">รายการ</div>
-            </div>
-            <div className="hero-divider" />
-            <div>
-              <div className="hero-stat-num tabular-nums">{totalSheets}</div>
-              <div className="hero-stat-label">ดวง</div>
-            </div>
-            <div className="hero-divider" />
-            <div>
-              <div className="hero-stat-num tabular-nums">{tapeCm.toFixed(0)}</div>
-              <div className="hero-stat-label">ซม.เทป</div>
-            </div>
-          </div>
-        </header>
+          }
+        />
 
         {/* ─── MAIN GRID ────────────────────────────────── */}
         <div className="main-grid">
@@ -747,67 +741,6 @@ export default function StickerPrintPage() {
           padding: 1mm 1.5mm;
           font-family: 'IBM Plex Sans Thai', system-ui, sans-serif;
           box-sizing: border-box;
-        }
-
-        /* ─── Hero ──────────────────────────────────────── */
-        .hero {
-          display: flex;
-          align-items: flex-end;
-          justify-content: space-between;
-          gap: 1.5rem;
-          padding: 1.25rem 1.5rem;
-          margin-bottom: 1.25rem;
-          background: linear-gradient(
-            135deg,
-            hsl(var(--card)) 0%,
-            hsl(var(--card)) 60%,
-            hsl(var(--primary) / 0.06) 100%
-          );
-          border: 1px solid hsl(var(--border));
-          border-radius: 14px;
-          position: relative;
-          overflow: hidden;
-        }
-        .hero::before {
-          content: '';
-          position: absolute;
-          inset: 0;
-          background-image:
-            radial-gradient(circle at 1px 1px, hsl(var(--primary) / 0.06) 1px, transparent 0);
-          background-size: 22px 22px;
-          mask-image: linear-gradient(to right, transparent 30%, black 100%);
-          pointer-events: none;
-        }
-        .hero-stats {
-          display: flex;
-          align-items: center;
-          gap: 1rem;
-          padding: 0.75rem 1.25rem;
-          background: hsl(var(--background));
-          border: 1px solid hsl(var(--border));
-          border-radius: 10px;
-          z-index: 1;
-        }
-        .hero-stat-num {
-          font-size: 24px;
-          font-weight: 700;
-          line-height: 1;
-          color: hsl(var(--foreground));
-        }
-        .hero-stat-label {
-          font-size: 10px;
-          text-transform: uppercase;
-          letter-spacing: 0.16em;
-          color: hsl(var(--muted-foreground));
-          margin-top: 4px;
-        }
-        .hero-divider {
-          width: 1px;
-          height: 32px;
-          background: hsl(var(--border));
-        }
-        @media (max-width: 640px) {
-          .hero { flex-direction: column; align-items: flex-start; }
         }
 
         /* ─── Layout ────────────────────────────────────── */

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -168,7 +168,7 @@ function StickerCard({ data }: { data: StickerData }) {
       {/* Footer: IMEI + brand mark */}
       <div className="st-footer">
         <span className="st-imei truncate">
-          {data.imei ? `IMEI ${data.imei}` : ' '}
+          {data.imei ?? ' '}
         </span>
         {data.shopLogoUrl ? (
           <img src={data.shopLogoUrl} alt="" className="st-logo" />

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -1,12 +1,22 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
-import { Printer, Plus, X } from 'lucide-react';
+import {
+  Printer,
+  Plus,
+  X,
+  ScanBarcode,
+  CornerDownLeft,
+  CheckCircle2,
+  CircleAlert,
+  Loader2,
+  Layers,
+  Ruler,
+  Trash2,
+} from 'lucide-react';
 import api from '@/lib/api';
 import { formatGregorianDate } from '@/lib/date';
-import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
-import { Button } from '@/components/ui/button';
 
 interface StickerRate {
   downPayment: number;
@@ -34,16 +44,49 @@ interface PrintItem {
   qty: number;
 }
 
+const RECENT_KEY = 'sticker-print:recent';
+const MAX_RECENT = 6;
+
 function formatBaht(n: number): string {
   return n.toLocaleString('th-TH');
 }
 
+// 50mm sticker + ~2mm gap between labels on a continuous roll
+const TAPE_PER_STICKER_MM = 52;
+
+function loadRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr.slice(0, MAX_RECENT) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(ids: string[]) {
+  try {
+    const merged = Array.from(new Set([...ids, ...loadRecent()])).slice(0, MAX_RECENT);
+    localStorage.setItem(RECENT_KEY, JSON.stringify(merged));
+  } catch {
+    // ignore
+  }
+}
+
+// Physical-size sticker (50×30mm) — used for both screen preview AND print.
 function StickerCard({ data }: { data: StickerData }) {
-  const specParts = [data.color, data.storage, data.batteryHealth !== null ? `แบต ${data.batteryHealth}%` : null].filter(Boolean);
-  const warrantyText = data.warrantyExpireDate ? `ประกันศูนย์ ${formatGregorianDate(data.warrantyExpireDate)}` : null;
+  const specParts = [
+    data.color,
+    data.storage,
+    data.batteryHealth !== null ? `แบต ${data.batteryHealth}%` : null,
+  ].filter(Boolean);
+  const warrantyText = data.warrantyExpireDate
+    ? `ประกันศูนย์ ${formatGregorianDate(data.warrantyExpireDate)}`
+    : null;
 
   return (
-    <div className="sticker bg-white text-black relative overflow-hidden border border-dashed border-border print:border-0">
+    <div className="sticker bg-white text-black relative overflow-hidden">
       <div className="flex justify-between items-start gap-1">
         <div className="font-bold text-[8pt] leading-tight truncate">
           {data.brand} {data.model}
@@ -64,12 +107,14 @@ function StickerCard({ data }: { data: StickerData }) {
 
       {data.rate1 && (
         <div className="text-[6.5pt] leading-tight tabular-nums">
-          เรทที่ 1  ดาวน์ {formatBaht(data.rate1.downPayment)}  {formatBaht(data.rate1.monthlyPrice)} × {data.rate1.termMonths} ด.
+          เรทที่ 1 ดาวน์ {formatBaht(data.rate1.downPayment)} {formatBaht(data.rate1.monthlyPrice)} ×{' '}
+          {data.rate1.termMonths} ด.
         </div>
       )}
       {data.rate2 && (
         <div className="text-[6.5pt] leading-tight tabular-nums">
-          เรทที่ 2  ดาวน์ {formatBaht(data.rate2.downPayment)}  {formatBaht(data.rate2.monthlyPrice)} × {data.rate2.termMonths} ด.
+          เรทที่ 2 ดาวน์ {formatBaht(data.rate2.downPayment)} {formatBaht(data.rate2.monthlyPrice)} ×{' '}
+          {data.rate2.termMonths} ด.
         </div>
       )}
 
@@ -88,12 +133,61 @@ function StickerCard({ data }: { data: StickerData }) {
   );
 }
 
+// Wraps a StickerCard inside crop-mark frame for on-screen preview only.
+function DielineFrame({ children, label }: { children: React.ReactNode; label?: string }) {
+  return (
+    <div className="dieline-frame">
+      <div className="dieline-marks" aria-hidden="true">
+        <span className="mark mark-tl" />
+        <span className="mark mark-tr" />
+        <span className="mark mark-bl" />
+        <span className="mark mark-br" />
+      </div>
+      {children}
+      {label && <div className="dieline-label font-mono">{label}</div>}
+    </div>
+  );
+}
+
+function StatusBadge({
+  state,
+}: {
+  state: 'ready' | 'loading' | 'missing' | 'pending';
+}) {
+  if (state === 'ready')
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-primary">
+        <CheckCircle2 className="size-3" /> ready
+      </span>
+    );
+  if (state === 'loading')
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" /> lookup
+      </span>
+    );
+  if (state === 'missing')
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-warning">
+        <CircleAlert className="size-3" /> not found
+      </span>
+    );
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase text-muted-foreground/60">
+      <span className="size-1.5 rounded-full bg-muted-foreground/40" /> queued
+    </span>
+  );
+}
+
 export default function StickerPrintPage() {
   const [searchParams] = useSearchParams();
   const idsFromUrl = searchParams.get('productIds');
 
   const [items, setItems] = useState<PrintItem[]>([]);
-  const [manualId, setManualId] = useState('');
+  const [manualInput, setManualInput] = useState('');
+  const [recent, setRecent] = useState<string[]>(() => loadRecent());
+  const [now, setNow] = useState(() => new Date());
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Initialize from URL once on mount
   useEffect(() => {
@@ -105,13 +199,23 @@ export default function StickerPrintPage() {
         .map((id) => ({ productId: id, qty: 1 }));
       setItems(initial);
     }
+    inputRef.current?.focus();
   }, [idsFromUrl]);
 
-  const productIdsKey = useMemo(() => items.map((i) => i.productId).sort().join(','), [items]);
+  // Live clock for the operator strip — refreshes once a minute
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const productIdsKey = useMemo(
+    () => items.map((i) => i.productId).sort().join(','),
+    [items],
+  );
 
   const {
     data: stickerData = [],
-    isLoading,
+    isFetching,
     isError,
     error,
     refetch,
@@ -120,15 +224,21 @@ export default function StickerPrintPage() {
     queryFn: async () => {
       if (items.length === 0) return [];
       const ids = items.map((i) => i.productId).join(',');
-      const res = await api.get(`/sticker-templates/products/data?ids=${encodeURIComponent(ids)}`);
+      const res = await api.get(
+        `/sticker-templates/products/data?ids=${encodeURIComponent(ids)}`,
+      );
       return Array.isArray(res.data) ? res.data : [];
     },
     enabled: items.length > 0,
   });
 
+  const dataMap = useMemo(
+    () => new Map(stickerData.map((d) => [d.productId, d])),
+    [stickerData],
+  );
+
   // Build flat list expanded by qty, in user's input order
   const expandedStickers = useMemo(() => {
-    const dataMap = new Map(stickerData.map((d) => [d.productId, d]));
     const out: StickerData[] = [];
     for (const item of items) {
       const data = dataMap.get(item.productId);
@@ -136,17 +246,36 @@ export default function StickerPrintPage() {
       for (let i = 0; i < item.qty; i++) out.push(data);
     }
     return out;
-  }, [items, stickerData]);
+  }, [items, dataMap]);
 
-  const addManual = () => {
-    const id = manualId.trim();
-    if (!id) return;
-    if (items.some((i) => i.productId === id)) {
-      setManualId('');
-      return;
-    }
-    setItems([...items, { productId: id, qty: 1 }]);
-    setManualId('');
+  const totalSheets = expandedStickers.length;
+  const totalItems = items.length;
+  const readyCount = items.filter((i) => dataMap.has(i.productId)).length;
+  const tapeCm = (totalSheets * TAPE_PER_STICKER_MM) / 10; // mm → cm
+
+  const addManual = (raw?: string) => {
+    const value = raw ?? manualInput;
+    const ids = value
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (ids.length === 0) return;
+
+    setItems((prev) => {
+      const seen = new Set(prev.map((p) => p.productId));
+      const next = [...prev];
+      for (const id of ids) {
+        if (!seen.has(id)) {
+          next.push({ productId: id, qty: 1 });
+          seen.add(id);
+        }
+      }
+      return next;
+    });
+    saveRecent(ids);
+    setRecent(loadRecent());
+    setManualInput('');
+    inputRef.current?.focus();
   };
 
   const updateQty = (productId: string, qty: number) => {
@@ -157,85 +286,297 @@ export default function StickerPrintPage() {
     setItems(items.filter((i) => i.productId !== productId));
   };
 
-  const handlePrint = () => {
-    window.print();
+  const clearAll = () => {
+    setItems([]);
+    inputRef.current?.focus();
   };
+
+  const handlePrint = () => window.print();
+
+  const dateLabel = now.toLocaleDateString('th-TH', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+  });
+  const timeLabel = now.toLocaleTimeString('th-TH', { hour: '2-digit', minute: '2-digit' });
 
   return (
     <div>
+      {/* ─── PRINT-HIDDEN OPERATOR CONSOLE ──────────────────────────── */}
       <div className="print:hidden">
-        <PageHeader title="พิมพ์สติกเกอร์" subtitle="สติกเกอร์ติดเครื่อง 50×30mm สำหรับเครื่องพิมพ์ thermal" />
-
-        <div className="bg-card rounded-xl border border-border/50 shadow-sm p-6 mb-6 space-y-4">
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={manualId}
-              onChange={(e) => setManualId(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && addManual()}
-              placeholder="วาง Product ID หรือ scan barcode แล้วกด Enter"
-              className="flex-1 px-3 py-2 border border-input rounded-lg text-sm outline-hidden focus:ring-2 focus:ring-ring/30 focus:border-ring"
-            />
-            <Button onClick={addManual} disabled={!manualId.trim()} variant="outline">
-              <Plus className="size-4 mr-1" /> เพิ่ม
-            </Button>
-            <Button onClick={handlePrint} disabled={expandedStickers.length === 0}>
-              <Printer className="size-4 mr-1" /> พิมพ์ ({expandedStickers.length} ดวง)
-            </Button>
-          </div>
-
-          {items.length > 0 && (
-            <div className="space-y-1">
-              {items.map((item) => {
-                const data = stickerData.find((d) => d.productId === item.productId);
-                return (
-                  <div key={item.productId} className="flex items-center gap-2 text-sm py-1 border-b border-border/30 last:border-0">
-                    <div className="flex-1 truncate">
-                      {data ? `${data.brand} ${data.model}` : <span className="text-muted-foreground">{item.productId}</span>}
-                    </div>
-                    <input
-                      type="number"
-                      min={1}
-                      value={item.qty}
-                      onChange={(e) => updateQty(item.productId, parseInt(e.target.value) || 1)}
-                      className="w-16 px-2 py-1 border border-input rounded text-sm text-center"
-                    />
-                    <span className="text-xs text-muted-foreground">ดวง</span>
-                    <button
-                      onClick={() => removeItem(item.productId)}
-                      className="text-muted-foreground hover:text-destructive"
-                      aria-label="ลบ"
-                    >
-                      <X className="size-4" />
-                    </button>
-                  </div>
-                );
-              })}
+        <header className="sticker-header">
+          <div className="flex items-baseline gap-3 min-w-0">
+            <div className="font-mono text-xs uppercase tracking-[0.18em] text-primary">
+              <span className="inline-block size-1.5 rounded-full bg-primary mr-2 animate-pulse" />
+              station / labels
             </div>
-          )}
+            <h1 className="text-lg font-semibold tracking-tight truncate">เครื่องพิมพ์สติกเกอร์</h1>
+            <span className="text-xs text-muted-foreground hidden sm:inline">
+              สติกเกอร์ติดเครื่อง 50 × 30 mm · thermal roll
+            </span>
+          </div>
+          <div className="hidden md:flex items-center gap-4 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+            <span>{dateLabel}</span>
+            <span className="text-foreground tabular-nums">{timeLabel}</span>
+          </div>
+        </header>
+
+        <div className="sticker-grid">
+          {/* ─── LEFT: SCANNER + QUEUE ─────────────────────────── */}
+          <section className="sticker-panel">
+            {/* Scanner input */}
+            <div className="scanner">
+              <ScanBarcode className={`scanner-icon ${manualInput ? 'is-active' : ''}`} />
+              <input
+                ref={inputRef}
+                type="text"
+                value={manualInput}
+                onChange={(e) => setManualInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addManual();
+                  }
+                }}
+                placeholder="สแกน หรือ วาง Product ID / IMEI"
+                className="scanner-input font-mono"
+                spellCheck={false}
+                autoComplete="off"
+              />
+              <kbd className="scanner-hint">
+                <CornerDownLeft className="size-3" />
+                <span>Enter</span>
+              </kbd>
+              <button
+                type="button"
+                onClick={() => addManual()}
+                disabled={!manualInput.trim()}
+                className="scanner-add"
+              >
+                <Plus className="size-3.5" />
+                เพิ่ม
+              </button>
+            </div>
+
+            {/* Stats strip */}
+            <dl className="stats-strip">
+              <div>
+                <dt>รายการ</dt>
+                <dd className="tabular-nums">
+                  <span className="text-foreground font-semibold">{totalItems}</span>
+                  <span className="text-muted-foreground/60 text-[11px] ml-1">/ {readyCount} พร้อม</span>
+                </dd>
+              </div>
+              <div>
+                <dt>ดวงทั้งหมด</dt>
+                <dd className="tabular-nums">
+                  <Layers className="size-3 inline-block mr-1 text-muted-foreground/70" />
+                  <span className="text-foreground font-semibold">{totalSheets}</span>
+                </dd>
+              </div>
+              <div>
+                <dt>เทปประมาณ</dt>
+                <dd className="tabular-nums">
+                  <Ruler className="size-3 inline-block mr-1 text-muted-foreground/70" />
+                  <span className="text-foreground font-semibold">
+                    {tapeCm > 0 ? tapeCm.toFixed(1) : '—'}
+                  </span>
+                  <span className="text-muted-foreground/60 text-[11px] ml-1">cm</span>
+                </dd>
+              </div>
+            </dl>
+
+            {/* Recent chips */}
+            {recent.length > 0 && (
+              <div className="recent">
+                <span className="recent-label">ใช้ล่าสุด</span>
+                <div className="recent-chips">
+                  {recent.map((id) => (
+                    <button
+                      key={id}
+                      type="button"
+                      onClick={() => addManual(id)}
+                      className="recent-chip font-mono"
+                      disabled={items.some((i) => i.productId === id)}
+                      title={`เพิ่ม ${id}`}
+                    >
+                      <Plus className="size-3 opacity-60" />
+                      {id.length > 14 ? `…${id.slice(-12)}` : id}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Queue */}
+            <div className="queue">
+              <div className="queue-head">
+                <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                  คิวพิมพ์
+                </span>
+                {items.length > 0 && (
+                  <button type="button" onClick={clearAll} className="queue-clear">
+                    <Trash2 className="size-3" />
+                    ล้างทั้งหมด
+                  </button>
+                )}
+              </div>
+
+              {items.length === 0 ? (
+                <div className="queue-empty">
+                  <p className="text-sm text-muted-foreground">
+                    คิวยังว่าง — สแกน barcode, วาง ID,
+                    <br />
+                    หรือเปิดจากหน้า "สต็อกสินค้า" → "พิมพ์สติกเกอร์"
+                  </p>
+                </div>
+              ) : (
+                <ul className="queue-list">
+                  {items.map((item, idx) => {
+                    const data = dataMap.get(item.productId);
+                    const state: 'ready' | 'loading' | 'missing' | 'pending' = data
+                      ? 'ready'
+                      : isFetching
+                        ? 'loading'
+                        : 'missing';
+                    return (
+                      <li key={item.productId} className="queue-row">
+                        <span className="queue-num font-mono">
+                          {String(idx + 1).padStart(2, '0')}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <div className="font-mono text-xs text-foreground/90 truncate">
+                            {item.productId}
+                          </div>
+                          <div className="text-[11px] text-muted-foreground truncate">
+                            {data ? (
+                              <>
+                                {data.brand} {data.model}
+                                {data.cashPrice !== null && (
+                                  <span className="ml-2 tabular-nums text-foreground/70">
+                                    ฿ {formatBaht(data.cashPrice)}
+                                  </span>
+                                )}
+                              </>
+                            ) : (
+                              <StatusBadge state={state} />
+                            )}
+                          </div>
+                        </div>
+                        {data && <StatusBadge state="ready" />}
+                        <div className="qty-stepper">
+                          <button
+                            type="button"
+                            onClick={() => updateQty(item.productId, item.qty - 1)}
+                            disabled={item.qty <= 1}
+                            aria-label="ลด"
+                          >
+                            −
+                          </button>
+                          <span className="font-mono tabular-nums">{item.qty}</span>
+                          <button
+                            type="button"
+                            onClick={() => updateQty(item.productId, item.qty + 1)}
+                            aria-label="เพิ่ม"
+                          >
+                            +
+                          </button>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => removeItem(item.productId)}
+                          className="queue-remove"
+                          aria-label="ลบรายการ"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </section>
+
+          {/* ─── RIGHT: PREVIEW DECK ────────────────────────────── */}
+          <section className="sticker-deck">
+            <div className="deck-head">
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                  preview deck
+                </span>
+                <span className="text-xs text-muted-foreground">· แสดงผลตามจริง 1 : 1</span>
+              </div>
+              <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground tabular-nums">
+                {totalSheets} / {totalSheets} ดวง
+              </div>
+            </div>
+
+            <QueryBoundary
+              isLoading={false}
+              isError={isError}
+              error={error}
+              onRetry={refetch}
+              errorTitle="โหลดข้อมูลสติกเกอร์ไม่สำเร็จ"
+            >
+              <div className="deck-surface">
+                {expandedStickers.length === 0 ? (
+                  <div className="deck-empty">
+                    <DielineFrame label="50 × 30 mm">
+                      <div className="ghost-sticker">
+                        <div className="text-[7pt] uppercase tracking-[0.2em] text-black/30 font-mono">
+                          awaiting input
+                        </div>
+                        <div className="text-[10pt] text-black/40 mt-2">
+                          รอข้อมูลแรก…
+                        </div>
+                      </div>
+                    </DielineFrame>
+                    <p className="text-xs text-muted-foreground text-center max-w-[28ch]">
+                      ตัวอย่างจะปรากฏที่นี่ทันทีหลังเพิ่ม Product ID จากช่องสแกนทางซ้าย
+                    </p>
+                  </div>
+                ) : (
+                  <div className="deck-grid">
+                    {expandedStickers.map((data, idx) => (
+                      <DielineFrame
+                        key={`${data.productId}-${idx}`}
+                        label={`#${String(idx + 1).padStart(3, '0')}`}
+                      >
+                        <StickerCard data={data} />
+                      </DielineFrame>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </QueryBoundary>
+          </section>
         </div>
 
-        <QueryBoundary
-          isLoading={isLoading}
-          isError={isError}
-          error={error}
-          onRetry={refetch}
-          errorTitle="โหลดข้อมูลสติกเกอร์ไม่สำเร็จ"
-        >
-          {expandedStickers.length === 0 && items.length > 0 && (
-            <div className="text-center text-muted-foreground py-8">ไม่พบสินค้าตาม ID ที่ระบุ</div>
-          )}
-        </QueryBoundary>
+        {/* Sticky action bar */}
+        {totalSheets > 0 && (
+          <div className="print-bar">
+            <div className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+              {totalSheets} ดวง · {tapeCm.toFixed(1)} cm tape
+            </div>
+            <button type="button" onClick={handlePrint} className="print-btn">
+              <Printer className="size-4" />
+              <span>พิมพ์</span>
+              <span className="font-mono tabular-nums opacity-80">({totalSheets})</span>
+            </button>
+          </div>
+        )}
       </div>
 
-      {/* Preview / Print area */}
-      <div className="print-stickers flex flex-wrap gap-2 print:gap-0 print:block justify-center">
+      {/* ─── PRINT-ONLY AREA ───────────────────────────────────────── */}
+      <div className="print-stickers hidden print:block">
         {expandedStickers.map((data, idx) => (
-          <StickerCard key={`${data.productId}-${idx}`} data={data} />
+          <StickerCard key={`p-${data.productId}-${idx}`} data={data} />
         ))}
       </div>
 
       <style>{`
+        /* ─── physical 50×30mm sticker ─────────────────────── */
         .sticker {
           width: 50mm;
           height: 30mm;
@@ -243,10 +584,440 @@ export default function StickerPrintPage() {
           font-family: 'IBM Plex Sans Thai', system-ui, sans-serif;
           box-sizing: border-box;
         }
+
+        /* ─── operator console layout ──────────────────────── */
+        .sticker-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 1rem;
+          padding: 1rem 1.25rem;
+          margin-bottom: 1rem;
+          background: hsl(var(--card));
+          border: 1px solid hsl(var(--border));
+          border-radius: 8px;
+          position: relative;
+          overflow: hidden;
+        }
+        .sticker-header::before {
+          content: '';
+          position: absolute;
+          left: 0; right: 0; bottom: 0;
+          height: 2px;
+          background: repeating-linear-gradient(
+            90deg,
+            hsl(var(--primary)) 0 8px,
+            transparent 8px 16px
+          );
+          opacity: 0.6;
+        }
+
+        .sticker-grid {
+          display: grid;
+          grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+          gap: 1rem;
+          align-items: start;
+        }
+        @media (max-width: 1024px) {
+          .sticker-grid { grid-template-columns: 1fr; }
+        }
+
+        .sticker-panel,
+        .sticker-deck {
+          background: hsl(var(--card));
+          border: 1px solid hsl(var(--border));
+          border-radius: 8px;
+          padding: 1rem;
+        }
+
+        /* ─── scanner input ────────────────────────────────── */
+        .scanner {
+          position: relative;
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.625rem 0.75rem;
+          background: hsl(var(--background));
+          border: 1px solid hsl(var(--border));
+          border-radius: 6px;
+          transition: border-color 200ms, box-shadow 200ms;
+        }
+        .scanner:focus-within {
+          border-color: hsl(var(--primary));
+          box-shadow: 0 0 0 3px hsl(var(--primary) / 0.12);
+        }
+        .scanner::after {
+          content: '';
+          position: absolute;
+          left: 2.25rem;
+          right: 8rem;
+          bottom: -1px;
+          height: 1px;
+          background: linear-gradient(
+            90deg,
+            transparent 0%,
+            hsl(var(--primary)) 50%,
+            transparent 100%
+          );
+          opacity: 0;
+          transition: opacity 200ms;
+        }
+        .scanner:focus-within::after { opacity: 0.4; animation: scan-line 1.6s ease-in-out infinite; }
+        @keyframes scan-line {
+          0%   { transform: translateX(-30%); opacity: 0; }
+          50%  { opacity: 0.6; }
+          100% { transform: translateX(30%); opacity: 0; }
+        }
+        .scanner-icon {
+          color: hsl(var(--muted-foreground));
+          flex-shrink: 0;
+          width: 1.125rem;
+          height: 1.125rem;
+        }
+        .scanner-icon.is-active { color: hsl(var(--primary)); }
+        .scanner-input {
+          flex: 1;
+          background: transparent;
+          border: 0;
+          outline: 0;
+          font-size: 0.95rem;
+          letter-spacing: 0.02em;
+          min-width: 0;
+        }
+        .scanner-input::placeholder { color: hsl(var(--muted-foreground) / 0.7); letter-spacing: 0; }
+        .scanner-hint {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+          padding: 0.125rem 0.4rem;
+          font-family: var(--font-mono);
+          font-size: 10px;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: hsl(var(--muted-foreground));
+          background: hsl(var(--muted));
+          border: 1px solid hsl(var(--border));
+          border-radius: 4px;
+        }
+        .scanner-add {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+          padding: 0.375rem 0.75rem;
+          font-size: 0.8rem;
+          font-weight: 600;
+          color: hsl(var(--foreground));
+          background: hsl(var(--muted));
+          border: 1px solid hsl(var(--border));
+          border-radius: 4px;
+          cursor: pointer;
+          transition: background 150ms;
+        }
+        .scanner-add:hover:not(:disabled) { background: hsl(var(--accent)); }
+        .scanner-add:disabled { opacity: 0.4; cursor: not-allowed; }
+
+        /* ─── stats strip ─────────────────────────────────── */
+        .stats-strip {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 0;
+          margin: 0.875rem 0;
+          padding: 0;
+          border-top: 1px dashed hsl(var(--border));
+          border-bottom: 1px dashed hsl(var(--border));
+        }
+        .stats-strip > div {
+          padding: 0.625rem 0.75rem;
+          border-right: 1px dashed hsl(var(--border));
+        }
+        .stats-strip > div:last-child { border-right: 0; }
+        .stats-strip dt {
+          font-family: var(--font-mono);
+          font-size: 10px;
+          text-transform: uppercase;
+          letter-spacing: 0.16em;
+          color: hsl(var(--muted-foreground));
+          margin-bottom: 0.125rem;
+        }
+        .stats-strip dd {
+          font-size: 0.95rem;
+          margin: 0;
+        }
+
+        /* ─── recent chips ────────────────────────────────── */
+        .recent {
+          display: flex;
+          align-items: flex-start;
+          gap: 0.625rem;
+          margin-bottom: 0.875rem;
+        }
+        .recent-label {
+          flex-shrink: 0;
+          padding-top: 0.3rem;
+          font-family: var(--font-mono);
+          font-size: 10px;
+          text-transform: uppercase;
+          letter-spacing: 0.16em;
+          color: hsl(var(--muted-foreground));
+        }
+        .recent-chips {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.3rem;
+          min-width: 0;
+        }
+        .recent-chip {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+          padding: 0.25rem 0.5rem;
+          font-size: 11px;
+          color: hsl(var(--foreground));
+          background: hsl(var(--background));
+          border: 1px solid hsl(var(--border));
+          border-radius: 4px;
+          cursor: pointer;
+          transition: all 120ms;
+        }
+        .recent-chip:hover:not(:disabled) {
+          border-color: hsl(var(--primary));
+          color: hsl(var(--primary));
+        }
+        .recent-chip:disabled { opacity: 0.35; cursor: not-allowed; }
+
+        /* ─── queue list ──────────────────────────────────── */
+        .queue-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 0.5rem 0.25rem 0.625rem;
+          border-bottom: 1px solid hsl(var(--border));
+        }
+        .queue-clear {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+          font-size: 11px;
+          color: hsl(var(--muted-foreground));
+          cursor: pointer;
+          background: none;
+          border: 0;
+          padding: 0.25rem 0.5rem;
+          border-radius: 4px;
+          transition: color 150ms, background 150ms;
+        }
+        .queue-clear:hover { color: hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); }
+
+        .queue-list {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          max-height: 50vh;
+          overflow-y: auto;
+        }
+        .queue-row {
+          display: flex;
+          align-items: center;
+          gap: 0.625rem;
+          padding: 0.625rem 0.25rem;
+          border-bottom: 1px dashed hsl(var(--border));
+          animation: queue-in 220ms ease-out;
+        }
+        .queue-row:last-child { border-bottom: 0; }
+        @keyframes queue-in {
+          from { opacity: 0; transform: translateX(-4px); }
+          to   { opacity: 1; transform: translateX(0); }
+        }
+        .queue-num {
+          font-size: 10px;
+          color: hsl(var(--muted-foreground) / 0.7);
+          min-width: 1.5ch;
+          text-align: right;
+        }
+
+        .qty-stepper {
+          display: inline-flex;
+          align-items: center;
+          border: 1px solid hsl(var(--border));
+          border-radius: 4px;
+          overflow: hidden;
+          background: hsl(var(--background));
+        }
+        .qty-stepper button {
+          width: 1.5rem;
+          height: 1.5rem;
+          font-size: 14px;
+          line-height: 1;
+          color: hsl(var(--foreground));
+          background: transparent;
+          border: 0;
+          cursor: pointer;
+          transition: background 120ms;
+        }
+        .qty-stepper button:hover:not(:disabled) { background: hsl(var(--accent)); }
+        .qty-stepper button:disabled { opacity: 0.3; cursor: not-allowed; }
+        .qty-stepper span {
+          min-width: 1.75rem;
+          text-align: center;
+          font-size: 12px;
+          padding: 0 0.25rem;
+          border-left: 1px solid hsl(var(--border));
+          border-right: 1px solid hsl(var(--border));
+        }
+
+        .queue-remove {
+          width: 1.5rem;
+          height: 1.5rem;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          color: hsl(var(--muted-foreground));
+          background: transparent;
+          border: 0;
+          border-radius: 4px;
+          cursor: pointer;
+          transition: color 150ms, background 150ms;
+        }
+        .queue-remove:hover { color: hsl(var(--destructive)); background: hsl(var(--destructive) / 0.08); }
+
+        .queue-empty {
+          padding: 2rem 1rem;
+          text-align: center;
+          background: repeating-linear-gradient(
+            -45deg,
+            hsl(var(--muted) / 0.4) 0 6px,
+            transparent 6px 12px
+          );
+          border-radius: 6px;
+          margin-top: 0.625rem;
+        }
+
+        /* ─── preview deck ────────────────────────────────── */
+        .deck-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding-bottom: 0.625rem;
+          margin-bottom: 0.875rem;
+          border-bottom: 1px solid hsl(var(--border));
+        }
+        .deck-surface {
+          background:
+            radial-gradient(circle at 1px 1px, hsl(var(--muted-foreground) / 0.18) 1px, transparent 0)
+            0 0 / 16px 16px,
+            hsl(var(--muted) / 0.4);
+          border: 1px solid hsl(var(--border));
+          border-radius: 6px;
+          min-height: 320px;
+          padding: 1.5rem;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .deck-grid {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1.5rem;
+          justify-content: center;
+          width: 100%;
+        }
+        .deck-empty {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 1rem;
+        }
+
+        /* ─── dieline frame (crop marks around sticker) ─── */
+        .dieline-frame {
+          position: relative;
+          padding: 8px;
+          background: white;
+          box-shadow:
+            0 1px 0 hsl(var(--border)),
+            0 8px 20px -8px hsl(0 0% 0% / 0.18);
+          animation: dieline-in 260ms ease-out;
+        }
+        @keyframes dieline-in {
+          from { opacity: 0; transform: translateY(4px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .dieline-marks .mark {
+          position: absolute;
+          width: 8px;
+          height: 8px;
+          border-color: hsl(var(--primary) / 0.65);
+          border-style: solid;
+          border-width: 0;
+        }
+        .dieline-marks .mark-tl { top: -2px; left: -2px; border-top-width: 1.5px; border-left-width: 1.5px; }
+        .dieline-marks .mark-tr { top: -2px; right: -2px; border-top-width: 1.5px; border-right-width: 1.5px; }
+        .dieline-marks .mark-bl { bottom: -2px; left: -2px; border-bottom-width: 1.5px; border-left-width: 1.5px; }
+        .dieline-marks .mark-br { bottom: -2px; right: -2px; border-bottom-width: 1.5px; border-right-width: 1.5px; }
+        .dieline-label {
+          position: absolute;
+          right: 0;
+          top: -1.1rem;
+          font-size: 9px;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: hsl(var(--muted-foreground));
+        }
+
+        .ghost-sticker {
+          width: 50mm;
+          height: 30mm;
+          background: white;
+          border: 1px dashed hsl(var(--border));
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          padding: 1mm;
+        }
+
+        /* ─── sticky print bar ────────────────────────────── */
+        .print-bar {
+          position: fixed;
+          right: 1.5rem;
+          bottom: 1.5rem;
+          display: flex;
+          align-items: center;
+          gap: 1rem;
+          padding: 0.5rem 0.5rem 0.5rem 1rem;
+          background: hsl(var(--card));
+          border: 1px solid hsl(var(--border));
+          border-radius: 999px;
+          box-shadow: 0 12px 32px -8px hsl(0 0% 0% / 0.25);
+          z-index: 30;
+          animation: bar-in 240ms cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        @keyframes bar-in {
+          from { opacity: 0; transform: translateY(8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .print-btn {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.5rem 1rem;
+          font-weight: 600;
+          color: hsl(var(--primary-foreground));
+          background: hsl(var(--primary));
+          border: 0;
+          border-radius: 999px;
+          cursor: pointer;
+          transition: filter 150ms, transform 150ms;
+        }
+        .print-btn:hover { filter: brightness(1.1); transform: translateY(-1px); }
+        .print-btn:active { transform: translateY(0); }
+
+        /* ─── print rules ─────────────────────────────────── */
         @media print {
           @page { size: 50mm 30mm; margin: 0; }
           body { margin: 0; padding: 0; background: white; }
           .print\\:hidden { display: none !important; }
+          .print\\:block { display: block !important; }
           .sticker {
             page-break-after: always;
             border: 0 !important;

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -1410,15 +1410,34 @@ export default function StickerPrintPage() {
         /* ─── Print rules ────────────────────────────────── */
         @media print {
           @page { size: 50mm 30mm; margin: 0; }
-          body { margin: 0; padding: 0; background: white; }
+
+          /* Hide everything (MainLayout sidebar/topbar/etc.) */
+          html, body { margin: 0; padding: 0; background: white; }
+          body * { visibility: hidden !important; }
+
+          /* Reveal only the stickers */
+          .print-stickers, .print-stickers * { visibility: visible !important; }
+          .print-stickers {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 50mm;
+          }
+
           .print\\:hidden { display: none !important; }
           .print\\:block { display: block !important; }
           .sticker {
             page-break-after: always;
+            page-break-inside: avoid;
+            break-after: page;
+            break-inside: avoid;
             border: 0 !important;
             margin: 0;
           }
-          .sticker:last-child { page-break-after: auto; }
+          .sticker:last-child {
+            page-break-after: auto;
+            break-after: auto;
+          }
         }
       `}</style>
     </div>

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -104,7 +104,7 @@ function saveRecent(ids: string[]) {
   }
 }
 
-/* ─── 50×30mm sticker (used for both print & preview) ─ */
+/* ─── 50×30mm thermal sticker — receipt-card aesthetic ─ */
 function StickerCard({ data }: { data: StickerData }) {
   const specParts = [
     data.color,
@@ -112,53 +112,73 @@ function StickerCard({ data }: { data: StickerData }) {
     data.batteryHealth !== null ? `แบต ${data.batteryHealth}%` : null,
   ].filter(Boolean);
   const warrantyText = data.warrantyExpireDate
-    ? `ประกันศูนย์ ${formatGregorianDate(data.warrantyExpireDate)}`
+    ? `ประกัน ${formatGregorianDate(data.warrantyExpireDate)}`
     : null;
 
   return (
-    <div className="sticker bg-white text-black relative overflow-hidden">
-      <div className="flex justify-between items-start gap-1">
-        <div className="font-bold text-[8pt] leading-tight truncate">
-          {data.brand} {data.model}
+    <div className="sticker bg-white text-black relative">
+      {/* Top: brand badge + model + price hero */}
+      <div className="st-row st-row-top">
+        <div className="st-brandblock min-w-0">
+          <span className="st-brand">{data.brand}</span>
+          <span className="st-model">{data.model}</span>
         </div>
         {data.cashPrice !== null && (
-          <div className="font-bold text-[9pt] leading-tight whitespace-nowrap">
-            ฿ {formatBaht(data.cashPrice)}
+          <div className="st-price tabular-nums">
+            <span className="st-currency">฿</span>
+            <span className="st-amount">{formatBaht(data.cashPrice)}</span>
           </div>
         )}
       </div>
 
-      <div className="flex justify-between items-start gap-1 text-[6.5pt] leading-tight mt-[0.5mm]">
-        <div className="truncate">{specParts.join(' · ') || ' '}</div>
-        {warrantyText && <div className="whitespace-nowrap">{warrantyText}</div>}
-      </div>
-
-      <hr className="my-[0.8mm] border-t border-black/40" />
-
-      {data.rate1 && (
-        <div className="text-[6.5pt] leading-tight tabular-nums">
-          เรทที่ 1 ดาวน์ {formatBaht(data.rate1.downPayment)} {formatBaht(data.rate1.monthlyPrice)} ×{' '}
-          {data.rate1.termMonths} ด.
-        </div>
-      )}
-      {data.rate2 && (
-        <div className="text-[6.5pt] leading-tight tabular-nums">
-          เรทที่ 2 ดาวน์ {formatBaht(data.rate2.downPayment)} {formatBaht(data.rate2.monthlyPrice)} ×{' '}
-          {data.rate2.termMonths} ด.
+      {/* Spec line */}
+      {(specParts.length > 0 || warrantyText) && (
+        <div className="st-row st-spec">
+          <span className="truncate">{specParts.join(' · ') || ' '}</span>
+          {warrantyText && <span className="st-warranty whitespace-nowrap">{warrantyText}</span>}
         </div>
       )}
 
-      <div className="absolute left-[1mm] right-[8mm] bottom-[0.5mm] text-[6pt] font-mono leading-none truncate">
-        {data.imei ? `IMEI: ${data.imei}` : ' '}
-      </div>
+      <div className="st-rule" />
 
-      {data.shopLogoUrl && (
-        <img
-          src={data.shopLogoUrl}
-          alt=""
-          className="absolute right-[1mm] bottom-[1mm] w-[7mm] h-[7mm] object-contain"
-        />
+      {/* Rates as mini-table */}
+      {(data.rate1 || data.rate2) && (
+        <div className="st-rates tabular-nums">
+          {data.rate1 && (
+            <div className="st-rate">
+              <span className="st-rate-tag">1</span>
+              <span className="st-rate-down">ดาวน์ {formatBaht(data.rate1.downPayment)}</span>
+              <span className="st-rate-monthly">
+                {formatBaht(data.rate1.monthlyPrice)}<span className="st-x"> × </span>{data.rate1.termMonths} ด.
+              </span>
+            </div>
+          )}
+          {data.rate2 && (
+            <div className="st-rate">
+              <span className="st-rate-tag">2</span>
+              <span className="st-rate-down">ดาวน์ {formatBaht(data.rate2.downPayment)}</span>
+              <span className="st-rate-monthly">
+                {formatBaht(data.rate2.monthlyPrice)}<span className="st-x"> × </span>{data.rate2.termMonths} ด.
+              </span>
+            </div>
+          )}
+        </div>
       )}
+
+      {/* Footer: IMEI + brand mark */}
+      <div className="st-footer">
+        <span className="st-imei truncate">
+          {data.imei ? `IMEI ${data.imei}` : ' '}
+        </span>
+        {data.shopLogoUrl ? (
+          <img src={data.shopLogoUrl} alt="" className="st-logo" />
+        ) : (
+          <span className="st-mark">
+            <span className="st-mark-b">B</span>
+            <span className="st-mark-rest">ESTCHOICE</span>
+          </span>
+        )}
+      </div>
     </div>
   );
 }
@@ -706,14 +726,157 @@ export default function StickerPrintPage() {
       </div>
 
       <style>{`
-        /* ─── Physical sticker ──────────────────────────── */
+        /* ─── Physical thermal sticker (50×30mm B&W) ───── */
         .sticker {
           width: 50mm;
           height: 30mm;
-          padding: 1mm 1.5mm;
+          padding: 1.4mm 1.6mm 1mm;
           font-family: 'IBM Plex Sans Thai', system-ui, sans-serif;
           box-sizing: border-box;
+          display: flex;
+          flex-direction: column;
+          color: #000;
+          line-height: 1.15;
         }
+        .st-row {
+          display: flex;
+          justify-content: space-between;
+          align-items: flex-start;
+          gap: 1mm;
+        }
+        .st-row-top { align-items: flex-start; }
+        .st-brandblock {
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
+        }
+        .st-brand {
+          font-size: 5.6pt;
+          font-weight: 700;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          line-height: 1;
+          color: #000;
+          margin-bottom: 0.3mm;
+        }
+        .st-model {
+          font-size: 8.5pt;
+          font-weight: 700;
+          line-height: 1.05;
+          letter-spacing: -0.005em;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .st-price {
+          display: inline-flex;
+          align-items: baseline;
+          gap: 0.4mm;
+          flex-shrink: 0;
+          padding: 0.6mm 1mm;
+          background: #000;
+          color: #fff;
+          border-radius: 0.6mm;
+        }
+        .st-currency {
+          font-size: 5.6pt;
+          font-weight: 600;
+          line-height: 1;
+        }
+        .st-amount {
+          font-size: 9pt;
+          font-weight: 800;
+          line-height: 1;
+          letter-spacing: -0.01em;
+        }
+        .st-spec {
+          font-size: 6.2pt;
+          margin-top: 0.7mm;
+          color: #1a1a1a;
+        }
+        .st-warranty { color: #444; }
+        .st-rule {
+          margin: 0.7mm 0 0.6mm;
+          height: 0;
+          border-top: 0.18mm solid #000;
+        }
+        .st-rates {
+          display: flex;
+          flex-direction: column;
+          gap: 0.4mm;
+        }
+        .st-rate {
+          display: grid;
+          grid-template-columns: 3.4mm 1fr auto;
+          align-items: baseline;
+          gap: 1mm;
+          font-size: 6.5pt;
+          line-height: 1.15;
+        }
+        .st-rate-tag {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 3mm;
+          height: 3mm;
+          font-family: var(--font-mono);
+          font-size: 5.5pt;
+          font-weight: 700;
+          color: #fff;
+          background: #000;
+          border-radius: 0.5mm;
+          line-height: 1;
+        }
+        .st-rate-down { font-weight: 600; color: #000; }
+        .st-rate-monthly { font-weight: 600; color: #000; white-space: nowrap; }
+        .st-x { color: #555; font-weight: 400; }
+
+        .st-footer {
+          margin-top: auto;
+          padding-top: 0.6mm;
+          border-top: 0.18mm dotted #000;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 1mm;
+        }
+        .st-imei {
+          font-family: var(--font-mono);
+          font-size: 5.4pt;
+          letter-spacing: 0.02em;
+          color: #1a1a1a;
+          flex: 1;
+          min-width: 0;
+        }
+        .st-logo {
+          width: 6mm;
+          height: 4.5mm;
+          object-fit: contain;
+          flex-shrink: 0;
+        }
+        .st-mark {
+          display: inline-flex;
+          align-items: center;
+          flex-shrink: 0;
+          font-size: 5.4pt;
+          font-weight: 700;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+        }
+        .st-mark-b {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 3mm;
+          height: 3mm;
+          margin-right: 0.6mm;
+          color: #fff;
+          background: #000;
+          border-radius: 0.4mm;
+          font-size: 5.4pt;
+          font-weight: 800;
+        }
+        .st-mark-rest { color: #000; }
 
         /* ─── Layout ────────────────────────────────────── */
         .main-grid {

--- a/apps/web/src/pages/StickerPrintPage.tsx
+++ b/apps/web/src/pages/StickerPrintPage.tsx
@@ -730,40 +730,40 @@ export default function StickerPrintPage() {
         .sticker {
           width: 50mm;
           height: 30mm;
-          padding: 1.4mm 1.6mm 1mm;
+          padding: 1.6mm 1.8mm 1.2mm;
           font-family: 'IBM Plex Sans Thai', system-ui, sans-serif;
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
           color: #000;
-          line-height: 1.15;
+          line-height: 1.12;
         }
         .st-row {
           display: flex;
           justify-content: space-between;
           align-items: flex-start;
-          gap: 1mm;
+          gap: 1.2mm;
         }
-        .st-row-top { align-items: flex-start; }
+        .st-row-top { align-items: center; }
         .st-brandblock {
           display: flex;
           flex-direction: column;
           min-width: 0;
         }
         .st-brand {
-          font-size: 5.6pt;
+          font-size: 7pt;
           font-weight: 700;
-          letter-spacing: 0.06em;
+          letter-spacing: 0.08em;
           text-transform: uppercase;
           line-height: 1;
           color: #000;
-          margin-bottom: 0.3mm;
+          margin-bottom: 0.5mm;
         }
         .st-model {
-          font-size: 8.5pt;
-          font-weight: 700;
-          line-height: 1.05;
-          letter-spacing: -0.005em;
+          font-size: 11pt;
+          font-weight: 800;
+          line-height: 1;
+          letter-spacing: -0.01em;
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
@@ -771,86 +771,88 @@ export default function StickerPrintPage() {
         .st-price {
           display: inline-flex;
           align-items: baseline;
-          gap: 0.4mm;
+          gap: 0.6mm;
           flex-shrink: 0;
-          padding: 0.6mm 1mm;
+          padding: 0.9mm 1.4mm;
           background: #000;
           color: #fff;
-          border-radius: 0.6mm;
+          border-radius: 0.8mm;
         }
         .st-currency {
-          font-size: 5.6pt;
+          font-size: 7pt;
           font-weight: 600;
           line-height: 1;
         }
         .st-amount {
-          font-size: 9pt;
+          font-size: 12pt;
           font-weight: 800;
           line-height: 1;
-          letter-spacing: -0.01em;
+          letter-spacing: -0.015em;
         }
         .st-spec {
-          font-size: 6.2pt;
-          margin-top: 0.7mm;
-          color: #1a1a1a;
+          font-size: 7.5pt;
+          margin-top: 1mm;
+          color: #000;
+          font-weight: 500;
         }
-        .st-warranty { color: #444; }
+        .st-warranty { color: #333; font-weight: 400; }
         .st-rule {
-          margin: 0.7mm 0 0.6mm;
+          margin: 1mm 0 0.8mm;
           height: 0;
-          border-top: 0.18mm solid #000;
+          border-top: 0.22mm solid #000;
         }
         .st-rates {
           display: flex;
           flex-direction: column;
-          gap: 0.4mm;
+          gap: 0.6mm;
         }
         .st-rate {
           display: grid;
-          grid-template-columns: 3.4mm 1fr auto;
-          align-items: baseline;
-          gap: 1mm;
-          font-size: 6.5pt;
-          line-height: 1.15;
+          grid-template-columns: 3.8mm 1fr auto;
+          align-items: center;
+          gap: 1.2mm;
+          font-size: 8pt;
+          line-height: 1.1;
         }
         .st-rate-tag {
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          width: 3mm;
-          height: 3mm;
+          width: 3.4mm;
+          height: 3.4mm;
           font-family: var(--font-mono);
-          font-size: 5.5pt;
+          font-size: 7pt;
           font-weight: 700;
           color: #fff;
           background: #000;
-          border-radius: 0.5mm;
+          border-radius: 0.6mm;
           line-height: 1;
         }
         .st-rate-down { font-weight: 600; color: #000; }
-        .st-rate-monthly { font-weight: 600; color: #000; white-space: nowrap; }
+        .st-rate-monthly { font-weight: 700; color: #000; white-space: nowrap; }
         .st-x { color: #555; font-weight: 400; }
 
         .st-footer {
           margin-top: auto;
-          padding-top: 0.6mm;
-          border-top: 0.18mm dotted #000;
+          padding-top: 0.8mm;
+          border-top: 0.22mm dotted #000;
           display: flex;
           align-items: center;
           justify-content: space-between;
-          gap: 1mm;
+          gap: 1.2mm;
         }
         .st-imei {
           font-family: var(--font-mono);
-          font-size: 5.4pt;
+          font-size: 6.6pt;
           letter-spacing: 0.02em;
-          color: #1a1a1a;
+          color: #000;
           flex: 1;
           min-width: 0;
+          font-weight: 500;
         }
         .st-logo {
-          width: 6mm;
-          height: 4.5mm;
+          width: 7mm;
+          height: 5.5mm;
           object-fit: contain;
           flex-shrink: 0;
         }
@@ -858,22 +860,22 @@ export default function StickerPrintPage() {
           display: inline-flex;
           align-items: center;
           flex-shrink: 0;
-          font-size: 5.4pt;
+          font-size: 6.4pt;
           font-weight: 700;
-          letter-spacing: 0.06em;
+          letter-spacing: 0.08em;
           text-transform: uppercase;
         }
         .st-mark-b {
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          width: 3mm;
-          height: 3mm;
-          margin-right: 0.6mm;
+          width: 3.6mm;
+          height: 3.6mm;
+          margin-right: 0.8mm;
           color: #fff;
           background: #000;
-          border-radius: 0.4mm;
-          font-size: 5.4pt;
+          border-radius: 0.5mm;
+          font-size: 6.6pt;
           font-weight: 800;
         }
         .st-mark-rest { color: #000; }


### PR DESCRIPTION
## Summary
ออกแบบหน้า /stickers ใหม่หมด + redesign สติกเกอร์ 50×30mm ให้สวย + แก้ปัญหา print เพี้ยน

## หน้า /stickers (Frontend redesign)
- **PageHeader มาตรฐาน** + stats chip (รายการ/ดวง/ซม.เทป)
- **Catalog picker** — ดึงสินค้าจาก stock พร้อมขาย (`status=IN_STOCK`)
- **List rows** — thumbnail 44px + brand+model + spec pills + ราคา + ปุ่ม +/qty stepper
- **Search + brand chips + scanner panel** (paste IMEI หลายตัว, รองรับ comma/whitespace)
- **Recent IDs** เก็บใน localStorage 8 ตัว
- **Sticky queue panel** ขวา + dieline preview + PRINT button gradient

## สติกเกอร์ 50×30mm (B&W thermal)
- Brand uppercase + model bold เป็น hero ซ้าย
- ฿ ราคาใน **black pill** (กล่องดำตัวอักษรขาว) เป็น hero ขวา
- Hairline rule + dotted footer divider
- Rates เป็น mini-table — black tag pill (1/2) + ดาวน์ + monthly × n
- Footer: เลข IMEI ล้วน (ไม่มีคำว่า "IMEI") + BESTCHOICE wordmark fallback

## Bug fixes
- กด print แล้วเป็น app shell ทั้งหน้า → ใช้ `visibility` trick ซ่อนทุกอย่างในหน้า แสดงเฉพาะ `.print-stickers`
- `shopLogoUrl=null` ใน DB → ใส่ wordmark fallback

## Test plan
- [ ] เปิด /stickers → product list โหลดได้
- [ ] คลิก add → เห็น check + ใน queue ขวา
- [ ] กด PRINT → preview แสดงเฉพาะสติกเกอร์ 1 ดวง = 1 หน้า ไม่มี sidebar/header
- [ ] Brand filter, search, scanner panel ทำงาน

🤖 Generated with [Claude Code](https://claude.com/claude-code)