### PR TITLE
feat(shop-ai): dual-mode Gemini provider + 2.5-flash default (Vertex unblocked)

### DIFF
--- a/apps/api/src/modules/sales-bot/providers/gemini.provider.spec.ts
+++ b/apps/api/src/modules/sales-bot/providers/gemini.provider.spec.ts
@@ -10,204 +10,264 @@ jest.mock('google-auth-library', () => ({
   })),
 }));
 
+function makeConfig(overrides: Record<string, string | undefined> = {}) {
+  const base: Record<string, string | undefined> = {
+    GEMINI_MODEL: 'gemini-2.0-flash',
+    VERTEX_LOCATION: 'us-central1',
+    ...overrides,
+  };
+  return {
+    provide: ConfigService,
+    useValue: { get: (k: string) => base[k] },
+  };
+}
+
+async function buildProvider(overrides: Record<string, string | undefined> = {}) {
+  const mod = await Test.createTestingModule({
+    providers: [GeminiProvider, makeConfig(overrides)],
+  }).compile();
+  return mod.get(GeminiProvider);
+}
+
+function fakeFetchResponse(spy: jest.SpyInstance, body: object, status = 200) {
+  spy.mockResolvedValue(
+    new Response(JSON.stringify(body), { status }) as unknown as Response,
+  );
+}
+
 describe('GeminiProvider', () => {
-  let provider: GeminiProvider;
   let fetchSpy: jest.SpyInstance;
 
-  beforeEach(async () => {
-    const mod = await Test.createTestingModule({
-      providers: [
-        GeminiProvider,
-        {
-          provide: ConfigService,
-          useValue: {
-            get: (key: string) => {
-              if (key === 'GOOGLE_CLOUD_PROJECT') return 'test-project';
-              if (key === 'VERTEX_LOCATION') return 'us-central1';
-              if (key === 'VERTEX_GEMINI_MODEL') return 'gemini-2.0-flash-001';
-              return undefined;
-            },
-          },
-        },
-      ],
-    }).compile();
-    provider = mod.get(GeminiProvider);
+  beforeEach(() => {
     fetchSpy = jest.spyOn(global, 'fetch');
   });
-
   afterEach(() => {
     fetchSpy.mockRestore();
   });
 
-  function fakeFetchResponse(body: object) {
-    fetchSpy.mockResolvedValue(
-      new Response(JSON.stringify(body), { status: 200 }) as unknown as Response,
-    );
-  }
-
-  it('parses text-only Vertex response → LlmChatResponse', async () => {
-    fakeFetchResponse({
-      candidates: [
-        {
-          content: { parts: [{ text: 'สวัสดีค่ะ' }] },
-          finishReason: 'STOP',
-        },
-      ],
-      usageMetadata: { promptTokenCount: 50, candidatesTokenCount: 12 },
+  describe('mode detection', () => {
+    it('uses AI Studio when GEMINI_API_KEY set (regardless of GOOGLE_CLOUD_PROJECT)', async () => {
+      const p = await buildProvider({
+        GEMINI_API_KEY: 'ai-studio-key',
+        GOOGLE_CLOUD_PROJECT: 'some-project',
+      });
+      expect(p.isReady()).toBe(true);
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'hi' }] } }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 1 },
+      });
+      await p.chat({
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const [url] = fetchSpy.mock.calls[0];
+      expect(url).toContain('generativelanguage.googleapis.com');
+      expect(url).toContain('key=ai-studio-key');
     });
 
-    const resp = await provider.chat({
-      systemPrompt: 'persona',
-      messages: [{ role: 'user', content: 'hello' }],
+    it('uses Vertex when GOOGLE_CLOUD_PROJECT set and no GEMINI_API_KEY', async () => {
+      const p = await buildProvider({ GOOGLE_CLOUD_PROJECT: 'bestchoice-prod' });
+      expect(p.isReady()).toBe(true);
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'hi' }] } }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 1 },
+      });
+      await p.chat({
+        systemPrompt: 'sys',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toContain('us-central1-aiplatform.googleapis.com');
+      expect(url).toContain('bestchoice-prod');
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        'Bearer fake-token',
+      );
     });
 
-    expect(resp.text).toBe('สวัสดีค่ะ');
-    expect(resp.toolCalls).toHaveLength(0);
-    expect(resp.inputTokens).toBe(50);
-    expect(resp.outputTokens).toBe(12);
-    expect(resp.modelName).toBe('gemini-2.0-flash-001');
+    it('isReady=false when neither env set', async () => {
+      const p = await buildProvider({});
+      expect(p.isReady()).toBe(false);
+    });
+
+    it('throws ServiceUnavailable when chat called without config', async () => {
+      const p = await buildProvider({});
+      await expect(
+        p.chat({ systemPrompt: 'x', messages: [{ role: 'user', content: 'hi' }] }),
+      ).rejects.toThrow(/not configured/);
+    });
   });
 
