### PR TITLE
hotfix(p4-sp2): export TS interfaces — fix TS4053 build failure

### DIFF
--- a/apps/api/src/modules/finance-tax/finance-tax.service.ts
+++ b/apps/api/src/modules/finance-tax/finance-tax.service.ts
@@ -16,7 +16,7 @@ const WHT_PND3_ACCOUNTS = ['21-3102'];
 const WHT_PND53_ACCOUNTS = ['21-3103'];
 const ALL_WHT_ACCOUNTS = [...WHT_PND1_ACCOUNTS, ...WHT_PND3_ACCOUNTS, ...WHT_PND53_ACCOUNTS];
 
-interface PeriodBounds {
+export interface PeriodBounds {
   year: number;
   month: number;
   start: Date;
@@ -29,7 +29,7 @@ function buildPeriod(year: number, month: number): PeriodBounds {
   return { year, month, start, end };
 }
 
-interface VatLine {
+export interface VatLine {
   accountCode: string;
   documentNumber: string;
   postedAt: Date | null;
@@ -38,14 +38,14 @@ interface VatLine {
   credit: number;
 }
 
-interface WhtLine {
+export interface WhtLine {
   documentNumber: string;
   postedAt: Date | null;
   description: string | null;
   amount: number; // credit - debit (positive = payable accrual, negative = settlement)
 }
 
-interface VatAutoJournalVatLine {
+export interface VatAutoJournalVatLine {
   accountCode: string;
   debit: number;
   credit: number;


### PR DESCRIPTION
## Summary

**HOTFIX** — 3 consecutive deploys (SP2/SP3/SP4) failed at Build API Image stage with TS4053. SP5 in_progress will also fail.

**Root cause**: \`finance-tax.controller.ts\` methods have inferred return types referencing interfaces \`PeriodBounds\`, \`VatLine\`, \`WhtLine\`, \`VatAutoJournalVatLine\` from \`finance-tax.service.ts\`. Those interfaces were declared internal (no \`export\` keyword). Production Docker build's stricter \`tsc\` catches this; local \`tsc --noEmit\` doesn't (because the type is internally resolvable at the module level).

**Fix**: 4 interfaces in \`finance-tax.service.ts\` now have \`export\` keyword.

## Failed deploy runs

| Run | Commit | Result |
|---|---|---|
| 26080659689 | ce8aa38e (SP2) | FAILURE — TS4053 |
| 26081270058 | 7a020646 (SP3) | FAILURE (cascading) |
| 26082230662 | 0379341f (SP4) | FAILURE (cascading) |
| 26082659177 | bca02453 (SP5) | in_progress — will fail |

## Verification

- \`cd apps/api && npm run build\` — success after fix
- Production Docker build path: \`prisma generate && npm run build\` — same path that failed in CI

## Test plan
- [x] API build passes locally with strict TS
- [ ] After merge: auto-deploy triggers, this time should pass Build API Image stage
- [ ] After merge: verify SP1-SP5 code now actually live on Cloud Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)