### PR TITLE
fix(asset): reorder controllers — JV controller must register before AssetController

### DIFF
--- a/apps/api/src/modules/asset/asset.module.ts
+++ b/apps/api/src/modules/asset/asset.module.ts
@@ -11,10 +11,16 @@ import { JournalModule } from '../journal/journal.module';
 
 @Module({
   imports: [JournalModule],
+  // CRITICAL ordering: AssetJournalController MUST be registered before
+  // AssetController. AssetController has `@Get(':id')` which path-to-regexp
+  // matches /assets/journal with id='journal' — without this ordering,
+  // findOne('journal') throws NotFoundException → 404 and the JV page is
+  // permanently broken. NestJS uses Express's first-match routing so the
+  // more-specific 'assets/journal' must be added to the router first.
   controllers: [
+    AssetJournalController,
     AssetController,
     AssetTransferController,
-    AssetJournalController,
     AssetReportsController,
   ],
   providers: [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.3",
+  "version": "26.5.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Real root cause of JV 404 (the bug accountant P1 actually flagged)

After PR #854's cache fix didn't help, owner reported JV page **still 404** on v26.5.3 (`04d5e79`). DevTools showed `(disk cache)` was no longer the culprit — it was a real server-side 404.

### What's happening

`AssetController` has `@Controller('assets')` + `@Get(':id')` (line 113). NestJS uses Express's first-match path-to-regexp routing. With:

\`\`\`ts
controllers: [AssetController, ..., AssetJournalController]
\`\`\`

Express adds routes in order:

\`\`\`
GET /api/assets          → findAll
GET /api/assets/summary  → getSummary
GET /api/assets/:id      → findOne          ← matches /assets/journal !!
...
GET /api/assets/journal  → AssetJournalController.list   ← unreachable
\`\`\`

A request `GET /api/assets/journal` matches `AssetController.findOne` with `id='journal'`, hits `prisma.fixedAsset.findFirst({ where: { id: 'journal' }})`, gets null, throws `NotFoundException('ไม่พบสินทรัพย์')` → **HTTP 404**.

### Why curl returned 401 (route looks healthy)

Unauthenticated `curl /api/admin/assets/journal` returns 401 because `AssetController`'s `JwtAuthGuard` rejects before reaching `findOne`. That made the bug invisible to HTTP-level smoke tests.

### Why this is the original P1 from accountant ImplementationReview v1.2

The accountant reported "หน้า JV สินทรัพย์ — Request failed with status code 404" as P1 Critical. PR #845 added `AssetJournalController` but didn't fix the **registration order** — so the controller existed (passed code review) but was unreachable at runtime. Memory note PR #845 said "no-bug = deploy lag from PR #828" — that was wrong; deploy lag wasn't the issue, route ordering was.

### Fix

Swap the order so `AssetJournalController` registers first:

\`\`\`ts
controllers: [
  AssetJournalController,    // /api/assets/journal — registered first ✓
  AssetController,           // /api/assets/:id — second, only matches non-'journal' paths
  AssetTransferController,
  AssetReportsController,
]
\`\`\`

6 lines changed (counting comments + Prettier formatting). No logic touched. No migration. `assets/:id/audit` and `assets/:id/schedule` paths remain functional because they're registered as full patterns on AssetController.

Bumps `apps/web/package.json` 26.5.3 → **26.5.4** so the deploy is identifiable in the version badge.

## Test plan

- [ ] After merge + deploy, owner opens `/assets/journal` → page loads with data (not 404)
- [ ] DevTools shows the XHR returns 200 with `{data: [...], total, page, limit}`
- [ ] Other asset routes (`/assets/:id`, `/assets/:id/audit`, `/assets/:id/schedule`) still work for valid UUIDs
- [ ] Sidebar badge shows `v26.5.4·<sha>` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)