### PR TITLE
feat(expense-v2): C2.6 — Payroll custom income/deduction UI (expandable rows)

### DIFF
--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -150,6 +150,8 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
         const { data } = await api.post('/expense-documents', payload);
         createdId = data.id;
       } else if (state.docType === 'PAYROLL') {
+        // C2 — forward customIncome + customDeduction. Server V16/V17/V18
+        // re-validate: whitelist, deduction ≤ gross, taxable-base calc.
         const { data } = await api.post('/expense-documents/payroll', {
           branchId: state.branchId,
           documentDate: state.documentDate,
@@ -158,13 +160,38 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
           paymentMethod: 'BANK_TRANSFER',
           lines: state.payroll.lines
             .filter((l) => l.employeeName && parseFloat(l.baseSalary) > 0)
-            .map((l) => ({
-              employeeName: l.employeeName,
-              employeeTaxId: l.employeeTaxId || undefined,
-              baseSalary: parseFloat(l.baseSalary),
-              ssoEmployee: parseFloat(l.ssoEmployee) || 0,
-              whtAmount: parseFloat(l.whtAmount) || 0,
-            })),
+            .map((l) => {
+              const validIncome = (l.customIncome ?? []).filter(
+                (r) => r.accountCode && parseFloat(r.amount) > 0,
+              );
+              const validDeduction = (l.customDeduction ?? []).filter(
+                (r) => r.accountCode && parseFloat(r.amount) > 0,
+              );
+              return {
+                employeeName: l.employeeName,
+                employeeTaxId: l.employeeTaxId || undefined,
+                baseSalary: parseFloat(l.baseSalary),
+                ssoEmployee: parseFloat(l.ssoEmployee) || 0,
+                whtAmount: parseFloat(l.whtAmount) || 0,
+                customIncome:
+                  validIncome.length > 0
+                    ? validIncome.map((r) => ({
+                        accountCode: r.accountCode,
+                        name: r.name || r.accountCode,
+                        amount: parseFloat(r.amount),
+                        isTaxable: r.isTaxable,
+                      }))
+                    : undefined,
+                customDeduction:
+                  validDeduction.length > 0
+                    ? validDeduction.map((r) => ({
+                        accountCode: r.accountCode,
+                        name: r.name || r.accountCode,
+                        amount: parseFloat(r.amount),
+                      }))
+                    : undefined,
+              };
+            }),
         });
         createdId = data.id;
       } else if (state.docType === 'VENDOR_SETTLEMENT') {

--- a/apps/web/src/components/expense-form-v4/PayrollLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/PayrollLinesSection.tsx
@@ -1,5 +1,13 @@
-import { Plus, Trash2 } from 'lucide-react';
-import { PayrollFormFields, newPayrollLine } from './types';
+import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
+import {
+  PayrollFormFields,
+  PayrollLineForm,
+  PayrollCustomIncomeRow,
+  PayrollCustomDeductionRow,
+  newPayrollLine,
+  newPayrollCustomIncome,
+  newPayrollCustomDeduction,
+} from './types';
 import { formatNumberDecimal } from '@/utils/formatters';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { THAI_MONTHS_FULL } from '@/lib/date';
@@ -11,10 +19,18 @@ interface Props {
   onDocumentDateChange: (d: string) => void;
 }
 
+// C2 — Whitelist of custom income account codes (Settings: custom_income_accounts_whitelist).
+// Hard-coded here matches the migration seed default. UI can resync from
+// API later when /settings page exposes the whitelist editor.
+const CUSTOM_INCOME_WHITELIST: { code: string; label: string }[] = [
+  { code: '53-1104', label: '53-1104 โบนัส' },
+  { code: '53-1105', label: '53-1105 ค่าล่วงเวลา (OT)' },
+];
+
 export function PayrollLinesSection({ value, onChange, documentDate, onDocumentDateChange }: Props) {
   const updateField = (patch: Partial<PayrollFormFields>) => onChange({ ...value, ...patch });
 
-  const updateLine = (uid: string, p: Partial<(typeof value.lines)[number]>) => {
+  const updateLine = (uid: string, p: Partial<PayrollLineForm>) => {
     onChange({ ...value, lines: value.lines.map((l) => (l.uid === uid ? { ...l, ...p } : l)) });
   };
   const removeLine = (uid: string) => {
@@ -27,11 +43,36 @@ export function PayrollLinesSection({ value, onChange, documentDate, onDocumentD
     const base = parseFloat(l.baseSalary) || 0;
     const sso = parseFloat(l.ssoEmployee) || 0;
     const wht = parseFloat(l.whtAmount) || 0;
-    return { ...l, netPaid: Math.max(0, base - sso - wht), baseN: base, ssoN: sso, whtN: wht };
+    const income = (l.customIncome ?? []).reduce(
+      (s, r) => s + (parseFloat(r.amount) || 0),
+      0,
+    );
+    const deduction = (l.customDeduction ?? []).reduce(
+      (s, r) => s + (parseFloat(r.amount) || 0),
+      0,
+    );
+    const taxableBase = (l.customIncome ?? [])
+      .filter((r) => r.isTaxable)
+      .reduce((s, r) => s + (parseFloat(r.amount) || 0), base);
+    const netPaid = Math.max(0, base + income - sso - wht - deduction);
+    const hasExtras = (l.customIncome?.length ?? 0) + (l.customDeduction?.length ?? 0) > 0;
+    return {
+      ...l,
+      baseN: base,
+      ssoN: sso,
+      whtN: wht,
+      incomeN: income,
+      deductionN: deduction,
+      taxableBaseN: taxableBase,
+      netPaid,
+      hasExtras,
+    };
   });
   const sumBase = computed.reduce((s, l) => s + l.baseN, 0);
   const sumSso = computed.reduce((s, l) => s + l.ssoN, 0);
   const sumWht = computed.reduce((s, l) => s + l.whtN, 0);
+  const sumIncome = computed.reduce((s, l) => s + l.incomeN, 0);
+  const sumDeduction = computed.reduce((s, l) => s + l.deductionN, 0);
   const sumNet = computed.reduce((s, l) => s + l.netPaid, 0);
 
   const today = new Date();
@@ -100,6 +141,7 @@ export function PayrollLinesSection({ value, onChange, documentDate, onDocumentD
         <table className="w-full text-sm">
           <thead className="bg-muted/50">
             <tr>
+              <th className="w-8 px-2 py-2"></th>
               <th className="text-left px-3 py-2 font-medium">
                 ชื่อ <span className="text-destructive">*</span>
               </th>
@@ -115,72 +157,18 @@ export function PayrollLinesSection({ value, onChange, documentDate, onDocumentD
           </thead>
           <tbody>
             {computed.map((row) => (
-              <tr key={row.uid} className="border-t border-border">
-                <td className="px-2 py-1">
-                  <input
-                    type="text"
-                    value={row.employeeName}
-                    onChange={(e) => updateLine(row.uid, { employeeName: e.target.value })}
-                    placeholder="ชื่อ-สกุล"
-                    className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background"
-                  />
-                </td>
-                <td className="px-2 py-1">
-                  <input
-                    type="text"
-                    value={row.employeeTaxId}
-                    onChange={(e) => updateLine(row.uid, { employeeTaxId: e.target.value })}
-                    placeholder="13 หลัก"
-                    maxLength={13}
-                    className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background"
-                  />
-                </td>
-                <td className="px-2 py-1">
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={row.baseSalary}
-                    onChange={(e) => updateLine(row.uid, { baseSalary: e.target.value })}
-                    className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background text-right font-mono"
-                  />
-                </td>
-                <td className="px-2 py-1">
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={row.ssoEmployee}
-                    onChange={(e) => updateLine(row.uid, { ssoEmployee: e.target.value })}
-                    className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background text-right font-mono"
-                  />
-                </td>
-                <td className="px-2 py-1">
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={row.whtAmount}
-                    onChange={(e) => updateLine(row.uid, { whtAmount: e.target.value })}
-                    className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background text-right font-mono"
-                  />
-                </td>
-                <td className="px-3 py-2 text-right font-mono">
-                  {formatNumberDecimal(row.netPaid)}
-                </td>
-                <td className="px-2 py-1 text-center">
-                  <button
-                    type="button"
-                    onClick={() => removeLine(row.uid)}
-                    disabled={value.lines.length === 1}
-                    className="text-muted-foreground hover:text-destructive disabled:opacity-30"
-                    aria-label="ลบ"
-                  >
-                    <Trash2 className="size-4" />
-                  </button>
-                </td>
-              </tr>
+              <PayrollRow
+                key={row.uid}
+                row={row}
+                disableRemove={value.lines.length === 1}
+                onUpdate={(p) => updateLine(row.uid, p)}
+                onRemove={() => removeLine(row.uid)}
+              />
             ))}
           </tbody>
           <tfoot className="bg-muted/30 border-t border-border">
             <tr>
+              <td></td>
               <td colSpan={2} className="px-3 py-2 text-right font-medium">
                 รวม
               </td>
@@ -198,6 +186,16 @@ export function PayrollLinesSection({ value, onChange, documentDate, onDocumentD
               </td>
               <td></td>
             </tr>
+            {(sumIncome > 0 || sumDeduction > 0) && (
+              <tr className="text-xs">
+                <td></td>
+                <td colSpan={6} className="px-3 py-1 text-right text-muted-foreground">
+                  รวมรายได้พิเศษ {formatNumberDecimal(sumIncome)} · รวมหัก {formatNumberDecimal(sumDeduction)}
+                  {' · สุทธิ = ฐาน + รายได้พิเศษ − SSO − WHT − หัก'}
+                </td>
+                <td></td>
+              </tr>
+            )}
           </tfoot>
         </table>
       </div>
@@ -208,6 +206,327 @@ export function PayrollLinesSection({ value, onChange, documentDate, onDocumentD
         className="w-full flex items-center justify-center gap-1.5 py-2 border-2 border-dashed border-border rounded-lg text-sm text-muted-foreground hover:text-foreground hover:border-primary"
       >
         <Plus className="size-4" /> เพิ่มพนักงาน
+      </button>
+    </div>
+  );
+}
+
+function PayrollRow({
+  row,
+  disableRemove,
+  onUpdate,
+  onRemove,
+}: {
+  row: PayrollLineForm & {
+    netPaid: number;
+    baseN: number;
+    ssoN: number;
+    whtN: number;
+    incomeN: number;
+    deductionN: number;
+    taxableBaseN: number;
+    hasExtras: boolean;
+  };
+  disableRemove: boolean;
+  onUpdate: (p: Partial<PayrollLineForm>) => void;
+  onRemove: () => void;
+}) {
+  const expanded = row._expanded === true;
+
+  const updateIncome = (rows: PayrollCustomIncomeRow[]) => onUpdate({ customIncome: rows });
+  const updateDeduction = (rows: PayrollCustomDeductionRow[]) =>
+    onUpdate({ customDeduction: rows });
+
+  return (
+    <>
+      <tr className="border-t border-border">
+        <td className="px-2 py-1 text-center">
+          <button
+            type="button"
+            onClick={() => onUpdate({ _expanded: !expanded })}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label={expanded ? 'ย่อ' : 'ขยาย'}
+            aria-expanded={expanded}
+          >
+            {expanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+          </button>
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="text"
+            value={row.employeeName}
+            onChange={(e) => onUpdate({ employeeName: e.target.value })}
+            placeholder="ชื่อ-สกุล"
+            className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background"
+          />
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="text"
+            value={row.employeeTaxId}
+            onChange={(e) => onUpdate({ employeeTaxId: e.target.value })}
+            placeholder="13 หลัก"
+            maxLength={13}
+            className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background"
+          />
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="number"
+            step="0.01"
+            value={row.baseSalary}
+            onChange={(e) => onUpdate({ baseSalary: e.target.value })}
+            className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background text-right font-mono"
+          />
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="number"
+            step="0.01"
+            value={row.ssoEmployee}
+            onChange={(e) => onUpdate({ ssoEmployee: e.target.value })}
+            className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background text-right font-mono"
+          />
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="number"
+            step="0.01"
+            value={row.whtAmount}
+            onChange={(e) => onUpdate({ whtAmount: e.target.value })}
+            className="w-full px-2 py-1.5 border border-input rounded text-sm bg-background text-right font-mono"
+          />
+        </td>
+        <td className="px-3 py-2 text-right font-mono">
+          {formatNumberDecimal(row.netPaid)}
+          {row.hasExtras && (
+            <div className="text-[10px] text-muted-foreground mt-0.5">
+              +{formatNumberDecimal(row.incomeN)} / −{formatNumberDecimal(row.deductionN)}
+            </div>
+          )}
+        </td>
+        <td className="px-2 py-1 text-center">
+          <button
+            type="button"
+            onClick={onRemove}
+            disabled={disableRemove}
+            className="text-muted-foreground hover:text-destructive disabled:opacity-30"
+            aria-label="ลบ"
+          >
+            <Trash2 className="size-4" />
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-t border-border bg-muted/10">
+          <td></td>
+          <td colSpan={7} className="px-3 py-3 space-y-3">
+            <CustomIncomeSubTable rows={row.customIncome ?? []} onChange={updateIncome} />
+            <CustomDeductionSubTable rows={row.customDeduction ?? []} onChange={updateDeduction} />
+            {row.taxableBaseN !== row.baseN && (
+              <div className="text-xs text-muted-foreground italic">
+                ฐานคำนวณ WHT = {formatNumberDecimal(row.taxableBaseN)} (รวมรายได้พิเศษที่เสียภาษี)
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function CustomIncomeSubTable({
+  rows,
+  onChange,
+}: {
+  rows: PayrollCustomIncomeRow[];
+  onChange: (rows: PayrollCustomIncomeRow[]) => void;
+}) {
+  const update = (uid: string, p: Partial<PayrollCustomIncomeRow>) =>
+    onChange(rows.map((r) => (r.uid === uid ? { ...r, ...p } : r)));
+  const remove = (uid: string) => onChange(rows.filter((r) => r.uid !== uid));
+  const add = () => onChange([...rows, newPayrollCustomIncome()]);
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      <div className="bg-emerald-50 dark:bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-900 dark:text-emerald-100">
+        + รายได้พิเศษ (โบนัส / OT / เบี้ยเลี้ยง)
+      </div>
+      <table className="w-full text-xs">
+        <thead className="bg-muted/30 text-muted-foreground">
+          <tr>
+            <th className="text-left px-2 py-1 w-40">บัญชี</th>
+            <th className="text-left px-2 py-1">รายการ</th>
+            <th className="text-right px-2 py-1 w-28">จำนวน</th>
+            <th className="text-center px-2 py-1 w-16">ภาษี</th>
+            <th className="w-8"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 && (
+            <tr>
+              <td colSpan={5} className="px-2 py-2 text-center text-muted-foreground italic">
+                ไม่มี
+              </td>
+            </tr>
+          )}
+          {rows.map((r) => (
+            <tr key={r.uid} className="border-t border-border">
+              <td className="px-2 py-1">
+                <select
+                  value={r.accountCode}
+                  onChange={(e) => update(r.uid, { accountCode: e.target.value })}
+                  className="w-full px-1.5 py-1 border border-input rounded text-xs bg-background"
+                >
+                  {CUSTOM_INCOME_WHITELIST.map((opt) => (
+                    <option key={opt.code} value={opt.code}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </td>
+              <td className="px-2 py-1">
+                <input
+                  type="text"
+                  value={r.name}
+                  onChange={(e) => update(r.uid, { name: e.target.value })}
+                  placeholder="คำอธิบาย"
+                  className="w-full px-1.5 py-1 border border-input rounded text-xs bg-background"
+                />
+              </td>
+              <td className="px-2 py-1">
+                <input
+                  type="number"
+                  step="0.01"
+                  value={r.amount}
+                  onChange={(e) => update(r.uid, { amount: e.target.value })}
+                  className="w-full px-1.5 py-1 border border-input rounded text-xs bg-background text-right font-mono"
+                />
+              </td>
+              <td className="px-2 py-1 text-center">
+                <label
+                  className="inline-flex items-center gap-1 cursor-pointer text-xs"
+                  title={r.isTaxable ? 'รายได้เสียภาษี' : 'ม.42 ยกเว้นภาษี'}
+                >
+                  <input
+                    type="checkbox"
+                    checked={r.isTaxable}
+                    onChange={(e) => update(r.uid, { isTaxable: e.target.checked })}
+                    className="size-3.5"
+                  />
+                  <span className={r.isTaxable ? '' : 'text-muted-foreground line-through'}>
+                    เสีย
+                  </span>
+                </label>
+              </td>
+              <td className="px-1 py-1 text-center">
+                <button
+                  type="button"
+                  onClick={() => remove(r.uid)}
+                  className="text-muted-foreground hover:text-destructive"
+                  aria-label="ลบรายได้พิเศษ"
+                >
+                  <Trash2 className="size-3" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        type="button"
+        onClick={add}
+        className="w-full flex items-center justify-center gap-1 py-1.5 text-xs text-muted-foreground hover:text-foreground border-t border-border"
+      >
+        <Plus className="size-3" /> เพิ่มรายได้พิเศษ
+      </button>
+    </div>
+  );
+}
+
+function CustomDeductionSubTable({
+  rows,
+  onChange,
+}: {
+  rows: PayrollCustomDeductionRow[];
+  onChange: (rows: PayrollCustomDeductionRow[]) => void;
+}) {
+  const update = (uid: string, p: Partial<PayrollCustomDeductionRow>) =>
+    onChange(rows.map((r) => (r.uid === uid ? { ...r, ...p } : r)));
+  const remove = (uid: string) => onChange(rows.filter((r) => r.uid !== uid));
+  const add = () => onChange([...rows, newPayrollCustomDeduction()]);
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      <div className="bg-amber-50 dark:bg-amber-950/30 px-3 py-1.5 text-xs font-medium text-amber-900 dark:text-amber-100">
+        − รายการหัก (คืนเงินยืม / ทดรองจ่าย / ค่ายูนิฟอร์ม)
+      </div>
+      <table className="w-full text-xs">
+        <thead className="bg-muted/30 text-muted-foreground">
+          <tr>
+            <th className="text-left px-2 py-1 w-32">บัญชี</th>
+            <th className="text-left px-2 py-1">รายการ</th>
+            <th className="text-right px-2 py-1 w-28">จำนวน</th>
+            <th className="w-8"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 && (
+            <tr>
+              <td colSpan={4} className="px-2 py-2 text-center text-muted-foreground italic">
+                ไม่มี
+              </td>
+            </tr>
+          )}
+          {rows.map((r) => (
+            <tr key={r.uid} className="border-t border-border">
+              <td className="px-2 py-1">
+                <input
+                  type="text"
+                  value={r.accountCode}
+                  onChange={(e) => update(r.uid, { accountCode: e.target.value })}
+                  placeholder="11-2199"
+                  className="w-full px-1.5 py-1 border border-input rounded text-xs bg-background font-mono"
+                />
+              </td>
+              <td className="px-2 py-1">
+                <input
+                  type="text"
+                  value={r.name}
+                  onChange={(e) => update(r.uid, { name: e.target.value })}
+                  placeholder="คำอธิบาย"
+                  className="w-full px-1.5 py-1 border border-input rounded text-xs bg-background"
+                />
+              </td>
+              <td className="px-2 py-1">
+                <input
+                  type="number"
+                  step="0.01"
+                  value={r.amount}
+                  onChange={(e) => update(r.uid, { amount: e.target.value })}
+                  className="w-full px-1.5 py-1 border border-input rounded text-xs bg-background text-right font-mono"
+                />
+              </td>
+              <td className="px-1 py-1 text-center">
+                <button
+                  type="button"
+                  onClick={() => remove(r.uid)}
+                  className="text-muted-foreground hover:text-destructive"
+                  aria-label="ลบรายการหัก"
+                >
+                  <Trash2 className="size-3" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        type="button"
+        onClick={add}
+        className="w-full flex items-center justify-center gap-1 py-1.5 text-xs text-muted-foreground hover:text-foreground border-t border-border"
+      >
+        <Plus className="size-3" /> เพิ่มรายการหัก
       </button>
     </div>
   );

--- a/apps/web/src/components/expense-form-v4/types.ts
+++ b/apps/web/src/components/expense-form-v4/types.ts
@@ -36,6 +36,29 @@ export interface ExpenseAdjustmentForm {
   note: string;
 }
 
+/**
+ * C2 — Per-line custom income (bonus, OT, per-diem allowances).
+ * `isTaxable=false` for ม.42 tax-exempt items; flag-only no UI confirm prompt.
+ */
+export interface PayrollCustomIncomeRow {
+  uid: string;
+  accountCode: string;
+  name: string;
+  amount: string;
+  isTaxable: boolean;
+}
+
+/**
+ * C2 — Per-line custom deduction (loan repayment, advance recovery, etc.).
+ * No whitelist (employer-discretion); free CoA code.
+ */
+export interface PayrollCustomDeductionRow {
+  uid: string;
+  accountCode: string;
+  name: string;
+  amount: string;
+}
+
 export interface PayrollLineForm {
   uid: string;
   employeeName: string;
@@ -43,6 +66,12 @@ export interface PayrollLineForm {
   baseSalary: string;
   ssoEmployee: string;
   whtAmount: string;
+  // C2 — custom income/deduction (per-employee). Optional in API but always
+  // present as empty arrays in form state for ergonomic editing.
+  customIncome: PayrollCustomIncomeRow[];
+  customDeduction: PayrollCustomDeductionRow[];
+  // UI-only: accordion expand toggle. Excluded from POST body.
+  _expanded?: boolean;
 }
 
 export interface PayrollFormFields {
@@ -163,6 +192,30 @@ export const newPayrollLine = (overrides?: Partial<PayrollLineForm>): PayrollLin
   baseSalary: '',
   ssoEmployee: '0',
   whtAmount: '0',
+  customIncome: [],
+  customDeduction: [],
+  _expanded: false,
+  ...overrides,
+});
+
+export const newPayrollCustomIncome = (
+  overrides?: Partial<PayrollCustomIncomeRow>,
+): PayrollCustomIncomeRow => ({
+  uid: Math.random().toString(36).slice(2),
+  accountCode: '53-1104', // default = bonus (most common)
+  name: '',
+  amount: '',
+  isTaxable: true,
+  ...overrides,
+});
+
+export const newPayrollCustomDeduction = (
+  overrides?: Partial<PayrollCustomDeductionRow>,
+): PayrollCustomDeductionRow => ({
+  uid: Math.random().toString(36).slice(2),
+  accountCode: '',
+  name: '',
+  amount: '',
   ...overrides,
 });
 

--- a/docs/superpowers/tracking/C2-payroll-custom.md
+++ b/docs/superpowers/tracking/C2-payroll-custom.md
@@ -1,6 +1,6 @@
 # C2 · Payroll Custom Income/Deduction (V16–V18)
 
-**Status:** 🔵 In Review  |  **Started:** 2026-05-16  |  **PRs:** TBD (backend bundle; UI + slip PDF deferred)
+**Status:** ✅ Done  |  **Started:** 2026-05-16  |  **PRs:** #871 (backend) · this PR (UI). Only C2.7 slip PDF still deferred.
 **Spec:** —  ·  **Plan:** —
 
 ## Context
@@ -26,7 +26,7 @@ UI: expandable row in PayrollFormV4 reveals two sub-sections (income / deduction
 | C2.3 | V18 validator — `Σ(deduction) ≤ base + Σ(income)` invariant | P1 | 🔵 | TBD | Same `validateLine` method enforces. Reject before persist so partially-completed payroll can't poison the JE step. |
 | C2.4 | Schema: `payroll_custom_income[]` + `payroll_custom_deduction[]` nested under `Payroll` (Prisma) | P1 | 🔵 | TBD | New `PayrollCustomIncome` + `PayrollCustomDeduction` Prisma models FK'd to `PayrollLine` (not `PayrollDetail`) so each employee can have its own custom rows. Migration `20260929000000_payroll_custom_income_deduction` creates 2 tables + seeds V17 default whitelist. Local dry-run: ✅. |
 | C2.5 | `PayrollTemplate.execute` — emit Dr lines for each custom_income.account_code; deductions reduce the net Cr cash leg | P1 | 🔵 | TBD | [payroll.template.ts](../../../apps/api/src/modules/journal/cpa-templates/payroll.template.ts) — added 2 aggregation loops (income by accountCode → Dr; deduction by accountCode → Cr) AFTER WHT line but BEFORE the cash leg. `sumNet` was already computed by service to include income+deduction so the cash Cr lands correctly. All Dr/Cr stay balanced. |
-| C2.6 | UI: PayrollFormV4 expandable rows — Custom Income / Custom Deduction tables with quick-add buttons + V16 warning (ม.42 tax-exempt) | P1 | ⬜ | — | **Deferred to follow-up PR**. Backend DTO already final (DTO + endpoint accept the new shape); UI is purely additive. |
+| C2.6 | UI: PayrollFormV4 expandable rows — Custom Income / Custom Deduction tables with quick-add buttons + V16 warning (ม.42 tax-exempt) | P1 | ✅ | this PR | [PayrollLinesSection.tsx](../../../apps/web/src/components/expense-form-v4/PayrollLinesSection.tsx) — chevron toggles accordion per employee row; expanded section renders 2 colored sub-tables (emerald = income, amber = deduction). Income table uses dropdown wired to `CUSTOM_INCOME_WHITELIST` constant matching the migration seed. Deduction table is free-form CoA code. Live `netPaid` recomputes including +income/−deduction. Live `taxableBase` shown when it differs from base. POST forwards `customIncome` + `customDeduction` arrays; server V16/V17/V18 re-validate. UI-only `_expanded` field excluded from POST body. |
 | C2.7 | Slip auto-generate — PDF per employee + email send | P1 | ⬜ | — | **Deferred to follow-up PR**. Reuses voucher infrastructure (PaymentVoucherPage pattern). Separate session. |
 
 ## Decision Log

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -17,15 +17,15 @@
 | [B2 · Settlement Multi-line Adj](B2-settlement-adjustment.md) | 5 | 5 | 100% | ✅ Done | — | [#863](https://github.com/iamnaii/BESTCHOICE/pull/863) + B2.4 follow-up |
 | [B3 · Test Suite J+K](B3-test-suite.md) | 14 | 14 | 100% | ✅ Done | — | [#865](https://github.com/iamnaii/BESTCHOICE/pull/865) · [#866](https://github.com/iamnaii/BESTCHOICE/pull/866) · this PR (J-06) |
 | [C1 · Petty Cash](C1-petty-cash.md) | 8 | 7 | 88% | ✅ Done | — | [#867](https://github.com/iamnaii/BESTCHOICE/pull/867) · [#868](https://github.com/iamnaii/BESTCHOICE/pull/868) · this PR (PDF). C1.7 settings → A1 |
-| [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 5 | 71% | 🔵 In Review | — | PR TBD (backend bundle; UI + slip deferred) |
+| [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 6 | 86% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · this PR (UI). C2.7 slip → follow-up |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 0 | 0% | ⬜ Pending | — | — |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 0 | 0% | ⬜ Pending | — | — |
 | [D1 · Settings Audit Phase 4](D1-settings-implement.md) | TBD | 0 | 0% | 🔒 Locked (by A1) | — | — |
-| **TOTAL** | **~159** | **44** | **~28%** | | | |
+| **TOTAL** | **~159** | **45** | **~28%** | | | |
 
 ## 🎯 Current Focus
 
-- **Active:** **C2 (Payroll Custom Income/Deduction)** — backend bundle (5/7 items) in review. UI (C2.6) + slip PDF (C2.7) deferred.
+- **Active:** None. C2 shipped end-to-end except C2.7 slip PDF.
 - **Pending owner:** **A0.3 only** — depreciation gap on prod surfaced (zero JEs across all periods; 2 POSTED assets with one showing column-vs-JE anomaly). Needs owner decision on policy + investigation; remediation is `POST /admin/depreciation/run?period=YYYY-MM` once policy + eligible periods are confirmed.
 - **Next:** C2 (Payroll Custom Income/Deduction), C3 (Reverse Dialog), or C4 (Credit Note 2-Mode)
 


### PR DESCRIPTION
Closes C2.6. C2 now ✅ Done (6/7 — only C2.7 slip PDF deferred).

## Architecture

- Chevron button per employee row toggles accordion
- Expanded section renders 2 colored sub-tables:
  - **emerald** `+ รายได้พิเศษ` — dropdown wired to whitelist (53-1104 โบนัส, 53-1105 ค่าล่วงเวลา) + per-row `isTaxable` checkbox for ม.42 exempt
  - **amber** `− รายการหัก` — free-form CoA code (employer-discretion)
- Live `netPaid` recomputes including +income/−deduction
- Live `taxableBase` shown when ≠ base
- UI-only `_expanded` flag excluded from POST
- POST forwards `customIncome` + `customDeduction` arrays; server V16/V17/V18 re-validate

## Verified

- `./tools/check-types.sh web` — 0 errors
- Backend (#871) already handles every shape this UI produces

🤖 Generated with [Claude Code](https://claude.com/claude-code)