### PR TITLE
feat(expense-v2): A0 pre-flight verify — psql script + tracking flip

### DIFF
--- a/docs/superpowers/tracking/A0-preflight-verify.md
+++ b/docs/superpowers/tracking/A0-preflight-verify.md
@@ -1,6 +1,6 @@
 # A0 · Pre-flight Verify
 
-**Status:** ⬜ Pending  |  **Started:** —  |  **PRs:** —
+**Status:** 🟡 In Progress  |  **Started:** 2026-05-16  |  **PRs:** TBD (script-only)
 **Deadline:** before any code change in v2.0 work
 **Spec:** —  ·  **Plan:** —
 
@@ -13,14 +13,15 @@ A0 has no code deliverable — it's `psql` queries against prod + recovery actio
 ## Source
 
 - [Dev Action Items v1.0](_owner-package/Dev_Action_Items_v1.0.md) Action #1 (page 3), #3 (page 12), #5 (page 19)
+- Ready-to-run consolidated script: [scripts/a0-preflight-verify.sql](../../../scripts/a0-preflight-verify.sql)
 
 ## Items Checklist
 
 | ID | Item | Priority | Status | PR | Evidence/Notes |
 |---|---|---|---|---|---|
-| A0.1 | Verify `adj_underpay = 52-1104` in prod `account_role_map` | P0 | ⬜ | — | Run Dev Action #1 Step 1 SQL on prod. If row says `53-1503` (the old wrong value), run Step 2 UPDATE and create adjusting JEs per Step 3+4 |
-| A0.2 | Reclassify SSO catch-up — `21-1104` rows still containing `%SSO%` or `%ประกันสังคม%` | P1 | ⬜ | — | Run Dev Action #3 Section 3.2 verification query on prod. If count > 0, apply Dev Action #3 Section 3.3 cleanup migration |
-| A0.3 | Recover missing depreciation JEs for งวด มี.ค.–เม.ย. 2569 | P1 | ⬜ | — | Run Dev Action #5 Section 5.2 query on prod. If count = 0, run Option A (`POST /depreciation/run` for each missing period) per Section 5.3 |
+| A0.1 | Verify `adj_underpay = 52-1104` in prod `account_role_map` | P0 | 🟡 | — | Script ready. Local dev DB shows `adj_underpay=52-1104` ✅ (correct) — strong signal prod is also correct since same migration source, but **owner must still run on prod**. If prod shows `53-1503` → run Dev Action #1 Step 2 UPDATE + Steps 3-4 |
+| A0.2 | Reclassify SSO catch-up — `21-1104` rows still containing `%SSO%` or `%ประกันสังคม%` | P1 | 🟡 | — | Script ready. Local dev DB shows 0 leftover SSO rows ✅. Owner runs on prod; if > 0 → apply Action #3 Section 3.3 cleanup migration |
+| A0.3 | Recover missing depreciation JEs for งวด มี.ค.–เม.ย. 2569 | P1 | 🟡 | — | Script ready. Local dev DB has 0 active assets so query returns empty — uninformative locally. Owner runs on prod; if 2026-03 / 2026-04 missing → Option A (`POST /depreciation/run`) per Section 5.3 |
 
 ## Phase
 
@@ -29,12 +30,13 @@ A0 has no code deliverable — it's `psql` queries against prod + recovery actio
 ## Decision Log
 
 - **2026-05-16:** A0 placed before B1 because Action #1 (adj_underpay routing) could affect any future SETTLEMENT/EXP that uses an adjustment — must be correct before B2 lands
+- **2026-05-16:** Schema-corrected the source SQL queries (Dev Action Items used logical names — `audit_log`/`asset_register`/`cr_amount`/`line_note` — that diverge from the actual Prisma schema). Consolidated all 3 verification queries into one `psql -f`-runnable script: `scripts/a0-preflight-verify.sql`. Smoke-tested on local dev DB (results: A0.1 correct, A0.2 clean, A0.3 uninformative locally due to no POSTED fixed_assets).
 
 ## Open Questions
 
