### PR TITLE
feat(a1): D1.1.3.1 follow-up — InterestConfigPage writes VAT_RATE (kills orphan collision)

### DIFF
--- a/apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql
+++ b/apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql
@@ -1,0 +1,64 @@
+-- D1.1.3.1 follow-up — soft-delete the legacy `vat_pct`/`vat_rate` rows
+-- AFTER PR #940 (the backfill) has been verified.
+--
+-- Why this lives in a SEPARATE manual file from `2026-05-17-merge-vat-rate-keys.sql`:
+--   - The backfill SQL deliberately leaves `vat_pct` in place so the operator
+--     can verify `VAT_RATE` reflects the intended percentage before destroying
+--     the source-of-truth.
+--   - InterestConfigPage previously WROTE to `vat_pct` whenever OWNER saved
+--     defaults — so even after the backfill + admin tab edit, the next time
+--     OWNER opened InterestConfigPage and clicked "บันทึก" the orphan key
+--     would regenerate. The frontend now writes to `VAT_RATE` (PR D1.1.3.1
+--     follow-up, this branch). With both halves in place this cleanup is
+--     idempotent and safe to re-run.
+--
+-- USAGE:
+--   psql "$DATABASE_URL" -f apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql
+--
+-- Operator will be prompted to type `YES_CLEANUP_VAT_PCT`. Anything else aborts.
+
+\set ON_ERROR_STOP on
+
+\echo '----------------------------------------------------------------------'
+\echo 'D1.1.3.1 follow-up — about to soft-delete legacy vat_pct/vat_rate rows.'
+\echo '----------------------------------------------------------------------'
+\echo 'Current VAT-related SystemConfig rows:'
+
+SELECT key, value, deleted_at IS NOT NULL AS soft_deleted
+FROM system_config
+WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate')
+ORDER BY key;
+
+\echo ''
+\echo 'Confirm VAT_RATE above matches the intended percentage (e.g. "7" = 7%).'
+\echo 'After this script runs, vat_pct and vat_rate rows will be soft-deleted.'
+\echo 'The frontend (InterestConfigPage) now writes to VAT_RATE so they will'
+\echo 'not regenerate on next save.'
+\echo ''
+
+\prompt 'Type YES_CLEANUP_VAT_PCT to proceed (anything else aborts): ' CONFIRMATION
+
+SELECT (:'CONFIRMATION' = 'YES_CLEANUP_VAT_PCT') AS proceed \gset
+
+\if :proceed
+  \echo 'Confirmed — soft-deleting legacy keys...'
+\else
+  \echo '!! ABORTED — confirmation string did not match YES_CLEANUP_VAT_PCT.'
+  \echo '!! Nothing was written. Re-run to retry.'
+  \q
+\endif
+
+BEGIN;
+
+-- Soft-delete (so we can revert in emergencies). Idempotent — running twice
+-- is a no-op because `deleted_at IS NULL` filters out already-deleted rows.
+UPDATE system_config
+SET deleted_at = NOW(),
+    updated_at = NOW()
+WHERE key IN ('vat_pct', 'vat_rate')
+  AND deleted_at IS NULL;
+
+COMMIT;
+
+\echo 'Cleanup complete. Verify:'
+\echo 'SELECT key, value, deleted_at FROM system_config WHERE key IN ('"'"'VAT_RATE'"'"', '"'"'vat_pct'"'"', '"'"'vat_rate'"'"');'

--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -93,6 +93,51 @@ describe('SettingsService audit trail', () => {
     expect(actions).toContain('SYSTEM_CONFIG_CREATE');
   });
 
