### PR TITLE
feat(other-income): redesign list cards + entry form to prototype

### DIFF
--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -388,8 +388,9 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
 
         {/* Footer */}
         <div className="flex-none bg-background border-t px-6 py-3 flex items-center justify-between">
-          <Button variant="ghost" onClick={onClose}>
-            ← ยกเลิก
+          <Button variant="ghost" onClick={onClose} className="gap-1.5">
+            <ArrowLeft className="size-4" />
+            ยกเลิก
           </Button>
           <div className="flex items-center gap-3 text-xs">
             <span>Items: {itemCount}</span>

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -1,18 +1,32 @@
-import { useMemo, useEffect, useRef } from 'react';
+import { useMemo, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Save, Send, ArrowLeft, Receipt, FileText, Paperclip, AlertTriangle } from 'lucide-react';
-import PageHeader from '@/components/ui/PageHeader';
+import {
+  Save,
+  Send,
+  ArrowLeft,
+  FileText,
+  AlertTriangle,
+  CloudUpload,
+  CheckCircle2,
+  Upload,
+  Wallet,
+  Building2,
+  Zap,
+  Lightbulb,
+  XCircle,
+} from 'lucide-react';
 import QueryBoundary from '@/components/QueryBoundary';
+import { useAuth } from '@/contexts/AuthContext';
+import { formatNumber, formatNumberDecimal } from '@/utils/formatters';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import { otherIncomeFormSchema, type OtherIncomeFormValues } from '@/lib/otherIncome.schema';
 import { ItemsTable } from './components/ItemsTable';
 import { AdjustmentTable } from './components/AdjustmentTable';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
-import { PaymentCompareCard } from './components/PaymentCompareCard';
 import { CounterpartyPicker } from './components/CounterpartyPicker';
 
 // Fallback while config is loading; live value comes from /other-income/config/attachment-threshold
