### PR TITLE
feat(ops): re-enable FB + LINE Shop bot kill switches (Phase A go-live)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -318,10 +318,10 @@ jobs:
           API_BASE_URL=https://api.bestchoicephone.app,\
           LIFF_CHANNEL_ID=2009442540,\
           SMS_PAYMENT_REMINDER_DISABLED=true,\
-          FB_BOT_DISABLED=true,\
+          FB_BOT_DISABLED=false,\
           FACEBOOK_APP_ID=2736219233418171,\
           LINE_FINANCE_BOT_DISABLED=true,\
-          LINE_SHOP_BOT_DISABLED=true,\
+          LINE_SHOP_BOT_DISABLED=false,\
           GOOGLE_CLOUD_PROJECT=${{ secrets.GCP_PROJECT_ID }},\
           VERTEX_LOCATION=us-central1,\
           VERTEX_EMBEDDING_MODEL=text-multilingual-embedding-002" \


### PR DESCRIPTION
## Why

Phase A + A.1 shipped (PR #1049/#1050/#1051) but AI never replied to customers — discovered in production debug session.

**Root cause:** 3 deploy-time kill switches block all bot pathways at message-router/webhook level:
- \`FB_BOT_DISABLED=true\` → message-router.service.ts:147 early-return
- \`LINE_SHOP_BOT_DISABLED=true\` → line-oa-chatbot.controller.ts:104 early-return
- \`LINE_FINANCE_BOT_DISABLED=true\` → chatbot-finance.service.ts:126 early-return

These were set deliberately on 2026-05-13 (commits 1cfb00e7 + cfb52e92) — \"owner paused all chat bots during FB App Review wait period\".

## What changes

Owner confirmed 2026-05-21:
1. FB App Review: partial approval — OK to enable FB bot
2. LINE Shop pause: no separate reason — OK to enable
3. LINE Finance: owner will enable independently — **keep paused**

\`\`\`diff
- FB_BOT_DISABLED=true
+ FB_BOT_DISABLED=false
- LINE_SHOP_BOT_DISABLED=true
+ LINE_SHOP_BOT_DISABLED=false
  LINE_FINANCE_BOT_DISABLED=true  # unchanged
\`\`\`

## Blast radius

After deploy, **3 pathways re-activate for FB + LINE Shop**:
1. ✅ Phase A AiAutoReplyService → SalesBot tool loop (what we want)
2. ⚠️ AfterHoursService — auto-reply outside business hours (PR #1047 removed the gate, so this auto-fires now)
3. ⚠️ FacebookDomainHandler welcome flow + reactions

Owner verified all 3 are acceptable.

## Pre-flight already done (Phase A)

- \`User.isSystemUser=true\` exists in prod ✅ (else capture_lead crashes)
- \`shop_bot_central_branch_id\` set ✅ (else shouldAutoReply fail-loud)
- AI Auto Mode toggle ON in \`/settings/ai-chat\` ✅ (badge visible per owner's screenshot)
- FACEBOOK + LINE_SHOP in \`ai.autoChannels\` ✅

## Test plan

- [ ] CI green
- [ ] After deploy: customer sends test message via FB Messenger or LINE Shop OA → AI replies within 5-10s
- [ ] Check production logs: \`[AiAutoReply] Replied to room ... with confidence=0.95\` should appear
- [ ] Verify badge in \`/inbox\` ConversationItem changes 🟢 AI → 🔴 ต้องตอบ on capture_lead

## Rollback

If AI replies misbehave:
\`\`\`bash
gcloud run services update bestchoice-api --region=asia-southeast1 \\
  --update-env-vars FB_BOT_DISABLED=true,LINE_SHOP_BOT_DISABLED=true
\`\`\`
(Or toggle \`ai.autoEnabled=false\` in \`/settings/ai-chat\` — softer kill, keeps welcome/after-hours but stops AI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)