### PR TITLE
feat(a1): D1.2.2.7 — render verification QR on voucher footers

### DIFF
--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -154,6 +154,8 @@ export class SettingsService {
      * the period boundary when this is not 31. Validated 1–31.
      */
     periodCloseDay: number;
+    /** D1.2.2.7 — render verification QR code on voucher footers. Default true. */
+    voucherShowQrCode: boolean;
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -183,6 +185,7 @@ export class SettingsService {
       Number.isInteger(periodCloseDayRaw) && periodCloseDayRaw >= 1 && periodCloseDayRaw <= 31
         ? periodCloseDayRaw
         : 31;
+    const voucherShowQrCode = await this.readBoolean('voucher_show_qr_code', true);
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -191,6 +194,7 @@ export class SettingsService {
       paymentDateWarningBackdate,
       paymentDateAllowFuture,
       periodCloseDay,
+      voucherShowQrCode,
     };
   }
 

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -26,6 +26,8 @@ export interface UiFlags {
   paymentDateAllowFuture: boolean;
   /** D1.2.6.1 — day-of-month when periods close. Default 31. Informational. */
   periodCloseDay: number;
+  /** D1.2.2.7 — render verification QR on voucher footers. Default true. */
+  voucherShowQrCode: boolean;
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -43,6 +45,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   paymentDateWarningBackdate: 30,
   paymentDateAllowFuture: true,
   periodCloseDay: 31,
+  voucherShowQrCode: true,
 };
 
 export function useUiFlags(): UiFlags {

--- a/apps/web/src/pages/PaymentVoucherPage.tsx
+++ b/apps/web/src/pages/PaymentVoucherPage.tsx
@@ -14,6 +14,7 @@ import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Printer } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
 import Decimal from 'decimal.js';
 import api from '@/lib/api';
 import QueryBoundary from '@/components/QueryBoundary';
@@ -26,6 +27,7 @@ import {
   useCompanyTaxId,
   useCompanyLogoUrl,
 } from '@/hooks/useCompanyInfo';
+import { useUiFlags } from '@/hooks/useUiFlags';
 
 export interface ExpenseLine {
   lineNo: number;
@@ -645,7 +647,13 @@ function Sheet({
   const companyAddress = useCompanyAddress();
   const companyTaxId = useCompanyTaxId();
   const companyLogoUrl = useCompanyLogoUrl();
+  const { voucherShowQrCode } = useUiFlags();
   const lines = doc.expenseDetail?.lines ?? [];
+  // D1.2.2.7 — verification QR linking to /verify/<doc.number>. Default
+  // on; OWNER can disable via SystemConfig `voucher_show_qr_code = false`.
+  const verifyUrl = typeof window !== 'undefined'
+    ? `${window.location.origin}/verify/${doc.number}`
+    : `/verify/${doc.number}`;
   return (
     <article
       className="voucher-sheet bg-white border border-border rounded-md p-8 shadow-sm print:border-0 print:p-0 print:shadow-none"
@@ -792,6 +800,14 @@ function Sheet({
         <SignatureSlot label="ผู้รับเงิน" />
         <SignatureSlot label="ตราประทับ" border={false} />
       </section>
+
+      {/* D1.2.2.7 — verification QR (OWNER toggleable via voucher_show_qr_code) */}
+      {voucherShowQrCode && (
+        <section className="mt-6 flex flex-col items-end gap-1">
+          <QRCodeSVG value={verifyUrl} size={80} level="M" />
+          <span className="text-[9px] text-muted-foreground">สแกนเพื่อตรวจสอบ</span>
+        </section>
+      )}
 
       <footer className="mt-8 pt-3 border-t border-border text-[10px] text-muted-foreground flex justify-between">
         <span>ออกเอกสารจากระบบ BESTCHOICE — ไม่ต้องเซ็นต์ถือเป็นโมฆะ</span>

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882-#894 · this PR (D1.2.2.4)  |  **Done:** 14/75 — 2.6 ✅ · 2.7 ✅ · 2.2 4/7
+**Started:** 2026-05-16  |  **PRs:** #882-#895 · this PR (D1.2.2.7)  |  **Done:** 15/75 — 2.6 ✅ · 2.7 ✅ · 2.2 5/7
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -45,7 +45,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.2.4 | `logo_url` (upload + render) | P1 | ✅ | this PR | `useCompanyLogoUrl()` hook + `<img>` render before `<h1>` in 3 voucher headers (PettyCashSheet/PayrollSlipSheet/Sheet). Hidden when null. h-12 contain-fit. Upload UI not in scope — uses existing CompanyInfo.logoUrl set via /companies CRUD. Type-check 0 errors |
 | D1.2.2.5 | `theme_color` admin override | P1 | ⬜ | — | Tailwind CSS var override at runtime |
 | D1.2.2.6 | `language` (i18n) | P1 | ⬜ | — | Larger — defer if time short |
-| D1.2.2.7 | `show_qr_code` toggle | P1 | ⬜ | — | qrcode.react already imported in MobileReceipt |
+| D1.2.2.7 | `show_qr_code` toggle | P1 | ✅ | this PR | SystemConfig `voucher_show_qr_code` (default true). `getUiFlags()` exposes `voucherShowQrCode`. Sheet voucher component renders `<QRCodeSVG value="{origin}/verify/{doc.number}" size=80>` + "สแกนเพื่อตรวจสอบ" caption above footer. Hidden when flag off. PettyCash/Payroll/WhtCertificate not included (smaller layouts) — can be added in a follow-up if owner wants |
 | D1.2.6.1 | `period_close_day` | P1 | ✅ | this PR | SystemConfig `period_close_day` (default 31). `getUiFlags()` returns `periodCloseDay` clamped to 1-31. **Informational for now** — period-lock still anchors at calendar month-end. Future enhancement: shift period boundary when ≠ 31. 4 new tests (default / valid range / out-of-range clamp / zero clamp) |
 | D1.2.6.2 | `period_grace_days` | P1 | ✅ | this PR | SystemConfig key `period_grace_days` (default 5). `period-lock.util.ts:validatePeriodOpen` extended — closed-period throws only if today > periodLastDay + graceDays (Tier 1) or today > closedUntil + graceDays (Tier 2). 10 new tests (CLOSED within/beyond grace, SYNCED, OPEN, OWNER override 0/30, malformed/negative fallback, legacy Tier 2). Direct callers (journal-auto, expense-documents, receipts) all pass |
 | D1.2.6.3 | `payment_date_warning_backdate` | P1 | ✅ | this PR | SystemConfig `payment_date_warning_backdate` (default 30). `getUiFlags()` exposes `paymentDateWarningBackdate`; ReverseDialog hardcoded `30` replaced with the flag (both the threshold for the broader warning AND the upper bound for the 7d manager-approval warning). 2 new tests on default + override |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 14 | 19% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#894 · this PR |
-| **TOTAL** | **~159** | **81** | **~51%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 15 | 20% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#895 · this PR |
+| **TOTAL** | **~159** | **82** | **~52%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #15. `voucher_show_qr_code` SystemConfig flag (default true). When on, the generic `Sheet` voucher renders a QR linking to `/verify/{doc.number}` above the footer.

## Changes

- Backend: `getUiFlags()` adds `voucherShowQrCode` (default true)
- Frontend: `useUiFlags()` exposes it; `PaymentVoucherPage` imports `QRCodeSVG` from existing `qrcode.react` dep
- Generic `Sheet` renders 80px QR + Thai caption when flag on
- PettyCash/Payroll/WhtCertificate skipped (smaller layouts) — follow-up if owner wants

## Tests

- Type-check 0 errors · 26/26 settings tests pass

## Tracking

- D1.2.2.7 → ✅ · D1 15/75 · 2.2 sub-section 5/7 · README 81→82

🤖 Generated with [Claude Code](https://claude.com/claude-code)