### PR TITLE
feat(p2-sp4): การจอง/มัดจำ Booking system

### DIFF
--- a/apps/api/prisma/migrations/20260942000000_add_booking/migration.sql
+++ b/apps/api/prisma/migrations/20260942000000_add_booking/migration.sql
@@ -1,11 +1,17 @@
 -- P2-SP4: Booking module (การจอง / มัดจำ) — SHOP-side pre-sale reservation.
 -- Adds Booking + BookingItem tables and BookingStatus enum.
+-- All statements are idempotent so the migration is safe to re-run after a
+-- partial failure (matches the pattern from PR #828 + P2-SP3 quote module).
 
--- CreateEnum
-CREATE TYPE "BookingStatus" AS ENUM ('PENDING_DEPOSIT', 'PAID', 'CANCELED', 'EXPIRED', 'CONVERTED');
+-- CreateEnum (idempotent — postgres enum CREATE TYPE has no IF NOT EXISTS)
+DO $$ BEGIN
+    CREATE TYPE "BookingStatus" AS ENUM ('PENDING_DEPOSIT', 'PAID', 'CANCELED', 'EXPIRED', 'CONVERTED');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
 -- CreateTable
-CREATE TABLE "bookings" (
+CREATE TABLE IF NOT EXISTS "bookings" (
     "id" TEXT NOT NULL,
     "booking_number" TEXT NOT NULL,
     "customer_id" TEXT NOT NULL,
@@ -17,6 +23,7 @@ CREATE TABLE "bookings" (
     "notes" TEXT,
     "deposit_paid_at" TIMESTAMP(3),
     "deposit_method" "PaymentMethod",
+    "deposit_account_code" TEXT,
     "deposit_received_by_id" TEXT,
     "canceled_at" TIMESTAMP(3),
     "canceled_by_id" TEXT,
@@ -31,8 +38,12 @@ CREATE TABLE "bookings" (
     CONSTRAINT "bookings_pkey" PRIMARY KEY ("id")
 );
 
+-- Add column if table pre-existed without it (no-op when CREATE TABLE just
+-- ran above with the column already inline).
+ALTER TABLE "bookings" ADD COLUMN IF NOT EXISTS "deposit_account_code" TEXT;
+
 -- CreateTable
-CREATE TABLE "booking_items" (
+CREATE TABLE IF NOT EXISTS "booking_items" (
     "id" TEXT NOT NULL,
     "booking_id" TEXT NOT NULL,
     "product_id" TEXT,
@@ -46,46 +57,68 @@ CREATE TABLE "booking_items" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "bookings_booking_number_key" ON "bookings"("booking_number");
+CREATE UNIQUE INDEX IF NOT EXISTS "bookings_booking_number_key" ON "bookings"("booking_number");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "bookings_converted_to_sale_id_key" ON "bookings"("converted_to_sale_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "bookings_converted_to_sale_id_key" ON "bookings"("converted_to_sale_id");
 
 -- CreateIndex
-CREATE INDEX "bookings_customer_id_deleted_at_idx" ON "bookings"("customer_id", "deleted_at");
+CREATE INDEX IF NOT EXISTS "bookings_customer_id_deleted_at_idx" ON "bookings"("customer_id", "deleted_at");
 
 -- CreateIndex
-CREATE INDEX "bookings_branch_id_status_deleted_at_idx" ON "bookings"("branch_id", "status", "deleted_at");
+CREATE INDEX IF NOT EXISTS "bookings_branch_id_status_deleted_at_idx" ON "bookings"("branch_id", "status", "deleted_at");
 
 -- CreateIndex
-CREATE INDEX "bookings_status_expire_date_idx" ON "bookings"("status", "expire_date");
+CREATE INDEX IF NOT EXISTS "bookings_status_expire_date_idx" ON "bookings"("status", "expire_date");
 
 -- CreateIndex
-CREATE INDEX "bookings_created_at_idx" ON "bookings"("created_at");
+CREATE INDEX IF NOT EXISTS "bookings_created_at_idx" ON "bookings"("created_at");
 
 -- CreateIndex
-CREATE INDEX "booking_items_booking_id_idx" ON "booking_items"("booking_id");
+CREATE INDEX IF NOT EXISTS "booking_items_booking_id_idx" ON "booking_items"("booking_id");
 
 -- CreateIndex
-CREATE INDEX "booking_items_product_id_idx" ON "booking_items"("product_id");
+CREATE INDEX IF NOT EXISTS "booking_items_product_id_idx" ON "booking_items"("product_id");
 
--- AddForeignKey
-ALTER TABLE "bookings" ADD CONSTRAINT "bookings_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+-- AddForeignKey (idempotent via DO block — Postgres FKs have no IF NOT EXISTS)
+DO $$ BEGIN
+    ALTER TABLE "bookings" ADD CONSTRAINT "bookings_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
--- AddForeignKey
-ALTER TABLE "bookings" ADD CONSTRAINT "bookings_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+DO $$ BEGIN
+    ALTER TABLE "bookings" ADD CONSTRAINT "bookings_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
--- AddForeignKey
-ALTER TABLE "bookings" ADD CONSTRAINT "bookings_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+DO $$ BEGIN
+    ALTER TABLE "bookings" ADD CONSTRAINT "bookings_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
--- AddForeignKey
-ALTER TABLE "bookings" ADD CONSTRAINT "bookings_canceled_by_id_fkey" FOREIGN KEY ("canceled_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+DO $$ BEGIN
+    ALTER TABLE "bookings" ADD CONSTRAINT "bookings_canceled_by_id_fkey" FOREIGN KEY ("canceled_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
--- AddForeignKey
-ALTER TABLE "bookings" ADD CONSTRAINT "bookings_converted_to_sale_id_fkey" FOREIGN KEY ("converted_to_sale_id") REFERENCES "sales"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+DO $$ BEGIN
+    ALTER TABLE "bookings" ADD CONSTRAINT "bookings_converted_to_sale_id_fkey" FOREIGN KEY ("converted_to_sale_id") REFERENCES "sales"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
--- AddForeignKey
-ALTER TABLE "booking_items" ADD CONSTRAINT "booking_items_booking_id_fkey" FOREIGN KEY ("booking_id") REFERENCES "bookings"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$ BEGIN
+    ALTER TABLE "booking_items" ADD CONSTRAINT "booking_items_booking_id_fkey" FOREIGN KEY ("booking_id") REFERENCES "bookings"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
--- AddForeignKey
-ALTER TABLE "booking_items" ADD CONSTRAINT "booking_items_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+DO $$ BEGIN
+    ALTER TABLE "booking_items" ADD CONSTRAINT "booking_items_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;

--- a/apps/api/prisma/migrations/20260942000000_add_booking/migration.sql
+++ b/apps/api/prisma/migrations/20260942000000_add_booking/migration.sql
@@ -1,0 +1,91 @@
+-- P2-SP4: Booking module (การจอง / มัดจำ) — SHOP-side pre-sale reservation.
+-- Adds Booking + BookingItem tables and BookingStatus enum.
+
+-- CreateEnum
+CREATE TYPE "BookingStatus" AS ENUM ('PENDING_DEPOSIT', 'PAID', 'CANCELED', 'EXPIRED', 'CONVERTED');
+
+-- CreateTable
+CREATE TABLE "bookings" (
+    "id" TEXT NOT NULL,
+    "booking_number" TEXT NOT NULL,
+    "customer_id" TEXT NOT NULL,
+    "branch_id" TEXT NOT NULL,
+    "status" "BookingStatus" NOT NULL DEFAULT 'PENDING_DEPOSIT',
+    "deposit_amount" DECIMAL(12,2) NOT NULL,
+    "total_amount" DECIMAL(12,2) NOT NULL,
+    "expire_date" TIMESTAMP(3) NOT NULL,
+    "notes" TEXT,
+    "deposit_paid_at" TIMESTAMP(3),
+    "deposit_method" "PaymentMethod",
+    "deposit_received_by_id" TEXT,
+    "canceled_at" TIMESTAMP(3),
+    "canceled_by_id" TEXT,
+    "cancel_reason" TEXT,
+    "converted_to_sale_id" TEXT,
+    "converted_at" TIMESTAMP(3),
+    "created_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "bookings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "booking_items" (
+    "id" TEXT NOT NULL,
+    "booking_id" TEXT NOT NULL,
+    "product_id" TEXT,
+    "description" TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "unit_price" DECIMAL(12,2) NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "booking_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "bookings_booking_number_key" ON "bookings"("booking_number");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "bookings_converted_to_sale_id_key" ON "bookings"("converted_to_sale_id");
+
+-- CreateIndex
+CREATE INDEX "bookings_customer_id_deleted_at_idx" ON "bookings"("customer_id", "deleted_at");
+
+-- CreateIndex
+CREATE INDEX "bookings_branch_id_status_deleted_at_idx" ON "bookings"("branch_id", "status", "deleted_at");
+
+-- CreateIndex
+CREATE INDEX "bookings_status_expire_date_idx" ON "bookings"("status", "expire_date");
+
+-- CreateIndex
+CREATE INDEX "bookings_created_at_idx" ON "bookings"("created_at");
+
+-- CreateIndex
+CREATE INDEX "booking_items_booking_id_idx" ON "booking_items"("booking_id");
+
+-- CreateIndex
+CREATE INDEX "booking_items_product_id_idx" ON "booking_items"("product_id");
+
+-- AddForeignKey
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "branches"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_canceled_by_id_fkey" FOREIGN KEY ("canceled_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_converted_to_sale_id_fkey" FOREIGN KEY ("converted_to_sale_id") REFERENCES "sales"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "booking_items" ADD CONSTRAINT "booking_items_booking_id_fkey" FOREIGN KEY ("booking_id") REFERENCES "bookings"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "booking_items" ADD CONSTRAINT "booking_items_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -6427,6 +6427,10 @@ model Booking {
   notes               String?
   depositPaidAt       DateTime?     @map("deposit_paid_at")
   depositMethod       PaymentMethod? @map("deposit_method")
+  /// Cash Account Dimension (CoA code) — required on payDeposit per
+  /// `.claude/rules/accounting.md`. Nullable column for back-compat with
+  /// any row created before payDeposit was called (PENDING_DEPOSIT rows).
+  depositAccountCode  String?       @map("deposit_account_code")
   depositReceivedById String?       @map("deposit_received_by_id")
   canceledAt          DateTime?     @map("canceled_at")
   canceledById        String?       @map("canceled_by_id")

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -549,6 +549,9 @@ model Branch {
   // SP5 — ใบเสนอราคา
   quotes Quote[] @relation("BranchQuotes")
 
+  // P2-SP4 — การจอง / มัดจำ
+  bookings Booking[] @relation("BranchBookings")
+
   @@index([companyId])
   @@map("branches")
 }
@@ -726,6 +729,10 @@ model User {
   // SP5 — ใบเสนอราคา (created by this user)
   quotesCreated Quote[] @relation("QuoteCreatedBy")
 
+  // P2-SP4 — การจอง / มัดจำ
+  bookingsCreated  Booking[] @relation("BookingCreatedBy")
+  bookingsCanceled Booking[] @relation("BookingCanceledBy")
+
   @@index([branchId])
   @@index([yeastarExtension])
   @@map("users")
@@ -860,6 +867,9 @@ model Customer {
 
   // SP5 — ใบเสนอราคา
   quotes Quote[] @relation("CustomerQuotes")
+
+  // P2-SP4 — การจอง / มัดจำ
+  bookings Booking[] @relation("CustomerBookings")
 
   @@index([phone])
   @@index([name])
@@ -1484,6 +1494,9 @@ model Product {
 
   // SP5 — ใบเสนอราคา
   quoteItems QuoteItem[] @relation("ProductQuoteItems")
+
+  // P2-SP4 — การจอง / มัดจำ
+  bookingItems BookingItem[] @relation("ProductBookingItems")
 
   @@index([branchId])
   @@index([status])
@@ -2296,6 +2309,9 @@ model Sale {
 
   // SP5 — ใบเสนอราคา (origin) — set when sale was created via Quote conversion
   quote Quote? @relation("SaleQuote")
+
+  // P2-SP4 — การจอง (origin) — set when sale was created via Booking conversion
+  booking Booking? @relation("SaleBooking")
 
   @@index([saleType])
   @@index([branchId])
@@ -6377,6 +6393,81 @@ model QuoteItem {
   @@index([quoteId])
   @@index([productId])
   @@map("quote_items")
+}
+
+/// P2-SP4 — การจอง / มัดจำ (Booking).
+/// Lifecycle: PENDING_DEPOSIT -> PAID -> (CANCELED | EXPIRED | CONVERTED).
+/// On CONVERTED, `convertedToSaleId` links to the resulting Sale row and the
+/// deposit transfers to Sale.downPaymentAmount.
+/// On CANCELED before expireDate: 100% refund.
+/// On CANCELED after expireDate or EXPIRED: 0% refund (forfeit).
+enum BookingStatus {
+  PENDING_DEPOSIT
+  PAID
+  CANCELED
+  EXPIRED
+  CONVERTED
+}
+
+/// P2-SP4 — การจอง / มัดจำ. Numbering: BK-YYYYMMDD-NNNN (per-day reset, BKK time).
+/// Deposit info is stored as native fields (depositPaidAt / depositMethod /
+/// depositReceivedById) rather than reusing the Payment model — Payment is
+/// strictly contract-installment-bound (Payment.contractId is required), while
+/// a booking is SHOP-side pre-sale with no contract yet. On conversion the
+/// depositAmount flows into Sale.downPaymentAmount.
+model Booking {
+  id                  String        @id @default(uuid())
+  bookingNumber       String        @unique @map("booking_number")
+  customerId          String        @map("customer_id")
+  branchId            String        @map("branch_id")
+  status              BookingStatus @default(PENDING_DEPOSIT)
+  depositAmount       Decimal       @map("deposit_amount") @db.Decimal(12, 2)
+  totalAmount         Decimal       @map("total_amount") @db.Decimal(12, 2)
+  expireDate          DateTime      @map("expire_date")
+  notes               String?
+  depositPaidAt       DateTime?     @map("deposit_paid_at")
+  depositMethod       PaymentMethod? @map("deposit_method")
+  depositReceivedById String?       @map("deposit_received_by_id")
+  canceledAt          DateTime?     @map("canceled_at")
+  canceledById        String?       @map("canceled_by_id")
+  cancelReason        String?       @map("cancel_reason")
+  convertedToSaleId   String?       @unique @map("converted_to_sale_id")
+  convertedAt         DateTime?     @map("converted_at")
+  createdById         String        @map("created_by_id")
+  createdAt           DateTime      @default(now()) @map("created_at")
+  updatedAt           DateTime      @updatedAt @map("updated_at")
+  deletedAt           DateTime?     @map("deleted_at")
+
+  customer        Customer      @relation("CustomerBookings", fields: [customerId], references: [id])
+  branch          Branch        @relation("BranchBookings", fields: [branchId], references: [id])
+  createdBy       User          @relation("BookingCreatedBy", fields: [createdById], references: [id])
+  canceledBy      User?         @relation("BookingCanceledBy", fields: [canceledById], references: [id])
+  convertedToSale Sale?         @relation("SaleBooking", fields: [convertedToSaleId], references: [id])
+  items           BookingItem[]
+
+  @@index([customerId, deletedAt])
+  @@index([branchId, status, deletedAt])
+  @@index([status, expireDate])
+  @@index([createdAt])
+  @@map("bookings")
+}
+
+model BookingItem {
+  id          String   @id @default(uuid())
+  bookingId   String   @map("booking_id")
+  productId   String?  @map("product_id")
+  description String
+  quantity    Int      @default(1)
+  unitPrice   Decimal  @map("unit_price") @db.Decimal(12, 2)
+  amount      Decimal  @db.Decimal(12, 2)
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  booking Booking  @relation(fields: [bookingId], references: [id], onDelete: Cascade)
+  product Product? @relation("ProductBookingItems", fields: [productId], references: [id])
+
+  @@index([bookingId])
+  @@index([productId])
+  @@map("booking_items")
 }
 
 /// SP6 — Bank/Cash Account directory.

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -60,6 +60,7 @@ import { FinanceReceivableModule } from './modules/finance-receivable/finance-re
 import { AccountingModule } from './modules/accounting/accounting.module';
 import { OtherIncomeModule } from './modules/other-income/other-income.module';
 import { QuotesModule } from './modules/quotes/quotes.module';
+import { BookingsModule } from './modules/bookings/bookings.module';
 import { DraftsModule } from './modules/drafts/drafts.module';
 import { ExpenseDocumentsModule } from './modules/expense-documents/expense-documents.module';
 import { PaymentMethodConfigModule } from './modules/payment-method-config/payment-method-config.module';
@@ -221,6 +222,8 @@ import { AppCacheModule } from './cache/cache.module';
     OtherIncomeModule,
     // SP5 — ใบเสนอราคา (SHOP-side pre-sale)
     QuotesModule,
+    // P2-SP4 — การจอง / มัดจำ (SHOP-side reservation + deposit)
+    BookingsModule,
     // SP5 — Drafts hub (federated DRAFT-status docs across modules)
     DraftsModule,
     // Expense Documents (เอกสารค่าใช้จ่าย — accrual workflow)

--- a/apps/api/src/modules/bookings/__tests__/bookings.service.spec.ts
+++ b/apps/api/src/modules/bookings/__tests__/bookings.service.spec.ts
@@ -1,0 +1,426 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { BookingsService } from '../bookings.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+// Mock sequence util so tests don't need a real `booking` delegate
+jest.mock('../../../utils/sequence.util', () => ({
+  generateBookingNumber: jest.fn().mockResolvedValue('BK-20260517-0001'),
+  generateSaleNumber: jest.fn().mockResolvedValue('SL000123'),
+}));
+
+const OWNER = { id: 'u-owner', role: 'OWNER', branchId: null as string | null };
+const SALES_BR1 = { id: 'u-sales', role: 'SALES', branchId: 'br-1' };
+const SALES_BR2 = { id: 'u-sales-other', role: 'SALES', branchId: 'br-2' };
+
+describe('BookingsService', () => {
+  let service: BookingsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    const txAuditLog = { create: jest.fn().mockResolvedValue({ id: 'log-1' }) };
+
+    const txBooking = {
+      create: jest.fn((args) =>
+        Promise.resolve({
+          id: 'bk-new',
+          bookingNumber: 'BK-20260517-0001',
+          status: 'PENDING_DEPOSIT',
+          depositAmount: args.data.depositAmount,
+          totalAmount: args.data.totalAmount,
+          expireDate: args.data.expireDate,
+          branchId: args.data.branchId,
+          ...args.data,
+          items: [{ id: 'bki-1', quantity: 1 }],
+        }),
+      ),
+      update: jest.fn((args) => Promise.resolve({ id: args.where.id, ...args.data })),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      findFirst: jest
+        .fn()
+        .mockResolvedValue({ id: 'bk-1', items: [], depositAmount: new Prisma.Decimal(1000) }),
+    };
+
+    const txBookingItem = {
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      findMany: jest.fn().mockResolvedValue([]),
+    };
+
+    const txSale = {
+      create: jest.fn((args) =>
+        Promise.resolve({ id: 'sale-new', saleNumber: 'SL000123', ...args.data }),
+      ),
+    };
+
+    prisma = {
+      booking: {
+        findFirst: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
+        update: jest.fn((args) => Promise.resolve({ id: args.where.id, ...args.data })),
+      },
+      customer: { findFirst: jest.fn().mockResolvedValue({ id: 'cust-1' }) },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'br-1' }) },
+      user: { findFirst: jest.fn().mockResolvedValue({ id: 'u-admin' }) },
+      systemConfig: { findFirst: jest.fn().mockResolvedValue(null) },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: jest.fn(async (fn: any) =>
+        fn({
+          booking: txBooking,
+          bookingItem: txBookingItem,
+          sale: txSale,
+          auditLog: txAuditLog,
+        }),
+      ),
+      _tx: { booking: txBooking, bookingItem: txBookingItem, sale: txSale, auditLog: txAuditLog },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [BookingsService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(BookingsService);
+  });
+
+  // 1. create — happy path
+  it('create — computes totalAmount, defaults expireDate +7d, persists PENDING_DEPOSIT + audit', async () => {
+    const result = await service.create(
+      {
+        customerId: 'cust-1',
+        branchId: 'br-1',
+        items: [
+          { description: 'iPhone 15', quantity: 1, unitPrice: 35000 },
+          { description: 'AirPods', quantity: 1, unitPrice: 5990 },
+        ],
+        depositAmount: 5000,
+      },
+      'user-1',
+      OWNER,
+    );
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    const createArgs = prisma._tx.booking.create.mock.calls[0][0];
+    expect(Number(createArgs.data.totalAmount)).toBe(40990);
+    expect(Number(createArgs.data.depositAmount)).toBe(5000);
+    expect(createArgs.data.status).toBe('PENDING_DEPOSIT');
+    expect(createArgs.data.bookingNumber).toBe('BK-20260517-0001');
+    // Default expireDate roughly +7d (allow ±2d slack so test isn't flaky)
+    const days =
+      (new Date(createArgs.data.expireDate).getTime() - Date.now()) / 86400000;
+    expect(days).toBeGreaterThan(5);
+    expect(days).toBeLessThan(9);
+    expect(result.id).toBe('bk-new');
+    expect(prisma._tx.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'BOOKING_CREATED',
+          entity: 'booking',
+        }),
+      }),
+    );
+  });
+
+  it('create — uses Prisma.Decimal for totals (0.1+0.2 precision)', async () => {
+    await service.create(
+      {
+        customerId: 'cust-1',
+        branchId: 'br-1',
+        items: [{ description: 'penny test', quantity: 3, unitPrice: 0.1 }],
+        depositAmount: 0.1,
+      },
+      'user-1',
+      OWNER,
+    );
+    const createArgs = prisma._tx.booking.create.mock.calls[0][0];
+    expect(createArgs.data.totalAmount).toBeInstanceOf(Prisma.Decimal);
+    expect(createArgs.data.depositAmount).toBeInstanceOf(Prisma.Decimal);
+    expect(createArgs.data.totalAmount.toFixed(2)).toBe('0.30');
+  });
+
+  it('create — rejects depositAmount > totalAmount', async () => {
+    await expect(
+      service.create(
+        {
+          customerId: 'cust-1',
+          branchId: 'br-1',
+          items: [{ description: 'X', quantity: 1, unitPrice: 1000 }],
+          depositAmount: 5000, // > totalAmount 1000
+        },
+        'user-1',
+        OWNER,
+      ),
+    ).rejects.toThrow(/มัดจำ.*ห้ามมากกว่า/);
+  });
+
+  it('create — SALES cannot create against another branch', async () => {
+    await expect(
+      service.create(
+        {
+          customerId: 'cust-1',
+          branchId: 'br-1',
+          items: [{ description: 'X', quantity: 1, unitPrice: 1000 }],
+          depositAmount: 500,
+        },
+        'user-1',
+        SALES_BR2,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  // 2. payDeposit — happy path + race protection
+  it('payDeposit — PENDING_DEPOSIT → PAID with updateMany race claim + audit', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PENDING_DEPOSIT',
+      branchId: 'br-1',
+      expireDate: new Date(Date.now() + 86400000),
+    });
+    await service.payDeposit('bk-1', { depositMethod: 'CASH' }, OWNER);
+    expect(prisma._tx.booking.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'bk-1',
+          status: 'PENDING_DEPOSIT',
+        }),
+        data: expect.objectContaining({
+          status: 'PAID',
+          depositMethod: 'CASH',
+          depositReceivedById: OWNER.id,
+        }),
+      }),
+    );
+    expect(prisma._tx.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'BOOKING_DEPOSIT_PAID' }),
+      }),
+    );
+  });
+
+  it('payDeposit — race: second concurrent caller throws Conflict (updateMany count=0)', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PENDING_DEPOSIT',
+      branchId: 'br-1',
+      expireDate: new Date(Date.now() + 86400000),
+    });
+    prisma._tx.booking.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      service.payDeposit('bk-1', { depositMethod: 'CASH' }, OWNER),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('payDeposit — rejects expired booking', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PENDING_DEPOSIT',
+      branchId: 'br-1',
+      expireDate: new Date(Date.now() - 86400000),
+    });
+    await expect(service.payDeposit('bk-1', {}, OWNER)).rejects.toThrow(BadRequestException);
+  });
+
+  // 3. cancel — before expire only
+  it('cancel — PAID booking before expire → CANCELED + refund noted', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      branchId: 'br-1',
+      expireDate: new Date(Date.now() + 86400000),
+      depositAmount: new Prisma.Decimal(1000),
+      depositPaidAt: new Date(),
+    });
+    await service.cancel('bk-1', { cancelReason: 'ลูกค้าเปลี่ยนใจ' }, OWNER);
+    expect(prisma._tx.booking.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'bk-1',
+          status: { in: ['PENDING_DEPOSIT', 'PAID'] },
+        }),
+        data: expect.objectContaining({
+          status: 'CANCELED',
+          canceledById: OWNER.id,
+          cancelReason: 'ลูกค้าเปลี่ยนใจ',
+        }),
+      }),
+    );
+    expect(prisma._tx.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'BOOKING_CANCELED',
+          newValue: expect.objectContaining({ refundAmount: '1000.00' }),
+        }),
+      }),
+    );
+  });
+
+  it('cancel — rejects when expireDate already past (use cron instead)', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      branchId: 'br-1',
+      expireDate: new Date(Date.now() - 86400000),
+      depositAmount: new Prisma.Decimal(1000),
+    });
+    await expect(service.cancel('bk-1', {}, OWNER)).rejects.toThrow(/หมดอายุ/);
+  });
+
+  // 4. convertToSale — happy path + idempotency
+  it('convertToSale — PAID → CONVERTED + Sale row with downPaymentAmount + audit', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      convertedToSaleId: null,
+      bookingNumber: 'BK-20260517-0001',
+      customerId: 'cust-1',
+      branchId: 'br-1',
+      totalAmount: new Prisma.Decimal(40990),
+      depositAmount: new Prisma.Decimal(5000),
+      depositMethod: 'CASH',
+      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 35000, amount: 35000 }],
+    });
+    const result = await service.convertToSale('bk-1', {}, 'user-1', OWNER);
+    expect(prisma._tx.booking.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'bk-1',
+          status: 'PAID',
+          convertedToSaleId: null,
+        }),
+        data: expect.objectContaining({ status: 'CONVERTED' }),
+      }),
+    );
+    const saleArgs = prisma._tx.sale.create.mock.calls[0][0];
+    expect(Number(saleArgs.data.downPaymentAmount)).toBe(5000);
+    expect(Number(saleArgs.data.sellingPrice)).toBe(40990);
+    expect(result.sale.id).toBe('sale-new');
+    expect(prisma._tx.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'BOOKING_CONVERTED',
+          newValue: expect.objectContaining({ depositTransferred: '5000.00' }),
+        }),
+      }),
+    );
+  });
+
+  it('convertToSale — race: second concurrent caller throws Conflict (no Sale created)', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      convertedToSaleId: null,
+      bookingNumber: 'BK-20260517-0001',
+      customerId: 'cust-1',
+      branchId: 'br-1',
+      totalAmount: new Prisma.Decimal(40990),
+      depositAmount: new Prisma.Decimal(5000),
+      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 35000, amount: 35000 }],
+    });
+    prisma._tx.booking.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(service.convertToSale('bk-1', {}, 'user-1', OWNER)).rejects.toThrow(
+      ConflictException,
+    );
+    expect(prisma._tx.sale.create).not.toHaveBeenCalled();
+  });
+
+  it('convertToSale — rejects double-convert (already linked)', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      convertedToSaleId: 'sale-existing',
+      branchId: 'br-1',
+      items: [{ productId: 'prod-1' }],
+    });
+    await expect(service.convertToSale('bk-1', {}, 'user-1', OWNER)).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  // 5. autoExpire — cron path
+  it('autoExpire — flips PAID + past-expireDate rows to EXPIRED and writes audit', async () => {
+    prisma.booking.findMany.mockResolvedValueOnce([
+      {
+        id: 'bk-late-1',
+        depositAmount: new Prisma.Decimal(1000),
+        bookingNumber: 'BK-20260510-0001',
+      },
+      {
+        id: 'bk-late-2',
+        depositAmount: new Prisma.Decimal(2500),
+        bookingNumber: 'BK-20260510-0002',
+      },
+    ]);
+    const count = await service.autoExpire();
+    expect(count).toBe(2);
+    const auditCalls = prisma._tx.auditLog.create.mock.calls.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (call: any) => call[0].data,
+    );
+    expect(
+      auditCalls.every(
+        (data: { action: string; entity: string }) =>
+          data.action === 'BOOKING_AUTO_EXPIRED' && data.entity === 'booking',
+      ),
+    ).toBe(true);
+  });
+
+  it('autoExpire — returns 0 when no candidates (and skips audit writes)', async () => {
+    prisma.booking.findMany.mockResolvedValueOnce([]);
+    const count = await service.autoExpire();
+    expect(count).toBe(0);
+    expect(prisma._tx.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  // 6. Branch scoping — findAll + findOne
+  it('findAll — SALES is forced to own branchId regardless of query param', async () => {
+    await service.findAll({}, SALES_BR1);
+    const findArgs = prisma.booking.findMany.mock.calls[0][0];
+    expect(findArgs.where.branchId).toBe('br-1');
+  });
+
+  it('findAll — SALES requesting another branchId is forbidden', async () => {
+    await expect(service.findAll({ branchId: 'br-2' }, SALES_BR1)).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('findOne — throws NotFound when row missing OR scope forbids', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce(null);
+    await expect(service.findOne('bk-missing', OWNER)).rejects.toThrow(NotFoundException);
+  });
+
+  // 7. soft delete — DRAFT-equivalent only
+  it('remove — soft-deletes PENDING_DEPOSIT booking + audit', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PENDING_DEPOSIT',
+      branchId: 'br-1',
+    });
+    await service.remove('bk-1', OWNER);
+    expect(prisma._tx.booking.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'bk-1' },
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      }),
+    );
+    expect(prisma._tx.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'BOOKING_DELETED' }),
+      }),
+    );
+  });
+
+  it('remove — rejects non-PENDING_DEPOSIT (e.g. PAID) booking', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      branchId: 'br-1',
+    });
+    await expect(service.remove('bk-1', OWNER)).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/bookings/__tests__/bookings.service.spec.ts
+++ b/apps/api/src/modules/bookings/__tests__/bookings.service.spec.ts
@@ -59,6 +59,23 @@ describe('BookingsService', () => {
       ),
     };
 
