### PR TITLE
hotfix(sp7.1): Dockerfile must copy @prisma/client-finance into runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,11 @@ COPY --from=deps --chown=appuser:appgroup /app/node_modules ./node_modules
 COPY --from=deps --chown=appuser:appgroup /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=builder --chown=appuser:appgroup /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder --chown=appuser:appgroup /app/apps/api/prisma ./apps/api/prisma
+# SP7.1 — finance Prisma client generated to apps/api/node_modules/@prisma/client-finance
+# (per generator output="../node_modules/@prisma/client-finance" in prisma-finance/schema.prisma).
+# Dep-stage copy at line 97 doesn't include generated client — must pull from builder explicitly.
+COPY --from=builder --chown=appuser:appgroup /app/apps/api/node_modules/@prisma/client-finance ./apps/api/node_modules/@prisma/client-finance
+COPY --from=builder --chown=appuser:appgroup /app/apps/api/prisma-finance ./apps/api/prisma-finance
 
 # ⚠️ TEMPORARY: Legacy migration data — remove after migration done
 COPY --chown=appuser:appgroup apps/api/scripts/import-legacy/data ./apps/api/scripts/import-legacy/data

--- a/apps/api/src/modules/health/health.controller.spec.ts
+++ b/apps/api/src/modules/health/health.controller.spec.ts
@@ -30,7 +30,9 @@ describe('HealthController', () => {
     // Simulate both DBs unreachable so that both DB checks exercise the error branch.
     const dbError = new Error('password authentication failed for user "postgres"');
     prismaShop = { $queryRaw: jest.fn().mockRejectedValue(dbError) };
-    prismaFin = { $queryRaw: jest.fn().mockRejectedValue(dbError) };
+    // SP7.1 hotfix: PrismaFinanceService gained an isEnabled flag.
+    // Default mocks to enabled=true so existing error-path tests still exercise pingDb.
+    prismaFin = { $queryRaw: jest.fn().mockRejectedValue(dbError), isEnabled: true };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -24,9 +24,10 @@ interface CheckResult {
 
 interface DbProbeResult {
   db: string;
-  status: 'ok' | 'error';
+  status: 'ok' | 'error' | 'skipped';
   latency_ms?: number;
   error?: string;
+  message?: string;
 }
 
 interface PublicHealthResponse {
@@ -96,7 +97,8 @@ export class HealthController {
       this.checkStorage(),
     ]);
 
-    const allOk = dbProbes.every((p) => p.status === 'ok') && storageCheck.status === 'ok';
+    // 'skipped' counts as OK (e.g. bc_finance not yet provisioned)
+    const allOk = dbProbes.every((p) => p.status === 'ok' || p.status === 'skipped') && storageCheck.status === 'ok';
     const response: DetailedHealthResponse = {
       status: allOk ? 'ok' : 'error',
       timestamp,
@@ -122,8 +124,24 @@ export class HealthController {
   private async checkDatabases(): Promise<DbProbeResult[]> {
     return Promise.all([
       this.pingDb(this.prisma, 'shop'),
-      this.pingDb(this.prismaFin, 'finance'),
+      this.pingFinanceDb(),
     ]);
+  }
+
+  /**
+   * SP7.1 hotfix — bc_finance is optional until provisioned.
+   * When PrismaFinanceService.isEnabled = false, return 'skipped' instead of
+   * probing (which would throw because $connect() was never called).
+   */
+  private async pingFinanceDb(): Promise<DbProbeResult> {
+    if (!this.prismaFin.isEnabled) {
+      return {
+        db: 'finance',
+        status: 'skipped',
+        message: 'DATABASE_URL_FINANCE not set — bc_finance not yet provisioned (SP7.1)',
+      };
+    }
+    return this.pingDb(this.prismaFin, 'finance');
   }
 
   private async pingDb(

--- a/apps/api/src/prisma/prisma-finance.service.ts
+++ b/apps/api/src/prisma/prisma-finance.service.ts
@@ -4,6 +4,13 @@ import { PrismaClient } from '@prisma/client-finance';
 @Injectable()
 export class PrismaFinanceService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(PrismaFinanceService.name);
+  /**
+   * SP7.1 hotfix — bc_finance DB is optional until provisioned.
+   * `false` when DATABASE_URL_FINANCE is unset; consumers should check before
+   * making queries. HealthController reports a 'skipped' status, app boots
+   * normally so Cloud Run revision can become healthy.
+   */
+  public readonly isEnabled: boolean;
 
   constructor() {
     // Same pool-config strategy as PrismaService — append connection_limit + pool_timeout
@@ -20,14 +27,24 @@ export class PrismaFinanceService extends PrismaClient implements OnModuleInit, 
     super({
       log: process.env.NODE_ENV === 'development' ? ['warn', 'error'] : ['error'],
     });
+
+    this.isEnabled = !!dbUrl;
   }
 
   async onModuleInit() {
+    if (!this.isEnabled) {
+      this.logger.warn(
+        'DATABASE_URL_FINANCE not set — PrismaFinanceService is disabled. ' +
+          'SP7.7 migration scripts + cross-entity flows will no-op until bc_finance Cloud SQL provisioned.',
+      );
+      return;
+    }
     await this.$connect();
     this.logger.log('Finance database connected');
   }
 
   async onModuleDestroy() {
+    if (!this.isEnabled) return;
     await this.$disconnect();
     this.logger.log('Finance database disconnected');
   }


### PR DESCRIPTION
PR #1021 unblocked the boot at code-level but Cloud Run still failed:

```
Error: Cannot find module '@prisma/client-finance'
  at apps/api/dist/src/prisma/prisma-finance.service.js:15
```

Root cause: matches the PR #1010 Phase 2 hotfix pattern. The finance Prisma schema generator outputs to `apps/api/node_modules/@prisma/client-finance`, but the Dockerfile copies `apps/api/node_modules` from the **deps** stage (before generate). Builder stage runs generate but its post-generate node_modules never reaches the runtime image.

Fix: explicit `COPY --from=builder` for both the generated client + the prisma-finance/ schema directory (the latter needed if the entrypoint runs `prisma migrate deploy` for the finance side later).

Production currently still serving on previous Cloud Run revision (PR #1020 + #1021 deploys both failed in this step — old revision kept serving).