### PR TITLE
fix(other-income): v2.1 PR-1 — accountant Gap Analysis bug fixes (B1-B6)

### DIFF
--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -607,8 +607,16 @@ describe('OtherIncomeService — post — period lock (B1)', () => {
     }
 
     // Clean up accounting period rows created by this suite
+    // (2026-04 for the post() tests + today's period for the reverse() test)
+    const today = new Date();
     await prisma.accountingPeriod.deleteMany({
-      where: { companyId: financeCompanyId, year: 2026, month: 4 },
+      where: {
+        companyId: financeCompanyId,
+        OR: [
+          { year: 2026, month: 4 },
+          { year: today.getFullYear(), month: today.getMonth() + 1 },
+        ],
+      },
     });
 
     await prisma.user.delete({ where: { id: userId } }).catch(() => {});
@@ -666,5 +674,53 @@ describe('OtherIncomeService — post — period lock (B1)', () => {
 
     const result = await service.post(doc.id, {}, userId);
     expect(result.status).toBe('POSTED');
+  }, 30_000);
+
+  it('reverse() rejects when today\'s period is CLOSED (B1 — reverse path)', async () => {
+    // Arrange: today's year/month (reverse() uses new Date(), not original issueDate)
+    const today = new Date();
+    const todayYear = today.getFullYear();
+    const todayMonth = today.getMonth() + 1;
+
+    // Step 1: ensure today's period is OPEN so we can POST the doc first
+    await prisma.accountingPeriod.upsert({
+      where: {
+        companyId_year_month: {
+          companyId: financeCompanyId,
+          year: todayYear,
+          month: todayMonth,
+        },
+      },
+      update: { status: 'OPEN' },
+      create: {
+        companyId: financeCompanyId,
+        year: todayYear,
+        month: todayMonth,
+        status: 'OPEN',
+      },
+    });
+
+    // Step 2: create + POST a fresh doc dated today (so doc.issueDate also falls in OPEN period)
+    const issueDate = today.toISOString().slice(0, 10);
+    const draft = await createDraftOtherIncome(issueDate);
+    const posted = await service.post(draft.id, {}, userId);
+    expect(posted.status).toBe('POSTED');
+
+    // Step 3: flip today's period to CLOSED — now reverse() should reject
+    await prisma.accountingPeriod.update({
+      where: {
+        companyId_year_month: {
+          companyId: financeCompanyId,
+          year: todayYear,
+          month: todayMonth,
+        },
+      },
+      data: { status: 'CLOSED' },
+    });
+
+    // Act + Assert: reverse() must fail because today's period is CLOSED
+    await expect(
+      service.reverse(posted.id, { reason: 'INPUT_ERROR', note: 'test' }, userId),
+    ).rejects.toThrow(/งวดที่ปิดแล้ว/);
   }, 30_000);
 });

--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -521,3 +521,150 @@ describe('OtherIncomeService — post + reverse + copy', () => {
     expect(sheet.summary).toHaveProperty('wht');
   }, 30_000);
 });
