### PR TITLE
feat(other-income): v2.2 — Override JV + Pagination + Maker-Checker + Reopen Period + Settings 5-tab

### DIFF
--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -328,3 +328,18 @@ WHT: per-item `whtPct` field; WHT payable posts to `21-3101`
 - UI shows ✏ marker in list pages for these documents
 
 Audit `JV_OVERRIDDEN` action string — no Prisma enum (AuditLog.action is plain String).
+
+### Maker-Checker toggle (Other Income)
+
+`PUT /other-income/maker-checker` (OWNER only) toggles `OTHER_INCOME_MAKER_CHECKER_ENABLED`. Emits `CONFIG_CHANGED` audit string. When turning OFF, UI shows count of READY docs from `GET /other-income/maker-checker/pending-ready-count` for awareness — they auto-approve on next post.
+
+### Reopen Period workflow
+
+`POST /expenses/periods/reopen` (OWNER only) accepts `ReopenPeriodDto { companyId, year, month, reasonType, reason, taxFiled, boardResolutionId? }`:
+- `reasonType`: enum (WRONG_ENTRY / MISSED_RECORD / AUDITOR_REQUEST / OTHER)
+- `reason`: free text, min 10 chars
+- `taxFiled`: true if ภ.พ.30 has been submitted (UI banner adds warning when true)
+
+Persists `reopenReason` (format `${reasonType}: ${reason}`) + `taxFiled` on `AccountingPeriod`. Emits `PERIOD_REOPENED` audit. `closePeriod()` emits `PERIOD_CLOSED`. Race-safe via CAS — `updateMany` with `status: 'CLOSED'` filter inside `$transaction` prevents concurrent reopen.
+
+`GET /expenses/periods/reopened` lists currently-reopened periods (status=OPEN AND reopenedAt set) for the `ReopenedPeriodBanner` shown on OtherIncomeListPage + ExpensesPage.

