### PR TITLE
feat(other-income): v2.1 combined — accountant Gap Analysis Report (PR-1+PR-2+PR-3)

### DIFF
--- a/apps/api/prisma/migrations/20260920000000_add_other_income_maker_checker/migration.sql
+++ b/apps/api/prisma/migrations/20260920000000_add_other_income_maker_checker/migration.sql
@@ -1,0 +1,19 @@
+-- Add READY + APPROVED to OtherIncomeStatus enum
+ALTER TYPE "OtherIncomeStatus" ADD VALUE 'READY';
+ALTER TYPE "OtherIncomeStatus" ADD VALUE 'APPROVED';
+
+-- Add approver/rejecter columns (all nullable — backward-compat)
+ALTER TABLE "other_incomes"
+  ADD COLUMN "approver_id"     TEXT,
+  ADD COLUMN "approved_at"     TIMESTAMP(3),
+  ADD COLUMN "approve_note"    TEXT,
+  ADD COLUMN "rejected_by_id"  TEXT,
+  ADD COLUMN "rejected_at"     TIMESTAMP(3),
+  ADD COLUMN "reject_note"     TEXT;
+
+-- FKs to User
+ALTER TABLE "other_incomes"
+  ADD CONSTRAINT "other_incomes_approver_id_fkey"
+    FOREIGN KEY ("approver_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "other_incomes_rejected_by_id_fkey"
+    FOREIGN KEY ("rejected_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260921000000_add_other_income_template/migration.sql
+++ b/apps/api/prisma/migrations/20260921000000_add_other_income_template/migration.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "other_income_templates" (
+  "id"             TEXT NOT NULL,
+  "company_id"     TEXT NOT NULL,
+  "name"           TEXT NOT NULL,
+  "is_favorite"    BOOLEAN NOT NULL DEFAULT false,
+  "use_count"      INTEGER NOT NULL DEFAULT 0,
+  "last_used_at"   TIMESTAMP(3),
+  "items_json"     JSONB NOT NULL,
+  "price_type"     "OtherIncomePriceType" NOT NULL DEFAULT 'EXCLUSIVE',
+  "created_by_id"  TEXT NOT NULL,
+  "created_at"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"     TIMESTAMP(3) NOT NULL,
+  "deleted_at"     TIMESTAMP(3),
+
+  CONSTRAINT "other_income_templates_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "other_income_templates_company_deleted_idx"
+  ON "other_income_templates" ("company_id", "deleted_at");
+CREATE INDEX "other_income_templates_favorite_used_idx"
+  ON "other_income_templates" ("is_favorite", "last_used_at");
+
+ALTER TABLE "other_income_templates"
+  ADD CONSTRAINT "other_income_templates_company_id_fkey"
+    FOREIGN KEY ("company_id") REFERENCES "company_info"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "other_income_templates_created_by_id_fkey"
+    FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -701,6 +701,7 @@ model User {
   // Other Income module
   otherIncomesCreated    OtherIncome[]           @relation("OtherIncomeCreatedBy")
   otherIncomeAttachments OtherIncomeAttachment[] @relation("OtherIncomeAttachmentUploader")
+  otherIncomeTemplates   OtherIncomeTemplate[]   @relation("OtherIncomeTemplateCreator")
 
   @@index([branchId])
   @@index([yeastarExtension])
@@ -2979,7 +2980,8 @@ model CompanyInfo {
   taxReports         TaxReport[]
   ownedProducts      Product[]                 @relation("ProductOwnership")
   accountingPeriods  AccountingPeriod[]
-  otherIncomes       OtherIncome[]
+  otherIncomes          OtherIncome[]
+  otherIncomeTemplates  OtherIncomeTemplate[]
 
   @@map("company_info")
 }
@@ -5944,6 +5946,32 @@ model OtherIncomeAttachment {
 
   @@index([otherIncomeId])
   @@map("other_income_attachments")
+}
+
+model OtherIncomeTemplate {
+  id        String @id @default(uuid())
+  companyId String @map("company_id")
+  name      String
+
+  isFavorite Boolean   @default(false) @map("is_favorite")
+  useCount   Int       @default(0) @map("use_count")
+  lastUsedAt DateTime? @map("last_used_at")
+
+  /// JSON array of item snapshots: { lineNo, accountCode, description, quantity, unitAmount, discountAmount, vatPct, whtPct }
+  itemsJson Json                 @map("items_json")
+  priceType OtherIncomePriceType @default(EXCLUSIVE) @map("price_type")
+
+  createdById String    @map("created_by_id")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
+  deletedAt   DateTime? @map("deleted_at")
+
+  company   CompanyInfo @relation(fields: [companyId], references: [id])
+  createdBy User        @relation("OtherIncomeTemplateCreator", fields: [createdById], references: [id])
+
+  @@index([companyId, deletedAt])
+  @@index([isFavorite, lastUsedAt])
+  @@map("other_income_templates")
 }
 
 /// Maps each payment method (CASH/TRANSFER/QR) to one or more Chart-of-Accounts

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -700,6 +700,8 @@ model User {
 
   // Other Income module
   otherIncomesCreated    OtherIncome[]           @relation("OtherIncomeCreatedBy")
+  otherIncomesApproved   OtherIncome[]           @relation("OtherIncomeApprover")
+  otherIncomesRejected   OtherIncome[]           @relation("OtherIncomeRejecter")
   otherIncomeAttachments OtherIncomeAttachment[] @relation("OtherIncomeAttachmentUploader")
 
   @@index([branchId])
@@ -5780,6 +5782,8 @@ model SmsTemplate {
 
 enum OtherIncomeStatus {
   DRAFT
+  READY      // PR-2: requested for approval (Maker-Checker opt-in flow)
+  APPROVED   // PR-2: transient — approved + auto-posted in same tx
   POSTED
   REVERSED
 }
@@ -5854,10 +5858,20 @@ model OtherIncome {
   updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
 
+  // PR-2 Maker-Checker (opt-in via SystemConfig OTHER_INCOME_MAKER_CHECKER_ENABLED)
+  approverId    String?   @map("approver_id")
+  approvedAt    DateTime? @map("approved_at")
+  approveNote   String?   @map("approve_note")
+  rejectedById  String?   @map("rejected_by_id")
+  rejectedAt    DateTime? @map("rejected_at")
+  rejectNote    String?   @map("reject_note")
+
   // Relations
   company    CompanyInfo   @relation(fields: [companyId], references: [id])
   customer   Customer?     @relation("CustomerOtherIncome", fields: [customerId], references: [id])
   createdBy  User          @relation("OtherIncomeCreatedBy", fields: [createdById], references: [id])
+  approver   User?         @relation("OtherIncomeApprover", fields: [approverId], references: [id])
+  rejectedBy User?         @relation("OtherIncomeRejecter", fields: [rejectedById], references: [id])
   reverses   OtherIncome?  @relation("OtherIncomeReverse", fields: [reversesId], references: [id])
   reversedBy OtherIncome?  @relation("OtherIncomeReverse")
   copiedFrom OtherIncome?  @relation("OtherIncomeCopy", fields: [copiedFromId], references: [id])

--- a/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
@@ -1,0 +1,369 @@
+/**
+ * PR-2: Maker-Checker integration tests for OtherIncomeService.
+ * Uses real DB (matches pattern in other-income.service.spec.ts).
+ */
+
+import { Test } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { OtherIncomeService } from '../other-income.service';
+import { DocNumberService } from '../services/doc-number.service';
+import { ValidationService } from '../services/validation.service';
+import { AutoJournalService } from '../services/auto-journal.service';
+import { OtherIncomeTemplate } from '../templates/other-income.template';
+import { JournalAutoService } from '../../journal/journal-auto.service';
+import { StorageService } from '../../storage/storage.service';
+
+const stubStorage = {
+  upload: async () => undefined,
+  delete: async () => undefined,
+  getSignedUrl: async () => 'https://stub/url',
+};
+
+const D = (n: number | string) => new Prisma.Decimal(n);
+
+// ============================================================
+// Suite: Maker-Checker lifecycle (requestApproval / approve / reject)
+// ============================================================
+
+describe('OtherIncomeService — Maker-Checker', () => {
+  let service: OtherIncomeService;
+  let prisma: PrismaService;
+  let makerId: string;
+  let approverId: string;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        OtherIncomeService,
+        DocNumberService,
+        ValidationService,
+        AutoJournalService,
+        OtherIncomeTemplate,
+        JournalAutoService,
+        PrismaService,
+        { provide: StorageService, useValue: stubStorage },
+      ],
+    }).compile();
+    await module.init();
+    service = module.get(OtherIncomeService);
+    prisma = module.get(PrismaService);
+
+    // Ensure FINANCE CompanyInfo exists
+    await prisma.companyInfo.upsert({
+      where: { companyCode: 'FINANCE' },
+      update: {},
+      create: {
+        companyCode: 'FINANCE',
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000001',
+        address: 'TEST',
+        directorName: 'ผู้อำนวยการ',
+        vatRegistered: true,
+      },
+    });
+
+    // Ensure system user (required by JournalAutoService.resolveSystemUserId)
+    await prisma.user.upsert({
+      where: { email: 'admin@bestchoice.com' },
+      update: {},
+      create: {
+        email: 'admin@bestchoice.com',
+        password: 'x',
+        name: 'admin',
+        role: 'OWNER',
+      },
+    });
+
+    // Seed required CoA codes
+    const coaSeeds = [
+      { code: '42-1102', name: 'รายได้ดอกเบี้ยฝากธนาคาร', type: 'รายได้', normalBalance: 'Cr', category: 'รายได้อื่น' },
+      { code: '11-1201', name: 'ธนาคาร KBank', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'เงินฝากธนาคาร' },
+      { code: '11-4103', name: 'ลูกหนี้ภาษีหัก ณ ที่จ่าย', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'สินทรัพย์หมุนเวียน' },
+    ];
+    for (const seed of coaSeeds) {
+      await prisma.chartOfAccount.upsert({
+        where: { code: seed.code },
+        update: {},
+        create: seed,
+      });
+    }
+
+    // Create test users: maker and approver
+    const ts = Date.now();
+    const maker = await prisma.user.create({
+      data: {
+        email: `oi-maker+${ts}@bestchoice.test`,
+        password: 'x',
+        name: 'OI Maker',
+        role: 'ACCOUNTANT',
+      },
+    });
+    makerId = maker.id;
+
+    const approverUser = await prisma.user.create({
+      data: {
+        email: `oi-approver+${ts}@bestchoice.test`,
+        password: 'x',
+        name: 'OI Approver',
+        role: 'FINANCE_MANAGER',
+      },
+    });
+    approverId = approverUser.id;
+
+    // Enable Maker-Checker flag in SystemConfig
+    await prisma.systemConfig.upsert({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      update: { value: 'true' },
+      create: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED', value: 'true' },
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    // Clean up test data
+    const ois = await prisma.otherIncome.findMany({
+      where: { createdById: makerId },
+    });
+    const ourIds = ois.map((o) => o.id);
+    const jeIds = ois.filter((o) => o.journalEntryId).map((o) => o.journalEntryId as string);
+
+    await prisma.otherIncomeItem.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncomeAdjustment.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncome.deleteMany({ where: { createdById: makerId } });
+
+    if (jeIds.length > 0) {
+      await prisma.journalLine.deleteMany({ where: { journalEntryId: { in: jeIds } } });
+      await prisma.journalEntry.deleteMany({ where: { id: { in: jeIds } } });
+    }
+
+    await prisma.user.delete({ where: { id: makerId } }).catch(() => {});
+    await prisma.user.delete({ where: { id: approverId } }).catch(() => {});
+
+    // Restore Maker-Checker flag to false (avoid polluting other test suites)
+    await prisma.systemConfig.upsert({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      update: { value: 'false' },
+      create: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED', value: 'false' },
+    });
+
+    await prisma.$disconnect();
+  }, 30_000);
+
+  // Helper: create a standard KBank interest DRAFT
+  async function createStandardDraft(issueDate = '2026-05-06') {
+    return service.create(
+      {
+        issueDate,
+        priceType: 'EXCLUSIVE',
+        paymentAccountCode: '11-1201',
+        amountReceived: 850,
+        counterpartyName: 'KBank',
+        items: [
+          {
+            accountCode: '42-1102',
+            description: 'ดอกเบี้ยฝาก',
+            quantity: 1,
+            unitAmount: 1000,
+            vatPct: 0,
+            whtPct: 15,
+          },
+        ],
+      },
+      makerId,
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Task 3: requestApproval()
+  // ─────────────────────────────────────────────────────────────
+
+  it('requestApproval(): DRAFT → READY when flag enabled', async () => {
+    const draft = await createStandardDraft();
+    expect(draft.status).toBe('DRAFT');
+
+    const ready = await service.requestApproval(draft.id, makerId);
+
+    expect(ready.status).toBe('READY');
+    // Rejection metadata should be cleared
+    expect(ready.rejectedById).toBeNull();
+    expect(ready.rejectedAt).toBeNull();
+    expect(ready.rejectNote).toBeNull();
+  }, 30_000);
+
+  it('requestApproval(): 400 when Maker-Checker flag disabled', async () => {
+    // Temporarily disable the flag
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'false' },
+    });
+
+    const draft = await createStandardDraft();
+
+    await expect(service.requestApproval(draft.id, makerId)).rejects.toMatchObject({
+      message: 'Maker-Checker disabled — use POST directly',
+    });
+
+    // Re-enable for subsequent tests
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'true' },
+    });
+  }, 30_000);
+
+  it('requestApproval(): 409 when doc not in DRAFT', async () => {
+    const draft = await createStandardDraft();
+    // Force doc to POSTED state
+    await prisma.otherIncome.update({
+      where: { id: draft.id },
+      data: { status: 'POSTED', postedAt: new Date() },
+    });
+
+    await expect(service.requestApproval(draft.id, makerId)).rejects.toMatchObject({
+      status: 409,
+    });
+  }, 30_000);
+
+  // ─────────────────────────────────────────────────────────────
+  // Task 4: approve()
+  // ─────────────────────────────────────────────────────────────
+
+  it('approve(): READY → POSTED atomically with approver metadata + receipt', async () => {
+    const draft = await createStandardDraft();
+    const ready = await service.requestApproval(draft.id, makerId);
+    expect(ready.status).toBe('READY');
+
+    const posted = await service.approve(ready.id, { note: 'อนุมัติแล้ว' }, approverId);
+
+    expect(posted.status).toBe('POSTED');
+    expect(posted.approverId).toBe(approverId);
+    expect(posted.approvedAt).toBeTruthy();
+    expect(posted.approveNote).toBe('อนุมัติแล้ว');
+    expect(posted.journalEntryId).toBeTruthy();
+    expect(posted.receiptNo).toMatch(/^RC-\d{8}-\d{3}$/);
+    expect(posted.postedAt).toBeTruthy();
+
+    // Verify JE was created
+    const je = await prisma.journalEntry.findUnique({
+      where: { id: posted.journalEntryId! },
+      include: { lines: true },
+    });
+    expect(je).toBeDefined();
+    expect(je!.status).toBe('POSTED');
+    // 3 lines: Dr cash, Dr WHT receivable, Cr income
+    expect(je!.lines.length).toBe(3);
+  }, 30_000);
+
+  it('approve(): V9 rejects self-approval (maker === approver)', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await expect(service.approve(draft.id, {}, makerId)).rejects.toMatchObject({
+      response: expect.objectContaining({
+        errors: expect.arrayContaining([
+          expect.objectContaining({ rule: 'V9' }),
+        ]),
+      }),
+    });
+  }, 30_000);
+
+  it('approve(): 409 when doc not in READY', async () => {
+    const draft = await createStandardDraft();
+    // Doc is DRAFT, not READY
+
+    await expect(service.approve(draft.id, {}, approverId)).rejects.toMatchObject({
+      status: 409,
+    });
+  }, 30_000);
+
+  it('approve(): 400 when Maker-Checker flag disabled', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'false' },
+    });
+
+    await expect(service.approve(draft.id, {}, approverId)).rejects.toMatchObject({
+      message: 'Maker-Checker disabled',
+    });
+
+    // Re-enable
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'true' },
+    });
+  }, 30_000);
+
+  // ─────────────────────────────────────────────────────────────
+  // Task 5: reject()
+  // ─────────────────────────────────────────────────────────────
+
+  it('reject(): READY → DRAFT with rejection metadata', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    const rejected = await service.reject(draft.id, { note: 'รายการผิดพลาด' }, approverId);
+
+    expect(rejected.status).toBe('DRAFT');
+    expect(rejected.rejectedById).toBe(approverId);
+    expect(rejected.rejectedAt).toBeTruthy();
+    expect(rejected.rejectNote).toBe('รายการผิดพลาด');
+  }, 30_000);
+
+  it('reject(): requires non-empty note', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await expect(service.reject(draft.id, { note: '' }, approverId)).rejects.toMatchObject({
+      message: 'กรุณาระบุหมายเหตุการปฏิเสธ',
+    });
+  }, 30_000);
+
+  it('reject(): 409 when doc not in READY', async () => {
+    const draft = await createStandardDraft();
+    // Doc is DRAFT, not READY
+
+    await expect(service.reject(draft.id, { note: 'หมายเหตุ' }, approverId)).rejects.toMatchObject({
+      status: 409,
+    });
+  }, 30_000);
+
+  it('reject(): 400 when Maker-Checker flag disabled', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'false' },
+    });
+
+    await expect(
+      service.reject(draft.id, { note: 'ปฏิเสธ' }, approverId),
+    ).rejects.toMatchObject({ message: 'Maker-Checker disabled' });
+
+    // Re-enable
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'true' },
+    });
+  }, 30_000);
+
+  it('reject() → requestApproval(): re-submission clears prior rejection metadata', async () => {
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+    // Reject it first
+    await service.reject(draft.id, { note: 'แก้ไขก่อน' }, approverId);
+
+    // Verify rejection metadata is set
+    const afterReject = await prisma.otherIncome.findUnique({ where: { id: draft.id } });
+    expect(afterReject?.rejectNote).toBe('แก้ไขก่อน');
+
+    // Re-submit for approval — should clear rejection metadata
+    const resubmitted = await service.requestApproval(draft.id, makerId);
+    expect(resubmitted.status).toBe('READY');
+    expect(resubmitted.rejectedAt).toBeNull();
+    expect(resubmitted.rejectedById).toBeNull();
+    expect(resubmitted.rejectNote).toBeNull();
+  }, 30_000);
+});

