### PR TITLE
feat(auth): VIEWER role scope wiring (Owner Q4 follow-up to #1035)

### DIFF
--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -48,7 +48,7 @@ export class AccountingController {
   // ============================================================
 
   @Get('ledger/trial-balance')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getTrialBalance(
     @Query('asOfDate') asOfDate?: string,
     @Query('scope') scope?: 'FINANCE' | 'SHOP' | 'ALL',
@@ -60,7 +60,7 @@ export class AccountingController {
   }
 
   @Get('ledger/profit-loss')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getProfitLossFromJournal(
     @Query('periodStart') periodStart: string,
     @Query('periodEnd') periodEnd: string,
@@ -88,13 +88,13 @@ export class AccountingController {
   // global guard will block it anyway.
 
   @Get('ledger/shop/trial-balance')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getShopTrialBalance(@Query('asOfDate') asOfDate?: string) {
     return this.service.getTrialBalance(asOfDate ? new Date(asOfDate) : undefined, 'SHOP');
   }
 
   @Get('ledger/shop/profit-loss')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getShopProfitLoss(
     @Query('periodStart') periodStart: string,
     @Query('periodEnd') periodEnd: string,
@@ -106,7 +106,7 @@ export class AccountingController {
   }
 
   @Get('ledger/balance-sheet')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getBalanceSheetFromJournal(@Query('asOfDate') asOfDate?: string) {
     return this.service.getBalanceSheetFromJournal(asOfDate ? new Date(asOfDate) : undefined);
   }
@@ -114,7 +114,7 @@ export class AccountingController {
   // ─── P4-SP1: Aging Report ────────────────────────────────────────────────
 
   @Get('ledger/aging')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getAgingReport(@Query('asOf') asOf?: string) {
     return this.service.getAgingReport(asOf ? new Date(asOf) : new Date());
   }
@@ -122,7 +122,7 @@ export class AccountingController {
   // ─── P4-SP1: Bad Debt Report ──────────────────────────────────────────────
 
   @Get('ledger/bad-debt')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getBadDebtReport(
     @Query('start') start: string,
     @Query('end') end: string,
@@ -139,7 +139,7 @@ export class AccountingController {
   // ============================================================
 
   @Get('ledger/cash-flow')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getCashFlowFromJournal(
     @Query('periodStart') periodStart: string,
     @Query('periodEnd') periodEnd: string,
@@ -152,7 +152,7 @@ export class AccountingController {
   }
 
   @Get('ledger/equity-statement')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getEquityStatementFromJournal(
     @Query('periodStart') periodStart: string,
     @Query('periodEnd') periodEnd: string,
@@ -175,7 +175,7 @@ export class AccountingController {
    * can surface a warning banner.
    */
   @Get('journal/export-peak')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   async exportJournalPeak(
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
@@ -203,7 +203,7 @@ export class AccountingController {
   }
 
   @Get('ledger/general-journal')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getGeneralJournal(
     @Query('start') start: string,
     @Query('end') end: string,
@@ -219,7 +219,7 @@ export class AccountingController {
   }
 
   @Get('ledger/general-ledger')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getGeneralLedger(
     @Query('accountCode') accountCode: string,
     @Query('periodStart') periodStart: string,
@@ -237,7 +237,7 @@ export class AccountingController {
   // ============================================================
 
   @Get('period-status')
-  @Roles('OWNER')
+  @Roles('OWNER', 'VIEWER')
   getPeriodStatus() {
     return this.service.getAccountingPeriodStatus();
   }
@@ -262,7 +262,7 @@ export class AccountingController {
   }
 
   @Get('bad-debt/summary')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getProvisionSummary() {
     return this.badDebtService.getProvisionSummary();
   }
@@ -287,7 +287,7 @@ export class AccountingController {
   // ============================================================
 
   @Get('periods/overview')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getPeriodsOverview(
     @Query('companyId') companyId: string,
     @Query('year') year: string,
@@ -296,13 +296,13 @@ export class AccountingController {
   }
 
   @Get('periods/reopened')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getReopenedPeriods() {
     return this.monthlyCloseService.listReopenedPeriods();
   }
 
   @Get('periods/:companyId/:year/:month')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getMonthlyPeriodStatus(
     @Param('companyId') companyId: string,
     @Param('year') year: string,
@@ -357,7 +357,7 @@ export class AccountingController {
   // ============================================================
 
   @Get('inter-co/report')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getInterCoReport(
     @Query('start') start: string,
     @Query('end') end: string,

--- a/apps/api/src/modules/accounting/consolidated.controller.ts
+++ b/apps/api/src/modules/accounting/consolidated.controller.ts
@@ -10,7 +10,7 @@ import { ConsolidatedService } from './consolidated.service';
  */
 @Controller('accounting/consolidated')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles('OWNER', 'ACCOUNTANT')
+@Roles('OWNER', 'ACCOUNTANT', 'VIEWER')
 export class ConsolidatedController {
   constructor(private readonly svc: ConsolidatedService) {}
 

--- a/apps/api/src/modules/audit/audit.controller.ts
+++ b/apps/api/src/modules/audit/audit.controller.ts
@@ -14,7 +14,7 @@ export class AuditController {
   constructor(private auditService: AuditService) {}
 
   @Get('financial/:contractId')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getFinancialTrail(
     @Param('contractId') contractId: string,
     @Query('page') page?: string,
@@ -27,7 +27,7 @@ export class AuditController {
   }
 
   @Get('logs')
-  @Roles('OWNER')
+  @Roles('OWNER', 'VIEWER')
   getLogs(
     @Query('userId') userId?: string,
     @Query('entity') entity?: string,
@@ -62,17 +62,21 @@ export class AuditController {
   }
 
   @Get('stats')
-  @Roles('OWNER')
+  @Roles('OWNER', 'VIEWER')
   getStats() {
     return this.auditService.getAuditStats();
   }
 
   /**
    * T2-C4 ext: walk the Merkle hash chain over AuditLog and return
-   * ok/first-mismatch. OWNER only — information leak potential.
+   * ok/first-mismatch. OWNER + VIEWER (external auditor, gated by
+   * `viewer_role_enabled` SystemConfig per Owner Q4 2026-05-17) — both
+   * roles need chain-integrity verification, and the response surface
+   * (ok / rowsChecked / firstMismatchSeq / firstMismatchId) is what an
+   * auditor needs to certify the log.
    */
   @Get('verify-chain')
-  @Roles('OWNER')
+  @Roles('OWNER', 'VIEWER')
   async verifyChain() {
     const result = await this.auditService.verifyChain({ maxRows: 50_000 });
     return {

--- a/apps/api/src/modules/auth/decorators/roles.decorator.ts
+++ b/apps/api/src/modules/auth/decorators/roles.decorator.ts
@@ -3,18 +3,20 @@ import { SetMetadata } from '@nestjs/common';
 export const ROLES_KEY = 'roles';
 
 /**
- * D1.3.2.1 — Role union mirrors the Prisma `UserRole` enum. `VIEWER` exists
- * as a future-use read-only auditor role; today it has ZERO permissions wired
- * (no @Roles() decorator in the codebase includes it). When OWNER enables the
- * SystemConfig flag `viewer_role_enabled = 'true'`, the optional helper
- * `RolesWhenViewerEnabled` (below) augments a route's role list with VIEWER
- * at request time via a Reflector lookup. Until that flag flips, a VIEWER
- * user can authenticate but sees empty pages on GET endpoints that do NOT
- * include VIEWER in their @Roles() decorator.
+ * Role union mirrors the Prisma `UserRole` enum.
  *
- * Q4-gated: this is the conservative default — schema enum exists so OWNER
- * has the option to create Viewer accounts, but no permissions are wired.
- * If owner's Q4 answer is "no viewer role at all" we drop this PR.
+ * VIEWER is a read-only auditor role (CPA / สรรพากร). Owner Response Q4
+ * (signed 2026-05-17) scoped its access to GET endpoints on
+ * `/accounting/*`, `/audit-logs`, `/reports/*`. The role is gated at
+ * runtime via SystemConfig `viewer_role_enabled`:
+ *
+ *   - 'true'  → VIEWER passes routes that include 'VIEWER' in @Roles()
+ *   - 'false' → RolesGuard denies VIEWER everywhere (default; safe to
+ *               leave the schema enum even if the role is unused)
+ *
+ * To grant a new endpoint to VIEWER: add `'VIEWER'` to its @Roles()
+ * decorator. The activation gate happens in `RolesGuard` — no extra
+ * decorator needed.
  */
 type UserRole =
   | 'OWNER'

--- a/apps/api/src/modules/auth/guards/roles.guard.spec.ts
+++ b/apps/api/src/modules/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,137 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard, __resetViewerFlagCacheForTests } from './roles.guard';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+/**
+ * RolesGuard behavior:
+ *   - No @Roles() metadata → allow (route is public to all authenticated users)
+ *   - No user on request → deny
+ *   - User.role NOT in requiredRoles → deny
+ *   - User.role IN requiredRoles AND not VIEWER → allow
+ *   - User.role === 'VIEWER':
+ *       → check SystemConfig `viewer_role_enabled` (cached 60s)
+ *       → 'true' allows, 'false'/missing/DB-error denies
+ */
+describe('RolesGuard', () => {
+  let reflector: Reflector;
+  let prisma: { systemConfig: { findFirst: jest.Mock } };
+  let guard: RolesGuard;
+
+  function makeCtx(user: { role: string } | null, requiredRoles: string[] | undefined): ExecutionContext {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockImplementation((key: string) => (key === ROLES_KEY ? requiredRoles : undefined));
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+      getHandler: () => () => undefined,
+      getClass: () => class {},
+    } as unknown as ExecutionContext;
+  }
+
+  beforeEach(() => {
+    __resetViewerFlagCacheForTests();
+    reflector = new Reflector();
+    prisma = { systemConfig: { findFirst: jest.fn() } };
+    guard = new RolesGuard(reflector, prisma as unknown as PrismaService);
+  });
+
+  it('allows when no @Roles() metadata is set on the route', async () => {
+    const ctx = makeCtx({ role: 'OWNER' }, undefined);
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(prisma.systemConfig.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('denies when user is missing from request', async () => {
+    const ctx = makeCtx(null, ['OWNER']);
+    await expect(guard.canActivate(ctx)).resolves.toBe(false);
+  });
+
+  it('denies when user.role is not in requiredRoles', async () => {
+    const ctx = makeCtx({ role: 'SALES' }, ['OWNER', 'FINANCE_MANAGER']);
+    await expect(guard.canActivate(ctx)).resolves.toBe(false);
+    expect(prisma.systemConfig.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('allows when non-VIEWER user.role is in requiredRoles', async () => {
+    const ctx = makeCtx({ role: 'ACCOUNTANT' }, ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER']);
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    // No DB call needed for non-VIEWER users.
+    expect(prisma.systemConfig.findFirst).not.toHaveBeenCalled();
+  });
+
+  describe('VIEWER gate', () => {
+    it("denies VIEWER when SystemConfig row is missing (default 'false')", async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue(null);
+      const ctx = makeCtx({ role: 'VIEWER' }, ['OWNER', 'VIEWER']);
+      await expect(guard.canActivate(ctx)).resolves.toBe(false);
+      expect(prisma.systemConfig.findFirst).toHaveBeenCalledWith({
+        where: { key: 'viewer_role_enabled', deletedAt: null },
+        select: { value: true },
+      });
+    });
+
+    it("denies VIEWER when SystemConfig value === 'false'", async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'false' });
+      const ctx = makeCtx({ role: 'VIEWER' }, ['VIEWER']);
+      await expect(guard.canActivate(ctx)).resolves.toBe(false);
+    });
+
+    it("allows VIEWER when SystemConfig value === 'true' AND requiredRoles includes VIEWER", async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+      const ctx = makeCtx({ role: 'VIEWER' }, ['OWNER', 'ACCOUNTANT', 'VIEWER']);
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    });
+
+    it('denies VIEWER on routes that DO NOT list VIEWER in @Roles()', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+      const ctx = makeCtx({ role: 'VIEWER' }, ['OWNER', 'ACCOUNTANT']);
+      await expect(guard.canActivate(ctx)).resolves.toBe(false);
+      // Short-circuits BEFORE the DB lookup — user.role missing from
+      // requiredRoles is the cheaper-to-compute condition.
+      expect(prisma.systemConfig.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('denies VIEWER (fail closed) when SystemConfig read throws', async () => {
+      prisma.systemConfig.findFirst.mockRejectedValue(new Error('DB unreachable'));
+      const ctx = makeCtx({ role: 'VIEWER' }, ['VIEWER']);
+      await expect(guard.canActivate(ctx)).resolves.toBe(false);
+    });
+
+    it('caches the SystemConfig lookup across requests (single DB read per TTL)', async () => {
+      prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+      const ctx1 = makeCtx({ role: 'VIEWER' }, ['VIEWER']);
+      await guard.canActivate(ctx1);
+      const ctx2 = makeCtx({ role: 'VIEWER' }, ['VIEWER']);
+      await guard.canActivate(ctx2);
+      const ctx3 = makeCtx({ role: 'VIEWER' }, ['VIEWER']);
+      await guard.canActivate(ctx3);
+      expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes the cache after TTL expires', async () => {
+      jest.useFakeTimers();
+      try {
+        prisma.systemConfig.findFirst
+          .mockResolvedValueOnce({ value: 'true' })
+          .mockResolvedValueOnce({ value: 'false' });
+
+        const ctx1 = makeCtx({ role: 'VIEWER' }, ['VIEWER']);
+        await expect(guard.canActivate(ctx1)).resolves.toBe(true);
+
+        // Advance past 60s TTL.
+        jest.advanceTimersByTime(61_000);
+
+        const ctx2 = makeCtx({ role: 'VIEWER' }, ['VIEWER']);
+        await expect(guard.canActivate(ctx2)).resolves.toBe(false);
+
+        expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+});

--- a/apps/api/src/modules/auth/guards/roles.guard.ts
+++ b/apps/api/src/modules/auth/guards/roles.guard.ts
@@ -1,12 +1,40 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from '../decorators/roles.decorator';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * VIEWER role gate (Owner Response Q4 signed 2026-05-17)
+ *
+ * The schema enum `UserRole.VIEWER` always exists so OWNER can create
+ * read-only auditor accounts (CPA / สรรพากร). Whether requests from a
+ * VIEWER user actually pass through depends on SystemConfig
+ * `viewer_role_enabled`:
+ *
+ *   - flag = 'true'  → VIEWER passes routes that list 'VIEWER' in @Roles()
+ *   - flag = 'false' → VIEWER is denied everywhere (treated as if no @Roles
+ *                       decoration includes them)
+ *
+ * Cached in-process for 60 s so the hot path doesn't add a SystemConfig
+ * query on every request. The flag changes rarely (owner toggle); the
+ * staleness window is bounded.
+ */
+let viewerFlagCache: { value: boolean; expires: number } | null = null;
+const VIEWER_FLAG_TTL_MS = 60_000;
+
+/** Test-only: reset the cache between cases. */
+export function __resetViewerFlagCacheForTests(): void {
+  viewerFlagCache = null;
+}
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+  constructor(
+    private reflector: Reflector,
+    private prisma: PrismaService,
+  ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
@@ -18,6 +46,36 @@ export class RolesGuard implements CanActivate {
 
     const { user } = context.switchToHttp().getRequest();
     if (!user) return false;
-    return requiredRoles.includes(user.role);
+
+    if (!requiredRoles.includes(user.role)) {
+      return false;
+    }
+
+    if (user.role === 'VIEWER') {
+      return this.isViewerEnabled();
+    }
+
+    return true;
+  }
+
+  private async isViewerEnabled(): Promise<boolean> {
+    const now = Date.now();
+    if (viewerFlagCache && viewerFlagCache.expires > now) {
+      return viewerFlagCache.value;
+    }
+    let value = false;
+    try {
+      const row = await this.prisma.systemConfig.findFirst({
+        where: { key: 'viewer_role_enabled', deletedAt: null },
+        select: { value: true },
+      });
+      value = row?.value === 'true';
+    } catch {
+      // DB read failure → fail closed (deny). Better to 403 an auditor
+      // than to leak data if SystemConfig is unreachable.
+      value = false;
+    }
+    viewerFlagCache = { value, expires: now + VIEWER_FLAG_TTL_MS };
+    return value;
   }
 }

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -11,7 +11,7 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 @ApiBearerAuth('JWT')
 @Controller('reports')
 @UseGuards(JwtAuthGuard, RolesGuard, BranchGuard)
-@Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+@Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
 export class ReportsController {
   constructor(private reportsService: ReportsService) {}
 
@@ -71,7 +71,7 @@ export class ReportsController {
   }
 
   @Get('comparative-pl')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getComparativePL(
     @Query('year') year: string,
     @Query('month') month: string,
@@ -87,7 +87,7 @@ export class ReportsController {
   }
 
   @Get('balance-sheet')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   async getBalanceSheet(
     @Query('asOfDate') asOfDate?: string,
     @Query('branchId') branchId?: string,
@@ -102,7 +102,7 @@ export class ReportsController {
   }
 
   @Get('cash-flow')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getCashFlowStatement(
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
@@ -152,7 +152,7 @@ export class ReportsController {
   }
 
   @Get('branch-comparison')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getBranchComparison(
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
@@ -189,7 +189,7 @@ export class ReportsController {
   }
 
   @Get('entity-profit')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   async getEntityProfit(
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
@@ -207,7 +207,7 @@ export class ReportsController {
   }
 
   @Get('quarterly')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER', 'VIEWER')
   getQuarterly(
     @Query('year') year: string,
     @Query('quarter') quarter: string,
@@ -223,7 +223,7 @@ export class ReportsController {
   }
 
   @Get('finance-portfolio')
-  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
   getFinancePortfolio(
     @Query('status') status?: string,
     @Query('page') page?: string,


### PR DESCRIPTION
## Summary

Follow-up to **#1035** which seeded \`viewer_role_enabled = 'true'\` in SystemConfig. By itself that flag was a no-op — no \`@Roles()\` decorator in the codebase included \`'VIEWER'\` and the \`RolesWhenViewerEnabled\` helper referenced in \`roles.decorator.ts:10\` never actually existed.

This PR makes the flag enforce.

| File | Change |
|------|--------|
| \`auth/guards/roles.guard.ts\` | Now async + injects PrismaService. When user.role === 'VIEWER', checks SystemConfig \`viewer_role_enabled\` (cached 60s, fails CLOSED on DB error). Non-VIEWER requests skip the DB read entirely. |
| \`auth/decorators/roles.decorator.ts\` | Replaced the stale comment that promised a helper which never existed. |
| \`accounting.controller.ts\` | +VIEWER on 18 GET methods (TB, P&L, BS, GL/GJ, periods, aging, bad-debt summary, cash-flow, equity, PEAK export, inter-co). POSTs untouched. |
| \`audit.controller.ts\` | +VIEWER on all 4 GET methods (financial trail, logs, stats, verify-chain). Comment refreshed. |
| \`reports.controller.ts\` | +VIEWER on class-level @Roles (covers all 16 GETs; controller has no POSTs). |
| \`consolidated.controller.ts\` | +VIEWER on class-level @Roles (3 GETs for \`/accounting/consolidated/*\`). |
| \`auth/guards/roles.guard.spec.ts\` | **NEW** — 11 specs covering empty metadata, missing user, role mismatch, non-VIEWER allow, VIEWER allow/deny on flag toggle, cache TTL, fail-closed on DB error. |

## Security model

\`\`\`
non-VIEWER → existing RolesGuard logic (unchanged)
VIEWER     → required-roles must include 'VIEWER' (cheap check first)
           → AND SystemConfig viewer_role_enabled === 'true' (cached)
           → DB error / flag missing / 'false' = DENY (fail closed)
\`\`\`

Cache TTL = 60s. The flag changes rarely (owner toggle), so a 60s window is acceptable. Cache reset helper exposed for tests only via \`__resetViewerFlagCacheForTests\`.

## What's NOT changed

- \`closing.controller.ts\` — only POSTs (preview / close / reverse). Skipped per VIEWER read-only policy.
- \`reporting.controller.ts\` + \`compliance.controller.ts\` — regulator-reporting domain, not under Owner Q4 scope (\`/accounting/\*\`, \`/audit-logs\`, \`/reports/\*\` only).
- Web frontend — VIEWER login + menu visibility ships in a later PR. This PR is API-side enforcement only so the flag flip from #1035 isn't a security half-fix.

## Test plan

- [x] \`npx jest --testPathPattern='roles.guard.spec'\` — 11/11 pass
- [x] \`npx tsc --noEmit\` on apps/api — 0 errors
- [x] Broader \`npx jest --testPathPattern='accounting|audit|reports|auth'\` — 351/357 (6 failures are pre-existing DB-integration tests in \`asset-reports.service.spec.ts\` not affected by this PR)
- [ ] Dev smoke: log in as a VIEWER user → \`GET /audit/logs\` returns data; \`POST /accounting/close-period\` returns 403
- [ ] Dev smoke: \`PATCH /settings\` flipping \`viewer_role_enabled = 'false'\` → VIEWER endpoints return 403 within 60s (cache TTL)

## Merge order

Merge **#1035 first** so prod has \`viewer_role_enabled = 'true'\` seeded before this PR's @Roles changes go live. Reversed order would block VIEWER unconditionally for the gap window — not strictly wrong but the flag flip wouldn't take effect until both PRs are in.

## References

- Owner sign-off: \`Owner_Response_Q1-Q8_BESTCHOICE_v2.0.pdf\` (signed 2026-05-17)
- Memory note: \`project_owner_response_q1_q8_2026_05_17.md\`
- Sister PR: #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)