### PR TITLE
feat(expense-v2): C3 backend — Reverse Dialog V19 + cascade + audit

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
@@ -80,9 +80,19 @@ describe('ExpenseDocumentsController', () => {
     expect(service.post).toHaveBeenCalledWith('doc-1', 'user-1');
   });
 
-  it('POST /:id/void fires voidDocument', async () => {
-    await controller.void('doc-1', { id: 'user-1' } as never);
-    expect(service.voidDocument).toHaveBeenCalledWith('doc-1', 'user-1');
+  it('POST /:id/void fires voidDocument with dto', async () => {
+    await controller.void('doc-1', {}, { id: 'user-1' } as never);
+    expect(service.voidDocument).toHaveBeenCalledWith('doc-1', 'user-1', {});
+  });
+
+  it('POST /:id/void forwards reasonCode + reasonDetail + reverseDate to service', async () => {
+    const dto = {
+      reasonCode: 'data_entry_error' as const,
+      reasonDetail: 'ป้อนผิด',
+      reverseDate: '2026-05-16',
+    };
+    await controller.void('doc-1', dto, { id: 'user-1' } as never);
+    expect(service.voidDocument).toHaveBeenCalledWith('doc-1', 'user-1', dto);
   });
 
   it('PATCH /:id calls update', async () => {

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -64,6 +64,10 @@ describe('ExpenseDocumentsService', () => {
       accountingPeriod: {
         findUnique: jest.fn().mockResolvedValue(null),
       },
+      // C3 — voidDocument writes an audit entry with reason metadata.
+      auditLog: {
+        create: jest.fn().mockResolvedValue({}),
+      },
     };
     docNumber = { next: jest.fn().mockResolvedValue('EX-20260510-0001') };
     transition = {
@@ -967,6 +971,123 @@ describe('ExpenseDocumentsService', () => {
           where: { id: 'ex-deleted', deletedAt: null },
         }),
       );
+    });
+
+    // B3 / C3 — Cascade check + audit + reverseDate (C3.1, C3.3, C3.4)
+    it('C3.4: rejects void when an active SETTLEMENT references this doc', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-1', status: 'ACCRUAL', journalEntryId: 'je-1', documentType: 'EXPENSE',
+      });
+      // First count() call = pending CN → 0
+      // Second count() call = pending SE → 1 (this is our cascade hit)
+      prisma.expenseDocument.count = jest
+        .fn()
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(1);
+      await expect(service.voidDocument('doc-1', 'user-1')).rejects.toThrow(
+        /SE.*ยกเลิก|ยกเลิก SE/,
+      );
+    });
+
+    it('C3.3: writes audit log with reasonCode + reasonDetail + reverseJournalEntryId', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-1',
+        status: 'POSTED',
+        journalEntryId: 'je-original',
+        documentType: 'EXPENSE',
+        number: 'EX-001',
+      });
+      // Mock journal-auto returning a reversal JE id
+      const journalMock = {
+        createAndPost: jest.fn().mockResolvedValue({ id: 'je-reverse-1', entryNumber: 'JE-202605-X' }),
+      };
+      // Need to grab the spec's `original` JE mock — earlier test pattern uses
+      // tx.journalEntry.findUniqueOrThrow. Stitch it in.
+      prisma.journalEntry = {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: 'je-original',
+          companyId: 'shop-co-id',
+          lines: [
+            { accountCode: '53-1101', debit: '100.00', credit: '0', description: 'salary' },
+            { accountCode: '11-1101', debit: '0', credit: '100.00', description: 'cash' },
+          ],
+        }),
+      };
+      const svc = new ExpenseDocumentsService(
+        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
+        journalMock as never,
+        new LineAggregatorService(),
+        { preview: jest.fn() } as never,
+        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
+        { execute: jest.fn() } as never,
+        { getConfig: jest.fn(), validate: jest.fn() } as never,
+        { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
+      );
+
+      await svc.voidDocument('doc-1', 'user-1', {
+        reasonCode: 'data_entry_error',
+        reasonDetail: 'ป้อนยอดผิด',
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          action: 'EXPENSE_VOIDED',
+          entity: 'expense_document',
+          entityId: 'doc-1',
+          userId: 'user-1',
+          newValue: expect.objectContaining({
+            status: 'VOIDED',
+            reverseJournalEntryId: 'je-reverse-1',
+            reasonCode: 'data_entry_error',
+            reasonDetail: 'ป้อนยอดผิด',
+            documentNumber: 'EX-001',
+            documentType: 'EXPENSE',
+          }),
+        }),
+      });
+    });
+
+    it('C3.1: reverseDate from DTO overrides today for postedAt on reversal JE', async () => {
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-1',
+        status: 'POSTED',
+        journalEntryId: 'je-original',
+        documentType: 'EXPENSE',
+        number: 'EX-001',
+      });
+      const journalMock = {
+        createAndPost: jest.fn().mockResolvedValue({ id: 'je-reverse-2', entryNumber: 'JE-X' }),
+      };
+      prisma.journalEntry = {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: 'je-original',
+          companyId: 'shop-co-id',
+          lines: [
+            { accountCode: '53-1101', debit: '100.00', credit: '0', description: 'salary' },
+          ],
+        }),
+      };
+      const svc = new ExpenseDocumentsService(
+        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
+        journalMock as never,
+        new LineAggregatorService(),
+        { preview: jest.fn() } as never,
+        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
+        { execute: jest.fn() } as never,
+        { getConfig: jest.fn(), validate: jest.fn() } as never,
+        { loadWhitelist: jest.fn().mockResolvedValue(new Set(['53-1104', '53-1105'])), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
+      );
+
+      await svc.voidDocument('doc-1', 'user-1', {
+        reasonCode: 'cancel_transaction',
+        reverseDate: '2026-04-30',
+      });
+
+      // Reversal JE postedAt should be derived from '2026-04-30' not today.
+      const call = journalMock.createAndPost.mock.calls[0][0];
+      const postedAtYmd = (call.postedAt as Date)
+        .toLocaleString('en-CA', { timeZone: 'Asia/Bangkok', year: 'numeric', month: '2-digit', day: '2-digit' });
+      expect(postedAtYmd).toBe('2026-04-30');
     });
   });
 });

