### PR TITLE
feat(other-income): allow 42-1103 for late-fee-only payments

### DIFF
--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -310,7 +310,7 @@ Routes: `/other-income`, `/other-income/new`, `/other-income/:id`, `/other-incom
 
 Key accounts (from FINANCE 99-account chart):
 - `42-1102` — ดอกเบี้ยเงินฝาก (Bank interest income — exempt from VAT, subject to 15% WHT)
-- `42-1103` — ค่าปรับชำระล่าช้า (Late fee — auto-posted via `PaymentReceipt2BTemplate`; **blocked at V4 in this module to prevent duplicate entry**)
+- `42-1103` — ค่าปรับชำระล่าช้า (Late fee — usually auto-posted via `PaymentReceipt2BTemplate` together with installment payment. Also bookable here for "late-fee-only" scenarios where customer pays just the penalty without settling the installment. **Watch for duplicate-entry risk**: if booked here, do NOT also pass `lateFee` on the next installment Payment for the same month, or 42-1103 will be credited twice.)
 - `42-1104` — รายได้จากการหักค่าจ้าง (Payroll deduction — Pattern B deferred until payroll module exists)
 - `42-1105` — กำไรจากการจำหน่ายสินทรัพย์ (Gain on disposal of assets — VAT 7%)
 

--- a/apps/api/src/modules/other-income/__tests__/validation.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/validation.spec.ts
@@ -48,14 +48,13 @@ describe('ValidationService', () => {
     expect(result.errors.find((e) => e.rule === 'V4')).toBeDefined();
   });
 
-  it('V4: blocks 42-1103 (already auto-posted by PaymentReceipt2BTemplate)', () => {
+  it('V4: allows 42-1103 (late-fee-only payment scenario)', () => {
     const doc = {
       ...goldenCases.bankInterest,
       items: [{ ...goldenCases.bankInterest.items[0], accountCode: '42-1103' }],
     };
     const result = service.validate(doc, baseCtx);
-    const v4 = result.errors.find((e) => e.rule === 'V4');
-    expect(v4?.msg).toMatch(/42-1103/);
+    expect(result.errors.find((e) => e.rule === 'V4')).toBeUndefined();
   });
 
   it('V6: VAT% > 0 must coexist with VAT account on JE', () => {

--- a/apps/api/src/modules/other-income/services/validation.service.ts
+++ b/apps/api/src/modules/other-income/services/validation.service.ts
@@ -48,7 +48,6 @@ export interface ValidationResult {
 }
 
 const VALID_WHT_PCT = [0, 1, 2, 3, 5, 7, 10, 15];
-const BLOCKED_INCOME_CODES = new Set(['42-1103']);
 
 /**
  * Validation rule numbering — aligned to the accountant's PDF Spec v1.0
@@ -97,12 +96,6 @@ export class ValidationService {
           rule: 'V4',
           lineNo: it.lineNo,
           msg: `รายการที่ ${it.lineNo}: ต้องเลือกบัญชีกลุ่ม 42-XXXX`,
-        });
-      } else if (BLOCKED_INCOME_CODES.has(it.accountCode)) {
-        errors.push({
-          rule: 'V4',
-          lineNo: it.lineNo,
-          msg: `บัญชี ${it.accountCode} ถูกบันทึกอัตโนมัติผ่านหน้ารับชำระค่างวดอยู่แล้ว — ไม่ต้องบันทึกซ้ำที่นี่`,
         });
       }
 

--- a/apps/web/src/pages/other-income/components/ItemsTable.tsx
+++ b/apps/web/src/pages/other-income/components/ItemsTable.tsx
@@ -92,7 +92,7 @@ export function ItemsTable({ control, register, watch, setValue }: Props) {
                     onChange={(c) => {
                       setValue(`items.${idx}.accountCode`, c, { shouldValidate: true });
                     }}
-                    filter={(a) => a.code.startsWith('42-') && a.code !== '42-1103'}
+                    filter={(a) => a.code.startsWith('42-')}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- ปลดล็อก `42-1103` (ค่าปรับชำระล่าช้า) ในหน้า `/other-income/new` รองรับเคสลูกค้าจ่ายเฉพาะค่าปรับ ไม่จ่ายงวด
- ลบ frontend filter + backend V4 BLOCKED_INCOME_CODES + flip validation test + update accounting.md

## Why
`PaymentReceipt2BTemplate` บังคับ amountReceived = installmentTotal + lateFee (±1฿ tolerance) ทำให้ "จ่ายค่าปรับเดี่ยว" ไม่มีทางลงในระบบเลย เดิม 42-1103 ถูก block ไว้ที่ V4 เพราะ assume ว่ามากับงวดเสมอ แต่ business จริงไม่ใช่

## Trade-off (documented in accounting.md)
ต้องระวัง double-count: ถ้าลงในหน้านี้แล้ว ตอนรับงวดเดือนเดียวกัน **ห้ามใส่ `lateFee`** อีก ไม่งั้น Cr 42-1103 ซ้ำ

## Test plan
- [x] TypeScript: 0 errors (api + web)
- [x] Jest: 13/13 ผ่าน (`validation.spec.ts` รวม flip test "allows 42-1103")
- [ ] Manual: ไปที่ `/other-income/new` → dropdown "บัญชีรายได้" ต้องเห็น 4 ตัว (42-1102/1103/1104/1105) → ลอง POST รายการ 42-1103 100฿ → JE ลง Dr cash / Cr 42-1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)