### PR TITLE
feat(a1): D1.2.7.2 — reverse_reasons dropdown (DB-driven)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -1061,6 +1061,65 @@ describe('ExpenseDocumentsService', () => {
       await expect(service.voidDocument('doc-1', 'user-1')).rejects.toThrow(/เหตุผล/);
     });
 
+    // D1.2.7.2 — DB-driven reasons whitelist
+    it('D1.2.7.2: rejects void when reasonCode is not in configured whitelist', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_reasons') {
+          return Promise.resolve({
+            value: JSON.stringify([{ code: 'manager_decision', label: 'x' }]),
+          });
+        }
+        // reverse_reason_required defaults to true so we leave it alone
+        if (args.where.key === 'reverse_reason_required') return Promise.resolve(null);
+        return Promise.resolve(null);
+      });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-1', status: 'ACCRUAL', journalEntryId: 'je-1', documentType: 'EXPENSE',
+      });
+      prisma.expenseDocument.count = jest.fn().mockResolvedValue(0);
+      await expect(
+        service.voidDocument('doc-1', 'user-1', { reasonCode: 'data_entry_error' }),
+      ).rejects.toThrow(/ไม่อยู่ในรายการ/);
+    });
+
+    it('D1.2.7.2: accepts custom reasonCode when in configured whitelist', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_reasons') {
+          return Promise.resolve({
+            value: JSON.stringify([{ code: 'manager_decision', label: 'x' }]),
+          });
+        }
+        return Promise.resolve(null);
+      });
+      prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue({
+        id: 'doc-1', status: 'ACCRUAL', journalEntryId: 'je-orig', documentType: 'EXPENSE', number: 'EX-001',
+      });
+      prisma.expenseDocument.count = jest.fn().mockResolvedValue(0);
+      prisma.journalEntry = {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: 'je-orig', entryNumber: 'JE-OLD',
+          lines: [{ accountCode: '53-1404', debit: '100', credit: '0', description: 'x' }],
+          metadata: {},
+        }),
+      };
+      const journalMock = {
+        createAndPost: jest.fn().mockResolvedValue({ id: 'je-rev', entryNumber: 'JE-REV-001' }),
+      };
+      const svc = new ExpenseDocumentsService(
+        prisma, docNumber, transition, sameDay, accrual, creditNote, payroll, settlement,
+        journalMock as never,
+        new LineAggregatorService(),
+        { preview: jest.fn() } as never,
+        { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
+        { execute: jest.fn() } as never,
+        { getConfig: jest.fn(), validate: jest.fn() } as never,
+        { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
+      );
+      await expect(
+        svc.voidDocument('doc-1', 'user-1', { reasonCode: 'manager_decision' }),
+      ).resolves.toBeDefined();
+    });
+
     it('D1.2.7.1: allows void without reasonCode when flag is off', async () => {
       prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
         if (args.where.key === 'reverse_reason_required') return Promise.resolve({ value: 'false' });

--- a/apps/api/src/modules/expense-documents/dto/void-expense.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/void-expense.dto.ts
@@ -1,37 +1,46 @@
-import { IsString, IsOptional, IsIn, IsDateString, MaxLength } from 'class-validator';
+import { IsString, IsOptional, IsDateString, MaxLength } from 'class-validator';
 
 /**
  * C3 — Reverse Dialog payload. Replaces the previously parameterless
  * `POST /expense-documents/:id/void`. All fields optional for backward
  * compatibility with older callers that still send an empty body.
  *
- * `reasonCode` is one of 6 canonical strings (per mockup 02E). UI dropdown
- * sources the same labels. `reasonDetail` is free-text for any context that
- * doesn't fit a canonical reason. Both end up in the AuditLog row's
- * `newValue` JSON for forensic queryability.
+ * `reasonCode` is validated at the SERVICE layer against the configured
+ * reasons list (D1.2.7.2 — `reverse_reasons` SystemConfig key, default = the
+ * 6 codes below). DTO keeps the field permissive so OWNER can introduce
+ * custom codes via SystemConfig without a redeploy.
+ *
+ * `reasonDetail` is free-text for any context that doesn't fit a canonical
+ * reason. Both end up in the AuditLog row's `newValue` JSON for forensic
+ * queryability.
  *
  * `reverseDate` lets the reversal JE post on a user-chosen date (still
  * subject to V19 period-open guard). When omitted, the existing behavior
  * (today, BKK noon) is preserved.
  */
-export const REVERSE_REASON_CODES = [
-  'data_entry_error',     // ป้อนข้อมูลผิด
-  'wrong_vendor',         // ผู้ขายผิด
-  'wrong_amount',         // จำนวนเงินผิด
-  'duplicate_entry',      // ข้อมูลซ้ำ
-  'cancel_transaction',   // ยกเลิกรายการ
-  'other',                // อื่นๆ (ต้องระบุใน reasonDetail)
+export const DEFAULT_REVERSE_REASONS = [
+  { code: 'data_entry_error',   label: 'ป้อนข้อมูลผิด' },
+  { code: 'wrong_vendor',       label: 'ผู้ขายผิด' },
+  { code: 'wrong_amount',       label: 'จำนวนเงินผิด' },
+  { code: 'duplicate_entry',    label: 'ข้อมูลซ้ำ' },
+  { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
+  { code: 'other',              label: 'อื่นๆ (ระบุรายละเอียด)' },
 ] as const;
 
-export type ReverseReasonCode = (typeof REVERSE_REASON_CODES)[number];
+/** Back-compat — code-only string union of the default whitelist. */
+export const REVERSE_REASON_CODES = DEFAULT_REVERSE_REASONS.map((r) => r.code);
+export type ReverseReasonCode = (typeof DEFAULT_REVERSE_REASONS)[number]['code'];
 
 export class VoidExpenseDocumentDto {
+  /**
+   * Validated against the configured `reverse_reasons` list inside `voidDocument`
+   * (D1.2.7.2). DTO keeps the @IsString minimum so OWNER can extend codes via
+   * SystemConfig without DTO redeploy.
+   */
   @IsString()
-  @IsIn([...REVERSE_REASON_CODES], {
-    message: `เหตุผลการกลับรายการต้องเป็นหนึ่งใน: ${REVERSE_REASON_CODES.join(', ')}`,
-  })
+  @MaxLength(64)
   @IsOptional()
-  reasonCode?: ReverseReasonCode;
+  reasonCode?: string;
 
   @IsString()
   @MaxLength(500, { message: 'รายละเอียดเหตุผลยาวเกิน 500 ตัวอักษร' })

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -147,6 +147,48 @@ export class ExpenseDocumentsService implements OnModuleInit {
     }
   }
 
+  /**
+   * D1.2.7.2 — reverse-reasons whitelist. Inlined (vs. importing
+   * SettingsService) for the same reasons as readBoolFlag — keeps the ctor
+   * stable and dodges audit↔settings cycles.
+   */
+  private async getReverseReasons(
+    tx: Prisma.TransactionClient | PrismaService,
+  ): Promise<{ code: string; label: string }[]> {
+    const defaults = [
+      { code: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
+      { code: 'wrong_vendor', label: 'ผู้ขายผิด' },
+      { code: 'wrong_amount', label: 'จำนวนเงินผิด' },
+      { code: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
+      { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
+      { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
+    ];
+    try {
+      const row = await tx.systemConfig.findFirst({
+        where: { key: 'reverse_reasons', deletedAt: null },
+        select: { value: true },
+      });
+      if (!row?.value) return defaults;
+      const parsed = JSON.parse(row.value);
+      if (
+        Array.isArray(parsed) &&
+        parsed.length > 0 &&
+        parsed.every(
+          (r) =>
+            r &&
+            typeof r === 'object' &&
+            typeof r.code === 'string' &&
+            typeof r.label === 'string',
+        )
+      ) {
+        return parsed;
+      }
+      return defaults;
+    } catch {
+      return defaults;
+    }
+  }
+
   // ─── V12/V13/V14 — Multi-line Adjustment validation (shared) ────────
   // Fix Report P0-4 + B2. Validates that:
   //   V12  Σ signed(adjustments) === amountPaid − netExpected
@@ -1737,6 +1779,19 @@ export class ExpenseDocumentsService implements OnModuleInit {
       const reasonRequired = await this.readBoolFlag(tx, 'reverse_reason_required', true);
       if (reasonRequired && !dto.reasonCode?.trim()) {
         throw new BadRequestException('กรุณาระบุเหตุผลในการยกเลิกเอกสาร');
+      }
+
+      // D1.2.7.2 — `reverse_reasons` SystemConfig (default = 6 canonical
+      // codes). Validate dto.reasonCode against the configured whitelist
+      // when present. OWNER can extend/override the list via SettingsService.
+      if (dto.reasonCode?.trim()) {
+        const reasons = await this.getReverseReasons(tx);
+        const allowed = new Set(reasons.map((r) => r.code));
+        if (!allowed.has(dto.reasonCode)) {
+          throw new BadRequestException(
+            `เหตุผล "${dto.reasonCode}" ไม่อยู่ในรายการที่ตั้งค่าไว้`,
+          );
+        }
       }
 
       this.transition.assertCanVoid({ from: doc.status });

--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -139,5 +139,62 @@ describe('SettingsService audit trail', () => {
       expect(flags.taxExemptWarningEnabled).toBe(true);
       expect(flags.reverseReasonRequired).toBe(true);
     });
+
+    // D1.2.7.2 — DB-driven reverse reasons
+    it('reverseReasons defaults to 6 canonical codes', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.reverseReasons).toHaveLength(6);
+      expect(flags.reverseReasons.map((r) => r.code)).toEqual([
+        'data_entry_error',
+        'wrong_vendor',
+        'wrong_amount',
+        'duplicate_entry',
+        'cancel_transaction',
+        'other',
+      ]);
+    });
+
+    it('reverseReasons returns custom list when SystemConfig set', async () => {
+      const custom = JSON.stringify([
+        { code: 'manager_decision', label: 'ตัดสินใจของผู้บริหาร' },
+        { code: 'audit_finding', label: 'ผลการตรวจสอบ' },
+      ]);
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_reasons') return Promise.resolve({ value: custom });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.reverseReasons).toHaveLength(2);
+      expect(flags.reverseReasons[0].code).toBe('manager_decision');
+    });
+
+    it('reverseReasons falls back to defaults when stored JSON is malformed', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_reasons') return Promise.resolve({ value: 'not-json' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.reverseReasons).toHaveLength(6);
+    });
+
+    it('reverseReasons falls back to defaults when stored array is empty', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_reasons') return Promise.resolve({ value: '[]' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.reverseReasons).toHaveLength(6);
+    });
+
+    it('reverseReasons falls back to defaults when row shape is wrong', async () => {
+      const bad = JSON.stringify([{ id: 'x', name: 'y' }]); // missing code+label
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_reasons') return Promise.resolve({ value: bad });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.reverseReasons).toHaveLength(6);
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -99,11 +99,48 @@ export class SettingsService {
    * Defaults match the spec-defined "on" behaviour so first-boot behaviour
    * is identical whether the SystemConfig key has been seeded or not.
    */
+  /**
+   * D1.2.7.2 — DB-driven reverse-reason dropdown. JSON-encoded array of
+   * `{code, label}` objects stored in SystemConfig key `reverse_reasons`.
+   * Default = the 6 canonical reasons. Caller is responsible for treating
+   * an empty/invalid stored list as "use default" — never as "empty list".
+   */
+  async getReverseReasons(): Promise<{ code: string; label: string }[]> {
+    const raw = await this.getKey('reverse_reasons');
+    const defaults: { code: string; label: string }[] = [
+      { code: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
+      { code: 'wrong_vendor', label: 'ผู้ขายผิด' },
+      { code: 'wrong_amount', label: 'จำนวนเงินผิด' },
+      { code: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
+      { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
+      { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
+    ];
+    if (!raw) return defaults;
+    try {
+      const parsed = JSON.parse(raw);
+      if (
+        Array.isArray(parsed) &&
+        parsed.length > 0 &&
+        parsed.every(
+          (r) =>
+            r && typeof r === 'object' && typeof r.code === 'string' && typeof r.label === 'string',
+        )
+      ) {
+        return parsed;
+      }
+      return defaults;
+    } catch {
+      return defaults;
+    }
+  }
+
   async getUiFlags(): Promise<{
     /** D1.2.8.2 — show ม.42 tax-exempt warning when a payroll custom-income line is marked non-taxable. Default true. */
     taxExemptWarningEnabled: boolean;
     /** D1.2.7.1 — require reason on void/reverse dialog. Default true. */
     reverseReasonRequired: boolean;
+    /** D1.2.7.2 — configurable reverse-reason dropdown. Always at least the 6 defaults. */
+    reverseReasons: { code: string; label: string }[];
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -113,7 +150,8 @@ export class SettingsService {
       'reverse_reason_required',
       true,
     );
-    return { taxExemptWarningEnabled, reverseReasonRequired };
+    const reverseReasons = await this.getReverseReasons();
+    return { taxExemptWarningEnabled, reverseReasonRequired, reverseReasons };
   }
 
   /**

--- a/apps/web/src/components/expense-form-v4/ReverseDialog.tsx
+++ b/apps/web/src/components/expense-form-v4/ReverseDialog.tsx
@@ -26,22 +26,13 @@ import { useUiFlags } from '@/hooks/useUiFlags';
  * this doc — error propagates via `onError` upstream.
  */
 
-export type ReverseReasonCode =
-  | 'data_entry_error'
-  | 'wrong_vendor'
-  | 'wrong_amount'
-  | 'duplicate_entry'
-  | 'cancel_transaction'
-  | 'other';
-
-const REASON_OPTIONS: { value: ReverseReasonCode; label: string }[] = [
-  { value: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
-  { value: 'wrong_vendor', label: 'ผู้ขายผิด' },
-  { value: 'wrong_amount', label: 'จำนวนเงินผิด' },
-  { value: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
-  { value: 'cancel_transaction', label: 'ยกเลิกรายการ' },
-  { value: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
-];
+/**
+ * D1.2.7.2 — reasons now come from `useUiFlags().reverseReasons` (default
+ * matches the 6 canonical codes; OWNER may extend/override via SystemConfig).
+ * `ReverseReasonCode` kept as a string alias for caller compat — runtime
+ * validation happens on the server against the configured whitelist.
+ */
+export type ReverseReasonCode = string;
 
 interface Props {
   open: boolean;
@@ -59,10 +50,10 @@ interface Props {
 const todayBkk = () => new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
 
 export function ReverseDialog({ open, onOpenChange, docNumber, loading, onConfirm }: Props) {
-  // D1.2.7.1 — `reverseReasonRequired` (default true). When OWNER turns this off,
-  // the reason dropdown shows "— ไม่ระบุ —" as a valid selection (server still
-  // accepts; UI no longer blocks submit on missing reason).
-  const { reverseReasonRequired } = useUiFlags();
+  // D1.2.7.1 + D1.2.7.2 — reasons + reason-required flag both come from
+  // /settings/ui-flags. Reasons fall back to the 6 canonical codes; flag
+  // defaults true so first-render shows the existing strict UX.
+  const { reverseReasonRequired, reverseReasons } = useUiFlags();
   const [reasonCode, setReasonCode] = useState<ReverseReasonCode | ''>('');
   const [reasonDetail, setReasonDetail] = useState('');
   const [reverseDate, setReverseDate] = useState(todayBkk());
@@ -124,8 +115,8 @@ export function ReverseDialog({ open, onOpenChange, docNumber, loading, onConfir
               aria-required={reverseReasonRequired}
             >
               <option value="">{reverseReasonRequired ? '— เลือกเหตุผล —' : '— ไม่ระบุ —'}</option>
-              {REASON_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
+              {reverseReasons.map((opt) => (
+                <option key={opt.code} value={opt.code}>
                   {opt.label}
                 </option>
               ))}

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -16,11 +16,21 @@ export interface UiFlags {
   taxExemptWarningEnabled: boolean;
   /** D1.2.7.1 — require reason on void/reverse dialog. */
   reverseReasonRequired: boolean;
+  /** D1.2.7.2 — configurable reverse-reason dropdown. */
+  reverseReasons: { code: string; label: string }[];
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
   taxExemptWarningEnabled: true,
   reverseReasonRequired: true,
+  reverseReasons: [
+    { code: 'data_entry_error', label: 'ป้อนข้อมูลผิด' },
+    { code: 'wrong_vendor', label: 'ผู้ขายผิด' },
+    { code: 'wrong_amount', label: 'จำนวนเงินผิด' },
+    { code: 'duplicate_entry', label: 'ข้อมูลซ้ำ' },
+    { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
+    { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
+  ],
 };
 
 export function useUiFlags(): UiFlags {

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882 · #883 · #884 · this PR (D1.2.7.1)  |  **Done:** 4/75
+**Started:** 2026-05-16  |  **PRs:** #882 · #883 · #884 · #885 · this PR (D1.2.7.2)  |  **Done:** 5/75
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -51,7 +51,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.6.3 | `payment_date_warning_backdate` | P1 | ⬜ | — | Replace hardcoded `30` at ReverseDialog.tsx:74,167 |
 | D1.2.6.4 | `payment_date_allow_future` toggle | P1 | ⬜ | — | Block-or-warn on future-dated reverse |
 | D1.2.7.1 | `reverse_reason_required` | P1 | ✅ | this PR | Server-side gate in `voidDocument` (reads `reverse_reason_required`, default true). UI: `useUiFlags()` reads `reverseReasonRequired` from `/settings/ui-flags`; `ReverseDialog` shows "— ไม่ระบุ —" + drops `*` when flag off + relaxes `canSubmit`. 3 new tests on the void path + 2 new getUiFlags tests |
-| D1.2.7.2 | `reverse_reasons_dropdown` | P1 | ⬜ | — | DB-driven 6-option list |
+| D1.2.7.2 | `reverse_reasons_dropdown` | P1 | ✅ | this PR | SystemConfig key `reverse_reasons` JSON `[{code,label}]` array. Defaults to 6 canonical codes. Backend: DTO relaxed (drops @IsIn); `voidDocument` validates reasonCode against configured whitelist; `getReverseReasons()` helper in both service + ExpenseDocumentsService. UI: `useUiFlags().reverseReasons` drives the dropdown. 5 settings tests + 2 void path tests added |
 | D1.2.7.3 | `reverse_manager_approval_days` | P1 | ⬜ | — | Age-gate the void path |
 | D1.2.7.4 | `reverse_block_cascaded` toggle | P1 | ✅ | this PR | New private helper `readBoolFlag()` in `ExpenseDocumentsService` (reads `system_config` directly via PrismaService to keep ctor lean + avoid circular-dep risk with audit/settings modules). Cascade-block check at `expense-documents.service.ts:1681-1700` now reads `reverse_block_cascaded` (default true). Both CN and SE cascade throws gated by the same flag. 2 new tests (toggle off → both bypassed; default → preserved). 52/52 service-spec tests pass |
 | D1.2.3.1 | `default_time_range` | P1 | ⬜ | — | DateRangeChips presets configurable |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 4 | 5% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882 · #883 · #884 · this PR |
-| **TOTAL** | **~159** | **71** | **~45%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 5 | 7% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882 · #883 · #884 · #885 · this PR |
+| **TOTAL** | **~159** | **72** | **~45%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #5. Moves the 6 canonical reverse reasons from hardcoded enum+UI mirror into SystemConfig — OWNER can now extend/override the list (and per-org labels) without redeploy.

## Behavior

| `reverse_reasons` SystemConfig | Dropdown |
|---|---|
| absent / malformed / empty | 6 default canonical codes (existing UX) |
| JSON `[{code,label}, ...]` | OWNER-defined list |

Server validates submitted `reasonCode` against the configured whitelist.

## Implementation

- DTO drops compile-time `@IsIn`; keeps `@IsString` + `@MaxLength(64)`
- `voidDocument` validates against configured list at runtime
- `SettingsService.getReverseReasons()` + new helper inside `ExpenseDocumentsService`
- `getUiFlags()` extended with `reverseReasons` (single round-trip for the frontend)
- Frontend dropdown maps over `useUiFlags().reverseReasons`

## Tests

- 5 new SettingsService tests (defaults / valid override / malformed / empty / wrong shape)
- 2 new voidDocument tests (rejects out-of-list code; accepts custom code)
- 77/77 tests pass · 0 type errors

## OWNER admin

```sql
INSERT INTO system_config (key, value) VALUES (
  'reverse_reasons',
  '[{"code":"audit_finding","label":"ผลการตรวจสอบ"},...]'
);
```
Audit-tracked via existing bulkUpdate path.

## Tracking

- D1.2.7.2 → ✅ · D1 5/75 · README 71→72

🤖 Generated with [Claude Code](https://claude.com/claude-code)