### PR TITLE
feat(a1): D1.2.8.2 — tax_exempt_warning_enabled toggle + ม.42 warning UI

### DIFF
--- a/apps/api/src/modules/settings/settings.controller.ts
+++ b/apps/api/src/modules/settings/settings.controller.ts
@@ -21,6 +21,17 @@ export class SettingsController {
     return this.settingsService.findAll();
   }
 
+  /**
+   * D1.* — UI feature flags read by web app for non-OWNER users (payroll
+   * editors, accountants etc.). Authenticated but NOT @Roles-gated so the
+   * web app can fetch them in any role context.
+   */
+  @Get('ui-flags')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT', 'SALES')
+  getUiFlags() {
+    return this.settingsService.getUiFlags();
+  }
+
   @Patch()
   bulkUpdate(@Body() dto: BulkUpdateSettingsDto, @CurrentUser() user: { id: string }) {
     return this.settingsService.bulkUpdate(dto.items, user.id);

--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -103,4 +103,31 @@ describe('SettingsService audit trail', () => {
     await expect(service.update('k', 'v', 'u-1')).rejects.toThrow();
     expect(prisma.systemConfig.upsert).toHaveBeenCalled();
   });
+
+  // D1.2.8.2 — UI feature flags endpoint
+  describe('getUiFlags', () => {
+    it('defaults taxExemptWarningEnabled=true when SystemConfig row missing', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.taxExemptWarningEnabled).toBe(true);
+    });
+
+    it('returns taxExemptWarningEnabled=false when SystemConfig row set to "false"', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue({ value: 'false' });
+      const flags = await service.getUiFlags();
+      expect(flags.taxExemptWarningEnabled).toBe(false);
+    });
+
+    it('returns taxExemptWarningEnabled=true when SystemConfig row set to "true"', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue({ value: 'true' });
+      const flags = await service.getUiFlags();
+      expect(flags.taxExemptWarningEnabled).toBe(true);
+    });
+
+    it('falls back to default for unparseable SystemConfig value', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue({ value: 'maybe' });
+      const flags = await service.getUiFlags();
+      expect(flags.taxExemptWarningEnabled).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -81,6 +81,35 @@ export class SettingsService {
     return Number.isFinite(n) ? n : fallback;
   }
 
+  private async readBoolean(key: string, fallback: boolean): Promise<boolean> {
+    const raw = await this.getKey(key);
+    if (raw == null) return fallback;
+    const v = raw.trim().toLowerCase();
+    if (v === 'true' || v === '1') return true;
+    if (v === 'false' || v === '0') return false;
+    return fallback;
+  }
+
+  /**
+   * D1.* — UI feature flags accessible to ANY authenticated user (not OWNER-only).
+   * Keep this method's response shape small and additive — every D1 item that
+   * needs a runtime UI toggle should land here so the web app can fetch one
+   * lightweight payload at app boot instead of per-feature endpoints.
+   *
+   * Defaults match the spec-defined "on" behaviour so first-boot behaviour
+   * is identical whether the SystemConfig key has been seeded or not.
+   */
+  async getUiFlags(): Promise<{
+    /** D1.2.8.2 — show ม.42 tax-exempt warning when a payroll custom-income line is marked non-taxable. Default true. */
+    taxExemptWarningEnabled: boolean;
+  }> {
+    const taxExemptWarningEnabled = await this.readBoolean(
+      'TAX_EXEMPT_WARNING_ENABLED',
+      true,
+    );
+    return { taxExemptWarningEnabled };
+  }
+
   /**
    * Typed bundle of collections-session tuning knobs. Defaults match the
    * pre-Phase-2 hardcoded constants so first-boot behaviour is unchanged

--- a/apps/web/src/components/expense-form-v4/PayrollLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/PayrollLinesSection.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
+import { AlertTriangle, ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import {
   PayrollFormFields,
   PayrollLineForm,
@@ -11,6 +11,7 @@ import {
 import { formatNumberDecimal } from '@/utils/formatters';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { THAI_MONTHS_FULL } from '@/lib/date';
+import { useUiFlags } from '@/hooks/useUiFlags';
 
 interface Props {
   value: PayrollFormFields;
@@ -28,6 +29,7 @@ const CUSTOM_INCOME_WHITELIST: { code: string; label: string }[] = [
 ];
 
 export function PayrollLinesSection({ value, onChange, documentDate, onDocumentDateChange }: Props) {
+  const { taxExemptWarningEnabled } = useUiFlags();
   const updateField = (patch: Partial<PayrollFormFields>) => onChange({ ...value, ...patch });
 
   const updateLine = (uid: string, p: Partial<PayrollLineForm>) => {
@@ -342,10 +344,17 @@ function CustomIncomeSubTable({
   rows: PayrollCustomIncomeRow[];
   onChange: (rows: PayrollCustomIncomeRow[]) => void;
 }) {
+  const { taxExemptWarningEnabled } = useUiFlags();
   const update = (uid: string, p: Partial<PayrollCustomIncomeRow>) =>
     onChange(rows.map((r) => (r.uid === uid ? { ...r, ...p } : r)));
   const remove = (uid: string) => onChange(rows.filter((r) => r.uid !== uid));
   const add = () => onChange([...rows, newPayrollCustomIncome()]);
+
+  // D1.2.8.2 — show ม.42 tax-exempt warning when any row marked non-taxable.
+  // Gated by SystemConfig TAX_EXEMPT_WARNING_ENABLED (default true, OWNER toggleable).
+  const taxExemptRows = rows.filter((r) => !r.isTaxable);
+  const showWarning =
+    taxExemptWarningEnabled && taxExemptRows.length > 0;
 
   return (
     <div className="rounded-lg border border-border bg-card overflow-hidden">
@@ -440,6 +449,20 @@ function CustomIncomeSubTable({
       >
         <Plus className="size-3" /> เพิ่มรายได้พิเศษ
       </button>
+      {showWarning && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 px-3 py-2 border-t border-border bg-warning/5 text-warning"
+        >
+          <AlertTriangle className="size-3.5 mt-0.5 shrink-0" />
+          <div className="text-xs leading-snug">
+            <span className="font-medium">ยกเว้นภาษี ม.42</span> —{' '}
+            มี {taxExemptRows.length} รายการที่ติ๊กไม่เสียภาษี
+            (ป.รัษฎากร ม.42). ตรวจสอบให้แน่ใจว่าเข้าเงื่อนไข เช่น เงินชดเชย ค่าใช้จ่ายเดินทาง
+            ตามอัตรา ก่อน POST เพราะ ภ.ง.ด.1 จะไม่นับฐานนี้
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+/**
+ * D1.* — UI feature flags fetched from /settings/ui-flags.
+ *
+ * Backed by SystemConfig rows that OWNER edits via Settings page (existing
+ * PATCH /settings flow). Endpoint is authenticated but NOT @Roles-gated to
+ * OWNER, so any role can read the flags they need to render their UI.
+ *
+ * Defaults match the spec-defined "on" behavior — first-render before fetch
+ * resolves uses the defaults so the warning UI never silently flickers off.
+ */
+export interface UiFlags {
+  /** D1.2.8.2 — show ม.42 tax-exempt warning when payroll line marked non-taxable. */
+  taxExemptWarningEnabled: boolean;
+}
+
+const DEFAULT_UI_FLAGS: UiFlags = {
+  taxExemptWarningEnabled: true,
+};
+
+export function useUiFlags(): UiFlags {
+  const { data } = useQuery<UiFlags>({
+    queryKey: ['settings-ui-flags'],
+    queryFn: async () => {
+      const { data } = await api.get<UiFlags>('/settings/ui-flags');
+      return data;
+    },
+    staleTime: 5 * 60_000, // 5 min — flags rarely change mid-session
+  });
+  return data ?? DEFAULT_UI_FLAGS;
+}

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** (one per item per anti-pattern #3)
+**Started:** 2026-05-16  |  **PRs:** this PR (D1.2.8.2)  |  **Done:** 1/75
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -34,7 +34,7 @@ Sub-prioritization within expanded D1 scope:
 
 | ID | Item | Priority | Status | PR | Evidence/Notes |
 |---|---|---|---|---|---|
-| D1.2.8.2 | `tax_exempt_warning_enabled` (UI ม.42 warning toggle) | P1 | ⬜ | — | Smallest item (~2 hrs) — flip first |
+| D1.2.8.2 | `tax_exempt_warning_enabled` (UI ม.42 warning toggle) | P1 | ✅ | this PR | `SystemConfig.TAX_EXEMPT_WARNING_ENABLED` (default true, OWNER-editable via existing PATCH /settings). New `GET /settings/ui-flags` endpoint (authenticated, all roles). New `useUiFlags()` hook + warning row in `CustomIncomeSubTable` (PayrollLinesSection.tsx) when any custom-income line has `isTaxable=false` and flag is on. 4 unit tests on getUiFlags. Pattern: reusable for future D1 UI flags |
 | D1.4.3.1 | `audit_log_retention_days` 180→1825d (พ.ร.บ.บัญชี ม.7 compliance) | P3 | ⬜ | — | env-var-tunable already; needs SystemConfig wrap + default raise |
 | D1.1.6.1 | `adj_underpay_account` (wire consumers to AccountRoleService) | P0 | ⬜ | — | `payment-receipt-2b.template.ts:249`, `payment-receipt-2b-split.template.ts:212`, `payments.service.ts:1989`, `AdjustmentSection.tsx:30` |
 | D1.1.6.2 | `adj_overpay_account` (wire consumers to AccountRoleService) | P0 | ⬜ | — | Same pattern with 53-1503 |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 0 | 0% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | (per-item PRs incoming) |
-| **TOTAL** | **~159** | **67** | **~42%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 1 | 1% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | this PR (D1.2.8.2) |
+| **TOTAL** | **~159** | **68** | **~43%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #1 — smallest, unblocked. Adds ม.42 tax-exempt warning to payroll custom-income editor, gated by a new OWNER-editable SystemConfig flag (default true).

Establishes the **`getUiFlags()` + `useUiFlags()` pattern** that future D1 UI-flag items (~10+ items) will reuse: typed bundle on the backend, single React Query hook on the frontend, no extra endpoint per flag.

## Changes

**Backend** ([settings.service.ts](apps/api/src/modules/settings/settings.service.ts), [settings.controller.ts](apps/api/src/modules/settings/settings.controller.ts)):
- `SettingsService.getUiFlags()` returns typed flags with sensible defaults
- `readBoolean()` helper (accepts `true`/`false`/`1`/`0`, fallback on unparseable)
- `GET /settings/ui-flags` — authenticated, all 5 roles allowed (not OWNER-only)

**Frontend** ([useUiFlags.ts](apps/web/src/hooks/useUiFlags.ts), [PayrollLinesSection.tsx](apps/web/src/components/expense-form-v4/PayrollLinesSection.tsx)):
- New `useUiFlags()` hook — 5-min staleTime, returns typed flags with defaults
- `CustomIncomeSubTable` renders warning row when any row has `isTaxable=false` and flag is on
- Thai warning text + AlertTriangle icon + row count

**Tests:**
- 4 new unit tests on `getUiFlags`: default-true, "false"/"true" reads, unparseable fallback
- 10/10 settings.service.spec.ts pass · 0 type errors

## OWNER admin path

OWNER toggles via existing Settings page (PATCH /settings flow already covers all SystemConfig keys). No new admin UI needed for this item.

## Tracking

- D1.2.8.2 → ✅ this PR
- D1 progress: 1/75
- README TOTAL 67→68

## Test plan

- [x] Type check passes (both apps)
- [x] Settings unit tests pass (10/10)
- [ ] Manual UAT: open payroll form → expand custom income → uncheck "เสีย" on a row → warning row appears below table
- [ ] Manual UAT: `INSERT INTO system_config (key, value) VALUES ('TAX_EXEMPT_WARNING_ENABLED', 'false')` → re-render → warning row hidden
- [ ] Manual UAT: `GET /settings/ui-flags` as ACCOUNTANT role → 200 with `{ taxExemptWarningEnabled: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)