### PR TITLE
feat(a5): tax-disallowed expense flag for ภ.ง.ด.50/51 deduction filtering

### DIFF
--- a/apps/api/prisma/migrations/20260937000000_expense_tax_disallowed/migration.sql
+++ b/apps/api/prisma/migrations/20260937000000_expense_tax_disallowed/migration.sql
@@ -1,0 +1,34 @@
+-- Phase A.5 — Tax-disallowed expense flag for ภ.ง.ด.50/51 deduction filtering.
+--
+-- TFRS for NPAEs alignment: disallowed expenses are STILL booked normally
+-- in the books (no special JE, no separate CoA routing). The flag only
+-- affects the corporate income-tax filing (ภ.ง.ด.50/51) so the accountant
+-- can deduct them from the deductible-expense total at year-end.
+--
+-- Typical disallowed examples (ม.65 ตรี ป.รัษฎากร):
+--   - Personal expenses charged to the company
+--   - Gifts / entertainment exceeding statutory cap (THB 2,000/event)
+--   - Tax penalties + late-fees paid to the Revenue Department
+--   - Donations beyond 2% / 10% caps
+--
+-- Two scopes:
+--   - `expense_documents.tax_disallowed`: doc-level default for all lines.
+--   - `expense_lines.tax_disallowed`: per-line override (rare; an EX doc
+--     mixing deductible + non-deductible categories). When line-level is
+--     true, the line is disallowed regardless of doc-level flag.
+--
+-- Both columns are NOT NULL with DEFAULT false → backwards compatible:
+-- every existing row implicitly = "deductible" until the accountant flips it.
+
+ALTER TABLE "expense_documents"
+  ADD COLUMN "tax_disallowed" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "expense_lines"
+  ADD COLUMN "tax_disallowed" BOOLEAN NOT NULL DEFAULT false;
+
+-- Partial-ish index: filters by (tax_disallowed, deletedAt). Used by the
+-- ภ.ง.ด.50/51 summary endpoint to scan only flagged rows over a date range.
+-- Composite covers both equality (tax_disallowed = true) and the soft-delete
+-- guard in the same lookup.
+CREATE INDEX "expense_documents_tax_disallowed_deleted_at_idx"
+  ON "expense_documents" ("tax_disallowed", "deleted_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3600,6 +3600,15 @@ model ExpenseDocument {
 
   fromTemplateId String? @map("from_template_id")
 
+  /// Phase A.5 — Tax-disallowed flag for ภ.ง.ด.50/51 deduction filtering.
+  /// When true, the document's expense lines are excluded from the deductible
+  /// total at year-end corporate income-tax filing (ม.65 ตรี ป.รัษฎากร — e.g.
+  /// personal expenses, gifts > THB 2,000, tax penalties, late fees paid to
+  /// Revenue). Disallowed expenses are STILL booked normally — this flag only
+  /// affects tax reporting, never the journal entry. ExpenseLine carries the
+  /// same flag for per-line override (rare mixed-category docs).
+  taxDisallowed Boolean @default(false) @map("tax_disallowed")
+
   createdById  String    @map("created_by_id")
   approvedById String?   @map("approved_by_id")
   createdAt    DateTime  @default(now()) @map("created_at")
@@ -3617,6 +3626,7 @@ model ExpenseDocument {
   @@index([status, paidAt])
   @@index([status, createdAt(sort: Desc)])
   @@index([fromTemplateId])
+  @@index([taxDisallowed, deletedAt])
   @@map("expense_documents")
 }
 
@@ -3654,6 +3664,14 @@ model ExpenseLine {
   amountBeforeVat Decimal       @map("amount_before_vat") @db.Decimal(12, 2)
   vatAmount       Decimal       @default(0) @map("vat_amount") @db.Decimal(12, 2)
   whtAmount       Decimal       @default(0) @map("wht_amount") @db.Decimal(12, 2)
+  /// Phase A.5 — Per-line tax-disallowed override (ม.65 ตรี).
+  /// When true, THIS line is excluded from ภ.ง.ด.50/51 deductible totals
+  /// regardless of the doc-level flag. Rare path — only set when one EX
+  /// document mixes deductible + non-deductible categories (e.g. a vendor
+  /// invoice combining genuine business expenses with personal gifts).
+  /// Effective rule = doc.taxDisallowed OR line.taxDisallowed (line never
+  /// overrides to "allowed" once doc-level is true).
+  taxDisallowed   Boolean       @default(false) @map("tax_disallowed")
   createdAt       DateTime      @default(now()) @map("created_at")
   updatedAt       DateTime      @updatedAt @map("updated_at")
 

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
@@ -133,4 +133,49 @@ describe('ExpenseDocumentsController', () => {
     await controller.previewJe(dto as never);
     expect(service.previewJe).toHaveBeenCalledWith(dto);
   });
+
+  // Phase A.5 — Tax-disallowed summary endpoint
+  describe('GET /tax-disallowed (Phase A.5)', () => {
+    beforeEach(() => {
+      service.getTaxDisallowedSummary = jest.fn().mockResolvedValue({
+        docLevelCount: 0,
+        docLevelTotal: '0.00',
+        lineLevelCount: 0,
+        lineLevelTotal: '0.00',
+        grandTotal: '0.00',
+        filters: { from: null, to: null },
+      });
+    });
+
+    it('cross-branch role (OWNER) can scope by ?branchId or see all', async () => {
+      await controller.taxDisallowed(
+        { user: { id: 'u', branchId: 'home-branch', role: 'OWNER' } } as never,
+        '2026-01-01',
+        '2026-12-31',
+        'b1',
+      );
+      // OWNER is cross-branch — passed-through branchId is the query param, not user's
+      expect(service.getTaxDisallowedSummary).toHaveBeenCalledWith({
+        branchId: 'b1',
+        from: '2026-01-01',
+        to: '2026-12-31',
+      });
+    });
+
+    it('non-cross-branch role (BRANCH_MANAGER) is pinned to their own branch (cross-branch leak guard)', async () => {
+      // BRANCH_MANAGER is NOT in CROSS_BRANCH_ROLES — query ?branchId is ignored,
+      // user's own branchId wins. Prevents cross-branch leak.
+      await controller.taxDisallowed(
+        { user: { id: 'u', branchId: 'b-mine', role: 'BRANCH_MANAGER' } } as never,
+        '2026-01-01',
+        '2026-12-31',
+        'b-other',
+      );
+      expect(service.getTaxDisallowedSummary).toHaveBeenCalledWith({
+        branchId: 'b-mine',
+        from: '2026-01-01',
+        to: '2026-12-31',
+      });
+    });
+  });
 });

