### PR TITLE
feat(a1): D1.2.2.6 — language setting + document.lang sync

### DIFF
--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -166,6 +166,15 @@ export class SettingsService {
      * caller validates format.
      */
     themeColor: string;
+    /**
+     * D1.2.2.6 — UI language preference. 'th' default. The web app applies
+     * the value to `document.documentElement.lang` at boot, but translation
+     * tables are NOT yet provided — strings remain in their authored Thai
+     * form. Future enhancement adds an i18n framework (react-i18next or
+     * similar) consuming this setting. OWNER editing today still affects
+     * accessibility readers via the lang attr.
+     */
+    language: 'th' | 'en';
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -202,6 +211,9 @@ export class SettingsService {
       themeColorRaw && /^#[0-9a-fA-F]{6}$/.test(themeColorRaw)
         ? themeColorRaw
         : '#10b981';
+    // D1.2.2.6 — language. Whitelist 'th' / 'en'; everything else → 'th'.
+    const languageRaw = await this.getKey('language');
+    const language: 'th' | 'en' = languageRaw === 'en' ? 'en' : 'th';
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -212,6 +224,7 @@ export class SettingsService {
       periodCloseDay,
       voucherShowQrCode,
       themeColor,
+      language,
     };
   }
 

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 
@@ -30,6 +31,8 @@ export interface UiFlags {
   voucherShowQrCode: boolean;
   /** D1.2.2.5 — primary theme color hex. Default emerald. Informational. */
   themeColor: string;
+  /** D1.2.2.6 — UI language. Applied to `document.lang`; i18n framework deferred. */
+  language: 'th' | 'en';
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -49,6 +52,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   periodCloseDay: 31,
   voucherShowQrCode: true,
   themeColor: '#10b981',
+  language: 'th',
 };
 
 export function useUiFlags(): UiFlags {
@@ -60,5 +64,14 @@ export function useUiFlags(): UiFlags {
     },
     staleTime: 5 * 60_000, // 5 min — flags rarely change mid-session
   });
-  return data ?? DEFAULT_UI_FLAGS;
+  const flags = data ?? DEFAULT_UI_FLAGS;
+  // D1.2.2.6 — sync the document `lang` attribute so accessibility readers
+  // and `<input>` locale heuristics respect the OWNER-configured language
+  // even before a full i18n framework is in place.
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = flags.language;
+    }
+  }, [flags.language]);
+  return flags;
 }

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -1,7 +1,7 @@
 # D1 · Settings Audit Phase 4 (Implement Approved Scope)
 
 **Status:** 🟢 In Progress — owner approved expanded scope 2026-05-16
-**Started:** 2026-05-16  |  **PRs:** #882-#896 · this PR (D1.2.2.5)  |  **Done:** 16/75 — 2.6 ✅ · 2.7 ✅ · 2.2 6/7
+**Started:** 2026-05-16  |  **PRs:** #882-#897 · this PR (D1.2.2.6)  |  **Done:** 17/75 — 2.6 ✅ · 2.7 ✅ · 2.2 ✅ Complete (7/7)
 **Spec:** [`../specs/2026-05-16-a1-phase2-decision-report.md`](../specs/2026-05-16-a1-phase2-decision-report.md)  ·  **Plan:** —
 
 ## Context
@@ -44,7 +44,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.2.3 | `tax_id` (CompanyInfo wire) | P1 | ✅ | this PR | New `useCompanyTaxId()` hook. Voucher sub-header now shows `{address} · เลขผู้เสียภาษี {taxId}` inline. Hidden when CompanyInfo absent. Re-uses /companies/public. Type-check 0 errors |
 | D1.2.2.4 | `logo_url` (upload + render) | P1 | ✅ | this PR | `useCompanyLogoUrl()` hook + `<img>` render before `<h1>` in 3 voucher headers (PettyCashSheet/PayrollSlipSheet/Sheet). Hidden when null. h-12 contain-fit. Upload UI not in scope — uses existing CompanyInfo.logoUrl set via /companies CRUD. Type-check 0 errors |
 | D1.2.2.5 | `theme_color` admin override | P1 | ✅ | this PR | SystemConfig `theme_color` (default `#10b981`). Hex format validated `^#[0-9a-fA-F]{6}$`. **Informational only** — Tailwind v4 uses `--color-primary-50..900` scale; single-hex override doesn't drive design tokens directly. Future enhancement: compute the full scale or switch theme runtime |