--- a/apps/api/src/modules/other-income/__tests__/other-income.controller.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.controller.spec.ts
@@ -21,6 +21,7 @@ import { RolesGuard } from '../../auth/guards/roles.guard';
 import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
 import { OtherIncomeController } from '../other-income.controller';
 import { OtherIncomeService } from '../other-income.service';
+import { TemplateService } from '../services/template.service';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -99,7 +100,20 @@ describe('OtherIncomeController — unit (mocked service)', () => {
 
     const module = await Test.createTestingModule({
       controllers: [OtherIncomeController],
-      providers: [{ provide: OtherIncomeService, useValue: mockService }],
+      providers: [
+        { provide: OtherIncomeService, useValue: mockService },
+        {
+          provide: TemplateService,
+          useValue: {
+            list: jest.fn().mockResolvedValue([]),
+            create: jest.fn(),
+            createFromDoc: jest.fn(),
+            update: jest.fn(),
+            softDelete: jest.fn(),
+            use: jest.fn(),
+          },
+        },
+      ],
     })
       .overrideGuard(JwtAuthGuard)
       .useValue({ canActivate: () => true })
@@ -186,7 +200,20 @@ describe('OtherIncomeController — ValidationPipe (TestingModule + http)', () =
   beforeAll(async () => {
     const module = await Test.createTestingModule({
       controllers: [OtherIncomeController],
-      providers: [{ provide: OtherIncomeService, useValue: mockService }],
+      providers: [
+        { provide: OtherIncomeService, useValue: mockService },
+        {
+          provide: TemplateService,
+          useValue: {
+            list: jest.fn().mockResolvedValue([]),
+            create: jest.fn(),
+            createFromDoc: jest.fn(),
+            update: jest.fn(),
+            softDelete: jest.fn(),
+            use: jest.fn(),
+          },
+        },
+      ],
     })
       .overrideGuard(JwtAuthGuard)
       .useValue({

--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -607,8 +607,16 @@ describe('OtherIncomeService — post — period lock (B1)', () => {
     }
 
     // Clean up accounting period rows created by this suite
+    // (2026-04 for the post() tests + today's period for the reverse() test)
+    const today = new Date();
     await prisma.accountingPeriod.deleteMany({
-      where: { companyId: financeCompanyId, year: 2026, month: 4 },
+      where: {
+        companyId: financeCompanyId,
+        OR: [
+          { year: 2026, month: 4 },
+          { year: today.getFullYear(), month: today.getMonth() + 1 },
+        ],
+      },
     });
 
     await prisma.user.delete({ where: { id: userId } }).catch(() => {});
@@ -666,5 +674,53 @@ describe('OtherIncomeService — post — period lock (B1)', () => {
 
     const result = await service.post(doc.id, {}, userId);
     expect(result.status).toBe('POSTED');
+  }, 30_000);
+
+  it('reverse() rejects when today\'s period is CLOSED (B1 — reverse path)', async () => {
+    // Arrange: today's year/month (reverse() uses new Date(), not original issueDate)
+    const today = new Date();
+    const todayYear = today.getFullYear();
+    const todayMonth = today.getMonth() + 1;
+
+    // Step 1: ensure today's period is OPEN so we can POST the doc first
+    await prisma.accountingPeriod.upsert({
+      where: {
+        companyId_year_month: {
+          companyId: financeCompanyId,
+          year: todayYear,
+          month: todayMonth,
+        },
+      },
+      update: { status: 'OPEN' },
+      create: {
+        companyId: financeCompanyId,
+        year: todayYear,
+        month: todayMonth,
+        status: 'OPEN',
+      },
+    });
+
+    // Step 2: create + POST a fresh doc dated today (so doc.issueDate also falls in OPEN period)
+    const issueDate = today.toISOString().slice(0, 10);
+    const draft = await createDraftOtherIncome(issueDate);
+    const posted = await service.post(draft.id, {}, userId);
+    expect(posted.status).toBe('POSTED');
+
+    // Step 3: flip today's period to CLOSED — now reverse() should reject
+    await prisma.accountingPeriod.update({
+      where: {
+        companyId_year_month: {
+          companyId: financeCompanyId,
+          year: todayYear,
+          month: todayMonth,
+        },
+      },
+      data: { status: 'CLOSED' },
+    });
+
+    // Act + Assert: reverse() must fail because today's period is CLOSED
+    await expect(
+      service.reverse(posted.id, { reason: 'INPUT_ERROR', note: 'test' }, userId),
+    ).rejects.toThrow(/งวดที่ปิดแล้ว/);
   }, 30_000);
 });

--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -521,3 +521,150 @@ describe('OtherIncomeService — post + reverse + copy', () => {
     expect(sheet.summary).toHaveProperty('wht');
   }, 30_000);
 });
+
+// ============================================================
+// Suite 3: post — period lock (B1)
+// ============================================================
+
+describe('OtherIncomeService — post — period lock (B1)', () => {
+  let service: OtherIncomeService;
+  let prisma: PrismaService;
+  let userId: string;
+  let financeCompanyId: string;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        OtherIncomeService,
+        DocNumberService,
+        ValidationService,
+        AutoJournalService,
+        OtherIncomeTemplate,
+        JournalAutoService,
+        PrismaService,
+        { provide: StorageService, useValue: stubStorage },
+      ],
+    }).compile();
+    await module.init();
+    service = module.get(OtherIncomeService);
+    prisma = module.get(PrismaService);
+
+    // Ensure FINANCE CompanyInfo
+    const company = await prisma.companyInfo.upsert({
+      where: { companyCode: 'FINANCE' },
+      update: {},
+      create: {
+        companyCode: 'FINANCE',
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000001',
+        address: 'TEST',
+        directorName: 'ผู้อำนวยการ',
+        vatRegistered: true,
+      },
+    });
+    financeCompanyId = company.id;
+
+    // Ensure system user
+    await prisma.user.upsert({
+      where: { email: 'admin@bestchoice.com' },
+      update: {},
+      create: { email: 'admin@bestchoice.com', password: 'x', name: 'admin', role: 'OWNER' },
+    });
+
+    // Seed required CoA codes
+    const coaSeeds = [
+      { code: '42-1102', name: 'รายได้ดอกเบี้ยฝากธนาคาร', type: 'รายได้', normalBalance: 'Cr', category: 'รายได้อื่น' },
+      { code: '11-1201', name: 'ธนาคาร KBank', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'เงินฝากธนาคาร' },
+      { code: '11-4103', name: 'ลูกหนี้ภาษีหัก ณ ที่จ่าย', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'สินทรัพย์หมุนเวียน' },
+    ];
+    for (const seed of coaSeeds) {
+      await prisma.chartOfAccount.upsert({ where: { code: seed.code }, update: {}, create: seed });
+    }
+
+    const user = await prisma.user.create({
+      data: {
+        email: `oi-period-lock+${Date.now()}@bestchoice.test`,
+        password: 'x',
+        name: 'OI Period Lock Tester',
+        role: 'ACCOUNTANT',
+      },
+    });
+    userId = user.id;
+  }, 30_000);
+
+  afterAll(async () => {
+    const ois = await prisma.otherIncome.findMany({ where: { createdById: userId } });
+    const ourIds = ois.map((o) => o.id);
+    const jeIds = ois.filter((o) => o.journalEntryId).map((o) => o.journalEntryId as string);
+
+    await prisma.otherIncomeItem.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncomeAdjustment.deleteMany({ where: { otherIncomeId: { in: ourIds } } });
+    await prisma.otherIncome.deleteMany({ where: { createdById: userId } });
+
+    if (jeIds.length > 0) {
+      await prisma.journalLine.deleteMany({ where: { journalEntryId: { in: jeIds } } });
+      await prisma.journalEntry.deleteMany({ where: { id: { in: jeIds } } });
+    }
+
+    // Clean up accounting period rows created by this suite
+    await prisma.accountingPeriod.deleteMany({
+      where: { companyId: financeCompanyId, year: 2026, month: 4 },
+    });
+
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.$disconnect();
+  }, 30_000);
+
+  function createDraftOtherIncome(issueDate: string) {
+    return service.create(
+      {
+        issueDate,
+        priceType: 'EXCLUSIVE',
+        paymentAccountCode: '11-1201',
+        amountReceived: 850,
+        counterpartyName: 'KBank',
+        items: [
+          {
+            accountCode: '42-1102',
+            description: 'ดอกเบี้ยฝาก',
+            quantity: 1,
+            unitAmount: 1000,
+            vatPct: 0,
+            whtPct: 15,
+          },
+        ],
+      },
+      userId,
+    );
+  }
+
+  it('passes companyId so AccountingPeriod tier-1 check fires', async () => {
+    // Arrange: a CLOSED FINANCE AccountingPeriod for the doc's month
+    const doc = await createDraftOtherIncome('2026-04-15');
+    await prisma.accountingPeriod.upsert({
+      where: { companyId_year_month: { companyId: financeCompanyId, year: 2026, month: 4 } },
+      update: { status: 'CLOSED' },
+      create: { companyId: financeCompanyId, year: 2026, month: 4, status: 'CLOSED' },
+    });
+
+    // Act + Assert: should reject because period is CLOSED
+    await expect(service.post(doc.id, {}, userId)).rejects.toThrow(/งวดที่ปิดแล้ว/);
+
+    // Cleanup this doc (it was not posted, so no JE)
+    await prisma.otherIncomeItem.deleteMany({ where: { otherIncomeId: doc.id } });
+    await prisma.otherIncome.delete({ where: { id: doc.id } });
+  }, 30_000);
+
+  it('allows POST when period is OPEN', async () => {
+    // Arrange: ensure AccountingPeriod is OPEN for 2026-04
+    await prisma.accountingPeriod.upsert({
+      where: { companyId_year_month: { companyId: financeCompanyId, year: 2026, month: 4 } },
+      update: { status: 'OPEN' },
+      create: { companyId: financeCompanyId, year: 2026, month: 4, status: 'OPEN' },
+    });
+    const doc = await createDraftOtherIncome('2026-04-15');
+
+    const result = await service.post(doc.id, {}, userId);
+    expect(result.status).toBe('POSTED');
+  }, 30_000);
+});

--- a/apps/api/src/modules/other-income/__tests__/template-vars.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/template-vars.spec.ts
@@ -1,0 +1,38 @@
+import { replaceVariables } from '../services/template-vars.util';
+
+describe('replaceVariables', () => {
+  it('replaces {เดือน} with Thai short month abbreviation', () => {
+    const may = new Date('2026-05-12T00:00:00Z');  // 2026-05-12 07:00 BKK
+    expect(replaceVariables('ดอกเบี้ยเดือน {เดือน}', may)).toBe('ดอกเบี้ยเดือน พ.ค.');
+  });
+
+  it('replaces {ปี} with Buddhist Era year', () => {
+    const d = new Date('2026-05-12T00:00:00Z');
+    expect(replaceVariables('ปี {ปี}', d)).toBe('ปี 2569');
+  });
+
+  it('replaces {เดือนปี} with combined form', () => {
+    const d = new Date('2026-05-12T00:00:00Z');
+    expect(replaceVariables('ค่างวด {เดือนปี}', d)).toBe('ค่างวด พ.ค. 2569');
+  });
+
+  it('handles UTC late-night that flips to next day in BKK', () => {
+    // 2026-05-12 18:30 UTC = 2026-05-13 01:30 BKK (next day, still พ.ค.)
+    const lateUtc = new Date('2026-05-12T18:30:00Z');
+    expect(replaceVariables('{เดือนปี}', lateUtc)).toBe('พ.ค. 2569');
+  });
+
+  it('handles year boundary: 2026-12-31 18:30 UTC = 2027-01-01 01:30 BKK', () => {
+    const yearFlip = new Date('2026-12-31T18:30:00Z');
+    expect(replaceVariables('{เดือนปี}', yearFlip)).toBe('ม.ค. 2570');
+  });
+
+  it('replaces multiple occurrences', () => {
+    const d = new Date('2026-05-12T00:00:00Z');
+    expect(replaceVariables('{เดือน}/{ปี} — {เดือน}', d)).toBe('พ.ค./2569 — พ.ค.');
+  });
+
+  it('leaves text without tokens unchanged', () => {
+    expect(replaceVariables('no tokens here', new Date())).toBe('no tokens here');
+  });
+});

