### PR TITLE
feat(a1): D1.1.3.1 — VAT_RATE/vat_pct orphan-key fix (P0 bug)

### DIFF
--- a/apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql
+++ b/apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql
@@ -1,0 +1,64 @@
+-- D1.1.3.1 follow-up — soft-delete the legacy `vat_pct`/`vat_rate` rows
+-- AFTER PR #940 (the backfill) has been verified.
+--
+-- Why this lives in a SEPARATE manual file from `2026-05-17-merge-vat-rate-keys.sql`:
+--   - The backfill SQL deliberately leaves `vat_pct` in place so the operator
+--     can verify `VAT_RATE` reflects the intended percentage before destroying
+--     the source-of-truth.
+--   - InterestConfigPage previously WROTE to `vat_pct` whenever OWNER saved
+--     defaults — so even after the backfill + admin tab edit, the next time
+--     OWNER opened InterestConfigPage and clicked "บันทึก" the orphan key
+--     would regenerate. The frontend now writes to `VAT_RATE` (PR D1.1.3.1
+--     follow-up, this branch). With both halves in place this cleanup is
+--     idempotent and safe to re-run.
+--
+-- USAGE:
+--   psql "$DATABASE_URL" -f apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql
+--
+-- Operator will be prompted to type `YES_CLEANUP_VAT_PCT`. Anything else aborts.
+
+\set ON_ERROR_STOP on
+
+\echo '----------------------------------------------------------------------'
+\echo 'D1.1.3.1 follow-up — about to soft-delete legacy vat_pct/vat_rate rows.'
+\echo '----------------------------------------------------------------------'
+\echo 'Current VAT-related SystemConfig rows:'
+
+SELECT key, value, deleted_at IS NOT NULL AS soft_deleted
+FROM system_config
+WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate')
+ORDER BY key;
+
+\echo ''
+\echo 'Confirm VAT_RATE above matches the intended percentage (e.g. "7" = 7%).'
+\echo 'After this script runs, vat_pct and vat_rate rows will be soft-deleted.'
+\echo 'The frontend (InterestConfigPage) now writes to VAT_RATE so they will'
+\echo 'not regenerate on next save.'
+\echo ''
+
+\prompt 'Type YES_CLEANUP_VAT_PCT to proceed (anything else aborts): ' CONFIRMATION
+
+SELECT (:'CONFIRMATION' = 'YES_CLEANUP_VAT_PCT') AS proceed \gset
+
+\if :proceed
+  \echo 'Confirmed — soft-deleting legacy keys...'
+\else
+  \echo '!! ABORTED — confirmation string did not match YES_CLEANUP_VAT_PCT.'
+  \echo '!! Nothing was written. Re-run to retry.'
+  \q
+\endif
+
+BEGIN;
+
+-- Soft-delete (so we can revert in emergencies). Idempotent — running twice
+-- is a no-op because `deleted_at IS NULL` filters out already-deleted rows.
+UPDATE system_config
+SET deleted_at = NOW(),
+    updated_at = NOW()
+WHERE key IN ('vat_pct', 'vat_rate')
+  AND deleted_at IS NULL;
+
+COMMIT;
+
+\echo 'Cleanup complete. Verify:'
+\echo 'SELECT key, value, deleted_at FROM system_config WHERE key IN ('"'"'VAT_RATE'"'"', '"'"'vat_pct'"'"', '"'"'vat_rate'"'"');'

--- a/apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
+++ b/apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
@@ -1,0 +1,88 @@
+-- D1.1.3.1 — VAT_RATE/vat_pct orphan-key fix
+--
+-- Manual (NOT auto-applied) migration. Run via psql AFTER verifying that
+-- the legacy `vat_pct` / `vat_rate` rows agree with the operator's intent.
+--
+-- Background:
+--   - Code path 1 (legacy): `purchase-orders.service.ts`, `config.util.ts`,
+--     `InterestConfigPage.tsx` read SystemConfig key `vat_pct` expecting the
+--     DECIMAL form ("0.07" = 7%).
+--   - Code path 2 (newer admin UI): `SettingsPage > VAT` tab (VatTab.tsx)
+--     writes SystemConfig key `VAT_RATE` in the PERCENTAGE form ("7" = 7%).
+--
+-- After PR D1.1.3.1 all readers use the canonical-key-first helper
+-- `loadVatRateDecimal()` which:
+--   1. Reads VAT_RATE   (percentage)
+--   2. Falls back to vat_pct (decimal-or-percent — parser handles both)
+--   3. Falls back to vat_rate (decimal)
+--   4. Defaults to 0.07 (7%)
+--
+-- This SQL is a SAFETY NET — it ensures `VAT_RATE` is populated even if the
+-- operator never touched the new admin tab.
+--
+-- USAGE (single transaction so the file can be re-run safely):
+--   psql $DATABASE_URL -f apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
+--
+-- After running:
+--   1. Verify `SELECT key, value FROM system_config WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate');`
+--   2. Confirm with the OWNER that `VAT_RATE` reflects the intended percent.
+--   3. Once verified, OPTIONALLY delete the legacy keys:
+--        UPDATE system_config SET deleted_at = NOW()
+--        WHERE key IN ('vat_pct', 'vat_rate') AND deleted_at IS NULL;
+--      (We soft-delete so an emergency revert can restore them.)
+
+BEGIN;
+
+-- Step 1: backfill VAT_RATE from legacy `vat_pct` if VAT_RATE is missing.
+-- Stored as a percentage (multiply decimal by 100) — matches the form that
+-- the new admin UI saves and that downstream code's parser expects.
+INSERT INTO system_config (id, key, value, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    'VAT_RATE',
+    CASE
+        WHEN (vp.value)::numeric >= 1 THEN vp.value        -- already percent-shaped
+        ELSE ((vp.value)::numeric * 100)::text             -- decimal → percent
+    END,
+    NOW(),
+    NOW()
+FROM system_config vp
+WHERE vp.key = 'vat_pct'
+  AND vp.deleted_at IS NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM system_config
+      WHERE key = 'VAT_RATE' AND deleted_at IS NULL
+  );
+
+-- Step 2: same backfill from `vat_rate` (decimal form) if neither VAT_RATE
+-- nor vat_pct was present.
+INSERT INTO system_config (id, key, value, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    'VAT_RATE',
+    CASE
+        WHEN (vr.value)::numeric >= 1 THEN vr.value
+        ELSE ((vr.value)::numeric * 100)::text
+    END,
+    NOW(),
+    NOW()
+FROM system_config vr
+WHERE vr.key = 'vat_rate'
+  AND vr.deleted_at IS NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM system_config
+      WHERE key = 'VAT_RATE' AND deleted_at IS NULL
+  );
+
+-- NOTE: legacy keys (`vat_pct`, `vat_rate`) are intentionally LEFT IN PLACE.
+-- Deleting them in the same transaction risks data loss if the SQL is run
+-- against a DB where `VAT_RATE` already exists with a stale value. Operator
+-- should verify VAT_RATE matches the intended percent, then run the
+-- soft-delete UPDATE in the header comment.
+
+COMMIT;
+
+-- Verification query (run separately):
+-- SELECT key, value, created_at, updated_at FROM system_config
+-- WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate')
+-- ORDER BY key;