-  it('parses functionCall part → toolCalls with synthesized id', async () => {
-    fakeFetchResponse({
-      candidates: [
-        {
-          content: {
-            parts: [
-              {
-                functionCall: {
-                  name: 'search_products',
-                  args: { query: 'iPhone 15' },
+  describe('chat — AI Studio mode', () => {
+    let p: GeminiProvider;
+    beforeEach(async () => {
+      p = await buildProvider({ GEMINI_API_KEY: 'test-key' });
+    });
+
+    it('parses text response', async () => {
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'สวัสดีค่ะ' }] } }],
+        usageMetadata: { promptTokenCount: 50, candidatesTokenCount: 12 },
+      });
+      const resp = await p.chat({
+        systemPrompt: 'persona',
+        messages: [{ role: 'user', content: 'hello' }],
+      });
+      expect(resp.text).toBe('สวัสดีค่ะ');
+      expect(resp.toolCalls).toHaveLength(0);
+      expect(resp.inputTokens).toBe(50);
+      expect(resp.outputTokens).toBe(12);
+      expect(resp.modelName).toBe('gemini-2.0-flash (aistudio)');
+    });
+
+    it('does NOT send Authorization header (uses key param)', async () => {
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 1 },
+      });
+      await p.chat({
+        systemPrompt: 'x',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    });
+  });
+
+  describe('chat — Vertex mode', () => {
+    let p: GeminiProvider;
+    beforeEach(async () => {
+      p = await buildProvider({ GOOGLE_CLOUD_PROJECT: 'test-project' });
+    });
+
+    it('parses functionCall part → toolCalls with synthesized id', async () => {
+      fakeFetchResponse(fetchSpy, {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'search_products',
+                    args: { query: 'iPhone 15' },
+                  },
                 },
+              ],
+            },
+          },
+        ],
+        usageMetadata: { promptTokenCount: 80, candidatesTokenCount: 5 },
+      });
+      const resp = await p.chat({
+        systemPrompt: 'persona',
+        messages: [{ role: 'user', content: 'หา iPhone 15' }],
+        tools: [
+          {
+            name: 'search_products',
+            description: 'Search catalog',
+            inputSchema: {
+              type: 'object',
+              properties: { query: { type: 'string' } },
+              required: ['query'],
+            },
+          },
+        ],
+      });
+      expect(resp.text).toBe('');
+      expect(resp.toolCalls).toHaveLength(1);
+      expect(resp.toolCalls[0].name).toBe('search_products');
+      expect(resp.toolCalls[0].input).toEqual({ query: 'iPhone 15' });
+      expect(resp.toolCalls[0].id).toMatch(/^fn_\d+_search_products$/);
+      expect(resp.modelName).toBe('gemini-2.0-flash (vertex)');
+    });
+
+    it('sends system instruction + tools as functionDeclarations + sanitizes schema', async () => {
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 1 },
+      });
+      await p.chat({
+        systemPrompt: 'YOU ARE A SALES BOT',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [
+          {
+            name: 't1',
+            description: 'desc',
+            inputSchema: {
+              type: 'object',
+              properties: { q: { type: 'string' } },
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              additionalProperties: false,
+            },
+          },
+        ],
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.systemInstruction.parts[0].text).toBe('YOU ARE A SALES BOT');
+      expect(body.tools[0].functionDeclarations[0].name).toBe('t1');
+      expect(body.tools[0].functionDeclarations[0].parameters).not.toHaveProperty(
+        '$schema',
+      );
+      expect(body.tools[0].functionDeclarations[0].parameters).not.toHaveProperty(
+        'additionalProperties',
+      );
+      expect(body.tools[0].functionDeclarations[0].parameters.properties.q.type).toBe(
+        'string',
+      );
+    });
+
+    it('round-trips tool-use turn → tool result correctly', async () => {
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'พบ iPhone 15 ราคา 32,900' }] } }],
+        usageMetadata: { promptTokenCount: 200, candidatesTokenCount: 25 },
+      });
+      await p.chat({
+        systemPrompt: 'persona',
+        messages: [
+          { role: 'user', content: 'iPhone 15 กี่บาท' },
+          {
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              {
+                id: 'fn_0_search_products',
+                name: 'search_products',
+                input: { query: 'iPhone 15' },
               },
             ],
           },
-        },
-      ],
-      usageMetadata: { promptTokenCount: 80, candidatesTokenCount: 5 },
-    });
-
-    const resp = await provider.chat({
-      systemPrompt: 'persona',
-      messages: [{ role: 'user', content: 'หา iPhone 15' }],
-      tools: [
-        {
-          name: 'search_products',
-          description: 'Search catalog',
-          inputSchema: {
-            type: 'object',
-            properties: { query: { type: 'string' } },
-            required: ['query'],
+          {
+            role: 'tool',
+            toolCallId: 'fn_0_search_products',
+            content: '{"products":[{"name":"iPhone 15","priceThb":32900}]}',
           },
-        },
-      ],
+        ],
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.contents).toHaveLength(3);
+      expect(body.contents[0]).toEqual({
+        role: 'user',
+        parts: [{ text: 'iPhone 15 กี่บาท' }],
+      });
+      expect(body.contents[1].role).toBe('model');
+      expect(body.contents[1].parts[0].functionCall.name).toBe('search_products');
+      expect(body.contents[2].role).toBe('user');
+      expect(body.contents[2].parts[0].functionResponse.name).toBe(
+        'search_products',
+      );
+      expect(
+        body.contents[2].parts[0].functionResponse.response.products[0].name,
+      ).toBe('iPhone 15');
     });
 
