### PR TITLE
refactor(a1): D1.2.1 — extract executePostBody helper (dedupe post/approve)

### DIFF
--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -1557,165 +1557,192 @@ export class ExpenseDocumentsService implements OnModuleInit {
         totalAmount: doc.totalAmount.toString(),
       });
 
-      // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
-      // Period-open guard at the module boundary. Previously the guard lived
-      // inside createAndPost, which broke payment + contract atomicity (it
-      // would reject mid-tx JE writes and roll back the Payment record).
-      // The guard belongs HERE because:
-      //   1. We know the canonical posting date — doc.documentDate, not
-      //      "now" (which would let a backdated post slip through if the
-      //      clock crossed midnight between create + post).
-      //   2. We know the canonical companyId — SHOP (all expense flows post
-      //      SHOP-side per accounting.md §VAT Policy; expense template
-      //      resolves SHOP later, this guard mirrors that).
-      // Resolve SHOP companyId once via tx + cache; re-using the same
-      // pattern as expense templates' getShopCompanyId.
-      const shopForPeriod = await tx.companyInfo.findFirst({
-        where: { companyCode: 'SHOP', deletedAt: null },
-        select: { id: true },
-      });
-      if (!shopForPeriod) {
-        throw new NotFoundException(
-          'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
-        );
-      }
-      // documentDate is required on the schema but defend against legacy
-      // rows with NULL via fallback to "now" (matches receipts.service +
-      // payments.service behavior — neither has a per-row date column on
-      // the doc, both pass new Date()).
-      const periodDate = doc.documentDate ?? new Date();
-      await validatePeriodOpen(tx, periodDate, shopForPeriod.id);
+      return this.executePostBody(doc, tx);
+    });
+  }
 
