### PR TITLE
feat(a1): D1.3.2.2 — settings_access_role dynamic guard (Q4-gated)

### DIFF
--- a/apps/api/src/modules/settings/settings-access.guard.spec.ts
+++ b/apps/api/src/modules/settings/settings-access.guard.spec.ts
@@ -1,0 +1,92 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { SettingsAccessGuard, SETTINGS_ACCESS_BYPASS } from './settings-access.guard';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * D1.3.2.2 — SettingsAccessGuard dynamic role gating.
+ *
+ * Conservative default: when SystemConfig key `settings_access_role` is
+ * absent / malformed / DB-fails, guard locks down to OWNER only — matches
+ * pre-existing `@Roles('OWNER')` behavior.
+ */
+
+function makeContext(user: { role?: string } | null, handler: object = {}, classRef: object = {}) {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+    getHandler: () => handler,
+    getClass: () => classRef,
+  } as unknown as Parameters<SettingsAccessGuard['canActivate']>[0];
+}
+
+describe('SettingsAccessGuard', () => {
+  let prisma: { systemConfig: { findFirst: jest.Mock } };
+  let reflector: Reflector;
+  let guard: SettingsAccessGuard;
+
+  beforeEach(() => {
+    prisma = {
+      systemConfig: { findFirst: jest.fn() },
+    };
+    reflector = new Reflector();
+    guard = new SettingsAccessGuard(reflector, prisma as unknown as PrismaService);
+  });
+
+  it('defaults to OWNER-only when SystemConfig row missing', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue(null);
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('OWNER+FINANCE_MANAGER allows FINANCE_MANAGER but not ACCOUNTANT', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER+FINANCE_MANAGER' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('OWNER+ALL allows OWNER/FINANCE_MANAGER/BRANCH_MANAGER/ACCOUNTANT but NOT SALES', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER+ALL' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'BRANCH_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'SALES' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('falls back to OWNER-only on unknown / malformed value', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER+EVERYBODY' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('falls back to OWNER-only on DB error', async () => {
+    prisma.systemConfig.findFirst.mockRejectedValue(new Error('db down'));
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('bypass marker (e.g. /settings/ui-flags) skips role check entirely', async () => {
+    // Setup: pretend handler has SETTINGS_ACCESS_BYPASS metadata
+    const handler = {};
+    Reflect.defineMetadata(SETTINGS_ACCESS_BYPASS, true, handler);
+    // SALES would normally be rejected — bypass marker means it passes
+    await expect(
+      guard.canActivate(makeContext({ role: 'SALES' }, handler, {})),
+    ).resolves.toBe(true);
+    // DB should NOT even be queried
+    expect(prisma.systemConfig.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/settings/settings-access.guard.ts
+++ b/apps/api/src/modules/settings/settings-access.guard.ts
@@ -1,0 +1,131 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  SetMetadata,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Marker metadata key — controller routes that want to opt-OUT of the
+ * dynamic settings-access check (e.g. `/settings/ui-flags`, which every
+ * authenticated user needs to read) can set this via the
+ * `@AllowAnyAuthenticated()` decorator below.
+ */
+export const SETTINGS_ACCESS_BYPASS = 'settings_access_bypass';
+
+/**
+ * D1.3.2.2 — Dynamic role gate for the Settings controller.
+ *
+ * SystemConfig key `settings_access_role` (whitelisted, default `'OWNER'`)
+ * controls which roles can hit the Settings CRUD endpoints. Default
+ * matches the pre-existing static `@Roles('OWNER')` behavior, so flipping
+ * the SystemConfig row is opt-in and current owners see no change.
+ *
+ * Allowed values:
+ *   - `'OWNER'` (default — current behavior)
+ *   - `'OWNER+FINANCE_MANAGER'`
+ *   - `'OWNER+ACCOUNTANT'`
+ *   - `'OWNER+ALL'` (OWNER + FINANCE_MANAGER + BRANCH_MANAGER + ACCOUNTANT;
+ *     intentionally excludes SALES — settings are non-trivial)
+ *
+ * The guard reads SystemConfig at request time via PrismaService directly
+ * (mirrors the `readBoolFlag` pattern from PR #884 — keeps guard ctor
+ * lean + sidesteps potential circular-dep risk). On DB error the guard
+ * falls back to default OWNER-only.
+ *
+ * Routes that should remain accessible to ALL authenticated users (e.g.
+ * `/settings/ui-flags`) must annotate themselves with the marker via
+ * `@SetMetadata(SETTINGS_ACCESS_BYPASS, true)` (helper decorator below).
+ * The class-level `@Roles(...)` on the controller is still enforced by
+ * RolesGuard, so this guard only widens; it does not replace RolesGuard.
+ *
+ * Must be applied AFTER `JwtAuthGuard` and AFTER `RolesGuard` so the
+ * widening decision sees `request.user`.
+ *
+ * Q4-gated: default behavior preserved. Owner can flip the SystemConfig
+ * row when ready.
+ */
+export const SETTINGS_ACCESS_ALLOWED_VALUES = new Set<string>([
+  'OWNER',
+  'OWNER+FINANCE_MANAGER',
+  'OWNER+ACCOUNTANT',
+  'OWNER+ALL',
+]);
+
+export const SETTINGS_ACCESS_ROLE_SETS: Record<string, ReadonlySet<string>> = {
+  OWNER: new Set(['OWNER']),
+  'OWNER+FINANCE_MANAGER': new Set(['OWNER', 'FINANCE_MANAGER']),
+  'OWNER+ACCOUNTANT': new Set(['OWNER', 'ACCOUNTANT']),
+  'OWNER+ALL': new Set(['OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT']),
+};
+
+/**
+ * Shared resolver — reads SystemConfig.settings_access_role and returns
+ * the corresponding role set. Defaults to OWNER-only on missing key,
+ * unknown value, or DB error. Used by both `SettingsAccessGuard.canActivate`
+ * AND service-side `assertCanWriteSettings()` defense-in-depth.
+ */
+export async function resolveSettingsAccessRoles(
+  prisma: PrismaService,
+): Promise<ReadonlySet<string>> {
+  try {
+    const row = await prisma.systemConfig.findFirst({
+      where: { key: 'settings_access_role', deletedAt: null },
+      select: { value: true },
+    });
+    const raw = row?.value?.trim();
+    if (raw && SETTINGS_ACCESS_ALLOWED_VALUES.has(raw)) {
+      return SETTINGS_ACCESS_ROLE_SETS[raw];
+    }
+    return SETTINGS_ACCESS_ROLE_SETS.OWNER;
+  } catch {
+    return SETTINGS_ACCESS_ROLE_SETS.OWNER;
+  }
+}
+
+@Injectable()
+export class SettingsAccessGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private prisma: PrismaService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Opt-out via marker: e.g. /settings/ui-flags is for all authenticated users.
+    const bypass = this.reflector.getAllAndOverride<boolean>(SETTINGS_ACCESS_BYPASS, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (bypass === true) return true;
+
+    const request = context.switchToHttp().getRequest<{ user?: { role?: string } }>();
+    const user = request.user;
+    if (!user || !user.role) {
+      throw new ForbiddenException('ไม่พบข้อมูลผู้ใช้');
+    }
+
+    const allowed = await this.getAllowedRoles();
+    if (allowed.has(user.role)) return true;
+
+    throw new ForbiddenException('ไม่มีสิทธิ์เข้าถึงหน้าตั้งค่า');
+  }
+
+  /**
+   * Resolve the SystemConfig key to a Set of allowed role names. Defaults
+   * to OWNER-only if the key is missing, malformed, or DB read fails.
+   */
+  async getAllowedRoles(): Promise<ReadonlySet<string>> {
+    return resolveSettingsAccessRoles(this.prisma);
+  }
+}
+
+/**
+ * Helper decorator for routes that intentionally allow any authenticated
+ * user, bypassing the SettingsAccessGuard widening logic. Use sparingly —
+ * only routes that genuinely need cross-role access (e.g. ui-flags) should
+ * carry this marker.
+ */
+export const AllowAnyAuthenticated = () => SetMetadata(SETTINGS_ACCESS_BYPASS, true);

--- a/apps/api/src/modules/settings/settings.controller.ts
+++ b/apps/api/src/modules/settings/settings.controller.ts
@@ -15,12 +15,28 @@ import {
   ROLE_MAP_WRITE_ROLES,
 } from '../journal/account-role.service';
 import { RoleMapValidationService } from './role-map-validation.service';
+import { SettingsAccessGuard, AllowAnyAuthenticated } from './settings-access.guard';
 
+/**
+ * D1.3.2.2 — class-level `@Roles(...)` is widened to the SUPERSET of any
+ * value the dynamic SystemConfig key `settings_access_role` may select
+ * (OWNER+FINANCE_MANAGER+BRANCH_MANAGER+ACCOUNTANT). `SettingsAccessGuard`
+ * then narrows per-request based on the live SystemConfig value. Default
+ * `settings_access_role = 'OWNER'` preserves OWNER-only behavior, so
+ * flipping the SystemConfig row is opt-in.
+ *
+ * SALES is intentionally excluded from the superset — settings are not
+ * sales-team workflows; widening to SALES would require a fresh security
+ * review.
+ *
+ * Per-route `@Roles(...)` decorators (e.g. role-map endpoints) still
+ * narrow the class-level allowed set as before.
+ */
 @ApiTags('Settings')
 @ApiBearerAuth('JWT')
 @Controller('settings')
-@UseGuards(JwtAuthGuard, RolesGuard)
-@Roles('OWNER')
+@UseGuards(JwtAuthGuard, RolesGuard, SettingsAccessGuard)
+@Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT')
 export class SettingsController {
   constructor(
     private settingsService: SettingsService,
@@ -37,9 +53,14 @@ export class SettingsController {
    * D1.* — UI feature flags read by web app for non-OWNER users (payroll
    * editors, accountants etc.). Authenticated but NOT @Roles-gated so the
    * web app can fetch them in any role context.
+   *
+   * D1.3.2.2 — bypass SettingsAccessGuard so SALES (and any other
+   * authenticated role) can still fetch their ui-flags regardless of the
+   * `settings_access_role` SystemConfig value.
    */
   @Get('ui-flags')
   @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT', 'SALES')
+  @AllowAnyAuthenticated()
   getUiFlags() {
     return this.settingsService.getUiFlags();
   }
@@ -88,8 +109,12 @@ export class SettingsController {
   }
 
   @Patch()
-  bulkUpdate(@Body() dto: BulkUpdateSettingsDto, @CurrentUser() user: { id: string }) {
-    return this.settingsService.bulkUpdate(dto.items, user.id);
+  bulkUpdate(
+    @Body() dto: BulkUpdateSettingsDto,
+    @CurrentUser() user: { id: string; role: string },
+  ) {
+    // D1.3.2.2 (S3) — pass role for service-side defense-in-depth check.
+    return this.settingsService.bulkUpdate(dto.items, user.id, user.role);
   }
 
   @Get('collections')
@@ -100,7 +125,7 @@ export class SettingsController {
   @Put('collections')
   async updateCollectionsConfig(
     @Body() dto: CollectionsConfigDto,
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string; role: string },
   ) {
     // Reuse existing bulkUpdate plumbing so audit log + cache invalidation
     // continue to flow through the same path as the generic Patch endpoint.
@@ -113,6 +138,7 @@ export class SettingsController {
         { key: 'collections.selfClaimLockHours', value: String(dto.selfClaimLockHours) },
       ],
       user.id,
+      user.role,
     );
     return this.settingsService.getCollectionsConfig();
   }

--- a/apps/api/src/modules/settings/settings.module.ts
+++ b/apps/api/src/modules/settings/settings.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { SettingsController } from './settings.controller';
 import { SettingsService } from './settings.service';
 import { RoleMapValidationService } from './role-map-validation.service';
+import { SettingsAccessGuard } from './settings-access.guard';
 import { JournalModule } from '../journal/journal.module';
 
 @Module({
@@ -13,7 +14,9 @@ import { JournalModule } from '../journal/journal.module';
   // `validate` callback into AccountRoleService.update().
   imports: [JournalModule],
   controllers: [SettingsController],
-  providers: [SettingsService, RoleMapValidationService],
+  // D1.3.2.2 — SettingsAccessGuard is consumed by the controller via
+  // `@UseGuards(...)` so Nest needs it in the providers list.
+  providers: [SettingsService, RoleMapValidationService, SettingsAccessGuard],
   exports: [SettingsService, RoleMapValidationService],
 })
 export class SettingsModule {}

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { DocumentType } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { readBoolFlag, readNumberFlag } from '../../utils/config.util';
 import { SSO_RATE } from '../sso-config/sso-config.service';
+import { resolveSettingsAccessRoles } from './settings-access.guard';
 
 /**
  * D1.1.3.3 — keys that are exposed read-only through SystemConfig.
@@ -120,7 +121,32 @@ export class SettingsService {
    * null/undefined skips the audit log and is reserved for system-internal
    * writes (e.g. automated migrations).
    */
-  async update(key: string, value: string, userId?: string) {
+  /**
+   * D1.3.2.2 (S3 defense-in-depth) — Service-side mirror of
+   * `SettingsAccessGuard`. Mutating callsites (`update`, `bulkUpdate`)
+   * invoke this with the request user's role. Throws ForbiddenException
+   * if the role is not in the currently-allowed bundle.
+   *
+   * The guard is the primary gate; this check survives a future refactor
+   * that accidentally widens the controller decorator or replaces the
+   * guard pipeline. `userRole === undefined` is treated as "skip check"
+   * for two legitimate cases:
+   *   - system-internal callers (cron jobs, migrations) that don't carry
+   *     a user identity (matches existing `userId === undefined` skip),
+   *   - unit tests that don't construct a full guard pipeline.
+   */
+  async assertCanWriteSettings(userRole: string | undefined): Promise<void> {
+    if (userRole === undefined) return; // system-internal / test bypass
+    const allowed = await resolveSettingsAccessRoles(this.prisma);
+    if (!allowed.has(userRole)) {
+      throw new ForbiddenException(
+        `ไม่มีสิทธิ์แก้ไขการตั้งค่า (role ปัจจุบัน: ${userRole})`,
+      );
+    }
+  }
+
+  async update(key: string, value: string, userId?: string, userRole?: string) {
+    await this.assertCanWriteSettings(userRole);
     if (READ_ONLY_KEYS.has(key)) {
       throw new BadRequestException(
         `key "${key}" เป็น read-only ตามกฎหมาย/ระเบียบ — ไม่สามารถแก้ไขผ่านระบบได้`,
@@ -790,6 +816,15 @@ export class SettingsService {
      * SystemConfig-only; no migration needed to roll forward/back.
      */
     viewerRoleEnabled: boolean;
+    /**
+     * D1.3.2.2 — dynamic bundle name controlling who can access Settings.
+     * Whitelisted: `'OWNER'` (default) / `'OWNER+FINANCE_MANAGER'` /
+     * `'OWNER+ACCOUNTANT'` / `'OWNER+ALL'`. Read at request time by
+     * `SettingsAccessGuard`; exposed here so the web app can render an
+     * informational badge on /settings. Invalid SystemConfig values fall
+     * back to `'OWNER'` (preserves OWNER-only behavior).
+     */
+    settingsAccessRole: 'OWNER' | 'OWNER+FINANCE_MANAGER' | 'OWNER+ACCOUNTANT' | 'OWNER+ALL';
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -1092,6 +1127,16 @@ export class SettingsService {
         : 300;
     // D1.3.2.1 — VIEWER role activation. Conservative default false.
     const viewerRoleEnabled = await this.readBoolean('viewer_role_enabled', false);
+    // D1.3.2.2 — settings_access_role. Whitelist 4 values; everything else
+    // (missing key, malformed value) falls back to 'OWNER' so behavior
+    // matches the pre-Phase-2 hardcoded @Roles('OWNER').
+    const settingsAccessRoleRaw = await this.getKey('settings_access_role');
+    const settingsAccessRole: 'OWNER' | 'OWNER+FINANCE_MANAGER' | 'OWNER+ACCOUNTANT' | 'OWNER+ALL' =
+      settingsAccessRoleRaw === 'OWNER+FINANCE_MANAGER' ||
+      settingsAccessRoleRaw === 'OWNER+ACCOUNTANT' ||
+      settingsAccessRoleRaw === 'OWNER+ALL'
+        ? settingsAccessRoleRaw
+        : 'OWNER';
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -1151,6 +1196,7 @@ export class SettingsService {
       cacheTtlDashboard,
       cacheTtlReports,
       viewerRoleEnabled,
+      settingsAccessRole,
     };
   }
 
@@ -1211,7 +1257,13 @@ export class SettingsService {
     });
   }
 
-  async bulkUpdate(items: { key: string; value: string }[], userId?: string) {
+  async bulkUpdate(
+    items: { key: string; value: string }[],
+    userId?: string,
+    userRole?: string,
+  ) {
+    // D1.3.2.2 (S3) — defense-in-depth role check (mirrors SettingsAccessGuard).
+    await this.assertCanWriteSettings(userRole);
     // D1.1.3.3 — reject the whole batch if any read-only key is present
     // (atomicity: don't silently drop entries; the caller has a UI bug).
     const readOnlyHit = items.find((i) => READ_ONLY_KEYS.has(i.key));

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -277,6 +277,14 @@ export interface UiFlags {
    * SystemConfig-only; no migration needed to roll forward/back.
    */
   viewerRoleEnabled: boolean;
+  /**
+   * D1.3.2.2 — dynamic bundle name controlling who can access Settings.
+   * Whitelisted: `'OWNER'` (default) / `'OWNER+FINANCE_MANAGER'` /
+   * `'OWNER+ACCOUNTANT'` / `'OWNER+ALL'`. The server's `SettingsAccessGuard`
+   * narrows per-request based on this value; the frontend uses it for the
+   * informational badge on /settings.
+   */
+  settingsAccessRole: 'OWNER' | 'OWNER+FINANCE_MANAGER' | 'OWNER+ACCOUNTANT' | 'OWNER+ALL';
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -356,6 +364,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   cacheTtlDashboard: 60,
   cacheTtlReports: 300,
   viewerRoleEnabled: false,
+  settingsAccessRole: 'OWNER',
 };
 
 export function useUiFlags(): UiFlags {


### PR DESCRIPTION
## Summary

D1 item 5. SystemConfig key `settings_access_role` (whitelisted, default `'OWNER'`) dynamically controls which roles can hit the Settings controller. Default preserves current OWNER-only behavior — owner can flip the SystemConfig row to widen at any time.

**Allowed values:**
- `'OWNER'` (default — current behavior)
- `'OWNER+FINANCE_MANAGER'`
- `'OWNER+ACCOUNTANT'`
- `'OWNER+ALL'` (OWNER+FINANCE_MANAGER+BRANCH_MANAGER+ACCOUNTANT — SALES intentionally excluded)

**Implementation:**
- `SettingsAccessGuard` new — reads SystemConfig at request time via Prisma directly. DB error → OWNER-only fallback.
- `@AllowAnyAuthenticated()` marker on `/settings/ui-flags` so SALES users keep their UI flag access.
- `getUiFlags()` exposes `settingsAccessRole` for sidebar visibility.

## Owner decision points

- **Accept**: leave the flag at `'OWNER'`; flip later when ready.
- **Reject**: revert the guard's UseGuards entry — DB row stays harmless.

## Test plan (6 cases, all in settings-access.guard.spec.ts)

- [ ] defaults to OWNER-only when SystemConfig row missing
- [ ] OWNER+FINANCE_MANAGER allows FM but not ACCOUNTANT
- [ ] OWNER+ALL allows non-SALES roles, rejects SALES
- [ ] unknown / malformed value falls back to OWNER-only
- [ ] DB error falls back to OWNER-only
- [ ] bypass marker (ui-flags) skips role check entirely
- [ ] TypeScript: api + web clean

Tracking: D1.3.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)