-- [ ] Q: Owner approval required to run UPDATE on prod `account_role_map` if Step 1 finds a discrepancy?
-- [ ] Q: For A0.3 (depreciation recovery) — Option A (POST /depreciation/run) requires the endpoint to exist; if not, fall back to Option B manual adjusting JEs
-- [ ] Q: A0.2 — does memory note "PR #810 reclassify SSO" already cover all rows? Need verification query result first
+- [ ] Q: Owner approval required to run UPDATE on prod `account_role_map` if Step 1 finds a discrepancy? — **Pending owner answer** (A0.1 verification result will tell us if remediation is even needed)
+- [x] Q: For A0.3 (depreciation recovery) — Option A (POST /depreciation/run) requires the endpoint to exist; if not, fall back to Option B manual adjusting JEs — ✅ **Endpoint exists at `apps/api/src/modules/depreciation/depreciation.controller.ts:30` (`@Post('run')` on `@Controller('depreciation')`)**. Option A is viable.
+- [ ] Q: A0.2 — does memory note "PR #810 reclassify SSO" already cover all rows? Need verification query result first — **Local dev DB shows clean; prod result pending owner run**
 
 ## Dependencies
 

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -11,7 +11,7 @@
 | Sub-project | Items | Done | Progress | Status | Spec | Plan |
 |---|---|---|---|---|---|---|
 | [T0 · Tracking System](T0-tracking-system.md) | 5 | 5 | 100% | ✅ Done | [spec](../specs/2026-05-16-bestchoice-expense-v2-tracking-design.md) | [plan](../plans/2026-05-16-bestchoice-expense-v2-tracking.md) |
-| [A0 · Pre-flight Verify](A0-preflight-verify.md) | 3 | 0 | 0% | ⬜ Pending | — | — |
+| [A0 · Pre-flight Verify](A0-preflight-verify.md) | 3 | 0 | 0% | 🟡 In Progress | — | [script](../../../scripts/a0-preflight-verify.sql) |
 | [A1 · Settings Audit Phase 1+2](A1-settings-audit.md) | 102 | 0 | 0% | ⬜ Pending | — | — |
 | [B1 · SSO 875 Configurable](B1-sso-875.md) | 6 | 0 | 0% | ⬜ Pending | — | — |
 | [B2 · Settlement Multi-line Adj](B2-settlement-adjustment.md) | 5 | 0 | 0% | ⬜ Pending | — | — |
@@ -25,7 +25,7 @@
 
 ## 🎯 Current Focus
 
-- **Active:** None — T0 just shipped
+- **Active:** **A0 (Pre-flight Verify)** — script `scripts/a0-preflight-verify.sql` ready for owner to run on prod psql. 3 items remain "in progress" until prod output is captured back into A0 tracking Evidence/Notes
 - **Next:** **A0 (Pre-flight Verify)** — read-only DB checks before any code change. Critical because Action #1 in Dev_Action_Items requires verifying that `adj_underpay = 52-1104` in production before any other work
 - **Then:** **B1 (SSO 875)** — deadline-critical, government rule active for May 2026 close
 

