### PR TITLE
feat(other-income): v2.1 PR-2 — opt-in Maker-Checker workflow

### DIFF
--- a/apps/api/prisma/migrations/20260920000000_add_other_income_maker_checker/migration.sql
+++ b/apps/api/prisma/migrations/20260920000000_add_other_income_maker_checker/migration.sql
@@ -1,0 +1,19 @@
+-- Add READY + APPROVED to OtherIncomeStatus enum
+ALTER TYPE "OtherIncomeStatus" ADD VALUE 'READY';
+ALTER TYPE "OtherIncomeStatus" ADD VALUE 'APPROVED';
+
+-- Add approver/rejecter columns (all nullable — backward-compat)
+ALTER TABLE "other_incomes"
+  ADD COLUMN "approver_id"     TEXT,
+  ADD COLUMN "approved_at"     TIMESTAMP(3),
+  ADD COLUMN "approve_note"    TEXT,
+  ADD COLUMN "rejected_by_id"  TEXT,
+  ADD COLUMN "rejected_at"     TIMESTAMP(3),
+  ADD COLUMN "reject_note"     TEXT;
+
+-- FKs to User
+ALTER TABLE "other_incomes"
+  ADD CONSTRAINT "other_incomes_approver_id_fkey"
+    FOREIGN KEY ("approver_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "other_incomes_rejected_by_id_fkey"
+    FOREIGN KEY ("rejected_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -700,6 +700,8 @@ model User {
 
   // Other Income module
   otherIncomesCreated    OtherIncome[]           @relation("OtherIncomeCreatedBy")
+  otherIncomesApproved   OtherIncome[]           @relation("OtherIncomeApprover")
+  otherIncomesRejected   OtherIncome[]           @relation("OtherIncomeRejecter")
   otherIncomeAttachments OtherIncomeAttachment[] @relation("OtherIncomeAttachmentUploader")
 
   @@index([branchId])
@@ -5780,6 +5782,8 @@ model SmsTemplate {
 
 enum OtherIncomeStatus {
   DRAFT
+  READY      // PR-2: requested for approval (Maker-Checker opt-in flow)
+  APPROVED   // PR-2: transient — approved + auto-posted in same tx
   POSTED
   REVERSED
 }
@@ -5854,10 +5858,20 @@ model OtherIncome {
   updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
 
+  // PR-2 Maker-Checker (opt-in via SystemConfig OTHER_INCOME_MAKER_CHECKER_ENABLED)
+  approverId    String?   @map("approver_id")
+  approvedAt    DateTime? @map("approved_at")
+  approveNote   String?   @map("approve_note")
+  rejectedById  String?   @map("rejected_by_id")
+  rejectedAt    DateTime? @map("rejected_at")
+  rejectNote    String?   @map("reject_note")
+
   // Relations
   company    CompanyInfo   @relation(fields: [companyId], references: [id])
   customer   Customer?     @relation("CustomerOtherIncome", fields: [customerId], references: [id])
   createdBy  User          @relation("OtherIncomeCreatedBy", fields: [createdById], references: [id])
+  approver   User?         @relation("OtherIncomeApprover", fields: [approverId], references: [id])
+  rejectedBy User?         @relation("OtherIncomeRejecter", fields: [rejectedById], references: [id])
   reverses   OtherIncome?  @relation("OtherIncomeReverse", fields: [reversesId], references: [id])
   reversedBy OtherIncome?  @relation("OtherIncomeReverse")
   copiedFrom OtherIncome?  @relation("OtherIncomeCopy", fields: [copiedFromId], references: [id])

--- a/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
@@ -1,0 +1,369 @@
+/**
+ * PR-2: Maker-Checker integration tests for OtherIncomeService.
+ * Uses real DB (matches pattern in other-income.service.spec.ts).
+ */
+
+import { Test } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { OtherIncomeService } from '../other-income.service';
+import { DocNumberService } from '../services/doc-number.service';
+import { ValidationService } from '../services/validation.service';
+import { AutoJournalService } from '../services/auto-journal.service';
+import { OtherIncomeTemplate } from '../templates/other-income.template';
+import { JournalAutoService } from '../../journal/journal-auto.service';
+import { StorageService } from '../../storage/storage.service';
+
+const stubStorage = {
+  upload: async () => undefined,
+  delete: async () => undefined,
+  getSignedUrl: async () => 'https://stub/url',
+};
+
+const D = (n: number | string) => new Prisma.Decimal(n);
+
+// ============================================================
+// Suite: Maker-Checker lifecycle (requestApproval / approve / reject)
+// ============================================================
+
+describe('OtherIncomeService — Maker-Checker', () => {
+  let service: OtherIncomeService;
+  let prisma: PrismaService;
+  let makerId: string;
+  let approverId: string;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        OtherIncomeService,
+        DocNumberService,
+        ValidationService,
+        AutoJournalService,
+        OtherIncomeTemplate,
+        JournalAutoService,
+        PrismaService,
+        { provide: StorageService, useValue: stubStorage },
+      ],
+    }).compile();
+    await module.init();
+    service = module.get(OtherIncomeService);
+    prisma = module.get(PrismaService);
+
+    // Ensure FINANCE CompanyInfo exists
+    await prisma.companyInfo.upsert({
+      where: { companyCode: 'FINANCE' },
+      update: {},
+      create: {
+        companyCode: 'FINANCE',
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000001',
+        address: 'TEST',
+        directorName: 'ผู้อำนวยการ',
+        vatRegistered: true,
+      },
+    });
+
+    // Ensure system user (required by JournalAutoService.resolveSystemUserId)
+    await prisma.user.upsert({
+      where: { email: 'admin@bestchoice.com' },
+      update: {},
+      create: {
+        email: 'admin@bestchoice.com',
+        password: 'x',
+        name: 'admin',
+        role: 'OWNER',
+      },
+    });
+
+    // Seed required CoA codes
+    const coaSeeds = [
+      { code: '42-1102', name: 'รายได้ดอกเบี้ยฝากธนาคาร', type: 'รายได้', normalBalance: 'Cr', category: 'รายได้อื่น' },
+      { code: '11-1201', name: 'ธนาคาร KBank', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'เงินฝากธนาคาร' },
+      { code: '11-4103', name: 'ลูกหนี้ภาษีหัก ณ ที่จ่าย', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'สินทรัพย์หมุนเวียน' },
+    ];
+    for (const seed of coaSeeds) {
+      await prisma.chartOfAccount.upsert({
+        where: { code: seed.code },
+        update: {},
+        create: seed,
+      });
+    }
+
+    // Create test users: maker and approver
+    const ts = Date.now();
+    const maker = await prisma.user.create({
+      data: {
+        email: `oi-maker+${ts}@bestchoice.test`,
+        password: 'x',
+        name: 'OI Maker',
+        role: 'ACCOUNTANT',
+      },
+    });
+    makerId = maker.id;
+
+    const approverUser = await prisma.user.create({
+      data: {
+        email: `oi-approver+${ts}@bestchoice.test`,
+        password: 'x',
+        name: 'OI Approver',
+        role: 'FINANCE_MANAGER',
+      },
+    });
+    approverId = approverUser.id;
+
+    // Enable Maker-Checker flag in SystemConfig
+    await prisma.systemConfig.upsert({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      update: { value: 'true' },
+      create: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED', value: 'true' },
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    // Clean up test data
+    const ois = await prisma.otherIncome.findMany({
+      where: { createdById: makerId },
+    });
+    const ourIds = ois.map((o) => o.id);
+    const jeIds = ois.filter((o) => o.journalEntryId).map((o) => o.journalEntryId as string);
+
+    await prisma.otherIncomeItem.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncomeAdjustment.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncome.deleteMany({ where: { createdById: makerId } });
+
+    if (jeIds.length > 0) {
+      await prisma.journalLine.deleteMany({ where: { journalEntryId: { in: jeIds } } });
+      await prisma.journalEntry.deleteMany({ where: { id: { in: jeIds } } });
+    }
+
+    await prisma.user.delete({ where: { id: makerId } }).catch(() => {});
+    await prisma.user.delete({ where: { id: approverId } }).catch(() => {});
+
+    // Restore Maker-Checker flag to false (avoid polluting other test suites)
+    await prisma.systemConfig.upsert({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      update: { value: 'false' },
+      create: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED', value: 'false' },
+    });
+
+    await prisma.$disconnect();
+  }, 30_000);
+
+  // Helper: create a standard KBank interest DRAFT
+  async function createStandardDraft(issueDate = '2026-05-06') {
+    return service.create(
+      {
+        issueDate,
+        priceType: 'EXCLUSIVE',
+        paymentAccountCode: '11-1201',
+        amountReceived: 850,
+        counterpartyName: 'KBank',
+        items: [
+          {
+            accountCode: '42-1102',
+            description: 'ดอกเบี้ยฝาก',
+            quantity: 1,
+            unitAmount: 1000,
+            vatPct: 0,
+            whtPct: 15,
+          },
+        ],
+      },
+      makerId,
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Task 3: requestApproval()
+  // ─────────────────────────────────────────────────────────────
+
+  it('requestApproval(): DRAFT → READY when flag enabled', async () => {
+    const draft = await createStandardDraft();
+    expect(draft.status).toBe('DRAFT');
+
+    const ready = await service.requestApproval(draft.id, makerId);
+
+    expect(ready.status).toBe('READY');
+    // Rejection metadata should be cleared
+    expect(ready.rejectedById).toBeNull();
+    expect(ready.rejectedAt).toBeNull();
+    expect(ready.rejectNote).toBeNull();
+  }, 30_000);
+
+  it('requestApproval(): 400 when Maker-Checker flag disabled', async () => {
+    // Temporarily disable the flag
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'false' },
+    });
+
+    const draft = await createStandardDraft();
+
+    await expect(service.requestApproval(draft.id, makerId)).rejects.toMatchObject({
+      message: 'Maker-Checker disabled — use POST directly',
+    });
+
+    // Re-enable for subsequent tests
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'true' },
+    });
+  }, 30_000);
+
+  it('requestApproval(): 409 when doc not in DRAFT', async () => {
+    const draft = await createStandardDraft();
+    // Force doc to POSTED state
+    await prisma.otherIncome.update({
+      where: { id: draft.id },
+      data: { status: 'POSTED', postedAt: new Date() },
+    });
+
+    await expect(service.requestApproval(draft.id, makerId)).rejects.toMatchObject({
+      status: 409,
+    });
+  }, 30_000);
+
+  // ─────────────────────────────────────────────────────────────
+  // Task 4: approve()
+  // ─────────────────────────────────────────────────────────────
+
+  it('approve(): READY → POSTED atomically with approver metadata + receipt', async () => {
+    const draft = await createStandardDraft();
+    const ready = await service.requestApproval(draft.id, makerId);
+    expect(ready.status).toBe('READY');
+
+    const posted = await service.approve(ready.id, { note: 'อนุมัติแล้ว' }, approverId);
+
+    expect(posted.status).toBe('POSTED');
+    expect(posted.approverId).toBe(approverId);
+    expect(posted.approvedAt).toBeTruthy();
+    expect(posted.approveNote).toBe('อนุมัติแล้ว');
+    expect(posted.journalEntryId).toBeTruthy();
+    expect(posted.receiptNo).toMatch(/^RC-\d{8}-\d{3}$/);
+    expect(posted.postedAt).toBeTruthy();
+
+    // Verify JE was created
+    const je = await prisma.journalEntry.findUnique({
+      where: { id: posted.journalEntryId! },
+      include: { lines: true },
+    });
+    expect(je).toBeDefined();
+    expect(je!.status).toBe('POSTED');
+    // 3 lines: Dr cash, Dr WHT receivable, Cr income
+    expect(je!.lines.length).toBe(3);
+  }, 30_000);
+
+  it('approve(): V9 rejects self-approval (maker === approver)', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await expect(service.approve(draft.id, {}, makerId)).rejects.toMatchObject({
+      response: expect.objectContaining({
+        errors: expect.arrayContaining([
+          expect.objectContaining({ rule: 'V9' }),
+        ]),
+      }),
+    });
+  }, 30_000);
+
+  it('approve(): 409 when doc not in READY', async () => {
+    const draft = await createStandardDraft();
+    // Doc is DRAFT, not READY
+
+    await expect(service.approve(draft.id, {}, approverId)).rejects.toMatchObject({
+      status: 409,
+    });
+  }, 30_000);
+
+  it('approve(): 400 when Maker-Checker flag disabled', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'false' },
+    });
+
+    await expect(service.approve(draft.id, {}, approverId)).rejects.toMatchObject({
+      message: 'Maker-Checker disabled',
+    });
+
+    // Re-enable
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'true' },
+    });
+  }, 30_000);
+
+  // ─────────────────────────────────────────────────────────────
+  // Task 5: reject()
+  // ─────────────────────────────────────────────────────────────
+
+  it('reject(): READY → DRAFT with rejection metadata', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    const rejected = await service.reject(draft.id, { note: 'รายการผิดพลาด' }, approverId);
+
+    expect(rejected.status).toBe('DRAFT');
+    expect(rejected.rejectedById).toBe(approverId);
+    expect(rejected.rejectedAt).toBeTruthy();
+    expect(rejected.rejectNote).toBe('รายการผิดพลาด');
+  }, 30_000);
+
+  it('reject(): requires non-empty note', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await expect(service.reject(draft.id, { note: '' }, approverId)).rejects.toMatchObject({
+      message: 'กรุณาระบุหมายเหตุการปฏิเสธ',
+    });
+  }, 30_000);
+
+  it('reject(): 409 when doc not in READY', async () => {
+    const draft = await createStandardDraft();
+    // Doc is DRAFT, not READY
+
+    await expect(service.reject(draft.id, { note: 'หมายเหตุ' }, approverId)).rejects.toMatchObject({
+      status: 409,
+    });
+  }, 30_000);
+
+  it('reject(): 400 when Maker-Checker flag disabled', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'false' },
+    });
+
+    await expect(
+      service.reject(draft.id, { note: 'ปฏิเสธ' }, approverId),
+    ).rejects.toMatchObject({ message: 'Maker-Checker disabled' });
+
+    // Re-enable
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'true' },
+    });
+  }, 30_000);
+
+  it('reject() → requestApproval(): re-submission clears prior rejection metadata', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+    // Reject it first
+    await service.reject(draft.id, { note: 'แก้ไขก่อน' }, approverId);
+
+    // Verify rejection metadata is set
+    const afterReject = await prisma.otherIncome.findUnique({ where: { id: draft.id } });
+    expect(afterReject?.rejectNote).toBe('แก้ไขก่อน');
+
+    // Re-submit for approval — should clear rejection metadata
+    const resubmitted = await service.requestApproval(draft.id, makerId);
+    expect(resubmitted.status).toBe('READY');
+    expect(resubmitted.rejectedAt).toBeNull();
+    expect(resubmitted.rejectedById).toBeNull();
+    expect(resubmitted.rejectNote).toBeNull();
+  }, 30_000);
+});

