### PR TITLE
feat(other-income): downloadable PDF receipt via puppeteer

### DIFF
--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -11,6 +11,7 @@ import {
   Put,
   Query,
   Request,
+  Res,
   UploadedFile,
   UseGuards,
   UseInterceptors,
@@ -18,6 +19,7 @@ import {
   MaxFileSizeValidator,
   FileTypeValidator,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -25,6 +27,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { OtherIncomeService } from './other-income.service';
 import { TemplateService } from './services/template.service';
+import { OtherIncomeReceiptPdfService } from './services/receipt-pdf.service';
 import { CreateOtherIncomeDto } from './dto/create-other-income.dto';
 import { UpdateOtherIncomeDto } from './dto/update-other-income.dto';
 import { PostOtherIncomeDto } from './dto/post-other-income.dto';
@@ -45,6 +48,7 @@ export class OtherIncomeController {
   constructor(
     private readonly service: OtherIncomeService,
     private readonly templateService: TemplateService,
+    private readonly receiptPdf: OtherIncomeReceiptPdfService,
   ) {}
 
   // CRITICAL: declare daily-sheet BEFORE :id so the literal string
@@ -162,6 +166,20 @@ export class OtherIncomeController {
   @Get(':id/audit')
   getAuditTrail(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.service.getAuditTrail(id);
+  }
+
+  @Get(':id/receipt.pdf')
+  async getReceiptPdf(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Res() res: Response,
+  ) {
+    const pdf = await this.receiptPdf.generate(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `inline; filename="other-income-receipt-${id}.pdf"`,
+      'Content-Length': pdf.length.toString(),
+    });
+    res.send(pdf);
   }
 
   @Post()

--- a/apps/api/src/modules/other-income/other-income.module.ts
+++ b/apps/api/src/modules/other-income/other-income.module.ts
@@ -9,6 +9,7 @@ import { AutoJournalService } from './services/auto-journal.service';
 import { TemplateService } from './services/template.service';
 import { OtherIncomeTemplate } from './templates/other-income.template';
 import { JournalOverrideService } from './services/journal-override.service';
+import { OtherIncomeReceiptPdfService } from './services/receipt-pdf.service';
 
 // PrismaService is provided globally via PrismaModule (@Global) — no import needed.
 
@@ -23,6 +24,7 @@ import { JournalOverrideService } from './services/journal-override.service';
     TemplateService,
     OtherIncomeTemplate,
     JournalOverrideService,
+    OtherIncomeReceiptPdfService,
   ],
   exports: [OtherIncomeService, TemplateService],
 })

