### PR TITLE
feat(web): VIEWER role menu + user form (Owner Q4 frontend)

### DIFF
--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -119,3 +119,48 @@ describe('getSidebarForRole — populated ZONE_CONFIG', () => {
     expect(keys).toContain('acc-bank');
   });
 });
+
+describe('VIEWER role (Owner Q4 2026-05-17)', () => {
+  it('VIEWER zone config is fin-only with no settings gear', () => {
+    const cfg = getZoneConfigForRole('VIEWER');
+    expect(cfg).toBeDefined();
+    expect(cfg?.zones).toEqual(['fin']);
+    expect(cfg?.defaultZone).toBe('fin');
+    expect(cfg?.showSettingsGear).toBe(false);
+  });
+
+  it('VIEWER + fin returns the 4 expected read-only sections', () => {
+    const keys = getSidebarForRole('VIEWER', 'fin').map((s) => s.key);
+    expect(keys).toEqual([
+      'viewer-accounting',
+      'viewer-reports',
+      'viewer-shop-accounting',
+      'viewer-audit',
+    ]);
+  });
+
+  it('VIEWER + shop returns empty (out of read-only scope)', () => {
+    expect(getSidebarForRole('VIEWER', 'shop')).toEqual([]);
+  });
+
+  it('VIEWER + settings returns empty (no gear)', () => {
+    expect(getSidebarForRole('VIEWER', 'settings')).toEqual([]);
+  });
+
+  it('VIEWER menu paths stay inside the Q4-approved scope', () => {
+    const sections = getSidebarForRole('VIEWER', 'fin');
+    const paths = sections.flatMap((s) => s.items.map((i) => i.path));
+    // Every path must read /reports, /accounting/*, /audit-logs, /finance/*,
+    // /profit-loss, /shop/accounting, or /financial-audit — all map to
+    // backend GETs that PR #1036 wired with @Roles('VIEWER').
+    const allowed = (p: string) =>
+      p.startsWith('/reports') ||
+      p.startsWith('/accounting') ||
+      p === '/audit-logs' ||
+      p.startsWith('/finance/') ||
+      p === '/profit-loss' ||
+      p === '/shop/accounting' ||
+      p === '/financial-audit';
+    expect(paths.every(allowed)).toBe(true);
+  });
+});

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -799,6 +799,70 @@ const OWNER_CONFIG: RoleMenuConfig = {
   ],
 };
 
