### PR TITLE
feat(a1): D1.1.6 follow-up — AdjustmentSection reads codes from getUiFlags

### DIFF
--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -287,5 +287,33 @@ describe('SettingsService audit trail', () => {
       const flags = await service.getUiFlags();
       expect(flags.periodCloseDay).toBe(31);
     });
+
+    // D1.1.6 — adjustmentCodes for V4 form's Multi-line Adjustment row.
+    it('adjustmentCodes defaults to 52-1104 (underpay) / 53-1503 (overpay)', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.adjustmentCodes).toEqual({ underpay: '52-1104', overpay: '53-1503' });
+    });
+
+    it('adjustmentCodes accepts OWNER override from SystemConfig', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'adjustment_code_underpay') return Promise.resolve({ value: '52-9999' });
+        if (args.where.key === 'adjustment_code_overpay') return Promise.resolve({ value: '53-9999' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.adjustmentCodes).toEqual({ underpay: '52-9999', overpay: '53-9999' });
+    });
+
+    it('adjustmentCodes rejects malformed code via regex fallback', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'adjustment_code_underpay') return Promise.resolve({ value: 'BAD-CODE' });
+        if (args.where.key === 'adjustment_code_overpay') return Promise.resolve({ value: '' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      // Both bad → fall back to legacy defaults.
+      expect(flags.adjustmentCodes).toEqual({ underpay: '52-1104', overpay: '53-1503' });
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -175,6 +175,21 @@ export class SettingsService {
      * accessibility readers via the lang attr.
      */
     language: 'th' | 'en';
+    /**
+     * D1.1.6 — adjustment account codes for the V4 multi-line Adjustment
+     * row. Frontend `AdjustmentSection.tsx` previously hardcoded
+     * '52-1104' / '53-1503'; now reads from this flag so OWNER can rebind
+     * the codes (e.g. branch-specific CoA variant) without a frontend
+     * deploy. Defaults preserve the legacy behaviour.
+     *
+     * `underpay` is suggested when amountPaid < expected (Dr side).
+     * `overpay` is suggested when amountPaid > expected (Cr side).
+     *
+     * Backend JE templates (PaymentReceipt2BTemplate, etc.) still
+     * hardcode these codes — keeping this scoped to the V4 form so
+     * server-side templates stay deterministic for golden CSV.
+     */
+    adjustmentCodes: { underpay: string; overpay: string };
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -214,6 +229,18 @@ export class SettingsService {
     // D1.2.2.6 — language. Whitelist 'th' / 'en'; everything else → 'th'.
     const languageRaw = await this.getKey('language');
     const language: 'th' | 'en' = languageRaw === 'en' ? 'en' : 'th';
+    // D1.1.6 — adjustment codes for the V4 form's manual reconciliation
+    // row. Codes must match the format `\d{2}-\d{4}` to be accepted;
+    // anything malformed falls back to the legacy default. Empty string
+    // never returned — defensive against half-saved SystemConfig rows.
+    const isValidCode = (raw: string | null): raw is string =>
+      !!raw && /^\d{2}-\d{4}$/.test(raw);
+    const underpayRaw = await this.getKey('adjustment_code_underpay');
+    const overpayRaw = await this.getKey('adjustment_code_overpay');
+    const adjustmentCodes = {
+      underpay: isValidCode(underpayRaw) ? underpayRaw : '52-1104',
+      overpay: isValidCode(overpayRaw) ? overpayRaw : '53-1503',
+    };
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -225,6 +252,7 @@ export class SettingsService {
       voucherShowQrCode,
       themeColor,
       language,
+      adjustmentCodes,
     };
   }
 

--- a/apps/web/src/components/expense-form-v4/AdjustmentSection.tsx
+++ b/apps/web/src/components/expense-form-v4/AdjustmentSection.tsx
@@ -8,9 +8,11 @@
 // This component shows the live signed sum + diff so the user can self-check
 // before POST.
 
+import { useMemo } from 'react';
 import { Plus, Trash2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import type { ExpenseAdjustmentForm } from './types';
 import { newAdjustment } from './types';
+import { useUiFlags } from '@/hooks/useUiFlags';
 
 interface Props {
   /** Reconciliation diff = amountPaid − (totalAmount − wht). Sign decides side. */
@@ -19,16 +21,16 @@ interface Props {
   onAmountPaidChange: (value: string) => void;
   adjustments: ExpenseAdjustmentForm[];
   onChange: (rows: ExpenseAdjustmentForm[]) => void;
-  /** Suggested account codes (rounding-tolerance + discount accounts, etc.) */
+  /**
+   * Suggested account codes (rounding-tolerance + discount accounts, etc.).
+   * When omitted, falls back to OWNER-configured codes from getUiFlags
+   * (`adjustmentCodes.underpay` + `adjustmentCodes.overpay`), with legacy
+   * defaults '52-1104' (Dr) + '53-1503' (Cr) baked into useUiFlags.
+   */
   suggestedAccounts?: Array<{ code: string; name: string; defaultSide: 'DR' | 'CR' }>;
   /** Sum of items + VAT − WHT — shown for context */
   netExpected: string;
 }
-
-const DEFAULT_SUGGESTED: Array<{ code: string; name: string; defaultSide: 'DR' | 'CR' }> = [
-  { code: '53-1503', name: 'กำไร/ขาดทุน-สุทธิปัดเศษ', defaultSide: 'CR' },
-  { code: '52-1104', name: 'ส่วนลดไม่จ่ายเศษสตางค์', defaultSide: 'DR' },
-];
 
 const D = (s: string) => {
   const n = parseFloat(s || '0');
@@ -43,9 +45,29 @@ export function AdjustmentSection({
   onAmountPaidChange,
   adjustments,
   onChange,
-  suggestedAccounts = DEFAULT_SUGGESTED,
+  suggestedAccounts,
   netExpected,
 }: Props) {
+  // D1.1.6 — read configurable adjustment codes from getUiFlags so OWNER
+  // can rebind without a frontend deploy. Caller-supplied list still wins
+  // (overrides the flag) — preserves backwards-compatible API.
+  const { adjustmentCodes } = useUiFlags();
+  const effectiveSuggested = useMemo(
+    () =>
+      suggestedAccounts ?? [
+        {
+          code: adjustmentCodes.overpay,
+          name: 'กำไร/ขาดทุน-สุทธิปัดเศษ',
+          defaultSide: 'CR' as const,
+        },
+        {
+          code: adjustmentCodes.underpay,
+          name: 'ส่วนลดไม่จ่ายเศษสตางค์',
+          defaultSide: 'DR' as const,
+        },
+      ],
+    [suggestedAccounts, adjustmentCodes.overpay, adjustmentCodes.underpay],
+  );
   const diffNum = D(diff);
   const adjustmentsActive = adjustments.length > 0 || Math.abs(diffNum) > 0.005;
 
@@ -145,7 +167,7 @@ export function AdjustmentSection({
                     value={row.accountCode}
                     onChange={(e) => {
                       const code = e.target.value;
-                      const match = suggestedAccounts.find((s) => s.code === code);
+                      const match = effectiveSuggested.find((s) => s.code === code);
                       updateRow(row.uid, {
                         accountCode: code,
                         side: match?.defaultSide ?? row.side,
@@ -154,7 +176,7 @@ export function AdjustmentSection({
                     className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
                   >
                     <option value="">— เลือกบัญชี —</option>
-                    {suggestedAccounts.map((s) => (
+                    {effectiveSuggested.map((s) => (
                       <option key={s.code} value={s.code}>
                         {s.code} — {s.name}
                       </option>

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -33,6 +33,12 @@ export interface UiFlags {
   themeColor: string;
   /** D1.2.2.6 — UI language. Applied to `document.lang`; i18n framework deferred. */
   language: 'th' | 'en';
+  /**
+   * D1.1.6 — adjustment account codes for the V4 multi-line Adjustment row.
+   * Frontend was hardcoding '52-1104' / '53-1503'; now reads from this flag
+   * so OWNER can rebind the codes without a frontend deploy.
+   */
+  adjustmentCodes: { underpay: string; overpay: string };
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -53,6 +59,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   voucherShowQrCode: true,
   themeColor: '#10b981',
   language: 'th',
+  adjustmentCodes: { underpay: '52-1104', overpay: '53-1503' },
 };
 
 export function useUiFlags(): UiFlags {


### PR DESCRIPTION
## Summary
- Wires the V4 form's Multi-line Adjustment row to read account codes from `getUiFlags()` instead of hardcoded '52-1104' / '53-1503', so OWNER can rebind via SystemConfig without a frontend deploy.
- Backend templates (PaymentReceipt2BTemplate etc.) intentionally keep hardcoded codes — golden CSV determinism preserved.

## Changes
- `apps/api/src/modules/settings/settings.service.ts` — adds `adjustmentCodes: { underpay, overpay }` to `getUiFlags()` return. Reads keys `adjustment_code_underpay` / `adjustment_code_overpay` with regex validation; defaults to legacy codes.
- `apps/web/src/hooks/useUiFlags.ts` — types + default fallback updated.
- `apps/web/src/components/expense-form-v4/AdjustmentSection.tsx` — `useUiFlags()` provides `effectiveSuggested`; caller-supplied `suggestedAccounts` still wins (back-compat).

## Test plan
- [x] `apps/api`: `npm test -- settings.service.spec` (29/29 pass, 3 new)
- [x] TypeScript clean both `apps/api` + `apps/web`
- [ ] Manual: OWNER edits SystemConfig `adjustment_code_underpay='52-9999'` → AdjustmentSection dropdown shows new code
- [ ] Manual: malformed value (`'BAD'`) falls back to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)