### PR TITLE
feat(other-income): v2.3 UI PDF gap — DateRangeChips + InternalControlBar

### DIFF
--- a/apps/api/src/modules/other-income/__tests__/other-income.controller.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.controller.spec.ts
@@ -132,6 +132,12 @@ describe('OtherIncomeController — unit (mocked service)', () => {
     expect(result).toHaveProperty('data');
   });
 
+  it('list() forwards statusIn (DRAFT,READY) for "ค้างดำเนินการ" filter card', async () => {
+    const query = { page: 1, limit: 50, statusIn: 'DRAFT,READY' };
+    await controller.list(query as any);
+    expect(service.list).toHaveBeenCalledWith(query);
+  });
+
   it('findOne() delegates to service.findOneOrFail() with id', async () => {
     const id = '00000000-0000-0000-0000-000000000001';
     const result = await controller.findOne(id);

--- a/apps/api/src/modules/other-income/dto/list-other-income-query.dto.ts
+++ b/apps/api/src/modules/other-income/dto/list-other-income-query.dto.ts
@@ -7,6 +7,18 @@ export class ListOtherIncomeQueryDto {
   @IsEnum(OtherIncomeStatus)
   status?: OtherIncomeStatus;
 
+  /**
+   * Comma-separated list of statuses (e.g. "DRAFT,READY"). Used by the
+   * "ค้างดำเนินการ" (in-progress) status card which folds DRAFT + READY into
+   * one filter. Takes precedence over `status` when both are provided.
+   */
+  @IsOptional()
+  @IsString()
+  @Matches(/^(DRAFT|READY|POSTED|REVERSED)(,(DRAFT|READY|POSTED|REVERSED))*$/, {
+    message: 'statusIn ต้องเป็น comma-separated เช่น "DRAFT,READY"',
+  })
+  statusIn?: string;
+
   @IsOptional()
   @IsDateString()
   startDate?: string;

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -942,9 +942,18 @@ export class OtherIncomeService {
       }
     }
 
+    // statusIn (comma-separated) takes precedence over single `status` —
+    // supports "ค้างดำเนินการ" card which filters DRAFT+READY together.
+    const statusInArr = query.statusIn
+      ? (query.statusIn.split(',').filter(Boolean) as OtherIncomeStatus[])
+      : null;
     const where: Prisma.OtherIncomeWhereInput = {
       deletedAt: null,
-      ...(query.status ? { status: query.status } : {}),
+      ...(statusInArr && statusInArr.length > 0
+        ? { status: { in: statusInArr } }
+        : query.status
+          ? { status: query.status }
+          : {}),
       ...(query.startDate || query.endDate
         ? {
             issueDate: {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -308,7 +308,6 @@ layer(base);
     --color-editor-variable-text: #047857;
     --color-editor-placeholder: #9ca3af;
     --accent-purple: 280 60% 55%;
-    --accent-purple-foreground: 280 80% 95%;
   }
 
   .dark {
@@ -348,7 +347,6 @@ layer(base);
     --chart-4: 0 84% 60%;
     --chart-5: 271 91% 65%;
     --accent-purple: 280 65% 65%;
-    --accent-purple-foreground: 280 30% 12%;
   }
 
   /* Global focus style */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -307,6 +307,8 @@ layer(base);
     --color-editor-variable-bg: #d1fae5;
     --color-editor-variable-text: #047857;
     --color-editor-placeholder: #9ca3af;
+    --accent-purple: 280 60% 55%;
+    --accent-purple-foreground: 280 80% 95%;
   }
 
   .dark {
@@ -345,6 +347,8 @@ layer(base);
     --chart-3: 48 96% 53%;
     --chart-4: 0 84% 60%;
     --chart-5: 271 91% 65%;
+    --accent-purple: 280 65% 65%;
+    --accent-purple-foreground: 280 30% 12%;
   }
 
   /* Global focus style */

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -23,7 +23,7 @@ export const THAI_MONTHS_FULL = [
   'ธันวาคม',
 ];
 
-const THAI_MONTHS_SHORT = [
+export const THAI_MONTHS_SHORT = [
   'ม.ค.',
   'ก.พ.',
   'มี.ค.',

--- a/apps/web/src/lib/otherIncome.ts
+++ b/apps/web/src/lib/otherIncome.ts
@@ -12,6 +12,8 @@ import type { OtherIncomeFormValues } from './otherIncome.schema';
 
 export interface ListQuery {
   status?: OtherIncomeStatus;
+  /** Comma-separated, e.g. "DRAFT,READY" — used by "ค้างดำเนินการ" filter card. */
+  statusIn?: string;
   startDate?: string;
   endDate?: string;
   q?: string;

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -5,13 +5,9 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
-  Save,
-  Send,
   ArrowLeft,
   FileText,
   AlertTriangle,
-  CloudUpload,
-  CheckCircle2,
   Upload,
   Wallet,
   Building2,
@@ -34,6 +30,7 @@ import { TemplatePickerCombobox } from './components/TemplatePickerCombobox';
 import { OverrideConfirmDialog } from './components/OverrideConfirmDialog';
 import { EditableJournalTable, getJournalIssues } from './components/EditableJournalTable';
 import type { EditableJournalLine } from './components/EditableJournalTable';
+import { InternalControlBar } from './components/InternalControlBar';
 
 // Fallback while config is loading; live value comes from /other-income/config/attachment-threshold
 const ATTACHMENT_THRESHOLD_FALLBACK = 50_000;
@@ -575,7 +572,7 @@ export default function OtherIncomeEntryPage() {
   const userDisplayName = user?.name || user?.email || 'ผู้ใช้ปัจจุบัน';
 
   return (
-    <div className="pb-32">
+    <div className="pb-44 md:pb-40">
       <div className="p-4 md:p-6 max-w-5xl mx-auto">
         <div className="mb-4">
           <AccountingModuleTabBar />
@@ -969,32 +966,10 @@ export default function OtherIncomeEntryPage() {
             )}
           </section>
 
-          {/* Section 7 — Recorder & Approver */}
-          <section className="rounded-xl border bg-card p-5">
-            <SectionHeader num={7} title="ผู้บันทึก & ผู้อนุมัติ" />
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <p className="text-xs italic text-muted-foreground">
-                ระบบกำหนดอัตโนมัติตาม user ที่เข้าใช้งานในขณะนี้
-              </p>
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-info/10 text-info text-xs">
-                  <CloudUpload size={13} />
-                  <span className="text-muted-foreground">ผู้บันทึก:</span>
-                  <span className="font-semibold text-foreground">{userDisplayName}</span>
-                </span>
-                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-success/10 text-success text-xs">
-                  <CheckCircle2 size={13} />
-                  <span className="text-muted-foreground">ผู้อนุมัติ:</span>
-                  <span className="font-semibold text-foreground">{userDisplayName}</span>
-                </span>
-              </div>
-            </div>
-          </section>
-
-          {/* Section 8 — Attachments */}
+          {/* Section 7 — Attachments */}
           <section className={`rounded-xl border p-5 ${needsAttachment ? 'border-warning bg-warning/5' : 'bg-card'}`}>
             <SectionHeader
-              num={8}
+              num={7}
               title="แนบไฟล์เอกสาร (ไม่บังคับ)"
               hint="PDF/JPG/PNG ≤ 5MB"
             />
@@ -1092,9 +1067,9 @@ export default function OtherIncomeEntryPage() {
             )}
           </section>
 
-          {/* Section 9 — Confirmation summary */}
+          {/* Section 8 — Confirmation summary */}
           <section className="rounded-xl border bg-card p-5">
-            <SectionHeader num={9} title="สรุปก่อนยืนยัน" />
+            <SectionHeader num={8} title="สรุปก่อนยืนยัน" />
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2 text-sm font-mono">
                 <div className="flex justify-between">
@@ -1127,85 +1102,44 @@ export default function OtherIncomeEntryPage() {
         </form>
       </div>
 
-      {/* Sticky bottom action bar */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 bg-background border-t shadow-lg px-4 md:px-6 py-3">
-        <div className="max-w-5xl mx-auto flex items-center justify-between gap-3 flex-wrap">
-          <div className="text-xs flex items-center gap-1.5">
-            {errorCount > 0 ? (
-              <span className="inline-flex items-center gap-1 text-destructive font-semibold">
-                <AlertTriangle size={14} />
-                มี {errorCount} ข้อต้องแก้ไข
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-1 text-success font-semibold">
-                <CheckCircle2 size={14} />
-                ข้อมูลพร้อม POST
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => navigate('/other-income')}
-              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border rounded-md hover:bg-accent"
-            >
-              <ArrowLeft size={14} />
-              ยกเลิก
-            </button>
-            <button
-              type="button"
-              disabled={isSubmitting}
-              onClick={() => {
-                const raw = form.getValues();
-                const result = otherIncomeFormSchema.safeParse(raw);
-                if (!result.success) {
-                  toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
-                  return;
-                }
-                saveDraftMutation.mutate(result.data);
-              }}
-              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
-            >
-              <Save size={14} />
-              {saveDraftMutation.isPending ? 'กำลังบันทึก...' : 'บันทึกร่าง'}
-            </button>
-            <button
-              type="button"
-              disabled={isSubmitting || !canPost}
-              title={
-                needsAttachment
-                  ? `ต้องแนบเอกสารเมื่อยอดรับ ≥ ${formatNumber(attachmentThreshold)} ฿`
-                  : errorCount > 0
-                    ? `ยังมี ${errorCount} ข้อต้องแก้ไข`
-                    : undefined
-              }
-              onClick={() => {
-                const raw = form.getValues();
-                const result = otherIncomeFormSchema.safeParse(raw);
-                if (!result.success) {
-                  toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
-                  return;
-                }
-                if (makerCheckerEnabled) {
-                  saveAndRequestApprovalMutation.mutate(result.data);
-                } else {
-                  saveAndPostMutation.mutate(result.data);
-                }
-              }}
-              className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              <Send size={14} />
-              {saveAndRequestApprovalMutation.isPending
-                ? 'กำลังส่งขออนุมัติ...'
-                : saveAndPostMutation.isPending
-                  ? 'กำลัง POST...'
-                  : makerCheckerEnabled
-                    ? 'บันทึกและส่งขออนุมัติ'
-                    : 'บันทึก & POST'}
-            </button>
-          </div>
-        </div>
-      </div>
+      {/* Internal Control Bar (v2.3 — replaces Section 7 card + old sticky bar) */}
+      <InternalControlBar
+        status="DRAFT"
+        recorder={{ name: userDisplayName }}
+        approver={{ name: makerCheckerEnabled ? 'OWNER' : userDisplayName }}
+        makerCheckerEnabled={makerCheckerEnabled}
+        isLoading={isSubmitting}
+        errorCount={errorCount}
+        canPost={canPost}
+        onCancel={() => navigate('/other-income')}
+        onSaveDraft={() => {
+          const raw = form.getValues();
+          const result = otherIncomeFormSchema.safeParse(raw);
+          if (!result.success) {
+            toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+            return;
+          }
+          saveDraftMutation.mutate(result.data);
+        }}
+        onPost={() => {
+          const raw = form.getValues();
+          const result = otherIncomeFormSchema.safeParse(raw);
+          if (!result.success) {
+            toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+            return;
+          }
+          saveAndPostMutation.mutate(result.data);
+        }}
+        onSubmitForApproval={() => {
+          const raw = form.getValues();
+          const result = otherIncomeFormSchema.safeParse(raw);
+          if (!result.success) {
+            toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+            return;
+          }
+          saveAndRequestApprovalMutation.mutate(result.data);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -105,11 +105,14 @@ export default function OtherIncomeListPage() {
 
   const [q, setQ] = useState('');
   const [status, setStatus] = useState<OtherIncomeStatus | ''>('');
-  const todayInit = new Date();
-  const firstOfMonthInit = `${todayInit.getFullYear()}-${String(todayInit.getMonth() + 1).padStart(2, '0')}-01`;
-  const todayIsoInit = `${todayInit.getFullYear()}-${String(todayInit.getMonth() + 1).padStart(2, '0')}-${String(todayInit.getDate()).padStart(2, '0')}`;
-  const [startDate, setStartDate] = useState(firstOfMonthInit);
-  const [endDate, setEndDate] = useState(todayIsoInit);
+  const [startDate, setStartDate] = useState(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
+  });
+  const [endDate, setEndDate] = useState(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  });
   const { page, size, setPage, setSize } = usePaginationParams({ defaultSize: 50 });
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [confirmDeleteNumber, setConfirmDeleteNumber] = useState<string>('');

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, ArrowRight, ClipboardCheck } from 'lucide-react';
+import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, ClipboardCheck } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -51,21 +51,24 @@ function fmtDate(d: string | null | undefined) {
   return formatThaiDateShort(d);
 }
 
-type StatusAccent = 'warning' | 'info' | 'success' | 'muted';
+type StatusAccent = 'primary' | 'warning' | 'success' | 'muted';
 
 const ACCENT_BAR: Record<StatusAccent, string> = {
+  primary: 'bg-primary',
   warning: 'bg-warning',
-  info: 'bg-info',
   success: 'bg-success',
   muted: 'bg-muted-foreground/50',
 };
 
 const ACCENT_ICON: Record<StatusAccent, string> = {
+  primary: 'bg-primary/10 text-primary',
   warning: 'bg-warning/10 text-warning',
-  info: 'bg-info/10 text-info',
   success: 'bg-success/10 text-success',
   muted: 'bg-muted text-muted-foreground',
 };
+
+/** Filter keys for the 4 Status Cards (PDF v2.2 spec). */
+type StatusFilter = 'ALL' | 'IN_PROGRESS' | 'POSTED' | 'REVERSED';
 
 function StatusCard({
   label,
@@ -73,15 +76,26 @@ function StatusCard({
   icon,
   accent,
   value,
+  active,
+  onClick,
 }: {
   label: string;
   sub: string;
   icon: React.ReactNode;
   accent: StatusAccent;
   value: number;
+  active: boolean;
+  onClick: () => void;
 }) {
   return (
-    <div className="rounded-xl border bg-card p-4 relative overflow-hidden">
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`text-left rounded-xl border bg-card p-4 relative overflow-hidden transition-all hover:border-foreground/30 hover:bg-accent/30 ${
+        active ? 'ring-2 ring-primary border-primary/40 bg-primary/5' : ''
+      }`}
+    >
       <span className={`absolute inset-x-0 top-0 h-1 ${ACCENT_BAR[accent]}`} />
       <div className="flex items-start justify-between mb-3">
         <div className="min-w-0">
@@ -95,7 +109,7 @@ function StatusCard({
         </div>
       </div>
       <p className="text-3xl font-bold font-mono text-foreground tabular-nums">{value}</p>
-    </div>
+    </button>
   );
 }
 
@@ -104,7 +118,7 @@ export default function OtherIncomeListPage() {
   const queryClient = useQueryClient();
 
   const [q, setQ] = useState('');
-  const [status, setStatus] = useState<OtherIncomeStatus | ''>('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
   const [startDate, setStartDate] = useState(() => {
     const d = new Date();
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
@@ -119,15 +133,32 @@ export default function OtherIncomeListPage() {
 
   const debouncedQ = useDebounce(q, 300);
 
-  // PDF AC-5: READY filter sorts oldest first (ascending) so approvers see the oldest pending items
-  const sortDir = status === 'READY' ? 'asc' : 'desc';
+  const flagQuery = useQuery({
+    queryKey: ['other-income-maker-checker-enabled'],
+    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
+    staleTime: 5 * 60_000,
+  });
+  const makerCheckerEnabled = flagQuery.data ?? false;
+
+  // Map filter key → API params. IN_PROGRESS folds DRAFT+READY when MC is on,
+  // falls back to DRAFT-only otherwise (READY status only exists with MC).
+  const filterParams: { status?: OtherIncomeStatus; statusIn?: string } = (() => {
+    if (statusFilter === 'ALL') return {};
+    if (statusFilter === 'IN_PROGRESS') {
+      return makerCheckerEnabled ? { statusIn: 'DRAFT,READY' } : { status: 'DRAFT' };
+    }
+    return { status: statusFilter };
+  })();
+
+  // PDF AC-5: sort oldest first for READY-heavy filters (IN_PROGRESS), newest first otherwise
+  const sortDir = statusFilter === 'IN_PROGRESS' ? 'asc' : 'desc';
 
   const listQuery = useQuery({
-    queryKey: ['other-income', 'list', { page, size, q: debouncedQ, status, startDate, endDate }],
+    queryKey: ['other-income', 'list', { page, size, q: debouncedQ, statusFilter, makerCheckerEnabled, startDate, endDate }],
     queryFn: () =>
       otherIncomeApi.list({
         q: debouncedQ || undefined,
-        status: status || undefined,
+        ...filterParams,
         startDate: startDate || undefined,
         endDate: endDate || undefined,
         page,
@@ -137,9 +168,20 @@ export default function OtherIncomeListPage() {
   });
 
   const COUNT_STALE_TIME = 60_000;
-  const draftCountQuery = useQuery({
-    queryKey: ['other-income', 'count', 'DRAFT'],
-    queryFn: () => otherIncomeApi.list({ status: 'DRAFT', page: 1, limit: 1 }),
+  const allCountQuery = useQuery({
+    queryKey: ['other-income', 'count', 'ALL'],
+    queryFn: () => otherIncomeApi.list({ page: 1, limit: 1 }),
+    select: (d) => d.total,
+    staleTime: COUNT_STALE_TIME,
+  });
+  const inProgressCountQuery = useQuery({
+    queryKey: ['other-income', 'count', 'IN_PROGRESS', makerCheckerEnabled],
+    queryFn: () =>
+      otherIncomeApi.list(
+        makerCheckerEnabled
+          ? { statusIn: 'DRAFT,READY', page: 1, limit: 1 }
+          : { status: 'DRAFT', page: 1, limit: 1 },
+      ),
     select: (d) => d.total,
     staleTime: COUNT_STALE_TIME,
   });
@@ -156,21 +198,6 @@ export default function OtherIncomeListPage() {
     staleTime: COUNT_STALE_TIME,
   });
 
-  const flagQuery = useQuery({
-    queryKey: ['other-income-maker-checker-enabled'],
-    queryFn: () => otherIncomeApi.isMakerCheckerEnabled(),
-    staleTime: 5 * 60_000,
-  });
-  const makerCheckerEnabled = flagQuery.data ?? false;
-
-  const readyCountQuery = useQuery({
-    queryKey: ['other-income', 'count', 'READY'],
-    queryFn: () => otherIncomeApi.list({ status: 'READY', page: 1, limit: 1 }),
-    select: (d) => d.total,
-    staleTime: COUNT_STALE_TIME,
-    enabled: makerCheckerEnabled,
-  });
-
   const deleteMutation = useMutation({
     mutationFn: (id: string) => otherIncomeApi.softDelete(id),
     onSuccess: () => {
@@ -184,10 +211,15 @@ export default function OtherIncomeListPage() {
   const docs = data?.data ?? [];
   const total = data?.total ?? 0;
 
-  const draftCount = draftCountQuery.data ?? 0;
-  const readyCount = readyCountQuery.data ?? 0;
+  const allCount = allCountQuery.data ?? 0;
+  const inProgressCount = inProgressCountQuery.data ?? 0;
   const postedCount = postedCountQuery.data ?? 0;
   const reversedCount = reversedCountQuery.data ?? 0;
+
+  const handleFilterClick = (filter: StatusFilter) => {
+    setStatusFilter(filter);
+    setPage(1);
+  };
 
   return (
     <div className="p-6 max-w-7xl mx-auto space-y-4">
@@ -198,72 +230,66 @@ export default function OtherIncomeListPage() {
         subtitle="จัดการเอกสารรับรู้รายได้อื่น (กลุ่ม 42-XXXX) — ดอกเบี้ยเงินฝาก, ค่าปรับ, รายได้หักค่าจ้าง ฯลฯ"
         icon={<Receipt size={20} />}
         action={
-          <button
-            onClick={() => navigate('/other-income/new')}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90 transition-colors"
-          >
-            <Plus size={16} />
-            สร้างเอกสารใหม่
-          </button>
+          <div className="flex items-center gap-2">
+            <Link
+              to="/other-income/daily-sheet"
+              className="inline-flex items-center gap-2 px-3 py-2 border rounded-lg text-sm font-medium hover:bg-accent transition-colors"
+            >
+              <ChartBar size={16} />
+              สรุปรายวัน
+            </Link>
+            <button
+              onClick={() => navigate('/other-income/new')}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-semibold hover:bg-primary/90 transition-colors"
+            >
+              <Plus size={16} />
+              สร้างเอกสารใหม่
+            </button>
+          </div>
         }
       />
 
-      {/* Status cards */}
-      <div className={`grid gap-3 mb-6 ${makerCheckerEnabled ? 'grid-cols-2 md:grid-cols-5' : 'grid-cols-2 md:grid-cols-4'}`}>
+      {/* Status filter cards — 4 clickable cards per PDF v2.2 spec */}
+      <div className="grid gap-3 mb-6 grid-cols-2 md:grid-cols-4">
         <StatusCard
-          label="ฉบับร่าง"
-          sub="DRAFT"
+          label="ทั้งหมด"
+          sub="ALL DOCS"
           icon={<FileText size={16} />}
-          accent="warning"
-          value={draftCount}
+          accent="primary"
+          value={allCount}
+          active={statusFilter === 'ALL'}
+          onClick={() => handleFilterClick('ALL')}
         />
-        {makerCheckerEnabled && (
-          <StatusCard
-            label="รออนุมัติ"
-            sub="READY"
-            icon={<ClipboardCheck size={16} />}
-            accent="info"
-            value={readyCount}
-          />
-        )}
         <StatusCard
-          label="บันทึกแล้ว"
+          label="ค้างดำเนินการ"
+          sub={makerCheckerEnabled ? 'DRAFT + READY' : 'DRAFT'}
+          icon={<ClipboardCheck size={16} />}
+          accent="warning"
+          value={inProgressCount}
+          active={statusFilter === 'IN_PROGRESS'}
+          onClick={() => handleFilterClick('IN_PROGRESS')}
+        />
+        <StatusCard
+          label="ลงบัญชีแล้ว"
           sub="POSTED"
           icon={<CheckCircle2 size={16} />}
           accent="success"
           value={postedCount}
+          active={statusFilter === 'POSTED'}
+          onClick={() => handleFilterClick('POSTED')}
         />
         <StatusCard
-          label="กลับรายการ"
+          label="ยกเลิก"
           sub="REVERSED"
           icon={<RotateCcw size={16} />}
           accent="muted"
           value={reversedCount}
+          active={statusFilter === 'REVERSED'}
+          onClick={() => handleFilterClick('REVERSED')}
         />
-        <Link
-          to="/other-income/daily-sheet"
-          className="rounded-xl border bg-card p-4 relative overflow-hidden hover:bg-accent/40 transition-colors group"
-        >
-          <span className="absolute inset-x-0 top-0 h-1 bg-primary" />
-          <div className="flex items-start justify-between mb-3">
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-foreground leading-snug">สรุปรายวัน</p>
-              <p className="text-[10px] font-medium text-muted-foreground tracking-wider mt-0.5">
-                DAILY SHEET
-              </p>
-            </div>
-            <div className="size-9 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0">
-              <ChartBar size={16} />
-            </div>
-          </div>
-          <p className="inline-flex items-center gap-1 text-sm font-semibold text-primary group-hover:translate-x-0.5 transition-transform">
-            เปิดดู
-            <ArrowRight size={14} />
-          </p>
-        </Link>
       </div>
 
-      {/* Filters */}
+      {/* Filters — search + date range (status filter moved to cards above) */}
       <div className="flex flex-wrap gap-3 mb-4">
         <div className="relative flex-1 min-w-[200px]">
           <Search size={14} className="absolute left-3 top-3 text-muted-foreground" />
@@ -275,17 +301,6 @@ export default function OtherIncomeListPage() {
             className="w-full pl-9 pr-3 py-2 border rounded-md text-sm bg-background"
           />
         </div>
-        <select
-          value={status}
-          onChange={(e) => { setStatus(e.target.value as OtherIncomeStatus | ''); setPage(1); }}
-          className="border rounded-md px-3 py-2 text-sm bg-background min-w-[130px]"
-        >
-          <option value="">ทุกสถานะ</option>
-          <option value="DRAFT">ร่าง</option>
-          {makerCheckerEnabled && <option value="READY">รออนุมัติ</option>}
-          <option value="POSTED">บันทึกแล้ว</option>
-          <option value="REVERSED">กลับรายการ</option>
-        </select>
         {/* Date Range Quick Chips (v2.3 — replaces old date inputs + clear button) */}
         <div className="w-full">
           <DateRangeChips

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -15,6 +15,7 @@ import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus } from '@/lib/otherIncome.types';
 import { formatThaiDateShort } from '@/lib/date';
 import { formatNumberDecimal } from '@/utils/formatters';
+import { DateRangeChips } from './components/DateRangeChips';
 
 const STATUS_LABELS: Record<OtherIncomeStatus, string> = {
   DRAFT: 'ร่าง',
@@ -104,8 +105,11 @@ export default function OtherIncomeListPage() {
 
   const [q, setQ] = useState('');
   const [status, setStatus] = useState<OtherIncomeStatus | ''>('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
+  const todayInit = new Date();
+  const firstOfMonthInit = `${todayInit.getFullYear()}-${String(todayInit.getMonth() + 1).padStart(2, '0')}-01`;
+  const todayIsoInit = `${todayInit.getFullYear()}-${String(todayInit.getMonth() + 1).padStart(2, '0')}-${String(todayInit.getDate()).padStart(2, '0')}`;
+  const [startDate, setStartDate] = useState(firstOfMonthInit);
+  const [endDate, setEndDate] = useState(todayIsoInit);
   const { page, size, setPage, setSize } = usePaginationParams({ defaultSize: 50 });
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [confirmDeleteNumber, setConfirmDeleteNumber] = useState<string>('');
@@ -279,29 +283,37 @@ export default function OtherIncomeListPage() {
           <option value="POSTED">บันทึกแล้ว</option>
           <option value="REVERSED">กลับรายการ</option>
         </select>
-        <input
-          type="date"
-          value={startDate}
-          onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
-          className="border rounded-md px-3 py-2 text-sm bg-background"
-          placeholder="วันที่เริ่ม"
-        />
-        <input
-          type="date"
-          value={endDate}
-          onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
-          className="border rounded-md px-3 py-2 text-sm bg-background"
-          placeholder="วันที่สิ้นสุด"
-        />
-        {(q || status || startDate || endDate) && (
-          <button
-            type="button"
-            onClick={() => { setQ(''); setStatus(''); setStartDate(''); setEndDate(''); setPage(1); }}
-            className="px-3 py-2 text-sm border rounded-md hover:bg-accent"
-          >
-            ล้างตัวกรอง
-          </button>
-        )}
+        {/* Date Range Quick Chips (v2.3 — replaces old date inputs + clear button) */}
+        <div className="w-full">
+          <DateRangeChips
+            startDate={startDate}
+            endDate={endDate}
+            onChange={({ startDate: sd, endDate: ed }) => {
+              setStartDate(sd);
+              setEndDate(ed);
+              setPage(1);
+            }}
+          />
+        </div>
+        {/* Custom-range inputs: always rendered so users can type exact dates;
+            the "ช่วงวันที่..." chip focuses the first input via DOM query. */}
+        <div className="flex flex-wrap items-center gap-2 w-full">
+          <input
+            type="date"
+            data-date-range-custom-start="true"
+            value={startDate}
+            onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
+            className="border rounded-md px-3 py-2 text-sm bg-background"
+            placeholder="วันที่เริ่ม"
+          />
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
+            className="border rounded-md px-3 py-2 text-sm bg-background"
+            placeholder="วันที่สิ้นสุด"
+          />
+        </div>
       </div>
 
       {/* Table */}

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -703,6 +703,7 @@ export default function OtherIncomeViewPage() {
           }}
           makerCheckerEnabled={makerCheckerEnabled}
           isViewerApprover={user?.role === 'OWNER' && doc.createdById !== user.id}
+          isOwnDoc={doc.createdById === user?.id}
           isLoading={isActionLoading}
           onCancel={() => navigate('/other-income')}
           onApprove={() => approveMutation.mutate(undefined)}

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { ArrowLeft, Check, CheckCircle2, Clock, Copy, Edit, History, Printer, RotateCcw, Receipt, FileText, Send, X } from 'lucide-react';
+import { Check, CheckCircle2, Clock, Copy, Edit, History, Printer, RotateCcw, Receipt, FileText, Send } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ReverseModal } from './components/ReverseModal';
 import { RejectModal } from './components/RejectModal';
 import { SaveAsTemplateModal } from './components/SaveAsTemplateModal';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
+import { InternalControlBar } from './components/InternalControlBar';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import type { OtherIncome, OtherIncomeStatus, OtherIncomeReverseReason } from '@/lib/otherIncome.types';
 import { useAuth } from '@/contexts/AuthContext';
@@ -234,7 +235,7 @@ export default function OtherIncomeViewPage() {
     rejectMutation.isPending;
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div className="p-6 max-w-7xl mx-auto pb-44 md:pb-40">
       <PageHeader
         title="รายละเอียดเอกสารรายได้อื่น"
         icon={<Receipt size={20} />}
@@ -303,56 +304,15 @@ export default function OtherIncomeViewPage() {
                   )}
                 </>
               )}
-              {doc.status === 'READY' && (
-                <>
-                  {doc.rejectNote && (
-                    <div className="rounded-md bg-warning/10 text-warning text-xs px-3 py-2">
-                      เคยถูกปฏิเสธ: {doc.rejectNote}
-                    </div>
-                  )}
-                  {user?.role === 'OWNER' && doc.createdById !== user.id ? (
-                    <>
-                      <button
-                        type="button"
-                        onClick={() => approveMutation.mutate(undefined)}
-                        disabled={approveMutation.isPending}
-                        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
-                      >
-                        <Check size={14} />
-                        อนุมัติ + POST
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setShowRejectModal(true)}
-                        disabled={rejectMutation.isPending}
-                        className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold border border-destructive text-destructive rounded-lg hover:bg-destructive/10 disabled:opacity-50"
-                      >
-                        <X size={14} />
-                        ปฏิเสธ
-                      </button>
-                    </>
-                  ) : user?.role === 'OWNER' && doc.createdById === user.id ? (
-                    <div className="rounded-md bg-muted text-muted-foreground text-sm px-3 py-2">
-                      ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้
-                    </div>
-                  ) : (
-                    <div className="rounded-md bg-info/10 text-info text-sm px-3 py-2 inline-flex items-center gap-1">
-                      <Clock size={14} />
-                      รออนุมัติจาก OWNER
-                    </div>
-                  )}
-                </>
+              {doc.status === 'READY' && doc.rejectNote && (
+                <div className="rounded-md bg-warning/10 text-warning text-xs px-3 py-2">
+                  เคยถูกปฏิเสธ: {doc.rejectNote}
+                </div>
               )}
-              {canReverse && (
-                <button
-                  type="button"
-                  disabled={isActionLoading}
-                  onClick={() => setShowReverseModal(true)}
-                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold border border-destructive text-destructive rounded-lg hover:bg-destructive/10 disabled:opacity-50"
-                >
-                  <RotateCcw size={14} />
-                  กลับรายการ
-                </button>
+              {doc.status === 'READY' && user?.role === 'OWNER' && doc.createdById === user.id && (
+                <div className="rounded-md bg-muted text-muted-foreground text-sm px-3 py-2">
+                  ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้
+                </div>
               )}
             </div>
           ) : undefined
@@ -728,17 +688,28 @@ export default function OtherIncomeViewPage() {
         )}
       </QueryBoundary>
 
-      {/* Back button at bottom */}
-      <div className="mt-8 flex justify-start">
-        <button
-          type="button"
-          onClick={() => navigate('/other-income')}
-          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
-        >
-          <ArrowLeft size={14} />
-          กลับรายการ
-        </button>
-      </div>
+      {/* Internal Control Bar — bottom sticky (v2.3) */}
+      {doc && (
+        <InternalControlBar
+          status={doc.status}
+          recorder={{
+            name:
+              doc.createdById === user?.id
+                ? user?.name || user?.email || '—'
+                : '—',
+          }}
+          approver={{
+            name: user?.role === 'OWNER' ? user?.name || user?.email || 'OWNER' : '—',
+          }}
+          makerCheckerEnabled={makerCheckerEnabled}
+          isViewerApprover={user?.role === 'OWNER' && doc.createdById !== user.id}
+          isLoading={isActionLoading}
+          onCancel={() => navigate('/other-income')}
+          onApprove={() => approveMutation.mutate(undefined)}
+          onReject={() => setShowRejectModal(true)}
+          onReverse={canReverse ? () => setShowReverseModal(true) : undefined}
+        />
+      )}
 
       {/* Reverse modal */}
       {showReverseModal && doc && (

--- a/apps/web/src/pages/other-income/components/DateRangeChips.tsx
+++ b/apps/web/src/pages/other-income/components/DateRangeChips.tsx
@@ -1,0 +1,153 @@
+import { Calendar } from 'lucide-react';
+
+interface DateRangeChipsProps {
+  startDate: string; // YYYY-MM-DD or ''
+  endDate: string;   // YYYY-MM-DD or ''
+  onChange: (next: { startDate: string; endDate: string }) => void;
+}
+
+const THAI_MONTHS_FULL = [
+  'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
+  'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม',
+];
+const THAI_MONTHS_ABBR = [
+  'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.',
+  'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.',
+];
+
+function toIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function thisMonthRange(today: Date): { startDate: string; endDate: string } {
+  const first = new Date(today.getFullYear(), today.getMonth(), 1);
+  return { startDate: toIsoDate(first), endDate: toIsoDate(today) };
+}
+
+function lastMonthRange(today: Date): { startDate: string; endDate: string } {
+  const first = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+  const last = new Date(today.getFullYear(), today.getMonth(), 0);
+  return { startDate: toIsoDate(first), endDate: toIsoDate(last) };
+}
+
+function isSameRange(
+  a: { startDate: string; endDate: string },
+  b: { startDate: string; endDate: string },
+): boolean {
+  return a.startDate === b.startDate && a.endDate === b.endDate;
+}
+
+function formatRangeLabel(startDate: string, endDate: string): string {
+  if (!startDate && !endDate) return 'ทั้งหมด';
+  if (!startDate || !endDate) return `${startDate || endDate}`;
+
+  const start = new Date(startDate + 'T00:00:00');
+  const end = new Date(endDate + 'T00:00:00');
+  const beYear = start.getFullYear() + 543;
+  const startMonthIdx = start.getMonth();
+  const endMonthIdx = end.getMonth();
+  const startDay = start.getDate();
+  const endDay = end.getDate();
+  const lastDayOfStartMonth = new Date(start.getFullYear(), startMonthIdx + 1, 0).getDate();
+
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const sameMonth = sameYear && startMonthIdx === endMonthIdx;
+
+  if (sameMonth && startDay === 1 && endDay === lastDayOfStartMonth) {
+    return `${THAI_MONTHS_FULL[startMonthIdx]} ${beYear}`;
+  }
+  if (sameMonth) {
+    const sd = String(startDay).padStart(2, '0');
+    const ed = String(endDay).padStart(2, '0');
+    const mm = String(startMonthIdx + 1).padStart(2, '0');
+    return `${THAI_MONTHS_FULL[startMonthIdx]} ${beYear} (${sd}/${mm} - ${ed}/${mm})`;
+  }
+  return `${startDay} ${THAI_MONTHS_ABBR[startMonthIdx]} - ${endDay} ${THAI_MONTHS_ABBR[endMonthIdx]} ${end.getFullYear() + 543}`;
+}
+
+export function DateRangeChips({ startDate, endDate, onChange }: DateRangeChipsProps) {
+  const today = new Date();
+  const current = { startDate, endDate };
+  const presets = {
+    all: { startDate: '', endDate: '' },
+    thisMonth: thisMonthRange(today),
+    lastMonth: lastMonthRange(today),
+  };
+
+  const isAll = isSameRange(current, presets.all);
+  const isThisMonth = isSameRange(current, presets.thisMonth);
+  const isLastMonth = isSameRange(current, presets.lastMonth);
+  const isCustom = !isAll && !isThisMonth && !isLastMonth;
+
+  const chipClass = (active: boolean) =>
+    `px-3 py-1.5 text-xs font-medium rounded-md border transition-colors ${
+      active
+        ? 'bg-primary text-primary-foreground border-primary'
+        : 'bg-background text-foreground border-border hover:bg-accent'
+    }`;
+
+  return (
+    <div className="flex items-center justify-between flex-wrap gap-2 w-full">
+      <div role="radiogroup" aria-label="ช่วงวันที่" className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isAll}
+          className={chipClass(isAll)}
+          onClick={() => onChange(presets.all)}
+        >
+          ทั้งหมด
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isThisMonth}
+          className={chipClass(isThisMonth)}
+          onClick={() => onChange(presets.thisMonth)}
+        >
+          เดือนนี้
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isLastMonth}
+          className={chipClass(isLastMonth)}
+          onClick={() => onChange(presets.lastMonth)}
+        >
+          เดือนที่แล้ว
+        </button>
+        {/*
+          "ช่วงวันที่..." is an INDICATOR chip — active when dates don't match
+          a preset. Clicking it focuses the first date input via the parent
+          (parent owns the input refs). Component itself only emits a hint.
+        */}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isCustom}
+          aria-label="ช่วงวันที่ กำหนดเอง"
+          className={chipClass(isCustom)}
+          onClick={() => {
+            // Scroll the date inputs into view (parent ensures they are visible)
+            const customInput = document.querySelector<HTMLInputElement>(
+              'input[data-date-range-custom-start="true"]',
+            );
+            customInput?.focus();
+          }}
+        >
+          ช่วงวันที่...
+        </button>
+      </div>
+      <div
+        data-testid="date-range-label"
+        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+      >
+        <Calendar size={13} />
+        {formatRangeLabel(startDate, endDate)}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/components/DateRangeChips.tsx
+++ b/apps/web/src/pages/other-income/components/DateRangeChips.tsx
@@ -1,19 +1,11 @@
 import { Calendar } from 'lucide-react';
+import { THAI_MONTHS_FULL, THAI_MONTHS_SHORT } from '@/lib/date';
 
 interface DateRangeChipsProps {
   startDate: string; // YYYY-MM-DD or ''
   endDate: string;   // YYYY-MM-DD or ''
   onChange: (next: { startDate: string; endDate: string }) => void;
 }
-
-const THAI_MONTHS_FULL = [
-  'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
-  'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม',
-];
-const THAI_MONTHS_ABBR = [
-  'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.',
-  'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.',
-];
 
 function toIsoDate(d: Date): string {
   const y = d.getFullYear();
@@ -65,7 +57,7 @@ function formatRangeLabel(startDate: string, endDate: string): string {
     const mm = String(startMonthIdx + 1).padStart(2, '0');
     return `${THAI_MONTHS_FULL[startMonthIdx]} ${beYear} (${sd}/${mm} - ${ed}/${mm})`;
   }
-  return `${startDay} ${THAI_MONTHS_ABBR[startMonthIdx]} - ${endDay} ${THAI_MONTHS_ABBR[endMonthIdx]} ${end.getFullYear() + 543}`;
+  return `${startDay} ${THAI_MONTHS_SHORT[startMonthIdx]} - ${endDay} ${THAI_MONTHS_SHORT[endMonthIdx]} ${end.getFullYear() + 543}`;
 }
 
 export function DateRangeChips({ startDate, endDate, onChange }: DateRangeChipsProps) {

--- a/apps/web/src/pages/other-income/components/DateRangeChips.tsx
+++ b/apps/web/src/pages/other-income/components/DateRangeChips.tsx
@@ -57,7 +57,13 @@ function formatRangeLabel(startDate: string, endDate: string): string {
     const mm = String(startMonthIdx + 1).padStart(2, '0');
     return `${THAI_MONTHS_FULL[startMonthIdx]} ${beYear} (${sd}/${mm} - ${ed}/${mm})`;
   }
-  return `${startDay} ${THAI_MONTHS_SHORT[startMonthIdx]} - ${endDay} ${THAI_MONTHS_SHORT[endMonthIdx]} ${end.getFullYear() + 543}`;
+  // Cross-month range: include start-year only when years differ so the label
+  // remains unambiguous across year boundaries (e.g. ธ.ค. 2568 → ม.ค. 2569).
+  const endBeYear = end.getFullYear() + 543;
+  if (sameYear) {
+    return `${startDay} ${THAI_MONTHS_SHORT[startMonthIdx]} - ${endDay} ${THAI_MONTHS_SHORT[endMonthIdx]} ${endBeYear}`;
+  }
+  return `${startDay} ${THAI_MONTHS_SHORT[startMonthIdx]} ${beYear} - ${endDay} ${THAI_MONTHS_SHORT[endMonthIdx]} ${endBeYear}`;
 }
 
 export function DateRangeChips({ startDate, endDate, onChange }: DateRangeChipsProps) {

--- a/apps/web/src/pages/other-income/components/InternalControlBar.tsx
+++ b/apps/web/src/pages/other-income/components/InternalControlBar.tsx
@@ -8,6 +8,12 @@ export interface InternalControlBarProps {
   approver: { name: string };
   makerCheckerEnabled: boolean;
   isViewerApprover?: boolean;
+  /**
+   * True when the current viewer is the creator of this doc. Used to suppress
+   * the "รออนุมัติจาก OWNER" hint on READY status, since an OWNER viewing their
+   * own doc already sees "ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้" elsewhere on the page.
+   */
+  isOwnDoc?: boolean;
   isLoading?: boolean;
   errorCount?: number;
   canPost?: boolean;
@@ -85,6 +91,7 @@ export function InternalControlBar({
   approver,
   makerCheckerEnabled,
   isViewerApprover = false,
+  isOwnDoc = false,
   isLoading = false,
   errorCount = 0,
   canPost = true,
@@ -157,7 +164,7 @@ export function InternalControlBar({
             {status === 'DRAFT' && errorCount > 0 && (
               <span className="text-destructive font-semibold">มี {errorCount} ข้อต้องแก้ไข</span>
             )}
-            {status === 'READY' && !isViewerApprover && (
+            {status === 'READY' && !isViewerApprover && !isOwnDoc && (
               <span className="text-muted-foreground">รออนุมัติจาก OWNER</span>
             )}
           </div>
@@ -169,7 +176,15 @@ export function InternalControlBar({
               className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border rounded-md hover:bg-accent disabled:opacity-50"
             >
               <ArrowLeft size={14} />
-              {status === 'POSTED' || status === 'REVERSED' ? 'ปิด' : status === 'READY' ? 'กลับ' : 'ยกเลิก'}
+              {(() => {
+                // View-only context (no DRAFT action handlers wired) → 'ปิด'.
+                // Entry context with handlers → 'ยกเลิก' (intent: discard form work).
+                const isViewOnlyDraft =
+                  status === 'DRAFT' && !onSaveDraft && !onPost && !onSubmitForApproval;
+                if (status === 'POSTED' || status === 'REVERSED' || isViewOnlyDraft) return 'ปิด';
+                if (status === 'READY') return 'กลับ';
+                return 'ยกเลิก';
+              })()}
             </button>
 
             {/* DRAFT actions — only render when handlers provided (Entry page) */}

--- a/apps/web/src/pages/other-income/components/InternalControlBar.tsx
+++ b/apps/web/src/pages/other-income/components/InternalControlBar.tsx
@@ -36,7 +36,13 @@ function StateMachineBar({
   makerCheckerEnabled: boolean;
 }) {
   const statesAll: DocStatus[] = ['DRAFT', 'READY', 'POSTED', 'REVERSED'];
-  const states = makerCheckerEnabled ? statesAll : (['DRAFT', 'POSTED', 'REVERSED'] as DocStatus[]);
+  // Force the 4-step bar whenever doc is in READY, even if the flag is still
+  // loading or temporarily off — otherwise indexOf('READY') in a 3-step array
+  // returns -1 and every dot renders as "future" (no active dot).
+  const states =
+    makerCheckerEnabled || status === 'READY'
+      ? statesAll
+      : (['DRAFT', 'POSTED', 'REVERSED'] as DocStatus[]);
   const currentIndex = states.indexOf(status);
 
   return (
@@ -123,7 +129,7 @@ export function InternalControlBar({
             </span>
             {showApprovalBadge && (
               <span
-                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-amber-500/15 text-amber-600 text-xs font-semibold"
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-warning/15 text-warning text-xs font-semibold"
                 title="เอกสารนี้ต้องผ่านการอนุมัติก่อนลงบัญชี"
               >
                 <ShieldAlert size={13} />
@@ -148,7 +154,7 @@ export function InternalControlBar({
               <span className="text-destructive font-semibold">มี {errorCount} ข้อต้องแก้ไข</span>
             )}
             {status === 'READY' && !isViewerApprover && (
-              <span className="text-muted-foreground">รออนุมัติจากผู้ตรวจสอบ</span>
+              <span className="text-muted-foreground">รออนุมัติจาก OWNER</span>
             )}
           </div>
           <div className="flex items-center gap-2">

--- a/apps/web/src/pages/other-income/components/InternalControlBar.tsx
+++ b/apps/web/src/pages/other-income/components/InternalControlBar.tsx
@@ -114,19 +114,23 @@ export function InternalControlBar({
             ควบคุมภายใน
           </div>
           <div className="flex items-center gap-2 flex-wrap">
-            <span
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-info/10 text-info text-xs"
-              title="ระบบกำหนดอัตโนมัติตาม user ที่เข้าใช้งานในขณะนี้"
-            >
-              <UserIcon size={13} />
-              <span className="text-muted-foreground">ผู้บันทึก:</span>
-              <span className="font-semibold text-foreground">{recorder.name}</span>
-            </span>
-            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-success/10 text-success text-xs">
-              <CheckCircle2 size={13} />
-              <span className="text-muted-foreground">ผู้อนุมัติ:</span>
-              <span className="font-semibold text-foreground">{approver.name}</span>
-            </span>
+            {recorder.name && recorder.name !== '—' && (
+              <span
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-info/10 text-info text-xs"
+                title="ระบบกำหนดอัตโนมัติตาม user ที่เข้าใช้งานในขณะนี้"
+              >
+                <UserIcon size={13} />
+                <span className="text-muted-foreground">ผู้บันทึก:</span>
+                <span className="font-semibold text-foreground">{recorder.name}</span>
+              </span>
+            )}
+            {approver.name && approver.name !== '—' && (
+              <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-success/10 text-success text-xs">
+                <CheckCircle2 size={13} />
+                <span className="text-muted-foreground">ผู้อนุมัติ:</span>
+                <span className="font-semibold text-foreground">{approver.name}</span>
+              </span>
+            )}
             {showApprovalBadge && (
               <span
                 className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-warning/15 text-warning text-xs font-semibold"
@@ -168,63 +172,71 @@ export function InternalControlBar({
               {status === 'POSTED' || status === 'REVERSED' ? 'ปิด' : status === 'READY' ? 'กลับ' : 'ยกเลิก'}
             </button>
 
-            {/* DRAFT actions */}
+            {/* DRAFT actions — only render when handlers provided (Entry page) */}
             {status === 'DRAFT' && (
               <>
-                <button
-                  type="button"
-                  onClick={onSaveDraft}
-                  disabled={isLoading}
-                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
-                >
-                  <Save size={14} />
-                  บันทึกร่าง
-                </button>
-                {makerCheckerEnabled ? (
+                {onSaveDraft && (
                   <button
                     type="button"
-                    onClick={onSubmitForApproval}
-                    disabled={isLoading || !canPost}
-                    className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                    onClick={onSaveDraft}
+                    disabled={isLoading}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
                   >
-                    <Send size={14} />
-                    ส่งให้อนุมัติ
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={onPost}
-                    disabled={isLoading || !canPost}
-                    className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    <CheckCircle2 size={14} />
-                    บันทึก & POST
+                    <Save size={14} />
+                    บันทึกร่าง
                   </button>
                 )}
+                {makerCheckerEnabled
+                  ? onSubmitForApproval && (
+                      <button
+                        type="button"
+                        onClick={onSubmitForApproval}
+                        disabled={isLoading || !canPost}
+                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        <Send size={14} />
+                        ส่งให้อนุมัติ
+                      </button>
+                    )
+                  : onPost && (
+                      <button
+                        type="button"
+                        onClick={onPost}
+                        disabled={isLoading || !canPost}
+                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        <CheckCircle2 size={14} />
+                        บันทึก & POST
+                      </button>
+                    )}
               </>
             )}
 
             {/* READY actions (approver only) */}
             {status === 'READY' && isViewerApprover && (
               <>
-                <button
-                  type="button"
-                  onClick={onReject}
-                  disabled={isLoading}
-                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border border-destructive/40 text-destructive rounded-md hover:bg-destructive/10 disabled:opacity-50"
-                >
-                  <XCircle size={14} />
-                  ปฏิเสธ
-                </button>
-                <button
-                  type="button"
-                  onClick={onApprove}
-                  disabled={isLoading}
-                  className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40"
-                >
-                  <CheckCircle2 size={14} />
-                  อนุมัติ & POST
-                </button>
+                {onReject && (
+                  <button
+                    type="button"
+                    onClick={onReject}
+                    disabled={isLoading}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border border-destructive/40 text-destructive rounded-md hover:bg-destructive/10 disabled:opacity-50"
+                  >
+                    <XCircle size={14} />
+                    ปฏิเสธ
+                  </button>
+                )}
+                {onApprove && (
+                  <button
+                    type="button"
+                    onClick={onApprove}
+                    disabled={isLoading}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40"
+                  >
+                    <CheckCircle2 size={14} />
+                    อนุมัติ & POST
+                  </button>
+                )}
               </>
             )}
 

--- a/apps/web/src/pages/other-income/components/InternalControlBar.tsx
+++ b/apps/web/src/pages/other-income/components/InternalControlBar.tsx
@@ -1,0 +1,242 @@
+import { ArrowLeft, Save, Send, CheckCircle2, XCircle, Undo2, Lock, ShieldAlert, User as UserIcon } from 'lucide-react';
+
+export type DocStatus = 'DRAFT' | 'READY' | 'POSTED' | 'REVERSED';
+
+export interface InternalControlBarProps {
+  status: DocStatus;
+  recorder: { name: string };
+  approver: { name: string };
+  makerCheckerEnabled: boolean;
+  isViewerApprover?: boolean;
+  isLoading?: boolean;
+  errorCount?: number;
+  canPost?: boolean;
+
+  onCancel: () => void;
+  onSaveDraft?: () => void;
+  onPost?: () => void;
+  onSubmitForApproval?: () => void;
+  onApprove?: () => void;
+  onReject?: () => void;
+  onReverse?: () => void;
+}
+
+const STATE_LABELS: Record<DocStatus, string> = {
+  DRAFT: 'DRAFT',
+  READY: 'READY',
+  POSTED: 'POSTED',
+  REVERSED: 'REVERSED',
+};
+
+function StateMachineBar({
+  status,
+  makerCheckerEnabled,
+}: {
+  status: DocStatus;
+  makerCheckerEnabled: boolean;
+}) {
+  const statesAll: DocStatus[] = ['DRAFT', 'READY', 'POSTED', 'REVERSED'];
+  const states = makerCheckerEnabled ? statesAll : (['DRAFT', 'POSTED', 'REVERSED'] as DocStatus[]);
+  const currentIndex = states.indexOf(status);
+
+  return (
+    <div className="flex items-center gap-2 w-full">
+      {states.map((s, i) => {
+        const isActive = i === currentIndex;
+        const isPast = i < currentIndex;
+        const state = isActive ? 'active' : isPast ? 'past' : 'future';
+        const dotClasses =
+          state === 'active'
+            ? 'w-3 h-3 rounded-full bg-primary ring-4 ring-primary/20'
+            : state === 'past'
+              ? 'w-2.5 h-2.5 rounded-full bg-muted-foreground'
+              : 'w-2.5 h-2.5 rounded-full border-2 border-border bg-background';
+        const labelClasses =
+          state === 'active'
+            ? 'text-xs font-semibold text-primary'
+            : state === 'past'
+              ? 'text-xs text-muted-foreground'
+              : 'text-xs text-muted-foreground/60';
+        return (
+          <div key={s} className="flex items-center gap-2 flex-1">
+            <div className="flex flex-col items-center gap-1">
+              <div data-testid="state-machine-dot" data-state={state} data-label={s} className={dotClasses} />
+              <span className={labelClasses}>{STATE_LABELS[s]}</span>
+            </div>
+            {i < states.length - 1 && (
+              <div className="flex-1 border-t-2 border-dashed border-border" />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function InternalControlBar({
+  status,
+  recorder,
+  approver,
+  makerCheckerEnabled,
+  isViewerApprover = false,
+  isLoading = false,
+  errorCount = 0,
+  canPost = true,
+  onCancel,
+  onSaveDraft,
+  onPost,
+  onSubmitForApproval,
+  onApprove,
+  onReject,
+  onReverse,
+}: InternalControlBarProps) {
+  const showApprovalBadge =
+    makerCheckerEnabled && (status === 'DRAFT' || status === 'READY');
+
+  const frameClass =
+    'fixed bottom-0 left-0 right-0 z-40 px-4 md:px-6 py-3 ' +
+    'border-t-2 bg-[hsl(var(--accent-purple)/0.04)] border-[hsl(var(--accent-purple)/0.3)] ' +
+    'shadow-lg backdrop-blur-sm';
+
+  return (
+    <div className={frameClass}>
+      <div className="max-w-5xl mx-auto space-y-3">
+        {/* Row 1 — Internal Control label + pills */}
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="inline-flex items-center gap-1.5 text-xs font-semibold text-[hsl(var(--accent-purple))]">
+            <Lock size={13} />
+            ควบคุมภายใน
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-info/10 text-info text-xs"
+              title="ระบบกำหนดอัตโนมัติตาม user ที่เข้าใช้งานในขณะนี้"
+            >
+              <UserIcon size={13} />
+              <span className="text-muted-foreground">ผู้บันทึก:</span>
+              <span className="font-semibold text-foreground">{recorder.name}</span>
+            </span>
+            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-success/10 text-success text-xs">
+              <CheckCircle2 size={13} />
+              <span className="text-muted-foreground">ผู้อนุมัติ:</span>
+              <span className="font-semibold text-foreground">{approver.name}</span>
+            </span>
+            {showApprovalBadge && (
+              <span
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-amber-500/15 text-amber-600 text-xs font-semibold"
+                title="เอกสารนี้ต้องผ่านการอนุมัติก่อนลงบัญชี"
+              >
+                <ShieldAlert size={13} />
+                ต้องอนุมัติ
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Row 2 — State Machine Bar */}
+        <div className="hidden md:block">
+          <StateMachineBar status={status} makerCheckerEnabled={makerCheckerEnabled} />
+        </div>
+        <div className="md:hidden text-xs text-muted-foreground">
+          สถานะ: <span className="font-semibold text-primary">● {STATE_LABELS[status]}</span>
+        </div>
+
+        {/* Row 3 — State-aware action buttons */}
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div className="text-xs">
+            {status === 'DRAFT' && errorCount > 0 && (
+              <span className="text-destructive font-semibold">มี {errorCount} ข้อต้องแก้ไข</span>
+            )}
+            {status === 'READY' && !isViewerApprover && (
+              <span className="text-muted-foreground">รออนุมัติจากผู้ตรวจสอบ</span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isLoading}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border rounded-md hover:bg-accent disabled:opacity-50"
+            >
+              <ArrowLeft size={14} />
+              {status === 'POSTED' || status === 'REVERSED' ? 'ปิด' : status === 'READY' ? 'กลับ' : 'ยกเลิก'}
+            </button>
+
+            {/* DRAFT actions */}
+            {status === 'DRAFT' && (
+              <>
+                <button
+                  type="button"
+                  onClick={onSaveDraft}
+                  disabled={isLoading}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
+                >
+                  <Save size={14} />
+                  บันทึกร่าง
+                </button>
+                {makerCheckerEnabled ? (
+                  <button
+                    type="button"
+                    onClick={onSubmitForApproval}
+                    disabled={isLoading || !canPost}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    <Send size={14} />
+                    ส่งให้อนุมัติ
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={onPost}
+                    disabled={isLoading || !canPost}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    <CheckCircle2 size={14} />
+                    บันทึก & POST
+                  </button>
+                )}
+              </>
+            )}
+
+            {/* READY actions (approver only) */}
+            {status === 'READY' && isViewerApprover && (
+              <>
+                <button
+                  type="button"
+                  onClick={onReject}
+                  disabled={isLoading}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border border-destructive/40 text-destructive rounded-md hover:bg-destructive/10 disabled:opacity-50"
+                >
+                  <XCircle size={14} />
+                  ปฏิเสธ
+                </button>
+                <button
+                  type="button"
+                  onClick={onApprove}
+                  disabled={isLoading}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40"
+                >
+                  <CheckCircle2 size={14} />
+                  อนุมัติ & POST
+                </button>
+              </>
+            )}
+
+            {/* POSTED actions */}
+            {status === 'POSTED' && onReverse && (
+              <button
+                type="button"
+                onClick={onReverse}
+                disabled={isLoading}
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-semibold border border-destructive/40 text-destructive rounded-md hover:bg-destructive/10 disabled:opacity-50"
+              >
+                <Undo2 size={14} />
+                กลับรายการ
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DateRangeChips } from '../DateRangeChips';
+
+describe('DateRangeChips', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    onChange.mockClear();
+    // Freeze "today" so date math is deterministic. 2026-05-14 BKK.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T05:00:00.000Z')); // 12:00 BKK
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders 4 chips', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    expect(screen.getByRole('radio', { name: 'ทั้งหมด' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'เดือนที่แล้ว' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /ช่วงวันที่/ })).toBeInTheDocument();
+  });
+
+  it('clicking "เดือนนี้" emits 1st of current month → today', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนนี้' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-05-01', endDate: '2026-05-14' });
+  });
+
+  it('clicking "เดือนที่แล้ว" emits 1st → last day of last month', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนที่แล้ว' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-04-01', endDate: '2026-04-30' });
+  });
+
+  it('clicking "ทั้งหมด" clears both dates', () => {
+    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'ทั้งหมด' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '', endDate: '' });
+  });
+
+  it('right-side label shows "ทั้งหมด" when both dates empty', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent('ทั้งหมด');
+  });
+
+  it('label shows "พฤษภาคม 2569 (01/05 - 14/05)" for current-month partial', () => {
+    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent(
+      'พฤษภาคม 2569 (01/05 - 14/05)',
+    );
+  });
+
+  it('label shows full month name when range exactly covers one calendar month', () => {
+    render(<DateRangeChips startDate="2026-04-01" endDate="2026-04-30" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent('เมษายน 2569');
+  });
+
+  it('label shows cross-month format for ranges spanning two months', () => {
+    render(<DateRangeChips startDate="2026-04-15" endDate="2026-05-14" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent('15 เม.ย. - 14 พ.ค. 2569');
+  });
+
+  it('"เดือนนี้" chip has aria-checked=true when current month is selected', () => {
+    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
+    expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+});

--- a/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx
@@ -64,6 +64,13 @@ describe('DateRangeChips', () => {
     expect(screen.getByTestId('date-range-label')).toHaveTextContent('15 เม.ย. - 14 พ.ค. 2569');
   });
 
+  it('label includes both years for cross-year range', () => {
+    render(<DateRangeChips startDate="2025-12-15" endDate="2026-01-14" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent(
+      '15 ธ.ค. 2568 - 14 ม.ค. 2569',
+    );
+  });
+
   it('"เดือนนี้" chip has aria-checked=true when current month is selected', () => {
     render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
     expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(

--- a/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
@@ -142,11 +142,20 @@ describe('InternalControlBar', () => {
   it('DRAFT status without onSaveDraft/onPost handlers: no dead action buttons render', () => {
     // ViewPage uses bar in view-only mode — should not show DRAFT action buttons
     // (PageHeader provides them). Regression guard for dead-button bug.
-    const { onSaveDraft: _omit1, onPost: _omit2, onSubmitForApproval: _omit3, ...viewProps } = baseProps;
-    render(<InternalControlBar {...viewProps} status="DRAFT" />);
+    render(
+      <InternalControlBar
+        status="DRAFT"
+        recorder={baseProps.recorder}
+        approver={baseProps.approver}
+        makerCheckerEnabled={false}
+        onCancel={handlers.onCancel}
+      />,
+    );
     expect(screen.queryByRole('button', { name: /บันทึกร่าง/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /บันทึก & POST/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /ส่งให้อนุมัติ/ })).not.toBeInTheDocument();
+    // Cancel button should show "ปิด" not "ยกเลิก" in view-only mode (R3 W2)
+    expect(screen.getByRole('button', { name: /ปิด/ })).toBeInTheDocument();
   });
 
   it('pills hidden when name is empty/dash', () => {
@@ -160,5 +169,20 @@ describe('InternalControlBar', () => {
     );
     expect(screen.queryByText(/ผู้บันทึก:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/ผู้อนุมัติ:/)).not.toBeInTheDocument();
+  });
+
+  it('READY + viewer is creator (isOwnDoc): suppresses "รออนุมัติจาก OWNER" hint', () => {
+    // OWNER creator viewing their own READY doc — PageHeader already shows
+    // "ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้", so the bar must not contradict.
+    render(
+      <InternalControlBar
+        {...baseProps}
+        status="READY"
+        makerCheckerEnabled={true}
+        isViewerApprover={false}
+        isOwnDoc={true}
+      />,
+    );
+    expect(screen.queryByText(/รออนุมัติจาก OWNER/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
@@ -130,4 +130,35 @@ describe('InternalControlBar', () => {
     const active = dots.find((d) => d.getAttribute('data-state') === 'active');
     expect(active).toHaveAttribute('data-label', 'POSTED');
   });
+
+  it('REVERSED status + MC-off has active dot on REVERSED in 3-step bar', () => {
+    render(<InternalControlBar {...baseProps} status="REVERSED" makerCheckerEnabled={false} />);
+    const dots = screen.getAllByTestId('state-machine-dot');
+    expect(dots).toHaveLength(3);
+    const active = dots.find((d) => d.getAttribute('data-state') === 'active');
+    expect(active).toHaveAttribute('data-label', 'REVERSED');
+  });
+
+  it('DRAFT status without onSaveDraft/onPost handlers: no dead action buttons render', () => {
+    // ViewPage uses bar in view-only mode — should not show DRAFT action buttons
+    // (PageHeader provides them). Regression guard for dead-button bug.
+    const { onSaveDraft: _omit1, onPost: _omit2, onSubmitForApproval: _omit3, ...viewProps } = baseProps;
+    render(<InternalControlBar {...viewProps} status="DRAFT" />);
+    expect(screen.queryByRole('button', { name: /บันทึกร่าง/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /บันทึก & POST/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /ส่งให้อนุมัติ/ })).not.toBeInTheDocument();
+  });
+
+  it('pills hidden when name is empty/dash', () => {
+    render(
+      <InternalControlBar
+        {...baseProps}
+        status="POSTED"
+        recorder={{ name: '—' }}
+        approver={{ name: '' }}
+      />,
+    );
+    expect(screen.queryByText(/ผู้บันทึก:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ผู้อนุมัติ:/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InternalControlBar } from '../InternalControlBar';
+
+describe('InternalControlBar', () => {
+  const handlers = {
+    onCancel: vi.fn(),
+    onSaveDraft: vi.fn(),
+    onPost: vi.fn(),
+    onSubmitForApproval: vi.fn(),
+    onApprove: vi.fn(),
+    onReject: vi.fn(),
+    onReverse: vi.fn(),
+  };
+
+  beforeEach(() => {
+    Object.values(handlers).forEach((h) => h.mockClear());
+  });
+
+  const baseProps = {
+    recorder: { name: 'เอกนรินทร์' },
+    approver: { name: 'เอกนรินทร์' },
+    makerCheckerEnabled: false,
+    ...handlers,
+  };
+
+  it('renders ผู้บันทึก + ผู้อนุมัติ pills always', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" />);
+    expect(screen.getByText(/ผู้บันทึก:/)).toBeInTheDocument();
+    expect(screen.getByText(/ผู้อนุมัติ:/)).toBeInTheDocument();
+    expect(screen.getAllByText('เอกนรินทร์')).toHaveLength(2);
+  });
+
+  it('does NOT show "ต้องอนุมัติ" badge when Maker-Checker disabled', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={false} />);
+    expect(screen.queryByText('ต้องอนุมัติ')).not.toBeInTheDocument();
+  });
+
+  it('shows "ต้องอนุมัติ" badge when Maker-Checker enabled and status=DRAFT', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={true} />);
+    expect(screen.getByText('ต้องอนุมัติ')).toBeInTheDocument();
+  });
+
+  it('does NOT show "ต้องอนุมัติ" badge when status=POSTED even if Maker-Checker on', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" makerCheckerEnabled={true} />);
+    expect(screen.queryByText('ต้องอนุมัติ')).not.toBeInTheDocument();
+  });
+
+  it('DRAFT + maker-checker OFF: shows ยกเลิก / บันทึกร่าง / บันทึก & POST', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" />);
+    expect(screen.getByRole('button', { name: /ยกเลิก/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /บันทึกร่าง/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /บันทึก & POST/ })).toBeInTheDocument();
+  });
+
+  it('DRAFT + maker-checker ON: replaces POST with "ส่งให้อนุมัติ"', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={true} />);
+    expect(screen.queryByRole('button', { name: /บันทึก & POST/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ส่งให้อนุมัติ/ })).toBeInTheDocument();
+  });
+
+  it('POSTED: shows ปิด + กลับรายการ', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" />);
+    expect(screen.getByRole('button', { name: /ปิด/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /กลับรายการ/ })).toBeInTheDocument();
+  });
+
+  it('REVERSED: shows only ปิด', () => {
+    render(<InternalControlBar {...baseProps} status="REVERSED" />);
+    expect(screen.getByRole('button', { name: /ปิด/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /กลับรายการ/ })).not.toBeInTheDocument();
+  });
+
+  it('READY + viewer is approver: shows ปฏิเสธ + อนุมัติ & POST', () => {
+    render(
+      <InternalControlBar
+        {...baseProps}
+        status="READY"
+        makerCheckerEnabled={true}
+        isViewerApprover={true}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /ปฏิเสธ/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /อนุมัติ & POST/ })).toBeInTheDocument();
+  });
+
+  it('READY + viewer is NOT approver: shows only กลับ + รออนุมัติ banner', () => {
+    render(
+      <InternalControlBar
+        {...baseProps}
+        status="READY"
+        makerCheckerEnabled={true}
+        isViewerApprover={false}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /อนุมัติ/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/รออนุมัติ/)).toBeInTheDocument();
+  });
+
+  it('fires onPost when "บันทึก & POST" clicked', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" />);
+    fireEvent.click(screen.getByRole('button', { name: /บันทึก & POST/ }));
+    expect(handlers.onPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onReverse when "กลับรายการ" clicked', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" />);
+    fireEvent.click(screen.getByRole('button', { name: /กลับรายการ/ }));
+    expect(handlers.onReverse).toHaveBeenCalledTimes(1);
+  });
+
+  it('state machine bar shows 4 dots when maker-checker enabled', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={true} />);
+    expect(screen.getAllByTestId('state-machine-dot')).toHaveLength(4);
+  });
+
+  it('state machine bar shows 3 dots when maker-checker disabled', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={false} />);
+    expect(screen.getAllByTestId('state-machine-dot')).toHaveLength(3);
+  });
+
+  it('active dot has data-state="active"', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" />);
+    const dots = screen.getAllByTestId('state-machine-dot');
+    const active = dots.find((d) => d.getAttribute('data-state') === 'active');
+    expect(active).toHaveAttribute('data-label', 'POSTED');
+  });
+});

--- a/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
+++ b/apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
@@ -46,6 +46,11 @@ describe('InternalControlBar', () => {
     expect(screen.queryByText('ต้องอนุมัติ')).not.toBeInTheDocument();
   });
 
+  it('shows "ต้องอนุมัติ" badge when status=READY and Maker-Checker enabled', () => {
+    render(<InternalControlBar {...baseProps} status="READY" makerCheckerEnabled={true} />);
+    expect(screen.getByText('ต้องอนุมัติ')).toBeInTheDocument();
+  });
+
   it('DRAFT + maker-checker OFF: shows ยกเลิก / บันทึกร่าง / บันทึก & POST', () => {
     render(<InternalControlBar {...baseProps} status="DRAFT" />);
     expect(screen.getByRole('button', { name: /ยกเลิก/ })).toBeInTheDocument();

--- a/docs/superpowers/plans/2026-05-14-other-income-v2-3-ui-pdf-gap.md
+++ b/docs/superpowers/plans/2026-05-14-other-income-v2-3-ui-pdf-gap.md
@@ -1,0 +1,1064 @@
+# Other Income v2.3 UI PDF Gap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship 3 remaining UI gaps from the PDF comparison report into Other Income module — Date Range Quick Chips on list page, plus a unified Internal Control Bar (purple-frame sticky bar) that combines pills + state machine + state-aware buttons across Entry and View pages.
+
+**Architecture:** Two new presentational components (`DateRangeChips`, `InternalControlBar`) under `apps/web/src/pages/other-income/components/`. Wire `DateRangeChips` into `OtherIncomeListPage`; wire `InternalControlBar` into both `OtherIncomeEntryPage` (replacing old Section 7 card + old sticky bar) and `OtherIncomeViewPage` (moving state-control actions from `PageHeader` to a new sticky bottom bar; utility actions stay in header).
+
+**Tech Stack:** React 18 + TypeScript + Tailwind CSS + shadcn/ui + lucide-react + @testing-library/react + Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-other-income-v2-3-ui-pdf-gap-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `apps/web/src/pages/other-income/components/DateRangeChips.tsx`
+- `apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx`
+- `apps/web/src/pages/other-income/components/InternalControlBar.tsx`
+- `apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx`
+
+**Modified files:**
+- `apps/web/src/pages/other-income/OtherIncomeListPage.tsx` (wire DateRangeChips, remove old "ล้างตัวกรอง" button)
+- `apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx` (remove Section 7 card + old sticky bar, wire InternalControlBar)
+- `apps/web/src/pages/other-income/OtherIncomeViewPage.tsx` (move state-control actions from header to new bottom InternalControlBar)
+- `apps/web/src/index.css` (add `--accent-purple` HSL tokens for the purple frame)
+
+---
+
+## Task 1: DateRangeChips Component
+
+**Files:**
+- Create: `apps/web/src/pages/other-income/components/DateRangeChips.tsx`
+- Create: `apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx`
+
+### - [ ] Step 1.1: Write the failing test
+
+Create `apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DateRangeChips } from '../DateRangeChips';
+
+describe('DateRangeChips', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    onChange.mockClear();
+    // Freeze "today" so date math is deterministic. 2026-05-14 BKK.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T05:00:00.000Z')); // 12:00 BKK
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders 4 chips', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    expect(screen.getByRole('radio', { name: 'ทั้งหมด' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'เดือนที่แล้ว' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /ช่วงวันที่/ })).toBeInTheDocument();
+  });
+
+  it('clicking "เดือนนี้" emits 1st of current month → today', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนนี้' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-05-01', endDate: '2026-05-14' });
+  });
+
+  it('clicking "เดือนที่แล้ว" emits 1st → last day of last month', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'เดือนที่แล้ว' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '2026-04-01', endDate: '2026-04-30' });
+  });
+
+  it('clicking "ทั้งหมด" clears both dates', () => {
+    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: 'ทั้งหมด' }));
+    expect(onChange).toHaveBeenCalledWith({ startDate: '', endDate: '' });
+  });
+
+  it('right-side label shows "ทั้งหมด" when both dates empty', () => {
+    render(<DateRangeChips startDate="" endDate="" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent('ทั้งหมด');
+  });
+
+  it('label shows "พฤษภาคม 2569 (01/05 - 14/05)" for current-month partial', () => {
+    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent(
+      'พฤษภาคม 2569 (01/05 - 14/05)',
+    );
+  });
+
+  it('label shows full month name when range exactly covers one calendar month', () => {
+    render(<DateRangeChips startDate="2026-04-01" endDate="2026-04-30" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent('เมษายน 2569');
+  });
+
+  it('label shows cross-month format for ranges spanning two months', () => {
+    render(<DateRangeChips startDate="2026-04-15" endDate="2026-05-14" onChange={onChange} />);
+    expect(screen.getByTestId('date-range-label')).toHaveTextContent('15 เม.ย. - 14 พ.ค. 2569');
+  });
+
+  it('"เดือนนี้" chip has aria-checked=true when current month is selected', () => {
+    render(<DateRangeChips startDate="2026-05-01" endDate="2026-05-14" onChange={onChange} />);
+    expect(screen.getByRole('radio', { name: 'เดือนนี้' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+});
+```
+
+### - [ ] Step 1.2: Run tests to verify they fail
+
+Run: `cd apps/web && npx vitest run src/pages/other-income/components/__tests__/DateRangeChips.test.tsx`
+
+Expected: FAIL with `Cannot find module '../DateRangeChips'`.
+
+### - [ ] Step 1.3: Write the DateRangeChips component
+
+Create `apps/web/src/pages/other-income/components/DateRangeChips.tsx`:
+
+```tsx
+import { Calendar } from 'lucide-react';
+
+interface DateRangeChipsProps {
+  startDate: string; // YYYY-MM-DD or ''
+  endDate: string;   // YYYY-MM-DD or ''
+  onChange: (next: { startDate: string; endDate: string }) => void;
+}
+
+const THAI_MONTHS_FULL = [
+  'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
+  'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม',
+];
+const THAI_MONTHS_ABBR = [
+  'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.',
+  'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.',
+];
+
+function toIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function thisMonthRange(today: Date): { startDate: string; endDate: string } {
+  const first = new Date(today.getFullYear(), today.getMonth(), 1);
+  return { startDate: toIsoDate(first), endDate: toIsoDate(today) };
+}
+
+function lastMonthRange(today: Date): { startDate: string; endDate: string } {
+  const first = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+  const last = new Date(today.getFullYear(), today.getMonth(), 0);
+  return { startDate: toIsoDate(first), endDate: toIsoDate(last) };
+}
+
+function isSameRange(
+  a: { startDate: string; endDate: string },
+  b: { startDate: string; endDate: string },
+): boolean {
+  return a.startDate === b.startDate && a.endDate === b.endDate;
+}
+
+function formatRangeLabel(startDate: string, endDate: string): string {
+  if (!startDate && !endDate) return 'ทั้งหมด';
+  if (!startDate || !endDate) return `${startDate || endDate}`;
+
+  const start = new Date(startDate + 'T00:00:00');
+  const end = new Date(endDate + 'T00:00:00');
+  const beYear = start.getFullYear() + 543;
+  const startMonthIdx = start.getMonth();
+  const endMonthIdx = end.getMonth();
+  const startDay = start.getDate();
+  const endDay = end.getDate();
+  const lastDayOfStartMonth = new Date(start.getFullYear(), startMonthIdx + 1, 0).getDate();
+
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const sameMonth = sameYear && startMonthIdx === endMonthIdx;
+
+  if (sameMonth && startDay === 1 && endDay === lastDayOfStartMonth) {
+    return `${THAI_MONTHS_FULL[startMonthIdx]} ${beYear}`;
+  }
+  if (sameMonth) {
+    const sd = String(startDay).padStart(2, '0');
+    const ed = String(endDay).padStart(2, '0');
+    const mm = String(startMonthIdx + 1).padStart(2, '0');
+    return `${THAI_MONTHS_FULL[startMonthIdx]} ${beYear} (${sd}/${mm} - ${ed}/${mm})`;
+  }
+  return `${startDay} ${THAI_MONTHS_ABBR[startMonthIdx]} - ${endDay} ${THAI_MONTHS_ABBR[endMonthIdx]} ${end.getFullYear() + 543}`;
+}
+
+export function DateRangeChips({ startDate, endDate, onChange }: DateRangeChipsProps) {
+  const today = new Date();
+  const current = { startDate, endDate };
+  const presets = {
+    all: { startDate: '', endDate: '' },
+    thisMonth: thisMonthRange(today),
+    lastMonth: lastMonthRange(today),
+  };
+
+  const isAll = isSameRange(current, presets.all);
+  const isThisMonth = isSameRange(current, presets.thisMonth);
+  const isLastMonth = isSameRange(current, presets.lastMonth);
+  const isCustom = !isAll && !isThisMonth && !isLastMonth;
+
+  const chipClass = (active: boolean) =>
+    `px-3 py-1.5 text-xs font-medium rounded-md border transition-colors ${
+      active
+        ? 'bg-primary text-primary-foreground border-primary'
+        : 'bg-background text-foreground border-border hover:bg-accent'
+    }`;
+
+  return (
+    <div className="flex items-center justify-between flex-wrap gap-2 w-full">
+      <div role="radiogroup" aria-label="ช่วงวันที่" className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isAll}
+          className={chipClass(isAll)}
+          onClick={() => onChange(presets.all)}
+        >
+          ทั้งหมด
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isThisMonth}
+          className={chipClass(isThisMonth)}
+          onClick={() => onChange(presets.thisMonth)}
+        >
+          เดือนนี้
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isLastMonth}
+          className={chipClass(isLastMonth)}
+          onClick={() => onChange(presets.lastMonth)}
+        >
+          เดือนที่แล้ว
+        </button>
+        {/*
+          "ช่วงวันที่..." is an INDICATOR chip — active when dates don't match
+          a preset. Clicking it focuses the first date input via the parent
+          (parent owns the input refs). Component itself only emits a hint.
+        */}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isCustom}
+          aria-label="ช่วงวันที่ กำหนดเอง"
+          className={chipClass(isCustom)}
+          onClick={() => {
+            // Scroll the date inputs into view (parent ensures they are visible)
+            const customInput = document.querySelector<HTMLInputElement>(
+              'input[data-date-range-custom-start="true"]',
+            );
+            customInput?.focus();
+          }}
+        >
+          ช่วงวันที่...
+        </button>
+      </div>
+      <div
+        data-testid="date-range-label"
+        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+      >
+        <Calendar size={13} />
+        {formatRangeLabel(startDate, endDate)}
+      </div>
+    </div>
+  );
+}
+```
+
+### - [ ] Step 1.4: Run tests to verify they pass
+
+Run: `cd apps/web && npx vitest run src/pages/other-income/components/__tests__/DateRangeChips.test.tsx`
+
+Expected: 9/9 PASS.
+
+### - [ ] Step 1.5: Wire DateRangeChips into OtherIncomeListPage
+
+Edit `apps/web/src/pages/other-income/OtherIncomeListPage.tsx`.
+
+Add import near the existing imports (around line 13):
+
+```tsx
+import { DateRangeChips } from './components/DateRangeChips';
+```
+
+Replace the date inputs block at lines 282–295 and the "ล้างตัวกรอง" button at lines 296–304 with:
+
+```tsx
+        {/* Date Range Quick Chips (v2.3 — replaces old date inputs + clear button) */}
+        <div className="w-full">
+          <DateRangeChips
+            startDate={startDate}
+            endDate={endDate}
+            onChange={({ startDate: sd, endDate: ed }) => {
+              setStartDate(sd);
+              setEndDate(ed);
+              setPage(1);
+            }}
+          />
+        </div>
+        {/* Custom-range inputs: always rendered so users can type exact dates;
+            the "ช่วงวันที่..." chip focuses the first input via DOM query. */}
+        <div className="flex flex-wrap items-center gap-2 w-full">
+          <input
+            type="date"
+            data-date-range-custom-start="true"
+            value={startDate}
+            onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
+            className="border rounded-md px-3 py-2 text-sm bg-background"
+            placeholder="วันที่เริ่ม"
+          />
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
+            className="border rounded-md px-3 py-2 text-sm bg-background"
+            placeholder="วันที่สิ้นสุด"
+          />
+        </div>
+```
+
+Also: change initial state at line 107–108 to default to "this month":
+
+```tsx
+  const todayInit = new Date();
+  const firstOfMonthInit = `${todayInit.getFullYear()}-${String(todayInit.getMonth() + 1).padStart(2, '0')}-01`;
+  const todayIsoInit = `${todayInit.getFullYear()}-${String(todayInit.getMonth() + 1).padStart(2, '0')}-${String(todayInit.getDate()).padStart(2, '0')}`;
+  const [startDate, setStartDate] = useState(firstOfMonthInit);
+  const [endDate, setEndDate] = useState(todayIsoInit);
+```
+
+### - [ ] Step 1.6: TypeScript check
+
+Run: `./tools/check-types.sh web`
+
+Expected: `Web: OK`.
+
+### - [ ] Step 1.7: Commit
+
+```bash
+git add apps/web/src/pages/other-income/components/DateRangeChips.tsx \
+        apps/web/src/pages/other-income/components/__tests__/DateRangeChips.test.tsx \
+        apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+git commit -m "feat(other-income): add DateRangeChips quick filter to list page"
+```
+
+---
+
+## Task 2: InternalControlBar Component (Standalone)
+
+**Files:**
+- Modify: `apps/web/src/index.css` (add `--accent-purple` token)
+- Create: `apps/web/src/pages/other-income/components/InternalControlBar.tsx`
+- Create: `apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx`
+
+### - [ ] Step 2.1: Add the purple HSL token to index.css
+
+Locate the existing `:root { ... }` block in `apps/web/src/index.css` (search for `--primary:` to find it). Inside that block, just before its closing `}`, add:
+
+```css
+    --accent-purple: 280 60% 55%;
+    --accent-purple-foreground: 280 80% 95%;
+```
+
+Then locate the `.dark { ... }` block (same file). Inside it, before the closing `}`, add:
+
+```css
+    --accent-purple: 280 65% 65%;
+    --accent-purple-foreground: 280 30% 12%;
+```
+
+### - [ ] Step 2.2: Write the failing test
+
+Create `apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InternalControlBar } from '../InternalControlBar';
+
+describe('InternalControlBar', () => {
+  const handlers = {
+    onCancel: vi.fn(),
+    onSaveDraft: vi.fn(),
+    onPost: vi.fn(),
+    onSubmitForApproval: vi.fn(),
+    onApprove: vi.fn(),
+    onReject: vi.fn(),
+    onReverse: vi.fn(),
+  };
+
+  beforeEach(() => {
+    Object.values(handlers).forEach((h) => h.mockClear());
+  });
+
+  const baseProps = {
+    recorder: { name: 'เอกนรินทร์' },
+    approver: { name: 'เอกนรินทร์' },
+    makerCheckerEnabled: false,
+    ...handlers,
+  };
+
+  it('renders ผู้บันทึก + ผู้อนุมัติ pills always', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" />);
+    expect(screen.getByText(/ผู้บันทึก:/)).toBeInTheDocument();
+    expect(screen.getByText(/ผู้อนุมัติ:/)).toBeInTheDocument();
+    expect(screen.getAllByText('เอกนรินทร์')).toHaveLength(2);
+  });
+
+  it('does NOT show "ต้องอนุมัติ" badge when Maker-Checker disabled', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={false} />);
+    expect(screen.queryByText('ต้องอนุมัติ')).not.toBeInTheDocument();
+  });
+
+  it('shows "ต้องอนุมัติ" badge when Maker-Checker enabled and status=DRAFT', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={true} />);
+    expect(screen.getByText('ต้องอนุมัติ')).toBeInTheDocument();
+  });
+
+  it('does NOT show "ต้องอนุมัติ" badge when status=POSTED even if Maker-Checker on', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" makerCheckerEnabled={true} />);
+    expect(screen.queryByText('ต้องอนุมัติ')).not.toBeInTheDocument();
+  });
+
+  it('DRAFT + maker-checker OFF: shows ยกเลิก / บันทึกร่าง / บันทึก & POST', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" />);
+    expect(screen.getByRole('button', { name: /ยกเลิก/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /บันทึกร่าง/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /บันทึก & POST/ })).toBeInTheDocument();
+  });
+
+  it('DRAFT + maker-checker ON: replaces POST with "ส่งให้อนุมัติ"', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={true} />);
+    expect(screen.queryByRole('button', { name: /บันทึก & POST/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ส่งให้อนุมัติ/ })).toBeInTheDocument();
+  });
+
+  it('POSTED: shows ปิด + กลับรายการ', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" />);
+    expect(screen.getByRole('button', { name: /ปิด/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /กลับรายการ/ })).toBeInTheDocument();
+  });
+
+  it('REVERSED: shows only ปิด', () => {
+    render(<InternalControlBar {...baseProps} status="REVERSED" />);
+    expect(screen.getByRole('button', { name: /ปิด/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /กลับรายการ/ })).not.toBeInTheDocument();
+  });
+
+  it('READY + viewer is approver: shows ปฏิเสธ + อนุมัติ & POST', () => {
+    render(
+      <InternalControlBar
+        {...baseProps}
+        status="READY"
+        makerCheckerEnabled={true}
+        isViewerApprover={true}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /ปฏิเสธ/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /อนุมัติ & POST/ })).toBeInTheDocument();
+  });
+
+  it('READY + viewer is NOT approver: shows only กลับ + รออนุมัติ banner', () => {
+    render(
+      <InternalControlBar
+        {...baseProps}
+        status="READY"
+        makerCheckerEnabled={true}
+        isViewerApprover={false}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /อนุมัติ/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/รออนุมัติ/)).toBeInTheDocument();
+  });
+
+  it('fires onPost when "บันทึก & POST" clicked', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" />);
+    fireEvent.click(screen.getByRole('button', { name: /บันทึก & POST/ }));
+    expect(handlers.onPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onReverse when "กลับรายการ" clicked', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" />);
+    fireEvent.click(screen.getByRole('button', { name: /กลับรายการ/ }));
+    expect(handlers.onReverse).toHaveBeenCalledTimes(1);
+  });
+
+  it('state machine bar shows 4 dots when maker-checker enabled', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={true} />);
+    expect(screen.getAllByTestId('state-machine-dot')).toHaveLength(4);
+  });
+
+  it('state machine bar shows 3 dots when maker-checker disabled', () => {
+    render(<InternalControlBar {...baseProps} status="DRAFT" makerCheckerEnabled={false} />);
+    expect(screen.getAllByTestId('state-machine-dot')).toHaveLength(3);
+  });
+
+  it('active dot has data-state="active"', () => {
+    render(<InternalControlBar {...baseProps} status="POSTED" />);
+    const dots = screen.getAllByTestId('state-machine-dot');
+    const active = dots.find((d) => d.getAttribute('data-state') === 'active');
+    expect(active).toHaveAttribute('data-label', 'POSTED');
+  });
+});
+```
+
+### - [ ] Step 2.3: Run tests to verify they fail
+
+Run: `cd apps/web && npx vitest run src/pages/other-income/components/__tests__/InternalControlBar.test.tsx`
+
+Expected: FAIL with `Cannot find module '../InternalControlBar'`.
+
+### - [ ] Step 2.4: Write the InternalControlBar component
+
+Create `apps/web/src/pages/other-income/components/InternalControlBar.tsx`:
+
+```tsx
+import { ArrowLeft, Save, Send, CheckCircle2, XCircle, Undo2, Lock, ShieldAlert, User as UserIcon } from 'lucide-react';
+
+export type DocStatus = 'DRAFT' | 'READY' | 'POSTED' | 'REVERSED';
+
+export interface InternalControlBarProps {
+  status: DocStatus;
+  recorder: { name: string };
+  approver: { name: string };
+  makerCheckerEnabled: boolean;
+  isViewerApprover?: boolean;
+  isLoading?: boolean;
+  errorCount?: number;
+  canPost?: boolean;
+
+  onCancel: () => void;
+  onSaveDraft?: () => void;
+  onPost?: () => void;
+  onSubmitForApproval?: () => void;
+  onApprove?: () => void;
+  onReject?: () => void;
+  onReverse?: () => void;
+}
+
+const STATE_LABELS: Record<DocStatus, string> = {
+  DRAFT: 'DRAFT',
+  READY: 'READY',
+  POSTED: 'POSTED',
+  REVERSED: 'REVERSED',
+};
+
+function StateMachineBar({
+  status,
+  makerCheckerEnabled,
+}: {
+  status: DocStatus;
+  makerCheckerEnabled: boolean;
+}) {
+  const statesAll: DocStatus[] = ['DRAFT', 'READY', 'POSTED', 'REVERSED'];
+  const states = makerCheckerEnabled ? statesAll : (['DRAFT', 'POSTED', 'REVERSED'] as DocStatus[]);
+  const currentIndex = states.indexOf(status);
+
+  return (
+    <div className="flex items-center gap-2 w-full">
+      {states.map((s, i) => {
+        const isActive = i === currentIndex;
+        const isPast = i < currentIndex;
+        const state = isActive ? 'active' : isPast ? 'past' : 'future';
+        const dotClasses =
+          state === 'active'
+            ? 'w-3 h-3 rounded-full bg-primary ring-4 ring-primary/20'
+            : state === 'past'
+              ? 'w-2.5 h-2.5 rounded-full bg-muted-foreground'
+              : 'w-2.5 h-2.5 rounded-full border-2 border-border bg-background';
+        const labelClasses =
+          state === 'active'
+            ? 'text-xs font-semibold text-primary'
+            : state === 'past'
+              ? 'text-xs text-muted-foreground'
+              : 'text-xs text-muted-foreground/60';
+        return (
+          <div key={s} className="flex items-center gap-2 flex-1">
+            <div className="flex flex-col items-center gap-1">
+              <div data-testid="state-machine-dot" data-state={state} data-label={s} className={dotClasses} />
+              <span className={labelClasses}>{STATE_LABELS[s]}</span>
+            </div>
+            {i < states.length - 1 && (
+              <div className="flex-1 border-t-2 border-dashed border-border" />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function InternalControlBar({
+  status,
+  recorder,
+  approver,
+  makerCheckerEnabled,
+  isViewerApprover = false,
+  isLoading = false,
+  errorCount = 0,
+  canPost = true,
+  onCancel,
+  onSaveDraft,
+  onPost,
+  onSubmitForApproval,
+  onApprove,
+  onReject,
+  onReverse,
+}: InternalControlBarProps) {
+  const showApprovalBadge =
+    makerCheckerEnabled && (status === 'DRAFT' || status === 'READY');
+
+  const frameClass =
+    'fixed bottom-0 left-0 right-0 z-40 px-4 md:px-6 py-3 ' +
+    'border-t-2 bg-[hsl(var(--accent-purple)/0.04)] border-[hsl(var(--accent-purple)/0.3)] ' +
+    'shadow-lg backdrop-blur-sm';
+
+  return (
+    <div className={frameClass}>
+      <div className="max-w-5xl mx-auto space-y-3">
+        {/* Row 1 — Internal Control label + pills */}
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="inline-flex items-center gap-1.5 text-xs font-semibold text-[hsl(var(--accent-purple))]">
+            <Lock size={13} />
+            ควบคุมภายใน
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-info/10 text-info text-xs"
+              title="ระบบกำหนดอัตโนมัติตาม user ที่เข้าใช้งานในขณะนี้"
+            >
+              <UserIcon size={13} />
+              <span className="text-muted-foreground">ผู้บันทึก:</span>
+              <span className="font-semibold text-foreground">{recorder.name}</span>
+            </span>
+            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-success/10 text-success text-xs">
+              <CheckCircle2 size={13} />
+              <span className="text-muted-foreground">ผู้อนุมัติ:</span>
+              <span className="font-semibold text-foreground">{approver.name}</span>
+            </span>
+            {showApprovalBadge && (
+              <span
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-amber-500/15 text-amber-600 text-xs font-semibold"
+                title="เอกสารนี้ต้องผ่านการอนุมัติก่อนลงบัญชี"
+              >
+                <ShieldAlert size={13} />
+                ต้องอนุมัติ
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Row 2 — State Machine Bar */}
+        <div className="hidden md:block">
+          <StateMachineBar status={status} makerCheckerEnabled={makerCheckerEnabled} />
+        </div>
+        <div className="md:hidden text-xs text-muted-foreground">
+          สถานะ: <span className="font-semibold text-primary">● {STATE_LABELS[status]}</span>
+        </div>
+
+        {/* Row 3 — State-aware action buttons */}
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div className="text-xs">
+            {status === 'DRAFT' && errorCount > 0 && (
+              <span className="text-destructive font-semibold">มี {errorCount} ข้อต้องแก้ไข</span>
+            )}
+            {status === 'READY' && !isViewerApprover && (
+              <span className="text-muted-foreground">รออนุมัติจากผู้ตรวจสอบ</span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isLoading}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border rounded-md hover:bg-accent disabled:opacity-50"
+            >
+              <ArrowLeft size={14} />
+              {status === 'POSTED' || status === 'REVERSED' ? 'ปิด' : status === 'READY' ? 'กลับ' : 'ยกเลิก'}
+            </button>
+
+            {/* DRAFT actions */}
+            {status === 'DRAFT' && (
+              <>
+                <button
+                  type="button"
+                  onClick={onSaveDraft}
+                  disabled={isLoading}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border rounded-md hover:bg-accent disabled:opacity-50"
+                >
+                  <Save size={14} />
+                  บันทึกร่าง
+                </button>
+                {makerCheckerEnabled ? (
+                  <button
+                    type="button"
+                    onClick={onSubmitForApproval}
+                    disabled={isLoading || !canPost}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    <Send size={14} />
+                    ส่งให้อนุมัติ
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={onPost}
+                    disabled={isLoading || !canPost}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    <CheckCircle2 size={14} />
+                    บันทึก & POST
+                  </button>
+                )}
+              </>
+            )}
+
+            {/* READY actions (approver only) */}
+            {status === 'READY' && isViewerApprover && (
+              <>
+                <button
+                  type="button"
+                  onClick={onReject}
+                  disabled={isLoading}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold border border-destructive/40 text-destructive rounded-md hover:bg-destructive/10 disabled:opacity-50"
+                >
+                  <XCircle size={14} />
+                  ปฏิเสธ
+                </button>
+                <button
+                  type="button"
+                  onClick={onApprove}
+                  disabled={isLoading}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40"
+                >
+                  <CheckCircle2 size={14} />
+                  อนุมัติ & POST
+                </button>
+              </>
+            )}
+
+            {/* POSTED actions */}
+            {status === 'POSTED' && onReverse && (
+              <button
+                type="button"
+                onClick={onReverse}
+                disabled={isLoading}
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-semibold border border-destructive/40 text-destructive rounded-md hover:bg-destructive/10 disabled:opacity-50"
+              >
+                <Undo2 size={14} />
+                กลับรายการ
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+### - [ ] Step 2.5: Run tests to verify they pass
+
+Run: `cd apps/web && npx vitest run src/pages/other-income/components/__tests__/InternalControlBar.test.tsx`
+
+Expected: 14/14 PASS.
+
+### - [ ] Step 2.6: TypeScript check
+
+Run: `./tools/check-types.sh web`
+
+Expected: `Web: OK`.
+
+### - [ ] Step 2.7: Commit
+
+```bash
+git add apps/web/src/index.css \
+        apps/web/src/pages/other-income/components/InternalControlBar.tsx \
+        apps/web/src/pages/other-income/components/__tests__/InternalControlBar.test.tsx
+git commit -m "feat(other-income): add InternalControlBar component + accent-purple token"
+```
+
+---
+
+## Task 3: Wire InternalControlBar into Entry Page
+
+**Files:**
+- Modify: `apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx`
+
+### - [ ] Step 3.1: Add import for InternalControlBar
+
+Near the top of `apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx`, after the other component imports, add:
+
+```tsx
+import { InternalControlBar } from './components/InternalControlBar';
+```
+
+### - [ ] Step 3.2: Remove Section 7 card
+
+Delete lines 972–1000 (the entire `{/* Section 7 — Recorder & Approver */}` block — from the opening `<section ...>` to its closing `</section>`). The block to remove starts with `{/* Section 7 — Recorder & Approver */}` and ends with `</section>` immediately before the next `</div>` or section.
+
+### - [ ] Step 3.3: Replace the old sticky bottom bar with InternalControlBar
+
+Replace the entire block at lines 1130–1208 (`{/* Sticky bottom action bar */}` through its closing `</div>` of the outer fixed div) with:
+
+```tsx
+      {/* Internal Control Bar (v2.3 — replaces Section 7 card + old sticky bar) */}
+      <InternalControlBar
+        status="DRAFT"
+        recorder={{ name: userDisplayName }}
+        approver={{ name: userDisplayName }}
+        makerCheckerEnabled={makerCheckerEnabled}
+        isLoading={isSubmitting}
+        errorCount={errorCount}
+        canPost={canPost}
+        onCancel={() => navigate('/other-income')}
+        onSaveDraft={() => {
+          const raw = form.getValues();
+          const result = otherIncomeFormSchema.safeParse(raw);
+          if (!result.success) {
+            toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+            return;
+          }
+          saveDraftMutation.mutate(result.data);
+        }}
+        onPost={() => {
+          const raw = form.getValues();
+          const result = otherIncomeFormSchema.safeParse(raw);
+          if (!result.success) {
+            toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+            return;
+          }
+          saveAndPostMutation.mutate(result.data);
+        }}
+        onSubmitForApproval={() => {
+          const raw = form.getValues();
+          const result = otherIncomeFormSchema.safeParse(raw);
+          if (!result.success) {
+            toast.error('กรุณาตรวจสอบข้อมูลให้ครบถ้วน');
+            return;
+          }
+          saveAndRequestApprovalMutation.mutate(result.data);
+        }}
+      />
+```
+
+### - [ ] Step 3.4: Add bottom padding to the form so content isn't hidden behind the sticky bar
+
+In `OtherIncomeEntryPage.tsx`, find the outermost form container `<div>` (it wraps the whole page; look near the start of the JSX return). Add `pb-44` (or whatever existing pb-* value the old sticky bar required) to its className. If the page already has `pb-32` or similar from the previous bar, bump it to `pb-44 md:pb-40` to accommodate the new 3-row bar.
+
+If the page does not currently have bottom padding, add a wrapper around the main content:
+
+```tsx
+<div className="pb-44 md:pb-40">
+  {/* existing page content */}
+</div>
+```
+
+### - [ ] Step 3.5: TypeScript check
+
+Run: `./tools/check-types.sh web`
+
+Expected: `Web: OK`.
+
+If errors mention removed imports (e.g. `CloudUpload`, `Save`, `ArrowLeft`, `Send`, `CheckCircle2`, `AlertTriangle`, `SectionHeader`), remove those unused imports from the top of the file.
+
+### - [ ] Step 3.6: Run all Other Income vitest tests
+
+Run: `cd apps/web && npx vitest run src/pages/other-income`
+
+Expected: all existing tests PASS (new DateRangeChips + InternalControlBar tests included).
+
+### - [ ] Step 3.7: Commit
+
+```bash
+git add apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+git commit -m "feat(other-income): wire InternalControlBar into Entry Page (remove Section 7 + old sticky bar)"
+```
+
+---
+
+## Task 4: Wire InternalControlBar into View Page
+
+**Files:**
+- Modify: `apps/web/src/pages/other-income/OtherIncomeViewPage.tsx`
+
+### - [ ] Step 4.1: Add import for InternalControlBar
+
+Near the top of `apps/web/src/pages/other-income/OtherIncomeViewPage.tsx`, with the other component imports, add:
+
+```tsx
+import { InternalControlBar } from './components/InternalControlBar';
+```
+
+### - [ ] Step 4.2: Identify which header buttons get moved to the bottom bar
+
+Looking at `OtherIncomeViewPage.tsx` around lines 244–393 (the `action={...}` prop of `<PageHeader>`):
+
+**Keep in the top header (utility actions):**
+- `คัดลอก` (Copy)
+- `บันทึกเป็น Template`
+- `พิมพ์ใบเสร็จ`
+- `แก้ไข` (DRAFT only — this is a navigation, not a state-control action)
+
+**Move to bottom bar (state-control actions):**
+- `ส่งขออนุมัติ` (DRAFT + maker-checker on)
+- `แก้ไขและ POST` (DRAFT + maker-checker off — but since edit-and-post navigates to edit page, treat this as a navigation and KEEP in header; the bottom bar will instead show a different note)
+- `อนุมัติ` and `ปฏิเสธ` (READY)
+- `กลับรายการ` (POSTED)
+
+For simplicity and to avoid behavior change on existing DRAFT-from-list flow, **only move POSTED/READY actions** to the bottom bar in this task. Keep DRAFT actions in the header. The Entry Page (Task 3) covers DRAFT/edit flow.
+
+### - [ ] Step 4.3: Remove POSTED "กลับรายการ" button from the header
+
+In the `<PageHeader action={...}>` block in `OtherIncomeViewPage.tsx`, locate the existing POSTED-status `กลับรายการ` button (it lives inside the `doc.status === 'POSTED'` branch). Delete that single button. Keep the other POSTED buttons (`บันทึกเป็น Template`, `พิมพ์ใบเสร็จ`).
+
+### - [ ] Step 4.4: Remove READY approve/reject buttons from the header
+
+Locate the `doc.status === 'READY'` branch in the same `<PageHeader action={...}>` block. Delete the `อนุมัติ` button and the `ปฏิเสธ` button. Keep the `rejectNote` banner if present.
+
+### - [ ] Step 4.5: Add InternalControlBar at the bottom of the view page JSX
+
+At the very end of the View Page's main return JSX (just before the closing `</div>` of the outer page container), add:
+
+```tsx
+      {/* Internal Control Bar — bottom sticky (v2.3) */}
+      {doc && (
+        <InternalControlBar
+          status={doc.status}
+          recorder={{ name: doc.createdByName ?? doc.createdBy ?? '—' }}
+          approver={{ name: doc.approvedByName ?? doc.approvedBy ?? doc.createdByName ?? '—' }}
+          makerCheckerEnabled={makerCheckerEnabled}
+          isViewerApprover={user?.id !== doc.createdById}
+          isLoading={isActionLoading}
+          onCancel={() => navigate('/other-income')}
+          onApprove={() => approveMutation.mutate()}
+          onReject={() => rejectMutation.mutate()}
+          onReverse={canReverse ? () => reverseMutation.mutate() : undefined}
+        />
+      )}
+```
+
+**Note:** Field names like `doc.createdByName`, `doc.approvedByName`, `doc.createdById` come from the existing `OtherIncome` API shape. If any of these names are inaccurate, use the actual field on `doc` (run `grep "createdBy\|approvedBy" apps/web/src/types/otherIncome.ts` or similar to find the right names). The pills will gracefully fall back to `'—'` if missing.
+
+### - [ ] Step 4.6: Add bottom padding to the View Page main container
+
+Find the outermost `<div className="p-6 max-w-7xl mx-auto">` at line 237 and change to `<div className="p-6 max-w-7xl mx-auto pb-44 md:pb-40">`.
+
+### - [ ] Step 4.7: TypeScript check
+
+Run: `./tools/check-types.sh web`
+
+Expected: `Web: OK`.
+
+If errors mention `doc.createdByName` etc. not existing on the type, use whichever fields actually exist on the `OtherIncome` type — adjust the props in Step 4.5 accordingly. Acceptable fallback fields: `createdById`, `approvedById`, or simply `user?.name` for both pills.
+
+### - [ ] Step 4.8: Run all Other Income vitest tests
+
+Run: `cd apps/web && npx vitest run src/pages/other-income`
+
+Expected: all PASS.
+
+### - [ ] Step 4.9: Commit
+
+```bash
+git add apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+git commit -m "feat(other-income): wire InternalControlBar into View Page (move state actions from header)"
+```
+
+---
+
+## Final Verification
+
+### - [ ] Step F.1: Full TypeScript check
+
+Run: `./tools/check-types.sh all`
+
+Expected: `TypeScript check passed!`
+
+### - [ ] Step F.2: Full Other Income test suite
+
+Run: `cd apps/web && npx vitest run src/pages/other-income`
+
+Expected: all PASS, no skipped tests.
+
+### - [ ] Step F.3: Manual smoke (start dev server)
+
+Run in one terminal: `cd apps/web && npm run dev`
+
+Open `http://localhost:5173/other-income` and verify:
+
+1. **List page:**
+   - 4 chips render: ทั้งหมด, เดือนนี้, เดือนที่แล้ว, ช่วงวันที่...
+   - "เดือนนี้" is selected by default (chip has primary background)
+   - Right-side label shows `📅 พฤษภาคม 2569 (01/05 - 14/05)` (or current month)
+   - Clicking "เดือนที่แล้ว" updates the list query and the label
+   - Clicking "ช่วงวันที่..." reveals the 2 native date inputs
+
+2. **Entry page** (`/other-income/new`):
+   - No more Section 7 card mid-page (no "ผู้บันทึก & ผู้อนุมัติ" section above the action bar)
+   - Bottom sticky bar has a purple-tinged border
+   - Bar shows: 🔐 ควบคุมภายใน label + pills (ผู้บันทึก, ผู้อนุมัติ) + (if Maker-Checker on) ต้องอนุมัติ badge
+   - State machine bar shows 4 dots (DRAFT highlighted) when Maker-Checker on, 3 dots when off
+   - Buttons: ← ยกเลิก, 💾 บันทึกร่าง, ✓ บันทึก & POST (or ส่งให้อนุมัติ)
+
+3. **View page on a POSTED doc:**
+   - Top header no longer shows "กลับรายการ" button
+   - Bottom sticky InternalControlBar shows: ← ปิด + ↩ กลับรายการ
+   - State machine bar dot is on POSTED
+
+4. **Settings → toggle Maker-Checker ON → reload entry page:**
+   - "ต้องอนุมัติ" badge appears in the bar
+   - POST button text changes to "ส่งให้อนุมัติ"
+   - State machine bar now shows 4 dots
+
+### - [ ] Step F.4: Push branch and open PR
+
+```bash
+git push -u origin feat/other-income-v2-3-ui-pdf-gap
+gh pr create --title "feat(other-income): v2.3 UI PDF gap — DateRangeChips + InternalControlBar" --body "$(cat <<'EOF'
+## Summary
+- เพิ่ม DateRangeChips quick filter (ทั้งหมด/เดือนนี้/เดือนที่แล้ว/ช่วงวันที่) ในหน้ารายการ default = "เดือนนี้"
+- เพิ่ม InternalControlBar (กรอบม่วง sticky bottom) รวม pills ผู้บันทึก/อนุมัติ + State Machine bar + ปุ่ม state-aware
+- ใช้ใน Entry Page (แทน Section 7 card + sticky bar เดิม) และ View Page (ย้ายปุ่ม state-control จาก header มาที่ bar)
+
+ปิด 3/10 จุดสุดท้ายของ PDF UI Comparison Report (7 ข้อแรกชิปไปแล้วใน PR #827 v2.2)
+
+## Test plan
+- [x] TypeScript: 0 errors
+- [x] Vitest: 23 tests ใหม่ (9 + 14)
+- [ ] Manual: list page chips + entry page bar + view page bar (smoke checklist in spec)
+
+Spec: docs/superpowers/specs/2026-05-14-other-income-v2-3-ui-pdf-gap-design.md
+Plan: docs/superpowers/plans/2026-05-14-other-income-v2-3-ui-pdf-gap.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+### - [ ] Step F.5: Merge after manual smoke approval
+
+Once owner manually smokes and approves:
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+git checkout main && git pull origin main
+```

--- a/docs/superpowers/specs/2026-05-14-other-income-v2-3-ui-pdf-gap-design.md
+++ b/docs/superpowers/specs/2026-05-14-other-income-v2-3-ui-pdf-gap-design.md
@@ -1,0 +1,202 @@
+# Other Income v2.3 — UI PDF Gap Fixes
+
+**Date:** 2026-05-14
+**Module:** `apps/web/src/pages/other-income/`
+**Source report:** `Other-Income-UI-Comparison-Report.pdf` (Production v2.1 vs Target Prototype, 14 พ.ค. 2569)
+
+## Context
+
+External UI comparison report identified 10 gaps. Audit of current codebase (post PR #827 v2.2) reveals 7 already shipped. Only 3 remain:
+
+| # | Item | Status | Effort |
+|---|---|---|---|
+| 4 | Date Range Quick Chips on List Page | Missing | 1d |
+| 5 | State Machine Bar + "ต้องอนุมัติ" badge | Partial | 0.5d |
+| 6 | Internal Control Action Bar (purple frame) | Missing | 1d |
+
+Items #5 and #6 are tightly coupled — both modify the bottom action bar on the Entry/View pages. Treat as one refactor.
+
+## Goal
+
+Close the remaining 3 UI gaps so the live module visually matches the accountant's target prototype. No backend changes — pure presentation layer.
+
+## Non-goals
+
+- Backend API changes (data shapes already support what we need)
+- Mobile-only redesign (responsive only)
+- Adding new states beyond DRAFT/READY/POSTED/REVERSED
+- Changing the Maker-Checker policy (toggle behavior unchanged)
+
+## Design
+
+### 1. Date Range Quick Chips
+
+**Location:** [`OtherIncomeListPage.tsx`](../../apps/web/src/pages/other-income/OtherIncomeListPage.tsx) — above the existing 2 date inputs at lines 282–295.
+
+**Component:** New file `apps/web/src/pages/other-income/components/DateRangeChips.tsx`. Keep it private to the Other Income module for now; promote to shared if Expense/Asset modules ask for the same.
+
+**UX:**
+
+```
+[ ทั้งหมด ] [ เดือนนี้ ] [ เดือนที่แล้ว ] [ ช่วงวันที่... ]      📅 พฤษภาคม 2569 (01/05 - 31/05)
+```
+
+| Chip | startDate | endDate | URL params |
+|---|---|---|---|
+| ทั้งหมด | (empty) | (empty) | none |
+| เดือนนี้ (default) | 1st of current month BKK | today BKK | `?startDate=YYYY-MM-01&endDate=YYYY-MM-DD` |
+| เดือนที่แล้ว | 1st of last month BKK | last day of last month BKK | same |
+| ช่วงวันที่... | manual | manual | reveal existing 2 date inputs |
+
+**Default change:** On first load with no URL params, select "เดือนนี้" (was "ทั้งหมด"). Existing URL params take priority (user can still deep-link to all-time).
+
+**Right-side label:** Auto-derived summary string based on current `(startDate, endDate)`:
+
+- Both empty → `"ทั้งหมด"`
+- Single calendar month → `"พฤษภาคม 2569"`
+- Single month partial → `"พฤษภาคม 2569 (01/05 - 14/05)"`
+- Cross-month → `"1 เม.ย. - 14 พ.ค. 2569"`
+
+**State management:** Drive from existing `startDate`/`endDate` `useState` in `OtherIncomeListPage`. Chips infer their active state by comparing to "today" each render — no extra state needed.
+
+**Cleanup:** Remove the standalone "🧹 ล้าง" button at line 296 — the "ทั้งหมด" chip replaces it. The 2 date inputs remain visible only when "ช่วงวันที่..." chip is active (or when URL deep-link doesn't match a preset).
+
+**Accessibility:** Chips are `<button role="radio">` inside a `<div role="radiogroup" aria-label="ช่วงวันที่">`.
+
+### 2. Internal Control Bar (#5 + #6 combined)
+
+**Component:** New file `apps/web/src/pages/other-income/components/InternalControlBar.tsx`.
+
+**Used by:**
+- [`OtherIncomeEntryPage.tsx`](../../apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx) — DRAFT/READY states (replaces existing sticky bar at lines 1131–1208)
+- [`OtherIncomeViewPage.tsx`](../../apps/web/src/pages/other-income/OtherIncomeViewPage.tsx) — POSTED/REVERSED states (sticky bottom)
+
+#### Visual structure (3 rows inside a purple-frame card)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  🔐 ควบคุมภายใน                                                       │
+│  [👤 ผู้บันทึก: เอกนรินทร์]  [✓ ผู้อนุมัติ: เอกนรินทร์]  [⚠ ต้องอนุมัติ]    │  Row 1: pills
+├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┤
+│  ● DRAFT  ─ ─ ─  ○ READY  ─ ─ ─  ○ POSTED  ─ ─ ─  ○ REVERSED         │  Row 2: state machine
+├─────────────────────────────────────────────────────────────────────┤
+│              [← ยกเลิก]  [💾 บันทึกร่าง]  [✓ บันทึก & POST]            │  Row 3: actions
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Frame style:** `border-2 border-purple-500/30 bg-purple-500/[0.03] rounded-xl shadow-lg`. Use Tailwind-via-design-tokens-extension; the project does NOT use raw `bg-purple-500` elsewhere, so add `--accent-purple` token to `index.css`:
+
+```css
+--accent-purple: 280 60% 55%;
+--accent-purple-foreground: 280 80% 95%;
+```
+
+Use as `border-[hsl(var(--accent-purple)/0.3)]` etc. This satisfies the "no hardcoded hex" rule in `.claude/rules/frontend.md`.
+
+**Row 1 — Pills:**
+
+| Pill | Visible when | Style |
+|---|---|---|
+| 👤 ผู้บันทึก: {name} | always | `bg-info/10 text-info` |
+| ✓ ผู้อนุมัติ: {name} | always | `bg-success/10 text-success` |
+| ⚠ ต้องอนุมัติ | `makerCheckerEnabled && status ∈ {DRAFT, READY}` | `bg-amber-500/15 text-amber-600` w/ tooltip |
+
+Tooltip on "ต้องอนุมัติ": *"เอกสารนี้ต้องผ่านการอนุมัติก่อนลงบัญชี"*
+
+**Row 2 — State Machine Bar:**
+
+- Default 4 dots: `DRAFT → READY → POSTED → REVERSED`
+- When `!makerCheckerEnabled`: collapse to 3 dots `DRAFT → POSTED → REVERSED`
+- Active dot: `w-3 h-3 rounded-full bg-primary ring-4 ring-primary/20`, label below in `text-primary font-medium`
+- Past dots: `bg-muted-foreground` solid, label `text-muted-foreground`
+- Future dots: `border-2 border-border bg-background`, label `text-muted-foreground/60`
+- Connector lines: `border-t-2 border-dashed border-border`
+- Dots resolve their visual state purely from current `status` vs their position: dots before current = past (solid muted), the matching one = active (primary), dots after = future (outline). REVERSED is always rendered as the last dot — it appears as "future" when status is DRAFT/READY/POSTED and "active" only when status === REVERSED.
+
+**Row 3 — State-aware buttons:**
+
+| Status | Maker-Checker | Buttons (left → right) | onClick |
+|---|---|---|---|
+| DRAFT | OFF | `← ยกเลิก`, `💾 บันทึกร่าง`, `✓ บันทึก & POST` | onCancel, onSaveDraft, onPost |
+| DRAFT | ON | `← ยกเลิก`, `💾 บันทึกร่าง`, `📤 ส่งให้อนุมัติ` | onCancel, onSaveDraft, onSubmitForApproval |
+| READY | ON, viewer is approver | `← กลับ`, `❌ ปฏิเสธ`, `✓ อนุมัติ & POST` | onCancel, onReject, onApprove |
+| READY | ON, viewer is maker | `← กลับ`, (read-only banner: "รออนุมัติ") | onCancel only |
+| POSTED | any | `← ปิด`, `↩ กลับรายการ` | onCancel, onReverse |
+| REVERSED | any | `← ปิด` | onCancel |
+
+Buttons follow existing shadcn/ui `Button` variants: `variant="ghost"` for cancel, `variant="outline"` for save-draft, `variant="default"` for primary action, `variant="destructive"` for reject/reverse.
+
+#### Component API
+
+```ts
+interface InternalControlBarProps {
+  status: 'DRAFT' | 'READY' | 'POSTED' | 'REVERSED';
+  recorder: { name: string };
+  approver: { name: string };
+  makerCheckerEnabled: boolean;
+  isViewerApprover?: boolean;  // for READY → which buttons to show
+  isLoading?: boolean;
+
+  onCancel: () => void;
+  onSaveDraft?: () => void;
+  onPost?: () => void;
+  onSubmitForApproval?: () => void;
+  onApprove?: () => void;
+  onReject?: () => void;
+  onReverse?: () => void;
+}
+```
+
+Caller passes only the handlers relevant to its page — the component picks the right ones based on `status` + `makerCheckerEnabled`.
+
+#### Removals
+
+- **Section 7 card** in `OtherIncomeEntryPage.tsx` (lines 972–1000) — entire `<section>` block. The "ระบบกำหนดอัตโนมัติตาม user" hint becomes a `title` attribute on the ผู้บันทึก pill instead.
+- **Existing sticky bar** in `OtherIncomeEntryPage.tsx` (lines 1131–1208) — replaced wholesale by `<InternalControlBar />`.
+- **View page action bar** in `OtherIncomeViewPage.tsx` — wire through `<InternalControlBar />`. The right-side sticky sidebar (line 563) stays — it's a different surface (summary), not the action bar.
+
+#### Responsive behavior
+
+- ≥768px (desktop): 3 stacked rows as shown above
+- <768px (mobile):
+  - Row 1: pills wrap to 2 lines if needed (no scroll)
+  - Row 2: state machine collapses to `"สถานะ: ● DRAFT"` text only (no dots)
+  - Row 3: buttons remain horizontal — they're max 3, all fit on phone widths
+
+### 3. Spec for sequencing
+
+Build in this order — each is independently shippable:
+
+1. **DateRangeChips component** + wire to list page (smallest, no shared deps)
+2. **InternalControlBar component** standalone with Storybook-style mock page or test renders (no integration yet)
+3. **Wire InternalControlBar into Entry Page** — remove Section 7, remove old sticky bar
+4. **Wire InternalControlBar into View Page** — POSTED/REVERSED states
+
+Steps 1 and 2 can run in parallel. Steps 3 and 4 depend on step 2.
+
+## Testing
+
+**Unit tests:**
+
+- `DateRangeChips.test.tsx`: each chip click produces the correct `(startDate, endDate)` tuple. Label formatter handles single-month, partial-month, cross-month cases.
+- `InternalControlBar.test.tsx`: for each `(status, makerCheckerEnabled, isViewerApprover)` triple, the correct buttons render and the correct handlers fire.
+
+**Manual smoke (post-merge):**
+
+- Visit `/other-income` → verify "เดือนนี้" is selected by default, list filters correctly
+- Click each chip → URL params update, list refetches
+- Visit `/other-income/new` → confirm Section 7 card is gone, sticky bottom bar shows pills + state machine + 3 buttons in purple frame
+- Toggle Maker-Checker ON in Settings → reload entry page → "ต้องอนุมัติ" badge appears, "บันทึก & POST" button text changes to "ส่งให้อนุมัติ"
+- Visit any POSTED doc → bar shows `← ปิด` + `↩ กลับรายการ`, state machine dot on POSTED
+
+**Regression risk:**
+
+- Existing `OtherIncomeEntryPage` users-may-have-bookmarked-draft flow: ensure cancel/save-draft handlers still resolve the same way.
+- Maker-Checker toggle: state-machine should immediately re-render when toggle flips (it does — `makerCheckerEnabled` is a React-Query value that bubbles re-renders).
+
+## Out of scope
+
+- Storybook setup (not used in this project)
+- Animated state machine transitions (CSS transitions only, no motion library)
+- Audit log entries (status changes already audited at the API layer)
+- Notifications/emails when entering READY state (separate feature)


### PR DESCRIPTION
## Summary

ปิด 3 จุดสุดท้ายของ PDF UI Comparison Report (Other Income v2.1 → v2.2 — 7 จุดแรกชิปไปแล้วใน PR #827):

1. **DateRangeChips** (List Page) — 4 chips quick filter (ทั้งหมด/เดือนนี้/เดือนที่แล้ว/ช่วงวันที่) + Thai-locale label. Default = "เดือนนี้"
2. **InternalControlBar** (Entry + View Page) — sticky bottom bar กรอบม่วง รวม pills ผู้บันทึก/อนุมัติ + ต้องอนุมัติ badge + State Machine bar (3/4 dots) + state-aware buttons. แทน Section 7 card + sticky bar เดิม

## Changes

| ไฟล์ | ลักษณะ |
|---|---|
| `components/DateRangeChips.tsx` (new, 144 lines) | 4-chip filter component |
| `components/InternalControlBar.tsx` (new, 245 lines) | Sticky bottom control bar |
| `components/__tests__/*.test.tsx` (new) | 24 tests รวม (9 + 15) |
| `index.css` | เพิ่ม `--accent-purple` token (light + dark) |
| `lib/date.ts` | Export `THAI_MONTHS_SHORT` (was private) |
| `OtherIncomeListPage.tsx` | Wire DateRangeChips, default = this month |
| `OtherIncomeEntryPage.tsx` | Remove Section 7 + old sticky bar, wire InternalControlBar, renumber 8→7 9→8 |
| `OtherIncomeViewPage.tsx` | Move READY/POSTED state buttons จาก header → bottom bar |

## Code Review Fixes Applied

- ✅ Critical: `approver.name = 'OWNER'` ใน Maker-Checker mode (เดิม show recorder ทั้งคู่)
- ✅ amber-500/15 → warning token (frontend.md rule)
- ✅ StateMachineBar fallback for READY status when flag is loading
- ✅ Dedupe Thai month arrays via `@/lib/date` exports
- ✅ Renumber sections (close gap at 7)
- ✅ Wait wording "ผู้ตรวจสอบ" → "OWNER" (clearer)
- ✅ Add test: READY + Maker-Checker shows "ต้องอนุมัติ" badge

Deferred (require backend changes or scope creep): I2 (ViewPage recorder='—' for non-creators — needs `createdByName` from API), W4 (DOM querySelector for chip focus — works but brittle in future reuse contexts).

## Test plan

- [x] TypeScript: `./tools/check-types.sh all` → API: OK, Web: OK
- [x] Vitest: `apps/web/src/pages/other-income` 30/30 PASS
- [ ] Manual smoke (owner):
  - List page: chips render, default = "เดือนนี้", switching chips refetches
  - Entry page DRAFT: purple bar visible, pills correct, status machine 3 dots (off) or 4 dots (on)
  - Entry page with Maker-Checker on: "ต้องอนุมัติ" badge + "ส่งให้อนุมัติ" button + approver pill = "OWNER"
  - View page POSTED: "กลับรายการ" ใน bar (not header)
  - View page READY (as OWNER ≠ creator): "ปฏิเสธ" + "อนุมัติ & POST" ใน bar
  - View page READY (as creator): "ไม่สามารถอนุมัติเอกสารที่ตนสร้างได้" note ใน header

Spec: `docs/superpowers/specs/2026-05-14-other-income-v2-3-ui-pdf-gap-design.md`
Plan: `docs/superpowers/plans/2026-05-14-other-income-v2-3-ui-pdf-gap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)