### PR TITLE
feat(shop-ai): UI toggle for SalesBot LLM provider in /settings/ai-chat

### DIFF
--- a/apps/api/src/modules/sales-bot/providers/llm-provider.registry.spec.ts
+++ b/apps/api/src/modules/sales-bot/providers/llm-provider.registry.spec.ts
@@ -76,6 +76,22 @@ describe('LlmProviderRegistry', () => {
     expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(1);
   });
 
+  it('invalidateCache() forces next call to re-read SystemConfig', async () => {
+    const { registry, prisma } = await build('gemini');
+    await registry.getActive();
+    registry.invalidateCache();
+    await registry.getActive();
+    expect(prisma.systemConfig.findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidateCache() is idempotent — safe to call when cache empty', async () => {
+    const { registry } = await build('gemini');
+    expect(() => registry.invalidateCache()).not.toThrow();
+    expect(() => registry.invalidateCache()).not.toThrow();
+    const p = await registry.getActive();
+    expect(p.providerName).toBe('gemini');
+  });
+
   it('falls back to claude when DB errors', async () => {
     const prisma = {
       systemConfig: {

--- a/apps/api/src/modules/sales-bot/providers/llm-provider.registry.ts
+++ b/apps/api/src/modules/sales-bot/providers/llm-provider.registry.ts
@@ -34,6 +34,17 @@ export class LlmProviderRegistry {
     return this.claude;
   }
 
+  /**
+   * Force the next `getActive()` call to re-read SystemConfig. Called by
+   * `AiAutoReplyService.updateSettings` when the owner flips
+   * `shop_bot_llm_provider` from the UI so the change takes effect immediately
+   * instead of after the 60-second TTL. Idempotent — clearing an already-empty
+   * cache is a no-op.
+   */
+  invalidateCache(): void {
+    this.cached = null;
+  }
+
   private async resolveName(): Promise<LlmProviderName> {
     if (this.cached && Date.now() - this.cached.readAt < CACHE_TTL_MS) {
       return this.cached.name;

--- a/apps/api/src/modules/staff-chat/dto/ai-settings.dto.ts
+++ b/apps/api/src/modules/staff-chat/dto/ai-settings.dto.ts
@@ -1,4 +1,7 @@
-import { IsBoolean, IsNumber, IsArray, IsOptional, IsString, Min, Max } from 'class-validator';
+import { IsBoolean, IsNumber, IsArray, IsIn, IsOptional, IsString, Min, Max } from 'class-validator';
+
+export const LLM_PROVIDERS = ['claude', 'gemini'] as const;
+export type LlmProviderChoice = (typeof LLM_PROVIDERS)[number];
 
 export class UpdateAiSettingsDto {
   @IsBoolean()
@@ -32,6 +35,10 @@ export class UpdateAiSettingsDto {
   @IsOptional()
   @IsString()
   shopBotTestUserId?: string;
+
+  @IsOptional()
+  @IsIn(LLM_PROVIDERS, { message: 'llmProvider ต้องเป็น "claude" หรือ "gemini" เท่านั้น' })
+  llmProvider?: LlmProviderChoice;
 }
 
 export interface AiAutoSettings {
@@ -42,4 +49,5 @@ export interface AiAutoSettings {
   shopBotCentralBranchId: string | null;
   shopBotPromptpayId: string | null;
   shopBotTestUserId: string | null;
+  llmProvider: LlmProviderChoice;
 }

--- a/apps/api/src/modules/staff-chat/services/__tests__/shop-ai-flow.unit.spec.ts
+++ b/apps/api/src/modules/staff-chat/services/__tests__/shop-ai-flow.unit.spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { AiAutoReplyService } from '../ai-auto-reply.service';
 import { AiSuggestService } from '../ai-suggest.service';
 import { SalesBotService } from '../../../sales-bot/sales-bot.service';
+import { LlmProviderRegistry } from '../../../sales-bot/providers/llm-provider.registry';
 import { PrismaService } from '../../../../prisma/prisma.service';
 
 describe('SHOP AI integration — autoReply with SalesBot mock', () => {
@@ -26,6 +27,7 @@ describe('SHOP AI integration — autoReply with SalesBot mock', () => {
         { provide: PrismaService, useValue: prisma },
         { provide: AiSuggestService, useValue: { suggest: jest.fn() } },
         { provide: SalesBotService, useValue: salesBot },
+        { provide: LlmProviderRegistry, useValue: { invalidateCache: jest.fn() } },
       ],
     }).compile();
     svc = mod.get(AiAutoReplyService);

--- a/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.spec.ts
+++ b/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.spec.ts
@@ -3,8 +3,11 @@ import { ConfigService } from '@nestjs/config';
 import { AiAutoReplyService } from './ai-auto-reply.service';
 import { AiSuggestService } from './ai-suggest.service';
 import { SalesBotService } from '../../sales-bot/sales-bot.service';
+import { LlmProviderRegistry } from '../../sales-bot/providers/llm-provider.registry';
 import { MessageRouterService } from '../../chat-engine/services/message-router.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+
+const makeLlmRegistryMock = () => ({ invalidateCache: jest.fn() });
 
 describe('AiAutoReplyService.shouldAutoReply', () => {
   let svc: AiAutoReplyService;
@@ -27,6 +30,7 @@ describe('AiAutoReplyService.shouldAutoReply', () => {
         { provide: AiSuggestService, useValue: {} },
         { provide: SalesBotService, useValue: { generateReply: jest.fn() } },
         { provide: MessageRouterService, useValue: { getAdapter: jest.fn() } },
+        { provide: LlmProviderRegistry, useValue: makeLlmRegistryMock() },
       ],
     }).compile();
     svc = mod.get(AiAutoReplyService);
@@ -93,6 +97,7 @@ describe('AiAutoReplyService.autoReply', () => {
         // NEW dep: SalesBotService
         { provide: SalesBotService, useValue: salesBot },
         { provide: MessageRouterService, useValue: { getAdapter: jest.fn() } },
+        { provide: LlmProviderRegistry, useValue: makeLlmRegistryMock() },
       ],
     }).compile();
     svc = mod.get(AiAutoReplyService);
@@ -157,6 +162,7 @@ describe('AiAutoReplyService.testSend', () => {
         { provide: AiSuggestService, useValue: {} },
         { provide: SalesBotService, useValue: {} },
         { provide: MessageRouterService, useValue: messageRouter },
+        { provide: LlmProviderRegistry, useValue: makeLlmRegistryMock() },
       ],
     }).compile();
     svc = mod.get(AiAutoReplyService);
@@ -202,5 +208,84 @@ describe('AiAutoReplyService.testSend', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('token invalid');
+  });
+});
+
+describe('AiAutoReplyService.llmProvider — get + update + cache invalidation', () => {
+  let svc: AiAutoReplyService;
+  let prisma: any;
+  let llmRegistry: { invalidateCache: jest.Mock };
+
+  beforeEach(async () => {
+    llmRegistry = makeLlmRegistryMock();
+    prisma = {
+      systemConfig: {
+        findMany: jest.fn(),
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        AiAutoReplyService,
+        { provide: ConfigService, useValue: { get: () => undefined } },
+        { provide: PrismaService, useValue: prisma },
+        { provide: AiSuggestService, useValue: {} },
+        { provide: SalesBotService, useValue: {} },
+        { provide: MessageRouterService, useValue: { getAdapter: jest.fn() } },
+        { provide: LlmProviderRegistry, useValue: llmRegistry },
+      ],
+    }).compile();
+    svc = mod.get(AiAutoReplyService);
+  });
+
+  it('getSettings defaults llmProvider to "claude" when config row absent', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([]);
+    const s = await svc.getSettings();
+    expect(s.llmProvider).toBe('claude');
+  });
+
+  it('getSettings returns "gemini" when shop_bot_llm_provider=gemini', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([
+      { key: 'shop_bot_llm_provider', value: 'gemini' },
+    ]);
+    const s = await svc.getSettings();
+    expect(s.llmProvider).toBe('gemini');
+  });
+
+  it('getSettings is case-insensitive — "GEMINI" still parses as gemini', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([
+      { key: 'shop_bot_llm_provider', value: 'GEMINI' },
+    ]);
+    const s = await svc.getSettings();
+    expect(s.llmProvider).toBe('gemini');
+  });
+
+  it('getSettings falls back to "claude" on unknown value (matches registry behavior)', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([
+      { key: 'shop_bot_llm_provider', value: 'llama' },
+    ]);
+    const s = await svc.getSettings();
+    expect(s.llmProvider).toBe('claude');
+  });
+
+  it('updateSettings({llmProvider: "gemini"}) upserts SystemConfig + invalidates registry cache', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([
+      { key: 'shop_bot_llm_provider', value: 'gemini' },
+    ]);
+    await svc.updateSettings({ llmProvider: 'gemini' });
+    expect(prisma.systemConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: 'shop_bot_llm_provider' },
+        create: expect.objectContaining({ key: 'shop_bot_llm_provider', value: 'gemini' }),
+        update: expect.objectContaining({ value: 'gemini' }),
+      }),
+    );
+    expect(llmRegistry.invalidateCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('updateSettings without llmProvider does NOT invalidate cache (no LLM-touching change)', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([]);
+    await svc.updateSettings({ aiAutoEnabled: true });
+    expect(llmRegistry.invalidateCache).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.ts
+++ b/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.ts
@@ -4,8 +4,14 @@ import { ChatChannel, MessageRole, MessageType } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { AiSuggestService } from './ai-suggest.service';
 import { SalesBotService, SalesBotResult } from '../../sales-bot/sales-bot.service';
+import { LlmProviderRegistry } from '../../sales-bot/providers/llm-provider.registry';
 import { MessageRouterService } from '../../chat-engine/services/message-router.service';
-import type { AiAutoSettings, UpdateAiSettingsDto } from '../dto/ai-settings.dto';
+import {
+  LLM_PROVIDERS,
+  type AiAutoSettings,
+  type LlmProviderChoice,
+  type UpdateAiSettingsDto,
+} from '../dto/ai-settings.dto';
 
 @Injectable()
 export class AiAutoReplyService {
@@ -16,6 +22,7 @@ export class AiAutoReplyService {
     private prisma: PrismaService,
     private aiSuggest: AiSuggestService,
     private salesBot: SalesBotService,
+    private llmRegistry: LlmProviderRegistry,
     @Optional()
     @Inject(forwardRef(() => MessageRouterService))
     private messageRouter?: MessageRouterService,
@@ -144,6 +151,7 @@ export class AiAutoReplyService {
       'shop_bot_central_branch_id',
       'shop_bot_promptpay_id',
       'shop_bot_test_user_id',
+      'shop_bot_llm_provider',
     ];
 
     const configs = await this.prisma.systemConfig.findMany({
@@ -151,6 +159,13 @@ export class AiAutoReplyService {
     });
 
     const configMap = new Map(configs.map((c) => [c.key, c.value]));
+
+    const rawProvider = (configMap.get('shop_bot_llm_provider') ?? '').trim().toLowerCase();
+    const llmProvider: LlmProviderChoice = (LLM_PROVIDERS as readonly string[]).includes(
+      rawProvider,
+    )
+      ? (rawProvider as LlmProviderChoice)
+      : 'claude';
 
     return {
       aiAutoEnabled: configMap.has('ai.autoEnabled')
@@ -168,6 +183,7 @@ export class AiAutoReplyService {
       shopBotCentralBranchId: configMap.get('shop_bot_central_branch_id') ?? null,
       shopBotPromptpayId: configMap.get('shop_bot_promptpay_id') ?? null,
       shopBotTestUserId: configMap.get('shop_bot_test_user_id') ?? null,
+      llmProvider,
     };
   }
 
@@ -223,6 +239,13 @@ export class AiAutoReplyService {
         label: 'SHOP Bot test LINE userId',
       });
     }
+    if (dto.llmProvider !== undefined) {
+      entries.push({
+        key: 'shop_bot_llm_provider',
+        value: dto.llmProvider,
+        label: 'SHOP Bot LLM provider (claude | gemini)',
+      });
+    }
 
     for (const entry of entries) {
       await this.prisma.systemConfig.upsert({
@@ -230,6 +253,15 @@ export class AiAutoReplyService {
         create: { key: entry.key, value: entry.value, label: entry.label },
         update: { value: entry.value, deletedAt: null },
       });
+    }
+
+    // If the LLM provider was flipped, drop the in-memory registry cache so
+    // the next customer message routes to the new provider immediately instead
+    // of after the 60-second TTL. Cheap (single field assignment) and
+    // idempotent, so it's safe to call unconditionally when llmProvider is in
+    // the patch — even if the value didn't actually change.
+    if (dto.llmProvider !== undefined) {
+      this.llmRegistry.invalidateCache();
     }
 
     return this.getSettings();

--- a/apps/web/src/pages/AiSettingsPage.tsx
+++ b/apps/web/src/pages/AiSettingsPage.tsx
@@ -179,10 +179,13 @@ function AiSettingsForm({ initial }: { initial: AiSettings }) {
   );
 }
 
+type LlmProviderChoice = 'claude' | 'gemini';
+
 interface ShopBotConfig {
   shopBotCentralBranchId: string | null;
   shopBotPromptpayId: string | null;
   shopBotTestUserId: string | null;
+  llmProvider: LlmProviderChoice;
 }
 
 function ShopBotSetupForm() {
@@ -190,6 +193,7 @@ function ShopBotSetupForm() {
   const [branchId, setBranchId] = useState('');
   const [promptpayId, setPromptpayId] = useState('');
   const [testUserId, setTestUserId] = useState('');
+  const [llmProvider, setLlmProvider] = useState<LlmProviderChoice>('claude');
 
   // Read SHOP bot config from same ai-settings endpoint (extended in Task 20a).
   // Use a distinct query key so the raw response shape doesn't conflict with
@@ -199,10 +203,12 @@ function ShopBotSetupForm() {
     queryFn: () =>
       api.get('/staff-chat/ai/settings').then((r: any) => {
         const d = r.data?.data ?? r.data;
+        const provider: LlmProviderChoice = d.llmProvider === 'gemini' ? 'gemini' : 'claude';
         return {
           shopBotCentralBranchId: d.shopBotCentralBranchId ?? null,
           shopBotPromptpayId: d.shopBotPromptpayId ?? null,
           shopBotTestUserId: d.shopBotTestUserId ?? null,
+          llmProvider: provider,
         };
       }),
   });
@@ -217,6 +223,7 @@ function ShopBotSetupForm() {
     setBranchId(shopBotQuery.data.shopBotCentralBranchId ?? '');
     setPromptpayId(shopBotQuery.data.shopBotPromptpayId ?? '');
     setTestUserId(shopBotQuery.data.shopBotTestUserId ?? '');
+    setLlmProvider(shopBotQuery.data.llmProvider);
   }, [shopBotQuery.data]);
 
   const saveMutation = useMutation({
@@ -225,6 +232,7 @@ function ShopBotSetupForm() {
         shopBotCentralBranchId: branchId || null,
         shopBotPromptpayId: promptpayId || null,
         shopBotTestUserId: testUserId || null,
+        llmProvider,
       }),
     onSuccess: () => {
       toast.success('บันทึก SHOP Bot Setup เรียบร้อย');
@@ -296,6 +304,29 @@ function ShopBotSetupForm() {
             onChange={(e) => setTestUserId(e.target.value)}
             placeholder="U1234567890abcdef..."
           />
+        </div>
+        <div className="space-y-2">
+          <Label className="leading-snug">AI Provider</Label>
+          <Select
+            value={llmProvider}
+            onValueChange={(v) => setLlmProvider(v as LlmProviderChoice)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="เลือก AI provider" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="claude">
+                Claude (Anthropic) — default, persona-refined Thai
+              </SelectItem>
+              <SelectItem value="gemini">
+                Gemini 2.5-flash (Vertex) — ~8x ถูกกว่า, thinking-mode ปิด
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground leading-snug">
+            เปลี่ยน provider จะมีผลทันทีหลังกดบันทึก (cache ถูกล้างพร้อมกัน) —
+            ไม่ต้องรอ 60 วินาที, ไม่ต้อง redeploy
+          </p>
         </div>
         <div className="flex justify-end gap-2">
           <Button


### PR DESCRIPTION
## Summary

Replaces the SQL-or-browser-snippet ritual for flipping the SalesBot LLM provider with a dropdown in **AI Provider** under SHOP Bot Setup at `/settings/ai-chat`.

Before this PR, switching Claude ↔ Gemini required either:
- A `SystemConfig.upsert` over a Cloud SQL Auth Proxy (needs the DB password), or
- A logged-in browser-console snippet that auth-refreshes and PATCHes `/api/settings` directly.

After: a dropdown. The save mutation calls `LlmProviderRegistry.invalidateCache()` server-side so the change is live on the next message — no 60s TTL lag, no redeploy.

## Wiring

| Layer | File | Change |
|---|---|---|
| DTO | `apps/api/src/modules/staff-chat/dto/ai-settings.dto.ts` | Adds `llmProvider?: 'claude' \| 'gemini'` with `@IsIn` + Thai error message. Also exports `LLM_PROVIDERS` const + `LlmProviderChoice` type so the service can share them. |
| Service | `apps/api/src/modules/staff-chat/services/ai-auto-reply.service.ts` | Injects `LlmProviderRegistry`; `getSettings` reads `shop_bot_llm_provider` from SystemConfig (case-insensitive, falls back to `claude`); `updateSettings` upserts the row and calls `invalidateCache()` only when `llmProvider` is in the patch. |
| Registry | `apps/api/src/modules/sales-bot/providers/llm-provider.registry.ts` | New public `invalidateCache()` — idempotent, drops the in-memory snapshot. |
| Page | `apps/web/src/pages/AiSettingsPage.tsx` | New shadcn `<Select>` row in SHOP Bot Setup; PATCH body includes `llmProvider`; helper hint explains the cache-flush behavior. |

## Why a separate Registry method instead of just clearing the cache from the service

`LlmProviderRegistry.cached` is `private` and the rest of the registry's API only exposes `getActive()`. A public `invalidateCache()` keeps the encapsulation intact, makes the intent obvious at the call-site, and is testable in isolation (no need to wait for the 60s TTL to verify cache behavior). It's also a no-op when called twice in a row, so a future "save without changing provider" flow can call it unconditionally without harm.

## Test plan

- [x] `llm-provider.registry.spec.ts` — 9 tests (2 new): `invalidateCache()` forces DB re-read + is idempotent
- [x] `ai-auto-reply.service.spec.ts` — 12 tests (6 new): default=claude, reads gemini, case-insensitive, unknown→claude, updateSettings upserts+invalidates, no-op when llmProvider absent
- [x] `shop-ai-flow.unit.spec.ts` — DI module updated to include `LlmProviderRegistry` mock (constructor change)
- [x] All 16 `sales-bot` + `staff-chat` test suites pass (**136/136 tests**)
- [x] Web TypeScript: 0 errors
- [x] API TypeScript: 0 new errors (the 7 `@prisma/client-finance` errors that show up are pre-existing — they trace to P3-SP7 dual-prisma scaffolding and require `npm run prisma:finance:generate`, which is not part of this PR)
- [ ] After merge + deploy: flip provider via dropdown → verify next 🧪 test-send hits Gemini (Cloud Run logs should show `GeminiProvider: Vertex mode (...gemini-2.5-flash...)` instead of Claude usage)

## Notes for owner

The dropdown labels reflect the current tradeoff:
- **Claude** — default; persona-refined Thai (anti-translation rules shipped in #1056)
- **Gemini 2.5-flash** — ~8x cheaper input tokens, thinking-mode off by default (per #1057 measurement)

This PR does NOT change the default. If the SystemConfig row doesn't exist, the registry still returns Claude. So merging this is safe even if you haven't decided yet — it just exposes the lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)