+
+// ============================================================
+// Suite 3: post — period lock (B1)
+// ============================================================
+
+describe('OtherIncomeService — post — period lock (B1)', () => {
+  let service: OtherIncomeService;
+  let prisma: PrismaService;
+  let userId: string;
+  let financeCompanyId: string;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        OtherIncomeService,
+        DocNumberService,
+        ValidationService,
+        AutoJournalService,
+        OtherIncomeTemplate,
+        JournalAutoService,
+        PrismaService,
+        { provide: StorageService, useValue: stubStorage },
+      ],
+    }).compile();
+    await module.init();
+    service = module.get(OtherIncomeService);
+    prisma = module.get(PrismaService);
+
+    // Ensure FINANCE CompanyInfo
+    const company = await prisma.companyInfo.upsert({
+      where: { companyCode: 'FINANCE' },
+      update: {},
+      create: {
+        companyCode: 'FINANCE',
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000001',
+        address: 'TEST',
+        directorName: 'ผู้อำนวยการ',
+        vatRegistered: true,
+      },
+    });
+    financeCompanyId = company.id;
+
+    // Ensure system user
+    await prisma.user.upsert({
+      where: { email: 'admin@bestchoice.com' },
+      update: {},
+      create: { email: 'admin@bestchoice.com', password: 'x', name: 'admin', role: 'OWNER' },
+    });
+
+    // Seed required CoA codes
+    const coaSeeds = [
+      { code: '42-1102', name: 'รายได้ดอกเบี้ยฝากธนาคาร', type: 'รายได้', normalBalance: 'Cr', category: 'รายได้อื่น' },
+      { code: '11-1201', name: 'ธนาคาร KBank', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'เงินฝากธนาคาร' },
+      { code: '11-4103', name: 'ลูกหนี้ภาษีหัก ณ ที่จ่าย', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'สินทรัพย์หมุนเวียน' },
+    ];
+    for (const seed of coaSeeds) {
+      await prisma.chartOfAccount.upsert({ where: { code: seed.code }, update: {}, create: seed });
+    }
+
+    const user = await prisma.user.create({
+      data: {
+        email: `oi-period-lock+${Date.now()}@bestchoice.test`,
+        password: 'x',
+        name: 'OI Period Lock Tester',
+        role: 'ACCOUNTANT',
+      },
+    });
+    userId = user.id;
+  }, 30_000);
+
+  afterAll(async () => {
+    const ois = await prisma.otherIncome.findMany({ where: { createdById: userId } });
+    const ourIds = ois.map((o) => o.id);
+    const jeIds = ois.filter((o) => o.journalEntryId).map((o) => o.journalEntryId as string);
+
+    await prisma.otherIncomeItem.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncomeAdjustment.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncome.deleteMany({ where: { createdById: userId } });
+
+    if (jeIds.length > 0) {
+      await prisma.journalLine.deleteMany({ where: { journalEntryId: { in: jeIds } } });
+      await prisma.journalEntry.deleteMany({ where: { id: { in: jeIds } } });
+    }
+
+    // Clean up accounting period rows created by this suite
+    await prisma.accountingPeriod.deleteMany({
+      where: { companyId: financeCompanyId, year: 2026, month: 4 },
+    });
+
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.$disconnect();
+  }, 30_000);
+
+  function createDraftOtherIncome(issueDate: string) {
+    return service.create(
+      {
+        issueDate,
+        priceType: 'EXCLUSIVE',
+        paymentAccountCode: '11-1201',
+        amountReceived: 850,
+        counterpartyName: 'KBank',
+        items: [
+          {
+            accountCode: '42-1102',
+            description: 'ดอกเบี้ยฝาก',
+            quantity: 1,
+            unitAmount: 1000,
+            vatPct: 0,
+            whtPct: 15,
+          },
+        ],
+      },
+      userId,
+    );
+  }
+
+  it('passes companyId so AccountingPeriod tier-1 check fires', async () => {
+    // Arrange: a CLOSED FINANCE AccountingPeriod for the doc's month
+    const doc = await createDraftOtherIncome('2026-04-15');
+    await prisma.accountingPeriod.upsert({
+      where: { companyId_year_month: { companyId: financeCompanyId, year: 2026, month: 4 } },
+      update: { status: 'CLOSED' },
+      create: { companyId: financeCompanyId, year: 2026, month: 4, status: 'CLOSED' },
+    });
+
+    // Act + Assert: should reject because period is CLOSED
+    await expect(service.post(doc.id, {}, userId)).rejects.toThrow(/งวดที่ปิดแล้ว/);
+
+    // Cleanup this doc (it was not posted, so no JE)
+    await prisma.otherIncomeItem.deleteMany({ where: { otherIncomeId: doc.id } });
+    await prisma.otherIncome.delete({ where: { id: doc.id } });
+  }, 30_000);
+
+  it('allows POST when period is OPEN', async () => {
+    // Arrange: ensure AccountingPeriod is OPEN for 2026-04
+    await prisma.accountingPeriod.upsert({
+      where: { companyId_year_month: { companyId: financeCompanyId, year: 2026, month: 4 } },
+      update: { status: 'OPEN' },
+      create: { companyId: financeCompanyId, year: 2026, month: 4, status: 'OPEN' },
+    });
+    const doc = await createDraftOtherIncome('2026-04-15');
+
+    const result = await service.post(doc.id, {}, userId);
+    expect(result.status).toBe('POSTED');
+  }, 30_000);
+});

--- a/apps/api/src/modules/other-income/__tests__/validation.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/validation.spec.ts
@@ -110,3 +110,49 @@ describe('ValidationService', () => {
     expect(result.errors.find((e) => e.rule === 'V13')).toBeDefined();
   });
 });