+    const txProduct = {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'prod-1',
+        status: 'IN_STOCK',
+        deletedAt: null,
+      }),
+      update: jest.fn((args) => Promise.resolve({ id: args.where.id, ...args.data })),
+    };
+
+    const txCommissionRule = {
+      findFirst: jest.fn().mockResolvedValue({ rate: 0.03 }),
+    };
+
+    const txSalesCommission = {
+      create: jest.fn((args) => Promise.resolve({ id: 'cm-1', ...args.data })),
+    };
+
     prisma = {
       booking: {
         findFirst: jest.fn(),
@@ -76,10 +93,21 @@ describe('BookingsService', () => {
           booking: txBooking,
           bookingItem: txBookingItem,
           sale: txSale,
+          product: txProduct,
+          commissionRule: txCommissionRule,
+          salesCommission: txSalesCommission,
           auditLog: txAuditLog,
         }),
       ),
-      _tx: { booking: txBooking, bookingItem: txBookingItem, sale: txSale, auditLog: txAuditLog },
+      _tx: {
+        booking: txBooking,
+        bookingItem: txBookingItem,
+        sale: txSale,
+        product: txProduct,
+        commissionRule: txCommissionRule,
+        salesCommission: txSalesCommission,
+        auditLog: txAuditLog,
+      },
     };
 
     const mod: TestingModule = await Test.createTestingModule({
@@ -174,30 +202,40 @@ describe('BookingsService', () => {
   });
 
   // 2. payDeposit — happy path + race protection
-  it('payDeposit — PENDING_DEPOSIT → PAID with updateMany race claim + audit', async () => {
+  it('payDeposit — PENDING_DEPOSIT → PAID with updateMany race claim + audit + persists depositAccountCode (C3)', async () => {
     prisma.booking.findFirst.mockResolvedValueOnce({
       id: 'bk-1',
       status: 'PENDING_DEPOSIT',
       branchId: 'br-1',
       expireDate: new Date(Date.now() + 86400000),
     });
-    await service.payDeposit('bk-1', { depositMethod: 'CASH' }, OWNER);
+    await service.payDeposit(
+      'bk-1',
+      { depositMethod: 'CASH', depositAccountCode: '11-1101' },
+      OWNER,
+    );
     expect(prisma._tx.booking.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           id: 'bk-1',
           status: 'PENDING_DEPOSIT',
+          // C6 — expireDate enforced atomically in the filter
+          expireDate: expect.objectContaining({ gt: expect.any(Date) }),
         }),
         data: expect.objectContaining({
           status: 'PAID',
           depositMethod: 'CASH',
+          depositAccountCode: '11-1101',
           depositReceivedById: OWNER.id,
         }),
       }),
     );
     expect(prisma._tx.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ action: 'BOOKING_DEPOSIT_PAID' }),
+        data: expect.objectContaining({
+          action: 'BOOKING_DEPOSIT_PAID',
+          newValue: expect.objectContaining({ depositAccountCode: '11-1101' }),
+        }),
       }),
     );
   });