--- a/apps/api/src/modules/other-income/services/receipt-pdf.service.ts
+++ b/apps/api/src/modules/other-income/services/receipt-pdf.service.ts
@@ -1,0 +1,241 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as puppeteer from 'puppeteer';
+import * as QRCode from 'qrcode';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+type DocWithItems = Prisma.OtherIncomeGetPayload<{
+  include: {
+    items: true;
+    customer: { select: { id: true; name: true; phone: true } };
+  };
+}>;
+
+const THAI_MONTHS_FULL = [
+  'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
+  'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม',
+];
+
+function fmtThaiDate(d: Date | string | null | undefined): string {
+  if (!d) return '—';
+  const dt = typeof d === 'string' ? new Date(d) : d;
+  if (isNaN(dt.getTime())) return '—';
+  return `${dt.getDate()} ${THAI_MONTHS_FULL[dt.getMonth()]} ${dt.getFullYear() + 543}`;
+}
+
+function fmtMoney(v: unknown): string {
+  const n = typeof v === 'string' ? parseFloat(v) : Number(v);
+  if (!isFinite(n)) return '0.00';
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function escapeHtml(text: string | null | undefined): string {
+  if (!text) return '';
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+@Injectable()
+export class OtherIncomeReceiptPdfService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async generate(id: string): Promise<Buffer> {
+    const doc = await this.prisma.otherIncome.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        items: { orderBy: { lineNo: 'asc' } },
+        customer: { select: { id: true, name: true, phone: true } },
+      },
+    });
+    if (!doc) throw new NotFoundException('ไม่พบเอกสาร');
+
+    const company = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE' },
+    });
+
+    const html = await this.renderHtml(doc, company);
+
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(html, { waitUntil: 'networkidle0' });
+      const pdf = await page.pdf({
+        format: 'A4',
+        margin: { top: '12mm', right: '12mm', bottom: '12mm', left: '12mm' },
+        printBackground: true,
+      });
+      return Buffer.from(pdf);
+    } finally {
+      await browser.close();
+    }
+  }
+
+  private async renderHtml(
+    doc: DocWithItems,
+    company: { nameTh: string; taxId: string | null; address: string | null; phone: string | null } | null,
+  ): Promise<string> {
+
+    const verifyUrl = `https://bestchoicephone.app/other-income/${doc.id}`;
+    const qrDataUrl = await QRCode.toDataURL(verifyUrl, {
+      margin: 0,
+      width: 200,
+      color: { dark: '#18181b', light: '#ffffff' },
+    });
+
+    const items = (doc.items || [])
+      .map(
+        (it) => `
+          <tr>
+            <td>
+              <div style="font-weight:600">${escapeHtml(it.accountName)}</div>
+              <div style="font-size:10px;color:#71717a">(${escapeHtml(it.accountCode)})</div>
+              ${it.description ? `<div style="font-size:10px;color:#71717a">${escapeHtml(it.description)}</div>` : ''}
+            </td>
+            <td style="text-align:right;font-family:monospace">${fmtMoney(it.quantity)}</td>
+            <td style="text-align:right;font-family:monospace">${fmtMoney(it.unitAmount)}</td>
+            <td style="text-align:center;font-size:11px">${Number(it.vatPct) > 0 ? `${it.vatPct}%` : '-'}</td>
+            <td style="text-align:right;font-family:monospace">${fmtMoney(it.amountBeforeVat)}</td>
+          </tr>`,
+      )
+      .join('');
+
+    const firstWhtPct = doc.items?.[0]?.whtPct;
+    const showVatRow = Number(doc.vatAmount) > 0;
+    const showWhtRow = Number(doc.whtAmount) > 0;
+
+    const customerName = doc.customer?.name || doc.counterpartyName || '—';
+
+    return `<!DOCTYPE html>
+<html lang="th">
+<head>
+<meta charset="UTF-8" />
+<title>ใบเสร็จรับเงิน ${escapeHtml(doc.docNumber)}</title>
+<style>
+  * { box-sizing: border-box; }
+  body { font-family: 'Sarabun', 'Helvetica Neue', Arial, sans-serif; color: #18181b; font-size: 13px; line-height: 1.45; margin: 0; padding: 0; }
+  .title-block { text-align: right; margin-bottom: 16px; }
+  .title-original { font-size: 11px; color: #71717a; }
+  .title-h1 { font-size: 24px; font-weight: 700; color: #059669; margin: 4px 0 0; }
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
+  .seller p { margin: 0; }
+  .seller .name { font-weight: 700; font-size: 14px; margin-bottom: 4px; }
+  .seller .subline { font-size: 11px; color: #52525b; }
+  .info-box { background: #f0fdf4; border: 1px solid #bbf7d0; padding: 12px; border-radius: 6px; font-size: 13px; }
+  .info-box p { margin: 0 0 4px; }
+  .info-box .small { font-size: 10px; color: #71717a; word-break: break-all; }
+  .customer-block { border-top: 1px solid #e4e4e7; border-bottom: 1px solid #e4e4e7; padding: 12px 0; margin-bottom: 16px; }
+  .customer-block .label { font-weight: 700; margin-bottom: 4px; }
+  .customer-block .sub { font-size: 11px; color: #71717a; }
+  table.items { width: 100%; border-collapse: collapse; margin-bottom: 24px; }
+  table.items thead tr { background: #f4f4f5; border-top: 1px solid #e4e4e7; border-bottom: 1px solid #e4e4e7; }
+  table.items th { padding: 8px; text-align: left; font-weight: 600; }
+  table.items th.num { text-align: right; }
+  table.items th.ctr { text-align: center; }
+  table.items td { padding: 8px; border-bottom: 1px solid #e4e4e7; vertical-align: top; }
+  .totals-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; font-size: 13px; margin-bottom: 32px; }
+  .totals-left p { margin: 0 0 4px; font-size: 11px; color: #52525b; }
+  .totals-right > div { display: flex; justify-content: space-between; margin-bottom: 4px; }
+  .totals-right .hl { background: #f0fdf4; border: 1px solid #bbf7d0; padding: 8px; border-radius: 4px; font-weight: 700; }
+  .totals-right .wht { font-size: 11px; color: #71717a; }
+  .totals-right .net { border-top: 1px solid #e4e4e7; padding-top: 4px; font-size: 11px; color: #52525b; }
+  .signatures { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; text-align: center; font-size: 11px; color: #71717a; margin-top: 24px; }
+  .signatures .line { border-bottom: 1px solid #d4d4d8; height: 56px; margin-bottom: 8px; }
+  .signatures .stamp { border: 1px dashed #d4d4d8; height: 56px; margin-bottom: 8px; display: flex; align-items: center; justify-content: center; border-radius: 4px; color: #a1a1aa; }
+  .signatures .name { font-weight: 600; color: #18181b; }
+  .qr-block { display: flex; flex-direction: column; align-items: center; margin-top: 24px; gap: 4px; }
+  .qr-block img { width: 80px; height: 80px; }
+  .qr-block .doc-no { font-size: 11px; color: #71717a; font-family: monospace; margin-top: 4px; }
+</style>
+</head>
+<body>
+  <div class="title-block">
+    <div class="title-original">(ต้นฉบับ)</div>
+    <h1 class="title-h1">ใบเสร็จรับเงิน / ใบกำกับภาษี</h1>
+  </div>
+
+  <div class="two-col">
+    <div class="seller">
+      <p class="name">${escapeHtml(company?.nameTh) || 'บริษัท เบสท์ช้อยส์ ไฟแนนท์ จำกัด'}</p>
+      <p class="subline">เลขที่ผู้เสียภาษี: ${escapeHtml(company?.taxId) || '—'}</p>
+      <p class="subline">ที่อยู่: ${escapeHtml(company?.address) || '—'}</p>
+      <p class="subline">โทร: ${escapeHtml(company?.phone) || '—'}</p>
+    </div>
+    <div class="info-box">
+      <p>เลขที่: <strong>${escapeHtml(doc.receiptNo) || escapeHtml(doc.docNumber)}</strong></p>
+      <p>วันที่: ${fmtThaiDate(doc.issueDate)}</p>
+      ${doc.journalEntryId ? `<p class="small">JV: ${escapeHtml(doc.journalEntryId)}</p>` : ''}
+    </div>
+  </div>
+
+  <div class="customer-block">
+    <p class="label">ลูกค้า / คู่ค้า:</p>
+    <p>${escapeHtml(customerName)}</p>
+    ${doc.counterpartyAddress ? `<p class="sub">${escapeHtml(doc.counterpartyAddress)}</p>` : ''}
+    ${doc.counterpartyTaxId ? `<p class="sub">เลขผู้เสียภาษี: ${escapeHtml(doc.counterpartyTaxId)}</p>` : ''}
+    ${doc.counterpartyPhone ? `<p class="sub">โทร: ${escapeHtml(doc.counterpartyPhone)}</p>` : ''}
+  </div>
+
+  <table class="items">
+    <thead>
+      <tr>
+        <th>รายละเอียด</th>
+        <th class="num">จำนวน</th>
+        <th class="num">ราคา/หน่วย</th>
+        <th class="ctr">VAT</th>
+        <th class="num">ก่อนภาษี</th>
+      </tr>
+    </thead>
+    <tbody>${items}</tbody>
+  </table>
+
+  <div class="totals-grid">
+    <div class="totals-left">
+      <p>ช่องทางชำระ: ${escapeHtml(doc.paymentAccountCode)}</p>
+      ${doc.paymentDate ? `<p>วันที่รับเงิน: ${fmtThaiDate(doc.paymentDate)}</p>` : ''}
+      ${doc.customerNote ? `<p>หมายเหตุ: ${escapeHtml(doc.customerNote)}</p>` : ''}
+    </div>
+    <div class="totals-right">
+      <div><span>รวมก่อน VAT:</span><strong style="font-family:monospace">${fmtMoney(doc.incomeGross)}</strong></div>
+      ${showVatRow ? `<div><span>VAT 7%:</span><strong style="font-family:monospace">${fmtMoney(doc.vatAmount)}</strong></div>` : ''}
+      <div class="hl"><span>จำนวนเงินทั้งสิ้น:</span><strong style="font-family:monospace">${fmtMoney(doc.totalAmount)} ฿</strong></div>
+      ${showWhtRow ? `<div class="wht"><span>หัก ณ ที่จ่าย${firstWhtPct ? ` (${firstWhtPct}%)` : ''}:</span><span style="font-family:monospace">(${fmtMoney(doc.whtAmount)})</span></div>` : ''}
+      <div class="net"><span>ยอดที่ชำระสุทธิ:</span><span style="font-family:monospace;font-weight:700">${fmtMoney(doc.amountReceived)} ฿</span></div>
+    </div>
+  </div>
+
+  <div class="signatures">
+    <div>
+      <div class="line"></div>
+      <div class="name">ผู้ออกเอกสาร</div>
+      <div>ลายเซ็น / วันที่</div>
+    </div>
+    <div>
+      <div class="stamp">ตราประทับ</div>
+      <div class="name">ตราประทับ (ผู้ขาย)</div>
+    </div>
+    <div>
+      <div class="line"></div>
+      <div class="name">ผู้รับเอกสาร</div>
+      <div>ลายเซ็น / วันที่</div>
+    </div>
+    <div>
+      <div class="stamp">ตราประทับ</div>
+      <div class="name">ตราประทับ (ลูกค้า)</div>
+    </div>
+  </div>
+
+  <div class="qr-block">
+    <img src="${qrDataUrl}" alt="QR" />
+    <div class="doc-no">${escapeHtml(doc.docNumber)}</div>
+  </div>
+</body>
+</html>`;
+  }
+}

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -11,6 +11,7 @@ import { SaveAsTemplateModal } from './components/SaveAsTemplateModal';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
 import { InternalControlBar } from './components/InternalControlBar';
 import { otherIncomeApi } from '@/lib/otherIncome';
