### PR TITLE
feat(a1): D1.2.2.1 — wire CompanyInfo into voucher headers (sub-section foundation)

### DIFF
--- a/apps/api/src/modules/company/company.controller.ts
+++ b/apps/api/src/modules/company/company.controller.ts
@@ -33,6 +33,17 @@ export class CompanyController {
     return this.companyService.findAll();
   }
 
+  /**
+   * D1.2.2.* — Public-safe CompanyInfo for voucher headers.
+   * Authenticated but allowed for all roles (any user printing a voucher).
+   * Excludes director PII, bank credentials, VAT internals.
+   */
+  @Get('public')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT', 'SALES')
+  findPublic() {
+    return this.companyService.findPublic();
+  }
+
   @Get(':id')
   @Roles('OWNER')
   findOne(@Param('id') id: string) {

--- a/apps/api/src/modules/company/company.service.spec.ts
+++ b/apps/api/src/modules/company/company.service.spec.ts
@@ -119,4 +119,74 @@ describe('CompanyService', () => {
       await expect(service.remove('missing')).rejects.toThrow(NotFoundException);
     });
   });
+
+  // D1.2.2.* — Public-safe CompanyInfo for voucher branding
+  describe('findPublic', () => {
+    it('returns SHOP + FINANCE with only public-safe fields', async () => {
+      prisma.companyInfo.findMany.mockResolvedValue([
+        {
+          id: 'shop-1',
+          nameTh: 'BEST CHOICE SHOP',
+          nameEn: null,
+          taxId: '0105561234567',
+          companyCode: 'SHOP',
+          address: 'BKK',
+          phone: null,
+          logoUrl: null,
+        },
+        {
+          id: 'fin-1',
+          nameTh: 'BEST CHOICE FINANCE',
+          nameEn: null,
+          taxId: '0105561234567',
+          companyCode: 'FINANCE',
+          address: 'BKK',
+          phone: null,
+          logoUrl: 'https://x/logo.png',
+        },
+      ]);
+      const result = await service.findPublic();
+      expect(result.shop?.companyCode).toBe('SHOP');
+      expect(result.finance?.companyCode).toBe('FINANCE');
+      expect(result.finance?.logoUrl).toBe('https://x/logo.png');
+      // Query must request only the safe field set (no director_*, bank_*, etc.)
+      const call = prisma.companyInfo.findMany.mock.calls[0][0];
+      expect(call.select).toEqual(
+        expect.objectContaining({
+          id: true,
+          nameTh: true,
+          taxId: true,
+          address: true,
+          logoUrl: true,
+        }),
+      );
+      expect(call.select).not.toHaveProperty('directorName');
+      expect(call.select).not.toHaveProperty('bankAccountNumber');
+    });
+
+    it('returns nulls when no SHOP or FINANCE row is configured', async () => {
+      prisma.companyInfo.findMany.mockResolvedValue([]);
+      const result = await service.findPublic();
+      expect(result.shop).toBeNull();
+      expect(result.finance).toBeNull();
+    });
+
+    it('returns shop only if FINANCE is missing', async () => {
+      prisma.companyInfo.findMany.mockResolvedValue([
+        {
+          id: 'shop-1',
+          nameTh: 'BEST CHOICE SHOP',
+          nameEn: null,
+          taxId: '0105561234567',
+          companyCode: 'SHOP',
+          address: 'BKK',
+          phone: null,
+          logoUrl: null,
+        },
+      ]);
+      const result = await service.findPublic();
+      expect(result.shop?.nameTh).toBe('BEST CHOICE SHOP');
+      expect(result.finance).toBeNull();
+    });
+  });
 });

--- a/apps/api/src/modules/company/company.service.ts
+++ b/apps/api/src/modules/company/company.service.ts
@@ -7,6 +7,18 @@ import {
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateCompanyDto, UpdateCompanyDto } from './dto/company.dto';
 
+/** D1.2.2.* — Public-safe slice of CompanyInfo for voucher rendering. */
+export interface PublicCompanyInfo {
+  id: string;
+  nameTh: string;
+  nameEn: string | null;
+  taxId: string;
+  companyCode: string | null;
+  address: string;
+  phone: string | null;
+  logoUrl: string | null;
+}
+
 @Injectable()
 export class CompanyService {
   constructor(private prisma: PrismaService) {}
@@ -37,6 +49,41 @@ export class CompanyService {
       where: { companyCode, deletedAt: null },
       include: { branches: { where: { deletedAt: null } } },
     });
