### PR TITLE
feat(a1): D1.2.7.4 — reverse_block_cascaded toggle

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -50,9 +50,11 @@ describe('ExpenseDocumentsService', () => {
           { code: '53-1404', type: 'ค่าใช้จ่าย' },
         ]),
       },
-      // C10 attachment-threshold check reads ATTACHMENT_REQUIRED_ABOVE_AMOUNT
+      // C10 attachment-threshold check reads ATTACHMENT_REQUIRED_ABOVE_AMOUNT.
+      // D1.2.7.4 — voidDocument now also reads `reverse_block_cascaded` via findFirst.
       systemConfig: {
         findUnique: jest.fn().mockResolvedValue(null),
+        findFirst: jest.fn().mockResolvedValue(null),
       },
       // C9 Round 2 — post/voidDocument resolve SHOP companyId for the
       // module-level validatePeriodOpen call (mirroring expense templates).
@@ -986,6 +988,56 @@ describe('ExpenseDocumentsService', () => {
         .mockResolvedValueOnce(1);
       await expect(service.voidDocument('doc-1', 'user-1')).rejects.toThrow(
         /SE.*ยกเลิก|ยกเลิก SE/,
+      );
+    });
+
+    // D1.2.7.4 — cascade block toggle
+    it('D1.2.7.4: OWNER can disable cascade block via SystemConfig — void proceeds even with pending CN/SE', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_block_cascaded') return Promise.resolve({ value: 'false' });
+        return Promise.resolve(null);
+      });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-1', status: 'ACCRUAL', journalEntryId: 'je-orig', documentType: 'EXPENSE', number: 'EX-001',
+      });
+      // CN cascade hit and SE cascade hit — both should be IGNORED when flag is off
+      prisma.expenseDocument.count = jest
+        .fn()
+        .mockResolvedValueOnce(3) // pending CN > 0
+        .mockResolvedValueOnce(2); // pending SE > 0
+      prisma.journalEntry = {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: 'je-orig', entryNumber: 'JE-OLD',
+          lines: [{ accountCode: '53-1404', debit: '100', credit: '0', description: 'x' }],
+          metadata: {},
+        }),
+      };
+      const journalMock = {
+        createAndPost: jest.fn().mockResolvedValue({ id: 'je-rev', entryNumber: 'JE-REV-001' }),
+      };
+      const svc = new ExpenseDocumentsService(
+        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
+        journalMock as never,
+        new LineAggregatorService(),
+        { preview: jest.fn() } as never,
+        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
+        { execute: jest.fn() } as never,
+        { getConfig: jest.fn(), validate: jest.fn() } as never,
+        { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
+      );
+      // Should NOT throw — both cascade checks are bypassed
+      await expect(svc.voidDocument('doc-1', 'user-1')).resolves.toBeDefined();
+    });
+
+    it('D1.2.7.4: default behavior unchanged when SystemConfig key absent (flag = true)', async () => {
+      // No SystemConfig override → cascade block enforced (= existing C3.4 behavior)
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-1', status: 'ACCRUAL', journalEntryId: 'je-1', documentType: 'EXPENSE',
+      });
+      prisma.expenseDocument.count = jest.fn().mockResolvedValue(1); // pending CN
+      await expect(service.voidDocument('doc-1', 'user-1')).rejects.toThrow(
+        /ใบลดหนี้/,
       );
     });
 

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -121,6 +121,32 @@ export class ExpenseDocumentsService implements OnModuleInit {
     private readonly payrollCustom: PayrollCustomService,
   ) {}
 
