### PR TITLE
feat(web): show deploy version (v26.5.1) on sidebar + auth pages

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -94,6 +94,9 @@ jobs:
         run: npm run build --workspace=apps/web
         env:
           VITE_API_URL: http://localhost:3000/api
+          # Surface short commit SHA so the version badge can show it next
+          # to the CalVer (e.g. "v26.5.1·a1b2c3d"). vite.config.ts trims to 7 chars.
+          GIT_COMMIT: ${{ github.sha }}
 
       # E2E tests run in separate workflow (e2e-tests.yml) — skip here for faster deploy
       # - name: Install Playwright Browsers
@@ -327,6 +330,9 @@ jobs:
         env:
           VITE_API_URL: https://api.bestchoicephone.app/api
           VITE_LIFF_ID: 2009442540-d9XnzWwl
+          # Surface short commit SHA so the version badge can show it next
+          # to the CalVer (e.g. "v26.5.1·a1b2c3d"). vite.config.ts trims to 7 chars.
+          GIT_COMMIT: ${{ github.sha }}
 
       - name: Build customer shop (apps/web-shop → hosting:shop)
         run: npm run build --workspace=apps/web-shop

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "1.0.0",
+  "version": "26.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { Link } from 'react-router';
+import { VersionBadge } from './VersionBadge';
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -11,7 +12,7 @@ interface AuthLayoutProps {
  */
 export default function AuthLayout({ children }: AuthLayoutProps) {
   return (
-    <div className="grid lg:grid-cols-2 grow min-h-screen bg-background">
+    <div className="grid lg:grid-cols-2 grow min-h-screen bg-background relative">
       {/* Left Side — Form */}
       <div className="flex justify-center items-center p-8 lg:p-10 order-2 lg:order-1">
         <div className="w-full max-w-[440px]">
@@ -64,6 +65,11 @@ export default function AuthLayout({ children }: AuthLayoutProps) {
         <div className="absolute -top-20 -right-20 w-96 h-96 bg-primary/20 rounded-full blur-[100px]" />
         <div className="absolute -bottom-20 -left-20 w-80 h-80 bg-primary/15 rounded-full blur-[80px]" />
         <div className="absolute top-1/2 right-1/4 w-48 h-48 bg-primary/10 rounded-full blur-[60px]" />
+      </div>
+
+      {/* Version badge — bottom-right of form panel */}
+      <div className="absolute bottom-4 right-4 lg:bottom-6 lg:right-auto lg:left-6 z-10">
+        <VersionBadge variant="login" />
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -35,6 +35,7 @@ import { getMenuConfig } from '@/config/menu';
 import type { MenuSection, MenuBadgeKey } from '@/config/menu';
 import { useCollectionsFlag } from '@/pages/CollectionsPage/hooks/useCollectionsFlag';
 import { useDraftAssetCount } from '@/hooks/useDraftAssetCount';
+import { VersionBadge } from './VersionBadge';
 
 /* ── NavBadge — dynamic count badge for sidebar items ── */
 function NavBadge({ badgeKey }: { badgeKey: MenuBadgeKey }) {
@@ -444,6 +445,7 @@ function ExpandedSidebar({ onToggle }: { onToggle: () => void }) {
         >
           <ChevronsLeft className="size-4" />
         </button>
+        <VersionBadge />
         <button
           onClick={logout}
           className="flex items-center justify-center size-8 rounded-lg text-muted-foreground/70 hover:text-destructive hover:bg-destructive/10 dark:text-muted-foreground/85 transition-all duration-200"
@@ -564,7 +566,8 @@ function MobileSidebarContent() {
       </ScrollArea>
 
       {/* Footer (logout) */}
-      <div className="px-4 py-3 border-t border-sidebar-border shrink-0 flex justify-end">
+      <div className="px-4 py-3 border-t border-sidebar-border shrink-0 flex items-center justify-between">
+        <VersionBadge />
         <button
           onClick={logout}
           className="flex items-center justify-center size-8 rounded-lg text-muted-foreground/70 hover:text-destructive hover:bg-destructive/10 dark:text-muted-foreground/85 transition-all duration-200"

--- a/apps/web/src/components/layout/VersionBadge.tsx
+++ b/apps/web/src/components/layout/VersionBadge.tsx
@@ -1,0 +1,80 @@
+import { cn } from '@/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+// Format BUILD_TIME (ISO) as Asia/Bangkok local date+time.
+const formatBuildTime = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleString('th-TH', {
+      timeZone: 'Asia/Bangkok',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+};
+
+interface VersionBadgeProps {
+  className?: string;
+  variant?: 'sidebar' | 'login';
+}
+
+/**
+ * Subtle version label injected at build time via vite define.
+ * Format: `v26.5.1` with tooltip "Built {date} · {commit}".
+ * Bumped manually in `apps/web/package.json` before each deploy.
+ * GIT_COMMIT is set by CI from `${{ github.sha }}`, "dev" locally.
+ */
+export function VersionBadge({ className, variant = 'sidebar' }: VersionBadgeProps) {
+  const version = __APP_VERSION__;
+  const commit = __GIT_COMMIT__;
+  const builtAt = formatBuildTime(__BUILD_TIME__);
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              'inline-flex select-none items-center text-[11px] font-mono tabular-nums leading-none',
+              variant === 'sidebar'
+                ? 'text-muted-foreground/60 hover:text-muted-foreground'
+                : 'text-muted-foreground/70',
+              className,
+            )}
+            aria-label={`เวอร์ชัน ${version}`}
+          >
+            v{version}
+            {commit !== 'dev' && (
+              <span className="ml-1 text-muted-foreground/50">·{commit}</span>
+            )}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          side={variant === 'sidebar' ? 'top' : 'top'}
+          className="text-[12px] leading-snug"
+        >
+          <div className="space-y-0.5">
+            <div>
+              <span className="text-muted-foreground">Version:</span> {version}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Built:</span> {builtAt}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Commit:</span> {commit}
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+// Compile-time constants injected by vite.config.ts → define.
+// Format: CalVer YY.M.PATCH (e.g. "26.5.1") bumped in apps/web/package.json
+// before each deploy. GIT_COMMIT is the 7-char short SHA in CI, "dev" locally.
+declare const __APP_VERSION__: string;
+declare const __BUILD_TIME__: string;
+declare const __GIT_COMMIT__: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,9 +2,23 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
+import { readFileSync } from 'node:fs';
+
+// Read version from package.json — single source of truth. Bump that file
+// on every deploy (CalVer YY.M.PATCH, e.g. "26.5.1"). GIT_COMMIT is set by
+// the CI workflow at build time; defaults to 'dev' for local builds.
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf8'));
+const APP_VERSION = pkg.version as string;
+const BUILD_TIME = new Date().toISOString();
+const GIT_COMMIT = (process.env.GIT_COMMIT ?? 'dev').slice(0, 7);
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(APP_VERSION),
+    __BUILD_TIME__: JSON.stringify(BUILD_TIME),
+    __GIT_COMMIT__: JSON.stringify(GIT_COMMIT),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

Owner asked for a visible deploy version (obi pattern — `__APP_VERSION__` injected via vite define, shown in login + sidebar). Each rollout is now identifiable in the UI without digging into Cloud Run logs.

## What you see

- **Sidebar footer** (expanded + mobile drawer): `v26.5.1·a1b2c3d` (font-mono, muted)
- **AuthLayout** (login + forgot-password + reset + 2FA setup): same badge bottom-left of the form panel
- **Hover** anywhere on the badge → tooltip with:
  - Version: 26.5.1
  - Built: 16 พ.ค. 2569 22:00 (Asia/Bangkok)
  - Commit: a1b2c3d

When `__GIT_COMMIT__` is "dev" (local builds) the SHA suffix is hidden — only `v26.5.1` shows.

## How it works

1. **`apps/web/package.json`** is the version source — bumped "1.0.0" → "26.5.1". **Bump this file before each deploy.**
2. **`apps/web/vite.config.ts`** reads package.json + sets 3 compile-time constants via `define`:
   - `__APP_VERSION__` = package.json version
   - `__BUILD_TIME__` = `new Date().toISOString()` at build time
   - `__GIT_COMMIT__` = `process.env.GIT_COMMIT.slice(0, 7)` (defaults "dev" locally)
3. **`apps/web/src/vite-env.d.ts`** declares the globals for TypeScript
4. **`.github/workflows/deploy-gcp.yml`** injects `GIT_COMMIT=${{ github.sha }}` into both web build steps:
   - `lint-and-test` (PR builds)
   - `firebase-hosting` admin web deploy

## Files

- `apps/web/src/components/layout/VersionBadge.tsx` — shared display component (Tooltip + th-TH date format)
- Wired into:
  - `Sidebar.tsx` → `ExpandedSidebar` + `MobileSidebarContent` footers
  - `AuthLayout.tsx` → absolutely positioned bottom-corner (works on all auth pages)

## Versioning convention going forward

CalVer **YY.M.PATCH** — patch resets each month:

```
26.5.1  first deploy in May 2026 (this PR)
26.5.2  second deploy same month
26.6.1  first deploy in June 2026
```

To cut a release: bump `apps/web/package.json` "version" → merge to main → CI does the rest.

## Test plan

- [ ] Open `/login` → see `v26.5.1·<sha>` bottom-left (or just `v26.5.1` if testing locally with `GIT_COMMIT=dev`)
- [ ] Hover the badge → tooltip shows Version / Built / Commit (Asia/Bangkok date format)
- [ ] Login → expanded sidebar footer shows the same badge between ChevronsLeft and LogOut buttons
- [ ] Toggle sidebar → mobile drawer footer also shows it (left of LogOut)
- [ ] Manually bump `apps/web/package.json` to `26.5.2` locally → `npm run dev` → version updates without a rebuild restart needed (HMR)
- [ ] After merge: confirm CI's `deploy-gcp.yml` build logs include `GIT_COMMIT=<sha>` env var
- [ ] After deploy to prod: open admin UI → badge shows the actual short SHA matching the merged commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)