### PR TITLE
feat(a1): D1.4.3.1 — audit_log_retention 180→1825d (พ.ร.บ.บัญชี ม.7 compliance)

### DIFF
--- a/apps/api/src/modules/audit/audit-retention.cron.spec.ts
+++ b/apps/api/src/modules/audit/audit-retention.cron.spec.ts
@@ -21,6 +21,7 @@ describe('AuditRetentionCron.archiveOldEntries', () => {
     delete process.env.AUDIT_LOG_RETENTION_DAYS;
     prisma = {
       auditLog: { updateMany: jest.fn().mockResolvedValue({ count: 0 }) },
+      systemConfig: { findFirst: jest.fn().mockResolvedValue(null) },
     };
     const mod: TestingModule = await Test.createTestingModule({
       providers: [AuditRetentionCron, { provide: PrismaService, useValue: prisma }],
@@ -55,10 +56,10 @@ describe('AuditRetentionCron.archiveOldEntries', () => {
     expect(call.where.archivedAt).toBeNull();
     expect(call.where.createdAt.lt).toBeInstanceOf(Date);
 
-    // Default cutoff should be ~180d ago
+    // D1.4.3.1 — default raised to 1825d (5 yr per พ.ร.บ.บัญชี ม.7)
     const ageDays = (Date.now() - (call.where.createdAt.lt as Date).getTime()) / (24 * 60 * 60 * 1000);
-    expect(ageDays).toBeGreaterThan(179.9);
-    expect(ageDays).toBeLessThan(180.1);
+    expect(ageDays).toBeGreaterThan(1824.9);
+    expect(ageDays).toBeLessThan(1825.1);
 
     // Sentry info when rows were actually archived
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
@@ -67,7 +68,7 @@ describe('AuditRetentionCron.archiveOldEntries', () => {
     );
   });
 
-  it('honours AUDIT_LOG_RETENTION_DAYS env override', async () => {
+  it('honours AUDIT_LOG_RETENTION_DAYS env override when SystemConfig absent', async () => {
     process.env.AUDIT_LOG_RETENTION_DAYS = '30';
     prisma.auditLog.updateMany.mockResolvedValue({ count: 0 });
     const result = await cron.archiveOldEntries();
@@ -77,5 +78,30 @@ describe('AuditRetentionCron.archiveOldEntries', () => {
     const ageDays = (Date.now() - (where.createdAt.lt as Date).getTime()) / (24 * 60 * 60 * 1000);
     expect(ageDays).toBeGreaterThan(29.9);
     expect(ageDays).toBeLessThan(30.1);
+  });
+
+  // D1.4.3.1 — SystemConfig override
+  it('SystemConfig audit_log_retention_days takes precedence over env var', async () => {
+    process.env.AUDIT_LOG_RETENTION_DAYS = '30';
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: '900' });
+    const result = await cron.archiveOldEntries();
+    expect(result.retentionDays).toBe(900);
+    const where = prisma.auditLog.updateMany.mock.calls[0][0].where;
+    const ageDays = (Date.now() - (where.createdAt.lt as Date).getTime()) / (24 * 60 * 60 * 1000);
+    expect(ageDays).toBeGreaterThan(899.9);
+    expect(ageDays).toBeLessThan(900.1);
+  });
+
+  it('falls through to default when SystemConfig + env are missing/invalid', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'not-a-number' });
+    const result = await cron.archiveOldEntries();
+    expect(result.retentionDays).toBe(AuditRetentionCron.DEFAULT_RETENTION_DAYS);
+    expect(AuditRetentionCron.DEFAULT_RETENTION_DAYS).toBe(1825);
+  });
+
+  it('survives SystemConfig DB error (falls through to env/default)', async () => {
+    prisma.systemConfig.findFirst.mockRejectedValue(new Error('db down'));
+    const result = await cron.archiveOldEntries();
+    expect(result.retentionDays).toBe(AuditRetentionCron.DEFAULT_RETENTION_DAYS);
   });
 });

--- a/apps/api/src/modules/audit/audit-retention.cron.ts
+++ b/apps/api/src/modules/audit/audit-retention.cron.ts
@@ -9,11 +9,18 @@ import { PrismaService } from '../../prisma/prisma.service';
  * The AuditLog table carries the legal audit trail (who did what, when).
  * The BEFORE DELETE trigger installed by 20260520300000_audit_log_archive_immutable
  * refuses physical DELETEs, so we *archive* instead: set archived_at on any
- * row older than AUDIT_LOG_RETENTION_DAYS.
+ * row older than the configured retention.
  *
  * Archived rows remain queryable for forensics but fall outside the hot
  * reporting set. A separate purge path (not this cron) can later hard-cull
- * archived rows beyond the 7-year legal retention.
+ * archived rows beyond the legal retention.
+ *
+ * **D1.4.3.1 (2026-05-16):** default raised 180→1825d (5 years) per
+ * พ.ร.บ.บัญชี ม.7 legal compliance. Retention is now resolved in this order:
+ *   1. SystemConfig key `audit_log_retention_days` (OWNER-editable via UI)
+ *   2. env var `AUDIT_LOG_RETENTION_DAYS` (ops escape hatch, no restart needed
+ *      to override DB temporarily)
+ *   3. DEFAULT_RETENTION_DAYS (1825)
  *
  * Schedule: Sunday 03:00 Asia/Bangkok. Lines up after the audit-chain-verify
  * cron at 03:45 on other days, avoiding lock contention.
@@ -21,21 +28,44 @@ import { PrismaService } from '../../prisma/prisma.service';
 @Injectable()
 export class AuditRetentionCron {
   private readonly logger = new Logger(AuditRetentionCron.name);
-  static readonly DEFAULT_RETENTION_DAYS = 180;
+  /** D1.4.3.1 — 1825d = 5 years per พ.ร.บ.บัญชี ม.7 (was 180d pre-A1). */
+  static readonly DEFAULT_RETENTION_DAYS = 1825;
 
   constructor(private readonly prisma: PrismaService) {}
 
-  private getRetentionDays(): number {
+  private async getRetentionDays(): Promise<number> {
+    // Precedence 1: SystemConfig key `audit_log_retention_days` (OWNER-editable
+    // via existing PATCH /settings flow, no restart). Read via PrismaService
+    // directly rather than SettingsService to avoid an AuditModule ↔
+    // SettingsModule circular dependency (SettingsService consumes AuditService
+    // for change tracking; AuditModule providers cannot transitively re-import
+    // SettingsModule).
+    try {
+      const row = await this.prisma.systemConfig.findFirst({
+        where: { key: 'audit_log_retention_days', deletedAt: null },
+        select: { value: true },
+      });
+      if (row?.value) {
+        const n = Number.parseInt(row.value, 10);
+        if (Number.isFinite(n) && n > 0) return n;
+      }
+    } catch {
+      // DB error during config read shouldn't break the cron — fall through
+      // to env var / default.
+    }
+    // Precedence 2: env var (ops escape hatch)
     const raw = process.env.AUDIT_LOG_RETENTION_DAYS;
-    if (!raw) return AuditRetentionCron.DEFAULT_RETENTION_DAYS;
-    const n = Number.parseInt(raw, 10);
-    if (!Number.isFinite(n) || n <= 0) return AuditRetentionCron.DEFAULT_RETENTION_DAYS;
-    return n;
+    if (raw) {
+      const n = Number.parseInt(raw, 10);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+    // Precedence 3: compliance default
+    return AuditRetentionCron.DEFAULT_RETENTION_DAYS;
   }
 
   @Cron('0 3 * * 0', { timeZone: 'Asia/Bangkok' })
   async archiveOldEntries(): Promise<{ archived: number; retentionDays: number }> {
-    const retentionDays = this.getRetentionDays();
+    const retentionDays = await this.getRetentionDays();
     try {
       const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
       // Soft-archive only: the BEFORE DELETE trigger (T2-C4 ext) refuses

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** this PR (D1.2.8.2)  |  **Done:** 1/75
+**Started:** 2026-05-16  |  **PRs:** #882 (D1.2.8.2) · this PR (D1.4.3.1)  |  **Done:** 2/75
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -35,7 +35,7 @@ Sub-prioritization within expanded D1 scope:
 | ID | Item | Priority | Status | PR | Evidence/Notes |
 |---|---|---|---|---|---|
 | D1.2.8.2 | `tax_exempt_warning_enabled` (UI ม.42 warning toggle) | P1 | ✅ | this PR | `SystemConfig.TAX_EXEMPT_WARNING_ENABLED` (default true, OWNER-editable via existing PATCH /settings). New `GET /settings/ui-flags` endpoint (authenticated, all roles). New `useUiFlags()` hook + warning row in `CustomIncomeSubTable` (PayrollLinesSection.tsx) when any custom-income line has `isTaxable=false` and flag is on. 4 unit tests on getUiFlags. Pattern: reusable for future D1 UI flags |
-| D1.4.3.1 | `audit_log_retention_days` 180→1825d (พ.ร.บ.บัญชี ม.7 compliance) | P3 | ⬜ | — | env-var-tunable already; needs SystemConfig wrap + default raise |
+| D1.4.3.1 | `audit_log_retention_days` 180→1825d (พ.ร.บ.บัญชี ม.7 compliance) | P3 | ✅ | this PR | `AuditRetentionCron.DEFAULT_RETENTION_DAYS` raised 180→1825 (5 yr per ม.7). Precedence: SystemConfig key `audit_log_retention_days` → env `AUDIT_LOG_RETENTION_DAYS` → default 1825. Read via PrismaService directly (avoids AuditModule↔SettingsModule circular dep). 6/6 tests pass incl. new precedence + DB-failure paths |
 | D1.1.6.1 | `adj_underpay_account` (wire consumers to AccountRoleService) | P0 | ⬜ | — | `payment-receipt-2b.template.ts:249`, `payment-receipt-2b-split.template.ts:212`, `payments.service.ts:1989`, `AdjustmentSection.tsx:30` |
 | D1.1.6.2 | `adj_overpay_account` (wire consumers to AccountRoleService) | P0 | ⬜ | — | Same pattern with 53-1503 |
 | D1.1.6.3 | `adj_auto_route` toggle | P0 | ⬜ | — | Flag in SystemConfig + check in template |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 1 | 1% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | this PR (D1.2.8.2) |
-| **TOTAL** | **~159** | **68** | **~43%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 2 | 3% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | [#882](https://github.com/iamnaii/BESTCHOICE/pull/882) · this PR |
+| **TOTAL** | **~159** | **69** | **~43%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #2. **Legal compliance fix** — raises the audit log retention default from 180d to 1825d (5 years per พ.ร.บ.การบัญชี พ.ศ.2543 ม.7) and adds runtime OWNER-editability via SystemConfig.

## Default raised

`AuditRetentionCron.DEFAULT_RETENTION_DAYS`: **180 → 1825**

Five years matches Thai accounting law's minimum retention for accounting records and audit trails. The old 180d default was a Phase A/B placeholder that violated ม.7 compliance.

## Resolution precedence (new)

1. **SystemConfig** key `audit_log_retention_days` — OWNER edits via existing PATCH /settings flow; no restart
2. **env var** `AUDIT_LOG_RETENTION_DAYS` — ops escape hatch for incident response
3. **Default** 1825

## Notable: avoiding circular dep

SystemConfig is read via `PrismaService.systemConfig.findFirst` directly, NOT via `SettingsService.getKey()`. SettingsService consumes AuditService for change-tracking; AuditModule providers cannot transitively re-import SettingsModule without `forwardRef`. A try/catch wraps the DB read so transient DB issues fall through to env/default cleanly.

## Tests

- Default cutoff now ~1825d (was 180d)
- New: SystemConfig precedence over env var
- New: invalid SystemConfig value falls through to default
- New: DB error during read still completes via fallback
- **6/6 pass · type-check 0 errors**

## Deploy notes

- **No DB migration** — SystemConfig key is optional
- Deployments using `AUDIT_LOG_RETENTION_DAYS` env var keep working unchanged
- All prod systems automatically gain 1825d retention on next Sunday 03:00 BKK cron run after deploy
- OWNER can add the SystemConfig row anytime via Settings page to override (e.g. raise to 7 yr for stricter policy)

## Tracking

- D1.4.3.1 → ✅ this PR
- D1 progress: 2/75
- README TOTAL 68→69

## Test plan

- [x] Type check (0 errors)
- [x] Unit tests (6/6 pass)
- [ ] Manual UAT: `SELECT * FROM system_config WHERE key='audit_log_retention_days'` → null; cron uses 1825
- [ ] Manual UAT: `INSERT INTO system_config (key, value) VALUES ('audit_log_retention_days', '900')` → cron uses 900

🤖 Generated with [Claude Code](https://claude.com/claude-code)