### PR TITLE
feat(a1): D1.4.2.1 — query_timeout_seconds setting (informational)

### DIFF
--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -287,5 +287,30 @@ describe('SettingsService audit trail', () => {
       const flags = await service.getUiFlags();
       expect(flags.periodCloseDay).toBe(31);
     });
+
+    // D1.4.2.1 — query_timeout_seconds
+    it('queryTimeoutSeconds defaults to 30 when SystemConfig missing', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.queryTimeoutSeconds).toBe(30);
+    });
+
+    it('queryTimeoutSeconds accepts valid 5-300 range', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'query_timeout_seconds') return Promise.resolve({ value: '120' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.queryTimeoutSeconds).toBe(120);
+    });
+
+    it('queryTimeoutSeconds clamps out-of-range values back to 30', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'query_timeout_seconds') return Promise.resolve({ value: '600' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.queryTimeoutSeconds).toBe(30);
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -175,6 +175,18 @@ export class SettingsService {
      * accessibility readers via the lang attr.
      */
     language: 'th' | 'en';
+    /**
+     * D1.4.2.1 — long-running query timeout (seconds). Default 30, valid
+     * range 5–300 (clamped). Currently INFORMATIONAL — applying this to
+     * Postgres requires a DB-level `statement_timeout` setting, and the
+     * shared axios client in `apps/web/src/lib/api.ts` uses a fixed 15s
+     * timeout. The flag is exposed so OWNER can advertise the intended
+     * cutoff to operators and a future PR can wire it into either the
+     * axios `timeout` field or a Postgres `SET LOCAL statement_timeout`
+     * pre-hook. Originally SKIP per Phase 2; shipped per owner directive
+     * 2026-05-17 to reach 100% A1 coverage.
+     */
+    queryTimeoutSeconds: number;
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -214,6 +226,12 @@ export class SettingsService {
     // D1.2.2.6 — language. Whitelist 'th' / 'en'; everything else → 'th'.
     const languageRaw = await this.getKey('language');
     const language: 'th' | 'en' = languageRaw === 'en' ? 'en' : 'th';
+    // D1.4.2.1 — query_timeout_seconds. Clamp to [5, 300].
+    const queryTimeoutSecondsRaw = await this.readNumber('query_timeout_seconds', 30);
+    const queryTimeoutSeconds =
+      Number.isFinite(queryTimeoutSecondsRaw) && queryTimeoutSecondsRaw >= 5 && queryTimeoutSecondsRaw <= 300
+        ? Math.floor(queryTimeoutSecondsRaw)
+        : 30;
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -225,6 +243,7 @@ export class SettingsService {
       voucherShowQrCode,
       themeColor,
       language,
+      queryTimeoutSeconds,
     };
   }
 

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -33,6 +33,13 @@ export interface UiFlags {
   themeColor: string;
   /** D1.2.2.6 — UI language. Applied to `document.lang`; i18n framework deferred. */
   language: 'th' | 'en';
+  /**
+   * D1.4.2.1 — long-running query timeout (seconds). Default 30; valid 5–300.
+   * INFORMATIONAL today — axios client uses a fixed 15s timeout and Postgres
+   * `statement_timeout` is a DB-level setting. Exposed so OWNER can advertise
+   * the intended cutoff; a future PR can wire it.
+   */
+  queryTimeoutSeconds: number;
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -53,6 +60,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   voucherShowQrCode: true,
   themeColor: '#10b981',
   language: 'th',
+  queryTimeoutSeconds: 30,
 };
 
 export function useUiFlags(): UiFlags {


### PR DESCRIPTION
## Summary
- Adds OWNER-configurable `query_timeout_seconds` SystemConfig key (default `30`, valid 5–300, clamped) exposed via `/settings/ui-flags` as `queryTimeoutSeconds`.
- **Wiring level: INFORMATIONAL.** The shared axios client uses a fixed 15s timeout and Postgres `statement_timeout` is a database-level setting. Future PR can wire it into either the axios `timeout` field or a `SET LOCAL statement_timeout` pre-hook.

> Originally SKIP per Phase 2; shipped per owner directive 2026-05-17 to reach 100%. Wiring level documented per item (informational vs actively-wired).

## Changes
**Backend** (`apps/api/src/modules/settings/`)
- `settings.service.ts`: `getUiFlags()` returns `queryTimeoutSeconds` (clamped to [5, 300] via `Math.floor` + range check; falls back to 30 on out-of-range / non-numeric).
- `settings.service.spec.ts`: +3 jest cases (default-missing, in-range, clamp out-of-range).

**Frontend** (`apps/web/src/hooks/useUiFlags.ts`)
- `UiFlags` interface gets `queryTimeoutSeconds`.
- `DEFAULT_UI_FLAGS.queryTimeoutSeconds = 30` for first-paint stability.

## Test plan
- [x] `npx tsc --noEmit` clean in `apps/api` + `apps/web`
- [x] `npx jest settings.service.spec.ts` — 29/29 passed
- [ ] Visual smoke after merge — SystemConfig row added via Settings page reflects on `/settings/ui-flags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)