### PR TITLE
feat(p4-sp5): Dashboard FINANCE widgets (3 cards)

### DIFF
--- a/apps/api/src/modules/contracts/contracts.controller.ts
+++ b/apps/api/src/modules/contracts/contracts.controller.ts
@@ -64,6 +64,13 @@ export class ContractsController {
     return this.documentService.getDocumentDashboard(branchId);
   }
 
+  // P4-SP5: Dashboard milestones summary — new + completing this month
+  @Get('milestones-summary')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER')
+  getMilestonesSummary() {
+    return this.contractsService.getMilestonesSummary();
+  }
+
   @Get(':id')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
   findOne(

--- a/apps/api/src/modules/contracts/contracts.service.ts
+++ b/apps/api/src/modules/contracts/contracts.service.ts
@@ -1044,4 +1044,131 @@ export class ContractsService {
       },
     });
   }
+
+  /**
+   * P4-SP5: Dashboard milestones summary.
+   * Returns new contracts this month, contracts completing this month,
+   * and top 5 recent new contracts + top 20 final installments.
+   */
+  async getMilestonesSummary() {
+    const now = new Date();
+    // Current month bounds (UTC — server stores UTC but created_at/due_date are aligned to BKK days)
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+    // --- newThisMonth: contracts created this month (ACTIVE or later = signed & activated) ---
+    const newContracts = await this.prisma.contract.findMany({
+      where: {
+        createdAt: { gte: monthStart, lte: monthEnd },
+        status: { notIn: ['DRAFT', 'CANCELED'] },
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        contractNumber: true,
+        financedAmount: true,
+        createdAt: true,
+        customer: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const newThisMonthCount = newContracts.length;
+    const newThisMonthSum = newContracts.reduce(
+      (acc, c) => acc + Number(c.financedAmount),
+      0,
+    );
+    const recentNewContracts = newContracts.slice(0, 5).map((c) => ({
+      id: c.id,
+      contractNumber: c.contractNumber,
+      customerName: c.customer.name,
+      financedAmount: Number(c.financedAmount),
+      createdAt: c.createdAt,
+    }));
+
+    // --- completingThisMonth: ACTIVE contracts where last installment dueDate is this month ---
+    // Find max dueDate per contract among PENDING/OVERDUE payments, check if in this month
+    const lastInstallmentsRaw = await this.prisma.payment.findMany({
+      where: {
+        dueDate: { gte: monthStart, lte: monthEnd },
+        status: { in: ['PENDING', 'OVERDUE'] },
+        deletedAt: null,
+        contract: {
+          status: 'ACTIVE',
+          deletedAt: null,
+        },
+      },
+      select: {
+        id: true,
+        contractId: true,
+        dueDate: true,
+        amountDue: true,
+        amountPaid: true,
+        installmentNo: true,
+        contract: {
+          select: {
+            id: true,
+            contractNumber: true,
+            totalMonths: true,
+            customer: { select: { id: true, name: true } },
+          },
+        },
+      },
+      orderBy: { dueDate: 'asc' },
+    });
+
+    // Keep only the max installmentNo per contract to identify "last" installment
+    const contractMaxInstallment = new Map<string, number>();
+    for (const p of lastInstallmentsRaw) {
+      const existing = contractMaxInstallment.get(p.contractId) ?? 0;
+      if (p.installmentNo > existing) {
+        contractMaxInstallment.set(p.contractId, p.installmentNo);
+      }
+    }
+
+    // Also get actual max installmentNo for each contract (to find truly last installment)
+    const contractIds = [...new Set(lastInstallmentsRaw.map((p) => p.contractId))];
+    const maxInstallments = await this.prisma.payment.groupBy({
+      by: ['contractId'],
+      where: { contractId: { in: contractIds }, deletedAt: null },
+      _max: { installmentNo: true },
+    });
+    const contractTotalInstallments = new Map(
+      maxInstallments.map((m) => [m.contractId, m._max.installmentNo ?? 0]),
+    );
+
+    // Filter to payments that are the final installment for their contract
+    const finalInstallmentsThisMonth = lastInstallmentsRaw
+      .filter((p) => p.installmentNo === contractTotalInstallments.get(p.contractId))
+      .slice(0, 20)
+      .map((p) => ({
+        paymentId: p.id,
+        contractId: p.contractId,
+        contractNumber: p.contract.contractNumber,
+        customerName: p.contract.customer.name,
+        dueDate: p.dueDate,
+        amountDue: Number(p.amountDue),
+        installmentNo: p.installmentNo,
+        totalMonths: p.contract.totalMonths,
+      }));
+
+    const completingThisMonthCount = new Set(finalInstallmentsThisMonth.map((p) => p.contractId)).size;
+    const completingThisMonthSum = finalInstallmentsThisMonth.reduce(
+      (acc, p) => acc + p.amountDue,
+      0,
+    );
+
+    return {
+      newThisMonth: {
+        count: newThisMonthCount,
+        totalAmount: newThisMonthSum,
+      },
+      completingThisMonth: {
+        count: completingThisMonthCount,
+        totalAmount: completingThisMonthSum,
+      },
+      recentNewContracts,
+      finalInstallmentsThisMonth: finalInstallmentsThisMonth.slice(0, 5),
+    };
+  }
 }

--- a/apps/api/src/modules/overdue/overdue.controller.ts
+++ b/apps/api/src/modules/overdue/overdue.controller.ts
@@ -18,6 +18,7 @@ import { AnalyticsRecoveryService } from './analytics-recovery.service';
 import { StuckContractsService } from './stuck-contracts.service';
 import { ContractSnoozeService } from './snooze.service';
 import { AutoBalanceService } from './auto-balance.service';
+import { PromiseService } from './promise.service';
 import { CreateSnoozeDto } from './dto/snooze.dto';
 import { AnalyticsQueryDto } from './dto/analytics-query.dto';
 import { CreateCallLogDto } from './dto/create-call-log.dto';
@@ -64,6 +65,7 @@ export class OverdueController {
     private stuckContractsService: StuckContractsService,
     private snoozeService: ContractSnoozeService,
     private autoBalanceService: AutoBalanceService,
+    private promiseService: PromiseService,
   ) {}
 
   // --- Collections Workflow Hub endpoints (Plan 2) ---
@@ -721,5 +723,12 @@ export class OverdueController {
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES', 'ACCOUNTANT')
   getOverdueInstallments(@Param('id') id: string) {
     return this.overdueService.getOverdueInstallments(id);
+  }
+
+  // P4-SP5: Dashboard widget — ติดตามหนี้วันนี้
+  @Get('promises/due-today')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER')
+  getPromisesDueToday() {
+    return this.promiseService.getPromisesDueToday();
   }
 }

--- a/apps/api/src/modules/overdue/promise.service.ts
+++ b/apps/api/src/modules/overdue/promise.service.ts
@@ -222,4 +222,58 @@ export class PromiseService {
       orderBy: { createdAt: 'desc' },
     });
   }
