### PR TITLE
hotfix(pdpa): extract CustomerPiiModule to fully break OverdueModule→ChatEngine cycle

### DIFF
--- a/apps/api/src/modules/customers/customer-pii.module.ts
+++ b/apps/api/src/modules/customers/customer-pii.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { CustomerPiiService } from './customer-pii.service';
+
+/**
+ * Hotfix 2026-05-18 — CustomerPiiService extracted into its own minimal module
+ * so PDPAModule can consume it without pulling in the full CustomersModule
+ * (which transitively reaches the ChatEngineModule ↔ StaffChatModule cycle
+ * via OverdueModule → ChatEngineModule → StaffChatModule).
+ *
+ * CustomerPiiService depends only on PrismaService — no chat/customer/overdue
+ * deps — so this module is leaf and safe to import from anywhere.
+ *
+ * CustomersModule continues to re-export CustomerPiiService for its own use;
+ * PDPAModule imports THIS module instead.
+ */
+@Module({
+  imports: [PrismaModule],
+  providers: [CustomerPiiService],
+  exports: [CustomerPiiService],
+})
+export class CustomerPiiModule {}

--- a/apps/api/src/modules/customers/customer-pii.module.ts
+++ b/apps/api/src/modules/customers/customer-pii.module.ts
@@ -21,3 +21,4 @@ import { CustomerPiiService } from './customer-pii.service';
 })
 export class CustomerPiiModule {}
 // hotfix 2026-05-18
+// hotfix trigger 2

--- a/apps/api/src/modules/customers/customer-pii.module.ts
+++ b/apps/api/src/modules/customers/customer-pii.module.ts
@@ -20,3 +20,4 @@ import { CustomerPiiService } from './customer-pii.service';
   exports: [CustomerPiiService],
 })
 export class CustomerPiiModule {}
+// hotfix 2026-05-18

--- a/apps/api/src/modules/customers/customers.module.ts
+++ b/apps/api/src/modules/customers/customers.module.ts
@@ -4,25 +4,24 @@ import { CustomersService } from './customers.service';
 import { CustomerTierService } from './customer-tier.service';
 import { CustomerPreCheckService } from './customer-precheck.service';
 import { SkipTracingService } from './skip-tracing.service';
-import { CustomerPiiService } from './customer-pii.service';
+import { CustomerPiiModule } from './customer-pii.module';
 import { OverdueModule } from '../overdue/overdue.module';
 
 @Module({
-  imports: [OverdueModule],
+  imports: [OverdueModule, CustomerPiiModule],
   controllers: [CustomersController],
   providers: [
     CustomersService,
     CustomerTierService,
     CustomerPreCheckService,
     SkipTracingService,
-    CustomerPiiService,
   ],
   exports: [
     CustomersService,
     CustomerTierService,
     CustomerPreCheckService,
     SkipTracingService,
-    CustomerPiiService,
+    CustomerPiiModule,
   ],
 })
 export class CustomersModule {}