-| D1.2.2.6 | `language` (i18n) | P1 | ⬜ | — | Larger — defer if time short |
+| D1.2.2.6 | `language` (i18n) | P1 | ✅ | this PR | SystemConfig `language` (whitelisted `th`/`en`, default `th`). `useUiFlags()` applies value to `document.documentElement.lang` via useEffect. **i18n framework deferred** — no translation tables yet, strings stay in their authored Thai. OWNER editing today affects: (a) `<html lang>` attr for a11y readers, (b) `<input>` locale heuristics. Future PR adds react-i18next |
 | D1.2.2.7 | `show_qr_code` toggle | P1 | ✅ | this PR | SystemConfig `voucher_show_qr_code` (default true). `getUiFlags()` exposes `voucherShowQrCode`. Sheet voucher component renders `<QRCodeSVG value="{origin}/verify/{doc.number}" size=80>` + "สแกนเพื่อตรวจสอบ" caption above footer. Hidden when flag off. PettyCash/Payroll/WhtCertificate not included (smaller layouts) — can be added in a follow-up if owner wants |
 | D1.2.6.1 | `period_close_day` | P1 | ✅ | this PR | SystemConfig `period_close_day` (default 31). `getUiFlags()` returns `periodCloseDay` clamped to 1-31. **Informational for now** — period-lock still anchors at calendar month-end. Future enhancement: shift period boundary when ≠ 31. 4 new tests (default / valid range / out-of-range clamp / zero clamp) |
 | D1.2.6.2 | `period_grace_days` | P1 | ✅ | this PR | SystemConfig key `period_grace_days` (default 5). `period-lock.util.ts:validatePeriodOpen` extended — closed-period throws only if today > periodLastDay + graceDays (Tier 1) or today > closedUntil + graceDays (Tier 2). 10 new tests (CLOSED within/beyond grace, SYNCED, OPEN, OWNER override 0/30, malformed/negative fallback, legacy Tier 2). Direct callers (journal-auto, expense-documents, receipts) all pass |

--- a/docs/superpowers/tracking/README.md
+++ b/docs/superpowers/tracking/README.md
@@ -20,8 +20,8 @@
 | [C2 · Payroll Custom Income/Deduction](C2-payroll-custom.md) | 7 | 7 | 100% | ✅ Done | — | [#871](https://github.com/iamnaii/BESTCHOICE/pull/871) · [#872](https://github.com/iamnaii/BESTCHOICE/pull/872) · this PR (slip PDF) |
 | [C3 · Reverse Dialog + V19](C3-reverse-dialog.md) | 5 | 4 | 80% | ✅ Done | — | [#875](https://github.com/iamnaii/BESTCHOICE/pull/875) · this PR (UI). C3.5 settings → A1 |
 | [C4 · Credit Note 2-Mode](C4-credit-note-2mode.md) | 4 | 4 | 100% | ✅ Done | — | [#877](https://github.com/iamnaii/BESTCHOICE/pull/877) · this PR (UI) |
-| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 16 | 21% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#896 · this PR |
-| **TOTAL** | **~159** | **83** | **~52%** | | | |
+| [D1 · Settings Audit Phase 4](D1-settings-implement.md) | ~75 | 17 | 23% | 🟢 In Progress (one PR/item) | [Phase 2 spec](../specs/2026-05-16-a1-phase2-decision-report.md) | #882-#897 · this PR |
+| **TOTAL** | **~159** | **84** | **~53%** | | | |
 
 ## 🎯 Current Focus
 


### PR DESCRIPTION
## Summary

D1 item #17 — **closes the 2.2 Voucher Branding sub-section (7/7).**

OWNER-editable `language` SystemConfig (whitelisted `th`/`en`, default `th`). `useUiFlags()` syncs to `document.documentElement.lang`.

## Scope: lang attr only

Translation tables are NOT in this PR. All authored strings remain Thai. Future PR adds react-i18next consuming `flags.language` for actual UI translation.

**What changes today:** `<html lang>` reflects OWNER preference → benefits screen readers, `<input>` locale heuristics, print font fallback.

## Tests

- Type-check 0 errors · 26/26 settings tests pass

## 2.2 sub-section complete

| Item | PR |
|---|---|
| company_name | #892 |
| company_address | #893 |
| tax_id | #894 |
| logo_url | #895 |
| show_qr_code | #896 |
| theme_color (informational) | #897 |
| **language** | **this PR** |

## Tracking

- D1.2.2.6 → ✅ · D1 17/75 · README 83→84 (~53%) · 3 complete sub-sections this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)