### PR TITLE
feat(expense-v2): C4 UI — Credit Note 2-Mode selector + STANDALONE form

### DIFF
--- a/apps/web/src/components/expense-form-v4/CreditNoteLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/CreditNoteLinesSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
-import { Search, FileText, AlertCircle } from 'lucide-react';
+import { Search, FileText, AlertCircle, Link2, FilePlus2 } from 'lucide-react';
 import { ExpenseFormState, ExpenseLineForm } from './types';
 import { ItemLinesSection } from './ItemLinesSection';
 import { formatNumberDecimal } from '@/utils/formatters';
@@ -23,8 +23,15 @@ interface Props {
   onLinesChange: (lines: ExpenseLineForm[]) => void;
 }
 
+/**
+ * C4 · 2-Mode CN section. Mockup v5 page 02D.
+ *
+ * Mode LINKED (default) — pick source EX, auto-load lines, cap-capped by server.
+ * Mode STANDALONE — free-form supplier + free-form lines, no source FK.
+ */
 export function CreditNoteLinesSection({ state, onChange, onLinesChange }: Props) {
   const [search, setSearch] = useState('');
+  const isStandalone = state.cnMode === 'STANDALONE';
 
   const { data: searchResults } = useQuery<{ data: OriginalDoc[] }>({
     queryKey: ['cn-search', search, state.branchId],
@@ -35,7 +42,7 @@ export function CreditNoteLinesSection({ state, onChange, onLinesChange }: Props
       );
       return data;
     },
-    enabled: search.trim().length >= 3,
+    enabled: !isStandalone && search.trim().length >= 3,
   });
 
   const selectedDoc = searchResults?.data.find((d) => d.id === state.originalDocumentId);
@@ -50,10 +57,10 @@ export function CreditNoteLinesSection({ state, onChange, onLinesChange }: Props
       const { data } = await api.get(`/expense-documents/${state.originalDocumentId}/cn-cap`);
       return data;
     },
-    enabled: !!state.originalDocumentId,
+    enabled: !isStandalone && !!state.originalDocumentId,
   });
 