-    expect(resp.text).toBe('');
-    expect(resp.toolCalls).toHaveLength(1);
-    expect(resp.toolCalls[0].name).toBe('search_products');
-    expect(resp.toolCalls[0].input).toEqual({ query: 'iPhone 15' });
-    expect(resp.toolCalls[0].id).toMatch(/^fn_\d+_search_products$/);
-  });
-
-  it('sends system instruction + tools as functionDeclarations', async () => {
-    fakeFetchResponse({
-      candidates: [{ content: { parts: [{ text: 'ok' }] } }],
-      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 1 },
+    it('throws ServiceUnavailable when Vertex returns non-2xx', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response('quota exceeded', { status: 429 }) as unknown as Response,
+      );
+      await expect(
+        p.chat({ systemPrompt: 'x', messages: [{ role: 'user', content: 'hi' }] }),
+      ).rejects.toThrow(/Gemini vertex failed: 429/);
     });
-
-    await provider.chat({
-      systemPrompt: 'YOU ARE A SALES BOT',
-      messages: [{ role: 'user', content: 'hi' }],
-      tools: [
-        {
-          name: 't1',
-          description: 'desc',
-          inputSchema: {
-            type: 'object',
-            properties: { q: { type: 'string' } },
-            $schema: 'http://json-schema.org/draft-07/schema#',
-            additionalProperties: false,
-          },
-        },
-      ],
-    });
-
-    const [, init] = fetchSpy.mock.calls[0];
-    const body = JSON.parse(init.body as string);
-    expect(body.systemInstruction.parts[0].text).toBe('YOU ARE A SALES BOT');
-    expect(body.tools[0].functionDeclarations[0].name).toBe('t1');
-    // Schema sanitization: drops $schema + additionalProperties
-    expect(body.tools[0].functionDeclarations[0].parameters).not.toHaveProperty('$schema');
-    expect(body.tools[0].functionDeclarations[0].parameters).not.toHaveProperty(
-      'additionalProperties',
-    );
-    expect(body.tools[0].functionDeclarations[0].parameters.properties.q.type).toBe(
-      'string',
-    );
-  });
-
-  it('round-trips tool-use turn → tool result correctly', async () => {
-    fakeFetchResponse({
-      candidates: [{ content: { parts: [{ text: 'พบ iPhone 15 ราคา 32,900' }] } }],
-      usageMetadata: { promptTokenCount: 200, candidatesTokenCount: 25 },
-    });
-
-    await provider.chat({
-      systemPrompt: 'persona',
-      messages: [
-        { role: 'user', content: 'iPhone 15 กี่บาท' },
-        {
-          role: 'assistant',
-          content: '',
-          toolCalls: [
-            { id: 'fn_0_search_products', name: 'search_products', input: { query: 'iPhone 15' } },
-          ],
-        },
-        {
-          role: 'tool',
-          toolCallId: 'fn_0_search_products',
-          content: '{"products":[{"name":"iPhone 15","priceThb":32900}]}',
-        },
-      ],
-    });
-
-    const [, init] = fetchSpy.mock.calls[0];
-    const body = JSON.parse(init.body as string);
-
-    expect(body.contents).toHaveLength(3);
-    expect(body.contents[0]).toEqual({
-      role: 'user',
-      parts: [{ text: 'iPhone 15 กี่บาท' }],
-    });
-    expect(body.contents[1].role).toBe('model');
-    expect(body.contents[1].parts[0].functionCall.name).toBe('search_products');
-    expect(body.contents[2].role).toBe('user');
-    expect(body.contents[2].parts[0].functionResponse.name).toBe('search_products');
-    expect(body.contents[2].parts[0].functionResponse.response.products[0].name).toBe(
-      'iPhone 15',
-    );
-  });
-
-  it('throws ServiceUnavailable when project not configured', async () => {
-    const mod = await Test.createTestingModule({
-      providers: [
-        GeminiProvider,
-        { provide: ConfigService, useValue: { get: () => undefined } },
-      ],
-    }).compile();
-    const p = mod.get(GeminiProvider);
-    await expect(
-      p.chat({ systemPrompt: 'x', messages: [{ role: 'user', content: 'hi' }] }),
-    ).rejects.toThrow(/GOOGLE_CLOUD_PROJECT/);
-  });
-
-  it('throws ServiceUnavailable when Vertex returns non-2xx', async () => {
-    fetchSpy.mockResolvedValue(
-      new Response('quota exceeded', { status: 429 }) as unknown as Response,
-    );
-    await expect(
-      provider.chat({ systemPrompt: 'x', messages: [{ role: 'user', content: 'hi' }] }),
-    ).rejects.toThrow(/Vertex Gemini failed: 429/);
   });
 });

