### PR TITLE
fix(a1): D1.2.4.3 follow-up — lock single-branch users to own branch in template list

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-templates.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-templates.service.spec.ts
@@ -69,6 +69,40 @@ describe('ExpenseTemplatesService', () => {
         }),
       );
     });
+
+    // ── Branch-scope hardening (Group 1 review follow-up) ──────────────
+    it('OWNER (cross-branch) sees all branches when no filter passed', async () => {
+      await service.list({}, { id: 'u1', branchId: 'b1', role: 'OWNER' });
+      // No branchId on the where clause = "all branches" (cross-branch view)
+      const callArg = prisma.expenseTemplate.findMany.mock.calls[0][0];
+      expect(callArg.where.deletedAt).toBeNull();
+      expect(callArg.where.branchId).toBeUndefined();
+    });
+
+    it('SALES (single-branch) is locked to user.branchId — ignores cross-branch filter', async () => {
+      // SALES tries to spoof another branch via ?branchId=b2 — must be forced back to b1
+      await service.list({ branchId: 'b2' }, { id: 'u1', branchId: 'b1', role: 'SALES' });
+      expect(prisma.expenseTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ branchId: 'b1', deletedAt: null }),
+        }),
+      );
+    });
+
+    it('SALES with no user.branchId is rejected (misconfigured user)', async () => {
+      await expect(
+        service.list({ branchId: 'b2' }, { id: 'u1', branchId: null, role: 'SALES' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('BRANCH_MANAGER without filter is locked to their own branch', async () => {
+      await service.list({}, { id: 'u1', branchId: 'b1', role: 'BRANCH_MANAGER' });
+      expect(prisma.expenseTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ branchId: 'b1', deletedAt: null }),
+        }),
+      );
+    });
   });
 
   describe('softDelete', () => {

--- a/apps/api/src/modules/expense-documents/expense-templates.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-templates.service.ts
@@ -61,8 +61,27 @@ export class ExpenseTemplatesService {
 
   async list(filters: { branchId?: string; type?: string }, user: UserContext) {
     const where: Prisma.ExpenseTemplateWhereInput = { deletedAt: null };
-    const branchId = hasCrossBranchAccess(user) ? filters.branchId : (user.branchId ?? filters.branchId);
-    if (branchId) where.branchId = branchId;
+
+    // Branch-scope enforcement.
+    // Cross-branch roles (OWNER / FINANCE_MANAGER / ACCOUNTANT) see ALL
+    //   templates by default, optionally filtered by ?branchId.
+    // Single-branch roles (SALES / BRANCH_MANAGER) MUST be locked to
+    //   `user.branchId`. The previous logic fell through to
+    //   `filters.branchId` when `user.branchId` was nullish, which let a
+    //   single-branch user pass `?branchId=<anyOtherBranchId>` and read
+    //   templates from a sibling shop. We now ignore the filter for
+    //   single-branch users (or 403 if their branchId is missing — a
+    //   misconfigured user record is a programming error, not a security
+    //   bypass).
+    if (hasCrossBranchAccess(user)) {
+      if (filters.branchId) where.branchId = filters.branchId;
+    } else {
+      if (!user.branchId) {
+        throw new ForbiddenException('ผู้ใช้งานยังไม่ได้ผูกกับสาขา ไม่สามารถดูรายการโปรดได้');
+      }
+      where.branchId = user.branchId;
+    }
+
     if (filters.type) where.documentType = filters.type as never;
     // Hard cap on rows returned. Favorites are user-curated so this should
     // never realistically be hit, but it prevents an unbounded findMany if a


### PR DESCRIPTION
## Summary

Group 1 review flagged a cross-branch leak in `ExpenseTemplatesService.list()`. The old branch-scope logic fell through to `filters.branchId` when `user.branchId` was nullish, letting a single-branch user (SALES / BRANCH_MANAGER) pass `?branchId=<otherBranch>` and read templates from sibling shops. It also omitted the `branchId` filter entirely when neither was set — returning all branches.

Note: `ExpenseTemplate` schema does NOT (yet) have a `visibility` field (PUBLIC / PRIVATE / TEAM) on `main`. The visibility-tier work referenced in the original review thread is pre-merge. This PR hardens the branch-scope filter as it exists today; the visibility tier can layer on top without further change to this clause.

## What changed

`apps/api/src/modules/expense-documents/expense-templates.service.ts`:

```ts
if (hasCrossBranchAccess(user)) {
  if (filters.branchId) where.branchId = filters.branchId;
} else {
  if (!user.branchId) {
    throw new ForbiddenException('ผู้ใช้งานยังไม่ได้ผูกกับสาขา ...');
  }
  where.branchId = user.branchId;
}
```

- OWNER / FINANCE_MANAGER / ACCOUNTANT → all branches (optionally `?branchId=<x>` to scope)
- SALES / BRANCH_MANAGER → forced `where.branchId = user.branchId` (filter from query string is ignored)
- SALES / BRANCH_MANAGER without `user.branchId` → 403 (misconfigured user)

## Follow-up to

- Group 1 review observation on D1 deep review session — `ExpenseTemplate.branchId` filter optional could leak across branches when caller lacks cross-branch access

## Dependencies

- None. This PR is off `origin/main` directly. The original review thread mentioned PR #919 (a visibility-tier PR); that work is independent and not blocking this hardening.

## Test plan

- [x] `expense-templates.service.spec.ts` — 12/12 pass (4 new cases):
  - OWNER (cross-branch) sees all branches when no filter
  - SALES (single-branch) cannot spoof another branch via `?branchId=`
  - SALES with no `user.branchId` is rejected
  - BRANCH_MANAGER without filter is locked to their own branch
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)