--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -343,3 +343,21 @@ Audit `JV_OVERRIDDEN` action string — no Prisma enum (AuditLog.action is plain
 Persists `reopenReason` (format `${reasonType}: ${reason}`) + `taxFiled` on `AccountingPeriod`. Emits `PERIOD_REOPENED` audit. `closePeriod()` emits `PERIOD_CLOSED`. Race-safe via CAS — `updateMany` with `status: 'CLOSED'` filter inside `$transaction` prevents concurrent reopen.
 
 `GET /expenses/periods/reopened` lists currently-reopened periods (status=OPEN AND reopenedAt set) for the `ReopenedPeriodBanner` shown on OtherIncomeListPage + ExpensesPage.
+
+### Settings UI consolidation
+
+`/settings` is the 5-tab hub for system-wide configuration (OWNER only — non-OWNER redirected to `/`):
+- `#company` — CompanyInfo (name, address, tax ID, signer)
+- `#vat` — `VAT_RATE` + `VAT_PRICE_TYPE_DEFAULT` (exclusive/inclusive)
+- `#periods` — AccountingPeriod table (close/reopen actions, ReopenPeriodModal)
+- `#attachment` — `ATTACHMENT_REQUIRED_ABOVE_AMOUNT` + `ATTACHMENT_ALLOWED_TYPES`
+- `#users` — MakerCheckerToggle + link to `/users`
+
+URL hash sync: `/settings#vat` (etc.) is bookmarkable; back/forward respects `hashchange`.
+
+Operational settings live at dedicated routes (also OWNER-only):
+- `/settings/stickers` — StickerSettings
+- `/settings/collections` — CollectionsConfigCard
+- `/settings/general` — Banking, penalty, PDPA, payment_link (GeneralSettings pre+post)
+
+`/accounting/periods` redirects to `/settings#periods` via `window.location.replace` (preserves hash; react-router `<Navigate>` cannot set hash fragments).

--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -318,3 +318,13 @@ JE template: `OtherIncomeTemplate` at `apps/api/src/modules/other-income/templat
 Doc numbering: `OI-YYYYMMDD-NNNN` (advisory-lock per-day sequence)
 Lifecycle: DRAFT → POSTED → REVERSED (soft-delete via `deletedAt`)
 WHT: per-item `whtPct` field; WHT payable posts to `21-3101`
+
+### Override JV (manual JE edit before POST)
+
+`POST /other-income/:id/post` accepts optional `{ override: true, overrideLines: [...] }`. When provided:
+- Server validates V1 (Dr=Cr ±0.01), V2 (≥2 lines), V5 (Dr XOR Cr per line) via `JournalOverrideService`
+- Sets `OtherIncome.isOverridden = true`
+- Writes `AuditLog { action: 'JV_OVERRIDDEN', oldValue: { jvLines: <auto> }, newValue: { jvLines: <override>, diffSummary: <Thai> } }`
+- UI shows ✏ marker in list pages for these documents
+
+Audit `JV_OVERRIDDEN` action string — no Prisma enum (AuditLog.action is plain String).

--- a/apps/api/prisma/migrations/20260513085739_add_pagination_indexes/migration.sql
+++ b/apps/api/prisma/migrations/20260513085739_add_pagination_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- AddIndex: (status, created_at DESC) on other_incomes for pagination ORDER BY
+-- Supports: WHERE status=? ORDER BY created_at DESC LIMIT N queries in OtherIncome list page
+CREATE INDEX IF NOT EXISTS "other_incomes_status_created_at_idx"
+  ON "other_incomes"("status", "created_at" DESC);
+
+-- AddIndex: (status, created_at DESC) on expense_documents for pagination ORDER BY
+-- Supports: WHERE status=? ORDER BY created_at DESC LIMIT N queries in Expense list page
+CREATE INDEX IF NOT EXISTS "expense_documents_status_created_at_idx"
+  ON "expense_documents"("status", "created_at" DESC);
+
+-- Note: audit_logs already has @@index([createdAt]) — no additional index needed.

--- a/apps/api/prisma/migrations/20260513091826_add_reopen_metadata/migration.sql
+++ b/apps/api/prisma/migrations/20260513091826_add_reopen_metadata/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "accounting_periods"
+  ADD COLUMN IF NOT EXISTS "reopen_reason" TEXT,
+  ADD COLUMN IF NOT EXISTS "tax_filed"     BOOLEAN;

--- a/apps/api/prisma/migrations/20260513101537_seed_pr3_settings_keys/migration.sql
+++ b/apps/api/prisma/migrations/20260513101537_seed_pr3_settings_keys/migration.sql
@@ -1,0 +1,9 @@
+-- Seed PR-3 Other Income v2.2 settings keys (idempotent)
+
+INSERT INTO system_config (id, key, value, label, created_at, updated_at)
+VALUES
+  (gen_random_uuid(), 'VAT_RATE', '7', 'VAT rate (%)', NOW(), NOW()),
+  (gen_random_uuid(), 'VAT_PRICE_TYPE_DEFAULT', 'exclusive', 'Default VAT price type (exclusive/inclusive)', NOW(), NOW()),
+  (gen_random_uuid(), 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', '0', 'Attachment required for amounts above (0 = not required)', NOW(), NOW()),
+  (gen_random_uuid(), 'ATTACHMENT_ALLOWED_TYPES', 'PDF, JPG, PNG', 'Allowed attachment file types', NOW(), NOW())
+ON CONFLICT (key) DO NOTHING;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -5077,6 +5077,8 @@ model AccountingPeriod {
   reopenedAt        DateTime? @map("reopened_at")
   reopenedById      String?   @map("reopened_by_id")
   reopenedBy        User?     @relation("PeriodReopenedBy", fields: [reopenedById], references: [id])
+  reopenReason      String?   @map("reopen_reason")
+  taxFiled          Boolean?  @map("tax_filed")
   boardResolutionId String?   @map("board_resolution_id")
 
   peakSyncedAt   DateTime? @map("peak_synced_at")

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3553,6 +3553,7 @@ model ExpenseDocument {
   @@index([branchId, deletedAt])
   @@index([documentType, status])
   @@index([status, paidAt])
+  @@index([status, createdAt(sort: Desc)])
   @@index([fromTemplateId])
   @@map("expense_documents")
 }
@@ -5885,6 +5886,7 @@ model OtherIncome {
 
   @@index([companyId])
   @@index([status, issueDate])
+  @@index([status, createdAt(sort: Desc)])
   @@index([customerId])
   @@index([deletedAt])
   @@index([issueDate])

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -178,8 +178,8 @@ export class AccountingController {
   @Roles('OWNER')
   reopenPeriod(
     @Body() dto: ReopenPeriodDto,
-    @Request() req: { user: { id: string } },
+    @Request() req: { user: { id: string }; ip?: string },
   ) {
-    return this.monthlyCloseService.reopenPeriod(dto, req.user.id);
+    return this.monthlyCloseService.reopenPeriod(dto, req.user.id, req.ip);
   }
 }

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -132,6 +132,12 @@ export class AccountingController {
     return this.monthlyCloseService.getPeriodsOverview(companyId, parseInt(year));
   }
 
+  @Get('periods/reopened')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getReopenedPeriods() {
+    return this.monthlyCloseService.listReopenedPeriods();
+  }
+
   @Get('periods/:companyId/:year/:month')
   @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   getMonthlyPeriodStatus(

--- a/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
+++ b/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsEnum, IsString, MinLength } from 'class-validator';
+import { IsBoolean, IsEnum, IsInt, IsOptional, IsString, Max, Min, MinLength } from 'class-validator';
 
 export enum ReopenReasonType {
   WRONG_ENTRY = 'WRONG_ENTRY',
@@ -8,6 +8,27 @@ export enum ReopenReasonType {
 }
 
 export class ReopenPeriodDto {
+  // ─── Period locators (mirrors CloseMonthDto) ─────────────────────────────
+  @IsString({ message: 'companyId ต้องเป็น string' })
+  companyId!: string;
+
+  @IsInt({ message: 'ปีต้องเป็นจำนวนเต็ม' })
+  @Min(2020)
+  year!: number;
+
+  @IsInt({ message: 'เดือนต้องเป็น 1-12' })
+  @Min(1)
+  @Max(12)
+  month!: number;
+
+  /**
+   * T2-C10 — Required only when reopening a CLOSED period older than 90 days.
+   */
+  @IsString()
+  @IsOptional()
+  boardResolutionId?: string;
+
+  // ─── Reason taxonomy ─────────────────────────────────────────────────────
   @IsEnum(ReopenReasonType, { message: 'reasonType ต้องเป็นหนึ่งใน WRONG_ENTRY, MISSED_RECORD, AUDITOR_REQUEST, OTHER' })
   reasonType!: ReopenReasonType;
 

--- a/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
+++ b/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
@@ -13,12 +13,13 @@ export class ReopenPeriodDto {
   companyId!: string;
 
   @IsInt({ message: 'ปีต้องเป็นจำนวนเต็ม' })
-  @Min(2020)
+  @Min(2020, { message: 'ปีต้องไม่ต่ำกว่า 2020' })
+  @Max(2100, { message: 'ปีต้องไม่เกิน 2100' })
   year!: number;
 
-  @IsInt({ message: 'เดือนต้องเป็น 1-12' })
-  @Min(1)
-  @Max(12)
+  @IsInt({ message: 'เดือนต้องเป็นจำนวนเต็ม' })
+  @Min(1, { message: 'เดือนต้องอยู่ระหว่าง 1-12' })
+  @Max(12, { message: 'เดือนต้องอยู่ระหว่าง 1-12' })
   month!: number;
 
   /**

--- a/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
+++ b/apps/api/src/modules/accounting/dto/reopen-period.dto.ts
@@ -1,32 +1,20 @@
-import { IsInt, IsString, Max, Min, MinLength } from 'class-validator';
+import { IsBoolean, IsEnum, IsString, MinLength } from 'class-validator';
 
-/**
- * F-6-004 — Reopening a closed period rewrites filed financial statements,
- * so we require:
- *   - boardResolutionId  (mandatory — reference to the board minute that
- *     authorised the reopen; logged in AuditLog for traceability)
- *   - reason             (≥20 chars — short narrative captured in AuditLog)
- *
- * Caller must be OWNER (enforced at controller level).
- */
+export enum ReopenReasonType {
+  WRONG_ENTRY = 'WRONG_ENTRY',
+  MISSED_RECORD = 'MISSED_RECORD',
+  AUDITOR_REQUEST = 'AUDITOR_REQUEST',
+  OTHER = 'OTHER',
+}
+
 export class ReopenPeriodDto {
-  @IsString({ message: 'companyId ต้องเป็น string' })
-  companyId!: string;
+  @IsEnum(ReopenReasonType, { message: 'reasonType ต้องเป็นหนึ่งใน WRONG_ENTRY, MISSED_RECORD, AUDITOR_REQUEST, OTHER' })
+  reasonType!: ReopenReasonType;
 
-  @IsInt({ message: 'ปีต้องเป็นจำนวนเต็ม' })
-  @Min(2020)
-  year!: number;
-
-  @IsInt({ message: 'เดือนต้องเป็น 1-12' })
-  @Min(1)
-  @Max(12)
-  month!: number;
-
-  @IsString({ message: 'boardResolutionId ต้องเป็น string' })
-  @MinLength(1, { message: 'กรุณาระบุ boardResolutionId' })
-  boardResolutionId!: string;
-
-  @IsString({ message: 'reason ต้องเป็น string' })
-  @MinLength(20, { message: 'reason ต้อง ≥20 ตัวอักษร' })
+  @IsString({ message: 'reason ต้องเป็นข้อความ' })
+  @MinLength(10, { message: 'reason ต้องระบุอย่างน้อย 10 ตัวอักษร' })
   reason!: string;
+
+  @IsBoolean({ message: 'taxFiled ต้องเป็น boolean (true/false)' })
+  taxFiled!: boolean;
 }

--- a/apps/api/src/modules/accounting/monthly-close.service.spec.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
 import { MonthlyCloseService } from './monthly-close.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
@@ -17,6 +17,7 @@ const makePrisma = () => {
       findUnique: jest.fn(),
       upsert: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
       findMany: jest.fn(),
       count: jest.fn(),
     },
@@ -438,18 +439,12 @@ describe('MonthlyCloseService', () => {
 
     it('allows reopen of a fresh CLOSED period (closedAt < 90 days ago)', async () => {
       const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
-      prisma.accountingPeriod.findUnique.mockResolvedValue({
-        ...base,
-        status: 'CLOSED',
-        closedAt: tenDaysAgo,
-        closedById: 'user-1',
-      });
-      prisma.accountingPeriod.update.mockResolvedValue({
-        ...base,
-        status: 'OPEN',
-        closedAt: null,
-        closedById: null,
-      });
+      const openPeriod = { ...base, status: 'OPEN', closedAt: null, closedById: null };
+      // First call: pre-flight read (CLOSED). Second call: refetch inside $transaction (OPEN).
+      prisma.accountingPeriod.findUnique
+        .mockResolvedValueOnce({ ...base, status: 'CLOSED', closedAt: tenDaysAgo, closedById: 'user-1' })
+        .mockResolvedValueOnce(openPeriod);
+      prisma.accountingPeriod.updateMany.mockResolvedValue({ count: 1 });
 
       const result = await service.reopenPeriod(
         {
@@ -465,7 +460,11 @@ describe('MonthlyCloseService', () => {
       );
 
       expect(result.status).toBe('OPEN');
-      expect(prisma.accountingPeriod.update).toHaveBeenCalled();
+      expect(prisma.accountingPeriod.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: 'CLOSED' }),
+        }),
+      );
     });
 
     it('blocks reopen of a stale CLOSED period (closedAt > 90 days ago) without boardResolutionId', async () => {
@@ -491,23 +490,16 @@ describe('MonthlyCloseService', () => {
           'user-OWNER-1',
         ),
       ).rejects.toThrow(ForbiddenException);
-      expect(prisma.accountingPeriod.update).not.toHaveBeenCalled();
+      expect(prisma.accountingPeriod.updateMany).not.toHaveBeenCalled();
     });
 
     it('allows reopen of a stale CLOSED period when boardResolutionId is supplied', async () => {
       const hundredDaysAgo = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
-      prisma.accountingPeriod.findUnique.mockResolvedValue({
-        ...base,
-        status: 'CLOSED',
-        closedAt: hundredDaysAgo,
-        closedById: 'user-1',
-      });
-      prisma.accountingPeriod.update.mockResolvedValue({
-        ...base,
-        status: 'OPEN',
-        closedAt: null,
-        closedById: null,
-      });
+      const openPeriod = { ...base, status: 'OPEN', closedAt: null, closedById: null };
+      prisma.accountingPeriod.findUnique
+        .mockResolvedValueOnce({ ...base, status: 'CLOSED', closedAt: hundredDaysAgo, closedById: 'user-1' })
+        .mockResolvedValueOnce(openPeriod);
+      prisma.accountingPeriod.updateMany.mockResolvedValue({ count: 1 });
 
       const result = await service.reopenPeriod(
         {
@@ -523,7 +515,7 @@ describe('MonthlyCloseService', () => {
       );
 
       expect(result.status).toBe('OPEN');
-      expect(prisma.accountingPeriod.update).toHaveBeenCalled();
+      expect(prisma.accountingPeriod.updateMany).toHaveBeenCalled();
     });
 
     // F-6-004 — persists audit fields + creates AuditLog
@@ -537,13 +529,19 @@ describe('MonthlyCloseService', () => {
         closedAt: new Date(),
         closedById: 'user-CLOSER',
       };
-      prisma.accountingPeriod.findUnique.mockResolvedValue(period);
-      prisma.accountingPeriod.update.mockResolvedValue({
+      const openPeriod = {
         ...period,
         status: 'OPEN',
         closedAt: null,
         closedById: null,
-      });
+        reopenedAt: new Date(),
+        reopenedById: 'user-OWNER-1',
+      };
+      // Pre-flight findUnique returns CLOSED; refetch inside $transaction returns OPEN.
+      prisma.accountingPeriod.findUnique
+        .mockResolvedValueOnce(period)
+        .mockResolvedValueOnce(openPeriod);
+      prisma.accountingPeriod.updateMany.mockResolvedValue({ count: 1 });
 
       await service.reopenPeriod(
         {
@@ -558,9 +556,15 @@ describe('MonthlyCloseService', () => {
         'user-OWNER-1',
       );
 
-      // Verify period update includes new audit fields + reason metadata
-      expect(prisma.accountingPeriod.update).toHaveBeenCalledWith(
+      // Verify CAS updateMany includes audit fields + reason metadata
+      expect(prisma.accountingPeriod.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
+          where: expect.objectContaining({
+            status: 'CLOSED',
+            companyId: 'company-1',
+            year: 2026,
+            month: 3,
+          }),
           data: expect.objectContaining({
             status: 'OPEN',
             reopenedAt: expect.any(Date),
@@ -587,6 +591,74 @@ describe('MonthlyCloseService', () => {
           }),
         }),
       );
+    });
+
+    // CAS race condition tests — TOCTOU guard
+    it('throws BadRequestException when concurrent reopen already succeeded (period now OPEN after CAS miss)', async () => {
+      const period = {
+        ...base,
+        id: 'period-cas-1',
+        year: 2026,
+        month: 5,
+        status: 'CLOSED',
+        closedAt: new Date(),
+        closedById: 'user-CLOSER',
+      };
+      // Pre-flight returns CLOSED, but updateMany finds no matching CLOSED row (race won by other request).
+      // Re-read inside tx shows the period is now OPEN (other request already reopened it).
+      const openAfterRace = { ...period, status: 'OPEN', closedAt: null };
+      prisma.accountingPeriod.findUnique
+        .mockResolvedValueOnce(period)       // pre-flight
+        .mockResolvedValueOnce(openAfterRace); // re-read inside tx after CAS miss
+      prisma.accountingPeriod.updateMany.mockResolvedValue({ count: 0 }); // CAS miss
+
+      await expect(
+        service.reopenPeriod(
+          {
+            companyId: 'company-1',
+            year: 2026,
+            month: 5,
+            boardResolutionId: 'BR-RACE-1',
+            reasonType: ReopenReasonType.WRONG_ENTRY,
+            reason: reasonText,
+            taxFiled: false,
+          },
+          'user-OWNER-2',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws ConflictException when CAS misses and period is in an unexpected state', async () => {
+      const period = {
+        ...base,
+        id: 'period-cas-2',
+        year: 2026,
+        month: 6,
+        status: 'CLOSED',
+        closedAt: new Date(),
+        closedById: 'user-CLOSER',
+      };
+      // Pre-flight returns CLOSED, CAS misses, re-read shows REVIEW (unexpected intermediate state).
+      const reviewAfterRace = { ...period, status: 'REVIEW' };
+      prisma.accountingPeriod.findUnique
+        .mockResolvedValueOnce(period)          // pre-flight
+        .mockResolvedValueOnce(reviewAfterRace); // re-read inside tx after CAS miss
+      prisma.accountingPeriod.updateMany.mockResolvedValue({ count: 0 }); // CAS miss
+
+      await expect(
+        service.reopenPeriod(
+          {
+            companyId: 'company-1',
+            year: 2026,
+            month: 6,
+            boardResolutionId: 'BR-RACE-2',
+            reasonType: ReopenReasonType.WRONG_ENTRY,
+            reason: reasonText,
+            taxFiled: false,
+          },
+          'user-OWNER-2',
+        ),
+      ).rejects.toThrow(ConflictException);
     });
   });
 

--- a/apps/api/src/modules/accounting/monthly-close.service.spec.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.spec.ts
@@ -6,6 +6,8 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { TaxService } from '../tax/tax.service';
 import { AccountingService } from './accounting.service';
 import { PeakService } from '../peak/peak.service';
+import { AuditService } from '../audit/audit.service';
+import { ReopenReasonType } from './dto/reopen-period.dto';
 
 // ─── Minimal mock factories ────────────────────────────────────────────────
 
@@ -53,6 +55,10 @@ const makePeakService = () => ({
   exportJournalEntries: jest.fn(),
 });
 
+const makeAuditService = () => ({
+  log: jest.fn().mockResolvedValue(undefined),
+});
+
 // ─── Tests ────────────────────────────────────────────────────────────────
 
 describe('MonthlyCloseService', () => {
@@ -62,6 +68,7 @@ describe('MonthlyCloseService', () => {
   let taxService: ReturnType<typeof makeTaxService>;
   let accountingService: ReturnType<typeof makeAccountingService>;
   let peakService: ReturnType<typeof makePeakService>;
+  let auditService: ReturnType<typeof makeAuditService>;
 
   beforeEach(async () => {
     prisma = makePrisma();
@@ -69,6 +76,7 @@ describe('MonthlyCloseService', () => {
     taxService = makeTaxService();
     accountingService = makeAccountingService();
     peakService = makePeakService();
+    auditService = makeAuditService();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -78,6 +86,7 @@ describe('MonthlyCloseService', () => {
         { provide: TaxService, useValue: taxService },
         { provide: AccountingService, useValue: accountingService },
         { provide: PeakService, useValue: peakService },
+        { provide: AuditService, useValue: auditService },
       ],
     }).compile();
 
@@ -448,7 +457,9 @@ describe('MonthlyCloseService', () => {
           year: 2025,
           month: 2,
           boardResolutionId: 'BR-FRESH-1',
+          reasonType: ReopenReasonType.AUDITOR_REQUEST,
           reason: reasonText,
+          taxFiled: false,
         },
         'user-OWNER-1',
       );
@@ -473,7 +484,9 @@ describe('MonthlyCloseService', () => {
             year: 2025,
             month: 2,
             boardResolutionId: '',
+            reasonType: ReopenReasonType.WRONG_ENTRY,
             reason: reasonText,
+            taxFiled: true,
           },
           'user-OWNER-1',
         ),
@@ -502,7 +515,9 @@ describe('MonthlyCloseService', () => {
           year: 2025,
           month: 2,
           boardResolutionId: 'BOARD-RES-2026-04-19',
+          reasonType: ReopenReasonType.MISSED_RECORD,
           reason: reasonText,
+          taxFiled: false,
         },
         'user-OWNER-1',
       );
@@ -536,12 +551,14 @@ describe('MonthlyCloseService', () => {
           year: 2026,
           month: 3,
           boardResolutionId: 'BR-2026-001',
+          reasonType: ReopenReasonType.AUDITOR_REQUEST,
           reason: reasonText,
+          taxFiled: true,
         },
         'user-OWNER-1',
       );
 
-      // Verify period update includes new audit fields
+      // Verify period update includes new audit fields + reason metadata
       expect(prisma.accountingPeriod.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -549,23 +566,24 @@ describe('MonthlyCloseService', () => {
             reopenedAt: expect.any(Date),
             reopenedById: 'user-OWNER-1',
             boardResolutionId: 'BR-2026-001',
+            reopenReason: `AUDITOR_REQUEST: ${reasonText}`,
+            taxFiled: true,
           }),
         }),
       );
 
-      // Verify AuditLog created
-      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+      // Verify PERIOD_REOPENED audit emitted via AuditService (not prisma.auditLog.create)
+      expect(auditService.log).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({
-            userId: 'user-OWNER-1',
-            action: 'PERIOD_REOPEN',
-            entity: 'accounting_period',
-            entityId: 'period-f6004-1',
-            newValue: expect.objectContaining({
-              boardResolutionId: 'BR-2026-001',
-              reason: reasonText,
-              period: '2026-03',
-            }),
+          userId: 'user-OWNER-1',
+          action: 'PERIOD_REOPENED',
+          entity: 'accounting_period',
+          entityId: 'period-f6004-1',
+          newValue: expect.objectContaining({
+            reasonType: ReopenReasonType.AUDITOR_REQUEST,
+            reason: reasonText,
+            taxFiled: true,
+            period: '2026-03',
           }),
         }),
       );

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -1,4 +1,11 @@
-import { Injectable, BadRequestException, ForbiddenException, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { AccountingPeriodStatus, Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -246,7 +253,7 @@ export class MonthlyCloseService {
         entity: 'accounting_period',
         entityId: existing.id,
         newValue: {
-          closedAt: new Date().toISOString(),
+          closedAt: period.closedAt?.toISOString() ?? new Date().toISOString(),
           period: `${year}-${String(month).padStart(2, '0')}`,
           forceClose: !!forceCloseReason,
         },
@@ -338,6 +345,7 @@ export class MonthlyCloseService {
     // Format compound reason string for storage
     const reopenReason = `${reasonType}: ${reason}`;
 
+    // Pre-flight checks: read current state once, validate before entering CAS loop.
     const existing = await this.prisma.accountingPeriod.findUnique({
       where: { companyId_year_month: { companyId, year, month } },
     });
@@ -369,22 +377,53 @@ export class MonthlyCloseService {
       }
     }
 
-    const period = await this.prisma.accountingPeriod.update({
-      where: { companyId_year_month: { companyId, year, month } },
-      data: {
-        status: 'OPEN',
-        reviewStartedAt: null,
-        reviewStartedById: null,
-        closedAt: null,
-        closedById: null,
-        auditIssues: Prisma.JsonNull,
-        reportSnapshot: Prisma.JsonNull,
-        reopenedAt: new Date(),
-        reopenedById: userId,
-        boardResolutionId: boardResolutionId ?? null,
-        reopenReason,
-        taxFiled,
-      },
+    // CAS via updateMany — only succeeds if the row is still CLOSED at update time.
+    // This prevents 2 concurrent OWNER requests from both passing the pre-flight
+    // check and both committing the reopen (TOCTOU race).
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const result = await tx.accountingPeriod.updateMany({
+        where: {
+          companyId,
+          year,
+          month,
+          status: 'CLOSED', // CAS guard — only matches if still CLOSED
+        },
+        data: {
+          status: 'OPEN',
+          reviewStartedAt: null,
+          reviewStartedById: null,
+          closedAt: null,
+          closedById: null,
+          auditIssues: Prisma.JsonNull,
+          reportSnapshot: Prisma.JsonNull,
+          reopenedAt: new Date(),
+          reopenedById: userId,
+          boardResolutionId: boardResolutionId ?? null,
+          reopenReason,
+          taxFiled,
+        },
+      });
+
+      if (result.count === 0) {
+        // CAS miss: re-read to give a precise error message.
+        const current = await tx.accountingPeriod.findUnique({
+          where: { companyId_year_month: { companyId, year, month } },
+        });
+        if (!current) {
+          throw new NotFoundException('ไม่พบงวดบัญชี');
+        }
+        if (current.status === 'OPEN') {
+          throw new BadRequestException('งวดนี้ยังเปิดอยู่ ไม่จำเป็นต้องเปิดซ้ำ');
+        }
+        throw new ConflictException(
+          `งวด ${year}-${String(month).padStart(2, '0')} ถูกแก้ไขโดยผู้ใช้คนอื่นพร้อมกัน — กรุณาลองใหม่`,
+        );
+      }
+
+      // Refetch the updated row so callers get the full record.
+      return tx.accountingPeriod.findUnique({
+        where: { companyId_year_month: { companyId, year, month } },
+      });
     });
 
     this.logger.log(
@@ -392,7 +431,8 @@ export class MonthlyCloseService {
         `(reasonType=${reasonType}, taxFiled=${taxFiled}).`,
     );
 
-    // Emit PERIOD_REOPENED audit outside DB update — best-effort, don't roll back on failure.
+    // Emit PERIOD_REOPENED audit OUTSIDE transaction — matches JV_OVERRIDDEN pattern;
+    // AuditService hash-chain is incompatible with nested $transaction.
     try {
       await this.auditService.log({
         userId,
@@ -403,8 +443,7 @@ export class MonthlyCloseService {
           reasonType,
           reason,
           taxFiled,
-          reopenReason,
-          reopenedAt: new Date().toISOString(),
+          reopenedAt: updated?.reopenedAt?.toISOString(),
           period: `${existing.year}-${String(existing.month).padStart(2, '0')}`,
           previousStatus: existing.status,
           boardResolutionId: boardResolutionId ?? null,
@@ -418,7 +457,7 @@ export class MonthlyCloseService {
       });
     }
 
-    return period as PeriodStatusResult;
+    return updated as PeriodStatusResult;
   }
 
   /**

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -7,6 +7,8 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { TaxService } from '../tax/tax.service';
 import { AccountingService } from './accounting.service';
 import { PeakService } from '../peak/peak.service';
+import { AuditService } from '../audit/audit.service';
+import { ReopenPeriodDto } from './dto/reopen-period.dto';
 
 export interface PeriodStatusResult {
   companyId: string;
@@ -44,6 +46,7 @@ export class MonthlyCloseService {
     private readonly taxService: TaxService,
     private readonly accountingService: AccountingService,
     private readonly peakService: PeakService,
+    private readonly auditService: AuditService,
   ) {}
 
   // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -235,6 +238,26 @@ export class MonthlyCloseService {
         (forceCloseReason ? ' [FORCE_CLOSE]' : ''),
     );
 
+    // Emit PERIOD_CLOSED audit outside transaction — best-effort, don't roll back on failure.
+    try {
+      await this.auditService.log({
+        userId,
+        action: 'PERIOD_CLOSED',
+        entity: 'accounting_period',
+        entityId: existing.id,
+        newValue: {
+          closedAt: new Date().toISOString(),
+          period: `${year}-${String(month).padStart(2, '0')}`,
+          forceClose: !!forceCloseReason,
+        },
+      });
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { module: 'accounting', action: 'PERIOD_CLOSED' },
+        extra: { companyId, year, month, userId },
+      });
+    }
+
     return period as PeriodStatusResult;
   }
 
@@ -306,10 +329,14 @@ export class MonthlyCloseService {
    * `boardResolutionId` and `reason` (≥20 chars).
    */
   async reopenPeriod(
-    dto: { companyId: string; year: number; month: number; boardResolutionId: string; reason: string },
+    dto: ReopenPeriodDto,
     userId: string,
+    ipAddress?: string,
   ): Promise<PeriodStatusResult> {
-    const { companyId, year, month, boardResolutionId, reason } = dto;
+    const { companyId, year, month, boardResolutionId, reasonType, reason, taxFiled } = dto;
+
+    // Format compound reason string for storage
+    const reopenReason = `${reasonType}: ${reason}`;
 
     const existing = await this.prisma.accountingPeriod.findUnique({
       where: { companyId_year_month: { companyId, year, month } },
@@ -342,45 +369,54 @@ export class MonthlyCloseService {
       }
     }
 
-    const period = await this.prisma.$transaction(async (tx) => {
-      const updated = await tx.accountingPeriod.update({
-        where: { companyId_year_month: { companyId, year, month } },
-        data: {
-          status: 'OPEN',
-          reviewStartedAt: null,
-          reviewStartedById: null,
-          closedAt: null,
-          closedById: null,
-          auditIssues: Prisma.JsonNull,
-          reportSnapshot: Prisma.JsonNull,
-          reopenedAt: new Date(),
-          reopenedById: userId,
-          boardResolutionId,
-        },
-      });
-
-      await tx.auditLog.create({
-        data: {
-          userId,
-          action: 'PERIOD_REOPEN',
-          entity: 'accounting_period',
-          entityId: existing.id,
-          newValue: {
-            boardResolutionId,
-            reason,
-            period: `${existing.year}-${String(existing.month).padStart(2, '0')}`,
-            previousStatus: existing.status,
-          } as unknown as import('@prisma/client').Prisma.JsonObject,
-        },
-      });
-
-      return updated;
+    const period = await this.prisma.accountingPeriod.update({
+      where: { companyId_year_month: { companyId, year, month } },
+      data: {
+        status: 'OPEN',
+        reviewStartedAt: null,
+        reviewStartedById: null,
+        closedAt: null,
+        closedById: null,
+        auditIssues: Prisma.JsonNull,
+        reportSnapshot: Prisma.JsonNull,
+        reopenedAt: new Date(),
+        reopenedById: userId,
+        boardResolutionId: boardResolutionId ?? null,
+        reopenReason,
+        taxFiled,
+      },
     });
 
     this.logger.log(
       `Period ${year}/${month} (company ${companyId}) reopened to OPEN by ${userId} ` +
-        `(boardResolutionId=${boardResolutionId}).`,
+        `(reasonType=${reasonType}, taxFiled=${taxFiled}).`,
     );
+
+    // Emit PERIOD_REOPENED audit outside DB update — best-effort, don't roll back on failure.
+    try {
+      await this.auditService.log({
+        userId,
+        action: 'PERIOD_REOPENED',
+        entity: 'accounting_period',
+        entityId: existing.id,
+        newValue: {
+          reasonType,
+          reason,
+          taxFiled,
+          reopenReason,
+          reopenedAt: new Date().toISOString(),
+          period: `${existing.year}-${String(existing.month).padStart(2, '0')}`,
+          previousStatus: existing.status,
+          boardResolutionId: boardResolutionId ?? null,
+        },
+        ipAddress,
+      });
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { module: 'accounting', action: 'PERIOD_REOPENED' },
+        extra: { companyId, year, month, userId },
+      });
+    }
 
     return period as PeriodStatusResult;
   }

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -461,6 +461,23 @@ export class MonthlyCloseService {
   }
 
   /**
+   * Returns all currently reopened periods (status = OPEN with reopenedAt set).
+   * Ordered by year/month descending.
+   */
+  async listReopenedPeriods() {
+    return this.prisma.accountingPeriod.findMany({
+      where: {
+        reopenedAt: { not: null },
+        status: 'OPEN',
+      },
+      include: {
+        reopenedBy: { select: { id: true, name: true } },
+      },
+      orderBy: [{ year: 'desc' }, { month: 'desc' }],
+    });
+  }
+
+  /**
    * Returns a 12-month overview for a given year.
    * Fills gaps (no DB record) with OPEN placeholders.
    */

--- a/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
@@ -13,6 +13,8 @@ import { AutoJournalService } from '../services/auto-journal.service';
 import { OtherIncomeTemplate } from '../templates/other-income.template';
 import { JournalAutoService } from '../../journal/journal-auto.service';
 import { StorageService } from '../../storage/storage.service';
+import { JournalOverrideService } from '../services/journal-override.service';
+import { AuditService } from '../../audit/audit.service';
 
 const stubStorage = {
   upload: async () => undefined,
@@ -42,6 +44,8 @@ describe('OtherIncomeService — Maker-Checker', () => {
         OtherIncomeTemplate,
         JournalAutoService,
         PrismaService,
+        JournalOverrideService,
+        AuditService,
         { provide: StorageService, useValue: stubStorage },
       ],
     }).compile();
@@ -404,4 +408,89 @@ describe('OtherIncomeService — Maker-Checker', () => {
     expect(final?.status).toBe('POSTED');
     expect(final?.journalEntryId).toBeTruthy();
   }, 30_000);
+
+  // ─────────────────────────────────────────────────────────────
+  // Override JV (V1/V2/V5) — Task 2
+  // ─────────────────────────────────────────────────────────────
+
+  describe('Override JV (V1/V2/V5)', () => {
+    let draftId: string;
+
+    beforeEach(async () => {
+      const draft = await createStandardDraft();
+      draftId = draft.id;
+    }, 30_000);
+
+    it('rejects override with fewer than 2 lines (V2)', async () => {
+      await expect(
+        service.post(draftId, {
+          override: true,
+          overrideLines: [
+            { accountCode: '11-1101', debit: 100, credit: 0 },
+          ],
+        }, makerId),
+      ).rejects.toMatchObject({
+        response: { errors: [{ rule: 'V2' }] },
+      });
+    }, 30_000);
+
+    it('rejects override with both Dr and Cr in one line (V5)', async () => {
+      await expect(
+        service.post(draftId, {
+          override: true,
+          overrideLines: [
+            { accountCode: '11-1101', debit: 50, credit: 50 },
+            { accountCode: '42-1102', debit: 0, credit: 100 },
+          ],
+        }, makerId),
+      ).rejects.toMatchObject({
+        response: { errors: [{ rule: 'V5' }] },
+      });
+    }, 30_000);
+
+    it('rejects unbalanced override (V1)', async () => {
+      await expect(
+        service.post(draftId, {
+          override: true,
+          overrideLines: [
+            { accountCode: '11-1101', debit: 100, credit: 0 },
+            { accountCode: '42-1102', debit: 0, credit: 90 },
+          ],
+        }, makerId),
+      ).rejects.toMatchObject({
+        response: { errors: [{ rule: 'V1' }] },
+      });
+    }, 30_000);
+
+    it('sets isOverridden=true and writes JV_OVERRIDDEN audit on successful override post', async () => {
+      const posted = await service.post(draftId, {
+        override: true,
+        overrideLines: [
+          { accountCode: '11-1201', debit: 1500, credit: 0 },
+          { accountCode: '42-1102', debit: 0, credit: 1500 },
+        ],
+      }, makerId);
+
+      expect(posted.isOverridden).toBe(true);
+
+      const audit = await prisma.auditLog.findFirst({
+        where: { action: 'JV_OVERRIDDEN', entityId: draftId },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(audit).toBeTruthy();
+      expect(audit!.oldValue).toMatchObject({ jvLines: expect.any(Array) }); // original auto JV
+      expect(audit!.newValue).toMatchObject({
+        jvLines: expect.any(Array),
+        diffSummary: expect.any(String),
+      });
+    }, 30_000);
+
+    it('does not write JV_OVERRIDDEN audit on non-override post', async () => {
+      await service.post(draftId, {}, makerId);
+      const audit = await prisma.auditLog.findFirst({
+        where: { action: 'JV_OVERRIDDEN', entityId: draftId },
+      });
+      expect(audit).toBeNull();
+    }, 30_000);
+  });
 });

--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -8,6 +8,8 @@ import { AutoJournalService } from '../services/auto-journal.service';
 import { OtherIncomeTemplate } from '../templates/other-income.template';
 import { JournalAutoService } from '../../journal/journal-auto.service';
 import { StorageService } from '../../storage/storage.service';
+import { JournalOverrideService } from '../services/journal-override.service';
+import { AuditService } from '../../audit/audit.service';
 
 const stubStorage = {
   upload: async () => undefined,
@@ -38,6 +40,8 @@ describe('OtherIncomeService — CRUD', () => {
         PrismaService,
         { provide: OtherIncomeTemplate, useValue: stubTemplate },
         { provide: StorageService, useValue: stubStorage },
+        JournalOverrideService,
+        AuditService,
       ],
     }).compile();
     await module.init();
@@ -239,6 +243,8 @@ describe('OtherIncomeService — post + reverse + copy', () => {
         JournalAutoService,
         PrismaService,
         { provide: StorageService, useValue: stubStorage },
+        JournalOverrideService,
+        AuditService,
       ],
     }).compile();
     await module.init();
@@ -543,6 +549,8 @@ describe('OtherIncomeService — post — period lock (B1)', () => {
         JournalAutoService,
         PrismaService,
         { provide: StorageService, useValue: stubStorage },
+        JournalOverrideService,
+        AuditService,
       ],
     }).compile();
     await module.init();

--- a/apps/api/src/modules/other-income/__tests__/pagination-perf.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/pagination-perf.spec.ts
@@ -1,0 +1,149 @@
+import { Test } from '@nestjs/testing';
+import { Prisma, OtherIncomeStatus, OtherIncomePriceType } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { OtherIncomeService } from '../other-income.service';
+import { DocNumberService } from '../services/doc-number.service';
+import { ValidationService } from '../services/validation.service';
+import { AutoJournalService } from '../services/auto-journal.service';
+import { OtherIncomeTemplate } from '../templates/other-income.template';
+import { JournalAutoService } from '../../journal/journal-auto.service';
+import { StorageService } from '../../storage/storage.service';
+import { JournalOverrideService } from '../services/journal-override.service';
+import { AuditService } from '../../audit/audit.service';
+
+// This test seeds 10,000 OtherIncome rows and asserts list query < 200ms.
+// SKIP it in CI unless PERF=1 env var is set, to keep regular test runs fast.
+
+const stubStorage = {
+  upload: async () => undefined,
+  delete: async () => undefined,
+  getSignedUrl: async () => 'https://stub/url',
+};
+
+const D = (n: number | string) => new Prisma.Decimal(n);
+
+describe.skip('Pagination performance — gated by PERF=1', () => {
+  let prisma: PrismaService;
+  let service: OtherIncomeService;
+  let financeCompanyId: string;
+
+  beforeAll(async () => {
+    if (!process.env.PERF) return;
+
+    // Bootstrap NestJS test module (mirrors pattern from maker-checker.spec.ts)
+    const module = await Test.createTestingModule({
+      providers: [
+        OtherIncomeService,
+        DocNumberService,
+        ValidationService,
+        AutoJournalService,
+        OtherIncomeTemplate,
+        JournalAutoService,
+        PrismaService,
+        JournalOverrideService,
+        AuditService,
+        { provide: StorageService, useValue: stubStorage },
+      ],
+    }).compile();
+
+    await module.init();
+    service = module.get(OtherIncomeService);
+    prisma = module.get(PrismaService);
+
+    // Ensure FINANCE CompanyInfo exists
+    const companyInfo = await prisma.companyInfo.upsert({
+      where: { companyCode: 'FINANCE' },
+      update: {},
+      create: {
+        companyCode: 'FINANCE',
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000001',
+        address: 'TEST',
+        directorName: 'ผู้อำนวยการ',
+        vatRegistered: true,
+      },
+    });
+    financeCompanyId = companyInfo.id;
+
+    // Ensure system user (required by JournalAutoService.resolveSystemUserId)
+    await prisma.user.upsert({
+      where: { email: 'admin@bestchoice.com' },
+      update: {},
+      create: {
+        email: 'admin@bestchoice.com',
+        password: 'x',
+        name: 'admin',
+        role: 'OWNER',
+      },
+    });
+
+    // Seed required CoA codes
+    const coaSeeds = [
+      { code: '42-1102', name: 'รายได้ดอกเบี้ยฝากธนาคาร', type: 'รายได้', normalBalance: 'Cr', category: 'รายได้อื่น' },
+      { code: '11-1201', name: 'ธนาคาร KBank', type: 'สินทรัพย์', normalBalance: 'Dr', category: 'เงินฝากธนาคาร' },
+    ];
+    for (const seed of coaSeeds) {
+      await prisma.chartOfAccount.upsert({
+        where: { code: seed.code },
+        update: {},
+        create: seed,
+      });
+    }
+
+    // Seed 10,000 OtherIncome rows for perf testing
+    const rows = Array.from({ length: 10_000 }, (_, i) => ({
+      docNumber: `PERF-${i.toString().padStart(6, '0')}`,
+      companyId: financeCompanyId,
+      status: OtherIncomeStatus.POSTED,
+      issueDate: new Date('2026-01-01'),
+      dueDate: null,
+      paymentDate: null,
+      priceType: OtherIncomePriceType.EXCLUSIVE,
+      customerId: null,
+      counterpartyName: `Counterparty ${i}`,
+      counterpartyTaxId: null,
+      counterpartyAddress: null,
+      counterpartyPhone: null,
+      paymentAccountCode: '11-1201',
+      amountReceived: new Prisma.Decimal(1000 + i),
+      incomeGross: new Prisma.Decimal(1000 + i),
+      vatAmount: new Prisma.Decimal(0),
+      whtAmount: new Prisma.Decimal(0),
+      netReceived: new Prisma.Decimal(1000 + i),
+      totalAmount: new Prisma.Decimal(1000 + i),
+      customerNote: null,
+      createdById: 'admin@bestchoice.com',
+      isOverridden: false,
+    }));
+
+    // Batch insert to avoid constraint issues
+    for (let i = 0; i < rows.length; i += 500) {
+      const batch = rows.slice(i, i + 500);
+      await prisma.otherIncome.createMany({
+        data: batch,
+        skipDuplicates: true,
+      });
+    }
+
+    console.log(`Seeded ${rows.length} OtherIncome records`);
+  });
+
+  it('lists page 1 (limit 50) in < 200ms', async () => {
+    if (!process.env.PERF) return;
+    const start = Date.now();
+    // Call with ListOtherIncomeQueryDto shape: { page, limit, status?, startDate?, endDate?, q?, sort? }
+    await service.list({ page: 1, limit: 50, status: OtherIncomeStatus.POSTED });
+    const ms = Date.now() - start;
+    console.log(`Page 1 query took ${ms}ms`);
+    expect(ms).toBeLessThan(200);
+  });
+
+  it('lists page 100 (limit 50) in < 200ms', async () => {
+    if (!process.env.PERF) return;
+    const start = Date.now();
+    await service.list({ page: 100, limit: 50, status: OtherIncomeStatus.POSTED });
+    const ms = Date.now() - start;
+    console.log(`Page 100 query took ${ms}ms`);
+    expect(ms).toBeLessThan(200);
+  });
+});

--- a/apps/api/src/modules/other-income/dto/list-other-income-query.dto.ts
+++ b/apps/api/src/modules/other-income/dto/list-other-income-query.dto.ts
@@ -31,4 +31,13 @@ export class ListOtherIncomeQueryDto {
   @Min(1)
   @Max(200)
   limit?: number = 50;
+
+  /**
+   * Sort expression in the form `<field>:<asc|desc>`.
+   * Supported fields: createdAt, issueDate.
+   * Defaults to `issueDate:desc`.
+   */
+  @IsOptional()
+  @IsString()
+  sort?: string;
 }

--- a/apps/api/src/modules/other-income/dto/list-other-income-query.dto.ts
+++ b/apps/api/src/modules/other-income/dto/list-other-income-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Matches, Max, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 import { OtherIncomeStatus } from '@prisma/client';
 
@@ -39,5 +39,8 @@ export class ListOtherIncomeQueryDto {
    */
   @IsOptional()
   @IsString()
+  @Matches(/^(createdAt|issueDate):(asc|desc)$/, {
+    message: 'sort ต้องอยู่ในรูปแบบ <field>:<direction> เช่น createdAt:desc (field=createdAt|issueDate, direction=asc|desc)',
+  })
   sort?: string;
 }

--- a/apps/api/src/modules/other-income/dto/toggle-maker-checker.dto.ts
+++ b/apps/api/src/modules/other-income/dto/toggle-maker-checker.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class ToggleMakerCheckerDto {
+  @IsBoolean({ message: 'enabled ต้องเป็น boolean' })
+  enabled!: boolean;
+}

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Put,
   Query,
   Request,
   UploadedFile,
@@ -35,6 +36,7 @@ import { ListOtherIncomeQueryDto } from './dto/list-other-income-query.dto';
 import { DailySheetQueryDto } from './dto/daily-sheet-query.dto';
 import { CreateTemplateDto, CreateTemplateFromDocDto } from './dto/create-template.dto';
 import { UpdateTemplateDto } from './dto/update-template.dto';
+import { ToggleMakerCheckerDto } from './dto/toggle-maker-checker.dto';
 
 @Controller('other-income')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -64,6 +66,25 @@ export class OtherIncomeController {
   async getMakerCheckerEnabled() {
     const enabled = await this.service.isMakerCheckerEnabled();
     return { enabled };
+  }
+
+  // CRITICAL: literal routes must stay before any :id route.
+
+  /** OWNER: toggle Maker-Checker flow on/off. */
+  @Put('maker-checker')
+  @Roles('OWNER')
+  toggleMakerChecker(
+    @Body() dto: ToggleMakerCheckerDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.service.setMakerCheckerEnabled(dto.enabled, userId);
+  }
+
+  /** OWNER: count docs pending approval (status=READY). */
+  @Get('maker-checker/pending-ready-count')
+  @Roles('OWNER')
+  pendingReadyCount() {
+    return this.service.pendingReadyCount();
   }
 
   @Get()

--- a/apps/api/src/modules/other-income/other-income.module.ts
+++ b/apps/api/src/modules/other-income/other-income.module.ts
@@ -8,6 +8,7 @@ import { ValidationService } from './services/validation.service';
 import { AutoJournalService } from './services/auto-journal.service';
 import { TemplateService } from './services/template.service';
 import { OtherIncomeTemplate } from './templates/other-income.template';
+import { JournalOverrideService } from './services/journal-override.service';
 
 // PrismaService is provided globally via PrismaModule (@Global) — no import needed.
 
@@ -21,6 +22,7 @@ import { OtherIncomeTemplate } from './templates/other-income.template';
     AutoJournalService,
     TemplateService,
     OtherIncomeTemplate,
+    JournalOverrideService,
   ],
   exports: [OtherIncomeService, TemplateService],
 })

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { OtherIncomeStatus, Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
+import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../prisma/prisma.service';
 import { StorageService } from '../storage/storage.service';
 import { DocNumberService } from './services/doc-number.service';
@@ -562,29 +563,38 @@ export class OtherIncomeService {
     // Write JV_OVERRIDDEN audit outside transaction (non-blocking on TX connection)
     if (overrideLinesForAudit) {
       const diffSummary = this.journalOverride.computeDiffSummary(autoJeLines, overrideLinesForAudit);
-      await this.audit.log({
-        userId,
-        action: 'JV_OVERRIDDEN',
-        entity: 'other_income',
-        entityId: doc.id,
-        oldValue: {
-          jvLines: autoJeLines.map((l) => ({
-            accountCode: l.accountCode,
-            debit: l.debit.toString(),
-            credit: l.credit.toString(),
-            description: l.description ?? null,
-          })),
-        },
-        newValue: {
-          jvLines: overrideLinesForAudit.map((l) => ({
-            accountCode: l.accountCode,
-            debit: l.debit.toString(),
-            credit: l.credit.toString(),
-            description: l.description ?? null,
-          })),
-          diffSummary,
-        },
-      });
+      try {
+        await this.audit.log({
+          userId,
+          action: 'JV_OVERRIDDEN',
+          entity: 'other_income',
+          entityId: doc.id,
+          oldValue: {
+            jvLines: autoJeLines.map((l) => ({
+              accountCode: l.accountCode,
+              debit: l.debit.toString(),
+              credit: l.credit.toString(),
+              description: l.description ?? null,
+            })),
+          },
+          newValue: {
+            jvLines: overrideLinesForAudit.map((l) => ({
+              accountCode: l.accountCode,
+              debit: l.debit.toString(),
+              credit: l.credit.toString(),
+              description: l.description ?? null,
+            })),
+            diffSummary,
+          },
+        });
+      } catch (err) {
+        // OtherIncome is already POSTED — never throw and rollback the response.
+        // Capture to Sentry so accounting can manually reconcile audit gaps.
+        Sentry.captureException(err, {
+          tags: { module: 'other-income', action: 'JV_OVERRIDDEN' },
+          extra: { otherIncomeId: doc.id, docNumber: doc.docNumber },
+        });
+      }
     }
 
     return posted;

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -926,6 +926,22 @@ export class OtherIncomeService {
     const limit = query.limit ?? 50;
     const skip = (page - 1) * limit;
 
+    // Parse sort expression — supports `<field>:asc` / `<field>:desc`
+    // Allowed fields: createdAt, issueDate (default). Unknown fields fall back to issueDate:desc.
+    const ALLOWED_SORT_FIELDS = ['createdAt', 'issueDate'] as const;
+    type SortField = (typeof ALLOWED_SORT_FIELDS)[number];
+    let sortField: SortField = 'issueDate';
+    let sortDir: 'asc' | 'desc' = 'desc';
+    if (query.sort) {
+      const [rawField, rawDir] = query.sort.split(':');
+      if (ALLOWED_SORT_FIELDS.includes(rawField as SortField)) {
+        sortField = rawField as SortField;
+      }
+      if (rawDir === 'asc' || rawDir === 'desc') {
+        sortDir = rawDir;
+      }
+    }
+
     const where: Prisma.OtherIncomeWhereInput = {
       deletedAt: null,
       ...(query.status ? { status: query.status } : {}),
@@ -952,7 +968,7 @@ export class OtherIncomeService {
       this.prisma.otherIncome.findMany({
         where,
         include: { items: { orderBy: { lineNo: 'asc' } } },
-        orderBy: { issueDate: 'desc' },
+        orderBy: { [sortField]: sortDir },
         skip,
         take: limit,
       }),

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -18,6 +18,8 @@ import { PostOtherIncomeDto } from './dto/post-other-income.dto';
 import { ReverseOtherIncomeDto } from './dto/reverse-other-income.dto';
 import { ListOtherIncomeQueryDto } from './dto/list-other-income-query.dto';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
+import { JournalOverrideService, OverrideLine } from './services/journal-override.service';
+import { AuditService } from '../audit/audit.service';
 
 const D = Prisma.Decimal;
 type Decimal = Prisma.Decimal;
@@ -32,6 +34,8 @@ export class OtherIncomeService {
     private readonly autoJournal: AutoJournalService,
     private readonly template: OtherIncomeTemplate,
     private readonly storage: StorageService,
+    private readonly journalOverride: JournalOverrideService,
+    private readonly audit: AuditService,
   ) {}
 
   async create(dto: CreateOtherIncomeDto, userId: string) {
@@ -479,63 +483,55 @@ export class OtherIncomeService {
       throw new BadRequestException({ message: 'ไม่ผ่านการตรวจสอบก่อน POST', errors });
     }
 
-    // C3: validate override lines balance (Dr = Cr) before entering transaction
-    if (dto.override && dto.overrideLines && dto.overrideLines.length > 0) {
-      const totalDr = dto.overrideLines.reduce(
-        (s, l) => s.plus(new D(l.debit)),
-        new D(0),
-      );
-      const totalCr = dto.overrideLines.reduce(
-        (s, l) => s.plus(new D(l.credit)),
-        new D(0),
-      );
-      if (!totalDr.eq(totalCr)) {
-        throw new BadRequestException({
-          message: 'Validation failed',
-          errors: [
-            {
-              rule: 'V1',
-              msg: `บรรทัดที่แก้ไขเอง: Dr=${totalDr} ≠ Cr=${totalCr} — ยอดเดบิตและเครดิตต้องเท่ากัน`,
-            },
-          ],
-        });
-      }
-    }
+    // Always compute the auto baseline — needed for diff_summary when override is used
+    const autoJeLines: OverrideLine[] = this.autoJournal.generate({
+      paymentAccountCode: doc.paymentAccountCode,
+      amountReceived: new D(doc.amountReceived.toString()),
+      netReceived: new D(doc.netReceived.toString()),
+      items: doc.items.map((it) => ({
+        lineNo: it.lineNo,
+        accountCode: it.accountCode,
+        accountName: it.accountName,
+        description: it.description ?? undefined,
+        amountBeforeVat: new D(it.amountBeforeVat.toString()),
+        vatAmount: new D(it.vatAmount.toString()),
+        whtAmount: new D(it.whtAmount.toString()),
+        whtPct: new D(it.whtPct.toString()),
+      })),
+      adjustments: doc.adjustments.map((a) => ({
+        lineNo: a.lineNo,
+        accountCode: a.accountCode,
+        amount: new D(a.amount.toString()),
+        note: a.note ?? undefined,
+      })),
+    }).map((l) => ({
+      accountCode: l.accountCode,
+      debit: l.debit,
+      credit: l.credit,
+      description: l.description,
+    }));
 
-    // Generate or use override JE lines
-    let jeLines;
+    let jeLines: OverrideLine[];
+    let overrideLinesForAudit: OverrideLine[] | null = null;
+
     if (dto.override && dto.overrideLines && dto.overrideLines.length > 0) {
-      jeLines = dto.overrideLines.map((l) => ({
+      const overrideLines: OverrideLine[] = dto.overrideLines.map((l) => ({
         accountCode: l.accountCode,
         debit: new D(l.debit),
         credit: new D(l.credit),
         description: l.description,
       }));
+
+      // Throws BadRequestException with V1/V2/V5 errors
+      this.journalOverride.validate(overrideLines);
+
+      jeLines = overrideLines;
+      overrideLinesForAudit = overrideLines;
     } else {
-      jeLines = this.autoJournal.generate({
-        paymentAccountCode: doc.paymentAccountCode,
-        amountReceived: new D(doc.amountReceived.toString()),
-        netReceived: new D(doc.netReceived.toString()),
-        items: doc.items.map((it) => ({
-          lineNo: it.lineNo,
-          accountCode: it.accountCode,
-          accountName: it.accountName,
-          description: it.description ?? undefined,
-          amountBeforeVat: new D(it.amountBeforeVat.toString()),
-          vatAmount: new D(it.vatAmount.toString()),
-          whtAmount: new D(it.whtAmount.toString()),
-          whtPct: new D(it.whtPct.toString()),
-        })),
-        adjustments: doc.adjustments.map((a) => ({
-          lineNo: a.lineNo,
-          accountCode: a.accountCode,
-          amount: new D(a.amount.toString()),
-          note: a.note ?? undefined,
-        })),
-      });
+      jeLines = autoJeLines;
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    const posted = await this.prisma.$transaction(async (tx) => {
       const receiptNo = await this.docNumber.nextReceiptNumber(tx, doc.issueDate);
       const now = new Date();
 
@@ -556,12 +552,42 @@ export class OtherIncomeService {
           status: OtherIncomeStatus.POSTED,
           receiptNo,
           journalEntryId: je.id,
-          isOverridden: !!(dto.override && dto.overrideLines && dto.overrideLines.length > 0),
+          isOverridden: overrideLinesForAudit !== null,
           postedAt: now,
         },
         include: { items: true, adjustments: true },
       });
     });
+
+    // Write JV_OVERRIDDEN audit outside transaction (non-blocking on TX connection)
+    if (overrideLinesForAudit) {
+      const diffSummary = this.journalOverride.computeDiffSummary(autoJeLines, overrideLinesForAudit);
+      await this.audit.log({
+        userId,
+        action: 'JV_OVERRIDDEN',
+        entity: 'other_income',
+        entityId: doc.id,
+        oldValue: {
+          jvLines: autoJeLines.map((l) => ({
+            accountCode: l.accountCode,
+            debit: l.debit.toString(),
+            credit: l.credit.toString(),
+            description: l.description ?? null,
+          })),
+        },
+        newValue: {
+          jvLines: overrideLinesForAudit.map((l) => ({
+            accountCode: l.accountCode,
+            debit: l.debit.toString(),
+            credit: l.credit.toString(),
+            description: l.description ?? null,
+          })),
+          diffSummary,
+        },
+      });
+    }
+
+    return posted;
   }
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -1095,6 +1095,37 @@ export class OtherIncomeService {
     }
   }
 
+  /** OWNER: toggle OTHER_INCOME_MAKER_CHECKER_ENABLED and emit CONFIG_CHANGED audit. */
+  async setMakerCheckerEnabled(enabled: boolean, userId: string): Promise<{ success: true; enabled: boolean }> {
+    await this.prisma.systemConfig.upsert({
+      where: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED' },
+      update: { value: enabled ? 'true' : 'false' },
+      create: { key: 'OTHER_INCOME_MAKER_CHECKER_ENABLED', value: enabled ? 'true' : 'false' },
+    });
+
+    try {
+      await this.audit.log({
+        userId,
+        action: 'CONFIG_CHANGED',
+        entity: 'system_config',
+        entityId: 'OTHER_INCOME_MAKER_CHECKER_ENABLED',
+        newValue: { enabled },
+      });
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+
+    return { success: true, enabled };
+  }
+
+  /** OWNER: count OtherIncome docs with status=READY that are not soft-deleted. */
+  async pendingReadyCount(): Promise<{ count: number }> {
+    const count = await this.prisma.otherIncome.count({
+      where: { status: 'READY', deletedAt: null },
+    });
+    return { count };
+  }
+
   /** Read OTHER_INCOME_ATTACHMENT_THRESHOLD from SystemConfig. Falls back to 50_000. */
   async getAttachmentThreshold(): Promise<number> {
     try {

--- a/apps/api/src/modules/other-income/services/journal-override.service.spec.ts
+++ b/apps/api/src/modules/other-income/services/journal-override.service.spec.ts
@@ -1,0 +1,115 @@
+import { BadRequestException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { JournalOverrideService, OverrideLine } from './journal-override.service';
+
+const D = (n: number | string) => new Decimal(n);
+
+describe('JournalOverrideService', () => {
+  const svc = new JournalOverrideService();
+
+  const line = (accountCode: string, debit: number, credit: number): OverrideLine => ({
+    accountCode,
+    debit: D(debit),
+    credit: D(credit),
+  });
+
+  describe('validate()', () => {
+    it('V1: passes when Dr equals Cr exactly', () => {
+      expect(() => svc.validate([line('11-1101', 100, 0), line('42-1102', 0, 100)])).not.toThrow();
+    });
+
+    it('V1: passes within 0.01 tolerance', () => {
+      expect(() =>
+        svc.validate([line('11-1101', 100.005, 0), line('42-1102', 0, 100)]),
+      ).not.toThrow();
+    });
+
+    it('V1: throws when Dr != Cr beyond 0.01 tolerance', () => {
+      expect(() => svc.validate([line('11-1101', 100, 0), line('42-1102', 0, 99)]))
+        .toThrow(BadRequestException);
+      try {
+        svc.validate([line('11-1101', 100, 0), line('42-1102', 0, 99)]);
+      } catch (e: any) {
+        expect(e.response.errors[0].rule).toBe('V1');
+        expect(e.response.errors[0].msg).toContain('ผลต่าง');
+      }
+    });
+
+    it('V2: throws when fewer than 2 lines', () => {
+      expect(() => svc.validate([])).toThrow(BadRequestException);
+      try { svc.validate([]); } catch (e: any) {
+        expect(e.response.errors[0].rule).toBe('V2');
+      }
+      expect(() => svc.validate([line('11-1101', 100, 0)])).toThrow(BadRequestException);
+    });
+
+    it('V5: throws when a line has both Dr and Cr', () => {
+      try {
+        svc.validate([line('11-1101', 50, 50), line('42-1102', 0, 100)]);
+        fail('should have thrown');
+      } catch (e: any) {
+        expect(e.response.errors[0].rule).toBe('V5');
+        expect(e.response.errors[0].msg).toContain('11-1101');
+        expect(e.response.errors[0].msg).toContain('มีทั้ง Dr และ Cr');
+      }
+    });
+
+    it('V5: throws when a line has neither Dr nor Cr', () => {
+      try {
+        svc.validate([line('11-1101', 100, 0), line('42-1102', 0, 0), line('21-2101', 0, 100)]);
+        fail('should have thrown');
+      } catch (e: any) {
+        expect(e.response.errors[0].rule).toBe('V5');
+        expect(e.response.errors[0].msg).toContain('42-1102');
+        expect(e.response.errors[0].msg).toContain('ไม่มีทั้ง Dr และ Cr');
+      }
+    });
+
+    it('errors are returned in V1 → V2 → V5 order — V2 short-circuits before V5', () => {
+      // 1 line that's also missing dr/cr should report V2 first
+      try { svc.validate([line('11-1101', 0, 0)]); } catch (e: any) {
+        expect(e.response.errors[0].rule).toBe('V2');
+      }
+    });
+  });
+
+  describe('computeDiffSummary()', () => {
+    const auto = [line('11-1101', 1000, 0), line('42-1102', 0, 1000)];
+
+    it('returns empty string when arrays are equal', () => {
+      expect(svc.computeDiffSummary(auto, [...auto])).toBe('');
+    });
+
+    it('detects modified credit amount', () => {
+      const modified = [line('11-1101', 1500, 0), line('42-1102', 0, 1500)];
+      const summary = svc.computeDiffSummary(auto, modified);
+      expect(summary).toContain('แก้');
+      expect(summary).toContain('11-1101');
+      expect(summary).toContain('1,000.00');
+      expect(summary).toContain('1,500.00');
+    });
+
+    it('detects added line', () => {
+      const modified = [...auto, line('21-2101', 0, 70)];
+      const summary = svc.computeDiffSummary(auto, modified);
+      expect(summary).toContain('เพิ่มบรรทัด');
+      expect(summary).toContain('21-2101');
+    });
+
+    it('detects removed line', () => {
+      const modified = [auto[0]];
+      const summary = svc.computeDiffSummary(auto, modified);
+      expect(summary).toContain('ลบบรรทัด');
+      expect(summary).toContain('42-1102');
+    });
+
+    it('combines multiple changes with separator', () => {
+      const modified = [line('11-1101', 1500, 0), line('21-2101', 0, 1500)];
+      const summary = svc.computeDiffSummary(auto, modified);
+      expect(summary).toContain('แก้');
+      expect(summary).toContain('ลบบรรทัด');
+      expect(summary).toContain('เพิ่มบรรทัด');
+      expect(summary).toContain(';'); // separator
+    });
+  });
+});

--- a/apps/api/src/modules/other-income/services/journal-override.service.spec.ts
+++ b/apps/api/src/modules/other-income/services/journal-override.service.spec.ts
@@ -44,9 +44,11 @@ describe('JournalOverrideService', () => {
     });
 
     it('V5: throws when a line has both Dr and Cr', () => {
+      expect(() =>
+        svc.validate([line('11-1101', 50, 50), line('42-1102', 0, 100)]),
+      ).toThrow(BadRequestException);
       try {
         svc.validate([line('11-1101', 50, 50), line('42-1102', 0, 100)]);
-        fail('should have thrown');
       } catch (e: any) {
         expect(e.response.errors[0].rule).toBe('V5');
         expect(e.response.errors[0].msg).toContain('11-1101');
@@ -55,9 +57,11 @@ describe('JournalOverrideService', () => {
     });
 
     it('V5: throws when a line has neither Dr nor Cr', () => {
+      expect(() =>
+        svc.validate([line('11-1101', 100, 0), line('42-1102', 0, 0), line('21-2101', 0, 100)]),
+      ).toThrow(BadRequestException);
       try {
         svc.validate([line('11-1101', 100, 0), line('42-1102', 0, 0), line('21-2101', 0, 100)]);
-        fail('should have thrown');
       } catch (e: any) {
         expect(e.response.errors[0].rule).toBe('V5');
         expect(e.response.errors[0].msg).toContain('42-1102');
@@ -65,7 +69,7 @@ describe('JournalOverrideService', () => {
       }
     });
 
-    it('errors are returned in V1 → V2 → V5 order — V2 short-circuits before V5', () => {
+    it('short-circuit priority — V2 fires before V5 when both would apply', () => {
       // 1 line that's also missing dr/cr should report V2 first
       try { svc.validate([line('11-1101', 0, 0)]); } catch (e: any) {
         expect(e.response.errors[0].rule).toBe('V2');

--- a/apps/api/src/modules/other-income/services/journal-override.service.ts
+++ b/apps/api/src/modules/other-income/services/journal-override.service.ts
@@ -101,8 +101,10 @@ export class JournalOverrideService {
 
   private fmt(d: Decimal): string {
     // Thai-style number with 2 decimals, comma thousands
-    return new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-      .format(d.toNumber());
+    // Avoid Decimal.toNumber() — use toFixed + regex grouping (accounting rule)
+    const [intPart, decPart = '00'] = d.toFixed(2).split('.');
+    const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return `${intFormatted}.${decPart}`;
   }
 
   private fail(rule: 'V1' | 'V2' | 'V5', msg: string): never {

--- a/apps/api/src/modules/other-income/services/journal-override.service.ts
+++ b/apps/api/src/modules/other-income/services/journal-override.service.ts
@@ -1,0 +1,114 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+
+export interface OverrideLine {
+  accountCode: string;
+  debit: Decimal;
+  credit: Decimal;
+  description?: string;
+}
+
+export interface ValidationError {
+  rule: 'V1' | 'V2' | 'V5';
+  msg: string;
+}
+
+const TOLERANCE = new Decimal('0.01');
+
+@Injectable()
+export class JournalOverrideService {
+  /**
+   * Validate override JE lines against V1 (balanced), V2 (>=2 lines), V5 (Dr XOR Cr per line).
+   * Short-circuits at first failing rule in order V2 → V5 → V1 so users see the most
+   * fundamental problem first.
+   */
+  validate(lines: OverrideLine[]): void {
+    // V2 — must have at least 2 lines
+    if (lines.length < 2) {
+      this.fail('V2', 'ต้องมีอย่างน้อย 2 บรรทัด');
+    }
+
+    // V5 — each line must be Dr XOR Cr
+    for (const line of lines) {
+      const hasDr = line.debit.gt(0);
+      const hasCr = line.credit.gt(0);
+      if (hasDr && hasCr) {
+        this.fail('V5', `บรรทัด ${line.accountCode} มีทั้ง Dr และ Cr — ต้องระบุอย่างใดอย่างหนึ่ง`);
+      }
+      if (!hasDr && !hasCr) {
+        this.fail('V5', `บรรทัด ${line.accountCode} ไม่มีทั้ง Dr และ Cr`);
+      }
+    }
+
+    // V1 — balanced within 0.01 THB tolerance
+    const drTotal = lines.reduce((s, l) => s.plus(l.debit), new Decimal(0));
+    const crTotal = lines.reduce((s, l) => s.plus(l.credit), new Decimal(0));
+    const diff = drTotal.minus(crTotal).abs();
+    if (diff.gt(TOLERANCE)) {
+      this.fail('V1', `Dr (${drTotal.toFixed(2)}) ≠ Cr (${crTotal.toFixed(2)}) — ผลต่าง ${diff.toFixed(2)} บาท`);
+    }
+  }
+
+  /**
+   * Diff two JE line arrays by accountCode. Returns a Thai-language summary used in
+   * audit log "diff_summary" field. Empty string when identical.
+   *
+   * Limitations: assumes one entry per accountCode per side. If a real-world override
+   * needs duplicate accountCode lines, we'd need to use index-based keys.
+   */
+  computeDiffSummary(original: OverrideLine[], modified: OverrideLine[]): string {
+    const origMap = new Map(original.map((l) => [l.accountCode, l]));
+    const modMap = new Map(modified.map((l) => [l.accountCode, l]));
+
+    const parts: string[] = [];
+
+    // Modified lines (in both, but with different amounts)
+    for (const [code, modLine] of modMap) {
+      const origLine = origMap.get(code);
+      if (!origLine) continue; // handled in "added" pass below
+      const drChanged = !origLine.debit.eq(modLine.debit);
+      const crChanged = !origLine.credit.eq(modLine.credit);
+      if (drChanged) {
+        parts.push(
+          `แก้ Dr ${code} จาก ${this.fmt(origLine.debit)} → ${this.fmt(modLine.debit)}`,
+        );
+      }
+      if (crChanged) {
+        parts.push(
+          `แก้ Cr ${code} จาก ${this.fmt(origLine.credit)} → ${this.fmt(modLine.credit)}`,
+        );
+      }
+    }
+
+    // Added lines (in modified, not in original)
+    for (const [code, modLine] of modMap) {
+      if (origMap.has(code)) continue;
+      const side = modLine.debit.gt(0) ? 'Dr' : 'Cr';
+      const amt = modLine.debit.gt(0) ? modLine.debit : modLine.credit;
+      parts.push(`เพิ่มบรรทัด ${side} ${code} ${this.fmt(amt)}`);
+    }
+
+    // Removed lines (in original, not in modified)
+    for (const [code, origLine] of origMap) {
+      if (modMap.has(code)) continue;
+      const side = origLine.debit.gt(0) ? 'Dr' : 'Cr';
+      const amt = origLine.debit.gt(0) ? origLine.debit : origLine.credit;
+      parts.push(`ลบบรรทัด ${side} ${code} ${this.fmt(amt)}`);
+    }
+
+    return parts.join('; ');
+  }
+
+  private fmt(d: Decimal): string {
+    // Thai-style number with 2 decimals, comma thousands
+    return new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+      .format(d.toNumber());
+  }
+
+  private fail(rule: 'V1' | 'V2' | 'V5', msg: string): never {
+    throw new BadRequestException({
+      message: 'ไม่ผ่านการตรวจสอบ Override JV',
+      errors: [{ rule, msg } satisfies ValidationError],
+    });
+  }
+}

--- a/apps/web/e2e/other-income-override-jv.spec.ts
+++ b/apps/web/e2e/other-income-override-jv.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+
+test.describe('Other Income — Override JV', () => {
+  test.beforeEach(async ({ page }) => {
+    // Login as admin (OWNER role) using established pattern
+    await loginAsAdmin(page);
+  });
+
+  test('creates DRAFT, toggles override, edits JV, POSTs, sees ✏ marker', async ({ page }) => {
+    // Step 1: navigate to create new Other Income
+    await page.goto('/other-income/new');
+
+    // Wait for page to load (basic wait for form existence)
+    await page.waitForSelector('form', { timeout: 10000 });
+
+    // Fill in basic form fields — adapt field names to actual UI
+    // Assuming form has fields for: amount, accountCode, description, etc.
+    await page.fill('input[name="amount"]', '1000');
+    await page.fill('input[name="description"]', 'Test override flow');
+
+    // Fill in the auto-generated JV lines (selectors may vary)
+    // Expected: first line is debit 1000, second line is credit 1000
+    const drInput = page.locator('input[name="autoLines.0.debit"]');
+    if (await drInput.count() > 0) {
+      await drInput.fill('1000');
+    }
+
+    // Step 2: save as DRAFT
+    await page.click('button:has-text("บันทึกร่าง")');
+
+    // Wait for redirect to entry/view page
+    await page.waitForURL(/\/other-income\/[a-f0-9-]+/, { timeout: 10000 });
+
+    // Step 3: toggle override checkbox
+    const overrideCheckbox = page.locator('input[type="checkbox"]:near(:text("ใช้เอง"))');
+    if (await overrideCheckbox.count() > 0) {
+      await overrideCheckbox.check();
+    } else {
+      // Fallback: look for checkbox by aria-label or other attribute
+      await page.check('input:near(:text("Override"))');
+    }
+
+    // Wait for warning dialog to appear
+    await expect(page.getByText('คุณกำลังจะแก้ไข')).toBeVisible({ timeout: 5000 });
+
+    // Acknowledge the override
+    const acknowledgeCheckbox = page.locator('input[type="checkbox"]:near(:text("ฉันเข้าใจ"))');
+    if (await acknowledgeCheckbox.count() > 0) {
+      await acknowledgeCheckbox.check();
+    }
+
+    // Click edit mode button
+    await page.click('button:has-text("เปิดโหมดแก้ไข")');
+    await page.waitForSelector('table, div[role="table"]', { timeout: 5000 });
+
+    // Step 4: introduce a V1 violation (Dr != Cr)
+    const firstDrInput = page.locator('input[type="number"]').first();
+    await firstDrInput.fill('999999');
+
+    // Verify error message appears
+    await expect(page.getByText(/V1.*ผลต่าง/)).toBeVisible({ timeout: 5000 });
+
+    // Verify POST button is disabled
+    const postButton = page.getByRole('button', { name: /POST|บันทึก/ });
+    if (await postButton.count() > 0) {
+      await expect(postButton).toBeDisabled();
+    }
+
+    // Step 5: fix balance and POST
+    await firstDrInput.fill('1000');
+
+    // Wait for error to clear (no error text visible)
+    await expect(page.getByText(/V1.*ผลต่าง/)).not.toBeVisible({ timeout: 3000 });
+
+    // POST button should now be enabled
+    if (await postButton.count() > 0) {
+      await expect(postButton).toBeEnabled({ timeout: 3000 });
+      await postButton.click();
+    }
+
+    // Wait for success message
+    await expect(page.getByText(/บันทึกสำเร็จ|POSTED|สำเร็จ/)).toBeVisible({ timeout: 10000 });
+
+    // Step 6: verify ✏ marker on list page
+    await page.goto('/other-income');
+    await page.waitForSelector('table, div[role="table"]', { timeout: 10000 });
+
+    // Check for edit marker (✏) in the first row — selector may be in a cell or badge
+    const editMarker = page.locator('text=/✏|แก้ไข|override/i').first();
+    await expect(editMarker).toBeVisible({ timeout: 5000 });
+  });
+
+  test('V2 validation: blocks POST when only 1 line', async ({ page }) => {
+    // Create a new entry
+    await page.goto('/other-income/new');
+    await page.waitForSelector('form', { timeout: 10000 });
+
+    // Fill basic form
+    await page.fill('input[name="amount"]', '500');
+
+    // Save draft
+    await page.click('button:has-text("บันทึกร่าง")');
+    await page.waitForURL(/\/other-income\/[a-f0-9-]+/, { timeout: 10000 });
+
+    // Toggle override
+    await page.check('input[type="checkbox"]:near(:text("ใช้เอง"))');
+    await expect(page.getByText('คุณกำลังจะแก้ไข')).toBeVisible({ timeout: 5000 });
+    await page.check('input[type="checkbox"]:near(:text("ฉันเข้าใจ"))');
+    await page.click('button:has-text("เปิดโหมดแก้ไข")');
+
+    // Delete one line to leave only 1
+    const deleteButtons = page.locator('button:has-text("ลบ")');
+    if (await deleteButtons.count() > 0) {
+      await deleteButtons.first().click();
+    }
+
+    // Expect V2 error (at least 2 lines required)
+    await expect(page.getByText(/V2|อย่างน้อย.*2.*บรรทัด/)).toBeVisible({ timeout: 5000 });
+
+    // POST button should be disabled
+    const postButton = page.getByRole('button', { name: /POST|บันทึก/ });
+    if (await postButton.count() > 0) {
+      await expect(postButton).toBeDisabled();
+    }
+  });
+
+  test('V5 validation: blocks POST when line has both Dr and Cr', async ({ page }) => {
+    // Create a new entry
+    await page.goto('/other-income/new');
+    await page.waitForSelector('form', { timeout: 10000 });
+
+    // Fill basic form
+    await page.fill('input[name="amount"]', '750');
+
+    // Save draft
+    await page.click('button:has-text("บันทึกร่าง")');
+    await page.waitForURL(/\/other-income\/[a-f0-9-]+/, { timeout: 10000 });
+
+    // Toggle override
+    await page.check('input[type="checkbox"]:near(:text("ใช้เอง"))');
+    await expect(page.getByText('คุณกำลังจะแก้ไข')).toBeVisible({ timeout: 5000 });
+    await page.check('input[type="checkbox"]:near(:text("ฉันเข้าใจ"))');
+    await page.click('button:has-text("เปิดโหมดแก้ไข")');
+
+    // Set both Dr and Cr on the same line
+    const drInputs = page.locator('input[name*="debit"]');
+    const crInputs = page.locator('input[name*="credit"]');
+
+    if (await drInputs.count() > 0 && await crInputs.count() > 0) {
+      await drInputs.first().fill('500');
+      await crInputs.first().fill('250');
+    }
+
+    // Expect V5 error (Dr XOR Cr, not both)
+    await expect(page.getByText(/V5|มีทั้ง Dr และ Cr/)).toBeVisible({ timeout: 5000 });
+
+    // POST button should be disabled
+    const postButton = page.getByRole('button', { name: /POST|บันทึก/ });
+    if (await postButton.count() > 0) {
+      await expect(postButton).toBeDisabled();
+    }
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1065,7 +1065,14 @@ function App() {
           />
 
           {/* งวดบัญชี → /settings#periods (Task 7 backward-compat redirect) */}
-          <Route path="/accounting/periods" element={<PeriodsRedirect />} />
+          <Route
+            path="/accounting/periods"
+            element={
+              <ProtectedRoute roles={['OWNER']}>
+                <PeriodsRedirect />
+              </ProtectedRoute>
+            }
+          />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,14 @@ function ExternalRedirect({ to }: { to: string }) {
   return null;
 }
 
+// Redirect /accounting/periods → /settings#periods (preserves hash via window.location.replace).
+function PeriodsRedirect() {
+  useEffect(() => {
+    window.location.replace('/settings#periods');
+  }, []);
+  return null;
+}
+
 // Lazy-load all pages (separate chunks, loaded on demand)
 const LandingPage = lazy(() => import('@/pages/LandingPage'));
 const PrivacyPolicyPage = lazy(() => import('@/pages/PrivacyPolicyPage'));
@@ -40,6 +48,9 @@ const ReportsPage = lazy(() => import('@/pages/ReportsPage'));
 const MigrationPage = lazy(() => import('@/pages/MigrationPage'));
 const UsersPage = lazy(() => import('@/pages/UsersPage'));
 const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
+const StickersSettingsPage = lazy(() => import('@/pages/SettingsPage/StickersPage'));
+const CollectionsSettingsPage = lazy(() => import('@/pages/SettingsPage/CollectionsPage'));
+const GeneralSettingsPage = lazy(() => import('@/pages/SettingsPage/GeneralSettingsPage'));
 const PaymentMethodSettingsPage = lazy(() => import('@/pages/PaymentMethodSettingsPage'));
 const DefectExchangePage = lazy(() => import('@/pages/DefectExchangePage'));
 const AuditLogsPage = lazy(() => import('@/pages/AuditLogsPage'));
@@ -392,6 +403,9 @@ function App() {
           <Route path="/ads" element={<ProtectedRoute roles={['OWNER']}><AdsTrackingPage /></ProtectedRoute>} />
           <Route path="/settings/channels" element={<ProtectedRoute roles={['OWNER']}><ChannelSettingsPage /></ProtectedRoute>} />
           <Route path="/settings/payment-methods" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER']}><PaymentMethodSettingsPage /></ProtectedRoute>} />
+          <Route path="/settings/stickers" element={<ProtectedRoute roles={['OWNER']}><StickersSettingsPage /></ProtectedRoute>} />
+          <Route path="/settings/collections" element={<ProtectedRoute roles={['OWNER']}><CollectionsSettingsPage /></ProtectedRoute>} />
+          <Route path="/settings/general" element={<ProtectedRoute roles={['OWNER']}><GeneralSettingsPage /></ProtectedRoute>} />
           <Route path="/chatbot-finance" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER']}><ChatbotFinanceAnalyticsPage /></ProtectedRoute>} />
           <Route path="/chatbot-finance/sessions" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}><ChatbotFinanceSessionsPage /></ProtectedRoute>} />
           <Route path="/chatbot-finance/knowledge" element={<ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER']}><ChatbotFinanceKnowledgePage /></ProtectedRoute>} />
@@ -1050,15 +1064,8 @@ function App() {
             }
           />
 
-          {/* งวดบัญชี (Accounting Periods) */}
-          <Route
-            path="/accounting/periods"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <PeriodClosePage />
-              </ProtectedRoute>
-            }
-          />
+          {/* งวดบัญชี → /settings#periods (Task 7 backward-compat redirect) */}
+          <Route path="/accounting/periods" element={<PeriodsRedirect />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/web/src/components/accounting/ReopenedPeriodBanner.tsx
+++ b/apps/web/src/components/accounting/ReopenedPeriodBanner.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { AlertTriangle } from 'lucide-react';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { accountingApi, type ReopenedPeriod } from '@/lib/accounting';
+import { formatThaiDateTime } from '@/lib/date';
 
 export function ReopenedPeriodBanner() {
   const { data } = useQuery<ReopenedPeriod[]>({
@@ -22,7 +23,7 @@ export function ReopenedPeriodBanner() {
             <AlertTitle>งวด {periodLabel} ถูกเปิดชั่วคราว</AlertTitle>
             <AlertDescription className="space-y-1">
               <p>
-                เปิดเมื่อ: {new Date(p.reopenedAt).toLocaleString('th-TH')}
+                เปิดเมื่อ: {formatThaiDateTime(p.reopenedAt)}
                 {p.reopenedBy?.name ? ` โดย ${p.reopenedBy.name}` : ''}
               </p>
               {p.reopenReason && <p>เหตุผล: {p.reopenReason}</p>}

--- a/apps/web/src/components/accounting/ReopenedPeriodBanner.tsx
+++ b/apps/web/src/components/accounting/ReopenedPeriodBanner.tsx
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle } from 'lucide-react';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { accountingApi, type ReopenedPeriod } from '@/lib/accounting';
+
+export function ReopenedPeriodBanner() {
+  const { data } = useQuery<ReopenedPeriod[]>({
+    queryKey: ['accounting-periods', 'reopened'],
+    queryFn: () => accountingApi.listReopenedPeriods(),
+    staleTime: 60_000,
+  });
+
+  if (!data || data.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {data.map((p) => {
+        const periodLabel = `${p.year}-${String(p.month).padStart(2, '0')}`;
+        return (
+          <Alert key={p.id || periodLabel} variant="warning" className="border-warning bg-warning/10">
+            <AlertTriangle className="w-4 h-4 text-warning" />
+            <AlertTitle>งวด {periodLabel} ถูกเปิดชั่วคราว</AlertTitle>
+            <AlertDescription className="space-y-1">
+              <p>
+                เปิดเมื่อ: {new Date(p.reopenedAt).toLocaleString('th-TH')}
+                {p.reopenedBy?.name ? ` โดย ${p.reopenedBy.name}` : ''}
+              </p>
+              {p.reopenReason && <p>เหตุผล: {p.reopenReason}</p>}
+              {p.taxFiled && <p className="text-destructive font-medium">ภ.พ.30 ยื่นแล้ว — ต้องยื่นแก้ไขด้วย</p>}
+            </AlertDescription>
+          </Alert>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/accounting/__tests__/ReopenedPeriodBanner.test.tsx
+++ b/apps/web/src/components/accounting/__tests__/ReopenedPeriodBanner.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReopenedPeriodBanner } from '../ReopenedPeriodBanner';
+
+vi.mock('@/lib/accounting', () => ({
+  accountingApi: {
+    listReopenedPeriods: vi.fn(),
+  },
+}));
+
+import { accountingApi } from '@/lib/accounting';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ReopenedPeriodBanner', () => {
+  it('renders nothing when no periods are reopened', async () => {
+    (accountingApi.listReopenedPeriods as any).mockResolvedValue([]);
+    render(<ReopenedPeriodBanner />, { wrapper });
+    expect(screen.queryByText(/ถูกเปิดชั่วคราว/)).not.toBeInTheDocument();
+  });
+
+  it('renders one banner per reopened period', async () => {
+    (accountingApi.listReopenedPeriods as any).mockResolvedValue([
+      {
+        year: 2026,
+        month: 4,
+        reopenedAt: '2026-05-12T14:00:00Z',
+        reopenedBy: { id: 'u1', name: 'สุทธินีย์' },
+        reopenReason: 'WRONG_ENTRY: เอกสาร OI-26040015 ระบุลูกค้าผิด',
+        taxFiled: true,
+      },
+    ]);
+    render(<ReopenedPeriodBanner />, { wrapper });
+    expect(await screen.findByText(/2026-04/)).toBeInTheDocument();
+    expect(screen.getByText(/สุทธินีย์/)).toBeInTheDocument();
+    expect(screen.getByText(/ภ.พ.30 ยื่นแล้ว/)).toBeInTheDocument();
+  });
+
+  it('omits tax-filed warning when taxFiled is false', async () => {
+    (accountingApi.listReopenedPeriods as any).mockResolvedValue([
+      { year: 2026, month: 3, reopenedAt: '2026-05-12T14:00:00Z', reopenedBy: { id: 'u1', name: 'สุทธินีย์' }, reopenReason: 'WRONG_ENTRY: ...', taxFiled: false },
+    ]);
+    render(<ReopenedPeriodBanner />, { wrapper });
+    await screen.findByText(/2026-03/);
+    expect(screen.queryByText(/ภ.พ.30 ยื่นแล้ว/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/PaginationBar.tsx
+++ b/apps/web/src/components/ui/PaginationBar.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { Button } from './button';
+import { Input } from './input';
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
+
+type Props = {
+  total: number;
+  page: number;
+  size: number;
+  sizeOptions?: number[];
+  onPageChange: (page: number) => void;
+  onSizeChange: (size: number) => void;
+};
+
+function pagesAround(current: number, total: number, span = 5): number[] {
+  if (total <= span) return Array.from({ length: total }, (_, i) => i + 1);
+  let start = Math.max(1, current - Math.floor(span / 2));
+  const end = Math.min(total, start + span - 1);
+  start = Math.max(1, end - span + 1);
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+}
+
+export function PaginationBar({
+  total,
+  page,
+  size,
+  sizeOptions = [20, 50, 100],
+  onPageChange,
+  onSizeChange,
+}: Props) {
+  const totalPages = Math.max(1, Math.ceil(total / size));
+  const start = total === 0 ? 0 : (page - 1) * size + 1;
+  const end = Math.min(page * size, total);
+  const [jumpValue, setJumpValue] = useState('');
+
+  const handleJump = () => {
+    const n = Number(jumpValue);
+    if (Number.isFinite(n) && n >= 1 && n <= totalPages) {
+      onPageChange(Math.floor(n));
+      setJumpValue('');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3 flex-wrap py-2 text-sm">
+      <span className="text-muted-foreground">
+        แสดง {start.toLocaleString()}-{end.toLocaleString()} จาก {total.toLocaleString()} รายการ
+      </span>
+
+      <div className="flex items-center gap-1">
+        <Button variant="ghost" size="sm" aria-label="First" onClick={() => onPageChange(1)} disabled={page === 1}>
+          <ChevronsLeft className="w-4 h-4" />
+        </Button>
+        <Button variant="ghost" size="sm" aria-label="Prev" onClick={() => onPageChange(page - 1)} disabled={page === 1}>
+          <ChevronLeft className="w-4 h-4" />
+        </Button>
+        {pagesAround(page, totalPages).map((p) => (
+          <Button
+            key={p}
+            variant={p === page ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => onPageChange(p)}
+            aria-current={p === page ? 'page' : undefined}
+            aria-label={String(p)}
+          >
+            {p}
+          </Button>
+        ))}
+        <Button variant="ghost" size="sm" aria-label="Next" onClick={() => onPageChange(page + 1)} disabled={page === totalPages}>
+          <ChevronRight className="w-4 h-4" />
+        </Button>
+        <Button variant="ghost" size="sm" aria-label="Last" onClick={() => onPageChange(totalPages)} disabled={page === totalPages}>
+          <ChevronsRight className="w-4 h-4" />
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Input
+          className="w-16 h-8 text-sm"
+          placeholder="ไปหน้า"
+          value={jumpValue}
+          onChange={(e) => setJumpValue(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleJump()}
+        />
+        <label className="flex items-center gap-1 text-xs text-muted-foreground">
+          แสดงต่อหน้า:
+          <select
+            aria-label="แสดงต่อหน้า"
+            value={size}
+            onChange={(e) => onSizeChange(Number(e.target.value))}
+            className="border border-border bg-background rounded px-1 py-0.5 text-sm"
+          >
+            {sizeOptions.map((opt) => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/PaginationBar.tsx
+++ b/apps/web/src/components/ui/PaginationBar.tsx
@@ -57,7 +57,7 @@ export function PaginationBar({
         {pagesAround(page, totalPages).map((p) => (
           <Button
             key={p}
-            variant={p === page ? 'default' : 'ghost'}
+            variant={p === page ? 'primary' : 'ghost'}
             size="sm"
             onClick={() => onPageChange(p)}
             aria-current={p === page ? 'page' : undefined}

--- a/apps/web/src/components/ui/__tests__/PaginationBar.test.tsx
+++ b/apps/web/src/components/ui/__tests__/PaginationBar.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PaginationBar } from '../PaginationBar';
+
+describe('PaginationBar', () => {
+  const props = (overrides = {}) => ({
+    total: 247,
+    page: 3,
+    size: 50,
+    onPageChange: vi.fn(),
+    onSizeChange: vi.fn(),
+    ...overrides,
+  });
+
+  it('shows "แสดง X-Y จาก Z รายการ"', () => {
+    render(<PaginationBar {...props()} />);
+    expect(screen.getByText(/แสดง 101-150 จาก 247 รายการ/)).toBeInTheDocument();
+  });
+
+  it('shows last partial range correctly', () => {
+    render(<PaginationBar {...props({ page: 5, size: 50, total: 247 })} />);
+    expect(screen.getByText(/แสดง 201-247 จาก 247 รายการ/)).toBeInTheDocument();
+  });
+
+  it('disables Prev/First on page 1', () => {
+    render(<PaginationBar {...props({ page: 1 })} />);
+    expect(screen.getByRole('button', { name: /First/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Prev/i })).toBeDisabled();
+  });
+
+  it('disables Next/Last on final page', () => {
+    render(<PaginationBar {...props({ page: 5, size: 50, total: 247 })} />);
+    expect(screen.getByRole('button', { name: /Next/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Last/i })).toBeDisabled();
+  });
+
+  it('calls onPageChange when numeric page clicked', () => {
+    const onPageChange = vi.fn();
+    render(<PaginationBar {...props({ onPageChange })} />);
+    fireEvent.click(screen.getByRole('button', { name: '4' }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  it('calls onSizeChange when page-size selector changes', () => {
+    const onSizeChange = vi.fn();
+    render(<PaginationBar {...props({ onSizeChange })} />);
+    // shadcn Select uses role=combobox or similar — adapt to actual impl
+    const select = screen.getByLabelText(/แสดงต่อหน้า/i);
+    fireEvent.change(select, { target: { value: '100' } });
+    expect(onSizeChange).toHaveBeenCalledWith(100);
+  });
+
+  it('jump-to-page input invokes onPageChange on Enter', () => {
+    const onPageChange = vi.fn();
+    render(<PaginationBar {...props({ onPageChange })} />);
+    const input = screen.getByPlaceholderText(/ไปหน้า/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '4' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+});

--- a/apps/web/src/hooks/__tests__/usePaginationParams.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePaginationParams.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, useLocation } from 'react-router';
+import { usePaginationParams } from '../usePaginationParams';
+
+function wrapper({ initial }: { initial: string }) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <MemoryRouter initialEntries={[initial]}>{children}</MemoryRouter>;
+  };
+}
+
+describe('usePaginationParams', () => {
+  it('returns defaults when URL has no params', () => {
+    const { result } = renderHook(() => usePaginationParams({ defaultSize: 50 }), {
+      wrapper: wrapper({ initial: '/list' }),
+    });
+    expect(result.current.page).toBe(1);
+    expect(result.current.size).toBe(50);
+  });
+
+  it('reads page + size from URL', () => {
+    const { result } = renderHook(() => usePaginationParams({ defaultSize: 50 }), {
+      wrapper: wrapper({ initial: '/list?page=3&size=20' }),
+    });
+    expect(result.current.page).toBe(3);
+    expect(result.current.size).toBe(20);
+  });
+
+  it('setPage updates URL', () => {
+    const { result } = renderHook(() => usePaginationParams({ defaultSize: 50 }), {
+      wrapper: wrapper({ initial: '/list' }),
+    });
+    act(() => result.current.setPage(2));
+    expect(result.current.page).toBe(2);
+  });
+
+  it('setSize resets page to 1', () => {
+    const { result } = renderHook(() => usePaginationParams({ defaultSize: 50 }), {
+      wrapper: wrapper({ initial: '/list?page=5&size=20' }),
+    });
+    act(() => result.current.setSize(100));
+    expect(result.current.size).toBe(100);
+    expect(result.current.page).toBe(1);
+  });
+
+  it('preserves other query params', () => {
+    let location: ReturnType<typeof useLocation> | null = null;
+    function Capture() { location = useLocation(); return null; }
+    const { result } = renderHook(() => usePaginationParams({ defaultSize: 50 }), {
+      wrapper: wrapper({ initial: '/list?status=READY&page=2' }),
+    });
+    act(() => result.current.setPage(3));
+    expect(result.current.page).toBe(3);
+  });
+});

--- a/apps/web/src/hooks/usePaginationParams.ts
+++ b/apps/web/src/hooks/usePaginationParams.ts
@@ -1,0 +1,41 @@
+import { useSearchParams } from 'react-router';
+import { useCallback, useMemo } from 'react';
+
+type Options = {
+  defaultPage?: number;
+  defaultSize?: number;
+};
+
+export function usePaginationParams(options: Options = {}) {
+  const { defaultPage = 1, defaultSize = 50 } = options;
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = useMemo(() => {
+    const raw = Number(searchParams.get('page'));
+    return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : defaultPage;
+  }, [searchParams, defaultPage]);
+
+  const size = useMemo(() => {
+    const raw = Number(searchParams.get('size'));
+    return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : defaultSize;
+  }, [searchParams, defaultSize]);
+
+  const setPage = useCallback((nextPage: number) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('page', String(nextPage));
+      return next;
+    });
+  }, [setSearchParams]);
+
+  const setSize = useCallback((nextSize: number) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('size', String(nextSize));
+      next.set('page', '1'); // reset to first page on size change
+      return next;
+    });
+  }, [setSearchParams]);
+
+  return { page, size, setPage, setSize };
+}

--- a/apps/web/src/lib/accounting.ts
+++ b/apps/web/src/lib/accounting.ts
@@ -1,0 +1,16 @@
+import api from './api';
+
+export type ReopenedPeriod = {
+  id?: string;
+  year: number;
+  month: number;
+  reopenedAt: string;
+  reopenedBy: { id: string; name: string };
+  reopenReason: string | null;
+  taxFiled: boolean | null;
+};
+
+export const accountingApi = {
+  listReopenedPeriods: () =>
+    api.get<ReopenedPeriod[]>('/accounting/periods/reopened').then((r: { data: ReopenedPeriod[] }) => r.data),
+};

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -17,6 +17,7 @@ export interface ListQuery {
   q?: string;
   page?: number;
   limit?: number;
+  sort?: string;
 }
 
 export const otherIncomeApi = {

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -81,6 +81,12 @@ export const otherIncomeApi = {
   isMakerCheckerEnabled: () =>
     api.get<{ enabled: boolean }>('/other-income/maker-checker-enabled').then((r) => r.data.enabled),
 
+  setMakerCheckerEnabled: (enabled: boolean) =>
+    api.put('/other-income/maker-checker', { enabled }).then((r) => r.data),
+
+  getPendingReadyCount: () =>
+    api.get<{ count: number }>('/other-income/maker-checker/pending-ready-count').then((r) => r.data.count),
+
   requestApproval: (id: string) =>
     api.post(`/other-income/${id}/request-approval`).then((r) => r.data),
 

--- a/apps/web/src/pages/AuditLogsPage.tsx
+++ b/apps/web/src/pages/AuditLogsPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useQuery } from '@tanstack/react-query';
+import { usePaginationParams } from '@/hooks/usePaginationParams';
+import { PaginationBar } from '@/components/ui/PaginationBar';
 import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import { useDebounce } from '@/hooks/useDebounce';
@@ -125,12 +127,11 @@ export default function AuditLogsPage() {
   const [action, setAction] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
-  const [page, setPage] = useState(1);
+  const { page, size, setPage, setSize } = usePaginationParams({ defaultSize: 100 });
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [collectionPreset, setCollectionPreset] = useState<CollectionPreset>(null);
   // Server-side filter for preset actions (multi-action filter, sent as `actions` query param)
   const [presetActions, setPresetActions] = useState<string[]>([]);
-  const limit = 25;
 
   const debouncedEntity = useDebounce(entity, 300);
 
@@ -147,11 +148,11 @@ export default function AuditLogsPage() {
     page: number;
     totalPages: number;
   }>({
-    queryKey: ['audit-logs', debouncedEntity, action, dateFrom, dateTo, page, presetActionsKey],
+    queryKey: ['audit-logs', debouncedEntity, action, dateFrom, dateTo, page, size, presetActionsKey],
     queryFn: async () => {
       const params: Record<string, string | string[]> = {
         page: String(page),
-        limit: String(limit),
+        limit: String(size),
       };
       if (debouncedEntity) params.entity = debouncedEntity;
       // `actions` (multi) takes precedence over `action` (single) — matches backend
@@ -167,7 +168,7 @@ export default function AuditLogsPage() {
   });
 
   const logs = result?.data || [];
-  const totalPages = result?.totalPages || 1;
+  const total = result?.total ?? 0;
 
   function applyPreset(key: string) {
     setCollectionPreset(key as CollectionPreset);
@@ -435,32 +436,13 @@ export default function AuditLogsPage() {
         )}
 
         {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="flex items-center justify-between px-4 py-3 border-t bg-muted">
-            <p className="text-xs text-muted-foreground">
-              แสดง {logs.length} จาก {result?.total?.toLocaleString()} รายการ
-            </p>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page <= 1}
-                className="px-3 py-1.5 text-xs border rounded-lg disabled:opacity-50 hover:bg-muted/50"
-              >
-                ก่อนหน้า
-              </button>
-              <span className="text-xs text-muted-foreground">
-                {page} / {totalPages}
-              </span>
-              <button
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page >= totalPages}
-                className="px-3 py-1.5 text-xs border rounded-lg disabled:opacity-50 hover:bg-muted/50"
-              >
-                ถัดไป
-              </button>
-            </div>
-          </div>
-        )}
+        <PaginationBar
+          total={total}
+          page={page}
+          size={size}
+          onPageChange={setPage}
+          onSizeChange={setSize}
+        />
         </QueryBoundary>
       </Card>
     </div>

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePaginationParams } from '@/hooks/usePaginationParams';
+import { PaginationBar } from '@/components/ui/PaginationBar';
 import { toast } from 'sonner';
 import api, { getErrorMessage } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -110,7 +112,7 @@ export default function ExpensesPage() {
   const branchFilter = searchParams.get('branch') || '';
   const startDate = searchParams.get('startDate') || '';
   const endDate = searchParams.get('endDate') || '';
-  const page = parseInt(searchParams.get('page') || '1');
+  const { page, size, setPage, setSize } = usePaginationParams({ defaultSize: 50 });
   const [search, setSearch] = useState(searchParams.get('search') || '');
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const debouncedSearch = useDebounce(search, 300);
@@ -124,14 +126,15 @@ export default function ExpensesPage() {
   const setFilter = (key: string, value: string) => {
     const params = new URLSearchParams(searchParams);
     if (value) params.set(key, value); else params.delete(key);
-    if (key !== 'page') params.delete('page');
+    // reset to page 1 whenever any filter changes (PDF AC-5.6)
+    params.set('page', '1');
     setSearchParams(params, { replace: true });
   };
 
   const setTab = (tab: string) => {
     const params = new URLSearchParams(searchParams);
     if (tab === 'all') params.delete('tab'); else params.set('tab', tab);
-    params.delete('page');
+    params.delete('page'); // reset pagination when switching tabs
     params.delete('status'); // tab supersedes manual status filter
     setSearchParams(params, { replace: true });
   };
@@ -167,9 +170,9 @@ export default function ExpensesPage() {
     error,
     refetch,
   } = useQuery<{ data: Expense[]; total: number }>({
-    queryKey: ['expenses', tabFilter, statusFilter, categoryFilter, branchFilter, startDate, endDate, debouncedSearch, page],
+    queryKey: ['expenses', tabFilter, statusFilter, categoryFilter, branchFilter, startDate, endDate, debouncedSearch, page, size],
     queryFn: async () => {
-      const p = new URLSearchParams({ limit: '20', page: String(page) });
+      const p = new URLSearchParams({ limit: String(size), page: String(page) });
       if (tabFilter && tabFilter !== 'all') p.set('tab', tabFilter);
       if (statusFilter) p.set('status', statusFilter);
       if (categoryFilter) p.set('category', categoryFilter);
@@ -196,7 +199,7 @@ export default function ExpensesPage() {
   const openEdit = (e: Expense) => { setEditingExpense(e); setShowForm(true); setOpenMenuId(null); };
   const handleFormSaved = () => { setShowForm(false); setEditingExpense(null); invalidateAll(); };
 
-  const totalPages = Math.ceil((expensesData?.total || 0) / 20);
+  const total = expensesData?.total ?? 0;
 
   // Tab counts derived from summary endpoint
   const totalCount = summary?.totalCount ?? 0;
@@ -445,7 +448,7 @@ export default function ExpensesPage() {
           <input
             type="text"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
             placeholder="ค้นหาเลขเอกสาร / ผู้ขาย / เลขใบกำกับ..."
             className="w-full pl-10 pr-3 py-2.5 border border-input rounded-lg text-sm focus-visible:ring-2 focus-visible:ring-ring/30 outline-hidden bg-background"
           />
@@ -538,15 +541,13 @@ export default function ExpensesPage() {
       </QueryBoundary>
 
       {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between mt-4">
-          <span className="text-sm text-muted-foreground">หน้า {page} / {totalPages} (ทั้งหมด {expensesData?.total} รายการ)</span>
-          <div className="flex gap-1">
-            <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setFilter('page', String(page - 1))}>ก่อนหน้า</Button>
-            <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => setFilter('page', String(page + 1))}>ถัดไป</Button>
-          </div>
-        </div>
-      )}
+      <PaginationBar
+        total={total}
+        page={page}
+        size={size}
+        onPageChange={setPage}
+        onSizeChange={setSize}
+      />
 
       {/* Unified Expense Form V4 */}
       {showForm && (

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -17,6 +17,7 @@ import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { Button } from '@/components/ui/button';
 import { formatDateShortThai, formatNumberDecimal } from '@/utils/formatters';
 import { ExpenseFormV4 } from '@/components/expense-form-v4/ExpenseFormV4';
+import { ReopenedPeriodBanner } from '@/components/accounting/ReopenedPeriodBanner';
 
 // ─── Types ───
 interface ExpenseDocument {
@@ -352,6 +353,7 @@ export default function ExpensesPage() {
 
   return (
     <div onClick={() => { setOpenMenuId(null); setShowCreateMenu(false); }} onKeyDown={(e) => { if (e.key === 'Escape') { setOpenMenuId(null); setShowCreateMenu(false); } }}>
+      <ReopenedPeriodBanner />
       {/* Compact branded header */}
       <div className="flex items-center justify-between gap-4 pb-4 mb-5 border-b border-border flex-wrap">
         <div className="flex items-center gap-3 min-w-0">

--- a/apps/web/src/pages/SettingsPage/CollectionsPage.tsx
+++ b/apps/web/src/pages/SettingsPage/CollectionsPage.tsx
@@ -1,0 +1,17 @@
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+import CollectionsConfigCard from './components/CollectionsConfigCard';
+
+export default function CollectionsPage() {
+  useDocumentTitle('ตั้งค่าการติดตามหนี้');
+
+  return (
+    <div>
+      <PageHeader
+        title="ตั้งค่าการติดตามหนี้"
+        subtitle="กำหนด workload cap, session target และ self-claim lock สำหรับทีม collections"
+      />
+      <CollectionsConfigCard />
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/GeneralSettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage/GeneralSettingsPage.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+import api, { getErrorMessage } from '@/lib/api';
+import GeneralSettings from './components/GeneralSettings';
+import type { ConfigItem } from './components/shared';
+
+export default function GeneralSettingsPage() {
+  useDocumentTitle('ตั้งค่าทั่วไป');
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [editingSection, setEditingSection] = useState<string | null>(null);
+
+  const { data: configs = [] } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length > 0 && !editingSection) {
+      const map: Record<string, string> = {};
+      configs.forEach((c) => {
+        map[c.key] = c.value;
+      });
+      setValues(map);
+    }
+  }, [configs, editingSection]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (items: { key: string; value: string }[]) =>
+      api.patch('/settings', { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกสำเร็จ');
+      setEditingSection(null);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="ตั้งค่าทั่วไป"
+        subtitle="บัญชีธนาคาร, ค่าปรับ, PDPA และ payment gateway"
+      />
+      {/* penalty + pdpa */}
+      <GeneralSettings
+        values={values}
+        editingSection={editingSection}
+        onEdit={setEditingSection}
+        onSave={(items) => saveMutation.mutate(items)}
+        onCancel={() => setEditingSection(null)}
+        isSaving={saveMutation.isPending}
+        slot="pre"
+      />
+      {/* banking + payment_link */}
+      <GeneralSettings
+        values={values}
+        editingSection={editingSection}
+        onEdit={setEditingSection}
+        onSave={(items) => saveMutation.mutate(items)}
+        onCancel={() => setEditingSection(null)}
+        isSaving={saveMutation.isPending}
+        slot="post"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/StickersPage.tsx
+++ b/apps/web/src/pages/SettingsPage/StickersPage.tsx
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+import api, { getErrorMessage } from '@/lib/api';
+import StickerSettings from './components/StickerSettings';
+import type { ConfigItem } from './components/shared';
+
+export default function StickersPage() {
+  useDocumentTitle('ตั้งค่าสติกเกอร์');
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [editingSection, setEditingSection] = useState<string | null>(null);
+
+  const { data: configs = [] } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length > 0 && !editingSection) {
+      const map: Record<string, string> = {};
+      configs.forEach((c) => {
+        map[c.key] = c.value;
+      });
+      setValues(map);
+    }
+  }, [configs, editingSection]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (items: { key: string; value: string }[]) =>
+      api.patch('/settings', { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกสำเร็จ');
+      setEditingSection(null);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  return (
+    <div>
+      <PageHeader
+        title="ตั้งค่าสติกเกอร์"
+        subtitle="ค่า default สติกเกอร์ติดเครื่องเมื่อ PricingTemplate ไม่ได้ override"
+      />
+      <StickerSettings
+        values={values}
+        editingSection={editingSection}
+        onEdit={setEditingSection}
+        onSave={(items) => saveMutation.mutate(items)}
+        onCancel={() => setEditingSection(null)}
+        isSaving={saveMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/components/MakerCheckerConfirmDialog.tsx
+++ b/apps/web/src/pages/SettingsPage/components/MakerCheckerConfirmDialog.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { AlertTriangle } from 'lucide-react';
+
+type Props = {
+  open: boolean;
+  nextValue: boolean | null; // true = OFF→ON, false = ON→OFF
+  pendingReadyCount: number; // shown when ON→OFF
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function MakerCheckerConfirmDialog({
+  open,
+  nextValue,
+  pendingReadyCount,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  useEffect(() => {
+    if (!open) setAcknowledged(false);
+  }, [open]);
+
+  const isEnabling = nextValue === true;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="w-5 h-5" />
+            {isEnabling
+              ? 'คุณกำลังจะเปิดระบบ Maker-Checker'
+              : 'คุณกำลังจะปิดระบบ Maker-Checker'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 text-sm">
+          <p className="font-semibold">ผลกระทบ:</p>
+          {isEnabling ? (
+            <ul className="space-y-1 list-disc list-inside text-muted-foreground">
+              <li>เอกสารทุกฉบับจะต้องผ่านผู้อนุมัติก่อน POST</li>
+              <li>เอกสาร DRAFT ปัจจุบันจะต้องส่งอนุมัติ</li>
+              <li>ผู้สร้าง ≠ ผู้อนุมัติ (segregation of duties)</li>
+            </ul>
+          ) : (
+            <>
+              <ul className="space-y-1 list-disc list-inside text-muted-foreground">
+                <li>เอกสารที่อยู่ในสถานะ READY จะถูก auto-approve</li>
+                <li>เอกสารใหม่จะ POST ทันที (ไม่ต้องอนุมัติ)</li>
+              </ul>
+              <p className="text-warning font-medium">
+                จำนวนเอกสาร READY ตอนนี้: {pendingReadyCount} ฉบับ
+              </p>
+            </>
+          )}
+
+          <div className="flex items-start gap-2 pt-2">
+            <Checkbox
+              id="mc-ack"
+              checked={acknowledged}
+              onCheckedChange={(v) => setAcknowledged(Boolean(v))}
+            />
+            <label htmlFor="mc-ack" className="text-sm cursor-pointer">
+              {isEnabling
+                ? 'ฉันเข้าใจและยืนยันเปิดระบบ'
+                : 'ฉันเข้าใจและยืนยันปิดระบบ'}
+            </label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            ยกเลิก
+          </Button>
+          <Button onClick={onConfirm} disabled={!acknowledged}>
+            {isEnabling ? 'ยืนยันเปิด' : 'ยืนยันปิด'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/components/MakerCheckerToggle.tsx
+++ b/apps/web/src/pages/SettingsPage/components/MakerCheckerToggle.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { toast } from 'sonner';
+import { Info } from 'lucide-react';
+import { MakerCheckerConfirmDialog } from './MakerCheckerConfirmDialog';
+import { otherIncomeApi } from '@/lib/otherIncome';
+
+export function MakerCheckerToggle() {
+  const { user } = useAuth();
+  const isOwner = user?.role === 'OWNER';
+  const queryClient = useQueryClient();
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [pendingNext, setPendingNext] = useState<boolean | null>(null);
+
+  const enabledQuery = useQuery({
+    queryKey: ['other-income', 'maker-checker', 'enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+  });
+
+  const pendingCountQuery = useQuery({
+    queryKey: ['other-income', 'maker-checker', 'pending-ready-count'],
+    queryFn: () => otherIncomeApi.getPendingReadyCount(),
+    enabled: showConfirm && pendingNext === false, // only fetch when turning OFF
+  });
+
+  const mutation = useMutation({
+    mutationFn: (enabled: boolean) => otherIncomeApi.setMakerCheckerEnabled(enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['other-income', 'maker-checker'] });
+      queryClient.invalidateQueries({ queryKey: ['other-income-maker-checker-enabled'] });
+      toast.success('บันทึกการตั้งค่าสำเร็จ');
+    },
+    onError: () => toast.error('ไม่สามารถบันทึกการตั้งค่าได้'),
+  });
+
+  const currentEnabled = enabledQuery.data ?? false;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>ระบบ Maker-Checker (ผู้สร้าง ≠ ผู้อนุมัติ)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-3">
+          <Switch
+            checked={currentEnabled}
+            onCheckedChange={(next) => {
+              if (!isOwner) return;
+              setPendingNext(next);
+              setShowConfirm(true);
+            }}
+            disabled={!isOwner || mutation.isPending}
+            aria-label="Toggle Maker-Checker"
+          />
+          <span className="text-sm font-medium">
+            {currentEnabled ? 'เปิดใช้งาน' : 'ปิดใช้งาน'}
+          </span>
+        </div>
+
+        {!isOwner && (
+          <p className="text-xs text-muted-foreground">เฉพาะ OWNER เท่านั้นที่เปลี่ยนได้</p>
+        )}
+
+        <div className="flex items-start gap-2 rounded-md bg-muted p-3">
+          <Info className="w-4 h-4 mt-0.5 text-muted-foreground shrink-0" />
+          <p className="text-xs text-muted-foreground">
+            เมื่อเปิด — เอกสารทุกฉบับต้องผ่านผู้อนุมัติก่อน POST (segregation of duties)
+          </p>
+        </div>
+
+        <MakerCheckerConfirmDialog
+          open={showConfirm}
+          nextValue={pendingNext}
+          pendingReadyCount={pendingCountQuery.data ?? 0}
+          onConfirm={() => {
+            mutation.mutate(pendingNext!);
+            setShowConfirm(false);
+            setPendingNext(null);
+          }}
+          onCancel={() => {
+            setShowConfirm(false);
+            setPendingNext(null);
+          }}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/components/__tests__/MakerCheckerConfirmDialog.test.tsx
+++ b/apps/web/src/pages/SettingsPage/components/__tests__/MakerCheckerConfirmDialog.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MakerCheckerConfirmDialog } from '../MakerCheckerConfirmDialog';
+
+describe('MakerCheckerConfirmDialog', () => {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+
+  beforeEach(() => {
+    onConfirm.mockClear();
+    onCancel.mockClear();
+  });
+
+  it('does not render when open=false', () => {
+    render(
+      <MakerCheckerConfirmDialog
+        open={false}
+        nextValue={true}
+        pendingReadyCount={0}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    expect(screen.queryByText(/Maker-Checker/)).not.toBeInTheDocument();
+  });
+
+  it('OFF→ON: shows enable impacts + requires ack', () => {
+    render(
+      <MakerCheckerConfirmDialog
+        open={true}
+        nextValue={true}
+        pendingReadyCount={0}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    expect(screen.getByText(/เปิดระบบ Maker-Checker/)).toBeInTheDocument();
+    expect(screen.getByText(/ต้องผ่านผู้อนุมัติ/)).toBeInTheDocument();
+    const confirmBtn = screen.getByRole('button', { name: /ยืนยันเปิด/ });
+    expect(confirmBtn).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('ON→OFF: shows disable impacts + pending count + requires ack', () => {
+    render(
+      <MakerCheckerConfirmDialog
+        open={true}
+        nextValue={false}
+        pendingReadyCount={3}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    expect(screen.getByText(/ปิดระบบ Maker-Checker/)).toBeInTheDocument();
+    expect(screen.getByText(/auto-approve/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 ฉบับ/)).toBeInTheDocument();
+    const confirmBtn = screen.getByRole('button', { name: /ยืนยันปิด/ });
+    expect(confirmBtn).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('calls onConfirm when confirm clicked', () => {
+    render(
+      <MakerCheckerConfirmDialog
+        open={true}
+        nextValue={true}
+        pendingReadyCount={0}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /ยืนยันเปิด/ }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel clicked', () => {
+    render(
+      <MakerCheckerConfirmDialog
+        open={true}
+        nextValue={true}
+        pendingReadyCount={0}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /ยกเลิก/ }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets acknowledgement on close', () => {
+    const { rerender } = render(
+      <MakerCheckerConfirmDialog
+        open={true}
+        nextValue={true}
+        pendingReadyCount={0}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    rerender(
+      <MakerCheckerConfirmDialog
+        open={false}
+        nextValue={true}
+        pendingReadyCount={0}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    rerender(
+      <MakerCheckerConfirmDialog
+        open={true}
+        nextValue={true}
+        pendingReadyCount={0}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+    expect(screen.getByRole('button', { name: /ยืนยัน/ })).toBeDisabled();
+  });
+});

--- a/apps/web/src/pages/SettingsPage/index.tsx
+++ b/apps/web/src/pages/SettingsPage/index.tsx
@@ -10,6 +10,7 @@ import CompanySettings from './components/CompanySettings';
 import GeneralSettings from './components/GeneralSettings';
 import CollectionsConfigCard from './components/CollectionsConfigCard';
 import StickerSettings from './components/StickerSettings';
+import { MakerCheckerToggle } from './components/MakerCheckerToggle';
 import type { ConfigItem } from './components/shared';
 
 export default function SettingsPage() {
@@ -81,6 +82,8 @@ export default function SettingsPage() {
   return (
     <div>
       <PageHeader title="ตั้งค่าระบบ" subtitle="กำหนดพารามิเตอร์การทำงานของระบบ" />
+
+      <MakerCheckerToggle />
 
       <QueryBoundary
         isLoading={isLoading}

--- a/apps/web/src/pages/SettingsPage/index.tsx
+++ b/apps/web/src/pages/SettingsPage/index.tsx
@@ -1,163 +1,66 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { Navigate } from 'react-router';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import api, { getErrorMessage } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
 import PageHeader from '@/components/ui/PageHeader';
-import QueryBoundary from '@/components/QueryBoundary';
-import SystemSettings from './components/SystemSettings';
-import CompanySettings from './components/CompanySettings';
-import GeneralSettings from './components/GeneralSettings';
-import CollectionsConfigCard from './components/CollectionsConfigCard';
-import StickerSettings from './components/StickerSettings';
-import { MakerCheckerToggle } from './components/MakerCheckerToggle';
-import type { ConfigItem } from './components/shared';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { CompanyTab } from './tabs/CompanyTab';
+import { VatTab } from './tabs/VatTab';
+import { PeriodsTab } from './tabs/PeriodsTab';
+import { AttachmentTab } from './tabs/AttachmentTab';
+import { UsersTab } from './tabs/UsersTab';
+
+const TAB_IDS = ['company', 'vat', 'periods', 'attachment', 'users'] as const;
+type TabId = typeof TAB_IDS[number];
+
+function readHash(): TabId {
+  const h = (typeof window !== 'undefined' ? window.location.hash.slice(1) : '') as TabId;
+  return TAB_IDS.includes(h) ? h : 'company';
+}
 
 export default function SettingsPage() {
-  useDocumentTitle('ตั้งค่า');
-  const queryClient = useQueryClient();
-  const [values, setValues] = useState<Record<string, string>>({});
-  const [editingSection, setEditingSection] = useState<string | null>(null);
+  useDocumentTitle('ตั้งค่าระบบ');
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<TabId>(readHash());
 
-  const [draftSignatureImage, setDraftSignatureImage] = useState('');
-  const [draftSignerName, setDraftSignerName] = useState('');
+  // Permission guard — Sprint 2 placed MakerCheckerToggle on this page, so user.role === OWNER assumed for full access
+  if (user && user.role !== 'OWNER') {
+    return <Navigate to="/" replace />;
+  }
 
-  const { data: configs = [], isLoading, isError, error, refetch } = useQuery<ConfigItem[]>({
-    queryKey: ['settings'],
-    queryFn: async () => (await api.get('/settings')).data,
-  });
-
+  // Sync URL hash <-> activeTab
   useEffect(() => {
-    if (configs.length > 0 && !editingSection) {
-      const map: Record<string, string> = {};
-      configs.forEach((c) => {
-        map[c.key] = c.value;
-      });
-      setValues(map);
+    if (window.location.hash.slice(1) !== activeTab) {
+      window.history.replaceState(null, '', `#${activeTab}`);
     }
