### PR TITLE
feat(a1): D1.2.2.2 — wire CompanyInfo.address into voucher sub-header

### DIFF
--- a/apps/web/src/hooks/useCompanyInfo.ts
+++ b/apps/web/src/hooks/useCompanyInfo.ts
@@ -56,3 +56,13 @@ export function useCompanyDisplayName(): string {
   if (shop) return shop.nameTh;
   return 'BESTCHOICE FINANCE × SHOP';
 }
+
+/**
+ * D1.2.2.2 — single address string for the voucher sub-header.
+ * Prefers FINANCE (primary entity for accounting docs) then SHOP, then a
+ * legacy placeholder so first-render never prints blank.
+ */
+export function useCompanyAddress(): string {
+  const { shop, finance } = useCompanyInfo();
+  return finance?.address ?? shop?.address ?? 'เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่';
+}

--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -20,7 +20,7 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { formatNumberDecimal } from '@/utils/formatters';
 import { formatThaiDateLong } from '@/lib/date';
 import { numToThaiText } from '@/utils/numToThaiText';
-import { useCompanyDisplayName } from '@/hooks/useCompanyInfo';
+import { useCompanyDisplayName, useCompanyAddress } from '@/hooks/useCompanyInfo';
 
 export interface ExpenseLine {
   lineNo: number;
@@ -257,6 +257,7 @@ function PettyCashSheet({
   net: string;
 }) {
   const companyName = useCompanyDisplayName();
+  const companyAddress = useCompanyAddress();
   const lines = doc.expenseDetail?.lines ?? [];
   // Distinct supplier count for the badge — useful auditing surface since
   // petty cash is the only doc type that mixes vendors per document.
@@ -271,7 +272,7 @@ function PettyCashSheet({
       <header className="text-center border-b-2 border-foreground pb-3">
         <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
+          {companyAddress}
         </p>
         <h2 className="text-2xl font-bold tracking-wider mt-4">ใบเบิกชดเชยเงินสดย่อย</h2>
         <p className="text-xs text-muted-foreground">Petty Cash Reimbursement Voucher</p>
@@ -424,6 +425,7 @@ function PayrollSlipSheet({
   totalSlips: number;
 }) {
   const companyName = useCompanyDisplayName();
+  const companyAddress = useCompanyAddress();
   const base = new Decimal(line.baseSalary || '0');
   const sso = new Decimal(line.ssoEmployee || '0');
   const wht = new Decimal(line.whtAmount || '0');
@@ -457,7 +459,7 @@ function PayrollSlipSheet({
       <header className="text-center border-b-2 border-foreground pb-3">
         <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
+          {companyAddress}
         </p>
         <h2 className="text-2xl font-bold tracking-wider mt-4">ใบจ่ายเงินเดือน</h2>
         <p className="text-xs text-muted-foreground">
@@ -617,6 +619,7 @@ function Sheet({
   net: string;
 }) {
   const companyName = useCompanyDisplayName();
+  const companyAddress = useCompanyAddress();
   const lines = doc.expenseDetail?.lines ?? [];
   return (
     <article
@@ -627,7 +630,7 @@ function Sheet({
       <header className="text-center border-b-2 border-foreground pb-3">
         <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่
+          {companyAddress}
         </p>
         <h2 className="text-2xl font-bold tracking-wider mt-4">ใบสำคัญจ่าย</h2>
         <p className="text-xs text-muted-foreground">Payment Voucher</p>
@@ -805,6 +808,7 @@ export function bucketWhtByRate(
 
 function WhtCertificate({ doc }: { doc: VoucherDoc }) {
   const companyName = useCompanyDisplayName();
+  const companyAddress = useCompanyAddress();
   // W7 (Round 2) — see bucketWhtByRate above for the Decimal-precision
   // rationale. Convert to display strings only at render time via toFixed.
   const wht = new Decimal(doc.withholdingTax || '0');
@@ -829,7 +833,7 @@ function WhtCertificate({ doc }: { doc: VoucherDoc }) {
         <div>
           <p className="text-xs text-muted-foreground mb-1">ผู้มีหน้าที่หักภาษี ณ ที่จ่าย</p>
           <p className="font-semibold">{companyName}</p>
-          <p className="text-xs text-muted-foreground">เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่</p>
+          <p className="text-xs text-muted-foreground">{companyAddress}</p>
         </div>
         <div>
           <p className="text-xs text-muted-foreground mb-1">ผู้ถูกหัก ณ ที่จ่าย</p>

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882-#891 · this PR (D1.2.2.1)  |  **Done:** 11/75 — 2.6 ✅ · 2.7 ✅ · 2.2 1/7
+**Started:** 2026-05-16  |  **PRs:** #882-#892 · this PR (D1.2.2.2)  |  **Done:** 12/75 — 2.6 ✅ · 2.7 ✅ · 2.2 2/7
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -40,7 +40,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.1.6.2 | `adj_overpay_account` (wire consumers to AccountRoleService) | P0 | ⬜ | — | Same pattern with 53-1503 |
 | D1.1.6.3 | `adj_auto_route` toggle | P0 | ⬜ | — | Flag in SystemConfig + check in template |
 | D1.2.2.1 | `company_name` (CompanyInfo wire) | P1 | ✅ | this PR | **Foundation for 2.2 sub-section.** New `GET /companies/public` (authenticated, all roles, returns public-safe SHOP+FINANCE fields). New `useCompanyInfo()` + `useCompanyDisplayName()` hooks in apps/web/src/hooks/useCompanyInfo.ts. All 4 hardcoded `BESTCHOICE FINANCE × SHOP` literals in PaymentVoucherPage.tsx (lines 271/456/625/827 across PettyCashSheet/PayrollSlipSheet/Sheet/WhtCertificate) replaced with `{companyName}` from the hook. Fallback to legacy literal if API hasn't responded yet. 3 new service tests on findPublic |
-| D1.2.2.2 | `company_address` (CompanyInfo wire) | P1 | ⬜ | — | Replace placeholder Thai at :271-272 etc. |
+| D1.2.2.2 | `company_address` (CompanyInfo wire) | P1 | ✅ | this PR | New `useCompanyAddress()` hook (prefers FINANCE then SHOP). Replaces all 4 hardcoded "เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่" placeholders in PaymentVoucherPage components. Re-uses the existing /companies/public endpoint from D1.2.2.1. Type-check 0 errors |
 | D1.2.2.3 | `tax_id` (CompanyInfo wire) | P1 | ⬜ | — | |
 | D1.2.2.4 | `logo_url` (upload + render) | P1 | ⬜ | — | CompanyInfo.logoUrl already in schema |
 | D1.2.2.5 | `theme_color` admin override | P1 | ⬜ | — | Tailwind CSS var override at runtime |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 11 | 15% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#891 · this PR |
-| **TOTAL** | **~159** | **78** | **~49%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 12 | 16% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#892 · this PR |
+| **TOTAL** | **~159** | **79** | **~50%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #12. `useCompanyAddress()` hook replaces 4 hardcoded "เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่" placeholders with the real address from CompanyInfo (prefers FINANCE, falls back to SHOP, legacy literal as last resort).

## Changes

- Frontend hook only — re-uses existing `GET /companies/public` from #892
- 4 placeholder strings in PaymentVoucherPage replaced with `{companyAddress}`

## Tests

- Type-check 0 errors
- Re-uses tested findPublic() path

## Tracking

- D1.2.2.2 → ✅ · D1 12/75 · 2.2 sub-section 2/7 · README ~50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)