### PR TITLE
chore(other-income): remove AccountingModuleTabBar from List + Entry pages

### DIFF
--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -17,7 +17,6 @@ import {
 } from 'lucide-react';
 import Decimal from 'decimal.js';
 import QueryBoundary from '@/components/QueryBoundary';
-import { AccountingModuleTabBar } from '@/components/accounting/AccountingModuleTabBar';
 import { useAuth } from '@/contexts/AuthContext';
 import { formatNumber, formatNumberDecimal } from '@/utils/formatters';
 import { otherIncomeApi } from '@/lib/otherIncome';
@@ -574,9 +573,6 @@ export default function OtherIncomeEntryPage() {
   return (
     <div className="pb-44 md:pb-40">
       <div className="p-4 md:p-6 max-w-5xl mx-auto">
-        <div className="mb-4">
-          <AccountingModuleTabBar />
-        </div>
         {/* Custom header */}
         <div className="flex items-start justify-between gap-4 mb-6">
           <div className="min-w-0">

--- a/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeListPage.tsx
@@ -6,7 +6,6 @@ import { Plus, Search, FileText, Receipt, RotateCcw, CheckCircle2, ChartBar, Cli
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { AccountingModuleTabBar } from '@/components/accounting/AccountingModuleTabBar';
 import { ReopenedPeriodBanner } from '@/components/accounting/ReopenedPeriodBanner';
 import { useDebounce } from '@/hooks/useDebounce';
 import { usePaginationParams } from '@/hooks/usePaginationParams';
@@ -223,7 +222,6 @@ export default function OtherIncomeListPage() {
 
   return (
     <div className="p-6 max-w-7xl mx-auto space-y-4">
-      <AccountingModuleTabBar />
       <ReopenedPeriodBanner />
       <PageHeader
         title="รายได้อื่น"


### PR DESCRIPTION
## Summary

ลบ `AccountingModuleTabBar` ออกจาก Other Income List + Entry pages (ตาม owner request — ปุ่ม tab bar ซ้ำกับ AppSidebar และไม่ปรากฏใน PDF v2.2 target design)

## Changes

| ไฟล์ | การแก้ |
|---|---|
| OtherIncomeListPage.tsx | ลบ import + `<AccountingModuleTabBar />` |
| OtherIncomeEntryPage.tsx | ลบ import + wrapper `<div className="mb-4">` |

## Scope

ลบเฉพาะ Other Income — Asset pages (AssetsListPage + AssetEntryPage) ยังใช้ component นี้อยู่. Component file ไม่ได้ลบ ถ้า owner อยากลบทั้ง module ค่อยทำ follow-up.

## Test plan

- [x] TypeScript: Web OK
- [ ] Visual: ดู /other-income และ /other-income/new — ไม่มี tab bar กรอบม่วงด้านบน

🤖 Generated with [Claude Code](https://claude.com/claude-code)