### PR TITLE
chore(release): bump web to v26.5.2 — sidebar asset section + version display rollout

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.1",
+  "version": "26.5.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Combined release for the post-#848 UX wave (bumps `apps/web/package.json` 26.5.1 → 26.5.2):

- **#849** OWNER sidebar declutter (47 → 39 items, sub-groups for accounting)
- **#850** Deploy version badge on Sidebar + AuthLayout (`v26.5.x·sha`)
- **#851** Pre-existing CI lint fix unblocking PR builds
- **#852** สินทรัพย์ promoted to its own top-level section (out of บัญชี & รายงาน)

## Why a separate version-bump PR

The 26.5.1 deploy already shipped through #850 → #851 → #852 squashes on main. However **#852's push event did not trigger a deploy workflow run** — `gh run list --commit 8f236888` returned 0 runs (transient GitHub event miss). This bump serves two purposes:

1. **Forces a fresh push-to-main deploy** that picks up #852 changes
2. **Demonstrates the convention** documented in PR #850: bump `apps/web/package.json` "version" before each deploy. Going forward owner can do this from the GitHub web UI when cutting a release.

## After merge

- Prod badge will show `v26.5.2·<new-sha>` (currently shows `v26.5.1·84d15ef`)
- OWNER sidebar will have **สินทรัพย์** as its own collapsible section (right after "บัญชี & รายงาน"), with the draft-count badge on "บันทึกซื้อ"
- FINANCE_MANAGER + ACCOUNTANT see the same asset section

## Test plan

- [ ] PR's "Lint Web" step ✅ green (post #851 fix)
- [ ] PR's Build Web step succeeds with new version
- [ ] After merge: `gh run list --commit <squash-sha>` shows a deploy run started
- [ ] After deploy: refresh `/login` → badge reads `v26.5.2·...`
- [ ] OWNER login → "สินทรัพย์" appears as separate collapsible section (no longer nested under บัญชี)

🤖 Generated with [Claude Code](https://claude.com/claude-code)