### PR TITLE
feat(p3-sp2): off-site backup replication (GCS cross-region sync)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,3 +149,18 @@ FACEBOOK_APP_SECRET=
 # Bot defense (Phase 1 Task 3)
 CLOUDFLARE_TURNSTILE_SITE_KEY=
 CLOUDFLARE_TURNSTILE_SECRET=
+
+# Off-site backup (Phase 3 SP2)
+# Cross-region replication of Cloud SQL exports + GCS document bucket
+# into a separate off-site bucket (different region from primary) for DR.
+# Bucket creation + IAM granting is an OWNER deliverable — see
+# docs/guides/OFFSITE-BACKUP.md. Leave OFFSITE_BACKUP_ENABLED=false until
+# the destination bucket exists and the Cloud Run service account has
+# storage.objects.create/delete/get on it.
+OFFSITE_BACKUP_ENABLED=false
+OFFSITE_BACKUP_DEST_BUCKET=bestchoice-backups-offsite
+OFFSITE_BACKUP_RETENTION_DAYS=30
+OFFSITE_BACKUP_SQL_PREFIX=cloudsql-backups/
+# Source bucket for Cloud SQL daily SQL dump exports — leave blank to skip
+# the SQL replication step (document bucket replication still runs).
+OFFSITE_BACKUP_SQL_SOURCE_BUCKET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,17 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Install wget (health check) + chromium (puppeteer PDF generation)
-# Puppeteer-core has no bundled Chromium — must provide system one.
-# Chromium + minimal font/ca deps are needed for headless PDF rendering in
-# documents.service.ts::htmlToPdf. Thai fonts (TH Sarabun PSK) are base64
-# embedded at runtime from public/fonts/, so we only need ttf-freefont here
-# for fallback glyphs.
+# Install wget (health check) + chromium (puppeteer PDF generation) + tzdata
+# - Puppeteer-core has no bundled Chromium — must provide system one.
+# - Chromium + minimal font/ca deps are needed for headless PDF rendering in
+#   documents.service.ts::htmlToPdf. Thai fonts (TH Sarabun PSK) are base64
+#   embedded at runtime from public/fonts/, so we only need ttf-freefont here
+#   for fallback glyphs.
+# - tzdata is REQUIRED for @nestjs/schedule timezone-bound crons
+#   (e.g. OffsiteBackupCron at 03:30 Asia/Bangkok). Without it Alpine has no
+#   IANA zoneinfo and the cron silently falls back to UTC — daily backup
+#   would run at 10:30 BKK instead of the intended 03:30. We also force
+#   process TZ for consistent log timestamps.
 RUN apk add --no-cache \
       wget \
       chromium \
@@ -64,7 +69,9 @@ RUN apk add --no-cache \
       freetype \
       harfbuzz \
       ca-certificates \
-      ttf-freefont
+      ttf-freefont \
+      tzdata
+ENV TZ=Asia/Bangkok
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser

--- a/apps/api/prisma/migrations/20260945000000_add_offsite_backup_runs/migration.sql
+++ b/apps/api/prisma/migrations/20260945000000_add_offsite_backup_runs/migration.sql
@@ -1,0 +1,29 @@
+-- Phase 3 SP2 — Off-site backup replication run log
+--
+-- One row per cron tick (hourly default 03:30 BKK) or manual trigger.
+-- Append-only operational history; UI surfaces the last 30 rows.
+--
+-- IF NOT EXISTS guards are used so a re-run of `migrate deploy` on an
+-- environment that already applied this migration is a safe no-op.
+
+DO $$ BEGIN
+  CREATE TYPE "OffsiteBackupStatus" AS ENUM ('RUNNING', 'SUCCESS', 'FAILED', 'SKIPPED');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS "offsite_backup_runs" (
+  "id"             TEXT NOT NULL,
+  "started_at"     TIMESTAMP(3) NOT NULL,
+  "finished_at"    TIMESTAMP(3),
+  "status"         "OffsiteBackupStatus" NOT NULL,
+  "files_count"    INTEGER NOT NULL DEFAULT 0,
+  "total_bytes"    BIGINT NOT NULL DEFAULT 0,
+  "error_message"  TEXT,
+  "triggered_by"   TEXT,
+  "dest_bucket"    TEXT,
+  "created_at"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "offsite_backup_runs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "offsite_backup_runs_started_at_idx"
+  ON "offsite_backup_runs"("started_at");

--- a/apps/api/prisma/migrations/20260947000000_offsite_backup_audit_columns_retention/migration.sql
+++ b/apps/api/prisma/migrations/20260947000000_offsite_backup_audit_columns_retention/migration.sql
@@ -8,27 +8,29 @@
 -- IF NOT EXISTS / DO $$ guards make this migration idempotent — safe to
 -- re-run after a partial failure or on environments that already applied.
 
--- 1) Add nullable FK column (idempotent).
+-- 1) Add nullable FK column (idempotent). User.id is mapped to TEXT in
+--    Prisma's default UUID-string mode (no @db.Uuid), so the FK column
+--    must also be TEXT to be type-compatible for the constraint.
 ALTER TABLE "offsite_backup_runs"
-  ADD COLUMN IF NOT EXISTS "triggered_by_user_id" UUID;
+  ADD COLUMN IF NOT EXISTS "triggered_by_user_id" TEXT;
 
 -- 2) Backfill: normalize triggered_by values.
 --    Anything that is NOT one of the two known categories ('cron'|'manual')
 --    is assumed to be a stray user UUID written by the pre-fix code. Move
---    it into triggered_by_user_id (best-effort — invalid UUIDs silently
---    skipped) and reset triggered_by to 'manual'. Defaults
---    `triggered_by IS NULL` to 'cron' so existing rows always have a value.
+--    it into triggered_by_user_id (best-effort — only when the value
+--    matches an existing user) and reset triggered_by to 'manual'.
 DO $$
 BEGIN
-  -- Migrate stray UUIDs from triggered_by → triggered_by_user_id.
-  UPDATE "offsite_backup_runs"
-  SET "triggered_by_user_id" = "triggered_by"::uuid
-  WHERE "triggered_by" IS NOT NULL
-    AND "triggered_by" NOT IN ('cron', 'manual')
-    AND "triggered_by" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-    AND EXISTS (SELECT 1 FROM "users" WHERE "users"."id"::text = "offsite_backup_runs"."triggered_by");
+  -- Migrate stray UUIDs from triggered_by → triggered_by_user_id, only
+  -- when the value matches an existing user row. Both columns are TEXT
+  -- so no casting required.
+  UPDATE "offsite_backup_runs" o
+  SET "triggered_by_user_id" = o."triggered_by"
+  WHERE o."triggered_by" IS NOT NULL
+    AND o."triggered_by" NOT IN ('cron', 'manual')
+    AND EXISTS (SELECT 1 FROM "users" u WHERE u."id" = o."triggered_by");
 EXCEPTION WHEN OTHERS THEN
-  -- Defensive: any cast failure should not break the migration.
+  -- Defensive: any error should not break the migration.
   NULL;
 END $$;
 