--- a/apps/api/src/modules/expense-documents/dto/void-expense.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/void-expense.dto.ts
@@ -1,0 +1,48 @@
+import { IsString, IsOptional, IsIn, IsDateString, MaxLength } from 'class-validator';
+
+/**
+ * C3 — Reverse Dialog payload. Replaces the previously parameterless
+ * `POST /expense-documents/:id/void`. All fields optional for backward
+ * compatibility with older callers that still send an empty body.
+ *
+ * `reasonCode` is one of 6 canonical strings (per mockup 02E). UI dropdown
+ * sources the same labels. `reasonDetail` is free-text for any context that
+ * doesn't fit a canonical reason. Both end up in the AuditLog row's
+ * `newValue` JSON for forensic queryability.
+ *
+ * `reverseDate` lets the reversal JE post on a user-chosen date (still
+ * subject to V19 period-open guard). When omitted, the existing behavior
+ * (today, BKK noon) is preserved.
+ */
+export const REVERSE_REASON_CODES = [
+  'data_entry_error',     // ป้อนข้อมูลผิด
+  'wrong_vendor',         // ผู้ขายผิด
+  'wrong_amount',         // จำนวนเงินผิด
+  'duplicate_entry',      // ข้อมูลซ้ำ
+  'cancel_transaction',   // ยกเลิกรายการ
+  'other',                // อื่นๆ (ต้องระบุใน reasonDetail)
+] as const;
+
+export type ReverseReasonCode = (typeof REVERSE_REASON_CODES)[number];
+
+export class VoidExpenseDocumentDto {
+  @IsString()
+  @IsIn([...REVERSE_REASON_CODES], {
+    message: `เหตุผลการกลับรายการต้องเป็นหนึ่งใน: ${REVERSE_REASON_CODES.join(', ')}`,
+  })
+  @IsOptional()
+  reasonCode?: ReverseReasonCode;
+
+  @IsString()
+  @MaxLength(500, { message: 'รายละเอียดเหตุผลยาวเกิน 500 ตัวอักษร' })
+  @IsOptional()
+  reasonDetail?: string;
+
+  /**
+   * ISO date string. When set, the reversal JE postedAt uses this date
+   * (V19 period-open guard still applies). Omitted = today BKK noon.
+   */
+  @IsDateString({}, { message: 'วันที่กลับรายการไม่ถูกต้อง' })
+  @IsOptional()
+  reverseDate?: string;
+}

