### PR TITLE
feat(a1): D1.2.6.2 — period_grace_days configurable grace window

### DIFF
--- a/apps/api/src/utils/period-lock.util.spec.ts
+++ b/apps/api/src/utils/period-lock.util.spec.ts
@@ -1,0 +1,130 @@
+import { BadRequestException } from '@nestjs/common';
+import { validatePeriodOpen } from './period-lock.util';
+
+/**
+ * Tests for D1.2.6.2 — `period_grace_days` SystemConfig knob. The default 5d
+ * grace window lets owners post invoices into the just-closed period for a
+ * few days after the period's last calendar day.
+ *
+ * Note: validatePeriodOpen reads `new Date()` to compare against `today` —
+ * we use Jest's fake timers so the grace-window math is deterministic.
+ */
+
+describe('validatePeriodOpen — D1.2.6.2 period_grace_days', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function mockPrisma(opts: {
+    period?: { status: string } | null;
+    graceDays?: string | null; // raw string as stored in SystemConfig
+    closedUntil?: string | null;
+  }) {
+    return {
+      systemConfig: {
+        findUnique: jest.fn().mockImplementation((args: { where: { key: string } }) => {
+          if (args.where.key === 'period_grace_days') {
+            return Promise.resolve(opts.graceDays ? { value: opts.graceDays } : null);
+          }
+          if (args.where.key === 'accounting_period_closed_until') {
+            return Promise.resolve(opts.closedUntil ? { value: opts.closedUntil } : null);
+          }
+          return Promise.resolve(null);
+        }),
+      },
+      accountingPeriod: {
+        findUnique: jest.fn().mockResolvedValue(opts.period ?? null),
+      },
+    };
+  }
+
+  // ── Tier 1: AccountingPeriod (companyId provided) ──────────────────────
+
+  it('CLOSED period: rejects when today is BEYOND grace window (default 5d)', async () => {
+    jest.setSystemTime(new Date('2026-06-10T00:00:00Z')); // 10d past May 31
+    const prisma = mockPrisma({ period: { status: 'CLOSED' } });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('CLOSED period: ALLOWS when today is WITHIN grace window (default 5d)', async () => {
+    jest.setSystemTime(new Date('2026-06-03T00:00:00Z')); // 3d past May 31 — within grace
+    const prisma = mockPrisma({ period: { status: 'CLOSED' } });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('CLOSED period: OWNER-configured grace=0 → no grace, immediate block', async () => {
+    jest.setSystemTime(new Date('2026-06-01T12:00:00Z')); // 1d past period end
+    const prisma = mockPrisma({ period: { status: 'CLOSED' }, graceDays: '0' });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('CLOSED period: OWNER-configured grace=30 → extended window', async () => {
+    jest.setSystemTime(new Date('2026-06-20T00:00:00Z')); // 20d past May 31
+    const prisma = mockPrisma({ period: { status: 'CLOSED' }, graceDays: '30' });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('OPEN period: never throws regardless of grace window', async () => {
+    jest.setSystemTime(new Date('2027-01-01T00:00:00Z'));
+    const prisma = mockPrisma({ period: { status: 'OPEN' } });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('SYNCED period: treated same as CLOSED for grace purposes', async () => {
+    jest.setSystemTime(new Date('2026-06-10T00:00:00Z')); // beyond default grace
+    const prisma = mockPrisma({ period: { status: 'SYNCED' } });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // ── Tier 2: legacy `accounting_period_closed_until` ────────────────────
+
+  it('legacy closedUntil: rejects when today is BEYOND grace', async () => {
+    jest.setSystemTime(new Date('2026-06-15T00:00:00Z'));
+    const prisma = mockPrisma({ closedUntil: '2026-05-31' });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-30')),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('legacy closedUntil: ALLOWS when today is WITHIN grace', async () => {
+    jest.setSystemTime(new Date('2026-06-03T00:00:00Z'));
+    const prisma = mockPrisma({ closedUntil: '2026-05-31' });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-30')),
+    ).resolves.toBeUndefined();
+  });
+
+  // ── Edge: malformed/missing grace config falls back to default 5 ───────
+
+  it('grace_days unparseable: falls back to default 5', async () => {
+    jest.setSystemTime(new Date('2026-06-03T00:00:00Z'));
+    const prisma = mockPrisma({ period: { status: 'CLOSED' }, graceDays: 'soon' });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('grace_days negative: falls back to default 5', async () => {
+    jest.setSystemTime(new Date('2026-06-10T00:00:00Z'));
+    const prisma = mockPrisma({ period: { status: 'CLOSED' }, graceDays: '-2' });
+    await expect(
+      validatePeriodOpen(prisma, new Date('2026-05-31'), 'co-1'),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/utils/period-lock.util.ts
+++ b/apps/api/src/utils/period-lock.util.ts
@@ -8,6 +8,10 @@ import { BadRequestException } from '@nestjs/common';
 interface PrismaLike {
   systemConfig: {
     findUnique(args: { where: { key: string } }): Promise<{ value: string } | null>;
+    findFirst?(args: {
+      where: { key: string; deletedAt?: null };
+      select?: { value: true };
+    }): Promise<{ value: string } | null>;
   };
   accountingPeriod?: {
     findUnique(args: {
@@ -18,13 +22,45 @@ interface PrismaLike {
 }
 
 /**
+ * D1.2.6.2 — read the OWNER-editable `period_grace_days` SystemConfig key.
+ * Default 5 (matches the project deadline reference "grace through
+ * 5 มิ.ย. 2569 per period_grace_days"). Invalid/missing → default.
+ */
+async function getGraceDays(prisma: PrismaLike): Promise<number> {
+  try {
+    const row = await prisma.systemConfig.findUnique({
+      where: { key: 'period_grace_days' },
+    });
+    if (!row?.value) return 5;
+    const n = Number.parseInt(row.value, 10);
+    return Number.isFinite(n) && n >= 0 ? n : 5;
+  } catch {
+    return 5;
+  }
+}
+
+/** Last day of the given calendar month (month 1-12). */
+function lastDayOfMonth(year: number, month: number): Date {
+  return new Date(year, month, 0);
+}
+
+/** Returns `base + days` as a Date. */
+function addDays(base: Date, days: number): Date {
+  const d = new Date(base);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/**
  * Validate that a transaction date is not in a closed accounting period.
  *
  * Two-tier check:
  * 1. If companyId is provided: look up AccountingPeriod for the date's year+month.
- *    Throws if status is CLOSED or SYNCED (period locked).
+ *    Throws if status is CLOSED or SYNCED — UNLESS today is within
+ *    `period_grace_days` after the period's last calendar day (D1.2.6.2).
  * 2. Fallback: check legacy SystemConfig key `accounting_period_closed_until`.
- *    Throws if the date falls on or before the closed-until date.
+ *    Throws if `date <= closedUntil` — UNLESS today is within
+ *    `period_grace_days` after `closedUntil`.
  *
  * Both checks are run when companyId is provided (belt-and-suspenders).
  */
@@ -33,6 +69,9 @@ export async function validatePeriodOpen(
   date: Date,
   companyId?: string,
 ): Promise<void> {
+  const graceDays = await getGraceDays(prisma);
+  const today = new Date();
+
   // ── Tier 1: AccountingPeriod model check (when companyId is available) ────
   if (companyId && prisma.accountingPeriod) {
     const year = date.getFullYear();
@@ -42,9 +81,16 @@ export async function validatePeriodOpen(
       select: { status: true },
     });
     if (period && (period.status === 'CLOSED' || period.status === 'SYNCED')) {
-      throw new BadRequestException(
-        `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (${year}/${String(month).padStart(2, '0')} สถานะ: ${period.status})`,
-      );
+      // D1.2.6.2 — grace window. Allow posting INTO a closed period for
+      // `graceDays` after the period's last calendar day.
+      const periodLastDay = lastDayOfMonth(year, month);
+      const graceEnd = addDays(periodLastDay, graceDays);
+      if (today > graceEnd) {
+        throw new BadRequestException(
+          `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (${year}/${String(month).padStart(2, '0')} สถานะ: ${period.status})`,
+        );
+      }
+      // else: within grace window → fall through (allowed)
     }
   }
 
@@ -55,9 +101,13 @@ export async function validatePeriodOpen(
   if (config) {
     const closedUntil = new Date(config.value);
     if (date <= closedUntil) {
-      throw new BadRequestException(
-        `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (ปิดถึง ${closedUntil.toISOString().split('T')[0]})`,
-      );
+      // D1.2.6.2 — same grace window applied to the legacy cutoff.
+      const graceEnd = addDays(closedUntil, graceDays);
+      if (today > graceEnd) {
+        throw new BadRequestException(
+          `ไม่สามารถบันทึกรายการในงวดที่ปิดแล้ว (ปิดถึง ${closedUntil.toISOString().split('T')[0]})`,
+        );
+      }
     }
   }
 }

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882 · #883 · #884 · #885 · #886 · this PR (D1.2.7.3)  |  **Done:** 6/75 — 2.7 Reverse Entry sub-section ✅ Complete (4/4)
+**Started:** 2026-05-16  |  **PRs:** #882 · #883 · #884 · #885 · #886 · #887 · this PR (D1.2.6.2)  |  **Done:** 7/75 — 2.7 ✅ · 2.6 1/4
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -47,7 +47,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.2.6 | `language` (i18n) | P1 | ⬜ | — | Larger — defer if time short |
 | D1.2.2.7 | `show_qr_code` toggle | P1 | ⬜ | — | qrcode.react already imported in MobileReceipt |
 | D1.2.6.1 | `period_close_day` | P1 | ⬜ | — | Already supports closedUntil date; add day-of-month config wrapper |
-| D1.2.6.2 | `period_grace_days` | P1 | ⬜ | — | Wrap period-lock.util with grace check |
+| D1.2.6.2 | `period_grace_days` | P1 | ✅ | this PR | SystemConfig key `period_grace_days` (default 5). `period-lock.util.ts:validatePeriodOpen` extended — closed-period throws only if today > periodLastDay + graceDays (Tier 1) or today > closedUntil + graceDays (Tier 2). 10 new tests (CLOSED within/beyond grace, SYNCED, OPEN, OWNER override 0/30, malformed/negative fallback, legacy Tier 2). Direct callers (journal-auto, expense-documents, receipts) all pass |
 | D1.2.6.3 | `payment_date_warning_backdate` | P1 | ⬜ | — | Replace hardcoded `30` at ReverseDialog.tsx:74,167 |
 | D1.2.6.4 | `payment_date_allow_future` toggle | P1 | ⬜ | — | Block-or-warn on future-dated reverse |
 | D1.2.7.1 | `reverse_reason_required` | P1 | ✅ | this PR | Server-side gate in `voidDocument` (reads `reverse_reason_required`, default true). UI: `useUiFlags()` reads `reverseReasonRequired` from `/settings/ui-flags`; `ReverseDialog` shows "— ไม่ระบุ —" + drops `*` when flag off + relaxes `canSubmit`. 3 new tests on the void path + 2 new getUiFlags tests |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 6 | 8% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882 · #883 · #884 · #885 · #886 · this PR |
-| **TOTAL** | **~159** | **73** | **~46%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 7 | 9% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#887 · this PR |
+| **TOTAL** | **~159** | **74** | **~47%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #7. Adds OWNER-editable grace window for the accounting period lock — matches the spec's intent ("grace through 5 มิ.ย. 2569 per `period_grace_days`") which was previously **documented but never enforced in code**. Default 5 days.

## Behavior change

Both tiers of `validatePeriodOpen`:

| Scenario | Before | After (default grace=5) |
|---|---|---|
| Period 2026-05 CLOSED, today=2026-06-03, post-date=2026-05-31 | ❌ blocked | ✅ allowed (within 5d) |
| Period 2026-05 CLOSED, today=2026-06-10, post-date=2026-05-31 | ❌ blocked | ❌ blocked (beyond 5d) |
| Period 2026-05 OPEN | ✅ allowed | ✅ allowed |

OWNER can set `period_grace_days = '0'` to restore strict old behavior, or extend (`'30'` for month-end accountants).

## Why this matters

Owners frequently receive invoices dated 2026-05-31 on 2026-06-02, **after** closing May's books. Previously the only path was a heavyweight period reopen (audit-tracked). This automates the common case.

## Implementation

- New helpers in `period-lock.util.ts`: `getGraceDays()`, `lastDayOfMonth()`, `addDays()`
- Reads `new Date()` for "today" — tests use Jest fake timers for determinism
- try/catch around the SystemConfig read so transient DB issues fall through to default

## Tests

- 10 new tests in `period-lock.util.spec.ts` covering both tiers, OWNER overrides (0 / 30 / negative / unparseable), CLOSED/SYNCED/OPEN
- Direct callers (journal-auto, expense-documents, receipts) all pass
- The 147 broader test failures present in the repo are pre-existing local dev-DB drift (per memory; not caused by this PR)

## Backward compat

Prod behavior changes from "0d grace" to "5d grace" by default — owners who relied on the strict block must add `INSERT INTO system_config (key, value) VALUES ('period_grace_days', '0')` if they want it back.

## Tracking

- D1.2.6.2 → ✅ · D1 7/75 · README 73→74
- 2.6 Date & Period: 1/4 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)