+
+describe('V15 — bank interest policy (B2)', () => {
+  let service: ValidationService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [ValidationService],
+    }).compile();
+    service = module.get(ValidationService);
+  });
+
+  it('does NOT warn when 42-1102 uses WHT 1% (นิติบุคคล ออมทรัพย์)', () => {
+    const doc = {
+      ...goldenCases.bankInterest,
+      items: [
+        {
+          ...goldenCases.bankInterest.items[0],
+          whtPct: D(1),
+          whtAmount: D(10),
+        },
+      ],
+      whtAmount: D(10),
+      netReceived: D(990),
+      amountReceived: D(990),
+    };
+    const result = service.validate(doc, baseCtx);
+    const v15Warning = result.warnings.find((w) => w.rule === 'V15');
+    expect(v15Warning).toBeUndefined();
+  });
+
+  it('still errors when 42-1102 has VAT% > 0 (ม.81(1)(ฏ) violation)', () => {
+    const doc = {
+      ...goldenCases.bankInterest,
+      items: [
+        {
+          ...goldenCases.bankInterest.items[0],
+          vatPct: D(7),
+        },
+      ],
+    };
+    const result = service.validate(doc, baseCtx);
+    const v15Error = result.errors.find((e) => e.rule === 'V15');
+    expect(v15Error).toBeDefined();
+    expect(v15Error?.msg).toMatch(/ยกเว้น VAT/);
+  });
+});

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -231,8 +231,10 @@ export class OtherIncomeService {
       );
     }
 
-    // V8: period lock check (non-transactional pre-check)
-    await validatePeriodOpen(this.prisma, doc.issueDate);
+    // V8: period lock check (non-transactional pre-check) — B1: pass companyId so
+    // AccountingPeriod tier-1 check fires (without it, only legacy SystemConfig is consulted)
+    const companyId = await this.resolveFinanceCompanyId();
+    await validatePeriodOpen(this.prisma, doc.issueDate, companyId);
 
     // Compute attachment threshold
     const threshold = await this.getAttachmentThreshold();
@@ -367,8 +369,10 @@ export class OtherIncomeService {
       );
     }
 
-    // Period lock on today — the reversal JE is posted today, not on original's issueDate
-    await validatePeriodOpen(this.prisma, new Date());
+    // Period lock on today — the reversal JE is posted today, not on original's issueDate.
+    // B1: pass companyId so AccountingPeriod tier-1 check fires.
+    const companyId = await this.resolveFinanceCompanyId();
+    await validatePeriodOpen(this.prisma, new Date(), companyId);
 
     // Load original JE lines
     if (!original.journalEntryId) {

--- a/apps/api/src/modules/other-income/services/validation.service.ts
+++ b/apps/api/src/modules/other-income/services/validation.service.ts
@@ -106,9 +106,9 @@ export class ValidationService {
       }
     });
 
-    // V15 — Bank interest income (42-1102) is VAT-exempt under ม.81(1)(ฏ) and
-    // is statutorily WHT-deducted at 15% by the bank (ม.50(2)(ข) + ม.50 ทวิ).
-    // Bookings that violate either are almost always a misclassified account.
+    // V15 — Bank interest income (42-1102) is VAT-exempt under ม.81(1)(ฏ).
+    // WHT rate is left to user judgement (1% for นิติบุคคล ออมทรัพย์ ท.ป.4/2528;
+    // 15% for ฝากประจำ ม.50). UI tooltip surfaces per-account suggestions.
     doc.items?.forEach((it) => {
       if (it.accountCode !== '42-1102') return;
       if (it.vatPct.gt(0)) {
@@ -116,13 +116,6 @@ export class ValidationService {
           rule: 'V15',
           lineNo: it.lineNo,
           msg: `รายการที่ ${it.lineNo}: ดอกเบี้ยเงินฝาก (42-1102) ได้รับยกเว้น VAT (ม.81(1)(ฏ)) — กรุณาตั้ง VAT% = 0`,
-        });
-      }
-      if (!it.whtPct.eq(15)) {
-        warnings.push({
-          rule: 'V15',
-          lineNo: it.lineNo,
-          msg: `รายการที่ ${it.lineNo}: ดอกเบี้ยเงินฝาก (42-1102) ถูกหัก ณ ที่จ่าย 15% โดยธนาคารตามกฎหมาย — ตรวจสอบ WHT% อีกครั้ง`,
         });
       }
     });

