### PR TITLE
feat(asset): 11-4102 → 11-4101 transfer flow when supplier tax invoice arrives

### DIFF
--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -192,6 +192,27 @@ Two accounts look similar; **use them differently**:
 
 Expense module JE templates (`expense-accrual`, `expense-same-day`, `credit-note`) **all** book purchase VAT to **11-4101**. Booking to 11-2104 silently inflates the "ลูกหนี้" line on the balance sheet AND blocks the VAT refund. Anti-regression test exists in each template spec.
 
+### Asset VAT — 11-4102 deferred → 11-4101 transfer flow
+
+Assets can be POSTed before the supplier tax invoice physically arrives (TFRS accrual). For that case the asset entry form lets the user pick `vatAccount = '11-4102' ภาษีซื้อรอเรียกเก็บ` — the purchase JE then books the VAT to 11-4102 instead of 11-4101. Because 11-4102 is NOT claimable on ภ.พ.30, this VAT is parked until the invoice arrives.
+
+When the invoice physically arrives, the user clicks "ใบกำกับมาถึงแล้ว" on `AssetDetailPage`. `AssetService.markInvoiceReceived` runs `AssetInvoiceReceivedTemplate`:
+
+```
+Dr 11-4101 ภาษีซื้อ          [vatAmount]
+   Cr 11-4102 ภาษีซื้อรอเรียกเก็บ [vatAmount]
+```
+
+Guards:
+- Asset must be POSTED + `hasVat` + `vatAccount === '11-4102'` + `!invoiceReceivedAt`
+- V15 period guard uses TODAY (transfer posts to current period — purchaseDate may be in a closed period and that's fine)
+- Idempotent via `metadata.flow = 'asset-invoice-received' + assetId` (mirrors asset-purchase pattern) + unique constraint on `FixedAsset.invoiceTransferJournalEntryId`
+- After success: `asset.vatAccount` flips to `'11-4101'`, `invoiceReceivedAt/ById/JournalEntryId` populated, AuditLog `INVOICE_RECEIVED` written in same `$transaction`
+
+Template: `apps/api/src/modules/journal/cpa-templates/asset-invoice-received.template.ts`
+Endpoint: `POST /assets/:id/invoice-received` (Roles: OWNER, FINANCE_MANAGER, ACCOUNTANT)
+Schema: 3 nullable fields on `FixedAsset` (migration `20260926000000_asset_invoice_received`).
+
 ---
 
 ## V15 — ACCRUAL ห้ามมี WHT (ม.50 ป.รัษฎากร)

--- a/apps/api/prisma/migrations/20260926000000_asset_invoice_received/migration.sql
+++ b/apps/api/prisma/migrations/20260926000000_asset_invoice_received/migration.sql
@@ -1,0 +1,23 @@
+-- 11-4102 → 11-4101 transfer ("ใบกำกับมาถึงแล้ว") tracking.
+-- Additive: 3 nullable columns + 1 unique index + 1 FK + 1 lookup index.
+
+ALTER TABLE "fixed_assets"
+  ADD COLUMN "invoice_received_at"               TIMESTAMP(3),
+  ADD COLUMN "invoice_received_by_id"            TEXT,
+  ADD COLUMN "invoice_transfer_journal_entry_id" TEXT;
+
+CREATE UNIQUE INDEX "fixed_assets_invoice_transfer_journal_entry_id_key"
+  ON "fixed_assets" ("invoice_transfer_journal_entry_id");
+
+CREATE INDEX "fixed_assets_invoice_received_at_idx"
+  ON "fixed_assets" ("invoice_received_at");
+
+ALTER TABLE "fixed_assets"
+  ADD CONSTRAINT "fixed_assets_invoice_received_by_id_fkey"
+  FOREIGN KEY ("invoice_received_by_id") REFERENCES "users" ("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "fixed_assets"
+  ADD CONSTRAINT "fixed_assets_invoice_transfer_journal_entry_id_fkey"
+  FOREIGN KEY ("invoice_transfer_journal_entry_id") REFERENCES "journal_entries" ("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -630,6 +630,7 @@ model User {
   assetsApproved              FixedAsset[]              @relation("AssetApprover")
   assetsPosted                FixedAsset[]              @relation("AssetPostedBy")
   assetsReversed              FixedAsset[]              @relation("AssetReversedBy")
+  assetsInvoiceReceived       FixedAsset[]              @relation("AssetInvoiceReceivedBy")
   assetsTransferred           AssetTransferHistory[]    @relation("AssetTransferredBy")
   depreciationEntriesReversed DepreciationEntry[]       @relation("DepreciationEntryReversedBy")
   todosCreated                Todo[]                    @relation("TodoCreatedBy")
@@ -3142,6 +3143,15 @@ model FixedAsset {
   reversedAt     DateTime? @map("reversed_at")
   reversalReason String?   @map("reversal_reason")
 
+  // 11-4102 → 11-4101 transfer ("ใบกำกับมาถึงแล้ว"). When vatAccount was
+  // 11-4102 at POST (accrual: invoice not yet received), marking the invoice
+  // received transfers deferred input VAT to claimable 11-4101 and pins
+  // vatAccount to 11-4101. Idempotent — invoiceTransferJournalEntryId guards
+  // against double-posting.
+  invoiceReceivedAt             DateTime? @map("invoice_received_at")
+  invoiceReceivedById           String?   @map("invoice_received_by_id")
+  invoiceTransferJournalEntryId String?   @unique @map("invoice_transfer_journal_entry_id")
+
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
@@ -3151,6 +3161,8 @@ model FixedAsset {
   approver            User?                  @relation("AssetApprover", fields: [approverId], references: [id])
   postedBy            User?                  @relation("AssetPostedBy", fields: [postedById], references: [id])
   reversedBy          User?                  @relation("AssetReversedBy", fields: [reversedById], references: [id])
+  invoiceReceivedBy   User?                  @relation("AssetInvoiceReceivedBy", fields: [invoiceReceivedById], references: [id])
+  invoiceTransferJE   JournalEntry?          @relation("AssetInvoiceTransferJE", fields: [invoiceTransferJournalEntryId], references: [id])
   depreciationEntries DepreciationEntry[]
   transferHistory     AssetTransferHistory[]
 
@@ -3159,6 +3171,7 @@ model FixedAsset {
   @@index([purchaseDate])
   @@index([branchId])
   @@index([vendorId])
+  @@index([invoiceReceivedAt])
   @@map("fixed_assets")
 }
 
@@ -3443,6 +3456,7 @@ model JournalEntry {
   createdBy     User                  @relation("JournalCreatedBy", fields: [createdById], references: [id])
   postedBy      User?                 @relation("JournalPostedBy", fields: [postedById], references: [id])
   postAuditLogs JournalPostAuditLog[]
+  assetInvoiceTransferFor FixedAsset? @relation("AssetInvoiceTransferJE")
   // Partial unique index enforced via migration (CREATE UNIQUE INDEX ... WHERE reference_type IS NOT NULL)
   // Prisma cannot express partial @@unique; see migration 20260428010000_journal_entries_ref_unique
 

--- a/apps/api/src/modules/asset/asset.controller.ts
+++ b/apps/api/src/modules/asset/asset.controller.ts
@@ -193,6 +193,15 @@ export class AssetController {
     return this.assetService.reverseDispose(id, dto.reason, userId);
   }
 
+  @Post(':id/invoice-received')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  markInvoiceReceived(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.assetService.markInvoiceReceived(id, userId);
+  }
+
   @Post(':id/copy')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   copy(@Param('id') id: string, @CurrentUser('id') userId: string) {

--- a/apps/api/src/modules/asset/asset.service.ts
+++ b/apps/api/src/modules/asset/asset.service.ts
@@ -14,6 +14,7 @@ import { AssetPurchaseTemplate } from '../journal/cpa-templates/asset-purchase.t
 import { AssetPurchaseReverseTemplate } from '../journal/cpa-templates/asset-purchase-reverse.template';
 import { AssetDisposalTemplate } from '../journal/cpa-templates/asset-disposal.template';
 import { AssetDisposalReverseTemplate } from '../journal/cpa-templates/asset-disposal-reverse.template';
+import { AssetInvoiceReceivedTemplate } from '../journal/cpa-templates/asset-invoice-received.template';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 
 const CATEGORY_PREFIX: Record<AssetCategory, string> = {
@@ -42,6 +43,7 @@ export class AssetService {
     private readonly reverseTemplate: AssetPurchaseReverseTemplate,
     private readonly disposalTemplate: AssetDisposalTemplate,
     private readonly disposalReverseTemplate: AssetDisposalReverseTemplate,
+    private readonly invoiceReceivedTemplate: AssetInvoiceReceivedTemplate,
   ) {}
 
   /**
@@ -953,6 +955,110 @@ export class AssetService {
 
     this.logger.log(
       `[Phase1] REVERSE asset ${asset.assetCode} → ${result.entryNo}`,
+    );
+    return result;
+  }
+
+  /**
+   * Mark a supplier tax invoice as received and transfer the deferred input
+   * VAT from 11-4102 to 11-4101 (claimable).
+   *
+   * Preconditions: asset POSTED, hasVat, vatAccount === '11-4102',
+   * !invoiceReceivedAt. V15 period guard uses TODAY (not purchaseDate) — the
+   * transfer JE posts in the current period.
+   *
+   * Atomic: template (JE post + idempotency + journalPostAuditLog) + asset
+   * field updates + INVOICE_RECEIVED audit log all run in ONE outer
+   * $transaction. After this, vatAccount becomes '11-4101' and the next ภ.พ.30
+   * filing can credit the input VAT.
+   */
+  async markInvoiceReceived(
+    id: string,
+    triggeredById: string,
+  ): Promise<{ entryNo: string; invoiceReceivedAt: Date }> {
+    const asset = await this.prisma.fixedAsset.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!asset) throw new NotFoundException('ไม่พบสินทรัพย์');
+    if (asset.status !== AssetStatus.POSTED) {
+      throw new BadRequestException(
+        `บันทึกใบกำกับมาถึงได้เฉพาะสถานะ POSTED (ปัจจุบัน: ${asset.status})`,
+      );
+    }
+    if (!asset.hasVat) {
+      throw new BadRequestException(
+        'สินทรัพย์นี้ไม่มี VAT — ไม่ต้องโอน 11-4102 → 11-4101',
+      );
+    }
+    if (asset.vatAccount !== '11-4102') {
+      throw new BadRequestException(
+        `ภาษีซื้ออยู่บัญชี ${asset.vatAccount ?? '(ไม่ระบุ)'} แล้ว — ใช้ flow นี้ได้เฉพาะสินทรัพย์ที่บันทึก 11-4102`,
+      );
+    }
+    if (asset.invoiceReceivedAt) {
+      throw new BadRequestException(
+        `บันทึกใบกำกับมาถึงแล้วเมื่อ ${asset.invoiceReceivedAt.toISOString()}`,
+      );
+    }
+
+    // V15: period guard with TODAY (transfer JE posts in current period).
+    const financeCompanyId = await this.getFinanceCompanyId();
+    try {
+      await validatePeriodOpen(this.prisma, new Date(), financeCompanyId);
+    } catch (err: any) {
+      await this.prisma.auditLog.create({
+        data: {
+          userId: triggeredById,
+          action: 'ASSET_INVOICE_RECEIVED_BLOCKED',
+          entity: 'fixed_asset',
+          entityId: id,
+          oldValue: { vatAccount: '11-4102' },
+          newValue: { reason: err?.message ?? 'period closed' },
+        },
+      });
+      throw new BadRequestException(
+        `ไม่สามารถบันทึกใบกำกับ: ${err?.message ?? 'งวดบัญชีปิดแล้ว'}`,
+      );
+    }
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      const inner = await this.invoiceReceivedTemplate.execute(
+        { assetId: id, triggeredById },
+        tx,
+      );
+
+      const now = new Date();
+      await tx.fixedAsset.update({
+        where: { id },
+        data: {
+          vatAccount: '11-4101',
+          invoiceReceivedAt: now,
+          invoiceReceivedById: triggeredById,
+          invoiceTransferJournalEntryId: inner.journalEntryId,
+        },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          userId: triggeredById,
+          action: 'INVOICE_RECEIVED',
+          entity: 'fixed_asset',
+          entityId: id,
+          oldValue: { vatAccount: '11-4102', invoiceReceivedAt: null },
+          newValue: {
+            vatAccount: '11-4101',
+            invoiceReceivedAt: now.toISOString(),
+            transferEntryNumber: inner.entryNo,
+            vatAmount: asset.vatAmount.toString(),
+          },
+        },
+      });
+
+      return { entryNo: inner.entryNo, invoiceReceivedAt: now };
+    });
+
+    this.logger.log(
+      `INVOICE_RECEIVED asset ${asset.assetCode} → ${result.entryNo}`,
     );
     return result;
   }

--- a/apps/api/src/modules/asset/asset.service.ts
+++ b/apps/api/src/modules/asset/asset.service.ts
@@ -484,6 +484,7 @@ export class AssetService {
         approver: { select: { id: true, name: true } },
         postedBy: { select: { id: true, name: true } },
         reversedBy: { select: { id: true, name: true } },
+        invoiceReceivedBy: { select: { id: true, name: true } },
         transferHistory: {
           orderBy: { transferDate: 'desc' },
           take: 10,
@@ -1028,8 +1029,21 @@ export class AssetService {
       );
 
       const now = new Date();
-      await tx.fixedAsset.update({
-        where: { id },
+      // TOCTOU guard: precondition checks above ran outside this tx, so two
+      // concurrent clicks could both reach here. Use updateMany with a
+      // composite where-clause + rowCount check so the second caller's update
+      // affects 0 rows and we throw to roll the whole tx back (including the
+      // duplicate JE that the template just posted). The UNIQUE index on
+      // invoice_transfer_journal_entry_id provides a second defense at the DB
+      // level if a different code path ever skipped the where filter.
+      const upd = await tx.fixedAsset.updateMany({
+        where: {
+          id,
+          vatAccount: '11-4102',
+          invoiceReceivedAt: null,
+          invoiceTransferJournalEntryId: null,
+          deletedAt: null,
+        },
         data: {
           vatAccount: '11-4101',
           invoiceReceivedAt: now,
@@ -1037,6 +1051,11 @@ export class AssetService {
           invoiceTransferJournalEntryId: inner.journalEntryId,
         },
       });
+      if (upd.count !== 1) {
+        throw new BadRequestException(
+          'มีคนกดบันทึกใบกำกับไปแล้วในระหว่างนี้ — กรุณารีเฟรชหน้า',
+        );
+      }
 
       await tx.auditLog.create({
         data: {
@@ -1049,7 +1068,7 @@ export class AssetService {
             vatAccount: '11-4101',
             invoiceReceivedAt: now.toISOString(),
             transferEntryNumber: inner.entryNo,
-            vatAmount: asset.vatAmount.toString(),
+            vatAmount: new Decimal(asset.vatAmount.toString()).toFixed(2),
           },
         },
       });

--- a/apps/api/src/modules/journal/cpa-templates/asset-invoice-received.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/asset-invoice-received.template.spec.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { PrismaClient, AssetCategory, AssetStatus, Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { seedFinanceCoa } from '../../../../prisma/seed-coa-finance';
+import { AssetInvoiceReceivedTemplate } from './asset-invoice-received.template';
+import { AssetPurchaseTemplate } from './asset-purchase.template';
+import { JournalAutoService } from '../journal-auto.service';
+
+const prisma = new PrismaClient();
+
+let template: AssetInvoiceReceivedTemplate;
+let purchase: AssetPurchaseTemplate;
+let userId: string;
+
+async function createPostedAssetWith11_4102(): Promise<string> {
+  const rand = Math.random().toString(36).slice(2, 8).toUpperCase();
+  const data: Prisma.FixedAssetUncheckedCreateInput = {
+    assetCode: `INV-${Date.now()}-${rand}`,
+    docNo: `ASSET-2605-${rand}`,
+    name: 'Notebook with deferred VAT',
+    category: 'EQUIPMENT' as AssetCategory,
+    basePrice: new Decimal(10000),
+    shippingCost: new Decimal(0),
+    installationCost: new Decimal(0),
+    otherCapitalized: new Decimal(0),
+    hasVat: true,
+    vatInclusive: false,
+    vatAmount: new Decimal(700),
+    vatAccount: '11-4102', // ← deferred input VAT
+    whtAmount: new Decimal(0),
+    purchaseCost: new Decimal(10000),
+    residualValue: new Decimal(0),
+    usefulLifeMonths: 36,
+    monthlyDepr: new Decimal('277.78'),
+    netBookValue: new Decimal(10000),
+    purchaseDate: new Date('2026-05-01'),
+    paymentAccount: '11-1201',
+    status: 'DRAFT' as AssetStatus,
+    createdById: userId,
+  };
+  const asset = await prisma.fixedAsset.create({ data });
+
+  // POST it via purchase template (creates the original JE that booked Dr 11-4102)
+  await purchase.execute({ assetId: asset.id, postedById: userId });
+  await prisma.fixedAsset.update({
+    where: { id: asset.id },
+    data: { status: 'POSTED', postedById: userId, postedAt: new Date() },
+  });
+  return asset.id;
+}
+
+async function setup() {
+  await prisma.journalPostAuditLog.deleteMany({});
+  await prisma.journalLine.deleteMany({});
+  await prisma.journalEntry.deleteMany({});
+  await prisma.depreciationEntry.deleteMany({});
+  await prisma.assetTransferHistory.deleteMany({});
+  await prisma.fixedAsset.deleteMany({});
+
+  await seedFinanceCoa(prisma);
+
+  let admin = await prisma.user.findFirst({ where: { email: 'admin@bestchoice.com' } });
+  if (!admin) {
+    admin = await prisma.user.create({
+      data: { email: 'admin@bestchoice.com', password: 'x', name: 'admin', role: 'OWNER' },
+    });
+  }
+  userId = admin.id;
+
+  const finance = await prisma.companyInfo.findFirst({ where: { companyCode: 'FINANCE' } });
+  if (!finance) {
+    await prisma.companyInfo.create({
+      data: {
+        nameTh: 'BESTCHOICE FINANCE',
+        taxId: '0000000000002',
+        companyCode: 'FINANCE',
+        address: '1 Finance Rd.',
+        directorName: 'Test Director',
+        vatRegistered: true,
+        vatRate: new Decimal('0.0700'),
+      },
+    });
+  }
+
+  const journal = new JournalAutoService(prisma as any);
+  purchase = new AssetPurchaseTemplate(journal, prisma as any);
+  return new AssetInvoiceReceivedTemplate(journal, prisma as any);
+}
+
+describe('AssetInvoiceReceivedTemplate', () => {
+  beforeAll(async () => {
+    template = await setup();
+  });
+
+  beforeEach(async () => {
+    await prisma.journalPostAuditLog.deleteMany({});
+    await prisma.journalLine.deleteMany({});
+    await prisma.journalEntry.deleteMany({});
+    await prisma.assetTransferHistory.deleteMany({});
+    await prisma.fixedAsset.deleteMany({});
+  });
+
+  it('posts Dr 11-4101 / Cr 11-4102 for the full VAT amount', async () => {
+    const assetId = await createPostedAssetWith11_4102();
+    const result = await template.execute({ assetId, triggeredById: userId });
+    expect(result.entryNo).toMatch(/^JE-\d{6}-\d{5}$/);
+
+    const je = await prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'asset-invoice-received' } as any },
+          { metadata: { path: ['assetId'], equals: assetId } as any },
+        ],
+      },
+      include: { lines: true },
+    });
+    expect(je).toBeTruthy();
+    expect(je!.status).toBe('POSTED');
+
+    const dr = je!.lines.find((l) => new Decimal(l.debit.toString()).gt(0));
+    const cr = je!.lines.find((l) => new Decimal(l.credit.toString()).gt(0));
+    expect(dr!.accountCode).toBe('11-4101');
+    expect(cr!.accountCode).toBe('11-4102');
+    expect(new Decimal(dr!.debit.toString()).toFixed(2)).toBe('700.00');
+    expect(new Decimal(cr!.credit.toString()).toFixed(2)).toBe('700.00');
+  });
+
+  it('is idempotent — second call returns the same entry without duplicating', async () => {
+    const assetId = await createPostedAssetWith11_4102();
+    const first = await template.execute({ assetId, triggeredById: userId });
+    const second = await template.execute({ assetId, triggeredById: userId });
+    expect(second.entryNo).toBe(first.entryNo);
+    expect(second.journalEntryId).toBe(first.journalEntryId);
+
+    const count = await prisma.journalEntry.count({
+      where: {
+        metadata: { path: ['flow'], equals: 'asset-invoice-received' } as any,
+      },
+    });
+    expect(count).toBe(1);
+  });
+
+  it('rejects when asset.vatAccount is already 11-4101 (nothing to transfer)', async () => {
+    const rand = Math.random().toString(36).slice(2, 8).toUpperCase();
+    const asset = await prisma.fixedAsset.create({
+      data: {
+        assetCode: `INV-${Date.now()}-${rand}`,
+        docNo: `ASSET-2605-${rand}`,
+        name: 'Cash-and-carry purchase',
+        category: 'EQUIPMENT' as AssetCategory,
+        basePrice: new Decimal(10000),
+        shippingCost: new Decimal(0),
+        installationCost: new Decimal(0),
+        otherCapitalized: new Decimal(0),
+        hasVat: true,
+        vatAmount: new Decimal(700),
+        vatAccount: '11-4101', // ← claimable directly, no deferred VAT
+        whtAmount: new Decimal(0),
+        purchaseCost: new Decimal(10000),
+        residualValue: new Decimal(0),
+        usefulLifeMonths: 36,
+        monthlyDepr: new Decimal('277.78'),
+        netBookValue: new Decimal(10000),
+        purchaseDate: new Date('2026-05-01'),
+        paymentAccount: '11-1201',
+        status: 'POSTED' as AssetStatus,
+        createdById: userId,
+        postedById: userId,
+        postedAt: new Date(),
+      },
+    });
+
+    await expect(
+      template.execute({ assetId: asset.id, triggeredById: userId }),
+    ).rejects.toThrow(/11-4102/);
+  });
+
+  it('rejects when asset is not POSTED', async () => {
+    const rand = Math.random().toString(36).slice(2, 8).toUpperCase();
+    const asset = await prisma.fixedAsset.create({
+      data: {
+        assetCode: `INV-${Date.now()}-${rand}`,
+        docNo: `ASSET-2605-${rand}`,
+        name: 'Draft asset',
+        category: 'EQUIPMENT' as AssetCategory,
+        basePrice: new Decimal(10000),
+        shippingCost: new Decimal(0),
+        installationCost: new Decimal(0),
+        otherCapitalized: new Decimal(0),
+        hasVat: true,
+        vatAmount: new Decimal(700),
+        vatAccount: '11-4102',
+        whtAmount: new Decimal(0),
+        purchaseCost: new Decimal(10000),
+        residualValue: new Decimal(0),
+        usefulLifeMonths: 36,
+        monthlyDepr: new Decimal('277.78'),
+        netBookValue: new Decimal(10000),
+        purchaseDate: new Date('2026-05-01'),
+        paymentAccount: '11-1201',
+        status: 'DRAFT' as AssetStatus,
+        createdById: userId,
+      },
+    });
+
+    await expect(
+      template.execute({ assetId: asset.id, triggeredById: userId }),
+    ).rejects.toThrow(/POSTED/);
+  });
+
+  it('rejects when VAT amount is zero (nothing to transfer)', async () => {
+    const rand = Math.random().toString(36).slice(2, 8).toUpperCase();
+    const asset = await prisma.fixedAsset.create({
+      data: {
+        assetCode: `INV-${Date.now()}-${rand}`,
+        docNo: `ASSET-2605-${rand}`,
+        name: 'Zero VAT',
+        category: 'EQUIPMENT' as AssetCategory,
+        basePrice: new Decimal(10000),
+        shippingCost: new Decimal(0),
+        installationCost: new Decimal(0),
+        otherCapitalized: new Decimal(0),
+        hasVat: true,
+        vatAmount: new Decimal(0),
+        vatAccount: '11-4102',
+        whtAmount: new Decimal(0),
+        purchaseCost: new Decimal(10000),
+        residualValue: new Decimal(0),
+        usefulLifeMonths: 36,
+        monthlyDepr: new Decimal('277.78'),
+        netBookValue: new Decimal(10000),
+        purchaseDate: new Date('2026-05-01'),
+        paymentAccount: '11-1201',
+        status: 'POSTED' as AssetStatus,
+        createdById: userId,
+        postedById: userId,
+        postedAt: new Date(),
+      },
+    });
+
+    await expect(
+      template.execute({ assetId: asset.id, triggeredById: userId }),
+    ).rejects.toThrow(/VAT amount/);
+  });
+});

--- a/apps/api/src/modules/journal/cpa-templates/asset-invoice-received.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/asset-invoice-received.template.ts
@@ -1,0 +1,158 @@
+import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { Prisma } from '@prisma/client';
+import { JournalAutoService } from '../journal-auto.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+export interface AssetInvoiceReceivedInput {
+  assetId: string;
+  triggeredById: string;
+}
+
+/**
+ * Template — 11-4102 → 11-4101 transfer when supplier tax invoice arrives.
+ *
+ * Context (Acknowledgment v1 §4.1, Handover v3.7 §5.11.1):
+ *   When an asset is POSTed before the tax invoice arrives, ภ.พ.30 cannot yet
+ *   claim the input VAT. TFRS accrual practice books to 11-4102 (deferred input
+ *   VAT) at POST. Once the tax invoice physically arrives, this template
+ *   reclassifies the VAT to 11-4101 (claimable input tax) and the next ภ.พ.30
+ *   filing can credit it.
+ *
+ * JE:
+ *   Dr 11-4101  ภาษีซื้อ (เครดิตได้ทันที)         [vatAmount]
+ *     Cr 11-4102 ภาษีซื้อรอเรียกเก็บ              [vatAmount]
+ *
+ * Idempotent — guards by metadata.flow + assetId. A second call with the same
+ * assetId returns the existing JE entryNo without posting a duplicate.
+ *
+ * Period guard (V15): the caller (AssetService.markInvoiceReceived) calls
+ * validatePeriodOpen with the trigger date (今 = current date) before invoking
+ * this template, mirroring asset-purchase + asset-disposal.
+ */
+@Injectable()
+export class AssetInvoiceReceivedTemplate {
+  private readonly logger = new Logger(AssetInvoiceReceivedTemplate.name);
+
+  constructor(
+    private readonly journal: JournalAutoService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async execute(
+    input: AssetInvoiceReceivedInput,
+    outerTx?: Prisma.TransactionClient,
+  ): Promise<{ entryNo: string; journalEntryId: string }> {
+    const { assetId, triggeredById } = input;
+
+    const asset = await this.prisma.fixedAsset.findFirst({
+      where: { id: assetId, deletedAt: null },
+    });
+    if (!asset) {
+      throw new NotFoundException(`ไม่พบสินทรัพย์ ${assetId}`);
+    }
+    if (asset.status !== 'POSTED') {
+      throw new BadRequestException(
+        `Asset ${asset.assetCode} ต้องอยู่สถานะ POSTED (ปัจจุบัน: ${asset.status})`,
+      );
+    }
+    if (!asset.hasVat) {
+      throw new BadRequestException(
+        `Asset ${asset.assetCode} ไม่มี VAT — ไม่ต้องโอน 11-4102 → 11-4101`,
+      );
+    }
+    if (asset.vatAccount !== '11-4102') {
+      throw new BadRequestException(
+        `Asset ${asset.assetCode} ภาษีซื้ออยู่บัญชี ${asset.vatAccount ?? '(ไม่ระบุ)'} — ใช้ flow นี้ได้เฉพาะ 11-4102`,
+      );
+    }
+    const vatAmount = new Decimal(asset.vatAmount.toString());
+    if (!vatAmount.gt(0)) {
+      throw new BadRequestException(
+        `Asset ${asset.assetCode} VAT amount = 0 — ไม่ต้องโอน`,
+      );
+    }
+
+    type Line = { accountCode: string; dr: Decimal; cr: Decimal; description?: string };
+    const zero = new Decimal(0);
+    const lines: Line[] = [
+      {
+        accountCode: '11-4101',
+        dr: vatAmount,
+        cr: zero,
+        description: `ภาษีซื้อ (รับใบกำกับ) - ${asset.assetCode}`,
+      },
+      {
+        accountCode: '11-4102',
+        dr: zero,
+        cr: vatAmount,
+        description: `ล้างภาษีซื้อรอเรียกเก็บ - ${asset.assetCode}`,
+      },
+    ];
+
+    const totalDr = lines.reduce((s, l) => s.plus(l.dr), zero);
+    const totalCr = lines.reduce((s, l) => s.plus(l.cr), zero);
+    if (!totalDr.equals(totalCr)) {
+      throw new BadRequestException(
+        `AssetInvoiceReceived JE unbalanced: Dr=${totalDr.toFixed(2)} Cr=${totalCr.toFixed(2)} for asset ${asset.assetCode}`,
+      );
+    }
+
+    const run = async (
+      tx: Prisma.TransactionClient,
+    ): Promise<{ entryNo: string; journalEntryId: string }> => {
+      const existing = await tx.journalEntry.findFirst({
+        where: {
+          metadata: { path: ['assetId'], equals: assetId } as any,
+          AND: [{ metadata: { path: ['flow'], equals: 'asset-invoice-received' } as any }],
+          deletedAt: null,
+        },
+      });
+      if (existing) {
+        this.logger.log(
+          `AssetInvoiceReceivedTemplate idempotency — JE ${existing.entryNumber} already exists for asset ${assetId}, skipping`,
+        );
+        return { entryNo: existing.entryNumber, journalEntryId: existing.id };
+      }
+
+      const result = await this.journal.createAndPost(
+        {
+          description: `รับใบกำกับภาษีซื้อ ${asset.assetCode} - ${asset.name}`,
+          reference: `${asset.id}:asset-invoice-received`,
+          metadata: {
+            tag: 'ASSET_INVOICE_RECEIVED',
+            flow: 'asset-invoice-received',
+            assetId: asset.id,
+            assetCode: asset.assetCode,
+            vatAmount: vatAmount.toFixed(2),
+          },
+          postedAt: new Date(),
+          lines,
+        },
+        tx,
+      );
+
+      // Pair the JE post with an immutable audit log entry in the same tx
+      // (same pattern as asset-purchase / asset-disposal). A failure here
+      // rolls back the JE creation — never end up POSTED without audit.
+      await tx.journalPostAuditLog.create({
+        data: {
+          journalEntryId: result.id,
+          postedById: triggeredById,
+          postedAt: new Date(),
+        },
+      });
+
+      return { entryNo: result.entryNumber, journalEntryId: result.id };
+    };
+
+    const out = outerTx
+      ? await run(outerTx)
+      : await this.prisma.$transaction(run);
+
+    this.logger.log(
+      `AssetInvoiceReceivedTemplate posted JE ${out.entryNo} for asset ${asset.assetCode} vat=${vatAmount.toFixed(2)}`,
+    );
+    return out;
+  }
+}

--- a/apps/api/src/modules/journal/cpa-templates/asset-invoice-received.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/asset-invoice-received.template.ts
@@ -27,8 +27,8 @@ export interface AssetInvoiceReceivedInput {
  * assetId returns the existing JE entryNo without posting a duplicate.
  *
  * Period guard (V15): the caller (AssetService.markInvoiceReceived) calls
- * validatePeriodOpen with the trigger date (今 = current date) before invoking
- * this template, mirroring asset-purchase + asset-disposal.
+ * validatePeriodOpen with the trigger date (today = current date) before
+ * invoking this template, mirroring asset-purchase + asset-disposal.
  */
 @Injectable()
 export class AssetInvoiceReceivedTemplate {

--- a/apps/api/src/modules/journal/journal.module.ts
+++ b/apps/api/src/modules/journal/journal.module.ts
@@ -25,6 +25,7 @@ import { DepreciationTemplate } from './cpa-templates/depreciation.template';
 import { AssetDisposalTemplate } from './cpa-templates/asset-disposal.template';
 import { AssetPurchaseTemplate } from './cpa-templates/asset-purchase.template';
 import { AssetPurchaseReverseTemplate } from './cpa-templates/asset-purchase-reverse.template';
+import { AssetInvoiceReceivedTemplate } from './cpa-templates/asset-invoice-received.template';
 import { AssetDisposalReverseTemplate } from './cpa-templates/asset-disposal-reverse.template';
 import { DepreciationReverseTemplate } from './cpa-templates/depreciation-reverse.template';
 import { DepreciationCron } from './cron/depreciation.cron';
@@ -64,6 +65,7 @@ import { VendorSettlementTemplate } from './cpa-templates/vendor-settlement.temp
     AssetDisposalTemplate,
     AssetPurchaseTemplate,
     AssetPurchaseReverseTemplate,
+    AssetInvoiceReceivedTemplate,
     AssetDisposalReverseTemplate,
     DepreciationReverseTemplate,
     DepreciationCron,
@@ -98,6 +100,7 @@ import { VendorSettlementTemplate } from './cpa-templates/vendor-settlement.temp
     AssetDisposalTemplate,
     AssetPurchaseTemplate,
     AssetPurchaseReverseTemplate,
+    AssetInvoiceReceivedTemplate,
     AssetDisposalReverseTemplate,
     DepreciationReverseTemplate,
     WhtAccrualTemplate,

--- a/apps/web/src/pages/assets/AssetDetailPage.tsx
+++ b/apps/web/src/pages/assets/AssetDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   CheckSquare,
   TrendingDown,
   History,
+  ReceiptText,
 } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -61,6 +62,7 @@ export default function AssetDetailPage() {
   const [showReverseDisposal, setShowReverseDisposal] = useState(false);
   const [showTransfer, setShowTransfer] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
+  const [showInvoiceReceived, setShowInvoiceReceived] = useState(false);
 
   const reverseMutation = useMutation({
     mutationFn: (reason: string) => assetsApi.reverse(id!, reason),
@@ -134,6 +136,19 @@ export default function AssetDetailPage() {
     onError: (e) => toast.error(getErrorMessage(e)),
   });
 
+  const invoiceReceivedMutation = useMutation({
+    mutationFn: () => assetsApi.markInvoiceReceived(id!),
+    onSuccess: (r) => {
+      toast.success(`บันทึกใบกำกับและโอน 11-4102 → 11-4101 แล้ว (${r.entryNo})`);
+      queryClient.invalidateQueries({ queryKey: ['asset', id] });
+      queryClient.invalidateQueries({ queryKey: ['asset-audit', id] });
+      queryClient.invalidateQueries({ queryKey: ['assets'] });
+      queryClient.invalidateQueries({ queryKey: ['assets-journal'] });
+      setShowInvoiceReceived(false);
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
   const asset = assetQuery.data;
 
   return (
@@ -173,6 +188,11 @@ export default function AssetDetailPage() {
                 )}
                 {asset.status === 'POSTED' && (
                   <>
+                    {asset.vatAccount === '11-4102' && !asset.invoiceReceivedAt && (
+                      <DropdownMenuItem onClick={() => setShowInvoiceReceived(true)}>
+                        <ReceiptText className="mr-2 size-4" /> ใบกำกับมาถึงแล้ว
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem onClick={() => setShowTransfer(true)}>
                       <ArrowRightLeft className="mr-2 size-4" /> โอนผู้ดูแล/ที่ตั้ง
                     </DropdownMenuItem>
@@ -259,12 +279,36 @@ export default function AssetDetailPage() {
                     </div>
                     <div>
                       <dt className="text-muted-foreground">VAT</dt>
-                      <dd className="tabular-nums">{fmt(asset.vatAmount)}</dd>
+                      <dd className="tabular-nums">
+                        {fmt(asset.vatAmount)}
+                        {asset.hasVat && asset.vatAccount && (
+                          <span
+                            className={`ml-2 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                              asset.vatAccount === '11-4102'
+                                ? 'bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300'
+                                : 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
+                            }`}
+                          >
+                            {asset.vatAccount}
+                            {asset.vatAccount === '11-4102' && ' รอใบกำกับ'}
+                            {asset.vatAccount === '11-4101' && asset.invoiceReceivedAt && ' เครดิตได้'}
+                          </span>
+                        )}
+                      </dd>
                     </div>
                     <div>
                       <dt className="text-muted-foreground">WHT</dt>
                       <dd className="tabular-nums">{fmt(asset.whtAmount)}</dd>
                     </div>
+                    {asset.invoiceReceivedAt && (
+                      <div className="sm:col-span-2">
+                        <dt className="text-muted-foreground">ใบกำกับมาถึงเมื่อ</dt>
+                        <dd className="text-emerald-700 dark:text-emerald-400">
+                          {formatDateTime(asset.invoiceReceivedAt)}
+                          {asset.invoiceReceivedBy && ` · ${asset.invoiceReceivedBy.name}`}
+                        </dd>
+                      </div>
+                    )}
                     <div>
                       <dt className="text-muted-foreground">อายุการใช้งาน</dt>
                       <dd>{asset.usefulLifeMonths} เดือน</dd>
@@ -404,6 +448,15 @@ export default function AssetDetailPage() {
             variant="destructive"
             loading={deleteMutation.isPending}
             onConfirm={() => deleteMutation.mutate()}
+          />
+          <ConfirmDialog
+            open={showInvoiceReceived}
+            onOpenChange={setShowInvoiceReceived}
+            title="บันทึกใบกำกับมาถึงแล้ว?"
+            description={`โอน VAT ${fmt(asset.vatAmount)} บาท จาก 11-4102 (รอเรียกเก็บ) → 11-4101 (เครดิตได้) — ภ.พ.30 งวดถัดไปจะหักภาษีซื้อได้`}
+            confirmLabel="บันทึกใบกำกับ"
+            loading={invoiceReceivedMutation.isPending}
+            onConfirm={() => invoiceReceivedMutation.mutate()}
           />
         </>
       )}

--- a/apps/web/src/pages/assets/api.ts
+++ b/apps/web/src/pages/assets/api.ts
@@ -141,6 +141,15 @@ export const assetsApi = {
     return data;
   },
 
+  markInvoiceReceived: async (
+    id: string,
+  ): Promise<{ entryNo: string; invoiceReceivedAt: string }> => {
+    const { data } = await api.post<{ entryNo: string; invoiceReceivedAt: string }>(
+      `/assets/${id}/invoice-received`,
+    );
+    return data;
+  },
+
   listAllTransfers: async (filters: {
     page?: number;
     limit?: number;

--- a/apps/web/src/pages/assets/types.ts
+++ b/apps/web/src/pages/assets/types.ts
@@ -87,6 +87,12 @@ export interface Asset {
   reversedBy: { id: string; name: string } | null;
   reversedAt: string | null;
   reversalReason: string | null;
+  // 11-4102 → 11-4101 transfer (ใบกำกับมาถึงแล้ว). Set when the supplier tax
+  // invoice arrives and the deferred VAT is reclassified to claimable.
+  invoiceReceivedAt: string | null;
+  invoiceReceivedById: string | null;
+  invoiceReceivedBy: { id: string; name: string } | null;
+  invoiceTransferJournalEntryId: string | null;
   createdAt: string;
   updatedAt: string;
   transferHistory?: AssetTransferHistory[];


### PR DESCRIPTION
## Summary

Closes the **last open feature gap** from `Acknowledgment_v1.pdf §4.1` + `Handover v3.7 §5.11.1` — accountant's "Phase ถัดไป" item. Assets POSTed with `vatAccount = '11-4102'` (deferred input VAT, TFRS accrual when supplier tax invoice has not yet arrived) can now be reclassified to `11-4101` (claimable on ภ.พ.30) via a one-click "ใบกำกับมาถึงแล้ว" action.

Stacks on PR #847 (asset module final polish).

## What's in it

**Backend:**
- New JE template `AssetInvoiceReceivedTemplate` — posts `Dr 11-4101 / Cr 11-4102` for the full vatAmount. Idempotent via `metadata.flow + assetId` + DB-level UNIQUE on `invoiceTransferJournalEntryId`.
- `AssetService.markInvoiceReceived(id, userId)` — guards `status=POSTED && hasVat && vatAccount='11-4102' && !invoiceReceivedAt`. V15 period guard uses **TODAY** (transfer posts to current period — original `purchaseDate`'s period may be closed and that's fine). TOCTOU-safe via `updateMany` composite-where + `count===1` guard inside `\$transaction`.
- New endpoint `POST /assets/:id/invoice-received` — Roles `OWNER, FINANCE_MANAGER, ACCOUNTANT`.
- AuditLog actions: `INVOICE_RECEIVED` (success) + `ASSET_INVOICE_RECEIVED_BLOCKED` (period-guard fail, mirrors `ASSET_POST_BLOCKED`).

**Schema (additive only — migration `20260926000000_asset_invoice_received`):**
- 3 nullable columns on `fixed_assets`: `invoice_received_at`, `invoice_received_by_id` (FK users), `invoice_transfer_journal_entry_id` (FK journal_entries, UNIQUE).
- 2 indexes (one unique, one lookup on `invoice_received_at`).
- No backfill needed — pre-existing 11-4102 rows just gain the "ใบกำกับมาถึงแล้ว" button.

**Frontend (`AssetDetailPage`):**
- DropdownMenuItem "ใบกำกับมาถึงแล้ว" — shown only when `status === 'POSTED' && vatAccount === '11-4102' && !invoiceReceivedAt`.
- ConfirmDialog explains VAT amount + ภ.พ.30 implications before posting.
- VAT row badge: amber "11-4102 รอใบกำกับ" / emerald "11-4101 เครดิตได้".
- New row "ใบกำกับมาถึงเมื่อ {date} · {user}" appears after success.

**Docs:** `.claude/rules/accounting.md` — new "Asset VAT — 11-4102 deferred → 11-4101 transfer flow" section under VAT input account routing.

## Tests

5 vitest spec cases on the template (real-DB integration, runs against fresh CI DB):
- Balanced JE Dr 11-4101 / Cr 11-4102 for the full VAT amount
- Idempotency — second call returns same entryNo, no duplicate JE
- Rejects when `vatAccount === '11-4101'` (nothing to transfer)
- Rejects when asset is not POSTED
- Rejects when `vatAmount === 0`

TypeScript: 0 errors (api + web).

## Review round

Independent code-review on commit `e7996ea1` found 0 Critical / 6 Warning / 5 Info. Verdict: APPROVE WITH MINOR FIXES. Three actionable Warnings addressed in commit `dbe59f0a`:
1. **UI bug** — `findOne` now includes `invoiceReceivedBy` (was always null, breaking the " · {name}" sub-row)
2. **TOCTOU race** — composite-where `updateMany` + rowCount guard so two concurrent clicks → second one rolls back its duplicate JE
3. **Decimal serialization** — `.toFixed(2)` in audit log `newValue` (was raw `.toString()` which could emit scientific notation)

## Test plan

- [ ] Apply migration on prod DB
- [ ] Smoke: create a DRAFT asset with VAT 7% inclusive, change vatAccount → 11-4102, POST it
- [ ] Open `/assets/<id>` — confirm amber "11-4102 รอใบกำกับ" badge appears next to VAT amount
- [ ] Click ⋮ menu → "ใบกำกับมาถึงแล้ว" → ConfirmDialog appears with correct VAT amount
- [ ] Confirm → toast shows JE entryNo, badge flips to emerald "11-4101 เครดิตได้", "ใบกำกับมาถึงเมื่อ" row appears
- [ ] Check `/journal` — new JE with Dr 11-4101 / Cr 11-4102 lines
- [ ] Check AuditLog page — `INVOICE_RECEIVED` action visible
- [ ] Idempotency: try the API endpoint manually a second time — returns 400 "มีคนกดบันทึกใบกำกับไปแล้ว"
- [ ] Period closed: close the current period, try the action → 400 "งวดบัญชีปิดแล้ว" + `ASSET_INVOICE_RECEIVED_BLOCKED` audit row

🤖 Generated with [Claude Code](https://claude.com/claude-code)