--- a/apps/api/src/modules/other-income/__tests__/template.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/template.service.spec.ts
@@ -1,0 +1,206 @@
+import { Test } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { TemplateService } from '../services/template.service';
+
+// ============================================================
+// Real-DB integration tests against bestchoice_oi_test
+// ============================================================
+
+describe('TemplateService — integration', () => {
+  let service: TemplateService;
+  let prisma: PrismaService;
+  let userId: string;
+  let companyId: string;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      providers: [TemplateService, PrismaService],
+    }).compile();
+    await module.init();
+    service = module.get(TemplateService);
+    prisma = module.get(PrismaService);
+
+    // Ensure FINANCE CompanyInfo exists
+    const co = await prisma.companyInfo.upsert({
+      where: { companyCode: 'FINANCE' },
+      update: {},
+      create: {
+        companyCode: 'FINANCE',
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000001',
+        address: 'TEST',
+        directorName: 'ผู้อำนวยการ',
+        vatRegistered: true,
+      },
+    });
+    companyId = co.id;
+
+    // Create a unique test user
+    const user = await prisma.user.create({
+      data: {
+        email: `tpl-test+${Date.now()}@bestchoice.test`,
+        password: 'x',
+        name: 'Tpl Tester',
+        role: 'ACCOUNTANT',
+      },
+    });
+    userId = user.id;
+  });
+
+  afterAll(async () => {
+    await prisma.otherIncomeTemplate.deleteMany({ where: { createdById: userId } });
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  const baseItems = [
+    {
+      lineNo: 1,
+      accountCode: '42-1102',
+      description: 'ดอกเบี้ยฝาก {เดือนปี}',
+      quantity: 1,
+      unitAmount: 1000,
+      discountAmount: 0,
+      vatPct: 0,
+      whtPct: 15,
+    },
+  ];
+
+  it('1. create() creates template', async () => {
+    const tpl = await service.create(
+      { name: 'ดอกเบี้ยธนาคาร', itemsJson: baseItems, priceType: 'EXCLUSIVE' },
+      userId,
+    );
+    expect(tpl.id).toBeDefined();
+    expect(tpl.name).toBe('ดอกเบี้ยธนาคาร');
+    expect(tpl.priceType).toBe('EXCLUSIVE');
+    expect(tpl.useCount).toBe(0);
+    expect(tpl.isFavorite).toBe(false);
+  });
+
+  it('2. list() shows newly created', async () => {
+    // Create a distinctly named template
+    await service.create(
+      { name: 'รายได้อื่น-test-list', itemsJson: baseItems, priceType: 'EXCLUSIVE' },
+      userId,
+    );
+    const list = await service.list({});
+    const found = list.find((t) => t.name === 'รายได้อื่น-test-list');
+    expect(found).toBeDefined();
+  });
+
+  it('3. soft-deleted template excluded from list', async () => {
+    const tpl = await service.create(
+      { name: 'to-delete-template', itemsJson: baseItems, priceType: 'EXCLUSIVE' },
+      userId,
+    );
+    await service.softDelete(tpl.id);
+    const list = await service.list({});
+    const found = list.find((t) => t.id === tpl.id);
+    expect(found).toBeUndefined();
+  });
+
+  it('4. list sorted favorites-first then lastUsedAt desc', async () => {
+    // Create a non-favorite then a favorite
+    const normal = await service.create(
+      { name: 'normal-sort-test', itemsJson: baseItems, priceType: 'EXCLUSIVE' },
+      userId,
+    );
+    const fav = await service.create(
+      { name: 'fav-sort-test', itemsJson: baseItems, priceType: 'EXCLUSIVE' },
+      userId,
+    );
+    await service.update(fav.id, { isFavorite: true });
+
+    const list = await service.list({});
+    const favIdx = list.findIndex((t) => t.id === fav.id);
+    const normIdx = list.findIndex((t) => t.id === normal.id);
+    expect(favIdx).toBeLessThan(normIdx);
+  });
+
+  it('5. use() increments useCount + sets lastUsedAt', async () => {
+    const tpl = await service.create(
+      { name: 'use-count-test', itemsJson: baseItems, priceType: 'EXCLUSIVE' },
+      userId,
+    );
+    expect(tpl.useCount).toBe(0);
+
+    const now = new Date('2026-05-12T10:00:00Z');
+    await service.use(tpl.id, now);
+
+    const updated = await prisma.otherIncomeTemplate.findUnique({ where: { id: tpl.id } });
+    expect(updated?.useCount).toBe(1);
+    expect(updated?.lastUsedAt).not.toBeNull();
+  });
+
+  it('6. use() applies variable replacement on item.description', async () => {
+    const tpl = await service.create(
+      {
+        name: 'var-replace-test',
+        itemsJson: [{ ...baseItems[0], description: 'รายได้ {เดือน} {ปี}' }],
+        priceType: 'EXCLUSIVE',
+      },
+      userId,
+    );
+
+    // 2026-05-12 BKK → เดือน = พ.ค., ปี = 2569
+    const fixedDate = new Date('2026-05-12T03:00:00Z'); // 10:00 BKK
+    const result = await service.use(tpl.id, fixedDate);
+
+    expect(result.items[0].description).toContain('พ.ค.');
+    expect(result.items[0].description).toContain('2569');
+  });
+
+  it('7. createFromDoc() snapshots all item fields', async () => {
+    // Create a real OtherIncome doc first via prisma direct insert
+    const co = await prisma.companyInfo.findFirst({ where: { companyCode: 'FINANCE', deletedAt: null } });
+    expect(co).not.toBeNull();
+
+    const doc = await prisma.otherIncome.create({
+      data: {
+        docNumber: `OI-TEST-${Date.now()}`,
+        companyId: co!.id,
+        createdById: userId,
+        issueDate: new Date('2026-05-06'),
+        priceType: 'EXCLUSIVE',
+        paymentAccountCode: '11-1201',
+        amountReceived: new (require('@prisma/client').Prisma.Decimal)(850),
+        incomeGross: new (require('@prisma/client').Prisma.Decimal)(1000),
+        vatAmount: new (require('@prisma/client').Prisma.Decimal)(0),
+        whtAmount: new (require('@prisma/client').Prisma.Decimal)(150),
+        netReceived: new (require('@prisma/client').Prisma.Decimal)(850),
+        items: {
+          create: [
+            {
+              lineNo: 1,
+              accountCode: '42-1102',
+              accountName: 'รายได้ดอกเบี้ยฝากธนาคาร',
+              description: 'ดอกเบี้ย พ.ค.',
+              quantity: new (require('@prisma/client').Prisma.Decimal)(1),
+              unitAmount: new (require('@prisma/client').Prisma.Decimal)(1000),
+              discountAmount: new (require('@prisma/client').Prisma.Decimal)(0),
+              vatPct: new (require('@prisma/client').Prisma.Decimal)(0),
+              whtPct: new (require('@prisma/client').Prisma.Decimal)(15),
+              amountBeforeVat: new (require('@prisma/client').Prisma.Decimal)(1000),
+              vatAmount: new (require('@prisma/client').Prisma.Decimal)(0),
+              whtAmount: new (require('@prisma/client').Prisma.Decimal)(150),
+            },
+          ],
+        },
+      },
+    });
+
+    const tpl = await service.createFromDoc(doc.id, 'snapshot-from-doc', userId);
+
+    expect(tpl.name).toBe('snapshot-from-doc');
+    const items = tpl.itemsJson as any[];
+    expect(items).toHaveLength(1);
+    expect(items[0].accountCode).toBe('42-1102');
+    expect(items[0].description).toBe('ดอกเบี้ย พ.ค.');
+    expect(items[0].whtPct).toBe(15);
+
+    // cleanup
+    await prisma.otherIncomeItem.deleteMany({ where: { otherIncomeId: doc.id } });
+    await prisma.otherIncome.delete({ where: { id: doc.id } });
+  });
+});

--- a/apps/api/src/modules/other-income/__tests__/template.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/template.service.spec.ts
@@ -1,6 +1,9 @@
 import { Test } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { TemplateService } from '../services/template.service';
+
+const D = (n: number | string) => new Prisma.Decimal(n);
 
 // ============================================================
 // Real-DB integration tests against bestchoice_oi_test
@@ -164,11 +167,11 @@ describe('TemplateService — integration', () => {
         issueDate: new Date('2026-05-06'),
         priceType: 'EXCLUSIVE',
         paymentAccountCode: '11-1201',
-        amountReceived: new (require('@prisma/client').Prisma.Decimal)(850),
-        incomeGross: new (require('@prisma/client').Prisma.Decimal)(1000),
-        vatAmount: new (require('@prisma/client').Prisma.Decimal)(0),
-        whtAmount: new (require('@prisma/client').Prisma.Decimal)(150),
-        netReceived: new (require('@prisma/client').Prisma.Decimal)(850),
+        amountReceived: D(850),
+        incomeGross: D(1000),
+        vatAmount: D(0),
+        whtAmount: D(150),
+        netReceived: D(850),
         items: {
           create: [
             {
@@ -176,14 +179,14 @@ describe('TemplateService — integration', () => {
               accountCode: '42-1102',
               accountName: 'รายได้ดอกเบี้ยฝากธนาคาร',
               description: 'ดอกเบี้ย พ.ค.',
-              quantity: new (require('@prisma/client').Prisma.Decimal)(1),
-              unitAmount: new (require('@prisma/client').Prisma.Decimal)(1000),
-              discountAmount: new (require('@prisma/client').Prisma.Decimal)(0),
-              vatPct: new (require('@prisma/client').Prisma.Decimal)(0),
-              whtPct: new (require('@prisma/client').Prisma.Decimal)(15),
-              amountBeforeVat: new (require('@prisma/client').Prisma.Decimal)(1000),
-              vatAmount: new (require('@prisma/client').Prisma.Decimal)(0),
-              whtAmount: new (require('@prisma/client').Prisma.Decimal)(150),
+              quantity: D(1),
+              unitAmount: D(1000),
+              discountAmount: D(0),
+              vatPct: D(0),
+              whtPct: D(15),
+              amountBeforeVat: D(1000),
+              vatAmount: D(0),
+              whtAmount: D(150),
             },
           ],
         },

--- a/apps/api/src/modules/other-income/__tests__/validation.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/validation.spec.ts
@@ -110,3 +110,49 @@ describe('ValidationService', () => {
     expect(result.errors.find((e) => e.rule === 'V13')).toBeDefined();
   });
 });
+
+describe('V15 — bank interest policy (B2)', () => {
+  let service: ValidationService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [ValidationService],
+    }).compile();
+    service = module.get(ValidationService);
+  });
+
+  it('does NOT warn when 42-1102 uses WHT 1% (นิติบุคคล ออมทรัพย์)', () => {
+    const doc = {
+      ...goldenCases.bankInterest,
+      items: [
+        {
+          ...goldenCases.bankInterest.items[0],
+          whtPct: D(1),
+          whtAmount: D(10),
+        },
+      ],
+      whtAmount: D(10),
+      netReceived: D(990),
+      amountReceived: D(990),
+    };
+    const result = service.validate(doc, baseCtx);
+    const v15Warning = result.warnings.find((w) => w.rule === 'V15');
+    expect(v15Warning).toBeUndefined();
+  });
+
+  it('still errors when 42-1102 has VAT% > 0 (ม.81(1)(ฏ) violation)', () => {
+    const doc = {
+      ...goldenCases.bankInterest,
+      items: [
+        {
+          ...goldenCases.bankInterest.items[0],
+          vatPct: D(7),
+        },
+      ],
+    };
+    const result = service.validate(doc, baseCtx);
+    const v15Error = result.errors.find((e) => e.rule === 'V15');
+    expect(v15Error).toBeDefined();
+    expect(v15Error?.msg).toMatch(/ยกเว้น VAT/);
+  });
+});

--- a/apps/api/src/modules/other-income/dto/approve-other-income.dto.ts
+++ b/apps/api/src/modules/other-income/dto/approve-other-income.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ApproveOtherIncomeDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
+}

--- a/apps/api/src/modules/other-income/dto/create-template.dto.ts
+++ b/apps/api/src/modules/other-income/dto/create-template.dto.ts
@@ -1,20 +1,50 @@
-import { IsArray, IsEnum, IsNotEmpty, IsString, MaxLength, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 class TemplateItemDto {
   @IsString()
+  @IsNotEmpty({ message: 'กรุณาเลือกบัญชี' })
   accountCode!: string;
 
+  @IsOptional()
   @IsString()
   @MaxLength(200)
   description?: string;
 
-  // Allow string or number from form
-  quantity!: number | string;
-  unitAmount!: number | string;
-  discountAmount!: number | string;
-  vatPct!: number | string;
-  whtPct!: number | string;
+  @Type(() => Number)
+  @IsNumber({ allowNaN: false }, { message: 'จำนวนต้องเป็นตัวเลข' })
+  @Min(0, { message: 'จำนวนต้องไม่ติดลบ' })
+  quantity!: number;
+
+  @Type(() => Number)
+  @IsNumber({ allowNaN: false }, { message: 'ราคา/หน่วยต้องเป็นตัวเลข' })
+  @Min(0, { message: 'ราคา/หน่วยต้องไม่ติดลบ' })
+  unitAmount!: number;
+
+  @Type(() => Number)
+  @IsNumber({ allowNaN: false })
+  @Min(0)
+  discountAmount!: number;
+
+  @Type(() => Number)
+  @IsNumber({ allowNaN: false })
+  @Min(0)
+  vatPct!: number;
+
+  @Type(() => Number)
+  @IsNumber({ allowNaN: false })
+  @Min(0)
+  whtPct!: number;
 }
 
 export class CreateTemplateDto {

--- a/apps/api/src/modules/other-income/dto/create-template.dto.ts
+++ b/apps/api/src/modules/other-income/dto/create-template.dto.ts
@@ -1,0 +1,40 @@
+import { IsArray, IsEnum, IsNotEmpty, IsString, MaxLength, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class TemplateItemDto {
+  @IsString()
+  accountCode!: string;
+
+  @IsString()
+  @MaxLength(200)
+  description?: string;
+
+  // Allow string or number from form
+  quantity!: number | string;
+  unitAmount!: number | string;
+  discountAmount!: number | string;
+  vatPct!: number | string;
+  whtPct!: number | string;
+}
+
+export class CreateTemplateDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุชื่อ Template' })
+  @MaxLength(100)
+  name!: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TemplateItemDto)
+  items!: TemplateItemDto[];
+
+  @IsEnum(['EXCLUSIVE', 'INCLUSIVE'])
+  priceType!: 'EXCLUSIVE' | 'INCLUSIVE';
+}
+
+export class CreateTemplateFromDocDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุชื่อ Template' })
+  @MaxLength(100)
+  name!: string;
+}

