### PR TITLE
fix(inbox): search now matches displayName + externalUserId (FB/TikTok/Web rooms)

### DIFF
--- a/apps/api/src/modules/chat-engine/services/room-manager.service.ts
+++ b/apps/api/src/modules/chat-engine/services/room-manager.service.ts
@@ -324,6 +324,11 @@ export class RoomManagerService {
         { customer: { name: { contains: params.search, mode: 'insensitive' } } },
         { customer: { phone: { contains: params.search } } },
         { lineUserId: { contains: params.search } },
+        // FB/TikTok/Web rooms often have no linked Customer yet — match on
+        // the platform-fetched displayName + the channel-specific user id
+        // (FB PSID, TikTok user id, web visitor id).
+        { displayName: { contains: params.search, mode: 'insensitive' } },
+        { externalUserId: { contains: params.search } },
       ];
     }
 


### PR DESCRIPTION
## Bug

Owner reported \"Nai Kongdach หายไปจากหน้า inbox\" when searching \"nai\" — but room exists in DB with displayName=\"Nai Kongdach\".

**Root cause:** \`listRooms\` search OR clause only checked:
- \`customer.name\` (needs Customer link)
- \`customer.phone\` (needs Customer link)
- \`lineUserId\` (LINE rooms only)

FB/TikTok/Web rooms that haven't yet been linked to a Customer (e.g., capture_lead never fired) → no clause matches → search returns empty even though room is visible in unfiltered list.

## Fix

5 lines — add 2 more OR clauses:
\`\`\`typescript
{ displayName: { contains: search, mode: 'insensitive' } },  // FB displayName, TikTok user name, etc.
{ externalUserId: { contains: search } },                    // FB PSID, TikTok user id, web visitor id
\`\`\`

## Test plan

- [x] 112/112 tests pass (chat-engine + staff-chat)
- [x] tsc clean (only pre-existing prisma-finance errors)
- [ ] After deploy: search \"nai\" in /inbox → Nai Kongdach FB room appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)