### PR TITLE
fix(sidebar): promote ผังบัญชี to direct item under บัญชี & รายงาน

### DIFF
--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -400,6 +400,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
         { label: 'รายจ่าย', path: '/expenses', icon: Receipt },
         { label: 'รายได้อื่น', path: '/other-income', icon: TrendingUp },
+        { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
         // Reports & period-close grouped under collapsible parents
         {
           label: 'รายงาน',
@@ -420,7 +421,6 @@ const OWNER_CONFIG: RoleMenuConfig = {
             { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
             { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
             { label: 'ชำระเงินระหว่างบริษัท', path: '/accounting/intercompany', icon: ClipboardList },
-            { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
           ],
         },
       ],


### PR DESCRIPTION
## Summary

- Promote `ผังบัญชี` from being nested 2 levels deep (`บัญชี & รายงาน → ปิดบัญชี → ผังบัญชี`) up to a direct item alongside `รับชำระค่างวด` / `รายจ่าย` / `รายได้อื่น`
- Owner-reported issue: "ผังบัญชี หายไปไหน ไม่มีใน side menu" — root cause was PR #849 grouping 12 items into collapsibles, which buried this one too deep
- Affects OWNER role only; FINANCE_MANAGER / ACCOUNTANT already had it at 1 level

## Before / After (OWNER)

**Before** (2 clicks)
```
บัญชี & รายงาน  ▼
  └── ▼ ปิดบัญชี
        └── ผังบัญชี   ← 2 clicks to reach
```

**After** (1 click)
```
บัญชี & รายงาน  ▼
  ├── ผังบัญชี   ← direct item, 1 click
  └── ▼ ปิดบัญชี (no longer contains ผังบัญชี)
```

## Test plan

- [ ] Open dev server, login as OWNER → click "บัญชี & รายงาน" → see "ผังบัญชี" appearing as 4th direct item (after "รายได้อื่น")
- [ ] Click "ผังบัญชี" → navigates to `/settings/chart-of-accounts`
- [ ] Expand "▼ ปิดบัญชี" sub-group → confirm `ปิดบัญชีรายเดือน` / `งวดบัญชี` / `ชำระเงินระหว่างบริษัท` remain, no `ผังบัญชี` duplicate
- [ ] Login as FINANCE_MANAGER → confirm `ผังบัญชี` still appears under "ปิดบัญชี" section (unchanged)
- [ ] Login as ACCOUNTANT → confirm same as FINANCE_MANAGER (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)