### PR TITLE
feat(expense-v2): C2.7 — Payroll slip PDF (one A4 per employee)

### DIFF
--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -1331,7 +1331,16 @@ export class ExpenseDocumentsService implements OnModuleInit {
         creditNote: docType.documentType === 'CREDIT_NOTE',
         payroll:
           docType.documentType === 'PAYROLL'
-            ? { include: { lines: true } }
+            ? {
+                include: {
+                  lines: {
+                    include: {
+                      customIncome: { orderBy: { createdAt: 'asc' } },
+                      customDeduction: { orderBy: { createdAt: 'asc' } },
+                    },
+                  },
+                },
+              }
             : false,
         settlement:
           docType.documentType === 'VENDOR_SETTLEMENT'

--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -46,13 +46,41 @@ interface JournalLine {
   credit: string;
 }
 
+/**
+ * C2.7 — Payroll slip line with per-employee custom income/deduction.
+ * Optional fields populated only for PAYROLL docs.
+ */
+export interface PayrollSlipLine {
+  id: string;
+  employeeName: string;
+  employeeTaxId: string | null;
+  baseSalary: string;
+  ssoEmployee: string;
+  whtAmount: string;
+  netPaid: string;
+  customIncome?: Array<{
+    id: string;
+    accountCode: string;
+    name: string;
+    amount: string;
+    isTaxable: boolean;
+  }>;
+  customDeduction?: Array<{
+    id: string;
+    accountCode: string;
+    name: string;
+    amount: string;
+  }>;
+}
+
 interface VoucherDoc {
   id: string;
   number: string;
   /**
-   * C1 — branches voucher layout: PETTY_CASH_REIMBURSEMENT renders a
-   * compact multi-supplier sheet (no WHT cert, no signature grid). All other
-   * doc types use the standard ใบสำคัญจ่าย layout.
+   * Branches voucher layout:
+   *   - PETTY_CASH_REIMBURSEMENT — compact multi-supplier sheet (C1.8)
+   *   - PAYROLL — one A4 slip per employee (C2.7)
+   *   - All others — standard ใบสำคัญจ่าย
    */
   documentType:
     | 'EXPENSE'
@@ -76,6 +104,11 @@ interface VoucherDoc {
   reference: string | null;
   note: string | null;
   expenseDetail: { lines: ExpenseLine[] } | null;
+  // C2.7 — Payroll slip data (populated only for PAYROLL docs).
+  payroll?: {
+    payrollPeriod: string;
+    lines: PayrollSlipLine[];
+  } | null;
   journalLines?: JournalLine[];
 }
 
@@ -101,10 +134,14 @@ export default function PaymentVoucherPage() {
       document.title = 'ใบสำคัญจ่าย';
       return;
     }
-    const title =
-      data.documentType === 'PETTY_CASH_REIMBURSEMENT'
-        ? `ใบเบิกชดเชยเงินสดย่อย ${data.number}`
-        : `ใบสำคัญจ่าย ${data.number}`;
+    let title: string;
+    if (data.documentType === 'PETTY_CASH_REIMBURSEMENT') {
+      title = `ใบเบิกชดเชยเงินสดย่อย ${data.number}`;
+    } else if (data.documentType === 'PAYROLL') {
+      title = `ใบจ่ายเงินเดือน ${data.number}`;
+    } else {
+      title = `ใบสำคัญจ่าย ${data.number}`;
+    }
     document.title = title;
   }, [docQuery.data]);
 