+import api from '@/lib/api';
 import type { OtherIncome, OtherIncomeStatus, OtherIncomeReverseReason } from '@/lib/otherIncome.types';
 import { useAuth } from '@/contexts/AuthContext';
 import { formatThaiDateLong, formatThaiDateShort } from '@/lib/date';
@@ -128,6 +129,34 @@ function buildJeFromDoc(doc: OtherIncome): JeLine[] {
 // Roles that can reverse a POSTED document
 // B9: ACCOUNTANT removed — backend @Roles only allows OWNER/FINANCE_MANAGER on POST :id/reverse
 const REVERSE_ROLES = ['OWNER', 'FINANCE_MANAGER'];
+
+/**
+ * Fetch server-rendered PDF receipt and open in a new tab.
+ * Uses axios (JWT in-memory) since the in-memory token isn't on cookies.
+ */
+async function openReceiptPdf(docId: string, docNumber: string): Promise<void> {
+  try {
+    const res = await api.get(`/other-income/${docId}/receipt.pdf`, {
+      responseType: 'blob',
+    });
+    const blob = new Blob([res.data], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    const win = window.open(url, '_blank');
+    if (!win) {
+      // Popup blocked — fall back to download
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${docNumber}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    }
+    // Revoke after a delay to avoid breaking the new tab before it loads
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  } catch {
+    toast.error('ไม่สามารถสร้างใบเสร็จ PDF ได้');
+  }
+}
 
 // ------------------------------------------------------------------
 // Main component
@@ -265,7 +294,7 @@ export default function OtherIncomeViewPage() {
               {doc.status === 'POSTED' && doc.customerId && (
                 <button
                   type="button"
-                  onClick={() => navigate(`/other-income/${doc.id}/receipt`)}
+                  onClick={() => openReceiptPdf(doc.id, doc.docNumber)}
                   className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-lg hover:bg-accent"
                 >
                   <Printer size={14} />
@@ -338,7 +367,7 @@ export default function OtherIncomeViewPage() {
               </div>
               {doc.customerId && (
                 <button
-                  onClick={() => navigate(`/other-income/${doc.id}/receipt`)}
+                  onClick={() => openReceiptPdf(doc.id, doc.docNumber)}
                   className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-bold bg-primary text-primary-foreground rounded-md animate-pulse"
                 >
                   <Printer size={16} /> พิมพ์ใบเสร็จ


### PR DESCRIPTION
## Summary

แทนที่ flow `window.print()` (ที่เปิด browser dialog ทับ React receipt page) ด้วย **server-rendered PDF** เปิดใน tab ใหม่ตรง ๆ — ตามที่ owner request: "มันต้องเป็น PDF ที่เป็นใบเสร็จสิ จะส่งออกมาเป็นไฟล์ก็ได้"

## Changes

### Backend

| ไฟล์ | การแก้ |
|---|---|
| `services/receipt-pdf.service.ts` (new, 230 LOC) | OtherIncomeReceiptPdfService — สร้าง Thai tax-invoice HTML inline + puppeteer render A4 PDF |
| `other-income.module.ts` | wire new service into providers |
| `other-income.controller.ts` | new `GET /other-income/:id/receipt.pdf` endpoint (same guards: OWNER/FINANCE_MANAGER/ACCOUNTANT) |

### Frontend

| ไฟล์ | การแก้ |
|---|---|
| `OtherIncomeViewPage.tsx` | "พิมพ์ใบเสร็จ" 2 ปุ่ม (header + post-success banner) เปลี่ยนจาก `navigate('/receipt')` → fetch PDF blob ผ่าน axios + เปิด tab ใหม่ (fallback download ถ้า popup ถูกบล็อก) |

## Notes

- ใช้ puppeteer (มีอยู่แล้วใน deps — pattern เดียวกับ `receipts.service.ts:generatePDF`)
- HTML template inline (no external CSS) — render บน Cloud Run ได้ไม่ต้องมี internet
- เก็บ React `/other-income/:id/receipt` page ไว้ก่อน — route ยังใช้ได้ ถ้า production verify แล้วค่อยลบ follow-up
- QR ใน PDF point ไป `https://bestchoicephone.app/other-income/:id` (verify URL)

## Test plan

- [x] TypeScript: API OK + Web OK
- [ ] Visual: เปิด POSTED doc → กด "พิมพ์ใบเสร็จ" → PDF เปิด tab ใหม่ตรง ๆ (ไม่ขึ้น browser print dialog)
- [ ] PDF เนื้อหา: เลขที่/วันที่/บริษัท/ลูกค้า/items/totals/QR ครบตรง spec
- [ ] Popup-blocked fallback: ถ้า browser block popup, ดาวน์โหลดเป็น `<docNumber>.pdf` แทน

🤖 Generated with [Claude Code](https://claude.com/claude-code)