### PR TITLE
fix(a1): D1.2.1.5 follow-up — enrich APPROVAL_REQUESTED audit with PII-safe doc summary

### DIFF
--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.service.spec.ts
@@ -681,15 +681,48 @@ describe('ExpenseDocumentsService', () => {
 
   // D1.2.1.5 — notification_on_pending fan-out
   describe('submitForApproval + notifyApprovers (D1.2.1.5)', () => {
-    function setupDraftDoc() {
-      const docFields = {
+    function setupDraftDoc(
+      overrides: Partial<{
+        documentType: string;
+        vendorName: string | null;
+        expenseLineCount: number;
+        payrollPeriod: string;
+        payrollLineCount: number;
+        settlementLineCount: number;
+      }> = {},
+    ) {
+      const documentType = overrides.documentType ?? 'EXPENSE';
+      const docFields: Record<string, unknown> = {
         id: 'doc-sub-n',
         number: 'EX-20260510-0001',
         status: 'DRAFT',
-        documentType: 'EXPENSE',
+        documentType,
+        vendorName: overrides.vendorName ?? null,
         totalAmount: new Decimal('500.00'),
         deletedAt: null,
       };
+      // Attach the related-detail include shape that submitForApproval pulls
+      // for its PDPA-safe audit summary. Each branch only gets the relation
+      // for its own documentType to mirror real Prisma behavior.
+      if (documentType === 'EXPENSE') {
+        const n = overrides.expenseLineCount ?? 2;
+        docFields.expenseDetail = {
+          lines: Array.from({ length: n }, (_, i) => ({ id: `line-${i}` })),
+        };
+      } else if (documentType === 'PAYROLL') {
+        const n = overrides.payrollLineCount ?? 3;
+        docFields.payroll = {
+          payrollPeriod: overrides.payrollPeriod ?? '2026-05',
+          lines: Array.from({ length: n }, (_, i) => ({ id: `pline-${i}` })),
+        };
+      } else if (documentType === 'VENDOR_SETTLEMENT') {
+        const n = overrides.settlementLineCount ?? 1;
+        docFields.settlement = {
+          settlementLines: Array.from({ length: n }, (_, i) => ({ id: `sline-${i}` })),
+        };
+      } else if (documentType === 'CREDIT_NOTE') {
+        docFields.creditNote = { mode: 'LINKED' };
+      }
       prisma.expenseDocument.findUniqueOrThrow.mockResolvedValue(docFields);
       // update() in the global mock returns a stub w/o totalAmount → set it
       // explicitly so submitForApproval's notifyApprovers() can read it.
@@ -815,6 +848,82 @@ describe('ExpenseDocumentsService', () => {
       expect(arg.data.newValue.documentNumber).toBe('EX-20260510-0001');
       expect(arg.data.newValue.totalAmount).toBe('500');
       expect(arg.data.newValue.documentType).toBe('EXPENSE');
+    });
+
+    // ── PDPA-safe summary on APPROVAL_REQUESTED audit (W4) ─────────────
+    // Enrich audit.newValue with non-PII contextual fields so compliance
+    // can reconstruct who-approved-what WITHOUT line-level salary data.
+    describe('APPROVAL_REQUESTED audit — PDPA-safe summary (D1.2.1.5 follow-up)', () => {
+      function getRequestedAudit() {
+        const auditCalls = prisma.auditLog.create.mock.calls;
+        const requestedCall = auditCalls.find((c: unknown[]) => {
+          const arg = c[0] as { data?: { action?: string } };
+          return arg?.data?.action === 'APPROVAL_REQUESTED';
+        });
+        expect(requestedCall).toBeDefined();
+        return (requestedCall![0] as { data: { newValue: Record<string, unknown> } }).data.newValue;
+      }
+
+      it('EXPENSE submit → audit has documentNumber + totalAmount + vendorName + lineCount + requesterUserId', async () => {
+        setupDraftDoc({
+          documentType: 'EXPENSE',
+          vendorName: 'การไฟฟ้านครหลวง',
+          expenseLineCount: 4,
+        });
+        prisma.systemConfig.findFirst.mockResolvedValue(null);
+        prisma.user.findMany.mockResolvedValue([]);
+        await service.submitForApproval('doc-sub-n', 'user-1');
+        const v = getRequestedAudit();
+        expect(v.documentNumber).toBe('EX-20260510-0001');
+        expect(v.totalAmount).toBe('500');
+        expect(v.documentType).toBe('EXPENSE');
+        expect(v.vendorName).toBe('การไฟฟ้านครหลวง');
+        expect(v.requesterUserId).toBe('user-1');
+        expect(v.lineCount).toBe(4);
+        // No employee data on EXPENSE — payrollPeriod must be absent
+        expect(v.payrollPeriod).toBeUndefined();
+      });
+
+      it('PAYROLL submit → audit has payrollPeriod + lineCount, NO employee names / salaries', async () => {
+        setupDraftDoc({
+          documentType: 'PAYROLL',
+          payrollPeriod: '2026-05',
+          payrollLineCount: 8,
+        });
+        prisma.systemConfig.findFirst.mockResolvedValue(null);
+        prisma.user.findMany.mockResolvedValue([]);
+        await service.submitForApproval('doc-sub-n', 'user-1');
+        const v = getRequestedAudit();
+        expect(v.documentNumber).toBe('EX-20260510-0001');
+        expect(v.documentType).toBe('PAYROLL');
+        expect(v.payrollPeriod).toBe('2026-05');
+        expect(v.lineCount).toBe(8);
+        expect(v.requesterUserId).toBe('user-1');
+        // PDPA: payroll line bodies (employeeName, employeeTaxId, baseSalary,
+        // ssoEmployee, netPaid, whtAmount) must NOT appear in the audit payload
+        const json = JSON.stringify(v);
+        expect(json).not.toMatch(/employeeName/i);
+        expect(json).not.toMatch(/employeeTaxId/i);
+        expect(json).not.toMatch(/baseSalary/i);
+        expect(json).not.toMatch(/netPaid/i);
+        expect(json).not.toMatch(/lines/i); // not an array, just the count
+        // vendorName is N/A for payroll
+        expect(v.vendorName).toBeUndefined();
+      });
+
+      it('audit row is queryable by documentNumber for compliance lookup', async () => {
+        setupDraftDoc({ documentType: 'EXPENSE', vendorName: 'Vendor A', expenseLineCount: 1 });
+        prisma.systemConfig.findFirst.mockResolvedValue(null);
+        prisma.user.findMany.mockResolvedValue([]);
+        await service.submitForApproval('doc-sub-n', 'user-1');
+        const v = getRequestedAudit();
+        // The contract: documentNumber is the stable handle compliance uses
+        // to reconstruct context. It must be present + non-empty + match the
+        // doc number on the source document — never anonymized.
+        expect(typeof v.documentNumber).toBe('string');
+        expect((v.documentNumber as string).length).toBeGreaterThan(0);
+        expect(v.documentNumber).toBe('EX-20260510-0001');
+      });
     });
 
     it('fires notifyApprovers AFTER status flip (notifications.send invoked)', async () => {

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -1636,11 +1636,51 @@ export class ExpenseDocumentsService implements OnModuleInit {
   //
   // NOTE: references the enum value `PENDING_APPROVAL` from D1.2.1.6's
   // schema migration. Pre-merge we use `as unknown as DocumentStatus`.
+  /**
+   * Submit a DRAFT document for approval. Writes an `APPROVAL_REQUESTED`
+   * AuditLog row inside the same `$transaction` as the status flip so the
+   * compliance trail is atomic with the state change.
+   *
+   * **PDPA / audit-payload policy** (D1.2.1.5 follow-up):
+   * The `newValue` field MUST NOT include line-level personal data. For
+   * PAYROLL docs the line array touches salary + employee names + tax IDs
+   * — booking that into AuditLog would expose it in any compliance export
+   * (audit-log retention runs 1yr by default; tighter PII handling is
+   * required by Thai PDPA). The audit row therefore contains only:
+   *
+   *  - `documentNumber`  — non-PII identifier (queryable by compliance)
+   *  - `totalAmount`     — aggregate; not personally identifying
+   *  - `documentType`    — enum value
+   *  - `requesterUserId` — who clicked submit
+   *  - `lineCount`       — array length only (NOT line bodies)
+   *
+   * Plus exactly ONE flow-specific contextual key:
+   *  - `vendorName`      — for EXPENSE / CREDIT_NOTE / VENDOR_SETTLEMENT
+   *                        (vendors are juristic persons / business names,
+   *                        not natural-person PII per PDPA §6 exemption)
+   *  - `payrollPeriod`   — for PAYROLL, in `YYYY-MM` form, with NO
+   *                        employee names / employee tax IDs / per-line
+   *                        salary numbers. Reviewers can still query the
+   *                        live ExpenseDocument by documentNumber if they
+   *                        need the operational detail; the audit trail
+   *                        deliberately doesn't carry it.
+   *
+   * The `documentNumber` index lets compliance reconstruct who-approved-
+   * what without joining the audit row to the live (mutable) doc body.
+   */
   async submitForApproval(id: string, userId: string) {
     const updated = await this.prisma.$transaction(async (tx) => {
       await tx.$executeRawUnsafe(`SELECT pg_advisory_xact_lock(hashtext($1))`, `post:${id}`);
 
-      const doc = await tx.expenseDocument.findUniqueOrThrow({ where: { id } });
+      const doc = await tx.expenseDocument.findUniqueOrThrow({
+        where: { id },
+        include: {
+          expenseDetail: { include: { lines: { select: { id: true } } } },
+          creditNote: true,
+          payroll: { include: { lines: { select: { id: true } } } },
+          settlement: { include: { settlementLines: { select: { id: true } } } },
+        },
+      });
       if (doc.deletedAt) throw new NotFoundException('เอกสารถูกลบแล้ว');
       if (doc.status !== 'DRAFT') {
         throw new BadRequestException(
@@ -1654,6 +1694,35 @@ export class ExpenseDocumentsService implements OnModuleInit {
         data: { status: PENDING_APPROVAL },
       });
 
+      // PDPA-safe summary — no line-level salary / employee names.
+      // See JSDoc above for policy rationale.
+      const baseSummary: Record<string, unknown> = {
+        documentNumber: doc.number,
+        totalAmount: doc.totalAmount.toString(),
+        documentType: doc.documentType,
+        requesterUserId: userId,
+      };
+
+      let lineCount = 0;
+      if (doc.documentType === 'PAYROLL') {
+        lineCount = doc.payroll?.lines.length ?? 0;
+        if (doc.payroll?.payrollPeriod) {
+          baseSummary.payrollPeriod = doc.payroll.payrollPeriod;
+        }
+      } else if (doc.documentType === 'VENDOR_SETTLEMENT') {
+        lineCount = doc.settlement?.settlementLines.length ?? 0;
+        if (doc.vendorName) baseSummary.vendorName = doc.vendorName;
+      } else if (doc.documentType === 'CREDIT_NOTE') {
+        // CN has no line array of its own — it references the original.
+        lineCount = 1;
+        if (doc.vendorName) baseSummary.vendorName = doc.vendorName;
+      } else {
+        // EXPENSE (the default — V4 multi-line)
+        lineCount = doc.expenseDetail?.lines.length ?? 0;
+        if (doc.vendorName) baseSummary.vendorName = doc.vendorName;
+      }
+      baseSummary.lineCount = lineCount;
+
       // D1.2.1.5 — APPROVAL_REQUESTED audit log inside the tx so status
       // transition + audit stay atomic.
       await tx.auditLog.create({
@@ -1662,11 +1731,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
           entity: 'expense_document',
           entityId: id,
           userId,
-          newValue: {
-            documentNumber: doc.number,
-            totalAmount: doc.totalAmount.toString(),
-            documentType: doc.documentType,
-          },
+          newValue: baseSummary as Prisma.InputJsonValue,
         },
       });
 


### PR DESCRIPTION
## Summary

Group 3 review caught that `submitForApproval()` for PAYROLL docs touches salary data, but the audit row captured only `{documentNumber, totalAmount, documentType}`. Safe by omission, but compliance reviewers couldn't reconstruct who-approved-what without joining to the live (mutable) doc body. This PR enriches the `APPROVAL_REQUESTED` audit `newValue` with a PDPA-safe summary that includes enough context for compliance review but explicitly excludes line-level personal data.

## What changed

`apps/api/src/modules/expense-documents/expense-documents.service.ts` — `submitForApproval`:

**Audit `newValue` now includes:**
- `documentNumber` — non-PII identifier (queryable by compliance)
- `totalAmount` — aggregate, not personally identifying
- `documentType` — enum
- `requesterUserId` — who clicked submit *(new)*
- `lineCount` — NUMBER only, not line bodies *(new)*
- `vendorName` — for EXPENSE / CREDIT_NOTE / VENDOR_SETTLEMENT *(new)*
- `payrollPeriod` — for PAYROLL, `YYYY-MM` form *(new)*

**Explicit PDPA omissions** (documented in JSDoc):
- PAYROLL employee names / tax IDs / per-line salary / SSO / WHT amounts → NEVER in audit payload. Reviewers query the live `ExpenseDocument` by `documentNumber` when they need operational detail.
- `vendorName` is OK because vendors are juristic persons / business names — not natural-person PII per PDPA §6 exemption.

The transaction now `include`s `expenseDetail` / `payroll` / `creditNote` / `settlement` relations on the `findUniqueOrThrow` so the audit summary can fan out by documentType without a second query (stays within the advisory lock window).

## Follow-up to

- Group 3 review observation on D1 deep review session — PAYROLL `APPROVAL_REQUESTED` audit needs richer PDPA-safe context

## Dependencies

- **Stacks on PR #933** (`feat/a1-d1.2.1.5-notification-on-pending`). Base branch = `feat/a1-d1.2.1.5-notification-on-pending`. Will rebase onto `main` automatically when #933 lands.

## Test plan

- [x] `expense-documents.service.spec.ts` — 67/67 pass (3 new PDPA-safe cases):
  - EXPENSE submit → audit has `vendorName` + `lineCount` (4), no `payrollPeriod`
  - PAYROLL submit → audit has `payrollPeriod` + `lineCount` (8); JSON-stringify check verifies absence of `employeeName` / `employeeTaxId` / `baseSalary` / `netPaid`
  - `documentNumber` stable + non-empty + matches source doc number (compliance lookup contract)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)