### PR TITLE
feat(a1): D1.2.7.3 — reverse_manager_approval_days soft warning

### DIFF
--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -196,5 +196,30 @@ describe('SettingsService audit trail', () => {
       const flags = await service.getUiFlags();
       expect(flags.reverseReasons).toHaveLength(6);
     });
+
+    // D1.2.7.3 — manager approval days threshold
+    it('reverseManagerApprovalDays defaults to 7 when SystemConfig missing', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.reverseManagerApprovalDays).toBe(7);
+    });
+
+    it('reverseManagerApprovalDays returns OWNER-configured value', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_manager_approval_days') return Promise.resolve({ value: '14' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.reverseManagerApprovalDays).toBe(14);
+    });
+
+    it('reverseManagerApprovalDays falls back to default on unparseable value', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'reverse_manager_approval_days') return Promise.resolve({ value: 'soon' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.reverseManagerApprovalDays).toBe(7);
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -141,6 +141,8 @@ export class SettingsService {
     reverseReasonRequired: boolean;
     /** D1.2.7.2 — configurable reverse-reason dropdown. Always at least the 6 defaults. */
     reverseReasons: { code: string; label: string }[];
+    /** D1.2.7.3 — soft warning threshold (days) when reverse backdate exceeds this; default 7. UI-only, no server block. */
+    reverseManagerApprovalDays: number;
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -151,7 +153,16 @@ export class SettingsService {
       true,
     );
     const reverseReasons = await this.getReverseReasons();
-    return { taxExemptWarningEnabled, reverseReasonRequired, reverseReasons };
+    const reverseManagerApprovalDays = await this.readNumber(
+      'reverse_manager_approval_days',
+      7,
+    );
+    return {
+      taxExemptWarningEnabled,
+      reverseReasonRequired,
+      reverseReasons,
+      reverseManagerApprovalDays,
+    };
   }
 
   /**

--- a/apps/web/src/components/expense-form-v4/ReverseDialog.tsx
+++ b/apps/web/src/components/expense-form-v4/ReverseDialog.tsx
@@ -50,10 +50,10 @@ interface Props {
 const todayBkk = () => new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
 
 export function ReverseDialog({ open, onOpenChange, docNumber, loading, onConfirm }: Props) {
-  // D1.2.7.1 + D1.2.7.2 — reasons + reason-required flag both come from
-  // /settings/ui-flags. Reasons fall back to the 6 canonical codes; flag
-  // defaults true so first-render shows the existing strict UX.
-  const { reverseReasonRequired, reverseReasons } = useUiFlags();
+  // D1.2.7.1 + D1.2.7.2 + D1.2.7.3 — reverse settings from /settings/ui-flags.
+  // Default true / 7d / 6 canonical reasons so first-render matches the
+  // pre-D1 strict UX.
+  const { reverseReasonRequired, reverseReasons, reverseManagerApprovalDays } = useUiFlags();
   const [reasonCode, setReasonCode] = useState<ReverseReasonCode | ''>('');
   const [reasonDetail, setReasonDetail] = useState('');
   const [reverseDate, setReverseDate] = useState(todayBkk());
@@ -162,6 +162,16 @@ export function ReverseDialog({ open, onOpenChange, docNumber, loading, onConfir
             <p className="text-xs text-muted-foreground mt-1">
               JE กลับรายการจะ post ในวันที่นี้ (server ตรวจ V19 ว่างวดยังเปิดอยู่)
             </p>
+            {/* D1.2.7.3 — manager-approval soft warning at configurable threshold
+                (default 7d). Only shows when backdate ≤ 30 (the broader generic
+                warning supersedes for big backdates). */}
+            {daysBackdate > reverseManagerApprovalDays && daysBackdate <= 30 && (
+              <p className="text-xs text-warning mt-1 flex items-start gap-1">
+                <AlertTriangle className="size-3 mt-0.5 shrink-0" />
+                ย้อนหลัง {daysBackdate} วัน (เกิน {reverseManagerApprovalDays} วัน) —
+                ควรมีอนุมัติจากผู้จัดการก่อน
+              </p>
+            )}
             {daysBackdate > 30 && (
               <p className="text-xs text-warning mt-1 flex items-start gap-1">
                 <AlertTriangle className="size-3 mt-0.5 shrink-0" />

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -18,6 +18,8 @@ export interface UiFlags {
   reverseReasonRequired: boolean;
   /** D1.2.7.2 — configurable reverse-reason dropdown. */
   reverseReasons: { code: string; label: string }[];
+  /** D1.2.7.3 — soft warning threshold (days) when reverse backdate exceeds this; UI-only. */
+  reverseManagerApprovalDays: number;
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -31,6 +33,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
     { code: 'cancel_transaction', label: 'ยกเลิกรายการ' },
     { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
   ],
+  reverseManagerApprovalDays: 7,
 };
 
 export function useUiFlags(): UiFlags {

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882 · #883 · #884 · #885 · this PR (D1.2.7.2)  |  **Done:** 5/75
+**Started:** 2026-05-16  |  **PRs:** #882 · #883 · #884 · #885 · #886 · this PR (D1.2.7.3)  |  **Done:** 6/75 — 2.7 Reverse Entry sub-section ✅ Complete (4/4)
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -52,7 +52,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.6.4 | `payment_date_allow_future` toggle | P1 | ⬜ | — | Block-or-warn on future-dated reverse |
 | D1.2.7.1 | `reverse_reason_required` | P1 | ✅ | this PR | Server-side gate in `voidDocument` (reads `reverse_reason_required`, default true). UI: `useUiFlags()` reads `reverseReasonRequired` from `/settings/ui-flags`; `ReverseDialog` shows "— ไม่ระบุ —" + drops `*` when flag off + relaxes `canSubmit`. 3 new tests on the void path + 2 new getUiFlags tests |
 | D1.2.7.2 | `reverse_reasons_dropdown` | P1 | ✅ | this PR | SystemConfig key `reverse_reasons` JSON `[{code,label}]` array. Defaults to 6 canonical codes. Backend: DTO relaxed (drops @IsIn); `voidDocument` validates reasonCode against configured whitelist; `getReverseReasons()` helper in both service + ExpenseDocumentsService. UI: `useUiFlags().reverseReasons` drives the dropdown. 5 settings tests + 2 void path tests added |
-| D1.2.7.3 | `reverse_manager_approval_days` | P1 | ⬜ | — | Age-gate the void path |
+| D1.2.7.3 | `reverse_manager_approval_days` | P1 | ✅ | this PR | Soft UI warning (per C3 Q2 owner decision). SystemConfig `reverse_manager_approval_days` (default 7). `getUiFlags()` exposes it; `ReverseDialog` shows "ควรมีอนุมัติจากผู้จัดการ" warning when daysBackdate exceeds threshold (but ≤30; the broader 30+ warning supersedes). No server block. 3 new tests on the threshold default + override + unparseable fallback |
 | D1.2.7.4 | `reverse_block_cascaded` toggle | P1 | ✅ | this PR | New private helper `readBoolFlag()` in `ExpenseDocumentsService` (reads `system_config` directly via PrismaService to keep ctor lean + avoid circular-dep risk with audit/settings modules). Cascade-block check at `expense-documents.service.ts:1681-1700` now reads `reverse_block_cascaded` (default true). Both CN and SE cascade throws gated by the same flag. 2 new tests (toggle off → both bypassed; default → preserved). 52/52 service-spec tests pass |
 | D1.2.3.1 | `default_time_range` | P1 | ⬜ | — | DateRangeChips presets configurable |
 | D1.2.3.2 | `pagination_size` | P1 | ⬜ | — | Central default for list pages |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 5 | 7% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882 · #883 · #884 · #885 · this PR |
-| **TOTAL** | **~159** | **72** | **~45%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 6 | 8% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882 · #883 · #884 · #885 · #886 · this PR |
+| **TOTAL** | **~159** | **73** | **~46%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #6. **Closes the 2.7 Reverse Entry sub-section (4/4 items done).**

Adds configurable threshold for the "manager approval recommended" soft warning in `ReverseDialog`. Per C3 Open Question Q2, owner decision was soft (UI-only) — no server block.

## Behavior

| `daysBackdate` | Warning shown |
|---|---|
| ≤ threshold (default 7) | none |
| threshold < daysBackdate ≤ 30 | "ย้อนหลัง N วัน (เกิน X วัน) — ควรมีอนุมัติจากผู้จัดการก่อน" |
| > 30 | existing broader warning supersedes |

## Implementation

- `SettingsService.getUiFlags()` returns `reverseManagerApprovalDays` (number, default 7)
- Sources from SystemConfig key `reverse_manager_approval_days` via existing `readNumber()` helper
- `useUiFlags()` + `ReverseDialog` consume it; new warning row gated on the threshold

## Tests

- 3 new SettingsService tests (default / override / unparseable fallback)
- 18/18 settings tests pass · 0 type errors

## 2.7 sub-section complete

| Item | PR |
|---|---|
| D1.2.7.1 reverse_reason_required | #885 |
| D1.2.7.2 reverse_reasons_dropdown | #886 |
| **D1.2.7.3** reverse_manager_approval_days | **this PR** |
| D1.2.7.4 reverse_block_cascaded | #884 |

## Tracking

- D1.2.7.3 → ✅ · D1 6/75 · README 72→73

🤖 Generated with [Claude Code](https://claude.com/claude-code)