@@ -130,8 +144,14 @@ function computeJePreview(values: OtherIncomeFormValues): JeLine[] {
 
 // ------------------------------------------------------------------
 
+// "Today" in Asia/Bangkok — guards against UTC server returning yesterday
+// between 00:00–07:00 BKK time when an accounting doc is created.
+function todayBangkok(): string {
+  return new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Bangkok' });
+}
+
 const defaultValues: OtherIncomeFormValues = {
-  issueDate: new Date().toISOString().slice(0, 10),
+  issueDate: todayBangkok(),
   dueDate: '',
   paymentDate: '',
   priceType: 'EXCLUSIVE',
@@ -159,13 +179,48 @@ const defaultValues: OtherIncomeFormValues = {
 
 // Cash/bank account options
 const PAYMENT_ACCOUNTS = [
-  { code: '11-1101', label: '11-1101 เงินสด — สุทธินีย์' },
-  { code: '11-1102', label: '11-1102 เงินสด — เอกนรินทร์' },
-  { code: '11-1103', label: '11-1103 เงินสด — พนักงานบัญชี' },
-  { code: '11-1201', label: '11-1201 ธนาคาร KBank' },
-  { code: '11-1202', label: '11-1202 ธนาคาร SCB (ค่าใช้จ่าย)' },
-  { code: '11-1203', label: '11-1203 ธนาคาร SCB (ค่าเสื่อม)' },
+  { code: '11-1101', name: 'สุทธินีย์', kind: 'cash' as const },
+  { code: '11-1102', name: 'เอกนรินทร์', kind: 'cash' as const },
+  { code: '11-1103', name: 'พนักงานบัญชี', kind: 'cash' as const },
+  { code: '11-1201', name: 'กสิกรไทย', kind: 'bank' as const },
+  { code: '11-1202', name: 'SCB ค่าใช้จ่าย', kind: 'bank' as const },
+  { code: '11-1203', name: 'SCB ค่าเสื่อม', kind: 'bank' as const },
 ];
+
+const ALLOWED_MIME = ['application/pdf', 'image/jpeg', 'image/png', 'image/webp'];
+
+function fmt(n: number) {
+  return formatNumberDecimal(n, 2);
+}
+
+function SectionHeader({
+  num,
+  title,
+  hint,
+  action,
+}: {
+  num: number;
+  title: string;
+  hint?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="size-6 rounded bg-primary/15 text-primary text-xs font-bold flex items-center justify-center shrink-0">
+          {num}
+        </span>
+        <h2 className="text-sm font-bold text-foreground leading-snug">{title}</h2>
+        {hint && (
+          <span className="text-xs text-muted-foreground font-normal hidden md:inline">
+            {hint}
+          </span>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
 
 export default function OtherIncomeEntryPage() {
   const navigate = useNavigate();
@@ -183,8 +238,11 @@ export default function OtherIncomeEntryPage() {
   const form = useForm<OtherIncomeFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: standardSchemaResolver(otherIncomeFormSchema) as any,
-    defaultValues,
+    defaultValues: { ...defaultValues, issueDate: todayBangkok() },
+    mode: 'onChange',
   });
+
+  const { user } = useAuth();
 
   // Populate form when existing doc loads (edit mode)
   const { reset } = form;
@@ -258,7 +316,7 @@ export default function OtherIncomeEntryPage() {
   const jeLines = useMemo(() => computeJePreview(values), [values]);
 
   // Compute net expected vs received for AdjustmentTable
-  const { netExpected, totalDiff, diffSign } = useMemo(() => {
+  const { totalDiff, diffSign } = useMemo(() => {
     let totalAmountBeforeVat = 0;
     let totalVat = 0;
     let totalWht = 0;
@@ -295,15 +353,85 @@ export default function OtherIncomeEntryPage() {
     if (Math.abs(diff) < 0.01) sign = 'zero';
     else if (diff > 0) sign = 'over';
     else sign = 'under';
-    return { netExpected: net, totalDiff: +Math.abs(diff).toFixed(2), diffSign: sign };
+    return { totalDiff: +Math.abs(diff).toFixed(2), diffSign: sign };
   }, [values]);
 
   const watchedAdjustments = form.watch('adjustments') ?? [];
 
   const isSubmitting = saveDraftMutation.isPending || saveAndPostMutation.isPending;
 
+  // Income totals across all items (for footer/summary cards)
+  const incomeTotals = useMemo(() => {
+    let beforeVat = 0;
+    let vat = 0;
+    let wht = 0;
+    for (const item of values.items ?? []) {
+      const qty = Number(item.quantity) || 0;
+      const unit = Number(item.unitAmount) || 0;
+      const disc = Number(item.discountAmount) || 0;
+      const vatPct = Number(item.vatPct) || 0;
+      const whtPct = Number(item.whtPct) || 0;
+      const gross = qty * unit - disc;
+      let bv: number;
+      let v: number;
+      if (vatPct > 0) {
+        if (values.priceType === 'INCLUSIVE') {
+          bv = +(gross / (1 + vatPct / 100)).toFixed(2);
+          v = +(gross - bv).toFixed(2);
+        } else {
+          bv = gross;
+          v = +((gross * vatPct) / 100).toFixed(2);
+        }
+      } else {
+        bv = gross;
+        v = 0;
+      }
+      const w = +((bv * whtPct) / 100).toFixed(2);
+      beforeVat += bv;
+      vat += v;
+      wht += w;
+    }
+    return {
+      beforeVat: +beforeVat.toFixed(2),
+      vat: +vat.toFixed(2),
+      wht: +wht.toFixed(2),
+      total: +(beforeVat + vat).toFixed(2),
+      net: +(beforeVat + vat - wht).toFixed(2),
+    };
+  }, [values]);
+
+  // Live validation messages (Section 5 red box)
+  const validationMessages = useMemo(() => {
+    const msgs: string[] = [];
+    if (!values.customerId && !(values.counterpartyName ?? '').trim()) {
+      msgs.push('กรุณาเลือกลูกค้า');
+    }
+    if (!values.items || values.items.length === 0) {
+      msgs.push('รายการ #1: ใส่จำนวนเงิน');
+    } else {
+      values.items.forEach((item, idx) => {
+        const qty = Number(item.quantity) || 0;
+        const unit = Number(item.unitAmount) || 0;
+        if (qty <= 0 || unit <= 0) {
+          msgs.push(`รายการ #${idx + 1}: ใส่จำนวนเงิน`);
+        }
+        if (!item.accountCode) {
+          msgs.push(`รายการ #${idx + 1}: เลือกบัญชี`);
+        }
+      });
+    }
+    if (!values.paymentAccountCode) {
+      msgs.push('กรุณาเลือกช่องทางการชำระ');
+    }
+    if (!values.amountReceived || Number(values.amountReceived) <= 0) {
+      msgs.push('กรุณาระบุจำนวนเงินที่ได้รับจริง');
+    }
+    return msgs;
+  }, [values]);
+
   // B7: Attachment uploader (only available after doc is saved and has an id)
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
   const uploadAttachmentMutation = useMutation({
     mutationFn: (file: File) => otherIncomeApi.uploadAttachment(id!, file),
     onSuccess: () => {
@@ -312,6 +440,18 @@ export default function OtherIncomeEntryPage() {
     },
     onError: () => toast.error('ไม่สามารถแนบไฟล์ได้'),
   });
+
+  function handleFileSelect(file: File) {
+    if (!ALLOWED_MIME.includes(file.type)) {
+      toast.error('รองรับเฉพาะ PDF / JPG / PNG / WebP');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('ไฟล์มีขนาดเกิน 5 MB');
+      return;
+    }
+    uploadAttachmentMutation.mutate(file);
+  }
 
   const thresholdQuery = useQuery({
     queryKey: ['other-income-attachment-threshold'],
@@ -324,15 +464,50 @@ export default function OtherIncomeEntryPage() {
   const amountReceived = Number(values.amountReceived) || 0;
   const needsAttachment = amountReceived >= attachmentThreshold && currentAttachments.length === 0;
 
+  const docNumber = loadQuery.data?.docNumber;
+  const docStatus = loadQuery.data?.status ?? 'DRAFT';
+  const errorCount = validationMessages.length;
+  const canPost = errorCount === 0 && !needsAttachment;
+  const userDisplayName = user?.name || user?.email || 'ผู้ใช้ปัจจุบัน';
+
   return (
     <div className="pb-32">
-      <div className="p-6 max-w-7xl mx-auto">
-        <PageHeader
-          title={isEdit ? 'แก้ไขเอกสารรายได้อื่น' : 'สร้างเอกสารรายได้อื่น'}
-          subtitle="กรอกข้อมูลรายได้พร้อม JE Preview อัตโนมัติ"
-          icon={<Receipt size={20} />}
-          onBack={() => navigate('/other-income')}
-        />
+      <div className="p-4 md:p-6 max-w-5xl mx-auto">
+        {/* Custom header */}
+        <div className="flex items-start justify-between gap-4 mb-6">
+          <div className="min-w-0">
+            <button
+              type="button"
+              onClick={() => navigate('/other-income')}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mb-2"
+            >
+              <ArrowLeft size={14} /> กลับไปหน้ารายการ
+            </button>
+            <h1 className="text-xl md:text-2xl font-bold text-foreground leading-tight">
+              {isEdit ? 'แก้ไขเอกสารรายได้อื่น' : 'บันทึกรายได้อื่น'}
+            </h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              กลุ่มบัญชี 42-XXXX · Auto Journal · Validation V1-V10
+            </p>
+          </div>
+          <div className="text-right shrink-0">
+            <p className="text-xs text-muted-foreground">เลขที่เอกสาร</p>
+            <p className="font-mono text-sm font-semibold text-foreground">
+              {docNumber ?? '— จะออกหลังบันทึก —'}
+            </p>
+            <span
+              className={`mt-1 inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold tracking-wider ${
+                docStatus === 'POSTED'
+                  ? 'bg-success/10 text-success'
+                  : docStatus === 'REVERSED'
+                    ? 'bg-destructive/10 text-destructive'
+                    : 'bg-warning/15 text-warning'
+              }`}
+            >
+              {docStatus}
+            </span>
+          </div>
+        </div>
 
         {isEdit && (
           <QueryBoundary
@@ -345,20 +520,45 @@ export default function OtherIncomeEntryPage() {
           </QueryBoundary>
         )}
 
-        <form
-          onSubmit={(e) => e.preventDefault()}
-          className="grid grid-cols-1 xl:grid-cols-3 gap-6"
-        >
-          {/* Left / Main column */}
-          <div className="xl:col-span-2 space-y-6">
-            {/* --- Header section --- */}
-            <div className="rounded-xl border bg-card p-5 space-y-4">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                ข้อมูลเอกสาร
-              </h2>
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <form onSubmit={(e) => e.preventDefault()} className="space-y-6">
+          {/* Section 1 — Customer & document */}
+          <section className="rounded-xl border bg-card p-5">
+            <SectionHeader num={1} title="ข้อมูลลูกค้า & เอกสาร" />
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">
+                  ลูกค้า <span className="text-destructive">*</span>
+                </label>
+                <div className="mt-1">
+                  <CounterpartyPicker
+                    value={{
+                      customerId: values.customerId ?? null,
+                      name: values.counterpartyName ?? '',
+                      taxId: values.counterpartyTaxId,
+                      address: values.counterpartyAddress,
+                      phone: values.counterpartyPhone,
+                    }}
+                    onChange={(cp) => {
+                      form.setValue('customerId', cp.customerId ?? '', {
+                        shouldDirty: true,
+                        shouldValidate: true,
+                      });
+                      form.setValue('counterpartyName', cp.name, {
+                        shouldDirty: true,
+                        shouldValidate: true,
+                      });
+                      form.setValue('counterpartyTaxId', cp.taxId ?? '', { shouldDirty: true });
+                      form.setValue('counterpartyAddress', cp.address ?? '', { shouldDirty: true });
+                      form.setValue('counterpartyPhone', cp.phone ?? '', { shouldDirty: true });
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground">วันที่เอกสาร *</label>
+                  <label className="text-xs font-medium text-muted-foreground">
+                    วันที่ออกเอกสาร <span className="text-destructive">*</span>
+                  </label>
                   <input
                     type="date"
                     {...form.register('issueDate')}
@@ -371,7 +571,9 @@ export default function OtherIncomeEntryPage() {
                   )}
                 </div>
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground">วันครบกำหนด</label>
+                  <label className="text-xs font-medium text-muted-foreground">
+                    วันที่ครบกำหนด
+                  </label>
                   <input
                     type="date"
                     {...form.register('dueDate')}
@@ -379,140 +581,168 @@ export default function OtherIncomeEntryPage() {
                   />
                 </div>
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground">วันที่รับเงิน</label>
+                  <label className="text-xs font-medium text-muted-foreground">ประเภท VAT</label>
+                  <select
+                    {...form.register('priceType')}
+                    className="mt-1 w-full border rounded-md px-3 py-2 text-sm bg-background"
+                  >
+                    <option value="EXCLUSIVE">แยกภาษี</option>
+                    <option value="INCLUSIVE">รวมภาษี</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Section 2 — Accounting items */}
+          <section className="rounded-xl border bg-card p-5">
+            <SectionHeader num={2} title="รายการบันทึกทางบัญชี" />
+            {form.formState.errors.items && typeof form.formState.errors.items.message === 'string' && (
+              <p className="text-xs text-destructive mb-2">{form.formState.errors.items.message}</p>
+            )}
+            <ItemsTable
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              control={form.control as any}
+              register={form.register}
+              watch={form.watch}
+              setValue={form.setValue}
+            />
+            <div className="mt-4 flex items-center justify-between border-t pt-3 text-xs">
+              <div className="inline-flex items-center gap-2 text-muted-foreground">
+                <FileText size={14} />
+                <span>
+                  ก่อนภาษี:{' '}
+                  <span className="font-mono font-semibold text-foreground">
+                    {fmt(incomeTotals.beforeVat)}
+                  </span>
+                </span>
+              </div>
+              <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary/10 text-primary font-semibold">
+                <span>ยอดรวม:</span>
+                <span className="font-mono">{fmt(incomeTotals.total)} ฿</span>
+              </div>
+            </div>
+          </section>
+
+          {/* Section 3 — Payment channel */}
+          <section className="rounded-xl border bg-card p-5">
+            <SectionHeader num={3} title="ช่องทางการชำระเงิน" />
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs font-medium text-muted-foreground">
+                  เลือกบัญชีรับเงิน <span className="text-destructive">*</span>
+                </label>
+                <div
+                  className="mt-2 grid grid-cols-2 md:grid-cols-3 gap-2"
+                  role="radiogroup"
+                  aria-label="เลือกบัญชีรับเงิน"
+                >
+                  {PAYMENT_ACCOUNTS.map((a) => {
+                    const selected = values.paymentAccountCode === a.code;
+                    const Icon = a.kind === 'cash' ? Wallet : Building2;
+                    return (
+                      <button
+                        key={a.code}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        aria-label={`${a.name} (${a.code})`}
+                        onClick={() =>
+                          form.setValue('paymentAccountCode', a.code, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
+                        }
+                        className={`flex items-center gap-2 p-3 rounded-lg border-2 text-left transition-colors ${
+                          selected
+                            ? 'border-primary bg-primary/5'
+                            : 'border-border hover:border-primary/40 hover:bg-accent/40'
+                        }`}
+                      >
+                        <div
+                          className={`size-8 rounded-md flex items-center justify-center shrink-0 ${
+                            selected ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
+                          }`}
+                        >
+                          <Icon size={16} />
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold text-foreground leading-tight truncate">
+                            {a.name}
+                          </p>
+                          <p className="text-[10px] font-mono text-muted-foreground">{a.code}</p>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+                {form.formState.errors.paymentAccountCode && (
+                  <p className="text-xs text-destructive mt-1">
+                    {form.formState.errors.paymentAccountCode.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground">วันที่ชำระ</label>
                   <input
                     type="date"
                     {...form.register('paymentDate')}
                     className="mt-1 w-full border rounded-md px-3 py-2 text-sm bg-background"
                   />
                 </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground">ประเภทราคา</label>
-                  <select
-                    {...form.register('priceType')}
-                    className="mt-1 w-full border rounded-md px-3 py-2 text-sm bg-background"
-                  >
-                    <option value="EXCLUSIVE">ราคาไม่รวม VAT (EXCLUSIVE)</option>
-                    <option value="INCLUSIVE">ราคารวม VAT (INCLUSIVE)</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="text-xs font-medium text-muted-foreground">ช่องทางรับเงิน *</label>
-                  <select
-                    {...form.register('paymentAccountCode')}
-                    className="mt-1 w-full border rounded-md px-3 py-2 text-sm bg-background"
-                  >
-                    {PAYMENT_ACCOUNTS.map((a) => (
-                      <option key={a.code} value={a.code}>
-                        {a.label}
-                      </option>
-                    ))}
-                  </select>
-                  {form.formState.errors.paymentAccountCode && (
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs font-medium text-muted-foreground">
+                      จำนวนเงินที่ได้รับจริง <span className="text-destructive">*</span>
+                    </label>
+                    {incomeTotals.net > 0 && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          form.setValue('amountReceived', incomeTotals.net, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
+                        }
+                        className="inline-flex items-center gap-1 text-xs text-primary font-semibold hover:underline"
+                      >
+                        <Zap size={11} />
+                        ใช้ยอดสุทธิ ({fmt(incomeTotals.net)})
+                      </button>
+                    )}
+                  </div>
+                  <div className="mt-1 relative">
+                    <input
+                      type="number"
+                      step="0.01"
+                      {...form.register('amountReceived')}
+                      placeholder="0.00"
+                      className="w-full border rounded-md px-3 py-2 text-sm font-mono text-right bg-background pr-8"
+                    />
+                    <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
+                      ฿
+                    </span>
+                  </div>
+                  <p className="text-[10px] text-muted-foreground mt-1 text-right">
+                    ยอดที่ลูกค้าจ่ายมาจริง
+                  </p>
+                  {form.formState.errors.amountReceived && (
                     <p className="text-xs text-destructive mt-1">
-                      {form.formState.errors.paymentAccountCode.message}
+                      {form.formState.errors.amountReceived.message}
                     </p>
                   )}
                 </div>
               </div>
-            </div>
 
-            {/* --- Counterparty section --- */}
-            <div className="rounded-xl border bg-card p-5 space-y-4">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                คู่ค้า / ลูกค้า
-              </h2>
-              <CounterpartyPicker
-                value={{
-                  customerId: values.customerId ?? null,
-                  name: values.counterpartyName ?? '',
-                  taxId: values.counterpartyTaxId,
-                  address: values.counterpartyAddress,
-                  phone: values.counterpartyPhone,
-                }}
-                onChange={(cp) => {
-                  form.setValue('customerId', cp.customerId ?? '', { shouldDirty: true });
-                  form.setValue('counterpartyName', cp.name, { shouldDirty: true });
-                  form.setValue('counterpartyTaxId', cp.taxId ?? '', { shouldDirty: true });
-                  form.setValue('counterpartyAddress', cp.address ?? '', { shouldDirty: true });
-                  form.setValue('counterpartyPhone', cp.phone ?? '', { shouldDirty: true });
-                }}
-              />
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="text-xs font-medium text-muted-foreground">เลขที่ผู้เสียภาษี</label>
-                  <input
-                    type="text"
-                    {...form.register('counterpartyTaxId')}
-                    className="mt-1 w-full border rounded-md px-3 py-2 text-sm bg-background"
-                    placeholder="13 หลัก"
-                  />
+              {(Number(values.amountReceived) || 0) === 0 && (
+                <div className="flex items-start gap-2 p-3 rounded-md bg-muted/40 text-xs text-muted-foreground">
+                  <Lightbulb size={14} className="text-warning shrink-0 mt-0.5" />
+                  <span>กรอก "จำนวนเงินที่ได้รับจริง" เพื่อตรวจเปรียบเทียบกับยอดสุทธิ</span>
                 </div>
-                <div>
-                  <label className="text-xs font-medium text-muted-foreground">เบอร์โทร</label>
-                  <input
-                    type="text"
-                    {...form.register('counterpartyPhone')}
-                    className="mt-1 w-full border rounded-md px-3 py-2 text-sm bg-background"
-                  />
-                </div>
-              </div>
-              <div>
-                <label className="text-xs font-medium text-muted-foreground">ที่อยู่</label>
-                <textarea
-                  {...form.register('counterpartyAddress')}
-                  rows={2}
-                  className="mt-1 w-full border rounded-md px-3 py-2 text-sm bg-background"
-                />
-              </div>
-            </div>
-
-            {/* --- Items section --- */}
-            <div className="rounded-xl border bg-card p-5 space-y-4">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                รายการรายได้
-              </h2>
-              {form.formState.errors.items && (
-                <p className="text-xs text-destructive">
-                  {typeof form.formState.errors.items?.message === 'string'
-                    ? form.formState.errors.items.message
-                    : 'กรุณาเพิ่มอย่างน้อย 1 รายการ'}
-                </p>
               )}
-              <ItemsTable
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                control={form.control as any}
-                register={form.register}
-                watch={form.watch}
-                setValue={form.setValue}
-              />
-            </div>
 
-            {/* --- Amount received vs net --- */}
-            <div className="rounded-xl border bg-card p-5 space-y-4">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                ยอดเงินที่ได้รับจริง
-              </h2>
-              <div>
-                <label className="text-xs font-medium text-muted-foreground">จำนวนเงินที่ได้รับ (฿)</label>
-                <input
-                  type="number"
-                  step="0.01"
-                  {...form.register('amountReceived')}
-                  className="mt-1 w-full border rounded-md px-3 py-2 text-sm font-mono bg-background"
-                  placeholder="0.00"
-                />
-                {form.formState.errors.amountReceived && (
-                  <p className="text-xs text-destructive mt-1">
-                    {form.formState.errors.amountReceived.message}
-                  </p>
-                )}
-              </div>
-              <PaymentCompareCard expected={netExpected} received={Number(values.amountReceived) || null} />
-
-              {/* Adjustment table — only when there's a diff */}
               {diffSign !== 'zero' && (
                 <AdjustmentTable
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -525,161 +755,245 @@ export default function OtherIncomeEntryPage() {
                 />
               )}
             </div>
+          </section>
 
-            {/* --- Note --- */}
-            <div className="rounded-xl border bg-card p-5">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                หมายเหตุ
-              </h2>
-              <textarea
-                {...form.register('customerNote')}
-                rows={3}
-                placeholder="หมายเหตุสำหรับลูกค้า / ใบเสร็จ (optional)"
-                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-              />
-            </div>
+          {/* Section 4 — Note */}
+          <section className="rounded-xl border bg-card p-5">
+            <SectionHeader num={4} title="หมายเหตุสำหรับลูกค้า" />
+            <textarea
+              {...form.register('customerNote')}
+              rows={3}
+              placeholder="ข้อความที่จะแสดงในใบเสร็จ (ไม่บังคับ)"
+              className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+            />
+          </section>
 
-            {/* --- B7: Attachment section (visible in edit mode when doc exists) --- */}
-            {isEdit && (
-              <div className={`rounded-xl border p-5 space-y-3 ${needsAttachment ? 'border-warning bg-warning/5' : 'bg-card'}`}>
-                <div className="flex items-center gap-2">
-                  <Paperclip size={16} className={needsAttachment ? 'text-warning' : 'text-muted-foreground'} />
-                  <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-                    เอกสารแนบ
-                  </h2>
+          {/* Section 5 — Validation errors (POST-time only; draft can still save) */}
+          {validationMessages.length > 0 && (
+            <section className="rounded-xl border border-destructive/40 bg-destructive/5 p-4">
+              <div className="flex items-start gap-2">
+                <XCircle size={16} className="text-destructive shrink-0 mt-0.5" />
+                <div className="min-w-0">
+                  <p className="text-sm font-bold text-destructive">
+                    ต้องแก้ไข {validationMessages.length} ข้อก่อน POST:
+                  </p>
+                  <ul className="mt-1 space-y-0.5 text-xs text-destructive/90">
+                    {validationMessages.map((m, i) => (
+                      <li key={i}>• {m}</li>
+                    ))}
+                  </ul>
+                  <p className="mt-2 text-[11px] text-muted-foreground">
+                    (สามารถบันทึกร่างไว้ก่อนได้)
+                  </p>
                 </div>
+              </div>
+            </section>
+          )}
+
+          {/* Section 6 — Auto Journal Preview */}
+          <section className="rounded-xl border bg-card p-5">
+            <SectionHeader
+              num={6}
+              title="AUTO JOURNAL PREVIEW"
+              action={
+                <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground cursor-not-allowed opacity-60">
+                  <input type="checkbox" disabled className="size-3.5" />
+                  แก้ไขเอง (Override)
+                </label>
+              }
+            />
+            <AutoJournalPreview lines={jeLines} />
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
+              <SummaryTile label="รายได้" value={incomeTotals.beforeVat} tone="primary" />
+              <SummaryTile label="VAT" value={incomeTotals.vat} tone="info" />
+              <SummaryTile label="WHT" value={incomeTotals.wht} tone="warning" />
+              <SummaryTile label="สุทธิรับ" value={incomeTotals.net} tone="success" />
+            </div>
+          </section>
+
+          {/* Section 7 — Recorder & Approver */}
+          <section className="rounded-xl border bg-card p-5">
+            <SectionHeader num={7} title="ผู้บันทึก & ผู้อนุมัติ" />
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-xs italic text-muted-foreground">
+                ระบบกำหนดอัตโนมัติตาม user ที่เข้าใช้งานในขณะนี้
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-info/10 text-info text-xs">
+                  <CloudUpload size={13} />
+                  <span className="text-muted-foreground">ผู้บันทึก:</span>
+                  <span className="font-semibold text-foreground">{userDisplayName}</span>
+                </span>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-success/10 text-success text-xs">
+                  <CheckCircle2 size={13} />
+                  <span className="text-muted-foreground">ผู้อนุมัติ:</span>
+                  <span className="font-semibold text-foreground">{userDisplayName}</span>
+                </span>
+              </div>
+            </div>
+          </section>
+
+          {/* Section 8 — Attachments */}
+          <section className={`rounded-xl border p-5 ${needsAttachment ? 'border-warning bg-warning/5' : 'bg-card'}`}>
+            <SectionHeader
+              num={8}
+              title="แนบไฟล์เอกสาร (ไม่บังคับ)"
+              hint="PDF/JPG/PNG ≤ 5MB"
+            />
+            {!isEdit && (
+              <p className="text-xs text-muted-foreground italic">
+                บันทึกร่างก่อนเพื่อเปิดใช้งานการแนบไฟล์
+              </p>
+            )}
+            {isEdit && (
+              <>
                 {needsAttachment && (
-                  <div className="flex items-start gap-2 text-xs text-warning">
+                  <div className="flex items-start gap-2 mb-3 text-xs text-warning">
                     <AlertTriangle size={14} className="shrink-0 mt-0.5" />
-                    <span>ยอดรับ ≥ {attachmentThreshold.toLocaleString()} ฿ — ต้องแนบไฟล์ประกอบเพื่อ POST</span>
+                    <span>
+                      ยอดรับ ≥ {formatNumber(attachmentThreshold)} ฿ — ต้องแนบไฟล์ประกอบเพื่อ POST
+                    </span>
                   </div>
                 )}
-                {/* Existing attachments */}
                 {currentAttachments.length > 0 && (
-                  <ul className="space-y-1">
+                  <ul className="mb-3 space-y-1">
                     {currentAttachments.map((att) => (
-                      <li key={att.id} className="flex items-center gap-2 text-xs">
-                        <FileText size={12} className="text-muted-foreground shrink-0" />
-                        <span className="flex-1 truncate">{att.filename}</span>
-                        <span className="text-muted-foreground">
-                          {(att.size / 1024).toFixed(1)} KB
-                        </span>
+                      <li
+                        key={att.id}
+                        className="flex items-center gap-2 px-3 py-2 rounded-md border bg-background text-xs"
+                      >
+                        <FileText size={14} className="text-muted-foreground shrink-0" />
+                        <span className="flex-1 truncate font-medium">{att.filename}</span>
+                        <span className="text-muted-foreground">{(att.size / 1024).toFixed(1)} KB</span>
                       </li>
                     ))}
                   </ul>
                 )}
-                {/* Upload button */}
-                <div>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    aria-hidden="true"
-                    tabIndex={-1}
-                    className="hidden"
-                    accept="application/pdf,image/jpeg,image/png,image/webp"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0];
-                      if (file) {
-                        if (file.size > 5 * 1024 * 1024) {
-                          toast.error('ไฟล์มีขนาดเกิน 5 MB');
-                        } else {
-                          uploadAttachmentMutation.mutate(file);
-                        }
-                      }
-                      if (fileInputRef.current) fileInputRef.current.value = '';
-                    }}
-                  />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  aria-hidden="true"
+                  tabIndex={-1}
+                  className="hidden"
+                  accept="application/pdf,image/jpeg,image/png,image/webp"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) handleFileSelect(file);
+                    if (fileInputRef.current) fileInputRef.current.value = '';
+                  }}
+                />
+                <div
+                  onDragEnter={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (uploadAttachmentMutation.isPending) return;
+                    setIsDraggingFile(true);
+                  }}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onDragLeave={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    // Ignore leave events from child elements (icon, text)
+                    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+                    setIsDraggingFile(false);
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setIsDraggingFile(false);
+                    if (uploadAttachmentMutation.isPending) return;
+                    const file = e.dataTransfer.files?.[0];
+                    if (file) handleFileSelect(file);
+                  }}
+                  className={`rounded-lg border-2 border-dashed transition-colors ${
+                    isDraggingFile
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:bg-accent/40'
+                  } ${uploadAttachmentMutation.isPending ? 'opacity-50 pointer-events-none' : ''}`}
+                >
                   <button
                     type="button"
                     disabled={uploadAttachmentMutation.isPending}
                     onClick={() => fileInputRef.current?.click()}
-                    className="inline-flex items-center gap-2 px-3 py-2 text-xs font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
+                    className="w-full flex flex-col items-center justify-center gap-2 py-8 px-4 disabled:cursor-not-allowed"
                   >
-                    <Paperclip size={12} />
-                    {uploadAttachmentMutation.isPending ? 'กำลังอัปโหลด...' : 'แนบไฟล์'}
+                    <Upload
+                      size={24}
+                      className={isDraggingFile ? 'text-primary' : 'text-muted-foreground'}
+                    />
+                    <p className="text-sm text-muted-foreground">
+                      ลากไฟล์มาวางที่นี่ หรือ{' '}
+                      <span className="text-primary font-semibold">คลิกเพื่อเลือกไฟล์</span>
+                    </p>
                   </button>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    รองรับ PDF, JPG, PNG, WebP — ขนาดสูงสุด 5 MB
-                  </p>
+                </div>
+              </>
+            )}
+          </section>
+
+          {/* Section 9 — Confirmation summary */}
+          <section className="rounded-xl border bg-card p-5">
+            <SectionHeader num={9} title="สรุปก่อนยืนยัน" />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2 text-sm font-mono">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">ยอดรวมก่อนหักส่วนลด</span>
+                  <span className="font-semibold">{fmt(incomeTotals.beforeVat + incomeTotals.vat)} ฿</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">ยอดสุทธิที่ควรได้รับ</span>
+                  <span className="font-semibold">{fmt(incomeTotals.net)} ฿</span>
                 </div>
               </div>
-            )}
-          </div>
-
-          {/* Right column — JE Preview */}
-          <div className="space-y-4 xl:sticky xl:top-6 xl:self-start">
-            <div className="rounded-xl border bg-card p-5">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                สรุปยอด
-              </h2>
-              <div className="space-y-2 font-mono text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">รายได้ก่อนภาษี</span>
-                  <span className="font-semibold">
-                    {(values.items ?? [])
-                      .reduce((s, item) => {
-                        const qty = Number(item.quantity) || 0;
-                        const unit = Number(item.unitAmount) || 0;
-                        const disc = Number(item.discountAmount) || 0;
-                        const vatPct = Number(item.vatPct) || 0;
-                        const gross = qty * unit - disc;
-                        if (vatPct > 0 && values.priceType === 'INCLUSIVE') {
-                          return s + +(gross / (1 + vatPct / 100)).toFixed(2);
-                        }
-                        return s + gross;
-                      }, 0)
-                      .toFixed(2)}{' '}
-                    ฿
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">VAT</span>
-                  <span>
-                    {jeLines
-                      .filter((l) => l.accountCode === '21-2101')
-                      .reduce((s, l) => s + l.credit, 0)
-                      .toFixed(2)}{' '}
-                    ฿
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">WHT</span>
-                  <span>
-                    -{jeLines
-                      .filter((l) => l.accountCode === '11-4103')
-                      .reduce((s, l) => s + l.debit, 0)
-                      .toFixed(2)}{' '}
-                    ฿
-                  </span>
-                </div>
-                <div className="flex justify-between border-t pt-2 font-bold">
-                  <span>สุทธิที่คาดรับ</span>
-                  <span>{netExpected.toFixed(2)} ฿</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">ได้รับจริง</span>
-                  <span>{(Number(values.amountReceived) || 0).toFixed(2)} ฿</span>
-                </div>
+              <div className="rounded-xl bg-primary/10 p-4 text-primary">
+                <p className="text-xs font-semibold opacity-80">จำนวนเงินทั้งสิ้น</p>
+                <p className="text-3xl font-bold font-mono mt-1">{fmt(incomeTotals.total)} ฿</p>
+                <p className="text-xs mt-2 opacity-80">
+                  บัญชีรายได้: {values.items?.[0]?.accountCode || '—'}
+                </p>
+                <p className="text-xs opacity-80">
+                  ลูกค้า: {values.counterpartyName?.trim() || '—'}
+                </p>
               </div>
             </div>
-
-            <AutoJournalPreview lines={jeLines} />
-          </div>
+            {(Number(values.amountReceived) || 0) === 0 && (
+              <div className="mt-4 flex items-start gap-2 p-3 rounded-md bg-muted/40 text-xs text-muted-foreground">
+                <Lightbulb size={14} className="text-warning shrink-0 mt-0.5" />
+                <span>กรอก "จำนวนเงินที่ได้รับจริง" เพื่อตรวจเปรียบเทียบกับยอดสุทธิ</span>
+              </div>
+            )}
+          </section>
         </form>
       </div>
 
       {/* Sticky bottom action bar */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 bg-background border-t shadow-lg px-6 py-4">
-        <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
-          <button
-            type="button"
-            onClick={() => navigate('/other-income')}
-            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
-          >
-            <ArrowLeft size={16} />
-            ยกเลิก
-          </button>
-          <div className="flex items-center gap-3">
+      <div className="fixed bottom-0 left-0 right-0 z-40 bg-background border-t shadow-lg px-4 md:px-6 py-3">
+        <div className="max-w-5xl mx-auto flex items-center justify-between gap-3 flex-wrap">
+          <div className="text-xs flex items-center gap-1.5">
+            {errorCount > 0 ? (
+              <span className="inline-flex items-center gap-1 text-destructive font-semibold">
+                <AlertTriangle size={14} />
+                มี {errorCount} ข้อต้องแก้ไข
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1 text-success font-semibold">
+                <CheckCircle2 size={14} />
+                ข้อมูลพร้อม POST
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => navigate('/other-income')}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border rounded-md hover:bg-accent"
+            >
+              <ArrowLeft size={14} />
+              ยกเลิก
+            </button>
             <button
               type="button"
               disabled={isSubmitting}
@@ -692,44 +1006,61 @@ export default function OtherIncomeEntryPage() {
                 }
                 saveDraftMutation.mutate(result.data);
               }}
-              className="inline-flex items-center gap-2 px-5 py-2 text-sm font-semibold border rounded-lg hover:bg-accent disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
             >
-              <Save size={16} />
+              <Save size={14} />
               {saveDraftMutation.isPending ? 'กำลังบันทึก...' : 'บันทึกร่าง'}
             </button>
-            {(() => {
-              const errors = form.formState.errors;
-              const errorKeys = Object.keys(errors);
-              const hasErrors = errorKeys.length > 0;
-              const tooltipMsg = needsAttachment
-                ? `ต้องแนบเอกสารเมื่อยอดรับ ≥ ${attachmentThreshold.toLocaleString()} ฿`
-                : hasErrors
-                  ? `ฟิลด์ที่ยังไม่ผ่าน: ${errorKeys.join(', ')}`
-                  : undefined;
-              return (
-                <button
-                  type="button"
-                  disabled={isSubmitting || hasErrors || needsAttachment}
-                  title={tooltipMsg}
-                  onClick={() => {
-                    const raw = form.getValues();
-                    const result = otherIncomeFormSchema.safeParse(raw);
-                    if (!result.success) {
-                      toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
-                      return;
-                    }
-                    saveAndPostMutation.mutate(result.data);
-                  }}
-                  className="inline-flex items-center gap-2 px-5 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
-                >
-                  <Send size={16} />
-                  {saveAndPostMutation.isPending ? 'กำลัง POST...' : 'บันทึก & POST'}
-                </button>
-              );
-            })()}
+            <button
+              type="button"
+              disabled={isSubmitting || !canPost}
+              title={
+                needsAttachment
+                  ? `ต้องแนบเอกสารเมื่อยอดรับ ≥ ${formatNumber(attachmentThreshold)} ฿`
+                  : errorCount > 0
+                    ? `ยังมี ${errorCount} ข้อต้องแก้ไข`
+                    : undefined
+              }
+              onClick={() => {
+                const raw = form.getValues();
+                const result = otherIncomeFormSchema.safeParse(raw);
+                if (!result.success) {
+                  toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+                  return;
+                }
+                saveAndPostMutation.mutate(result.data);
+              }}
+              className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Send size={14} />
+              {saveAndPostMutation.isPending ? 'กำลัง POST...' : 'บันทึก & POST'}
+            </button>
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function SummaryTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: 'primary' | 'info' | 'warning' | 'success';
+}) {
+  const toneCls = {
+    primary: 'bg-primary/5 text-primary',
+    info: 'bg-info/5 text-info',
+    warning: 'bg-warning/5 text-warning',
+    success: 'bg-success/5 text-success',
+  }[tone];
+  return (
+    <div className={`rounded-lg p-3 ${toneCls}`}>
+      <p className="text-[10px] font-semibold tracking-wider uppercase">{label}</p>
+      <p className="font-mono font-bold text-lg mt-1 text-foreground">{formatNumberDecimal(value, 2)}</p>
     </div>
   );
 }

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Plus, Search, FileText, TrendingUp, Receipt, RotateCcw } from 'lucide-react';
+import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, ArrowRight } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -10,6 +10,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus } from '@/lib/otherIncome.types';
 import { formatThaiDateShort } from '@/lib/date';
+import { formatNumberDecimal } from '@/utils/formatters';
 
 const STATUS_LABELS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'ร่าง',
@@ -35,12 +36,58 @@ function fmt(v: string | number | undefined | null) {
   if (v === undefined || v === null) return '—';
   const n = typeof v === 'string' ? parseFloat(v) : v;
   if (isNaN(n)) return '—';
-  return n.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return formatNumberDecimal(n, 2);
 }
 
 function fmtDate(d: string | null | undefined) {
   if (!d) return '—';
   return formatThaiDateShort(d);
+}
+
+type StatusAccent = 'warning' | 'success' | 'muted';
+
+const ACCENT_BAR: Record<StatusAccent, string> = {
+  warning: 'bg-warning',
+  success: 'bg-success',
+  muted: 'bg-muted-foreground/50',
+};
+
+const ACCENT_ICON: Record<StatusAccent, string> = {
+  warning: 'bg-warning/10 text-warning',
+  success: 'bg-success/10 text-success',
+  muted: 'bg-muted text-muted-foreground',
+};
+
+function StatusCard({
+  label,
+  sub,
+  icon,
+  accent,
+  value,
+}: {
+  label: string;
+  sub: string;
+  icon: React.ReactNode;
+  accent: StatusAccent;
+  value: number;
+}) {
+  return (
+    <div className="rounded-xl border bg-card p-4 relative overflow-hidden">
+      <span className={`absolute inset-x-0 top-0 h-1 ${ACCENT_BAR[accent]}`} />
+      <div className="flex items-start justify-between mb-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-foreground leading-snug">{label}</p>
+          <p className="text-[10px] font-medium text-muted-foreground tracking-wider mt-0.5">
+            {sub}
+          </p>
+        </div>
+        <div className={`size-9 rounded-full flex items-center justify-center shrink-0 ${ACCENT_ICON[accent]}`}>
+          {icon}
+        </div>
+      </div>
+      <p className="text-3xl font-bold font-mono text-foreground tabular-nums">{value}</p>
+    </div>
+  );
 }
 
 export default function OtherIncomeListPage() {
@@ -70,6 +117,26 @@ export default function OtherIncomeListPage() {
       }),
   });
 
+  const COUNT_STALE_TIME = 60_000;
+  const draftCountQuery = useQuery({
+    queryKey: ['other-income', 'count', 'DRAFT'],
+    queryFn: () => otherIncomeApi.list({ status: 'DRAFT', page: 1, limit: 1 }),
+    select: (d) => d.total,
+    staleTime: COUNT_STALE_TIME,
+  });
+  const postedCountQuery = useQuery({
+    queryKey: ['other-income', 'count', 'POSTED'],
+    queryFn: () => otherIncomeApi.list({ status: 'POSTED', page: 1, limit: 1 }),
+    select: (d) => d.total,
+    staleTime: COUNT_STALE_TIME,
+  });
+  const reversedCountQuery = useQuery({
+    queryKey: ['other-income', 'count', 'REVERSED'],
+    queryFn: () => otherIncomeApi.list({ status: 'REVERSED', page: 1, limit: 1 }),
+    select: (d) => d.total,
+    staleTime: COUNT_STALE_TIME,
+  });
+
   const deleteMutation = useMutation({
     mutationFn: (id: string) => otherIncomeApi.softDelete(id),
     onSuccess: () => {
@@ -84,17 +151,15 @@ export default function OtherIncomeListPage() {
   const total = data?.total ?? 0;
   const totalPages = Math.ceil(total / 50) || 1;
 
-  // Summary cards from current page data
-  const postedDocs = docs.filter((d) => d.status === 'POSTED');
-  const draftDocs = docs.filter((d) => d.status === 'DRAFT');
-  const totalPostedGross = postedDocs.reduce((s, d) => s + parseFloat(d.incomeGross || '0'), 0);
-  const totalPostedNet = postedDocs.reduce((s, d) => s + parseFloat(d.netReceived || '0'), 0);
+  const draftCount = draftCountQuery.data ?? 0;
+  const postedCount = postedCountQuery.data ?? 0;
+  const reversedCount = reversedCountQuery.data ?? 0;
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
       <PageHeader
         title="รายได้อื่น"
-        subtitle="จัดการเอกสารรายได้นอกเหนือจากสัญญาผ่อนชำระ"
+        subtitle="จัดการเอกสารรับรู้รายได้อื่น (กลุ่ม 42-XXXX) — ดอกเบี้ยเงินฝาก, ค่าปรับ, รายได้หักค่าจ้าง ฯลฯ"
         icon={<Receipt size={20} />}
         action={
           <button
@@ -107,36 +172,50 @@ export default function OtherIncomeListPage() {
         }
       />
 
-      {/* Summary cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <div className="rounded-xl border bg-card p-4">
-          <div className="flex items-center gap-2 mb-1">
-            <FileText size={16} className="text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">เอกสารทั้งหมด</span>
+      {/* Status cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+        <StatusCard
+          label="ฉบับร่าง"
+          sub="DRAFT"
+          icon={<FileText size={16} />}
+          accent="warning"
+          value={draftCount}
+        />
+        <StatusCard
+          label="บันทึกแล้ว"
+          sub="POSTED"
+          icon={<CheckCircle2 size={16} />}
+          accent="success"
+          value={postedCount}
+        />
+        <StatusCard
+          label="กลับรายการ"
+          sub="REVERSED"
+          icon={<RotateCcw size={16} />}
+          accent="muted"
+          value={reversedCount}
+        />
+        <Link
+          to="/other-income/daily-sheet"
+          className="rounded-xl border bg-card p-4 relative overflow-hidden hover:bg-accent/40 transition-colors group"
+        >
+          <span className="absolute inset-x-0 top-0 h-1 bg-primary" />
+          <div className="flex items-start justify-between mb-3">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-foreground leading-snug">สรุปรายวัน</p>
+              <p className="text-[10px] font-medium text-muted-foreground tracking-wider mt-0.5">
+                DAILY SHEET
+              </p>
+            </div>
+            <div className="size-9 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0">
+              <ChartBar size={16} />
+            </div>
           </div>
-          <p className="text-2xl font-bold font-mono">{total}</p>
-        </div>
-        <div className="rounded-xl border bg-card p-4">
-          <div className="flex items-center gap-2 mb-1">
-            <TrendingUp size={16} className="text-success" />
-            <span className="text-xs text-muted-foreground">บันทึกแล้ว</span>
-          </div>
-          <p className="text-2xl font-bold font-mono text-success">{postedDocs.length}</p>
-        </div>
-        <div className="rounded-xl border bg-card p-4">
-          <div className="flex items-center gap-2 mb-1">
-            <Receipt size={16} className="text-primary" />
-            <span className="text-xs text-muted-foreground">รวมรายได้ก่อนภาษี</span>
-          </div>
-          <p className="text-xl font-bold font-mono">{fmt(totalPostedGross)} ฿</p>
-        </div>
-        <div className="rounded-xl border bg-card p-4">
-          <div className="flex items-center gap-2 mb-1">
-            <RotateCcw size={16} className="text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">สุทธิที่รับ</span>
-          </div>
-          <p className="text-xl font-bold font-mono">{fmt(totalPostedNet)} ฿</p>
-        </div>
+          <p className="inline-flex items-center gap-1 text-sm font-semibold text-primary group-hover:translate-x-0.5 transition-transform">
+            เปิดดู
+            <ArrowRight size={14} />
+          </p>
+        </Link>
       </div>
 
       {/* Filters */}

--- a/apps/web/src/pages/other-income/components/AutoJournalPreview.tsx
+++ b/apps/web/src/pages/other-income/components/AutoJournalPreview.tsx
@@ -1,3 +1,5 @@
+import { CheckCircle2, XCircle } from 'lucide-react';
+
 interface JeLine {
   accountCode: string;
   debit: number;
@@ -52,12 +54,14 @@ export function AutoJournalPreview({ lines }: Props) {
       <div className="mt-2 pt-2 border-t flex items-center justify-between text-sm">
         <span className="text-muted-foreground text-xs">Dr รวม = Cr รวม</span>
         {balanced ? (
-          <span className="text-success font-bold font-mono">
-            ✓ {totalDr.toFixed(2)} = {totalCr.toFixed(2)} BALANCED
+          <span className="inline-flex items-center gap-1.5 text-success font-bold font-mono">
+            <CheckCircle2 size={14} />
+            {totalDr.toFixed(2)} = {totalCr.toFixed(2)} BALANCED
           </span>
         ) : (
-          <span className="text-destructive font-bold font-mono">
-            ✗ Dr {totalDr.toFixed(2)} ≠ Cr {totalCr.toFixed(2)}
+          <span className="inline-flex items-center gap-1.5 text-destructive font-bold font-mono">
+            <XCircle size={14} />
+            Dr {totalDr.toFixed(2)} ≠ Cr {totalCr.toFixed(2)}
           </span>
         )}
       </div>

--- a/apps/web/src/pages/other-income/components/ItemsTable.tsx
+++ b/apps/web/src/pages/other-income/components/ItemsTable.tsx
@@ -5,8 +5,9 @@ import {
   type UseFormWatch,
   type UseFormSetValue,
 } from 'react-hook-form';
-import { Plus, Trash2 } from 'lucide-react';
+import { Plus, Trash2, Lightbulb } from 'lucide-react';
 import { AccountSearchDropdown } from './AccountSearchDropdown';
+import { formatNumberDecimal } from '@/utils/formatters';
 import type { OtherIncomeFormValues } from '@/lib/otherIncome.schema';
 
 interface Props {
@@ -14,6 +15,10 @@ interface Props {
   register: UseFormRegister<OtherIncomeFormValues>;
   watch: UseFormWatch<OtherIncomeFormValues>;
   setValue: UseFormSetValue<OtherIncomeFormValues>;
+}
+
+function fmt(n: number) {
+  return formatNumberDecimal(n, 2);
 }
 
 export function ItemsTable({ control, register, watch, setValue }: Props) {
@@ -48,103 +53,137 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
 
   return (
     <div className="space-y-3">
-      {fields.map((f, idx) => (
-        <div key={f.id} className="rounded-lg border p-3 bg-card">
-          <div className="flex items-center justify-between mb-2">
-            <span className="font-bold text-sm">รายการ #{idx + 1}</span>
-            {fields.length > 1 && (
-              <button
-                type="button"
-                onClick={() => remove(idx)}
-                className="text-destructive hover:opacity-80"
-              >
-                <Trash2 size={14} />
-              </button>
-            )}
+      {fields.map((f, idx) => {
+        const row = computed[idx];
+        const code = items[idx]?.accountCode || '42-XXXX';
+        const whtPct = Number(items[idx]?.whtPct) || 0;
+        return (
+          <div key={f.id} className="rounded-lg border bg-card overflow-hidden">
+            <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-bold text-foreground">#{idx + 1}</span>
+                <span className="font-mono text-xs px-2 py-0.5 rounded bg-primary/10 text-primary font-semibold">
+                  {code}
+                </span>
+              </div>
+              {fields.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => remove(idx)}
+                  className="text-muted-foreground hover:text-destructive transition-colors"
+                  aria-label="ลบรายการ"
+                >
+                  <Trash2 size={14} />
+                </button>
+              )}
+            </div>
+            <div className="p-3 space-y-3">
+              <div>
+                <label className="text-xs text-muted-foreground font-medium">บัญชีรายได้</label>
+                <div className="mt-1">
+                  <AccountSearchDropdown
+                    value={items[idx]?.accountCode ?? ''}
+                    onChange={(c) => {
+                      setValue(`items.${idx}.accountCode`, c, { shouldValidate: true });
+                    }}
+                    filter={(a) => a.code.startsWith('42-') && a.code !== '42-1103'}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 md:grid-cols-6 gap-2 text-xs">
+                <div>
+                  <label className="text-muted-foreground font-medium">จำนวน</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...register(`items.${idx}.quantity`)}
+                    className="mt-1 w-full border rounded px-2 py-1.5 text-right font-mono bg-background"
+                  />
+                </div>
+                <div>
+                  <label className="text-muted-foreground font-medium">ราคา/หน่วย</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...register(`items.${idx}.unitAmount`)}
+                    className="mt-1 w-full border rounded px-2 py-1.5 text-right font-mono bg-background"
+                  />
+                </div>
+                <div>
+                  <label className="text-muted-foreground font-medium">ส่วนลด</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...register(`items.${idx}.discountAmount`)}
+                    className="mt-1 w-full border rounded px-2 py-1.5 text-right font-mono bg-background"
+                  />
+                </div>
+                <div>
+                  <label className="text-muted-foreground font-medium">VAT%</label>
+                  <select
+                    {...register(`items.${idx}.vatPct`)}
+                    className="mt-1 w-full border rounded px-2 py-1.5 text-xs font-mono bg-background"
+                  >
+                    <option value={0}>0%</option>
+                    <option value={7}>7%</option>
+                  </select>
+                </div>
+                <div>
+                  <label
+                    className="text-muted-foreground font-medium inline-flex items-center gap-1"
+                    title="แนะนำ: ดอกเบี้ย 15% / ค่าบริการ 3% / ค่าเช่า 5% / นิติบุคคล 1%"
+                  >
+                    WHT%
+                    {whtPct > 0 && (
+                      <span className="inline-flex items-center gap-0.5 text-warning">
+                        <Lightbulb size={10} />
+                        {whtPct}%
+                      </span>
+                    )}
+                  </label>
+                  <select
+                    {...register(`items.${idx}.whtPct`)}
+                    title="แนะนำ: ดอกเบี้ย 15% / ค่าบริการ 3% / ค่าเช่า 5% / นิติบุคคล 1%"
+                    className="mt-1 w-full border rounded px-2 py-1.5 text-xs font-mono bg-background"
+                  >
+                    {[0, 1, 2, 3, 5, 7, 10, 15].map((p) => (
+                      <option key={p} value={p}>
+                        {p}%
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-muted-foreground font-medium">ก่อนภาษี</label>
+                  <div className="mt-1 w-full border rounded px-2 py-1.5 text-right font-mono bg-muted/40 text-foreground font-semibold">
+                    {fmt(row?.amountBeforeVat ?? 0)}
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground font-medium">คำอธิบาย</label>
+                <input
+                  type="text"
+                  {...register(`items.${idx}.description`)}
+                  className="mt-1 w-full border rounded px-2 py-1.5 text-xs bg-background"
+                  placeholder="เช่น ดอกเบี้ยเดือน พ.ค. 2569"
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-end gap-4 px-3 py-2 border-t bg-muted/20 text-xs font-mono text-muted-foreground">
+              <span>
+                VAT: <span className="text-foreground font-semibold">{fmt(row?.vatAmount ?? 0)}</span>
+              </span>
+              <span>
+                WHT: <span className="text-foreground font-semibold">{fmt(row?.whtAmount ?? 0)}</span>
+              </span>
+              <span className="text-foreground font-semibold">
+                รวม: {fmt((row?.amountBeforeVat ?? 0) + (row?.vatAmount ?? 0))}
+              </span>
+            </div>
           </div>
-          <div className="grid grid-cols-12 gap-2 text-xs">
-            <div className="col-span-4">
-              <label className="text-muted-foreground">บัญชี (42-XXXX)</label>
-              <AccountSearchDropdown
-                value={items[idx]?.accountCode ?? ''}
-                onChange={(code) => {
-                  setValue(`items.${idx}.accountCode`, code, { shouldValidate: true });
-                }}
-                filter={(a) => a.code.startsWith('42-') && a.code !== '42-1103'}
-              />
-            </div>
-            <div className="col-span-1">
-              <label className="text-muted-foreground">จำนวน</label>
-              <input
-                type="number"
-                step="0.01"
-                {...register(`items.${idx}.quantity`)}
-                className="w-full border rounded px-2 py-1 text-right font-mono"
-              />
-            </div>
-            <div className="col-span-2">
-              <label className="text-muted-foreground">ราคา</label>
-              <input
-                type="number"
-                step="0.01"
-                {...register(`items.${idx}.unitAmount`)}
-                className="w-full border rounded px-2 py-1 text-right font-mono"
-              />
-            </div>
-            <div className="col-span-1">
-              <label className="text-muted-foreground">ส่วนลด</label>
-              <input
-                type="number"
-                step="0.01"
-                {...register(`items.${idx}.discountAmount`)}
-                className="w-full border rounded px-2 py-1 text-right font-mono"
-              />
-            </div>
-            <div className="col-span-1">
-              <label className="text-muted-foreground">VAT%</label>
-              <select
-                {...register(`items.${idx}.vatPct`)}
-                className="w-full border rounded px-1 py-1 text-xs font-mono"
-              >
-                <option value={0}>0</option>
-                <option value={7}>7</option>
-              </select>
-            </div>
-            <div className="col-span-1">
-              <label
-                className="text-muted-foreground"
-                title="แนะนำ: ดอกเบี้ย 15% / ค่าบริการ 3% / ค่าเช่า 5% / นิติบุคคล 1%"
-              >
-                WHT%
-              </label>
-              <select
-                {...register(`items.${idx}.whtPct`)}
-                title="แนะนำ: ดอกเบี้ย 15% / ค่าบริการ 3% / ค่าเช่า 5% / นิติบุคคล 1%"
-                className="w-full border rounded px-1 py-1 text-xs font-mono"
-              >
-                {[0, 1, 2, 3, 5, 7, 10, 15].map((p) => (
-                  <option key={p} value={p}>
-                    {p}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="col-span-2 text-right">
-              <label className="text-muted-foreground">ก่อนภาษี</label>
-              <p className="font-mono font-bold">{computed[idx]?.amountBeforeVat.toFixed(2)}</p>
-            </div>
-          </div>
-          <div className="mt-2">
-            <label className="text-xs text-muted-foreground">คำอธิบาย (optional)</label>
-            <textarea
-              {...register(`items.${idx}.description`)}
-              rows={1}
-              className="w-full border rounded px-2 py-1 text-xs"
-              placeholder="เช่น ดอกเบี้ยเดือน พ.ค. 2569"
-            />
-          </div>
-        </div>
-      ))}
+        );
+      })}
       <button
         type="button"
         onClick={() =>
@@ -158,9 +197,9 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
             description: '',
           })
         }
-        className="inline-flex items-center gap-1 px-3 py-2 border rounded-md text-xs font-semibold hover:bg-accent"
+        className="w-full inline-flex items-center justify-center gap-2 px-3 py-3 border border-dashed rounded-lg text-sm font-semibold text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
       >
-        <Plus size={14} /> เพิ่มรายการ
+        <Plus size={16} /> เพิ่มบัญชี
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- **List page**: 4 stat cards → 4 status-count cards (DRAFT/POSTED/REVERSED + DAILY SHEET nav). Counts use 3 parallel status-scoped queries (`staleTime:60s`) instead of in-page filter (which under-counted).
- **Entry page**: full layout rewrite to match owner prototype — single-column flow, 9 numbered sections with green-pill headers, 6 payment-account pill buttons (radiogroup + aria-checked), live validation error box, auto-filled recorder/approver pills, real drag-and-drop attachment zone, "สรุปก่อนยืนยัน" big card.
- **Code quality**: shared `formatNumberDecimal`/`formatNumber` replaces inline `toLocaleString`; emoji-as-icon (`✓`/`✗`/`→`/`←`) → lucide icons (`CheckCircle2`/`XCircle`/`ArrowRight`/`ArrowLeft`).

## Behavior changes
- `mode: 'onChange'` on form — validation messages update on every keystroke.
- Validation box explicitly labelled "ต้องแก้ไข N ข้อก่อน POST" with hint "(สามารถบันทึกร่างไว้ก่อนได้)" — drafts remain lenient (schema-conforming), POST is strict.
- `issueDate` default uses Bangkok timezone — fixes UTC drift at 00:00–07:00 BKK.

## Out of scope (per Round 1-4 reviews)
- Pre-existing `QueryBoundary <></>` race in edit mode
- `useMemo` arithmetic loop duplication (4 copies) — refactor pending
- Recorder/approver same user — matches prototype intent
- Section 5 number gap — matches prototype intent
- MIME magic-bytes validation — no project rule mandates it; backend pattern matches 6 other modules

## Reviews
4 rounds of `code-reviewer` agent passes. 5 issues fixed (staleTime, aria-checked, drag handlers, validation copy, shared formatters). Final round PASS.

## Test plan
- [ ] Open `/other-income` — verify 4 status cards display counts; click DAILY SHEET → nav to `/other-income/daily-sheet`
- [ ] Click `สร้างเอกสารใหม่` — verify 9 sections render in order
- [ ] Fill name + 1 item + select payment account + amount — verify red box disappears + "บันทึก & POST" enables
- [ ] Verify pill buttons have selected state + keyboard navigable
- [ ] Drag a PDF onto Section 8 (after saving draft) — verify dashed border highlights + upload triggers
- [ ] Verify TypeScript: `./tools/check-types.sh all` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)