### PR TITLE
fix(shop-ai): @Max(20)→100 on aiAutoMaxRepliesPerSession (Phase A hotfix)

### DIFF
--- a/apps/api/src/modules/staff-chat/dto/ai-settings.dto.ts
+++ b/apps/api/src/modules/staff-chat/dto/ai-settings.dto.ts
@@ -18,7 +18,7 @@ export class UpdateAiSettingsDto {
   @IsNumber()
   @IsOptional()
   @Min(1)
-  @Max(20)
+  @Max(100)
   aiAutoMaxRepliesPerSession?: number;
 
   @IsOptional()


### PR DESCRIPTION
## Bug

After PR #1049 deployed, owner can't save AiSettings — toast "ไม่สามารถบันทึกการตั้งค่าได้".

**Root cause:** Task 6 raised runtime default 5→50 in service + .env.example BUT the class-validator `@Max(20)` on DTO wasn't updated. Default 50 fails the 20-cap validator → 400 → save fail.

## Fix

`@Max(20)` → `@Max(100)` (1 line) in `UpdateAiSettingsDto.aiAutoMaxRepliesPerSession`.

## Test plan

- [x] 91/91 staff-chat tests pass
- [ ] After merge + deploy: owner saves AiSettings successfully

🚨 Urgent — owner blocked on Phase A testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)