### PR TITLE
fix(other-income): post-merge review followups — TOCTOU race + role consistency + Thai errors

### DIFF
--- a/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
@@ -119,6 +119,17 @@ describe('OtherIncomeService — Maker-Checker', () => {
     });
   }, 30_000);
 
+  // Safety net: re-enable flag after every test. The "flag disabled" tests
+  // explicitly restore the flag, but if an assertion failure short-circuits
+  // before the restore line, subsequent tests would see the wrong state.
+  // This afterEach guarantees a clean baseline.
+  afterEach(async () => {
+    await prisma.systemConfig.update({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      data: { value: 'true' },
+    }).catch(() => undefined);
+  });
+
   afterAll(async () => {
     // Clean up test data
     const ois = await prisma.otherIncome.findMany({
@@ -200,7 +211,7 @@ describe('OtherIncomeService — Maker-Checker', () => {
     const draft = await createStandardDraft();
 
     await expect(service.requestApproval(draft.id, makerId)).rejects.toMatchObject({
-      message: 'Maker-Checker disabled — use POST directly',
+      message: 'Maker-Checker ปิดอยู่ — ใช้ /post โดยตรง',
     });
 
     // Re-enable for subsequent tests
@@ -285,7 +296,7 @@ describe('OtherIncomeService — Maker-Checker', () => {
     });
 
     await expect(service.approve(draft.id, {}, approverId)).rejects.toMatchObject({
-      message: 'Maker-Checker disabled',
+      message: 'Maker-Checker ปิดอยู่',
     });
 
     // Re-enable
@@ -340,7 +351,7 @@ describe('OtherIncomeService — Maker-Checker', () => {
 
     await expect(
       service.reject(draft.id, { note: 'ปฏิเสธ' }, approverId),
-    ).rejects.toMatchObject({ message: 'Maker-Checker disabled' });
+    ).rejects.toMatchObject({ message: 'Maker-Checker ปิดอยู่' });
 
     // Re-enable
     await prisma.systemConfig.update({

--- a/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
@@ -366,4 +366,31 @@ describe('OtherIncomeService — Maker-Checker', () => {
     expect(resubmitted.rejectedById).toBeNull();
     expect(resubmitted.rejectNote).toBeNull();
   }, 30_000);
+
+  it('approve(): concurrent CAS-claim — only one approval wins on a single READY doc', async () => {
+    // Regression for review feedback (TOCTOU race in approve()):
+    // Two simultaneous approve() calls must not both succeed.
+    const draft = await createStandardDraft();
+    await service.requestApproval(draft.id, makerId);
+
+    const [resA, resB] = await Promise.allSettled([
+      service.approve(draft.id, { note: 'A' }, approverId),
+      service.approve(draft.id, { note: 'B' }, approverId),
+    ]);
+
+    const fulfilled = [resA, resB].filter((r) => r.status === 'fulfilled');
+    const rejected = [resA, resB].filter((r) => r.status === 'rejected');
+    expect(fulfilled.length).toBe(1);
+    expect(rejected.length).toBe(1);
+
+    // Loser must hit the CAS error, not pass silently
+    const err = (rejected[0] as PromiseRejectedResult).reason;
+    const msg = err?.message ?? err?.response?.message ?? '';
+    expect(msg).toMatch(/ผู้อื่น|สถานะ/);
+
+    // Doc lands in POSTED with exactly one journalEntryId
+    const final = await prisma.otherIncome.findUnique({ where: { id: draft.id } });
+    expect(final?.status).toBe('POSTED');
+    expect(final?.journalEntryId).toBeTruthy();
+  }, 30_000);
 });

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -76,13 +76,13 @@ export class OtherIncomeController {
   // "templates" being captured as an OtherIncome doc id by Nest's matcher.
 
   @Get('templates')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   listTemplates(@Query('q') q?: string, @Query('favoritesOnly') favoritesOnly?: string) {
     return this.templateService.list({ q, favoritesOnly: favoritesOnly === 'true' });
   }
 
   @Post('templates')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   createTemplate(@Body() dto: CreateTemplateDto, @CurrentUser('id') userId: string) {
     return this.templateService.create(
       {
@@ -104,7 +104,7 @@ export class OtherIncomeController {
   }
 
   @Post('from-doc/:id/save-template')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   saveAsTemplate(
     @Param('id') id: string,
     @Body() dto: CreateTemplateFromDocDto,
@@ -114,19 +114,19 @@ export class OtherIncomeController {
   }
 
   @Patch('templates/:id')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   updateTemplate(@Param('id') id: string, @Body() dto: UpdateTemplateDto) {
     return this.templateService.update(id, dto);
   }
 
   @Delete('templates/:id')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   deleteTemplate(@Param('id') id: string) {
     return this.templateService.softDelete(id);
   }
 
   @Post('templates/:id/use')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   useTemplate(@Param('id') id: string) {
     return this.templateService.use(id);
   }
@@ -185,7 +185,7 @@ export class OtherIncomeController {
   }
 
   @Post(':id/request-approval')
-  @Roles('OWNER', 'ACCOUNTANT', 'SALES')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   @HttpCode(200)
   requestApproval(@Param('id', new ParseUUIDPipe()) id: string, @CurrentUser('id') userId: string) {
     return this.service.requestApproval(id, userId);

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -229,7 +229,7 @@ export class OtherIncomeService {
    */
   async requestApproval(id: string, userId: string) {
     if (!(await this.isMakerCheckerEnabled())) {
-      throw new BadRequestException('Maker-Checker disabled — use POST directly');
+      throw new BadRequestException('Maker-Checker ปิดอยู่ — ใช้ /post โดยตรง');
     }
     const doc = await this.findOneOrFail(id);
     if (doc.status !== OtherIncomeStatus.DRAFT) {
@@ -264,7 +264,7 @@ export class OtherIncomeService {
     userId: string,
   ) {
     if (!(await this.isMakerCheckerEnabled())) {
-      throw new BadRequestException('Maker-Checker disabled');
+      throw new BadRequestException('Maker-Checker ปิดอยู่ — ใช้ /post โดยตรง');
     }
     const doc = await this.findOneOrFail(id);
     if (doc.status !== OtherIncomeStatus.READY) {
@@ -285,7 +285,8 @@ export class OtherIncomeService {
       });
     }
 
-    // Re-run validation (period lock, balance, etc.)
+    // Re-run validation (period lock, balance, etc.) — happens outside tx, fine
+    // because the CAS-claim below is the real concurrency gate.
     const companyId = await this.resolveFinanceCompanyId();
     await validatePeriodOpen(this.prisma, doc.issueDate, companyId);
 
@@ -342,8 +343,28 @@ export class OtherIncomeService {
     });
 
     return this.prisma.$transaction(async (tx) => {
-      const receiptNo = await this.docNumber.nextReceiptNumber(tx, doc.issueDate);
       const now = new Date();
+
+      // CAS-claim: atomically flip READY → POSTED, but only if still READY.
+      // This guards against two OWNERs approving simultaneously — only one
+      // updateMany will affect a row. The loser sees count===0 and bails out.
+      const claimed = await tx.otherIncome.updateMany({
+        where: { id, status: OtherIncomeStatus.READY },
+        data: {
+          status: OtherIncomeStatus.POSTED,
+          approverId: userId,
+          approvedAt: now,
+          approveNote: dto.note ?? null,
+          postedAt: now,
+        },
+      });
+      if (claimed.count === 0) {
+        throw new ConflictException(
+          `เอกสาร ${doc.docNumber} ถูกอนุมัติหรือปฏิเสธโดยผู้อื่นแล้ว — กรุณารีโหลด`,
+        );
+      }
+
+      const receiptNo = await this.docNumber.nextReceiptNumber(tx, doc.issueDate);
 
       const je = await this.template.post(
         {
@@ -358,15 +379,7 @@ export class OtherIncomeService {
 
       return tx.otherIncome.update({
         where: { id },
-        data: {
-          status: OtherIncomeStatus.POSTED,
-          receiptNo,
-          journalEntryId: je.id,
-          approverId: userId,
-          approvedAt: now,
-          approveNote: dto.note ?? null,
-          postedAt: now,
-        },
+        data: { receiptNo, journalEntryId: je.id },
         include: { items: true, adjustments: true },
       });
     });
@@ -383,7 +396,7 @@ export class OtherIncomeService {
     userId: string,
   ) {
     if (!(await this.isMakerCheckerEnabled())) {
-      throw new BadRequestException('Maker-Checker disabled');
+      throw new BadRequestException('Maker-Checker ปิดอยู่');
     }
     if (!dto.note || dto.note.trim().length === 0) {
       throw new BadRequestException('กรุณาระบุหมายเหตุการปฏิเสธ');
@@ -394,16 +407,23 @@ export class OtherIncomeService {
         `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — ไม่สามารถปฏิเสธได้`,
       );
     }
-    return this.prisma.otherIncome.update({
-      where: { id },
+    // CAS: atomically flip READY → DRAFT, only if still READY.
+    // Mirrors the same guard used in approve() against concurrent approver actions.
+    const claimed = await this.prisma.otherIncome.updateMany({
+      where: { id, status: OtherIncomeStatus.READY },
       data: {
         status: OtherIncomeStatus.DRAFT,
         rejectedById: userId,
         rejectedAt: new Date(),
         rejectNote: dto.note,
       },
-      include: { items: true, adjustments: true },
     });
+    if (claimed.count === 0) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} ถูกอนุมัติหรือปฏิเสธโดยผู้อื่นแล้ว — กรุณารีโหลด`,
+      );
+    }
+    return this.findOneOrFail(id);
   }
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -264,7 +264,7 @@ export class OtherIncomeService {
     userId: string,
   ) {
     if (!(await this.isMakerCheckerEnabled())) {
-      throw new BadRequestException('Maker-Checker ปิดอยู่ — ใช้ /post โดยตรง');
+      throw new BadRequestException('Maker-Checker ปิดอยู่');
     }
     const doc = await this.findOneOrFail(id);
     if (doc.status !== OtherIncomeStatus.READY) {

--- a/apps/web/src/pages/other-income/OtherIncomeTemplatesPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeTemplatesPage.tsx
@@ -43,7 +43,7 @@ export default function OtherIncomeTemplatesPage() {
     },
   });
 
-  const useMutation_ = useMutation({
+  const applyTemplateMutation = useMutation({
     mutationFn: (id: string) => otherIncomeApi.templates.use(id),
     onSuccess: (data) => {
       sessionStorage.setItem('oi-template-prefill', JSON.stringify(data));
@@ -127,7 +127,7 @@ export default function OtherIncomeTemplatesPage() {
                 </div>
                 <div className="flex gap-1">
                   <button
-                    onClick={() => useMutation_.mutate(t.id)}
+                    onClick={() => applyTemplateMutation.mutate(t.id)}
                     className="px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs inline-flex items-center gap-1 hover:bg-primary/90"
                   >
                     <PlayCircle size={12} /> ใช้

--- a/apps/web/src/pages/other-income/components/TemplatePickerCombobox.tsx
+++ b/apps/web/src/pages/other-income/components/TemplatePickerCombobox.tsx
@@ -27,7 +27,7 @@ export function TemplatePickerCombobox({ onApply }: Props) {
     queryFn: () => otherIncomeApi.templates.list(),
     enabled: open,
   });
-  const useMutation_ = useMutation({
+  const applyTemplateMutation = useMutation({
     mutationFn: (id: string) => otherIncomeApi.templates.use(id),
     onSuccess: (data) => {
       onApply(data.items, data.priceType);
@@ -50,7 +50,7 @@ export function TemplatePickerCombobox({ onApply }: Props) {
             <button
               key={t.id}
               type="button"
-              onClick={() => useMutation_.mutate(t.id)}
+              onClick={() => applyTemplateMutation.mutate(t.id)}
               className="w-full text-left px-3 py-2 hover:bg-accent text-xs"
             >
               <div className="font-semibold">{t.name}</div>


### PR DESCRIPTION
## Summary

Addresses findings from post-merge code review of PR #823 (other-income v2.1 combined).

### Critical — TOCTOU race in approve() / reject()
Both methods previously did read → status check → update, with the read OUTSIDE the `$transaction`. Two concurrent OWNER clicks could both pass the check, both enter the tx, and both create separate journal entries on the same doc.

Fixed by replacing the in-tx `update()` with a CAS-claim `updateMany({ where: { id, status: 'READY' }, ... })`:
- Atomic at the DB layer
- Loser sees `count === 0` → throws `ConflictException('เอกสารถูกอนุมัติหรือปฏิเสธโดยผู้อื่นแล้ว')`
- Pre-validation (period lock, V9, balance) stays outside tx — those are user-facing input errors, not concurrency gates

Regression test added: 2 concurrent `approve()` calls via `Promise.allSettled` — asserts exactly 1 fulfilled + 1 rejected + final POSTED state.

### Important — Role consistency
Class-level `@Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')` was overridden in 7 endpoints to grant `SALES` access. But SALES cannot reach `create()` or any other OI endpoint, making template/maker-checker access pointless and inconsistent.

Aligned all 7 endpoints:
- `GET/POST /templates`, `POST /from-doc/:id/save-template`, `PATCH/DELETE /templates/:id`, `POST /templates/:id/use` (6 template routes)
- `POST /:id/request-approval` (Maker-Checker maker side)

All now use `OWNER, FINANCE_MANAGER, ACCOUNTANT` matching class default.

### Minor — Thai error messages
3 English strings leaked to UI toast:
- `'Maker-Checker disabled — use POST directly'` → `'Maker-Checker ปิดอยู่ — ใช้ /post โดยตรง'`
- `'Maker-Checker disabled'` (×2) → `'Maker-Checker ปิดอยู่'`

### Minor — Variable naming
`useMutation_` (trailing underscore to avoid shadowing the imported hook) → `applyTemplateMutation` in TemplatesPage + TemplatePickerCombobox.

## Items deliberately deferred (acceptable per spec / low impact)
- **createFromDoc Decimal precision**: theoretical precision loss for amounts > 9 trillion. BESTCHOICE OI amounts <<< 1 billion; template values are presentation-only (re-validated when used). Lint rule isn't enforced. Skip.
- **PendingApprovalPage limit:100**: known limitation. Owner won't have 100 pending docs at once. Add pagination if/when needed.
- **sessionStorage prefill no schema validation**: same-origin, user's own browser, low risk.
- **maker-checker.spec uses FINANCE_MANAGER as approver**: integration test bypasses RolesGuard. HTTP-layer role check happens in code-review only. Adding e2e tests is a separate task.

## Test plan
- [x] tsc clean (api)
- [x] Existing 22 maker-checker tests still pass
- [x] New concurrent-approve test passes
- [x] No `window.prompt/confirm/alert` introduced
- [x] No emoji
- [x] No hardcoded hex colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)