### PR TITLE
feat(p4-sp4): ยกเลิกสัญญา + Inter-co Report (2 pages + schema + JE template)

### DIFF
--- a/apps/api/prisma/migrations/20260954000000_contract_cancellation/migration.sql
+++ b/apps/api/prisma/migrations/20260954000000_contract_cancellation/migration.sql
@@ -1,0 +1,58 @@
+-- P4-SP4: ContractCancellation model + CANCELED enum value
+-- Adds contract cancellation workflow with JE reversal support.
+
+-- Add CANCELED to ContractStatus enum
+ALTER TYPE "ContractStatus" ADD VALUE 'CANCELED';
+
+-- Add ContractCancellationStatus enum
+CREATE TYPE "ContractCancellationStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- Create contract_cancellations table
+CREATE TABLE "contract_cancellations" (
+    "id" TEXT NOT NULL,
+    "contract_id" TEXT NOT NULL,
+    "requested_by_id" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "refund_amount" DECIMAL(12,2) NOT NULL,
+    "status" "ContractCancellationStatus" NOT NULL DEFAULT 'PENDING',
+    "approved_by_id" TEXT,
+    "approved_at" TIMESTAMP(3),
+    "reversal_journal_entry_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "contract_cancellations_pkey" PRIMARY KEY ("id")
+);
+
+-- Unique constraint on reversal_journal_entry_id (1:1 with JournalEntry)
+CREATE UNIQUE INDEX "contract_cancellations_reversal_journal_entry_id_key"
+    ON "contract_cancellations"("reversal_journal_entry_id");
+
+-- Indexes for common query patterns
+CREATE INDEX "contract_cancellations_contract_id_idx"
+    ON "contract_cancellations"("contract_id");
+
+CREATE INDEX "contract_cancellations_status_idx"
+    ON "contract_cancellations"("status");
+
+-- Foreign keys
+ALTER TABLE "contract_cancellations"
+    ADD CONSTRAINT "contract_cancellations_contract_id_fkey"
+    FOREIGN KEY ("contract_id") REFERENCES "contracts"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "contract_cancellations"
+    ADD CONSTRAINT "contract_cancellations_requested_by_id_fkey"
+    FOREIGN KEY ("requested_by_id") REFERENCES "users"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "contract_cancellations"
+    ADD CONSTRAINT "contract_cancellations_approved_by_id_fkey"
+    FOREIGN KEY ("approved_by_id") REFERENCES "users"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "contract_cancellations"
+    ADD CONSTRAINT "contract_cancellations_reversal_journal_entry_id_fkey"
+    FOREIGN KEY ("reversal_journal_entry_id") REFERENCES "journal_entries"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -45,6 +45,13 @@ enum ContractStatus {
   EXCHANGED
   DEFECT_EXCHANGED
   CLOSED_BAD_DEBT
+  CANCELED // ยกเลิกสัญญา — ย้อนรายการบัญชีทั้งหมด (ContractCancellation)
+}
+
+enum ContractCancellationStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 // P1 Collections UI — Saved Filter Presets (Task 3)
@@ -746,6 +753,10 @@ model User {
   // P3-SP4 — PDPA PII encryption backfill triggers (forensics: who started a backfill run)
   pdpaBackfillRunsTriggered PdpaBackfillRun[] @relation("PdpaBackfillTriggeredBy")
 
+  // P4-SP4 — Contract cancellation requests made/approved by this user
+  cancellationRequests  ContractCancellation[] @relation("CancellationRequester")
+  cancellationsApproved ContractCancellation[] @relation("CancellationApprover")
+
   @@index([branchId])
   @@index([yeastarExtension])
   @@map("users")
@@ -1064,6 +1075,9 @@ model Contract {
 
   // Phase A.4 — installment schedule rows
   installmentSchedules InstallmentSchedule[]
+
+  // P4-SP4: Contract cancellation requests
+  cancellations ContractCancellation[] @relation("ContractCancellations")
 
   @@index([customerId])
   @@index([branchId])
@@ -3569,6 +3583,8 @@ model JournalEntry {
   assetInvoiceTransferFor FixedAsset?               @relation("AssetInvoiceTransferJE")
   /// SP2: InterCompanyTransactions that this JE settled (typically 1 per JE).
   icSettlements           InterCompanyTransaction[] @relation("ICSettlementJE")
+  /// P4-SP4: ContractCancellation that this JE is the reversal for (0..1).
+  contractCancellationReversal ContractCancellation? @relation("CancellationReversal")
   // Partial unique index enforced via migration (CREATE UNIQUE INDEX ... WHERE reference_type IS NOT NULL)
   // Prisma cannot express partial @@unique; see migration 20260428010000_journal_entries_ref_unique
 
@@ -6773,4 +6789,31 @@ model ExternalFinanceCommission {
   @@index([status])
   @@index([receivedAt])
   @@map("external_finance_commissions")
+}
+
+// ============================================================
+// P4-SP4: Contract Cancellation (Task 1)
+// ============================================================
+
+model ContractCancellation {
+  id                     String                     @id @default(uuid())
+  contractId             String                     @map("contract_id")
+  contract               Contract                   @relation("ContractCancellations", fields: [contractId], references: [id])
+  requestedById          String                     @map("requested_by_id")
+  requestedBy            User                       @relation("CancellationRequester", fields: [requestedById], references: [id])
+  reason                 String
+  refundAmount           Decimal                    @map("refund_amount") @db.Decimal(12, 2)
+  status                 ContractCancellationStatus @default(PENDING)
+  approvedById           String?                    @map("approved_by_id")
+  approvedBy             User?                      @relation("CancellationApprover", fields: [approvedById], references: [id])
+  approvedAt             DateTime?                  @map("approved_at")
+  reversalJournalEntryId String?                    @unique @map("reversal_journal_entry_id")
+  reversalJournalEntry   JournalEntry?              @relation("CancellationReversal", fields: [reversalJournalEntryId], references: [id])
+  createdAt              DateTime                   @default(now()) @map("created_at")
+  updatedAt              DateTime                   @updatedAt @map("updated_at")
+  deletedAt              DateTime?                  @map("deleted_at")
+
+  @@index([contractId])
+  @@index([status])
+  @@map("contract_cancellations")
 }

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -15,6 +15,7 @@ import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { AccountingService } from './accounting.service';
 import { BadDebtService } from './bad-debt.service';
 import { MonthlyCloseService } from './monthly-close.service';
+import { IntercompanyReportService } from './intercompany-report.service';
 import { CloseMonthDto } from './dto/monthly-close.dto';
 import { ReopenPeriodDto } from './dto/reopen-period.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -39,6 +40,7 @@ export class AccountingController {
     private service: AccountingService,
     private badDebtService: BadDebtService,
     private monthlyCloseService: MonthlyCloseService,
+    private intercoReportService: IntercompanyReportService,
   ) {}
 
   // ============================================================
@@ -348,5 +350,21 @@ export class AccountingController {
     @Request() req: { user: { id: string }; ip?: string },
   ) {
     return this.monthlyCloseService.reopenPeriod(dto, req.user.id, req.ip);
+  }
+
+  // ============================================================
+  // P4-SP4: Inter-Company Report — FINANCE↔SHOP payables (21-1101, 21-1102)
+  // ============================================================
+
+  @Get('inter-co/report')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getInterCoReport(
+    @Query('start') start: string,
+    @Query('end') end: string,
+  ) {
+    if (!start || !end) {
+      throw new BadRequestException('กรุณาระบุ start และ end (ISO date string)');
+    }
+    return this.intercoReportService.getReport(new Date(start), new Date(end));
   }
 }

--- a/apps/api/src/modules/accounting/accounting.module.ts
+++ b/apps/api/src/modules/accounting/accounting.module.ts
@@ -9,6 +9,7 @@ import { MonthlyCloseService } from './monthly-close.service';
 import { AccountingClosingService } from './closing.service';
 import { ConsolidatedService } from './consolidated.service';
 import { ConsolidatedController } from './consolidated.controller';
+import { IntercompanyReportService } from './intercompany-report.service';
 import { JournalModule } from '../journal/journal.module';
 import { TaxModule } from '../tax/tax.module';
 import { PeakModule } from '../peak/peak.module';
@@ -24,6 +25,7 @@ import { PeakModule } from '../peak/peak.module';
     MonthlyCloseService,
     AccountingClosingService,
     ConsolidatedService,
+    IntercompanyReportService,
   ],
   exports: [
     AccountingService,
@@ -32,6 +34,7 @@ import { PeakModule } from '../peak/peak.module';
     MonthlyCloseService,
     AccountingClosingService,
     ConsolidatedService,
+    IntercompanyReportService,
   ],
 })
 export class AccountingModule {}