-      // Fix #C10 — attachment threshold enforced server-side.
-      // ATTACHMENT_REQUIRED_ABOVE_AMOUNT is set in /settings#attachment but
-      // was previously only enforced by the frontend submit button. A direct
-      // API call could POST a 500k expense with no receiptImageUrl → tax-audit
-      // risk. Defense in depth: re-check at post() before any JE is written.
-      const thresholdCfg = await tx.systemConfig.findUnique({
-        where: { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT' },
-      });
-      const rawThreshold = thresholdCfg?.value ?? '0';
-      const threshold = new Prisma.Decimal(
-        Number.isFinite(Number(rawThreshold)) ? rawThreshold : '0',
+  /**
+   * Shared post body — period guard, attachment threshold, WHT routing,
+   * JE template dispatch. Called from both post() (after assertCanPost) and
+   * approve() (after assertCanApprove + status flip to APPROVED, when
+   * auto_post_on_approve is true).
+   *
+   * Pure refactor extracted to eliminate ~150 LOC of drift-prone duplication
+   * (see deep-review finding Group 3 #1). Behaviour is identical to the inline
+   * blocks it replaces — caller is responsible for:
+   *   • advisory lock acquisition
+   *   • doc load + deletedAt check
+   *   • transition assertion (assertCanPost / assertCanApprove)
+   *   • status flip + APPROVED audit (approve path only)
+   *   • AUTO_POSTED audit after success (approve path only)
+   *
+   * Returns the JE template result (`{ journalEntryId, ... }` shape varies
+   * by template) so the caller can propagate it.
+   */
+  private async executePostBody(
+    doc: Prisma.ExpenseDocumentGetPayload<{}>,
+    tx: Prisma.TransactionClient,
+  ): Promise<unknown> {
+    const id = doc.id;
+
+    // Fix #C9 (Round 2 — moved from journal-auto.service.createAndPost):
+    // Period-open guard at the module boundary. Previously the guard lived
+    // inside createAndPost, which broke payment + contract atomicity (it
+    // would reject mid-tx JE writes and roll back the Payment record).
+    // The guard belongs HERE because:
+    //   1. We know the canonical posting date — doc.documentDate, not
+    //      "now" (which would let a backdated post slip through if the
+    //      clock crossed midnight between create + post).
+    //   2. We know the canonical companyId — SHOP (all expense flows post
+    //      SHOP-side per accounting.md §VAT Policy; expense template
+    //      resolves SHOP later, this guard mirrors that).
+    // Resolve SHOP companyId once via tx + cache; re-using the same
+    // pattern as expense templates' getShopCompanyId.
+    const shopForPeriod = await tx.companyInfo.findFirst({
+      where: { companyCode: 'SHOP', deletedAt: null },
+      select: { id: true },
+    });
+    if (!shopForPeriod) {
+      throw new NotFoundException(
+        'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
       );
-      const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
-      if (threshold.gt(0) && docTotal.gte(threshold) && !doc.receiptImageUrl) {
-        throw new BadRequestException(
-          `เอกสารยอด ${docTotal.toFixed(2)} บาท ต้องแนบไฟล์ประกอบ (เกณฑ์ ${threshold.toFixed(2)} บาท)`,
-        );
-      }
+    }
+    // documentDate is required on the schema but defend against legacy
+    // rows with NULL via fallback to "now" (matches receipts.service +
+    // payments.service behavior — neither has a per-row date column on
+    // the doc, both pass new Date()).
+    const periodDate = doc.documentDate ?? new Date();
+    await validatePeriodOpen(tx, periodDate, shopForPeriod.id);
 
-      // EXPENSE + CREDIT_NOTE + PAYROLL + VENDOR_SETTLEMENT supported
-      if (!['EXPENSE', 'CREDIT_NOTE', 'PAYROLL', 'VENDOR_SETTLEMENT'].includes(doc.documentType)) {
-        throw new BadRequestException(`type ${doc.documentType} not supported`);
-      }
+    // Fix #C10 — attachment threshold enforced server-side.
+    // ATTACHMENT_REQUIRED_ABOVE_AMOUNT is set in /settings#attachment but
+    // was previously only enforced by the frontend submit button. A direct
+    // API call could POST a 500k expense with no receiptImageUrl → tax-audit
+    // risk. Defense in depth: re-check at post() before any JE is written.
+    const thresholdCfg = await tx.systemConfig.findUnique({
+      where: { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT' },
+    });
+    const rawThreshold = thresholdCfg?.value ?? '0';
+    const threshold = new Prisma.Decimal(
+      Number.isFinite(Number(rawThreshold)) ? rawThreshold : '0',
+    );
+    const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
+    if (threshold.gt(0) && docTotal.gte(threshold) && !doc.receiptImageUrl) {
+      throw new BadRequestException(
+        `เอกสารยอด ${docTotal.toFixed(2)} บาท ต้องแนบไฟล์ประกอบ (เกณฑ์ ${threshold.toFixed(2)} บาท)`,
+      );
+    }
 
-      // Fix #C12 — WHT routing invariant. When the doc has WHT > 0, doc.whtFormType
-      // MUST be non-null (and a recognised form). Previously the JE template silently
-      // defaulted to PND3 → routed to 21-3102, misfiling juristic-vendor WHT under
-      // ภ.ง.ด.3 instead of ภ.ง.ด.53 (government compliance bug).
-      //
-      // C12-symmetry (this PR): mirror the guard across all 4 doc types so any
-      // future bypass surfaces at post() instead of being silently misrouted by
-      // the template. Each doc type carries WHT differently:
-      //   - EXPENSE: doc.whtFormType OR every ExpenseLine.whtFormType is set
-      //     (per-line routing — P2-4)
-      //   - PAYROLL: doc.withholdingTax > 0 → always Cr 21-3101 (ภ.ง.ด.1) —
-      //     payroll WHT is employee income tax, NOT PND3/PND53, so no formType
-      //     enforcement here (BUT we still require it to be null since the field
-      //     is meaningless for payroll)
-      //   - VENDOR_SETTLEMENT: single-vendor invariant means doc-level form type
-      //     applies (intentionally no per-line routing per accounting.md)
-      //   - CREDIT_NOTE: createCreditNote already blocks original-with-WHT
-      //     (so CN itself ideally has no WHT), but if the original had WHT and
-      //     this branch is reached, we still need doc-level formType
-      const wht = new Prisma.Decimal(doc.withholdingTax?.toString() ?? '0');
-      if (wht.gt(0)) {
-        if (doc.documentType === 'EXPENSE') {
-          if (!doc.whtFormType) {
-            // Check if every WHT-bearing line has its own form type → fall through to
-            // per-line routing in the template. Otherwise the doc-level is mandatory.
-            const detail = await tx.expenseDetail.findUnique({
-              where: { documentId: id },
-              include: { lines: true },
-            });
-            const whtLines = (detail?.lines ?? []).filter(
-              (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
-            );
-            const allLinesHaveFormType =
-              whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
-            if (!allLinesHaveFormType) {
-              throw new BadRequestException(
-                'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
-              );
-            }
-            // If every line has a form type, validate each is PND3/PND53 (no other strings)
-            for (const l of whtLines) {
-              if (l.whtFormType !== 'PND3' && l.whtFormType !== 'PND53') {
-                throw new BadRequestException(
-                  `whtFormType ของบรรทัด ${(l as { lineNo?: number }).lineNo ?? '?'} ` +
-                    `ต้องเป็น PND3 หรือ PND53 (พบ ${l.whtFormType ?? 'null'})`,
-                );
-              }
-            }
-          } else if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
-            throw new BadRequestException(
-              `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
-            );
-          }
-        } else if (doc.documentType === 'VENDOR_SETTLEMENT' || doc.documentType === 'CREDIT_NOTE') {
-          // Per-line routing intentionally NOT supported for SE (single-vendor
-          // invariant per accounting.md) and CN (template routes by original.whtFormType
-          // since CN itself carries no WHT — but defense in depth).
-          if (!doc.whtFormType) {
+    // EXPENSE + CREDIT_NOTE + PAYROLL + VENDOR_SETTLEMENT supported
+    if (!['EXPENSE', 'CREDIT_NOTE', 'PAYROLL', 'VENDOR_SETTLEMENT'].includes(doc.documentType)) {
+      throw new BadRequestException(`type ${doc.documentType} not supported`);
+    }
+
+    // Fix #C12 — WHT routing invariant. When the doc has WHT > 0, doc.whtFormType
+    // MUST be non-null (and a recognised form). Previously the JE template silently
+    // defaulted to PND3 → routed to 21-3102, misfiling juristic-vendor WHT under
+    // ภ.ง.ด.3 instead of ภ.ง.ด.53 (government compliance bug).
+    //
+    // C12-symmetry: mirror the guard across all 4 doc types so any
+    // future bypass surfaces at post() instead of being silently misrouted by
+    // the template. Each doc type carries WHT differently:
+    //   - EXPENSE: doc.whtFormType OR every ExpenseLine.whtFormType is set
+    //     (per-line routing — P2-4)
+    //   - PAYROLL: doc.withholdingTax > 0 → always Cr 21-3101 (ภ.ง.ด.1) —
+    //     payroll WHT is employee income tax, NOT PND3/PND53, so no formType
+    //     enforcement here (BUT we still require it to be null since the field
+    //     is meaningless for payroll)
+    //   - VENDOR_SETTLEMENT: single-vendor invariant means doc-level form type
+    //     applies (intentionally no per-line routing per accounting.md)
+    //   - CREDIT_NOTE: createCreditNote already blocks original-with-WHT
+    //     (so CN itself ideally has no WHT), but if the original had WHT and
+    //     this branch is reached, we still need doc-level formType
+    const wht = new Prisma.Decimal(doc.withholdingTax?.toString() ?? '0');
+    if (wht.gt(0)) {
+      if (doc.documentType === 'EXPENSE') {
+        if (!doc.whtFormType) {
+          // Check if every WHT-bearing line has its own form type → fall through to
+          // per-line routing in the template. Otherwise the doc-level is mandatory.
+          const detail = await tx.expenseDetail.findUnique({
+            where: { documentId: id },
+            include: { lines: true },
+          });
+          const whtLines = (detail?.lines ?? []).filter(
+            (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
+          );
+          const allLinesHaveFormType =
+            whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
+          if (!allLinesHaveFormType) {
             throw new BadRequestException(
               'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
             );
           }
-          if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
-            throw new BadRequestException(
-              `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
-            );
+          // If every line has a form type, validate each is PND3/PND53 (no other strings)
+          for (const l of whtLines) {
+            if (l.whtFormType !== 'PND3' && l.whtFormType !== 'PND53') {
+              throw new BadRequestException(
+                `whtFormType ของบรรทัด ${(l as { lineNo?: number }).lineNo ?? '?'} ` +
+                  `ต้องเป็น PND3 หรือ PND53 (พบ ${l.whtFormType ?? 'null'})`,
+              );
+            }
           }
-        }
-        // PAYROLL: doc.whtFormType is meaningless (employee income tax always
-        // routes to 21-3101 / ภ.ง.ด.1). No enforcement — payroll.template
-        // posts to 21-3101 unconditionally when sumWht > 0.
-      }
-
-      if (doc.documentType === 'CREDIT_NOTE') {
-        return this.creditNoteTemplate.execute(id, tx);
-      }
-      if (doc.documentType === 'PAYROLL') {
-        return this.payrollTemplate.execute(id, tx);
-      }
-      if (doc.documentType === 'VENDOR_SETTLEMENT') {
-        return this.settlementTemplate.execute(id, tx);
-      }
-      if (doc.documentType === 'PETTY_CASH_REIMBURSEMENT') {
-        return this.pettyCashTemplate.execute(id, tx);
-      }
-      const target = this.transition.resolveTargetStatus(
-        doc.documentType,
-        !!doc.paymentMethod && !!doc.depositAccountCode,
-      );
-      if (target === 'POSTED') {
-        return this.sameDayTemplate.execute(id, tx);
-      } else {
-        // V15 — ACCRUAL ห้ามมี WHT (ม.50 ป.รัษฎากร).
-        // WHT เกิด "ขณะที่จ่ายเงินได้" → ACCRUAL is the accrual leg before
-        // payment, so WHT must defer to the SETTLEMENT step. Booking WHT now
-        // would put it in the wrong tax period and cause ภงด.53 misfile.
-        // Fix Report P0-2.
-        if (doc.withholdingTax && doc.withholdingTax.gt(0)) {
+        } else if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
           throw new BadRequestException(
-            'V15: เอกสารตั้งหนี้ (ACCRUAL) ห้ามมี WHT (มาตรา 50 ป.รัษฎากร) — ' +
-              'WHT จะถูกบันทึกตอน Settlement เมื่อจ่ายเงินจริง',
+            `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
           );
         }
-        return this.accrualTemplate.execute(id, tx);
+      } else if (doc.documentType === 'VENDOR_SETTLEMENT' || doc.documentType === 'CREDIT_NOTE') {
+        // Per-line routing intentionally NOT supported for SE (single-vendor
+        // invariant per accounting.md) and CN (template routes by original.whtFormType
+        // since CN itself carries no WHT — but defense in depth).
+        if (!doc.whtFormType) {
+          throw new BadRequestException(
+            'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
+          );
+        }
+        if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
+          throw new BadRequestException(
+            `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
+          );
+        }
       }
-    });
+      // PAYROLL: doc.whtFormType is meaningless (employee income tax always
+      // routes to 21-3101 / ภ.ง.ด.1). No enforcement — payroll.template
+      // posts to 21-3101 unconditionally when sumWht > 0.
+    }
+
+    if (doc.documentType === 'CREDIT_NOTE') {
+      return this.creditNoteTemplate.execute(id, tx);
+    }
+    if (doc.documentType === 'PAYROLL') {
+      return this.payrollTemplate.execute(id, tx);
+    }
+    if (doc.documentType === 'VENDOR_SETTLEMENT') {
+      return this.settlementTemplate.execute(id, tx);
+    }
+    if (doc.documentType === 'PETTY_CASH_REIMBURSEMENT') {
+      return this.pettyCashTemplate.execute(id, tx);
+    }
+    const target = this.transition.resolveTargetStatus(
+      doc.documentType,
+      !!doc.paymentMethod && !!doc.depositAccountCode,
+    );
+    if (target === 'POSTED') {
+      return this.sameDayTemplate.execute(id, tx);
+    } else {
+      // V15 — ACCRUAL ห้ามมี WHT (ม.50 ป.รัษฎากร).
+      // WHT เกิด "ขณะที่จ่ายเงินได้" → ACCRUAL is the accrual leg before
+      // payment, so WHT must defer to the SETTLEMENT step. Booking WHT now
+      // would put it in the wrong tax period and cause ภงด.53 misfile.
+      // Fix Report P0-2.
+      if (doc.withholdingTax && doc.withholdingTax.gt(0)) {
+        throw new BadRequestException(
+          'V15: เอกสารตั้งหนี้ (ACCRUAL) ห้ามมี WHT (มาตรา 50 ป.รัษฎากร) — ' +
+            'WHT จะถูกบันทึกตอน Settlement เมื่อจ่ายเงินจริง',
+        );
+      }
+      return this.accrualTemplate.execute(id, tx);
+    }
   }
 
   // ─── Approve (PENDING_APPROVAL → APPROVED → optionally POSTED) ────────
