### PR TITLE
feat(a1): D1.3.2.4 — reverse_permission dynamic guard (Q4-gated)

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/reverse-permission.guard.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/reverse-permission.guard.spec.ts
@@ -1,0 +1,65 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ReversePermissionGuard } from '../reverse-permission.guard';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * D1.3.2.4 — ReversePermissionGuard dynamic role gating for
+ * `POST /expense-documents/:id/void` (reverse).
+ *
+ * Default: 'OWNER+FINANCE_MANAGER' — matches the pre-existing static
+ * `@Roles('OWNER', 'FINANCE_MANAGER')` decorator.
+ */
+
+function makeContext(user: { role?: string } | null) {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as Parameters<ReversePermissionGuard['canActivate']>[0];
+}
+
+describe('ReversePermissionGuard', () => {
+  let prisma: { systemConfig: { findFirst: jest.Mock } };
+  let guard: ReversePermissionGuard;
+
+  beforeEach(() => {
+    prisma = {
+      systemConfig: { findFirst: jest.fn() },
+    };
+    guard = new ReversePermissionGuard(prisma as unknown as PrismaService);
+  });
+
+  it('defaults to OWNER+FINANCE_MANAGER when SystemConfig row missing (current behavior)', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue(null);
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('OWNER_ONLY narrows to OWNER only — rejects FINANCE_MANAGER', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER_ONLY' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('falls back to default on malformed value (e.g. typo)', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'OWNER+EVERYONE' });
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'FINANCE_MANAGER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('falls back to default on DB error', async () => {
+    prisma.systemConfig.findFirst.mockRejectedValue(new Error('db down'));
+    await expect(guard.canActivate(makeContext({ role: 'OWNER' }))).resolves.toBe(true);
+    await expect(guard.canActivate(makeContext({ role: 'ACCOUNTANT' }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+});

--- a/apps/api/src/modules/expense-documents/expense-documents.controller.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.controller.ts
@@ -16,6 +16,7 @@ import { BranchGuard } from '../auth/guards/branch.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { PostPermissionGuard } from './post-permission.guard';
+import { ReversePermissionGuard } from './reverse-permission.guard';
 import { ExpenseDocumentsService } from './expense-documents.service';
 import { CreateExpenseDocumentDto } from './dto/create.dto';
 import { UpdateExpenseDocumentDto } from './dto/update.dto';
@@ -232,14 +233,25 @@ export class ExpenseDocumentsController {
     return this.service.approve(id, user.id, user.role);
   }
 
+  /**
+   * D1.3.2.4 — Reverse / void a posted doc.
+   *
+   * Class-level guards (JwtAuthGuard, RolesGuard, BranchGuard) run first.
+   * Method-level `@Roles(...)` matches the SUPERSET of any value that the
+   * dynamic SystemConfig key `reverse_permission` may select (OWNER +
+   * FINANCE_MANAGER). The `ReversePermissionGuard` then narrows
+   * per-request. Default `reverse_permission = 'OWNER+FINANCE_MANAGER'`
+   * preserves current behavior.
+   */
   @Post(':id/void')
   @Roles('OWNER', 'FINANCE_MANAGER')
+  @UseGuards(ReversePermissionGuard)
   void(
     @Param('id') id: string,
     @Body() dto: VoidExpenseDocumentDto,
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string; role: string },
   ) {
-    return this.service.voidDocument(id, user.id, dto);
+    return this.service.voidDocument(id, user.id, dto, user.role);
   }
 
   @Delete(':id')

--- a/apps/api/src/modules/expense-documents/expense-documents.module.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.module.ts
@@ -22,6 +22,7 @@ import { PettyCashReplenishAlertCron } from './crons/petty-cash-replenish-alert.
 import { DraftAlertsCron } from './crons/draft-alerts.cron';
 import { ApDueAlertsCron } from './crons/ap-due-alerts.cron';
 import { PostPermissionGuard } from './post-permission.guard';
+import { ReversePermissionGuard } from './reverse-permission.guard';
 
 @Module({
   // NotificationsModule import is required so DraftAlertsCron + ApDueAlertsCron can
@@ -57,6 +58,8 @@ import { PostPermissionGuard } from './post-permission.guard';
     ApDueAlertsCron,
     // D1.3.2.3 — dynamic post-permission guard for POST /expense-documents/:id/post
     PostPermissionGuard,
+    // D1.3.2.4 — dynamic reverse-permission guard for POST /expense-documents/:id/void
+    ReversePermissionGuard,
   ],
   exports: [ExpenseDocumentsService, ExpenseTemplatesService],
 })

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -10,6 +10,7 @@ import { Prisma, DocumentStatus } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { resolvePostPermissionRoles } from './post-permission.guard';
+import { resolveReversePermissionRoles } from './reverse-permission.guard';
 import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
 import { ExpenseSameDayTemplate } from '../journal/cpa-templates/expense-same-day.template';
@@ -2281,7 +2282,23 @@ export class ExpenseDocumentsService implements OnModuleInit {
   // C3 — Optionally accepts reasonCode + reasonDetail + reverseDate (caller-chosen
   // posting date for the reversal JE). All optional → existing parameterless
   // void path still works (back-compat).
-  async voidDocument(id: string, userId: string, dto: VoidExpenseDocumentDto = {}) {
+  async voidDocument(
+    id: string,
+    userId: string,
+    dto: VoidExpenseDocumentDto = {},
+    userRole?: string,
+  ) {
+    // D1.3.2.4 (S3 defense-in-depth) — mirror the ReversePermissionGuard
+    // check at the service boundary. Skipped when userRole is undefined
+    // (system-internal / unit-test paths).
+    if (userRole !== undefined) {
+      const allowed = await resolveReversePermissionRoles(this.prisma);
+      if (!allowed.has(userRole)) {
+        throw new ForbiddenException(
+          `ไม่มีสิทธิ์กลับรายการเอกสาร (role ปัจจุบัน: ${userRole})`,
+        );
+      }
+    }
     return this.prisma.$transaction(async (tx) => {
       // Per-doc advisory lock — serializes concurrent voids on the same id so
       // two callers cannot both pass assertCanVoid and double-post a reversal JE.

--- a/apps/api/src/modules/expense-documents/reverse-permission.guard.ts
+++ b/apps/api/src/modules/expense-documents/reverse-permission.guard.ts
@@ -1,0 +1,75 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * D1.3.2.4 — Dynamic role gate for the `POST /expense-documents/:id/void`
+ * endpoint (reverse / void). SystemConfig key `reverse_permission`
+ * (whitelisted) controls which roles can reverse a posted doc.
+ *
+ * Allowed values:
+ *   - `'OWNER+FINANCE_MANAGER'` (default — current behavior, matches the
+ *     pre-existing static `@Roles('OWNER', 'FINANCE_MANAGER')` decorator)
+ *   - `'OWNER_ONLY'` (tightens to OWNER only)
+ *
+ * Default preserves current behavior. On DB error or malformed value the
+ * guard falls back to default. Q4-gated: owner can flip the SystemConfig
+ * row when ready.
+ *
+ * Pattern: mirrors `PostPermissionGuard` (D1.3.2.3) and `readBoolFlag`
+ * (PR #884).
+ */
+const DEFAULT_VALUE = 'OWNER+FINANCE_MANAGER' as const;
+
+export const REVERSE_PERMISSION_ROLE_SETS: Record<string, ReadonlySet<string>> = {
+  'OWNER+FINANCE_MANAGER': new Set(['OWNER', 'FINANCE_MANAGER']),
+  OWNER_ONLY: new Set(['OWNER']),
+};
+
+/**
+ * Shared resolver — reads SystemConfig.reverse_permission and returns the
+ * matching role set. Defaults to OWNER+FM on missing key, unknown value,
+ * or DB error.
+ *
+ * Used by both `ReversePermissionGuard.canActivate` (primary gate) AND
+ * service-side `assertCanReverseByRole()` (S3 defense-in-depth).
+ */
+export async function resolveReversePermissionRoles(
+  prisma: PrismaService,
+): Promise<ReadonlySet<string>> {
+  try {
+    const row = await prisma.systemConfig.findFirst({
+      where: { key: 'reverse_permission', deletedAt: null },
+      select: { value: true },
+    });
+    const raw = row?.value?.trim();
+    if (raw && REVERSE_PERMISSION_ROLE_SETS[raw]) return REVERSE_PERMISSION_ROLE_SETS[raw];
+    return REVERSE_PERMISSION_ROLE_SETS[DEFAULT_VALUE];
+  } catch {
+    return REVERSE_PERMISSION_ROLE_SETS[DEFAULT_VALUE];
+  }
+}
+
+@Injectable()
+export class ReversePermissionGuard implements CanActivate {
+  constructor(private prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<{ user?: { role?: string } }>();
+    const user = request.user;
+    if (!user || !user.role) {
+      throw new ForbiddenException('ไม่พบข้อมูลผู้ใช้');
+    }
+    const allowed = await this.getAllowedRoles();
+    if (allowed.has(user.role)) return true;
+    throw new ForbiddenException('ไม่มีสิทธิ์กลับรายการเอกสาร');
+  }
+
+  async getAllowedRoles(): Promise<ReadonlySet<string>> {
+    return resolveReversePermissionRoles(this.prisma);
+  }
+}

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -878,6 +878,14 @@ export class SettingsService {
       | 'OWNER+FINANCE_MANAGER'
       | 'OWNER_ONLY'
       | 'OWNER+ALL_NON_SALES';
+    /**
+     * D1.3.2.4 — dynamic bundle controlling who can reverse/void expense
+     * documents. Whitelisted: `'OWNER+FINANCE_MANAGER'` (default — current
+     * behavior) / `'OWNER_ONLY'`. Enforced at request time by
+     * `ReversePermissionGuard`; exposed here so UIs can hide the "Void"
+     * button for roles that won't be allowed.
+     */
+    reversePermission: 'OWNER+FINANCE_MANAGER' | 'OWNER_ONLY';
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -1246,6 +1254,11 @@ export class SettingsService {
       postPermissionRaw === 'OWNER+ALL_NON_SALES'
         ? postPermissionRaw
         : 'OWNER+FINANCE_MANAGER+ACCOUNTANT';
+    // D1.3.2.4 — reverse_permission. Whitelist 2 values; everything else
+    // falls back to the default OWNER+FM bundle.
+    const reversePermissionRaw = await this.getKey('reverse_permission');
+    const reversePermission: 'OWNER+FINANCE_MANAGER' | 'OWNER_ONLY' =
+      reversePermissionRaw === 'OWNER_ONLY' ? 'OWNER_ONLY' : 'OWNER+FINANCE_MANAGER';
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -1313,6 +1326,7 @@ export class SettingsService {
       webhooksEnabled,
       settingsAccessRole,
       postPermission,
+      reversePermission,
     };
   }
 

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -335,6 +335,13 @@ export interface UiFlags {
     | 'OWNER+FINANCE_MANAGER'
     | 'OWNER_ONLY'
     | 'OWNER+ALL_NON_SALES';
+  /**
+   * D1.3.2.4 — dynamic bundle controlling who can reverse/void expense
+   * documents. Whitelisted: `'OWNER+FINANCE_MANAGER'` (default) /
+   * `'OWNER_ONLY'`. UI uses this to hide the "Void" button for roles that
+   * will be 403'd at the server.
+   */
+  reversePermission: 'OWNER+FINANCE_MANAGER' | 'OWNER_ONLY';
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -422,6 +429,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   webhooksEnabled: false,
   settingsAccessRole: 'OWNER',
   postPermission: 'OWNER+FINANCE_MANAGER+ACCOUNTANT',
+  reversePermission: 'OWNER+FINANCE_MANAGER',
 };
 
 export function useUiFlags(): UiFlags {


### PR DESCRIPTION
## Summary

D1 item 7. SystemConfig key `reverse_permission` (whitelisted, default `'OWNER+FINANCE_MANAGER'`) controls which roles can reverse/void posted documents. Default matches pre-existing @Roles — flip to `'OWNER_ONLY'` to tighten.

**Allowed values:**
- `'OWNER+FINANCE_MANAGER'` (default — current behavior)
- `'OWNER_ONLY'`

**Implementation:**
- `ReversePermissionGuard` new — Prisma direct read, DB-error → default fallback.
- `void()` controller method `@UseGuards(ReversePermissionGuard)` (static @Roles is already the SUPERSET).
- `getUiFlags()` exposes `reversePermission` for UI button visibility.

## Test plan (4 cases)

- [ ] defaults to OWNER+FINANCE_MANAGER when SystemConfig row missing
- [ ] OWNER_ONLY rejects FINANCE_MANAGER
- [ ] malformed value falls back to default
- [ ] DB error falls back to default
- [ ] TypeScript: api + web clean

Tracking: D1.3.2.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)