--- a/apps/api/src/modules/other-income/dto/reject-other-income.dto.ts
+++ b/apps/api/src/modules/other-income/dto/reject-other-income.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class RejectOtherIncomeDto {
+  @IsString()
+  @IsNotEmpty({ message: 'กรุณาระบุหมายเหตุการปฏิเสธ' })
+  @MaxLength(500)
+  note!: string;
+}

--- a/apps/api/src/modules/other-income/dto/request-approval.dto.ts
+++ b/apps/api/src/modules/other-income/dto/request-approval.dto.ts
@@ -1,0 +1,2 @@
+// Empty body — no fields required. Defined for OpenAPI consistency.
+export class RequestApprovalDto {}

--- a/apps/api/src/modules/other-income/dto/update-template.dto.ts
+++ b/apps/api/src/modules/other-income/dto/update-template.dto.ts
@@ -1,0 +1,12 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateTemplateDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isFavorite?: boolean;
+}

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -51,6 +51,15 @@ export class OtherIncomeController {
     return { threshold: await this.service.getAttachmentThreshold() };
   }
 
+  // CRITICAL: must stay before any :id route so the literal string
+  // 'maker-checker-enabled' is not captured as a UUID param.
+  @Get('maker-checker-enabled')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'BRANCH_MANAGER', 'FINANCE_MANAGER')
+  async getMakerCheckerEnabled() {
+    const enabled = await this.service.isMakerCheckerEnabled();
+    return { enabled };
+  }
+
   @Get()
   list(@Query() query: ListOtherIncomeQueryDto) {
     return this.service.list(query);

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -22,18 +22,24 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { OtherIncomeService } from './other-income.service';
+import { TemplateService } from './services/template.service';
 import { CreateOtherIncomeDto } from './dto/create-other-income.dto';
 import { UpdateOtherIncomeDto } from './dto/update-other-income.dto';
 import { PostOtherIncomeDto } from './dto/post-other-income.dto';
 import { ReverseOtherIncomeDto } from './dto/reverse-other-income.dto';
 import { ListOtherIncomeQueryDto } from './dto/list-other-income-query.dto';
 import { DailySheetQueryDto } from './dto/daily-sheet-query.dto';
+import { CreateTemplateDto, CreateTemplateFromDocDto } from './dto/create-template.dto';
+import { UpdateTemplateDto } from './dto/update-template.dto';
 
 @Controller('other-income')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
 export class OtherIncomeController {
-  constructor(private readonly service: OtherIncomeService) {}
+  constructor(
+    private readonly service: OtherIncomeService,
+    private readonly templateService: TemplateService,
+  ) {}
 
   // CRITICAL: declare daily-sheet BEFORE :id so the literal string
   // doesn't get parsed as a UUID by ParseUUIDPipe on the :id routes.
@@ -51,6 +57,68 @@ export class OtherIncomeController {
   list(@Query() query: ListOtherIncomeQueryDto) {
     return this.service.list(query);
   }
+
+  // ─── Templates (PR-3) ───────────────────────────────────────────────────
+  // CRITICAL: these routes MUST be declared BEFORE any /:id route to avoid
+  // "templates" being captured as an OtherIncome doc id by Nest's matcher.
+
+  @Get('templates')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  listTemplates(@Query('q') q?: string, @Query('favoritesOnly') favoritesOnly?: string) {
+    return this.templateService.list({ q, favoritesOnly: favoritesOnly === 'true' });
+  }
+
+  @Post('templates')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  createTemplate(@Body() dto: CreateTemplateDto, @CurrentUser('id') userId: string) {
+    return this.templateService.create(
+      {
+        name: dto.name,
+        priceType: dto.priceType,
+        itemsJson: dto.items.map((it, i) => ({
+          lineNo: i + 1,
+          accountCode: it.accountCode,
+          description: it.description ?? null,
+          quantity: Number(it.quantity),
+          unitAmount: Number(it.unitAmount),
+          discountAmount: Number(it.discountAmount ?? 0),
+          vatPct: Number(it.vatPct ?? 0),
+          whtPct: Number(it.whtPct ?? 0),
+        })),
+      },
+      userId,
+    );
+  }
+
+  @Post('from-doc/:id/save-template')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  saveAsTemplate(
+    @Param('id') id: string,
+    @Body() dto: CreateTemplateFromDocDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.templateService.createFromDoc(id, dto.name, userId);
+  }
+
+  @Patch('templates/:id')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  updateTemplate(@Param('id') id: string, @Body() dto: UpdateTemplateDto) {
+    return this.templateService.update(id, dto);
+  }
+
+  @Delete('templates/:id')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  deleteTemplate(@Param('id') id: string) {
+    return this.templateService.softDelete(id);
+  }
+
+  @Post('templates/:id/use')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  useTemplate(@Param('id') id: string) {
+    return this.templateService.use(id);
+  }
+
+  // ─── OtherIncome docs (parameterized — must stay AFTER literal routes) ──
 
   @Get(':id')
   findOne(@Param('id', new ParseUUIDPipe()) id: string) {

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -63,13 +63,13 @@ export class OtherIncomeController {
   // "templates" being captured as an OtherIncome doc id by Nest's matcher.
 
   @Get('templates')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
   listTemplates(@Query('q') q?: string, @Query('favoritesOnly') favoritesOnly?: string) {
     return this.templateService.list({ q, favoritesOnly: favoritesOnly === 'true' });
   }
 
   @Post('templates')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
   createTemplate(@Body() dto: CreateTemplateDto, @CurrentUser('id') userId: string) {
     return this.templateService.create(
       {
@@ -79,11 +79,11 @@ export class OtherIncomeController {
           lineNo: i + 1,
           accountCode: it.accountCode,
           description: it.description ?? null,
-          quantity: Number(it.quantity),
-          unitAmount: Number(it.unitAmount),
-          discountAmount: Number(it.discountAmount ?? 0),
-          vatPct: Number(it.vatPct ?? 0),
-          whtPct: Number(it.whtPct ?? 0),
+          quantity: it.quantity,
+          unitAmount: it.unitAmount,
+          discountAmount: it.discountAmount,
+          vatPct: it.vatPct,
+          whtPct: it.whtPct,
         })),
       },
       userId,
@@ -91,7 +91,7 @@ export class OtherIncomeController {
   }
 
   @Post('from-doc/:id/save-template')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
   saveAsTemplate(
     @Param('id') id: string,
     @Body() dto: CreateTemplateFromDocDto,
@@ -101,19 +101,19 @@ export class OtherIncomeController {
   }
 
   @Patch('templates/:id')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
   updateTemplate(@Param('id') id: string, @Body() dto: UpdateTemplateDto) {
     return this.templateService.update(id, dto);
   }
 
   @Delete('templates/:id')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
   deleteTemplate(@Param('id') id: string) {
     return this.templateService.softDelete(id);
   }
 
   @Post('templates/:id/use')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
   useTemplate(@Param('id') id: string) {
     return this.templateService.use(id);
   }

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   Param,
   ParseUUIDPipe,
   Patch,
@@ -26,6 +27,9 @@ import { CreateOtherIncomeDto } from './dto/create-other-income.dto';
 import { UpdateOtherIncomeDto } from './dto/update-other-income.dto';
 import { PostOtherIncomeDto } from './dto/post-other-income.dto';
 import { ReverseOtherIncomeDto } from './dto/reverse-other-income.dto';
+import { RequestApprovalDto } from './dto/request-approval.dto';
+import { ApproveOtherIncomeDto } from './dto/approve-other-income.dto';
+import { RejectOtherIncomeDto } from './dto/reject-other-income.dto';
 import { ListOtherIncomeQueryDto } from './dto/list-other-income-query.dto';
 import { DailySheetQueryDto } from './dto/daily-sheet-query.dto';
 
@@ -101,6 +105,35 @@ export class OtherIncomeController {
     @CurrentUser('id') userId: string,
   ) {
     return this.service.reverse(id, dto, userId);
+  }
+
+  @Post(':id/request-approval')
+  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @HttpCode(200)
+  requestApproval(@Param('id', new ParseUUIDPipe()) id: string, @CurrentUser('id') userId: string) {
+    return this.service.requestApproval(id, userId);
+  }
+
+  @Post(':id/approve')
+  @Roles('OWNER')
+  @HttpCode(200)
+  approve(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: ApproveOtherIncomeDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.service.approve(id, dto, userId);
+  }
+
+  @Post(':id/reject')
+  @Roles('OWNER')
+  @HttpCode(200)
+  reject(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: RejectOtherIncomeDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.service.reject(id, dto, userId);
   }
 
   @Post(':id/copy')

--- a/apps/api/src/modules/other-income/other-income.module.ts
+++ b/apps/api/src/modules/other-income/other-income.module.ts
@@ -6,6 +6,7 @@ import { OtherIncomeController } from './other-income.controller';
 import { DocNumberService } from './services/doc-number.service';
 import { ValidationService } from './services/validation.service';
 import { AutoJournalService } from './services/auto-journal.service';
+import { TemplateService } from './services/template.service';
 import { OtherIncomeTemplate } from './templates/other-income.template';
 
 // PrismaService is provided globally via PrismaModule (@Global) — no import needed.
@@ -18,8 +19,9 @@ import { OtherIncomeTemplate } from './templates/other-income.template';
     DocNumberService,
     ValidationService,
     AutoJournalService,
+    TemplateService,
     OtherIncomeTemplate,
   ],
-  exports: [OtherIncomeService],
+  exports: [OtherIncomeService, TemplateService],
 })
 export class OtherIncomeModule {}

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -220,6 +220,193 @@ export class OtherIncomeService {
   }
 
   // -------------------------------------------------------------------------
+  // requestApproval(): PR-2 — DRAFT → READY
+  // -------------------------------------------------------------------------
+
+  /**
+   * PR-2: DRAFT → READY. Only callable when Maker-Checker flag is enabled.
+   * Maker initiates the approval cycle. State stays in DRAFT until approver acts.
+   */
+  async requestApproval(id: string, userId: string) {
+    if (!(await this.isMakerCheckerEnabled())) {
+      throw new BadRequestException('Maker-Checker disabled — use POST directly');
+    }
+    const doc = await this.findOneOrFail(id);
+    if (doc.status !== OtherIncomeStatus.DRAFT) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — ไม่สามารถส่งขออนุมัติได้`,
+      );
+    }
+    // Reset any prior reject metadata (re-submission after rejection)
+    return this.prisma.otherIncome.update({
+      where: { id },
+      data: {
+        status: OtherIncomeStatus.READY,
+        rejectedAt: null,
+        rejectedById: null,
+        rejectNote: null,
+      },
+      include: { items: true, adjustments: true },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // approve(): PR-2 — READY → POSTED atomic
+  // -------------------------------------------------------------------------
+
+  /**
+   * PR-2: READY → POSTED atomically (APPROVED is transient inside tx).
+   * V9: approver must differ from maker (createdById).
+   */
+  async approve(
+    id: string,
+    dto: { note?: string },
+    userId: string,
+  ) {
+    if (!(await this.isMakerCheckerEnabled())) {
+      throw new BadRequestException('Maker-Checker disabled');
+    }
+    const doc = await this.findOneOrFail(id);
+    if (doc.status !== OtherIncomeStatus.READY) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — ไม่สามารถอนุมัติ`,
+      );
+    }
+    // V9: maker ≠ approver
+    if (doc.createdById === userId) {
+      throw new BadRequestException({
+        message: 'Validation failed',
+        errors: [
+          {
+            rule: 'V9',
+            msg: 'ผู้สร้างเอกสารไม่สามารถอนุมัติเอกสารตัวเองได้',
+          },
+        ],
+      });
+    }
+
+    // Re-run validation (period lock, balance, etc.)
+    const companyId = await this.resolveFinanceCompanyId();
+    await validatePeriodOpen(this.prisma, doc.issueDate, companyId);
+
+    const threshold = await this.getAttachmentThreshold();
+    const validationDoc = {
+      issueDate: doc.issueDate,
+      paymentAccountCode: doc.paymentAccountCode,
+      amountReceived: new D(doc.amountReceived.toString()),
+      netReceived: new D(doc.netReceived.toString()),
+      items: doc.items.map((it) => ({
+        lineNo: it.lineNo,
+        accountCode: it.accountCode,
+        vatPct: new D(it.vatPct.toString()),
+        whtPct: new D(it.whtPct.toString()),
+        amountBeforeVat: new D(it.amountBeforeVat.toString()),
+        vatAmount: new D(it.vatAmount.toString()),
+        whtAmount: new D(it.whtAmount.toString()),
+      })),
+      adjustments: doc.adjustments.map((a) => ({
+        lineNo: a.lineNo,
+        accountCode: a.accountCode,
+        amount: new D(a.amount.toString()),
+      })),
+    };
+    const { errors } = this.validation.validate(validationDoc, {
+      isPeriodOpen: () => true,
+      attachmentThreshold: threshold,
+      hasAttachment: doc.attachments.length > 0,
+    });
+    if (errors.length > 0) {
+      throw new BadRequestException({ message: 'ไม่ผ่านการตรวจสอบก่อนอนุมัติ', errors });
+    }
+
+    const jeLines = this.autoJournal.generate({
+      paymentAccountCode: doc.paymentAccountCode,
+      amountReceived: new D(doc.amountReceived.toString()),
+      netReceived: new D(doc.netReceived.toString()),
+      items: doc.items.map((it) => ({
+        lineNo: it.lineNo,
+        accountCode: it.accountCode,
+        accountName: it.accountName,
+        description: it.description ?? undefined,
+        amountBeforeVat: new D(it.amountBeforeVat.toString()),
+        vatAmount: new D(it.vatAmount.toString()),
+        whtAmount: new D(it.whtAmount.toString()),
+        whtPct: new D(it.whtPct.toString()),
+      })),
+      adjustments: doc.adjustments.map((a) => ({
+        lineNo: a.lineNo,
+        accountCode: a.accountCode,
+        amount: new D(a.amount.toString()),
+        note: a.note ?? undefined,
+      })),
+    });
+
+    return this.prisma.$transaction(async (tx) => {
+      const receiptNo = await this.docNumber.nextReceiptNumber(tx, doc.issueDate);
+      const now = new Date();
+
+      const je = await this.template.post(
+        {
+          description: `รายได้อื่น ${doc.docNumber}${doc.counterpartyName ? ` — ${doc.counterpartyName}` : ''}`,
+          entryDate: doc.issueDate,
+          otherIncomeId: doc.id,
+          docNumber: doc.docNumber,
+          lines: jeLines,
+        },
+        tx,
+      );
+
+      return tx.otherIncome.update({
+        where: { id },
+        data: {
+          status: OtherIncomeStatus.POSTED,
+          receiptNo,
+          journalEntryId: je.id,
+          approverId: userId,
+          approvedAt: now,
+          approveNote: dto.note ?? null,
+          postedAt: now,
+        },
+        include: { items: true, adjustments: true },
+      });
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // reject(): PR-2 — READY → DRAFT
+  // -------------------------------------------------------------------------
+
+  /** PR-2: READY → DRAFT. Persists rejection note + rejecter. */
+  async reject(
+    id: string,
+    dto: { note: string },
+    userId: string,
+  ) {
+    if (!(await this.isMakerCheckerEnabled())) {
+      throw new BadRequestException('Maker-Checker disabled');
+    }
+    if (!dto.note || dto.note.trim().length === 0) {
+      throw new BadRequestException('กรุณาระบุหมายเหตุการปฏิเสธ');
+    }
+    const doc = await this.findOneOrFail(id);
+    if (doc.status !== OtherIncomeStatus.READY) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — ไม่สามารถปฏิเสธได้`,
+      );
+    }
+    return this.prisma.otherIncome.update({
+      where: { id },
+      data: {
+        status: OtherIncomeStatus.DRAFT,
+        rejectedById: userId,
+        rejectedAt: new Date(),
+        rejectNote: dto.note,
+      },
+      include: { items: true, adjustments: true },
+    });
+  }
+
+  // -------------------------------------------------------------------------
   // post(): DRAFT → POSTED
   // -------------------------------------------------------------------------
 

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -1008,7 +1008,7 @@ export class OtherIncomeService {
   }
 
   /** Read OTHER_INCOME_MAKER_CHECKER_ENABLED from SystemConfig. Default false. */
-  private async isMakerCheckerEnabled(): Promise<boolean> {
+  async isMakerCheckerEnabled(): Promise<boolean> {
     try {
       const row = await this.prisma.systemConfig.findUnique({
         where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -820,6 +820,18 @@ export class OtherIncomeService {
     return co.id;
   }
 
+  /** Read OTHER_INCOME_MAKER_CHECKER_ENABLED from SystemConfig. Default false. */
+  async isMakerCheckerEnabled(): Promise<boolean> {
+    try {
+      const row = await this.prisma.systemConfig.findUnique({
+        where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      });
+      return row?.value === 'true';
+    } catch {
+      return false;
+    }
+  }
+
   /** Read OTHER_INCOME_ATTACHMENT_THRESHOLD from SystemConfig. Falls back to 50_000. */
   async getAttachmentThreshold(): Promise<number> {
     try {

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -1008,7 +1008,7 @@ export class OtherIncomeService {
   }
 
   /** Read OTHER_INCOME_MAKER_CHECKER_ENABLED from SystemConfig. Default false. */
-  async isMakerCheckerEnabled(): Promise<boolean> {
+  private async isMakerCheckerEnabled(): Promise<boolean> {
     try {
       const row = await this.prisma.systemConfig.findUnique({
         where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -231,8 +231,10 @@ export class OtherIncomeService {
       );
     }
 
-    // V8: period lock check (non-transactional pre-check)
-    await validatePeriodOpen(this.prisma, doc.issueDate);
+    // V8: period lock check (non-transactional pre-check) — B1: pass companyId so
+    // AccountingPeriod tier-1 check fires (without it, only legacy SystemConfig is consulted)
+    const companyId = await this.resolveFinanceCompanyId();
+    await validatePeriodOpen(this.prisma, doc.issueDate, companyId);
 
     // Compute attachment threshold
     const threshold = await this.getAttachmentThreshold();
@@ -367,8 +369,10 @@ export class OtherIncomeService {
       );
     }
 
-    // Period lock on today — the reversal JE is posted today, not on original's issueDate
-    await validatePeriodOpen(this.prisma, new Date());
+    // Period lock on today — the reversal JE is posted today, not on original's issueDate.
+    // B1: pass companyId so AccountingPeriod tier-1 check fires.
+    const companyId = await this.resolveFinanceCompanyId();
+    await validatePeriodOpen(this.prisma, new Date(), companyId);
 
     // Load original JE lines
     if (!original.journalEntryId) {

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -103,7 +103,7 @@ export class OtherIncomeService {
     const existing = await this.findOneOrFail(id);
     if (existing.status !== OtherIncomeStatus.DRAFT) {
       throw new ConflictException(
-        `เอกสาร ${existing.docNumber} เป็น POSTED แล้ว ไม่สามารถแก้ไขได้ — ใช้ Reverse Entry`,
+        `เอกสาร ${existing.docNumber} สถานะ ${existing.status} — ไม่สามารถแก้ไขได้ใน DRAFT เท่านั้น`,
       );
     }
 

--- a/apps/api/src/modules/other-income/services/template-vars.util.ts
+++ b/apps/api/src/modules/other-income/services/template-vars.util.ts
@@ -1,0 +1,37 @@
+/**
+ * Replace Thai locale tokens in template text. Always evaluated in Asia/Bangkok.
+ * Tokens:
+ *   {เดือน}   → Thai short month abbreviation, e.g. "พ.ค."
+ *   {ปี}      → Buddhist Era year, e.g. "2569"
+ *   {เดือนปี} → combined, e.g. "พ.ค. 2569"
+ */
+
+const THAI_MONTHS_SHORT = [
+  'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.',
+  'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.',
+];
+
+function getBkkParts(date: Date): { month: number; year: number } {
+  // `en-CA` locale yields YYYY-MM-DD which is trivial to parse.
+  const ymd = date.toLocaleDateString('en-CA', {
+    timeZone: 'Asia/Bangkok',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const [y, m] = ymd.split('-').map(Number);
+  return { month: m, year: y };
+}
+
+export function replaceVariables(text: string, now: Date): string {
+  if (!text) return text;
+  const { month, year } = getBkkParts(now);
+  const monthStr = THAI_MONTHS_SHORT[month - 1];
+  const beYear = year + 543;
+
+  return text
+    // Note: {เดือนปี} must be replaced before {เดือน} to avoid partial-match consuming the prefix
+    .replace(/\{เดือนปี\}/g, `${monthStr} ${beYear}`)
+    .replace(/\{เดือน\}/g, monthStr)
+    .replace(/\{ปี\}/g, String(beYear));
+}

--- a/apps/api/src/modules/other-income/services/template.service.ts
+++ b/apps/api/src/modules/other-income/services/template.service.ts
@@ -89,6 +89,7 @@ export class TemplateService {
     return this.prisma.otherIncomeTemplate.findMany({
       where,
       orderBy: [{ isFavorite: 'desc' }, { lastUsedAt: 'desc' }, { createdAt: 'desc' }],
+      take: 200,
     });
   }
 

--- a/apps/api/src/modules/other-income/services/template.service.ts
+++ b/apps/api/src/modules/other-income/services/template.service.ts
@@ -1,0 +1,142 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { replaceVariables } from './template-vars.util';
+
+interface TemplateItem {
+  lineNo: number;
+  accountCode: string;
+  description?: string | null;
+  quantity: number;
+  unitAmount: number;
+  discountAmount: number;
+  vatPct: number;
+  whtPct: number;
+}
+
+interface CreateInput {
+  name: string;
+  itemsJson: TemplateItem[];
+  priceType: 'EXCLUSIVE' | 'INCLUSIVE';
+}
+
+interface UpdateInput {
+  name?: string;
+  isFavorite?: boolean;
+}
+
+@Injectable()
+export class TemplateService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private async resolveFinanceCompanyId(): Promise<string> {
+    const co = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+      select: { id: true },
+    });
+    if (!co) throw new BadRequestException('CompanyInfo FINANCE not found');
+    return co.id;
+  }
+
+  async create(dto: CreateInput, userId: string) {
+    if (!dto.name?.trim()) {
+      throw new BadRequestException('กรุณาระบุชื่อ Template');
+    }
+    if (!dto.itemsJson || dto.itemsJson.length === 0) {
+      throw new BadRequestException('Template ต้องมีรายการอย่างน้อย 1 รายการ');
+    }
+    const companyId = await this.resolveFinanceCompanyId();
+    return this.prisma.otherIncomeTemplate.create({
+      data: {
+        companyId,
+        name: dto.name.trim(),
+        itemsJson: dto.itemsJson as any,
+        priceType: dto.priceType,
+        createdById: userId,
+      },
+    });
+  }
+
+  async createFromDoc(docId: string, name: string, userId: string) {
+    if (!name?.trim()) throw new BadRequestException('กรุณาระบุชื่อ Template');
+    const doc = await this.prisma.otherIncome.findFirst({
+      where: { id: docId, deletedAt: null },
+      include: { items: { orderBy: { lineNo: 'asc' } } },
+    });
+    if (!doc) throw new NotFoundException(`OtherIncome ${docId} not found`);
+
+    const itemsJson: TemplateItem[] = doc.items.map((it) => ({
+      lineNo: it.lineNo,
+      accountCode: it.accountCode,
+      description: it.description,
+      quantity: Number(it.quantity),
+      unitAmount: Number(it.unitAmount),
+      discountAmount: Number(it.discountAmount),
+      vatPct: Number(it.vatPct),
+      whtPct: Number(it.whtPct),
+    }));
+
+    return this.create(
+      { name: name.trim(), itemsJson, priceType: doc.priceType },
+      userId,
+    );
+  }
+
+  async list(query: { q?: string; favoritesOnly?: boolean }) {
+    const where: any = { deletedAt: null };
+    if (query.favoritesOnly) where.isFavorite = true;
+    if (query.q) where.name = { contains: query.q, mode: 'insensitive' };
+
+    return this.prisma.otherIncomeTemplate.findMany({
+      where,
+      orderBy: [{ isFavorite: 'desc' }, { lastUsedAt: 'desc' }, { createdAt: 'desc' }],
+    });
+  }
+
+  async update(id: string, dto: UpdateInput) {
+    const tpl = await this.prisma.otherIncomeTemplate.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!tpl) throw new NotFoundException(`Template ${id} not found`);
+    return this.prisma.otherIncomeTemplate.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined ? { name: dto.name.trim() } : {}),
+        ...(dto.isFavorite !== undefined ? { isFavorite: dto.isFavorite } : {}),
+      },
+    });
+  }
+
+  async softDelete(id: string) {
+    const tpl = await this.prisma.otherIncomeTemplate.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!tpl) throw new NotFoundException(`Template ${id} not found`);
+    return this.prisma.otherIncomeTemplate.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  /**
+   * "Use" a template: return its items with variables resolved + bump usage counters.
+   * Does NOT create the OtherIncome doc — the caller (frontend) pre-fills the entry form.
+   */
+  async use(id: string, now: Date = new Date()) {
+    const tpl = await this.prisma.otherIncomeTemplate.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!tpl) throw new NotFoundException(`Template ${id} not found`);
+
+    const items = (tpl.itemsJson as unknown as TemplateItem[]).map((it) => ({
+      ...it,
+      description: it.description ? replaceVariables(it.description, now) : it.description,
+    }));
+
+    await this.prisma.otherIncomeTemplate.update({
+      where: { id },
+      data: { useCount: { increment: 1 }, lastUsedAt: now },
+    });
+
+    return { id: tpl.id, name: tpl.name, priceType: tpl.priceType, items };
+  }
+}

--- a/apps/api/src/modules/other-income/services/validation.service.ts
+++ b/apps/api/src/modules/other-income/services/validation.service.ts
@@ -106,9 +106,9 @@ export class ValidationService {
       }
     });
 
-    // V15 — Bank interest income (42-1102) is VAT-exempt under ม.81(1)(ฏ) and
-    // is statutorily WHT-deducted at 15% by the bank (ม.50(2)(ข) + ม.50 ทวิ).
-    // Bookings that violate either are almost always a misclassified account.
+    // V15 — Bank interest income (42-1102) is VAT-exempt under ม.81(1)(ฏ).
+    // WHT rate is left to user judgement (1% for นิติบุคคล ออมทรัพย์ ท.ป.4/2528;
+    // 15% for ฝากประจำ ม.50). UI tooltip surfaces per-account suggestions.
     doc.items?.forEach((it) => {
       if (it.accountCode !== '42-1102') return;
       if (it.vatPct.gt(0)) {
@@ -116,13 +116,6 @@ export class ValidationService {
           rule: 'V15',
           lineNo: it.lineNo,
           msg: `รายการที่ ${it.lineNo}: ดอกเบี้ยเงินฝาก (42-1102) ได้รับยกเว้น VAT (ม.81(1)(ฏ)) — กรุณาตั้ง VAT% = 0`,
-        });
-      }
-      if (!it.whtPct.eq(15)) {
-        warnings.push({
-          rule: 'V15',
-          lineNo: it.lineNo,
-          msg: `รายการที่ ${it.lineNo}: ดอกเบี้ยเงินฝาก (42-1102) ถูกหัก ณ ที่จ่าย 15% โดยธนาคารตามกฎหมาย — ตรวจสอบ WHT% อีกครั้ง`,
         });
       }
     });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -147,6 +147,9 @@ const OtherIncomeEntryPage = lazy(() => import('@/pages/other-income/OtherIncome
 const OtherIncomeViewPage = lazy(() => import('@/pages/other-income/OtherIncomeViewPage'));
 const OtherIncomeReceiptPage = lazy(() => import('@/pages/other-income/OtherIncomeReceiptPage'));
 const OtherIncomeDailySheetPage = lazy(() => import('@/pages/other-income/OtherIncomeDailySheetPage'));
+const OtherIncomePendingApprovalPage = lazy(
+  () => import('@/pages/other-income/OtherIncomePendingApprovalPage'),
+);
 const PeriodClosePage = lazy(() => import('@/pages/accounting/PeriodClosePage'));
 
 const PageLoader = () => (
@@ -1002,6 +1005,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <OtherIncomeDailySheetPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/other-income/pending-approval"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <OtherIncomePendingApprovalPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -147,6 +147,7 @@ const OtherIncomeEntryPage = lazy(() => import('@/pages/other-income/OtherIncome
 const OtherIncomeViewPage = lazy(() => import('@/pages/other-income/OtherIncomeViewPage'));
 const OtherIncomeReceiptPage = lazy(() => import('@/pages/other-income/OtherIncomeReceiptPage'));
 const OtherIncomeDailySheetPage = lazy(() => import('@/pages/other-income/OtherIncomeDailySheetPage'));
+const OtherIncomeTemplatesPage = lazy(() => import('@/pages/other-income/OtherIncomeTemplatesPage'));
 const PeriodClosePage = lazy(() => import('@/pages/accounting/PeriodClosePage'));
 
 const PageLoader = () => (
@@ -980,7 +981,7 @@ function App() {
             }
           />
 
-          {/* รายได้อื่น (Other Income) — CRITICAL: /daily-sheet BEFORE /:id */}
+          {/* รายได้อื่น (Other Income) — CRITICAL: /daily-sheet and /templates BEFORE /:id */}
           <Route
             path="/other-income"
             element={
@@ -1002,6 +1003,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <OtherIncomeDailySheetPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/other-income/templates"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <OtherIncomeTemplatesPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -76,4 +76,31 @@ export const otherIncomeApi = {
     api
       .get<{ threshold: number }>('/other-income/config/attachment-threshold')
       .then((r) => r.data.threshold),
+
+  // Templates (PR-3)
+  templates: {
+    list: (params?: { q?: string; favoritesOnly?: boolean }) =>
+      api.get('/other-income/templates', { params }).then((r) => r.data),
+    create: (data: {
+      name: string;
+      priceType: 'EXCLUSIVE' | 'INCLUSIVE';
+      items: Array<{
+        accountCode: string;
+        description?: string;
+        quantity: number | string;
+        unitAmount: number | string;
+        discountAmount: number | string;
+        vatPct: number | string;
+        whtPct: number | string;
+      }>;
+    }) => api.post('/other-income/templates', data).then((r) => r.data),
+    saveAsFromDoc: (docId: string, name: string) =>
+      api.post(`/other-income/from-doc/${docId}/save-template`, { name }).then((r) => r.data),
+    update: (id: string, data: { name?: string; isFavorite?: boolean }) =>
+      api.patch(`/other-income/templates/${id}`, data).then((r) => r.data),
+    remove: (id: string) =>
+      api.delete(`/other-income/templates/${id}`).then((r) => r.data),
+    use: (id: string) =>
+      api.post(`/other-income/templates/${id}/use`).then((r) => r.data),
+  },
 };

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -77,6 +77,9 @@ export const otherIncomeApi = {
       .get<{ threshold: number }>('/other-income/config/attachment-threshold')
       .then((r) => r.data.threshold),
 
+  isMakerCheckerEnabled: () =>
+    api.get<{ enabled: boolean }>('/other-income/maker-checker-enabled').then((r) => r.data.enabled),
+
   requestApproval: (id: string) =>
     api.post(`/other-income/${id}/request-approval`).then((r) => r.data),
 

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -76,4 +76,13 @@ export const otherIncomeApi = {
     api
       .get<{ threshold: number }>('/other-income/config/attachment-threshold')
       .then((r) => r.data.threshold),
+
+  requestApproval: (id: string) =>
+    api.post(`/other-income/${id}/request-approval`).then((r) => r.data),
+
+  approve: (id: string, note?: string) =>
+    api.post(`/other-income/${id}/approve`, { note }).then((r) => r.data),
+
+  reject: (id: string, note: string) =>
+    api.post(`/other-income/${id}/reject`, { note }).then((r) => r.data),
 };

--- a/apps/web/src/lib/otherIncome.types.ts
+++ b/apps/web/src/lib/otherIncome.types.ts
@@ -1,4 +1,4 @@
-export type OtherIncomeStatus = 'DRAFT' | 'POSTED' | 'REVERSED';
+export type OtherIncomeStatus = 'DRAFT' | 'READY' | 'POSTED' | 'REVERSED';
 export type OtherIncomePriceType = 'EXCLUSIVE' | 'INCLUSIVE';
 export type OtherIncomeReverseReason =
   | 'INPUT_ERROR'
@@ -67,6 +67,8 @@ export interface OtherIncome {
   isOverridden: boolean;
   customerNote: string | null;
   createdById: string;
+  rejectNote: string | null;
+  rejectedAt: string | null;
   postedAt: string | null;
   reversesId: string | null;
   // Auto-derived inverse of the self-FK `reversesId`; populated by the API when

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -30,6 +30,7 @@ import { ItemsTable } from './components/ItemsTable';
 import { AdjustmentTable } from './components/AdjustmentTable';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { CounterpartyPicker } from './components/CounterpartyPicker';
+import { TemplatePickerCombobox } from './components/TemplatePickerCombobox';
 
 // Fallback while config is loading; live value comes from /other-income/config/attachment-threshold
 const ATTACHMENT_THRESHOLD_FALLBACK = 50_000;
@@ -234,6 +235,7 @@ function SectionHeader({
 export default function OtherIncomeEntryPage() {
   const navigate = useNavigate();
   const { id } = useParams<{ id?: string }>();
+  const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const isEdit = !!id;
 
@@ -288,6 +290,37 @@ export default function OtherIncomeEntryPage() {
       });
     }
   }, [loadQuery.data, isEdit, reset]);
+
+  // Template prefill — hydrate form when navigated from TemplatesPage with ?fromTemplate=1
+  const { setValue } = form;
+  useEffect(() => {
+    if (searchParams.get('fromTemplate') !== '1') return;
+    const raw = sessionStorage.getItem('oi-template-prefill');
+    if (!raw) return;
+    try {
+      const tpl = JSON.parse(raw);
+      setValue('priceType', tpl.priceType);
+      setValue(
+        'items',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tpl.items.map((it: any, idx: number) => ({
+          accountCode: it.accountCode,
+          description: it.description ?? '',
+          quantity: it.quantity,
+          unitAmount: it.unitAmount,
+          discountAmount: it.discountAmount,
+          vatPct: it.vatPct,
+          whtPct: it.whtPct,
+          lineNo: idx + 1,
+        })),
+      );
+    } catch {
+      /* ignore malformed prefill */
+    } finally {
+      sessionStorage.removeItem('oi-template-prefill');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const saveDraftMutation = useMutation({
     mutationFn: (data: OtherIncomeFormValues) =>
@@ -608,7 +641,19 @@ export default function OtherIncomeEntryPage() {
 
           {/* Section 2 — Accounting items */}
           <section className="rounded-xl border bg-card p-5">
-            <SectionHeader num={2} title="รายการบันทึกทางบัญชี" />
+            <SectionHeader
+              num={2}
+              title="รายการบันทึกทางบัญชี"
+              action={
+                <TemplatePickerCombobox
+                  onApply={(items, priceType) => {
+                    setValue('priceType', priceType);
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    setValue('items', items.map((it: any, idx: number) => ({ ...it, lineNo: idx + 1 })));
+                  }}
+                />
+              }
+            />
             {form.formState.errors.items && typeof form.formState.errors.items.message === 'string' && (
               <p className="text-xs text-destructive mb-2">{form.formState.errors.items.message}</p>
             )}

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -319,6 +319,32 @@ export default function OtherIncomeEntryPage() {
     onError: () => toast.error('ไม่สามารถ POST เอกสารได้'),
   });
 
+  const flagQuery = useQuery({
+    queryKey: ['other-income-maker-checker-enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+    staleTime: 5 * 60_000,
+  });
+  const makerCheckerEnabled = flagQuery.data ?? false;
+
+  const saveAndRequestApprovalMutation = useMutation({
+    mutationFn: async (data: OtherIncomeFormValues) => {
+      let docId = id;
+      if (!docId) {
+        const created = await otherIncomeApi.create(data);
+        docId = created.id;
+      } else {
+        await otherIncomeApi.update(docId, data);
+      }
+      return otherIncomeApi.requestApproval(docId);
+    },
+    onSuccess: (doc: any) => {
+      toast.success('บันทึกและส่งขออนุมัติแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income'] });
+      navigate(`/other-income/${doc.id}`);
+    },
+    onError: () => toast.error('ส่งขออนุมัติไม่สำเร็จ'),
+  });
+
   const values = form.watch();
 
   // Compute live JE preview
@@ -367,7 +393,10 @@ export default function OtherIncomeEntryPage() {
 
   const watchedAdjustments = form.watch('adjustments') ?? [];
 
-  const isSubmitting = saveDraftMutation.isPending || saveAndPostMutation.isPending;
+  const isSubmitting =
+    saveDraftMutation.isPending ||
+    saveAndPostMutation.isPending ||
+    saveAndRequestApprovalMutation.isPending;
 
   // Income totals across all items (for footer/summary cards)
   const incomeTotals = useMemo(() => {
@@ -1040,12 +1069,22 @@ export default function OtherIncomeEntryPage() {
                   toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
                   return;
                 }
-                saveAndPostMutation.mutate(result.data);
+                if (makerCheckerEnabled) {
+                  saveAndRequestApprovalMutation.mutate(result.data);
+                } else {
+                  saveAndPostMutation.mutate(result.data);
+                }
               }}
               className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <Send size={14} />
-              {saveAndPostMutation.isPending ? 'กำลัง POST...' : 'บันทึก & POST'}
+              {saveAndRequestApprovalMutation.isPending
+                ? 'กำลังส่งขออนุมัติ...'
+                : saveAndPostMutation.isPending
+                  ? 'กำลัง POST...'
+                  : makerCheckerEnabled
+                    ? 'บันทึกและส่งขออนุมัติ'
+                    : 'บันทึก & POST'}
             </button>
           </div>
         </div>

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, ArrowRight } from 'lucide-react';
+import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, ArrowRight, ClipboardCheck } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -15,12 +15,14 @@ import { formatNumberDecimal } from '@/utils/formatters';
 
 const STATUS_LABELS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'ร่าง',
+  READY: 'รออนุมัติ',
   POSTED: 'บันทึกแล้ว',
   REVERSED: 'กลับรายการ',
 };
 
 const STATUS_COLORS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'bg-muted text-muted-foreground',
+  READY: 'bg-warning/10 text-warning',
   POSTED: 'bg-success/10 text-success',
   REVERSED: 'bg-destructive/10 text-destructive',
 };
@@ -45,16 +47,18 @@ function fmtDate(d: string | null | undefined) {
   return formatThaiDateShort(d);
 }
 
-type StatusAccent = 'warning' | 'success' | 'muted';
+type StatusAccent = 'warning' | 'info' | 'success' | 'muted';
 
 const ACCENT_BAR: Record<StatusAccent, string> = {
   warning: 'bg-warning',
+  info: 'bg-info',
   success: 'bg-success',
   muted: 'bg-muted-foreground/50',
 };
 
 const ACCENT_ICON: Record<StatusAccent, string> = {
   warning: 'bg-warning/10 text-warning',
+  info: 'bg-info/10 text-info',
   success: 'bg-success/10 text-success',
   muted: 'bg-muted text-muted-foreground',
 };
@@ -138,6 +142,21 @@ export default function OtherIncomeListPage() {
     staleTime: COUNT_STALE_TIME,
   });
 
+  const flagQuery = useQuery({
+    queryKey: ['other-income-maker-checker-enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+    staleTime: 5 * 60_000,
+  });
+  const makerCheckerEnabled = flagQuery.data ?? false;
+
+  const readyCountQuery = useQuery({
+    queryKey: ['other-income', 'count', 'READY'],
+    queryFn: () => otherIncomeApi.list({ status: 'READY', page: 1, limit: 1 }),
+    select: (d) => d.total,
+    staleTime: COUNT_STALE_TIME,
+    enabled: makerCheckerEnabled,
+  });
+
   const deleteMutation = useMutation({
     mutationFn: (id: string) => otherIncomeApi.softDelete(id),
     onSuccess: () => {
@@ -153,6 +172,7 @@ export default function OtherIncomeListPage() {
   const totalPages = Math.ceil(total / 50) || 1;
 
   const draftCount = draftCountQuery.data ?? 0;
+  const readyCount = readyCountQuery.data ?? 0;
   const postedCount = postedCountQuery.data ?? 0;
   const reversedCount = reversedCountQuery.data ?? 0;
 
@@ -175,7 +195,7 @@ export default function OtherIncomeListPage() {
       />
 
       {/* Status cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+      <div className={`grid gap-3 mb-6 ${makerCheckerEnabled ? 'grid-cols-2 md:grid-cols-5' : 'grid-cols-2 md:grid-cols-4'}`}>
         <StatusCard
           label="ฉบับร่าง"
           sub="DRAFT"
@@ -183,6 +203,15 @@ export default function OtherIncomeListPage() {
           accent="warning"
           value={draftCount}
         />
+        {makerCheckerEnabled && (
+          <StatusCard
+            label="รออนุมัติ"
+            sub="READY"
+            icon={<ClipboardCheck size={16} />}
+            accent="info"
+            value={readyCount}
+          />
+        )}
         <StatusCard
           label="บันทึกแล้ว"
           sub="POSTED"
@@ -239,6 +268,7 @@ export default function OtherIncomeListPage() {
         >
           <option value="">ทุกสถานะ</option>
           <option value="DRAFT">ร่าง</option>
+          {makerCheckerEnabled && <option value="READY">รออนุมัติ</option>}
           <option value="POSTED">บันทึกแล้ว</option>
           <option value="REVERSED">กลับรายการ</option>
         </select>

--- a/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
@@ -4,6 +4,8 @@ import { Clock, Inbox } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { otherIncomeApi } from '@/lib/otherIncome';
+import { formatThaiDateShort } from '@/lib/date';
+import { formatNumberDecimal } from '@/utils/formatters';
 
 export default function OtherIncomePendingApprovalPage() {
   const navigate = useNavigate();
@@ -54,7 +56,7 @@ export default function OtherIncomePendingApprovalPage() {
                   >
                     <td className="px-4 py-2 font-mono font-semibold text-primary">{d.docNumber}</td>
                     <td className="px-4 py-2 text-muted-foreground">
-                      {new Date(d.issueDate).toLocaleDateString('th-TH')}
+                      {formatThaiDateShort(d.issueDate)}
                     </td>
                     <td className="px-4 py-2">
                       {d.counterpartyName ?? d.customer?.name ?? (
@@ -62,9 +64,7 @@ export default function OtherIncomePendingApprovalPage() {
                       )}
                     </td>
                     <td className="px-4 py-2 text-right font-mono">
-                      {Number(d.amountReceived).toLocaleString('en-US', {
-                        minimumFractionDigits: 2,
-                      })}
+                      {formatNumberDecimal(d.amountReceived)}
                     </td>
                     <td className="px-4 py-2 text-right">
                       <Clock size={14} className="inline text-warning" />

--- a/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
@@ -1,0 +1,81 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
+import { Clock, Inbox } from 'lucide-react';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { otherIncomeApi } from '@/lib/otherIncome';
+
+export default function OtherIncomePendingApprovalPage() {
+  const navigate = useNavigate();
+  const query = useQuery({
+    queryKey: ['other-income', 'list', { status: 'READY' }],
+    queryFn: () => otherIncomeApi.list({ status: 'READY', limit: 100 }),
+  });
+
+  const data = query.data;
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <PageHeader
+        title="เอกสารรออนุมัติ"
+        subtitle="รายได้อื่น"
+        icon={<Clock size={20} />}
+        onBack={() => navigate('/other-income')}
+      />
+      <QueryBoundary
+        isLoading={query.isLoading}
+        isError={query.isError}
+        error={query.error}
+        onRetry={query.refetch}
+      >
+        {data && data.data.length === 0 ? (
+          <div className="text-center py-16 text-muted-foreground">
+            <Inbox className="mx-auto mb-3 opacity-50" size={40} />
+            <p>ไม่มีเอกสารรออนุมัติ</p>
+          </div>
+        ) : (
+          <div className="rounded-xl border bg-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-xs font-medium text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2 text-left">เลขที่</th>
+                  <th className="px-4 py-2 text-left">วันที่</th>
+                  <th className="px-4 py-2 text-left">ผู้ติดต่อ</th>
+                  <th className="px-4 py-2 text-right">ยอดรับ</th>
+                  <th className="px-4 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data?.data ?? []).map((d) => (
+                  <tr
+                    key={d.id}
+                    className="border-t hover:bg-accent/30 cursor-pointer"
+                    onClick={() => navigate(`/other-income/${d.id}`)}
+                  >
+                    <td className="px-4 py-2 font-mono font-semibold text-primary">{d.docNumber}</td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {new Date(d.issueDate).toLocaleDateString('th-TH')}
+                    </td>
+                    <td className="px-4 py-2">
+                      {d.counterpartyName ?? d.customer?.name ?? (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono">
+                      {Number(d.amountReceived).toLocaleString('en-US', {
+                        minimumFractionDigits: 2,
+                      })}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <Clock size={14} className="inline text-warning" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/OtherIncomeTemplatesPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeTemplatesPage.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Star, Trash2, Edit3, PlayCircle, Search, Inbox } from 'lucide-react';
+import { toast } from 'sonner';
+import { useDebounce } from '@/hooks/useDebounce';
+import { otherIncomeApi } from '@/lib/otherIncome';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { formatThaiDateShort } from '@/lib/date';
+import { RenameTemplateModal } from './components/RenameTemplateModal';
+
+export default function OtherIncomeTemplatesPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const debounced = useDebounce(search, 250);
+
+  // rename state
+  const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
+  // delete confirm state
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+
+  const query = useQuery({
+    queryKey: ['other-income-templates', debounced, favoritesOnly],
+    queryFn: () => otherIncomeApi.templates.list({ q: debounced || undefined, favoritesOnly }),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: { name?: string; isFavorite?: boolean } }) =>
+      otherIncomeApi.templates.update(id, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['other-income-templates'] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => otherIncomeApi.templates.remove(id),
+    onSuccess: () => {
+      toast.success('ลบ template แล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income-templates'] });
+      setDeleteTarget(null);
+    },
+  });
+
+  const useMutation_ = useMutation({
+    mutationFn: (id: string) => otherIncomeApi.templates.use(id),
+    onSuccess: (data) => {
+      sessionStorage.setItem('oi-template-prefill', JSON.stringify(data));
+      navigate('/other-income/new?fromTemplate=1');
+    },
+  });
+
+  return (
+    <div className="p-6 max-w-5xl">
+      <PageHeader
+        title="Templates รายได้อื่น"
+        action={
+          <button
+            onClick={() => navigate('/other-income/new')}
+            className="px-3 py-1.5 rounded-md border text-sm hover:bg-accent"
+          >
+            + สร้างเอกสารใหม่
+          </button>
+        }
+      />
+
+      <div className="flex gap-2 mb-4">
+        <div className="relative flex-1">
+          <Search
+            size={14}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="ค้นหาชื่อ template"
+            className="w-full pl-9 pr-3 py-2 border rounded-md text-sm bg-background"
+          />
+        </div>
+        <button
+          onClick={() => setFavoritesOnly((v) => !v)}
+          className={`px-3 py-2 rounded-md border text-sm inline-flex items-center gap-1 ${
+            favoritesOnly ? 'bg-warning/10 border-warning text-warning' : ''
+          }`}
+        >
+          <Star size={14} />
+          ที่ชอบ
+        </button>
+      </div>
+
+      <QueryBoundary
+        isLoading={query.isLoading}
+        isError={query.isError}
+        error={query.error}
+        onRetry={query.refetch}
+      >
+        {query.data?.length === 0 ? (
+          <div className="text-center py-16 text-muted-foreground">
+            <Inbox className="mx-auto mb-3 opacity-50" size={40} />
+            <p>ไม่มี Template — บันทึกจากเอกสารที่ POSTED แล้วเพื่อเริ่มต้น</p>
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {(query.data ?? []).map((t: any) => (
+              <li key={t.id} className="rounded-lg border bg-card p-3 flex items-start gap-3">
+                <button
+                  onClick={() =>
+                    updateMutation.mutate({ id: t.id, data: { isFavorite: !t.isFavorite } })
+                  }
+                  className="mt-1"
+                  aria-label={t.isFavorite ? 'ถอด template ออกจากรายการที่ชอบ' : 'เพิ่ม template เข้ารายการที่ชอบ'}
+                >
+                  <Star
+                    size={16}
+                    className={
+                      t.isFavorite ? 'fill-warning text-warning' : 'text-muted-foreground'
+                    }
+                  />
+                </button>
+                <div className="flex-1">
+                  <div className="font-semibold">{t.name}</div>
+                  <div className="text-xs text-muted-foreground mt-0.5">
+                    {t.itemsJson?.length ?? 0} รายการ · ใช้ {t.useCount} ครั้ง
+                    {t.lastUsedAt && ` · ล่าสุด ${formatThaiDateShort(t.lastUsedAt)}`}
+                  </div>
+                </div>
+                <div className="flex gap-1">
+                  <button
+                    onClick={() => useMutation_.mutate(t.id)}
+                    className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs inline-flex items-center gap-1 hover:bg-primary/90"
+                  >
+                    <PlayCircle size={12} /> ใช้
+                  </button>
+                  <button
+                    onClick={() => setRenameTarget({ id: t.id, name: t.name })}
+                    className="p-1.5 rounded-md border hover:bg-accent"
+                    title="แก้ชื่อ"
+                    aria-label="แก้ชื่อ template"
+                  >
+                    <Edit3 size={12} />
+                  </button>
+                  <button
+                    onClick={() => setDeleteTarget({ id: t.id, name: t.name })}
+                    className="p-1.5 rounded-md border hover:bg-destructive/10 text-destructive"
+                    title="ลบ"
+                    aria-label="ลบ template"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </QueryBoundary>
+
+      {/* Rename modal */}
+      {renameTarget && (
+        <RenameTemplateModal
+          defaultName={renameTarget.name}
+          isLoading={updateMutation.isPending}
+          onCancel={() => setRenameTarget(null)}
+          onConfirm={(name) => {
+            updateMutation.mutate(
+              { id: renameTarget.id, data: { name } },
+              { onSuccess: () => setRenameTarget(null) },
+            );
+          }}
+        />
+      )}
+
+      {/* Delete confirm dialog */}
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+        title="ยืนยันการลบ"
+        description={`ลบ "${deleteTarget?.name ?? ''}"?`}
+        confirmLabel="ลบ"
+        variant="destructive"
+        loading={deleteMutation.isPending}
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Check, CheckCircle2, Clock, Copy, Edit, History, Printer, Ro
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ReverseModal } from './components/ReverseModal';
+import { RejectModal } from './components/RejectModal';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus, OtherIncomeReverseReason } from '@/lib/otherIncome.types';
@@ -137,6 +138,7 @@ export default function OtherIncomeViewPage() {
   const { user } = useAuth();
 
   const [showReverseModal, setShowReverseModal] = useState(false);
+  const [showRejectModal, setShowRejectModal] = useState(false);
 
   const auditQuery = useQuery({
     queryKey: ['other-income', id, 'audit'],
@@ -300,10 +302,7 @@ export default function OtherIncomeViewPage() {
                       </button>
                       <button
                         type="button"
-                        onClick={() => {
-                          const note = window.prompt('เหตุผลการปฏิเสธ:');
-                          if (note?.trim()) rejectMutation.mutate(note.trim());
-                        }}
+                        onClick={() => setShowRejectModal(true)}
                         disabled={rejectMutation.isPending}
                         className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold border border-destructive text-destructive rounded-lg hover:bg-destructive/10 disabled:opacity-50"
                       >
@@ -675,6 +674,19 @@ export default function OtherIncomeViewPage() {
           onCancel={() => setShowReverseModal(false)}
           onConfirm={(reason, note) => reverseMutation.mutate({ reason, note })}
           isLoading={reverseMutation.isPending}
+        />
+      )}
+
+      {/* Reject modal (PR-2 Maker-Checker) */}
+      {showRejectModal && doc && (
+        <RejectModal
+          docNumber={doc.docNumber}
+          isLoading={rejectMutation.isPending}
+          onCancel={() => setShowRejectModal(false)}
+          onConfirm={(note) => {
+            rejectMutation.mutate(note);
+            setShowRejectModal(false);
+          }}
         />
       )}
     </div>

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, CheckCircle2, Copy, Edit, History, Printer, RotateCcw, Recei
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ReverseModal } from './components/ReverseModal';
+import { SaveAsTemplateModal } from './components/SaveAsTemplateModal';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus, OtherIncomeReverseReason } from '@/lib/otherIncome.types';
@@ -135,6 +136,7 @@ export default function OtherIncomeViewPage() {
   const { user } = useAuth();
 
   const [showReverseModal, setShowReverseModal] = useState(false);
+  const [showTemplateModal, setShowTemplateModal] = useState(false);
 
   const auditQuery = useQuery({
     queryKey: ['other-income', id, 'audit'],
@@ -170,6 +172,16 @@ export default function OtherIncomeViewPage() {
     onError: () => toast.error('ไม่สามารถคัดลอกเอกสารได้'),
   });
 
+  const saveTemplateMutation = useMutation({
+    mutationFn: (name: string) => otherIncomeApi.templates.saveAsFromDoc(id!, name),
+    onSuccess: () => {
+      toast.success('บันทึกเป็น template แล้ว');
+      setShowTemplateModal(false);
+    },
+    onError: (err: any) =>
+      toast.error(err?.response?.data?.message ?? 'บันทึก template ไม่สำเร็จ'),
+  });
+
   const canReverse =
     user?.role && REVERSE_ROLES.includes(user.role) && docQuery.data?.status === 'POSTED';
 
@@ -197,6 +209,15 @@ export default function OtherIncomeViewPage() {
                 <Copy size={14} />
                 คัดลอก
               </button>
+              {(doc.status === 'POSTED' || doc.status === 'REVERSED') && (
+                <button
+                  type="button"
+                  onClick={() => setShowTemplateModal(true)}
+                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
+                >
+                  บันทึกเป็น Template
+                </button>
+              )}
               {doc.status === 'POSTED' && doc.customerId && (
                 <button
                   type="button"
@@ -547,6 +568,16 @@ export default function OtherIncomeViewPage() {
           onCancel={() => setShowReverseModal(false)}
           onConfirm={(reason, note) => reverseMutation.mutate({ reason, note })}
           isLoading={reverseMutation.isPending}
+        />
+      )}
+
+      {/* Save-as-template modal */}
+      {showTemplateModal && doc && (
+        <SaveAsTemplateModal
+          defaultName={`${doc.counterpartyName ?? 'รายได้อื่น'} — ${formatThaiDateShort(doc.issueDate)}`}
+          isLoading={saveTemplateMutation.isPending}
+          onCancel={() => setShowTemplateModal(false)}
+          onConfirm={(name) => saveTemplateMutation.mutate(name)}
         />
       )}
     </div>

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -11,7 +11,7 @@ import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus, OtherIncomeReverseReason } from '@/lib/otherIncome.types';
 import { useAuth } from '@/contexts/AuthContext';
-import { formatThaiDateLong } from '@/lib/date';
+import { formatThaiDateLong, formatThaiDateShort } from '@/lib/date';
 
 // ------------------------------------------------------------------
 // Helpers

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -313,7 +313,7 @@ export default function OtherIncomeViewPage() {
                     </>
                   ) : user?.role === 'OWNER' && doc.createdById === user.id ? (
                     <div className="rounded-md bg-muted text-muted-foreground text-sm px-3 py-2">
-                      ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้ (V9)
+                      ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้
                     </div>
                   ) : (
                     <div className="rounded-md bg-info/10 text-info text-sm px-3 py-2 inline-flex items-center gap-1">

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -18,12 +18,14 @@ import { formatThaiDateLong } from '@/lib/date';
 
 const STATUS_LABELS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'ร่าง',
+  READY: 'รออนุมัติ',
   POSTED: 'บันทึกแล้ว',
   REVERSED: 'กลับรายการแล้ว',
 };
 
 const STATUS_COLORS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'bg-muted text-muted-foreground',
+  READY: 'bg-warning/10 text-warning',
   POSTED: 'bg-success/10 text-success',
   REVERSED: 'bg-destructive/10 text-destructive',
 };

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { ArrowLeft, CheckCircle2, Copy, Edit, History, Printer, RotateCcw, Receipt, FileText } from 'lucide-react';
+import { ArrowLeft, Check, CheckCircle2, Clock, Copy, Edit, History, Printer, RotateCcw, Receipt, FileText, Send, X } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ReverseModal } from './components/ReverseModal';
@@ -172,13 +172,52 @@ export default function OtherIncomeViewPage() {
     onError: () => toast.error('ไม่สามารถคัดลอกเอกสารได้'),
   });
 
+  const flagQuery = useQuery({
+    queryKey: ['other-income-maker-checker-enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+    staleTime: 5 * 60_000,
+  });
+  const makerCheckerEnabled = flagQuery.data ?? false;
+
+  const requestApprovalMutation = useMutation({
+    mutationFn: () => otherIncomeApi.requestApproval(id!),
+    onSuccess: () => {
+      toast.success('ส่งขออนุมัติแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income', id] });
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'ส่งขออนุมัติไม่สำเร็จ'),
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (note: string | undefined) => otherIncomeApi.approve(id!, note),
+    onSuccess: () => {
+      toast.success('อนุมัติและบันทึกบัญชีเรียบร้อย');
+      queryClient.invalidateQueries({ queryKey: ['other-income', id] });
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'อนุมัติไม่สำเร็จ'),
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: (note: string) => otherIncomeApi.reject(id!, note),
+    onSuccess: () => {
+      toast.success('ปฏิเสธคำขอแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['other-income', id] });
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'ปฏิเสธไม่สำเร็จ'),
+  });
+
   const canReverse =
     user?.role && REVERSE_ROLES.includes(user.role) && docQuery.data?.status === 'POSTED';
 
   const doc = docQuery.data;
   const jeLines = doc ? buildJeFromDoc(doc) : [];
 
-  const isActionLoading = reverseMutation.isPending || copyMutation.isPending;
+  const isActionLoading =
+    reverseMutation.isPending ||
+    copyMutation.isPending ||
+    requestApprovalMutation.isPending ||
+    approveMutation.isPending ||
+    rejectMutation.isPending;
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
@@ -210,14 +249,79 @@ export default function OtherIncomeViewPage() {
                 </button>
               )}
               {doc.status === 'DRAFT' && (
-                <button
-                  type="button"
-                  onClick={() => navigate(`/other-income/${doc.id}/edit`)}
-                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
-                >
-                  <Edit size={14} />
-                  แก้ไข
-                </button>
+                <>
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/other-income/${doc.id}/edit`)}
+                    className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
+                  >
+                    <Edit size={14} />
+                    แก้ไข
+                  </button>
+                  {makerCheckerEnabled ? (
+                    <button
+                      type="button"
+                      onClick={() => requestApprovalMutation.mutate()}
+                      disabled={requestApprovalMutation.isPending}
+                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      <Send size={14} />
+                      ส่งขออนุมัติ
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/other-income/${doc.id}/edit`)}
+                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90"
+                    >
+                      <Check size={14} />
+                      แก้ไขและ POST
+                    </button>
+                  )}
+                </>
+              )}
+              {doc.status === 'READY' && (
+                <>
+                  {doc.rejectNote && (
+                    <div className="rounded-md bg-warning/10 text-warning text-xs px-3 py-2">
+                      เคยถูกปฏิเสธ: {doc.rejectNote}
+                    </div>
+                  )}
+                  {user?.role === 'OWNER' && doc.createdById !== user.id ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => approveMutation.mutate(undefined)}
+                        disabled={approveMutation.isPending}
+                        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
+                      >
+                        <Check size={14} />
+                        อนุมัติ + POST
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const note = window.prompt('เหตุผลการปฏิเสธ:');
+                          if (note?.trim()) rejectMutation.mutate(note.trim());
+                        }}
+                        disabled={rejectMutation.isPending}
+                        className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold border border-destructive text-destructive rounded-lg hover:bg-destructive/10 disabled:opacity-50"
+                      >
+                        <X size={14} />
+                        ปฏิเสธ
+                      </button>
+                    </>
+                  ) : user?.role === 'OWNER' && doc.createdById === user.id ? (
+                    <div className="rounded-md bg-muted text-muted-foreground text-sm px-3 py-2">
+                      ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้ (V9)
+                    </div>
+                  ) : (
+                    <div className="rounded-md bg-info/10 text-info text-sm px-3 py-2 inline-flex items-center gap-1">
+                      <Clock size={14} />
+                      รออนุมัติจาก OWNER
+                    </div>
+                  )}
+                </>
               )}
               {canReverse && (
                 <button
@@ -486,14 +590,36 @@ export default function OtherIncomeViewPage() {
               {doc.status === 'DRAFT' && (
                 <div className="rounded-xl border bg-card p-5 space-y-2">
                   <p className="text-sm text-muted-foreground">เอกสารนี้ยังเป็นร่าง — ยังไม่มี Journal Entry</p>
-                  <button
-                    type="button"
-                    onClick={() => navigate(`/other-income/${doc.id}/edit`)}
-                    className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90"
-                  >
-                    <Edit size={14} />
-                    แก้ไขและ POST
-                  </button>
+                  {makerCheckerEnabled ? (
+                    <button
+                      type="button"
+                      onClick={() => requestApprovalMutation.mutate()}
+                      disabled={requestApprovalMutation.isPending}
+                      className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      <Send size={14} />
+                      ส่งขออนุมัติ
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/other-income/${doc.id}/edit`)}
+                      className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90"
+                    >
+                      <Edit size={14} />
+                      แก้ไขและ POST
+                    </button>
+                  )}
+                </div>
+              )}
+              {/* READY shortcut info */}
+              {doc.status === 'READY' && (
+                <div className="rounded-xl border bg-card p-5 space-y-2">
+                  <div className="inline-flex items-center gap-2 text-warning text-sm font-semibold">
+                    <Clock size={16} />
+                    รออนุมัติ
+                  </div>
+                  <p className="text-xs text-muted-foreground">เอกสารนี้รอการอนุมัติจาก OWNER — ยังไม่มี Journal Entry</p>
                 </div>
               )}
             </div>

