### PR TITLE
feat(expense): line-level journal_lines preserve breakdown (Fix Report P2-2)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-same-day.template.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-same-day.template.spec.ts
@@ -261,7 +261,8 @@ describe('ExpenseSameDayTemplate', () => {
     expect(dr5x.find((l: { accountCode: string; dr: { toString: () => string } }) => l.accountCode === '53-1101').dr.toString()).toBe('1000');
   });
 
-  it('multi-line: 3 lines, 2 share category — 2 Dr rows (1000+500 vs 800)', async () => {
+  // Fix Report P2-2 — per-line journal_lines (no collapse by category).
+  it('multi-line: 3 lines, 2 share category — 3 Dr rows (line-level preserved)', async () => {
     prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
       id: 'doc-collapse', number: 'EX-20260511-0011',
       documentType: 'EXPENSE',
@@ -275,17 +276,27 @@ describe('ExpenseSameDayTemplate', () => {
       expenseDetail: {
         priceType: 'EXCLUSIVE',
         lines: [
-          { lineNo: 1, category: '53-1101', amountBeforeVat: new Decimal('1000'), vatAmount: new Decimal('70'),  whtAmount: new Decimal('0') },
-          { lineNo: 2, category: '53-1404', amountBeforeVat: new Decimal('800'),  vatAmount: new Decimal('56'),  whtAmount: new Decimal('0') },
-          { lineNo: 3, category: '53-1101', amountBeforeVat: new Decimal('500'),  vatAmount: new Decimal('35'),  whtAmount: new Decimal('0') },
+          { lineNo: 1, category: '53-1101', description: 'รายการ A', amountBeforeVat: new Decimal('1000'), vatAmount: new Decimal('70'),  whtAmount: new Decimal('0') },
+          { lineNo: 2, category: '53-1404', description: 'รายการ B', amountBeforeVat: new Decimal('800'),  vatAmount: new Decimal('56'),  whtAmount: new Decimal('0') },
+          { lineNo: 3, category: '53-1101', description: 'รายการ C', amountBeforeVat: new Decimal('500'),  vatAmount: new Decimal('35'),  whtAmount: new Decimal('0') },
         ],
       },
     });
     await template.execute('doc-collapse');
     const args = journal.createAndPost.mock.calls[0][0];
     const dr5x = args.lines.filter((l: { accountCode: string }) => l.accountCode.startsWith('5'));
-    expect(dr5x).toHaveLength(2);
-    expect(dr5x.find((l: { accountCode: string; dr: { toString: () => string } }) => l.accountCode === '53-1101').dr.toString()).toBe('1500');
-    expect(dr5x.find((l: { accountCode: string; dr: { toString: () => string } }) => l.accountCode === '53-1404').dr.toString()).toBe('800');
+    expect(dr5x).toHaveLength(3); // P2-2: per-line, NOT collapsed by category
+    // Sum across the 53-1101 lines (2 of them) still = 1500 — total preserved
+    const sum1101 = dr5x
+      .filter((l: { accountCode: string }) => l.accountCode === '53-1101')
+      .reduce(
+        (s: number, l: { dr: { toString: () => string } }) => s + parseFloat(l.dr.toString()),
+        0,
+      );
+    expect(sum1101).toBe(1500);
+    const drA = dr5x.find((l: { description: string }) => l.description.includes('รายการ A'));
+    expect(drA.dr.toString()).toBe('1000');
+    const drC = dr5x.find((l: { description: string }) => l.description.includes('รายการ C'));
+    expect(drC.dr.toString()).toBe('500');
   });
 });

--- a/apps/api/src/modules/journal/cpa-templates/credit-note.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/credit-note.template.ts
@@ -144,15 +144,21 @@ export class CreditNoteTemplate {
         }
       }
 