+/* ── VIEWER — ผู้ตรวจสอบ Read-only (Owner Q4 2026-05-17) ─
+ * Scope per Owner Response Q4: /accounting/*, /audit-logs, /reports/* —
+ * external auditor view (CPA / สรรพากร). Backend RolesGuard gates
+ * VIEWER via `viewer_role_enabled` SystemConfig flag (PR #1036). The
+ * menu mirrors that scope: no SHOP zone, no settings gear, no mutating
+ * action links. Pages reached via this menu serve read-only data; any
+ * action button on them returns 403 via the gated @Roles().
+ */
+const VIEWER_CONFIG: RoleMenuConfig = {
+  sidebar: [
+    {
+      key: 'viewer-accounting',
+      label: 'บัญชี + งบการเงิน',
+      icon: PieChart,
+      zone: 'fin',
+      items: [
+        { label: 'งบดุล (Balance Sheet)', path: '/finance/balance-sheet', icon: PieChart },
+        { label: 'กำไร-ขาดทุน (P&L)', path: '/profit-loss', icon: PieChart },
+        { label: 'งบกระแสเงินสด', path: '/finance/cash-flow', icon: Banknote },
+        { label: 'งบ Equity', path: '/finance/equity-statement', icon: BarChart3 },
+      ],
+    },
+    {
+      key: 'viewer-reports',
+      label: 'รายงาน',
+      icon: BarChart3,
+      zone: 'fin',
+      items: [
+        { label: 'รายงานรวม', path: '/reports', icon: BarChart3 },
+        { label: 'รายงานลูกหนี้ + Aging', path: '/finance/aging-report', icon: AlertTriangle },
+        { label: 'สมุดรายวัน', path: '/finance/general-journal', icon: BookOpen },
+        { label: 'สมุดแยกประเภท', path: '/finance/general-ledger', icon: BookOpen },
+        { label: 'รายงานหนี้สูญ', path: '/finance/bad-debt-report', icon: TrendingDown },
+        { label: 'รายงานลูกหนี้ Inter-co', path: '/finance/intercompany-report', icon: Building2 },
+        { label: 'ตรวจสอบบัญชี', path: '/financial-audit', icon: ClipboardList },
+      ],
+    },
+    {
+      key: 'viewer-shop-accounting',
+      label: 'บัญชีหน้าร้าน (SHOP)',
+      icon: Store,
+      zone: 'fin',
+      items: [
+        { label: 'งบทดลอง + P&L', path: '/shop/accounting', icon: PieChart },
+      ],
+    },
+    {
+      key: 'viewer-audit',
+      label: 'บันทึกระบบ',
+      icon: ScrollText,
+      zone: 'fin',
+      items: [
+        { label: 'Audit Log', path: '/audit-logs', icon: ScrollText },
+      ],
+    },
+  ],
+  bottomNav: [
+    { label: 'รายงาน', path: '/reports', icon: BarChart3 },
+    { label: 'งบดุล', path: '/finance/balance-sheet', icon: PieChart },
+    { label: 'P&L', path: '/profit-loss', icon: PieChart },
+    { label: 'Audit Log', path: '/audit-logs', icon: ScrollText },
+  ],
+};
+
 /* ── Config map ────────────────────────────────────── */
 
 const MENU_CONFIG: Record<string, RoleMenuConfig> = {
@@ -807,6 +871,7 @@ const MENU_CONFIG: Record<string, RoleMenuConfig> = {
   FINANCE_MANAGER: FINANCE_MANAGER_CONFIG,
   ACCOUNTANT: ACCOUNTANT_CONFIG,
   OWNER: OWNER_CONFIG,
+  VIEWER: VIEWER_CONFIG,
 };
 
 export function getMenuConfig(role: string): RoleMenuConfig {
@@ -890,6 +955,17 @@ const ZONE_CONFIG: Record<string, RoleZoneConfig> = {
     bottomNav: {
       shop: [],
       fin: ACCOUNTANT_CONFIG.bottomNav,
+      settings: [],
+    },
+  },
+  VIEWER: {
+    zones: ['fin'],
+    defaultZone: 'fin',
+    showSettingsGear: false,
+    sections: VIEWER_CONFIG.sidebar,
+    bottomNav: {
+      shop: [],
+      fin: VIEWER_CONFIG.bottomNav,
       settings: [],
     },
   },

--- a/apps/web/src/pages/UsersPage/components/InviteModal.tsx
+++ b/apps/web/src/pages/UsersPage/components/InviteModal.tsx
@@ -1,4 +1,5 @@
 import { Mail, Copy, Clock } from 'lucide-react';
+import { useUiFlags } from '@/hooks/useUiFlags';
 import { roleLabels, inputClass, labelClass } from '../types';
 
 interface InviteForm {
@@ -28,6 +29,13 @@ export default function InviteModal({
   onSubmit,
   onCopyUrl,
 }: InviteModalProps) {
+  // Owner Q4 (2026-05-17): VIEWER role only appears in the picker when
+  // `viewer_role_enabled = 'true'`. Otherwise OWNER shouldn't be inviting
+  // auditors yet — backend would deny their requests anyway.
+  const { viewerRoleEnabled } = useUiFlags();
+  const availableRoles = Object.entries(roleLabels).filter(
+    ([k]) => k !== 'VIEWER' || viewerRoleEnabled,
+  );
   return (
     <div
       className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs flex items-start justify-center pt-8 pb-8"
@@ -110,7 +118,7 @@ export default function InviteModal({
                     onChange={(e) => setInviteForm({ ...inviteForm, role: e.target.value })}
                     className={inputClass}
                   >
-                    {Object.entries(roleLabels).map(([k, v]) => (
+                    {availableRoles.map(([k, v]) => (
                       <option key={k} value={k}>
                         {v}
                       </option>

--- a/apps/web/src/pages/UsersPage/components/UserForm.tsx
+++ b/apps/web/src/pages/UsersPage/components/UserForm.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import { Camera, X, CreditCard } from 'lucide-react';
 import { compressImageForOcr } from '@/lib/compressImage';
 import { checkCardReaderStatus, readSmartCard } from '@/lib/cardReader';
+import { useUiFlags } from '@/hooks/useUiFlags';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { User, roleLabels, inputClass, labelClass, emptyForm } from '../types';
 
@@ -29,6 +30,15 @@ export default function UserForm({
 }: UserFormProps) {
   const avatarInputRef = useRef<HTMLInputElement>(null);
   const [isReadingCard, setIsReadingCard] = useState(false);
+  // Owner Q4 (2026-05-17): VIEWER role only appears in the role dropdown
+  // when `viewer_role_enabled = 'true'`. When OWNER edits an EXISTING
+  // VIEWER user we keep VIEWER visible in the picker regardless of the
+  // flag so the role doesn't silently disappear from the form.
+  const { viewerRoleEnabled } = useUiFlags();
+  const isEditingViewer = editingUser?.role === 'VIEWER';
+  const availableRoles = Object.entries(roleLabels).filter(
+    ([k]) => k !== 'VIEWER' || viewerRoleEnabled || isEditingViewer,
+  );
 
   const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -271,7 +281,7 @@ export default function UserForm({
                   onChange={(e) => setForm({ ...form, role: e.target.value })}
                   className={inputClass}
                 >
-                  {Object.entries(roleLabels).map(([k, v]) => (
+                  {availableRoles.map(([k, v]) => (
                     <option key={k} value={k}>
                       {v}
                     </option>

--- a/apps/web/src/pages/UsersPage/types.ts
+++ b/apps/web/src/pages/UsersPage/types.ts
@@ -25,6 +25,9 @@ export const roleAvatarColors: Record<string, string> = {
   FINANCE_MANAGER: 'bg-info/15 text-info',
   SALES: 'bg-success/15 text-success',
   ACCOUNTANT: 'bg-warning/15 text-warning',
+  // Owner Q4 (2026-05-17) — external auditor (CPA / สรรพากร). Read-only;
+  // backend RolesGuard gates via `viewer_role_enabled` SystemConfig.
+  VIEWER: 'bg-secondary text-secondary-foreground',
 };
 
 export interface InviteToken {
@@ -45,6 +48,7 @@ export const roleLabels: Record<string, string> = {
   FINANCE_MANAGER: 'ผู้จัดการการเงิน',
   SALES: 'พนักงานขาย',
   ACCOUNTANT: 'ฝ่ายบัญชี',
+  VIEWER: 'ผู้ตรวจสอบ (Read-only)',
 };
 
 export const roleColors: Record<string, string> = {
@@ -53,6 +57,7 @@ export const roleColors: Record<string, string> = {
   FINANCE_MANAGER: 'bg-info/10 text-info dark:bg-info/15',
   SALES: 'bg-success/10 text-success dark:bg-success/15',
   ACCOUNTANT: 'bg-warning/10 text-warning dark:bg-warning/15',
+  VIEWER: 'bg-secondary text-secondary-foreground',
 };
 
 export const inputClass =


### PR DESCRIPTION
## Summary

Frontend complement to **#1036**. Without this, the VIEWER backend permissions are unreachable from the UI: OWNER has no role option to invite an auditor, and a logged-in VIEWER falls back to OWNER_CONFIG (showing menus that 403 on every click).

Standalone — depends on neither #1035 nor #1036 to ship safely (if landed first, VIEWER simply has no functioning backend yet).

## Changes

| File | What |
|------|------|
| \`config/menu.ts\` | Add \`VIEWER_CONFIG\` (4 read-only fin sections) + register in \`MENU_CONFIG\` + \`ZONE_CONFIG\`. Zones=['fin'], no shop, no settings gear. Bottom nav has 4 quick-access items. |
| \`UsersPage/types.ts\` | Add VIEWER to \`roleLabels\` ('ผู้ตรวจสอบ (Read-only)'), \`roleColors\`, \`roleAvatarColors\` — bg-secondary so it stays neutral against brand-colored roles. |
| \`InviteModal\` + \`UserForm\` | Filter the role dropdown by \`useUiFlags().viewerRoleEnabled\`. UserForm has an "editing existing VIEWER" override so the role doesn't silently vanish when OWNER reopens an auditor after disabling the flag. |
| \`menu.test.ts\` | 5 new VIEWER assertions: zone config shape, exact 4 sidebar keys, empty shop/settings zones, **path-scope regression guard** (every VIEWER path must map to a backend GET that #1036 widened). All 24 vitest cases pass. |

## VIEWER menu surface

\`\`\`
บัญชี + งบการเงิน
  - งบดุล (Balance Sheet)         /finance/balance-sheet
  - กำไร-ขาดทุน (P&L)              /profit-loss
  - งบกระแสเงินสด                  /finance/cash-flow
  - งบ Equity                      /finance/equity-statement

รายงาน
  - รายงานรวม                      /reports
  - รายงานลูกหนี้ + Aging          /finance/aging-report
  - สมุดรายวัน                     /finance/general-journal
  - สมุดแยกประเภท                 /finance/general-ledger
  - รายงานหนี้สูญ                  /finance/bad-debt-report
  - รายงานลูกหนี้ Inter-co        /finance/intercompany-report
  - ตรวจสอบบัญชี                  /financial-audit

บัญชีหน้าร้าน (SHOP)
  - งบทดลอง + P&L                  /shop/accounting

บันทึกระบบ
  - Audit Log                      /audit-logs
\`\`\`

Every path maps to a backend GET that #1036 widened with \`@Roles('VIEWER')\` — verified by the new \`menu.test.ts\` regression guard.

## What's NOT in this PR

- ProtectedRoute / route guards — existing AuthContext + role-aware route filtering handles this once VIEWER is in menus.
- Login flow — VIEWER uses the same email/password flow as other roles.
- Dashboard route — VIEWER lands on \`/reports\` via bottomNav default; the Dashboard would 403 on its KPI cards anyway.
- Tax-disallowed UI hints (Owner B2) — separate PR per Phase A.5 brief.

## Test plan

- [x] \`npx vitest run src/config/menu.test.ts\` — **24/24 pass** (5 new VIEWER cases)
- [x] \`npx tsc --noEmit\` on apps/web — 0 errors
- [ ] Dev smoke: invite/create a VIEWER user with \`viewer_role_enabled=true\`, log in → see only the 4 read-only sections
- [ ] Dev smoke: \`viewer_role_enabled=false\` → VIEWER option hidden from invite dropdown (OWNER can't accidentally create a useless account)

## References

- Sister PRs: #1035 (SystemConfig flag flip), #1036 (backend RolesGuard + @Roles wiring)
- Memory note: \`project_owner_response_q1_q8_2026_05_17.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)