### PR TITLE
feat(assets): final UI polish P9-P17 + CoA SSOT compliance (PR 2b)

### DIFF
--- a/apps/web/src/pages/assets/AssetEntryPage.tsx
+++ b/apps/web/src/pages/assets/AssetEntryPage.tsx
@@ -17,8 +17,10 @@ import {
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { ArrowLeft, AlertCircle, Save, Send, X } from 'lucide-react';
+import { ArrowLeft, AlertCircle, CheckCircle2, Save, Send, X } from 'lucide-react';
 import api, { getErrorMessage } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { formatNumberDecimal } from '@/utils/formatters';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { assetsApi } from './api';
@@ -239,7 +241,7 @@ export default function AssetEntryPage() {
 
   return (
     <FormProvider {...form}>
-      <div className="space-y-4 pb-32">
+      <div className="space-y-4">
         {/* Page header card */}
         <div className="rounded-xl border border-border/60 bg-card p-5 shadow-sm">
           <button
@@ -293,23 +295,36 @@ export default function AssetEntryPage() {
           </div>
         )}
 
-        {/* Sticky action bar */}
-        <div className="fixed bottom-0 left-0 right-0 bg-card border-t border-border z-10 shadow-lg">
-          <div className="container mx-auto flex flex-wrap items-center justify-between gap-3 p-4">
-            <div className="flex items-center gap-2 text-sm">
+        {/* Sticky action bar — validation status + Σ Dr = Σ Cr + 3 actions */}
+        <div className="sticky bottom-0 z-10 -mx-4 sm:-mx-6 px-4 sm:px-6 py-3 bg-background/95 backdrop-blur border-t border-border">
+          <div className="container mx-auto flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-3 text-xs">
               {errorCount > 0 ? (
                 <span className="inline-flex items-center gap-1.5 text-destructive">
-                  <AlertCircle className="size-4" />
-                  มี {errorCount} ข้อต้องแก้ไข
-                </span>
-              ) : !calc.isBalanced ? (
-                <span className="inline-flex items-center gap-1.5 text-warning">
-                  <AlertCircle className="size-4" />
-                  Auto Journal Preview ยังไม่สมดุล
+                  <AlertCircle className="size-3.5" />
+                  พบ {errorCount} ข้อผิดพลาด
                 </span>
               ) : (
-                <span className="text-muted-foreground">พร้อมบันทึก & POST</span>
+                <span className="inline-flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
+                  <CheckCircle2 className="size-3.5" />
+                  ผ่านการตรวจสอบ
+                </span>
               )}
+              <span
+                className={cn(
+                  'inline-flex items-center gap-1.5',
+                  calc.isBalanced
+                    ? 'text-emerald-600 dark:text-emerald-400'
+                    : 'text-destructive',
+                )}
+              >
+                {calc.isBalanced ? (
+                  <CheckCircle2 className="size-3.5" />
+                ) : (
+                  <AlertCircle className="size-3.5" />
+                )}
+                Σ Dr = Σ Cr ({formatNumberDecimal(calc.totalDr)})
+              </span>
             </div>
             <div className="flex flex-wrap items-center justify-end gap-2">
               <Button

--- a/apps/web/src/pages/assets/AssetEntryPage.tsx
+++ b/apps/web/src/pages/assets/AssetEntryPage.tsx
@@ -296,7 +296,7 @@ export default function AssetEntryPage() {
         )}
 
         {/* Sticky action bar — validation status + Σ Dr = Σ Cr + 3 actions */}
-        <div className="sticky bottom-0 z-10 -mx-4 sm:-mx-6 px-4 sm:px-6 py-3 bg-background/95 backdrop-blur border-t border-border">
+        <div className="sticky bottom-[56px] lg:bottom-0 z-20 -mx-5 lg:-mx-7 px-5 lg:px-7 py-3 bg-background/95 backdrop-blur border-t border-border">
           <div className="container mx-auto flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-3 text-xs">
               {errorCount > 0 ? (

--- a/apps/web/src/pages/assets/AssetRegisterPage.tsx
+++ b/apps/web/src/pages/assets/AssetRegisterPage.tsx
@@ -224,7 +224,7 @@ export default function AssetRegisterPage() {
 
       {/* Filters */}
       <Card>
-        <CardContent className="p-4 grid grid-cols-1 md:grid-cols-4 gap-3">
+        <CardContent className="p-4 grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
           <div>
             <label className="text-sm font-medium mb-1 block">ณ วันที่</label>
             <ThaiDateInput
@@ -232,43 +232,52 @@ export default function AssetRegisterPage() {
               onChange={(e) => setParam('asOfDate', e.target.value || null)}
             />
           </div>
-          <Select
-            value={category || 'ALL'}
-            onValueChange={(v) => setParam('category', v === 'ALL' ? null : v)}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="หมวด" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="ALL">ทุกหมวด</SelectItem>
-              <SelectItem value="EQUIPMENT">{CATEGORY_LABEL.EQUIPMENT}</SelectItem>
-              <SelectItem value="IMPROVEMENT">{CATEGORY_LABEL.IMPROVEMENT}</SelectItem>
-              <SelectItem value="FURNITURE">{CATEGORY_LABEL.FURNITURE}</SelectItem>
-              <SelectItem value="VEHICLE">{CATEGORY_LABEL.VEHICLE}</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select
-            value={status || 'ALL'}
-            onValueChange={(v) => setParam('status', v === 'ALL' ? null : v)}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="สถานะ" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="ALL">ทุกสถานะ</SelectItem>
-              <SelectItem value="POSTED">ลงบัญชีแล้ว</SelectItem>
-              <SelectItem value="DISPOSED">จำหน่าย</SelectItem>
-              <SelectItem value="WRITTEN_OFF">ตัดบัญชี</SelectItem>
-            </SelectContent>
-          </Select>
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              className="pl-10"
-              placeholder="ค้นหา รหัส/ชื่อ/serial"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-            />
+          <div>
+            <label className="text-sm font-medium mb-1 block">หมวด</label>
+            <Select
+              value={category || 'ALL'}
+              onValueChange={(v) => setParam('category', v === 'ALL' ? null : v)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="หมวด" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">ทุกหมวด</SelectItem>
+                <SelectItem value="EQUIPMENT">{CATEGORY_LABEL.EQUIPMENT}</SelectItem>
+                <SelectItem value="IMPROVEMENT">{CATEGORY_LABEL.IMPROVEMENT}</SelectItem>
+                <SelectItem value="FURNITURE">{CATEGORY_LABEL.FURNITURE}</SelectItem>
+                <SelectItem value="VEHICLE">{CATEGORY_LABEL.VEHICLE}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <label className="text-sm font-medium mb-1 block">สถานะ</label>
+            <Select
+              value={status || 'ALL'}
+              onValueChange={(v) => setParam('status', v === 'ALL' ? null : v)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="สถานะ" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">ทุกสถานะ</SelectItem>
+                <SelectItem value="POSTED">ลงบัญชีแล้ว</SelectItem>
+                <SelectItem value="DISPOSED">จำหน่าย</SelectItem>
+                <SelectItem value="WRITTEN_OFF">ตัดบัญชี</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <label className="text-sm font-medium mb-1 block">ค้นหา</label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                className="pl-10"
+                placeholder="ค้นหา รหัส/ชื่อ/serial"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+              />
+            </div>
           </div>
         </CardContent>
       </Card>
@@ -280,16 +289,19 @@ export default function AssetRegisterPage() {
         onRetry={() => query.refetch()}
         errorTitle="โหลดทะเบียนสินทรัพย์ไม่สำเร็จ"
       >
-        <DataTable
-          columns={columns}
-          data={query.data?.data ?? []}
-          pagination={{
-            page,
-            totalPages: query.data ? Math.max(1, Math.ceil(query.data.total / PAGE_SIZE)) : 1,
-            total: query.data?.total ?? 0,
-            onPageChange: (p: number) => setParam('page', String(p)),
-          }}
-        />
+        {/* P12: enhanced header contrast (bg-muted/60 + border-b-2) */}
+        <div className="[&_thead_tr]:bg-muted/60 [&_thead_tr]:border-b-2 [&_thead_tr]:border-border [&_thead_th]:text-foreground">
+          <DataTable
+            columns={columns}
+            data={query.data?.data ?? []}
+            pagination={{
+              page,
+              totalPages: query.data ? Math.max(1, Math.ceil(query.data.total / PAGE_SIZE)) : 1,
+              total: query.data?.total ?? 0,
+              onPageChange: (p: number) => setParam('page', String(p)),
+            }}
+          />
+        </div>
       </QueryBoundary>
     </div>
   );

--- a/apps/web/src/pages/assets/AssetRegisterPage.tsx
+++ b/apps/web/src/pages/assets/AssetRegisterPage.tsx
@@ -6,7 +6,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { FileSpreadsheet, FileText, Search, BookOpen } from 'lucide-react';
+import { FileSpreadsheet, FileText, Printer, Search, BookOpen } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -175,6 +175,13 @@ export default function AssetRegisterPage() {
             </Button>
             <Button variant="outline" onClick={handleExportXlsx} disabled={!query.data}>
               <FileSpreadsheet className="mr-2 h-4 w-4" /> Excel
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => window.print()}
+              disabled={!query.data}
+            >
+              <Printer className="mr-2 h-4 w-4" /> พิมพ์ PDF
             </Button>
           </div>
         }

--- a/apps/web/src/pages/assets/AssetSummaryReportPage.tsx
+++ b/apps/web/src/pages/assets/AssetSummaryReportPage.tsx
@@ -1,18 +1,130 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
-import { BarChart3, ArrowRightLeft } from 'lucide-react';
+import { BarChart3, ArrowRightLeft, Monitor, Wrench, Sofa, Car, Package } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import DataTable from '@/components/ui/DataTable';
 import QueryBoundary from '@/components/QueryBoundary';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { formatDateShortThai, formatNumberDecimal } from '@/utils/formatters';
 import { assetsApi } from './api';
+import { CATEGORY_LABEL, type AssetCategory } from './types';
 import type { SummaryRow, AssetTransferRow } from './types';
 
 const today = () => new Date().toISOString().slice(0, 10);
+
+const CATEGORY_ICON: Record<AssetCategory, LucideIcon> = {
+  EQUIPMENT: Monitor,
+  IMPROVEMENT: Wrench,
+  FURNITURE: Sofa,
+  VEHICLE: Car,
+};
+
+function isAssetCategory(key: string): key is AssetCategory {
+  return key === 'EQUIPMENT' || key === 'IMPROVEMENT' || key === 'FURNITURE' || key === 'VEHICLE';
+}
+
+function CategoryGroupCards({ data }: { data: SummaryRow[] }) {
+  const grandTotal = useMemo(() => {
+    return data.reduce(
+      (acc, r) => ({
+        count: acc.count + r.count,
+        totalPurchaseCost: acc.totalPurchaseCost + parseFloat(r.totalPurchaseCost || '0'),
+        totalAccumulatedDepr: acc.totalAccumulatedDepr + parseFloat(r.totalAccumulatedDepr || '0'),
+        totalNbv: acc.totalNbv + parseFloat(r.totalNbv || '0'),
+      }),
+      { count: 0, totalPurchaseCost: 0, totalAccumulatedDepr: 0, totalNbv: 0 },
+    );
+  }, [data]);
+
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-8 text-center text-sm text-muted-foreground">
+          ไม่มีข้อมูลสินทรัพย์ ณ วันที่นี้
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {data.map((row) => {
+        const Icon = isAssetCategory(row.key) ? CATEGORY_ICON[row.key] : Package;
+        const label = isAssetCategory(row.key) ? CATEGORY_LABEL[row.key] : row.label;
+        return (
+          <Card key={row.key}>
+            <CardHeader className="flex flex-row items-center justify-between gap-4 p-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-md bg-primary/10 text-primary">
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div>
+                  <h3 className="font-semibold">{label}</h3>
+                  <p className="text-xs text-muted-foreground">{row.count} รายการ</p>
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-6 text-right">
+                <div>
+                  <p className="text-xs text-muted-foreground">ราคาทุน</p>
+                  <p className="font-semibold tabular-nums">
+                    {formatNumberDecimal(parseFloat(row.totalPurchaseCost))}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">ค่าเสื่อมสะสม</p>
+                  <p className="font-semibold tabular-nums">
+                    {formatNumberDecimal(parseFloat(row.totalAccumulatedDepr))}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">มูลค่าตามบัญชีสุทธิ (NBV)</p>
+                  <p className="font-semibold tabular-nums text-emerald-600">
+                    {formatNumberDecimal(parseFloat(row.totalNbv))}
+                  </p>
+                </div>
+              </div>
+            </CardHeader>
+          </Card>
+        );
+      })}
+
+      <Card className="bg-muted/30 border-primary/30">
+        <CardContent className="p-4">
+          <div className="flex flex-row items-center justify-between gap-4">
+            <div>
+              <h3 className="font-semibold">รวมทั้งหมด</h3>
+              <p className="text-xs text-muted-foreground">{grandTotal.count} รายการ</p>
+            </div>
+            <div className="grid grid-cols-3 gap-6 text-right">
+              <div>
+                <p className="text-xs text-muted-foreground">ราคาทุนรวม</p>
+                <p className="font-semibold tabular-nums">
+                  {formatNumberDecimal(grandTotal.totalPurchaseCost)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">ค่าเสื่อมสะสมรวม</p>
+                <p className="font-semibold tabular-nums">
+                  {formatNumberDecimal(grandTotal.totalAccumulatedDepr)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">มูลค่าตามบัญชีสุทธิ (NBV) รวม</p>
+                <p className="font-semibold tabular-nums text-emerald-600">
+                  {formatNumberDecimal(grandTotal.totalNbv)}
+                </p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 function SummaryTable({ data }: { data: SummaryRow[] }) {
   const columns = [
@@ -115,7 +227,7 @@ export default function AssetSummaryReportPage() {
             error={summaryQuery.error}
             onRetry={() => summaryQuery.refetch()}
           >
-            <SummaryTable data={summaryQuery.data ?? []} />
+            <CategoryGroupCards data={summaryQuery.data ?? []} />
           </QueryBoundary>
         </TabsContent>
         <TabsContent value="custodian">

--- a/apps/web/src/pages/assets/AssetSummaryReportPage.tsx
+++ b/apps/web/src/pages/assets/AssetSummaryReportPage.tsx
@@ -82,7 +82,7 @@ function CategoryGroupCards({ data }: { data: SummaryRow[] }) {
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">มูลค่าตามบัญชีสุทธิ (NBV)</p>
-                  <p className="font-semibold tabular-nums text-emerald-600">
+                  <p className="font-semibold tabular-nums text-emerald-600 dark:text-emerald-400">
                     {formatNumberDecimal(parseFloat(row.totalNbv))}
                   </p>
                 </div>
@@ -114,7 +114,7 @@ function CategoryGroupCards({ data }: { data: SummaryRow[] }) {
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">มูลค่าตามบัญชีสุทธิ (NBV) รวม</p>
-                <p className="font-semibold tabular-nums text-emerald-600">
+                <p className="font-semibold tabular-nums text-emerald-600 dark:text-emerald-400">
                   {formatNumberDecimal(grandTotal.totalNbv)}
                 </p>
               </div>

--- a/apps/web/src/pages/assets/AssetsListPage.tsx
+++ b/apps/web/src/pages/assets/AssetsListPage.tsx
@@ -316,12 +316,6 @@ export default function AssetsListPage() {
               </BreadcrumbItem>
               <BreadcrumbSeparator />
               <BreadcrumbItem>
-                <BreadcrumbLink asChild>
-                  <Link to="/assets">สินทรัพย์</Link>
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
                 <BreadcrumbPage>รายการเอกสารทั้งหมด</BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>

--- a/apps/web/src/pages/assets/AssetsListPage.tsx
+++ b/apps/web/src/pages/assets/AssetsListPage.tsx
@@ -3,7 +3,7 @@
 // Stats: ทั้งหมด / รอดำเนินการ / ลงบัญชี / ยกเลิก (P3 of PR 2a).
 
 import { useState, useMemo, type ReactNode } from 'react';
-import { useNavigate, useSearchParams } from 'react-router';
+import { useNavigate, useSearchParams, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -20,6 +20,14 @@ import {
   Inbox,
 } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -298,6 +306,27 @@ export default function AssetsListPage() {
         title="ซื้อสินทรัพย์ถาวร"
         subtitle="จัดการการซื้อสินทรัพย์ถาวร (กลุ่ม 12-21XX) — อุปกรณ์ · ส่วนปรับปรุง · ตกแต่ง · ยานพาหนะ · TFRS + Accrual VAT"
         icon={<Boxes className="size-5" />}
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link to="/">หน้าหลัก</Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link to="/assets">สินทรัพย์</Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>รายการเอกสารทั้งหมด</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        }
         action={
           <Button variant="primary" size="md" onClick={() => navigate('/assets/new')}>
             <Plus className="size-4" /> สร้างเอกสารใหม่

--- a/apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx
@@ -70,7 +70,7 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
         </div>
 
         {/* VAT */}
-        <div className="rounded-lg border p-4 space-y-3">
+        <div className="border-l-4 border-violet-500 bg-violet-50/30 dark:bg-violet-950/30 rounded-r-lg p-3 space-y-3">
           <div className="flex items-center gap-2">
             <Switch
               id="asset-has-vat"
@@ -126,7 +126,7 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
         </div>
 
         {/* WHT */}
-        <div className="rounded-lg border p-4 space-y-3">
+        <div className="border-l-4 border-amber-500 bg-amber-50/30 dark:bg-amber-950/30 rounded-r-lg p-3 space-y-3">
           <div className="flex items-center gap-2">
             <Switch
               id="asset-has-wht"

--- a/apps/web/src/pages/assets/components/AssetStatusBadge.tsx
+++ b/apps/web/src/pages/assets/components/AssetStatusBadge.tsx
@@ -1,6 +1,7 @@
 // Asset module — status chip (uses shared assetStatusMap for labels,
 // overrides classes per PDF spec page 8: POSTED green · DISPOSED purple ·
-// WRITE-OFF red · FULLY DEPR เทา).
+// WRITE-OFF red). FULLY DEPR เทา applies to depreciation schedule status
+// (handled by a separate badge), not to AssetStatus.
 
 import { Badge } from '@/components/ui/badge';
 import { assetStatusMap, getStatusBadgeProps } from '@/lib/status-badges';
@@ -14,7 +15,6 @@ const STATUS_CLASS_OVERRIDE: Record<string, string> = {
   REVERSED: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
   DISPOSED: 'bg-purple-500/15 text-purple-700 dark:text-purple-400',
   WRITTEN_OFF: 'bg-red-500/15 text-red-700 dark:text-red-400',
-  FULLY_DEPRECIATED: 'bg-zinc-500/15 text-zinc-700 dark:text-zinc-400',
 };
 
 export function AssetStatusBadge({ status }: { status: AssetStatus }) {

--- a/apps/web/src/pages/assets/components/AssetStatusBadge.tsx
+++ b/apps/web/src/pages/assets/components/AssetStatusBadge.tsx
@@ -1,13 +1,31 @@
-// Asset module — status chip (uses shared assetStatusMap)
+// Asset module — status chip (uses shared assetStatusMap for labels,
+// overrides classes per PDF spec page 8: POSTED green · DISPOSED purple ·
+// WRITE-OFF red · FULLY DEPR เทา).
 
 import { Badge } from '@/components/ui/badge';
 import { assetStatusMap, getStatusBadgeProps } from '@/lib/status-badges';
 import type { AssetStatus } from '../types';
 
+// PDF page 8 color spec — per-status Tailwind override.
+// Falls back to the shared map's variant/appearance when unset.
+const STATUS_CLASS_OVERRIDE: Record<string, string> = {
+  DRAFT: 'bg-muted text-muted-foreground',
+  POSTED: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400',
+  REVERSED: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  DISPOSED: 'bg-purple-500/15 text-purple-700 dark:text-purple-400',
+  WRITTEN_OFF: 'bg-red-500/15 text-red-700 dark:text-red-400',
+  FULLY_DEPRECIATED: 'bg-zinc-500/15 text-zinc-700 dark:text-zinc-400',
+};
+
 export function AssetStatusBadge({ status }: { status: AssetStatus }) {
   const cfg = getStatusBadgeProps(status, assetStatusMap);
+  const override = STATUS_CLASS_OVERRIDE[status];
   return (
-    <Badge variant={cfg.variant} appearance={cfg.appearance}>
+    <Badge
+      variant={cfg.variant}
+      appearance={cfg.appearance}
+      className={override}
+    >
       {cfg.label}
     </Badge>
   );

--- a/apps/web/src/pages/assets/hooks/__tests__/no-hardcoded-account-name.test.ts
+++ b/apps/web/src/pages/assets/hooks/__tests__/no-hardcoded-account-name.test.ts
@@ -1,0 +1,63 @@
+// Anti-regression test for P13 SSOT (PR #847 / accountant ImplementationReview v1.2 page 11).
+//
+// Rule: account names rendered in JE preview MUST come from the chart_of_accounts
+// (via useCoaByCodes / useCoaGroups) — NEVER hardcoded in the calculation hook.
+//
+// Hardcoding example (BAD — what this test catches):
+//   accountName: 'Dr ภาษีซื้อ'
+//   accountName: `Cr WHT ${formType}`
+//
+// Correct pattern (what should be in the hook):
+//   accountName: accountName(values.vatAccount)   // resolved via useCoaByCodes lookup
+//
+// If this test fails, it means a developer added a hardcoded accountName literal.
+// Replace it with a lookup against the CoA map (see existing pattern in the hook).
+
+import { describe, it, expect } from 'vitest';
+// Vite's ?raw suffix imports file contents as a string at build/test time —
+// no Node fs API required, keeping this test web-tsconfig-friendly.
+import useAssetCalculationSource from '../useAssetCalculation.ts?raw';
+import useDisposalCalculationSource from '../useDisposalCalculation.ts?raw';
+
+const FILES_UNDER_RULE: Array<{ name: string; source: string }> = [
+  { name: 'useAssetCalculation.ts', source: useAssetCalculationSource },
+  { name: 'useDisposalCalculation.ts', source: useDisposalCalculationSource },
+];
+
+// Forbidden patterns: accountName followed by a string literal (single, double, or template).
+// We allow: accountName: accountName(...) — function call returning a looked-up name.
+// We also allow `code` (the fallback when CoA hasn't loaded — see hook implementation).
+const FORBIDDEN_PATTERNS: RegExp[] = [
+  /accountName:\s*'[^']+'/,             // accountName: 'literal'
+  /accountName:\s*"[^"]+"/,             // accountName: "literal"
+  /accountName:\s*`[^`]*\$\{[^}]*\}[^`]*`/,  // accountName: `template ${var}`
+  /accountName:\s*`[^`]+`/,             // accountName: `static template`
+];
+
+describe('P13 SSOT — no hardcoded accountName in asset calculation hooks', () => {
+  for (const { name, source } of FILES_UNDER_RULE) {
+    it(`${name} has no hardcoded accountName literal`, () => {
+      const lines = source.split('\n');
+
+      const violations: string[] = [];
+      lines.forEach((line: string, idx: number) => {
+        for (const pattern of FORBIDDEN_PATTERNS) {
+          if (pattern.test(line)) {
+            violations.push(`  Line ${idx + 1}: ${line.trim()}`);
+            break;
+          }
+        }
+      });
+
+      if (violations.length > 0) {
+        throw new Error(
+          `Found hardcoded accountName literal(s) in ${name}:\n${violations.join('\n')}\n\n` +
+            `Fix: use the accountName() lookup helper from useCoaByCodes. ` +
+            `See PR #847 commit acb94627 for the pattern.`,
+        );
+      }
+
+      expect(violations).toHaveLength(0);
+    });
+  }
+});

--- a/apps/web/src/pages/assets/hooks/useAssetCalculation.ts
+++ b/apps/web/src/pages/assets/hooks/useAssetCalculation.ts
@@ -1,6 +1,12 @@
 // Asset module — derived-value hook (memoized VAT/WHT/totals + JE preview)
+//
+// P13 (PDF page 11+13): account names MUST come from chart_of_accounts via
+// `/chart-of-accounts/by-codes` — no hardcoded strings, no Dr/Cr prefixes.
+// The render layer shows DR/CR amounts in dedicated columns, so the name
+// column should carry only the real bookkeeping name.
 
 import { useMemo } from 'react';
+import { useCoaByCodes } from '@/hooks/useCoa';
 import type { AssetEntryFormValues } from '../schema';
 import { CATEGORY_COA } from '../types';
 
@@ -30,6 +36,31 @@ const round2 = (n: number) => Math.round(n * 100) / 100;
 const round4 = (n: number) => Math.round(n * 10000) / 10000;
 
 export function useAssetCalculation(values: Partial<AssetEntryFormValues>): CalculationResult {
+  // Collect candidate account codes BEFORE the JE memo so we can resolve
+  // names via the CoA endpoint. The set is small (≤4 distinct codes) and the
+  // hook is cached with staleTime: Infinity.
+  const candidateCodes = useMemo(() => {
+    const cat = values.category;
+    const coa = cat ? CATEGORY_COA[cat] : null;
+    const codes: string[] = [];
+    if (coa) codes.push(coa.cost);
+    if (values.vatAccount) codes.push(values.vatAccount);
+    if (values.whtAccount) codes.push(values.whtAccount);
+    if (values.paymentAccount) codes.push(values.paymentAccount);
+    return Array.from(new Set(codes.filter(Boolean)));
+  }, [values.category, values.vatAccount, values.whtAccount, values.paymentAccount]);
+
+  const { data: coaRows } = useCoaByCodes(candidateCodes);
+  const nameByCode = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const r of coaRows ?? []) map.set(r.code, r.name);
+    return map;
+  }, [coaRows]);
+  // Fallback to the code itself while CoA data is loading or unknown — avoids
+  // rendering "undefined" / empty cell. The real name backfills once the query
+  // resolves (React Query re-renders the consumer).
+  const accountName = (code: string) => nameByCode.get(code) ?? code;
+
   return useMemo(() => {
     const basePriceRaw = Number(values.basePrice) || 0;
     const shipping = Number(values.shippingCost) || 0;
@@ -62,14 +93,14 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
     const totalPayable = round2(purchaseCost + vatAmount - whtAmount);
     const monthlyDepr = round4((purchaseCost - residual) / usefulLife);
 
-    // JE preview lines
+    // JE preview lines — names resolved from chart_of_accounts (P13).
     const cat = values.category;
     const coa = cat ? CATEGORY_COA[cat] : null;
     const lines: JournalLine[] = [];
     if (coa && purchaseCost > 0) {
       lines.push({
         accountCode: coa.cost,
-        accountName: `Dr ${cat} cost`,
+        accountName: accountName(coa.cost),
         debit: purchaseCost,
         credit: 0,
       });
@@ -77,7 +108,7 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
     if (values.hasVat && vatAmount > 0 && values.vatAccount) {
       lines.push({
         accountCode: values.vatAccount,
-        accountName: 'Dr ภาษีซื้อ',
+        accountName: accountName(values.vatAccount),
         debit: vatAmount,
         credit: 0,
       });
@@ -85,7 +116,7 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
     if (values.hasWht && whtAmount > 0 && values.whtAccount) {
       lines.push({
         accountCode: values.whtAccount,
-        accountName: `Cr WHT ${values.whtFormType ?? ''}`,
+        accountName: accountName(values.whtAccount),
         debit: 0,
         credit: whtAmount,
       });
@@ -93,7 +124,7 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
     if (values.paymentAccount && totalPayable > 0) {
       lines.push({
         accountCode: values.paymentAccount,
-        accountName: 'Cr ชำระเงิน',
+        accountName: accountName(values.paymentAccount),
         debit: 0,
         credit: totalPayable,
       });
@@ -117,5 +148,8 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
       totalCr: round2(totalCr),
       isBalanced,
     };
-  }, [values]);
+    // accountName() depends on nameByCode; including the map ensures the lines
+    // re-resolve once CoA data lands.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values, nameByCode]);
 }

--- a/apps/web/src/pages/assets/hooks/useAssetCalculation.ts
+++ b/apps/web/src/pages/assets/hooks/useAssetCalculation.ts
@@ -21,6 +21,8 @@ export interface CalculationResult {
   monthlyDepr: number;
   netBookValue: number;
   journalLines: JournalLine[];
+  totalDr: number;
+  totalCr: number;
   isBalanced: boolean;
 }
 
@@ -111,6 +113,8 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
       monthlyDepr,
       netBookValue: purchaseCost,
       journalLines: lines,
+      totalDr: round2(totalDr),
+      totalCr: round2(totalCr),
       isBalanced,
     };
   }, [values]);

--- a/apps/web/src/pages/assets/hooks/useDisposalCalculation.ts
+++ b/apps/web/src/pages/assets/hooks/useDisposalCalculation.ts
@@ -4,9 +4,13 @@
 // All money arithmetic uses decimal.js to avoid IEEE-754 floating-point drift.
 // `isBalanced` gates form submission, so a 0.01 drift could silently block valid
 // disposals or allow unbalanced JEs through.
+//
+// P13 (PDF page 11+13): account names come from chart_of_accounts via
+// `/chart-of-accounts/by-codes` — no hardcoded strings, no Dr/Cr prefixes.
 
 import { useMemo } from 'react';
 import Decimal from 'decimal.js';
+import { useCoaByCodes } from '@/hooks/useCoa';
 import type { Asset, DisposalCalculation } from '../types';
 import { CATEGORY_COA } from '../types';
 import type { DisposalFormValues } from '../disposal-schema';
@@ -20,6 +24,31 @@ export function useDisposalCalculation(
   asset: Asset | undefined,
   values: Partial<DisposalFormValues>,
 ): DisposalCalculation {
+  // Collect candidate codes BEFORE the JE memo so we can resolve names via CoA.
+  // Disposal touches at most 5 distinct codes; `useCoaByCodes` is cached.
+  const candidateCodes = useMemo(() => {
+    const codes: string[] = [];
+    if (asset) {
+      const coa = CATEGORY_COA[asset.category];
+      codes.push(asset.coaDeprAccount ?? coa.accDepr);
+      codes.push(asset.coaCostAccount ?? coa.cost);
+    }
+    if (values.depositAccountCode) codes.push(values.depositAccountCode);
+    codes.push('53-1605'); // loss on disposal
+    codes.push('42-1105'); // gain on disposal
+    return Array.from(new Set(codes.filter(Boolean)));
+  }, [asset, values.depositAccountCode]);
+
+  const { data: coaRows } = useCoaByCodes(candidateCodes);
+  const nameByCode = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const r of coaRows ?? []) map.set(r.code, r.name);
+    return map;
+  }, [coaRows]);
+  // Fallback to the code itself while CoA data loads — backfills once the
+  // React Query resolves.
+  const accountName = (code: string) => nameByCode.get(code) ?? code;
+
   return useMemo(() => {
     if (!asset) {
       return {
@@ -48,9 +77,10 @@ export function useDisposalCalculation(
     }> = [];
 
     if (accumulatedDepr.gt(0)) {
+      const code = asset.coaDeprAccount ?? coa.accDepr;
       lines.push({
-        accountCode: asset.coaDeprAccount ?? coa.accDepr,
-        accountName: 'Dr ค่าเสื่อมราคาสะสม',
+        accountCode: code,
+        accountName: accountName(code),
         debit: accumulatedDepr,
         credit: ZERO,
       });
@@ -62,7 +92,7 @@ export function useDisposalCalculation(
     ) {
       lines.push({
         accountCode: values.depositAccountCode,
-        accountName: 'Dr เงินสด/ธนาคาร',
+        accountName: accountName(values.depositAccountCode),
         debit: proceeds,
         credit: ZERO,
       });
@@ -70,21 +100,24 @@ export function useDisposalCalculation(
     if (gainLoss.lt(0)) {
       lines.push({
         accountCode: '53-1605',
-        accountName: 'Dr ขาดทุนจากการจำหน่าย',
+        accountName: accountName('53-1605'),
         debit: round2(gainLoss.negated()),
         credit: ZERO,
       });
     }
-    lines.push({
-      accountCode: asset.coaCostAccount ?? coa.cost,
-      accountName: 'Cr สินทรัพย์',
-      debit: ZERO,
-      credit: purchaseCost,
-    });
+    {
+      const code = asset.coaCostAccount ?? coa.cost;
+      lines.push({
+        accountCode: code,
+        accountName: accountName(code),
+        debit: ZERO,
+        credit: purchaseCost,
+      });
+    }
     if (gainLoss.gt(0)) {
       lines.push({
         accountCode: '42-1105',
-        accountName: 'Cr กำไรจากการจำหน่าย',
+        accountName: accountName('42-1105'),
         debit: ZERO,
         credit: round2(gainLoss),
       });
@@ -106,5 +139,8 @@ export function useDisposalCalculation(
       })),
       isBalanced,
     };
-  }, [asset, values]);
+    // accountName() depends on nameByCode; including the map ensures lines
+    // re-resolve once CoA data lands.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asset, values, nameByCode]);
 }

--- a/apps/web/src/pages/depreciation/DepreciationPage.tsx
+++ b/apps/web/src/pages/depreciation/DepreciationPage.tsx
@@ -6,7 +6,7 @@ import { useState, useMemo, type ReactNode } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import Decimal from 'decimal.js';
-import { TrendingDown, Undo2 } from 'lucide-react';
+import { TrendingDown, RotateCcw } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -137,13 +137,14 @@ export default function DepreciationPage() {
         render: (row: RunRow): ReactNode =>
           row.status === 'POSTED' ? (
             <Button
-              size="icon"
-              mode="icon"
+              type="button"
+              size="sm"
               variant="ghost"
               aria-label="กลับรายการ"
               onClick={() => setReverseTargetPeriod(row.period)}
             >
-              <Undo2 className="size-4" />
+              <RotateCcw className="size-3.5 mr-1" />
+              กลับรายการ
             </Button>
           ) : null,
       },

--- a/docs/superpowers/plans/2026-05-15-asset-ui-polish-pr2b.md
+++ b/docs/superpowers/plans/2026-05-15-asset-ui-polish-pr2b.md
@@ -1,0 +1,392 @@
+# Asset UI Polish PR 2b — Implementation Plan
+
+> All implementer + reviewer subagents use `model="opus"` per owner directive.
+
+**Goal:** Ship final 9 items P9-P17 from accountant ImplementationReview v1.2 (Day 3).
+
+**Architecture:** UI-only changes for P9/P11/P12/P14/P15/P16/P17. P10 is medium (group cards refactor). P13 is the largest (cross-cutting account-name join, backend + frontend).
+
+**Spec:** [docs/superpowers/specs/2026-05-15-asset-ui-polish-pr2b-design.md](../specs/2026-05-15-asset-ui-polish-pr2b-design.md)
+
+---
+
+## File Structure (summary)
+
+See spec §12 for full file list. Key files:
+- `AssetEntryPage.tsx` (P9 sticky footer)
+- `AssetSummaryReportPage.tsx` (P10 group cards — biggest UI refactor)
+- `AssetRegisterPage.tsx` (P11+P12+P16)
+- `AssetEntrySection2Cost.tsx` (P15 VAT/WHT styling)
+- `AssetsListPage.tsx` (P14 breadcrumb)
+- `AssetStatusBadge.tsx` (P16 colors)
+- `DepreciationPage.tsx` (P17 reverse button)
+- JE preview render sites (P13 chart_of_accounts join — multiple files)
+
+---
+
+## Task 1: Small UI polish bundle (P11 + P12 + P14 + P15)
+
+These are all small CSS/JSX edits — bundle into one commit.
+
+- [ ] **Step 1: P11 filter row baseline**
+
+`apps/web/src/pages/assets/AssetRegisterPage.tsx` — find the filter row (date picker + dropdowns + search input). Wrap each control in `<div className="space-y-1">` with consistent label-input structure. Ensure parent grid uses `items-end` or set label height uniformly.
+
+- [ ] **Step 2: P12 table header styling**
+
+Same file — find the `<TableHead>` / `<thead>` element of the main register table. Add Tailwind classes for contrast: `bg-muted/60` + `font-semibold` + `border-b-2`. Match existing table patterns elsewhere in the codebase if a richer pattern exists.
+
+- [ ] **Step 3: P14 breadcrumb**
+
+`apps/web/src/pages/assets/AssetsListPage.tsx` — add Breadcrumb component above `<PageHeader>`. First check whether `<PageHeader>` already accepts a `breadcrumb` prop:
+
+```bash
+grep -n "breadcrumb" apps/web/src/components/ui/PageHeader.tsx
+```
+
+If yes, pass:
+```tsx
+<PageHeader
+  breadcrumb={[
+    { label: 'หน้าหลัก', href: '/' },
+    { label: 'สินทรัพย์', href: '/assets' },
+    { label: 'รายการเอกสารทั้งหมด' },
+  ]}
+  ...existing props
+/>
+```
+
+If `PageHeader` doesn't accept a breadcrumb prop, render a standalone `<Breadcrumb>` component above PageHeader.
+
+- [ ] **Step 4: P15 VAT/WHT subsection styling**
+
+`apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx` — find the VAT toggle block and WHT toggle block. Wrap each:
+
+```tsx
+{/* VAT block */}
+<div className="border-l-4 border-violet-500 bg-violet-50/30 dark:bg-violet-950/30 rounded-r-lg p-3 space-y-3">
+  {/* existing VAT inputs */}
+</div>
+
+{/* WHT block */}
+<div className="border-l-4 border-amber-500 bg-amber-50/30 dark:bg-amber-950/30 rounded-r-lg p-3 space-y-3">
+  {/* existing WHT inputs */}
+</div>
+```
+
+- [ ] **Step 5: Type check + commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.claude/worktrees/asset-ui-polish-pr2b && ./tools/check-types.sh web
+```
+
+```bash
+git add -A && git commit -m "feat(assets): P11+P12+P14+P15 small UI polish (filter alignment, table header, breadcrumb, VAT/WHT styling)"
+```
+
+---
+
+## Task 2: P9 Sticky Footer
+
+`apps/web/src/pages/assets/AssetEntryPage.tsx` — convert the bottom button row to a sticky footer.
+
+- [ ] **Step 1: Locate current button row**
+
+```bash
+grep -n "ยกเลิก\|บันทึกร่าง\|บันทึก.*POST" apps/web/src/pages/assets/AssetEntryPage.tsx
+```
+
+- [ ] **Step 2: Wrap in sticky container**
+
+Replace the existing button row's parent `<div>` with:
+
+```tsx
+<div className="sticky bottom-0 z-10 -mx-4 px-4 py-3 bg-background/95 backdrop-blur border-t border-border">
+  <div className="flex items-center justify-between gap-3 max-w-screen-lg mx-auto">
+    <div className="flex items-center gap-2 text-xs">
+      {/* Validation summary */}
+      {errorKeys.length > 0 ? (
+        <span className="inline-flex items-center gap-1 text-destructive">
+          <AlertCircle className="size-3.5" />
+          พบ {errorKeys.length} ข้อผิดพลาด
+        </span>
+      ) : (
+        <span className="inline-flex items-center gap-1 text-emerald-600">
+          <CheckCircle2 className="size-3.5" />
+          ผ่านการตรวจสอบ
+        </span>
+      )}
+      {calc?.isBalanced && (
+        <span className="inline-flex items-center gap-1 text-emerald-600 ml-2">
+          Σ Dr = Σ Cr ({formatNumberDecimal(calc.totalDr ?? 0)})
+        </span>
+      )}
+    </div>
+    <div className="flex items-center gap-2">
+      {/* existing buttons: ยกเลิก / บันทึกร่าง / บันทึก & POST */}
+    </div>
+  </div>
+</div>
+```
+
+(Adapt variable names like `errorKeys` and `calc` to match what's actually in scope at the bottom of the component. Verify with grep.)
+
+- [ ] **Step 3: Type check + commit**
+
+```bash
+git add apps/web/src/pages/assets/AssetEntryPage.tsx && git commit -m "feat(assets): P9 sticky footer with validation status + action buttons"
+```
+
+---
+
+## Task 3: P17 Reverse button in depreciation history
+
+`apps/web/src/pages/depreciation/DepreciationPage.tsx`
+
+- [ ] **Step 1: Locate history table action column**
+
+```bash
+grep -n "history\|action\|ประวัติ" apps/web/src/pages/depreciation/DepreciationPage.tsx
+```
+
+- [ ] **Step 2: Check for existing reverse mutation**
+
+```bash
+grep -rn "reverse\|gainsay\|cancel" apps/web/src/pages/depreciation/
+```
+
+If a reverse mutation hook exists, reuse it. If not, identify the API endpoint by checking apps/api/src/modules/depreciation for a POST `:id/reverse` or similar.
+
+- [ ] **Step 3: Add Reverse button**
+
+For each row in the history table, conditionally render:
+
+```tsx
+{row.status === 'POSTED' && (
+  <Button variant="ghost" size="sm" onClick={() => openReverseDialog(row.id)}>
+    <RotateCcw className="size-3.5 mr-1" /> กลับรายการ
+  </Button>
+)}
+```
+
+Add a confirm dialog before performing the reverse. Reuse existing `ConfirmDialog` pattern from the codebase.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat(depreciation): P17 reverse button in monthly run history table"
+```
+
+---
+
+## Task 4: P16 PDF Export + Status Badge colors
+
+### Part A — PDF Export
+
+`apps/web/src/pages/assets/AssetRegisterPage.tsx`
+
+- [ ] **Step 1: Locate existing export buttons (CSV + Excel)**
+
+```bash
+grep -n "Export\|CSV\|Excel" apps/web/src/pages/assets/AssetRegisterPage.tsx
+```
+
+- [ ] **Step 2: Add PDF print button**
+
+Simplest approach — `window.print()` with print-friendly CSS:
+
+```tsx
+<Button variant="outline" size="sm" onClick={() => window.print()}>
+  <FileText className="size-4 mr-1" /> พิมพ์ PDF
+</Button>
+```
+
+Then add a print stylesheet section at the top of the file or in a sibling `.css` to ensure the register table prints cleanly:
+
+```tsx
+<style media="print">{`
+  .no-print { display: none !important; }
+  /* hide sidebar / filters / actions when printing */
+`}</style>
+```
+
+Or check if `apps/web/src/index.css` already has print-friendly classes.
+
+### Part B — Status Badge colors
+
+`apps/web/src/pages/assets/components/AssetStatusBadge.tsx`
+
+- [ ] **Step 3: Update color map**
+
+```tsx
+const STATUS_VARIANT = {
+  DRAFT:       'bg-muted text-muted-foreground',
+  POSTED:      'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400',
+  REVERSED:    'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  DISPOSED:    'bg-purple-500/15 text-purple-700 dark:text-purple-400',
+  WRITTEN_OFF: 'bg-red-500/15 text-red-700 dark:text-red-400',
+  FULLY_DEPR:  'bg-zinc-500/15 text-zinc-700 dark:text-zinc-400',
+};
+```
+
+(Verify the existing status enum values and adapt — `FULLY_DEPR` may not be a real persisted status; could be a derived UI-only status. Check before adding.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat(assets): P16 PDF print button + status badge color coding"
+```
+
+---
+
+## Task 5: P10 Group Cards Summary Report
+
+`apps/web/src/pages/assets/AssetSummaryReportPage.tsx` — refactor `category` tab from flat table to group cards.
+
+- [ ] **Step 1: Inspect current category-tab structure**
+
+```bash
+sed -n '100,150p' apps/web/src/pages/assets/AssetSummaryReportPage.tsx
+```
+
+- [ ] **Step 2: Group data by category client-side**
+
+The API returns a flat list. Group in a `useMemo`:
+
+```tsx
+const grouped = useMemo(() => {
+  const map = new Map<AssetCategory, SummaryRow[]>();
+  for (const row of rows ?? []) {
+    if (!map.has(row.category)) map.set(row.category, []);
+    map.get(row.category)!.push(row);
+  }
+  return Array.from(map.entries());
+}, [rows]);
+```
+
+- [ ] **Step 3: Render group cards**
+
+For each category, render a `<Card>` with:
+- `<CardHeader>` showing category icon + Thai name + 3 totals (sum within group)
+- `<CardContent>` with the existing table for items in this category + subtotal row
+
+After all groups, render a Grand Total footer card.
+
+- [ ] **Step 4: Type check + commit**
+
+```bash
+./tools/check-types.sh web && git add -A && git commit -m "feat(assets): P10 group cards summary report with grand total"
+```
+
+---
+
+## Task 6: P13 Chart of Accounts join (cross-cutting)
+
+This is the largest task. Render account codes WITH names everywhere.
+
+- [ ] **Step 1: Enumerate render sites for accountCode**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.claude/worktrees/asset-ui-polish-pr2b && grep -rn "accountCode" apps/web/src/pages/assets apps/web/src/pages/depreciation | head -30
+```
+
+Identify each site. For each, check if the data shape already includes `accountName` (via API include) or not.
+
+- [ ] **Step 2: For sites where accountName is already available, render it**
+
+Change e.g.:
+```tsx
+<span className="font-mono">{line.accountCode}</span>
+```
+
+to:
+```tsx
+<span className="font-mono">{line.accountCode}</span>
+<span className="text-muted-foreground ml-1">{line.accountName ?? ''}</span>
+```
+
+- [ ] **Step 3: For sites where accountName is NOT available, identify the API + add the join**
+
+Search for endpoints that return JournalEntryLine without `chartOfAccount` include:
+
+```bash
+grep -rn "findMany\|findUnique\|findFirst" apps/api/src/modules/journal apps/api/src/modules/depreciation 2>/dev/null | grep -i "journalEntryLine\|JournalEntryLine" | head -10
+```
+
+For each query missing the `chartOfAccount` include, add:
+
+```ts
+include: {
+  chartOfAccount: {
+    select: { code: true, name: true },
+  },
+}
+```
+
+Then update the response DTO type to include `chartOfAccount: { code: string; name: string } | null` on the line.
+
+- [ ] **Step 4: For frontend rendering, prefer the joined data**
+
+Use `line.chartOfAccount?.name ?? line.accountName ?? ''` to gracefully degrade if old data lacks the join.
+
+- [ ] **Step 5: Anti-regression test**
+
+Add a small jest test asserting that the API endpoint for `/depreciation/preview` or `/assets/:id/journal-preview` (whichever exists) includes account names:
+
+```ts
+it('JE preview includes account name from chart_of_accounts', async () => {
+  const result = await controller.preview(...);
+  expect(result.lines[0].chartOfAccount?.name).toBeDefined();
+});
+```
+
+(Adapt the controller / method names to what exists. If the endpoint doesn't exist as such, find the closest equivalent.)
+
+- [ ] **Step 6: Type check + commit**
+
+```bash
+./tools/check-types.sh all && git add -A && git commit -m "feat(assets): P13 chart_of_accounts join — render account names everywhere, no hardcode"
+```
+
+---
+
+## Task 7: Final integration
+
+- [ ] **Step 1: Type check**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE/.claude/worktrees/asset-ui-polish-pr2b && ./tools/check-types.sh all
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 2: All tests**
+
+```bash
+cd apps/web && npx vitest run src/pages/assets/__tests__/ src/pages/depreciation/__tests__/
+cd ../api && npx jest src/modules/asset/__tests__/ src/modules/depreciation/__tests__/ 2>&1 | tail -10
+```
+
+Expected: existing pass (~22 from PR #846), new tests added by P13 Task 6 also pass.
+
+- [ ] **Step 3: NBV terminology re-grep**
+
+```bash
+grep -rn "'NBV'\|\"NBV\"\|>NBV<" apps/web/src 2>/dev/null | grep -v "//\|netBookValue\|\bnbv\b"
+```
+
+Expected: 0 (carried from PR #846).
+
+- [ ] **Step 4: Manual UAT checklist (post-deploy)**
+
+For each role (OWNER / FINANCE_MANAGER / ACCOUNTANT):
+- [ ] `/assets/new` → Section 2 → VAT block has violet border + WHT block has amber border (P15)
+- [ ] `/assets/new` → bottom of form → sticky footer with validation chip + 3 buttons (P9)
+- [ ] `/assets` → top of page → Breadcrumb (P14)
+- [ ] `/assets/register` → filter row aligned (P11), thead styled (P12), PDF button works (P16a), status badges colored (P16b)
+- [ ] `/assets/summary-report` → category tab shows group cards + grand total (P10)
+- [ ] `/depreciation` → history table has Reverse button on POSTED rows (P17)
+- [ ] `/assets/new` → Section 4 JE preview → each row shows "53-1601 ค่าเสื่อมราคา-อุปกรณ์" (code + name) (P13)
+- [ ] `/depreciation` Preview JV → same code + name format (P13)
+
+- [ ] **Step 5: No additional commit. Branch ready for PR.**

--- a/docs/superpowers/specs/2026-05-15-asset-ui-polish-pr2b-design.md
+++ b/docs/superpowers/specs/2026-05-15-asset-ui-polish-pr2b-design.md
@@ -1,0 +1,208 @@
+# Asset Module — PR 2b Design: P9-P17 (Day 3 polish + chart-of-accounts join)
+
+**Date:** 2026-05-15
+**Branch:** `feat/asset-ui-polish-pr2b` (off PR #846 `feat/asset-ui-polish-pr2a`)
+**Scope:** Last 9 items P9-P17 from accountant's ImplementationReview v1.2 Day 3
+**Effort:** ~7-8 hours (accountant estimated 4.5hr but P10 + P13 are larger than estimated)
+
+---
+
+## 1. Context
+
+PR #845 shipped P1+P2. PR #846 shipped P3-P8. This PR ships **P9-P17** — completing the 17-item accountant backlog.
+
+Owner directive remains: **"ทำตาม PDF เท่านั้น"** + use Opus for all subagent dispatches.
+
+---
+
+## 2. Scope per PDF §8 (Action Plan rows 9-17)
+
+| # | Page | Change | ETA |
+|---|------|--------|-----|
+| **P9** | AssetEntryPage (whole form) | Sticky Footer with validation status + buttons (ยกเลิก / บันทึกร่าง / บันทึก & POST) | 1hr |
+| **P10** | AssetSummaryReportPage | flat table → Group Cards per category + Grand Total footer | 2hr |
+| **P11** | AssetRegisterPage | Align "ณ วันที่" date picker baseline with adjacent filter dropdowns | 15min |
+| **P12** | AssetRegisterPage | `<thead>` background gradient + bolder font for contrast vs body rows | 15min |
+| **P13** | Cross-cutting (JE preview + Reports + Schedule) | Account codes must render with account name from chart_of_accounts (join, no hardcode) | 1hr |
+| **P14** | AssetsListPage | Breadcrumb "หน้าหลัก › assets › รายการเอกสารทั้งหมด" | 30min |
+| **P15** | AssetEntrySection2Cost | VAT subsection violet border-left · WHT subsection amber border-left | 30min |
+| **P16** | AssetRegisterPage | (a) PDF Export button + (b) Status Badge colors (POSTED green / DISPOSED purple / WRITE-OFF red / FULLY DEPR gray) | 1hr |
+| **P17** | DepreciationPage | Reverse button in history table action column | 1hr |
+
+**Total: 7.5 hours**
+
+### P13 — Chart of Accounts join (architectural)
+
+PDF page 11+13 (P13):
+> รหัสบัญชี ต้องแสดงชื่อบัญชีต่อท้ายทุกที่ (เช่น "53-1601 [ชื่อบัญชี]") ดึงจาก ผังบัญชี (Chart of Accounts) ห้าม hardcode — Backend join journal_entry_line × chart_of_accounts บน account_code
+
+**Approach:**
+1. Verify whether existing `JournalEntryLine` queries already include `chartOfAccount` relation; if not, add the include in relevant services
+2. Frontend rendering layer: change every place that shows just `accountCode` to also show `accountName` (from joined data)
+3. No hardcoded account name maps in TS/React — must come from DB
+
+**Out of scope:**
+- Renaming any existing `accountCode` field
+- Adding account name to API responses that don't currently include it (only modify places where we already have the data via existing relations)
+- Backfilling missing chart_of_accounts seed data — assume the seed is correct
+
+If the API doesn't already return account names, add the include + adjust the response DTO. This may touch journal-related endpoints.
+
+---
+
+## 3. P9 — Sticky Footer
+
+`AssetEntryPage.tsx` currently has buttons inline at the bottom. Move to a `<div className="sticky bottom-0 ...">` that always shows:
+- Validation summary chip (passes V1-V15 / "x errors")
+- Σ Dr = Σ Cr indicator (from JE preview)
+- 3 buttons: ยกเลิก / บันทึกร่าง / บันทึก & POST (with appropriate disabled states)
+
+---
+
+## 4. P10 — Group Cards (Summary Report)
+
+Current `AssetSummaryReportPage.tsx` `category` tab renders a flat table. Target per PDF page 10:
+
+```
+┌─ EQUIPMENT (อุปกรณ์สำนักงาน) ─── ราคาทุน 50,000 · ค่าเสื่อมสะสม 10,000 · NBV 40,000 ┐
+│ [items table 1...n]                                                                  │
+│ subtotal row: ราคาทุน / Acc.Depr / NBV                                                │
+└──────────────────────────────────────────────────────────────────────────────────────┘
+┌─ IMPROVEMENT (ปรับปรุงสำนักงาน) ─── ราคาทุน X · Acc.Depr Y · NBV Z ┐
+│ ...                                                                  │
+└──────────────────────────────────────────────────────────────────────┘
+
+Grand Total: ราคาทุนรวม · ค่าเสื่อมสะสมรวม · มูลค่าตามบัญชีสุทธิ (NBV) รวม
+```
+
+Each Group Card has:
+- Header: category icon + Thai name + 3 totals
+- Body: items table (existing columns)
+- Footer: subtotal row
+
+Grand Total: footer below all cards aggregating across categories.
+
+---
+
+## 5. P11 — Filter row baseline alignment
+
+`AssetRegisterPage.tsx` filter row currently has label-above-input pattern. The "ณ วันที่" date picker has its label rendered slightly different from dropdown labels causing baseline drift.
+
+Fix: wrap each filter control in a consistent `<div className="space-y-1">` with label first then input. Use `items-end` on the parent grid OR uniform label height.
+
+---
+
+## 6. P12 — Table header styling
+
+`AssetRegisterPage.tsx` `<thead>` currently has minimal styling. Add:
+- Background gradient (e.g. `bg-gradient-to-b from-muted/80 to-muted/40` or `bg-muted/60`)
+- `font-semibold` or `font-bold` for column headers
+- Optional: border-bottom-2 for contrast
+
+Match patterns from other tables in the codebase if any exist.
+
+---
+
+## 7. P13 — Account name from chart_of_accounts join
+
+Files affected:
+- Backend: any service that returns JournalEntryLine with accountCode but no accountName — add `chartOfAccount` include
+- Frontend: render `${accountCode} ${accountName}` everywhere we currently show `accountCode` alone
+- Specifically check:
+  - JE preview in AssetEntrySection4Journal
+  - JE preview in Depreciation/Disposal pages
+  - Journal listing in AssetJournalPage (already-fetched data — verify shape)
+  - any schedule/report tables
+
+Concrete steps:
+1. Grep `accountCode` in frontend asset/depreciation pages
+2. For each render site, check if `accountName` is available in the same record; if not, identify the API endpoint returning the data and amend service to include `chartOfAccount.name`
+3. Update render to show `<code>{code}</code> <span>{name}</span>` (or similar)
+
+---
+
+## 8. P14 — Breadcrumb on List page
+
+Add a Breadcrumb component above the AssetsListPage `PageHeader`:
+
+```tsx
+<Breadcrumb items={[
+  { label: 'หน้าหลัก', href: '/' },
+  { label: 'สินทรัพย์', href: '/assets' },
+  { label: 'รายการเอกสารทั้งหมด' },
+]} />
+```
+
+Reuse existing Breadcrumb component if available (search `apps/web/src/components/` for it).
+
+---
+
+## 9. P15 — VAT/WHT subsection styling
+
+`AssetEntrySection2Cost.tsx` has VAT toggle + WHT toggle sections. Currently renders as plain rows. Target:
+- VAT block: `border-l-4 border-violet-500` + `bg-violet-50/30 dark:bg-violet-950/30`
+- WHT block: `border-l-4 border-amber-500` + `bg-amber-50/30 dark:bg-amber-950/30`
+- Padding + rounded corners for visual grouping
+
+Use semantic color tokens if they exist; otherwise direct Tailwind classes are acceptable (per existing patterns in the codebase).
+
+---
+
+## 10. P16 — PDF Export + Status Badge colors
+
+### P16(a) — PDF Export button
+
+Register page already has CSV + Excel export. Add a "พิมพ์ PDF" button. Approach:
+- Use existing `window.print()` with `@media print` styles, OR
+- Generate PDF client-side using jsPDF/pdfmake (if already in package.json)
+
+Simplest implementation: `window.print()` with print-friendly stylesheet. Test it works for the register table.
+
+### P16(b) — Status Badge colors
+
+Currently `AssetStatusBadge.tsx` may use uniform colors. Per PDF:
+- POSTED → green
+- DISPOSED → purple
+- WRITE-OFF → red
+- FULLY DEPR → gray
+
+Verify current colors, adjust as needed. Use Tailwind semantic tokens (e.g. `bg-emerald-500/15 text-emerald-700`) or shadcn Badge variants.
+
+---
+
+## 11. P17 — Reverse button in depreciation history
+
+`DepreciationPage.tsx` shows a history table of monthly depreciation runs. Add a "Reverse" button in the action column for each POSTED run. Wire to existing reversal endpoint if available.
+
+---
+
+## 12. Files to change
+
+| File | Items |
+|------|-------|
+| `apps/web/src/pages/assets/AssetEntryPage.tsx` | P9 sticky footer |
+| `apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx` | P15 VAT/WHT styling |
+| `apps/web/src/pages/assets/AssetsListPage.tsx` | P14 breadcrumb |
+| `apps/web/src/pages/assets/AssetRegisterPage.tsx` | P11, P12, P16(a), P16(b) |
+| `apps/web/src/pages/assets/AssetSummaryReportPage.tsx` | P10 group cards |
+| `apps/web/src/pages/assets/components/AssetStatusBadge.tsx` | P16(b) |
+| `apps/web/src/pages/depreciation/DepreciationPage.tsx` | P17 reverse |
+| `apps/web/src/pages/depreciation/components/*.tsx` | P13 account name |
+| Possibly: `apps/api/src/modules/journal/*.ts` or `apps/api/src/modules/depreciation/*.ts` | P13 include chartOfAccount |
+
+---
+
+## 13. Out of Scope
+
+- E2E tests (PDF doesn't request)
+- I2 from PR #846 review (existing-data backfill SQL for permissionConfig) — separate manual SQL script
+- Pagination UI in Asset audit log (deferred from PR #845 I4)
+
+---
+
+## 14. References
+
+- PDF: `ImplementationReview_v1.2.pdf` §8 (Action Plan rows 9-17) + earlier sections per page
+- Prior PRs: #845 (P1+P2), #846 (P3-P8)
+- Owner directive (durable): "ทำตาม PDF เท่านั้น"
+- Subagent model: Opus (per `feedback_use_opus_for_all_subagents.md`)


### PR DESCRIPTION
## Summary

PR 2b — Day 3 (P9-P17) จาก accountant ImplementationReview_v1.2 · **ปิดทั้ง 17 items** ของ accountant review ครบเรียบร้อย

- **P9** — Sticky Footer + validation chip + Σ Dr=Σ Cr chip (AssetEntryPage)
- **P10** — Group Cards summary report + Grand Total footer (เฉพาะ category tab)
- **P11** — Filter row baseline alignment
- **P12** — Table header styling (bg + bold contrast)
- **P13** — Chart of Accounts SSOT — 8 hardcoded \`accountName\` literals → \`useCoaByCodes\` lookup
- **P14** — Breadcrumb (หน้าหลัก › รายการเอกสารทั้งหมด)
- **P15** — VAT/WHT subsection styling (violet/amber border-l + bg)
- **P16** — PDF print button + Status Badge color coding
- **P17** — Reverse button label + icon (was icon-only) in Depreciation history

ตาม PDF 100% — ไม่มี scope creep · ใช้ Opus model สำหรับทุก subagent dispatch (per owner directive)

Base = PR #846 (\`feat/asset-ui-polish-pr2a\`) → merge stack: #845 → #846 → this

## Changes (8 commits, ~10 files, +362/-94 + docs)

- \`c4eb22bb\` P11+P12+P14+P15 small UI polish
- \`64879c96\` P9 sticky footer
- \`20160b4b\` P17 reverse button (label + icon)
- \`ffabc096\` P16 PDF print + status badge colors
- \`9e3e223f\` P10 group cards summary
- \`acb94627\` P13 chart_of_accounts join — 8 hardcodes removed
- \`95519401\` docs spec + plan
- \`e8341a64\` fix review I1-I5 — mobile sticky offset, padding, dark variant, breadcrumb, dead key

## P13 Highlight — SSOT compliance

**Before:** 8 hardcoded \`accountName\` strings in \`useAssetCalculation.ts\` + \`useDisposalCalculation.ts\` (e.g. \`'Dr ภาษีซื้อ'\`, \`'Cr ค่าเสื่อมราคาสะสม'\`, \`'Dr ขาดทุนจากการจำหน่าย'\`) — guesses with Dr/Cr prefixes that don't match the real chart_of_accounts seed.

**After:** \`useCoaByCodes(codes)\` lookup from \`/chart-of-accounts/grouped\` (same pattern as PR #759 A.6 + OtherIncome's AutoJournalPreview). JE preview shows real account names from DB — no hardcode anywhere. Dr/Cr prefixes removed (rendered in dedicated columns).

## Tests

- Type check (\`./tools/check-types.sh all\`): **0 errors**
- All asset web tests: **15/15 PASS** (no new tests added — UI-only changes, mostly cosmetic)
- Backend asset module: pre-existing test infra failures (deferred per Acknowledgment §3.2)

## Final Code Review (opus)

PASS — 0 Critical · 6 Important (5 fixed in commit e8341a64 · I6 register status filter pre-existing/out of scope) · 6 Info.

Key catches fixed: I1 mobile sticky-footer hidden behind MobileBottomNav (action buttons unreachable on mobile) · I3 missing dark variant on emerald text · I4 self-linking breadcrumb crumb · I5 unreachable status enum value in badge map.

PDF compliance: **9/9 verified** by reviewer (all P9-P17).

## Test Plan (manual UAT — pre-merge)

- [ ] \`/assets\` → Breadcrumb "หน้าหลัก › รายการเอกสารทั้งหมด" (P14)
- [ ] \`/assets/new\` → Section 2 → VAT block violet · WHT block amber border-l + bg (P15)
- [ ] \`/assets/new\` → form bottom → sticky footer with validation chip + Σ Dr=Σ Cr chip + 3 buttons (P9)
- [ ] \`/assets/new\` → mobile viewport → sticky footer NOT hidden behind MobileBottomNav (I1 fix)
- [ ] \`/assets/new\` → Section 4 JE preview → real account names "12-2101 อุปกรณ์สำนักงาน" (not "Dr EQUIPMENT cost") (P13)
- [ ] \`/assets/register\` → filter row baseline aligned (P11) + thead contrast (P12) + PDF button works (P16a) + status badges colored (P16b)
- [ ] \`/assets/summary-report\` → category tab shows group cards + grand total (P10)
- [ ] \`/depreciation\` → history table → Reverse button shows label "กลับรายการ" + RotateCcw icon (P17)

## Out of Scope (deferred)

- I6 register status filter missing REVERSED+DRAFT — pre-existing
- E2E tests — owner directive
- I2 from PR #846 (existing data backfill of approverId → permissionConfig) — manual SQL one-shot, separate task

🤖 Generated with [Claude Code](https://claude.com/claude-code)