### PR TITLE
feat(a1): D1.4.1.3 — animation_enabled flag

### DIFF
--- a/apps/api/src/modules/settings/settings.service.spec.ts
+++ b/apps/api/src/modules/settings/settings.service.spec.ts
@@ -287,5 +287,30 @@ describe('SettingsService audit trail', () => {
       const flags = await service.getUiFlags();
       expect(flags.periodCloseDay).toBe(31);
     });
+
+    // D1.4.1.3 — animation_enabled
+    it('animationEnabled defaults to true when SystemConfig missing', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockResolvedValue(null);
+      const flags = await service.getUiFlags();
+      expect(flags.animationEnabled).toBe(true);
+    });
+
+    it('animationEnabled returns false when OWNER stores "false"', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'animation_enabled') return Promise.resolve({ value: 'false' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.animationEnabled).toBe(false);
+    });
+
+    it('animationEnabled falls back to default on unparseable value', async () => {
+      prisma.systemConfig.findFirst = jest.fn().mockImplementation((args: { where: { key: string } }) => {
+        if (args.where.key === 'animation_enabled') return Promise.resolve({ value: 'maybe' });
+        return Promise.resolve(null);
+      });
+      const flags = await service.getUiFlags();
+      expect(flags.animationEnabled).toBe(true);
+    });
   });
 });

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -175,6 +175,14 @@ export class SettingsService {
      * accessibility readers via the lang attr.
      */
     language: 'th' | 'en';
+    /**
+     * D1.4.1.3 — global animations + transitions toggle. Default true.
+     * When false, the web app sets `data-animations-disabled="true"` on
+     * `<html>` and a CSS rule strips `transition` / `animation` properties.
+     * Complements the OS-level `prefers-reduced-motion` media query for
+     * accessibility users on browsers that don't expose the OS setting.
+     */
+    animationEnabled: boolean;
   }> {
     const taxExemptWarningEnabled = await this.readBoolean(
       'TAX_EXEMPT_WARNING_ENABLED',
@@ -214,6 +222,8 @@ export class SettingsService {
     // D1.2.2.6 — language. Whitelist 'th' / 'en'; everything else → 'th'.
     const languageRaw = await this.getKey('language');
     const language: 'th' | 'en' = languageRaw === 'en' ? 'en' : 'th';
+    // D1.4.1.3 — animation enabled. Default true.
+    const animationEnabled = await this.readBoolean('animation_enabled', true);
     return {
       taxExemptWarningEnabled,
       reverseReasonRequired,
@@ -225,6 +235,7 @@ export class SettingsService {
       voucherShowQrCode,
       themeColor,
       language,
+      animationEnabled,
     };
   }
 

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useGlobalShortcuts } from '@/hooks/useGlobalShortcuts';
+import { useUiFlags } from '@/hooks/useUiFlags';
 import { LayoutProvider, useLayout } from './LayoutContext';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
@@ -113,6 +114,10 @@ function MainContent() {
 
 /* ── Layout root ──────────────────────────────────── */
 export default function MainLayout() {
+  // D1.4.1.3 — useUiFlags side-effects (animation toggle + future) run at the
+  // earliest authenticated paint. Hook is React-Query cached so the extra
+  // mount here is cheap.
+  useUiFlags();
   return (
     <LayoutProvider>
       <MainContent />

--- a/apps/web/src/hooks/useUiFlags.test.tsx
+++ b/apps/web/src/hooks/useUiFlags.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+// --- mock api ----------------------------------------------------------------
+const apiGet = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+}));
+
+// IMPORTANT: import after mocks so the hook picks up the mocked module.
+import { useUiFlags } from './useUiFlags';
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { wrapper };
+}
+
+describe('useUiFlags — animationEnabled effect (D1.4.1.3)', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    // Ensure the attribute is clean before each case
+    document.documentElement.removeAttribute('data-animations-disabled');
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-animations-disabled');
+  });
+
+  it('does NOT set data-animations-disabled when animationEnabled=true (default)', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        taxExemptWarningEnabled: true,
+        reverseReasonRequired: true,
+        reverseReasons: [],
+        reverseManagerApprovalDays: 7,
+        paymentDateWarningBackdate: 30,
+        paymentDateAllowFuture: true,
+        periodCloseDay: 31,
+        voucherShowQrCode: true,
+        themeColor: '#10b981',
+        language: 'th',
+        animationEnabled: true,
+      },
+    });
+    const { wrapper } = makeWrapper();
+    renderHook(() => useUiFlags(), { wrapper });
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith('/settings/ui-flags');
+    });
+    // Attribute should not be present (or explicitly removed) when enabled
+    expect(document.documentElement.getAttribute('data-animations-disabled')).toBeNull();
+  });
+
+  it('sets data-animations-disabled="true" when animationEnabled=false', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        taxExemptWarningEnabled: true,
+        reverseReasonRequired: true,
+        reverseReasons: [],
+        reverseManagerApprovalDays: 7,
+        paymentDateWarningBackdate: 30,
+        paymentDateAllowFuture: true,
+        periodCloseDay: 31,
+        voucherShowQrCode: true,
+        themeColor: '#10b981',
+        language: 'th',
+        animationEnabled: false,
+      },
+    });
+    const { wrapper } = makeWrapper();
+    renderHook(() => useUiFlags(), { wrapper });
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-animations-disabled')).toBe('true');
+    });
+  });
+});

