### PR TITLE
fix(chat-ai-draft): skip SHOP channels (root cause of Nai test silent handoff)

### DIFF
--- a/apps/api/src/modules/chat-ai-draft/chat-ai-draft.service.ts
+++ b/apps/api/src/modules/chat-ai-draft/chat-ai-draft.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, NotFoundException, Optional, Inject } from '@nestjs/common';
+import { ChatChannel } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ChatIntentRouterService } from '../chat-intent-router/chat-intent-router.service';
 import { SalesBotService } from '../sales-bot/sales-bot.service';
@@ -8,6 +9,16 @@ import {
   IChatGateway,
   CHAT_GATEWAY_TOKEN,
 } from '../chat-engine/interfaces/chat-gateway.interface';
+
+// Phase A: SHOP channels (LINE_SHOP, FACEBOOK, WEB) are handled by
+// AiAutoReplyService directly — they MUST NOT pass through this legacy
+// draft pipeline, whose catch-all else silently flips handoffMode=true
+// (reason 'router_handoff') and blocks all subsequent AI replies.
+const SHOP_CHANNELS: ReadonlySet<ChatChannel> = new Set([
+  ChatChannel.LINE_SHOP,
+  ChatChannel.FACEBOOK,
+  ChatChannel.WEB,
+]);
 
 @Injectable()
 export class ChatAiDraftService {
@@ -30,6 +41,12 @@ export class ChatAiDraftService {
       include: { room: true },
     });
     if (!inbound || !inbound.text) throw new NotFoundException('inbound message not found');
+    if (SHOP_CHANNELS.has(inbound.room.channel)) {
+      this.logger.debug(
+        `Room ${inbound.room.id} on SHOP channel ${inbound.room.channel} — Phase A AiAutoReplyService owns this; skipping legacy draft pipeline`,
+      );
+      return { draftMessageId: '' };
+    }
     if (inbound.room.aiPaused || inbound.room.handoffMode) {
       this.logger.log(`Room ${inbound.room.id} AI paused/handoff — skipping draft`);
       return { draftMessageId: '' };
@@ -122,6 +139,9 @@ export class ChatAiDraftService {
       inputTokens = r.inputTokens;
       outputTokens = r.outputTokens;
     } else {
+      this.logger.warn(
+        `[ChatAiDraft] router_handoff triggered for room ${inbound.room.id} channel=${inbound.room.channel} text="${inbound.text}"`,
+      );
       await this.prisma.chatRoom.update({
         where: { id: inbound.roomId },
         data: { handoffMode: true, handoffReason: 'router_handoff', handoffTaggedAt: new Date() },


### PR DESCRIPTION
## Bug
หลัง deploy PR #1054 (FB whitelist), ทดสอบกับ Nai Kongdach แต่ AI **ไม่ตอบ** หลัง message แรก

## Root cause (4-step debug mantra)

`ChatAiDraftService.generateDraft` ถูกเรียก **parallel** กับ Phase A AiAutoReply ทุก CUSTOMER inbound (fire-and-forget ที่ `room-manager.service.ts:263`).

สำหรับ intent ที่ไม่ใช่ sales/service (greeting, small talk):
- `chat-ai-draft.service.ts:117-122` (catch-all else) → set \`handoffMode=true\` reason \`router_handoff\`
- **ไม่มี log statement** → silent setter

ผลที่ตามมา: AiAutoReplyService.shouldAutoReply เช็ค handoffMode เป็นอันดับแรก → return false → block ทุกข้อความถัดไป

### Timeline (จาก Cloud Logging)
| Time | Event |
|---|---|
| 10:48 | Nai ส่ง "สวัสดีครัย" |
| 10:49:05 | `[AiAutoReply] Replied to room ...343f` (Bot ทักทาย) |
| 10:49:05.x | **ChatAiDraft router_handoff silently set handoffMode=true** |
| 10:49:07 | `[MessageRouter] Room ... in handoff mode — skipping AI` (Nai ข้อความถัดไป block) |
| 11:19:59 | Owner กด "ส่งกลับ Bot" → handoffMode=false |
| 11:20:13 | Nai "สสวัสดีครับ" → **silent re-handoff** |
| 11:21:26 | Nai ข้อความถัดไป → block อีก |

## Fix
SHOP channels (\`LINE_SHOP\`, \`FACEBOOK\`, \`WEB\`) skip legacy draft pipeline ที่หัวฟังก์ชัน — Phase A AiAutoReplyService เป็น AI เดียวของ rooms เหล่านั้น

\`LINE_FINANCE\` ยังผ่าน chat-ai-draft ตามเดิม (ไม่กระทบ Finance bot flow)

## Disproof breadcrumb
เพิ่ม \`logger.warn\` ที่ catch-all else ด้วย — ถ้า bug recur ใน LINE_FINANCE flow จะเห็นใน log ทันที

## Test plan
- [ ] Deploy success (Cloud Run revision rolled out)
- [ ] หลัง deploy: owner กด **ส่งกลับ Bot** ที่ห้อง Nai (handoff ติดอยู่จาก bug นี้)
- [ ] Nai ส่งข้อความใหม่ → AI ตอบ ✓
- [ ] Nai ส่งข้อความถัดไป → AI ตอบอีก ✓ (no silent handoff)
- [ ] FB user อื่นส่งข้อความ → ไม่มี AI ตอบ (whitelist ยังทำงาน)
- [ ] ไม่มี \`[ChatAiDraft] router_handoff triggered\` warn สำหรับ FB rooms ใน Cloud Logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)