### PR TITLE
PR-6: Daily Summary (final PR)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -221,6 +221,129 @@ describe('ExpenseDocumentsService', () => {
     });
   });
 
+  describe('getDailySummary', () => {
+    beforeEach(() => {
+      prisma.expenseDocument.findMany.mockResolvedValue([]);
+    });
+
+    it('throws when branchId missing', async () => {
+      await expect(
+        service.getDailySummary(
+          { date: '2026-05-10' } as never,
+          { id: 'u1', branchId: null, role: 'OWNER' },
+        ),
+      ).rejects.toThrow();
+    });
+
+    it('filters by branchId + date range + excludes VOIDED + deleted', async () => {
+      await service.getDailySummary(
+        { date: '2026-05-10', branchId: 'b1' } as never,
+        { id: 'u1', branchId: 'b1', role: 'OWNER' },
+      );
+      expect(prisma.expenseDocument.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            branchId: 'b1',
+            status: { not: 'VOIDED' },
+            deletedAt: null,
+          }),
+        }),
+      );
+    });
+
+    it('aggregates byType correctly across multiple docs', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Decimal } = require('@prisma/client/runtime/library');
+      prisma.expenseDocument.findMany.mockResolvedValue([
+        {
+          documentType: 'EXPENSE',
+          totalAmount: new Decimal('1000'),
+          netPayment: null,
+          paymentMethod: null,
+          paidAt: null,
+          depositAccountCode: null,
+          expenseDetail: { category: '53-1302' },
+          branch: { id: 'b1', name: 'A' },
+        },
+        {
+          documentType: 'EXPENSE',
+          totalAmount: new Decimal('500'),
+          netPayment: null,
+          paymentMethod: null,
+          paidAt: null,
+          depositAccountCode: null,
+          expenseDetail: { category: '53-1302' },
+          branch: { id: 'b1', name: 'A' },
+        },
+        {
+          documentType: 'PAYROLL',
+          totalAmount: new Decimal('30000'),
+          netPayment: null,
+          paymentMethod: null,
+          paidAt: null,
+          depositAccountCode: null,
+          expenseDetail: null,
+          branch: { id: 'b1', name: 'A' },
+        },
+      ]);
+      const result = await service.getDailySummary(
+        { date: '2026-05-10', branchId: 'b1' } as never,
+        { id: 'u1', branchId: 'b1', role: 'OWNER' },
+      );
+      expect(result.byType.EXPENSE.count).toBe(2);
+      expect(result.byType.EXPENSE.total).toBe('1500.00');
+      expect(result.byType.PAYROLL.count).toBe(1);
+      expect(result.byType.PAYROLL.total).toBe('30000.00');
+      expect(result.grandTotal).toBe('31500.00');
+    });
+
+    it('aggregates cashMovement only for docs with paidAt today + depositAccountCode', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Decimal } = require('@prisma/client/runtime/library');
+      const today = new Date('2026-05-10T10:00:00Z');
+      const yesterday = new Date('2026-05-09T10:00:00Z');
+      prisma.expenseDocument.findMany.mockResolvedValue([
+        {
+          documentType: 'EXPENSE',
+          totalAmount: new Decimal('1000'),
+          netPayment: new Decimal('1000'),
+          paymentMethod: 'CASH',
+          paidAt: today,
+          depositAccountCode: '11-1101',
+          expenseDetail: null,
+          branch: { id: 'b1', name: 'A' },
+        },
+        {
+          documentType: 'EXPENSE',
+          totalAmount: new Decimal('500'),
+          netPayment: null,
+          paymentMethod: null,
+          paidAt: null,
+          depositAccountCode: null,
+          expenseDetail: null,
+          branch: { id: 'b1', name: 'A' },
+        },
+        {
+          documentType: 'EXPENSE',
+          totalAmount: new Decimal('300'),
+          netPayment: new Decimal('300'),
+          paymentMethod: 'CASH',
+          paidAt: yesterday,
+          depositAccountCode: '11-1101',
+          expenseDetail: null,
+          branch: { id: 'b1', name: 'A' },
+        },
+      ]);
+      const result = await service.getDailySummary(
+        { date: '2026-05-10', branchId: 'b1' } as never,
+        { id: 'u1', branchId: 'b1', role: 'OWNER' },
+      );
+      // Only the first doc (paidAt=today) should be in cashMovement
+      expect(result.cashMovement['11-1101']?.count).toBe(1);
+      expect(result.cashMovement['11-1101']?.out).toBe('1000.00');
+    });
+  });
+
   describe('voidDocument', () => {
     it('flips status to VOIDED for non-VOIDED doc', async () => {
       prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({

--- a/apps/api/src/modules/expense-documents/expense-documents.controller.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.controller.ts
@@ -89,6 +89,16 @@ export class ExpenseDocumentsController {
     return this.service.getSummary({ branchId: effective, startDate, endDate });
   }
 
+  @Get('daily-summary')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  dailySummary(
+    @Query('date') date: string,
+    @Query('branchId') branchId: string | undefined,
+    @CurrentUser() user: { id: string; branchId?: string | null; role?: string | null },
+  ) {
+    return this.service.getDailySummary({ date, branchId }, user);
+  }
+
   @Get(':id')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   findOne(@Param('id') id: string) {

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -509,6 +509,103 @@ export class ExpenseDocumentsService {
     };
   }
 
+  // ─── Daily summary (print-ready aggregation) ─────────────────────────
+  async getDailySummary(
+    filters: { date: string; branchId?: string },
+    user: { id: string; branchId?: string | null; role?: string | null },
+  ) {
+    const branchId = hasCrossBranchAccess(user)
+      ? filters.branchId
+      : (user.branchId ?? filters.branchId);
+    if (!branchId) {
+      throw new BadRequestException('ต้องระบุสาขา');
+    }
+    const start = new Date(filters.date);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(filters.date);
+    end.setHours(23, 59, 59, 999);
+
+    const documents = await this.prisma.expenseDocument.findMany({
+      where: {
+        branchId,
+        documentDate: { gte: start, lte: end },
+        status: { not: 'VOIDED' },
+        deletedAt: null,
+      },
+      include: {
+        expenseDetail: true,
+        creditNote: true,
+        payroll: { include: { lines: true } },
+        settlement: { include: { settlementLines: true } },
+        branch: { select: { id: true, name: true } },
+      },
+      orderBy: { number: 'asc' },
+    });
+
+    // Aggregate
+    const byType: Record<string, { count: number; total: string }> = {};
+    const byPaymentMethod: Record<string, { count: number; total: string }> = {};
+    const byCategory: Record<string, { count: number; total: string }> = {};
+    const cashMovement: Record<string, { out: string; count: number }> = {};
+
+    let grandTotal = new Prisma.Decimal(0);
+
+    for (const d of documents) {
+      const total = new Prisma.Decimal(d.totalAmount.toString());
+      grandTotal = grandTotal.plus(total);
+
+      // By type
+      const tKey = d.documentType;
+      const tBucket = byType[tKey] ?? { count: 0, total: '0' };
+      tBucket.count++;
+      tBucket.total = new Prisma.Decimal(tBucket.total).plus(total).toFixed(2);
+      byType[tKey] = tBucket;
+
+      // By payment method (only if doc has paymentMethod set)
+      if (d.paymentMethod) {
+        const mKey = d.paymentMethod;
+        const mBucket = byPaymentMethod[mKey] ?? { count: 0, total: '0' };
+        mBucket.count++;
+        const netAmt = d.netPayment ? new Prisma.Decimal(d.netPayment.toString()) : total;
+        mBucket.total = new Prisma.Decimal(mBucket.total).plus(netAmt).toFixed(2);
+        byPaymentMethod[mKey] = mBucket;
+      }
+
+      // By category (EXPENSE + CREDIT_NOTE — others have no category)
+      const cat =
+        (d as { expenseDetail?: { category: string } | null }).expenseDetail?.category ??
+        (d as { creditNote?: { category: string } | null }).creditNote?.category;
+      if (cat) {
+        const cBucket = byCategory[cat] ?? { count: 0, total: '0' };
+        cBucket.count++;
+        cBucket.total = new Prisma.Decimal(cBucket.total).plus(total).toFixed(2);
+        byCategory[cat] = cBucket;
+      }
+
+      // Cash movement (only docs with depositAccountCode + paidAt today)
+      if (d.depositAccountCode && d.paidAt && d.paidAt >= start && d.paidAt <= end) {
+        const aKey = d.depositAccountCode;
+        const aBucket = cashMovement[aKey] ?? { out: '0', count: 0 };
+        const netAmt = d.netPayment ? new Prisma.Decimal(d.netPayment.toString()) : total;
+        aBucket.out = new Prisma.Decimal(aBucket.out).plus(netAmt).toFixed(2);
+        aBucket.count++;
+        cashMovement[aKey] = aBucket;
+      }
+    }
+
+    return {
+      date: filters.date,
+      branchId,
+      branchName: documents[0]?.branch?.name ?? null,
+      documents,
+      grandTotal: grandTotal.toFixed(2),
+      byType,
+      byPaymentMethod,
+      byCategory,
+      cashMovement,
+    };
+  }
+
   // ─── Find one ────────────────────────────────────────────────────────
   async findOne(id: string) {
     const doc = await this.prisma.expenseDocument.findUniqueOrThrow({

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -535,8 +535,8 @@ export class ExpenseDocumentsService {
       include: {
         expenseDetail: true,
         creditNote: true,
-        payroll: { include: { lines: true } },
-        settlement: { include: { settlementLines: true } },
+        payroll: true,
+        settlement: true,
         branch: { select: { id: true, name: true } },
       },
       orderBy: { number: 'asc' },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -83,6 +83,7 @@ const FinancePortfolioPage = lazy(() => import('@/pages/FinancePortfolioPage'));
 const ExpensesPage = lazy(() => import('@/pages/ExpensesPage'));
 const ExpenseDocumentNewPage = lazy(() => import('@/pages/ExpenseDocumentNewPage'));
 const ExpenseFavoritesPage = lazy(() => import('@/pages/ExpenseFavoritesPage'));
+const ExpenseDailySummaryPage = lazy(() => import('@/pages/ExpenseDailySummaryPage'));
 const ProfitLossPage = lazy(() => import('@/pages/ProfitLossPage'));
 const CompanySettingsPage = lazy(() => import('@/pages/CompanySettingsPage'));
 const TaxReportsPage = lazy(() => import('@/pages/TaxReportsPage'));
@@ -441,6 +442,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <ExpenseFavoritesPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/expenses/daily-summary"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ExpenseDailySummaryPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -522,10 +522,17 @@ layer(base);
 
 /* ── Print Styles for the public verify page ─────────── */
 @media print {
+  @page {
+    size: A4;
+    margin: 1cm;
+  }
+
   body {
     margin: 0;
     padding: 0;
     background: white;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 
   button,

--- a/apps/web/src/pages/ExpenseDailySummaryPage.tsx
+++ b/apps/web/src/pages/ExpenseDailySummaryPage.tsx
@@ -5,7 +5,8 @@ import api from '@/lib/api';
 import { ArrowLeft, Printer, FileSpreadsheet } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
-import { formatNumberDecimal, formatDateShortThai } from '@/utils/formatters';
+import { formatNumberDecimal } from '@/utils/formatters';
+import { formatThaiDateLong } from '@/lib/date';
 import { useAuth } from '@/contexts/AuthContext';
 
 // ─── Types ─────────────────────────────────────────────────────────────
@@ -160,15 +161,19 @@ export default function ExpenseDailySummaryPage() {
       <div className="hidden print:block mb-4">
         <h1 className="text-lg font-bold text-center">ใบสรุปรายจ่ายประจำวัน</h1>
         <div className="text-center text-sm">
-          วันที่ {formatDateShortThai(date)} · สาขา {summary?.branchName ?? '-'}
+          วันที่ {formatThaiDateLong(date)} · สาขา {summary?.branchName ?? '-'}
         </div>
         <div className="text-center text-xs text-muted-foreground">
           ผู้จัดทำ: {user?.name ?? '-'}
         </div>
       </div>
 
-      {isLoading || !summary ? (
+      {!branchId ? (
+        <div className="text-center py-12 text-muted-foreground">กรุณาเลือกสาขา</div>
+      ) : isLoading ? (
         <div className="text-center py-12 text-muted-foreground">กำลังโหลด...</div>
+      ) : !summary ? (
+        <div className="text-center py-12 text-muted-foreground">ไม่พบข้อมูลในวันที่เลือก</div>
       ) : (
         <div className="space-y-6">
           {/* Documents table */}

--- a/apps/web/src/pages/ExpenseDailySummaryPage.tsx
+++ b/apps/web/src/pages/ExpenseDailySummaryPage.tsx
@@ -1,0 +1,347 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams, useNavigate } from 'react-router';
+import api from '@/lib/api';
+import { ArrowLeft, Printer, FileSpreadsheet } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { formatNumberDecimal, formatDateShortThai } from '@/utils/formatters';
+import { useAuth } from '@/contexts/AuthContext';
+
+// ─── Types ─────────────────────────────────────────────────────────────
+interface ExpenseDocumentRow {
+  id: string;
+  number: string;
+  documentType: 'EXPENSE' | 'CREDIT_NOTE' | 'PAYROLL' | 'VENDOR_SETTLEMENT';
+  vendorName: string | null;
+  totalAmount: string;
+  netPayment: string | null;
+  paymentMethod: string | null;
+  depositAccountCode: string | null;
+  expenseDetail: { category: string } | null;
+  creditNote: { category: string } | null;
+}
+
+interface Summary {
+  date: string;
+  branchId: string;
+  branchName: string | null;
+  documents: ExpenseDocumentRow[];
+  grandTotal: string;
+  byType: Record<string, { count: number; total: string }>;
+  byPaymentMethod: Record<string, { count: number; total: string }>;
+  byCategory: Record<string, { count: number; total: string }>;
+  cashMovement: Record<string, { out: string; count: number }>;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  EXPENSE: 'รายจ่าย (EX)',
+  CREDIT_NOTE: 'ใบลดหนี้ (CN)',
+  PAYROLL: 'เงินเดือน (PR)',
+  VENDOR_SETTLEMENT: 'จ่ายเจ้าหนี้ (SE)',
+};
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  CASH: 'เงินสด',
+  BANK_TRANSFER: 'โอนธนาคาร',
+  QR_EWALLET: 'QR/E-Wallet',
+};
+
+export default function ExpenseDailySummaryPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [date, setDate] = useState<string>(
+    searchParams.get('date') ?? new Date().toISOString().slice(0, 10),
+  );
+  const [branchId, setBranchId] = useState<string>(
+    searchParams.get('branchId') ?? user?.branchId ?? '',
+  );
+
+  const { data: branches } = useQuery<{ id: string; name: string }[]>({
+    queryKey: ['branches'],
+    queryFn: async () => (await api.get('/branches')).data,
+  });
+
+  const { data: summary, isLoading } = useQuery<Summary>({
+    queryKey: ['daily-summary', date, branchId],
+    queryFn: async () =>
+      (await api.get(`/expense-documents/daily-summary?date=${date}&branchId=${branchId}`)).data,
+    enabled: !!branchId && !!date,
+  });
+
+  const handlePrint = () => window.print();
+
+  const handleExportExcel = async () => {
+    if (!summary) return;
+    const ExcelJS = (await import('exceljs')).default;
+    const wb = new ExcelJS.Workbook();
+    const sh1 = wb.addWorksheet('รายการเอกสาร');
+    sh1.addRow(['เลข', 'ประเภท', 'ผู้ขาย', 'หมวดบัญชี', 'ยอด', 'วิธีจ่าย']);
+    summary.documents.forEach((d) => {
+      sh1.addRow([
+        d.number,
+        TYPE_LABELS[d.documentType] ?? d.documentType,
+        d.vendorName ?? '',
+        d.expenseDetail?.category ?? d.creditNote?.category ?? '',
+        d.totalAmount,
+        d.paymentMethod ? (PAYMENT_METHOD_LABELS[d.paymentMethod] ?? d.paymentMethod) : '',
+      ]);
+    });
+
+    const sh2 = wb.addWorksheet('สรุปยอด');
+    sh2.addRow(['ตามประเภท', 'จำนวน', 'รวม']);
+    Object.entries(summary.byType).forEach(([k, v]) =>
+      sh2.addRow([TYPE_LABELS[k] ?? k, v.count, v.total]),
+    );
+    sh2.addRow([]);
+    sh2.addRow(['ตามวิธีจ่าย', 'จำนวน', 'รวม']);
+    Object.entries(summary.byPaymentMethod).forEach(([k, v]) =>
+      sh2.addRow([PAYMENT_METHOD_LABELS[k] ?? k, v.count, v.total]),
+    );
+    sh2.addRow([]);
+    sh2.addRow(['เงินสด/ธนาคาร', 'จำนวนครั้ง', 'ยอดออก']);
+    Object.entries(summary.cashMovement).forEach(([k, v]) =>
+      sh2.addRow([k, v.count, v.out]),
+    );
+    sh2.addRow([]);
+    sh2.addRow(['รวมทั้งสิ้น', '', summary.grandTotal]);
+
+    const buf = await wb.xlsx.writeBuffer();
+    const blob = new Blob([buf], {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `daily-summary-${date.replace(/-/g, '')}-${branchId}.xlsx`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto print:p-0 print:max-w-none">
+      {/* Header — hidden in print */}
+      <div className="print:hidden flex items-center justify-between mb-5 flex-wrap gap-3">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate('/expenses')}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" /> กลับ
+          </button>
+          <h1 className="text-base font-semibold">ใบสรุปรายจ่ายประจำวัน</h1>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <ThaiDateInput value={date} onChange={(e) => setDate(e.target.value)} />
+          {branches && branches.length > 1 && (
+            <select
+              value={branchId}
+              onChange={(e) => setBranchId(e.target.value)}
+              className="px-3 py-2 border border-input rounded-lg text-sm bg-background"
+            >
+              {branches.map((b) => (
+                <option key={b.id} value={b.id}>
+                  {b.name}
+                </option>
+              ))}
+            </select>
+          )}
+          <Button variant="outline" size="sm" onClick={handlePrint} disabled={!summary}>
+            <Printer className="size-4" /> พิมพ์
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleExportExcel} disabled={!summary}>
+            <FileSpreadsheet className="size-4" /> Excel
+          </Button>
+        </div>
+      </div>
+
+      {/* Print-only header */}
+      <div className="hidden print:block mb-4">
+        <h1 className="text-lg font-bold text-center">ใบสรุปรายจ่ายประจำวัน</h1>
+        <div className="text-center text-sm">
+          วันที่ {formatDateShortThai(date)} · สาขา {summary?.branchName ?? '-'}
+        </div>
+        <div className="text-center text-xs text-muted-foreground">
+          ผู้จัดทำ: {user?.name ?? '-'}
+        </div>
+      </div>
+
+      {isLoading || !summary ? (
+        <div className="text-center py-12 text-muted-foreground">กำลังโหลด...</div>
+      ) : (
+        <div className="space-y-6">
+          {/* Documents table */}
+          <div className="border border-border rounded-xl overflow-hidden bg-card">
+            <div className="px-4 py-3 border-b border-border text-sm font-medium">
+              รายการเอกสาร ({summary.documents.length} รายการ)
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/30">
+                  <tr className="border-b border-border">
+                    <th className="text-left p-2">เลข</th>
+                    <th className="text-left p-2">ประเภท</th>
+                    <th className="text-left p-2">ผู้ขาย</th>
+                    <th className="text-left p-2">บัญชี</th>
+                    <th className="text-right p-2">ยอด</th>
+                    <th className="text-left p-2">จ่ายโดย</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.documents.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={6}
+                        className="p-6 text-center text-muted-foreground"
+                      >
+                        ไม่มีเอกสารในวันนี้
+                      </td>
+                    </tr>
+                  ) : (
+                    summary.documents.map((d) => (
+                      <tr key={d.id} className="border-b border-border last:border-0">
+                        <td className="p-2 font-mono">{d.number}</td>
+                        <td className="p-2">{TYPE_LABELS[d.documentType] ?? d.documentType}</td>
+                        <td className="p-2">{d.vendorName ?? '–'}</td>
+                        <td className="p-2 font-mono text-xs">
+                          {d.expenseDetail?.category ?? d.creditNote?.category ?? '-'}
+                        </td>
+                        <td className="p-2 text-right font-mono">
+                          {formatNumberDecimal(d.totalAmount)}
+                        </td>
+                        <td className="p-2">
+                          {d.paymentMethod
+                            ? (PAYMENT_METHOD_LABELS[d.paymentMethod] ?? d.paymentMethod)
+                            : '-'}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+                <tfoot className="bg-muted font-semibold">
+                  <tr>
+                    <td colSpan={4} className="p-2 text-right">
+                      รวมทั้งสิ้น
+                    </td>
+                    <td className="p-2 text-right font-mono">
+                      {formatNumberDecimal(summary.grandTotal)}
+                    </td>
+                    <td></td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+
+          {/* Totals grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 print:grid-cols-2">
+            <div className="border border-border rounded-xl p-4 bg-card">
+              <h3 className="text-sm font-semibold mb-3">รวมตามประเภท</h3>
+              {Object.keys(summary.byType).length === 0 ? (
+                <div className="text-xs text-muted-foreground">—</div>
+              ) : (
+                <table className="w-full text-sm">
+                  <tbody>
+                    {Object.entries(summary.byType).map(([k, v]) => (
+                      <tr key={k} className="border-b border-border last:border-0">
+                        <td className="py-1.5">{TYPE_LABELS[k] ?? k}</td>
+                        <td className="py-1.5 text-right text-muted-foreground">
+                          {v.count} รายการ
+                        </td>
+                        <td className="py-1.5 text-right font-mono">
+                          {formatNumberDecimal(v.total)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+
+            <div className="border border-border rounded-xl p-4 bg-card">
+              <h3 className="text-sm font-semibold mb-3">รวมตามวิธีจ่าย</h3>
+              {Object.keys(summary.byPaymentMethod).length === 0 ? (
+                <div className="text-xs text-muted-foreground">—</div>
+              ) : (
+                <table className="w-full text-sm">
+                  <tbody>
+                    {Object.entries(summary.byPaymentMethod).map(([k, v]) => (
+                      <tr key={k} className="border-b border-border last:border-0">
+                        <td className="py-1.5">{PAYMENT_METHOD_LABELS[k] ?? k}</td>
+                        <td className="py-1.5 text-right text-muted-foreground">
+                          {v.count} รายการ
+                        </td>
+                        <td className="py-1.5 text-right font-mono">
+                          {formatNumberDecimal(v.total)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+
+          {/* Category breakdown — optional */}
+          {Object.keys(summary.byCategory).length > 0 && (
+            <div className="border border-border rounded-xl p-4 bg-card">
+              <h3 className="text-sm font-semibold mb-3">รวมตามหมวดบัญชี</h3>
+              <table className="w-full text-sm">
+                <tbody>
+                  {Object.entries(summary.byCategory).map(([k, v]) => (
+                    <tr key={k} className="border-b border-border last:border-0">
+                      <td className="py-1.5 font-mono text-xs">{k}</td>
+                      <td className="py-1.5 text-right text-muted-foreground">
+                        {v.count} รายการ
+                      </td>
+                      <td className="py-1.5 text-right font-mono">
+                        {formatNumberDecimal(v.total)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Cash movement */}
+          {Object.keys(summary.cashMovement).length > 0 && (
+            <div className="border border-border rounded-xl p-4 bg-card">
+              <h3 className="text-sm font-semibold mb-3">เงินสด/ธนาคาร เคลื่อนไหววันนี้</h3>
+              <table className="w-full text-sm">
+                <tbody>
+                  {Object.entries(summary.cashMovement).map(([k, v]) => (
+                    <tr key={k} className="border-b border-border last:border-0">
+                      <td className="py-1.5 font-mono text-xs">{k}</td>
+                      <td className="py-1.5 text-right text-muted-foreground">
+                        ออก {v.count} ครั้ง
+                      </td>
+                      <td className="py-1.5 text-right font-mono text-destructive">
+                        ({formatNumberDecimal(v.out)})
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Signature footer (visible in print) */}
+          <div className="grid grid-cols-3 gap-8 mt-12 pt-8 print:mt-12 print:pt-8 text-sm">
+            <div className="text-center">
+              <div className="border-t border-foreground pt-2">ผู้จัดทำ</div>
+              <div className="text-xs text-muted-foreground mt-1">{user?.name ?? ''}</div>
+            </div>
+            <div className="text-center">
+              <div className="border-t border-foreground pt-2">ผู้ตรวจสอบ</div>
+            </div>
+            <div className="text-center">
+              <div className="border-t border-foreground pt-2">ผู้อนุมัติ</div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -765,6 +765,10 @@ export default function ExpensesPage() {
                   navigate('/expenses/favorites');
                   return;
                 }
+                if (tab.id === 'daily-summary') {
+                  navigate('/expenses/daily-summary');
+                  return;
+                }
                 if (isAction) return;
                 setTab(tab.id);
               }}

--- a/docs/superpowers/plans/2026-05-10-expense-document-pr6.md
+++ b/docs/superpowers/plans/2026-05-10-expense-document-pr6.md
@@ -1,0 +1,448 @@
+# PR-6: Daily Summary — Implementation Plan (Final)
+
+**Goal:** Print-ready "ใบสรุปรายจ่ายประจำวัน" page. Backend aggregates documents for selected date+branch into totals (by type/method/category/cash-account). Frontend renders A4 printable layout + Excel export.
+
+**Architecture:** New backend service method `getDailySummary(date, branchId)` returning `{ documents, byType, byPaymentMethod, byCategory, cashMovement }`. Endpoint `GET /expense-documents/daily-summary`. Frontend `/expenses/daily-summary` page with date+branch selector, table+totals sections, `@media print` CSS for A4, exceljs for Excel.
+
+**Branch:** `feat/expense-documents-pr6` (off `feat/expense-documents-pr5`).
+
+**Spec ref:** §7.2 (Daily Summary).
+
+---
+
+## File Structure
+
+### API
+- Modify: `expense-documents.service.ts` — add `getDailySummary()` method
+- Modify: `expense-documents.controller.ts` — add `GET /daily-summary` endpoint
+- Test: extend service spec
+
+### Web
+- Create: `pages/ExpenseDailySummaryPage.tsx` — date selector + render + print + Excel buttons
+- Modify: `App.tsx` — add `/expenses/daily-summary` route
+- Modify: `pages/ExpensesPage.tsx` — wire `สรุปรายวัน` tab → navigate to new page
+
+---
+
+## Task 1: Backend service + endpoint
+
+**1.1** — Add method to `apps/api/src/modules/expense-documents/expense-documents.service.ts`:
+
+```ts
+async getDailySummary(filters: { date: string; branchId?: string }, user: UserContext) {
+  const branchId = hasCrossBranchAccess(user) ? filters.branchId : (user.branchId ?? filters.branchId);
+  if (!branchId) {
+    throw new BadRequestException('ต้องระบุสาขา');
+  }
+  const start = new Date(filters.date);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(filters.date);
+  end.setHours(23, 59, 59, 999);
+
+  const documents = await this.prisma.expenseDocument.findMany({
+    where: {
+      branchId,
+      documentDate: { gte: start, lte: end },
+      status: { not: 'VOIDED' },
+      deletedAt: null,
+    },
+    include: {
+      expenseDetail: true,
+      creditNote: true,
+      payroll: { include: { lines: true } },
+      settlement: { include: { settlementLines: true } },
+      branch: { select: { id: true, name: true } },
+    },
+    orderBy: { number: 'asc' },
+  });
+
+  // Aggregate
+  const byType: Record<string, { count: number; total: string }> = {};
+  const byPaymentMethod: Record<string, { count: number; total: string }> = {};
+  const byCategory: Record<string, { count: number; total: string }> = {};
+  const cashMovement: Record<string, { out: string; count: number }> = {};
+
+  let grandTotal = new Prisma.Decimal(0);
+
+  for (const d of documents) {
+    const total = new Prisma.Decimal(d.totalAmount.toString());
+    grandTotal = grandTotal.plus(total);
+
+    // By type
+    const tKey = d.documentType;
+    const tBucket = byType[tKey] ?? { count: 0, total: '0' };
+    tBucket.count++;
+    tBucket.total = new Prisma.Decimal(tBucket.total).plus(total).toFixed(2);
+    byType[tKey] = tBucket;
+
+    // By payment method (only if doc has paymentMethod set)
+    if (d.paymentMethod) {
+      const mKey = d.paymentMethod;
+      const mBucket = byPaymentMethod[mKey] ?? { count: 0, total: '0' };
+      mBucket.count++;
+      mBucket.total = new Prisma.Decimal(mBucket.total).plus(d.netPayment ?? total).toFixed(2);
+      byPaymentMethod[mKey] = mBucket;
+    }
+
+    // By category (EXPENSE only — others have no category)
+    const cat = d.expenseDetail?.category ?? d.creditNote?.category;
+    if (cat) {
+      const cBucket = byCategory[cat] ?? { count: 0, total: '0' };
+      cBucket.count++;
+      cBucket.total = new Prisma.Decimal(cBucket.total).plus(total).toFixed(2);
+      byCategory[cat] = cBucket;
+    }
+
+    // Cash movement (only docs with depositAccountCode + paidAt today)
+    if (d.depositAccountCode && d.paidAt && d.paidAt >= start && d.paidAt <= end) {
+      const aKey = d.depositAccountCode;
+      const aBucket = cashMovement[aKey] ?? { out: '0', count: 0 };
+      aBucket.out = new Prisma.Decimal(aBucket.out).plus(d.netPayment ?? total).toFixed(2);
+      aBucket.count++;
+      cashMovement[aKey] = aBucket;
+    }
+  }
+
+  return {
+    date: filters.date,
+    branchId,
+    branchName: documents[0]?.branch.name ?? null,
+    documents,
+    grandTotal: grandTotal.toFixed(2),
+    byType,
+    byPaymentMethod,
+    byCategory,
+    cashMovement,
+  };
+}
+```
+
+**1.2** — Add endpoint to `apps/api/src/modules/expense-documents/expense-documents.controller.ts`:
+
+```ts
+@Get('daily-summary')
+@Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+dailySummary(
+  @Query('date') date: string,
+  @Query('branchId') branchId: string | undefined,
+  @CurrentUser() user: { id: string; branchId?: string; role: string },
+) {
+  return this.service.getDailySummary({ date, branchId }, user);
+}
+```
+
+NOTE: Place this BEFORE `@Get(':id')` route to avoid Nest matching `:id = daily-summary` literal.
+
+**1.3** — Tests in `apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts`:
+
+Add `describe('getDailySummary', () => { ... })` with 4 tests:
+1. Filters by date + branchId
+2. Excludes VOIDED + deleted
+3. Aggregates byType correctly
+4. Aggregates cashMovement only for docs with paidAt today
+
+Run + commit:
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/apps/api
+npx jest --testPathPattern="expense-documents.service.spec" --runInBand 2>&1 | tail -10
+git add apps/api/src/modules/expense-documents/
+git commit -m "feat(expense-documents): add getDailySummary endpoint"
+```
+
+## Task 2: Frontend Daily Summary page
+
+Create `apps/web/src/pages/ExpenseDailySummaryPage.tsx`:
+
+Layout per spec mockup:
+- Header: title + date selector (ThaiDateInput) + branch selector + Print button + Excel button
+- Section 1: Documents table (zebra rows, monospace number column)
+- Section 2: 2-column grid — Totals by type | Totals by payment method
+- Section 3: Cash movement (per depositAccountCode)
+- Section 4: Signature lines (3 lines: prepared / reviewed / approved)
+- Print CSS: `@media print` hides nav/buttons, A4 page-size, signature section forced visible
+
+Key implementation:
+```tsx
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams, useNavigate } from 'react-router';
+import api from '@/lib/api';
+import { ArrowLeft, Printer, FileSpreadsheet } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { formatNumberDecimal, formatDateShortThai } from '@/utils/formatters';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface Summary {
+  date: string;
+  branchId: string;
+  branchName: string | null;
+  documents: ExpenseDocument[]; // header + nested detail
+  grandTotal: string;
+  byType: Record<string, { count: number; total: string }>;
+  byPaymentMethod: Record<string, { count: number; total: string }>;
+  byCategory: Record<string, { count: number; total: string }>;
+  cashMovement: Record<string, { out: string; count: number }>;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  EXPENSE: 'รายจ่าย (EX)',
+  CREDIT_NOTE: 'ใบลดหนี้ (CN)',
+  PAYROLL: 'เงินเดือน (PR)',
+  VENDOR_SETTLEMENT: 'จ่ายเจ้าหนี้ (SE)',
+};
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  CASH: 'เงินสด',
+  BANK_TRANSFER: 'โอนธนาคาร',
+  QR_EWALLET: 'QR/E-Wallet',
+};
+
+export default function ExpenseDailySummaryPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [date, setDate] = useState(searchParams.get('date') ?? new Date().toISOString().slice(0, 10));
+  const [branchId, setBranchId] = useState(searchParams.get('branchId') ?? user?.branchId ?? '');
+
+  const { data: branches } = useQuery<{ id: string; name: string }[]>({
+    queryKey: ['branches'],
+    queryFn: async () => (await api.get('/branches')).data,
+  });
+
+  const { data: summary, isLoading } = useQuery<Summary>({
+    queryKey: ['daily-summary', date, branchId],
+    queryFn: async () => (await api.get(`/expense-documents/daily-summary?date=${date}&branchId=${branchId}`)).data,
+    enabled: !!branchId && !!date,
+  });
+
+  const handlePrint = () => window.print();
+
+  const handleExportExcel = async () => {
+    if (!summary) return;
+    const ExcelJS = await import('exceljs');
+    const wb = new ExcelJS.Workbook();
+    const sh1 = wb.addWorksheet('รายการเอกสาร');
+    sh1.addRow(['เลข', 'ประเภท', 'ผู้ขาย', 'ยอด', 'วิธีจ่าย']);
+    summary.documents.forEach((d) => {
+      sh1.addRow([d.number, d.documentType, d.vendorName ?? '', d.totalAmount, d.paymentMethod ?? '']);
+    });
+    const sh2 = wb.addWorksheet('สรุปยอด');
+    sh2.addRow(['ตามประเภท', '', '']);
+    Object.entries(summary.byType).forEach(([k, v]) => sh2.addRow([TYPE_LABELS[k] ?? k, v.count, v.total]));
+    sh2.addRow(['ตามวิธีจ่าย', '', '']);
+    Object.entries(summary.byPaymentMethod).forEach(([k, v]) => sh2.addRow([PAYMENT_METHOD_LABELS[k] ?? k, v.count, v.total]));
+    const buf = await wb.xlsx.writeBuffer();
+    const blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `daily-summary-${date.replace(/-/g, '')}-${branchId}.xlsx`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div>
+      {/* Header — hidden in print */}
+      <div className="print:hidden flex items-center justify-between mb-5">
+        <div className="flex items-center gap-3">
+          <button onClick={() => navigate('/expenses')} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+            <ArrowLeft className="size-4" /> กลับ
+          </button>
+          <h1 className="text-base font-semibold">ใบสรุปรายจ่ายประจำวัน</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <ThaiDateInput value={date} onChange={(e) => setDate(e.target.value)} />
+          {branches && branches.length > 1 && (
+            <select value={branchId} onChange={(e) => setBranchId(e.target.value)} className="px-3 py-2 border rounded text-sm">
+              {branches.map((b) => <option key={b.id} value={b.id}>{b.name}</option>)}
+            </select>
+          )}
+          <Button variant="outline" size="sm" onClick={handlePrint} disabled={!summary}>
+            <Printer className="size-4" /> พิมพ์
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleExportExcel} disabled={!summary}>
+            <FileSpreadsheet className="size-4" /> Excel
+          </Button>
+        </div>
+      </div>
+
+      {/* Print-only header */}
+      <div className="hidden print:block mb-4">
+        <h1 className="text-lg font-bold text-center">ใบสรุปรายจ่ายประจำวัน</h1>
+        <div className="text-center text-sm">วันที่ {formatDateShortThai(date)} · สาขา {summary?.branchName ?? '-'}</div>
+        <div className="text-center text-xs text-muted-foreground">ผู้จัดทำ: {user?.name ?? '-'}</div>
+      </div>
+
+      {isLoading || !summary ? (
+        <div className="text-center py-12 text-muted-foreground">กำลังโหลด...</div>
+      ) : (
+        <div className="space-y-6">
+          {/* Documents table */}
+          <div className="border rounded-xl overflow-hidden bg-card">
+            <div className="px-4 py-3 border-b text-sm font-medium">รายการเอกสาร ({summary.documents.length} รายการ)</div>
+            <table className="w-full text-sm">
+              <thead className="bg-muted/30">
+                <tr className="border-b">
+                  <th className="text-left p-2">เลข</th>
+                  <th className="text-left p-2">ประเภท</th>
+                  <th className="text-left p-2">ผู้ขาย</th>
+                  <th className="text-left p-2">บัญชี</th>
+                  <th className="text-right p-2">ยอด</th>
+                  <th className="text-left p-2">จ่ายโดย</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.documents.map((d) => (
+                  <tr key={d.id} className="border-b last:border-0">
+                    <td className="p-2 font-mono text-warning">{d.number}</td>
+                    <td className="p-2">{TYPE_LABELS[d.documentType]}</td>
+                    <td className="p-2">{d.vendorName ?? '–'}</td>
+                    <td className="p-2 font-mono text-xs">{d.expenseDetail?.category ?? d.creditNote?.category ?? '-'}</td>
+                    <td className="p-2 text-right font-mono">{formatNumberDecimal(d.totalAmount)}</td>
+                    <td className="p-2">{d.paymentMethod ? PAYMENT_METHOD_LABELS[d.paymentMethod] : '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot className="bg-muted font-semibold">
+                <tr>
+                  <td colSpan={4} className="p-2 text-right">รวมทั้งสิ้น</td>
+                  <td className="p-2 text-right font-mono">{formatNumberDecimal(summary.grandTotal)}</td>
+                  <td></td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+
+          {/* Totals grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 print:grid-cols-2">
+            <div className="border rounded-xl p-4 bg-card">
+              <h3 className="text-sm font-semibold mb-3">รวมตามประเภท</h3>
+              <table className="w-full text-sm">
+                <tbody>
+                  {Object.entries(summary.byType).map(([k, v]) => (
+                    <tr key={k} className="border-b last:border-0">
+                      <td className="py-1.5">{TYPE_LABELS[k] ?? k}</td>
+                      <td className="py-1.5 text-right text-muted-foreground">{v.count} รายการ</td>
+                      <td className="py-1.5 text-right font-mono">{formatNumberDecimal(v.total)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="border rounded-xl p-4 bg-card">
+              <h3 className="text-sm font-semibold mb-3">รวมตามวิธีจ่าย</h3>
+              <table className="w-full text-sm">
+                <tbody>
+                  {Object.entries(summary.byPaymentMethod).map(([k, v]) => (
+                    <tr key={k} className="border-b last:border-0">
+                      <td className="py-1.5">{PAYMENT_METHOD_LABELS[k] ?? k}</td>
+                      <td className="py-1.5 text-right text-muted-foreground">{v.count} รายการ</td>
+                      <td className="py-1.5 text-right font-mono">{formatNumberDecimal(v.total)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Cash movement */}
+          {Object.keys(summary.cashMovement).length > 0 && (
+            <div className="border rounded-xl p-4 bg-card">
+              <h3 className="text-sm font-semibold mb-3">เงินสด/ธนาคาร เคลื่อนไหววันนี้</h3>
+              <table className="w-full text-sm">
+                <tbody>
+                  {Object.entries(summary.cashMovement).map(([k, v]) => (
+                    <tr key={k} className="border-b last:border-0">
+                      <td className="py-1.5 font-mono text-xs">{k}</td>
+                      <td className="py-1.5 text-right text-muted-foreground">ออก {v.count} ครั้ง</td>
+                      <td className="py-1.5 text-right font-mono text-destructive">({formatNumberDecimal(v.out)})</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Signature footer (visible in print) */}
+          <div className="grid grid-cols-3 gap-8 mt-12 pt-8 print:mt-12 print:pt-8 text-sm">
+            <div className="text-center">
+              <div className="border-t border-foreground pt-2">ผู้จัดทำ</div>
+              <div className="text-xs text-muted-foreground mt-1">{user?.name ?? ''}</div>
+            </div>
+            <div className="text-center">
+              <div className="border-t border-foreground pt-2">ผู้ตรวจสอบ</div>
+            </div>
+            <div className="text-center">
+              <div className="border-t border-foreground pt-2">ผู้อนุมัติ</div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Add print CSS to global stylesheet (or inline `<style>` in this page):
+
+```css
+@media print {
+  @page { size: A4; margin: 1cm; }
+  body { font-family: 'IBM Plex Sans Thai', sans-serif; font-size: 10pt; }
+  /* Tailwind handles print:hidden */
+}
+```
+
+(Use Tailwind `print:hidden` + `print:block` utilities; @page rules belong in `index.css` if not already present.)
+
+## Task 3: Wire `สรุปรายวัน` tab + add route
+
+In `apps/web/src/App.tsx` add:
+```ts
+const ExpenseDailySummaryPage = lazy(() => import('@/pages/ExpenseDailySummaryPage'));
+```
+
+Route:
+```tsx
+<Route path="/expenses/daily-summary" element={<ProtectedRoute><MainLayout><ExpenseDailySummaryPage /></MainLayout></ProtectedRoute>} />
+```
+
+In `apps/web/src/pages/ExpensesPage.tsx`, find the tabs render and update the onClick:
+```tsx
+onClick={() => {
+  if (tab.id === 'favorites') {
+    navigate('/expenses/favorites');
+    return;
+  }
+  if (tab.id === 'daily-summary') {
+    navigate('/expenses/daily-summary');
+    return;
+  }
+  if (isAction) return;
+  setTab(tab.id);
+}}
+```
+
+## Task 4: Verify + push + PR
+
+```bash
+./tools/check-types.sh all
+git push -u origin feat/expense-documents-pr6
+gh pr create --base feat/expense-documents-pr5 --title "PR-6: Daily Summary (final PR)"
+```
+
+---
+
+## Self-Review
+
+- §7.2 backend aggregation ✅, frontend layout ✅, print + Excel ✅
+- Cash movement only counted when paidAt is within day range
+- All branches with multiple branches get selector
+
+## Out of scope
+
+- PDF export (CSS print is sufficient — A4 layout)
+- Cross-module daily summary (incl. RT/OI income) — Phase A.7
+- Multi-branch consolidated view


### PR DESCRIPTION
## Summary

Final PR — adds print-ready "ใบสรุปรายจ่ายประจำวัน" with backend aggregation, frontend page, and Excel export.

**Branched off** `feat/expense-documents-pr5` (PR #799).

### Backend
- New service method `getDailySummary({ date, branchId }, user)` — aggregates non-VOIDED docs for selected date+branch into byType/byPaymentMethod/byCategory/cashMovement totals
- Endpoint `GET /expense-documents/daily-summary?date=YYYY-MM-DD&branchId=X`
- Endpoint placed BEFORE `:id` route to avoid Nest matching `:id = "daily-summary"`
- Branch scoping via `hasCrossBranchAccess` (OWNER/FINANCE_MANAGER override branchId; others limited to own)
- All Decimal arithmetic — no float drift

### Frontend
- New `/expenses/daily-summary` page with date + branch selector, table, totals grid, category breakdown, cash movement, signature footer
- Print CSS `@page A4 + 1cm margin` + `print-color-adjust: exact`
- Excel export via `(await import('exceljs')).default` (2 sheets: รายการเอกสาร + สรุปยอด)
- ExpensesPage `สรุปรายวัน` tab now navigates here

## Test plan
- [x] getDailySummary: 4 unit tests (branchId required / filters / byType aggregation / cashMovement same-day-only)
- [x] All previous PR tests still pass (21/21 in service spec, 235/235 across expense-documents+journal+accounting)
- [x] TypeScript: 0 errors (api + web)

## Out of scope
- PDF export (CSS print sufficient for A4)
- Cross-module daily summary (RT/OI income) — Phase A.7
- Multi-branch consolidated view

## Spec
docs/superpowers/specs/2026-05-10-expense-document-polymorphic-redesign.md §7.2

## Sequence — All 6 PRs complete
- PR-1 #795 EXPENSE foundation
- PR-2 #796 CREDIT_NOTE
- PR-3 #797 PAYROLL
- PR-4 #798 VENDOR_SETTLEMENT (4 doc types done)
- PR-5 #799 Favorites + recurring cron
- **PR-6 (this) Daily Summary (final)**