--- a/apps/api/src/modules/accounting/intercompany-report.service.spec.ts
+++ b/apps/api/src/modules/accounting/intercompany-report.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { IntercompanyReportService } from './intercompany-report.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('IntercompanyReportService', () => {
+  let service: IntercompanyReportService;
+  let prisma: any;
+
+  const periodStart = new Date('2026-01-01T00:00:00Z');
+  const periodEnd = new Date('2026-01-31T23:59:59Z');
+
+  beforeEach(async () => {
+    prisma = {
+      journalLine: {
+        groupBy: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IntercompanyReportService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<IntercompanyReportService>(IntercompanyReportService);
+  });
+
+  // ─── Test 1: zero activity → all zeros ───────────────────────────────────
+
+  it('returns zero balances when no journal lines exist for the period', async () => {
+    prisma.journalLine.groupBy.mockResolvedValue([]);
+
+    const report = await service.getReport(periodStart, periodEnd);
+
+    expect(report.lines).toHaveLength(2);
+    expect(report.total.openingBalance).toBe(0);
+    expect(report.total.accruals).toBe(0);
+    expect(report.total.settlements).toBe(0);
+    expect(report.total.closingBalance).toBe(0);
+  });
+
+  // ─── Test 2: correct opening + period aggregation ────────────────────────
+
+  it('computes opening, accruals, settlements, closing correctly', async () => {
+    // First groupBy call: opening (before periodStart)
+    // 21-1101: Cr 17000, Dr 0 → opening = 17000
+    // 21-1102: Cr 1700, Dr 0  → opening = 1700
+    prisma.journalLine.groupBy
+      .mockResolvedValueOnce([
+        { accountCode: '21-1101', _sum: { debit: new Prisma.Decimal(0), credit: new Prisma.Decimal(17000) } },
+        { accountCode: '21-1102', _sum: { debit: new Prisma.Decimal(0), credit: new Prisma.Decimal(1700) } },
+      ])
+      // Second groupBy call: period movements
+      // 21-1101: Cr 5000 (new contract), Dr 17000 (settlement) → accruals=5000, settlements=17000
+      // 21-1102: Cr 500, Dr 1700 → accruals=500, settlements=1700
+      .mockResolvedValueOnce([
+        { accountCode: '21-1101', _sum: { debit: new Prisma.Decimal(17000), credit: new Prisma.Decimal(5000) } },
+        { accountCode: '21-1102', _sum: { debit: new Prisma.Decimal(1700), credit: new Prisma.Decimal(500) } },
+      ]);
+
+    const report = await service.getReport(periodStart, periodEnd);
+
+    const line1101 = report.lines.find((l) => l.accountCode === '21-1101')!;
+    expect(line1101.openingBalance).toBe(17000);
+    expect(line1101.accruals).toBe(5000);
+    expect(line1101.settlements).toBe(17000);
+    expect(line1101.closingBalance).toBe(5000); // 17000 + 5000 - 17000
+
+    const line1102 = report.lines.find((l) => l.accountCode === '21-1102')!;
+    expect(line1102.openingBalance).toBe(1700);
+    expect(line1102.accruals).toBe(500);
+    expect(line1102.settlements).toBe(1700);
+    expect(line1102.closingBalance).toBe(500);
+
+    // Total
+    expect(report.total.openingBalance).toBe(18700);
+    expect(report.total.accruals).toBe(5500);
+    expect(report.total.settlements).toBe(18700);
+    expect(report.total.closingBalance).toBe(5500);
+  });
+
+  // ─── Test 3: correct query parameters ────────────────────────────────────
+
+  it('queries opening balance with entryDate.lt = periodStart', async () => {
+    prisma.journalLine.groupBy.mockResolvedValue([]);
+
+    await service.getReport(periodStart, periodEnd);
+
+    const [openingCall, periodCall] = prisma.journalLine.groupBy.mock.calls;
+
+    // Opening balance query: lt periodStart
+    expect(openingCall[0].where.journalEntry.entryDate).toEqual({ lt: periodStart });
+
+    // Period query: gte periodStart, lte periodEnd
+    expect(periodCall[0].where.journalEntry.entryDate).toEqual({
+      gte: periodStart,
+      lte: periodEnd,
+    });
+  });
+
+  // ─── Test 4: both INTERCO_AP_CODES are included in lines output ──────────
+
+  it('always returns both 21-1101 and 21-1102 even with partial data', async () => {
+    // Only 21-1101 has data
+    prisma.journalLine.groupBy
+      .mockResolvedValueOnce([
+        { accountCode: '21-1101', _sum: { debit: new Prisma.Decimal(0), credit: new Prisma.Decimal(10000) } },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const report = await service.getReport(periodStart, periodEnd);
+
+    expect(report.lines).toHaveLength(2);
+    const codes = report.lines.map((l) => l.accountCode);
+    expect(codes).toContain('21-1101');
+    expect(codes).toContain('21-1102');
+
+    const line1102 = report.lines.find((l) => l.accountCode === '21-1102')!;
+    expect(line1102.openingBalance).toBe(0);
+    expect(line1102.closingBalance).toBe(0);
+  });
+});

--- a/apps/api/src/modules/accounting/intercompany-report.service.ts
+++ b/apps/api/src/modules/accounting/intercompany-report.service.ts
@@ -1,0 +1,141 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * P4-SP4 Task 5 — IntercompanyReportService
+ *
+ * Aggregates FINANCE-side inter-company balances for accounts:
+ *   21-1101  เจ้าหนี้-หน้าร้าน (ยอดจัด)        ← payable to SHOP for financed amount
+ *   21-1102  เจ้าหนี้ค่าคอม-หน้าร้าน             ← payable to SHOP for commission
+ *
+ * Both are Cr-normal (liability) accounts. Per period:
+ *   - Opening balance  = cumulative net (Cr − Dr) on all POSTED lines before periodStart
+ *   - Accruals         = Cr movements within period (liability increases — new contracts)
+ *   - Settlements      = Dr movements within period (liability decreases — vendor clearance)
+ *   - Closing balance  = opening + accruals − settlements
+ *
+ * Report structure per account + combined total.
+ */
+
+export interface InterCoAccountLine {
+  accountCode: string;
+  accountName: string;
+  openingBalance: number;
+  accruals: number;
+  settlements: number;
+  closingBalance: number;
+}
+
+export interface InterCoReport {
+  periodStart: string;
+  periodEnd: string;
+  lines: InterCoAccountLine[];
+  total: {
+    openingBalance: number;
+    accruals: number;
+    settlements: number;
+    closingBalance: number;
+  };
+}
+
+const INTERCO_AP_CODES = ['21-1101', '21-1102'] as const;
+
+const ACCOUNT_NAMES: Record<string, string> = {
+  '21-1101': 'เจ้าหนี้-หน้าร้าน (ยอดจัด)',
+  '21-1102': 'เจ้าหนี้ค่าคอม-หน้าร้าน',
+};
+
+@Injectable()
+export class IntercompanyReportService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getReport(periodStart: Date, periodEnd: Date): Promise<InterCoReport> {
+    // Opening balance: sum of all Cr − Dr on these accounts BEFORE periodStart
+    const openingLines = await this.prisma.journalLine.groupBy({
+      by: ['accountCode'],
+      where: {
+        accountCode: { in: [...INTERCO_AP_CODES] },
+        journalEntry: {
+          status: 'POSTED',
+          entryDate: { lt: periodStart },
+          deletedAt: null,
+        },
+        deletedAt: null,
+      },
+      _sum: { debit: true, credit: true },
+    });
+
+    // Period movements: Cr = accruals, Dr = settlements
+    const periodLines = await this.prisma.journalLine.groupBy({
+      by: ['accountCode'],
+      where: {
+        accountCode: { in: [...INTERCO_AP_CODES] },
+        journalEntry: {
+          status: 'POSTED',
+          entryDate: { gte: periodStart, lte: periodEnd },
+          deletedAt: null,
+        },
+        deletedAt: null,
+      },
+      _sum: { debit: true, credit: true },
+    });
+
+    const makeMap = (
+      rows: { accountCode: string; _sum: { debit: Prisma.Decimal | null; credit: Prisma.Decimal | null } }[],
+    ) => {
+      const m = new Map<string, { dr: number; cr: number }>();
+      for (const r of rows) {
+        m.set(r.accountCode, {
+          dr: Number(r._sum.debit ?? 0),
+          cr: Number(r._sum.credit ?? 0),
+        });
+      }
+      return m;
+    };
+
+    const openingMap = makeMap(openingLines);
+    const periodMap = makeMap(periodLines);
+
+    const lines: InterCoAccountLine[] = INTERCO_AP_CODES.map((code) => {
+      const opening = openingMap.get(code) ?? { dr: 0, cr: 0 };
+      const period = periodMap.get(code) ?? { dr: 0, cr: 0 };
+
+      // Liability accounts: normal balance = Cr. Opening = cumulative Cr − Dr.
+      const openingBalance = opening.cr - opening.dr;
+      const accruals = period.cr;       // new Cr → liability increases
+      const settlements = period.dr;    // new Dr → liability decreases
+      const closingBalance = openingBalance + accruals - settlements;
+
+      return {
+        accountCode: code,
+        accountName: ACCOUNT_NAMES[code] ?? code,
+        openingBalance: round2(openingBalance),
+        accruals: round2(accruals),
+        settlements: round2(settlements),
+        closingBalance: round2(closingBalance),
+      };
+    });
+
+    const total = lines.reduce(
+      (acc, l) => ({
+        openingBalance: round2(acc.openingBalance + l.openingBalance),
+        accruals: round2(acc.accruals + l.accruals),
+        settlements: round2(acc.settlements + l.settlements),
+        closingBalance: round2(acc.closingBalance + l.closingBalance),
+      }),
+      { openingBalance: 0, accruals: 0, settlements: 0, closingBalance: 0 },
+    );
+
+    return {
+      periodStart: periodStart.toISOString(),
+      periodEnd: periodEnd.toISOString(),
+      lines,
+      total,
+    };
+  }
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/apps/api/src/modules/contracts/contracts.controller.ts
+++ b/apps/api/src/modules/contracts/contracts.controller.ts
@@ -6,7 +6,7 @@ import { ContractWorkflowService } from './contract-workflow.service';
 import { ContractPaymentService } from './contract-payment.service';
 import { ContractDocumentService } from './contract-document.service';
 import { ContractSnapshotService } from './contract-snapshot.service';
-import { CreateContractDto, UpdateContractDto, EarlyPayoffDto, ReviewContractDto, RejectContractDto } from './dto/contract.dto';
+import { CreateContractDto, UpdateContractDto, EarlyPayoffDto, ReviewContractDto, RejectContractDto, RequestCancellationDto, RejectCancellationDto } from './dto/contract.dto';
 import { PdpaConsentDto } from './dto/pdpa-consent.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -229,5 +229,42 @@ export class ContractsController {
   @Roles('OWNER', 'BRANCH_MANAGER', 'SALES')
   getPdpaConsent(@Param('id') id: string) {
     return this.documentService.getPdpaConsent(id);
+  }
+
+  // === P4-SP4: Contract Cancellation ===
+
+  @Get('cancellations/pending')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  listPendingCancellations() {
+    return this.contractsService.listPendingCancellations();
+  }
+
+  @Post(':id/request-cancellation')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'SALES')
+  requestCancellation(
+    @Param('id') id: string,
+    @Body() dto: RequestCancellationDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractsService.requestCancellation(id, user.id, dto.reason, dto.refundAmount);
+  }
+
+  @Post('cancellations/:id/approve')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  approveCancellation(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractsService.approveCancellation(id, user.id);
+  }
+
+  @Post('cancellations/:id/reject')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  rejectCancellation(
+    @Param('id') id: string,
+    @Body() dto: RejectCancellationDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    return this.contractsService.rejectCancellation(id, user.id, dto.reason);
   }
 }