--- a/apps/api/src/modules/sales-bot/providers/gemini.provider.spec.ts
+++ b/apps/api/src/modules/sales-bot/providers/gemini.provider.spec.ts
@@ -12,7 +12,7 @@ jest.mock('google-auth-library', () => ({
 
 function makeConfig(overrides: Record<string, string | undefined> = {}) {
   const base: Record<string, string | undefined> = {
-    GEMINI_MODEL: 'gemini-2.0-flash',
+    GEMINI_MODEL: 'gemini-2.5-flash',
     VERTEX_LOCATION: 'us-central1',
     ...overrides,
   };
@@ -116,7 +116,7 @@ describe('GeminiProvider', () => {
       expect(resp.toolCalls).toHaveLength(0);
       expect(resp.inputTokens).toBe(50);
       expect(resp.outputTokens).toBe(12);
-      expect(resp.modelName).toBe('gemini-2.0-flash (aistudio)');
+      expect(resp.modelName).toBe('gemini-2.5-flash (aistudio)');
     });
 
     it('does NOT send Authorization header (uses key param)', async () => {
@@ -177,7 +177,7 @@ describe('GeminiProvider', () => {
       expect(resp.toolCalls[0].name).toBe('search_products');
       expect(resp.toolCalls[0].input).toEqual({ query: 'iPhone 15' });
       expect(resp.toolCalls[0].id).toMatch(/^fn_\d+_search_products$/);
-      expect(resp.modelName).toBe('gemini-2.0-flash (vertex)');
+      expect(resp.modelName).toBe('gemini-2.5-flash (vertex)');
     });
 
     it('sends system instruction + tools as functionDeclarations + sanitizes schema', async () => {
@@ -268,6 +268,44 @@ describe('GeminiProvider', () => {
       await expect(
         p.chat({ systemPrompt: 'x', messages: [{ role: 'user', content: 'hi' }] }),
       ).rejects.toThrow(/Gemini vertex failed: 429/);
+    });
+  });
+
+  describe('thinkingConfig (2.5-series only)', () => {
+    it('sets thinkingBudget=0 on gemini-2.5-flash to skip hidden reasoning', async () => {
+      const p = await buildProvider({
+        GOOGLE_CLOUD_PROJECT: 'bestchoice-prod',
+        GEMINI_MODEL: 'gemini-2.5-flash',
+      });
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 1 },
+      });
+      await p.chat({
+        systemPrompt: 'x',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 0 });
+    });
+
+    it('does NOT set thinkingConfig on pre-2.5 models', async () => {
+      const p = await buildProvider({
+        GOOGLE_CLOUD_PROJECT: 'bestchoice-prod',
+        GEMINI_MODEL: 'gemini-2.0-flash',
+      });
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 1 },
+      });
+      await p.chat({
+        systemPrompt: 'x',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.generationConfig.thinkingConfig).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/modules/sales-bot/providers/gemini.provider.ts
+++ b/apps/api/src/modules/sales-bot/providers/gemini.provider.ts
@@ -15,7 +15,7 @@ import {
   LlmToolDefinition,
 } from './llm-provider.interface';
 
-const DEFAULT_MODEL = 'gemini-2.0-flash';
+const DEFAULT_MODEL = 'gemini-2.5-flash';
 const DEFAULT_LOCATION = 'us-central1';
 const VERTEX_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const DEFAULT_MAX_TOKENS = 1024;
@@ -178,13 +178,26 @@ export class GeminiProvider implements ILlmProvider {
 
   private buildRequestBody(req: LlmChatRequest): Record<string, unknown> {
     const contents = this.projectMessages(req.messages);
+    const generationConfig: Record<string, unknown> = {
+      maxOutputTokens: req.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
+      temperature: 0.7,
+    };
+
+    // Gemini 2.5+ defaults to "thinking mode" — model consumes hundreds of
+    // hidden reasoning tokens before producing user-visible output. For a
+    // sales chat (latency-sensitive, short replies) that's pure overhead:
+    // it makes greetings hit MAX_TOKENS truncation and inflates cost ~8x.
+    // Verified empirically on 2026-05-21: same Thai greeting prompt used
+    // 190 thoughtsTokens at default vs 0 with thinkingBudget=0, output
+    // identical-quality and complete instead of truncated.
+    if (this.model.startsWith('gemini-2.5')) {
+      generationConfig.thinkingConfig = { thinkingBudget: 0 };
+    }
+
     const body: Record<string, unknown> = {
       systemInstruction: { parts: [{ text: req.systemPrompt }] },
       contents,
-      generationConfig: {
-        maxOutputTokens: req.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
-        temperature: 0.7,
-      },
+      generationConfig,
     };
 
     if (req.tools && req.tools.length > 0) {

--- a/apps/api/src/modules/sales-bot/providers/gemini.provider.ts
+++ b/apps/api/src/modules/sales-bot/providers/gemini.provider.ts
@@ -15,12 +15,12 @@ import {
   LlmToolDefinition,
 } from './llm-provider.interface';
 
-const DEFAULT_MODEL = 'gemini-2.0-flash-001';
+const DEFAULT_MODEL = 'gemini-2.0-flash';
 const DEFAULT_LOCATION = 'us-central1';
 const VERTEX_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const DEFAULT_MAX_TOKENS = 1024;
 
-interface VertexGeminiResponse {
+interface GeminiResponse {
   candidates?: {
     content?: {
       parts?: Array<
@@ -37,91 +37,119 @@ interface VertexGeminiResponse {
   };
 }
 
+type Mode = 'aistudio' | 'vertex';
+
 /**
- * Wraps Vertex AI's Gemini generateContent endpoint behind ILlmProvider.
+ * Wraps Google's Gemini chat API behind ILlmProvider.
  *
- * Auth: reuses Application Default Credentials (same as EmbeddingService).
- * Tool calling: converts JSON Schema → OpenAPI subset (Gemini's `parameters`).
+ * Two transport paths supported, selected at startup:
+ *
+ * 1. **AI Studio** (`mode='aistudio'`) — used when `GEMINI_API_KEY` env is set.
+ *    Hits `generativelanguage.googleapis.com` with API key auth.
+ *    Faster to set up: paid tier API key (https://aistudio.google.com/app/apikey),
+ *    no GCP project approval needed. **Paid tier opts out of data training**
+ *    (free tier does train, so we explicitly require paid).
+ *
+ * 2. **Vertex AI** (`mode='vertex'`) — used when GEMINI_API_KEY absent but
+ *    `GOOGLE_CLOUD_PROJECT` is set. Hits
+ *    `${LOCATION}-aiplatform.googleapis.com` with ADC (GoogleAuth).
+ *    Requires owner to accept Gemini terms in GCP console first.
+ *    Better long-term: GCP-native IAM, single billing, enterprise compliance.
+ *
+ * If neither env present → isReady() returns false → registry falls back to Claude.
+ *
+ * Tool calling: converts JSON Schema → OpenAPI subset (same wire format for both).
  * Function-call id: Gemini doesn't return one — we synthesize `fn_<i>_<name>`
- * so SalesBotService can correlate tool result back to the call. The synthetic
- * id round-trips correctly because both halves of the loop live in
- * SalesBotService memory — Gemini itself never sees the id field.
+ * so SalesBotService can correlate tool result back to the call.
  */
 @Injectable()
 export class GeminiProvider implements ILlmProvider {
   readonly providerName: LlmProviderName = 'gemini';
   private readonly logger = new Logger(GeminiProvider.name);
+  private readonly mode: Mode | null;
+  private readonly model: string;
+  // Vertex-only fields
   private readonly auth: GoogleAuth;
   private readonly project: string | undefined;
   private readonly location: string;
-  private readonly model: string;
+  // AI Studio-only fields
+  private readonly apiKey: string | undefined;
 
   constructor(private config: ConfigService) {
+    this.apiKey = this.config.get<string>('GEMINI_API_KEY');
     this.project =
       this.config.get<string>('GOOGLE_CLOUD_PROJECT') ??
       this.config.get<string>('GCP_PROJECT_ID');
     this.location = this.config.get<string>('VERTEX_LOCATION') ?? DEFAULT_LOCATION;
-    this.model = this.config.get<string>('VERTEX_GEMINI_MODEL') ?? DEFAULT_MODEL;
+    this.model = this.config.get<string>('GEMINI_MODEL') ?? DEFAULT_MODEL;
     this.auth = new GoogleAuth({ scopes: [VERTEX_SCOPE] });
 
-    if (!this.project) {
+    if (this.apiKey) {
+      this.mode = 'aistudio';
+      this.logger.log(`GeminiProvider: AI Studio mode (model=${this.model})`);
+    } else if (this.project) {
+      this.mode = 'vertex';
+      this.logger.log(
+        `GeminiProvider: Vertex mode (project=${this.project}, location=${this.location}, model=${this.model})`,
+      );
+    } else {
+      this.mode = null;
       this.logger.warn(
-        'GOOGLE_CLOUD_PROJECT not set — GeminiProvider will fail at call time. Set env var or run `gcloud auth application-default login`.',
+        'GeminiProvider: neither GEMINI_API_KEY nor GOOGLE_CLOUD_PROJECT set — provider not ready, registry will fall back to Claude',
       );
     }
   }
 
   isReady(): boolean {
-    return Boolean(this.project);
+    return this.mode !== null;
   }
 
   async chat(req: LlmChatRequest): Promise<LlmChatResponse> {
-    if (!this.project) {
+    if (this.mode === null) {
       throw new ServiceUnavailableException(
-        'GOOGLE_CLOUD_PROJECT ไม่ได้ตั้งค่า — GeminiProvider ใช้ไม่ได้',
+        'GeminiProvider not configured — set GEMINI_API_KEY (AI Studio) or GOOGLE_CLOUD_PROJECT (Vertex)',
       );
     }
 
-    const endpoint = `https://${this.location}-aiplatform.googleapis.com/v1/projects/${this.project}/locations/${this.location}/publishers/google/models/${this.model}:generateContent`;
+    const body = this.buildRequestBody(req);
 
-    const client = await this.auth.getClient();
-    const accessToken = (await client.getAccessToken()).token;
-    if (!accessToken) {
-      throw new ServiceUnavailableException(
-        'ไม่สามารถขอ access token ของ Google Cloud ได้ — ตรวจสอบ ADC',
-      );
-    }
+    const endpoint =
+      this.mode === 'aistudio'
+        ? `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent?key=${this.apiKey}`
+        : `https://${this.location}-aiplatform.googleapis.com/v1/projects/${this.project}/locations/${this.location}/publishers/google/models/${this.model}:generateContent`;
 
-    const contents = this.projectMessages(req.messages);
-    const body: Record<string, unknown> = {
-      systemInstruction: { parts: [{ text: req.systemPrompt }] },
-      contents,
-      generationConfig: {
-        maxOutputTokens: req.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
-        temperature: 0.7,
-      },
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
     };
 
-    if (req.tools && req.tools.length > 0) {
-      body.tools = [{ functionDeclarations: req.tools.map((t) => this.toVertexTool(t)) }];
+    if (this.mode === 'vertex') {
+      const client = await this.auth.getClient();
+      const accessToken = (await client.getAccessToken()).token;
+      if (!accessToken) {
+        throw new ServiceUnavailableException(
+          'ไม่สามารถขอ access token ของ Google Cloud ได้ — ตรวจสอบ ADC',
+        );
+      }
+      headers.Authorization = `Bearer ${accessToken}`;
     }
 
     const res = await fetch(endpoint, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(body),
     });
 
     if (!res.ok) {
       const errBody = await res.text().catch(() => '');
-      this.logger.error(`Vertex Gemini failed (${res.status}): ${errBody}`);
-      throw new ServiceUnavailableException(`Vertex Gemini failed: ${res.status}`);
+      this.logger.error(
+        `Gemini ${this.mode} failed (${res.status}): ${errBody.slice(0, 300)}`,
+      );
+      throw new ServiceUnavailableException(
+        `Gemini ${this.mode} failed: ${res.status}`,
+      );
     }
 
-    const json = (await res.json()) as VertexGeminiResponse;
+    const json = (await res.json()) as GeminiResponse;
     const candidate = json.candidates?.[0];
     const parts = candidate?.content?.parts ?? [];
 
@@ -144,14 +172,34 @@ export class GeminiProvider implements ILlmProvider {
       toolCalls,
       inputTokens: json.usageMetadata?.promptTokenCount ?? 0,
       outputTokens: json.usageMetadata?.candidatesTokenCount ?? 0,
-      modelName: this.model,
+      modelName: `${this.model} (${this.mode})`,
     };
   }
 
+  private buildRequestBody(req: LlmChatRequest): Record<string, unknown> {
+    const contents = this.projectMessages(req.messages);
+    const body: Record<string, unknown> = {
+      systemInstruction: { parts: [{ text: req.systemPrompt }] },
+      contents,
+      generationConfig: {
+        maxOutputTokens: req.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
+        temperature: 0.7,
+      },
+    };
+
+    if (req.tools && req.tools.length > 0) {
+      body.tools = [
+        { functionDeclarations: req.tools.map((t) => this.toGeminiTool(t)) },
+      ];
+    }
+
+    return body;
+  }
+
   /**
-   * Project provider-agnostic LlmChatMessage[] to Vertex `contents` array.
+   * Project provider-agnostic LlmChatMessage[] to Gemini `contents` array.
    *
-   * Vertex maps:
+   * Wire format is identical between Vertex and AI Studio for chat content:
    * - user → { role: 'user', parts: [{ text }] }
    * - assistant text → { role: 'model', parts: [{ text }] }
    * - assistant tool_calls → { role: 'model', parts: [{ functionCall }, ...] }
@@ -164,10 +212,6 @@ export class GeminiProvider implements ILlmProvider {
    */
   private projectMessages(messages: LlmChatMessage[]): unknown[] {
     const out: unknown[] = [];
-    /**
-     * Map from synthesized toolCallId → original tool name. SalesBotService
-     * accumulates tool messages by id, but Gemini wants name. We track here.
-     */
     const idToName = new Map<string, string>();
 
     for (const msg of messages) {
@@ -225,14 +269,7 @@ export class GeminiProvider implements ILlmProvider {
     }
   }
 
-  /**
-   * Convert tool definition from neutral JSON Schema → Vertex FunctionDeclaration.
-   *
-   * Vertex's `parameters` accepts OpenAPI schema subset. Most JSON Schema
-   * features map 1:1. Strip unsupported keys (e.g. $schema, definitions) to
-   * avoid 400 INVALID_ARGUMENT.
-   */
-  private toVertexTool(t: LlmToolDefinition): {
+  private toGeminiTool(t: LlmToolDefinition): {
     name: string;
     description: string;
     parameters: Record<string, unknown>;
@@ -244,6 +281,10 @@ export class GeminiProvider implements ILlmProvider {
     };
   }
 
+  /**
+   * Sanitize JSON Schema → Gemini-accepted OpenAPI subset.
+   * Both Vertex and AI Studio accept the same schema shape.
+   */
   private sanitizeSchema(schema: Record<string, unknown>): Record<string, unknown> {
     const out: Record<string, unknown> = {};
     const allowed = new Set([


### PR DESCRIPTION
## Summary

- Adds AI Studio path to `GeminiProvider` as a runtime-selected alternative to Vertex. Auto-detection at startup: `GEMINI_API_KEY` set → AI Studio mode, else `GOOGLE_CLOUD_PROJECT` → Vertex mode, else `isReady=false` → registry falls back to Claude.
- Bumps default model `gemini-2.0-flash` → `gemini-2.5-flash` because Vertex publisher catalog deprecated 2.0/1.5 (verified by direct probe on `bestchoice-prod` 2026-05-21 — only `gemini-2.5-flash` and `gemini-2.5-pro` return 200; everything older 404s).
- Disables Gemini 2.5 thinking mode (`thinkingConfig.thinkingBudget=0`) for sales chat — same Thai greeting prompt uses 207 vs 24 tokens with/without thinking, and the with-thinking version actually hits MAX_TOKENS truncation. Gated on `model.startsWith('gemini-2.5')` so a future pin to a non-2.5 model leaves the budget alone.

## Why now

Previous session (PR #1056) shipped the LLMProvider abstraction with Vertex-only Gemini and Claude as fallback. Two blockers prevented the live flip:

1. Vertex Gemini 404'd in `bestchoice-prod` — looked like "owner needs to accept ToS in GCP console" but was actually "wrong model name in code" (2.0-flash is deprecated on the publisher catalog).
2. AI Studio was floated as a quicker alternative for the same reason.

This PR closes both: AI Studio path now exists *and* the Vertex 404 root cause is fixed by switching default to a current model.

## Production state after merge

- No Cloud Run env-var changes required for Vertex path (`GOOGLE_CLOUD_PROJECT=bestchoice-prod` already set).
- To flip live: insert `SystemConfig` row `shop_bot_llm_provider='gemini'` → 60s cache → SalesBot starts routing to Gemini. No redeploy.
- To revert: flip back to `'claude'` (or delete the row).
- Optional: set `GEMINI_MODEL=gemini-2.5-pro` env to swap to the higher-quality variant; reasoning model price is higher.

## Test plan

- [x] 12/12 `gemini.provider.spec.ts` pass (includes 2 new assertions for thinkingConfig + 1 negative test for pre-2.5 models)
- [x] 37/37 `sales-bot` module pass (`npx jest --testPathPattern=sales-bot`)
- [ ] After merge: smoke test via `/settings/ai-chat` → 🧪 ส่งข้อความทดสอบไปยัง LINE (verify Gemini reply arrives at `shop_bot_test_user_id`)
- [ ] Then: Nai re-test on FB whitelist (`FB_BOT_WHITELIST_PSIDS=8830107663706216`) — owner judges Thai quality vs the persona-refined Claude baseline already in prod
- [ ] Optional: `npm run shop-ai:bench` to regenerate side-by-side HTML report with the corrected Gemini wiring

## /scrutinize reminders (carried from session handoff doc)

- Before declaring Gemini "the answer", run Nai test on Claude+persona (already in prod as of PR #1056) — the anti-translation rules in the persona may already be sufficient and Gemini swap may be unnecessary.
- AI Studio paid tier opts out of training; free tier trains. If using AI Studio path, owner must verify the key is on the paid plan (PDPA).
- Vertex path uses GCP service-account IAM — no key rotation needed; Cloud Logging audits every Gemini call (PDPA ม.28 cross-border evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)