### PR TITLE
feat(ops): FB bot whitelist for staged testing (Nai Kongdach PSID only)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -318,10 +318,11 @@ jobs:
           API_BASE_URL=https://api.bestchoicephone.app,\
           LIFF_CHANNEL_ID=2009442540,\
           SMS_PAYMENT_REMINDER_DISABLED=true,\
-          FB_BOT_DISABLED=false,\
+          FB_BOT_DISABLED=true,\
+          FB_BOT_WHITELIST_PSIDS=8830107663706216,\
           FACEBOOK_APP_ID=2736219233418171,\
           LINE_FINANCE_BOT_DISABLED=true,\
-          LINE_SHOP_BOT_DISABLED=false,\
+          LINE_SHOP_BOT_DISABLED=true,\
           GOOGLE_CLOUD_PROJECT=${{ secrets.GCP_PROJECT_ID }},\
           VERTEX_LOCATION=us-central1,\
           VERTEX_EMBEDDING_MODEL=text-multilingual-embedding-002" \

--- a/apps/api/src/modules/chat-engine/services/message-router.service.ts
+++ b/apps/api/src/modules/chat-engine/services/message-router.service.ts
@@ -145,11 +145,18 @@ export class MessageRouterService {
 
     // 3a. Global FB kill switch — stop ALL bot pathways (welcome, AI, after-hours)
     // when FB_BOT_DISABLED=true. Inbound is still saved and staff are notified above.
+    // FB_BOT_WHITELIST_PSIDS (comma-separated) bypasses the kill switch for staged testing.
     if (
       message.channel === ChatChannel.FACEBOOK &&
       this.configService.get<string>('FB_BOT_DISABLED') === 'true'
     ) {
-      return;
+      const whitelist = (this.configService.get<string>('FB_BOT_WHITELIST_PSIDS') ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (!whitelist.includes(message.externalUserId ?? '')) {
+        return;
+      }
     }
 
     // 3b. Check handoff mode — if staff is handling, don't run AI


### PR DESCRIPTION
## Summary
- เพิ่ม env var `FB_BOT_WHITELIST_PSIDS` (comma-separated PSIDs) ใช้ bypass FB kill switch สำหรับการทดสอบเป็นขั้นๆ
- Stage 1: whitelist Nai Kongdach (PSID `8830107663706216`) เท่านั้น — FB user อื่นยังถูก block เหมือนเดิม
- แก้ yaml drift: `LINE_SHOP_BOT_DISABLED` ใน yaml เป็น `false` แต่ runtime เป็น `true` (gcloud override) — ปรับ yaml ให้ตรง

## เหตุผล
หลัง deploy PR #1052 (flip FB+LINE_SHOP kill switches), owner correct ว่าตั้งใจให้ AI ตอบกลับ **เฉพาะ Nai Kongdach** ก่อน ไม่ใช่ FB users ทั้งหมด → rolled back via gcloud → ตอนนี้ใช้ whitelist pattern แทน

## Code change
`message-router.service.ts:148-160`: เมื่อ `FB_BOT_DISABLED=true` + FB channel:
- เดิม: `return` ทันที (block ทุก PSID)
- ใหม่: check `FB_BOT_WHITELIST_PSIDS` — ถ้า `message.externalUserId` อยู่ใน list → ผ่าน; อื่น → `return`

## Stage roadmap
- **Stage 1 (this PR)**: whitelist Nai only → owner UAT
- **Stage 2 (later)**: flip `FB_BOT_DISABLED=false` → enable all FB customers
- **Stage 3 (later)**: flip `LINE_SHOP_BOT_DISABLED=false` → enable LINE Shop

## Test plan
- [ ] Deploy success (Cloud Run revision rolled out, /api/health 200)
- [ ] Runtime env: `FB_BOT_DISABLED=true`, `FB_BOT_WHITELIST_PSIDS=8830107663706216`, `LINE_SHOP_BOT_DISABLED=true`
- [ ] Owner sends msg from Nai Kongdach FB DM → AI replies (room handoffMode ต้อง toggle "ส่งกลับ Bot" ก่อน เพราะเดิม staff handoff อยู่)
- [ ] Owner sends msg from other FB customer → AI ไม่ตอบ (kill switch ยังทำงาน)

🤖 Generated with [Claude Code](https://claude.com/claude-code)