--- a/scripts/a0-preflight-verify.sql
+++ b/scripts/a0-preflight-verify.sql
@@ -1,0 +1,129 @@
+-- A0 · Pre-flight Verify — Production DB Verification Queries
+-- ============================================================
+-- Source: docs/superpowers/tracking/_owner-package/Dev_Action_Items_v1.0.md
+--         Actions #1 (page 3), #3 (page 12), #5 (page 19)
+-- Tracking: docs/superpowers/tracking/A0-preflight-verify.md
+--
+-- These are READ-ONLY queries. They do NOT modify data.
+-- Schema names have been corrected from the source doc to match the
+-- actual live Prisma schema (audit_log → audit_logs, asset_register → fixed_assets,
+-- cr_amount/dr_amount → credit/debit, line_note → description, etc.).
+--
+-- Usage:
+--   psql "$PROD_DATABASE_URL" -f scripts/a0-preflight-verify.sql
+--
+-- Then paste the output back into the A0 tracking row (Evidence/Notes column).
+
+\echo
+\echo '╔══════════════════════════════════════════════════════════════════════╗'
+\echo '║ A0.1 — Verify account_role_map (adj_underpay → 52-1104)             ║'
+\echo '╠══════════════════════════════════════════════════════════════════════╣'
+\echo '║ Expected:                                                             ║'
+\echo '║   adj_overpay  | 53-1503 | priority=1 | is_active=t                  ║'
+\echo '║   adj_underpay | 52-1104 | priority=1 | is_active=t                  ║'
+\echo '║ If adj_underpay row shows 53-1503 → run Dev Action #1 Step 2 UPDATE  ║'
+\echo '║   then Step 3 to find affected JEs + Step 4 to create reversing JEs. ║'
+\echo '╚══════════════════════════════════════════════════════════════════════╝'
+
+SELECT role, account_code, priority, is_active
+FROM account_role_map
+WHERE role IN ('adj_overpay', 'adj_underpay')
+ORDER BY role, priority;
+
+\echo
+\echo '— A0.1 follow-up: JEs that may have used the WRONG (53-1503) account on underpay'
+\echo '— Expected: 0 rows. > 0 rows → reverse-and-reclassify per Action #1 Step 4.'
+
+SELECT
+  je.id            AS journal_entry_id,
+  je.posted_at,
+  ed.number        AS doc_no,
+  ea.side          AS adj_side,
+  ea.amount,
+  ea.account_code,
+  ea.note
+FROM expense_adjustments ea
+JOIN expense_documents ed ON ed.id = ea.document_id
+JOIN journal_entries  je ON je.metadata->>'documentId' = ed.id::text
+WHERE ea.account_code = '53-1503'
+  AND ea.side         = 'CR'
+  AND je.posted_at   >= '2026-05-11'
+ORDER BY je.posted_at DESC;
+
+\echo
+\echo '╔══════════════════════════════════════════════════════════════════════╗'
+\echo '║ A0.2 — SSO rows leftover in 21-1104 (should be 21-3105 post-PR#810) ║'
+\echo '╠══════════════════════════════════════════════════════════════════════╣'
+\echo '║ Expected: 0 rows.                                                    ║'
+\echo '║ If > 0  → run Dev Action #3 Section 3.3 cleanup migration            ║'
+\echo '║          (reclassifies remaining_sso rows from 21-1104 → 21-3105).   ║'
+\echo '║ Then re-run this query — expect 0 again.                             ║'
+\echo '╚══════════════════════════════════════════════════════════════════════╝'
+
+SELECT
+  je.id,
+  je.posted_at,
+  je.metadata->>'flow' AS flow,
+  jl.account_code,
+  jl.credit            AS cr_amount,
+  jl.description
+FROM journal_lines jl
+JOIN journal_entries je ON je.id = jl.journal_entry_id
+WHERE je.metadata->>'flow' = 'expense-payroll'
+  AND jl.account_code      = '21-1104'
+  AND jl.credit            > 0
+  AND (
+       jl.description ILIKE '%SSO%'
+    OR jl.description ILIKE '%ประกันสังคม%'
+  )
+  AND jl.description NOT ILIKE '%[migrated%'
+ORDER BY je.posted_at DESC;
+
+\echo
+\echo '╔══════════════════════════════════════════════════════════════════════╗'
+\echo '║ A0.3 — Depreciation JEs for งวด มี.ค.–เม.ย. 2569                    ║'
+\echo '╠══════════════════════════════════════════════════════════════════════╣'
+\echo '║ Expected: 2 period rows (2026-03 + 2026-04), each with count > 0    ║'
+\echo '║ If empty or count=0 → cron missed those periods.                     ║'
+\echo '║   Option A: POST /depreciation/run with period=YYYY-MM (per period). ║'
+\echo '║   Option B: Manual adjusting JE (Dr 53-16XX / Cr 12-22XX).          ║'
+\echo '╚══════════════════════════════════════════════════════════════════════╝'
+
+SELECT
+  date_trunc('month', je.posted_at) AS period,
+  COUNT(*)                          AS depreciation_count,
+  SUM(jl.debit)                     AS total_depreciation
+FROM journal_entries je
+JOIN journal_lines  jl ON jl.journal_entry_id = je.id
+WHERE je.metadata->>'flow' = 'asset-depreciation'
+  AND jl.account_code     LIKE '53-16%'
+  AND jl.debit            > 0
+  AND je.posted_at       >= '2026-03-01'
+  AND je.posted_at       <  '2026-05-01'
+GROUP BY 1
+ORDER BY 1;
+
+\echo
+\echo '— A0.3 context: Active fixed assets eligible for depreciation'
+\echo '— Use this list to estimate expected monthly depreciation if A0.3 above shows gaps.'
+\echo '— monthly_amount = cost_value / useful_life. missed_2_months_estimate = monthly × 2.'
+
+SELECT
+  asset_code,
+  cost_value,
+  useful_life,
+  ROUND(cost_value / useful_life, 2)        AS monthly_amount,
+  ROUND((cost_value / useful_life) * 2, 2)  AS missed_2_months_estimate
+FROM fixed_assets
+WHERE status         = 'POSTED'
+  AND purchase_date  < '2026-03-01'
+  AND deleted_at    IS NULL
+  AND disposed_at   IS NULL
+ORDER BY asset_code;
+
+\echo
+\echo '╔══════════════════════════════════════════════════════════════════════╗'
+\echo '║ A0 — DONE                                                            ║'
+\echo '║ Copy the output above into A0 tracking Evidence/Notes column.        ║'
+\echo '║ If any check fails: STOP — do not start B1/C2 until remediated.     ║'
+\echo '╚══════════════════════════════════════════════════════════════════════╝'


