### PR TITLE
feat(a1): D1.2.6.3 — payment_date_warning_backdate threshold configurable

### DIFF
--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -221,5 +221,21 @@ describe('SettingsService audit trail', () => {
       const flags = await service.getUiFlags();
       expect(flags.reverseManagerApprovalDays).toBe(7);
     });
+
+    // D1.2.6.3 — payment_date_warning_backdate
+    it('paymentDateWarningBackdate defaults to 30 when SystemConfig missing', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.paymentDateWarningBackdate).toBe(30);
+    });
+
+    it('paymentDateWarningBackdate returns OWNER-configured value', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'payment_date_warning_backdate') return Promise.resolve({ value: '90' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.paymentDateWarningBackdate).toBe(90);
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -143,6 +143,8 @@ export class SettingsService {
     reverseReasons: { code: string; label: string }[];
     /** D1.2.7.3 — soft warning threshold (days) when reverse backdate exceeds this; default 7. UI-only, no server block. */
     reverseManagerApprovalDays: number;
+    /** D1.2.6.3 — broader backdate warning threshold (days). Default 30. Distinct from D1.2.7.3 (the manager-approval threshold at 7d). */
+    paymentDateWarningBackdate: number;
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -157,11 +159,16 @@ export class SettingsService {
       'reverse_manager_approval_days',
       7,
     );
+    const paymentDateWarningBackdate = await this.readNumber(
+      'payment_date_warning_backdate',
+      30,
+    );
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
       reverseReasons,
       reverseManagerApprovalDays,
+      paymentDateWarningBackdate,
     };
   }
 

