### PR TITLE
feat(a1): D1.2.3.4 — decimal_places setting (formatNumberDecimal default)

### DIFF
--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -287,5 +287,48 @@ describe('SettingsService audit trail', () => {
       const flags = await service.getUiFlags();
       expect(flags.periodCloseDay).toBe(31);
     });
+
+    // D1.2.3.4 — decimal_places
+    it('decimalPlaces defaults to 2 when SystemConfig missing', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.decimalPlaces).toBe(2);
+    });
+
+    it('decimalPlaces accepts override 0 from SystemConfig', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'decimal_places') return Promise.resolve({ value: '0' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.decimalPlaces).toBe(0);
+    });
+
+    it('decimalPlaces accepts override 4 from SystemConfig', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'decimal_places') return Promise.resolve({ value: '4' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.decimalPlaces).toBe(4);
+    });
+
+    it('decimalPlaces clamps to default 2 when out-of-range (5)', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'decimal_places') return Promise.resolve({ value: '5' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.decimalPlaces).toBe(2);
+    });
+
+    it('decimalPlaces falls back to default 2 when non-numeric', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'decimal_places') return Promise.resolve({ value: 'two' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.decimalPlaces).toBe(2);
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -175,6 +175,15 @@ export class SettingsService {
      * accessibility readers via the lang attr.
      */
     language: 'th' | 'en';
+    /**
+     * D1.2.3.4 — default number of decimal places for the generic number
+     * formatter. Integer 0-4 inclusive. Default 2 (Thai currency convention).
+     * SystemConfig key `decimal_places`. Out-of-range/non-integer values
+     * clamp to default. The pref is the *default only* — `formatNumberDecimal`
+     * call sites that explicitly pass a digit count continue to work as
+     * before, preserving backwards compat.
+     */
+    decimalPlaces: number;
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -214,6 +223,13 @@ export class SettingsService {
     // D1.2.2.6 — language. Whitelist 'th' / 'en'; everything else → 'th'.
     const languageRaw = await this.getKey('language');
     const language: 'th' | 'en' = languageRaw === 'en' ? 'en' : 'th';
+    // D1.2.3.4 — decimal_places. Integer 0-4 inclusive; clamp to 2 default
+    // for out-of-range / non-integer values.
+    const decimalPlacesRaw = await this.readNumber('decimal_places', 2);
+    const decimalPlaces =
+      Number.isInteger(decimalPlacesRaw) && decimalPlacesRaw >= 0 && decimalPlacesRaw <= 4
+        ? decimalPlacesRaw
+        : 2;
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -225,6 +241,7 @@ export class SettingsService {
       voucherShowQrCode,
       themeColor,
       language,
+      decimalPlaces,
     };
   }
 

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
+import { setDefaultDecimalPlaces } from '@/utils/formatters';
 
 /**
  * D1.* — UI feature flags fetched from /settings/ui-flags.
@@ -33,6 +34,8 @@ export interface UiFlags {
   themeColor: string;
   /** D1.2.2.6 — UI language. Applied to `document.lang`; i18n framework deferred. */
   language: 'th' | 'en';
+  /** D1.2.3.4 — default decimal places (0-4) for the generic number formatter. */
+  decimalPlaces: number;
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -53,6 +56,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   voucherShowQrCode: true,
   themeColor: '#10b981',
   language: 'th',
+  decimalPlaces: 2,
 };
 
 export function useUiFlags(): UiFlags {
@@ -73,5 +77,12 @@ export function useUiFlags(): UiFlags {
       document.documentElement.lang = flags.language;
     }
   }, [flags.language]);
+  // D1.2.3.4 — sync the module-level default decimal-places preference so
+  // pure `formatNumberDecimal()` calls (in exports, badges, etc.) respect
+  // the OWNER pref. Call sites that pass an explicit digit count are
+  // unaffected — the pref is the *default only*.
+  useEffect(() => {
+    setDefaultDecimalPlaces(flags.decimalPlaces);
+  }, [flags.decimalPlaces]);
   return flags;
 }

--- a/apps/web/src/utils/formatters.test.ts
+++ b/apps/web/src/utils/formatters.test.ts
@@ -182,4 +182,22 @@ describe('formatters — decimal_places default (D1.2.3.4)', () => {
     // 1.0049999…). For correct half-up on string sources, callers should
     // pass the string form unchanged (parseFloat is the lossy step).
   });
+
+  // Review-round-2 — negative half-up edge cases. The implementation rounds
+  // on the absolute value then re-applies the sign, so the magnitude rounds
+  // up the same way for negatives. Without this symmetry, ROUND_HALF_UP on
+  // -0.5 would yield 0 (banker / asymmetric) instead of the expected -1.
+  it('ROUND_HALF_UP symmetric on negatives (-0.5 → -1, -2.5 → -3)', () => {
+    // -0.5 rounds AWAY from zero → -1 (banker would give 0; asymmetric
+    // half-up would give 0; our symmetric impl gives -1 to match positive
+    // 0.5 → 1).
+    expect(formatNumberDecimal(-0.5, 0)).toBe('-1');
+    // -1.5 → -2 (banker would also give -2 — odd half-up matches)
+    expect(formatNumberDecimal(-1.5, 0)).toBe('-2');
+    // -2.5 → -3 (banker would give -2; divergence proves symmetric half-up)
+    expect(formatNumberDecimal(-2.5, 0)).toBe('-3');
+    // Negative non-half edge — verify the sign reapplies cleanly.
+    expect(formatNumberDecimal(-21468.6, 0)).toBe('-21,469');
+    expect(formatNumberDecimal(-21468.4, 0)).toBe('-21,468');
+  });
 });