--- a/apps/web/src/pages/other-income/components/ItemsTable.tsx
+++ b/apps/web/src/pages/other-income/components/ItemsTable.tsx
@@ -10,6 +10,12 @@ import { AccountSearchDropdown } from './AccountSearchDropdown';
 import { formatNumberDecimal } from '@/utils/formatters';
 import type { OtherIncomeFormValues } from '@/lib/otherIncome.schema';
 
+/** Per-account WHT% suggestion. Soft tooltip — never blocks. */
+const WHT_SUGGESTION: Record<string, { pct: number; reason: string }> = {
+  '42-1102': { pct: 1, reason: 'นิติบุคคล ออมทรัพย์ (ท.ป.4/2528)' },
+  '42-1105': { pct: 1, reason: 'ขายสินทรัพย์ให้นิติบุคคล (ท.ป.4/2528)' },
+};
+
 interface Props {
   control: Control<OtherIncomeFormValues>;
   register: UseFormRegister<OtherIncomeFormValues>;
@@ -152,6 +158,17 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
                       </option>
                     ))}
                   </select>
+                  {(() => {
+                    const acc = items[idx]?.accountCode ?? '';
+                    const sug = WHT_SUGGESTION[acc];
+                    if (!sug || whtPct === sug.pct) return null;
+                    return (
+                      <p className="mt-1 text-[10px] text-muted-foreground inline-flex items-center gap-1">
+                        <Lightbulb size={10} className="text-warning" />
+                        แนะนำ {sug.pct}% — {sug.reason}
+                      </p>
+                    );
+                  })()}
                 </div>
                 <div>
                   <label className="text-muted-foreground font-medium">ก่อนภาษี</label>