--- a/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
@@ -1,6 +1,8 @@
 import {
   BadRequestException,
   ConflictException,
+  forwardRef,
+  Inject,
   Injectable,
   Logger,
   NotFoundException,
@@ -128,6 +130,7 @@ export class PdpaEncryptionService {
 
   constructor(
     private readonly prisma: PrismaService,
+    @Inject(forwardRef(() => CustomerPiiService))
     private readonly piiService: CustomerPiiService,
     private readonly audit: AuditService,
   ) {}

--- a/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
+++ b/apps/api/src/modules/pdpa/pdpa-encryption.service.ts
@@ -1,8 +1,6 @@
 import {
   BadRequestException,
   ConflictException,
-  forwardRef,
-  Inject,
   Injectable,
   Logger,
   NotFoundException,
@@ -130,7 +128,6 @@ export class PdpaEncryptionService {
 
   constructor(
     private readonly prisma: PrismaService,
-    @Inject(forwardRef(() => CustomerPiiService))
     private readonly piiService: CustomerPiiService,
     private readonly audit: AuditService,
   ) {}

--- a/apps/api/src/modules/pdpa/pdpa.module.ts
+++ b/apps/api/src/modules/pdpa/pdpa.module.ts
@@ -1,30 +1,22 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { PDPAController } from './pdpa.controller';
 import { PDPAService } from './pdpa.service';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
-import { CustomersModule } from '../customers/customers.module';
+import { CustomerPiiModule } from '../customers/customer-pii.module';
 import { AuditModule } from '../audit/audit.module';
 import { PdpaEncryptionService } from './pdpa-encryption.service';
 import { PdpaEncryptionController } from './pdpa-encryption.controller';
 import { PdpaBackfillRetentionCron } from './pdpa-backfill-retention.cron';
 
 /**
- * Hotfix 2026-05-18 — PDPAModule was imported by NotificationsModule (pre-P3-SP4).
- * P3-SP4 added CustomersModule to PDPAModule.imports. CustomersModule transitively
- * imports NotificationsModule (via OverdueModule chain), creating a circular dep.
- * Symptom: bestchoice-api revision crashed at boot with
- *   "Nest cannot create the PDPAModule instance. The module at index [1] of
- *    the PDPAModule 'imports' array is undefined."
- * Fix: wrap AuthModule + CustomersModule with forwardRef to defer resolution.
+ * Hotfix 2026-05-18 — was importing CustomersModule (P3-SP4) which transitively
+ * pulled in OverdueModule → ChatEngineModule → StaffChatModule cycle, breaking
+ * boot. Now imports the leaf CustomerPiiModule directly — same CustomerPiiService
+ * is exported, no other deps come along.
  */
 @Module({
-  imports: [
-    PrismaModule,
-    forwardRef(() => AuthModule),
-    forwardRef(() => CustomersModule),
-    AuditModule,
-  ],
+  imports: [PrismaModule, AuthModule, CustomerPiiModule, AuditModule],
   controllers: [PDPAController, PdpaEncryptionController],
   providers: [PDPAService, PdpaEncryptionService, PdpaBackfillRetentionCron],
   exports: [PDPAService, PdpaEncryptionService],

--- a/apps/api/src/modules/pdpa/pdpa.module.ts
+++ b/apps/api/src/modules/pdpa/pdpa.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PDPAController } from './pdpa.controller';
 import { PDPAService } from './pdpa.service';
 import { PrismaModule } from '../../prisma/prisma.module';
@@ -9,8 +9,22 @@ import { PdpaEncryptionService } from './pdpa-encryption.service';
 import { PdpaEncryptionController } from './pdpa-encryption.controller';
 import { PdpaBackfillRetentionCron } from './pdpa-backfill-retention.cron';
 
+/**
+ * Hotfix 2026-05-18 — PDPAModule was imported by NotificationsModule (pre-P3-SP4).
+ * P3-SP4 added CustomersModule to PDPAModule.imports. CustomersModule transitively
+ * imports NotificationsModule (via OverdueModule chain), creating a circular dep.
+ * Symptom: bestchoice-api revision crashed at boot with
+ *   "Nest cannot create the PDPAModule instance. The module at index [1] of
+ *    the PDPAModule 'imports' array is undefined."
+ * Fix: wrap AuthModule + CustomersModule with forwardRef to defer resolution.
+ */
 @Module({
-  imports: [PrismaModule, AuthModule, CustomersModule, AuditModule],
+  imports: [
+    PrismaModule,
+    forwardRef(() => AuthModule),
+    forwardRef(() => CustomersModule),
+    AuditModule,
+  ],
   controllers: [PDPAController, PdpaEncryptionController],
   providers: [PDPAService, PdpaEncryptionService, PdpaBackfillRetentionCron],
   exports: [PDPAService, PdpaEncryptionService],


### PR DESCRIPTION
## Summary

**API still DOWN.** First hotfix (#1017) used forwardRef on PDPAModule but the cycle just moved deeper — boot now crashes at StaffChatModule because PDPAModule still transitively pulls OverdueModule → ChatEngineModule → StaffChatModule (pre-existing cycle).

Real fix: extract CustomerPiiService into a new leaf-only \`CustomerPiiModule\` that depends only on PrismaService. PDPAModule imports \`CustomerPiiModule\` (not CustomersModule). CustomersModule re-exports it for its own consumers.

## Test plan

- [x] TypeScript clean
- [ ] CI Lint & Test green
- [ ] Cloud Run deploy success
- [ ] /api/health returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)