-      // Cr expense legs — aggregate by category (collapse lines with same category)
-      const byCategory = new Map<string, Decimal>();
+      // Cr expense legs — Fix Report P2-2: emit one JE line per CN line so
+      // the reversal preserves the same breakdown shape as the original
+      // ExpenseDocument. Joining ExpenseLine → JournalLine becomes a simple
+      // lookup by line description (no aggregation to undo).
       for (const l of cnLines) {
         const amt = new Decimal(l.amountBeforeVat.toString());
-        byCategory.set(l.category, (byCategory.get(l.category) ?? zero).plus(amt));
-      }
-      for (const [code, amt] of byCategory.entries()) {
-        if (amt.lte(zero)) continue; // skip zero/negative aggregations
-        lines.push({ accountCode: code, dr: zero, cr: amt, description: `กลับค่าใช้จ่าย — ${cn.number}` });
+        if (amt.lte(zero)) continue;
+        lines.push({
+          accountCode: l.category,
+          dr: zero,
+          cr: amt,
+          description: l.description
+            ? `กลับค่าใช้จ่าย — ${l.description}`
+            : `กลับค่าใช้จ่าย — ${cn.number}#${l.lineNo}`,
+        });
       }
       if (vat.gt(zero)) {
         lines.push({

--- a/apps/api/src/modules/journal/cpa-templates/expense-accrual.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense-accrual.template.ts
@@ -72,17 +72,21 @@ export class ExpenseAccrualTemplate {
       const vat = new Decimal(doc.vatAmount?.toString() ?? '0');
       const total = new Decimal(doc.totalAmount.toString());
 
-      // Aggregate Dr by category (multiple lines with same category collapse)
-      const byCategory = new Map<string, Decimal>();
+      // Dr expense — Fix Report P2-2: emit one JE line per ExpenseLine so the
+      // GL preserves the full breakdown. Description carries the line text so
+      // auditors can trace back without joining ExpenseDetail.
+      const lines: JeLineInput[] = [];
       for (const l of expenseLines) {
         const amt = new Decimal(l.amountBeforeVat.toString());
-        byCategory.set(l.category, (byCategory.get(l.category) ?? zero).plus(amt));
-      }
-
-      const lines: JeLineInput[] = [];
-      for (const [code, amt] of byCategory.entries()) {
-        if (amt.lte(zero)) continue; // skip zero/negative aggregations
-        lines.push({ accountCode: code, dr: amt, cr: zero, description: `ค่าใช้จ่าย — ${doc.number}` });
+        if (amt.lte(zero)) continue;
+        lines.push({
+          accountCode: l.category,
+          dr: amt,
+          cr: zero,
+          description: l.description
+            ? `ค่าใช้จ่าย — ${l.description}`
+            : `ค่าใช้จ่าย — ${doc.number}#${l.lineNo}`,
+        });
       }
       if (vat.gt(zero)) {
         lines.push({

--- a/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
@@ -89,13 +89,6 @@ export class ExpenseSameDayTemplate {
         ? new Decimal(doc.netPayment.toString())
         : total.minus(wht);
 
-      // Aggregate Dr by category (multiple lines with same category collapse)
-      const byCategory = new Map<string, Decimal>();
-      for (const l of expenseLines) {
-        const amt = new Decimal(l.amountBeforeVat.toString());
-        byCategory.set(l.category, (byCategory.get(l.category) ?? zero).plus(amt));
-      }
-
       // Adjustments (Fix Report P0-4): per-line Dr/Cr postings that absorb the
       // diff between cash leg actually paid and `totalAmount − wht`. Each row
       // carries its own `side` (DR/CR) so the JE template doesn't infer signs
@@ -103,10 +96,23 @@ export class ExpenseSameDayTemplate {
       // that the signed sum balances.
       const adjustments = doc.adjustments ?? [];
 
+      // Dr expense — Fix Report P2-2: emit one JE line per ExpenseLine so the
+      // GL preserves the full breakdown (lines from different invoices, or
+      // different sub-descriptions within one category, no longer get squashed
+      // together). Description carries the line text so auditors can trace
+      // back to the original document line without joining.
       const lines: JeLineInput[] = [];
-      for (const [code, amt] of byCategory.entries()) {
-        if (amt.lte(zero)) continue; // skip zero/negative aggregations
-        lines.push({ accountCode: code, dr: amt, cr: zero, description: `ค่าใช้จ่าย — ${doc.number}` });
+      for (const l of expenseLines) {
+        const amt = new Decimal(l.amountBeforeVat.toString());
+        if (amt.lte(zero)) continue;
+        lines.push({
+          accountCode: l.category,
+          dr: amt,
+          cr: zero,
+          description: l.description
+            ? `ค่าใช้จ่าย — ${l.description}`
+            : `ค่าใช้จ่าย — ${doc.number}#${l.lineNo}`,
+        });
       }
       if (vat.gt(zero)) {
         lines.push({


### PR DESCRIPTION
## Summary

Fix Report v1.0 **P2-2** — preserves per-line breakdown in \`journal_lines\` instead of collapsing by category.

## What changed

\`expense-same-day.template\`, \`expense-accrual.template\`, and \`credit-note.template\` previously aggregated Dr lines that shared a \`category\` (e.g. 3 ExpenseLines in category 53-1101 → 1 Dr row of the sum).

Now each ExpenseLine produces its own JE line, with \`description\` carrying the per-line text (or \`\${docNumber}#\${lineNo}\` fallback). Auditors can trace \`JournalLine\` → \`ExpenseLine\` by \`(description, amount)\` without re-aggregating.

## Why

Fix Report §1.4 P2-2 / §3.1 Phase 3 — preserve traceability. Σ Dr stays identical so JE balance is unchanged and existing reports that sum by \`accountCode\` still match.

## Tests

- \`expense-same-day.template\` multi-line collapse test rewritten to assert 3 Dr rows (1 per line) + sum across same-category lines still = 1500
- 30/30 affected JE-template unit tests pass
- API tsc: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)