### PR TITLE
feat(a1): D1.2.6.1 — period_close_day configurable (informational)

### DIFF
--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -253,5 +253,39 @@ describe('SettingsService audit trail', () => {
       const flags = await service.getUiFlags();
       expect(flags.paymentDateAllowFuture).toBe(false);
     });
+
+    // D1.2.6.1 — period_close_day
+    it('periodCloseDay defaults to 31 (end-of-month) when SystemConfig missing', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.periodCloseDay).toBe(31);
+    });
+
+    it('periodCloseDay accepts valid 1-31 range from SystemConfig', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'period_close_day') return Promise.resolve({ value: '25' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.periodCloseDay).toBe(25);
+    });
+
+    it('periodCloseDay clamps to default when out of valid range', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'period_close_day') return Promise.resolve({ value: '32' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.periodCloseDay).toBe(31);
+    });
+
+    it('periodCloseDay clamps to default when zero or negative', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'period_close_day') return Promise.resolve({ value: '0' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.periodCloseDay).toBe(31);
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -147,6 +147,13 @@ export class SettingsService {
     paymentDateWarningBackdate: number;
     /** D1.2.6.4 — allow forward-dated transactions (reverse JE / payment / etc.). Default true. */
     paymentDateAllowFuture: boolean;
+    /**
+     * D1.2.6.1 — day-of-month when the accounting period closes. Default 31
+     * (= last day of each month). Currently INFORMATIONAL only: period-lock
+     * still anchors at calendar month-end. A future enhancement can shift
+     * the period boundary when this is not 31. Validated 1–31.
+     */
+    periodCloseDay: number;
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -169,6 +176,13 @@ export class SettingsService {
       'payment_date_allow_future',
       true,
     );
+    // D1.2.6.1 — clamp to valid day-of-month range (1–31) on read so a
+    // bad SystemConfig row can't cause undefined behaviour downstream.
+    const periodCloseDayRaw = await this.readNumber('period_close_day', 31);
+    const periodCloseDay =
+      Number.isInteger(periodCloseDayRaw) && periodCloseDayRaw >= 1 && periodCloseDayRaw <= 31
+        ? periodCloseDayRaw
+        : 31;
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -176,6 +190,7 @@ export class SettingsService {
       reverseManagerApprovalDays,
       paymentDateWarningBackdate,
       paymentDateAllowFuture,
+      periodCloseDay,
     };
   }
 

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -24,6 +24,8 @@ export interface UiFlags {
   paymentDateWarningBackdate: number;
   /** D1.2.6.4 — allow forward-dated transactions. Default true. */
   paymentDateAllowFuture: boolean;
+  /** D1.2.6.1 — day-of-month when periods close. Default 31. Informational. */
+  periodCloseDay: number;
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -40,6 +42,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   reverseManagerApprovalDays: 7,
   paymentDateWarningBackdate: 30,
   paymentDateAllowFuture: true,
+  periodCloseDay: 31,
 };
 
 export function useUiFlags(): UiFlags {

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882-#889 · this PR (D1.2.6.4)  |  **Done:** 9/75 — 2.7 ✅ · 2.6 3/4
+**Started:** 2026-05-16  |  **PRs:** #882-#890 · this PR (D1.2.6.1)  |  **Done:** 10/75 — 2.6 ✅ Complete (4/4) · 2.7 ✅ Complete (4/4)
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -46,7 +46,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.2.5 | `theme_color` admin override | P1 | ⬜ | — | Tailwind CSS var override at runtime |
 | D1.2.2.6 | `language` (i18n) | P1 | ⬜ | — | Larger — defer if time short |
 | D1.2.2.7 | `show_qr_code` toggle | P1 | ⬜ | — | qrcode.react already imported in MobileReceipt |
-| D1.2.6.1 | `period_close_day` | P1 | ⬜ | — | Already supports closedUntil date; add day-of-month config wrapper |
+| D1.2.6.1 | `period_close_day` | P1 | ✅ | this PR | SystemConfig `period_close_day` (default 31). `getUiFlags()` returns `periodCloseDay` clamped to 1-31. **Informational for now** — period-lock still anchors at calendar month-end. Future enhancement: shift period boundary when ≠ 31. 4 new tests (default / valid range / out-of-range clamp / zero clamp) |
 | D1.2.6.2 | `period_grace_days` | P1 | ✅ | this PR | SystemConfig key `period_grace_days` (default 5). `period-lock.util.ts:validatePeriodOpen` extended — closed-period throws only if today > periodLastDay + graceDays (Tier 1) or today > closedUntil + graceDays (Tier 2). 10 new tests (CLOSED within/beyond grace, SYNCED, OPEN, OWNER override 0/30, malformed/negative fallback, legacy Tier 2). Direct callers (journal-auto, expense-documents, receipts) all pass |
 | D1.2.6.3 | `payment_date_warning_backdate` | P1 | ✅ | this PR | SystemConfig `payment_date_warning_backdate` (default 30). `getUiFlags()` exposes `paymentDateWarningBackdate`; ReverseDialog hardcoded `30` replaced with the flag (both the threshold for the broader warning AND the upper bound for the 7d manager-approval warning). 2 new tests on default + override |
 | D1.2.6.4 | `payment_date_allow_future` toggle | P1 | ✅ | this PR | SystemConfig `payment_date_allow_future` (default true). Server `voidDocument` rejects future-dated `reverseDate` when flag off. UI: ReverseDialog shows destructive inline error + disables submit. 2 settings tests + 2 void path tests added |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 9 | 12% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#889 · this PR |
-| **TOTAL** | **~159** | **76** | **~48%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 10 | 13% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#890 · this PR |
+| **TOTAL** | **~159** | **77** | **~48%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #10 — **closes the 2.6 Date & Period sub-section (4/4 shipped).**

OWNER-editable SystemConfig `period_close_day` (default 31, clamped 1-31).

## Scope: INFORMATIONAL only

Value is stored, exposed via `getUiFlags().periodCloseDay`, reachable by the web. **Period-lock behavior is UNCHANGED** — periods still anchor at calendar month-end regardless of this setting.

Wiring `period_close_day != 31` into the actual period-boundary logic would require restructuring `validatePeriodOpen` (re-compute "which period does this date belong to" based on close_day). Out of scope for this single-item PR — needs design discussion + AccountingPeriod row migration.

This satisfies the audit item (setting exists, OWNER-editable, exposed to UI) without breaking anything. Future PR can wire the behavior.

## Tests

- 4 new SettingsService tests: default, valid range (25), out-of-range (32) clamps to 31, zero/negative clamps to 31
- 26/26 settings tests pass · 0 type errors

## 2.6 sub-section complete

| Item | PR |
|---|---|
| **D1.2.6.1** period_close_day | **this PR** |
| D1.2.6.2 period_grace_days | #888 |
| D1.2.6.3 payment_date_warning_backdate | #889 |
| D1.2.6.4 payment_date_allow_future | #890 |

## Tracking

- D1.2.6.1 → ✅ · D1 10/75 · README 76→77 · Two sub-sections fully done

🤖 Generated with [Claude Code](https://claude.com/claude-code)