@@ -211,18 +249,28 @@ describe('BookingsService', () => {
     });
     prisma._tx.booking.updateMany.mockResolvedValueOnce({ count: 0 });
     await expect(
-      service.payDeposit('bk-1', { depositMethod: 'CASH' }, OWNER),
+      service.payDeposit(
+        'bk-1',
+        { depositMethod: 'CASH', depositAccountCode: '11-1101' },
+        OWNER,
+      ),
     ).rejects.toThrow(ConflictException);
   });
 
-  it('payDeposit — rejects expired booking', async () => {
+  it('payDeposit — rejects expired booking (pre-tx guard)', async () => {
     prisma.booking.findFirst.mockResolvedValueOnce({
       id: 'bk-1',
       status: 'PENDING_DEPOSIT',
       branchId: 'br-1',
       expireDate: new Date(Date.now() - 86400000),
     });
-    await expect(service.payDeposit('bk-1', {}, OWNER)).rejects.toThrow(BadRequestException);
+    await expect(
+      service.payDeposit(
+        'bk-1',
+        { depositMethod: 'CASH', depositAccountCode: '11-1101' },
+        OWNER,
+      ),
+    ).rejects.toThrow(BadRequestException);
   });
 
   // 3. cancel — before expire only
@@ -271,7 +319,7 @@ describe('BookingsService', () => {
   });
 
   // 4. convertToSale — happy path + idempotency
-  it('convertToSale — PAID → CONVERTED + Sale row with downPaymentAmount + audit', async () => {
+  it('convertToSale — full-prepay (deposit==total) → CONVERTED + Sale.amountReceived=total + Product SOLD_CASH + commission (C1, C2)', async () => {
     prisma.booking.findFirst.mockResolvedValueOnce({
       id: 'bk-1',
       status: 'PAID',
@@ -280,9 +328,9 @@ describe('BookingsService', () => {
       customerId: 'cust-1',
       branchId: 'br-1',
       totalAmount: new Prisma.Decimal(40990),
-      depositAmount: new Prisma.Decimal(5000),
+      depositAmount: new Prisma.Decimal(40990),
       depositMethod: 'CASH',
-      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 35000, amount: 35000 }],
+      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 40990, amount: 40990 }],
     });
     const result = await service.convertToSale('bk-1', {}, 'user-1', OWNER);
     expect(prisma._tx.booking.updateMany).toHaveBeenCalledWith(
@@ -296,17 +344,79 @@ describe('BookingsService', () => {
       }),
     );
     const saleArgs = prisma._tx.sale.create.mock.calls[0][0];
-    expect(Number(saleArgs.data.downPaymentAmount)).toBe(5000);
+    expect(Number(saleArgs.data.downPaymentAmount)).toBe(40990);
     expect(Number(saleArgs.data.sellingPrice)).toBe(40990);
+    // C2 — amountReceived = totalAmount because the whole sale was prepaid
+    expect(Number(saleArgs.data.amountReceived)).toBe(40990);
+    // C1 — product flipped to SOLD_CASH
+    expect(prisma._tx.product.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'prod-1' },
+        data: { status: 'SOLD_CASH' },
+      }),
+    );
+    // C1 — SalesCommission row created
+    expect(prisma._tx.salesCommission.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          saleId: 'sale-new',
+          salespersonId: 'user-1',
+          commissionRate: 0.03,
+        }),
+      }),
+    );
     expect(result.sale.id).toBe('sale-new');
     expect(prisma._tx.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           action: 'BOOKING_CONVERTED',
-          newValue: expect.objectContaining({ depositTransferred: '5000.00' }),
+          newValue: expect.objectContaining({
+            depositTransferred: '40990.00',
+            amountReceived: '40990.00',
+          }),
         }),
       }),
     );
