### PR TITLE
feat(expense): P0-4 Multi-line Adjustment + closes P0-1 same-day VAT

### DIFF
--- a/apps/api/prisma/migrations/20260917000000_add_expense_adjustments/migration.sql
+++ b/apps/api/prisma/migrations/20260917000000_add_expense_adjustments/migration.sql
@@ -1,0 +1,29 @@
+-- ExpenseAdjustment table — per-line breakdown of amount_paid vs amount_expected
+-- diff (Fix Report P0-4). Each row carries its own Dr/Cr direction via `side`.
+
+CREATE TYPE "ExpenseAdjustmentSide" AS ENUM ('DR', 'CR');
+
+CREATE TABLE "expense_adjustments" (
+  "id"           TEXT                    NOT NULL,
+  "document_id"  TEXT                    NOT NULL,
+  "line_no"      INTEGER                 NOT NULL,
+  "account_code" TEXT                    NOT NULL,
+  "side"         "ExpenseAdjustmentSide" NOT NULL,
+  "amount"       DECIMAL(12, 2)          NOT NULL,
+  "note"         TEXT,
+  "created_at"   TIMESTAMP(3)            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"   TIMESTAMP(3)            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "expense_adjustments_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "expense_adjustments_document_id_line_no_key"
+  ON "expense_adjustments"("document_id", "line_no");
+
+CREATE INDEX "expense_adjustments_document_id_idx"
+  ON "expense_adjustments"("document_id");
+
+ALTER TABLE "expense_adjustments"
+  ADD CONSTRAINT "expense_adjustments_document_id_fkey"
+  FOREIGN KEY ("document_id") REFERENCES "expense_documents"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3524,6 +3524,7 @@ model ExpenseDocument {
   settlement              VendorSettlementDetail?
   settlementsClearingThis SettlementLine[]        @relation("SettlementCleared")
   creditNotesAgainst      CreditNoteDetail[]      @relation("CreditNoteOriginal")
+  adjustments             ExpenseAdjustment[]
 
   journalEntryId String? @unique @map("journal_entry_id")
 
@@ -3582,6 +3583,44 @@ model ExpenseLine {
 
   @@unique([expenseDetailId, lineNo])
   @@map("expense_lines")
+}
+
+enum ExpenseAdjustmentSide {
+  DR
+  CR
+}
+
+/// Fix Report P0-4 — Multi-line adjustment for amount_paid ≠ amount_expected
+/// cases (rounding tolerance, overpay/underpay, bank/vendor discounts).
+/// Captures the per-line breakdown of the difference into account-specific
+/// Dr/Cr postings so the JE still balances.
+///
+/// Each row carries its own direction (`side`) so the UI is explicit and the
+/// JE template doesn't need to infer signs from document-level math. `amount`
+/// is always stored as a positive Decimal; direction comes from `side`.
+///
+/// Validation rules (V12/V13/V14):
+///   - V12 — Σ (signed) adjustments = `amountPaid − netExpected`, where
+///     positive adjustments post Cr (offset Dr expense) and negative
+///     adjustments post Dr (offset Cr cash). Signed convention:
+///       signed[i] = side == 'CR' ? +amount : -amount
+///   - V13 — every row must have `accountCode`
+///   - V14 — `amount > 0` (signs go through `side`, not the amount itself)
+model ExpenseAdjustment {
+  id          String                @id @default(uuid())
+  documentId  String                @map("document_id")
+  document    ExpenseDocument       @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  lineNo      Int                   @map("line_no")
+  accountCode String                @map("account_code")
+  side        ExpenseAdjustmentSide
+  amount      Decimal               @db.Decimal(12, 2)
+  note        String?
+  createdAt   DateTime              @default(now()) @map("created_at")
+  updatedAt   DateTime              @updatedAt @map("updated_at")
+
+  @@unique([documentId, lineNo])
+  @@index([documentId])
+  @@map("expense_adjustments")
 }
 
 /// Lifecycle delegated to parent ExpenseDocument — timestamps/soft-delete intentionally omitted.

--- a/apps/api/src/modules/expense-documents/__tests__/expense-same-day.template.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-same-day.template.spec.ts
@@ -56,7 +56,7 @@ describe('ExpenseSameDayTemplate', () => {
     expect(args.lines).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ accountCode: '53-1302', dr: new Decimal('1000.00') }),
-        expect.objectContaining({ accountCode: '11-2104', dr: new Decimal('70.00') }),
+        expect.objectContaining({ accountCode: '11-4101', dr: new Decimal('70.00') }),
         expect.objectContaining({ accountCode: '11-1101', cr: new Decimal('1070.00') }),
       ]),
     );

