### PR TITLE
feat(receipts): RT-YYYYMM-NNNNN format + partial receipt fields (CPA Policy A)

### DIFF
--- a/apps/api/prisma/migrations/20260809000000_add_receipt_partial_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260809000000_add_receipt_partial_fields/migration.sql
@@ -6,3 +6,9 @@ ALTER TABLE "receipts"
   ADD COLUMN "payment_status" TEXT NOT NULL DEFAULT 'PAID',
   ADD COLUMN "installment_partial_seq" INTEGER,
   ADD COLUMN "remaining_amount" DECIMAL(12, 2);
+
+-- Compound index speeds up the cumulative-sum query
+-- (generateReceipt looks up (contract_id, installment_no) on every partial
+-- payment to compute installment_partial_seq + remaining_amount).
+CREATE INDEX "receipts_contract_id_installment_no_idx"
+  ON "receipts" ("contract_id", "installment_no");

--- a/apps/api/prisma/migrations/20260809000000_add_receipt_partial_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260809000000_add_receipt_partial_fields/migration.sql
@@ -1,0 +1,8 @@
+-- Add partial-receipt fields per CPA Policy A spec.
+-- payment_status: PARTIAL until installmentTotal cleared, then PAID.
+-- installment_partial_seq: 1, 2, 3 ... for partial receipts within same installment.
+-- remaining_amount: installment balance still owed AFTER this receipt.
+ALTER TABLE "receipts"
+  ADD COLUMN "payment_status" TEXT NOT NULL DEFAULT 'PAID',
+  ADD COLUMN "installment_partial_seq" INTEGER,
+  ADD COLUMN "remaining_amount" DECIMAL(12, 2);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2886,6 +2886,10 @@ model Receipt {
   @@index([receiptNumber])
   @@index([paymentId])
   @@index([createdAt])
+  // Speeds up the partial-receipt cumulative-sum query
+  // (`generateReceipt` looks up `(contractId, installmentNo)` rows on every
+  // partial payment to compute installmentPartialSeq + remainingAmount).
+  @@index([contractId, installmentNo])
   @@map("receipts")
 }
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2844,7 +2844,7 @@ model KycVerification {
 
 model Receipt {
   id               String    @id @default(uuid())
-  receiptNumber    String    @unique @map("receipt_number") // RC-YYYY-MM-NNNNN
+  receiptNumber    String    @unique @map("receipt_number") // RT-YYYYMM-NNNNN
   contractId       String    @map("contract_id")
   paymentId        String?   @map("payment_id")
   receiptType      String    @default("PAYMENT") // PAYMENT, DOWN_PAYMENT, EARLY_PAYOFF, CREDIT_NOTE
@@ -2856,8 +2856,14 @@ model Receipt {
   amountBeforeVat  Decimal?  @map("amount_before_vat") @db.Decimal(12, 2) // ราคาก่อน VAT
   vatAmount        Decimal?  @map("vat_amount") @db.Decimal(12, 2) // จำนวน VAT
   installmentNo    Int?      @map("installment_no") // งวดที่
-  remainingBalance Decimal?  @map("remaining_balance") @db.Decimal(12, 2)
+  remainingBalance Decimal?  @map("remaining_balance") @db.Decimal(12, 2) // contract balance after this payment
   remainingMonths  Int?      @map("remaining_months")
+  /// Per-installment payment status — PARTIAL until installmentTotal cleared, then PAID.
+  paymentStatus    String    @default("PAID") @map("payment_status")
+  /// 1, 2, 3 ... for partial receipts within the same installment (null for full payment).
+  installmentPartialSeq Int? @map("installment_partial_seq")
+  /// Installment balance still owed AFTER this receipt (0 when paymentStatus=PAID).
+  remainingAmount  Decimal?  @map("remaining_amount") @db.Decimal(12, 2)
   paymentMethod    String?   @map("payment_method")
   transactionRef   String?   @map("transaction_ref") // เลขอ้างอิงธุรกรรม
   itemDescription  String?   @map("item_description") // รายละเอียดสินค้า/บริการ

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -102,7 +102,7 @@ describe('PaymentsService', () => {
     };
 
     const mockReceiptsService = {
-      generateReceipt: jest.fn().mockResolvedValue({ id: 'receipt-1', receiptNumber: 'RC-2026-03-00001' }),
+      generateReceipt: jest.fn().mockResolvedValue({ id: 'receipt-1', receiptNumber: 'RT-202603-00001' }),
     };
 
     const mockAuditService = {

--- a/apps/api/src/modules/receipts/receipts.service.spec.ts
+++ b/apps/api/src/modules/receipts/receipts.service.spec.ts
@@ -73,7 +73,7 @@ describe('ReceiptsService', () => {
       // Existing receipt that can be voided (issued recently, has paymentId).
       tx.receipt.findUnique.mockResolvedValue({
         id: receiptId,
-        receiptNumber: 'RC-2026-04-00001',
+        receiptNumber: 'RT-202604-00001',
         contractId: 'ct-1',
         paymentId: 'pay-1',
         payerName: 'Customer A',
@@ -89,7 +89,7 @@ describe('ReceiptsService', () => {
 
       tx.receipt.create.mockResolvedValue({
         id: 'cn-1',
-        receiptNumber: 'RC-2026-04-00002',
+        receiptNumber: 'RT-202604-00002',
         receiptType: 'CREDIT_NOTE',
       });
       tx.receipt.update.mockResolvedValue({ id: receiptId, isVoided: true });
@@ -123,7 +123,7 @@ describe('ReceiptsService', () => {
 
       tx.receipt.findUnique.mockResolvedValue({
         id: receiptId,
-        receiptNumber: 'RC-2026-04-00001',
+        receiptNumber: 'RT-202604-00001',
         contractId: 'ct-1',
         paymentId: 'pay-1',
         payerName: 'Customer A',
@@ -139,7 +139,7 @@ describe('ReceiptsService', () => {
 
       tx.receipt.create.mockResolvedValue({
         id: 'cn-1',
-        receiptNumber: 'RC-2026-04-00002',
+        receiptNumber: 'RT-202604-00002',
         receiptType: 'CREDIT_NOTE',
       });
       tx.receipt.update.mockResolvedValue({ id: receiptId, isVoided: true });
@@ -165,7 +165,7 @@ describe('ReceiptsService', () => {
   describe('voidReceipt — Wave 3 T2 authorization (ปพพ.386 W-3)', () => {
     const validReceiptMock = () => ({
       id: receiptId,
-      receiptNumber: 'RC-2026-04-00001',
+      receiptNumber: 'RT-202604-00001',
       contractId: 'ct-1',
       paymentId: 'pay-1',
       payerName: 'Customer A',
@@ -183,7 +183,7 @@ describe('ReceiptsService', () => {
       tx.receipt.findUnique.mockResolvedValue(validReceiptMock());
       tx.receipt.create.mockResolvedValue({
         id: 'cn-1',
-        receiptNumber: 'RC-2026-04-00002',
+        receiptNumber: 'RT-202604-00002',
         receiptType: 'CREDIT_NOTE',
       });
       tx.receipt.update.mockResolvedValue({ id: receiptId, isVoided: true });
@@ -227,7 +227,7 @@ describe('ReceiptsService', () => {
       expect(auditCall.data.newValue.reason).toBe('wrong amount');
       expect(auditCall.data.newValue.userRole).toBe('OWNER');
       expect(auditCall.data.newValue.creditNoteId).toBe('cn-1');
-      expect(auditCall.data.oldValue.receiptNumber).toBe('RC-2026-04-00001');
+      expect(auditCall.data.oldValue.receiptNumber).toBe('RT-202604-00001');
     });
 
     it('allows ACCOUNTANT role', async () => {
@@ -267,6 +267,150 @@ describe('ReceiptsService', () => {
       await expect(
         service.voidReceipt(receiptId, 'wrong amount', userId, approverId),
       ).resolves.toBeDefined();
+    });
+  });
+
+  describe('generateReceipt — RT-YYYYMM format + partial fields', () => {
+    function buildPrismaForGenerate(opts: {
+      lastReceiptNumber?: string;
+      paymentStatus: 'PAID' | 'PARTIALLY_PAID';
+      amountDue: string;
+      priorReceipts: Array<{ amount: string }>;
+    }) {
+      const created = jest.fn(async ({ data }: any) => ({ id: 'rcpt-new', ...data }));
+      const tx = {
+        contract: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'ct-1',
+            financedAmount: '20000',
+            totalMonths: 12,
+            customer: { name: 'ลูกค้า ก' },
+            payments: [],
+            deletedAt: null,
+          }),
+        },
+        companyInfo: {
+          findFirst: jest.fn().mockResolvedValue({ nameTh: 'BESTCHOICE FINANCE' }),
+        },
+        payment: {
+          findUnique: jest.fn().mockResolvedValue({
+            status: opts.paymentStatus,
+            amountDue: opts.amountDue,
+          }),
+        },
+        receipt: {
+          findMany: jest.fn().mockResolvedValue(opts.priorReceipts),
+          create: created,
+        },
+        customer: { findFirst: jest.fn().mockResolvedValue(null) },
+        $queryRaw: jest
+          .fn()
+          // pg_advisory_xact_lock — no-op
+          .mockResolvedValueOnce(undefined)
+          // last receipt number lookup
+          .mockResolvedValueOnce(
+            opts.lastReceiptNumber
+              ? [{ receiptNumber: opts.lastReceiptNumber }]
+              : [],
+          ),
+      };
+      const local = {
+        $transaction: jest.fn().mockImplementation((cb: any) => cb(tx)),
+        __tx: tx,
+        __created: created,
+      };
+      return local;
+    }
+
+    function buildService(localPrisma: any) {
+      return new ReceiptsService(
+        localPrisma,
+        { createReversalJournal: jest.fn() } as any,
+        { voidReceipt: jest.fn() } as any,
+        {} as any,
+      );
+    }
+
+    it('generates RT-YYYYMM-NNNNN with seq=1 when month is empty', async () => {
+      const local = buildPrismaForGenerate({
+        paymentStatus: 'PAID',
+        amountDue: '1515.83',
+        priorReceipts: [],
+      });
+      const svc = buildService(local);
+
+      await svc.generateReceipt('ct-1', 'pay-1', 'INSTALLMENT', 1515.83, 1, 'CASH', null, 'u-1');
+
+      const data = local.__created.mock.calls[0][0].data;
+      expect(data.receiptNumber).toMatch(/^RT-\d{6}-00001$/);
+      expect(data.paymentStatus).toBe('PAID');
+      expect(data.installmentPartialSeq).toBeNull();
+    });
+
+    it('increments seq from last receipt of the same month', async () => {
+      const now = new Date();
+      const yyyymm = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
+      const local = buildPrismaForGenerate({
+        lastReceiptNumber: `RT-${yyyymm}-00042`,
+        paymentStatus: 'PAID',
+        amountDue: '1515.83',
+        priorReceipts: [],
+      });
+      const svc = buildService(local);
+
+      await svc.generateReceipt('ct-1', 'pay-1', 'INSTALLMENT', 1515.83, 1, 'CASH', null, 'u-1');
+
+      const data = local.__created.mock.calls[0][0].data;
+      expect(data.receiptNumber).toBe(`RT-${yyyymm}-00043`);
+    });
+
+    it('partial payment: paymentStatus=PARTIAL, installmentPartialSeq counts prior receipts +1, remainingAmount = due - cumulative', async () => {
+      const local = buildPrismaForGenerate({
+        paymentStatus: 'PARTIALLY_PAID',
+        amountDue: '1515.83',
+        priorReceipts: [{ amount: '500' }, { amount: '300' }],
+      });
+      const svc = buildService(local);
+
+      await svc.generateReceipt('ct-1', 'pay-1', 'INSTALLMENT', 200, 1, 'CASH', null, 'u-1');
+
+      const data = local.__created.mock.calls[0][0].data;
+      expect(data.paymentStatus).toBe('PARTIAL');
+      expect(data.installmentPartialSeq).toBe(3);
+      // 1515.83 - (500 + 300 + 200) = 515.83
+      expect(data.remainingAmount.toString()).toBe('515.83');
+    });
+
+    it('final partial payment that clears installment: paymentStatus=PAID, seq=null, remainingAmount=0', async () => {
+      const local = buildPrismaForGenerate({
+        paymentStatus: 'PAID',
+        amountDue: '1515.83',
+        priorReceipts: [{ amount: '500' }, { amount: '500' }],
+      });
+      const svc = buildService(local);
+
+      await svc.generateReceipt('ct-1', 'pay-1', 'INSTALLMENT', 515.83, 1, 'CASH', null, 'u-1');
+
+      const data = local.__created.mock.calls[0][0].data;
+      expect(data.paymentStatus).toBe('PAID');
+      expect(data.installmentPartialSeq).toBeNull();
+      expect(data.remainingAmount.toString()).toBe('0');
+    });
+
+    it('clamps remainingAmount to 0 when overpay is recorded as receipt', async () => {
+      const local = buildPrismaForGenerate({
+        paymentStatus: 'PAID',
+        amountDue: '1515.83',
+        priorReceipts: [],
+      });
+      const svc = buildService(local);
+
+      // Customer pays 1600 (overpay 84.17) — remainingAmount should clamp to 0,
+      // not surface as negative.
+      await svc.generateReceipt('ct-1', 'pay-1', 'INSTALLMENT', 1600, 1, 'CASH', null, 'u-1');
+
+      const data = local.__created.mock.calls[0][0].data;
+      expect(data.remainingAmount.toString()).toBe('0');
     });
   });
 });

--- a/apps/api/src/modules/receipts/receipts.service.ts
+++ b/apps/api/src/modules/receipts/receipts.service.ts
@@ -26,22 +26,20 @@ export class ReceiptsService {
   ) {}
 
   /**
-   * Generate receipt number: RC-YYYY-MM-NNNNN
+   * Generate receipt number: RT-YYYYMM-NNNNN (CPA Policy A spec).
    *
-   * Phase W-2: pg_advisory_xact_lock serialises concurrent generation within
-   * the same month, even when no rows yet exist for that prefix. The previous
-   * SELECT ... FOR UPDATE only locked existing rows — first receipt of a new
-   * month still race-conditioned (two callers both saw empty, both wrote -00001).
-   * Lock key = numeric YYYYMM with a +1 prefix (1<YYYYMM>) to namespace separate
-   * from journal entries which use the same lock space (raw YYYYMM).
-   * Auto-released at tx commit/rollback.
+   * Per-month sequence guarded by pg_advisory_xact_lock so concurrent generation
+   * within the same month — even on the first row of a new month — stays serialised
+   * and never produces duplicate -00001 sequences. Lock key is `1<YYYYMM>` (numeric)
+   * to namespace receipts separately from journal entries (which use raw YYYYMM).
+   * Lock auto-releases on tx commit/rollback.
    */
   private async generateReceiptNumber(tx?: Prisma.TransactionClient): Promise<string> {
     const db = tx || this.prisma;
     const now = new Date();
     const year = now.getFullYear();
     const month = String(now.getMonth() + 1).padStart(2, '0');
-    const prefix = `RC-${year}-${month}-`;
+    const prefix = `RT-${year}${month}-`;
 
     const lockKey = parseInt(`1${year}${month}`, 10);
     await db.$queryRaw`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`;
@@ -105,6 +103,41 @@ export class ReceiptsService {
       const paidMonths = contract.payments.length;
       const remainingMonths = totalMonths - paidMonths;
 
+      // Per-installment partial receipt fields (CPA Policy A spec):
+      //   paymentStatus: PARTIAL until Payment.status flips to PAID, then PAID
+      //   installmentPartialSeq: 1, 2, 3 ... within same installment (null on full payment)
+      //   remainingAmount: amountDue - cumulative receipt amounts for this installment
+      let paymentStatus = 'PAID';
+      let installmentPartialSeq: number | null = null;
+      let remainingAmount: Prisma.Decimal | null = null;
+      if (paymentId && installmentNo != null) {
+        const payment = await tx.payment.findUnique({
+          where: { id: paymentId },
+          select: { status: true, amountDue: true },
+        });
+        if (payment) {
+          const priorReceipts = await tx.receipt.findMany({
+            where: {
+              contractId,
+              installmentNo,
+              isVoided: false,
+              deletedAt: null,
+            },
+            select: { amount: true },
+          });
+          const priorTotal = priorReceipts.reduce(
+            (acc, r) => acc.plus(r.amount),
+            new Prisma.Decimal(0),
+          );
+          const cumulative = priorTotal.plus(amount);
+          const due = new Prisma.Decimal((payment.amountDue ?? 0).toString());
+          paymentStatus = payment.status === 'PAID' ? 'PAID' : 'PARTIAL';
+          installmentPartialSeq = paymentStatus === 'PARTIAL' ? priorReceipts.length + 1 : null;
+          const remainder = due.minus(cumulative);
+          remainingAmount = remainder.gt(0) ? remainder : new Prisma.Decimal(0);
+        }
+      }
+
       // Generate receipt number inside transaction (uses FOR UPDATE lock)
       const receiptNumber = await this.generateReceiptNumber(tx);
 
@@ -130,6 +163,9 @@ export class ReceiptsService {
           installmentNo,
           remainingBalance,
           remainingMonths: Math.max(0, remainingMonths),
+          paymentStatus,
+          installmentPartialSeq,
+          remainingAmount,
           paymentMethod,
           transactionRef,
           paidDate: new Date(),

--- a/apps/api/src/modules/receipts/receipts.service.ts
+++ b/apps/api/src/modules/receipts/receipts.service.ts
@@ -107,6 +107,12 @@ export class ReceiptsService {
       //   paymentStatus: PARTIAL until Payment.status flips to PAID, then PAID
       //   installmentPartialSeq: 1, 2, 3 ... within same installment (null on full payment)
       //   remainingAmount: amountDue - cumulative receipt amounts for this installment
+      //
+      // Voided receipts are intentionally excluded from priorReceipts: a voided
+      // receipt is legally non-existent (มาตรฐานการบัญชี — กลับรายการแล้วถือ
+      // เสมือนไม่ได้ออก) so the next receipt re-uses its slot in the seq —
+      // e.g. if seq #2 is voided, the following partial becomes #2, not #3.
+      // This matches how an accountant would re-issue a corrected receipt.
       let paymentStatus = 'PAID';
       let installmentPartialSeq: number | null = null;
       let remainingAmount: Prisma.Decimal | null = null;


### PR DESCRIPTION
## Summary

PR-4 of the 5-PR CPA Policy A 100% compliance plan. Aligns the payment receipt module with the CPA spec for partial-payment lifecycle.

- **Format change:** `RC-YYYY-MM-NNNNN` → `RT-YYYYMM-NNNNN` (per-month sequence, still serialised by `pg_advisory_xact_lock`).
- **Receipt schema fields** (migration `20260809000000_add_receipt_partial_fields`):
  - `paymentStatus` — `PARTIAL` until the underlying Payment is `PAID`, then `PAID`. Default `PAID` to keep historical rows untouched.
  - `installmentPartialSeq` — 1, 2, 3 ... within the same installment (null on full payment).
  - `remainingAmount` — installment balance still owed AFTER this receipt; clamps to 0 on overpay.
- **Per-installment partial logic in `generateReceipt`:** looks up the underlying Payment + sums prior receipts for the same `(contractId, installmentNo)` to compute the three new fields atomically inside the existing receipt-generation transaction.
- Receipts are already issued every payment (incl. partials) — that path was already wired.

## Test plan
- [x] `jest src/modules/receipts/receipts.service.spec` — **13/13 pass** (8 existing void/auth + 5 new generate/partial).
- [x] `tsc --noEmit` — 0 errors.
- [ ] Manual smoke after merge: record a partial payment via `RecordPaymentWizard` and verify the receipt PDF says "ชำระบางส่วน งวด N — ครั้งที่ X" with the correct `remainingAmount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)