### PR TITLE
test(a1): D1.1.1.5 follow-up — assert all REQUIRED_ROLES have EXPECTED_NORMAL_BALANCE entry

### DIFF
--- a/apps/api/src/modules/settings/role-map-validation.service.spec.ts
+++ b/apps/api/src/modules/settings/role-map-validation.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { RoleMapValidationService } from './role-map-validation.service';
 import { PrismaService } from '../../prisma/prisma.service';
+import { AccountRoleService } from '../journal/account-role.service';
 
 /**
  * D1.1.1.5 — Validation rules.
@@ -115,5 +116,32 @@ describe('RoleMapValidationService', () => {
         update: { priority: 5 },
       }),
     ).resolves.toBeUndefined();
+  });
+
+  /**
+   * D1.1.1.5 follow-up — Group 4 deep-review drift guard.
+   *
+   * EXPECTED_NORMAL_BALANCE is keyed by role name. A role in REQUIRED_ROLES
+   * without an entry here silently skips rule 2b (the Dr/Cr side check) —
+   * the bug would only surface as a wrong-side JE much later. This test
+   * fails fast when a future role is added to REQUIRED_ROLES without
+   * registering its expected side. It's pure metadata coverage, no mocks
+   * needed.
+   */
+  describe('EXPECTED_NORMAL_BALANCE coverage (drift guard)', () => {
+    it('every REQUIRED_ROLE has an entry in EXPECTED_NORMAL_BALANCE', () => {
+      const required = AccountRoleService.getRequiredRoles();
+      const expected = RoleMapValidationService.EXPECTED_NORMAL_BALANCE;
+      const missing = required.filter((role: string) => !(role in expected));
+      expect(missing).toEqual([]);
+    });
+
+    it('every EXPECTED_NORMAL_BALANCE value is "Dr" or "Cr" (typo guard)', () => {
+      const expected = RoleMapValidationService.EXPECTED_NORMAL_BALANCE;
+      const invalid = Object.entries(expected).filter(
+        ([, side]) => side !== 'Dr' && side !== 'Cr',
+      );
+      expect(invalid).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Group 4 deep-review drift guard. `RoleMapValidationService` has a static `EXPECTED_NORMAL_BALANCE` map keyed by role. Rule 2b (the Dr/Cr side check) silently **skips** any role NOT in the map. If a future role is added to `AccountRoleService.REQUIRED_ROLES` without registering its expected side, a wrong-side `accountCode` would slip through validation and only surface much later as an unbalanced JE.

Two pure-metadata tests (no mocks):

1. Every `REQUIRED_ROLE` has an entry in `EXPECTED_NORMAL_BALANCE`
2. Every value in the map is `"Dr"` or `"Cr"` (typo guard — catches `"DR"`, `"Debit"`, etc.)

## Implementation note

Brief suggested bracket-notation access of the private static fields, but two public statics already exist on the relevant classes:

- `AccountRoleService.getRequiredRoles()` — already public-readonly array
- `RoleMapValidationService.EXPECTED_NORMAL_BALANCE` — already a public `static readonly Record`

So the test uses those directly — no private-field reach-in, no API change.

## Why this PR is based off `feat/a1-d1.1.1.5-role-map-validation`

The `RoleMapValidationService` + `EXPECTED_NORMAL_BALANCE` are introduced in D1.1.1.5 (commit `d114fc75`), which is not yet merged to main. This follow-up depends on that PR.

Once D1.1.1.5 lands on main, this PR's base can be retargeted to `main`.

## Tests

- 7 existing `RoleMapValidationService` tests still pass
- 2 new drift-guard tests added (9 total)
- `npx tsc --noEmit` clean

## Test plan

- [ ] Verify all 9 tests pass: `cd apps/api && npx jest src/modules/settings/role-map-validation.service.spec.ts`
- [ ] Sanity: temporarily push a role into `REQUIRED_ROLES` without adding to `EXPECTED_NORMAL_BALANCE`, re-run → confirm the drift test fails