--- a/apps/web/src/hooks/useUiFlags.ts
+++ b/apps/web/src/hooks/useUiFlags.ts
@@ -33,6 +33,12 @@ export interface UiFlags {
   themeColor: string;
   /** D1.2.2.6 — UI language. Applied to `document.lang`; i18n framework deferred. */
   language: 'th' | 'en';
+  /**
+   * D1.4.1.3 — global animations + transitions toggle. When false, the
+   * hook sets `data-animations-disabled="true"` on `<html>` and a CSS rule
+   * strips `transition` / `animation` from every element. Default true.
+   */
+  animationEnabled: boolean;
 }
 
 const DEFAULT_UI_FLAGS: UiFlags = {
@@ -53,6 +59,7 @@ const DEFAULT_UI_FLAGS: UiFlags = {
   voucherShowQrCode: true,
   themeColor: '#10b981',
   language: 'th',
+  animationEnabled: true,
 };
 
 export function useUiFlags(): UiFlags {
@@ -73,5 +80,15 @@ export function useUiFlags(): UiFlags {
       document.documentElement.lang = flags.language;
     }
   }, [flags.language]);
+  // D1.4.1.3 — toggle global animations. CSS rule in `index.css` matches
+  // `[data-animations-disabled="true"]` and strips transitions + animations.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (flags.animationEnabled) {
+      document.documentElement.removeAttribute('data-animations-disabled');
+    } else {
+      document.documentElement.setAttribute('data-animations-disabled', 'true');
+    }
+  }, [flags.animationEnabled]);
   return flags;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -625,3 +625,16 @@ layer(base);
     scroll-behavior: auto !important;
   }
 }
+
+/*
+ * D1.4.1.3 — animation_enabled SystemConfig
+ * useUiFlags toggles data-animations-disabled on <html> when OWNER sets
+ * `animation_enabled=false`. Equivalent to a manual prefers-reduced-motion
+ * for browsers / OS profiles where the user can't or won't set it.
+ */
+html[data-animations-disabled='true'] *,
+html[data-animations-disabled='true'] *::before,
+html[data-animations-disabled='true'] *::after {
+  transition: none !important;
+  animation: none !important;
+}


### PR DESCRIPTION
## Summary

D1 4.1.3. OWNER-editable SystemConfig `animation_enabled` (whitelist `'true'`/`'false'`, default `'true'`).

Complements OS-level `prefers-reduced-motion` for accessibility users on browsers/OS profiles that don't expose the system setting.

## Scope

- Backend: `SettingsService.getUiFlags()` exposes `animationEnabled: boolean` (default true)
- Frontend: `useUiFlags` toggles `data-animations-disabled="true"` on `<html>` when false
- `index.css` strips `transition` + `animation` via `html[data-animations-disabled='true'] *`
- `MainLayout` calls `useUiFlags` for early effect application

## Tests

- 3 new SettingsService cases (default / OWNER override / unparseable)
- 2 new `useUiFlags` vitest cases (attribute set/cleared based on flag)
- TypeScript: 0 errors · 29/29 settings tests pass · 2/2 hook tests pass

## Status

Originally SKIP per Phase 2; shipped per owner directive 2026-05-17 to reach 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)