--- a/apps/api/src/modules/expense-documents/dto/create.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create.dto.ts
@@ -6,9 +6,11 @@ import {
   IsArray,
   ArrayMinSize,
   IsIn,
+  IsNumberString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ExpenseLineInput } from './expense-line-input.dto';
+import { ExpenseAdjustmentInput } from './expense-adjustment-input.dto';
 
 const PRICE_TYPES = ['EXCLUSIVE', 'INCLUSIVE'] as const;
 const CASH_ACCOUNT_CODES = ['11-1101', '11-1102', '11-1103', '11-1201', '11-1202', '11-1203'] as const;
@@ -84,4 +86,23 @@ export class CreateExpenseDocumentDto {
   @ValidateNested({ each: true })
   @Type(() => ExpenseLineInput)
   lines!: ExpenseLineInput[];
+
+  /**
+   * Optional `amount_paid ≠ amount_expected` adjustment rows (Fix Report P0-4).
+   * Service-level V12 enforces Σ signed(adjustments) = amountPaid − netExpected.
+   */
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ExpenseAdjustmentInput)
+  @IsOptional()
+  adjustments?: ExpenseAdjustmentInput[];
+
+  /**
+   * Optional explicit "what we actually paid" amount. When set, must reconcile
+   * to `totalAmount − wht` ± Σ signed(adjustments) (V12). When omitted, the
+   * cash leg defaults to `totalAmount − wht` (legacy zero-adjustment behaviour).
+   */
+  @IsNumberString({ no_symbols: true })
+  @IsOptional()
+  amountPaid?: string;
 }

--- a/apps/api/src/modules/expense-documents/dto/expense-adjustment-input.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/expense-adjustment-input.dto.ts
@@ -1,0 +1,34 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsNumberString,
+  IsIn,
+  IsOptional,
+} from 'class-validator';
+
+/**
+ * Single adjustment row for an ExpenseDocument's diff between cash leg
+ * actually paid and `totalAmount − wht`. See ExpenseAdjustment model docs
+ * (schema.prisma) for the V12/V13/V14 rules.
+ */
+export class ExpenseAdjustmentInput {
+  /** CoA code where the adjustment posts (e.g. 53-1503 ปัดเศษ, 52-1104 ส่วนลด). */
+  @IsString()
+  @IsNotEmpty({ message: 'V13: บัญชีปรับผลต่างต้องไม่ว่าง' })
+  accountCode!: string;
+
+  @IsString()
+  @IsIn(['DR', 'CR'], { message: 'side ต้องเป็น "DR" หรือ "CR"' })
+  side!: 'DR' | 'CR';
+
+  /**
+   * Always positive — direction is carried by `side`. V14 enforces > 0
+   * server-side; class-validator only ensures string-numeric shape here.
+   */
+  @IsNumberString({ no_symbols: true })
+  amount!: string;
+
+  @IsString()
+  @IsOptional()
+  note?: string;
+}

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -86,6 +86,63 @@ export class ExpenseDocumentsService {
         if (t !== 'ค่าใช้จ่าย') throw new BadRequestException(`หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"`);
       }
 
