### PR TITLE
feat(p3-sp1): Year-end closing JE (39-9999 → 33-1101)

### DIFF
--- a/.claude/rules/accounting.md
+++ b/.claude/rules/accounting.md
@@ -385,4 +385,84 @@ Operational settings live at dedicated routes (also OWNER-only):
 - `/settings/collections` — CollectionsConfigCard
 - `/settings/general` — Banking, penalty, PDPA, payment_link (GeneralSettings pre+post)
 
+---
+
+## Year-End Closing (P3-SP1)
+
+Runs once at the end of each fiscal year (typically Jan-March of the following
+year, after all 12 monthly periods are CLOSED). Closes revenue + expense
+accounts into Income Summary (39-9999), then transfers net income/loss to
+Retained Earnings (33-1101 — กำไร(ขาดทุน)สุทธิประจำปี).
+
+Template: `apps/api/src/modules/journal/cpa-templates/year-end-closing.template.ts`
+Service: `apps/api/src/modules/accounting/closing.service.ts`
+Page: `apps/web/src/pages/YearEndClosingPage.tsx` → route `/finance/year-end-closing`
+
+### 3-step JE flow
+
+All 3 entries share `metadata.batchId` (uuid) for traceability:
+
+```
+Step 1 — Close revenue (per non-zero 41/42-XXXX account):
+  Dr 41-XXXX  [net Cr balance for the year]
+  Dr 42-XXXX  ...
+    Cr 39-9999 Income Summary  [revenueTotal]
+
+Step 2 — Close expenses (per non-zero 51/52/53/54-XXXX account):
+  Dr 39-9999 Income Summary  [expenseTotal]
+    Cr 51-XXXX  [net Dr balance]
+    Cr 52-XXXX  ...
+
+Step 3 — Transfer net to retained earnings (skipped if net = 0):
+  If profit:  Dr 39-9999 / Cr 33-1101  [netIncome]
+  If loss:    Dr 33-1101 / Cr 39-9999  [|netLoss|]
+```
+
+Entry-date for all 3 JEs = `Dec 31 23:59:59.999 BKK` of the closed year (keeps
+the closing entries inside the year window).
+
+### Guards
+
+- **Year window**: 2020-2030, must be strictly `< current year` (cannot close
+  future or in-progress year)
+- **Monthly periods**: all 12 months for FINANCE company must be in
+  `CLOSED` or `SYNCED` status — otherwise `BadRequestException` with the
+  list of open months
+- **Idempotency**: a year can only be closed once. `ConflictException` on
+  re-attempt unless prior batch was reversed first (then re-close allowed)
+- **Tx atomicity**: 3 JEs created in a single `$transaction` — partial
+  failure rolls all 3 back
+
+### Reversal escape hatch (OWNER only)
+
+```
+POST /accounting/year-end-closing/reverse
+Body: { year, reason }  // reason min 10 chars
+```
+
+Creates 3 mirror-flipped JEs (Dr/Cr swapped), dated today (NOT the original
+Dec 31). Original entries keep their POSTED status — reversal sits beside
+them with `metadata.flow = 'year-end-closing-reverse'` + back-ref via
+`reversesEntryId`. Originals are marked `metadata.reversedByBatchId` so the
+idempotency guard no longer blocks a re-close.
+
+AuditLog actions:
+- `YEAR_END_CLOSED` — entity=accounting_period, entityId=batchId, newValue includes year + netIncome + 3 JE ids
+- `YEAR_END_CLOSING_REVERSED` — entity=accounting_period, entityId=originalBatchId
+
+### Reports impact
+
+After year-end closing posts:
+- `getProfitLossFromJournal(Jan-Dec)` for the closed year returns ~0 for
+  Revenue and Expense (they've been zeroed out), and `netIncome ≈ 0`
+- `getTrialBalance(asOfDate >= Dec 31)` shows 33-1101 increased by net income,
+  Income Summary (39-9999) back to 0
+- `getBalanceSheetFromJournal(asOfDate >= Dec 31)` — equity section reflects
+  the year's profit moved to retained earnings (no longer "implicit" derived
+  from P&L)
+
+The "ค่าประมาณกำไรปีปัจจุบัน — ยังไม่ปิดบัญชีจริงเข้า 33-1101" caveat on the
+balance-sheet equity matrix (accounting.service.ts:1564) disappears for years
+that have been closed via this flow.
+
 `/accounting/periods` redirects to `/settings#periods` via `window.location.replace` (preserves hash; react-router `<Navigate>` cannot set hash fragments).

--- a/apps/api/src/modules/accounting/accounting.module.ts
+++ b/apps/api/src/modules/accounting/accounting.module.ts
@@ -1,24 +1,33 @@
 import { Module } from '@nestjs/common';
 import { AccountingController } from './accounting.controller';
+import { AccountingClosingController } from './closing.controller';
 import { AccountingService } from './accounting.service';
 import { BadDebtService } from './bad-debt.service';
 import { BadDebtProvisionCron } from './bad-debt-provision.cron';
 import { BankReconciliationService } from './bank-reconciliation.service';
 import { MonthlyCloseService } from './monthly-close.service';
+import { AccountingClosingService } from './closing.service';
 import { JournalModule } from '../journal/journal.module';
 import { TaxModule } from '../tax/tax.module';
 import { PeakModule } from '../peak/peak.module';
 
 @Module({
   imports: [JournalModule, TaxModule, PeakModule],
-  controllers: [AccountingController],
+  controllers: [AccountingController, AccountingClosingController],
   providers: [
     AccountingService,
     BadDebtService,
     BadDebtProvisionCron,
     BankReconciliationService,
     MonthlyCloseService,
+    AccountingClosingService,
   ],
-  exports: [AccountingService, BadDebtService, BankReconciliationService, MonthlyCloseService],
+  exports: [
+    AccountingService,
+    BadDebtService,
+    BankReconciliationService,
+    MonthlyCloseService,
+    AccountingClosingService,
+  ],
 })
 export class AccountingModule {}

--- a/apps/api/src/modules/accounting/closing.controller.ts
+++ b/apps/api/src/modules/accounting/closing.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Post, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { AccountingClosingService } from './closing.service';
+import {
+  YearEndClosingPostDto,
+  YearEndClosingPreviewDto,
+  YearEndClosingReverseDto,
+} from './dto/year-end-closing.dto';
+
+/**
+ * P3-SP1 — Year-End Closing endpoints.
+ *
+ * Mounted at `/accounting/year-end-closing*` — separate prefix from the legacy
+ * `/expenses` group in AccountingController (year-end is conceptually a
+ * "ปิดบัญชี" workflow, not a report).
+ */
+@ApiTags('Accounting — Year-End Closing')
+@ApiBearerAuth('JWT')
+@Controller('accounting/year-end-closing')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AccountingClosingController {
+  constructor(private readonly service: AccountingClosingService) {}
+
+  @Post('preview')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  preview(@Body() dto: YearEndClosingPreviewDto) {
+    return this.service.previewYearEndClosing(dto.year);
+  }
+
+  @Post()
+  @Roles('OWNER', 'ACCOUNTANT')
+  post(
+    @Body() dto: YearEndClosingPostDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.service.postYearEndClosing(dto.year, req.user.id);
+  }
+
+  @Post('reverse')
+  @Roles('OWNER')
+  reverse(
+    @Body() dto: YearEndClosingReverseDto,
+    @Request() req: { user: { id: string; role?: string } },
+  ) {
+    return this.service.reverseYearEndClosing(dto.year, req.user.id, dto.reason, req.user.role);
+  }
+}

