### PR TITLE
feat(termination): JP5 LEGAL guard + 2A cron skip-LEGAL

### DIFF
--- a/apps/api/src/modules/journal/cron/installment-accrual.cron.ts
+++ b/apps/api/src/modules/journal/cron/installment-accrual.cron.ts
@@ -28,11 +28,19 @@ export class InstallmentAccrualCron {
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
 
+    // CPA Manual Termination Policy: skip contracts that have been terminated
+    // via 60D dispatch (status='LEGAL'). Once หนังสือบอกเลิก is dispatched,
+    // 2A accrual must stop — contract is closed legally (ปพพ.386).
+    // Refs: docs/superpowers/specs/2026-05-09-manual-termination-workflow-design.md
     const due = await this.prisma.installmentSchedule.findMany({
       where: {
         dueDate: { gte: today, lt: tomorrow },
         accrualJournalEntryId: null,
         deletedAt: null,
+        contract: {
+          status: { notIn: ['LEGAL', 'CLOSED_BAD_DEBT', 'COMPLETED', 'EARLY_PAYOFF', 'EXCHANGED', 'DEFECT_EXCHANGED'] },
+          deletedAt: null,
+        },
       },
     });
 

--- a/apps/api/src/modules/repossessions/repossessions.service.spec.ts
+++ b/apps/api/src/modules/repossessions/repossessions.service.spec.ts
@@ -141,6 +141,9 @@ describe('RepossessionsService', () => {
       user: {
         findUnique: jest.fn().mockResolvedValue({ defaultCashAccountCode: '11-1101' }),
       },
+      systemConfig: {
+        findUnique: jest.fn().mockResolvedValue(null), // strict mode off by default
+      },
       $transaction: jest.fn().mockImplementation(async (fn: unknown) => {
         if (typeof fn === 'function') return fn(prisma);
         return Promise.all(fn as Promise<unknown>[]);
@@ -301,7 +304,7 @@ describe('RepossessionsService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('throws BadRequestException when contract status is not DEFAULT or OVERDUE', async () => {
+    it('throws BadRequestException when contract status is ACTIVE (no termination)', async () => {
       prisma.contract.findUnique.mockResolvedValue(
         makeContract({ status: 'ACTIVE' }),
       );
@@ -309,6 +312,30 @@ describe('RepossessionsService', () => {
       await expect(
         service.create(baseDto as never, 'user-1'),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('allows JP5 when contract status is LEGAL (termination letter dispatched)', async () => {
+      prisma.contract.findUnique.mockResolvedValue(
+        makeContract({ status: 'LEGAL' }),
+      );
+      prisma.repossession.create.mockResolvedValue(makeRepossession({ id: 'repo-legal' }));
+      prisma.contract.update.mockResolvedValue({});
+      prisma.product.update.mockResolvedValue({});
+
+      const result = await service.create(baseDto as never, 'user-1');
+      expect(result).toBeDefined();
+    });
+
+    it('strict mode: rejects DEFAULT status when jp5_require_legal_status=true', async () => {
+      // CPA Manual Termination Policy: enforce LEGAL-only via SystemConfig
+      prisma.systemConfig.findUnique.mockResolvedValue({ value: 'true' });
+      prisma.contract.findUnique.mockResolvedValue(
+        makeContract({ status: 'DEFAULT' }),
+      );
+
+      await expect(
+        service.create(baseDto as never, 'user-1'),
+      ).rejects.toThrow(/strict mode|หนังสือบอกเลิก/);
     });
 
     it('throws BadRequestException when product is already repossessed', async () => {

--- a/apps/api/src/modules/repossessions/repossessions.service.ts
+++ b/apps/api/src/modules/repossessions/repossessions.service.ts
@@ -191,8 +191,26 @@ export class RepossessionsService {
       });
 
       if (!contract || contract.deletedAt) throw new NotFoundException('ไม่พบสัญญา');
-      if (!['DEFAULT', 'OVERDUE'].includes(contract.status)) {
-        throw new BadRequestException('สัญญานี้ไม่อยู่ในสถานะที่สามารถยึดคืนได้');
+      // CPA Manual Termination Policy (ปพพ.386):
+      //   ยึดเครื่อง (JP5) ต้องมีหนังสือบอกเลิกสัญญาดิสแพตช์แล้ว = status='LEGAL'
+      //   หากยังไม่ได้ส่งหนังสือ → ห้ามยึด · ต้องสร้าง CONTRACT_TERMINATION_60D letter
+      //   ผ่าน /api/contract-letters/:id/dispatch ก่อน
+      // Allow LEGAL (after letter dispatch) · DEFAULT/OVERDUE for legacy compat
+      // (existing contracts pre-Manual-Termination workflow may still be DEFAULT)
+      if (!['LEGAL', 'DEFAULT', 'OVERDUE'].includes(contract.status)) {
+        throw new BadRequestException(
+          'สัญญานี้ไม่อยู่ในสถานะที่สามารถยึดคืนได้ — ต้องเป็น LEGAL (ส่งหนังสือบอกเลิกแล้ว) หรือ DEFAULT/OVERDUE',
+        );
+      }
+      // Strict mode: require LEGAL (letter dispatched) — flagged via SystemConfig
+      const strictTerminationConfig = await tx.systemConfig.findUnique({
+        where: { key: 'jp5_require_legal_status' },
+      });
+      const requireLegal = strictTerminationConfig?.value === 'true';
+      if (requireLegal && contract.status !== 'LEGAL') {
+        throw new BadRequestException(
+          'JP5 strict mode: ต้องส่งหนังสือบอกเลิกสัญญา (CONTRACT_TERMINATION_60D) ก่อนยึดเครื่อง',
+        );
       }
 
       // Check if product is already repossessed


### PR DESCRIPTION
PR-2 ของ CPA 100% compliance — Manual Termination integration.

## Changes

### JP5 Pre-condition Guard (`repossessions.service.ts`)
- Allow LEGAL status (termination letter dispatched)
- Keep DEFAULT/OVERDUE for legacy compat
- Strict mode via SystemConfig key=`jp5_require_legal_status`

### 2A Cron Filter (`installment-accrual.cron.ts`)
- Skip status IN (LEGAL, CLOSED_BAD_DEBT, COMPLETED, EARLY_PAYOFF, EXCHANGED, DEFECT_EXCHANGED)
- หลังส่งหนังสือบอกเลิก (status=LEGAL) → 2A หยุด accrual อัตโนมัติ

## Verification
- ✅ Repossessions tests: 23/23 (2 new + 21 existing)

## Out of Scope (Follow-up)
- Decision Memo / 3-tier approval (60-90/90-120/120+)
- Customer Reply tracking
- Existing `POST /api/contract-letters/:id/dispatch` covers basic flow

Source: termination_policy.pdf v1.0 + ปพพ.386 + ม.36/2536 ข้อ 2(6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)