@@ -1771,121 +1798,13 @@ export class ExpenseDocumentsService implements OnModuleInit {
         return tx.expenseDocument.findUniqueOrThrow({ where: { id } });
       }
 
-      // Auto-post chain — replicates the body of post() but skips the lock
-      // (already held) and the assertCanPost from-DRAFT check (we just set
-      // APPROVED, and the same guard permits APPROVED).
-      // We DO re-run all the integrity guards (period open, attachment,
-      // WHT routing, etc.) because they validate the doc itself, not the
-      // transition. Pulling these out of post() into a shared helper would
-      // be cleaner but risks a wider blast radius — keep the duplication
-      // tight to this method until D1.2.1.1 wires the DRAFT→PENDING gate.
-      const shopForPeriod = await tx.companyInfo.findFirst({
-        where: { companyCode: 'SHOP', deletedAt: null },
-        select: { id: true },
-      });
-      if (!shopForPeriod) {
-        throw new NotFoundException(
-          'CompanyInfo with companyCode=SHOP not found — seed accounting data first',
-        );
-      }
-      const periodDate = doc.documentDate ?? new Date();
-      await validatePeriodOpen(tx, periodDate, shopForPeriod.id);
-
-      const thresholdCfg = await tx.systemConfig.findUnique({
-        where: { key: 'ATTACHMENT_REQUIRED_ABOVE_AMOUNT' },
-      });
-      const rawThreshold = thresholdCfg?.value ?? '0';
-      const threshold = new Prisma.Decimal(
-        Number.isFinite(Number(rawThreshold)) ? rawThreshold : '0',
-      );
-      const docTotal = new Prisma.Decimal(doc.totalAmount.toString());
-      if (threshold.gt(0) && docTotal.gte(threshold) && !doc.receiptImageUrl) {
-        throw new BadRequestException(
-          `เอกสารยอด ${docTotal.toFixed(2)} บาท ต้องแนบไฟล์ประกอบ (เกณฑ์ ${threshold.toFixed(2)} บาท)`,
-        );
-      }
-
-      if (!['EXPENSE', 'CREDIT_NOTE', 'PAYROLL', 'VENDOR_SETTLEMENT'].includes(doc.documentType)) {
-        throw new BadRequestException(`type ${doc.documentType} not supported`);
-      }
-
-      // WHT routing guard (mirrors post() — defense in depth)
-      const wht = new Prisma.Decimal(doc.withholdingTax?.toString() ?? '0');
-      if (wht.gt(0)) {
-        if (doc.documentType === 'EXPENSE') {
-          if (!doc.whtFormType) {
-            const detail = await tx.expenseDetail.findUnique({
-              where: { documentId: id },
-              include: { lines: true },
-            });
-            const whtLines = (detail?.lines ?? []).filter(
-              (l) => l.whtAmount && new Prisma.Decimal(l.whtAmount.toString()).gt(0),
-            );
-            const allLinesHaveFormType =
-              whtLines.length > 0 && whtLines.every((l) => !!l.whtFormType);
-            if (!allLinesHaveFormType) {
-              throw new BadRequestException(
-                'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
-              );
-            }
-            for (const l of whtLines) {
-              if (l.whtFormType !== 'PND3' && l.whtFormType !== 'PND53') {
-                throw new BadRequestException(
-                  `whtFormType ของบรรทัด ${(l as { lineNo?: number }).lineNo ?? '?'} ` +
-                    `ต้องเป็น PND3 หรือ PND53 (พบ ${l.whtFormType ?? 'null'})`,
-                );
-              }
-            }
-          } else if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
-            throw new BadRequestException(
-              `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
-            );
-          }
-        } else if (
-          doc.documentType === 'VENDOR_SETTLEMENT' ||
-          doc.documentType === 'CREDIT_NOTE'
-        ) {
-          if (!doc.whtFormType) {
-            throw new BadRequestException(
-              'whtFormType ต้องระบุเมื่อมี WHT — เลือก PND3 หรือ PND53',
-            );
-          }
-          if (doc.whtFormType !== 'PND3' && doc.whtFormType !== 'PND53') {
-            throw new BadRequestException(
-              `whtFormType ต้องเป็น PND3 หรือ PND53 (พบ ${doc.whtFormType})`,
-            );
-          }
-        }
-      }
-
-      // Capture the auto-post result so we can write an AUTO_POSTED audit
-      // log after the template runs (still inside the same $transaction).
-      let result;
-      if (doc.documentType === 'CREDIT_NOTE') {
-        result = await this.creditNoteTemplate.execute(id, tx);
-      } else if (doc.documentType === 'PAYROLL') {
-        result = await this.payrollTemplate.execute(id, tx);
-      } else if (doc.documentType === 'VENDOR_SETTLEMENT') {
-        result = await this.settlementTemplate.execute(id, tx);
-      } else if (doc.documentType === 'PETTY_CASH_REIMBURSEMENT') {
-        result = await this.pettyCashTemplate.execute(id, tx);
-      } else {
-        const target = this.transition.resolveTargetStatus(
-          doc.documentType,
-          !!doc.paymentMethod && !!doc.depositAccountCode,
-        );
-        if (target === 'POSTED') {
-          result = await this.sameDayTemplate.execute(id, tx);
-        } else {
-          if (doc.withholdingTax && doc.withholdingTax.gt(0)) {
-            throw new BadRequestException(
-              'V15: เอกสารตั้งหนี้ (ACCRUAL) ห้ามมี WHT (มาตรา 50 ป.รัษฎากร) — ' +
-                'WHT จะถูกบันทึกตอน Settlement เมื่อจ่ายเงินจริง',
-            );
-          }
-          result = await this.accrualTemplate.execute(id, tx);
-        }
-      }
+      // Auto-post chain — delegated to executePostBody() shared helper.
+      // Skips the lock (already held) and the from-DRAFT assertCanPost (we
+      // just set APPROVED, which assertCanPost permits per D1.2.1.6). All
+      // integrity guards (period open, attachment threshold, WHT routing,
+      // V15 ACCRUAL-no-WHT, type allow-list) run via the helper so any
+      // future change to those guards lands in both paths automatically.
+      const result = await this.executePostBody(doc, tx);
 
       // D1.2.1.6 — AUTO_POSTED audit log (only when auto_post_on_approve=true
       // and the auto-post chain completed without throwing).


### PR DESCRIPTION
## Summary

Pure refactor — no behaviour change. Extracts the period guard, attachment threshold, type allow-list, WHT routing guard, and JE template dispatch from `post()` into a new private `executePostBody()` helper, called from both `post()` and `approve()` (when `auto_post_on_approve=true`).

Net delta: **180 ins / 261 del = −81 LOC**.

## Why

Deep-review finding Group 3 #1: `approve()` (added in #912) duplicates ~150 LOC of `post()` body. Any future change to `post()`'s guards (added by upcoming D1.2.1.x PRs or unrelated hardening) would silently bypass the same guard on the auto-post-on-approve chain. The drift risk was already called out in the inline comment that #912 itself added:

> Pulling these out of post() into a shared helper would be cleaner but risks a wider blast radius — keep the duplication tight to this method until D1.2.1.1 wires the DRAFT→PENDING gate.

Now that the second site exists (and the D1.2.1.x stack is ready to ship), the **duplication is the bigger risk than the refactor**.

## What stays in `post()` / `approve()`

The helper is private + behaviour-identical. Callers retain responsibility for:

- Advisory lock acquisition (`pg_advisory_xact_lock`)
- Doc load + `deletedAt` check
- Transition assertion (`assertCanPost` / `assertCanApprove`)
- Status flip to `APPROVED` + `APPROVED` audit log (approve path only)
- `AUTO_POSTED` audit log after success (approve path only)

## What moves into `executePostBody()`

- Period-open guard (Fix #C9)
- Attachment threshold (Fix #C10)
- Type allow-list check
- WHT routing guard (Fix #C12 + symmetry across EXPENSE/SE/CN)
- JE template dispatch (CN / Payroll / SE / PettyCash / SameDay / Accrual)
- V15 ACCRUAL-no-WHT guard

## Stacking

Stacked PR — base = `feat/a1-d1.2.1.6-auto-post-on-approve` (#912). The approve() method (containing the largest divergence point) was added in #912, so this refactor is built off that branch.

**Merge order:** wait for all D1.2.1.x PRs (#912, #923, #930, #931, #932, #933) to land on `main`, then re-base this onto `main`. Merging earlier risks conflicts on any approval-gate guards those PRs add inside `post()` / `approve()`.

D1.2.1.1-1.6 are unaffected — they continue to ship independently per anti-pattern #3.

## Test plan

- [x] Service unit tests: **67/67 pass** (including the 8 `approve (D1.2.1.6)` cases that exercise both auto-post-on / auto-post-off paths + attachment guard + audit logs)
- [x] Controller unit tests: **13/13 pass**
- [x] TypeScript: only pre-existing TS2367 errors in `status-transition.service.ts` (existed on base branch — confirmed via `git stash`)
- [ ] Smoke test the manual approve → post path in dev (post-merge)
- [ ] Smoke test the auto-post-on-approve path with each documentType: EXPENSE / CREDIT_NOTE / PAYROLL / VENDOR_SETTLEMENT (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)