### PR TITLE
feat(expense-v2): C1.8 — Petty Cash voucher PDF (mockup 04B layout)

### DIFF
--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -34,6 +34,9 @@ export interface ExpenseLine {
   // 50 ทวิ requirement (itemize the WHT rate per income type) is met when a
   // single document mixes vendors with different rates.
   whtPercent?: string;
+  // C1 — Petty Cash carries supplier per line (relaxes 1-doc-1-supplier).
+  // Null for non-petty doc types.
+  supplierName?: string | null;
 }
 
 interface JournalLine {
@@ -46,6 +49,17 @@ interface JournalLine {
 interface VoucherDoc {
   id: string;
   number: string;
+  /**
+   * C1 — branches voucher layout: PETTY_CASH_REIMBURSEMENT renders a
+   * compact multi-supplier sheet (no WHT cert, no signature grid). All other
+   * doc types use the standard ใบสำคัญจ่าย layout.
+   */
+  documentType:
+    | 'EXPENSE'
+    | 'CREDIT_NOTE'
+    | 'PAYROLL'
+    | 'VENDOR_SETTLEMENT'
+    | 'PETTY_CASH_REIMBURSEMENT';
   documentDate: string;
   vendorName: string | null;
   vendorTaxId: string | null;
@@ -82,9 +96,16 @@ export default function PaymentVoucherPage() {
   // No auto-print — owner asked for explicit button.
 
   useEffect(() => {
-    document.title = docQuery.data
-      ? `ใบสำคัญจ่าย ${docQuery.data.number}`
-      : 'ใบสำคัญจ่าย';
+    const data = docQuery.data;
+    if (!data) {
+      document.title = 'ใบสำคัญจ่าย';
+      return;
+    }
+    const title =
+      data.documentType === 'PETTY_CASH_REIMBURSEMENT'
+        ? `ใบเบิกชดเชยเงินสดย่อย ${data.number}`
+        : `ใบสำคัญจ่าย ${data.number}`;
+    document.title = title;
   }, [docQuery.data]);
 
   return (
@@ -134,15 +155,186 @@ export default function PaymentVoucherPage() {
 }
 
 function VoucherSheet({ doc }: { doc: VoucherDoc }) {
+  const isPettyCash = doc.documentType === 'PETTY_CASH_REIMBURSEMENT';
   const hasWht = parseFloat(doc.withholdingTax || '0') > 0;
   const net = doc.netPayment ?? doc.totalAmount;
   const amountText = numToThaiText(parseFloat(net));
+
+  // C1.8 — Petty Cash uses its own compact sheet (no WHT, multi-supplier table,
+  // no signature grid per spec). All other doc types fall through to the
+  // standard ใบสำคัญจ่าย layout.
+  if (isPettyCash) {
+    return (
+      <div className="max-w-[210mm] mx-auto py-6 px-6 print:px-0 print:py-0 space-y-6">
+        <PettyCashSheet doc={doc} amountInText={amountText} net={net} />
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-[210mm] mx-auto py-6 px-6 print:px-0 print:py-0 space-y-6">
       <Sheet doc={doc} amountInText={amountText} net={net} />
       {hasWht && <WhtCertificate doc={doc} />}
     </div>
+  );
+}
+
+/**
+ * C1.8 — Petty Cash voucher sheet (mockup 04B).
+ * Differences vs standard ใบสำคัญจ่าย:
+ *   - title: "ใบเบิกชดเชยเงินสดย่อย"
+ *   - meta: custodian (from doc.vendorName which we repurpose at backend) instead of vendor
+ *   - item table: per-row supplier column; no WHT column
+ *   - totals: drop WHT row
+ *   - no WHT certificate
+ *   - no signature grid (mockup 04B: signed inline in description, no formal sigs)
+ */
+function PettyCashSheet({
+  doc,
+  amountInText,
+  net,
+}: {
+  doc: VoucherDoc;
+  amountInText: string;
+  net: string;
+}) {
+  const lines = doc.expenseDetail?.lines ?? [];
+  // Distinct supplier count for the badge — useful auditing surface since
+  // petty cash is the only doc type that mixes vendors per document.
+  const supplierCount = new Set(
+    lines.map((l) => (l.supplierName ?? '').trim()).filter(Boolean),
+  ).size;
+  return (
+    <article
+      className="voucher-sheet bg-white border border-border rounded-md p-8 shadow-sm print:border-0 print:p-0 print:shadow-none"
+      style={{ minHeight: '270mm' }}
+    >
+      <header className="text-center border-b-2 border-foreground pb-3">
+        <h1 className="text-xl font-bold">BESTCHOICE FINANCE × SHOP</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
+        </p>
+        <h2 className="text-2xl font-bold tracking-wider mt-4">ใบเบิกชดเชยเงินสดย่อย</h2>
+        <p className="text-xs text-muted-foreground">Petty Cash Reimbursement Voucher</p>
+      </header>
+
+      <section className="grid grid-cols-2 gap-x-8 gap-y-2 mt-5 text-sm">
+        <MetaRow label="เลขที่เอกสาร" value={doc.number} mono />
+        <MetaRow label="วันที่" value={formatThaiDateLong(doc.documentDate)} />
+        <MetaRow label="ผู้ดูแลเงินสดย่อย" value={doc.vendorName ?? '—'} />
+        <MetaRow label="บัญชีเงินสดย่อย" value={doc.depositAccountCode ?? '—'} mono />
+        <MetaRow label="จำนวนผู้ขาย" value={`${supplierCount} ราย · ${lines.length} รายการ`} />
+        <MetaRow label="สถานะ" value={doc.status} mono />
+        {doc.description && (
+          <div className="col-span-2">
+            <MetaRow label="คำอธิบาย" value={doc.description} />
+          </div>
+        )}
+      </section>
+
+      <table className="w-full mt-6 text-xs border border-border">
+        <thead className="bg-muted/40">
+          <tr>
+            <th className="border border-border p-2 text-left w-10">#</th>
+            <th className="border border-border p-2 text-left">ผู้ขาย/ผู้รับเงิน</th>
+            <th className="border border-border p-2 text-left">หมวดบัญชี</th>
+            <th className="border border-border p-2 text-left">รายละเอียด</th>
+            <th className="border border-border p-2 text-right w-24">ก่อน VAT</th>
+            <th className="border border-border p-2 text-right w-20">VAT</th>
+            <th className="border border-border p-2 text-right w-24">รวม</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lines.length === 0 ? (
+            <tr>
+              <td colSpan={7} className="border border-border p-3 text-center text-muted-foreground">
+                ไม่มีรายการ
+              </td>
+            </tr>
+          ) : (
+            lines.map((l) => {
+              const base = parseFloat(l.amountBeforeVat || '0');
+              const vat = parseFloat(l.vatAmount || '0');
+              return (
+                <tr key={l.lineNo}>
+                  <td className="border border-border p-2 tabular-nums">{l.lineNo}</td>
+                  <td className="border border-border p-2">{l.supplierName ?? '—'}</td>
+                  <td className="border border-border p-2 font-mono">{l.category}</td>
+                  <td className="border border-border p-2">{l.description ?? '—'}</td>
+                  <td className="border border-border p-2 text-right tabular-nums">
+                    {formatNumberDecimal(l.amountBeforeVat)}
+                  </td>
+                  <td className="border border-border p-2 text-right tabular-nums">
+                    {vat > 0 ? formatNumberDecimal(l.vatAmount) : '—'}
+                  </td>
+                  <td className="border border-border p-2 text-right tabular-nums">
+                    {formatNumberDecimal((base + vat).toString())}
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+
+      <section className="grid grid-cols-2 gap-6 mt-5">
+        <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+          <p className="text-xs text-muted-foreground mb-1">จำนวนเงิน (ตัวอักษร)</p>
+          <p className="font-semibold leading-relaxed">{amountInText}</p>
+        </div>
+        <table className="text-sm">
+          <tbody>
+            <TotalRow label="ยอดรวมก่อน VAT" value={doc.subtotal} />
+            <TotalRow label="VAT 7%" value={doc.vatAmount} />
+            <TotalRow label="รวมที่เบิก" value={net} bold highlight />
+          </tbody>
+        </table>
+      </section>
+
+      {doc.journalLines && doc.journalLines.length > 0 && (
+        <section className="mt-6">
+          <p className="text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+            Auto Journal
+          </p>
+          <table className="w-full text-xs border border-border">
+            <thead className="bg-muted/40">
+              <tr>
+                <th className="border border-border p-2 text-left">บัญชี</th>
+                <th className="border border-border p-2 text-left">ชื่อบัญชี</th>
+                <th className="border border-border p-2 text-right w-24">Dr (฿)</th>
+                <th className="border border-border p-2 text-right w-24">Cr (฿)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {doc.journalLines.map((l, i) => (
+                <tr key={i}>
+                  <td className="border border-border p-2 font-mono">{l.accountCode}</td>
+                  <td className="border border-border p-2">{l.accountName}</td>
+                  <td className="border border-border p-2 text-right tabular-nums">
+                    {parseFloat(l.debit) > 0 ? formatNumberDecimal(l.debit) : '—'}
+                  </td>
+                  <td className="border border-border p-2 text-right tabular-nums">
+                    {parseFloat(l.credit) > 0 ? formatNumberDecimal(l.credit) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {doc.note && (
+        <section className="mt-6">
+          <p className="text-xs text-muted-foreground mb-1">หมายเหตุ</p>
+          <p className="text-sm">{doc.note}</p>
+        </section>
+      )}
+
+      <footer className="mt-8 pt-3 border-t border-border text-[10px] text-muted-foreground flex justify-between">
+        <span>ออกเอกสารจากระบบ BESTCHOICE — ไม่ต้องเซ็นต์ถือเป็นโมฆะ</span>
+        <span>ใบเบิกชดเชยเงินสดย่อย v1.0</span>
+      </footer>
+    </article>
   );
 }
 

--- a/docs/superpowers/tracking/C1-petty-cash.md
+++ b/docs/superpowers/tracking/C1-petty-cash.md
@@ -1,6 +1,6 @@
 # C1 · Petty Cash Reimbursement
 
-**Status:** 🔵 In Review  |  **Started:** 2026-05-16  |  **PRs:** #867 (backend) + this PR (UI). PDF (C1.8) still deferred.
+**Status:** ✅ Done  |  **Started:** 2026-05-16  |  **PRs:** #867 (backend) · #868 (UI) · this PR (PDF voucher). Only C1.7 settings rows deferred to A1 admin UI.
 **Spec:** —  ·  **Plan:** —
 
 ## Context
@@ -25,7 +25,7 @@ JE shape: Dr each `53-XXXX` per line + Dr `11-4101` for VATable lines / Cr `11-1
 | C1.5 | `PettyCashService` — config lookup + V20 | P0 | 🔵 | TBD | [petty-cash.service.ts](../../../apps/api/src/modules/expense-documents/services/petty-cash.service.ts) — `getConfig()` reads SystemConfig keys with defaults (`account: 11-1201, limit: 5000`). `createPettyCash` orchestrates: compute lines → aggregate → V20 validate → persist with `ExpenseDetail` + per-line supplier. New `POST /expense-documents/petty-cash` controller endpoint. |
 | C1.6 | UI: `PettyCashFormV4` page | P0 | 🔵 | this PR | [PettyCashLinesSection.tsx](../../../apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx) — per-line table (supplier / category / description / amount / VAT% / tax-invoice). Wires into existing `ExpenseFormV4` rather than a new page — DocTypePicker now 6 chips, render gate adds `PETTY_CASH_REIMBURSEMENT` case, POST handler targets `/expense-documents/petty-cash`. Reuses `CashAccountVisualPicker` for the float account. Custodian name is doc-level (header), suppliers are per-line. ExpensesPage list shows `Petty Cash` label badge. |
 | C1.7 | Settings rows: `petty_cash_*` keys | P0 | ⬜ | deferred to A1 | Owner can add via /settings UI when ready. `PettyCashService.getConfig()` falls back to safe defaults if rows are absent (account=11-1201, limit=5000) so the feature works out-of-the-box. Maps to A1.1.5.1–A1.1.5.5 which will land in the Settings Audit phase. |
-| C1.8 | Voucher PDF template (mockup 04B) | P1 | ⬜ | — | **Deferred to follow-up PR**. Standalone work that doesn't gate API usage. Receipt PDF service can be extended in a separate session. |
+| C1.8 | Voucher PDF template (mockup 04B) | P1 | ✅ | this PR | Extended existing [PaymentVoucherPage.tsx](../../../apps/web/src/pages/PaymentVoucherPage.tsx) rather than create a new page — same `/expenses/:id/voucher` route works for both ใบสำคัญจ่าย and ใบเบิกชดเชยเงินสดย่อย. New `PettyCashSheet` component branches on `doc.documentType === 'PETTY_CASH_REIMBURSEMENT'`: title swapped, meta replaces vendor with custodian, item table adds Supplier column + drops WHT column, totals omit WHT row, no WHT certificate, no signature grid (per mockup 04B — petty cash receipts are signed inline at intake, not on the reimbursement voucher). Browser `window.print()` for PDF export, same as standard voucher. |
 
 ## Decision Log
 

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -16,18 +16,18 @@
 | [B1 · SSO 875 Configurable](B1-sso-875.md) | 6 | 6 | 100% | ✅ Done | — | [#861](https://github.com/iamnaii/BESTCHOICE/pull/861) |
 | [B2 · Settlement Multi-line Adj](B2-settlement-adjustment.md) | 5 | 5 | 100% | ✅ Done | — | [#863](https://github.com/iamnaii/BESTCHOICE/pull/863) + B2.4 follow-up |
 | [B3 · Test Suite J+K](B3-test-suite.md) | 14 | 13 | 93% | 🔵 In Review | — | [#865](https://github.com/iamnaii/BESTCHOICE/pull/865) + this PR (K-04 PP30 input VAT) |
-| [C1 · Petty Cash](C1-petty-cash.md) | 8 | 6 | 75% | 🔵 In Review | — | [#867](https://github.com/iamnaii/BESTCHOICE/pull/867) + this PR (UI) |
+| [C1 · Petty Cash](C1-petty-cash.md) | 8 | 7 | 88% | ✅ Done | — | [#867](https://github.com/iamnaii/BESTCHOICE/pull/867) · [#868](https://github.com/iamnaii/BESTCHOICE/pull/868) · this PR (PDF). C1.7 settings → A1 |
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 0 | 0% | ⬜ Pending | — | — |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 0 | 0% | ⬜ Pending | — | — |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 0 | 0% | ⬜ Pending | — | — |
 | [D1 · Settings Audit Phase 4](D1-settings-implement.md) | TBD | 0 | 0% | 🔒 Locked (by A1) | — | — |
-| **TOTAL** | **~159** | **35** | **~22%** | | | |
+| **TOTAL** | **~159** | **36** | **~23%** | | | |
 
 ## 🎯 Current Focus
 
-- **Active:** **C1 (Petty Cash)** — backend bundle (5/8 items) in code review. UI (C1.6) + PDF (C1.8) deferred to follow-up. Settings (C1.7) deferred to A1; service uses safe defaults meantime.
+- **Active:** None (C1 just shipped end-to-end except C1.7 settings which is A1-territory).
 - **Pending owner:** **A0** — owner runs `scripts/a0-preflight-verify.sql` on prod → unblocks B3.J-06
-- **Next:** C1.6 UI follow-up, or C2 (Payroll Custom Income/Deduction)
+- **Next:** C2 (Payroll Custom Income/Deduction), C3 (Reverse Dialog), or C4 (Credit Note 2-Mode)
 
 ## 📅 Timeline
 


### PR DESCRIPTION
Closes C1.8 (last code item in C1). C1 now ✅ Done end-to-end except C1.7 settings rows (deferred to A1 admin UI).

## What

Extended existing `PaymentVoucherPage.tsx` rather than create a new page — same `/expenses/:id/voucher` route handles both ใบสำคัญจ่าย and ใบเบิกชดเชยเงินสดย่อย.

Branches on `doc.documentType === 'PETTY_CASH_REIMBURSEMENT'`:

- Title: ใบเบิกชดเชยเงินสดย่อย / Petty Cash Reimbursement Voucher
- Meta: custodian + supplier count (replaces vendor block)
- Item table: adds Supplier column, drops WHT column
- Totals: omit WHT row
- No WHT certificate (no PND.3/53)
- No signature grid (mockup 04B: petty cash receipts signed inline at intake)
- Same `window.print()` PDF export

## Verified

- `./tools/check-types.sh web` — 0 errors
- Reuses `supplier_name` column already in expense_lines from #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)