+  // D1.1.3.1 follow-up — VAT-rate write normalisation.
+  describe('bulkUpdate VAT_RATE normalisation', () => {
+    beforeEach(() => {
+      // Mock the upsert side-effect so we can read the call args.
+      prisma.systemConfig.upsert = jest.fn(
+        (args: { where: { key: string }; update: { value: string }; create: { key: string; value: string } }) =>
+          Promise.resolve({ id: 'sc-1', key: args.where.key, value: args.update.value }),
+      );
+    });
+
+    it('rewrites vat_pct decimal form to VAT_RATE percent form', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      await service.bulkUpdate([{ key: 'vat_pct', value: '0.07' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+
+    it('passes through VAT_RATE writes unchanged', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      await service.bulkUpdate([{ key: 'VAT_RATE', value: '7' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+
+    it('rewrites legacy vat_rate alias the same way as vat_pct', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      await service.bulkUpdate([{ key: 'vat_rate', value: '0.07' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+
+    it('preserves percent-form value sent under vat_pct (operator confusion)', async () => {
+      prisma.systemConfig.findMany.mockResolvedValue([]);
+      // Operator types "7" into a field labelled vat_pct — that's percent,
+      // not decimal. Heuristic treats >=1 as already percent.
+      await service.bulkUpdate([{ key: 'vat_pct', value: '7' }], 'u-1');
+      const upsertArgs = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(upsertArgs.where).toEqual({ key: 'VAT_RATE' });
+      expect(upsertArgs.update).toEqual({ value: '7' });
+    });
+  });
+
   it('audit failure does NOT block config update (audit.log is fire-and-forget-style)', async () => {
     prisma.systemConfig.findUnique.mockResolvedValue({ value: 'old' });
     audit.log.mockRejectedValue(new Error('audit DB down'));

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -248,7 +248,46 @@ export class SettingsService {
     return { dailyCap, workloadFloor, etaPerContractMin, sessionTargetMin, selfClaimLockHours };
   }
 
+  /**
+   * D1.1.3.1 follow-up — defensive normalisation for VAT-rate writes.
+   *
+   * Legacy frontends (or operators using a generic SQL client) may still
+   * send `{ key: 'vat_pct', value: '0.07' }` to `/settings`. After PR #940
+   * (the canonical `VAT_RATE` migration) any such write resurrects the
+   * orphan key and `VatRateBootstrapService` warns on the next boot.
+   *
+   * This helper rewrites the item in-place: `vat_pct` writes become
+   * `VAT_RATE` writes, converting decimal form to percent form when
+   * needed. `vat_rate` (older legacy) treated the same. Already-canonical
+   * `VAT_RATE` items pass through unchanged.
+   *
+   * Idempotent: if both legacy and canonical keys are sent in the same
+   * batch, the canonical wins (last write wins inside the same batch).
+   */
+  private normaliseVatRateWrites(
+    items: { key: string; value: string }[],
+  ): { key: string; value: string }[] {
+    return items.map((item) => {
+      if (item.key !== 'vat_pct' && item.key !== 'vat_rate') return item;
+      const trimmed = String(item.value ?? '').trim();
+      if (!trimmed) return { key: 'VAT_RATE', value: '' };
+      const n = Number(trimmed);
+      if (!Number.isFinite(n) || n < 0) {
+        return { key: 'VAT_RATE', value: trimmed };
+      }
+      // Values < 1 are decimal-form ('0.07') → multiply by 100 for percent.
+      // Values >= 1 are already percent-form. Round to 4 decimal places so
+      // floating-point math (0.07*100=7.000000000000001) doesn't leak into
+      // the audit log or back to the UI.
+      const asPercent = n < 1 ? n * 100 : n;
+      const rounded = Math.round(asPercent * 10000) / 10000;
+      return { key: 'VAT_RATE', value: String(rounded) };
+    });
+  }
+
   async bulkUpdate(items: { key: string; value: string }[], userId?: string) {
+    // D1.1.3.1 follow-up — rewrite legacy VAT keys before persist.
+    items = this.normaliseVatRateWrites(items);
     // Fetch "before" snapshot in one query so the transaction stays bounded.
     const keys = items.map((i) => i.key);
     const existing = await this.prisma.systemConfig.findMany({

--- a/apps/web/src/pages/InterestConfigPage.tsx
+++ b/apps/web/src/pages/InterestConfigPage.tsx
@@ -67,12 +67,36 @@ function validateForm(form: typeof defaultForm): FormErrors {
   return errors;
 }
 
+/**
+ * D1.1.3.1 follow-up — InterestConfigPage now writes to canonical `VAT_RATE`
+ * (percentage form, e.g. "7") instead of legacy `vat_pct` (decimal form,
+ * e.g. "0.07"). The display + save logic for VAT below handles legacy reads
+ * (decimal form → multiply by 100 for display) so the same OWNER can swap
+ * between this page and `/settings#vat` without seeing 700% or 0.07%.
+ *
+ * Other keys (`interest_rate`, `min_down_payment_pct`, `store_commission_pct`)
+ * remain in decimal form — those don't have a canonical-key counterpart yet.
+ */
 const defaultKeys = [
   { key: 'interest_rate', label: 'อัตราดอกเบี้ยต่อเดือน (Flat rate)', step: '0.01' },
   { key: 'min_down_payment_pct', label: 'เงินดาวน์ขั้นต่ำ (%)', step: '0.01' },
   { key: 'store_commission_pct', label: 'ค่าคอมหน้าร้าน (เช่น 0.10 = 10%)', step: '0.01' },
-  { key: 'vat_pct', label: 'VAT (เช่น 0.07 = 7%)', step: '0.01' },
+  { key: 'VAT_RATE', label: 'VAT (%) — เช่น 7 = 7%', step: '0.01' },
 ];
+
+/**
+ * Mirror of `parseVatValue` from `apps/api/src/utils/vat-rate.util.ts` —
+ * converts a raw SystemConfig VAT value into the percent-form string used
+ * by this editor. `"7"` stays "7", `"0.07"` becomes "7", malformed → "7".
+ */
+function toVatPercentString(raw: string | null | undefined): string {
+  if (raw == null || String(raw).trim() === '') return '7';
+  const n = Number(String(raw).trim());
+  if (!Number.isFinite(n) || n < 0) return '7';
+  // Values < 1 are decimal form ("0.07") → multiply by 100.
+  // Values >= 1 are percent form ("7") → unchanged.
+  return String(n < 1 ? n * 100 : n);
+}
 
 export default function InterestConfigPage() {
   const queryClient = useQueryClient();
@@ -98,6 +122,14 @@ export default function InterestConfigPage() {
     if (systemConfigs.length > 0 && !defaultsChangedRef.current) {
       const map: Record<string, string> = {};
       systemConfigs.forEach((c) => { map[c.key] = c.value; });
+      // D1.1.3.1 follow-up — VAT_RATE editor stores percentage form ("7"),
+      // but legacy `vat_pct` rows may still contain decimal form ("0.07").
+      // If canonical key absent + legacy present, hydrate the editor with
+      // the canonical key's value derived from the legacy form so the
+      // user sees the expected percent in the input.
+      if (!map['VAT_RATE'] && (map['vat_pct'] || map['vat_rate'])) {
+        map['VAT_RATE'] = toVatPercentString(map['vat_pct'] || map['vat_rate']);
+      }
       setDefaults(map);
     }
   }, [systemConfigs]);
@@ -277,8 +309,9 @@ export default function InterestConfigPage() {
                   </div>
                   <div>
                     <div className="text-xs text-muted-foreground">VAT</div>
-                    {/* D1.1.3.1 — prefer canonical VAT_RATE key, fall back to legacy vat_pct */}
-                    <div className="text-lg font-bold">{defaults['VAT_RATE'] || defaults['vat_pct'] || '-'}</div>
+                    {/* D1.1.3.1 follow-up — canonical VAT_RATE (percent) only.
+                        Legacy vat_pct/vat_rate normalised at hydrate-time. */}
+                    <div className="text-lg font-bold">{defaults['VAT_RATE'] ? `${defaults['VAT_RATE']}%` : '-'}</div>
                   </div>
                 </div>
               </>


### PR DESCRIPTION
## Summary
- Closes the SAVE-path half of PR #940: previously InterestConfigPage still wrote `vat_pct` whenever OWNER saved the "ค่า Default" card, regenerating the orphan key + triggering `VatRateBootstrapService` warning on every boot.
- Frontend now writes canonical `VAT_RATE` (percent form). Legacy decimal values hydrated to percent on read so editor shows expected number.
- Backend `bulkUpdate` defensively normalises any incoming `vat_pct`/`vat_rate` write into `VAT_RATE` (belt + braces against legacy scripts / unmigrated UIs).
- Manual SQL `2026-05-17-cleanup-vat-pct-orphan.sql` soft-deletes the legacy keys after operator confirms `VAT_RATE` is correct.

## Test plan
- [x] `apps/api`: `npm test -- settings.service.spec` (30/30 pass, 4 new)
- [x] TypeScript clean both `apps/api` + `apps/web`
- [ ] Manual: open `/settings/interest-config`, "ค่า Default" → "แก้ไข" → edit VAT field → "บันทึก" → reload → `SELECT key FROM system_config WHERE key IN ('VAT_RATE','vat_pct')` should show only `VAT_RATE`
- [ ] Manual: with `vat_pct='0.07'` seeded in DB, open `/settings/interest-config` → field shows `7` (not `0.07`)
- [ ] Operations: after this lands, run `psql -f apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql` to soft-delete the orphan
- [ ] Verify: no more `VatRateBootstrapService` warnings on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)