### PR TITLE
chore(deploy): add FACEBOOK_APP_ID env (preserves PR #830 echo dedup across redeploys)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -281,6 +281,7 @@ jobs:
           LIFF_CHANNEL_ID=2009442540,\
           SMS_PAYMENT_REMINDER_DISABLED=true,\
           FB_BOT_DISABLED=true,\
+          FACEBOOK_APP_ID=2736219233418171,\
           LINE_FINANCE_BOT_DISABLED=true,\
           LINE_SHOP_BOT_DISABLED=true,\
           GOOGLE_CLOUD_PROJECT=${{ secrets.GCP_PROJECT_ID }},\


### PR DESCRIPTION
## Why

PR #830 introduced an own-send dedup that skips FB \`message_echoes\` whose \`message.app_id\` matches our app. Without \`FACEBOOK_APP_ID\` set, the fallback path (UNIQUE constraint on \`ChatMessage.externalMessageId\`) still works but logs a warn on every echo.

Already applied to prod revision \`bestchoice-api-00522-h4q\` via \`gcloud run services update --update-env-vars\`. This commit adds the same value to \`deploy-gcp.yml\` so the next CI \`--set-env-vars\` doesn't drop it (per [project_cicd_set_secrets_pattern memory](https://github.com/iamnaii/BESTCHOICE/issues)).

## Value

\`FACEBOOK_APP_ID=2736219233418171\` — BESTCHOICE FB App ID. Public information (app secret stays in Secret Manager separately), so plain env var instead of secret.

## Test plan

- [x] Health check on new revision (00522-h4q) returns 200
- [x] FACEBOOK_APP_ID present in \`gcloud run services describe\` env list
- [ ] Confirm next CI deploy preserves the var