--- a/apps/api/src/modules/expense-documents/expense-documents.controller.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.controller.ts
@@ -23,6 +23,7 @@ import { CreateCreditNoteDto } from './dto/create-credit-note.dto';
 import { CreatePayrollDto } from './dto/create-payroll.dto';
 import { CreateSettlementDto } from './dto/create-settlement.dto';
 import { CreatePettyCashDto } from './dto/create-petty-cash.dto';
+import { VoidExpenseDocumentDto } from './dto/void-expense.dto';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 
 @Controller('expense-documents')
@@ -165,8 +166,12 @@ export class ExpenseDocumentsController {
 
   @Post(':id/void')
   @Roles('OWNER', 'FINANCE_MANAGER')
-  void(@Param('id') id: string, @CurrentUser() user: { id: string }) {
-    return this.service.voidDocument(id, user.id);
+  void(
+    @Param('id') id: string,
+    @Body() dto: VoidExpenseDocumentDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.service.voidDocument(id, user.id, dto);
   }
 
   @Delete(':id')

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -24,6 +24,7 @@ import { CreateCreditNoteDto } from './dto/create-credit-note.dto';
 import { CreatePayrollDto } from './dto/create-payroll.dto';
 import { CreateSettlementDto } from './dto/create-settlement.dto';
 import { CreatePettyCashDto } from './dto/create-petty-cash.dto';
+import { VoidExpenseDocumentDto } from './dto/void-expense.dto';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { LineAggregatorService } from './services/line-aggregator.service';
 import { JePreviewService } from './services/je-preview.service';
@@ -1626,7 +1627,10 @@ export class ExpenseDocumentsService implements OnModuleInit {
   // ─── Void (any non-VOIDED → VOIDED) ──────────────────────────────────
   // Posts a reversal JE (flipped Dr/Cr) when the doc had a journal entry,
   // and for VENDOR_SETTLEMENT also reverts each cleared EX back to ACCRUAL.
-  async voidDocument(id: string, _userId: string) {
+  // C3 — Optionally accepts reasonCode + reasonDetail + reverseDate (caller-chosen
+  // posting date for the reversal JE). All optional → existing parameterless
+  // void path still works (back-compat).
+  async voidDocument(id: string, userId: string, dto: VoidExpenseDocumentDto = {}) {
     return this.prisma.$transaction(async (tx) => {
       // Per-doc advisory lock — serializes concurrent voids on the same id so
       // two callers cannot both pass assertCanVoid and double-post a reversal JE.
@@ -1651,13 +1655,34 @@ export class ExpenseDocumentsService implements OnModuleInit {
         throw new BadRequestException('มีใบลดหนี้ที่ยังไม่ถูกยกเลิก ไม่สามารถยกเลิกเอกสารต้นฉบับได้');
       }
 
+      // C3.4 — Cascade check: also block void when an active SETTLEMENT
+      // clears this doc. (Settlement-on-void of the SE itself separately
+      // reverts cleared docs back to ACCRUAL — that's the SE-being-voided
+      // path, not this one.)
+      const pendingSe = await tx.expenseDocument.count({
+        where: {
+          documentType: 'VENDOR_SETTLEMENT',
+          status: { not: 'VOIDED' },
+          deletedAt: null,
+          settlement: { settlementLines: { some: { clearedDocumentId: id } } },
+        },
+      });
+      if (pendingSe > 0) {
+        throw new BadRequestException(
+          'มีใบจ่ายเจ้าหนี้ (SE) ที่ยังไม่ถูกยกเลิกอ้างถึงเอกสารนี้อยู่ — ' +
+            'กรุณายกเลิก SE ก่อน',
+        );
+      }
+
       this.transition.assertCanVoid({ from: doc.status });
 
       // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
-      // Period-open guard at the module boundary. The reversal JE postedAt
-      // is BKK noon "today" (bkkBusinessDate(new Date())), so the check uses
-      // the same "now" reference. SHOP companyId resolved fresh (cache lives
-      // on JournalAutoService) — small cost, but voids are rare.
+      // Period-open guard at the module boundary. C3.1 — when caller passes
+      // `reverseDate`, the reversal JE postedAt uses it (still V19-gated); else
+      // the legacy behavior (today BKK noon).
+      const reverseAt = dto.reverseDate
+        ? bkkBusinessDate(new Date(dto.reverseDate))
+        : bkkBusinessDate(new Date());
       const shopForVoidPeriod = await tx.companyInfo.findFirst({
         where: { companyCode: 'SHOP', deletedAt: null },
         select: { id: true },
@@ -1667,12 +1692,13 @@ export class ExpenseDocumentsService implements OnModuleInit {
           'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
         );
       }
-      await validatePeriodOpen(tx, bkkBusinessDate(new Date()), shopForVoidPeriod.id);
+      await validatePeriodOpen(tx, reverseAt, shopForVoidPeriod.id);
 
       // Post reversal JE (flipped Dr/Cr) if doc had one. The original JE stays
       // intact; the reversal lives as a separate POSTED entry tagged via metadata.
       // Reversal postedAt is BKK noon "today" — keeps the entry inside the
       // intended Thai accounting day regardless of UTC server clock.
+      let reverseJournalEntryId: string | null = null;
       if (doc.journalEntryId) {
         const original = await tx.journalEntry.findUniqueOrThrow({
           where: { id: doc.journalEntryId },
@@ -1699,7 +1725,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
           }
           companyId = shop.id;
         }
-        await this.journal.createAndPost(
+        const reverseEntry = await this.journal.createAndPost(
           {
             description: `กลับรายการ ${doc.number}`,
             reference: doc.id,
@@ -1710,8 +1736,12 @@ export class ExpenseDocumentsService implements OnModuleInit {
               documentType: doc.documentType,
               originalJournalEntryId: original.id,
               flow: `expense-${doc.documentType.toLowerCase()}-void`,
+              // C3 — reason metadata embedded so JE-side audits can grep
+              // by reasonCode without joining audit_logs.
+              reverseReasonCode: dto.reasonCode ?? null,
+              reverseReasonDetail: dto.reasonDetail ?? null,
             },
-            postedAt: bkkBusinessDate(new Date()),
+            postedAt: reverseAt,
             companyId,
             lines: original.lines.map((l) => ({
               accountCode: l.accountCode,
@@ -1722,6 +1752,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
           },
           tx,
         );
+        reverseJournalEntryId = reverseEntry.id;
       }
 
       // VENDOR_SETTLEMENT side-effect: revert each cleared EX back to ACCRUAL.
@@ -1752,6 +1783,29 @@ export class ExpenseDocumentsService implements OnModuleInit {
       if (flip.count === 0) {
         throw new BadRequestException('เอกสารถูกยกเลิกไปแล้ว');
       }
+
+      // C3.3 — Audit trail with reason + reverse JE pointer. Stuffed into
+      // `newValue` JSON rather than adding columns (AuditLog has a Merkle hash
+      // chain — adding columns would break the verification path on existing rows).
+      await tx.auditLog.create({
+        data: {
+          action: 'EXPENSE_VOIDED',
+          entity: 'expense_document',
+          entityId: id,
+          userId,
+          oldValue: { status: doc.status, journalEntryId: doc.journalEntryId },
+          newValue: {
+            status: 'VOIDED',
+            reverseJournalEntryId,
+            reverseDate: reverseAt.toISOString(),
+            reasonCode: dto.reasonCode ?? null,
+            reasonDetail: dto.reasonDetail ?? null,
+            documentNumber: doc.number,
+            documentType: doc.documentType,
+          },
+        },
+      });
+
       return tx.expenseDocument.findUniqueOrThrow({ where: { id } });
     });
   }

--- a/docs/superpowers/tracking/C3-reverse-dialog.md
+++ b/docs/superpowers/tracking/C3-reverse-dialog.md
@@ -1,6 +1,6 @@
 # C3 · Reverse Dialog + V19 (Period Guard)
 
-**Status:** ⬜ Pending  |  **Started:** —  |  **PRs:** —
+**Status:** 🔵 In Review  |  **Started:** 2026-05-16  |  **PRs:** TBD (backend bundle; UI + settings deferred)
 **Spec:** —  ·  **Plan:** —
 
 ## Context
@@ -16,20 +16,23 @@ Adds a modal Reverse Dialog with required reason (dropdown of 6 + free text), da
 
 | ID | Item | Priority | Status | PR | Evidence/Notes |
 |---|---|---|---|---|---|
-| C3.1 | V19 validator — reverse date ≤ period_close_date + grace_days; soft warning if backdate > 30 days | P1 | ⬜ | — | File: `expense-documents.service.ts` |
-| C3.2 | ReverseDialog modal component — 6-option dropdown + free text + JE before/after preview + date picker | P1 | ⬜ | — | New file: `apps/web/src/components/expense-form-v4/ReverseDialog.tsx` |
-| C3.3 | Audit log schema — add `reason_code` (enum) + `reason_detail` (text) + `reverse_je_id` (FK) columns to `audit_log` (or extend existing JSON metadata field if present) | P1 | ⬜ | — | Migration |
-| C3.4 | Cascade check service method — given an EX, return list of downstream SETTLEMENT/CN that reference it; block reverse if non-empty | P1 | ⬜ | — | New method on expense-documents.service.ts |
-| C3.5 | Settings rows: `reverse_reason_required` / `reverse_reasons_dropdown` (6 strings) / `reverse_manager_approval_days` / `reverse_block_cascaded` | P1 | ⬜ | — | Maps to A1.2.7.1–A1.2.7.4 |
+| C3.1 | V19 validator — reverse date ≤ period_close_date + grace_days; soft warning if backdate > 30 days | P1 | 🔵 | TBD | [`voidDocument`](../../../apps/api/src/modules/expense-documents/expense-documents.service.ts) now accepts optional `reverseDate` in DTO. When provided, reversal JE `postedAt` derives from it via `bkkBusinessDate(new Date(dto.reverseDate))` and `validatePeriodOpen` runs against that date (V19). Soft warning for >30-day backdate is UI concern (C3.2). |
+| C3.2 | ReverseDialog modal component — 6-option dropdown + free text + JE before/after preview + date picker | P1 | ⬜ | — | **Deferred to follow-up PR**. Backend DTO accepts the new shape; UI is purely additive. Same pattern as B2/C1/C2. |
+| C3.3 | Audit log schema — add `reason_code` (enum) + `reason_detail` (text) + `reverse_je_id` (FK) columns to `audit_log` (or extend existing JSON metadata field if present) | P1 | 🔵 | TBD | **Decision (Q1): use existing `newValue` JSON** instead of new columns. AuditLog has a Merkle hash chain — adding columns would break verification on existing rows. `voidDocument` now writes `tx.auditLog.create({ action: 'EXPENSE_VOIDED', entity: 'expense_document', newValue: { status, reverseJournalEntryId, reverseDate, reasonCode, reasonDetail, documentNumber, documentType } })`. Reason metadata also embedded in the reversal JE's own `metadata.reverseReasonCode/Detail` so JE-side queries don't need to join `audit_logs`. |
+| C3.4 | Cascade check service method — given an EX, return list of downstream SETTLEMENT/CN that reference it; block reverse if non-empty | P1 | 🔵 | TBD | Extended existing cascade check in `voidDocument` (pre-existing CN check) to also count active VENDOR_SETTLEMENT docs whose `settlement.settlementLines` reference this doc. Blocks with Thai error if any exist. Voiding a SE itself still cascades-revert cleared EXs back to ACCRUAL (existing behavior, separate path). |
+| C3.5 | Settings rows: `reverse_reason_required` / `reverse_reasons_dropdown` (6 strings) / `reverse_manager_approval_days` / `reverse_block_cascaded` | P1 | ⬜ | — | **Deferred to A1.** Backend currently uses a hard-coded 6-option enum in `VoidExpenseDocumentDto`. Owner can later add settings rows + service-side override of the whitelist when /settings UI is built. The cascade block (C3.4) is always-on for now per safety. |
 
 ## Decision Log
 
-(empty)
+- **2026-05-16:** Backend bundle (3/5 items) in one PR — C3.1 + C3.3 + C3.4. UI (C3.2) + Settings (C3.5) deferred. Same pattern as B2/C1/C2.
+- **2026-05-16:** Q1 answered — embed reason metadata in existing AuditLog `newValue` JSON (not new columns). AuditLog has Merkle hash chain so column additions break verification.
+- **2026-05-16:** Q2 answered — soft warning (UI concern, ships with C3.2). Server doesn't block based on backdate age; only enforces V19 (period-open).
+- **2026-05-16:** Reason metadata duplicated into the reversal JE's own `metadata` field — lets accounting queries grep by reason without joining `audit_logs`.
 
 ## Open Questions
 
-- [ ] Q: C3.3 — extend existing audit_log schema or use existing JSON metadata field?
-- [ ] Q: Manager approval after 7 days — soft (warning) or hard (block)?
+- [x] Q: C3.3 — extend existing audit_log schema or use existing JSON metadata field? — **JSON field**. Merkle chain concerns.
+- [x] Q: Manager approval after 7 days — soft (warning) or hard (block)? — **Soft (UI-only)**.
 
 ## Dependencies
 

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -18,14 +18,15 @@
 | [B3 · Test Suite J+K](B3-test-suite.md) | 14 | 14 | 100% | ✅ Done | — | [#865](https://github.com/iamnaii/BESTCHOICE/pull/865) · [#866](https://github.com/iamnaii/BESTCHOICE/pull/866) · this PR (J-06) |
 | [C1 · Petty Cash](C1-petty-cash.md) | 8 | 7 | 88% | ✅ Done | — | [#867](https://github.com/iamnaii/BESTCHOICE/pull/867) · [#868](https://github.com/iamnaii/BESTCHOICE/pull/868) · this PR (PDF). C1.7 settings → A1 |
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
-| [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 0 | 0% | ⬜ Pending | — | — |
+| [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 3 | 60% | 🔵 In Review | — | PR TBD (backend bundle; UI + Settings deferred) |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 0 | 0% | ⬜ Pending | — | — |
 | [D1 · Settings Audit Phase 4](D1-settings-implement.md) | TBD | 0 | 0% | 🔒 Locked (by A1) | — | — |
-| **TOTAL** | **~159** | **47** | **~30%** | | | |
+| **TOTAL** | **~159** | **50** | **~31%** | | | |
 
 ## 🎯 Current Focus
 
 - **Active:** None. C2 shipped end-to-end except C2.7 slip PDF.
+- **Active:** **C3 (Reverse Dialog + V19)** — backend bundle (3/5 items) in review. UI (C3.2) + Settings (C3.5) deferred.
 - **Optional housekeeping:** EQ-002 missing เม.ย. depreciation (~฿287). Not a blocker; owner can run `POST /admin/depreciation/run?period=2026-04` for catch-up at convenience. พ.ค. depreciation will tick automatically on May 31.
 - **Next:** C2 (Payroll Custom Income/Deduction), C3 (Reverse Dialog), or C4 (Credit Note 2-Mode)
 


### PR DESCRIPTION
Closes C3.1 (V19 reverseDate) + C3.3 (audit log enhancement) + C3.4 (cascade check ext). C3.2 (UI modal) + C3.5 (settings) deferred to follow-ups.

## Architecture

- **DTO** `VoidExpenseDocumentDto` accepts `reasonCode?` (6 enum) + `reasonDetail?` (text) + `reverseDate?` (ISO date). All optional → back-compat.
- **C3.1** `reverseDate` overrides today for reversal JE `postedAt` (V19 period guard still applies)
- **C3.3** writes `tx.auditLog.create({ action: 'EXPENSE_VOIDED', entity: 'expense_document', newValue: { status, reverseJournalEntryId, reverseDate, reasonCode, reasonDetail, ... } })`. Decision (Q1): use existing `newValue` JSON field — AuditLog has Merkle hash chain; column additions break verification.
- **C3.4** cascade check now also counts active VENDOR_SETTLEMENT docs referencing the EX → block void.

## Tests

- 3 new service spec tests (C3.1/C3.3/C3.4)
- 1 new controller test (DTO forwarding)
- 50/50 service + 5/5 controller pass
- 0 type errors

## Tracking

- C3: ⬜ → 🔵 (3/5 = 60%)
- TOTAL: 47 → 50 (~31%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)