### PR TITLE
feat(a1): D1.3.2.3 — post_permission dynamic guard (Q4-gated)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/post-permission.guard.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/post-permission.guard.spec.ts
@@ -1,0 +1,75 @@
+import { ForbiddenException } from '@nestjs/common';
+import { PostPermissionGuard } from '../post-permission.guard';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * D1.3.2.3 — PostPermissionGuard dynamic role gating for
+ * `POST /expense-documents/:id/post`.
+ *
+ * Default: 'OWNER+FINANCE_MANAGER+ACCOUNTANT' — matches the pre-existing
+ * static `@Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')` decorator.
+ */
+
+function makeContext(user: { role?: string } | null) {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as Parameters<PostPermissionGuard['canActivate']>[0];
+}
+
+describe('PostPermissionGuard', () => {
+  let prisma: { systemConfig: { findFirst: jest.Mock } };
+  let guard: PostPermissionGuard;
+
+  beforeEach(() => {
+    prisma = {
+      systemConfig: { findFirst: jest.fn() },
+    };
+    guard = new PostPermissionGuard(prisma as unknown as PrismaService);
+  });
+
+  it('defaults to OWNER+FINANCE_MANAGER+ACCOUNTANT when SystemConfig row missing (current behavior)', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue(null);
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'BRANCH_MANAGER' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    await expect(guard.canActivate(makeContext({ role: 'SALES' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('OWNER+FINANCE_MANAGER narrows access (excludes ACCOUNTANT)', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER+FINANCE_MANAGER' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('OWNER_ONLY further narrows access to OWNER only', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER_ONLY' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('OWNER+ALL_NON_SALES adds BRANCH_MANAGER, still excludes SALES', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER+ALL_NON_SALES' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'BRANCH_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'SALES' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+});

--- a/apps/api/src/modules/expense-documents/expense-documents.controller.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.controller.ts
@@ -15,6 +15,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PostPermissionGuard } from './post-permission.guard';
 import { ExpenseDocumentsService } from './expense-documents.service';
 import { CreateExpenseDocumentDto } from './dto/create.dto';
 import { UpdateExpenseDocumentDto } from './dto/update.dto';
@@ -176,10 +177,25 @@ export class ExpenseDocumentsController {
     return this.service.update(id, dto, user.id);
   }
 
+  /**
+   * D1.3.2.3 — Post DRAFT → ACCRUAL.
+   *
+   * Class-level guards (JwtAuthGuard, RolesGuard, BranchGuard) run first.
+   * The method-level `@Roles(...)` decorator is widened to the SUPERSET of
+   * any value the dynamic SystemConfig key `post_permission` may select
+   * (OWNER + FINANCE_MANAGER + BRANCH_MANAGER + ACCOUNTANT). The
+   * `PostPermissionGuard` then narrows per-request based on the live
+   * SystemConfig value. Default `post_permission =
+   * 'OWNER+FINANCE_MANAGER+ACCOUNTANT'` preserves current behavior.
+   *
+   * SALES is intentionally excluded from the superset — they don't post
+   * accounting documents.
+   */
   @Post(':id/post')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
-  post(@Param('id') id: string, @CurrentUser() user: { id: string }) {
-    return this.service.post(id, user.id);
+  @Roles('OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT')
+  @UseGuards(PostPermissionGuard)
+  post(@Param('id') id: string, @CurrentUser() user: { id: string; role: string }) {
+    return this.service.post(id, user.id, user.role);
   }
 
   /**

--- a/apps/api/src/modules/expense-documents/expense-documents.module.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.module.ts
@@ -21,6 +21,7 @@ import { ExpenseRecurringCron } from './crons/expense-recurring.cron';
 import { PettyCashReplenishAlertCron } from './crons/petty-cash-replenish-alert.cron';
 import { DraftAlertsCron } from './crons/draft-alerts.cron';
 import { ApDueAlertsCron } from './crons/ap-due-alerts.cron';
+import { PostPermissionGuard } from './post-permission.guard';
 
 @Module({
   // NotificationsModule import is required so DraftAlertsCron + ApDueAlertsCron can
@@ -54,6 +55,8 @@ import { ApDueAlertsCron } from './crons/ap-due-alerts.cron';
     DraftAlertsCron,
     // D1.3.1.2 — AP-due alerts cron. Default OFF (opt-in) — see ap-due-alerts.cron.ts for rationale.
     ApDueAlertsCron,
+    // D1.3.2.3 — dynamic post-permission guard for POST /expense-documents/:id/post
+    PostPermissionGuard,
   ],
   exports: [ExpenseDocumentsService, ExpenseTemplatesService],
 })

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -9,6 +9,7 @@ import {
 import { Prisma, DocumentStatus } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
+import { resolvePostPermissionRoles } from './post-permission.guard';
 import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
 import { ExpenseSameDayTemplate } from '../journal/cpa-templates/expense-same-day.template';
@@ -1940,7 +1941,18 @@ export class ExpenseDocumentsService implements OnModuleInit {
   // D1.2.1.6 — also accepts APPROVED → POSTED (when approval_enabled is on
   // AND auto_post_on_approve is false, OWNER manually calls post() on an
   // APPROVED doc; assertCanPost permits both DRAFT + APPROVED).
-  async post(id: string, _userId: string) {
+  async post(id: string, _userId: string, userRole?: string) {
+    // D1.3.2.3 (S3 defense-in-depth) — mirror the PostPermissionGuard
+    // check at the service boundary. Skipped when userRole is undefined
+    // (system-internal / unit-test paths).
+    if (userRole !== undefined) {
+      const allowed = await resolvePostPermissionRoles(this.prisma);
+      if (!allowed.has(userRole)) {
+        throw new ForbiddenException(
+          `ไม่มีสิทธิ์โพสต์เอกสาร (role ปัจจุบัน: ${userRole})`,
+        );
+      }
+    }
     return this.prisma.$transaction(async (tx) => {
       // Per-doc advisory lock — serializes concurrent post calls on the same id.
       // Without this, two callers could both read DRAFT, both pass assertCanPost,

--- a/apps/api/src/modules/expense-documents/post-permission.guard.ts
+++ b/apps/api/src/modules/expense-documents/post-permission.guard.ts
@@ -1,0 +1,85 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * D1.3.2.3 — Dynamic role gate for the `POST /expense-documents/:id/post`
+ * endpoint. SystemConfig key `post_permission` (whitelisted) controls
+ * which roles can transition a doc from DRAFT → ACCRUAL.
+ *
+ * Allowed values:
+ *   - `'OWNER+FINANCE_MANAGER+ACCOUNTANT'` (default — current behavior,
+ *     matches the pre-existing static @Roles decorator)
+ *   - `'OWNER+FINANCE_MANAGER'`
+ *   - `'OWNER_ONLY'`
+ *   - `'OWNER+ALL_NON_SALES'` (OWNER+FINANCE_MANAGER+BRANCH_MANAGER+
+ *     ACCOUNTANT — widens to BRANCH_MANAGER for branch-specific posting)
+ *
+ * Default preserves current behavior (OWNER+FM+ACC). On DB error or
+ * malformed value the guard falls back to default. Q4-gated: owner can
+ * flip the SystemConfig row when ready.
+ *
+ * Pattern: mirrors `SettingsAccessGuard` (D1.3.2.2) and `readBoolFlag`
+ * (PR #884). The guard is route-specific — only the `post()` controller
+ * method needs `@UseGuards(..., PostPermissionGuard)`.
+ *
+ * RolesGuard runs first with a WIDENED `@Roles(...)` on the method (the
+ * superset of any value `post_permission` may select); this guard then
+ * narrows per-request based on the live SystemConfig value.
+ */
+const DEFAULT_VALUE = 'OWNER+FINANCE_MANAGER+ACCOUNTANT' as const;
+
+export const POST_PERMISSION_ROLE_SETS: Record<string, ReadonlySet<string>> = {
+  'OWNER+FINANCE_MANAGER+ACCOUNTANT': new Set(['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']),
+  'OWNER+FINANCE_MANAGER': new Set(['OWNER', 'FINANCE_MANAGER']),
+  OWNER_ONLY: new Set(['OWNER']),
+  'OWNER+ALL_NON_SALES': new Set(['OWNER', 'FINANCE_MANAGER', 'BRANCH_MANAGER', 'ACCOUNTANT']),
+};
+
+/**
+ * Shared resolver — reads SystemConfig.post_permission and returns the
+ * matching role set. Defaults to the current OWNER+FM+ACC bundle on
+ * missing key, unknown value, or DB error.
+ *
+ * Used by both `PostPermissionGuard.canActivate` (primary gate) AND
+ * service-side `assertCanPost()` (S3 defense-in-depth).
+ */
+export async function resolvePostPermissionRoles(
+  prisma: PrismaService,
+): Promise<ReadonlySet<string>> {
+  try {
+    const row = await prisma.systemConfig.findFirst({
+      where: { key: 'post_permission', deletedAt: null },
+      select: { value: true },
+    });
+    const raw = row?.value?.trim();
+    if (raw && POST_PERMISSION_ROLE_SETS[raw]) return POST_PERMISSION_ROLE_SETS[raw];
+    return POST_PERMISSION_ROLE_SETS[DEFAULT_VALUE];
+  } catch {
+    return POST_PERMISSION_ROLE_SETS[DEFAULT_VALUE];
+  }
+}
+
+@Injectable()
+export class PostPermissionGuard implements CanActivate {
+  constructor(private prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<{ user?: { role?: string } }>();
+    const user = request.user;
+    if (!user || !user.role) {
+      throw new ForbiddenException('ไม่พบข้อมูลผู้ใช้');
+    }
+    const allowed = await this.getAllowedRoles();
+    if (allowed.has(user.role)) return true;
+    throw new ForbiddenException('ไม่มีสิทธิ์โพสต์เอกสาร');
+  }
+
+  async getAllowedRoles(): Promise<ReadonlySet<string>> {
+    return resolvePostPermissionRoles(this.prisma);
+  }
+}

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -841,6 +841,19 @@ export class SettingsService {
      * back to `'OWNER'` (preserves OWNER-only behavior).
      */
     settingsAccessRole: 'OWNER' | 'OWNER+FINANCE_MANAGER' | 'OWNER+ACCOUNTANT' | 'OWNER+ALL';
+    /**
+     * D1.3.2.3 — dynamic bundle controlling who can POST expense documents
+     * (DRAFT → ACCRUAL). Whitelisted: `'OWNER+FINANCE_MANAGER+ACCOUNTANT'`
+     * (default — current behavior) / `'OWNER+FINANCE_MANAGER'` /
+     * `'OWNER_ONLY'` / `'OWNER+ALL_NON_SALES'`. Enforced at request time by
+     * `PostPermissionGuard`; exposed here so UIs can hide the "Post" button
+     * for roles that won't be allowed (defence against confusing 403s).
+     */
+    postPermission:
+      | 'OWNER+FINANCE_MANAGER+ACCOUNTANT'
+      | 'OWNER+FINANCE_MANAGER'
+      | 'OWNER_ONLY'
+      | 'OWNER+ALL_NON_SALES';
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -1163,6 +1176,20 @@ export class SettingsService {
       settingsAccessRoleRaw === 'OWNER+ALL'
         ? settingsAccessRoleRaw
         : 'OWNER';
+    // D1.3.2.3 — post_permission. Whitelist 4 values; everything else falls
+    // back to the default OWNER+FM+ACCOUNTANT bundle (matches the
+    // pre-Phase-2 static @Roles decorator).
+    const postPermissionRaw = await this.getKey('post_permission');
+    const postPermission:
+      | 'OWNER+FINANCE_MANAGER+ACCOUNTANT'
+      | 'OWNER+FINANCE_MANAGER'
+      | 'OWNER_ONLY'
+      | 'OWNER+ALL_NON_SALES' =
+      postPermissionRaw === 'OWNER+FINANCE_MANAGER' ||
+      postPermissionRaw === 'OWNER_ONLY' ||
+      postPermissionRaw === 'OWNER+ALL_NON_SALES'
+        ? postPermissionRaw
+        : 'OWNER+FINANCE_MANAGER+ACCOUNTANT';
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -1225,6 +1252,7 @@ export class SettingsService {
       settlementPartialPaymentEnabled,
       viewerRoleEnabled,
       settingsAccessRole,
+      postPermission,
     };
   }
 

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -298,6 +298,18 @@ export interface UiFlags {
    * informational badge on /settings.
    */
   settingsAccessRole: 'OWNER' | 'OWNER+FINANCE_MANAGER' | 'OWNER+ACCOUNTANT' | 'OWNER+ALL';
+  /**
+   * D1.3.2.3 — dynamic bundle controlling who can POST expense documents
+   * (DRAFT → ACCRUAL). Whitelisted: `'OWNER+FINANCE_MANAGER+ACCOUNTANT'`
+   * (default) / `'OWNER+FINANCE_MANAGER'` / `'OWNER_ONLY'` /
+   * `'OWNER+ALL_NON_SALES'`. UI uses this to hide the "Post" button for
+   * roles that will be 403'd at the server.
+   */
+  postPermission:
+    | 'OWNER+FINANCE_MANAGER+ACCOUNTANT'
+    | 'OWNER+FINANCE_MANAGER'
+    | 'OWNER_ONLY'
+    | 'OWNER+ALL_NON_SALES';
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -380,6 +392,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   settlementPartialPaymentEnabled: true,
   viewerRoleEnabled: false,
   settingsAccessRole: 'OWNER',
+  postPermission: 'OWNER+FINANCE_MANAGER+ACCOUNTANT',
 };
 
 export function useUiFlags(): UiFlags {


### PR DESCRIPTION
## Summary

D1 item 6. SystemConfig key `post_permission` (whitelisted, default `'OWNER+FINANCE_MANAGER+ACCOUNTANT'`) controls which roles can transition an expense doc DRAFT → ACCRUAL. Default matches the pre-existing static @Roles decorator — owner can flip the SystemConfig row to narrow OR widen at any time.

**Allowed values:**
- `'OWNER+FINANCE_MANAGER+ACCOUNTANT'` (default — current behavior)
- `'OWNER+FINANCE_MANAGER'`
- `'OWNER_ONLY'`
- `'OWNER+ALL_NON_SALES'` (widens to BRANCH_MANAGER)

**Implementation:**
- `PostPermissionGuard` new — reads SystemConfig at request time via Prisma directly. DB error → default fallback.
- `post()` controller method `@UseGuards(PostPermissionGuard)` + widened `@Roles(...)` to the SUPERSET.
- `getUiFlags()` exposes `postPermission` for UI button visibility.

## Owner decision points

- **Accept**: leave the flag at default; flip later when ready to narrow/widen.
- **Reject**: drop @UseGuards entry — DB row stays harmless.

## Test plan (4 cases)

- [ ] defaults to OWNER+FINANCE_MANAGER+ACCOUNTANT when SystemConfig row missing
- [ ] OWNER+FINANCE_MANAGER excludes ACCOUNTANT
- [ ] OWNER_ONLY rejects everyone except OWNER
- [ ] OWNER+ALL_NON_SALES adds BRANCH_MANAGER, rejects SALES
- [ ] TypeScript: api + web clean

Tracking: D1.3.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)