### PR TITLE
feat(web): ม.65 ตรี category popover for tax-disallowed flag (Owner B2)

### DIFF
--- a/apps/web/src/components/expense-form-v4/ItemLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/ItemLinesSection.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { ExpenseLineForm, newLine } from './types';
 import { formatNumberDecimal } from '@/utils/formatters';
 import { useUiFlags } from '@/hooks/useUiFlags';
+import TaxDisallowedHint from './TaxDisallowedHint';
 
 interface Props {
   lines: ExpenseLineForm[];
@@ -128,18 +129,24 @@ export function ItemLinesSection({ lines, onChange, priceTypeLabel }: Props) {
             {/* Phase A.5 — Per-line tax-disallowed override.
                 Rare path — set only when this single line is non-deductible
                 while the rest of the doc is deductible (or vice versa).
-                Effective rule = doc-level OR line-level. */}
-            <label className="flex items-start gap-2 text-xs cursor-pointer text-muted-foreground hover:text-foreground transition-colors">
-              <input
-                type="checkbox"
-                checked={line.taxDisallowed === true}
-                onChange={(e) => updateLine(line.uid, { taxDisallowed: e.target.checked })}
-                className="mt-0.5"
-              />
-              <span>
-                บรรทัดนี้เป็น <span className="font-medium">ค่าใช้จ่ายต้องห้าม</span> (ใช้เฉพาะกรณีเอกสารปนรายการที่หักได้+หักไม่ได้ — ปกติติ๊กที่ระดับเอกสารแทน)
-              </span>
-            </label>
+                Effective rule = doc-level OR line-level.
+                Owner B2 (2026-05-17): compact ม.65 ตรี popover next to
+                the checkbox so line-level users see the same category
+                list. */}
+            <div className="flex items-start gap-2">
+              <label className="flex items-start gap-2 text-xs cursor-pointer text-muted-foreground hover:text-foreground transition-colors flex-1">
+                <input
+                  type="checkbox"
+                  checked={line.taxDisallowed === true}
+                  onChange={(e) => updateLine(line.uid, { taxDisallowed: e.target.checked })}
+                  className="mt-0.5"
+                />
+                <span>
+                  บรรทัดนี้เป็น <span className="font-medium">ค่าใช้จ่ายต้องห้าม</span> (ใช้เฉพาะกรณีเอกสารปนรายการที่หักได้+หักไม่ได้ — ปกติติ๊กที่ระดับเอกสารแทน)
+                </span>
+              </label>
+              <TaxDisallowedHint compact />
+            </div>
           </div>
         </div>
       ))}