--- a/apps/web/src/utils/formatters.test.ts
+++ b/apps/web/src/utils/formatters.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   formatDateShort,
   formatDateMedium,
@@ -10,7 +10,15 @@ import {
   formatNumber,
   formatNumberDecimal,
   applyFormat,
+  setDefaultDecimalPlaces,
 } from './formatters';
+
+// D1.2.3.4 — `formatNumberDecimal` reads from a module-level pref when the
+// 2nd argument is omitted. Reset to 2 after each test to keep blocks
+// independent.
+afterEach(() => {
+  setDefaultDecimalPlaces(2);
+});
 
 // 3 มีนาคม 2026 14:30:05 local time
 const sampleDate = new Date(2026, 2, 3, 14, 30, 5);
@@ -132,5 +140,46 @@ describe('applyFormat', () => {
 
   it('trims whitespace from the format string', () => {
     expect(applyFormat(21468, ' num ')).toBe('21,468');
+  });
+});
+
+// D1.2.3.4 — decimal_places module-level default
+describe('formatters — decimal_places default (D1.2.3.4)', () => {
+  it('default 2: formatNumberDecimal(value) uses 2 digits when omitted', () => {
+    expect(formatNumberDecimal(21468.4)).toBe('21,468.40');
+  });
+
+  it('override 0: formatNumberDecimal(value) uses 0 digits when pref=0', () => {
+    setDefaultDecimalPlaces(0);
+    expect(formatNumberDecimal(21468.4)).toBe('21,468');
+    expect(formatNumberDecimal(21468.6)).toBe('21,469'); // ROUND_HALF_UP
+  });
+
+  it('override 4: formatNumberDecimal(value) uses 4 digits when pref=4', () => {
+    setDefaultDecimalPlaces(4);
+    expect(formatNumberDecimal(1.23456)).toBe('1.2346'); // ROUND_HALF_UP
+  });
+
+  it('out-of-range pref (5) falls back to default 2', () => {
+    setDefaultDecimalPlaces(5);
+    expect(formatNumberDecimal(21468.4)).toBe('21,468.40');
+  });
+
+  it('explicit 2nd arg always wins over the pref', () => {
+    setDefaultDecimalPlaces(0);
+    expect(formatNumberDecimal(21468.4, 2)).toBe('21,468.40');
+    expect(formatNumberDecimal(1.23456, 3)).toBe('1.235');
+  });
+
+  it('ROUND_HALF_UP applied: representable 0.5 boundaries round UP not banker', () => {
+    // 0.5 → 1 with ROUND_HALF_UP (banker would give 0). Representable exactly.
+    expect(formatNumberDecimal(0.5, 0)).toBe('1');
+    // 1.5 → 2 (banker would give 2 anyway — odd half-up matches)
+    expect(formatNumberDecimal(1.5, 0)).toBe('2');
+    // 2.5 → 3 with ROUND_HALF_UP (banker would give 2 here — divergence proves the rule)
+    expect(formatNumberDecimal(2.5, 0)).toBe('3');
+    // Note: 1.005 → "1.00" is unavoidable in IEEE 754 (`1.005` is really
+    // 1.0049999…). For correct half-up on string sources, callers should
+    // pass the string form unchanged (parseFloat is the lossy step).
   });
 });

--- a/apps/web/src/utils/formatters.ts
+++ b/apps/web/src/utils/formatters.ts
@@ -1,5 +1,23 @@
 // Thai date & number formatting utilities
 
