### PR TITLE
feat(sidebar): pull "รายงาน" out as top-level group + dedupe accounting menu

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.4",
+  "version": "26.5.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -78,17 +78,18 @@ describe('getSidebarForRole — populated ZONE_CONFIG', () => {
       'owner-overview',
       'owner-inventory',
       'owner-sales',
-      'owner-drafts',
       'owner-collection',
       'owner-online-shop',
+      'owner-shop-accounting',
       'owner-marketing',
     ]);
   });
 
   it('OWNER fin sections include all FIN-zone keys (regression guard)', () => {
     const keys = getSidebarForRole('OWNER', 'fin').map((s) => s.key);
-    // Order should be: accounting, tax, statements, bank, asset, fin-tools
+    // Order should be: accounting, reports, tax, statements, bank, asset, fin-tools
     expect(keys).toContain('owner-accounting');
+    expect(keys).toContain('owner-reports');
     expect(keys).toContain('owner-tax');
     expect(keys).toContain('owner-statements');
     expect(keys).toContain('owner-bank');

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -551,7 +551,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
     },
     {
       key: 'owner-accounting',
-      label: 'บัญชี & รายงาน',
+      label: 'บัญชี',
       icon: Calculator,
       zone: 'fin',
       items: [
@@ -559,27 +559,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
         { label: 'รายจ่าย', path: '/expenses', icon: Receipt },
         { label: 'รายได้อื่น', path: '/other-income', icon: TrendingUp },
-        { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
-        // SP6 — Bank/Cash account directory (mirrors CoA 11-1101..1203)
-        { label: 'บัญชีเงินสด/ธนาคาร', path: '/finance/bank-accounts', icon: Landmark },
-        // Reports & period-close grouped under collapsible parents
-        {
-          label: 'รายงาน',
-          path: '/reports',
-          icon: BarChart3,
-          children: [
-            { label: 'รายงานรวม', path: '/reports', icon: BarChart3 },
-            { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote },
-            { label: 'งบ Equity', path: '/finance/equity-statement', icon: Landmark },
-            { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
-            { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
-            // SP3 — Tax module split
-            { label: 'ภ.พ.30 (VAT)', path: '/finance/vat', icon: Calculator },
-            { label: 'ภ.ง.ด. 1/3/53 (WHT)', path: '/finance/wht', icon: Calculator },
-            { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText },
-            { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
-          ],
-        },
+        // Period-close grouped under collapsible parent
         {
           label: 'ปิดบัญชี',
           path: '/monthly-close',
@@ -593,6 +573,28 @@ const OWNER_CONFIG: RoleMenuConfig = {
             { label: 'ส่งออก PEAK CSV', path: '/finance/peak-export', icon: Plug },
           ],
         },
+      ],
+    },
+    {
+      // Promoted from collapsible inside "บัญชี & รายงาน" — owner directive
+      // "ดึงรายงานออกมา" (find-menu friction reduction follow-up to PR #849).
+      // Items intentionally mirror entries in owner-tax / owner-statements
+      // — this is the curated report index for one-click discovery.
+      key: 'owner-reports',
+      label: 'รายงาน',
+      icon: BarChart3,
+      zone: 'fin',
+      items: [
+        { label: 'รายงานรวม', path: '/reports', icon: BarChart3 },
+        { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote },
+        { label: 'งบ Equity', path: '/finance/equity-statement', icon: Landmark },
+        { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
+        { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
+        // SP3 — Tax module split
+        { label: 'ภ.พ.30 (VAT)', path: '/finance/vat', icon: Calculator },
+        { label: 'ภ.ง.ด. 1/3/53 (WHT)', path: '/finance/wht', icon: Calculator },
+        { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText },
+        { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
       ],
     },
     {
@@ -654,12 +656,9 @@ const OWNER_CONFIG: RoleMenuConfig = {
       icon: Landmark,
       zone: 'fin',
       items: [
-        {
-          label: 'บัญชีธนาคาร',
-          path: '/finance/bank-accounts',
-          icon: Landmark,
-          placeholder: { trackingSP: 'SP6', eta: 'ภายในไตรมาส 4/2026' },
-        },
+        { label: 'ผังบัญชี', path: '/settings/chart-of-accounts', icon: ClipboardList },
+        // SP6 — Bank/Cash account directory (mirrors CoA 11-1101..1203)
+        { label: 'บัญชีเงินสด/ธนาคาร', path: '/finance/bank-accounts', icon: Landmark },
       ],
     },
     {


### PR DESCRIPTION
## Summary

Owner directive (this session) — follow-up to PR #849 (OWNER sidebar declutter):

1. **"รายงาน" promoted** from collapsible inside "บัญชี & รายงาน" to its own top-level section in FINANCE zone. All 9 report entries (รายงานรวม / 3 statements / commissions / 3 tax forms / audit) now visible at one click — no accordion expansion needed.
2. **"บัญชี & รายงาน" → "บัญชี"** (reports moved out).
3. **ผังบัญชี + บัญชีเงินสด/ธนาคาร** moved out of "บัญชี" → into the existing **"ผังบัญชี + ธนาคาร"** section. Eliminates the dup the owner spotted ("ทำไมยังอยู่ในเมนูบัญชีอยู่เพราะมีเมนูแยกแล้ว"). Also removes stale SP6 placeholder since `/finance/bank-accounts` is live.
4. **menu.test.ts** regression guard fix: removed stale `owner-drafts` + added `owner-shop-accounting` (drift from P3-SP5 #1016) + added `owner-reports` to FIN-zone assertions.

Web version `26.5.4 → 26.5.5` for deploy event trigger (per memory pattern from PR #850/#853).

**Affects:** OWNER role only. FM + ACCOUNTANT keep their combined "บัญชี & รายงาน" since their report items are already flat (not nested in a collapsible).

## FINANCE zone after this PR

| กลุ่ม | รายการ |
|-------|--------|
| **บัญชี** | รับชำระค่างวด · รายจ่าย · รายได้อื่น · ▼ ปิดบัญชี |
| **รายงาน** ⬅️ ใหม่ | รายงานรวม · 3 งบ · ค่าคอม · VAT · WHT · e-Tax · ตรวจสอบบัญชี |
| **ภาษี** | (เดิม) |
| **งบการเงิน** | (เดิม) |
| **ผังบัญชี + ธนาคาร** ⬅️ เพิ่มของจริง | ผังบัญชี · บัญชีเงินสด/ธนาคาร |
| **สินทรัพย์** | (เดิม) |
| **เครื่องมือไฟแนนซ์** | (เดิม) |

## Test plan
- [x] TypeScript: 0 errors
- [x] menu.test.ts: 19/19 pass (was 18/19 on main — fixed pre-existing `owner-drafts` drift)
- [x] ESLint: 0 errors
- [x] Web build: success
- [ ] After merge: verify auto-deploy via Cloud Run + Firebase
- [ ] After deploy: visual check on `bestchoicephone.app/?zone=fin` as OWNER

🤖 Generated with [Claude Code](https://claude.com/claude-code)