### PR TITLE
feat(p4-sp2): ภาษี UI + VAT Auto Journal + e-Receipt (5 pages + 4 endpoints)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -131,6 +131,8 @@ import { CollectionsSessionModule } from './modules/collections-session/collecti
 import { BackupModule } from './modules/backup/backup.module';
 // SP7.4 — External Finance Companies + Commission (SHOP-side GFIN/Krungsri)
 import { ExternalFinanceModule } from './modules/external-finance/external-finance.module';
+// P4-SP2 — Finance Tax (VAT/WHT monthly aggregation + auto-journal history)
+import { FinanceTaxModule } from './modules/finance-tax/finance-tax.module';
 import { AuditInterceptor } from './modules/audit/audit.interceptor';
 import { SecurityMiddleware } from './modules/audit/security.middleware';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
@@ -363,6 +365,8 @@ import { AppCacheModule } from './cache/cache.module';
     BackupModule,
     // SP7.4 — External Finance Companies + Commission (SHOP-side GFIN/Krungsri)
     ExternalFinanceModule,
+    // P4-SP2 — Finance Tax (VAT/WHT monthly aggregation + auto-journal history)
+    FinanceTaxModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/modules/finance-tax/dto/finance-tax.dto.ts
+++ b/apps/api/src/modules/finance-tax/dto/finance-tax.dto.ts
@@ -1,0 +1,36 @@
+import { IsInt, IsOptional, IsString, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class VatMonthlyQueryDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(2020)
+  year: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month: number;
+
+  @IsOptional()
+  @IsString()
+  companyId?: string;
+}
+
+export class WhtMonthlyQueryDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(2020)
+  year: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month: number;
+
+  @IsOptional()
+  @IsString()
+  companyId?: string;
+}

--- a/apps/api/src/modules/finance-tax/finance-tax.controller.ts
+++ b/apps/api/src/modules/finance-tax/finance-tax.controller.ts
@@ -1,0 +1,65 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { FinanceTaxService } from './finance-tax.service';
+
+@Controller('finance-tax')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FinanceTaxController {
+  constructor(private readonly financeTaxService: FinanceTaxService) {}
+
+  /**
+   * GET /finance-tax/vat-monthly?year=2026&month=5&companyId=...
+   * Returns VAT aggregation for ภ.พ.30 filing.
+   */
+  @Get('vat-monthly')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getVatMonthly(
+    @Query('year') year: string,
+    @Query('month') month: string,
+    @Query('companyId') companyId?: string,
+  ) {
+    return this.financeTaxService.getVatMonthly(
+      parseInt(year, 10),
+      parseInt(month, 10),
+      companyId,
+    );
+  }
+
+  /**
+   * GET /finance-tax/wht-monthly?year=2026&month=5&companyId=...
+   * Returns WHT aggregation grouped by form type (PND.1/3/53).
+   */
+  @Get('wht-monthly')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getWhtMonthly(
+    @Query('year') year: string,
+    @Query('month') month: string,
+    @Query('companyId') companyId?: string,
+  ) {
+    return this.financeTaxService.getWhtMonthly(
+      parseInt(year, 10),
+      parseInt(month, 10),
+      companyId,
+    );
+  }
+
+  /**
+   * GET /finance-tax/vat-auto-journal?year=2026&month=5&companyId=...
+   * Returns all journal entries that touched VAT accounts in the period.
+   */
+  @Get('vat-auto-journal')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getVatAutoJournalHistory(
+    @Query('year') year: string,
+    @Query('month') month: string,
+    @Query('companyId') companyId?: string,
+  ) {
+    return this.financeTaxService.getVatAutoJournalHistory(
+      parseInt(year, 10),
+      parseInt(month, 10),
+      companyId,
+    );
+  }
+}

--- a/apps/api/src/modules/finance-tax/finance-tax.module.ts
+++ b/apps/api/src/modules/finance-tax/finance-tax.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { FinanceTaxController } from './finance-tax.controller';
+import { FinanceTaxService } from './finance-tax.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [FinanceTaxController],
+  providers: [FinanceTaxService],
+  exports: [FinanceTaxService],
+})
+export class FinanceTaxModule {}

--- a/apps/api/src/modules/finance-tax/finance-tax.service.spec.ts
+++ b/apps/api/src/modules/finance-tax/finance-tax.service.spec.ts
@@ -170,4 +170,58 @@ describe('FinanceTaxService', () => {
       expect(callArgs.where.journalEntry.companyId).toBe('company-finance-id');
     });
   });
+
+  // ─── Task 4: getVatAutoJournalHistory ──────────────────────────────────────
+
+  describe('getVatAutoJournalHistory', () => {
+    /** Helper: build a JournalEntry mock with nested VAT lines */
+    function makeEntry(
+      id: string,
+      entryNumber: string,
+      referenceType: string | null,
+      lines: Array<{ accountCode: string; debit: string; credit: string }>,
+    ) {
+      return {
+        id,
+        entryNumber,
+        postedAt: new Date('2026-05-15T10:00:00Z'),
+        referenceType,
+        description: 'auto journal entry',
+        lines: lines.map((l) => ({
+          accountCode: l.accountCode,
+          debit: new Decimal(l.debit),
+          credit: new Decimal(l.credit),
+        })),
+      };
+    }
+
+    it('returns empty entries list when no matching journal entries exist', async () => {
+      prisma.journalEntry.findMany.mockResolvedValue([]);
+
+      const result = await service.getVatAutoJournalHistory(2026, 5);
+
+      expect(result.entries).toEqual([]);
+      expect(result.period.year).toBe(2026);
+      expect(result.period.month).toBe(5);
+    });
+
+    it('maps entryNumber → documentNumber and referenceType → sourceType', async () => {
+      prisma.journalEntry.findMany.mockResolvedValue([
+        makeEntry('entry-uuid-1', 'JE-202605-0001', 'PAYMENT', [
+          { accountCode: '21-2101', debit: '0', credit: '700' },
+          { accountCode: '11-2105', debit: '700', credit: '0' },
+        ]),
+      ]);
+
+      const result = await service.getVatAutoJournalHistory(2026, 5);
+
+      const entry = result.entries[0];
+      expect(entry.documentNumber).toBe('JE-202605-0001'); // entryNumber → documentNumber
+      expect(entry.sourceType).toBe('PAYMENT'); // referenceType → sourceType
+      expect(entry.vatLines).toHaveLength(2);
+      expect(entry.vatLines[0].accountCode).toBe('21-2101');
+      expect(entry.vatLines[0].debit).toBe(0);
+      expect(entry.vatLines[0].credit).toBe(700);
+    });
+  });
 });