+// D1.2.3.4 — module-level default decimal places. Pure formatter calls
+// without an explicit count read from here; explicit overrides still win.
+// Default 2 matches Thai currency convention + the original hardcoded value.
+let defaultDecimalPlaces = 2;
+
+/**
+ * D1.2.3.4 — Set the global default decimal-place count. Clamped to 0-4.
+ * Called from `useUiFlags` on mount and on SystemConfig changes. Out-of-range
+ * silently coerces to 2 (matches server-side clamp).
+ */
+export function setDefaultDecimalPlaces(n: number): void {
+  if (Number.isInteger(n) && n >= 0 && n <= 4) {
+    defaultDecimalPlaces = n;
+  } else {
+    defaultDecimalPlaces = 2;
+  }
+}
+
 const THAI_MONTHS = [
   'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
   'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม',
@@ -77,10 +95,27 @@ export function formatNumber(value: number | string): string {
 }
 
 // num:2 → 21,468.48
-export function formatNumberDecimal(value: number | string, decimals = 2): string {
+// D1.2.3.4 — when `decimals` is omitted, falls back to the module-level
+// pref (configurable via SystemConfig `decimal_places`, default 2). Explicit
+// digit-count callers preserve the previous behaviour exactly.
+// ROUND_HALF_UP applied on the magnitude (so negatives round symmetrically):
+// `Math.round` itself is ROUND_HALF_UP for non-negative numbers (0.5→1,
+// 2.5→3), unlike `toLocaleString` which on Chromium does banker rounding.
+// Note: IEEE 754 means values like 1.005 are stored as 1.00499…, so the
+// half-up boundary lies just below — callers that need exact half-up on
+// decimal strings should pass them as strings and round before formatting.
+export function formatNumberDecimal(value: number | string, decimals?: number): string {
   const n = typeof value === 'string' ? parseFloat(value) : value;
   if (isNaN(n)) return String(value);
-  return n.toLocaleString('th-TH', { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+  const digits = decimals ?? defaultDecimalPlaces;
+  const factor = Math.pow(10, digits);
+  // Round on absolute value so negative inputs use the same half-up direction.
+  const sign = n < 0 ? -1 : 1;
+  const rounded = (sign * Math.round(Math.abs(n) * factor)) / factor;
+  return rounded.toLocaleString('th-TH', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
 }
 
 // Apply format pipe

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -57,7 +57,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.2.3.1 | `default_time_range` | P1 | ⬜ | — | DateRangeChips presets configurable |
 | D1.2.3.2 | `pagination_size` | P1 | ⬜ | — | Central default for list pages |
 | D1.2.3.3 | `date_format` BE↔ค.ศ. toggle | P1 | ⬜ | — | formatDateShort branch on pref |
-| D1.2.3.4 | `decimal_places` | P1 | ⬜ | — | formatNumberDecimal default from pref |
+| D1.2.3.4 | `decimal_places` | P1 | ✅ | this PR | SystemConfig `decimal_places` (default 2, integer 0-4 inclusive; out-of-range/non-integer clamps to 2). `getUiFlags()` exposes `decimalPlaces`; `useUiFlags()` syncs `apps/web/src/utils/formatters.ts` module-level pref via `setDefaultDecimalPlaces()`. `formatNumberDecimal(value, decimals?)` signature: when `decimals` omitted, reads pref; explicit 2nd-arg call sites unchanged (backwards compat). Switched to explicit ROUND_HALF_UP via `Math.round` on absolute scaled value (was banker rounding via `toLocaleString` on some engines). 5 settings spec tests + 6 vitest cases (default 2, override 0, override 4, out-of-range fallback, explicit-arg wins, ROUND_HALF_UP on representable halves like 0.5/2.5). 32/32 formatters tests passing |
 | D1.2.3.5 | `thousands_separator` | P1 | ⬜ | — | toLocaleString locale from pref |
 | D1.2.4.1 | `templates_enabled` flag | P1 | ⬜ | — | Feature flag at controller |
 | D1.2.4.2 | `max_templates_per_user` quota | P1 | ⬜ | — | Count check in createTemplate |


### PR DESCRIPTION
## Summary
- Adds OWNER-configurable `decimal_places` SystemConfig (default 2, valid 0-4 integer, clamp out-of-range to default).
- `getUiFlags()` exposes `decimalPlaces`; `useUiFlags()` syncs module-level pref in `apps/web/src/utils/formatters.ts`.
- `formatNumberDecimal(value, decimals?)` — explicit 2nd arg still wins; omitted = pref. Backwards-compatible.
- Switches to explicit ROUND_HALF_UP (was banker rounding via toLocaleString on some engines).

## Tests
- 5 new jest cases in settings.service.spec.ts (default, override 0, override 4, clamp 5, non-numeric).
- 6 new vitest cases in formatters.test.ts (default omitted, override 0+ROUND, override 4, out-of-range fallback, explicit arg wins, ROUND_HALF_UP on representable halves 0.5/2.5).
- 31/31 settings + 32/32 formatters passing. TypeScript: 0 errors.

## Caveats
- IEEE 754 means `1.005` is stored as `1.00499…`, so ROUND_HALF_UP on the float literal is mathematically impossible without a Decimal library. Documented in function comment + test relies on `0.5` / `2.5` (exact representations). The legacy regex test `/^1\.0[01]$/` for `1.005` stays — it tolerated this ambiguity.

## Test plan
- [x] `cd apps/api && npx tsc --noEmit` — 0 errors
- [x] `cd apps/web && npx tsc --noEmit` — 0 errors
- [x] `cd apps/api && npx jest src/modules/settings/settings.service.spec.ts` — 31/31 pass
- [x] `cd apps/web && npx vitest run src/utils/formatters.test.ts` — 32/32 pass
- [ ] Manual: set `decimal_places=0` via SystemConfig → integer-only views (e.g. dashboard totals) lose decimals
- [ ] Manual: set `decimal_places=4` → fractional rates show 4 decimal places

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>