### PR TITLE
fix(other-income): align v2.1 PDF audit promises with actual code

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -5837,7 +5837,7 @@ model OtherIncome {
   totalAmount Decimal @default(0) @map("total_amount") @db.Decimal(15, 2)
 
   // Output references
-  receiptNo      String? @unique @map("receipt_no") // RC-YYYYMMDD-NNN
+  receiptNo      String? @unique @map("receipt_no") // RT-YYYYMM-NNNNN (legacy RC-YYYYMMDD-NNN may still exist)
   journalEntryId String? @unique @map("journal_entry_id") // null until POSTED
 
   // Override JV (when user manually edits the auto-generated JE)

--- a/apps/api/src/modules/other-income/__tests__/doc-number.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/doc-number.service.spec.ts
@@ -58,8 +58,8 @@ describe('DocNumberService', () => {
     expect(b).toBe('OI-20260507-0001');
   });
 
-  it('generates RC-YYYYMMDD-001 receipt number', async () => {
+  it('generates RT-YYYYMM-00001 receipt number (monthly seq)', async () => {
     const rc = await service.nextReceiptNumber(prisma, new Date('2026-05-06'));
-    expect(rc).toBe('RC-20260506-001');
+    expect(rc).toBe('RT-202605-00001');
   });
 });

--- a/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/maker-checker.spec.ts
@@ -254,7 +254,7 @@ describe('OtherIncomeService — Maker-Checker', () => {
     expect(posted.approvedAt).toBeTruthy();
     expect(posted.approveNote).toBe('อนุมัติแล้ว');
     expect(posted.journalEntryId).toBeTruthy();
-    expect(posted.receiptNo).toMatch(/^RC-\d{8}-\d{3}$/);
+    expect(posted.receiptNo).toMatch(/^RT-\d{6}-\d{5}$/);
     expect(posted.postedAt).toBeTruthy();
 
     // Verify JE was created

--- a/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.service.spec.ts
@@ -377,7 +377,7 @@ describe('OtherIncomeService — post + reverse + copy', () => {
 
     expect(posted.status).toBe('POSTED');
     expect(posted.journalEntryId).toBeTruthy();
-    expect(posted.receiptNo).toMatch(/^RC-20260506-\d{3}$/);
+    expect(posted.receiptNo).toMatch(/^RT-202605-\d{5}$/);
     expect(posted.postedAt).toBeTruthy();
 
     // Verify JE was created correctly

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -42,7 +42,7 @@ export class OtherIncomeService {
   async create(dto: CreateOtherIncomeDto, userId: string) {
     const companyId = await this.resolveFinanceCompanyId();
 
-    return this.prisma.$transaction(async (tx) => {
+    const created = await this.prisma.$transaction(async (tx) => {
       const issueDate = new Date(dto.issueDate);
       const docNumber = await this.docNumber.nextDocNumber(tx, issueDate);
       const totals = this.computeTotals(dto);
@@ -102,6 +102,9 @@ export class OtherIncomeService {
         include: { items: true, adjustments: true },
       });
     });
+
+    await this.auditLifecycle('OI_CREATED', userId, created);
+    return created;
   }
 
   async update(id: string, dto: UpdateOtherIncomeDto, userId: string) {
@@ -112,7 +115,7 @@ export class OtherIncomeService {
       );
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    const updated = await this.prisma.$transaction(async (tx) => {
       if (dto.items) {
         await tx.otherIncomeItem.deleteMany({ where: { otherIncomeId: id } });
       }
@@ -211,6 +214,9 @@ export class OtherIncomeService {
         include: { items: true, adjustments: true },
       });
     });
+
+    await this.auditLifecycle('OI_UPDATED', userId, updated);
+    return updated;
   }
 
   async softDelete(id: string, userId: string) {
@@ -218,10 +224,14 @@ export class OtherIncomeService {
     if (existing.status !== OtherIncomeStatus.DRAFT) {
       throw new ConflictException(`เอกสาร POSTED/REVERSED ลบไม่ได้ — ใช้ Reverse Entry`);
     }
-    return this.prisma.otherIncome.update({
+    const deleted = await this.prisma.otherIncome.update({
       where: { id },
       data: { deletedAt: new Date() },
+      include: { items: true, adjustments: true },
     });
+
+    await this.auditLifecycle('OI_DELETED', userId, deleted);
+    return deleted;
   }
 
   // -------------------------------------------------------------------------
@@ -243,7 +253,7 @@ export class OtherIncomeService {
       );
     }
     // Reset any prior reject metadata (re-submission after rejection)
-    return this.prisma.otherIncome.update({
+    const requested = await this.prisma.otherIncome.update({
       where: { id },
       data: {
         status: OtherIncomeStatus.READY,
@@ -253,6 +263,9 @@ export class OtherIncomeService {
       },
       include: { items: true, adjustments: true },
     });
+
+    await this.auditLifecycle('OI_APPROVAL_REQUESTED', userId, requested);
+    return requested;
   }
 
   // -------------------------------------------------------------------------
@@ -347,7 +360,7 @@ export class OtherIncomeService {
       })),
     });
 
-    return this.prisma.$transaction(async (tx) => {
+    const approved = await this.prisma.$transaction(async (tx) => {
       const now = new Date();
 
       // CAS-claim: atomically flip READY → POSTED, but only if still READY.
@@ -388,6 +401,12 @@ export class OtherIncomeService {
         include: { items: true, adjustments: true },
       });
     });
+
+    await this.auditLifecycle('OI_APPROVED', userId, approved, {
+      receiptNo: approved.receiptNo,
+      journalEntryId: approved.journalEntryId,
+    });
+    return approved;
   }
 
   // -------------------------------------------------------------------------
@@ -428,7 +447,13 @@ export class OtherIncomeService {
         `เอกสาร ${doc.docNumber} ถูกอนุมัติหรือปฏิเสธโดยผู้อื่นแล้ว — กรุณารีโหลด`,
       );
     }
-    return this.findOneOrFail(id);
+    const rejected = await this.findOneOrFail(id);
+    await this.auditLifecycle('OI_REJECTED', userId, rejected, {
+      fromStatus: 'READY',
+      toStatus: 'DRAFT',
+      rejectNote: dto.note,
+    });
+    return rejected;
   }
 
   // -------------------------------------------------------------------------
@@ -560,6 +585,12 @@ export class OtherIncomeService {
       });
     });
 
+    await this.auditLifecycle('OI_POSTED', userId, posted, {
+      receiptNo: posted.receiptNo,
+      journalEntryId: posted.journalEntryId,
+      isOverridden: posted.isOverridden,
+    });
+
     // Write JV_OVERRIDDEN audit outside transaction (non-blocking on TX connection)
     if (overrideLinesForAudit) {
       const diffSummary = this.journalOverride.computeDiffSummary(autoJeLines, overrideLinesForAudit);
@@ -630,7 +661,7 @@ export class OtherIncomeService {
       throw new NotFoundException(`JE ${original.journalEntryId} not found`);
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    const reversal = await this.prisma.$transaction(async (tx) => {
       const issueDate = new Date();
       const reverseDocNumber = await this.docNumber.nextDocNumber(tx, issueDate);
       const receiptNo = await this.docNumber.nextReceiptNumber(tx, issueDate);
@@ -719,6 +750,13 @@ export class OtherIncomeService {
 
       return reversalDoc;
     });
+
+    await this.auditLifecycle('OI_REVERSED', userId, reversal, {
+      originalDocNumber: original.docNumber,
+      reverseReason: dto.reason,
+      reverseNote: dto.note,
+    });
+    return reversal;
   }
 
   // -------------------------------------------------------------------------
@@ -1016,8 +1054,14 @@ export class OtherIncomeService {
   async uploadAttachment(id: string, file: Express.Multer.File, userId: string) {
     const doc = await this.findOneOrFail(id);
 
-    if (doc.status === OtherIncomeStatus.REVERSED) {
-      throw new BadRequestException('ไม่สามารถแนบไฟล์เอกสารที่ถูกกลับรายการ');
+    // Maker-Checker integrity (PDF Section 5 rule 5): once the doc has left
+    // DRAFT, the attachments the approver/auditor saw must be frozen. Allowing
+    // late uploads on READY/POSTED/REVERSED would let a maker swap evidence
+    // after approval.
+    if (doc.status !== OtherIncomeStatus.DRAFT) {
+      throw new ConflictException(
+        `เอกสาร ${doc.docNumber} สถานะ ${doc.status} — แนบไฟล์ได้เฉพาะตอนเป็น DRAFT`,
+      );
     }
 
     // Defence-in-depth: controller's FileTypeValidator only inspects the
@@ -1069,6 +1113,10 @@ export class OtherIncomeService {
         // The ViewPage uses this to render "ดูเอกสาร Reversing Entry" on the original
         // doc once it has been reversed. Without this include the link never appears.
         reversedBy: { select: { id: true, docNumber: true } },
+        // Maker + approver name surfaced into the InternalControlBar so we don't
+        // mis-attribute the bar to the currently-logged-in viewer (PDF Section 5).
+        createdBy: { select: { id: true, name: true, email: true } },
+        approver: { select: { id: true, name: true, email: true } },
       },
     });
     if (!doc) throw new NotFoundException(`OtherIncome ${id} not found`);
@@ -1090,6 +1138,40 @@ export class OtherIncomeService {
       );
     }
     return co.id;
+  }
+
+  /**
+   * Lifecycle audit. Non-blocking — never throws to caller; Sentry on failure.
+   * Used by create/update/post/reverse/softDelete/approve/reject/requestApproval.
+   */
+  private async auditLifecycle(
+    action:
+      | 'OI_CREATED'
+      | 'OI_UPDATED'
+      | 'OI_DELETED'
+      | 'OI_POSTED'
+      | 'OI_REVERSED'
+      | 'OI_APPROVED'
+      | 'OI_REJECTED'
+      | 'OI_APPROVAL_REQUESTED',
+    userId: string,
+    doc: { id: string; docNumber: string; status?: string | null },
+    extra?: Record<string, unknown>,
+  ) {
+    try {
+      await this.audit.log({
+        userId,
+        action,
+        entity: 'other_income',
+        entityId: doc.id,
+        newValue: { docNumber: doc.docNumber, status: doc.status ?? null, ...extra },
+      });
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { module: 'other-income', action },
+        extra: { otherIncomeId: doc.id, docNumber: doc.docNumber },
+      });
+    }
   }
 
   /** Read OTHER_INCOME_MAKER_CHECKER_ENABLED from SystemConfig. Default false. */

