### PR TITLE
feat(p3-sp4): PII column-level encryption (PDPA strict mode)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,7 +28,9 @@
     "seed:coa:help": "echo 'Usage: EXPECTED_DB_NAME=<db> npm run seed:coa  (non-destructive upsert from CSV)'",
     "backfill:schedules": "node dist/src/cli/backfill-installment-schedules.cli.js",
     "backfill:asset-vat": "node dist/src/cli/backfill-asset-vat-corrections.cli.js",
-    "backfill:asset-vat:help": "echo 'Usage: EXPECTED_DB_NAME=<db> [DRY_RUN=true|false] [ALLOW_PROD_BACKFILL=YES_I_AM_SURE] npm run backfill:asset-vat'"
+    "backfill:asset-vat:help": "echo 'Usage: EXPECTED_DB_NAME=<db> [DRY_RUN=true|false] [ALLOW_PROD_BACKFILL=YES_I_AM_SURE] npm run backfill:asset-vat'",
+    "backfill:encrypt-pii": "tsx src/cli/encrypt-customer-pii.cli.ts",
+    "backfill:encrypt-pii:help": "echo 'Usage: CONFIRM_BACKFILL=YES_I_AM_SURE EXPECTED_DB_NAME=<db> PII_ENCRYPTION_KEY=<64hex> PII_HASH_SALT=<>=32chars> [ALLOW_PROD_BACKFILL=YES_I_AM_SURE] [PDPA_BACKFILL_BATCH_SIZE=100] npm run backfill:encrypt-pii'"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",

--- a/apps/api/prisma/migrations/20260948000000_pdpa_backfill_runs/migration.sql
+++ b/apps/api/prisma/migrations/20260948000000_pdpa_backfill_runs/migration.sql
@@ -1,0 +1,90 @@
+-- Phase 3 SP4 — PDPA PII encryption infrastructure
+-- Adds:
+--   1. PdpaBackfillRun table — append-only event log for backfill runs
+--   2. Column comments on legacy plaintext PII columns flagging them for
+--      eventual drop after the strict-mode stability window (Phase 6.6).
+--
+-- The Customer.*Encrypted + *Hash columns themselves were created by an
+-- earlier migration (20260528400000_add_pii_encrypted_columns). This migration
+-- is purely additive — no existing column is altered, no constraint is removed.
+-- Every statement uses IF NOT EXISTS so the migration is idempotent and safe
+-- to re-run against environments that already have parts of it.
+
+-- =============================================================================
+-- 1. PdpaBackfillRun table
+-- =============================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'PdpaBackfillStatus'
+  ) THEN
+    CREATE TYPE "PdpaBackfillStatus" AS ENUM ('RUNNING', 'COMPLETED', 'FAILED');
+  END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS "pdpa_backfill_runs" (
+  "id"                  TEXT NOT NULL,
+  "status"              "PdpaBackfillStatus" NOT NULL,
+  "total_records"       INTEGER NOT NULL DEFAULT 0,
+  "processed_records"   INTEGER NOT NULL DEFAULT 0,
+  "skipped_records"     INTEGER NOT NULL DEFAULT 0,
+  "started_at"          TIMESTAMP(3) NOT NULL,
+  "finished_at"         TIMESTAMP(3),
+  "error_message"       TEXT,
+  "triggered_by"        TEXT NOT NULL DEFAULT 'cli',
+  "triggered_by_user_id" TEXT,
+  "hostname"            TEXT,
+  "created_at"          TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "pdpa_backfill_runs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "pdpa_backfill_runs_started_at_idx"
+  ON "pdpa_backfill_runs" ("started_at");
+CREATE INDEX IF NOT EXISTS "pdpa_backfill_runs_triggered_by_user_id_idx"
+  ON "pdpa_backfill_runs" ("triggered_by_user_id");
+CREATE INDEX IF NOT EXISTS "pdpa_backfill_runs_status_idx"
+  ON "pdpa_backfill_runs" ("status");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'pdpa_backfill_runs_triggered_by_user_id_fkey'
+  ) THEN
+    ALTER TABLE "pdpa_backfill_runs"
+      ADD CONSTRAINT "pdpa_backfill_runs_triggered_by_user_id_fkey"
+      FOREIGN KEY ("triggered_by_user_id") REFERENCES "users"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END
+$$;
+
+-- =============================================================================
+-- 2. Column comments on legacy plaintext PII columns (Phase 6.6 will drop them)
+-- =============================================================================
+-- These comments make the deprecation status discoverable via psql \d+ or any
+-- DB GUI without having to grep through the schema file.
+
+COMMENT ON COLUMN "customers"."national_id" IS
+  'LEGACY plaintext PII — use national_id_encrypted + national_id_hash. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."phone" IS
+  'LEGACY plaintext PII — use phone_encrypted + phone_hash. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."phone_secondary" IS
+  'LEGACY plaintext PII — use phone_secondary_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."email" IS
+  'LEGACY plaintext PII — use email_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."address_id_card" IS
+  'LEGACY plaintext PII — use address_id_card_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."address_current" IS
+  'LEGACY plaintext PII — use address_current_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."address_work" IS
+  'LEGACY plaintext PII — use address_work_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."guardian_national_id" IS
+  'LEGACY plaintext PII — use guardian_national_id_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."guardian_phone" IS
+  'LEGACY plaintext PII — use guardian_phone_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."guardian_address" IS
+  'LEGACY plaintext PII — use guardian_address_encrypted. Cleared in Phase 6.6.';
+COMMENT ON COLUMN "customers"."references" IS
+  'LEGACY plaintext PII JSON — use references_encrypted. Cleared in Phase 6.6.';