--- a/apps/api/src/modules/finance-tax/finance-tax.service.spec.ts
+++ b/apps/api/src/modules/finance-tax/finance-tax.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Decimal } from '@prisma/client/runtime/library';
+import { FinanceTaxService } from './finance-tax.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * FinanceTaxService — VAT & WHT monthly aggregation + auto-journal history
+ *
+ * Tests cover:
+ *   Task 2 — getVatMonthly: response shape, empty period, computed netVat, companyId filter
+ *   Task 3 — getWhtMonthly: PND1/3/53 grouping, grandTotal, empty period
+ *   Task 4 — getVatAutoJournalHistory: entry→vatLines mapping, referenceType→sourceType mapping
+ *
+ * Schema reality:
+ *   - JournalLine: debit (Decimal), credit (Decimal), accountCode, description
+ *   - JournalEntry: entryNumber (→ documentNumber), referenceType (→ sourceType), referenceId (→ sourceId)
+ *   - Number(field) used for Decimal conversion — never aggregate Decimals directly
+ */
+describe('FinanceTaxService', () => {
+  let service: FinanceTaxService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  /** Helper: build a JournalLine mock with nested journalEntry */
+  function makeLine(
+    accountCode: string,
+    debit: string,
+    credit: string,
+    entryNumber = 'JE-202605-0001',
+    postedAt: Date = new Date('2026-05-15T10:00:00Z'),
+  ) {
+    return {
+      accountCode,
+      debit: new Decimal(debit),
+      credit: new Decimal(credit),
+      description: `test line ${accountCode}`,
+      journalEntry: {
+        entryNumber,
+        postedAt,
+        description: 'test entry description',
+      },
+    };
+  }
+
+  beforeEach(async () => {
+    prisma = {
+      journalLine: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      journalEntry: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FinanceTaxService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<FinanceTaxService>(FinanceTaxService);
+  });
+
+  // ─── Task 2: getVatMonthly ─────────────────────────────────────────────────
+
+  describe('getVatMonthly', () => {
+    it('returns correct shape with zero values when no lines exist', async () => {
+      prisma.journalLine.findMany.mockResolvedValue([]);
+
+      const result = await service.getVatMonthly(2026, 5);
+
+      expect(result).toMatchObject({
+        period: { year: 2026, month: 5 },
+        vatOutput: 0,
+        vatDeferred: 0,
+        vatInput: 0,
+        netVat: 0,
+        lineCount: 0,
+        lines: [],
+      });
+
+      // Period bounds should be correct
+      expect(result.period.start).toEqual(new Date(2026, 4, 1)); // May 1
+      expect(result.period.end).toEqual(new Date(2026, 5, 1)); // June 1 (exclusive)
+    });
+
+    it('aggregates VAT output (21-2101) and input (11-4101) correctly', async () => {
+      prisma.journalLine.findMany.mockResolvedValue([
+        makeLine('21-2101', '0', '700'),   // VAT output: credit 700, debit 0 → +700
+        makeLine('11-4101', '100', '0'),   // VAT input: debit 100, credit 0 → +100
+      ]);
+
+      const result = await service.getVatMonthly(2026, 5);
+
+      expect(result.vatOutput).toBe(700);
+      expect(result.vatInput).toBe(100);
+      expect(result.netVat).toBe(600); // 700 - 100
+      expect(result.lineCount).toBe(2);
+    });
+
+    it('maps entryNumber to documentNumber in each line', async () => {
+      prisma.journalLine.findMany.mockResolvedValue([
+        makeLine('21-2101', '0', '350', 'JE-202605-0042'),
+      ]);
+
+      const result = await service.getVatMonthly(2026, 5);
+
+      expect(result.lines[0].documentNumber).toBe('JE-202605-0042');
+      expect(result.lines[0].accountCode).toBe('21-2101');
+      expect(result.lines[0].debit).toBe(0);
+      expect(result.lines[0].credit).toBe(350);
+    });
+
+    it('applies companyId filter in the journalEntry where clause', async () => {
+      prisma.journalLine.findMany.mockResolvedValue([]);
+
+      await service.getVatMonthly(2026, 5, 'company-finance-uuid');
+
+      const callArgs = prisma.journalLine.findMany.mock.calls[0][0];
+      expect(callArgs.where.journalEntry.companyId).toBe('company-finance-uuid');
+    });
+  });
+});

--- a/apps/api/src/modules/finance-tax/finance-tax.service.spec.ts
+++ b/apps/api/src/modules/finance-tax/finance-tax.service.spec.ts
@@ -121,4 +121,53 @@ describe('FinanceTaxService', () => {
       expect(callArgs.where.journalEntry.companyId).toBe('company-finance-uuid');
     });
   });
+
+  // ─── Task 3: getWhtMonthly ─────────────────────────────────────────────────
+
+  describe('getWhtMonthly', () => {
+    it('returns correct shape with zero totals when no lines exist', async () => {
+      prisma.journalLine.findMany.mockResolvedValue([]);
+
+      const result = await service.getWhtMonthly(2026, 5);
+
+      expect(result).toMatchObject({
+        period: { year: 2026, month: 5 },
+        PND1: { lines: [], total: 0 },
+        PND3: { lines: [], total: 0 },
+        PND53: { lines: [], total: 0 },
+        grandTotal: 0,
+      });
+    });
+
+    it('groups lines by WHT form type and computes totals correctly', async () => {
+      prisma.journalLine.findMany.mockResolvedValue([
+        makeLine('21-3101', '0', '500', 'JE-202605-0010'),   // PND1 accrual
+        makeLine('21-3102', '0', '1200', 'JE-202605-0011'),  // PND3 accrual
+        makeLine('21-3102', '300', '0', 'JE-202605-0020'),   // PND3 settlement (negative)
+        makeLine('21-3103', '0', '800', 'JE-202605-0012'),   // PND53 accrual
+      ]);
+
+      const result = await service.getWhtMonthly(2026, 5);
+
+      expect(result.PND1.total).toBe(500);
+      expect(result.PND1.lines).toHaveLength(1);
+
+      expect(result.PND3.total).toBe(900); // 1200 - 300
+      expect(result.PND3.lines).toHaveLength(2);
+
+      expect(result.PND53.total).toBe(800);
+      expect(result.PND53.lines).toHaveLength(1);
+
+      expect(result.grandTotal).toBe(2200); // 500 + 900 + 800
+    });
+
+    it('applies companyId filter when provided', async () => {
+      prisma.journalLine.findMany.mockResolvedValue([]);
+
+      await service.getWhtMonthly(2026, 6, 'company-finance-id');
+
+      const callArgs = prisma.journalLine.findMany.mock.calls[0][0];
+      expect(callArgs.where.journalEntry.companyId).toBe('company-finance-id');
+    });
+  });
 });

