### PR TITLE
chore(other-income): default dates to today + show account name in JE preview

### DIFF
--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -161,8 +161,8 @@ function todayBangkok(): string {
 
 const defaultValues: OtherIncomeFormValues = {
   issueDate: todayBangkok(),
-  dueDate: '',
-  paymentDate: '',
+  dueDate: todayBangkok(),
+  paymentDate: todayBangkok(),
   priceType: 'EXCLUSIVE',
   customerId: '',
   counterpartyName: '',

--- a/apps/web/src/pages/other-income/components/AutoJournalPreview.tsx
+++ b/apps/web/src/pages/other-income/components/AutoJournalPreview.tsx
@@ -1,4 +1,6 @@
 import { CheckCircle2, XCircle } from 'lucide-react';
+import { useMemo } from 'react';
+import { useCoaByCodes } from '@/hooks/useCoa';
 
 interface JeLine {
   accountCode: string;
@@ -20,6 +22,19 @@ export function AutoJournalPreview({ lines }: Props) {
   const totalCr = lines.reduce((s, l) => s + l.credit, 0);
   const balanced = Math.abs(totalDr - totalCr) < 0.01;
 
+  // Resolve account codes → names via CoA lookup. Hook is cached (staleTime: Infinity),
+  // so subsequent renders with the same code set hit cache instantly.
+  const uniqueCodes = useMemo(
+    () => Array.from(new Set(lines.map((l) => l.accountCode).filter(Boolean))),
+    [lines],
+  );
+  const { data: coaRows } = useCoaByCodes(uniqueCodes);
+  const nameByCode = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const r of coaRows ?? []) map[r.code] = r.name;
+    return map;
+  }, [coaRows]);
+
   return (
     <div className="rounded-lg border p-3 bg-card">
       <p className="text-sm font-bold mb-2">JOURNAL PREVIEW (Auto)</p>
@@ -29,22 +44,28 @@ export function AutoJournalPreview({ lines }: Props) {
         <div className="font-mono text-xs space-y-1">
           {lines.map((l, idx) => {
             const isDr = l.debit > 0;
+            const accountName = nameByCode[l.accountCode];
             return (
               <div
                 key={idx}
                 className="flex items-baseline gap-2 px-2 py-1 hover:bg-accent rounded"
               >
-                <span className={`font-bold w-6 ${isDr ? 'text-info' : 'text-primary'}`}>
+                <span className={`font-bold w-6 shrink-0 ${isDr ? 'text-info' : 'text-primary'}`}>
                   {isDr ? 'Dr' : 'Cr'}
                 </span>
-                <span className={`font-bold w-20 ${isDr ? 'text-info' : 'text-primary'}`}>
+                <span className={`font-bold w-20 shrink-0 ${isDr ? 'text-info' : 'text-primary'}`}>
                   {l.accountCode}
                 </span>
-                <span className="font-bold w-28 text-right">
+                <span className="flex-1 truncate text-foreground">
+                  {accountName || <span className="text-muted-foreground">—</span>}
+                </span>
+                <span className="font-bold w-28 text-right shrink-0">
                   {(isDr ? l.debit : l.credit).toFixed(2)}
                 </span>
                 {l.description && (
-                  <span className="flex-1 text-muted-foreground truncate">({l.description})</span>
+                  <span className="w-40 text-muted-foreground truncate text-right shrink-0">
+                    ({l.description})
+                  </span>
                 )}
               </div>
             );


### PR DESCRIPTION
## Summary

Two UX tweaks per owner request on /other-income/new:

1. **Default dates = today** — `dueDate` + `paymentDate` ตอน new doc default เป็นวันนี้ (เดิมว่าง — user ต้องกรอกทุกครั้ง). Most other-income docs (interest, late fee, etc.) are received same-day so today is the right default.

2. **JE Preview แสดงชื่อบัญชี** — บรรทัด Auto Journal Preview เดิมโชว์แค่รหัสบัญชี (`42-1102`) ตอนนี้โชว์ชื่อด้วย (`42-1102  ดอกเบี้ยเงินฝาก`) ดึงจาก `/chart-of-accounts/by-codes` ผ่าน existing `useCoaByCodes` hook (cached `staleTime: Infinity`)

## Changes

| ไฟล์ | การแก้ |
|---|---|
| OtherIncomeEntryPage.tsx | defaultValues.dueDate + paymentDate = todayBangkok() |
| AutoJournalPreview.tsx | useCoaByCodes lookup + render name column |

## Test plan

- [x] TypeScript: Web OK
- [ ] Visual: /other-income/new — วันที่ครบกำหนด + วันที่ชำระ default เป็นวันนี้
- [ ] Visual: JE preview แสดง "42-1102  ดอกเบี้ยเงินฝาก" แทน "42-1102" เท่านั้น

🤖 Generated with [Claude Code](https://claude.com/claude-code)