--- a/apps/api/src/modules/expense-documents/__tests__/tax-disallowed.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/tax-disallowed.service.spec.ts
@@ -1,0 +1,201 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { ExpenseDocumentsService } from '../expense-documents.service';
+import { LineAggregatorService } from '../services/line-aggregator.service';
+
+/**
+ * Phase A.5 — Tax-disallowed expense flag.
+ *
+ * Verifies:
+ *   1. create() persists doc-level `taxDisallowed` when provided
+ *   2. create() persists per-line `taxDisallowed` on each line
+ *   3. getTaxDisallowedSummary() splits doc-level vs line-level + grand total
+ *   4. summary respects date range + branch filter (POSTED + non-deleted only)
+ */
+describe('ExpenseDocumentsService — tax-disallowed (Phase A.5)', () => {
+  let service: ExpenseDocumentsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let docNumber: any;
+
+  beforeEach(() => {
+    prisma = {
+      $transaction: jest.fn(async (cb: (tx: unknown) => unknown) => cb(prisma)),
+      $executeRawUnsafe: jest.fn().mockResolvedValue(1),
+      expenseDocument: {
+        create: jest.fn().mockResolvedValue({ id: 'doc-1', number: 'EX-20260510-0001' }),
+        findMany: jest.fn().mockResolvedValue([]),
+        findUniqueOrThrow: jest.fn(),
+        update: jest.fn().mockResolvedValue({ id: 'doc-1' }),
+        count: jest.fn().mockResolvedValue(0),
+        groupBy: jest.fn().mockResolvedValue([]),
+        aggregate: jest.fn().mockResolvedValue({
+          _count: { _all: 0 },
+          _sum: { totalAmount: null, amountBeforeVat: null },
+        }),
+      },
+      expenseLine: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        aggregate: jest.fn().mockResolvedValue({
+          _count: { _all: 0 },
+          _sum: { amountBeforeVat: null },
+        }),
+      },
+      chartOfAccount: {
+        findMany: jest.fn().mockResolvedValue([
+          { code: '53-1302', type: 'ค่าใช้จ่าย' },
+          { code: '53-1404', type: 'ค่าใช้จ่าย' },
+        ]),
+      },
+      systemConfig: { findUnique: jest.fn().mockResolvedValue(null), findFirst: jest.fn().mockResolvedValue(null) },
+      companyInfo: { findFirst: jest.fn().mockResolvedValue({ id: 'shop-co-id' }) },
+      accountingPeriod: { findUnique: jest.fn().mockResolvedValue(null) },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
+      expenseDetail: {
+        update: jest.fn().mockResolvedValue({}),
+        findUnique: jest.fn().mockResolvedValue({ lines: [] }),
+      },
+    };
+    docNumber = { next: jest.fn().mockResolvedValue('EX-20260510-0001') };
+    service = new ExpenseDocumentsService(
+      prisma,
+      docNumber,
+      { assertCanPost: jest.fn(), assertCanVoid: jest.fn(), assertCanEdit: jest.fn() } as never,
+      { execute: jest.fn() } as never,
+      { execute: jest.fn() } as never,
+      { execute: jest.fn() } as never,
+      { execute: jest.fn() } as never,
+      { execute: jest.fn() } as never,
+      { createAndPost: jest.fn() } as never,
+      new LineAggregatorService(),
+      { preview: jest.fn() } as never,
+      { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
+      { execute: jest.fn() } as never,
+      { getConfig: jest.fn(), validate: jest.fn() } as never,
+      { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn().mockResolvedValue({ taxableBase: new Decimal(0) }) } as never,
+    );
+  });
+
+  describe('create() — persists tax-disallowed flag', () => {
+    it('persists doc-level taxDisallowed=true when supplied', async () => {
+      await service.create(
+        {
+          documentType: 'EXPENSE',
+          branchId: 'branch-1',
+          documentDate: '2026-05-10',
+          priceType: 'EXCLUSIVE',
+          taxDisallowed: true,
+          lines: [
+            { category: '53-1302', quantity: 1, unitPrice: 1000, vatPercent: 7, whtPercent: 0 },
+          ],
+        } as never,
+        'user-1',
+      );
+      const callArg = prisma.expenseDocument.create.mock.calls[0][0];
+      expect(callArg.data.taxDisallowed).toBe(true);
+    });
+
+    it('defaults taxDisallowed=false when omitted (backwards compatible)', async () => {
+      await service.create(
+        {
+          documentType: 'EXPENSE',
+          branchId: 'branch-1',
+          documentDate: '2026-05-10',
+          priceType: 'EXCLUSIVE',
+          lines: [
+            { category: '53-1302', quantity: 1, unitPrice: 1000, vatPercent: 7, whtPercent: 0 },
+          ],
+        } as never,
+        'user-1',
+      );
+      const callArg = prisma.expenseDocument.create.mock.calls[0][0];
+      expect(callArg.data.taxDisallowed).toBe(false);
+    });
+
+    it('persists per-line taxDisallowed override (line-level can mix true/false)', async () => {
+      await service.create(
+        {
+          documentType: 'EXPENSE',
+          branchId: 'branch-1',
+          documentDate: '2026-05-10',
+          priceType: 'EXCLUSIVE',
+          taxDisallowed: false,
+          lines: [
+            { category: '53-1302', quantity: 1, unitPrice: 1000, vatPercent: 0, whtPercent: 0, taxDisallowed: true },
+            { category: '53-1404', quantity: 1, unitPrice: 500, vatPercent: 0, whtPercent: 0 },
+          ],
+        } as never,
+        'user-1',
+      );
+      const callArg = prisma.expenseDocument.create.mock.calls[0][0];
+      const createdLines = callArg.data.expenseDetail.create.lines.create;
+      expect(createdLines).toHaveLength(2);
+      expect(createdLines[0].taxDisallowed).toBe(true);
+      expect(createdLines[1].taxDisallowed).toBe(false);
+    });
+  });
+
+  describe('getTaxDisallowedSummary()', () => {
+    it('returns zero totals when no flagged docs in the period', async () => {
+      const result = await service.getTaxDisallowedSummary({
+        from: '2026-01-01',
+        to: '2026-12-31',
+      });
+      expect(result.docLevelCount).toBe(0);
+      expect(result.docLevelTotal).toBe('0.00');
+      expect(result.lineLevelCount).toBe(0);
+      expect(result.lineLevelTotal).toBe('0.00');
+      expect(result.grandTotal).toBe('0.00');
+    });
+
+    it('sums doc-level totalAmount + line-level amountBeforeVat into grandTotal', async () => {
+      prisma.expenseDocument.aggregate.mockResolvedValue({
+        _count: { _all: 3 },
+        _sum: { totalAmount: new Decimal('12345.67') },
+      });
+      prisma.expenseLine.aggregate.mockResolvedValue({
+        _count: { _all: 2 },
+        _sum: { amountBeforeVat: new Decimal('500.33') },
+      });
+
+      const result = await service.getTaxDisallowedSummary({
+        from: '2026-01-01',
+        to: '2026-12-31',
+      });
+      expect(result.docLevelCount).toBe(3);
+      expect(result.docLevelTotal).toBe('12345.67');
+      expect(result.lineLevelCount).toBe(2);
+      expect(result.lineLevelTotal).toBe('500.33');
+      // 12345.67 + 500.33 = 12846.00 exactly (Decimal arithmetic)
+      expect(result.grandTotal).toBe('12846.00');
+    });
+
+    it('passes date range + branch filter into the doc-level query (POSTED only, no deleted)', async () => {
+      await service.getTaxDisallowedSummary({
+        branchId: 'b1',
+        from: '2026-05-01',
+        to: '2026-05-31',
+      });
+      const callArg = prisma.expenseDocument.aggregate.mock.calls[0][0];
+      expect(callArg.where.branchId).toBe('b1');
+      expect(callArg.where.deletedAt).toBeNull();
+      expect(callArg.where.status).toBe('POSTED');
+      expect(callArg.where.taxDisallowed).toBe(true);
+      expect(callArg.where.documentDate.gte).toEqual(new Date('2026-05-01'));
+      // upper bound clamps to 23:59:59.999 of the chosen day
+      const lte = callArg.where.documentDate.lte as Date;
+      expect(lte.getHours()).toBe(23);
+      expect(lte.getMinutes()).toBe(59);
+    });
+
+    it('line-level query excludes lines whose parent doc is already flagged (avoid double-count)', async () => {
+      await service.getTaxDisallowedSummary({ from: '2026-01-01', to: '2026-12-31' });
+      const lineCallArg = prisma.expenseLine.aggregate.mock.calls[0][0];
+      expect(lineCallArg.where.taxDisallowed).toBe(true);
+      // Parent doc must NOT be doc-level disallowed (those are already counted)
+      expect(lineCallArg.where.expenseDetail.document.taxDisallowed).toBe(false);
+      expect(lineCallArg.where.expenseDetail.document.status).toBe('POSTED');
+      expect(lineCallArg.where.expenseDetail.document.deletedAt).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/modules/expense-documents/dto/create.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create.dto.ts
@@ -7,6 +7,7 @@ import {
   ArrayMinSize,
   IsIn,
   IsNumberString,
+  IsBoolean,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ExpenseLineInput } from './expense-line-input.dto';
@@ -80,6 +81,17 @@ export class CreateExpenseDocumentDto {
   @IsString()
   @IsOptional()
   approvedById?: string;
+
+  /**
+   * Phase A.5 — Tax-disallowed doc-level flag (ม.65 ตรี ป.รัษฎากร).
+   * When true, ALL lines in this document are excluded from ภ.ง.ด.50/51
+   * deductible totals. Disallowed expenses are still booked normally — the
+   * flag only affects year-end corporate income-tax filing, never the JE.
+   * Default false (deductible) for backwards compatibility.
+   */
+  @IsBoolean()
+  @IsOptional()
+  taxDisallowed?: boolean;
 
   @IsArray()
   @ArrayMinSize(1, { message: 'ต้องมีรายการบัญชีอย่างน้อย 1 บรรทัด' })

--- a/apps/api/src/modules/expense-documents/dto/expense-line-input.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/expense-line-input.dto.ts
@@ -6,6 +6,7 @@ import {
   Min,
   Max,
   Matches,
+  IsBoolean,
 } from 'class-validator';
 
 export class ExpenseLineInput {
@@ -56,4 +57,14 @@ export class ExpenseLineInput {
   @IsIn(['PND3', 'PND53'])
   @IsOptional()
   whtFormType?: 'PND3' | 'PND53';
+
+  /**
+   * Phase A.5 — Per-line tax-disallowed override (ม.65 ตรี ป.รัษฎากร).
+   * When true, THIS line is excluded from ภ.ง.ด.50/51 deductible totals
+   * regardless of the doc-level flag. Only set when one document mixes
+   * deductible + non-deductible categories. Default false.
+   */
+  @IsBoolean()
+  @IsOptional()
+  taxDisallowed?: boolean;
 }

--- a/apps/api/src/modules/expense-documents/expense-documents.controller.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.controller.ts
@@ -103,6 +103,24 @@ export class ExpenseDocumentsController {
   }
 
   /**
+   * Phase A.5 — Tax-disallowed summary for ภ.ง.ด.50/51 prep.
+   * Returns total amount of POSTED expense docs flagged as non-deductible
+   * (ม.65 ตรี) over a date range. Doc-level + line-level overrides counted
+   * separately (no double-count). Cross-branch roles see all; others scoped.
+   */
+  @Get('tax-disallowed')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  taxDisallowed(
+    @Req() req: { user: { id: string; branchId?: string; role: string } },
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('branchId') branchId?: string,
+  ) {
+    const effective = hasCrossBranchAccess(req.user) ? branchId : req.user.branchId;
+    return this.service.getTaxDisallowedSummary({ branchId: effective, from, to });
+  }
+
+  /**
    * AP Aging — Fix Report P1-1.
    * Buckets unpaid ACCRUAL expenses by days-since-documentDate into
    * 0-30 / 31-60 / 61-90 / >90 + Total. Optional filter by vendorName or

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -318,6 +318,9 @@ export class ExpenseDocumentsService implements OnModuleInit {
           note: dto.note ?? null,
           fromTemplateId: dto.fromTemplateId ?? null,
           approvedById: dto.approvedById ?? null,
+          // Phase A.5 — tax-disallowed flag (ม.65 ตรี). Lines inherit from doc-level
+          // unless they set their own override.
+          taxDisallowed: dto.taxDisallowed ?? false,
           createdById: userId,
           expenseDetail: {
             create: {
@@ -336,6 +339,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
                   amountBeforeVat: l.amountBeforeVat,
                   vatAmount: l.vatAmount,
                   whtAmount: l.whtAmount,
+                  taxDisallowed: l.taxDisallowed ?? false,
                 })),
               },
             },
@@ -1100,6 +1104,80 @@ export class ExpenseDocumentsService implements OnModuleInit {
   }
 
   /**
+   * Phase A.5 — Tax-disallowed summary for ภ.ง.ด.50/51 prep.
+   *
+   * Returns the total amount of expense documents flagged as tax-disallowed
+   * (ม.65 ตรี ป.รัษฎากร) over a date range. Used by the accountant at year-
+   * end to exclude these from the deductible-expense total on the corporate
+   * income-tax filing.
+   *
+   * Two roll-ups:
+   *   - `docLevelTotal`: sum(totalAmount) of POSTED docs with doc-level flag
+   *   - `lineLevelTotal`: sum(amountBeforeVat) of line-level overrides on
+   *      docs NOT already disallowed at doc-level (avoid double-count)
+   *
+   * Both are POSTED-only — DRAFT / ACCRUAL / VOIDED are excluded since they
+   * aren't yet on the books. `from` / `to` filter by `documentDate` (BKK).
+   * When omitted, scans every POSTED document (use the calling controller's
+   * default = current calendar year if you want a "this year" view).
+   */
+  async getTaxDisallowedSummary(filters: {
+    branchId?: string;
+    from?: string;
+    to?: string;
+  }) {
+    const where: Prisma.ExpenseDocumentWhereInput = {
+      deletedAt: null,
+      status: 'POSTED',
+    };
+    if (filters.branchId) where.branchId = filters.branchId;
+    if (filters.from || filters.to) {
+      where.documentDate = {};
+      if (filters.from) where.documentDate.gte = new Date(filters.from);
+      if (filters.to) {
+        const end = new Date(filters.to);
+        end.setHours(23, 59, 59, 999);
+        where.documentDate.lte = end;
+      }
+    }
+
+    // Doc-level: all lines in the doc are disallowed → sum totalAmount.
+    const docLevel = await this.prisma.expenseDocument.aggregate({
+      where: { ...where, taxDisallowed: true },
+      _count: { _all: true },
+      _sum: { totalAmount: true },
+    });
+
+    // Line-level: only count rows where the PARENT doc is NOT already flagged
+    // doc-level (otherwise we'd double-count those lines). Sum `amountBeforeVat`
+    // because tax deductibility is computed on the pre-VAT amount — VAT input
+    // is handled separately on ภ.พ.30, not on ภ.ง.ด.50/51.
+    const lineLevel = await this.prisma.expenseLine.aggregate({
+      where: {
+        taxDisallowed: true,
+        expenseDetail: {
+          document: { ...where, taxDisallowed: false },
+        },
+      },
+      _count: { _all: true },
+      _sum: { amountBeforeVat: true },
+    });
+
+    const docTotal = docLevel._sum.totalAmount ?? new Prisma.Decimal(0);
+    const lineTotal = lineLevel._sum.amountBeforeVat ?? new Prisma.Decimal(0);
+    const grandTotal = docTotal.plus(lineTotal);
+
+    return {
+      docLevelCount: docLevel._count._all,
+      docLevelTotal: docTotal.toFixed(2),
+      lineLevelCount: lineLevel._count._all,
+      lineLevelTotal: lineTotal.toFixed(2),
+      grandTotal: grandTotal.toFixed(2),
+      filters: { from: filters.from ?? null, to: filters.to ?? null },
+    };
+  }
+
+  /**
    * AP Aging — Fix Report P1-1.
    *
    * Returns ACCRUAL (unpaid) expenses bucketed by age since `documentDate`,
@@ -1471,6 +1549,9 @@ export class ExpenseDocumentsService implements OnModuleInit {
           ? { connect: { id: dto.approvedById } }
           : { disconnect: true };
       }
+      // Phase A.5 — accountants may flip the flag retroactively while a doc
+      // is still editable (DRAFT/ACCRUAL). Persisted as plain Boolean.
+      if (dto.taxDisallowed !== undefined) data.taxDisallowed = dto.taxDisallowed;
 
       if (dto.lines !== undefined) {
         const priceType = dto.priceType ?? existing.expenseDetail?.priceType ?? 'EXCLUSIVE';
@@ -1522,6 +1603,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
                 amountBeforeVat: l.amountBeforeVat,
                 vatAmount: l.vatAmount,
                 whtAmount: l.whtAmount,
+                taxDisallowed: l.taxDisallowed ?? false,
               })),
             },
           },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -162,6 +162,9 @@ const OtherIncomePendingApprovalPage = lazy(
 );
 const OtherIncomeTemplatesPage = lazy(() => import('@/pages/other-income/OtherIncomeTemplatesPage'));
 const PeriodClosePage = lazy(() => import('@/pages/accounting/PeriodClosePage'));
+const TaxDisallowedSummaryPage = lazy(
+  () => import('@/pages/accounting/TaxDisallowedSummaryPage'),
+);
 
 const PageLoader = () => (
   <div className="flex items-center justify-center py-20">
@@ -1070,6 +1073,15 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER']}>
                 <PeriodsRedirect />
+              </ProtectedRoute>
+            }
+          />
+          {/* Phase A.5 — Tax-disallowed expense summary for ภ.ง.ด.50/51 prep */}
+          <Route
+            path="/accounting/tax-disallowed-summary"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <TaxDisallowedSummaryPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -75,6 +75,9 @@ const initial = (branchId: string, defaultCash: string): ExpenseFormState => {
     },
     adjustments: [],
     amountPaid: '',
+    // Phase A.5 — default false (deductible). Accountant flips for non-deductible
+    // expenses (gifts > 2,000, personal expenses, tax penalties, etc.).
+    taxDisallowed: false,
   };
 };
 
@@ -122,6 +125,10 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
             state.docType === 'EXPENSE_SAMEDAY' ? state.depositAccountCode : undefined,
           approvedById: state.approvedById || undefined,
           fromTemplateId: state.fromTemplateId || undefined,
+          // Phase A.5 — doc-level non-deductible flag. Server defaults to false
+          // if omitted; we always send the explicit boolean so the value is
+          // round-trippable.
+          taxDisallowed: state.taxDisallowed,
           lines: state.lines
             .filter((l) => l.category && parseFloat(l.unitPrice) > 0)
             .map((l) => ({
@@ -132,6 +139,8 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
               discount: parseFloat(l.discount) || 0,
               vatPercent: parseFloat(l.vatPercent) || 0,
               whtPercent: parseFloat(l.whtPercent) || 0,
+              // Per-line override; backend interprets undefined as false.
+              taxDisallowed: l.taxDisallowed === true ? true : undefined,
             })),
           // Fix Report P0-4 — pass adjustments + amountPaid when set.
           // Backend V12/V13/V14 verify the signed sum closes the diff.

--- a/apps/web/src/components/expense-form-v4/ItemLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/ItemLinesSection.tsx
@@ -113,6 +113,21 @@ export function ItemLinesSection({ lines, onChange, priceTypeLabel }: Props) {
                 className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
               />
             </div>
+            {/* Phase A.5 — Per-line tax-disallowed override.
+                Rare path — set only when this single line is non-deductible
+                while the rest of the doc is deductible (or vice versa).
+                Effective rule = doc-level OR line-level. */}
+            <label className="flex items-start gap-2 text-xs cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
+              <input
+                type="checkbox"
+                checked={line.taxDisallowed === true}
+                onChange={(e) => updateLine(line.uid, { taxDisallowed: e.target.checked })}
+                className="mt-0.5"
+              />
+              <span>
+                บรรทัดนี้เป็น <span className="font-medium">ค่าใช้จ่ายต้องห้าม</span> (ใช้เฉพาะกรณีเอกสารปนรายการที่หักได้+หักไม่ได้ — ปกติติ๊กที่ระดับเอกสารแทน)
+              </span>
+            </label>
           </div>
         </div>
       ))}

--- a/apps/web/src/components/expense-form-v4/VendorSection.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorSection.tsx
@@ -8,70 +8,91 @@ interface Props {
 
 export function VendorSection({ state, onChange }: Props) {
   return (
-    <div className="grid grid-cols-3 gap-4">
-      <div>
-        <label className="block text-xs font-medium mb-1">ผู้ขาย <span className="text-destructive">*</span></label>
+    <div className="space-y-4">
+      <div className="grid grid-cols-3 gap-4">
+        <div>
+          <label className="block text-xs font-medium mb-1">ผู้ขาย <span className="text-destructive">*</span></label>
+          <input
+            type="text"
+            value={state.vendorName}
+            onChange={(e) => onChange({ vendorName: e.target.value })}
+            placeholder="ชื่อผู้ขาย"
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">ประเภทผู้ขาย</label>
+          <select
+            value={state.whtFormType}
+            onChange={(e) => onChange({ whtFormType: e.target.value as 'PND3' | 'PND53' | '' })}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+          >
+            <option value="">— เลือก —</option>
+            <option value="PND53">นิติบุคคล (ภงด.53)</option>
+            <option value="PND3">บุคคลธรรมดา (ภงด.3)</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">เลขประจำตัวผู้เสียภาษี</label>
+          <input
+            type="text"
+            value={state.vendorTaxId}
+            onChange={(e) => onChange({ vendorTaxId: e.target.value })}
+            placeholder="13 หลัก"
+            maxLength={13}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">เลขใบกำกับ</label>
+          <input
+            type="text"
+            value={state.taxInvoiceNo}
+            onChange={(e) => onChange({ taxInvoiceNo: e.target.value })}
+            placeholder="INV-..."
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">วันที่ใบกำกับ <span className="text-destructive">*</span></label>
+          <ThaiDateInput
+            value={state.documentDate}
+            onChange={(e) => onChange({ documentDate: e.target.value })}
+            required
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">ประเภทราคา</label>
+          <select
+            value={state.priceType}
+            onChange={(e) => onChange({ priceType: e.target.value as 'EXCLUSIVE' | 'INCLUSIVE' })}
+            className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+          >
+            <option value="EXCLUSIVE">ไม่รวม VAT</option>
+            <option value="INCLUSIVE">รวม VAT</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Phase A.5 — Tax-disallowed flag (ม.65 ตรี ป.รัษฎากร).
+          Bookkeeping unchanged — flag only affects ภ.ง.ด.50/51 deductible total
+          at year-end. Display as a single doc-level checkbox; per-line override
+          lives on each line row for the rare mixed-category case. */}
+      <label className="flex items-start gap-2.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5 cursor-pointer hover:bg-muted/50 transition-colors">
         <input
-          type="text"
-          value={state.vendorName}
-          onChange={(e) => onChange({ vendorName: e.target.value })}
-          placeholder="ชื่อผู้ขาย"
-          className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
+          type="checkbox"
+          checked={state.taxDisallowed}
+          onChange={(e) => onChange({ taxDisallowed: e.target.checked })}
+          className="mt-0.5"
         />
-      </div>
-      <div>
-        <label className="block text-xs font-medium mb-1">ประเภทผู้ขาย</label>
-        <select
-          value={state.whtFormType}
-          onChange={(e) => onChange({ whtFormType: e.target.value as 'PND3' | 'PND53' | '' })}
-          className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
-        >
-          <option value="">— เลือก —</option>
-          <option value="PND53">นิติบุคคล (ภงด.53)</option>
-          <option value="PND3">บุคคลธรรมดา (ภงด.3)</option>
-        </select>
-      </div>
-      <div>
-        <label className="block text-xs font-medium mb-1">เลขประจำตัวผู้เสียภาษี</label>
-        <input
-          type="text"
-          value={state.vendorTaxId}
-          onChange={(e) => onChange({ vendorTaxId: e.target.value })}
-          placeholder="13 หลัก"
-          maxLength={13}
-          className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
-        />
-      </div>
-      <div>
-        <label className="block text-xs font-medium mb-1">เลขใบกำกับ</label>
-        <input
-          type="text"
-          value={state.taxInvoiceNo}
-          onChange={(e) => onChange({ taxInvoiceNo: e.target.value })}
-          placeholder="INV-..."
-          className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
-        />
-      </div>
-      <div>
-        <label className="block text-xs font-medium mb-1">วันที่ใบกำกับ <span className="text-destructive">*</span></label>
-        <ThaiDateInput
-          value={state.documentDate}
-          onChange={(e) => onChange({ documentDate: e.target.value })}
-          required
-          className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
-        />
-      </div>
-      <div>
-        <label className="block text-xs font-medium mb-1">ประเภทราคา</label>
-        <select
-          value={state.priceType}
-          onChange={(e) => onChange({ priceType: e.target.value as 'EXCLUSIVE' | 'INCLUSIVE' })}
-          className="w-full px-3 py-2 border border-input rounded-lg text-sm bg-background"
-        >
-          <option value="EXCLUSIVE">ไม่รวม VAT</option>
-          <option value="INCLUSIVE">รวม VAT</option>
-        </select>
-      </div>
+        <div className="text-xs leading-snug">
+          <div className="font-medium">ค่าใช้จ่ายต้องห้าม (ม.65 ตรี ป.รัษฎากร)</div>
+          <div className="text-muted-foreground mt-0.5">
+            ติ๊กเมื่อเป็นค่าใช้จ่ายที่หักลดหย่อนภาษีนิติบุคคลไม่ได้ (เช่น ค่ารับรองเกิน 2,000 บาท, ค่าปรับสรรพากร, รายจ่ายส่วนตัว). บันทึกบัญชีปกติ — มีผลเฉพาะรายงาน ภ.ง.ด.50/51
+          </div>
+        </div>
+      </label>
     </div>
   );
 }

--- a/apps/web/src/components/expense-form-v4/types.ts
+++ b/apps/web/src/components/expense-form-v4/types.ts
@@ -17,6 +17,11 @@ export interface ExpenseLineForm {
   discount: string;
   vatPercent: string;
   whtPercent: string;
+  // Phase A.5 — Per-line tax-disallowed override (ม.65 ตรี ป.รัษฎากร).
+  // When true, this line is excluded from ภ.ง.ด.50/51 deductible totals
+  // regardless of doc-level flag. Only relevant when one doc mixes
+  // deductible + non-deductible categories.
+  taxDisallowed?: boolean;
   // computed (server-authoritative)
   amountBeforeVat?: string;
   vatAmount?: string;
@@ -153,6 +158,11 @@ export interface ExpenseFormState {
   // computed totalAmount − wht. When set, signed Σ adjustments must equal
   // (amountPaid − (totalAmount − wht)).
   amountPaid: string;
+  // Phase A.5 — Doc-level tax-disallowed flag (ม.65 ตรี ป.รัษฎากร). When true,
+  // every line in this doc is excluded from ภ.ง.ด.50/51 deductible totals.
+  // The flag does not change the JE — disallowed expenses are still booked
+  // normally. Only affects year-end corporate income-tax filing.
+  taxDisallowed: boolean;
 }
 
 export interface JePreviewLine {

--- a/apps/web/src/pages/accounting/TaxDisallowedSummaryPage.tsx
+++ b/apps/web/src/pages/accounting/TaxDisallowedSummaryPage.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Ban, FileText, Layers, TrendingDown } from 'lucide-react';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import { formatNumberDecimal } from '@/utils/formatters';
+
+/**
+ * Phase A.5 — Tax-disallowed expense summary for ภ.ง.ด.50/51 prep.
+ *
+ * Year-end view that totals expense documents flagged as non-deductible
+ * (ม.65 ตรี ป.รัษฎากร). Accountant uses this to subtract from the
+ * deductible-expense total on the corporate income-tax filing.
+ *
+ * Two roll-ups (no double-count):
+ *   - Doc-level total — sum(totalAmount) of POSTED docs with doc-level flag
+ *   - Line-level total — sum(amountBeforeVat) of line overrides on
+ *     docs that are NOT already doc-level disallowed
+ */
+
+interface TaxDisallowedSummary {
+  docLevelCount: number;
+  docLevelTotal: string;
+  lineLevelCount: number;
+  lineLevelTotal: string;
+  grandTotal: string;
+  filters: { from: string | null; to: string | null };
+}
+
+const bkkYear = (): number => {
+  const ymd = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Bangkok' });
+  return Number(ymd.slice(0, 4));
+};
+
+export default function TaxDisallowedSummaryPage() {
+  const [year, setYear] = useState<number>(bkkYear());
+  const from = `${year}-01-01`;
+  const to = `${year}-12-31`;
+
+  const query = useQuery({
+    queryKey: ['tax-disallowed', year],
+    queryFn: async () => {
+      const { data } = await api.get<TaxDisallowedSummary>('/expense-documents/tax-disallowed', {
+        params: { from, to },
+      });
+      return data;
+    },
+  });
+
+  const yearOptions: number[] = [];
+  const current = bkkYear();
+  for (let y = current; y >= current - 4; y--) yearOptions.push(y);
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <Ban className="size-6 text-warning" />
+        <div>
+          <h1 className="text-2xl font-semibold leading-snug">
+            ค่าใช้จ่ายต้องห้าม (ภ.ง.ด.50/51)
+          </h1>
+          <p className="text-sm text-muted-foreground leading-snug mt-0.5">
+            สรุปยอดค่าใช้จ่ายที่หักลดหย่อนภาษีนิติบุคคลไม่ได้ (ม.65 ตรี ป.รัษฎากร) — ใช้ประกอบการยื่นแบบ ภ.ง.ด.50/51 ปลายปี
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-5">
+        <label className="block text-xs font-medium mb-2 leading-snug">รอบปีภาษี</label>
+        <select
+          value={year}
+          onChange={(e) => setYear(Number(e.target.value))}
+          className="w-48 rounded-lg border border-input bg-background px-3 py-2 text-sm"
+        >
+          {yearOptions.map((y) => (
+            <option key={y} value={y}>
+              {y} (พ.ศ. {y + 543})
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-muted-foreground mt-2 leading-snug">
+          ช่วง {from} ถึง {to} — เฉพาะเอกสาร POSTED (ที่ลงบัญชีแล้ว)
+        </p>
+      </div>
+
+      <QueryBoundary
+        isLoading={query.isLoading}
+        isError={query.isError}
+        error={query.error}
+        onRetry={query.refetch}
+      >
+        {query.data && (
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card
+              icon={FileText}
+              label="ระดับเอกสาร"
+              sub={`${query.data.docLevelCount.toLocaleString('th-TH')} เอกสาร`}
+              value={query.data.docLevelTotal}
+            />
+            <Card
+              icon={Layers}
+              label="ระดับบรรทัด (override)"
+              sub={`${query.data.lineLevelCount.toLocaleString('th-TH')} บรรทัด`}
+              value={query.data.lineLevelTotal}
+            />
+            <Card
+              icon={TrendingDown}
+              label="รวมยอดต้องห้าม (สุทธิ)"
+              sub="ใช้บวกกลับใน ภ.ง.ด.50/51"
+              value={query.data.grandTotal}
+              highlight
+            />
+          </div>
+        )}
+      </QueryBoundary>
+
+      <div className="rounded-xl border border-border bg-muted/30 p-5">
+        <h2 className="text-sm font-semibold mb-2 leading-snug">หมายเหตุทางบัญชี (TFRS for NPAEs)</h2>
+        <ul className="text-xs leading-snug text-muted-foreground space-y-1.5 list-disc pl-5">
+          <li>
+            ค่าใช้จ่ายต้องห้ามยัง <span className="font-medium text-foreground">บันทึกบัญชีตามปกติ</span> — Dr 5x-xxxx / Cr 21-xxxx เหมือนค่าใช้จ่ายทั่วไป.
+          </li>
+          <li>
+            Flag นี้ใช้สำหรับ <span className="font-medium text-foreground">รายงานภาษีเงินได้นิติบุคคล</span> เท่านั้น — ไม่กระทบ JE/งบกำไรขาดทุน.
+          </li>
+          <li>
+            ตัวอย่าง: ค่ารับรองเกิน 2,000 บาท/คน/ครั้ง, ค่าปรับสรรพากร, รายจ่ายส่วนตัวของผู้ถือหุ้น, บริจาคเกินเพดาน 2% / 10%.
+          </li>
+          <li>
+            ระดับเอกสาร = ทั้งใบ; ระดับบรรทัด = เฉพาะรายการที่ติ๊กไว้ในใบที่ไม่ได้ติ๊กทั้งใบ. ระบบรวมยอดแบบไม่ซ้ำซ้อนให้แล้ว.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  icon: Icon,
+  label,
+  sub,
+  value,
+  highlight,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  sub: string;
+  value: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={
+        highlight
+          ? 'rounded-xl border-2 border-warning/60 bg-warning/5 p-5'
+          : 'rounded-xl border border-border bg-card p-5'
+      }
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <Icon className={highlight ? 'size-4 text-warning' : 'size-4 text-muted-foreground'} />
+        <span className="text-xs font-medium leading-snug">{label}</span>
+      </div>
+      <div className={`font-mono ${highlight ? 'text-2xl font-bold text-warning' : 'text-xl font-semibold'}`}>
+        {formatNumberDecimal(value)}
+        <span className="text-xs font-normal text-muted-foreground ml-1.5">บาท</span>
+      </div>
+      <div className="text-xs text-muted-foreground mt-1 leading-snug">{sub}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes one of the deferred items from `.claude/rules/accounting.md` Phase A.5 list ("Tax-disallowed expenses | 54-XXXX | Flag on expense type"). Lets accountants mark non-deductible expenses (ม.65 ตรี ป.รัษฎากร) so they can be excluded from the deductible-expense total when filing corporate income tax (ภ.ง.ด.50/51) at year-end.

## TFRS for NPAEs alignment

Disallowed expenses are **STILL booked normally** — `Dr 5x-xxxx / Cr 21-xxxx` exactly as deductible expenses. The flag affects ONLY the tax filing report, never the journal entry, the trial balance, or the P&L. This matches Thai accounting practice where books follow accrual + the matching principle, and "บวกกลับค่าใช้จ่ายต้องห้าม" is a year-end reconciliation done on the tax form (not the books).

Typical examples (ม.65 ตรี ป.รัษฎากร): personal expenses charged to company, gifts/entertainment > 2,000 THB/event, tax penalties, donations beyond caps.

## Two scopes

- `ExpenseDocument.taxDisallowed` — doc-level default for all lines (the usual path)
- `ExpenseLine.taxDisallowed` — per-line override (rare; for mixed-category docs)
- Effective rule: `doc.taxDisallowed OR line.taxDisallowed` (line never overrides to allowed once doc-level is true)

## Schema (additive only — fully backwards compatible)

Migration `20260937000000_expense_tax_disallowed`:
- `expense_documents.tax_disallowed BOOLEAN NOT NULL DEFAULT false`
- `expense_lines.tax_disallowed BOOLEAN NOT NULL DEFAULT false`
- Index `(tax_disallowed, deleted_at)` on expense_documents

Every existing row implicitly = "deductible" until the accountant flips it. No backfill needed.

## Backend changes

- DTOs: `taxDisallowed?: boolean` on `CreateExpenseDocumentDto` + `ExpenseLineInput`. `Update` inherits via `PartialType`.
- `ExpenseDocumentsService.create()` / `update()`: persist flags
- New endpoint `GET /expense-documents/tax-disallowed?from=&to=&branchId=` — POSTED-only, double-count guard (line-level query excludes parents already doc-flagged), cross-branch leak guard (BRANCH_MANAGER pinned to own branch)

## Frontend changes

- `ExpenseFormV4`: doc-level checkbox in `VendorSection` with Thai-language ม.65 ตรี explanation
- `ItemLinesSection`: per-line override checkbox below description (with explanation that doc-level is the normal path)
- New page `/accounting/tax-disallowed-summary` — 3 KPI cards (doc-level / line-level / grand total) with year picker (BKK calendar year default). Roles: OWNER, FINANCE_MANAGER, ACCOUNTANT.

## Tests

- 7 new vitest cases on `tax-disallowed.service.spec.ts`:
  - 3 `create`: doc-level persisted, default false, per-line override mixed
  - 4 `getTaxDisallowedSummary`: zero totals, sum to grand total, date+branch filter shape, double-count guard
- 2 new controller cases: cross-branch role can scope by ?branchId; non-cross-branch role pinned to own branch (leak guard)
- All 221 expense-documents tests pass
- `npx tsc --noEmit` clean on apps/api + apps/web

## Test plan

- [ ] Apply migration `20260937000000_expense_tax_disallowed` (additive — no backfill)
- [ ] Create a new expense doc, tick the doc-level checkbox in step 2, POST it
- [ ] Visit `/accounting/tax-disallowed-summary` — verify the doc-level card shows count=1 with the correct total
- [ ] Edit a posted doc → uncheck and resave (DRAFT/ACCRUAL only) — verify count decrements
- [ ] Create a mixed doc: leave doc-level off, tick one line — verify line-level card shows that line's amountBeforeVat
- [ ] BRANCH_MANAGER login: hit `/expense-documents/tax-disallowed?branchId=other-branch` → must scope to own branch
- [ ] Verify no JE / P&L impact: existing expense JEs are unchanged regardless of flag value