### PR TITLE
fix(api): add Cache-Control: no-store on /api/* + bump v26.5.3

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -37,6 +37,22 @@ async function bootstrap() {
   const adminPrefix = new AdminPrefixMiddleware();
   app.use((req, res, next) => adminPrefix.use(req, res, next));
 
+  // No-cache headers for all /api/* responses. Chrome's heuristic cache will
+  // store 404 / non-2xx responses without explicit Cache-Control headers,
+  // which caused production users to see stale 404 from disk-cache even after
+  // a route was fixed (observed on /api/admin/assets/journal after PR #845
+  // deploy). Setting Cache-Control: no-store + Pragma: no-cache on every API
+  // response forces the browser to revalidate. Cheap (one header), safe for
+  // JSON APIs (clients should always re-fetch dashboard data anyway).
+  app.use((req, res, next) => {
+    if (req.url.startsWith('/api/')) {
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+      res.setHeader('Pragma', 'no-cache');
+      res.setHeader('Expires', '0');
+    }
+    next();
+  });
+
   // Increase body size limit for base64 image uploads
   // `verify` callback captures raw body bytes for LINE webhook HMAC verification
   app.use(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.2",
+  "version": "26.5.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Root cause (from owner DevTools)

User reported JV page = 404 on prod (v26.5.2). DevTools shows the `/api/admin/assets/journal` request returning 404 from **`(disk cache)`** — the browser was replaying an OLD 404 response that Chrome's heuristic cache had stored.

Verified the route actually works:
\`\`\`bash
curl -i https://bestchoicephone.app/api/admin/assets/journal
HTTP/2 401  # ← route exists, just needs auth
\`\`\`

So the issue is browser cache, not the server. The 404 was probably real briefly during the PR #845 → PR #828 deploy gap and got stuck in Chrome's disk cache.

## Fix

Add a middleware at the Express level (right after AdminPrefixMiddleware) that sets cache-busting headers on every `/api/*` response:

\`\`\`
Cache-Control: no-store, no-cache, must-revalidate, private
Pragma:        no-cache
Expires:       0
\`\`\`

Why all three: Chrome respects `Cache-Control: no-store` unconditionally; `Pragma` is HTTP/1.0 fallback (some intermediate proxies still honor it); `Expires: 0` disables timestamp-based caching.

Why `/api/*` gated: Firebase Hosting serves the SPA bundle from `/` with its own cache rules (long-cache JS/CSS by content hash). We only want to disable caching for dynamic data — never for static assets.

Bump `apps/web/package.json` 26.5.2 → 26.5.3 so this deploy is identifiable in the version badge.

## Test plan

- [ ] After merge, hard-refresh JV page → loads without 404
- [ ] DevTools → Network → any /api/admin/* response → Response Headers includes `Cache-Control: no-store`
- [ ] /assets/journal endpoint works for OWNER as expected
- [ ] Static JS/CSS bundles (under `/assets/`) still get long-cache headers from Firebase (unchanged)

## Manual fix for users still on 26.5.2

`Cmd+Shift+R` hard refresh busts the cached 404 once. Going forward, no-store headers prevent it from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)