### PR TITLE
fix(expenses): 6 Critical GL bugs — JE preview, partial settlement, period guard, attachment, SSO cap, WHT routing

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/cn-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/cn-lifecycle.integration.spec.ts
@@ -109,7 +109,7 @@ describe('Credit Note lifecycle (integration)', () => {
     const codes = je.lines.map((l) => l.accountCode);
     expect(codes).toContain('21-1104'); // Reverses AP
     expect(codes).toContain('53-1302'); // Reverses expense
-    expect(codes).toContain('11-2104'); // Reverses VAT
+    expect(codes).toContain('11-4101'); // Reverses VAT (Input Tax Credit) — Fix Report P0-1
   });
 
   it('CN amount cap: cumulative CNs cannot exceed original totalAmount', async () => {

--- a/apps/api/src/modules/expense-documents/__tests__/create-payroll.dto.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/create-payroll.dto.spec.ts
@@ -1,0 +1,68 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreatePayrollDto } from '../dto/create-payroll.dto';
+
+/**
+ * Fix #C11 — SSO 750/person/month cap. Per Thai SSO law: employee + employer
+ * each contribute 5% of min(salary, 15000) → max 750 each. payroll.template.ts
+ * reuses ssoEmployee for the employer side, so the single Max enforces both.
+ */
+describe('CreatePayrollDto — SSO 750 cap (Fix #C11)', () => {
+  const baseDto = (overrides: Record<string, unknown>) => ({
+    branchId: 'branch-1',
+    documentDate: '2026-05-11',
+    payrollPeriod: '2026-05',
+    depositAccountCode: '11-1101',
+    lines: [
+      {
+        employeeName: 'พนักงาน A',
+        baseSalary: 15000,
+        ...overrides,
+      },
+    ],
+  });
+
+  async function validateDto(payload: Record<string, unknown>) {
+    const inst = plainToInstance(CreatePayrollDto, payload);
+    return validate(inst, { whitelist: true, forbidNonWhitelisted: false });
+  }
+
+  it('rejects ssoEmployee=900 (over 750 cap)', async () => {
+    const errors = await validateDto(baseDto({ ssoEmployee: 900 }));
+    // Nested validation errors live under .children[0].children[?].constraints
+    const flat = JSON.stringify(errors);
+    expect(flat).toMatch(/SSO ต่อคนไม่เกิน 750/);
+  });
+
+  it('accepts ssoEmployee=750 (exact cap)', async () => {
+    const errors = await validateDto(baseDto({ ssoEmployee: 750 }));
+    const flat = JSON.stringify(errors);
+    expect(flat).not.toMatch(/SSO ต่อคนไม่เกิน 750/);
+  });
+
+  it('accepts ssoEmployee=375 (salary 7500 × 5% = 375)', async () => {
+    const errors = await validateDto(baseDto({ baseSalary: 7500, ssoEmployee: 375 }));
+    const flat = JSON.stringify(errors);
+    expect(flat).not.toMatch(/SSO ต่อคนไม่เกิน 750/);
+  });
+
+  it('accepts ssoEmployee=0 (new hire mid-month, salary=0)', async () => {
+    // baseSalary must be > 0 (min 0.01), but ssoEmployee=0 is valid (no contribution).
+    const errors = await validateDto(baseDto({ baseSalary: 0.01, ssoEmployee: 0 }));
+    const flat = JSON.stringify(errors);
+    expect(flat).not.toMatch(/SSO ต่อคนไม่เกิน 750/);
+  });
+
+  it('accepts when ssoEmployee is omitted (optional)', async () => {
+    const errors = await validateDto(baseDto({}));
+    const flat = JSON.stringify(errors);
+    expect(flat).not.toMatch(/SSO ต่อคนไม่เกิน 750/);
+  });
+
+  it('rejects ssoEmployee=751 (off by 1 above cap)', async () => {
+    const errors = await validateDto(baseDto({ ssoEmployee: 751 }));
+    const flat = JSON.stringify(errors);
+    expect(flat).toMatch(/SSO ต่อคนไม่เกิน 750/);
+  });
+});

--- a/apps/api/src/modules/expense-documents/__tests__/doc-number.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/doc-number.service.spec.ts
@@ -62,4 +62,19 @@ describe('DocNumberService', () => {
     const num = await service.next(tx, 'EXPENSE', new Date('2026-05-10T19:00:00Z'));
     expect(num).toBe('EX-20260511-0001');
   });
+
+  // W4 — explicit throw when seq overflows 4-digit slot (rather than silently
+  // emitting EX-YYYYMMDD-10000 which sorts wrong and breaks downstream parsers).
+  it('W4: throws when seq exceeds 9999 for a day', async () => {
+    tx.expenseDocument.findFirst.mockResolvedValue({ number: 'EX-20260510-9999' });
+    await expect(
+      service.next(tx, 'EXPENSE', new Date('2026-05-10T12:00:00Z')),
+    ).rejects.toThrow(/เกิน 9999/);
+  });
+
+  it('W4: still works at 9998 → 9999', async () => {
+    tx.expenseDocument.findFirst.mockResolvedValue({ number: 'EX-20260510-9998' });
+    const num = await service.next(tx, 'EXPENSE', new Date('2026-05-10T12:00:00Z'));
+    expect(num).toBe('EX-20260510-9999');
+  });
 });

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -126,6 +126,57 @@ describe('ExpenseDocumentsService', () => {
       // subtotal=1000, vat=70, total=1070
       expect(callArg.data.totalAmount.toFixed(2)).toBe('1070.00');
     });
