### PR TITLE
hotfix(pdpa): forwardRef to break CustomersModule↔NotificationsModule cycle

### DIFF
--- a/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
@@ -1,6 +1,8 @@
 import {
   BadRequestException,
   ConflictException,
+  forwardRef,
+  Inject,
   Injectable,
   Logger,
   NotFoundException,
@@ -128,6 +130,7 @@ export class PdpaEncryptionService {
 
   constructor(
     private readonly prisma: PrismaService,
+    @Inject(forwardRef(() => CustomerPiiService))
     private readonly piiService: CustomerPiiService,
     private readonly audit: AuditService,
   ) {}

--- a/apps/api/src/modules/pdpa/pdpa.module.ts
+++ b/apps/api/src/modules/pdpa/pdpa.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PDPAController } from './pdpa.controller';
 import { PDPAService } from './pdpa.service';
 import { PrismaModule } from '../../prisma/prisma.module';
@@ -9,8 +9,22 @@ import { PdpaEncryptionService } from './pdpa-encryption.service';
 import { PdpaEncryptionController } from './pdpa-encryption.controller';
 import { PdpaBackfillRetentionCron } from './pdpa-backfill-retention.cron';
 
+/**
+ * Hotfix 2026-05-18 — PDPAModule was imported by NotificationsModule (pre-P3-SP4).
+ * P3-SP4 added CustomersModule to PDPAModule.imports. CustomersModule transitively
+ * imports NotificationsModule (via OverdueModule chain), creating a circular dep.
+ * Symptom: bestchoice-api revision crashed at boot with
+ *   "Nest cannot create the PDPAModule instance. The module at index [1] of
+ *    the PDPAModule 'imports' array is undefined."
+ * Fix: wrap AuthModule + CustomersModule with forwardRef to defer resolution.
+ */
 @Module({
-  imports: [PrismaModule, AuthModule, CustomersModule, AuditModule],
+  imports: [
+    PrismaModule,
+    forwardRef(() => AuthModule),
+    forwardRef(() => CustomersModule),
+    AuditModule,
+  ],
   controllers: [PDPAController, PdpaEncryptionController],
   providers: [PDPAService, PdpaEncryptionService, PdpaBackfillRetentionCron],
   exports: [PDPAService, PdpaEncryptionService],


### PR DESCRIPTION
## Summary

**Production API DOWN** since 12:48 UTC. The P3-SP4 #1015 merge introduced a circular module dependency that NestJS detects at boot.

Cycle: NotificationsModule → PDPAModule → CustomersModule (new dep from #1015) → ... → NotificationsModule

Fix: wrap AuthModule + CustomersModule with \`forwardRef()\` in PDPAModule.imports; matching @Inject(forwardRef(...)) on PdpaEncryptionService constructor.

P3-SP5 #1016 also failed to deploy because it landed on the same broken revision (Cloud Run held the previous good revision). This hotfix unblocks both PRs.

## Test plan

- [x] TypeScript clean
- [ ] CI Lint & Test green
- [ ] Cloud Run deploy success
- [ ] /api/health returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)