--- a/apps/api/src/modules/accounting/closing.service.spec.ts
+++ b/apps/api/src/modules/accounting/closing.service.spec.ts
@@ -1,0 +1,366 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { AccountingClosingService } from './closing.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { YearEndClosingTemplate } from '../journal/cpa-templates/year-end-closing.template';
+
+/**
+ * Year-end Closing service tests.
+ *
+ * Tests the orchestration logic only — JE math is owned by
+ * YearEndClosingTemplate (separate spec). Focus here:
+ *  - year window validation (no future / current-year closes)
+ *  - period-closure gate (ต้องปิดงวดทุกเดือนก่อน)
+ *  - idempotency (a year closed twice → ConflictException)
+ *  - audit log emission with proper shape
+ *  - OWNER-only reverse + 10-char reason guard
+ *  - reverse mirror: 3 JEs flipped Dr/Cr
+ */
+describe('AccountingClosingService', () => {
+  let service: AccountingClosingService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let template: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let journalAuto: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let audit: any;
+
+  // year in the past — services reject current/future year
+  const PAST_YEAR = new Date().getFullYear() - 1;
+
+  beforeEach(async () => {
+    prisma = {
+      journalEntry: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'finance-co-1' }),
+      },
+      accountingPeriod: {
+        findMany: jest.fn().mockResolvedValue(
+          // all 12 months CLOSED by default
+          Array.from({ length: 12 }, (_, i) => ({
+            month: i + 1,
+            status: 'CLOSED',
+          })),
+        ),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn: any) => {
+        if (typeof fn === 'function') return fn(prisma);
+        return Promise.all(fn);
+      }),
+    };
+
+    template = {
+      getYearAccountActivity: jest.fn().mockResolvedValue({
+        revenues: [
+          { code: '41-1101', name: 'รายได้ดอกเบี้ย', balance: new Prisma.Decimal('100000.00') },
+          { code: '42-1102', name: 'ดอกเบี้ยเงินฝาก', balance: new Prisma.Decimal('5000.00') },
+        ],
+        expenses: [
+          { code: '51-1102', name: 'หนี้สูญ', balance: new Prisma.Decimal('20000.00') },
+        ],
+        revenueTotal: new Prisma.Decimal('105000.00'),
+        expenseTotal: new Prisma.Decimal('20000.00'),
+        netIncome: new Prisma.Decimal('85000.00'),
+      }),
+      execute: jest.fn().mockResolvedValue({
+        batchId: 'batch-uuid-1',
+        step1: { entryNo: 'JE-202612-00001', journalEntryId: 'je-1' },
+        step2: { entryNo: 'JE-202612-00002', journalEntryId: 'je-2' },
+        step3: { entryNo: 'JE-202612-00003', journalEntryId: 'je-3' },
+        netIncome: new Prisma.Decimal('85000.00'),
+        revenueTotal: new Prisma.Decimal('105000.00'),
+        expenseTotal: new Prisma.Decimal('20000.00'),
+      }),
+    };
+
+    journalAuto = {
+      createAndPost: jest.fn().mockImplementation(async () => ({
+        id: 'je-reverse-1',
+        entryNumber: 'JE-202605-00099',
+      })),
+    };
+
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AccountingClosingService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: YearEndClosingTemplate, useValue: template },
+        { provide: JournalAutoService, useValue: journalAuto },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+
+    service = module.get<AccountingClosingService>(AccountingClosingService);
+  });
+
+  // ─── previewYearEndClosing ─────────────────────────────────────────────
+
+  describe('previewYearEndClosing', () => {
+    it('returns revenue/expense rows + netIncome summary', async () => {
+      const out = await service.previewYearEndClosing(PAST_YEAR);
+      expect(out.year).toBe(PAST_YEAR);
+      expect(out.revenues).toHaveLength(2);
+      expect(out.revenues[0]).toEqual({
+        code: '41-1101',
+        name: 'รายได้ดอกเบี้ย',
+        balance: '100000.00',
+      });
+      expect(out.expenses).toHaveLength(1);
+      expect(out.netIncome).toBe('85000.00');
+      expect(out.isProfit).toBe(true);
+      expect(out.totalSteps).toBe(3);
+      expect(out.alreadyClosed).toBe(false);
+      expect(out.openMonths).toEqual([]);
+    });
+
+    it('rejects future year', async () => {
+      const futureYear = new Date().getFullYear() + 1;
+      await expect(service.previewYearEndClosing(futureYear)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects current year', async () => {
+      const currentYear = new Date().getFullYear();
+      await expect(service.previewYearEndClosing(currentYear)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('reports openMonths when some periods are not CLOSED/SYNCED', async () => {
+      prisma.accountingPeriod.findMany.mockResolvedValueOnce([
+        { month: 1, status: 'CLOSED' },
+        { month: 2, status: 'OPEN' }, // problem
+        { month: 3, status: 'CLOSED' },
+        // months 4-12 missing → also flagged as OPEN
+      ]);
+      const out = await service.previewYearEndClosing(PAST_YEAR);
+      expect(out.openMonths.length).toBeGreaterThan(0);
+      expect(out.openMonths.some((p: { month: number }) => p.month === 2)).toBe(true);
+    });
+
+    it('flags alreadyClosed=true when a YEAR_END_CLOSING JE already exists', async () => {
+      prisma.journalEntry.findFirst.mockResolvedValueOnce({
+        id: 'existing-je',
+        entryDate: new Date('2026-12-31T16:59:59.999Z'),
+        metadata: { batchId: 'old-batch' },
+      });
+      const out = await service.previewYearEndClosing(PAST_YEAR);
+      expect(out.alreadyClosed).toBe(true);
+      expect(out.closingBatchId).toBe('old-batch');
+    });
+
+    it('totalSteps=2 when netIncome is effectively zero', async () => {
+      template.getYearAccountActivity.mockResolvedValueOnce({
+        revenues: [{ code: '41-1101', name: 'x', balance: new Prisma.Decimal('100') }],
+        expenses: [{ code: '51-1102', name: 'y', balance: new Prisma.Decimal('100') }],
+        revenueTotal: new Prisma.Decimal('100'),
+        expenseTotal: new Prisma.Decimal('100'),
+        netIncome: new Prisma.Decimal('0'),
+      });
+      const out = await service.previewYearEndClosing(PAST_YEAR);
+      expect(out.totalSteps).toBe(2);
+    });
+  });
+
+  // ─── postYearEndClosing ───────────────────────────────────────────────
+
+  describe('postYearEndClosing', () => {
+    it('posts 3 JEs and emits YEAR_END_CLOSED audit log', async () => {
+      const out = await service.postYearEndClosing(PAST_YEAR, 'user-owner-1');
+      expect(out.batchId).toBe('batch-uuid-1');
+      expect(out.step1.entryNo).toBe('JE-202612-00001');
+      expect(out.step3?.entryNo).toBe('JE-202612-00003');
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-owner-1',
+          action: 'YEAR_END_CLOSED',
+          entity: 'accounting_period',
+          entityId: 'batch-uuid-1',
+          newValue: expect.objectContaining({
+            year: PAST_YEAR,
+            netIncome: '85000.00',
+          }),
+        }),
+      );
+    });
+
+    it('rejects if any monthly period is still OPEN', async () => {
+      prisma.accountingPeriod.findMany.mockResolvedValueOnce([
+        { month: 1, status: 'OPEN' },
+        ...Array.from({ length: 11 }, (_, i) => ({ month: i + 2, status: 'CLOSED' })),
+      ]);
+      await expect(
+        service.postYearEndClosing(PAST_YEAR, 'user-owner-1'),
+      ).rejects.toThrow(BadRequestException);
+      expect(template.execute).not.toHaveBeenCalled();
+    });
+
+    it('rejects if year is already closed (idempotency)', async () => {
+      prisma.journalEntry.findFirst.mockResolvedValueOnce({
+        id: 'existing-je',
+        entryDate: new Date(),
+        metadata: { batchId: 'old' },
+      });
+      await expect(
+        service.postYearEndClosing(PAST_YEAR, 'user-owner-1'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects future year before any DB work', async () => {
+      const fut = new Date().getFullYear() + 5;
+      await expect(service.postYearEndClosing(fut, 'user-1')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(template.execute).not.toHaveBeenCalled();
+    });
+
+    it('treats a reversed prior batch as not-blocking (allows re-close)', async () => {
+      // First findFirst (pre-tx) returns a reversed batch — must NOT block
+      prisma.journalEntry.findFirst.mockResolvedValueOnce({
+        id: 'old-je',
+        entryDate: new Date(),
+        metadata: { batchId: 'old', reversedByBatchId: 'old:R' },
+      });
+      // Inside-tx findFirst → none active
+      prisma.journalEntry.findFirst.mockResolvedValueOnce(null);
+      const out = await service.postYearEndClosing(PAST_YEAR, 'user-1');
+      expect(out.batchId).toBe('batch-uuid-1');
+    });
+  });
+
+  // ─── reverseYearEndClosing ────────────────────────────────────────────
+
+  describe('reverseYearEndClosing', () => {
+    const buildBatchEntries = () => [
+      {
+        id: 'je-1',
+        description: 'ปิดบัญชีรายได้',
+        entryDate: new Date(),
+        metadata: { flow: 'year-end-closing', year: PAST_YEAR, step: 1, batchId: 'b1' },
+        lines: [
+          { accountCode: '41-1101', debit: new Prisma.Decimal('100000'), credit: new Prisma.Decimal('0'), description: 'x' },
+          { accountCode: '39-9999', debit: new Prisma.Decimal('0'), credit: new Prisma.Decimal('100000'), description: 'y' },
+        ],
+      },
+      {
+        id: 'je-2',
+        description: 'ปิดบัญชีค่าใช้จ่าย',
+        entryDate: new Date(),
+        metadata: { flow: 'year-end-closing', year: PAST_YEAR, step: 2, batchId: 'b1' },
+        lines: [
+          { accountCode: '39-9999', debit: new Prisma.Decimal('20000'), credit: new Prisma.Decimal('0'), description: 'x' },
+          { accountCode: '51-1102', debit: new Prisma.Decimal('0'), credit: new Prisma.Decimal('20000'), description: 'y' },
+        ],
+      },
+      {
+        id: 'je-3',
+        description: 'โอนกำไรสุทธิเข้ากำไรสะสม',
+        entryDate: new Date(),
+        metadata: { flow: 'year-end-closing', year: PAST_YEAR, step: 3, batchId: 'b1' },
+        lines: [
+          { accountCode: '39-9999', debit: new Prisma.Decimal('80000'), credit: new Prisma.Decimal('0'), description: 'x' },
+          { accountCode: '33-1101', debit: new Prisma.Decimal('0'), credit: new Prisma.Decimal('80000'), description: 'y' },
+        ],
+      },
+    ];
+
+    it('reverses all 3 JEs and writes YEAR_END_CLOSING_REVERSED audit', async () => {
+      prisma.journalEntry.findMany.mockResolvedValue(buildBatchEntries());
+      const out = await service.reverseYearEndClosing(
+        PAST_YEAR,
+        'owner-1',
+        'พบข้อผิดพลาดในบัญชีค่าใช้จ่าย ต้องกลับรายการ',
+        'OWNER',
+      );
+      expect(out.originalBatchId).toBe('b1');
+      expect(out.reverseBatchId).toBe('b1:R');
+      expect(out.entries).toHaveLength(3);
+      expect(journalAuto.createAndPost).toHaveBeenCalledTimes(3);
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'YEAR_END_CLOSING_REVERSED',
+          userId: 'owner-1',
+        }),
+      );
+    });
+
+    it('rejects non-OWNER roles', async () => {
+      prisma.journalEntry.findMany.mockResolvedValue(buildBatchEntries());
+      await expect(
+        service.reverseYearEndClosing(
+          PAST_YEAR,
+          'acc-1',
+          'ขอกลับรายการเพื่อทดสอบระบบ',
+          'ACCOUNTANT',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects reason shorter than 10 characters', async () => {
+      await expect(
+        service.reverseYearEndClosing(PAST_YEAR, 'owner-1', 'สั้น', 'OWNER'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when no closing exists for the year', async () => {
+      prisma.journalEntry.findMany.mockResolvedValue([]);
+      await expect(
+        service.reverseYearEndClosing(
+          PAST_YEAR,
+          'owner-1',
+          'พยายามกลับรายการที่ไม่เคยทำ',
+          'OWNER',
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects when prior batch was already reversed', async () => {
+      const reversed = buildBatchEntries().map((e) => ({
+        ...e,
+        metadata: { ...e.metadata, reversedByBatchId: 'b1:R' },
+      }));
+      prisma.journalEntry.findMany.mockResolvedValue(reversed);
+      await expect(
+        service.reverseYearEndClosing(
+          PAST_YEAR,
+          'owner-1',
+          'ปีนี้ถูกกลับรายการไปแล้ว ลองอีกครั้ง',
+          'OWNER',
+        ),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('flips Dr/Cr in the reverse JE lines (mirror)', async () => {
+      prisma.journalEntry.findMany.mockResolvedValue(buildBatchEntries());
+      await service.reverseYearEndClosing(
+        PAST_YEAR,
+        'owner-1',
+        'ทดสอบ flip Dr/Cr ในกระบวนการ reverse',
+        'OWNER',
+      );
+      // Inspect the first createAndPost call (corresponds to step1 reverse)
+      const firstCall = journalAuto.createAndPost.mock.calls[0][0];
+      const origRevenueLine = firstCall.lines.find((l: { accountCode: string }) => l.accountCode === '41-1101');
+      // Original had Dr 100000 — reverse should have Cr 100000
+      expect(origRevenueLine.cr.toString()).toBe('100000');
+      expect(origRevenueLine.dr.toString()).toBe('0');
+    });
+  });
+});

--- a/apps/api/src/modules/accounting/closing.service.spec.ts
+++ b/apps/api/src/modules/accounting/closing.service.spec.ts
@@ -232,16 +232,69 @@ describe('AccountingClosingService', () => {
     });
 
     it('treats a reversed prior batch as not-blocking (allows re-close)', async () => {
-      // First findFirst (pre-tx) returns a reversed batch — must NOT block
-      prisma.journalEntry.findFirst.mockResolvedValueOnce({
+      // Both findFirst calls (pre-tx + inside-tx) hit the SAME reversed row in
+      // real Prisma — the post-filter on metadata.reversedByBatchId is what
+      // turns the truthy row into null. Use mockResolvedValue (not Once) so
+      // both calls receive the reversed batch.
+      prisma.journalEntry.findFirst.mockResolvedValue({
         id: 'old-je',
         entryDate: new Date(),
-        metadata: { batchId: 'old', reversedByBatchId: 'old:R' },
+        metadata: {
+          flow: 'year-end-closing',
+          year: PAST_YEAR,
+          step: 1,
+          batchId: 'old',
+          reversedByBatchId: 'old:R',
+        },
       });
-      // Inside-tx findFirst → none active
-      prisma.journalEntry.findFirst.mockResolvedValueOnce(null);
       const out = await service.postYearEndClosing(PAST_YEAR, 'user-1');
       expect(out.batchId).toBe('batch-uuid-1');
+      // Verify findFirst was hit at least twice (pre-tx + inside-tx race check)
+      expect(prisma.journalEntry.findFirst).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects re-close when a non-reversed batch reappears mid-transaction (race)', async () => {
+      // Simulates the race: pre-tx check sees nothing, but between pre-tx
+      // and the inside-tx guard, a concurrent request inserted an active
+      // (non-reversed) batch. The inside-tx ConflictException MUST fire.
+      // First call (pre-tx) → null
+      prisma.journalEntry.findFirst.mockResolvedValueOnce(null);
+      // Second call (inside-tx) → active batch
+      prisma.journalEntry.findFirst.mockResolvedValueOnce({
+        id: 'concurrent-je',
+        entryDate: new Date(),
+        metadata: {
+          flow: 'year-end-closing',
+          year: PAST_YEAR,
+          step: 1,
+          batchId: 'concurrent',
+        },
+      });
+      await expect(
+        service.postYearEndClosing(PAST_YEAR, 'user-1'),
+      ).rejects.toThrow(ConflictException);
+      expect(template.execute).not.toHaveBeenCalled();
+    });
+
+    it('rejects when a monthly period is reopened mid-transaction (race)', async () => {
+      // Simulates the W2 race: pre-tx sees all 12 months CLOSED, but
+      // between pre-tx and JE post, OWNER reopens month 5. The inside-tx
+      // re-check MUST fire BadRequestException and template.execute MUST NOT
+      // be called.
+      // First findMany (pre-tx) → all CLOSED (default beforeEach mock)
+      // Second findMany (inside-tx) → month 5 reopened
+      prisma.accountingPeriod.findMany.mockResolvedValueOnce(
+        Array.from({ length: 12 }, (_, i) => ({ month: i + 1, status: 'CLOSED' })),
+      );
+      prisma.accountingPeriod.findMany.mockResolvedValueOnce([
+        ...Array.from({ length: 4 }, (_, i) => ({ month: i + 1, status: 'CLOSED' })),
+        { month: 5, status: 'OPEN' },
+        ...Array.from({ length: 7 }, (_, i) => ({ month: i + 6, status: 'CLOSED' })),
+      ]);
+      await expect(
+        service.postYearEndClosing(PAST_YEAR, 'user-1'),
+      ).rejects.toThrow(BadRequestException);
+      expect(template.execute).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/accounting/closing.service.ts
+++ b/apps/api/src/modules/accounting/closing.service.ts
@@ -96,18 +96,24 @@ export class AccountingClosingService {
     // posts 3 JEs; if the audit log write fails, all 3 must roll back.
     const result = await this.prisma.$transaction(async (tx) => {
       // Re-check inside tx — guards against two requests racing past the
-      // pre-tx check and both attempting to post.
-      const existingInTx = await tx.journalEntry.findFirst({
-        where: {
-          AND: [
-            { metadata: { path: ['flow'], equals: 'year-end-closing' } as any },
-            { metadata: { path: ['year'], equals: year } as any },
-          ],
-          deletedAt: null,
-        },
-      });
+      // pre-tx check and both attempting to post. Mirrors the post-filter
+      // logic in `findExistingClosingBatch` (excludes reversed batches so
+      // reverse → re-close is allowed).
+      const existingInTx = await this.findActiveClosingBatchTx(tx, year);
       if (existingInTx) {
         throw new ConflictException(`ปี ${year} ปิดบัญชีไปแล้ว`);
+      }
+
+      // Re-check open monthly periods inside tx — guards against OWNER
+      // reopening a period via `/expenses/periods/reopen` after the pre-tx
+      // check but before the JE is posted. Mirrors the CAS pattern from
+      // monthly-close.service.ts reopenPeriod().
+      const openPeriodsInTx = await this.findOpenMonthlyPeriods(year, tx);
+      if (openPeriodsInTx.length > 0) {
+        const monthList = openPeriodsInTx.map((p) => p.month).join(', ');
+        throw new BadRequestException(
+          `ต้องปิดงวดทุกเดือนก่อนปิดบัญชีปี ${year} — เดือนที่ยังไม่ปิด: ${monthList}`,
+        );
       }
 
       const out = await this.template.execute(year, tx);
@@ -318,8 +324,11 @@ export class AccountingClosingService {
 
   private validateYear(year: number) {
     const currentYear = new Date().getFullYear();
-    if (!Number.isInteger(year) || year < 2020 || year > 2030) {
-      throw new BadRequestException('ปีไม่ถูกต้อง (รองรับ 2020-2030)');
+    // Lower bound 2020 = historical backfill window. NO hardcoded upper bound:
+    // `year < currentYear` is the meaningful check (cannot close future/current
+    // year). Hardcoding e.g. 2030 would silently break the system in Jan 2031.
+    if (!Number.isInteger(year) || year < 2020) {
+      throw new BadRequestException('ปีไม่ถูกต้อง (รองรับตั้งแต่ปี 2020 เป็นต้นไป)');
     }
     if (year >= currentYear) {
       throw new BadRequestException(
@@ -329,7 +338,23 @@ export class AccountingClosingService {
   }
 
   private async findExistingClosingBatch(year: number) {
-    return this.prisma.journalEntry.findFirst({
+    return this.findActiveClosingBatchTx(this.prisma, year);
+  }
+
+  /**
+   * Tx-aware variant of `findExistingClosingBatch`. Returns the most recent
+   * step-1 closing JE for the year IF it is still active (i.e. not marked
+   * as reversed via `metadata.reversedByBatchId`). Returns null when the
+   * prior batch has been fully reversed — allowing a fresh re-close.
+   *
+   * Accepts either the root PrismaService or a `Prisma.TransactionClient`
+   * so it can be safely reused inside `$transaction` for race-free guards.
+   */
+  private async findActiveClosingBatchTx(
+    client: PrismaService | Prisma.TransactionClient,
+    year: number,
+  ) {
+    const entry = await client.journalEntry.findFirst({
       where: {
         AND: [
           { metadata: { path: ['flow'], equals: 'year-end-closing' } as any },
@@ -341,22 +366,28 @@ export class AccountingClosingService {
         deletedAt: null,
       },
       orderBy: { createdAt: 'desc' },
-    }).then((e) => {
-      if (!e) return null;
-      const meta = e.metadata as { reversedByBatchId?: string } | null;
-      if (meta?.reversedByBatchId) return null;
-      return e;
     });
+    if (!entry) return null;
+    const meta = entry.metadata as { reversedByBatchId?: string } | null;
+    if (meta?.reversedByBatchId) return null;
+    return entry;
   }
 
   /**
    * Returns array of months whose AccountingPeriod for FINANCE company is
    * NOT CLOSED/SYNCED. Empty array = all 12 months are closed.
+   *
+   * Accepts an optional transaction client so the same check can run inside
+   * a `$transaction` to close the race window where an OWNER reopens a
+   * period between the pre-tx check and JE posting.
    */
   private async findOpenMonthlyPeriods(
     year: number,
+    client?: PrismaService | Prisma.TransactionClient,
   ): Promise<Array<{ month: number; status: string }>> {
-    const financeCompany = await this.prisma.companyInfo.findFirst({
+    const db = client ?? this.prisma;
+
+    const financeCompany = await db.companyInfo.findFirst({
       where: { companyCode: 'FINANCE', deletedAt: null },
       select: { id: true },
     });
@@ -364,7 +395,7 @@ export class AccountingClosingService {
       throw new BadRequestException('ไม่พบ FINANCE company ในระบบ');
     }
 
-    const periods = await this.prisma.accountingPeriod.findMany({
+    const periods = await db.accountingPeriod.findMany({
       where: { companyId: financeCompany.id, year },
       select: { month: true, status: true },
     });

--- a/apps/api/src/modules/accounting/closing.service.ts
+++ b/apps/api/src/modules/accounting/closing.service.ts
@@ -1,0 +1,386 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { YearEndClosingTemplate } from '../journal/cpa-templates/year-end-closing.template';
+
+/**
+ * Phase 3 SP1 — Year-End Closing Service.
+ *
+ * Orchestrates the YearEndClosingTemplate with business-level guards:
+ *   • Year must be in the past (cannot close current or future year)
+ *   • Every monthly AccountingPeriod for the year must be CLOSED/SYNCED
+ *     (so reopening individual months happens BEFORE running year-end)
+ *   • Idempotency — a year can only be closed once. Subsequent calls error
+ *     with ConflictException unless the prior closing was reversed first.
+ *   • OWNER-only escape hatch: reverseYearEndClosing reverses all 3 JEs
+ *     (creates 3 mirror-flipped JEs) with mandatory reason.
+ */
+@Injectable()
+export class AccountingClosingService {
+  private readonly logger = new Logger(AccountingClosingService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly template: YearEndClosingTemplate,
+    private readonly journalAuto: JournalAutoService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  /**
+   * Preview the closing JE without posting. Returns the same shape that the
+   * Page will render in its table — list of accounts + balances + net.
+   */
+  async previewYearEndClosing(year: number) {
+    this.validateYear(year);
+
+    const activity = await this.template.getYearAccountActivity(year);
+    const existing = await this.findExistingClosingBatch(year);
+    const periodIssues = await this.findOpenMonthlyPeriods(year);
+
+    return {
+      year,
+      revenues: activity.revenues.map((r) => ({
+        code: r.code,
+        name: r.name,
+        balance: r.balance.toFixed(2),
+      })),
+      expenses: activity.expenses.map((e) => ({
+        code: e.code,
+        name: e.name,
+        balance: e.balance.toFixed(2),
+      })),
+      revenueTotal: activity.revenueTotal.toFixed(2),
+      expenseTotal: activity.expenseTotal.toFixed(2),
+      netIncome: activity.netIncome.toFixed(2),
+      isProfit: activity.netIncome.gte(0),
+      totalSteps: activity.netIncome.abs().lessThan(new Prisma.Decimal('0.005')) ? 2 : 3,
+      // Pre-flight problems for the UI banner:
+      alreadyClosed: existing ? true : false,
+      closedAt: existing?.entryDate.toISOString() ?? null,
+      closingBatchId: (existing?.metadata as { batchId?: string } | null)?.batchId ?? null,
+      openMonths: periodIssues, // [] when all OK; array of {month, status} otherwise
+    };
+  }
+
+  /**
+   * Post all 3 closing JEs atomically. Throws on duplicate or open period.
+   * Returns the 3 JE numbers + batch id.
+   */
+  async postYearEndClosing(year: number, userId: string) {
+    this.validateYear(year);
+
+    // Pre-tx checks (cheap fail-fast — also re-checked inside tx to close race)
+    const openPeriods = await this.findOpenMonthlyPeriods(year);
+    if (openPeriods.length > 0) {
+      const monthList = openPeriods.map((p) => p.month).join(', ');
+      throw new BadRequestException(
+        `ต้องปิดงวดทุกเดือนก่อนปิดบัญชีปี ${year} — เดือนที่ยังไม่ปิด: ${monthList}`,
+      );
+    }
+
+    const existingPre = await this.findExistingClosingBatch(year);
+    if (existingPre) {
+      throw new ConflictException(`ปี ${year} ปิดบัญชีไปแล้ว`);
+    }
+
+    // Wrap template + audit log in $transaction for atomicity. The template
+    // posts 3 JEs; if the audit log write fails, all 3 must roll back.
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Re-check inside tx — guards against two requests racing past the
+      // pre-tx check and both attempting to post.
+      const existingInTx = await tx.journalEntry.findFirst({
+        where: {
+          AND: [
+            { metadata: { path: ['flow'], equals: 'year-end-closing' } as any },
+            { metadata: { path: ['year'], equals: year } as any },
+          ],
+          deletedAt: null,
+        },
+      });
+      if (existingInTx) {
+        throw new ConflictException(`ปี ${year} ปิดบัญชีไปแล้ว`);
+      }
+
+      const out = await this.template.execute(year, tx);
+      return out;
+    });
+
+    // Audit log emitted outside tx (best-effort — chain insert can't roll back
+    // a successful JE post anyway, and AuditService.log already has retry/log
+    // semantics built in).
+    await this.auditService.log({
+      userId,
+      action: 'YEAR_END_CLOSED',
+      entity: 'accounting_period',
+      entityId: result.batchId,
+      newValue: {
+        year,
+        batchId: result.batchId,
+        netIncome: result.netIncome.toFixed(2),
+        revenueTotal: result.revenueTotal.toFixed(2),
+        expenseTotal: result.expenseTotal.toFixed(2),
+        step1JournalEntryId: result.step1.journalEntryId,
+        step2JournalEntryId: result.step2.journalEntryId,
+        step3JournalEntryId: result.step3?.journalEntryId ?? null,
+      },
+    });
+
+    this.logger.log(
+      `Year ${year} closed: batchId=${result.batchId} netIncome=${result.netIncome.toFixed(2)} by user ${userId}`,
+    );
+
+    return {
+      year,
+      batchId: result.batchId,
+      step1: result.step1,
+      step2: result.step2,
+      step3: result.step3,
+      netIncome: result.netIncome.toFixed(2),
+      revenueTotal: result.revenueTotal.toFixed(2),
+      expenseTotal: result.expenseTotal.toFixed(2),
+    };
+  }
+
+  /**
+   * OWNER-only escape hatch. Posts 3 mirror-flipped JEs (same date as
+   * originals) and marks all originals with `metadata.reversedByBatchId` so
+   * subsequent post calls succeed once reversal is in place.
+   *
+   * The role check is also enforced at the controller boundary — this is a
+   * defense-in-depth check.
+   */
+  async reverseYearEndClosing(
+    year: number,
+    userId: string,
+    reason: string,
+    userRole?: string,
+  ) {
+    if (userRole && userRole !== 'OWNER') {
+      throw new ForbiddenException('เฉพาะ OWNER เท่านั้นที่กลับรายการปิดบัญชีได้');
+    }
+    if (!reason || reason.trim().length < 10) {
+      throw new BadRequestException('กรุณาระบุเหตุผลการกลับรายการ (อย่างน้อย 10 ตัวอักษร)');
+    }
+
+    const entries = await this.prisma.journalEntry.findMany({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'year-end-closing' } as any },
+          { metadata: { path: ['year'], equals: year } as any },
+        ],
+        deletedAt: null,
+      },
+      include: { lines: { where: { deletedAt: null } } },
+      orderBy: { entryDate: 'asc' },
+    });
+
+    if (entries.length === 0) {
+      throw new NotFoundException(`ไม่พบรายการปิดบัญชีของปี ${year}`);
+    }
+
+    // Filter to the most recent un-reversed batch (in case prior reversal +
+    // re-close exists). batchId groups the 3 entries together.
+    const groupedByBatch = new Map<
+      string,
+      Array<(typeof entries)[number]>
+    >();
+    for (const e of entries) {
+      const meta = e.metadata as { batchId?: string; reversedByBatchId?: string } | null;
+      if (meta?.reversedByBatchId) continue; // skip already-reversed
+      if (!meta?.batchId) continue;
+      const list = groupedByBatch.get(meta.batchId) ?? [];
+      list.push(e);
+      groupedByBatch.set(meta.batchId, list);
+    }
+
+    // The active (latest) batch is the one we'll reverse
+    let activeBatchId: string | null = null;
+    let activeEntries: Array<(typeof entries)[number]> = [];
+    for (const [batchId, batchEntries] of groupedByBatch) {
+      if (batchEntries.length >= 2) {
+        activeBatchId = batchId;
+        activeEntries = batchEntries;
+      }
+    }
+
+    if (!activeBatchId) {
+      throw new ConflictException(`ปี ${year} ไม่มีรายการปิดบัญชีที่ยังไม่ถูกกลับรายการ`);
+    }
+
+    const reverseBatchId = `${activeBatchId}:R`;
+    const now = new Date();
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      const reverseEntries: Array<{
+        originalId: string;
+        reverseEntryNo: string;
+        reverseEntryId: string;
+      }> = [];
+
+      for (const orig of activeEntries) {
+        // Flip Dr/Cr
+        const flippedLines = orig.lines.map((l) => ({
+          accountCode: l.accountCode,
+          dr: new Prisma.Decimal(l.credit.toString()),
+          cr: new Prisma.Decimal(l.debit.toString()),
+          description: l.description
+            ? `[กลับรายการ] ${l.description}`
+            : '[กลับรายการปิดบัญชี]',
+        }));
+
+        const meta = orig.metadata as {
+          year?: number;
+          step?: number;
+          batchId?: string;
+        } | null;
+
+        const reverseResult = await this.journalAuto.createAndPost(
+          {
+            description: `กลับรายการ ${orig.description} (${reason})`,
+            reference: `${activeBatchId}:reverse:step${meta?.step ?? '?'}`,
+            postedAt: now,
+            metadata: {
+              flow: 'year-end-closing-reverse',
+              year,
+              step: meta?.step ?? null,
+              batchId: reverseBatchId,
+              reversesEntryId: orig.id,
+              reverseReason: reason,
+              tag: 'YEAR_END_CLOSING_REVERSE',
+            } as unknown as Prisma.JsonValue,
+            lines: flippedLines,
+          },
+          tx,
+        );
+
+        // Mark the original entry as reversed (metadata-only, NOT status — JEs
+        // retain POSTED for audit trail; the reversal sits beside them).
+        const updatedMeta = {
+          ...(meta ?? {}),
+          reversedByBatchId: reverseBatchId,
+          reversedAt: now.toISOString(),
+          reversedByUserId: userId,
+        };
+        await tx.journalEntry.update({
+          where: { id: orig.id },
+          data: { metadata: updatedMeta as Prisma.InputJsonValue },
+        });
+
+        reverseEntries.push({
+          originalId: orig.id,
+          reverseEntryNo: reverseResult.entryNumber,
+          reverseEntryId: reverseResult.id,
+        });
+      }
+
+      return reverseEntries;
+    });
+
+    await this.auditService.log({
+      userId,
+      action: 'YEAR_END_CLOSING_REVERSED',
+      entity: 'accounting_period',
+      entityId: activeBatchId,
+      oldValue: { year, batchId: activeBatchId },
+      newValue: {
+        year,
+        reverseBatchId,
+        reason,
+        entries: result.map((r) => ({
+          originalId: r.originalId,
+          reverseEntryNo: r.reverseEntryNo,
+        })),
+      },
+    });
+
+    this.logger.warn(
+      `Year ${year} closing batch ${activeBatchId} REVERSED by user ${userId}: ${reason}`,
+    );
+
+    return {
+      year,
+      originalBatchId: activeBatchId,
+      reverseBatchId,
+      entries: result,
+    };
+  }
+
+  // ───────────────────────── Helpers ─────────────────────────
+
+  private validateYear(year: number) {
+    const currentYear = new Date().getFullYear();
+    if (!Number.isInteger(year) || year < 2020 || year > 2030) {
+      throw new BadRequestException('ปีไม่ถูกต้อง (รองรับ 2020-2030)');
+    }
+    if (year >= currentYear) {
+      throw new BadRequestException(
+        `ไม่สามารถปิดบัญชีปี ${year} ได้ — ต้องปิดปีที่ผ่านมาเท่านั้น (ปีปัจจุบัน ${currentYear})`,
+      );
+    }
+  }
+
+  private async findExistingClosingBatch(year: number) {
+    return this.prisma.journalEntry.findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'year-end-closing' } as any },
+          { metadata: { path: ['year'], equals: year } as any },
+          { metadata: { path: ['step'], equals: 1 } as any },
+          // Exclude entries that have a `reversedByBatchId` — those were
+          // reversed by `reverseYearEndClosing` and a fresh re-close is OK.
+        ],
+        deletedAt: null,
+      },
+      orderBy: { createdAt: 'desc' },
+    }).then((e) => {
+      if (!e) return null;
+      const meta = e.metadata as { reversedByBatchId?: string } | null;
+      if (meta?.reversedByBatchId) return null;
+      return e;
+    });
+  }
+
+  /**
+   * Returns array of months whose AccountingPeriod for FINANCE company is
+   * NOT CLOSED/SYNCED. Empty array = all 12 months are closed.
+   */
+  private async findOpenMonthlyPeriods(
+    year: number,
+  ): Promise<Array<{ month: number; status: string }>> {
+    const financeCompany = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE', deletedAt: null },
+      select: { id: true },
+    });
+    if (!financeCompany) {
+      throw new BadRequestException('ไม่พบ FINANCE company ในระบบ');
+    }
+
+    const periods = await this.prisma.accountingPeriod.findMany({
+      where: { companyId: financeCompany.id, year },
+      select: { month: true, status: true },
+    });
+
+    const periodMap = new Map(periods.map((p) => [p.month, p.status]));
+    const issues: Array<{ month: number; status: string }> = [];
+
+    for (let month = 1; month <= 12; month++) {
+      const status = periodMap.get(month);
+      // Missing OR OPEN/REVIEW = not closed
+      if (!status || (status !== 'CLOSED' && status !== 'SYNCED')) {
+        issues.push({ month, status: status ?? 'OPEN' });
+      }
+    }
+
+    return issues;
+  }
+
+}

--- a/apps/api/src/modules/accounting/dto/year-end-closing.dto.ts
+++ b/apps/api/src/modules/accounting/dto/year-end-closing.dto.ts
@@ -1,18 +1,19 @@
-import { IsInt, IsNotEmpty, IsString, Max, Min, MinLength } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString, Min, MinLength } from 'class-validator';
 import { Type } from 'class-transformer';
 
 /**
  * P3-SP1 — Year-End Closing DTOs.
  *
- * Year window is 2020–2030 (deliberately wide so historical backfill is
- * possible). The service further restricts the year to < current year
- * (cannot close future or in-progress fiscal year).
+ * Year lower bound is 2020 (historical backfill window). No upper bound is
+ * applied here — the service-side `validateYear` enforces `year < currentYear`
+ * which is the meaningful guard (cannot close future or in-progress fiscal
+ * year). Hardcoding an upper bound here would silently break the system in
+ * that year (e.g. `Max(2030)` would 400 every request starting Jan 2031).
  */
 export class YearEndClosingPreviewDto {
   @Type(() => Number)
   @IsInt({ message: 'ปีต้องเป็นตัวเลข' })
   @Min(2020, { message: 'ปีต้องไม่น้อยกว่า 2020' })
-  @Max(2030, { message: 'ปีต้องไม่มากกว่า 2030' })
   year!: number;
 }
 
@@ -20,7 +21,6 @@ export class YearEndClosingPostDto {
   @Type(() => Number)
   @IsInt({ message: 'ปีต้องเป็นตัวเลข' })
   @Min(2020, { message: 'ปีต้องไม่น้อยกว่า 2020' })
-  @Max(2030, { message: 'ปีต้องไม่มากกว่า 2030' })
   year!: number;
 }
 
@@ -28,7 +28,6 @@ export class YearEndClosingReverseDto {
   @Type(() => Number)
   @IsInt({ message: 'ปีต้องเป็นตัวเลข' })
   @Min(2020, { message: 'ปีต้องไม่น้อยกว่า 2020' })
-  @Max(2030, { message: 'ปีต้องไม่มากกว่า 2030' })
   year!: number;
 
   @IsString({ message: 'กรุณาระบุเหตุผลการกลับรายการ' })

--- a/apps/api/src/modules/accounting/dto/year-end-closing.dto.ts
+++ b/apps/api/src/modules/accounting/dto/year-end-closing.dto.ts
@@ -1,0 +1,38 @@
+import { IsInt, IsNotEmpty, IsString, Max, Min, MinLength } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * P3-SP1 — Year-End Closing DTOs.
+ *
+ * Year window is 2020–2030 (deliberately wide so historical backfill is
+ * possible). The service further restricts the year to < current year
+ * (cannot close future or in-progress fiscal year).
+ */
+export class YearEndClosingPreviewDto {
+  @Type(() => Number)
+  @IsInt({ message: 'ปีต้องเป็นตัวเลข' })
+  @Min(2020, { message: 'ปีต้องไม่น้อยกว่า 2020' })
+  @Max(2030, { message: 'ปีต้องไม่มากกว่า 2030' })
+  year!: number;
+}
+
+export class YearEndClosingPostDto {
+  @Type(() => Number)
+  @IsInt({ message: 'ปีต้องเป็นตัวเลข' })
+  @Min(2020, { message: 'ปีต้องไม่น้อยกว่า 2020' })
+  @Max(2030, { message: 'ปีต้องไม่มากกว่า 2030' })
+  year!: number;
+}
+
+export class YearEndClosingReverseDto {
+  @Type(() => Number)
+  @IsInt({ message: 'ปีต้องเป็นตัวเลข' })
+  @Min(2020, { message: 'ปีต้องไม่น้อยกว่า 2020' })
+  @Max(2030, { message: 'ปีต้องไม่มากกว่า 2030' })
+  year!: number;
+
+  @IsString({ message: 'กรุณาระบุเหตุผลการกลับรายการ' })
+  @IsNotEmpty({ message: 'กรุณาระบุเหตุผลการกลับรายการ' })
+  @MinLength(10, { message: 'เหตุผลต้องยาวอย่างน้อย 10 ตัวอักษร' })
+  reason!: string;
+}

--- a/apps/api/src/modules/journal/cpa-templates/year-end-closing.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/year-end-closing.template.ts
@@ -1,0 +1,343 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { JournalAutoService } from '../journal-auto.service';
+
+/**
+ * Template — Year-End Closing (P3-SP1).
+ *
+ * Closes all Revenue (41-XXXX, 42-XXXX) and Expense (51-XXXX, 52-XXXX,
+ * 53-XXXX, 54-XXXX) accounts into the Income Summary account (39-9999)
+ * for a fiscal year, then transfers the net income/loss from 39-9999
+ * to Retained Earnings (33-1101 — กำไร(ขาดทุน)สุทธิประจำปี).
+ *
+ * Posts EXACTLY 3 JournalEntry rows, all linked through metadata.batchId:
+ *
+ *   Step 1 — Close revenue
+ *     Dr 41-XXXX, 42-XXXX (each non-zero net)
+ *       Cr 39-9999 Income Summary
+ *
+ *   Step 2 — Close expenses
+ *     Dr 39-9999 Income Summary
+ *       Cr 51-XXXX, 52-XXXX, 53-XXXX, 54-XXXX (each non-zero net)
+ *
+ *   Step 3 — Transfer to retained earnings
+ *     If net income > 0:  Dr 39-9999 / Cr 33-1101 [netIncome]
+ *     If net loss   < 0:  Dr 33-1101 / Cr 39-9999 [absLoss]
+ *     If exactly 0:        no Step 3 emitted (returns step3 = null)
+ *
+ * Balances are computed from posted JournalLine rows whose JournalEntry.entryDate
+ * falls in the Asia/Bangkok local year [Jan 1 00:00, Dec 31 23:59:59.999].
+ *
+ * Accounts with zero net (within 0.005 tolerance) are SKIPPED — no no-op lines.
+ *
+ * Idempotency: callers (AccountingClosingService.postYearEndClosing) are
+ * responsible for checking that no prior YEAR_END_CLOSING JE exists for the
+ * year. Template itself does not gate — wrap in $transaction so all 3 entries
+ * commit together or roll back together.
+ */
+@Injectable()
+export class YearEndClosingTemplate {
+  private readonly logger = new Logger(YearEndClosingTemplate.name);
+
+  // Income Summary + Retained Earnings codes (FINANCE chart)
+  static readonly INCOME_SUMMARY_CODE = '39-9999';
+  static readonly RETAINED_EARNINGS_CODE = '33-1101';
+  static readonly REVENUE_PREFIXES = ['41', '42'] as const;
+  static readonly EXPENSE_PREFIXES = ['51', '52', '53', '54'] as const;
+
+  constructor(
+    private readonly journal: JournalAutoService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * Calculate Asia/Bangkok local-year boundary as UTC instants.
+   * Jan 1, YYYY 00:00:00.000 BKK = Dec 31, YYYY-1 17:00 UTC
+   * Dec 31, YYYY 23:59:59.999 BKK = Dec 31, YYYY 16:59:59.999 UTC
+   * Bangkok is UTC+7 with no DST.
+   */
+  static bkkYearBounds(year: number): { start: Date; end: Date } {
+    // 00:00 BKK = 17:00 prev day UTC
+    const start = new Date(Date.UTC(year - 1, 11, 31, 17, 0, 0, 0));
+    // 23:59:59.999 BKK = 16:59:59.999 same day UTC
+    const end = new Date(Date.UTC(year, 11, 31, 16, 59, 59, 999));
+    return { start, end };
+  }
+
+  /**
+   * Compute net balance per account for the BKK year window.
+   * Returns Map<accountCode, { name, netDr, netCr }> for accounts touched
+   * by at least one POSTED JournalLine in window.
+   */
+  async getYearAccountActivity(
+    year: number,
+  ): Promise<{
+    revenues: Array<{ code: string; name: string; balance: Prisma.Decimal }>;
+    expenses: Array<{ code: string; name: string; balance: Prisma.Decimal }>;
+    revenueTotal: Prisma.Decimal;
+    expenseTotal: Prisma.Decimal;
+    netIncome: Prisma.Decimal;
+  }> {
+    const { start, end } = YearEndClosingTemplate.bkkYearBounds(year);
+
+    const lineSums = await this.prisma.journalLine.groupBy({
+      by: ['accountCode'],
+      where: {
+        journalEntry: {
+          status: 'POSTED',
+          entryDate: { gte: start, lte: end },
+          deletedAt: null,
+        },
+        deletedAt: null,
+      },
+      _sum: { debit: true, credit: true },
+    });
+
+    const codes = lineSums.map((r) => r.accountCode);
+    const coa =
+      codes.length > 0
+        ? await this.prisma.chartOfAccount.findMany({
+            where: { code: { in: codes }, deletedAt: null },
+            select: { code: true, name: true },
+          })
+        : [];
+    const nameMap = new Map(coa.map((c) => [c.code, c.name]));
+
+    const revenues: Array<{ code: string; name: string; balance: Prisma.Decimal }> = [];
+    const expenses: Array<{ code: string; name: string; balance: Prisma.Decimal }> = [];
+    let revenueTotal = new Prisma.Decimal(0);
+    let expenseTotal = new Prisma.Decimal(0);
+
+    for (const row of lineSums) {
+      const prefix = row.accountCode.slice(0, 2);
+      const dr = new Prisma.Decimal((row._sum.debit ?? 0).toString());
+      const cr = new Prisma.Decimal((row._sum.credit ?? 0).toString());
+      const name = nameMap.get(row.accountCode) ?? row.accountCode;
+
+      if ((YearEndClosingTemplate.REVENUE_PREFIXES as readonly string[]).includes(prefix)) {
+        // Revenue is Cr-normal: net credit balance = cr - dr
+        const balance = cr.sub(dr);
+        if (!this.isEffectivelyZero(balance)) {
+          revenues.push({ code: row.accountCode, name, balance });
+          revenueTotal = revenueTotal.add(balance);
+        }
+      } else if ((YearEndClosingTemplate.EXPENSE_PREFIXES as readonly string[]).includes(prefix)) {
+        // Expense is Dr-normal: net debit balance = dr - cr
+        const balance = dr.sub(cr);
+        if (!this.isEffectivelyZero(balance)) {
+          expenses.push({ code: row.accountCode, name, balance });
+          expenseTotal = expenseTotal.add(balance);
+        }
+      }
+      // 55-XXXX or other prefixes (assets/liabilities/equity): skipped
+    }
+
+    revenues.sort((a, b) => a.code.localeCompare(b.code));
+    expenses.sort((a, b) => a.code.localeCompare(b.code));
+
+    return {
+      revenues,
+      expenses,
+      revenueTotal,
+      expenseTotal,
+      netIncome: revenueTotal.sub(expenseTotal),
+    };
+  }
+
+  private isEffectivelyZero(d: Prisma.Decimal): boolean {
+    // <0.005 absolute is treated as zero (rounding noise below 0.01 cent)
+    return d.abs().lessThan(new Prisma.Decimal('0.005'));
+  }
+
+  /**
+   * Post the 3 closing JEs (step 1 + 2, plus step 3 if net != 0).
+   * MUST be invoked from inside a $transaction by the caller, OR pass no
+   * outerTx and the template will manage its own $transaction.
+   */
+  async execute(
+    year: number,
+    outerTx?: Prisma.TransactionClient,
+  ): Promise<{
+    batchId: string;
+    step1: { entryNo: string; journalEntryId: string };
+    step2: { entryNo: string; journalEntryId: string };
+    step3: { entryNo: string; journalEntryId: string } | null;
+    netIncome: Prisma.Decimal;
+    revenueTotal: Prisma.Decimal;
+    expenseTotal: Prisma.Decimal;
+  }> {
+    const activity = await this.getYearAccountActivity(year);
+    const { revenues, expenses, revenueTotal, expenseTotal, netIncome } = activity;
+
+    if (revenues.length === 0 && expenses.length === 0) {
+      throw new BadRequestException(
+        `ปี ${year} ไม่มี Journal Entry รายได้/ค่าใช้จ่าย — ไม่จำเป็นต้องปิดบัญชี`,
+      );
+    }
+
+    // postedAt = Dec 31 23:59:59.999 BKK — keeps year-end JE inside the year
+    const { end: yearEndAt } = YearEndClosingTemplate.bkkYearBounds(year);
+    const batchId = randomUUID();
+
+    const ZERO = new Prisma.Decimal(0);
+    const ISC = YearEndClosingTemplate.INCOME_SUMMARY_CODE;
+    const REC = YearEndClosingTemplate.RETAINED_EARNINGS_CODE;
+
+    const run = async (tx: Prisma.TransactionClient) => {
+      // ── Step 1: Close revenue → 39-9999 ───────────────────────────────
+      const step1Lines = revenues.map((r) => ({
+        accountCode: r.code,
+        dr: r.balance,
+        cr: ZERO,
+        description: `ปิดบัญชี ${r.name} ปี ${year}`,
+      }));
+      step1Lines.push({
+        accountCode: ISC,
+        dr: ZERO,
+        cr: revenueTotal,
+        description: `รวมรายได้เข้า Income Summary ปี ${year}`,
+      });
+
+      const step1 = await this.journal.createAndPost(
+        {
+          description: `ปิดบัญชีรายได้ ปี ${year}`,
+          reference: `${year}:year-end-closing:step1`,
+          postedAt: yearEndAt,
+          metadata: {
+            flow: 'year-end-closing',
+            year,
+            step: 1,
+            batchId,
+            tag: 'YEAR_END_CLOSING',
+          },
+          lines: step1Lines,
+        },
+        tx,
+      );
+
+      // ── Step 2: Close expenses ← 39-9999 ──────────────────────────────
+      const step2Lines: {
+        accountCode: string;
+        dr: Prisma.Decimal;
+        cr: Prisma.Decimal;
+        description: string;
+      }[] = [
+        {
+          accountCode: ISC,
+          dr: expenseTotal,
+          cr: ZERO,
+          description: `รวมค่าใช้จ่ายจาก Income Summary ปี ${year}`,
+        },
+        ...expenses.map((e) => ({
+          accountCode: e.code,
+          dr: ZERO,
+          cr: e.balance,
+          description: `ปิดบัญชี ${e.name} ปี ${year}`,
+        })),
+      ];
+
+      const step2 = await this.journal.createAndPost(
+        {
+          description: `ปิดบัญชีค่าใช้จ่าย ปี ${year}`,
+          reference: `${year}:year-end-closing:step2`,
+          postedAt: yearEndAt,
+          metadata: {
+            flow: 'year-end-closing',
+            year,
+            step: 2,
+            batchId,
+            tag: 'YEAR_END_CLOSING',
+          },
+          lines: step2Lines,
+        },
+        tx,
+      );
+
+      // ── Step 3: Transfer net to 33-1101 (skip if exactly zero) ────────
+      let step3: { entryNo: string; journalEntryId: string } | null = null;
+
+      if (!this.isEffectivelyZero(netIncome)) {
+        const isProfit = netIncome.gt(0);
+        const absAmount = netIncome.abs();
+
+        const step3Lines = isProfit
+          ? [
+              {
+                accountCode: ISC,
+                dr: absAmount,
+                cr: ZERO,
+                description: `โอนกำไรสุทธิเข้า กำไรสะสม ปี ${year}`,
+              },
+              {
+                accountCode: REC,
+                dr: ZERO,
+                cr: absAmount,
+                description: `กำไรสุทธิประจำปี ${year}`,
+              },
+            ]
+          : [
+              {
+                accountCode: REC,
+                dr: absAmount,
+                cr: ZERO,
+                description: `รับโอนขาดทุนสุทธิประจำปี ${year}`,
+              },
+              {
+                accountCode: ISC,
+                dr: ZERO,
+                cr: absAmount,
+                description: `โอนขาดทุนสุทธิจาก Income Summary ปี ${year}`,
+              },
+            ];
+
+        const step3Result = await this.journal.createAndPost(
+          {
+            description: isProfit
+              ? `โอนกำไรสุทธิเข้ากำไรสะสม ปี ${year}`
+              : `โอนขาดทุนสุทธิเข้ากำไรสะสม ปี ${year}`,
+            reference: `${year}:year-end-closing:step3`,
+            postedAt: yearEndAt,
+            metadata: {
+              flow: 'year-end-closing',
+              year,
+              step: 3,
+              batchId,
+              tag: 'YEAR_END_CLOSING',
+              netIncome: netIncome.toFixed(2),
+            },
+            lines: step3Lines,
+          },
+          tx,
+        );
+
+        step3 = {
+          entryNo: step3Result.entryNumber,
+          journalEntryId: step3Result.id,
+        };
+      }
+
+      return {
+        batchId,
+        step1: { entryNo: step1.entryNumber, journalEntryId: step1.id },
+        step2: { entryNo: step2.entryNumber, journalEntryId: step2.id },
+        step3,
+        netIncome,
+        revenueTotal,
+        expenseTotal,
+      };
+    };
+
+    const out = outerTx ? await run(outerTx) : await this.prisma.$transaction(run);
+
+    this.logger.log(
+      `YearEndClosingTemplate posted batch ${batchId} for ${year}: ` +
+        `step1=${out.step1.entryNo} step2=${out.step2.entryNo} ` +
+        `step3=${out.step3?.entryNo ?? '(none — net=0)'} ` +
+        `netIncome=${out.netIncome.toFixed(2)}`,
+    );
+
+    return out;
+  }
+}

--- a/apps/api/src/modules/journal/cpa-templates/year-end-closing.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/year-end-closing.template.ts
@@ -187,16 +187,36 @@ export class YearEndClosingTemplate {
 
     const run = async (tx: Prisma.TransactionClient) => {
       // ── Step 1: Close revenue → 39-9999 ───────────────────────────────
-      const step1Lines = revenues.map((r) => ({
-        accountCode: r.code,
-        dr: r.balance,
-        cr: ZERO,
-        description: `ปิดบัญชี ${r.name} ปี ${year}`,
-      }));
+      //
+      // Revenue is Cr-normal. Closing entry Dr's the revenue account to
+      // zero it out, Cr's Income Summary by the same total.
+      //
+      // If a revenue account ends the year with a NET DEBIT balance (e.g.
+      // refunds exceed sales), `balance` from getYearAccountActivity is
+      // negative. Posting `dr: <negative>` is mathematically balanced but
+      // not standard accounting practice — we flip the side so a negative
+      // revenue posts as `Cr <abs>` on the revenue account (effectively
+      // unwinding the abnormal Dr balance). The matching Income Summary
+      // contribution flips too, but the net impact on the ISC side is
+      // already captured in `revenueTotal` (it nets the negatives), so
+      // the contra line stays uniform on the Cr side.
+      const step1Lines = revenues.map((r) => {
+        const isAbnormal = r.balance.isNegative();
+        return {
+          accountCode: r.code,
+          dr: isAbnormal ? ZERO : r.balance,
+          cr: isAbnormal ? r.balance.abs() : ZERO,
+          description: `ปิดบัญชี ${r.name} ปี ${year}`,
+        };
+      });
+      // Revenue contra into Income Summary. `revenueTotal` already nets
+      // any negative balances. If the overall net is negative (highly
+      // unusual — all revenue accounts net-debit), post the opposite side.
+      const revenueTotalAbnormal = revenueTotal.isNegative();
       step1Lines.push({
         accountCode: ISC,
-        dr: ZERO,
-        cr: revenueTotal,
+        dr: revenueTotalAbnormal ? revenueTotal.abs() : ZERO,
+        cr: revenueTotalAbnormal ? ZERO : revenueTotal,
         description: `รวมรายได้เข้า Income Summary ปี ${year}`,
       });
 
@@ -218,6 +238,15 @@ export class YearEndClosingTemplate {
       );
 
       // ── Step 2: Close expenses ← 39-9999 ──────────────────────────────
+      //
+      // Expense is Dr-normal. Closing entry Cr's the expense account to
+      // zero it out, Dr's Income Summary by the same total.
+      //
+      // If an expense account ends the year with a NET CREDIT (e.g.
+      // refunds/recoveries exceed billed expense), `balance` is negative.
+      // We flip the side: post `Dr <abs>` on the expense account to
+      // unwind the abnormal Cr position, with matching adjustment on ISC.
+      const expenseTotalAbnormal = expenseTotal.isNegative();
       const step2Lines: {
         accountCode: string;
         dr: Prisma.Decimal;
@@ -226,16 +255,19 @@ export class YearEndClosingTemplate {
       }[] = [
         {
           accountCode: ISC,
-          dr: expenseTotal,
-          cr: ZERO,
+          dr: expenseTotalAbnormal ? ZERO : expenseTotal,
+          cr: expenseTotalAbnormal ? expenseTotal.abs() : ZERO,
           description: `รวมค่าใช้จ่ายจาก Income Summary ปี ${year}`,
         },
-        ...expenses.map((e) => ({
-          accountCode: e.code,
-          dr: ZERO,
-          cr: e.balance,
-          description: `ปิดบัญชี ${e.name} ปี ${year}`,
-        })),
+        ...expenses.map((e) => {
+          const isAbnormal = e.balance.isNegative();
+          return {
+            accountCode: e.code,
+            dr: isAbnormal ? e.balance.abs() : ZERO,
+            cr: isAbnormal ? ZERO : e.balance,
+            description: `ปิดบัญชี ${e.name} ปี ${year}`,
+          };
+        }),
       ];
 
       const step2 = await this.journal.createAndPost(

--- a/apps/api/src/modules/journal/journal.module.ts
+++ b/apps/api/src/modules/journal/journal.module.ts
@@ -37,6 +37,7 @@ import { CreditNoteTemplate } from './cpa-templates/credit-note.template';
 import { PayrollTemplate } from './cpa-templates/payroll.template';
 import { VendorSettlementTemplate } from './cpa-templates/vendor-settlement.template';
 import { PettyCashTemplate } from './cpa-templates/petty-cash.template';
+import { YearEndClosingTemplate } from './cpa-templates/year-end-closing.template';
 
 @Module({
   imports: [PrismaModule],
@@ -78,6 +79,7 @@ import { PettyCashTemplate } from './cpa-templates/petty-cash.template';
     PayrollTemplate,
     VendorSettlementTemplate,
     PettyCashTemplate,
+    YearEndClosingTemplate,
   ],
   exports: [
     JournalService,
@@ -113,6 +115,7 @@ import { PettyCashTemplate } from './cpa-templates/petty-cash.template';
     PayrollTemplate,
     VendorSettlementTemplate,
     PettyCashTemplate,
+    YearEndClosingTemplate,
   ],
 })
 export class JournalModule {}

--- a/apps/api/src/modules/journal/year-end-closing.template.spec.ts
+++ b/apps/api/src/modules/journal/year-end-closing.template.spec.ts
@@ -123,5 +123,164 @@ describe('YearEndClosingTemplate (unit)', () => {
       const out = await t.getYearAccountActivity(2026);
       expect(out.netIncome.toFixed(2)).toBe('-40000.00');
     });
+
+    it('preserves negative balance for revenue with net DEBIT position', async () => {
+      // Revenue Cr-normal but ended year with Dr > Cr (refunds > sales)
+      const t = buildTemplate([
+        { accountCode: '41-1101', _sum: { debit: '5000', credit: '1000' } },
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.revenues).toHaveLength(1);
+      // cr - dr = 1000 - 5000 = -4000 (kept negative; execute() flips side)
+      expect(out.revenues[0].balance.toFixed(2)).toBe('-4000.00');
+    });
+
+    it('preserves negative balance for expense with net CREDIT position', async () => {
+      // Expense Dr-normal but ended year with Cr > Dr (refunds/recoveries)
+      const t = buildTemplate([
+        { accountCode: '51-1101', _sum: { debit: '500', credit: '2000' } },
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.expenses).toHaveLength(1);
+      // dr - cr = 500 - 2000 = -1500
+      expect(out.expenses[0].balance.toFixed(2)).toBe('-1500.00');
+    });
+  });
+
+  describe('execute (negative-balance JE flip)', () => {
+    function buildTemplateWithJournal(
+      rows: Array<{ accountCode: string; _sum: { debit: string; credit: string } }>,
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const journalCalls: any[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const journal: any = {
+        createAndPost: jest.fn().mockImplementation((dto: any) => {
+          journalCalls.push(dto);
+          return Promise.resolve({
+            id: `je-${journalCalls.length}`,
+            entryNumber: `JE-${journalCalls.length}`,
+          });
+        }),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prisma: any = {
+        journalLine: {
+          groupBy: jest.fn().mockResolvedValue(
+            rows.map((r) => ({
+              accountCode: r.accountCode,
+              _sum: {
+                debit: new Prisma.Decimal(r._sum.debit),
+                credit: new Prisma.Decimal(r._sum.credit),
+              },
+            })),
+          ),
+        },
+        chartOfAccount: {
+          findMany: jest.fn().mockResolvedValue(
+            rows.map((r) => ({ code: r.accountCode, name: `Name ${r.accountCode}` })),
+          ),
+        },
+        // Pass through $transaction so execute() can run without a real DB
+        $transaction: jest.fn().mockImplementation(async (fn: any) => fn(prisma)),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const template = new YearEndClosingTemplate(journal as any, prisma as any);
+      return { template, journal, journalCalls };
+    }
+
+    it('flips revenue Dr/Cr when balance is negative (refunds > sales)', async () => {
+      // 41-1101 has Dr 5000 + Cr 1000 → net -4000 (abnormal Dr position)
+      // 51-1101 normal Dr 1000 → expense 1000
+      // Net income = -4000 - 1000 = -5000 (loss)
+      const { template, journalCalls } = buildTemplateWithJournal([
+        { accountCode: '41-1101', _sum: { debit: '5000', credit: '1000' } },
+        { accountCode: '51-1101', _sum: { debit: '1000', credit: '0' } },
+      ]);
+
+      await template.execute(2026);
+
+      // Step 1 = close revenue. Find the 41-1101 line in step 1.
+      const step1 = journalCalls[0];
+      const revenueLine = step1.lines.find(
+        (l: { accountCode: string }) => l.accountCode === '41-1101',
+      );
+      // Abnormal negative balance must post as Cr (not negative Dr)
+      expect(revenueLine.dr.toString()).toBe('0');
+      expect(revenueLine.cr.toString()).toBe('4000');
+
+      // Income Summary side must mirror to keep entry balanced
+      const iscLine = step1.lines.find(
+        (l: { accountCode: string }) => l.accountCode === '39-9999',
+      );
+      // Net revenue total is -4000 (abnormal). Cr revenue 4000 + Dr ISC 4000.
+      expect(iscLine.dr.toString()).toBe('4000');
+      expect(iscLine.cr.toString()).toBe('0');
+
+      // Verify the entry is still balanced (Dr total = Cr total)
+      const drTotal = step1.lines.reduce(
+        (acc: Prisma.Decimal, l: { dr: Prisma.Decimal }) => acc.add(l.dr),
+        new Prisma.Decimal(0),
+      );
+      const crTotal = step1.lines.reduce(
+        (acc: Prisma.Decimal, l: { cr: Prisma.Decimal }) => acc.add(l.cr),
+        new Prisma.Decimal(0),
+      );
+      expect(drTotal.toString()).toBe(crTotal.toString());
+    });
+
+    it('flips expense Dr/Cr when balance is negative (recoveries > expense)', async () => {
+      const { template, journalCalls } = buildTemplateWithJournal([
+        { accountCode: '41-1101', _sum: { debit: '0', credit: '10000' } },
+        // 51-1101 abnormal Cr position: Dr 200 + Cr 800 → net -600
+        { accountCode: '51-1101', _sum: { debit: '200', credit: '800' } },
+      ]);
+
+      await template.execute(2026);
+
+      // Step 2 = close expenses
+      const step2 = journalCalls[1];
+      const expenseLine = step2.lines.find(
+        (l: { accountCode: string }) => l.accountCode === '51-1101',
+      );
+      // Abnormal negative balance must post as Dr (not negative Cr)
+      expect(expenseLine.dr.toString()).toBe('600');
+      expect(expenseLine.cr.toString()).toBe('0');
+
+      const iscLine = step2.lines.find(
+        (l: { accountCode: string }) => l.accountCode === '39-9999',
+      );
+      // Net expense total is -600 (abnormal). Dr expense 600 + Cr ISC 600.
+      expect(iscLine.dr.toString()).toBe('0');
+      expect(iscLine.cr.toString()).toBe('600');
+
+      // Balance check
+      const drTotal = step2.lines.reduce(
+        (acc: Prisma.Decimal, l: { dr: Prisma.Decimal }) => acc.add(l.dr),
+        new Prisma.Decimal(0),
+      );
+      const crTotal = step2.lines.reduce(
+        (acc: Prisma.Decimal, l: { cr: Prisma.Decimal }) => acc.add(l.cr),
+        new Prisma.Decimal(0),
+      );
+      expect(drTotal.toString()).toBe(crTotal.toString());
+    });
+
+    it('normal-side path unchanged for positive balances (no regression)', async () => {
+      const { template, journalCalls } = buildTemplateWithJournal([
+        { accountCode: '41-1101', _sum: { debit: '0', credit: '10000' } },
+        { accountCode: '51-1101', _sum: { debit: '3000', credit: '0' } },
+      ]);
+
+      await template.execute(2026);
+
+      const step1 = journalCalls[0];
+      const revenueLine = step1.lines.find(
+        (l: { accountCode: string }) => l.accountCode === '41-1101',
+      );
+      // Normal Cr-normal revenue → close with Dr <balance>
+      expect(revenueLine.dr.toString()).toBe('10000');
+      expect(revenueLine.cr.toString()).toBe('0');
+    });
   });
 });

--- a/apps/api/src/modules/journal/year-end-closing.template.spec.ts
+++ b/apps/api/src/modules/journal/year-end-closing.template.spec.ts
@@ -1,0 +1,127 @@
+import { Prisma } from '@prisma/client';
+import { YearEndClosingTemplate } from './cpa-templates/year-end-closing.template';
+
+/**
+ * Unit tests for the YearEndClosingTemplate helpers (jest — placed outside the
+ * cpa-templates/ directory because jest's `testPathIgnorePatterns` excludes
+ * that path; cpa-templates specs are vitest-integration tests run separately).
+ *
+ * Avoids real DB — exercises:
+ *  - bkkYearBounds: correct UTC instants for Asia/Bangkok year window
+ *  - getYearAccountActivity: revenue/expense classification + zero-skip
+ *  - prefix filter: 55-XXXX and other prefixes ignored
+ *  - netIncome sign for profit vs loss
+ */
+describe('YearEndClosingTemplate (unit)', () => {
+  describe('bkkYearBounds', () => {
+    it('returns Jan 1 00:00 BKK as start for the year', () => {
+      const { start } = YearEndClosingTemplate.bkkYearBounds(2026);
+      // 00:00 BKK = 17:00 prev day UTC (BKK = UTC+7, no DST)
+      expect(start.toISOString()).toBe('2025-12-31T17:00:00.000Z');
+    });
+
+    it('returns Dec 31 23:59:59.999 BKK as end for the year', () => {
+      const { end } = YearEndClosingTemplate.bkkYearBounds(2026);
+      expect(end.toISOString()).toBe('2026-12-31T16:59:59.999Z');
+    });
+
+    it('window covers exactly one calendar year (~365 days)', () => {
+      const { start, end } = YearEndClosingTemplate.bkkYearBounds(2027);
+      const days = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24);
+      expect(days).toBeGreaterThan(364.999);
+      expect(days).toBeLessThan(365.001);
+    });
+  });
+
+  describe('getYearAccountActivity', () => {
+    function buildTemplate(
+      rows: Array<{ accountCode: string; _sum: { debit: string; credit: string } }>,
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prisma: any = {
+        journalLine: {
+          groupBy: jest.fn().mockResolvedValue(
+            rows.map((r) => ({
+              accountCode: r.accountCode,
+              _sum: {
+                debit: new Prisma.Decimal(r._sum.debit),
+                credit: new Prisma.Decimal(r._sum.credit),
+              },
+            })),
+          ),
+        },
+        chartOfAccount: {
+          findMany: jest.fn().mockResolvedValue(
+            rows.map((r) => ({ code: r.accountCode, name: `Name ${r.accountCode}` })),
+          ),
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return new YearEndClosingTemplate({} as any, prisma);
+    }
+
+    it('classifies 41-XXXX / 42-XXXX as revenue (Cr-normal)', async () => {
+      const t = buildTemplate([
+        { accountCode: '41-1101', _sum: { debit: '0', credit: '100000' } },
+        { accountCode: '42-1102', _sum: { debit: '0', credit: '5000' } },
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.revenues).toHaveLength(2);
+      expect(out.revenueTotal.toFixed(2)).toBe('105000.00');
+      expect(out.expenses).toHaveLength(0);
+    });
+
+    it('classifies 51/52/53/54-XXXX as expense (Dr-normal)', async () => {
+      const t = buildTemplate([
+        { accountCode: '51-1101', _sum: { debit: '10000', credit: '0' } },
+        { accountCode: '52-1104', _sum: { debit: '500', credit: '0' } },
+        { accountCode: '53-1503', _sum: { debit: '200', credit: '0' } },
+        { accountCode: '54-1101', _sum: { debit: '300', credit: '0' } },
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.expenses).toHaveLength(4);
+      expect(out.expenseTotal.toFixed(2)).toBe('11000.00');
+    });
+
+    it('skips accounts with zero net balance', async () => {
+      const t = buildTemplate([
+        { accountCode: '41-1101', _sum: { debit: '100', credit: '100' } }, // net 0 — skip
+        { accountCode: '41-1102', _sum: { debit: '0', credit: '500' } }, // keep
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.revenues).toHaveLength(1);
+      expect(out.revenues[0].code).toBe('41-1102');
+    });
+
+    it('IGNORES non-rev/non-exp prefixes (11-XXXX assets, 55-XXXX, 21-XXXX liab)', async () => {
+      const t = buildTemplate([
+        { accountCode: '11-2101', _sum: { debit: '999999', credit: '0' } },
+        { accountCode: '55-1101', _sum: { debit: '12345', credit: '0' } },
+        { accountCode: '21-2101', _sum: { debit: '0', credit: '500' } },
+        { accountCode: '41-1101', _sum: { debit: '0', credit: '100' } },
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.revenues).toHaveLength(1);
+      expect(out.expenses).toHaveLength(0);
+      expect(out.revenueTotal.toFixed(2)).toBe('100.00');
+    });
+
+    it('netIncome = revenue - expense (profit case)', async () => {
+      const t = buildTemplate([
+        { accountCode: '41-1101', _sum: { debit: '0', credit: '100000' } },
+        { accountCode: '51-1101', _sum: { debit: '30000', credit: '0' } },
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.netIncome.toFixed(2)).toBe('70000.00');
+    });
+
+    it('netIncome < 0 for loss case', async () => {
+      const t = buildTemplate([
+        { accountCode: '41-1101', _sum: { debit: '0', credit: '10000' } },
+        { accountCode: '51-1101', _sum: { debit: '50000', credit: '0' } },
+      ]);
+      const out = await t.getYearAccountActivity(2026);
+      expect(out.netIncome.toFixed(2)).toBe('-40000.00');
+    });
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -156,6 +156,7 @@ const CollectionsPage = lazy(() => import('@/pages/CollectionsPage'));
 const DunningSettingsPage = lazy(() => import('@/pages/DunningSettingsPage'));
 const SmsTemplatesPage = lazy(() => import('@/pages/SmsTemplatesPage'));
 const MonthlyClosePage = lazy(() => import('@/pages/MonthlyClosePage'));
+const YearEndClosingPage = lazy(() => import('@/pages/YearEndClosingPage'));
 const IntercompanySettlementPage = lazy(() => import('@/pages/IntercompanySettlementPage'));
 // SP2 — Accounting Reports Gap
 const CashFlowPage = lazy(() =>
@@ -726,6 +727,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <MonthlyClosePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/year-end-closing"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <YearEndClosingPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -337,6 +337,7 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
         // SP6 — Bank/Cash account directory
         { label: 'บัญชีเงินสด/ธนาคาร', path: '/finance/bank-accounts', icon: Landmark },
         { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
+        { label: 'ปิดบัญชีสิ้นปี', path: '/finance/year-end-closing', icon: CalendarDays },
       ],
     },
     assetMenuSection,
@@ -405,6 +406,7 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
+        { label: 'ปิดบัญชีสิ้นปี', path: '/finance/year-end-closing', icon: CalendarDays },
         { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
         { label: 'ชำระเงินระหว่างบริษัท', path: '/accounting/intercompany', icon: ClipboardList },
         { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
@@ -569,6 +571,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
           icon: CalendarDays,
           children: [
             { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
+            { label: 'ปิดบัญชีสิ้นปี', path: '/finance/year-end-closing', icon: CalendarDays },
             { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
             { label: 'ชำระเงินระหว่างบริษัท', path: '/accounting/intercompany', icon: ClipboardList },
           ],

--- a/apps/web/src/pages/YearEndClosingPage.test.tsx
+++ b/apps/web/src/pages/YearEndClosingPage.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import YearEndClosingPage from './YearEndClosingPage';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'owner-1', role: 'OWNER', branchId: null },
+    isLoading: false,
+    isAuthenticated: true,
+  }),
+}));
+
+const apiPost = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    post: (...args: unknown[]) => apiPost(...args),
+    get: vi.fn(),
+  },
+  getErrorMessage: (e: unknown) => String(e),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <YearEndClosingPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  apiPost.mockReset();
+});
+
+describe('YearEndClosingPage', () => {
+  it('renders header + preview button + defaults year to prior year', async () => {
+    renderPage();
+    expect(await screen.findByText('ปิดบัญชีสิ้นปี')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ดูตัวอย่างการปิดบัญชี/ })).toBeInTheDocument();
+
+    const select = screen.getByLabelText('ปี (ค.ศ.)') as HTMLSelectElement;
+    const expected = new Date().getFullYear() - 1;
+    expect(Number(select.value)).toBe(expected);
+  });
+
+  it('renders preview data after clicking preview (revenues + expenses + net)', async () => {
+    apiPost.mockResolvedValueOnce({
+      data: {
+        year: 2025,
+        revenues: [
+          { code: '41-1101', name: 'รายได้ดอกเบี้ย', balance: '100000.00' },
+        ],
+        expenses: [
+          { code: '51-1102', name: 'หนี้สูญ', balance: '20000.00' },
+        ],
+        revenueTotal: '100000.00',
+        expenseTotal: '20000.00',
+        netIncome: '80000.00',
+        isProfit: true,
+        totalSteps: 3,
+        alreadyClosed: false,
+        closedAt: null,
+        closingBatchId: null,
+        openMonths: [],
+      },
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /ดูตัวอย่างการปิดบัญชี/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('รายได้ดอกเบี้ย')).toBeInTheDocument();
+    });
+    expect(screen.getByText('หนี้สูญ')).toBeInTheDocument();
+    // Net income summary card label
+    expect(screen.getByText('กำไรสุทธิ')).toBeInTheDocument();
+    // "ปิดบัญชี" button should appear under preview
+    expect(screen.getByRole('button', { name: /ปิดบัญชีปี/i })).toBeInTheDocument();
+  });
+
+  it('disables Preview button when year is current/future', async () => {
+    renderPage();
+    const customInput = screen.getByLabelText('ปีกำหนดเอง') as HTMLInputElement;
+    const currentYear = new Date().getFullYear();
+    fireEvent.change(customInput, { target: { value: String(currentYear + 1) } });
+
+    const previewBtn = screen.getByRole('button', { name: /ดูตัวอย่างการปิดบัญชี/ });
+    await waitFor(() => {
+      expect(previewBtn).toBeDisabled();
+    });
+    // Error hint visible
+    expect(
+      screen.getByText(new RegExp(`ไม่สามารถปิดบัญชีปี ${currentYear + 1}`)),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/YearEndClosingPage.test.tsx
+++ b/apps/web/src/pages/YearEndClosingPage.test.tsx
@@ -4,9 +4,12 @@ import { MemoryRouter } from 'react-router';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import YearEndClosingPage from './YearEndClosingPage';
 
+// Mutable role for tests that need to swap roles (W4 — FM gets a different UI)
+let mockRole: 'OWNER' | 'ACCOUNTANT' | 'FINANCE_MANAGER' | 'BRANCH_MANAGER' | 'SALES' = 'OWNER';
+
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
-    user: { id: 'owner-1', role: 'OWNER', branchId: null },
+    user: { id: 'user-1', role: mockRole, branchId: null },
     isLoading: false,
     isAuthenticated: true,
   }),
@@ -42,6 +45,7 @@ function renderPage() {
 
 beforeEach(() => {
   apiPost.mockReset();
+  mockRole = 'OWNER';
 });
 
 describe('YearEndClosingPage', () => {
@@ -104,5 +108,89 @@ describe('YearEndClosingPage', () => {
     expect(
       screen.getByText(new RegExp(`ไม่สามารถปิดบัญชีปี ${currentYear + 1}`)),
     ).toBeInTheDocument();
+  });
+
+  it('renders pa.. (Buddhist Era) year in headings (W1)', async () => {
+    apiPost.mockResolvedValueOnce({
+      data: {
+        year: 2025,
+        revenues: [],
+        expenses: [{ code: '51-1102', name: 'หนี้สูญ', balance: '500.00' }],
+        revenueTotal: '0.00',
+        expenseTotal: '500.00',
+        netIncome: '-500.00',
+        isProfit: false,
+        totalSteps: 3,
+        alreadyClosed: true,
+        closedAt: new Date('2026-01-15T10:30:00.000Z').toISOString(),
+        closingBatchId: 'batch-1',
+        openMonths: [],
+      },
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /ดูตัวอย่างการปิดบัญชี/ }));
+    // "ปี 2025 (พ.ศ. 2568)" — 2025 + 543 = 2568. Banner + action card + button
+    // each display it — use getAllByText.
+    await waitFor(() => {
+      const matches = screen.getAllByText(/พ\.ศ\. 2568/);
+      expect(matches.length).toBeGreaterThan(0);
+    });
+    // Banner says "ปิดบัญชีไปแล้ว"
+    expect(screen.getByText(/ปิดบัญชีไปแล้ว/)).toBeInTheDocument();
+  });
+
+  it('hides post Card for FINANCE_MANAGER and shows role-explainer Alert (W4)', async () => {
+    mockRole = 'FINANCE_MANAGER';
+    apiPost.mockResolvedValueOnce({
+      data: {
+        year: 2025,
+        revenues: [{ code: '41-1101', name: 'รายได้ดอกเบี้ย', balance: '1000.00' }],
+        expenses: [],
+        revenueTotal: '1000.00',
+        expenseTotal: '0.00',
+        netIncome: '1000.00',
+        isProfit: true,
+        totalSteps: 3,
+        alreadyClosed: false,
+        closedAt: null,
+        closingBatchId: null,
+        openMonths: [],
+      },
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /ดูตัวอย่างการปิดบัญชี/ }));
+    await waitFor(() => {
+      expect(screen.getByText('โหมดดูอย่างเดียว')).toBeInTheDocument();
+    });
+    // No disabled "ปิดบัญชีปี" submit button rendered
+    expect(screen.queryByRole('button', { name: /ปิดบัญชีปี/i })).not.toBeInTheDocument();
+    // Explainer mentions allowed roles
+    expect(screen.getByText(/OWNER และ ACCOUNTANT/)).toBeInTheDocument();
+  });
+
+  it('shows post Card for ACCOUNTANT (canPost path)', async () => {
+    mockRole = 'ACCOUNTANT';
+    apiPost.mockResolvedValueOnce({
+      data: {
+        year: 2025,
+        revenues: [{ code: '41-1101', name: 'รายได้ดอกเบี้ย', balance: '1000.00' }],
+        expenses: [],
+        revenueTotal: '1000.00',
+        expenseTotal: '0.00',
+        netIncome: '1000.00',
+        isProfit: true,
+        totalSteps: 3,
+        alreadyClosed: false,
+        closedAt: null,
+        closingBatchId: null,
+        openMonths: [],
+      },
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /ดูตัวอย่างการปิดบัญชี/ }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /ปิดบัญชีปี/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByText('โหมดดูอย่างเดียว')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/YearEndClosingPage.tsx
+++ b/apps/web/src/pages/YearEndClosingPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { z } from 'zod';
 import { toast } from 'sonner';
 import {
@@ -159,7 +159,7 @@ export default function YearEndClosingPage() {
 
   // ─── Reverse form ─────────────────────────────────────────────────────
   const reverseForm = useForm<ReverseFormValues>({
-    resolver: zodResolver(reverseSchema),
+    resolver: standardSchemaResolver(reverseSchema),
     defaultValues: { reason: '' },
   });
 

--- a/apps/web/src/pages/YearEndClosingPage.tsx
+++ b/apps/web/src/pages/YearEndClosingPage.tsx
@@ -1,0 +1,564 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import {
+  AlertTriangle,
+  CalendarCheck,
+  CheckCircle2,
+  Loader2,
+  Lock,
+  RotateCcw,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
+import api, { getErrorMessage } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { THAI_MONTHS_FULL } from '@/lib/date';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface AccountRow {
+  code: string;
+  name: string;
+  balance: string;
+}
+
+interface OpenMonth {
+  month: number;
+  status: string;
+}
+
+interface PreviewResponse {
+  year: number;
+  revenues: AccountRow[];
+  expenses: AccountRow[];
+  revenueTotal: string;
+  expenseTotal: string;
+  netIncome: string;
+  isProfit: boolean;
+  totalSteps: number;
+  alreadyClosed: boolean;
+  closedAt: string | null;
+  closingBatchId: string | null;
+  openMonths: OpenMonth[];
+}
+
+interface PostResponse {
+  year: number;
+  batchId: string;
+  step1: { entryNo: string; journalEntryId: string };
+  step2: { entryNo: string; journalEntryId: string };
+  step3: { entryNo: string; journalEntryId: string } | null;
+  netIncome: string;
+  revenueTotal: string;
+  expenseTotal: string;
+}
+
+// ─── Formatters ─────────────────────────────────────────────────────────────
+
+const fmtTHB = (s: string) =>
+  new Intl.NumberFormat('th-TH', {
+    style: 'currency',
+    currency: 'THB',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number(s));
+
+// ─── Reverse form schema ────────────────────────────────────────────────────
+
+const reverseSchema = z.object({
+  reason: z
+    .string()
+    .min(10, 'เหตุผลต้องยาวอย่างน้อย 10 ตัวอักษร')
+    .max(500, 'เหตุผลยาวเกินไป (สูงสุด 500 ตัวอักษร)'),
+});
+type ReverseFormValues = z.infer<typeof reverseSchema>;
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export default function YearEndClosingPage() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const currentYear = new Date().getFullYear();
+  const defaultYear = currentYear - 1;
+
+  const [year, setYear] = useState<number>(defaultYear);
+  const [postConfirmOpen, setPostConfirmOpen] = useState(false);
+  const [reverseDialogOpen, setReverseDialogOpen] = useState(false);
+  const [lastPosted, setLastPosted] = useState<PostResponse | null>(null);
+
+  const isOwner = user?.role === 'OWNER';
+  const canPost = isOwner || user?.role === 'ACCOUNTANT';
+
+  // ─── Preview query (manual trigger via refetch) ─────────────────────────
+  const previewQuery = useQuery<PreviewResponse>({
+    queryKey: ['year-end-closing-preview', year],
+    queryFn: async () => {
+      const { data } = await api.post<PreviewResponse>(
+        '/accounting/year-end-closing/preview',
+        { year },
+      );
+      return data;
+    },
+    enabled: false, // user clicks "Preview" to trigger
+  });
+
+  const preview = previewQuery.data;
+
+  // ─── Post mutation ─────────────────────────────────────────────────────
+  const postMutation = useMutation<PostResponse, unknown, void>({
+    mutationFn: async () => {
+      const { data } = await api.post<PostResponse>('/accounting/year-end-closing', { year });
+      return data;
+    },
+    onSuccess: (data) => {
+      toast.success(`ปิดบัญชีปี ${year} เรียบร้อย — สร้าง JE 3 รายการ`);
+      setLastPosted(data);
+      queryClient.invalidateQueries({ queryKey: ['year-end-closing-preview', year] });
+      void previewQuery.refetch();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  // ─── Reverse mutation ──────────────────────────────────────────────────
+  const reverseMutation = useMutation<unknown, unknown, ReverseFormValues>({
+    mutationFn: async (values) => {
+      const { data } = await api.post('/accounting/year-end-closing/reverse', {
+        year,
+        reason: values.reason,
+      });
+      return data;
+    },
+    onSuccess: () => {
+      toast.success(`กลับรายการปิดบัญชีปี ${year} เรียบร้อย`);
+      setReverseDialogOpen(false);
+      queryClient.invalidateQueries({ queryKey: ['year-end-closing-preview', year] });
+      void previewQuery.refetch();
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  // ─── Reverse form ─────────────────────────────────────────────────────
+  const reverseForm = useForm<ReverseFormValues>({
+    resolver: zodResolver(reverseSchema),
+    defaultValues: { reason: '' },
+  });
+
+  // ─── Year options (current - 6 ... current - 1) ───────────────────────
+  const yearOptions = useMemo(
+    () => Array.from({ length: 6 }, (_, i) => currentYear - 1 - i),
+    [currentYear],
+  );
+
+  const isFutureYear = year >= currentYear;
+  const blockPost = !canPost || isFutureYear || (preview?.openMonths.length ?? 0) > 0 || preview?.alreadyClosed === true;
+
+  return (
+    <>
+      <PageHeader
+        title="ปิดบัญชีสิ้นปี"
+        subtitle="ปิดยอดรายได้/ค่าใช้จ่ายเข้า Income Summary (39-9999) แล้วโอนเข้ากำไรสะสม (33-1101)"
+        icon={<CalendarCheck className="h-6 w-6" />}
+      />
+
+      <div className="space-y-6 px-4 sm:px-6 lg:px-8 max-w-6xl mx-auto pb-12">
+        {/* Year selector + Preview */}
+        <Card>
+          <CardHeader>
+            <h2 className="text-base font-semibold leading-snug">เลือกปีที่ต้องการปิดบัญชี</h2>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1.5">
+                <label htmlFor="year-input" className="text-sm font-medium leading-snug">
+                  ปี (ค.ศ.)
+                </label>
+                <div className="flex gap-2">
+                  <select
+                    id="year-input"
+                    value={year}
+                    onChange={(e) => setYear(Number(e.target.value))}
+                    className="h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring/30"
+                  >
+                    {yearOptions.map((y) => (
+                      <option key={y} value={y}>
+                        {y}
+                      </option>
+                    ))}
+                  </select>
+                  <Input
+                    type="number"
+                    min={2020}
+                    max={currentYear - 1}
+                    value={year}
+                    onChange={(e) => setYear(Number(e.target.value))}
+                    className="w-28"
+                    aria-label="ปีกำหนดเอง"
+                  />
+                </div>
+              </div>
+              <Button
+                onClick={() => void previewQuery.refetch()}
+                disabled={previewQuery.isFetching || isFutureYear}
+              >
+                {previewQuery.isFetching ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    กำลังคำนวณ...
+                  </>
+                ) : (
+                  'ดูตัวอย่างการปิดบัญชี'
+                )}
+              </Button>
+            </div>
+            {isFutureYear && (
+              <p className="text-sm text-destructive leading-snug">
+                ไม่สามารถปิดบัญชีปี {year} ได้ — เลือกปีที่ผ่านมา (น้อยกว่า {currentYear})
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <QueryBoundary
+          isLoading={previewQuery.isLoading}
+          isError={previewQuery.isError}
+          error={previewQuery.error}
+          onRetry={() => void previewQuery.refetch()}
+        >
+          {preview && (
+            <>
+              {/* Already closed banner */}
+              {preview.alreadyClosed && (
+                <Card className="border-success/40 bg-success/5">
+                  <CardContent className="flex items-start gap-3 pt-6">
+                    <Lock className="h-5 w-5 text-success shrink-0 mt-0.5" />
+                    <div className="flex-1 space-y-1">
+                      <p className="text-sm font-semibold leading-snug">
+                        ปี {preview.year} ปิดบัญชีไปแล้ว
+                      </p>
+                      {preview.closedAt && (
+                        <p className="text-sm text-muted-foreground leading-snug">
+                          วันที่บันทึก: {new Date(preview.closedAt).toLocaleString('th-TH')}
+                        </p>
+                      )}
+                      {preview.closingBatchId && (
+                        <p className="text-xs text-muted-foreground leading-snug font-mono">
+                          Batch ID: {preview.closingBatchId}
+                        </p>
+                      )}
+                    </div>
+                    {isOwner && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setReverseDialogOpen(true)}
+                      >
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                        กลับรายการ
+                      </Button>
+                    )}
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Open months warning */}
+              {preview.openMonths.length > 0 && (
+                <Card className="border-destructive/40 bg-destructive/5">
+                  <CardContent className="flex items-start gap-3 pt-6">
+                    <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+                    <div className="flex-1 space-y-2">
+                      <p className="text-sm font-semibold leading-snug text-destructive">
+                        ต้องปิดงวดบัญชีรายเดือนก่อนปิดบัญชีปี
+                      </p>
+                      <p className="text-sm text-muted-foreground leading-snug">
+                        เดือนที่ยังไม่ปิด (สถานะ {preview.openMonths[0]?.status}):
+                      </p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {preview.openMonths.map((m) => (
+                          <Badge key={m.month} variant="destructive" appearance="light">
+                            {THAI_MONTHS_FULL[m.month - 1]}
+                          </Badge>
+                        ))}
+                      </div>
+                      <p className="text-xs text-muted-foreground leading-snug mt-2">
+                        ไปที่หน้า{' '}
+                        <a href="/monthly-close" className="text-primary underline">
+                          ปิดบัญชีรายเดือน
+                        </a>{' '}
+                        เพื่อปิดงวดที่เหลือ
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Net Income summary */}
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <Card className="border-success/30">
+                  <CardContent className="pt-6">
+                    <p className="text-xs uppercase tracking-wider text-muted-foreground leading-snug">
+                      รายได้รวม
+                    </p>
+                    <p className="text-2xl font-bold leading-snug mt-1.5">
+                      {fmtTHB(preview.revenueTotal)}
+                    </p>
+                    <p className="text-xs text-muted-foreground leading-snug mt-1">
+                      {preview.revenues.length} บัญชี
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="border-destructive/30">
+                  <CardContent className="pt-6">
+                    <p className="text-xs uppercase tracking-wider text-muted-foreground leading-snug">
+                      ค่าใช้จ่ายรวม
+                    </p>
+                    <p className="text-2xl font-bold leading-snug mt-1.5">
+                      {fmtTHB(preview.expenseTotal)}
+                    </p>
+                    <p className="text-xs text-muted-foreground leading-snug mt-1">
+                      {preview.expenses.length} บัญชี
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card
+                  className={
+                    preview.isProfit ? 'border-success/40 bg-success/5' : 'border-destructive/40 bg-destructive/5'
+                  }
+                >
+                  <CardContent className="pt-6">
+                    <p className="text-xs uppercase tracking-wider text-muted-foreground leading-snug">
+                      {preview.isProfit ? 'กำไรสุทธิ' : 'ขาดทุนสุทธิ'}
+                    </p>
+                    <div className="flex items-center gap-2 mt-1.5">
+                      {preview.isProfit ? (
+                        <TrendingUp className="h-5 w-5 text-success" />
+                      ) : (
+                        <TrendingDown className="h-5 w-5 text-destructive" />
+                      )}
+                      <p className="text-2xl font-bold leading-snug">{fmtTHB(preview.netIncome)}</p>
+                    </div>
+                    <p className="text-xs text-muted-foreground leading-snug mt-1">
+                      โอนเข้า 33-1101 กำไรสะสม
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+
+              {/* Account detail tables */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <AccountTable
+                  title="รายได้ (Cr → 39-9999)"
+                  rows={preview.revenues}
+                  total={preview.revenueTotal}
+                  totalLabel="รวมรายได้"
+                />
+                <AccountTable
+                  title="ค่าใช้จ่าย (39-9999 → Dr)"
+                  rows={preview.expenses}
+                  total={preview.expenseTotal}
+                  totalLabel="รวมค่าใช้จ่าย"
+                />
+              </div>
+
+              {/* Post action */}
+              <Card>
+                <CardContent className="pt-6 flex flex-wrap items-center justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium leading-snug">
+                      จะสร้าง Journal Entry รวม {preview.totalSteps} รายการ
+                    </p>
+                    <p className="text-xs text-muted-foreground leading-snug">
+                      บันทึกวันที่ 31 ธันวาคม {preview.year} 23:59 — ไม่สามารถแก้ไขได้หลังบันทึก
+                    </p>
+                  </div>
+                  <Button
+                    variant="destructive"
+                    disabled={blockPost || postMutation.isPending}
+                    onClick={() => setPostConfirmOpen(true)}
+                  >
+                    {postMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        กำลังบันทึก...
+                      </>
+                    ) : (
+                      <>
+                        <Lock className="mr-2 h-4 w-4" />
+                        ปิดบัญชีปี {preview.year}
+                      </>
+                    )}
+                  </Button>
+                </CardContent>
+              </Card>
+
+              {/* Posted JE links */}
+              {lastPosted && (
+                <Card className="border-primary/40 bg-primary/5">
+                  <CardHeader className="pb-2">
+                    <div className="flex items-center gap-2">
+                      <CheckCircle2 className="h-5 w-5 text-success" />
+                      <h3 className="text-base font-semibold leading-snug">บันทึกเรียบร้อย</h3>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-1.5 text-sm">
+                      <li>
+                        <span className="text-muted-foreground">Step 1 (รายได้):</span>{' '}
+                        <span className="font-mono font-medium">{lastPosted.step1.entryNo}</span>
+                      </li>
+                      <li>
+                        <span className="text-muted-foreground">Step 2 (ค่าใช้จ่าย):</span>{' '}
+                        <span className="font-mono font-medium">{lastPosted.step2.entryNo}</span>
+                      </li>
+                      {lastPosted.step3 && (
+                        <li>
+                          <span className="text-muted-foreground">Step 3 (โอน 33-1101):</span>{' '}
+                          <span className="font-mono font-medium">{lastPosted.step3.entryNo}</span>
+                        </li>
+                      )}
+                      <li className="pt-2 text-xs text-muted-foreground font-mono">
+                        Batch ID: {lastPosted.batchId}
+                      </li>
+                    </ul>
+                  </CardContent>
+                </Card>
+              )}
+            </>
+          )}
+        </QueryBoundary>
+      </div>
+
+      {/* Post confirmation */}
+      <ConfirmDialog
+        open={postConfirmOpen}
+        onOpenChange={setPostConfirmOpen}
+        title={`ยืนยันการปิดบัญชีปี ${year}`}
+        description={`การปิดบัญชีจะสร้าง JE ${preview?.totalSteps ?? 3} รายการ และไม่สามารถแก้ไขได้ — เฉพาะ OWNER เท่านั้นที่กลับรายการได้`}
+        confirmLabel={`ปิดบัญชีปี ${year}`}
+        cancelLabel="ยกเลิก"
+        variant="destructive"
+        loading={postMutation.isPending}
+        onConfirm={() => postMutation.mutate()}
+      />
+
+      {/* Reverse dialog (OWNER) */}
+      <Dialog open={reverseDialogOpen} onOpenChange={setReverseDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>กลับรายการปิดบัญชีปี {year}</DialogTitle>
+            <DialogDescription className="leading-snug">
+              จะสร้าง JE กลับรายการตรงข้ามทั้ง 3 รายการ — รายการเดิมจะคงอยู่เพื่อ audit trail
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            onSubmit={reverseForm.handleSubmit((values) => reverseMutation.mutate(values))}
+            className="space-y-3"
+          >
+            <div className="space-y-1.5">
+              <label htmlFor="reverse-reason" className="text-sm font-medium leading-snug">
+                เหตุผล (อย่างน้อย 10 ตัวอักษร)
+              </label>
+              <Textarea
+                id="reverse-reason"
+                rows={4}
+                placeholder="ระบุเหตุผลการกลับรายการอย่างละเอียด..."
+                {...reverseForm.register('reason')}
+                disabled={reverseMutation.isPending}
+              />
+              {reverseForm.formState.errors.reason && (
+                <p className="text-xs text-destructive leading-snug">
+                  {reverseForm.formState.errors.reason.message}
+                </p>
+              )}
+            </div>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setReverseDialogOpen(false)}
+                disabled={reverseMutation.isPending}
+              >
+                ยกเลิก
+              </Button>
+              <Button type="submit" variant="destructive" disabled={reverseMutation.isPending}>
+                {reverseMutation.isPending ? 'กำลังกลับรายการ...' : 'ยืนยันกลับรายการ'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// ─── Account Table ──────────────────────────────────────────────────────────
+
+function AccountTable({
+  title,
+  rows,
+  total,
+  totalLabel,
+}: {
+  title: string;
+  rows: AccountRow[];
+  total: string;
+  totalLabel: string;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <h3 className="text-sm font-semibold leading-snug">{title}</h3>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground leading-snug">ไม่มีรายการ</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-xs uppercase tracking-wider text-muted-foreground">
+                  <th className="py-2 font-medium">รหัส</th>
+                  <th className="py-2 font-medium">ชื่อบัญชี</th>
+                  <th className="py-2 font-medium text-right">ยอดสุทธิ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.code} className="border-b border-border/40">
+                    <td className="py-1.5 font-mono text-xs">{r.code}</td>
+                    <td className="py-1.5 leading-snug">{r.name}</td>
+                    <td className="py-1.5 text-right font-medium tabular-nums">{fmtTHB(r.balance)}</td>
+                  </tr>
+                ))}
+                <tr className="border-t-2 border-border font-semibold">
+                  <td className="py-2" />
+                  <td className="py-2 leading-snug">{totalLabel}</td>
+                  <td className="py-2 text-right tabular-nums">{fmtTHB(total)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/YearEndClosingPage.tsx
+++ b/apps/web/src/pages/YearEndClosingPage.tsx
@@ -8,6 +8,7 @@ import {
   AlertTriangle,
   CalendarCheck,
   CheckCircle2,
+  Info,
   Loader2,
   Lock,
   RotateCcw,
@@ -32,7 +33,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { THAI_MONTHS_FULL } from '@/lib/date';
+import { formatThaiDateTime, THAI_MONTHS_FULL } from '@/lib/date';
+
+// Convert ค.ศ. (Gregorian) year to พ.ศ. (Buddhist Era) for display.
+const toBE = (yearCE: number) => yearCE + 543;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -131,7 +135,7 @@ export default function YearEndClosingPage() {
       return data;
     },
     onSuccess: (data) => {
-      toast.success(`ปิดบัญชีปี ${year} เรียบร้อย — สร้าง JE 3 รายการ`);
+      toast.success(`ปิดบัญชีปี ${toBE(year)} (พ.ศ.) เรียบร้อย — สร้าง JE 3 รายการ`);
       setLastPosted(data);
       queryClient.invalidateQueries({ queryKey: ['year-end-closing-preview', year] });
       void previewQuery.refetch();
@@ -149,7 +153,7 @@ export default function YearEndClosingPage() {
       return data;
     },
     onSuccess: () => {
-      toast.success(`กลับรายการปิดบัญชีปี ${year} เรียบร้อย`);
+      toast.success(`กลับรายการปิดบัญชีปี ${toBE(year)} (พ.ศ.) เรียบร้อย`);
       setReverseDialogOpen(false);
       queryClient.invalidateQueries({ queryKey: ['year-end-closing-preview', year] });
       void previewQuery.refetch();
@@ -232,7 +236,8 @@ export default function YearEndClosingPage() {
             </div>
             {isFutureYear && (
               <p className="text-sm text-destructive leading-snug">
-                ไม่สามารถปิดบัญชีปี {year} ได้ — เลือกปีที่ผ่านมา (น้อยกว่า {currentYear})
+                ไม่สามารถปิดบัญชีปี {year} (พ.ศ. {toBE(year)}) ได้ — เลือกปีที่ผ่านมา (น้อยกว่า{' '}
+                {currentYear})
               </p>
             )}
           </CardContent>
@@ -253,11 +258,11 @@ export default function YearEndClosingPage() {
                     <Lock className="h-5 w-5 text-success shrink-0 mt-0.5" />
                     <div className="flex-1 space-y-1">
                       <p className="text-sm font-semibold leading-snug">
-                        ปี {preview.year} ปิดบัญชีไปแล้ว
+                        ปีบัญชี {preview.year} (พ.ศ. {toBE(preview.year)}) ปิดบัญชีไปแล้ว
                       </p>
                       {preview.closedAt && (
                         <p className="text-sm text-muted-foreground leading-snug">
-                          วันที่บันทึก: {new Date(preview.closedAt).toLocaleString('th-TH')}
+                          วันที่บันทึก: {formatThaiDateTime(preview.closedAt)} น.
                         </p>
                       )}
                       {preview.closingBatchId && (
@@ -379,36 +384,52 @@ export default function YearEndClosingPage() {
                 />
               </div>
 
-              {/* Post action */}
-              <Card>
-                <CardContent className="pt-6 flex flex-wrap items-center justify-between gap-3">
-                  <div className="space-y-1">
-                    <p className="text-sm font-medium leading-snug">
-                      จะสร้าง Journal Entry รวม {preview.totalSteps} รายการ
-                    </p>
-                    <p className="text-xs text-muted-foreground leading-snug">
-                      บันทึกวันที่ 31 ธันวาคม {preview.year} 23:59 — ไม่สามารถแก้ไขได้หลังบันทึก
-                    </p>
-                  </div>
-                  <Button
-                    variant="destructive"
-                    disabled={blockPost || postMutation.isPending}
-                    onClick={() => setPostConfirmOpen(true)}
-                  >
-                    {postMutation.isPending ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        กำลังบันทึก...
-                      </>
-                    ) : (
-                      <>
-                        <Lock className="mr-2 h-4 w-4" />
-                        ปิดบัญชีปี {preview.year}
-                      </>
-                    )}
-                  </Button>
-                </CardContent>
-              </Card>
+              {/* Post action — only show full action card to roles that can post */}
+              {canPost ? (
+                <Card>
+                  <CardContent className="pt-6 flex flex-wrap items-center justify-between gap-3">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium leading-snug">
+                        จะสร้าง Journal Entry รวม {preview.totalSteps} รายการ
+                      </p>
+                      <p className="text-xs text-muted-foreground leading-snug">
+                        บันทึกวันที่ 31 ธันวาคม {preview.year} (พ.ศ. {toBE(preview.year)}) 23:59 น. —
+                        ไม่สามารถแก้ไขได้หลังบันทึก
+                      </p>
+                    </div>
+                    <Button
+                      variant="destructive"
+                      disabled={blockPost || postMutation.isPending}
+                      onClick={() => setPostConfirmOpen(true)}
+                    >
+                      {postMutation.isPending ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          กำลังบันทึก...
+                        </>
+                      ) : (
+                        <>
+                          <Lock className="mr-2 h-4 w-4" />
+                          ปิดบัญชีปี {preview.year} (พ.ศ. {toBE(preview.year)})
+                        </>
+                      )}
+                    </Button>
+                  </CardContent>
+                </Card>
+              ) : (
+                <Card className="border-warning/40 bg-warning/5">
+                  <CardContent className="flex items-start gap-3 pt-6">
+                    <Info className="h-5 w-5 text-warning shrink-0 mt-0.5" />
+                    <div className="flex-1 space-y-1">
+                      <p className="text-sm font-semibold leading-snug">โหมดดูอย่างเดียว</p>
+                      <p className="text-sm text-muted-foreground leading-snug">
+                        เฉพาะ OWNER และ ACCOUNTANT เท่านั้นที่บันทึกการปิดบัญชีได้ — บัญชีของคุณดูข้อมูลได้
+                        แต่ไม่สามารถสร้าง Journal Entry ปิดบัญชี
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
 
               {/* Posted JE links */}
               {lastPosted && (
@@ -451,7 +472,7 @@ export default function YearEndClosingPage() {
       <ConfirmDialog
         open={postConfirmOpen}
         onOpenChange={setPostConfirmOpen}
-        title={`ยืนยันการปิดบัญชีปี ${year}`}
+        title={`ยืนยันการปิดบัญชีปี ${year} (พ.ศ. ${toBE(year)})`}
         description={`การปิดบัญชีจะสร้าง JE ${preview?.totalSteps ?? 3} รายการ และไม่สามารถแก้ไขได้ — เฉพาะ OWNER เท่านั้นที่กลับรายการได้`}
         confirmLabel={`ปิดบัญชีปี ${year}`}
         cancelLabel="ยกเลิก"
@@ -464,7 +485,7 @@ export default function YearEndClosingPage() {
       <Dialog open={reverseDialogOpen} onOpenChange={setReverseDialogOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>กลับรายการปิดบัญชีปี {year}</DialogTitle>
+            <DialogTitle>กลับรายการปิดบัญชีปี {year} (พ.ศ. {toBE(year)})</DialogTitle>
             <DialogDescription className="leading-snug">
               จะสร้าง JE กลับรายการตรงข้ามทั้ง 3 รายการ — รายการเดิมจะคงอยู่เพื่อ audit trail
             </DialogDescription>


### PR DESCRIPTION
## Summary

Phase 3 SP1 — closes Revenue (41/42-XXXX) and Expense (51/52/53/54-XXXX)
accounts into Income Summary (39-9999), then transfers net income/loss to
Retained Earnings (33-1101) at year-end.

### 3-step JE flow (all share `metadata.batchId`)

1. **Close revenue** — `Dr 41/42-XXXX (each non-zero) / Cr 39-9999 [revenueTotal]`
2. **Close expenses** — `Dr 39-9999 [expenseTotal] / Cr 51/52/53/54-XXXX (each non-zero)`
3. **Transfer net** (skipped if net = 0):
   - Profit: `Dr 39-9999 / Cr 33-1101 [netIncome]`
   - Loss: `Dr 33-1101 / Cr 39-9999 [|netLoss|]`

Entry date for all 3 = `Dec 31 23:59:59.999 BKK` of the closed year.
Skips zero-balance accounts. Uses `Prisma.Decimal` throughout — no `Number()`.

### Guards

- **Year window**: 2020-2030, must be strictly `< current year`
- **Monthly periods**: all 12 months for FINANCE must be CLOSED/SYNCED
- **Idempotency**: `ConflictException` on re-close unless prior batch was
  reversed (then re-close allowed). Pre-tx check + inside-tx re-check
  guards against race
- **Tx atomicity**: 3 JEs created in single `$transaction`

### Reverse escape hatch (OWNER-only)

`POST /accounting/year-end-closing/reverse` with mandatory 10-char reason.
Creates 3 mirror-flipped JEs dated today, marks originals
`metadata.reversedByBatchId` so re-close is allowed.

### Endpoints (new `/accounting/year-end-closing/*`)

- `POST /preview` — OWNER, FINANCE_MANAGER, ACCOUNTANT (no DB writes)
- `POST /` — OWNER, ACCOUNTANT
- `POST /reverse` — OWNER

### Frontend

`/finance/year-end-closing` — year selector + preview + 3-card summary
(revenue/expense/netIncome) + per-account tables + open-month warning +
destructive ConfirmDialog before post + react-hook-form+zod reverse
dialog for OWNER.

Menu wired into OWNER (collapsible "ปิดบัญชี"), FINANCE_MANAGER
(fm-finance), and ACCOUNTANT (acc-close).

### Docs

`.claude/rules/accounting.md` — new Year-End Closing section covering
template + service location, JE flow, guards, reverse path, and how
existing report methods behave after closing.

### Tests

- API: **26 tests** (jest)
  - `year-end-closing.template.spec.ts` (7 unit) — BKK year bounds,
    revenue/expense classification, zero-skip, prefix filter, profit/loss
    sign
  - `closing.service.spec.ts` (19 orchestration) — preview shape,
    year-window validation, period-closure gate, idempotency,
    OWNER-only reverse, mirror Dr/Cr flip, audit emission
- Web: **3 tests** (vitest) — default-year render, preview data display,
  future-year disables Preview

### Audit actions (new)

- `YEAR_END_CLOSED` — entity=accounting_period, entityId=batchId
- `YEAR_END_CLOSING_REVERSED` — entity=accounting_period

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean on api + web
- [x] `npx jest accounting/closing.service journal/year-end-closing.template` — 26 passing
- [x] `npx vitest run YearEndClosingPage` — 3 passing
- [ ] CI Lint & Test green
- [ ] Manual smoke (post-merge): close 2025 in staging → check 3 JEs created via Trial Balance + verify 33-1101 increased

🤖 Generated with [Claude Code](https://claude.com/claude-code)