### PR TITLE
hotfix(expense-form-v4): ApproverSection paginated /users response

### DIFF
--- a/apps/web/src/components/expense-form-v4/ApproverSection.tsx
+++ b/apps/web/src/components/expense-form-v4/ApproverSection.tsx
@@ -13,11 +13,19 @@ interface UserRow {
   role: string;
 }
 
+const APPROVER_ROLES = ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'];
+
 export function ApproverSection({ approvedById, onChange }: Props) {
   const { user } = useAuth();
+  // /users returns paginated { data, total, page, limit } — not a bare array.
+  // Backend findAll doesn't filter by role, so we filter client-side.
   const { data: approvers } = useQuery<UserRow[]>({
     queryKey: ['users', 'approvers'],
-    queryFn: async () => (await api.get('/users?roles=OWNER,FINANCE_MANAGER,ACCOUNTANT')).data,
+    queryFn: async () => {
+      const res = await api.get('/users?limit=200');
+      const list: UserRow[] = res.data?.data ?? (Array.isArray(res.data) ? res.data : []);
+      return list.filter((u) => APPROVER_ROLES.includes(u.role));
+    },
     staleTime: 60_000,
   });
 


### PR DESCRIPTION
## P0 Production Bug Fix

After merging PR #802, opening the expense form modal throws:
\`r?.map is not a function\`

### Root cause
\`ApproverSection.tsx\` calls \`GET /users?roles=...\` expecting a plain array.
Backend \`/users\` returns paginated \`{ data, total, page, limit, totalPages }\` —
not an array. The \`approvers?.map(...)\` call hits the object → throws.

The \`?roles=\` query param is ignored by the backend (findAll only honors
page + limit) — filter must happen client-side.

### Fix
1. Read \`res.data.data\` (or fall back to \`res.data\` defensively)
2. Client-side filter by APPROVER_ROLES = OWNER / FINANCE_MANAGER / ACCOUNTANT
3. limit=200 to avoid pagination cutoff

Type check: Web OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)