+  }
+
+  /**
+   * D1.2.2.1+ — Public-safe CompanyInfo for voucher/receipt rendering.
+   * Returns the SHOP and FINANCE companies with only the fields needed to
+   * print a header: id, nameTh, nameEn, taxId, companyCode, address, phone,
+   * logoUrl. Excludes director PII, bank account numbers, VAT internals.
+   * Authenticated but accessible to all roles (any user printing a voucher).
+   */
+  async findPublic(): Promise<{
+    shop: PublicCompanyInfo | null;
+    finance: PublicCompanyInfo | null;
+  }> {
+    const rows = await this.prisma.companyInfo.findMany({
+      where: {
+        companyCode: { in: ['SHOP', 'FINANCE'] },
+        deletedAt: null,
+        isActive: true,
+      },
+      select: {
+        id: true,
+        nameTh: true,
+        nameEn: true,
+        taxId: true,
+        companyCode: true,
+        address: true,
+        phone: true,
+        logoUrl: true,
+      },
+    });
+    return {
+      shop: (rows.find((r) => r.companyCode === 'SHOP') ?? null) as PublicCompanyInfo | null,
+      finance:
+        (rows.find((r) => r.companyCode === 'FINANCE') ?? null) as PublicCompanyInfo | null,
+    };
   }
 
   async create(dto: CreateCompanyDto) {

--- a/apps/web/src/hooks/useCompanyInfo.ts
+++ b/apps/web/src/hooks/useCompanyInfo.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+/**
+ * D1.2.2.* — Public-safe CompanyInfo for voucher/receipt branding.
+ *
+ * Reads via the authenticated-but-all-roles endpoint `GET /companies/public`.
+ * Returns SHOP and FINANCE entities (the two-entity structure documented in
+ * CLAUDE.md: SHOP = retail, FINANCE = installment). Voucher headers can pick
+ * either, or both for combined documents.
+ *
+ * Default fallback used during the first fetch (or on error) is the project's
+ * pre-D1 hardcoded "BESTCHOICE FINANCE × SHOP" header so existing print jobs
+ * never produce a blank header.
+ */
+export interface PublicCompanyInfo {
+  id: string;
+  nameTh: string;
+  nameEn: string | null;
+  taxId: string;
+  companyCode: string | null;
+  address: string;
+  phone: string | null;
+  logoUrl: string | null;
+}
+
+export interface CompanyInfoBundle {
+  shop: PublicCompanyInfo | null;
+  finance: PublicCompanyInfo | null;
+}
+
+const DEFAULT_COMPANY_INFO: CompanyInfoBundle = { shop: null, finance: null };
+
+export function useCompanyInfo(): CompanyInfoBundle {
+  const { data } = useQuery<CompanyInfoBundle>({
+    queryKey: ['company-info-public'],
+    queryFn: async () => {
+      const { data } = await api.get<CompanyInfoBundle>('/companies/public');
+      return data;
+    },
+    staleTime: 15 * 60_000, // 15 min — branding rarely changes mid-session
+  });
+  return data ?? DEFAULT_COMPANY_INFO;
+}
+
+/**
+ * D1.2.2.1 — combined name string for the voucher `<h1>` header. Renders
+ * the canonical "FINANCE × SHOP" pattern when both companies are configured,
+ * single name when only one, or the legacy literal as last-resort fallback
+ * so we never print a blank header.
+ */
+export function useCompanyDisplayName(): string {
+  const { shop, finance } = useCompanyInfo();
+  if (finance && shop) return `${finance.nameTh} × ${shop.nameTh}`;
+  if (finance) return finance.nameTh;
+  if (shop) return shop.nameTh;
+  return 'BESTCHOICE FINANCE × SHOP';
+}

--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -20,6 +20,7 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { formatNumberDecimal } from '@/utils/formatters';
 import { formatThaiDateLong } from '@/lib/date';
 import { numToThaiText } from '@/utils/numToThaiText';
+import { useCompanyDisplayName } from '@/hooks/useCompanyInfo';
 
 export interface ExpenseLine {
   lineNo: number;
@@ -255,6 +256,7 @@ function PettyCashSheet({
   amountInText: string;
   net: string;
 }) {
+  const companyName = useCompanyDisplayName();
   const lines = doc.expenseDetail?.lines ?? [];
   // Distinct supplier count for the badge — useful auditing surface since
   // petty cash is the only doc type that mixes vendors per document.
@@ -267,7 +269,7 @@ function PettyCashSheet({
       style={{ minHeight: '270mm' }}
     >
       <header className="text-center border-b-2 border-foreground pb-3">
-        <h1 className="text-xl font-bold">BESTCHOICE FINANCE × SHOP</h1>
+        <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
           เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
         </p>
@@ -421,6 +423,7 @@ function PayrollSlipSheet({
   slipNo: number;
   totalSlips: number;
 }) {
+  const companyName = useCompanyDisplayName();
   const base = new Decimal(line.baseSalary || '0');
   const sso = new Decimal(line.ssoEmployee || '0');
   const wht = new Decimal(line.whtAmount || '0');
@@ -452,7 +455,7 @@ function PayrollSlipSheet({
       }}
     >
       <header className="text-center border-b-2 border-foreground pb-3">
-        <h1 className="text-xl font-bold">BESTCHOICE FINANCE × SHOP</h1>
+        <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
           เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
         </p>
@@ -613,6 +616,7 @@ function Sheet({
   amountInText: string;
   net: string;
 }) {
+  const companyName = useCompanyDisplayName();
   const lines = doc.expenseDetail?.lines ?? [];
   return (
     <article
@@ -621,7 +625,7 @@ function Sheet({
     >
       {/* Company header */}
       <header className="text-center border-b-2 border-foreground pb-3">
-        <h1 className="text-xl font-bold">BESTCHOICE FINANCE × SHOP</h1>
+        <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
           เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
         </p>
@@ -800,6 +804,7 @@ export function bucketWhtByRate(
 }
 
 function WhtCertificate({ doc }: { doc: VoucherDoc }) {
+  const companyName = useCompanyDisplayName();
   // W7 (Round 2) — see bucketWhtByRate above for the Decimal-precision
   // rationale. Convert to display strings only at render time via toFixed.
   const wht = new Decimal(doc.withholdingTax || '0');
@@ -823,7 +828,7 @@ function WhtCertificate({ doc }: { doc: VoucherDoc }) {
       <section className="grid grid-cols-2 gap-x-8 gap-y-3 mt-6 text-sm">
         <div>
           <p className="text-xs text-muted-foreground mb-1">ผู้มีหน้าที่หักภาษี ณ ที่จ่าย</p>
-          <p className="font-semibold">BESTCHOICE FINANCE × SHOP</p>
+          <p className="font-semibold">{companyName}</p>
           <p className="text-xs text-muted-foreground">เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่</p>
         </div>
         <div>

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882-#890 · this PR (D1.2.6.1)  |  **Done:** 10/75 — 2.6 ✅ Complete (4/4) · 2.7 ✅ Complete (4/4)
+**Started:** 2026-05-16  |  **PRs:** #882-#891 · this PR (D1.2.2.1)  |  **Done:** 11/75 — 2.6 ✅ · 2.7 ✅ · 2.2 1/7
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -39,7 +39,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.1.6.1 | `adj_underpay_account` (wire consumers to AccountRoleService) | P0 | ⬜ | — | `payment-receipt-2b.template.ts:249`, `payment-receipt-2b-split.template.ts:212`, `payments.service.ts:1989`, `AdjustmentSection.tsx:30` |
 | D1.1.6.2 | `adj_overpay_account` (wire consumers to AccountRoleService) | P0 | ⬜ | — | Same pattern with 53-1503 |
 | D1.1.6.3 | `adj_auto_route` toggle | P0 | ⬜ | — | Flag in SystemConfig + check in template |
-| D1.2.2.1 | `company_name` (CompanyInfo wire) | P1 | ⬜ | — | Replace `<h1>BESTCHOICE FINANCE × SHOP</h1>` at PaymentVoucherPage.tsx:270,455,624,826 |
+| D1.2.2.1 | `company_name` (CompanyInfo wire) | P1 | ✅ | this PR | **Foundation for 2.2 sub-section.** New `GET /companies/public` (authenticated, all roles, returns public-safe SHOP+FINANCE fields). New `useCompanyInfo()` + `useCompanyDisplayName()` hooks in apps/web/src/hooks/useCompanyInfo.ts. All 4 hardcoded `BESTCHOICE FINANCE × SHOP` literals in PaymentVoucherPage.tsx (lines 271/456/625/827 across PettyCashSheet/PayrollSlipSheet/Sheet/WhtCertificate) replaced with `{companyName}` from the hook. Fallback to legacy literal if API hasn't responded yet. 3 new service tests on findPublic |
 | D1.2.2.2 | `company_address` (CompanyInfo wire) | P1 | ⬜ | — | Replace placeholder Thai at :271-272 etc. |
 | D1.2.2.3 | `tax_id` (CompanyInfo wire) | P1 | ⬜ | — | |
 | D1.2.2.4 | `logo_url` (upload + render) | P1 | ⬜ | — | CompanyInfo.logoUrl already in schema |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 10 | 13% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#890 · this PR |
-| **TOTAL** | **~159** | **77** | **~48%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 11 | 15% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#891 · this PR |
+| **TOTAL** | **~159** | **78** | **~49%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #11 + **foundation for 2.2 Voucher Branding (7 items).**

The 4 hardcoded `BESTCHOICE FINANCE × SHOP` literals in `PaymentVoucherPage` now read from the CompanyInfo schema (which has existed in the DB for months but was never consumed by the print layer).

## Changes

**Backend:**
- `CompanyService.findPublic()` — public-safe slice of CompanyInfo
- `GET /companies/public` — authenticated, all 5 roles (so non-OWNER print operators don't 403)

**Frontend:**
- New `useCompanyInfo()` + `useCompanyDisplayName()` hooks (15-min staleTime)
- 4 hardcoded literals in PettyCashSheet / PayrollSlipSheet / Sheet / WhtCertificate replaced with `{companyName}`
- Last-resort fallback to legacy literal so we never print a blank header

## Tests

- 3 new CompanyService tests (SHOP+FINANCE result shape; null fallbacks)
- Verified the public-safe field set excludes director PII + bank credentials
- 10/10 tests pass · 0 type errors

## Foundation reuse

Subsequent items in 2.2 will piggyback on this:
- D1.2.2.2/2.2.3/2.2.4 (address / tax_id / logo) → consume the same hook
- D1.2.2.5/2.2.6/2.2.7 (theme / language / QR) → move into `useUiFlags`

## Tracking

- D1.2.2.1 → ✅ · D1 11/75 · README 77→78 · 2.2 sub-section 1/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)