### PR DESCRIPTION
## Summary

A0 (Pre-flight Verify) — 3 production-DB read-only checks that MUST pass before any code in expense-v2 lands. This PR delivers a single ready-to-run `psql -f` script that consolidates Dev Action Items #1, #3, #5 with schema-corrected SQL.

**No prod action taken by this PR.** Owner runs the script, pastes output into A0 tracking Evidence/Notes, then we either flip 🟡 → ✅ (if all clean) or open remediation PRs (if any check fails).

## Why schema-corrected SQL

The source `Dev_Action_Items_v1.0.md` was written against logical names that diverge from the actual live Prisma schema. Running the doc's SQL verbatim would fail with \"relation does not exist\" or \"column does not exist\". This PR fixes the SQL once, in one place:

| Doc references | Actual schema |
|---|---|
| \`audit_log\` | \`audit_logs\` |
| \`asset_register\` | \`fixed_assets\` (with column renames: \`purchase_cost\` → \`cost_value\`, \`depreciation_period_months\` → \`useful_life\`, \`accumulated_depr\` → \`accumulated_depre\`, \`status='ACTIVE'\` → \`status='POSTED'\`) |
| \`journal_lines.cr_amount\` / \`dr_amount\` | \`credit\` / \`debit\` |
| \`journal_lines.line_note\` | \`description\` (no separate \`line_note\` column) |
| \`expense_documents.doc_no\` | \`expense_documents.number\` |

## Smoke test (local dev DB)

\`psql \"\$DATABASE_URL\" -f scripts/a0-preflight-verify.sql\` runs cleanly:

- ✅ A0.1 — \`account_role_map\` returns \`adj_overpay=53-1503, adj_underpay=52-1104\` (matches expected)
- ✅ A0.1 follow-up — 0 misclassified JEs
- ✅ A0.2 — 0 leftover SSO rows in \`21-1104\` (PR #810 reclassification looks complete)
- ⚠️ A0.3 — uninformative locally (0 POSTED \`fixed_assets\` in local DB); owner runs on prod to see real depreciation coverage

Local results suggest prod is likely clean too (same migration history), but only the prod run is authoritative.

## Open Question answered

Tracking file Q2: *\"Does POST /depreciation/run endpoint exist?\"* — ✅ **Yes**, at \`apps/api/src/modules/depreciation/depreciation.controller.ts:30\` (\`@Post('run')\` under \`@Controller('depreciation')\`). Option A for A0.3 recovery is viable if needed.

## What the owner does next

1. \`psql \"\$PROD_DATABASE_URL\" -f scripts/a0-preflight-verify.sql\` (or copy/paste sections into the prod psql session)
2. Paste output into \`docs/superpowers/tracking/A0-preflight-verify.md\` Evidence/Notes for each row
3. For each item:
   - All ✅ → flip 🟡 → ✅ in tracking + bump README Done count
   - Discrepancy → open remediation PR per linked Dev Action section

## Files

- \`scripts/a0-preflight-verify.sql\` — new, 129 LOC
- \`docs/superpowers/tracking/A0-preflight-verify.md\` — status ⬜ → 🟡, evidence + Q2 answer
- \`docs/superpowers/tracking/README.md\` — A0 row status + Active Focus updated

## Out of scope

- Running on prod (requires owner)
- Remediation actions (separate PRs if any check fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)