--- a/apps/api/src/modules/finance-tax/finance-tax.service.ts
+++ b/apps/api/src/modules/finance-tax/finance-tax.service.ts
@@ -1,0 +1,302 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+// VAT accounts used across tasks
+const VAT_OUTPUT_ACCOUNTS = ['21-2101'];
+const VAT_DEFERRED_ACCOUNTS = ['21-2102'];
+const VAT_INPUT_ACCOUNTS = ['11-4101'];
+const VAT_INPUT_BEHALF_ACCOUNTS = ['11-2104'];
+
+// All VAT-related accounts (for auto-journal history — includes 11-2105 accrual VAT)
+const ALL_VAT_ACCOUNTS = ['21-2101', '21-2102', '11-4101', '11-2104', '11-2105'];
+
+// WHT accounts
+const WHT_PND1_ACCOUNTS = ['21-3101'];
+const WHT_PND3_ACCOUNTS = ['21-3102'];
+const WHT_PND53_ACCOUNTS = ['21-3103'];
+const ALL_WHT_ACCOUNTS = [...WHT_PND1_ACCOUNTS, ...WHT_PND3_ACCOUNTS, ...WHT_PND53_ACCOUNTS];
+
+interface PeriodBounds {
+  year: number;
+  month: number;
+  start: Date;
+  end: Date;
+}
+
+function buildPeriod(year: number, month: number): PeriodBounds {
+  const start = new Date(year, month - 1, 1, 0, 0, 0, 0);
+  const end = new Date(year, month, 1, 0, 0, 0, 0); // exclusive upper bound
+  return { year, month, start, end };
+}
+
+interface VatLine {
+  accountCode: string;
+  documentNumber: string;
+  postedAt: Date | null;
+  description: string | null;
+  debit: number;
+  credit: number;
+}
+
+interface WhtLine {
+  documentNumber: string;
+  postedAt: Date | null;
+  description: string | null;
+  amount: number; // credit - debit (positive = payable accrual, negative = settlement)
+}
+
+interface VatAutoJournalVatLine {
+  accountCode: string;
+  debit: number;
+  credit: number;
+}
+
+@Injectable()
+export class FinanceTaxService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Task 2 — VAT monthly aggregation
+   * Queries JournalLines for VAT accounts within the given month.
+   * Maps entryNumber → documentNumber per SP1 convention.
+   */
+  async getVatMonthly(year: number, month: number, companyId?: string) {
+    const period = buildPeriod(year, month);
+
+    const entryWhere: Record<string, unknown> = {
+      deletedAt: null,
+      status: 'POSTED',
+      entryDate: {
+        gte: period.start,
+        lt: period.end,
+      },
+    };
+
+    if (companyId) {
+      entryWhere.companyId = companyId;
+    }
+
+    const allVatAccountCodes = [
+      ...VAT_OUTPUT_ACCOUNTS,
+      ...VAT_DEFERRED_ACCOUNTS,
+      ...VAT_INPUT_ACCOUNTS,
+      ...VAT_INPUT_BEHALF_ACCOUNTS,
+    ];
+
+    const lines = await this.prisma.journalLine.findMany({
+      where: {
+        deletedAt: null,
+        accountCode: { in: allVatAccountCodes },
+        journalEntry: entryWhere,
+      },
+      include: {
+        journalEntry: {
+          select: {
+            entryNumber: true,
+            postedAt: true,
+            description: true,
+          },
+        },
+      },
+      orderBy: [
+        { journalEntry: { entryDate: 'asc' } },
+        { accountCode: 'asc' },
+      ],
+    });
+
+    // Aggregate per-account totals
+    let vatOutput = 0; // 21-2101: credit - debit (liability account)
+    let vatDeferred = 0; // 21-2102: credit - debit (liability account)
+    let vatInput = 0; // 11-4101: debit - credit (asset account)
+
+    const responseLines: VatLine[] = lines.map((l) => {
+      const debit = Number(l.debit ?? 0);
+      const credit = Number(l.credit ?? 0);
+
+      if (VAT_OUTPUT_ACCOUNTS.includes(l.accountCode)) {
+        vatOutput += credit - debit;
+      } else if (VAT_DEFERRED_ACCOUNTS.includes(l.accountCode)) {
+        vatDeferred += credit - debit;
+      } else if (VAT_INPUT_ACCOUNTS.includes(l.accountCode)) {
+        vatInput += debit - credit; // asset increases on debit
+      }
+      // VAT_INPUT_BEHALF_ACCOUNTS (11-2104) tracked in lines but not in netVat
+      // per CLAUDE.md: 11-2104 is ม.83/6 cases, not claimable on ภ.พ.30
+
+      return {
+        accountCode: l.accountCode,
+        documentNumber: l.journalEntry.entryNumber, // entryNumber → documentNumber
+        postedAt: l.journalEntry.postedAt,
+        description: l.description ?? l.journalEntry.description,
+        debit,
+        credit,
+      };
+    });
+
+    // netVat = vatOutput - vatInput (standard ภ.พ.30 calculation)
+    const netVat = vatOutput - vatInput;
+
+    return {
+      period,
+      vatOutput: Math.round(vatOutput * 100) / 100,
+      vatDeferred: Math.round(vatDeferred * 100) / 100,
+      vatInput: Math.round(vatInput * 100) / 100,
+      netVat: Math.round(netVat * 100) / 100,
+      lineCount: lines.length,
+      lines: responseLines,
+    };
+  }
+
+  /**
+   * Task 3 — WHT monthly aggregation
+   * Queries JournalLines for WHT accounts within the given month.
+   * Groups by form type: PND1 (21-3101), PND3 (21-3102), PND53 (21-3103).
+   */
+  async getWhtMonthly(year: number, month: number, companyId?: string) {
+    const period = buildPeriod(year, month);
+
+    const entryWhere: Record<string, unknown> = {
+      deletedAt: null,
+      status: 'POSTED',
+      entryDate: {
+        gte: period.start,
+        lt: period.end,
+      },
+    };
+
+    if (companyId) {
+      entryWhere.companyId = companyId;
+    }
+
+    const lines = await this.prisma.journalLine.findMany({
+      where: {
+        deletedAt: null,
+        accountCode: { in: ALL_WHT_ACCOUNTS },
+        journalEntry: entryWhere,
+      },
+      include: {
+        journalEntry: {
+          select: {
+            entryNumber: true,
+            postedAt: true,
+            description: true,
+          },
+        },
+      },
+      orderBy: [
+        { journalEntry: { entryDate: 'asc' } },
+        { accountCode: 'asc' },
+      ],
+    });
+
+    const pnd1Lines: WhtLine[] = [];
+    const pnd3Lines: WhtLine[] = [];
+    const pnd53Lines: WhtLine[] = [];
+
+    for (const l of lines) {
+      const debit = Number(l.debit ?? 0);
+      const credit = Number(l.credit ?? 0);
+      const amount = credit - debit; // positive = payable accrual, negative = settlement
+
+      const whtLine: WhtLine = {
+        documentNumber: l.journalEntry.entryNumber,
+        postedAt: l.journalEntry.postedAt,
+        description: l.description ?? l.journalEntry.description,
+        amount: Math.round(amount * 100) / 100,
+      };
+
+      if (WHT_PND1_ACCOUNTS.includes(l.accountCode)) {
+        pnd1Lines.push(whtLine);
+      } else if (WHT_PND3_ACCOUNTS.includes(l.accountCode)) {
+        pnd3Lines.push(whtLine);
+      } else if (WHT_PND53_ACCOUNTS.includes(l.accountCode)) {
+        pnd53Lines.push(whtLine);
+      }
+    }
+
+    const pnd1Total = pnd1Lines.reduce((s, l) => s + l.amount, 0);
+    const pnd3Total = pnd3Lines.reduce((s, l) => s + l.amount, 0);
+    const pnd53Total = pnd53Lines.reduce((s, l) => s + l.amount, 0);
+    const grandTotal = pnd1Total + pnd3Total + pnd53Total;
+
+    return {
+      period,
+      PND1: {
+        lines: pnd1Lines,
+        total: Math.round(pnd1Total * 100) / 100,
+      },
+      PND3: {
+        lines: pnd3Lines,
+        total: Math.round(pnd3Total * 100) / 100,
+      },
+      PND53: {
+        lines: pnd53Lines,
+        total: Math.round(pnd53Total * 100) / 100,
+      },
+      grandTotal: Math.round(grandTotal * 100) / 100,
+    };
+  }
+
+  /**
+   * Task 4 — VAT Auto Journal history
+   * Returns all JournalEntries where any line touches VAT accounts.
+   * Uses nested include.where to filter only VAT lines per entry.
+   */
+  async getVatAutoJournalHistory(year: number, month: number, companyId?: string) {
+    const period = buildPeriod(year, month);
+
+    const entryWhere: Record<string, unknown> = {
+      deletedAt: null,
+      status: 'POSTED',
+      entryDate: {
+        gte: period.start,
+        lt: period.end,
+      },
+      lines: {
+        some: {
+          accountCode: { in: ALL_VAT_ACCOUNTS },
+          deletedAt: null,
+        },
+      },
+    };
+
+    if (companyId) {
+      entryWhere.companyId = companyId;
+    }
+
+    const entries = await this.prisma.journalEntry.findMany({
+      where: entryWhere,
+      include: {
+        lines: {
+          where: {
+            accountCode: { in: ALL_VAT_ACCOUNTS },
+            deletedAt: null,
+          },
+        },
+      },
+      orderBy: { entryDate: 'asc' },
+    });
+
+    const responseEntries = entries.map((entry) => {
+      const vatLines: VatAutoJournalVatLine[] = entry.lines.map((l) => ({
+        accountCode: l.accountCode,
+        debit: Number(l.debit ?? 0),
+        credit: Number(l.credit ?? 0),
+      }));
+
+      return {
+        id: entry.id,
+        documentNumber: entry.entryNumber, // entryNumber → documentNumber
+        postedAt: entry.postedAt,
+        sourceType: entry.referenceType, // referenceType → sourceType
+        description: entry.description,
+        vatLines,
+      };
+    });
+
+    return {
+      period,
+      entries: responseEntries,
+    };
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.9",
+  "version": "26.5.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -175,6 +175,12 @@ const BalanceSheetPage = lazy(() => import('@/pages/finance/BalanceSheetPage'));
 const GeneralJournalPage = lazy(() => import('@/pages/finance/GeneralJournalPage'));
 const AgingReportPage = lazy(() => import('@/pages/finance/AgingReportPage'));
 const BadDebtReportPage = lazy(() => import('@/pages/finance/BadDebtReportPage'));
+// P4-SP2 — Tax UI pages (finance-tax endpoints + e-receipt config)
+const VatPage = lazy(() => import('@/pages/finance/VatPage'));
+const WhtPage = lazy(() => import('@/pages/finance/WhtPage'));
+const ETaxPage = lazy(() => import('@/pages/finance/ETaxPage'));
+const VatAutoJournalPage = lazy(() => import('@/pages/finance/VatAutoJournalPage'));
+const EReceiptAutoPage = lazy(() => import('@/pages/finance/EReceiptAutoPage'));
 const PeakSyncPage = lazy(() => import('@/pages/PeakSyncPage'));
 const PeakExportPage = lazy(() => import('@/pages/PeakExportPage'));
 const AiSettingsPage = lazy(() => import('@/pages/AiSettingsPage'));
@@ -814,12 +820,12 @@ function App() {
               </ProtectedRoute>
             }
           />
-          {/* SP3 — Tax module split */}
+          {/* P4-SP2 — Tax UI (finance-tax endpoints replace SP3 placeholders) */}
           <Route
             path="/finance/vat"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <VatReportPage />
+                <VatPage />
               </ProtectedRoute>
             }
           />
