### PR TITLE
chore(ci): cut Actions minutes ~50% — skip lint+test on main push, halve E2E shards

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -25,10 +25,16 @@ env:
 jobs:
   # ============================================
   # Job 1: Lint, Test, Build (same as deploy.yml)
+  #
+  # Runs on pull_request only — once a PR's lint+test passes and gets
+  # merged, the same commit doesn't need to re-run lint+test on push to
+  # main (build-and-push-api uses Docker layer caching independently).
+  # Saves ~5 min per merge × every PR = significant Actions minutes/month.
   # ============================================
   lint-and-test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
 
     services:
       postgres:
@@ -101,7 +107,6 @@ jobs:
   # ============================================
   build-and-push-api:
     name: Build & Push API Image
-    needs: lint-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
@@ -291,7 +296,6 @@ jobs:
   # ============================================
   deploy-web:
     name: Deploy Web to Firebase Hosting
-    needs: lint-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,8 +36,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Shard E2E tests across 4 parallel runners for speed
-        shard: [1, 2, 3, 4]
+        # Shard E2E tests across 2 parallel runners (was 4) — halves the
+        # setup overhead (npm ci + Prisma generate + build × shards) which
+        # is the dominant cost. Tests still run in parallel so wall time is
+        # only marginally longer.
+        shard: [1, 2]
 
     env:
       DATABASE_URL: postgresql://test:test@localhost:5432/test_db?schema=public
@@ -96,8 +99,8 @@ jobs:
       - name: Wait for Web
         run: npx wait-on http://localhost:5173 --timeout 15000
 
-      - name: Run E2E tests (shard ${{ matrix.shard }}/4)
-        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/4
+      - name: Run E2E tests (shard ${{ matrix.shard }}/2)
+        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/2
         working-directory: apps/web
 
       - name: Upload test results


### PR DESCRIPTION
## Summary

ลด GitHub Actions minutes ~50% — แก้ root cause ของ budget exhaustion ที่เจอวันนี้

## Changes

**`deploy-gcp.yml`**
- `lint-and-test` job รันเฉพาะ `pull_request` (ไม่รันบน push to main) — ของ PR ผ่านมาแล้ว ไม่ต้องรันซ้ำ
- `build-and-push-api` + `deploy-web` ไม่ต้อง `needs: lint-and-test` แล้ว — kick off ตรงบน push
- ประหยัด: **~5 min × ทุก PR ที่ merge**

**`e2e-tests.yml`**
- ลด Playwright shards 4 → 2 — setup overhead (npm ci + Prisma + build × shards) เป็นตัวกินเวลาหลัก
- Wall time ช้าขึ้นเล็กน้อย (test parallel ใน shard) แต่ minutes รวมลดครึ่งหนึ่ง
- ประหยัด: **~10-15 min × ทุก PR ที่แตะ apps/**

## Estimate

ที่ merge cadence เดิม (6 PRs/วัน):
- ก่อน: ~300 mins/วัน → budget หมดใน ~7 วัน
- หลัง: ~150 mins/วัน → ใต้ quota สบายๆ

🤖 Generated with [Claude Code](https://claude.com/claude-code)