--- a/apps/api/src/modules/other-income/services/doc-number.service.ts
+++ b/apps/api/src/modules/other-income/services/doc-number.service.ts
@@ -35,15 +35,12 @@ export class DocNumberService {
     tx: Prisma.TransactionClient | PrismaService,
     issueDate: Date,
   ): Promise<string> {
-    const { yyyymmdd } = this.getBkkDayBounds(issueDate);
-    const lockKey = this.hashLockKey(`rc:${yyyymmdd}`);
+    const yyyymm = this.getBkkYyyymm(issueDate);
+    const lockKey = this.hashLockKey(`rt:${yyyymm}`);
     await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(${lockKey})`);
 
-    // Same approach as nextDocNumber — use max(seq) to avoid collision with
-    // any existing receiptNo (POSTED docs cannot be soft-deleted, but using
-    // the same pattern keeps both methods consistent and safe).
     const lastDoc = await tx.otherIncome.findFirst({
-      where: { receiptNo: { startsWith: `RC-${yyyymmdd}-` } },
+      where: { receiptNo: { startsWith: `RT-${yyyymm}-` } },
       orderBy: { receiptNo: 'desc' },
       select: { receiptNo: true },
     });
@@ -51,8 +48,20 @@ export class DocNumberService {
     const lastSeq = lastDoc?.receiptNo
       ? parseInt(lastDoc.receiptNo.split('-')[2], 10) || 0
       : 0;
-    const seq = String(lastSeq + 1).padStart(3, '0');
-    return `RC-${yyyymmdd}-${seq}`;
+    const seq = String(lastSeq + 1).padStart(5, '0');
+    return `RT-${yyyymm}-${seq}`;
+  }
+
+  private getBkkYyyymm(date: Date): string {
+    const parts = date.toLocaleString('en-CA', {
+      timeZone: 'Asia/Bangkok',
+      year: 'numeric',
+      month: '2-digit',
+    });
+    // Defensive: en-CA with year+month returns "YYYY-MM" today, but slice the
+    // first two segments to stay robust against ICU output shape drift across
+    // Node versions. Mirrors getBkkDayBounds() style.
+    return parts.split('-').slice(0, 2).join('');
   }
 
   /**

--- a/apps/web/src/lib/otherIncome.types.ts
+++ b/apps/web/src/lib/otherIncome.types.ts
@@ -67,6 +67,9 @@ export interface OtherIncome {
   isOverridden: boolean;
   customerNote: string | null;
   createdById: string;
+  createdBy?: { id: string; name: string | null; email: string } | null;
+  approverId?: string | null;
+  approver?: { id: string; name: string | null; email: string } | null;
   rejectNote: string | null;
   rejectedAt: string | null;
   postedAt: string | null;

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -178,7 +178,7 @@ const defaultValues: OtherIncomeFormValues = {
       unitAmount: 0,
       discountAmount: 0,
       vatPct: 0,
-      whtPct: 15,
+      whtPct: 1,
       description: '',
     },
   ],

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -727,12 +727,12 @@ export default function OtherIncomeViewPage() {
           status={doc.status}
           recorder={{
             name:
-              doc.createdById === user?.id
-                ? user?.name || user?.email || '—'
-                : '—',
+              doc.createdBy?.name ||
+              doc.createdBy?.email ||
+              (doc.createdById === user?.id ? user?.name || user?.email || '—' : '—'),
           }}
           approver={{
-            name: user?.role === 'OWNER' ? user?.name || user?.email || 'OWNER' : '—',
+            name: doc.approver?.name || doc.approver?.email || '—',
           }}
           makerCheckerEnabled={makerCheckerEnabled}
           isViewerApprover={user?.role === 'OWNER' && doc.createdById !== user.id}


### PR DESCRIPTION
## Summary

Cross-checked accountant's v2.1 PDF audit report (12 พ.ค. 2569) against live code → found 5 promises that drifted from reality. This PR restores all 5.

| Fix | PDF Section | Before | After |
|---|---|---|---|
| Default WHT% | 7-A (ท.ป.4/2528) | 15 | 1 |
| Audit lifecycle | Test F | only `JV_OVERRIDDEN`/`CONFIG_CHANGED`/`PERIOD_REOPENED` | + 8 OI_* events on every state transition |
| Receipt format | accounting.md §6 | `RC-YYYYMMDD-NNN` (daily seq 3-digit) | `RT-YYYYMM-NNNNN` (monthly seq 5-digit) |
| Approver name | Section 5 rule 1 | current viewer's name | `doc.approver?.name` (real approver) |
| Attachment lock | Section 5 rule 5 | only REVERSED rejected | only DRAFT accepted (freeze evidence after submit) |

## Implementation notes

- **`auditLifecycle()`** — private helper, non-blocking (try/catch + Sentry on failure), mirrors existing `JV_OVERRIDDEN` audit pattern. Called AFTER each `$transaction` commits (audit.log has its own internal `$transaction` — nesting would deadlock).
- **`OI_REJECTED`** carries `extra.fromStatus='READY'` + `toStatus='DRAFT'` so accountants can distinguish it from `OI_UPDATED` in the timeline.
- **`getBkkYyyymm()`** uses `split('-').slice(0,2).join('')` (not `.replace('-','')`) for robustness against ICU output shape drift across Node versions — matches sibling `getBkkDayBounds` style.
- **Legacy `RC-` receipt numbers** stay intact via UNIQUE constraint allowing mixed prefixes. No backfill needed.
- **`findOneOrFail`** includes `createdBy` + `approver` user relations; `OtherIncome` frontend type extended with optional fields (backwards-compat).

## Verified (no fix needed)

- Daily Sheet CSV UTF-8 BOM — already at `OtherIncomeDailySheetPage.tsx:76`
- WHT tooltip 1% recommend — already at `ItemsTable.tsx:14-17, 161-171`
- Templates page — fully functional at `/other-income/templates`

## Code review

Self-reviewed via subagent: 0 Critical, 4 Warning (3 actionable fixed: getBkkYyyymm split safety, OI_REJECTED audit clarity, softDelete include consistency), 3 Info deferred.

## Test plan

- [ ] Test A: Create new OI doc → first item row default WHT% = 1% (not 15)
- [ ] Test F: Post a doc → ViewPage "ประวัติการแก้ไข" shows OI_CREATED + OI_POSTED with timestamp + creator name
- [ ] Receipt PDF prints `RT-202605-00001` format (next month rolls to `RT-202606-00001`)
- [ ] InternalControlBar at bottom of POSTED doc shows real approver name (Maker-Checker enabled flow)
- [ ] Upload attachment fails with Thai message on READY/POSTED docs (only DRAFT accepted)
- [ ] `tsc` ✓ passes (both API + Web)
- [ ] Existing 3 receiptNo regex tests updated to `RT-` pattern — run jest

🤖 Generated with [Claude Code](https://claude.com/claude-code)