--- a/apps/web/src/components/expense-form-v4/ReverseDialog.tsx
+++ b/apps/web/src/components/expense-form-v4/ReverseDialog.tsx
@@ -50,10 +50,15 @@ interface Props {
 const todayBkk = () => new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
 
 export function ReverseDialog({ open, onOpenChange, docNumber, loading, onConfirm }: Props) {
-  // D1.2.7.1 + D1.2.7.2 + D1.2.7.3 — reverse settings from /settings/ui-flags.
-  // Default true / 7d / 6 canonical reasons so first-render matches the
-  // pre-D1 strict UX.
-  const { reverseReasonRequired, reverseReasons, reverseManagerApprovalDays } = useUiFlags();
+  // D1.2.7.1 + D1.2.7.2 + D1.2.7.3 + D1.2.6.3 — reverse + backdate settings
+  // from /settings/ui-flags. Defaults true / 7d / 30d / 6 canonical reasons
+  // so first-render matches the pre-D1 strict UX.
+  const {
+    reverseReasonRequired,
+    reverseReasons,
+    reverseManagerApprovalDays,
+    paymentDateWarningBackdate,
+  } = useUiFlags();
   const [reasonCode, setReasonCode] = useState<ReverseReasonCode | ''>('');
   const [reasonDetail, setReasonDetail] = useState('');
   const [reverseDate, setReverseDate] = useState(todayBkk());
@@ -163,16 +168,19 @@ export function ReverseDialog({ open, onOpenChange, docNumber, loading, onConfir
               JE กลับรายการจะ post ในวันที่นี้ (server ตรวจ V19 ว่างวดยังเปิดอยู่)
             </p>
             {/* D1.2.7.3 — manager-approval soft warning at configurable threshold
-                (default 7d). Only shows when backdate ≤ 30 (the broader generic
-                warning supersedes for big backdates). */}
-            {daysBackdate > reverseManagerApprovalDays && daysBackdate <= 30 && (
-              <p className="text-xs text-warning mt-1 flex items-start gap-1">
-                <AlertTriangle className="size-3 mt-0.5 shrink-0" />
-                ย้อนหลัง {daysBackdate} วัน (เกิน {reverseManagerApprovalDays} วัน) —
-                ควรมีอนุมัติจากผู้จัดการก่อน
-              </p>
-            )}
-            {daysBackdate > 30 && (
+                (default 7d). Only shows when backdate ≤ paymentDateWarningBackdate
+                (the broader warning supersedes for big backdates). */}
+            {daysBackdate > reverseManagerApprovalDays &&
+              daysBackdate <= paymentDateWarningBackdate && (
+                <p className="text-xs text-warning mt-1 flex items-start gap-1">
+                  <AlertTriangle className="size-3 mt-0.5 shrink-0" />
+                  ย้อนหลัง {daysBackdate} วัน (เกิน {reverseManagerApprovalDays} วัน) —
+                  ควรมีอนุมัติจากผู้จัดการก่อน
+                </p>
+              )}
+            {/* D1.2.6.3 — broader backdate warning at configurable threshold
+                (default 30d). */}
+            {daysBackdate > paymentDateWarningBackdate && (
               <p className="text-xs text-warning mt-1 flex items-start gap-1">
                 <AlertTriangle className="size-3 mt-0.5 shrink-0" />
                 เลือกย้อนหลัง {daysBackdate} วัน — ตรวจสอบให้แน่ใจว่างวดยังเปิด

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -20,6 +20,8 @@ export interface UiFlags {
   reverseReasons: { code: string; label: string }[];
   /** D1.2.7.3 — soft warning threshold (days) when reverse backdate exceeds this; UI-only. */
   reverseManagerApprovalDays: number;
+  /** D1.2.6.3 — broader backdate warning threshold (days). Default 30. */
+  paymentDateWarningBackdate: number;
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -34,6 +36,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
     { code: 'other', label: 'อื่นๆ (ระบุรายละเอียด)' },
   ],
   reverseManagerApprovalDays: 7,
+  paymentDateWarningBackdate: 30,
 };
 
 export function useUiFlags(): UiFlags {

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882 · #883 · #884 · #885 · #886 · #887 · this PR (D1.2.6.2)  |  **Done:** 7/75 — 2.7 ✅ · 2.6 1/4
+**Started:** 2026-05-16  |  **PRs:** #882-#888 · this PR (D1.2.6.3)  |  **Done:** 8/75 — 2.7 ✅ · 2.6 2/4
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -48,7 +48,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.2.7 | `show_qr_code` toggle | P1 | ⬜ | — | qrcode.react already imported in MobileReceipt |
 | D1.2.6.1 | `period_close_day` | P1 | ⬜ | — | Already supports closedUntil date; add day-of-month config wrapper |
 | D1.2.6.2 | `period_grace_days` | P1 | ✅ | this PR | SystemConfig key `period_grace_days` (default 5). `period-lock.util.ts:validatePeriodOpen` extended — closed-period throws only if today > periodLastDay + graceDays (Tier 1) or today > closedUntil + graceDays (Tier 2). 10 new tests (CLOSED within/beyond grace, SYNCED, OPEN, OWNER override 0/30, malformed/negative fallback, legacy Tier 2). Direct callers (journal-auto, expense-documents, receipts) all pass |
-| D1.2.6.3 | `payment_date_warning_backdate` | P1 | ⬜ | — | Replace hardcoded `30` at ReverseDialog.tsx:74,167 |
+| D1.2.6.3 | `payment_date_warning_backdate` | P1 | ✅ | this PR | SystemConfig `payment_date_warning_backdate` (default 30). `getUiFlags()` exposes `paymentDateWarningBackdate`; ReverseDialog hardcoded `30` replaced with the flag (both the threshold for the broader warning AND the upper bound for the 7d manager-approval warning). 2 new tests on default + override |
 | D1.2.6.4 | `payment_date_allow_future` toggle | P1 | ⬜ | — | Block-or-warn on future-dated reverse |
 | D1.2.7.1 | `reverse_reason_required` | P1 | ✅ | this PR | Server-side gate in `voidDocument` (reads `reverse_reason_required`, default true). UI: `useUiFlags()` reads `reverseReasonRequired` from `/settings/ui-flags`; `ReverseDialog` shows "— ไม่ระบุ —" + drops `*` when flag off + relaxes `canSubmit`. 3 new tests on the void path + 2 new getUiFlags tests |
 | D1.2.7.2 | `reverse_reasons_dropdown` | P1 | ✅ | this PR | SystemConfig key `reverse_reasons` JSON `[{code,label}]` array. Defaults to 6 canonical codes. Backend: DTO relaxed (drops @IsIn); `voidDocument` validates reasonCode against configured whitelist; `getReverseReasons()` helper in both service + ExpenseDocumentsService. UI: `useUiFlags().reverseReasons` drives the dropdown. 5 settings tests + 2 void path tests added |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 7 | 9% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#887 · this PR |
-| **TOTAL** | **~159** | **74** | **~47%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 8 | 11% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#888 · this PR |
+| **TOTAL** | **~159** | **75** | **~47%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #8. Replaces the hardcoded 30-day backdate warning in `ReverseDialog` with OWNER-editable SystemConfig. Default 30 preserves existing UX.

## Changes

- `getUiFlags()` returns `paymentDateWarningBackdate` (default 30)
- `useUiFlags()` exposes it; `ReverseDialog` uses it in 2 places (broader warning condition + upper bound for the 7d manager-approval warning)

## Tests

- 2 new SettingsService tests (default / override)
- 20/20 tests pass · 0 type errors

## Tracking

- D1.2.6.3 → ✅ · D1 8/75 · README 74→75 · 2.6 sub-section 2/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)