### PR TITLE
feat(sidebar): add 15 CSV-driven placeholder routes for FINANCE menu

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.7",
+  "version": "26.5.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1423,6 +1423,131 @@ function App() {
               </ProtectedRoute>
             }
           />
+          {/* ── FIN menu CSV-driven placeholders (15 routes) ─────────
+              Owner CSV indicated these need to be reachable as menu
+              entries even before backend impl. ComingSoonPage handles
+              the user landing while SP2/3/4/5/6 ship their UIs. */}
+          <Route
+            path="/finance/contract-cancellation"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="เอกสารยกเลิกสัญญา" trackingSP="SP5" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/balance-sheet"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="งบดุล (Balance Sheet)" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/aging-report"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="รายงานลูกหนี้ + วิเคราะห์อายุหนี้ (Aging)" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/general-journal"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="สมุดรายวันทั่วไป" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/bad-debt-report"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="รายงานหนี้สูญ" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/intercompany-report"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="รายงานลูกหนี้ Inter-co (FINANCE ↔ SHOP)" trackingSP="SP6" eta="ภายในไตรมาส 4/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/e-receipt-auto"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ" trackingSP="SP3" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          {/* ตั้งค่าเอกสาร — 8 doc-type sub-pages (CSV §8 sub-grouping) */}
+          <Route
+            path="/settings/document-config/deposit-receipt"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่าใบรับเงินมัดจำ" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/document-config/receipt"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่าใบเสร็จรับเงิน" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/document-config/credit-note"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่าใบลดหนี้" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/document-config/purchase-order"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่าใบสั่งซื้อ (PO)" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/document-config/expense-doc"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่าเอกสารค่าใช้จ่าย" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/document-config/credit-note-received"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่ารับใบลดหนี้" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/document-config/payment-summary"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่าใบรวมจ่าย" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/document-config/asset-purchase"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ComingSoonPage feature="ตั้งค่าเอกสารซื้อสินทรัพย์" trackingSP="SP4" eta="ภายในไตรมาส 3/2026" />
+              </ProtectedRoute>
+            }
+          />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -568,6 +568,8 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'เปลี่ยนเครื่องเสีย (7 วัน)', path: '/defect-exchange', icon: Wrench },
         { label: 'ล็อคเครื่อง (MDM)', path: '/mdm', icon: Lock },
         { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
+        // CSV §2 placeholder — owner-flagged ✏ "ต้องสร้าง"
+        { label: 'เอกสารยกเลิกสัญญา', path: '/finance/contract-cancellation', icon: FileText, placeholder: { trackingSP: 'SP5', eta: 'ภายในไตรมาส 3/2026' } },
       ],
     },
     {
@@ -615,6 +617,8 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'ปิดบัญชีรายเดือน', path: '/monthly-close', icon: CalendarDays },
         { label: 'ปิดบัญชีสิ้นปี', path: '/finance/year-end-closing', icon: CalendarDays },
         { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
+        // CSV §5 — "งบ 4 ประเภท" (full 4-statement set per TFRS)
+        { label: 'งบดุล (Balance Sheet)', path: '/finance/balance-sheet', icon: PieChart, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'กำไร-ขาดทุน (P&L)', path: '/profit-loss', icon: PieChart },
         { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'งบ Equity', path: '/finance/equity-statement', icon: BarChart3, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
@@ -627,7 +631,12 @@ const OWNER_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'รายงานรวม', path: '/reports', icon: BarChart3 },
+        // CSV §6 placeholders — flagged "ต้องสร้าง"
+        { label: 'รายงานลูกหนี้ + Aging', path: '/finance/aging-report', icon: AlertTriangle, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'รายงานลูกหนี้ Inter-co', path: '/finance/intercompany-report', icon: Building2, placeholder: { trackingSP: 'SP6', eta: 'ภายในไตรมาส 4/2026' } },
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
         { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
         // P3-SP3 — PEAK CSV export (mapping config lives in /settings#peak-mapping)
@@ -649,12 +658,36 @@ const OWNER_CONFIG: RoleMenuConfig = {
       // MOVED from `zone: 'settings'` → `zone: 'fin'` per CSV §8.
       // SystemConfig backend (D1.1.2.x) is shared but UX-wise this is a
       // finance-team config, so it belongs in the FIN zone for OWNER.
+      // CSV §8 sub-grouping: รายรับ (3 doc types) + รายจ่าย (5 doc types).
+      // Sub-items are placeholders — backend config UI per doc type pending.
       key: 'owner-doc-config',
       label: 'ตั้งค่าเอกสาร',
       icon: FileText,
       zone: 'fin',
       items: [
         { label: 'เลขที่/รูปแบบเอกสาร', path: '/settings/document-config', icon: FileText },
+        {
+          label: 'เอกสารรายรับ',
+          path: '/settings/document-config/revenue',
+          icon: TrendingUp,
+          children: [
+            { label: 'ใบรับเงินมัดจำ', path: '/settings/document-config/deposit-receipt', icon: Receipt, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+            { label: 'ใบเสร็จรับเงิน', path: '/settings/document-config/receipt', icon: ReceiptText, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+            { label: 'ใบลดหนี้', path: '/settings/document-config/credit-note', icon: FileText, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+          ],
+        },
+        {
+          label: 'เอกสารรายจ่าย',
+          path: '/settings/document-config/expense',
+          icon: TrendingDown,
+          children: [
+            { label: 'ใบสั่งซื้อ (PO)', path: '/settings/document-config/purchase-order', icon: ClipboardList, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+            { label: 'ค่าใช้จ่าย', path: '/settings/document-config/expense-doc', icon: Receipt, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+            { label: 'รับใบลดหนี้', path: '/settings/document-config/credit-note-received', icon: FileText, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+            { label: 'ใบรวมจ่าย', path: '/settings/document-config/payment-summary', icon: FileText, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+            { label: 'ซื้อสินทรัพย์', path: '/settings/document-config/asset-purchase', icon: Landmark, placeholder: { trackingSP: 'SP4', eta: 'ภายในไตรมาส 3/2026' } },
+          ],
+        },
       ],
     },
     {
@@ -739,6 +772,8 @@ const OWNER_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'Dunning (เตือนค่างวด)', path: '/settings/dunning', icon: Bell },
+        // CSV §10 placeholder — "แจ้งสร้างอีเล็คทรอนิกส์รอบอินส์" = auto e-receipt
+        { label: 'ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ', path: '/finance/e-receipt-auto', icon: FileText, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
       ],
     },
     {


### PR DESCRIPTION
## Summary

Owner CSV called for menu items without backend implementations — ship them now as visible entries pointing to ComingSoonPage so users see the full target structure.

## Added (FINANCE zone, OWNER role)

| Section | Item | Route | SP |
|---|---|---|---|
| รายรับ | เอกสารยกเลิกสัญญา | /finance/contract-cancellation | SP5 |
| บัญชี+งบ | **งบดุล (Balance Sheet)** | /finance/balance-sheet | SP2 |
| รายงาน | รายงานลูกหนี้ + Aging | /finance/aging-report | SP2 |
| รายงาน | สมุดรายวัน | /finance/general-journal | SP2 |
| รายงาน | รายงานหนี้สูญ | /finance/bad-debt-report | SP2 |
| รายงาน | รายงานลูกหนี้ Inter-co | /finance/intercompany-report | SP6 |
| ตั้งค่าเอกสาร | ▼ เอกสารรายรับ (3 sub) | /settings/document-config/{deposit-receipt,receipt,credit-note} | SP4 |
| ตั้งค่าเอกสาร | ▼ เอกสารรายจ่าย (5 sub) | /settings/document-config/{purchase-order,expense-doc,credit-note-received,payment-summary,asset-purchase} | SP4 |
| การแจ้งเตือน | ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ | /finance/e-receipt-auto | SP3 |

**Total: 15 new ComingSoonPage routes** + 2 sub-group restructures.

Notable: Balance Sheet was inadvertently omitted in PR #1025 (CSV §5 says "งบ 4 ประเภท" but only P&L/Cash Flow/Equity were added). Fixed here.

## Deferred

- **เบิกลงทุน** (CSV §5) — unclear flow, needs owner clarification
- **เอกสารใช้ในให้ทำระดับ** (CSV §2) — OCR-unclear text
- **VAT Auto Journal / WHT summary** — CSV §4 marked "⚠️ ต้องเพิ่ม" but these need backend impl beyond placeholder
- **Dashboard widgets** (Aging summary, ติดตามหนี้วันนี้ alert) — UI work in dashboard not menu

Web version \`26.5.7 → 26.5.8\`.

## Test plan
- [x] TypeScript: 0 errors
- [x] Vitest: 29/29 (menu config + Sidebar layout)
- [x] ESLint: 0 errors
- [x] Vite build: success
- [ ] After merge: visual check that all 15 menu items appear + clicking each shows ComingSoonPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)