### PR TITLE
feat(p2-sp1): CRM Pipeline 4-stage Kanban Thai labels

### DIFF
--- a/apps/web/e2e/crm-kanban-stages.spec.ts
+++ b/apps/web/e2e/crm-kanban-stages.spec.ts
@@ -1,0 +1,43 @@
+// P2-SP1: CRM Pipeline 4-stage Kanban with Thai labels.
+// SALES role has access to /crm — verifies they see the 4 active Thai-labeled
+// columns + filter chip row + LOST collapsed by default.
+//
+// PREREQ: Dev servers running (api :3000, web :5173).
+
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/auth';
+import { gotoWithRetry, hasErrorBoundary } from './helpers/navigation';
+
+test.describe('CRM Pipeline — Kanban Thai labels (P2-SP1)', () => {
+  test('SALES sees 4 active Thai-labeled columns + filter chips, LOST hidden by default', async ({
+    page,
+  }) => {
+    await loginAsRole(page, 'SALES');
+    const loaded = await gotoWithRetry(page, '/crm');
+    if (!loaded || (await hasErrorBoundary(page))) {
+      test.skip(true, 'CRM page failed to load — likely missing dev API');
+      return;
+    }
+
+    // Page header
+    await expect(page.getByRole('heading', { name: 'CRM Pipeline' })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Filter chip row — "ทั้งหมด" + 5 stage labels (each appears at least once
+    // here, since the column header below adds another occurrence for active
+    // columns).
+    await expect(page.getByRole('tab', { name: 'ทั้งหมด' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'เสนอ' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'ติดต่อ' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'เสนอราคา' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'ปิดการขาย' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'ยกเลิก' })).toBeVisible();
+
+    // "แสดงยกเลิก" toggle button is present (LOST collapsed by default)
+    await expect(page.getByRole('button', { name: /แสดงยกเลิก/ })).toBeVisible();
+
+    // No error banner
+    await expect(page.locator('body')).not.toContainText('เกิดข้อผิดพลาด');
+  });
+});

--- a/apps/web/src/pages/CrmPipelinePage.test.tsx
+++ b/apps/web/src/pages/CrmPipelinePage.test.tsx
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import type { ReactNode } from 'react';
+
+// --- mock api -----------------------------------------------------
+const apiGet = vi.fn();
+const apiPatch = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+    patch: (...args: unknown[]) => apiPatch(...args),
+  },
+}));
+
+// --- mock useNavigate ---------------------------------------------
+const navigateMock = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+// IMPORTANT: import after mocks.
+import CrmPipelinePage, { STAGES, stageEnumToKey } from './CrmPipelinePage';
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPatch.mockReset();
+  navigateMock.mockReset();
+});
+
+describe('CrmPipelinePage — Kanban with Thai labels', () => {
+  it('renders the 4 active Thai-labeled columns (LOST collapsed by default)', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/crm/leads') {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: 'l1',
+                stage: 'NEW_LEAD',
+                customer: { id: 'c1', name: 'สมชาย ใจดี', phone: '0812345678' },
+              },
+              {
+                id: 'l2',
+                stage: 'QUALIFIED',
+                customer: { id: 'c2', name: 'สมหญิง รักดี' },
+              },
+              {
+                id: 'l3',
+                stage: 'PROPOSAL',
+                customer: { id: 'c3', name: 'อนันต์ มั่งมี' },
+              },
+              {
+                id: 'l4',
+                stage: 'WON',
+                customer: { id: 'c4', name: 'ปิยะ สำเร็จ' },
+              },
+              {
+                id: 'l5',
+                stage: 'LOST',
+                customer: { id: 'c5', name: 'ขจร เลิกซื้อ' },
+              },
+            ],
+            total: 5,
+            page: 1,
+            limit: 200,
+          },
+        });
+      }
+      if (url === '/crm/dashboard') {
+        return Promise.resolve({
+          data: {
+            total: 5,
+            conversionRate: 20,
+            stages: { NEW_LEAD: 1, QUALIFIED: 1, PROPOSAL: 1, WON: 1, LOST: 1 },
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    wrap(<CrmPipelinePage />);
+
+    // Wait for data, then assert the 4 active column titles appear in the
+    // Kanban board. Each label appears in both the filter chip row AND the
+    // column header — so we expect getAllByText length >= 1.
+    await waitFor(() => {
+      expect(screen.getAllByText('เสนอ').length).toBeGreaterThanOrEqual(1);
+    });
+    expect(screen.getAllByText('ติดต่อ').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('เสนอราคา').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('ปิดการขาย').length).toBeGreaterThanOrEqual(1);
+
+    // LOST column is hidden by default — only the filter chip should match.
+    // The Kanban column header has class size-2.5 + rounded-full; we sanity
+    // check by counting the "ยกเลิก" occurrences: should equal 1 (filter chip
+    // only, no column header).
+    expect(screen.getAllByText('ยกเลิก').length).toBe(1);
+  });
+
+  it('shows LOST column when "แสดงยกเลิก" toggle clicked', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/crm/leads') {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: 'l5',
+                stage: 'LOST',
+                customer: { id: 'c5', name: 'ขจร เลิกซื้อ' },
+              },
+            ],
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    wrap(<CrmPipelinePage />);
+
+    await waitFor(() => expect(screen.getByText('แสดงยกเลิก')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('แสดงยกเลิก'));
+
+    // Now "ยกเลิก" should appear twice (filter chip + column header).
+    await waitFor(() => {
+      expect(screen.getAllByText('ยกเลิก').length).toBe(2);
+    });
+    expect(screen.getByText('ขจร เลิกซื้อ')).toBeInTheDocument();
+  });
+
+  it('navigates to /quotes?customerId=<id> when "สร้างใบเสนอราคา" is clicked', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/crm/leads') {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: 'lead-q',
+                stage: 'PROPOSAL',
+                customer: { id: 'cust-99', name: 'ลูกค้าเสนอราคา' },
+              },
+            ],
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    wrap(<CrmPipelinePage />);
+
+    const btn = await screen.findByRole('button', { name: 'สร้างใบเสนอราคา' });
+    fireEvent.click(btn);
+
+    expect(navigateMock).toHaveBeenCalledWith('/quotes?customerId=cust-99');
+  });
+
+  it('navigates to /pos?customerId=<id> when "เปิด POS" is clicked on WON card', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/crm/leads') {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: 'lead-w',
+                stage: 'WON',
+                customer: { id: 'cust-77', name: 'ลูกค้าปิดการขาย' },
+              },
+            ],
+            total: 1,
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    wrap(<CrmPipelinePage />);
+
+    const btn = await screen.findByRole('button', { name: 'เปิด POS' });
+    fireEvent.click(btn);
+
+    expect(navigateMock).toHaveBeenCalledWith('/pos?customerId=cust-77');
+  });
+
+  it('filter chips switch the active stage view', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/crm/leads') {
+        return Promise.resolve({
+          data: {
+            data: [
+              { id: 'l1', stage: 'NEW_LEAD', customer: { id: 'c1', name: 'A' } },
+              { id: 'l2', stage: 'WON', customer: { id: 'c2', name: 'B' } },
+            ],
+            total: 2,
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    wrap(<CrmPipelinePage />);
+
+    await waitFor(() => expect(screen.getByText('A')).toBeInTheDocument());
+    expect(screen.getByText('B')).toBeInTheDocument();
+
+    // Click the "ปิดการขาย" filter chip — only WON card visible.
+    const wonChip = screen
+      .getAllByRole('tab')
+      .find((el) => el.textContent === 'ปิดการขาย');
+    expect(wonChip).toBeTruthy();
+    fireEvent.click(wonChip!);
+
+    await waitFor(() => {
+      expect(screen.queryByText('A')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+});
+
+describe('stageEnumToKey', () => {
+  it('maps NEW_LEAD → LEAD', () => {
+    expect(stageEnumToKey('NEW_LEAD')).toBe('LEAD');
+  });
+
+  it('maps QUALIFIED → CONTACTED', () => {
+    expect(stageEnumToKey('QUALIFIED')).toBe('CONTACTED');
+  });
+
+  it('collapses PROPOSAL and NEGOTIATION → QUOTED', () => {
+    expect(stageEnumToKey('PROPOSAL')).toBe('QUOTED');
+    expect(stageEnumToKey('NEGOTIATION')).toBe('QUOTED');
+  });
+
+  it('maps WON → WON, LOST → LOST', () => {
+    expect(stageEnumToKey('WON')).toBe('WON');
+    expect(stageEnumToKey('LOST')).toBe('LOST');
+  });
+
+  it('falls back to LEAD for unknown / null input', () => {
+    expect(stageEnumToKey(null)).toBe('LEAD');
+    expect(stageEnumToKey('UNKNOWN_STAGE')).toBe('LEAD');
+  });
+});
+
+describe('STAGES write values', () => {
+  it('QUOTED column writes PROPOSAL (canonical "quote sent" value)', () => {
+    const quoted = STAGES.find((s) => s.key === 'QUOTED');
+    expect(quoted?.writeValue).toBe('PROPOSAL');
+  });
+
+  it('all 5 stages exposed in order LEAD → CONTACTED → QUOTED → WON → LOST', () => {
+    expect(STAGES.map((s) => s.key)).toEqual([
+      'LEAD',
+      'CONTACTED',
+      'QUOTED',
+      'WON',
+      'LOST',
+    ]);
+  });
+});

--- a/apps/web/src/pages/CrmPipelinePage.tsx
+++ b/apps/web/src/pages/CrmPipelinePage.tsx
@@ -1,30 +1,116 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { toast } from 'sonner';
 import QueryBoundary from '@/components/QueryBoundary';
 import PageHeader from '@/components/ui/PageHeader';
-import { User, Phone, ChevronRight } from 'lucide-react';
+import { KanbanBoard, type KanbanColumn } from '@/components/ui/KanbanBoard';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
+import { User, Phone, FileText, ShoppingCart, ChevronDown, ChevronUp } from 'lucide-react';
 
-const STAGES = [
-  { key: 'NEW_LEAD', label: 'Lead ใหม่', color: 'bg-info' },
-  { key: 'QUALIFIED', label: 'สนใจจริง', color: 'bg-info/80' },
-  { key: 'PROPOSAL', label: 'เสนอราคา', color: 'bg-warning' },
-  { key: 'NEGOTIATION', label: 'รอตัดสินใจ', color: 'bg-warning/80' },
-  { key: 'WON', label: 'ปิดการขาย', color: 'bg-success' },
-  { key: 'LOST', label: 'ไม่ซื้อ', color: 'bg-muted' },
+/* ─── Stage model ──────────────────────────────────────────────
+ *
+ * Spec target (CSV / P2-SP1):  เสนอ / ติดต่อ / เสนอราคา / ปิดการขาย / ยกเลิก
+ * Schema enum LeadStage:        NEW_LEAD / QUALIFIED / PROPOSAL / NEGOTIATION / WON / LOST
+ *
+ * The schema has 6 enum values but the spec defines 4 active stages + LOST.
+ * To avoid a destructive enum migration we collapse PROPOSAL+NEGOTIATION into
+ * a single visual column "เสนอราคา" (CrmStageKey = QUOTED). Drag-drop into
+ * that column writes PROPOSAL (the canonical "quote sent" value). Legacy
+ * NEGOTIATION rows render in the QUOTED column until the user moves them.
+ */
+
+export type CrmStageKey = 'LEAD' | 'CONTACTED' | 'QUOTED' | 'WON' | 'LOST';
+
+interface StageConfig {
+  key: CrmStageKey;
+  label: string;
+  color: string; // tailwind bg-* token (no hardcoded hex)
+  /** LeadStage enum values that fall under this column. */
+  enumValues: string[];
+  /** Canonical LeadStage value written when a card is dropped into this column. */
+  writeValue: string;
+}
+
+export const STAGES: StageConfig[] = [
+  {
+    key: 'LEAD',
+    label: 'เสนอ',
+    color: 'bg-sky-500',
+    enumValues: ['NEW_LEAD'],
+    writeValue: 'NEW_LEAD',
+  },
+  {
+    key: 'CONTACTED',
+    label: 'ติดต่อ',
+    color: 'bg-amber-500',
+    enumValues: ['QUALIFIED'],
+    writeValue: 'QUALIFIED',
+  },
+  {
+    key: 'QUOTED',
+    label: 'เสนอราคา',
+    color: 'bg-purple-500',
+    enumValues: ['PROPOSAL', 'NEGOTIATION'],
+    writeValue: 'PROPOSAL',
+  },
+  {
+    key: 'WON',
+    label: 'ปิดการขาย',
+    color: 'bg-emerald-500',
+    enumValues: ['WON'],
+    writeValue: 'WON',
+  },
+  {
+    key: 'LOST',
+    label: 'ยกเลิก',
+    color: 'bg-destructive',
+    enumValues: ['LOST'],
+    writeValue: 'LOST',
+  },
 ];
 
-export default function CrmPipelinePage() {
-  const queryClient = useQueryClient();
-  const [activeStage, setActiveStage] = useState<string | undefined>();
+/** Map a raw LeadStage enum value to its display column key. */
+export function stageEnumToKey(enumValue: string | undefined | null): CrmStageKey {
+  if (!enumValue) return 'LEAD';
+  for (const s of STAGES) {
+    if (s.enumValues.includes(enumValue)) return s.key;
+  }
+  return 'LEAD';
+}
 
+type FilterKey = 'ALL' | CrmStageKey;
+
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: 'ALL', label: 'ทั้งหมด' },
+  { key: 'LEAD', label: 'เสนอ' },
+  { key: 'CONTACTED', label: 'ติดต่อ' },
+  { key: 'QUOTED', label: 'เสนอราคา' },
+  { key: 'WON', label: 'ปิดการขาย' },
+  { key: 'LOST', label: 'ยกเลิก' },
+];
+
+interface CrmLead {
+  id: string;
+  stage: string; // LeadStage enum value
+  interestedProduct?: string | null;
+  customer?: { id: string; name: string; phone?: string | null } | null;
+  assignedTo?: { id: string; name: string } | null;
+}
+
+export default function CrmPipelinePage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [filter, setFilter] = useState<FilterKey>('ALL');
+  const [showLost, setShowLost] = useState(false);
+
+  // Fetch up to 200 leads (Kanban needs ALL stages at once — no server-side
+  // stage filter so we can rebuild every column locally on each render).
   const leadsQuery = useQuery({
-    queryKey: ['crm-leads', activeStage],
-    queryFn: () =>
-      api.get('/crm/leads', { params: { stage: activeStage, limit: 100 } }).then((r: any) => r.data),
+    queryKey: ['crm-leads', 'all'],
+    queryFn: () => api.get('/crm/leads', { params: { limit: 200 } }).then((r: any) => r.data),
   });
 
   const dashboardQuery = useQuery({
@@ -40,9 +126,36 @@ export default function CrmPipelinePage() {
       queryClient.invalidateQueries({ queryKey: ['crm-leads'] });
       queryClient.invalidateQueries({ queryKey: ['crm-dashboard'] });
     },
+    onError: () => {
+      toast.error('อัปเดต stage ไม่สำเร็จ');
+    },
   });
 
-  const leads = leadsQuery.data?.data ?? [];
+  const allLeads: CrmLead[] = leadsQuery.data?.data ?? [];
+
+  // Build the 5 Kanban columns. Filter by chip first (ALL = no filter).
+  const columns = useMemo<KanbanColumn<CrmLead>[]>(() => {
+    const visibleStages =
+      filter === 'ALL' ? STAGES : STAGES.filter((s) => s.key === filter);
+
+    return visibleStages
+      // When LOST is collapsed and filter is ALL, skip the LOST column entirely.
+      .filter((s) => !(s.key === 'LOST' && filter === 'ALL' && !showLost))
+      .map((s) => ({
+        id: s.key,
+        title: s.label,
+        color: s.color,
+        items: allLeads.filter((l) => s.enumValues.includes(l.stage)),
+      }));
+  }, [allLeads, filter, showLost]);
+
+  const handleCardMove = (leadId: string, fromColumnId: string, toColumnId: string) => {
+    if (fromColumnId === toColumnId) return;
+    const target = STAGES.find((s) => s.key === (toColumnId as CrmStageKey));
+    if (!target) return;
+    moveStageMutation.mutate({ id: leadId, stage: target.writeValue });
+  };
+
   const dashboard = dashboardQuery.data;
 
   return (
@@ -57,111 +170,156 @@ export default function CrmPipelinePage() {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
           <div className="bg-card rounded-xl p-4 shadow-sm">
             <p className="text-xs text-muted-foreground">ทั้งหมด</p>
-            <p className="text-2xl font-bold text-foreground">{dashboard.total}</p>
+            <p className="text-2xl font-bold text-foreground">{dashboard.total ?? 0}</p>
           </div>
           <div className="bg-card rounded-xl p-4 shadow-sm">
             <p className="text-xs text-muted-foreground">Conversion Rate</p>
-            <p className="text-2xl font-bold text-success">{dashboard.conversionRate}%</p>
+            <p className="text-2xl font-bold text-success">
+              {dashboard.conversionRate ?? 0}%
+            </p>
           </div>
-          {STAGES.slice(0, 2).map((s) => (
-            <div key={s.key} className="bg-card rounded-xl p-4 shadow-sm">
-              <p className="text-xs text-muted-foreground">{s.label}</p>
-              <p className="text-2xl font-bold text-foreground">{dashboard.stages?.[s.key] ?? 0}</p>
-            </div>
-          ))}
+          <div className="bg-card rounded-xl p-4 shadow-sm">
+            <p className="text-xs text-muted-foreground">เสนอ</p>
+            <p className="text-2xl font-bold text-foreground">
+              {dashboard.stages?.NEW_LEAD ?? 0}
+            </p>
+          </div>
+          <div className="bg-card rounded-xl p-4 shadow-sm">
+            <p className="text-xs text-muted-foreground">ปิดการขาย</p>
+            <p className="text-2xl font-bold text-emerald-600">
+              {dashboard.stages?.WON ?? 0}
+            </p>
+          </div>
         </div>
       )}
 
-      {/* Stage filter tabs */}
-      <div className="flex gap-2 mb-4 overflow-x-auto pb-2">
-        <button
-          onClick={() => setActiveStage(undefined)}
-          className={`px-4 py-2 rounded-lg text-sm whitespace-nowrap transition-colors ${
-            !activeStage ? 'bg-foreground text-background' : 'bg-card text-muted-foreground hover:bg-muted'
-          }`}
-        >
-          ทั้งหมด
-        </button>
-        {STAGES.map((s) => (
+      {/* Filter chip row */}
+      <div
+        className="flex flex-wrap gap-2 mb-4"
+        role="tablist"
+        aria-label="กรอง stage"
+      >
+        {FILTERS.map((f) => {
+          const isActive = filter === f.key;
+          return (
+            <button
+              key={f.key}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setFilter(f.key)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium leading-snug transition-colors ${
+                isActive
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-card text-muted-foreground hover:bg-accent border border-border'
+              }`}
+            >
+              {f.label}
+            </button>
+          );
+        })}
+
+        {/* Toggle LOST visibility (only meaningful in ALL view) */}
+        {filter === 'ALL' && (
           <button
-            key={s.key}
-            onClick={() => setActiveStage(s.key)}
-            className={`px-4 py-2 rounded-lg text-sm whitespace-nowrap transition-colors ${
-              activeStage === s.key ? 'bg-foreground text-background' : 'bg-card text-muted-foreground hover:bg-muted'
-            }`}
+            onClick={() => setShowLost((v) => !v)}
+            className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium leading-snug text-muted-foreground hover:bg-accent border border-dashed border-border"
+            aria-label={showLost ? 'ซ่อนยกเลิก' : 'แสดงยกเลิก'}
+            aria-expanded={showLost}
           >
-            {s.label}
+            {showLost ? (
+              <ChevronUp className="size-4" />
+            ) : (
+              <ChevronDown className="size-4" />
+            )}
+            {showLost ? 'ซ่อนยกเลิก' : 'แสดงยกเลิก'}
           </button>
-        ))}
+        )}
       </div>
 
-      {/* Leads list */}
+      {/* Kanban board */}
       <QueryBoundary
         isLoading={leadsQuery.isLoading}
         isError={leadsQuery.isError}
         error={leadsQuery.error}
         onRetry={() => leadsQuery.refetch()}
+        errorTitle="ไม่สามารถโหลด Lead ได้"
       >
-        <Card className="overflow-hidden">
-          <CardContent className="p-0">
-          {leads.length === 0 ? (
-            <div className="p-12 text-center text-muted-foreground">ไม่พบ Lead</div>
-          ) : (
-            <div className="divide-y">
-              {leads.map((lead: any) => {
-                const stageInfo = STAGES.find((s) => s.key === lead.stage);
-                return (
-                  <div key={lead.id} className="px-4 py-3 flex items-center gap-4 hover:bg-accent">
-                    <div className={`w-2 h-2 rounded-full flex-shrink-0 ${stageInfo?.color ?? 'bg-muted'}`} />
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <User className="w-4 h-4 text-muted-foreground" />
-                        <span className="font-medium text-sm text-foreground">
-                          {lead.customer?.name ?? 'ไม่ระบุชื่อ'}
-                        </span>
-                        <Badge variant="secondary" size="sm">
-                          {stageInfo?.label}
-                        </Badge>
-                      </div>
-                      <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
-                        {lead.customer?.phone && (
-                          <span className="flex items-center gap-1">
-                            <Phone className="w-3 h-3" /> {lead.customer.phone}
-                          </span>
-                        )}
-                        {lead.interestedProduct && (
-                          <span>{lead.interestedProduct}</span>
-                        )}
-                        {lead.assignedTo && (
-                          <span>พนง: {lead.assignedTo.name}</span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      {lead.stage !== 'WON' && lead.stage !== 'LOST' && (
-                        <button
-                          onClick={() => {
-                            const currentIdx = STAGES.findIndex((s) => s.key === lead.stage);
-                            const nextStage = STAGES[currentIdx + 1];
-                            if (nextStage) {
-                              moveStageMutation.mutate({ id: lead.id, stage: nextStage.key });
-                            }
-                          }}
-                          className="p-1.5 text-muted-foreground hover:text-primary hover:bg-primary/10 rounded-lg"
-                          title="ไปขั้นต่อไป"
-                          aria-label="ไปขั้นต่อไป"
-                        >
-                          <ChevronRight className="w-4 h-4" />
-                        </button>
-                      )}
-                    </div>
+        {allLeads.length === 0 ? (
+          <Card>
+            <CardContent className="p-12 text-center text-muted-foreground">
+              ไม่พบ Lead
+            </CardContent>
+          </Card>
+        ) : (
+          <KanbanBoard<CrmLead>
+            columns={columns}
+            onCardMove={handleCardMove}
+            emptyMessage="ไม่มี Lead ในขั้นนี้"
+            renderCard={(lead) => {
+              const stageKey = stageEnumToKey(lead.stage);
+              return (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2">
+                    <User className="size-4 text-muted-foreground shrink-0" />
+                    <span className="text-sm font-semibold text-foreground leading-snug truncate">
+                      {lead.customer?.name ?? 'ไม่ระบุชื่อ'}
+                    </span>
                   </div>
-                );
-              })}
-            </div>
-          )}
-          </CardContent>
-        </Card>
+
+                  {lead.customer?.phone && (
+                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground leading-snug">
+                      <Phone className="size-3" />
+                      <span className="truncate">{lead.customer.phone}</span>
+                    </div>
+                  )}
+
+                  {lead.interestedProduct && (
+                    <p className="text-xs text-muted-foreground leading-snug line-clamp-2">
+                      {lead.interestedProduct}
+                    </p>
+                  )}
+
+                  {lead.assignedTo && (
+                    <Badge variant="secondary" size="sm" className="self-start">
+                      พนง: {lead.assignedTo.name}
+                    </Badge>
+                  )}
+
+                  {/* Stage-specific quick actions */}
+                  {stageKey === 'QUOTED' && lead.customer?.id && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate(`/quotes?customerId=${lead.customer!.id}`);
+                      }}
+                      className="mt-1 inline-flex items-center justify-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium leading-snug bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                      aria-label="สร้างใบเสนอราคา"
+                    >
+                      <FileText className="size-3.5" />
+                      สร้างใบเสนอราคา
+                    </button>
+                  )}
+
+                  {stageKey === 'WON' && lead.customer?.id && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate(`/pos?customerId=${lead.customer!.id}`);
+                      }}
+                      className="mt-1 inline-flex items-center justify-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium leading-snug bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/20 transition-colors"
+                      aria-label="เปิด POS"
+                    >
+                      <ShoppingCart className="size-3.5" />
+                      เปิด POS
+                    </button>
+                  )}
+                </div>
+              );
+            }}
+          />
+        )}
       </QueryBoundary>
     </div>
   );

--- a/docs/superpowers/specs/2026-05-18-phase-2-csv-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-05-18-phase-2-csv-completion-roadmap.md
@@ -1,0 +1,161 @@
+# Phase 2 — CSV 100% Completion Roadmap
+
+**Status:** Spec 2026-05-18. Closes remaining 5 gaps vs original CSV after Phase 1 (Sidebar Redesign SP1-SP6 deployed)
+**Goal:** ครบ 100% ตาม CSV ที่ owner ส่ง 2026-05-17
+
+---
+
+## 1. Gap Analysis vs CSV
+
+After Phase 1 deploy, these 5 CSV items remain partial/missing:
+
+| # | CSV item | Phase 1 status | Phase 2 SP |
+|---|---|---|---|
+| 1 | CRM Pipeline (สนใจ→ติดต่อ→เสนอราคา→ปิดการขาย) | Existing Kanban, needs 4-stage labels + filter | P2-SP1 |
+| 2 | ตั้งค่าเลขที่/รูปแบบเอกสาร UI | D1.1.2.x backend exists, no UI | P2-SP2 |
+| 3 | e-Tax PDF Thai font | ASCII placeholder | P2-SP3 |
+| 4 | การจอง / มัดจำ booking system | Not built | P2-SP4 |
+| 5 | e-Tax XML ส่ง RD (ม.86/4 + ขมธอ.21-2562) | Phase 1 Receipt only | P2-SP5 |
+
+## 2. Decomposition (5 sub-projects)
+
+### Wave 1 — Quick wins (parallel, ship same-day)
+
+**P2-SP1: CRM 4-stage Kanban Thai labels**
+- Schema: confirm `CrmLead.stage` enum has LEAD/CONTACTED/QUOTED/WON/LOST
+- Frontend: Kanban columns with Thai labels: เสนอ / ติดต่อ / เสนอราคา / ปิดการขาย / ยกเลิก
+- Drag-and-drop between columns
+- Link "เสนอราคา" → /quotes (new Quote)
+- Link "ปิดการขาย" → /pos with prefilled customer
+- ETA: 1 hour
+
+**P2-SP2: Document Number Config UI**
+- Frontend: `DocumentConfigPage.tsx` at `/settings/document-config`
+- Backend: reuse D1.1.2.x SystemConfig keys (`doc_prefix_per_type`, `doc_number_format`, `doc_number_reset_cycle`)
+- Form: edit prefix per doc type + select format from whitelist + select reset cadence
+- Live preview using existing `DocNumberService.peek()` (if not exists, add)
+- Audit log on save (action='DOC_NUMBER_CONFIG_UPDATED')
+- OWNER only
+- ETA: 2 hours
+
+**P2-SP3: e-Tax PDF Thai font**
+- Bundle Noto Sans Thai (Apache 2.0) per PR #843 pattern
+- Replace jsPDF Helvetica with pdfmake (or jsPDF + addFileToVFS for custom font)
+- Real customer name in Thai (not `[contract <num>]` placeholder)
+- ETA: 1 hour
+
+### Wave 2 — Booking system (defaults applied)
+
+**P2-SP4: การจอง / มัดจำ (Booking)**
+
+Defaults (use unless OWNER overrides via settings):
+- 1 booking = 1+ products (multiple allowed)
+- มัดจำ = THB amount (fixed, not %)
+- Expire = 7 days (configurable via SystemConfig `booking_expire_days`)
+- Cancel before expire = 100% refund (configurable)
+- Cancel after expire = 0% refund (forfeit)
+- Convert to sale: deposit transfers to down payment, no separate dialog
+
+Backend:
+- `Booking` model: customer, branch, items[], depositAmount, expireDate, status (PENDING/PAID/CANCELED/CONVERTED/EXPIRED), depositPaymentId
+- `BookingItem` model: productId, quantity, unitPrice
+- Service: create, payDeposit, cancel (refund), convertToSale, autoExpireCron
+- Endpoints: POST/GET/PATCH/DELETE `/bookings`
+- Migration: new tables + cron job
+
+Frontend:
+- `BookingsPage.tsx` at `/bookings`
+- Create from POS or standalone
+- Status column with Thai labels: รอชำระ / มัดจำแล้ว / ยกเลิก / ขายแล้ว / หมดอายุ
+- Convert button → POS prefilled with customer + items + remaining balance
+
+Routes: `/bookings`, `/bookings/new`, `/bookings/:id`
+
+ETA: 1-2 days
+
+### Wave 3 — e-Tax XML legal (infrastructure, cert plug-in later)
+
+**P2-SP5: e-Tax XML submission scaffolding**
+
+Build infrastructure, owner plugs in CA cert + RD sandbox creds later:
+
+Backend:
+- Module: `apps/api/src/modules/e-tax-xml/`
+- Service:
+  - `generateXml(paymentId)` — produces XML per ขมธอ.21-2562 (Thailand UBL 2.1)
+  - `signXml(xml, certPath, certPass)` — PKCS#7 detached signature using node-signpdf or @signpdf/signpdf
+  - `submitToRd(signedXml, mode: 'sandbox' | 'prod')` — POST to RD endpoint
+  - `pollStatus(submissionId)` — check RD response
+- Env vars: `ETAX_CERT_PATH`, `ETAX_CERT_PASS`, `ETAX_RD_ENDPOINT`, `ETAX_RD_USERNAME`, `ETAX_RD_PASSWORD`, `ETAX_SUBMIT_MODE` (default 'disabled')
+- Schema: `ETaxSubmission` model — paymentId, xmlContent, status (PENDING/SIGNED/SUBMITTED/ACCEPTED/REJECTED), rdResponse, submittedAt
+
+Frontend:
+- Extend `ETaxInvoicePage.tsx`:
+  - "ส่งให้สรรพากร" button per invoice (disabled if ETAX_SUBMIT_MODE='disabled' with tooltip "ยังไม่ได้ตั้งค่า e-Tax CA cert")
+  - Status badge: รอส่ง / ส่งแล้ว / สรรพากรรับ / ปฏิเสธ
+  - Resubmit failed
+  - Bulk submit (monthly)
+
+Configuration UI (OWNER only):
+- `/settings/e-tax-config` — upload cert + RD creds + sandbox/prod toggle
+- Test connection button
+
+When `ETAX_SUBMIT_MODE='enabled'`:
+- Cron job submits all eligible invoices nightly
+- Sentry alarms on RD rejections
+
+ETA: 1 week (infrastructure) + owner adds cert/creds when ready
+
+---
+
+## 3. PR Strategy
+
+5 worktrees, 5 parallel branches:
+- `feat/p2-sp1-crm-stages`
+- `feat/p2-sp2-doc-config-ui`
+- `feat/p2-sp3-etax-thai-font`
+- `feat/p2-sp4-booking`
+- `feat/p2-sp5-etax-xml-scaffolding`
+
+Merge sequence (after each CI green):
+1. P2-SP3 (Thai font) — smallest, fastest
+2. P2-SP1 (CRM stages) — small, frontend only
+3. P2-SP2 (Doc config UI) — small-medium
+4. P2-SP4 (Booking) — medium with migration
+5. P2-SP5 (e-Tax XML) — largest
+
+## 4. Test Plan
+
+- P2-SP1: 2 vitest + 1 Playwright
+- P2-SP2: 5 jest + 2 vitest + 1 Playwright
+- P2-SP3: 3 jest (PDF Thai render)
+- P2-SP4: 12 jest + 4 vitest + 2 Playwright
+- P2-SP5: 8 jest + 1 vitest + 1 Playwright (mock RD response)
+
+## 5. Owner deliverables for Wave 3 go-live
+
+After P2-SP5 merge, to actually submit to RD:
+1. ลงทะเบียนเป็นผู้ออก e-Tax กับสรรพากร (form ภ.อ.01)
+2. ขอ Digital Signature Certificate จาก CA (NDID, INET, ThaiCERT — ลิงก์: https://etax.rd.go.th/etax_staging/etaxws/)
+3. ได้ username/password สำหรับ RD sandbox + prod
+4. Upload cert + creds ใน `/settings/e-tax-config`
+5. Toggle `ETAX_SUBMIT_MODE='enabled'` + restart API service
+
+## 6. Acceptance Criteria
+
+- [ ] CRM 4-stage Kanban with Thai labels working
+- [ ] OWNER can edit doc number prefix/format/cadence via UI
+- [ ] e-Tax PDF shows Thai customer names correctly
+- [ ] Booking flow: create → payDeposit → expire/cancel/convert all working
+- [ ] e-Tax XML generates per ขมธอ.21-2562, ready to sign + submit (cert pending)
+- [ ] All Playwright E2E pass
+- [ ] Each SP through DEEP /review + fix cycle
+- [ ] 0 TS errors
+
+## 7. Out of Scope (Phase 3+ if needed)
+
+- VAT-on-interest CR-001 (CPA consult)
+- GFIN integration
+- Year-end closing entries (39-9999 → 33-1101 flow)
+- Off-site backup replication
+- PII column-level encryption


### PR DESCRIPTION
## Summary
CRM Pipeline page redesigned as drag-and-drop Kanban with Thai stage labels per CSV (เสนอ→ติดต่อ→เสนอราคา→ปิดการขาย, ยกเลิก hidden by toggle).

Schema deviation: existing LeadStage enum has 6 values (NEW_LEAD/QUALIFIED/PROPOSAL/NEGOTIATION/WON/LOST). Subagent kept schema intact + mapped PROPOSAL+NEGOTIATION → `QUOTED` UI column to avoid destructive enum migration.

## Quick actions
- QUOTED card → "สร้างใบเสนอราคา" → `/quotes?customerId=<id>` 
- WON card → "เปิด POS" → `/pos?customerId=<id>`

## Test plan
- [x] 12/12 vitest
- [x] 1 Playwright smoke
- [x] TypeScript 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)