-  // Compute totals to check cap
+  // Compute totals to check cap (LINKED only)
   const lineTotal = state.lines
     .filter((l) => l.category && parseFloat(l.unitPrice) > 0)
     .reduce((s, l) => {
@@ -63,115 +70,242 @@ export function CreditNoteLinesSection({ state, onChange, onLinesChange }: Props
       return s + Math.max(0, q * u - d);
     }, 0);
   const remaining = capInfo ? parseFloat(capInfo.remainingCap) : Infinity;
-  const exceedsCap = !!capInfo && lineTotal > remaining;
+  const exceedsCap = !isStandalone && !!capInfo && lineTotal > remaining;
+
+  const switchMode = (mode: 'LINKED' | 'STANDALONE') => {
+    if (state.cnMode === mode) return;
+    onChange({
+      cnMode: mode,
+      // Switching modes wipes the cross-mode-specific fields so server validation
+      // doesn't see stale values from the other branch.
+      originalDocumentId: '',
+      vendorName: mode === 'STANDALONE' ? state.vendorName : '',
+      vendorTaxId: mode === 'STANDALONE' ? state.vendorTaxId : '',
+    });
+    setSearch('');
+  };
 
   return (
     <div className="space-y-4">
-      {/* Original document picker */}
-      <div className="rounded-xl border border-border bg-card">
-        <div className="px-4 py-2 border-b border-border flex items-center gap-2">
-          <FileText className="size-4 text-primary" />
-          <span className="text-sm font-medium">เอกสารต้นฉบับ</span>
-          <span className="text-xs text-muted-foreground ml-1">เลือกเอกสาร EX ที่ต้องการลดหนี้</span>
-        </div>
-        <div className="p-4 space-y-3">
-          {state.originalDocumentId && selectedDoc ? (
-            <div className="rounded-lg border border-primary/30 bg-primary/5 p-3 flex items-center justify-between">
-              <div>
-                <div className="font-mono text-sm">{selectedDoc.number}</div>
-                <div className="text-sm">
-                  {selectedDoc.vendorName ?? '—'} · ยอด {formatNumberDecimal(selectedDoc.totalAmount)} ฿
-                </div>
-                {capInfo && (
-                  <div className="text-xs text-muted-foreground mt-1">
-                    เหลือลดได้: {formatNumberDecimal(capInfo.remainingCap)} ฿ (ใช้ไปแล้ว{' '}
-                    {formatNumberDecimal(capInfo.usedTotal)} ฿)
-                  </div>
-                )}
+      {/* C4.1 — Mode selector (radio-style chip cards) */}
+      <div>
+        <div className="text-xs font-medium text-muted-foreground mb-2">โหมดใบลดหนี้</div>
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={() => switchMode('LINKED')}
+            className={`flex items-start gap-2 rounded-lg border p-3 text-left transition ${
+              !isStandalone
+                ? 'border-primary bg-primary/5 ring-1 ring-primary/40'
+                : 'border-border bg-card hover:bg-accent'
+            }`}
+            aria-pressed={!isStandalone}
+          >
+            <Link2 className={`size-4 mt-0.5 ${!isStandalone ? 'text-primary' : 'text-muted-foreground'}`} />
+            <div className="space-y-0.5">
+              <div className="text-sm font-medium">อ้างอิงใบเดิม</div>
+              <div className="text-xs text-muted-foreground leading-snug">
+                ลด/คืนจากเอกสาร EX ต้นทาง · ภ.30 link อัตโนมัติ
               </div>
-              <button
-                type="button"
-                onClick={() => {
-                  onChange({ originalDocumentId: '' });
-                  setSearch('');
-                }}
-                className="text-xs text-destructive hover:underline"
-              >
-                เปลี่ยน
-              </button>
             </div>
-          ) : (
-            <>
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
-                <input
-                  type="text"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="ค้นหาเลข EX-... / ผู้ขาย (3 ตัวขึ้นไป)"
-                  className="w-full pl-10 pr-3 py-2 border border-input rounded-lg text-sm bg-background"
-                />
+          </button>
+          <button
+            type="button"
+            onClick={() => switchMode('STANDALONE')}
+            className={`flex items-start gap-2 rounded-lg border p-3 text-left transition ${
+              isStandalone
+                ? 'border-primary bg-primary/5 ring-1 ring-primary/40'
+                : 'border-border bg-card hover:bg-accent'
+            }`}
+            aria-pressed={isStandalone}
+          >
+            <FilePlus2 className={`size-4 mt-0.5 ${isStandalone ? 'text-primary' : 'text-muted-foreground'}`} />
+            <div className="space-y-0.5">
+              <div className="text-sm font-medium">Standalone (ไม่มีใบเดิม)</div>
+              <div className="text-xs text-muted-foreground leading-snug">
+                ผู้ขายคืนเงินโดยไม่มีใบกำกับเดิม · ระบุผู้ขายเอง
               </div>
-              {(searchResults?.data ?? []).length > 0 && (
-                <div className="rounded-lg border border-border max-h-48 overflow-y-auto">
-                  {searchResults!.data
-                    .filter((d) => ['POSTED', 'ACCRUAL'].includes(d.status))
-                    .map((doc) => (
-                      <button
-                        type="button"
-                        key={doc.id}
-                        onClick={() => {
-                          onChange({ originalDocumentId: doc.id });
-                          // Pre-populate CN lines from original doc if available
-                          const sourceLines = doc.expenseDetail?.lines ?? [];
-                          if (sourceLines.length > 0) {
-                            onLinesChange(
-                              sourceLines.map((l, idx) => ({
-                                uid: `cn-${idx}-${Math.random().toString(36).slice(2)}`,
-                                category: l.category,
-                                description: '',
-                                quantity: '1',
-                                unitPrice: l.amountBeforeVat,
-                                discount: '0',
-                                vatPercent: '7',
-                                whtPercent: '0',
-                              })),
-                            );
-                          }
-                        }}
-                        className="w-full flex items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent border-b border-border last:border-b-0"
-                      >
-                        <div>
-                          <div className="font-mono">{doc.number}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {doc.vendorName ?? '—'} · {doc.status}
-                          </div>
-                        </div>
-                        <div className="font-mono text-sm">{formatNumberDecimal(doc.totalAmount)}</div>
-                      </button>
-                    ))}
-                </div>
-              )}
-            </>
-          )}
-
-          <div>
-            <label className="block text-xs font-medium mb-1">
-              เหตุผลลดหนี้ <span className="text-destructive">*</span>
-            </label>
-            <input
-              type="text"
-              value={state.cnReason}
-              onChange={(e) => onChange({ cnReason: e.target.value })}
-              placeholder="เช่น สินค้าคืน, ปรับราคา, ส่วนลดหลังการขาย"
-              className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
-            />
-          </div>
+            </div>
+          </button>
         </div>
       </div>
 
-      {/* Credit lines — only shown when original doc selected */}
-      {state.originalDocumentId && (
+      {/* LINKED — source doc picker */}
+      {!isStandalone && (
+        <div className="rounded-xl border border-border bg-card">
+          <div className="px-4 py-2 border-b border-border flex items-center gap-2">
+            <FileText className="size-4 text-primary" />
+            <span className="text-sm font-medium">เอกสารต้นฉบับ</span>
+            <span className="text-xs text-muted-foreground ml-1">
+              เลือกเอกสาร EX ที่ต้องการลดหนี้
+            </span>
+          </div>
+          <div className="p-4 space-y-3">
+            {state.originalDocumentId && selectedDoc ? (
+              <div className="rounded-lg border border-primary/30 bg-primary/5 p-3 flex items-center justify-between">
+                <div>
+                  <div className="font-mono text-sm">{selectedDoc.number}</div>
+                  <div className="text-sm">
+                    {selectedDoc.vendorName ?? '—'} · ยอด{' '}
+                    {formatNumberDecimal(selectedDoc.totalAmount)} ฿
+                  </div>
+                  {capInfo && (
+                    <div className="text-xs text-muted-foreground mt-1">
+                      เหลือลดได้: {formatNumberDecimal(capInfo.remainingCap)} ฿ (ใช้ไปแล้ว{' '}
+                      {formatNumberDecimal(capInfo.usedTotal)} ฿)
+                    </div>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onChange({ originalDocumentId: '' });
+                    setSearch('');
+                  }}
+                  className="text-xs text-destructive hover:underline"
+                >
+                  เปลี่ยน
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="ค้นหาเลข EX-... / ผู้ขาย (3 ตัวขึ้นไป)"
+                    className="w-full pl-10 pr-3 py-2 border border-input rounded-lg text-sm bg-background"
+                  />
+                </div>
+                {(searchResults?.data ?? []).length > 0 && (
+                  <div className="rounded-lg border border-border max-h-48 overflow-y-auto">
+                    {searchResults!.data
+                      .filter((d) => ['POSTED', 'ACCRUAL'].includes(d.status))
+                      .map((doc) => (
+                        <button
+                          type="button"
+                          key={doc.id}
+                          onClick={() => {
+                            onChange({ originalDocumentId: doc.id });
+                            // Pre-populate CN lines from original doc if available
+                            const sourceLines = doc.expenseDetail?.lines ?? [];
+                            if (sourceLines.length > 0) {
+                              onLinesChange(
+                                sourceLines.map((l, idx) => ({
+                                  uid: `cn-${idx}-${Math.random().toString(36).slice(2)}`,
+                                  category: l.category,
+                                  description: '',
+                                  quantity: '1',
+                                  unitPrice: l.amountBeforeVat,
+                                  discount: '0',
+                                  vatPercent: '7',
+                                  whtPercent: '0',
+                                })),
+                              );
+                            }
+                          }}
+                          className="w-full flex items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent border-b border-border last:border-b-0"
+                        >
+                          <div>
+                            <div className="font-mono">{doc.number}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {doc.vendorName ?? '—'} · {doc.status}
+                            </div>
+                          </div>
+                          <div className="font-mono text-sm">
+                            {formatNumberDecimal(doc.totalAmount)}
+                          </div>
+                        </button>
+                      ))}
+                  </div>
+                )}
+              </>
+            )}
+
+            <div>
+              <label className="block text-xs font-medium mb-1">
+                เหตุผลลดหนี้ <span className="text-destructive">*</span>
+              </label>
+              <input
+                type="text"
+                value={state.cnReason}
+                onChange={(e) => onChange({ cnReason: e.target.value })}
+                placeholder="เช่น สินค้าคืน, ปรับราคา, ส่วนลดหลังการขาย"
+                className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* STANDALONE — vendor inputs + reason */}
+      {isStandalone && (
+        <div className="rounded-xl border border-border bg-card">
+          <div className="px-4 py-2 border-b border-border flex items-center gap-2">
+            <FilePlus2 className="size-4 text-primary" />
+            <span className="text-sm font-medium">ข้อมูลผู้ขาย</span>
+            <span className="text-xs text-muted-foreground ml-1">
+              ระบุเอง — ไม่มีเอกสารต้นฉบับ
+            </span>
+          </div>
+          <div className="p-4 space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium mb-1">
+                  ชื่อผู้ขาย <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={state.vendorName}
+                  onChange={(e) => onChange({ vendorName: e.target.value })}
+                  placeholder="เช่น บจก. แอลฟ่า เซอร์วิส"
+                  maxLength={255}
+                  className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium mb-1">
+                  เลขผู้เสียภาษี (ทางเลือก)
+                </label>
+                <input
+                  type="text"
+                  value={state.vendorTaxId}
+                  onChange={(e) => onChange({ vendorTaxId: e.target.value })}
+                  placeholder="13 หลัก"
+                  maxLength={20}
+                  className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background font-mono"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium mb-1">
+                เหตุผลลดหนี้ <span className="text-destructive">*</span>
+              </label>
+              <input
+                type="text"
+                value={state.cnReason}
+                onChange={(e) => onChange({ cnReason: e.target.value })}
+                placeholder="เช่น คืนเงินมัดจำ, ส่วนลดพิเศษ, ปรับยอด AP"
+                className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+              />
+            </div>
+
+            <div className="rounded-lg border border-warning/30 bg-warning/5 p-2 text-xs text-warning flex items-start gap-2">
+              <AlertCircle className="size-3.5 mt-0.5 shrink-0" />
+              <span>
+                ใบลดหนี้แบบ Standalone ไม่ถูก cap ด้วยยอดของเอกสารต้นฉบับ
+                — โปรดตรวจสอบยอดให้ถูกต้องก่อนกด POST
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Credit lines — shown for STANDALONE always, LINKED only after source picked */}
+      {(isStandalone || state.originalDocumentId) && (
         <div>
           <div className="text-xs text-muted-foreground mb-2">รายการที่จะลด</div>
           <ItemLinesSection

--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -54,6 +54,7 @@ const initial = (branchId: string, defaultCash: string): ExpenseFormState => {
     approvedById: '',
     fromTemplateId: '',
     lines: [newLine()],
+    cnMode: 'LINKED',
     originalDocumentId: '',
     cnReason: '',
     payroll: {
@@ -250,8 +251,15 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
         });
         createdId = data.id;
       } else if (state.docType === 'CREDIT_NOTE') {
-        if (!state.originalDocumentId || !state.cnReason.trim()) {
-          throw new Error('กรุณาเลือกเอกสารต้นฉบับและระบุเหตุผล');
+        const isStandalone = state.cnMode === 'STANDALONE';
+        if (!state.cnReason.trim()) {
+          throw new Error('กรุณาระบุเหตุผลในการลดหนี้');
+        }
+        if (!isStandalone && !state.originalDocumentId) {
+          throw new Error('โหมด LINKED ต้องเลือกเอกสารต้นฉบับ');
+        }
+        if (isStandalone && !state.vendorName.trim()) {
+          throw new Error('โหมด STANDALONE ต้องระบุชื่อผู้ขาย');
         }
         const validLines = state.lines.filter((l) => l.category && parseFloat(l.unitPrice) > 0);
         if (validLines.length === 0) {
@@ -260,11 +268,19 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
         // Server computes totals from lines — no preview-je hop needed.
         // This also eliminates the float-string-Decimal dance at the money boundary.
         const { data } = await api.post('/expense-documents/credit-note', {
+          mode: state.cnMode,
           branchId: state.branchId,
           documentDate: state.documentDate,
-          originalDocumentId: state.originalDocumentId,
+          originalDocumentId: isStandalone ? undefined : state.originalDocumentId,
+          vendorName: isStandalone ? state.vendorName.trim() : undefined,
+          vendorTaxId: isStandalone ? state.vendorTaxId.trim() || undefined : undefined,
           reason: state.cnReason,
-          depositAccountCode: state.depositAccountCode || undefined,
+          // STANDALONE per mockup §4 defaults to AP-clearing (Dr 21-1104) — omit
+          // depositAccountCode so the backend takes the no-deposit branch.
+          // LINKED retains the existing behavior (backend uses original.status
+          // to decide Dr 21-1104 vs Dr cash; sends current cash account anyway
+          // for POSTED-original refund flow).
+          depositAccountCode: isStandalone ? undefined : state.depositAccountCode || undefined,
           note: state.note || undefined,
           lines: validLines.map((l) => ({
             category: l.category,

--- a/apps/web/src/components/expense-form-v4/types.ts
+++ b/apps/web/src/components/expense-form-v4/types.ts
@@ -132,6 +132,11 @@ export interface ExpenseFormState {
   fromTemplateId: string;
   lines: ExpenseLineForm[];
   // CN-only
+  /**
+   * C4 · 2-Mode. `LINKED` (default) requires `originalDocumentId`; `STANDALONE`
+   * requires top-level `vendorName` and skips the source-doc picker entirely.
+   */
+  cnMode: 'LINKED' | 'STANDALONE';
   originalDocumentId: string;
   cnReason: string;
   // PR-only

--- a/docs/superpowers/tracking/C4-credit-note-2mode.md
+++ b/docs/superpowers/tracking/C4-credit-note-2mode.md
@@ -1,6 +1,6 @@
 # C4 · Credit Note 2-Mode UI
 
-**Status:** 🟡 Backend done (1/4)  |  **Started:** 2026-05-16  |  **PRs:** this PR (backend)
+**Status:** ✅ Done (4/4)  |  **Started:** 2026-05-16  |  **PRs:** #877 (backend) · this PR (UI)
 **Spec:** —  ·  **Plan:** —
 
 ## Context
@@ -19,16 +19,16 @@ JE shape is the existing CN reversal logic — backend branches on `creditNote.m
 
 | ID | Item | Priority | Status | PR | Evidence/Notes |
 |---|---|---|---|---|---|
-| C4.1 | UI: Mode selector at top of CreditNoteForm (radio: Linked / Standalone) | P2 | ⬜ | — | New section in `apps/web/src/components/expense-form-v4/` — pending UI PR |
-| C4.2 | Mode A — auto-load source EX (supplier, lines, VAT) into editable rows; credit amount defaults to source amount | P2 | 🟡 | this PR | Backend already inherits `vendorName`/`vendorTaxId` from source on the CN doc. UI auto-load wiring exists in `CreditNoteLinesSection.tsx`. Full UI flow shipped with UI PR. |
-| C4.3 | Mode B — standalone form with supplier picker + free-form lines (no source EX FK) | P2 | 🟡 | this PR | Backend ready: DTO accepts `mode: 'STANDALONE'` + required `vendorName`. Service skips original lookup/cap/branch-match. Template branches Dr leg on `creditNote.mode` (Dr 21-1104 if no deposit, Dr cash if deposit set). JE metadata.flow=`expense-credit-note-standalone` + metadata.mode for downstream ภ.พ.30 filtering. UI shipped with UI PR. |
-| C4.4 | Metadata field `creditNoteMode` (`LINKED` / `STANDALONE`) on `CreditNote` schema; ภ.30 export filters appropriately | P2 | ✅ | this PR | `CreditNoteMode` enum + `mode` column (default `LINKED`) on `credit_note_details`. `original_document_id` nullable. Migration `20260930000000_credit_note_2mode`. PP30 query already excludes CN via `debit > 0` on 11-4101 (CN books `Cr 11-4101`) — naturally excludes both LINKED + STANDALONE. New `expense-credit-note-standalone` flow string + metadata.mode lets future reports distinguish if needed. |
+| C4.1 | UI: Mode selector at top of CreditNoteForm (radio: Linked / Standalone) | P2 | ✅ | this PR | Two chip-card buttons at top of [`CreditNoteLinesSection`](../../../apps/web/src/components/expense-form-v4/CreditNoteLinesSection.tsx) — `Link2`/`FilePlus2` icons + aria-pressed. Switching modes wipes the cross-mode fields so server-side validation doesn't see stale values. `state.cnMode` (`'LINKED' \| 'STANDALONE'`) added to `ExpenseFormState`. |
+| C4.2 | Mode A — auto-load source EX (supplier, lines, VAT) into editable rows; credit amount defaults to source amount | P2 | ✅ | #877 + this PR | Backend inherits `vendorName`/`vendorTaxId` from source onto the CN doc. UI source-doc picker (existing) auto-loads ExpenseLine rows when selected — quantity=1, unitPrice=source.amountBeforeVat, editable. Cap-bound by server. |
+| C4.3 | Mode B — standalone form with supplier picker + free-form lines (no source EX FK) | P2 | ✅ | #877 + this PR | Backend: DTO accepts `mode: 'STANDALONE'` + required `vendorName`; service skips original lookup/cap/branch-match; template branches Dr leg on `creditNote.mode` (Dr 21-1104 if no deposit, Dr cash if deposit set). UI: STANDALONE renders vendor inputs (name required, taxId optional) + reason + free-form `ItemLinesSection`. Form omits `depositAccountCode` for STANDALONE per mockup §4 → backend takes Dr 21-1104 path. |
+| C4.4 | Metadata field `creditNoteMode` (`LINKED` / `STANDALONE`) on `CreditNote` schema; ภ.30 export filters appropriately | P2 | ✅ | #877 | `CreditNoteMode` enum + `mode` column (default `LINKED`) on `credit_note_details`. `original_document_id` nullable. Migration `20260930000000_credit_note_2mode`. PP30 query already excludes CN via `debit > 0` on 11-4101 (CN books `Cr 11-4101`) — naturally excludes both LINKED + STANDALONE. New `expense-credit-note-standalone` flow string + metadata.mode lets future reports distinguish if needed. |
 
 ## Decision Log
 
-- **2026-05-16:** Backend-first PR (1/4 items completed, 2/4 partially via groundwork) — UI PR follows next. Same cadence as B2/C1/C2/C3 splits.
+- **2026-05-16:** Backend-first PR (#877) — DTO/service/template/migration/tests ready. UI shipped next in this PR.
 - **2026-05-16:** Q1 answered — for LINKED Mode A partial-paid source, cap stays at `original.totalAmount − Σ prior CN totals` (existing behavior). Owner can revisit if remaining-AP semantics become needed.
-- **2026-05-16:** STANDALONE refund routing: no `depositAccountCode` → Dr 21-1104 (AP-credit-pending); `depositAccountCode` set → Dr cash. Mirrors LINKED ACCRUAL vs POSTED branching without needing a source doc.
+- **2026-05-16:** STANDALONE refund routing: no `depositAccountCode` → Dr 21-1104 (AP-credit-pending); `depositAccountCode` set → Dr cash. UI omits depositAccountCode for STANDALONE per mockup §4 → defaults to AP-clearing. Cash-refund-STANDALONE supported by backend but not surfaced yet; add a toggle later if owner needs it.
 - **2026-05-16:** PP30 filter unchanged — existing `debit > 0` on 11-4101 + `flow LIKE 'expense-%'` naturally excludes CN reversals (both LINKED + STANDALONE) since they book `Cr 11-4101`. No tax.service change required.
 
 ## Open Questions

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -19,15 +19,15 @@
 | [C1 · Petty Cash](C1-petty-cash.md) | 8 | 7 | 88% | ✅ Done | — | [#867](https://github.com/iamnaii/BESTCHOICE/pull/867) · [#868](https://github.com/iamnaii/BESTCHOICE/pull/868) · this PR (PDF). C1.7 settings → A1 |
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
-| [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 1 | 25% | 🟡 In Progress | — | this PR (backend) |
+| [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
 | [D1 · Settings Audit Phase 4](D1-settings-implement.md) | TBD | 0 | 0% | 🔒 Locked (by A1) | — | — |
-| **TOTAL** | **~159** | **52** | **~33%** | | | |
+| **TOTAL** | **~159** | **55** | **~35%** | | | |
 
 ## 🎯 Current Focus
 
-- **Active:** C4 · Credit Note 2-Mode — backend shipped (C4.4 ✅ + C4.2/C4.3 groundwork). UI PR next (mode selector + standalone form).
+- **Active:** None. C4 shipped end-to-end (4/4).
 - **Optional housekeeping:** EQ-002 missing เม.ย. depreciation (~฿287). Not a blocker; owner can run `POST /admin/depreciation/run?period=2026-04` for catch-up at convenience. พ.ค. depreciation will tick automatically on May 31.
-- **Next:** C4.1 + finalize C4.2/C4.3 UI
+- **Next:** A1 audit (Phase 1 scan only, no code) — owner workflow says Phase 1 → STOP for owner approval before Phase 2
 
 ## 📅 Timeline
 


### PR DESCRIPTION
## Summary

Closes the UI half of C4 (mockup v5 page 02D). Wires `state.cnMode` through the form and adds the mode-selector + STANDALONE vendor section. Backend in PR #877.

## Changes

**Mode selector** ([CreditNoteLinesSection.tsx](apps/web/src/components/expense-form-v4/CreditNoteLinesSection.tsx)):
- Two chip-card buttons at top with `Link2` / `FilePlus2` icons + `aria-pressed`
- Switching modes wipes the cross-mode fields so server-side validation doesn't see stale values

**LINKED branch** (unchanged):
- Source-doc search picker + auto-load lines + reason
- Cap-aware via `cn-cap` endpoint — line total exceeded = inline error
- Default mode, so legacy users see no change

**STANDALONE branch** (new):
- Vendor name (required, 255 chars) + tax ID (optional, 20 chars)
- Reason (required)
- Inline warning: "STANDALONE ไม่ถูก cap ด้วยยอดของเอกสารต้นฉบับ"
- Free-form `ItemLinesSection` (always visible, no cap)

**Submit branch** ([ExpenseFormV4.tsx](apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx)):
- Sends `mode: state.cnMode` to `POST /expense-documents/credit-note`
- LINKED: forwards `originalDocumentId` (validated client-side)
- STANDALONE: forwards `vendorName` (required) + `vendorTaxId` (optional); explicitly omits `depositAccountCode` per mockup §4 → backend takes the AP-clearing Dr 21-1104 path
- Cash-refund-STANDALONE is supported by backend but not surfaced in UI yet — owner can add a toggle later if needed

## Tracking

- C4.1/C4.2/C4.3 → ✅ this PR; C4.4 stays ✅ #877
- C4 sub-project status: ✅ Done (4/4)
- README TOTAL 52 → 55 (~35%); Active Focus cleared

## Test plan

- [x] Web type-check passes (0 errors)
- [ ] Manual UAT: open CN form → switch to STANDALONE → vendor inputs appear → submit without source doc → JE posts Dr 21-1104 / Cr expense + 11-4101
- [ ] Manual UAT: STANDALONE without vendorName → form blocks with toast "STANDALONE ต้องระบุชื่อผู้ขาย"
- [ ] Manual UAT: switch back to LINKED → source picker reappears, vendor fields cleared
- [ ] Manual UAT: LINKED unchanged — existing CN-from-EX flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)