+
+    // W1 — adjustment row accountCode must be on the allow-list (52-1104,
+    // 52-1106, 53-1303, 53-1503). Without this, an accountant could pick
+    // Revenue or Cash as the offset, balancing the JE but causing drift.
+    it('W1: rejects adjustment accountCode outside the allow-list (e.g. 41-1101 Revenue)', async () => {
+      // CoA mock returns the rev code so the existence check passes,
+      // forcing the allow-list check to be the gate.
+      prisma.chartOfAccount.findMany.mockResolvedValue([
+        { code: '53-1302', type: 'ค่าใช้จ่าย' },
+        { code: '41-1101', type: 'รายได้' },
+      ]);
+      await expect(
+        service.create(
+          {
+            documentType: 'EXPENSE',
+            branchId: 'branch-1',
+            documentDate: '2026-05-10',
+            priceType: 'EXCLUSIVE',
+            lines: [
+              { category: '53-1302', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 0 },
+            ],
+            amountPaid: '999',
+            adjustments: [{ accountCode: '41-1101', side: 'CR', amount: '1' }],
+          } as never,
+          'user-1',
+        ),
+      ).rejects.toThrow(/ไม่อยู่ในรายการที่อนุญาต/);
+    });
+
+    it('W1: accepts adjustment accountCode 52-1104 (rounding tolerance allow-list)', async () => {
+      prisma.chartOfAccount.findMany.mockResolvedValue([
+        { code: '53-1302', type: 'ค่าใช้จ่าย' },
+        { code: '52-1104', type: 'ค่าใช้จ่าย' },
+      ]);
+      await expect(
+        service.create(
+          {
+            documentType: 'EXPENSE',
+            branchId: 'branch-1',
+            documentDate: '2026-05-10',
+            priceType: 'EXCLUSIVE',
+            lines: [
+              { category: '53-1302', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 0 },
+            ],
+            amountPaid: '999',
+            adjustments: [{ accountCode: '52-1104', side: 'DR', amount: '1' }],
+          } as never,
+          'user-1',
+        ),
+      ).resolves.toBeDefined();
+    });
   });
 
   describe('list', () => {

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -38,6 +38,8 @@ describe('ExpenseDocumentsService', () => {
       },
       expenseDetail: {
         update: jest.fn().mockResolvedValue({}),
+        // C12 guard reads the lines to decide if per-line whtFormType is enough
+        findUnique: jest.fn().mockResolvedValue({ lines: [] }),
       },
       expenseLine: {
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
@@ -47,6 +49,10 @@ describe('ExpenseDocumentsService', () => {
           { code: '53-1302', type: 'ค่าใช้จ่าย' },
           { code: '53-1404', type: 'ค่าใช้จ่าย' },
         ]),
+      },
+      // C10 attachment-threshold check reads ATTACHMENT_REQUIRED_ABOVE_AMOUNT
+      systemConfig: {
+        findUnique: jest.fn().mockResolvedValue(null),
       },
     };
     docNumber = { next: jest.fn().mockResolvedValue('EX-20260510-0001') };
@@ -202,6 +208,128 @@ describe('ExpenseDocumentsService', () => {
       });
       transition.assertCanPost.mockImplementation(() => { throw new BadRequestException('not draft'); });
       await expect(service.post('doc-3', 'user-1')).rejects.toThrow(BadRequestException);
+    });
+
+    // Fix #C10 — attachment threshold server-enforced
+    it('Fix #C10: rejects post when totalAmount ≥ threshold and no receiptImageUrl', async () => {
+      prisma.systemConfig.findUnique.mockResolvedValue({
+        key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT',
+        value: '50000',
+      });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c10', status: 'DRAFT', documentType: 'EXPENSE',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('100000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('0'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c10', 'user-1')).rejects.toThrow(
+        /ต้องแนบไฟล์ประกอบ/,
+      );
+      expect(sameDay.execute).not.toHaveBeenCalled();
+    });
+
+    it('Fix #C10: allows post when totalAmount ≥ threshold WITH receiptImageUrl', async () => {
+      prisma.systemConfig.findUnique.mockResolvedValue({
+        key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT',
+        value: '50000',
+      });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c10b', status: 'DRAFT', documentType: 'EXPENSE',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('100000.00'),
+        receiptImageUrl: 's3://bucket/receipt.pdf',
+        withholdingTax: new Decimal('0'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c10b', 'user-1')).resolves.toBeDefined();
+      expect(sameDay.execute).toHaveBeenCalled();
+    });
+
+    it('Fix #C10: allows post when totalAmount < threshold, no receipt required', async () => {
+      prisma.systemConfig.findUnique.mockResolvedValue({
+        key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT',
+        value: '50000',
+      });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c10c', status: 'DRAFT', documentType: 'EXPENSE',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('1000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('0'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c10c', 'user-1')).resolves.toBeDefined();
+    });
+
+    it('Fix #C10: threshold=0 disables the check (default config)', async () => {
+      // null systemConfig → threshold defaults to 0 → never enforced
+      prisma.systemConfig.findUnique.mockResolvedValue(null);
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c10d', status: 'DRAFT', documentType: 'EXPENSE',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('999999.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('0'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c10d', 'user-1')).resolves.toBeDefined();
+    });
+
+    // Fix #C12 — WHT form type required when wht > 0
+    it('Fix #C12: rejects post when wht > 0 and doc.whtFormType is null (no per-line override)', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c12a', status: 'DRAFT', documentType: 'EXPENSE',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('1000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('30.00'),
+        whtFormType: null,
+      });
+      prisma.expenseDetail.findUnique.mockResolvedValue({
+        lines: [{ whtAmount: new Decimal('30.00'), whtFormType: null }],
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c12a', 'user-1')).rejects.toThrow(
+        /whtFormType ต้องระบุ/,
+      );
+      expect(sameDay.execute).not.toHaveBeenCalled();
+    });
+
+    it('Fix #C12: allows post when wht > 0 and doc.whtFormType=PND53', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c12b', status: 'DRAFT', documentType: 'EXPENSE',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('1000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('30.00'),
+        whtFormType: 'PND53',
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c12b', 'user-1')).resolves.toBeDefined();
+      expect(sameDay.execute).toHaveBeenCalled();
+    });
+
+    it('Fix #C12: allows post when doc.whtFormType is null BUT every wht-line has its own form type', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c12c', status: 'DRAFT', documentType: 'EXPENSE',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('1000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('30.00'),
+        whtFormType: null,
+      });
+      prisma.expenseDetail.findUnique.mockResolvedValue({
+        lines: [{ whtAmount: new Decimal('30.00'), whtFormType: 'PND53' }],
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c12c', 'user-1')).resolves.toBeDefined();
+      expect(sameDay.execute).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -54,6 +54,16 @@ describe('ExpenseDocumentsService', () => {
       systemConfig: {
         findUnique: jest.fn().mockResolvedValue(null),
       },
+      // C9 Round 2 — post/voidDocument resolve SHOP companyId for the
+      // module-level validatePeriodOpen call (mirroring expense templates).
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'shop-co-id' }),
+      },
+      // C9 Round 2 — validatePeriodOpen reads accountingPeriod by
+      // (companyId, year, month). Default = no row (= OPEN), so post() passes.
+      accountingPeriod: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
     };
     docNumber = { next: jest.fn().mockResolvedValue('EX-20260510-0001') };
     transition = {
@@ -263,10 +273,15 @@ describe('ExpenseDocumentsService', () => {
 
     // Fix #C10 — attachment threshold server-enforced
     it('Fix #C10: rejects post when totalAmount ≥ threshold and no receiptImageUrl', async () => {
-      prisma.systemConfig.findUnique.mockResolvedValue({
-        key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT',
-        value: '50000',
-      });
+      // Key-aware mock — period-lock util reads `accounting_period_closed_until`
+      // from the same table; treat that key as missing (period OPEN) so the
+      // C10 attachment-threshold test doesn't accidentally fail on a phantom
+      // period lock.
+      prisma.systemConfig.findUnique.mockImplementation((args: { where: { key: string } }) =>
+        args.where.key === 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT'
+          ? { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', value: '50000' }
+          : null,
+      );
       prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
         id: 'doc-c10', status: 'DRAFT', documentType: 'EXPENSE',
         paymentMethod: 'CASH', depositAccountCode: '11-1101',
@@ -283,10 +298,15 @@ describe('ExpenseDocumentsService', () => {
     });
 
     it('Fix #C10: allows post when totalAmount ≥ threshold WITH receiptImageUrl', async () => {
-      prisma.systemConfig.findUnique.mockResolvedValue({
-        key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT',
-        value: '50000',
-      });
+      // Key-aware mock — period-lock util reads `accounting_period_closed_until`
+      // from the same table; treat that key as missing (period OPEN) so the
+      // C10 attachment-threshold test doesn't accidentally fail on a phantom
+      // period lock.
+      prisma.systemConfig.findUnique.mockImplementation((args: { where: { key: string } }) =>
+        args.where.key === 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT'
+          ? { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', value: '50000' }
+          : null,
+      );
       prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
         id: 'doc-c10b', status: 'DRAFT', documentType: 'EXPENSE',
         paymentMethod: 'CASH', depositAccountCode: '11-1101',
@@ -301,10 +321,15 @@ describe('ExpenseDocumentsService', () => {
     });
 
     it('Fix #C10: allows post when totalAmount < threshold, no receipt required', async () => {
-      prisma.systemConfig.findUnique.mockResolvedValue({
-        key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT',
-        value: '50000',
-      });
+      // Key-aware mock — period-lock util reads `accounting_period_closed_until`
+      // from the same table; treat that key as missing (period OPEN) so the
+      // C10 attachment-threshold test doesn't accidentally fail on a phantom
+      // period lock.
+      prisma.systemConfig.findUnique.mockImplementation((args: { where: { key: string } }) =>
+        args.where.key === 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT'
+          ? { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT', value: '50000' }
+          : null,
+      );
       prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
         id: 'doc-c10c', status: 'DRAFT', documentType: 'EXPENSE',
         paymentMethod: 'CASH', depositAccountCode: '11-1101',
@@ -441,6 +466,76 @@ describe('ExpenseDocumentsService', () => {
       transition.resolveTargetStatus.mockReturnValue('POSTED');
       await expect(service.post('doc-pr-c12', 'user-1')).resolves.toBeDefined();
       expect(payroll.execute).toHaveBeenCalled();
+    });
+
+    // Fix #C9 Round 2 — period guard moved from journal-auto.createAndPost
+    // to the expense module's service entry point. Expense post in a CLOSED
+    // FINANCE/SHOP period must still reject; payment receipt JEs (which
+    // share createAndPost) must NOT be affected by this guard (see
+    // journal-auto.service.spec.ts for the converse: createAndPost itself
+    // no longer checks period).
+    it('Fix #C9 Round 2: rejects post when SHOP AccountingPeriod for documentDate is CLOSED', async () => {
+      prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c9-1',
+        status: 'DRAFT',
+        documentType: 'EXPENSE',
+        documentDate: new Date('2026-03-15'), // period closed
+        paymentMethod: 'CASH',
+        depositAccountCode: '11-1101',
+        totalAmount: new Decimal('1000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('0'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c9-1', 'user-1')).rejects.toThrow(/ปิดแล้ว/);
+      expect(sameDay.execute).not.toHaveBeenCalled();
+      // Verify the period check ran with SHOP companyId + the doc's date
+      expect(prisma.companyInfo.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ companyCode: 'SHOP' }),
+        }),
+      );
+    });
+
+    it('Fix #C9 Round 2: rejects post when SHOP AccountingPeriod is SYNCED', async () => {
+      prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'SYNCED' });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c9-2',
+        status: 'DRAFT',
+        documentType: 'EXPENSE',
+        documentDate: new Date('2026-03-15'),
+        paymentMethod: 'CASH',
+        depositAccountCode: '11-1101',
+        totalAmount: new Decimal('1000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('0'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c9-2', 'user-1')).rejects.toThrow(/ปิดแล้ว/);
+    });
+
+    it('Fix #C9 Round 2: throws NotFoundException when SHOP CompanyInfo is missing', async () => {
+      prisma.companyInfo.findFirst.mockResolvedValue(null);
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-c9-3',
+        status: 'DRAFT',
+        documentType: 'EXPENSE',
+        documentDate: new Date('2026-05-10'),
+        paymentMethod: 'CASH',
+        depositAccountCode: '11-1101',
+        totalAmount: new Decimal('1000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('0'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-c9-3', 'user-1')).rejects.toThrow(NotFoundException);
+      await expect(service.post('doc-c9-3', 'user-1')).rejects.toThrow(
+        /CompanyInfo with companyCode=SHOP/,
+      );
     });
   });
 

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -331,6 +331,66 @@ describe('ExpenseDocumentsService', () => {
       await expect(service.post('doc-c12c', 'user-1')).resolves.toBeDefined();
       expect(sameDay.execute).toHaveBeenCalled();
     });
+
+    // C12-symmetry — extend service-level guard to SE / CN / PAYROLL
+    it('C12-symmetry: rejects post on VENDOR_SETTLEMENT when wht > 0 and whtFormType null', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-se-c12', status: 'DRAFT', documentType: 'VENDOR_SETTLEMENT',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('5000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('100.00'),
+        whtFormType: null,
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-se-c12', 'user-1')).rejects.toThrow(
+        /whtFormType ต้องระบุ/,
+      );
+      expect(settlement.execute).not.toHaveBeenCalled();
+    });
+
+    it('C12-symmetry: allows post on VENDOR_SETTLEMENT when wht > 0 and whtFormType=PND53', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-se-c12b', status: 'DRAFT', documentType: 'VENDOR_SETTLEMENT',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('5000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('100.00'),
+        whtFormType: 'PND53',
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-se-c12b', 'user-1')).resolves.toBeDefined();
+      expect(settlement.execute).toHaveBeenCalled();
+    });
+
+    it('C12-symmetry: rejects post on VENDOR_SETTLEMENT when whtFormType is unknown string', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-se-c12c', status: 'DRAFT', documentType: 'VENDOR_SETTLEMENT',
+        paymentMethod: 'CASH', depositAccountCode: '11-1101',
+        totalAmount: new Decimal('5000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('100.00'),
+        whtFormType: 'PND91',
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-se-c12c', 'user-1')).rejects.toThrow(
+        /whtFormType ต้องเป็น PND3 หรือ PND53/,
+      );
+    });
+
+    it('C12-symmetry: allows PAYROLL post with wht > 0 (whtFormType not required — always 21-3101)', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-pr-c12', status: 'DRAFT', documentType: 'PAYROLL',
+        depositAccountCode: '11-1101',
+        totalAmount: new Decimal('30000.00'),
+        receiptImageUrl: null,
+        withholdingTax: new Decimal('500.00'),
+        whtFormType: null, // payroll WHT always ภ.ง.ด.1 → 21-3101
+      });
+      transition.resolveTargetStatus.mockReturnValue('POSTED');
+      await expect(service.post('doc-pr-c12', 'user-1')).resolves.toBeDefined();
+      expect(payroll.execute).toHaveBeenCalled();
+    });
   });
 
   describe('update', () => {

--- a/apps/api/src/modules/expense-documents/__tests__/expense-same-day.template.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-same-day.template.spec.ts
@@ -261,6 +261,79 @@ describe('ExpenseSameDayTemplate', () => {
     expect(dr5x.find((l: { accountCode: string; dr: { toString: () => string } }) => l.accountCode === '53-1101').dr.toString()).toBe('1000');
   });
 
+  // Fix #C12 — template-level defense: throw when WHT > 0 but no resolvable
+  // whtFormType anywhere. The service guard at expense-documents.service.ts
+  // post() catches this at request time; the template re-checks to surface
+  // any future caller bypass instead of silently misfiling under PND3.
+  it('Fix #C12: throws when WHT > 0 and doc.whtFormType is null (no per-line override)', async () => {
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: docId,
+      number: 'EX-20260511-C12-1',
+      documentType: 'EXPENSE',
+      branchId: 'branch-1',
+      documentDate: new Date('2026-05-11'),
+      subtotal: new Decimal('1000.00'),
+      vatAmount: new Decimal('0.00'),
+      withholdingTax: new Decimal('30.00'),
+      whtFormType: null, // ← missing
+      totalAmount: new Decimal('1000.00'),
+      depositAccountCode: '11-1201',
+      paymentMethod: 'BANK_TRANSFER',
+      journalEntryId: null,
+      expenseDetail: {
+        priceType: 'EXCLUSIVE',
+        lines: [
+          {
+            lineNo: 1,
+            category: '53-1702',
+            amountBeforeVat: new Decimal('1000.00'),
+            // no per-line whtFormType override either
+          },
+        ],
+      },
+    });
+
+    await expect(template.execute(docId)).rejects.toThrow(/PND3 หรือ PND53/);
+    expect(journal.createAndPost).not.toHaveBeenCalled();
+  });
+
+  // Fix #C12 — per-line override still works when doc-level is null. As long
+  // as every WHT-bearing line has its own form type, the template aggregates
+  // them per the P2-4 routing rule.
+  it('Fix #C12: per-line override allowed when every WHT-line has its own form type', async () => {
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: docId,
+      number: 'EX-20260511-C12-2',
+      documentType: 'EXPENSE',
+      branchId: 'branch-1',
+      documentDate: new Date('2026-05-11'),
+      subtotal: new Decimal('1000.00'),
+      vatAmount: new Decimal('0.00'),
+      withholdingTax: new Decimal('50.00'),
+      whtFormType: null,
+      totalAmount: new Decimal('1000.00'),
+      depositAccountCode: '11-1201',
+      paymentMethod: 'BANK_TRANSFER',
+      journalEntryId: null,
+      expenseDetail: {
+        priceType: 'EXCLUSIVE',
+        lines: [
+          {
+            lineNo: 1,
+            category: '53-1303',
+            amountBeforeVat: new Decimal('1000.00'),
+            whtAmount: new Decimal('50.00'),
+            whtFormType: 'PND53', // line-level override
+          },
+        ],
+      },
+    });
+
+    await template.execute(docId);
+    const [args] = journal.createAndPost.mock.calls[0];
+    expect(args.lines.find((l: { accountCode: string }) => l.accountCode === '21-3103')).toBeDefined();
+  });
+
   // Fix Report P2-2 — per-line journal_lines (no collapse by category).
   it('multi-line: 3 lines, 2 share category — 3 Dr rows (line-level preserved)', async () => {
     prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({

--- a/apps/api/src/modules/expense-documents/__tests__/je-preview.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/je-preview.service.spec.ts
@@ -105,4 +105,65 @@ describe('JePreviewService', () => {
     expect(r.lines.some((l) => l.accountCode === '11-2104')).toBe(false);
     expect(r.lines.some((l) => l.accountCode === '11-4101')).toBe(true);
   });
+
+  // W8 — adjustments are rendered as Dr/Cr rows in the preview, matching
+  // the actual JE that expense-same-day.template.ts will book. Service
+  // V12 keeps signedSum=diff so the rendered JE balances.
+  // Scenario: expected 1000, paid 1001 → overpay, Cr cash=1001 and we Dr
+  //   the 1฿ to 53-1503 (loss on rounding).
+  //   Service signedSum check: side='DR' amt=1 → signedSum = -1.
+  //   diff = amountPaid − netExpected = 1001 − 1000 = +1.
+  //   ❌ -1 ≠ +1 → would fail V12.
+  //   So the only consistent direction here is side='CR' amt=1.
+  // We bypass service V12 here (we're testing JePreviewService directly).
+  it('W8: renders adjustment rows in the preview', () => {
+    const r = svc.preview({
+      documentType: 'EXPENSE', branchId: 'b1', documentDate: '2026-05-11',
+      priceType: 'EXCLUSIVE',
+      paymentMethod: 'CASH', depositAccountCode: '11-1101',
+      lines: [{ category: '53-1101', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 0 }],
+      // No amountPaid → cashCr = totalAmount − wht = 1000. Adjustment row
+      // appears in the preview regardless of V12 balance (preview is best-
+      // effort; service validates V12 separately before the JE is written).
+      adjustments: [
+        { accountCode: '52-1104', side: 'DR', amount: '1', note: 'ปรับเศษ' },
+        { accountCode: '53-1503', side: 'CR', amount: '1' },
+      ],
+    } as never, new Map<string, string>([
+      ['53-1101', 'salary'],
+      ['11-1101', 'cash'],
+      ['52-1104', 'ส่วนลดเศษสตางค์'],
+      ['53-1503', 'กำไรจากการปัดเศษ'],
+    ]));
+    const dradj = r.lines.find((l) => l.accountCode === '52-1104');
+    const cradj = r.lines.find((l) => l.accountCode === '53-1503');
+    expect(dradj).toBeDefined();
+    expect(dradj!.dr).toBe('1.00');
+    expect(dradj!.cr).toBe('0.00');
+    expect(cradj).toBeDefined();
+    expect(cradj!.cr).toBe('1.00');
+    expect(cradj!.dr).toBe('0.00');
+    // Both adjustments balance each other (Dr 1, Cr 1) — overall JE balanced.
+    expect(r.totals.balanced).toBe(true);
+  });
+
+  // W8 — per-line whtFormType emits both 21-3102 and 21-3103 when a doc
+  // mixes individual + juristic vendors. Mirrors expense-same-day.template
+  // line 146-182 (P2-4 routing).
+  it('W8: per-line whtFormType routes WHT to both 21-3102 and 21-3103', () => {
+    const r = svc.preview({
+      documentType: 'EXPENSE', branchId: 'b1', documentDate: '2026-05-11',
+      priceType: 'EXCLUSIVE',
+      paymentMethod: 'BANK_TRANSFER', depositAccountCode: '11-1201',
+      lines: [
+        { category: '53-1101', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 1, whtFormType: 'PND3' },
+        { category: '53-1404', quantity: 1, unitPrice: 2000, vatPercent: 0, whtPercent: 3, whtFormType: 'PND53' },
+      ],
+    } as never, names);
+    const pnd3 = r.lines.find((l) => l.accountCode === '21-3102');
+    const pnd53 = r.lines.find((l) => l.accountCode === '21-3103');
+    expect(pnd3?.cr).toBe('10.00'); // 1% × 1000
+    expect(pnd53?.cr).toBe('60.00'); // 3% × 2000
+    expect(r.totals.balanced).toBe(true);
+  });
 });

--- a/apps/api/src/modules/expense-documents/__tests__/je-preview.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/je-preview.service.spec.ts
@@ -6,7 +6,7 @@ describe('JePreviewService', () => {
   const names = new Map<string, string>([
     ['53-1101', 'ค่าใช้จ่ายเงินเดือน'],
     ['53-1404', 'ค่าทำความสะอาด'],
-    ['11-2104', 'VAT ซื้อ'],
+    ['11-4101', 'ภาษีซื้อ'],
     ['11-1101', 'เงินสด'],
     ['11-1201', 'KBank'],
     ['21-1104', 'AP กิจการ'],
@@ -30,7 +30,10 @@ describe('JePreviewService', () => {
     expect(r.totals.drSum).toBe('4815.00');
     expect(r.totals.crSum).toBe('4815.00');
     expect(r.lines.find((l) => l.accountCode === '53-1101')?.dr).toBe('4500.00');
-    expect(r.lines.find((l) => l.accountCode === '11-2104')?.dr).toBe('315.00');
+    // VAT must book to 11-4101 (Input Tax Credit), NOT 11-2104 (ม.83/6 overseas).
+    // Mirrors expense-same-day.template.ts:119 and expense-accrual.template.ts:93.
+    expect(r.lines.find((l) => l.accountCode === '11-4101')?.dr).toBe('315.00');
+    expect(r.lines.find((l) => l.accountCode === '11-2104')).toBeUndefined();
     expect(r.lines.find((l) => l.accountCode === '11-1101')?.cr).toBe('4815.00');
   });
 
@@ -73,5 +76,33 @@ describe('JePreviewService', () => {
     const drExpense = r.lines.filter((l) => l.accountCode === '53-1101');
     expect(drExpense).toHaveLength(1);
     expect(drExpense[0].dr).toBe('2000.00');
+  });
+
+  // Regression: Fix #C7. The accounts shown in the preview must match
+  // the accounts the post() will actually book. Specifically, VAT must
+  // always be 11-4101 (Input Tax Credit) and never 11-2104 (ม.83/6 overseas).
+  it('preview never books VAT to 11-2104 (P0-1 regression guard)', () => {
+    const r = svc.preview({
+      documentType: 'EXPENSE', branchId: 'b1', documentDate: '2026-05-11',
+      priceType: 'EXCLUSIVE',
+      paymentMethod: 'CASH', depositAccountCode: '11-1101',
+      lines: [{ category: '53-1101', quantity: 1, unitPrice: 1000, vatPercent: 7, whtPercent: 0 }],
+    } as never, names);
+    expect(r.lines.some((l) => l.accountCode === '11-2104')).toBe(false);
+    expect(r.lines.some((l) => l.accountCode === '11-4101')).toBe(true);
+  });
+
+  // Regression: Fix #C7. Same VAT routing rule on the accrual path
+  // (no payment supplied → flow=expense-accrual). Mirrors the
+  // expense-accrual.template.ts:93 booking.
+  it('accrual preview also books VAT to 11-4101 (not 11-2104)', () => {
+    const r = svc.preview({
+      documentType: 'EXPENSE', branchId: 'b1', documentDate: '2026-05-11',
+      priceType: 'EXCLUSIVE',
+      lines: [{ category: '53-1101', quantity: 1, unitPrice: 1000, vatPercent: 7, whtPercent: 0 }],
+    } as never, names);
+    expect(r.flow).toBe('expense-accrual');
+    expect(r.lines.some((l) => l.accountCode === '11-2104')).toBe(false);
+    expect(r.lines.some((l) => l.accountCode === '11-4101')).toBe(true);
   });
 });

--- a/apps/api/src/modules/expense-documents/__tests__/multi-line-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/multi-line-lifecycle.integration.spec.ts
@@ -151,7 +151,7 @@ describe('ExpenseDocuments multi-line lifecycle (integration)', () => {
     const codes = je.lines.map((l) => l.accountCode);
     expect(codes).toContain('53-1302'); // Expense category
     expect(codes).toContain('53-1404'); // Expense category
-    expect(codes).toContain('11-2104'); // VAT Input
+    expect(codes).toContain('11-4101'); // VAT Input (Input Tax Credit) — Fix Report P0-1
     expect(codes).toContain('11-1201'); // Bank
     expect(codes).toContain('21-3103'); // WHT Payable
 
@@ -169,7 +169,7 @@ describe('ExpenseDocuments multi-line lifecycle (integration)', () => {
     const expenseSum = expenseLines.reduce((s, l) => s + Number(l.debit), 0);
     expect(expenseSum).toBeCloseTo(7000, 2);
 
-    const vatInputLine = je.lines.find((l) => l.accountCode === '11-2104');
+    const vatInputLine = je.lines.find((l) => l.accountCode === '11-4101');
     expect(vatInputLine?.debit).toBeDefined();
     expect(Number(vatInputLine!.debit)).toBeCloseTo(455, 2);
 

--- a/apps/api/src/modules/expense-documents/__tests__/vendor-settlement.template.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/vendor-settlement.template.spec.ts
@@ -388,4 +388,56 @@ describe('VendorSettlementTemplate', () => {
       }),
     );
   });
+
+  // C12-symmetry — template-level defense throws when whtFormType is unknown.
+  // Service-level guard normally rejects first, but template throws too so any
+  // bypass surfaces here instead of silently misrouting under PND3.
+  it('C12-symmetry: throws when wht > 0 and whtFormType is null', async () => {
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: docId,
+      number: 'SE-20260514-C12A',
+      documentType: 'VENDOR_SETTLEMENT',
+      documentDate: new Date('2026-05-14'),
+      totalAmount: new Decimal('5000.00'),
+      withholdingTax: new Decimal('100.00'),
+      whtFormType: null,
+      depositAccountCode: '11-1101',
+      journalEntryId: null,
+      settlement: {
+        settlementLines: [
+          { id: 'l1', clearedDocumentId: 'ex-1', amountSettled: new Decimal('5000.00') },
+        ],
+      },
+    });
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+
+    await expect(template.execute(docId)).rejects.toThrow(/whtFormType ต้องเป็น PND3 หรือ PND53/);
+    expect(journal.createAndPost).not.toHaveBeenCalled();
+  });
+
+  it('C12-symmetry: throws when whtFormType is unknown string (defensive)', async () => {
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: docId,
+      number: 'SE-20260514-C12B',
+      documentType: 'VENDOR_SETTLEMENT',
+      documentDate: new Date('2026-05-14'),
+      totalAmount: new Decimal('5000.00'),
+      withholdingTax: new Decimal('100.00'),
+      whtFormType: 'PND91',
+      depositAccountCode: '11-1101',
+      journalEntryId: null,
+      settlement: {
+        settlementLines: [
+          { id: 'l1', clearedDocumentId: 'ex-1', amountSettled: new Decimal('5000.00') },
+        ],
+      },
+    });
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+
+    await expect(template.execute(docId)).rejects.toThrow(/whtFormType ต้องเป็น PND3 หรือ PND53/);
+  });
 });

--- a/apps/api/src/modules/expense-documents/__tests__/vendor-settlement.template.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/vendor-settlement.template.spec.ts
@@ -19,10 +19,15 @@ describe('VendorSettlementTemplate', () => {
       expenseDocument: {
         findUniqueOrThrow: jest.fn(),
         // findMany used for single-vendor invariant check (added in PR-1 hardening)
+        // AND for partial-vs-full settlement lookup (Fix #C8 — totalAmount per cleared id).
         findMany: jest.fn().mockResolvedValue([]),
         update: jest.fn().mockResolvedValue({}),
         // updateMany used for batched cleared-EX status flip (replaces N x update)
         updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      // groupBy used for cumulative-settled lookup (Fix #C8 — partial vs full).
+      settlementLine: {
+        groupBy: jest.fn().mockResolvedValue([]),
       },
       journalEntry: {
         findUnique: jest.fn().mockResolvedValue({ entryNumber: 'JE-SE-001' }),
@@ -51,6 +56,14 @@ describe('VendorSettlementTemplate', () => {
         ],
       },
     });
+    // findMany #1 — single-vendor invariant (one vendor, OK)
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+    // findMany #2 — totalAmount lookup (Fix #C8 partial vs full check)
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', totalAmount: new Decimal('1000.00') },
+    ]);
 
     const result = await template.execute(docId);
     expect(result.entryNo).toBe('JE-SE-001');
@@ -99,6 +112,16 @@ describe('VendorSettlementTemplate', () => {
         ],
       },
     });
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+      { id: 'ex-2', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+      { id: 'ex-3', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', totalAmount: new Decimal('1000.00') },
+      { id: 'ex-2', totalAmount: new Decimal('2000.00') },
+      { id: 'ex-3', totalAmount: new Decimal('3000.00') },
+    ]);
 
     await template.execute(docId);
 
@@ -138,6 +161,12 @@ describe('VendorSettlementTemplate', () => {
         ],
       },
     });
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', totalAmount: new Decimal('5000.00') },
+    ]);
 
     await template.execute(docId);
 
@@ -162,7 +191,7 @@ describe('VendorSettlementTemplate', () => {
     expect(sumCr.toString()).toBe('5000');
   });
 
-  it('side effect — each cleared EX status → POSTED + paidAt = SE.documentDate', async () => {
+  it('side effect — each fully-cleared EX status → POSTED + paidAt = SE.documentDate', async () => {
     const documentDate = new Date('2026-05-10');
     prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
       id: docId,
@@ -181,6 +210,15 @@ describe('VendorSettlementTemplate', () => {
         ],
       },
     });
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-a', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+      { id: 'ex-b', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+    // Both EXs fully settled by this SE (settled == totalAmount).
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-a', totalAmount: new Decimal('1000.00') },
+      { id: 'ex-b', totalAmount: new Decimal('2000.00') },
+    ]);
 
     await template.execute(docId);
 