--- a/apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
+++ b/apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
@@ -3,6 +3,20 @@
 -- Manual (NOT auto-applied) migration. Run via psql AFTER verifying that
 -- the legacy `vat_pct` / `vat_rate` rows agree with the operator's intent.
 --
+-- ============================================================================
+-- !! OPERATOR CONFIRMATION REQUIRED !!
+-- ============================================================================
+-- This file MUST be executed with `psql` so the `\prompt` directive runs.
+-- Running it with anything else (DBeaver "execute file", pgAdmin, copy-paste
+-- into a generic SQL client) will likely SKIP the confirmation gate and
+-- silently execute the backfill — which is exactly what the gate prevents.
+--
+-- Correct invocation:
+--   psql "$DATABASE_URL" -f apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
+--
+-- Operator will be prompted to type `YES_BACKFILL_VAT`. Anything else aborts.
+-- ============================================================================
+--
 -- Background:
 --   - Code path 1 (legacy): `purchase-orders.service.ts`, `config.util.ts`,
 --     `InterestConfigPage.tsx` read SystemConfig key `vat_pct` expecting the
@@ -20,8 +34,32 @@
 -- This SQL is a SAFETY NET — it ensures `VAT_RATE` is populated even if the
 -- operator never touched the new admin tab.
 --
+-- ---------------------------------------------------------------------------
+-- AMBIGUOUS-VALUE EDGE CASE (the reason the gate is mandatory)
+-- ---------------------------------------------------------------------------
+-- The shape detector `(vp.value)::numeric >= 1 THEN value ELSE value * 100`
+-- is a heuristic. It works perfectly for the canonical Thai VAT values:
+--     '0.07'  → '7'    (correct: 7% decimal → 7% percent)
+--     '7'     → '7'    (correct: already percent)
+--     '0.10'  → '10'   (correct, used during temporary 10% VAT period)
+--
+-- It FAILS SILENTLY for unusual stored values:
+--     '0.7'   → '70'   (treats 0.7 as a decimal fraction = 70% VAT;
+--                       likely the operator meant 0.7% — but this script
+--                       cannot tell the two intents apart from the value alone)
+--     '1.0'   → '1'    (interpreted as 1% — likely wrong if intent was 100%)
+--
+-- The operator MUST inspect current row values using the verification query
+-- at the bottom of this file BEFORE typing the confirmation token. If any
+-- value smells wrong (especially 0.7 / 1.0 / values that look like decimal
+-- fractions but are >= 0.1), fix it BY HAND first and re-run.
+--
+-- After this file runs you also need to soft-delete the legacy keys (see
+-- the soft-delete UPDATE in the verification section) so future writers
+-- don't reintroduce the ambiguity.
+--
 -- USAGE (single transaction so the file can be re-run safely):
---   psql $DATABASE_URL -f apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
+--   psql "$DATABASE_URL" -f apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
 --
 -- After running:
 --   1. Verify `SELECT key, value FROM system_config WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate');`
@@ -30,6 +68,49 @@
 --        UPDATE system_config SET deleted_at = NOW()
 --        WHERE key IN ('vat_pct', 'vat_rate') AND deleted_at IS NULL;
 --      (We soft-delete so an emergency revert can restore them.)
+
+\set ON_ERROR_STOP on
+
+\echo '----------------------------------------------------------------------'
+\echo 'D1.1.3.1 VAT_RATE backfill — about to inspect current state.'
+\echo '----------------------------------------------------------------------'
+\echo 'Current VAT-related SystemConfig rows:'
+
+SELECT key, value, deleted_at IS NOT NULL AS soft_deleted
+FROM system_config
+WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate')
+ORDER BY key;
+
+\echo ''
+\echo 'Review the values above. If any value looks ambiguous (e.g. 0.7 / 1.0),'
+\echo 'abort here and fix it by hand first.'
+\echo ''
+
+-- Operator confirmation prompt. Skips the backfill unless the operator
+-- types `YES_BACKFILL_VAT` exactly (case-sensitive). Any other string,
+-- empty input, or running via a client that ignores \prompt → abort.
+\prompt 'Type YES_BACKFILL_VAT to proceed (anything else aborts): ' CONFIRMATION
+
+-- Materialize the comparison into a psql boolean variable via \gset.
+-- We can't use raw "\if :'CONFIRMATION' = 'YES_BACKFILL_VAT'" because
+-- psql's \if does NOT evaluate SQL-like comparison expressions.
+SELECT (:'CONFIRMATION' = 'YES_BACKFILL_VAT') AS proceed \gset
+
+\if :proceed
+  \echo 'Confirmed — running backfill...'
+\else
+  \echo '!! ABORTED — confirmation string did not match YES_BACKFILL_VAT.'
+  \echo '!! Nothing was written. Re-run to retry.'
+  \q
+\endif
+
+-- ============================================================================
+-- Confirmed — backfill below
+-- ============================================================================
+
+-- Ensure gen_random_uuid() is available. pgcrypto is enabled on GCP Cloud SQL
+-- by default; this CREATE is idempotent and protects fresh local databases.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 BEGIN;
 