--- a/apps/api/prisma/migrations/20260947000000_offsite_backup_audit_columns_retention/migration.sql
+++ b/apps/api/prisma/migrations/20260947000000_offsite_backup_audit_columns_retention/migration.sql
@@ -1,0 +1,59 @@
+-- Phase 3 SP2 — DEEP review fixes (C2 + C3)
+--
+-- C2: split triggered_by into category + nullable FK to users(id).
+--     Previously raw UUIDs were stored in `triggered_by` with no FK —
+--     orphans survived user soft-delete and the UI showed `user:abcd1234`.
+-- C3: add /// retention comment + daily retention cron (added in code).
+--
+-- IF NOT EXISTS / DO $$ guards make this migration idempotent — safe to
+-- re-run after a partial failure or on environments that already applied.
+
+-- 1) Add nullable FK column (idempotent).
+ALTER TABLE "offsite_backup_runs"
+  ADD COLUMN IF NOT EXISTS "triggered_by_user_id" UUID;
+
+-- 2) Backfill: normalize triggered_by values.
+--    Anything that is NOT one of the two known categories ('cron'|'manual')
+--    is assumed to be a stray user UUID written by the pre-fix code. Move
+--    it into triggered_by_user_id (best-effort — invalid UUIDs silently
+--    skipped) and reset triggered_by to 'manual'. Defaults
+--    `triggered_by IS NULL` to 'cron' so existing rows always have a value.
+DO $$
+BEGIN
+  -- Migrate stray UUIDs from triggered_by → triggered_by_user_id.
+  UPDATE "offsite_backup_runs"
+  SET "triggered_by_user_id" = "triggered_by"::uuid
+  WHERE "triggered_by" IS NOT NULL
+    AND "triggered_by" NOT IN ('cron', 'manual')
+    AND "triggered_by" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    AND EXISTS (SELECT 1 FROM "users" WHERE "users"."id"::text = "offsite_backup_runs"."triggered_by");
+EXCEPTION WHEN OTHERS THEN
+  -- Defensive: any cast failure should not break the migration.
+  NULL;
+END $$;
+
+-- Normalize category column. Anything that isn't 'cron' is treated as
+-- a manual trigger (whether the UUID matched a real user or not — the
+-- audit log still has it via the FK column or audit_logs.userId).
+UPDATE "offsite_backup_runs"
+SET "triggered_by" = 'manual'
+WHERE "triggered_by" IS NULL
+   OR "triggered_by" NOT IN ('cron', 'manual');
+
+-- 3) Tighten the column: NOT NULL + default 'cron'.
+ALTER TABLE "offsite_backup_runs"
+  ALTER COLUMN "triggered_by" SET NOT NULL,
+  ALTER COLUMN "triggered_by" SET DEFAULT 'cron';
+
+-- 4) Add FK constraint + index (idempotent via DO blocks).
+DO $$ BEGIN
+  ALTER TABLE "offsite_backup_runs"
+    ADD CONSTRAINT "offsite_backup_runs_triggered_by_user_id_fkey"
+    FOREIGN KEY ("triggered_by_user_id")
+    REFERENCES "users"("id")
+    ON DELETE SET NULL
+    ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "offsite_backup_runs_triggered_by_user_id_idx"
+  ON "offsite_backup_runs"("triggered_by_user_id");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -733,6 +733,9 @@ model User {
   bookingsCreated  Booking[] @relation("BookingCreatedBy")
   bookingsCanceled Booking[] @relation("BookingCanceledBy")
 
+  // P3-SP2 — Off-site backup manual triggers (forensics: who clicked "Run Now")
+  offsiteBackupRunsTriggered OffsiteBackupRun[] @relation("OffsiteBackupTriggeredBy")
+
   @@index([branchId])
   @@index([yeastarExtension])
   @@map("users")
@@ -6581,22 +6584,31 @@ enum ETaxSubmissionStatus {
 /// Run-log for the off-site GCS replication cron.
 /// Append-only operational history (last 30 rows surfaced in UI).
 /// Created via OffsiteBackupService — never edited after finishedAt set.
+/// Append-only event log — updatedAt/deletedAt intentionally omitted.
+/// Retention handled by offsite-backup-retention cron (rows older than 1
+/// year pruned daily at 02:00 BKK to match AuditLog policy + avoid PDPA
+/// risk on lingering user UUIDs after soft-delete).
 model OffsiteBackupRun {
-  id            String                @id @default(uuid())
-  startedAt     DateTime              @map("started_at")
-  finishedAt    DateTime?             @map("finished_at")
-  status        OffsiteBackupStatus
-  filesCount    Int                   @default(0) @map("files_count")
-  totalBytes    BigInt                @default(0) @map("total_bytes")
+  id                String              @id @default(uuid())
+  startedAt         DateTime            @map("started_at")
+  finishedAt        DateTime?           @map("finished_at")
+  status            OffsiteBackupStatus
+  filesCount        Int                 @default(0) @map("files_count")
+  totalBytes        BigInt              @default(0) @map("total_bytes")
   /// First error message (truncated to 1000 chars) when status = FAILED.
-  errorMessage  String?               @map("error_message")
-  /// 'cron' | 'manual' | userId — for forensics on who/what triggered the run.
-  triggeredBy   String?               @map("triggered_by")
+  errorMessage      String?             @map("error_message")
+  /// Category: 'cron' | 'manual'. Was previously also storing raw UUIDs
+  /// — split into triggeredByUserId for proper FK + audit-safe joins.
+  triggeredBy       String              @default("cron") @map("triggered_by")
+  /// Set when triggeredBy = 'manual' (OWNER clicked "Run Now"). Null for cron.
+  triggeredByUserId String?             @map("triggered_by_user_id")
+  triggeredByUser   User?               @relation("OffsiteBackupTriggeredBy", fields: [triggeredByUserId], references: [id])
   /// Off-site destination bucket name captured at run time (for audit).
-  destBucket    String?               @map("dest_bucket")
-  createdAt     DateTime              @default(now()) @map("created_at")
+  destBucket        String?             @map("dest_bucket")
+  createdAt         DateTime            @default(now()) @map("created_at")
 
   @@index([startedAt])
+  @@index([triggeredByUserId])
   @@map("offsite_backup_runs")
 }
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -6573,3 +6573,40 @@ enum ETaxSubmissionStatus {
   /// Transport / server error — eligible for retry
   ERROR
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Phase 3 SP2 — Off-site backup replication
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Run-log for the off-site GCS replication cron.
+/// Append-only operational history (last 30 rows surfaced in UI).
+/// Created via OffsiteBackupService — never edited after finishedAt set.
+model OffsiteBackupRun {
+  id            String                @id @default(uuid())
+  startedAt     DateTime              @map("started_at")
+  finishedAt    DateTime?             @map("finished_at")
+  status        OffsiteBackupStatus
+  filesCount    Int                   @default(0) @map("files_count")
+  totalBytes    BigInt                @default(0) @map("total_bytes")
+  /// First error message (truncated to 1000 chars) when status = FAILED.
+  errorMessage  String?               @map("error_message")
+  /// 'cron' | 'manual' | userId — for forensics on who/what triggered the run.
+  triggeredBy   String?               @map("triggered_by")
+  /// Off-site destination bucket name captured at run time (for audit).
+  destBucket    String?               @map("dest_bucket")
+  createdAt     DateTime              @default(now()) @map("created_at")
+
+  @@index([startedAt])
+  @@map("offsite_backup_runs")
+}
+
+enum OffsiteBackupStatus {
+  /// Run started, files being replicated
+  RUNNING
+  /// Run finished without errors
+  SUCCESS
+  /// Run aborted with error (see errorMessage)
+  FAILED
+  /// Cron triggered but skipped (OFFSITE_BACKUP_ENABLED=false)
+  SKIPPED
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -127,6 +127,8 @@ import { IntegrationsModule } from './modules/integrations/integrations.module';
 import { TwoFactorModule } from './modules/two-factor/two-factor.module';
 import { ReportingModule } from './modules/reporting/reporting.module';
 import { CollectionsSessionModule } from './modules/collections-session/collections-session.module';
+// P3-SP2 — Off-site backup replication (GCS cross-region sync)
+import { BackupModule } from './modules/backup/backup.module';
 import { AuditInterceptor } from './modules/audit/audit.interceptor';
 import { SecurityMiddleware } from './modules/audit/security.middleware';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
@@ -351,6 +353,8 @@ import { AppCacheModule } from './cache/cache.module';
     TwoFactorModule,
     // Reporting — weekly PDF analytics report + compliance dashboard (P3 D1+D2)
     ReportingModule,
+    // P3-SP2 — Off-site backup replication (GCS cross-region sync, daily 03:30 BKK)
+    BackupModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/modules/backup/backup.controller.spec.ts
+++ b/apps/api/src/modules/backup/backup.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BackupController } from './backup.controller';
 import { OffsiteBackupService } from './offsite-backup.service';
+import { AuditService } from '../audit/audit.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 
@@ -8,6 +9,11 @@ describe('BackupController', () => {
   let controller: BackupController;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let service: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let audit: any;
+
+  const ownerUser = { id: 'owner-id', role: 'OWNER' };
+  const accountantUser = { id: 'acc-id', role: 'ACCOUNTANT' };
 
   beforeEach(async () => {
     service = {
@@ -19,9 +25,13 @@ describe('BackupController', () => {
       getRetentionDays: jest.fn().mockReturnValue(30),
       getSqlSourceBucket: jest.fn().mockReturnValue('sql-src'),
     };
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
     const mod: TestingModule = await Test.createTestingModule({
       controllers: [BackupController],
-      providers: [{ provide: OffsiteBackupService, useValue: service }],
+      providers: [
+        { provide: OffsiteBackupService, useValue: service },
+        { provide: AuditService, useValue: audit },
+      ],
     })
       // Bypass guards — JwtAuthGuard + RolesGuard wiring is validated by
       // unit tests for those guards; we only care about controller logic here.
@@ -34,7 +44,7 @@ describe('BackupController', () => {
   });
 
   describe('POST /backup/offsite-now', () => {
-    it('passes userId from CurrentUser to service.run as triggeredBy', async () => {
+    it('forwards manual + userId to service.run + writes AuditLog (C2)', async () => {
       service.run.mockResolvedValue({
         id: 'run-1',
         status: 'SUCCESS',
@@ -44,14 +54,25 @@ describe('BackupController', () => {
         startedAt: new Date(),
         finishedAt: new Date(),
       });
-      const res = await controller.triggerNow('user-uuid-123');
-      expect(service.run).toHaveBeenCalledWith('user-uuid-123');
+      const res = await controller.triggerNow(ownerUser);
+      expect(service.run).toHaveBeenCalledWith({
+        triggeredBy: 'manual',
+        triggeredByUserId: 'owner-id',
+      });
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'owner-id',
+          action: 'OFFSITE_BACKUP_RUN_NOW',
+          entity: 'offsite_backup',
+          entityId: 'run-1',
+        }),
+      );
       expect(res.status).toBe('SUCCESS');
       expect(res.filesCount).toBe(3);
       expect(res.errorMessage).toBeNull();
     });
 
-    it('falls back to "manual" when no user id present (e.g. service-account)', async () => {
+    it('handles failed runs and surfaces errorMessage', async () => {
       service.run.mockResolvedValue({
         id: 'run-2',
         status: 'FAILED',
@@ -62,30 +83,44 @@ describe('BackupController', () => {
         finishedAt: new Date(),
         errorMessage: 'boom',
       });
-      const res = await controller.triggerNow('');
-      expect(service.run).toHaveBeenCalledWith('manual');
+      const res = await controller.triggerNow(ownerUser);
       expect(res.errorMessage).toBe('boom');
     });
   });
 
   describe('GET /backup/offsite-status', () => {
-    it('returns enabled flag, config, and recent runs', async () => {
-      service.getRecentRuns.mockResolvedValue([{ id: 'r1', status: 'SUCCESS' }]);
-      const res = await controller.getStatus();
+    it('returns full bucket names + run dest bucket for OWNER', async () => {
+      service.getRecentRuns.mockResolvedValue([
+        { id: 'r1', status: 'SUCCESS', destBucket: 'dest-bkt' },
+      ]);
+      const res = await controller.getStatus(ownerUser);
       expect(res.enabled).toBe(true);
       expect(res.destBucket).toBe('dest-bkt');
-      expect(res.retentionDays).toBe(30);
       expect(res.sqlSourceBucket).toBe('sql-src');
-      expect(res.runs).toHaveLength(1);
+      expect(res.retentionDays).toBe(30);
+      expect(res.runs[0].destBucket).toBe('dest-bkt');
       expect(service.getRecentRuns).toHaveBeenCalledWith(7);
     });
 
+    it('strips bucket names from response when caller is not OWNER (W7)', async () => {
+      service.getRecentRuns.mockResolvedValue([
+        { id: 'r1', status: 'SUCCESS', destBucket: 'dest-bkt' },
+      ]);
+      const res = await controller.getStatus(accountantUser);
+      expect(res.enabled).toBe(true);
+      expect(res.destBucket).toBeNull();
+      expect(res.sqlSourceBucket).toBeNull();
+      // retentionDays is policy not infra — non-sensitive
+      expect(res.retentionDays).toBe(30);
+      expect(res.runs[0].destBucket).toBeNull();
+    });
+
     it('clamps limit to [1, 30]', async () => {
-      await controller.getStatus('100');
+      await controller.getStatus(ownerUser, '100');
       expect(service.getRecentRuns).toHaveBeenLastCalledWith(7); // out-of-range → default 7
-      await controller.getStatus('15');
+      await controller.getStatus(ownerUser, '15');
       expect(service.getRecentRuns).toHaveBeenLastCalledWith(15);
-      await controller.getStatus('not-a-number');
+      await controller.getStatus(ownerUser, 'not-a-number');
       expect(service.getRecentRuns).toHaveBeenLastCalledWith(7);
     });
   });

--- a/apps/api/src/modules/backup/backup.controller.spec.ts
+++ b/apps/api/src/modules/backup/backup.controller.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BackupController } from './backup.controller';
+import { OffsiteBackupService } from './offsite-backup.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+
+describe('BackupController', () => {
+  let controller: BackupController;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let service: any;
+
+  beforeEach(async () => {
+    service = {
+      run: jest.fn(),
+      isEnabled: jest.fn().mockResolvedValue(true),
+      setEnabled: jest.fn(),
+      getRecentRuns: jest.fn().mockResolvedValue([]),
+      getDestBucket: jest.fn().mockReturnValue('dest-bkt'),
+      getRetentionDays: jest.fn().mockReturnValue(30),
+      getSqlSourceBucket: jest.fn().mockReturnValue('sql-src'),
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      controllers: [BackupController],
+      providers: [{ provide: OffsiteBackupService, useValue: service }],
+    })
+      // Bypass guards — JwtAuthGuard + RolesGuard wiring is validated by
+      // unit tests for those guards; we only care about controller logic here.
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = mod.get(BackupController);
+  });
+
+  describe('POST /backup/offsite-now', () => {
+    it('passes userId from CurrentUser to service.run as triggeredBy', async () => {
+      service.run.mockResolvedValue({
+        id: 'run-1',
+        status: 'SUCCESS',
+        filesCount: 3,
+        totalBytes: 1024,
+        durationMs: 1000,
+        startedAt: new Date(),
+        finishedAt: new Date(),
+      });
+      const res = await controller.triggerNow('user-uuid-123');
+      expect(service.run).toHaveBeenCalledWith('user-uuid-123');
+      expect(res.status).toBe('SUCCESS');
+      expect(res.filesCount).toBe(3);
+      expect(res.errorMessage).toBeNull();
+    });
+
+    it('falls back to "manual" when no user id present (e.g. service-account)', async () => {
+      service.run.mockResolvedValue({
+        id: 'run-2',
+        status: 'FAILED',
+        filesCount: 0,
+        totalBytes: 0,
+        durationMs: 50,
+        startedAt: new Date(),
+        finishedAt: new Date(),
+        errorMessage: 'boom',
+      });
+      const res = await controller.triggerNow('');
+      expect(service.run).toHaveBeenCalledWith('manual');
+      expect(res.errorMessage).toBe('boom');
+    });
+  });
+
+  describe('GET /backup/offsite-status', () => {
+    it('returns enabled flag, config, and recent runs', async () => {
+      service.getRecentRuns.mockResolvedValue([{ id: 'r1', status: 'SUCCESS' }]);
+      const res = await controller.getStatus();
+      expect(res.enabled).toBe(true);
+      expect(res.destBucket).toBe('dest-bkt');
+      expect(res.retentionDays).toBe(30);
+      expect(res.sqlSourceBucket).toBe('sql-src');
+      expect(res.runs).toHaveLength(1);
+      expect(service.getRecentRuns).toHaveBeenCalledWith(7);
+    });
+
+    it('clamps limit to [1, 30]', async () => {
+      await controller.getStatus('100');
+      expect(service.getRecentRuns).toHaveBeenLastCalledWith(7); // out-of-range → default 7
+      await controller.getStatus('15');
+      expect(service.getRecentRuns).toHaveBeenLastCalledWith(15);
+      await controller.getStatus('not-a-number');
+      expect(service.getRecentRuns).toHaveBeenLastCalledWith(7);
+    });
+  });
+
+  describe('PUT /backup/offsite-enabled', () => {
+    it('forwards boolean to service.setEnabled', async () => {
+      service.setEnabled.mockResolvedValue(true);
+      const res = await controller.setEnabled({ enabled: true });
+      expect(res.enabled).toBe(true);
+      expect(service.setEnabled).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/apps/api/src/modules/backup/backup.controller.ts
+++ b/apps/api/src/modules/backup/backup.controller.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Get, Post, Put, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { OffsiteBackupService } from './offsite-backup.service';
+import { ToggleOffsiteBackupDto } from './dto/toggle-offsite-backup.dto';
+
+/**
+ * Phase 3 SP2 — Backup controller.
+ *
+ * Three endpoints:
+ *   POST /backup/offsite-now      — manual trigger (OWNER)
+ *   GET  /backup/offsite-status   — history + current enabled state (OWNER/FM/ACC)
+ *   PUT  /backup/offsite-enabled  — flip toggle (OWNER)
+ *
+ * The status endpoint also returns metadata (destination bucket, retention
+ * days) that the Settings UI shows alongside the run history.
+ */
+@ApiTags('Backup')
+@ApiBearerAuth('JWT')
+@Controller('backup')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class BackupController {
+  constructor(private readonly service: OffsiteBackupService) {}
+
+  @Post('offsite-now')
+  @Roles('OWNER')
+  async triggerNow(@CurrentUser('id') userId: string) {
+    const result = await this.service.run(userId || 'manual');
+    return {
+      id: result.id,
+      status: result.status,
+      filesCount: result.filesCount,
+      totalBytes: result.totalBytes,
+      durationMs: result.durationMs,
+      errorMessage: result.errorMessage ?? null,
+    };
+  }
+
+  @Get('offsite-status')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  async getStatus(@Query('limit') limitRaw?: string) {
+    const parsed = limitRaw ? Number.parseInt(limitRaw, 10) : 7;
+    const limit = Number.isFinite(parsed) && parsed > 0 && parsed <= 30 ? parsed : 7;
+    const [runs, enabled] = await Promise.all([
+      this.service.getRecentRuns(limit),
+      this.service.isEnabled(),
+    ]);
+    return {
+      enabled,
+      destBucket: this.service.getDestBucket(),
+      retentionDays: this.service.getRetentionDays(),
+      sqlSourceBucket: this.service.getSqlSourceBucket(),
+      runs,
+    };
+  }
+
+  @Put('offsite-enabled')
+  @Roles('OWNER')
+  async setEnabled(@Body() dto: ToggleOffsiteBackupDto) {
+    const enabled = await this.service.setEnabled(dto.enabled);
+    return { enabled };
+  }
+}

--- a/apps/api/src/modules/backup/backup.controller.ts
+++ b/apps/api/src/modules/backup/backup.controller.ts
@@ -4,8 +4,17 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
-import { OffsiteBackupService } from './offsite-backup.service';
+import { OffsiteBackupService, type RecentRun } from './offsite-backup.service';
 import { ToggleOffsiteBackupDto } from './dto/toggle-offsite-backup.dto';
+import { AuditService } from '../audit/audit.service';
+
+/**
+ * Authenticated request principal — populated by JwtStrategy onto req.user.
+ */
+interface AuthUser {
+  id: string;
+  role: 'OWNER' | 'BRANCH_MANAGER' | 'FINANCE_MANAGER' | 'ACCOUNTANT' | 'SALES' | string;
+}
 
 /**
  * Phase 3 SP2 — Backup controller.
@@ -16,19 +25,42 @@ import { ToggleOffsiteBackupDto } from './dto/toggle-offsite-backup.dto';
  *   PUT  /backup/offsite-enabled  — flip toggle (OWNER)
  *
  * The status endpoint also returns metadata (destination bucket, retention
- * days) that the Settings UI shows alongside the run history.
+ * days) that the Settings UI shows alongside the run history. W7 fix:
+ * bucket names are masked for non-OWNER callers — FM/ACC don't need that
+ * level of infrastructure detail and exposing it risks reconnaissance.
  */
 @ApiTags('Backup')
 @ApiBearerAuth('JWT')
 @Controller('backup')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class BackupController {
-  constructor(private readonly service: OffsiteBackupService) {}
+  constructor(
+    private readonly service: OffsiteBackupService,
+    private readonly audit: AuditService,
+  ) {}
 
   @Post('offsite-now')
   @Roles('OWNER')
-  async triggerNow(@CurrentUser('id') userId: string) {
-    const result = await this.service.run(userId || 'manual');
+  async triggerNow(@CurrentUser() user: AuthUser) {
+    const result = await this.service.run({
+      triggeredBy: 'manual',
+      triggeredByUserId: user?.id ?? null,
+    });
+    // C2 — explicit audit log so the hash-chained AuditLog table captures
+    // who clicked "Run Now" (the OffsiteBackupRun FK is a convenience join,
+    // not the legal audit trail).
+    await this.audit.log({
+      userId: user?.id,
+      action: 'OFFSITE_BACKUP_RUN_NOW',
+      entity: 'offsite_backup',
+      entityId: result.id,
+      newValue: {
+        status: result.status,
+        filesCount: result.filesCount,
+        totalBytes: result.totalBytes,
+        durationMs: result.durationMs,
+      },
+    });
     return {
       id: result.id,
       status: result.status,
@@ -41,19 +73,25 @@ export class BackupController {
 
   @Get('offsite-status')
   @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
-  async getStatus(@Query('limit') limitRaw?: string) {
+  async getStatus(@CurrentUser() user: AuthUser, @Query('limit') limitRaw?: string) {
     const parsed = limitRaw ? Number.parseInt(limitRaw, 10) : 7;
     const limit = Number.isFinite(parsed) && parsed > 0 && parsed <= 30 ? parsed : 7;
     const [runs, enabled] = await Promise.all([
       this.service.getRecentRuns(limit),
       this.service.isEnabled(),
     ]);
+    const isOwner = user?.role === 'OWNER';
     return {
       enabled,
-      destBucket: this.service.getDestBucket(),
+      // W7: only OWNER sees bucket names. FM/ACC need to see the audit
+      // trail + status, not the infrastructure config.
+      destBucket: isOwner ? this.service.getDestBucket() : null,
       retentionDays: this.service.getRetentionDays(),
-      sqlSourceBucket: this.service.getSqlSourceBucket(),
-      runs,
+      sqlSourceBucket: isOwner ? this.service.getSqlSourceBucket() : null,
+      runs: runs.map((r: RecentRun) => ({
+        ...r,
+        destBucket: isOwner ? r.destBucket : null,
+      })),
     };
   }
 

--- a/apps/api/src/modules/backup/backup.module.ts
+++ b/apps/api/src/modules/backup/backup.module.ts
@@ -3,19 +3,21 @@ import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from '../auth/auth.module';
 import { OffsiteBackupService } from './offsite-backup.service';
 import { OffsiteBackupCron } from './offsite-backup.cron';
+import { OffsiteBackupRetentionCron } from './offsite-backup-retention.cron';
 import { BackupController } from './backup.controller';
 
 /**
  * Phase 3 SP2 — Backup module.
  *
- * Provides the off-site replication service + cron + admin controller.
- * AuthModule is imported so JwtAuthGuard can resolve its strategy
- * dependencies for the controller.
+ * Provides the off-site replication service + replication cron + 1-year
+ * retention cron + admin controller. AuthModule is imported so
+ * JwtAuthGuard can resolve its strategy dependencies for the controller.
+ * AuditService is supplied by the global AuditModule.
  */
 @Module({
   imports: [ConfigModule, AuthModule],
   controllers: [BackupController],
-  providers: [OffsiteBackupService, OffsiteBackupCron],
+  providers: [OffsiteBackupService, OffsiteBackupCron, OffsiteBackupRetentionCron],
   exports: [OffsiteBackupService],
 })
 export class BackupModule {}

--- a/apps/api/src/modules/backup/backup.module.ts
+++ b/apps/api/src/modules/backup/backup.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AuthModule } from '../auth/auth.module';
+import { OffsiteBackupService } from './offsite-backup.service';
+import { OffsiteBackupCron } from './offsite-backup.cron';
+import { BackupController } from './backup.controller';
+
+/**
+ * Phase 3 SP2 — Backup module.
+ *
+ * Provides the off-site replication service + cron + admin controller.
+ * AuthModule is imported so JwtAuthGuard can resolve its strategy
+ * dependencies for the controller.
+ */
+@Module({
+  imports: [ConfigModule, AuthModule],
+  controllers: [BackupController],
+  providers: [OffsiteBackupService, OffsiteBackupCron],
+  exports: [OffsiteBackupService],
+})
+export class BackupModule {}

--- a/apps/api/src/modules/backup/dto/toggle-offsite-backup.dto.ts
+++ b/apps/api/src/modules/backup/dto/toggle-offsite-backup.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class ToggleOffsiteBackupDto {
+  @IsBoolean({ message: 'enabled ต้องเป็น boolean' })
+  enabled!: boolean;
+}

--- a/apps/api/src/modules/backup/offsite-backup-retention.cron.spec.ts
+++ b/apps/api/src/modules/backup/offsite-backup-retention.cron.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OffsiteBackupRetentionCron } from './offsite-backup-retention.cron';
+import { OffsiteBackupService } from './offsite-backup.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('OffsiteBackupRetentionCron (C3)', () => {
+  let cron: OffsiteBackupRetentionCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let service: any;
+
+  beforeEach(async () => {
+    service = { pruneOldRuns: jest.fn() };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        OffsiteBackupRetentionCron,
+        { provide: OffsiteBackupService, useValue: service },
+      ],
+    }).compile();
+    cron = mod.get(OffsiteBackupRetentionCron);
+  });
+
+  it('delegates to service.pruneOldRuns with 365-day window', async () => {
+    service.pruneOldRuns.mockResolvedValue(7);
+    const result = await cron.pruneOldRuns();
+    expect(service.pruneOldRuns).toHaveBeenCalledWith(365);
+    expect(result).toEqual({ pruned: 7 });
+  });
+
+  it('matches the documented retention constant (1 year)', () => {
+    expect(OffsiteBackupRetentionCron.RETENTION_DAYS).toBe(365);
+  });
+
+  it('swallows errors so the scheduler never crashes (still returns)', async () => {
+    service.pruneOldRuns.mockRejectedValue(new Error('db gone'));
+    const result = await cron.pruneOldRuns();
+    expect(result).toEqual({ pruned: 0 });
+  });
+});

--- a/apps/api/src/modules/backup/offsite-backup-retention.cron.ts
+++ b/apps/api/src/modules/backup/offsite-backup-retention.cron.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { OffsiteBackupService } from './offsite-backup.service';
+
+/**
+ * Phase 3 SP2 — DEEP review C3 — OffsiteBackupRun retention cron.
+ *
+ * Hard-deletes OffsiteBackupRun rows older than 1 year. Matches AuditLog
+ * retention policy + the model's "append-only event log" exception in
+ * database.md.
+ *
+ * Why this matters:
+ *   - Without retention the table grows ~30 rows/month — small per-month
+ *     but stale rows accumulate user UUIDs (PDPA-risk after the user is
+ *     soft-deleted).
+ *   - The original SP2 runbook claimed "stays small forever, no retention
+ *     cron". Fix Report v1.0 corrected the claim — see OFFSITE-BACKUP.md §9.
+ *
+ * Schedule: 02:00 BKK daily. Sits between AuditRetentionCron (Sun 03:00)
+ * and OffsiteBackupCron (03:30) so no scheduler contention.
+ */
+@Injectable()
+export class OffsiteBackupRetentionCron {
+  private readonly logger = new Logger(OffsiteBackupRetentionCron.name);
+  static readonly RETENTION_DAYS = 365;
+
+  constructor(private readonly service: OffsiteBackupService) {}
+
+  @Cron('0 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async pruneOldRuns(): Promise<{ pruned: number }> {
+    try {
+      const pruned = await this.service.pruneOldRuns(
+        OffsiteBackupRetentionCron.RETENTION_DAYS,
+      );
+      if (pruned > 0) {
+        Sentry.captureMessage(`offsite-backup retention pruned ${pruned} row(s)`, {
+          level: 'info',
+          tags: { kind: 'cron-job', cron: 'offsite-backup-retention' },
+          extra: { pruned, retentionDays: OffsiteBackupRetentionCron.RETENTION_DAYS },
+        });
+      }
+      return { pruned };
+    } catch (err) {
+      this.logger.error(
+        `offsite-backup retention failed: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'offsite-backup-retention' },
+      });
+      return { pruned: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/backup/offsite-backup.cron.ts
+++ b/apps/api/src/modules/backup/offsite-backup.cron.ts
@@ -1,0 +1,42 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { OffsiteBackupService } from './offsite-backup.service';
+
+/**
+ * Phase 3 SP2 — off-site backup cron.
+ *
+ * Runs daily at 03:30 Asia/Bangkok. Cloud SQL automated backups finish
+ * around 03:00 BKK, so 03:30 gives the export pipeline ~30 minutes to
+ * land the daily dump file before we try to replicate it.
+ *
+ * The actual replication logic lives in OffsiteBackupService. This cron
+ * is intentionally tiny — it just forwards to the service with
+ * `triggeredBy: 'cron'` and forwards exceptions to Sentry. The service
+ * already records a SKIPPED OffsiteBackupRun row when the toggle is off,
+ * so the cron never reads SystemConfig directly.
+ */
+@Injectable()
+export class OffsiteBackupCron {
+  private readonly logger = new Logger(OffsiteBackupCron.name);
+
+  constructor(private readonly service: OffsiteBackupService) {}
+
+  @Cron('30 3 * * *', { timeZone: 'Asia/Bangkok' })
+  async handleDaily(): Promise<void> {
+    try {
+      const result = await this.service.run('cron');
+      this.logger.log(
+        `offsite-backup cron tick: ${result.status} — ${result.filesCount} files / ${result.totalBytes}B / ${result.durationMs}ms`,
+      );
+    } catch (err) {
+      // The service itself already captures per-step errors. This is a
+      // last-ditch catch for an unexpected throw at the service boundary
+      // (e.g. PrismaClient unavailable). Never crash the scheduler.
+      this.logger.error(
+        `offsite-backup cron failed unexpectedly: ${(err as Error).message}`,
+      );
+      Sentry.captureException(err, { tags: { kind: 'cron-job', cron: 'offsite-backup' } });
+    }
+  }
+}

--- a/apps/api/src/modules/backup/offsite-backup.cron.ts
+++ b/apps/api/src/modules/backup/offsite-backup.cron.ts
@@ -22,17 +22,49 @@ export class OffsiteBackupCron {
 
   constructor(private readonly service: OffsiteBackupService) {}
 
+  /**
+   * W5 fix: emit a boot log line confirming the scheduler resolved the
+   * Asia/Bangkok zone. On node:20-alpine without `tzdata` installed,
+   * @nestjs/schedule silently falls back to UTC — this log lets ops
+   * verify the next planned tick during deploy smoke.
+   */
+  onModuleInit(): void {
+    const now = new Date();
+    const bkk = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Asia/Bangkok',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(now);
+    this.logger.log(
+      `OffsiteBackupCron scheduled '30 3 * * *' in Asia/Bangkok (current BKK: ${bkk}, UTC: ${now.toISOString()})`,
+    );
+  }
+
   @Cron('30 3 * * *', { timeZone: 'Asia/Bangkok' })
   async handleDaily(): Promise<void> {
     try {
-      const result = await this.service.run('cron');
+      const result = await this.service.run({ triggeredBy: 'cron' });
       this.logger.log(
         `offsite-backup cron tick: ${result.status} — ${result.filesCount} files / ${result.totalBytes}B / ${result.durationMs}ms`,
       );
     } catch (err) {
       // The service itself already captures per-step errors. This is a
       // last-ditch catch for an unexpected throw at the service boundary
-      // (e.g. PrismaClient unavailable). Never crash the scheduler.
+      // (e.g. PrismaClient unavailable, or another pod holds the advisory
+      // lock — ConflictException is expected when the cron + a manual run
+      // overlap; log it as a warning rather than an error).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const status = (err as any)?.status;
+      if (status === 409) {
+        this.logger.warn(
+          `offsite-backup cron: skipped tick — another run is already in progress`,
+        );
+        return;
+      }
       this.logger.error(
         `offsite-backup cron failed unexpectedly: ${(err as Error).message}`,
       );

--- a/apps/api/src/modules/backup/offsite-backup.service.spec.ts
+++ b/apps/api/src/modules/backup/offsite-backup.service.spec.ts
@@ -36,8 +36,12 @@ class FakeBucket {
     this.files = files;
     this.fileMap = new Map(files.map((f) => [f.name, f]));
   }
+  // Accepts the paginated form `{ prefix, autoPaginate, maxResults, pageToken }`
+  // — the production code passes `autoPaginate: false`. Returns
+  // `[files, nextQuery]` where nextQuery.pageToken is undefined for the
+  // single-page fake (no need to paginate fixture lists).
   getFiles = jest.fn(async ({ prefix }: { prefix: string }) => {
-    return [this.files.filter((f) => f.name.startsWith(prefix))];
+    return [this.files.filter((f) => f.name.startsWith(prefix)), null];
   });
   file = jest.fn((name: string) => {
     let f = this.fileMap.get(name);
@@ -87,7 +91,12 @@ describe('OffsiteBackupService', () => {
           return Promise.resolve({ id: args.where.id, ...args.data });
         }),
         findMany: jest.fn().mockResolvedValue([]),
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
+      // Default: advisory lock acquired. Individual tests can override
+      // with mockResolvedValueOnce({ acquired: false }) to simulate
+      // contention.
+      $queryRaw: jest.fn().mockResolvedValue([{ acquired: true }]),
     };
     config = {
       get: jest.fn((key: string) => {
@@ -144,7 +153,7 @@ describe('OffsiteBackupService', () => {
       const bucketMap: Record<string, FakeBucket> = {};
       service.setStorageClient(makeFakeStorage(bucketMap));
 
-      const result = await service.run('cron');
+      const result = await service.run({ triggeredBy: 'cron' });
       expect(result.status).toBe('SKIPPED');
       expect(result.filesCount).toBe(0);
       expect(createdRuns).toHaveLength(1);
@@ -175,7 +184,7 @@ describe('OffsiteBackupService', () => {
       };
       service.setStorageClient(makeFakeStorage(bucketMap));
 
-      const result = await service.run('cron');
+      const result = await service.run({ triggeredBy: 'cron' });
       expect(result.status).toBe('SUCCESS');
       expect(result.filesCount).toBe(2);
       expect(result.totalBytes).toBe(1024 + 512);
@@ -204,7 +213,7 @@ describe('OffsiteBackupService', () => {
         }),
       );
       // First run — populate dest
-      await service.run('cron');
+      await service.run({ triggeredBy: 'cron' });
       expect(sqlSrc.files[0].copy).toHaveBeenCalledTimes(1);
 
       // Set up the dest file as already existing with matching md5
@@ -215,7 +224,7 @@ describe('OffsiteBackupService', () => {
       sqlSrc.files[0].copy.mockClear();
 
       // Second run on same day — should skip
-      const result = await service.run('cron');
+      const result = await service.run({ triggeredBy: 'cron' });
       expect(sqlSrc.files[0].copy).not.toHaveBeenCalled();
       expect(result.status).toBe('SUCCESS');
     });
@@ -236,7 +245,7 @@ describe('OffsiteBackupService', () => {
           'dest-bkt': dest,
         }),
       );
-      const result = await service.run('cron');
+      const result = await service.run({ triggeredBy: 'cron' });
       expect(result.filesCount).toBe(1);
       expect(result.totalBytes).toBe(200);
       expect(docsSrc.files[0].copy).not.toHaveBeenCalled(); // old.pdf skipped
@@ -256,7 +265,7 @@ describe('OffsiteBackupService', () => {
           'dest-bkt': new FakeBucket(),
         }),
       );
-      const result = await service.run('cron');
+      const result = await service.run({ triggeredBy: 'cron' });
       expect(result.status).toBe('SUCCESS'); // run as a whole still succeeded
       expect(result.filesCount).toBe(1); // only f2 was counted
     });
@@ -276,7 +285,7 @@ describe('OffsiteBackupService', () => {
           'dest-bkt': dest,
         }),
       );
-      await service.run('cron');
+      await service.run({ triggeredBy: 'cron' });
       expect(dest.files[0].delete).toHaveBeenCalled(); // sql/old-dump
       expect(dest.files[1].delete).not.toHaveBeenCalled(); // sql/new-dump
       expect(dest.files[2].delete).toHaveBeenCalled(); // docs/old
@@ -294,7 +303,7 @@ describe('OffsiteBackupService', () => {
       service.setStorageClient(
         makeFakeStorage({ 'docs-src': docsSrc, 'dest-bkt': new FakeBucket() }),
       );
-      const result = await service.run('cron');
+      const result = await service.run({ triggeredBy: 'cron' });
       expect(result.status).toBe('SUCCESS');
       expect(result.filesCount).toBe(0);
     });
@@ -307,7 +316,7 @@ describe('OffsiteBackupService', () => {
         }),
       } as unknown as Parameters<OffsiteBackupService['setStorageClient']>[0];
       service.setStorageClient(broken);
-      const result = await service.run('manual');
+      const result = await service.run({ triggeredBy: 'manual', triggeredByUserId: 'u1' });
       expect(result.status).toBe('FAILED');
       expect(result.errorMessage).toContain('ADC unavailable');
       expect(updatedRuns[0].data.status).toBe('FAILED');
@@ -340,6 +349,8 @@ describe('OffsiteBackupService', () => {
           totalBytes: BigInt(1024),
           errorMessage: null,
           triggeredBy: 'cron',
+          triggeredByUserId: null,
+          triggeredByUser: null,
           destBucket: 'dest-bkt',
         },
       ];
@@ -347,9 +358,157 @@ describe('OffsiteBackupService', () => {
       const result = await service.getRecentRuns(7);
       expect(result).toHaveLength(1);
       expect(result[0].totalBytes).toBe(1024);
+      expect(result[0].triggeredBy).toBe('cron');
+      expect(result[0].triggeredByUser).toBeNull();
       expect(prisma.offsiteBackupRun.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ take: 7, orderBy: { startedAt: 'desc' } }),
+        expect.objectContaining({
+          take: 7,
+          orderBy: { startedAt: 'desc' },
+          include: expect.objectContaining({
+            triggeredByUser: { select: { id: true, name: true, email: true } },
+          }),
+        }),
       );
+    });
+
+    it('joins the manual-trigger user so UI can show name (C2 fix)', async () => {
+      const rows = [
+        {
+          id: 'r2',
+          startedAt: new Date(),
+          finishedAt: new Date(),
+          status: 'SUCCESS',
+          filesCount: 1,
+          totalBytes: BigInt(1),
+          errorMessage: null,
+          triggeredBy: 'manual',
+          triggeredByUserId: 'u-1',
+          triggeredByUser: { id: 'u-1', name: 'Owner Account', email: 'owner@example.com' },
+          destBucket: 'dest-bkt',
+        },
+      ];
+      prisma.offsiteBackupRun.findMany.mockResolvedValue(rows);
+      const result = await service.getRecentRuns(7);
+      expect(result[0].triggeredBy).toBe('manual');
+      expect(result[0].triggeredByUser).toEqual({ id: 'u-1', name: 'Owner Account' });
+    });
+  });
+
+  describe('advisory lock (C1)', () => {
+    beforeEach(() => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+      service.setStorageClient(
+        makeFakeStorage({
+          'sql-src': new FakeBucket(),
+          'docs-src': new FakeBucket(),
+          'dest-bkt': new FakeBucket(),
+        }),
+      );
+    });
+
+    it('throws ConflictException when another run already holds the lock', async () => {
+      // First $queryRaw call (lock acquire) returns acquired: false.
+      prisma.$queryRaw.mockReset();
+      prisma.$queryRaw.mockResolvedValueOnce([{ acquired: false }]);
+
+      await expect(service.run({ triggeredBy: 'cron' })).rejects.toMatchObject({
+        status: 409,
+        message: expect.stringContaining('สำรองข้อมูลกำลังทำงานอยู่'),
+      });
+      // No run row should have been created when lock was rejected.
+      expect(createdRuns).toHaveLength(0);
+    });
+
+    it('releases the lock after a successful run', async () => {
+      prisma.$queryRaw.mockReset();
+      prisma.$queryRaw
+        .mockResolvedValueOnce([{ acquired: true }]) // acquire
+        .mockResolvedValueOnce([{ pg_advisory_unlock: true }]); // release
+
+      const result = await service.run({ triggeredBy: 'cron' });
+      expect(result.status).toBe('SUCCESS');
+      // Acquire + release were both called.
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
+    });
+
+    it('still releases the lock when the run throws mid-flight', async () => {
+      prisma.$queryRaw.mockReset();
+      prisma.$queryRaw
+        .mockResolvedValueOnce([{ acquired: true }])
+        .mockResolvedValueOnce([{ pg_advisory_unlock: true }]);
+      const broken = {
+        bucket: jest.fn(() => {
+          throw new Error('boom');
+        }),
+      } as unknown as Parameters<OffsiteBackupService['setStorageClient']>[0];
+      service.setStorageClient(broken);
+      const result = await service.run({ triggeredBy: 'cron' });
+      // Run reports FAILED but lock release still ran (2 $queryRaw calls).
+      expect(result.status).toBe('FAILED');
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('triggeredByUserId persistence (C2)', () => {
+    beforeEach(() => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+      service.setStorageClient(
+        makeFakeStorage({
+          'sql-src': new FakeBucket(),
+          'docs-src': new FakeBucket(),
+          'dest-bkt': new FakeBucket(),
+        }),
+      );
+    });
+
+    it('persists triggeredBy=cron + triggeredByUserId=null for scheduler runs', async () => {
+      await service.run({ triggeredBy: 'cron' });
+      expect(createdRuns[0]).toMatchObject({
+        status: 'RUNNING',
+        triggeredBy: 'cron',
+        triggeredByUserId: null,
+      });
+    });
+
+    it('persists triggeredBy=manual + triggeredByUserId=<id> for manual runs', async () => {
+      await service.run({ triggeredBy: 'manual', triggeredByUserId: 'user-uuid-1' });
+      expect(createdRuns[0]).toMatchObject({
+        status: 'RUNNING',
+        triggeredBy: 'manual',
+        triggeredByUserId: 'user-uuid-1',
+      });
+    });
+
+    it('records SKIPPED rows with the same triggeredBy+userId split', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'false' });
+      await service.run({ triggeredBy: 'manual', triggeredByUserId: 'user-uuid-1' });
+      expect(createdRuns[0]).toMatchObject({
+        status: 'SKIPPED',
+        triggeredBy: 'manual',
+        triggeredByUserId: 'user-uuid-1',
+      });
+    });
+  });
+
+  describe('pruneOldRuns (C3 retention)', () => {
+    it('deletes rows older than the cutoff and returns the count', async () => {
+      prisma.offsiteBackupRun.deleteMany.mockResolvedValue({ count: 12 });
+      const result = await service.pruneOldRuns(365);
+      expect(result).toBe(12);
+      const call = prisma.offsiteBackupRun.deleteMany.mock.calls[0][0];
+      expect(call.where.startedAt.lt).toBeInstanceOf(Date);
+      // Cutoff is ~365 days back from now.
+      const expectedCutoff = Date.now() - 365 * 24 * 60 * 60 * 1000;
+      expect(Math.abs(call.where.startedAt.lt.getTime() - expectedCutoff)).toBeLessThan(5_000);
+    });
+  });
+
+  describe('setEnabled (W1)', () => {
+    it('revives a soft-deleted SystemConfig row by clearing deletedAt', async () => {
+      prisma.systemConfig.upsert.mockResolvedValue({});
+      await service.setEnabled(true);
+      const args = prisma.systemConfig.upsert.mock.calls[0][0];
+      expect(args.update).toMatchObject({ value: 'true', deletedAt: null });
     });
   });
 

--- a/apps/api/src/modules/backup/offsite-backup.service.spec.ts
+++ b/apps/api/src/modules/backup/offsite-backup.service.spec.ts
@@ -1,0 +1,378 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { OffsiteBackupService } from './offsite-backup.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+// Lightweight fakes for the bits of the GCS SDK we touch.
+type FakeFileMetadata = { md5Hash?: string; size?: string; updated?: string };
+class FakeFile {
+  metadata: FakeFileMetadata;
+  copy = jest.fn();
+  exists = jest.fn();
+  getMetadata = jest.fn();
+  delete = jest.fn();
+  constructor(
+    public name: string,
+    metadata: FakeFileMetadata = {},
+    public existsResult: boolean = false,
+    public existingMd5: string | undefined = undefined,
+  ) {
+    this.metadata = metadata;
+    this.copy.mockResolvedValue(undefined);
+    this.exists.mockResolvedValue([existsResult]);
+    this.getMetadata.mockResolvedValue([{ md5Hash: existingMd5 } as FakeFileMetadata]);
+    this.delete.mockResolvedValue(undefined);
+  }
+}
+class FakeBucket {
+  files: FakeFile[];
+  fileMap: Map<string, FakeFile>;
+  constructor(files: FakeFile[] = []) {
+    this.files = files;
+    this.fileMap = new Map(files.map((f) => [f.name, f]));
+  }
+  getFiles = jest.fn(async ({ prefix }: { prefix: string }) => {
+    return [this.files.filter((f) => f.name.startsWith(prefix))];
+  });
+  file = jest.fn((name: string) => {
+    let f = this.fileMap.get(name);
+    if (!f) {
+      f = new FakeFile(name);
+      this.fileMap.set(name, f);
+      this.files.push(f);
+    }
+    return f;
+  });
+}
+
+function makeFakeStorage(bucketMap: Record<string, FakeBucket>) {
+  return {
+    bucket: jest.fn((name: string) => {
+      if (!bucketMap[name]) bucketMap[name] = new FakeBucket();
+      return bucketMap[name];
+    }),
+  } as unknown as Parameters<OffsiteBackupService['setStorageClient']>[0];
+}
+
+describe('OffsiteBackupService', () => {
+  let service: OffsiteBackupService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let config: any;
+  // Captured copy of OffsiteBackupRun rows created during a run.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let createdRuns: any[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let updatedRuns: any[];
+
+  beforeEach(async () => {
+    createdRuns = [];
+    updatedRuns = [];
+    prisma = {
+      systemConfig: { findFirst: jest.fn().mockResolvedValue(null), upsert: jest.fn() },
+      offsiteBackupRun: {
+        create: jest.fn((args: { data: Record<string, unknown> }) => {
+          const row = { id: `run-${createdRuns.length + 1}`, ...args.data };
+          createdRuns.push(row);
+          return Promise.resolve(row);
+        }),
+        update: jest.fn((args: { where: { id: string }; data: Record<string, unknown> }) => {
+          updatedRuns.push(args);
+          return Promise.resolve({ id: args.where.id, ...args.data });
+        }),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+    config = {
+      get: jest.fn((key: string) => {
+        const env: Record<string, string> = {
+          OFFSITE_BACKUP_DEST_BUCKET: 'dest-bkt',
+          OFFSITE_BACKUP_SQL_PREFIX: 'cloudsql/',
+          OFFSITE_BACKUP_SQL_SOURCE_BUCKET: 'sql-src',
+          OFFSITE_BACKUP_RETENTION_DAYS: '30',
+          GCS_BUCKET: 'docs-src',
+        };
+        return env[key];
+      }),
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        OffsiteBackupService,
+        { provide: ConfigService, useValue: config },
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = mod.get(OffsiteBackupService);
+  });
+
+  describe('isEnabled', () => {
+    it('reads SystemConfig OFFSITE_BACKUP_ENABLED first', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+      await expect(service.isEnabled()).resolves.toBe(true);
+    });
+
+    it('SystemConfig false overrides env var', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'false' });
+      config.get.mockReturnValueOnce('true');
+      await expect(service.isEnabled()).resolves.toBe(false);
+    });
+
+    it('falls back to env var when SystemConfig absent', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue(null);
+      config.get.mockImplementation((k: string) =>
+        k === 'OFFSITE_BACKUP_ENABLED' ? 'true' : undefined,
+      );
+      await expect(service.isEnabled()).resolves.toBe(true);
+    });
+
+    it('defaults to false when neither source is set', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue(null);
+      config.get.mockReturnValue(undefined);
+      await expect(service.isEnabled()).resolves.toBe(false);
+    });
+  });
+
+  describe('run — disabled path', () => {
+    it('writes a SKIPPED row when disabled and does not touch GCS', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'false' });
+      const bucketMap: Record<string, FakeBucket> = {};
+      service.setStorageClient(makeFakeStorage(bucketMap));
+
+      const result = await service.run('cron');
+      expect(result.status).toBe('SKIPPED');
+      expect(result.filesCount).toBe(0);
+      expect(createdRuns).toHaveLength(1);
+      expect(createdRuns[0].status).toBe('SKIPPED');
+      expect(createdRuns[0].triggeredBy).toBe('cron');
+      expect(Object.keys(bucketMap)).toHaveLength(0); // never asked for a bucket
+    });
+  });
+
+  describe('run — enabled path', () => {
+    beforeEach(() => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+    });
+
+    it('copies new SQL dumps + recent docs and records a SUCCESS run row', async () => {
+      const sqlSrc = new FakeBucket([
+        new FakeFile('cloudsql/2026-05-18.sql.gz', { size: '1024', md5Hash: 'abc' }),
+      ]);
+      const recent = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const docsSrc = new FakeBucket([
+        new FakeFile('contracts/abc.pdf', { size: '512', md5Hash: 'd1', updated: recent }),
+      ]);
+      const dest = new FakeBucket();
+      const bucketMap: Record<string, FakeBucket> = {
+        'sql-src': sqlSrc,
+        'docs-src': docsSrc,
+        'dest-bkt': dest,
+      };
+      service.setStorageClient(makeFakeStorage(bucketMap));
+
+      const result = await service.run('cron');
+      expect(result.status).toBe('SUCCESS');
+      expect(result.filesCount).toBe(2);
+      expect(result.totalBytes).toBe(1024 + 512);
+      // Each source file gets copied to the destination via copy(destFile)
+      expect(sqlSrc.files[0].copy).toHaveBeenCalledTimes(1);
+      expect(docsSrc.files[0].copy).toHaveBeenCalledTimes(1);
+      // RUNNING -> SUCCESS row writes
+      expect(createdRuns[0].status).toBe('RUNNING');
+      const finalUpdate = updatedRuns[0].data;
+      expect(finalUpdate.status).toBe('SUCCESS');
+      expect(finalUpdate.filesCount).toBe(2);
+      expect(finalUpdate.totalBytes).toBe(BigInt(1024 + 512));
+    });
+
+    it('idempotent — skips files whose dest md5 matches the source', async () => {
+      const sqlSrc = new FakeBucket([
+        new FakeFile('cloudsql/2026-05-18.sql.gz', { size: '1024', md5Hash: 'abc' }),
+      ]);
+      const docsSrc = new FakeBucket();
+      const dest = new FakeBucket();
+      service.setStorageClient(
+        makeFakeStorage({
+          'sql-src': sqlSrc,
+          'docs-src': docsSrc,
+          'dest-bkt': dest,
+        }),
+      );
+      // First run — populate dest
+      await service.run('cron');
+      expect(sqlSrc.files[0].copy).toHaveBeenCalledTimes(1);
+
+      // Set up the dest file as already existing with matching md5
+      const destFile = dest.fileMap.get('sql/2026-05-18.sql.gz');
+      expect(destFile).toBeDefined();
+      destFile!.exists.mockResolvedValue([true]);
+      destFile!.getMetadata.mockResolvedValue([{ md5Hash: 'abc' }]);
+      sqlSrc.files[0].copy.mockClear();
+
+      // Second run on same day — should skip
+      const result = await service.run('cron');
+      expect(sqlSrc.files[0].copy).not.toHaveBeenCalled();
+      expect(result.status).toBe('SUCCESS');
+    });
+
+    it('skips docs older than the 26h lookback window', async () => {
+      const sqlSrc = new FakeBucket();
+      const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+      const fresh = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const docsSrc = new FakeBucket([
+        new FakeFile('contracts/old.pdf', { size: '100', md5Hash: 'old', updated: old }),
+        new FakeFile('contracts/new.pdf', { size: '200', md5Hash: 'new', updated: fresh }),
+      ]);
+      const dest = new FakeBucket();
+      service.setStorageClient(
+        makeFakeStorage({
+          'sql-src': sqlSrc,
+          'docs-src': docsSrc,
+          'dest-bkt': dest,
+        }),
+      );
+      const result = await service.run('cron');
+      expect(result.filesCount).toBe(1);
+      expect(result.totalBytes).toBe(200);
+      expect(docsSrc.files[0].copy).not.toHaveBeenCalled(); // old.pdf skipped
+      expect(docsSrc.files[1].copy).toHaveBeenCalledTimes(1); // new.pdf copied
+    });
+
+    it('continues replicating when one file copy fails (per-file fault tolerance)', async () => {
+      const fresh = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const f1 = new FakeFile('docs/a.pdf', { size: '100', md5Hash: '1', updated: fresh });
+      const f2 = new FakeFile('docs/b.pdf', { size: '200', md5Hash: '2', updated: fresh });
+      f1.copy.mockRejectedValueOnce(new Error('quota exceeded'));
+      const docsSrc = new FakeBucket([f1, f2]);
+      service.setStorageClient(
+        makeFakeStorage({
+          'sql-src': new FakeBucket(),
+          'docs-src': docsSrc,
+          'dest-bkt': new FakeBucket(),
+        }),
+      );
+      const result = await service.run('cron');
+      expect(result.status).toBe('SUCCESS'); // run as a whole still succeeded
+      expect(result.filesCount).toBe(1); // only f2 was counted
+    });
+
+    it('deletes destination objects older than retentionDays during cleanup', async () => {
+      const veryOld = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+      const recent = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+      const dest = new FakeBucket([
+        new FakeFile('sql/old-dump.sql.gz', { updated: veryOld }),
+        new FakeFile('sql/new-dump.sql.gz', { updated: recent }),
+        new FakeFile('docs/old.pdf', { updated: veryOld }),
+      ]);
+      service.setStorageClient(
+        makeFakeStorage({
+          'sql-src': new FakeBucket(),
+          'docs-src': new FakeBucket(),
+          'dest-bkt': dest,
+        }),
+      );
+      await service.run('cron');
+      expect(dest.files[0].delete).toHaveBeenCalled(); // sql/old-dump
+      expect(dest.files[1].delete).not.toHaveBeenCalled(); // sql/new-dump
+      expect(dest.files[2].delete).toHaveBeenCalled(); // docs/old
+    });
+
+    it('skips SQL step gracefully when OFFSITE_BACKUP_SQL_SOURCE_BUCKET is unset', async () => {
+      config.get.mockImplementation((k: string) => {
+        const env: Record<string, string> = {
+          OFFSITE_BACKUP_DEST_BUCKET: 'dest-bkt',
+          GCS_BUCKET: 'docs-src',
+        };
+        return env[k];
+      });
+      const docsSrc = new FakeBucket();
+      service.setStorageClient(
+        makeFakeStorage({ 'docs-src': docsSrc, 'dest-bkt': new FakeBucket() }),
+      );
+      const result = await service.run('cron');
+      expect(result.status).toBe('SUCCESS');
+      expect(result.filesCount).toBe(0);
+    });
+
+    it('records a FAILED run when an unexpected error escapes the replication step', async () => {
+      // Make getStorage().bucket throw to simulate ADC error.
+      const broken = {
+        bucket: jest.fn(() => {
+          throw new Error('ADC unavailable');
+        }),
+      } as unknown as Parameters<OffsiteBackupService['setStorageClient']>[0];
+      service.setStorageClient(broken);
+      const result = await service.run('manual');
+      expect(result.status).toBe('FAILED');
+      expect(result.errorMessage).toContain('ADC unavailable');
+      expect(updatedRuns[0].data.status).toBe('FAILED');
+    });
+  });
+
+  describe('setEnabled', () => {
+    it('upserts SystemConfig and returns the new value', async () => {
+      prisma.systemConfig.upsert.mockResolvedValue({});
+      const result = await service.setEnabled(true);
+      expect(result).toBe(true);
+      expect(prisma.systemConfig.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { key: 'OFFSITE_BACKUP_ENABLED' },
+          update: expect.objectContaining({ value: 'true' }),
+        }),
+      );
+    });
+  });
+
+  describe('getRecentRuns', () => {
+    it('returns the most recent N rows ordered desc and converts BigInt to Number', async () => {
+      const rows = [
+        {
+          id: 'r1',
+          startedAt: new Date(),
+          finishedAt: new Date(),
+          status: 'SUCCESS',
+          filesCount: 5,
+          totalBytes: BigInt(1024),
+          errorMessage: null,
+          triggeredBy: 'cron',
+          destBucket: 'dest-bkt',
+        },
+      ];
+      prisma.offsiteBackupRun.findMany.mockResolvedValue(rows);
+      const result = await service.getRecentRuns(7);
+      expect(result).toHaveLength(1);
+      expect(result[0].totalBytes).toBe(1024);
+      expect(prisma.offsiteBackupRun.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 7, orderBy: { startedAt: 'desc' } }),
+      );
+    });
+  });
+
+  describe('config getters', () => {
+    it('getDestBucket falls back to default name when env unset', () => {
+      config.get.mockReturnValue(undefined);
+      expect(service.getDestBucket()).toBe('bestchoice-backups-offsite');
+    });
+
+    it('getSqlPrefix appends trailing slash when missing', () => {
+      config.get.mockImplementation((k: string) =>
+        k === 'OFFSITE_BACKUP_SQL_PREFIX' ? 'cloudsql' : undefined,
+      );
+      expect(service.getSqlPrefix()).toBe('cloudsql/');
+    });
+
+    it('getRetentionDays defaults to 30 when env unset / invalid', () => {
+      config.get.mockReturnValue(undefined);
+      expect(service.getRetentionDays()).toBe(30);
+      config.get.mockReturnValue('not-a-number');
+      expect(service.getRetentionDays()).toBe(30);
+      config.get.mockReturnValue('60');
+      expect(service.getRetentionDays()).toBe(60);
+    });
+  });
+});

--- a/apps/api/src/modules/backup/offsite-backup.service.ts
+++ b/apps/api/src/modules/backup/offsite-backup.service.ts
@@ -1,0 +1,448 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Storage as GcsStorage, type Bucket, type File as GcsFile } from '@google-cloud/storage';
+import * as Sentry from '@sentry/nestjs';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Phase 3 SP2 — Off-site backup replication service.
+ *
+ * Mirrors two data sets from the in-region primary GCS buckets to a single
+ * cross-region "off-site" bucket so a regional outage or accidental mass
+ * delete on the primary cannot wipe out our recoverable evidence:
+ *
+ *   1. Cloud SQL daily SQL dumps  — copied into `sql/YYYY-MM-DD.sql.gz`
+ *   2. Document bucket diff       — last-24h files copied into `docs/<path>`
+ *
+ * Then prunes anything older than the retention window (default 30d) under
+ * those two prefixes only — never touches anything outside the two prefixes
+ * in case ops keeps non-replication artifacts in the same bucket.
+ *
+ * Design notes:
+ * - Idempotent: re-running the same day re-checks each file's md5 against
+ *   the existing object in the off-site bucket and skips identical copies.
+ *   A retry after a partial failure never duplicates data.
+ * - Single Storage client instance — credentials resolved by Application
+ *   Default Credentials on Cloud Run (no secrets needed).
+ * - Skipped vs disabled vs failed are distinct OffsiteBackupStatus values
+ *   so the UI history can show why a run is missing.
+ * - Errors during per-file copy are logged + counted but do not abort the
+ *   whole run — partial replication is more valuable than no replication.
+ * - Every run writes one row to OffsiteBackupRun (RUNNING → SUCCESS/FAILED).
+ *
+ * Hard constraints (from spec):
+ * - Buckets and IAM are owner-managed deliverables — this service does
+ *   NOT auto-create buckets or grant permissions.
+ * - Off-site bucket is configured via OFFSITE_BACKUP_DEST_BUCKET.
+ * - Source SQL prefix configurable via OFFSITE_BACKUP_SQL_PREFIX
+ *   (Cloud SQL exports go into a per-instance backup bucket; the prefix
+ *   may legitimately vary across environments).
+ */
+@Injectable()
+export class OffsiteBackupService {
+  private readonly logger = new Logger(OffsiteBackupService.name);
+  private gcs: GcsStorage | null = null;
+  /** Lookup window for the "last 24h" document slice — buffer for clock drift. */
+  static readonly DOCS_LOOKBACK_MS = 26 * 60 * 60 * 1000;
+  /** Cap error message field at 1000 chars (text column, no point storing full stack). */
+  static readonly ERROR_TRUNC_CHARS = 1000;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * Lazy-init the GCS client. Skipped in tests (which inject a fake via
+   * setStorageClient) and on environments without ADC.
+   */
+  private getStorage(): GcsStorage {
+    if (!this.gcs) {
+      this.gcs = new GcsStorage();
+    }
+    return this.gcs;
+  }
+
+  /** Test seam — replaces the lazy GCS client before run(). */
+  setStorageClient(client: GcsStorage): void {
+    this.gcs = client;
+  }
+
+  /**
+   * Resolve the enabled toggle. SystemConfig key wins, env var falls back.
+   * Returns `false` when neither source explicitly sets `true`.
+   *
+   * SystemConfig is read directly via PrismaService to avoid a SettingsModule
+   * dependency (this module is meant to be tiny and isolated).
+   */
+  async isEnabled(): Promise<boolean> {
+    try {
+      const row = await this.prisma.systemConfig.findFirst({
+        where: { key: 'OFFSITE_BACKUP_ENABLED', deletedAt: null },
+        select: { value: true },
+      });
+      if (row?.value) {
+        const v = row.value.trim().toLowerCase();
+        if (v === 'true' || v === '1') return true;
+        if (v === 'false' || v === '0') return false;
+      }
+    } catch {
+      // ignore — fall through to env
+    }
+    const env = (this.config.get<string>('OFFSITE_BACKUP_ENABLED') || '').trim().toLowerCase();
+    return env === 'true' || env === '1';
+  }
+
+  /**
+   * Manually toggle the SystemConfig flag (used by SettingsService /
+   * controller endpoint). Returns the new effective value.
+   */
+  async setEnabled(enabled: boolean): Promise<boolean> {
+    await this.prisma.systemConfig.upsert({
+      where: { key: 'OFFSITE_BACKUP_ENABLED' },
+      update: { value: enabled ? 'true' : 'false', updatedAt: new Date() },
+      create: {
+        key: 'OFFSITE_BACKUP_ENABLED',
+        value: enabled ? 'true' : 'false',
+        label: 'Off-site backup cron enabled',
+      },
+    });
+    return enabled;
+  }
+
+  getDestBucket(): string {
+    return (
+      this.config.get<string>('OFFSITE_BACKUP_DEST_BUCKET') || 'bestchoice-backups-offsite'
+    );
+  }
+
+  getSqlPrefix(): string {
+    const raw = (this.config.get<string>('OFFSITE_BACKUP_SQL_PREFIX') || 'cloudsql-backups/').trim();
+    return raw.endsWith('/') ? raw : `${raw}/`;
+  }
+
+  getRetentionDays(): number {
+    const raw = this.config.get<string>('OFFSITE_BACKUP_RETENTION_DAYS');
+    if (raw) {
+      const n = Number.parseInt(raw, 10);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+    return 30;
+  }
+
+  getSourceDocsBucket(): string {
+    return this.config.get<string>('GCS_BUCKET') || 'bestchoice-documents';
+  }
+
+  /**
+   * The Cloud SQL automated backup machinery writes daily SQL dumps into a
+   * source bucket (separate from the document bucket). We don't auto-create
+   * this — ops sets OFFSITE_BACKUP_SQL_SOURCE_BUCKET. If unset, we skip the
+   * SQL replication step entirely (still replicate docs).
+   */
+  getSqlSourceBucket(): string | null {
+    return this.config.get<string>('OFFSITE_BACKUP_SQL_SOURCE_BUCKET') || null;
+  }
+
+  /**
+   * Main entry point — runs the full replication cycle and writes a
+   * RunOffsiteBackupResult to OffsiteBackupRun.
+   *
+   * `triggeredBy` is stored on the run row for forensics. Pass 'cron' from
+   * the scheduler, 'manual' / userId from the controller.
+   */
+  async run(triggeredBy: string): Promise<OffsiteBackupRunResult> {
+    const startedAt = new Date();
+    const destBucket = this.getDestBucket();
+
+    // Pre-flight: enabled check
+    if (!(await this.isEnabled())) {
+      // We still record a SKIPPED row so the UI shows "we noticed the cron
+      // fired but it was disabled" rather than a silent gap in history.
+      const skipped = await this.prisma.offsiteBackupRun.create({
+        data: {
+          startedAt,
+          finishedAt: new Date(),
+          status: 'SKIPPED',
+          filesCount: 0,
+          totalBytes: BigInt(0),
+          triggeredBy,
+          destBucket,
+        },
+      });
+      this.logger.log(`offsite-backup skipped (OFFSITE_BACKUP_ENABLED=false): run ${skipped.id}`);
+      return {
+        id: skipped.id,
+        status: 'SKIPPED',
+        filesCount: 0,
+        totalBytes: 0,
+        durationMs: 0,
+        startedAt,
+        finishedAt: skipped.finishedAt,
+      };
+    }
+
+    // Reserve the run row in RUNNING state so even a hard crash leaves a trail.
+    const run = await this.prisma.offsiteBackupRun.create({
+      data: {
+        startedAt,
+        status: 'RUNNING',
+        triggeredBy,
+        destBucket,
+      },
+    });
+
+    let filesCount = 0;
+    let totalBytes = 0n;
+    let errorMessage: string | undefined;
+
+    try {
+      const storage = this.getStorage();
+      const dest = storage.bucket(destBucket);
+
+      // 1. SQL dumps
+      const sqlSource = this.getSqlSourceBucket();
+      if (sqlSource) {
+        const sqlPrefix = this.getSqlPrefix();
+        const sqlResult = await this.replicatePrefix({
+          source: storage.bucket(sqlSource),
+          sourcePrefix: sqlPrefix,
+          dest,
+          destPrefix: 'sql/',
+          modifiedSince: null, // replicate every dump that's not yet off-site
+        });
+        filesCount += sqlResult.filesCount;
+        totalBytes += sqlResult.totalBytes;
+      } else {
+        this.logger.warn(
+          'OFFSITE_BACKUP_SQL_SOURCE_BUCKET not set — SQL replication step skipped',
+        );
+      }
+
+      // 2. Document bucket — last 26h diff
+      const docsSource = this.getSourceDocsBucket();
+      const docsLookback = new Date(Date.now() - OffsiteBackupService.DOCS_LOOKBACK_MS);
+      const docsResult = await this.replicatePrefix({
+        source: storage.bucket(docsSource),
+        sourcePrefix: '',
+        dest,
+        destPrefix: 'docs/',
+        modifiedSince: docsLookback,
+      });
+      filesCount += docsResult.filesCount;
+      totalBytes += docsResult.totalBytes;
+
+      // 3. Cleanup — under both `sql/` and `docs/` only
+      const retentionDays = this.getRetentionDays();
+      const cleanupCutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+      await this.cleanupPrefix(dest, 'sql/', cleanupCutoff);
+      await this.cleanupPrefix(dest, 'docs/', cleanupCutoff);
+    } catch (err) {
+      errorMessage = this.truncErr(err);
+      this.logger.error(`offsite-backup failed: ${errorMessage}`);
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'offsite-backup' },
+        extra: { runId: run.id, triggeredBy, destBucket },
+      });
+    }
+
+    const finishedAt = new Date();
+    const durationMs = finishedAt.getTime() - startedAt.getTime();
+    const status: 'SUCCESS' | 'FAILED' = errorMessage ? 'FAILED' : 'SUCCESS';
+
+    await this.prisma.offsiteBackupRun.update({
+      where: { id: run.id },
+      data: {
+        finishedAt,
+        status,
+        filesCount,
+        totalBytes,
+        errorMessage,
+      },
+    });
+
+    this.logger.log(
+      `offsite-backup ${status}: run ${run.id} — ${filesCount} files / ${totalBytes}B / ${durationMs}ms`,
+    );
+    if (status === 'SUCCESS') {
+      Sentry.captureMessage(`offsite-backup replicated ${filesCount} files`, {
+        level: 'info',
+        tags: { kind: 'cron-job', cron: 'offsite-backup' },
+        extra: { runId: run.id, filesCount, totalBytes: totalBytes.toString(), durationMs },
+      });
+    }
+
+    return {
+      id: run.id,
+      status,
+      filesCount,
+      totalBytes: Number(totalBytes),
+      durationMs,
+      startedAt,
+      finishedAt,
+      errorMessage,
+    };
+  }
+
+  /**
+   * Stream-copy every object under `sourcePrefix` whose updated time falls
+   * after `modifiedSince` (or all of them, when null) into the destination
+   * bucket under `destPrefix`. Skips when the destination object already
+   * has the same md5 (idempotent re-run safety).
+   */
+  private async replicatePrefix(args: {
+    source: Bucket;
+    sourcePrefix: string;
+    dest: Bucket;
+    destPrefix: string;
+    modifiedSince: Date | null;
+  }): Promise<{ filesCount: number; totalBytes: bigint }> {
+    const { source, sourcePrefix, dest, destPrefix, modifiedSince } = args;
+    let filesCount = 0;
+    let totalBytes = 0n;
+
+    const [files] = await source.getFiles({ prefix: sourcePrefix });
+    for (const file of files) {
+      try {
+        if (modifiedSince && !this.isFileModifiedAfter(file, modifiedSince)) {
+          continue;
+        }
+        const relPath = file.name.startsWith(sourcePrefix)
+          ? file.name.slice(sourcePrefix.length)
+          : file.name;
+        const destName = `${destPrefix}${relPath}`;
+        const destFile = dest.file(destName);
+
+        // Idempotency: skip if dest already exists and md5 matches the source.
+        const [destExists] = await destFile.exists();
+        if (destExists) {
+          const [destMeta] = await destFile.getMetadata();
+          if (destMeta.md5Hash && file.metadata.md5Hash === destMeta.md5Hash) {
+            this.logger.debug(`offsite-backup skip (md5 match): ${destName}`);
+            continue;
+          }
+        }
+
+        await file.copy(destFile);
+        const size = this.parseSize(file.metadata.size);
+        filesCount++;
+        totalBytes += BigInt(size);
+        this.logger.debug(`offsite-backup copied: ${file.name} -> ${destName} (${size}B)`);
+      } catch (err) {
+        // Partial-failure semantics — log + Sentry + keep going on next file.
+        this.logger.warn(
+          `offsite-backup copy failed for ${file.name}: ${this.truncErr(err)}`,
+        );
+        Sentry.captureException(err, {
+          tags: { kind: 'cron-job', cron: 'offsite-backup', step: 'replicate' },
+          extra: { sourceFile: file.name, destPrefix },
+        });
+      }
+    }
+
+    return { filesCount, totalBytes };
+  }
+
+  /**
+   * Delete objects under `prefix` that haven't been updated since `cutoff`.
+   * Returns the deleted count.
+   */
+  private async cleanupPrefix(dest: Bucket, prefix: string, cutoff: Date): Promise<number> {
+    const [files] = await dest.getFiles({ prefix });
+    let deleted = 0;
+    for (const file of files) {
+      const updated = this.parseDate(file.metadata.updated);
+      if (updated && updated.getTime() < cutoff.getTime()) {
+        try {
+          await file.delete({ ignoreNotFound: true });
+          deleted++;
+          this.logger.debug(`offsite-backup cleanup deleted: ${file.name}`);
+        } catch (err) {
+          this.logger.warn(
+            `offsite-backup cleanup failed for ${file.name}: ${this.truncErr(err)}`,
+          );
+          Sentry.captureException(err, {
+            tags: { kind: 'cron-job', cron: 'offsite-backup', step: 'cleanup' },
+            extra: { destFile: file.name },
+          });
+        }
+      }
+    }
+    if (deleted > 0) {
+      this.logger.log(`offsite-backup cleanup: deleted ${deleted} object(s) under ${prefix}`);
+    }
+    return deleted;
+  }
+
+  private isFileModifiedAfter(file: GcsFile, after: Date): boolean {
+    const updated = this.parseDate(file.metadata.updated);
+    if (!updated) return true; // unknown — replicate, safer than skip
+    return updated.getTime() >= after.getTime();
+  }
+
+  private parseDate(raw: string | undefined | null): Date | null {
+    if (!raw) return null;
+    const d = new Date(raw);
+    return Number.isFinite(d.getTime()) ? d : null;
+  }
+
+  private parseSize(raw: string | number | undefined | null): number {
+    if (typeof raw === 'number') return raw;
+    if (typeof raw === 'string') {
+      const n = Number.parseInt(raw, 10);
+      return Number.isFinite(n) ? n : 0;
+    }
+    return 0;
+  }
+
+  private truncErr(err: unknown): string {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.length > OffsiteBackupService.ERROR_TRUNC_CHARS
+      ? `${msg.slice(0, OffsiteBackupService.ERROR_TRUNC_CHARS)}…`
+      : msg;
+  }
+
+  /**
+   * History endpoint backing — newest first.
+   */
+  async getRecentRuns(limit = 7): Promise<RecentRun[]> {
+    const rows = await this.prisma.offsiteBackupRun.findMany({
+      orderBy: { startedAt: 'desc' },
+      take: limit,
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      startedAt: r.startedAt,
+      finishedAt: r.finishedAt,
+      status: r.status,
+      filesCount: r.filesCount,
+      totalBytes: Number(r.totalBytes),
+      errorMessage: r.errorMessage,
+      triggeredBy: r.triggeredBy,
+      destBucket: r.destBucket,
+    }));
+  }
+}
+
+export interface OffsiteBackupRunResult {
+  id: string;
+  status: 'RUNNING' | 'SUCCESS' | 'FAILED' | 'SKIPPED';
+  filesCount: number;
+  totalBytes: number;
+  durationMs: number;
+  startedAt: Date;
+  finishedAt: Date | null;
+  errorMessage?: string;
+}
+
+export interface RecentRun {
+  id: string;
+  startedAt: Date;
+  finishedAt: Date | null;
+  status: 'RUNNING' | 'SUCCESS' | 'FAILED' | 'SKIPPED';
+  filesCount: number;
+  totalBytes: number;
+  errorMessage: string | null;
+  triggeredBy: string | null;
+  destBucket: string | null;
+}

--- a/apps/api/src/modules/backup/offsite-backup.service.ts
+++ b/apps/api/src/modules/backup/offsite-backup.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Storage as GcsStorage, type Bucket, type File as GcsFile } from '@google-cloud/storage';
 import * as Sentry from '@sentry/nestjs';
@@ -96,11 +96,20 @@ export class OffsiteBackupService {
   /**
    * Manually toggle the SystemConfig flag (used by SettingsService /
    * controller endpoint). Returns the new effective value.
+   *
+   * W1 fix: pass `deletedAt: null` on the update branch so a previously
+   * soft-deleted SystemConfig row is revived. Without this, isEnabled()
+   * would still return false (its WHERE clause filters `deletedAt: null`)
+   * and the toggle would silently no-op.
    */
   async setEnabled(enabled: boolean): Promise<boolean> {
     await this.prisma.systemConfig.upsert({
       where: { key: 'OFFSITE_BACKUP_ENABLED' },
-      update: { value: enabled ? 'true' : 'false', updatedAt: new Date() },
+      update: {
+        value: enabled ? 'true' : 'false',
+        updatedAt: new Date(),
+        deletedAt: null,
+      },
       create: {
         key: 'OFFSITE_BACKUP_ENABLED',
         value: enabled ? 'true' : 'false',
@@ -145,13 +154,67 @@ export class OffsiteBackupService {
   }
 
   /**
-   * Main entry point — runs the full replication cycle and writes a
-   * RunOffsiteBackupResult to OffsiteBackupRun.
+   * Cross-pod advisory lock key — `pg_try_advisory_lock(hashtext(...))`
+   * returns true only for the first caller to acquire it. Released either
+   * by `pg_advisory_unlock` or when the underlying connection closes.
    *
-   * `triggeredBy` is stored on the run row for forensics. Pass 'cron' from
-   * the scheduler, 'manual' / userId from the controller.
+   * Exposed as `static readonly` so tests can assert the same hash without
+   * coupling to the string literal.
    */
-  async run(triggeredBy: string): Promise<OffsiteBackupRunResult> {
+  static readonly ADVISORY_LOCK_KEY = 'offsite-backup';
+
+  /**
+   * Main entry point — runs the full replication cycle and writes one
+   * OffsiteBackupRun row.
+   *
+   * C1 fix: PostgreSQL advisory lock guards against concurrent runs.
+   *   - OWNER click + scheduled cron firing within the same minute
+   *   - 2 Cloud Run pods both firing the same cron tick
+   * Without the lock, both would replicate the same files and double-
+   * cleanup — md5 TOCTOU race, swallowed errors, unreliable history.
+   *
+   * C2 fix: triggeredBy is split into category ('cron'|'manual') +
+   * triggeredByUserId (real FK, NULL for cron). UI displays user name
+   * via the relation instead of `user:abcd1234` prefix.
+   *
+   * @throws ConflictException when another run already holds the lock.
+   */
+  async run(opts: OffsiteBackupRunOptions): Promise<OffsiteBackupRunResult> {
+    const { triggeredBy, triggeredByUserId = null } = opts;
+
+    // C1: try to acquire the advisory lock. pg_try_advisory_lock returns
+    // false (no wait) if someone else already holds it.
+    const lockResult = await this.prisma.$queryRaw<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(hashtext(${OffsiteBackupService.ADVISORY_LOCK_KEY})) AS acquired
+    `;
+    if (!lockResult[0]?.acquired) {
+      this.logger.warn(
+        `offsite-backup: advisory lock already held — refusing concurrent run (triggeredBy=${triggeredBy})`,
+      );
+      throw new ConflictException(
+        'สำรองข้อมูลกำลังทำงานอยู่ — กรุณารอจนเสร็จ',
+      );
+    }
+
+    try {
+      return await this.runUnderLock({ triggeredBy, triggeredByUserId });
+    } finally {
+      // Always release. If the connection died, the lock auto-releases.
+      try {
+        await this.prisma.$queryRaw`
+          SELECT pg_advisory_unlock(hashtext(${OffsiteBackupService.ADVISORY_LOCK_KEY}))
+        `;
+      } catch (err) {
+        this.logger.warn(`offsite-backup: advisory unlock failed (non-fatal): ${this.truncErr(err)}`);
+      }
+    }
+  }
+
+  private async runUnderLock(opts: {
+    triggeredBy: 'cron' | 'manual';
+    triggeredByUserId: string | null;
+  }): Promise<OffsiteBackupRunResult> {
+    const { triggeredBy, triggeredByUserId } = opts;
     const startedAt = new Date();
     const destBucket = this.getDestBucket();
 
@@ -167,6 +230,7 @@ export class OffsiteBackupService {
           filesCount: 0,
           totalBytes: BigInt(0),
           triggeredBy,
+          triggeredByUserId,
           destBucket,
         },
       });
@@ -188,6 +252,7 @@ export class OffsiteBackupService {
         startedAt,
         status: 'RUNNING',
         triggeredBy,
+        triggeredByUserId,
         destBucket,
       },
     });
@@ -284,11 +349,20 @@ export class OffsiteBackupService {
     };
   }
 
+  /** GCS list-page size — capped to stay well under the per-pod memory budget. */
+  static readonly LIST_PAGE_SIZE = 1000;
+
   /**
    * Stream-copy every object under `sourcePrefix` whose updated time falls
    * after `modifiedSince` (or all of them, when null) into the destination
    * bucket under `destPrefix`. Skips when the destination object already
    * has the same md5 (idempotent re-run safety).
+   *
+   * W2 fix: pages through the source listing 1000 objects at a time. The
+   * previous single-call `getFiles({ prefix })` materialized every object
+   * descriptor into memory — on a 100GB document bucket (50k+ files) that
+   * was a ~250MB JS heap spike per run, risking OOM on Cloud Run's 512MB
+   * default. Memory now bounded to one page at a time.
    */
   private async replicatePrefix(args: {
     source: Bucket;
@@ -301,44 +375,79 @@ export class OffsiteBackupService {
     let filesCount = 0;
     let totalBytes = 0n;
 
-    const [files] = await source.getFiles({ prefix: sourcePrefix });
-    for (const file of files) {
-      try {
-        if (modifiedSince && !this.isFileModifiedAfter(file, modifiedSince)) {
-          continue;
-        }
-        const relPath = file.name.startsWith(sourcePrefix)
-          ? file.name.slice(sourcePrefix.length)
-          : file.name;
-        const destName = `${destPrefix}${relPath}`;
-        const destFile = dest.file(destName);
+    let pageToken: string | undefined;
+    do {
+      const listOpts = {
+        prefix: sourcePrefix,
+        autoPaginate: false,
+        maxResults: OffsiteBackupService.LIST_PAGE_SIZE,
+        pageToken,
+      };
+      // GCS SDK overloads return `[File[], Query | null, ApiResponse]` when
+      // called without a callback. Types lose the tuple shape across the
+      // union — cast through unknown for safety.
+      const [files, nextQuery] = (await source.getFiles(
+        listOpts as unknown as Parameters<Bucket['getFiles']>[0],
+      )) as unknown as [GcsFile[], { pageToken?: string } | null];
 
-        // Idempotency: skip if dest already exists and md5 matches the source.
-        const [destExists] = await destFile.exists();
-        if (destExists) {
-          const [destMeta] = await destFile.getMetadata();
-          if (destMeta.md5Hash && file.metadata.md5Hash === destMeta.md5Hash) {
-            this.logger.debug(`offsite-backup skip (md5 match): ${destName}`);
+      for (const file of files) {
+        try {
+          if (modifiedSince && !this.isFileModifiedAfter(file, modifiedSince)) {
             continue;
           }
-        }
+          const relPath = file.name.startsWith(sourcePrefix)
+            ? file.name.slice(sourcePrefix.length)
+            : file.name;
+          const destName = `${destPrefix}${relPath}`;
+          const destFile = dest.file(destName);
 
-        await file.copy(destFile);
-        const size = this.parseSize(file.metadata.size);
-        filesCount++;
-        totalBytes += BigInt(size);
-        this.logger.debug(`offsite-backup copied: ${file.name} -> ${destName} (${size}B)`);
-      } catch (err) {
-        // Partial-failure semantics — log + Sentry + keep going on next file.
-        this.logger.warn(
-          `offsite-backup copy failed for ${file.name}: ${this.truncErr(err)}`,
-        );
-        Sentry.captureException(err, {
-          tags: { kind: 'cron-job', cron: 'offsite-backup', step: 'replicate' },
-          extra: { sourceFile: file.name, destPrefix },
-        });
+          // Idempotency: skip if dest already exists and md5 matches the source.
+          const [destExists] = await destFile.exists();
+          if (destExists) {
+            const [destMeta] = await destFile.getMetadata();
+            if (destMeta.md5Hash && file.metadata.md5Hash === destMeta.md5Hash) {
+              this.logger.debug(`offsite-backup skip (md5 match): ${destName}`);
+              continue;
+            }
+          }
+
+          await file.copy(destFile);
+
+          // W6 fix: some GCS object types (e.g. composed objects, transcoded
+          // media) return `size` undefined on source — refresh from dest as
+          // a fallback rather than silently under-counting totalBytes.
+          let copiedBytes = this.parseSize(file.metadata.size);
+          if (copiedBytes === 0) {
+            try {
+              const [destMeta] = await destFile.getMetadata();
+              copiedBytes = this.parseSize(destMeta.size);
+            } catch {
+              // Already copied — metadata refresh failure shouldn't fail run.
+            }
+            if (copiedBytes === 0) {
+              this.logger.warn(
+                `offsite-backup: size=0 reported for ${file.name} after copy — totalBytes will under-count by this file`,
+              );
+            }
+          }
+
+          filesCount++;
+          totalBytes += BigInt(copiedBytes);
+          this.logger.debug(`offsite-backup copied: ${file.name} -> ${destName} (${copiedBytes}B)`);
+        } catch (err) {
+          // Partial-failure semantics — log + Sentry + keep going on next file.
+          this.logger.warn(
+            `offsite-backup copy failed for ${file.name}: ${this.truncErr(err)}`,
+          );
+          Sentry.captureException(err, {
+            tags: { kind: 'cron-job', cron: 'offsite-backup', step: 'replicate' },
+            extra: { sourceFile: file.name, destPrefix },
+          });
+        }
       }
-    }
+
+      pageToken = nextQuery?.pageToken ?? undefined;
+    } while (pageToken);
 
     return { filesCount, totalBytes };
   }
@@ -346,28 +455,46 @@ export class OffsiteBackupService {
   /**
    * Delete objects under `prefix` that haven't been updated since `cutoff`.
    * Returns the deleted count.
+   *
+   * W2 fix: pages through 1000 objects at a time — same memory bound as
+   * replicatePrefix.
    */
   private async cleanupPrefix(dest: Bucket, prefix: string, cutoff: Date): Promise<number> {
-    const [files] = await dest.getFiles({ prefix });
     let deleted = 0;
-    for (const file of files) {
-      const updated = this.parseDate(file.metadata.updated);
-      if (updated && updated.getTime() < cutoff.getTime()) {
-        try {
-          await file.delete({ ignoreNotFound: true });
-          deleted++;
-          this.logger.debug(`offsite-backup cleanup deleted: ${file.name}`);
-        } catch (err) {
-          this.logger.warn(
-            `offsite-backup cleanup failed for ${file.name}: ${this.truncErr(err)}`,
-          );
-          Sentry.captureException(err, {
-            tags: { kind: 'cron-job', cron: 'offsite-backup', step: 'cleanup' },
-            extra: { destFile: file.name },
-          });
+    let pageToken: string | undefined;
+    do {
+      const listOpts = {
+        prefix,
+        autoPaginate: false,
+        maxResults: OffsiteBackupService.LIST_PAGE_SIZE,
+        pageToken,
+      };
+      const [files, nextQuery] = (await dest.getFiles(
+        listOpts as unknown as Parameters<Bucket['getFiles']>[0],
+      )) as unknown as [GcsFile[], { pageToken?: string } | null];
+
+      for (const file of files) {
+        const updated = this.parseDate(file.metadata.updated);
+        if (updated && updated.getTime() < cutoff.getTime()) {
+          try {
+            await file.delete({ ignoreNotFound: true });
+            deleted++;
+            this.logger.debug(`offsite-backup cleanup deleted: ${file.name}`);
+          } catch (err) {
+            this.logger.warn(
+              `offsite-backup cleanup failed for ${file.name}: ${this.truncErr(err)}`,
+            );
+            Sentry.captureException(err, {
+              tags: { kind: 'cron-job', cron: 'offsite-backup', step: 'cleanup' },
+              extra: { destFile: file.name },
+            });
+          }
         }
       }
-    }
+
+      pageToken = nextQuery?.pageToken ?? undefined;
+    } while (pageToken);
+
     if (deleted > 0) {
       this.logger.log(`offsite-backup cleanup: deleted ${deleted} object(s) under ${prefix}`);
     }
@@ -403,12 +530,16 @@ export class OffsiteBackupService {
   }
 
   /**
-   * History endpoint backing — newest first.
+   * History endpoint backing — newest first. Joins the user that triggered
+   * a manual run so the UI can display a real name instead of a UUID slice.
    */
   async getRecentRuns(limit = 7): Promise<RecentRun[]> {
     const rows = await this.prisma.offsiteBackupRun.findMany({
       orderBy: { startedAt: 'desc' },
       take: limit,
+      include: {
+        triggeredByUser: { select: { id: true, name: true, email: true } },
+      },
     });
     return rows.map((r) => ({
       id: r.id,
@@ -419,9 +550,43 @@ export class OffsiteBackupService {
       totalBytes: Number(r.totalBytes),
       errorMessage: r.errorMessage,
       triggeredBy: r.triggeredBy,
+      triggeredByUser: r.triggeredByUser
+        ? { id: r.triggeredByUser.id, name: r.triggeredByUser.name }
+        : null,
       destBucket: r.destBucket,
     }));
   }
+
+  /**
+   * C3 fix — daily retention. Prunes OffsiteBackupRun rows older than
+   * `days` (default 365). Called by `OffsiteBackupRetentionCron` at
+   * 02:00 BKK; exposed as a method so tests can drive it without the
+   * scheduler.
+   *
+   * Hard-delete is correct here — these rows are pure operational logs
+   * (no legal evidence; the actual backup files live in GCS with their own
+   * lifecycle). Matches AuditLog 1-year policy + the model's
+   * "append-only event log" exception in database.md.
+   */
+  async pruneOldRuns(days = 365): Promise<number> {
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const result = await this.prisma.offsiteBackupRun.deleteMany({
+      where: { startedAt: { lt: cutoff } },
+    });
+    if (result.count > 0) {
+      this.logger.log(
+        `offsite-backup retention: pruned ${result.count} row(s) older than ${days}d`,
+      );
+    }
+    return result.count;
+  }
+}
+
+export interface OffsiteBackupRunOptions {
+  /** Always required — disambiguates whether the row came from a scheduler tick or a human button click. */
+  triggeredBy: 'cron' | 'manual';
+  /** When triggeredBy = 'manual', the OWNER who clicked "Run Now". Null for cron. */
+  triggeredByUserId?: string | null;
 }
 
 export interface OffsiteBackupRunResult {
@@ -443,6 +608,7 @@ export interface RecentRun {
   filesCount: number;
   totalBytes: number;
   errorMessage: string | null;
-  triggeredBy: string | null;
+  triggeredBy: string;
+  triggeredByUser: { id: string; name: string } | null;
   destBucket: string | null;
 }

--- a/apps/web/src/pages/SettingsPage/index.tsx
+++ b/apps/web/src/pages/SettingsPage/index.tsx
@@ -9,8 +9,9 @@ import { VatTab } from './tabs/VatTab';
 import { PeriodsTab } from './tabs/PeriodsTab';
 import { AttachmentTab } from './tabs/AttachmentTab';
 import { UsersTab } from './tabs/UsersTab';
+import { OffsiteBackupTab } from './tabs/OffsiteBackupTab';
 
-const TAB_IDS = ['company', 'vat', 'periods', 'attachment', 'users'] as const;
+const TAB_IDS = ['company', 'vat', 'periods', 'attachment', 'users', 'offsite-backup'] as const;
 type TabId = typeof TAB_IDS[number];
 
 function readHash(): TabId {
@@ -47,12 +48,13 @@ export default function SettingsPage() {
       <PageHeader title="ตั้งค่าระบบ" subtitle="กำหนดพารามิเตอร์การทำงานของระบบ" />
 
       <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabId)}>
-        <TabsList className="grid grid-cols-2 md:grid-cols-5 mb-4">
+        <TabsList className="grid grid-cols-2 md:grid-cols-6 mb-4">
           <TabsTrigger value="company">บริษัท</TabsTrigger>
           <TabsTrigger value="vat">VAT</TabsTrigger>
           <TabsTrigger value="periods">งวดบัญชี</TabsTrigger>
           <TabsTrigger value="attachment">เอกสารแนบ</TabsTrigger>
           <TabsTrigger value="users">ผู้ใช้งาน</TabsTrigger>
+          <TabsTrigger value="offsite-backup">สำรองข้อมูล</TabsTrigger>
         </TabsList>
 
         <TabsContent value="company"><CompanyTab /></TabsContent>
@@ -60,6 +62,7 @@ export default function SettingsPage() {
         <TabsContent value="periods"><PeriodsTab /></TabsContent>
         <TabsContent value="attachment"><AttachmentTab /></TabsContent>
         <TabsContent value="users"><UsersTab /></TabsContent>
+        <TabsContent value="offsite-backup"><OffsiteBackupTab /></TabsContent>
       </Tabs>
     </div>
   );

--- a/apps/web/src/pages/SettingsPage/tabs/OffsiteBackupTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/OffsiteBackupTab.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
 interface OffsiteBackupRun {
   id: string;
@@ -17,13 +18,14 @@ interface OffsiteBackupRun {
   filesCount: number;
   totalBytes: number;
   errorMessage: string | null;
-  triggeredBy: string | null;
+  triggeredBy: string;
+  triggeredByUser: { id: string; name: string } | null;
   destBucket: string | null;
 }
 
 interface OffsiteBackupStatus {
   enabled: boolean;
-  destBucket: string;
+  destBucket: string | null;
   retentionDays: number;
   sqlSourceBucket: string | null;
   runs: OffsiteBackupRun[];
@@ -64,13 +66,28 @@ function formatThaiDateTime(iso: string): string {
   });
 }
 
+function formatTrigger(run: OffsiteBackupRun): string {
+  if (run.triggeredBy === 'cron') return 'cron';
+  // W3/C2: prefer joined user name; fall back to category label (no UUID slice).
+  return run.triggeredByUser?.name || 'manual';
+}
+
 export function OffsiteBackupTab() {
   const queryClient = useQueryClient();
-  const [confirming, setConfirming] = useState(false);
+  // W4 — replaces 2-click toast confirm. Modal dialog before enabling.
+  const [showEnableConfirm, setShowEnableConfirm] = useState(false);
 
   const { data, isLoading } = useQuery<OffsiteBackupStatus>({
     queryKey: ['backup', 'offsite-status'],
     queryFn: async () => (await api.get('/backup/offsite-status')).data,
+    // W3 — auto-refresh every 5s while the topmost run is still RUNNING so
+    // the UI reflects progress without manual refresh. Once the top row
+    // leaves RUNNING the interval stops (returns false).
+    refetchInterval: (query) => {
+      const status = query.state.data as OffsiteBackupStatus | undefined;
+      const top = status?.runs?.[0];
+      return top?.status === 'RUNNING' ? 5_000 : false;
+    },
   });
 
   const toggleMutation = useMutation({
@@ -95,19 +112,33 @@ export function OffsiteBackupTab() {
         toast.error(`สำรองข้อมูลล้มเหลว: ${resp.errorMessage || 'ไม่ทราบสาเหตุ'}`);
       }
     },
+    // W3 — combined with server-side advisory lock (C1). A 409 ConflictException
+    // from concurrent runs (cron + manual click) surfaces here with a friendly
+    // Thai message instead of a generic axios error.
     onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   if (isLoading) {
-    return <p className="text-sm text-muted-foreground">กำลังโหลด...</p>;
+    return <p className="text-sm text-muted-foreground leading-snug">กำลังโหลด...</p>;
   }
 
   if (!data) {
-    return <p className="text-sm text-muted-foreground">ไม่สามารถโหลดสถานะได้</p>;
+    return <p className="text-sm text-muted-foreground leading-snug">ไม่สามารถโหลดสถานะได้</p>;
   }
 
   return (
     <div className="space-y-4">
+      <ConfirmDialog
+        open={showEnableConfirm}
+        onOpenChange={setShowEnableConfirm}
+        title="เปิดใช้งาน Off-site Backup?"
+        description="ต้องสร้าง destination bucket + grant IAM ก่อน — กรุณาตรวจสอบใน docs/guides/OFFSITE-BACKUP.md ก่อนเปิดใช้งาน"
+        confirmLabel="ยืนยัน"
+        cancelLabel="ยกเลิก"
+        loading={toggleMutation.isPending}
+        onConfirm={() => toggleMutation.mutate(true)}
+      />
+
       {/* Enable toggle + config */}
       <Card>
         <CardHeader>
@@ -124,7 +155,7 @@ export function OffsiteBackupTab() {
         <CardContent className="space-y-4">
           <div className="flex items-start justify-between gap-4 rounded-lg border border-border/60 bg-muted p-4">
             <div className="flex-1">
-              <p className="text-sm font-medium text-foreground">เปิดใช้งาน Off-site Backup</p>
+              <p className="text-sm font-medium text-foreground leading-snug">เปิดใช้งาน Off-site Backup</p>
               <p className="text-xs text-muted-foreground leading-snug mt-1">
                 เมื่อเปิดอยู่ cron จะรันทุกวัน 03:30 น. และเขียนประวัติการรันลงตาราง
                 ด้านล่าง — ก่อนเปิดต้องให้ owner สร้าง destination bucket
@@ -136,14 +167,13 @@ export function OffsiteBackupTab() {
               checked={data.enabled}
               disabled={toggleMutation.isPending}
               onCheckedChange={(v) => {
-                if (v && !confirming) {
-                  setConfirming(true);
-                  toast.warning('ยืนยันอีกครั้งเพื่อเปิดใช้งาน (กดอีกครั้ง)');
-                  setTimeout(() => setConfirming(false), 4000);
-                  return;
+                // W4 — modal confirm for ON (destructive surface);
+                // OFF is a one-click action.
+                if (v) {
+                  setShowEnableConfirm(true);
+                } else {
+                  toggleMutation.mutate(false);
                 }
-                setConfirming(false);
-                toggleMutation.mutate(v);
               }}
               aria-label="เปิดปิด Off-site Backup"
             />
@@ -151,22 +181,28 @@ export function OffsiteBackupTab() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <div className="rounded-lg bg-muted p-3">
-              <p className="text-xs text-muted-foreground">Destination Bucket</p>
-              <p className="text-sm font-mono text-foreground mt-1 break-all">{data.destBucket}</p>
+              <p className="text-xs text-muted-foreground leading-snug">Destination Bucket</p>
+              <p className="text-sm font-mono text-foreground mt-1 break-all">
+                {data.destBucket || <span className="text-muted-foreground italic">— ปกปิดสำหรับ role นี้</span>}
+              </p>
             </div>
             <div className="rounded-lg bg-muted p-3">
-              <p className="text-xs text-muted-foreground">ระยะเก็บข้อมูล (Retention)</p>
+              <p className="text-xs text-muted-foreground leading-snug">ระยะเก็บข้อมูล (Retention)</p>
               <p className="text-sm font-semibold text-foreground mt-1">{data.retentionDays} วัน</p>
             </div>
             <div className="rounded-lg bg-muted p-3">
-              <p className="text-xs text-muted-foreground">SQL Source Bucket</p>
+              <p className="text-xs text-muted-foreground leading-snug">SQL Source Bucket</p>
               <p className="text-sm font-mono text-foreground mt-1 break-all">
-                {data.sqlSourceBucket || <span className="text-muted-foreground italic">ไม่ได้ตั้งค่า (จะข้าม SQL replication)</span>}
+                {data.sqlSourceBucket === null ? (
+                  <span className="text-muted-foreground italic leading-snug">— ปกปิด / ไม่ได้ตั้งค่า</span>
+                ) : (
+                  data.sqlSourceBucket
+                )}
               </p>
             </div>
           </div>
 
-          {!data.sqlSourceBucket && (
+          {data.destBucket !== null && !data.sqlSourceBucket && (
             <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 p-3 text-sm">
               <ShieldAlert className="size-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
               <p className="text-amber-900 dark:text-amber-200 leading-snug">
@@ -201,7 +237,7 @@ export function OffsiteBackupTab() {
         </CardHeader>
         <CardContent>
           {data.runs.length === 0 ? (
-            <p className="text-sm text-muted-foreground">ยังไม่มีประวัติการสำรองข้อมูล</p>
+            <p className="text-sm text-muted-foreground leading-snug">ยังไม่มีประวัติการสำรองข้อมูล</p>
           ) : (
             <div className="overflow-x-auto">
               <Table>
@@ -228,10 +264,10 @@ export function OffsiteBackupTab() {
                         <TableCell className="text-right tabular-nums">{run.filesCount.toLocaleString('th-TH')}</TableCell>
                         <TableCell className="text-right tabular-nums">{formatBytes(run.totalBytes)}</TableCell>
                         <TableCell className="text-right tabular-nums">{formatDuration(run.startedAt, run.finishedAt)}</TableCell>
-                        <TableCell className="text-xs text-muted-foreground font-mono">
-                          {run.triggeredBy === 'cron' ? 'cron' : run.triggeredBy === 'manual' ? 'manual' : run.triggeredBy ? `user:${run.triggeredBy.slice(0, 8)}` : '-'}
+                        <TableCell className="text-xs text-muted-foreground leading-snug">
+                          {formatTrigger(run)}
                         </TableCell>
-                        <TableCell className="text-xs text-destructive max-w-[18rem] truncate" title={run.errorMessage || ''}>
+                        <TableCell className="text-xs text-destructive max-w-[18rem] truncate leading-snug" title={run.errorMessage || ''}>
                           {run.errorMessage || ''}
                         </TableCell>
                       </TableRow>

--- a/apps/web/src/pages/SettingsPage/tabs/OffsiteBackupTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/OffsiteBackupTab.tsx
@@ -1,0 +1,248 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Play, Database, ShieldAlert } from 'lucide-react';
+import api, { getErrorMessage } from '@/lib/api';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+interface OffsiteBackupRun {
+  id: string;
+  startedAt: string;
+  finishedAt: string | null;
+  status: 'RUNNING' | 'SUCCESS' | 'FAILED' | 'SKIPPED';
+  filesCount: number;
+  totalBytes: number;
+  errorMessage: string | null;
+  triggeredBy: string | null;
+  destBucket: string | null;
+}
+
+interface OffsiteBackupStatus {
+  enabled: boolean;
+  destBucket: string;
+  retentionDays: number;
+  sqlSourceBucket: string | null;
+  runs: OffsiteBackupRun[];
+}
+
+const STATUS_LABELS: Record<OffsiteBackupRun['status'], { label: string; variant: 'success' | 'destructive' | 'secondary' | 'outline' | 'info' }> = {
+  RUNNING: { label: 'กำลังทำงาน', variant: 'info' },
+  SUCCESS: { label: 'สำเร็จ', variant: 'success' },
+  FAILED: { label: 'ล้มเหลว', variant: 'destructive' },
+  SKIPPED: { label: 'ข้าม (ปิดอยู่)', variant: 'outline' },
+};
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return '-';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDuration(startedAt: string, finishedAt: string | null): string {
+  if (!finishedAt) return '-';
+  const ms = new Date(finishedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} วิ`;
+  return `${(ms / 60_000).toFixed(1)} นาที`;
+}
+
+function formatThaiDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('th-TH', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Bangkok',
+  });
+}
+
+export function OffsiteBackupTab() {
+  const queryClient = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
+
+  const { data, isLoading } = useQuery<OffsiteBackupStatus>({
+    queryKey: ['backup', 'offsite-status'],
+    queryFn: async () => (await api.get('/backup/offsite-status')).data,
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: async (enabled: boolean) =>
+      (await api.put('/backup/offsite-enabled', { enabled })).data,
+    onSuccess: (resp: { enabled: boolean }) => {
+      queryClient.invalidateQueries({ queryKey: ['backup', 'offsite-status'] });
+      toast.success(resp.enabled ? 'เปิด Off-site Backup แล้ว' : 'ปิด Off-site Backup แล้ว');
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const runNowMutation = useMutation({
+    mutationFn: async () => (await api.post('/backup/offsite-now')).data,
+    onSuccess: (resp: { status: string; filesCount: number; totalBytes: number; durationMs: number; errorMessage: string | null }) => {
+      queryClient.invalidateQueries({ queryKey: ['backup', 'offsite-status'] });
+      if (resp.status === 'SUCCESS') {
+        toast.success(`สำรองข้อมูลสำเร็จ — ${resp.filesCount} ไฟล์ / ${formatBytes(resp.totalBytes)} / ${(resp.durationMs / 1000).toFixed(1)} วิ`);
+      } else if (resp.status === 'SKIPPED') {
+        toast.warning('Off-site Backup ถูกปิดอยู่ — เปิดสวิตช์ก่อนแล้วลองอีกครั้ง');
+      } else {
+        toast.error(`สำรองข้อมูลล้มเหลว: ${resp.errorMessage || 'ไม่ทราบสาเหตุ'}`);
+      }
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">กำลังโหลด...</p>;
+  }
+
+  if (!data) {
+    return <p className="text-sm text-muted-foreground">ไม่สามารถโหลดสถานะได้</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Enable toggle + config */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Database className="size-5" />
+            Off-site Backup Replication
+          </CardTitle>
+          <CardDescription className="leading-snug">
+            สำเนาข้อมูลสำคัญ (Cloud SQL dumps + เอกสารใน GCS) ไปยัง bucket อีก
+            ภูมิภาคหนึ่งวันละครั้ง (03:30 น. ตามเวลาไทย) เพื่อป้องกันเหตุการณ์
+            ภูมิภาคหลักล่ม / ลบข้อมูลโดยไม่ตั้งใจ
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-start justify-between gap-4 rounded-lg border border-border/60 bg-muted p-4">
+            <div className="flex-1">
+              <p className="text-sm font-medium text-foreground">เปิดใช้งาน Off-site Backup</p>
+              <p className="text-xs text-muted-foreground leading-snug mt-1">
+                เมื่อเปิดอยู่ cron จะรันทุกวัน 03:30 น. และเขียนประวัติการรันลงตาราง
+                ด้านล่าง — ก่อนเปิดต้องให้ owner สร้าง destination bucket
+                และ grant สิทธิ์ให้ Cloud Run service account ก่อน
+                (ดู <code className="text-foreground">docs/guides/OFFSITE-BACKUP.md</code>)
+              </p>
+            </div>
+            <Switch
+              checked={data.enabled}
+              disabled={toggleMutation.isPending}
+              onCheckedChange={(v) => {
+                if (v && !confirming) {
+                  setConfirming(true);
+                  toast.warning('ยืนยันอีกครั้งเพื่อเปิดใช้งาน (กดอีกครั้ง)');
+                  setTimeout(() => setConfirming(false), 4000);
+                  return;
+                }
+                setConfirming(false);
+                toggleMutation.mutate(v);
+              }}
+              aria-label="เปิดปิด Off-site Backup"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <div className="rounded-lg bg-muted p-3">
+              <p className="text-xs text-muted-foreground">Destination Bucket</p>
+              <p className="text-sm font-mono text-foreground mt-1 break-all">{data.destBucket}</p>
+            </div>
+            <div className="rounded-lg bg-muted p-3">
+              <p className="text-xs text-muted-foreground">ระยะเก็บข้อมูล (Retention)</p>
+              <p className="text-sm font-semibold text-foreground mt-1">{data.retentionDays} วัน</p>
+            </div>
+            <div className="rounded-lg bg-muted p-3">
+              <p className="text-xs text-muted-foreground">SQL Source Bucket</p>
+              <p className="text-sm font-mono text-foreground mt-1 break-all">
+                {data.sqlSourceBucket || <span className="text-muted-foreground italic">ไม่ได้ตั้งค่า (จะข้าม SQL replication)</span>}
+              </p>
+            </div>
+          </div>
+
+          {!data.sqlSourceBucket && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 p-3 text-sm">
+              <ShieldAlert className="size-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+              <p className="text-amber-900 dark:text-amber-200 leading-snug">
+                ตั้งค่า <code>OFFSITE_BACKUP_SQL_SOURCE_BUCKET</code> เพื่อสำรอง SQL dump ด้วย
+                หากไม่ตั้ง จะมีเฉพาะเอกสาร (GCS) เท่านั้น
+              </p>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <Button
+              onClick={() => runNowMutation.mutate()}
+              disabled={runNowMutation.isPending}
+              variant="outline"
+              className="gap-2"
+            >
+              <Play className="size-4" />
+              {runNowMutation.isPending ? 'กำลังสำรอง...' : 'สำรองข้อมูลตอนนี้'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* History table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>ประวัติการสำรองข้อมูล (7 ครั้งล่าสุด)</CardTitle>
+          <CardDescription className="leading-snug">
+            แสดงการรันทั้งจาก cron และ manual trigger — รวมรอบที่ถูกข้ามเพราะ
+            Off-site Backup ปิดอยู่ ณ ขณะที่ cron ตื่น
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.runs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">ยังไม่มีประวัติการสำรองข้อมูล</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>เวลาเริ่ม</TableHead>
+                    <TableHead>สถานะ</TableHead>
+                    <TableHead className="text-right">ไฟล์</TableHead>
+                    <TableHead className="text-right">ขนาด</TableHead>
+                    <TableHead className="text-right">ระยะเวลา</TableHead>
+                    <TableHead>Trigger</TableHead>
+                    <TableHead>หมายเหตุ</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.runs.map((run) => {
+                    const status = STATUS_LABELS[run.status];
+                    return (
+                      <TableRow key={run.id}>
+                        <TableCell className="font-mono text-xs">{formatThaiDateTime(run.startedAt)}</TableCell>
+                        <TableCell>
+                          <Badge variant={status.variant}>{status.label}</Badge>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">{run.filesCount.toLocaleString('th-TH')}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatBytes(run.totalBytes)}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatDuration(run.startedAt, run.finishedAt)}</TableCell>
+                        <TableCell className="text-xs text-muted-foreground font-mono">
+                          {run.triggeredBy === 'cron' ? 'cron' : run.triggeredBy === 'manual' ? 'manual' : run.triggeredBy ? `user:${run.triggeredBy.slice(0, 8)}` : '-'}
+                        </TableCell>
+                        <TableCell className="text-xs text-destructive max-w-[18rem] truncate" title={run.errorMessage || ''}>
+                          {run.errorMessage || ''}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/tabs/__tests__/OffsiteBackupTab.test.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/__tests__/OffsiteBackupTab.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+// Mock api before importing the component
+const apiGet = vi.fn();
+const apiPost = vi.fn();
+const apiPut = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+    post: (...args: unknown[]) => apiPost(...args),
+    put: (...args: unknown[]) => apiPut(...args),
+  },
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { OffsiteBackupTab } from '../OffsiteBackupTab';
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    React.createElement(QueryClientProvider, { client: qc }, ui),
+  );
+}
+
+describe('OffsiteBackupTab', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    apiPost.mockReset();
+    apiPut.mockReset();
+  });
+
+  it('renders config + history table when status returns runs', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        enabled: true,
+        destBucket: 'bestchoice-backups-offsite',
+        retentionDays: 30,
+        sqlSourceBucket: 'bestchoice-sql-exports',
+        runs: [
+          {
+            id: 'r1',
+            startedAt: '2026-05-18T03:30:00Z',
+            finishedAt: '2026-05-18T03:31:42Z',
+            status: 'SUCCESS',
+            filesCount: 12,
+            totalBytes: 1024 * 1024 * 5,
+            errorMessage: null,
+            triggeredBy: 'cron',
+            destBucket: 'bestchoice-backups-offsite',
+          },
+        ],
+      },
+    });
+
+    wrap(<OffsiteBackupTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('bestchoice-backups-offsite')).toBeInTheDocument();
+    });
+    expect(screen.getByText('30 วัน')).toBeInTheDocument();
+    expect(screen.getByText('สำเร็จ')).toBeInTheDocument();
+    // Size formatted
+    expect(screen.getByText('5.0 MB')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('cron')).toBeInTheDocument();
+  });
+
+  it('shows warning banner when sqlSourceBucket is not set', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        enabled: false,
+        destBucket: 'dest',
+        retentionDays: 30,
+        sqlSourceBucket: null,
+        runs: [],
+      },
+    });
+
+    wrap(<OffsiteBackupTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/OFFSITE_BACKUP_SQL_SOURCE_BUCKET/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/ยังไม่มีประวัติการสำรองข้อมูล/)).toBeInTheDocument();
+  });
+
+  it('runs backup when "สำรองข้อมูลตอนนี้" is clicked', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        enabled: true,
+        destBucket: 'dest',
+        retentionDays: 30,
+        sqlSourceBucket: 'sql-src',
+        runs: [],
+      },
+    });
+    apiPost.mockResolvedValue({
+      data: {
+        id: 'r-new',
+        status: 'SUCCESS',
+        filesCount: 7,
+        totalBytes: 2048,
+        durationMs: 4321,
+        errorMessage: null,
+      },
+    });
+
+    wrap(<OffsiteBackupTab />);
+
+    const btn = await screen.findByRole('button', { name: /สำรองข้อมูลตอนนี้/ });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('/backup/offsite-now');
+    });
+  });
+});

--- a/apps/web/src/pages/SettingsPage/tabs/__tests__/OffsiteBackupTab.test.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/__tests__/OffsiteBackupTab.test.tsx
@@ -60,6 +60,7 @@ describe('OffsiteBackupTab', () => {
             totalBytes: 1024 * 1024 * 5,
             errorMessage: null,
             triggeredBy: 'cron',
+            triggeredByUser: null,
             destBucket: 'bestchoice-backups-offsite',
           },
         ],
@@ -127,5 +128,107 @@ describe('OffsiteBackupTab', () => {
     await waitFor(() => {
       expect(apiPost).toHaveBeenCalledWith('/backup/offsite-now');
     });
+  });
+
+  it('W4 — opens ConfirmDialog before enabling toggle (no 2-click toast)', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        enabled: false,
+        destBucket: 'dest',
+        retentionDays: 30,
+        sqlSourceBucket: 'sql-src',
+        runs: [],
+      },
+    });
+    apiPut.mockResolvedValue({ data: { enabled: true } });
+
+    wrap(<OffsiteBackupTab />);
+
+    const toggle = await screen.findByRole('switch', { name: /เปิดปิด Off-site Backup/ });
+    fireEvent.click(toggle);
+
+    // Dialog should appear with action description
+    await waitFor(() => {
+      expect(screen.getByText(/ต้องสร้าง destination bucket/)).toBeInTheDocument();
+    });
+
+    // No PUT yet — must confirm
+    expect(apiPut).not.toHaveBeenCalled();
+
+    // Click the confirm button in the dialog
+    const confirmBtn = screen.getAllByRole('button', { name: /^ยืนยัน$/ }).pop();
+    if (!confirmBtn) throw new Error('confirm button not rendered');
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(apiPut).toHaveBeenCalledWith('/backup/offsite-enabled', { enabled: true });
+    });
+  });
+
+  it('W7 — handles destBucket=null gracefully (FM/ACC role)', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        enabled: true,
+        destBucket: null,
+        retentionDays: 30,
+        sqlSourceBucket: null,
+        runs: [
+          {
+            id: 'r1',
+            startedAt: '2026-05-18T03:30:00Z',
+            finishedAt: '2026-05-18T03:31:00Z',
+            status: 'SUCCESS',
+            filesCount: 1,
+            totalBytes: 100,
+            errorMessage: null,
+            triggeredBy: 'cron',
+            triggeredByUser: null,
+            destBucket: null,
+          },
+        ],
+      },
+    });
+
+    wrap(<OffsiteBackupTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ปกปิดสำหรับ role นี้/)).toBeInTheDocument();
+    });
+    // No "OFFSITE_BACKUP_SQL_SOURCE_BUCKET" warning when destBucket is masked
+    // (warning only relevant when user can see infra config).
+    expect(screen.queryByText(/OFFSITE_BACKUP_SQL_SOURCE_BUCKET/)).toBeNull();
+  });
+
+  it('C2 — displays triggered-by-user name from joined relation', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        enabled: true,
+        destBucket: 'dest',
+        retentionDays: 30,
+        sqlSourceBucket: 'sql',
+        runs: [
+          {
+            id: 'r1',
+            startedAt: '2026-05-18T03:30:00Z',
+            finishedAt: '2026-05-18T03:31:00Z',
+            status: 'SUCCESS',
+            filesCount: 1,
+            totalBytes: 100,
+            errorMessage: null,
+            triggeredBy: 'manual',
+            triggeredByUser: { id: 'u1', name: 'อาเค' },
+            destBucket: 'dest',
+          },
+        ],
+      },
+    });
+
+    wrap(<OffsiteBackupTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('อาเค')).toBeInTheDocument();
+    });
+    // Old `user:abcd1234` slice format must NOT appear
+    expect(screen.queryByText(/^user:/)).toBeNull();
   });
 });

--- a/docs/guides/OFFSITE-BACKUP.md
+++ b/docs/guides/OFFSITE-BACKUP.md
@@ -1,0 +1,362 @@
+# Off-site Backup Runbook (Phase 3 SP2)
+
+> Cross-region replication of Cloud SQL exports + the GCS document bucket
+> into a second-region "off-site" bucket. Designed for the case where the
+> primary region (`asia-southeast1`) goes down or someone mass-deletes
+> the primary bucket — without an off-site copy we'd have no recoverable
+> evidence.
+
+This document covers WHY, WHAT, HOW TO ENABLE, HOW TO RESTORE, and HOW TO
+TEST. Read it end-to-end before touching production.
+
+---
+
+## 1. Why we need this
+
+BESTCHOICE production runs entirely in `asia-southeast1` (Singapore):
+
+| Component | Service | Region |
+|---|---|---|
+| API | Cloud Run | asia-southeast1 |
+| DB | Cloud SQL Postgres + automated backups + PITR | asia-southeast1 |
+| Files | GCS bucket `bestchoice-documents` | asia-southeast1 |
+| Web | Firebase Hosting | global (CDN) |
+
+Cloud SQL automated backups + PITR are managed by GCP, encrypted at rest,
+and recover any point in the last 7 days. That covers normal
+"oops-I-deleted-a-row" incidents. It does **not** cover:
+
+1. **Region-wide outage** — full asia-southeast1 unavailability. Both the
+   primary DB and the Cloud SQL backups live in the same region.
+2. **Mass delete of the GCS document bucket** (compromised credentials,
+   misconfigured retention policy, fat-fingered `gcloud storage rm -r`).
+   Bucket versioning helps but versioning itself can be disabled.
+3. **Auditor / legal requirement** for a copy stored outside the primary
+   provider region.
+
+The off-site backup module mirrors two data sets daily into a bucket
+in a different region. The destination bucket is the OWNER's choice but
+the spec uses `asia-east1` (Taiwan) for low latency + clear region
+separation. `us-central1` is another reasonable pick if the priority is
+maximum geographic distance.
+
+---
+
+## 2. What gets replicated
+
+Two prefixes inside one off-site bucket:
+
+```
+gs://bestchoice-backups-offsite/
+├── sql/
+│   ├── 2026-05-18.sql.gz
+│   ├── 2026-05-19.sql.gz
+│   └── ...                  ← Cloud SQL daily dumps, one per day
+└── docs/
+    ├── contracts/<uuid>/...  ← mirror of bestchoice-documents/contracts/
+    ├── slips/<uuid>/...      ← mirror of bestchoice-documents/slips/
+    └── ...                   ← mirror of every other doc-bucket prefix
+```
+
+**SQL dumps** are produced by Cloud SQL's automated export job (you must
+schedule one with `gcloud sql export sql`, see §5.3). They land in a
+"SQL backup source" bucket; the off-site module then copies the latest
+dump to `sql/YYYY-MM-DD.sql.gz` in the off-site bucket.
+
+**Documents** are diffed for the last 26 hours of activity (the 26-hour
+window adds a 2h safety buffer for clock drift across the daily 03:30
+cron tick) and copied into `docs/<path>` in the off-site bucket. The
+prefix is preserved so restoration is a simple `gsutil rsync` back.
+
+The module's idempotency rule is "skip if dest object exists AND md5
+matches" — so re-running the same day (manual trigger or cron retry)
+costs zero egress on files that are already replicated.
+
+### Retention
+
+Default 30 days at the off-site bucket. The daily cron prunes anything
+older than `OFFSITE_BACKUP_RETENTION_DAYS` under the `sql/` and `docs/`
+prefixes. The cleanup never touches other objects in the same bucket,
+so it's safe to share the bucket with non-replication artifacts.
+
+Why 30 days? Long enough for a DR drill to discover stale data and roll
+back; short enough to keep storage costs negligible (~$3/mo for ~100GB).
+Lengthen via `OFFSITE_BACKUP_RETENTION_DAYS=90` (etc.) if your retention
+policy requires it.
+
+---
+
+## 3. Topology
+
+```
+Primary region (asia-southeast1)             Off-site region (asia-east1)
+─────────────────────────────────             ────────────────────────────
+
+bestchoice-documents/         ─copy─▶       bestchoice-backups-offsite/
+  contracts/<uuid>/...                         docs/contracts/<uuid>/...
+  slips/<uuid>/...                             docs/slips/<uuid>/...
+
+bestchoice-sql-exports/       ─copy─▶       bestchoice-backups-offsite/
+  cloudsql-backups/                            sql/2026-05-18.sql.gz
+    YYYY/MM/DD/...                             sql/2026-05-19.sql.gz
+```
+
+The Cloud Run service account (the one your API runs as) is the agent
+that performs the copies. It needs:
+
+- `storage.objects.list` on the primary buckets (already has it for the
+  document bucket; needs new IAM on the SQL export bucket)
+- `storage.objects.get` on the primary buckets
+- `storage.objects.create` + `storage.objects.delete` + `storage.objects.list`
+  on the off-site bucket
+
+No new service account is required. No keys exit GCP.
+
+---
+
+## 4. Cost estimate
+
+At ~100 GB of documents and 7 daily SQL dumps ~5 GB each:
+
+| Item | Detail | Monthly |
+|---|---|---|
+| Off-site bucket storage | 100 GB · $0.020/GB (Standard, asia-east1) | $2.00 |
+| Class A operations (copies) | ~10k object writes · $0.05 / 10k | $0.05 |
+| Class B operations (lists) | ~1k list calls · $0.004 / 10k | <$0.01 |
+| Cross-region egress (one-time bootstrap) | 100 GB · $0.08/GB | $8 (one-time) |
+| Cross-region egress (daily diff ~1 GB) | 30 days · 1 GB · $0.08/GB | $2.40 |
+| Cleanup deletes | free | $0 |
+| **Total recurring (after bootstrap)** | | **~$4.50 / mo** |
+
+PITR + Cloud SQL automated backups are NOT counted — those are still in
+the primary region and bill separately at their existing rate.
+
+---
+
+## 5. How to enable
+
+> Bucket creation and IAM granting are **OWNER deliverables**. The code
+> in this repo does not auto-create buckets or grant IAM, by design.
+
+### 5.1. Create the destination bucket
+
+```bash
+# Pick a region different from the primary.
+DEST_REGION=asia-east1
+DEST_BUCKET=bestchoice-backups-offsite
+PROJECT_ID=$(gcloud config get-value project)
+
+gcloud storage buckets create gs://${DEST_BUCKET} \
+  --project=${PROJECT_ID} \
+  --location=${DEST_REGION} \
+  --uniform-bucket-level-access \
+  --public-access-prevention
+
+# Optional but recommended — object versioning + 30d soft-delete so an
+# accidental cron misconfiguration cannot wipe the off-site copy.
+gcloud storage buckets update gs://${DEST_BUCKET} --versioning
+```
+
+### 5.2. Grant Cloud Run service account access
+
+```bash
+# Look up the Cloud Run service account email — usually
+# bestchoice-api@${PROJECT_ID}.iam.gserviceaccount.com
+SA_EMAIL=$(gcloud run services describe bestchoice-api \
+  --region=asia-southeast1 --format='value(spec.template.spec.serviceAccountName)')
+
+# Write + list + delete on the off-site bucket
+gcloud storage buckets add-iam-policy-binding gs://${DEST_BUCKET} \
+  --member=serviceAccount:${SA_EMAIL} \
+  --role=roles/storage.objectAdmin
+
+# Read on the SQL export source bucket (if Cloud SQL writes to its own)
+gcloud storage buckets add-iam-policy-binding gs://bestchoice-sql-exports \
+  --member=serviceAccount:${SA_EMAIL} \
+  --role=roles/storage.objectViewer
+```
+
+### 5.3. Configure Cloud SQL daily SQL export
+
+Cloud SQL's automated backups are *not* SQL dumps — they're internal
+snapshots usable only via `gcloud sql import`. For the off-site backup
+we need a real `.sql.gz` file we can restore anywhere. Schedule one via
+Cloud Scheduler (or your CI):
+
+```bash
+gcloud sql export sql bestchoice-prod \
+  gs://bestchoice-sql-exports/cloudsql-backups/$(date +%Y/%m/%d)/dump.sql.gz \
+  --database=bestchoice \
+  --offload  # avoids load on the prod instance
+```
+
+Schedule this at 03:00 BKK daily so the off-site cron at 03:30 BKK has
+~30 minutes of headroom for the export to finish writing.
+
+### 5.4. Set environment variables on Cloud Run
+
+```bash
+gcloud run services update bestchoice-api \
+  --region=asia-southeast1 \
+  --update-env-vars \
+    OFFSITE_BACKUP_ENABLED=false,\
+OFFSITE_BACKUP_DEST_BUCKET=bestchoice-backups-offsite,\
+OFFSITE_BACKUP_RETENTION_DAYS=30,\
+OFFSITE_BACKUP_SQL_PREFIX=cloudsql-backups/,\
+OFFSITE_BACKUP_SQL_SOURCE_BUCKET=bestchoice-sql-exports
+```
+
+Leave `OFFSITE_BACKUP_ENABLED=false` for now — we want to test manually
+before turning the cron loose.
+
+### 5.5. Test with a manual trigger
+
+1. Log in as OWNER → `/settings#offsite-backup`
+2. Toggle **Off-site Backup** to ON (the UI requires a 2-click confirm).
+3. Click **สำรองข้อมูลตอนนี้** ("Run Now").
+4. Wait — first run takes proportional to your document bucket size.
+5. Verify the toast shows `สำเร็จ — N ไฟล์ / size / duration`.
+6. Verify off-site bucket has objects:
+   ```
+   gsutil ls -lh gs://bestchoice-backups-offsite/docs/ | head -20
+   gsutil ls -lh gs://bestchoice-backups-offsite/sql/
+   ```
+7. The history table should show 1 SUCCESS row.
+
+### 5.6. Activate the cron
+
+Once §5.5 passes, the toggle stays ON. The daily 03:30 BKK cron will
+run automatically. No additional setup — `@nestjs/schedule` runs in the
+same Cloud Run process.
+
+If you need to disable temporarily (e.g. while debugging a region issue):
+flip the toggle off in the UI. The cron will keep firing but each tick
+will write a `SKIPPED` row instead of doing any GCS work.
+
+---
+
+## 6. How to restore from off-site
+
+### 6.1. Restore the document bucket
+
+```bash
+# Full restore — copies every doc back into the primary bucket
+gsutil -m rsync -r \
+  gs://bestchoice-backups-offsite/docs/ \
+  gs://bestchoice-documents/
+
+# Partial restore — single contract directory
+gsutil -m cp -r \
+  gs://bestchoice-backups-offsite/docs/contracts/<uuid>/ \
+  gs://bestchoice-documents/contracts/<uuid>/
+```
+
+### 6.2. Restore the database from an off-site SQL dump
+
+```bash
+# 1. Copy the dump to a bucket the destination Cloud SQL instance can read
+#    (Cloud SQL import requires a bucket in the same project + region as
+#    the instance; cross-region import is not supported).
+gsutil cp gs://bestchoice-backups-offsite/sql/2026-05-18.sql.gz \
+  gs://bestchoice-sql-import-staging/restore.sql.gz
+
+# 2. Provision a fresh Cloud SQL instance in the recovery region
+gcloud sql instances create bestchoice-recovery \
+  --region=asia-east1 \
+  --tier=db-custom-2-7680 \
+  --database-version=POSTGRES_15
+
+# 3. Grant the recovery instance's service account read on the staging bucket
+RECOVERY_SA=$(gcloud sql instances describe bestchoice-recovery \
+  --format='value(serviceAccountEmailAddress)')
+gcloud storage buckets add-iam-policy-binding gs://bestchoice-sql-import-staging \
+  --member=serviceAccount:${RECOVERY_SA} \
+  --role=roles/storage.objectViewer
+
+# 4. Create the empty database
+gcloud sql databases create bestchoice --instance=bestchoice-recovery
+
+# 5. Import
+gcloud sql import sql bestchoice-recovery \
+  gs://bestchoice-sql-import-staging/restore.sql.gz \
+  --database=bestchoice
+
+# 6. Re-point the API at the recovery instance (Cloud Run env DATABASE_URL)
+gcloud run services update bestchoice-api \
+  --region=asia-southeast1 \
+  --update-env-vars=DATABASE_URL=postgresql://...recovery...
+```
+
+The off-site SQL dump is gzipped, so a 5 GB dump becomes ~2 GB on disk
+and ~5-10 min to restore on a `db-custom-2-7680` instance.
+
+---
+
+## 7. How to test (monthly DR drill)
+
+Run on the **first business day of each month**. Owner or accountant on call.
+
+- [ ] Open `/settings#offsite-backup` — verify last cron run was SUCCESS
+- [ ] Click "สำรองข้อมูลตอนนี้" — verify toast says SUCCESS within 5 min
+- [ ] Inspect off-site bucket:
+  ```
+  gsutil du -sh gs://bestchoice-backups-offsite/sql/
+  gsutil du -sh gs://bestchoice-backups-offsite/docs/
+  ```
+  Expect SQL count = `OFFSITE_BACKUP_RETENTION_DAYS` (rounded) and docs
+  size proportional to your active document volume.
+- [ ] Pick a random SQL dump from off-site → restore to a temporary
+  Cloud SQL instance (steps §6.2 #1-#5). Smoke-test by querying
+  `SELECT COUNT(*) FROM contracts WHERE deleted_at IS NULL`. Delete the
+  temporary instance after.
+- [ ] Pick a random contract directory → restore via §6.1 to a sandbox
+  bucket. Verify file count + a sample file checksums match the off-site.
+- [ ] Inspect history table for any FAILED runs in the last 30 days —
+  if found, investigate the `errorMessage` column and Sentry tag
+  `cron:offsite-backup`.
+- [ ] Update this runbook if anything was unclear or wrong during the drill.
+
+---
+
+## 8. Operational notes
+
+- The cron logs to Cloud Run stdout with prefix `[OffsiteBackupService]`
+  and `[OffsiteBackupCron]`. Filter in Cloud Logging:
+  ```
+  resource.type="cloud_run_revision"
+  textPayload =~ "OffsiteBackup"
+  ```
+- Successful runs page Sentry at `level=info` with tag
+  `kind=cron-job, cron=offsite-backup` (so the success path is visible
+  in Sentry's cron monitoring dashboard, not just failures).
+- Failures page Sentry as exceptions with the same tag. Set an alert on
+  `kind:cron-job AND cron:offsite-backup AND level:error` if you want
+  a pager event on each failure.
+- The `OffsiteBackupRun` table grows by ~30 rows / month at the daily
+  cadence. No retention cron — it stays small forever.
+- The toggle is a **SystemConfig** row (`OFFSITE_BACKUP_ENABLED`) not an
+  env var, so flipping it doesn't require a Cloud Run redeploy. The env
+  var is a fallback for environments where SystemConfig isn't seeded
+  (e.g. brand-new dev DB).
+
+---
+
+## 9. What's deferred
+
+The following are out of scope for SP2 and tracked separately:
+
+- **Restore-from-off-site UI** — currently restoration is gcloud CLI only.
+  A web UI button "restore this run" is a Phase 4 candidate.
+- **GCS Object Lifecycle / Bucket Lock** — the 30-day retention is
+  enforced by our cron, not by GCS lifecycle rules. Adding a lifecycle
+  rule "delete after 31 days" gives belt-and-suspenders protection
+  against a stuck cron leaving stale data forever. Configure manually
+  when you create the bucket.
+- **Multi-region replication of the off-site bucket itself** — would
+  require a third-region copy. Overkill at current scale.
+- **PII redaction in SQL dumps** — the dump contains every customer's
+  full record. PDPA-strict mode (Phase 6.5) would need a sanitized
+  variant. Not addressed here.
+- **Restore drill automation** — §7 is manual. A scripted drill that
+  spins up a recovery instance + runs a query + tears down would catch
+  regressions earlier. Phase 4 candidate.

--- a/docs/guides/OFFSITE-BACKUP.md
+++ b/docs/guides/OFFSITE-BACKUP.md
@@ -333,11 +333,28 @@ Run on the **first business day of each month**. Owner or accountant on call.
   `kind:cron-job AND cron:offsite-backup AND level:error` if you want
   a pager event on each failure.
 - The `OffsiteBackupRun` table grows by ~30 rows / month at the daily
-  cadence. No retention cron — it stays small forever.
+  cadence. Rows older than **1 year** are pruned daily by
+  `offsite-backup-retention.cron` at **02:00 BKK** (matches AuditLog policy
+  + avoids PDPA risk on stale user UUIDs after soft-delete). Adjust the
+  window by editing `OffsiteBackupRetentionCron.RETENTION_DAYS`.
 - The toggle is a **SystemConfig** row (`OFFSITE_BACKUP_ENABLED`) not an
   env var, so flipping it doesn't require a Cloud Run redeploy. The env
   var is a fallback for environments where SystemConfig isn't seeded
   (e.g. brand-new dev DB).
+- **Concurrency safety:** `OffsiteBackupService.run` takes a PostgreSQL
+  advisory lock (`pg_try_advisory_lock(hashtext('offsite-backup'))`)
+  before touching GCS. A 2nd attempt while a run is in flight returns
+  HTTP **409 Conflict** — the cron logs the conflict as a warning and
+  exits cleanly. Lock is released in a `finally` (and auto-released by
+  the database when the connection closes).
+- **Manual trigger audit:** `POST /backup/offsite-now` writes an
+  `OFFSITE_BACKUP_RUN_NOW` event into AuditLog (hash-chained, immutable).
+  The `OffsiteBackupRun.triggeredByUserId` FK is a convenience join — the
+  hash-chained AuditLog is the legal trail.
+- **Bucket-name masking:** `GET /backup/offsite-status` returns
+  `destBucket` and `sqlSourceBucket` only when the caller is `OWNER`.
+  FM / ACC see `null` (so they can monitor the audit trail without
+  learning the infra topology).
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 3 SP2 — implements cross-region GCS replication for Cloud SQL exports + document bucket. Closes the long-deferred "Off-site backup replication" hardening gap (tracked in CLAUDE.md hardening history v1-v4 "Things deferred").

## What's in this PR

**Backend (apps/api/src/modules/backup/):**
- `OffsiteBackupService` — `run(triggeredBy)` orchestrates the daily cycle:
  1. Pre-flight `isEnabled()` check (SystemConfig `OFFSITE_BACKUP_ENABLED` → env var, default false). Disabled runs persist a `SKIPPED` row so UI shows the gap rather than a silent miss.
  2. SQL dump replication — copies every object under `cloudsql-backups/` prefix into dest bucket's `sql/`. Skipped gracefully when `OFFSITE_BACKUP_SQL_SOURCE_BUCKET` is unset.
  3. Document bucket diff — copies last 26h files from `bestchoice-documents` into `docs/<original-path>`.
  4. Cleanup — deletes destination objects older than `OFFSITE_BACKUP_RETENTION_DAYS` under `sql/` and `docs/` only.
  Idempotent — re-running the same day re-checks md5 against dest and skips identical copies. Per-file errors don't abort the whole run (partial replication > none).
- `OffsiteBackupCron` — daily 03:30 Asia/Bangkok. Thin delegator with last-ditch Sentry catch.
- `BackupController` (3 endpoints):
  - `POST /backup/offsite-now` (OWNER) — manual trigger
  - `GET  /backup/offsite-status` (OWNER, FINANCE_MANAGER, ACCOUNTANT) — config + last 7 runs
  - `PUT  /backup/offsite-enabled` (OWNER) — flip the toggle

**Database (apps/api/prisma/):**
- New model `OffsiteBackupRun` + enum `OffsiteBackupStatus` (RUNNING/SUCCESS/FAILED/SKIPPED)
- Migration `20260945000000_add_offsite_backup_runs` with `IF NOT EXISTS` guards so re-running `migrate deploy` on an already-migrated env is safe

**Frontend (apps/web/src/pages/SettingsPage/tabs/):**
- New 6th tab `#offsite-backup` (OWNER-only — uses existing `/settings` page guard)
- Status card with toggle (2-click confirm before enabling), destination bucket, retention days, SQL source bucket, warning banner when SQL source unset
- "Run Now" button with toast on result
- Last 7 backup runs table with status badge, files count, size (formatBytes B/KB/MB/GB), duration, trigger source, error tooltip

**Docs:**
- `docs/guides/OFFSITE-BACKUP.md` — end-to-end runbook (363 lines): why we need it, what gets replicated, topology + IAM, cost estimate (~$4.50/mo), how to enable (bucket creation + IAM + Cloud SQL export schedule + env vars + smoke test), how to restore (gsutil + Cloud SQL import), monthly DR drill checklist, operational notes, deferred items

**Env vars (`.env.example`):** 5 new `OFFSITE_BACKUP_*` knobs, all default-off

## Hard constraints respected

- DOES NOT auto-create GCS buckets — that's an OWNER deliverable documented in the runbook
- DOES NOT grant IAM
- DOES NOT hit real GCS in tests (fake Storage client injected via `service.setStorageClient` seam)
- DOES NOT add binary backup files to the repo
- Cron is fully idempotent — re-running same day produces same result

## Tests

- **API:** 22 jest tests (`offsite-backup.service.spec.ts` 18 + `backup.controller.spec.ts` 4) covering replication, idempotency (md5 skip), 26h lookback window, per-file fault tolerance, cleanup, disabled path, FAILED path, controller delegation, role wiring.
- **Web:** 3 vitest tests for status render, sqlSourceBucket warning banner, run-now POST.
- **API TSC:** 0 errors
- **Web TSC:** 0 errors

## What's deferred (documented in runbook §9)

- Restore-from-off-site UI (currently gcloud CLI only)
- GCS Object Lifecycle / Bucket Lock as belt-and-suspenders
- Multi-region replication of the off-site bucket itself
- PII redaction in SQL dumps (would gate on Phase 6.5 PDPA-strict)
- Scripted DR drill (currently manual checklist)

## Test plan

- [ ] Wait for Lint & Test CI green
- [ ] OWNER reviews `docs/guides/OFFSITE-BACKUP.md` end-to-end before approving
- [ ] After merge + deploy: create dest bucket + grant IAM per §5.1-5.2
- [ ] Schedule Cloud SQL daily SQL export per §5.3
- [ ] Set Cloud Run env vars per §5.4 (keep `OFFSITE_BACKUP_ENABLED=false`)
- [ ] Smoke test via `/settings#offsite-backup` → toggle ON → "Run Now" → verify success per §5.5
- [ ] After 1st successful run leaves cron enabled; verify daily 03:30 BKK tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)