--- a/apps/web/src/pages/other-income/components/ItemsTable.tsx
+++ b/apps/web/src/pages/other-income/components/ItemsTable.tsx
@@ -193,7 +193,7 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
             unitAmount: 0,
             discountAmount: 0,
             vatPct: 0,
-            whtPct: 15,
+            whtPct: 1,
             description: '',
           })
         }

--- a/apps/web/src/pages/other-income/components/RejectModal.tsx
+++ b/apps/web/src/pages/other-income/components/RejectModal.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { XCircle } from 'lucide-react';
+
+interface Props {
+  docNumber: string;
+  onCancel: () => void;
+  onConfirm: (note: string) => void;
+  isLoading?: boolean;
+}
+
+export function RejectModal({ docNumber, onCancel, onConfirm, isLoading }: Props) {
+  const [note, setNote] = useState('');
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+      <div className="bg-background rounded-2xl border-2 border-destructive max-w-2xl w-full p-6">
+        <h3 className="text-lg font-bold flex items-center gap-2 text-destructive mb-3">
+          <XCircle size={20} /> ปฏิเสธคำขออนุมัติ
+        </h3>
+        <p className="text-sm mb-4">
+          ปฏิเสธเอกสาร <span className="font-mono font-bold">{docNumber}</span> —
+          ระบบจะส่งเอกสารกลับเป็นสถานะ DRAFT พร้อมเหตุผลของผู้ปฏิเสธ
+        </p>
+        <label className="text-xs font-semibold uppercase">เหตุผลการปฏิเสธ</label>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          autoFocus
+          placeholder="เหตุผลการปฏิเสธ"
+          className="w-full border rounded-md px-3 py-2 text-sm"
+        />
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            onClick={onCancel}
+            type="button"
+            className="px-4 py-2 text-sm font-semibold rounded-md border"
+          >
+            ยกเลิก
+          </button>
+          <button
+            onClick={() => onConfirm(note.trim())}
+            disabled={note.trim().length === 0 || isLoading}
+            className="px-5 py-2 text-sm font-bold rounded-md bg-destructive text-destructive-foreground disabled:opacity-50"
+          >
+            {isLoading ? 'กำลังปฏิเสธ...' : 'ปฏิเสธ'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/components/RenameTemplateModal.tsx
+++ b/apps/web/src/pages/other-income/components/RenameTemplateModal.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface Props {
+  defaultName: string;
+  isLoading: boolean;
+  onCancel: () => void;
+  onConfirm: (name: string) => void;
+}
+
+export function RenameTemplateModal({ defaultName, isLoading, onCancel, onConfirm }: Props) {
+  const [name, setName] = useState(defaultName);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (name.trim()) onConfirm(name.trim());
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-card rounded-xl border p-5 w-full max-w-md mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="font-bold">แก้ชื่อ Template</h3>
+          <button onClick={onCancel} aria-label="ปิด">
+            <X size={16} />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit}>
+          <label className="text-xs text-muted-foreground font-medium">ชื่อ Template</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="mt-1 w-full border rounded px-3 py-2 text-sm bg-background"
+            placeholder="ชื่อ template"
+            autoFocus
+          />
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-3 py-1.5 rounded-md border text-sm"
+            >
+              ยกเลิก
+            </button>
+            <button
+              type="submit"
+              disabled={!name.trim() || isLoading}
+              className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm disabled:opacity-50"
+            >
+              {isLoading ? 'กำลังบันทึก...' : 'บันทึก'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/components/SaveAsTemplateModal.tsx
+++ b/apps/web/src/pages/other-income/components/SaveAsTemplateModal.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface Props {
+  defaultName: string;
+  isLoading: boolean;
+  onCancel: () => void;
+  onConfirm: (name: string) => void;
+}
+
+export function SaveAsTemplateModal({ defaultName, isLoading, onCancel, onConfirm }: Props) {
+  const [name, setName] = useState(defaultName);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (name.trim()) onConfirm(name.trim());
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-card rounded-xl border p-5 w-full max-w-md mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="font-bold">บันทึกเป็น Template</h3>
+          <button onClick={onCancel} aria-label="ปิด">
+            <X size={16} />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit}>
+          <label className="text-xs text-muted-foreground font-medium">ชื่อ Template</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="mt-1 w-full border rounded px-3 py-2 text-sm bg-background"
+            placeholder="เช่น ดอกเบี้ย KBank รายเดือน"
+            autoFocus
+          />
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-3 py-1.5 rounded-md border text-sm"
+            >
+              ยกเลิก
+            </button>
+            <button
+              type="submit"
+              disabled={!name.trim() || isLoading}
+              className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm disabled:opacity-50"
+            >
+              {isLoading ? 'กำลังบันทึก...' : 'บันทึก'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/components/TemplatePickerCombobox.tsx
+++ b/apps/web/src/pages/other-income/components/TemplatePickerCombobox.tsx
@@ -1,0 +1,59 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import { otherIncomeApi } from '@/lib/otherIncome';
+
+interface Props {
+  onApply: (resolvedItems: any[], priceType: 'EXCLUSIVE' | 'INCLUSIVE') => void;
+}
+
+export function TemplatePickerCombobox({ onApply }: Props) {
+  const [open, setOpen] = useState(false);
+  const query = useQuery({
+    queryKey: ['other-income-templates-picker'],
+    queryFn: () => otherIncomeApi.templates.list(),
+    enabled: open,
+  });
+  const useMutation_ = useMutation({
+    mutationFn: (id: string) => otherIncomeApi.templates.use(id),
+    onSuccess: (data) => {
+      onApply(data.items, data.priceType);
+      setOpen(false);
+    },
+  });
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 px-3 py-1.5 border rounded-md text-xs hover:bg-accent"
+      >
+        ใช้ template <ChevronDown size={12} />
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-1 w-72 max-h-72 overflow-auto border rounded-md bg-popover shadow-lg">
+          {(query.data ?? []).map((t: any) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => useMutation_.mutate(t.id)}
+              className="w-full text-left px-3 py-2 hover:bg-accent text-xs"
+            >
+              <div className="font-semibold">{t.name}</div>
+              <div className="text-muted-foreground">
+                {t.itemsJson?.length ?? 0} รายการ · ใช้ {t.useCount} ครั้ง
+              </div>
+            </button>
+          ))}
+          {query.data?.length === 0 && (
+            <div className="px-3 py-4 text-xs text-muted-foreground text-center">ไม่มี template</div>
+          )}
+          {query.isLoading && (
+            <div className="px-3 py-4 text-xs text-muted-foreground text-center">กำลังโหลด...</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/components/TemplatePickerCombobox.tsx
+++ b/apps/web/src/pages/other-income/components/TemplatePickerCombobox.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { ChevronDown } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { otherIncomeApi } from '@/lib/otherIncome';
 
 interface Props {
@@ -9,6 +9,19 @@ interface Props {
 
 export function TemplatePickerCombobox({ onApply }: Props) {
   const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
   const query = useQuery({
     queryKey: ['other-income-templates-picker'],
     queryFn: () => otherIncomeApi.templates.list(),
@@ -23,7 +36,7 @@ export function TemplatePickerCombobox({ onApply }: Props) {
   });
 
   return (
-    <div className="relative">
+    <div className="relative" ref={ref}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}


### PR DESCRIPTION
## Summary

Combined PR closing accountant Gap Analysis Report on Other Income module (was 3 separate PRs #820 + #821 + #822, bundled for single review/merge).

### PR-1 — Bug fixes B1-B6 (6 commits)
- **B1** pass `companyId` to `validatePeriodOpen()` on `post()` + `reverse()` → AccountingPeriod tier-1 check now fires per-company
- **B2** drop V15 WHT-rate warning (forced 15% but BESTCHOICE = นิติบุคคล ออมทรัพย์ → 1% per ท.ป.4/2528)
- **B3** default `whtPct: 1` for new ItemsTable rows
- **B4** verified audit trail section already exists
- **B5** per-account WHT suggestion tooltip
- **B6** verified mobile responsive

### PR-2 — Maker-Checker workflow (14 commits)
- SystemConfig flag `OTHER_INCOME_MAKER_CHECKER_ENABLED` (default **false** → backward compat)
- Workflow when ON: DRAFT → READY → APPROVED → POSTED (APPROVED transient, never persisted; approve() does READY → POSTED atomically in `\$transaction`)
- V9: maker ≠ approver enforced inside `approve()`
- Approver = OWNER only
- 3 endpoints + ListPage 5th card + ViewPage action bar + PendingApprovalPage + EntryPage submit label
- Schema migration adds 6 nullable columns + 2 new enum values

### PR-3 — Templates with variable replacement (10 commits)
- New `OtherIncomeTemplate` model — global per-company scope, OI only
- Variable replacement `{เดือน}` / `{ปี}` / `{เดือนปี}` — always Asia/Bangkok
- Favorites + search + save-from-doc
- 6 endpoints + TemplatesPage + EntryPage prefill + ViewPage save-as-template modal

### Combined size
- 31 work commits + 3 merge commits = 34 total
- 3 conflicts resolved: `apps/web/src/App.tsx` (combined 2 routes), `apps/web/src/lib/otherIncome.ts` (combined 2 API namespaces), `apps/web/src/pages/other-income/OtherIncomeViewPage.tsx` (combined 2 modal sets)
- All conflicts were purely additive — no semantic clashes

### Migrations (apply in order)
1. \`20260920000000_add_other_income_maker_checker\` — enum extension + 6 nullable cols
2. \`20260921000000_add_other_income_template\` — new table

### Backward compat
- PR-1 fixes — closing bugs, no behavior regression
- PR-2 — feature-flagged off by default. Zero behavior change until owner toggles SystemConfig flag.
- PR-3 — purely additive (new model, new routes, new pages, new buttons on existing pages)

### Test results (per individual PR, before combining)
- API: 22/22 maker-checker + 7/7 template + 47/47 other-income service tests passing
- TS: 0 errors on api + web

Spec: \`docs/superpowers/specs/2026-05-12-other-income-v2-1-pdf-gap-fixes-design.md\`
Plans: \`docs/superpowers/plans/2026-05-12-other-income-v2-1-pr{1,2,3}-*.md\`

Supersedes (and will close on merge): #820 #821 #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)