@@ -156,6 +193,7 @@ export default function PaymentVoucherPage() {
 
 function VoucherSheet({ doc }: { doc: VoucherDoc }) {
   const isPettyCash = doc.documentType === 'PETTY_CASH_REIMBURSEMENT';
+  const isPayroll = doc.documentType === 'PAYROLL';
   const hasWht = parseFloat(doc.withholdingTax || '0') > 0;
   const net = doc.netPayment ?? doc.totalAmount;
   const amountText = numToThaiText(parseFloat(net));
@@ -167,6 +205,25 @@ function VoucherSheet({ doc }: { doc: VoucherDoc }) {
     return (
       <div className="max-w-[210mm] mx-auto py-6 px-6 print:px-0 print:py-0 space-y-6">
         <PettyCashSheet doc={doc} amountInText={amountText} net={net} />
+      </div>
+    );
+  }
+
+  // C2.7 — Payroll renders one A4 slip per employee. Each slip = own
+  // ใบจ่ายเงินเดือน with base + custom income + custom deduction + SSO + WHT
+  // + net + Thai-text + 2 signature slots. Browser `print()` will paginate.
+  if (isPayroll && doc.payroll && doc.payroll.lines.length > 0) {
+    return (
+      <div className="max-w-[210mm] mx-auto py-6 px-6 print:px-0 print:py-0 space-y-6">
+        {doc.payroll.lines.map((line, idx) => (
+          <PayrollSlipSheet
+            key={line.id}
+            doc={doc}
+            line={line}
+            slipNo={idx + 1}
+            totalSlips={doc.payroll!.lines.length}
+          />
+        ))}
       </div>
     );
   }
@@ -333,6 +390,215 @@ function PettyCashSheet({
       <footer className="mt-8 pt-3 border-t border-border text-[10px] text-muted-foreground flex justify-between">
         <span>ออกเอกสารจากระบบ BESTCHOICE — ไม่ต้องเซ็นต์ถือเป็นโมฆะ</span>
         <span>ใบเบิกชดเชยเงินสดย่อย v1.0</span>
+      </footer>
+    </article>
+  );
+}
+
+/**
+ * C2.7 — Payroll slip per employee. One A4 sheet per `PayrollSlipLine`.
+ * `pageBreakBefore: 'always'` from slip #2 onwards so the browser print
+ * dialog renders one slip per page. Email dispatch deferred to follow-up
+ * (involves Mailer service + employee email column on PayrollLine).
+ *
+ * Layout (mockup 02B Payroll Slip):
+ *   - Company header
+ *   - Title: ใบจ่ายเงินเดือน + slip n/N
+ *   - Employee meta (name, tax ID, period, doc no)
+ *   - Earnings table: base + custom income (with ม.42 flag if non-taxable)
+ *   - Deductions table: SSO + WHT + custom deduction
+ *   - Net paid + Thai-text amount
+ *   - 2 signature slots (ผู้รับเงิน · ผู้จัดทำ)
+ */
+function PayrollSlipSheet({
+  doc,
+  line,
+  slipNo,
+  totalSlips,
+}: {
+  doc: VoucherDoc;
+  line: PayrollSlipLine;
+  slipNo: number;
+  totalSlips: number;
+}) {
+  const base = new Decimal(line.baseSalary || '0');
+  const sso = new Decimal(line.ssoEmployee || '0');
+  const wht = new Decimal(line.whtAmount || '0');
+  const net = new Decimal(line.netPaid || '0');
+  const customIncome = line.customIncome ?? [];
+  const customDeduction = line.customDeduction ?? [];
+
+  const sumIncome = customIncome.reduce<Decimal>(
+    (s, r) => s.plus(new Decimal(r.amount || '0')),
+    new Decimal(0),
+  );
+  const sumDeduction = customDeduction.reduce<Decimal>(
+    (s, r) => s.plus(new Decimal(r.amount || '0')),
+    new Decimal(0),
+  );
+  // Earnings = base + Σ custom income (the gross-up)
+  const earningsTotal = base.plus(sumIncome);
+  // Deductions = SSO + WHT + Σ custom deduction
+  const deductionsTotal = sso.plus(wht).plus(sumDeduction);
+
+  const amountInText = numToThaiText(parseFloat(line.netPaid));
+
+  return (
+    <article
+      className="voucher-sheet bg-white border border-border rounded-md p-8 shadow-sm print:border-0 print:p-0 print:shadow-none"
+      style={{
+        minHeight: '270mm',
+        pageBreakBefore: slipNo > 1 ? 'always' : 'auto',
+      }}
+    >
+      <header className="text-center border-b-2 border-foreground pb-3">
+        <h1 className="text-xl font-bold">BESTCHOICE FINANCE × SHOP</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
+        </p>
+        <h2 className="text-2xl font-bold tracking-wider mt-4">ใบจ่ายเงินเดือน</h2>
+        <p className="text-xs text-muted-foreground">
+          Payroll Slip {slipNo}/{totalSlips}
+        </p>
+      </header>
+
+      <section className="grid grid-cols-2 gap-x-8 gap-y-2 mt-5 text-sm">
+        <MetaRow label="ชื่อพนักงาน" value={line.employeeName} />
+        <MetaRow label="เลขประจำตัวผู้เสียภาษี" value={line.employeeTaxId ?? '—'} mono />
+        <MetaRow label="งวด" value={doc.payroll?.payrollPeriod ?? '—'} mono />
+        <MetaRow label="วันที่จ่าย" value={formatThaiDateLong(doc.documentDate)} />
+        <MetaRow label="เลขที่เอกสารต้นทาง" value={doc.number} mono />
+        <MetaRow label="ช่องทางจ่าย" value={doc.depositAccountCode ?? '—'} mono />
+      </section>
+
+      {/* Earnings */}
+      <section className="mt-6">
+        <p className="text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+          รายได้ (Earnings)
+        </p>
+        <table className="w-full text-sm border border-border">
+          <tbody>
+            <tr>
+              <td className="border border-border p-2">เงินเดือนพื้นฐาน</td>
+              <td className="border border-border p-2 text-right tabular-nums w-32">
+                {formatNumberDecimal(base.toString())}
+              </td>
+            </tr>
+            {customIncome.map((ci) => (
+              <tr key={ci.id}>
+                <td className="border border-border p-2">
+                  <span className="font-mono text-xs text-muted-foreground mr-2">
+                    {ci.accountCode}
+                  </span>
+                  {ci.name}
+                  {!ci.isTaxable && (
+                    <span className="ml-2 inline-block rounded bg-info/10 px-1.5 py-0.5 text-[10px] text-info">
+                      ม.42 ยกเว้นภาษี
+                    </span>
+                  )}
+                </td>
+                <td className="border border-border p-2 text-right tabular-nums">
+                  {formatNumberDecimal(ci.amount)}
+                </td>
+              </tr>
+            ))}
+            <tr className="bg-muted/30">
+              <td className="border border-border p-2 font-semibold">รวมรายได้</td>
+              <td className="border border-border p-2 text-right tabular-nums font-semibold">
+                {formatNumberDecimal(earningsTotal.toString())}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      {/* Deductions */}
+      <section className="mt-5">
+        <p className="text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wider">
+          รายการหัก (Deductions)
+        </p>
+        <table className="w-full text-sm border border-border">
+          <tbody>
+            {sso.gt(0) && (
+              <tr>
+                <td className="border border-border p-2">เงินสมทบประกันสังคม (พนักงาน)</td>
+                <td className="border border-border p-2 text-right tabular-nums w-32">
+                  {formatNumberDecimal(sso.toString())}
+                </td>
+              </tr>
+            )}
+            {wht.gt(0) && (
+              <tr>
+                <td className="border border-border p-2">หัก ณ ที่จ่าย (ภ.ง.ด. 1)</td>
+                <td className="border border-border p-2 text-right tabular-nums">
+                  {formatNumberDecimal(wht.toString())}
+                </td>
+              </tr>
+            )}
+            {customDeduction.map((cd) => (
+              <tr key={cd.id}>
+                <td className="border border-border p-2">
+                  <span className="font-mono text-xs text-muted-foreground mr-2">
+                    {cd.accountCode}
+                  </span>
+                  {cd.name}
+                </td>
+                <td className="border border-border p-2 text-right tabular-nums">
+                  {formatNumberDecimal(cd.amount)}
+                </td>
+              </tr>
+            ))}
+            {sso.eq(0) && wht.eq(0) && customDeduction.length === 0 && (
+              <tr>
+                <td colSpan={2} className="border border-border p-3 text-center text-muted-foreground italic">
+                  ไม่มี
+                </td>
+              </tr>
+            )}
+            <tr className="bg-muted/30">
+              <td className="border border-border p-2 font-semibold">รวมรายการหัก</td>
+              <td className="border border-border p-2 text-right tabular-nums font-semibold">
+                {formatNumberDecimal(deductionsTotal.toString())}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      {/* Net */}
+      <section className="grid grid-cols-2 gap-6 mt-5">
+        <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+          <p className="text-xs text-muted-foreground mb-1">จำนวนเงินสุทธิ (ตัวอักษร)</p>
+          <p className="font-semibold leading-relaxed">{amountInText}</p>
+        </div>
+        <table className="text-sm">
+          <tbody>
+            <TotalRow label="รายได้รวม" value={earningsTotal.toString()} />
+            <TotalRow label="รายการหักรวม" value={deductionsTotal.toString()} negative />
+            <TotalRow label="สุทธิที่จ่าย" value={net.toString()} bold highlight />
+          </tbody>
+        </table>
+      </section>
+
+      {doc.note && (
+        <section className="mt-6">
+          <p className="text-xs text-muted-foreground mb-1">หมายเหตุ</p>
+          <p className="text-sm">{doc.note}</p>
+        </section>
+      )}
+
+      {/* Signatures — 2 slots only (no full grid). Employees sign on receipt;
+          preparer signs on issuance. ตราประทับ unnecessary on individual slips. */}
+      <section className="grid grid-cols-2 gap-6 mt-12">
+        <SignatureSlot label="ผู้รับเงิน" />
+        <SignatureSlot label="ผู้จัดทำ" />
+      </section>
+
+      <footer className="mt-8 pt-3 border-t border-border text-[10px] text-muted-foreground flex justify-between">
+        <span>ออกเอกสารจากระบบ BESTCHOICE — ไม่ต้องเซ็นต์ถือเป็นโมฆะ</span>
+        <span>
+          ใบจ่ายเงินเดือน v1.0 · {slipNo}/{totalSlips}
+        </span>
       </footer>
     </article>
   );

--- a/docs/superpowers/tracking/C2-payroll-custom.md
+++ b/docs/superpowers/tracking/C2-payroll-custom.md
@@ -1,6 +1,6 @@
 # C2 · Payroll Custom Income/Deduction (V16–V18)
 
-**Status:** ✅ Done  |  **Started:** 2026-05-16  |  **PRs:** #871 (backend) · this PR (UI). Only C2.7 slip PDF still deferred.
+**Status:** ✅ Done (7/7)  |  **Started:** 2026-05-16  |  **PRs:** #871 (backend) · #872 (UI) · this PR (slip PDF). Email dispatch deferred to a follow-up (needs Mailer service + employee email field).
 **Spec:** —  ·  **Plan:** —
 
 ## Context
@@ -27,7 +27,7 @@ UI: expandable row in PayrollFormV4 reveals two sub-sections (income / deduction
 | C2.4 | Schema: `payroll_custom_income[]` + `payroll_custom_deduction[]` nested under `Payroll` (Prisma) | P1 | 🔵 | TBD | New `PayrollCustomIncome` + `PayrollCustomDeduction` Prisma models FK'd to `PayrollLine` (not `PayrollDetail`) so each employee can have its own custom rows. Migration `20260929000000_payroll_custom_income_deduction` creates 2 tables + seeds V17 default whitelist. Local dry-run: ✅. |
 | C2.5 | `PayrollTemplate.execute` — emit Dr lines for each custom_income.account_code; deductions reduce the net Cr cash leg | P1 | 🔵 | TBD | [payroll.template.ts](../../../apps/api/src/modules/journal/cpa-templates/payroll.template.ts) — added 2 aggregation loops (income by accountCode → Dr; deduction by accountCode → Cr) AFTER WHT line but BEFORE the cash leg. `sumNet` was already computed by service to include income+deduction so the cash Cr lands correctly. All Dr/Cr stay balanced. |
 | C2.6 | UI: PayrollFormV4 expandable rows — Custom Income / Custom Deduction tables with quick-add buttons + V16 warning (ม.42 tax-exempt) | P1 | ✅ | this PR | [PayrollLinesSection.tsx](../../../apps/web/src/components/expense-form-v4/PayrollLinesSection.tsx) — chevron toggles accordion per employee row; expanded section renders 2 colored sub-tables (emerald = income, amber = deduction). Income table uses dropdown wired to `CUSTOM_INCOME_WHITELIST` constant matching the migration seed. Deduction table is free-form CoA code. Live `netPaid` recomputes including +income/−deduction. Live `taxableBase` shown when it differs from base. POST forwards `customIncome` + `customDeduction` arrays; server V16/V17/V18 re-validate. UI-only `_expanded` field excluded from POST body. |
-| C2.7 | Slip auto-generate — PDF per employee + email send | P1 | ⬜ | — | **Deferred to follow-up PR**. Reuses voucher infrastructure (PaymentVoucherPage pattern). Separate session. |
+| C2.7 | Slip auto-generate — PDF per employee + email send | P1 | ✅ | this PR | Extended [PaymentVoucherPage.tsx](../../../apps/web/src/pages/PaymentVoucherPage.tsx) with PAYROLL branch — renders one A4 sheet per employee (`pageBreakBefore: 'always'` from slip #2 onwards). Layout per mockup 02B: company header → ใบจ่ายเงินเดือน n/N → employee meta → Earnings table (base + custom income with `ม.42 ยกเว้นภาษี` badge when not taxable) → Deductions table (SSO + WHT + custom deduction) → net + Thai-text amount → 2 signature slots (ผู้รับเงิน + ผู้จัดทำ). Backend `findOne` now eagerly includes `payroll.lines.customIncome` + `customDeduction` for PAYROLL docs. **Email dispatch deferred** to a follow-up — needs Mailer service wiring + an email column on PayrollLine. PDF + print path already covers the immediate "give employee their slip" use case via browser print. |
 
 ## Decision Log
 

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -17,11 +17,11 @@
 | [B2 · Settlement Multi-line Adj](B2-settlement-adjustment.md) | 5 | 5 | 100% | ✅ Done | — | [#863](https://github.com/iamnaii/BESTCHOICE/pull/863) + B2.4 follow-up |
 | [B3 · Test Suite J+K](B3-test-suite.md) | 14 | 14 | 100% | ✅ Done | — | [#865](https://github.com/iamnaii/BESTCHOICE/pull/865) · [#866](https://github.com/iamnaii/BESTCHOICE/pull/866) · this PR (J-06) |
 | [C1 · Petty Cash](C1-petty-cash.md) | 8 | 7 | 88% | ✅ Done | — | [#867](https://github.com/iamnaii/BESTCHOICE/pull/867) · [#868](https://github.com/iamnaii/BESTCHOICE/pull/868) · this PR (PDF). C1.7 settings → A1 |
-| [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 6 | 86% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · this PR (UI). C2.7 slip → follow-up |
+| [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 0 | 0% | ⬜ Pending | — | — |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 0 | 0% | ⬜ Pending | — | — |
 | [D1 · Settings Audit Phase 4](D1-settings-implement.md) | TBD | 0 | 0% | 🔒 Locked (by A1) | — | — |
-| **TOTAL** | **~159** | **45** | **~28%** | | | |
+| **TOTAL** | **~159** | **46** | **~29%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
Closes C2.7. C2 now 7/7 ✅. Email dispatch deferred (needs Mailer + employee email column).

## What

Extended PaymentVoucherPage with PAYROLL branch — renders one A4 slip per employee, paginated via `pageBreakBefore: 'always'`.

Each slip (mockup 02B):
- Company header + ใบจ่ายเงินเดือน slip n/N
- Employee meta
- **Earnings**: base + custom income (with `ม.42 ยกเว้นภาษี` badge for non-taxable)
- **Deductions**: SSO + WHT + custom deduction
- Net + Thai-text + 2 signature slots (ผู้รับเงิน + ผู้จัดทำ)

Backend `findOne` now eagerly includes `payroll.lines.customIncome` + `customDeduction` for PAYROLL docs.

## Out of scope

- Email dispatch (separate session — needs Mailer service + email column on PayrollLine)
- Per-slip download button on list view (browser print covers immediate use case)

## Verified

- `./tools/check-types.sh all` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)