@@ -81,6 +162,8 @@ WHERE vr.key = 'vat_rate'
 -- soft-delete UPDATE in the header comment.
 
 COMMIT;
+
+\echo 'Backfill complete. Run the verification query below to confirm the result.'
 
 -- Verification query (run separately):
 -- SELECT key, value, created_at, updated_at FROM system_config

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -124,6 +124,8 @@ import { CollectionsSessionModule } from './modules/collections-session/collecti
 import { AuditInterceptor } from './modules/audit/audit.interceptor';
 import { SecurityMiddleware } from './modules/audit/security.middleware';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
+// D1.1.3.1 — One-shot startup warning for VAT_RATE/vat_pct orphan keys.
+import { VatRateBootstrapService } from './utils/vat-rate-bootstrap.service';
 import { CsrfGuard } from './guards/csrf.guard';
 import { JwtAudienceGuard } from './modules/auth/guards/jwt-audience.guard';
 import { AppCacheModule } from './cache/cache.module';
@@ -353,6 +355,10 @@ import { AppCacheModule } from './cache/cache.module';
       provide: APP_INTERCEPTOR,
       useClass: AuditInterceptor,
     },
+    // D1.1.3.1 — VAT_RATE orphan-key bootstrap warning. No exports, no
+    // controllers — just a one-shot OnModuleInit that warns when both the
+    // canonical VAT_RATE and a legacy vat_pct/vat_rate row coexist.
+    VatRateBootstrapService,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { CreatePODto, UpdatePODto, ReceivePODto, GoodsReceivingDto, UpdatePaymentDto } from './dto/create-po.dto';
 import { generatePONumber } from '../../utils/sequence.util';
 import { d, dAdd, dSub, dSum } from '../../utils/decimal.util';