@@ -827,7 +833,7 @@ function App() {
             path="/finance/wht"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <WhtReportPage />
+                <WhtPage />
               </ProtectedRoute>
             }
           />
@@ -835,7 +841,15 @@ function App() {
             path="/finance/e-tax"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ETaxInvoicePage />
+                <ETaxPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/finance/vat-auto-journal"
+            element={
+              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <VatAutoJournalPage />
               </ProtectedRoute>
             }
           />
@@ -1308,42 +1322,7 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/finance/vat"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage
-                  feature="VAT (ภ.พ.30)"
-                  trackingSP="SP3"
-                  eta="ภายในไตรมาส 3/2026"
-                />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/finance/wht"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage
-                  feature="ภาษีหัก ณ ที่จ่าย (ภ.ง.ด. 1/3/53)"
-                  trackingSP="SP3"
-                  eta="ภายในไตรมาส 3/2026"
-                />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/finance/e-tax"
-            element={
-              <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage
-                  feature="e-Tax Invoice"
-                  trackingSP="SP3"
-                  eta="ภายในไตรมาส 3/2026"
-                />
-              </ProtectedRoute>
-            }
-          />
+          {/* /finance/vat, /finance/wht, /finance/e-tax — handled by P4-SP2 routes above */}
           {/* /finance/cash-flow — handled by SP2 CashFlowPage route above (line ~763) */}
           {/* /finance/equity-statement — handled by SP2 EquityStatementPage route above (line ~773) */}
           {/* /finance/general-ledger — handled by SP2 GeneralLedgerPage route above (line ~780) */}
@@ -1451,7 +1430,7 @@ function App() {
             path="/finance/e-receipt-auto"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage feature="ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ" trackingSP="SP3" eta="ภายในไตรมาส 3/2026" />
+                <EReceiptAutoPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -340,10 +340,11 @@ const FINANCE_MANAGER_CONFIG: RoleMenuConfig = {
         { label: 'รายได้อื่น', path: '/other-income', icon: TrendingUp },
         { label: 'เอกสารร่าง', path: '/drafts', icon: Inbox },
         { label: 'กำไร-ขาดทุน', path: '/profit-loss', icon: PieChart },
-        // SP3 — Tax module split
+        // P4-SP2 — Tax module (finance-tax endpoints)
         { label: 'ภ.พ.30 (VAT)', path: '/finance/vat', icon: Calculator },
         { label: 'ภ.ง.ด. 1/3/53 (WHT)', path: '/finance/wht', icon: Calculator },
         { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText },
+        { label: 'VAT Auto Journal', path: '/finance/vat-auto-journal', icon: Calculator },
         // SP6 — Bank/Cash account directory
         { label: 'บัญชีเงินสด/ธนาคาร', path: '/finance/bank-accounts', icon: Landmark },
         { label: 'งวดบัญชี', path: '/accounting/periods', icon: CalendarDays },
@@ -403,10 +404,11 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
         { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote },
         { label: 'งบ Equity', path: '/finance/equity-statement', icon: Landmark },
         { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
-        // SP3 — Tax module split (replaces /tax-reports)
+        // P4-SP2 — Tax module (finance-tax endpoints)
         { label: 'ภ.พ.30 (VAT)', path: '/finance/vat', icon: Calculator },
         { label: 'ภ.ง.ด. 1/3/53 (WHT)', path: '/finance/wht', icon: Calculator },
         { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText },
+        { label: 'VAT Auto Journal', path: '/finance/vat-auto-journal', icon: Calculator },
         { label: 'รายงาน', path: '/reports', icon: BarChart3 },
         // P3-SP5 — SHOP-side accounting reports
         { label: 'บัญชีหน้าร้าน (SHOP)', path: '/shop/accounting', icon: Store },
@@ -437,9 +439,10 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
       icon: Calculator,
       zone: 'fin',
       items: [
-        { label: 'VAT (ภ.พ.30)', path: '/finance/vat', icon: Receipt, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
-        { label: 'WHT (ภ.ง.ด. 1/3/53)', path: '/finance/wht', icon: Receipt, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
-        { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
+        { label: 'VAT (ภ.พ.30)', path: '/finance/vat', icon: Receipt },
+        { label: 'WHT (ภ.ง.ด. 1/3/53)', path: '/finance/wht', icon: Receipt },
+        { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText },
+        { label: 'VAT Auto Journal', path: '/finance/vat-auto-journal', icon: Calculator },
       ],
     },
     {
@@ -602,9 +605,10 @@ const OWNER_CONFIG: RoleMenuConfig = {
       icon: Calculator,
       zone: 'fin',
       items: [
-        { label: 'VAT (ภ.พ.30)', path: '/finance/vat', icon: Receipt, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
-        { label: 'WHT (ภ.ง.ด. 1/3/53)', path: '/finance/wht', icon: Receipt, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
-        { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
+        { label: 'VAT (ภ.พ.30)', path: '/finance/vat', icon: Receipt },
+        { label: 'WHT (ภ.ง.ด. 1/3/53)', path: '/finance/wht', icon: Receipt },
+        { label: 'e-Tax Invoice', path: '/finance/e-tax', icon: FileText },
+        { label: 'VAT Auto Journal', path: '/finance/vat-auto-journal', icon: Calculator },
       ],
     },
     {
@@ -772,8 +776,8 @@ const OWNER_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'Dunning (เตือนค่างวด)', path: '/settings/dunning', icon: Bell },
-        // CSV §10 placeholder — "แจ้งสร้างอีเล็คทรอนิกส์รอบอินส์" = auto e-receipt
-        { label: 'ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ', path: '/finance/e-receipt-auto', icon: FileText, placeholder: { trackingSP: 'SP3', eta: 'ภายในไตรมาส 3/2026' } },
+        // P4-SP2 — auto e-receipt config (e_receipt_auto SystemConfig key)
+        { label: 'ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ', path: '/finance/e-receipt-auto', icon: FileText },
       ],
     },
     {

--- a/apps/web/src/pages/finance/EReceiptAutoPage.tsx
+++ b/apps/web/src/pages/finance/EReceiptAutoPage.tsx
@@ -1,0 +1,178 @@
+/**
+ * EReceiptAutoPage — auto e-receipt delivery config (SP2-Task9)
+ *
+ * Reads/writes SystemConfig key `e_receipt_auto` as a JSON-encoded object.
+ * Uses existing PATCH /settings endpoint (D1.1.2.x pattern).
+ */
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { FileText, Save } from 'lucide-react';
+import { toast } from 'sonner';
+
+const CONFIG_KEY = 'e_receipt_auto';
+
+interface EReceiptConfig {
+  enabled: boolean;
+  deliveryChannel: 'LINE' | 'EMAIL' | 'BOTH';
+  template: 'STANDARD' | 'SIMPLE';
+  signerName: string;
+}
+
+const DEFAULT_CONFIG: EReceiptConfig = {
+  enabled: false,
+  deliveryChannel: 'LINE',
+  template: 'STANDARD',
+  signerName: '',
+};
+
+interface SystemConfigRow {
+  key: string;
+  value: string;
+}
+
+function parseConfig(rows: SystemConfigRow[]): EReceiptConfig {
+  const row = rows.find((r) => r.key === CONFIG_KEY);
+  if (!row) return DEFAULT_CONFIG;
+  try {
+    return { ...DEFAULT_CONFIG, ...JSON.parse(row.value) };
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+export default function EReceiptAutoPage() {
+  const qc = useQueryClient();
+  const [draft, setDraft] = useState<EReceiptConfig | null>(null);
+
+  const query = useQuery({
+    queryKey: ['settings', 'e-receipt-auto'],
+    queryFn: () => api.get<SystemConfigRow[]>('/settings').then((r) => r.data),
+  });
+
+  // Sync draft from loaded data (only once on first load)
+  useEffect(() => {
+    if (query.data && !draft) {
+      setDraft(parseConfig(query.data));
+    }
+  }, [query.data, draft]);
+
+  const saveMutation = useMutation({
+    mutationFn: (cfg: EReceiptConfig) =>
+      api.patch('/settings', {
+        items: [{ key: CONFIG_KEY, value: JSON.stringify(cfg) }],
+      }),
+    onSuccess: () => {
+      toast.success('บันทึกการตั้งค่าสำเร็จ');
+      qc.invalidateQueries({ queryKey: ['settings'] });
+    },
+    onError: () => toast.error('บันทึกล้มเหลว กรุณาลองใหม่'),
+  });
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="ใบเสร็จอิเล็กทรอนิกส์อัตโนมัติ"
+        icon={<FileText className="size-5" />}
+        subtitle="ตั้งค่าการส่งใบเสร็จอัตโนมัติเมื่อบันทึกรับชำระค่างวด"
+      />
+      <QueryBoundary
+        isLoading={query.isLoading}
+        isError={query.isError}
+        error={query.error}
+        onRetry={query.refetch}
+      >
+        {draft && (
+          <Card className="max-w-lg">
+            <CardHeader>
+              <h3 className="font-semibold text-foreground">ตั้งค่าการส่งใบเสร็จ</h3>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* Enabled toggle */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="font-medium text-sm">เปิดใช้งานอัตโนมัติ</div>
+                  <div className="text-xs text-muted-foreground leading-snug mt-0.5">
+                    ส่งใบเสร็จทันทีเมื่อบันทึกการรับชำระ
+                  </div>
+                </div>
+                <Switch
+                  checked={draft.enabled}
+                  onCheckedChange={(v) => setDraft({ ...draft, enabled: v })}
+                />
+              </div>
+
+              {/* Delivery channel */}
+              <div>
+                <label className="text-sm font-medium block mb-2">ช่องทางการส่ง</label>
+                <div className="flex gap-2">
+                  {(['LINE', 'EMAIL', 'BOTH'] as const).map((c) => (
+                    <Button
+                      key={c}
+                      type="button"
+                      variant={draft.deliveryChannel === c ? 'primary' : 'outline'}
+                      size="sm"
+                      onClick={() => setDraft({ ...draft, deliveryChannel: c })}
+                    >
+                      {c === 'BOTH' ? 'LINE + Email' : c}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Template */}
+              <div>
+                <label className="text-sm font-medium block mb-2">รูปแบบ Template</label>
+                <div className="flex gap-2">
+                  {(['STANDARD', 'SIMPLE'] as const).map((t) => (
+                    <Button
+                      key={t}
+                      type="button"
+                      variant={draft.template === t ? 'primary' : 'outline'}
+                      size="sm"
+                      onClick={() => setDraft({ ...draft, template: t })}
+                    >
+                      {t === 'STANDARD' ? 'มาตรฐาน (เต็มรูปแบบ)' : 'แบบย่อ (สั้น)'}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Signer name */}
+              <div>
+                <label className="text-sm font-medium block mb-2" htmlFor="signer-name">
+                  ชื่อผู้เซ็นใบเสร็จ
+                </label>
+                <input
+                  id="signer-name"
+                  type="text"
+                  className="w-full border border-input rounded-lg px-3 py-2 bg-card text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 outline-none text-sm"
+                  value={draft.signerName}
+                  onChange={(e) => setDraft({ ...draft, signerName: e.target.value })}
+                  placeholder="ชื่อ-นามสกุล ผู้เซ็น"
+                />
+              </div>
+
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="primary"
+                  onClick={() => draft && saveMutation.mutate(draft)}
+                  disabled={saveMutation.isPending}
+                >
+                  <Save className="size-4 mr-1.5" />
+                  บันทึก
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/ETaxPage.tsx
+++ b/apps/web/src/pages/finance/ETaxPage.tsx
@@ -1,0 +1,264 @@
+/**
+ * ETaxPage — e-Tax Invoice document center (SP2 frontend)
+ *
+ * Uses the existing /e-tax/invoices endpoint (Phase 2-SP5).
+ * Requires companyId + year + month selection before data loads.
+ */
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import CompanyFilter from '@/components/CompanyFilter';
+import { formatNumberDecimal, formatDateMedium } from '@/utils/formatters';
+import { FileText, Download, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface ETaxInvoice {
+  paymentId: string;
+  paidDate: string | Date | null;
+  installmentNo: number;
+  contractNumber: string;
+  customerName: string;
+  amountBeforeVat: number | string;
+  vatAmount: number | string;
+  total: number | string;
+}
+
+interface ETaxListResponse {
+  data: ETaxInvoice[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+interface ETaxSubmission {
+  id: string;
+  paymentId: string;
+  status: 'PENDING' | 'SIGNED' | 'SUBMITTED' | 'ACCEPTED' | 'REJECTED' | 'ERROR';
+  rdSubmissionId: string | null;
+  rejectReason: string | null;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  PENDING: 'รอเซ็น',
+  SIGNED: 'รอส่ง',
+  SUBMITTED: 'ส่งแล้ว',
+  ACCEPTED: 'สรรพากรรับ',
+  REJECTED: 'ปฏิเสธ',
+  ERROR: 'ข้อผิดพลาด',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  PENDING: 'bg-muted text-muted-foreground',
+  SIGNED: 'bg-blue-500/15 text-blue-700',
+  SUBMITTED: 'bg-amber-500/15 text-amber-700',
+  ACCEPTED: 'bg-emerald-500/15 text-emerald-700',
+  REJECTED: 'bg-red-500/15 text-red-700',
+  ERROR: 'bg-red-500/15 text-red-700',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const color = STATUS_COLOR[status] ?? 'bg-muted text-muted-foreground';
+  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${color}`}>{STATUS_LABEL[status] ?? status}</span>;
+}
+
+export default function ETaxPage() {
+  const now = new Date();
+  const qc = useQueryClient();
+  const [companyId, setCompanyId] = useState('');
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const enabled = Boolean(companyId);
+
+  const invoicesQuery = useQuery<ETaxListResponse>({
+    queryKey: ['e-tax-finance', 'invoices', companyId, year, month],
+    enabled,
+    queryFn: () =>
+      api
+        .get<ETaxListResponse>(
+          `/e-tax/invoices?companyId=${encodeURIComponent(companyId)}&year=${year}&month=${month}&limit=200`,
+        )
+        .then((r) => r.data),
+  });
+
+  const submissionsQuery = useQuery<{ data: ETaxSubmission[] }>({
+    queryKey: ['e-tax-finance', 'submissions'],
+    enabled,
+    queryFn: () =>
+      api.get<{ data: ETaxSubmission[] }>('/e-tax-xml?limit=500').then((r) => r.data),
+  });
+
+  const submissionsByPayment = new Map<string, ETaxSubmission>();
+  for (const s of submissionsQuery.data?.data ?? []) {
+    submissionsByPayment.set(s.paymentId, s);
+  }
+
+  const generateMutation = useMutation({
+    mutationFn: (paymentId: string) =>
+      api.post(`/e-tax-xml/generate/${paymentId}`).then((r) => r.data),
+    onSuccess: () => {
+      toast.success('สร้าง XML สำเร็จ');
+      qc.invalidateQueries({ queryKey: ['e-tax-finance', 'submissions'] });
+    },
+    onError: (e: Error) => toast.error(e.message ?? 'สร้าง XML ล้มเหลว'),
+  });
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="e-Tax Invoice — Document Center"
+        icon={<FileText className="size-5" />}
+      />
+      <Card>
+        <CardHeader className="flex flex-row gap-3 items-center flex-wrap pb-4">
+          <CompanyFilter value={companyId} onChange={setCompanyId} />
+          <Select value={String(year)} onValueChange={(v) => setYear(parseInt(v, 10))}>
+            <SelectTrigger className="w-[110px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[year - 2, year - 1, year, year + 1].map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y + 543}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={String(month)} onValueChange={(v) => setMonth(parseInt(v, 10))}>
+            <SelectTrigger className="w-[130px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Array.from({ length: 12 }, (_, i) => (
+                <SelectItem key={i} value={String(i + 1)}>
+                  เดือน {i + 1}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </CardHeader>
+        <CardContent>
+          {!companyId ? (
+            <div className="text-center text-muted-foreground py-12">
+              กรุณาเลือกบริษัทเพื่อดูรายการ e-Tax Invoice
+            </div>
+          ) : (
+            <QueryBoundary
+              isLoading={invoicesQuery.isLoading}
+              isError={invoicesQuery.isError}
+              error={invoicesQuery.error}
+              onRetry={invoicesQuery.refetch}
+            >
+              {invoicesQuery.data && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>วันที่</TableHead>
+                      <TableHead>สัญญา</TableHead>
+                      <TableHead>งวด</TableHead>
+                      <TableHead>ลูกค้า</TableHead>
+                      <TableHead className="text-right">ก่อน VAT (฿)</TableHead>
+                      <TableHead className="text-right">VAT (฿)</TableHead>
+                      <TableHead className="text-right">รวม (฿)</TableHead>
+                      <TableHead className="text-center">สถานะ XML</TableHead>
+                      <TableHead className="text-center">การกระทำ</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {invoicesQuery.data.data.length === 0 ? (
+                      <TableRow>
+                        <TableCell
+                          colSpan={9}
+                          className="text-center text-muted-foreground py-10"
+                        >
+                          ไม่มีรายการในงวดที่เลือก
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      invoicesQuery.data.data.map((inv) => {
+                        const sub = submissionsByPayment.get(inv.paymentId);
+                        const isFailed = sub?.status === 'REJECTED' || sub?.status === 'ERROR';
+                        return (
+                          <TableRow key={inv.paymentId}>
+                            <TableCell>
+                              {inv.paidDate ? formatDateMedium(String(inv.paidDate)) : '—'}
+                            </TableCell>
+                            <TableCell className="font-mono text-xs">
+                              {inv.contractNumber}
+                            </TableCell>
+                            <TableCell className="text-center">{inv.installmentNo}</TableCell>
+                            <TableCell className="text-sm leading-snug">
+                              {inv.customerName}
+                            </TableCell>
+                            <TableCell className="text-right font-mono tabular-nums">
+                              {formatNumberDecimal(Number(inv.amountBeforeVat), 2)}
+                            </TableCell>
+                            <TableCell className="text-right font-mono tabular-nums">
+                              {formatNumberDecimal(Number(inv.vatAmount), 2)}
+                            </TableCell>
+                            <TableCell className="text-right font-mono tabular-nums">
+                              {formatNumberDecimal(Number(inv.total), 2)}
+                            </TableCell>
+                            <TableCell className="text-center">
+                              {sub ? <StatusBadge status={sub.status} /> : <span className="text-xs text-muted-foreground">—</span>}
+                            </TableCell>
+                            <TableCell className="text-center">
+                              <div className="flex items-center justify-center gap-1">
+                                {sub?.status === 'ACCEPTED' && (
+                                  <Button variant="outline" size="sm" asChild>
+                                    <a
+                                      href={`/api/e-tax/invoices/${inv.paymentId}/pdf`}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      aria-label="ดาวน์โหลด PDF"
+                                    >
+                                      <Download className="size-4" />
+                                    </a>
+                                  </Button>
+                                )}
+                                {(isFailed || !sub) && (
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => generateMutation.mutate(inv.paymentId)}
+                                    disabled={generateMutation.isPending}
+                                    aria-label="สร้าง XML ใหม่"
+                                  >
+                                    <RefreshCw className="size-4" />
+                                  </Button>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
+                    )}
+                  </TableBody>
+                </Table>
+              )}
+            </QueryBoundary>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/VatAutoJournalPage.tsx
+++ b/apps/web/src/pages/finance/VatAutoJournalPage.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import { formatNumberDecimal, formatDateMedium } from '@/utils/formatters';
+import { Calculator } from 'lucide-react';
+
+interface VatLine {
+  accountCode: string;
+  accountName: string;
+  debit: number;
+  credit: number;
+}
+
+interface VatJEEntry {
+  id: string;
+  documentNumber: string;
+  postedAt: string;
+  sourceType: string;
+  description: string;
+  vatLines: VatLine[];
+}
+
+interface VatAutoJournalData {
+  period: { year: number; month: number };
+  entries: VatJEEntry[];
+}
+
+export default function VatAutoJournalPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const query = useQuery({
+    queryKey: ['vat-auto-journal', year, month],
+    queryFn: () =>
+      api
+        .get<VatAutoJournalData>(
+          `/finance-tax/vat-auto-journal?year=${year}&month=${month}`,
+        )
+        .then((r) => r.data),
+  });
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="VAT Auto Journal — รายการอัตโนมัติประจำเดือน"
+        icon={<Calculator className="size-5" />}
+        subtitle="รายการสมุดรายวันที่มีบัญชี VAT (21-2101, 21-2102, 11-4101, 11-2104, 11-2105)"
+      />
+      <Card>
+        <CardHeader className="flex flex-row gap-3 items-center flex-wrap pb-4">
+          <Select value={String(year)} onValueChange={(v) => setYear(parseInt(v, 10))}>
+            <SelectTrigger className="w-[110px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[year - 2, year - 1, year, year + 1].map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y + 543}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={String(month)} onValueChange={(v) => setMonth(parseInt(v, 10))}>
+            <SelectTrigger className="w-[130px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Array.from({ length: 12 }, (_, i) => (
+                <SelectItem key={i} value={String(i + 1)}>
+                  เดือน {i + 1}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {query.data && (
+            <span className="text-sm text-muted-foreground ml-auto">
+              {query.data.entries.length} รายการ
+            </span>
+          )}
+        </CardHeader>
+        <CardContent>
+          <QueryBoundary
+            isLoading={query.isLoading}
+            isError={query.isError}
+            error={query.error}
+            onRetry={query.refetch}
+          >
+            {query.data && (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>วันที่</TableHead>
+                    <TableHead>เลขเอกสาร</TableHead>
+                    <TableHead>ที่มา (Source)</TableHead>
+                    <TableHead>คำอธิบาย</TableHead>
+                    <TableHead>บัญชี VAT</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {query.data.entries.length === 0 ? (
+                    <TableRow>
+                      <TableCell
+                        colSpan={5}
+                        className="text-center text-muted-foreground py-10"
+                      >
+                        ไม่มีรายการ VAT Journal ในงวดที่เลือก
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    query.data.entries.map((entry) => (
+                      <TableRow key={entry.id}>
+                        <TableCell className="whitespace-nowrap">
+                          {formatDateMedium(entry.postedAt)}
+                        </TableCell>
+                        <TableCell>
+                          <Link
+                            to={`/finance/general-journal?je=${entry.id}`}
+                            className="font-mono text-xs text-primary hover:underline"
+                          >
+                            {entry.documentNumber}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {entry.sourceType}
+                        </TableCell>
+                        <TableCell className="text-sm leading-snug max-w-[200px] truncate">
+                          {entry.description}
+                        </TableCell>
+                        <TableCell>
+                          <div className="space-y-0.5">
+                            {entry.vatLines.map((l, i) => (
+                              <div key={i} className="text-xs flex gap-2">
+                                <span className="font-mono text-muted-foreground w-[52px] shrink-0">
+                                  {l.accountCode}
+                                </span>
+                                {l.debit > 0 ? (
+                                  <span>
+                                    Dr{' '}
+                                    <span className="font-mono tabular-nums">
+                                      {formatNumberDecimal(l.debit, 2)}
+                                    </span>
+                                  </span>
+                                ) : (
+                                  <span className="text-muted-foreground">
+                                    Cr{' '}
+                                    <span className="font-mono tabular-nums">
+                                      {formatNumberDecimal(l.credit, 2)}
+                                    </span>
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            )}
+          </QueryBoundary>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/VatPage.tsx
+++ b/apps/web/src/pages/finance/VatPage.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import { formatNumberDecimal, formatDateMedium } from '@/utils/formatters';
+import { Calculator, Download } from 'lucide-react';
+
+const MONTHS = [
+  'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.',
+  'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.',
+];
+
+interface VatLine {
+  accountCode: string;
+  documentNumber: string;
+  postedAt: string;
+  description: string;
+  debit: number;
+  credit: number;
+}
+
+interface VatData {
+  period: { year: number; month: number };
+  vatOutput: number;
+  vatDeferred: number;
+  vatInput: number;
+  netVat: number;
+  lineCount: number;
+  lines: VatLine[];
+}
+
+function SummaryCard({
+  label,
+  value,
+  className,
+  bold,
+}: {
+  label: string;
+  value: number;
+  className?: string;
+  bold?: boolean;
+}) {
+  return (
+    <Card className={className}>
+      <CardContent className="p-4">
+        <div className="text-xs font-medium text-muted-foreground leading-snug">{label}</div>
+        <div className={`text-xl mt-1 font-mono ${bold ? 'font-bold' : 'font-semibold'}`}>
+          {formatNumberDecimal(value, 2)} ฿
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function VatPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const query = useQuery({
+    queryKey: ['vat-monthly', year, month],
+    queryFn: () =>
+      api
+        .get<VatData>(`/finance-tax/vat-monthly?year=${year}&month=${month}`)
+        .then((r) => r.data),
+  });
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="VAT (ภ.พ.30) — รายเดือน"
+        icon={<Calculator className="size-5" />}
+      />
+      <Card>
+        <CardHeader className="flex flex-row gap-3 items-end flex-wrap pb-4">
+          <div className="flex gap-3 items-center">
+            <Select value={String(year)} onValueChange={(v) => setYear(parseInt(v, 10))}>
+              <SelectTrigger className="w-[110px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[year - 2, year - 1, year, year + 1].map((y) => (
+                  <SelectItem key={y} value={String(y)}>
+                    {y + 543}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={String(month)} onValueChange={(v) => setMonth(parseInt(v, 10))}>
+              <SelectTrigger className="w-[130px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MONTHS.map((m, i) => (
+                  <SelectItem key={i} value={String(i + 1)}>
+                    {m}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <QueryBoundary
+            isLoading={query.isLoading}
+            isError={query.isError}
+            error={query.error}
+            onRetry={query.refetch}
+          >
+            {query.data && (
+              <>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+                  <SummaryCard
+                    label="ภาษีขาย 21-2101"
+                    value={query.data.vatOutput}
+                    className="border-emerald-500/30 bg-emerald-500/5"
+                  />
+                  <SummaryCard
+                    label="ภาษีขายรอเรียกเก็บ 21-2102"
+                    value={query.data.vatDeferred}
+                    className="border-amber-500/30 bg-amber-500/5"
+                  />
+                  <SummaryCard
+                    label="ภาษีซื้อ 11-4101"
+                    value={query.data.vatInput}
+                    className="border-blue-500/30 bg-blue-500/5"
+                  />
+                  <SummaryCard
+                    label="VAT สุทธิ (ออก − ซื้อ)"
+                    value={query.data.netVat}
+                    className="border-primary/30 bg-primary/5"
+                    bold
+                  />
+                </div>
+
+                <div className="flex justify-end mb-4 gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => toast.info('Excel export — coming soon')}
+                  >
+                    <Download className="size-4 mr-1.5" />
+                    Excel
+                  </Button>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => toast.info('XML e-filing — coming soon')}
+                  >
+                    <Download className="size-4 mr-1.5" />
+                    XML (e-filing)
+                  </Button>
+                </div>
+
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>วันที่</TableHead>
+                      <TableHead>เลขเอกสาร</TableHead>
+                      <TableHead>คำอธิบาย</TableHead>
+                      <TableHead>บัญชี</TableHead>
+                      <TableHead className="text-right">เดบิต</TableHead>
+                      <TableHead className="text-right">เครดิต</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {query.data.lines.length === 0 ? (
+                      <TableRow>
+                        <TableCell
+                          colSpan={6}
+                          className="text-center text-muted-foreground py-10"
+                        >
+                          ไม่มีรายการในงวดที่เลือก
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      query.data.lines.map((l, i) => (
+                        <TableRow key={i}>
+                          <TableCell>{formatDateMedium(l.postedAt)}</TableCell>
+                          <TableCell className="font-mono text-xs">{l.documentNumber}</TableCell>
+                          <TableCell className="text-sm leading-snug">{l.description}</TableCell>
+                          <TableCell className="font-mono text-xs">{l.accountCode}</TableCell>
+                          <TableCell className="text-right font-mono tabular-nums">
+                            {l.debit ? formatNumberDecimal(l.debit, 2) : '—'}
+                          </TableCell>
+                          <TableCell className="text-right font-mono tabular-nums">
+                            {l.credit ? formatNumberDecimal(l.credit, 2) : '—'}
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </>
+            )}
+          </QueryBoundary>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/WhtPage.tsx
+++ b/apps/web/src/pages/finance/WhtPage.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { formatNumberDecimal, formatDateMedium } from '@/utils/formatters';
+import { Calculator } from 'lucide-react';
+
+interface WhtLine {
+  documentNumber: string;
+  postedAt: string;
+  description: string;
+  amount: number;
+}
+
+interface WhtBucket {
+  lines: WhtLine[];
+  total: number;
+}
+
+interface WhtData {
+  period: { year: number; month: number };
+  PND1: WhtBucket;
+  PND3: WhtBucket;
+  PND53: WhtBucket;
+  grandTotal: number;
+}
+
+const FORM_LABELS: Record<string, string> = {
+  PND1: 'ภ.ง.ด. 1 — เงินเดือน',
+  PND3: 'ภ.ง.ด. 3 — บุคคลธรรมดา',
+  PND53: 'ภ.ง.ด. 53 — นิติบุคคล',
+};
+
+function WhtTable({ bucket, formKey }: { bucket: WhtBucket; formKey: string }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>วันที่</TableHead>
+          <TableHead>เลขเอกสาร</TableHead>
+          <TableHead>คำอธิบาย</TableHead>
+          <TableHead className="text-right">จำนวน (฿)</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {bucket.lines.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
+              ไม่มีรายการ {formKey} ในงวดที่เลือก
+            </TableCell>
+          </TableRow>
+        ) : (
+          <>
+            {bucket.lines.map((l, i) => (
+              <TableRow key={i}>
+                <TableCell>{formatDateMedium(l.postedAt)}</TableCell>
+                <TableCell className="font-mono text-xs">{l.documentNumber}</TableCell>
+                <TableCell className="text-sm leading-snug">{l.description}</TableCell>
+                <TableCell className="text-right font-mono tabular-nums">
+                  {formatNumberDecimal(l.amount, 2)}
+                </TableCell>
+              </TableRow>
+            ))}
+            <TableRow className="font-semibold border-t-2 border-border">
+              <TableCell colSpan={3} className="text-sm">
+                รวม {formKey}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {formatNumberDecimal(bucket.total, 2)} ฿
+              </TableCell>
+            </TableRow>
+          </>
+        )}
+      </TableBody>
+    </Table>
+  );
+}
+
+export default function WhtPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const query = useQuery({
+    queryKey: ['wht-monthly', year, month],
+    queryFn: () =>
+      api
+        .get<WhtData>(`/finance-tax/wht-monthly?year=${year}&month=${month}`)
+        .then((r) => r.data),
+  });
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="WHT (ภ.ง.ด. 1/3/53) — รายเดือน"
+        icon={<Calculator className="size-5" />}
+      />
+      <Card>
+        <CardHeader className="flex flex-row gap-3 items-center flex-wrap pb-4">
+          <Select value={String(year)} onValueChange={(v) => setYear(parseInt(v, 10))}>
+            <SelectTrigger className="w-[110px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[year - 2, year - 1, year, year + 1].map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y + 543}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={String(month)} onValueChange={(v) => setMonth(parseInt(v, 10))}>
+            <SelectTrigger className="w-[130px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Array.from({ length: 12 }, (_, i) => (
+                <SelectItem key={i} value={String(i + 1)}>
+                  เดือน {i + 1}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {query.data && (
+            <span className="text-sm text-muted-foreground ml-auto">
+              รวมทุกแบบ:{' '}
+              <span className="font-mono font-semibold">
+                {formatNumberDecimal(query.data.grandTotal, 2)} ฿
+              </span>
+            </span>
+          )}
+        </CardHeader>
+        <CardContent>
+          <QueryBoundary
+            isLoading={query.isLoading}
+            isError={query.isError}
+            error={query.error}
+            onRetry={query.refetch}
+          >
+            {query.data && (
+              <Tabs defaultValue="PND3">
+                <TabsList className="mb-4">
+                  {(['PND1', 'PND3', 'PND53'] as const).map((form) => (
+                    <TabsTrigger key={form} value={form}>
+                      {FORM_LABELS[form]}{' '}
+                      <span className="ml-1.5 font-mono text-xs">
+                        {formatNumberDecimal(query.data![form].total, 2)} ฿
+                      </span>
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+                {(['PND1', 'PND3', 'PND53'] as const).map((form) => (
+                  <TabsContent key={form} value={form}>
+                    <WhtTable bucket={query.data![form]} formKey={form} />
+                  </TabsContent>
+                ))}
+              </Tabs>
+            )}
+          </QueryBoundary>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements P4-SP2 per [plan](https://github.com/iamnaii/BESTCHOICE/blob/main/docs/superpowers/plans/2026-05-19-p4-sp2-tax-ui.md). Adds tax submission UI on top of existing CPA journal templates that already write VAT/WHT to JE lines.

## Backend (Tasks 1-4)

New module \`apps/api/src/modules/finance-tax/\`:

| Endpoint | Method | Purpose |
|---|---|---|
| \`GET /finance-tax/vat-monthly\` | \`getVatMonthly\` | VAT output/deferred/input aggregation per month |
| \`GET /finance-tax/wht-monthly\` | \`getWhtMonthly\` | WHT split by PND.1/3/53 with per-form totals |
| \`GET /finance-tax/vat-auto-journal\` | \`getVatAutoJournalHistory\` | All JEs touching VAT accounts within period |

**Tests:** 9/9 pass (4 VAT + 3 WHT + 2 Auto-Journal).

## Frontend (Tasks 5-9)

5 new pages replacing ComingSoonPage placeholders:

1. \`/finance/vat\` — **VatPage** (year/month + 4 summary cards + JE table)
2. \`/finance/wht\` — **WhtPage** (3 tabs: PND.1/3/53)
3. \`/finance/e-tax\` — **ETaxPage** (e-Tax doc center w/ resend)
4. \`/finance/vat-auto-journal\` — **VatAutoJournalPage** (NEW item in menu)
5. \`/finance/e-receipt-auto\` — **EReceiptAutoPage** (SystemConfig form)

Menu config updates:
- Removed \`placeholder\` markers from 4 tax items (owner-tax + acc-tax + acc-reports + e-receipt-auto)
- Added VAT Auto Journal to owner-tax, acc-tax, acc-reports, fm-finance sections

## Adaptations from plan (discovered during impl)

- \`formatTHB\` doesn't exist → used \`formatNumberDecimal(val, 2)\` + \` ฿\` suffix (matches ExpensesPage pattern)
- \`QueryBoundary\` is prop-based (\`isLoading/isError/onRetry\`), not render-prop
- ETaxPage uses existing \`/e-tax/invoices\` endpoint (needs companyId/year/month) — added CompanyFilter + "select company" prompt
- EReceiptAutoPage saves via \`PATCH /settings\` with snake_case key \`e_receipt_auto\` (matches existing SettingItemDto regex)
- \`PageHeader.icon\` is ReactNode not LucideIcon — wrapped as \`<Calculator className="size-5" />\`

Web version: **26.5.9 → 26.5.10**

## Test plan
- [x] API jest: 9 new tests pass
- [x] Web vitest menu.test.ts: 19/19 pass
- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] Vite build: success
- [ ] After merge: auto-deploy + visual check on all 5 menu items

## Commits

\`\`\`
8516178a EReceiptAutoPage + wire all routes
16ec404f VatAutoJournalPage — VAT JE history viewer
44e5699b ETaxPage — invoice list + resend on failed
34c071ff WhtPage — tabs per PND form
c7ccbbb7 VatPage — monthly aggregation + summary cards
1d6e6236 VAT auto-journal history endpoint
be2b8aaf WHT monthly aggregation per form (PND.1/3/53)
ef9e6995 VAT monthly aggregation endpoint
d0e271ba scaffold finance-tax module
+ chore: bump web 26.5.9 → 26.5.10
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)