### PR TITLE
feat(settings): Owner Q1/Q2/Q4/Q8 SystemConfig decisions (signed 2026-05-17)

### DIFF
--- a/apps/api/e2e/approval-workflow.e2e-spec.ts
+++ b/apps/api/e2e/approval-workflow.e2e-spec.ts
@@ -114,6 +114,7 @@ describe('Approval Workflow (D1.2.1) — API integration', () => {
       findUnique: jest.fn(async () => null),
     } as any,
     $transaction: jest.fn(async (cb: any) => cb(prismaMock as PrismaService)),
+    $executeRawUnsafe: jest.fn(async () => 0) as any,
   };
 
   beforeAll(async () => {

--- a/apps/api/prisma/migrations/20260955000000_owner_q1q8_systemconfig_decisions/migration.sql
+++ b/apps/api/prisma/migrations/20260955000000_owner_q1q8_systemconfig_decisions/migration.sql
@@ -1,0 +1,45 @@
+-- Owner Response Q1-Q8 sign-off (2026-05-17) — apply 4 SystemConfig defaults
+-- locked in by owner. Reference: Owner_Response_Q1-Q8_BESTCHOICE_v2.0.pdf
+--
+-- Idempotent: ON CONFLICT (key) DO UPDATE rewrites value + label, clears
+-- deletedAt (in case a previous soft-delete left the row dormant), and
+-- bumps updated_at. Safe to re-run.
+--
+-- Q1 (CRITICAL) — Petty Cash Cr leg = 11-1103 เงินสดพนักงานบัญชี
+--   (Imprest Fund pattern). Owner directive supersedes the in-code default
+--   `11-1201` in apps/api/src/modules/expense-documents/services/petty-cash.service.ts.
+--   A parallel commit flips that default for defense in depth so future
+--   environments missing this row still get the correct account.
+--
+-- Q2 — Audit log retention = 1,825 days (5 years) per พ.ร.บ.การบัญชี ม.7.
+--   Read by AuditRetentionCron.getRetentionDays() with OWNER-editable
+--   precedence over env var + compliance default.
+--
+-- Q4 — VIEWER role activation flag flipped ON. Note: actual @Roles() wiring
+--   for VIEWER on /accounting/*, /audit-logs, /reports/* is delivered in a
+--   FOLLOW-UP PR. Flipping the flag here alone is currently a no-op for
+--   permission grants — but it lets that follow-up PR ship as a pure
+--   addition with no SystemConfig writes.
+--
+-- Q8 — Petty cash replenish alert threshold lowered 5000 -> 1000 (IN_APP
+--   channel only). Owner can set 0 later to disable the alert entirely.
+
+INSERT INTO "system_config" ("id", "key", "value", "label", "created_at", "updated_at")
+VALUES
+  (gen_random_uuid()::text, 'petty_cash_account', '11-1103',
+    'บัญชีเงินสดสำหรับ Petty Cash (Cr leg ของ PETTY_CASH_REIMBURSEMENT) — Imprest Fund pattern',
+    NOW(), NOW()),
+  (gen_random_uuid()::text, 'audit_log_retention_days', '1825',
+    'จำนวนวันเก็บ Audit Log (พ.ร.บ.การบัญชี ม.7 — 5 ปี)',
+    NOW(), NOW()),
+  (gen_random_uuid()::text, 'viewer_role_enabled', 'true',
+    'เปิดใช้งาน VIEWER role (read-only สำหรับ external auditor — CPA / สรรพากร)',
+    NOW(), NOW()),
+  (gen_random_uuid()::text, 'petty_cash_replenish_threshold', '1000',
+    'เกณฑ์แจ้งเตือนเติมเงินสด Petty Cash (บาท; 0 = ปิด alert)',
+    NOW(), NOW())
+ON CONFLICT ("key") DO UPDATE
+SET "value"      = EXCLUDED."value",
+    "label"      = EXCLUDED."label",
+    "deleted_at" = NULL,
+    "updated_at" = NOW();

--- a/apps/api/src/modules/expense-documents/dto/create-petty-cash.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-petty-cash.dto.ts
@@ -17,7 +17,8 @@ import { Type } from 'class-transformer';
  *
  * Differences vs CreateExpenseDocumentDto:
  *   - No doc-level `vendorName` / `vendorTaxId` — moved per-line via `supplierName`
- *   - `depositAccountCode` is the petty-cash float account (typically 11-1201)
+ *   - `depositAccountCode` is the petty-cash float account (default 11-1103
+ *     เงินสดพนักงานบัญชี per Owner Response Q1 2026-05-17 — Imprest Fund pattern)
  *     and is REQUIRED — V20 rejects other accounts unless config overrides
  *   - WHT intentionally omitted at line level (small-cash scope; vendors with
  *     WHT must use regular EXPENSE flow)
@@ -65,8 +66,9 @@ export class CreatePettyCashDto {
   description?: string;
 
   /**
-   * Petty-cash float account — V20 enforces this is 11-1201 (or whatever the
-   * `petty_cash_account` system_config row says). Required.
+   * Petty-cash float account — V20 enforces this matches the
+   * `petty_cash_account` system_config row (default 11-1103 เงินสดพนักงานบัญชี
+   * per Owner Response Q1 2026-05-17). Required.
    */
   @IsString()
   depositAccountCode!: string;

--- a/apps/api/src/modules/expense-documents/services/__tests__/petty-cash.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/services/__tests__/petty-cash.service.spec.ts
@@ -22,21 +22,25 @@ describe('PettyCashService', () => {
   });
 
   describe('getConfig', () => {
-    it('defaults to 11-1201 / 5000 when no SystemConfig rows exist', async () => {
+    it('defaults to 11-1103 / 5000 when no SystemConfig rows exist', async () => {
+      // Owner Response Q1 (signed 2026-05-17): Petty Cash Cr leg = 11-1103
+      // (เงินสดพนักงานบัญชี — Imprest Fund pattern). Default flipped from the
+      // previous 11-1201 (KBank) — see migration
+      // 20260955000000_owner_q1q8_systemconfig_decisions.
       const cfg = await service.getConfig();
-      expect(cfg.account).toBe('11-1201');
+      expect(cfg.account).toBe('11-1103');
       expect(cfg.limit.toString()).toBe('5000');
       expect(cfg.replenishThreshold).toBeNull();
     });
 
     it('reads overrides from SystemConfig when present', async () => {
       prisma.systemConfig.findMany.mockResolvedValue([
-        { key: 'petty_cash_account', value: '11-1103' },
+        { key: 'petty_cash_account', value: '11-1201' },
         { key: 'petty_cash_limit', value: '10000' },
         { key: 'petty_cash_replenish_threshold', value: '2000' },
       ]);
       const cfg = await service.getConfig();
-      expect(cfg.account).toBe('11-1103');
+      expect(cfg.account).toBe('11-1201');
       expect(cfg.limit.toString()).toBe('10000');
       expect(cfg.replenishThreshold?.toString()).toBe('2000');
     });

--- a/apps/api/src/modules/expense-documents/services/petty-cash.service.ts
+++ b/apps/api/src/modules/expense-documents/services/petty-cash.service.ts
@@ -3,7 +3,12 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 
 export interface PettyCashConfig {
-  /** Float account code (Cr side of every JE). Default 11-1201. */
+  /**
+   * Float account code (Cr side of every JE). Default 11-1103 (เงินสดพนักงานบัญชี
+   * — Imprest Fund pattern, per Owner Response Q1 signed 2026-05-17). Migration
+   * 20260955000000_owner_q1q8_systemconfig_decisions seeds this into prod;
+   * the default here is defense in depth for fresh / un-migrated DBs.
+   */
   account: string;
   /** Max total per document. Default 5000฿. Set via system_config `petty_cash_limit`. */
   limit: Prisma.Decimal;
@@ -36,7 +41,7 @@ export class PettyCashService {
     });
     const byKey = new Map(rows.map((r) => [r.key, r.value]));
     return {
-      account: byKey.get('petty_cash_account') ?? '11-1201',
+      account: byKey.get('petty_cash_account') ?? '11-1103',
       limit: new Prisma.Decimal(byKey.get('petty_cash_limit') ?? '5000'),
       replenishThreshold:
         byKey.has('petty_cash_replenish_threshold')

--- a/apps/web/src/components/expense-form-v4/types.ts
+++ b/apps/web/src/components/expense-form-v4/types.ts
@@ -101,7 +101,8 @@ export interface SettlementFormFields {
 /**
  * C1 — Petty Cash Reimbursement. Per-line supplier (relaxes 1-doc-1-supplier).
  * No WHT support — vendors with WHT use regular EXPENSE flow. The cash leg
- * routes to the petty-cash float account (default 11-1201, configurable via
+ * routes to the petty-cash float account (default 11-1103 เงินสดพนักงานบัญชี —
+ * Imprest Fund pattern per Owner Response Q1 2026-05-17; configurable via
  * system_config.petty_cash_account).
  */
 export interface PettyCashLineForm {

--- a/docs/accounting/owner-pending-decisions-2026-05-19.html
+++ b/docs/accounting/owner-pending-decisions-2026-05-19.html
@@ -1,0 +1,599 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>คำถามรอคำตอบ Owner — Owner Response v2.0 follow-up</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Thai:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg:           #ffffff;
+    --bg-muted:    #fafaf9;
+    --bg-elev:    #f4f4f3;
+    --fg:           #18181b;
+    --fg-muted:   #71717a;
+    --fg-subtle:  #a1a1aa;
+    --border:     #e4e4e7;
+    --border-soft:#f1f1f0;
+    --emerald-50: #ecfdf5;
+    --emerald-600:#059669;
+    --emerald-700:#047857;
+    --amber-50:   #fffbeb;
+    --amber-600:  #d97706;
+    --amber-800:  #92400e;
+    --rose-50:    #fff1f2;
+    --rose-600:   #e11d48;
+    --rose-800:   #9f1239;
+    --indigo-50:  #eef2ff;
+    --indigo-600: #4f46e5;
+    --indigo-800: #3730a3;
+    --slate-50:   #f8fafc;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+
+  html { -webkit-text-size-adjust: 100%; }
+
+  body {
+    margin: 0;
+    font-family: 'IBM Plex Sans Thai', system-ui, -apple-system, sans-serif;
+    font-feature-settings: 'liga', 'kern';
+    line-height: 1.6;
+    color: var(--fg);
+    background: var(--bg-muted);
+    padding: 24px 16px 80px;
+  }
+
+  .wrap {
+    max-width: 880px;
+    margin: 0 auto;
+  }
+
+  .hero {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 28px 28px 24px;
+    margin-bottom: 24px;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--emerald-50);
+    color: var(--emerald-700);
+    border: 1px solid var(--emerald-600);
+    margin-bottom: 12px;
+  }
+
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    margin: 0 0 8px;
+    color: var(--fg);
+    line-height: 1.3;
+  }
+
+  .subtitle {
+    font-size: 13.5px;
+    color: var(--fg-muted);
+    margin: 0;
+    line-height: 1.55;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border-soft);
+  }
+
+  @media (max-width: 600px) {
+    .stats { grid-template-columns: repeat(2, 1fr); }
+  }
+
+  .stat {
+    text-align: center;
+  }
+
+  .stat-num {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--fg);
+    font-family: 'JetBrains Mono', monospace;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+  }
+
+  .stat-label {
+    font-size: 11.5px;
+    color: var(--fg-muted);
+    margin-top: 4px;
+    line-height: 1.4;
+  }
+
+  /* Section block */
+  .section {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    margin-bottom: 18px;
+    overflow: hidden;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 22px;
+    border-bottom: 1px solid var(--border-soft);
+  }
+
+  .section-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    flex-shrink: 0;
+  }
+
+  .section-icon.cpa  { background: var(--rose-50);    color: var(--rose-600);    border: 1px solid #fecdd3; }
+  .section-icon.owner{ background: var(--indigo-50);  color: var(--indigo-600);  border: 1px solid #c7d2fe; }
+  .section-icon.ops  { background: var(--amber-50);   color: var(--amber-600);   border: 1px solid #fde68a; }
+
+  .section-title {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0;
+    color: var(--fg);
+  }
+
+  .section-meta {
+    font-size: 12.5px;
+    color: var(--fg-muted);
+    margin: 2px 0 0;
+    line-height: 1.4;
+  }
+
+  /* Question card */
+  .q {
+    padding: 18px 22px;
+    border-top: 1px solid var(--border-soft);
+  }
+
+  .q:first-of-type { border-top: 0; }
+
+  .q-tag {
+    display: inline-block;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--fg-muted);
+    background: var(--bg-elev);
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin-bottom: 8px;
+    letter-spacing: 0.02em;
+  }
+
+  .q-title {
+    font-size: 14.5px;
+    font-weight: 600;
+    color: var(--fg);
+    margin: 0 0 6px;
+    line-height: 1.45;
+  }
+
+  .q-body {
+    font-size: 13.5px;
+    color: var(--fg);
+    line-height: 1.65;
+  }
+
+  .q-body p { margin: 0 0 8px; }
+  .q-body p:last-child { margin-bottom: 0; }
+
+  .q-body em {
+    background: var(--bg-elev);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-style: normal;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+  }
+
+  .q-context {
+    margin-top: 12px;
+    padding: 12px 14px;
+    background: var(--bg-elev);
+    border-radius: 8px;
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: var(--fg-muted);
+    border-left: 3px solid var(--border);
+  }
+
+  .q-context strong {
+    color: var(--fg);
+    font-weight: 600;
+  }
+
+  /* Options for owner to pick */
+  .opts {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 12px;
+  }
+
+  .opt {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 10px 12px;
+    background: var(--slate-50);
+    border: 1px solid var(--border-soft);
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .opt-letter {
+    font-weight: 700;
+    color: var(--emerald-700);
+    flex-shrink: 0;
+    width: 22px;
+  }
+
+  .opt-body { flex: 1; }
+  .opt-body strong { color: var(--fg); font-weight: 600; }
+
+  /* Answer space */
+  .answer-box {
+    margin-top: 12px;
+    padding: 14px 16px;
+    border: 1.5px dashed var(--border);
+    border-radius: 8px;
+    min-height: 56px;
+    font-size: 13px;
+    color: var(--fg-subtle);
+    background: #fff;
+  }
+
+  .answer-box::before {
+    content: "✏  คำตอบ Owner: ";
+    font-weight: 600;
+    color: var(--fg-muted);
+  }
+
+  /* Action checklist */
+  .actions {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 22px 24px;
+    margin-top: 24px;
+  }
+
+  .actions h2 {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 4px;
+    color: var(--fg);
+  }
+
+  .actions .lead {
+    font-size: 12.5px;
+    color: var(--fg-muted);
+    margin: 0 0 16px;
+    line-height: 1.5;
+  }
+
+  .check-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .check-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 0;
+    border-top: 1px solid var(--border-soft);
+    font-size: 13.5px;
+    line-height: 1.55;
+  }
+
+  .check-list li:first-child { border-top: 0; padding-top: 0; }
+
+  .check-box {
+    width: 18px;
+    height: 18px;
+    border: 1.5px solid var(--fg-subtle);
+    border-radius: 4px;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  .check-body { flex: 1; }
+
+  .check-body strong {
+    display: block;
+    color: var(--fg);
+    font-weight: 600;
+    margin-bottom: 2px;
+  }
+
+  .check-body .check-meta {
+    font-size: 12px;
+    color: var(--fg-muted);
+  }
+
+  /* Footer */
+  .foot {
+    text-align: center;
+    font-size: 11.5px;
+    color: var(--fg-subtle);
+    padding-top: 28px;
+    line-height: 1.6;
+  }
+
+  .foot strong { color: var(--fg-muted); }
+
+  /* Print */
+  @media print {
+    body { background: white; padding: 0; }
+    .section, .hero, .actions { break-inside: avoid; border-radius: 0; }
+    .answer-box { min-height: 64px; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- ============ HERO ============ -->
+  <header class="hero">
+    <span class="badge">⏳ Pending Owner Decision</span>
+    <h1>คำถามรอคำตอบ Owner</h1>
+    <p class="subtitle">
+      Owner Response v2.0 ปิดครบ 11/11 ข้อแล้ว (4 PR + 2 docs). คำถามที่เหลือมาจาก Phase A.5 brief — <strong>ส่งให้ Owner ตรวจก่อน Dev เริ่ม implement</strong> ตามคำสั่ง Bonus B3. <br><br>
+      Session: 2026-05-19 · Dev: Claude (Opus 4.7) · จากเอกสาร <em>2026-05-19-phase-a5-brief.md</em>
+    </p>
+    <div class="stats">
+      <div class="stat">
+        <div class="stat-num">8</div>
+        <div class="stat-label">คำถามทั้งหมด</div>
+      </div>
+      <div class="stat">
+        <div class="stat-num" style="color: var(--rose-600);">4</div>
+        <div class="stat-label">CPA-blocked</div>
+      </div>
+      <div class="stat">
+        <div class="stat-num" style="color: var(--indigo-600);">3</div>
+        <div class="stat-label">Owner-decision</div>
+      </div>
+      <div class="stat">
+        <div class="stat-num" style="color: var(--amber-600);">1</div>
+        <div class="stat-label">Ops-verify</div>
+      </div>
+    </div>
+  </header>
+
+  <!-- ============ SECTION A — OPS VERIFY ============ -->
+  <section class="section">
+    <header class="section-header">
+      <div class="section-icon ops">⚙</div>
+      <div>
+        <h2 class="section-title">A · Ops verify (Owner ทำเอง)</h2>
+        <p class="section-meta">เปิด psql ตรวจค่า → ถ้าตรง ลุย soft-delete ตามรันบุค</p>
+      </div>
+    </header>
+
+    <article class="q">
+      <span class="q-tag">A1 · Q6 VAT-RATE</span>
+      <h3 class="q-title">ค่า <code>VAT_RATE</code> ใน SystemConfig prod ตอนนี้ตรงไหม?</h3>
+      <div class="q-body">
+        <p>ก่อน soft-delete legacy keys <code>vat_pct</code> + <code>vat_rate</code> ผม ต้อง verify ว่า <code>VAT_RATE</code> ถือค่าที่ถูกต้องอยู่ (น่าจะ <code>'7'</code> = 7%).</p>
+        <div class="q-context">
+          <strong>เปิด psql รัน:</strong><br>
+          <code>SELECT key, value, deleted_at IS NOT NULL AS deleted FROM system_config WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate');</code><br><br>
+          คาดหวัง: <code>VAT_RATE = '7'</code>, deleted = false. ถ้าผิดให้แจ้ง Dev เพื่อ backfill ก่อน.
+        </div>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+  </section>
+
+  <!-- ============ SECTION B — OWNER DECISION ============ -->
+  <section class="section">
+    <header class="section-header">
+      <div class="section-icon owner">🧭</div>
+      <div>
+        <h2 class="section-title">B · Owner decisions (Dev รอ go/no-go)</h2>
+        <p class="section-meta">ตัดสินใจอย่างเดียวก็พอ — ไม่ต้องปรึกษา CPA</p>
+      </div>
+    </header>
+
+    <article class="q">
+      <span class="q-tag">B1 · Phase A.5 §8.1 · CPA channel</span>
+      <h3 class="q-title">Dev คุย CPA โดยตรงเรื่อง CR-001 + N-005 ได้เลย หรือ Owner เป็นช่องทาง?</h3>
+      <div class="q-body">
+        <p>Dev มีข้อมูลครบในมือพอจะ brief CPA เรื่อง VAT-on-interest (CR-001) + Interest recognition (N-005 EIR-vs-straight-line) — เริ่มได้เมื่อ Owner OK.</p>
+        <div class="opts">
+          <div class="opt"><span class="opt-letter">A</span><span class="opt-body"><strong>Dev brief CPA โดยตรง</strong> — Owner ฟัง CC, Dev ส่งคำถามเป็นเอกสารให้ CPA, รับคำตอบกลับ → Dev เริ่ม implement</span></div>
+          <div class="opt"><span class="opt-letter">B</span><span class="opt-body"><strong>Owner เป็นช่องทาง</strong> — Dev ส่ง memo ให้ Owner เห็นก่อน → Owner ส่งต่อ CPA → คำตอบกลับมาที่ Owner → forward ให้ Dev</span></div>
+        </div>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+
+    <article class="q">
+      <span class="q-tag">B2 · Phase A.5 §8.2 / §4 · SHOP pairing scope</span>
+      <h3 class="q-title">SHOP-side accounting pairing ควรครอบคลุมแค่ Contract Activation หรือเพิ่ม Repossession ด้วย?</h3>
+      <div class="q-body">
+        <p>ปัจจุบัน P3-SP5 ship PairedJournalService แล้ว แต่ใช้แค่ "ย้ายของระหว่าง SHOP→FINANCE" ตอน activation. งาน A.5 จะ extend ไปไหน:</p>
+        <div class="opts">
+          <div class="opt"><span class="opt-letter">A</span><span class="opt-body"><strong>Activation อย่างเดียว</strong> — ลด risk ของ orphan FINANCE JE ตอนสร้างสัญญา (3 วัน)</span></div>
+          <div class="opt"><span class="opt-letter">B</span><span class="opt-body"><strong>Activation + Repossession</strong> — เพิ่ม SHOP repossession-reversal template (ตี inventory คืน + reverse COGS) (≈7 วัน รวม)</span></div>
+          <div class="opt"><span class="opt-letter">C</span><span class="opt-body"><strong>ยังไม่ต้อง</strong> — รอ P3-SP7 multi-entity legal split (2027) แทน</span></div>
+        </div>
+        <div class="q-context">
+          <strong>Trade-off:</strong> A เร็วและปลอดภัย แต่ Repossession ปัจจุบันยังเป็น "FINANCE post repo, SHOP ลืม book inventory คืน" → SHOP TB ผิดเฉย ๆ ถ้าเกิด repo จริง. B ปิด gap นี้แต่ใช้เวลา 2x.
+        </div>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+
+    <article class="q">
+      <span class="q-tag">B3 · Phase A.5 §8.4 · CR-001 historical re-stating</span>
+      <h3 class="q-title">ถ้า CPA ตอบว่า ม.79/4(7) บังคับ ไม่ vat บนดอกเบี้ย — Owner ยอม re-state ย้อนหลังในกรณีไหน?</h3>
+      <div class="q-body">
+        <p>ถ้า CPA confirm ว่าต้องยกเว้น VAT บนดอกเบี้ย ระบบมี 3 paths:</p>
+        <div class="opts">
+          <div class="opt"><span class="opt-letter">A</span><span class="opt-body"><strong>Forward-only</strong> — สัญญาใหม่หลังวันที่ X ไม่คิด VAT บนดอกเบี้ย, สัญญาเก่าไม่แตะ (recommended)</span></div>
+          <div class="opt"><span class="opt-letter">B</span><span class="opt-body"><strong>Back-correct เฉพาะถ้าสรรพากรเรียกตรวจ</strong> — เก็บ stance ปัจจุบันไว้, refile ภ.พ.30 เมื่อถูก audit</span></div>
+          <div class="opt"><span class="opt-letter">C</span><span class="opt-body"><strong>Back-correct ทันที (proactive)</strong> — reverse 21-2102 over-bookings, refile ภ.พ.30 ทุกเดือนตั้งแต่ปีเปิด, ขอ refund</span></div>
+        </div>
+        <div class="q-context">
+          <strong>Risk:</strong> C มีค่าใช้จ่าย CPA + ขั้นตอนเยอะที่สุด แต่เป็น defense ที่หนาที่สุดถ้าโดน audit. A เป็น golden mean.
+        </div>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+
+    <article class="q">
+      <span class="q-tag">B4 · CLAUDE.md cleanup (small)</span>
+      <h3 class="q-title">อนุญาตให้ Dev ลบ "W-003 Unearned interest field" จาก CLAUDE.md "Things deferred"?</h3>
+      <div class="q-body">
+        <p>Phase A.4 implement W-003 ผ่าน 11-2106 Contra Asset ไปแล้ว (ดู accounting.md "Full Accrual TFRS 15"). แต่ CLAUDE.md ยังโชว์ว่า deferred — ทำให้ Dev คนใหม่งง.</p>
+        <div class="opts">
+          <div class="opt"><span class="opt-letter">A</span><span class="opt-body"><strong>OK ลบได้</strong> — Dev จะลบ W-003 line + เพิ่มบันทึก v6 (Owner Response 2026-05-17) ใน Hardening History</span></div>
+          <div class="opt"><span class="opt-letter">B</span><span class="opt-body"><strong>ยังไม่ต้อง</strong> — เก็บไว้เพื่อ visibility</span></div>
+        </div>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+  </section>
+
+  <!-- ============ SECTION C — CPA QUESTIONS ============ -->
+  <section class="section">
+    <header class="section-header">
+      <div class="section-icon cpa">🧾</div>
+      <div>
+        <h2 class="section-title">C · CPA questions (4 ข้อ)</h2>
+        <p class="section-meta">ส่งให้ CPA ตอบ — Dev รอผลก่อน implement Phase A.5-SP5/SP6</p>
+      </div>
+    </header>
+
+    <article class="q">
+      <span class="q-tag">C1 · CR-001 VAT-on-interest #1</span>
+      <h3 class="q-title">ภ.พ.30 ของบริษัทที่ผ่านมาเคย report VAT บน "ดอกเบี้ยเช่าซื้อ" ไหม?</h3>
+      <div class="q-body">
+        <p>ระบบปัจจุบัน book VAT 7% บนยอดรวม (เงินต้น + ดอกเบี้ย + ค่าคอม) แล้วยังนำส่งทาง ภ.พ.30 ทุกเดือน. คำถามนี้สำหรับยืนยันว่าวันนี้ทำอยู่ตามนี้จริง — ก่อนตัดสินใจว่าจะแก้.</p>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+
+    <article class="q">
+      <span class="q-tag">C2 · CR-001 VAT-on-interest #2</span>
+      <h3 class="q-title">ม.79/4(7) ป.รัษฎากร ใช้กับ "ดอกเบี้ยเช่าซื้อ" ในนิยามของเราหรือไม่?</h3>
+      <div class="q-body">
+        <p>มาตรา 79/4(7) ยกเว้น VAT สำหรับ "ดอกเบี้ย" — แต่ definition ของ "ดอกเบี้ย" ใน hire-purchase context เป็นอะไรกันแน่? ถือว่า interest component ของยอดผ่อนเป็น "ดอกเบี้ย" ตาม ม.79/4(7) ได้ไหม?</p>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+
+    <article class="q">
+      <span class="q-tag">C3 · CR-001 VAT-on-interest #3</span>
+      <h3 class="q-title">ถ้ายกเว้นจริง — split base ออกเป็น taxable principal + exempt interest บนใบกำกับภาษีอย่างไร?</h3>
+      <div class="q-body">
+        <p>ตัวอย่าง ค่างวด 1,515.83฿ = principal 1,416.66 + interest 0 (ปัจจุบัน) + VAT 99.17. ถ้าแยก base: ค่างวด = principal 1,416.66 + interest X (exempt) + VAT = principal × 7% เท่านั้น. CPA แนะนำ format ใบกำกับให้แสดงยอดอย่างไรเพื่อให้ผ่านการตรวจ?</p>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+
+    <article class="q">
+      <span class="q-tag">C4 · N-005 Interest recognition</span>
+      <h3 class="q-title">เคสของเรา (37.5% flat / ≈154% EIR / 12 งวด) ผ่าน NPAEs §11 simplification ได้ไหม?</h3>
+      <div class="q-body">
+        <p>ปัจจุบันใช้ straight-line allocation: <code>interestTotal / totalMonths</code>. TFRS 15 §60-65 ให้ใช้ Effective Interest Method (EIR) แต่ NPAEs §11 ผ่อนปรนถ้า "significant financing component" ไม่ material. คำถามนี้สำคัญ:</p>
+        <ul style="margin: 6px 0 8px; padding-left: 18px; font-size: 13px;">
+          <li>NPAEs §11 simplification ใช้ได้ในเคสเรา?</li>
+          <li>ถ้าใช่ — ออก Policy Memo ลายลักษณ์อักษรให้ดี เก็บไว้ audit trail</li>
+          <li>ถ้าไม่ใช่ — กำหนด timeline migration เป็น EIR (Dev บอก ~1 อาทิตย์)</li>
+        </ul>
+        <div class="q-context">
+          <strong>เอกสารอ้างอิง:</strong> docs/accounting/eir-decision-memo.md (มีตารางเทียบ per-period P&L difference ระหว่าง 2 methods)
+        </div>
+      </div>
+      <div class="answer-box"></div>
+    </article>
+  </section>
+
+  <!-- ============ ACTION CHECKLIST ============ -->
+  <section class="actions">
+    <h2>สิ่งที่ต้องทำหลัง Owner ตอบ</h2>
+    <p class="lead">เพื่อ unblock Phase A.5 และเริ่ม merge / deploy / ส่ง CPA</p>
+
+    <ol class="check-list">
+      <li>
+        <div class="check-box"></div>
+        <div class="check-body">
+          <strong>Owner ตอบ A1 + B1-B4 (5 ข้อ) → Dev ลุย</strong>
+          <div class="check-meta">A.5-SP1 docs cleanup, A.5-SP3/SP4 SHOP pairing — เริ่มได้ทันทีหลัง B2 ตอบ</div>
+        </div>
+      </li>
+      <li>
+        <div class="check-box"></div>
+        <div class="check-body">
+          <strong>Owner ส่ง C1-C4 ให้ CPA (channel ตาม B1) → รอผล</strong>
+          <div class="check-meta">A.5-SP5 (N-005) + A.5-SP6 (CR-001) start หลัง CPA ตอบ — ปกติ 1-2 สัปดาห์</div>
+        </div>
+      </li>
+      <li>
+        <div class="check-box"></div>
+        <div class="check-body">
+          <strong>Merge PR #1035 → #1036 → #1037 → #1038</strong>
+          <div class="check-meta">รอ CI เขียวทั้ง 4 PR (ตอนนี้ MERGEABLE ทุกตัว) — Owner กดเอง หรือบอก Dev "merge ตามลำดับ"</div>
+        </div>
+      </li>
+      <li>
+        <div class="check-box"></div>
+        <div class="check-body">
+          <strong>หลัง #1035 merged + deployed → Owner รัน Q6 SQL runbook</strong>
+          <div class="check-meta">docs/runbooks/2026-05-19-owner-q6-vat-key-cleanup.md (2 step + verify SELECT)</div>
+        </div>
+      </li>
+      <li>
+        <div class="check-box"></div>
+        <div class="check-body">
+          <strong>(Optional) บอก Dev ให้สร้าง VIEWER user ตัวอย่างเพื่อ smoke test</strong>
+          <div class="check-meta">หลัง 3 PR แรก merged — ตรวจว่า auditor เห็นเฉพาะ /reports + /audit-logs + /accounting + /finance/*-report</div>
+        </div>
+      </li>
+    </ol>
+  </section>
+
+  <p class="foot">
+    <strong>BESTCHOICE FINANCE × SHOP</strong> · Owner Response v2.0 follow-up · Session 2026-05-19<br>
+    เอกสารต้นทาง: <em>docs/superpowers/specs/2026-05-19-phase-a5-brief.md</em> + Owner_Response_Q1-Q8_BESTCHOICE_v2.0.pdf
+  </p>
+
+</div>
+</body>
+</html>

--- a/docs/runbooks/2026-05-19-owner-q6-vat-key-cleanup.md
+++ b/docs/runbooks/2026-05-19-owner-q6-vat-key-cleanup.md
@@ -1,0 +1,116 @@
+# Runbook — Owner Q6 VAT legacy-key cleanup
+
+**Trigger:** Owner Response Q6 (signed 2026-05-17)
+**Owner:** akenarin.ak
+**Status:** Ready to execute — owner-verified VAT_RATE first, then soft-delete legacy keys
+
+---
+
+## What this runbook does
+
+Owner Response Q6 directs us to soft-delete the SystemConfig legacy keys
+`vat_pct` + `vat_rate` once `VAT_RATE` (canonical) is confirmed to hold
+the intended percentage value. After cleanup, the `[D1.1.3.1]` WARN-log
+"Found legacy vat_pct alongside VAT_RATE" stops firing on app boot.
+
+The SQL was already drafted under D1.1.3.1 (May 2026) — this runbook
+just sequences the existing scripts.
+
+## Pre-flight (~2 min)
+
+Run from a host with `DATABASE_URL` pointing at the target environment.
+
+```bash
+psql "$DATABASE_URL" -c "SELECT key, value, deleted_at IS NOT NULL AS soft_deleted
+FROM system_config
+WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate')
+ORDER BY key;"
+```
+
+Expected output:
+- `VAT_RATE` row present with `value = '7'` (or whatever rate is in effect)
+  + `soft_deleted = false`
+- Possibly `vat_pct` row with `value = '0.07'` or `'7'` (legacy) + `soft_deleted = false`
+- Possibly `vat_rate` row with `value = '0.07'` (older legacy) + `soft_deleted = false`
+
+⚠ **STOP and call CPA** if any of these are true:
+- `VAT_RATE` row is missing.
+- `VAT_RATE` value looks wrong (e.g. `'0.7'` interpreted as 70%; `'1.0'` interpreted as 1%).
+- `vat_pct` / `vat_rate` values differ in ways that suggest someone edited one but not the other.
+
+In any of those cases, run the backfill first
+(`2026-05-17-merge-vat-rate-keys.sql`) — it's the safer path because it
+infers `VAT_RATE` from `vat_pct` with explicit operator confirmation.
+
+## Step 1 (only if `VAT_RATE` is missing)
+
+```bash
+psql "$DATABASE_URL" \
+  -f apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql
+# Prompts for: YES_BACKFILL_VAT
+```
+
+This INSERTs a `VAT_RATE` row computed from `vat_pct` (or `vat_rate`).
+Legacy keys remain in place — they get cleaned up in step 2.
+
+## Step 2 — soft-delete legacy keys (Owner Q6 main action)
+
+```bash
+psql "$DATABASE_URL" \
+  -f apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql
+# Prompts for: YES_CLEANUP_VAT_PCT
+```
+
+Internal effect: one `UPDATE system_config SET deleted_at = NOW() WHERE
+key IN ('vat_pct', 'vat_rate') AND deleted_at IS NULL`. Idempotent —
+re-runs are no-ops. Soft-delete (NOT hard-delete) — values stay
+recoverable for emergency revert.
+
+## Verification (~2 min)
+
+```bash
+# 1. Confirm legacy keys are soft-deleted, canonical key is alive
+psql "$DATABASE_URL" -c "SELECT key, value, deleted_at IS NOT NULL AS soft_deleted
+FROM system_config
+WHERE key IN ('VAT_RATE', 'vat_pct', 'vat_rate')
+ORDER BY key;"
+
+# Expected:
+#  VAT_RATE | 7    | f   ← alive
+#  vat_pct  | …    | t   ← soft-deleted
+#  vat_rate | …    | t   ← soft-deleted
+
+# 2. Trigger the orphan-key check (deploys a fresh app boot or just re-runs the bootstrap).
+#    Look for the [D1.1.3.1] WARN message in logs — should be ABSENT after cleanup.
+#    Pattern that was firing pre-cleanup:
+#      "[D1.1.3.1] Found legacy vat_pct/vat_rate alongside VAT_RATE — please…"
+```
+
+## Rollback (if Owner discovers value drift after the fact)
+
+```sql
+UPDATE system_config
+SET deleted_at = NULL, updated_at = NOW()
+WHERE key IN ('vat_pct', 'vat_rate')
+  AND deleted_at IS NOT NULL;
+```
+
+This restores the rows; `VAT_RATE` will continue to be the primary read
+path because `vat-rate.util.ts:89-95` prefers it. The WARN log will
+resume firing until the legacy rows are removed (or until `VAT_RATE` is
+brought into agreement with them).
+
+## After this runbook
+
+- Memory note: project_owner_response_q1_q8_2026_05_17.md → mark Q6 as DONE.
+- No code change required — InterestConfigPage (frontend) already writes
+  to `VAT_RATE` only since D1.1.3.1 follow-up, so legacy keys won't
+  regenerate.
+
+## References
+
+- Owner Response v2.0 (signed 2026-05-17), Q6
+- `apps/api/src/utils/vat-rate.util.ts` — canonical read order (VAT_RATE → vat_pct → vat_rate → 7%)
+- `apps/api/src/utils/vat-rate-bootstrap.service.ts` — emits the WARN log this cleanup quiets
+- `apps/api/prisma/migrations-manual/2026-05-17-cleanup-vat-pct-orphan.sql` — the SQL this runbook invokes
+- `apps/api/prisma/migrations-manual/2026-05-17-merge-vat-rate-keys.sql` — fallback backfill (Step 1)

--- a/docs/superpowers/specs/2026-05-19-phase-a5-brief.md
+++ b/docs/superpowers/specs/2026-05-19-phase-a5-brief.md
@@ -1,0 +1,271 @@
+# Phase A.5 — Brief for Owner Review
+
+**Date:** 2026-05-19
+**Trigger:** Owner Response v2.0 (signed 2026-05-17), Bonus item B3
+**Author:** Dev (Claude)
+**Status:** ⚠️ Draft — sending to Owner for review **BEFORE implementation begins**, per B3 directive
+**Standard:** TFRS for NPAEs (continuing the A.4 chart)
+
+---
+
+## TL;DR
+
+Owner asked for Dev's view on what Phase A.5 should cover. Below is an
+audit of the 4 items Owner listed, plus a 5th item that's been blocked
+by the same CPA dependencies.
+
+**Verdict:** Only **2 of the 4 listed items** still require CPA input.
+The other 2 are already in production (Phase A.4 / P3-SP5) and the
+"deferred" labels in CLAUDE.md are stale — see §4 to update.
+
+| # | Item | Real status | A.5 action |
+|---|------|-------------|------------|
+| **B3.1** | **CR-001** VAT-on-interest | OPEN — CPA decision required | Brief CPA; spec depends on answer |
+| **B3.2** | **N-005** Interest recognition (upfront vs accrual) | **PARTIAL** — accrual done in A.4 (per-period via 11-2106); EIR vs straight-line still open | Brief CPA on §60-65 simplification |
+| **B3.3** | **W-003** Unearned interest field | ✅ **DONE in A.4** via 11-2106 Contra Asset | Update CLAUDE.md "deferred" list |
+| **B3.4** | SHOP-side accounting / paired JEs | **PARTIAL** — P3-SP5 added SHOP chart + templates + `PairedJournalService`; only inventory transfer currently uses pairing | Scope decision: which lifecycle events need atomic pairing |
+
+A 5th item, also explicitly listed in `accounting.md` "DEFERRED to Phase A.5":
+| # | Item | Status | A.5 action |
+|---|------|--------|------------|
+| **A.5-X** | PPE depreciation (12-21XX, 53-16XX); WHT (21-31XX/32XX, 54-XXXX); tax-disallowed expense flag (54-XXXX) | Partly done — fixed-asset module + ม.65 ตรี flag landed (PR #937) | Verify scope; closing-out work |
+
+---
+
+## §1 — CR-001 VAT-on-interest (open)
+
+### Current state
+- **SHOP** is not VAT-registered; SHOP transactions never carry VAT.
+- **FINANCE** is VAT-registered at 7%.
+- Today: FINANCE issues a single VAT invoice at contract activation covering
+  **(เงินต้น + ดอกเบี้ย + ค่าคอม)** × 7% — booked via
+  `ContractActivation1ATemplate` (Cr 21-2102 ภาษีขายรอเรียกเก็บ).
+- The 21-2102 balance unwinds into 21-2101 (ภ.พ.30 settled) via
+  `PaymentReceipt2BTemplate` each month as the customer pays.
+
+### What's unsettled
+Legally, **interest component of installment revenue ≠ subject to VAT** in
+ภ.พ. ม.79/4(7) — only the principal + service-fee portion is taxable.
+Owner has been booking VAT on the whole basis (incl. interest) since
+business inception. Continuing this is conservative (overpays VAT, which
+สรรพากร will not complain about) but may not survive an audit, and
+overpaid VAT is **not refundable retroactively** more than a few months.
+
+### CPA questions
+1. ภ.พ.30 ของเรา ที่ผ่านมาเคย report VAT บนดอกเบี้ยไหม? (= "did we historically file VAT including interest?")
+2. ม.79/4(7) ใช้กับ "ดอกเบี้ยเช่าซื้อ" ตามนิยามนี้หรือไม่?
+3. ถ้าจริง — ตั้งแต่ไหนเริ่มยกเว้น VAT บนดอกเบี้ย? (forward-only? back-correct?)
+4. ถ้าใช่ accountant ต้อง split base ออกเป็น taxable principal + exempt interest บนใบกำกับภาษีไหม?
+
+### Implementation paths (depending on CPA answer)
+
+**Path A — Status quo (continue VAT on full base)**
+- Zero code change.
+- Add a CPA-signed policy memo into `docs/accounting/eir-decision-memo.md` siblings.
+- Pros: Simple, no historical re-stating.
+- Cons: Inflates ภ.พ.30 output VAT; not aligned with ม.79/4(7) spirit.
+
+**Path B — Forward-only switch (most likely)**
+- Schema: `Contract.vatableComponent = 'PRINCIPAL_PLUS_FEE' | 'FULL'`
+  (default `'FULL'` for legacy contracts, `'PRINCIPAL_PLUS_FEE'` for new).
+- Effective-date in `system_config` (e.g. `vat_on_interest_exempt_from = '2026-07-01'`).
+- `ContractActivation1ATemplate` reads the flag; new contracts after the
+  date book VAT only on (principal + commission).
+- New CoA codes from A.1a spec:
+  - `21-2104` ภาษีขายดอกเบี้ยรอตัดบัญชี (deferred output VAT exempt portion) — already drafted in `2026-04-29-accounting-phase-a1a-coa-split.md`
+- ~3 new JE templates (contract activation variant; payment receipt variant).
+- ~10 CPA case CSV variants needed (gold tests).
+- **Estimated effort:** 1.5-2 weeks dev + 1 week CPA review.
+
+**Path C — Back-correction (only if regulator demands)**
+- Reverse historical 21-2102 over-bookings, refile ภ.พ.30, request refund.
+- High risk, only if CPA + regulator request.
+- **NOT recommending unless mandated.**
+
+---
+
+## §2 — N-005 Interest recognition (partial)
+
+### Current state (Phase A.4)
+- Accrual model is **already wired** via `InstallmentAccrual2ATemplate`
+  (daily cron 00:01 BKK).
+- Per-period interest recognized as `interestTotal / totalMonths`
+  (= straight-line allocation, not effective-interest method).
+- 11-2106 (รายได้รอตัดบัญชี-ดอกเบี้ย Contra Asset) holds the
+  unrecognized portion until each accrual entry releases its share to
+  41-1101 (รายได้ดอกเบี้ย).
+
+### What's unsettled
+TFRS 15 §60-65 prescribes the **Effective Interest Method (EIR)** for
+contracts with a "significant financing component". For 12-month
+contracts at 37.5% flat → 154% EIR, the financing component is
+material — auditors may flag the use of straight-line.
+
+TFRS for NPAEs §11 allows simplification when financing is
+"insignificant". The threshold is judgment-based — no statutory cutoff.
+See `docs/accounting/eir-decision-memo.md` for the full per-period
+difference table.
+
+### CPA questions
+1. ผ่าน NPAEs §11 simplification ในเคสของเราหรือไม่?
+2. ถ้าผ่าน — ออก Policy Memo ลายลักษณ์อักษร (สำหรับ audit trail) ได้หรือไม่?
+3. ถ้าไม่ผ่าน — กำหนด timeline migration เป็น EIR
+
+### Implementation paths
+
+**Path A — Stay straight-line + CPA Policy Memo**
+- Zero code change.
+- File the memo into accounting evidence.
+- Recommended if CPA agrees.
+
+**Path B — Migrate to EIR**
+- Rewrite `InstallmentAccrual2ATemplate` formula.
+- Regenerate 7 CPA case CSV gold files.
+- Update ~30 test cases.
+- **Estimated effort:** 1 week dev + verification.
+
+**Path C — Hybrid (straight-line in books, EIR in notes-to-FS)**
+- Add EIR computation as report-only output.
+- No JE change.
+- **Estimated effort:** ~3 days.
+
+---
+
+## §3 — W-003 Unearned interest field — ALREADY DONE
+
+### Reality check
+Phase A.4 (Full Accrual TFRS 15 chart, 2026-05-04) introduced
+`11-2106 รายได้รอตัดบัญชี-ดอกเบี้ย` as a **Contra Asset** holding
+unrecognized interest. The same line item the W-003 deferred note
+was talking about. See:
+
+- `ContractActivation1ATemplate`: Cr 11-2106 for `interestTotal`
+- `InstallmentAccrual2ATemplate`: Dr 11-2106 / Cr 41-1101 per period
+- `EarlyPayoffJP4Template`: reverses remaining 11-2106
+- Repossession / reschedule flows: also drain 11-2106 correctly
+- `accounting.service.ts.getBalanceSheetFromJournal`: contra-asset rule
+  shows 11-2106 as a negative under Asset (per TFRS presentation).
+
+**No additional schema column** (`Contract.unearnedInterest` or
+`Installment.unearnedInterest`) was needed — the GL itself is the
+source of truth (correct per TFRS — don't denormalize).
+
+### A.5 action
+**No implementation work** — but two cleanup items:
+
+1. Remove "W-003 Unearned interest field" from `CLAUDE.md` "Things
+   deferred" list. It's misleading.
+2. Update `docs/accounting/eir-decision-memo.md` to clarify that W-003
+   itself is closed; only N-005 EIR-vs-straight-line is what's left.
+
+---
+
+## §4 — SHOP-side accounting / paired JEs (partial)
+
+### What's done (P3-SP5)
+- SHOP chart-of-accounts (~50 accounts under `S*` prefix) — seeded.
+- SHOP JE templates: `ShopCashSale`, `ShopDownPayment`,
+  `ShopDownPaymentReversal`, `ShopInventoryTransfer`, `ShopFinanceReceipt`,
+  `ShopTradeIn`, `ShopExpense`.
+- `PairedJournalService.postPaired()` exists — posts SHOP + FINANCE JEs
+  atomically in one `$transaction` with shared `metadata.batchId`.
+- SHOP-scoped Trial Balance + P&L (`/expenses/ledger/shop/*` endpoints +
+  `ShopAccountingPage`).
+
+### What's not paired yet
+| Lifecycle event | FINANCE side | SHOP side | Paired? |
+|---|---|---|---|
+| Contract activation | `ContractActivation1A` | — (SHOP side is `ShopInventoryTransfer`, posted by a different call site) | ❌ Not atomic |
+| Down payment received | — | `ShopDownPayment` | n/a |
+| FINANCE wires to SHOP | — | `ShopFinanceReceipt` | n/a |
+| Repossession | `RepossessionJP5` | — (no SHOP reversal template yet) | ❌ Missing pair |
+| Trade-in accepted | — | `ShopTradeIn` | n/a |
+| SHOP expense | — | `ShopExpense` | n/a |
+| Inventory transfer to FINANCE pool | (covered by activation flow) | (covered by activation flow) | ✅ Inside PairedJournalService |
+
+### A.5 questions for Owner
+1. ต้องการให้ Contract Activation รวม SHOP + FINANCE ใน 1 $transaction (atomic) หรือไม่?
+   - **ข้อดี:** ถ้า SHOP-side fail → FINANCE rolls back → ไม่มี orphan JE
+   - **ข้อเสีย:** Activation request ช้าขึ้น ~10-20ms (extra JE writes), shared lock on more rows
+2. Repossession SHOP-side reversal template — ต้องการ implement หรือไม่?
+   - ปัจจุบัน: FINANCE post repo เท่านั้น (`RepossessionJP5Template`).
+   - ที่ขาด: SHOP-side ยังถือ stock inventory ของเครื่องไปแล้ว (ตอน activation) → ตอนยึดเครื่องคืนเข้าสต็อก ต้อง book Dr S11-2002 used inventory / Cr S50-XXXX COGS reversal.
+
+### Implementation effort
+- Pair Contract Activation: ~3 days (refactor 1 service call site, add tests)
+- SHOP repossession reversal template: ~4 days (new template + CoA verification + tests)
+- **Total:** ~1.5 weeks.
+
+### Risk
+P3-SP7 (multi-entity legal split, 2027) will refactor `PairedJournalService`
+into a cross-DB transaction (or eventual-consistency saga). If we pair
+more events now, P3-SP7 has more to migrate. Recommendation: **only pair
+events that have a real risk of partial-write today.** Right now
+ContractActivation is the only one with that risk.
+
+---
+
+## §5 — Adjacent A.5 items already shipped or pending
+
+These don't appear in Owner B3 but are in `accounting.md` "DEFERRED to
+Phase A.5":
+
+| Item | Status | Notes |
+|---|---|---|
+| **PPE + depreciation** (12-21XX, 53-16XX) | ✅ **Done** (Asset module, PR #828 et al) | Asset register + monthly depreciation cron live |
+| **WHT** (21-31XX/32XX, 54-XXXX) | ✅ **Done** (Expense, Payroll, Other Income, Vendor Settlement) | Per-line WHT routing, ม.50 / ม.65 ตรี / V17 base = amountBeforeVat |
+| **Tax-disallowed expense flag** (54-XXXX) | ✅ **Done** (PR #937) | `Expense.isTaxDisallowed` boolean. Owner Bonus B2 asks for inline UI hints per ม.65 ตรี category — see §6 |
+| **41-2101/02 HP Revenue** | NOT NEEDED | Owner FINANCE income IS interest (41-1101); principal is repayment, not revenue |
+
+So §5 ของ A.5 ที่ owner ฝากใน B3 จริง ๆ **ทำเสร็จไปแล้วเกือบหมด** — เหลือเฉพาะ §1 / §2 / §4.
+
+---
+
+## §6 — Owner Bonus B2 — Tax-disallowed UI hints (small, separate)
+
+Owner asked for inline hints on the tax-disallowed flag — e.g.
+"ของขวัญ > 2,000฿" / "ค่าปรับภาษี" / "ค่าใช้จ่ายส่วนตัว". This is a
+small frontend addition on the Expense entry form:
+
+- Tooltip / Popover anchored to the `isTaxDisallowed` checkbox.
+- Shows the ม.65 ตรี category list (10-15 items) so user picks the
+  reason BEFORE marking the flag.
+- Persist optional `taxDisallowedCategory String?` per ExpenseLine for
+  ภ.ง.ด.50/51 prep.
+
+**Estimated effort:** ~1-2 days. Can ship as a sub-PR of Phase A.5 §3
+docs cleanup, or as a standalone.
+
+---
+
+## §7 — Suggested Phase A.5 sequencing
+
+If Owner approves this brief, the rollout would look like:
+
+```
+Week 0  ─ Send §1+§2 CPA questions; wait for answers
+Week 1  ─ A.5-SP1 docs cleanup (§3 W-003 closure, CLAUDE.md update)
+        ─ A.5-SP2 Owner B2 tax-disallowed UI hints (§6)
+Week 2  ─ A.5-SP3 SHOP repossession reversal template (§4 part 1)
+        ─ A.5-SP4 ContractActivation pairing (§4 part 2)
+Week 3+ ─ A.5-SP5 N-005 implementation (§2) — path A/B/C per CPA
+        ─ A.5-SP6 CR-001 implementation (§1) — path A/B/C per CPA
+```
+
+A.5-SP1/2/3/4 are **independent of CPA** — can ship in parallel.
+A.5-SP5/6 are **CPA-blocked** — start only after answers in.
+
+Total: ~6-8 weeks of dev + CPA cycle time. Most cost is in the §1
+back-correction risk (Path C) — if CPA picks Path A/B for both items,
+Phase A.5 fits in ~3-4 weeks.
+
+---
+
+## §8 — Open questions for Owner BEFORE we start
+
+1. Should Dev brief CPA directly on §1 + §2, or does Owner want to be the channel?
+2. SHOP pairing scope — pair just ContractActivation, or also Repossession + future SHOP-aware Settlement?
+3. B2 UI hints — bundle into Phase A.5 or ship standalone now (1-2 day PR)?
+4. CR-001 Path C (historical re-stating) — under what circumstance is Owner willing to consider this?
+
+Reply on this brief → we lock the plan and open the first SP after Owner sign-off.


### PR DESCRIPTION
## Summary

Implements 4 SystemConfig decisions locked in by Owner on **2026-05-17**
(Owner_Response_Q1-Q8_BESTCHOICE_v2.0.pdf). Single additive migration +
1-line in-code default flip.

| # | Decision | Mechanism |
|---|----------|-----------|
| **Q1** | Petty Cash Cr leg → `11-1103` เงินสดพนักงานบัญชี (Imprest Fund pattern) | SystemConfig `petty_cash_account = '11-1103'` + flip in-code default 11-1201 → 11-1103 |
| **Q2** | Audit log retention = 1,825 วัน (5 ปี ตาม พ.ร.บ.การบัญชี ม.7) | SystemConfig `audit_log_retention_days = '1825'` |
| **Q4** | VIEWER role activation flag = `true` (read-only auditor) | SystemConfig `viewer_role_enabled = 'true'` ⚠️ flag-only; `@Roles()` wiring lands in follow-up PR |
| **Q8** | Petty cash replenish alert threshold = 1,000฿ (was 5,000฿) | SystemConfig `petty_cash_replenish_threshold = '1000'` |

Migration `20260955000000_owner_q1q8_systemconfig_decisions` is fully
idempotent (`ON CONFLICT (key) DO UPDATE`) and clears `deleted_at` so
soft-deleted rows from past sessions get restored with the owner-locked
value. Safe to re-run.

### What's NOT in this PR (intentional)

- **Q3 doc# format** — already shipped in PRs #941/#947 (PREFIX-YYMM-NNN, yearly reset). No change.
- **Q5 SMTP default** — already default in `settings.service.ts:1222`. No change.
- **Q6 soft-delete `vat_pct`/`vat_rate`** — manual ops step after verifying current `VAT_RATE` value. Owner-driven, not in migration.
- **Q7 role-map audit log** — already wired (D1.1.1.6, `ROLE_MAP_CREATED/UPDATED/DEACTIVATED` in `account-role.service.ts`). No change.
- **Bonus B1 SSO 875 verification** — already correct in `20260927000000_sso_config_table` seed (17500 ceiling × 5% = 875 for พ.ศ. 2569-2571). No change needed.
- **Q4 VIEWER `@Roles()` wiring** — flipping the flag alone is currently a no-op because no `@Roles()` decorator includes `'VIEWER'` and the `RolesWhenViewerEnabled` helper referenced in `roles.decorator.ts:10` doesn't actually exist. A follow-up PR will add `VIEWER` to GET endpoints in `accounting.controller.ts` / `audit.controller.ts` / `reports.controller.ts` and gate via `viewer_role_enabled`. This PR ships the flag flip ahead so that follow-up PR is pure additive code with no SystemConfig writes.

## Test plan

- [x] `npx jest --testPathPattern='petty-cash|audit-retention|settings.service|expense-documents.service.spec'` — **316 specs pass green** in worktree
- [x] `npx tsc --noEmit` on apps/api + apps/web — 0 errors
- [x] Migration SQL is idempotent — verified `ON CONFLICT (key) DO UPDATE` clause + `deleted_at = NULL` restore path
- [ ] Smoke test in dev: create one PETTY_CASH_REIMBURSEMENT with `depositAccountCode: '11-1103'` → POST succeeds → JE Cr leg lands on 11-1103
- [ ] Smoke test in dev: trigger `PettyCashReplenishAlertCron` with balance < 1000 → IN_APP notification fires for OWNER

## References

- Owner sign-off doc: `Owner_Response_Q1-Q8_BESTCHOICE_v2.0.pdf`
- Memory note: `.claude/projects/-Users-iamnaii-Desktop-App-BESTCHOICE/memory/project_owner_response_q1_q8_2026_05_17.md`
- Standard: TFRS for NPAEs · Full Accrual · 99-account FINANCE chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)