### PR TITLE
feat(expense-v2): B2 — Multi-line Adjustment on VENDOR_SETTLEMENT

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/settlement-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/settlement-lifecycle.integration.spec.ts
@@ -194,4 +194,138 @@ describe('Vendor Settlement lifecycle (integration)', () => {
       ),
     ).rejects.toThrow(/เกินยอดที่ค้าง/);
   });
+
+  // ── B2 / K-07 — Settlement with Multi-line Adjustment ──────────────
+  // Clear 1000฿ AP, take 20฿ early-payoff discount → actual cash leg = 980.
+  // V12: signedSum(CR 52-1106: 20) = +20 = amountPaid(980) − netExpected(1000)
+  it('B2 / K-07: SE with discount adjustment posts balanced JE (Dr AP / Cr cash + Cr 52-1106)', async () => {
+    const service = buildService();
+    const user = { id: userId, branchId, role: 'OWNER' };
+    // Create fresh ACCRUAL EX of 1000฿
+    const ex = await service.create(
+      {
+        documentType: 'EXPENSE',
+        branchId,
+        documentDate: new Date().toISOString(),
+        priceType: 'EXCLUSIVE',
+        lines: [{ category: '53-1404', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 0 }],
+      } as never,
+      userId,
+    );
+    await service.post(ex.id, userId); // → ACCRUAL
+
+    // Settlement with 20฿ discount adjustment
+    const se = await service.createSettlement(
+      {
+        branchId,
+        documentDate: new Date().toISOString(),
+        depositAccountCode: '11-1101',
+        lines: [{ clearedDocumentId: ex.id, amountSettled: 1000 }],
+        amountPaid: '980',
+        adjustments: [
+          { accountCode: '52-1106', side: 'CR', amount: '20', note: 'ส่วนลดปิดยอดก่อนกำหนด' },
+        ],
+      } as never,
+      user,
+    );
+    await service.post(se.id, userId);
+
+    const seAfter = await prisma.expenseDocument.findUniqueOrThrow({
+      where: { id: se.id },
+      include: { adjustments: true },
+    });
+    expect(seAfter.status).toBe(DocumentStatus.POSTED);
+    expect(seAfter.netPayment?.toString()).toBe('980');
+    expect(seAfter.adjustments).toHaveLength(1);
+    expect(seAfter.adjustments[0].accountCode).toBe('52-1106');
+    expect(seAfter.adjustments[0].side).toBe('CR');
+
+    // Balanced JE — Dr 21-1104 = 1000 / Cr cash 980 + Cr 52-1106 20 = 1000
+    const je = await prisma.journalEntry.findFirstOrThrow({
+      where: { id: seAfter.journalEntryId! },
+      include: { lines: true },
+    });
+    const drSum = je.lines.reduce((s, l) => s + Number(l.debit), 0);
+    const crSum = je.lines.reduce((s, l) => s + Number(l.credit), 0);
+    expect(drSum).toBeCloseTo(crSum, 2);
+    expect(drSum).toBeCloseTo(1000, 2);
+
+    const apLine = je.lines.find((l) => l.accountCode === '21-1104');
+    const cashLine = je.lines.find((l) => l.accountCode === '11-1101');
+    const discountLine = je.lines.find((l) => l.accountCode === '52-1106');
+    expect(Number(apLine!.debit)).toBeCloseTo(1000, 2);
+    expect(Number(cashLine!.credit)).toBeCloseTo(980, 2);
+    expect(Number(discountLine!.credit)).toBeCloseTo(20, 2);
+
+    // EX is fully cleared → POSTED
+    const exAfter = await prisma.expenseDocument.findUniqueOrThrow({ where: { id: ex.id } });
+    expect(exAfter.status).toBe('POSTED');
+  });
+
+  it('B2 / K-07 negative: SE with adjustments that violate V12 rejects', async () => {
+    const service = buildService();
+    const user = { id: userId, branchId, role: 'OWNER' };
+    const ex = await service.create(
+      {
+        documentType: 'EXPENSE',
+        branchId,
+        documentDate: new Date().toISOString(),
+        priceType: 'EXCLUSIVE',
+        lines: [{ category: '53-1404', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 0 }],
+      } as never,
+      userId,
+    );
+    await service.post(ex.id, userId);
+
+    // amountPaid = 980 but adjustment only sums to +10 (not the required +20)
+    await expect(
+      service.createSettlement(
+        {
+          branchId,
+          documentDate: new Date().toISOString(),
+          depositAccountCode: '11-1101',
+          lines: [{ clearedDocumentId: ex.id, amountSettled: 1000 }],
+          amountPaid: '980',
+          adjustments: [
+            { accountCode: '52-1106', side: 'CR', amount: '10' },
+          ],
+        } as never,
+        user,
+      ),
+    ).rejects.toThrow(/V12/);
+  });
+
+  it('B2 / K-07 disallowed code: SE with adjustment outside ADJUSTMENT_ALLOWLIST rejects', async () => {
+    const service = buildService();
+    const user = { id: userId, branchId, role: 'OWNER' };
+    const ex = await service.create(
+      {
+        documentType: 'EXPENSE',
+        branchId,
+        documentDate: new Date().toISOString(),
+        priceType: 'EXCLUSIVE',
+        lines: [{ category: '53-1404', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 0 }],
+      } as never,
+      userId,
+    );
+    await service.post(ex.id, userId);
+
+    // Try to route the discount to a Revenue account (would balance arithmetically
+    // but violate accounting policy — V13 must reject).
+    await expect(
+      service.createSettlement(
+        {
+          branchId,
+          documentDate: new Date().toISOString(),
+          depositAccountCode: '11-1101',
+          lines: [{ clearedDocumentId: ex.id, amountSettled: 1000 }],
+          amountPaid: '980',
+          adjustments: [
+            { accountCode: '41-1101', side: 'CR', amount: '20' },
+          ],
+        } as never,
+        user,
+      ),
+    ).rejects.toThrow(/V13|allow/i);
+  });
 });