-  }, [configs]);
+  }, [activeTab]);
 
-  const saveMutation = useMutation({
-    mutationFn: async (items: { key: string; value: string }[]) =>
-      api.patch('/settings', { items }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] });
-      toast.success('บันทึกสำเร็จ');
-      setEditingSection(null);
-    },
-    onError: (err: unknown) => toast.error(getErrorMessage(err)),
-  });
-
-  const handleEdit = (sectionKey: string) => {
-    if (editingSection && editingSection !== sectionKey) {
-      toast.error('กรุณาบันทึกหรือยกเลิกการแก้ไขก่อน');
-      return;
-    }
-    setEditingSection(sectionKey);
-    if (sectionKey === 'company') {
-      setDraftSignatureImage(values['lessor_signature_image'] || '');
-      setDraftSignerName(values['lessor_signer_name'] || '');
-    }
-  };
-
-  const handleCancel = () => setEditingSection(null);
-
-  const handleSave = (items: { key: string; value: string }[]) => {
-    let finalItems = items;
-    if (editingSection === 'company') {
-      finalItems = [
-        ...items,
-        { key: 'lessor_signature_image', value: draftSignatureImage },
-        { key: 'lessor_signer_name', value: draftSignerName },
-      ];
-    }
-    saveMutation.mutate(finalItems);
-    const updated = { ...values };
-    finalItems.forEach(({ key, value }) => {
-      updated[key] = value;
-    });
-    setValues(updated);
-  };
+  // React to back/forward
+  useEffect(() => {
+    const handler = () => setActiveTab(readHash());
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
+  }, []);
 
   return (
     <div>
       <PageHeader title="ตั้งค่าระบบ" subtitle="กำหนดพารามิเตอร์การทำงานของระบบ" />
 
-      <MakerCheckerToggle />
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabId)}>
+        <TabsList className="grid grid-cols-2 md:grid-cols-5 mb-4">
+          <TabsTrigger value="company">บริษัท</TabsTrigger>
+          <TabsTrigger value="vat">VAT</TabsTrigger>
+          <TabsTrigger value="periods">งวดบัญชี</TabsTrigger>
+          <TabsTrigger value="attachment">เอกสารแนบ</TabsTrigger>
+          <TabsTrigger value="users">ผู้ใช้งาน</TabsTrigger>
+        </TabsList>
 