+      // Fix Report P0-4 — multi-line adjustment validation (V12/V13/V14).
+      // When `amountPaid` differs from `netExpected = totalAmount − wht`, the
+      // signed sum of adjustments must close the gap exactly.
+      const adjustments = dto.adjustments ?? [];
+      const totalAmount = new Prisma.Decimal(totals.totalAmount.toString());
+      const wht = new Prisma.Decimal(totals.withholdingTax.toString());
+      const netExpected = totalAmount.minus(wht);
+      const amountPaid =
+        dto.amountPaid !== undefined ? new Prisma.Decimal(dto.amountPaid) : netExpected;
+      const diff = amountPaid.minus(netExpected);
+
+      if (adjustments.length > 0 || !diff.eq(0)) {
+        // V13/V14 — each row must have accountCode + amount > 0
+        for (let i = 0; i < adjustments.length; i++) {
+          const a = adjustments[i];
+          if (!a.accountCode || !a.accountCode.trim()) {
+            throw new BadRequestException(
+              `V13: บัญชีปรับผลต่างแถวที่ ${i + 1} ยังไม่ได้เลือกบัญชี`,
+            );
+          }
+          const amt = new Prisma.Decimal(a.amount);
+          if (amt.lte(0)) {
+            throw new BadRequestException(
+              `V14: บัญชีปรับผลต่างแถวที่ ${i + 1}: จำนวนต้องมากกว่า 0`,
+            );
+          }
+        }
+
+        // V13 — adjustment account codes must exist in CoA (any type)
+        if (adjustments.length > 0) {
+          const adjCodes = [...new Set(adjustments.map((a) => a.accountCode))];
+          const adjCoaRows = await tx.chartOfAccount.findMany({
+            where: { code: { in: adjCodes }, deletedAt: null },
+            select: { code: true },
+          });
+          const adjFound = new Set(adjCoaRows.map((r) => r.code));
+          for (const c of adjCodes) {
+            if (!adjFound.has(c)) {
+              throw new BadRequestException(`V13: บัญชีปรับผลต่าง ${c} ไม่พบในผังบัญชี`);
+            }
+          }
+        }
+
+        // V12 — Σ signed(adjustments) must equal diff.
+        // Signed convention: side='CR' contributes +amount (offsets Dr); side='DR' contributes −amount (offsets Cr).
+        const signedSum = adjustments.reduce<Prisma.Decimal>((s, a) => {
+          const amt = new Prisma.Decimal(a.amount);
+          return a.side === 'CR' ? s.plus(amt) : s.minus(amt);
+        }, new Prisma.Decimal(0));
+        if (!signedSum.eq(diff)) {
+          throw new BadRequestException(
+            `V12: ผลรวมบัญชีปรับผลต่าง (signed = ${signedSum.toFixed(2)}) ` +
+              `ไม่เท่ากับผลต่าง amount_paid − net_expected (${diff.toFixed(2)})`,
+          );
+        }
+      }
+
       const number = await this.docNumber.next(tx, 'EXPENSE', documentDate);
 
       return tx.expenseDocument.create({
@@ -103,7 +160,7 @@ export class ExpenseDocumentsService {
           withholdingTax: totals.withholdingTax,
           whtFormType: dto.whtFormType ?? null,
           totalAmount: totals.totalAmount,
-          netPayment: dto.depositAccountCode ? totals.netPayment : null,
+          netPayment: dto.depositAccountCode ? amountPaid : null,
           paymentMethod: (dto.paymentMethod as never) ?? null,
           depositAccountCode: dto.depositAccountCode ?? null,
           status: 'DRAFT',
@@ -133,8 +190,23 @@ export class ExpenseDocumentsService {
               },
             },
           },
+          adjustments:
+            adjustments.length > 0
+              ? {
+                  create: adjustments.map((a, idx) => ({
+                    lineNo: idx + 1,
+                    accountCode: a.accountCode,
+                    side: a.side,
+                    amount: new Prisma.Decimal(a.amount),
+                    note: a.note ?? null,
+                  })),
+                }
+              : undefined,
         },
-        include: { expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } } },
+        include: {
+          expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
+          adjustments: { orderBy: { lineNo: 'asc' } },
+        },
       });
     });
   }

--- a/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
@@ -9,10 +9,15 @@ import { PrismaService } from '../../../prisma/prisma.service';
  *
  * Spec §4.1 — records expense + cash payment in one JE.
  *
- *   Dr 5x-xxxx ค่าใช้จ่ายตาม category    (subtotal)
- *   Dr 11-2104 ลูกหนี้-VAT                (vatAmount)        [if VAT > 0]
- *     Cr depositAccountCode               (totalAmount - whtAmount)
- *     Cr 21-3102/3103 หัก ณ ที่จ่าย       (whtAmount)        [if WHT > 0; route by whtFormType]
+ *   Dr 5x-xxxx ค่าใช้จ่ายตาม category     (subtotal)
+ *   Dr 11-4101 ภาษีซื้อ                   (vatAmount)        [if VAT > 0]
+ *   Dr <adj-account>                      (adjustment)       [if underpay diff < 0]
+ *     Cr depositAccountCode                (amountReceived if set, else totalAmount - whtAmount)
+ *     Cr 21-3102/3103 หัก ณ ที่จ่าย         (whtAmount)        [if WHT > 0; route by whtFormType]
+ *     Cr <adj-account>                      (adjustment)       [if overpay diff > 0]
+ *
+ * Fix Report P0-1: VAT input → 11-4101 (was 11-2104).
+ * Fix Report P0-4: adjustments line up to balance amount_paid ≠ amount_expected.
  *
  * ⚠️ CPA AUDIT REQUIRED — accounts logical-correct against Phase A.4 chart
  * but pending CPA case verification (Phase A.7).
@@ -49,7 +54,10 @@ export class ExpenseSameDayTemplate {
     const exec = async (tx: Prisma.TransactionClient): Promise<{ entryNo: string }> => {
       const doc = await tx.expenseDocument.findUniqueOrThrow({
         where: { id: documentId },
-        include: { expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } } },
+        include: {
+          expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
+          adjustments: { orderBy: { lineNo: 'asc' } },
+        },
       });
 
       // Idempotency — journalEntryId stores JournalEntry.id (UUID).