--- a/apps/api/src/modules/contracts/contracts.service.spec.ts
+++ b/apps/api/src/modules/contracts/contracts.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { ContractsService } from './contracts.service';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -1086,6 +1086,186 @@ describe('ContractsService', () => {
               overrideReason: 'OWNER_OVERRIDE_AFTER_LOCK',
             }),
           }),
+        }),
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // P4-SP4: Contract Cancellation
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('requestCancellation', () => {
+    it('creates a PENDING cancellation row for an ACTIVE contract', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: 'ACTIVE',
+        deletedAt: null,
+      });
+      prisma.contractCancellation = {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({
+          id: 'cancel-1',
+          contractId: 'contract-1',
+          status: 'PENDING',
+          reason: 'ลูกค้าขอยกเลิก',
+          refundAmount: 500,
+          requestedBy: { id: 'user-1', name: 'พนักงาน 1' },
+          contract: { id: 'contract-1', contractNumber: 'BC-2026-001', status: 'ACTIVE' },
+        }),
+      };
+
+      const result = await service.requestCancellation(
+        'contract-1',
+        'user-1',
+        'ลูกค้าขอยกเลิก',
+        500,
+      );
+
+      expect(result.status).toBe('PENDING');
+      expect(prisma.contractCancellation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            contractId: 'contract-1',
+            requestedById: 'user-1',
+            reason: 'ลูกค้าขอยกเลิก',
+            status: 'PENDING',
+          }),
+        }),
+      );
+    });
+
+    it('throws ConflictException when a PENDING cancellation already exists', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: 'ACTIVE',
+        deletedAt: null,
+      });
+      prisma.contractCancellation = {
+        findFirst: jest.fn().mockResolvedValue({ id: 'cancel-existing', status: 'PENDING' }),
+        create: jest.fn(),
+      };
+
+      await expect(
+        service.requestCancellation('contract-1', 'user-1', 'เหตุผล', 0),
+      ).rejects.toThrow(ConflictException);
+      expect(prisma.contractCancellation.create).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when contract is already CANCELED', async () => {
+      prisma.contract.findUnique.mockResolvedValue({
+        ...mockContract,
+        status: 'CANCELED',
+        deletedAt: null,
+      });
+      prisma.contractCancellation = {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+      };
+
+      await expect(
+        service.requestCancellation('contract-1', 'user-1', 'เหตุผล', 0),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('approveCancellation', () => {
+    it('posts JE + updates cancellation to APPROVED + updates contract to CANCELED', async () => {
+      const mockCancellationTemplate = {
+        execute: jest.fn().mockResolvedValue({
+          entryNumber: 'JE-202601-00010',
+          refundEntryNumber: undefined,
+        }),
+      };
+
+      // Re-create service with template injected
+      const moduleWithTemplate = await Test.createTestingModule({
+        providers: [
+          ContractsService,
+          { provide: PrismaService, useValue: prisma },
+          { provide: 'ContractCancellationTemplate', useValue: mockCancellationTemplate },
+        ],
+      }).compile();
+      const svcWithTemplate = moduleWithTemplate.get<ContractsService>(ContractsService);
+      // Inject template via the Optional private property
+      (svcWithTemplate as any).cancellationTemplate = mockCancellationTemplate;
+
+      const mockCancellation = {
+        id: 'cancel-1',
+        contractId: 'contract-1',
+        status: 'PENDING',
+        refundAmount: { toString: () => '0' },
+        deletedAt: null,
+        contract: { ...mockContract, status: 'ACTIVE' },
+      };
+
+      prisma.contractCancellation = {
+        findUnique: jest.fn().mockResolvedValue(mockCancellation),
+        update: jest.fn().mockResolvedValue({ ...mockCancellation, status: 'APPROVED' }),
+      };
+
+      prisma.journalEntry = {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({ id: 'je-reversal-1' }),
+      };
+
+      prisma.$transaction = jest.fn().mockImplementation(async (fn: (tx: any) => Promise<any>) => {
+        return fn({
+          ...prisma,
+          contractCancellation: prisma.contractCancellation,
+          contract: prisma.contract,
+          journalEntry: prisma.journalEntry,
+          auditLog: prisma.auditLog,
+        });
+      });
+
+      const result = await svcWithTemplate.approveCancellation('cancel-1', 'approver-1');
+
+      expect(result.status).toBe('APPROVED');
+      expect(mockCancellationTemplate.execute).toHaveBeenCalled();
+      expect(prisma.contractCancellation.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'cancel-1' },
+          data: expect.objectContaining({ status: 'APPROVED', approvedById: 'approver-1' }),
+        }),
+      );
+      expect(prisma.contract.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'contract-1' },
+          data: expect.objectContaining({ status: 'CANCELED' }),
+        }),
+      );
+    });
+  });
+
+  describe('rejectCancellation', () => {
+    it('updates cancellation to REJECTED without posting any JE', async () => {
+      const mockCancellationTemplate = {
+        execute: jest.fn(),
+      };
+
+      prisma.contractCancellation = {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'cancel-1',
+          status: 'PENDING',
+          deletedAt: null,
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'cancel-1',
+          contractId: 'contract-1',
+          status: 'REJECTED',
+          contract: { id: 'contract-1', contractNumber: 'BC-2026-001' },
+          requestedBy: { id: 'user-1', name: 'พนักงาน 1' },
+          approvedBy: { id: 'approver-1', name: 'ผู้อนุมัติ' },
+        }),
+      };
+
+      const result = await service.rejectCancellation('cancel-1', 'approver-1', 'ไม่อนุมัติ');
+
+      expect(result.status).toBe('REJECTED');
+      expect(mockCancellationTemplate.execute).not.toHaveBeenCalled();
+      expect(prisma.contractCancellation.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'REJECTED' }),
         }),
       );
     });

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -1,9 +1,11 @@
 import { Injectable, Logger, Optional, NotFoundException, BadRequestException, ForbiddenException, ConflictException, InternalServerErrorException } from '@nestjs/common';
 import { StructuredLoggerService } from '../../common/logger';
 import { PlanType, Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../prisma/prisma.service';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { paginatedResponse } from '../../common/helpers/pagination.helper';
+import { ContractCancellationTemplate } from '../journal/cpa-templates/contract-cancellation.template';
 
 /** User context for branch-level access control */
 export interface BranchAccessUser {
@@ -34,6 +36,7 @@ export class ContractsService {
   constructor(
     private prisma: PrismaService,
     @Optional() private warrantyService?: WarrantyService,
+    @Optional() private cancellationTemplate?: ContractCancellationTemplate,
   ) {}
 
   async findAll(filters: {
@@ -827,5 +830,218 @@ export class ContractsService {
     // designed (see docs/ceo-review/tier-8-fraud-heatmap-master.md §T4-C1).
 
     return this.findOne(contractId);
+  }
+
+  // =========================================================================
+  // P4-SP4: Contract Cancellation (request / approve / reject)
+  // =========================================================================
+
+  /**
+   * Request a cancellation for an existing contract.
+   *
+   * Business rules:
+   * - Cannot cancel an already-CANCELED contract.
+   * - Cannot create a second PENDING cancellation for the same contract.
+   */
+  async requestCancellation(
+    contractId: string,
+    userId: string,
+    reason: string,
+    refundAmount: number,
+  ) {
+    const contract = await this.prisma.contract.findUnique({
+      where: { id: contractId },
+      select: { id: true, contractNumber: true, status: true, deletedAt: true },
+    });
+    if (!contract || contract.deletedAt) {
+      throw new NotFoundException('ไม่พบสัญญา');
+    }
+    if (contract.status === 'CANCELED') {
+      throw new BadRequestException('สัญญานี้ถูกยกเลิกไปแล้ว');
+    }
+
+    const pending = await this.prisma.contractCancellation.findFirst({
+      where: { contractId, status: 'PENDING', deletedAt: null },
+    });
+    if (pending) {
+      throw new ConflictException('มีคำขอยกเลิกสัญญาที่รอดำเนินการอยู่แล้ว');
+    }
+
+    const cancellation = await this.prisma.contractCancellation.create({
+      data: {
+        contractId,
+        requestedById: userId,
+        reason,
+        refundAmount: new Decimal(refundAmount),
+        status: 'PENDING',
+      },
+      include: {
+        contract: { select: { id: true, contractNumber: true, status: true } },
+        requestedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    return cancellation;
+  }
+
+  /**
+   * Approve a pending cancellation: posts reversal JE, sets contract to CANCELED.
+   * Wrapped in a $transaction for full atomicity.
+   */
+  async approveCancellation(cancellationId: string, approverId: string) {
+    const cancellation = await this.prisma.contractCancellation.findUnique({
+      where: { id: cancellationId },
+      include: { contract: true },
+    });
+    if (!cancellation || cancellation.deletedAt) {
+      throw new NotFoundException('ไม่พบคำขอยกเลิกสัญญา');
+    }
+    if (cancellation.status !== 'PENDING') {
+      throw new BadRequestException(
+        `ไม่สามารถอนุมัติได้ สถานะปัจจุบัน: ${cancellation.status}`,
+      );
+    }
+
+    if (!this.cancellationTemplate) {
+      throw new InternalServerErrorException(
+        'ContractCancellationTemplate not available — check module wiring',
+      );
+    }
+
+    const template = this.cancellationTemplate;
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Post reversal JE (+ optional refund JE)
+      const jeResult = await template.execute(
+        {
+          contractId: cancellation.contractId,
+          cancellationId,
+          refundAmount: new Decimal(cancellation.refundAmount.toString()),
+        },
+        tx,
+      );
+
+      // Find the JE id by entryNumber to store FK
+      const reversalJE = await tx.journalEntry.findUniqueOrThrow({
+        where: { entryNumber: jeResult.entryNumber },
+        select: { id: true },
+      });
+
+      // Update ContractCancellation → APPROVED
+      await tx.contractCancellation.update({
+        where: { id: cancellationId },
+        data: {
+          status: 'APPROVED',
+          approvedById: approverId,
+          approvedAt: new Date(),
+          reversalJournalEntryId: reversalJE.id,
+        },
+      });
+
+      // Update Contract → CANCELED
+      await tx.contract.update({
+        where: { id: cancellation.contractId },
+        data: { status: 'CANCELED' },
+      });
+
+      // Audit log
+      await tx.auditLog.create({
+        data: {
+          userId: approverId,
+          action: 'CONTRACT_CANCELED',
+          entity: 'contract',
+          entityId: cancellation.contractId,
+          oldValue: {
+            status: cancellation.contract.status,
+            cancellationId,
+          },
+          newValue: {
+            status: 'CANCELED',
+            reversalEntryNumber: jeResult.entryNumber,
+            refundEntryNumber: jeResult.refundEntryNumber ?? null,
+            refundAmount: cancellation.refundAmount.toString(),
+          },
+        },
+      });
+
+      return {
+        cancellationId,
+        status: 'APPROVED',
+        reversalEntryNumber: jeResult.entryNumber,
+        refundEntryNumber: jeResult.refundEntryNumber,
+      };
+    });
+
+    return result;
+  }
+
+  /**
+   * Reject a pending cancellation (no JE needed).
+   */
+  async rejectCancellation(
+    cancellationId: string,
+    approverId: string,
+    reason: string,
+  ) {
+    const cancellation = await this.prisma.contractCancellation.findUnique({
+      where: { id: cancellationId },
+      select: { id: true, status: true, deletedAt: true },
+    });
+    if (!cancellation || cancellation.deletedAt) {
+      throw new NotFoundException('ไม่พบคำขอยกเลิกสัญญา');
+    }
+    if (cancellation.status !== 'PENDING') {
+      throw new BadRequestException(
+        `ไม่สามารถปฏิเสธได้ สถานะปัจจุบัน: ${cancellation.status}`,
+      );
+    }
+
+    const updated = await this.prisma.contractCancellation.update({
+      where: { id: cancellationId },
+      data: {
+        status: 'REJECTED',
+        approvedById: approverId,
+        approvedAt: new Date(),
+      },
+      include: {
+        contract: { select: { id: true, contractNumber: true } },
+        requestedBy: { select: { id: true, name: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    await this.prisma.auditLog.create({
+      data: {
+        userId: approverId,
+        action: 'CANCELLATION_REJECTED',
+        entity: 'contract',
+        entityId: updated.contractId,
+        oldValue: { cancellationId, status: 'PENDING' },
+        newValue: { status: 'REJECTED', reason },
+      },
+    });
+
+    return updated;
+  }
+
+  /**
+   * List all PENDING cancellation requests (for FM/OWNER approval queue).
+   */
+  async listPendingCancellations() {
+    return this.prisma.contractCancellation.findMany({
+      where: { status: 'PENDING', deletedAt: null },
+      orderBy: { createdAt: 'asc' },
+      include: {
+        contract: {
+          select: {
+            id: true,
+            contractNumber: true,
+            status: true,
+            customer: { select: { id: true, name: true, phone: true } },
+          },
+        },
+        requestedBy: { select: { id: true, name: true } },
+      },
+    });
   }
 }

--- a/apps/api/src/modules/contracts/dto/contract.dto.ts
+++ b/apps/api/src/modules/contracts/dto/contract.dto.ts
@@ -139,3 +139,19 @@ export class RejectContractDto {
   @IsString()
   reviewNotes: string; // เหตุผลปฏิเสธ (บังคับ)
 }
+
+// ─── P4-SP4: Contract Cancellation DTOs ──────────────────────────────────────
+
+export class RequestCancellationDto {
+  @IsString()
+  reason: string;
+
+  @IsNumber()
+  @Min(0, { message: 'จำนวนเงินคืนต้องไม่ติดลบ' })
+  refundAmount: number;
+}
+
+export class RejectCancellationDto {
+  @IsString()
+  reason: string;
+}

--- a/apps/api/src/modules/journal/cpa-templates/contract-cancellation.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/contract-cancellation.template.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * contract-cancellation.template.spec.ts
+ *
+ * Unit tests for ContractCancellationTemplate using Jest mocks (no real DB).
+ *
+ * NOTE: cpa-templates specs are excluded from the default jest run via
+ * testPathIgnorePatterns. Run individually with:
+ *   npx jest --testPathPattern=contract-cancellation.template.spec
+ */
+import { Decimal } from '@prisma/client/runtime/library';
+import { BadRequestException } from '@nestjs/common';
+import { ContractCancellationTemplate } from './contract-cancellation.template';
+import { JournalAutoService } from '../journal-auto.service';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeActivationJeLine(accountCode: string, debit: string, credit: string) {
+  return {
+    accountCode,
+    debit: new Decimal(debit),
+    credit: new Decimal(credit),
+    description: `Test line ${accountCode}`,
+  };
+}
+
+/** Standard 1A activation JE lines for a 17,000 / 12-month contract. */
+const ACTIVATION_LINES = [
+  makeActivationJeLine('11-2101', '19600', '0'),    // HP Receivable Gross Dr
+  makeActivationJeLine('11-2105', '1274', '0'),     // VAT Receivable Dr
+  makeActivationJeLine('21-1101', '0', '17000'),    // เจ้าหนี้-หน้าร้าน Cr
+  makeActivationJeLine('21-1102', '0', '1700'),     // เจ้าหนี้ค่าคอม Cr
+  makeActivationJeLine('11-2106', '0', '900'),      // Unearned Interest Cr
+  makeActivationJeLine('21-2102', '0', '1274'),     // VAT Deferred Cr
+];
+
+const mockActivationJE = {
+  id: 'je-activation-1',
+  entryNumber: 'JE-202601-00001',
+  status: 'POSTED',
+  metadata: { tag: '1A', contractId: 'contract-1' },
+  lines: ACTIVATION_LINES,
+  deletedAt: null,
+};
+
+const mockContract = {
+  contractNumber: 'BC-2026-001',
+};
+
+// ─── suite ───────────────────────────────────────────────────────────────────
+
+describe('ContractCancellationTemplate', () => {
+  let template: ContractCancellationTemplate;
+  let journalMock: jest.Mocked<Pick<JournalAutoService, 'createAndPost'>>;
+  let prismaMock: any;
+
+  beforeEach(() => {
+    journalMock = {
+      createAndPost: jest.fn().mockResolvedValue({ id: 'je-new', entryNumber: 'JE-202601-00010' }),
+    };
+
+    prismaMock = {
+      contract: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue(mockContract),
+      },
+      journalEntry: {
+        findFirst: jest.fn(),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    template = new ContractCancellationTemplate(
+      journalMock as unknown as JournalAutoService,
+      prismaMock,
+    );
+  });
+
+  // ─── Test 1: reversal entries are balanced ──────────────────────────────
+
+  it('reversal JE lines sum to zero (balanced) — Dr = Cr', async () => {
+    // First findFirst call: no existing reversal
+    // Second findFirst call: return the activation JE
+    prismaMock.journalEntry.findFirst
+      .mockResolvedValueOnce(mockActivationJE)   // activation JE found
+      .mockResolvedValueOnce(null);              // no existing reversal
+
+    // Override createAndPost to capture the lines passed
+    const capturedInputs: any[] = [];
+    journalMock.createAndPost.mockImplementation(async (input) => {
+      capturedInputs.push(input);
+      return { id: `je-${capturedInputs.length}`, entryNumber: `JE-202601-0001${capturedInputs.length}` };
+    });
+
+    await template.execute({
+      contractId: 'contract-1',
+      cancellationId: 'cancel-1',
+      refundAmount: new Decimal(0),
+    });
+
+    expect(capturedInputs.length).toBe(1); // only reversal, no refund
+    const reversalInput = capturedInputs[0];
+
+    const totalDr = reversalInput.lines.reduce((s: Decimal, l: any) => s.plus(l.dr), new Decimal(0));
+    const totalCr = reversalInput.lines.reduce((s: Decimal, l: any) => s.plus(l.cr), new Decimal(0));
+
+    expect(totalDr.toFixed(2)).toBe(totalCr.toFixed(2));
+  });
+
+  // ─── Test 2: with refundAmount > 0, refund lines added ─────────────────
+
+  it('with refundAmount > 0 adds Dr 52-1106 / Cr 11-1201 refund JE', async () => {
+    prismaMock.journalEntry.findFirst
+      .mockResolvedValueOnce(mockActivationJE)
+      .mockResolvedValueOnce(null);
+
+    const capturedInputs: any[] = [];
+    journalMock.createAndPost.mockImplementation(async (input) => {
+      capturedInputs.push(input);
+      return { id: `je-${capturedInputs.length}`, entryNumber: `JE-202601-0001${capturedInputs.length}` };
+    });
+
+    const refundAmount = new Decimal('500.00');
+    await template.execute({
+      contractId: 'contract-1',
+      cancellationId: 'cancel-1',
+      refundAmount,
+    });
+
+    // Two JEs should be created: reversal + refund
+    expect(capturedInputs.length).toBe(2);
+
+    const refundInput = capturedInputs[1];
+    const discountLine = refundInput.lines.find((l: any) => l.accountCode === '52-1106');
+    const bankLine = refundInput.lines.find((l: any) => l.accountCode === '11-1201');
+
+    expect(discountLine).toBeDefined();
+    expect(bankLine).toBeDefined();
+    expect(new Decimal(discountLine.dr.toString()).toFixed(2)).toBe('500.00');
+    expect(new Decimal(bankLine.cr.toString()).toFixed(2)).toBe('500.00');
+
+    // Refund JE is also balanced
+    const refundDr = refundInput.lines.reduce((s: Decimal, l: any) => s.plus(l.dr), new Decimal(0));
+    const refundCr = refundInput.lines.reduce((s: Decimal, l: any) => s.plus(l.cr), new Decimal(0));
+    expect(refundDr.toFixed(2)).toBe(refundCr.toFixed(2));
+  });
+
+  // ─── Test 3: throws when no activation JE found ─────────────────────────
+
+  it('throws BadRequestException when no activation 1A JE exists for contract', async () => {
+    prismaMock.journalEntry.findFirst
+      .mockResolvedValueOnce(null)  // no activation JE
+      .mockResolvedValueOnce(null); // no existing reversal
+
+    await expect(
+      template.execute({
+        contractId: 'contract-1',
+        cancellationId: 'cancel-1',
+        refundAmount: new Decimal(0),
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // ─── Test 4: idempotent — returns existing reversal if already posted ───
+
+  it('returns existing reversal entry number without re-posting (idempotent)', async () => {
+    const existingReversal = { entryNumber: 'JE-202601-EXISTING' };
+    prismaMock.journalEntry.findFirst
+      .mockResolvedValueOnce(mockActivationJE)     // activation found
+      .mockResolvedValueOnce(existingReversal);    // reversal already exists
+
+    const result = await template.execute({
+      contractId: 'contract-1',
+      cancellationId: 'cancel-1',
+      refundAmount: new Decimal(0),
+    });
+
+    expect(result.entryNumber).toBe('JE-202601-EXISTING');
+    expect(journalMock.createAndPost).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/journal/cpa-templates/contract-cancellation.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/contract-cancellation.template.ts
@@ -1,0 +1,159 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { Decimal } from '@prisma/client/runtime/library';
+import { Prisma } from '@prisma/client';
+import { JournalAutoService } from '../journal-auto.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * Template — Contract Cancellation (P4-SP4).
+ *
+ * Reverses the 1A activation JE and, when refundAmount > 0, posts the refund:
+ *
+ * Reversal (mirror of 1A, Dr/Cr swapped):
+ *   Dr 21-1101 เจ้าหนี้-หน้าร้าน    (financedAmount)
+ *   Dr 21-1102 เจ้าหนี้ค่าคอม       (commission)
+ *   Dr 11-2106 รายได้รอตัดบัญชี-ดอกเบี้ย (interest)
+ *   Dr 21-2102 ภาษีขายรอเรียกเก็บ   (vat)
+ *     Cr 11-2101 ลูกหนี้ Gross
+ *     Cr 11-2105 ลูกหนี้ภาษีขายรอเรียกเก็บ
+ *
+ * Refund (when refundAmount > 0):
+ *   Dr 52-1106 ส่วนลดดอกเบี้ย-ปิดยอด (refundAmount)
+ *     Cr 11-1201 ธนาคาร KBank         (refundAmount)
+ *
+ * Idempotency: checks metadata.flow = 'contract-cancellation' + cancellationId
+ * to prevent double-posting on retry.
+ */
+@Injectable()
+export class ContractCancellationTemplate {
+  constructor(
+    private readonly journal: JournalAutoService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async execute(
+    params: {
+      contractId: string;
+      cancellationId: string;
+      refundAmount: Decimal;
+    },
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ entryNumber: string; refundEntryNumber?: string }> {
+    const { contractId, cancellationId, refundAmount } = params;
+    const client = tx ?? this.prisma;
+
+    const contract = await client.contract.findUniqueOrThrow({
+      where: { id: contractId },
+      select: { contractNumber: true },
+    });
+
+    // Find the 1A activation JE tagged to this contract
+    const activationJe = await (client.journalEntry as Prisma.JournalEntryDelegate).findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['tag'], equals: '1A' } } as Prisma.JournalEntryWhereInput,
+          { metadata: { path: ['contractId'], equals: contractId } } as Prisma.JournalEntryWhereInput,
+        ],
+        status: 'POSTED',
+        deletedAt: null,
+      },
+      include: { lines: true },
+    });
+
+    if (!activationJe) {
+      throw new BadRequestException(
+        `ไม่พบรายการบัญชีเปิดสัญญา (1A) สำหรับสัญญา ${contract.contractNumber} — ไม่สามารถยกเลิกได้`,
+      );
+    }
+
+    // Idempotency check: ensure we haven't already posted the cancellation reversal
+    const existingReversal = await (client.journalEntry as Prisma.JournalEntryDelegate).findFirst({
+      where: {
+        AND: [
+          { metadata: { path: ['flow'], equals: 'contract-cancellation' } } as Prisma.JournalEntryWhereInput,
+          { metadata: { path: ['cancellationId'], equals: cancellationId } } as Prisma.JournalEntryWhereInput,
+        ],
+        deletedAt: null,
+      },
+    });
+
+    if (existingReversal) {
+      return { entryNumber: existingReversal.entryNumber };
+    }
+
+    // Build reversal lines (swap Dr/Cr from 1A)
+    const reversalLines = activationJe.lines.map((l) => ({
+      accountCode: l.accountCode,
+      dr: new Decimal(l.credit.toString()),
+      cr: new Decimal(l.debit.toString()),
+      description: `[ยกเลิกสัญญา] ${l.description ?? ''}`.trim(),
+    }));
+
+    const reversalResult = await this.journal.createAndPost(
+      {
+        description: `ยกเลิกสัญญา ${contract.contractNumber} — ย้อนรายการ ${activationJe.entryNumber}`,
+        reference: contractId,
+        metadata: {
+          tag: 'CANCELLATION',
+          flow: 'contract-cancellation',
+          contractId,
+          cancellationId,
+          originalEntryId: activationJe.id,
+          originalEntryNumber: activationJe.entryNumber,
+        },
+        lines: reversalLines,
+      },
+      tx,
+    );
+
+    // Mark original 1A as reversed
+    const meta = (activationJe.metadata ?? {}) as Prisma.InputJsonObject;
+    await client.journalEntry.update({
+      where: { id: activationJe.id },
+      data: {
+        metadata: {
+          ...meta,
+          reversed: true,
+          reversedByEntryNumber: reversalResult.entryNumber,
+          reversedByCancellationId: cancellationId,
+        },
+      },
+    });
+
+    // Refund JE (when refundAmount > 0)
+    let refundEntryNumber: string | undefined;
+    const zero = new Decimal(0);
+    if (refundAmount.greaterThan(zero)) {
+      const refundResult = await this.journal.createAndPost(
+        {
+          description: `คืนเงิน ${contract.contractNumber} — ยกเลิกสัญญา`,
+          reference: contractId,
+          metadata: {
+            tag: 'CANCELLATION_REFUND',
+            flow: 'contract-cancellation-refund',
+            contractId,
+            cancellationId,
+          },
+          lines: [
+            {
+              accountCode: '52-1106',
+              dr: refundAmount,
+              cr: zero,
+              description: 'ส่วนลดดอกเบี้ย-คืนเงินยกเลิกสัญญา',
+            },
+            {
+              accountCode: '11-1201',
+              dr: zero,
+              cr: refundAmount,
+              description: 'ธนาคาร KBank — จ่ายคืนลูกค้า',
+            },
+          ],
+        },
+        tx,
+      );
+      refundEntryNumber = refundResult.entryNumber;
+    }
+
+    return { entryNumber: reversalResult.entryNumber, refundEntryNumber };
+  }
+}

--- a/apps/api/src/modules/journal/journal.module.ts
+++ b/apps/api/src/modules/journal/journal.module.ts
@@ -53,6 +53,8 @@ import { OutboxService } from './outbox.service';
 import { OutboxProcessorService } from './outbox-processor.service';
 import { OutboxProcessorCron } from './cron/outbox-processor.cron';
 import { ReconciliationCron } from './cron/reconciliation.cron';
+// P4-SP4 — Contract cancellation JE reversal
+import { ContractCancellationTemplate } from './cpa-templates/contract-cancellation.template';
 import { ReconcileController } from './reconcile.controller';
 
 @Module({
@@ -111,6 +113,8 @@ import { ReconcileController } from './reconcile.controller';
     OutboxProcessorService,
     OutboxProcessorCron,
     ReconciliationCron,
+    // P4-SP4 — Contract cancellation
+    ContractCancellationTemplate,
   ],
   exports: [
     JournalService,
@@ -160,6 +164,8 @@ import { ReconcileController } from './reconcile.controller';
     // SP7.2 — Outbox + saga infrastructure
     OutboxService,
     OutboxProcessorService,
+    // P4-SP4 — Contract cancellation
+    ContractCancellationTemplate,
   ],
 })
 export class JournalModule {}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.11",
+  "version": "26.5.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -175,6 +175,9 @@ const BalanceSheetPage = lazy(() => import('@/pages/finance/BalanceSheetPage'));
 const GeneralJournalPage = lazy(() => import('@/pages/finance/GeneralJournalPage'));
 const AgingReportPage = lazy(() => import('@/pages/finance/AgingReportPage'));
 const BadDebtReportPage = lazy(() => import('@/pages/finance/BadDebtReportPage'));
+// P4-SP4 — Contract cancellation approval queue + Inter-co report
+const ContractCancellationPage = lazy(() => import('@/pages/finance/ContractCancellationPage'));
+const IntercompanyReportPage = lazy(() => import('@/pages/finance/IntercompanyReportPage'));
 // P4-SP2 — Tax UI pages (finance-tax endpoints + e-receipt config)
 const VatPage = lazy(() => import('@/pages/finance/VatPage'));
 const WhtPage = lazy(() => import('@/pages/finance/WhtPage'));
@@ -1382,7 +1385,7 @@ function App() {
             path="/finance/contract-cancellation"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage feature="เอกสารยกเลิกสัญญา" trackingSP="SP5" eta="ภายในไตรมาส 3/2026" />
+                <ContractCancellationPage />
               </ProtectedRoute>
             }
           />
@@ -1422,7 +1425,7 @@ function App() {
             path="/finance/intercompany-report"
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
-                <ComingSoonPage feature="รายงานลูกหนี้ Inter-co (FINANCE ↔ SHOP)" trackingSP="SP6" eta="ภายในไตรมาส 4/2026" />
+                <IntercompanyReportPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -572,7 +572,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'ล็อคเครื่อง (MDM)', path: '/mdm', icon: Lock },
         { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
         // CSV §2 placeholder — owner-flagged ✏ "ต้องสร้าง"
-        { label: 'เอกสารยกเลิกสัญญา', path: '/finance/contract-cancellation', icon: FileText, placeholder: { trackingSP: 'SP5', eta: 'ภายในไตรมาส 3/2026' } },
+        { label: 'เอกสารยกเลิกสัญญา', path: '/finance/contract-cancellation', icon: FileText },
       ],
     },
     {
@@ -640,7 +640,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
         { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen },
         { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
         { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown },
-        { label: 'รายงานลูกหนี้ Inter-co', path: '/finance/intercompany-report', icon: Building2, placeholder: { trackingSP: 'SP6', eta: 'ภายในไตรมาส 4/2026' } },
+        { label: 'รายงานลูกหนี้ Inter-co', path: '/finance/intercompany-report', icon: Building2 },
         { label: 'ค่าคอมมิชชัน', path: '/commissions', icon: Coins },
         { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
         // P3-SP3 — PEAK CSV export (mapping config lives in /settings#peak-mapping)

--- a/apps/web/src/pages/finance/ContractCancellationPage.tsx
+++ b/apps/web/src/pages/finance/ContractCancellationPage.tsx
@@ -1,0 +1,284 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Lock } from 'lucide-react';
+import { toast } from 'sonner';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { formatDateMedium, formatNumberDecimal } from '@/utils/formatters';
+
+interface PendingCancellation {
+  id: string;
+  createdAt: string;
+  reason: string;
+  refundAmount: number | string;
+  status: 'PENDING';
+  contract: {
+    id: string;
+    contractNumber: string;
+    status: string;
+    customer: {
+      id: string;
+      name: string;
+      phone: string;
+    };
+  };
+  requestedBy: {
+    id: string;
+    name: string;
+  };
+}
+
+type ActionTarget = {
+  id: string;
+  contractNumber: string;
+  action: 'approve' | 'reject';
+};
+
+export default function ContractCancellationPage() {
+  const queryClient = useQueryClient();
+  const [target, setTarget] = useState<ActionTarget | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+
+  const { data: cancellations, isLoading, isError, error, refetch } = useQuery<PendingCancellation[]>({
+    queryKey: ['contract-cancellations-pending'],
+    queryFn: async () => (await api.get('/contracts/cancellations/pending')).data,
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (cancellationId: string) =>
+      api.post(`/contracts/cancellations/${cancellationId}/approve`),
+    onSuccess: () => {
+      toast.success('อนุมัติการยกเลิกสัญญาสำเร็จ');
+      queryClient.invalidateQueries({ queryKey: ['contract-cancellations-pending'] });
+      setTarget(null);
+    },
+    onError: (err: unknown) => {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        'เกิดข้อผิดพลาด กรุณาลองใหม่';
+      toast.error(msg);
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      api.post(`/contracts/cancellations/${id}/reject`, { reason }),
+    onSuccess: () => {
+      toast.success('ปฏิเสธคำขอยกเลิกสัญญาแล้ว');
+      queryClient.invalidateQueries({ queryKey: ['contract-cancellations-pending'] });
+      setTarget(null);
+      setRejectReason('');
+    },
+    onError: (err: unknown) => {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        'เกิดข้อผิดพลาด กรุณาลองใหม่';
+      toast.error(msg);
+    },
+  });
+
+  const handleApprove = (item: PendingCancellation) => {
+    setTarget({ id: item.id, contractNumber: item.contract.contractNumber, action: 'approve' });
+  };
+
+  const handleReject = (item: PendingCancellation) => {
+    setRejectReason('');
+    setTarget({ id: item.id, contractNumber: item.contract.contractNumber, action: 'reject' });
+  };
+
+  const handleApproveConfirm = () => {
+    if (!target) return;
+    approveMutation.mutate(target.id);
+  };
+
+  const handleRejectConfirm = () => {
+    if (!target) return;
+    rejectMutation.mutate({ id: target.id, reason: rejectReason });
+  };
+
+  const isMutating = approveMutation.isPending || rejectMutation.isPending;
+
+  return (
+    <div>
+      <PageHeader
+        title="เอกสารยกเลิกสัญญา"
+        subtitle="คิวคำขอยกเลิก — รออนุมัติจากผู้จัดการ"
+        icon={<Lock className="size-5" />}
+      />
+
+      <QueryBoundary
+        isLoading={isLoading && !cancellations}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        errorTitle="ไม่สามารถโหลดรายการคำขอยกเลิกสัญญาได้"
+      >
+        <Card className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+          <CardHeader>
+            <h2 className="text-base font-semibold leading-snug">
+              รายการรอการอนุมัติ{' '}
+              {cancellations && cancellations.length > 0 && (
+                <span className="ml-1 inline-flex items-center rounded-full bg-warning/15 px-2 py-0.5 text-xs font-medium text-warning leading-snug">
+                  {cancellations.length} รายการ
+                </span>
+              )}
+            </h2>
+          </CardHeader>
+          <CardContent className="p-0">
+            {!cancellations || cancellations.length === 0 ? (
+              <div className="p-10 text-center text-muted-foreground leading-snug">
+                <Lock className="size-10 mx-auto mb-3 opacity-30" />
+                <p className="text-sm">ไม่มีคำขอรอการอนุมัติ</p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm leading-snug">
+                  <thead className="bg-muted/50">
+                    <tr>
+                      <th className="text-left p-3 font-medium text-muted-foreground">วันที่ขอ</th>
+                      <th className="text-left p-3 font-medium text-muted-foreground">เลขสัญญา</th>
+                      <th className="text-left p-3 font-medium text-muted-foreground">ลูกค้า</th>
+                      <th className="text-left p-3 font-medium text-muted-foreground">ผู้ยื่นคำขอ</th>
+                      <th className="text-left p-3 font-medium text-muted-foreground">เหตุผล</th>
+                      <th className="text-right p-3 font-medium text-muted-foreground">
+                        ยอดคืน (฿)
+                      </th>
+                      <th className="text-center p-3 font-medium text-muted-foreground">
+                        ดำเนินการ
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cancellations.map((item) => (
+                      <tr key={item.id} className="border-t border-border hover:bg-accent/30">
+                        <td className="p-3 text-muted-foreground whitespace-nowrap">
+                          {formatDateMedium(item.createdAt)}
+                        </td>
+                        <td className="p-3 whitespace-nowrap">
+                          <Link
+                            to={`/contracts/${item.contract.id}`}
+                            className="text-primary hover:underline font-medium"
+                          >
+                            {item.contract.contractNumber}
+                          </Link>
+                        </td>
+                        <td className="p-3">
+                          <div className="font-medium">{item.contract.customer.name}</div>
+                          <div className="text-xs text-muted-foreground font-mono">
+                            {item.contract.customer.phone || '—'}
+                          </div>
+                        </td>
+                        <td className="p-3 text-muted-foreground">{item.requestedBy.name}</td>
+                        <td className="p-3 max-w-[240px]">
+                          <span className="line-clamp-2 leading-snug">{item.reason}</span>
+                        </td>
+                        <td className="p-3 text-right tabular-nums font-semibold">
+                          {formatNumberDecimal(Number(item.refundAmount), 2)} ฿
+                        </td>
+                        <td className="p-3">
+                          <div className="flex items-center justify-center gap-2">
+                            <Button
+                              size="sm"
+                              variant="primary"
+                              className="h-7 px-3 text-xs"
+                              onClick={() => handleApprove(item)}
+                            >
+                              อนุมัติ
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-7 px-3 text-xs text-destructive border-destructive/50 hover:bg-destructive/10"
+                              onClick={() => handleReject(item)}
+                            >
+                              ปฏิเสธ
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </QueryBoundary>
+
+      {/* Approve confirm dialog */}
+      <ConfirmDialog
+        open={target?.action === 'approve'}
+        onOpenChange={(open) => !open && setTarget(null)}
+        title="ยืนยันการอนุมัติยกเลิกสัญญา"
+        description={`อนุมัติการยกเลิกสัญญา ${target?.contractNumber ?? ''} ระบบจะบันทึกรายการย้อนกลับ JE อัตโนมัติ`}
+        confirmLabel="อนุมัติ"
+        cancelLabel="ยกเลิก"
+        variant="default"
+        loading={isMutating}
+        onConfirm={handleApproveConfirm}
+      />
+
+      {/* Reject dialog — needs textarea for reason input */}
+      <Dialog
+        open={target?.action === 'reject'}
+        onOpenChange={(open) => {
+          if (!open) {
+            setTarget(null);
+            setRejectReason('');
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>ปฏิเสธคำขอยกเลิกสัญญา</DialogTitle>
+            <DialogDescription>
+              ปฏิเสธคำขอสัญญา{' '}
+              <span className="font-semibold">{target?.contractNumber ?? ''}</span>{' '}
+              — กรุณาระบุเหตุผล
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-2">
+            <textarea
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm leading-snug focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 min-h-[80px] resize-none"
+              placeholder="ระบุเหตุผลในการปฏิเสธ..."
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+            />
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTarget(null);
+                setRejectReason('');
+              }}
+              disabled={isMutating}
+            >
+              ยกเลิก
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleRejectConfirm}
+              disabled={isMutating || !rejectReason.trim()}
+            >
+              {isMutating ? 'กำลังดำเนินการ...' : 'ปฏิเสธ'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/pages/finance/IntercompanyReportPage.tsx
+++ b/apps/web/src/pages/finance/IntercompanyReportPage.tsx
@@ -1,0 +1,397 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { Building2, TrendingDown, TrendingUp } from 'lucide-react';
+import api from '@/lib/api';
+import QueryBoundary from '@/components/QueryBoundary';
+import PageHeader from '@/components/ui/PageHeader';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { formatDateMedium, formatNumberDecimal } from '@/utils/formatters';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+interface InterCoAccountLine {
+  accountCode: string;
+  accountName: string;
+  openingBalance: number;
+  accruals: number;
+  settlements: number;
+  closingBalance: number;
+}
+
+interface InterCoReport {
+  periodStart: string;
+  periodEnd: string;
+  lines: InterCoAccountLine[];
+  total: {
+    openingBalance: number;
+    accruals: number;
+    settlements: number;
+    closingBalance: number;
+  };
+}
+
+interface LedgerLine {
+  entryDate: string;
+  entryNumber: string;
+  description: string;
+  referenceType: string | null;
+  referenceId: string | null;
+  debit: number;
+  credit: number;
+  runningBalance: number;
+}
+
+interface LedgerData {
+  accountCode: string;
+  accountName: string;
+  normalBalance: string;
+  lines: LedgerLine[];
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function fmt(n: number | null | undefined): string {
+  if (n == null) return '0.00';
+  return Number(n).toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function fmtSigned(n: number): string {
+  const abs = Math.abs(n);
+  const str = abs.toLocaleString('th-TH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return n < 0 ? `(${str})` : str;
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-input rounded-lg focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-[3px] focus-visible:ring-offset-background outline-hidden';
+
+// ── Summary card ───────────────────────────────────────────────────
+
+interface SummaryCardProps {
+  line: InterCoAccountLine;
+}
+
+function SummaryCard({ line }: SummaryCardProps) {
+  const isPositive = line.closingBalance >= 0;
+  return (
+    <Card className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+      <div className="flex h-full">
+        <div className="w-1 shrink-0 rounded-r-full bg-primary/60" />
+        <div className="p-4 flex-1 min-w-0">
+          <div className="text-2xs font-semibold text-muted-foreground uppercase tracking-wider mb-1 leading-snug truncate">
+            {line.accountCode} — {line.accountName}
+          </div>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1 mt-2 text-sm">
+            <div className="text-muted-foreground leading-snug text-xs">ยอดยกมา</div>
+            <div className="text-right tabular-nums leading-snug text-xs">{fmt(line.openingBalance)}</div>
+
+            <div className="flex items-center gap-1 text-muted-foreground leading-snug text-xs">
+              <TrendingUp className="size-3 text-destructive shrink-0" />
+              เกิดใหม่ (Cr)
+            </div>
+            <div className="text-right tabular-nums leading-snug text-xs text-destructive">
+              + {fmt(line.accruals)}
+            </div>
+
+            <div className="flex items-center gap-1 text-muted-foreground leading-snug text-xs">
+              <TrendingDown className="size-3 text-success shrink-0" />
+              ชำระแล้ว (Dr)
+            </div>
+            <div className="text-right tabular-nums leading-snug text-xs text-success">
+              − {fmt(line.settlements)}
+            </div>
+
+            <div className="font-semibold text-xs leading-snug border-t border-border/40 pt-1 mt-0.5">
+              ยอดคงเหลือ
+            </div>
+            <div
+              className={`text-right tabular-nums font-bold leading-snug border-t border-border/40 pt-1 mt-0.5 text-sm ${isPositive ? 'text-foreground' : 'text-destructive'}`}
+            >
+              {fmtSigned(line.closingBalance)}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ── Main page ──────────────────────────────────────────────────────
+
+export default function IntercompanyReportPage() {
+  const now = new Date();
+  const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const [startDate, setStartDate] = useState(firstOfMonth.toISOString().split('T')[0]);
+  const [endDate, setEndDate] = useState(now.toISOString().split('T')[0]);
+
+  // Summary report
+  const {
+    data: report,
+    isLoading: reportLoading,
+    isError: reportError,
+    error: reportErr,
+    refetch: reportRefetch,
+  } = useQuery<InterCoReport>({
+    queryKey: ['interco-report', startDate, endDate],
+    queryFn: async () => {
+      const params = new URLSearchParams({ start: startDate, end: endDate });
+      return (await api.get(`/expenses/inter-co/report?${params}`)).data;
+    },
+    enabled: !!startDate && !!endDate,
+  });
+
+  // Ledger lines for 21-1101
+  const {
+    data: ledger1101,
+    isLoading: ledger1101Loading,
+    isError: ledger1101Error,
+    refetch: ledger1101Refetch,
+  } = useQuery<LedgerData>({
+    queryKey: ['interco-ledger-21-1101', startDate, endDate],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        accountCode: '21-1101',
+        periodStart: startDate,
+        periodEnd: endDate,
+      });
+      return (await api.get(`/expenses/ledger/general-ledger?${params}`)).data;
+    },
+    enabled: !!startDate && !!endDate,
+  });
+
+  // Ledger lines for 21-1102
+  const {
+    data: ledger1102,
+    isLoading: ledger1102Loading,
+    isError: ledger1102Error,
+    refetch: ledger1102Refetch,
+  } = useQuery<LedgerData>({
+    queryKey: ['interco-ledger-21-1102', startDate, endDate],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        accountCode: '21-1102',
+        periodStart: startDate,
+        periodEnd: endDate,
+      });
+      return (await api.get(`/expenses/ledger/general-ledger?${params}`)).data;
+    },
+    enabled: !!startDate && !!endDate,
+  });
+
+  // Merge and sort lines from both accounts
+  const mergedLines: (LedgerLine & { accountCode: string })[] = [
+    ...(ledger1101?.lines ?? []).map((l) => ({ ...l, accountCode: '21-1101' })),
+    ...(ledger1102?.lines ?? []).map((l) => ({ ...l, accountCode: '21-1102' })),
+  ].sort((a, b) => {
+    const d = a.entryDate.localeCompare(b.entryDate);
+    if (d !== 0) return d;
+    return a.entryNumber.localeCompare(b.entryNumber);
+  });
+
+  const isLedgerLoading = (ledger1101Loading || ledger1102Loading) && !ledger1101 && !ledger1102;
+  const isLedgerError = ledger1101Error || ledger1102Error;
+
+  const handleRetryAll = () => {
+    reportRefetch();
+    ledger1101Refetch();
+    ledger1102Refetch();
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title="รายงานลูกหนี้ Inter-co"
+        subtitle="FINANCE ↔ SHOP — ยอดเจ้าหนี้หน้าร้าน (21-1101, 21-1102)"
+        icon={<Building2 className="size-5" />}
+      />
+
+      {/* Date range controls */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ตั้งแต่
+          </label>
+          <ThaiDateInput
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+        <div>
+          <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            ถึง
+          </label>
+          <ThaiDateInput
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className={`${inputClass} w-auto`}
+          />
+        </div>
+      </div>
+
+      {/* Summary cards — per account */}
+      <QueryBoundary
+        isLoading={reportLoading && !report}
+        isError={reportError}
+        error={reportErr}
+        onRetry={reportRefetch}
+        errorTitle="ไม่สามารถโหลดรายงาน Inter-co ได้"
+      >
+        {report && (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+              {report.lines.map((line) => (
+                <SummaryCard key={line.accountCode} line={line} />
+              ))}
+            </div>
+
+            {/* Total row */}
+            <Card className="rounded-xl border border-border/50 bg-card shadow-sm mb-6">
+              <CardContent className="p-4">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <span className="text-sm font-semibold leading-snug">รวมทั้งหมด (21-1101 + 21-1102)</span>
+                  <div className="flex flex-wrap gap-6 text-sm tabular-nums">
+                    <div className="text-center">
+                      <div className="text-2xs text-muted-foreground mb-0.5 leading-snug">ยอดยกมา</div>
+                      <div className="font-medium">{fmt(report.total.openingBalance)}</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-2xs text-muted-foreground mb-0.5 leading-snug">เกิดใหม่ (+)</div>
+                      <div className="font-medium text-destructive">+ {fmt(report.total.accruals)}</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-2xs text-muted-foreground mb-0.5 leading-snug">ชำระแล้ว (−)</div>
+                      <div className="font-medium text-success">− {fmt(report.total.settlements)}</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-2xs text-muted-foreground mb-0.5 leading-snug">คงเหลือ</div>
+                      <div className="font-bold text-base">{fmt(report.total.closingBalance)}</div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </QueryBoundary>
+
+      {/* JE lines drill-down table */}
+      <QueryBoundary
+        isLoading={isLedgerLoading}
+        isError={isLedgerError}
+        onRetry={handleRetryAll}
+        errorTitle="ไม่สามารถโหลดรายการเคลื่อนไหวได้"
+      >
+        <Card className="rounded-xl border border-border/50 bg-card shadow-sm overflow-hidden">
+          <CardHeader>
+            <h2 className="text-base font-semibold leading-snug">
+              รายการเคลื่อนไหวในงวด{' '}
+              {mergedLines.length > 0 && (
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  ({mergedLines.length} รายการ)
+                </span>
+              )}
+            </h2>
+          </CardHeader>
+          <CardContent className="p-0">
+            {mergedLines.length === 0 ? (
+              <div className="p-10 text-center text-muted-foreground leading-snug">
+                <Building2 className="size-10 mx-auto mb-3 opacity-30" />
+                <p className="text-sm">ไม่มีรายการเคลื่อนไหวในช่วงเวลานี้</p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm leading-snug">
+                  <thead className="bg-muted/50">
+                    <tr>
+                      <th className="text-left p-3 font-medium text-muted-foreground whitespace-nowrap">
+                        วันที่
+                      </th>
+                      <th className="text-left p-3 font-medium text-muted-foreground whitespace-nowrap">
+                        เลขที่เอกสาร
+                      </th>
+                      <th className="text-left p-3 font-medium text-muted-foreground">รหัสบัญชี</th>
+                      <th className="text-left p-3 font-medium text-muted-foreground">คำอธิบาย</th>
+                      <th className="text-left p-3 font-medium text-muted-foreground whitespace-nowrap">
+                        ประเภท
+                      </th>
+                      <th className="text-right p-3 font-medium text-muted-foreground">Dr</th>
+                      <th className="text-right p-3 font-medium text-muted-foreground">Cr</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {mergedLines.map((line, idx) => (
+                      <tr
+                        key={`${line.entryNumber}-${line.accountCode}-${idx}`}
+                        className="border-t border-border hover:bg-accent/30"
+                      >
+                        <td className="p-3 text-muted-foreground whitespace-nowrap">
+                          {formatDateMedium(line.entryDate)}
+                        </td>
+                        <td className="p-3 whitespace-nowrap">
+                          <Link
+                            to={`/finance/general-journal?je=${encodeURIComponent(line.entryNumber)}`}
+                            className="text-primary hover:underline font-mono text-xs"
+                          >
+                            {line.entryNumber}
+                          </Link>
+                        </td>
+                        <td className="p-3 font-mono text-xs text-muted-foreground">
+                          {line.accountCode}
+                        </td>
+                        <td className="p-3 max-w-[280px]">
+                          <span className="line-clamp-2 leading-snug">{line.description || '—'}</span>
+                        </td>
+                        <td className="p-3">
+                          {line.referenceType ? (
+                            <span className="inline-flex items-center rounded-full bg-muted/80 px-2 py-0.5 text-xs font-medium leading-snug">
+                              {line.referenceType}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td className="p-3 text-right tabular-nums">
+                          {line.debit > 0 ? (
+                            <span className="font-medium">
+                              {formatNumberDecimal(line.debit, 2)}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground/40">—</span>
+                          )}
+                        </td>
+                        <td className="p-3 text-right tabular-nums">
+                          {line.credit > 0 ? (
+                            <span className="font-medium">
+                              {formatNumberDecimal(line.credit, 2)}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground/40">—</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                  <tfoot className="bg-muted/30 border-t-2 border-border">
+                    <tr>
+                      <td colSpan={5} className="p-3 text-xs font-semibold text-muted-foreground">
+                        รวม
+                      </td>
+                      <td className="p-3 text-right tabular-nums font-bold">
+                        {fmt(mergedLines.reduce((s, l) => s + l.debit, 0))}
+                      </td>
+                      <td className="p-3 text-right tabular-nums font-bold">
+                        {fmt(mergedLines.reduce((s, l) => s + l.credit, 0))}
+                      </td>
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </QueryBoundary>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Per [plan](https://github.com/iamnaii/BESTCHOICE/blob/main/docs/superpowers/plans/2026-05-19-p4-sp4-cancel-and-interco.md). Adds contract cancellation flow with JE reversal + Inter-co receivable report.

## Schema (Task 1)

- New \`ContractCancellation\` model with FK to Contract, User (×2 for requester/approver), JournalEntry (1:1 reversalJournalEntry)
- New enum \`ContractCancellationStatus\` (PENDING/APPROVED/REJECTED)
- Added \`CANCELED\` to existing \`ContractStatus\` enum
- Migration: \`20260954000000_contract_cancellation\` (hand-written due to local pgvector blocking shadow DB)

## Backend

| Component | What |
|---|---|
| \`ContractCancellationTemplate\` (Task 2) | Reversal JE template — reverses ContractActivation 1A lines + optional refund Dr 52-1106 / Cr 11-1201 |
| Contracts service (Task 3) | requestCancellation / approveCancellation / rejectCancellation / listPendingCancellations |
| Contracts controller (Task 3) | 4 new endpoints under /contracts/ |
| \`IntercompanyReportService\` (Task 5) | Aggregates 21-1101 / 21-1102 — opening / accruals / settlements / closing |

Activation JE located via metadata.tag \`'1A'\` + contractId (no direct FK on Contract).

**Tests:** 64 Jest tests pass (contracts.service: 60, intercompany: 4)

## Frontend (Tasks 4 + 6)

- \`/finance/contract-cancellation\` — **ContractCancellationPage** (approval queue with Approve/Reject dialogs)
- \`/finance/intercompany-report\` — **IntercompanyReportPage** (2 summary cards + drill-down table merged from 2 general-ledger calls)

Both replace ComingSoonPage routes; \`placeholder\` markers removed from menu.

**Adaptation**: inter-co drill-down uses 2 calls to \`/expenses/ledger/general-ledger\` (one per account) since the inter-co endpoint only returns aggregates. No backend change needed.

Web version: **26.5.11 → 26.5.12**

## Test plan
- [x] Jest API: 64 tests pass
- [x] Vitest web menu config: 19/19 pass
- [x] TypeScript: 0 errors (7 pre-existing errors in prisma-finance.service.ts unrelated)
- [x] Build: success

## Commits

\`\`\`
838ffa64 IntercompanyReportPage
ab56f11c ContractCancellationPage
bf49172c IntercompanyReportService
b6405488 contracts service — request/approve/reject cancellation
e4c0a374 ContractCancellationTemplate — reversal JE template
a2667dc2 ContractCancellation model + migration
+ chore: bump web 26.5.11 → 26.5.12
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)