### PR TITLE
fix(other-income): remove dead `{true && (...)}` wrapper blocking CI lint

### DIFF
--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -1126,8 +1126,7 @@ export default function OtherIncomeEntryPage() {
                 ระบบจะบันทึกร่างอัตโนมัติเมื่อแนบไฟล์เป็นครั้งแรก
               </p>
             )}
-            {true && (
-              <>
+            <>
                 {needsAttachment && (
                   <div className="flex items-start gap-2 mb-3 text-xs text-warning">
                     <AlertTriangle size={14} className="shrink-0 mt-0.5" />
@@ -1220,7 +1219,6 @@ export default function OtherIncomeEntryPage() {
                   </button>
                 </div>
               </>
-            )}
           </section>
 
           {/* Section 8 — Confirmation summary */}


### PR DESCRIPTION
## Summary

Discovered while checking why PR #849 + #850 had ✖ red CI on lint — `OtherIncomeEntryPage.tsx` line 1129 had a literal `{true && (...)}` JSX wrapper. ESLint `no-constant-binary-expression` flags this as a real error (not warning), so **"Lint Web" has been red for every PR** since whenever it landed.

\`\`\`tsx
// Before — 1129:14  error  Unexpected constant truthiness on the left-hand side of a \`&&\` expression
{true && (
  <>
    {needsAttachment && (
      ...95 lines of JSX...
    )}
  </>
)}

// After
<>
  {needsAttachment && (
    ...95 lines of JSX...
  )}
</>
\`\`\`

Likely a leftover from a feature-flag A/B refactor that was inlined but never cleaned up. Semantically identical (always-true wrapper is no-op), lint-clean.

## Why it didn't block production

`.github/workflows/deploy-gcp.yml` runs `lint-and-test` only on `pull_request` events. Post-merge push to main skips lint and goes straight to build → deploy. So main deploys have been fine, but every PR's "Lint Web" step has been red.

PR #849 and #850 (both merged earlier today) had this red. Future PRs benefit.

## Result

- Before: 332 problems (**1 error**, 331 warnings)
- After: 331 problems (0 errors, 331 warnings)

Warnings remain as existing tech debt (mostly `@typescript-eslint/no-explicit-any`) but CI's lint step only fails on errors → now green.

## Test plan

- [ ] CI's "Lint Web" step on this PR is ✅ green
- [ ] Visit `/other-income/new` → fill required fields → attachment section in Section 7 renders identical to before
- [ ] needsAttachment warning still appears when ยอดรับ ≥ threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)