### PR TITLE
chore(sidebar): promote สินทรัพย์ to top-level section (out of บัญชี & รายงาน)

### DIFF
--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -84,13 +84,18 @@ export interface RoleMenuConfig {
 
 /* ── Shared menu items ─────────────────────────────── */
 
-const assetMenuItem: MenuItem = {
+// Asset section — promoted to its own top-level section per owner directive
+// ("เอาสินทรัพย์ แยกออกจากบัญชีเลยดีกว่า"). Previously nested as a
+// collapsible item inside "บัญชี & รายงาน" via the now-removed assetMenuItem.
+// Shared across OWNER / FINANCE_MANAGER / ACCOUNTANT — visible to roles that
+// own asset workflows. The `asset-draft-count` badge moves from the parent
+// to the "บันทึกซื้อ" item where drafts are actually listed.
+const assetMenuSection: MenuSection = {
+  key: 'asset',
   label: 'สินทรัพย์',
-  path: '/assets',
   icon: Landmark,
-  badgeKey: 'asset-draft-count',
-  children: [
-    { label: 'บันทึกซื้อ',                          path: '/assets',                icon: FileText },
+  items: [
+    { label: 'บันทึกซื้อ',                          path: '/assets',                icon: FileText, badgeKey: 'asset-draft-count' },
     { label: 'ทะเบียน + มูลค่าตามบัญชีสุทธิ (NBV)', path: '/assets/register',       icon: BookOpen },
     { label: 'สมุดรายวัน',                          path: '/assets/journal',        icon: FileText },
     { label: 'สรุปแยกหมวด',                         path: '/assets/summary-report', icon: BarChart3 },
@@ -263,10 +268,10 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
         { label: 'รายจ่าย', path: '/expenses', icon: Receipt },
         { label: 'รายได้อื่น', path: '/other-income', icon: TrendingUp },
         { label: 'กำไร-ขาดทุน', path: '/profit-loss', icon: PieChart },
-        assetMenuItem,
         { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
       ],
     },
+    assetMenuSection,
     {
       key: 'fm-online-shop',
       label: 'ร้านค้าออนไลน์',
@@ -311,9 +316,9 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
         { label: 'กำไร-ขาดทุน', path: '/profit-loss', icon: PieChart },
         { label: 'ภาษี', path: '/tax-reports', icon: Calculator },
         { label: 'รายงาน', path: '/reports', icon: BarChart3 },
-        assetMenuItem,
       ],
     },
+    assetMenuSection,
     {
       key: 'acc-close',
       label: 'ปิดบัญชี',
@@ -395,7 +400,6 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
         { label: 'รายจ่าย', path: '/expenses', icon: Receipt },
         { label: 'รายได้อื่น', path: '/other-income', icon: TrendingUp },
-        assetMenuItem,
         // Reports & period-close grouped under collapsible parents
         {
           label: 'รายงาน',
@@ -421,6 +425,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         },
       ],
     },
+    assetMenuSection,
     {
       key: 'owner-online-shop',
       label: 'ร้านค้าออนไลน์',


### PR DESCRIPTION
## Summary

Owner directive: **"เอาสินทรัพย์ แยกออกจากบัญชีเลยดีกว่า"**.

Asset workflow has 6 sub-items (บันทึกซื้อ, ทะเบียน+NBV, สมุดรายวัน, สรุปแยกหมวด, ค่าเสื่อม, ประวัติสินทรัพย์) — nested under "บัญชี & รายงาน" as a collapsible item meant clicking twice to get there (open accounting → expand asset). Promoted to its own top-level section, same accordion-ladder pattern as the other sections.

## Changes

- New shared `assetMenuSection: MenuSection` (replaces the removed `assetMenuItem`)
- `asset-draft-count` badge moves from the parent down to "บันทึกซื้อ" (drafts are listed there — UX makes more sense)
- Wired into 3 roles, inserted right after each one's "บัญชี & รายงาน" section to preserve accounting flow:
  - OWNER (9 → 10 sections)
  - FINANCE_MANAGER (5 → 6 sections)
  - ACCOUNTANT (3 → 4 sections)
- SALES + BRANCH_MANAGER unchanged (no asset access)

Item count unchanged — same 6 items, just regrouped under a top-level parent.

## Test plan

- [ ] Login as OWNER → confirm "สินทรัพย์" appears as its own collapsible section right after "บัญชี & รายงาน"
- [ ] Expand → see 6 items (บันทึกซื้อ has draft-count badge if there are DRAFT assets)
- [ ] Click "บันทึกซื้อ" → navigates `/assets` ✓
- [ ] Click "ค่าเสื่อม" → navigates `/depreciation` ✓
- [ ] Login as FINANCE_MANAGER / ACCOUNTANT → same section visible
- [ ] Login as SALES / BRANCH_MANAGER → no asset section (unchanged)
- [ ] Collapsed sidebar popover renders 6 items correctly
- [ ] Mobile drawer shows "สินทรัพย์" as top-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)