### PR TITLE
feat(a1): D1.1.1.7 — permission control for account_role_map

### DIFF
--- a/apps/api/src/modules/journal/account-role.service.ts
+++ b/apps/api/src/modules/journal/account-role.service.ts
@@ -1,6 +1,13 @@
-import { Injectable, OnModuleInit, Logger, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  OnModuleInit,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 
 /**
  * Resolves semantic roles → CoA codes via the `account_role_map` table
@@ -33,7 +40,10 @@ export class AccountRoleService implements OnModuleInit {
     'payroll_sso_expense',
   ];
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
 
   async onModuleInit(): Promise<void> {
     await this.loadCache();
@@ -74,6 +84,194 @@ export class AccountRoleService implements OnModuleInit {
       select: { role: true, accountCode: true, priority: true, note: true },
     });
     return rows;
+  }
+
+  /**
+   * D1.1.1.2 — All AccountRoleMap rows joined with ChartOfAccount.name +
+   * REQUIRED_ROLES `required` flag, for the admin UI's table view.
+   */
+  async listWithCoa(): Promise<
+    Array<{
+      id: string;
+      role: string;
+      accountCode: string;
+      accountName: string | null;
+      priority: number;
+      isActive: boolean;
+      note: string | null;
+      required: boolean;
+    }>
+  > {
+    const rows = await this.prisma.accountRoleMap.findMany({
+      orderBy: [{ role: 'asc' }, { priority: 'asc' }],
+      select: {
+        id: true,
+        role: true,
+        accountCode: true,
+        priority: true,
+        isActive: true,
+        note: true,
+      },
+    });
+    if (rows.length === 0) return [];
+    const codes = Array.from(new Set(rows.map((r) => r.accountCode)));
+    const coas = await this.prisma.chartOfAccount.findMany({
+      where: { code: { in: codes }, deletedAt: null },
+      select: { code: true, name: true },
+    });
+    const nameByCode = new Map(coas.map((c) => [c.code, c.name]));
+    const requiredSet = new Set<string>(AccountRoleService.REQUIRED_ROLES);
+    return rows.map((r) => ({
+      id: r.id,
+      role: r.role,
+      accountCode: r.accountCode,
+      accountName: nameByCode.get(r.accountCode) ?? null,
+      priority: r.priority,
+      isActive: r.isActive,
+      note: r.note,
+      required: requiredSet.has(r.role),
+    }));
+  }
+
+  /** D1.1.1.5 — public access to the required-roles whitelist. */
+  static getRequiredRoles(): readonly string[] {
+    return AccountRoleService.REQUIRED_ROLES;
+  }
+
+  /**
+   * D1.1.1.3 + D1.1.1.5 — Update a single AccountRoleMap row. Validation
+   * is delegated to `RoleMapValidationService.validateUpdate` (callable
+   * by PUT, future POST, bulk-import). Writes a `ROLE_MAP_UPDATED` audit
+   * entry then invalidates the cache.
+   *
+   * Callers should pass a `validator` instance (or rely on the
+   * controller injecting RoleMapValidationService and calling it before
+   * delegating here — both flows are supported so this method stays
+   * useful for unit tests without a NestJS context).
+   */
+  async update(
+    id: string,
+    dto: {
+      accountCode?: string;
+      priority?: number;
+      isActive?: boolean;
+      note?: string | null;
+    },
+    userId: string,
+    validate?: (args: {
+      id: string;
+      currentRow: {
+        id: string;
+        role: string;
+        accountCode: string;
+        priority: number;
+        isActive: boolean;
+      };
+      update: { accountCode?: string; priority?: number; isActive?: boolean };
+    }) => Promise<void>,
+  ): Promise<{
+    id: string;
+    role: string;
+    accountCode: string;
+    priority: number;
+    isActive: boolean;
+    note: string | null;
+  }> {
+    const before = await this.prisma.accountRoleMap.findUnique({ where: { id } });
+    if (!before) {
+      throw new NotFoundException(`ไม่พบแถวบัญชี role-map: ${id}`);
+    }
+    if (validate) {
+      await validate({
+        id,
+        currentRow: {
+          id: before.id,
+          role: before.role,
+          accountCode: before.accountCode,
+          priority: before.priority,
+          isActive: before.isActive,
+        },
+        update: {
+          accountCode: dto.accountCode,
+          priority: dto.priority,
+          isActive: dto.isActive,
+        },
+      });
+    } else {
+      // Fallback inline checks if no validator supplied (keeps the
+      // service self-sufficient for unit tests that don't import the
+      // settings module). Mirrors the canonical rules.
+      if (
+        dto.isActive === false &&
+        AccountRoleService.REQUIRED_ROLES.includes(before.role)
+      ) {
+        throw new BadRequestException(
+          `Role "${before.role}" จำเป็นสำหรับการทำงานของระบบ — ห้ามปิดใช้งาน`,
+        );
+      }
+      if (dto.accountCode && dto.accountCode !== before.accountCode) {
+        const coa = await this.prisma.chartOfAccount.findFirst({
+          where: { code: dto.accountCode, deletedAt: null },
+          select: { code: true },
+        });
+        if (!coa) {
+          throw new BadRequestException(`บัญชี ${dto.accountCode} ไม่พบในผังบัญชี`);
+        }
+      }
+    }
+    const updateData: Prisma.AccountRoleMapUpdateInput = {};
+    if (dto.accountCode !== undefined) updateData.accountCode = dto.accountCode;
+    if (dto.priority !== undefined) updateData.priority = dto.priority;
+    if (dto.isActive !== undefined) updateData.isActive = dto.isActive;
+    if (dto.note !== undefined) updateData.note = dto.note;
+    const updated = await this.prisma.accountRoleMap.update({
+      where: { id },
+      data: updateData,
+      select: {
+        id: true,
+        role: true,
+        accountCode: true,
+        priority: true,
+        isActive: true,
+        note: true,
+      },
+    });
+    const diff: string[] = [];
+    if (dto.accountCode !== undefined && dto.accountCode !== before.accountCode) {
+      diff.push(`accountCode: ${before.accountCode} → ${updated.accountCode}`);
+    }
+    if (dto.priority !== undefined && dto.priority !== before.priority) {
+      diff.push(`priority: ${before.priority} → ${updated.priority}`);
+    }
+    if (dto.isActive !== undefined && dto.isActive !== before.isActive) {
+      diff.push(`isActive: ${before.isActive} → ${updated.isActive}`);
+    }
+    if (dto.note !== undefined && dto.note !== before.note) {
+      diff.push(`note: ${before.note ?? '—'} → ${updated.note ?? '—'}`);
+    }
+    await this.audit.log({
+      userId,
+      action: 'ROLE_MAP_UPDATED',
+      entity: 'account_role_map',
+      entityId: id,
+      oldValue: {
+        role: before.role,
+        accountCode: before.accountCode,
+        priority: before.priority,
+        isActive: before.isActive,
+        note: before.note,
+      },
+      newValue: {
+        role: updated.role,
+        accountCode: updated.accountCode,
+        priority: updated.priority,
+        isActive: updated.isActive,
+        note: updated.note,
+        diffSummary: `role ${updated.role}: ${diff.join(', ') || 'no field changes'}`,
+      },
+    });
+    await this.invalidate();
+    return updated;
   }
 
   /** Call after a mutation through the admin UI. */

--- a/apps/api/src/modules/journal/account-role.service.ts
+++ b/apps/api/src/modules/journal/account-role.service.ts
@@ -3,11 +3,24 @@ import {
   OnModuleInit,
   Logger,
   BadRequestException,
+  ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
+
+/**
+ * D1.1.1.7 — Role permission constants. Single source of truth for which
+ * roles can read vs write the account_role_map. Used by both the @Roles
+ * decorators on the controller AND the runtime `assertCanWrite()` guard
+ * (defense in depth — if a future refactor accidentally widens the
+ * decorator scope, the service-level check still blocks the write).
+ */
+export const ROLE_MAP_READ_ROLES = ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'] as const;
+export const ROLE_MAP_WRITE_ROLES = ['OWNER'] as const;
+export type RoleMapReadRole = (typeof ROLE_MAP_READ_ROLES)[number];
+export type RoleMapWriteRole = (typeof ROLE_MAP_WRITE_ROLES)[number];
 
 /**
  * Resolves semantic roles → CoA codes via the `account_role_map` table
@@ -44,6 +57,35 @@ export class AccountRoleService implements OnModuleInit {
     private readonly prisma: PrismaService,
     private readonly audit: AuditService,
   ) {}
+
+  /**
+   * D1.1.1.7 — Runtime double-check that the caller can write to
+   * account_role_map. Throws ForbiddenException with a Thai message
+   * otherwise. The @Roles decorator on the controller is the primary
+   * gate; this is a defense-in-depth check that survives accidental
+   * decorator removal in future refactors.
+   */
+  assertCanWrite(userRole: string | undefined): void {
+    const allowed = ROLE_MAP_WRITE_ROLES as readonly string[];
+    if (!userRole || !allowed.includes(userRole)) {
+      throw new ForbiddenException(
+        `เฉพาะ OWNER เท่านั้นที่แก้ไข role mapping ได้ (role ปัจจุบัน: ${userRole ?? 'unknown'})`,
+      );
+    }
+  }
+
+  /**
+   * D1.1.1.7 — Read-side guard. Throws ForbiddenException unless the
+   * caller has one of `ROLE_MAP_READ_ROLES`.
+   */
+  assertCanRead(userRole: string | undefined): void {
+    const allowed = ROLE_MAP_READ_ROLES as readonly string[];
+    if (!userRole || !allowed.includes(userRole)) {
+      throw new ForbiddenException(
+        `ไม่มีสิทธิ์อ่าน role mapping (role ปัจจุบัน: ${userRole ?? 'unknown'})`,
+      );
+    }
+  }
 
   async onModuleInit(): Promise<void> {
     await this.loadCache();
@@ -139,15 +181,20 @@ export class AccountRoleService implements OnModuleInit {
   }
 
   /**
-   * D1.1.1.3 + D1.1.1.5 — Update a single AccountRoleMap row. Validation
-   * is delegated to `RoleMapValidationService.validateUpdate` (callable
-   * by PUT, future POST, bulk-import). Writes a `ROLE_MAP_UPDATED` audit
-   * entry then invalidates the cache.
+   * D1.1.1.3 + D1.1.1.5 + D1.1.1.7 — Update a single AccountRoleMap row.
    *
-   * Callers should pass a `validator` instance (or rely on the
-   * controller injecting RoleMapValidationService and calling it before
-   * delegating here — both flows are supported so this method stays
-   * useful for unit tests without a NestJS context).
+   * Permission (D1.1.1.7): the caller MUST pass `userRole`. `assertCanWrite`
+   * runs FIRST — before any DB I/O — as defense-in-depth so that even if a
+   * future refactor accidentally widens the controller's @Roles decorator,
+   * the service-level OWNER check still rejects the write.
+   *
+   * Validation (D1.1.1.5): delegated to `RoleMapValidationService.validateUpdate`
+   * via the optional `validate` callback (callable by PUT, future POST,
+   * bulk-import). When the callback is not supplied (unit tests without
+   * the settings module), an inline mirror of the canonical rules runs.
+   *
+   * Audit: writes `ROLE_MAP_UPDATED` with `diffSummary` then invalidates
+   * the in-memory cache.
    */
   async update(
     id: string,
@@ -158,6 +205,7 @@ export class AccountRoleService implements OnModuleInit {
       note?: string | null;
     },
     userId: string,
+    userRole: string,
     validate?: (args: {
       id: string;
       currentRow: {
@@ -177,6 +225,11 @@ export class AccountRoleService implements OnModuleInit {
     isActive: boolean;
     note: string | null;
   }> {
+    // D1.1.1.7 — runtime double-check that the caller is OWNER.
+    // MUST run before any DB I/O so an unauthorised caller never even
+    // sees the existence of the row.
+    this.assertCanWrite(userRole);
+
     const before = await this.prisma.accountRoleMap.findUnique({ where: { id } });
     if (!before) {
       throw new NotFoundException(`ไม่พบแถวบัญชี role-map: ${id}`);

--- a/apps/api/src/modules/settings/dto/update-role-map.dto.ts
+++ b/apps/api/src/modules/settings/dto/update-role-map.dto.ts
@@ -1,0 +1,22 @@
+import { IsBoolean, IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+
+export class UpdateRoleMapDto {
+  @IsOptional()
+  @IsString({ message: 'รหัสบัญชีต้องเป็นข้อความ' })
+  @MaxLength(20, { message: 'รหัสบัญชีต้องไม่เกิน 20 ตัวอักษร' })
+  accountCode?: string;
+
+  @IsOptional()
+  @IsInt({ message: 'ลำดับความสำคัญต้องเป็นเลขจำนวนเต็ม' })
+  @Min(1, { message: 'ลำดับความสำคัญต้องมากกว่า 0' })
+  priority?: number;
+
+  @IsOptional()
+  @IsBoolean({ message: 'สถานะใช้งานต้องเป็น true/false' })
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsString({ message: 'หมายเหตุต้องเป็นข้อความ' })
+  @MaxLength(500, { message: 'หมายเหตุต้องไม่เกิน 500 ตัวอักษร' })
+  note?: string | null;
+}

--- a/apps/api/src/modules/settings/role-map-perm.spec.ts
+++ b/apps/api/src/modules/settings/role-map-perm.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import {
+  AccountRoleService,
+  ROLE_MAP_READ_ROLES,
+  ROLE_MAP_WRITE_ROLES,
+} from '../journal/account-role.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+/**
+ * D1.1.1.7 — Permission control (defense in depth).
+ *
+ * The @Roles decorator on the controller is the primary gate, but the
+ * service-level `assertCanRead` / `assertCanWrite` checks survive
+ * accidental decorator misconfiguration in future refactors.
+ *
+ * Required matrix:
+ *   GET  — OWNER, FINANCE_MANAGER, ACCOUNTANT allowed; SALES/BRANCH_MANAGER denied
+ *   PUT  — OWNER allowed; everyone else denied
+ */
+describe('AccountRoleService permission guards (D1.1.1.7)', () => {
+  let service: AccountRoleService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let audit: any;
+
+  beforeEach(async () => {
+    prisma = {
+      accountRoleMap: {
+        findUnique: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn(),
+      },
+      chartOfAccount: { findFirst: jest.fn(), findMany: jest.fn().mockResolvedValue([]) },
+    };
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        AccountRoleService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = mod.get(AccountRoleService);
+  });
+
+  it('assertCanRead allows OWNER, FINANCE_MANAGER, ACCOUNTANT and denies SALES/BRANCH_MANAGER', () => {
+    for (const role of ROLE_MAP_READ_ROLES) {
+      expect(() => service.assertCanRead(role)).not.toThrow();
+    }
+    for (const denied of ['SALES', 'BRANCH_MANAGER', 'GUEST']) {
+      expect(() => service.assertCanRead(denied)).toThrow(ForbiddenException);
+    }
+  });
+
+  it('assertCanWrite allows only OWNER and denies everyone else', () => {
+    expect(() => service.assertCanWrite('OWNER')).not.toThrow();
+    for (const denied of [
+      'FINANCE_MANAGER',
+      'ACCOUNTANT',
+      'SALES',
+      'BRANCH_MANAGER',
+      undefined,
+    ]) {
+      expect(() => service.assertCanWrite(denied)).toThrow(ForbiddenException);
+    }
+    // Constant alignment: WRITE_ROLES must contain exactly ['OWNER'].
+    expect([...ROLE_MAP_WRITE_ROLES]).toEqual(['OWNER']);
+  });
+
+  it('update() runs the OWNER write check before any DB lookup', async () => {
+    // ACCOUNTANT has read access (visible in admin UI) but trying to PUT
+    // should be blocked even before we hit the prisma findUnique call.
+    await expect(
+      service.update('r1', { priority: 5 }, 'user-1', 'ACCOUNTANT'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.accountRoleMap.findUnique).not.toHaveBeenCalled();
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+
+  it('update() proceeds when caller is OWNER (happy path)', async () => {
+    prisma.accountRoleMap.findUnique.mockResolvedValue({
+      id: 'r1',
+      role: 'custom_role',
+      accountCode: '11-4101',
+      priority: 1,
+      isActive: true,
+      note: null,
+    });
+    prisma.accountRoleMap.update.mockResolvedValue({
+      id: 'r1',
+      role: 'custom_role',
+      accountCode: '11-4101',
+      priority: 5,
+      isActive: true,
+      note: null,
+    });
+
+    const updated = await service.update('r1', { priority: 5 }, 'user-1', 'OWNER');
+    expect(updated.priority).toBe(5);
+    expect(audit.log).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/settings/role-map-validation.service.spec.ts
+++ b/apps/api/src/modules/settings/role-map-validation.service.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { RoleMapValidationService } from './role-map-validation.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * D1.1.1.5 — Validation rules.
+ *   1. Required-role lock — REQUIRED_ROLES cannot be deactivated.
+ *   2. CoA presence + normalBalance side match.
+ *   3. Priority uniqueness within a role.
+ */
+describe('RoleMapValidationService', () => {
+  let service: RoleMapValidationService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      accountRoleMap: { findFirst: jest.fn() },
+      chartOfAccount: { findFirst: jest.fn() },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoleMapValidationService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = mod.get(RoleMapValidationService);
+  });
+
+  const baseRow = {
+    id: 'r1',
+    role: 'custom_role',
+    accountCode: '11-4101',
+    priority: 1,
+    isActive: true,
+  };
+
+  it('rule 1 — rejects deactivating a REQUIRED_ROLES row', async () => {
+    await expect(
+      service.validateUpdate({
+        id: 'r1',
+        currentRow: { ...baseRow, role: 'vat_input' },
+        update: { isActive: false },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rule 1 — allows deactivating a non-required role', async () => {
+    await expect(
+      service.validateUpdate({
+        id: 'r1',
+        currentRow: { ...baseRow, role: 'custom_role' },
+        update: { isActive: false },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rule 2a — rejects accountCode missing from chart_of_accounts', async () => {
+    prisma.chartOfAccount.findFirst.mockResolvedValue(null);
+    await expect(
+      service.validateUpdate({
+        id: 'r1',
+        currentRow: baseRow,
+        update: { accountCode: '99-9999' },
+      }),
+    ).rejects.toThrow('99-9999 ไม่พบในผังบัญชี');
+  });
+
+  it('rule 2b — rejects wrong normalBalance side (vat_input must be Dr)', async () => {
+    prisma.chartOfAccount.findFirst.mockResolvedValue({
+      code: '21-2101',
+      normalBalance: 'Cr',
+    });
+    await expect(
+      service.validateUpdate({
+        id: 'r1',
+        currentRow: { ...baseRow, role: 'vat_input' },
+        update: { accountCode: '21-2101' },
+      }),
+    ).rejects.toThrow(/ฝั่ง Dr.*ฝั่ง Cr/);
+  });
+
+  it('rule 2b — accepts matching normalBalance (vat_output must be Cr)', async () => {
+    prisma.chartOfAccount.findFirst.mockResolvedValue({
+      code: '21-2101',
+      normalBalance: 'Cr',
+    });
+    await expect(
+      service.validateUpdate({
+        id: 'r1',
+        currentRow: { ...baseRow, role: 'vat_output' },
+        update: { accountCode: '21-2101' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rule 3 — rejects priority that conflicts with another row of the same role', async () => {
+    prisma.accountRoleMap.findFirst.mockResolvedValue({ id: 'r2' });
+    await expect(
+      service.validateUpdate({
+        id: 'r1',
+        currentRow: baseRow,
+        update: { priority: 5 },
+      }),
+    ).rejects.toThrow(/Priority 5 ถูกใช้แล้ว/);
+  });
+
+  it('rule 3 — passes when priority is unique within the role', async () => {
+    prisma.accountRoleMap.findFirst.mockResolvedValue(null);
+    await expect(
+      service.validateUpdate({
+        id: 'r1',
+        currentRow: baseRow,
+        update: { priority: 5 },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/settings/role-map-validation.service.ts
+++ b/apps/api/src/modules/settings/role-map-validation.service.ts
@@ -1,0 +1,137 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AccountRoleService } from '../journal/account-role.service';
+
+/**
+ * D1.1.1.5 — Validation rules for `account_role_map` mutations.
+ * Pulled out of `AccountRoleService.update()` so other entry points
+ * (future POST, bulk-import) can reuse the same checks.
+ *
+ * Three rules:
+ * 1. **Required-role lock** — REQUIRED_ROLES rows cannot be deactivated.
+ *    Boot-time invariants in `AccountRoleService.assertRequiredRolesPresent`
+ *    would fail on the next deploy.
+ * 2. **CoA presence + normalBalance match** — accountCode must exist in
+ *    `chart_of_accounts` AND its `normalBalance` must match the expected
+ *    side for that role (e.g. `vat_input` expects Dr-side). Catches the
+ *    "OWNER pasted the wrong code" class of bug before it lands in a JE.
+ * 3. **Priority uniqueness per role** — multiple rows can share the same
+ *    `role` (context-aware lookup), but each must use a distinct `priority`
+ *    so the cache load can pick a deterministic winner. The unique index
+ *    on `(role, accountCode)` alone doesn't enforce this.
+ */
+@Injectable()
+export class RoleMapValidationService {
+  /**
+   * Expected normal balance per role. Codes outside this map are accepted
+   * with either Dr/Cr (free-form). Add new roles as they appear in
+   * `account_role_map`.
+   *
+   * - assets (sit on Dr side) → 'Dr'
+   * - liabilities + revenue + contra-assets → 'Cr'
+   * - expenses (Dr side) → 'Dr'
+   */
+  static readonly EXPECTED_NORMAL_BALANCE: Record<string, 'Dr' | 'Cr'> = {
+    // VAT input — asset (Dr)
+    vat_input: 'Dr',
+    vat_input_pending: 'Dr',
+    // VAT output — liability (Cr)
+    vat_output: 'Cr',
+    // Payables — liability (Cr)
+    payable_default: 'Cr',
+    payable_canva: 'Cr',
+    // WHT payables — liability (Cr)
+    wht_individual: 'Cr',
+    wht_juristic: 'Cr',
+    wht_payroll: 'Cr',
+    wht_dividend: 'Cr',
+    // SSO payables — liability (Cr)
+    sso_employee: 'Cr',
+    sso_employer: 'Cr',
+    // Payroll expenses — expense (Dr)
+    payroll_expense: 'Dr',
+    payroll_sso_expense: 'Dr',
+    payroll_overtime: 'Dr',
+    payroll_bonus: 'Dr',
+    // Payroll deduction — other income (Cr)
+    payroll_deduction: 'Cr',
+    // Employee bond — liability (Cr)
+    employee_bond: 'Cr',
+    // Adjustment routes — both expense-side accounts on Dr,
+    // overpay account (53-1503) on Dr too (income-or-expense combo line)
+    adj_overpay: 'Dr',
+    adj_underpay: 'Dr',
+  };
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Validate a proposed update against rules 1+2+3. Throws BadRequest
+   * with a Thai message on failure. Pass `currentRow` so we can skip
+   * checks for unchanged fields.
+   */
+  async validateUpdate(args: {
+    id: string;
+    currentRow: {
+      id: string;
+      role: string;
+      accountCode: string;
+      priority: number;
+      isActive: boolean;
+    };
+    update: {
+      accountCode?: string;
+      priority?: number;
+      isActive?: boolean;
+    };
+  }): Promise<void> {
+    const { currentRow, update } = args;
+
+    // Rule 1 — required-role lock.
+    if (
+      update.isActive === false &&
+      AccountRoleService.getRequiredRoles().includes(currentRow.role)
+    ) {
+      throw new BadRequestException(
+        `Role "${currentRow.role}" จำเป็นสำหรับการทำงานของระบบ — ห้ามปิดใช้งาน`,
+      );
+    }
+
+    // Rule 2a — CoA presence (only when accountCode is changing).
+    const newCode = update.accountCode;
+    if (newCode && newCode !== currentRow.accountCode) {
+      const coa = await this.prisma.chartOfAccount.findFirst({
+        where: { code: newCode, deletedAt: null },
+        select: { code: true, normalBalance: true },
+      });
+      if (!coa) {
+        throw new BadRequestException(`บัญชี ${newCode} ไม่พบในผังบัญชี`);
+      }
+      // Rule 2b — normalBalance must match the role's expected side.
+      const expected = RoleMapValidationService.EXPECTED_NORMAL_BALANCE[currentRow.role];
+      if (expected && coa.normalBalance !== expected) {
+        throw new BadRequestException(
+          `Role "${currentRow.role}" ต้องใช้บัญชีฝั่ง ${expected} — ` +
+            `แต่บัญชี ${newCode} อยู่ฝั่ง ${coa.normalBalance}`,
+        );
+      }
+    }
+
+    // Rule 3 — priority uniqueness within (role).
+    if (update.priority !== undefined && update.priority !== currentRow.priority) {
+      const conflict = await this.prisma.accountRoleMap.findFirst({
+        where: {
+          role: currentRow.role,
+          priority: update.priority,
+          NOT: { id: currentRow.id },
+        },
+        select: { id: true },
+      });
+      if (conflict) {
+        throw new BadRequestException(
+          `Priority ${update.priority} ถูกใช้แล้วใน role "${currentRow.role}" — เลือกค่าอื่น`,
+        );
+      }
+    }
+  }
+}

--- a/apps/api/src/modules/settings/settings.controller.ts
+++ b/apps/api/src/modules/settings/settings.controller.ts
@@ -8,7 +8,11 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
-import { AccountRoleService } from '../journal/account-role.service';
+import {
+  AccountRoleService,
+  ROLE_MAP_READ_ROLES,
+  ROLE_MAP_WRITE_ROLES,
+} from '../journal/account-role.service';
 import { RoleMapValidationService } from './role-map-validation.service';
 
 @ApiTags('Settings')
@@ -39,30 +43,45 @@ export class SettingsController {
     return this.settingsService.getUiFlags();
   }
 
-  /** D1.1.1.2 — list account_role_map joined with chart_of_accounts. */
+  /**
+   * D1.1.1.2 / D1.1.1.7 — Read account_role_map joined with CoA.
+   *
+   * Permission: OWNER + FINANCE_MANAGER + ACCOUNTANT (read-only).
+   * Explicit `...ROLE_MAP_READ_ROLES` spread keeps the decorator + the
+   * `assertCanRead()` runtime check pointing at the same constant — no
+   * drift possible.
+   */
   @Get('role-map')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
-  getRoleMap() {
+  @Roles(...ROLE_MAP_READ_ROLES)
+  getRoleMap(@CurrentUser() user: { id: string; role: string }) {
+    // D1.1.1.7 — runtime double-check (defense in depth — if a future
+    // refactor widens the decorator scope, this still blocks).
+    this.accountRoleService.assertCanRead(user.role);
     return this.accountRoleService.listWithCoa();
   }
 
   /**
-   * D1.1.1.3 + D1.1.1.5 — Update one role-map row (OWNER-only). Validation
-   * runs through `RoleMapValidationService` (required-role lock, CoA
-   * presence + normal-balance match, priority uniqueness per role).
+   * D1.1.1.3 + D1.1.1.5 + D1.1.1.7 — Update one role-map row (OWNER-only).
+   *
+   * - Permission (D1.1.1.7): `@Roles(...ROLE_MAP_WRITE_ROLES)` + the
+   *   service-side `assertCanWrite()` gate — defense in depth.
+   * - Validation (D1.1.1.5): `RoleMapValidationService.validateUpdate`
+   *   handles the required-role lock, CoA presence + normal-balance match,
+   *   priority uniqueness per role. Service `update()` invokes it via the
+   *   `validate` callback so other entry points (POST, bulk) can reuse.
    */
   @Put('role-map/:id')
-  @Roles('OWNER')
+  @Roles(...ROLE_MAP_WRITE_ROLES)
   updateRoleMap(
     @Param('id') id: string,
     @Body() dto: UpdateRoleMapDto,
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string; role: string },
   ) {
     return this.accountRoleService.update(
       id,
       dto,
       user.id,
-      // Delegate validation so other entry points (POST, bulk) can reuse.
+      user.role,
       (args) => this.roleMapValidation.validateUpdate(args),
     );
   }

--- a/apps/api/src/modules/settings/settings.controller.ts
+++ b/apps/api/src/modules/settings/settings.controller.ts
@@ -1,12 +1,15 @@
-import { Controller, Get, Patch, Put, Body, UseGuards } from '@nestjs/common';
+import { Controller, Get, Patch, Put, Body, Param, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { SettingsService } from './settings.service';
 import { BulkUpdateSettingsDto } from './dto/update-settings.dto';
 import { CollectionsConfigDto } from './dto/collections-config.dto';
+import { UpdateRoleMapDto } from './dto/update-role-map.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { AccountRoleService } from '../journal/account-role.service';
+import { RoleMapValidationService } from './role-map-validation.service';
 
 @ApiTags('Settings')
 @ApiBearerAuth('JWT')
@@ -14,7 +17,11 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('OWNER')
 export class SettingsController {
-  constructor(private settingsService: SettingsService) {}
+  constructor(
+    private settingsService: SettingsService,
+    private accountRoleService: AccountRoleService,
+    private roleMapValidation: RoleMapValidationService,
+  ) {}
 
   @Get()
   findAll() {
@@ -30,6 +37,34 @@ export class SettingsController {
   @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT', 'SALES')
   getUiFlags() {
     return this.settingsService.getUiFlags();
+  }
+
+  /** D1.1.1.2 — list account_role_map joined with chart_of_accounts. */
+  @Get('role-map')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getRoleMap() {
+    return this.accountRoleService.listWithCoa();
+  }
+
+  /**
+   * D1.1.1.3 + D1.1.1.5 — Update one role-map row (OWNER-only). Validation
+   * runs through `RoleMapValidationService` (required-role lock, CoA
+   * presence + normal-balance match, priority uniqueness per role).
+   */
+  @Put('role-map/:id')
+  @Roles('OWNER')
+  updateRoleMap(
+    @Param('id') id: string,
+    @Body() dto: UpdateRoleMapDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.accountRoleService.update(
+      id,
+      dto,
+      user.id,
+      // Delegate validation so other entry points (POST, bulk) can reuse.
+      (args) => this.roleMapValidation.validateUpdate(args),
+    );
   }
 
   @Patch()

--- a/apps/api/src/modules/settings/settings.module.ts
+++ b/apps/api/src/modules/settings/settings.module.ts
@@ -5,8 +5,10 @@ import { RoleMapValidationService } from './role-map-validation.service';
 import { JournalModule } from '../journal/journal.module';
 
 @Module({
-  // D1.1.1.5 — pull in JournalModule (exports AccountRoleService); the
-  // RoleMapValidationService reuses the same prisma instance.
+  // D1.1.1.5 + D1.1.1.7 — pull in JournalModule (exports AccountRoleService
+  // and the ROLE_MAP_*_ROLES permission constants). RoleMapValidationService
+  // reuses the same prisma instance and is invoked by SettingsController as
+  // a `validate` callback into AccountRoleService.update().
   imports: [JournalModule],
   controllers: [SettingsController],
   providers: [SettingsService, RoleMapValidationService],

--- a/apps/api/src/modules/settings/settings.module.ts
+++ b/apps/api/src/modules/settings/settings.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common';
 import { SettingsController } from './settings.controller';
 import { SettingsService } from './settings.service';
+import { RoleMapValidationService } from './role-map-validation.service';
+import { JournalModule } from '../journal/journal.module';
 
 @Module({
+  // D1.1.1.5 — pull in JournalModule (exports AccountRoleService); the
+  // RoleMapValidationService reuses the same prisma instance.
+  imports: [JournalModule],
   controllers: [SettingsController],
-  providers: [SettingsService],
-  exports: [SettingsService],
+  providers: [SettingsService, RoleMapValidationService],
+  exports: [SettingsService, RoleMapValidationService],
 })
 export class SettingsModule {}

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -98,7 +98,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.1.1.4 | Admin UI for role map | P0 | ⬜ | Q7 | |
 | D1.1.1.5 | Validation rules | P0 | ✅ | this PR | New `RoleMapValidationService` at `apps/api/src/modules/settings/role-map-validation.service.ts`. Enforces 3 rules: (1) REQUIRED_ROLES cannot be deactivated, (2) accountCode must exist in chart_of_accounts AND match expected normalBalance per role (e.g. vat_input=Dr, vat_output=Cr), (3) priority unique per role. `EXPECTED_NORMAL_BALANCE` map covers all 19 seeded roles. AccountRoleService.update() accepts optional `validate` callback — controller injects RoleMapValidationService; tests can pass inline checks. 7 vitest cases (rule 1 required+non-required, rule 2a missing CoA, rule 2b wrong side + matching side, rule 3 conflict + unique). Type-check 0 errors |
 | D1.1.1.6 | Audit log on change | P0 | ⬜ | Q7 | |
-| D1.1.1.7 | Permission control (admin only) | P0 | ⬜ | Q7 | |
+| D1.1.1.7 | Permission control (admin only) | P0 | ✅ | this PR | Defense-in-depth permission control. New exported constants `ROLE_MAP_READ_ROLES` (OWNER+FINANCE_MANAGER+ACCOUNTANT) + `ROLE_MAP_WRITE_ROLES` (OWNER) — single source of truth for both `@Roles` decorator (spread into decorator args) AND runtime `assertCanRead()`/`assertCanWrite()` service-side checks. `update()` now requires `userRole` arg + calls `assertCanWrite()` BEFORE any DB lookup (denied callers never trigger findUnique). 4 vitest cases (read allow/deny matrix, write OWNER-only matrix, update() pre-DB block on non-OWNER, OWNER happy path). Type-check 0 errors |
 | D1.1.2.1 | `doc_prefix_per_type` | P0 | ⬜ | Q3 | Rename or accept current? |
 | D1.1.2.2 | `doc_number_format` | P0 | ⬜ | Q3 | Same |
 | D1.1.2.3 | `reset_cycle` | P0 | ⬜ | Q3 | |

--- a/docs/superpowers/tracking/D1-settings-implement.md
+++ b/docs/superpowers/tracking/D1-settings-implement.md
@@ -96,7 +96,7 @@ Sub-prioritization within expanded D1 scope:
 | D1.1.1.2 | `GET /api/settings/role-map` | P0 | ⬜ | Q7 | Wire AccountRoleService or drop table? |
 | D1.1.1.3 | `PUT /api/settings/role-map` | P0 | ⬜ | Q7 | |
 | D1.1.1.4 | Admin UI for role map | P0 | ⬜ | Q7 | |
-| D1.1.1.5 | Validation rules | P0 | ⬜ | Q7 | |
+| D1.1.1.5 | Validation rules | P0 | ✅ | this PR | New `RoleMapValidationService` at `apps/api/src/modules/settings/role-map-validation.service.ts`. Enforces 3 rules: (1) REQUIRED_ROLES cannot be deactivated, (2) accountCode must exist in chart_of_accounts AND match expected normalBalance per role (e.g. vat_input=Dr, vat_output=Cr), (3) priority unique per role. `EXPECTED_NORMAL_BALANCE` map covers all 19 seeded roles. AccountRoleService.update() accepts optional `validate` callback — controller injects RoleMapValidationService; tests can pass inline checks. 7 vitest cases (rule 1 required+non-required, rule 2a missing CoA, rule 2b wrong side + matching side, rule 3 conflict + unique). Type-check 0 errors |
 | D1.1.1.6 | Audit log on change | P0 | ⬜ | Q7 | |
 | D1.1.1.7 | Permission control (admin only) | P0 | ⬜ | Q7 | |
 | D1.1.2.1 | `doc_prefix_per_type` | P0 | ⬜ | Q3 | Rename or accept current? |


### PR DESCRIPTION
## Summary
- Two exported constants — single source of truth for permissions:
  - `ROLE_MAP_READ_ROLES` = [OWNER, FINANCE_MANAGER, ACCOUNTANT]
  - `ROLE_MAP_WRITE_ROLES` = [OWNER]
- Controller spreads them into `@Roles(...ROLE_MAP_*_ROLES)` so the decorator + the runtime `assertCanRead/Write` service-side check cannot drift apart
- `AccountRoleService.update()` now requires `userRole` as a mandatory arg and calls `assertCanWrite()` BEFORE any DB lookup — defense in depth

## Q7 decision
WIRE IT (per owner).

## Test plan
- [x] `npx tsc --noEmit` apps/api — 0 errors
- [x] `npx tsc --noEmit` apps/web — 0 errors
- [x] 4 vitest cases (read matrix, write OWNER-only matrix, update() pre-DB block, OWNER happy path) — passing
- [ ] Manual: PUT as FINANCE_MANAGER → expect 403; GET as ACCOUNTANT → expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)