@@ -74,7 +82,12 @@ export class ExpenseSameDayTemplate {
       const vat = new Decimal(doc.vatAmount?.toString() ?? '0');
       const wht = new Decimal(doc.withholdingTax?.toString() ?? '0');
       const total = new Decimal(doc.totalAmount.toString());
-      const cashAmount = total.minus(wht);
+      // Cash leg: prefer `netPayment` (the actual amount paid; reconciled to
+      // `total − wht` ± Σ adjustments by V12 in the service). Fall back to
+      // `total − wht` for legacy docs without adjustments + amountPaid.
+      const cashAmount = doc.netPayment
+        ? new Decimal(doc.netPayment.toString())
+        : total.minus(wht);
 
       // Aggregate Dr by category (multiple lines with same category collapse)
       const byCategory = new Map<string, Decimal>();
@@ -83,6 +96,13 @@ export class ExpenseSameDayTemplate {
         byCategory.set(l.category, (byCategory.get(l.category) ?? zero).plus(amt));
       }
 
+      // Adjustments (Fix Report P0-4): per-line Dr/Cr postings that absorb the
+      // diff between cash leg actually paid and `totalAmount − wht`. Each row
+      // carries its own `side` (DR/CR) so the JE template doesn't infer signs
+      // from document-level math — V12 in the service has already validated
+      // that the signed sum balances.
+      const adjustments = doc.adjustments ?? [];
+
       const lines: JeLineInput[] = [];
       for (const [code, amt] of byCategory.entries()) {
         if (amt.lte(zero)) continue; // skip zero/negative aggregations
@@ -90,10 +110,20 @@ export class ExpenseSameDayTemplate {
       }
       if (vat.gt(zero)) {
         lines.push({
-          accountCode: '11-2104',
+          accountCode: '11-4101',
           dr: vat,
           cr: zero,
-          description: 'ลูกหนี้-VAT ที่ออกแทน',
+          description: 'ภาษีซื้อ',
+        });
+      }
+      for (const adj of adjustments) {
+        const amt = new Decimal(adj.amount.toString());
+        if (amt.lte(zero)) continue;
+        lines.push({
+          accountCode: adj.accountCode,
+          dr: adj.side === 'DR' ? amt : zero,
+          cr: adj.side === 'CR' ? amt : zero,
+          description: adj.note ?? `ปรับผลต่าง — ${doc.number}`,
         });
       }
       lines.push({


### PR DESCRIPTION
## Summary

Completes Fix Report v1.0 **P0-4** (Multi-line Adjustment, backend) and closes the **third spot of P0-1** (same-day template VAT account). #810 fixed P0-1 in expense-accrual + credit-note but missed expense-same-day.

## P0-4 Backend (FE Section 5 deferred)

**Schema** — new \`ExpenseAdjustment\` model + \`ExpenseAdjustmentSide\` enum (DR/CR), 1-to-many on \`ExpenseDocument\`. Each row carries its own \`side\` so the JE template never infers signs.

**DTO** — \`CreateExpenseDocumentDto\` gains optional \`adjustments[]\` + \`amountPaid\` (string Decimal).

**Service validation V12/V13/V14**:
- **V12** — Σ signed(adjustments) must equal \`amountPaid − netExpected\`. \`side='CR'\` → +amount, \`side='DR'\` → −amount.
- **V13** — every row must have non-empty \`accountCode\` AND it must exist in \`chart_of_accounts\`.
- **V14** — amount > 0.

**Same-day JE template** — cash leg now reads \`doc.netPayment ?? (total − wht)\`. Adjustment rows post one JE line each, direction from \`adj.side\`.

## P0-1 (third spot)

\`expense-same-day.template.ts\` was still posting VAT to **11-2104 ลูกหนี้-VAT ที่ออกแทน** (not claimable on ภ.พ.30). Switched to **11-4101 ภาษีซื้อ** (Input Tax Credit). Test updated to assert the new account.

## Verification

- [x] API tsc: 0 errors
- [x] 145/145 expense-documents tests pass (17 suites)
- [x] 29/29 affected JE template tests pass
- [x] Legacy callers unaffected: \`adjustments\` + \`amountPaid\` are both optional; defaults reproduce previous behaviour

## Deferred to follow-up PRs

- **FE Section 5** — Multi-line Adjustment UI in ExpenseFormV4 / ExpenseDocumentNewPage
- **ACCRUAL / CREDIT_NOTE / PAYROLL** adjustment integration (only SAMEDAY currently meaningful — others have no cash leg or are reversals)
- **P1** (Fix Report) — APAgingPage 5 buckets, PaymentVoucher A4 + numToThaiText, account_role_map full refactor, V17 documentation
- **P2** — DocTypePicker chip cards, line-level JE refactor, docPrefix standardize, mixed PND.3/PND.53 routing

## Production rollout

1. CI/CD auto-deploy runs \`prisma migrate deploy\` → creates \`expense_adjustments\` table + enum
2. Legacy callers unaffected (new fields optional)
3. No data migration needed (new table starts empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)