--- a/apps/api/prisma/migrations/20260949000000_pii_backfill_pending_indexes/migration.sql
+++ b/apps/api/prisma/migrations/20260949000000_pii_backfill_pending_indexes/migration.sql
@@ -1,0 +1,48 @@
+-- Phase 3 SP4 — DEEP review W10
+--
+-- Partial indexes on the 4 high-cardinality PII columns the backfill
+-- cursor scans. Each index covers rows where the plaintext column is
+-- non-NULL but the encrypted counterpart is still NULL — i.e. exactly
+-- the rows the backfill needs to find. Without them, the cursor query
+-- table-scans `customers` on every batch (~100k rows in prod).
+--
+-- Partial index size scales with PENDING work, not total customers, so
+-- it collapses to ~0 bytes once the backfill is complete (Postgres
+-- doesn't index NULL columns under the WHERE predicate). Drop is not
+-- required after Phase 6.6 plaintext-column removal — the predicate
+-- becomes unsatisfiable and the index naturally goes empty.
+--
+-- IF NOT EXISTS keeps the migration idempotent — safe to re-apply
+-- against environments that already have a partial set of indexes.
+--
+-- NOTE: not all 10 PII columns get an index. The 4 here cover the
+-- common backfill-pending paths (national_id / phone are dedup-keyed;
+-- email + address_id_card are the next-most-populated). The other 6
+-- columns are guardian / secondary fields that are usually populated
+-- only when nationalId or phone is — the OR clause in the cursor
+-- planner will use one of these 4 indexes and filter the rest. Adding
+-- 10 indexes wastes catalog space without measurable benefit.
+
+CREATE INDEX IF NOT EXISTS customers_backfill_pending_national_id_idx
+  ON customers (id)
+  WHERE national_id_encrypted IS NULL
+    AND national_id IS NOT NULL
+    AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS customers_backfill_pending_phone_idx
+  ON customers (id)
+  WHERE phone_encrypted IS NULL
+    AND phone IS NOT NULL
+    AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS customers_backfill_pending_email_idx
+  ON customers (id)
+  WHERE email_encrypted IS NULL
+    AND email IS NOT NULL
+    AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS customers_backfill_pending_address_id_card_idx
+  ON customers (id)
+  WHERE address_id_card_encrypted IS NULL
+    AND address_id_card IS NOT NULL
+    AND deleted_at IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -6636,7 +6636,7 @@ enum OffsiteBackupStatus {
 
 /// Append-only event log for PDPA PII encryption backfill runs.
 /// updatedAt/deletedAt intentionally omitted — runs are immutable once finished;
-/// retention via dedicated retention job (see docs/guides/PDPA-COMPLIANCE.md).
+/// 1-year retention via PdpaBackfillRetentionCron (W2 — see docs/guides/PDPA-COMPLIANCE.md §3).
 model PdpaBackfillRun {
   id               String              @id @default(uuid())
   status           PdpaBackfillStatus

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -736,6 +736,9 @@ model User {
   // P3-SP2 — Off-site backup manual triggers (forensics: who clicked "Run Now")
   offsiteBackupRunsTriggered OffsiteBackupRun[] @relation("OffsiteBackupTriggeredBy")
 
+  // P3-SP4 — PDPA PII encryption backfill triggers (forensics: who started a backfill run)
+  pdpaBackfillRunsTriggered PdpaBackfillRun[] @relation("PdpaBackfillTriggeredBy")
+
   @@index([branchId])
   @@index([yeastarExtension])
   @@map("users")
@@ -6625,4 +6628,52 @@ enum OffsiteBackupStatus {
   FAILED
   /// Cron triggered but skipped (OFFSITE_BACKUP_ENABLED=false)
   SKIPPED
+}
+
+// =============================================================================
+// Phase 3 SP4 — PDPA PII column-level encryption
+// =============================================================================
+
+/// Append-only event log for PDPA PII encryption backfill runs.
+/// updatedAt/deletedAt intentionally omitted — runs are immutable once finished;
+/// retention via dedicated retention job (see docs/guides/PDPA-COMPLIANCE.md).
+model PdpaBackfillRun {
+  id               String              @id @default(uuid())
+  status           PdpaBackfillStatus
+  /// Total Customer rows considered (where at least one *Encrypted column is NULL).
+  totalRecords     Int                 @default(0) @map("total_records")
+  /// Rows actually processed so far. Updated incrementally between batches so
+  /// the UI can render a live progress bar without a separate counter table.
+  processedRecords Int                 @default(0) @map("processed_records")
+  /// Sum of rows skipped because every encrypted column was already populated
+  /// (idempotent re-runs). Helps distinguish "no-op" vs "did real work".
+  skippedRecords   Int                 @default(0) @map("skipped_records")
+  startedAt        DateTime            @map("started_at")
+  finishedAt       DateTime?           @map("finished_at")
+  /// First error message (truncated to 1000 chars) when status = FAILED.
+  errorMessage     String?             @map("error_message")
+  /// Category: 'cli' | 'manual'. CLI = `npm run backfill:encrypt-pii`, manual =
+  /// OWNER clicks "Run Backfill" in /settings#pdpa.
+  triggeredBy       String             @default("cli") @map("triggered_by")
+  /// Set when triggeredBy = 'manual' (OWNER from UI). Null for cli.
+  triggeredByUserId String?            @map("triggered_by_user_id")
+  triggeredByUser   User?              @relation("PdpaBackfillTriggeredBy", fields: [triggeredByUserId], references: [id])
+  /// Hostname / Cloud Run revision the run executed on — useful when
+  /// reproducing failures with environment-specific drift.
+  hostname          String?            @map("hostname")
+  createdAt         DateTime           @default(now()) @map("created_at")
+
+  @@index([startedAt])
+  @@index([triggeredByUserId])
+  @@index([status])
+  @@map("pdpa_backfill_runs")
+}
+
+enum PdpaBackfillStatus {
+  /// Run started, batches being processed
+  RUNNING
+  /// Run finished without errors
+  COMPLETED
+  /// Run aborted with error (see errorMessage); partial progress in processedRecords
+  FAILED
 }

--- a/apps/api/src/cli/encrypt-customer-pii.cli.ts
+++ b/apps/api/src/cli/encrypt-customer-pii.cli.ts
@@ -1,0 +1,132 @@
+/**
+ * Phase 3 SP4 — PDPA PII backfill CLI.
+ *
+ * Encrypts + hashes any Customer rows whose `*Encrypted` columns are still
+ * NULL. Idempotent — re-runs skip rows that are already done.
+ *
+ * Usage:
+ *   CONFIRM_BACKFILL=YES_I_AM_SURE \
+ *   EXPECTED_DB_NAME=bestchoice_dev \
+ *   PII_ENCRYPTION_KEY=<64-hex-chars> \
+ *   PII_HASH_SALT=<>=32-chars> \
+ *   npm --prefix apps/api run backfill:encrypt-pii
+ *
+ * Production: also add ALLOW_PROD_BACKFILL=YES_I_AM_SURE.
+ *
+ * Architectural notes:
+ *   - We don't bootstrap the full NestJS DI container — instantiating
+ *     PdpaEncryptionService directly with PrismaClient keeps the CLI fast
+ *     and lets it run inside Cloud Run Jobs without the HTTP server.
+ *   - The service writes one PdpaBackfillRun row regardless of CLI vs UI
+ *     trigger, so ops gets a single auditable history.
+ *   - NEVER prints decrypted PII. Progress lines only carry counters.
+ */
+import { PrismaClient } from '@prisma/client';
+import { PdpaEncryptionService } from '../modules/pdpa/pdpa-encryption.service';
+import { CustomerPiiService } from '../modules/customers/customer-pii.service';
+import type { PrismaService } from '../prisma/prisma.service';
+
+const REQUIRED_CONSENT = 'YES_I_AM_SURE';
+
+async function main(): Promise<void> {
+  if (process.env.CONFIRM_BACKFILL !== REQUIRED_CONSENT) {
+    console.error(`ERROR: Refusing to run without CONFIRM_BACKFILL=${REQUIRED_CONSENT}`);
+    console.error('');
+    console.error('This script encrypts + hashes plaintext PII columns on the `customers`');
+    console.error('table in-place. It is idempotent (already-encrypted rows are skipped) but');
+    console.error('it WRITES to production data. Run a Cloud SQL backup first if in doubt.');
+    console.error('');
+    console.error('Required env vars:');
+    console.error(`  CONFIRM_BACKFILL=${REQUIRED_CONSENT}      (consent)`);
+    console.error('  EXPECTED_DB_NAME=<db-name>              (must match current_database())');
+    console.error('  PII_ENCRYPTION_KEY=<64 hex chars>       (AES-256-GCM key)');
+    console.error('  PII_HASH_SALT=<32+ chars>               (HMAC salt for lookup hashes)');
+    console.error('');
+    console.error('Optional:');
+    console.error('  ALLOW_PROD_BACKFILL=YES_I_AM_SURE       (required when NODE_ENV=production)');
+    console.error('  PDPA_BACKFILL_BATCH_SIZE=100            (rows per batch; default 100)');
+    process.exit(1);
+  }
+
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_PROD_BACKFILL !== REQUIRED_CONSENT) {
+    console.error(`ERROR: Refusing to backfill in NODE_ENV=production without ALLOW_PROD_BACKFILL=${REQUIRED_CONSENT}`);
+    process.exit(1);
+  }
+
+  const expectedDb = process.env.EXPECTED_DB_NAME;
+  if (!expectedDb) {
+    console.error('ERROR: Refusing to run without EXPECTED_DB_NAME=<exact-db-name>');
+    process.exit(1);
+  }
+
+  if (!process.env.PII_ENCRYPTION_KEY || process.env.PII_ENCRYPTION_KEY.length !== 64) {
+    console.error('ERROR: PII_ENCRYPTION_KEY must be set to 64 hex chars (32 bytes for AES-256)');
+    process.exit(1);
+  }
+  if (!process.env.PII_HASH_SALT || process.env.PII_HASH_SALT.length < 32) {
+    console.error('ERROR: PII_HASH_SALT must be set to >=32 chars');
+    process.exit(1);
+  }
+
+  const batchSize = parseBatchSize(process.env.PDPA_BACKFILL_BATCH_SIZE);
+
+  const prisma = new PrismaClient();
+  const [{ current_database: actualDb }] = await prisma.$queryRaw<{ current_database: string }[]>`SELECT current_database()`;
+  if (actualDb !== expectedDb) {
+    console.error(`ERROR: DB mismatch: connected to "${actualDb}" but EXPECTED_DB_NAME="${expectedDb}". Aborting.`);
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+
+  console.log(`[pdpa-backfill] DB: ${actualDb}`);
+  console.log(`[pdpa-backfill] Batch size: ${batchSize}`);
+  console.log('[pdpa-backfill] Press Ctrl+C within 5 seconds to abort.');
+  await new Promise((r) => setTimeout(r, 5000));
+
+  try {
+    // Instantiate the service with the bare PrismaClient. CustomerPiiService
+    // depends on PrismaService only for the strict-mode SystemConfig read,
+    // which the backfill itself doesn't need, so we cast the client.
+    const piiService = new CustomerPiiService(prisma as unknown as PrismaService);
+    const pdpaService = new PdpaEncryptionService(prisma as unknown as PrismaService, piiService);
+
+    console.log('[pdpa-backfill] Starting backfill...');
+    const result = await pdpaService.runBackfill({
+      triggeredBy: 'cli',
+      triggeredByUserId: null,
+      batchSize,
+      onProgress: (p) => {
+        const pct = p.total > 0 ? Math.round((p.processed * 100) / p.total) : 100;
+        console.log(`[pdpa-backfill]   batch ${p.batchNumber}: processed=${p.processed}/${p.total} (${pct}%), skipped=${p.skipped}`);
+      },
+    });
+
+    console.log('');
+    console.log(`[pdpa-backfill] Run id: ${result.id}`);
+    console.log(`[pdpa-backfill] Status: ${result.status}`);
+    console.log(`[pdpa-backfill] Total:     ${result.totalRecords}`);
+    console.log(`[pdpa-backfill] Processed: ${result.processedRecords}`);
+    console.log(`[pdpa-backfill] Skipped:   ${result.skippedRecords}`);
+    console.log(`[pdpa-backfill] Duration:  ${(result.durationMs / 1000).toFixed(1)}s`);
+    if (result.errorMessage) {
+      console.error(`[pdpa-backfill] Error: ${result.errorMessage}`);
+      process.exit(1);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+function parseBatchSize(raw: string | undefined): number {
+  if (!raw) return PdpaEncryptionService.DEFAULT_BATCH_SIZE;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0 || n > 1000) {
+    return PdpaEncryptionService.DEFAULT_BATCH_SIZE;
+  }
+  return n;
+}
+
+main().catch((err) => {
+  console.error('[pdpa-backfill] FATAL:', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/apps/api/src/cli/encrypt-customer-pii.cli.ts
+++ b/apps/api/src/cli/encrypt-customer-pii.cli.ts
@@ -17,13 +17,16 @@
  *   - We don't bootstrap the full NestJS DI container — instantiating
  *     PdpaEncryptionService directly with PrismaClient keeps the CLI fast
  *     and lets it run inside Cloud Run Jobs without the HTTP server.
- *   - The service writes one PdpaBackfillRun row regardless of CLI vs UI
- *     trigger, so ops gets a single auditable history.
+ *   - The service writes one PdpaBackfillRun row AND one AuditLog
+ *     `PDPA_BACKFILL_RUN` entry regardless of CLI vs UI trigger (W7),
+ *     so ops gets a single auditable history. CLI rows carry the SYSTEM
+ *     user UUID (User.isSystemUser=true) — same pattern as cron jobs.
  *   - NEVER prints decrypted PII. Progress lines only carry counters.
  */
 import { PrismaClient } from '@prisma/client';
 import { PdpaEncryptionService } from '../modules/pdpa/pdpa-encryption.service';
 import { CustomerPiiService } from '../modules/customers/customer-pii.service';
+import { AuditService } from '../modules/audit/audit.service';
 import type { PrismaService } from '../prisma/prisma.service';
 
 const REQUIRED_CONSENT = 'YES_I_AM_SURE';
@@ -88,7 +91,8 @@ async function main(): Promise<void> {
     // depends on PrismaService only for the strict-mode SystemConfig read,
     // which the backfill itself doesn't need, so we cast the client.
     const piiService = new CustomerPiiService(prisma as unknown as PrismaService);
-    const pdpaService = new PdpaEncryptionService(prisma as unknown as PrismaService, piiService);
+    const audit = new AuditService(prisma as unknown as PrismaService);
+    const pdpaService = new PdpaEncryptionService(prisma as unknown as PrismaService, piiService, audit);
 
     console.log('[pdpa-backfill] Starting backfill...');
     const result = await pdpaService.runBackfill({
@@ -111,6 +115,12 @@ async function main(): Promise<void> {
     if (result.errorMessage) {
       console.error(`[pdpa-backfill] Error: ${result.errorMessage}`);
       process.exit(1);
+    }
+    if (result.status === 'COMPLETED_WITH_RACE') {
+      console.warn(
+        '[pdpa-backfill] WARNING: Completed with race — concurrent writes added new plaintext during the run.',
+      );
+      console.warn('[pdpa-backfill] WARNING: Re-run during a maintenance window to converge.');
     }
   } finally {
     await prisma.$disconnect();

--- a/apps/api/src/modules/customers/customer-pii.service.spec.ts
+++ b/apps/api/src/modules/customers/customer-pii.service.spec.ts
@@ -47,9 +47,10 @@ describe('CustomerPiiService', () => {
         nationalId: '1234567890123',
         phone: '0812345678',
       });
-      expect(out.nationalIdEncrypted).toMatch(/^[a-f0-9]{32}:/);
+      // GCM wire format: iv(24):tag(32):cipher (3 colon-separated parts).
+      expect(out.nationalIdEncrypted).toMatch(/^[a-f0-9]{24}:[a-f0-9]{32}:/);
       expect(out.nationalIdHash).toMatch(/^[a-f0-9]{64}$/);
-      expect(out.phoneEncrypted).toMatch(/^[a-f0-9]{32}:/);
+      expect(out.phoneEncrypted).toMatch(/^[a-f0-9]{24}:[a-f0-9]{32}:/);
       expect(out.phoneHash).toMatch(/^[a-f0-9]{64}$/);
     });
 
@@ -83,11 +84,26 @@ describe('CustomerPiiService', () => {
       expect(a.phoneEncrypted).not.toBe(b.phoneEncrypted);
     });
 
-    it('passes through plaintext when PII_ENCRYPTION_KEY missing (dev fallback)', () => {
+    it('THROWS when PII_ENCRYPTION_KEY missing and caller writes a non-empty PII field (C2)', () => {
+      // C2 — the previous behaviour passed the plaintext straight through
+      // into `phoneEncrypted`, then strict-mode `isEncrypted` was happy to
+      // accept it because the format check was looking at the legacy
+      // plaintext column. Hard-fail now instead.
       delete process.env.PII_ENCRYPTION_KEY;
       const svc = new CustomerPiiService(makePrismaMock());
-      const out = svc.encryptCustomerFields({ phone: '0812345678' });
-      expect(out.phoneEncrypted).toBe('0812345678');
+      expect(() => svc.encryptCustomerFields({ phone: '0812345678' })).toThrow(
+        /PII_ENCRYPTION_KEY missing/i,
+      );
+    });
+
+    it('allows empty / null inputs even when key missing (no-op path)', () => {
+      delete process.env.PII_ENCRYPTION_KEY;
+      const svc = new CustomerPiiService(makePrismaMock());
+      // Passing only null/empty values is a no-op and should not throw —
+      // useful for partial updates that clear other columns.
+      expect(() =>
+        svc.encryptCustomerFields({ nationalId: null, phone: '' }),
+      ).not.toThrow();
     });
   });
 
@@ -190,28 +206,21 @@ describe('CustomerPiiService', () => {
       await expect(svc.isStrictMode()).resolves.toBe(true);
     });
 
-    it('caches results within the TTL window', async () => {
+    it('hits the DB on every call (no in-process cache — W1 fix)', async () => {
       const prisma = makePrismaMock('true') as unknown as { systemConfig: { findFirst: jest.Mock } };
       const svc = new CustomerPiiService(prisma as unknown as PrismaService);
       await svc.isStrictMode();
       await svc.isStrictMode();
       await svc.isStrictMode();
-      // Three calls but only one DB query thanks to cache.
-      expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(1);
-    });
-
-    it('invalidateStrictModeCache() forces a re-read', async () => {
-      const prisma = makePrismaMock('true') as unknown as { systemConfig: { findFirst: jest.Mock } };
-      const svc = new CustomerPiiService(prisma as unknown as PrismaService);
-      await svc.isStrictMode();
-      svc.invalidateStrictModeCache();
-      await svc.isStrictMode();
-      expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(2);
+      // 3 calls → 3 DB queries (previously 1 due to 30s cache). Cache was
+      // dropped because the toggle is hot-path and stale-cache produces
+      // cross-pod inconsistency.
+      expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(3);
     });
   });
 
   describe('setStrictMode', () => {
-    it('upserts the SystemConfig row and clears the cache', async () => {
+    it('upserts the SystemConfig row', async () => {
       const prisma = makePrismaMock(null);
       const svc = new CustomerPiiService(prisma);
       await svc.setStrictMode(true);

--- a/apps/api/src/modules/customers/customer-pii.service.spec.ts
+++ b/apps/api/src/modules/customers/customer-pii.service.spec.ts
@@ -1,0 +1,249 @@
+import { BadRequestException } from '@nestjs/common';
+import { CustomerPiiService } from './customer-pii.service';
+import type { PrismaService } from '../../prisma/prisma.service';
+
+// Test PII secrets — 64 hex chars (32 bytes) for AES-256, 32+ chars for salt.
+const TEST_KEY = 'a'.repeat(64);
+const TEST_SALT = 'b'.repeat(48);
+
+function makePrismaMock(systemConfigValue?: string | null) {
+  return {
+    systemConfig: {
+      findFirst: jest.fn().mockResolvedValue(
+        systemConfigValue !== undefined ? { value: systemConfigValue } : null,
+      ),
+      upsert: jest.fn().mockResolvedValue({}),
+    },
+  } as unknown as PrismaService;
+}
+
+describe('CustomerPiiService', () => {
+  let originalKey: string | undefined;
+  let originalSalt: string | undefined;
+  let originalStrict: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.PII_ENCRYPTION_KEY;
+    originalSalt = process.env.PII_HASH_SALT;
+    originalStrict = process.env.PDPA_STRICT_MODE;
+    process.env.PII_ENCRYPTION_KEY = TEST_KEY;
+    process.env.PII_HASH_SALT = TEST_SALT;
+    delete process.env.PDPA_STRICT_MODE;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.PII_ENCRYPTION_KEY;
+    else process.env.PII_ENCRYPTION_KEY = originalKey;
+    if (originalSalt === undefined) delete process.env.PII_HASH_SALT;
+    else process.env.PII_HASH_SALT = originalSalt;
+    if (originalStrict === undefined) delete process.env.PDPA_STRICT_MODE;
+    else process.env.PDPA_STRICT_MODE = originalStrict;
+  });
+
+  describe('encryptCustomerFields', () => {
+    it('produces *Encrypted + *Hash columns for nationalId and phone', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const out = svc.encryptCustomerFields({
+        nationalId: '1234567890123',
+        phone: '0812345678',
+      });
+      expect(out.nationalIdEncrypted).toMatch(/^[a-f0-9]{32}:/);
+      expect(out.nationalIdHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(out.phoneEncrypted).toMatch(/^[a-f0-9]{32}:/);
+      expect(out.phoneHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('leaves undefined fields untouched (partial-update safe)', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const out = svc.encryptCustomerFields({ phone: '0812345678' });
+      expect('nationalIdEncrypted' in out).toBe(false);
+      expect('nationalIdHash' in out).toBe(false);
+      expect(out.phoneEncrypted).toBeDefined();
+    });
+
+    it('passes through null / empty without encrypting', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const out = svc.encryptCustomerFields({
+        nationalId: null,
+        phone: '',
+      });
+      expect(out.nationalIdEncrypted).toBeNull();
+      expect(out.nationalIdHash).toBeNull();
+      expect(out.phoneEncrypted).toBe('');
+      expect(out.phoneHash).toBe('');
+    });
+
+    it('produces deterministic hashes (same input → same hash)', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const a = svc.encryptCustomerFields({ phone: '0812345678' });
+      const b = svc.encryptCustomerFields({ phone: '0812345678' });
+      // hashes must match for unique-constraint based lookup to work
+      expect(a.phoneHash).toBe(b.phoneHash);
+      // ciphertexts must differ (IV randomness — same plaintext → different ciphertext)
+      expect(a.phoneEncrypted).not.toBe(b.phoneEncrypted);
+    });
+
+    it('passes through plaintext when PII_ENCRYPTION_KEY missing (dev fallback)', () => {
+      delete process.env.PII_ENCRYPTION_KEY;
+      const svc = new CustomerPiiService(makePrismaMock());
+      const out = svc.encryptCustomerFields({ phone: '0812345678' });
+      expect(out.phoneEncrypted).toBe('0812345678');
+    });
+  });
+
+  describe('decryptCustomerFields', () => {
+    it('round-trips a record through encrypt then decrypt', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const enc = svc.encryptCustomerFields({
+        nationalId: '1234567890123',
+        phone: '0812345678',
+        email: 'alice@example.com',
+      });
+      const row = {
+        id: 'c1',
+        nationalIdEncrypted: enc.nationalIdEncrypted!,
+        phoneEncrypted: enc.phoneEncrypted!,
+        emailEncrypted: enc.emailEncrypted!,
+      } as Record<string, unknown>;
+
+      const dec = svc.decryptCustomerFields(row)!;
+      expect(dec.nationalId).toBe('1234567890123');
+      expect(dec.phone).toBe('0812345678');
+      expect(dec.email).toBe('alice@example.com');
+    });
+
+    it('falls back to legacy plaintext column when encrypted is null (non-strict)', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const dec = svc.decryptCustomerFields({
+        id: 'c1',
+        nationalId: '9999999999999',
+        nationalIdEncrypted: null,
+      })!;
+      expect(dec.nationalId).toBe('9999999999999');
+    });
+
+    it('throws BadRequestException in strict mode if encrypted is null but plaintext present', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(() =>
+        svc.decryptCustomerFields(
+          {
+            id: 'c1',
+            nationalId: '9999999999999',
+            nationalIdEncrypted: null,
+          },
+          { strict: true },
+        ),
+      ).toThrow(BadRequestException);
+    });
+
+    it('returns the input unchanged when row is null', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(svc.decryptCustomerFields(null)).toBeNull();
+    });
+  });
+
+  describe('searchByHash', () => {
+    it('returns { phoneHash } for phone field', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const where = svc.searchByHash('phone', '0812345678');
+      expect(where).toEqual({ phoneHash: expect.any(String) });
+      expect(where!.phoneHash).toHaveLength(64);
+    });
+
+    it('returns { nationalIdHash } for nationalId field', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      const where = svc.searchByHash('nationalId', '1234567890123');
+      expect(where).toEqual({ nationalIdHash: expect.any(String) });
+    });
+
+    it('returns null for email (not hash-searchable)', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(svc.searchByHash('email', 'a@b.com')).toBeNull();
+    });
+
+    it('returns null when value is empty', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(svc.searchByHash('phone', '')).toBeNull();
+    });
+
+    it('returns null when salt is unconfigured', () => {
+      delete process.env.PII_HASH_SALT;
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(svc.searchByHash('phone', '0812345678')).toBeNull();
+    });
+  });
+
+  describe('isStrictMode', () => {
+    it('returns true when SystemConfig PDPA_STRICT_MODE=true', async () => {
+      const svc = new CustomerPiiService(makePrismaMock('true'));
+      await expect(svc.isStrictMode()).resolves.toBe(true);
+    });
+
+    it('returns false when SystemConfig is unset and env var unset', async () => {
+      const svc = new CustomerPiiService(makePrismaMock(null));
+      await expect(svc.isStrictMode()).resolves.toBe(false);
+    });
+
+    it('falls back to PDPA_STRICT_MODE env var when SystemConfig is missing', async () => {
+      process.env.PDPA_STRICT_MODE = '1';
+      const svc = new CustomerPiiService(makePrismaMock(null));
+      await expect(svc.isStrictMode()).resolves.toBe(true);
+    });
+
+    it('caches results within the TTL window', async () => {
+      const prisma = makePrismaMock('true') as unknown as { systemConfig: { findFirst: jest.Mock } };
+      const svc = new CustomerPiiService(prisma as unknown as PrismaService);
+      await svc.isStrictMode();
+      await svc.isStrictMode();
+      await svc.isStrictMode();
+      // Three calls but only one DB query thanks to cache.
+      expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateStrictModeCache() forces a re-read', async () => {
+      const prisma = makePrismaMock('true') as unknown as { systemConfig: { findFirst: jest.Mock } };
+      const svc = new CustomerPiiService(prisma as unknown as PrismaService);
+      await svc.isStrictMode();
+      svc.invalidateStrictModeCache();
+      await svc.isStrictMode();
+      expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('setStrictMode', () => {
+    it('upserts the SystemConfig row and clears the cache', async () => {
+      const prisma = makePrismaMock(null);
+      const svc = new CustomerPiiService(prisma);
+      await svc.setStrictMode(true);
+      // upsert called
+      expect(
+        (prisma as unknown as { systemConfig: { upsert: jest.Mock } }).systemConfig.upsert,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { key: 'PDPA_STRICT_MODE' },
+          create: expect.objectContaining({ key: 'PDPA_STRICT_MODE', value: 'true' }),
+        }),
+      );
+    });
+  });
+
+  describe('hash', () => {
+    it('produces a 64-char hex hash for a non-empty string', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(svc.hash('0812345678')).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('returns null for empty / null inputs', () => {
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(svc.hash(null)).toBeNull();
+      expect(svc.hash('')).toBeNull();
+      expect(svc.hash(undefined)).toBeNull();
+    });
+
+    it('returns null when salt is unconfigured', () => {
+      delete process.env.PII_HASH_SALT;
+      const svc = new CustomerPiiService(makePrismaMock());
+      expect(svc.hash('x')).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/modules/customers/customer-pii.service.ts
+++ b/apps/api/src/modules/customers/customer-pii.service.ts
@@ -1,0 +1,335 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { encryptPII, decryptPII, isEncrypted } from '../../utils/crypto.util';
+import {
+  hashPII,
+  encryptReferencesJson,
+  decryptReferencesJson,
+} from '../../utils/pii.util';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * Phase 3 SP4 — Customer PII service.
+ *
+ * Centralizes encrypt / decrypt / hash logic for Customer PII columns
+ * (Phase 2 added the columns; Phase 3 dual-writes; Phase 6 will drop
+ * plaintext). Previously the same code lived inside CustomersService —
+ * extracted here so:
+ *
+ *   1. Tests can mock PII handling without spinning CustomersService.
+ *   2. PDPA "strict mode" toggle has one chokepoint to enforce.
+ *   3. Other modules that need to write Customer PII (e.g. chatbot-finance
+ *      auto-registration, LIFF onboarding) share the same dual-write logic
+ *      instead of re-implementing it.
+ *
+ * NB: this service NEVER logs decrypted values. The only log statements
+ * here are about config drift (missing key/salt) and strict-mode rejections,
+ * neither of which carries customer data.
+ */
+
+/** Plaintext PII inputs a caller might supply for create/update. */
+export interface CustomerPiiInput {
+  nationalId?: string | null;
+  phone?: string | null;
+  phoneSecondary?: string | null;
+  email?: string | null;
+  addressIdCard?: string | null;
+  addressCurrent?: string | null;
+  addressWork?: string | null;
+  guardianNationalId?: string | null;
+  guardianPhone?: string | null;
+  guardianAddress?: string | null;
+  references?: unknown;
+}
+
+/**
+ * Encrypted / hash columns produced by encryptCustomerFields(). All fields
+ * are optional because callers only pass the subset they're updating.
+ */
+export interface CustomerPiiEncrypted {
+  nationalIdEncrypted?: string | null;
+  nationalIdHash?: string | null;
+  phoneEncrypted?: string | null;
+  phoneHash?: string | null;
+  phoneSecondaryEncrypted?: string | null;
+  emailEncrypted?: string | null;
+  addressIdCardEncrypted?: string | null;
+  addressCurrentEncrypted?: string | null;
+  addressWorkEncrypted?: string | null;
+  guardianNationalIdEncrypted?: string | null;
+  guardianPhoneEncrypted?: string | null;
+  guardianAddressEncrypted?: string | null;
+  referencesEncrypted?: unknown;
+}
+
+/** Which PII field a search-by-hash query is targeting. */
+export type HashSearchField = 'phone' | 'nationalId' | 'email';
+
+@Injectable()
+export class CustomerPiiService {
+  private readonly logger = new Logger(CustomerPiiService.name);
+  /** Cached strict-mode flag — refreshed via isStrictMode(); cheap because it's a single bool. */
+  private strictModeCache: { value: boolean; checkedAt: number } | null = null;
+  /** Strict-mode cache TTL — 30s. Long enough to avoid hammering SystemConfig
+   *  on hot read paths, short enough that toggling the flag in /settings#pdpa
+   *  takes effect promptly. */
+  static readonly STRICT_MODE_TTL_MS = 30_000;
+  /** SystemConfig key that controls strict mode. */
+  static readonly STRICT_MODE_CONFIG_KEY = 'PDPA_STRICT_MODE';
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  private get piiKey(): string {
+    return process.env.PII_ENCRYPTION_KEY || '';
+  }
+
+  private get hashSalt(): string {
+    return process.env.PII_HASH_SALT || '';
+  }
+
+  /**
+   * Read the strict-mode toggle. SystemConfig wins, env var falls back. The
+   * env var path matters in tests + CLI runs that have no DB session, but
+   * production toggling happens through the SystemConfig UI.
+   */
+  async isStrictMode(): Promise<boolean> {
+    const now = Date.now();
+    if (
+      this.strictModeCache &&
+      now - this.strictModeCache.checkedAt < CustomerPiiService.STRICT_MODE_TTL_MS
+    ) {
+      return this.strictModeCache.value;
+    }
+    let value = false;
+    try {
+      const row = await this.prisma.systemConfig.findFirst({
+        where: { key: CustomerPiiService.STRICT_MODE_CONFIG_KEY, deletedAt: null },
+        select: { value: true },
+      });
+      if (row?.value) {
+        const v = row.value.trim().toLowerCase();
+        value = v === 'true' || v === '1';
+      } else {
+        const env = (process.env.PDPA_STRICT_MODE || '').trim().toLowerCase();
+        value = env === 'true' || env === '1';
+      }
+    } catch {
+      // Database unreachable (CLI bootstrap, ts-node first connect, etc.)
+      // — fall back to env var rather than throwing. Strict-mode rejection
+      // is enforced in user-facing paths only, so a fallback of `false`
+      // here is safe (dual-write still happens).
+      const env = (process.env.PDPA_STRICT_MODE || '').trim().toLowerCase();
+      value = env === 'true' || env === '1';
+    }
+    this.strictModeCache = { value, checkedAt: now };
+    return value;
+  }
+
+  /** Test seam — bypass the SystemConfig cache without waiting 30s. */
+  invalidateStrictModeCache(): void {
+    this.strictModeCache = null;
+  }
+
+  /**
+   * Set the strict-mode flag. Upserts SystemConfig and clears the cache
+   * so the next isStrictMode() call sees the new value immediately.
+   *
+   * Returns the new effective value.
+   */
+  async setStrictMode(enabled: boolean): Promise<boolean> {
+    await this.prisma.systemConfig.upsert({
+      where: { key: CustomerPiiService.STRICT_MODE_CONFIG_KEY },
+      update: {
+        value: enabled ? 'true' : 'false',
+        updatedAt: new Date(),
+        deletedAt: null,
+      },
+      create: {
+        key: CustomerPiiService.STRICT_MODE_CONFIG_KEY,
+        value: enabled ? 'true' : 'false',
+        label: 'PDPA strict mode — require encrypted PII columns on every read',
+      },
+    });
+    this.invalidateStrictModeCache();
+    return enabled;
+  }
+
+  /**
+   * Encrypt + hash a set of PII fields. Only fields the caller passes
+   * (typeof !== 'undefined') are touched, so partial updates leave
+   * untouched columns alone.
+   *
+   * Null / empty inputs become null/empty in the output, NOT encrypted —
+   * encrypting an empty string would produce ciphertext that decrypts to
+   * '' but burns CPU + bytes for nothing.
+   */
+  encryptCustomerFields(input: CustomerPiiInput): CustomerPiiEncrypted {
+    const key = this.piiKey;
+    const salt = this.hashSalt;
+    const out: CustomerPiiEncrypted = {};
+
+    const enc = (v: string | null | undefined): string | null | undefined => {
+      if (v === undefined) return undefined;
+      if (v === null || v === '') return v;
+      return key ? encryptPII(v, key) : v;
+    };
+    const hsh = (v: string | null | undefined): string | null | undefined => {
+      if (v === undefined) return undefined;
+      if (v === null || v === '') return v;
+      return salt ? hashPII(v, salt) : v;
+    };
+
+    if (input.nationalId !== undefined) {
+      out.nationalIdEncrypted = enc(input.nationalId);
+      out.nationalIdHash = hsh(input.nationalId);
+    }
+    if (input.phone !== undefined) {
+      out.phoneEncrypted = enc(input.phone);
+      out.phoneHash = hsh(input.phone);
+    }
+    if (input.phoneSecondary !== undefined) {
+      out.phoneSecondaryEncrypted = enc(input.phoneSecondary);
+    }
+    if (input.email !== undefined) {
+      out.emailEncrypted = enc(input.email);
+    }
+    if (input.addressIdCard !== undefined) {
+      out.addressIdCardEncrypted = enc(input.addressIdCard);
+    }
+    if (input.addressCurrent !== undefined) {
+      out.addressCurrentEncrypted = enc(input.addressCurrent);
+    }
+    if (input.addressWork !== undefined) {
+      out.addressWorkEncrypted = enc(input.addressWork);
+    }
+    if (input.guardianNationalId !== undefined) {
+      out.guardianNationalIdEncrypted = enc(input.guardianNationalId);
+    }
+    if (input.guardianPhone !== undefined) {
+      out.guardianPhoneEncrypted = enc(input.guardianPhone);
+    }
+    if (input.guardianAddress !== undefined) {
+      out.guardianAddressEncrypted = enc(input.guardianAddress);
+    }
+    if (input.references !== undefined) {
+      out.referencesEncrypted =
+        key && input.references
+          ? encryptReferencesJson(input.references, key)
+          : input.references;
+    }
+
+    return out;
+  }
+
+  /**
+   * Decrypt PII columns and project them back onto the legacy field names.
+   * Strict mode: if the encrypted column is NULL and the row is referenced
+   * by the caller, throw — the row hasn't been backfilled yet.
+   * Non-strict: fall back to the legacy plaintext column (rolling-deploy
+   * safety).
+   */
+  decryptCustomerFields<T extends Record<string, unknown>>(c: T | null, opts: { strict?: boolean } = {}): T | null {
+    if (!c) return c;
+    const key = this.piiKey;
+    if (!key) return c;
+    const strict = opts.strict === true;
+
+    const dec = (encField: string, legacyField: string): string | null | undefined => {
+      const enc = c[encField] as string | null | undefined;
+      if (enc && typeof enc === 'string' && isEncrypted(enc)) {
+        return decryptPII(enc, key);
+      }
+      // In strict mode, reading a row whose encrypted column is missing
+      // means the backfill hasn't run. Surface that loudly rather than
+      // silently leaking plaintext.
+      if (strict) {
+        const legacy = c[legacyField];
+        if (legacy !== undefined && legacy !== null && legacy !== '') {
+          throw new BadRequestException(
+            `ข้อมูลยังไม่ได้เข้ารหัส (${encField}) — กรุณารัน backfill ก่อนเปิด PDPA strict mode`,
+          );
+        }
+      }
+      return c[legacyField] as string | null | undefined;
+    };
+
+    const refEnc = c['referencesEncrypted'];
+    let references: unknown = c['references'];
+    if (refEnc) {
+      references = decryptReferencesJson(refEnc, key);
+    } else if (strict && c['references']) {
+      throw new BadRequestException(
+        'ข้อมูล references ยังไม่ได้เข้ารหัส — กรุณารัน backfill ก่อนเปิด PDPA strict mode',
+      );
+    }
+
+    return {
+      ...c,
+      nationalId: dec('nationalIdEncrypted', 'nationalId'),
+      phone: dec('phoneEncrypted', 'phone'),
+      phoneSecondary: dec('phoneSecondaryEncrypted', 'phoneSecondary'),
+      email: dec('emailEncrypted', 'email'),
+      addressIdCard: dec('addressIdCardEncrypted', 'addressIdCard'),
+      addressCurrent: dec('addressCurrentEncrypted', 'addressCurrent'),
+      addressWork: dec('addressWorkEncrypted', 'addressWork'),
+      guardianNationalId: dec('guardianNationalIdEncrypted', 'guardianNationalId'),
+      guardianPhone: dec('guardianPhoneEncrypted', 'guardianPhone'),
+      guardianAddress: dec('guardianAddressEncrypted', 'guardianAddress'),
+      references,
+    } as T;
+  }
+
+  /** Bulk variant of decryptCustomerFields for list endpoints. */
+  decryptCustomerList<T extends Record<string, unknown>>(rows: T[], opts: { strict?: boolean } = {}): T[] {
+    return rows.map((r) => this.decryptCustomerFields(r, opts) as T);
+  }
+
+  /**
+   * Build a Prisma where fragment that looks up a customer by the
+   * deterministic hash of a PII field. Returns null if the salt is
+   * unconfigured (test env, dev without secrets) — caller is expected
+   * to fall back to the plaintext path in that case.
+   *
+   * Address is intentionally NOT hash-searchable — addresses are
+   * variable-cased free text, exact-match lookup makes no sense.
+   */
+  searchByHash(field: HashSearchField, value: string): Record<string, string> | null {
+    if (!value) return null;
+    const salt = this.hashSalt;
+    if (field === 'email') {
+      // Email is not hashed (case sensitivity + normalization complicates it).
+      // Callers should use Prisma's `mode: 'insensitive'` on the plaintext
+      // column. Returning null nudges them to do that instead of mis-using
+      // this helper.
+      return null;
+    }
+    if (!salt) return null;
+    const h = hashPII(value, salt);
+    if (field === 'phone') return { phoneHash: h };
+    if (field === 'nationalId') return { nationalIdHash: h };
+    return null;
+  }
+
+  /**
+   * Convenience: produce the hash for a given input (e.g. for unique-
+   * constraint lookups inside CustomersService.create()). Returns null if
+   * the salt is missing so callers can fall back to the plaintext path.
+   */
+  hash(value: string | null | undefined): string | null {
+    if (!value) return null;
+    const salt = this.hashSalt;
+    if (!salt) return null;
+    return hashPII(value, salt);
+  }
+
+  /**
+   * Quick "is at least one encrypted column populated?" sniff on a raw
+   * Customer row. Used by strict-mode read guards before they descend
+   * into per-field decryption.
+   */
+  isRowEncrypted(c: Record<string, unknown> | null): boolean {
+    if (!c) return false;
+    return (
+      typeof c['nationalIdEncrypted'] === 'string' && isEncrypted(c['nationalIdEncrypted'] as string)
+    );
+  }
+}

--- a/apps/api/src/modules/customers/customer-pii.service.ts
+++ b/apps/api/src/modules/customers/customer-pii.service.ts
@@ -67,12 +67,6 @@ export type HashSearchField = 'phone' | 'nationalId' | 'email';
 @Injectable()
 export class CustomerPiiService {
   private readonly logger = new Logger(CustomerPiiService.name);
-  /** Cached strict-mode flag — refreshed via isStrictMode(); cheap because it's a single bool. */
-  private strictModeCache: { value: boolean; checkedAt: number } | null = null;
-  /** Strict-mode cache TTL — 30s. Long enough to avoid hammering SystemConfig
-   *  on hot read paths, short enough that toggling the flag in /settings#pdpa
-   *  takes effect promptly. */
-  static readonly STRICT_MODE_TTL_MS = 30_000;
   /** SystemConfig key that controls strict mode. */
   static readonly STRICT_MODE_CONFIG_KEY = 'PDPA_STRICT_MODE';
 
@@ -90,16 +84,14 @@ export class CustomerPiiService {
    * Read the strict-mode toggle. SystemConfig wins, env var falls back. The
    * env var path matters in tests + CLI runs that have no DB session, but
    * production toggling happens through the SystemConfig UI.
+   *
+   * DEEP review W1 — there is intentionally NO in-process cache here. The
+   * SystemConfig SELECT is sub-millisecond (indexed `key` column, ~99
+   * rows total) and caching produces cross-pod inconsistency (one pod
+   * reads strict=true, peer pod still serves strict=false from its
+   * 30s-old cache, callers see flapping 400s). Hit the DB every time.
    */
   async isStrictMode(): Promise<boolean> {
-    const now = Date.now();
-    if (
-      this.strictModeCache &&
-      now - this.strictModeCache.checkedAt < CustomerPiiService.STRICT_MODE_TTL_MS
-    ) {
-      return this.strictModeCache.value;
-    }
-    let value = false;
     try {
       const row = await this.prisma.systemConfig.findFirst({
         where: { key: CustomerPiiService.STRICT_MODE_CONFIG_KEY, deletedAt: null },
@@ -107,32 +99,20 @@ export class CustomerPiiService {
       });
       if (row?.value) {
         const v = row.value.trim().toLowerCase();
-        value = v === 'true' || v === '1';
-      } else {
-        const env = (process.env.PDPA_STRICT_MODE || '').trim().toLowerCase();
-        value = env === 'true' || env === '1';
+        return v === 'true' || v === '1';
       }
     } catch {
       // Database unreachable (CLI bootstrap, ts-node first connect, etc.)
       // — fall back to env var rather than throwing. Strict-mode rejection
       // is enforced in user-facing paths only, so a fallback of `false`
       // here is safe (dual-write still happens).
-      const env = (process.env.PDPA_STRICT_MODE || '').trim().toLowerCase();
-      value = env === 'true' || env === '1';
     }
-    this.strictModeCache = { value, checkedAt: now };
-    return value;
-  }
-
-  /** Test seam — bypass the SystemConfig cache without waiting 30s. */
-  invalidateStrictModeCache(): void {
-    this.strictModeCache = null;
+    const env = (process.env.PDPA_STRICT_MODE || '').trim().toLowerCase();
+    return env === 'true' || env === '1';
   }
 
   /**
-   * Set the strict-mode flag. Upserts SystemConfig and clears the cache
-   * so the next isStrictMode() call sees the new value immediately.
-   *
+   * Set the strict-mode flag. Upserts SystemConfig.
    * Returns the new effective value.
    */
   async setStrictMode(enabled: boolean): Promise<boolean> {
@@ -149,7 +129,6 @@ export class CustomerPiiService {
         label: 'PDPA strict mode — require encrypted PII columns on every read',
       },
     });
-    this.invalidateStrictModeCache();
     return enabled;
   }
 
@@ -161,21 +140,56 @@ export class CustomerPiiService {
    * Null / empty inputs become null/empty in the output, NOT encrypted —
    * encrypting an empty string would produce ciphertext that decrypts to
    * '' but burns CPU + bytes for nothing.
+   *
+   * @throws Error when PII_ENCRYPTION_KEY is missing or too short and the
+   *   caller is trying to write a non-empty value. Refusing here prevents
+   *   the historical bug where misconfigured prod wrote literal plaintext
+   *   into the `*_encrypted` columns (DEEP review C2).
    */
   encryptCustomerFields(input: CustomerPiiInput): CustomerPiiEncrypted {
     const key = this.piiKey;
     const salt = this.hashSalt;
     const out: CustomerPiiEncrypted = {};
 
+    // Hard guard: if any non-empty PII value is being written but the key
+    // / salt are missing, refuse the operation. Empty values stay legal
+    // because they bypass crypto entirely.
+    const hasNonEmptyPii = ([
+      input.nationalId,
+      input.phone,
+      input.phoneSecondary,
+      input.email,
+      input.addressIdCard,
+      input.addressCurrent,
+      input.addressWork,
+      input.guardianNationalId,
+      input.guardianPhone,
+      input.guardianAddress,
+    ] as Array<string | null | undefined>).some((v) => typeof v === 'string' && v.length > 0) ||
+      (Array.isArray(input.references) && input.references.length > 0);
+
+    if (hasNonEmptyPii) {
+      if (!key || key.length < 32) {
+        throw new Error(
+          'PII_ENCRYPTION_KEY missing or too short — refusing to write plaintext into *_encrypted columns',
+        );
+      }
+      if (!salt || salt.length < 32) {
+        throw new Error(
+          'PII_HASH_SALT missing or too short — refusing to write plaintext into *_hash columns',
+        );
+      }
+    }
+
     const enc = (v: string | null | undefined): string | null | undefined => {
       if (v === undefined) return undefined;
       if (v === null || v === '') return v;
-      return key ? encryptPII(v, key) : v;
+      return encryptPII(v, key);
     };
     const hsh = (v: string | null | undefined): string | null | undefined => {
       if (v === undefined) return undefined;
       if (v === null || v === '') return v;
-      return salt ? hashPII(v, salt) : v;
+      return hashPII(v, salt);
     };
 
     if (input.nationalId !== undefined) {

--- a/apps/api/src/modules/customers/customers.module.ts
+++ b/apps/api/src/modules/customers/customers.module.ts
@@ -4,6 +4,7 @@ import { CustomersService } from './customers.service';
 import { CustomerTierService } from './customer-tier.service';
 import { CustomerPreCheckService } from './customer-precheck.service';
 import { SkipTracingService } from './skip-tracing.service';
+import { CustomerPiiService } from './customer-pii.service';
 import { OverdueModule } from '../overdue/overdue.module';
 
 @Module({
@@ -14,12 +15,14 @@ import { OverdueModule } from '../overdue/overdue.module';
     CustomerTierService,
     CustomerPreCheckService,
     SkipTracingService,
+    CustomerPiiService,
   ],
   exports: [
     CustomersService,
     CustomerTierService,
     CustomerPreCheckService,
     SkipTracingService,
+    CustomerPiiService,
   ],
 })
 export class CustomersModule {}

--- a/apps/api/src/modules/customers/customers.service.spec.ts
+++ b/apps/api/src/modules/customers/customers.service.spec.ts
@@ -247,10 +247,10 @@ describe('PII dual-write (Phase 3)', () => {
     // Legacy columns still populated
     expect(call.data.nationalId).toBe('1234567890123');
     expect(call.data.phone).toMatch(/^08\d{8}$/);
-    // Encrypted columns populated (iv:cipher format)
-    expect(call.data.nationalIdEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);
-    expect(call.data.phoneEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);
-    expect(call.data.emailEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);
+    // Encrypted columns populated (GCM iv:tag:cipher format — C1)
+    expect(call.data.nationalIdEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+    expect(call.data.phoneEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+    expect(call.data.emailEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
     // Hash columns populated (sha256 = 64 hex chars)
     expect(call.data.nationalIdHash).toMatch(/^[0-9a-f]{64}$/);
     expect(call.data.phoneHash).toMatch(/^[0-9a-f]{64}$/);
@@ -273,7 +273,7 @@ describe('PII dual-write (Phase 3)', () => {
 
     const call = (prisma.customer.update as jest.Mock).mock.calls[0][0];
     expect(call.data.phone).toMatch(/^08\d{8}$/);
-    expect(call.data.phoneEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);
+    expect(call.data.phoneEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
     expect(call.data.phoneHash).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, BadRequestException, Optional } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { paginatedResponse } from '../../common/helpers/pagination.helper';
@@ -6,12 +6,17 @@ import { CreateCustomerDto, UpdateCustomerDto } from './dto/customer.dto';
 import { encryptPII, decryptPII, isEncrypted } from '../../utils/crypto.util';
 import { hashPII, encryptReferencesJson, decryptReferencesJson } from '../../utils/pii.util';
 import { CustomerTierService } from './customer-tier.service';
+import { CustomerPiiService } from './customer-pii.service';
 
 @Injectable()
 export class CustomersService {
   constructor(
     private prisma: PrismaService,
     private readonly tierService: CustomerTierService,
+    // Optional so legacy spec tests that construct CustomersService with
+    // only PrismaService + CustomerTierService keep working. Production
+    // wires the real provider through CustomersModule.
+    @Optional() private readonly piiService?: CustomerPiiService,
   ) {}
 
   async findAll(
@@ -120,13 +125,17 @@ export class CustomersService {
       })(),
     ]);
 
+    // Phase 3 SP4 — strict mode resolved once per request; null piiService
+    // (legacy spec injection) treats as non-strict.
+    const strict = this.piiService ? await this.piiService.isStrictMode() : false;
+
     const enriched = data.map((c) => {
       const activeContracts = c.contracts.filter((ct) => ct.status === 'ACTIVE').length;
       const overdueContracts = c.contracts.filter((ct) => ['OVERDUE', 'DEFAULT'].includes(ct.status)).length;
       const latestCredit = c.creditChecks[0] || null;
       const { contracts, creditChecks, ...rest } = c;
       // Phase 5: decrypt PII fields, then strip encrypted columns from response
-      const decrypted = this.decryptCustomerPII(rest as Record<string, unknown>);
+      const decrypted = this.decryptCustomerPII(rest as Record<string, unknown>, { strict });
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { nationalIdEncrypted: _ne, phoneEncrypted: _pe, ...clean } =
         decrypted as typeof rest & { nationalIdEncrypted?: unknown; phoneEncrypted?: unknown };
@@ -198,8 +207,11 @@ export class CustomersService {
       },
     });
     if (!customer || customer.deletedAt) throw new NotFoundException('ไม่พบลูกค้า');
-    // Phase 5: decrypt PII before returning
-    return this.decryptCustomerPII(customer as unknown as Record<string, unknown>) as typeof customer;
+    // Phase 5: decrypt PII before returning. Phase 3 SP4 also enforces
+    // strict-mode rejection — if PDPA_STRICT_MODE=true and the row hasn't
+    // been backfilled, BadRequestException is thrown with a clear message.
+    const strict = this.piiService ? await this.piiService.isStrictMode() : false;
+    return this.decryptCustomerPII(customer as unknown as Record<string, unknown>, { strict }) as typeof customer;
   }
 
   async getReferrals(id: string) {
@@ -291,7 +303,8 @@ export class CustomersService {
       orderBy: { name: 'asc' },
     });
     // Phase 5: decrypt PII, then project only the fields callers expect
-    return this.decryptCustomerList(rows as unknown as Record<string, unknown>[]).map((r) => ({
+    const strict = this.piiService ? await this.piiService.isStrictMode() : false;
+    return this.decryptCustomerList(rows as unknown as Record<string, unknown>[], { strict }).map((r) => ({
       id: r['id'],
       name: r['name'],
       phone: r['phone'],
@@ -333,6 +346,12 @@ export class CustomersService {
     guardianAddress?: string | null;
     references?: unknown;
   }): Record<string, unknown> {
+    // Phase 3 SP4 — delegate to CustomerPiiService when injected. Falls back
+    // to inline logic so legacy spec tests that construct CustomersService
+    // without the new dependency keep working (jest 'as unknown as ...' DI).
+    if (this.piiService) {
+      return this.piiService.encryptCustomerFields(data) as Record<string, unknown>;
+    }
     const key = this.piiKey;
     const salt = this.hashSalt;
     const out: Record<string, unknown> = {};
@@ -379,7 +398,14 @@ export class CustomersService {
    * be populated. We still gracefully fall back to the legacy plaintext
    * column if encrypted is NULL — supports rolling deploy + rollback safety.
    */
-  private decryptCustomerPII<T extends Record<string, unknown>>(c: T | null): T | null {
+  private decryptCustomerPII<T extends Record<string, unknown>>(c: T | null, opts: { strict?: boolean } = {}): T | null {
+    // Phase 3 SP4 — delegate to CustomerPiiService when injected (also
+    // surfaces strict-mode rejection). Falls back to inline logic so legacy
+    // tests that construct CustomersService without the new dependency
+    // continue to work.
+    if (this.piiService) {
+      return this.piiService.decryptCustomerFields(c, opts);
+    }
     if (!c) return c;
     const key = this.piiKey;
     if (!key) return c;
@@ -413,8 +439,8 @@ export class CustomersService {
   /**
    * Decrypt a list of customer rows.
    */
-  private decryptCustomerList<T extends Record<string, unknown>>(rows: T[]): T[] {
-    return rows.map((r) => this.decryptCustomerPII(r) as T);
+  private decryptCustomerList<T extends Record<string, unknown>>(rows: T[], opts: { strict?: boolean } = {}): T[] {
+    return rows.map((r) => this.decryptCustomerPII(r, opts) as T);
   }
 
   /**

--- a/apps/api/src/modules/pdpa/dto/strict-mode.dto.ts
+++ b/apps/api/src/modules/pdpa/dto/strict-mode.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class SetStrictModeDto {
+  @IsBoolean({ message: 'enabled ต้องเป็น boolean' })
+  enabled: boolean;
+}

--- a/apps/api/src/modules/pdpa/pdpa-backfill-retention.cron.spec.ts
+++ b/apps/api/src/modules/pdpa/pdpa-backfill-retention.cron.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PdpaBackfillRetentionCron } from './pdpa-backfill-retention.cron';
+import { PdpaEncryptionService } from './pdpa-encryption.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('PdpaBackfillRetentionCron (W2)', () => {
+  let cron: PdpaBackfillRetentionCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let service: any;
+
+  beforeEach(async () => {
+    service = { pruneOldRuns: jest.fn() };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        PdpaBackfillRetentionCron,
+        { provide: PdpaEncryptionService, useValue: service },
+      ],
+    }).compile();
+    cron = mod.get(PdpaBackfillRetentionCron);
+  });
+
+  it('delegates to service.pruneOldRuns with 365-day window', async () => {
+    service.pruneOldRuns.mockResolvedValue(7);
+    const result = await cron.pruneOldRuns();
+    expect(service.pruneOldRuns).toHaveBeenCalledWith(365);
+    expect(result).toEqual({ pruned: 7 });
+  });
+
+  it('matches the documented retention constant (1 year)', () => {
+    expect(PdpaBackfillRetentionCron.RETENTION_DAYS).toBe(365);
+  });
+
+  it('swallows errors so the scheduler never crashes (still returns)', async () => {
+    service.pruneOldRuns.mockRejectedValue(new Error('db gone'));
+    const result = await cron.pruneOldRuns();
+    expect(result).toEqual({ pruned: 0 });
+  });
+});

--- a/apps/api/src/modules/pdpa/pdpa-backfill-retention.cron.ts
+++ b/apps/api/src/modules/pdpa/pdpa-backfill-retention.cron.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PdpaEncryptionService } from './pdpa-encryption.service';
+
+/**
+ * Phase 3 SP4 — DEEP review W2 — PdpaBackfillRun retention cron.
+ *
+ * Hard-deletes PdpaBackfillRun rows older than 1 year. Matches AuditLog
+ * + OffsiteBackupRun retention policy and the model's "append-only event
+ * log" exception in database.md.
+ *
+ * The schema-level comment on `PdpaBackfillRun` promises a retention job —
+ * this is that job. Without it, the table grows unbounded (~1 row per
+ * backfill, but historical UUIDs of triggering OWNER users linger after
+ * those users are soft-deleted → PDPA risk).
+ *
+ * Schedule: 02:00 BKK daily — sits between AuditRetentionCron
+ * (Sun 03:00) and OffsiteBackupCron (03:30), no scheduler contention.
+ * Same time as OffsiteBackupRetentionCron — both are tiny deletes so
+ * stacking is fine.
+ */
+@Injectable()
+export class PdpaBackfillRetentionCron {
+  private readonly logger = new Logger(PdpaBackfillRetentionCron.name);
+  static readonly RETENTION_DAYS = 365;
+
+  constructor(private readonly service: PdpaEncryptionService) {}
+
+  @Cron('0 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async pruneOldRuns(): Promise<{ pruned: number }> {
+    try {
+      const pruned = await this.service.pruneOldRuns(
+        PdpaBackfillRetentionCron.RETENTION_DAYS,
+      );
+      if (pruned > 0) {
+        Sentry.captureMessage(`pdpa-backfill retention pruned ${pruned} row(s)`, {
+          level: 'info',
+          tags: { kind: 'cron-job', cron: 'pdpa-backfill-retention' },
+          extra: { pruned, retentionDays: PdpaBackfillRetentionCron.RETENTION_DAYS },
+        });
+      }
+      return { pruned };
+    } catch (err) {
+      this.logger.error(
+        `pdpa-backfill retention failed: ${err instanceof Error ? err.message : err}`,
+      );
+      Sentry.captureException(err, {
+        tags: { kind: 'cron-job', cron: 'pdpa-backfill-retention' },
+      });
+      return { pruned: 0 };
+    }
+  }
+}

--- a/apps/api/src/modules/pdpa/pdpa-encryption.controller.spec.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.controller.spec.ts
@@ -1,0 +1,86 @@
+import { PdpaEncryptionController } from './pdpa-encryption.controller';
+import type { PdpaEncryptionService } from './pdpa-encryption.service';
+import type { AuditService } from '../audit/audit.service';
+
+describe('PdpaEncryptionController', () => {
+  let svc: jest.Mocked<PdpaEncryptionService>;
+  let audit: jest.Mocked<AuditService>;
+  let controller: PdpaEncryptionController;
+
+  beforeEach(() => {
+    svc = {
+      getStatus: jest.fn(),
+      setStrictMode: jest.fn(),
+      runBackfill: jest.fn(),
+      getRun: jest.fn(),
+      getRecentRuns: jest.fn(),
+    } as unknown as jest.Mocked<PdpaEncryptionService>;
+    audit = { log: jest.fn().mockResolvedValue(undefined) } as unknown as jest.Mocked<AuditService>;
+    controller = new PdpaEncryptionController(svc, audit);
+  });
+
+  describe('setStrictMode', () => {
+    it('writes PDPA_STRICT_MODE_TOGGLED audit log with old/new value', async () => {
+      svc.getStatus.mockResolvedValue({
+        strictMode: false,
+        totalCustomers: 10,
+        encryptedCount: 10,
+        plaintextCount: 0,
+        readyForStrictMode: true,
+        encryptionKeyConfigured: true,
+        hashSaltConfigured: true,
+      });
+      svc.setStrictMode.mockResolvedValue({ strictMode: true });
+
+      const result = await controller.setStrictMode({ enabled: true }, { id: 'u1', role: 'OWNER' });
+      expect(result).toEqual({ strictMode: true });
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'u1',
+          action: 'PDPA_STRICT_MODE_TOGGLED',
+          entity: 'system_config',
+          entityId: 'PDPA_STRICT_MODE',
+          oldValue: { strictMode: false },
+          newValue: { strictMode: true },
+        }),
+      );
+    });
+  });
+
+  describe('runBackfill', () => {
+    it('writes PDPA_BACKFILL_RUN audit log with run metrics', async () => {
+      svc.runBackfill.mockResolvedValue({
+        id: 'run-1',
+        status: 'COMPLETED',
+        totalRecords: 10,
+        processedRecords: 10,
+        skippedRecords: 0,
+        durationMs: 1234,
+      });
+      const result = await controller.runBackfill({ id: 'u1', role: 'OWNER' });
+      expect(result.id).toBe('run-1');
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'u1',
+          action: 'PDPA_BACKFILL_RUN',
+          entity: 'pdpa_backfill_run',
+          entityId: 'run-1',
+        }),
+      );
+    });
+  });
+
+  describe('getRecentRuns', () => {
+    it('caps limit at 30 and defaults to 7', async () => {
+      svc.getRecentRuns.mockResolvedValue([]);
+      await controller.getRecentRuns(undefined);
+      expect(svc.getRecentRuns).toHaveBeenCalledWith(7);
+      svc.getRecentRuns.mockClear();
+      await controller.getRecentRuns('100');
+      expect(svc.getRecentRuns).toHaveBeenCalledWith(7); // 100 > 30 → falls back to 7
+      svc.getRecentRuns.mockClear();
+      await controller.getRecentRuns('15');
+      expect(svc.getRecentRuns).toHaveBeenCalledWith(15);
+    });
+  });
+});

--- a/apps/api/src/modules/pdpa/pdpa-encryption.controller.spec.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.controller.spec.ts
@@ -1,11 +1,19 @@
 import { PdpaEncryptionController } from './pdpa-encryption.controller';
 import type { PdpaEncryptionService } from './pdpa-encryption.service';
 import type { AuditService } from '../audit/audit.service';
+import type { Request } from 'express';
 
 describe('PdpaEncryptionController', () => {
   let svc: jest.Mocked<PdpaEncryptionService>;
   let audit: jest.Mocked<AuditService>;
   let controller: PdpaEncryptionController;
+
+  function makeReq(): Request {
+    return {
+      ip: '10.1.2.3',
+      headers: { 'user-agent': 'Jest/1.0' },
+    } as unknown as Request;
+  }
 
   beforeEach(() => {
     svc = {
@@ -20,19 +28,24 @@ describe('PdpaEncryptionController', () => {
   });
 
   describe('setStrictMode', () => {
-    it('writes PDPA_STRICT_MODE_TOGGLED audit log with old/new value', async () => {
+    it('writes PDPA_STRICT_MODE_TOGGLED audit log with old/new value + ip + userAgent (W6)', async () => {
       svc.getStatus.mockResolvedValue({
         strictMode: false,
         totalCustomers: 10,
         encryptedCount: 10,
         plaintextCount: 0,
+        plaintextByColumn: [],
         readyForStrictMode: true,
         encryptionKeyConfigured: true,
         hashSaltConfigured: true,
       });
       svc.setStrictMode.mockResolvedValue({ strictMode: true });
 
-      const result = await controller.setStrictMode({ enabled: true }, { id: 'u1', role: 'OWNER' });
+      const result = await controller.setStrictMode(
+        { enabled: true },
+        { id: 'u1', role: 'OWNER' },
+        makeReq(),
+      );
       expect(result).toEqual({ strictMode: true });
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -40,6 +53,8 @@ describe('PdpaEncryptionController', () => {
           action: 'PDPA_STRICT_MODE_TOGGLED',
           entity: 'system_config',
           entityId: 'PDPA_STRICT_MODE',
+          ipAddress: '10.1.2.3',
+          userAgent: 'Jest/1.0',
           oldValue: { strictMode: false },
           newValue: { strictMode: true },
         }),
@@ -48,7 +63,7 @@ describe('PdpaEncryptionController', () => {
   });
 
   describe('runBackfill', () => {
-    it('writes PDPA_BACKFILL_RUN audit log with run metrics', async () => {
+    it('delegates to service.runBackfill and forwards ip + userAgent (W7)', async () => {
       svc.runBackfill.mockResolvedValue({
         id: 'run-1',
         status: 'COMPLETED',
@@ -57,16 +72,20 @@ describe('PdpaEncryptionController', () => {
         skippedRecords: 0,
         durationMs: 1234,
       });
-      const result = await controller.runBackfill({ id: 'u1', role: 'OWNER' });
+      const result = await controller.runBackfill({ id: 'u1', role: 'OWNER' }, makeReq());
       expect(result.id).toBe('run-1');
-      expect(audit.log).toHaveBeenCalledWith(
+      expect(svc.runBackfill).toHaveBeenCalledWith(
         expect.objectContaining({
-          userId: 'u1',
-          action: 'PDPA_BACKFILL_RUN',
-          entity: 'pdpa_backfill_run',
-          entityId: 'run-1',
+          triggeredBy: 'manual',
+          triggeredByUserId: 'u1',
+          ipAddress: '10.1.2.3',
+          userAgent: 'Jest/1.0',
         }),
       );
+      // Controller no longer writes its own audit log — the service does
+      // (so the CLI path also gets one). Test confirms the controller is
+      // NOT double-writing.
+      expect(audit.log).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/pdpa/pdpa-encryption.controller.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.controller.ts
@@ -1,0 +1,100 @@
+import { Body, Controller, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PdpaEncryptionService } from './pdpa-encryption.service';
+import { SetStrictModeDto } from './dto/strict-mode.dto';
+import { AuditService } from '../audit/audit.service';
+
+interface AuthUser {
+  id: string;
+  role: 'OWNER' | 'BRANCH_MANAGER' | 'FINANCE_MANAGER' | 'ACCOUNTANT' | 'SALES' | string;
+}
+
+/**
+ * Phase 3 SP4 — PDPA PII encryption admin endpoints.
+ *
+ *   GET  /pdpa/status                 — strict-mode flag + plaintext/encrypted counts
+ *                                       (OWNER/FM/ACCOUNTANT — needed for compliance dashboard)
+ *   PUT  /pdpa/strict-mode            — flip strict mode (OWNER only)
+ *   POST /pdpa/backfill               — run backfill once (OWNER only; advisory-locked)
+ *   GET  /pdpa/backfill/:id           — poll a specific run's progress
+ *   GET  /pdpa/backfill-runs?limit=7  — recent run history
+ *
+ * Mounted at /pdpa-encryption to avoid colliding with the existing PDPA
+ * consent/DSAR controller which already owns /pdpa/consent, /pdpa/dsar, etc.
+ */
+@ApiTags('PDPA Encryption')
+@ApiBearerAuth('JWT')
+@Controller('pdpa-encryption')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class PdpaEncryptionController {
+  constructor(
+    private readonly service: PdpaEncryptionService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @Get('status')
+  @ApiOperation({ summary: 'PDPA strict-mode + backfill status' })
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  async getStatus() {
+    return this.service.getStatus();
+  }
+
+  @Put('strict-mode')
+  @ApiOperation({ summary: 'Toggle PDPA strict mode (OWNER only)' })
+  @Roles('OWNER')
+  async setStrictMode(@Body() dto: SetStrictModeDto, @CurrentUser() user: AuthUser) {
+    const before = await this.service.getStatus();
+    const result = await this.service.setStrictMode(dto.enabled);
+    await this.audit.log({
+      userId: user?.id,
+      action: 'PDPA_STRICT_MODE_TOGGLED',
+      entity: 'system_config',
+      entityId: 'PDPA_STRICT_MODE',
+      oldValue: { strictMode: before.strictMode },
+      newValue: { strictMode: result.strictMode },
+    });
+    return result;
+  }
+
+  @Post('backfill')
+  @ApiOperation({ summary: 'Run PDPA PII backfill (OWNER only)' })
+  @Roles('OWNER')
+  async runBackfill(@CurrentUser() user: AuthUser) {
+    const result = await this.service.runBackfill({
+      triggeredBy: 'manual',
+      triggeredByUserId: user?.id ?? null,
+    });
+    await this.audit.log({
+      userId: user?.id,
+      action: 'PDPA_BACKFILL_RUN',
+      entity: 'pdpa_backfill_run',
+      entityId: result.id,
+      newValue: {
+        status: result.status,
+        totalRecords: result.totalRecords,
+        processedRecords: result.processedRecords,
+        skippedRecords: result.skippedRecords,
+        durationMs: result.durationMs,
+      },
+    });
+    return result;
+  }
+
+  @Get('backfill/:id')
+  @Roles('OWNER')
+  async getRun(@Param('id') id: string) {
+    return this.service.getRun(id);
+  }
+
+  @Get('backfill-runs')
+  @Roles('OWNER')
+  async getRecentRuns(@Query('limit') limitRaw?: string) {
+    const parsed = limitRaw ? Number.parseInt(limitRaw, 10) : 7;
+    const limit = Number.isFinite(parsed) && parsed > 0 && parsed <= 30 ? parsed : 7;
+    return this.service.getRecentRuns(limit);
+  }
+}

--- a/apps/api/src/modules/pdpa/pdpa-encryption.controller.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -46,14 +57,21 @@ export class PdpaEncryptionController {
   @Put('strict-mode')
   @ApiOperation({ summary: 'Toggle PDPA strict mode (OWNER only)' })
   @Roles('OWNER')
-  async setStrictMode(@Body() dto: SetStrictModeDto, @CurrentUser() user: AuthUser) {
+  async setStrictMode(
+    @Body() dto: SetStrictModeDto,
+    @CurrentUser() user: AuthUser,
+    @Req() req: Request,
+  ) {
     const before = await this.service.getStatus();
     const result = await this.service.setStrictMode(dto.enabled);
+    // W6 — capture request IP + UA so PDPA audit trail is forensics-grade.
     await this.audit.log({
       userId: user?.id,
       action: 'PDPA_STRICT_MODE_TOGGLED',
       entity: 'system_config',
       entityId: 'PDPA_STRICT_MODE',
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'],
       oldValue: { strictMode: before.strictMode },
       newValue: { strictMode: result.strictMode },
     });
@@ -63,25 +81,16 @@ export class PdpaEncryptionController {
   @Post('backfill')
   @ApiOperation({ summary: 'Run PDPA PII backfill (OWNER only)' })
   @Roles('OWNER')
-  async runBackfill(@CurrentUser() user: AuthUser) {
-    const result = await this.service.runBackfill({
+  async runBackfill(@CurrentUser() user: AuthUser, @Req() req: Request) {
+    // W7 — the service writes the `PDPA_BACKFILL_RUN` AuditLog itself so
+    // the CLI invocation path also gets one entry. We forward IP + UA so
+    // the audit row records who initiated from where.
+    return this.service.runBackfill({
       triggeredBy: 'manual',
       triggeredByUserId: user?.id ?? null,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'],
     });
-    await this.audit.log({
-      userId: user?.id,
-      action: 'PDPA_BACKFILL_RUN',
-      entity: 'pdpa_backfill_run',
-      entityId: result.id,
-      newValue: {
-        status: result.status,
-        totalRecords: result.totalRecords,
-        processedRecords: result.processedRecords,
-        skippedRecords: result.skippedRecords,
-        durationMs: result.durationMs,
-      },
-    });
-    return result;
   }
 
   @Get('backfill/:id')

--- a/apps/api/src/modules/pdpa/pdpa-encryption.service.spec.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.service.spec.ts
@@ -1,0 +1,261 @@
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { PdpaEncryptionService } from './pdpa-encryption.service';
+import { CustomerPiiService } from '../customers/customer-pii.service';
+import type { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+}));
+
+const TEST_KEY = 'a'.repeat(64);
+const TEST_SALT = 'b'.repeat(48);
+
+interface FakeRow {
+  id: string;
+  nationalId: string | null;
+  nationalIdEncrypted: string | null;
+  nationalIdHash: string | null;
+  phone: string | null;
+  phoneEncrypted: string | null;
+  phoneHash: string | null;
+  references?: unknown;
+  referencesEncrypted?: unknown;
+  [k: string]: unknown;
+}
+
+function makePrismaMock(opts: {
+  rows?: FakeRow[];
+  totalCustomers?: number;
+  plaintextCount?: number;
+  lockAcquired?: boolean;
+  systemConfigValue?: string | null;
+}) {
+  let rows = (opts.rows ?? []).map((r) => ({ ...r }));
+  const runRows: Array<Record<string, unknown>> = [];
+
+  return {
+    customer: {
+      count: jest.fn().mockImplementation((args: { where?: { AND?: unknown } } = {}) => {
+        // The plaintext-count query has the AND filter; the all-customers
+        // query doesn't. Use that to differentiate.
+        if (args.where && (args.where as { AND?: unknown }).AND) {
+          return Promise.resolve(opts.plaintextCount ?? rows.filter((r) => r.nationalIdEncrypted === null && r.nationalId).length);
+        }
+        return Promise.resolve(opts.totalCustomers ?? rows.length);
+      }),
+      findMany: jest.fn().mockImplementation((args: { cursor?: { id: string }; take?: number } = {}) => {
+        const sorted = rows
+          .filter((r) => r.nationalIdEncrypted === null && r.nationalId)
+          .sort((a, b) => a.id.localeCompare(b.id));
+        const start = args.cursor ? sorted.findIndex((r) => r.id === args.cursor!.id) + 1 : 0;
+        return Promise.resolve(sorted.slice(start, start + (args.take ?? 100)));
+      }),
+      update: jest.fn().mockImplementation((args: { where: { id: string }; data: Record<string, unknown> }) => {
+        const row = rows.find((r) => r.id === args.where.id);
+        if (row) Object.assign(row, args.data);
+        return Promise.resolve(row);
+      }),
+    },
+    pdpaBackfillRun: {
+      create: jest.fn().mockImplementation((args: { data: Record<string, unknown> }) => {
+        const row = { id: `run-${runRows.length + 1}`, ...args.data };
+        runRows.push(row);
+        return Promise.resolve(row);
+      }),
+      update: jest.fn().mockImplementation((args: { where: { id: string }; data: Record<string, unknown> }) => {
+        const row = runRows.find((r) => r.id === args.where.id);
+        if (row) Object.assign(row, args.data);
+        return Promise.resolve(row);
+      }),
+      findUnique: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    systemConfig: {
+      findFirst: jest.fn().mockResolvedValue(
+        opts.systemConfigValue !== undefined ? { value: opts.systemConfigValue } : null,
+      ),
+      upsert: jest.fn().mockResolvedValue({}),
+    },
+    $queryRaw: jest.fn().mockImplementation((strings: TemplateStringsArray | string) => {
+      const sql = Array.isArray(strings) ? (strings as TemplateStringsArray).join('?') : String(strings);
+      if (sql.includes('pg_try_advisory_lock')) {
+        return Promise.resolve([{ acquired: opts.lockAcquired ?? true }]);
+      }
+      if (sql.includes('pg_advisory_unlock')) {
+        return Promise.resolve([{ pg_advisory_unlock: true }]);
+      }
+      return Promise.resolve([]);
+    }),
+    // expose for assertion
+    _rows: rows,
+    _runRows: runRows,
+  } as unknown as PrismaService & { _rows: FakeRow[]; _runRows: Array<Record<string, unknown>> };
+}
+
+function makeService(prisma: PrismaService) {
+  const piiService = new CustomerPiiService(prisma);
+  const svc = new PdpaEncryptionService(prisma, piiService);
+  return { svc, piiService };
+}
+
+describe('PdpaEncryptionService', () => {
+  let origKey: string | undefined;
+  let origSalt: string | undefined;
+
+  beforeEach(() => {
+    origKey = process.env.PII_ENCRYPTION_KEY;
+    origSalt = process.env.PII_HASH_SALT;
+    process.env.PII_ENCRYPTION_KEY = TEST_KEY;
+    process.env.PII_HASH_SALT = TEST_SALT;
+    delete process.env.PDPA_STRICT_MODE;
+  });
+
+  afterEach(() => {
+    if (origKey === undefined) delete process.env.PII_ENCRYPTION_KEY;
+    else process.env.PII_ENCRYPTION_KEY = origKey;
+    if (origSalt === undefined) delete process.env.PII_HASH_SALT;
+    else process.env.PII_HASH_SALT = origSalt;
+  });
+
+  describe('getStatus', () => {
+    it('reports totalCustomers, encryptedCount, plaintextCount, readyForStrictMode', async () => {
+      const prisma = makePrismaMock({ totalCustomers: 100, plaintextCount: 5 });
+      const { svc } = makeService(prisma);
+      const status = await svc.getStatus();
+      expect(status.totalCustomers).toBe(100);
+      expect(status.plaintextCount).toBe(5);
+      expect(status.encryptedCount).toBe(95);
+      expect(status.readyForStrictMode).toBe(false);
+      expect(status.encryptionKeyConfigured).toBe(true);
+      expect(status.hashSaltConfigured).toBe(true);
+    });
+
+    it('readyForStrictMode true when plaintextCount is 0', async () => {
+      const prisma = makePrismaMock({ totalCustomers: 100, plaintextCount: 0 });
+      const { svc } = makeService(prisma);
+      const status = await svc.getStatus();
+      expect(status.readyForStrictMode).toBe(true);
+    });
+  });
+
+  describe('setStrictMode', () => {
+    it('refuses to enable when plaintext rows still exist', async () => {
+      const prisma = makePrismaMock({ totalCustomers: 100, plaintextCount: 3 });
+      const { svc } = makeService(prisma);
+      await expect(svc.setStrictMode(true)).rejects.toThrow(BadRequestException);
+    });
+
+    it('refuses to enable when PII_ENCRYPTION_KEY missing', async () => {
+      delete process.env.PII_ENCRYPTION_KEY;
+      const prisma = makePrismaMock({ totalCustomers: 100, plaintextCount: 0 });
+      const { svc } = makeService(prisma);
+      await expect(svc.setStrictMode(true)).rejects.toThrow(BadRequestException);
+    });
+
+    it('enables when all rows are encrypted', async () => {
+      const prisma = makePrismaMock({ totalCustomers: 50, plaintextCount: 0 });
+      const { svc } = makeService(prisma);
+      await expect(svc.setStrictMode(true)).resolves.toEqual({ strictMode: true });
+    });
+
+    it('disables without preflight checks', async () => {
+      const prisma = makePrismaMock({ totalCustomers: 100, plaintextCount: 99 });
+      const { svc } = makeService(prisma);
+      await expect(svc.setStrictMode(false)).resolves.toEqual({ strictMode: false });
+    });
+  });
+
+  describe('runBackfill', () => {
+    it('throws ConflictException when advisory lock already held', async () => {
+      const prisma = makePrismaMock({ lockAcquired: false });
+      const { svc } = makeService(prisma);
+      await expect(svc.runBackfill({ triggeredBy: 'cli' })).rejects.toThrow(ConflictException);
+    });
+
+    it('throws BadRequestException when key/salt missing', async () => {
+      delete process.env.PII_ENCRYPTION_KEY;
+      const prisma = makePrismaMock({});
+      const { svc } = makeService(prisma);
+      await expect(svc.runBackfill({ triggeredBy: 'cli' })).rejects.toThrow(BadRequestException);
+    });
+
+    it('encrypts plaintext rows and reports processed count', async () => {
+      const rows: FakeRow[] = [
+        {
+          id: 'c1',
+          nationalId: '1234567890123',
+          nationalIdEncrypted: null,
+          nationalIdHash: null,
+          phone: '0812345678',
+          phoneEncrypted: null,
+          phoneHash: null,
+        },
+        {
+          id: 'c2',
+          nationalId: '9876543210987',
+          nationalIdEncrypted: null,
+          nationalIdHash: null,
+          phone: '0898765432',
+          phoneEncrypted: null,
+          phoneHash: null,
+        },
+      ];
+      const prisma = makePrismaMock({ rows, totalCustomers: 2 });
+      const { svc } = makeService(prisma);
+      const result = await svc.runBackfill({ triggeredBy: 'cli', batchSize: 50 });
+      expect(result.status).toBe('COMPLETED');
+      expect(result.processedRecords).toBe(2);
+      expect(result.skippedRecords).toBe(0);
+      // Sanity-check the rows got written
+      const c1 = (prisma as unknown as { _rows: FakeRow[] })._rows.find((r) => r.id === 'c1')!;
+      expect(c1.nationalIdEncrypted).toMatch(/^[a-f0-9]{32}:/);
+      expect(c1.phoneHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('is idempotent — already-encrypted rows are skipped', async () => {
+      const rows: FakeRow[] = [
+        {
+          id: 'c1',
+          nationalId: '1234567890123',
+          nationalIdEncrypted: 'abcdef0123456789abcdef0123456789:dead',
+          nationalIdHash: 'a'.repeat(64),
+          phone: '0812345678',
+          phoneEncrypted: 'abcdef0123456789abcdef0123456789:beef',
+          phoneHash: 'b'.repeat(64),
+        },
+      ];
+      // findMany filter requires nationalIdEncrypted === null — the mock
+      // returns 0 rows for already-encrypted, so the loop simply exits.
+      const prisma = makePrismaMock({ rows, totalCustomers: 1, plaintextCount: 0 });
+      const { svc } = makeService(prisma);
+      const result = await svc.runBackfill({ triggeredBy: 'cli' });
+      expect(result.status).toBe('COMPLETED');
+      expect(result.processedRecords).toBe(0);
+    });
+
+    it('emits per-batch progress callbacks', async () => {
+      const rows: FakeRow[] = Array.from({ length: 5 }, (_, i) => ({
+        id: `c${i}`,
+        nationalId: '1234567890123',
+        nationalIdEncrypted: null,
+        nationalIdHash: null,
+        phone: '0812345678',
+        phoneEncrypted: null,
+        phoneHash: null,
+      }));
+      const prisma = makePrismaMock({ rows, totalCustomers: 5 });
+      const { svc } = makeService(prisma);
+      const progress: Array<{ processed: number; total: number }> = [];
+      const result = await svc.runBackfill({
+        triggeredBy: 'cli',
+        batchSize: 2,
+        onProgress: (p) => progress.push({ processed: p.processed, total: p.total }),
+      });
+      expect(result.status).toBe('COMPLETED');
+      expect(result.processedRecords).toBe(5);
+      // 5 rows / 2 per batch = 3 batches → 3 progress events
+      expect(progress.length).toBe(3);
+      expect(progress[progress.length - 1].processed).toBe(5);
+    });
+  });
+});

--- a/apps/api/src/modules/pdpa/pdpa-encryption.service.spec.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.service.spec.ts
@@ -2,9 +2,11 @@ import { BadRequestException, ConflictException } from '@nestjs/common';
 import { PdpaEncryptionService } from './pdpa-encryption.service';
 import { CustomerPiiService } from '../customers/customer-pii.service';
 import type { PrismaService } from '../../prisma/prisma.service';
+import type { AuditService } from '../audit/audit.service';
 
 jest.mock('@sentry/nestjs', () => ({
   captureException: jest.fn(),
+  captureMessage: jest.fn(),
 }));
 
 const TEST_KEY = 'a'.repeat(64);
@@ -18,6 +20,22 @@ interface FakeRow {
   phone: string | null;
   phoneEncrypted: string | null;
   phoneHash: string | null;
+  phoneSecondary?: string | null;
+  phoneSecondaryEncrypted?: string | null;
+  email?: string | null;
+  emailEncrypted?: string | null;
+  addressIdCard?: string | null;
+  addressIdCardEncrypted?: string | null;
+  addressCurrent?: string | null;
+  addressCurrentEncrypted?: string | null;
+  addressWork?: string | null;
+  addressWorkEncrypted?: string | null;
+  guardianNationalId?: string | null;
+  guardianNationalIdEncrypted?: string | null;
+  guardianPhone?: string | null;
+  guardianPhoneEncrypted?: string | null;
+  guardianAddress?: string | null;
+  guardianAddressEncrypted?: string | null;
   references?: unknown;
   referencesEncrypted?: unknown;
   [k: string]: unknown;
@@ -27,23 +45,68 @@ function makePrismaMock(opts: {
   rows?: FakeRow[];
   totalCustomers?: number;
   plaintextCount?: number;
+  /** Per-column count overrides for getPlaintextCountsByColumn. Keyed by plaintext column name. */
+  perColumnCounts?: Record<string, number>;
   lockAcquired?: boolean;
   systemConfigValue?: string | null;
+  /** Concurrent-writer count for W9 race tests — number of new
+   *  plaintext rows that "appear" after the main loop's first pass. */
+  raceRemaining?: number;
 }) {
   let rows = (opts.rows ?? []).map((r) => ({ ...r }));
   const runRows: Array<Record<string, unknown>> = [];
+  let countCallSinceFindMany = 0;
+  // For W9 retry: after the main loop finishes (lots of findMany calls),
+  // the first subsequent count() returns raceRemaining > 0 to simulate
+  // concurrent writers. Subsequent count() calls return 0 (or
+  // continueRaceForever).
+  let racePollIdx = 0;
+
+  function isPlaintextWhere(where: unknown): boolean {
+    // Heuristic: any where with OR conditions is a "plaintext count" query.
+    return Boolean(where && (where as { OR?: unknown }).OR);
+  }
+  function isPerColumnWhere(where: unknown): { column: string } | null {
+    // Per-column counts use AND: [{ <plain>: { not: '' } }, { <plain>: { not: null } }, { <enc>: null }].
+    if (!where || !(where as { AND?: unknown }).AND) return null;
+    const and = (where as { AND: Array<Record<string, unknown>> }).AND;
+    const plainKey = Object.keys(and[0] ?? {})[0];
+    return plainKey ? { column: plainKey } : null;
+  }
 
   return {
     customer: {
-      count: jest.fn().mockImplementation((args: { where?: { AND?: unknown } } = {}) => {
-        // The plaintext-count query has the AND filter; the all-customers
-        // query doesn't. Use that to differentiate.
-        if (args.where && (args.where as { AND?: unknown }).AND) {
-          return Promise.resolve(opts.plaintextCount ?? rows.filter((r) => r.nationalIdEncrypted === null && r.nationalId).length);
+      count: jest.fn().mockImplementation((args: { where?: unknown } = {}) => {
+        const where = args.where;
+        if (!where || (Object.keys(where).length === 1 && (where as { deletedAt?: unknown }).deletedAt !== undefined)) {
+          return Promise.resolve(opts.totalCustomers ?? rows.length);
+        }
+        const perCol = isPerColumnWhere(where);
+        if (perCol) {
+          if (opts.perColumnCounts && opts.perColumnCounts[perCol.column] !== undefined) {
+            return Promise.resolve(opts.perColumnCounts[perCol.column]);
+          }
+          if (perCol.column === 'nationalId') {
+            return Promise.resolve(rows.filter((r) => r.nationalIdEncrypted === null && r.nationalId).length);
+          }
+          return Promise.resolve(0);
+        }
+        if (isPlaintextWhere(where)) {
+          // W9: after main loop iterations, simulate race by returning > 0 once.
+          if (opts.raceRemaining !== undefined && countCallSinceFindMany > 0) {
+            if (racePollIdx === 0) {
+              racePollIdx++;
+              return Promise.resolve(opts.raceRemaining);
+            }
+            return Promise.resolve(0);
+          }
+          if (opts.plaintextCount !== undefined) return Promise.resolve(opts.plaintextCount);
+          return Promise.resolve(rows.filter((r) => r.nationalIdEncrypted === null && r.nationalId).length);
         }
         return Promise.resolve(opts.totalCustomers ?? rows.length);
       }),
       findMany: jest.fn().mockImplementation((args: { cursor?: { id: string }; take?: number } = {}) => {
+        countCallSinceFindMany++;
         const sorted = rows
           .filter((r) => r.nationalIdEncrypted === null && r.nationalId)
           .sort((a, b) => a.id.localeCompare(b.id));
@@ -69,6 +132,7 @@ function makePrismaMock(opts: {
       }),
       findUnique: jest.fn().mockResolvedValue(null),
       findMany: jest.fn().mockResolvedValue([]),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
     },
     systemConfig: {
       findFirst: jest.fn().mockResolvedValue(
@@ -76,6 +140,15 @@ function makePrismaMock(opts: {
       ),
       upsert: jest.fn().mockResolvedValue({}),
     },
+    user: {
+      findFirst: jest.fn().mockResolvedValue({ id: 'system-user-uuid' }),
+    },
+    $transaction: jest.fn().mockImplementation(async (queries: Array<Promise<unknown>>) => {
+      // Sequentially resolve the array of pre-issued promises (Prisma's
+      // batch transaction signature). This mirrors the real behaviour
+      // closely enough to verify atomicity wiring.
+      return Promise.all(queries);
+    }),
     $queryRaw: jest.fn().mockImplementation((strings: TemplateStringsArray | string) => {
       const sql = Array.isArray(strings) ? (strings as TemplateStringsArray).join('?') : String(strings);
       if (sql.includes('pg_try_advisory_lock')) {
@@ -94,8 +167,9 @@ function makePrismaMock(opts: {
 
 function makeService(prisma: PrismaService) {
   const piiService = new CustomerPiiService(prisma);
-  const svc = new PdpaEncryptionService(prisma, piiService);
-  return { svc, piiService };
+  const audit = { log: jest.fn().mockResolvedValue(undefined) } as unknown as AuditService;
+  const svc = new PdpaEncryptionService(prisma, piiService, audit);
+  return { svc, piiService, audit };
 }
 
 describe('PdpaEncryptionService', () => {
@@ -118,8 +192,12 @@ describe('PdpaEncryptionService', () => {
   });
 
   describe('getStatus', () => {
-    it('reports totalCustomers, encryptedCount, plaintextCount, readyForStrictMode', async () => {
-      const prisma = makePrismaMock({ totalCustomers: 100, plaintextCount: 5 });
+    it('reports totalCustomers, encryptedCount, plaintextCount, readyForStrictMode + per-column breakdown (W3)', async () => {
+      const prisma = makePrismaMock({
+        totalCustomers: 100,
+        plaintextCount: 5,
+        perColumnCounts: { nationalId: 3, phone: 4, email: 2 },
+      });
       const { svc } = makeService(prisma);
       const status = await svc.getStatus();
       expect(status.totalCustomers).toBe(100);
@@ -128,6 +206,12 @@ describe('PdpaEncryptionService', () => {
       expect(status.readyForStrictMode).toBe(false);
       expect(status.encryptionKeyConfigured).toBe(true);
       expect(status.hashSaltConfigured).toBe(true);
+      // Per-column breakdown should include every PII_COLUMN.
+      expect(status.plaintextByColumn.length).toBe(10);
+      const byCol = Object.fromEntries(status.plaintextByColumn.map((c) => [c.column, c.plaintextCount]));
+      expect(byCol.nationalId).toBe(3);
+      expect(byCol.phone).toBe(4);
+      expect(byCol.email).toBe(2);
     });
 
     it('readyForStrictMode true when plaintextCount is 0', async () => {
@@ -139,10 +223,16 @@ describe('PdpaEncryptionService', () => {
   });
 
   describe('setStrictMode', () => {
-    it('refuses to enable when plaintext rows still exist', async () => {
-      const prisma = makePrismaMock({ totalCustomers: 100, plaintextCount: 3 });
+    it('refuses to enable when plaintext rows still exist on ANY PII column (W4)', async () => {
+      const prisma = makePrismaMock({
+        totalCustomers: 100,
+        plaintextCount: 3,
+        perColumnCounts: { phone: 2, email: 1 },
+      });
       const { svc } = makeService(prisma);
       await expect(svc.setStrictMode(true)).rejects.toThrow(BadRequestException);
+      // Error message should name the offending columns.
+      await expect(svc.setStrictMode(true)).rejects.toThrow(/phone|email/);
     });
 
     it('refuses to enable when PII_ENCRYPTION_KEY missing', async () => {
@@ -206,10 +296,29 @@ describe('PdpaEncryptionService', () => {
       expect(result.status).toBe('COMPLETED');
       expect(result.processedRecords).toBe(2);
       expect(result.skippedRecords).toBe(0);
-      // Sanity-check the rows got written
+      // Sanity-check the rows got written — GCM 3-part format.
       const c1 = (prisma as unknown as { _rows: FakeRow[] })._rows.find((r) => r.id === 'c1')!;
-      expect(c1.nationalIdEncrypted).toMatch(/^[a-f0-9]{32}:/);
+      expect(c1.nationalIdEncrypted).toMatch(/^[a-f0-9]{24}:[a-f0-9]{32}:/);
       expect(c1.phoneHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('uses $transaction to commit batch writes + counter atomically (W5)', async () => {
+      const rows: FakeRow[] = [
+        {
+          id: 'c1',
+          nationalId: '1234567890123',
+          nationalIdEncrypted: null,
+          nationalIdHash: null,
+          phone: '0812345678',
+          phoneEncrypted: null,
+          phoneHash: null,
+        },
+      ];
+      const prisma = makePrismaMock({ rows, totalCustomers: 1 });
+      const { svc } = makeService(prisma);
+      await svc.runBackfill({ triggeredBy: 'cli' });
+      // The batch tx should have been called — one $transaction per batch.
+      expect((prisma as unknown as { $transaction: jest.Mock }).$transaction).toHaveBeenCalled();
     });
 
     it('is idempotent — already-encrypted rows are skipped', async () => {
@@ -256,6 +365,64 @@ describe('PdpaEncryptionService', () => {
       // 5 rows / 2 per batch = 3 batches → 3 progress events
       expect(progress.length).toBe(3);
       expect(progress[progress.length - 1].processed).toBe(5);
+    });
+
+    it('writes PDPA_BACKFILL_RUN audit log from CLI path using SYSTEM user (W7)', async () => {
+      const prisma = makePrismaMock({ totalCustomers: 0, plaintextCount: 0 });
+      const { svc, audit } = makeService(prisma);
+      await svc.runBackfill({ triggeredBy: 'cli', triggeredByUserId: null });
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'system-user-uuid',
+          action: 'PDPA_BACKFILL_RUN',
+          entity: 'pdpa_backfill_run',
+        }),
+      );
+    });
+
+    it('writes PDPA_BACKFILL_RUN audit log from UI path using OWNER userId + ip + UA (W6, W7)', async () => {
+      const prisma = makePrismaMock({ totalCustomers: 0, plaintextCount: 0 });
+      const { svc, audit } = makeService(prisma);
+      await svc.runBackfill({
+        triggeredBy: 'manual',
+        triggeredByUserId: 'owner-uuid',
+        ipAddress: '10.1.2.3',
+        userAgent: 'TestAgent/1.0',
+      });
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'owner-uuid',
+          action: 'PDPA_BACKFILL_RUN',
+          entity: 'pdpa_backfill_run',
+          ipAddress: '10.1.2.3',
+          userAgent: 'TestAgent/1.0',
+        }),
+      );
+    });
+  });
+
+  describe('pruneOldRuns (W2 retention)', () => {
+    it('delegates to prisma.pdpaBackfillRun.deleteMany with a cutoff date', async () => {
+      const prisma = makePrismaMock({});
+      const deleteMany = (prisma as unknown as { pdpaBackfillRun: { deleteMany: jest.Mock } })
+        .pdpaBackfillRun.deleteMany;
+      deleteMany.mockResolvedValue({ count: 7 });
+      const { svc } = makeService(prisma);
+      const count = await svc.pruneOldRuns(365);
+      expect(count).toBe(7);
+      expect(deleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { startedAt: { lt: expect.any(Date) } },
+        }),
+      );
+    });
+
+    it('returns 0 for invalid retention windows', async () => {
+      const prisma = makePrismaMock({});
+      const { svc } = makeService(prisma);
+      await expect(svc.pruneOldRuns(0)).resolves.toBe(0);
+      await expect(svc.pruneOldRuns(-1)).resolves.toBe(0);
+      await expect(svc.pruneOldRuns(NaN)).resolves.toBe(0);
     });
   });
 });

--- a/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
@@ -12,6 +12,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { CustomerPiiService } from '../customers/customer-pii.service';
 import { encryptPII, isEncrypted } from '../../utils/crypto.util';
 import { hashPII, encryptReferencesJson } from '../../utils/pii.util';
+import { AuditService } from '../audit/audit.service';
 
 /**
  * Phase 3 SP4 — PDPA strict-mode + backfill orchestrator.
@@ -22,15 +23,41 @@ import { hashPII, encryptReferencesJson } from '../../utils/pii.util';
  *   1. Status — count plaintext vs encrypted customers + report strict-mode flag
  *      (powers /settings#pdpa status card).
  *   2. Toggle — flip the SystemConfig PDPA_STRICT_MODE flag (OWNER only). When
- *      flipping to STRICT, refuses if plaintext rows still exist.
+ *      flipping to STRICT, refuses if plaintext rows still exist on ANY of
+ *      the 11 PII columns (DEEP review W4 — was previously only checking
+ *      nationalId).
  *   3. Backfill — encrypt + hash any row whose *Encrypted columns are NULL.
  *      Both the CLI and the UI "Run Backfill" button route through this same
- *      runBackfill() method so the logic + audit trail (PdpaBackfillRun row)
- *      are identical.
+ *      runBackfill() method so the logic + audit trail (PdpaBackfillRun row +
+ *      AuditLog PDPA_BACKFILL_RUN) are identical.
  *
  * Hard rule: **NEVER log decrypted PII**. The only logger calls here describe
  * batch counts + error class names, never row content.
  */
+
+/**
+ * 11 Customer PII columns this service tracks. The status / strict-mode /
+ * backfill code paths all need the same column inventory — keeping it in
+ * one constant means adding a 12th PII column is a single-line change.
+ *
+ * Each tuple = [plaintext column, encrypted column].
+ *
+ * Trade-in PII (`transfer_account_*`) is intentionally NOT included —
+ * those columns are owned by `TradeInService` and have their own
+ * dual-write path.
+ */
+const PII_COLUMNS: ReadonlyArray<[plain: string, enc: string]> = [
+  ['nationalId', 'nationalIdEncrypted'],
+  ['phone', 'phoneEncrypted'],
+  ['phoneSecondary', 'phoneSecondaryEncrypted'],
+  ['email', 'emailEncrypted'],
+  ['addressIdCard', 'addressIdCardEncrypted'],
+  ['addressCurrent', 'addressCurrentEncrypted'],
+  ['addressWork', 'addressWorkEncrypted'],
+  ['guardianNationalId', 'guardianNationalIdEncrypted'],
+  ['guardianPhone', 'guardianPhoneEncrypted'],
+  ['guardianAddress', 'guardianAddressEncrypted'],
+];
 
 export interface RunBackfillOptions {
   triggeredBy: 'cli' | 'manual';
@@ -41,6 +68,9 @@ export interface RunBackfillOptions {
   /** On-progress callback for the CLI — emits per-batch progress so the
    *  user sees output instead of staring at a blank terminal. */
   onProgress?: (p: BackfillProgress) => void;
+  /** Optional IP / UA for audit log enrichment (controller forwards from req). */
+  ipAddress?: string | null;
+  userAgent?: string | null;
 }
 
 export interface BackfillProgress {
@@ -52,7 +82,7 @@ export interface BackfillProgress {
 
 export interface BackfillResult {
   id: string;
-  status: 'COMPLETED' | 'FAILED';
+  status: 'COMPLETED' | 'FAILED' | 'COMPLETED_WITH_RACE';
   totalRecords: number;
   processedRecords: number;
   skippedRecords: number;
@@ -60,11 +90,20 @@ export interface BackfillResult {
   errorMessage?: string;
 }
 
+export interface PiiColumnPlaintextCount {
+  column: string;
+  plaintextCount: number;
+}
+
 export interface PdpaStatus {
   strictMode: boolean;
   totalCustomers: number;
   encryptedCount: number;
   plaintextCount: number;
+  /** Per-column breakdown — every column listed in PII_COLUMNS, value
+   *  = number of rows where `<column>` is non-empty but `<column>_encrypted`
+   *  is NULL. Used by the UI to surface which exact field is missing. */
+  plaintextByColumn: PiiColumnPlaintextCount[];
   /** Whether every existing Customer row has been backfilled. Equivalent
    *  to `plaintextCount === 0`. */
   readyForStrictMode: boolean;
@@ -83,10 +122,14 @@ export class PdpaEncryptionService {
   static readonly DEFAULT_BATCH_SIZE = 100;
   /** Truncate cap on error message column (matches OffsiteBackupRun pattern). */
   static readonly ERROR_TRUNC_CHARS = 1000;
+  /** Used by the cursor-race retry path (W9 fix). Stops at this many passes
+   *  to bound the worst-case in pathological concurrent-writer scenarios. */
+  static readonly MAX_RETRY_PASSES = 2;
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly piiService: CustomerPiiService,
+    private readonly audit: AuditService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -94,28 +137,72 @@ export class PdpaEncryptionService {
   // ---------------------------------------------------------------------------
 
   /**
+   * Per-column count of rows where the plaintext column has data but the
+   * encrypted column is still NULL.  DEEP review W3 — the previous
+   * implementation only counted `nationalId`, missing customers whose
+   * nationalId was empty but phone / email / address was populated.
+   *
+   * Returns one entry per PII column (with 0 counts for fully-encrypted
+   * columns, so the UI can render a stable table).
+   */
+  async getPlaintextCountsByColumn(): Promise<PiiColumnPlaintextCount[]> {
+    const out: PiiColumnPlaintextCount[] = [];
+    for (const [plain, enc] of PII_COLUMNS) {
+      // Each column needs its own count() — we can't compound them with
+      // OR efficiently because we want per-column visibility for the UI.
+      const count = await this.prisma.customer.count({
+        where: {
+          deletedAt: null,
+          AND: [
+            { [plain]: { not: '' } } as Prisma.CustomerWhereInput,
+            { [plain]: { not: null } } as Prisma.CustomerWhereInput,
+            { [enc]: null } as Prisma.CustomerWhereInput,
+          ],
+        },
+      });
+      out.push({ column: plain, plaintextCount: count });
+    }
+    return out;
+  }
+
+  /**
+   * Aggregate count of rows that still have ANY plaintext PII column with
+   * a missing encrypted counterpart. Powers the headline "X customers
+   * not yet encrypted" number on /settings#pdpa.
+   *
+   * One query — uses OR across all 11 columns so we don't accidentally
+   * double-count a row that has multiple unencrypted columns.
+   */
+  async getAnyPlaintextCount(): Promise<number> {
+    const orConditions: Prisma.CustomerWhereInput[] = PII_COLUMNS.map(([plain, enc]) => ({
+      AND: [
+        { [plain]: { not: '' } } as Prisma.CustomerWhereInput,
+        { [plain]: { not: null } } as Prisma.CustomerWhereInput,
+        { [enc]: null } as Prisma.CustomerWhereInput,
+      ],
+    }));
+    return this.prisma.customer.count({
+      where: {
+        deletedAt: null,
+        OR: orConditions,
+      },
+    });
+  }
+
+  /**
    * Returns the strict-mode flag + plaintext/encrypted counts. Used by the
    * /settings#pdpa header card AND by the backfill UI as the "do we need
    * to keep going?" check.
    *
-   * Counts use the simple approach: any Customer row whose nationalId is
-   * present but nationalIdEncrypted is NULL is "still plaintext". Rows
-   * where nationalId itself is empty (legacy data anomaly) are excluded —
-   * nothing to encrypt.
+   * DEEP review W3 — counts now scan ALL 11 PII columns (was previously
+   * only nationalId).
    */
   async getStatus(): Promise<PdpaStatus> {
-    const [strictMode, totalCustomers, plaintextCount] = await Promise.all([
+    const [strictMode, totalCustomers, plaintextCount, plaintextByColumn] = await Promise.all([
       this.piiService.isStrictMode(),
       this.prisma.customer.count({ where: { deletedAt: null } }),
-      this.prisma.customer.count({
-        where: {
-          deletedAt: null,
-          AND: [
-            { nationalId: { not: '' } },
-            { nationalIdEncrypted: null },
-          ],
-        },
-      }),
+      this.getAnyPlaintextCount(),
+      this.getPlaintextCountsByColumn(),
     ]);
 
     const encryptedCount = Math.max(0, totalCustomers - plaintextCount);
@@ -125,6 +212,7 @@ export class PdpaEncryptionService {
       totalCustomers,
       encryptedCount,
       plaintextCount,
+      plaintextByColumn,
       readyForStrictMode: plaintextCount === 0,
       encryptionKeyConfigured: !!process.env.PII_ENCRYPTION_KEY,
       hashSaltConfigured: !!process.env.PII_HASH_SALT,
@@ -135,6 +223,10 @@ export class PdpaEncryptionService {
    * Flip the strict-mode flag. Rejects turning STRICT on while plaintext
    * rows still exist — otherwise the very first read would 400 with
    * "ข้อมูลยังไม่ได้เข้ารหัส" for all those rows.
+   *
+   * DEEP review W4 — the rejection now considers ALL 11 PII columns
+   * (was previously only nationalId). Error message lists which columns
+   * still have plaintext so the operator can scope the backfill.
    */
   async setStrictMode(enabled: boolean): Promise<{ strictMode: boolean }> {
     if (enabled) {
@@ -145,8 +237,13 @@ export class PdpaEncryptionService {
         );
       }
       if (status.plaintextCount > 0) {
+        const offending = status.plaintextByColumn
+          .filter((c) => c.plaintextCount > 0)
+          .map((c) => `${c.column} (${c.plaintextCount})`)
+          .join(', ');
         throw new BadRequestException(
-          `ยังมีลูกค้า ${status.plaintextCount} คนที่ยังไม่ได้เข้ารหัส — กรุณารัน Backfill ก่อนเปิด strict mode`,
+          `ยังมีลูกค้าที่ยังไม่ได้เข้ารหัส รวม ${status.plaintextCount} แถว ` +
+            `— คอลัมน์ที่ยังเหลือ: ${offending} — กรุณารัน Backfill ก่อนเปิด strict mode`,
         );
       }
     }
@@ -188,13 +285,17 @@ export class PdpaEncryptionService {
    *
    * Idempotent: skips rows where every PII field already has a non-null
    * encrypted column. Safe to re-run after a partial-failure crash —
-   * progress is committed per batch, so a re-run resumes from the
-   * unencrypted tail.
+   * progress is committed per batch (atomically — DEEP review W5), so a
+   * re-run resumes from the unencrypted tail.
+   *
+   * DEEP review W7 — writes AuditLog `PDPA_BACKFILL_RUN` regardless of
+   * whether the trigger was CLI or UI. CLI runs go through the SYSTEM
+   * user (isSystemUser=true). UI runs carry the OWNER's userId.
    *
    * @throws ConflictException when another backfill run already holds the lock.
    */
   async runBackfill(opts: RunBackfillOptions): Promise<BackfillResult> {
-    const { triggeredBy, triggeredByUserId = null } = opts;
+    const { triggeredBy, triggeredByUserId = null, ipAddress = null, userAgent = null } = opts;
     const batchSize = opts.batchSize ?? PdpaEncryptionService.DEFAULT_BATCH_SIZE;
 
     if (!process.env.PII_ENCRYPTION_KEY || !process.env.PII_HASH_SALT) {
@@ -211,8 +312,14 @@ export class PdpaEncryptionService {
       throw new ConflictException('มี Backfill ทำงานอยู่ — กรุณารอจนเสร็จ');
     }
 
+    let result: BackfillResult;
     try {
-      return await this.runUnderLock({ triggeredBy, triggeredByUserId, batchSize, onProgress: opts.onProgress });
+      result = await this.runUnderLock({
+        triggeredBy,
+        triggeredByUserId,
+        batchSize,
+        onProgress: opts.onProgress,
+      });
     } finally {
       try {
         await this.prisma.$queryRaw`
@@ -221,6 +328,66 @@ export class PdpaEncryptionService {
       } catch (err) {
         this.logger.warn(`pdpa-backfill: advisory unlock failed: ${this.truncErr(err)}`);
       }
+    }
+
+    // W7 — single auditable PDPA_BACKFILL_RUN entry written from BOTH the
+    // CLI path and the UI button. The CLI uses the SYSTEM user UUID so
+    // `userId` is always a valid FK (AuditService.log returns early when
+    // userId is missing).
+    await this.writeBackfillAuditLog({
+      triggeredBy,
+      triggeredByUserId,
+      ipAddress,
+      userAgent,
+      result,
+    });
+
+    return result;
+  }
+
+  private async writeBackfillAuditLog(args: {
+    triggeredBy: 'cli' | 'manual';
+    triggeredByUserId: string | null;
+    ipAddress: string | null;
+    userAgent: string | null;
+    result: BackfillResult;
+  }): Promise<void> {
+    try {
+      // Resolve userId — for CLI, look up the SYSTEM user. For UI runs,
+      // the OWNER's userId is already on the entry.
+      let userId = args.triggeredByUserId;
+      if (!userId && args.triggeredBy === 'cli') {
+        const systemUser = await this.prisma.user.findFirst({
+          where: { isSystemUser: true },
+          select: { id: true },
+        });
+        userId = systemUser?.id ?? null;
+      }
+      if (!userId) {
+        this.logger.warn('pdpa-backfill: no userId resolved for audit log — skipping');
+        return;
+      }
+      await this.audit.log({
+        userId,
+        action: 'PDPA_BACKFILL_RUN',
+        entity: 'pdpa_backfill_run',
+        entityId: args.result.id,
+        ipAddress: args.ipAddress ?? undefined,
+        userAgent: args.userAgent ?? undefined,
+        newValue: {
+          triggeredBy: args.triggeredBy,
+          status: args.result.status,
+          totalRecords: args.result.totalRecords,
+          processedRecords: args.result.processedRecords,
+          skippedRecords: args.result.skippedRecords,
+          durationMs: args.result.durationMs,
+        },
+      });
+    } catch (err) {
+      // Audit-log failure must never crash a successful backfill.
+      this.logger.error(
+        `pdpa-backfill: failed to write audit log: ${this.truncErr(err)}`,
+      );
     }
   }
 
@@ -233,15 +400,7 @@ export class PdpaEncryptionService {
     const { triggeredBy, triggeredByUserId, batchSize, onProgress } = opts;
     const startedAt = new Date();
 
-    const totalRecords = await this.prisma.customer.count({
-      where: {
-        deletedAt: null,
-        AND: [
-          { nationalId: { not: '' } },
-          { nationalIdEncrypted: null },
-        ],
-      },
-    });
+    const totalRecords = await this.getAnyPlaintextCount();
 
     const run = await this.prisma.pdpaBackfillRun.create({
       data: {
@@ -258,61 +417,77 @@ export class PdpaEncryptionService {
     let skippedRecords = 0;
     let errorMessage: string | undefined;
     let batchNumber = 0;
+    let racy = false;
 
     try {
-      let cursorId: string | null = null;
+      // ----- First pass -----
+      const pass1 = await this.runMainLoop({
+        runId: run.id,
+        batchSize,
+        onProgress,
+        totalRecords,
+        startProcessed: 0,
+        startSkipped: 0,
+        startBatchNumber: 0,
+      });
+      processedRecords = pass1.processedRecords;
+      skippedRecords = pass1.skippedRecords;
+      batchNumber = pass1.batchNumber;
 
-      // Hard upper bound on iteration count prevents an infinite loop in
-      // the impossible-but-defensive case where the cursor stops
-      // advancing (e.g. concurrent writer adds rows faster than we
-      // process them).
-      const MAX_ITERATIONS = 10_000;
-      for (let i = 0; i < MAX_ITERATIONS; i++) {
-        const batch = (await this.prisma.customer.findMany({
-          where: {
-            deletedAt: null,
-            AND: [
-              { nationalId: { not: '' } },
-              { nationalIdEncrypted: null },
-            ],
-          },
-          take: batchSize,
-          ...(cursorId ? { skip: 1, cursor: { id: cursorId } } : {}),
-          orderBy: { id: 'asc' },
-        })) as unknown as Array<Record<string, unknown>>;
-
-        if (batch.length === 0) break;
-        cursorId = batch[batch.length - 1].id as string;
-        batchNumber++;
-
-        const { processed, skipped } = await this.processBatch(batch);
-        processedRecords += processed;
-        skippedRecords += skipped;
-
-        await this.prisma.pdpaBackfillRun.update({
-          where: { id: run.id },
-          data: { processedRecords, skippedRecords },
+      // ----- W9 cursor-race retry -----
+      // After the cursor-based loop completes, run a fresh count() to see
+      // if concurrent writers added new plaintext rows that the cursor
+      // skipped over. Retry once. If still > 0 after pass 2, mark the
+      // run COMPLETED_WITH_RACE and let ops re-run during a maintenance
+      // window.
+      const remaining = await this.getAnyPlaintextCount();
+      if (remaining > 0) {
+        this.logger.warn(
+          `pdpa-backfill: ${remaining} rows added during pass 1 — running pass 2`,
+        );
+        const pass2 = await this.runMainLoop({
+          runId: run.id,
+          batchSize,
+          onProgress,
+          totalRecords: totalRecords + remaining,
+          startProcessed: processedRecords,
+          startSkipped: skippedRecords,
+          startBatchNumber: batchNumber,
         });
+        processedRecords = pass2.processedRecords;
+        skippedRecords = pass2.skippedRecords;
+        batchNumber = pass2.batchNumber;
 
-        if (onProgress) {
-          onProgress({
-            processed: processedRecords,
-            skipped: skippedRecords,
-            total: totalRecords,
-            batchNumber,
-          });
+        const stillRemaining = await this.getAnyPlaintextCount();
+        if (stillRemaining > 0) {
+          racy = true;
+          this.logger.warn(
+            `pdpa-backfill: ${stillRemaining} rows STILL remaining after pass 2 — marking COMPLETED_WITH_RACE (re-run during maintenance window recommended)`,
+          );
         }
       }
 
       const finishedAt = new Date();
+      const status: BackfillResult['status'] = racy ? 'COMPLETED_WITH_RACE' : 'COMPLETED';
       await this.prisma.pdpaBackfillRun.update({
         where: { id: run.id },
-        data: { status: 'COMPLETED', finishedAt, processedRecords, skippedRecords },
+        data: {
+          // PdpaBackfillStatus enum only knows COMPLETED/FAILED — store
+          // COMPLETED with a note on errorMessage so the UI can surface
+          // the race condition without us migrating the enum.
+          status: 'COMPLETED',
+          finishedAt,
+          processedRecords,
+          skippedRecords,
+          errorMessage: racy
+            ? 'COMPLETED_WITH_RACE — รัน Backfill อีกครั้งใน maintenance window'
+            : null,
+        },
       });
 
       return {
         id: run.id,
-        status: 'COMPLETED',
+        status,
         totalRecords,
         processedRecords,
         skippedRecords,
@@ -345,18 +520,97 @@ export class PdpaEncryptionService {
   }
 
   /**
+   * Inner cursor-based loop. Extracted so the W9 retry path can reuse it.
+   */
+  private async runMainLoop(opts: {
+    runId: string;
+    batchSize: number;
+    onProgress?: (p: BackfillProgress) => void;
+    totalRecords: number;
+    startProcessed: number;
+    startSkipped: number;
+    startBatchNumber: number;
+  }): Promise<{ processedRecords: number; skippedRecords: number; batchNumber: number }> {
+    let processedRecords = opts.startProcessed;
+    let skippedRecords = opts.startSkipped;
+    let batchNumber = opts.startBatchNumber;
+    let cursorId: string | null = null;
+
+    const MAX_ITERATIONS = 10_000;
+    for (let i = 0; i < MAX_ITERATIONS; i++) {
+      const batch = (await this.prisma.customer.findMany({
+        where: this.plaintextWhere(),
+        take: opts.batchSize,
+        ...(cursorId ? { skip: 1, cursor: { id: cursorId } } : {}),
+        orderBy: { id: 'asc' },
+      })) as unknown as Array<Record<string, unknown>>;
+
+      if (batch.length === 0) break;
+      cursorId = batch[batch.length - 1].id as string;
+      batchNumber++;
+
+      const { processed, skipped } = await this.processBatch(batch, opts.runId, processedRecords, skippedRecords);
+      processedRecords += processed;
+      skippedRecords += skipped;
+
+      if (opts.onProgress) {
+        opts.onProgress({
+          processed: processedRecords,
+          skipped: skippedRecords,
+          total: opts.totalRecords,
+          batchNumber,
+        });
+      }
+    }
+
+    return { processedRecords, skippedRecords, batchNumber };
+  }
+
+  /**
+   * Where-clause for any-column-plaintext-and-encrypted-null rows.
+   * Shared by status counts + backfill cursor.
+   */
+  private plaintextWhere(): Prisma.CustomerWhereInput {
+    const orConditions: Prisma.CustomerWhereInput[] = PII_COLUMNS.map(([plain, enc]) => ({
+      AND: [
+        { [plain]: { not: '' } } as Prisma.CustomerWhereInput,
+        { [plain]: { not: null } } as Prisma.CustomerWhereInput,
+        { [enc]: null } as Prisma.CustomerWhereInput,
+      ],
+    }));
+    return {
+      deletedAt: null,
+      OR: orConditions,
+    };
+  }
+
+  /**
    * Encrypt + hash a single batch. Per-row failures are swallowed (logged
    * at warn level, NO PII) so one bad row doesn't halt the whole backfill.
    * Such rows show up as "skipped" in the result.
+   *
+   * DEEP review W5 — every batch wraps its row UPDATEs + the
+   * `pdpaBackfillRun.update` progress counter in a single
+   * `$transaction([...])` so a crash mid-batch never leaves the counter
+   * out of sync with the actual writes.
    */
-  private async processBatch(batch: Array<Record<string, unknown>>): Promise<{
-    processed: number;
-    skipped: number;
-  }> {
+  private async processBatch(
+    batch: Array<Record<string, unknown>>,
+    runId: string,
+    cumulativeProcessed: number,
+    cumulativeSkipped: number,
+  ): Promise<{ processed: number; skipped: number }> {
     let processed = 0;
     let skipped = 0;
     const key = process.env.PII_ENCRYPTION_KEY!;
     const salt = process.env.PII_HASH_SALT!;
+
+    // Build per-row update plans — we don't update inside the loop; we
+    // batch them into a single $transaction below so the counter +
+    // writes commit atomically.
+    type UpdatePlan = { id: string; data: Record<string, unknown> };
+    const plans: UpdatePlan[] = [];
+    const skipReasons: Array<{ id: string; reason: string }> = [];
 
     for (const row of batch) {
       try {
@@ -415,23 +669,104 @@ export class PdpaEncryptionService {
           continue;
         }
 
-        await this.prisma.customer.update({
-          where: { id: row['id'] as string },
-          data: encrypted as Prisma.CustomerUpdateInput,
-        });
-        processed++;
+        plans.push({ id: row['id'] as string, data: encrypted });
       } catch (err) {
-        // P2002 unique-constraint on nationalIdHash means there's a
-        // soft-deleted ghost with the same plaintext nationalId —
-        // leave it for the operator to reconcile manually.
+        // Build phase only catches encrypt/hash-time errors — Prisma
+        // P2002 happens in the tx below.
         skipped++;
-        this.logger.warn(
-          `pdpa-backfill: skipping customer (id-suffix=${this.idTail(row['id'])}) — ${this.errClass(err)}`,
-        );
+        skipReasons.push({ id: row['id'] as string, reason: this.errClass(err) });
       }
     }
 
+    // ----- W5 atomicity: writes + counter in one tx -----
+    if (plans.length > 0) {
+      try {
+        await this.prisma.$transaction([
+          ...plans.map((p) =>
+            this.prisma.customer.update({
+              where: { id: p.id },
+              data: p.data as Prisma.CustomerUpdateInput,
+            }),
+          ),
+          this.prisma.pdpaBackfillRun.update({
+            where: { id: runId },
+            data: {
+              processedRecords: cumulativeProcessed + plans.length,
+              skippedRecords: cumulativeSkipped + skipped,
+            },
+          }),
+        ]);
+        processed = plans.length;
+      } catch (err) {
+        // One bad row poisoning the whole batch (P2002 collision etc.) —
+        // fall back to per-row updates so the rest of the batch still
+        // commits. Each per-row failure becomes a "skipped" with a
+        // non-PII reason logged.
+        this.logger.warn(
+          `pdpa-backfill: batch tx failed (${this.errClass(err)}) — falling back to per-row writes`,
+        );
+        for (const p of plans) {
+          try {
+            await this.prisma.customer.update({
+              where: { id: p.id },
+              data: p.data as Prisma.CustomerUpdateInput,
+            });
+            processed++;
+          } catch (rowErr) {
+            skipped++;
+            this.logger.warn(
+              `pdpa-backfill: skipping customer (id-suffix=${this.idTail(p.id)}) — ${this.errClass(rowErr)}`,
+            );
+          }
+        }
+        // Counter update goes through after the salvage loop.
+        await this.prisma.pdpaBackfillRun.update({
+          where: { id: runId },
+          data: {
+            processedRecords: cumulativeProcessed + processed,
+            skippedRecords: cumulativeSkipped + skipped,
+          },
+        });
+      }
+    } else {
+      // Nothing to write — still flush the skip counter so the UI sees
+      // progress on idempotent re-runs (every row already encrypted).
+      await this.prisma.pdpaBackfillRun.update({
+        where: { id: runId },
+        data: {
+          processedRecords: cumulativeProcessed,
+          skippedRecords: cumulativeSkipped + skipped,
+        },
+      });
+    }
+
+    // Surface skip reasons in the logger AFTER the writes so a write
+    // failure doesn't drop the log line.
+    for (const r of skipReasons) {
+      this.logger.warn(
+        `pdpa-backfill: skipping customer (id-suffix=${this.idTail(r.id)}) — ${r.reason}`,
+      );
+    }
+
     return { processed, skipped };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Retention (W2 — see pdpa-backfill-retention.cron.ts)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Hard-delete PdpaBackfillRun rows older than the given retention window.
+   * Called by `PdpaBackfillRetentionCron` (daily at 02:00 BKK). Matches
+   * the existing AuditLog / OffsiteBackupRun retention patterns.
+   */
+  async pruneOldRuns(retentionDays: number): Promise<number> {
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+    const result = await this.prisma.pdpaBackfillRun.deleteMany({
+      where: { startedAt: { lt: cutoff } },
+    });
+    return result.count;
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
@@ -1,0 +1,468 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import * as os from 'os';
+import * as Sentry from '@sentry/nestjs';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CustomerPiiService } from '../customers/customer-pii.service';
+import { encryptPII, isEncrypted } from '../../utils/crypto.util';
+import { hashPII, encryptReferencesJson } from '../../utils/pii.util';
+
+/**
+ * Phase 3 SP4 — PDPA strict-mode + backfill orchestrator.
+ *
+ * Distinct from the existing PDPAService (which handles consent + DSAR
+ * lifecycle). This service owns three things:
+ *
+ *   1. Status — count plaintext vs encrypted customers + report strict-mode flag
+ *      (powers /settings#pdpa status card).
+ *   2. Toggle — flip the SystemConfig PDPA_STRICT_MODE flag (OWNER only). When
+ *      flipping to STRICT, refuses if plaintext rows still exist.
+ *   3. Backfill — encrypt + hash any row whose *Encrypted columns are NULL.
+ *      Both the CLI and the UI "Run Backfill" button route through this same
+ *      runBackfill() method so the logic + audit trail (PdpaBackfillRun row)
+ *      are identical.
+ *
+ * Hard rule: **NEVER log decrypted PII**. The only logger calls here describe
+ * batch counts + error class names, never row content.
+ */
+
+export interface RunBackfillOptions {
+  triggeredBy: 'cli' | 'manual';
+  triggeredByUserId?: string | null;
+  /** How many Customer rows per batch — 100 is a safe default that
+   *  doesn't blow the encrypt CPU budget or hold long row locks. */
+  batchSize?: number;
+  /** On-progress callback for the CLI — emits per-batch progress so the
+   *  user sees output instead of staring at a blank terminal. */
+  onProgress?: (p: BackfillProgress) => void;
+}
+
+export interface BackfillProgress {
+  processed: number;
+  skipped: number;
+  total: number;
+  batchNumber: number;
+}
+
+export interface BackfillResult {
+  id: string;
+  status: 'COMPLETED' | 'FAILED';
+  totalRecords: number;
+  processedRecords: number;
+  skippedRecords: number;
+  durationMs: number;
+  errorMessage?: string;
+}
+
+export interface PdpaStatus {
+  strictMode: boolean;
+  totalCustomers: number;
+  encryptedCount: number;
+  plaintextCount: number;
+  /** Whether every existing Customer row has been backfilled. Equivalent
+   *  to `plaintextCount === 0`. */
+  readyForStrictMode: boolean;
+  encryptionKeyConfigured: boolean;
+  hashSaltConfigured: boolean;
+}
+
+@Injectable()
+export class PdpaEncryptionService {
+  private readonly logger = new Logger(PdpaEncryptionService.name);
+  /** PostgreSQL advisory-lock key — guards against two simultaneous backfill
+   *  runs (CLI + UI button + cron all in the same minute). */
+  static readonly ADVISORY_LOCK_KEY = 'pdpa-backfill';
+  /** Default batch size. Each batch encrypts ~12 columns × 100 rows ≈ 1.2k
+   *  AES operations, comfortably under 100ms on a Cloud Run cpu. */
+  static readonly DEFAULT_BATCH_SIZE = 100;
+  /** Truncate cap on error message column (matches OffsiteBackupRun pattern). */
+  static readonly ERROR_TRUNC_CHARS = 1000;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly piiService: CustomerPiiService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Status + toggle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the strict-mode flag + plaintext/encrypted counts. Used by the
+   * /settings#pdpa header card AND by the backfill UI as the "do we need
+   * to keep going?" check.
+   *
+   * Counts use the simple approach: any Customer row whose nationalId is
+   * present but nationalIdEncrypted is NULL is "still plaintext". Rows
+   * where nationalId itself is empty (legacy data anomaly) are excluded —
+   * nothing to encrypt.
+   */
+  async getStatus(): Promise<PdpaStatus> {
+    const [strictMode, totalCustomers, plaintextCount] = await Promise.all([
+      this.piiService.isStrictMode(),
+      this.prisma.customer.count({ where: { deletedAt: null } }),
+      this.prisma.customer.count({
+        where: {
+          deletedAt: null,
+          AND: [
+            { nationalId: { not: '' } },
+            { nationalIdEncrypted: null },
+          ],
+        },
+      }),
+    ]);
+
+    const encryptedCount = Math.max(0, totalCustomers - plaintextCount);
+
+    return {
+      strictMode,
+      totalCustomers,
+      encryptedCount,
+      plaintextCount,
+      readyForStrictMode: plaintextCount === 0,
+      encryptionKeyConfigured: !!process.env.PII_ENCRYPTION_KEY,
+      hashSaltConfigured: !!process.env.PII_HASH_SALT,
+    };
+  }
+
+  /**
+   * Flip the strict-mode flag. Rejects turning STRICT on while plaintext
+   * rows still exist — otherwise the very first read would 400 with
+   * "ข้อมูลยังไม่ได้เข้ารหัส" for all those rows.
+   */
+  async setStrictMode(enabled: boolean): Promise<{ strictMode: boolean }> {
+    if (enabled) {
+      const status = await this.getStatus();
+      if (!status.encryptionKeyConfigured || !status.hashSaltConfigured) {
+        throw new BadRequestException(
+          'PII_ENCRYPTION_KEY / PII_HASH_SALT ยังไม่ได้ตั้งค่า — กรุณาตั้ง env vars ก่อนเปิด strict mode',
+        );
+      }
+      if (status.plaintextCount > 0) {
+        throw new BadRequestException(
+          `ยังมีลูกค้า ${status.plaintextCount} คนที่ยังไม่ได้เข้ารหัส — กรุณารัน Backfill ก่อนเปิด strict mode`,
+        );
+      }
+    }
+    await this.piiService.setStrictMode(enabled);
+    return { strictMode: enabled };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Backfill orchestration
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Look up a backfill run by id — used by the UI's status polling.
+   */
+  async getRun(id: string) {
+    const run = await this.prisma.pdpaBackfillRun.findUnique({
+      where: { id },
+      include: {
+        triggeredByUser: { select: { id: true, name: true } },
+      },
+    });
+    if (!run) throw new NotFoundException('ไม่พบประวัติ Backfill');
+    return run;
+  }
+
+  /** Recent runs for the history panel. */
+  async getRecentRuns(limit = 7) {
+    return this.prisma.pdpaBackfillRun.findMany({
+      take: limit,
+      orderBy: { startedAt: 'desc' },
+      include: {
+        triggeredByUser: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  /**
+   * Main backfill loop. Encrypts + hashes Customer rows in batches.
+   *
+   * Idempotent: skips rows where every PII field already has a non-null
+   * encrypted column. Safe to re-run after a partial-failure crash —
+   * progress is committed per batch, so a re-run resumes from the
+   * unencrypted tail.
+   *
+   * @throws ConflictException when another backfill run already holds the lock.
+   */
+  async runBackfill(opts: RunBackfillOptions): Promise<BackfillResult> {
+    const { triggeredBy, triggeredByUserId = null } = opts;
+    const batchSize = opts.batchSize ?? PdpaEncryptionService.DEFAULT_BATCH_SIZE;
+
+    if (!process.env.PII_ENCRYPTION_KEY || !process.env.PII_HASH_SALT) {
+      throw new BadRequestException(
+        'PII_ENCRYPTION_KEY และ PII_HASH_SALT ต้องตั้งค่าก่อนรัน Backfill',
+      );
+    }
+
+    const lockResult = await this.prisma.$queryRaw<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(hashtext(${PdpaEncryptionService.ADVISORY_LOCK_KEY})) AS acquired
+    `;
+    if (!lockResult[0]?.acquired) {
+      this.logger.warn(`pdpa-backfill: advisory lock already held — refusing concurrent run (triggeredBy=${triggeredBy})`);
+      throw new ConflictException('มี Backfill ทำงานอยู่ — กรุณารอจนเสร็จ');
+    }
+
+    try {
+      return await this.runUnderLock({ triggeredBy, triggeredByUserId, batchSize, onProgress: opts.onProgress });
+    } finally {
+      try {
+        await this.prisma.$queryRaw`
+          SELECT pg_advisory_unlock(hashtext(${PdpaEncryptionService.ADVISORY_LOCK_KEY}))
+        `;
+      } catch (err) {
+        this.logger.warn(`pdpa-backfill: advisory unlock failed: ${this.truncErr(err)}`);
+      }
+    }
+  }
+
+  private async runUnderLock(opts: {
+    triggeredBy: 'cli' | 'manual';
+    triggeredByUserId: string | null;
+    batchSize: number;
+    onProgress?: (p: BackfillProgress) => void;
+  }): Promise<BackfillResult> {
+    const { triggeredBy, triggeredByUserId, batchSize, onProgress } = opts;
+    const startedAt = new Date();
+
+    const totalRecords = await this.prisma.customer.count({
+      where: {
+        deletedAt: null,
+        AND: [
+          { nationalId: { not: '' } },
+          { nationalIdEncrypted: null },
+        ],
+      },
+    });
+
+    const run = await this.prisma.pdpaBackfillRun.create({
+      data: {
+        startedAt,
+        status: 'RUNNING',
+        triggeredBy,
+        triggeredByUserId,
+        totalRecords,
+        hostname: this.safeHostname(),
+      },
+    });
+
+    let processedRecords = 0;
+    let skippedRecords = 0;
+    let errorMessage: string | undefined;
+    let batchNumber = 0;
+
+    try {
+      let cursorId: string | null = null;
+
+      // Hard upper bound on iteration count prevents an infinite loop in
+      // the impossible-but-defensive case where the cursor stops
+      // advancing (e.g. concurrent writer adds rows faster than we
+      // process them).
+      const MAX_ITERATIONS = 10_000;
+      for (let i = 0; i < MAX_ITERATIONS; i++) {
+        const batch = (await this.prisma.customer.findMany({
+          where: {
+            deletedAt: null,
+            AND: [
+              { nationalId: { not: '' } },
+              { nationalIdEncrypted: null },
+            ],
+          },
+          take: batchSize,
+          ...(cursorId ? { skip: 1, cursor: { id: cursorId } } : {}),
+          orderBy: { id: 'asc' },
+        })) as unknown as Array<Record<string, unknown>>;
+
+        if (batch.length === 0) break;
+        cursorId = batch[batch.length - 1].id as string;
+        batchNumber++;
+
+        const { processed, skipped } = await this.processBatch(batch);
+        processedRecords += processed;
+        skippedRecords += skipped;
+
+        await this.prisma.pdpaBackfillRun.update({
+          where: { id: run.id },
+          data: { processedRecords, skippedRecords },
+        });
+
+        if (onProgress) {
+          onProgress({
+            processed: processedRecords,
+            skipped: skippedRecords,
+            total: totalRecords,
+            batchNumber,
+          });
+        }
+      }
+
+      const finishedAt = new Date();
+      await this.prisma.pdpaBackfillRun.update({
+        where: { id: run.id },
+        data: { status: 'COMPLETED', finishedAt, processedRecords, skippedRecords },
+      });
+
+      return {
+        id: run.id,
+        status: 'COMPLETED',
+        totalRecords,
+        processedRecords,
+        skippedRecords,
+        durationMs: finishedAt.getTime() - startedAt.getTime(),
+      };
+    } catch (err) {
+      errorMessage = this.truncErr(err);
+      Sentry.captureException(err, {
+        tags: { module: 'pdpa', op: 'backfill' },
+        extra: { runId: run.id, batchNumber, processedRecords, skippedRecords },
+      });
+      this.logger.error(`pdpa-backfill: failed at batch ${batchNumber}: ${errorMessage}`);
+
+      const finishedAt = new Date();
+      await this.prisma.pdpaBackfillRun.update({
+        where: { id: run.id },
+        data: { status: 'FAILED', finishedAt, errorMessage, processedRecords, skippedRecords },
+      });
+
+      return {
+        id: run.id,
+        status: 'FAILED',
+        totalRecords,
+        processedRecords,
+        skippedRecords,
+        durationMs: finishedAt.getTime() - startedAt.getTime(),
+        errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Encrypt + hash a single batch. Per-row failures are swallowed (logged
+   * at warn level, NO PII) so one bad row doesn't halt the whole backfill.
+   * Such rows show up as "skipped" in the result.
+   */
+  private async processBatch(batch: Array<Record<string, unknown>>): Promise<{
+    processed: number;
+    skipped: number;
+  }> {
+    let processed = 0;
+    let skipped = 0;
+    const key = process.env.PII_ENCRYPTION_KEY!;
+    const salt = process.env.PII_HASH_SALT!;
+
+    for (const row of batch) {
+      try {
+        const encrypted: Record<string, unknown> = {};
+        const enc = (v: unknown): string | null => {
+          if (typeof v !== 'string' || !v) return null;
+          if (isEncrypted(v)) return v;
+          return encryptPII(v, key);
+        };
+        const hsh = (v: unknown): string | null => {
+          if (typeof v !== 'string' || !v) return null;
+          return hashPII(v, salt);
+        };
+
+        const fieldPairs: Array<[plain: string, encField: string, hashField?: string]> = [
+          ['nationalId', 'nationalIdEncrypted', 'nationalIdHash'],
+          ['phone', 'phoneEncrypted', 'phoneHash'],
+          ['phoneSecondary', 'phoneSecondaryEncrypted'],
+          ['email', 'emailEncrypted'],
+          ['addressIdCard', 'addressIdCardEncrypted'],
+          ['addressCurrent', 'addressCurrentEncrypted'],
+          ['addressWork', 'addressWorkEncrypted'],
+          ['guardianNationalId', 'guardianNationalIdEncrypted'],
+          ['guardianPhone', 'guardianPhoneEncrypted'],
+          ['guardianAddress', 'guardianAddressEncrypted'],
+        ];
+
+        let touched = false;
+        for (const [plain, encField, hashField] of fieldPairs) {
+          if (row[encField] == null) {
+            const encVal = enc(row[plain]);
+            if (encVal !== null) {
+              encrypted[encField] = encVal;
+              touched = true;
+            }
+            if (hashField && row[hashField] == null) {
+              const hashVal = hsh(row[plain]);
+              if (hashVal !== null) {
+                encrypted[hashField] = hashVal;
+              }
+            }
+          }
+        }
+
+        if (
+          row['referencesEncrypted'] == null &&
+          Array.isArray(row['references']) &&
+          (row['references'] as unknown[]).length > 0
+        ) {
+          encrypted['referencesEncrypted'] = encryptReferencesJson(row['references'], key);
+          touched = true;
+        }
+
+        if (!touched) {
+          skipped++;
+          continue;
+        }
+
+        await this.prisma.customer.update({
+          where: { id: row['id'] as string },
+          data: encrypted as Prisma.CustomerUpdateInput,
+        });
+        processed++;
+      } catch (err) {
+        // P2002 unique-constraint on nationalIdHash means there's a
+        // soft-deleted ghost with the same plaintext nationalId —
+        // leave it for the operator to reconcile manually.
+        skipped++;
+        this.logger.warn(
+          `pdpa-backfill: skipping customer (id-suffix=${this.idTail(row['id'])}) — ${this.errClass(err)}`,
+        );
+      }
+    }
+
+    return { processed, skipped };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private truncErr(err: unknown): string {
+    const msg = (err as { message?: string })?.message ?? String(err);
+    return msg.length > PdpaEncryptionService.ERROR_TRUNC_CHARS
+      ? msg.slice(0, PdpaEncryptionService.ERROR_TRUNC_CHARS) + '…'
+      : msg;
+  }
+
+  /** Last 8 chars of the row UUID — enough for ops to grep, no PII. */
+  private idTail(id: unknown): string {
+    return typeof id === 'string' ? id.slice(-8) : 'unknown';
+  }
+
+  private errClass(err: unknown): string {
+    if (typeof err === 'object' && err !== null && 'code' in err) {
+      return String((err as { code: unknown }).code);
+    }
+    if (err instanceof Error) return err.constructor.name;
+    return 'Unknown';
+  }
+
+  private safeHostname(): string {
+    try {
+      return os.hostname();
+    } catch {
+      return 'unknown';
+    }
+  }
+}

--- a/apps/api/src/modules/pdpa/pdpa.module.ts
+++ b/apps/api/src/modules/pdpa/pdpa.module.ts
@@ -2,11 +2,15 @@ import { Module } from '@nestjs/common';
 import { PDPAController } from './pdpa.controller';
 import { PDPAService } from './pdpa.service';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { CustomersModule } from '../customers/customers.module';
+import { PdpaEncryptionService } from './pdpa-encryption.service';
+import { PdpaEncryptionController } from './pdpa-encryption.controller';
 
 @Module({
-  imports: [PrismaModule],
-  controllers: [PDPAController],
-  providers: [PDPAService],
-  exports: [PDPAService],
+  imports: [PrismaModule, AuthModule, CustomersModule],
+  controllers: [PDPAController, PdpaEncryptionController],
+  providers: [PDPAService, PdpaEncryptionService],
+  exports: [PDPAService, PdpaEncryptionService],
 })
 export class PDPAModule {}

--- a/apps/api/src/modules/pdpa/pdpa.module.ts
+++ b/apps/api/src/modules/pdpa/pdpa.module.ts
@@ -4,13 +4,15 @@ import { PDPAService } from './pdpa.service';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { CustomersModule } from '../customers/customers.module';
+import { AuditModule } from '../audit/audit.module';
 import { PdpaEncryptionService } from './pdpa-encryption.service';
 import { PdpaEncryptionController } from './pdpa-encryption.controller';
+import { PdpaBackfillRetentionCron } from './pdpa-backfill-retention.cron';
 
 @Module({
-  imports: [PrismaModule, AuthModule, CustomersModule],
+  imports: [PrismaModule, AuthModule, CustomersModule, AuditModule],
   controllers: [PDPAController, PdpaEncryptionController],
-  providers: [PDPAService, PdpaEncryptionService],
+  providers: [PDPAService, PdpaEncryptionService, PdpaBackfillRetentionCron],
   exports: [PDPAService, PdpaEncryptionService],
 })
 export class PDPAModule {}

--- a/apps/api/src/modules/trade-in/trade-in.service.spec.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.spec.ts
@@ -581,8 +581,8 @@ describe('TradeInService', () => {
         transferAccountNumber: '1234567890',
         transferAccountName: 'Mr Test',
       });
-      expect(result.transferAccountNumberEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);
-      expect(result.transferAccountNameEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);
+      expect(result.transferAccountNumberEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+      expect(result.transferAccountNameEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
     });
 
     it('returns null encrypted fields when paymentMethod=CASH', () => {

--- a/apps/api/src/utils/crypto.util.spec.ts
+++ b/apps/api/src/utils/crypto.util.spec.ts
@@ -1,21 +1,22 @@
 import { encryptPII, decryptPII, isEncrypted } from './crypto.util';
 import { randomBytes } from 'crypto';
 
-describe('crypto.util', () => {
-  // 32-byte hex key (256 bits)
+describe('crypto.util (AES-256-GCM)', () => {
+  // 32-byte hex key (256 bits) — AES-256 requires exactly this length.
   const key = randomBytes(32).toString('hex');
 
   describe('encryptPII / decryptPII', () => {
-    it('should encrypt and decrypt correctly', () => {
+    it('round-trips a 13-digit Thai national ID', () => {
       const plaintext = '1234567890123';
       const encrypted = encryptPII(plaintext, key);
       expect(encrypted).not.toBe(plaintext);
-      expect(encrypted).toContain(':');
+      // Wire format: iv(24):authTag(32):ciphertext — 3 colon-separated parts.
+      expect(encrypted.split(':').length).toBe(3);
       const decrypted = decryptPII(encrypted, key);
       expect(decrypted).toBe(plaintext);
     });
 
-    it('should produce different ciphertexts for same plaintext (random IV)', () => {
+    it('produces different ciphertexts for same plaintext (random IV)', () => {
       const plaintext = '0812345678';
       const enc1 = encryptPII(plaintext, key);
       const enc2 = encryptPII(plaintext, key);
@@ -24,34 +25,101 @@ describe('crypto.util', () => {
       expect(decryptPII(enc2, key)).toBe(plaintext);
     });
 
-    it('should return plaintext when no key provided', () => {
-      const plaintext = 'hello';
-      expect(encryptPII(plaintext, '')).toBe(plaintext);
-      expect(decryptPII(plaintext, '')).toBe(plaintext);
+    it('throws when key is missing or too short (no silent plaintext writes)', () => {
+      // C2 — encryptPII MUST refuse misconfigured callers. The previous
+      // passthrough behaviour wrote raw plaintext into the *_encrypted
+      // column, which strict-mode `isEncrypted` was happy to accept.
+      expect(() => encryptPII('hello', '')).toThrow(/missing or too short/i);
+      expect(() => encryptPII('hello', 'too-short')).toThrow(/missing or too short/i);
     });
 
-    it('should handle empty string', () => {
+    it('decryptPII passes through input untouched when key absent (legacy plaintext column fallback)', () => {
+      // Read-side keeps tolerant behaviour — strict-mode rejection
+      // lives in CustomerPiiService.decryptCustomerFields, not here.
+      expect(decryptPII('plain', '')).toBe('plain');
+      expect(decryptPII('', '')).toBe('');
+    });
+
+    it('handles empty string round-trip', () => {
       expect(encryptPII('', key)).toBe('');
       expect(decryptPII('', key)).toBe('');
     });
 
-    it('should handle Thai text', () => {
+    it('handles Thai text round-trip', () => {
       const thai = 'สวัสดีครับ';
       const encrypted = encryptPII(thai, key);
       expect(decryptPII(encrypted, key)).toBe(thai);
     });
+
+    it('THROWS on tampered ciphertext (1-bit flip in ciphertext segment)', () => {
+      // C1 — silent return-as-is would render `iv:tag:cipher` as the user's
+      // phone number. GCM auth-tag verification MUST surface tampering.
+      const encrypted = encryptPII('0812345678', key);
+      const [iv, tag, cipherHex] = encrypted.split(':');
+      // Flip the lowest bit of the last hex character of the ciphertext.
+      const lastChar = cipherHex.slice(-1);
+      const flipped = (parseInt(lastChar, 16) ^ 0x1).toString(16);
+      const tampered = `${iv}:${tag}:${cipherHex.slice(0, -1)}${flipped}`;
+      expect(() => decryptPII(tampered, key)).toThrow(/decryption failed/i);
+    });
+
+    it('THROWS on wrong key (decipher.final auth-tag mismatch)', () => {
+      const encrypted = encryptPII('1234567890123', key);
+      const wrongKey = randomBytes(32).toString('hex');
+      expect(() => decryptPII(encrypted, wrongKey)).toThrow(/decryption failed/i);
+    });
+
+    it('THROWS on tampered auth tag', () => {
+      const encrypted = encryptPII('1234567890123', key);
+      const [iv, tag, cipherHex] = encrypted.split(':');
+      const flippedTag = tag.slice(0, -1) + ((parseInt(tag.slice(-1), 16) ^ 0x1).toString(16));
+      const tampered = `${iv}:${flippedTag}:${cipherHex}`;
+      expect(() => decryptPII(tampered, key)).toThrow(/decryption failed/i);
+    });
+
+    it('error message NEVER leaks ciphertext or key material', () => {
+      const encrypted = encryptPII('secret-pii', key);
+      const wrongKey = randomBytes(32).toString('hex');
+      try {
+        decryptPII(encrypted, wrongKey);
+        fail('expected throw');
+      } catch (err) {
+        const msg = (err as Error).message;
+        expect(msg).not.toContain(encrypted);
+        expect(msg).not.toContain(wrongKey);
+        expect(msg).not.toContain('secret-pii');
+      }
+    });
   });
 
   describe('isEncrypted', () => {
-    it('should detect encrypted values', () => {
+    it('detects newly encrypted values (3-part GCM format)', () => {
       const encrypted = encryptPII('test', key);
       expect(isEncrypted(encrypted)).toBe(true);
     });
 
-    it('should not flag plaintext', () => {
+    it('rejects plaintext', () => {
       expect(isEncrypted('1234567890123')).toBe(false);
       expect(isEncrypted('')).toBe(false);
       expect(isEncrypted('hello world')).toBe(false);
+    });
+
+    it('rejects legacy CBC format (2 parts, 32-char IV) so legacy data falls back to plaintext column', () => {
+      // CBC format would be `<iv-hex(32)>:<ciphertext-hex>` (2 parts).
+      // GCM format requires 3 parts — CBC must NOT pass this check.
+      const fakeCbc = 'a'.repeat(32) + ':' + 'b'.repeat(32);
+      expect(isEncrypted(fakeCbc)).toBe(false);
+    });
+
+    it('rejects malformed inputs (wrong IV length, wrong tag length, non-hex)', () => {
+      // Wrong IV length (should be 24 hex chars)
+      expect(isEncrypted('aaaa:' + 'b'.repeat(32) + ':' + 'c'.repeat(8))).toBe(false);
+      // Wrong tag length (should be 32 hex chars)
+      expect(isEncrypted('a'.repeat(24) + ':bbb:' + 'c'.repeat(8))).toBe(false);
+      // Non-hex chars
+      expect(isEncrypted('x'.repeat(24) + ':' + 'b'.repeat(32) + ':' + 'c'.repeat(8))).toBe(false);
+      // Empty ciphertext part
+      expect(isEncrypted('a'.repeat(24) + ':' + 'b'.repeat(32) + ':')).toBe(false);
     });
   });
 });

--- a/apps/api/src/utils/crypto.util.ts
+++ b/apps/api/src/utils/crypto.util.ts
@@ -1,44 +1,131 @@
-import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
-
-const ALGO = 'aes-256-cbc';
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  type CipherGCM,
+  type DecipherGCM,
+} from 'crypto';
 
 /**
- * Encrypt a plaintext string using AES-256-CBC.
- * Returns `iv:ciphertext` hex string, or the original value if no key.
+ * Phase 3 SP4 — column-level PII encryption primitives.
+ *
+ * Algorithm: AES-256-GCM (authenticated encryption).
+ *
+ *   - 12-byte random IV per call (GCM standard — never reuse with the same key)
+ *   - 16-byte auth tag emitted by `cipher.getAuthTag()` after `cipher.final()`
+ *   - Wire format: `<iv-hex(24)>:<authTag-hex(32)>:<ciphertext-hex>`
+ *
+ * GCM is mandatory here (not CBC) because tamper detection is part of the
+ * PDPA threat model. A wrong key OR a flipped bit MUST throw — never
+ * silently leak garbage back as the customer's phone number.
+ *
+ * Migration note: a brief earlier draft of this util used AES-256-CBC with
+ * the format `<iv-hex(32)>:<ciphertext-hex>`. The 3-part `isEncrypted`
+ * format check distinguishes the two — any column that still holds CBC
+ * data after this PR ships will fail `isEncrypted`, fall back to its
+ * legacy plaintext column, and need to be re-encrypted by the next
+ * backfill pass (Customer PII rolls through `pdpa-encryption.service`;
+ * trade-in transferAccount* fields would need a one-off re-encrypt if
+ * any production rows exist — see runbook §3).
+ */
+const ALGO = 'aes-256-gcm';
+const IV_LENGTH_BYTES = 12;
+const AUTH_TAG_LENGTH_BYTES = 16;
+/** Hex-encoded lengths of IV / auth tag — used by isEncrypted format check. */
+const IV_HEX_LENGTH = IV_LENGTH_BYTES * 2; // 24
+const AUTH_TAG_HEX_LENGTH = AUTH_TAG_LENGTH_BYTES * 2; // 32
+
+/** Minimum acceptable key length (hex chars) — AES-256 needs 32 bytes = 64 hex. */
+const MIN_KEY_HEX_LENGTH = 32;
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM.
+ *
+ * Returns the wire format `iv:authTag:ciphertext` (all hex).
+ *
+ * @throws Error when `key` is missing or shorter than 32 chars. We refuse
+ *   to silently passthrough — see DEEP review C2 (a misconfigured prod
+ *   would otherwise write literal plaintext to *_encrypted columns and
+ *   strict-mode `isEncrypted` would happily accept it).
+ *
+ * Empty plaintext is returned as-is — encrypting '' would burn CPU + bytes
+ * for nothing and the round-trip still produces ''.
  */
 export function encryptPII(plaintext: string, key: string): string {
-  if (!key || key.length < 32 || !plaintext) return plaintext;
-  const iv = randomBytes(16);
-  const cipher = createCipheriv(ALGO, Buffer.from(key, 'hex'), iv);
-  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
-  encrypted += cipher.final('hex');
-  return iv.toString('hex') + ':' + encrypted;
+  if (!key || key.length < MIN_KEY_HEX_LENGTH) {
+    throw new Error(
+      'PII_ENCRYPTION_KEY missing or too short (need 32+ chars)',
+    );
+  }
+  if (!plaintext) return plaintext;
+  const iv = randomBytes(IV_LENGTH_BYTES);
+  const cipher = createCipheriv(ALGO, Buffer.from(key, 'hex'), iv) as CipherGCM;
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
 }
 
 /**
- * Decrypt an `iv:ciphertext` hex string back to plaintext.
- * Returns the original value if it doesn't look encrypted (no colon separator).
+ * Decrypt a GCM-encrypted `iv:authTag:ciphertext` string back to plaintext.
+ *
+ * Returns the original input unchanged when:
+ *   - input is empty, OR
+ *   - input doesn't carry an `:` separator (clearly not our format —
+ *     callers fall back to the legacy plaintext column path).
+ *
+ * @throws InternalServerErrorException equivalent (plain Error) when the
+ *   input LOOKS like our wire format (3 parts, valid hex lengths) but
+ *   `decipher.final()` rejects it — almost always a key mismatch or
+ *   tampering attempt. We REFUSE to swallow this — silent return-as-is
+ *   would render `iv:tag:ciphertext` as the user's national ID (DEEP
+ *   review C1).
  */
 export function decryptPII(ciphertext: string, key: string): string {
-  if (!key || key.length < 32 || !ciphertext || !ciphertext.includes(':')) return ciphertext;
+  if (!key || key.length < MIN_KEY_HEX_LENGTH) return ciphertext;
+  if (!ciphertext || !ciphertext.includes(':')) return ciphertext;
+  // Not our format → bail out untouched (legacy plaintext column passthrough).
+  if (!isEncrypted(ciphertext)) return ciphertext;
+
+  const [ivHex, authTagHex, encryptedHex] = ciphertext.split(':');
   try {
-    const [ivHex, encrypted] = ciphertext.split(':');
     const iv = Buffer.from(ivHex, 'hex');
-    const decipher = createDecipheriv(ALGO, Buffer.from(key, 'hex'), iv);
-    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
-    decrypted += decipher.final('utf8');
-    return decrypted;
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const decipher = createDecipheriv(ALGO, Buffer.from(key, 'hex'), iv) as DecipherGCM;
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([
+      decipher.update(encryptedHex, 'hex'),
+      decipher.final(),
+    ]);
+    return decrypted.toString('utf8');
   } catch {
-    // If decryption fails (e.g., plaintext data), return as-is
-    return ciphertext;
+    // NEVER include the ciphertext or key in the error message — that
+    // would leak the attack payload + key length into logs / Sentry.
+    throw new Error(
+      'PII decryption failed — possible key mismatch or tampering',
+    );
   }
 }
 
 /**
- * Check if a value looks like it's already encrypted (iv:hex format).
+ * Check if a value looks like a GCM-encrypted payload from this util.
+ *
+ * Format: `<iv-hex(24)>:<authTag-hex(32)>:<ciphertext-hex(>=2)>`
+ *
+ * Strict on lengths so a 13-digit national ID or an email address with `:`
+ * in it never matches. CBC-format strings (2 parts, 32-char IV) also
+ * fail this check — see migration note at top of file.
  */
 export function isEncrypted(value: string): boolean {
   if (!value || !value.includes(':')) return false;
-  const [ivHex] = value.split(':');
-  return ivHex.length === 32 && /^[0-9a-f]+$/i.test(ivHex);
+  const parts = value.split(':');
+  if (parts.length !== 3) return false;
+  const [ivHex, authTagHex, encryptedHex] = parts;
+  if (ivHex.length !== IV_HEX_LENGTH) return false;
+  if (authTagHex.length !== AUTH_TAG_HEX_LENGTH) return false;
+  if (encryptedHex.length < 2) return false;
+  const HEX_RE = /^[0-9a-f]+$/i;
+  return HEX_RE.test(ivHex) && HEX_RE.test(authTagHex) && HEX_RE.test(encryptedHex);
 }

--- a/apps/web/src/pages/SettingsPage/index.tsx
+++ b/apps/web/src/pages/SettingsPage/index.tsx
@@ -11,8 +11,9 @@ import { AttachmentTab } from './tabs/AttachmentTab';
 import { UsersTab } from './tabs/UsersTab';
 import { OffsiteBackupTab } from './tabs/OffsiteBackupTab';
 import { PeakMappingTab } from './tabs/PeakMappingTab';
+import { PdpaTab } from './tabs/PdpaTab';
 
-const TAB_IDS = ['company', 'vat', 'periods', 'attachment', 'users', 'offsite-backup', 'peak-mapping'] as const;
+const TAB_IDS = ['company', 'vat', 'periods', 'attachment', 'users', 'offsite-backup', 'peak-mapping', 'pdpa'] as const;
 type TabId = typeof TAB_IDS[number];
 
 function readHash(): TabId {
@@ -49,7 +50,7 @@ export default function SettingsPage() {
       <PageHeader title="ตั้งค่าระบบ" subtitle="กำหนดพารามิเตอร์การทำงานของระบบ" />
 
       <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabId)}>
-        <TabsList className="grid grid-cols-2 md:grid-cols-7 mb-4">
+        <TabsList className="grid grid-cols-2 md:grid-cols-8 mb-4">
           <TabsTrigger value="company">บริษัท</TabsTrigger>
           <TabsTrigger value="vat">VAT</TabsTrigger>
           <TabsTrigger value="periods">งวดบัญชี</TabsTrigger>
@@ -57,6 +58,7 @@ export default function SettingsPage() {
           <TabsTrigger value="users">ผู้ใช้งาน</TabsTrigger>
           <TabsTrigger value="offsite-backup">สำรองข้อมูล</TabsTrigger>
           <TabsTrigger value="peak-mapping">PEAK</TabsTrigger>
+          <TabsTrigger value="pdpa">PDPA</TabsTrigger>
         </TabsList>
 
         <TabsContent value="company"><CompanyTab /></TabsContent>
@@ -66,6 +68,7 @@ export default function SettingsPage() {
         <TabsContent value="users"><UsersTab /></TabsContent>
         <TabsContent value="offsite-backup"><OffsiteBackupTab /></TabsContent>
         <TabsContent value="peak-mapping"><PeakMappingTab /></TabsContent>
+        <TabsContent value="pdpa"><PdpaTab /></TabsContent>
       </Tabs>
     </div>
   );

--- a/apps/web/src/pages/SettingsPage/tabs/PdpaTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/PdpaTab.tsx
@@ -1,0 +1,395 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { ShieldCheck, ShieldAlert, KeyRound, PlayCircle, Lock, Unlock } from 'lucide-react';
+import api, { getErrorMessage } from '@/lib/api';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+
+/**
+ * Phase 3 SP4 — PDPA strict-mode + backfill console.
+ *
+ * Three concerns rendered top-to-bottom:
+ *   1. Status card — strict-mode toggle + ready/not-ready badge + env-var
+ *      configuration hints.
+ *   2. Backfill card — encrypted/plaintext counts, progress bar, "Run
+ *      Backfill" button (polls every 3s while the topmost run is RUNNING).
+ *   3. History table — last 7 backfill runs with status + duration.
+ *
+ * Important: this tab NEVER renders raw PII. The backend `/pdpa-encryption/status`
+ * endpoint only returns aggregate counts — there is no field on the page
+ * that could leak a customer's name, phone, etc.
+ */
+
+interface PdpaStatus {
+  strictMode: boolean;
+  totalCustomers: number;
+  encryptedCount: number;
+  plaintextCount: number;
+  readyForStrictMode: boolean;
+  encryptionKeyConfigured: boolean;
+  hashSaltConfigured: boolean;
+}
+
+interface PdpaBackfillRun {
+  id: string;
+  status: 'RUNNING' | 'COMPLETED' | 'FAILED';
+  totalRecords: number;
+  processedRecords: number;
+  skippedRecords: number;
+  startedAt: string;
+  finishedAt: string | null;
+  errorMessage: string | null;
+  triggeredBy: string;
+  triggeredByUser: { id: string; name: string } | null;
+  hostname: string | null;
+}
+
+const STATUS_LABELS: Record<PdpaBackfillRun['status'], { label: string; variant: 'success' | 'destructive' | 'info' }> = {
+  RUNNING: { label: 'กำลังทำงาน', variant: 'info' },
+  COMPLETED: { label: 'สำเร็จ', variant: 'success' },
+  FAILED: { label: 'ล้มเหลว', variant: 'destructive' },
+};
+
+function formatThaiDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('th-TH', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Bangkok',
+  });
+}
+
+function formatDuration(startedAt: string, finishedAt: string | null): string {
+  if (!finishedAt) return '-';
+  const ms = new Date(finishedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} วิ`;
+  return `${(ms / 60_000).toFixed(1)} นาที`;
+}
+
+function formatTrigger(run: PdpaBackfillRun): string {
+  if (run.triggeredBy === 'cli') return 'cli';
+  return run.triggeredByUser?.name || 'manual';
+}
+
+export function PdpaTab() {
+  const queryClient = useQueryClient();
+  const [showStrictConfirm, setShowStrictConfirm] = useState(false);
+  const [showBackfillConfirm, setShowBackfillConfirm] = useState(false);
+
+  const statusQuery = useQuery<PdpaStatus>({
+    queryKey: ['pdpa', 'status'],
+    queryFn: async () => (await api.get('/pdpa-encryption/status')).data,
+  });
+
+  const runsQuery = useQuery<PdpaBackfillRun[]>({
+    queryKey: ['pdpa', 'backfill-runs'],
+    queryFn: async () => (await api.get('/pdpa-encryption/backfill-runs')).data,
+    // Auto-refresh every 3s while the topmost run is still RUNNING — gives a
+    // live progress bar without forcing the user to click refresh.
+    refetchInterval: (query) => {
+      const runs = query.state.data as PdpaBackfillRun[] | undefined;
+      return runs?.[0]?.status === 'RUNNING' ? 3_000 : false;
+    },
+  });
+
+  const toggleStrictMutation = useMutation({
+    mutationFn: async (enabled: boolean) =>
+      (await api.put('/pdpa-encryption/strict-mode', { enabled })).data,
+    onSuccess: (resp: { strictMode: boolean }) => {
+      queryClient.invalidateQueries({ queryKey: ['pdpa', 'status'] });
+      toast.success(resp.strictMode ? 'เปิด PDPA strict mode แล้ว' : 'ปิด PDPA strict mode แล้ว');
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const runBackfillMutation = useMutation({
+    mutationFn: async () => (await api.post('/pdpa-encryption/backfill')).data,
+    onSuccess: (resp: { status: string; processedRecords: number; skippedRecords: number; durationMs: number; errorMessage?: string }) => {
+      queryClient.invalidateQueries({ queryKey: ['pdpa', 'status'] });
+      queryClient.invalidateQueries({ queryKey: ['pdpa', 'backfill-runs'] });
+      if (resp.status === 'COMPLETED') {
+        toast.success(
+          `Backfill สำเร็จ — เข้ารหัส ${resp.processedRecords} แถว / ข้าม ${resp.skippedRecords} / ${(resp.durationMs / 1000).toFixed(1)} วิ`,
+        );
+      } else {
+        toast.error(`Backfill ล้มเหลว: ${resp.errorMessage || 'ไม่ทราบสาเหตุ'}`);
+      }
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  if (statusQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground leading-snug">กำลังโหลด...</p>;
+  }
+
+  if (!statusQuery.data) {
+    return <p className="text-sm text-muted-foreground leading-snug">ไม่สามารถโหลดสถานะได้</p>;
+  }
+
+  const status = statusQuery.data;
+  const runs = runsQuery.data || [];
+  const topRun = runs[0];
+  const isRunning = topRun?.status === 'RUNNING';
+  const progressPct = status.totalCustomers > 0
+    ? Math.round((status.encryptedCount * 100) / status.totalCustomers)
+    : 100;
+
+  const envReady = status.encryptionKeyConfigured && status.hashSaltConfigured;
+
+  return (
+    <div className="space-y-4">
+      {/* Confirm dialogs */}
+      <ConfirmDialog
+        open={showStrictConfirm}
+        onOpenChange={setShowStrictConfirm}
+        title="เปิด PDPA strict mode?"
+        description="เมื่อเปิดแล้ว ระบบจะปฏิเสธการอ่านข้อมูลลูกค้าที่ยังไม่ได้เข้ารหัส กรุณายืนยันว่ารัน Backfill เรียบร้อย และคอลัมน์ทุกตัวอยู่ในสถานะ encrypted แล้ว"
+        confirmLabel="ยืนยันเปิด"
+        cancelLabel="ยกเลิก"
+        loading={toggleStrictMutation.isPending}
+        onConfirm={() => toggleStrictMutation.mutate(true)}
+      />
+      <ConfirmDialog
+        open={showBackfillConfirm}
+        onOpenChange={setShowBackfillConfirm}
+        title="เริ่ม Backfill เลย?"
+        description={`จะเข้ารหัสข้อมูลลูกค้าที่ยังไม่ได้เข้ารหัส ${status.plaintextCount.toLocaleString('th-TH')} คน — ใช้เวลาประมาณ ${Math.max(1, Math.ceil(status.plaintextCount / 500))} นาที (batch 100 แถว)`}
+        confirmLabel="เริ่ม"
+        cancelLabel="ยกเลิก"
+        loading={runBackfillMutation.isPending}
+        onConfirm={() => runBackfillMutation.mutate()}
+      />
+
+      {/* Status card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            {status.strictMode ? (
+              <ShieldCheck className="size-5 text-emerald-600 dark:text-emerald-400" />
+            ) : (
+              <ShieldAlert className="size-5 text-amber-600 dark:text-amber-400" />
+            )}
+            PDPA Strict Mode (PII column-level encryption)
+          </CardTitle>
+          <CardDescription className="leading-snug">
+            เมื่อเปิด strict mode ระบบจะอ่านข้อมูลส่วนบุคคล (เลขบัตรประชาชน,
+            เบอร์โทร, อีเมล, ที่อยู่) จากคอลัมน์ encrypted เท่านั้น —
+            ป้องกันการรั่วไหลของข้อมูลแม้ DB ถูกขโมย (PDPA พ.ร.บ. 2562)
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-start justify-between gap-4 rounded-lg border border-border/60 bg-muted p-4">
+            <div className="flex-1">
+              <p className="text-sm font-medium text-foreground leading-snug">เปิดใช้งาน Strict Mode</p>
+              <p className="text-xs text-muted-foreground leading-snug mt-1">
+                ก่อนเปิด — ต้องรัน Backfill ให้คอลัมน์ encrypted ครบทุกแถวก่อน
+                ไม่อย่างนั้นทุก API ที่อ่าน Customer จะ 400
+              </p>
+            </div>
+            <Switch
+              checked={status.strictMode}
+              disabled={toggleStrictMutation.isPending || (!status.strictMode && (!status.readyForStrictMode || !envReady))}
+              onCheckedChange={(v) => {
+                if (v) {
+                  setShowStrictConfirm(true);
+                } else {
+                  toggleStrictMutation.mutate(false);
+                }
+              }}
+              aria-label="เปิดปิด PDPA strict mode"
+            />
+          </div>
+
+          {/* Env-var configuration hints */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div className="rounded-lg bg-muted p-3 flex items-center gap-3">
+              <KeyRound className="size-5 text-muted-foreground" />
+              <div className="flex-1">
+                <p className="text-xs text-muted-foreground leading-snug">PII_ENCRYPTION_KEY</p>
+                <p className="text-sm font-medium text-foreground leading-snug">
+                  {status.encryptionKeyConfigured ? (
+                    <Badge variant="success">ตั้งค่าแล้ว</Badge>
+                  ) : (
+                    <Badge variant="destructive">ยังไม่ได้ตั้ง</Badge>
+                  )}
+                </p>
+              </div>
+            </div>
+            <div className="rounded-lg bg-muted p-3 flex items-center gap-3">
+              <KeyRound className="size-5 text-muted-foreground" />
+              <div className="flex-1">
+                <p className="text-xs text-muted-foreground leading-snug">PII_HASH_SALT</p>
+                <p className="text-sm font-medium text-foreground leading-snug">
+                  {status.hashSaltConfigured ? (
+                    <Badge variant="success">ตั้งค่าแล้ว</Badge>
+                  ) : (
+                    <Badge variant="destructive">ยังไม่ได้ตั้ง</Badge>
+                  )}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {!envReady && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 p-3 text-sm">
+              <ShieldAlert className="size-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+              <p className="text-amber-900 dark:text-amber-200 leading-snug">
+                ตั้ง <code className="font-mono">PII_ENCRYPTION_KEY</code> (64
+                hex chars) และ <code className="font-mono">PII_HASH_SALT</code> (≥32
+                chars) ใน env vars ก่อน — สร้างด้วย{' '}
+                <code className="font-mono">openssl rand -hex 32</code>
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Backfill card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            {status.readyForStrictMode ? (
+              <Lock className="size-5 text-emerald-600 dark:text-emerald-400" />
+            ) : (
+              <Unlock className="size-5 text-amber-600 dark:text-amber-400" />
+            )}
+            Backfill PII Encryption
+          </CardTitle>
+          <CardDescription className="leading-snug">
+            เข้ารหัสคอลัมน์ PII (nationalId, phone, email, address) สำหรับ
+            ลูกค้าที่ยังไม่ได้เข้ารหัส — รันได้หลายครั้ง (idempotent)
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Encryption progress */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm font-medium text-foreground leading-snug">
+                เข้ารหัสไปแล้ว{' '}
+                <span className="tabular-nums">{status.encryptedCount.toLocaleString('th-TH')}</span>
+                {' / '}
+                <span className="tabular-nums">{status.totalCustomers.toLocaleString('th-TH')}</span>
+                {' '}คน ({progressPct}%)
+              </p>
+              {status.readyForStrictMode ? (
+                <Badge variant="success">พร้อมเปิด Strict Mode</Badge>
+              ) : (
+                <Badge variant="outline">
+                  ยังเหลือ {status.plaintextCount.toLocaleString('th-TH')} คน
+                </Badge>
+              )}
+            </div>
+            <Progress value={progressPct} aria-label="ความคืบหน้าการเข้ารหัส" />
+          </div>
+
+          {/* Live progress when a run is in flight */}
+          {isRunning && topRun && (
+            <div className="rounded-lg border border-blue-200 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-900 p-3">
+              <p className="text-sm font-medium text-blue-900 dark:text-blue-200 leading-snug">
+                กำลังรัน — เข้ารหัสไปแล้ว{' '}
+                {topRun.processedRecords.toLocaleString('th-TH')} /
+                {' '}{topRun.totalRecords.toLocaleString('th-TH')} แถว
+                {topRun.skippedRecords > 0 ? ` (ข้าม ${topRun.skippedRecords})` : ''}
+              </p>
+            </div>
+          )}
+
+          {/* Plaintext warning when strict mode is OFF but we have plaintext rows */}
+          {!status.readyForStrictMode && !isRunning && envReady && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 p-3 text-sm">
+              <ShieldAlert className="size-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+              <p className="text-amber-900 dark:text-amber-200 leading-snug">
+                ลูกค้า {status.plaintextCount.toLocaleString('th-TH')} คน
+                ยังไม่ได้เข้ารหัส — รัน Backfill ก่อนเปิด Strict Mode
+              </p>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <Button
+              onClick={() => setShowBackfillConfirm(true)}
+              disabled={runBackfillMutation.isPending || isRunning || !envReady || status.plaintextCount === 0}
+              variant="outline"
+              className="gap-2"
+            >
+              <PlayCircle className="size-4" />
+              {isRunning ? 'กำลังรัน...' : runBackfillMutation.isPending ? 'กำลังเริ่ม...' : 'เริ่ม Backfill'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* History */}
+      <Card>
+        <CardHeader>
+          <CardTitle>ประวัติ Backfill (7 ครั้งล่าสุด)</CardTitle>
+          <CardDescription className="leading-snug">
+            ทั้งจาก CLI (npm run backfill:encrypt-pii) และจากการคลิกปุ่มใน
+            หน้านี้
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {runs.length === 0 ? (
+            <p className="text-sm text-muted-foreground leading-snug">ยังไม่มีประวัติ Backfill</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>เวลาเริ่ม</TableHead>
+                    <TableHead>สถานะ</TableHead>
+                    <TableHead className="text-right">เข้ารหัส</TableHead>
+                    <TableHead className="text-right">ข้าม</TableHead>
+                    <TableHead className="text-right">ระยะเวลา</TableHead>
+                    <TableHead>Trigger</TableHead>
+                    <TableHead>หมายเหตุ</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {runs.map((run) => {
+                    const label = STATUS_LABELS[run.status];
+                    return (
+                      <TableRow key={run.id}>
+                        <TableCell className="font-mono text-xs">{formatThaiDateTime(run.startedAt)}</TableCell>
+                        <TableCell>
+                          <Badge variant={label.variant}>{label.label}</Badge>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {run.processedRecords.toLocaleString('th-TH')}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {run.skippedRecords.toLocaleString('th-TH')}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatDuration(run.startedAt, run.finishedAt)}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground leading-snug">
+                          {formatTrigger(run)}
+                        </TableCell>
+                        <TableCell
+                          className="text-xs text-destructive max-w-[18rem] truncate leading-snug"
+                          title={run.errorMessage || ''}
+                        >
+                          {run.errorMessage || ''}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/tabs/PdpaTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/PdpaTab.tsx
@@ -10,6 +10,9 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+// W8 — shared formatter returns พ.ศ. ("8 เม.ย. 69 14:30") instead of the
+// local helper's ค.ศ. output. Removes the date-format drift across pages.
+import { formatThaiDateTime } from '@/lib/date';
 
 /**
  * Phase 3 SP4 — PDPA strict-mode + backfill console.
@@ -26,11 +29,19 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
  * that could leak a customer's name, phone, etc.
  */
 
+interface PiiColumnPlaintextCount {
+  column: string;
+  plaintextCount: number;
+}
+
 interface PdpaStatus {
   strictMode: boolean;
   totalCustomers: number;
   encryptedCount: number;
   plaintextCount: number;
+  /** W3 — per-column breakdown so the UI can surface which exact field is missing.
+   *  Optional for forward compat with older API responses that pre-date this field. */
+  plaintextByColumn?: PiiColumnPlaintextCount[];
   readyForStrictMode: boolean;
   encryptionKeyConfigured: boolean;
   hashSaltConfigured: boolean;
@@ -55,17 +66,6 @@ const STATUS_LABELS: Record<PdpaBackfillRun['status'], { label: string; variant:
   COMPLETED: { label: 'สำเร็จ', variant: 'success' },
   FAILED: { label: 'ล้มเหลว', variant: 'destructive' },
 };
-
-function formatThaiDateTime(iso: string): string {
-  return new Date(iso).toLocaleString('th-TH', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'Asia/Bangkok',
-  });
-}
 
 function formatDuration(startedAt: string, finishedAt: string | null): string {
   if (!finishedAt) return '-';
@@ -305,12 +305,29 @@ export function PdpaTab() {
 
           {/* Plaintext warning when strict mode is OFF but we have plaintext rows */}
           {!status.readyForStrictMode && !isRunning && envReady && (
-            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 p-3 text-sm">
-              <ShieldAlert className="size-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
-              <p className="text-amber-900 dark:text-amber-200 leading-snug">
-                ลูกค้า {status.plaintextCount.toLocaleString('th-TH')} คน
-                ยังไม่ได้เข้ารหัส — รัน Backfill ก่อนเปิด Strict Mode
-              </p>
+            <div className="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900 p-3 text-sm">
+              <div className="flex items-start gap-2">
+                <ShieldAlert className="size-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+                <p className="text-amber-900 dark:text-amber-200 leading-snug">
+                  ลูกค้า {status.plaintextCount.toLocaleString('th-TH')} คน
+                  ยังไม่ได้เข้ารหัส — รัน Backfill ก่อนเปิด Strict Mode
+                </p>
+              </div>
+              {/* W3 — per-column breakdown so the operator knows which
+                  exact columns still need backfilling. Falls back gracefully
+                  when the API response pre-dates this field. */}
+              {status.plaintextByColumn && status.plaintextByColumn.some((c) => c.plaintextCount > 0) && (
+                <ul className="mt-2 ml-6 list-disc text-xs text-amber-900 dark:text-amber-200 leading-snug">
+                  {status.plaintextByColumn
+                    .filter((c) => c.plaintextCount > 0)
+                    .map((c) => (
+                      <li key={c.column}>
+                        <span className="font-mono">{c.column}</span> —{' '}
+                        {c.plaintextCount.toLocaleString('th-TH')} แถว
+                      </li>
+                    ))}
+                </ul>
+              )}
             </div>
           )}
 

--- a/apps/web/src/pages/SettingsPage/tabs/__tests__/PdpaTab.test.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/__tests__/PdpaTab.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+// Mock api before importing the component
+const apiGet = vi.fn();
+const apiPost = vi.fn();
+const apiPut = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+    post: (...args: unknown[]) => apiPost(...args),
+    put: (...args: unknown[]) => apiPut(...args),
+  },
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { PdpaTab } from '../PdpaTab';
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(React.createElement(QueryClientProvider, { client: qc }, ui));
+}
+
+describe('PdpaTab', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    apiPost.mockReset();
+    apiPut.mockReset();
+  });
+
+  it('renders ready-for-strict-mode banner when plaintextCount=0', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/pdpa-encryption/status') {
+        return Promise.resolve({
+          data: {
+            strictMode: false,
+            totalCustomers: 100,
+            encryptedCount: 100,
+            plaintextCount: 0,
+            readyForStrictMode: true,
+            encryptionKeyConfigured: true,
+            hashSaltConfigured: true,
+          },
+        });
+      }
+      if (url === '/pdpa-encryption/backfill-runs') {
+        return Promise.resolve({ data: [] });
+      }
+      return Promise.reject(new Error('unexpected url ' + url));
+    });
+
+    wrap(<PdpaTab />);
+    await waitFor(() => {
+      expect(screen.getByText('พร้อมเปิด Strict Mode')).toBeInTheDocument();
+    });
+    // Progress sentence uses sub-spans, so match the wrapper paragraph by
+    // the text "เข้ารหัสไปแล้ว" + tolerance for the numeric spans.
+    expect(screen.getByText(/เข้ารหัสไปแล้ว/)).toBeInTheDocument();
+    // backfill button should be disabled when no plaintext rows remain
+    const backfillBtn = screen.getByRole('button', { name: /เริ่ม Backfill/ });
+    expect(backfillBtn).toBeDisabled();
+  });
+
+  it('renders plaintext warning + enables Backfill when plaintextCount > 0', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/pdpa-encryption/status') {
+        return Promise.resolve({
+          data: {
+            strictMode: false,
+            totalCustomers: 100,
+            encryptedCount: 70,
+            plaintextCount: 30,
+            readyForStrictMode: false,
+            encryptionKeyConfigured: true,
+            hashSaltConfigured: true,
+          },
+        });
+      }
+      if (url === '/pdpa-encryption/backfill-runs') {
+        return Promise.resolve({ data: [] });
+      }
+      return Promise.reject(new Error('unexpected url ' + url));
+    });
+
+    wrap(<PdpaTab />);
+    await waitFor(() => {
+      expect(screen.getByText(/ยังเหลือ 30 คน/)).toBeInTheDocument();
+    });
+    const backfillBtn = screen.getByRole('button', { name: /เริ่ม Backfill/ });
+    expect(backfillBtn).not.toBeDisabled();
+  });
+
+  it('shows env-var setup warning when PII_ENCRYPTION_KEY missing', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/pdpa-encryption/status') {
+        return Promise.resolve({
+          data: {
+            strictMode: false,
+            totalCustomers: 0,
+            encryptedCount: 0,
+            plaintextCount: 0,
+            readyForStrictMode: true,
+            encryptionKeyConfigured: false,
+            hashSaltConfigured: true,
+          },
+        });
+      }
+      if (url === '/pdpa-encryption/backfill-runs') {
+        return Promise.resolve({ data: [] });
+      }
+      return Promise.reject(new Error('unexpected url ' + url));
+    });
+
+    wrap(<PdpaTab />);
+    // Wait for the "ยังไม่ได้ตั้ง" badge (only rendered when key/salt absent).
+    await waitFor(() => {
+      expect(screen.getByText('ยังไม่ได้ตั้ง')).toBeInTheDocument();
+    });
+    // Switch must be disabled until env is ready
+    const toggle = screen.getByRole('switch', { name: /เปิดปิด PDPA strict mode/ });
+    expect(toggle).toBeDisabled();
+  });
+
+  it('renders backfill history when runs exist', async () => {
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/pdpa-encryption/status') {
+        return Promise.resolve({
+          data: {
+            strictMode: false,
+            totalCustomers: 100,
+            encryptedCount: 100,
+            plaintextCount: 0,
+            readyForStrictMode: true,
+            encryptionKeyConfigured: true,
+            hashSaltConfigured: true,
+          },
+        });
+      }
+      if (url === '/pdpa-encryption/backfill-runs') {
+        return Promise.resolve({
+          data: [
+            {
+              id: 'r1',
+              status: 'COMPLETED',
+              totalRecords: 100,
+              processedRecords: 100,
+              skippedRecords: 0,
+              startedAt: '2026-05-18T10:00:00Z',
+              finishedAt: '2026-05-18T10:00:42Z',
+              errorMessage: null,
+              triggeredBy: 'cli',
+              triggeredByUser: null,
+              hostname: 'pod-1',
+            },
+          ],
+        });
+      }
+      return Promise.reject(new Error('unexpected url ' + url));
+    });
+
+    wrap(<PdpaTab />);
+    await waitFor(() => {
+      expect(screen.getByText('สำเร็จ')).toBeInTheDocument();
+    });
+    // history table renders the row
+    expect(screen.getByText('cli')).toBeInTheDocument();
+  });
+});

--- a/docs/guides/PDPA-COMPLIANCE.md
+++ b/docs/guides/PDPA-COMPLIANCE.md
@@ -31,13 +31,36 @@ infrastructure delivered in PR `feat/p3-sp4-pii-encryption`.
 
 | Purpose | Algorithm | Implementation |
 | --- | --- | --- |
-| Confidentiality (column encryption) | AES-256-CBC with random 16-byte IV | `apps/api/src/utils/crypto.util.ts:encryptPII` |
+| Confidentiality + integrity (column encryption) | AES-256-GCM with random 12-byte IV + 16-byte auth tag | `apps/api/src/utils/crypto.util.ts:encryptPII` |
 | Deterministic lookup hash | HMAC-SHA-256 | `apps/api/src/utils/pii.util.ts:hashPII` |
-| Reference JSON encryption | Per-field AES-256-CBC | `apps/api/src/utils/pii.util.ts:encryptReferencesJson` |
+| Reference JSON encryption | Per-field AES-256-GCM | `apps/api/src/utils/pii.util.ts:encryptReferencesJson` |
+
+Wire format: `<iv-hex(24)>:<authTag-hex(32)>:<ciphertext-hex>`. Decryption
+verifies the auth tag — wrong key or tampered ciphertext throws an
+exception (we do NOT silently return the input — that would render
+ciphertext as the user's phone number).
 
 The hash is keyed by `PII_HASH_SALT` (≥32 chars) so two databases that share
 a `PII_ENCRYPTION_KEY` but differ in salt cannot cross-correlate plaintext
 identities.
+
+> **DEEP review C1 migration note** — a brief earlier draft of `crypto.util.ts`
+> used AES-256-CBC (no auth tag). The `isEncrypted` format check now requires
+> 3 colon-separated parts (iv:tag:ciphertext), so any column that still holds
+> CBC-format data after this PR ships will fail `isEncrypted`, fall back to
+> its legacy plaintext column, and need to be re-encrypted by the next
+> backfill pass. For the Customer 11 PII columns this is automatic via the
+> backfill cron. For trade-in `transfer_account_*` columns (Phase 2 PR #743),
+> any rows written between Phase 2 merge and Phase 3 SP4 deploy will need a
+> one-off re-encrypt — `apps/api/src/cli/encrypt-customer-pii.cli.ts` does NOT
+> cover trade-in. Verify with:
+> ```sql
+> SELECT COUNT(*) FROM trade_ins
+> WHERE transfer_account_number_encrypted IS NOT NULL
+>   AND transfer_account_number_encrypted NOT LIKE '%:%:%';
+> ```
+> If 0, no action needed. If > 0, schedule a trade-in re-encrypt CLI before
+> enabling PDPA strict mode.
 
 ---
 
@@ -47,12 +70,20 @@ identities.
 
 | Var | Purpose | How to generate |
 | --- | --- | --- |
-| `PII_ENCRYPTION_KEY` | AES-256-CBC key, hex-encoded | `openssl rand -hex 32` (64 chars) |
+| `PII_ENCRYPTION_KEY` | AES-256-GCM key, hex-encoded | `openssl rand -hex 32` (64 chars) |
 | `PII_HASH_SALT` | HMAC-SHA-256 salt | `openssl rand -hex 32` (64 chars) — anything ≥32 chars is accepted |
 | `PDPA_STRICT_MODE` | Optional fallback when `system_config` is unreachable | `'true'` / `'1'` to enable |
 
 Both are validated at boot — see `apps/api/src/utils/env-validation.ts`.
 A missing or malformed key crashes the API on startup in production.
+
+> **DEEP review C2 note** — `encryptPII` will now THROW if called with a
+> missing or too-short key. The previous "silent passthrough" path wrote
+> literal plaintext into the `*_encrypted` columns, which the strict-mode
+> `isEncrypted` check happily accepted. This affects `CustomerPiiService.
+> encryptCustomerFields` — any code path that writes Customer PII without
+> setting `PII_ENCRYPTION_KEY` (>=32 chars) will fail at request time
+> rather than silently corrupting data.
 
 Generate once and store in **Secret Manager** (GCP) or your secret backend.
 **Never** commit `.env` files. **Never** print these values to logs.
@@ -155,22 +186,55 @@ Backfill is protected by a PostgreSQL advisory lock keyed
 `pdpa-backfill`, so CLI + UI button + cron firing simultaneously cannot
 double-run.
 
+### Cursor-race retry (W9)
+
+If a concurrent writer inserts a new customer between two batches, the
+cursor-based loop can skip past the new row. The backfill detects this
+by running a final `count()` after the main loop completes — if
+remaining > 0, it runs one additional pass over the unencrypted tail.
+After 2 passes, if remaining is still > 0, the run is marked
+`COMPLETED_WITH_RACE` (visible in the `errorMessage` column of
+`PdpaBackfillRun`) and the operator is recommended to re-run during a
+maintenance window where writes are paused.
+
+### PdpaBackfillRun retention (W2)
+
+`PdpaBackfillRetentionCron` (apps/api/src/modules/pdpa/pdpa-backfill-retention.cron.ts)
+hard-deletes rows older than 365 days. Runs daily at 02:00 BKK.
+Matches the existing AuditLog + OffsiteBackupRun retention policy.
+
+### Backfill query indexes (W10)
+
+Migration `20260949000000_pii_backfill_pending_indexes` adds 4 partial
+indexes on `customers` covering the high-cardinality PII columns:
+`national_id`, `phone`, `email`, `address_id_card`. Each index covers
+only rows where the encrypted counterpart is NULL, so the index size
+collapses to ~0 bytes once the backfill is complete.
+
 ---
 
 ## 4. Audit + access patterns
 
 ### What gets logged
 
-| Event | AuditLog action | Triggered by |
-| --- | --- | --- |
-| Backfill run completed/failed | `PDPA_BACKFILL_RUN` | `POST /pdpa-encryption/backfill` |
-| Strict-mode toggle | `PDPA_STRICT_MODE_TOGGLED` | `PUT /pdpa-encryption/strict-mode` |
-| Per-row PII decryption (existing) | `PII_DECRYPT_FULL` / `PII_DECRYPT_MASKED` | every CustomersController read |
+| Event | AuditLog action | Triggered by | userId carries |
+| --- | --- | --- | --- |
+| Backfill run completed/failed | `PDPA_BACKFILL_RUN` | `POST /pdpa-encryption/backfill` (UI) OR CLI | OWNER user (UI) / SYSTEM user (CLI) — W7 |
+| Strict-mode toggle | `PDPA_STRICT_MODE_TOGGLED` | `PUT /pdpa-encryption/strict-mode` | OWNER user |
+| Per-row PII decryption (existing) | `PII_DECRYPT_FULL` / `PII_DECRYPT_MASKED` | every CustomersController read | reader user |
+
+> **DEEP review W6/W7** — `PDPA_STRICT_MODE_TOGGLED` and `PDPA_BACKFILL_RUN`
+> audit rows include `ipAddress` + `userAgent` from the request when
+> triggered through HTTP. CLI invocations have neither — the audit row
+> lists `triggeredBy: 'cli'` in `newValue` and uses the SYSTEM user UUID
+> (`User.isSystemUser=true`) as `userId`, mirroring the cron-job pattern
+> from `OffsiteBackupCron` / `etax-auto-submit.cron`.
 
 The `PdpaBackfillRun` model is the auditable history of every backfill,
 including the CLI invocations. It records `triggeredBy` ('cli' or
 'manual'), `triggeredByUserId` (FK to `User` when 'manual'), and the
-hostname/Cloud Run revision the run executed on.
+hostname/Cloud Run revision the run executed on. Rows older than 1 year
+are pruned by `PdpaBackfillRetentionCron` (see §3).
 
 ### Who can decrypt what
 
@@ -205,9 +269,10 @@ customers full deletion.
 
 ### "I lost the PII_ENCRYPTION_KEY"
 
-**Data is unrecoverable.** AES-256-CBC has no backdoor. Every encrypted
-column on every customer is now opaque ciphertext that decrypts to
-garbage with the wrong key.
+**Data is unrecoverable.** AES-256-GCM has no backdoor — the auth tag
+verifies key correctness and will THROW on the wrong key (no silent
+return of garbage). Every encrypted column on every customer is opaque
+ciphertext that cannot be decrypted without the original key.
 
 Recovery path:
 1. Restore the most recent Cloud SQL backup that pre-dates the key loss
@@ -272,6 +337,8 @@ safe and instantaneous.
 | Backfill CLI | `apps/api/src/cli/encrypt-customer-pii.cli.ts` |
 | Settings UI tab | `apps/web/src/pages/SettingsPage/tabs/PdpaTab.tsx` |
 | Backfill history schema | `model PdpaBackfillRun` in `apps/api/prisma/schema.prisma` |
+| Backfill retention cron (W2) | `apps/api/src/modules/pdpa/pdpa-backfill-retention.cron.ts` |
 | Existing PII decryption audit | `apps/api/src/modules/pii/pii-audit.service.ts` |
 | Phase 2 encrypted-column migration | `apps/api/prisma/migrations/20260528400000_add_pii_encrypted_columns/` |
 | SP4 PdpaBackfillRun migration | `apps/api/prisma/migrations/20260948000000_pdpa_backfill_runs/` |
+| SP4 partial-index migration (W10) | `apps/api/prisma/migrations/20260949000000_pii_backfill_pending_indexes/` |

--- a/docs/guides/PDPA-COMPLIANCE.md
+++ b/docs/guides/PDPA-COMPLIANCE.md
@@ -1,0 +1,277 @@
+# PDPA Compliance — PII Column-Level Encryption
+
+**Phase 3 SP4 — Strict-mode runbook**
+
+This document describes how customer PII is encrypted at rest in BESTCHOICE,
+how to operate the strict-mode + backfill workflow, and what to do if the
+encryption key is lost. It is the source of truth for the PII-encryption
+infrastructure delivered in PR `feat/p3-sp4-pii-encryption`.
+
+---
+
+## 1. What PII is encrypted
+
+| Column | Encrypted | Hashed (lookup) | Notes |
+| --- | --- | --- | --- |
+| `customers.national_id` | ✓ `national_id_encrypted` | ✓ `national_id_hash` (UNIQUE) | 13-digit Thai ID; hash powers dedup + lookup |
+| `customers.phone` | ✓ `phone_encrypted` | ✓ `phone_hash` (indexed) | Hash powers `?phone=` search endpoint |
+| `customers.phone_secondary` | ✓ `phone_secondary_encrypted` | — | Not searched by exact match |
+| `customers.email` | ✓ `email_encrypted` | — | Case-insensitive search uses plaintext column |
+| `customers.address_id_card` | ✓ `address_id_card_encrypted` | — | Free text; no exact-match lookup |
+| `customers.address_current` | ✓ `address_current_encrypted` | — | Free text |
+| `customers.address_work` | ✓ `address_work_encrypted` | — | Free text |
+| `customers.guardian_national_id` | ✓ `guardian_national_id_encrypted` | — | Guardian (อายุ 17-19) |
+| `customers.guardian_phone` | ✓ `guardian_phone_encrypted` | — | Guardian |
+| `customers.guardian_address` | ✓ `guardian_address_encrypted` | — | Guardian |
+| `customers.references` (JSON) | ✓ `references_encrypted` | — | Per-element encryption of firstName/lastName/phone/nationalId/address |
+| `trade_ins.transfer_account_number` | ✓ `transfer_account_number_encrypted` | — | Phase 2 (PR #743) |
+| `trade_ins.transfer_account_name` | ✓ `transfer_account_name_encrypted` | — | Phase 2 (PR #743) |
+
+### Algorithms
+
+| Purpose | Algorithm | Implementation |
+| --- | --- | --- |
+| Confidentiality (column encryption) | AES-256-CBC with random 16-byte IV | `apps/api/src/utils/crypto.util.ts:encryptPII` |
+| Deterministic lookup hash | HMAC-SHA-256 | `apps/api/src/utils/pii.util.ts:hashPII` |
+| Reference JSON encryption | Per-field AES-256-CBC | `apps/api/src/utils/pii.util.ts:encryptReferencesJson` |
+
+The hash is keyed by `PII_HASH_SALT` (≥32 chars) so two databases that share
+a `PII_ENCRYPTION_KEY` but differ in salt cannot cross-correlate plaintext
+identities.
+
+---
+
+## 2. Key management
+
+### Environment variables (production)
+
+| Var | Purpose | How to generate |
+| --- | --- | --- |
+| `PII_ENCRYPTION_KEY` | AES-256-CBC key, hex-encoded | `openssl rand -hex 32` (64 chars) |
+| `PII_HASH_SALT` | HMAC-SHA-256 salt | `openssl rand -hex 32` (64 chars) — anything ≥32 chars is accepted |
+| `PDPA_STRICT_MODE` | Optional fallback when `system_config` is unreachable | `'true'` / `'1'` to enable |
+
+Both are validated at boot — see `apps/api/src/utils/env-validation.ts`.
+A missing or malformed key crashes the API on startup in production.
+
+Generate once and store in **Secret Manager** (GCP) or your secret backend.
+**Never** commit `.env` files. **Never** print these values to logs.
+
+### Rotation procedure (annual)
+
+1. Generate the new key:
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. Store the new value alongside the current one as
+   `PII_ENCRYPTION_KEY_NEXT` in Secret Manager. Do **not** deploy yet.
+
+3. Pause writes briefly (set `READ_ONLY_MODE=true` if you have it) or run
+   during the lowest-traffic window.
+
+4. Run a custom re-encryption job (see "Future work" — not in SP4 scope):
+   for each customer row, decrypt with the old key then re-encrypt with
+   the new key, in-place.
+
+5. Verify counts:
+
+   ```sql
+   SELECT COUNT(*) FROM customers WHERE national_id_encrypted IS NOT NULL;
+   ```
+
+6. Swap the variables: `PII_ENCRYPTION_KEY` ← `PII_ENCRYPTION_KEY_NEXT`,
+   restart all pods.
+
+7. Decommission the old key after 30 days of stable operation.
+
+The salt does NOT rotate — rotating it invalidates every `*_hash` column
+and breaks dedup. If you must rotate the salt (e.g. compromise), plan a
+full hash-recompute migration first.
+
+---
+
+## 3. Transition from legacy plaintext
+
+The legacy plaintext columns (`customers.national_id`, `customers.phone`,
+etc.) still exist for backward compatibility during the rolling-deploy
+window. The plan is:
+
+| Phase | What's true | Reads | Writes |
+| --- | --- | --- | --- |
+| **Phase 2** (PR #743, merged) | Encrypted columns added (nullable) | Plaintext only | Plaintext only |
+| **Phase 3** (merged) | Dual-write live; non-strict reads prefer encrypted, fall back to plaintext | Both | Both |
+| **Phase 3 SP4** (this PR) | Backfill + strict-mode toggle available | Both (strict rejects null encrypted) | Both |
+| **Phase 6.6** (future) | Plaintext columns dropped via migration | Encrypted only | Encrypted only |
+
+### Going from Phase 3 → strict (production checklist)
+
+1. **Confirm env vars** — Settings → PDPA → both badges must show "ตั้งค่าแล้ว".
+
+2. **Run backfill** — either:
+   * UI: Settings → PDPA → "เริ่ม Backfill". Polls every 3s, shows live
+     progress.
+   * CLI (recommended for large datasets):
+
+     ```bash
+     CONFIRM_BACKFILL=YES_I_AM_SURE \
+     EXPECTED_DB_NAME=bestchoice_prod \
+     PII_ENCRYPTION_KEY=$PII_ENCRYPTION_KEY \
+     PII_HASH_SALT=$PII_HASH_SALT \
+     ALLOW_PROD_BACKFILL=YES_I_AM_SURE \
+     npm --prefix apps/api run backfill:encrypt-pii
+     ```
+
+   Idempotent — re-running skips already-encrypted rows.
+
+3. **Verify** — Settings → PDPA → `plaintextCount` shows 0, badge says
+   "พร้อมเปิด Strict Mode".
+
+4. **Enable strict mode** — toggle "เปิดใช้งาน Strict Mode". The
+   `ConfirmDialog` requires explicit confirmation because the setting
+   immediately starts rejecting reads of un-backfilled rows.
+
+5. **Smoke test** — open one customer detail page, run a customer search,
+   and create a new customer to confirm encrypted+plaintext columns are
+   written.
+
+If something breaks, toggle Strict Mode OFF — the system falls back to
+the Phase 3 behaviour (encrypted preferred, plaintext fallback).
+
+### Backfill performance
+
+| Row count | Batch size | Estimated duration |
+| --- | --- | --- |
+| 1,000 | 100 | < 10 s |
+| 10,000 | 100 | 1–2 min |
+| 50,000 | 100 | 5–10 min |
+| 100,000+ | 200 | 10–25 min |
+
+Override the batch size via `PDPA_BACKFILL_BATCH_SIZE=200`. The cap is 1000 —
+larger batches stress connection pooling without further speedup.
+
+Backfill is protected by a PostgreSQL advisory lock keyed
+`pdpa-backfill`, so CLI + UI button + cron firing simultaneously cannot
+double-run.
+
+---
+
+## 4. Audit + access patterns
+
+### What gets logged
+
+| Event | AuditLog action | Triggered by |
+| --- | --- | --- |
+| Backfill run completed/failed | `PDPA_BACKFILL_RUN` | `POST /pdpa-encryption/backfill` |
+| Strict-mode toggle | `PDPA_STRICT_MODE_TOGGLED` | `PUT /pdpa-encryption/strict-mode` |
+| Per-row PII decryption (existing) | `PII_DECRYPT_FULL` / `PII_DECRYPT_MASKED` | every CustomersController read |
+
+The `PdpaBackfillRun` model is the auditable history of every backfill,
+including the CLI invocations. It records `triggeredBy` ('cli' or
+'manual'), `triggeredByUserId` (FK to `User` when 'manual'), and the
+hostname/Cloud Run revision the run executed on.
+
+### Who can decrypt what
+
+| Role | nationalId | phone, email, address |
+| --- | --- | --- |
+| OWNER, FINANCE_MANAGER, ACCOUNTANT, BRANCH_MANAGER | Full | Full |
+| SALES | Masked (`12345-XXXXX-XX-3`) via `applyRoleMask` in CustomersController | Full |
+
+Other PII (LIFF-only paths, public webhooks) only decrypts what's required
+for that specific flow.
+
+---
+
+## 5. Right-to-deletion (PDPA Article 33)
+
+When a customer requests deletion via DSAR:
+
+1. Process the DSAR via existing flow (`POST /pdpa/dsar/<id>` with
+   `status: 'COMPLETED'`).
+2. Soft-delete the customer record (existing `DELETE /customers/:id`).
+3. **Run the optional anonymisation script** (not in SP4 scope — Phase
+   6.6 deliverable) to NULL the encrypted + hash + plaintext columns,
+   keeping the row only for audit-log referential integrity.
+
+Soft-delete alone is NOT sufficient for full PDPA erasure — the encrypted
+data still exists on disk. Plan the anonymisation step before promising
+customers full deletion.
+
+---
+
+## 6. Disaster recovery
+
+### "I lost the PII_ENCRYPTION_KEY"
+
+**Data is unrecoverable.** AES-256-CBC has no backdoor. Every encrypted
+column on every customer is now opaque ciphertext that decrypts to
+garbage with the wrong key.
+
+Recovery path:
+1. Restore the most recent Cloud SQL backup that pre-dates the key loss
+   AND has a known working key (you'll need to redeploy with that key).
+2. If no backup exists with a recoverable key — the encrypted columns
+   stay broken; you can fall back to the plaintext columns IF Phase 6.6
+   hasn't dropped them yet.
+
+**Mitigation:** Secret Manager has version history. Restore the
+previous version of the secret before deploying.
+
+### "I rotated the salt"
+
+Every `*_hash` column is now wrong. Dedup queries silently miss
+collisions, LIFF login by lineUserIdHash fails for legacy customers.
+Recovery: re-run the backfill, which recomputes hashes for any row
+where the hash is null OR doesn't match the current salt (see future
+"recompute-hashes" mode — out of SP4 scope).
+
+### "Strict mode rejects every read"
+
+You enabled strict mode before completing the backfill. Solution:
+1. UI: Settings → PDPA → toggle Strict Mode **OFF**.
+2. Run the backfill to completion.
+3. Toggle Strict Mode back ON.
+
+The toggle itself doesn't touch customer data — flipping it back is
+safe and instantaneous.
+
+---
+
+## 7. Compliance checklist (for legal review)
+
+- [x] PII encrypted at rest with AES-256 (matches NIST SP 800-175B
+      recommendations).
+- [x] Encryption keys stored outside the application database, in Secret
+      Manager.
+- [x] Deterministic hash separated from encryption key (HMAC-SHA-256).
+- [x] Audit trail for every backfill run + strict-mode toggle.
+- [x] Per-role access masking (SALES sees only last digit of national ID).
+- [x] Off-site backups also encrypted at rest (P3-SP2 — see
+      `OFFSITE-BACKUP.md`).
+- [x] Plaintext columns flagged with database comments (`COMMENT ON COLUMN
+      ... IS 'LEGACY plaintext PII — Cleared in Phase 6.6.'`).
+- [ ] Anonymisation-on-DSAR-completion script — **deferred to Phase 6.6**.
+- [ ] Column-level encryption for AuditLog PII — **deferred** (audit is
+      immutable; would require a new model).
+- [ ] HSM-backed key management — **deferred** (Secret Manager is the
+      interim solution; HSM is annual rotation justification only).
+
+---
+
+## 8. Reference paths
+
+| Component | Path |
+| --- | --- |
+| Crypto util | `apps/api/src/utils/crypto.util.ts` |
+| Hash + masking util | `apps/api/src/utils/pii.util.ts` |
+| Customer PII service | `apps/api/src/modules/customers/customer-pii.service.ts` |
+| Strict-mode + backfill service | `apps/api/src/modules/pdpa/pdpa-encryption.service.ts` |
+| Admin controller | `apps/api/src/modules/pdpa/pdpa-encryption.controller.ts` |
+| Backfill CLI | `apps/api/src/cli/encrypt-customer-pii.cli.ts` |
+| Settings UI tab | `apps/web/src/pages/SettingsPage/tabs/PdpaTab.tsx` |
+| Backfill history schema | `model PdpaBackfillRun` in `apps/api/prisma/schema.prisma` |
+| Existing PII decryption audit | `apps/api/src/modules/pii/pii-audit.service.ts` |
+| Phase 2 encrypted-column migration | `apps/api/prisma/migrations/20260528400000_add_pii_encrypted_columns/` |
+| SP4 PdpaBackfillRun migration | `apps/api/prisma/migrations/20260948000000_pdpa_backfill_runs/` |


### PR DESCRIPTION
## Summary

Phase 3 SP4 closes the long-deferred "PII column-level encryption (PDPA strict mode)" item from `.claude/CLAUDE.md`. Customer PII (nationalId, phone, email, addresses, guardian, references) was already dual-write encrypted under Phase 2 + Phase 3 (PR #743) — this PR adds the operational toolchain to drive the rollout to completion:

- **`CustomerPiiService`** — extracts the inline Phase 3 dual-write logic out of `CustomersService` into a reusable provider, adds a `{ strict }` decrypt mode that throws `BadRequestException` when an encrypted column is null but plaintext exists.
- **`PdpaEncryptionService`** — strict-mode toggle (refuses to enable until backfill is complete + env vars set) + batched, advisory-locked, idempotent backfill loop with per-batch progress commits to `PdpaBackfillRun`.
- **`PdpaEncryptionController`** — `/pdpa-encryption/status`, `PUT /strict-mode`, `POST /backfill`, `GET /backfill/:id`, `GET /backfill-runs` (OWNER only for mutations; FM/ACC read-only on status).
- **`encrypt-customer-pii.cli`** — same backfill logic via `npm run backfill:encrypt-pii` (consent + DB-name + ALLOW_PROD_BACKFILL guards mirror `wipe-accounting.cli`).
- **`/settings#pdpa` UI tab** — status card (strict-mode toggle, env-var badges), backfill card (progress bar, "เริ่ม Backfill" with confirm dialog, auto-polling every 3s while a run is RUNNING), history table.
- **`docs/guides/PDPA-COMPLIANCE.md`** — 277-line runbook covering keys, rotation, transition plan, audit, DSAR-deletion, disaster recovery, compliance checklist.

Hard rule honoured throughout: **never log decrypted PII** — only counters + error class names ever reach Logger output.

## Schema changes

- `model PdpaBackfillRun` + `enum PdpaBackfillStatus` (append-only event log, FK to user for forensics).
- One additive `User.pdpaBackfillRunsTriggered` reverse relation.
- Migration `20260948000000_pdpa_backfill_runs` is fully idempotent (DO blocks + IF NOT EXISTS).
- Also annotates every legacy plaintext PII column with `COMMENT ON COLUMN ... IS 'LEGACY plaintext PII — Cleared in Phase 6.6.'` for discoverability.

## Tests added

- API: **27 new tests** (CustomerPiiService 23, PdpaEncryptionService 11, PdpaEncryptionController 3) across 4 suites — all green. Existing 16 customers.service.spec tests still pass without modification (CustomerPiiService is `@Optional()` constructor param).
- Web: **4 new vitest tests** for PdpaTab (ready state, plaintext warning, env-var setup warning, history render) — all green.
- TypeScript: 0 errors API + web.

## Test plan

- [ ] Verify migration applies cleanly on a copy of prod (additive only — no FAILED state expected).
- [ ] Run backfill CLI against a copy of prod with the test PII_ENCRYPTION_KEY — verify `PdpaBackfillRun.status = COMPLETED` and `plaintextCount = 0` afterward.
- [ ] Smoke `/settings#pdpa` as OWNER — strict-mode toggle, "เริ่ม Backfill" button + history.
- [ ] Verify strict-mode toggle refuses to enable with plaintext rows still present.
- [ ] Confirm SALES role still sees masked `nationalId` after the refactor (existing applyRoleMask in CustomersController).

## Deferred items (out of SP4 scope)

- Phase 6.6 anonymisation-on-DSAR-completion script + plaintext column drop migration.
- Encrypted PII for Supplier / User models (Wave 3+).
- Column-level encryption for AuditLog PII (audit is immutable).
- Hardware Security Module (HSM) integration — Secret Manager is the interim solution.

## Files

- New: `apps/api/src/modules/customers/customer-pii.service.ts` (+ spec), `apps/api/src/modules/pdpa/pdpa-encryption.service.ts` (+ spec), `apps/api/src/modules/pdpa/pdpa-encryption.controller.ts` (+ spec), `apps/api/src/modules/pdpa/dto/strict-mode.dto.ts`, `apps/api/src/cli/encrypt-customer-pii.cli.ts`, `apps/api/prisma/migrations/20260948000000_pdpa_backfill_runs/migration.sql`, `apps/web/src/pages/SettingsPage/tabs/PdpaTab.tsx` (+ test), `docs/guides/PDPA-COMPLIANCE.md`.
- Edited: `apps/api/prisma/schema.prisma`, `apps/api/src/modules/customers/customers.module.ts`, `apps/api/src/modules/customers/customers.service.ts`, `apps/api/src/modules/pdpa/pdpa.module.ts`, `apps/api/package.json`, `apps/web/src/pages/SettingsPage/index.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)