### PR TITLE
design(stock): overhaul — dedupe + action zone + modern aesthetic

### DIFF
--- a/apps/web/src/pages/StockPage/components/BranchSummaryCards.tsx
+++ b/apps/web/src/pages/StockPage/components/BranchSummaryCards.tsx
@@ -7,32 +7,53 @@ export interface BranchSummaryCardsProps {
 }
 
 export function BranchSummaryCards({ summary, filterBranch, setFilterBranch }: BranchSummaryCardsProps) {
-  // Hide branches with zero stock so inactive/legacy branches don't clutter the dashboard.
-  // Fallback: if every branch has zero, show the full list so user isn't stuck with blank UI.
-  const visible = summary.some((s) => s.total > 0)
-    ? summary.filter((s) => s.total > 0)
-    : summary;
+  // Hide test branches (name starting with `__`) and inactive branches with zero stock.
+  const realBranches = summary.filter((s) => !s.branch.name.startsWith('__'));
+  const visible = realBranches.some((s) => s.total > 0)
+    ? realBranches.filter((s) => s.total > 0)
+    : realBranches;
 
   if (visible.length === 0) return null;
 
+  const totalStock = visible.reduce((sum, s) => sum + s.inStock, 0);
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-      {visible.map((s) => (
-        <button
-          key={s.branch.id}
-          onClick={() => setFilterBranch(filterBranch === s.branch.id ? '' : s.branch.id)}
-          className={`rounded-xl border p-4 text-left transition-all hover:shadow-card-hover ${
-            filterBranch === s.branch.id ? 'border-primary ring-2 ring-primary/20 border-l-[3px] border-l-primary shadow-card' : 'border-border/60 hover:border-border'
-          }`}
-        >
-          <div className="text-sm font-medium text-foreground mb-2">{s.branch.name}</div>
-          <div className="flex justify-between text-xs text-muted-foreground">
-            <span>พร้อมขาย: {s.inStock}</span>
-            <span>ทั้งหมด: {s.total}</span>
-          </div>
-          <div className="text-xs text-muted-foreground mt-1">มูลค่า: {s.totalValue.toLocaleString()} ฿</div>
-        </button>
-      ))}
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+      {visible.map((s) => {
+        const sharePct = totalStock > 0 ? (s.inStock / totalStock) * 100 : 0;
+        const isActive = filterBranch === s.branch.id;
+        return (
+          <button
+            key={s.branch.id}
+            onClick={() => setFilterBranch(isActive ? '' : s.branch.id)}
+            className={`relative overflow-hidden rounded-xl border p-3.5 text-left transition-all group ${
+              isActive
+                ? 'border-primary bg-primary/5 shadow-[0_0_0_1px_hsl(var(--primary))]'
+                : 'border-border/60 bg-card hover:border-primary/40 hover:bg-accent/30'
+            }`}
+          >
+            {/* Share fill bar */}
+            <div
+              className={`absolute inset-y-0 left-0 transition-all ${
+                isActive ? 'bg-primary/10' : 'bg-muted/50 group-hover:bg-muted'
+              }`}
+              style={{ width: `${sharePct}%` }}
+              aria-hidden
+            />
+            <div className="relative">
+              <div className="text-[13px] font-semibold text-foreground truncate mb-1.5">{s.branch.name}</div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-2xl font-bold tabular-nums">{s.inStock}</span>
+                <span className="text-[11px] text-muted-foreground">/ {s.total} ชิ้น</span>
+              </div>
+              <div className="flex items-center justify-between text-[11px] text-muted-foreground mt-1.5">
+                <span className="tabular-nums">{s.totalValue.toLocaleString()} ฿</span>
+                <span className="tabular-nums">{sharePct.toFixed(0)}%</span>
+              </div>
+            </div>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/pages/StockPage/components/StockActionZone.tsx
+++ b/apps/web/src/pages/StockPage/components/StockActionZone.tsx
@@ -1,0 +1,215 @@
+import { AlertTriangle, ArrowRightLeft, Clock, Camera, ShieldAlert, ChevronRight } from 'lucide-react';
+import { useNavigate } from 'react-router';
+import type { StockDashboard } from '../types';
+import { formatDateShort } from '@/utils/formatters';
+
+export interface StockActionZoneProps {
+  dashboard: StockDashboard | undefined;
+  warrantyExpiring: { id: string; name: string; brand: string; model: string; warrantyExpireDate: string }[];
+  onNavigateToList: (status?: string) => void;
+}
+
+interface ActionCard {
+  key: string;
+  count: number;
+  label: string;
+  hint: string;
+  icon: React.ReactNode;
+  tone: 'warning' | 'destructive' | 'primary' | 'info';
+  onClick: () => void;
+}
+
+const TONE_STYLES = {
+  warning: {
+    border: 'border-warning/40 hover:border-warning',
+    bg: 'bg-warning/5 hover:bg-warning/10',
+    accent: 'bg-warning/15 text-warning',
+    text: 'text-warning',
+    badge: 'bg-warning text-warning-foreground',
+  },
+  destructive: {
+    border: 'border-destructive/40 hover:border-destructive',
+    bg: 'bg-destructive/5 hover:bg-destructive/10',
+    accent: 'bg-destructive/15 text-destructive',
+    text: 'text-destructive',
+    badge: 'bg-destructive text-destructive-foreground',
+  },
+  primary: {
+    border: 'border-primary/40 hover:border-primary',
+    bg: 'bg-primary/5 hover:bg-primary/10',
+    accent: 'bg-primary/15 text-primary',
+    text: 'text-primary',
+    badge: 'bg-primary text-primary-foreground',
+  },
+  info: {
+    border: 'border-info/40 hover:border-info',
+    bg: 'bg-info/5 hover:bg-info/10',
+    accent: 'bg-info/15 text-info',
+    text: 'text-info',
+    badge: 'bg-info text-info-foreground',
+  },
+} as const;
+
+export function StockActionZone({ dashboard, warrantyExpiring, onNavigateToList }: StockActionZoneProps) {
+  const navigate = useNavigate();
+
+  if (!dashboard) return null;
+
+  const a = dashboard.actionRequired;
+  const total = a.inspection + (a.photoPending || 0) + a.pendingTransfers + a.repossessed + a.agingOver90;
+
+  if (total === 0 && warrantyExpiring.length === 0) {
+    return (
+      <div className="rounded-xl border border-border/60 bg-card p-4 mb-6 flex items-center gap-3">
+        <div className="size-9 rounded-lg bg-success/15 text-success flex items-center justify-center">
+          <ShieldAlert className="size-4" strokeWidth={1.5} />
+        </div>
+        <div>
+          <div className="text-sm font-semibold text-foreground">ไม่มีรายการต้องทำ</div>
+          <div className="text-xs text-muted-foreground">คลังสินค้าทั้งหมดอยู่ในสถานะปกติ</div>
+        </div>
+      </div>
+    );
+  }
+
+  const cards: ActionCard[] = [];
+
+  if (a.agingOver90 > 0) {
+    cards.push({
+      key: 'aging',
+      count: a.agingOver90,
+      label: 'ค้างสต็อค 90+ วัน',
+      hint: 'ทุนจม — ต้องเร่งระบาย',
+      icon: <Clock className="size-5" strokeWidth={1.5} />,
+      tone: 'warning',
+      onClick: () => onNavigateToList('IN_STOCK'),
+    });
+  }
+
+  if (a.repossessed > 0) {
+    cards.push({
+      key: 'repo',
+      count: a.repossessed,
+      label: 'ยึดคืน รอปรับสภาพ',
+      hint: 'ส่งซ่อม → QC → กลับเข้าคลัง',
+      icon: <ShieldAlert className="size-5" strokeWidth={1.5} />,
+      tone: 'destructive',
+      onClick: () => onNavigateToList('REPOSSESSED'),
+    });
+  }
+
+  if (a.pendingTransfers > 0) {
+    cards.push({
+      key: 'transfer',
+      count: a.pendingTransfers,
+      label: 'รอยืนยันโอน',
+      hint: 'สาขาปลายทางต้องตรวจรับ',
+      icon: <ArrowRightLeft className="size-5" strokeWidth={1.5} />,
+      tone: 'primary',
+      onClick: () => navigate('/stock/transfers'),
+    });
+  }
+
+  if (a.inspection > 0) {
+    cards.push({
+      key: 'inspect',
+      count: a.inspection,
+      label: 'รอตรวจสอบ (QC)',
+      hint: 'ตรวจสภาพก่อนเข้าคลัง',
+      icon: <ShieldAlert className="size-5" strokeWidth={1.5} />,
+      tone: 'warning',
+      onClick: () => onNavigateToList('INSPECTION'),
+    });
+  }
+
+  if ((a.photoPending || 0) > 0) {
+    cards.push({
+      key: 'photo',
+      count: a.photoPending,
+      label: 'รอถ่ายรูป',
+      hint: 'ถ่าย 6 มุม → พร้อมขาย',
+      icon: <Camera className="size-5" strokeWidth={1.5} />,
+      tone: 'info',
+      onClick: () => onNavigateToList('PHOTO_PENDING'),
+    });
+  }
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-[15px] font-semibold flex items-center gap-2">
+          <AlertTriangle className="size-4 text-warning" strokeWidth={1.75} />
+          ต้องทำเลย
+          <span className="font-mono text-[11px] text-muted-foreground tabular-nums">
+            ({total + warrantyExpiring.length})
+          </span>
+        </h2>
+      </div>
+
+      {/* Action cards grid */}
+      {cards.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-3">
+          {cards.map((card) => {
+            const t = TONE_STYLES[card.tone];
+            return (
+              <button
+                key={card.key}
+                onClick={card.onClick}
+                className={`relative text-left rounded-xl border p-3.5 transition-all group ${t.border} ${t.bg}`}
+              >
+                <div className="flex items-start gap-3">
+                  <div className={`size-10 shrink-0 rounded-lg flex items-center justify-center ${t.accent}`}>
+                    {card.icon}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-2 mb-0.5">
+                      <span className={`text-2xl font-bold tabular-nums leading-none ${t.text}`}>
+                        {card.count}
+                      </span>
+                      <ChevronRight className="size-4 text-muted-foreground/40 group-hover:text-muted-foreground transition-colors" />
+                    </div>
+                    <div className="text-[13px] font-semibold text-foreground leading-tight">
+                      {card.label}
+                    </div>
+                    <div className="text-[11px] text-muted-foreground mt-0.5">{card.hint}</div>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Warranty list — compact strip */}
+      {warrantyExpiring.length > 0 && (
+        <div className="rounded-xl border border-warning/30 bg-warning/5 p-3.5">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="size-4 text-warning" strokeWidth={1.75} />
+              <span className="text-[13px] font-semibold text-warning">
+                รับประกันใกล้หมด ({warrantyExpiring.length})
+              </span>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-1">
+            {warrantyExpiring.slice(0, 6).map((p) => (
+              <div key={p.id} className="flex items-center justify-between text-[12px] gap-2">
+                <span className="text-foreground/90 truncate">
+                  {p.brand} {p.model}
+                </span>
+                <span className="font-mono tabular-nums text-warning shrink-0">
+                  {formatDateShort(p.warrantyExpireDate)}
+                </span>
+              </div>
+            ))}
+          </div>
+          {warrantyExpiring.length > 6 && (
+            <div className="text-[11px] text-warning/80 mt-1.5">
+              + อีก {warrantyExpiring.length - 6} รายการ
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/StockPage/components/StockDashboardTab.tsx
+++ b/apps/web/src/pages/StockPage/components/StockDashboardTab.tsx
@@ -1,7 +1,5 @@
 import { StockDashboard } from '../types';
 import { statusLabels, categoryLabels } from '@/lib/constants';
-import AnimatedCounter from '@/components/ui/animated-counter';
-import { formatDateShort } from '@/utils/formatters';
 import {
   AlertTriangle,
   BarChart3,
@@ -12,8 +10,6 @@ import {
   PieChart as PieChartIcon,
   Tag,
   Trophy,
-  TrendingUp,
-  Wallet,
 } from 'lucide-react';
 import {
   Bar,
@@ -26,36 +22,23 @@ import {
   YAxis,
 } from 'recharts';
 
-// Slow-mover threshold — only highlight items that have been sitting for at least this many days.
-// Below this, the list would just echo the newest arrivals and carry no signal.
 const SLOW_MOVER_MIN_DAYS = 30;
 
 export interface StockDashboardTabProps {
   dashboard: StockDashboard | undefined;
   isManager: boolean;
-  actionTotal: number;
-  warrantyExpiring: { id: string; name: string; brand: string; model: string; warrantyExpireDate: string }[];
 }
 
-// --- Small Reusable Components (only used in dashboard) ---
-
-function SectionTitle({ icon, children }: { icon?: React.ReactNode; children: React.ReactNode }) {
+function SectionTitle({ icon, children, hint }: { icon?: React.ReactNode; children: React.ReactNode; hint?: string }) {
   return (
-    <h2 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-      {icon && <span className="text-muted-foreground [&>svg]:size-4">{icon}</span>}
-      {children}
-    </h2>
-  );
-}
-
-function StatCard({ label, value, sub, accent }: { label: string; value: string | number; sub?: React.ReactNode; accent?: string }) {
-  return (
-    <div className={`rounded-xl border p-4 transition-shadow hover:shadow-xs ${accent ? `border-l-4 ${accent}` : ''}`}>
-      <div className="text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">{label}</div>
-      <div className="text-xl font-bold text-foreground">
-        {typeof value === 'number' ? <AnimatedCounter value={value} /> : value}
-      </div>
-      {sub && <div className="text-xs text-muted-foreground mt-1">{sub}</div>}
+    <div className="flex items-baseline justify-between mb-3">
+      <h2 className="text-[14px] font-semibold flex items-center gap-2">
+        {icon && <span className="text-muted-foreground [&>svg]:size-4">{icon}</span>}
+        {children}
+      </h2>
+      {hint && (
+        <span className="text-[11px] text-muted-foreground font-mono tracking-wider uppercase">{hint}</span>
+      )}
     </div>
   );
 }
@@ -63,17 +46,16 @@ function StatCard({ label, value, sub, accent }: { label: string; value: string 
 function BarInline({ label, count, total, color }: { label: string; count: number; total: number; color: string }) {
   const pct = total > 0 ? (count / total) * 100 : 0;
   return (
-    <div className="flex items-center gap-2 text-sm">
-      <span className="w-24 truncate text-muted-foreground" title={label}>{label}</span>
-      <div className="flex-1 bg-muted rounded-full h-4 overflow-hidden">
+    <div className="flex items-center gap-2.5 text-sm">
+      <span className="w-20 truncate text-[12px] text-muted-foreground" title={label}>{label}</span>
+      <div className="flex-1 bg-muted/60 rounded-full h-2 overflow-hidden">
         <div className={`h-full rounded-full ${color}`} style={{ width: `${Math.max(pct, 2)}%` }} />
       </div>
-      <span className="w-8 text-right text-foreground font-medium">{count}</span>
+      <span className="w-7 text-right text-[12px] tabular-nums font-medium">{count}</span>
     </div>
   );
 }
 
-// Status → Tailwind bg color for the stacked bar. Falls back to muted-foreground.
 const STATUS_BAR_COLOR: Record<string, string> = {
   IN_STOCK: 'bg-success',
   SOLD_INSTALLMENT: 'bg-primary',
@@ -84,441 +66,304 @@ const STATUS_BAR_COLOR: Record<string, string> = {
   REPOSSESSED: 'bg-destructive',
 };
 
-function MoMBadge({ current, previous }: { current: number; previous: number }) {
-  if (previous === 0) {
-    return <span className="text-xs text-muted-foreground">เริ่มบันทึกข้อมูลเดือนนี้</span>;
+export function StockDashboardTab({ dashboard, isManager }: StockDashboardTabProps) {
+  if (!dashboard) {
+    return (
+      <div className="rounded-xl border border-border/60 p-8 text-center text-muted-foreground">
+        <div className="animate-spin rounded-full h-7 w-7 border-b-2 border-primary mx-auto mb-3" />
+        กำลังโหลด Dashboard...
+      </div>
+    );
   }
-  const delta = ((current - previous) / previous) * 100;
-  const up = delta >= 0;
-  const color = up ? 'text-success' : 'text-destructive';
+
   return (
-    <span className={`text-xs font-medium ${color}`}>
-      {up ? '+' : ''}
-      {delta.toFixed(0)}% MoM
-    </span>
-  );
-}
-
-export function StockDashboardTab({ dashboard, isManager, actionTotal, warrantyExpiring }: StockDashboardTabProps) {
-  return (
-    <>
-      {warrantyExpiring.length > 0 && (
-        <div className="bg-warning/5 dark:bg-warning/10 border border-warning/20 rounded-xl p-4 mb-4">
-          <div className="text-sm font-medium text-warning flex items-center gap-2">
-            <AlertTriangle className="size-4" />
-            รับประกันใกล้หมด: {warrantyExpiring.length} รายการ
-          </div>
-          <div className="mt-2 space-y-1">
-            {warrantyExpiring.slice(0, 5).map(p => (
-              <div key={p.id} className="text-xs text-warning/80 flex justify-between">
-                <span>{p.brand} {p.model}</span>
-                <span>{formatDateShort(p.warrantyExpireDate)}</span>
-              </div>
-            ))}
-            {warrantyExpiring.length > 5 && <div className="text-xs text-warning/70">...และอีก {warrantyExpiring.length - 5} รายการ</div>}
-          </div>
-        </div>
-      )}
-
-      {dashboard && (
-        <div className="flex flex-col gap-5 lg:gap-7.5">
-
-          {/* Row 1: Action Required + Stock Turnover */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-7.5">
-            {/* Action Required */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<AlertTriangle />}>รอดำเนินการ ({actionTotal})</SectionTitle>
-              <div className="grid grid-cols-2 gap-3">
-                {dashboard.actionRequired.inspection > 0 && (
-                  <div className="flex items-center gap-3 p-3 bg-warning/5 dark:bg-warning/10 rounded-xl">
-                    <div className="w-10 h-10 bg-warning/10 rounded-xl flex items-center justify-center text-warning text-lg font-bold">
-                      {dashboard.actionRequired.inspection}
-                    </div>
-                    <div className="text-sm text-warning">รอตรวจสอบ</div>
-                  </div>
-                )}
-                {(dashboard.actionRequired.photoPending || 0) > 0 && (
-                  <div className="flex items-center gap-3 p-3 bg-primary/5 dark:bg-primary/10 rounded-xl">
-                    <div className="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center text-primary text-lg font-bold">
-                      {dashboard.actionRequired.photoPending}
-                    </div>
-                    <div className="text-sm text-primary">รอถ่ายรูป</div>
-                  </div>
-                )}
-                {dashboard.actionRequired.pendingTransfers > 0 && (
-                  <div className="flex items-center gap-3 p-3 bg-primary/5 dark:bg-primary/10 rounded-xl">
-                    <div className="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center text-primary text-lg font-bold">
-                      {dashboard.actionRequired.pendingTransfers}
-                    </div>
-                    <div className="text-sm text-primary">รอยืนยันโอน</div>
-                  </div>
-                )}
-                {dashboard.actionRequired.repossessed > 0 && (
-                  <div className="flex items-center gap-3 p-3 bg-destructive/5 dark:bg-destructive/10 rounded-xl">
-                    <div className="w-10 h-10 bg-destructive/10 rounded-xl flex items-center justify-center text-destructive text-lg font-bold">
-                      {dashboard.actionRequired.repossessed}
-                    </div>
-                    <div className="text-sm text-destructive">ยึดคืน รอปรับสภาพ</div>
-                  </div>
-                )}
-                {dashboard.actionRequired.agingOver90 > 0 && (
-                  <div className="flex items-center gap-3 p-3 bg-warning/5 dark:bg-warning/10 rounded-xl">
-                    <div className="w-10 h-10 bg-warning/10 rounded-xl flex items-center justify-center text-warning text-lg font-bold">
-                      {dashboard.actionRequired.agingOver90}
-                    </div>
-                    <div className="text-sm text-warning">ค้างสต๊อค 90+ วัน</div>
-                  </div>
-                )}
-                {actionTotal === 0 && (
-                  <div className="col-span-2 text-center text-sm text-muted-foreground py-4">ไม่มีรายการรอดำเนินการ</div>
-                )}
-              </div>
-            </div>
-
-            {/* Stock Turnover */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<TrendingUp />}>อัตราหมุนเวียนสต๊อค</SectionTitle>
-              <div className="grid grid-cols-2 gap-4">
-                <StatCard label="อายุเฉลี่ยในสต๊อค" value={`${dashboard.stockTurnover.avgDaysInStock} วัน`} accent="border-l-primary" />
-                <StatCard label="สต๊อคปัจจุบัน" value={dashboard.stockTurnover.currentStock} sub="ชิ้น (IN_STOCK)" accent="border-l-success" />
-                <StatCard label="ขายเดือนนี้" value={dashboard.stockTurnover.soldThisMonth} sub="ชิ้น" accent="border-l-primary" />
-                <StatCard
-                  label="ขายเดือนที่แล้ว"
-                  value={dashboard.stockTurnover.soldLastMonth}
-                  sub={
-                    <MoMBadge
-                      current={dashboard.stockTurnover.soldThisMonth}
-                      previous={dashboard.stockTurnover.soldLastMonth}
-                    />
-                  }
-                  accent="border-l-muted-foreground"
-                />
-              </div>
-            </div>
-          </div>
-
-          {/* Row 2: Stock Aging */}
-          <div className="rounded-xl border border-border/60 p-5 shadow-card">
-            <SectionTitle icon={<Clock />}>อายุสต๊อค (Stock Aging)</SectionTitle>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              {dashboard.stockAging.map((bucket, i) => {
-                const colors = ['border-l-success', 'border-l-warning', 'border-l-warning', 'border-l-destructive'];
-                return (
-                  <div key={bucket.label} className={`bg-muted rounded-xl p-4 border-l-4 ${colors[i]}`}>
-                    <div className="text-sm font-medium text-foreground">{bucket.label}</div>
-                    <div className="text-2xl font-bold text-foreground mt-1">{bucket.count} <span className="text-sm font-normal text-muted-foreground">ชิ้น</span></div>
-                    <div className="text-xs text-muted-foreground mt-1">{bucket.value.toLocaleString()} ฿</div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Row 3: Value by Status + Stock Movement */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-7.5">
-            {/* Value by Status — stacked bar + list */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<PieChartIcon />}>มูลค่าสต๊อคตามสถานะ</SectionTitle>
-              {(() => {
-                const total = dashboard.valueByStatus.reduce((s, i) => s + i.value, 0);
-                if (total === 0) {
-                  return (
-                    <div className="text-sm text-muted-foreground text-center py-6">ยังไม่มีข้อมูลสต๊อค</div>
-                  );
-                }
-                return (
-                  <>
-                    <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted mb-4">
-                      {dashboard.valueByStatus.map((item) => {
-                        const pct = (item.value / total) * 100;
-                        const color = STATUS_BAR_COLOR[item.status] ?? 'bg-muted-foreground';
-                        return (
-                          <div
-                            key={item.status}
-                            className={color}
-                            style={{ width: `${pct}%` }}
-                            title={`${statusLabels[item.status]?.label ?? item.status}: ${pct.toFixed(1)}%`}
-                          />
-                        );
-                      })}
-                    </div>
-                    <div className="space-y-2">
-                      {dashboard.valueByStatus.map((item) => {
-                        const s = statusLabels[item.status] || { label: item.status, className: 'bg-muted text-foreground' };
-                        const pct = total > 0 ? (item.value / total) * 100 : 0;
-                        return (
-                          <div
-                            key={item.status}
-                            className="flex items-center justify-between py-2 border-b border-border last:border-0"
-                          >
-                            <div className="flex items-center gap-2">
-                              <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${s.className}`}>{s.label}</span>
-                              <span className="text-sm text-muted-foreground">{item.count} ชิ้น</span>
-                            </div>
-                            <div className="flex items-center gap-3">
-                              <span className="text-xs text-muted-foreground tabular-nums">{pct.toFixed(1)}%</span>
-                              <span className="text-sm font-medium text-foreground tabular-nums">
-                                {item.value.toLocaleString()} ฿
-                              </span>
-                            </div>
-                          </div>
-                        );
-                      })}
-                      <div className="flex items-center justify-between pt-2 border-t border-border font-medium">
-                        <span className="text-sm text-foreground">รวมทั้งหมด</span>
-                        <span className="text-sm text-foreground tabular-nums">{total.toLocaleString()} ฿</span>
-                      </div>
-                    </div>
-                  </>
-                );
-              })()}
-            </div>
-
-            {/* Stock Movement — recharts grouped bar */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<BarChart3 />}>การเคลื่อนไหวสต๊อค (6 เดือน)</SectionTitle>
-              {(() => {
-                // Trim leading zero-months so charts with only recent data don't look broken.
-                const firstNonZero = dashboard.stockMovement.findIndex((m) => m.in > 0 || m.out > 0);
-                const data =
-                  firstNonZero === -1 ? [] : dashboard.stockMovement.slice(firstNonZero);
-
-                if (data.length === 0) {
-                  return (
-                    <div className="text-sm text-muted-foreground text-center py-10">
-                      ยังไม่มีการเคลื่อนไหวของสต๊อค
-                    </div>
-                  );
-                }
-                return (
-                  <div className="h-64 -ml-2">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <BarChart data={data} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
-                        <CartesianGrid
-                          strokeDasharray="3 3"
-                          className="stroke-border"
-                          vertical={false}
-                        />
-                        <XAxis
-                          dataKey="month"
-                          tick={{ fontSize: 11 }}
-                          className="fill-muted-foreground"
-                          axisLine={false}
-                          tickLine={false}
-                        />
-                        <YAxis
-                          tick={{ fontSize: 11 }}
-                          className="fill-muted-foreground"
-                          axisLine={false}
-                          tickLine={false}
-                          allowDecimals={false}
-                        />
-                        <Tooltip
-                          cursor={{ fill: 'hsl(var(--muted) / 0.5)' }}
-                          contentStyle={{
-                            backgroundColor: 'hsl(var(--popover))',
-                            border: '1px solid hsl(var(--border))',
-                            borderRadius: 8,
-                            fontSize: 12,
-                          }}
-                          labelStyle={{ color: 'hsl(var(--foreground))' }}
-                        />
-                        <Legend wrapperStyle={{ fontSize: 12 }} iconType="circle" />
-                        <Bar dataKey="in" name="รับเข้า" fill="hsl(var(--success))" radius={[4, 4, 0, 0]} />
-                        <Bar dataKey="out" name="ขายออก" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </div>
-                );
-              })()}
-            </div>
-          </div>
-
-          {/* Row 4: Category + Brand + Color + Storage Breakdown */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 lg:gap-7.5">
-            {/* By Category */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<Package />}>ตามประเภท</SectionTitle>
-              <div className="space-y-2">
-                {dashboard.byCategory.map((item) => (
-                  <BarInline
-                    key={item.name}
-                    label={categoryLabels[item.name] || item.name}
-                    count={item.count}
-                    total={dashboard.stockTurnover.currentStock}
-                    color="bg-primary"
-                  />
-                ))}
-                {dashboard.byCategory.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">-</div>}
-              </div>
-            </div>
-
-            {/* By Brand */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<Tag />}>ตามแบรนด์</SectionTitle>
-              <div className="space-y-2">
-                {dashboard.byBrand.slice(0, 8).map((item) => (
-                  <BarInline
-                    key={item.name}
-                    label={item.name}
-                    count={item.count}
-                    total={dashboard.stockTurnover.currentStock}
-                    color="bg-primary"
-                  />
-                ))}
-                {dashboard.byBrand.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">-</div>}
-              </div>
-            </div>
-
-            {/* By Color */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<Palette />}>ตามสี</SectionTitle>
-              <div className="space-y-2">
-                {dashboard.byColor.slice(0, 8).map((item) => (
-                  <BarInline
-                    key={item.name}
-                    label={item.name}
-                    count={item.count}
-                    total={dashboard.stockTurnover.currentStock}
-                    color="bg-primary/60"
-                  />
-                ))}
-                {dashboard.byColor.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">-</div>}
-              </div>
-            </div>
-
-            {/* By Storage */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<HardDrive />}>ตามความจุ</SectionTitle>
-              <div className="space-y-2">
-                {dashboard.byStorage.slice(0, 8).map((item) => (
-                  <BarInline
-                    key={item.name}
-                    label={item.name}
-                    count={item.count}
-                    total={dashboard.stockTurnover.currentStock}
-                    color="bg-success/60"
-                  />
-                ))}
-                {dashboard.byStorage.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">-</div>}
-              </div>
-            </div>
-          </div>
-
-          {/* Row 5: Margin Overview -- Owner/Manager only */}
-          {isManager && (
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<Wallet />}>กำไรเฉลี่ย (Margin Overview) - สินค้าพร้อมขาย</SectionTitle>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <StatCard
-                  label="มูลค่าทุนรวม"
-                  value={`${dashboard.marginOverview.totalCost.toLocaleString()} ฿`}
-                  accent="border-l-muted-foreground"
-                />
-                <StatCard
-                  label="มูลค่าขายรวม"
-                  value={`${dashboard.marginOverview.totalSell.toLocaleString()} ฿`}
-                  accent="border-l-primary"
-                />
-                <StatCard
-                  label="กำไรรวม (ถ้าขายหมด)"
-                  value={`${dashboard.marginOverview.totalMargin.toLocaleString()} ฿`}
-                  sub={`Margin ${dashboard.marginOverview.avgMarginPct}%`}
-                  accent="border-l-success"
-                />
-                <StatCard
-                  label="กำไรเฉลี่ย/ชิ้น"
-                  value={`${dashboard.marginOverview.avgMarginPerUnit.toLocaleString()} ฿`}
-                  sub={`จาก ${dashboard.marginOverview.itemsWithPrice} ชิ้นที่มีราคาขาย`}
-                  accent="border-l-primary"
-                />
-              </div>
-            </div>
-          )}
-
-          {/* Row 7: Top Sellers + Slow Movers */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-7.5">
-            {/* Top Sellers */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<Trophy />}>สินค้าขายดี (6 เดือนล่าสุด)</SectionTitle>
-              {dashboard.topSellers.length > 0 ? (
-                <div className="space-y-2">
-                  {dashboard.topSellers.map((item, i) => (
-                    <div key={item.name} className="flex items-center gap-3">
-                      <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
-                        i === 0 ? 'bg-warning/10 text-warning dark:bg-warning/15' :
-                        i === 1 ? 'bg-muted text-muted-foreground' :
-                        i === 2 ? 'bg-warning/10 text-warning dark:bg-warning/15' :
-                        'bg-muted text-muted-foreground'
-                      }`}>{i + 1}</span>
-                      <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium text-foreground truncate">{item.name}</div>
-                      </div>
-                      <span className="text-sm font-bold text-primary">{item.count} ชิ้น</span>
-                    </div>
-                  ))}
+    <div className="flex flex-col gap-4">
+      {/* Stock Aging buckets — 4 across */}
+      <div className="rounded-xl border border-border/60 p-4 bg-card">
+        <SectionTitle icon={<Clock />} hint="aging">อายุสต็อค</SectionTitle>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {dashboard.stockAging.map((bucket, i) => {
+            const colors = ['border-l-success', 'border-l-warning', 'border-l-warning', 'border-l-destructive'];
+            const textColors = ['text-success', 'text-warning', 'text-warning', 'text-destructive'];
+            return (
+              <div key={bucket.label} className={`bg-muted/40 rounded-lg p-3 border-l-4 ${colors[i]}`}>
+                <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                  {bucket.label}
                 </div>
-              ) : (
-                <div className="text-sm text-muted-foreground text-center py-4">ยังไม่มีข้อมูลการขาย</div>
-              )}
-            </div>
+                <div className="flex items-baseline gap-1 mt-1">
+                  <span className={`text-2xl font-bold tabular-nums ${bucket.count > 0 ? textColors[i] : ''}`}>
+                    {bucket.count}
+                  </span>
+                  <span className="text-[11px] text-muted-foreground">ชิ้น</span>
+                </div>
+                <div className="text-[11px] text-muted-foreground mt-0.5 tabular-nums">
+                  {bucket.value.toLocaleString()} ฿
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
 
-            {/* Slow Movers */}
-            <div className="rounded-xl border border-border/60 p-5 shadow-card">
-              <SectionTitle icon={<AlertTriangle />}>สินค้าค้างสต๊อคนานสุด</SectionTitle>
-              {(() => {
-                const slow = dashboard.slowMovers.filter((i) => i.days >= SLOW_MOVER_MIN_DAYS);
-                if (slow.length === 0) {
-                  return (
-                    <div className="text-sm text-muted-foreground text-center py-4">
-                      ยังไม่มีสินค้าค้างเกิน {SLOW_MOVER_MIN_DAYS} วัน
-                    </div>
-                  );
-                }
-                return (
-                  <div className="space-y-2">
-                    {slow.map((item, i) => (
-                      <div key={`${item.name}-${i}`} className="flex items-center gap-3">
-                        <span
-                          className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
-                            item.days > 90
-                              ? 'bg-destructive/10 text-destructive dark:bg-destructive/15'
-                              : 'bg-warning/10 text-warning dark:bg-warning/15'
-                          }`}
-                        >
-                          {i + 1}
-                        </span>
-                        <div className="flex-1 min-w-0">
-                          <div className="text-sm font-medium text-foreground truncate">{item.name}</div>
-                          {isManager && (
-                            <div className="text-xs text-muted-foreground">
-                              {(Number(item.costPrice) || 0).toLocaleString()} ฿
-                            </div>
-                          )}
+      {/* Row: Value by Status + Stock Movement chart */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Value by Status */}
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<PieChartIcon />} hint="by status">มูลค่าสต็อคตามสถานะ</SectionTitle>
+          {(() => {
+            const total = dashboard.valueByStatus.reduce((s, i) => s + i.value, 0);
+            if (total === 0) {
+              return <div className="text-sm text-muted-foreground text-center py-6">ยังไม่มีข้อมูล</div>;
+            }
+            return (
+              <>
+                <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted mb-4">
+                  {dashboard.valueByStatus.map((item) => {
+                    const pct = (item.value / total) * 100;
+                    const color = STATUS_BAR_COLOR[item.status] ?? 'bg-muted-foreground';
+                    return (
+                      <div
+                        key={item.status}
+                        className={color}
+                        style={{ width: `${pct}%` }}
+                        title={`${statusLabels[item.status]?.label ?? item.status}: ${pct.toFixed(1)}%`}
+                      />
+                    );
+                  })}
+                </div>
+                <div className="space-y-1.5">
+                  {dashboard.valueByStatus.map((item) => {
+                    const s = statusLabels[item.status] || { label: item.status, className: 'bg-muted text-foreground' };
+                    const pct = (item.value / total) * 100;
+                    const dotColor = STATUS_BAR_COLOR[item.status] ?? 'bg-muted-foreground';
+                    return (
+                      <div key={item.status} className="flex items-center justify-between py-1 text-[13px]">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className={`size-2 rounded-full shrink-0 ${dotColor}`} />
+                          <span className="text-foreground truncate">{s.label}</span>
+                          <span className="text-muted-foreground/80 text-[11px] tabular-nums">
+                            {item.count}
+                          </span>
                         </div>
-                        <span
-                          className={`text-sm font-bold ${
-                            item.days > 90 ? 'text-destructive' : 'text-warning'
-                          }`}
-                        >
-                          {item.days} วัน
-                        </span>
+                        <div className="flex items-center gap-2.5 shrink-0">
+                          <span className="text-[11px] text-muted-foreground tabular-nums">
+                            {pct.toFixed(0)}%
+                          </span>
+                          <span className="font-medium tabular-nums">
+                            {item.value.toLocaleString()} ฿
+                          </span>
+                        </div>
                       </div>
-                    ))}
+                    );
+                  })}
+                  <div className="flex items-center justify-between pt-2 mt-1 border-t border-border text-[13px] font-semibold">
+                    <span>รวม</span>
+                    <span className="tabular-nums">{total.toLocaleString()} ฿</span>
                   </div>
-                );
-              })()}
-            </div>
+                </div>
+              </>
+            );
+          })()}
+        </div>
+
+        {/* Stock Movement chart */}
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<BarChart3 />} hint="6 mo">การเคลื่อนไหวสต็อค</SectionTitle>
+          {(() => {
+            const firstNonZero = dashboard.stockMovement.findIndex((m) => m.in > 0 || m.out > 0);
+            const data = firstNonZero === -1 ? [] : dashboard.stockMovement.slice(firstNonZero);
+
+            if (data.length === 0) {
+              return (
+                <div className="text-sm text-muted-foreground text-center py-10">
+                  ยังไม่มีการเคลื่อนไหว
+                </div>
+              );
+            }
+            return (
+              <div className="h-56 -ml-2">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={data} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" vertical={false} />
+                    <XAxis
+                      dataKey="month"
+                      tick={{ fontSize: 11 }}
+                      className="fill-muted-foreground"
+                      axisLine={false}
+                      tickLine={false}
+                    />
+                    <YAxis
+                      tick={{ fontSize: 11 }}
+                      className="fill-muted-foreground"
+                      axisLine={false}
+                      tickLine={false}
+                      allowDecimals={false}
+                    />
+                    <Tooltip
+                      cursor={{ fill: 'hsl(var(--muted) / 0.5)' }}
+                      contentStyle={{
+                        backgroundColor: 'hsl(var(--popover))',
+                        border: '1px solid hsl(var(--border))',
+                        borderRadius: 8,
+                        fontSize: 12,
+                      }}
+                      labelStyle={{ color: 'hsl(var(--foreground))' }}
+                    />
+                    <Legend wrapperStyle={{ fontSize: 12 }} iconType="circle" />
+                    <Bar dataKey="in" name="รับเข้า" fill="hsl(var(--success))" radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="out" name="ขายออก" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            );
+          })()}
+        </div>
+      </div>
+
+      {/* Breakdowns: Category / Brand / Color / Storage */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<Package />} hint="type">ตามประเภท</SectionTitle>
+          <div className="space-y-2">
+            {dashboard.byCategory.map((item) => (
+              <BarInline
+                key={item.name}
+                label={categoryLabels[item.name] || item.name}
+                count={item.count}
+                total={dashboard.stockTurnover.currentStock}
+                color="bg-primary"
+              />
+            ))}
+            {dashboard.byCategory.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">—</div>}
           </div>
         </div>
-      )}
 
-      {!dashboard && (
-        <div className="rounded-xl border border-border/60 p-8 text-center text-muted-foreground">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-3"></div>
-          กำลังโหลด Dashboard...
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<Tag />} hint="brand">ตามแบรนด์</SectionTitle>
+          <div className="space-y-2">
+            {dashboard.byBrand.slice(0, 8).map((item) => (
+              <BarInline
+                key={item.name}
+                label={item.name}
+                count={item.count}
+                total={dashboard.stockTurnover.currentStock}
+                color="bg-primary"
+              />
+            ))}
+            {dashboard.byBrand.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">—</div>}
+          </div>
         </div>
-      )}
-    </>
+
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<Palette />} hint="color">ตามสี</SectionTitle>
+          <div className="space-y-2">
+            {dashboard.byColor.slice(0, 8).map((item) => (
+              <BarInline
+                key={item.name}
+                label={item.name}
+                count={item.count}
+                total={dashboard.stockTurnover.currentStock}
+                color="bg-primary/60"
+              />
+            ))}
+            {dashboard.byColor.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">—</div>}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<HardDrive />} hint="storage">ตามความจุ</SectionTitle>
+          <div className="space-y-2">
+            {dashboard.byStorage.slice(0, 8).map((item) => (
+              <BarInline
+                key={item.name}
+                label={item.name}
+                count={item.count}
+                total={dashboard.stockTurnover.currentStock}
+                color="bg-success/60"
+              />
+            ))}
+            {dashboard.byStorage.length === 0 && <div className="text-sm text-muted-foreground text-center py-2">—</div>}
+          </div>
+        </div>
+      </div>
+
+      {/* Top Sellers + Slow Movers */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<Trophy />} hint="6 mo">สินค้าขายดี</SectionTitle>
+          {dashboard.topSellers.length > 0 ? (
+            <div className="space-y-2">
+              {dashboard.topSellers.map((item, i) => (
+                <div key={item.name} className="flex items-center gap-3">
+                  <span
+                    className={`size-6 rounded-md flex items-center justify-center text-[11px] font-mono font-bold tabular-nums ${
+                      i === 0
+                        ? 'bg-warning/15 text-warning'
+                        : i === 1
+                          ? 'bg-muted text-foreground'
+                          : i === 2
+                            ? 'bg-warning/10 text-warning/80'
+                            : 'bg-muted/60 text-muted-foreground'
+                    }`}
+                  >
+                    {i + 1}
+                  </span>
+                  <div className="flex-1 min-w-0 text-[13px] font-medium truncate">{item.name}</div>
+                  <span className="text-[12px] font-bold text-primary tabular-nums">
+                    {item.count} <span className="font-normal text-muted-foreground">ชิ้น</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground text-center py-4">ยังไม่มีข้อมูลการขาย</div>
+          )}
+        </div>
+
+        <div className="rounded-xl border border-border/60 p-4 bg-card">
+          <SectionTitle icon={<AlertTriangle />} hint="slow">สินค้าค้างสต็อคนานสุด</SectionTitle>
+          {(() => {
+            const slow = dashboard.slowMovers.filter((i) => i.days >= SLOW_MOVER_MIN_DAYS);
+            if (slow.length === 0) {
+              return (
+                <div className="text-sm text-muted-foreground text-center py-4">
+                  ยังไม่มีสินค้าค้างเกิน {SLOW_MOVER_MIN_DAYS} วัน
+                </div>
+              );
+            }
+            return (
+              <div className="space-y-2">
+                {slow.map((item, i) => (
+                  <div key={`${item.name}-${i}`} className="flex items-center gap-3">
+                    <span
+                      className={`size-6 rounded-md flex items-center justify-center text-[11px] font-mono font-bold tabular-nums ${
+                        item.days > 90 ? 'bg-destructive/15 text-destructive' : 'bg-warning/15 text-warning'
+                      }`}
+                    >
+                      {i + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-[13px] font-medium truncate">{item.name}</div>
+                      {isManager && (
+                        <div className="text-[11px] text-muted-foreground tabular-nums">
+                          {(Number(item.costPrice) || 0).toLocaleString()} ฿
+                        </div>
+                      )}
+                    </div>
+                    <span
+                      className={`text-[12px] font-bold tabular-nums ${
+                        item.days > 90 ? 'text-destructive' : 'text-warning'
+                      }`}
+                    >
+                      {item.days} <span className="font-normal text-muted-foreground">วัน</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            );
+          })()}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/pages/StockPage/components/StockHeroKpi.tsx
+++ b/apps/web/src/pages/StockPage/components/StockHeroKpi.tsx
@@ -1,4 +1,4 @@
-import { Package, Wallet, Clock, TrendingUp } from 'lucide-react';
+import { Package, Wallet, Clock, TrendingUp, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import AnimatedCounter from '@/components/ui/animated-counter';
 import { StockDashboard } from '../types';
 
@@ -9,64 +9,135 @@ export interface StockHeroKpiProps {
   isManager: boolean;
 }
 
-interface KpiProps {
-  icon: React.ReactNode;
-  label: string;
-  value: React.ReactNode;
-  hint?: string;
-  accent: string;
-}
-
-function Kpi({ icon, label, value, hint, accent }: KpiProps) {
+function MoMTone({ current, previous }: { current: number; previous: number }) {
+  if (previous === 0) {
+    return <span className="text-[11px] text-muted-foreground/80">เริ่มเก็บข้อมูลเดือนนี้</span>;
+  }
+  const delta = ((current - previous) / previous) * 100;
+  const up = delta >= 0;
   return (
-    <div className="rounded-xl border border-border/60 bg-card p-4 flex items-start gap-3 shadow-card">
-      <div className={`size-10 shrink-0 rounded-xl flex items-center justify-center ${accent}`}>
-        {icon}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="text-2xs font-medium text-muted-foreground uppercase tracking-wider">
-          {label}
-        </div>
-        <div className="text-xl font-bold text-foreground mt-0.5 truncate">{value}</div>
-        {hint && <div className="text-xs text-muted-foreground mt-0.5 truncate">{hint}</div>}
-      </div>
-    </div>
+    <span
+      className={`inline-flex items-center gap-0.5 text-[11px] font-medium tabular-nums ${
+        up ? 'text-success' : 'text-destructive'
+      }`}
+    >
+      {up ? <ArrowUpRight className="size-3" /> : <ArrowDownRight className="size-3" />}
+      {up ? '+' : ''}
+      {delta.toFixed(0)}% MoM
+    </span>
   );
 }
 
 export function StockHeroKpi({ totalInStock, totalValue, dashboard, isManager }: StockHeroKpiProps) {
   const avgDays = dashboard?.stockTurnover.avgDaysInStock;
   const marginPct = dashboard?.marginOverview.avgMarginPct;
+  const soldThisMonth = dashboard?.stockTurnover.soldThisMonth ?? 0;
+  const soldLastMonth = dashboard?.stockTurnover.soldLastMonth ?? 0;
+  const totalCost = dashboard?.marginOverview.totalCost ?? 0;
+  const totalSell = dashboard?.marginOverview.totalSell ?? 0;
+  const avgDaysAlarm = avgDays != null && avgDays > 90;
 
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-      <Kpi
-        icon={<Package className="size-5 text-primary" />}
-        label="พร้อมขาย"
-        value={<AnimatedCounter value={totalInStock} />}
-        hint="ชิ้น"
-        accent="bg-primary/10"
-      />
-      <Kpi
-        icon={<Wallet className="size-5 text-success" />}
-        label="มูลค่าพร้อมขาย"
-        value={`${totalValue.toLocaleString()} ฿`}
-        accent="bg-success/10"
-      />
-      <Kpi
-        icon={<Clock className="size-5 text-warning" />}
-        label="อายุเฉลี่ยในสต๊อค"
-        value={avgDays != null ? `${avgDays} วัน` : '-'}
-        accent="bg-warning/10"
-      />
-      {isManager && (
-        <Kpi
-          icon={<TrendingUp className="size-5 text-primary" />}
-          label="Margin เฉลี่ย"
-          value={marginPct != null ? `${marginPct}%` : '-'}
-          hint="สินค้าพร้อมขายที่ตั้งราคาแล้ว"
-          accent="bg-primary/10"
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
+      {/* 1. พร้อมขาย — count + value */}
+      <div className="rounded-xl border border-border/60 bg-card p-4 relative overflow-hidden">
+        <div className="absolute -right-4 -top-4 size-20 rounded-full bg-primary/5" aria-hidden />
+        <div className="relative">
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-[10px] font-mono uppercase tracking-[0.16em] text-muted-foreground">
+              พร้อมขาย
+            </span>
+            <Package className="size-4 text-primary" />
+          </div>
+          <div className="flex items-baseline gap-1">
+            <span className="text-3xl font-bold tabular-nums">
+              <AnimatedCounter value={totalInStock} />
+            </span>
+            <span className="text-xs text-muted-foreground">ชิ้น</span>
+          </div>
+          <div className="text-xs text-muted-foreground mt-1 tabular-nums">
+            {totalValue.toLocaleString()} ฿
+          </div>
+        </div>
+      </div>
+
+      {/* 2. ขายเดือนนี้ + MoM */}
+      <div className="rounded-xl border border-border/60 bg-card p-4 relative overflow-hidden">
+        <div className="absolute -right-4 -top-4 size-20 rounded-full bg-success/5" aria-hidden />
+        <div className="relative">
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-[10px] font-mono uppercase tracking-[0.16em] text-muted-foreground">
+              ขายเดือนนี้
+            </span>
+            <TrendingUp className="size-4 text-success" />
+          </div>
+          <div className="flex items-baseline gap-1">
+            <span className="text-3xl font-bold tabular-nums">
+              <AnimatedCounter value={soldThisMonth} />
+            </span>
+            <span className="text-xs text-muted-foreground">ชิ้น</span>
+          </div>
+          <div className="mt-1">
+            <MoMTone current={soldThisMonth} previous={soldLastMonth} />
+          </div>
+        </div>
+      </div>
+
+      {/* 3. อายุเฉลี่ย (alert if > 90) */}
+      <div
+        className={`rounded-xl border p-4 relative overflow-hidden ${
+          avgDaysAlarm
+            ? 'border-warning/50 bg-warning/5'
+            : 'border-border/60 bg-card'
+        }`}
+      >
+        <div
+          className={`absolute -right-4 -top-4 size-20 rounded-full ${
+            avgDaysAlarm ? 'bg-warning/15' : 'bg-warning/5'
+          }`}
+          aria-hidden
         />
+        <div className="relative">
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-[10px] font-mono uppercase tracking-[0.16em] text-muted-foreground">
+              อายุเฉลี่ย
+            </span>
+            <Clock className={`size-4 ${avgDaysAlarm ? 'text-warning' : 'text-muted-foreground'}`} />
+          </div>
+          <div className="flex items-baseline gap-1">
+            <span className={`text-3xl font-bold tabular-nums ${avgDaysAlarm ? 'text-warning' : ''}`}>
+              {avgDays != null ? <AnimatedCounter value={avgDays} /> : '—'}
+            </span>
+            <span className="text-xs text-muted-foreground">วัน</span>
+          </div>
+          <div className="text-[11px] text-muted-foreground mt-1">
+            {avgDaysAlarm ? 'ต้องเร่งระบาย' : 'หมุนเวียนได้ดี'}
+          </div>
+        </div>
+      </div>
+
+      {/* 4. Margin (manager only) */}
+      {isManager && (
+        <div className="rounded-xl border border-border/60 bg-card p-4 relative overflow-hidden">
+          <div className="absolute -right-4 -top-4 size-20 rounded-full bg-primary/5" aria-hidden />
+          <div className="relative">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-[10px] font-mono uppercase tracking-[0.16em] text-muted-foreground">
+                margin เฉลี่ย
+              </span>
+              <Wallet className="size-4 text-primary" />
+            </div>
+            <div className="flex items-baseline gap-1">
+              <span className="text-3xl font-bold tabular-nums">
+                {marginPct != null ? marginPct : '—'}
+              </span>
+              <span className="text-xs text-muted-foreground">%</span>
+            </div>
+            <div className="text-[11px] text-muted-foreground mt-1 tabular-nums">
+              ทุน {totalCost.toLocaleString()} → {totalSell.toLocaleString()} ฿
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/pages/StockPage/index.tsx
+++ b/apps/web/src/pages/StockPage/index.tsx
@@ -15,6 +15,7 @@ import { useStockFilters } from './hooks/useStockFilters';
 import QueryBoundary from '@/components/QueryBoundary';
 import { BranchSummaryCards } from './components/BranchSummaryCards';
 import { StockHeroKpi } from './components/StockHeroKpi';
+import { StockActionZone } from './components/StockActionZone';
 import { StockDashboardTab } from './components/StockDashboardTab';
 import { StockListTab } from './components/StockListTab';
 import { BulkTransferModal } from './components/BulkTransferModal';
@@ -255,9 +256,13 @@ export default function StockPage() {
     },
   ], [navigateToProduct, openPriceEdit, isManager, selectedIds, listProducts]);
 
-  const actionTotal = dashboard
-    ? dashboard.actionRequired.inspection + (dashboard.actionRequired.photoPending || 0) + dashboard.actionRequired.pendingTransfers + dashboard.actionRequired.repossessed + dashboard.actionRequired.agingOver90
-    : 0;
+  const handleActionZoneNav = useCallback(
+    (status?: string) => {
+      handleTabChange('list');
+      if (status) setFilterStatus(status);
+    },
+    [handleTabChange, setFilterStatus],
+  );
 
   return (
     <div>
@@ -265,28 +270,40 @@ export default function StockPage() {
         title="คลังสินค้า"
         subtitle="จัดการคลังสินค้าและดูภาพรวมสต๊อค"
         action={
-          isManager && activeTab === 'list' ? (
-            <div className="flex gap-2">
-              {selectedIds.size > 0 && (
-                <Button variant="outline" size="md" onClick={() => setShowBulkTransfer(true)}>
-                  <ArrowRightLeft className="size-4" />
-                  โอนสินค้า ({selectedIds.size})
-                </Button>
+          isManager ? (
+            <div className="flex gap-2 flex-wrap">
+              {activeTab === 'list' && selectedIds.size > 0 && (
+                <>
+                  <Button variant="outline" size="md" onClick={() => setShowBulkTransfer(true)}>
+                    <ArrowRightLeft className="size-4" />
+                    โอน ({selectedIds.size})
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="md"
+                    onClick={() =>
+                      navigate(
+                        `/stickers?productIds=${encodeURIComponent(Array.from(selectedIds).join(','))}`,
+                      )
+                    }
+                  >
+                    <Printer className="size-4" />
+                    พิมพ์ ({selectedIds.size})
+                  </Button>
+                </>
               )}
-              {selectedIds.size > 0 && (
-                <Button
-                  variant="outline"
-                  size="md"
-                  onClick={() => navigate(`/stickers?productIds=${encodeURIComponent(Array.from(selectedIds).join(','))}`)}
-                >
+              {activeTab !== 'list' && (
+                <Button variant="outline" size="md" onClick={() => navigate('/stickers')}>
                   <Printer className="size-4" />
-                  พิมพ์สติกเกอร์ ({selectedIds.size})
+                  พิมพ์สติกเกอร์
                 </Button>
               )}
-              <Button variant="outline" size="md" onClick={() => handleExport(listProducts)}>
-                <Download className="size-4" />
-                {selectedIds.size > 0 ? `ส่งออก (${selectedIds.size})` : 'ส่งออก CSV'}
-              </Button>
+              {activeTab === 'list' && (
+                <Button variant="outline" size="md" onClick={() => handleExport(listProducts)}>
+                  <Download className="size-4" />
+                  {selectedIds.size > 0 ? `ส่งออก (${selectedIds.size})` : 'ส่งออก CSV'}
+                </Button>
+              )}
               <Button variant="primary" size="md" onClick={() => navigate('/products/create')}>
                 <Plus className="size-4" />
                 เพิ่มสินค้า
@@ -303,6 +320,12 @@ export default function StockPage() {
         isManager={isManager}
       />
 
+      <StockActionZone
+        dashboard={dashboard}
+        warrantyExpiring={warrantyExpiring}
+        onNavigateToList={handleActionZoneNav}
+      />
+
       <BranchSummaryCards
         summary={summary}
         filterBranch={filterBranch}
@@ -310,22 +333,27 @@ export default function StockPage() {
       />
 
       {/* Tabs: Dashboard / List */}
-      <div className="flex gap-1 mb-6 bg-muted rounded-xl p-1 w-fit">
+      <div className="flex gap-1 mb-5 bg-muted rounded-lg p-1 w-fit">
         <button
           onClick={() => handleTabChange('dashboard')}
-          className={`px-4 py-2 text-sm rounded-lg font-medium transition-all ${
+          className={`px-4 py-1.5 text-[13px] rounded-md font-semibold transition-all ${
             activeTab === 'dashboard' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
           }`}
         >
-          Dashboard
+          ภาพรวม
         </button>
         <button
           onClick={() => handleTabChange('list')}
-          className={`px-4 py-2 text-sm rounded-lg font-medium transition-all ${
+          className={`px-4 py-1.5 text-[13px] rounded-md font-semibold transition-all ${
             activeTab === 'list' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
           }`}
         >
-          รายการสินค้า {listResult ? `(${listResult.total})` : ''}
+          รายการสินค้า
+          {listResult ? (
+            <span className="ml-1.5 font-mono tabular-nums text-muted-foreground/80">
+              ({listResult.total})
+            </span>
+          ) : ''}
         </button>
       </div>
 
@@ -333,8 +361,6 @@ export default function StockPage() {
         <StockDashboardTab
           dashboard={dashboard}
           isManager={isManager}
-          actionTotal={actionTotal}
-          warrantyExpiring={warrantyExpiring}
         />
       )}
 


### PR DESCRIPTION
## Summary
รื้อหน้า /stock ตาม user pain points ที่ระบุ — A→E ครบทุกข้อ

## A. ลบข้อมูลซ้ำ
- ตัดส่วน "อัตราหมุนเวียนสต็อค" (อายุเฉลี่ย / สต็อกปัจจุบัน / ขายเดือนนี้ — ซ้ำกับ hero KPI)
- ตัดส่วน "Margin Overview" (รวมเข้า hero KPI แล้ว)
- Warranty banner → ย้ายเข้า ActionZone

## B. Visual hierarchy + Action Zone
- **StockActionZone** ใหม่ (เหนือ tabs): clickable cards
  - ค้างสต็อค 90+ วัน — warning tint + ChevronRight
  - ยึดคืน รอปรับสภาพ — destructive tint
  - รอยืนยันโอน → /stock/transfers
  - รอตรวจ (QC) / รอถ่ายรูป
  - รับประกันใกล้หมด strip
- **Hero KPIs** — ตัวเลข `text-3xl font-bold tabular-nums` + soft circle accent
  - `อายุเฉลี่ย > 90` ติด warning tint อัตโนมัติ
  - `ขายเดือนนี้` มี MoM% badge
- **Branch cards** — share-bar fill + percentage

## C. Actions ใน PageHeader โผล่ตลอด
- Manager เห็น `+ เพิ่มสินค้า` + `พิมพ์สติกเกอร์` ทุก tab
- List tab + เลือกของ → ปุ่ม โอน / พิมพ์ที่เลือก / ส่งออก

## D. Aesthetic ทันสมัย
- Tabs: `ภาพรวม` แทน `Dashboard`, mono tabular count
- Section titles: uppercase mono hint badge (`aging` / `by status` / `6 mo` ฯลฯ)
- Status legend = colored dots
- Tabular-nums ทุกตัวเลข

## E. ซ่อน test branches
- BranchSummaryCards filter ชื่อขึ้นต้น `__`

## Test plan
- [ ] เปิด /stock → ActionZone โชว์ cards ที่กดได้
- [ ] กด "ค้างสต็อค 90+ วัน" → switch ไป list + filter status=IN_STOCK
- [ ] เลือก checkbox ใน list → ปุ่ม โอน/พิมพ์/ส่งออก โผล่
- [ ] `__test_branch__` ไม่โผล่ใน Branch cards
- [ ] เปลี่ยน tab → ปุ่ม + เพิ่มสินค้า ยังเห็นตลอด

🤖 Generated with [Claude Code](https://claude.com/claude-code)