--- a/apps/api/src/modules/other-income/dto/approve-other-income.dto.ts
+++ b/apps/api/src/modules/other-income/dto/approve-other-income.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ApproveOtherIncomeDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
+}

--- a/apps/api/src/modules/other-income/dto/reject-other-income.dto.ts
+++ b/apps/api/src/modules/other-income/dto/reject-other-income.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class RejectOtherIncomeDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุหมายเหตุการปฏิเสธ' })
+  @MaxLength(500)
+  note!: string;
+}

--- a/apps/api/src/modules/other-income/dto/request-approval.dto.ts
+++ b/apps/api/src/modules/other-income/dto/request-approval.dto.ts
@@ -1,0 +1,2 @@
+// Empty body — no fields required. Defined for OpenAPI consistency.
+export class RequestApprovalDto {}

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -51,6 +51,15 @@ export class OtherIncomeController {
     return { threshold: await this.service.getAttachmentThreshold() };
   }
 
+  // CRITICAL: must stay before any :id route so the literal string
+  // 'maker-checker-enabled' is not captured as a UUID param.
+  @Get('maker-checker-enabled')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  async getMakerCheckerEnabled() {
+    const enabled = await this.service.isMakerCheckerEnabled();
+    return { enabled };
+  }
+
   @Get()
   list(@Query() query: ListOtherIncomeQueryDto) {
     return this.service.list(query);

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   Param,
   ParseUUIDPipe,
   Patch,
@@ -26,6 +27,9 @@ import { CreateOtherIncomeDto } from './dto/create-other-income.dto';
 import { UpdateOtherIncomeDto } from './dto/update-other-income.dto';
 import { PostOtherIncomeDto } from './dto/post-other-income.dto';
 import { ReverseOtherIncomeDto } from './dto/reverse-other-income.dto';
+import { RequestApprovalDto } from './dto/request-approval.dto';
+import { ApproveOtherIncomeDto } from './dto/approve-other-income.dto';
+import { RejectOtherIncomeDto } from './dto/reject-other-income.dto';
 import { ListOtherIncomeQueryDto } from './dto/list-other-income-query.dto';
 import { DailySheetQueryDto } from './dto/daily-sheet-query.dto';
 
@@ -101,6 +105,35 @@ export class OtherIncomeController {
     @CurrentUser('id') userId: string,
   ) {
     return this.service.reverse(id, dto, userId);
+  }
+
+  @Post(':id/request-approval')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @HttpCode(200)
+  requestApproval(@Param('id', new ParseUUIDPipe()) id: string, @CurrentUser('id') userId: string) {
+    return this.service.requestApproval(id, userId);
+  }
+
+  @Post(':id/approve')
+  @Roles('OWNER')
+  @HttpCode(200)
+  approve(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: ApproveOtherIncomeDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.service.approve(id, dto, userId);
+  }
+
+  @Post(':id/reject')
+  @Roles('OWNER')
+  @HttpCode(200)
+  reject(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: RejectOtherIncomeDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.service.reject(id, dto, userId);
   }
 
   @Post(':id/copy')

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -220,6 +220,193 @@ export class OtherIncomeService {
   }
 
   // -------------------------------------------------------------------------
+  // requestApproval(): PR-2 — DRAFT → READY
+  // -------------------------------------------------------------------------
+
+  /**
+   * PR-2: DRAFT → READY. Only callable when Maker-Checker flag is enabled.
+   * Maker initiates the approval cycle. State stays in DRAFT until approver acts.
+   */
+  async requestApproval(id: string, userId: string) {
+    if (!(await this.isMakerCheckerEnabled())) {
+      throw new BadRequestException('Maker-Checker disabled — use POST directly');
+    }
+    const doc = await this.findOneOrFail(id);
+    if (doc.status !== OtherIncomeStatus.DRAFT) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — ไม่สามารถส่งขออนุมัติได้`,
+      );
+    }
+    // Reset any prior reject metadata (re-submission after rejection)
+    return this.prisma.otherIncome.update({
+      where: { id },
+      data: {
+        status: OtherIncomeStatus.READY,
+        rejectedAt: null,
+        rejectedById: null,
+        rejectNote: null,
+      },
+      include: { items: true, adjustments: true },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // approve(): PR-2 — READY → POSTED atomic
+  // -------------------------------------------------------------------------
+
+  /**
+   * PR-2: READY → POSTED atomically (APPROVED is transient inside tx).
+   * V9: approver must differ from maker (createdById).
+   */
+  async approve(
+    id: string,
+    dto: { note?: string },
+    userId: string,
+  ) {
+    if (!(await this.isMakerCheckerEnabled())) {
+      throw new BadRequestException('Maker-Checker disabled');
+    }
+    const doc = await this.findOneOrFail(id);
+    if (doc.status !== OtherIncomeStatus.READY) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — ไม่สามารถอนุมัติ`,
+      );
+    }
+    // V9: maker ≠ approver
+    if (doc.createdById === userId) {
+      throw new BadRequestException({
+        message: 'Validation failed',
+        errors: [
+          {
+            rule: 'V9',
+            msg: 'ผู้สร้างเอกสารไม่สามารถอนุมัติเอกสารตัวเองได้',
+          },
+        ],
+      });
+    }
+
+    // Re-run validation (period lock, balance, etc.)
+    const companyId = await this.resolveFinanceCompanyId();
+    await validatePeriodOpen(this.prisma, doc.issueDate, companyId);
+
+    const threshold = await this.getAttachmentThreshold();
+    const validationDoc = {
+      issueDate: doc.issueDate,
+      paymentAccountCode: doc.paymentAccountCode,
+      amountReceived: new D(doc.amountReceived.toString()),
+      netReceived: new D(doc.netReceived.toString()),
+      items: doc.items.map((it) => ({
+        lineNo: it.lineNo,
+        accountCode: it.accountCode,
+        vatPct: new D(it.vatPct.toString()),
+        whtPct: new D(it.whtPct.toString()),
+        amountBeforeVat: new D(it.amountBeforeVat.toString()),
+        vatAmount: new D(it.vatAmount.toString()),
+        whtAmount: new D(it.whtAmount.toString()),
+      })),
+      adjustments: doc.adjustments.map((a) => ({
+        lineNo: a.lineNo,
+        accountCode: a.accountCode,
+        amount: new D(a.amount.toString()),
+      })),
+    };
+    const { errors } = this.validation.validate(validationDoc, {
+      isPeriodOpen: () => true,
+      attachmentThreshold: threshold,
+      hasAttachment: doc.attachments.length > 0,
+    });
+    if (errors.length > 0) {
+      throw new BadRequestException({ message: 'ไม่ผ่านการตรวจสอบก่อนอนุมัติ', errors });
+    }
+
+    const jeLines = this.autoJournal.generate({
+      paymentAccountCode: doc.paymentAccountCode,
+      amountReceived: new D(doc.amountReceived.toString()),
+      netReceived: new D(doc.netReceived.toString()),
+      items: doc.items.map((it) => ({
+        lineNo: it.lineNo,
+        accountCode: it.accountCode,
+        accountName: it.accountName,
+        description: it.description ?? undefined,
+        amountBeforeVat: new D(it.amountBeforeVat.toString()),
+        vatAmount: new D(it.vatAmount.toString()),
+        whtAmount: new D(it.whtAmount.toString()),
+        whtPct: new D(it.whtPct.toString()),
+      })),
+      adjustments: doc.adjustments.map((a) => ({
+        lineNo: a.lineNo,
+        accountCode: a.accountCode,
+        amount: new D(a.amount.toString()),
+        note: a.note ?? undefined,
+      })),
+    });
+
+    return this.prisma.$transaction(async (tx) => {
+      const receiptNo = await this.docNumber.nextReceiptNumber(tx, doc.issueDate);
+      const now = new Date();
+
+      const je = await this.template.post(
+        {
+          description: `รายได้อื่น ${doc.docNumber}${doc.counterpartyName ? ` — ${doc.counterpartyName}` : ''}`,
+          entryDate: doc.issueDate,
+          otherIncomeId: doc.id,
+          docNumber: doc.docNumber,
+          lines: jeLines,
+        },
+        tx,
+      );
+
+      return tx.otherIncome.update({
+        where: { id },
+        data: {
+          status: OtherIncomeStatus.POSTED,
+          receiptNo,
+          journalEntryId: je.id,
+          approverId: userId,
+          approvedAt: now,
+          approveNote: dto.note ?? null,
+          postedAt: now,
+        },
+        include: { items: true, adjustments: true },
+      });
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // reject(): PR-2 — READY → DRAFT
+  // -------------------------------------------------------------------------
+
+  /** PR-2: READY → DRAFT. Persists rejection note + rejecter. */
+  async reject(
+    id: string,
+    dto: { note: string },
+    userId: string,
+  ) {
+    if (!(await this.isMakerCheckerEnabled())) {
+      throw new BadRequestException('Maker-Checker disabled');
+    }
+    if (!dto.note || dto.note.trim().length === 0) {
+      throw new BadRequestException('กรุณาระบุหมายเหตุการปฏิเสธ');
+    }
+    const doc = await this.findOneOrFail(id);
+    if (doc.status !== OtherIncomeStatus.READY) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — ไม่สามารถปฏิเสธได้`,
+      );
+    }
+    return this.prisma.otherIncome.update({
+      where: { id },
+      data: {
+        status: OtherIncomeStatus.DRAFT,
+        rejectedById: userId,
+        rejectedAt: new Date(),
+        rejectNote: dto.note,
+      },
+      include: { items: true, adjustments: true },
+    });
+  }
+
+  // -------------------------------------------------------------------------
   // post(): DRAFT → POSTED
   // -------------------------------------------------------------------------
 

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -1008,7 +1008,7 @@ export class OtherIncomeService {
   }
 
   /** Read OTHER_INCOME_MAKER_CHECKER_ENABLED from SystemConfig. Default false. */
-  private async isMakerCheckerEnabled(): Promise<boolean> {
+  async isMakerCheckerEnabled(): Promise<boolean> {
     try {
       const row = await this.prisma.systemConfig.findUnique({
         where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -820,6 +820,18 @@ export class OtherIncomeService {
     return co.id;
   }
 
+  /** Read OTHER_INCOME_MAKER_CHECKER_ENABLED from SystemConfig. Default false. */
+  async isMakerCheckerEnabled(): Promise<boolean> {
+    try {
+      const row = await this.prisma.systemConfig.findUnique({
+        where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      });
+      return row?.value === 'true';
+    } catch {
+      return false;
+    }
+  }
+
   /** Read OTHER_INCOME_ATTACHMENT_THRESHOLD from SystemConfig. Falls back to 50_000. */
   async getAttachmentThreshold(): Promise<number> {
     try {

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -1008,7 +1008,7 @@ export class OtherIncomeService {
   }
 
   /** Read OTHER_INCOME_MAKER_CHECKER_ENABLED from SystemConfig. Default false. */
-  async isMakerCheckerEnabled(): Promise<boolean> {
+  private async isMakerCheckerEnabled(): Promise<boolean> {
     try {
       const row = await this.prisma.systemConfig.findUnique({
         where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -103,7 +103,7 @@ export class OtherIncomeService {
     const existing = await this.findOneOrFail(id);
     if (existing.status !== OtherIncomeStatus.DRAFT) {
       throw new ConflictException(
-        `เอกสาร ${existing.docNumber} เป็น POSTED แล้ว ไม่สามารถแก้ไขได้ — ใช้ Reverse Entry`,
+        `เอกสาร ${existing.docNumber} สถานะ ${existing.status} — ไม่สามารถแก้ไขได้ใน DRAFT เท่านั้น`,
       );
     }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -147,6 +147,9 @@ const OtherIncomeEntryPage = lazy(() => import('@/pages/other-income/OtherIncome
 const OtherIncomeViewPage = lazy(() => import('@/pages/other-income/OtherIncomeViewPage'));
 const OtherIncomeReceiptPage = lazy(() => import('@/pages/other-income/OtherIncomeReceiptPage'));
 const OtherIncomeDailySheetPage = lazy(() => import('@/pages/other-income/OtherIncomeDailySheetPage'));
+const OtherIncomePendingApprovalPage = lazy(
+  () => import('@/pages/other-income/OtherIncomePendingApprovalPage'),
+);
 const PeriodClosePage = lazy(() => import('@/pages/accounting/PeriodClosePage'));
 
 const PageLoader = () => (
@@ -1002,6 +1005,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <OtherIncomeDailySheetPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/other-income/pending-approval"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <OtherIncomePendingApprovalPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -77,6 +77,9 @@ export const otherIncomeApi = {
       .get<{ threshold: number }>('/other-income/config/attachment-threshold')
       .then((r) => r.data.threshold),
 
+  isMakerCheckerEnabled: () =>
+    api.get<{ enabled: boolean }>('/other-income/maker-checker-enabled').then((r) => r.data.enabled),
+
   requestApproval: (id: string) =>
     api.post(`/other-income/${id}/request-approval`).then((r) => r.data),
 

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -76,4 +76,13 @@ export const otherIncomeApi = {
     api
       .get<{ threshold: number }>('/other-income/config/attachment-threshold')
       .then((r) => r.data.threshold),
+
+  requestApproval: (id: string) =>
+    api.post(`/other-income/${id}/request-approval`).then((r) => r.data),
+
+  approve: (id: string, note?: string) =>
+    api.post(`/other-income/${id}/approve`, { note }).then((r) => r.data),
+
+  reject: (id: string, note: string) =>
+    api.post(`/other-income/${id}/reject`, { note }).then((r) => r.data),
 };

--- a/apps/web/src/lib/otherIncome.types.ts
+++ b/apps/web/src/lib/otherIncome.types.ts
@@ -1,4 +1,4 @@
-export type OtherIncomeStatus = 'DRAFT' | 'POSTED' | 'REVERSED';
+export type OtherIncomeStatus = 'DRAFT' | 'READY' | 'POSTED' | 'REVERSED';
 export type OtherIncomePriceType = 'EXCLUSIVE' | 'INCLUSIVE';
 export type OtherIncomeReverseReason =
   | 'INPUT_ERROR'
@@ -67,6 +67,8 @@ export interface OtherIncome {
   isOverridden: boolean;
   customerNote: string | null;
   createdById: string;
+  rejectNote: string | null;
+  rejectedAt: string | null;
   postedAt: string | null;
   reversesId: string | null;
   // Auto-derived inverse of the self-FK `reversesId`; populated by the API when

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -319,6 +319,32 @@ export default function OtherIncomeEntryPage() {
     onError: () => toast.error('ไม่สามารถ POST เอกสารได้'),
   });
 
+  const flagQuery = useQuery({
+    queryKey: ['other-income-maker-checker-enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+    staleTime: 5 * 60_000,
+  });
+  const makerCheckerEnabled = flagQuery.data ?? false;
+
+  const saveAndRequestApprovalMutation = useMutation({
+    mutationFn: async (data: OtherIncomeFormValues) => {
+      let docId = id;
+      if (!docId) {
+        const created = await otherIncomeApi.create(data);
+        docId = created.id;
+      } else {
+        await otherIncomeApi.update(docId, data);
+      }
+      return otherIncomeApi.requestApproval(docId);
+    },
+    onSuccess: (doc: any) => {
+      toast.success('บันทึกและส่งขออนุมัติแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income'] });
+      navigate(`/other-income/${doc.id}`);
+    },
+    onError: () => toast.error('ส่งขออนุมัติไม่สำเร็จ'),
+  });
+
   const values = form.watch();
 
   // Compute live JE preview
@@ -367,7 +393,10 @@ export default function OtherIncomeEntryPage() {
 
   const watchedAdjustments = form.watch('adjustments') ?? [];
 
-  const isSubmitting = saveDraftMutation.isPending || saveAndPostMutation.isPending;
+  const isSubmitting =
+    saveDraftMutation.isPending ||
+    saveAndPostMutation.isPending ||
+    saveAndRequestApprovalMutation.isPending;
 
   // Income totals across all items (for footer/summary cards)
   const incomeTotals = useMemo(() => {
@@ -1040,12 +1069,22 @@ export default function OtherIncomeEntryPage() {
                   toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
                   return;
                 }
-                saveAndPostMutation.mutate(result.data);
+                if (makerCheckerEnabled) {
+                  saveAndRequestApprovalMutation.mutate(result.data);
+                } else {
+                  saveAndPostMutation.mutate(result.data);
+                }
               }}
               className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <Send size={14} />
-              {saveAndPostMutation.isPending ? 'กำลัง POST...' : 'บันทึก & POST'}
+              {saveAndRequestApprovalMutation.isPending
+                ? 'กำลังส่งขออนุมัติ...'
+                : saveAndPostMutation.isPending
+                  ? 'กำลัง POST...'
+                  : makerCheckerEnabled
+                    ? 'บันทึกและส่งขออนุมัติ'
+                    : 'บันทึก & POST'}
             </button>
           </div>
         </div>

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, ArrowRight } from 'lucide-react';
+import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, ArrowRight, ClipboardCheck } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -15,12 +15,14 @@ import { formatNumberDecimal } from '@/utils/formatters';
 
 const STATUS_LABELS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'ร่าง',
+  READY: 'รออนุมัติ',
   POSTED: 'บันทึกแล้ว',
   REVERSED: 'กลับรายการ',
 };
 
 const STATUS_COLORS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'bg-muted text-muted-foreground',
+  READY: 'bg-warning/10 text-warning',
   POSTED: 'bg-success/10 text-success',
   REVERSED: 'bg-destructive/10 text-destructive',
 };
@@ -45,16 +47,18 @@ function fmtDate(d: string | null | undefined) {
   return formatThaiDateShort(d);
 }
 
-type StatusAccent = 'warning' | 'success' | 'muted';
+type StatusAccent = 'warning' | 'info' | 'success' | 'muted';
 
 const ACCENT_BAR: Record<StatusAccent, string> = {
   warning: 'bg-warning',
+  info: 'bg-info',
   success: 'bg-success',
   muted: 'bg-muted-foreground/50',
 };
 
 const ACCENT_ICON: Record<StatusAccent, string> = {
   warning: 'bg-warning/10 text-warning',
+  info: 'bg-info/10 text-info',
   success: 'bg-success/10 text-success',
   muted: 'bg-muted text-muted-foreground',
 };
@@ -138,6 +142,21 @@ export default function OtherIncomeListPage() {
     staleTime: COUNT_STALE_TIME,
   });
 
+  const flagQuery = useQuery({
+    queryKey: ['other-income-maker-checker-enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+    staleTime: 5 * 60_000,
+  });
+  const makerCheckerEnabled = flagQuery.data ?? false;
+
+  const readyCountQuery = useQuery({
+    queryKey: ['other-income', 'count', 'READY'],
+    queryFn: () => otherIncomeApi.list({ status: 'READY', page: 1, limit: 1 }),
+    select: (d) => d.total,
+    staleTime: COUNT_STALE_TIME,
+    enabled: makerCheckerEnabled,
+  });
+
   const deleteMutation = useMutation({
     mutationFn: (id: string) => otherIncomeApi.softDelete(id),
     onSuccess: () => {
@@ -153,6 +172,7 @@ export default function OtherIncomeListPage() {
   const totalPages = Math.ceil(total / 50) || 1;
 
   const draftCount = draftCountQuery.data ?? 0;
+  const readyCount = readyCountQuery.data ?? 0;
   const postedCount = postedCountQuery.data ?? 0;
   const reversedCount = reversedCountQuery.data ?? 0;
 
@@ -175,7 +195,7 @@ export default function OtherIncomeListPage() {
       />
 
       {/* Status cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+      <div className={`grid gap-3 mb-6 ${makerCheckerEnabled ? 'grid-cols-2 md:grid-cols-5' : 'grid-cols-2 md:grid-cols-4'}`}>
         <StatusCard
           label="ฉบับร่าง"
           sub="DRAFT"
@@ -183,6 +203,15 @@ export default function OtherIncomeListPage() {
           accent="warning"
           value={draftCount}
         />
+        {makerCheckerEnabled && (
+          <StatusCard
+            label="รออนุมัติ"
+            sub="READY"
+            icon={<ClipboardCheck size={16} />}
+            accent="info"
+            value={readyCount}
+          />
+        )}
         <StatusCard
           label="บันทึกแล้ว"
           sub="POSTED"
@@ -239,6 +268,7 @@ export default function OtherIncomeListPage() {
         >
           <option value="">ทุกสถานะ</option>
           <option value="DRAFT">ร่าง</option>
+          {makerCheckerEnabled && <option value="READY">รออนุมัติ</option>}
           <option value="POSTED">บันทึกแล้ว</option>
           <option value="REVERSED">กลับรายการ</option>
         </select>

--- a/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
@@ -4,6 +4,8 @@ import { Clock, Inbox } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { otherIncomeApi } from '@/lib/otherIncome';
+import { formatThaiDateShort } from '@/lib/date';
+import { formatNumberDecimal } from '@/utils/formatters';
 
 export default function OtherIncomePendingApprovalPage() {
   const navigate = useNavigate();
@@ -54,7 +56,7 @@ export default function OtherIncomePendingApprovalPage() {
                   >
                     <td className="px-4 py-2 font-mono font-semibold text-primary">{d.docNumber}</td>
                     <td className="px-4 py-2 text-muted-foreground">
-                      {new Date(d.issueDate).toLocaleDateString('th-TH')}
+                      {formatThaiDateShort(d.issueDate)}
                     </td>
                     <td className="px-4 py-2">
                       {d.counterpartyName ?? d.customer?.name ?? (
@@ -62,9 +64,7 @@ export default function OtherIncomePendingApprovalPage() {
                       )}
                     </td>
                     <td className="px-4 py-2 text-right font-mono">
-                      {Number(d.amountReceived).toLocaleString('en-US', {
-                        minimumFractionDigits: 2,
-                      })}
+                      {formatNumberDecimal(d.amountReceived)}
                     </td>
                     <td className="px-4 py-2 text-right">
                       <Clock size={14} className="inline text-warning" />

--- a/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
@@ -1,0 +1,81 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
+import { Clock, Inbox } from 'lucide-react';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { otherIncomeApi } from '@/lib/otherIncome';
+
+export default function OtherIncomePendingApprovalPage() {
+  const navigate = useNavigate();
+  const query = useQuery({
+    queryKey: ['other-income', 'list', { status: 'READY' }],
+    queryFn: () => otherIncomeApi.list({ status: 'READY', limit: 100 }),
+  });
+
+  const data = query.data;
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <PageHeader
+        title="เอกสารรออนุมัติ"
+        subtitle="รายได้อื่น"
+        icon={<Clock size={20} />}
+        onBack={() => navigate('/other-income')}
+      />
+      <QueryBoundary
+        isLoading={query.isLoading}
+        isError={query.isError}
+        error={query.error}
+        onRetry={query.refetch}
+      >
+        {data && data.data.length === 0 ? (
+          <div className="text-center py-16 text-muted-foreground">
+            <Inbox className="mx-auto mb-3 opacity-50" size={40} />
+            <p>ไม่มีเอกสารรออนุมัติ</p>
+          </div>
+        ) : (
+          <div className="rounded-xl border bg-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-xs font-medium text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2 text-left">เลขที่</th>
+                  <th className="px-4 py-2 text-left">วันที่</th>
+                  <th className="px-4 py-2 text-left">ผู้ติดต่อ</th>
+                  <th className="px-4 py-2 text-right">ยอดรับ</th>
+                  <th className="px-4 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data?.data ?? []).map((d) => (
+                  <tr
+                    key={d.id}
+                    className="border-t hover:bg-accent/30 cursor-pointer"
+                    onClick={() => navigate(`/other-income/${d.id}`)}
+                  >
+                    <td className="px-4 py-2 font-mono font-semibold text-primary">{d.docNumber}</td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {new Date(d.issueDate).toLocaleDateString('th-TH')}
+                    </td>
+                    <td className="px-4 py-2">
+                      {d.counterpartyName ?? d.customer?.name ?? (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono">
+                      {Number(d.amountReceived).toLocaleString('en-US', {
+                        minimumFractionDigits: 2,
+                      })}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <Clock size={14} className="inline text-warning" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Check, CheckCircle2, Clock, Copy, Edit, History, Printer, Ro
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ReverseModal } from './components/ReverseModal';
+import { RejectModal } from './components/RejectModal';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus, OtherIncomeReverseReason } from '@/lib/otherIncome.types';
@@ -137,6 +138,7 @@ export default function OtherIncomeViewPage() {
   const { user } = useAuth();
 
   const [showReverseModal, setShowReverseModal] = useState(false);
+  const [showRejectModal, setShowRejectModal] = useState(false);
 
   const auditQuery = useQuery({
     queryKey: ['other-income', id, 'audit'],
@@ -300,10 +302,7 @@ export default function OtherIncomeViewPage() {
                       </button>
                       <button
                         type="button"
-                        onClick={() => {
-                          const note = window.prompt('เหตุผลการปฏิเสธ:');
-                          if (note?.trim()) rejectMutation.mutate(note.trim());
-                        }}
+                        onClick={() => setShowRejectModal(true)}
                         disabled={rejectMutation.isPending}
                         className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold border border-destructive text-destructive rounded-lg hover:bg-destructive/10 disabled:opacity-50"
                       >
@@ -675,6 +674,19 @@ export default function OtherIncomeViewPage() {
           onCancel={() => setShowReverseModal(false)}
           onConfirm={(reason, note) => reverseMutation.mutate({ reason, note })}
           isLoading={reverseMutation.isPending}
+        />
+      )}
+
+      {/* Reject modal (PR-2 Maker-Checker) */}
+      {showRejectModal && doc && (
+        <RejectModal
+          docNumber={doc.docNumber}
+          isLoading={rejectMutation.isPending}
+          onCancel={() => setShowRejectModal(false)}
+          onConfirm={(note) => {
+            rejectMutation.mutate(note);
+            setShowRejectModal(false);
+          }}
         />
       )}
     </div>

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -313,7 +313,7 @@ export default function OtherIncomeViewPage() {
                     </>
                   ) : user?.role === 'OWNER' && doc.createdById === user.id ? (
                     <div className="rounded-md bg-muted text-muted-foreground text-sm px-3 py-2">
-                      ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้ (V9)
+                      ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้
                     </div>
                   ) : (
                     <div className="rounded-md bg-info/10 text-info text-sm px-3 py-2 inline-flex items-center gap-1">

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -18,12 +18,14 @@ import { formatThaiDateLong } from '@/lib/date';
 
 const STATUS_LABELS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'ร่าง',
+  READY: 'รออนุมัติ',
   POSTED: 'บันทึกแล้ว',
   REVERSED: 'กลับรายการแล้ว',
 };
 
 const STATUS_COLORS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'bg-muted text-muted-foreground',
+  READY: 'bg-warning/10 text-warning',
   POSTED: 'bg-success/10 text-success',
   REVERSED: 'bg-destructive/10 text-destructive',
 };

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { ArrowLeft, CheckCircle2, Copy, Edit, History, Printer, RotateCcw, Receipt, FileText } from 'lucide-react';
+import { ArrowLeft, Check, CheckCircle2, Clock, Copy, Edit, History, Printer, RotateCcw, Receipt, FileText, Send, X } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ReverseModal } from './components/ReverseModal';
@@ -172,13 +172,52 @@ export default function OtherIncomeViewPage() {
     onError: () => toast.error('ไม่สามารถคัดลอกเอกสารได้'),
   });
 
+  const flagQuery = useQuery({
+    queryKey: ['other-income-maker-checker-enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+    staleTime: 5 * 60_000,
+  });
+  const makerCheckerEnabled = flagQuery.data ?? false;
+
+  const requestApprovalMutation = useMutation({
+    mutationFn: () => otherIncomeApi.requestApproval(id!),
+    onSuccess: () => {
+      toast.success('ส่งขออนุมัติแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income', id] });
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'ส่งขออนุมัติไม่สำเร็จ'),
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (note: string | undefined) => otherIncomeApi.approve(id!, note),
+    onSuccess: () => {
+      toast.success('อนุมัติและบันทึกบัญชีเรียบร้อย');
+      queryClient.invalidateQueries({ queryKey: ['other-income', id] });
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'อนุมัติไม่สำเร็จ'),
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: (note: string) => otherIncomeApi.reject(id!, note),
+    onSuccess: () => {
+      toast.success('ปฏิเสธคำขอแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income', id] });
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'ปฏิเสธไม่สำเร็จ'),
+  });
+
   const canReverse =
     user?.role && REVERSE_ROLES.includes(user.role) && docQuery.data?.status === 'POSTED';
 
   const doc = docQuery.data;
   const jeLines = doc ? buildJeFromDoc(doc) : [];
 
-  const isActionLoading = reverseMutation.isPending || copyMutation.isPending;
+  const isActionLoading =
+    reverseMutation.isPending ||
+    copyMutation.isPending ||
+    requestApprovalMutation.isPending ||
+    approveMutation.isPending ||
+    rejectMutation.isPending;
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
@@ -210,14 +249,79 @@ export default function OtherIncomeViewPage() {
                 </button>
               )}
               {doc.status === 'DRAFT' && (
-                <button
-                  type="button"
-                  onClick={() => navigate(`/other-income/${doc.id}/edit`)}
-                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
-                >
-                  <Edit size={14} />
-                  แก้ไข
-                </button>
+                <>
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/other-income/${doc.id}/edit`)}
+                    className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
+                  >
+                    <Edit size={14} />
+                    แก้ไข
+                  </button>
+                  {makerCheckerEnabled ? (
+                    <button
+                      type="button"
+                      onClick={() => requestApprovalMutation.mutate()}
+                      disabled={requestApprovalMutation.isPending}
+                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      <Send size={14} />
+                      ส่งขออนุมัติ
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/other-income/${doc.id}/edit`)}
+                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90"
+                    >
+                      <Check size={14} />
+                      แก้ไขและ POST
+                    </button>
+                  )}
+                </>
+              )}
+              {doc.status === 'READY' && (
+                <>
+                  {doc.rejectNote && (
+                    <div className="rounded-md bg-warning/10 text-warning text-xs px-3 py-2">
+                      เคยถูกปฏิเสธ: {doc.rejectNote}
+                    </div>
+                  )}
+                  {user?.role === 'OWNER' && doc.createdById !== user.id ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => approveMutation.mutate(undefined)}
+                        disabled={approveMutation.isPending}
+                        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                      >
+                        <Check size={14} />
+                        อนุมัติ + POST
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const note = window.prompt('เหตุผลการปฏิเสธ:');
+                          if (note?.trim()) rejectMutation.mutate(note.trim());
+                        }}
+                        disabled={rejectMutation.isPending}
+                        className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold border border-destructive text-destructive rounded-lg hover:bg-destructive/10 disabled:opacity-50"
+                      >
+                        <X size={14} />
+                        ปฏิเสธ
+                      </button>
+                    </>
+                  ) : user?.role === 'OWNER' && doc.createdById === user.id ? (
+                    <div className="rounded-md bg-muted text-muted-foreground text-sm px-3 py-2">
+                      ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้ (V9)
+                    </div>
+                  ) : (
+                    <div className="rounded-md bg-info/10 text-info text-sm px-3 py-2 inline-flex items-center gap-1">
+                      <Clock size={14} />
+                      รออนุมัติจาก OWNER
+                    </div>
+                  )}
+                </>
               )}
               {canReverse && (
                 <button
@@ -486,14 +590,36 @@ export default function OtherIncomeViewPage() {
               {doc.status === 'DRAFT' && (
                 <div className="rounded-xl border bg-card p-5 space-y-2">
                   <p className="text-sm text-muted-foreground">เอกสารนี้ยังเป็นร่าง — ยังไม่มี Journal Entry</p>
-                  <button
-                    type="button"
-                    onClick={() => navigate(`/other-income/${doc.id}/edit`)}
-                    className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90"
-                  >
-                    <Edit size={14} />
-                    แก้ไขและ POST
-                  </button>
+                  {makerCheckerEnabled ? (
+                    <button
+                      type="button"
+                      onClick={() => requestApprovalMutation.mutate()}
+                      disabled={requestApprovalMutation.isPending}
+                      className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      <Send size={14} />
+                      ส่งขออนุมัติ
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/other-income/${doc.id}/edit`)}
+                      className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90"
+                    >
+                      <Edit size={14} />
+                      แก้ไขและ POST
+                    </button>
+                  )}
+                </div>
+              )}
+              {/* READY shortcut info */}
+              {doc.status === 'READY' && (
+                <div className="rounded-xl border bg-card p-5 space-y-2">
+                  <div className="inline-flex items-center gap-2 text-warning text-sm font-semibold">
+                    <Clock size={16} />
+                    รออนุมัติ
+                  </div>
+                  <p className="text-xs text-muted-foreground">เอกสารนี้รอการอนุมัติจาก OWNER — ยังไม่มี Journal Entry</p>
                 </div>
               )}
             </div>