--- a/apps/web/src/components/expense-form-v4/TaxDisallowedHint.tsx
+++ b/apps/web/src/components/expense-form-v4/TaxDisallowedHint.tsx
@@ -1,0 +1,69 @@
+import { HelpCircle } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { TAX_DISALLOWED_CATEGORIES } from '@/constants/tax-disallowed';
+
+interface Props {
+  /** Compact variant for line-level usage; default = doc-level richer style */
+  compact?: boolean;
+}
+
+/**
+ * Owner Response v2.0 Bonus B2 (2026-05-17): inline category list for
+ * the tax-disallowed flag, so users see which ม.65 ตรี sub-clause their
+ * expense falls under BEFORE ticking the checkbox. Click the small "?"
+ * icon to open a Popover with the 12 most common categories. Selecting
+ * a category does NOT modify form state — it's a reference list only;
+ * ภ.ง.ด.50/51 still keys off the boolean flag.
+ */
+export default function TaxDisallowedHint({ compact = false }: Props) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="ดูประเภทค่าใช้จ่ายต้องห้าม (ม.65 ตรี)"
+          className={`inline-flex items-center gap-1 rounded-md text-muted-foreground transition-colors hover:text-foreground focus:outline-hidden focus:ring-2 focus:ring-primary/30 ${
+            compact ? 'p-0.5 text-[11px]' : 'px-1.5 py-0.5 text-xs'
+          }`}
+        >
+          <HelpCircle className={compact ? 'size-3' : 'size-3.5'} aria-hidden="true" />
+          {!compact && <span>ดูตัวอย่างประเภท</span>}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="top"
+        className="w-[min(28rem,calc(100vw-2rem))] max-h-[60vh] overflow-y-auto p-0"
+      >
+        <div className="sticky top-0 border-b border-border bg-popover/95 backdrop-blur-xs px-4 py-3">
+          <h4 className="text-sm font-semibold leading-snug text-foreground">
+            ประเภทค่าใช้จ่ายต้องห้าม (ม.65 ตรี ป.รัษฎากร)
+          </h4>
+          <p className="mt-1 text-xs leading-snug text-muted-foreground">
+            ติ๊กเลือกเฉพาะรายการที่หักลดหย่อนภาษีนิติบุคคลไม่ได้ — ตัวอย่างที่พบบ่อย
+          </p>
+        </div>
+        <ul className="divide-y divide-border">
+          {TAX_DISALLOWED_CATEGORIES.map((c) => (
+            <li key={c.ref} className="px-4 py-2.5 text-xs leading-snug">
+              <div className="flex items-baseline gap-2">
+                <span className="font-mono text-[10px] text-muted-foreground shrink-0 pt-0.5">
+                  ม.65 ตรี {c.ref}
+                </span>
+                <div className="flex-1">
+                  <div className="font-medium text-foreground">{c.label}</div>
+                  {c.example && (
+                    <div className="mt-0.5 text-muted-foreground">{c.example}</div>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="border-t border-border bg-muted/30 px-4 py-2.5 text-[11px] leading-snug text-muted-foreground">
+          ระบบบันทึกบัญชีปกติ — flag นี้มีผลเฉพาะตอนสรุปยอด ภ.ง.ด.50/51 ปลายปี
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/expense-form-v4/VendorSection.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorSection.tsx
@@ -1,5 +1,6 @@
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { ExpenseFormState } from './types';
+import TaxDisallowedHint from './TaxDisallowedHint';
 
 interface Props {
   state: ExpenseFormState;
@@ -78,21 +79,28 @@ export function VendorSection({ state, onChange }: Props) {
       {/* Phase A.5 — Tax-disallowed flag (ม.65 ตรี ป.รัษฎากร).
           Bookkeeping unchanged — flag only affects ภ.ง.ด.50/51 deductible total
           at year-end. Display as a single doc-level checkbox; per-line override
-          lives on each line row for the rare mixed-category case. */}
-      <label className="flex items-start gap-2.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5 cursor-pointer hover:bg-muted/50 transition-colors">
-        <input
-          type="checkbox"
-          checked={state.taxDisallowed}
-          onChange={(e) => onChange({ taxDisallowed: e.target.checked })}
-          className="mt-0.5"
-        />
-        <div className="text-xs leading-snug">
-          <div className="font-medium">ค่าใช้จ่ายต้องห้าม (ม.65 ตรี ป.รัษฎากร)</div>
-          <div className="text-muted-foreground mt-0.5">
-            ติ๊กเมื่อเป็นค่าใช้จ่ายที่หักลดหย่อนภาษีนิติบุคคลไม่ได้ (เช่น ค่ารับรองเกิน 2,000 บาท, ค่าปรับสรรพากร, รายจ่ายส่วนตัว). บันทึกบัญชีปกติ — มีผลเฉพาะรายงาน ภ.ง.ด.50/51
+          lives on each line row for the rare mixed-category case.
+          Owner B2 (2026-05-17): TaxDisallowedHint exposes the full ม.65 ตรี
+          category list via a Popover next to the inline description. */}
+      <div className="rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+        <label className="flex items-start gap-2.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={state.taxDisallowed}
+            onChange={(e) => onChange({ taxDisallowed: e.target.checked })}
+            className="mt-0.5"
+          />
+          <div className="text-xs leading-snug">
+            <div className="font-medium">ค่าใช้จ่ายต้องห้าม (ม.65 ตรี ป.รัษฎากร)</div>
+            <div className="text-muted-foreground mt-0.5">
+              ติ๊กเมื่อเป็นค่าใช้จ่ายที่หักลดหย่อนภาษีนิติบุคคลไม่ได้ (เช่น ค่ารับรองเกิน 2,000 บาท, ค่าปรับสรรพากร, รายจ่ายส่วนตัว). บันทึกบัญชีปกติ — มีผลเฉพาะรายงาน ภ.ง.ด.50/51
+            </div>
           </div>
+        </label>
+        <div className="mt-1.5 pl-6">
+          <TaxDisallowedHint />
         </div>
-      </label>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/constants/tax-disallowed.test.ts
+++ b/apps/web/src/constants/tax-disallowed.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { TAX_DISALLOWED_CATEGORIES } from './tax-disallowed';
+
+/**
+ * Shape regression for the ม.65 ตรี category list shown in the
+ * TaxDisallowedHint popover (Owner B2 2026-05-17). Catches accidental
+ * empty entries / mismatched refs.
+ */
+describe('TAX_DISALLOWED_CATEGORIES', () => {
+  it('has at least the 6 owner-mentioned common categories covered', () => {
+    expect(TAX_DISALLOWED_CATEGORIES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('every entry has a ref + non-empty label', () => {
+    for (const c of TAX_DISALLOWED_CATEGORIES) {
+      expect(c.ref).toMatch(/^\(\d+\)$/);
+      expect(c.label.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('refs are unique (no duplicate sub-clauses listed twice)', () => {
+    const refs = TAX_DISALLOWED_CATEGORIES.map((c) => c.ref);
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  it('covers the three examples Owner Response Q response cited', () => {
+    const joined = TAX_DISALLOWED_CATEGORIES.map((c) => `${c.label} ${c.example ?? ''}`).join(
+      ' | ',
+    );
+    // "ของขวัญ > 2,000฿"
+    expect(joined).toMatch(/2,?000/);
+    // "ค่าปรับภาษี" / "ค่าปรับสรรพากร"
+    expect(joined).toMatch(/ค่าปรับ/);
+    // "ค่าใช้จ่ายส่วนตัว" / "รายจ่ายส่วนตัว"
+    expect(joined).toMatch(/ส่วนตัว/);
+  });
+});

--- a/apps/web/src/constants/tax-disallowed.ts
+++ b/apps/web/src/constants/tax-disallowed.ts
@@ -1,0 +1,92 @@
+/**
+ * Tax-disallowed expense categories — ป.รัษฎากร ม.65 ตรี (1)-(20)
+ *
+ * Inline reference list shown to users when they tick the
+ * "ค่าใช้จ่ายต้องห้าม" flag on expense / petty cash documents.
+ *
+ * The system DOES NOT persist which category was picked — this is a
+ * decision-support hint only. ภ.ง.ด.50/51 prep still uses the boolean
+ * `taxDisallowed` flag on Expense + ExpenseLine; the category here helps
+ * the user pick correctly.
+ *
+ * Source: ม.65 ตรี ป.รัษฎากร (https://www.rd.go.th/5937.html). Numbering
+ * follows the statute's sub-clauses. Phrasing simplified for non-lawyer
+ * Thai users — formal legal language stays in the statute itself.
+ *
+ * Owner Response v2.0 Bonus B2 (signed 2026-05-17):
+ *   "ขอให้เพิ่ม inline hint บอก user ว่ารายการนี้เข้าข่ายมาตรา 65 ตรี
+ *    ข้อใด (เช่น 'ของขวัญ > 2,000฿', 'ค่าปรับภาษี', 'ค่าใช้จ่ายส่วนตัว')
+ *    เพื่อช่วยลดความผิดพลาดตอนกรอก ภ.ง.ด.50/51"
+ */
+
+export interface TaxDisallowedCategory {
+  /** Sub-clause reference, e.g. "(3)" — pin to the statute */
+  ref: string;
+  /** Short label for the popover list */
+  label: string;
+  /** Example / threshold to disambiguate */
+  example?: string;
+}
+
+export const TAX_DISALLOWED_CATEGORIES: TaxDisallowedCategory[] = [
+  {
+    ref: '(3)',
+    label: 'ค่ารับรอง / ของขวัญลูกค้า เกิน 2,000฿ ต่อคนต่อครั้ง',
+    example: 'ส่วนที่เกินจาก 2,000฿ เท่านั้น (ส่วนที่ไม่เกินยังหักได้)',
+  },
+  {
+    ref: '(4)',
+    label: 'รายจ่ายส่วนตัว / รายจ่ายของกรรมการ-ผู้ถือหุ้นที่ไม่เกี่ยวกับกิจการ',
+    example: 'ของใช้ส่วนตัว, ค่าโรงแรมท่องเที่ยวกรรมการ',
+  },
+  {
+    ref: '(5)',
+    label: 'รายจ่ายที่ผู้จ่ายมีหน้าที่ต้องจ่ายเอง',
+    example: 'เงินบริจาคส่วนตัวจ่ายแทนกรรมการ',
+  },
+  {
+    ref: '(6)',
+    label: 'รายจ่ายที่ไม่มีหลักฐาน หรือพิสูจน์ผู้รับเงินไม่ได้',
+    example: 'จ่ายให้แม่ค้าตลาด/บุคคลทั่วไป โดยไม่มีใบเสร็จ',
+  },
+  {
+    ref: '(7)',
+    label: 'รายจ่ายที่ไม่ใช่เพื่อหากำไรหรือกิจการของบริษัทโดยตรง',
+    example: 'ค่าใช้จ่ายโครงการ CSR ที่ไม่ใช่เพื่อหากำไร',
+  },
+  {
+    ref: '(8)',
+    label: 'รายจ่ายไม่สมเหตุสมผล (สูงกว่าราคาตลาด)',
+    example: 'ซื้อของจากกรรมการในราคาเกินจริง',
+  },
+  {
+    ref: '(9)',
+    label: 'ค่าตอบแทนทรัพย์สินที่บริษัทเป็นเจ้าของเอง',
+    example: 'บริษัทจ่ายค่าเช่าให้กรรมการสำหรับทรัพย์สินของบริษัท',
+  },
+  {
+    ref: '(11)',
+    label: 'ค่าปรับ / เงินเพิ่ม / เบี้ยปรับสรรพากร / ค่าปรับอาญา',
+    example: 'ค่าปรับ ภ.พ.30, ภ.ง.ด.50, ค่าปรับจราจร',
+  },
+  {
+    ref: '(12)',
+    label: 'รายจ่ายสำหรับการชำระภาษีเงินได้นิติบุคคล',
+    example: 'ภาษีเงินได้นิติบุคคลของบริษัท เอง',
+  },
+  {
+    ref: '(13)',
+    label: 'รายจ่ายที่จ่ายให้ผู้รับซึ่งไม่อยู่ในประเทศไทย โดยไม่มีหลักฐาน',
+    example: 'ค่าบริการต่างประเทศที่ไม่มี invoice',
+  },
+  {
+    ref: '(14)',
+    label: 'รายจ่ายที่ผิดกฎหมาย',
+    example: 'ค่านายหน้าผิดกฎหมาย, เงินใต้โต๊ะ',
+  },
+  {
+    ref: '(15)',
+    label: 'รายจ่ายของกรรมการ/ผู้ถือหุ้นซึ่งไม่ได้ทำงานในบริษัท',
+    example: 'เงินเดือนของผู้ที่ไม่ได้ปฏิบัติงานจริง',
+  },
+];


### PR DESCRIPTION
## Summary

Closes the last remaining Owner Response v2.0 item — Bonus B2:

> "ขอให้เพิ่ม inline hint บอก user ว่ารายการนี้เข้าข่ายมาตรา 65 ตรี ข้อใด (เช่น 'ของขวัญ > 2,000฿', 'ค่าปรับภาษี', 'ค่าใช้จ่ายส่วนตัว') เพื่อช่วยลดความผิดพลาดตอนกรอก ภ.ง.ด.50/51"

Pure UI addition — no schema, no API, no persistence change. The boolean `taxDisallowed` flag already covers what ภ.ง.ด.50/51 needs; this PR adds a decision-support reference list so users can verify they're picking the right category BEFORE ticking the checkbox.

## What you see

**Doc-level** (\`VendorSection\`): the existing checkbox stays. A small "ดูตัวอย่างประเภท ?" button appears below — clicking opens a Popover with 12 ม.65 ตรี sub-clauses, each with a short Thai label + concrete example.

**Per-line override** (\`ItemLinesSection\`): the same popover, compact icon-only variant, sits to the right of the line-level checkbox.

Popover content covers Owner's three cited examples plus the rest of the common ม.65 ตรี space:
- (3) ค่ารับรอง > 2,000฿/คน/ครั้ง ← *Owner example*
- (4) รายจ่ายส่วนตัว / กรรมการที่ไม่เกี่ยวกับกิจการ ← *Owner example*
- (11) ค่าปรับ / เบี้ยปรับสรรพากร / ค่าปรับอาญา ← *Owner example*
- (5)/(6)/(7)/(8)/(9)/(12)/(13)/(14)/(15) — full list in \`constants/tax-disallowed.ts\`

## Files

| File | Change |
|------|--------|
| \`constants/tax-disallowed.ts\` | NEW — 12 ม.65 ตรี categories + examples |
| \`constants/tax-disallowed.test.ts\` | NEW — 4 shape regression cases (refs unique, owner's 3 examples present) |
| \`components/expense-form-v4/TaxDisallowedHint.tsx\` | NEW — Popover button (default + compact variants) |
| \`VendorSection.tsx\` | Insert TaxDisallowedHint under doc-level checkbox |
| \`ItemLinesSection.tsx\` | Insert TaxDisallowedHint (compact) next to per-line checkbox |

## What's NOT in this PR (intentional)

- Persisting the chosen category — Owner B2 only asked for a hint, not a stored field. Brief §6 suggested optional \`taxDisallowedCategory\` but Owner's directive was just inline hints. Can add later if accountant requests aggregation by category.
- Popover open/close interaction tests — JSDOM + Radix Popover are known flaky per project convention; defer to Playwright if it ever lands as a smoke test.

## Test plan

- [x] \`npx vitest run src/constants/tax-disallowed.test.ts\` — 4/4 pass
- [x] \`npx tsc --noEmit\` on apps/web — 0 errors
- [ ] Dev smoke: open ExpenseFormV4 → click "ดูตัวอย่างประเภท ?" → popover shows 12 categories with refs/labels/examples; click outside closes
- [ ] Dev smoke: add line → tick line-level override → click adjacent compact "?" → same popover opens with same content

Standalone — independent of #1035 / #1036 / #1037. Closes Owner Response v2.0 implementation coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)