@@ -255,5 +293,99 @@ describe('VendorSettlementTemplate', () => {
     const result = await template.execute(docId);
     expect(result.entryNo).toBe('JE-EXISTING');
     expect(journal.createAndPost).not.toHaveBeenCalled();
+  });
+
+  // Fix #C8 — partial settlement (settled < total) must keep EX status=ACCRUAL
+  // so a subsequent SE can clear the residual. Without this guard the AP balance
+  // strands forever (cap check at expense-documents.service blocks SE on non-ACCRUAL).
+  it('Fix #C8 — keeps EX status=ACCRUAL when partial settlement < total', async () => {
+    const documentDate = new Date('2026-05-10');
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: docId,
+      number: 'SE-20260510-0010',
+      documentType: 'VENDOR_SETTLEMENT',
+      documentDate,
+      totalAmount: new Decimal('6000.00'),
+      withholdingTax: new Decimal('0.00'),
+      whtFormType: null,
+      depositAccountCode: '11-1101',
+      journalEntryId: null,
+      settlement: {
+        settlementLines: [
+          { id: 'l1', clearedDocumentId: 'ex-1', amountSettled: new Decimal('6000.00') },
+        ],
+      },
+    });
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+    // EX total = 10,000 but we only settle 6,000 → partial, must stay ACCRUAL.
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', totalAmount: new Decimal('10000.00') },
+    ]);
+
+    await template.execute(docId);
+
+    // EX must NOT be flipped to POSTED — updateMany on cleared EXs should not be
+    // called at all (no fullyPaidIds). The SE itself flips to POSTED via the
+    // separate single `update` call below; that's unrelated to the cleared EX.
+    const clearedFlipCalls = (prisma.expenseDocument.updateMany.mock.calls as unknown[][]).filter(
+      (args) => {
+        const where = (args[0] as { where: { id?: { in?: string[] } } }).where;
+        return where.id?.in?.includes('ex-1') ?? false;
+      },
+    );
+    expect(clearedFlipCalls).toHaveLength(0);
+    // SE itself still flips to POSTED (separate `update` call on SE.id)
+    expect(prisma.expenseDocument.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: docId },
+        data: expect.objectContaining({ status: 'POSTED', paidAt: documentDate }),
+      }),
+    );
+  });
+
+  // Fix #C8 — when cumulative prior + this SE = total, the EX must flip POSTED.
+  // Tests the "second SE clears the residual" path.
+  it('Fix #C8 — flips EX status=POSTED only when cumulative settled = total', async () => {
+    const documentDate = new Date('2026-05-12');
+    prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+      id: docId,
+      number: 'SE-20260512-0001',
+      documentType: 'VENDOR_SETTLEMENT',
+      documentDate,
+      totalAmount: new Decimal('4000.00'),
+      withholdingTax: new Decimal('0.00'),
+      whtFormType: null,
+      depositAccountCode: '11-1101',
+      journalEntryId: null,
+      settlement: {
+        settlementLines: [
+          { id: 'l2', clearedDocumentId: 'ex-1', amountSettled: new Decimal('4000.00') },
+        ],
+      },
+    });
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', vendorTaxId: '1234567890123', vendorName: 'Vendor A' },
+    ]);
+    prisma.expenseDocument.findMany.mockResolvedValueOnce([
+      { id: 'ex-1', totalAmount: new Decimal('10000.00') },
+    ]);
+    // Prior POSTED SE already settled 6,000 → this SE adds 4,000 = 10,000 (full).
+    prisma.settlementLine.groupBy.mockResolvedValueOnce([
+      { clearedDocumentId: 'ex-1', _sum: { amountSettled: new Decimal('6000.00') } },
+    ]);
+
+    await template.execute(docId);
+
+    expect(prisma.expenseDocument.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['ex-1'] },
+          deletedAt: null,
+        }),
+        data: expect.objectContaining({ status: 'POSTED', paidAt: documentDate }),
+      }),
+    );
   });
 });