--- a/apps/web/src/pages/other-income/components/RejectModal.tsx
+++ b/apps/web/src/pages/other-income/components/RejectModal.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { XCircle } from 'lucide-react';
+
+interface Props {
+  docNumber: string;
+  onCancel: () => void;
+  onConfirm: (note: string) => void;
+  isLoading?: boolean;
+}
+
+export function RejectModal({ docNumber, onCancel, onConfirm, isLoading }: Props) {
+  const [note, setNote] = useState('');
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+      <div className="bg-background rounded-2xl border-2 border-destructive max-w-2xl w-full p-6">
+        <h3 className="text-lg font-bold flex items-center gap-2 text-destructive mb-3">
+          <XCircle size={20} /> ปฏิเสธคำขออนุมัติ
+        </h3>
+        <p className="text-sm mb-4">
+          ปฏิเสธเอกสาร <span className="font-mono font-bold">{docNumber}</span> —
+          ระบบจะส่งเอกสารกลับเป็นสถานะ DRAFT พร้อมเหตุผลของผู้ปฏิเสธ
+        </p>
+        <label className="text-xs font-semibold uppercase">เหตุผลการปฏิเสธ</label>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          autoFocus
+          placeholder="เหตุผลการปฏิเสธ"
+          className="w-full border rounded-md px-3 py-2 text-sm"
+        />
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            onClick={onCancel}
+            type="button"
+            className="px-4 py-2 text-sm font-semibold rounded-md border"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={() => onConfirm(note.trim())}
+            disabled={note.trim().length === 0 || isLoading}
+            className="px-5 py-2 text-sm font-bold rounded-md bg-destructive text-destructive-foreground disabled:opacity-50"
+          >
+            {isLoading ? 'กำลังปฏิเสธ...' : 'ปฏิเสธ'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds opt-in Maker-Checker approval workflow to Other Income per accountant PDF Task T8.

- **Flag**: SystemConfig `OTHER_INCOME_MAKER_CHECKER_ENABLED` (default `false` → no behavior change)
- **Workflow when ON**: DRAFT → READY → APPROVED → POSTED (APPROVED is transient — never persisted; approve() does READY → POSTED atomically in `$transaction`)
- **Workflow when OFF**: DRAFT → POSTED (unchanged, fully backward compatible)
- **V9**: maker ≠ approver enforced inside `approve()` (`createdById !== userId`)
- **Approver role**: OWNER only

## Schema (migration `20260920000000_add_other_income_maker_checker`)

- `OtherIncomeStatus` enum gains `READY` + `APPROVED`
- `OtherIncome` gains 6 nullable columns: `approver_id`, `approved_at`, `approve_note`, `rejected_by_id`, `rejected_at`, `reject_note`
- 2 FKs to `users(id)` with `ON DELETE SET NULL`
- All additive — existing rows untouched, no backfill needed

## New endpoints

- `GET  /other-income/maker-checker-enabled` — `{ enabled: boolean }` (used by frontend to gate UI)
- `POST /other-income/:id/request-approval` (OWNER, ACCOUNTANT, SALES) — DRAFT → READY
- `POST /other-income/:id/approve` (OWNER) — READY → POSTED atomic
- `POST /other-income/:id/reject` (OWNER) — READY → DRAFT with mandatory note

## UI

- **ListPage**: 5th status card \"รออนุมัติ\" (only when flag = true), READY filter option
- **ViewPage**: status-aware action bar
  - DRAFT + flag on: [ส่งขออนุมัติ]
  - READY + OWNER + not maker: [อนุมัติ + POST] [ปฏิเสธ] (modal-based reject note)
  - READY + OWNER + maker: V9 banner
  - READY + others: \"รออนุมัติจาก OWNER\"
- **PendingApprovalPage** (new route `/other-income/pending-approval`): list of READY docs
- **EntryPage**: submit button label adapts (\"บันทึกและส่งขออนุมัติ\" when flag on)

Spec: \`docs/superpowers/specs/2026-05-12-other-income-v2-1-pdf-gap-fixes-design.md\`
Plan: \`docs/superpowers/plans/2026-05-12-other-income-v2-1-pr2-maker-checker.md\`

## Commits (15)

Schema + service: \`cf37bb95\` → \`fcd29533\`
Controller + web client: \`78a817a4\` → \`c764108e\`
Flag endpoint: \`bea3d88a\`
UI: \`56fc7038\` → \`f4956587\`
Review fixes: \`24c8d052\` (Thai date + currency helpers + V9 rule code), \`09621f31\` (RejectModal + service error msg)

## Test plan

- [x] V9: createdById === approverId → 400 with rule V9
- [x] approve() atomically posts (single $transaction) — receipt + JE in one tx
- [x] APPROVED enum value never observable in persisted state (transient)
- [x] reject() requires non-empty note, restores DRAFT, persists rejecter metadata
- [x] requestApproval() clears prior rejection metadata on re-submission
- [x] Flag off: new endpoints all return 400 \"Maker-Checker disabled\"
- [x] Flag off: legacy POST flow unchanged (DRAFT → POSTED)
- [x] UI dedupes flag query across 4 pages (same React Query key)
- [x] Route ordering: literal paths (`maker-checker-enabled`, `pending-approval`) BEFORE `:id` in both controller and App.tsx
- [x] Schema migration additive (6 nullable cols + enum extension + 2 FKs `ON DELETE SET NULL`)
- [x] Thai date + currency helpers used (no raw `toLocaleDateString` on user-facing data)
- [x] No `window.prompt`/`alert`/`confirm` (RejectModal instead)
- [x] 22/22 service tests pass (12 maker-checker + 10 pre-existing)
- [x] tsc 0 errors (api + web)

## Backward compatibility

Toggle flag = false (default) → zero behavior change from main. Verified by:
- Schema migration adds nullable columns only
- New enum values don’t affect existing switch statements
- New endpoints return 400 when flag off (graceful no-op)
- ListPage 5th card hidden when flag off (back to 4)
- ViewPage falls through to legacy [แก้ไขและ POST] when flag off
- EntryPage falls through to legacy POST flow when flag off

🤖 Generated with [Claude Code](https://claude.com/claude-code)