--- a/apps/api/src/modules/expense-documents/dto/create-settlement.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-settlement.dto.ts
@@ -4,6 +4,7 @@ import {
   IsIn,
   IsDateString,
   IsNumber,
+  IsNumberString,
   IsUUID,
   Min,
   ValidateNested,
@@ -11,6 +12,7 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { CASH_ACCOUNT_CODES } from '../../../constants/cash-account.constants';
+import { ExpenseAdjustmentInput } from './expense-adjustment-input.dto';
 
 class SettlementLineInput {
   @IsUUID('4', { message: 'รหัสเอกสารที่ต้องการเคลียร์ไม่ถูกต้อง' })
@@ -70,4 +72,26 @@ export class CreateSettlementDto {
   @IsString()
   @IsOptional()
   fromTemplateId?: string;
+
+  /**
+   * Multi-line Adjustment (B2 / Dev Action #2). When the actual amount paid
+   * to the vendor differs from `sumSettled − wht` (e.g. supplier discount,
+   * bank fee, rounding), adjustments balance the gap. Signed-sum rule (V12):
+   *   Σ signed(adjustments) === amountPaid − (sumSettled − wht)
+   * where CR contributes +amount and DR contributes −amount.
+   * Allow-list of accountCodes is enforced server-side (V13).
+   */
+  @ValidateNested({ each: true })
+  @Type(() => ExpenseAdjustmentInput)
+  @IsOptional()
+  adjustments?: ExpenseAdjustmentInput[];
+
+  /**
+   * Actual cash leg paid to vendor. When set, must reconcile via V12 against
+   * `sumSettled − wht` ± Σ signed(adjustments). Omitted ⇒ defaults to
+   * `sumSettled − wht` (legacy zero-adjustment behaviour).
+   */
+  @IsNumberString({ no_symbols: true })
+  @IsOptional()
+  amountPaid?: string;
 }

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -113,6 +113,73 @@ export class ExpenseDocumentsService implements OnModuleInit {
     private readonly ssoConfig: SsoConfigService,
   ) {}
 
+  // ─── V12/V13/V14 — Multi-line Adjustment validation (shared) ────────
+  // Fix Report P0-4 + B2. Validates that:
+  //   V12  Σ signed(adjustments) === amountPaid − netExpected
+  //   V13  every accountCode exists in CoA and is on ADJUSTMENT_ALLOWLIST
+  //   V14  every row.amount > 0 and accountCode is non-empty
+  // Signed convention: CR contributes +amount, DR contributes −amount.
+  private async validateAdjustments(
+    tx: Prisma.TransactionClient,
+    opts: {
+      adjustments: { accountCode: string; side: 'DR' | 'CR'; amount: string | number; note?: string }[];
+      netExpected: Prisma.Decimal;
+      amountPaid: Prisma.Decimal;
+    },
+  ): Promise<void> {
+    const { adjustments, netExpected, amountPaid } = opts;
+    const diff = amountPaid.minus(netExpected);
+
+    if (adjustments.length === 0 && diff.eq(0)) return; // fast path — no adjustments needed
+
+    // V14 — non-empty accountCode + positive amount
+    for (let i = 0; i < adjustments.length; i++) {
+      const a = adjustments[i];
+      if (!a.accountCode || !a.accountCode.trim()) {
+        throw new BadRequestException(`V13: บัญชีปรับผลต่างแถวที่ ${i + 1} ยังไม่ได้เลือกบัญชี`);
+      }
+      const amt = new Prisma.Decimal(a.amount);
+      if (amt.lte(0)) {
+        throw new BadRequestException(
+          `V14: บัญชีปรับผลต่างแถวที่ ${i + 1}: จำนวนต้องมากกว่า 0`,
+        );
+      }
+    }
+
+    // V13 — code exists in CoA AND on the allow-list
+    if (adjustments.length > 0) {
+      const adjCodes = [...new Set(adjustments.map((a) => a.accountCode))];
+      const adjCoaRows = await tx.chartOfAccount.findMany({
+        where: { code: { in: adjCodes }, deletedAt: null },
+        select: { code: true },
+      });
+      const adjFound = new Set(adjCoaRows.map((r) => r.code));
+      for (const c of adjCodes) {
+        if (!adjFound.has(c)) {
+          throw new BadRequestException(`V13: บัญชีปรับผลต่าง ${c} ไม่พบในผังบัญชี`);
+        }
+        if (!ADJUSTMENT_ALLOWLIST.has(c)) {
+          throw new BadRequestException(
+            `V13: บัญชีปรับผลต่าง ${c} ไม่อยู่ในรายการที่อนุญาต — ` +
+              `อนุญาตเฉพาะ ${[...ADJUSTMENT_ALLOWLIST].join(', ')}`,
+          );
+        }
+      }
+    }
+
+    // V12 — Σ signed(adjustments) === diff
+    const signedSum = adjustments.reduce<Prisma.Decimal>((s, a) => {
+      const amt = new Prisma.Decimal(a.amount);
+      return a.side === 'CR' ? s.plus(amt) : s.minus(amt);
+    }, new Prisma.Decimal(0));
+    if (!signedSum.eq(diff)) {
+      throw new BadRequestException(
+        `V12: ผลรวมบัญชีปรับผลต่าง (signed = ${signedSum.toFixed(2)}) ` +
+          `ไม่เท่ากับผลต่าง amount_paid − net_expected (${diff.toFixed(2)})`,
+      );
+    }
+  }
+
   // ─── Create ──────────────────────────────────────────────────────────
   async create(dto: CreateExpenseDocumentDto, userId: string) {
     const documentDate = new Date(dto.documentDate);
@@ -140,77 +207,14 @@ export class ExpenseDocumentsService implements OnModuleInit {
       }
 
       // Fix Report P0-4 — multi-line adjustment validation (V12/V13/V14).
-      // When `amountPaid` differs from `netExpected = totalAmount − wht`, the
-      // signed sum of adjustments must close the gap exactly.
-      const adjustments = dto.adjustments ?? [];
+      // Shared helper used here (EXPENSE) and by createSettlement (B2 / SE).
       const totalAmount = new Prisma.Decimal(totals.totalAmount.toString());
       const wht = new Prisma.Decimal(totals.withholdingTax.toString());
       const netExpected = totalAmount.minus(wht);
       const amountPaid =
         dto.amountPaid !== undefined ? new Prisma.Decimal(dto.amountPaid) : netExpected;
-      const diff = amountPaid.minus(netExpected);
-
-      if (adjustments.length > 0 || !diff.eq(0)) {
-        // V13/V14 — each row must have accountCode + amount > 0
-        for (let i = 0; i < adjustments.length; i++) {
-          const a = adjustments[i];
-          if (!a.accountCode || !a.accountCode.trim()) {
-            throw new BadRequestException(
-              `V13: บัญชีปรับผลต่างแถวที่ ${i + 1} ยังไม่ได้เลือกบัญชี`,
-            );
-          }
-          const amt = new Prisma.Decimal(a.amount);
-          if (amt.lte(0)) {
-            throw new BadRequestException(
-              `V14: บัญชีปรับผลต่างแถวที่ ${i + 1}: จำนวนต้องมากกว่า 0`,
-            );
-          }
-        }
-
-        // V13 — adjustment account codes must exist in CoA AND be on the
-        // explicit allow-list. Without the allow-list, an accountant could
-        // pick Revenue (41-xxxx) or Cash (11-1101) as the offset, balancing
-        // the JE arithmetically but causing P&L / cash-flow drift.
-        //
-        // Allow-list scope: small-amount rounding tolerance + bank fees +
-        // early-payoff discounts. Source: accounting.md chart.
-        //   52-1104 — ส่วนลดเศษสตางค์ (≤1฿ rounding tolerance)
-        //   52-1106 — ส่วนลดดอกเบี้ย-ปิดยอด
-        //   53-1303 — ค่าธรรมเนียมธนาคาร
-        //   53-1503 — กำไร/ขาดทุนจากการปัดเศษ
-        if (adjustments.length > 0) {
-          const adjCodes = [...new Set(adjustments.map((a) => a.accountCode))];
-          const adjCoaRows = await tx.chartOfAccount.findMany({
-            where: { code: { in: adjCodes }, deletedAt: null },
-            select: { code: true },
-          });
-          const adjFound = new Set(adjCoaRows.map((r) => r.code));
-          for (const c of adjCodes) {
-            if (!adjFound.has(c)) {
-              throw new BadRequestException(`V13: บัญชีปรับผลต่าง ${c} ไม่พบในผังบัญชี`);
-            }
-            if (!ADJUSTMENT_ALLOWLIST.has(c)) {
-              throw new BadRequestException(
-                `V13: บัญชีปรับผลต่าง ${c} ไม่อยู่ในรายการที่อนุญาต — ` +
-                  `อนุญาตเฉพาะ ${[...ADJUSTMENT_ALLOWLIST].join(', ')}`,
-              );
-            }
-          }
-        }
-
-        // V12 — Σ signed(adjustments) must equal diff.
-        // Signed convention: side='CR' contributes +amount (offsets Dr); side='DR' contributes −amount (offsets Cr).
-        const signedSum = adjustments.reduce<Prisma.Decimal>((s, a) => {
-          const amt = new Prisma.Decimal(a.amount);
-          return a.side === 'CR' ? s.plus(amt) : s.minus(amt);
-        }, new Prisma.Decimal(0));
-        if (!signedSum.eq(diff)) {
-          throw new BadRequestException(
-            `V12: ผลรวมบัญชีปรับผลต่าง (signed = ${signedSum.toFixed(2)}) ` +
-              `ไม่เท่ากับผลต่าง amount_paid − net_expected (${diff.toFixed(2)})`,
-          );
-        }
-      }
+      const adjustments = dto.adjustments ?? [];
+      await this.validateAdjustments(tx, { adjustments, netExpected, amountPaid });
 
       const number = await this.docNumber.next(tx, 'EXPENSE', documentDate);
 
@@ -597,6 +601,16 @@ export class ExpenseDocumentsService implements OnModuleInit {
           `หัก ณ ที่จ่าย (${wht}) เกินยอดรวมที่จ่าย (${sumSettled})`,
         );
       }
+
+      // B2 — V12/V13/V14 Multi-line Adjustment validation on SETTLEMENT.
+      // Mirrors EXPENSE_SAMEDAY: when the actual cash leg (amountPaid) differs
+      // from the expected `sumSettled − wht`, adjustments balance the gap.
+      const netExpected = sumSettled.minus(wht);
+      const amountPaid =
+        dto.amountPaid !== undefined ? new Prisma.Decimal(dto.amountPaid) : netExpected;
+      const adjustments = dto.adjustments ?? [];
+      await this.validateAdjustments(tx, { adjustments, netExpected, amountPaid });
+
       const documentDate = new Date(dto.documentDate);
       const number = await this.docNumber.next(tx, 'VENDOR_SETTLEMENT', documentDate);
 
@@ -613,7 +627,9 @@ export class ExpenseDocumentsService implements OnModuleInit {
           withholdingTax: wht,
           whtFormType: dto.whtFormType ?? null,
           totalAmount: sumSettled,
-          netPayment: sumSettled.minus(wht),
+          // netPayment = actual cash leg. With no adjustments this equals
+          // `sumSettled − wht`; with adjustments it absorbs the signed delta.
+          netPayment: amountPaid,
           depositAccountCode: dto.depositAccountCode,
           paymentMethod: (dto.paymentMethod as never) ?? null,
           status: 'DRAFT',
@@ -631,8 +647,23 @@ export class ExpenseDocumentsService implements OnModuleInit {
               },
             },
           },
+          adjustments:
+            adjustments.length > 0
+              ? {
+                  create: adjustments.map((a, idx) => ({
+                    lineNo: idx + 1,
+                    accountCode: a.accountCode,
+                    side: a.side,
+                    amount: new Prisma.Decimal(a.amount),
+                    note: a.note ?? null,
+                  })),
+                }
+              : undefined,
         },
