### PR TITLE
hotfix(sp7.1): graceful skip when DATABASE_URL_FINANCE not provisioned

### DIFF
--- a/apps/api/src/modules/health/health.controller.spec.ts
+++ b/apps/api/src/modules/health/health.controller.spec.ts
@@ -30,7 +30,9 @@ describe('HealthController', () => {
     // Simulate both DBs unreachable so that both DB checks exercise the error branch.
     const dbError = new Error('password authentication failed for user "postgres"');
     prismaShop = { $queryRaw: jest.fn().mockRejectedValue(dbError) };
-    prismaFin = { $queryRaw: jest.fn().mockRejectedValue(dbError) };
+    // SP7.1 hotfix: PrismaFinanceService gained an isEnabled flag.
+    // Default mocks to enabled=true so existing error-path tests still exercise pingDb.
+    prismaFin = { $queryRaw: jest.fn().mockRejectedValue(dbError), isEnabled: true };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -24,9 +24,10 @@ interface CheckResult {
 
 interface DbProbeResult {
   db: string;
-  status: 'ok' | 'error';
+  status: 'ok' | 'error' | 'skipped';
   latency_ms?: number;
   error?: string;
+  message?: string;
 }
 
 interface PublicHealthResponse {
@@ -96,7 +97,8 @@ export class HealthController {
       this.checkStorage(),
     ]);
 
-    const allOk = dbProbes.every((p) => p.status === 'ok') && storageCheck.status === 'ok';
+    // 'skipped' counts as OK (e.g. bc_finance not yet provisioned)
+    const allOk = dbProbes.every((p) => p.status === 'ok' || p.status === 'skipped') && storageCheck.status === 'ok';
     const response: DetailedHealthResponse = {
       status: allOk ? 'ok' : 'error',
       timestamp,
@@ -122,8 +124,24 @@ export class HealthController {
   private async checkDatabases(): Promise<DbProbeResult[]> {
     return Promise.all([
       this.pingDb(this.prisma, 'shop'),
-      this.pingDb(this.prismaFin, 'finance'),
+      this.pingFinanceDb(),
     ]);
+  }
+
+  /**
+   * SP7.1 hotfix — bc_finance is optional until provisioned.
+   * When PrismaFinanceService.isEnabled = false, return 'skipped' instead of
+   * probing (which would throw because $connect() was never called).
+   */
+  private async pingFinanceDb(): Promise<DbProbeResult> {
+    if (!this.prismaFin.isEnabled) {
+      return {
+        db: 'finance',
+        status: 'skipped',
+        message: 'DATABASE_URL_FINANCE not set — bc_finance not yet provisioned (SP7.1)',
+      };
+    }
+    return this.pingDb(this.prismaFin, 'finance');
   }
 
   private async pingDb(

--- a/apps/api/src/prisma/prisma-finance.service.ts
+++ b/apps/api/src/prisma/prisma-finance.service.ts
@@ -4,6 +4,13 @@ import { PrismaClient } from '@prisma/client-finance';
 @Injectable()
 export class PrismaFinanceService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(PrismaFinanceService.name);
+  /**
+   * SP7.1 hotfix — bc_finance DB is optional until provisioned.
+   * `false` when DATABASE_URL_FINANCE is unset; consumers should check before
+   * making queries. HealthController reports a 'skipped' status, app boots
+   * normally so Cloud Run revision can become healthy.
+   */
+  public readonly isEnabled: boolean;
 
   constructor() {
     // Same pool-config strategy as PrismaService — append connection_limit + pool_timeout
@@ -20,14 +27,24 @@ export class PrismaFinanceService extends PrismaClient implements OnModuleInit, 
     super({
       log: process.env.NODE_ENV === 'development' ? ['warn', 'error'] : ['error'],
     });
+
+    this.isEnabled = !!dbUrl;
   }
 
   async onModuleInit() {
+    if (!this.isEnabled) {
+      this.logger.warn(
+        'DATABASE_URL_FINANCE not set — PrismaFinanceService is disabled. ' +
+          'SP7.7 migration scripts + cross-entity flows will no-op until bc_finance Cloud SQL provisioned.',
+      );
+      return;
+    }
     await this.$connect();
     this.logger.log('Finance database connected');
   }
 
   async onModuleDestroy() {
+    if (!this.isEnabled) return;
     await this.$disconnect();
     this.logger.log('Finance database disconnected');
   }


### PR DESCRIPTION
## Why

PR #1020 merged but Cloud Run **failed to deploy** — container couldn't start:
> ERROR: (gcloud.run.deploy) The user-provided container failed to start and listen on the port

Root cause: \`PrismaFinanceService.onModuleInit()\` always calls \`\$connect()\`. Cloud Run doesn't have \`DATABASE_URL_FINANCE\` set (bc_finance Cloud SQL not yet provisioned — owner action item from PR #1020 description). So connect crashes the boot.

**Production is currently still live at the previous revision** (Cloud Run kept the healthy one). This PR unblocks the new revision deploy.

## What

- \`PrismaFinanceService.isEnabled = !!process.env.DATABASE_URL_FINANCE\`. When disabled, onModuleInit/onModuleDestroy no-op (warning log only).
- \`HealthController.pingFinanceDb()\` returns \`status: 'skipped'\` with explanatory message when disabled. Detailed health endpoint treats 'skipped' as ok.
- \`DbProbeResult\` type extended with 'skipped' + optional 'message' field.
- Existing health test updated (mock now has \`isEnabled: true\` by default).

## Forward compat

When owner provisions Cloud SQL bc_finance + sets \`DATABASE_URL_FINANCE\` in Cloud Run env vars, isEnabled becomes true automatically — no code change needed. All SP7.4-7.6 cross-entity flows already no-op until then (they don't yet wire into the outbox processor).

## Test plan

- [x] TypeScript: 0 errors
- [x] Jest: 5 health tests pass (\`npx jest src/modules/health\`)
- [ ] CI green (E2E + Lint & Test on this PR)
- [ ] Cloud Run revision becomes healthy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)