+import { loadVatRateDecimal } from '../../utils/vat-rate.util';
 
 @Injectable()
 export class PurchaseOrdersService {
@@ -96,8 +97,12 @@ export class PurchaseOrdersService {
     const discount = dto.discount || 0; // ส่วนลดก่อน VAT
     const discountAfterVat = supplier.hasVat ? dto.discountAfterVat || 0 : 0; // ส่วนลดหลัง VAT (เฉพาะ supplier มี VAT)
     const subtotalAfterDiscount = totalAmount - discount;
-    const vatConfig = await this.prisma.systemConfig.findUnique({ where: { key: 'vat_pct' } });
-    const vatRate = vatConfig ? Number(vatConfig.value) : 0.07;
+    // D1.1.3.1 — resolve VAT via canonical-key-first helper. Reads VAT_RATE
+    // (percent) first, falls back to legacy vat_pct/vat_rate (decimal), or
+    // 0.07 if all are absent. Replaces the previous direct `vat_pct` lookup
+    // that silently returned the default when admins saved through the new
+    // VatTab UI (which writes VAT_RATE).
+    const vatRate = await loadVatRateDecimal(this.prisma);
     const vatAmount = supplier.hasVat ? Math.round(subtotalAfterDiscount * vatRate * 100) / 100 : 0;
     const netAmount = subtotalAfterDiscount + vatAmount - discountAfterVat;
 

--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -93,6 +93,51 @@ describe('SettingsService audit trail', () => {
     expect(actions).toContain('SYSTEM_CONFIG_CREATE');
   });
 
+  // D1.1.3.1 follow-up — VAT-rate write normalisation.
+  describe('bulkUpdate VAT_RATE normalisation', () => {
+    beforeEach(() => {
+      // Mock the upsert side-effect so we can read the call args.
+      prisma.systemConfig.upsert = jest.fn(
+        (args: { where: { key: string }; update: { value: string }; create: { key: string; value: string } }) =>
+          Promise.resolve({ id: 'sc-1', key: args.where.key, value: args.update.value }),
+      );
+    });
+
+    it('rewrites vat_pct decimal form to VAT_RATE percent form', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      await service.bulkUpdate([{ key: 'vat_pct', value: '0.07' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+
+    it('passes through VAT_RATE writes unchanged', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      await service.bulkUpdate([{ key: 'VAT_RATE', value: '7' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+
+    it('rewrites legacy vat_rate alias the same way as vat_pct', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      await service.bulkUpdate([{ key: 'vat_rate', value: '0.07' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+
+    it('preserves percent-form value sent under vat_pct (operator confusion)', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      // Operator types "7" into a field labelled vat_pct — that's percent,
+      // not decimal. Heuristic treats >=1 as already percent.
+      await service.bulkUpdate([{ key: 'vat_pct', value: '7' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+  });
+
   it('audit failure does NOT block config update (audit.log is fire-and-forget-style)', async () => {
     prisma.systemConfig.findUnique.mockResolvedValue({ value: 'old' });
     audit.log.mockRejectedValue(new Error('audit DB down'));

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -248,7 +248,46 @@ export class SettingsService {
     return { dailyCap, workloadFloor, etaPerContractMin, sessionTargetMin, selfClaimLockHours };
   }
 
+  /**
+   * D1.1.3.1 follow-up — defensive normalisation for VAT-rate writes.
+   *
+   * Legacy frontends (or operators using a generic SQL client) may still
+   * send `{ key: 'vat_pct', value: '0.07' }` to `/settings`. After PR #940
+   * (the canonical `VAT_RATE` migration) any such write resurrects the
+   * orphan key and `VatRateBootstrapService` warns on the next boot.
+   *
+   * This helper rewrites the item in-place: `vat_pct` writes become
+   * `VAT_RATE` writes, converting decimal form to percent form when
+   * needed. `vat_rate` (older legacy) treated the same. Already-canonical
+   * `VAT_RATE` items pass through unchanged.
+   *
+   * Idempotent: if both legacy and canonical keys are sent in the same
+   * batch, the canonical wins (last write wins inside the same batch).
+   */
+  private normaliseVatRateWrites(
+    items: { key: string; value: string }[],
+  ): { key: string; value: string }[] {
+    return items.map((item) => {
+      if (item.key !== 'vat_pct' && item.key !== 'vat_rate') return item;
+      const trimmed = String(item.value ?? '').trim();
+      if (!trimmed) return { key: 'VAT_RATE', value: '' };
+      const n = Number(trimmed);
+      if (!Number.isFinite(n) || n < 0) {
+        return { key: 'VAT_RATE', value: trimmed };
+      }
+      // Values < 1 are decimal-form ('0.07') → multiply by 100 for percent.
+      // Values >= 1 are already percent-form. Round to 4 decimal places so
+      // floating-point math (0.07*100=7.000000000000001) doesn't leak into
+      // the audit log or back to the UI.
+      const asPercent = n < 1 ? n * 100 : n;
+      const rounded = Math.round(asPercent * 10000) / 10000;
+      return { key: 'VAT_RATE', value: String(rounded) };
+    });
+  }
+
   async bulkUpdate(items: { key: string; value: string }[], userId?: string) {
+    // D1.1.3.1 follow-up — rewrite legacy VAT keys before persist.
+    items = this.normaliseVatRateWrites(items);
     // Fetch "before" snapshot in one query so the transaction stays bounded.
     const keys = items.map((i) => i.key);
     const existing = await this.prisma.systemConfig.findMany({

--- a/apps/api/src/utils/config.util.ts
+++ b/apps/api/src/utils/config.util.ts
@@ -3,6 +3,7 @@
  * Eliminates duplication of config loading pattern across services
  */
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_VAT_DECIMAL, parseVatValue } from './vat-rate.util';
 
 const INSTALLMENT_CONFIG_KEYS = [
   'interest_rate',
@@ -10,7 +11,12 @@ const INSTALLMENT_CONFIG_KEYS = [
   'min_installment_months',
   'max_installment_months',
   'store_commission_pct',
+  // D1.1.3.1 — VAT rate now lives under canonical `VAT_RATE` (percentage form)
+  // with `vat_pct` retained as a legacy fallback. Both are fetched here; the
+  // resolution helper below picks the first one that parses.
+  'VAT_RATE',
   'vat_pct',
+  'vat_rate',
 ] as const;
 
 export interface InstallmentConfig {
@@ -69,13 +75,24 @@ export async function loadInstallmentConfig(
     return Math.round(raw * 10000) / 10000; // Round to 4 decimal places for rate precision
   };
 
+  // D1.1.3.1 — Resolve VAT rate with the canonical-key-first fallback chain.
+  // VAT_RATE (percent) → vat_pct (decimal) → vat_rate (decimal) → default.
+  const resolveVatPct = (): number => {
+    for (const k of ['VAT_RATE', 'vat_pct', 'vat_rate']) {
+      const row = configs.find((c) => c.key === k);
+      const parsed = parseVatValue(row?.value);
+      if (parsed != null) return Math.round(parsed * 10000) / 10000;
+    }
+    return DEFAULT_VAT_DECIMAL;
+  };
+
   return {
     interestRate: getValue('interest_rate', DEFAULTS.interestRate),
     minDownPaymentPct: getValue('min_down_payment_pct', DEFAULTS.minDownPaymentPct),
     minInstallmentMonths: getValue('min_installment_months', DEFAULTS.minInstallmentMonths),
     maxInstallmentMonths: getValue('max_installment_months', DEFAULTS.maxInstallmentMonths),
     storeCommissionPct: getValue('store_commission_pct', DEFAULTS.storeCommissionPct),
-    vatPct: getValue('vat_pct', DEFAULTS.vatPct),
+    vatPct: resolveVatPct(),
   };
 }
 

--- a/apps/api/src/utils/vat-rate-bootstrap.service.ts
+++ b/apps/api/src/utils/vat-rate-bootstrap.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { warnIfVatKeysCollide } from './vat-rate.util';
+
+/**
+ * D1.1.3.1 — One-shot bootstrap warning for the VAT_RATE/vat_pct/vat_rate
+ * orphan-key situation. Runs once per app boot, logs at WARN if both the
+ * canonical and a legacy key are present, otherwise silent.
+ *
+ * Intentionally a tiny service rather than inline in AppModule:
+ *   - Single responsibility, easy to unit-test
+ *   - Keeps `app.module.ts` providers list focused on framework wiring
+ *   - DB read failures swallow inside `warnIfVatKeysCollide` itself, so
+ *     this can never block startup
+ */
+@Injectable()
+export class VatRateBootstrapService implements OnModuleInit {
+  private readonly logger = new Logger(VatRateBootstrapService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit(): Promise<void> {
+    await warnIfVatKeysCollide(this.prisma);
+    this.logger.debug('[D1.1.3.1] VAT_RATE orphan-key check complete');
+  }
+}

--- a/apps/api/src/utils/vat-rate.util.spec.ts
+++ b/apps/api/src/utils/vat-rate.util.spec.ts
@@ -1,0 +1,173 @@
+import {
+  parseVatValue,
+  loadVatRateDecimal,
+  loadVatRatePercent,
+  warnIfVatKeysCollide,
+  DEFAULT_VAT_DECIMAL,
+  DEFAULT_VAT_PERCENT,
+} from './vat-rate.util';
+import { Logger } from '@nestjs/common';
+
+describe('vat-rate.util — D1.1.3.1 canonical key with legacy fallback', () => {
+  describe('parseVatValue heuristic', () => {
+    it('treats values >= 1 as percentage form ("7" → 0.07)', () => {
+      expect(parseVatValue('7')).toBeCloseTo(0.07, 8);
+      expect(parseVatValue('10')).toBeCloseTo(0.1, 8);
+    });
+
+    it('treats values < 1 as decimal form ("0.07" → 0.07)', () => {
+      expect(parseVatValue('0.07')).toBeCloseTo(0.07, 8);
+      expect(parseVatValue('0.10')).toBeCloseTo(0.1, 8);
+    });
+
+    it('returns null for malformed values', () => {
+      expect(parseVatValue('abc')).toBeNull();
+      expect(parseVatValue('')).toBeNull();
+      expect(parseVatValue(null)).toBeNull();
+      expect(parseVatValue(undefined)).toBeNull();
+      expect(parseVatValue('-1')).toBeNull(); // negative
+    });
+  });
+
+  describe('loadVatRateDecimal — canonical-key-first precedence', () => {
+    const mkPrisma = (rows: { key: string; value: string }[]) => ({
+      systemConfig: {
+        findMany: jest.fn().mockResolvedValue(rows),
+      },
+    });
+
+    it('returns VAT_RATE value when present (percentage form)', async () => {
+      const prisma = mkPrisma([{ key: 'VAT_RATE', value: '7' }]);
+      const result = await loadVatRateDecimal(prisma);
+      expect(result).toBeCloseTo(0.07, 8);
+    });
+
+    it('falls back to legacy vat_pct (decimal form) when VAT_RATE absent', async () => {
+      const prisma = mkPrisma([{ key: 'vat_pct', value: '0.07' }]);
+      const result = await loadVatRateDecimal(prisma);
+      expect(result).toBeCloseTo(0.07, 8);
+    });
+
+    it('falls back to legacy vat_pct percentage form too (data drift)', async () => {
+      // If somehow vat_pct was saved as "7" (percent shape), the parser still
+      // resolves it correctly via the >=1 → /100 heuristic.
+      const prisma = mkPrisma([{ key: 'vat_pct', value: '7' }]);
+      const result = await loadVatRateDecimal(prisma);
+      expect(result).toBeCloseTo(0.07, 8);
+    });
+
+    it('prefers VAT_RATE over vat_pct when BOTH present', async () => {
+      // Realistic post-migration state — both keys live until orphan is cleaned.
+      const prisma = mkPrisma([
+        { key: 'VAT_RATE', value: '10' },        // new admin UI saved 10%
+        { key: 'vat_pct', value: '0.07' },       // legacy seed value
+      ]);
+      const result = await loadVatRateDecimal(prisma);
+      expect(result).toBeCloseTo(0.1, 8); // VAT_RATE wins
+    });
+
+    it('defaults to 7% when no key is present', async () => {
+      const prisma = mkPrisma([]);
+      const result = await loadVatRateDecimal(prisma);
+      expect(result).toBe(DEFAULT_VAT_DECIMAL);
+    });
+
+    it('falls back to default when stored VAT_RATE is malformed', async () => {
+      const prisma = mkPrisma([{ key: 'VAT_RATE', value: 'banana' }]);
+      const result = await loadVatRateDecimal(prisma);
+      expect(result).toBe(DEFAULT_VAT_DECIMAL);
+    });
+
+    it('falls through to vat_rate when VAT_RATE+vat_pct both malformed', async () => {
+      const prisma = mkPrisma([
+        { key: 'VAT_RATE', value: '' },
+        { key: 'vat_pct', value: 'NaN' },
+        { key: 'vat_rate', value: '0.07' },
+      ]);
+      const result = await loadVatRateDecimal(prisma);
+      expect(result).toBeCloseTo(0.07, 8);
+    });
+  });
+
+  describe('loadVatRatePercent', () => {
+    it('returns percent form (e.g. 7 for 7%)', async () => {
+      const prisma = {
+        systemConfig: { findMany: jest.fn().mockResolvedValue([{ key: 'VAT_RATE', value: '7' }]) },
+      };
+      const result = await loadVatRatePercent(prisma);
+      expect(result).toBeCloseTo(7, 8);
+    });
+
+    it('defaults to 7 when no key set', async () => {
+      const prisma = { systemConfig: { findMany: jest.fn().mockResolvedValue([]) } };
+      const result = await loadVatRatePercent(prisma);
+      // toBeCloseTo handles the harmless 0.07 × 100 = 7.000000000000001 float artifact
+      expect(result).toBeCloseTo(DEFAULT_VAT_PERCENT, 8);
+    });
+  });
+
+  describe('warnIfVatKeysCollide — bootstrap orphan-key check', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns when VAT_RATE and vat_pct both present', async () => {
+      const prisma = {
+        systemConfig: {
+          findMany: jest.fn().mockResolvedValue([
+            { key: 'VAT_RATE', value: '7' },
+            { key: 'vat_pct', value: '0.07' },
+          ]),
+        },
+      } as unknown as Parameters<typeof warnIfVatKeysCollide>[0];
+
+      await warnIfVatKeysCollide(prisma);
+
+      expect(warnSpy).toHaveBeenCalled();
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toMatch(/orphan key should be removed manually/);
+      expect(msg).toMatch(/vat_pct/);
+    });
+
+    it('does NOT warn when only VAT_RATE present', async () => {
+      const prisma = {
+        systemConfig: {
+          findMany: jest.fn().mockResolvedValue([{ key: 'VAT_RATE', value: '7' }]),
+        },
+      } as unknown as Parameters<typeof warnIfVatKeysCollide>[0];
+
+      await warnIfVatKeysCollide(prisma);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT warn when only legacy vat_pct present', async () => {
+      const prisma = {
+        systemConfig: {
+          findMany: jest.fn().mockResolvedValue([{ key: 'vat_pct', value: '0.07' }]),
+        },
+      } as unknown as Parameters<typeof warnIfVatKeysCollide>[0];
+
+      await warnIfVatKeysCollide(prisma);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('swallows DB errors silently (boot should not crash)', async () => {
+      const prisma = {
+        systemConfig: {
+          findMany: jest.fn().mockRejectedValue(new Error('DB unreachable')),
+        },
+      } as unknown as Parameters<typeof warnIfVatKeysCollide>[0];
+
+      await expect(warnIfVatKeysCollide(prisma)).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/utils/vat-rate.util.ts
+++ b/apps/api/src/utils/vat-rate.util.ts
@@ -1,0 +1,151 @@
+/**
+ * D1.1.3.1 — Canonical VAT-rate loader with legacy-key fallback.
+ *
+ * History: the VAT-rate setting accumulated two different SystemConfig keys
+ * over time:
+ *   - `vat_pct`  — legacy decimal form (`"0.07"` = 7%). Read by
+ *     `config.util.ts::loadInstallmentConfig`, `purchase-orders.service.ts`,
+ *     and the `InterestConfigPage` admin form.
+ *   - `VAT_RATE` — newer percentage form (`"7"` = 7%). Written by the
+ *     `SettingsPage > VAT` tab admin UI.
+ *
+ * When the OWNER edits "อัตรา VAT" via the new admin tab they save `"7"`
+ * to `VAT_RATE`, but downstream code (purchase orders, installment params,
+ * etc.) still keys off `vat_pct` and ends up using the seeded default 7%.
+ * Worse, a stray `vat_pct = "7"` row (saved by a confused operator) would
+ * be parsed as 700% — silent overcharge.
+ *
+ * Resolution:
+ *   - Canonical key going forward is **`VAT_RATE`**. Value stored as a
+ *     percentage (e.g. `"7"`). This matches the visible admin label
+ *     "อัตรา VAT (%)" and avoids the decimal-vs-percent ambiguity.
+ *   - This helper reads `VAT_RATE` first. If absent, falls back to the
+ *     legacy `vat_pct` (decimal form) or the also-legacy `vat_rate` (which
+ *     never had a writer but appeared in earlier drafts).
+ *   - A bootstrap warning is logged when both keys coexist so operations
+ *     can clean up the orphan after verifying.
+ *
+ * Default: 7 (Thailand standard VAT rate).
+ *
+ * Caller picks the form they need via `asDecimal()` (e.g. 0.07) or
+ * `asPercent()` (e.g. 7).
+ */
+import { Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+const log = new Logger('VatRateUtil');
+
+/** Default VAT rate as a percentage (7%). */
+export const DEFAULT_VAT_PERCENT = 7;
+/** Default VAT rate as a decimal (0.07). */
+export const DEFAULT_VAT_DECIMAL = 0.07;
+
+/** Minimal Prisma surface — accepts both PrismaService and a transaction client. */
+type SystemConfigReader = {
+  systemConfig: {
+    findMany: (
+      ...args: unknown[]
+    ) => Promise<{ key: string; value: string }[]>;
+  };
+};
+
+/**
+ * Parses a raw SystemConfig value into a decimal VAT rate (e.g. 0.07).
+ * Returns null if the value is malformed (caller decides fallback).
+ *
+ * Heuristic: values >= 1 are treated as percentages, values < 1 as decimal
+ * fractions. So `"7"` → 0.07 and `"0.07"` → 0.07. `"700"` (clearly nonsense)
+ * still passes through but caller can clamp.
+ */
+export function parseVatValue(raw: string | null | undefined): number | null {
+  if (raw == null) return null;
+  const trimmed = String(raw).trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return null;
+  if (n < 0) return null;
+  // Anything >= 1 is treated as a percentage form (`"7"` = 7%).
+  // Anything < 1 is treated as the decimal fraction form (`"0.07"` = 7%).
+  return n >= 1 ? n / 100 : n;
+}
+
+/**
+ * Look up VAT rate from SystemConfig with legacy-key fallback.
+ *
+ * Order of precedence:
+ *   1. `VAT_RATE`  (canonical, percentage form)
+ *   2. `vat_pct`   (legacy, decimal form OR — in misconfigured DBs —
+ *                   percentage form). The shared `parseVatValue` handles
+ *                   both shapes.
+ *   3. `vat_rate`  (older legacy, decimal form)
+ *
+ * Returns the decimal form (e.g. 0.07) so caller-side math is uniform.
+ * Falls back to {@link DEFAULT_VAT_DECIMAL} when no key is set.
+ */
+export async function loadVatRateDecimal(
+  prisma: SystemConfigReader,
+): Promise<number> {
+  const rows = await prisma.systemConfig.findMany({
+    where: { key: { in: ['VAT_RATE', 'vat_pct', 'vat_rate'] }, deletedAt: null },
+    select: { key: true, value: true },
+  });
+  const byKey = new Map(rows.map((r) => [r.key, r.value]));
+
+  // Preference order. The first key whose value PARSES wins.
+  for (const k of ['VAT_RATE', 'vat_pct', 'vat_rate'] as const) {
+    const parsed = parseVatValue(byKey.get(k));
+    if (parsed != null) return parsed;
+  }
+  return DEFAULT_VAT_DECIMAL;
+}
+
+/**
+ * Same as {@link loadVatRateDecimal} but returns percentage form (e.g. 7).
+ */
+export async function loadVatRatePercent(
+  prisma: SystemConfigReader,
+): Promise<number> {
+  const decimal = await loadVatRateDecimal(prisma);
+  return decimal * 100;
+}
+
+/**
+ * Bootstrap warning — call once at app startup. If both the canonical
+ * `VAT_RATE` and the legacy `vat_pct`/`vat_rate` keys are present in
+ * SystemConfig, log a warning so operators clean up the orphan after
+ * verifying values agree.
+ *
+ * Silently no-ops when:
+ *   - PrismaService is not connected yet (caller wraps in try/catch)
+ *   - Only one (or zero) key(s) present (typical post-migration state)
+ */
+export async function warnIfVatKeysCollide(prisma: PrismaService): Promise<void> {
+  try {
+    const rows = await prisma.systemConfig.findMany({
+      where: { key: { in: ['VAT_RATE', 'vat_pct', 'vat_rate'] }, deletedAt: null },
+      select: { key: true, value: true },
+    });
+    const present = new Set(rows.map((r) => r.key));
+    const hasCanonical = present.has('VAT_RATE');
+    const hasLegacy = present.has('vat_pct') || present.has('vat_rate');
+    if (hasCanonical && hasLegacy) {
+      const legacyKeys = ['vat_pct', 'vat_rate'].filter((k) => present.has(k));
+      const summary = rows
+        .map((r) => `${r.key}=${r.value}`)
+        .join(', ');
+      log.warn(
+        `[D1.1.3.1] Found legacy ${legacyKeys.join('/')} alongside VAT_RATE — ` +
+          `orphan key should be removed manually after verification. ` +
+          `(current values: ${summary})`,
+      );
+    }
+  } catch (err) {
+    // Boot-time read failures are non-fatal — config helpers fall back to
+    // defaults at use-time. We don't want a transient DB blip to crash startup.
+    log.debug(
+      `[D1.1.3.1] warnIfVatKeysCollide skipped: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}

--- a/apps/web/src/pages/InterestConfigPage.tsx
+++ b/apps/web/src/pages/InterestConfigPage.tsx
@@ -277,7 +277,8 @@ export default function InterestConfigPage() {
                   </div>
                   <div>
                     <div className="text-xs text-muted-foreground">VAT</div>
-                    <div className="text-lg font-bold">{defaults['vat_pct'] || '-'}</div>
+                    {/* D1.1.3.1 — prefer canonical VAT_RATE key, fall back to legacy vat_pct */}
+                    <div className="text-lg font-bold">{defaults['VAT_RATE'] || defaults['vat_pct'] || '-'}</div>
                   </div>
                 </div>
               </>

--- a/apps/web/src/pages/InterestConfigPage.tsx
+++ b/apps/web/src/pages/InterestConfigPage.tsx
@@ -67,12 +67,36 @@ function validateForm(form: typeof defaultForm): FormErrors {
   return errors;
 }
 
+/**
+ * D1.1.3.1 follow-up — InterestConfigPage now writes to canonical `VAT_RATE`
+ * (percentage form, e.g. "7") instead of legacy `vat_pct` (decimal form,
+ * e.g. "0.07"). The display + save logic for VAT below handles legacy reads
+ * (decimal form → multiply by 100 for display) so the same OWNER can swap
+ * between this page and `/settings#vat` without seeing 700% or 0.07%.
+ *
+ * Other keys (`interest_rate`, `min_down_payment_pct`, `store_commission_pct`)
+ * remain in decimal form — those don't have a canonical-key counterpart yet.
+ */
 const defaultKeys = [
   { key: 'interest_rate', label: 'อัตราดอกเบี้ยต่อเดือน (Flat rate)', step: '0.01' },
   { key: 'min_down_payment_pct', label: 'เงินดาวน์ขั้นต่ำ (%)', step: '0.01' },
   { key: 'store_commission_pct', label: 'ค่าคอมหน้าร้าน (เช่น 0.10 = 10%)', step: '0.01' },
-  { key: 'vat_pct', label: 'VAT (เช่น 0.07 = 7%)', step: '0.01' },
+  { key: 'VAT_RATE', label: 'VAT (%) — เช่น 7 = 7%', step: '0.01' },
 ];
+
+/**
+ * Mirror of `parseVatValue` from `apps/api/src/utils/vat-rate.util.ts` —
+ * converts a raw SystemConfig VAT value into the percent-form string used
+ * by this editor. `"7"` stays "7", `"0.07"` becomes "7", malformed → "7".
+ */
+function toVatPercentString(raw: string | null | undefined): string {
+  if (raw == null || String(raw).trim() === '') return '7';
+  const n = Number(String(raw).trim());
+  if (!Number.isFinite(n) || n < 0) return '7';
+  // Values < 1 are decimal form ("0.07") → multiply by 100.
+  // Values >= 1 are percent form ("7") → unchanged.
+  return String(n < 1 ? n * 100 : n);
+}
 
 export default function InterestConfigPage() {
   const queryClient = useQueryClient();
@@ -98,6 +122,14 @@ export default function InterestConfigPage() {
     if (systemConfigs.length > 0 && !defaultsChangedRef.current) {
       const map: Record<string, string> = {};
       systemConfigs.forEach((c) => { map[c.key] = c.value; });
+      // D1.1.3.1 follow-up — VAT_RATE editor stores percentage form ("7"),
+      // but legacy `vat_pct` rows may still contain decimal form ("0.07").
+      // If canonical key absent + legacy present, hydrate the editor with
+      // the canonical key's value derived from the legacy form so the
+      // user sees the expected percent in the input.
+      if (!map['VAT_RATE'] && (map['vat_pct'] || map['vat_rate'])) {
+        map['VAT_RATE'] = toVatPercentString(map['vat_pct'] || map['vat_rate']);
+      }
       setDefaults(map);
     }
   }, [systemConfigs]);
@@ -277,8 +309,9 @@ export default function InterestConfigPage() {
                   </div>
                   <div>
                     <div className="text-xs text-muted-foreground">VAT</div>
-                    {/* D1.1.3.1 — prefer canonical VAT_RATE key, fall back to legacy vat_pct */}
-                    <div className="text-lg font-bold">{defaults['VAT_RATE'] || defaults['vat_pct'] || '-'}</div>
+                    {/* D1.1.3.1 follow-up — canonical VAT_RATE (percent) only.
+                        Legacy vat_pct/vat_rate normalised at hydrate-time. */}
+                    <div className="text-lg font-bold">{defaults['VAT_RATE'] ? `${defaults['VAT_RATE']}%` : '-'}</div>
                   </div>
                 </div>
               </>

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -104,7 +104,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.1.2.3 | `reset_cycle` | P0 | ⬜ | Q3 | |
 | D1.1.2.4 | `sequence_table` | P0 | ⬜ | Q3 | |
 | D1.1.2.5 | Admin reset capability | P0 | ⬜ | Q3 | |
-| D1.1.3.1 | `vat_rate` (Q6 P0 bug fix first) | P0 | ⬜ | Q6 | **VAT_RATE/vat_pct orphan-key fix** |
+| D1.1.3.1 | `vat_rate` (Q6 P0 bug fix first) | P0 | ✅ | this PR | **VAT_RATE/vat_pct orphan-key fix.** New `apps/api/src/utils/vat-rate.util.ts` — canonical-key-first loader (`loadVatRateDecimal`/`loadVatRatePercent`) reads `VAT_RATE` (percent form) → falls back to legacy `vat_pct` (decimal-or-percent) → `vat_rate` (decimal) → default 0.07. Heuristic: values ≥1 treated as percent (auto-divide by 100), values <1 as decimal. Migrated `purchase-orders.service.ts` + `config.util.ts::loadInstallmentConfig` + `InterestConfigPage.tsx` display. New `VatRateBootstrapService` logs WARN on startup when both canonical+legacy keys coexist. Manual SQL at `apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql` backfills `VAT_RATE` from `vat_pct` if missing (idempotent INSERT … WHERE NOT EXISTS). 16/16 jest cases (parseVatValue + loadVatRateDecimal precedence + percent + warn-collide). Type-check 0 errors |
 | D1.1.3.2 | `wht_rates` (1/3/5/10/15) | P0 | ⬜ | — | Mostly unblocked — extend SelectItem + table |
 | D1.1.3.3 | `sso_rate` (locked at 5% by law) | P0 | ⬜ | — | Just document the lock in service comment |
 | D1.1.3.5 | effective_date support | P0 | ⬜ | — | Per-rate effective dates |


### PR DESCRIPTION
## Summary
- **D1 item #18** — fixes a P0 SystemConfig key-name inconsistency that caused silent VAT-rate misconfiguration. The new admin VatTab saves to `VAT_RATE` (percent form, "7"), but every consumer keys off `vat_pct` (decimal form, "0.07") and falls back to the seeded default 7% — so OWNER edits had no effect downstream.
- New canonical-key-first helper `loadVatRateDecimal()` (apps/api/src/utils/vat-rate.util.ts) with parseVatValue heuristic: values ≥1 → percent, <1 → decimal.
- Bootstrap warning logs WARN when both canonical+legacy keys coexist.
- Manual SQL backfills `VAT_RATE` from `vat_pct` (idempotent INSERT… WHERE NOT EXISTS) — operator runs after verifying values.

## Files Changed
- `apps/api/src/utils/vat-rate.util.ts` (new) — canonical loader + parser
- `apps/api/src/utils/vat-rate-bootstrap.service.ts` (new) — OnModuleInit warning
- `apps/api/src/utils/vat-rate.util.spec.ts` (new) — 16 jest cases
- `apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql` (new) — manual backfill
- `apps/api/src/utils/config.util.ts` — loadInstallmentConfig now uses helper
- `apps/api/src/modules/purchase-orders/purchase-orders.service.ts` — PO VAT calc uses helper
- `apps/api/src/app.module.ts` — wire bootstrap service
- `apps/web/src/pages/InterestConfigPage.tsx` — display prefers VAT_RATE, falls back to vat_pct
- `docs/superpowers/tracking/D1-settings-implement.md` — mark item done

## Behavior
- **Before:** OWNER saves "7" via VAT tab → VAT_RATE='7' written → purchase orders still reads vat_pct → falls back to 0.07 (7%). Coincidentally correct only because default = 7%. Any non-7% edit silently lost.
- **After:** All readers call `loadVatRateDecimal()` which reads VAT_RATE first. Edits propagate to PO VAT, installment config, and InterestConfig display.

## Test plan
- [x] `cd apps/api && npx tsc --noEmit` — 0 errors
- [x] `cd apps/web && npx tsc --noEmit` — 0 errors
- [x] `npx jest --testPathPattern=vat-rate.util.spec` — 16/16 pass
- [ ] Smoke test: OWNER sets VAT_RATE='10' via Settings → create a PO with VAT supplier → verify vatAmount uses 10% (not default 7%)
- [ ] Verify bootstrap warning fires when both keys present in dev DB
- [ ] Run manual SQL on staging DB and verify VAT_RATE backfilled from vat_pct

🤖 Generated with [Claude Code](https://claude.com/claude-code)