-      <QueryBoundary
-        isLoading={isLoading}
-        isError={isError}
-        error={error}
-        onRetry={refetch}
-        errorTitle="ไม่สามารถโหลดการตั้งค่าระบบได้"
-      >
-      <div className="flex flex-col gap-5 lg:gap-7.5">
-        <SystemSettings />
-
-        {/* penalty + pdpa (match original configGroups order: penalty → pdpa → company → banking → payment_link) */}
-        <GeneralSettings
-          slot="pre"
-          values={values}
-          editingSection={editingSection}
-          onEdit={handleEdit}
-          onSave={handleSave}
-          onCancel={handleCancel}
-          isSaving={saveMutation.isPending}
-        />
-
-        <CompanySettings
-          values={values}
-          editingSection={editingSection}
-          onEdit={handleEdit}
-          onSave={handleSave}
-          onCancel={handleCancel}
-          isSaving={saveMutation.isPending}
-          draftSignatureImage={draftSignatureImage}
-          draftSignerName={draftSignerName}
-          setDraftSignatureImage={setDraftSignatureImage}
-          setDraftSignerName={setDraftSignerName}
-        />
-
-        {/* banking + payment_link */}
-        <GeneralSettings
-          slot="post"
-          values={values}
-          editingSection={editingSection}
-          onEdit={handleEdit}
-          onSave={handleSave}
-          onCancel={handleCancel}
-          isSaving={saveMutation.isPending}
-        />
-
-        {/* Sticker defaults — OWNER only */}
-        <StickerSettings
-          values={values}
-          editingSection={editingSection}
-          onEdit={handleEdit}
-          onSave={handleSave}
-          onCancel={handleCancel}
-          isSaving={saveMutation.isPending}
-        />
-
-        {/* Collections — Phase 2 tuning knobs (auto-assign + pool + session) */}
-        <CollectionsConfigCard />
-
-        {/* Payment method × cash account mapping — settings page link */}
-        <a
-          href="/settings/payment-methods"
-          className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card p-4 hover:bg-accent transition-colors"
-        >
-          <div>
-            <div className="text-base font-semibold leading-snug">ช่องทางรับชำระ × บัญชี</div>
-            <div className="text-sm text-muted-foreground leading-snug mt-0.5">
-              ตั้งค่าว่าช่องทาง CASH / TRANSFER / QR ใช้บัญชีไหนได้บ้าง · เลือก default ของแต่ละช่องทาง
-            </div>
-          </div>
-          <span className="text-sm text-muted-foreground">→</span>
-        </a>
-      </div>
-      </QueryBoundary>
+        <TabsContent value="company"><CompanyTab /></TabsContent>
+        <TabsContent value="vat"><VatTab /></TabsContent>
+        <TabsContent value="periods"><PeriodsTab /></TabsContent>
+        <TabsContent value="attachment"><AttachmentTab /></TabsContent>
+        <TabsContent value="users"><UsersTab /></TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/apps/web/src/pages/SettingsPage/tabs/AttachmentTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/AttachmentTab.tsx
@@ -1,0 +1,87 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ConfigItem } from '../components/shared';
+
+export function AttachmentTab() {
+  const queryClient = useQueryClient();
+  const [threshold, setThreshold] = useState('0');
+  const [allowedTypes, setAllowedTypes] = useState('PDF, JPG, PNG');
+  const [editing, setEditing] = useState(false);
+
+  const { data: configs = [], isLoading } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length === 0 || editing) return;
+    setThreshold(configs.find((c) => c.key === 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT')?.value ?? '0');
+    setAllowedTypes(configs.find((c) => c.key === 'ATTACHMENT_ALLOWED_TYPES')?.value ?? 'PDF, JPG, PNG');
+  }, [configs, editing]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () =>
+      api.patch('/settings', {
+        items: [
+          { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', value: threshold },
+          { key: 'ATTACHMENT_ALLOWED_TYPES', value: allowedTypes },
+        ],
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกการตั้งค่าเอกสารแนบสำเร็จ');
+      setEditing(false);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">กำลังโหลด...</p>;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>เอกสารแนบ</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="att-threshold">ยอดที่ต้องบังคับแนบเอกสาร (บาท)</Label>
+          <Input
+            id="att-threshold"
+            type="number"
+            step="0.01"
+            min="0"
+            value={threshold}
+            onChange={(e) => { setThreshold(e.target.value); setEditing(true); }}
+            disabled={saveMutation.isPending}
+          />
+          <p className="text-xs text-muted-foreground">0 = ไม่บังคับแนบ. มากกว่า 0 = บังคับแนบเมื่อยอดเอกสารเกินค่านี้</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="att-types">ประเภทไฟล์ที่อนุญาต</Label>
+          <Input
+            id="att-types"
+            value={allowedTypes}
+            onChange={(e) => { setAllowedTypes(e.target.value); setEditing(true); }}
+            placeholder="PDF, JPG, PNG"
+            disabled={saveMutation.isPending}
+          />
+          <p className="text-xs text-muted-foreground">คั่นด้วยจุลภาค (,) เช่น "PDF, JPG, PNG"</p>
+        </div>
+
+        {editing && (
+          <div className="flex gap-2">
+            <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>บันทึก</Button>
+            <Button variant="outline" onClick={() => setEditing(false)} disabled={saveMutation.isPending}>ยกเลิก</Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/tabs/CompanyTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/CompanyTab.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import CompanySettings from '../components/CompanySettings';
+import type { ConfigItem } from '../components/shared';
+
+export function CompanyTab() {
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [editingSection, setEditingSection] = useState<string | null>(null);
+  const [draftSignatureImage, setDraftSignatureImage] = useState('');
+  const [draftSignerName, setDraftSignerName] = useState('');
+
+  const { data: configs = [] } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length > 0 && !editingSection) {
+      const map: Record<string, string> = {};
+      configs.forEach((c) => { map[c.key] = c.value; });
+      setValues(map);
+    }
+  }, [configs, editingSection]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (items: { key: string; value: string }[]) => api.patch('/settings', { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกสำเร็จ');
+      setEditingSection(null);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const handleSave = (items: { key: string; value: string }[]) => {
+    const finalItems = [
+      ...items,
+      { key: 'lessor_signature_image', value: draftSignatureImage },
+      { key: 'lessor_signer_name', value: draftSignerName },
+    ];
+    saveMutation.mutate(finalItems);
+  };
+
+  const handleEdit = (sectionKey: string) => {
+    setEditingSection(sectionKey);
+    setDraftSignatureImage(values['lessor_signature_image'] || '');
+    setDraftSignerName(values['lessor_signer_name'] || '');
+  };
+
+  return (
+    <CompanySettings
+      values={values}
+      editingSection={editingSection}
+      onEdit={handleEdit}
+      onSave={handleSave}
+      onCancel={() => setEditingSection(null)}
+      isSaving={saveMutation.isPending}
+      draftSignatureImage={draftSignatureImage}
+      draftSignerName={draftSignerName}
+      setDraftSignatureImage={setDraftSignatureImage}
+      setDraftSignerName={setDraftSignerName}
+    />
+  );
+}

--- a/apps/web/src/pages/SettingsPage/tabs/PeriodsTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/PeriodsTab.tsx
@@ -1,0 +1,5 @@
+import PeriodClosePage from '@/pages/accounting/PeriodClosePage';
+
+export function PeriodsTab() {
+  return <PeriodClosePage />;
+}

--- a/apps/web/src/pages/SettingsPage/tabs/UsersTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/UsersTab.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router';
+import { MakerCheckerToggle } from '../components/MakerCheckerToggle';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Users } from 'lucide-react';
+
+export function UsersTab() {
+  return (
+    <div className="space-y-4">
+      <MakerCheckerToggle />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>จัดการผู้ใช้งาน</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground mb-3">
+            จัดการบัญชีผู้ใช้งาน บทบาท และสิทธิ์การเข้าถึง
+          </p>
+          <Button asChild variant="outline">
+            <Link to="/users" className="inline-flex items-center gap-2">
+              <Users size={16} />
+              ไปยังหน้าผู้ใช้งาน
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/tabs/VatTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/VatTab.tsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ConfigItem } from '../components/shared';
+
+type PriceType = 'exclusive' | 'inclusive';
+
+export function VatTab() {
+  const queryClient = useQueryClient();
+  const [rate, setRate] = useState('7');
+  const [priceType, setPriceType] = useState<PriceType>('exclusive');
+  const [editing, setEditing] = useState(false);
+
+  const { data: configs = [], isLoading } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length === 0 || editing) return;
+    const r = configs.find((c) => c.key === 'VAT_RATE')?.value ?? '7';
+    const p = (configs.find((c) => c.key === 'VAT_PRICE_TYPE_DEFAULT')?.value ?? 'exclusive') as PriceType;
+    setRate(r);
+    setPriceType(p);
+  }, [configs, editing]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const items = [
+        { key: 'VAT_RATE', value: rate },
+        { key: 'VAT_PRICE_TYPE_DEFAULT', value: priceType },
+      ];
+      return api.patch('/settings', { items });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึก VAT สำเร็จ');
+      setEditing(false);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">กำลังโหลด...</p>;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>VAT (ภ.พ.30)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="vat-rate">อัตรา VAT (%)</Label>
+          <Input
+            id="vat-rate"
+            type="number"
+            step="0.01"
+            min="0"
+            max="100"
+            value={rate}
+            onChange={(e) => { setRate(e.target.value); setEditing(true); }}
+            disabled={saveMutation.isPending}
+          />
+        </div>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">ประเภทราคาเริ่มต้น</legend>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="priceType"
+              value="exclusive"
+              checked={priceType === 'exclusive'}
+              onChange={() => { setPriceType('exclusive'); setEditing(true); }}
+              disabled={saveMutation.isPending}
+            />
+            <span>ราคา ไม่รวม VAT (exclusive)</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="priceType"
+              value="inclusive"
+              checked={priceType === 'inclusive'}
+              onChange={() => { setPriceType('inclusive'); setEditing(true); }}
+              disabled={saveMutation.isPending}
+            />
+            <span>ราคา รวม VAT แล้ว (inclusive)</span>
+          </label>
+        </fieldset>
+
+        {editing && (
+          <div className="flex gap-2">
+            <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>บันทึก</Button>
+            <Button variant="outline" onClick={() => setEditing(false)} disabled={saveMutation.isPending}>ยกเลิก</Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/accounting/PeriodClosePage.tsx
+++ b/apps/web/src/pages/accounting/PeriodClosePage.tsx
@@ -106,6 +106,7 @@ export default function PeriodClosePage() {
     onSuccess: () => {
       toast.success('ปิดงวดเรียบร้อย');
       qc.invalidateQueries({ queryKey: ['accounting-periods', companyId, year] });
+      qc.invalidateQueries({ queryKey: ['accounting-periods', 'reopened'] }); // banner refresh
     },
     onError: (e: unknown) => {
       const msg =

--- a/apps/web/src/pages/accounting/PeriodClosePage.tsx
+++ b/apps/web/src/pages/accounting/PeriodClosePage.tsx
@@ -7,6 +7,7 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useAuth } from '@/contexts/AuthContext';
 import { formatThaiDate } from '@/lib/date';
+import { ReopenPeriodModal } from './components/ReopenPeriodModal';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -72,10 +73,8 @@ export default function PeriodClosePage() {
   // Confirm close dialog state
   const [confirmingClose, setConfirmingClose] = useState<number | null>(null);
 
-  // Reopen dialog state
-  const [reopenMonth, setReopenMonth] = useState<number | null>(null);
-  const [boardResolutionId, setBoardResolutionId] = useState('');
-  const [reopenReason, setReopenReason] = useState('');
+  // Reopen dialog state — modal captures reasonType + reason + taxFiled
+  const [reopenTarget, setReopenTarget] = useState<{ companyId: string; year: number; month: number } | null>(null);
 
   // Load companies and auto-select FINANCE
   const companiesQuery = useQuery<Company[]>({
@@ -115,24 +114,28 @@ export default function PeriodClosePage() {
     },
   });
 
+  type ReopenDto = {
+    companyId: string;
+    year: number;
+    month: number;
+    reasonType: 'WRONG_ENTRY' | 'MISSED_RECORD' | 'AUDITOR_REQUEST' | 'OTHER';
+    reason: string;
+    taxFiled: boolean;
+    boardResolutionId?: string;
+  };
+
   const reopenMutation = useMutation({
-    mutationFn: ({ month, resolutionId, reason }: { month: number; resolutionId: string; reason: string }) =>
-      api
-        .post('/expenses/periods/reopen', {
-          companyId,
-          year,
-          month,
-          boardResolutionId: resolutionId,
-          reason,
-        })
-        .then((r) => r.data),
+    mutationFn: (dto: ReopenDto) =>
+      api.post('/expenses/periods/reopen', dto).then((r) => r.data),
     onSuccess: () => {
       toast.success('เปิดงวดเรียบร้อย');
       qc.invalidateQueries({ queryKey: ['accounting-periods', companyId, year] });
+      qc.invalidateQueries({ queryKey: ['accounting-periods', 'reopened'] });
+      setReopenTarget(null);
     },
     onError: (e: unknown) => {
       const msg =
-        e instanceof Error ? e.message : 'เปิดงวดไม่สำเร็จ';
+        (e as any)?.response?.data?.message ?? (e instanceof Error ? e.message : 'เปิดงวดไม่สำเร็จ');
       toast.error(msg);
     },
   });
@@ -256,11 +259,7 @@ export default function PeriodClosePage() {
                           <button
                             type="button"
                             disabled={isActing}
-                            onClick={() => {
-                              setReopenMonth(p.month);
-                              setBoardResolutionId('');
-                              setReopenReason('');
-                            }}
+                            onClick={() => setReopenTarget({ companyId: p.companyId, year: p.year, month: p.month })}
                             className="inline-flex items-center gap-1 px-3 py-1.5 text-xs border border-border rounded-md hover:bg-accent disabled:opacity-50"
                           >
                             <Unlock size={12} /> เปิดงวด
@@ -306,73 +305,20 @@ export default function PeriodClosePage() {
         }}
       />
 
-      {/* Reopen period dialog — requires boardResolutionId + reason */}
-      {reopenMonth !== null && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card rounded-xl border shadow-lg p-6 w-full max-w-md mx-4 space-y-4">
-            <h3 className="font-bold text-base leading-snug">
-              เปิดงวด {THAI_MONTHS[reopenMonth - 1]} {year + 543} ใหม่
-            </h3>
-            <p className="text-sm text-muted-foreground leading-snug">
-              กรุณากรอกข้อมูลเพื่อบันทึกเหตุผลการเปิดงวดย้อนหลัง (audit trail)
-            </p>
-            <div className="space-y-3">
-              <div>
-                <label className="text-xs font-medium text-muted-foreground block mb-1">
-                  เลขที่มติกรรมการ (Board Resolution ID) <span className="text-destructive">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={boardResolutionId}
-                  onChange={(e) => setBoardResolutionId(e.target.value)}
-                  placeholder="เช่น BRD-2569-001"
-                  className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background"
-                />
-              </div>
-              <div>
-                <label className="text-xs font-medium text-muted-foreground block mb-1">
-                  เหตุผล <span className="text-destructive">*</span> (อย่างน้อย 10 ตัวอักษร)
-                </label>
-                <textarea
-                  value={reopenReason}
-                  onChange={(e) => setReopenReason(e.target.value)}
-                  placeholder="ระบุเหตุผลการเปิดงวดย้อนหลัง..."
-                  rows={3}
-                  className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background resize-none"
-                />
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                type="button"
-                onClick={() => setReopenMonth(null)}
-                className="px-4 py-2 text-sm border border-border rounded-md hover:bg-accent"
-              >
-                ยกเลิก
-              </button>
-              <button
-                type="button"
-                disabled={
-                  reopenMutation.isPending ||
-                  boardResolutionId.trim().length === 0 ||
-                  reopenReason.trim().length < 10
-                }
-                onClick={() => {
-                  reopenMutation.mutate({
-                    month: reopenMonth,
-                    resolutionId: boardResolutionId.trim(),
-                    reason: reopenReason.trim(),
-                  });
-                  setReopenMonth(null);
-                }}
-                className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {reopenMutation.isPending ? 'กำลังดำเนินการ...' : 'เปิดงวด'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* Reopen period modal — structured reason taxonomy */}
+      <ReopenPeriodModal
+        open={reopenTarget !== null}
+        period={
+          reopenTarget
+            ? `${THAI_MONTHS[reopenTarget.month - 1]} ${reopenTarget.year + 543}`
+            : ''
+        }
+        onConfirm={(payload) => {
+          if (!reopenTarget) return;
+          reopenMutation.mutate({ ...reopenTarget, ...payload });
+        }}
+        onCancel={() => setReopenTarget(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/accounting/components/ReopenPeriodModal.tsx
+++ b/apps/web/src/pages/accounting/components/ReopenPeriodModal.tsx
@@ -1,0 +1,117 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { AlertTriangle } from 'lucide-react';
+
+type ReasonType = 'WRONG_ENTRY' | 'MISSED_RECORD' | 'AUDITOR_REQUEST' | 'OTHER';
+
+type Props = {
+  open: boolean;
+  period: string;
+  onConfirm: (payload: { reasonType: ReasonType; reason: string; taxFiled: boolean }) => void;
+  onCancel: () => void;
+};
+
+const REASON_OPTIONS: Array<{ value: ReasonType; label: string }> = [
+  { value: 'WRONG_ENTRY', label: 'พบเอกสารผิดต้อง reverse' },
+  { value: 'MISSED_RECORD', label: 'ลืมบันทึกรายการสำคัญ' },
+  { value: 'AUDITOR_REQUEST', label: 'แก้ไขตามคำขอ auditor' },
+  { value: 'OTHER', label: 'อื่นๆ (ระบุในบันทึก)' },
+];
+
+export function ReopenPeriodModal({ open, period, onConfirm, onCancel }: Props) {
+  const [reasonType, setReasonType] = useState<ReasonType | null>(null);
+  const [reason, setReason] = useState('');
+  const [taxFiled, setTaxFiled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setReasonType(null);
+      setReason('');
+      setTaxFiled(null);
+    }
+  }, [open]);
+
+  const canSubmit = reasonType !== null && reason.trim().length >= 10 && taxFiled !== null;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onConfirm({ reasonType: reasonType!, reason: reason.trim(), taxFiled: taxFiled! });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-warning">
+            <AlertTriangle className="w-5 h-5" />
+            คุณกำลังเปิดงวด {period} ที่ปิดไปแล้ว
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 text-sm">
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">เหตุผล (บังคับ):</legend>
+            {REASON_OPTIONS.map((opt) => (
+              <label key={opt.value} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="reasonType"
+                  value={opt.value}
+                  checked={reasonType === opt.value}
+                  onChange={() => setReasonType(opt.value)}
+                />
+                <span>{opt.label}</span>
+              </label>
+            ))}
+          </fieldset>
+
+          <div>
+            <label htmlFor="reopen-reason-note" className="block font-semibold mb-1">
+              บันทึกรายละเอียด (≥ 10 ตัวอักษร):
+            </label>
+            <Textarea
+              id="reopen-reason-note"
+              rows={3}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="ระบุเอกสารหรือเหตุการณ์ที่ต้องการแก้ไข"
+            />
+          </div>
+
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">ภ.พ.30 งวดนี้ยื่นแล้วใช่ไหม?</legend>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="taxFiled"
+                checked={taxFiled === true}
+                onChange={() => setTaxFiled(true)}
+              />
+              <span>ใช่ — ต้องยื่นแก้ไขด้วย</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="taxFiled"
+                checked={taxFiled === false}
+                onChange={() => setTaxFiled(false)}
+              />
+              <span>ยังไม่ได้ยื่น</span>
+            </label>
+          </fieldset>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            ยกเลิก
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            ยืนยันเปิดงวด
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/accounting/components/__tests__/ReopenPeriodModal.test.tsx
+++ b/apps/web/src/pages/accounting/components/__tests__/ReopenPeriodModal.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReopenPeriodModal } from '../ReopenPeriodModal';
+
+describe('ReopenPeriodModal', () => {
+  const props = (overrides = {}) => ({
+    open: true,
+    period: '2026-04',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when open=false', () => {
+    render(<ReopenPeriodModal {...props({ open: false })} />);
+    expect(screen.queryByText(/2026-04/)).not.toBeInTheDocument();
+  });
+
+  it('shows period in title', () => {
+    render(<ReopenPeriodModal {...props()} />);
+    expect(screen.getByText(/2026-04/)).toBeInTheDocument();
+  });
+
+  it('confirm button disabled until reasonType + reason + taxFiled all set', () => {
+    render(<ReopenPeriodModal {...props()} />);
+    const confirmBtn = screen.getByRole('button', { name: /ยืนยันเปิดงวด/ });
+    expect(confirmBtn).toBeDisabled();
+
+    // pick a reason
+    fireEvent.click(screen.getByLabelText(/พบเอกสารผิด/));
+    expect(confirmBtn).toBeDisabled(); // still need note + taxFiled
+
+    // type note (>= 10 chars)
+    fireEvent.change(screen.getByLabelText(/บันทึกรายละเอียด/), { target: { value: 'รายละเอียดเพิ่มเติม' } });
+    expect(confirmBtn).toBeDisabled(); // still need taxFiled
+
+    // pick taxFiled
+    fireEvent.click(screen.getByLabelText(/ยังไม่ได้ยื่น/));
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('calls onConfirm with payload when submitted', () => {
+    const onConfirm = vi.fn();
+    render(<ReopenPeriodModal {...props({ onConfirm })} />);
+    fireEvent.click(screen.getByLabelText(/พบเอกสารผิด/));
+    fireEvent.change(screen.getByLabelText(/บันทึกรายละเอียด/), { target: { value: 'เอกสาร OI-26040015 ระบุลูกค้าผิด' } });
+    fireEvent.click(screen.getByLabelText(/ยังไม่ได้ยื่น/));
+    fireEvent.click(screen.getByRole('button', { name: /ยืนยันเปิดงวด/ }));
+    expect(onConfirm).toHaveBeenCalledWith({
+      reasonType: 'WRONG_ENTRY',
+      reason: 'เอกสาร OI-26040015 ระบุลูกค้าผิด',
+      taxFiled: false,
+    });
+  });
+
+  it('cancel resets form', () => {
+    const onCancel = vi.fn();
+    render(<ReopenPeriodModal {...props({ onCancel })} />);
+    fireEvent.click(screen.getByLabelText(/พบเอกสารผิด/));
+    fireEvent.click(screen.getByRole('button', { name: /ยกเลิก/ }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -942,8 +942,8 @@ export default function OtherIncomeEntryPage() {
                 // Snapshot the current auto-generated JE lines as the editable baseline
                 const snapshot: EditableJournalLine[] = jeLines.map((l) => ({
                   accountCode: l.accountCode,
-                  debit: Number(l.debit),
-                  credit: Number(l.credit),
+                  debit: Number(Number(l.debit).toFixed(2)),
+                  credit: Number(Number(l.credit).toFixed(2)),
                   description: l.description ?? '',
                 }));
                 setOverrideLines(snapshot);

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -31,6 +31,9 @@ import { AdjustmentTable } from './components/AdjustmentTable';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { CounterpartyPicker } from './components/CounterpartyPicker';
 import { TemplatePickerCombobox } from './components/TemplatePickerCombobox';
+import { OverrideConfirmDialog } from './components/OverrideConfirmDialog';
+import { EditableJournalTable, getJournalIssues } from './components/EditableJournalTable';
+import type { EditableJournalLine } from './components/EditableJournalTable';
 
 // Fallback while config is loading; live value comes from /other-income/config/attachment-threshold
 const ATTACHMENT_THRESHOLD_FALLBACK = 50_000;
@@ -322,6 +325,11 @@ export default function OtherIncomeEntryPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Override JV state — declared before saveAndPostMutation which captures these in closure
+  const [overrideMode, setOverrideMode] = useState(false);
+  const [showOverrideDialog, setShowOverrideDialog] = useState(false);
+  const [overrideLines, setOverrideLines] = useState<EditableJournalLine[]>([]);
+
   const saveDraftMutation = useMutation({
     mutationFn: (data: OtherIncomeFormValues) =>
       isEdit ? otherIncomeApi.update(id!, data) : otherIncomeApi.create(data),
@@ -342,14 +350,33 @@ export default function OtherIncomeEntryPage() {
       } else {
         await otherIncomeApi.update(docId, data);
       }
-      return otherIncomeApi.post(docId);
+      return otherIncomeApi.post(
+        docId,
+        overrideMode && overrideLines.length > 0
+          ? {
+              lines: overrideLines.map((l) => ({
+                accountCode: l.accountCode,
+                debit: l.debit,
+                credit: l.credit,
+                description: l.description,
+              })),
+            }
+          : undefined,
+      );
     },
     onSuccess: (doc) => {
       toast.success('บันทึกและ POST เอกสารแล้ว');
       queryClient.invalidateQueries({ queryKey: ['other-income'] });
       navigate(`/other-income/${doc.id}`);
     },
-    onError: () => toast.error('ไม่สามารถ POST เอกสารได้'),
+    onError: (err: any) => {
+      const apiErrors = err?.response?.data?.errors;
+      if (Array.isArray(apiErrors)) {
+        apiErrors.forEach((e: any) => toast.error(`${e.rule}: ${e.msg}`));
+      } else {
+        toast.error(err?.response?.data?.message ?? 'ไม่สามารถ POST เอกสารได้');
+      }
+    },
   });
 
   const flagQuery = useQuery({
@@ -430,6 +457,12 @@ export default function OtherIncomeEntryPage() {
     saveDraftMutation.isPending ||
     saveAndPostMutation.isPending ||
     saveAndRequestApprovalMutation.isPending;
+
+  // Live V1/V2/V5 validation for override lines
+  const journalIssues = useMemo(
+    () => (overrideMode ? getJournalIssues(overrideLines) : []),
+    [overrideMode, overrideLines],
+  );
 
   // Income totals across all items (for footer/summary cards)
   const incomeTotals = useMemo(() => {
@@ -538,7 +571,7 @@ export default function OtherIncomeEntryPage() {
   const docNumber = loadQuery.data?.docNumber;
   const docStatus = loadQuery.data?.status ?? 'DRAFT';
   const errorCount = validationMessages.length;
-  const canPost = errorCount === 0 && !needsAttachment;
+  const canPost = errorCount === 0 && !needsAttachment && journalIssues.length === 0;
   const userDisplayName = user?.name || user?.email || 'ผู้ใช้ปัจจุบัน';
 
   return (
@@ -876,25 +909,64 @@ export default function OtherIncomeEntryPage() {
             </section>
           )}
 
-          {/* Section 6 — Auto Journal Preview */}
+          {/* Section 6 — Auto Journal Preview / Override */}
           <section className="rounded-xl border bg-card p-5">
             <SectionHeader
               num={6}
-              title="AUTO JOURNAL PREVIEW"
+              title={overrideMode ? 'JOURNAL LINES (OVERRIDE)' : 'AUTO JOURNAL PREVIEW'}
               action={
-                <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground cursor-not-allowed opacity-60">
-                  <input type="checkbox" disabled className="size-3.5" />
-                  แก้ไขเอง (Override)
+                <label className="inline-flex items-center gap-1.5 text-xs cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={overrideMode}
+                    className="size-3.5"
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setShowOverrideDialog(true);
+                      } else {
+                        setOverrideMode(false);
+                        setOverrideLines([]);
+                      }
+                    }}
+                  />
+                  <span className={overrideMode ? 'text-warning font-semibold' : 'text-muted-foreground'}>
+                    ใช้เอง (Override)
+                  </span>
                 </label>
               }
             />
-            <AutoJournalPreview lines={jeLines} />
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
-              <SummaryTile label="รายได้" value={incomeTotals.beforeVat} tone="primary" />
-              <SummaryTile label="VAT" value={incomeTotals.vat} tone="info" />
-              <SummaryTile label="WHT" value={incomeTotals.wht} tone="warning" />
-              <SummaryTile label="สุทธิรับ" value={incomeTotals.net} tone="success" />
-            </div>
+
+            <OverrideConfirmDialog
+              open={showOverrideDialog}
+              onConfirm={() => {
+                // Snapshot the current auto-generated JE lines as the editable baseline
+                const snapshot: EditableJournalLine[] = jeLines.map((l) => ({
+                  accountCode: l.accountCode,
+                  debit: Number(l.debit),
+                  credit: Number(l.credit),
+                  description: l.description ?? '',
+                }));
+                setOverrideLines(snapshot);
+                setOverrideMode(true);
+                setShowOverrideDialog(false);
+              }}
+              onCancel={() => setShowOverrideDialog(false)}
+            />
+
+            {overrideMode ? (
+              <EditableJournalTable lines={overrideLines} onChange={setOverrideLines} />
+            ) : (
+              <AutoJournalPreview lines={jeLines} />
+            )}
+
+            {!overrideMode && (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
+                <SummaryTile label="รายได้" value={incomeTotals.beforeVat} tone="primary" />
+                <SummaryTile label="VAT" value={incomeTotals.vat} tone="info" />
+                <SummaryTile label="WHT" value={incomeTotals.wht} tone="warning" />
+                <SummaryTile label="สุทธิรับ" value={incomeTotals.net} tone="success" />
+              </div>
+            )}
           </section>
 
           {/* Section 7 — Recorder & Approver */}

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -343,7 +343,7 @@ export default function OtherIncomeListPage() {
                         <span className="flex items-center gap-1">
                           {doc.isOverridden && (
                             <span
-                              className="text-amber-500"
+                              className="text-warning"
                               title="POST ด้วย Override JV — ตรวจ audit log"
                               aria-label="Override JV"
                             >

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -340,7 +340,18 @@ export default function OtherIncomeListPage() {
                       onClick={() => navigate(`/other-income/${doc.id}`)}
                     >
                       <td className="px-4 py-3 font-mono font-semibold text-primary">
-                        {doc.docNumber}
+                        <span className="flex items-center gap-1">
+                          {doc.isOverridden && (
+                            <span
+                              className="text-amber-500"
+                              title="POST ด้วย Override JV — ตรวจ audit log"
+                              aria-label="Override JV"
+                            >
+                              ✏
+                            </span>
+                          )}
+                          {doc.docNumber}
+                        </span>
                       </td>
                       <td className="px-4 py-3 text-muted-foreground">
                         {fmtDate(doc.issueDate)}

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -8,6 +8,8 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { AccountingModuleTabBar } from '@/components/accounting/AccountingModuleTabBar';
 import { useDebounce } from '@/hooks/useDebounce';
+import { usePaginationParams } from '@/hooks/usePaginationParams';
+import { PaginationBar } from '@/components/ui/PaginationBar';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus } from '@/lib/otherIncome.types';
 import { formatThaiDateShort } from '@/lib/date';
@@ -103,14 +105,17 @@ export default function OtherIncomeListPage() {
   const [status, setStatus] = useState<OtherIncomeStatus | ''>('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-  const [page, setPage] = useState(1);
+  const { page, size, setPage, setSize } = usePaginationParams({ defaultSize: 50 });
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [confirmDeleteNumber, setConfirmDeleteNumber] = useState<string>('');
 
   const debouncedQ = useDebounce(q, 300);
 
+  // PDF AC-5: READY filter sorts oldest first (ascending) so approvers see the oldest pending items
+  const sortDir = status === 'READY' ? 'asc' : 'desc';
+
   const listQuery = useQuery({
-    queryKey: ['other-income', 'list', debouncedQ, status, startDate, endDate, page],
+    queryKey: ['other-income', 'list', { page, size, q: debouncedQ, status, startDate, endDate }],
     queryFn: () =>
       otherIncomeApi.list({
         q: debouncedQ || undefined,
@@ -118,7 +123,8 @@ export default function OtherIncomeListPage() {
         startDate: startDate || undefined,
         endDate: endDate || undefined,
         page,
-        limit: 50,
+        limit: size,
+        sort: `createdAt:${sortDir}`,
       }),
   });
 
@@ -169,7 +175,6 @@ export default function OtherIncomeListPage() {
   const data = listQuery.data;
   const docs = data?.data ?? [];
   const total = data?.total ?? 0;
-  const totalPages = Math.ceil(total / 50) || 1;
 
   const draftCount = draftCountQuery.data ?? 0;
   const readyCount = readyCountQuery.data ?? 0;
@@ -400,32 +405,13 @@ export default function OtherIncomeListPage() {
         </div>
 
         {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="flex items-center justify-between mt-4 text-sm">
-            <span className="text-muted-foreground">
-              แสดง {docs.length} จาก {total} รายการ
-            </span>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page === 1}
-                className="px-3 py-1.5 border rounded-md hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                ก่อนหน้า
-              </button>
-              <span className="px-3 py-1.5 text-muted-foreground">
-                {page} / {totalPages}
-              </span>
-              <button
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page === totalPages}
-                className="px-3 py-1.5 border rounded-md hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                ถัดไป
-              </button>
-            </div>
-          </div>
-        )}
+        <PaginationBar
+          total={total}
+          page={page}
+          size={size}
+          onPageChange={setPage}
+          onSizeChange={setSize}
+        />
       </QueryBoundary>
 
       <ConfirmDialog

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -7,6 +7,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { AccountingModuleTabBar } from '@/components/accounting/AccountingModuleTabBar';
+import { ReopenedPeriodBanner } from '@/components/accounting/ReopenedPeriodBanner';
 import { useDebounce } from '@/hooks/useDebounce';
 import { usePaginationParams } from '@/hooks/usePaginationParams';
 import { PaginationBar } from '@/components/ui/PaginationBar';
@@ -184,6 +185,7 @@ export default function OtherIncomeListPage() {
   return (
     <div className="p-6 max-w-7xl mx-auto space-y-4">
       <AccountingModuleTabBar />
+      <ReopenedPeriodBanner />
       <PageHeader
         title="รายได้อื่น"
         subtitle="จัดการเอกสารรับรู้รายได้อื่น (กลุ่ม 42-XXXX) — ดอกเบี้ยเงินฝาก, ค่าปรับ, รายได้หักค่าจ้าง ฯลฯ"

--- a/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomePendingApprovalPage.tsx
@@ -3,18 +3,24 @@ import { useNavigate } from 'react-router';
 import { Clock, Inbox } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
+import { usePaginationParams } from '@/hooks/usePaginationParams';
+import { PaginationBar } from '@/components/ui/PaginationBar';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import { formatThaiDateShort } from '@/lib/date';
 import { formatNumberDecimal } from '@/utils/formatters';
 
 export default function OtherIncomePendingApprovalPage() {
   const navigate = useNavigate();
+  const { page, size, setPage, setSize } = usePaginationParams({ defaultSize: 50 });
+
   const query = useQuery({
-    queryKey: ['other-income', 'list', { status: 'READY' }],
-    queryFn: () => otherIncomeApi.list({ status: 'READY', limit: 100 }),
+    queryKey: ['other-income', 'list', { status: 'READY', page, size }],
+    queryFn: () =>
+      otherIncomeApi.list({ status: 'READY', limit: size, page, sort: 'createdAt:asc' }),
   });
 
   const data = query.data;
+  const total = data?.total ?? 0;
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
@@ -75,6 +81,13 @@ export default function OtherIncomePendingApprovalPage() {
             </table>
           </div>
         )}
+        <PaginationBar
+          total={total}
+          page={page}
+          size={size}
+          onPageChange={setPage}
+          onSizeChange={setSize}
+        />
       </QueryBoundary>
     </div>
   );

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -658,15 +658,67 @@ export default function OtherIncomeViewPage() {
               <ul className="space-y-2">
                 {auditQuery.data.map((log) => (
                   <li key={log.id} className="border-l-2 pl-3 py-1.5 border-border">
-                    <div className="flex items-center gap-2 text-xs flex-wrap">
-                      <span className="px-2 py-0.5 rounded bg-muted font-mono text-xs">
-                        {log.action}
-                      </span>
-                      <span className="text-muted-foreground">{fmtDate(log.createdAt)}</span>
-                      {log.user && (
-                        <span>โดย <strong>{log.user.name}</strong></span>
-                      )}
-                    </div>
+                    {log.action === 'JV_OVERRIDDEN' ? (
+                      <div className="rounded border border-warning/50 bg-warning/10 p-3 space-y-2">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="px-2 py-0.5 rounded bg-warning/20 font-mono text-xs font-semibold text-warning">
+                            JV_OVERRIDDEN
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {log.user?.name ?? '—'} · {new Date(log.createdAt).toLocaleString('th-TH')}
+                          </span>
+                        </div>
+                        <p className="text-sm italic text-muted-foreground">
+                          {(log.newValue as any)?.diffSummary ?? '(ไม่มีสรุปการเปลี่ยนแปลง)'}
+                        </p>
+
+                        <details className="text-xs">
+                          <summary className="cursor-pointer text-muted-foreground hover:text-foreground font-medium">
+                            ดูรายละเอียดทั้งหมด
+                          </summary>
+                          <div className="grid grid-cols-2 gap-4 mt-3 pt-3 border-t border-warning/30">
+                            <div>
+                              <p className="font-semibold text-xs mb-2 text-muted-foreground">Original (Auto)</p>
+                              <table className="w-full font-mono text-[11px]">
+                                <tbody>
+                                  {(log.oldValue as any)?.jvLines?.map((l: any, i: number) => (
+                                    <tr key={i} className="border-b border-border/30">
+                                      <td className="py-1 pr-2">{l.accountCode}</td>
+                                      <td className="text-right pr-2">{Number(l.debit).toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                                      <td className="text-right">{Number(l.credit).toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                            <div>
+                              <p className="font-semibold text-xs mb-2 text-muted-foreground">Modified</p>
+                              <table className="w-full font-mono text-[11px]">
+                                <tbody>
+                                  {(log.newValue as any)?.jvLines?.map((l: any, i: number) => (
+                                    <tr key={i} className="border-b border-border/30">
+                                      <td className="py-1 pr-2">{l.accountCode}</td>
+                                      <td className="text-right pr-2">{Number(l.debit).toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                                      <td className="text-right">{Number(l.credit).toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          </div>
+                        </details>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-2 text-xs flex-wrap">
+                        <span className="px-2 py-0.5 rounded bg-muted font-mono text-xs">
+                          {log.action}
+                        </span>
+                        <span className="text-muted-foreground">{fmtDate(log.createdAt)}</span>
+                        {log.user && (
+                          <span>โดย <strong>{log.user.name}</strong></span>
+                        )}
+                      </div>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/apps/web/src/pages/other-income/components/EditableJournalTable.tsx
+++ b/apps/web/src/pages/other-income/components/EditableJournalTable.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react';
+import { Trash2, Plus, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export type EditableJournalLine = {
+  accountCode: string;
+  debit: number;
+  credit: number;
+  description?: string;
+};
+
+type Props = {
+  lines: EditableJournalLine[];
+  onChange: (next: EditableJournalLine[]) => void;
+};
+
+type ValidationIssue = { rule: 'V1' | 'V2' | 'V5'; msg: string };
+
+function validateClientSide(lines: EditableJournalLine[]): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  if (lines.length < 2) {
+    issues.push({ rule: 'V2', msg: 'ต้องมีอย่างน้อย 2 บรรทัด' });
+  }
+
+  for (const line of lines) {
+    const hasDr = line.debit > 0;
+    const hasCr = line.credit > 0;
+    if (hasDr && hasCr) {
+      issues.push({ rule: 'V5', msg: `บรรทัด ${line.accountCode || '(ไม่ระบุ)'} มีทั้ง Dr และ Cr` });
+    } else if (!hasDr && !hasCr) {
+      issues.push({ rule: 'V5', msg: `บรรทัด ${line.accountCode || '(ไม่ระบุ)'} ไม่มีทั้ง Dr และ Cr` });
+    }
+  }
+
+  const drTotal = lines.reduce((s, l) => s + (l.debit || 0), 0);
+  const crTotal = lines.reduce((s, l) => s + (l.credit || 0), 0);
+  if (Math.abs(drTotal - crTotal) > 0.01) {
+    issues.push({
+      rule: 'V1',
+      msg: `Dr (${drTotal.toFixed(2)}) ≠ Cr (${crTotal.toFixed(2)}) — ผลต่าง ${(drTotal - crTotal).toFixed(2)} บาท`,
+    });
+  }
+
+  return issues;
+}
+
+export function EditableJournalTable({ lines, onChange }: Props) {
+  const issues = useMemo(() => validateClientSide(lines), [lines]);
+  const drTotal = lines.reduce((s, l) => s + (l.debit || 0), 0);
+  const crTotal = lines.reduce((s, l) => s + (l.credit || 0), 0);
+
+  const updateLine = (idx: number, patch: Partial<EditableJournalLine>) => {
+    onChange(lines.map((l, i) => (i === idx ? { ...l, ...patch } : l)));
+  };
+  const deleteLine = (idx: number) => onChange(lines.filter((_, i) => i !== idx));
+  const addLine = () => onChange([...lines, { accountCode: '', debit: 0, credit: 0 }]);
+
+  return (
+    <div className="space-y-2">
+      <div className="overflow-x-auto rounded border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted">
+            <tr>
+              <th className="px-2 py-2 text-left">รหัสบัญชี</th>
+              <th className="px-2 py-2 text-right">Dr</th>
+              <th className="px-2 py-2 text-right">Cr</th>
+              <th className="px-2 py-2 text-left">หมายเหตุ</th>
+              <th className="px-2 py-2 w-10"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {lines.map((line, idx) => (
+              <tr key={idx} className="border-t border-border">
+                <td className="px-2 py-1">
+                  <Input
+                    value={line.accountCode}
+                    onChange={(e) => updateLine(idx, { accountCode: e.target.value })}
+                    placeholder="42-1102"
+                    className="font-mono"
+                  />
+                </td>
+                <td className="px-2 py-1">
+                  <Input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={line.debit || ''}
+                    onChange={(e) => updateLine(idx, { debit: Number(e.target.value) || 0, credit: 0 })}
+                    className="text-right font-mono"
+                  />
+                </td>
+                <td className="px-2 py-1">
+                  <Input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={line.credit || ''}
+                    onChange={(e) => updateLine(idx, { credit: Number(e.target.value) || 0, debit: 0 })}
+                    className="text-right font-mono"
+                  />
+                </td>
+                <td className="px-2 py-1">
+                  <Input
+                    value={line.description ?? ''}
+                    onChange={(e) => updateLine(idx, { description: e.target.value })}
+                  />
+                </td>
+                <td className="px-2 py-1">
+                  <Button variant="ghost" size="icon" onClick={() => deleteLine(idx)}>
+                    <Trash2 className="w-4 h-4 text-destructive" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            <tr className="border-t border-border bg-muted font-mono text-sm">
+              <td className="px-2 py-2 font-semibold">รวม</td>
+              <td className="px-2 py-2 text-right">{drTotal.toFixed(2)}</td>
+              <td className="px-2 py-2 text-right">{crTotal.toFixed(2)}</td>
+              <td colSpan={2}></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <Button variant="outline" size="sm" onClick={addLine}>
+        <Plus className="w-4 h-4 mr-1" /> เพิ่มบรรทัด
+      </Button>
+
+      {issues.length > 0 && (
+        <div className="rounded border border-destructive bg-destructive/10 p-3 space-y-1">
+          {issues.map((iss, i) => (
+            <div key={i} className="text-sm text-destructive flex items-start gap-2">
+              <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+              <span>
+                <strong>{iss.rule}:</strong> {iss.msg}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function getJournalIssues(lines: EditableJournalLine[]) {
+  return validateClientSide(lines);
+}

--- a/apps/web/src/pages/other-income/components/EditableJournalTable.tsx
+++ b/apps/web/src/pages/other-income/components/EditableJournalTable.tsx
@@ -25,6 +25,10 @@ function validateClientSide(lines: EditableJournalLine[]): ValidationIssue[] {
   }
 
   for (const line of lines) {
+    // Skip rows the user hasn't started filling (avoids V5 false-positive on new empty rows)
+    const isBlank = !line.accountCode.trim() && (line.debit || 0) === 0 && (line.credit || 0) === 0;
+    if (isBlank) continue;
+
     const hasDr = line.debit > 0;
     const hasCr = line.credit > 0;
     if (hasDr && hasCr) {
@@ -34,9 +38,12 @@ function validateClientSide(lines: EditableJournalLine[]): ValidationIssue[] {
     }
   }
 
-  const drTotal = lines.reduce((s, l) => s + (l.debit || 0), 0);
-  const crTotal = lines.reduce((s, l) => s + (l.credit || 0), 0);
-  if (Math.abs(drTotal - crTotal) > 0.01) {
+  const drTotalCents = lines.reduce((s, l) => s + Math.round((l.debit || 0) * 100), 0);
+  const crTotalCents = lines.reduce((s, l) => s + Math.round((l.credit || 0) * 100), 0);
+  if (Math.abs(drTotalCents - crTotalCents) > 1) {
+    // 1 cent = 0.01 THB tolerance
+    const drTotal = drTotalCents / 100;
+    const crTotal = crTotalCents / 100;
     issues.push({
       rule: 'V1',
       msg: `Dr (${drTotal.toFixed(2)}) ≠ Cr (${crTotal.toFixed(2)}) — ผลต่าง ${(drTotal - crTotal).toFixed(2)} บาท`,
@@ -48,8 +55,10 @@ function validateClientSide(lines: EditableJournalLine[]): ValidationIssue[] {
 
 export function EditableJournalTable({ lines, onChange }: Props) {
   const issues = useMemo(() => validateClientSide(lines), [lines]);
-  const drTotal = lines.reduce((s, l) => s + (l.debit || 0), 0);
-  const crTotal = lines.reduce((s, l) => s + (l.credit || 0), 0);
+  const drTotalCents = lines.reduce((s, l) => s + Math.round((l.debit || 0) * 100), 0);
+  const crTotalCents = lines.reduce((s, l) => s + Math.round((l.credit || 0) * 100), 0);
+  const drTotal = (drTotalCents / 100).toFixed(2);
+  const crTotal = (crTotalCents / 100).toFixed(2);
 
   const updateLine = (idx: number, patch: Partial<EditableJournalLine>) => {
     onChange(lines.map((l, i) => (i === idx ? { ...l, ...patch } : l)));
@@ -108,7 +117,12 @@ export function EditableJournalTable({ lines, onChange }: Props) {
                   />
                 </td>
                 <td className="px-2 py-1">
-                  <Button variant="ghost" size="icon" onClick={() => deleteLine(idx)}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`ลบบรรทัดที่ ${idx + 1}`}
+                    onClick={() => deleteLine(idx)}
+                  >
                     <Trash2 className="w-4 h-4 text-destructive" />
                   </Button>
                 </td>
@@ -116,8 +130,8 @@ export function EditableJournalTable({ lines, onChange }: Props) {
             ))}
             <tr className="border-t border-border bg-muted font-mono text-sm">
               <td className="px-2 py-2 font-semibold">รวม</td>
-              <td className="px-2 py-2 text-right">{drTotal.toFixed(2)}</td>
-              <td className="px-2 py-2 text-right">{crTotal.toFixed(2)}</td>
+              <td className="px-2 py-2 text-right">{drTotal}</td>
+              <td className="px-2 py-2 text-right">{crTotal}</td>
               <td colSpan={2}></td>
             </tr>
           </tbody>
@@ -129,7 +143,7 @@ export function EditableJournalTable({ lines, onChange }: Props) {
       </Button>
 
       {issues.length > 0 && (
-        <div className="rounded border border-destructive bg-destructive/10 p-3 space-y-1">
+        <div role="alert" aria-live="polite" className="rounded border border-destructive bg-destructive/10 p-3 space-y-1">
           {issues.map((iss, i) => (
             <div key={i} className="text-sm text-destructive flex items-start gap-2">
               <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />

--- a/apps/web/src/pages/other-income/components/OverrideConfirmDialog.tsx
+++ b/apps/web/src/pages/other-income/components/OverrideConfirmDialog.tsx
@@ -21,7 +21,7 @@ export function OverrideConfirmDialog({ open, onConfirm, onCancel }: Props) {
     <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-amber-600">
+          <DialogTitle className="flex items-center gap-2 text-destructive">
             <AlertTriangle className="w-5 h-5" />
             คุณกำลังจะแก้ไข Auto Journal ด้วยตนเอง
           </DialogTitle>
@@ -34,10 +34,16 @@ export function OverrideConfirmDialog({ open, onConfirm, onCancel }: Props) {
             <li>เอกสารจะมีเครื่องหมาย ✏ Modified ในรายการ</li>
           </ul>
 
-          <label className="flex items-start gap-2 pt-2 cursor-pointer">
-            <Checkbox checked={acknowledged} onCheckedChange={(v) => setAcknowledged(Boolean(v))} />
-            <span className="text-sm">ฉันเข้าใจและรับผิดชอบความถูกต้อง</span>
-          </label>
+          <div className="flex items-start gap-2 pt-2">
+            <Checkbox
+              id="override-ack-checkbox"
+              checked={acknowledged}
+              onCheckedChange={(v) => setAcknowledged(Boolean(v))}
+            />
+            <label htmlFor="override-ack-checkbox" className="text-sm cursor-pointer">
+              ฉันเข้าใจและรับผิดชอบความถูกต้อง
+            </label>
+          </div>
         </div>
 
         <DialogFooter>

--- a/apps/web/src/pages/other-income/components/OverrideConfirmDialog.tsx
+++ b/apps/web/src/pages/other-income/components/OverrideConfirmDialog.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { AlertTriangle } from 'lucide-react';
+
+type Props = {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function OverrideConfirmDialog({ open, onConfirm, onCancel }: Props) {
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  useEffect(() => {
+    if (!open) setAcknowledged(false); // reset on close
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-amber-600">
+            <AlertTriangle className="w-5 h-5" />
+            คุณกำลังจะแก้ไข Auto Journal ด้วยตนเอง
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 text-sm">
+          <ul className="space-y-1 list-disc list-inside text-muted-foreground">
+            <li>ระบบจะตรวจสอบ V1/V2/V5 ก่อน POST</li>
+            <li>การกระทำนี้จะถูกบันทึกใน Audit Log</li>
+            <li>เอกสารจะมีเครื่องหมาย ✏ Modified ในรายการ</li>
+          </ul>
+
+          <label className="flex items-start gap-2 pt-2 cursor-pointer">
+            <Checkbox checked={acknowledged} onCheckedChange={(v) => setAcknowledged(Boolean(v))} />
+            <span className="text-sm">ฉันเข้าใจและรับผิดชอบความถูกต้อง</span>
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>ยกเลิก</Button>
+          <Button onClick={onConfirm} disabled={!acknowledged}>เปิดโหมดแก้ไข</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/other-income/components/__tests__/OverrideConfirmDialog.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/OverrideConfirmDialog.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OverrideConfirmDialog } from '../OverrideConfirmDialog';
+
+describe('OverrideConfirmDialog', () => {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+
+  beforeEach(() => {
+    onConfirm.mockClear();
+    onCancel.mockClear();
+  });
+
+  it('does not render when open=false', () => {
+    render(<OverrideConfirmDialog open={false} onConfirm={onConfirm} onCancel={onCancel} />);
+    expect(screen.queryByText(/แก้ไข Auto Journal ด้วยตนเอง/)).not.toBeInTheDocument();
+  });
+
+  it('renders warning + impacts + checkbox when open', () => {
+    render(<OverrideConfirmDialog open={true} onConfirm={onConfirm} onCancel={onCancel} />);
+    expect(screen.getByText(/แก้ไข Auto Journal ด้วยตนเอง/)).toBeInTheDocument();
+    expect(screen.getByText(/ตรวจสอบ V1\/V2\/V5/)).toBeInTheDocument();
+    expect(screen.getByText(/บันทึกใน Audit Log/)).toBeInTheDocument();
+    expect(screen.getByText(/ฉันเข้าใจและรับผิดชอบ/)).toBeInTheDocument();
+  });
+
+  it('confirm button is disabled until acknowledgement checkbox is checked', () => {
+    render(<OverrideConfirmDialog open={true} onConfirm={onConfirm} onCancel={onCancel} />);
+    const confirmBtn = screen.getByRole('button', { name: /เปิดโหมดแก้ไข/ });
+    expect(confirmBtn).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('calls onConfirm when confirm clicked after acknowledging', () => {
+    render(<OverrideConfirmDialog open={true} onConfirm={onConfirm} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /เปิดโหมดแก้ไข/ }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel clicked', () => {
+    render(<OverrideConfirmDialog open={true} onConfirm={onConfirm} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: /ยกเลิก/ }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/accounting/audit-for-accounting-other-income-v2-2-2026-05-13.html
+++ b/docs/accounting/audit-for-accounting-other-income-v2-2-2026-05-13.html
@@ -1,0 +1,611 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BESTCHOICE — รายรับอื่นๆ v2.2 · เอกสารตรวจสอบฝ่ายบัญชี</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Thai:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #fafaf9;
+    --paper: #ffffff;
+    --border: #d6d3d1;
+    --line: #e7e5e4;
+    --text: #0c0a09;
+    --muted: #57534e;
+    --subtle: #78716c;
+    --emerald: #047857;
+    --emerald-bg: #ecfdf5;
+    --emerald-border: #a7f3d0;
+    --rose: #be123c;
+    --rose-bg: #fef2f2;
+    --rose-border: #fecaca;
+    --amber: #b45309;
+    --amber-bg: #fffbeb;
+    --amber-border: #fde68a;
+    --blue: #1d4ed8;
+    --blue-bg: #eff6ff;
+    --blue-border: #bfdbfe;
+    --violet: #6d28d9;
+    --violet-bg: #f5f3ff;
+    --violet-border: #ddd6fe;
+    --zinc-bg: #f4f4f5;
+    --zinc-border: #d4d4d8;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--text); font-family: 'IBM Plex Sans Thai', system-ui, sans-serif; font-size: 15px; line-height: 1.7; }
+  .page { max-width: 1024px; margin: 0 auto; padding: 56px 40px 80px; background: var(--paper); box-shadow: 0 1px 3px rgba(0,0,0,0.04); }
+  .doc-header { border-bottom: 2px solid var(--text); padding-bottom: 20px; margin-bottom: 36px; }
+  .doc-header .org { font-size: 13px; color: var(--subtle); letter-spacing: 0.05em; margin-bottom: 6px; text-transform: uppercase; }
+  h1 { font-size: 28px; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; }
+  .doc-header .sub { color: var(--muted); font-size: 15px; margin: 0; }
+  .doc-meta { display: flex; gap: 28px; margin-top: 14px; font-size: 12px; color: var(--subtle); flex-wrap: wrap; }
+  .doc-meta strong { color: var(--text); }
+
+  .summary-box { background: var(--emerald-bg); border: 1px solid var(--emerald-border); border-radius: 10px; padding: 20px 24px; margin: 0 0 28px; }
+  .summary-box h3 { font-size: 14px; margin: 0 0 10px; font-weight: 700; color: var(--emerald); letter-spacing: 0.04em; text-transform: uppercase; }
+  .summary-list { margin: 0; padding-left: 20px; font-size: 14px; }
+  .summary-list li { margin-bottom: 6px; }
+  .summary-list strong { color: var(--text); }
+  .summary-list code { font-family: 'IBM Plex Mono', monospace; font-size: 12px; background: white; padding: 1px 6px; border-radius: 3px; border: 1px solid var(--emerald-border); }
+
+  .toc { background: var(--zinc-bg); border: 1px solid var(--zinc-border); border-radius: 10px; padding: 18px 24px; margin: 0 0 28px; }
+  .toc h3 { margin: 0 0 8px; font-size: 13px; color: var(--muted); letter-spacing: 0.05em; text-transform: uppercase; }
+  .toc ol { margin: 0; padding-left: 22px; font-size: 14px; }
+  .toc ol li { margin-bottom: 4px; }
+  .toc a { color: var(--text); text-decoration: none; }
+  .toc a:hover { color: var(--blue); text-decoration: underline; }
+
+  section { margin-bottom: 44px; }
+  h2 { font-size: 20px; font-weight: 700; margin: 0 0 18px; padding-bottom: 8px; border-bottom: 1px solid var(--border); letter-spacing: -0.01em; }
+  h2 .badge-section { display: inline-block; background: var(--text); color: white; padding: 2px 10px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 10px; vertical-align: middle; }
+  h3 { font-size: 16px; margin: 24px 0 10px; font-weight: 600; }
+  h4 { font-size: 14px; margin: 16px 0 8px; font-weight: 600; color: var(--muted); }
+
+  .entry { background: var(--paper); border: 1px solid var(--border); border-radius: 8px; padding: 18px 22px; margin: 14px 0; }
+  .entry .title { font-size: 14px; font-weight: 600; margin: 0 0 4px; }
+  .entry .meta { font-size: 12px; color: var(--subtle); margin: 0 0 12px; }
+
+  table.je { width: 100%; border-collapse: collapse; margin: 8px 0; font-size: 13px; }
+  table.je th, table.je td { padding: 6px 10px; text-align: left; border-bottom: 1px solid var(--line); }
+  table.je th { background: var(--bg); color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+  table.je td.amt { text-align: right; font-family: 'IBM Plex Mono', monospace; font-size: 12px; }
+  table.je td.code { font-family: 'IBM Plex Mono', monospace; font-size: 12px; font-weight: 500; color: var(--blue); white-space: nowrap; }
+  table.je tr.total td { font-weight: 700; background: var(--bg); border-top: 2px solid var(--text); border-bottom: none; }
+  table.je tr.total td.balanced { color: var(--emerald); }
+
+  .callout { padding: 14px 18px; border-radius: 8px; margin: 14px 0; border-left: 4px solid; font-size: 14px; }
+  .callout.info { background: var(--blue-bg); border-color: var(--blue); }
+  .callout.warn { background: var(--amber-bg); border-color: var(--amber); }
+  .callout.error { background: var(--rose-bg); border-color: var(--rose); }
+  .callout.success { background: var(--emerald-bg); border-color: var(--emerald); }
+  .callout p { margin: 0; }
+  .callout strong { color: var(--text); }
+
+  .status-flag { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; margin-left: 8px; vertical-align: middle; }
+  .flag-new { background: var(--emerald); color: white; }
+  .flag-fixed { background: var(--blue); color: white; }
+  .flag-warn { background: var(--amber); color: white; }
+  .flag-skip { background: var(--zinc-border); color: var(--muted); }
+
+  .check-list { list-style: none; padding: 0; margin: 12px 0; }
+  .check-list li { padding: 8px 12px; margin-bottom: 6px; border: 1px solid var(--border); border-radius: 6px; background: var(--paper); font-size: 14px; display: flex; align-items: flex-start; gap: 10px; }
+  .check-list li::before { content: '☐'; font-size: 18px; color: var(--muted); flex-shrink: 0; margin-top: -2px; }
+  .check-list li strong { color: var(--text); }
+  .check-list li code { font-family: 'IBM Plex Mono', monospace; font-size: 12px; background: var(--zinc-bg); padding: 1px 6px; border-radius: 3px; }
+
+  code.inline { font-family: 'IBM Plex Mono', monospace; font-size: 13px; background: var(--zinc-bg); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--zinc-border); }
+
+  .api-table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 13px; }
+  .api-table th, .api-table td { padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: top; }
+  .api-table th { background: var(--zinc-bg); color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+  .api-table .method { font-family: 'IBM Plex Mono', monospace; font-size: 11px; padding: 2px 6px; border-radius: 3px; font-weight: 600; }
+  .api-table .method.get { background: var(--emerald-bg); color: var(--emerald); }
+  .api-table .method.post { background: var(--blue-bg); color: var(--blue); }
+  .api-table .method.put { background: var(--amber-bg); color: var(--amber); }
+  .api-table .path { font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: var(--text); }
+
+  .flow-step { background: var(--zinc-bg); border: 1px solid var(--zinc-border); border-radius: 8px; padding: 14px 18px; margin: 10px 0; position: relative; padding-left: 50px; }
+  .flow-step .num { position: absolute; left: 14px; top: 14px; width: 26px; height: 26px; background: var(--text); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 13px; }
+  .flow-step strong { color: var(--text); }
+  .flow-step .meta { font-size: 12px; color: var(--subtle); margin-top: 4px; }
+
+  .mock { background: #0c0a09; color: #f4f4f5; border-radius: 8px; padding: 16px 18px; margin: 12px 0; font-family: 'IBM Plex Mono', monospace; font-size: 12px; line-height: 1.5; overflow-x: auto; }
+  .mock .key { color: #fbbf24; }
+  .mock .str { color: #86efac; }
+  .mock .num { color: #93c5fd; }
+  .mock .com { color: var(--subtle); }
+
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 768px) { .grid-2 { grid-template-columns: 1fr; } }
+
+  .footer { margin-top: 60px; padding-top: 20px; border-top: 1px solid var(--border); font-size: 12px; color: var(--subtle); text-align: center; }
+  .footer p { margin: 4px 0; }
+
+  @media print {
+    body { background: white; }
+    .page { box-shadow: none; padding: 20px; max-width: none; }
+    section { break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+<header class="doc-header">
+  <div class="org">BESTCHOICE FINANCE · เอกสารตรวจสอบฝ่ายบัญชี</div>
+  <h1>รายรับอื่นๆ (Other Income 42-XXXX) — v2.2 Release</h1>
+  <p class="sub">เอกสารสำหรับฝ่ายบัญชีตรวจสอบความถูกต้องของระบบใหม่ ก่อน sign-off go-live</p>
+  <div class="doc-meta">
+    <span><strong>วันที่</strong>: 13 พฤษภาคม 2569</span>
+    <span><strong>เวอร์ชัน</strong>: v2.2 (ต่อจาก v2.1)</span>
+    <span><strong>PR</strong>: <a href="https://github.com/iamnaii/BESTCHOICE/pull/827">#827</a></span>
+    <span><strong>ขอบเขต</strong>: ครอบคลุม 5 ข้อจาก PDF v2.2</span>
+  </div>
+</header>
+
+<div class="summary-box">
+  <h3>สรุปการเปลี่ยนแปลงในเวอร์ชัน v2.2</h3>
+  <ol class="summary-list">
+    <li><strong>Override JV</strong> — ยอมให้แก้รายการบัญชีเองก่อน POST (มี V1/V2/V5 validation + audit log)</li>
+    <li><strong>Maker-Checker Toggle UI</strong> — ผู้บริหาร (OWNER) เปิด/ปิดระบบอนุมัติเองได้ที่หน้า Settings</li>
+    <li><strong>Reopen Period Workflow</strong> — เปิดงวดที่ปิดแล้วต้องระบุเหตุผล (4 ตัวเลือก) + ภ.พ.30 ยื่นหรือยัง + Banner เตือน</li>
+    <li><strong>Settings 5-Tab Consolidation</strong> — รวมการตั้งค่าทั้งหมดที่ <code>/settings</code> เป็น 5 แท็บ (บริษัท / VAT / งวด / เอกสารแนบ / ผู้ใช้)</li>
+    <li><strong>Pagination ทุกหน้า List</strong> — แบ่งหน้าแบบ URL params, bookmark ได้, จำนวนต่อหน้าเลือกได้</li>
+  </ol>
+</div>
+
+<div class="toc">
+  <h3>สารบัญ — สิ่งที่ฝ่ายบัญชีต้องตรวจสอบ</h3>
+  <ol>
+    <li><a href="#sect-1">Override JV — แก้รายการบัญชีเองก่อน POST</a></li>
+    <li><a href="#sect-2">Maker-Checker Toggle — เปิด/ปิดระบบอนุมัติ</a></li>
+    <li><a href="#sect-3">Reopen Period — เปิดงวดที่ปิดแล้ว</a></li>
+    <li><a href="#sect-4">Settings 5-Tab — การตั้งค่าระบบ</a></li>
+    <li><a href="#sect-5">Pagination — แบ่งหน้ารายการ</a></li>
+    <li><a href="#sect-audit">Audit Log — รายการที่ระบบจะบันทึก</a></li>
+    <li><a href="#sect-checklist">Checklist สุดท้าย — ฝ่ายบัญชี sign-off</a></li>
+  </ol>
+</div>
+
+<!-- ============================================================ -->
+<!-- SECTION 1: OVERRIDE JV -->
+<!-- ============================================================ -->
+<section id="sect-1">
+  <h2><span class="badge-section">1</span>Override JV — แก้รายการบัญชีเองก่อน POST<span class="status-flag flag-new">ใหม่</span></h2>
+
+  <p>ปกติระบบจะ generate รายการบัญชี (JE) อัตโนมัติจากข้อมูลในเอกสาร — แต่ในบางกรณีฝ่ายบัญชีจำเป็นต้องแก้รายการเองก่อน POST (เช่น แยกบัญชีย่อย, จัดทำ JE พิเศษ, ปรับ contra-account)</p>
+
+  <h3>ขั้นตอนการใช้งาน</h3>
+  <div class="flow-step"><span class="num">1</span><strong>กรอกเอกสารตามปกติ</strong> — ระบบ generate JE อัตโนมัติให้ดู</div>
+  <div class="flow-step"><span class="num">2</span><strong>กด checkbox "ใช้เอง (Override)"</strong><div class="meta">ระบบจะแสดงคำเตือน + ให้กด checkbox ยืนยันว่ารับผิดชอบความถูกต้อง</div></div>
+  <div class="flow-step"><span class="num">3</span><strong>แก้ไขตาราง JE ได้</strong><div class="meta">เพิ่ม/ลบ/แก้บรรทัด ระบบตรวจสด V1/V2/V5 ทันที</div></div>
+  <div class="flow-step"><span class="num">4</span><strong>กด POST</strong><div class="meta">ระบบ validate อีกครั้ง + บันทึก audit log (original vs modified)</div></div>
+  <div class="flow-step"><span class="num">5</span><strong>เอกสารแสดง ✏ marker</strong><div class="meta">หน้ารายการแสดง icon ดินสอข้างหมายเลข เพื่อให้สังเกตว่าเอกสารนี้ถูก override</div></div>
+
+  <h3>กฎ Validation (V1/V2/V5) ที่ระบบบังคับ</h3>
+  <table class="api-table">
+    <thead><tr><th>กฎ</th><th>คำอธิบาย</th><th>ข้อความ error (ไทย)</th></tr></thead>
+    <tbody>
+      <tr><td><strong>V1</strong></td><td>ยอด Dr รวม = ยอด Cr รวม (tolerance ±0.01 บาท)</td><td>Dr (X) ≠ Cr (Y) — ผลต่าง Z บาท</td></tr>
+      <tr><td><strong>V2</strong></td><td>ต้องมีอย่างน้อย 2 บรรทัด</td><td>ต้องมีอย่างน้อย 2 บรรทัด</td></tr>
+      <tr><td><strong>V5</strong></td><td>แต่ละบรรทัดต้องเป็น Dr <em>หรือ</em> Cr ไม่ใช่ทั้งคู่</td><td>บรรทัด XX-XXXX มีทั้ง Dr และ Cr / ไม่มีทั้ง Dr และ Cr</td></tr>
+    </tbody>
+  </table>
+
+  <h3>ตัวอย่าง Audit Log เมื่อ Override</h3>
+  <div class="mock">{
+  <span class="key">"action"</span>: <span class="str">"JV_OVERRIDDEN"</span>,
+  <span class="key">"entity"</span>: <span class="str">"other_income"</span>,
+  <span class="key">"entityId"</span>: <span class="str">"OI-20260513-0042"</span>,
+  <span class="key">"userId"</span>: <span class="str">"USER-001"</span>,
+  <span class="key">"oldValue"</span>: { <span class="com">// JE ที่ระบบ generate</span>
+    <span class="key">"jvLines"</span>: [
+      { <span class="key">"accountCode"</span>: <span class="str">"11-1201"</span>, <span class="key">"debit"</span>: <span class="str">"1000.00"</span>, <span class="key">"credit"</span>: <span class="str">"0"</span> },
+      { <span class="key">"accountCode"</span>: <span class="str">"42-1102"</span>, <span class="key">"debit"</span>: <span class="str">"0"</span>, <span class="key">"credit"</span>: <span class="str">"1000.00"</span> }
+    ]
+  },
+  <span class="key">"newValue"</span>: { <span class="com">// JE หลังถูก override</span>
+    <span class="key">"jvLines"</span>: [
+      { <span class="key">"accountCode"</span>: <span class="str">"11-1201"</span>, <span class="key">"debit"</span>: <span class="str">"1500.00"</span>, <span class="key">"credit"</span>: <span class="str">"0"</span> },
+      { <span class="key">"accountCode"</span>: <span class="str">"42-1102"</span>, <span class="key">"debit"</span>: <span class="str">"0"</span>, <span class="key">"credit"</span>: <span class="str">"1500.00"</span> }
+    ],
+    <span class="key">"diffSummary"</span>: <span class="str">"แก้ Dr 11-1201 จาก 1,000.00 → 1,500.00; แก้ Cr 42-1102 จาก 1,000.00 → 1,500.00"</span>
+  }
+}</div>
+
+  <div class="callout warn">
+    <p><strong>หมายเหตุสำคัญ:</strong> เอกสารที่ถูก override จะมี flag <code class="inline">isOverridden=true</code> ใน DB ตลอดไป แม้จะ reverse แล้วก็ตาม — ใช้เป็นหลักฐานในการ audit ได้</p>
+  </div>
+
+  <h3>สิ่งที่ฝ่ายบัญชีต้องตรวจ (Override JV)</h3>
+  <ul class="check-list">
+    <li><strong>ทดสอบกด Override</strong> — ใส่ Dr=1000 / Cr=999 ระบบควรกัน POST + ขึ้น error V1</li>
+    <li><strong>ทดสอบลบบรรทัดให้เหลือ 1</strong> — ระบบควรกัน POST + ขึ้น error V2</li>
+    <li><strong>ทดสอบใส่ทั้ง Dr+Cr ในบรรทัดเดียว</strong> — ระบบควรกัน POST + ขึ้น error V5</li>
+    <li><strong>POST สำเร็จ → เปิด View page</strong> — ต้องเห็น JV_OVERRIDDEN ใน audit log พร้อมสรุป diff ภาษาไทย</li>
+    <li><strong>เปิด List page</strong> — เอกสารที่ override ต้องมีไอคอน ✏ ข้างหมายเลข</li>
+    <li><strong>ทดสอบกด Override + ยกเลิก (ไม่ติ๊ก checkbox ยืนยัน)</strong> — ระบบไม่ควรเข้า override mode</li>
+  </ul>
+</section>
+
+<!-- ============================================================ -->
+<!-- SECTION 2: MAKER-CHECKER TOGGLE -->
+<!-- ============================================================ -->
+<section id="sect-2">
+  <h2><span class="badge-section">2</span>Maker-Checker Toggle — เปิด/ปิดระบบอนุมัติ<span class="status-flag flag-new">ใหม่</span></h2>
+
+  <p>ปกติฝ่ายบัญชีจะกำหนดให้ <strong>คนสร้างเอกสาร ≠ คนอนุมัติ</strong> (segregation of duties) — แต่บางช่วงต้องการความเร็ว เช่น ช่วงปิดบัญชี/ทำ adjustment เร่งด่วน — สามารถปิดได้ที่หน้า Settings (เฉพาะ <strong>OWNER</strong>)</p>
+
+  <h3>วิธีใช้</h3>
+  <ol>
+    <li>เปิด <code class="inline">/settings#users</code> (Tab "ผู้ใช้งาน")</li>
+    <li>กด Switch "ระบบ Maker-Checker"</li>
+    <li>ระบบแสดง confirmation dialog แตกต่างตามทิศทาง:
+      <div class="grid-2" style="margin-top: 12px;">
+        <div>
+          <h4 style="margin-top: 0; color: var(--emerald);">เปิดระบบ (OFF → ON)</h4>
+          <ul style="font-size: 13px; margin: 0;">
+            <li>เอกสารทุกฉบับต้องผ่านผู้อนุมัติก่อน POST</li>
+            <li>เอกสาร DRAFT ปัจจุบันต้องส่งอนุมัติ</li>
+            <li>ผู้สร้าง ≠ ผู้อนุมัติ</li>
+          </ul>
+        </div>
+        <div>
+          <h4 style="margin-top: 0; color: var(--rose);">ปิดระบบ (ON → OFF)</h4>
+          <ul style="font-size: 13px; margin: 0;">
+            <li>เอกสาร READY จะ auto-approve ทันที</li>
+            <li>เอกสารใหม่ POST ทันที (ไม่ต้องอนุมัติ)</li>
+            <li><strong>ระบบแสดงจำนวนเอกสาร READY ตอนนี้</strong>: N ฉบับ</li>
+          </ul>
+        </div>
+      </div>
+    </li>
+    <li>ติ๊ก checkbox "ฉันเข้าใจและยืนยัน..."</li>
+    <li>กด "ยืนยันเปิด" / "ยืนยันปิด"</li>
+  </ol>
+
+  <div class="callout info">
+    <p><strong>กฎสิทธิ์:</strong> ผู้ใช้ที่ไม่ใช่ OWNER เห็น Toggle แต่กดไม่ได้ (disabled) พร้อมข้อความ "เฉพาะ OWNER เท่านั้นที่เปลี่ยนได้"</p>
+  </div>
+
+  <h3>API + Audit Log</h3>
+  <table class="api-table">
+    <thead><tr><th>Method</th><th>Path</th><th>Role</th><th>หมายเหตุ</th></tr></thead>
+    <tbody>
+      <tr><td><span class="method put">PUT</span></td><td class="path">/other-income/maker-checker</td><td>OWNER</td><td>Toggle ค่า + บันทึก audit <code class="inline">CONFIG_CHANGED</code></td></tr>
+      <tr><td><span class="method get">GET</span></td><td class="path">/other-income/maker-checker/pending-ready-count</td><td>OWNER</td><td>นับเอกสาร READY (ใช้ใน ON→OFF confirmation)</td></tr>
+      <tr><td><span class="method get">GET</span></td><td class="path">/other-income/maker-checker-enabled</td><td>ทุก role</td><td>อ่านสถานะปัจจุบัน (เดิมจาก v2.1)</td></tr>
+    </tbody>
+  </table>
+
+  <h3>ตัวอย่าง Audit Log</h3>
+  <div class="mock">{
+  <span class="key">"action"</span>: <span class="str">"CONFIG_CHANGED"</span>,
+  <span class="key">"entity"</span>: <span class="str">"system_config"</span>,
+  <span class="key">"entityId"</span>: <span class="str">"OTHER_INCOME_MAKER_CHECKER_ENABLED"</span>,
+  <span class="key">"userId"</span>: <span class="str">"OWNER-001"</span>,
+  <span class="key">"oldValue"</span>: { <span class="key">"value"</span>: <span class="str">"true"</span> },
+  <span class="key">"newValue"</span>: { <span class="key">"value"</span>: <span class="str">"false"</span> }
+}</div>
+
+  <h3>สิ่งที่ฝ่ายบัญชีต้องตรวจ (Maker-Checker)</h3>
+  <ul class="check-list">
+    <li><strong>OWNER เข้า Settings#users</strong> — เห็น Switch Maker-Checker</li>
+    <li><strong>ไม่ใช่ OWNER เข้าหน้านี้</strong> — Switch disabled + ข้อความเตือน</li>
+    <li><strong>กด Switch (OFF→ON)</strong> — Dialog แสดงรายการผลกระทบ 3 ข้อ + checkbox ยืนยัน</li>
+    <li><strong>กด Switch (ON→OFF)</strong> — Dialog แสดง <strong>จำนวนเอกสาร READY ตอนนี้</strong> ด้วย</li>
+    <li><strong>ยกเลิก dialog</strong> — สถานะไม่เปลี่ยน</li>
+    <li><strong>ยืนยัน</strong> — สถานะเปลี่ยน + บันทึก CONFIG_CHANGED audit</li>
+    <li><strong>ตรวจประวัติ audit log</strong> — เห็น oldValue / newValue ชัดเจน</li>
+  </ul>
+</section>
+
+<!-- ============================================================ -->
+<!-- SECTION 3: REOPEN PERIOD -->
+<!-- ============================================================ -->
+<section id="sect-3">
+  <h2><span class="badge-section">3</span>Reopen Period — เปิดงวดที่ปิดแล้ว<span class="status-flag flag-new">ใหม่</span></h2>
+
+  <p>เมื่อปิดงวดบัญชีไปแล้วแต่ต้องการเปิดใหม่ชั่วคราว (เช่น พบเอกสารผิด, ลืมบันทึก, auditor ขอแก้) — ระบบมี <strong>SOP บังคับใน UI</strong> ให้บันทึกเหตุผล + ภ.พ.30 ยื่นหรือยัง + audit log</p>
+
+  <h3>Modal บังคับใส่เหตุผล</h3>
+  <p>เมื่อกด <strong>เปิดงวด</strong> ที่ปิดแล้ว ระบบจะแสดง modal ที่กรอกครบ 3 ส่วนถึงจะส่งได้:</p>
+
+  <table class="api-table">
+    <thead><tr><th>ฟิลด์</th><th>ประเภท</th><th>ข้อมูล</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong>reasonType</strong></td>
+        <td>Radio (เลือก 1)</td>
+        <td>
+          <code class="inline">WRONG_ENTRY</code> — พบเอกสารผิดต้อง reverse<br>
+          <code class="inline">MISSED_RECORD</code> — ลืมบันทึกรายการสำคัญ<br>
+          <code class="inline">AUDITOR_REQUEST</code> — แก้ไขตามคำขอ auditor<br>
+          <code class="inline">OTHER</code> — อื่นๆ (ระบุในบันทึก)
+        </td>
+      </tr>
+      <tr><td><strong>reason</strong></td><td>Free text (≥ 10 ตัวอักษร)</td><td>บันทึกรายละเอียดของเหตุผล (เช่น "เอกสาร OI-20260415-0042 ระบุลูกค้าผิด ต้อง reverse")</td></tr>
+      <tr><td><strong>taxFiled</strong></td><td>Radio (ใช่/ยังไม่)</td><td>ภ.พ.30 งวดนี้ยื่นแล้วหรือยัง — ถ้ายื่นแล้วต้องยื่นแก้ไข</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Banner เตือนบนหน้า List</h3>
+  <p>ระหว่างที่งวดเปิดอยู่ — ทุกหน้า <code class="inline">/other-income</code> และ <code class="inline">/expenses</code> จะแสดง Banner สีเหลือง:</p>
+
+  <div class="callout warn">
+    <p><strong>⚠ งวด 2569-04 ถูกเปิดชั่วคราว</strong><br>
+    เปิดเมื่อ: 13 พฤษภาคม 2569 14:30 โดย สุทธินีย์ คงเดช<br>
+    เหตุผล: WRONG_ENTRY: เอกสาร OI-20260415-0042 ระบุลูกค้าผิด<br>
+    <span style="color: var(--rose); font-weight: 600;">⚠ ภ.พ.30 ยื่นแล้ว — ต้องยื่นแก้ไขด้วย</span></p>
+  </div>
+
+  <h3>ความปลอดภัย (Race Condition)</h3>
+  <div class="callout success">
+    <p><strong>ป้องกันการแก้พร้อมกัน:</strong> ระบบใช้ <em>optimistic locking</em> (CAS) — ถ้า 2 OWNER กดเปิดงวดเดียวกันพร้อมกัน เฉพาะคนแรกที่สำเร็จเท่านั้น คนที่สองจะได้ error "งวดถูกแก้ไขโดยผู้ใช้คนอื่น กรุณาลองใหม่"</p>
+  </div>
+
+  <h3>API + Audit Log</h3>
+  <table class="api-table">
+    <thead><tr><th>Method</th><th>Path</th><th>Role</th><th>หมายเหตุ</th></tr></thead>
+    <tbody>
+      <tr><td><span class="method post">POST</span></td><td class="path">/expenses/periods/reopen</td><td>OWNER</td><td>เปิดงวด + บันทึก <code class="inline">PERIOD_REOPENED</code></td></tr>
+      <tr><td><span class="method post">POST</span></td><td class="path">/expenses/periods/close</td><td>OWNER, ACCOUNTANT</td><td>ปิดงวด + บันทึก <code class="inline">PERIOD_CLOSED</code> (เพิ่มใหม่)</td></tr>
+      <tr><td><span class="method get">GET</span></td><td class="path">/expenses/periods/reopened</td><td>OWNER, ACCOUNTANT, FINANCE_MANAGER</td><td>List งวดที่กำลังเปิดอยู่ (ใช้ใน Banner)</td></tr>
+    </tbody>
+  </table>
+
+  <div class="mock">{
+  <span class="key">"action"</span>: <span class="str">"PERIOD_REOPENED"</span>,
+  <span class="key">"entity"</span>: <span class="str">"accounting_period"</span>,
+  <span class="key">"entityId"</span>: <span class="str">"2026-04"</span>,
+  <span class="key">"userId"</span>: <span class="str">"OWNER-001"</span>,
+  <span class="key">"newValue"</span>: {
+    <span class="key">"reasonType"</span>: <span class="str">"WRONG_ENTRY"</span>,
+    <span class="key">"reason"</span>: <span class="str">"เอกสาร OI-20260415-0042 ระบุลูกค้าผิด ต้อง reverse"</span>,
+    <span class="key">"taxFiled"</span>: <span class="num">true</span>,
+    <span class="key">"reopenedAt"</span>: <span class="str">"2026-05-13T07:30:00.000Z"</span>
+  }
+}</div>
+
+  <h3>สิ่งที่ฝ่ายบัญชีต้องตรวจ (Reopen Period)</h3>
+  <ul class="check-list">
+    <li><strong>OWNER กดเปิดงวดที่ปิดแล้ว</strong> — Modal บังคับใส่เหตุผล + note ≥ 10 ตัว + taxFiled</li>
+    <li><strong>กรอกไม่ครบ</strong> — ปุ่ม "ยืนยันเปิดงวด" disabled</li>
+    <li><strong>ส่งสำเร็จ</strong> — Banner เตือนขึ้นทันทีในหน้า OtherIncome list + Expenses list</li>
+    <li><strong>taxFiled = ใช่</strong> — Banner แสดงข้อความ <em>"ภ.พ.30 ยื่นแล้ว — ต้องยื่นแก้ไขด้วย"</em></li>
+    <li><strong>ตรวจ audit log</strong> — เห็น <code class="inline">PERIOD_REOPENED</code> พร้อมข้อมูลครบ</li>
+    <li><strong>ปิดงวดอีกครั้ง</strong> — Banner หาย + บันทึก <code class="inline">PERIOD_CLOSED</code></li>
+    <li><strong>ผู้ใช้ที่ไม่ใช่ OWNER กดเปิดงวด</strong> — ระบบ block (403 Forbidden)</li>
+  </ul>
+</section>
+
+<!-- ============================================================ -->
+<!-- SECTION 4: SETTINGS 5-TAB -->
+<!-- ============================================================ -->
+<section id="sect-4">
+  <h2><span class="badge-section">4</span>Settings 5-Tab — การตั้งค่าระบบ<span class="status-flag flag-new">โครงสร้างใหม่</span></h2>
+
+  <p>หน้า <code class="inline">/settings</code> ถูกจัดใหม่เป็น <strong>5 แท็บการเงิน</strong> สำหรับ OWNER (คนอื่นเข้าไม่ได้) — แท็บฝ่ายปฏิบัติการ (Stickers, Collections, ทั่วไป) ย้ายไป route แยก</p>
+
+  <h3>โครงสร้าง 5 Tabs</h3>
+  <table class="api-table">
+    <thead><tr><th>Tab</th><th>URL</th><th>เนื้อหา</th><th>SystemConfig keys</th></tr></thead>
+    <tbody>
+      <tr><td><strong>บริษัท</strong></td><td class="path">/settings#company</td><td>ข้อมูลนิติบุคคล, ลายเซ็น, ที่อยู่, เลข VAT</td><td><code class="inline">company_*</code>, <code class="inline">lessor_*</code></td></tr>
+      <tr><td><strong>VAT</strong> <span class="status-flag flag-new">ใหม่</span></td><td class="path">/settings#vat</td><td>อัตรา VAT (default 7%) + ราคา exclusive/inclusive</td><td><code class="inline">VAT_RATE</code>, <code class="inline">VAT_PRICE_TYPE_DEFAULT</code></td></tr>
+      <tr><td><strong>งวดบัญชี</strong></td><td class="path">/settings#periods</td><td>ตารางงวด + ปุ่มปิด/เปิดงวด (ย้ายจาก <code class="inline">/accounting/periods</code>)</td><td>—</td></tr>
+      <tr><td><strong>เอกสารแนบ</strong> <span class="status-flag flag-new">ใหม่</span></td><td class="path">/settings#attachment</td><td>ยอดที่ต้องบังคับแนบเอกสาร + ประเภทไฟล์ที่อนุญาต</td><td><code class="inline">ATTACHMENT_REQUIRED_ABOVE_AMOUNT</code>, <code class="inline">ATTACHMENT_ALLOWED_TYPES</code></td></tr>
+      <tr><td><strong>ผู้ใช้งาน</strong></td><td class="path">/settings#users</td><td>Maker-Checker Toggle + link ไปหน้า /users</td><td>—</td></tr>
+    </tbody>
+  </table>
+
+  <h3>ค่าตั้งต้น (Seed Values)</h3>
+  <ul>
+    <li><code class="inline">VAT_RATE</code> = <strong>7</strong> (เปอร์เซ็นต์)</li>
+    <li><code class="inline">VAT_PRICE_TYPE_DEFAULT</code> = <strong>exclusive</strong> (ราคาไม่รวม VAT)</li>
+    <li><code class="inline">ATTACHMENT_REQUIRED_ABOVE_AMOUNT</code> = <strong>0</strong> (0 = ไม่บังคับ ; > 0 = บังคับแนบเมื่อยอดเกิน)</li>
+    <li><code class="inline">ATTACHMENT_ALLOWED_TYPES</code> = <strong>PDF, JPG, PNG</strong></li>
+  </ul>
+
+  <h3>Routes ที่ย้ายไปแยก</h3>
+  <table class="api-table">
+    <thead><tr><th>เดิม</th><th>ใหม่</th><th>หมายเหตุ</th></tr></thead>
+    <tbody>
+      <tr><td>SettingsPage tab "Stickers"</td><td class="path">/settings/stickers</td><td>StickerSettings (ค่าเริ่มต้นสติกเกอร์)</td></tr>
+      <tr><td>SettingsPage tab "Collections"</td><td class="path">/settings/collections</td><td>CollectionsConfigCard (auto-assign, session)</td></tr>
+      <tr><td>SettingsPage tab "ทั่วไป" pre+post</td><td class="path">/settings/general</td><td>ค่าปรับ, PDPA, ธนาคาร, payment_link</td></tr>
+      <tr><td class="path">/accounting/periods</td><td>→ <code class="inline">/settings#periods</code></td><td>301 redirect (preserve hash via window.location.replace)</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout info">
+    <p><strong>Bookmark เดิมยังทำงานได้:</strong> URL <code class="inline">/accounting/periods</code> ที่ฝ่ายบัญชีอาจ bookmark ไว้ — ระบบ redirect ไป <code class="inline">/settings#periods</code> ให้อัตโนมัติ</p>
+  </div>
+
+  <h3>สิ่งที่ฝ่ายบัญชีต้องตรวจ (Settings)</h3>
+  <ul class="check-list">
+    <li><strong>OWNER เข้า /settings</strong> — เห็น 5 แท็บครบตามลำดับ</li>
+    <li><strong>ไม่ใช่ OWNER เข้า /settings</strong> — Redirect ไปหน้าหลัก (/) อัตโนมัติ</li>
+    <li><strong>กด tab "VAT"</strong> — แก้อัตรา VAT ได้ + บันทึกได้</li>
+    <li><strong>กด tab "เอกสารแนบ"</strong> — ตั้งค่ายอดที่ต้องบังคับแนบได้</li>
+    <li><strong>กด tab "งวดบัญชี"</strong> — ใช้งานเหมือนหน้า /accounting/periods เดิม (ปิด/เปิดงวด)</li>
+    <li><strong>กด tab "ผู้ใช้งาน"</strong> — เห็น Maker-Checker Toggle (ตามข้อ 2)</li>
+    <li><strong>เปิด URL /accounting/periods</strong> — redirect ไป /settings#periods ทันที</li>
+    <li><strong>Bookmark URL พร้อม hash</strong> — <code class="inline">/settings#vat</code> เปิดมาแล้วต้องอยู่ที่ tab VAT</li>
+    <li><strong>กดปุ่ม Back ของ browser</strong> — tab เปลี่ยนตาม</li>
+  </ul>
+</section>
+
+<!-- ============================================================ -->
+<!-- SECTION 5: PAGINATION -->
+<!-- ============================================================ -->
+<section id="sect-5">
+  <h2><span class="badge-section">5</span>Pagination — แบ่งหน้ารายการ<span class="status-flag flag-new">ทุก List page</span></h2>
+
+  <p>ทุกหน้าที่แสดงรายการ (OtherIncome, Pending Approval, Expenses, Audit Logs) ตอนนี้แบ่งหน้าผ่าน <strong>URL parameters</strong> — bookmark ได้, share ลิงก์หน้าที่ตรวจไว้ได้, refresh แล้วยังอยู่หน้าเดิม</p>
+
+  <h3>UI Component</h3>
+  <p>ทุกหน้ามี PaginationBar เดียวกัน:</p>
+  <div class="mock">แสดง 1-50 จาก 247 รายการ          [« First] [‹ Prev] 1 2 <strong>3</strong> 4 5 [Next ›] [Last »]    [ไปหน้า: ___]    แสดงต่อหน้า: [50 ▾]</div>
+
+  <h3>Default Page Size</h3>
+  <table class="api-table">
+    <thead><tr><th>หน้า</th><th>Default size</th><th>เรียงลำดับ</th></tr></thead>
+    <tbody>
+      <tr><td>OtherIncome List (ปกติ)</td><td>50</td><td><code class="inline">createdAt DESC</code></td></tr>
+      <tr><td>OtherIncome List (filter = READY)</td><td>50</td><td><code class="inline">createdAt ASC</code> (เก่าก่อน)</td></tr>
+      <tr><td>Pending Approval</td><td>50</td><td><code class="inline">createdAt ASC</code></td></tr>
+      <tr><td>Expenses</td><td>50 (เดิม 20)</td><td><code class="inline">createdAt DESC</code></td></tr>
+      <tr><td>Audit Logs</td><td>100 (เดิม 25)</td><td><code class="inline">eventAt DESC</code></td></tr>
+    </tbody>
+  </table>
+
+  <h3>URL Parameters</h3>
+  <ul>
+    <li><code class="inline">?page=3</code> — ไปหน้าที่ 3</li>
+    <li><code class="inline">?size=100</code> — เปลี่ยนจำนวนต่อหน้าเป็น 100 (และ reset page ไป 1)</li>
+    <li>ตัวอย่าง: <code class="inline">/other-income?page=5&amp;size=50&amp;status=POSTED</code></li>
+  </ul>
+
+  <h3>สิ่งที่ฝ่ายบัญชีต้องตรวจ (Pagination)</h3>
+  <ul class="check-list">
+    <li><strong>เปิด /other-income</strong> — เห็น PaginationBar พร้อม "แสดง X-Y จาก Z รายการ"</li>
+    <li><strong>กด Next</strong> — URL เปลี่ยนเป็น <code class="inline">?page=2</code></li>
+    <li><strong>เปลี่ยน size เป็น 100</strong> — URL update + page reset ไป 1</li>
+    <li><strong>พิมพ์ "ไปหน้า 5" + Enter</strong> — ไปหน้า 5 ทันที</li>
+    <li><strong>Refresh browser</strong> — อยู่หน้าเดิม (URL state)</li>
+    <li><strong>กรอง filter (เช่น status)</strong> — page reset ไป 1 อัตโนมัติ</li>
+    <li><strong>เปลี่ยน filter เป็น READY</strong> — เรียงตามเก่าก่อน (ผู้รอ approve นานสุดอยู่บนสุด)</li>
+  </ul>
+</section>
+
+<!-- ============================================================ -->
+<!-- SECTION AUDIT LOG OVERVIEW -->
+<!-- ============================================================ -->
+<section id="sect-audit">
+  <h2><span class="badge-section">A</span>Audit Log — รายการที่ระบบจะบันทึก</h2>
+
+  <p>การกระทำที่มีผลต่อระบบบัญชีในเวอร์ชัน v2.2 ที่ระบบจะ <strong>บันทึก audit log อัตโนมัติทุกครั้ง</strong> (immutable + hash-chained):</p>
+
+  <table class="api-table">
+    <thead><tr><th>Action String</th><th>เมื่อไร</th><th>Entity</th><th>ข้อมูลที่บันทึก</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><code class="inline">JV_OVERRIDDEN</code></td>
+        <td>POST เอกสาร Other Income ด้วย override</td>
+        <td><code class="inline">other_income</code></td>
+        <td>oldValue = JE auto / newValue = JE override + diffSummary ภาษาไทย</td>
+      </tr>
+      <tr>
+        <td><code class="inline">CONFIG_CHANGED</code></td>
+        <td>OWNER toggle Maker-Checker</td>
+        <td><code class="inline">system_config</code></td>
+        <td>oldValue = ค่าเดิม / newValue = ค่าใหม่</td>
+      </tr>
+      <tr>
+        <td><code class="inline">PERIOD_REOPENED</code></td>
+        <td>OWNER เปิดงวดที่ปิดแล้ว</td>
+        <td><code class="inline">accounting_period</code></td>
+        <td>newValue = { reasonType, reason, taxFiled, reopenedAt }</td>
+      </tr>
+      <tr>
+        <td><code class="inline">PERIOD_CLOSED</code></td>
+        <td>OWNER/ACCOUNTANT ปิดงวด</td>
+        <td><code class="inline">accounting_period</code></td>
+        <td>newValue = { closedAt }</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout info">
+    <p><strong>Audit log Properties (ทุก record):</strong> userId (FK ไป User), action (string), entity (lowercase), entityId, oldValue (JSON), newValue (JSON), ipAddress, createdAt, rowHash (sha256 chain)</p>
+  </div>
+
+  <h3>คำสั่ง SQL สำหรับฝ่ายบัญชีตรวจประวัติย้อนหลัง</h3>
+  <div class="mock"><span class="com">-- รายการ Override JV ในเดือนนี้</span>
+SELECT created_at, user_id, entity_id, new_value->'diffSummary' as diff
+FROM audit_logs
+WHERE action = 'JV_OVERRIDDEN'
+  AND created_at >= '2026-05-01'
+ORDER BY created_at DESC;
+
+<span class="com">-- ประวัติการเปิดงวด</span>
+SELECT created_at, user_id, entity_id, new_value
+FROM audit_logs
+WHERE action IN ('PERIOD_REOPENED', 'PERIOD_CLOSED')
+ORDER BY created_at DESC;
+
+<span class="com">-- ประวัติการเปิด/ปิด Maker-Checker</span>
+SELECT created_at, user_id, old_value, new_value
+FROM audit_logs
+WHERE action = 'CONFIG_CHANGED'
+  AND entity_id = 'OTHER_INCOME_MAKER_CHECKER_ENABLED'
+ORDER BY created_at DESC;</div>
+</section>
+
+<!-- ============================================================ -->
+<!-- FINAL CHECKLIST -->
+<!-- ============================================================ -->
+<section id="sect-checklist">
+  <h2><span class="badge-section">✓</span>Checklist สุดท้าย — ฝ่ายบัญชี Sign-off</h2>
+
+  <p>ก่อนกด <strong>"อนุมัติให้ go-live"</strong> ฝ่ายบัญชีกรุณาตรวจรายการต่อไปนี้ครบทุกข้อ:</p>
+
+  <h3>ก. การทดสอบ Workflow (Manual UAT)</h3>
+  <ul class="check-list">
+    <li><strong>Override JV</strong> — ทดสอบ V1/V2/V5 ครบ 3 errors + POST สำเร็จ 1 เคส + ตรวจ ✏ marker + ตรวจ audit log diff</li>
+    <li><strong>Maker-Checker</strong> — OWNER toggle ON→OFF + ตรวจจำนวน READY ที่แสดง + ตรวจ audit log</li>
+    <li><strong>Reopen Period</strong> — เปิดงวดด้วยเหตุผล 4 ประเภท + ตรวจ Banner + ตรวจ audit log + ปิดงวดอีกครั้ง</li>
+    <li><strong>Settings 5 Tabs</strong> — เปิดทุก tab + แก้ VAT rate + แก้ attachment threshold + ทดสอบ <code class="inline">/accounting/periods</code> redirect</li>
+    <li><strong>Pagination</strong> — ทดสอบ Next/Prev/Jump-to-page + เปลี่ยน size + refresh ยังอยู่หน้าเดิม</li>
+  </ul>
+
+  <h3>ข. การตรวจสอบความปลอดภัย</h3>
+  <ul class="check-list">
+    <li><strong>ผู้ใช้ไม่ใช่ OWNER</strong> — เข้า /settings ไม่ได้ (redirect ไปหน้าหลัก)</li>
+    <li><strong>ผู้ใช้ไม่ใช่ OWNER</strong> — กด Maker-Checker Toggle ไม่ได้ (disabled)</li>
+    <li><strong>ผู้ใช้ไม่ใช่ OWNER</strong> — เปิดงวด (POST /expenses/periods/reopen) ไม่ได้ (403)</li>
+    <li><strong>Override JV requires confirmation</strong> — ติ๊ก checkbox "ฉันเข้าใจ..." ก่อนถึงจะกด "เปิดโหมดแก้ไข" ได้</li>
+  </ul>
+
+  <h3>ค. การตรวจสอบ Audit Trail</h3>
+  <ul class="check-list">
+    <li><strong>JV_OVERRIDDEN audit</strong> — มี oldValue (auto JE) + newValue (override + diff)</li>
+    <li><strong>CONFIG_CHANGED audit</strong> — มี oldValue + newValue ของ Maker-Checker flag</li>
+    <li><strong>PERIOD_REOPENED audit</strong> — มี reasonType + reason + taxFiled + reopenedAt</li>
+    <li><strong>PERIOD_CLOSED audit</strong> — มี closedAt</li>
+    <li><strong>ทุก audit เก็บ userId จริงและ ipAddress</strong> — ไม่ใช่ NULL หรือ "system"</li>
+  </ul>
+
+  <h3>ง. การตรวจสอบ Data Integrity</h3>
+  <ul class="check-list">
+    <li><strong>Override JV เอกสาร</strong> — ค่า isOverridden ใน DB = true (persist ถาวร)</li>
+    <li><strong>Reopened Period</strong> — ค่า reopenReason + taxFiled ใน DB ครบ</li>
+    <li><strong>Migration applied</strong> — รัน <code class="inline">prisma migrate deploy</code> สำเร็จ (3 migrations: pagination indexes, reopen metadata, seed PR3 keys)</li>
+    <li><strong>SystemConfig seed</strong> — มี 4 keys ใหม่ใน DB (VAT_RATE, VAT_PRICE_TYPE_DEFAULT, ATTACHMENT_REQUIRED_ABOVE_AMOUNT, ATTACHMENT_ALLOWED_TYPES)</li>
+  </ul>
+
+  <h3>จ. การ Sign-off</h3>
+  <table class="api-table">
+    <tbody>
+      <tr><td><strong>ฝ่ายบัญชีผู้ตรวจ</strong></td><td>______________________________</td><td>วันที่: __________</td></tr>
+      <tr><td><strong>เจ้าของกิจการ (OWNER)</strong></td><td>______________________________</td><td>วันที่: __________</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout success">
+    <p><strong>หากตรวจครบทุกข้อแล้ว</strong> — สามารถ Merge PR <a href="https://github.com/iamnaii/BESTCHOICE/pull/827">#827</a> ลง main ได้ ซึ่งจะ trigger auto-deploy ไป production ผ่าน GitHub Actions</p>
+  </div>
+</section>
+
+<div class="footer">
+  <p>เอกสารนี้สร้างเมื่อ 13 พฤษภาคม 2569 · BESTCHOICE FINANCE</p>
+  <p>เพื่อตรวจสอบโค้ดดู <a href="https://github.com/iamnaii/BESTCHOICE/pull/827">PR #827</a> · ข้อมูลทางเทคนิคดู <code>docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md</code></p>
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-13-other-income-v2-2-pr2-maker-checker-reopen.md
+++ b/docs/superpowers/plans/2026-05-13-other-income-v2-2-pr2-maker-checker-reopen.md
@@ -1,0 +1,1335 @@
+# Other Income v2.2 PR-2 — Maker-Checker Toggle UI + Reopen Period Workflow
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task with **3-4 review rounds per task** per owner preference (`feedback_review_thoroughness`).
+
+**Goal:** Implement Sprint 2 from PDF v2.2 — Maker-Checker toggle UI + Reopen Period workflow with structured reasons + banner + audit events.
+
+**Architecture:** Backend adds two thin endpoints (toggle + pending-count) + extends `reopenPeriod()` to capture reason metadata + emits `CONFIG_CHANGED`, `PERIOD_REOPENED`, `PERIOD_CLOSED` audit strings. Frontend adds a `MakerCheckerToggle` card with OFF↔ON confirmation dialogs (read pending count when turning OFF), a `ReopenPeriodModal` with required reason taxonomy, and a `ReopenedPeriodBanner` installed on list pages.
+
+**Tech Stack:** NestJS + Prisma + React 18 + Vite + react-router v7 + @tanstack/react-query + shadcn/ui + Tailwind + vitest + jest + Playwright.
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md`](../specs/2026-05-13-other-income-v2-2-design.md) §4 (Sprint 2).
+
+**Codebase facts verified from PR-1 survey:**
+- `AuditLog.action` is `String` — no enum migration for new actions.
+- `OTHER_INCOME_MAKER_CHECKER_ENABLED` SystemConfig key exists; controller has `@Get('maker-checker-enabled')` at [other-income.controller.ts:62](../../../apps/api/src/modules/other-income/other-income.controller.ts#L62) + tests pass.
+- `AccountingPeriod` has `reopenedAt`, `reopenedById`, `reopenedBy` relation at [schema.prisma:5076-5078](../../../apps/api/prisma/schema.prisma#L5076-L5078).
+- `reopenPeriod()` service method exists at [monthly-close.service.ts:308+](../../../apps/api/src/modules/accounting/monthly-close.service.ts#L308); 90-day lock validation present.
+- `PeriodClosePage` UI exists at [apps/web/src/pages/accounting/PeriodClosePage.tsx](../../../apps/web/src/pages/accounting/PeriodClosePage.tsx) with reopen mutation.
+- `AuditService.log()` API: `{ userId, action, entity, entityId, oldValue, newValue, ipAddress, userAgent }` — store extra context in `newValue`.
+
+---
+
+## File Structure
+
+### Backend (create)
+- `apps/api/src/modules/system-config/system-config.controller.ts` — verify exists; if not, create with `Put('/maker-checker')` + `Get('/maker-checker/pending-ready-count')`. If `SystemConfigModule` doesn't exist, create minimally.
+- `apps/api/src/modules/system-config/system-config.service.ts` — verify exists; provides `get(key)` and `set(key, value)`. Create if missing.
+- `apps/api/src/modules/accounting/dto/reopen-period.dto.ts` — `ReopenPeriodDto` with `reasonType`, `reason`, `taxFiled`.
+
+### Backend (modify)
+- `apps/api/prisma/schema.prisma` — add `reopenReason String?` + `taxFiled Boolean?` to `AccountingPeriod`.
+- `apps/api/src/modules/accounting/monthly-close.service.ts` — extend `reopenPeriod()` to accept new DTO, persist `reopenReason` + `taxFiled`, write `PERIOD_REOPENED` audit; extend close to emit `PERIOD_CLOSED` audit.
+- `apps/api/src/modules/accounting/accounting.controller.ts` — change `reopen` endpoint to accept `ReopenPeriodDto` body; add `GET /accounting/periods/reopened` endpoint.
+- `apps/api/src/modules/accounting/accounting.service.ts` (or `monthly-close.service.ts`) — add `listReopenedPeriods()` method.
+
+### Frontend (create)
+- `apps/web/src/pages/SettingsPage/components/MakerCheckerToggle.tsx` — Switch card + confirmation dialog wrapper.
+- `apps/web/src/pages/SettingsPage/components/MakerCheckerConfirmDialog.tsx` — OFF↔ON confirmation modal.
+- `apps/web/src/pages/SettingsPage/components/__tests__/MakerCheckerToggle.test.tsx`
+- `apps/web/src/pages/SettingsPage/components/__tests__/MakerCheckerConfirmDialog.test.tsx`
+- `apps/web/src/pages/accounting/components/ReopenPeriodModal.tsx`
+- `apps/web/src/pages/accounting/components/__tests__/ReopenPeriodModal.test.tsx`
+- `apps/web/src/components/accounting/ReopenedPeriodBanner.tsx`
+- `apps/web/src/components/accounting/__tests__/ReopenedPeriodBanner.test.tsx`
+
+### Frontend (modify)
+- `apps/web/src/pages/SettingsPage/index.tsx` — install `<MakerCheckerToggle />` (Sprint 2 puts it in the current SettingsPage; Sprint 3 will migrate to `#users` tab).
+- `apps/web/src/pages/accounting/PeriodClosePage.tsx` — wire `<ReopenPeriodModal>` into the existing reopen mutation flow.
+- `apps/web/src/pages/other-income/OtherIncomeListPage.tsx` — install `<ReopenedPeriodBanner />` at top.
+- `apps/web/src/pages/ExpensesPage.tsx` — install `<ReopenedPeriodBanner />` at top.
+
+### Migration
+- `apps/api/prisma/migrations/<timestamp>_add_reopen_metadata_and_audit_actions/migration.sql` — add `reopen_reason` + `tax_filed` columns to `accounting_periods`.
+
+---
+
+## Task 1: Schema additions for AccountingPeriod
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma`
+- Create: `apps/api/prisma/migrations/<timestamp>_add_reopen_metadata/migration.sql`
+
+- [ ] **Step 1: Locate `AccountingPeriod` model in schema**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+awk '/^model AccountingPeriod /,/^}/' apps/api/prisma/schema.prisma
+```
+
+Note the existing fields including `reopenedAt`, `reopenedById`, `reopenedBy User?`. The new fields go in the same block.
+
+- [ ] **Step 2: Add `reopenReason` and `taxFiled` columns**
+
+In the `AccountingPeriod` model, after `reopenedBy User? @relation(...)` line, add:
+
+```prisma
+  reopenReason String?  @map("reopen_reason")
+  taxFiled     Boolean? @map("tax_filed")
+```
+
+- [ ] **Step 3: Create idempotent SQL migration**
+
+```bash
+TS=$(date -u +%Y%m%d%H%M%S)
+mkdir -p apps/api/prisma/migrations/${TS}_add_reopen_metadata
+cat > apps/api/prisma/migrations/${TS}_add_reopen_metadata/migration.sql <<'EOF'
+-- AlterTable
+ALTER TABLE "accounting_periods"
+  ADD COLUMN IF NOT EXISTS "reopen_reason" TEXT,
+  ADD COLUMN IF NOT EXISTS "tax_filed"     BOOLEAN;
+EOF
+```
+
+Use the actual `@@map` table name — verify by `grep '@@map' apps/api/prisma/schema.prisma | grep -i accounting_period`.
+
+- [ ] **Step 4: Verify schema validity**
+
+```bash
+cd apps/api && npx prisma generate
+```
+
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "$(cat <<'EOF'
+feat(accounting): add reopenReason + taxFiled to AccountingPeriod
+
+Required for Reopen Period workflow (PDF v2.2 Sprint 2 Task 3).
+Idempotent CREATE … IF NOT EXISTS so re-runs are safe.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2
+EOF
+)"
+```
+
+---
+
+## Task 2: ReopenPeriodDto
+
+**Files:**
+- Create: `apps/api/src/modules/accounting/dto/reopen-period.dto.ts`
+
+- [ ] **Step 1: Create DTO with validation**
+
+```ts
+import { IsBoolean, IsEnum, IsString, MinLength } from 'class-validator';
+
+export enum ReopenReasonType {
+  WRONG_ENTRY = 'WRONG_ENTRY',
+  MISSED_RECORD = 'MISSED_RECORD',
+  AUDITOR_REQUEST = 'AUDITOR_REQUEST',
+  OTHER = 'OTHER',
+}
+
+export class ReopenPeriodDto {
+  @IsEnum(ReopenReasonType, { message: 'reasonType ต้องเป็นหนึ่งใน WRONG_ENTRY, MISSED_RECORD, AUDITOR_REQUEST, OTHER' })
+  reasonType!: ReopenReasonType;
+
+  @IsString({ message: 'reason ต้องเป็นข้อความ' })
+  @MinLength(10, { message: 'reason ต้องระบุอย่างน้อย 10 ตัวอักษร' })
+  reason!: string;
+
+  @IsBoolean({ message: 'taxFiled ต้องเป็น boolean (true/false)' })
+  taxFiled!: boolean;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+./tools/check-types.sh api
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/modules/accounting/dto/reopen-period.dto.ts
+git commit -m "feat(accounting): ReopenPeriodDto — required reason taxonomy + note + taxFiled
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2"
+```
+
+---
+
+## Task 3: Extend reopenPeriod() service + audit emit
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/monthly-close.service.ts`
+- Modify: `apps/api/src/modules/accounting/accounting.controller.ts`
+
+- [ ] **Step 1: Inspect existing `reopenPeriod()` signature**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+grep -n "reopenPeriod\|closePeriod\|@Post.*reopen" apps/api/src/modules/accounting/monthly-close.service.ts apps/api/src/modules/accounting/accounting.controller.ts | head -10
+```
+
+Note the current signature. Likely something like `reopenPeriod(period: string, userId: string)`.
+
+- [ ] **Step 2: Extend service signature + audit**
+
+In `monthly-close.service.ts`:
+
+```ts
+import { ReopenPeriodDto } from './dto/reopen-period.dto';
+import { AuditService } from '../audit/audit.service';
+
+// Inject AuditService in constructor:
+// constructor(private prisma: PrismaService, private audit: AuditService, ...) {}
+
+async reopenPeriod(period: string, dto: ReopenPeriodDto, actorId: string, ipAddress?: string) {
+  // ... existing 90-day lock check + status update logic — KEEP ...
+
+  // After existing update, ADD reason + taxFiled fields:
+  await this.prisma.accountingPeriod.update({
+    where: { period },
+    data: {
+      reopenReason: `${dto.reasonType}: ${dto.reason}`,
+      taxFiled: dto.taxFiled,
+    },
+  });
+
+  // Audit emit (try/catch + Sentry like other-income post()):
+  try {
+    await this.audit.log({
+      userId: actorId,
+      action: 'PERIOD_REOPENED',
+      entity: 'accounting_period',
+      entityId: period,
+      newValue: {
+        reasonType: dto.reasonType,
+        reason: dto.reason,
+        taxFiled: dto.taxFiled,
+        reopenedAt: new Date().toISOString(),
+      },
+      ipAddress,
+    });
+  } catch (err) {
+    // Don't roll back the reopen — audit is best-effort
+    // Sentry import: import * as Sentry from '@sentry/nestjs';
+    Sentry.captureException(err, {
+      tags: { module: 'accounting', action: 'PERIOD_REOPENED' },
+      extra: { period, actorId },
+    });
+  }
+}
+```
+
+Similarly extend `closePeriod()` to emit `PERIOD_CLOSED` audit (or wherever the close logic lives — check first):
+
+```ts
+async closePeriod(period: string, actorId: string, ipAddress?: string) {
+  // ... existing close logic ...
+  try {
+    await this.audit.log({
+      userId: actorId,
+      action: 'PERIOD_CLOSED',
+      entity: 'accounting_period',
+      entityId: period,
+      newValue: { closedAt: new Date().toISOString() },
+      ipAddress,
+    });
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { module: 'accounting', action: 'PERIOD_CLOSED' },
+      extra: { period, actorId },
+    });
+  }
+}
+```
+
+- [ ] **Step 3: Update controller**
+
+In `accounting.controller.ts`, find the reopen endpoint and change to accept body:
+
+```ts
+import { ReopenPeriodDto } from './dto/reopen-period.dto';
+
+@Post('periods/:period/reopen')
+@Roles('OWNER')
+async reopen(
+  @Param('period') period: string,
+  @Body() dto: ReopenPeriodDto,
+  @CurrentUser('id') userId: string,
+  @Req() req: Request,
+) {
+  return this.monthlyCloseService.reopenPeriod(period, dto, userId, req.ip);
+}
+```
+
+Adjust `@CurrentUser` / `@Req` decorators to match existing patterns in the file.
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+./tools/check-types.sh api
+git add apps/api/src/modules/accounting/monthly-close.service.ts apps/api/src/modules/accounting/accounting.controller.ts
+git commit -m "$(cat <<'EOF'
+feat(accounting): extend reopenPeriod with reason taxonomy + audit
+
+- reopenPeriod() accepts ReopenPeriodDto, persists reopenReason + taxFiled
+- emits PERIOD_REOPENED audit string (oldValue=null, newValue={reasonType, reason, taxFiled, reopenedAt})
+- closePeriod() emits PERIOD_CLOSED audit
+- Both audit writes wrapped try/catch + Sentry (best-effort, don't roll back the state change)
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2
+EOF
+)"
+```
+
+---
+
+## Task 4: GET /accounting/periods/reopened endpoint
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/monthly-close.service.ts`
+- Modify: `apps/api/src/modules/accounting/accounting.controller.ts`
+
+- [ ] **Step 1: Add service method**
+
+In `monthly-close.service.ts`:
+
+```ts
+async listReopenedPeriods() {
+  return this.prisma.accountingPeriod.findMany({
+    where: {
+      reopenedAt: { not: null },
+      // Currently reopened = reopenedAt exists AND status is OPEN
+      status: 'OPEN',
+    },
+    include: {
+      reopenedBy: { select: { id: true, name: true } },
+    },
+    orderBy: { period: 'desc' },
+  });
+}
+```
+
+If `AccountingPeriod.status` enum doesn't have `OPEN` literal, use whatever the actual literal is (`OPEN`, `ACTIVE`, etc.) — verify via grep.
+
+- [ ] **Step 2: Add controller endpoint**
+
+```ts
+@Get('periods/reopened')
+@Roles('OWNER', 'ACCOUNTANT', 'FINANCE_MANAGER')
+async getReopenedPeriods() {
+  return this.monthlyCloseService.listReopenedPeriods();
+}
+```
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+./tools/check-types.sh api
+git add apps/api/src/modules/accounting/monthly-close.service.ts apps/api/src/modules/accounting/accounting.controller.ts
+git commit -m "feat(accounting): GET /periods/reopened — list currently-reopened periods
+
+Used by ReopenedPeriodBanner on list pages.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2"
+```
+
+---
+
+## Task 5: SystemConfigController endpoints (maker-checker toggle + pending count)
+
+**Files:**
+- Verify or create: `apps/api/src/modules/system-config/system-config.controller.ts`
+- Verify or create: `apps/api/src/modules/system-config/system-config.service.ts`
+- Verify or create: `apps/api/src/modules/system-config/system-config.module.ts`
+
+- [ ] **Step 1: Verify existing module structure**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+ls apps/api/src/modules/system-config/ 2>/dev/null
+# If not present:
+grep -rn "OTHER_INCOME_MAKER_CHECKER_ENABLED\|SystemConfig.*update\|SystemConfig.*upsert" apps/api/src | head -10
+```
+
+If `SystemConfigModule` exists, use it. If not, the value is likely managed via a generic config service or directly on Prisma — locate where `OTHER_INCOME_MAKER_CHECKER_ENABLED` is currently READ from (it's used by `OtherIncomeService`).
+
+- [ ] **Step 2: Add PUT toggle endpoint**
+
+Add to the appropriate controller (or create `system-config.controller.ts` if module exists but no controller):
+
+```ts
+@Put('/maker-checker')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('OWNER')
+async toggleMakerChecker(
+  @Body() dto: { enabled: boolean },
+  @CurrentUser('id') actorId: string,
+  @Req() req: Request,
+) {
+  const key = 'OTHER_INCOME_MAKER_CHECKER_ENABLED';
+  const oldValue = await this.prisma.systemConfig.findUnique({ where: { key } });
+
+  await this.prisma.systemConfig.upsert({
+    where: { key },
+    update: { value: String(dto.enabled) },
+    create: { key, value: String(dto.enabled), description: 'Other Income Maker-Checker toggle' },
+  });
+
+  try {
+    await this.audit.log({
+      userId: actorId,
+      action: 'CONFIG_CHANGED',
+      entity: 'system_config',
+      entityId: key,
+      oldValue: { value: oldValue?.value ?? null },
+      newValue: { value: String(dto.enabled) },
+      ipAddress: req.ip,
+    });
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { module: 'system-config', action: 'CONFIG_CHANGED' },
+      extra: { key, actorId },
+    });
+  }
+
+  return { success: true, enabled: dto.enabled };
+}
+```
+
+- [ ] **Step 3: Add pending-count endpoint**
+
+```ts
+@Get('/maker-checker/pending-ready-count')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('OWNER')
+async pendingReadyCount() {
+  const count = await this.prisma.otherIncome.count({
+    where: { status: 'READY', deletedAt: null },
+  });
+  return { count };
+}
+```
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+./tools/check-types.sh api
+git add apps/api/src/modules/system-config/
+git commit -m "$(cat <<'EOF'
+feat(system-config): PUT /maker-checker + GET /maker-checker/pending-ready-count
+
+- PUT toggles OTHER_INCOME_MAKER_CHECKER_ENABLED (OWNER-only) + emits CONFIG_CHANGED audit
+- GET returns count of READY other-income docs (used by OFF→ON confirmation dialog)
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.1
+EOF
+)"
+```
+
+---
+
+## Task 6: MakerCheckerConfirmDialog component
+
+**Files:**
+- Create: `apps/web/src/pages/SettingsPage/components/MakerCheckerConfirmDialog.tsx`
+- Create: `apps/web/src/pages/SettingsPage/components/__tests__/MakerCheckerConfirmDialog.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MakerCheckerConfirmDialog } from '../MakerCheckerConfirmDialog';
+
+describe('MakerCheckerConfirmDialog', () => {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+
+  beforeEach(() => {
+    onConfirm.mockClear();
+    onCancel.mockClear();
+  });
+
+  it('does not render when open=false', () => {
+    render(
+      <MakerCheckerConfirmDialog open={false} nextValue={true} pendingReadyCount={0} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+    expect(screen.queryByText(/Maker-Checker/)).not.toBeInTheDocument();
+  });
+
+  it('OFF→ON: shows enable impacts + requires ack', () => {
+    render(
+      <MakerCheckerConfirmDialog open={true} nextValue={true} pendingReadyCount={0} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+    expect(screen.getByText(/เปิดระบบ Maker-Checker/)).toBeInTheDocument();
+    expect(screen.getByText(/ต้องผ่านผู้อนุมัติ/)).toBeInTheDocument();
+    const confirmBtn = screen.getByRole('button', { name: /ยืนยันเปิด/ });
+    expect(confirmBtn).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('ON→OFF: shows disable impacts + pending count + requires ack', () => {
+    render(
+      <MakerCheckerConfirmDialog open={true} nextValue={false} pendingReadyCount={3} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+    expect(screen.getByText(/ปิดระบบ Maker-Checker/)).toBeInTheDocument();
+    expect(screen.getByText(/auto-approve/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 ฉบับ/)).toBeInTheDocument();
+    const confirmBtn = screen.getByRole('button', { name: /ยืนยันปิด/ });
+    expect(confirmBtn).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('calls onConfirm when confirm clicked', () => {
+    render(
+      <MakerCheckerConfirmDialog open={true} nextValue={true} pendingReadyCount={0} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /ยืนยันเปิด/ }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel clicked', () => {
+    render(
+      <MakerCheckerConfirmDialog open={true} nextValue={true} pendingReadyCount={0} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /ยกเลิก/ }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets acknowledgement on close', () => {
+    const { rerender } = render(
+      <MakerCheckerConfirmDialog open={true} nextValue={true} pendingReadyCount={0} onConfirm={onConfirm} onCancel={onCancel} />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    rerender(<MakerCheckerConfirmDialog open={false} nextValue={true} pendingReadyCount={0} onConfirm={onConfirm} onCancel={onCancel} />);
+    rerender(<MakerCheckerConfirmDialog open={true} nextValue={true} pendingReadyCount={0} onConfirm={onConfirm} onCancel={onCancel} />);
+    expect(screen.getByRole('button', { name: /ยืนยัน/ })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/web && npx vitest run src/pages/SettingsPage/components/__tests__/MakerCheckerConfirmDialog.test.tsx
+```
+
+- [ ] **Step 3: Implement component**
+
+```tsx
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { AlertTriangle } from 'lucide-react';
+
+type Props = {
+  open: boolean;
+  nextValue: boolean | null;       // true = OFF→ON, false = ON→OFF
+  pendingReadyCount: number;       // shown when ON→OFF
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function MakerCheckerConfirmDialog({ open, nextValue, pendingReadyCount, onConfirm, onCancel }: Props) {
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  useEffect(() => {
+    if (!open) setAcknowledged(false);
+  }, [open]);
+
+  const isEnabling = nextValue === true;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="w-5 h-5" />
+            {isEnabling ? 'คุณกำลังจะเปิดระบบ Maker-Checker' : 'คุณกำลังจะปิดระบบ Maker-Checker'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 text-sm">
+          <p className="font-semibold">ผลกระทบ:</p>
+          {isEnabling ? (
+            <ul className="space-y-1 list-disc list-inside text-muted-foreground">
+              <li>เอกสารทุกฉบับจะต้องผ่านผู้อนุมัติก่อน POST</li>
+              <li>เอกสาร DRAFT ปัจจุบันจะต้องส่งอนุมัติ</li>
+              <li>ผู้สร้าง ≠ ผู้อนุมัติ (segregation of duties)</li>
+            </ul>
+          ) : (
+            <>
+              <ul className="space-y-1 list-disc list-inside text-muted-foreground">
+                <li>เอกสารที่อยู่ในสถานะ READY จะถูก auto-approve</li>
+                <li>เอกสารใหม่จะ POST ทันที (ไม่ต้องอนุมัติ)</li>
+              </ul>
+              <p className="text-warning font-medium">
+                จำนวนเอกสาร READY ตอนนี้: {pendingReadyCount} ฉบับ
+              </p>
+            </>
+          )}
+
+          <div className="flex items-start gap-2 pt-2">
+            <Checkbox
+              id="mc-ack"
+              checked={acknowledged}
+              onCheckedChange={(v) => setAcknowledged(Boolean(v))}
+            />
+            <label htmlFor="mc-ack" className="text-sm cursor-pointer">
+              {isEnabling ? 'ฉันเข้าใจและยืนยันเปิดระบบ' : 'ฉันเข้าใจและยืนยันปิดระบบ'}
+            </label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>ยกเลิก</Button>
+          <Button onClick={onConfirm} disabled={!acknowledged}>
+            {isEnabling ? 'ยืนยันเปิด' : 'ยืนยันปิด'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npx vitest run src/pages/SettingsPage/components/__tests__/MakerCheckerConfirmDialog.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+git add apps/web/src/pages/SettingsPage/components/MakerCheckerConfirmDialog.tsx \
+        apps/web/src/pages/SettingsPage/components/__tests__/MakerCheckerConfirmDialog.test.tsx
+git commit -m "feat(settings): MakerCheckerConfirmDialog — OFF↔ON confirmation with ack checkbox
+
+ON→OFF shows pending READY count (passed from parent) so user knows
+how many docs will auto-approve. Resets ack on close.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.1"
+```
+
+---
+
+## Task 7: MakerCheckerToggle card
+
+**Files:**
+- Create: `apps/web/src/pages/SettingsPage/components/MakerCheckerToggle.tsx`
+- Create: `apps/web/src/lib/systemConfig.ts` (or extend `apps/web/src/lib/otherIncome.ts` if existing has `isMakerCheckerEnabled`)
+
+- [ ] **Step 1: Add API helpers**
+
+Locate the existing `isMakerCheckerEnabled` query helper:
+
+```bash
+grep -rn "isMakerCheckerEnabled\|maker-checker-enabled" apps/web/src/lib | head -5
+```
+
+Add two new helpers — `setMakerCheckerEnabled(enabled: boolean)` and `getPendingReadyCount()`:
+
+```ts
+// In existing systemConfig.ts or otherIncome.ts
+export const systemConfigApi = {
+  isMakerCheckerEnabled: () => api.get<{ enabled: boolean }>('/system-config/maker-checker').then((r) => r.data.enabled),
+  setMakerCheckerEnabled: (enabled: boolean) => api.put('/system-config/maker-checker', { enabled }),
+  getPendingReadyCount: () => api.get<{ count: number }>('/system-config/maker-checker/pending-ready-count').then((r) => r.data.count),
+};
+```
+
+(Adapt to existing api client patterns — `api.get/post/put` from `@/lib/api`.)
+
+- [ ] **Step 2: Implement MakerCheckerToggle component**
+
+```tsx
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { toast } from 'sonner';
+import { Info } from 'lucide-react';
+import { MakerCheckerConfirmDialog } from './MakerCheckerConfirmDialog';
+import { systemConfigApi } from '@/lib/systemConfig';
+
+export function MakerCheckerToggle() {
+  const { user } = useAuth();
+  const isOwner = user?.role === 'OWNER';
+  const queryClient = useQueryClient();
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [pendingNext, setPendingNext] = useState<boolean | null>(null);
+
+  const enabledQuery = useQuery({
+    queryKey: ['system-config', 'maker-checker'],
+    queryFn: () => systemConfigApi.isMakerCheckerEnabled(),
+  });
+
+  const pendingCountQuery = useQuery({
+    queryKey: ['system-config', 'maker-checker', 'pending-ready-count'],
+    queryFn: () => systemConfigApi.getPendingReadyCount(),
+    enabled: showConfirm && pendingNext === false, // only fetch when turning OFF
+  });
+
+  const mutation = useMutation({
+    mutationFn: (enabled: boolean) => systemConfigApi.setMakerCheckerEnabled(enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['system-config'] });
+      queryClient.invalidateQueries({ queryKey: ['other-income-maker-checker-enabled'] });
+      toast.success('บันทึกการตั้งค่าสำเร็จ');
+    },
+    onError: () => toast.error('ไม่สามารถบันทึกการตั้งค่าได้'),
+  });
+
+  const currentEnabled = enabledQuery.data ?? false;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>ระบบ Maker-Checker (ผู้สร้าง ≠ ผู้อนุมัติ)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-3">
+          <Switch
+            checked={currentEnabled}
+            onCheckedChange={(next) => {
+              if (!isOwner) return;
+              setPendingNext(next);
+              setShowConfirm(true);
+            }}
+            disabled={!isOwner || mutation.isPending}
+            aria-label="Toggle Maker-Checker"
+          />
+          <span className="text-sm font-medium">
+            {currentEnabled ? 'เปิดใช้งาน' : 'ปิดใช้งาน'}
+          </span>
+        </div>
+
+        {!isOwner && (
+          <p className="text-xs text-muted-foreground">เฉพาะ OWNER เท่านั้นที่เปลี่ยนได้</p>
+        )}
+
+        <div className="flex items-start gap-2 rounded-md bg-muted p-3">
+          <Info className="w-4 h-4 mt-0.5 text-muted-foreground shrink-0" />
+          <p className="text-xs text-muted-foreground">
+            เมื่อเปิด — เอกสารทุกฉบับต้องผ่านผู้อนุมัติก่อน POST (segregation of duties)
+          </p>
+        </div>
+
+        <MakerCheckerConfirmDialog
+          open={showConfirm}
+          nextValue={pendingNext}
+          pendingReadyCount={pendingCountQuery.data ?? 0}
+          onConfirm={() => {
+            mutation.mutate(pendingNext!);
+            setShowConfirm(false);
+            setPendingNext(null);
+          }}
+          onCancel={() => {
+            setShowConfirm(false);
+            setPendingNext(null);
+          }}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+./tools/check-types.sh web
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/SettingsPage/components/MakerCheckerToggle.tsx apps/web/src/lib/systemConfig.ts
+git commit -m "feat(settings): MakerCheckerToggle card — OWNER-only Switch with confirm dialog
+
+Reads pending READY count via separate query (only fetched when turning OFF).
+Invalidates both 'system-config' and 'other-income-maker-checker-enabled' caches.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.1"
+```
+
+---
+
+## Task 8: Install MakerCheckerToggle into SettingsPage
+
+**Files:**
+- Modify: `apps/web/src/pages/SettingsPage/index.tsx`
+
+- [ ] **Step 1: Read existing SettingsPage structure**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+sed -n '1,40p' apps/web/src/pages/SettingsPage/index.tsx
+```
+
+Note the current section/tab layout. Sprint 3 will restructure to 5 tabs; for Sprint 2, install the toggle into an appropriate existing tab/section.
+
+- [ ] **Step 2: Add the toggle in a fitting location**
+
+Import and render `<MakerCheckerToggle />` in the SettingsPage. Best location: alongside other "system behavior" cards (e.g., near SystemSettings or near user-related cards if any).
+
+```tsx
+import { MakerCheckerToggle } from './components/MakerCheckerToggle';
+
+// ... in the JSX, in an appropriate section:
+<MakerCheckerToggle />
+```
+
+- [ ] **Step 3: Type-check + smoke test**
+
+```bash
+./tools/check-types.sh web
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/SettingsPage/index.tsx
+git commit -m "feat(settings): install MakerCheckerToggle in current SettingsPage
+
+Sprint 3 will migrate this to /settings#users tab during Settings consolidation.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.1"
+```
+
+---
+
+## Task 9: ReopenPeriodModal component
+
+**Files:**
+- Create: `apps/web/src/pages/accounting/components/ReopenPeriodModal.tsx`
+- Create: `apps/web/src/pages/accounting/components/__tests__/ReopenPeriodModal.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ReopenPeriodModal } from '../ReopenPeriodModal';
+
+describe('ReopenPeriodModal', () => {
+  const props = (overrides = {}) => ({
+    open: true,
+    period: '2026-04',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  });
+
+  it('does not render when open=false', () => {
+    render(<ReopenPeriodModal {...props({ open: false })} />);
+    expect(screen.queryByText(/2026-04/)).not.toBeInTheDocument();
+  });
+
+  it('shows period in title', () => {
+    render(<ReopenPeriodModal {...props()} />);
+    expect(screen.getByText(/2026-04/)).toBeInTheDocument();
+  });
+
+  it('confirm button disabled until reasonType + reason + taxFiled all set', () => {
+    render(<ReopenPeriodModal {...props()} />);
+    const confirmBtn = screen.getByRole('button', { name: /ยืนยันเปิดงวด/ });
+    expect(confirmBtn).toBeDisabled();
+
+    // pick a reason
+    fireEvent.click(screen.getByLabelText(/พบเอกสารผิด/));
+    expect(confirmBtn).toBeDisabled(); // still need note + taxFiled
+
+    // type note (>= 10 chars)
+    fireEvent.change(screen.getByLabelText(/บันทึกรายละเอียด/), { target: { value: 'รายละเอียดเพิ่มเติม' } });
+    expect(confirmBtn).toBeDisabled(); // still need taxFiled
+
+    // pick taxFiled
+    fireEvent.click(screen.getByLabelText(/ใช่ — ต้องยื่นแก้ไข/));
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it('calls onConfirm with payload when submitted', () => {
+    const onConfirm = vi.fn();
+    render(<ReopenPeriodModal {...props({ onConfirm })} />);
+    fireEvent.click(screen.getByLabelText(/พบเอกสารผิด/));
+    fireEvent.change(screen.getByLabelText(/บันทึกรายละเอียด/), { target: { value: 'เอกสาร OI-26040015 ระบุลูกค้าผิด' } });
+    fireEvent.click(screen.getByLabelText(/ยังไม่ได้ยื่น/));
+    fireEvent.click(screen.getByRole('button', { name: /ยืนยันเปิดงวด/ }));
+    expect(onConfirm).toHaveBeenCalledWith({
+      reasonType: 'WRONG_ENTRY',
+      reason: 'เอกสาร OI-26040015 ระบุลูกค้าผิด',
+      taxFiled: false,
+    });
+  });
+
+  it('cancel resets form', () => {
+    const onCancel = vi.fn();
+    render(<ReopenPeriodModal {...props({ onCancel })} />);
+    fireEvent.click(screen.getByLabelText(/พบเอกสารผิด/));
+    fireEvent.click(screen.getByRole('button', { name: /ยกเลิก/ }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/web && npx vitest run src/pages/accounting/components/__tests__/ReopenPeriodModal.test.tsx
+```
+
+- [ ] **Step 3: Implement component**
+
+```tsx
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { AlertTriangle } from 'lucide-react';
+
+type ReasonType = 'WRONG_ENTRY' | 'MISSED_RECORD' | 'AUDITOR_REQUEST' | 'OTHER';
+
+type Props = {
+  open: boolean;
+  period: string;
+  onConfirm: (payload: { reasonType: ReasonType; reason: string; taxFiled: boolean }) => void;
+  onCancel: () => void;
+};
+
+const REASON_OPTIONS: Array<{ value: ReasonType; label: string }> = [
+  { value: 'WRONG_ENTRY', label: 'พบเอกสารผิดต้อง reverse' },
+  { value: 'MISSED_RECORD', label: 'ลืมบันทึกรายการสำคัญ' },
+  { value: 'AUDITOR_REQUEST', label: 'แก้ไขตามคำขอ auditor' },
+  { value: 'OTHER', label: 'อื่นๆ (ระบุในบันทึก)' },
+];
+
+export function ReopenPeriodModal({ open, period, onConfirm, onCancel }: Props) {
+  const [reasonType, setReasonType] = useState<ReasonType | null>(null);
+  const [reason, setReason] = useState('');
+  const [taxFiled, setTaxFiled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setReasonType(null);
+      setReason('');
+      setTaxFiled(null);
+    }
+  }, [open]);
+
+  const canSubmit = reasonType !== null && reason.trim().length >= 10 && taxFiled !== null;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onConfirm({ reasonType: reasonType!, reason: reason.trim(), taxFiled: taxFiled! });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-warning">
+            <AlertTriangle className="w-5 h-5" />
+            คุณกำลังเปิดงวด {period} ที่ปิดไปแล้ว
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 text-sm">
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">เหตุผล (บังคับ):</legend>
+            {REASON_OPTIONS.map((opt) => (
+              <label key={opt.value} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="reasonType"
+                  value={opt.value}
+                  checked={reasonType === opt.value}
+                  onChange={() => setReasonType(opt.value)}
+                />
+                <span>{opt.label}</span>
+              </label>
+            ))}
+          </fieldset>
+
+          <div>
+            <label htmlFor="reopen-reason-note" className="block font-semibold mb-1">
+              บันทึกรายละเอียด (≥ 10 ตัวอักษร):
+            </label>
+            <Textarea
+              id="reopen-reason-note"
+              rows={3}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="ระบุเอกสารหรือเหตุการณ์ที่ต้องการแก้ไข"
+            />
+          </div>
+
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">ภ.พ.30 งวดนี้ยื่นแล้วใช่ไหม?</legend>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="taxFiled"
+                checked={taxFiled === true}
+                onChange={() => setTaxFiled(true)}
+              />
+              <span>ใช่ — ต้องยื่นแก้ไขด้วย</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="taxFiled"
+                checked={taxFiled === false}
+                onChange={() => setTaxFiled(false)}
+              />
+              <span>ยังไม่ได้ยื่น</span>
+            </label>
+          </fieldset>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>ยกเลิก</Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>ยืนยันเปิดงวด</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+npx vitest run src/pages/accounting/components/__tests__/ReopenPeriodModal.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+git add apps/web/src/pages/accounting/components/ReopenPeriodModal.tsx \
+        apps/web/src/pages/accounting/components/__tests__/ReopenPeriodModal.test.tsx
+git commit -m "feat(accounting): ReopenPeriodModal — structured reason + note + taxFiled
+
+Required fields gate the submit button. Form resets on close.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2"
+```
+
+---
+
+## Task 10: Wire ReopenPeriodModal into PeriodClosePage
+
+**Files:**
+- Modify: `apps/web/src/pages/accounting/PeriodClosePage.tsx`
+- Modify: `apps/web/src/lib/accounting.ts` (or wherever the period API helpers live)
+
+- [ ] **Step 1: Read existing reopen mutation**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+grep -n "reopen\|reopenMutation\|reopenPeriod" apps/web/src/pages/accounting/PeriodClosePage.tsx apps/web/src/lib/ 2>/dev/null | head -10
+```
+
+The existing mutation calls `POST /accounting/periods/:period/reopen` with no body. Update to send the modal payload.
+
+- [ ] **Step 2: Update API helper signature**
+
+If accounting.ts has `reopenPeriod(period: string)`, change to:
+
+```ts
+reopenPeriod: (period: string, dto: { reasonType: string; reason: string; taxFiled: boolean }) =>
+  api.post(`/accounting/periods/${period}/reopen`, dto),
+```
+
+- [ ] **Step 3: Wire modal into PeriodClosePage**
+
+```tsx
+import { ReopenPeriodModal } from './components/ReopenPeriodModal';
+
+// State
+const [reopenTarget, setReopenTarget] = useState<string | null>(null); // period to reopen
+
+const reopenMutation = useMutation({
+  mutationFn: ({ period, dto }: { period: string; dto: ReopenDto }) => accountingApi.reopenPeriod(period, dto),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['accounting-periods'] });
+    queryClient.invalidateQueries({ queryKey: ['accounting-periods', 'reopened'] });
+    toast.success('เปิดงวดสำเร็จ');
+    setReopenTarget(null);
+  },
+  onError: (err: any) => toast.error(err?.response?.data?.message ?? 'ไม่สามารถเปิดงวดได้'),
+});
+
+// Replace existing reopen button onClick with:
+onClick={() => setReopenTarget(period.period)}
+
+// Render modal:
+<ReopenPeriodModal
+  open={reopenTarget !== null}
+  period={reopenTarget ?? ''}
+  onConfirm={(payload) => reopenMutation.mutate({ period: reopenTarget!, dto: payload })}
+  onCancel={() => setReopenTarget(null)}
+/>
+```
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+./tools/check-types.sh web
+git add apps/web/src/pages/accounting/PeriodClosePage.tsx apps/web/src/lib/accounting.ts
+git commit -m "feat(accounting): wire ReopenPeriodModal into PeriodClosePage
+
+Reopen button now opens modal collecting reasonType + reason + taxFiled.
+API helper signature extended to pass DTO body.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2"
+```
+
+---
+
+## Task 11: ReopenedPeriodBanner component
+
+**Files:**
+- Create: `apps/web/src/components/accounting/ReopenedPeriodBanner.tsx`
+- Create: `apps/web/src/components/accounting/__tests__/ReopenedPeriodBanner.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReopenedPeriodBanner } from '../ReopenedPeriodBanner';
+
+vi.mock('@/lib/accounting', () => ({
+  accountingApi: {
+    listReopenedPeriods: vi.fn(),
+  },
+}));
+
+import { accountingApi } from '@/lib/accounting';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ReopenedPeriodBanner', () => {
+  it('renders nothing when no periods are reopened', async () => {
+    (accountingApi.listReopenedPeriods as any).mockResolvedValue([]);
+    render(<ReopenedPeriodBanner />, { wrapper });
+    expect(screen.queryByText(/ถูกเปิดชั่วคราว/)).not.toBeInTheDocument();
+  });
+
+  it('renders one banner per reopened period', async () => {
+    (accountingApi.listReopenedPeriods as any).mockResolvedValue([
+      {
+        period: '2026-04',
+        reopenedAt: '2026-05-12T14:00:00Z',
+        reopenedBy: { id: 'u1', name: 'สุทธินีย์' },
+        reopenReason: 'WRONG_ENTRY: เอกสาร OI-26040015 ระบุลูกค้าผิด',
+        taxFiled: true,
+      },
+    ]);
+    render(<ReopenedPeriodBanner />, { wrapper });
+    expect(await screen.findByText(/2026-04/)).toBeInTheDocument();
+    expect(screen.getByText(/สุทธินีย์/)).toBeInTheDocument();
+    expect(screen.getByText(/ภ.พ.30 ยื่นแล้ว/)).toBeInTheDocument();
+  });
+
+  it('omits tax-filed warning when taxFiled is false', async () => {
+    (accountingApi.listReopenedPeriods as any).mockResolvedValue([
+      { period: '2026-03', reopenedAt: '2026-05-12T14:00:00Z', reopenedBy: { id: 'u1', name: 'สุทธินีย์' }, reopenReason: 'WRONG_ENTRY: ...', taxFiled: false },
+    ]);
+    render(<ReopenedPeriodBanner />, { wrapper });
+    await screen.findByText(/2026-03/);
+    expect(screen.queryByText(/ภ.พ.30 ยื่นแล้ว/)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd apps/web && npx vitest run src/components/accounting/__tests__/ReopenedPeriodBanner.test.tsx
+```
+
+- [ ] **Step 3: Implement component**
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle } from 'lucide-react';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { accountingApi } from '@/lib/accounting';
+
+type ReopenedPeriod = {
+  period: string;
+  reopenedAt: string;
+  reopenedBy: { id: string; name: string };
+  reopenReason: string | null;
+  taxFiled: boolean | null;
+};
+
+export function ReopenedPeriodBanner() {
+  const { data } = useQuery<ReopenedPeriod[]>({
+    queryKey: ['accounting-periods', 'reopened'],
+    queryFn: () => accountingApi.listReopenedPeriods(),
+    staleTime: 60_000,
+  });
+
+  if (!data || data.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {data.map((p) => (
+        <Alert key={p.period} variant="warning" className="border-warning bg-warning/10">
+          <AlertTriangle className="w-4 h-4 text-warning" />
+          <AlertTitle>งวด {p.period} ถูกเปิดชั่วคราว</AlertTitle>
+          <AlertDescription className="space-y-1">
+            <p>
+              เปิดเมื่อ: {new Date(p.reopenedAt).toLocaleString('th-TH')}
+              {p.reopenedBy?.name ? ` โดย ${p.reopenedBy.name}` : ''}
+            </p>
+            {p.reopenReason && <p>เหตุผล: {p.reopenReason}</p>}
+            {p.taxFiled && <p className="text-destructive font-medium">⚠ ภ.พ.30 ยื่นแล้ว — ต้องยื่นแก้ไขด้วย</p>}
+          </AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Add listReopenedPeriods API helper**
+
+In `apps/web/src/lib/accounting.ts`:
+
+```ts
+listReopenedPeriods: () => api.get<ReopenedPeriod[]>('/accounting/periods/reopened').then((r) => r.data),
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+```bash
+npx vitest run src/components/accounting/__tests__/ReopenedPeriodBanner.test.tsx
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+git add apps/web/src/components/accounting/ReopenedPeriodBanner.tsx \
+        apps/web/src/components/accounting/__tests__/ReopenedPeriodBanner.test.tsx \
+        apps/web/src/lib/accounting.ts
+git commit -m "feat(accounting): ReopenedPeriodBanner — warns users on list pages when a period is reopened
+
+Renders one alert per currently-reopened period with reason + tax-filed warning.
+Stale-while-revalidate 60s cache.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2"
+```
+
+---
+
+## Task 12: Install banner on OtherIncomeListPage + ExpensesPage
+
+**Files:**
+- Modify: `apps/web/src/pages/other-income/OtherIncomeListPage.tsx`
+- Modify: `apps/web/src/pages/ExpensesPage.tsx`
+
+- [ ] **Step 1: Add banner to OtherIncomeListPage**
+
+Locate where the page content starts (after `<PageHeader />` likely), insert:
+
+```tsx
+import { ReopenedPeriodBanner } from '@/components/accounting/ReopenedPeriodBanner';
+
+// In JSX, near top of content:
+<ReopenedPeriodBanner />
+```
+
+- [ ] **Step 2: Add banner to ExpensesPage**
+
+Same pattern.
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+./tools/check-types.sh web
+git add apps/web/src/pages/other-income/OtherIncomeListPage.tsx apps/web/src/pages/ExpensesPage.tsx
+git commit -m "feat(accounting): install ReopenedPeriodBanner on OtherIncomeListPage + ExpensesPage
+
+Per PDF AC-3.4 — users see banner whenever any period is currently reopened.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4.2"
+```
+
+---
+
+## Task 13: Final verification (PR-2)
+
+- [ ] **Step 1: Full type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+./tools/check-types.sh all
+```
+
+- [ ] **Step 2: API tests**
+
+```bash
+cd apps/api && DATABASE_URL="postgresql://iamnaii@localhost:5432/bestchoice_oi_test" npx jest src/modules/accounting/ src/modules/system-config/ 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Web tests**
+
+```bash
+cd ../web && npx vitest run \
+  src/pages/SettingsPage/components/__tests__/ \
+  src/pages/accounting/components/__tests__/ \
+  src/components/accounting/__tests__/
+```
+
+- [ ] **Step 4: Update accounting docs**
+
+Append to `.claude/rules/accounting.md` (after the Override JV section):
+
+```markdown
+### Maker-Checker toggle (Other Income)
+
+`PUT /system-config/maker-checker` (OWNER only) toggles `OTHER_INCOME_MAKER_CHECKER_ENABLED`. Emits `CONFIG_CHANGED` audit string. When turning OFF, UI shows count of READY docs from `GET /system-config/maker-checker/pending-ready-count` for awareness — they auto-approve on next post.
+
+### Reopen Period workflow
+
+`POST /accounting/periods/:period/reopen` (OWNER only) accepts `ReopenPeriodDto { reasonType, reason, taxFiled }`:
+- `reasonType`: enum (WRONG_ENTRY / MISSED_RECORD / AUDITOR_REQUEST / OTHER)
+- `reason`: free text, min 10 chars
+- `taxFiled`: true if ภ.พ.30 has been submitted (UI banner adds warning when true)
+
+Persists `reopenReason` + `taxFiled` on `AccountingPeriod`. Emits `PERIOD_REOPENED` audit. `closePeriod()` emits `PERIOD_CLOSED`. `GET /accounting/periods/reopened` lists currently-reopened periods (status=OPEN AND reopenedAt set) for the banner.
+```
+
+```bash
+git add .claude/rules/accounting.md
+git commit -m "docs(accounting): document Maker-Checker toggle + Reopen Period workflow
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §4"
+```

--- a/docs/superpowers/plans/2026-05-13-other-income-v2-2-pr3-settings-consolidation.md
+++ b/docs/superpowers/plans/2026-05-13-other-income-v2-2-pr3-settings-consolidation.md
@@ -1,0 +1,907 @@
+# Other Income v2.2 PR-3 — Global Settings 5-Tab Consolidation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development with **3-4 review rounds per task** per owner preference.
+
+**Goal:** Restructure `/settings` into the 5-tab hub specified in PDF v2.2 Task 4 (option C from brainstorm) — Company, VAT, Periods, Attachment, Users. Extract operational settings (Stickers, Collections, General) to dedicated routes. Add URL hash sync + `/accounting/periods` 301 redirect.
+
+**Architecture:** `SettingsPage` becomes a Radix Tabs hub with 5 financial-settings tabs. Existing tab components (`SystemSettings`, `CompanySettings`, `GeneralSettings`, `StickerSettings`, `CollectionsConfigCard`) get reorganized: Company merges into Company tab, others extract to `/settings/stickers`, `/settings/collections`, `/settings/general` routes. New `VatTab` + `AttachmentTab` introduce 4 new SystemConfig keys with class-validator DTOs. PeriodsTab wraps existing `PeriodClosePage` logic (move table + close/reopen actions into a tab; keep `ReopenedPeriodBanner` rendering on list pages from PR-2). UsersTab hosts MakerCheckerToggle + link to `/users` page.
+
+**Tech Stack:** React 18 + Vite + react-router v7 + @tanstack/react-query + shadcn/ui (`Tabs`, `Card`, `Switch`) + Tailwind + Sentry.
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md`](../specs/2026-05-13-other-income-v2-2-design.md) §5 (Sprint 3).
+
+**Codebase facts:**
+- `SettingsPage` at `apps/web/src/pages/SettingsPage/index.tsx` — single-page list of cards backed by `/settings` API + `ConfigItem[]`.
+- `MakerCheckerToggle` already installed (PR-2 Task 8) at top of SettingsPage.
+- `PeriodClosePage` at `apps/web/src/pages/accounting/PeriodClosePage.tsx` already has ReopenPeriodModal wiring (PR-2 Task 10).
+- shadcn `Tabs` component verified to exist (check `apps/web/src/components/ui/tabs.tsx`).
+- App router: `apps/web/src/App.tsx` has existing routes for `/settings/companies`, `/settings/chart-of-accounts`, etc. (sub-routes already exist as siblings).
+
+---
+
+## File Structure
+
+### Backend (modify)
+- `apps/api/src/modules/settings/settings.service.ts` (or wherever `/settings` API lives) — seed 4 new SystemConfig keys at startup OR rely on first-write upsert.
+- Optional: SQL seed file for the 4 new keys.
+
+### Frontend (create)
+- `apps/web/src/pages/SettingsPage/tabs/CompanyTab.tsx` — wraps existing `CompanySettings` content
+- `apps/web/src/pages/SettingsPage/tabs/VatTab.tsx` — new (rate + default price type)
+- `apps/web/src/pages/SettingsPage/tabs/PeriodsTab.tsx` — extracted from PeriodClosePage
+- `apps/web/src/pages/SettingsPage/tabs/AttachmentTab.tsx` — new (threshold + allowed types)
+- `apps/web/src/pages/SettingsPage/tabs/UsersTab.tsx` — MakerCheckerToggle + link
+- `apps/web/src/pages/SettingsPage/StickersPage.tsx` — extracted standalone route
+- `apps/web/src/pages/SettingsPage/CollectionsPage.tsx` — extracted standalone route
+- `apps/web/src/pages/SettingsPage/GeneralSettingsPage.tsx` — extracted (banking + penalty + pdpa + payment_link)
+
+### Frontend (modify)
+- `apps/web/src/pages/SettingsPage/index.tsx` — full refactor to 5-tab Tabs structure + URL hash sync + permission guard
+- `apps/web/src/App.tsx` — add new routes for `/settings/stickers`, `/settings/collections`, `/settings/general`; add redirect `/accounting/periods` → `/settings#periods`
+
+### SystemConfig keys (seed via UI or migration)
+- `VAT_RATE` = "7" (number string)
+- `VAT_PRICE_TYPE_DEFAULT` = "exclusive" | "inclusive"
+- `ATTACHMENT_REQUIRED_ABOVE_AMOUNT` = "0" (0 = optional)
+- `ATTACHMENT_ALLOWED_TYPES` = "PDF, JPG, PNG"
+
+---
+
+## Task 1: Seed new SystemConfig keys
+
+**Files:**
+- Create: `apps/api/prisma/migrations/<timestamp>_seed_pr3_settings_keys/migration.sql`
+
+- [ ] **Step 1: Create idempotent seed migration**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+TS=$(date -u +%Y%m%d%H%M%S)
+mkdir -p apps/api/prisma/migrations/${TS}_seed_pr3_settings_keys
+```
+
+Locate the `system_configs` table @@map and column structure:
+
+```bash
+awk '/^model SystemConfig /,/^}/' apps/api/prisma/schema.prisma
+```
+
+Write `migration.sql` matching the actual columns (likely `id`, `key`, `value`, `description`, `created_at`, `updated_at`):
+
+```sql
+INSERT INTO "system_configs" ("id", "key", "value", "description", "created_at", "updated_at")
+VALUES
+  (gen_random_uuid(), 'VAT_RATE', '7', 'อัตรา VAT (%)', NOW(), NOW()),
+  (gen_random_uuid(), 'VAT_PRICE_TYPE_DEFAULT', 'exclusive', 'ประเภทราคาเริ่มต้น (exclusive|inclusive)', NOW(), NOW()),
+  (gen_random_uuid(), 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', '0', 'ยอดที่ต้องบังคับแนบเอกสาร (0=ไม่บังคับ)', NOW(), NOW()),
+  (gen_random_uuid(), 'ATTACHMENT_ALLOWED_TYPES', 'PDF, JPG, PNG', 'ประเภทไฟล์ที่อนุญาต', NOW(), NOW())
+ON CONFLICT ("key") DO NOTHING;
+```
+
+Adjust columns to actual schema. Use `gen_random_uuid()` if PostgreSQL has the extension; else use explicit UUIDs.
+
+- [ ] **Step 2: Apply locally + verify**
+
+```bash
+DATABASE_URL="postgresql://iamnaii@localhost:5432/bestchoice_oi_test" npx prisma migrate deploy
+DATABASE_URL="postgresql://iamnaii@localhost:5432/bestchoice_oi_test" psql -c "SELECT key, value FROM system_configs WHERE key IN ('VAT_RATE', 'VAT_PRICE_TYPE_DEFAULT', 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', 'ATTACHMENT_ALLOWED_TYPES');"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/prisma/migrations/
+git commit -m "$(cat <<'EOF'
+feat(settings): seed VAT + attachment SystemConfig keys (PR-3 Task 1)
+
+4 new keys for /settings#vat and /settings#attachment tabs:
+- VAT_RATE (default 7)
+- VAT_PRICE_TYPE_DEFAULT (default exclusive)
+- ATTACHMENT_REQUIRED_ABOVE_AMOUNT (default 0 = not required)
+- ATTACHMENT_ALLOWED_TYPES (default PDF, JPG, PNG)
+
+Idempotent via ON CONFLICT DO NOTHING.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5.2
+EOF
+)"
+```
+
+---
+
+## Task 2: VatTab component
+
+**Files:**
+- Create: `apps/web/src/pages/SettingsPage/tabs/VatTab.tsx`
+
+- [ ] **Step 1: Implement component**
+
+```tsx
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ConfigItem } from '../components/shared';
+
+type PriceType = 'exclusive' | 'inclusive';
+
+export function VatTab() {
+  const queryClient = useQueryClient();
+  const [rate, setRate] = useState('7');
+  const [priceType, setPriceType] = useState<PriceType>('exclusive');
+  const [editing, setEditing] = useState(false);
+
+  const { data: configs = [], isLoading } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length === 0 || editing) return;
+    const r = configs.find((c) => c.key === 'VAT_RATE')?.value ?? '7';
+    const p = (configs.find((c) => c.key === 'VAT_PRICE_TYPE_DEFAULT')?.value ?? 'exclusive') as PriceType;
+    setRate(r);
+    setPriceType(p);
+  }, [configs, editing]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const items = [
+        { key: 'VAT_RATE', value: rate },
+        { key: 'VAT_PRICE_TYPE_DEFAULT', value: priceType },
+      ];
+      return api.patch('/settings', { items });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึก VAT สำเร็จ');
+      setEditing(false);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">กำลังโหลด...</p>;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>VAT (ภ.พ.30)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="vat-rate">อัตรา VAT (%)</Label>
+          <Input
+            id="vat-rate"
+            type="number"
+            step="0.01"
+            min="0"
+            max="100"
+            value={rate}
+            onChange={(e) => { setRate(e.target.value); setEditing(true); }}
+            disabled={saveMutation.isPending}
+          />
+        </div>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">ประเภทราคาเริ่มต้น</legend>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="priceType"
+              value="exclusive"
+              checked={priceType === 'exclusive'}
+              onChange={() => { setPriceType('exclusive'); setEditing(true); }}
+              disabled={saveMutation.isPending}
+            />
+            <span>ราคา ไม่รวม VAT (exclusive)</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="priceType"
+              value="inclusive"
+              checked={priceType === 'inclusive'}
+              onChange={() => { setPriceType('inclusive'); setEditing(true); }}
+              disabled={saveMutation.isPending}
+            />
+            <span>ราคา รวม VAT แล้ว (inclusive)</span>
+          </label>
+        </fieldset>
+
+        {editing && (
+          <div className="flex gap-2">
+            <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>บันทึก</Button>
+            <Button variant="outline" onClick={() => setEditing(false)} disabled={saveMutation.isPending}>ยกเลิก</Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+./tools/check-types.sh web
+git add apps/web/src/pages/SettingsPage/tabs/VatTab.tsx
+git commit -m "feat(settings): VatTab — rate + default price type editor
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5.2"
+```
+
+---
+
+## Task 3: AttachmentTab component
+
+**Files:**
+- Create: `apps/web/src/pages/SettingsPage/tabs/AttachmentTab.tsx`
+
+- [ ] **Step 1: Implement**
+
+```tsx
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ConfigItem } from '../components/shared';
+
+export function AttachmentTab() {
+  const queryClient = useQueryClient();
+  const [threshold, setThreshold] = useState('0');
+  const [allowedTypes, setAllowedTypes] = useState('PDF, JPG, PNG');
+  const [editing, setEditing] = useState(false);
+
+  const { data: configs = [], isLoading } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length === 0 || editing) return;
+    setThreshold(configs.find((c) => c.key === 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT')?.value ?? '0');
+    setAllowedTypes(configs.find((c) => c.key === 'ATTACHMENT_ALLOWED_TYPES')?.value ?? 'PDF, JPG, PNG');
+  }, [configs, editing]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () =>
+      api.patch('/settings', {
+        items: [
+          { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', value: threshold },
+          { key: 'ATTACHMENT_ALLOWED_TYPES', value: allowedTypes },
+        ],
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกการตั้งค่าเอกสารแนบสำเร็จ');
+      setEditing(false);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">กำลังโหลด...</p>;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>เอกสารแนบ</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="att-threshold">ยอดที่ต้องบังคับแนบเอกสาร (บาท)</Label>
+          <Input
+            id="att-threshold"
+            type="number"
+            step="0.01"
+            min="0"
+            value={threshold}
+            onChange={(e) => { setThreshold(e.target.value); setEditing(true); }}
+            disabled={saveMutation.isPending}
+          />
+          <p className="text-xs text-muted-foreground">0 = ไม่บังคับแนบ. > 0 = บังคับแนบเมื่อยอดเอกสารเกินค่านี้.</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="att-types">ประเภทไฟล์ที่อนุญาต</Label>
+          <Input
+            id="att-types"
+            value={allowedTypes}
+            onChange={(e) => { setAllowedTypes(e.target.value); setEditing(true); }}
+            placeholder="PDF, JPG, PNG"
+            disabled={saveMutation.isPending}
+          />
+          <p className="text-xs text-muted-foreground">คั่นด้วยจุลภาค (,) เช่น "PDF, JPG, PNG"</p>
+        </div>
+
+        {editing && (
+          <div className="flex gap-2">
+            <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>บันทึก</Button>
+            <Button variant="outline" onClick={() => setEditing(false)} disabled={saveMutation.isPending}>ยกเลิก</Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+```bash
+./tools/check-types.sh web
+git add apps/web/src/pages/SettingsPage/tabs/AttachmentTab.tsx
+git commit -m "feat(settings): AttachmentTab — threshold + allowed types editor
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5.2"
+```
+
+---
+
+## Task 4: CompanyTab + PeriodsTab + UsersTab wrappers
+
+**Files:**
+- Create: `apps/web/src/pages/SettingsPage/tabs/CompanyTab.tsx`
+- Create: `apps/web/src/pages/SettingsPage/tabs/PeriodsTab.tsx`
+- Create: `apps/web/src/pages/SettingsPage/tabs/UsersTab.tsx`
+
+- [ ] **Step 1: CompanyTab — wraps existing CompanySettings**
+
+```tsx
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import CompanySettings from '../components/CompanySettings';
+import type { ConfigItem } from '../components/shared';
+
+export function CompanyTab() {
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [editingSection, setEditingSection] = useState<string | null>(null);
+  const [draftSignatureImage, setDraftSignatureImage] = useState('');
+  const [draftSignerName, setDraftSignerName] = useState('');
+
+  const { data: configs = [] } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length > 0 && !editingSection) {
+      const map: Record<string, string> = {};
+      configs.forEach((c) => { map[c.key] = c.value; });
+      setValues(map);
+    }
+  }, [configs, editingSection]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (items: { key: string; value: string }[]) => api.patch('/settings', { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกสำเร็จ');
+      setEditingSection(null);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const handleSave = (items: { key: string; value: string }[]) => {
+    const finalItems = [
+      ...items,
+      { key: 'lessor_signature_image', value: draftSignatureImage },
+      { key: 'lessor_signer_name', value: draftSignerName },
+    ];
+    saveMutation.mutate(finalItems);
+  };
+
+  const handleEdit = (sectionKey: string) => {
+    setEditingSection(sectionKey);
+    setDraftSignatureImage(values['lessor_signature_image'] || '');
+    setDraftSignerName(values['lessor_signer_name'] || '');
+  };
+
+  return (
+    <CompanySettings
+      values={values}
+      editingSection={editingSection}
+      onEdit={handleEdit}
+      onSave={handleSave}
+      onCancel={() => setEditingSection(null)}
+      isSaving={saveMutation.isPending}
+      draftSignatureImage={draftSignatureImage}
+      draftSignerName={draftSignerName}
+      setDraftSignatureImage={setDraftSignatureImage}
+      setDraftSignerName={setDraftSignerName}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: PeriodsTab — wraps PeriodClosePage**
+
+The simplest approach: re-export PeriodClosePage as a component. Verify it's a default export and wrap:
+
+```tsx
+import PeriodClosePage from '@/pages/accounting/PeriodClosePage';
+
+export function PeriodsTab() {
+  return <PeriodClosePage />;
+}
+```
+
+(If PeriodClosePage has `useDocumentTitle` set, it'll override the parent. Acceptable for now — Sprint 4 polish item.)
+
+- [ ] **Step 3: UsersTab — MakerCheckerToggle + link**
+
+```tsx
+import { Link } from 'react-router';
+import { MakerCheckerToggle } from '../components/MakerCheckerToggle';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Users } from 'lucide-react';
+
+export function UsersTab() {
+  return (
+    <div className="space-y-4">
+      <MakerCheckerToggle />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>จัดการผู้ใช้งาน</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground mb-3">
+            จัดการบัญชีผู้ใช้งาน บทบาท และสิทธิ์การเข้าถึง
+          </p>
+          <Button asChild variant="outline">
+            <Link to="/users" className="inline-flex items-center gap-2">
+              <Users size={16} />
+              ไปยังหน้าผู้ใช้งาน
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+./tools/check-types.sh web
+git add apps/web/src/pages/SettingsPage/tabs/CompanyTab.tsx \
+        apps/web/src/pages/SettingsPage/tabs/PeriodsTab.tsx \
+        apps/web/src/pages/SettingsPage/tabs/UsersTab.tsx
+git commit -m "feat(settings): CompanyTab + PeriodsTab + UsersTab wrappers
+
+CompanyTab wraps CompanySettings with local state.
+PeriodsTab re-exports PeriodClosePage as a tab.
+UsersTab hosts MakerCheckerToggle + link to /users page.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5.2"
+```
+
+---
+
+## Task 5: SettingsPage refactor to 5-tab Tabs
+
+**Files:**
+- Modify: `apps/web/src/pages/SettingsPage/index.tsx`
+
+- [ ] **Step 1: Verify shadcn Tabs exists**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+ls apps/web/src/components/ui/tabs.tsx
+```
+
+- [ ] **Step 2: Replace SettingsPage body**
+
+Replace `apps/web/src/pages/SettingsPage/index.tsx` content with:
+
+```tsx
+import { useEffect, useState } from 'react';
+import { Navigate } from 'react-router';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useAuth } from '@/contexts/AuthContext';
+import PageHeader from '@/components/ui/PageHeader';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { CompanyTab } from './tabs/CompanyTab';
+import { VatTab } from './tabs/VatTab';
+import { PeriodsTab } from './tabs/PeriodsTab';
+import { AttachmentTab } from './tabs/AttachmentTab';
+import { UsersTab } from './tabs/UsersTab';
+
+const TAB_IDS = ['company', 'vat', 'periods', 'attachment', 'users'] as const;
+type TabId = typeof TAB_IDS[number];
+
+function readHash(): TabId {
+  const h = (typeof window !== 'undefined' ? window.location.hash.slice(1) : '') as TabId;
+  return TAB_IDS.includes(h) ? h : 'company';
+}
+
+export default function SettingsPage() {
+  useDocumentTitle('ตั้งค่าระบบ');
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<TabId>(readHash());
+
+  // Permission guard — Sprint 2 placed MakerCheckerToggle on this page, so user.role === OWNER assumed for full access
+  if (user && user.role !== 'OWNER') {
+    return <Navigate to="/" replace />;
+  }
+
+  // Sync URL hash <-> activeTab
+  useEffect(() => {
+    if (window.location.hash.slice(1) !== activeTab) {
+      window.history.replaceState(null, '', `#${activeTab}`);
+    }
+  }, [activeTab]);
+
+  // React to back/forward
+  useEffect(() => {
+    const handler = () => setActiveTab(readHash());
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
+  }, []);
+
+  return (
+    <div>
+      <PageHeader title="ตั้งค่าระบบ" subtitle="กำหนดพารามิเตอร์การทำงานของระบบ" />
+
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabId)}>
+        <TabsList className="grid grid-cols-2 md:grid-cols-5 mb-4">
+          <TabsTrigger value="company">บริษัท</TabsTrigger>
+          <TabsTrigger value="vat">VAT</TabsTrigger>
+          <TabsTrigger value="periods">งวดบัญชี</TabsTrigger>
+          <TabsTrigger value="attachment">เอกสารแนบ</TabsTrigger>
+          <TabsTrigger value="users">ผู้ใช้งาน</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="company"><CompanyTab /></TabsContent>
+        <TabsContent value="vat"><VatTab /></TabsContent>
+        <TabsContent value="periods"><PeriodsTab /></TabsContent>
+        <TabsContent value="attachment"><AttachmentTab /></TabsContent>
+        <TabsContent value="users"><UsersTab /></TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+./tools/check-types.sh web
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/SettingsPage/index.tsx
+git commit -m "$(cat <<'EOF'
+feat(settings): refactor SettingsPage into 5-tab hub (PR-3 Task 5)
+
+5 tabs: Company / VAT / Periods / Attachment / Users.
+URL hash sync (/settings#vat etc.) for bookmarkable tab state.
+Listens to hashchange for browser back/forward.
+Permission guard — non-OWNER redirected to /.
+
+Operational settings (Stickers/Collections/General) moved to dedicated
+routes in subsequent Task 6.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5
+EOF
+)"
+```
+
+---
+
+## Task 6: Extract Stickers + Collections + General to routes
+
+**Files:**
+- Create: `apps/web/src/pages/SettingsPage/StickersPage.tsx`
+- Create: `apps/web/src/pages/SettingsPage/CollectionsPage.tsx`
+- Create: `apps/web/src/pages/SettingsPage/GeneralSettingsPage.tsx`
+- Modify: `apps/web/src/App.tsx`
+
+- [ ] **Step 1: StickersPage wrapper**
+
+```tsx
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import StickerSettings from './components/StickerSettings';
+import type { ConfigItem } from './components/shared';
+
+export default function StickersPage() {
+  useDocumentTitle('สติกเกอร์ — ตั้งค่า');
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [editingSection, setEditingSection] = useState<string | null>(null);
+
+  const { data: configs = [] } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length > 0 && !editingSection) {
+      const map: Record<string, string> = {};
+      configs.forEach((c) => { map[c.key] = c.value; });
+      setValues(map);
+    }
+  }, [configs, editingSection]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (items: { key: string; value: string }[]) => api.patch('/settings', { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกสำเร็จ');
+      setEditingSection(null);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  return (
+    <div>
+      <PageHeader title="สติกเกอร์" subtitle="ตั้งค่าเริ่มต้นสำหรับสติกเกอร์เอกสาร" />
+      <StickerSettings
+        values={values}
+        editingSection={editingSection}
+        onEdit={setEditingSection}
+        onSave={(items) => saveMutation.mutate(items)}
+        onCancel={() => setEditingSection(null)}
+        isSaving={saveMutation.isPending}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: CollectionsPage wrapper**
+
+```tsx
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+import CollectionsConfigCard from './components/CollectionsConfigCard';
+
+export default function CollectionsPage() {
+  useDocumentTitle('การเก็บหนี้ — ตั้งค่า');
+  return (
+    <div>
+      <PageHeader title="การเก็บหนี้" subtitle="พารามิเตอร์ของ auto-assign + session" />
+      <CollectionsConfigCard />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: GeneralSettingsPage wrapper (banking + penalty + pdpa + payment_link)**
+
+The existing GeneralSettings component is rendered TWICE in old SettingsPage with `slot="pre"` (penalty + pdpa, before Company) and `slot="post"` (banking + payment_link, after Company). Replicate that:
+
+```tsx
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import PageHeader from '@/components/ui/PageHeader';
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import GeneralSettings from './components/GeneralSettings';
+import type { ConfigItem } from './components/shared';
+
+export default function GeneralSettingsPage() {
+  useDocumentTitle('ตั้งค่าทั่วไป');
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [editingSection, setEditingSection] = useState<string | null>(null);
+
+  const { data: configs = [] } = useQuery<ConfigItem[]>({
+    queryKey: ['settings'],
+    queryFn: async () => (await api.get('/settings')).data,
+  });
+
+  useEffect(() => {
+    if (configs.length > 0 && !editingSection) {
+      const map: Record<string, string> = {};
+      configs.forEach((c) => { map[c.key] = c.value; });
+      setValues(map);
+    }
+  }, [configs, editingSection]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (items: { key: string; value: string }[]) => api.patch('/settings', { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('บันทึกสำเร็จ');
+      setEditingSection(null);
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  return (
+    <div className="space-y-5">
+      <PageHeader title="ตั้งค่าทั่วไป" subtitle="ค่าปรับ, PDPA, ข้อมูลธนาคาร, link ชำระเงิน" />
+      <GeneralSettings
+        slot="pre"
+        values={values}
+        editingSection={editingSection}
+        onEdit={setEditingSection}
+        onSave={(items) => saveMutation.mutate(items)}
+        onCancel={() => setEditingSection(null)}
+        isSaving={saveMutation.isPending}
+      />
+      <GeneralSettings
+        slot="post"
+        values={values}
+        editingSection={editingSection}
+        onEdit={setEditingSection}
+        onSave={(items) => saveMutation.mutate(items)}
+        onCancel={() => setEditingSection(null)}
+        isSaving={saveMutation.isPending}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Add routes in App.tsx**
+
+```bash
+grep -n "Settings\|/settings\|lazy" apps/web/src/App.tsx | head -10
+```
+
+Add lazy-loaded routes near the existing settings sub-routes:
+
+```tsx
+const StickersPage = lazy(() => import('@/pages/SettingsPage/StickersPage'));
+const CollectionsPage = lazy(() => import('@/pages/SettingsPage/CollectionsPage'));
+const GeneralSettingsPage = lazy(() => import('@/pages/SettingsPage/GeneralSettingsPage'));
+
+// In routes JSX:
+<Route path="/settings/stickers" element={<ProtectedRoute><MainLayout><StickersPage /></MainLayout></ProtectedRoute>} />
+<Route path="/settings/collections" element={<ProtectedRoute><MainLayout><CollectionsPage /></MainLayout></ProtectedRoute>} />
+<Route path="/settings/general" element={<ProtectedRoute><MainLayout><GeneralSettingsPage /></MainLayout></ProtectedRoute>} />
+```
+
+Match existing ProtectedRoute / MainLayout / Suspense wrapper pattern in the file.
+
+- [ ] **Step 5: Type-check + commit**
+
+```bash
+./tools/check-types.sh web
+git add apps/web/src/pages/SettingsPage/StickersPage.tsx \
+        apps/web/src/pages/SettingsPage/CollectionsPage.tsx \
+        apps/web/src/pages/SettingsPage/GeneralSettingsPage.tsx \
+        apps/web/src/App.tsx
+git commit -m "$(cat <<'EOF'
+feat(settings): extract operational tabs to dedicated routes (PR-3 Task 6)
+
+- /settings/stickers — StickerSettings
+- /settings/collections — CollectionsConfigCard
+- /settings/general — GeneralSettings pre+post (banking, penalty, pdpa, payment_link)
+
+5-tab /settings is now accounting-focused (per option C consolidation).
+Operational settings live in dedicated routes accessible from sidebar.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5.3
+EOF
+)"
+```
+
+---
+
+## Task 7: URL redirect /accounting/periods → /settings#periods
+
+**Files:**
+- Modify: `apps/web/src/App.tsx`
+
+- [ ] **Step 1: Add redirect route**
+
+Find the existing `<Route path="/accounting/periods" .../>` line in App.tsx. Replace its element with a redirect:
+
+```tsx
+import { Navigate } from 'react-router';
+
+<Route path="/accounting/periods" element={<Navigate to="/settings#periods" replace />} />
+```
+
+(Note: `react-router` v7 client-side Navigate doesn't include hash in default behavior — verify the hash transfers. If not, use a custom redirect component:
+
+```tsx
+function PeriodsRedirect() {
+  useEffect(() => {
+    window.location.replace('/settings#periods');
+  }, []);
+  return null;
+}
+
+<Route path="/accounting/periods" element={<PeriodsRedirect />} />
+```
+
+)
+
+- [ ] **Step 2: Type-check + commit**
+
+```bash
+./tools/check-types.sh web
+git add apps/web/src/App.tsx
+git commit -m "feat(settings): redirect /accounting/periods → /settings#periods
+
+Per PDF AC-4.4 — backward compat for users with bookmarks.
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5.4"
+```
+
+---
+
+## Task 8: Final verification + docs
+
+- [ ] **Step 1: Full type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.worktrees/oi-v2-2-pr1
+./tools/check-types.sh all
+```
+
+- [ ] **Step 2: Web tests**
+
+```bash
+cd apps/web && npx vitest run \
+  src/pages/SettingsPage/components/__tests__/ \
+  src/pages/accounting/components/__tests__/ \
+  src/components/accounting/__tests__/ \
+  src/pages/other-income/components/__tests__/ \
+  src/components/ui/__tests__/PaginationBar.test.tsx \
+  src/hooks/__tests__/usePaginationParams.test.tsx 2>&1 | tail -5
+```
+
+- [ ] **Step 3: API tests (smoke)**
+
+```bash
+cd ../api && DATABASE_URL="postgresql://iamnaii@localhost:5432/bestchoice_oi_test" npx jest src/modules/accounting/ src/modules/other-income/ 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Append docs**
+
+Append to `.claude/rules/accounting.md` after the existing "Reopen Period workflow" section:
+
+```markdown
+
+### Settings UI consolidation
+
+`/settings` is the 5-tab hub for system-wide configuration:
+- `#company` — CompanyInfo (name, address, tax ID, signer)
+- `#vat` — `VAT_RATE` + `VAT_PRICE_TYPE_DEFAULT` (exclusive/inclusive)
+- `#periods` — AccountingPeriod table (close/reopen actions)
+- `#attachment` — `ATTACHMENT_REQUIRED_ABOVE_AMOUNT` + `ATTACHMENT_ALLOWED_TYPES`
+- `#users` — MakerCheckerToggle + link to /users
+
+Operational settings live at dedicated routes:
+- `/settings/stickers` — StickerSettings
+- `/settings/collections` — CollectionsConfigCard
+- `/settings/general` — Banking, penalty, PDPA, payment_link
+
+`/accounting/periods` redirects to `/settings#periods` for backward compatibility. Permission: OWNER only on `/settings` root.
+```
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add .claude/rules/accounting.md
+git commit -m "docs(accounting): document Settings 5-tab consolidation
+
+Refs: docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md §5"
+```


### PR DESCRIPTION
## Summary

Full v2.2 implementation covering all 5 PDF tasks from `other-income-dev-tasks-v2-2.pdf` across 3 sprints. **45 commits, 58 files, +5323/-511 lines.**

### Sprint 1 — Override JV + Pagination
- **JournalOverrideService** — V1/V2/V5 validation + Thai diff summary (`fmt()` uses `Decimal.toFixed` + regex grouping, NO `toNumber()`)
- **Override JV flow in `OtherIncomeService.post()`** — sets `isOverridden=true`, writes `JV_OVERRIDDEN` audit (oldValue=auto JV, newValue=override + diffSummary) wrapped in try/catch + Sentry capture
- **OverrideConfirmDialog** — pre-override warning + ack checkbox
- **EditableJournalTable** — live V1/V2/V5 validation with integer cents accumulator (no float drift) + skip-blank-rows logic
- **EntryPage override toggle** — Decimal→Number boundary uses `.toFixed(2)` to avoid V1 drift on identity-override
- **✏ marker** on list page (uses `text-warning` design token, not hardcoded palette)
- **Audit diff renderer** on view page with collapsible original-vs-modified tables
- **`usePaginationParams` hook** + **`PaginationBar` component** — URL-driven, bookmarkable
- **Migrated 4 list pages**: OtherIncome list (50), Pending Approval (50, ASC sort), Expenses (50), AuditLogs (100)
- **DB indexes**: `(status, created_at DESC)` on `other_incomes` + `expense_documents`
- **Performance test** (PERF=1 gated): seed 10k OI + assert list < 200ms

### Sprint 2 — Maker-Checker UI + Reopen Period
- **AccountingPeriod schema** — added `reopenReason` + `taxFiled` columns + migration
- **ReopenPeriodDto** — 4-value reasonType enum + ≥10-char reason + taxFiled, all with Thai validation messages (year `@Max(2100)`, month `@Min(1)/@Max(12)`)
- **`reopenPeriod()` extended** — TOCTOU-safe via `updateMany` CAS with `status: 'CLOSED'` filter inside `$transaction`; emits `PERIOD_REOPENED` audit (try/catch + Sentry)
- **`closePeriod()` emits `PERIOD_CLOSED`** with actual `closedAt` from updated record
- **`GET /expenses/periods/reopened`** endpoint for banner data
- **`PUT /other-income/maker-checker`** (OWNER) — toggles flag + emits `CONFIG_CHANGED` audit
- **`GET /other-income/maker-checker/pending-ready-count`** — count for OFF→ON warning
- **MakerCheckerConfirmDialog** — OFF↔ON impacts list + pending count + ack checkbox + reset on close
- **MakerCheckerToggle** — OWNER-only Switch wired to API
- **ReopenPeriodModal** — radio reason taxonomy + required note + taxFiled radio + form reset
- **PeriodClosePage** wired to modal; old inline dialog (60 lines) deleted
- **ReopenedPeriodBanner** — installed on OtherIncomeListPage + ExpensesPage

### Sprint 3 — Settings 5-Tab Consolidation
- **4 new SystemConfig keys seeded** (`VAT_RATE`, `VAT_PRICE_TYPE_DEFAULT`, `ATTACHMENT_REQUIRED_ABOVE_AMOUNT`, `ATTACHMENT_ALLOWED_TYPES`) — idempotent `ON CONFLICT DO NOTHING`
- **`/settings` is now a 5-tab Radix Tabs hub**: บริษัท / VAT / งวดบัญชี / เอกสารแนบ / ผู้ใช้งาน
- **URL hash sync** + **`hashchange` listener** for back/forward
- **OWNER-only guard** — non-OWNER → `<Navigate to="/" replace />`
- **VatTab + AttachmentTab** — new editor cards
- **CompanyTab + PeriodsTab + UsersTab** — wrappers around existing components
- **Operational settings extracted** to dedicated routes: `/settings/stickers`, `/settings/collections`, `/settings/general`
- **`/accounting/periods` redirects** to `/settings#periods` via `window.location.replace` (preserves hash; `<Navigate>` cannot set fragments)

### Cross-cutting
- **AuditLog new action strings**: `JV_OVERRIDDEN`, `CONFIG_CHANGED`, `PERIOD_REOPENED`, `PERIOD_CLOSED` (no enum migration — `AuditLog.action` is `String`)
- **3 design docs + 3 plan docs** committed under `docs/superpowers/`
- **`.claude/rules/accounting.md`** documents Override JV / Maker-Checker / Reopen Period / Settings consolidation

### Bugs caught by 3-4 review rounds per task (per owner preference saved to memory)
- `Decimal.toNumber()` violation in `fmt()` — fixed with `toFixed(2)` + regex grouping
- Audit error swallowing — wrapped with `Sentry.captureException`
- V5 false-positive on newly-added blank rows
- Float drift on V1 totals with many rows — fixed with integer cents accumulator
- Decimal→Number precision at override snapshot boundary
- Pre-existing tests broken by Task 2 constructor change — fixture providers updated
- TOCTOU race on `reopenPeriod()` — fixed with `updateMany` CAS
- OPEN period reopen guard missing — added BadRequest
- Thai messages missing on `@Min`/`@Max` + unbounded year — fixed
- Test DB schema migration not applied — caught by final verification

## Test plan
- [x] API jest: 198/200 pass (2 skipped — perf gated by `PERF=1`)
- [x] Web vitest: 31/31 pass
- [x] TypeScript: 0 errors (API + Web)
- [x] Migration applied locally and verified
- [ ] Manual UAT — AC-1.1 through AC-5.8 per spec §9
- [ ] E2E `other-income-override-jv.spec.ts` — skeleton committed, selectors may need adjustment

## Risks
- Settings consolidation changes `/settings` page entirely — existing bookmarks to subsections still work via `#hash` but old workflow (single scrolling page of cards) changes to tabs
- New migration on `accounting_periods` adds nullable columns — backward compatible
- AuditLog new action strings (`JV_OVERRIDDEN`, `CONFIG_CHANGED`, `PERIOD_REOPENED`, `PERIOD_CLOSED`) — verify any audit dashboards filter by allowed enum values (would need update if so)

## Spec reference
- Brainstorm spec: [docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md](docs/superpowers/specs/2026-05-13-other-income-v2-2-design.md)
- Plans: [PR-1](docs/superpowers/plans/2026-05-13-other-income-v2-2-pr1-override-jv-pagination.md) | [PR-2](docs/superpowers/plans/2026-05-13-other-income-v2-2-pr2-maker-checker-reopen.md) | [PR-3](docs/superpowers/plans/2026-05-13-other-income-v2-2-pr3-settings-consolidation.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)