--- a/apps/api/src/modules/expense-documents/__tests__/vendor-settlement.template.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/vendor-settlement.template.spec.ts
@@ -18,6 +18,10 @@ describe('VendorSettlementTemplate', () => {
       $transaction: jest.fn(async (cb: (tx: unknown) => unknown) => cb(prisma)),
       expenseDocument: {
         findUniqueOrThrow: jest.fn(),
+        // C8 Round 2 — cheap pre-check before the heavy findUniqueOrThrow.
+        // Default: returns { journalEntryId: null } so the cheap idempotency
+        // short-circuit treats the doc as un-posted and falls through.
+        findUnique: jest.fn().mockResolvedValue({ journalEntryId: null }),
         // findMany used for single-vendor invariant check (added in PR-1 hardening)
         // AND for partial-vs-full settlement lookup (Fix #C8 — totalAmount per cleared id).
         findMany: jest.fn().mockResolvedValue([]),
@@ -276,22 +280,43 @@ describe('VendorSettlementTemplate', () => {
   });
 
   it('idempotent — returns existing entryNo when journalEntryId already set, no createAndPost call', async () => {
+    // C8 Round 2 — the cheap pre-check `findUnique({select:journalEntryId})`
+    // runs first. Returning journalEntryId here trips the short-circuit
+    // BEFORE the heavy findUniqueOrThrow{include settlement} ever fires.
+    prisma.expenseDocument.findUnique.mockResolvedValue({
+      journalEntryId: 'je-existing-uuid',
+    });
+    prisma.journalEntry.findUnique.mockResolvedValueOnce({ entryNumber: 'JE-EXISTING' });
+
+    const result = await template.execute(docId);
+    expect(result.entryNo).toBe('JE-EXISTING');
+    expect(journal.createAndPost).not.toHaveBeenCalled();
+    // Heavy findUniqueOrThrow{include settlement} MUST NOT be called.
+    expect(prisma.expenseDocument.findUniqueOrThrow).not.toHaveBeenCalled();
+  });
+
+  // C8 Round 2 — concurrent retry that beats the cheap pre-check but
+  // races into the heavy fetch must still bail at the secondary check.
+  it('C8 belt-and-braces — also idempotent at secondary check after heavy fetch', async () => {
+    // First call (pre-check) returns null → proceed; then findUniqueOrThrow
+    // shows the JE was just posted by a parallel retry.
+    prisma.expenseDocument.findUnique.mockResolvedValue({ journalEntryId: null });
     prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
       id: docId,
-      number: 'SE-20260510-0005',
+      number: 'SE-20260510-0005b',
       documentType: 'VENDOR_SETTLEMENT',
       documentDate: new Date('2026-05-10'),
-      journalEntryId: 'je-existing-uuid',
+      journalEntryId: 'je-race-winner',
       settlement: {
         settlementLines: [
           { id: 'l1', clearedDocumentId: 'ex-1', amountSettled: new Decimal('1000.00') },
         ],
       },
     });
-    prisma.journalEntry.findUnique.mockResolvedValueOnce({ entryNumber: 'JE-EXISTING' });
+    prisma.journalEntry.findUnique.mockResolvedValueOnce({ entryNumber: 'JE-RACE-WINNER' });
 
     const result = await template.execute(docId);
-    expect(result.entryNo).toBe('JE-EXISTING');
+    expect(result.entryNo).toBe('JE-RACE-WINNER');
     expect(journal.createAndPost).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/modules/expense-documents/__tests__/wht-form-type.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/wht-form-type.spec.ts
@@ -1,0 +1,48 @@
+// I1 — narrowing helper for WHT form-type. Tests live under expense-documents
+// because the journal __tests__ folder is excluded from jest (those run via
+// vitest). The helper itself lives at apps/api/src/modules/journal/utils/.
+import { assertWhtFormType, isWhtFormType } from '../../journal/utils/wht-form-type';
+
+describe('wht-form-type helper (I1)', () => {
+  describe('assertWhtFormType', () => {
+    it('returns "PND3" when given "PND3"', () => {
+      expect(assertWhtFormType('PND3', 'ctx')).toBe('PND3');
+    });
+
+    it('returns "PND53" when given "PND53"', () => {
+      expect(assertWhtFormType('PND53', 'ctx')).toBe('PND53');
+    });
+
+    it('throws on null with context in message', () => {
+      expect(() => assertWhtFormType(null, 'EX-X')).toThrow(/PND3 หรือ PND53/);
+      expect(() => assertWhtFormType(null, 'EX-X')).toThrow(/EX-X/);
+    });
+
+    it('throws on undefined', () => {
+      expect(() => assertWhtFormType(undefined, 'ctx')).toThrow(/PND3 หรือ PND53/);
+    });
+
+    it('throws on unknown form-type (e.g. "PND91")', () => {
+      expect(() => assertWhtFormType('PND91', 'ctx')).toThrow(/PND91/);
+    });
+
+    it('throws on empty string', () => {
+      expect(() => assertWhtFormType('', 'ctx')).toThrow(/PND3 หรือ PND53/);
+    });
+  });
+
+  describe('isWhtFormType', () => {
+    it('narrows truthy on "PND3" / "PND53"', () => {
+      expect(isWhtFormType('PND3')).toBe(true);
+      expect(isWhtFormType('PND53')).toBe(true);
+    });
+
+    it('rejects null / undefined / unknown strings / non-strings', () => {
+      expect(isWhtFormType(null)).toBe(false);
+      expect(isWhtFormType(undefined)).toBe(false);
+      expect(isWhtFormType('PND91')).toBe(false);
+      expect(isWhtFormType(3)).toBe(false);
+      expect(isWhtFormType({})).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/modules/expense-documents/dto/create-payroll.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-payroll.dto.ts
@@ -5,6 +5,7 @@ import {
   IsDateString,
   IsNumber,
   Min,
+  Max,
   Matches,
   ValidateNested,
   ArrayMinSize,
@@ -26,8 +27,16 @@ class PayrollLineInput {
   @Min(0.01, { message: 'เงินเดือนพื้นฐานต้องมากกว่า 0' })
   baseSalary!: number;
 
+  /**
+   * Fix #C11 — SSO per-person cap (Thai law).
+   * SSO = 5% × min(salary, 15,000) → ceiling 750/person/month. payroll.template.ts
+   * reuses this value for the employer-side too (accounting.md §SSO accounts), so
+   * a single Max enforces both the employee deduction AND the employer match.
+   * Lower values are fine (salary < 15k → SSO < 750).
+   */
   @IsNumber({ maxDecimalPlaces: 2 })
   @Min(0)
+  @Max(750, { message: 'SSO ต่อคนไม่เกิน 750 บาท/เดือน (5% × 15000 ceiling)' })
   @IsOptional()
   ssoEmployee?: number;
 

--- a/apps/api/src/modules/expense-documents/dto/create-payroll.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-payroll.dto.ts
@@ -33,6 +33,11 @@ class PayrollLineInput {
    * reuses this value for the employer-side too (accounting.md §SSO accounts), so
    * a single Max enforces both the employee deduction AND the employer match.
    * Lower values are fine (salary < 15k → SSO < 750).
+   *
+   * TODO (Round 2 / I2): SSO cap is mandated by Thai SSO law (last changed
+   * 2019). If the cap moves, update this @Max + check `payroll.template.ts`
+   * for any other hardcoded references. Consider moving to
+   * SystemConfig['sso_monthly_cap'] when next refactoring payroll.
    */
   @IsNumber({ maxDecimalPlaces: 2 })
   @Min(0)

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -938,7 +938,9 @@ export class ExpenseDocumentsService {
     const codes = new Set<string>();
     for (const l of dto.lines) codes.add(l.category);
     if (dto.depositAccountCode) codes.add(dto.depositAccountCode);
-    codes.add('11-2104');
+    // 11-4101 = ภาษีซื้อ (Input Tax Credit, claimable). Mirrors expense
+    // templates' VAT routing — must match what post() actually books.
+    codes.add('11-4101');
     codes.add('21-1104');
     if (dto.whtFormType === 'PND53') codes.add('21-3103'); else codes.add('21-3102');
 
@@ -1075,9 +1077,58 @@ export class ExpenseDocumentsService {
         totalAmount: doc.totalAmount.toString(),
       });
 
+      // Fix #C10 — attachment threshold enforced server-side.
+      // ATTACHMENT_REQUIRED_ABOVE_AMOUNT is set in /settings#attachment but
+      // was previously only enforced by the frontend submit button. A direct
+      // API call could POST a 500k expense with no receiptImageUrl → tax-audit
+      // risk. Defense in depth: re-check at post() before any JE is written.
+      const thresholdCfg = await tx.systemConfig.findUnique({
+        where: { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT' },
+      });
+      const rawThreshold = thresholdCfg?.value ?? '0';
+      const threshold = new Prisma.Decimal(
+        Number.isFinite(Number(rawThreshold)) ? rawThreshold : '0',
+      );
+      const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
+      if (threshold.gt(0) && docTotal.gte(threshold) && !doc.receiptImageUrl) {
+        throw new BadRequestException(
+          `เอกสารยอด ${docTotal.toFixed(2)} บาท ต้องแนบไฟล์ประกอบ (เกณฑ์ ${threshold.toFixed(2)} บาท)`,
+        );
+      }
+
       // EXPENSE + CREDIT_NOTE + PAYROLL + VENDOR_SETTLEMENT supported
       if (!['EXPENSE', 'CREDIT_NOTE', 'PAYROLL', 'VENDOR_SETTLEMENT'].includes(doc.documentType)) {
         throw new BadRequestException(`type ${doc.documentType} not supported`);
+      }
+
+      // Fix #C12 — WHT routing invariant. When the doc has WHT > 0, doc.whtFormType
+      // MUST be non-null (and a recognised form). Previously the JE template silently
+      // defaulted to PND3 → routed to 21-3102, misfiling juristic-vendor WHT under
+      // ภ.ง.ด.3 instead of ภ.ง.ด.53 (government compliance bug).
+      // Per-line override (P2-4) still works — when any ExpenseLine.whtFormType is set,
+      // the template uses per-line aggregation. For lines that don't set their own
+      // form type, they fall back to doc.whtFormType, which is now guaranteed non-null.
+      if (
+        doc.documentType === 'EXPENSE' &&
+        doc.withholdingTax &&
+        new Prisma.Decimal(doc.withholdingTax.toString()).gt(0) &&
+        !doc.whtFormType
+      ) {
+        // Check if every WHT-bearing line has its own form type → fall through to
+        // per-line routing in the template. Otherwise the doc-level is mandatory.
+        const detail = await tx.expenseDetail.findUnique({
+          where: { documentId: id },
+          include: { lines: true },
+        });
+        const whtLines = (detail?.lines ?? []).filter(
+          (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
+        );
+        const allLinesHaveFormType = whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
+        if (!allLinesHaveFormType) {
+          throw new BadRequestException(
+            'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
+          );
+        }
       }
 
       if (doc.documentType === 'CREDIT_NOTE') {

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -1105,30 +1105,73 @@ export class ExpenseDocumentsService {
       // MUST be non-null (and a recognised form). Previously the JE template silently
       // defaulted to PND3 → routed to 21-3102, misfiling juristic-vendor WHT under
       // ภ.ง.ด.3 instead of ภ.ง.ด.53 (government compliance bug).
-      // Per-line override (P2-4) still works — when any ExpenseLine.whtFormType is set,
-      // the template uses per-line aggregation. For lines that don't set their own
-      // form type, they fall back to doc.whtFormType, which is now guaranteed non-null.
-      if (
-        doc.documentType === 'EXPENSE' &&
-        doc.withholdingTax &&
-        new Prisma.Decimal(doc.withholdingTax.toString()).gt(0) &&
-        !doc.whtFormType
-      ) {
-        // Check if every WHT-bearing line has its own form type → fall through to
-        // per-line routing in the template. Otherwise the doc-level is mandatory.
-        const detail = await tx.expenseDetail.findUnique({
-          where: { documentId: id },
-          include: { lines: true },
-        });
-        const whtLines = (detail?.lines ?? []).filter(
-          (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
-        );
-        const allLinesHaveFormType = whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
-        if (!allLinesHaveFormType) {
-          throw new BadRequestException(
-            'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
-          );
+      //
+      // C12-symmetry (this PR): mirror the guard across all 4 doc types so any
+      // future bypass surfaces at post() instead of being silently misrouted by
+      // the template. Each doc type carries WHT differently:
+      //   - EXPENSE: doc.whtFormType OR every ExpenseLine.whtFormType is set
+      //     (per-line routing — P2-4)
+      //   - PAYROLL: doc.withholdingTax > 0 → always Cr 21-3101 (ภ.ง.ด.1) —
+      //     payroll WHT is employee income tax, NOT PND3/PND53, so no formType
+      //     enforcement here (BUT we still require it to be null since the field
+      //     is meaningless for payroll)
+      //   - VENDOR_SETTLEMENT: single-vendor invariant means doc-level form type
+      //     applies (intentionally no per-line routing per accounting.md)
+      //   - CREDIT_NOTE: createCreditNote already blocks original-with-WHT
+      //     (so CN itself ideally has no WHT), but if the original had WHT and
+      //     this branch is reached, we still need doc-level formType
+      const wht = new Prisma.Decimal(doc.withholdingTax?.toString() ?? '0');
+      if (wht.gt(0)) {
+        if (doc.documentType === 'EXPENSE') {
+          if (!doc.whtFormType) {
+            // Check if every WHT-bearing line has its own form type → fall through to
+            // per-line routing in the template. Otherwise the doc-level is mandatory.
+            const detail = await tx.expenseDetail.findUnique({
+              where: { documentId: id },
+              include: { lines: true },
+            });
+            const whtLines = (detail?.lines ?? []).filter(
+              (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
+            );
+            const allLinesHaveFormType =
+              whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
+            if (!allLinesHaveFormType) {
+              throw new BadRequestException(
+                'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
+              );
+            }
+            // If every line has a form type, validate each is PND3/PND53 (no other strings)
+            for (const l of whtLines) {
+              if (l.whtFormType !== 'PND3' && l.whtFormType !== 'PND53') {
+                throw new BadRequestException(
+                  `whtFormType ของบรรทัด ${(l as { lineNo?: number }).lineNo ?? '?'} ` +
+                    `ต้องเป็น PND3 หรือ PND53 (พบ ${l.whtFormType ?? 'null'})`,
+                );
+              }
+            }
+          } else if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
+            throw new BadRequestException(
+              `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
+            );
+          }
+        } else if (doc.documentType === 'VENDOR_SETTLEMENT' || doc.documentType === 'CREDIT_NOTE') {
+          // Per-line routing intentionally NOT supported for SE (single-vendor
+          // invariant per accounting.md) and CN (template routes by original.whtFormType
+          // since CN itself carries no WHT — but defense in depth).
+          if (!doc.whtFormType) {
+            throw new BadRequestException(
+              'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
+            );
+          }
+          if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
+            throw new BadRequestException(
+              `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
+            );
+          }
         }
+        // PAYROLL: doc.whtFormType is meaningless (employee income tax always
+        // routes to 21-3101 / ภ.ง.ด.1). No enforcement — payroll.template
+        // posts to 21-3101 unconditionally when sumWht > 0.
       }
 
       if (doc.documentType === 'CREDIT_NOTE') {

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -26,6 +26,26 @@ import { LineAggregatorService } from './services/line-aggregator.service';
 import { JePreviewService } from './services/je-preview.service';
 
 /**
+ * Allow-list of account codes that may appear on a multi-line Adjustment row
+ * (W1 hardening). The adjustment rows absorb cash-leg deltas between
+ * amount_paid and (totalAmount − wht); only small-amount tolerance / bank-fee
+ * / discount accounts are sensible here. Allowing arbitrary CoA codes lets the
+ * preparer pick Revenue or Cash, balancing the JE but causing accounting drift.
+ *
+ * Codes from accounting.md FINANCE chart (apps/api/src/modules/journal/__tests__/fixtures/cpa-cases/finance-coa.csv):
+ *   52-1104 — ส่วนลดเศษสตางค์ (≤1฿ rounding tolerance)
+ *   52-1106 — ส่วนลดดอกเบี้ย-ปิดยอด (Early payoff discount)
+ *   53-1303 — ค่าธรรมเนียมธนาคาร
+ *   53-1503 — กำไร/ขาดทุนจากการปัดเศษ
+ */
+const ADJUSTMENT_ALLOWLIST = new Set<string>([
+  '52-1104',
+  '52-1106',
+  '53-1303',
+  '53-1503',
+]);
+
+/**
  * Returns a Date representing 12:00 noon Asia/Bangkok on the same calendar day
  * as `now`. Used as a stable `postedAt` for journal entries that should land
  * on the BKK business day regardless of the server's UTC clock — without this,
@@ -114,7 +134,17 @@ export class ExpenseDocumentsService {
           }
         }
 
-        // V13 — adjustment account codes must exist in CoA (any type)
+        // V13 — adjustment account codes must exist in CoA AND be on the
+        // explicit allow-list. Without the allow-list, an accountant could
+        // pick Revenue (41-xxxx) or Cash (11-1101) as the offset, balancing
+        // the JE arithmetically but causing P&L / cash-flow drift.
+        //
+        // Allow-list scope: small-amount rounding tolerance + bank fees +
+        // early-payoff discounts. Source: accounting.md chart.
+        //   52-1104 — ส่วนลดเศษสตางค์ (≤1฿ rounding tolerance)
+        //   52-1106 — ส่วนลดดอกเบี้ย-ปิดยอด
+        //   53-1303 — ค่าธรรมเนียมธนาคาร
+        //   53-1503 — กำไร/ขาดทุนจากการปัดเศษ
         if (adjustments.length > 0) {
           const adjCodes = [...new Set(adjustments.map((a) => a.accountCode))];
           const adjCoaRows = await tx.chartOfAccount.findMany({
@@ -125,6 +155,12 @@ export class ExpenseDocumentsService {
           for (const c of adjCodes) {
             if (!adjFound.has(c)) {
               throw new BadRequestException(`V13: บัญชีปรับผลต่าง ${c} ไม่พบในผังบัญชี`);
+            }
+            if (!ADJUSTMENT_ALLOWLIST.has(c)) {
+              throw new BadRequestException(
+                `V13: บัญชีปรับผลต่าง ${c} ไม่อยู่ในรายการที่อนุญาต — ` +
+                  `อนุญาตเฉพาะ ${[...ADJUSTMENT_ALLOWLIST].join(', ')}`,
+              );
             }
           }
         }
@@ -715,16 +751,27 @@ export class ExpenseDocumentsService {
       where.vendorName = { contains: filters.vendor, mode: 'insensitive' };
     }
 
-    // Today in BKK at 00:00. (toLocaleString en-CA = YYYY-MM-DD; offset to UTC start.)
-    const bkkParts = new Date().toLocaleString('en-CA', {
-      timeZone: 'Asia/Bangkok',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    });
-    const [y, m, d] = bkkParts.split('-').map((s) => parseInt(s, 10));
-    const bkkOffsetMs = 7 * 60 * 60 * 1000;
-    const todayBkkStart = new Date(Date.UTC(y, m - 1, d) - bkkOffsetMs);
+    // W2 fix — age in calendar days, computed on BKK date strings.
+    // Previous implementation took (todayBkkStart UTC ms − documentDate UTC ms)
+    // / 86_400_000 and floored. Because documentDate stores UTC midnight (00:00Z
+    // = 07:00 BKK same day) while todayBkkStart was UTC minus 7h (=BKK midnight
+    // mapped to 17:00Z previous UTC day), the ms-diff was non-integer around
+    // the boundary, so floor() shifted some rows by ±1 day (e.g. a doc dated
+    // today appeared as 1 day old, pushing it from 0-30 to 31-60 right at
+    // 17:00 BKK / 30 days later). Switch to calendar-day diff on YYYY-MM-DD
+    // strings instead.
+    const toBkkDate = (d: Date): string =>
+      d.toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
+    const todayBkkStr = toBkkDate(new Date());
+    const daysBetween = (a: string, b: string): number => {
+      // a, b are 'YYYY-MM-DD'. Build UTC midnights and subtract — exact integer
+      // because both sides are at the same UTC hour.
+      const [ay, am, ad] = a.split('-').map(Number);
+      const [by, bm, bd] = b.split('-').map(Number);
+      const aMs = Date.UTC(ay, am - 1, ad);
+      const bMs = Date.UTC(by, bm - 1, bd);
+      return Math.round((bMs - aMs) / (24 * 60 * 60 * 1000));
+    };
 
     const rows = await this.prisma.expenseDocument.findMany({
       where,
@@ -750,10 +797,8 @@ export class ExpenseDocumentsService {
     };
 
     const enriched = rows.map((r) => {
-      const ageDays = Math.max(
-        0,
-        Math.floor((todayBkkStart.getTime() - new Date(r.documentDate).getTime()) / (24 * 60 * 60 * 1000)),
-      );
+      const docBkkStr = toBkkDate(new Date(r.documentDate));
+      const ageDays = Math.max(0, daysBetween(docBkkStr, todayBkkStr));
       return { ...r, ageDays, bucket: toBucket(ageDays) };
     });
 
@@ -938,11 +983,19 @@ export class ExpenseDocumentsService {
     const codes = new Set<string>();
     for (const l of dto.lines) codes.add(l.category);
     if (dto.depositAccountCode) codes.add(dto.depositAccountCode);
+    // W8 — preload adjustment row codes + per-line WHT routes so the preview
+    // can resolve names for the new sections (adjustments + multi-line WHT).
+    for (const adj of dto.adjustments ?? []) {
+      if (adj.accountCode) codes.add(adj.accountCode);
+    }
     // 11-4101 = ภาษีซื้อ (Input Tax Credit, claimable). Mirrors expense
     // templates' VAT routing — must match what post() actually books.
     codes.add('11-4101');
     codes.add('21-1104');
-    if (dto.whtFormType === 'PND53') codes.add('21-3103'); else codes.add('21-3102');
+    // Always preload both WHT routes — the preview may emit either or both
+    // depending on per-line whtFormType (P2-4).
+    codes.add('21-3102');
+    codes.add('21-3103');
 
     const rows = await this.prisma.chartOfAccount.findMany({
       where: { code: { in: [...codes] }, deletedAt: null },
@@ -1245,6 +1298,23 @@ export class ExpenseDocumentsService {
           where: { id: doc.journalEntryId },
           include: { lines: true },
         });
+        // W6 fix — fall back to SHOP company id when legacy JE rows lack
+        // companyId (pre-A.1b migration). Without this, voiding an old EX
+        // throws "companyId required" from journal-auto.service. SHOP is the
+        // canonical home for expense-side flows per accounting.md.
+        let companyId = original.companyId;
+        if (!companyId) {
+          const shop = await tx.companyInfo.findFirst({
+            where: { companyCode: 'SHOP', deletedAt: null },
+            select: { id: true },
+          });
+          if (!shop) {
+            throw new Error(
+              'SHOP companyInfo not found — cannot reverse legacy JE without companyId',
+            );
+          }
+          companyId = shop.id;
+        }
         await this.journal.createAndPost(
           {
             description: `กลับรายการ ${doc.number}`,
@@ -1258,7 +1328,7 @@ export class ExpenseDocumentsService {
               flow: `expense-${doc.documentType.toLowerCase()}-void`,
             },
             postedAt: bkkBusinessDate(new Date()),
-            companyId: original.companyId,
+            companyId,
             lines: original.lines.map((l) => ({
               accountCode: l.accountCode,
               dr: new Prisma.Decimal(l.credit.toString()),

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   ForbiddenException,
   Logger,
+  OnModuleInit,
 } from '@nestjs/common';
 import { Prisma, DocumentStatus } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -24,6 +25,7 @@ import { CreateSettlementDto } from './dto/create-settlement.dto';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { LineAggregatorService } from './services/line-aggregator.service';
 import { JePreviewService } from './services/je-preview.service';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
 
 /**
  * Allow-list of account codes that may appear on a multi-line Adjustment row
@@ -63,8 +65,37 @@ function bkkBusinessDate(now: Date): Date {
 }
 
 @Injectable()
-export class ExpenseDocumentsService {
+export class ExpenseDocumentsService implements OnModuleInit {
   private readonly logger = new Logger(ExpenseDocumentsService.name);
+
+  /**
+   * W1 (Round 2) — Boot-time validation that every ADJUSTMENT_ALLOWLIST code
+   * actually exists (active, not deleted) in chart_of_accounts. Pattern
+   * mirrors AccountRoleService.assertCodesExistInCoa. Without this, a CoA
+   * rename or soft-delete would let the allow-list silently reference a
+   * dead account and a preparer could still pick it. Boot fails loud so
+   * the drift is caught before the first doc posts.
+   */
+  async onModuleInit(): Promise<void> {
+    const codes = [...ADJUSTMENT_ALLOWLIST];
+    const found = await this.prisma.chartOfAccount.findMany({
+      where: { code: { in: codes }, deletedAt: null },
+      select: { code: true },
+    });
+    const foundSet = new Set(found.map((c) => c.code));
+    const missing = codes.filter((c) => !foundSet.has(c));
+    if (missing.length > 0) {
+      throw new Error(
+        `ExpenseDocumentsService: ADJUSTMENT_ALLOWLIST references ` +
+          `${missing.length} code(s) not present (or soft-deleted) in ` +
+          `chart_of_accounts: ${missing.join(', ')}. Either seed the ` +
+          `accounts or update the allow-list constant.`,
+      );
+    }
+    this.logger.log(
+      `[W1] Adjustment allow-list verified: ${codes.length} codes present in CoA`,
+    );
+  }
 
   constructor(
     private readonly prisma: PrismaService,
@@ -1178,6 +1209,35 @@ export class ExpenseDocumentsService {
         totalAmount: doc.totalAmount.toString(),
       });
 
+      // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
+      // Period-open guard at the module boundary. Previously the guard lived
+      // inside createAndPost, which broke payment + contract atomicity (it
+      // would reject mid-tx JE writes and roll back the Payment record).
+      // The guard belongs HERE because:
+      //   1. We know the canonical posting date — doc.documentDate, not
+      //      "now" (which would let a backdated post slip through if the
+      //      clock crossed midnight between create + post).
+      //   2. We know the canonical companyId — SHOP (all expense flows post
+      //      SHOP-side per accounting.md §VAT Policy; expense template
+      //      resolves SHOP later, this guard mirrors that).
+      // Resolve SHOP companyId once via tx + cache; re-using the same
+      // pattern as expense templates' getShopCompanyId.
+      const shopForPeriod = await tx.companyInfo.findFirst({
+        where: { companyCode: 'SHOP', deletedAt: null },
+        select: { id: true },
+      });
+      if (!shopForPeriod) {
+        throw new NotFoundException(
+          'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
+        );
+      }
+      // documentDate is required on the schema but defend against legacy
+      // rows with NULL via fallback to "now" (matches receipts.service +
+      // payments.service behavior — neither has a per-row date column on
+      // the doc, both pass new Date()).
+      const periodDate = doc.documentDate ?? new Date();
+      await validatePeriodOpen(tx, periodDate, shopForPeriod.id);
+
       // Fix #C10 — attachment threshold enforced server-side.
       // ATTACHMENT_REQUIRED_ABOVE_AMOUNT is set in /settings#attachment but
       // was previously only enforced by the frontend submit button. A direct
@@ -1337,6 +1397,22 @@ export class ExpenseDocumentsService {
 
       this.transition.assertCanVoid({ from: doc.status });
 
+      // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
+      // Period-open guard at the module boundary. The reversal JE postedAt
+      // is BKK noon "today" (bkkBusinessDate(new Date())), so the check uses
+      // the same "now" reference. SHOP companyId resolved fresh (cache lives
+      // on JournalAutoService) — small cost, but voids are rare.
+      const shopForVoidPeriod = await tx.companyInfo.findFirst({
+        where: { companyCode: 'SHOP', deletedAt: null },
+        select: { id: true },
+      });
+      if (!shopForVoidPeriod) {
+        throw new NotFoundException(
+          'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
+        );
+      }
+      await validatePeriodOpen(tx, bkkBusinessDate(new Date()), shopForVoidPeriod.id);
+
       // Post reversal JE (flipped Dr/Cr) if doc had one. The original JE stays
       // intact; the reversal lives as a separate POSTED entry tagged via metadata.
       // Reversal postedAt is BKK noon "today" — keeps the entry inside the
@@ -1357,8 +1433,12 @@ export class ExpenseDocumentsService {
             select: { id: true },
           });
           if (!shop) {
-            throw new Error(
-              'SHOP companyInfo not found — cannot reverse legacy JE without companyId',
+            // W6 (Round 2) — replace bare Error with NestJS exception so the
+            // response is a clean 404 instead of a 500 with stack trace. Same
+            // wording shape as the post()/voidDocument() period-guard SHOP
+            // fallback and the FINANCE fallback in resolveFinanceCompanyId.
+            throw new NotFoundException(
+              'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
             );
           }
           companyId = shop.id;

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -274,7 +274,19 @@ export class ExpenseDocumentsService {
         if (t !== 'ค่าใช้จ่าย') throw new BadRequestException(`หมวดบัญชี ${c} ไม่ใช่ "ค่าใช้จ่าย"`);
       }
 
-      // Load + validate original
+      // I2 fix — acquire the advisory lock BEFORE loading the original so a
+      // concurrent void/edit can't slip between the read and the cap check.
+      // Then re-read the original under the lock. Previously the original was
+      // read once before the lock, so two threads could both see status=ACCRUAL
+      // (or matching totalAmount) even after one of them was about to flip it
+      // via a concurrent operation. Locking first → reading second gives
+      // serialisable semantics for the cap branch.
+      await tx.$executeRawUnsafe(
+        `SELECT pg_advisory_xact_lock(hashtext($1))`,
+        dto.originalDocumentId,
+      );
+
+      // Load + validate original (now under the advisory lock).
       const original = await tx.expenseDocument.findUniqueOrThrow({
         where: { id: dto.originalDocumentId },
         include: { expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } } },
@@ -298,13 +310,6 @@ export class ExpenseDocumentsService {
           'ไม่รองรับใบลดหนี้บนเอกสารที่มีการหัก ณ ที่จ่าย — กรุณาใช้การยกเลิก (void) แล้วสร้างเอกสารใหม่',
         );
       }
-
-      // Prevent race condition: two concurrent CN creations on same original could
-      // both pass the cap check. Lock per original-document for the tx.
-      await tx.$executeRawUnsafe(
-        `SELECT pg_advisory_xact_lock(hashtext($1))`,
-        dto.originalDocumentId,
-      );
 
       // Cumulative cap check — use server-computed totals.totalAmount
       const priorAgg = await tx.expenseDocument.aggregate({
@@ -874,7 +879,14 @@ export class ExpenseDocumentsService {
         deletedAt: null,
       },
       include: {
-        expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' }, take: 1 } } },
+        // I4 fix — pull ALL expense lines (not just the first) so the
+        // "by category" aggregation reflects every line's category, weighted
+        // by amountBeforeVat. Previously `take: 1` made multi-line docs all
+        // collapse to their first line's category — a 3-line doc with 1k of
+        // category A and 2x 5k of B would attribute all 11k to A. With this
+        // include the daily summary instead sums per-line amounts into the
+        // right buckets.
+        expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
         creditNote: true,
         payroll: true,
         settlement: true,
@@ -912,14 +924,27 @@ export class ExpenseDocumentsService {
         byPaymentMethod[mKey] = mBucket;
       }
 
-      // By category — primary line category (works for both EXPENSE and CREDIT_NOTE since
-      // CN now uses expenseDetail.lines[] rather than the legacy creditNote.category column)
-      const cat =
-        (d as { expenseDetail?: { lines?: { category: string }[] } | null }).expenseDetail?.lines?.[0]?.category;
-      if (cat) {
+      // I4 — By category: sum per-line amounts into category buckets so a
+      // multi-line doc contributes correctly to each category. count uses
+      // 1 per distinct category in the doc (not per line) so a doc with
+      // 3 cleaning lines counts once for "cleaning", not three times.
+      // Defensive: legacy rows without `amountBeforeVat` (data migration
+      // artefacts) fall back to 0 — they still count toward the bucket's
+      // doc count but contribute no value.
+      const lines =
+        (d as { expenseDetail?: { lines?: { category: string; amountBeforeVat?: unknown }[] } | null })
+          .expenseDetail?.lines ?? [];
+      const seenInDoc = new Set<string>();
+      for (const l of lines) {
+        const cat = l.category;
+        const raw = l.amountBeforeVat;
+        const lineAmt = raw != null ? new Prisma.Decimal(raw.toString()) : new Prisma.Decimal(0);
         const cBucket = byCategory[cat] ?? { count: 0, total: '0' };
-        cBucket.count++;
-        cBucket.total = new Prisma.Decimal(cBucket.total).plus(total).toFixed(2);
+        if (!seenInDoc.has(cat)) {
+          cBucket.count++;
+          seenInDoc.add(cat);
+        }
+        cBucket.total = new Prisma.Decimal(cBucket.total).plus(lineAmt).toFixed(2);
         byCategory[cat] = cBucket;
       }
 
@@ -1006,14 +1031,37 @@ export class ExpenseDocumentsService {
   }
 
   // ─── Find one ────────────────────────────────────────────────────────
+  // I5 — include type-specific detail so single-doc views (PaymentVoucher,
+  // CN view, payroll view, SE view) don't need a follow-up roundtrip. The
+  // base includes (expenseDetail / branch / approver) work for every type;
+  // creditNote / payroll / settlement detail are added based on documentType.
   async findOne(id: string) {
+    // First pass to read documentType, then a typed include.
+    const docType = await this.prisma.expenseDocument.findUniqueOrThrow({
+      where: { id },
+      select: { documentType: true, deletedAt: true },
+    });
+    if (docType.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
+
     const doc = await this.prisma.expenseDocument.findUniqueOrThrow({
       where: { id },
       include: {
         expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
+        adjustments: { orderBy: { lineNo: 'asc' } },
         branch: { select: { id: true, name: true } },
         createdBy: { select: { id: true, name: true } },
         approvedBy: { select: { id: true, name: true } },
+        // Conditional includes by documentType — Prisma allows boolean here
+        // and noop when the relation row doesn't exist for the type.
+        creditNote: docType.documentType === 'CREDIT_NOTE',
+        payroll:
+          docType.documentType === 'PAYROLL'
+            ? { include: { lines: true } }
+            : false,
+        settlement:
+          docType.documentType === 'VENDOR_SETTLEMENT'
+            ? { include: { settlementLines: true } }
+            : false,
       },
     });
     if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');

--- a/apps/api/src/modules/expense-documents/services/doc-number.service.ts
+++ b/apps/api/src/modules/expense-documents/services/doc-number.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { DocumentType, Prisma } from '@prisma/client';
 
 const PREFIX_MAP: Record<DocumentType, string> = {
@@ -15,6 +15,19 @@ export class DocNumberService {
    * advisory lock per (type, BKK-day) key. Mirrors OI/RT pattern.
    *
    * Format: <TYPE>-YYYYMMDD-NNNN — daily reset, 4-digit seq.
+   *
+   * `issueDate` convention (W5): the BKK-day is derived from the user-chosen
+   * `documentDate` (NOT server "now"), so a same-day creation backdated to
+   * yesterday will still number under yesterday's sequence. This is intentional
+   * — auditors expect a doc dated 2026-05-13 to carry an EX-20260513-NNNN
+   * number regardless of when it was keyed in. The per-day advisory lock still
+   * prevents collisions across concurrent backdates onto the same day. If the
+   * convention ever needs to change, see the W5 note in fix report v1.1.
+   *
+   * W4 — explicit throw when seq > 9999 (would overflow the 4-digit slot and
+   * silently produce a 5-digit number that sorts wrong). Real-world limit is
+   * ~100 docs/day, so this is purely a guard against runaway loops / data
+   * corruption / future high-volume regimes.
    */
   async next(
     tx: Prisma.TransactionClient,
@@ -34,7 +47,13 @@ export class DocNumberService {
     const lastSeq = last
       ? parseInt(last.number.slice(prefix.length), 10) || 0
       : 0;
-    const seq = String(lastSeq + 1).padStart(4, '0');
+    const nextSeq = lastSeq + 1;
+    if (nextSeq > 9999) {
+      throw new BadRequestException(
+        `เลขที่เอกสาร ${PREFIX_MAP[type]} เกิน 9999 ใน 1 วัน (BKK ${yyyymmdd}) — ติดต่อผู้ดูแลระบบ`,
+      );
+    }
+    const seq = String(nextSeq).padStart(4, '0');
     return `${prefix}${seq}`;
   }
 

--- a/apps/api/src/modules/expense-documents/services/je-preview.service.ts
+++ b/apps/api/src/modules/expense-documents/services/je-preview.service.ts
@@ -33,6 +33,17 @@ export class JePreviewService {
   /**
    * Build a JE preview from form-state DTO without touching the database.
    * Same logic as ExpenseSameDay/ExpenseAccrual templates but pure.
+   *
+   * W8 — now mirrors the templates' multi-line WHT routing (P2-4) and the
+   * adjustment rows (P0-4):
+   *   - When any line carries its own `whtFormType`, aggregate WHT per form
+   *     and emit one Cr line per form (21-3102 + 21-3103). Otherwise fall
+   *     back to legacy doc-level routing.
+   *   - Render adjustment rows in the appropriate Dr / Cr column.
+   *   - Cash leg = `amountPaid` when set (post-adjustment), else `total − wht`.
+   *
+   * Only renders EXPENSE flows. CN / PAYROLL / VENDOR_SETTLEMENT previews are
+   * deferred — the frontend hides the preview panel for those doc types.
    */
   preview(dto: CreateExpenseDocumentDto, accountNames: Map<string, string>): JePreview {
     const priceType = dto.priceType ?? 'EXCLUSIVE';
@@ -42,6 +53,7 @@ export class JePreviewService {
       description: l.description,
       vatPercent: l.vatPercent ?? 0,
       whtPercent: l.whtPercent ?? 0,
+      whtFormType: l.whtFormType ?? null,
       ...this.aggregator.computeLine(l, priceType),
     }));
     const totals = this.aggregator.aggregateLines(computed);
@@ -82,9 +94,28 @@ export class JePreviewService {
       });
     }
 
+    // W8 — adjustments (P0-4 multi-line). Render Dr/Cr per row using the
+    // explicit `side`. The service has already validated V12 (signed sum
+    // closes the diff), so we just echo what will hit the GL.
+    const adjustments = dto.adjustments ?? [];
+    for (const adj of adjustments) {
+      const amt = new Decimal(adj.amount);
+      if (amt.lte(zero)) continue;
+      previewLines.push({
+        accountCode: adj.accountCode,
+        accountName: accountNames.get(adj.accountCode) ?? '',
+        description: adj.note ?? 'ปรับผลต่าง',
+        dr: adj.side === 'DR' ? amt.toFixed(2) : '0.00',
+        cr: adj.side === 'CR' ? amt.toFixed(2) : '0.00',
+      });
+    }
+
     if (hasPayment) {
-      // Same-day: Cr cash (totalAmount − wht), Cr WHT (per formType)
-      const cashCr = totals.totalAmount.minus(totals.withholdingTax);
+      // Same-day: Cr cash + Cr WHT (per formType, with per-line routing if used)
+      // Cash leg = amountPaid when set (post-adjustment), else `total − wht`.
+      const cashCr = dto.amountPaid
+        ? new Decimal(dto.amountPaid)
+        : totals.totalAmount.minus(totals.withholdingTax);
       previewLines.push({
         accountCode: dto.depositAccountCode!,
         accountName: accountNames.get(dto.depositAccountCode!) ?? '',
@@ -93,14 +124,42 @@ export class JePreviewService {
         cr: cashCr.toFixed(2),
       });
       if (totals.withholdingTax.gt(0)) {
-        const whtAccount = dto.whtFormType === 'PND53' ? '21-3103' : '21-3102';
-        previewLines.push({
-          accountCode: whtAccount,
-          accountName: accountNames.get(whtAccount) ?? '',
-          description: `WHT ${dto.whtFormType ?? 'PND3'}`,
-          dr: '0.00',
-          cr: totals.withholdingTax.toFixed(2),
-        });
+        // W8 — per-line WHT routing mirrors expense-same-day.template.ts
+        // (P2-4). When any line sets its own whtFormType, we aggregate by
+        // form-type and emit up to 2 Cr lines (21-3102 + 21-3103).
+        const hasPerLineRouting = computed.some((c) => !!c.whtFormType);
+        if (hasPerLineRouting) {
+          const whtByForm = new Map<'PND3' | 'PND53', Decimal>();
+          for (const c of computed) {
+            if (c.whtAmount.lte(zero)) continue;
+            const formType = (c.whtFormType ?? dto.whtFormType ?? 'PND3') as 'PND3' | 'PND53';
+            // Unknown/invalid form types fall through to PND3 *here only*
+            // (preview is best-effort; service guard rejects bad form types
+            // before the JE is ever booked).
+            const f = formType === 'PND53' ? 'PND53' : 'PND3';
+            whtByForm.set(f, (whtByForm.get(f) ?? zero).plus(c.whtAmount));
+          }
+          for (const [form, amt] of whtByForm.entries()) {
+            if (amt.lte(zero)) continue;
+            const whtAccount = form === 'PND53' ? '21-3103' : '21-3102';
+            previewLines.push({
+              accountCode: whtAccount,
+              accountName: accountNames.get(whtAccount) ?? '',
+              description: `WHT ${form}`,
+              dr: '0.00',
+              cr: amt.toFixed(2),
+            });
+          }
+        } else {
+          const whtAccount = dto.whtFormType === 'PND53' ? '21-3103' : '21-3102';
+          previewLines.push({
+            accountCode: whtAccount,
+            accountName: accountNames.get(whtAccount) ?? '',
+            description: `WHT ${dto.whtFormType ?? 'PND3'}`,
+            dr: '0.00',
+            cr: totals.withholdingTax.toFixed(2),
+          });
+        }
       }
     } else {
       // Accrual: Cr 21-1104 AP for total

--- a/apps/api/src/modules/expense-documents/services/je-preview.service.ts
+++ b/apps/api/src/modules/expense-documents/services/je-preview.service.ts
@@ -66,12 +66,17 @@ export class JePreviewService {
       });
     }
 
-    // Dr 11-2104 VAT (if any)
+    // Dr 11-4101 VAT (if any) — Input Tax Credit, claimable on ภ.พ.30.
+    // Must mirror expense-same-day / expense-accrual / credit-note templates,
+    // all of which book purchase VAT to 11-4101 (Fix Report P0-1).
+    // 11-2104 ("ลูกหนี้-VAT ที่ออกแทน") is reserved for ม.83/6 overseas-service
+    // VAT — NOT routine purchase. Booking preview vs actual JE to different
+    // accounts deceives the accountant approving the JE.
     if (totals.vatAmount.gt(0)) {
       previewLines.push({
-        accountCode: '11-2104',
-        accountName: accountNames.get('11-2104') ?? 'ลูกหนี้-VAT ที่ออกแทน',
-        description: 'VAT ซื้อ',
+        accountCode: '11-4101',
+        accountName: accountNames.get('11-4101') ?? 'ภาษีซื้อ',
+        description: 'ภาษีซื้อ',
         dr: totals.vatAmount.toFixed(2),
         cr: '0.00',
       });

--- a/apps/api/src/modules/journal/cpa-templates/credit-note.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/credit-note.template.ts
@@ -3,6 +3,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService, JeLineInput } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { assertWhtFormType } from '../utils/wht-form-type';
 
 /**
  * Template — Credit Note (CN ใบลดหนี้). Reverses prior EXPENSE document,
@@ -134,22 +135,21 @@ export class CreditNoteTemplate {
           description: `รับคืนเงิน — ${cn.number}`,
         });
         if (origWht.gt(zero)) {
-          // C12-symmetry — hard throw on unknown form type when reversing
-          // original WHT. The createCreditNote service blocks CN on docs with
-          // WHT > 0 (defense in depth), so this branch is unreachable in
-          // practice, but we still validate so any future relaxation surfaces
-          // here instead of misrouting under PND3.
-          if (original.whtFormType !== 'PND3' && original.whtFormType !== 'PND53') {
-            throw new Error(
-              `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${original.whtFormType ?? 'null'}) — original wht=${origWht}`,
-            );
-          }
-          const whtAccount = original.whtFormType === 'PND53' ? '21-3103' : '21-3102';
+          // C12-symmetry + I1 — narrowing helper when reversing original WHT.
+          // The createCreditNote service blocks CN on docs with WHT > 0 (defense
+          // in depth), so this branch is unreachable in practice, but we still
+          // validate so any future relaxation surfaces here instead of
+          // misrouting under PND3.
+          const formType = assertWhtFormType(
+            original.whtFormType,
+            `original wht=${origWht.toString()}`,
+          );
+          const whtAccount = formType === 'PND53' ? '21-3103' : '21-3102';
           lines.push({
             accountCode: whtAccount,
             dr: origWht,
             cr: zero,
-            description: `กลับรายการ WHT ${original.whtFormType}`,
+            description: `กลับรายการ WHT ${formType}`,
           });
         }
       }

--- a/apps/api/src/modules/journal/cpa-templates/credit-note.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/credit-note.template.ts
@@ -134,12 +134,22 @@ export class CreditNoteTemplate {
           description: `รับคืนเงิน — ${cn.number}`,
         });
         if (origWht.gt(zero)) {
+          // C12-symmetry — hard throw on unknown form type when reversing
+          // original WHT. The createCreditNote service blocks CN on docs with
+          // WHT > 0 (defense in depth), so this branch is unreachable in
+          // practice, but we still validate so any future relaxation surfaces
+          // here instead of misrouting under PND3.
+          if (original.whtFormType !== 'PND3' && original.whtFormType !== 'PND53') {
+            throw new Error(
+              `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${original.whtFormType ?? 'null'}) — original wht=${origWht}`,
+            );
+          }
           const whtAccount = original.whtFormType === 'PND53' ? '21-3103' : '21-3102';
           lines.push({
             accountCode: whtAccount,
             dr: origWht,
             cr: zero,
-            description: `กลับรายการ WHT ${original.whtFormType ?? 'PND3'}`,
+            description: `กลับรายการ WHT ${original.whtFormType}`,
           });
         }
       }

--- a/apps/api/src/modules/journal/cpa-templates/expense-accrual.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense-accrual.template.ts
@@ -13,7 +13,13 @@ import { PrismaService } from '../../../prisma/prisma.service';
  *   Dr 11-4101 ภาษีซื้อ                   (vatAmount)        [if VAT > 0]
  *     Cr 21-1104 เจ้าหนี้-ค่าใช้จ่ายกิจการ (totalAmount)
  *
- * WHT does not post here — defers to SE settlement time (ม.50 ป.รัษฎากร).
+ * V15 (ม.50 ป.รัษฎากร): WHT only arises at payment, not accrual.
+ * Therefore expense-accrual has NO WHT routing leg and is intentionally
+ * exempt from `assertWhtFormType`. WHT lands at vendor-settlement (the
+ * payment step), where the assertion runs. Service-level guard
+ * (expense-documents.service.ts → V15 check) rejects DRAFT→ACCRUAL when
+ * withholdingTax > 0; if the doc reaches here, wht is guaranteed zero.
+ *
  * VAT input is booked to **11-4101 ภาษีซื้อ** (Input Tax Credit, claimable
  * in ภ.พ.30). The placeholder 11-2104 (ลูกหนี้-VAT ที่ออกแทน) used in earlier
  * commits was wrong — that account is for VAT-on-behalf cases (ม.83/6) only,

--- a/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
@@ -3,6 +3,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService, JeLineInput } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { assertWhtFormType, WhtFormType } from '../utils/wht-form-type';
 
 /**
  * Template — Expense Same-day (EX paid same day).
@@ -149,22 +150,22 @@ export class ExpenseSameDayTemplate {
         (l: { whtFormType?: string | null }) => !!l.whtFormType,
       );
       if (hasPerLineRouting) {
-        const whtByForm = new Map<'PND3' | 'PND53', Decimal>();
+        const whtByForm = new Map<WhtFormType, Decimal>();
         for (const l of expenseLines) {
           const rawWht = (l as { whtAmount?: unknown }).whtAmount;
           if (rawWht == null) continue;
           const lineWht = new Decimal(rawWht.toString());
           if (lineWht.lte(zero)) continue;
-          const formType = (l as { whtFormType?: string | null }).whtFormType ?? doc.whtFormType;
-          // Fix #C12 — defense in depth. The service-level guard at post()
-          // already rejects WHT > 0 without a resolvable form type, but the
+          const raw = (l as { whtFormType?: string | null }).whtFormType ?? doc.whtFormType;
+          // Fix #C12 + I1 — narrowing helper centralises the throw message
+          // and removes the inline cast pattern. Service-level guard at
+          // post() rejects WHT > 0 without a resolvable form type, but the
           // template throws too so any future caller bypass surfaces here
           // instead of silently misfiling under PND3.
-          if (formType !== 'PND3' && formType !== 'PND53') {
-            throw new Error(
-              `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${formType ?? 'null'}) — line wht=${lineWht}`,
-            );
-          }
+          const formType = assertWhtFormType(
+            raw,
+            `line wht=${lineWht.toString()} on ${doc.number}`,
+          );
           whtByForm.set(
             formType,
             (whtByForm.get(formType) ?? zero).plus(lineWht),
@@ -183,18 +184,17 @@ export class ExpenseSameDayTemplate {
       } else if (wht.gt(zero)) {
         // Legacy / single-vendor doc: one Cr line, route by doc.whtFormType.
         // Fix #C12 — no silent PND3 fallback. Service guard guarantees
-        // doc.whtFormType is set when wht > 0; template re-checks.
-        if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
-          throw new Error(
-            `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${doc.whtFormType ?? 'null'}) — doc wht=${wht}`,
-          );
-        }
-        const whtAccount = doc.whtFormType === 'PND53' ? '21-3103' : '21-3102';
+        // doc.whtFormType is set when wht > 0; helper enforces narrowing.
+        const formType = assertWhtFormType(
+          doc.whtFormType,
+          `doc wht=${wht.toString()} on ${doc.number}`,
+        );
+        const whtAccount = formType === 'PND53' ? '21-3103' : '21-3102';
         lines.push({
           accountCode: whtAccount,
           dr: zero,
           cr: wht,
-          description: `หัก ณ ที่จ่าย ${doc.whtFormType}`,
+          description: `หัก ณ ที่จ่าย ${formType}`,
         });
       }
 

--- a/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/expense-same-day.template.ts
@@ -155,10 +155,20 @@ export class ExpenseSameDayTemplate {
           if (rawWht == null) continue;
           const lineWht = new Decimal(rawWht.toString());
           if (lineWht.lte(zero)) continue;
-          const formType = ((l as { whtFormType?: string | null }).whtFormType ??
-            doc.whtFormType ??
-            'PND3') as 'PND3' | 'PND53';
-          whtByForm.set(formType, (whtByForm.get(formType) ?? zero).plus(lineWht));
+          const formType = (l as { whtFormType?: string | null }).whtFormType ?? doc.whtFormType;
+          // Fix #C12 — defense in depth. The service-level guard at post()
+          // already rejects WHT > 0 without a resolvable form type, but the
+          // template throws too so any future caller bypass surfaces here
+          // instead of silently misfiling under PND3.
+          if (formType !== 'PND3' && formType !== 'PND53') {
+            throw new Error(
+              `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${formType ?? 'null'}) — line wht=${lineWht}`,
+            );
+          }
+          whtByForm.set(
+            formType,
+            (whtByForm.get(formType) ?? zero).plus(lineWht),
+          );
         }
         for (const [form, amt] of whtByForm.entries()) {
           if (amt.lte(zero)) continue;
@@ -172,12 +182,19 @@ export class ExpenseSameDayTemplate {
         }
       } else if (wht.gt(zero)) {
         // Legacy / single-vendor doc: one Cr line, route by doc.whtFormType.
+        // Fix #C12 — no silent PND3 fallback. Service guard guarantees
+        // doc.whtFormType is set when wht > 0; template re-checks.
+        if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
+          throw new Error(
+            `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${doc.whtFormType ?? 'null'}) — doc wht=${wht}`,
+          );
+        }
         const whtAccount = doc.whtFormType === 'PND53' ? '21-3103' : '21-3102';
         lines.push({
           accountCode: whtAccount,
           dr: zero,
           cr: wht,
-          description: `หัก ณ ที่จ่าย ${doc.whtFormType ?? 'PND3'}`,
+          description: `หัก ณ ที่จ่าย ${doc.whtFormType}`,
         });
       }
 

--- a/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
@@ -35,12 +35,32 @@ export class VendorSettlementTemplate {
     outerTx?: Prisma.TransactionClient,
   ): Promise<{ entryNo: string }> {
     const exec = async (tx: Prisma.TransactionClient): Promise<{ entryNo: string }> => {
+      // C8 (Round 2) — cheap idempotency short-circuit BEFORE the heavy
+      // include query. A concurrent retry from a webhook / cron / manual
+      // re-post used to fetch the full settlement+settlementLines payload
+      // first, then bail at the secondary check below. Doing the cheap
+      // `select journalEntryId` first avoids the redundant join on every
+      // retry. Mirrors expense-accrual / expense-same-day templates.
+      const idemCheck = await tx.expenseDocument.findUnique({
+        where: { id: documentId },
+        select: { journalEntryId: true },
+      });
+      if (idemCheck?.journalEntryId) {
+        const existing = await tx.journalEntry.findUnique({
+          where: { id: idemCheck.journalEntryId },
+          select: { entryNumber: true },
+        });
+        return { entryNo: existing?.entryNumber ?? idemCheck.journalEntryId };
+      }
+
       const se = await tx.expenseDocument.findUniqueOrThrow({
         where: { id: documentId },
         include: { settlement: { include: { settlementLines: true } } },
       });
 
-      // Idempotency
+      // Belt-and-braces — same check after the heavy fetch, in case the
+      // window between the cheap select and this row was used by a parallel
+      // call that succeeded. Same shape as the cheap check above.
       if (se.journalEntryId) {
         const existing = await tx.journalEntry.findUnique({
           where: { id: se.journalEntryId },

--- a/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
@@ -128,18 +128,72 @@ export class VendorSettlementTemplate {
         tx,
       );
 
-      // SIDE EFFECT: each cleared EX → POSTED + paidAt (single batched update).
-      // Note: does NOT overwrite cleared.journalEntryId — original ACCRUAL JE stays intact.
-      await tx.expenseDocument.updateMany({
-        where: {
-          id: { in: se.settlement.settlementLines.map((l) => l.clearedDocumentId) },
-          deletedAt: null,
-        },
-        data: {
-          status: 'POSTED',
-          paidAt: se.documentDate,
-        },
+      // SIDE EFFECT: each cleared EX status flip.
+      // Fix #C8 — only flip to POSTED when cumulative settled = totalAmount.
+      // For partial settlements (Σ POSTED SettlementLine.amountSettled including
+      // *this* SE < cleared.totalAmount), keep the EX as ACCRUAL so a subsequent
+      // SE can clear the residual. Without this guard, partial-paying EX once
+      // strands the residual AP forever (expense-documents.service rejects any
+      // SE on non-ACCRUAL docs at line ~480).
+      //
+      // Original ACCRUAL JE on cleared.journalEntryId stays intact — we only
+      // toggle status/paidAt here. paidAt is set only when the doc is fully
+      // settled; partial-settled docs keep paidAt = null.
+      const clearedIds = se.settlement.settlementLines.map((l) => l.clearedDocumentId);
+      const clearedDocsAmts = await tx.expenseDocument.findMany({
+        where: { id: { in: clearedIds }, deletedAt: null },
+        select: { id: true, totalAmount: true },
       });
+      // Aggregate prior POSTED settlements per cleared doc so we know the
+      // cumulative settled-amount once *this* SE posts.
+      const priorAgg = await tx.settlementLine.groupBy({
+        by: ['clearedDocumentId'],
+        where: {
+          clearedDocumentId: { in: clearedIds },
+          settlement: {
+            document: {
+              status: 'POSTED',
+              deletedAt: null,
+            },
+          },
+        },
+        _sum: { amountSettled: true },
+      });
+      const priorByDoc = new Map(
+        priorAgg.map((a) => [a.clearedDocumentId, new Decimal(a._sum.amountSettled?.toString() ?? '0')]),
+      );
+      const thisByDoc = new Map<string, Decimal>();
+      for (const sl of se.settlement.settlementLines) {
+        const cur = thisByDoc.get(sl.clearedDocumentId) ?? zero;
+        thisByDoc.set(sl.clearedDocumentId, cur.plus(sl.amountSettled.toString()));
+      }
+      const fullyPaidIds: string[] = [];
+      const partiallyPaidIds: string[] = [];
+      for (const d of clearedDocsAmts) {
+        const cumulative = (priorByDoc.get(d.id) ?? zero).plus(thisByDoc.get(d.id) ?? zero);
+        const total = new Decimal(d.totalAmount.toString());
+        // ≥ instead of = because residual < 0.005 should still close the doc
+        // (tolerance — same approach as journal balanced check at 0.01).
+        if (cumulative.gte(total.minus(new Decimal('0.005')))) {
+          fullyPaidIds.push(d.id);
+        } else {
+          partiallyPaidIds.push(d.id);
+        }
+      }
+      if (fullyPaidIds.length > 0) {
+        await tx.expenseDocument.updateMany({
+          where: { id: { in: fullyPaidIds }, deletedAt: null },
+          data: {
+            status: 'POSTED',
+            paidAt: se.documentDate,
+          },
+        });
+      }
+      // Partial settlements keep status=ACCRUAL and paidAt=null so a
+      // subsequent SE can clear the residual. The cap check at
+      // expense-documents.service.ts ~488-500 only counts POSTED SE lines,
+      // so this partial SE will consume the cap correctly once it itself
+      // becomes POSTED below.
 
       // Update SE itself
       await tx.expenseDocument.update({

--- a/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
@@ -3,6 +3,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService, JeLineInput } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { assertWhtFormType } from '../utils/wht-form-type';
 
 /**
  * Template — Vendor Settlement (SE จ่ายเจ้าหนี้).
@@ -98,21 +99,17 @@ export class VendorSettlementTemplate {
         },
       ];
       if (wht.gt(zero)) {
-        // C12-symmetry — hard throw on unknown form type. The service-level
-        // guard at expense-documents.service.post() already rejects null /
-        // bad form types when withholdingTax > 0; this template-level check
-        // is defense-in-depth for any future caller that bypasses the service.
-        if (se.whtFormType !== 'PND3' && se.whtFormType !== 'PND53') {
-          throw new Error(
-            `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${se.whtFormType ?? 'null'}) — SE wht=${wht}`,
-          );
-        }
-        const whtAccount = se.whtFormType === 'PND53' ? '21-3103' : '21-3102';
+        // C12-symmetry + I1 — narrowing helper. Service-level guard at
+        // expense-documents.service.post() already rejects null / bad form
+        // types when withholdingTax > 0; this template-level assertion is
+        // defense-in-depth for any future caller that bypasses the service.
+        const formType = assertWhtFormType(se.whtFormType, `SE wht=${wht.toString()}`);
+        const whtAccount = formType === 'PND53' ? '21-3103' : '21-3102';
         lines.push({
           accountCode: whtAccount,
           dr: zero,
           cr: wht,
-          description: `หัก ณ ที่จ่าย ${se.whtFormType}`,
+          description: `หัก ณ ที่จ่าย ${formType}`,
         });
       }
 

--- a/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
@@ -98,12 +98,21 @@ export class VendorSettlementTemplate {
         },
       ];
       if (wht.gt(zero)) {
+        // C12-symmetry — hard throw on unknown form type. The service-level
+        // guard at expense-documents.service.post() already rejects null /
+        // bad form types when withholdingTax > 0; this template-level check
+        // is defense-in-depth for any future caller that bypasses the service.
+        if (se.whtFormType !== 'PND3' && se.whtFormType !== 'PND53') {
+          throw new Error(
+            `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${se.whtFormType ?? 'null'}) — SE wht=${wht}`,
+          );
+        }
         const whtAccount = se.whtFormType === 'PND53' ? '21-3103' : '21-3102';
         lines.push({
           accountCode: whtAccount,
           dr: zero,
           cr: wht,
-          description: `หัก ณ ที่จ่าย ${se.whtFormType ?? 'PND3'}`,
+          description: `หัก ณ ที่จ่าย ${se.whtFormType}`,
         });
       }
 

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { JournalAutoService } from './journal-auto.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Fix #C9 — createAndPost must enforce validatePeriodOpen before writing
+ * a JournalEntry. Without this guard, expense post/void, payroll, settlement,
+ * credit-note, and all other automated JE templates could write into CLOSED
+ * accounting periods (backdating after period close). Manual JournalService.create
+ * has had this guard since v4; auto-generated entries now match.
+ */
+describe('JournalAutoService.createAndPost — period lock enforcement (Fix #C9)', () => {
+  let service: JournalAutoService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const companyId = 'company-finance-1';
+
+  const balancedInput = (postedAt: Date) => ({
+    description: 'test JE',
+    postedAt,
+    companyId,
+    lines: [
+      { accountCode: '11-1101', dr: new Decimal('100'), cr: new Decimal('0') },
+      { accountCode: '21-1101', dr: new Decimal('0'), cr: new Decimal('100') },
+    ],
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      $executeRaw: jest.fn().mockResolvedValue(undefined),
+      chartOfAccount: {
+        findMany: jest.fn().mockResolvedValue([
+          { code: '11-1101', id: 'acct-cash' },
+          { code: '21-1101', id: 'acct-ap' },
+        ]),
+      },
+      journalEntry: {
+        count: jest.fn().mockResolvedValue(0),
+        create: jest.fn().mockResolvedValue({ id: 'je-uuid-1', entryNumber: 'JE-202604-00001' }),
+      },
+      accountingPeriod: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      systemConfig: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: companyId }),
+      },
+      user: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'user-system' }),
+      },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [JournalAutoService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(JournalAutoService);
+  });
+
+  it('rejects auto JE when AccountingPeriod for postedAt is CLOSED', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
+
+    await expect(
+      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
+    ).rejects.toThrow(/ปิดแล้ว/);
+
+    expect(prisma.journalEntry.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects auto JE when AccountingPeriod is SYNCED', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'SYNCED' });
+
+    await expect(
+      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.journalEntry.create).not.toHaveBeenCalled();
+  });
+
+  it('allows auto JE when AccountingPeriod is OPEN / not found', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue(null);
+
+    const result = await service.createAndPost(balancedInput(new Date('2026-04-10')), prisma);
+    expect(result.entryNumber).toBe('JE-202604-00001');
+    expect(prisma.journalEntry.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('also rejects when legacy SystemConfig `accounting_period_closed_until` blocks the date', async () => {
+    prisma.accountingPeriod.findUnique.mockResolvedValue(null);
+    prisma.systemConfig.findUnique.mockResolvedValue({
+      key: 'accounting_period_closed_until',
+      value: '2026-12-31',
+    });
+
+    await expect(
+      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.journalEntry.create).not.toHaveBeenCalled();
+  });
+
+  it('still rejects unbalanced JEs (regression for v4 guard)', async () => {
+    const unbalanced = balancedInput(new Date('2026-04-10'));
+    unbalanced.lines[1].cr = new Decimal('50'); // Dr=100, Cr=50
+
+    await expect(service.createAndPost(unbalanced, prisma)).rejects.toThrow(BadRequestException);
+    await expect(service.createAndPost(unbalanced, prisma)).rejects.toThrow(/Unbalanced JE/);
+    expect(prisma.journalEntry.create).not.toHaveBeenCalled();
+  });
+
+  // companyId resolution: when not provided, defaults to FINANCE. Verifies
+  // period check runs against the resolved companyId, not undefined.
+  it('resolves companyId to FINANCE when not provided, then validates period', async () => {
+    prisma.companyInfo.findFirst.mockResolvedValueOnce({ id: 'finance-co-id' });
+    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
+
+    const inputWithoutCompany = {
+      ...balancedInput(new Date('2026-04-10')),
+    };
+    delete (inputWithoutCompany as { companyId?: string }).companyId;
+
+    await expect(service.createAndPost(inputWithoutCompany, prisma)).rejects.toThrow(/ปิดแล้ว/);
+    // validatePeriodOpen must have been called with the resolved companyId
+    expect(prisma.accountingPeriod.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          companyId_year_month: expect.objectContaining({ companyId: 'finance-co-id' }),
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/journal/journal-auto.service.spec.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.spec.ts
@@ -5,13 +5,28 @@ import { JournalAutoService } from './journal-auto.service';
 import { PrismaService } from '../../prisma/prisma.service';
 
 /**
- * Fix #C9 — createAndPost must enforce validatePeriodOpen before writing
- * a JournalEntry. Without this guard, expense post/void, payroll, settlement,
- * credit-note, and all other automated JE templates could write into CLOSED
- * accounting periods (backdating after period close). Manual JournalService.create
- * has had this guard since v4; auto-generated entries now match.
+ * Fix #C9 (Round 2 — blast-radius correction)
+ *
+ * History:
+ *   - Initial Round 1 fix put `validatePeriodOpen` inside
+ *     `JournalAutoService.createAndPost`. That caused payment + contract
+ *     atomicity regressions: a reopened FINANCE period would reject a
+ *     mid-tx JE write and roll back the Payment record (the JE was meant
+ *     to be additive — not gating).
+ *   - Round 2 (this PR): period guard moved to each module's service entry
+ *     point (expense-documents.service.post + voidDocument). createAndPost
+ *     is now purely structural — it asserts balanced JE + posts.
+ *
+ * What this spec covers:
+ *   1. createAndPost still rejects unbalanced JEs (v4 regression guard).
+ *   2. createAndPost does NOT itself call validatePeriodOpen — closed
+ *      periods are filtered upstream by the module caller.
+ *   3. createAndPost resolves FINANCE companyId when caller omits one.
+ *
+ * Expense module-level period-lock enforcement is covered by
+ * expense-documents.service.spec.ts → "post() rejects closed period".
  */
-describe('JournalAutoService.createAndPost — period lock enforcement (Fix #C9)', () => {
+describe('JournalAutoService.createAndPost — structural invariants (Fix #C9 Round 2)', () => {
   let service: JournalAutoService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let prisma: any;
@@ -41,8 +56,12 @@ describe('JournalAutoService.createAndPost — period lock enforcement (Fix #C9)
         count: jest.fn().mockResolvedValue(0),
         create: jest.fn().mockResolvedValue({ id: 'je-uuid-1', entryNumber: 'JE-202604-00001' }),
       },
+      // Even with a CLOSED period in the DB, createAndPost itself does NOT
+      // call validatePeriodOpen any more. These mocks exist only to detect
+      // a regression — if the call ever sneaks back in, the test name
+      // "does NOT call validatePeriodOpen" will fail.
       accountingPeriod: {
-        findUnique: jest.fn().mockResolvedValue(null),
+        findUnique: jest.fn().mockResolvedValue({ status: 'CLOSED' }),
       },
       systemConfig: {
         findUnique: jest.fn().mockResolvedValue(null),
@@ -61,47 +80,20 @@ describe('JournalAutoService.createAndPost — period lock enforcement (Fix #C9)
     service = mod.get(JournalAutoService);
   });
 
-  it('rejects auto JE when AccountingPeriod for postedAt is CLOSED', async () => {
-    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
-
-    await expect(
-      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
-    ).rejects.toThrow(BadRequestException);
-    await expect(
-      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
-    ).rejects.toThrow(/ปิดแล้ว/);
-
-    expect(prisma.journalEntry.create).not.toHaveBeenCalled();
-  });
-
-  it('rejects auto JE when AccountingPeriod is SYNCED', async () => {
-    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'SYNCED' });
-
-    await expect(
-      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
-    ).rejects.toThrow(BadRequestException);
-    expect(prisma.journalEntry.create).not.toHaveBeenCalled();
-  });
-
-  it('allows auto JE when AccountingPeriod is OPEN / not found', async () => {
-    prisma.accountingPeriod.findUnique.mockResolvedValue(null);
-
-    const result = await service.createAndPost(balancedInput(new Date('2026-04-10')), prisma);
+  it('Round 2 — does NOT call validatePeriodOpen even when period is CLOSED', async () => {
+    // The guard moved upstream (expense-documents.service). createAndPost
+    // is now purely structural. A closed period at this layer must NOT
+    // throw — payment receipt JE writing into a reopened period must succeed.
+    const result = await service.createAndPost(
+      balancedInput(new Date('2026-04-10')),
+      prisma,
+    );
     expect(result.entryNumber).toBe('JE-202604-00001');
     expect(prisma.journalEntry.create).toHaveBeenCalledTimes(1);
-  });
-
-  it('also rejects when legacy SystemConfig `accounting_period_closed_until` blocks the date', async () => {
-    prisma.accountingPeriod.findUnique.mockResolvedValue(null);
-    prisma.systemConfig.findUnique.mockResolvedValue({
-      key: 'accounting_period_closed_until',
-      value: '2026-12-31',
-    });
-
-    await expect(
-      service.createAndPost(balancedInput(new Date('2026-04-10')), prisma),
-    ).rejects.toThrow(BadRequestException);
-    expect(prisma.journalEntry.create).not.toHaveBeenCalled();
+    // Belt-and-braces: accountingPeriod.findUnique must NOT have been
+    // queried by createAndPost (only the module-level caller queries it).
+    expect(prisma.accountingPeriod.findUnique).not.toHaveBeenCalled();
+    expect(prisma.systemConfig.findUnique).not.toHaveBeenCalled();
   });
 
   it('still rejects unbalanced JEs (regression for v4 guard)', async () => {
@@ -113,24 +105,24 @@ describe('JournalAutoService.createAndPost — period lock enforcement (Fix #C9)
     expect(prisma.journalEntry.create).not.toHaveBeenCalled();
   });
 
-  // companyId resolution: when not provided, defaults to FINANCE. Verifies
-  // period check runs against the resolved companyId, not undefined.
-  it('resolves companyId to FINANCE when not provided, then validates period', async () => {
+  it('resolves companyId to FINANCE when not provided', async () => {
     prisma.companyInfo.findFirst.mockResolvedValueOnce({ id: 'finance-co-id' });
-    prisma.accountingPeriod.findUnique.mockResolvedValue({ status: 'CLOSED' });
 
     const inputWithoutCompany = {
       ...balancedInput(new Date('2026-04-10')),
     };
     delete (inputWithoutCompany as { companyId?: string }).companyId;
 
-    await expect(service.createAndPost(inputWithoutCompany, prisma)).rejects.toThrow(/ปิดแล้ว/);
-    // validatePeriodOpen must have been called with the resolved companyId
-    expect(prisma.accountingPeriod.findUnique).toHaveBeenCalledWith(
+    const result = await service.createAndPost(inputWithoutCompany, prisma);
+    expect(result.entryNumber).toBeDefined();
+    expect(prisma.companyInfo.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          companyId_year_month: expect.objectContaining({ companyId: 'finance-co-id' }),
-        }),
+        where: expect.objectContaining({ companyCode: 'FINANCE' }),
+      }),
+    );
+    expect(prisma.journalEntry.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ companyId: 'finance-co-id' }),
       }),
     );
   });

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -3,7 +3,6 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../prisma/prisma.service';
-import { validatePeriodOpen } from '../../utils/period-lock.util';
 
 export interface JeLineInput {
   accountCode: string;
@@ -68,21 +67,36 @@ export class JournalAutoService {
     }
 
     // 3. resolve companyId — defaults to FINANCE if caller didn't pass one.
-    // Doing this up front (before validatePeriodOpen) so the period check has
-    // the actual companyId rather than `undefined`.
     const postedAt = input.postedAt ?? new Date();
     const companyId = input.companyId ?? (await this.resolveFinanceCompanyId(client));
 
-    // 4. Fix #C9 — period-open guard. Previously absent on createAndPost —
-    // expense post/void, payroll, settlement, credit-note, repossession all
-    // could write into CLOSED periods. Manual JournalService.create has had
-    // this since v4; auto-generated entries now match the same invariant.
-    await validatePeriodOpen(client, postedAt, companyId);
+    // Fix #C9 (Round 2 — blast-radius correction):
+    // The period-open guard was previously called HERE on every createAndPost
+    // invocation. That broke payment + contract atomicity: a reopened FINANCE
+    // period would reject the mid-tx JE write and roll back the Payment record.
+    // Per-module guards are the right boundary — they run BEFORE opening the tx
+    // and they know each module's date semantics (Payment.paidAt vs
+    // EX.documentDate vs contract activation date). Module callers that already
+    // honor period lock (verified 2026-05-14):
+    //   - payments.service.ts:138       → validatePeriodOpen(new Date())
+    //   - payments.service.ts:649,1003  → inside that same outer tx
+    //   - contract-payment.service.ts:256 → validatePeriodOpen(paidDate)
+    //   - receipts.service.ts:450       → validatePeriodOpen(new Date())
+    //   - asset.service.ts (×4)         → validatePeriodOpen(activityDate, FINANCE)
+    //   - asset-transfer.service.ts:105 → validatePeriodOpen(transferDate)
+    //   - depreciation.service.ts (×2)  → validatePeriodOpen(periodStart)
+    //   - journal.service.ts:62,201     → manual journal post + void
+    //   - installment-accrual.cron:90   → validatePeriodOpen(inst.dueDate)
+    // Expense module now guards at its own service entry points
+    // (expense-documents.service.ts post() + voidDocument()) — see those
+    // sites for the per-module period-lock invocation.
+    // OtherIncomeTemplate sits inside other-income.service.post(), which is
+    // also wrapped by its own period validation.
 
-    // 5. entry number via advisory lock (per-month series)
+    // 4. entry number via advisory lock (per-month series)
     const entryNumber = await this.generateEntryNumber(postedAt, client);
 
-    // 6. create entry + lines (POSTED immediately — auto-generated entries skip DRAFT/SoD)
+    // 5. create entry + lines (POSTED immediately — auto-generated entries skip DRAFT/SoD)
     const entry = await client.journalEntry.create({
       data: {
         entryNumber,

--- a/apps/api/src/modules/journal/journal-auto.service.ts
+++ b/apps/api/src/modules/journal/journal-auto.service.ts
@@ -3,6 +3,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
 import { PrismaService } from '../../prisma/prisma.service';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
 
 export interface JeLineInput {
   accountCode: string;
@@ -66,11 +67,22 @@ export class JournalAutoService {
       }
     }
 
-    // 3. entry number via advisory lock (per-month series)
+    // 3. resolve companyId — defaults to FINANCE if caller didn't pass one.
+    // Doing this up front (before validatePeriodOpen) so the period check has
+    // the actual companyId rather than `undefined`.
     const postedAt = input.postedAt ?? new Date();
+    const companyId = input.companyId ?? (await this.resolveFinanceCompanyId(client));
+
+    // 4. Fix #C9 — period-open guard. Previously absent on createAndPost —
+    // expense post/void, payroll, settlement, credit-note, repossession all
+    // could write into CLOSED periods. Manual JournalService.create has had
+    // this since v4; auto-generated entries now match the same invariant.
+    await validatePeriodOpen(client, postedAt, companyId);
+
+    // 5. entry number via advisory lock (per-month series)
     const entryNumber = await this.generateEntryNumber(postedAt, client);
 
-    // 4. create entry + lines (POSTED immediately — auto-generated entries skip DRAFT/SoD)
+    // 6. create entry + lines (POSTED immediately — auto-generated entries skip DRAFT/SoD)
     const entry = await client.journalEntry.create({
       data: {
         entryNumber,
@@ -83,7 +95,7 @@ export class JournalAutoService {
         postedAt,
         // companyId required by schema. Defaults to FINANCE; callers (e.g.
         // expense-documents PR #795) pass SHOP id when posting SHOP-side flows.
-        companyId: input.companyId ?? (await this.resolveFinanceCompanyId(client)),
+        companyId,
         createdById: await this.resolveSystemUserId(client),
         lines: {
           create: input.lines.map((l) => ({

--- a/apps/api/src/modules/journal/utils/wht-form-type.ts
+++ b/apps/api/src/modules/journal/utils/wht-form-type.ts
@@ -1,0 +1,41 @@
+/**
+ * WHT form-type narrowing helper (I1 — Info hardening).
+ *
+ * Several templates / service guards repeat the same pattern:
+ *   if (foo.whtFormType !== 'PND3' && foo.whtFormType !== 'PND53') throw ...
+ *
+ * Centralise it here so:
+ *   1. Future form-types (e.g. PND2 for foreign payers) only need to be
+ *      added in one place — chart of accounts + this helper.
+ *   2. The throw message stays consistent.
+ *   3. Call sites stop sprinkling `as 'PND3' | 'PND53'` casts (the helper's
+ *      return type narrows for TypeScript).
+ */
+
+export type WhtFormType = 'PND3' | 'PND53';
+
+const VALID_FORMS: ReadonlySet<string> = new Set<string>(['PND3', 'PND53']);
+
+/**
+ * Returns `value` typed as WhtFormType when valid, throws otherwise.
+ *
+ * Use at JE template boundary where we route WHT to either 21-3102 (PND.3) or
+ * 21-3103 (PND.53). Service-level guards reject bad form-types before they
+ * reach the template, but defense in depth keeps any future caller bypass
+ * from silently misfiling under PND3.
+ */
+export function assertWhtFormType(
+  value: string | null | undefined,
+  context: string,
+): WhtFormType {
+  if (value !== 'PND3' && value !== 'PND53') {
+    throw new Error(
+      `whtFormType ต้องเป็น PND3 หรือ PND53 (got ${value ?? 'null'}) — ${context}`,
+    );
+  }
+  return value;
+}
+
+export function isWhtFormType(value: unknown): value is WhtFormType {
+  return typeof value === 'string' && VALID_FORMS.has(value);
+}

--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -27,12 +27,19 @@ interface Props {
   onSaved: () => void;
 }
 
+// W3 fix — return YYYY-MM-DD for "today in Asia/Bangkok" (en-CA gives ISO-shaped
+// output). Previously used `new Date().toISOString().slice(0,10)` which returns
+// UTC-day — after 17:00 BKK that becomes tomorrow's BKK calendar date, so the
+// default for the docDate input was off by one half the working day.
+const todayBkkIso = (): string =>
+  new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
+
 const initial = (branchId: string, defaultCash: string): ExpenseFormState => {
   const today = new Date();
   return {
     docType: 'EXPENSE_SAMEDAY',
     branchId,
-    documentDate: today.toISOString().slice(0, 10),
+    documentDate: todayBkkIso(),
     vendorName: '',
     vendorTaxId: '',
     taxInvoiceNo: '',
@@ -77,7 +84,9 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
 
   // Smart default: switch SAMEDAY → ACCRUAL when invoice date is not today.
   // One-way: only auto-flip from SAMEDAY to ACCRUAL; does not revert manual ACCRUAL selection.
-  const todayIso = new Date().toISOString().slice(0, 10);
+  // W3 fix — compare against BKK calendar day, not UTC slice, to match the
+  // user's perception of "today" in Thailand.
+  const todayIso = todayBkkIso();
   const invoiceIsToday = state.documentDate === todayIso;
   useEffect(() => {
     if (state.docType === 'EXPENSE_SAMEDAY' && !invoiceIsToday) {

--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -422,10 +422,15 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
                   </Section>
                 )}
 
-                {/* Section: JE Preview */}
-                <Section num={next()} title="AUTO JOURNAL PREVIEW" Icon={Check}>
-                  <JePreview preview={preview} loading={loading} error={error} />
-                </Section>
+                {/* Section: JE Preview — only meaningful for EXPENSE flows.
+                    JePreviewService server-side only handles EXPENSE_SAMEDAY /
+                    EXPENSE_ACCRUAL today; PAYROLL / VENDOR_SETTLEMENT /
+                    CREDIT_NOTE previews are deferred (I3). */}
+                {(state.docType === 'EXPENSE_SAMEDAY' || state.docType === 'EXPENSE_ACCRUAL') && (
+                  <Section num={next()} title="AUTO JOURNAL PREVIEW" Icon={Check}>
+                    <JePreview preview={preview} loading={loading} error={error} />
+                  </Section>
+                )}
 
                 {/* Section: Approver */}
                 <Section num={next()} title="ผู้บันทึก & ผู้อนุมัติ" Icon={Users}>

--- a/apps/web/src/pages/PaymentVoucherPage.test.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+import { bucketWhtByRate } from './PaymentVoucherPage';
+
+/**
+ * W7 (Round 2) — Form 50 ทวิ is a legal cert; per-row sums MUST equal
+ * the line-by-line totals exactly. parseFloat + += would drift on mixed-
+ * rate docs. These tests pin the Decimal-precision contract.
+ */
+describe('bucketWhtByRate — W7 Decimal precision', () => {
+  it('mixed 3% + 5% + 1% rates → three buckets with exact per-rate sums', () => {
+    // Lines that intentionally exercise float drift: 0.1, 0.2, 0.3 + irrationals
+    const lines = [
+      // 3% bucket
+      { lineNo: 1, category: '53-1302', description: 'a', quantity: '1',
+        unitPrice: '100', amountBeforeVat: '100.10', vatAmount: '7',
+        whtAmount: '3.00', whtPercent: '3' },
+      { lineNo: 2, category: '53-1302', description: 'b', quantity: '1',
+        unitPrice: '200', amountBeforeVat: '200.20', vatAmount: '14',
+        whtAmount: '6.00', whtPercent: '3' },
+      // 5% bucket
+      { lineNo: 3, category: '53-1303', description: 'c', quantity: '1',
+        unitPrice: '1000', amountBeforeVat: '1000.33', vatAmount: '70',
+        whtAmount: '50.00', whtPercent: '5' },
+      // 1% bucket
+      { lineNo: 4, category: '53-1304', description: 'd', quantity: '1',
+        unitPrice: '5000', amountBeforeVat: '5000.10', vatAmount: '350',
+        whtAmount: '50.00', whtPercent: '1' },
+    ];
+    const subtotal = new Decimal('6300.73');
+    const wht = new Decimal('109.00');
+    const buckets = bucketWhtByRate(lines, subtotal, wht);
+
+    expect(buckets).toHaveLength(3);
+    const byRate = new Map(buckets.map((b) => [b.rate.toFixed(2), b]));
+
+    // 3% bucket: 100.10 + 200.20 = 300.30 (exact); tax = 9.00
+    expect(byRate.get('3.00')!.base.toFixed(2)).toBe('300.30');
+    expect(byRate.get('3.00')!.tax.toFixed(2)).toBe('9.00');
+    // 5% bucket
+    expect(byRate.get('5.00')!.base.toFixed(2)).toBe('1000.33');
+    expect(byRate.get('5.00')!.tax.toFixed(2)).toBe('50.00');
+    // 1% bucket
+    expect(byRate.get('1.00')!.base.toFixed(2)).toBe('5000.10');
+    expect(byRate.get('1.00')!.tax.toFixed(2)).toBe('50.00');
+  });
+
+  it('per-bucket totals equal the line-by-line sum exactly (no float drift)', () => {
+    // 100 lines @ 0.1 each = 10.00 exact (parseFloat would give 9.999...)
+    const lines = Array.from({ length: 100 }, (_, i) => ({
+      lineNo: i + 1, category: '53-1302', description: '', quantity: '1',
+      unitPrice: '0.1', amountBeforeVat: '0.1', vatAmount: '0',
+      whtAmount: '0.003', whtPercent: '3',
+    }));
+    const buckets = bucketWhtByRate(lines, new Decimal('10'), new Decimal('0.30'));
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].base.toFixed(2)).toBe('10.00');
+    expect(buckets[0].tax.toFixed(2)).toBe('0.30');
+  });
+
+  it('legacy fallback — no rated lines → single weighted-average bucket', () => {
+    const buckets = bucketWhtByRate([], new Decimal('1000'), new Decimal('30'));
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].rate.toFixed(2)).toBe('3.00');
+    expect(buckets[0].base.toFixed(2)).toBe('1000.00');
+    expect(buckets[0].tax.toFixed(2)).toBe('30.00');
+  });
+
+  it('legacy fallback — zero subtotal → zero rate (no division by zero)', () => {
+    const buckets = bucketWhtByRate([], new Decimal('0'), new Decimal('0'));
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].rate.toFixed(2)).toBe('0.00');
+  });
+
+  it('buckets are sorted descending by tax amount', () => {
+    const lines = [
+      { lineNo: 1, category: '53-1302', description: '', quantity: '1',
+        unitPrice: '100', amountBeforeVat: '100', vatAmount: '0',
+        whtAmount: '1', whtPercent: '1' },
+      { lineNo: 2, category: '53-1303', description: '', quantity: '1',
+        unitPrice: '100', amountBeforeVat: '100', vatAmount: '0',
+        whtAmount: '5', whtPercent: '5' },
+      { lineNo: 3, category: '53-1304', description: '', quantity: '1',
+        unitPrice: '100', amountBeforeVat: '100', vatAmount: '0',
+        whtAmount: '3', whtPercent: '3' },
+    ];
+    const buckets = bucketWhtByRate(lines, new Decimal('300'), new Decimal('9'));
+    expect(buckets[0].rate.toFixed(2)).toBe('5.00');
+    expect(buckets[1].rate.toFixed(2)).toBe('3.00');
+    expect(buckets[2].rate.toFixed(2)).toBe('1.00');
+  });
+
+  it('ignores lines with whtAmount=0 or whtPercent null', () => {
+    const lines = [
+      { lineNo: 1, category: '53-1302', description: '', quantity: '1',
+        unitPrice: '100', amountBeforeVat: '100', vatAmount: '0',
+        whtAmount: '0', whtPercent: '3' }, // zero wht → skip
+      { lineNo: 2, category: '53-1303', description: '', quantity: '1',
+        unitPrice: '100', amountBeforeVat: '100', vatAmount: '0',
+        whtAmount: '5' }, // no whtPercent → skip
+      { lineNo: 3, category: '53-1304', description: '', quantity: '1',
+        unitPrice: '100', amountBeforeVat: '100', vatAmount: '0',
+        whtAmount: '3', whtPercent: '3' }, // included
+    ];
+    const buckets = bucketWhtByRate(lines, new Decimal('300'), new Decimal('3'));
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].base.toFixed(2)).toBe('100.00');
+    expect(buckets[0].tax.toFixed(2)).toBe('3.00');
+  });
+});

--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -14,13 +14,14 @@ import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Printer } from 'lucide-react';
+import Decimal from 'decimal.js';
 import api from '@/lib/api';
 import QueryBoundary from '@/components/QueryBoundary';
 import { formatNumberDecimal } from '@/utils/formatters';
 import { formatThaiDateLong } from '@/lib/date';
 import { numToThaiText } from '@/utils/numToThaiText';
 
-interface ExpenseLine {
+export interface ExpenseLine {
   lineNo: number;
   category: string;
   description: string | null;
@@ -303,39 +304,51 @@ function Sheet({
   );
 }
 
-function WhtCertificate({ doc }: { doc: VoucherDoc }) {
-  const wht = parseFloat(doc.withholdingTax);
-  const subtotal = parseFloat(doc.subtotal);
-  const formLabel = doc.whtFormType === 'PND53' ? 'ภ.ง.ด. 53' : 'ภ.ง.ด. 3';
-
-  // W7 — group lines by whtPercent so the form 50 ทวิ table can render
-  // one row per rate when a doc mixes 3% / 5% / 1% withholdings. Falls back
-  // to one aggregate row (legacy doc-level rate) when every line shares the
-  // same percent or whtPercent is missing.
-  const lines = doc.expenseDetail?.lines ?? [];
+/**
+ * W7 (Round 2) — exported for unit testing. Form 50 ทวิ is a legal cert;
+ * per-row sums MUST equal the line-by-line totals exactly. Decimal.plus()
+ * preserves precision where parseFloat + += would drift a satang on
+ * mixed-rate docs.
+ */
+export interface RateBucket {
+  rate: Decimal;
+  base: Decimal;
+  tax: Decimal;
+}
+export function bucketWhtByRate(
+  lines: ExpenseLine[],
+  subtotal: Decimal,
+  wht: Decimal,
+): RateBucket[] {
   const ratedLines = lines.filter(
-    (l) => parseFloat(l.whtAmount ?? '0') > 0 && l.whtPercent != null,
+    (l) => new Decimal(l.whtAmount ?? '0').gt(0) && l.whtPercent != null,
   );
-  type RateBucket = { rate: number; base: number; tax: number };
-  const buckets: RateBucket[] = [];
-  if (ratedLines.length > 0) {
-    const map = new Map<string, RateBucket>();
-    for (const l of ratedLines) {
-      const rate = parseFloat(l.whtPercent ?? '0');
-      const key = rate.toFixed(2);
-      const b = map.get(key) ?? { rate, base: 0, tax: 0 };
-      b.base += parseFloat(l.amountBeforeVat ?? '0');
-      b.tax += parseFloat(l.whtAmount ?? '0');
-      map.set(key, b);
-    }
-    buckets.push(...map.values());
-    // Sort descending by tax amount for a stable, readable layout.
-    buckets.sort((a, b) => b.tax - a.tax);
-  } else {
+  if (ratedLines.length === 0) {
     // Legacy / fallback: single weighted-average row from doc totals.
-    const avgRate = subtotal > 0 ? (wht / subtotal) * 100 : 0;
-    buckets.push({ rate: avgRate, base: subtotal, tax: wht });
+    const avgRate = subtotal.gt(0) ? wht.div(subtotal).times(100) : new Decimal(0);
+    return [{ rate: avgRate, base: subtotal, tax: wht }];
   }
+  const map = new Map<string, RateBucket>();
+  for (const l of ratedLines) {
+    const rate = new Decimal(l.whtPercent ?? '0');
+    const key = rate.toFixed(2);
+    const b = map.get(key) ?? { rate, base: new Decimal(0), tax: new Decimal(0) };
+    b.base = b.base.plus(l.amountBeforeVat ?? '0');
+    b.tax = b.tax.plus(l.whtAmount ?? '0');
+    map.set(key, b);
+  }
+  // Sort descending by tax amount for a stable, readable layout.
+  return [...map.values()].sort((a, b) => b.tax.cmp(a.tax));
+}
+
+function WhtCertificate({ doc }: { doc: VoucherDoc }) {
+  // W7 (Round 2) — see bucketWhtByRate above for the Decimal-precision
+  // rationale. Convert to display strings only at render time via toFixed.
+  const wht = new Decimal(doc.withholdingTax || '0');
+  const subtotal = new Decimal(doc.subtotal || '0');
+  const formLabel = doc.whtFormType === 'PND53' ? 'ภ.ง.ด. 53' : 'ภ.ง.ด. 3';
+  const lines = doc.expenseDetail?.lines ?? [];
+  const buckets = bucketWhtByRate(lines, subtotal, wht);
   const hasMixedRates = buckets.length > 1;
   return (
     <article
@@ -407,7 +420,7 @@ function WhtCertificate({ doc }: { doc: VoucherDoc }) {
 
       <section className="mt-6 rounded-md border border-border bg-muted/20 p-4 text-sm">
         <p className="text-xs text-muted-foreground mb-1">ภาษีที่หักเป็นเงิน (ตัวอักษร)</p>
-        <p className="font-semibold leading-relaxed">{numToThaiText(wht)}</p>
+        <p className="font-semibold leading-relaxed">{numToThaiText(wht.toFixed(2))}</p>
       </section>
 
       <p className="mt-8 text-xs text-muted-foreground">

--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -29,6 +29,10 @@ interface ExpenseLine {
   amountBeforeVat: string;
   vatAmount: string;
   whtAmount: string;
+  // W7 — used by WhtCertificate to render a per-rate breakdown so the form
+  // 50 ทวิ requirement (itemize the WHT rate per income type) is met when a
+  // single document mixes vendors with different rates.
+  whtPercent?: string;
 }
 
 interface JournalLine {
@@ -302,8 +306,37 @@ function Sheet({
 function WhtCertificate({ doc }: { doc: VoucherDoc }) {
   const wht = parseFloat(doc.withholdingTax);
   const subtotal = parseFloat(doc.subtotal);
-  const whtPercent = subtotal > 0 ? (wht / subtotal) * 100 : 0;
   const formLabel = doc.whtFormType === 'PND53' ? 'ภ.ง.ด. 53' : 'ภ.ง.ด. 3';
+
+  // W7 — group lines by whtPercent so the form 50 ทวิ table can render
+  // one row per rate when a doc mixes 3% / 5% / 1% withholdings. Falls back
+  // to one aggregate row (legacy doc-level rate) when every line shares the
+  // same percent or whtPercent is missing.
+  const lines = doc.expenseDetail?.lines ?? [];
+  const ratedLines = lines.filter(
+    (l) => parseFloat(l.whtAmount ?? '0') > 0 && l.whtPercent != null,
+  );
+  type RateBucket = { rate: number; base: number; tax: number };
+  const buckets: RateBucket[] = [];
+  if (ratedLines.length > 0) {
+    const map = new Map<string, RateBucket>();
+    for (const l of ratedLines) {
+      const rate = parseFloat(l.whtPercent ?? '0');
+      const key = rate.toFixed(2);
+      const b = map.get(key) ?? { rate, base: 0, tax: 0 };
+      b.base += parseFloat(l.amountBeforeVat ?? '0');
+      b.tax += parseFloat(l.whtAmount ?? '0');
+      map.set(key, b);
+    }
+    buckets.push(...map.values());
+    // Sort descending by tax amount for a stable, readable layout.
+    buckets.sort((a, b) => b.tax - a.tax);
+  } else {
+    // Legacy / fallback: single weighted-average row from doc totals.
+    const avgRate = subtotal > 0 ? (wht / subtotal) * 100 : 0;
+    buckets.push({ rate: avgRate, base: subtotal, tax: wht });
+  }
+  const hasMixedRates = buckets.length > 1;
   return (
     <article
       className="voucher-sheet bg-white border border-border rounded-md p-8 shadow-sm print:border-0 print:p-0 print:shadow-none"
@@ -341,20 +374,24 @@ function WhtCertificate({ doc }: { doc: VoucherDoc }) {
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td className="border border-border p-2">
-              ค่าบริการ / ค่าจ้าง (ตาม {formLabel})
-            </td>
-            <td className="border border-border p-2 text-right tabular-nums">
-              {formatNumberDecimal(doc.subtotal)}
-            </td>
-            <td className="border border-border p-2 text-right tabular-nums">
-              {whtPercent.toFixed(2)}
-            </td>
-            <td className="border border-border p-2 text-right tabular-nums">
-              {formatNumberDecimal(doc.withholdingTax)}
-            </td>
-          </tr>
+          {buckets.map((b, idx) => (
+            <tr key={`${b.rate.toFixed(2)}-${idx}`}>
+              <td className="border border-border p-2">
+                {hasMixedRates
+                  ? `ค่าบริการ / ค่าจ้าง (อัตรา ${b.rate.toFixed(2)}%, ตาม ${formLabel})`
+                  : `ค่าบริการ / ค่าจ้าง (ตาม ${formLabel})`}
+              </td>
+              <td className="border border-border p-2 text-right tabular-nums">
+                {formatNumberDecimal(b.base.toFixed(2))}
+              </td>
+              <td className="border border-border p-2 text-right tabular-nums">
+                {b.rate.toFixed(2)}
+              </td>
+              <td className="border border-border p-2 text-right tabular-nums">
+                {formatNumberDecimal(b.tax.toFixed(2))}
+              </td>
+            </tr>
+          ))}
           <tr className="bg-muted/30">
             <td className="border border-border p-2 font-semibold">รวม</td>
             <td className="border border-border p-2 text-right tabular-nums font-semibold">


### PR DESCRIPTION
## Summary
Six P0/P1 Critical issues + C12 symmetry across all 4 doc types + 8 Warning + 5 Info issues found by a 3-pass audit of the post-Fix-Report v1.0 expense module. All Critical hits touch the General Ledger or operational integrity.

**Verification**: TypeScript clean. Jest scoped: 215 passed across expense-documents + cpa-templates + journal suites. Web vitest: 305 passed.

---

## Round 2 — review fixes (2026-05-15)

Round 1 code-reviewer returned FAIL with 1 Critical + 4 Warning + 2 Info. All addressed:

| # | Title | Fix |
|---|---|---|
| **C9 blast-radius** | `validatePeriodOpen` inside shared `createAndPost` blocked payment/contract callers — rolling back Payment records mid-tx | Moved guard to `expense-documents.service.post()` + `voidDocument()` (module boundary). Removed from `journal-auto.service.createAndPost`. Other modules already gate at their boundaries (payments, contracts, receipts, asset, depreciation). |
| **C8 idempotency** | Vendor-settlement template did the heavy `findUniqueOrThrow {include settlement}` join before short-circuiting on `journalEntryId` | Added cheap `findUnique({select: journalEntryId})` BEFORE the heavy fetch. Belt-and-braces secondary check kept for races. |
| **W1 allow-list stale risk** | `ADJUSTMENT_ALLOWLIST` was a module-level const — CoA rename would silently reference dead account | Added `OnModuleInit` boot validator mirroring `AccountRoleService.assertCodesExistInCoa`. Boot fails loud if any of the 4 codes drift. |
| **W6 bare Error** | SHOP fallback in `voidDocument` threw `new Error(...)` → 500 with stack trace | Replaced with `NotFoundException` matching the existing FINANCE fallback wording. |
| **W7 parseFloat float drift** | `WhtCertificate` used `parseFloat + +=` on per-rate buckets → satang drift on mixed-rate form 50 ทวิ legal cert | Replaced with `Decimal.plus()`. Extracted bucketing into exported `bucketWhtByRate()`. Added 6 unit tests including mixed-rate (3% + 5% + 1%) precision. |
| **I1 V15 exemption** | Expense-accrual template lacked JSDoc explaining why `assertWhtFormType` doesn't run | Added JSDoc explaining V15 / ม.50 ป.รัษฎากร — WHT only arises at payment, so accrual leg is exempt. Service-level guard rejects DRAFT→ACCRUAL with WHT > 0. |
| **I2 SSO cap TODO** | Hardcoded `@Max(750)` had no follow-up marker | Added TODO comment per spec: "if cap moves, update Max + payroll.template; consider `SystemConfig['sso_monthly_cap']` next refactor." |

### Round 2 commits

1. `e66fad8a` — fix(expenses): Critical — move C9 period guard off createAndPost + C8 cheap idempotency
2. `8f54dcc8` — fix(expenses): W7 — Decimal precision in form 50 ทวิ certificate
3. `70fc1cda` — docs(expenses): I1 + I2 — V15 exemption JSDoc + SSO cap TODO

### Round 2 test coverage

- `journal-auto.service.spec.ts` rewritten — `createAndPost` no longer calls `validatePeriodOpen` even when period CLOSED.
- `expense-documents.service.spec.ts` +3 new — rejects post on CLOSED / SYNCED period; NotFoundException when SHOP CompanyInfo missing.
- `vendor-settlement.template.spec.ts` updated — cheap pre-check (asserts heavy fetch NOT called) + belt-and-braces secondary idempotency.
- `apps/web/src/pages/PaymentVoucherPage.test.tsx` new — 6 tests covering Decimal precision, mixed-rate buckets, legacy fallback, sort order, filter on zero/null lines.
- All 215/215 expense+journal API tests + 73/73 payment tests + 177/177 contract tests + 305/305 web tests pass.

### Out-of-scope note

`payments.service.applyCreditBalance()` (line 943) calls `createAndPost` (line 1003) without its own `validatePeriodOpen`. Per Round 2 spec, any missing period guards on payment/contract paths are documented but not added — that's a separate PR.

---

## Critical fixes (original)

### Fix #C7 — JE Preview shows 11-2104, actual JE books 11-4101
The preview shown to the accountant pre-POST emitted `Dr 11-2104` (ม.83/6 overseas, NOT claimable on ภ.พ.30), but every actual template (expense-same-day, expense-accrual, credit-note) was already booking `Dr 11-4101` (Input Tax Credit, claimable — PR #810). Accountants approved JEs that didn't match what got posted.

### Fix #C8 — Vendor settlement partial-pay strands AP balance
`vendor-settlement.template.ts` always flipped every cleared EX to `POSTED` + `paidAt` regardless of partial vs full settlement. Combined with the rule that only `ACCRUAL` docs accept new SEs, paying `EX(10,000)` with `SE(6,000)` made the residual 4,000 AP unreachable. Added per-cleared-doc cumulative check; only flip POSTED when cumulative ≥ totalAmount (0.005 rounding tolerance). Round 2 also added a cheap idempotency short-circuit (see above).

### Fix #C9 — Auto JE bypassed period close guard
`journal-auto.service.createAndPost` (used by expense post/void, payroll, settlement, credit-note, repossession, asset, depreciation, contracts, payments) did NOT call `validatePeriodOpen`. Manual `JournalService.create` has had this guard since v4. Posting into a CLOSED period was silently accepted.

**Round 1**: Added guard inside `createAndPost`.
**Round 2**: Moved to module-level service entry points (expense post/void) to prevent payment/contract atomicity regressions.

### Fix #C10 — Attachment threshold only enforced by FE
`ATTACHMENT_REQUIRED_ABOVE_AMOUNT` was set in `/settings#attachment` but the API never read it. Direct API caller could POST 500k expense with no `receiptImageUrl`. Now read at `post()` and reject with Thai message.

### Fix #C11 — SSO per-person cap not enforced
`CreatePayrollDto.ssoEmployee` accepted any non-negative number. Thai SSO law caps employee + employer each at 750/person/month. `payroll.template.ts` reuses `ssoEmployee` for the employer side, so the single `@Max(750)` enforces both.

### Fix #C12 — whtFormType silent fallback misfiled juristic WHT under PND3
`expense-same-day.template.ts` silently defaulted to `'PND3'` when both line-level and doc-level `whtFormType` were null but WHT > 0. Juristic-vendor docs without an explicit form type were filed under ภ.ง.ด.3 instead of ภ.ง.ด.53. Service-level guard + template-level throw added.

---

## C12 symmetry (extended)

The C12 fix only covered EXPENSE. The other 3 doc types had their own WHT routing paths but never enforced the form type requirement.

- **VENDOR_SETTLEMENT** — doc-level `whtFormType` now required when wht > 0 (per `accounting.md`, single-vendor invariant means per-line routing intentionally NOT supported).
- **CREDIT_NOTE** — doc-level required for defense in depth (createCreditNote already blocks WHT-bearing originals).
- **PAYROLL** — NOT enforced; employee income tax always routes to 21-3101 (ภ.ง.ด.1), so `whtFormType` is meaningless for payroll. Documented.
- Both **service-level guard** + **template-level hard throws** mirror the EXPENSE pattern.

6 new tests across service + template specs.

---

## Warnings + Info (extended)

### Warnings (8)

| # | Title | Files |
|---|---|---|
| W1 | Adjustment row `accountCode` restricted to allow-list (`52-1104` / `52-1106` / `53-1303` / `53-1503`) + Round 2 boot validator | `expense-documents.service.ts` |
| W2 | APAging age-day drift ±1 around UTC midnight — switched to calendar-day diff on YYYY-MM-DD strings | `expense-documents.service.ts:getApAging` |
| W3 | Frontend `documentDate` defaulted to UTC `today` (off after 17:00 BKK) → BKK calendar day | `ExpenseFormV4.tsx` |
| W4 | DocNumber 4-digit sequence overflow silent — explicit throw above 9999 | `doc-number.service.ts` |
| W5 | DocNumber convention documented via JSDoc (BKK day from `issueDate`, not server now) | `doc-number.service.ts` |
| W6 | `EXPENSE_VOID_REVERSAL` legacy companyId fallback to SHOP + Round 2 NotFoundException | `expense-documents.service.ts:voidDocument` |
| W7 | WhtCertificate per-rate breakdown for form 50 ทวิ when doc mixes rates + Round 2 Decimal precision | `PaymentVoucherPage.tsx` |
| W8 | JE Preview now renders adjustments + multi-line WHT routing (P2-4) | `je-preview.service.ts` |

### Info (5 original + 2 Round 2)

| # | Title | Files |
|---|---|---|
| I1 | Typed `assertWhtFormType` / `isWhtFormType` helper — refactors inline casts across 3 templates + Round 2 V15 JSDoc | `journal/utils/wht-form-type.ts` (new) + 3 templates |
| I2 | `createCreditNote` reloads `original` AFTER advisory lock (was: lock after read → stale state) + Round 2 SSO cap TODO | `expense-documents.service.ts:createCreditNote` + `create-payroll.dto.ts` |
| I3 | JE Preview section hidden for non-EXPENSE doc types | `ExpenseFormV4.tsx` |
| I4 | Daily summary uses ALL lines (was `take: 1`) — multi-line docs now sum per category correctly | `expense-documents.service.ts:getDailySummary` |
| I5 | `findOne` includes type-specific detail (creditNote / payroll / settlement) + adjustments | `expense-documents.service.ts:findOne` |

---

## Constraint adherence

- Did not undo any Fix Report v1.0 work (PRs #806-#819).
- VAT account routing rule preserved: `11-4101` for routine purchase, `11-2104` only for ม.83/6.
- WHT base remains `amountBeforeVat` (V17).
- SSO 5% per side enforced by `@Max(750)`.
- Adjustment allow-list pulled from `accounting.md` chart.
- Round 2: did not touch payment/contract/OI paths (out of scope).

## Commits in this PR

1. `6847bc62` — fix(expenses): 6 Critical GL bugs (original)
2. `1d578bb4` — fix(expenses): C12 symmetry — extend WHT routing guard to SE / CN / PAYROLL
3. `05a871b3` — fix(expenses): 8 Warning fixes
4. `8957ea8c` — fix(expenses): 5 Info fixes — WHT helper, CN lock order, JE preview gating, daily summary multi-line, findOne typed includes
5. `e66fad8a` — fix(expenses): Round 2 Critical — C9 blast-radius + C8 cheap idempotency
6. `8f54dcc8` — fix(expenses): Round 2 W7 — Decimal precision in form 50 ทวิ certificate
7. `70fc1cda` — docs(expenses): Round 2 I1 + I2 — V15 exemption JSDoc + SSO cap TODO

## Test plan

- [x] `./tools/check-types.sh all` → 0 errors (api + web)
- [x] `cd apps/api && npx jest src/modules/expense-documents src/modules/journal` → 215 passed
- [x] `cd apps/api && npx jest src/modules/payments` → 73 passed (C9 atomicity regression check)
- [x] `cd apps/api && npx jest src/modules/contracts` → 177 passed (C9 atomicity regression check)
- [x] `cd apps/web && npx vitest run` → 305 passed (incl. 6 new W7 tests)
- [ ] Smoke: VAT preview shows `11-4101`
- [ ] Smoke: SE with `whtFormType=null` and `wht > 0` rejected
- [ ] Smoke: APAging row that crosses BKK midnight stays in correct bucket
- [ ] Smoke: ExpenseFormV4 evening (17:00+ BKK) defaults to today's BKK date
- [ ] Smoke: PaymentVoucher WhtCertificate splits 1% + 3% rate lines for mixed docs
- [ ] Smoke: JE Preview hidden for PAYROLL / VENDOR_SETTLEMENT / CREDIT_NOTE
- [ ] Smoke: Daily summary "by category" for a 3-line doc shows ALL three categories
- [ ] Smoke: Payment receipt during reopened FINANCE period now succeeds (Round 2 C9 fix)
- [ ] Smoke: Expense post on closed period still rejected (Round 2 C9 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)