### PR TITLE
feat(p4-sp1): งบการเงิน + รายงานบัญชี (7 pages)

### DIFF
--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -180,6 +180,22 @@ export class AccountingController {
     res.end(result.csv);
   }
 
+  @Get('ledger/general-journal')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getGeneralJournal(
+    @Query('start') start: string,
+    @Query('end') end: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('companyId') companyId?: string,
+  ) {
+    return this.service.getGeneralJournal(new Date(start), new Date(end), {
+      page: page ? parseInt(page, 10) : 1,
+      limit: limit ? parseInt(limit, 10) : 50,
+      companyId,
+    });
+  }
+
   @Get('ledger/general-ledger')
   @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   getGeneralLedger(

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -109,6 +109,14 @@ export class AccountingController {
     return this.service.getBalanceSheetFromJournal(asOfDate ? new Date(asOfDate) : undefined);
   }
 
+  // ─── P4-SP1: Aging Report ────────────────────────────────────────────────
+
+  @Get('ledger/aging')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getAgingReport(@Query('asOf') asOf?: string) {
+    return this.service.getAgingReport(asOf ? new Date(asOf) : new Date());
+  }
+
   // Balance Sheet & Cash Flow endpoints are in ReportsController (/reports/balance-sheet, /reports/cash-flow)
   // to avoid duplicate routes. See reports.controller.ts.
 

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -117,6 +117,18 @@ export class AccountingController {
     return this.service.getAgingReport(asOf ? new Date(asOf) : new Date());
   }
 
+  // ─── P4-SP1: Bad Debt Report ──────────────────────────────────────────────
+
+  @Get('ledger/bad-debt')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getBadDebtReport(
+    @Query('start') start: string,
+    @Query('end') end: string,
+    @Query('companyId') companyId?: string,
+  ) {
+    return this.service.getBadDebtReport(new Date(start), new Date(end), companyId);
+  }
+
   // Balance Sheet & Cash Flow endpoints are in ReportsController (/reports/balance-sheet, /reports/cash-flow)
   // to avoid duplicate routes. See reports.controller.ts.
 

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -89,6 +89,7 @@ describe('AccountingService', () => {
       journalEntry: {
         findFirst: jest.fn().mockResolvedValue(null),
         findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
       },
       journalLine: {
         groupBy: jest.fn().mockResolvedValue([]),
@@ -1235,6 +1236,58 @@ describe('AccountingService', () => {
       );
       // Only S41-1101 counted, 41-1101 ignored by the prefix check.
       expect(result.revenue.total.toNumber()).toBe(1000);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // getGeneralJournal
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('getGeneralJournal', () => {
+    it('returns JournalEntry list with lines, sorted by postedAt desc, paged', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      const result = await service.getGeneralJournal(start, end, { page: 1, limit: 50 });
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('total');
+      // Empty mock DB — shape assertions only
+      if (result.data.length > 0) {
+        expect(result.data[0]).toHaveProperty('lines');
+        // sorted desc by postedAt
+        for (let i = 1; i < result.data.length; i++) {
+          const prev = result.data[i - 1].postedAt;
+          const curr = result.data[i].postedAt;
+          if (prev != null && curr != null) {
+            expect(new Date(prev).getTime()).toBeGreaterThanOrEqual(new Date(curr).getTime());
+          }
+        }
+      }
+    });
+
+    it('returns correct pagination shape', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      const result = await service.getGeneralJournal(start, end, { page: 2, limit: 25 });
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(25);
+      expect(result.total).toBe(0);
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('filters by companyId when provided', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      await service.getGeneralJournal(start, end, { companyId: 'co-123' });
+      const call = prisma.journalEntry.findMany.mock.calls.at(-1)[0];
+      expect(call.where.companyId).toBe('co-123');
+    });
+
+    it('does not include deleted entries', async () => {
+      const start = new Date('2026-05-01');
+      const end = new Date('2026-05-31');
+      await service.getGeneralJournal(start, end);
+      const call = prisma.journalEntry.findMany.mock.calls.at(-1)[0];
+      expect(call.where.deletedAt).toBeNull();
     });
   });
 });

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -1330,6 +1330,117 @@ describe('AccountingService', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // getBadDebtReport
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('getBadDebtReport', () => {
+    const periodStart = new Date('2026-01-01');
+    const periodEnd = new Date('2026-01-31');
+
+    const makeJournalLine = (debit: number, overrides?: Record<string, unknown>) => ({
+      accountCode: '51-1102',
+      debit: new Prisma.Decimal(debit),
+      credit: new Prisma.Decimal(0),
+      description: 'หนี้สูญ',
+      journalEntry: {
+        id: 'je-1',
+        entryNumber: 'JP5-20260115-0001',
+        description: 'ยึดเครื่อง',
+        postedAt: new Date('2026-01-15'),
+        referenceType: 'REPOSSESSION',
+        referenceId: 'repo-1',
+        ...overrides,
+      },
+    });
+
+    beforeEach(() => {
+      prisma.journalLine.findMany.mockResolvedValue([]);
+    });
+
+    it('returns correct shape with period, totalBadDebt, and entries', async () => {
+      const result = await service.getBadDebtReport(periodStart, periodEnd);
+      expect(result).toHaveProperty('period');
+      expect(result.period.start).toEqual(periodStart);
+      expect(result.period.end).toEqual(periodEnd);
+      expect(result).toHaveProperty('totalBadDebt');
+      expect(result).toHaveProperty('entries');
+      expect(Array.isArray(result.entries)).toBe(true);
+    });
+
+    it('returns totalBadDebt=0 and empty entries when no 51-1102 lines exist', async () => {
+      prisma.journalLine.findMany.mockResolvedValueOnce([]);
+      const result = await service.getBadDebtReport(periodStart, periodEnd);
+      expect(result.totalBadDebt).toBe(0);
+      expect(result.entries).toHaveLength(0);
+    });
+
+    it('sums debit amounts correctly across multiple lines', async () => {
+      prisma.journalLine.findMany.mockResolvedValueOnce([
+        makeJournalLine(5000),
+        makeJournalLine(3000),
+        makeJournalLine(2000),
+      ]);
+      const result = await service.getBadDebtReport(periodStart, periodEnd);
+      expect(result.totalBadDebt).toBeCloseTo(10000, 2);
+      expect(result.entries).toHaveLength(3);
+    });
+
+    it('queries only account 51-1102 lines within the period', async () => {
+      await service.getBadDebtReport(periodStart, periodEnd);
+      const call = prisma.journalLine.findMany.mock.calls.at(-1)[0];
+      expect(call.where.accountCode).toBe('51-1102');
+      expect(call.where.journalEntry.postedAt.gte).toEqual(periodStart);
+      expect(call.where.journalEntry.postedAt.lte).toEqual(periodEnd);
+      expect(call.where.journalEntry.deletedAt).toBeNull();
+    });
+
+    it('filters by companyId when provided', async () => {
+      await service.getBadDebtReport(periodStart, periodEnd, 'co-FINANCE');
+      const call = prisma.journalLine.findMany.mock.calls.at(-1)[0];
+      expect(call.where.journalEntry.companyId).toBe('co-FINANCE');
+    });
+
+    it('omits companyId filter when not provided', async () => {
+      await service.getBadDebtReport(periodStart, periodEnd);
+      const call = prisma.journalLine.findMany.mock.calls.at(-1)[0];
+      expect(call.where.journalEntry).not.toHaveProperty('companyId');
+    });
+
+    it('maps entry fields correctly from journalLine and journalEntry', async () => {
+      prisma.journalLine.findMany.mockResolvedValueOnce([makeJournalLine(7500)]);
+      const result = await service.getBadDebtReport(periodStart, periodEnd);
+      const entry = result.entries[0];
+      expect(entry.journalEntryId).toBe('je-1');
+      // entryNumber is exposed as documentNumber in the response
+      expect(entry.documentNumber).toBe('JP5-20260115-0001');
+      expect(entry.amount).toBeCloseTo(7500, 2);
+      // referenceType is exposed as sourceType in the response
+      expect(entry.sourceType).toBe('REPOSSESSION');
+      // referenceId is exposed as sourceId in the response
+      expect(entry.sourceId).toBe('repo-1');
+    });
+
+    it('falls back to journalEntry.description when line description is null', async () => {
+      prisma.journalLine.findMany.mockResolvedValueOnce([
+        {
+          ...makeJournalLine(1000),
+          description: null,
+          journalEntry: {
+            id: 'je-2',
+            entryNumber: 'JP5-20260120-0001',
+            description: 'entry-level description',
+            postedAt: new Date('2026-01-20'),
+            referenceType: 'REPOSSESSION',
+            referenceId: 'repo-2',
+          },
+        },
+      ]);
+      const result = await service.getBadDebtReport(periodStart, periodEnd);
+      expect(result.entries[0].description).toBe('entry-level description');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // getGeneralJournal
   // ═══════════════════════════════════════════════════════════════════════════
 

--- a/apps/api/src/modules/accounting/accounting.service.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.service.spec.ts
@@ -1240,6 +1240,96 @@ describe('AccountingService', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // getAgingReport
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('getAgingReport', () => {
+    it('returns customer-by-customer aging with buckets 0-30/31-60/61-90/90+', async () => {
+      const result = await service.getAgingReport(new Date('2026-05-19'));
+      expect(result.summary).toHaveProperty('bucket_0_30');
+      expect(result.summary).toHaveProperty('bucket_31_60');
+      expect(result.summary).toHaveProperty('bucket_61_90');
+      expect(result.summary).toHaveProperty('bucket_90_plus');
+      expect(result.customers).toBeInstanceOf(Array);
+      if (result.customers.length > 0) {
+        expect(result.customers[0]).toHaveProperty('customerId');
+        expect(result.customers[0]).toHaveProperty('totalOverdue');
+        expect(result.customers[0]).toHaveProperty('bucket');
+      }
+    });
+
+    it('returns empty customers and zero summary when no overdue payments exist', async () => {
+      prisma.payment.findMany.mockResolvedValueOnce([]);
+      const result = await service.getAgingReport(new Date('2026-05-19'));
+      expect(result.customers).toHaveLength(0);
+      expect(result.summary.bucket_0_30).toBe(0);
+      expect(result.summary.bucket_31_60).toBe(0);
+      expect(result.summary.bucket_61_90).toBe(0);
+      expect(result.summary.bucket_90_plus).toBe(0);
+    });
+
+    it('correctly buckets a payment that is 45 days overdue into bucket_31_60', async () => {
+      const asOf = new Date('2026-05-19');
+      const dueDate = new Date('2026-04-04'); // 45 days before asOf
+      prisma.payment.findMany.mockResolvedValueOnce([
+        {
+          id: 'pay-1',
+          dueDate,
+          amountDue: new Prisma.Decimal(1500),
+          amountPaid: new Prisma.Decimal(0),
+          status: 'OVERDUE',
+          contract: {
+            customer: {
+              id: 'cust-1',
+              name: 'สมชาย ใจดี',
+              phone: '0812345678',
+            },
+          },
+        },
+      ]);
+      const result = await service.getAgingReport(asOf);
+      expect(result.summary.bucket_31_60).toBeCloseTo(1500, 2);
+      expect(result.summary.bucket_0_30).toBe(0);
+      expect(result.customers).toHaveLength(1);
+      expect(result.customers[0].customerName).toBe('สมชาย ใจดี');
+      expect(result.customers[0].bucket).toBe('bucket_31_60');
+    });
+
+    it('skips payments where remaining balance is zero', async () => {
+      const asOf = new Date('2026-05-19');
+      const dueDate = new Date('2026-04-01'); // overdue
+      prisma.payment.findMany.mockResolvedValueOnce([
+        {
+          id: 'pay-2',
+          dueDate,
+          amountDue: new Prisma.Decimal(1500),
+          amountPaid: new Prisma.Decimal(1500), // fully paid
+          status: 'PENDING',
+          contract: {
+            customer: { id: 'cust-2', name: 'มานะ ดี', phone: '0899999999' },
+          },
+        },
+      ]);
+      const result = await service.getAgingReport(asOf);
+      expect(result.customers).toHaveLength(0);
+    });
+
+    it('queries payment.findMany with deletedAt: null filter', async () => {
+      await service.getAgingReport(new Date('2026-05-19'));
+      const call = prisma.payment.findMany.mock.calls.at(-1)[0];
+      expect(call.where.deletedAt).toBeNull();
+      expect(call.where.status.in).toContain('PENDING');
+      expect(call.where.status.in).toContain('OVERDUE');
+    });
+
+    it('returns asOf in the response', async () => {
+      const asOf = new Date('2026-05-19');
+      const result = await service.getAgingReport(asOf);
+      expect(result.asOf).toEqual(asOf);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // getGeneralJournal
   // ═══════════════════════════════════════════════════════════════════════════
 

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -2042,4 +2042,89 @@ export class AccountingService implements OnModuleInit {
     ]);
     return { data, total, page, limit };
   }
+
+  // ─── P4-SP1: Aging Report ────────────────────────────────────────────────
+
+  async getAgingReport(asOf: Date) {
+    const overduePayments = await this.prisma.payment.findMany({
+      where: {
+        status: { in: ['PENDING', 'OVERDUE'] },
+        dueDate: { lt: asOf },
+        deletedAt: null,
+      },
+      include: {
+        contract: {
+          include: {
+            customer: {
+              select: { id: true, name: true, phone: true },
+            },
+          },
+        },
+      },
+    });
+
+    const summary = {
+      bucket_0_30: 0,
+      bucket_31_60: 0,
+      bucket_61_90: 0,
+      bucket_90_plus: 0,
+    };
+
+    const customerMap = new Map<
+      string,
+      {
+        customerId: string;
+        customerName: string;
+        phone: string;
+        totalOverdue: number;
+        daysOverdue: number;
+        bucket: string;
+        contracts: number;
+      }
+    >();
+
+    const calcBucket = (days: number): keyof typeof summary => {
+      if (days <= 30) return 'bucket_0_30';
+      if (days <= 60) return 'bucket_31_60';
+      if (days <= 90) return 'bucket_61_90';
+      return 'bucket_90_plus';
+    };
+
+    for (const p of overduePayments) {
+      const daysOverdue = Math.floor(
+        (asOf.getTime() - p.dueDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      const remaining = Number(p.amountDue) - Number(p.amountPaid ?? 0);
+      if (remaining <= 0) continue;
+
+      const bucket = calcBucket(daysOverdue);
+      summary[bucket] += remaining;
+
+      const cid = p.contract.customer.id;
+      const existing = customerMap.get(cid);
+      if (existing) {
+        existing.totalOverdue += remaining;
+        existing.daysOverdue = Math.max(existing.daysOverdue, daysOverdue);
+        existing.bucket = calcBucket(existing.daysOverdue);
+      } else {
+        customerMap.set(cid, {
+          customerId: cid,
+          customerName: p.contract.customer.name,
+          phone: p.contract.customer.phone ?? '',
+          totalOverdue: remaining,
+          daysOverdue,
+          bucket,
+          contracts: 1,
+        });
+      }
+    }
+
+    return {
+      asOf,
+      summary,
+      customers: Array.from(customerMap.values()).sort(
+        (a, b) => b.daysOverdue - a.daysOverdue,
+      ),
+    };
+  }
 }

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -2127,4 +2127,55 @@ export class AccountingService implements OnModuleInit {
       ),
     };
   }
+
+  // ─── P4-SP1 Task 3: Bad Debt Report ─────────────────────────────────────────
+
+  /**
+   * Returns journal lines posted to account 51-1102 (หนี้สูญ/ขาดทุนจากยึดเครื่อง)
+   * within the given period. Used by BadDebtReportPage to display write-off history.
+   *
+   * Per .claude/rules/accounting.md:
+   *   51-1102 = หนี้สูญ/ขาดทุนจากยึดเครื่อง (RepossessionJP5Template loss branch)
+   */
+  async getBadDebtReport(periodStart: Date, periodEnd: Date, companyId?: string) {
+    const lines = await this.prisma.journalLine.findMany({
+      where: {
+        accountCode: '51-1102',
+        journalEntry: {
+          postedAt: { gte: periodStart, lte: periodEnd },
+          deletedAt: null,
+          ...(companyId ? { companyId } : {}),
+        },
+      },
+      include: {
+        journalEntry: {
+          select: {
+            id: true,
+            entryNumber: true,
+            description: true,
+            postedAt: true,
+            referenceType: true,
+            referenceId: true,
+          },
+        },
+      },
+      orderBy: { journalEntry: { postedAt: 'desc' } },
+    });
+
+    const total = lines.reduce((sum, l) => sum + Number(l.debit ?? 0), 0);
+
+    return {
+      period: { start: periodStart, end: periodEnd },
+      totalBadDebt: total,
+      entries: lines.map((l) => ({
+        journalEntryId: l.journalEntry.id,
+        documentNumber: l.journalEntry.entryNumber,
+        postedAt: l.journalEntry.postedAt,
+        description: l.description ?? l.journalEntry.description,
+        amount: Number(l.debit ?? 0),
+        sourceType: l.journalEntry.referenceType,
+        sourceId: l.journalEntry.referenceId,
+      })),
+    };
+  }
 }

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -1999,4 +1999,47 @@ export class AccountingService implements OnModuleInit {
       skippedLineCount: skipped,
     };
   }
+
+  // ─── General Journal ──────────────────────────────────────────────────────
+
+  /**
+   * Returns a paginated list of JournalEntries within the given date range,
+   * ordered by postedAt descending, with their lines included.
+   *
+   * Used by the GeneralJournalPage (P4-SP1, Task 7).
+   */
+  async getGeneralJournal(
+    periodStart: Date,
+    periodEnd: Date,
+    opts: { page?: number; limit?: number; companyId?: string } = {},
+  ) {
+    const page = opts.page ?? 1;
+    const limit = opts.limit ?? 50;
+    const where = {
+      postedAt: { gte: periodStart, lte: periodEnd },
+      deletedAt: null,
+      ...(opts.companyId ? { companyId: opts.companyId } : {}),
+    };
+    const [data, total] = await Promise.all([
+      this.prisma.journalEntry.findMany({
+        where,
+        include: {
+          lines: {
+            select: {
+              accountCode: true,
+              debit: true,
+              credit: true,
+              description: true,
+            },
+            orderBy: { id: 'asc' },
+          },
+        },
+        orderBy: { postedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.journalEntry.count({ where }),
+    ]);
+    return { data, total, page, limit };
+  }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.8",
+  "version": "26.5.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1342,18 +1342,7 @@ function App() {
             }
           />
           {/* /finance/cash-flow — handled by SP2 CashFlowPage route above (line ~763) */}
-          <Route
-            path="/finance/equity-statement"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage
-                  feature="งบแสดงการเปลี่ยนแปลงในส่วนของผู้ถือหุ้น"
-                  trackingSP="SP2"
-                  eta="ภายในไตรมาส 2/2026"
-                />
-              </ProtectedRoute>
-            }
-          />
+          {/* /finance/equity-statement — handled by SP2 EquityStatementPage route above (line ~773) */}
           <Route
             path="/finance/general-ledger"
             element={

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -170,6 +170,8 @@ const EquityStatementPage = lazy(() =>
 const GeneralLedgerPage = lazy(() =>
   import('@/pages/GeneralLedgerPage').then((m) => ({ default: m.GeneralLedgerPage })),
 );
+// P4-SP1 — Financial report pages
+const BalanceSheetPage = lazy(() => import('@/pages/finance/BalanceSheetPage'));
 const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
 const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
@@ -1439,7 +1441,7 @@ function App() {
             path="/finance/balance-sheet"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage feature="งบดุล (Balance Sheet)" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+                <BalanceSheetPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -173,6 +173,7 @@ const GeneralLedgerPage = lazy(() =>
 // P4-SP1 — Financial report pages
 const BalanceSheetPage = lazy(() => import('@/pages/finance/BalanceSheetPage'));
 const GeneralJournalPage = lazy(() => import('@/pages/finance/GeneralJournalPage'));
+const AgingReportPage = lazy(() => import('@/pages/finance/AgingReportPage'));
 const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
 const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
@@ -1417,7 +1418,7 @@ function App() {
             path="/finance/aging-report"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage feature="รายงานลูกหนี้ + วิเคราะห์อายุหนี้ (Aging)" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+                <AgingReportPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -172,6 +172,7 @@ const GeneralLedgerPage = lazy(() =>
 );
 // P4-SP1 — Financial report pages
 const BalanceSheetPage = lazy(() => import('@/pages/finance/BalanceSheetPage'));
+const GeneralJournalPage = lazy(() => import('@/pages/finance/GeneralJournalPage'));
 const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
 const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
@@ -1435,7 +1436,7 @@ function App() {
             path="/finance/general-journal"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage feature="สมุดรายวันทั่วไป" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+                <GeneralJournalPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -174,6 +174,7 @@ const GeneralLedgerPage = lazy(() =>
 const BalanceSheetPage = lazy(() => import('@/pages/finance/BalanceSheetPage'));
 const GeneralJournalPage = lazy(() => import('@/pages/finance/GeneralJournalPage'));
 const AgingReportPage = lazy(() => import('@/pages/finance/AgingReportPage'));
+const BadDebtReportPage = lazy(() => import('@/pages/finance/BadDebtReportPage'));
 const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
 const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
@@ -1434,7 +1435,7 @@ function App() {
             path="/finance/bad-debt-report"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage feature="รายงานหนี้สูญ" trackingSP="SP2" eta="ภายในไตรมาส 2/2026" />
+                <BadDebtReportPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1344,18 +1344,7 @@ function App() {
           />
           {/* /finance/cash-flow — handled by SP2 CashFlowPage route above (line ~763) */}
           {/* /finance/equity-statement — handled by SP2 EquityStatementPage route above (line ~773) */}
-          <Route
-            path="/finance/general-ledger"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage
-                  feature="สมุดแยกประเภท"
-                  trackingSP="SP2"
-                  eta="ภายในไตรมาส 2/2026"
-                />
-              </ProtectedRoute>
-            }
-          />
+          {/* /finance/general-ledger — handled by SP2 GeneralLedgerPage route above (line ~780) */}
           <Route
             path="/finance/bank-accounts"
             element={

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1341,18 +1341,7 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/finance/cash-flow"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage
-                  feature="งบกระแสเงินสด"
-                  trackingSP="SP2"
-                  eta="ภายในไตรมาส 2/2026"
-                />
-              </ProtectedRoute>
-            }
-          />
+          {/* /finance/cash-flow — handled by SP2 CashFlowPage route above (line ~763) */}
           <Route
             path="/finance/equity-statement"
             element={

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -449,9 +449,9 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'กำไร-ขาดทุน (P&L)', path: '/profit-loss', icon: PieChart },
-        { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: TrendingUp, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
-        { label: 'งบ Equity', path: '/finance/equity-statement', icon: BarChart3, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
-        { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: TrendingUp },
+        { label: 'งบ Equity', path: '/finance/equity-statement', icon: BarChart3 },
+        { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
       ],
     },
     {
@@ -620,8 +620,8 @@ const OWNER_CONFIG: RoleMenuConfig = {
         // CSV §5 — "งบ 4 ประเภท" (full 4-statement set per TFRS)
         { label: 'งบดุล (Balance Sheet)', path: '/finance/balance-sheet', icon: PieChart },
         { label: 'กำไร-ขาดทุน (P&L)', path: '/profit-loss', icon: PieChart },
-        { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
-        { label: 'งบ Equity', path: '/finance/equity-statement', icon: BarChart3, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote },
+        { label: 'งบ Equity', path: '/finance/equity-statement', icon: BarChart3 },
       ],
     },
     {

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -632,7 +632,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'รายงานรวม', path: '/reports', icon: BarChart3 },
         // CSV §6 placeholders — flagged "ต้องสร้าง"
-        { label: 'รายงานลูกหนี้ + Aging', path: '/finance/aging-report', icon: AlertTriangle, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'รายงานลูกหนี้ + Aging', path: '/finance/aging-report', icon: AlertTriangle },
         { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen },
         { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
         { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -618,7 +618,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'ปิดบัญชีสิ้นปี', path: '/finance/year-end-closing', icon: CalendarDays },
         { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
         // CSV §5 — "งบ 4 ประเภท" (full 4-statement set per TFRS)
-        { label: 'งบดุล (Balance Sheet)', path: '/finance/balance-sheet', icon: PieChart, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'งบดุล (Balance Sheet)', path: '/finance/balance-sheet', icon: PieChart },
         { label: 'กำไร-ขาดทุน (P&L)', path: '/profit-loss', icon: PieChart },
         { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'งบ Equity', path: '/finance/equity-statement', icon: BarChart3, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -634,7 +634,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         // CSV §6 placeholders — flagged "ต้องสร้าง"
         { label: 'รายงานลูกหนี้ + Aging', path: '/finance/aging-report', icon: AlertTriangle, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen },
-        { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
         { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'รายงานลูกหนี้ Inter-co', path: '/finance/intercompany-report', icon: Building2, placeholder: { trackingSP: 'SP6', eta: 'ภายในไตรมาส 4/2026' } },
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -635,7 +635,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'รายงานลูกหนี้ + Aging', path: '/finance/aging-report', icon: AlertTriangle },
         { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen },
         { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
-        { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown },
         { label: 'รายงานลูกหนี้ Inter-co', path: '/finance/intercompany-report', icon: Building2, placeholder: { trackingSP: 'SP6', eta: 'ภายในไตรมาส 4/2026' } },
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
         { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -633,7 +633,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'รายงานรวม', path: '/reports', icon: BarChart3 },
         // CSV §6 placeholders — flagged "ต้องสร้าง"
         { label: 'รายงานลูกหนี้ + Aging', path: '/finance/aging-report', icon: AlertTriangle, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
-        { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
+        { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen },
         { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown, placeholder: { trackingSP: 'SP2', eta: 'ภายในไตรมาส 2/2026' } },
         { label: 'รายงานลูกหนี้ Inter-co', path: '/finance/intercompany-report', icon: Building2, placeholder: { trackingSP: 'SP6', eta: 'ภายในไตรมาส 4/2026' } },

--- a/apps/web/src/pages/finance/AgingReportPage.tsx
+++ b/apps/web/src/pages/finance/AgingReportPage.tsx
@@ -1,0 +1,232 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { AlertTriangle } from 'lucide-react';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { useUiFlags } from '@/hooks/useUiFlags';
+import { formatDateMedium } from '@/utils/formatters';
+
+interface AgingCustomer {
+  customerId: string;
+  customerName: string;
+  phone: string;
+  totalOverdue: number;
+  daysOverdue: number;
+  bucket: string;
+  contracts: number;
+}
+
+interface AgingData {
+  asOf: string;
+  summary: {
+    bucket_0_30: number;
+    bucket_31_60: number;
+    bucket_61_90: number;
+    bucket_90_plus: number;
+  };
+  customers: AgingCustomer[];
+}
+
+const BUCKET_KEYS = [
+  'bucket_0_30',
+  'bucket_31_60',
+  'bucket_61_90',
+  'bucket_90_plus',
+] as const;
+
+const BUCKET_LABELS: Record<string, string> = {
+  bucket_0_30: '0–30 วัน',
+  bucket_31_60: '31–60 วัน',
+  bucket_61_90: '61–90 วัน',
+  bucket_90_plus: '90+ วัน',
+};
+
+const BUCKET_BAR_COLORS: Record<string, string> = {
+  bucket_0_30: 'bg-success',
+  bucket_31_60: 'bg-warning',
+  bucket_61_90: 'bg-orange-500',
+  bucket_90_plus: 'bg-destructive',
+};
+
+const BUCKET_VALUE_COLORS: Record<string, string> = {
+  bucket_0_30: 'text-success',
+  bucket_31_60: 'text-warning',
+  bucket_61_90: 'text-orange-500',
+  bucket_90_plus: 'text-destructive',
+};
+
+const BUCKET_BADGE_COLORS: Record<string, string> = {
+  bucket_0_30: 'bg-success/10 text-success',
+  bucket_31_60: 'bg-warning/10 text-warning',
+  bucket_61_90: 'bg-orange-500/10 text-orange-600',
+  bucket_90_plus: 'bg-destructive/10 text-destructive',
+};
+
+function fmt(n: number | null | undefined): string {
+  if (n == null) return '0.00';
+  return Number(n).toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-input rounded-lg focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+export default function AgingReportPage() {
+  const now = new Date();
+  const [asOfDate, setAsOfDate] = useState(now.toISOString().split('T')[0]);
+  const { cacheTtlReports } = useUiFlags();
+
+  const {
+    data: aging,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<AgingData>({
+    queryKey: ['aging-report', asOfDate],
+    queryFn: async () => {
+      const params = new URLSearchParams({ asOf: asOfDate });
+      return (await api.get(`/expenses/ledger/aging?${params}`)).data;
+    },
+    enabled: !!asOfDate,
+    staleTime: cacheTtlReports * 1000,
+  });
+
+  return (
+    <div>
+      <PageHeader
+        title="รายงานลูกหนี้ + วิเคราะห์อายุหนี้"
+        subtitle="Aging Report — แยกตามอายุหนี้ที่ค้างชำระ"
+        icon={<AlertTriangle className="size-6" />}
+      />
+
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ณ วันที่
+          </label>
+          <ThaiDateInput
+            value={asOfDate}
+            onChange={(e) => setAsOfDate(e.target.value)}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+        {aging && (
+          <div className="flex items-end">
+            <span className="text-sm text-muted-foreground leading-snug">
+              ณ วันที่ {formatDateMedium(aging.asOf)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <QueryBoundary
+        isLoading={isLoading && !aging}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        errorTitle="ไม่สามารถโหลดรายงานลูกหนี้ได้"
+      >
+        {aging ? (
+          <>
+            {/* 4 Summary Cards */}
+            <div
+              data-testid="aging-buckets"
+              className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6"
+            >
+              {BUCKET_KEYS.map((b) => (
+                <Card
+                  key={b}
+                  className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden hover:shadow-card-hover transition-all"
+                >
+                  <div className="flex h-full">
+                    <div className={`w-1 shrink-0 rounded-r-full ${BUCKET_BAR_COLORS[b]}`} />
+                    <div className="p-4 flex-1">
+                      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1 leading-snug">
+                        {BUCKET_LABELS[b]}
+                      </div>
+                      <div
+                        className={`text-xl font-bold tabular-nums leading-snug ${BUCKET_VALUE_COLORS[b]}`}
+                      >
+                        {fmt(aging.summary[b])}
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+
+            {/* Customer table */}
+            <Card className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+              <CardHeader>
+                <h2 className="text-base font-semibold leading-snug">
+                  รายชื่อลูกหนี้ค้างชำระ ({aging.customers.length} ราย)
+                </h2>
+              </CardHeader>
+              <CardContent className="p-0">
+                {aging.customers.length === 0 ? (
+                  <div className="p-10 text-center text-muted-foreground leading-snug">
+                    <AlertTriangle className="size-10 mx-auto mb-3 opacity-40" />
+                    <p className="text-sm">ไม่มีลูกหนี้ค้างชำระ ณ วันที่นี้</p>
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm leading-snug">
+                      <thead className="bg-muted/50">
+                        <tr>
+                          <th className="text-left p-3 font-medium text-muted-foreground">ลูกค้า</th>
+                          <th className="text-left p-3 font-medium text-muted-foreground">โทรศัพท์</th>
+                          <th className="text-right p-3 font-medium text-muted-foreground">วันค้าง</th>
+                          <th className="text-right p-3 font-medium text-muted-foreground">
+                            ยอดค้างชำระ
+                          </th>
+                          <th className="text-center p-3 font-medium text-muted-foreground">กลุ่ม</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {aging.customers.map((c) => (
+                          <tr
+                            key={c.customerId}
+                            className="border-t border-border hover:bg-accent/30"
+                          >
+                            <td className="p-3">
+                              <Link
+                                to={`/customers/${c.customerId}`}
+                                className="text-primary hover:underline leading-snug"
+                              >
+                                {c.customerName}
+                              </Link>
+                            </td>
+                            <td className="p-3 font-mono text-sm text-muted-foreground">
+                              {c.phone || '—'}
+                            </td>
+                            <td className="p-3 text-right tabular-nums">
+                              {c.daysOverdue} วัน
+                            </td>
+                            <td className="p-3 text-right tabular-nums font-semibold">
+                              {fmt(c.totalOverdue)}
+                            </td>
+                            <td className="p-3 text-center">
+                              <span
+                                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium leading-snug ${BUCKET_BADGE_COLORS[c.bucket] ?? 'bg-muted text-muted-foreground'}`}
+                              >
+                                {BUCKET_LABELS[c.bucket] ?? c.bucket}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        ) : null}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/BadDebtReportPage.tsx
+++ b/apps/web/src/pages/finance/BadDebtReportPage.tsx
@@ -1,0 +1,223 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { TrendingDown } from 'lucide-react';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import CompanyFilter from '@/components/CompanyFilter';
+import { useUiFlags } from '@/hooks/useUiFlags';
+import { formatDateMedium } from '@/utils/formatters';
+
+interface BadDebtEntry {
+  journalEntryId: string;
+  documentNumber: string | null;
+  postedAt: string;
+  description: string | null;
+  amount: number;
+  sourceType: string | null;
+  sourceId: string | null;
+}
+
+interface BadDebtData {
+  period: { start: string; end: string };
+  totalBadDebt: number;
+  entries: BadDebtEntry[];
+}
+
+function fmt(n: number | null | undefined): string {
+  if (n == null) return '0.00';
+  return Number(n).toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-input rounded-lg focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+export default function BadDebtReportPage() {
+  const now = new Date();
+  const firstOfYear = `${now.getFullYear()}-01-01`;
+  const [startDate, setStartDate] = useState(firstOfYear);
+  const [endDate, setEndDate] = useState(now.toISOString().split('T')[0]);
+  const [companyId, setCompanyId] = useState('');
+  const { cacheTtlReports } = useUiFlags();
+
+  const {
+    data: bd,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<BadDebtData>({
+    queryKey: ['bad-debt-report', startDate, endDate, companyId],
+    queryFn: async () => {
+      const params = new URLSearchParams({ start: startDate, end: endDate });
+      if (companyId) params.set('companyId', companyId);
+      return (await api.get(`/expenses/ledger/bad-debt?${params}`)).data;
+    },
+    enabled: !!startDate && !!endDate,
+    staleTime: cacheTtlReports * 1000,
+  });
+
+  return (
+    <div>
+      <PageHeader
+        title="รายงานหนี้สูญ"
+        subtitle="Bad Debt Report — บัญชี 51-1102 หนี้สูญ/ขาดทุนจากยึดเครื่อง"
+        icon={<TrendingDown className="size-6" />}
+      />
+
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ตั้งแต่
+          </label>
+          <ThaiDateInput
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ถึง
+          </label>
+          <ThaiDateInput
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+        <CompanyFilter value={companyId} onChange={setCompanyId} />
+        <div className="flex items-end gap-1">
+          {[
+            {
+              label: 'ปีนี้',
+              fn: () => {
+                setStartDate(firstOfYear);
+                setEndDate(now.toISOString().split('T')[0]);
+              },
+            },
+          ].map((p) => (
+            <button
+              key={p.label}
+              onClick={p.fn}
+              className="px-3 py-2 text-xs border border-input rounded-lg hover:bg-accent transition-colors leading-snug"
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <QueryBoundary
+        isLoading={isLoading && !bd}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        errorTitle="ไม่สามารถโหลดรายงานหนี้สูญได้"
+      >
+        {bd ? (
+          <>
+            {/* Total summary card */}
+            <Card className="rounded-xl border border-border/50 bg-card shadow-sm mb-4 overflow-hidden">
+              <div className="flex h-full">
+                <div className="w-1 shrink-0 rounded-r-full bg-destructive" />
+                <div className="p-5 flex-1">
+                  <div className="flex items-center justify-between mb-1 flex-wrap gap-2">
+                    <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider leading-snug">
+                      หนี้สูญรวมงวด ({formatDateMedium(bd.period.start)} —{' '}
+                      {formatDateMedium(bd.period.end)})
+                    </div>
+                    <span className="text-xs text-muted-foreground leading-snug">
+                      {bd.entries.length} รายการ
+                    </span>
+                  </div>
+                  <div className="text-3xl font-bold tabular-nums text-destructive">
+                    {fmt(bd.totalBadDebt)}
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1 leading-snug">
+                    บัญชี 51-1102 หนี้สูญ/ขาดทุนจากยึดเครื่อง (Dr side)
+                  </div>
+                </div>
+              </div>
+            </Card>
+
+            {/* Entries table */}
+            <Card className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+              <CardHeader>
+                <h2 className="text-base font-semibold leading-snug">รายการบันทึกหนี้สูญ</h2>
+              </CardHeader>
+              <CardContent className="p-0">
+                {bd.entries.length === 0 ? (
+                  <div className="p-10 text-center text-muted-foreground leading-snug">
+                    <TrendingDown className="size-10 mx-auto mb-3 opacity-40" />
+                    <p className="text-sm">ไม่มีรายการหนี้สูญในช่วงเวลานี้</p>
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm leading-snug">
+                      <thead className="bg-muted/50">
+                        <tr>
+                          <th className="text-left p-3 font-medium text-muted-foreground whitespace-nowrap">
+                            วันที่
+                          </th>
+                          <th className="text-left p-3 font-medium text-muted-foreground whitespace-nowrap">
+                            เลขที่ JE
+                          </th>
+                          <th className="text-left p-3 font-medium text-muted-foreground">
+                            คำอธิบาย
+                          </th>
+                          <th className="text-left p-3 font-medium text-muted-foreground">
+                            อ้างอิง
+                          </th>
+                          <th className="text-right p-3 font-medium text-muted-foreground">
+                            จำนวน
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {bd.entries.map((e) => (
+                          <tr
+                            key={e.journalEntryId}
+                            className="border-t border-border hover:bg-accent/30"
+                          >
+                            <td className="p-3 whitespace-nowrap text-muted-foreground">
+                              {formatDateMedium(e.postedAt)}
+                            </td>
+                            <td className="p-3 font-mono text-xs text-primary">
+                              {e.documentNumber ?? '—'}
+                            </td>
+                            <td className="p-3">{e.description ?? '—'}</td>
+                            <td className="p-3 text-xs text-muted-foreground">
+                              {e.sourceType && e.sourceId
+                                ? `${e.sourceType} ${e.sourceId.slice(0, 8)}`
+                                : '—'}
+                            </td>
+                            <td className="p-3 text-right tabular-nums font-semibold text-destructive">
+                              {fmt(e.amount)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                      <tfoot className="bg-muted/50 border-t-2 border-foreground">
+                        <tr>
+                          <td colSpan={4} className="p-3 font-bold">
+                            รวมทั้งหมด
+                          </td>
+                          <td className="p-3 text-right tabular-nums font-bold text-destructive">
+                            {fmt(bd.totalBadDebt)}
+                          </td>
+                        </tr>
+                      </tfoot>
+                    </table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        ) : null}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/BalanceSheetPage.tsx
+++ b/apps/web/src/pages/finance/BalanceSheetPage.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Scale } from 'lucide-react';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { formatDateMedium } from '@/utils/formatters';
+import CompanyFilter from '@/components/CompanyFilter';
+import { useUiFlags } from '@/hooks/useUiFlags';
+
+interface BSRow {
+  code: string;
+  name: string;
+  type: string;
+  normalBalance: string;
+  netBalance: number;
+}
+
+interface BSSection {
+  rows: BSRow[];
+  total: number;
+  sectionName: string;
+}
+
+interface BalanceSheetData {
+  asOfDate: string;
+  assets: {
+    current: BSSection;
+    nonCurrent: BSSection;
+    total: number;
+  };
+  liabilities: {
+    current: BSSection;
+    nonCurrent: BSSection;
+    total: number;
+  };
+  equity: BSSection & { total: number };
+  isBalanced: boolean;
+}
+
+function fmt(n: number | null | undefined): string {
+  if (n == null) return '0.00';
+  return Number(n).toLocaleString('th-TH', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function BSSection({ section }: { section: BSSection }) {
+  return (
+    <div className="mb-4">
+      <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2 leading-snug">
+        {section.sectionName}
+      </div>
+      {section.rows.length === 0 ? (
+        <div className="text-sm text-muted-foreground pl-2 leading-snug">— ไม่มีรายการ —</div>
+      ) : (
+        section.rows.map((r) => (
+          <div
+            key={r.code}
+            className="flex justify-between items-center text-sm py-1 border-b border-border/30 leading-snug"
+          >
+            <span>
+              <span className="font-mono text-xs text-muted-foreground mr-2">{r.code}</span>
+              {r.name}
+            </span>
+            <span
+              className={`tabular-nums ${Number(r.netBalance) < 0 ? 'text-destructive' : ''}`}
+            >
+              {Number(r.netBalance) < 0
+                ? `(${fmt(Math.abs(Number(r.netBalance)))})`
+                : fmt(Number(r.netBalance))}
+            </span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+export default function BalanceSheetPage() {
+  const now = new Date();
+  const [asOfDate, setAsOfDate] = useState(now.toISOString().split('T')[0]);
+  const [companyId, setCompanyId] = useState('');
+  const { cacheTtlReports } = useUiFlags();
+
+  const {
+    data: bs,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<BalanceSheetData>({
+    queryKey: ['balance-sheet', asOfDate, companyId],
+    queryFn: async () => {
+      const params = new URLSearchParams({ asOfDate });
+      if (companyId) params.set('companyId', companyId);
+      return (await api.get(`/expenses/ledger/balance-sheet?${params}`)).data;
+    },
+    enabled: !!asOfDate,
+    staleTime: cacheTtlReports * 1000,
+  });
+
+  const inputClass =
+    'w-full px-3 py-2 border border-input rounded-lg focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+  return (
+    <div>
+      <PageHeader
+        title="งบดุล"
+        subtitle="Balance Sheet — ณ วันที่ระบุ"
+        icon={<Scale className="size-6" />}
+      />
+
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ณ วันที่
+          </label>
+          <ThaiDateInput
+            value={asOfDate}
+            onChange={(e) => setAsOfDate(e.target.value)}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+        <CompanyFilter value={companyId} onChange={setCompanyId} />
+      </div>
+
+      <QueryBoundary
+        isLoading={isLoading && !bs}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        errorTitle="ไม่สามารถโหลดงบดุลได้"
+      >
+        {bs ? (
+          <>
+            {/* Balanced badge */}
+            <div className="flex items-center gap-2 mb-4">
+              <span className="text-sm text-muted-foreground leading-snug">
+                ณ วันที่ {formatDateMedium(bs.asOfDate)}
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium leading-snug ${
+                  bs.isBalanced
+                    ? 'bg-success/10 text-success'
+                    : 'bg-destructive/10 text-destructive'
+                }`}
+              >
+                {bs.isBalanced ? 'Balanced ✓' : 'Unbalanced ✗'}
+              </span>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              {/* Left: Assets */}
+              <Card className="rounded-xl border border-border/50 bg-card shadow-sm">
+                <CardHeader>
+                  <h2 className="text-base font-bold leading-snug">สินทรัพย์ (Assets)</h2>
+                </CardHeader>
+                <CardContent className="space-y-0 pt-0">
+                  <BSSection section={bs.assets.current} />
+                  <BSSection section={bs.assets.nonCurrent} />
+                  <div className="flex justify-between items-center pt-3 border-t-2 border-foreground font-bold leading-snug">
+                    <span>รวมสินทรัพย์</span>
+                    <span className="tabular-nums">{fmt(Number(bs.assets.total))}</span>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Right: Liabilities + Equity */}
+              <Card className="rounded-xl border border-border/50 bg-card shadow-sm">
+                <CardHeader>
+                  <h2 className="text-base font-bold leading-snug">
+                    หนี้สิน + ส่วนของผู้ถือหุ้น
+                  </h2>
+                </CardHeader>
+                <CardContent className="space-y-0 pt-0">
+                  <BSSection section={bs.liabilities.current} />
+                  <BSSection section={bs.liabilities.nonCurrent} />
+                  <div className="flex justify-between items-center py-1 font-medium text-sm leading-snug">
+                    <span>รวมหนี้สิน</span>
+                    <span className="tabular-nums">{fmt(Number(bs.liabilities.total))}</span>
+                  </div>
+                  <BSSection section={bs.equity} />
+                  <div className="flex justify-between items-center py-1 font-medium text-sm leading-snug">
+                    <span>รวมส่วนของผู้ถือหุ้น</span>
+                    <span className="tabular-nums">{fmt(Number(bs.equity.total))}</span>
+                  </div>
+                  <div className="flex justify-between items-center pt-3 border-t-2 border-foreground font-bold leading-snug">
+                    <span>รวมหนี้สิน + ส่วนของผู้ถือหุ้น</span>
+                    <span className="tabular-nums">
+                      {fmt(Number(bs.liabilities.total) + Number(bs.equity.total))}
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </>
+        ) : null}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/GeneralJournalPage.tsx
+++ b/apps/web/src/pages/finance/GeneralJournalPage.tsx
@@ -1,0 +1,259 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { BookOpen, ChevronDown, ChevronRight } from 'lucide-react';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import CompanyFilter from '@/components/CompanyFilter';
+import { useUiFlags } from '@/hooks/useUiFlags';
+import { formatDateMedium } from '@/utils/formatters';
+
+interface JELine {
+  accountCode: string;
+  debit: string | number;
+  credit: string | number;
+  description?: string | null;
+}
+
+interface JournalEntry {
+  id: string;
+  entryNumber: string;
+  description: string;
+  postedAt: string | null;
+  entryDate: string;
+  lines: JELine[];
+}
+
+interface GeneralJournalData {
+  data: JournalEntry[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+function fmt(n: string | number | null | undefined): string {
+  const v = Number(n ?? 0);
+  if (!v) return '';
+  return v.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-input rounded-lg focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+export default function GeneralJournalPage() {
+  const now = new Date();
+  const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const [startDate, setStartDate] = useState(firstOfMonth.toISOString().split('T')[0]);
+  const [endDate, setEndDate] = useState(now.toISOString().split('T')[0]);
+  const [page, setPage] = useState(1);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [companyId, setCompanyId] = useState('');
+  const { cacheTtlReports } = useUiFlags();
+
+  const {
+    data: gj,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<GeneralJournalData>({
+    queryKey: ['general-journal', startDate, endDate, page, companyId],
+    queryFn: async () => {
+      const params = new URLSearchParams({ start: startDate, end: endDate, page: String(page), limit: '50' });
+      if (companyId) params.set('companyId', companyId);
+      return (await api.get(`/expenses/ledger/general-journal?${params}`)).data;
+    },
+    enabled: !!startDate && !!endDate,
+    staleTime: cacheTtlReports * 1000,
+  });
+
+  const toggle = (id: string) =>
+    setExpanded((s) => {
+      const next = new Set(s);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+
+  const totalPages = gj ? Math.max(1, Math.ceil(gj.total / gj.limit)) : 1;
+
+  return (
+    <div>
+      <PageHeader
+        title="สมุดรายวันทั่วไป"
+        subtitle="General Journal — รายการบันทึกบัญชีทั้งหมด"
+        icon={<BookOpen className="size-6" />}
+      />
+
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ตั้งแต่
+          </label>
+          <ThaiDateInput
+            value={startDate}
+            onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ถึง
+          </label>
+          <ThaiDateInput
+            value={endDate}
+            onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+        <CompanyFilter value={companyId} onChange={(v) => { setCompanyId(v); setPage(1); }} />
+        <div className="flex items-end gap-1">
+          {[
+            {
+              label: 'เดือนนี้',
+              fn: () => {
+                setStartDate(firstOfMonth.toISOString().split('T')[0]);
+                setEndDate(now.toISOString().split('T')[0]);
+                setPage(1);
+              },
+            },
+            {
+              label: 'ปีนี้',
+              fn: () => {
+                setStartDate(`${now.getFullYear()}-01-01`);
+                setEndDate(now.toISOString().split('T')[0]);
+                setPage(1);
+              },
+            },
+          ].map((p) => (
+            <button
+              key={p.label}
+              onClick={p.fn}
+              className="px-3 py-2 text-xs border border-input rounded-lg hover:bg-accent transition-colors leading-snug"
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <QueryBoundary
+        isLoading={isLoading && !gj}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        errorTitle="ไม่สามารถโหลดสมุดรายวันทั่วไปได้"
+      >
+        {gj ? (
+          <>
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-sm text-muted-foreground leading-snug">
+                รวม {gj.total.toLocaleString()} รายการ · หน้า {page} / {totalPages}
+              </span>
+            </div>
+
+            <div className="space-y-2">
+              {gj.data.length === 0 ? (
+                <Card className="rounded-xl border border-border/50 bg-card">
+                  <CardContent className="p-10 text-center text-muted-foreground leading-snug">
+                    <BookOpen className="size-10 mx-auto mb-3 opacity-40" />
+                    <p className="text-sm">ไม่มีรายการในช่วงเวลานี้</p>
+                  </CardContent>
+                </Card>
+              ) : (
+                gj.data.map((je) => (
+                  <Card
+                    key={je.id}
+                    className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden"
+                  >
+                    <button
+                      onClick={() => toggle(je.id)}
+                      className="w-full p-3 flex items-center gap-3 hover:bg-accent/40 text-left transition-colors"
+                      aria-expanded={expanded.has(je.id)}
+                    >
+                      {expanded.has(je.id) ? (
+                        <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+                      )}
+                      <span className="font-mono text-xs text-muted-foreground shrink-0">
+                        {je.entryNumber}
+                      </span>
+                      <span className="text-sm text-muted-foreground shrink-0">
+                        {formatDateMedium(je.postedAt ?? je.entryDate)}
+                      </span>
+                      <span className="text-sm leading-snug flex-1 truncate">{je.description}</span>
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        {je.lines.length} บรรทัด
+                      </span>
+                    </button>
+
+                    {expanded.has(je.id) && (
+                      <div className="border-t border-border/40 bg-muted/20">
+                        <table className="w-full text-xs leading-snug">
+                          <thead className="bg-muted/40">
+                            <tr>
+                              <th className="text-left p-2 font-medium text-muted-foreground">รหัสบัญชี</th>
+                              <th className="text-left p-2 font-medium text-muted-foreground">คำอธิบาย</th>
+                              <th className="text-right p-2 font-medium text-muted-foreground">Dr</th>
+                              <th className="text-right p-2 font-medium text-muted-foreground">Cr</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {je.lines.map((l, i) => (
+                              <tr key={i} className="border-t border-border/20">
+                                <td className="p-2 font-mono">{l.accountCode}</td>
+                                <td className="p-2 text-muted-foreground">{l.description ?? ''}</td>
+                                <td className="p-2 text-right tabular-nums text-success">
+                                  {fmt(l.debit)}
+                                </td>
+                                <td className="p-2 text-right tabular-nums text-destructive">
+                                  {fmt(l.credit)}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </Card>
+                ))
+              )}
+            </div>
+
+            {/* Pagination */}
+            <div className="flex justify-between items-center mt-4">
+              <span className="text-sm text-muted-foreground leading-snug">
+                หน้า {page} จาก {totalPages}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  ก่อนหน้า
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  ถัดไป
+                </Button>
+              </div>
+            </div>
+          </>
+        ) : null}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/__tests__/AgingReportPage.test.tsx
+++ b/apps/web/src/pages/finance/__tests__/AgingReportPage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import React from 'react';
+
+// Mock api BEFORE importing the page
+const apiGet = vi.fn();
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+}));
+
+// Mock useUiFlags to skip the settings/ui-flags fetch in tests
+vi.mock('@/hooks/useUiFlags', () => ({
+  useUiFlags: () => ({ cacheTtlReports: 300 }),
+}));
+
+// Mock CompanyFilter (depends on AuthContext)
+vi.mock('@/components/CompanyFilter', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import AgingReportPage from '../AgingReportPage';
+
+const sampleResponse = {
+  asOf: '2026-05-19T00:00:00.000Z',
+  summary: {
+    bucket_0_30: 10000,
+    bucket_31_60: 20000,
+    bucket_61_90: 30000,
+    bucket_90_plus: 40000,
+  },
+  customers: [
+    {
+      customerId: 'c1',
+      customerName: 'นาย ก',
+      phone: '0812345678',
+      totalOverdue: 15000,
+      daysOverdue: 45,
+      bucket: 'bucket_31_60',
+      contracts: 1,
+    },
+    {
+      customerId: 'c2',
+      customerName: 'นางสาว ข',
+      phone: '0898765432',
+      totalOverdue: 35000,
+      daysOverdue: 95,
+      bucket: 'bucket_90_plus',
+      contracts: 2,
+    },
+  ],
+};
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AgingReportPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('AgingReportPage', () => {
+  beforeEach(() => {
+    apiGet.mockResolvedValue({ data: sampleResponse });
+  });
+
+  it('renders 4 bucket cards with correct labels', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('aging-buckets')).toBeInTheDocument());
+    // Use getAllByText because bucket labels appear both in cards AND in badge column
+    expect(screen.getAllByText('0–30 วัน').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('31–60 วัน').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('61–90 วัน').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('90+ วัน').length).toBeGreaterThan(0);
+  });
+
+  it('renders customer rows with names', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('นาย ก')).toBeInTheDocument());
+    expect(screen.getByText('นางสาว ข')).toBeInTheDocument();
+  });
+
+  it('shows correct days overdue for each customer', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('นาย ก')).toBeInTheDocument());
+    expect(screen.getByText('45 วัน')).toBeInTheDocument();
+    expect(screen.getByText('95 วัน')).toBeInTheDocument();
+  });
+
+  it('calls the correct API endpoint', async () => {
+    renderPage();
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+    const [url] = apiGet.mock.calls[0] as [string];
+    expect(url).toMatch('/expenses/ledger/aging');
+  });
+});


### PR DESCRIPTION
## Summary

Implements P4-SP1 per plan [docs/superpowers/plans/2026-05-19-p4-sp1-financial-reports.md](https://github.com/iamnaii/BESTCHOICE/blob/main/docs/superpowers/plans/2026-05-19-p4-sp1-financial-reports.md). Replaces 7 ComingSoonPage placeholders with real, functional report pages, backed by 3 new accounting service methods + endpoints.

## Backend (Tasks 1-3)

| Endpoint | Method | Purpose |
|---|---|---|
| \`GET /expenses/ledger/general-journal?start&end&page&limit\` | \`getGeneralJournal\` | Paginated JE list with lines |
| \`GET /expenses/ledger/aging?asOf\` | \`getAgingReport\` | Customer-by-customer aging with 4 buckets (0-30/31-60/61-90/90+) |
| \`GET /expenses/ledger/bad-debt?start&end\` | \`getBadDebtReport\` | JournalLine 51-1102 entries with totals |

API tests: **+15 new tests** (Tasks 1-3 added 4+6+8 tests respectively). Existing 50 + new 18 = **68 tests pass**.

## Frontend (Tasks 4-10)

7 new/replaced report pages:

1. \`/finance/balance-sheet\` — **NEW** BalanceSheetPage
2. \`/finance/cash-flow\` — existing root page, ComingSoonPage duplicate removed
3. \`/finance/equity-statement\` — existing root page, ComingSoonPage duplicate removed
4. \`/finance/general-journal\` — **NEW** GeneralJournalPage (paged JE list w/ expandable lines)
5. \`/finance/general-ledger\` — existing root page, ComingSoonPage duplicate removed
6. \`/finance/aging-report\` — **NEW** AgingReportPage (4 bucket cards + customer drill-down)
7. \`/finance/bad-debt-report\` — **NEW** BadDebtReportPage

\`menu.ts\` placeholder markers removed from all 7 entries.

**Discovery during impl**: 3 pages (CashFlow / Equity / GL) already existed at \`apps/web/src/pages/\` root — implementer cleaned up duplicate ComingSoonPage routes in App.tsx (lines 1343-1376) and removed placeholder markers from menu.

## Schema corrections found during implementation

- JournalEntry: \`entryNumber\` (not documentNumber), \`referenceType/Id\` (not sourceType/Id)
- JournalLine: \`debit\`/\`credit\` (not debitAmount/creditAmount), no \`accountName\`
- Customer: \`name\` single field (not firstName/lastName)
- Payment: \`amountDue\`/\`amountPaid\` (not amount/paidAmount)
- All endpoints under \`/expenses/\` prefix (not \`/accounting/\`)
- Date params: aging uses \`asOf\`, others use \`start/end\` or \`periodStart/periodEnd\`

Service responses map to consistent frontend contracts (e.g. \`documentNumber\` in API response = \`entryNumber\` in DB).

Web version: **26.5.8 → 26.5.9**

## Test plan
- [x] API jest: 68 tests pass
- [x] Web vitest: 23 tests pass (4 AgingReportPage + 19 menu config)
- [x] TypeScript: 0 errors in changed files
- [x] ESLint: 0 errors
- [x] Vite build: success
- [ ] After merge: auto-deploy + visual check on \`bestchoicephone.app/?zone=fin\` — open each of the 7 menu items

## Commits (11 total)

\`\`\`
fd7bf2da BadDebtReportPage — JournalLine 51-1102 viewer
a01bb8b5 AgingReportPage — 4-bucket summary + customer drill-down
efc2e4eb GeneralLedgerPage — per-account ledger with running balance
e9bdefbb GeneralJournalPage — paged JE list with expandable lines
4fb42b2b EquityStatementPage — replace ComingSoonPage
708e4833 CashFlowPage — replace ComingSoonPage
cc074bcf BalanceSheetPage — replace ComingSoonPage
9673a1c7 add bad-debt report endpoint
5dc7bf78 add aging report endpoint with customer-level buckets
4f987266 add general-journal endpoint with paging
+ chore: bump web 26.5.8 → 26.5.9 for P4-SP1 deploy
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)