### PR TITLE
fix(chat-fb): persist message_echoes as STAFF (Page Inbox / Meta Business Suite replies)

### DIFF
--- a/apps/api/src/modules/chat-adapters/facebook-webhook.controller.spec.ts
+++ b/apps/api/src/modules/chat-adapters/facebook-webhook.controller.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as Sentry from '@sentry/nestjs';
 import { InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { createHmac } from 'crypto';
+import { ChatChannel, MessageRole } from '@prisma/client';
 import { FacebookWebhookController } from './facebook-webhook.controller';
 import { MessageRouterService } from '../chat-engine/services/message-router.service';
 import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
@@ -10,6 +12,21 @@ jest.mock('@sentry/nestjs', () => ({
   captureException: jest.fn(),
   captureMessage: jest.fn(),
 }));
+
+function signedRequest(secret: string, body: unknown): {
+  rawBody: Buffer;
+  signature: string;
+  req: import('express').Request;
+} {
+  const rawBody = Buffer.from(JSON.stringify(body), 'utf-8');
+  const signature = 'sha256=' + createHmac('sha256', secret).update(rawBody).digest('hex');
+  const req = {
+    ip: '31.13.64.1',
+    headers: { 'user-agent': 'facebookexternalua/1.0' },
+    rawBody,
+  } as unknown as import('express').Request;
+  return { rawBody, signature, req };
+}
 
 describe('FacebookWebhookController.handleWebhook — rawBody SLO alert (T6-C14)', () => {
   let controller: FacebookWebhookController;
@@ -62,5 +79,217 @@ describe('FacebookWebhookController.handleWebhook — rawBody SLO alert (T6-C14)
         meta: expect.objectContaining({ note: 'missing_raw_body' }),
       }),
     );
+  });
+});
+
+describe('FacebookWebhookController.handleWebhook — message_echoes', () => {
+  const FB_APP_SECRET = 'secret';
+  const OUR_APP_ID = '1234567890';
+  const PAGE_ID = 'page_id_xyz';
+  const CUSTOMER_PSID = 'psid_customer_999';
+
+  let controller: FacebookWebhookController;
+  let router: { routeInbound: jest.Mock; mirrorOutbound: jest.Mock };
+
+  beforeEach(async () => {
+    router = {
+      routeInbound: jest.fn().mockResolvedValue(undefined),
+      mirrorOutbound: jest.fn().mockResolvedValue(undefined),
+    };
+    const config = {
+      get: jest.fn((key: string) => {
+        if (key === 'FB_APP_SECRET') return FB_APP_SECRET;
+        if (key === 'FB_VERIFY_TOKEN') return 'verify-token';
+        if (key === 'FACEBOOK_APP_ID') return OUR_APP_ID;
+        return undefined;
+      }),
+    };
+    const anomaly = { record: jest.fn().mockResolvedValue(undefined) };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      controllers: [FacebookWebhookController],
+      providers: [
+        { provide: MessageRouterService, useValue: router },
+        { provide: ConfigService, useValue: config },
+        { provide: WebhookAnomalyService, useValue: anomaly },
+      ],
+    }).compile();
+
+    controller = mod.get(FacebookWebhookController);
+  });
+
+  function echoPayload(message: Record<string, unknown>) {
+    return {
+      object: 'page',
+      entry: [
+        {
+          id: PAGE_ID,
+          messaging: [
+            {
+              sender: { id: PAGE_ID },
+              recipient: { id: CUSTOMER_PSID },
+              timestamp: 1700000000000,
+              message,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it('persists external echo (app_id ≠ ours) as STAFF via mirrorOutbound', async () => {
+    const body = echoPayload({
+      is_echo: true,
+      app_id: 99999999, // some other app (e.g. Meta Business Suite)
+      mid: 'mid.external.echo.1',
+      text: 'สวัสดีครับ ตอบจาก Meta Business Suite',
+    });
+    const { signature, req } = signedRequest(FB_APP_SECRET, body);
+
+    await controller.handleWebhook(req, body, signature);
+
+    expect(router.mirrorOutbound).toHaveBeenCalledWith({
+      externalUserId: CUSTOMER_PSID,
+      channel: ChatChannel.FACEBOOK,
+      role: MessageRole.STAFF,
+      type: 'TEXT',
+      text: 'สวัสดีครับ ตอบจาก Meta Business Suite',
+      mediaUrl: undefined,
+      externalMessageId: 'mid.external.echo.1',
+    });
+    expect(router.routeInbound).not.toHaveBeenCalled();
+  });
+
+  it('skips echo when message.app_id matches our FACEBOOK_APP_ID (our own send)', async () => {
+    const body = echoPayload({
+      is_echo: true,
+      app_id: Number(OUR_APP_ID),
+      mid: 'mid.our.send.1',
+      text: 'sent by sendStaffMessage already',
+    });
+    const { signature, req } = signedRequest(FB_APP_SECRET, body);
+
+    await controller.handleWebhook(req, body, signature);
+
+    expect(router.mirrorOutbound).not.toHaveBeenCalled();
+    expect(router.routeInbound).not.toHaveBeenCalled();
+  });
+
+  it('still persists echo when FACEBOOK_APP_ID is not configured (relies on externalMessageId dedup)', async () => {
+    // Rebuild controller with FACEBOOK_APP_ID unset
+    const localRouter = {
+      routeInbound: jest.fn().mockResolvedValue(undefined),
+      mirrorOutbound: jest.fn().mockResolvedValue(undefined),
+    };
+    const config = {
+      get: jest.fn((key: string) => {
+        if (key === 'FB_APP_SECRET') return FB_APP_SECRET;
+        if (key === 'FB_VERIFY_TOKEN') return 'verify-token';
+        return undefined; // FACEBOOK_APP_ID intentionally missing
+      }),
+    };
+    const anomaly = { record: jest.fn().mockResolvedValue(undefined) };
+    const mod = await Test.createTestingModule({
+      controllers: [FacebookWebhookController],
+      providers: [
+        { provide: MessageRouterService, useValue: localRouter },
+        { provide: ConfigService, useValue: config },
+        { provide: WebhookAnomalyService, useValue: anomaly },
+      ],
+    }).compile();
+    const localController = mod.get(FacebookWebhookController);
+
+    const body = echoPayload({
+      is_echo: true,
+      app_id: Number(OUR_APP_ID),
+      mid: 'mid.unknown.source.1',
+      text: 'fallback path',
+    });
+    const { signature, req } = signedRequest(FB_APP_SECRET, body);
+
+    await localController.handleWebhook(req, body, signature);
+
+    expect(localRouter.mirrorOutbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: MessageRole.STAFF,
+        externalMessageId: 'mid.unknown.source.1',
+      }),
+    );
+  });
+
+  it('parses image echo into IMAGE type with mediaUrl', async () => {
+    const body = echoPayload({
+      is_echo: true,
+      app_id: 99999999,
+      mid: 'mid.image.echo.1',
+      attachments: [
+        { type: 'image', payload: { url: 'https://cdn.fb/image.jpg' } },
+      ],
+    });
+    const { signature, req } = signedRequest(FB_APP_SECRET, body);
+
+    await controller.handleWebhook(req, body, signature);
+
+    expect(router.mirrorOutbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'IMAGE',
+        mediaUrl: 'https://cdn.fb/image.jpg',
+        externalMessageId: 'mid.image.echo.1',
+      }),
+    );
+  });
+
+  it('skips echo gracefully when recipient.id is missing', async () => {
+    const body = {
+      object: 'page',
+      entry: [
+        {
+          id: PAGE_ID,
+          messaging: [
+            {
+              sender: { id: PAGE_ID },
+              // recipient intentionally missing
+              timestamp: 1700000000000,
+              message: { is_echo: true, app_id: 99999999, mid: 'mid.x', text: 'x' },
+            },
+          ],
+        },
+      ],
+    };
+    const { signature, req } = signedRequest(FB_APP_SECRET, body);
+
+    await expect(controller.handleWebhook(req, body, signature)).resolves.toBe('EVENT_RECEIVED');
+    expect(router.mirrorOutbound).not.toHaveBeenCalled();
+  });
+
+  it('routes regular inbound (non-echo) through routeInbound', async () => {
+    const body = {
+      object: 'page',
+      entry: [
+        {
+          id: PAGE_ID,
+          messaging: [
+            {
+              sender: { id: CUSTOMER_PSID },
+              recipient: { id: PAGE_ID },
+              timestamp: 1700000000000,
+              message: { mid: 'mid.in.1', text: 'hi from customer' },
+            },
+          ],
+        },
+      ],
+    };
+    const { signature, req } = signedRequest(FB_APP_SECRET, body);
+
+    await controller.handleWebhook(req, body, signature);
+
+    expect(router.routeInbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalUserId: CUSTOMER_PSID,
+        text: 'hi from customer',
+        channel: ChatChannel.FACEBOOK,
+      }),
+    );
+    expect(router.mirrorOutbound).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
+++ b/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
@@ -19,7 +19,7 @@ import { MessageRouterService } from '../chat-engine/services/message-router.ser
 import { InboundMessage } from '../chat-engine/interfaces/channel-adapter.interface';
 import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'crypto';
-import { ChatChannel, MessageType } from '@prisma/client';
+import { ChatChannel, MessageRole, MessageType } from '@prisma/client';
 import { RawBodyRequest } from '../../common/types/raw-body-request';
 import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
 
@@ -150,16 +150,25 @@ export class FacebookWebhookController {
 
   /**
    * Process a single messaging event from Facebook.
-   * Supports: text messages, attachments (image/audio/video/file), postbacks.
-   * Ignores: read receipts, delivery confirmations, echoes.
+   * Supports: text messages, attachments (image/audio/video/file), postbacks,
+   * and echoes (admin replied via Meta Business Suite / Page Inbox).
+   * Ignores: read receipts, delivery confirmations.
    */
   private async processMessagingEvent(event: any): Promise<void> {
     const senderId: string | undefined = event.sender?.id;
+    const recipientId: string | undefined = event.recipient?.id;
     const message = event.message;
     const postback = event.postback;
 
-    // Skip echo messages (sent by our page), delivery, and read events
     if (!senderId) return;
+
+    // Echo: admin replied via Meta Business Suite / FB Page Inbox / FB Page app.
+    // sender.id = our PAGE_ID, recipient.id = customer PSID, message.is_echo = true.
+    // Record as STAFF so the reply shows up in /chat alongside our own sends.
+    if (message?.is_echo === true) {
+      await this.processEchoEvent(event, recipientId);
+      return;
+    }
 
     // Handle postback events (persistent menu clicks, button taps)
     if (postback && !message) {
@@ -192,7 +201,7 @@ export class FacebookWebhookController {
       return;
     }
 
-    if (!message || message.is_echo) return;
+    if (!message) return;
 
     const { type, text, mediaUrl } = this.parseMessage(message);
 
@@ -224,6 +233,62 @@ export class FacebookWebhookController {
     );
 
     await this.messageRouter.routeInbound(inbound);
+  }
+
+  /**
+   * Persist a Facebook `message_echoes` event as a STAFF message so admin
+   * replies sent outside our /chat UI (Meta Business Suite, Page Inbox, FB
+   * Page mobile app) still appear in the unified inbox.
+   *
+   * Dedup strategy (two layers):
+   * 1. Skip echoes whose `message.app_id` matches our own FACEBOOK_APP_ID — those
+   *    were sent by `sendStaffMessage` and are already in the DB.
+   * 2. Fallback: rely on the UNIQUE constraint on `ChatMessage.externalMessageId`
+   *    (FB `mid`). `mirrorOutbound` swallows P2002 conflicts so retried webhook
+   *    deliveries don't double-record.
+   *
+   * Identifying *which* admin clicked Send is not possible — Facebook removed
+   * page-admin enumeration in Graph API v15+ and echoes do not carry the admin's
+   * user id. Source of the reply (Meta Business Suite vs Page Inbox vs an app)
+   * is only knowable via `message.app_id`, which we log but don't persist.
+   */
+  private async processEchoEvent(event: any, recipientId: string | undefined): Promise<void> {
+    const message = event.message;
+
+    if (!recipientId) {
+      this.logger.warn('[FB Webhook] Echo event missing recipient.id — cannot map to customer room');
+      return;
+    }
+
+    const ownAppId = this.configService.get<string>('FACEBOOK_APP_ID');
+    const echoAppId = message.app_id != null ? String(message.app_id) : undefined;
+
+    if (ownAppId && echoAppId && echoAppId === ownAppId) {
+      // Our own sendStaffMessage already persisted this message — skip.
+      return;
+    }
+
+    if (!ownAppId) {
+      this.logger.warn(
+        '[FB Webhook] FACEBOOK_APP_ID not set — cannot distinguish own sends from external echoes; relying on externalMessageId UNIQUE for dedup',
+      );
+    }
+
+    const { type, text, mediaUrl } = this.parseMessage(message);
+
+    this.logger.log(
+      `[FB Webhook] Echo ${type} → PSID ${recipientId} (mid: ${message.mid}, app_id: ${echoAppId ?? 'none'})`,
+    );
+
+    await this.messageRouter.mirrorOutbound({
+      externalUserId: recipientId,
+      channel: ChatChannel.FACEBOOK,
+      role: MessageRole.STAFF,
+      type,
+      text: text ?? undefined,
+      mediaUrl: mediaUrl ?? undefined,
+      externalMessageId: message.mid,
+    });
   }
 
   /**

--- a/apps/api/src/modules/chat-engine/services/message-router.service.ts
+++ b/apps/api/src/modules/chat-engine/services/message-router.service.ts
@@ -369,7 +369,15 @@ export class MessageRouterService {
     });
   }
 
-  /** Mirror an outbound (bot/staff) message to ChatRoom — for channels that send outside MessageRouter */
+  /**
+   * Mirror an outbound (bot/staff) message to ChatRoom — for channels that send
+   * outside MessageRouter (e.g. Facebook `message_echoes` when an admin replied
+   * via Meta Business Suite / Page Inbox instead of through our /chat UI).
+   *
+   * `externalMessageId` (if provided) carries the platform's message id (FB `mid`)
+   * — relies on the UNIQUE constraint on ChatMessage.externalMessageId to
+   * silently dedupe if the same echo is re-delivered.
+   */
   async mirrorOutbound(params: {
     externalUserId: string;
     channel: ChatChannel;
@@ -378,18 +386,40 @@ export class MessageRouterService {
     type?: MessageType;
     mediaUrl?: string;
     staffId?: string;
+    externalMessageId?: string;
   }): Promise<void> {
     const room = await this.roomManager.getOrCreateRoom({
       externalUserId: params.externalUserId,
       channel: params.channel,
     });
-    await this.roomManager.saveMessage({
-      roomId: room.id,
-      role: params.role,
+    try {
+      await this.roomManager.saveMessage({
+        roomId: room.id,
+        externalMessageId: params.externalMessageId,
+        role: params.role,
+        text: params.text,
+        type: params.type,
+        mediaUrl: params.mediaUrl,
+        staffId: params.staffId,
+      });
+    } catch (err) {
+      // UNIQUE violation on externalMessageId — echo replay; safe to ignore.
+      const code = (err as { code?: string })?.code;
+      if (params.externalMessageId && code === 'P2002') {
+        this.logger.debug(
+          `[mirrorOutbound] Duplicate echo skipped: ${params.externalMessageId}`,
+        );
+        return;
+      }
+      throw err;
+    }
+
+    this.gateway?.emitNewMessage(room.id, {
+      role: params.role === MessageRole.BOT ? 'BOT' : 'STAFF',
       text: params.text,
-      type: params.type,
-      mediaUrl: params.mediaUrl,
-      staffId: params.staffId,
+      type: params.type ?? MessageType.TEXT,
+      channel: params.channel,
+      roomId: room.id,
     });
   }
 


### PR DESCRIPTION
## Problem

When an admin replies to a customer via **Meta Business Suite**, **facebook.com Page Inbox**, or the **FB Pages mobile app** (i.e. not through /chat in BESTCHOICE), Facebook delivers the message back to us via webhook with `message.is_echo = true`. The old code dropped these events at [facebook-webhook.controller.ts:195](apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts#L195), so staff only saw the inbound customer side — the conversation looked one-sided in /chat.

## Fix

New `processEchoEvent` in the FB webhook controller maps the echo to a ChatRoom by `recipient.id` (customer PSID) and records it as `MessageRole.STAFF` via the existing `mirrorOutbound` path on `MessageRouterService`.

## Dedup (two layers)

1. **Primary** — skip when `message.app_id === FACEBOOK_APP_ID`. Those echoes are replays of `sendStaffMessage`, which already wrote the row.
2. **Fallback** — UNIQUE constraint on `ChatMessage.externalMessageId` (FB `mid`). `mirrorOutbound` now catches `P2002` and silently skips, so webhook retries do not double-record.

## Known limitation

We cannot identify *which* admin pressed Send. Facebook removed page-admin enumeration in Graph API v15+, and echoes carry only the page id in `sender.id` (not the admin's user id). All external echoes are recorded as a generic `STAFF` message with `staffId = null`.

## Required ops steps before this helps

1. Enable **`message_echoes`** in FB App Dashboard → Messenger → Webhooks → Page subscriptions (default off).
2. Set **`FACEBOOK_APP_ID`** in prod Cloud Run env (numeric App ID from FB App Dashboard → Settings → Basic) so own-send dedup runs cleanly. Without it the fallback UNIQUE protects integrity but logs a warn per echo.

## Test plan

- [x] `./tools/check-types.sh api` — 0 errors
- [x] `jest facebook-webhook.controller.spec` — 7/7 pass (1 existing rawBody test + 6 new echo tests covering: external app echo, own-app skip, no-app-id-env fallback, image attachment, missing recipient.id, regular inbound regression)
- [x] `jest message-router room-manager` — 13/13 pass (no regression on mirrorOutbound extension)
- [ ] Smoke test in prod: reply from Meta Business Suite to a FB customer → verify staff bubble appears in /chat with correct text and `staffId = null`