### PR TITLE
feat(a1): D1.2.2.3 — wire CompanyInfo.taxId into voucher header

### DIFF
--- a/apps/web/src/hooks/useCompanyInfo.ts
+++ b/apps/web/src/hooks/useCompanyInfo.ts
@@ -66,3 +66,13 @@ export function useCompanyAddress(): string {
   const { shop, finance } = useCompanyInfo();
   return finance?.address ?? shop?.address ?? 'เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่';
 }
+
+/**
+ * D1.2.2.3 — tax ID (เลขประจำตัวผู้เสียภาษี) for voucher header.
+ * Prefers FINANCE (primary VAT entity per CLAUDE.md two-entity structure)
+ * then SHOP, then empty string (caller hides the row).
+ */
+export function useCompanyTaxId(): string {
+  const { shop, finance } = useCompanyInfo();
+  return finance?.taxId ?? shop?.taxId ?? '';
+}

--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -20,7 +20,11 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { formatNumberDecimal } from '@/utils/formatters';
 import { formatThaiDateLong } from '@/lib/date';
 import { numToThaiText } from '@/utils/numToThaiText';
-import { useCompanyDisplayName, useCompanyAddress } from '@/hooks/useCompanyInfo';
+import {
+  useCompanyDisplayName,
+  useCompanyAddress,
+  useCompanyTaxId,
+} from '@/hooks/useCompanyInfo';
 
 export interface ExpenseLine {
   lineNo: number;
@@ -258,6 +262,7 @@ function PettyCashSheet({
 }) {
   const companyName = useCompanyDisplayName();
   const companyAddress = useCompanyAddress();
+  const companyTaxId = useCompanyTaxId();
   const lines = doc.expenseDetail?.lines ?? [];
   // Distinct supplier count for the badge — useful auditing surface since
   // petty cash is the only doc type that mixes vendors per document.
@@ -272,7 +277,7 @@ function PettyCashSheet({
       <header className="text-center border-b-2 border-foreground pb-3">
         <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          {companyAddress}
+          {companyAddress}{companyTaxId && ` · เลขผู้เสียภาษี ${companyTaxId}`}
         </p>
         <h2 className="text-2xl font-bold tracking-wider mt-4">ใบเบิกชดเชยเงินสดย่อย</h2>
         <p className="text-xs text-muted-foreground">Petty Cash Reimbursement Voucher</p>
@@ -426,6 +431,7 @@ function PayrollSlipSheet({
 }) {
   const companyName = useCompanyDisplayName();
   const companyAddress = useCompanyAddress();
+  const companyTaxId = useCompanyTaxId();
   const base = new Decimal(line.baseSalary || '0');
   const sso = new Decimal(line.ssoEmployee || '0');
   const wht = new Decimal(line.whtAmount || '0');
@@ -459,7 +465,7 @@ function PayrollSlipSheet({
       <header className="text-center border-b-2 border-foreground pb-3">
         <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          {companyAddress}
+          {companyAddress}{companyTaxId && ` · เลขผู้เสียภาษี ${companyTaxId}`}
         </p>
         <h2 className="text-2xl font-bold tracking-wider mt-4">ใบจ่ายเงินเดือน</h2>
         <p className="text-xs text-muted-foreground">
@@ -620,6 +626,7 @@ function Sheet({
 }) {
   const companyName = useCompanyDisplayName();
   const companyAddress = useCompanyAddress();
+  const companyTaxId = useCompanyTaxId();
   const lines = doc.expenseDetail?.lines ?? [];
   return (
     <article
@@ -630,7 +637,7 @@ function Sheet({
       <header className="text-center border-b-2 border-foreground pb-3">
         <h1 className="text-xl font-bold">{companyName}</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          {companyAddress}
+          {companyAddress}{companyTaxId && ` · เลขผู้เสียภาษี ${companyTaxId}`}
         </p>
         <h2 className="text-2xl font-bold tracking-wider mt-4">ใบสำคัญจ่าย</h2>
         <p className="text-xs text-muted-foreground">Payment Voucher</p>
@@ -809,6 +816,7 @@ export function bucketWhtByRate(
 function WhtCertificate({ doc }: { doc: VoucherDoc }) {
   const companyName = useCompanyDisplayName();
   const companyAddress = useCompanyAddress();
+  const companyTaxId = useCompanyTaxId();
   // W7 (Round 2) — see bucketWhtByRate above for the Decimal-precision
   // rationale. Convert to display strings only at render time via toFixed.
   const wht = new Decimal(doc.withholdingTax || '0');
@@ -833,7 +841,7 @@ function WhtCertificate({ doc }: { doc: VoucherDoc }) {
         <div>
           <p className="text-xs text-muted-foreground mb-1">ผู้มีหน้าที่หักภาษี ณ ที่จ่าย</p>
           <p className="font-semibold">{companyName}</p>
-          <p className="text-xs text-muted-foreground">{companyAddress}</p>
+          <p className="text-xs text-muted-foreground">{companyAddress}{companyTaxId && ` · เลขผู้เสียภาษี ${companyTaxId}`}</p>
         </div>
         <div>
           <p className="text-xs text-muted-foreground mb-1">ผู้ถูกหัก ณ ที่จ่าย</p>

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882-#892 · this PR (D1.2.2.2)  |  **Done:** 12/75 — 2.6 ✅ · 2.7 ✅ · 2.2 2/7
+**Started:** 2026-05-16  |  **PRs:** #882-#893 · this PR (D1.2.2.3)  |  **Done:** 13/75 — 2.6 ✅ · 2.7 ✅ · 2.2 3/7
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -41,7 +41,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.1.6.3 | `adj_auto_route` toggle | P0 | ⬜ | — | Flag in SystemConfig + check in template |
 | D1.2.2.1 | `company_name` (CompanyInfo wire) | P1 | ✅ | this PR | **Foundation for 2.2 sub-section.** New `GET /companies/public` (authenticated, all roles, returns public-safe SHOP+FINANCE fields). New `useCompanyInfo()` + `useCompanyDisplayName()` hooks in apps/web/src/hooks/useCompanyInfo.ts. All 4 hardcoded `BESTCHOICE FINANCE × SHOP` literals in PaymentVoucherPage.tsx (lines 271/456/625/827 across PettyCashSheet/PayrollSlipSheet/Sheet/WhtCertificate) replaced with `{companyName}` from the hook. Fallback to legacy literal if API hasn't responded yet. 3 new service tests on findPublic |
 | D1.2.2.2 | `company_address` (CompanyInfo wire) | P1 | ✅ | this PR | New `useCompanyAddress()` hook (prefers FINANCE then SHOP). Replaces all 4 hardcoded "เลขประจำตัวผู้เสียภาษี · สำนักงานใหญ่" placeholders in PaymentVoucherPage components. Re-uses the existing /companies/public endpoint from D1.2.2.1. Type-check 0 errors |
-| D1.2.2.3 | `tax_id` (CompanyInfo wire) | P1 | ⬜ | — | |
+| D1.2.2.3 | `tax_id` (CompanyInfo wire) | P1 | ✅ | this PR | New `useCompanyTaxId()` hook. Voucher sub-header now shows `{address} · เลขผู้เสียภาษี {taxId}` inline. Hidden when CompanyInfo absent. Re-uses /companies/public. Type-check 0 errors |
 | D1.2.2.4 | `logo_url` (upload + render) | P1 | ⬜ | — | CompanyInfo.logoUrl already in schema |
 | D1.2.2.5 | `theme_color` admin override | P1 | ⬜ | — | Tailwind CSS var override at runtime |
 | D1.2.2.6 | `language` (i18n) | P1 | ⬜ | — | Larger — defer if time short |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 12 | 16% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#892 · this PR |
-| **TOTAL** | **~159** | **79** | **~50%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 13 | 17% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#893 · this PR |
+| **TOTAL** | **~159** | **80** | **~50%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #13. `useCompanyTaxId()` hook adds inline "· เลขผู้เสียภาษี {taxId}" suffix to the voucher address sub-header. Empty taxId silently hides the suffix.

## Changes

- New `useCompanyTaxId()` hook (frontend only)
- 4 voucher headers now show `{address} · เลขผู้เสียภาษี {taxId}` when CompanyInfo has tax ID
- Re-uses /companies/public from #892

## Tracking

- D1.2.2.3 → ✅ · D1 13/75 · 2.2 sub-section 3/7 · README 79→80

🤖 Generated with [Claude Code](https://claude.com/claude-code)