--- a/apps/web/src/pages/other-income/components/ItemsTable.tsx
+++ b/apps/web/src/pages/other-income/components/ItemsTable.tsx
@@ -10,6 +10,12 @@ import { AccountSearchDropdown } from './AccountSearchDropdown';
 import { formatNumberDecimal } from '@/utils/formatters';
 import type { OtherIncomeFormValues } from '@/lib/otherIncome.schema';
 
+/** Per-account WHT% suggestion. Soft tooltip — never blocks. */
+const WHT_SUGGESTION: Record<string, { pct: number; reason: string }> = {
+  '42-1102': { pct: 1, reason: 'นิติบุคคล ออมทรัพย์ (ท.ป.4/2528)' },
+  '42-1105': { pct: 1, reason: 'ขายสินทรัพย์ให้นิติบุคคล (ท.ป.4/2528)' },
+};
+
 interface Props {
   control: Control<OtherIncomeFormValues>;
   register: UseFormRegister<OtherIncomeFormValues>;
@@ -152,6 +158,17 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
                       </option>
                     ))}
                   </select>
+                  {(() => {
+                    const acc = items[idx]?.accountCode ?? '';
+                    const sug = WHT_SUGGESTION[acc];
+                    if (!sug || whtPct === sug.pct) return null;
+                    return (
+                      <p className="mt-1 text-[10px] text-muted-foreground inline-flex items-center gap-1">
+                        <Lightbulb size={10} className="text-warning" />
+                        แนะนำ {sug.pct}% — {sug.reason}
+                      </p>
+                    );
+                  })()}
                 </div>
                 <div>
                   <label className="text-muted-foreground font-medium">ก่อนภาษี</label>

--- a/apps/web/src/pages/other-income/components/ItemsTable.tsx
+++ b/apps/web/src/pages/other-income/components/ItemsTable.tsx
@@ -193,7 +193,7 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
             unitAmount: 0,
             discountAmount: 0,
             vatPct: 0,
-            whtPct: 15,
+            whtPct: 1,
             description: '',
           })
         }


### PR DESCRIPTION
## Summary

Closes 6 bug gaps from accountant Gap Analysis Report on PR #805.

- **B1**: pass `companyId` to `validatePeriodOpen()` on both `post()` and `reverse()` → `AccountingPeriod` tier-1 check now fires per-company (was silently skipping to legacy SystemConfig tier-2)
- **B2**: drop V15 WHT-rate warning (the warning forced 15% but BESTCHOICE = นิติบุคคล KBank ออมทรัพย์ → **1%** per ท.ป.4/2528). V15 VAT-exempt enforcement (ม.81(1)(ฏ)) remains.
- **B3**: default `whtPct: 1` for new ItemsTable rows (was 15 — only correct for ฝากประจำ ม.50)
- **B4**: verified — ViewPage audit trail section already exists (lines 500-526)
- **B5**: per-account WHT suggestion tooltip — soft, non-blocking, shows "แนะนำ X% — reason" when selected rate ≠ recommended
- **B6**: verified — mobile responsive (status cards `grid-cols-2 md:grid-cols-4`, tables `overflow-x-auto`, ItemsTable card-per-row)

Spec: \`docs/superpowers/specs/2026-05-12-other-income-v2-1-pdf-gap-fixes-design.md\`
Plan: \`docs/superpowers/plans/2026-05-12-other-income-v2-1-pr1-bug-fixes.md\`

PR-2 (Maker-Checker) and PR-3 (Templates) will follow.

## Commits (6)

| SHA | Task |
|---|---|
| a413d64b | B1 fix |
| e6303292 | B1 reverse() test |
| d9f72fa6 | B2 |
| afb81797 | B3 |
| 45580801 | B5 |
| 11e2f507 | B4+B6 verify (empty) |

## Test plan

- [x] V15 VAT-exempt error still fires (ม.81(1)(ฏ))
- [x] V15 WHT-rate warning no longer fires
- [x] CLOSED FINANCE period blocks POST
- [x] CLOSED FINANCE period blocks reverse() (negative-tested)
- [x] OPEN FINANCE period allows POST
- [x] New row default whtPct = 1
- [x] Suggestion tooltip shows for 42-1102 + WHT ≠ 1
- [x] Suggestion tooltip hidden for unmapped accounts
- [x] Audit trail timeline renders on ViewPage (existing)
- [x] Mobile 375px: no overflow on 4 main pages (existing responsive classes)
- [x] tsc 0 errors (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)