### PR TITLE
fix(sidebar): pill click no longer instant-reverts (prod hotfix)

### DIFF
--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
@@ -84,11 +84,24 @@ function MainContent() {
 
   /* Task 15 — auto-sync currentZone to the pathname's zone, and redirect
      if this role has no path that lives in any of its zones. Common routes
-     (paths not in ANY role's sidebar — e.g., /profile, /404) pass through. */
+     (paths not in ANY role's sidebar — e.g., /profile, /404) pass through.
+
+     IMPORTANT: this effect must NOT run when only `currentZone` changed
+     (e.g., user clicked the PillSwitcher / GearButton). If it did, the
+     auto-resolve would immediately revert the user's manual pill choice
+     back to whatever zone owns the current path. Track previous pathname
+     via a ref and skip when only the zone changed. */
+  const prevPathnameRef = useRef<string | null>(null);
   useEffect(() => {
     const role = user?.role ?? '';
     if (!role) return;
     if (!getZoneConfigForRole(role)) return;
+
+    // Skip if only `currentZone` changed (pill click) — preserve manual intent.
+    const isFirstRun = prevPathnameRef.current === null;
+    const pathChanged = prevPathnameRef.current !== pathname;
+    prevPathnameRef.current = pathname;
+    if (!isFirstRun && !pathChanged) return;
 
     const targetZone = resolveZoneForPath(role, pathname);
 


### PR DESCRIPTION
## Production hotfix — SP1 sidebar pill switching broken

### Symptom (reported by owner)
- Click ไฟแนนซ์ pill on Dashboard → menu doesn't change
- Click ตั้งค่ากลาง gear → same issue
- URL also doesn't change to ?zone=fin

### Root cause
`MainLayout.tsx` auto-resolve effect (added in SP1) reruns on every `currentZone` change. Sequence:
1. Pill click → `setCurrentZone('fin')` → URL becomes ?zone=fin
2. React commits → effect re-fires
3. `resolveZoneForPath('OWNER', '/')` returns 'shop' (Dashboard is SHOP-zone)
4. Effect sees 'shop' !== 'fin' → calls `setCurrentZone('shop')` → **instant revert**

Affects all multi-zone roles (OWNER/BM/FM) on any default-zone page.

### Fix
`prevPathnameRef` short-circuits effect when only `currentZone` changed but `pathname` unchanged. Cross-zone auto-switch on actual route navigation still works.

### Why CI didn't catch
sidebar-zones.spec.ts hit ThrottlerGuard 429 cascade in PR #995's E2E run. Tests reported as 'failed' but Lint+Test was green so PR merged anyway. Should add follow-up:
- Unit/integration test that renders MainLayout + Sidebar together, clicks pill, asserts zone persists
- Fix loginAsRole 429 cascade (token caching not propagating)

### Test plan
- [x] TypeScript: 0 errors in MainLayout.tsx
- [x] Vitest LayoutContext.test.tsx: 7/7 pass (unchanged)
- [ ] Owner manual test post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)