+
+  /**
+   * Returns all promise slots due today (today 00:00–23:59 Asia/Bangkok).
+   * Only pending slots (keptAt=null, brokenAt=null) whose parent CallLog is active.
+   * Dashboard widget: ติดตามหนี้วันนี้.
+   */
+  async getPromisesDueToday() {
+    const now = new Date();
+    // Use UTC midnight offsets to represent Asia/Bangkok today (UTC+7)
+    // Today BKK start = today's UTC date minus 7h offset
+    const bkkOffsetMs = 7 * 60 * 60 * 1000;
+    const bkkNow = new Date(now.getTime() + bkkOffsetMs);
+    const bkkDateStr = bkkNow.toISOString().slice(0, 10); // YYYY-MM-DD in BKK
+    const [year, month, day] = bkkDateStr.split('-').map(Number);
+    // Compute UTC bounds for the full BKK day
+    const todayStart = new Date(Date.UTC(year, month - 1, day, 0, 0, 0) - bkkOffsetMs);
+    const todayEnd = new Date(Date.UTC(year, month - 1, day, 23, 59, 59, 999) - bkkOffsetMs);
+
+    const slots = await this.prisma.promiseSlot.findMany({
+      where: {
+        settlementDate: { gte: todayStart, lte: todayEnd },
+        keptAt: null,
+        brokenAt: null,
+        callLog: {
+          deletedAt: null,
+          canceledAt: null,
+          supersededAt: null,
+          result: 'PROMISED',
+        },
+      },
+      include: {
+        callLog: {
+          include: {
+            contract: {
+              include: {
+                customer: { select: { id: true, name: true, phone: true } },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { settlementDate: 'asc' },
+    });
+
+    return slots.map((slot) => ({
+      promiseSlotId: slot.id,
+      contractId: slot.callLog.contractId,
+      contractNumber: slot.callLog.contract.contractNumber,
+      customerId: slot.callLog.contract.customer.id,
+      customerName: slot.callLog.contract.customer.name,
+      phone: slot.callLog.contract.customer.phone ?? '',
+      settlementAmount: Number(slot.settlementAmount),
+    }));
+  }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.12",
+  "version": "26.5.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/pages/DashboardPage/index.tsx
+++ b/apps/web/src/pages/DashboardPage/index.tsx
@@ -6,6 +6,7 @@ import api from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import { DashboardSkeleton } from '@/components/ui/page-skeletons';
 import QueryBoundary from '@/components/QueryBoundary';
+import { useLayout } from '@/components/layout/LayoutContext';
 import DashboardAlerts from './components/DashboardAlerts';
 import DashboardKPIs from './components/DashboardKPIs';
 import DashboardWatchList from './components/DashboardWatchList';
@@ -15,6 +16,9 @@ import DashboardCharts from './components/DashboardCharts';
 import DashboardTables from './components/DashboardTables';
 import DashboardMySales from './components/DashboardMySales';
 import DashboardFinanceOverview from './components/DashboardFinanceOverview';
+import AgingSummaryWidget from './widgets/AgingSummaryWidget';
+import PromiseDueTodayWidget from './widgets/PromiseDueTodayWidget';
+import ContractMilestonesWidget from './widgets/ContractMilestonesWidget';
 import type {
   KPIs,
   MonthlyTrend,
@@ -35,6 +39,7 @@ import type {
 export default function DashboardPage() {
   useDocumentTitle('แดชบอร์ด');
   const { user } = useAuth();
+  const { currentZone } = useLayout();
   // D1.4.2.2 — OWNER-configurable react-query staleTime (in seconds).
   // Defaults to 60s via DEFAULT_UI_FLAGS; clamped server-side to [10, 3600].
   const { cacheTtlDashboard } = useUiFlags();
@@ -193,6 +198,15 @@ export default function DashboardPage() {
 
       {/* KPI Stats — all roles */}
       {kpis && <DashboardKPIs kpis={kpis} comparativePL={comparativePL} />}
+
+      {/* FINANCE zone widgets — Aging / Promises / Milestones */}
+      {currentZone === 'fin' && (
+        <div className="grid md:grid-cols-3 gap-4 mt-6">
+          <AgingSummaryWidget />
+          <PromiseDueTodayWidget />
+          <ContractMilestonesWidget />
+        </div>
+      )}
 
       {/* Watch List + Upsell — management + finance roles */}
       {role !== 'SALES' && (

--- a/apps/web/src/pages/DashboardPage/widgets/AgingSummaryWidget.tsx
+++ b/apps/web/src/pages/DashboardPage/widgets/AgingSummaryWidget.tsx
@@ -1,0 +1,85 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import { AlertTriangle, ArrowRight } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import QueryBoundary from '@/components/QueryBoundary';
+import api from '@/lib/api';
+import { formatNumberDecimal } from '@/utils/formatters';
+
+interface AgingBuckets {
+  bucket_0_30: number;
+  bucket_31_60: number;
+  bucket_61_90: number;
+  bucket_90_plus: number;
+}
+
+interface AgingReport {
+  asOf: string;
+  summary: AgingBuckets;
+}
+
+const BUCKETS: { key: keyof AgingBuckets; label: string; color: string }[] = [
+  { key: 'bucket_0_30', label: '0–30 วัน', color: 'text-warning' },
+  { key: 'bucket_31_60', label: '31–60 วัน', color: 'text-orange-500' },
+  { key: 'bucket_61_90', label: '61–90 วัน', color: 'text-destructive' },
+  { key: 'bucket_90_plus', label: '90+ วัน', color: 'text-destructive font-bold' },
+];
+
+export default function AgingSummaryWidget() {
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<AgingReport>({
+    queryKey: ['dashboard-fin-aging-widget'],
+    queryFn: async () => {
+      const asOf = new Date().toISOString();
+      const { data: res } = await api.get(`/expenses/ledger/aging?asOf=${encodeURIComponent(asOf)}`);
+      return res;
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  });
+
+  return (
+    <Card className="flex flex-col h-full">
+      <CardHeader className="pb-2 flex-row items-center gap-2">
+        <div className="size-8 rounded-lg bg-destructive/10 flex items-center justify-center shrink-0">
+          <AlertTriangle className="size-4 text-destructive" />
+        </div>
+        <span className="font-semibold text-sm leading-snug">ลูกหนี้ค้างชำระ (Aging)</span>
+      </CardHeader>
+      <CardContent className="flex-1 flex flex-col justify-between gap-3">
+        <QueryBoundary
+          isLoading={isLoading}
+          isError={isError}
+          onRetry={refetch}
+          errorTitle="โหลด Aging ไม่สำเร็จ"
+        >
+          {data ? (
+            <div className="grid grid-cols-2 gap-2">
+              {BUCKETS.map((bucket) => (
+                <div
+                  key={bucket.key}
+                  className="bg-muted rounded-lg p-2.5 flex flex-col gap-0.5"
+                >
+                  <span className="text-2xs text-muted-foreground leading-snug">{bucket.label}</span>
+                  <span className={`text-sm font-semibold leading-snug ${bucket.color}`}>
+                    {formatNumberDecimal(data.summary[bucket.key], 0)} ฿
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </QueryBoundary>
+        <Link
+          to="/finance/aging-report"
+          className="flex items-center gap-1 text-xs text-primary hover:underline mt-auto self-end"
+        >
+          ดูรายงานเต็ม <ArrowRight className="size-3" />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/DashboardPage/widgets/ContractMilestonesWidget.tsx
+++ b/apps/web/src/pages/DashboardPage/widgets/ContractMilestonesWidget.tsx
@@ -1,0 +1,129 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import { FileCheck } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import QueryBoundary from '@/components/QueryBoundary';
+import api from '@/lib/api';
+import { formatNumberDecimal, formatDateMedium } from '@/utils/formatters';
+
+interface FinalInstallment {
+  paymentId: string;
+  contractId: string;
+  contractNumber: string;
+  customerName: string;
+  dueDate: string;
+  amountDue: number;
+  installmentNo: number;
+  totalMonths: number;
+}
+
+interface MilestonesSummary {
+  newThisMonth: { count: number; totalAmount: number };
+  completingThisMonth: { count: number; totalAmount: number };
+  recentNewContracts: {
+    id: string;
+    contractNumber: string;
+    customerName: string;
+    financedAmount: number;
+    createdAt: string;
+  }[];
+  finalInstallmentsThisMonth: FinalInstallment[];
+}
+
+export default function ContractMilestonesWidget() {
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<MilestonesSummary>({
+    queryKey: ['dashboard-fin-contract-milestones'],
+    queryFn: async () => {
+      const { data: res } = await api.get('/contracts/milestones-summary');
+      return res;
+    },
+    staleTime: 10 * 60 * 1000,
+    refetchInterval: 10 * 60 * 1000,
+  });
+
+  return (
+    <Card className="flex flex-col h-full">
+      <CardHeader className="pb-2 flex-row items-center gap-2">
+        <div className="size-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+          <FileCheck className="size-4 text-primary" />
+        </div>
+        <span className="font-semibold text-sm leading-snug">สัญญาเดือนนี้</span>
+      </CardHeader>
+      <CardContent className="flex-1 flex flex-col gap-3">
+        <QueryBoundary
+          isLoading={isLoading}
+          isError={isError}
+          onRetry={refetch}
+          errorTitle="โหลดสัญญาไม่สำเร็จ"
+        >
+          {data ? (
+            <>
+              {/* Stat cards */}
+              <div className="grid grid-cols-2 gap-2">
+                <div className="bg-muted rounded-lg p-2.5 flex flex-col gap-0.5">
+                  <span className="text-2xs text-muted-foreground leading-snug">สัญญาใหม่</span>
+                  <span className="text-lg font-bold text-foreground leading-snug">
+                    {data.newThisMonth.count}
+                  </span>
+                  <span className="text-2xs text-muted-foreground leading-snug">
+                    {formatNumberDecimal(data.newThisMonth.totalAmount, 0)} ฿
+                  </span>
+                </div>
+                <div className="bg-muted rounded-lg p-2.5 flex flex-col gap-0.5">
+                  <span className="text-2xs text-muted-foreground leading-snug">งวดสุดท้าย</span>
+                  <span className="text-lg font-bold text-success leading-snug">
+                    {data.completingThisMonth.count}
+                  </span>
+                  <span className="text-2xs text-muted-foreground leading-snug">
+                    {formatNumberDecimal(data.completingThisMonth.totalAmount, 0)} ฿
+                  </span>
+                </div>
+              </div>
+
+              {/* Final installments this month */}
+              {data.finalInstallmentsThisMonth.length > 0 && (
+                <div>
+                  <p className="text-2xs text-muted-foreground uppercase tracking-wider mb-1.5 leading-snug">
+                    งวดสุดท้ายเดือนนี้
+                  </p>
+                  <ul className="divide-y divide-border">
+                    {data.finalInstallmentsThisMonth.map((item) => (
+                      <li key={item.paymentId} className="py-1.5 first:pt-0">
+                        <Link
+                          to={`/contracts/${item.contractId}`}
+                          className="flex items-start justify-between gap-2 group hover:bg-accent rounded px-1 -mx-1"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <p className="text-xs font-medium text-foreground leading-snug truncate group-hover:text-primary">
+                              {item.customerName}
+                            </p>
+                            <p className="text-2xs text-muted-foreground leading-snug">
+                              {item.contractNumber} · งวด {item.installmentNo}/{item.totalMonths}
+                            </p>
+                          </div>
+                          <div className="text-right shrink-0">
+                            <p className="text-xs font-semibold text-primary leading-snug">
+                              {formatNumberDecimal(item.amountDue, 0)} ฿
+                            </p>
+                            <p className="text-2xs text-muted-foreground leading-snug">
+                              {formatDateMedium(item.dueDate)}
+                            </p>
+                          </div>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          ) : null}
+        </QueryBoundary>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/DashboardPage/widgets/PromiseDueTodayWidget.tsx
+++ b/apps/web/src/pages/DashboardPage/widgets/PromiseDueTodayWidget.tsx
@@ -1,0 +1,89 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import { Bell } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import QueryBoundary from '@/components/QueryBoundary';
+import api from '@/lib/api';
+import { formatNumberDecimal } from '@/utils/formatters';
+
+interface PromiseDueItem {
+  promiseSlotId: string;
+  contractId: string;
+  contractNumber: string;
+  customerId: string;
+  customerName: string;
+  phone: string;
+  settlementAmount: number;
+}
+
+export default function PromiseDueTodayWidget() {
+  const {
+    data = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<PromiseDueItem[]>({
+    queryKey: ['dashboard-fin-promises-due-today'],
+    queryFn: async () => {
+      const { data: res } = await api.get('/overdue/promises/due-today');
+      return res;
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  });
+
+  return (
+    <Card className="flex flex-col h-full">
+      <CardHeader className="pb-2 flex-row items-center gap-2">
+        <div className="size-8 rounded-lg bg-warning/10 flex items-center justify-center shrink-0">
+          <Bell className="size-4 text-warning" />
+        </div>
+        <div className="flex items-center gap-1.5 flex-1 min-w-0">
+          <span className="font-semibold text-sm leading-snug">ติดตามหนี้วันนี้</span>
+          {data.length > 0 && (
+            <span className="text-2xs font-semibold bg-warning/15 text-warning px-1.5 py-0.5 rounded-full leading-snug shrink-0">
+              {data.length}
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 overflow-hidden">
+        <QueryBoundary
+          isLoading={isLoading}
+          isError={isError}
+          onRetry={refetch}
+          errorTitle="โหลดนัดหมายไม่สำเร็จ"
+        >
+          {data.length === 0 ? (
+            <p className="text-sm text-muted-foreground leading-snug py-4 text-center">
+              ไม่มีนัดวันนี้
+            </p>
+          ) : (
+            <ul className="divide-y divide-border">
+              {data.slice(0, 8).map((item) => (
+                <li key={item.promiseSlotId} className="py-2 first:pt-0">
+                  <Link
+                    to={`/contracts/${item.contractId}`}
+                    className="flex items-start justify-between gap-2 group hover:bg-accent rounded px-1 -mx-1"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-foreground leading-snug truncate group-hover:text-primary">
+                        {item.customerName}
+                      </p>
+                      <p className="text-2xs text-muted-foreground leading-snug">
+                        {item.contractNumber} · {item.phone || '—'}
+                      </p>
+                    </div>
+                    <span className="text-sm font-semibold text-primary shrink-0 leading-snug">
+                      {formatNumberDecimal(item.settlementAmount, 0)} ฿
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </QueryBoundary>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Per [plan](https://github.com/iamnaii/BESTCHOICE/blob/main/docs/superpowers/plans/2026-05-19-p4-sp5-dashboard-widgets.md). Adds 3 FIN-context widgets to Dashboard (visible only when \`currentZone === 'fin'\`).

## Backend (Tasks 1 + 5)

| Endpoint | Method | Purpose |
|---|---|---|
| \`GET /overdue/promises/due-today\` | \`getPromisesDueToday\` | Active PromiseSlots with settlementDate=today |
| \`GET /contracts/milestones-summary\` | \`getMilestonesSummary\` | This month's new + completing contracts + final installments |

Tests: 9/9 pass for promise.service + 60/60 contracts.service.

## Frontend — 3 Widgets (Tasks 2-4)

- **AgingSummaryWidget** — 4 bucket cards (0-30/31-60/61-90/90+), drill-down to /finance/aging-report. refetchInterval 5min.
- **PromiseDueTodayWidget** — list of today's promises, drill-down to contract. Empty state "ไม่มีนัดวันนี้". refetchInterval 5min.
- **ContractMilestonesWidget** — new/completing this month + top-5 final installments. refetchInterval 10min.

## Wiring (Task 6)

\`apps/web/src/pages/DashboardPage/index.tsx\` imports \`useLayout\` + 3 widgets. Conditional grid block renders only when \`currentZone === 'fin'\`.

## Schema adaptations

- \`Contract.activatedAt\` doesn't exist → used \`createdAt\`
- \`Contract.grossAmount\` doesn't exist → used \`financedAmount\` (principal)

Web version: **26.5.12 → 26.5.13**

## Test plan
- [x] Jest API: 9 + 60 tests pass
- [x] Vitest menu: 19/19 pass
- [x] TypeScript: 0 errors
- [x] Build: success
- [ ] After merge: visual check on Dashboard in FIN zone

## Commits

\`\`\`
f128545a chore: bump web 26.5.12 → 26.5.13
e91cb1ef wire 3 FIN-zone widgets into Dashboard
03f5bb79 AgingSummaryWidget + PromiseDueTodayWidget + ContractMilestonesWidget
b5496346 /contracts/milestones-summary endpoint
08bca64e /overdue/promises/due-today endpoint
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)