+  // ─── D1.* — Service-side SystemConfig flag readers ─────────────────────
+  // Read directly via PrismaService (avoids injecting SettingsService for a
+  // single-key lookup; also sidesteps potential audit↔settings circular dep
+  // pattern when this service is consumed by future audit-linked features).
+  // Each helper returns the spec-defined default if the SystemConfig row is
+  // missing or has an unparseable value, so first-boot behavior is preserved.
+  private async readBoolFlag(
+    tx: Prisma.TransactionClient | PrismaService,
+    key: string,
+    fallback: boolean,
+  ): Promise<boolean> {
+    try {
+      const row = await tx.systemConfig.findFirst({
+        where: { key, deletedAt: null },
+        select: { value: true },
+      });
+      if (!row?.value) return fallback;
+      const v = row.value.trim().toLowerCase();
+      if (v === 'true' || v === '1') return true;
+      if (v === 'false' || v === '0') return false;
+      return fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
   // ─── V12/V13/V14 — Multi-line Adjustment validation (shared) ────────
   // Fix Report P0-4 + B2. Validates that:
   //   V12  Σ signed(adjustments) === amountPaid − netExpected
@@ -1666,6 +1692,13 @@ export class ExpenseDocumentsService implements OnModuleInit {
       });
       if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
 
+      // D1.2.7.4 — `reverse_block_cascaded` (default true). OWNER may disable
+      // via SystemConfig to allow voiding upstream docs even when downstream CN/SE
+      // exist. Default-on preserves the strict safety from C3.4. If owner
+      // disables, downstream consumers will become orphaned — UI must surface
+      // this risk separately (out of scope here).
+      const cascadeBlockEnabled = await this.readBoolFlag(tx, 'reverse_block_cascaded', true);
+
       const pendingCn = await tx.expenseDocument.count({
         where: {
           documentType: 'CREDIT_NOTE',
@@ -1674,14 +1707,14 @@ export class ExpenseDocumentsService implements OnModuleInit {
           creditNote: { originalDocumentId: id },
         },
       });
-      if (pendingCn > 0) {
+      if (cascadeBlockEnabled && pendingCn > 0) {
         throw new BadRequestException('มีใบลดหนี้ที่ยังไม่ถูกยกเลิก ไม่สามารถยกเลิกเอกสารต้นฉบับได้');
       }
 
       // C3.4 — Cascade check: also block void when an active SETTLEMENT
       // clears this doc. (Settlement-on-void of the SE itself separately
       // reverts cleared docs back to ACCRUAL — that's the SE-being-voided
-      // path, not this one.)
+      // path, not this one.) Gated by the same `reverse_block_cascaded` flag.
       const pendingSe = await tx.expenseDocument.count({
         where: {
           documentType: 'VENDOR_SETTLEMENT',
@@ -1690,7 +1723,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
           settlement: { settlementLines: { some: { clearedDocumentId: id } } },
         },
       });
-      if (pendingSe > 0) {
+      if (cascadeBlockEnabled && pendingSe > 0) {
         throw new BadRequestException(
           'มีใบจ่ายเจ้าหนี้ (SE) ที่ยังไม่ถูกยกเลิกอ้างถึงเอกสารนี้อยู่ — ' +
             'กรุณายกเลิก SE ก่อน',

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882 (D1.2.8.2) · this PR (D1.4.3.1)  |  **Done:** 2/75
+**Started:** 2026-05-16  |  **PRs:** #882 · #883 · this PR (D1.2.7.4)  |  **Done:** 3/75
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -53,7 +53,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.7.1 | `reverse_reason_required` | P1 | ⬜ | — | Move @IsOptional to required when flag set |
 | D1.2.7.2 | `reverse_reasons_dropdown` | P1 | ⬜ | — | DB-driven 6-option list |
 | D1.2.7.3 | `reverse_manager_approval_days` | P1 | ⬜ | — | Age-gate the void path |
-| D1.2.7.4 | `reverse_block_cascaded` toggle | P1 | ⬜ | — | Wrap unconditional throw in flag check |
+| D1.2.7.4 | `reverse_block_cascaded` toggle | P1 | ✅ | this PR | New private helper `readBoolFlag()` in `ExpenseDocumentsService` (reads `system_config` directly via PrismaService to keep ctor lean + avoid circular-dep risk with audit/settings modules). Cascade-block check at `expense-documents.service.ts:1681-1700` now reads `reverse_block_cascaded` (default true). Both CN and SE cascade throws gated by the same flag. 2 new tests (toggle off → both bypassed; default → preserved). 52/52 service-spec tests pass |
 | D1.2.3.1 | `default_time_range` | P1 | ⬜ | — | DateRangeChips presets configurable |
 | D1.2.3.2 | `pagination_size` | P1 | ⬜ | — | Central default for list pages |
 | D1.2.3.3 | `date_format` BE↔ค.ศ. toggle | P1 | ⬜ | — | formatDateShort branch on pref |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 2 | 3% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | [#882](https://github.com/iamnaii/BESTCHOICE/pull/882) · this PR |
-| **TOTAL** | **~159** | **69** | **~43%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 3 | 4% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882 · #883 · this PR |
+| **TOTAL** | **~159** | **70** | **~44%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #3. Wraps the C3.4 cascade-block throws in an OWNER-editable SystemConfig flag. **Default behavior unchanged** — flag defaults true, so existing strict safety is preserved unless owner explicitly disables.

## Behavior

| `reverse_block_cascaded` | Result |
|---|---|
| absent / `"true"` (default) | Voiding upstream doc with pending CN/SE → throws (existing C3.4 behavior) |
| `"false"` | Cascade checks bypassed; void proceeds |

## Implementation

- New private helper `ExpenseDocumentsService.readBoolFlag()` reads SystemConfig via PrismaService directly (not via SettingsService) — keeps the already-15-arg ctor lean and avoids potential audit↔settings circular-dep risk
- try/catch around DB read → fall through to default on transient errors
- Same flag governs both CN check and SE check (one toggle per audit spec)

## Tests

- New: flag off → both CN and SE cascade hits bypassed
- New: flag absent → existing C3.4 behavior preserved
- 52/52 service-spec tests pass · type-check 0 errors

## Tracking

- D1.2.7.4 → ✅ this PR · D1 3/75 · README 69→70

## Test plan

- [x] Type check (0 errors)
- [x] Unit tests (52/52 pass)
- [ ] Manual UAT: default → void with pending CN throws Thai message
- [ ] Manual UAT: `INSERT INTO system_config (key, value) VALUES ('reverse_block_cascaded', 'false')` → void proceeds; downstream CN/SE remain (orphaned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)