+  });
+
+  it('convertToSale — partial deposit without collectBalance → BadRequest (C2 — no revenue overstatement)', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      convertedToSaleId: null,
+      bookingNumber: 'BK-20260517-0001',
+      customerId: 'cust-1',
+      branchId: 'br-1',
+      totalAmount: new Prisma.Decimal(40990),
+      depositAmount: new Prisma.Decimal(5000),
+      depositMethod: 'CASH',
+      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 35000, amount: 35000 }],
+    });
+    await expect(service.convertToSale('bk-1', {}, 'user-1', OWNER)).rejects.toThrow(
+      /เรียกเก็บยอดส่วนต่าง 35990\.00/,
+    );
+    // Sale must NOT be created — guard fires before tx
+    expect(prisma._tx.sale.create).not.toHaveBeenCalled();
+    expect(prisma._tx.product.update).not.toHaveBeenCalled();
+  });
+
+  it('convertToSale — partial deposit + collectBalance=true → amountReceived=totalAmount (C2)', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      convertedToSaleId: null,
+      bookingNumber: 'BK-20260517-0001',
+      customerId: 'cust-1',
+      branchId: 'br-1',
+      totalAmount: new Prisma.Decimal(40990),
+      depositAmount: new Prisma.Decimal(5000),
+      depositMethod: 'CASH',
+      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 35000, amount: 35000 }],
+    });
+    await service.convertToSale('bk-1', { collectBalance: true }, 'user-1', OWNER);
+    const saleArgs = prisma._tx.sale.create.mock.calls[0][0];
+    expect(Number(saleArgs.data.amountReceived)).toBe(40990);
+    expect(Number(saleArgs.data.downPaymentAmount)).toBe(5000);
   });
 
   it('convertToSale — race: second concurrent caller throws Conflict (no Sale created)', async () => {
@@ -318,8 +428,8 @@ describe('BookingsService', () => {
       customerId: 'cust-1',
       branchId: 'br-1',
       totalAmount: new Prisma.Decimal(40990),
-      depositAmount: new Prisma.Decimal(5000),
-      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 35000, amount: 35000 }],
+      depositAmount: new Prisma.Decimal(40990),
+      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 40990, amount: 40990 }],
     });
     prisma._tx.booking.updateMany.mockResolvedValueOnce({ count: 0 });
     await expect(service.convertToSale('bk-1', {}, 'user-1', OWNER)).rejects.toThrow(
@@ -339,6 +449,29 @@ describe('BookingsService', () => {
     await expect(service.convertToSale('bk-1', {}, 'user-1', OWNER)).rejects.toThrow(
       ConflictException,
     );
+  });
+
+  it('convertToSale — rejects when product no longer IN_STOCK (C1 — double-sell guard)', async () => {
+    prisma.booking.findFirst.mockResolvedValueOnce({
+      id: 'bk-1',
+      status: 'PAID',
+      convertedToSaleId: null,
+      bookingNumber: 'BK-20260517-0001',
+      customerId: 'cust-1',
+      branchId: 'br-1',
+      totalAmount: new Prisma.Decimal(40990),
+      depositAmount: new Prisma.Decimal(40990),
+      items: [{ productId: 'prod-1', quantity: 1, unitPrice: 40990, amount: 40990 }],
+    });
+    prisma._tx.product.findUnique.mockResolvedValueOnce({
+      id: 'prod-1',
+      status: 'SOLD_CASH',
+      deletedAt: null,
+    });
+    await expect(service.convertToSale('bk-1', {}, 'user-1', OWNER)).rejects.toThrow(
+      /ไม่พร้อมขาย/,
+    );
+    expect(prisma._tx.sale.create).not.toHaveBeenCalled();
   });
 
   // 5. autoExpire — cron path

--- a/apps/api/src/modules/bookings/booking-expire.cron.ts
+++ b/apps/api/src/modules/bookings/booking-expire.cron.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/node';
+import { BookingsService } from './bookings.service';
+
+/**
+ * P2-SP4 — Daily cron at 00:30 BKK that flips PAID bookings whose `expireDate`
+ * has passed into EXPIRED status (customer forfeits the deposit, per owner's
+ * configured policy: cancel-after-expire = 0% refund).
+ *
+ * Time window chosen to avoid contention with the 00:01 InstallmentAccrual
+ * cron and the 02:00 VAT-60day cron. Sentry capture mirrors the other
+ * cron jobs hardened in ultraplan v2 (PR #432).
+ */
+@Injectable()
+export class BookingExpireCron {
+  private readonly logger = new Logger(BookingExpireCron.name);
+
+  constructor(private readonly bookings: BookingsService) {}
+
+  @Cron('30 0 * * *', { timeZone: 'Asia/Bangkok' })
+  async expireOverdueBookings(): Promise<void> {
+    try {
+      const flipped = await this.bookings.autoExpire();
+      if (flipped > 0) {
+        this.logger.log(`Auto-expired ${flipped} booking(s) past expireDate`);
+      }
+    } catch (err) {
+      this.logger.error(
+        `BookingExpireCron failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      Sentry.captureException(err);
+    }
+  }
+}

--- a/apps/api/src/modules/bookings/bookings.controller.ts
+++ b/apps/api/src/modules/bookings/bookings.controller.ts
@@ -1,0 +1,141 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { BranchGuard } from '../auth/guards/branch.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { BookingsService } from './bookings.service';
+import { CreateBookingDto } from './dto/create-booking.dto';
+import { UpdateBookingDto } from './dto/update-booking.dto';
+import { PayDepositDto } from './dto/pay-deposit.dto';
+import { CancelBookingDto } from './dto/cancel-booking.dto';
+import { ConvertBookingDto } from './dto/convert-booking.dto';
+
+type RequestUser = { id: string; role: string; branchId?: string | null };
+type AuthRequest = Request & { user?: RequestUser };
+
+@ApiTags('Bookings')
+@ApiBearerAuth('JWT')
+@Controller('bookings')
+@UseGuards(JwtAuthGuard, RolesGuard, BranchGuard)
+export class BookingsController {
+  constructor(private readonly bookingsService: BookingsService) {}
+
+  @Get()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  @ApiOperation({ summary: 'ค้นหา / แสดงรายการใบจอง' })
+  findAll(
+    @Req() req: AuthRequest,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('status') status?: string,
+    @Query('branchId') branchId?: string,
+    @Query('customerId') customerId?: string,
+    @Query('search') search?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.findAll(
+      {
+        page: page ? Math.max(1, parseInt(page, 10) || 1) : undefined,
+        limit: limit ? Math.min(100, parseInt(limit, 10) || 50) : undefined,
+        status,
+        branchId,
+        customerId,
+        search,
+        from,
+        to,
+      },
+      user,
+    );
+  }
+
+  @Get(':id')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
+  findOne(@Param('id') id: string, @Req() req: AuthRequest) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.findOne(id, user);
+  }
+
+  @Post()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
+  @ApiOperation({ summary: 'สร้างใบจองใหม่ (PENDING_DEPOSIT)' })
+  create(@Body() dto: CreateBookingDto, @Req() req: AuthRequest) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.create(dto, user.id, user);
+  }
+
+  @Patch(':id')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
+  update(@Param('id') id: string, @Body() dto: UpdateBookingDto, @Req() req: AuthRequest) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.update(id, dto, user);
+  }
+
+  @Post(':id/pay-deposit')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
+  @ApiOperation({ summary: 'บันทึกการรับมัดจำ (PENDING_DEPOSIT → PAID)' })
+  payDeposit(
+    @Param('id') id: string,
+    @Body() dto: PayDepositDto,
+    @Req() req: AuthRequest,
+  ) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.payDeposit(id, dto, user);
+  }
+
+  @Post(':id/cancel')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
+  @ApiOperation({ summary: 'ยกเลิกใบจอง (ก่อนหมดอายุ — คืนมัดจำ 100%)' })
+  cancel(
+    @Param('id') id: string,
+    @Body() dto: CancelBookingDto,
+    @Req() req: AuthRequest,
+  ) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.cancel(id, dto, user);
+  }
+
+  @Post(':id/convert')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
+  @ApiOperation({
+    summary: 'แปลงใบจองเป็นการขาย (PAID → CONVERTED + Sale พร้อม downPayment)',
+  })
+  convert(
+    @Param('id') id: string,
+    @Body() dto: ConvertBookingDto,
+    @Req() req: AuthRequest,
+  ) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.convertToSale(id, dto, user.id, user);
+  }
+
+  @Delete(':id')
+  @Roles('OWNER', 'BRANCH_MANAGER')
+  @ApiOperation({ summary: 'ลบใบจอง (PENDING_DEPOSIT เท่านั้น, soft-delete)' })
+  remove(@Param('id') id: string, @Req() req: AuthRequest) {
+    const user = req.user;
+    if (!user) throw new Error('JWT user ไม่ถูกต้อง');
+    return this.bookingsService.remove(id, user);
+  }
+}

--- a/apps/api/src/modules/bookings/bookings.module.ts
+++ b/apps/api/src/modules/bookings/bookings.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { BookingsController } from './bookings.controller';
+import { BookingsService } from './bookings.service';
+import { BookingExpireCron } from './booking-expire.cron';
+
+@Module({
+  controllers: [BookingsController],
+  providers: [BookingsService, BookingExpireCron],
+  exports: [BookingsService],
+})
+export class BookingsModule {}

--- a/apps/api/src/modules/bookings/bookings.service.ts
+++ b/apps/api/src/modules/bookings/bookings.service.ts
@@ -7,6 +7,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/node';
 import { PrismaService } from '../../prisma/prisma.service';
 import { generateBookingNumber, generateSaleNumber } from '../../utils/sequence.util';
 import { readNumberFlag } from '../../utils/config.util';
@@ -387,21 +388,26 @@ export class BookingsService {
     }
 
     return this.prisma.$transaction(async (tx) => {
+      // C6 — expireDate enforced atomically in the updateMany filter so the
+      // expire-cron can't flip status between the read above and this write.
+      const now = new Date();
       const claim = await tx.booking.updateMany({
         where: {
           id,
           deletedAt: null,
           status: 'PENDING_DEPOSIT',
+          expireDate: { gt: now },
         },
         data: {
           status: 'PAID',
-          depositPaidAt: new Date(),
+          depositPaidAt: now,
           depositMethod: dto.depositMethod,
+          depositAccountCode: dto.depositAccountCode,
           depositReceivedById: user.id,
         },
       });
       if (claim.count !== 1) {
-        throw new ConflictException('ใบจองนี้ถูกบันทึกมัดจำหรือเปลี่ยนสถานะไปแล้ว');
+        throw new ConflictException('ใบจองนี้หมดอายุ ถูกบันทึกมัดจำ หรือเปลี่ยนสถานะไปแล้ว');
       }
 
       const updated = await tx.booking.findFirst({
@@ -418,7 +424,8 @@ export class BookingsService {
           oldValue: { status: 'PENDING_DEPOSIT' },
           newValue: {
             status: 'PAID',
-            depositMethod: dto.depositMethod ?? null,
+            depositMethod: dto.depositMethod,
+            depositAccountCode: dto.depositAccountCode,
             notes: dto.notes ?? null,
           },
         },
@@ -546,7 +553,29 @@ export class BookingsService {
       );
     }
 
+    // C2 — guard amountReceived honesty. The cashier MUST tell us whether the
+    // outstanding balance is being collected at convert time, so we don't lie
+    // about cash-in on the Sale row (which feeds revenue + cash reports).
+    const totalAmount = booking.totalAmount as Prisma.Decimal;
+    const depositAmount = booking.depositAmount as Prisma.Decimal;
+    const isFullPrepay = depositAmount.equals(totalAmount);
+
+    if (!isFullPrepay && !dto.collectBalance) {
+      throw new BadRequestException(
+        `ต้องเรียกเก็บยอดส่วนต่าง ${totalAmount
+          .sub(depositAmount)
+          .toFixed(2)} บาท ก่อนแปลงเป็นการขาย (ส่ง collectBalance: true เมื่อรับเงินครบ)`,
+      );
+    }
+
+    // C1 — inline the SalesService.createCashSale invariants the original
+    // tx.sale.create skipped: verifyProductInStock, Product.status flip to
+    // SOLD_CASH, SalesCommission row. Doing it inline (not by calling
+    // SalesService) keeps the booking module self-contained and avoids
+    // accidentally inheriting CASH-sale discount / loyalty branches that
+    // don't apply here.
     return this.prisma.$transaction(async (tx) => {
+      // 1. Claim the booking PAID → CONVERTED atomically.
       const claim = await tx.booking.updateMany({
         where: {
           id,
@@ -563,10 +592,23 @@ export class BookingsService {
         throw new ConflictException('ใบจองนี้ถูกแปลงเป็นการขายแล้ว');
       }
 
+      // 2. Verify the product is still IN_STOCK (race vs another POS sale).
+      const product = await tx.product.findUnique({
+        where: { id: firstItem.productId! },
+      });
+      if (!product || product.deletedAt || product.status !== 'IN_STOCK') {
+        throw new BadRequestException(
+          'สินค้าไม่พร้อมขาย หรือถูกขายไปแล้ว — กรุณาตรวจสอบสต็อก',
+        );
+      }
+
       const saleNumber = await generateSaleNumber(
         tx as unknown as Parameters<typeof generateSaleNumber>[0],
       );
 
+      // 3. Create the Sale row. amountReceived = depositAmount when no balance
+      // collected, totalAmount when fully prepaid OR balance collected now.
+      const amountReceived = isFullPrepay || dto.collectBalance ? totalAmount : depositAmount;
       const sale = await tx.sale.create({
         data: {
           saleNumber,
@@ -575,19 +617,51 @@ export class BookingsService {
           productId: firstItem.productId!,
           branchId: booking.branchId,
           salespersonId,
-          sellingPrice: booking.totalAmount,
+          sellingPrice: totalAmount,
           discount: ZERO,
-          netAmount: booking.totalAmount,
+          netAmount: totalAmount,
           paymentMethod:
             (dto.paymentMethod as Prisma.SaleCreateInput['paymentMethod']) ||
             booking.depositMethod ||
             null,
-          amountReceived: booking.totalAmount,
-          downPaymentAmount: booking.depositAmount,
+          amountReceived,
+          downPaymentAmount: depositAmount,
           notes: dto.notes || `แปลงจากใบจอง ${booking.bookingNumber}`,
         },
       });
 
+      // 4. Flip product → SOLD_CASH (mirrors SalesService.createCashSale).
+      await tx.product.update({
+        where: { id: firstItem.productId! },
+        data: { status: 'SOLD_CASH' },
+      });
+
+      // 5. Auto-create sales commission (read from CommissionRule, fallback 3%).
+      const nowCommission = new Date();
+      const period = `${nowCommission.getFullYear()}-${String(
+        nowCommission.getMonth() + 1,
+      ).padStart(2, '0')}`;
+      const rule = await tx.commissionRule.findFirst({
+        where: { isActive: true, deletedAt: null },
+        orderBy: { createdAt: 'desc' },
+      });
+      const commissionRate = rule?.rate ? Number(rule.rate) : 0.03;
+      const commissionAmount = totalAmount.mul(commissionRate).toDecimalPlaces(2);
+      await tx.salesCommission.create({
+        data: {
+          salespersonId,
+          // Cash sale has no contract — snapshot earner = current earner.
+          snapshotSalespersonId: salespersonId,
+          saleId: sale.id,
+          period,
+          saleAmount: totalAmount,
+          commissionRate,
+          commissionAmount,
+          status: 'PENDING',
+        },
+      });
+
+      // 6. Link booking → sale (FK on Booking side).
       await tx.booking.update({
         where: { id },
         data: { convertedToSaleId: sale.id },
@@ -604,7 +678,9 @@ export class BookingsService {
             status: 'CONVERTED',
             saleId: sale.id,
             saleNumber: sale.saleNumber,
-            depositTransferred: booking.depositAmount.toFixed(2),
+            depositTransferred: depositAmount.toFixed(2),
+            amountReceived: amountReceived.toFixed(2),
+            balanceCollectedAtConvert: !isFullPrepay && !!dto.collectBalance,
           },
         },
       });
@@ -734,6 +810,12 @@ export class BookingsService {
             err instanceof Error ? err.message : String(err)
           }`,
         );
+        // C5 — per-row Sentry capture so one bad candidate doesn't disappear
+        // into the log noise. Cron-level Sentry only fires on an overall throw,
+        // and the per-row try/catch above swallows individual failures.
+        Sentry.captureException(err, {
+          tags: { module: 'booking-expire', bookingId: candidate.id },
+        });
       }
     }
     return flipped;

--- a/apps/api/src/modules/bookings/bookings.service.ts
+++ b/apps/api/src/modules/bookings/bookings.service.ts
@@ -1,0 +1,741 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { generateBookingNumber, generateSaleNumber } from '../../utils/sequence.util';
+import { readNumberFlag } from '../../utils/config.util';
+import { getBranchScope, hasCrossBranchAccess } from '../auth/branch-access.util';
+import { CreateBookingDto } from './dto/create-booking.dto';
+import { UpdateBookingDto } from './dto/update-booking.dto';
+import { PayDepositDto } from './dto/pay-deposit.dto';
+import { CancelBookingDto } from './dto/cancel-booking.dto';
+import { ConvertBookingDto } from './dto/convert-booking.dto';
+
+type RequestUser = { id: string; role: string; branchId?: string | null };
+
+const BOOKING_DEFAULT_INCLUDE = {
+  items: { orderBy: { createdAt: 'asc' as const } },
+  customer: {
+    select: {
+      id: true,
+      name: true,
+      phone: true,
+      addressCurrent: true,
+      addressIdCard: true,
+    },
+  },
+  branch: { select: { id: true, name: true, companyId: true } },
+  createdBy: { select: { id: true, name: true, email: true } },
+  canceledBy: { select: { id: true, name: true } },
+  convertedToSale: { select: { id: true, saleNumber: true, saleType: true } },
+} as const;
+
+const ZERO = new Prisma.Decimal(0);
+
+const DEFAULT_EXPIRE_DAYS = 7;
+const BOOKING_EXPIRE_DAYS_KEY = 'booking_expire_days';
+
+@Injectable()
+export class BookingsService {
+  private readonly logger = new Logger(BookingsService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Branch scoping helpers (mirror QuotesService pattern — keep them
+  // in lockstep for consistency)
+  // ───────────────────────────────────────────────────────────────────────
+
+  private applyBranchScope(
+    where: Prisma.BookingWhereInput,
+    user: RequestUser,
+    requestedBranchId?: string,
+  ): { where: Prisma.BookingWhereInput; empty: boolean } {
+    const scope = getBranchScope(user);
+    if (scope.all) {
+      if (requestedBranchId) where.branchId = requestedBranchId;
+      return { where, empty: false };
+    }
+    if (!scope.branchId) return { where, empty: true };
+    if (requestedBranchId && requestedBranchId !== scope.branchId) {
+      throw new ForbiddenException('ไม่สามารถเข้าถึงข้อมูลของสาขาอื่นได้');
+    }
+    where.branchId = scope.branchId;
+    return { where, empty: false };
+  }
+
+  private assertCanWriteBranch(user: RequestUser, branchId: string) {
+    if (hasCrossBranchAccess(user)) return;
+    if (!user.branchId) {
+      throw new ForbiddenException('บัญชีนี้ยังไม่มีสาขาที่รับผิดชอบ');
+    }
+    if (user.branchId !== branchId) {
+      throw new ForbiddenException('ไม่สามารถเข้าถึงข้อมูลของสาขาอื่นได้');
+    }
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Read
+  // ───────────────────────────────────────────────────────────────────────
+
+  async findAll(
+    opts: {
+      page?: number;
+      limit?: number;
+      status?: string;
+      branchId?: string;
+      search?: string;
+      customerId?: string;
+      from?: string;
+      to?: string;
+    },
+    user: RequestUser,
+  ) {
+    const page = Math.max(1, opts.page ?? 1);
+    const limit = Math.min(100, Math.max(1, opts.limit ?? 50));
+    const skip = (page - 1) * limit;
+
+    const baseWhere: Prisma.BookingWhereInput = { deletedAt: null };
+    if (opts.status) baseWhere.status = opts.status as Prisma.BookingWhereInput['status'];
+    if (opts.customerId) baseWhere.customerId = opts.customerId;
+    if (opts.search) {
+      baseWhere.OR = [
+        { bookingNumber: { contains: opts.search, mode: 'insensitive' } },
+        { customer: { name: { contains: opts.search, mode: 'insensitive' } } },
+      ];
+    }
+    if (opts.from || opts.to) {
+      const createdAt: Prisma.DateTimeFilter = {};
+      if (opts.from) {
+        const f = new Date(opts.from);
+        if (!Number.isNaN(f.getTime())) createdAt.gte = f;
+      }
+      if (opts.to) {
+        const t = new Date(opts.to);
+        if (!Number.isNaN(t.getTime())) createdAt.lte = t;
+      }
+      if (createdAt.gte || createdAt.lte) baseWhere.createdAt = createdAt;
+    }
+
+    const { where, empty } = this.applyBranchScope(baseWhere, user, opts.branchId);
+    if (empty) return { data: [], total: 0, page, limit };
+
+    const [data, total] = await Promise.all([
+      this.prisma.booking.findMany({
+        where,
+        include: BOOKING_DEFAULT_INCLUDE,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.booking.count({ where }),
+    ]);
+
+    return { data, total, page, limit };
+  }
+
+  async findOne(id: string, user: RequestUser) {
+    const baseWhere: Prisma.BookingWhereInput = { id, deletedAt: null };
+    const { where, empty } = this.applyBranchScope(baseWhere, user);
+    if (empty) throw new NotFoundException('ไม่พบใบจอง');
+    const booking = await this.prisma.booking.findFirst({
+      where,
+      include: BOOKING_DEFAULT_INCLUDE,
+    });
+    if (!booking) throw new NotFoundException('ไม่พบใบจอง');
+    return booking;
+  }
+
+  private async loadBookingScoped(
+    id: string,
+    user: RequestUser,
+    select?: Prisma.BookingSelect,
+  ) {
+    const baseWhere: Prisma.BookingWhereInput = { id, deletedAt: null };
+    const { where, empty } = this.applyBranchScope(baseWhere, user);
+    if (empty) throw new NotFoundException('ไม่พบใบจอง');
+    return this.prisma.booking.findFirst({
+      where,
+      select: select ?? {
+        id: true,
+        status: true,
+        branchId: true,
+        expireDate: true,
+        depositAmount: true,
+      },
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Money math (Prisma.Decimal — never Number())
+  // ───────────────────────────────────────────────────────────────────────
+
+  private computeItemAmount(
+    quantity: number,
+    unitPrice: number | string | Prisma.Decimal,
+  ): Prisma.Decimal {
+    return new Prisma.Decimal(unitPrice).mul(quantity);
+  }
+
+  private computeTotal(
+    items: { quantity: number; unitPrice: number | string | Prisma.Decimal }[],
+  ): Prisma.Decimal {
+    return items.reduce<Prisma.Decimal>(
+      (sum, it) => sum.add(new Prisma.Decimal(it.unitPrice).mul(it.quantity)),
+      ZERO,
+    );
+  }
+
+  private assertDepositInRange(deposit: Prisma.Decimal, total: Prisma.Decimal) {
+    if (deposit.lessThan(0)) {
+      throw new BadRequestException('depositAmount ต้องไม่ติดลบ');
+    }
+    if (deposit.greaterThan(total)) {
+      throw new BadRequestException(
+        `มัดจำ (${deposit.toFixed(2)}) ห้ามมากกว่ายอดรวม (${total.toFixed(2)})`,
+      );
+    }
+  }
+
+  private async resolveExpireDate(dto: { expireDate?: string }): Promise<Date> {
+    if (dto.expireDate) {
+      const d = new Date(dto.expireDate);
+      if (Number.isNaN(d.getTime())) {
+        throw new BadRequestException('expireDate ไม่ใช่วันที่');
+      }
+      if (d.getTime() < Date.now() - 24 * 60 * 60 * 1000) {
+        throw new BadRequestException('expireDate ต้องไม่เลยมาแล้วเกิน 1 วัน');
+      }
+      return d;
+    }
+    const days = await readNumberFlag(this.prisma, BOOKING_EXPIRE_DAYS_KEY, DEFAULT_EXPIRE_DAYS);
+    const safeDays = days > 0 && days <= 365 ? days : DEFAULT_EXPIRE_DAYS;
+    const expire = new Date();
+    expire.setDate(expire.getDate() + safeDays);
+    return expire;
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Write
+  // ───────────────────────────────────────────────────────────────────────
+
+  async create(dto: CreateBookingDto, createdById: string, user: RequestUser) {
+    this.assertCanWriteBranch(user, dto.branchId);
+
+    const [customer, branch] = await Promise.all([
+      this.prisma.customer.findFirst({
+        where: { id: dto.customerId, deletedAt: null },
+        select: { id: true },
+      }),
+      this.prisma.branch.findFirst({
+        where: { id: dto.branchId, deletedAt: null },
+        select: { id: true },
+      }),
+    ]);
+    if (!customer) throw new NotFoundException('ไม่พบลูกค้า');
+    if (!branch) throw new NotFoundException('ไม่พบสาขา');
+
+    const total = this.computeTotal(dto.items);
+    const deposit = new Prisma.Decimal(dto.depositAmount);
+    this.assertDepositInRange(deposit, total);
+
+    const expireDate = await this.resolveExpireDate(dto);
+
+    return this.prisma.$transaction(async (tx) => {
+      const bookingNumber = await generateBookingNumber(
+        tx as unknown as Parameters<typeof generateBookingNumber>[0],
+      );
+
+      const booking = await tx.booking.create({
+        data: {
+          bookingNumber,
+          customerId: dto.customerId,
+          branchId: dto.branchId,
+          status: 'PENDING_DEPOSIT',
+          depositAmount: deposit,
+          totalAmount: total,
+          expireDate,
+          notes: dto.notes,
+          createdById,
+          items: {
+            create: dto.items.map((item) => ({
+              productId: item.productId,
+              description: item.description,
+              quantity: item.quantity,
+              unitPrice: new Prisma.Decimal(item.unitPrice),
+              amount: this.computeItemAmount(item.quantity, item.unitPrice),
+            })),
+          },
+        },
+        include: BOOKING_DEFAULT_INCLUDE,
+      });
+
+      await tx.auditLog.create({
+        data: {
+          action: 'BOOKING_CREATED',
+          entity: 'booking',
+          entityId: booking.id,
+          userId: createdById,
+          newValue: {
+            bookingNumber: booking.bookingNumber,
+            status: booking.status,
+            depositAmount: booking.depositAmount.toFixed(2),
+            totalAmount: booking.totalAmount.toFixed(2),
+            expireDate: booking.expireDate.toISOString(),
+            branchId: booking.branchId,
+          },
+        },
+      });
+
+      return booking;
+    });
+  }
+
+  async update(id: string, dto: UpdateBookingDto, user: RequestUser) {
+    const existing = await this.loadBookingScoped(id, user, {
+      id: true,
+      status: true,
+      branchId: true,
+      totalAmount: true,
+    });
+    if (!existing) throw new NotFoundException('ไม่พบใบจอง');
+    if (existing.status !== 'PENDING_DEPOSIT' && existing.status !== 'PAID') {
+      throw new BadRequestException(
+        `แก้ไขใบจองได้เฉพาะสถานะ PENDING_DEPOSIT หรือ PAID (สถานะปัจจุบัน: ${existing.status})`,
+      );
+    }
+    if (dto.branchId) this.assertCanWriteBranch(user, dto.branchId);
+
+    return this.prisma.$transaction(async (tx) => {
+      const updates: Prisma.BookingUpdateInput = {};
+
+      if (dto.customerId) updates.customer = { connect: { id: dto.customerId } };
+      if (dto.branchId) updates.branch = { connect: { id: dto.branchId } };
+      if (dto.notes !== undefined) updates.notes = dto.notes;
+      if (dto.expireDate) {
+        const d = new Date(dto.expireDate);
+        if (Number.isNaN(d.getTime())) throw new BadRequestException('expireDate ไม่ใช่วันที่');
+        updates.expireDate = d;
+      }
+
+      let total: Prisma.Decimal | null = null;
+      if (dto.items) {
+        total = this.computeTotal(dto.items);
+        updates.totalAmount = total;
+
+        await tx.bookingItem.deleteMany({ where: { bookingId: id } });
+        updates.items = {
+          create: dto.items.map((item) => ({
+            productId: item.productId,
+            description: item.description,
+            quantity: item.quantity,
+            unitPrice: new Prisma.Decimal(item.unitPrice),
+            amount: this.computeItemAmount(item.quantity, item.unitPrice),
+          })),
+        };
+      }
+
+      if (dto.depositAmount !== undefined) {
+        const deposit = new Prisma.Decimal(dto.depositAmount);
+        const compareTotal = total ?? (existing.totalAmount as Prisma.Decimal);
+        this.assertDepositInRange(deposit, compareTotal);
+        updates.depositAmount = deposit;
+      }
+
+      return tx.booking.update({
+        where: { id },
+        data: updates,
+        include: BOOKING_DEFAULT_INCLUDE,
+      });
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Lifecycle transitions
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Record the deposit receipt and flip the booking PENDING_DEPOSIT → PAID.
+   *
+   * Race-safe via composite-where updateMany — two concurrent payDeposit
+   * calls cannot both succeed. Status is filtered on PENDING_DEPOSIT inside
+   * the same $transaction that writes deposit metadata.
+   */
+  async payDeposit(id: string, dto: PayDepositDto, user: RequestUser) {
+    const booking = await this.loadBookingScoped(id, user, {
+      id: true,
+      status: true,
+      branchId: true,
+      expireDate: true,
+    });
+    if (!booking) throw new NotFoundException('ไม่พบใบจอง');
+    if (booking.status !== 'PENDING_DEPOSIT') {
+      throw new BadRequestException(
+        `บันทึกชำระมัดจำได้เฉพาะสถานะ PENDING_DEPOSIT (สถานะปัจจุบัน: ${booking.status})`,
+      );
+    }
+    if (booking.expireDate && booking.expireDate.getTime() < Date.now()) {
+      throw new BadRequestException(
+        'ใบจองหมดอายุแล้ว — ไม่สามารถบันทึกมัดจำได้ กรุณาออกใบจองใหม่',
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const claim = await tx.booking.updateMany({
+        where: {
+          id,
+          deletedAt: null,
+          status: 'PENDING_DEPOSIT',
+        },
+        data: {
+          status: 'PAID',
+          depositPaidAt: new Date(),
+          depositMethod: dto.depositMethod,
+          depositReceivedById: user.id,
+        },
+      });
+      if (claim.count !== 1) {
+        throw new ConflictException('ใบจองนี้ถูกบันทึกมัดจำหรือเปลี่ยนสถานะไปแล้ว');
+      }
+
+      const updated = await tx.booking.findFirst({
+        where: { id },
+        include: BOOKING_DEFAULT_INCLUDE,
+      });
+
+      await tx.auditLog.create({
+        data: {
+          action: 'BOOKING_DEPOSIT_PAID',
+          entity: 'booking',
+          entityId: id,
+          userId: user.id,
+          oldValue: { status: 'PENDING_DEPOSIT' },
+          newValue: {
+            status: 'PAID',
+            depositMethod: dto.depositMethod ?? null,
+            notes: dto.notes ?? null,
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  /**
+   * Manual cancel — only callable for PENDING_DEPOSIT or PAID bookings, and
+   * only when expireDate hasn't passed. Expired bookings are handled by the
+   * autoExpire cron path which marks them EXPIRED (forfeit), not CANCELED.
+   *
+   * Refund policy:
+   *   - cancel BEFORE expire → 100% refund of depositAmount (deposit was held
+   *     by the SHOP; cancellation simply doesn't book the income)
+   *   - cancel AFTER expire  → blocked here (use autoExpire instead)
+   */
+  async cancel(id: string, dto: CancelBookingDto, user: RequestUser) {
+    const booking = await this.loadBookingScoped(id, user, {
+      id: true,
+      status: true,
+      branchId: true,
+      expireDate: true,
+      depositAmount: true,
+      depositPaidAt: true,
+    });
+    if (!booking) throw new NotFoundException('ไม่พบใบจอง');
+    if (booking.status !== 'PENDING_DEPOSIT' && booking.status !== 'PAID') {
+      throw new BadRequestException(
+        `ยกเลิกใบจองได้เฉพาะสถานะ PENDING_DEPOSIT หรือ PAID (สถานะปัจจุบัน: ${booking.status})`,
+      );
+    }
+    if (booking.expireDate && booking.expireDate.getTime() < Date.now()) {
+      throw new BadRequestException(
+        'ใบจองหมดอายุแล้ว — กรุณารอ cron บันทึกสถานะ EXPIRED (ลูกค้าเสียมัดจำ)',
+      );
+    }
+
+    const fromStatus = booking.status;
+
+    return this.prisma.$transaction(async (tx) => {
+      const claim = await tx.booking.updateMany({
+        where: {
+          id,
+          deletedAt: null,
+          status: { in: ['PENDING_DEPOSIT', 'PAID'] },
+        },
+        data: {
+          status: 'CANCELED',
+          canceledAt: new Date(),
+          canceledById: user.id,
+          cancelReason: dto.cancelReason,
+        },
+      });
+      if (claim.count !== 1) {
+        throw new ConflictException('ใบจองนี้ถูกเปลี่ยนสถานะไปแล้ว');
+      }
+
+      const updated = await tx.booking.findFirst({
+        where: { id },
+        include: BOOKING_DEFAULT_INCLUDE,
+      });
+
+      await tx.auditLog.create({
+        data: {
+          action: 'BOOKING_CANCELED',
+          entity: 'booking',
+          entityId: id,
+          userId: user.id,
+          oldValue: { status: fromStatus },
+          newValue: {
+            status: 'CANCELED',
+            refundAmount:
+              fromStatus === 'PAID' ? booking.depositAmount.toFixed(2) : '0.00',
+            cancelReason: dto.cancelReason ?? null,
+          },
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  /**
+   * Convert a PAID booking into a CASH Sale row. Deposit transfers to
+   * Sale.downPaymentAmount.
+   *
+   * Race protection mirrors QuotesService.convert:
+   *   1. Composite-where `updateMany` flips status PAID → CONVERTED inside
+   *      the transaction; only one concurrent caller wins.
+   *   2. Sale row is created in the same tx — rollback on failure restores
+   *      the booking atomically.
+   *   3. Link-back update sets convertedToSaleId.
+   */
+  async convertToSale(
+    id: string,
+    dto: ConvertBookingDto,
+    salespersonId: string,
+    user: RequestUser,
+  ) {
+    const booking = await this.prisma.booking.findFirst({
+      where: { id, deletedAt: null },
+      include: { items: true },
+    });
+    if (!booking) throw new NotFoundException('ไม่พบใบจอง');
+
+    this.assertCanWriteBranch(user, booking.branchId);
+
+    if (booking.status !== 'PAID') {
+      throw new BadRequestException(
+        `แปลงเป็นการขายได้เฉพาะสถานะ PAID (สถานะปัจจุบัน: ${booking.status})`,
+      );
+    }
+    if (booking.convertedToSaleId) {
+      throw new ConflictException('ใบจองนี้ถูกแปลงเป็นการขายแล้ว');
+    }
+
+    const firstItem = booking.items[0];
+    if (!firstItem) throw new BadRequestException('ใบจองไม่มีรายการสินค้า');
+    if (!firstItem.productId) {
+      throw new BadRequestException(
+        'รายการแรกในใบจองไม่ได้ผูกกับสินค้าในสต็อก — กรุณาผูกสินค้าก่อนแปลง',
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const claim = await tx.booking.updateMany({
+        where: {
+          id,
+          deletedAt: null,
+          status: 'PAID',
+          convertedToSaleId: null,
+        },
+        data: {
+          status: 'CONVERTED',
+          convertedAt: new Date(),
+        },
+      });
+      if (claim.count !== 1) {
+        throw new ConflictException('ใบจองนี้ถูกแปลงเป็นการขายแล้ว');
+      }
+
+      const saleNumber = await generateSaleNumber(
+        tx as unknown as Parameters<typeof generateSaleNumber>[0],
+      );
+
+      const sale = await tx.sale.create({
+        data: {
+          saleNumber,
+          saleType: 'CASH',
+          customerId: booking.customerId,
+          productId: firstItem.productId!,
+          branchId: booking.branchId,
+          salespersonId,
+          sellingPrice: booking.totalAmount,
+          discount: ZERO,
+          netAmount: booking.totalAmount,
+          paymentMethod:
+            (dto.paymentMethod as Prisma.SaleCreateInput['paymentMethod']) ||
+            booking.depositMethod ||
+            null,
+          amountReceived: booking.totalAmount,
+          downPaymentAmount: booking.depositAmount,
+          notes: dto.notes || `แปลงจากใบจอง ${booking.bookingNumber}`,
+        },
+      });
+
+      await tx.booking.update({
+        where: { id },
+        data: { convertedToSaleId: sale.id },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          action: 'BOOKING_CONVERTED',
+          entity: 'booking',
+          entityId: id,
+          userId: user.id,
+          oldValue: { status: 'PAID' },
+          newValue: {
+            status: 'CONVERTED',
+            saleId: sale.id,
+            saleNumber: sale.saleNumber,
+            depositTransferred: booking.depositAmount.toFixed(2),
+          },
+        },
+      });
+
+      return { sale, bookingId: id };
+    });
+  }
+
+  async remove(id: string, user: RequestUser) {
+    const booking = await this.loadBookingScoped(id, user, {
+      id: true,
+      status: true,
+      branchId: true,
+    });
+    if (!booking) throw new NotFoundException('ไม่พบใบจอง');
+    if (booking.status !== 'PENDING_DEPOSIT') {
+      throw new BadRequestException(
+        `ลบใบจองได้เฉพาะสถานะ PENDING_DEPOSIT (สถานะปัจจุบัน: ${booking.status})`,
+      );
+    }
+    const deletedAt = new Date();
+    await this.prisma.$transaction(async (tx) => {
+      await tx.booking.update({
+        where: { id },
+        data: { deletedAt },
+      });
+      await tx.auditLog.create({
+        data: {
+          action: 'BOOKING_DELETED',
+          entity: 'booking',
+          entityId: id,
+          userId: user.id,
+          oldValue: { status: 'PENDING_DEPOSIT' },
+          newValue: { deletedAt: deletedAt.toISOString() },
+        },
+      });
+    });
+    return { id, deletedAt };
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Cron: auto-expire PAID bookings whose expireDate has passed
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Resolve the admin/system user for cron-triggered audit log writes. Cached
+   * across calls. AuditLog.userId is NOT NULL string — we route system actions
+   * to the OWNER admin account (matches journal-auto.service pattern).
+   */
+  private systemUserId: string | null = null;
+  private async resolveSystemUserId(): Promise<string> {
+    if (this.systemUserId) return this.systemUserId;
+    const user = await this.prisma.user.findFirst({
+      where: { email: 'admin@bestchoice.com', deletedAt: null },
+      select: { id: true },
+    });
+    if (!user) {
+      // Fall back to ANY OWNER if the seeded admin email isn't present
+      // (e.g. fresh dev env or renamed admin).
+      const owner = await this.prisma.user.findFirst({
+        where: { role: 'OWNER', deletedAt: null },
+        select: { id: true },
+      });
+      if (!owner) {
+        throw new Error('No system OWNER user found for autoExpire audit log');
+      }
+      this.systemUserId = owner.id;
+      return owner.id;
+    }
+    this.systemUserId = user.id;
+    return user.id;
+  }
+
+  /**
+   * Mark PAID bookings as EXPIRED (forfeit) once `expireDate` has passed.
+   * Returns the number of rows flipped. Each transition writes an audit log
+   * `BOOKING_AUTO_EXPIRED`. Called by `BookingExpireCron` daily at 00:30 BKK.
+   */
+  async autoExpire(now: Date = new Date()): Promise<number> {
+    const candidates = await this.prisma.booking.findMany({
+      where: {
+        status: 'PAID',
+        expireDate: { lt: now },
+        deletedAt: null,
+      },
+      select: { id: true, depositAmount: true, bookingNumber: true },
+      take: 500,
+    });
+    if (candidates.length === 0) return 0;
+
+    const systemUserId = await this.resolveSystemUserId();
+
+    let flipped = 0;
+    for (const candidate of candidates) {
+      // Per-row composite-where update so one stale candidate doesn't roll
+      // back the whole batch. Each succeeds-or-skips atomically.
+      try {
+        await this.prisma.$transaction(async (tx) => {
+          const claim = await tx.booking.updateMany({
+            where: {
+              id: candidate.id,
+              status: 'PAID',
+              deletedAt: null,
+            },
+            data: { status: 'EXPIRED' },
+          });
+          if (claim.count !== 1) return;
+          await tx.auditLog.create({
+            data: {
+              action: 'BOOKING_AUTO_EXPIRED',
+              entity: 'booking',
+              entityId: candidate.id,
+              userId: systemUserId,
+              oldValue: { status: 'PAID' },
+              newValue: {
+                status: 'EXPIRED',
+                forfeitAmount: candidate.depositAmount.toFixed(2),
+                bookingNumber: candidate.bookingNumber,
+              },
+            },
+          });
+          flipped += 1;
+        });
+      } catch (err) {
+        this.logger.error(
+          `autoExpire failed for booking ${candidate.id}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    return flipped;
+  }
+}

--- a/apps/api/src/modules/bookings/dto/cancel-booking.dto.ts
+++ b/apps/api/src/modules/bookings/dto/cancel-booking.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CancelBookingDto {
+  @IsOptional()
+  @IsString({ message: 'cancelReason ต้องเป็น string' })
+  @MaxLength(500, { message: 'cancelReason ยาวไม่เกิน 500 ตัวอักษร' })
+  cancelReason?: string;
+}

--- a/apps/api/src/modules/bookings/dto/convert-booking.dto.ts
+++ b/apps/api/src/modules/bookings/dto/convert-booking.dto.ts
@@ -1,10 +1,19 @@
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 
 /**
  * Convert a PAID booking into a Sale row. The booking's depositAmount transfers
  * to Sale.downPaymentAmount automatically.
  * Phase 1: supports CASH only (takes the first item's productId as the Sale's
  * product anchor — matches the SP5 Quote→Sale convention).
+ *
+ * `collectBalance` is mandatory when `depositAmount < totalAmount`:
+ *   - true  → cashier confirms collecting (totalAmount - depositAmount) at the
+ *             counter; Sale.amountReceived = totalAmount (paid in full).
+ *   - false → reject the convert; partial-payment bookings must collect the
+ *             balance before becoming a Sale.
+ *
+ * When depositAmount === totalAmount (full prepay), `collectBalance` is
+ * irrelevant — Sale.amountReceived = depositAmount = totalAmount.
  */
 export class ConvertBookingDto {
   @IsOptional()
@@ -16,6 +25,10 @@ export class ConvertBookingDto {
   @IsOptional()
   @IsString({ message: 'paymentMethod ต้องเป็น string' })
   paymentMethod?: string;
+
+  @IsOptional()
+  @IsBoolean({ message: 'collectBalance ต้องเป็น true/false' })
+  collectBalance?: boolean;
 
   @IsOptional()
   @IsString()

--- a/apps/api/src/modules/bookings/dto/convert-booking.dto.ts
+++ b/apps/api/src/modules/bookings/dto/convert-booking.dto.ts
@@ -1,0 +1,23 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+/**
+ * Convert a PAID booking into a Sale row. The booking's depositAmount transfers
+ * to Sale.downPaymentAmount automatically.
+ * Phase 1: supports CASH only (takes the first item's productId as the Sale's
+ * product anchor — matches the SP5 Quote→Sale convention).
+ */
+export class ConvertBookingDto {
+  @IsOptional()
+  @IsEnum(['CASH'], {
+    message: 'รองรับเฉพาะ CASH ในเฟสนี้ — ผ่อน/ไฟแนนซ์ภายนอกค่อยทำเฟสถัดไป',
+  })
+  saleType?: 'CASH';
+
+  @IsOptional()
+  @IsString({ message: 'paymentMethod ต้องเป็น string' })
+  paymentMethod?: string;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/apps/api/src/modules/bookings/dto/create-booking.dto.ts
+++ b/apps/api/src/modules/bookings/dto/create-booking.dto.ts
@@ -1,0 +1,58 @@
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateBookingItemDto {
+  @IsOptional()
+  @IsUUID(undefined, { message: 'productId ต้องเป็น UUID' })
+  productId?: string;
+
+  @IsString({ message: 'description ต้องเป็น string' })
+  description!: string;
+
+  @IsInt({ message: 'quantity ต้องเป็นจำนวนเต็ม' })
+  @Min(1, { message: 'quantity ต้องอย่างน้อย 1' })
+  quantity!: number;
+
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'unitPrice ต้องเป็นตัวเลข' })
+  @Min(0, { message: 'unitPrice ต้องไม่ติดลบ' })
+  unitPrice!: number;
+}
+
+export class CreateBookingDto {
+  @IsUUID(undefined, { message: 'กรุณาเลือกลูกค้า' })
+  customerId!: string;
+
+  @IsUUID(undefined, { message: 'กรุณาเลือกสาขา' })
+  branchId!: string;
+
+  @IsArray({ message: 'items ต้องเป็น array' })
+  @ArrayMinSize(1, { message: 'ต้องมีอย่างน้อย 1 รายการ' })
+  @ValidateNested({ each: true })
+  @Type(() => CreateBookingItemDto)
+  items!: CreateBookingItemDto[];
+
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'depositAmount ต้องเป็นตัวเลข' })
+  @Min(0, { message: 'depositAmount ต้องไม่ติดลบ' })
+  depositAmount!: number;
+
+  /** Optional explicit expire date (ISO). If omitted, service defaults to
+   *  now + `booking_expire_days` SystemConfig (default 7). */
+  @IsOptional()
+  @IsDateString({}, { message: 'expireDate ต้องเป็นวันที่' })
+  expireDate?: string;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/apps/api/src/modules/bookings/dto/pay-deposit.dto.ts
+++ b/apps/api/src/modules/bookings/dto/pay-deposit.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsOptional, IsString, Matches } from 'class-validator';
 
 // Mirror the Prisma PaymentMethod enum. Keep in lockstep with
 // apps/api/prisma/schema.prisma `enum PaymentMethod`.
@@ -17,13 +17,21 @@ export type DepositMethod = (typeof ALLOWED_METHODS)[number];
  * Note: we don't create a contract-Payment record here — Payment is strictly
  * contract-installment-bound. On conversion to a Sale, the deposit transfers
  * to Sale.downPaymentAmount.
+ *
+ * `depositAccountCode` is REQUIRED per `.claude/rules/accounting.md` Cash
+ * Account Dimension policy — every cash-touching record carries one of the
+ * 6 valid cash/bank CoA codes (11-1101..1103 cash, 11-1201..1203 bank).
  */
 export class PayDepositDto {
-  @IsOptional()
   @IsEnum(ALLOWED_METHODS, {
     message: 'depositMethod ต้องเป็นวิธีชำระเงินที่รองรับ (CASH/BANK_TRANSFER/QR_EWALLET/...)',
   })
-  depositMethod?: DepositMethod;
+  depositMethod!: DepositMethod;
+
+  @Matches(/^11-1[12]0[123]$/, {
+    message: 'รหัสบัญชีเงินสดไม่ถูกต้อง (ต้องเป็น 11-1101..1103 หรือ 11-1201..1203)',
+  })
+  depositAccountCode!: string;
 
   @IsOptional()
   @IsString()

--- a/apps/api/src/modules/bookings/dto/pay-deposit.dto.ts
+++ b/apps/api/src/modules/bookings/dto/pay-deposit.dto.ts
@@ -1,0 +1,31 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+// Mirror the Prisma PaymentMethod enum. Keep in lockstep with
+// apps/api/prisma/schema.prisma `enum PaymentMethod`.
+const ALLOWED_METHODS = [
+  'CASH',
+  'BANK_TRANSFER',
+  'QR_EWALLET',
+  'CREDIT_BALANCE',
+  'ONLINE_GATEWAY',
+] as const;
+export type DepositMethod = (typeof ALLOWED_METHODS)[number];
+
+/**
+ * Record the deposit receipt for a PENDING_DEPOSIT booking. Flips status to
+ * PAID and stores cash-in metadata directly on the Booking row.
+ * Note: we don't create a contract-Payment record here — Payment is strictly
+ * contract-installment-bound. On conversion to a Sale, the deposit transfers
+ * to Sale.downPaymentAmount.
+ */
+export class PayDepositDto {
+  @IsOptional()
+  @IsEnum(ALLOWED_METHODS, {
+    message: 'depositMethod ต้องเป็นวิธีชำระเงินที่รองรับ (CASH/BANK_TRANSFER/QR_EWALLET/...)',
+  })
+  depositMethod?: DepositMethod;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/apps/api/src/modules/bookings/dto/update-booking.dto.ts
+++ b/apps/api/src/modules/bookings/dto/update-booking.dto.ts
@@ -1,0 +1,43 @@
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreateBookingItemDto } from './create-booking.dto';
+
+export class UpdateBookingDto {
+  @IsOptional()
+  @IsUUID(undefined, { message: 'customerId ต้องเป็น UUID' })
+  customerId?: string;
+
+  @IsOptional()
+  @IsUUID(undefined, { message: 'branchId ต้องเป็น UUID' })
+  branchId?: string;
+
+  @IsOptional()
+  @IsArray({ message: 'items ต้องเป็น array' })
+  @ArrayMinSize(1, { message: 'ต้องมีอย่างน้อย 1 รายการ' })
+  @ValidateNested({ each: true })
+  @Type(() => CreateBookingItemDto)
+  items?: CreateBookingItemDto[];
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'depositAmount ต้องเป็นตัวเลข' })
+  @Min(0, { message: 'depositAmount ต้องไม่ติดลบ' })
+  depositAmount?: number;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'expireDate ต้องเป็นวันที่' })
+  expireDate?: string;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/apps/api/src/utils/sequence.util.ts
+++ b/apps/api/src/utils/sequence.util.ts
@@ -8,6 +8,7 @@ type PrismaTx = {
   sale: { findFirst: (...args: unknown[]) => Promise<{ saleNumber: string } | null> };
   purchaseOrder: { count: (...args: unknown[]) => Promise<number> };
   quote?: { findFirst: (...args: unknown[]) => Promise<{ quoteNumber: string } | null> };
+  booking?: { findFirst: (...args: unknown[]) => Promise<{ bookingNumber: string } | null> };
 };
 
 /**
@@ -81,6 +82,42 @@ export async function generateQuoteNumber(tx: PrismaTx): Promise<string> {
   let nextSeq = 1;
   if (last) {
     const lastSeq = parseInt(last.quoteNumber.slice(prefix.length), 10) || 0;
+    nextSeq = lastSeq + 1;
+  }
+  return `${prefix}${String(nextSeq).padStart(4, '0')}`;
+}
+
+/**
+ * P2-SP4 — Generate next booking number (BK-YYYYMMDD-NNNN, Asia/Bangkok date).
+ * Per-day reset, 4-digit zero-padded sequence. Mirrors generateQuoteNumber
+ * (lookup MAX(bookingNumber) for the day's prefix). Booking is SHOP-side
+ * pre-sale, low concurrency.
+ */
+export async function generateBookingNumber(tx: PrismaTx): Promise<string> {
+  if (!tx.booking) {
+    throw new Error('generateBookingNumber requires a transaction client with `booking` delegate');
+  }
+  const now = new Date();
+  // Asia/Bangkok local YYYYMMDD via Intl (BKK is UTC+7, no DST).
+  const parts = now.toLocaleString('en-CA', {
+    timeZone: 'Asia/Bangkok',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const [y, m, d] = parts.split('-');
+  const yyyymmdd = `${y}${m}${d}`;
+  const prefix = `BK-${yyyymmdd}-`;
+
+  const last = await tx.booking.findFirst({
+    where: { bookingNumber: { startsWith: prefix } },
+    orderBy: { bookingNumber: 'desc' as const },
+    select: { bookingNumber: true },
+  });
+
+  let nextSeq = 1;
+  if (last) {
+    const lastSeq = parseInt(last.bookingNumber.slice(prefix.length), 10) || 0;
     nextSeq = lastSeq + 1;
   }
   return `${prefix}${String(nextSeq).padStart(4, '0')}`;

--- a/apps/web/e2e/bookings.spec.ts
+++ b/apps/web/e2e/bookings.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { loginViaAPI, loginAsRole } from './helpers/auth';
+import { gotoWithRetry, hasErrorBoundary } from './helpers/navigation';
+
+/* ================================================================
+   P2-SP4 — Booking module (การจอง / มัดจำ) — smoke tests
+   ================================================================ */
+
+test.describe('/bookings — booking lifecycle smoke', () => {
+  test('SALES: page loads, can open create dialog (PENDING_DEPOSIT entry point)', async ({
+    page,
+  }) => {
+    await loginAsRole(page, 'SALES');
+    await gotoWithRetry(page, '/bookings');
+    if (await hasErrorBoundary(page)) return;
+
+    // Page header
+    await expect(page.getByRole('heading', { name: /การจอง.*มัดจำ/ }).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Status filter shows our Thai labels
+    const statusFilter = page.getByRole('combobox').first();
+    await statusFilter.click();
+    await expect(page.getByText('รอชำระมัดจำ').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('มัดจำแล้ว').first()).toBeVisible();
+    await expect(page.getByText('หมดอายุ').first()).toBeVisible();
+    // Close the dropdown
+    await page.keyboard.press('Escape');
+
+    // Create button visible for SALES (canCreate=true)
+    const createBtn = page.getByRole('button', { name: /สร้างใบจอง/ });
+    await expect(createBtn).toBeVisible();
+    await createBtn.click();
+
+    // Dialog title visible
+    await expect(page.getByRole('heading', { name: /สร้างใบจอง/ }).first()).toBeVisible({
+      timeout: 5000,
+    });
+    // Fields visible
+    await expect(page.getByText(/หมดอายุภายใน/).first()).toBeVisible();
+    await expect(page.getByText(/มัดจำ/).first()).toBeVisible();
+  });
+
+  test('OWNER: list view loads without error boundary (covers expired bookings present)', async ({
+    page,
+  }) => {
+    await loginViaAPI(page);
+    await gotoWithRetry(page, '/bookings');
+    if (await hasErrorBoundary(page)) return;
+
+    // Page must render its header — proves data fetch + render succeed even
+    // with mixed status rows (PENDING_DEPOSIT/PAID/CANCELED/EXPIRED/CONVERTED)
+    await expect(page.getByRole('heading', { name: /การจอง.*มัดจำ/ }).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // OWNER also sees create button + can filter by EXPIRED
+    await expect(page.getByRole('button', { name: /สร้างใบจอง/ })).toBeVisible();
+
+    const statusFilter = page.getByRole('combobox').first();
+    await statusFilter.click();
+    await page.getByText('หมดอายุ').first().click();
+
+    // No error boundary after filter mutation
+    await expect(page.locator('body')).not.toContainText(/เกิดข้อผิดพลาด/);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -55,6 +55,8 @@ const PaymentMethodSettingsPage = lazy(() => import('@/pages/PaymentMethodSettin
 const DefectExchangePage = lazy(() => import('@/pages/DefectExchangePage'));
 // SP5 — SHOP-side additions
 const QuotesPage = lazy(() => import('@/pages/QuotesPage'));
+// P2-SP4 — การจอง / มัดจำ (SHOP-side reservation)
+const BookingsPage = lazy(() => import('@/pages/BookingsPage'));
 const DraftsPage = lazy(() => import('@/pages/DraftsPage'));
 const InsurancePage = lazy(() => import('@/pages/InsurancePage'));
 const AuditLogsPage = lazy(() => import('@/pages/AuditLogsPage'));
@@ -601,6 +603,17 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES']}>
                 <QuotesPage />
+              </ProtectedRoute>
+            }
+          />
+          {/* P2-SP4 — การจอง / มัดจำ */}
+          <Route
+            path="/bookings"
+            element={
+              <ProtectedRoute
+                roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES']}
+              >
+                <BookingsPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -147,6 +147,7 @@ const SALES_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'ขายของ (POS)', path: '/pos', icon: ShoppingCart },
         { label: 'ใบเสนอราคา', path: '/quotes', icon: ReceiptText },
+        { label: 'การจอง / มัดจำ', path: '/bookings', icon: CalendarDays },
         { label: 'ลูกค้า', path: '/customers', icon: Users },
         { label: 'เช็คเครดิตลูกค้าใหม่', path: '/customer-intake', icon: UserSearch },
         { label: 'รับซื้อมือสอง', path: '/trade-in', icon: Smartphone },
@@ -212,6 +213,7 @@ const BRANCH_MANAGER_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'ขายของ (POS)', path: '/pos', icon: ShoppingCart },
         { label: 'ใบเสนอราคา', path: '/quotes', icon: ReceiptText },
+        { label: 'การจอง / มัดจำ', path: '/bookings', icon: CalendarDays },
         { label: 'ลูกค้า', path: '/customers', icon: Users },
         { label: 'เช็คเครดิตลูกค้าใหม่', path: '/customer-intake', icon: UserSearch },
         { label: 'สัญญาผ่อนชำระ', path: '/contracts', icon: FileCheck },
@@ -502,6 +504,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'ลูกค้า', path: '/customers', icon: Users },
         { label: 'ขายของ (POS)', path: '/pos', icon: ShoppingCart },
         { label: 'ใบเสนอราคา', path: '/quotes', icon: ReceiptText },
+        { label: 'การจอง / มัดจำ', path: '/bookings', icon: CalendarDays },
         { label: 'สัญญาผ่อนชำระ', path: '/contracts', icon: FileCheck },
         { label: 'เอกสารร่าง', path: '/drafts', icon: Inbox },
         { label: 'รับประกัน/ส่งซ่อม', path: '/insurance', icon: ShieldCheck },

--- a/apps/web/src/pages/BookingsPage.test.tsx
+++ b/apps/web/src/pages/BookingsPage.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeBookingTotal,
+  isDepositInRange,
+  STATUS_LABEL,
+  type BookingStatus,
+} from './BookingsPage';
+
+describe('computeBookingTotal', () => {
+  it('totalAmount = sum(quantity * unitPrice) per row, rounded to 2dp', () => {
+    const total = computeBookingTotal([
+      { quantity: 1, unitPrice: 35000 },
+      { quantity: 2, unitPrice: 5990 },
+    ]);
+    expect(total).toBe(46980);
+  });
+
+  it('returns 0 when there are no items', () => {
+    expect(computeBookingTotal([])).toBe(0);
+  });
+});
+
+describe('isDepositInRange', () => {
+  it('accepts 0 <= deposit <= total', () => {
+    expect(isDepositInRange(0, 1000)).toBe(true);
+    expect(isDepositInRange(500, 1000)).toBe(true);
+    expect(isDepositInRange(1000, 1000)).toBe(true);
+  });
+
+  it('rejects negative deposit OR deposit > total', () => {
+    expect(isDepositInRange(-1, 1000)).toBe(false);
+    expect(isDepositInRange(1001, 1000)).toBe(false);
+  });
+});
+
+describe('STATUS_LABEL (Thai)', () => {
+  it('covers all 5 BookingStatus values in Thai', () => {
+    const expected: Record<BookingStatus, string> = {
+      PENDING_DEPOSIT: 'รอชำระมัดจำ',
+      PAID: 'มัดจำแล้ว',
+      CANCELED: 'ยกเลิก',
+      EXPIRED: 'หมดอายุ',
+      CONVERTED: 'ขายแล้ว',
+    };
+    expect(STATUS_LABEL).toEqual(expected);
+  });
+});

--- a/apps/web/src/pages/BookingsPage.tsx
+++ b/apps/web/src/pages/BookingsPage.tsx
@@ -26,6 +26,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { CashAccountSelect } from '@/components/CashAccountSelect';
+import { Checkbox } from '@/components/ui/checkbox';
 import { toast } from 'sonner';
 import {
   CalendarDays,
@@ -605,10 +607,24 @@ function BookingDetailDialog({
   });
 
   const [depositMethod, setDepositMethod] = useState('CASH');
+  const [depositAccountCode, setDepositAccountCode] = useState('11-1101');
   const [cancelReason, setCancelReason] = useState('');
+  // C2 — convert UX: cashier must affirm balance collection when partial-paid
+  const [collectBalance, setCollectBalance] = useState(false);
+
+  // Derived: is this a partial-deposit booking? (deposit < total)
+  const isPartialDeposit =
+    !!booking && Number(booking.depositAmount) < Number(booking.totalAmount);
+  const outstandingBalance = booking
+    ? Number(booking.totalAmount) - Number(booking.depositAmount)
+    : 0;
 
   const payMut = useMutation({
-    mutationFn: () => api.post(`/bookings/${bookingId}/pay-deposit`, { depositMethod }),
+    mutationFn: () =>
+      api.post(`/bookings/${bookingId}/pay-deposit`, {
+        depositMethod,
+        depositAccountCode,
+      }),
     onSuccess: () => {
       toast.success('บันทึกการรับมัดจำแล้ว');
       qc.invalidateQueries({ queryKey: ['booking', bookingId] });
@@ -629,7 +645,12 @@ function BookingDetailDialog({
   });
 
   const convertMut = useMutation({
-    mutationFn: () => api.post(`/bookings/${bookingId}/convert`, { saleType: 'CASH' }),
+    mutationFn: () =>
+      api.post(`/bookings/${bookingId}/convert`, {
+        saleType: 'CASH',
+        // Only relevant on partial-deposit bookings; backend ignores otherwise.
+        collectBalance: isPartialDeposit ? collectBalance : undefined,
+      }),
     onSuccess: () => {
       toast.success('แปลงเป็นการขายแล้ว — มัดจำเข้า downPayment อัตโนมัติ');
       qc.invalidateQueries({ queryKey: ['booking', bookingId] });
@@ -745,22 +766,60 @@ function BookingDetailDialog({
             )}
 
             {canMutate && booking.status === 'PENDING_DEPOSIT' && (
-              <div className="space-y-2 rounded-md border border-border bg-muted/20 p-3">
-                <Label>วิธีรับมัดจำ</Label>
-                <Select value={depositMethod} onValueChange={setDepositMethod}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="CASH">เงินสด</SelectItem>
-                    <SelectItem value="BANK_TRANSFER">โอนธนาคาร</SelectItem>
-                    <SelectItem value="QR_EWALLET">QR / e-Wallet</SelectItem>
-                    <SelectItem value="CREDIT_BALANCE">หักจากเครดิตคงเหลือ</SelectItem>
-                    <SelectItem value="ONLINE_GATEWAY">ผ่าน Gateway</SelectItem>
-                  </SelectContent>
-                </Select>
+              <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
+                <div className="space-y-2">
+                  <Label>วิธีรับมัดจำ</Label>
+                  <Select value={depositMethod} onValueChange={setDepositMethod}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="CASH">เงินสด</SelectItem>
+                      <SelectItem value="BANK_TRANSFER">โอนธนาคาร</SelectItem>
+                      <SelectItem value="QR_EWALLET">QR / e-Wallet</SelectItem>
+                      <SelectItem value="CREDIT_BALANCE">หักจากเครดิตคงเหลือ</SelectItem>
+                      <SelectItem value="ONLINE_GATEWAY">ผ่าน Gateway</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>บัญชีเงินสด/ธนาคารปลายทาง</Label>
+                  <CashAccountSelect
+                    value={depositAccountCode}
+                    onChange={setDepositAccountCode}
+                  />
+                </div>
               </div>
             )}
+
+            {canMutate &&
+              booking.status === 'PAID' &&
+              !booking.convertedToSale &&
+              isPartialDeposit && (
+                <div className="space-y-2 rounded-md border border-amber-500/30 bg-amber-50/40 p-3 text-sm dark:bg-amber-950/20">
+                  <div className="font-medium">ก่อนแปลงเป็นการขาย</div>
+                  <div className="text-muted-foreground">
+                    ใบจองนี้รับมัดจำเพียง{' '}
+                    <span className="tabular-nums">{fmtMoney(booking.depositAmount)}</span>{' '}
+                    บาท คงเหลือ{' '}
+                    <span className="font-semibold tabular-nums">
+                      {fmtMoney(outstandingBalance)}
+                    </span>{' '}
+                    บาท
+                  </div>
+                  <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border bg-background p-2">
+                    <Checkbox
+                      checked={collectBalance}
+                      onCheckedChange={(v) => setCollectBalance(v === true)}
+                      className="mt-0.5"
+                    />
+                    <span className="leading-snug">
+                      เรียกเก็บยอดส่วนต่างที่เคาน์เตอร์แล้ว — บันทึก Sale.amountReceived =
+                      ยอดเต็ม
+                    </span>
+                  </label>
+                </div>
+              )}
 
             {canMutate &&
               (booking.status === 'PENDING_DEPOSIT' || booking.status === 'PAID') && (
@@ -800,8 +859,15 @@ function BookingDetailDialog({
           {canMutate && booking?.status === 'PAID' && !booking.convertedToSale && (
             <Button
               onClick={() => convertMut.mutate()}
-              disabled={convertMut.isPending}
+              disabled={
+                convertMut.isPending || (isPartialDeposit && !collectBalance)
+              }
               className="gap-2"
+              title={
+                isPartialDeposit && !collectBalance
+                  ? 'ติ๊ก "เรียกเก็บยอดส่วนต่างแล้ว" ก่อนแปลง'
+                  : undefined
+              }
             >
               <ShoppingCart className="h-4 w-4" /> แปลงเป็นการขาย
             </Button>

--- a/apps/web/src/pages/BookingsPage.tsx
+++ b/apps/web/src/pages/BookingsPage.tsx
@@ -1,0 +1,826 @@
+import { useMemo, useState } from 'react';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api, { getErrorMessage } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { formatThaiDate } from '@/lib/date';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+import {
+  CalendarDays,
+  Plus,
+  HandCoins,
+  Ban,
+  ShoppingCart,
+  Trash2,
+  Search,
+} from 'lucide-react';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────
+
+export type BookingStatus =
+  | 'PENDING_DEPOSIT'
+  | 'PAID'
+  | 'CANCELED'
+  | 'EXPIRED'
+  | 'CONVERTED';
+
+interface BookingItem {
+  id: string;
+  productId?: string | null;
+  description: string;
+  quantity: number;
+  unitPrice: string | number;
+  amount: string | number;
+}
+
+interface Booking {
+  id: string;
+  bookingNumber: string;
+  status: BookingStatus;
+  depositAmount: string | number;
+  totalAmount: string | number;
+  expireDate: string;
+  notes?: string | null;
+  depositPaidAt?: string | null;
+  depositMethod?: string | null;
+  canceledAt?: string | null;
+  cancelReason?: string | null;
+  customer: { id: string; name: string; phone?: string | null };
+  branch: { id: string; name: string };
+  createdBy: { id: string; name: string };
+  canceledBy?: { id: string; name: string } | null;
+  convertedToSale?: { id: string; saleNumber: string } | null;
+  items: BookingItem[];
+  createdAt: string;
+}
+
+interface BookingListResponse {
+  data: Booking[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+interface CustomerOption {
+  id: string;
+  name: string;
+  phone: string;
+}
+
+interface BranchOption {
+  id: string;
+  name: string;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+export const STATUS_LABEL: Record<BookingStatus, string> = {
+  PENDING_DEPOSIT: 'รอชำระมัดจำ',
+  PAID: 'มัดจำแล้ว',
+  CANCELED: 'ยกเลิก',
+  EXPIRED: 'หมดอายุ',
+  CONVERTED: 'ขายแล้ว',
+};
+
+const STATUS_VARIANT: Record<
+  BookingStatus,
+  'primary' | 'secondary' | 'destructive' | 'outline' | 'success' | 'info'
+> = {
+  PENDING_DEPOSIT: 'secondary',
+  PAID: 'success',
+  CANCELED: 'destructive',
+  EXPIRED: 'outline',
+  CONVERTED: 'primary',
+};
+
+export function computeBookingTotal(
+  items: { quantity: number; unitPrice: number }[],
+): number {
+  return items.reduce(
+    (sum, it) => sum + Math.round(it.quantity * it.unitPrice * 100) / 100,
+    0,
+  );
+}
+
+export function isDepositInRange(depositAmount: number, totalAmount: number): boolean {
+  if (!Number.isFinite(depositAmount) || !Number.isFinite(totalAmount)) return false;
+  if (depositAmount < 0) return false;
+  if (totalAmount < 0) return false;
+  return depositAmount <= totalAmount;
+}
+
+function fmtMoney(v: string | number): string {
+  const n = typeof v === 'string' ? parseFloat(v) : v;
+  if (!Number.isFinite(n)) return '0.00';
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function fmtDate(s: string): string {
+  return formatThaiDate(s);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Page
+// ──────────────────────────────────────────────────────────────────────────
+
+export default function BookingsPage() {
+  useDocumentTitle('การจอง / มัดจำ');
+  const { user } = useAuth();
+  const qc = useQueryClient();
+
+  const canCreate = ['OWNER', 'BRANCH_MANAGER', 'SALES'].includes(user?.role ?? '');
+  const canMutate = ['OWNER', 'BRANCH_MANAGER', 'SALES'].includes(user?.role ?? '');
+  const canDelete = ['OWNER', 'BRANCH_MANAGER'].includes(user?.role ?? '');
+
+  const [statusFilter, setStatusFilter] = useState<string>('ALL');
+  const [search, setSearch] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [detailBookingId, setDetailBookingId] = useState<string | null>(null);
+
+  const { data, isLoading, isError, error, refetch } = useQuery<BookingListResponse>({
+    queryKey: ['bookings', statusFilter, search],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (statusFilter && statusFilter !== 'ALL') params.set('status', statusFilter);
+      if (search.trim()) params.set('search', search.trim());
+      const { data } = await api.get(`/bookings?${params}`);
+      return data;
+    },
+  });
+
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      <PageHeader
+        title="การจอง / มัดจำ"
+        subtitle="สร้างใบจอง รับมัดจำ และแปลงเป็นการขาย — มัดจำเข้าเป็น downPayment อัตโนมัติ"
+        action={
+          canCreate ? (
+            <Button onClick={() => setCreateOpen(true)} className="gap-2">
+              <Plus className="h-4 w-4" />
+              สร้างใบจอง
+            </Button>
+          ) : null
+        }
+      />
+
+      <Card>
+        <CardContent className="space-y-4 pt-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="ค้นหาเลขที่ / ชื่อลูกค้า"
+                className="pl-9"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+            <div className="w-full md:w-56">
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger>
+                  <SelectValue placeholder="สถานะ" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">ทั้งหมด</SelectItem>
+                  {(Object.keys(STATUS_LABEL) as BookingStatus[]).map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {STATUS_LABEL[s]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <QueryBoundary
+            isLoading={isLoading}
+            isError={isError}
+            error={error}
+            errorTitle="โหลดรายการใบจองไม่สำเร็จ"
+            onRetry={refetch}
+          >
+            <BookingTable
+              bookings={data?.data ?? []}
+              onOpenDetail={(id) => setDetailBookingId(id)}
+            />
+          </QueryBoundary>
+        </CardContent>
+      </Card>
+
+      {createOpen && (
+        <CreateBookingDialog
+          open={createOpen}
+          onClose={() => setCreateOpen(false)}
+          onCreated={() => {
+            qc.invalidateQueries({ queryKey: ['bookings'] });
+            setCreateOpen(false);
+          }}
+        />
+      )}
+
+      {detailBookingId && (
+        <BookingDetailDialog
+          bookingId={detailBookingId}
+          canDelete={canDelete}
+          canMutate={canMutate}
+          onClose={() => setDetailBookingId(null)}
+          onChanged={() => qc.invalidateQueries({ queryKey: ['bookings'] })}
+        />
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// BookingTable
+// ──────────────────────────────────────────────────────────────────────────
+
+function BookingTable({
+  bookings,
+  onOpenDetail,
+}: {
+  bookings: Booking[];
+  onOpenDetail: (id: string) => void;
+}) {
+  if (bookings.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground">
+        <CalendarDays className="h-10 w-10 opacity-30" />
+        <p>ยังไม่มีใบจอง</p>
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="border-b border-border text-left text-xs uppercase text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2">เลขที่</th>
+            <th className="px-3 py-2">ลูกค้า</th>
+            <th className="px-3 py-2">สาขา</th>
+            <th className="px-3 py-2 text-right">มัดจำ</th>
+            <th className="px-3 py-2 text-right">ยอดรวม</th>
+            <th className="px-3 py-2">สถานะ</th>
+            <th className="px-3 py-2">หมดอายุ</th>
+            <th className="px-3 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {bookings.map((b) => (
+            <tr key={b.id} className="border-b border-border/60 hover:bg-accent/40">
+              <td className="px-3 py-2 font-mono text-xs">{b.bookingNumber}</td>
+              <td className="px-3 py-2">{b.customer.name}</td>
+              <td className="px-3 py-2">{b.branch.name}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{fmtMoney(b.depositAmount)}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{fmtMoney(b.totalAmount)}</td>
+              <td className="px-3 py-2">
+                <Badge variant={STATUS_VARIANT[b.status]}>{STATUS_LABEL[b.status]}</Badge>
+              </td>
+              <td className="px-3 py-2 text-muted-foreground">{fmtDate(b.expireDate)}</td>
+              <td className="px-3 py-2 text-right">
+                <Button size="sm" variant="ghost" onClick={() => onOpenDetail(b.id)}>
+                  เปิด
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// CreateBookingDialog
+// ──────────────────────────────────────────────────────────────────────────
+
+interface DraftItem {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  productId?: string;
+}
+
+function CreateBookingDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const { user } = useAuth();
+
+  const [customerId, setCustomerId] = useState('');
+  const [branchId, setBranchId] = useState(user?.branchId ?? '');
+  const [expireDate, setExpireDate] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return d.toISOString().slice(0, 10);
+  });
+  const [depositAmount, setDepositAmount] = useState(0);
+  const [notes, setNotes] = useState('');
+  const [items, setItems] = useState<DraftItem[]>([
+    { description: '', quantity: 1, unitPrice: 0 },
+  ]);
+
+  const { data: customers } = useQuery<CustomerOption[]>({
+    queryKey: ['booking-customer-search'],
+    queryFn: async () => {
+      const { data } = await api.get('/customers?limit=200');
+      return (data.data ?? data ?? []) as CustomerOption[];
+    },
+    enabled: open,
+  });
+
+  const { data: branches } = useQuery<BranchOption[]>({
+    queryKey: ['booking-branches'],
+    queryFn: async () => {
+      const { data } = await api.get('/branches');
+      return (data.data ?? data ?? []) as BranchOption[];
+    },
+    enabled: open,
+  });
+
+  const totalAmount = useMemo(() => computeBookingTotal(items), [items]);
+  const depositValid = isDepositInRange(depositAmount, totalAmount);
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      return api.post('/bookings', {
+        customerId,
+        branchId,
+        expireDate: new Date(expireDate).toISOString(),
+        depositAmount,
+        notes: notes || undefined,
+        items: items
+          .filter((i) => i.description.trim() && i.quantity > 0 && i.unitPrice >= 0)
+          .map((i) => ({
+            description: i.description.trim(),
+            quantity: Number(i.quantity),
+            unitPrice: Number(i.unitPrice),
+            productId: i.productId || undefined,
+          })),
+      });
+    },
+    onSuccess: () => {
+      toast.success('สร้างใบจองแล้ว');
+      onCreated();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const isValid =
+    customerId &&
+    branchId &&
+    expireDate &&
+    depositValid &&
+    items.some((i) => i.description.trim() && i.quantity > 0);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>สร้างใบจอง</DialogTitle>
+          <DialogDescription>
+            ระบุลูกค้า รายการสินค้า มัดจำ และวันหมดอายุ — บันทึกเป็น "รอชำระมัดจำ"
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label>ลูกค้า</Label>
+            <Select value={customerId} onValueChange={setCustomerId}>
+              <SelectTrigger>
+                <SelectValue placeholder="เลือกลูกค้า" />
+              </SelectTrigger>
+              <SelectContent>
+                {(customers ?? []).map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name}
+                    {c.phone ? ` — ${c.phone}` : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>สาขา</Label>
+            <Select value={branchId} onValueChange={setBranchId}>
+              <SelectTrigger>
+                <SelectValue placeholder="เลือกสาขา" />
+              </SelectTrigger>
+              <SelectContent>
+                {(branches ?? []).map((b) => (
+                  <SelectItem key={b.id} value={b.id}>
+                    {b.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>หมดอายุภายใน</Label>
+            <Input
+              type="date"
+              value={expireDate}
+              onChange={(e) => setExpireDate(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label>รายการ</Label>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() =>
+                setItems([...items, { description: '', quantity: 1, unitPrice: 0 }])
+              }
+            >
+              + เพิ่มรายการ
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {items.map((it, idx) => (
+              <div key={idx} className="grid grid-cols-12 gap-2">
+                <Input
+                  className="col-span-6"
+                  placeholder="รายละเอียดสินค้า/บริการ"
+                  value={it.description}
+                  onChange={(e) => {
+                    const copy = [...items];
+                    copy[idx] = { ...copy[idx], description: e.target.value };
+                    setItems(copy);
+                  }}
+                />
+                <Input
+                  className="col-span-2"
+                  type="number"
+                  min={1}
+                  placeholder="จำนวน"
+                  value={it.quantity}
+                  onChange={(e) => {
+                    const copy = [...items];
+                    copy[idx] = { ...copy[idx], quantity: Number(e.target.value) || 1 };
+                    setItems(copy);
+                  }}
+                />
+                <Input
+                  className="col-span-3"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  placeholder="ราคา/หน่วย"
+                  value={it.unitPrice}
+                  onChange={(e) => {
+                    const copy = [...items];
+                    copy[idx] = { ...copy[idx], unitPrice: Number(e.target.value) || 0 };
+                    setItems(copy);
+                  }}
+                />
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="col-span-1"
+                  onClick={() => setItems(items.filter((_, i) => i !== idx))}
+                  disabled={items.length === 1}
+                  aria-label="ลบรายการ"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="space-y-2">
+            <Label>มัดจำ (บาท)</Label>
+            <Input
+              type="number"
+              min={0}
+              step="0.01"
+              value={depositAmount}
+              onChange={(e) => setDepositAmount(Number(e.target.value) || 0)}
+              aria-invalid={!depositValid}
+            />
+            {!depositValid && (
+              <p className="text-xs text-destructive">
+                มัดจำต้องไม่ติดลบและไม่เกินยอดรวม ({fmtMoney(totalAmount)})
+              </p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label>ยอดรวมทั้งสิ้น</Label>
+            <Input value={fmtMoney(totalAmount)} readOnly className="font-mono tabular-nums" />
+          </div>
+          <div className="space-y-2">
+            <Label>ส่วนต่างต้องเก็บอีก</Label>
+            <Input
+              value={fmtMoney(Math.max(0, totalAmount - depositAmount))}
+              readOnly
+              className="font-mono tabular-nums text-muted-foreground"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label>หมายเหตุ</Label>
+          <Input
+            placeholder="ระบุหมายเหตุ (ไม่บังคับ)"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            ยกเลิก
+          </Button>
+          <Button
+            onClick={() => createMutation.mutate()}
+            disabled={!isValid || createMutation.isPending}
+          >
+            {createMutation.isPending ? 'กำลังบันทึก...' : 'บันทึกใบจอง'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// BookingDetailDialog
+// ──────────────────────────────────────────────────────────────────────────
+
+function BookingDetailDialog({
+  bookingId,
+  canDelete,
+  canMutate,
+  onClose,
+  onChanged,
+}: {
+  bookingId: string;
+  canDelete: boolean;
+  canMutate: boolean;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const qc = useQueryClient();
+  const { data: booking, isLoading } = useQuery<Booking>({
+    queryKey: ['booking', bookingId],
+    queryFn: async () => {
+      const { data } = await api.get(`/bookings/${bookingId}`);
+      return data;
+    },
+  });
+
+  const [depositMethod, setDepositMethod] = useState('CASH');
+  const [cancelReason, setCancelReason] = useState('');
+
+  const payMut = useMutation({
+    mutationFn: () => api.post(`/bookings/${bookingId}/pay-deposit`, { depositMethod }),
+    onSuccess: () => {
+      toast.success('บันทึกการรับมัดจำแล้ว');
+      qc.invalidateQueries({ queryKey: ['booking', bookingId] });
+      onChanged();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const cancelMut = useMutation({
+    mutationFn: () =>
+      api.post(`/bookings/${bookingId}/cancel`, { cancelReason: cancelReason || undefined }),
+    onSuccess: () => {
+      toast.success('ยกเลิกใบจองแล้ว (คืนมัดจำ 100% ก่อนหมดอายุ)');
+      qc.invalidateQueries({ queryKey: ['booking', bookingId] });
+      onChanged();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const convertMut = useMutation({
+    mutationFn: () => api.post(`/bookings/${bookingId}/convert`, { saleType: 'CASH' }),
+    onSuccess: () => {
+      toast.success('แปลงเป็นการขายแล้ว — มัดจำเข้า downPayment อัตโนมัติ');
+      qc.invalidateQueries({ queryKey: ['booking', bookingId] });
+      onChanged();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: () => api.delete(`/bookings/${bookingId}`),
+    onSuccess: () => {
+      toast.success('ลบใบจองแล้ว');
+      onClose();
+      onChanged();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{booking ? booking.bookingNumber : 'กำลังโหลด...'}</DialogTitle>
+          {booking && (
+            <DialogDescription>
+              <Badge variant={STATUS_VARIANT[booking.status]}>
+                {STATUS_LABEL[booking.status]}
+              </Badge>
+              <span className="ml-2 text-muted-foreground">
+                หมดอายุ {fmtDate(booking.expireDate)}
+              </span>
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {isLoading || !booking ? (
+          <div className="py-8 text-center text-muted-foreground">กำลังโหลด...</div>
+        ) : (
+          <div className="space-y-3 text-sm">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <div className="text-xs text-muted-foreground">ลูกค้า</div>
+                <div>{booking.customer.name}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">สาขา</div>
+                <div>{booking.branch.name}</div>
+              </div>
+            </div>
+
+            <div className="rounded-md border border-border">
+              <table className="w-full text-sm">
+                <thead className="border-b border-border bg-muted/50 text-xs text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left">รายการ</th>
+                    <th className="px-3 py-2 text-right">จำนวน</th>
+                    <th className="px-3 py-2 text-right">ราคา/หน่วย</th>
+                    <th className="px-3 py-2 text-right">รวม</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {booking.items.map((it) => (
+                    <tr key={it.id} className="border-b border-border/60">
+                      <td className="px-3 py-2">{it.description}</td>
+                      <td className="px-3 py-2 text-right">{it.quantity}</td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {fmtMoney(it.unitPrice)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">{fmtMoney(it.amount)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex justify-end">
+              <div className="w-64 space-y-1">
+                <div className="flex justify-between">
+                  <span>ยอดรวม</span>
+                  <span className="tabular-nums">{fmtMoney(booking.totalAmount)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>มัดจำ</span>
+                  <span className="tabular-nums">{fmtMoney(booking.depositAmount)}</span>
+                </div>
+                <div className="flex justify-between border-t border-border pt-1 font-semibold">
+                  <span>คงค้าง</span>
+                  <span className="tabular-nums">
+                    {fmtMoney(Number(booking.totalAmount) - Number(booking.depositAmount))}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {booking.notes && (
+              <div className="rounded-md border border-border bg-muted/30 p-3 text-muted-foreground">
+                {booking.notes}
+              </div>
+            )}
+
+            {booking.cancelReason && (
+              <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm">
+                <div className="font-semibold">เหตุผลการยกเลิก</div>
+                <div className="text-muted-foreground">{booking.cancelReason}</div>
+              </div>
+            )}
+
+            {booking.convertedToSale && (
+              <div className="rounded-md border border-border bg-accent/40 p-3 text-sm">
+                แปลงเป็นการขาย:{' '}
+                <span className="font-mono">{booking.convertedToSale.saleNumber}</span>
+              </div>
+            )}
+
+            {canMutate && booking.status === 'PENDING_DEPOSIT' && (
+              <div className="space-y-2 rounded-md border border-border bg-muted/20 p-3">
+                <Label>วิธีรับมัดจำ</Label>
+                <Select value={depositMethod} onValueChange={setDepositMethod}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="CASH">เงินสด</SelectItem>
+                    <SelectItem value="BANK_TRANSFER">โอนธนาคาร</SelectItem>
+                    <SelectItem value="QR_EWALLET">QR / e-Wallet</SelectItem>
+                    <SelectItem value="CREDIT_BALANCE">หักจากเครดิตคงเหลือ</SelectItem>
+                    <SelectItem value="ONLINE_GATEWAY">ผ่าน Gateway</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {canMutate &&
+              (booking.status === 'PENDING_DEPOSIT' || booking.status === 'PAID') && (
+                <div className="space-y-2 rounded-md border border-border bg-muted/20 p-3">
+                  <Label>เหตุผลการยกเลิก (ถ้ายกเลิก)</Label>
+                  <Input
+                    placeholder="เช่น ลูกค้าเปลี่ยนใจ / ไม่ผ่านเครดิต"
+                    value={cancelReason}
+                    onChange={(e) => setCancelReason(e.target.value)}
+                  />
+                </div>
+              )}
+          </div>
+        )}
+
+        <DialogFooter className="flex-wrap gap-2">
+          {canMutate && booking?.status === 'PENDING_DEPOSIT' && (
+            <Button
+              onClick={() => payMut.mutate()}
+              disabled={payMut.isPending}
+              className="gap-2"
+            >
+              <HandCoins className="h-4 w-4" /> ชำระมัดจำ
+            </Button>
+          )}
+          {canMutate &&
+            (booking?.status === 'PENDING_DEPOSIT' || booking?.status === 'PAID') && (
+              <Button
+                variant="outline"
+                onClick={() => cancelMut.mutate()}
+                disabled={cancelMut.isPending}
+                className="gap-2"
+              >
+                <Ban className="h-4 w-4" /> ยกเลิก
+              </Button>
+            )}
+          {canMutate && booking?.status === 'PAID' && !booking.convertedToSale && (
+            <Button
+              onClick={() => convertMut.mutate()}
+              disabled={convertMut.isPending}
+              className="gap-2"
+            >
+              <ShoppingCart className="h-4 w-4" /> แปลงเป็นการขาย
+            </Button>
+          )}
+          {canDelete && booking?.status === 'PENDING_DEPOSIT' && (
+            <Button
+              variant="destructive"
+              onClick={() => deleteMut.mutate()}
+              disabled={deleteMut.isPending}
+              className="gap-2"
+            >
+              <Trash2 className="h-4 w-4" /> ลบใบจอง
+            </Button>
+          )}
+          <Button variant="ghost" onClick={onClose}>
+            ปิด
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/docs/superpowers/specs/2026-05-18-phase-2-csv-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-05-18-phase-2-csv-completion-roadmap.md
@@ -1,0 +1,161 @@
+# Phase 2 — CSV 100% Completion Roadmap
+
+**Status:** Spec 2026-05-18. Closes remaining 5 gaps vs original CSV after Phase 1 (Sidebar Redesign SP1-SP6 deployed)
+**Goal:** ครบ 100% ตาม CSV ที่ owner ส่ง 2026-05-17
+
+---
+
+## 1. Gap Analysis vs CSV
+
+After Phase 1 deploy, these 5 CSV items remain partial/missing:
+
+| # | CSV item | Phase 1 status | Phase 2 SP |
+|---|---|---|---|
+| 1 | CRM Pipeline (สนใจ→ติดต่อ→เสนอราคา→ปิดการขาย) | Existing Kanban, needs 4-stage labels + filter | P2-SP1 |
+| 2 | ตั้งค่าเลขที่/รูปแบบเอกสาร UI | D1.1.2.x backend exists, no UI | P2-SP2 |
+| 3 | e-Tax PDF Thai font | ASCII placeholder | P2-SP3 |
+| 4 | การจอง / มัดจำ booking system | Not built | P2-SP4 |
+| 5 | e-Tax XML ส่ง RD (ม.86/4 + ขมธอ.21-2562) | Phase 1 Receipt only | P2-SP5 |
+
+## 2. Decomposition (5 sub-projects)
+
+### Wave 1 — Quick wins (parallel, ship same-day)
+
+**P2-SP1: CRM 4-stage Kanban Thai labels**
+- Schema: confirm `CrmLead.stage` enum has LEAD/CONTACTED/QUOTED/WON/LOST
+- Frontend: Kanban columns with Thai labels: เสนอ / ติดต่อ / เสนอราคา / ปิดการขาย / ยกเลิก
+- Drag-and-drop between columns
+- Link "เสนอราคา" → /quotes (new Quote)
+- Link "ปิดการขาย" → /pos with prefilled customer
+- ETA: 1 hour
+
+**P2-SP2: Document Number Config UI**
+- Frontend: `DocumentConfigPage.tsx` at `/settings/document-config`
+- Backend: reuse D1.1.2.x SystemConfig keys (`doc_prefix_per_type`, `doc_number_format`, `doc_number_reset_cycle`)
+- Form: edit prefix per doc type + select format from whitelist + select reset cadence
+- Live preview using existing `DocNumberService.peek()` (if not exists, add)
+- Audit log on save (action='DOC_NUMBER_CONFIG_UPDATED')
+- OWNER only
+- ETA: 2 hours
+
+**P2-SP3: e-Tax PDF Thai font**
+- Bundle Noto Sans Thai (Apache 2.0) per PR #843 pattern
+- Replace jsPDF Helvetica with pdfmake (or jsPDF + addFileToVFS for custom font)
+- Real customer name in Thai (not `[contract <num>]` placeholder)
+- ETA: 1 hour
+
+### Wave 2 — Booking system (defaults applied)
+
+**P2-SP4: การจอง / มัดจำ (Booking)**
+
+Defaults (use unless OWNER overrides via settings):
+- 1 booking = 1+ products (multiple allowed)
+- มัดจำ = THB amount (fixed, not %)
+- Expire = 7 days (configurable via SystemConfig `booking_expire_days`)
+- Cancel before expire = 100% refund (configurable)
+- Cancel after expire = 0% refund (forfeit)
+- Convert to sale: deposit transfers to down payment, no separate dialog
+
+Backend:
+- `Booking` model: customer, branch, items[], depositAmount, expireDate, status (PENDING/PAID/CANCELED/CONVERTED/EXPIRED), depositPaymentId
+- `BookingItem` model: productId, quantity, unitPrice
+- Service: create, payDeposit, cancel (refund), convertToSale, autoExpireCron
+- Endpoints: POST/GET/PATCH/DELETE `/bookings`
+- Migration: new tables + cron job
+
+Frontend:
+- `BookingsPage.tsx` at `/bookings`
+- Create from POS or standalone
+- Status column with Thai labels: รอชำระ / มัดจำแล้ว / ยกเลิก / ขายแล้ว / หมดอายุ
+- Convert button → POS prefilled with customer + items + remaining balance
+
+Routes: `/bookings`, `/bookings/new`, `/bookings/:id`
+
+ETA: 1-2 days
+
+### Wave 3 — e-Tax XML legal (infrastructure, cert plug-in later)
+
+**P2-SP5: e-Tax XML submission scaffolding**
+
+Build infrastructure, owner plugs in CA cert + RD sandbox creds later:
+
+Backend:
+- Module: `apps/api/src/modules/e-tax-xml/`
+- Service:
+  - `generateXml(paymentId)` — produces XML per ขมธอ.21-2562 (Thailand UBL 2.1)
+  - `signXml(xml, certPath, certPass)` — PKCS#7 detached signature using node-signpdf or @signpdf/signpdf
+  - `submitToRd(signedXml, mode: 'sandbox' | 'prod')` — POST to RD endpoint
+  - `pollStatus(submissionId)` — check RD response
+- Env vars: `ETAX_CERT_PATH`, `ETAX_CERT_PASS`, `ETAX_RD_ENDPOINT`, `ETAX_RD_USERNAME`, `ETAX_RD_PASSWORD`, `ETAX_SUBMIT_MODE` (default 'disabled')
+- Schema: `ETaxSubmission` model — paymentId, xmlContent, status (PENDING/SIGNED/SUBMITTED/ACCEPTED/REJECTED), rdResponse, submittedAt
+
+Frontend:
+- Extend `ETaxInvoicePage.tsx`:
+  - "ส่งให้สรรพากร" button per invoice (disabled if ETAX_SUBMIT_MODE='disabled' with tooltip "ยังไม่ได้ตั้งค่า e-Tax CA cert")
+  - Status badge: รอส่ง / ส่งแล้ว / สรรพากรรับ / ปฏิเสธ
+  - Resubmit failed
+  - Bulk submit (monthly)
+
+Configuration UI (OWNER only):
+- `/settings/e-tax-config` — upload cert + RD creds + sandbox/prod toggle
+- Test connection button
+
+When `ETAX_SUBMIT_MODE='enabled'`:
+- Cron job submits all eligible invoices nightly
+- Sentry alarms on RD rejections
+
+ETA: 1 week (infrastructure) + owner adds cert/creds when ready
+
+---
+
+## 3. PR Strategy
+
+5 worktrees, 5 parallel branches:
+- `feat/p2-sp1-crm-stages`
+- `feat/p2-sp2-doc-config-ui`
+- `feat/p2-sp3-etax-thai-font`
+- `feat/p2-sp4-booking`
+- `feat/p2-sp5-etax-xml-scaffolding`
+
+Merge sequence (after each CI green):
+1. P2-SP3 (Thai font) — smallest, fastest
+2. P2-SP1 (CRM stages) — small, frontend only
+3. P2-SP2 (Doc config UI) — small-medium
+4. P2-SP4 (Booking) — medium with migration
+5. P2-SP5 (e-Tax XML) — largest
+
+## 4. Test Plan
+
+- P2-SP1: 2 vitest + 1 Playwright
+- P2-SP2: 5 jest + 2 vitest + 1 Playwright
+- P2-SP3: 3 jest (PDF Thai render)
+- P2-SP4: 12 jest + 4 vitest + 2 Playwright
+- P2-SP5: 8 jest + 1 vitest + 1 Playwright (mock RD response)
+
+## 5. Owner deliverables for Wave 3 go-live
+
+After P2-SP5 merge, to actually submit to RD:
+1. ลงทะเบียนเป็นผู้ออก e-Tax กับสรรพากร (form ภ.อ.01)
+2. ขอ Digital Signature Certificate จาก CA (NDID, INET, ThaiCERT — ลิงก์: https://etax.rd.go.th/etax_staging/etaxws/)
+3. ได้ username/password สำหรับ RD sandbox + prod
+4. Upload cert + creds ใน `/settings/e-tax-config`
+5. Toggle `ETAX_SUBMIT_MODE='enabled'` + restart API service
+
+## 6. Acceptance Criteria
+
+- [ ] CRM 4-stage Kanban with Thai labels working
+- [ ] OWNER can edit doc number prefix/format/cadence via UI
+- [ ] e-Tax PDF shows Thai customer names correctly
+- [ ] Booking flow: create → payDeposit → expire/cancel/convert all working
+- [ ] e-Tax XML generates per ขมธอ.21-2562, ready to sign + submit (cert pending)
+- [ ] All Playwright E2E pass
+- [ ] Each SP through DEEP /review + fix cycle
+- [ ] 0 TS errors
+
+## 7. Out of Scope (Phase 3+ if needed)
+
+- VAT-on-interest CR-001 (CPA consult)
+- GFIN integration
+- Year-end closing entries (39-9999 → 33-1101 flow)
+- Off-site backup replication
+- PII column-level encryption


### PR DESCRIPTION
## Summary
- Schema: Booking + BookingItem + BookingStatus enum (migration 20260942000000)
- Service: create, payDeposit, cancel (refund), convertToSale, autoExpire cron
- Race-safe state transitions via composite-where updateMany (SP5 pattern)
- BranchGuard + getBranchScope (SHOP-side, branch-scoped)
- Frontend: /bookings page with Thai status badges
- Sidebar: SALES/BM/OWNER เห็น 'การจอง / มัดจำ'

## Defaults (per spec)
- Expire = 7 days (configurable via booking_expire_days)
- Deposit = THB amount (1+ items)
- Cancel before expire = 100% refund
- Convert: deposit transfers to Sale.downPaymentAmount

## Design deviation
- Replaced depositPaymentId Payment-FK with native fields (depositPaidAt/depositMethod/depositReceivedById) — Payment.contractId is required by schema, booking has no contract pre-sale. Deposit flows into Sale.downPaymentAmount on convert.

## Test plan
- [x] 19/19 jest (race + cancel + autoExpire + branch scope + decimal)
- [x] 5/5 vitest (helpers)
- [x] 2 Playwright (SALES create, OWNER expired filter)
- [x] TypeScript 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)