-        include: { settlement: { include: { settlementLines: true } } },
+        include: {
+          settlement: { include: { settlementLines: true } },
+          adjustments: { orderBy: { lineNo: 'asc' } },
+        },
       });
     });
   }

--- a/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts
@@ -55,7 +55,10 @@ export class VendorSettlementTemplate {
 
       const se = await tx.expenseDocument.findUniqueOrThrow({
         where: { id: documentId },
-        include: { settlement: { include: { settlementLines: true } } },
+        include: {
+          settlement: { include: { settlementLines: true } },
+          adjustments: { orderBy: { lineNo: 'asc' } },
+        },
       });
 
       // Belt-and-braces — same check after the heavy fetch, in case the
@@ -102,7 +105,12 @@ export class VendorSettlementTemplate {
         zero,
       );
       const wht = new Decimal(se.withholdingTax.toString());
-      const cashLeg = sumSettled.minus(wht);
+      // B2 — cash leg comes from netPayment (which the service set during create
+      // to honor V12: amountPaid ± Σ signed(adjustments)). For SE with no
+      // adjustments this equals `sumSettled − wht` (legacy path). With
+      // adjustments, the gap between sumSettled-wht and netPayment is exactly
+      // Σ signed(adjustments), so the JE still balances.
+      const cashLeg = new Decimal(se.netPayment?.toString() ?? sumSettled.minus(wht).toString());
 
       const lines: JeLineInput[] = [
         {
@@ -130,6 +138,21 @@ export class VendorSettlementTemplate {
           dr: zero,
           cr: wht,
           description: `หัก ณ ที่จ่าย ${formType}`,
+        });
+      }
+
+      // B2 — Multi-line Adjustment. Each row contributes one JE line on its
+      // declared side. V12 already proved Σ signed(adjustments) === amountPaid
+      // − (sumSettled − wht), so adding these lines after WHT keeps the JE
+      // balanced no matter the direction (discount → Cr 52-1106, bank fee →
+      // Dr 53-1303, rounding tolerance → Dr/Cr 52-1104, etc.).
+      for (const adj of se.adjustments ?? []) {
+        const amt = new Decimal(adj.amount.toString());
+        lines.push({
+          accountCode: adj.accountCode,
+          dr: adj.side === 'DR' ? amt : zero,
+          cr: adj.side === 'CR' ? amt : zero,
+          description: adj.note ?? `ปรับผลต่าง ${adj.accountCode}`,
         });
       }
 
@@ -221,14 +244,15 @@ export class VendorSettlementTemplate {
       // so this partial SE will consume the cap correctly once it itself
       // becomes POSTED below.
 
-      // Update SE itself
+      // Update SE itself. netPayment was already set during create — don't
+      // overwrite it (post-create it equals amountPaid; overwriting with
+      // cashLeg would be the same value but is redundant work).
       await tx.expenseDocument.update({
         where: { id: se.id },
         data: {
           status: 'POSTED',
           paidAt: se.documentDate,
           journalEntryId: result.id,
-          netPayment: cashLeg,
         },
       });
 

--- a/docs/superpowers/tracking/B2-settlement-adjustment.md
+++ b/docs/superpowers/tracking/B2-settlement-adjustment.md
@@ -1,6 +1,6 @@
 # B2 · Settlement Multi-line Adjustment (V12 expansion)
 
-**Status:** ⬜ Pending  |  **Started:** —  |  **PRs:** —
+**Status:** 🔵 In Review  |  **Started:** 2026-05-16  |  **PRs:** TBD (backend bundled; frontend B2.4 deferred)
 **Spec:** —  ·  **Plan:** —
 
 ## Context
@@ -16,22 +16,25 @@ V12 currently validates adjustment sums for `EXPENSE_SAMEDAY` only (`Σ adjustme
 
 | ID | Item | Priority | Status | PR | Evidence/Notes |
 |---|---|---|---|---|---|
-| B2.1 | V12 validator: extend switch to include `VENDOR_SETTLEMENT` case computing `netExpected = apTotal − wht` | P1 | ⬜ | — | File: `apps/api/src/modules/expense-documents/expense-documents.service.ts` (search for "V12") |
-| B2.2 | `VendorSettlementTemplate.execute` — emit adjustment lines from `settlement.adjustments[]` after WHT line | P1 | ⬜ | — | File: `apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts` |
-| B2.3 | DB schema: ensure `expense_adjustments` table has FK to `expense_documents` that accepts `VENDOR_SETTLEMENT` rows. If a CHECK constraint restricts doc_type, relax it per Dev Action #2 §2.4 | P1 | ⬜ | — | Run `\d expense_adjustments` against dev DB to verify |
-| B2.4 | Frontend: add Section 5 (Multi-line Adjustment) to SettlementForm — reuse `AdjustmentTable` component from ExpenseFormV4 | P1 | ⬜ | — | File: `apps/web/src/components/expense-form-v4/SettlementLinesSection.tsx` (add new section beneath) |
-| B2.5 | K-07 test case: SETTLEMENT + adjustment results in balanced JE with `52-1104` Cr line | P1 | ⬜ | — | Tracks B3.K-07. File: `apps/api/src/modules/expense-documents/__tests__/settlement-lifecycle.integration.spec.ts` |
+| B2.1 | V12 validator: extend to `VENDOR_SETTLEMENT` case computing `netExpected = sumSettled − wht` | P1 | 🔵 | TBD | Extracted shared `validateAdjustments(tx, opts)` private helper in [expense-documents.service.ts](../../../apps/api/src/modules/expense-documents/expense-documents.service.ts) and called from both `create` (EXPENSE) and `createSettlement` (SE). Same V12/V13/V14 logic, same ADJUSTMENT_ALLOWLIST. |
+| B2.2 | `VendorSettlementTemplate.execute` — emit adjustment lines from `doc.adjustments[]` after WHT line | P1 | 🔵 | TBD | [vendor-settlement.template.ts](../../../apps/api/src/modules/journal/cpa-templates/vendor-settlement.template.ts) — `include: { adjustments }`, cash leg now sourced from `doc.netPayment` (which createSettlement set to amountPaid honoring V12), then iterates `doc.adjustments` to emit one Dr/Cr line each per declared side. Existing balanced-JE check in `JournalAutoService.createAndPost` proves V12 invariant end-to-end. |
+| B2.3 | DB schema: ensure `expense_adjustments` FK accepts `VENDOR_SETTLEMENT` rows | P1 | ✅ | n/a | Verified `\d expense_adjustments` on dev DB: FK references `expense_documents(id)` with no CHECK constraint on document_type — polymorphic by design. No migration needed. |
+| B2.4 | Frontend: add Section 5 (Multi-line Adjustment) to SettlementForm — reuse `AdjustmentTable` component from ExpenseFormV4 | P1 | ⬜ | — | **Deferred to follow-up PR** to keep this PR backend-scoped + reviewable. Backend DTO already accepts `adjustments[]` + `amountPaid` so the UI work is purely additive (no further backend changes needed). |
+| B2.5 | K-07 test case: SETTLEMENT + adjustment results in balanced JE with allow-list Cr line | P1 | 🔵 | TBD | 3 new integration tests added to [settlement-lifecycle.integration.spec.ts](../../../apps/api/src/modules/expense-documents/__tests__/settlement-lifecycle.integration.spec.ts): (1) happy path SE with 20฿ discount → balanced JE Dr 21-1104 1000 / Cr cash 980 / Cr 52-1106 20; (2) negative V12 violation; (3) negative V13 violation (rev account 41-1101 rejected). Unit specs: 52/52 pass on the touched suites. |
 
 ## Decision Log
 
-(empty)
+- **2026-05-16:** Bundled B2.1+B2.2+B2.3(verify)+B2.5 backend into one PR. Frontend (B2.4) deferred to a follow-up to keep this PR backend-scoped — DTO already accepts the new fields, so UI is purely additive with no further backend changes.
+- **2026-05-16:** Extracted shared `validateAdjustments(tx, opts)` helper in `ExpenseDocumentsService` rather than copy-paste V12/V13/V14 between `create` (EXPENSE) and `createSettlement` (SE). DRY win; one place to evolve allow-list / messages.
+- **2026-05-16:** SE template cash leg now sourced from `doc.netPayment` (which the service sets to `dto.amountPaid ?? sumSettled − wht` during create). Previously the template derived cash as `sumSettled − wht`, which would have ignored any adjustments-driven delta. Now V12 invariant (`Σ signed(adj) === amountPaid − netExpected`) keeps the JE balanced automatically.
 
 ## Open Questions
 
-- [ ] Q: Should the schema migration in B2.3 happen — or does the FK already allow polymorphic doc_type? Need `\d` output first
-- [ ] Q: SettlementForm Section 5 — should the section appear before or after JE Preview?
+- [x] Q: Should the schema migration in B2.3 happen — or does the FK already allow polymorphic doc_type? Need `\d` output first — **No migration needed**. FK on `expense_adjustments.document_id → expense_documents.id` with no CHECK on document_type. Polymorphic by design.
+- [ ] Q: SettlementForm Section 5 — should the section appear before or after JE Preview? — **Deferred to B2.4 follow-up PR**
 
 ## Dependencies
 
 - ✅ T0
-- B2.5 depends on test infrastructure (B3 Suite K)
+- ✅ ExpenseDocument.adjustments relation (already in schema since P0-4)
+- B2.4 (frontend) is a follow-up after this PR lands — UI is purely additive

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -14,7 +14,7 @@
 | [A0 · Pre-flight Verify](A0-preflight-verify.md) | 3 | 0 | 0% | 🟡 In Progress | — | [script](../../../scripts/a0-preflight-verify.sql) |
 | [A1 · Settings Audit Phase 1+2](A1-settings-audit.md) | 102 | 0 | 0% | ⬜ Pending | — | — |
 | [B1 · SSO 875 Configurable](B1-sso-875.md) | 6 | 6 | 100% | ✅ Done | — | [#861](https://github.com/iamnaii/BESTCHOICE/pull/861) |
-| [B2 · Settlement Multi-line Adj](B2-settlement-adjustment.md) | 5 | 0 | 0% | ⬜ Pending | — | — |
+| [B2 · Settlement Multi-line Adj](B2-settlement-adjustment.md) | 5 | 1 | 20% | 🔵 In Review | — | PR TBD (B2.3 verified) |
 | [B3 · Test Suite J+K](B3-test-suite.md) | 14 | 0 | 0% | ⬜ Pending | — | — |
 | [C1 · Petty Cash](C1-petty-cash.md) | 8 | 0 | 0% | ⬜ Pending | — | — |
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 0 | 0% | ⬜ Pending | — | — |


### PR DESCRIPTION
Extends the Multi-line Adjustment pattern (V12/V13/V14) from EXPENSE_SAMEDAY to SETTLEMENT documents. Backend-only this PR; frontend B2.4 deferred to follow-up.

Closes B2.1, B2.2, B2.3 (verify), B2.5. B2.4 (UI Section 5) deferred.

## Why

Real-world need: supplier offers a discount at settlement time, or there's a small rounding diff after WHT. These should flow through Section 5 Multi-line Adjustment instead of being silently absorbed into the cash leg.

## Architecture

- `CreateSettlementDto` accepts `adjustments[]` + `amountPaid` (same shape as EXPENSE, reuses `ExpenseAdjustmentInput`)
- Extracted shared `validateAdjustments(tx, opts)` private helper on `ExpenseDocumentsService` — called by `create` (EXPENSE) and `createSettlement` (SE). Same V12/V13/V14, same ADJUSTMENT_ALLOWLIST
- `createSettlement` persists adjustments via nested `create` and sets `netPayment = amountPaid`
- `VendorSettlementTemplate` loads `doc.adjustments`, sources cash leg from `doc.netPayment`, emits one Dr/Cr line per adjustment after WHT
- `expense_adjustments` FK polymorphic (verified via `\d`) → no migration needed

## Example JE

Clear 1000฿ AP, WHT 0, take 20฿ early-payoff discount → cash 980:

```
Dr 21-1104    1000   จ่ายเจ้าหนี้
Cr 11-1101     980   cash
Cr 52-1106      20   discount
            ----   ----
            1000   1000   ✓ balanced
```

## Tests

- 52 existing unit tests still pass (helper extraction is behavior-preserving)
- 3 new integration tests for SE+adjustment: happy path, V12 violation, V13 violation
- `./tools/check-types.sh api` 0 errors

## Out of scope

- B2.4 frontend (separate PR; DTO already accepts the fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)