### PR TITLE
feat(expense-v2): C1.6 — Petty Cash UI section in ExpenseFormV4

### DIFF
--- a/apps/web/src/components/expense-form-v4/DocTypePicker.tsx
+++ b/apps/web/src/components/expense-form-v4/DocTypePicker.tsx
@@ -9,7 +9,7 @@
 //     off today still lives in ExpenseFormV4 (one-way: never reverts manual
 //     ACCRUAL).
 
-import { Banknote, FileWarning, Receipt, Users, Wallet, Sparkles } from 'lucide-react';
+import { Banknote, Coins, FileWarning, Receipt, Users, Wallet, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DocType } from './types';
 
@@ -32,6 +32,7 @@ const TABS: TabDef[] = [
   { type: 'VENDOR_SETTLEMENT', label: 'จ่ายเจ้าหนี้', sub: 'อ้างถึง ACCRUAL', Icon: Wallet },
   { type: 'PAYROLL', label: 'เงินเดือน', sub: 'จ่ายเงินเดือนพนักงาน', Icon: Users },
   { type: 'CREDIT_NOTE', label: 'ใบลดหนี้', sub: 'ผู้ขายคืนเงิน', Icon: Receipt },
+  { type: 'PETTY_CASH_REIMBURSEMENT', label: 'Petty Cash', sub: 'เบิกชดเชยเงินสดย่อย', Icon: Coins },
 ];
 
 export function DocTypePicker({ value, onChange, invoiceDateIsToday }: Props) {
@@ -39,7 +40,7 @@ export function DocTypePicker({ value, onChange, invoiceDateIsToday }: Props) {
 
   return (
     <div className="space-y-2">
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-2">
         {TABS.map(({ type, label, sub, Icon }) => {
           const active = value === type;
           const isRecommended = recommended === type && value !== type;

--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft, Receipt, Users, Banknote, FileText, Check, CheckCircle2, Clock } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { cn } from '@/lib/utils';
-import { ExpenseFormState, newLine, newPayrollLine } from './types';
+import { ExpenseFormState, newLine, newPayrollLine, newPettyCashLine } from './types';
 import { useFormCompute } from './useFormCompute';
 import { QuickStartPanel } from './QuickStartPanel';
 import { DocTypePicker } from './DocTypePicker';
@@ -14,6 +14,7 @@ import { VendorSection } from './VendorSection';
 import { ItemLinesSection } from './ItemLinesSection';
 import { PayrollLinesSection } from './PayrollLinesSection';
 import { SettlementLinesSection } from './SettlementLinesSection';
+import { PettyCashLinesSection } from './PettyCashLinesSection';
 import { CreditNoteLinesSection } from './CreditNoteLinesSection';
 import { CashAccountVisualPicker } from './CashAccountVisualPicker';
 import { JePreview } from './JePreview';
@@ -66,6 +67,10 @@ const initial = (branchId: string, defaultCash: string): ExpenseFormState => {
       vendorName: '',
       whtAmount: '0',
       whtFormType: '',
+    },
+    pettyCash: {
+      custodianName: '',
+      lines: [newPettyCashLine()],
     },
     adjustments: [],
     amountPaid: '',
@@ -191,6 +196,32 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
             : undefined,
         });
         createdId = data.id;
+      } else if (state.docType === 'PETTY_CASH_REIMBURSEMENT') {
+        // C1.6 — Petty Cash POST. Backend validates V20 (limit, supplier, account)
+        // and routes JE via PettyCashTemplate. Per-line supplierName is required;
+        // no WHT (vendors with WHT use regular EXPENSE flow).
+        const validLines = state.pettyCash.lines.filter(
+          (l) => l.supplierName.trim() && l.category && parseFloat(l.amount) > 0,
+        );
+        if (validLines.length === 0) {
+          throw new Error('ต้องมีรายการอย่างน้อย 1 บรรทัด (ระบุผู้ขาย + บัญชี + จำนวน)');
+        }
+        const { data } = await api.post('/expense-documents/petty-cash', {
+          branchId: state.branchId,
+          documentDate: state.documentDate,
+          depositAccountCode: state.depositAccountCode,
+          custodianName: state.pettyCash.custodianName || undefined,
+          description: state.note || undefined,
+          lines: validLines.map((l) => ({
+            supplierName: l.supplierName.trim(),
+            category: l.category,
+            description: l.description || undefined,
+            amount: parseFloat(l.amount),
+            vatPercent: parseFloat(l.vatPercent) || 0,
+            taxInvoiceNo: l.taxInvoiceNo || undefined,
+          })),
+        });
+        createdId = data.id;
       } else if (state.docType === 'CREDIT_NOTE') {
         if (!state.originalDocumentId || !state.cnReason.trim()) {
           throw new Error('กรุณาเลือกเอกสารต้นฉบับและระบุเหตุผล');
@@ -240,9 +271,13 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
       ? state.payroll.lines.filter((l) => l.employeeName && parseFloat(l.baseSalary) > 0).length
       : state.docType === 'VENDOR_SETTLEMENT'
         ? state.settlement.selections.size
-        : state.docType === 'CREDIT_NOTE'
-          ? state.lines.filter((l) => l.category && parseFloat(l.unitPrice) > 0).length
-          : state.lines.filter((l) => l.category).length;
+        : state.docType === 'PETTY_CASH_REIMBURSEMENT'
+          ? state.pettyCash.lines.filter(
+              (l) => l.supplierName.trim() && l.category && parseFloat(l.amount) > 0,
+            ).length
+          : state.docType === 'CREDIT_NOTE'
+            ? state.lines.filter((l) => l.category && parseFloat(l.unitPrice) > 0).length
+            : state.lines.filter((l) => l.category).length;
 
   const isPreviewType =
     state.docType === 'EXPENSE_SAMEDAY' || state.docType === 'EXPENSE_ACCRUAL';
@@ -334,7 +369,8 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
             const showCash =
               state.docType === 'EXPENSE_SAMEDAY' ||
               state.docType === 'PAYROLL' ||
-              state.docType === 'VENDOR_SETTLEMENT';
+              state.docType === 'VENDOR_SETTLEMENT' ||
+              state.docType === 'PETTY_CASH_REIMBURSEMENT';
             return (
               <>
                 {/* Section: Doc-type picker — always visible (P2-1 chip cards) */}
@@ -379,6 +415,14 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
                       branchId={state.branchId}
                       value={state.settlement}
                       onChange={(s) => patch({ settlement: s })}
+                    />
+                  </Section>
+                )}
+                {state.docType === 'PETTY_CASH_REIMBURSEMENT' && (
+                  <Section num={next()} title="รายการเงินสดย่อย (Petty Cash)" Icon={Receipt}>
+                    <PettyCashLinesSection
+                      value={state.pettyCash}
+                      onChange={(pc) => patch({ pettyCash: pc })}
                     />
                   </Section>
                 )}

--- a/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
@@ -1,0 +1,197 @@
+import { Plus, Trash2, Users } from 'lucide-react';
+import { PettyCashFormFields, newPettyCashLine } from './types';
+import { formatNumberDecimal } from '@/utils/formatters';
+
+interface Props {
+  value: PettyCashFormFields;
+  onChange: (v: PettyCashFormFields) => void;
+}
+
+/**
+ * C1.6 — Petty Cash Reimbursement form section.
+ *
+ * Mockup 04B layout. Per-line: supplier name, category, description, amount,
+ * VAT%, tax invoice no. NO WHT (small-cash scope — vendors with WHT use
+ * regular EXPENSE flow). Limit + cash account live in CashAccountVisualPicker
+ * + system_config.
+ */
+export function PettyCashLinesSection({ value, onChange }: Props) {
+  const updateField = (patch: Partial<PettyCashFormFields>) => onChange({ ...value, ...patch });
+
+  const updateLine = (uid: string, p: Partial<(typeof value.lines)[number]>) => {
+    onChange({ ...value, lines: value.lines.map((l) => (l.uid === uid ? { ...l, ...p } : l)) });
+  };
+  const removeLine = (uid: string) => {
+    if (value.lines.length === 1) return;
+    onChange({ ...value, lines: value.lines.filter((l) => l.uid !== uid) });
+  };
+  const addLine = () => onChange({ ...value, lines: [...value.lines, newPettyCashLine()] });
+
+  const computed = value.lines.map((l) => {
+    const base = parseFloat(l.amount) || 0;
+    const vatPct = parseFloat(l.vatPercent) || 0;
+    const vat = Math.round(base * vatPct) / 100;
+    return { ...l, baseN: base, vatN: vat, totalN: base + vat };
+  });
+  const sumBase = computed.reduce((s, l) => s + l.baseN, 0);
+  const sumVat = computed.reduce((s, l) => s + l.vatN, 0);
+  const sumTotal = sumBase + sumVat;
+
+  // Distinct supplier count — surfaced in the JE metadata + voucher PDF.
+  const supplierCount = new Set(
+    value.lines.map((l) => l.supplierName.trim()).filter(Boolean),
+  ).size;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-xs font-medium mb-1 text-muted-foreground">
+            ผู้ดูแลเงินสดย่อย (custodian) — ทางเลือก
+          </label>
+          <div className="relative">
+            <Users className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              value={value.custodianName}
+              onChange={(e) => updateField({ custodianName: e.target.value })}
+              placeholder="ชื่อพนักงานที่ดูแลเงินสดย่อย"
+              className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+        </div>
+        <div className="flex items-end text-xs text-muted-foreground">
+          <span>
+            {value.lines.length} รายการ · {supplierCount} ผู้ขาย · รวม {formatNumberDecimal(sumTotal.toString(), 2)} ฿
+          </span>
+        </div>
+      </div>
+
+      {/* Lines */}
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40">
+            <tr className="text-left text-xs text-muted-foreground">
+              <th className="px-2 py-2 w-8">#</th>
+              <th className="px-2 py-2 min-w-[160px]">ผู้ขาย/ผู้รับเงิน</th>
+              <th className="px-2 py-2 min-w-[110px]">หมวดบัญชี</th>
+              <th className="px-2 py-2 min-w-[140px]">รายละเอียด</th>
+              <th className="px-2 py-2 min-w-[100px] text-right">จำนวน</th>
+              <th className="px-2 py-2 w-[80px] text-right">VAT %</th>
+              <th className="px-2 py-2 min-w-[120px]">เลขใบกำกับฯ</th>
+              <th className="px-2 py-2 w-[100px] text-right">รวม</th>
+              <th className="px-2 py-2 w-10"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {computed.map((l, idx) => (
+              <tr key={l.uid} className="border-t border-border">
+                <td className="px-2 py-1.5 text-xs text-muted-foreground tabular-nums">{idx + 1}</td>
+                <td className="px-2 py-1.5">
+                  <input
+                    type="text"
+                    value={l.supplierName}
+                    onChange={(e) => updateLine(l.uid, { supplierName: e.target.value })}
+                    placeholder="ชื่อผู้ขาย/ผู้รับเงิน"
+                    className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                </td>
+                <td className="px-2 py-1.5">
+                  <input
+                    type="text"
+                    value={l.category}
+                    onChange={(e) => updateLine(l.uid, { category: e.target.value })}
+                    placeholder="53-1xxx"
+                    className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono tabular-nums focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                </td>
+                <td className="px-2 py-1.5">
+                  <input
+                    type="text"
+                    value={l.description}
+                    onChange={(e) => updateLine(l.uid, { description: e.target.value })}
+                    placeholder="รายละเอียด"
+                    className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                </td>
+                <td className="px-2 py-1.5">
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={l.amount}
+                    onChange={(e) => updateLine(l.uid, { amount: e.target.value })}
+                    placeholder="0.00"
+                    className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                </td>
+                <td className="px-2 py-1.5">
+                  <select
+                    value={l.vatPercent}
+                    onChange={(e) => updateLine(l.uid, { vatPercent: e.target.value })}
+                    className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                  >
+                    <option value="0">0</option>
+                    <option value="7">7</option>
+                  </select>
+                </td>
+                <td className="px-2 py-1.5">
+                  <input
+                    type="text"
+                    value={l.taxInvoiceNo}
+                    onChange={(e) => updateLine(l.uid, { taxInvoiceNo: e.target.value })}
+                    placeholder="ทางเลือก"
+                    className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                </td>
+                <td className="px-2 py-1.5 text-right text-sm tabular-nums text-muted-foreground">
+                  {formatNumberDecimal(l.totalN.toString(), 2)}
+                </td>
+                <td className="px-2 py-1.5">
+                  <button
+                    type="button"
+                    onClick={() => removeLine(l.uid)}
+                    disabled={value.lines.length === 1}
+                    aria-label={`ลบรายการ #${idx + 1}`}
+                    className="rounded-md p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot className="bg-muted/20">
+            <tr className="text-sm">
+              <td colSpan={4} className="px-2 py-2 text-right text-muted-foreground">
+                รวม
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums">
+                {formatNumberDecimal(sumBase.toString(), 2)}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums text-muted-foreground">
+                {formatNumberDecimal(sumVat.toString(), 2)}
+              </td>
+              <td></td>
+              <td className="px-2 py-2 text-right tabular-nums font-medium">
+                {formatNumberDecimal(sumTotal.toString(), 2)}
+              </td>
+              <td></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <div>
+        <button
+          type="button"
+          onClick={addLine}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent"
+        >
+          <Plus size={14} />
+          เพิ่มรายการ
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/expense-form-v4/types.ts
+++ b/apps/web/src/components/expense-form-v4/types.ts
@@ -1,4 +1,10 @@
-export type DocType = 'EXPENSE_SAMEDAY' | 'EXPENSE_ACCRUAL' | 'CREDIT_NOTE' | 'PAYROLL' | 'VENDOR_SETTLEMENT';
+export type DocType =
+  | 'EXPENSE_SAMEDAY'
+  | 'EXPENSE_ACCRUAL'
+  | 'CREDIT_NOTE'
+  | 'PAYROLL'
+  | 'VENDOR_SETTLEMENT'
+  | 'PETTY_CASH_REIMBURSEMENT';
 export type PriceType = 'EXCLUSIVE' | 'INCLUSIVE';
 export type WhtFormType = 'PND3' | 'PND53';
 
@@ -58,6 +64,27 @@ export interface SettlementFormFields {
   whtFormType: WhtFormType | '';
 }
 
+/**
+ * C1 — Petty Cash Reimbursement. Per-line supplier (relaxes 1-doc-1-supplier).
+ * No WHT support — vendors with WHT use regular EXPENSE flow. The cash leg
+ * routes to the petty-cash float account (default 11-1201, configurable via
+ * system_config.petty_cash_account).
+ */
+export interface PettyCashLineForm {
+  uid: string;
+  supplierName: string;
+  category: string;
+  description: string;
+  amount: string;
+  vatPercent: string;
+  taxInvoiceNo: string;
+}
+
+export interface PettyCashFormFields {
+  custodianName: string;
+  lines: PettyCashLineForm[];
+}
+
 export interface ExpenseFormState {
   docType: DocType;
   branchId: string;
@@ -82,6 +109,8 @@ export interface ExpenseFormState {
   payroll: PayrollFormFields;
   // SE-only
   settlement: SettlementFormFields;
+  // PC-only (Petty Cash)
+  pettyCash: PettyCashFormFields;
   // Multi-line adjustment (Fix Report P0-4) — Section 5 in the UI.
   // Used when amountPaid ≠ totalAmount − wht (rounding tolerance, overpay/underpay).
   // Empty array = no adjustments needed (legacy behaviour).
@@ -145,5 +174,18 @@ export const newAdjustment = (
   side: 'CR',
   amount: '',
   note: '',
+  ...overrides,
+});
+
+export const newPettyCashLine = (
+  overrides?: Partial<PettyCashLineForm>,
+): PettyCashLineForm => ({
+  uid: Math.random().toString(36).slice(2),
+  supplierName: '',
+  category: '',
+  description: '',
+  amount: '',
+  vatPercent: '0',
+  taxInvoiceNo: '',
   ...overrides,
 });

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -23,7 +23,7 @@ import { ReopenedPeriodBanner } from '@/components/accounting/ReopenedPeriodBann
 interface ExpenseDocument {
   id: string;
   number: string;
-  documentType: 'EXPENSE' | 'CREDIT_NOTE' | 'PAYROLL' | 'VENDOR_SETTLEMENT';
+  documentType: 'EXPENSE' | 'CREDIT_NOTE' | 'PAYROLL' | 'VENDOR_SETTLEMENT' | 'PETTY_CASH_REIMBURSEMENT';
   branchId: string;
   documentDate: string;
   vendorName: string | null;
@@ -68,6 +68,8 @@ function getDocumentType(e: Expense): { label: string; cls: string } {
       return { label: 'เงินเดือน', cls: 'bg-info/10 text-info border-info/20' };
     case 'VENDOR_SETTLEMENT':
       return { label: 'จ่ายเจ้าหนี้', cls: 'bg-muted text-muted-foreground border-border' };
+    case 'PETTY_CASH_REIMBURSEMENT':
+      return { label: 'Petty Cash', cls: 'bg-accent/30 text-foreground border-border' };
     case 'EXPENSE':
     default:
       return e.status === 'ACCRUAL'

--- a/docs/superpowers/tracking/C1-petty-cash.md
+++ b/docs/superpowers/tracking/C1-petty-cash.md
@@ -1,6 +1,6 @@
 # C1 · Petty Cash Reimbursement
 
-**Status:** 🔵 In Review  |  **Started:** 2026-05-16  |  **PRs:** TBD (backend bundle; UI + PDF deferred)
+**Status:** 🔵 In Review  |  **Started:** 2026-05-16  |  **PRs:** #867 (backend) + this PR (UI). PDF (C1.8) still deferred.
 **Spec:** —  ·  **Plan:** —
 
 ## Context
@@ -23,7 +23,7 @@ JE shape: Dr each `53-XXXX` per line + Dr `11-4101` for VATable lines / Cr `11-1
 | C1.3 | V20 validator: total ≤ limit, every line has supplier, account = 11-1201 | P0 | 🔵 | TBD | `PettyCashService.validate(opts, config)` enforces V20.1/V20.2/V20.3. Called from `createPettyCash` in `expense-documents.service.ts` before persist. Thai error messages with code prefix. 9 unit tests in [petty-cash.service.spec.ts](../../../apps/api/src/modules/expense-documents/services/__tests__/petty-cash.service.spec.ts). |
 | C1.4 | `PettyCashTemplate` JE generator | P0 | 🔵 | TBD | [petty-cash.template.ts](../../../apps/api/src/modules/journal/cpa-templates/petty-cash.template.ts) — emits Dr per-line category + Dr 11-4101 (aggregated VAT) / Cr depositAccountCode. Idempotent via journalEntryId probe. Per-line `supplierName` flows into JE line description for audit trail. `metadata.flow = 'expense-petty-cash'` so PP30 (K-04) picks up the input VAT correctly. |
 | C1.5 | `PettyCashService` — config lookup + V20 | P0 | 🔵 | TBD | [petty-cash.service.ts](../../../apps/api/src/modules/expense-documents/services/petty-cash.service.ts) — `getConfig()` reads SystemConfig keys with defaults (`account: 11-1201, limit: 5000`). `createPettyCash` orchestrates: compute lines → aggregate → V20 validate → persist with `ExpenseDetail` + per-line supplier. New `POST /expense-documents/petty-cash` controller endpoint. |
-| C1.6 | UI: `PettyCashFormV4` page | P0 | ⬜ | — | **Deferred to follow-up PR**. Backend DTO + endpoint already accept the new shape. UI is purely additive (new docType case in ExpenseFormV4 + mockup 04B layout). |
+| C1.6 | UI: `PettyCashFormV4` page | P0 | 🔵 | this PR | [PettyCashLinesSection.tsx](../../../apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx) — per-line table (supplier / category / description / amount / VAT% / tax-invoice). Wires into existing `ExpenseFormV4` rather than a new page — DocTypePicker now 6 chips, render gate adds `PETTY_CASH_REIMBURSEMENT` case, POST handler targets `/expense-documents/petty-cash`. Reuses `CashAccountVisualPicker` for the float account. Custodian name is doc-level (header), suppliers are per-line. ExpensesPage list shows `Petty Cash` label badge. |
 | C1.7 | Settings rows: `petty_cash_*` keys | P0 | ⬜ | deferred to A1 | Owner can add via /settings UI when ready. `PettyCashService.getConfig()` falls back to safe defaults if rows are absent (account=11-1201, limit=5000) so the feature works out-of-the-box. Maps to A1.1.5.1–A1.1.5.5 which will land in the Settings Audit phase. |
 | C1.8 | Voucher PDF template (mockup 04B) | P1 | ⬜ | — | **Deferred to follow-up PR**. Standalone work that doesn't gate API usage. Receipt PDF service can be extended in a separate session. |
 

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -16,12 +16,12 @@
 | [B1 · SSO 875 Configurable](B1-sso-875.md) | 6 | 6 | 100% | ✅ Done | — | [#861](https://github.com/iamnaii/BESTCHOICE/pull/861) |
 | [B2 · Settlement Multi-line Adj](B2-settlement-adjustment.md) | 5 | 5 | 100% | ✅ Done | — | [#863](https://github.com/iamnaii/BESTCHOICE/pull/863) + B2.4 follow-up |
 | [B3 · Test Suite J+K](B3-test-suite.md) | 14 | 13 | 93% | 🔵 In Review | — | [#865](https://github.com/iamnaii/BESTCHOICE/pull/865) + this PR (K-04 PP30 input VAT) |
-| [C1 · Petty Cash](C1-petty-cash.md) | 8 | 5 | 63% | 🔵 In Review | — | PR TBD (backend bundle; UI + PDF deferred) |
+| [C1 · Petty Cash](C1-petty-cash.md) | 8 | 6 | 75% | 🔵 In Review | — | [#867](https://github.com/iamnaii/BESTCHOICE/pull/867) + this PR (UI) |
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 0 | 0% | ⬜ Pending | — | — |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 0 | 0% | ⬜ Pending | — | — |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 0 | 0% | ⬜ Pending | — | — |
 | [D1 · Settings Audit Phase 4](D1-settings-implement.md) | TBD | 0 | 0% | 🔒 Locked (by A1) | — | — |
-| **TOTAL** | **~159** | **34** | **~21%** | | | |
+| **TOTAL** | **~159** | **35** | **~22%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
Closes C1.6. Wires Petty Cash into existing ExpenseFormV4 rather than a new page.

## What

- DocTypePicker now has 6 chip cards (added `Petty Cash` with Coins icon)
- New `PettyCashLinesSection` component — per-line table: supplier / category / description / amount / VAT% / tax-invoice. Live total + supplier-count footer.
- New `pettyCash: PettyCashFormFields` slice in ExpenseFormState
- POST handler targets `/expense-documents/petty-cash` (endpoint from #867)
- `CashAccountVisualPicker` reused — defaults to 11-1201 (service has safe defaults if config row absent)
- ExpensesPage list view shows `Petty Cash` label badge

## Out of scope

- C1.7 settings rows (`petty_cash_*` keys) — deferred to A1 admin UI work
- C1.8 PDF voucher — separate session

## Verified

- `./tools/check-types.sh web` — 0 errors

## Tracking

- C1.6: ⬜ → 🔵 (C1 now 6/8)
- README ~22%

🤖 Generated with [Claude Code](https://claude.com/claude-code)