### PR TITLE
feat(a1): D1.1.2.4 — doc_sequence_table_enabled forward-extension flag

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/cn-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/cn-lifecycle.integration.spec.ts
@@ -56,7 +56,9 @@ describe('Credit Note lifecycle (integration)', () => {
     const settlement = new VendorSettlementTemplate(journal, prisma as never);
     return new ExpenseDocumentsService(
       prisma as never,
-      new DocNumberService(),
+      // D1.1.2.4 — DocNumberService now takes SettingsService; integration
+      // tests pass a stub that returns null (→ sequence-table flag = false).
+      new DocNumberService({ getKey: async () => null } as never),
       new StatusTransitionService(),
       sameDay,
       accrual,

--- a/apps/api/src/modules/expense-documents/__tests__/doc-number.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/doc-number.service.spec.ts
@@ -1,10 +1,13 @@
 import { DocNumberService } from '../services/doc-number.service';
+import { SettingsService } from '../../settings/settings.service';
 import type { Prisma } from '@prisma/client';
 
 describe('DocNumberService', () => {
   let service: DocNumberService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let tx: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let settings: any;
 
   beforeEach(() => {
     tx = {
@@ -13,7 +16,10 @@ describe('DocNumberService', () => {
         findFirst: jest.fn(),
       },
     };
-    service = new DocNumberService();
+    settings = {
+      getKey: jest.fn().mockResolvedValue(null), // default: flag off
+    };
+    service = new DocNumberService(settings as unknown as SettingsService);
   });
 
   it('returns EX-YYYYMMDD-0001 for first EXPENSE on given date', async () => {
@@ -63,8 +69,7 @@ describe('DocNumberService', () => {
     expect(num).toBe('EX-20260511-0001');
   });
 
-  // W4 — explicit throw when seq overflows 4-digit slot (rather than silently
-  // emitting EX-YYYYMMDD-10000 which sorts wrong and breaks downstream parsers).
+  // W4 — explicit throw when seq overflows 4-digit slot.
   it('W4: throws when seq exceeds 9999 for a day', async () => {
     tx.expenseDocument.findFirst.mockResolvedValue({ number: 'EX-20260510-9999' });
     await expect(
@@ -76,5 +81,31 @@ describe('DocNumberService', () => {
     tx.expenseDocument.findFirst.mockResolvedValue({ number: 'EX-20260510-9998' });
     const num = await service.next(tx, 'EXPENSE', new Date('2026-05-10T12:00:00Z'));
     expect(num).toBe('EX-20260510-9999');
+  });
+
+  // D1.1.2.4 — sequence_table feature flag stub.
+  describe('D1.1.2.4 — doc_sequence_table_enabled flag', () => {
+    it('flag=true throws NotImplementedException without touching the DB', async () => {
+      settings.getKey.mockResolvedValue('true');
+      await expect(
+        service.next(tx, 'EXPENSE', new Date('2026-05-10T12:00:00Z')),
+      ).rejects.toThrow(/Sequence table mode not implemented/);
+      expect(tx.expenseDocument.findFirst).not.toHaveBeenCalled();
+      expect(tx.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('flag=false (default) uses the advisory-lock fast path', async () => {
+      settings.getKey.mockResolvedValue('false');
+      tx.expenseDocument.findFirst.mockResolvedValue(null);
+      const num = await service.next(tx, 'EXPENSE', new Date('2026-05-10T12:00:00Z'));
+      expect(num).toBe('EX-20260510-0001');
+    });
+
+    it('defensive: SettingsService throw is treated as flag=false', async () => {
+      settings.getKey.mockRejectedValue(new Error('db down'));
+      tx.expenseDocument.findFirst.mockResolvedValue(null);
+      const num = await service.next(tx, 'EXPENSE', new Date('2026-05-10T12:00:00Z'));
+      expect(num).toBe('EX-20260510-0001');
+    });
   });
 });

--- a/apps/api/src/modules/expense-documents/__tests__/full-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/full-lifecycle.integration.spec.ts
@@ -97,7 +97,9 @@ describe('ExpenseDocuments full lifecycle (integration)', () => {
     const settlement = new VendorSettlementTemplate(journal, prisma as never);
     return new ExpenseDocumentsService(
       prisma as never,
-      new DocNumberService(),
+      // D1.1.2.4 — DocNumberService now takes SettingsService; integration
+      // tests pass a stub that returns null (→ sequence-table flag = false).
+      new DocNumberService({ getKey: async () => null } as never),
       new StatusTransitionService(),
       sameDay,
       accrual,

--- a/apps/api/src/modules/expense-documents/__tests__/multi-line-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/multi-line-lifecycle.integration.spec.ts
@@ -97,7 +97,9 @@ describe('ExpenseDocuments multi-line lifecycle (integration)', () => {
     const aggregator = new LineAggregatorService();
     return new ExpenseDocumentsService(
       prisma as never,
-      new DocNumberService(),
+      // D1.1.2.4 — DocNumberService now takes SettingsService; integration
+      // tests pass a stub that returns null (→ sequence-table flag = false).
+      new DocNumberService({ getKey: async () => null } as never),
       new StatusTransitionService(),
       sameDay,
       accrual,

--- a/apps/api/src/modules/expense-documents/__tests__/payroll-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/payroll-lifecycle.integration.spec.ts
@@ -56,7 +56,9 @@ describe('Payroll lifecycle (integration)', () => {
     const settlement = new VendorSettlementTemplate(journal, prisma as never);
     return new ExpenseDocumentsService(
       prisma as never,
-      new DocNumberService(),
+      // D1.1.2.4 — DocNumberService now takes SettingsService; integration
+      // tests pass a stub that returns null (→ sequence-table flag = false).
+      new DocNumberService({ getKey: async () => null } as never),
       new StatusTransitionService(),
       sameDay,
       accrual,

--- a/apps/api/src/modules/expense-documents/__tests__/settlement-lifecycle.integration.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/settlement-lifecycle.integration.spec.ts
@@ -56,7 +56,9 @@ describe('Vendor Settlement lifecycle (integration)', () => {
     const settlement = new VendorSettlementTemplate(journal, prisma as never);
     return new ExpenseDocumentsService(
       prisma as never,
-      new DocNumberService(),
+      // D1.1.2.4 — DocNumberService now takes SettingsService; integration
+      // tests pass a stub that returns null (→ sequence-table flag = false).
+      new DocNumberService({ getKey: async () => null } as never),
       new StatusTransitionService(),
       sameDay,
       accrual,

--- a/apps/api/src/modules/expense-documents/expense-documents.module.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.module.ts
@@ -3,6 +3,7 @@ import { PrismaModule } from '../../prisma/prisma.module';
 import { JournalModule } from '../journal/journal.module';
 import { AuthModule } from '../auth/auth.module';
 import { SsoConfigModule } from '../sso-config/sso-config.module';
+import { SettingsModule } from '../settings/settings.module';
 import { ExpenseDocumentsController } from './expense-documents.controller';
 import { ExpenseDocumentsService } from './expense-documents.service';
 import { ExpenseTemplatesController } from './expense-templates.controller';
@@ -16,7 +17,7 @@ import { PayrollCustomService } from './services/payroll-custom.service';
 import { ExpenseRecurringCron } from './crons/expense-recurring.cron';
 
 @Module({
-  imports: [PrismaModule, JournalModule, AuthModule, SsoConfigModule],
+  imports: [PrismaModule, JournalModule, AuthModule, SsoConfigModule, SettingsModule],
   controllers: [ExpenseDocumentsController, ExpenseTemplatesController],
   providers: [
     ExpenseDocumentsService,

--- a/apps/api/src/modules/expense-documents/services/doc-number.service.ts
+++ b/apps/api/src/modules/expense-documents/services/doc-number.service.ts
@@ -1,5 +1,10 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotImplementedException,
+} from '@nestjs/common';
 import { DocumentType, Prisma } from '@prisma/client';
+import { SettingsService } from '../../settings/settings.service';
 
 const PREFIX_MAP: Record<DocumentType, string> = {
   EXPENSE: 'EX',
@@ -9,13 +14,40 @@ const PREFIX_MAP: Record<DocumentType, string> = {
   PETTY_CASH_REIMBURSEMENT: 'PC',
 };
 
+/**
+ * D1.1.2.4 — SystemConfig key `doc_sequence_table_enabled` (default `'false'`).
+ *
+ * Owner picked "accept current behavior" for Q3 — current implementation uses
+ * a PostgreSQL advisory lock + `MAX(docNumber)` lookup inside the same DB
+ * transaction. This works correctly under normal load (~100 docs/day) and
+ * doesn't require an additional table.
+ *
+ * The flag is reserved as a **forward-extension point** for a future migration
+ * to a dedicated `DocumentSequence` model. When `true`, the service throws
+ * `NotImplementedException` so the OWNER realizes the migration hasn't
+ * happened yet — silent fallback would create the impression a feature exists
+ * when it doesn't. To enable the new mode in the future:
+ *
+ *  1. Add `model DocumentSequence` to `schema.prisma` with `@@unique([type, period])`
+ *  2. Implement a `useSequenceTable()` branch in `next()` that does
+ *     `upsert + increment` against the new table inside the same `$transaction`
+ *  3. Drop the `NotImplementedException` throw
+ *
+ * Until then, OWNER setting this to `true` is a configuration error and the
+ * exception is the correct response.
+ */
 @Injectable()
 export class DocNumberService {
+  constructor(private readonly settings: SettingsService) {}
+
   /**
    * Generate next sequential document number with race-safe Postgres
    * advisory lock per (type, BKK-day) key. Mirrors OI/RT pattern.
    *
    * Format: <TYPE>-YYYYMMDD-NNNN — daily reset, 4-digit seq.
+   *
+   * D1.1.2.4 — when `doc_sequence_table_enabled = 'true'`, throws
+   * `NotImplementedException`. See class docstring for rationale.
    *
    * `issueDate` convention (W5): the BKK-day is derived from the user-chosen
    * `documentDate` (NOT server "now"), so a same-day creation backdated to
@@ -35,6 +67,14 @@ export class DocNumberService {
     type: DocumentType,
     issueDate: Date,
   ): Promise<string> {
+    // D1.1.2.4 — sequence table not implemented; reject explicitly if OWNER
+    // has flipped the flag without an accompanying migration.
+    if (await this.isSequenceTableEnabled()) {
+      throw new NotImplementedException(
+        'Sequence table mode not implemented yet — please disable this flag (doc_sequence_table_enabled = false)',
+      );
+    }
+
     const yyyymmdd = this.bkkYyyymmdd(issueDate);
     const prefix = `${PREFIX_MAP[type]}-${yyyymmdd}-`;
     const lockKey = this.hashLockKey(`expdoc:${type}:${yyyymmdd}`);
@@ -56,6 +96,23 @@ export class DocNumberService {
     }
     const seq = String(nextSeq).padStart(4, '0');
     return `${prefix}${seq}`;
+  }
+
+  /**
+   * D1.1.2.4 — read `doc_sequence_table_enabled` flag. Defensive: any error
+   * resolving the flag (DB down, malformed value) is treated as "false" so
+   * doc creation continues using the advisory-lock fast path. Only an
+   * explicit `'true'` / `'1'` value (case-insensitive) enables the throw branch.
+   */
+  private async isSequenceTableEnabled(): Promise<boolean> {
+    try {
+      const raw = await this.settings.getKey('doc_sequence_table_enabled');
+      if (!raw) return false;
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1';
+    } catch {
+      return false;
+    }
   }
 
   /** Asia/Bangkok local YYYYMMDD via Intl (BKK is UTC+7, no DST). */

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -102,7 +102,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.1.2.1 | `doc_prefix_per_type` | P0 | ⬜ | Q3 | Rename or accept current? |
 | D1.1.2.2 | `doc_number_format` | P0 | ⬜ | Q3 | Same |
 | D1.1.2.3 | `reset_cycle` | P0 | ⬜ | Q3 | |
-| D1.1.2.4 | `sequence_table` | P0 | ⬜ | Q3 | |
+| D1.1.2.4 | `sequence_table` | P0 | ✅ | this PR | SystemConfig key `doc_sequence_table_enabled` (default `'false'`). When `'true'` (case-insensitive — also `'1'`), `DocNumberService.next()` throws `NotImplementedException` before touching the DB. Reserved as forward-extension point for a future `DocumentSequence` Prisma model migration; current advisory-lock implementation handles the ~100 docs/day load without it. Defensive: SettingsService errors are treated as flag=false to preserve the fast path. 3 new vitest cases (flag=true throws + DB untouched; flag=false uses advisory lock; defensive throw fallback). 10/10 tests pass. Type-check 0 errors |
 | D1.1.2.5 | Admin reset capability | P0 | ⬜ | Q3 | |
 | D1.1.3.1 | `vat_rate` (Q6 P0 bug fix first) | P0 | ⬜ | Q6 | **VAT_RATE/vat_pct orphan-key fix** |
 | D1.1.3.2 | `wht_rates` (1/3/5/10/15) | P0 | ⬜ | — | Mostly unblocked — extend SelectItem + table |


### PR DESCRIPTION
## Summary

- OWNER-editable SystemConfig key `doc_sequence_table_enabled` (default `'false'`). Reserved as forward-extension point for a future `DocumentSequence` Prisma model.
- When `'true'`, `DocNumberService.next()` throws `NotImplementedException` before touching the DB. Surfaces the config error to OWNER (silent fallback would imply the feature exists).
- Defensive: SettingsService errors are treated as `false` to preserve the fast path.
- Class JSDoc documents the migration playbook to enable the flag in the future.

**Acceptance scope:** Q3 "Rename or accept current?" — **accept**. The flag is a documentation hook; runtime behaviour with default value matches today bit-for-bit.

## Test plan

- [x] `cd apps/api && npx tsc --noEmit` — 0 errors
- [x] `cd apps/web && npx tsc --noEmit` — 0 errors
- [x] DocNumberService spec — 3 new vitest cases (flag=true throws + DB untouched; flag=false uses advisory lock; defensive throw fallback). 10/10 tests pass.
- [ ] Integration tests skipped (pre-existing infra debt per MEMORY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Cluster K — merge order

**Merge order:** #937 → #952 → #941 → #947 → #955

Each PR in the cluster is self-contained with defensive fallbacks for any
sibling that has not yet merged. Conflicts in `doc-number.service.ts`
between #941 and #947 are expected and resolve cleanly by rebase (both
PRs touch the same import line + shared helpers but in compatible ways).

- **#937** (`doc_prefix_per_type`) — independent; ships standalone.
- **#952** (`doc_sequence_table_enabled` forward-extension flag) — independent.
- **#941** (`doc_number_format`) — reads optional `doc_number_reset_cycle`
  key from #947 with daily fallback if absent.
- **#947** (`doc_number_reset_cycle`) — reads optional `doc_number_format`
  key from #941 with legacy `PREFIX-YYYYMMDD-NNNN` fallback if absent.
- **#955** (admin sequence-reset endpoint) — depends on the underlying
  service from earlier PRs but uses fallbacks for any missing dimension.
