### PR TITLE
fix(shop-ai): skip SystemConfig upsert when value is null (prod 500 hotfix)

### DIFF
--- a/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.spec.ts
+++ b/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.spec.ts
@@ -288,4 +288,35 @@ describe('AiAutoReplyService.llmProvider — get + update + cache invalidation',
     await svc.updateSettings({ aiAutoEnabled: true });
     expect(llmRegistry.invalidateCache).not.toHaveBeenCalled();
   });
+
+  // Regression — 2026-05-21 prod incident.
+  // Saving SHOP Bot Setup with empty PromptPay / Test userId inputs sent
+  // `shopBotPromptpayId: null`, which the old `!== undefined` guard let pass
+  // through to prisma.systemConfig.upsert with `value: null`. Prisma rejected
+  // (SystemConfig.value is non-nullable) and the whole PATCH returned 500.
+  // Fix: skip null entries so the previously-saved value stays intact.
+  it('updateSettings skips entries where value is null (does not crash upsert)', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([]);
+    await svc.updateSettings({
+      shopBotCentralBranchId: 'branch-uuid',
+      shopBotPromptpayId: null as unknown as string, // simulating frontend `|| null`
+      shopBotTestUserId: null as unknown as string,
+      llmProvider: 'gemini',
+    });
+    const calls = prisma.systemConfig.upsert.mock.calls.map(
+      (c: any[]) => c[0].where.key as string,
+    );
+    expect(calls).toContain('shop_bot_central_branch_id');
+    expect(calls).toContain('shop_bot_llm_provider');
+    expect(calls).not.toContain('shop_bot_promptpay_id');
+    expect(calls).not.toContain('shop_bot_test_user_id');
+    // Cache invalidation still happens because llmProvider was non-null in this patch.
+    expect(llmRegistry.invalidateCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('updateSettings with all-null llmProvider does NOT invalidate cache', async () => {
+    prisma.systemConfig.findMany.mockResolvedValue([]);
+    await svc.updateSettings({ llmProvider: null as unknown as 'claude' });
+    expect(llmRegistry.invalidateCache).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.ts
+++ b/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.ts
@@ -190,56 +190,64 @@ export class AiAutoReplyService {
   async updateSettings(dto: UpdateAiSettingsDto): Promise<AiAutoSettings> {
     const entries: { key: string; value: string; label: string }[] = [];
 
-    if (dto.aiAutoEnabled !== undefined) {
+    // `!= null` covers both `undefined` (key absent from PATCH body) AND `null`
+    // (key explicitly cleared by client). SystemConfig.value is non-nullable,
+    // so passing null straight through to upsert crashes with
+    // `PrismaClientValidationError: Argument value must not be null` and the
+    // whole PATCH returns 500 — observed in prod 2026-05-21 when the
+    // ShopBotSetupForm save mutation sent `shopBotPromptpayId: null` for an
+    // empty input. Skipping the entry preserves the previously-saved value;
+    // explicit clearing of a value isn't a flow we expose today.
+    if (dto.aiAutoEnabled != null) {
       entries.push({
         key: 'ai.autoEnabled',
         value: String(dto.aiAutoEnabled),
         label: 'AI Auto Mode เปิด/ปิด',
       });
     }
-    if (dto.aiAutoChannels !== undefined) {
+    if (dto.aiAutoChannels != null) {
       entries.push({
         key: 'ai.autoChannels',
         value: JSON.stringify(dto.aiAutoChannels),
         label: 'AI Auto Channels',
       });
     }
-    if (dto.aiAutoConfidenceThreshold !== undefined) {
+    if (dto.aiAutoConfidenceThreshold != null) {
       entries.push({
         key: 'ai.autoConfidenceThreshold',
         value: String(dto.aiAutoConfidenceThreshold),
         label: 'AI Confidence Threshold',
       });
     }
-    if (dto.aiAutoMaxRepliesPerSession !== undefined) {
+    if (dto.aiAutoMaxRepliesPerSession != null) {
       entries.push({
         key: 'ai.autoMaxRepliesPerSession',
         value: String(dto.aiAutoMaxRepliesPerSession),
         label: 'AI Max Replies per Session',
       });
     }
-    if (dto.shopBotCentralBranchId !== undefined) {
+    if (dto.shopBotCentralBranchId != null) {
       entries.push({
         key: 'shop_bot_central_branch_id',
         value: dto.shopBotCentralBranchId,
         label: 'SHOP Bot central branch ID',
       });
     }
-    if (dto.shopBotPromptpayId !== undefined) {
+    if (dto.shopBotPromptpayId != null) {
       entries.push({
         key: 'shop_bot_promptpay_id',
         value: dto.shopBotPromptpayId,
         label: 'SHOP Bot PromptPay ID',
       });
     }
-    if (dto.shopBotTestUserId !== undefined) {
+    if (dto.shopBotTestUserId != null) {
       entries.push({
         key: 'shop_bot_test_user_id',
         value: dto.shopBotTestUserId,
         label: 'SHOP Bot test LINE userId',
       });
     }
-    if (dto.llmProvider !== undefined) {
+    if (dto.llmProvider != null) {
       entries.push({
         key: 'shop_bot_llm_provider',
         value: dto.llmProvider,
@@ -259,8 +267,9 @@ export class AiAutoReplyService {
     // the next customer message routes to the new provider immediately instead
     // of after the 60-second TTL. Cheap (single field assignment) and
     // idempotent, so it's safe to call unconditionally when llmProvider is in
-    // the patch — even if the value didn't actually change.
-    if (dto.llmProvider !== undefined) {
+    // the patch — even if the value didn't actually change. Skip on null so
+    // we don't churn the cache for clients that send the field cleared.
+    if (dto.llmProvider != null) {
       this.llmRegistry.invalidateCache();
     }
 


### PR DESCRIPTION
## Summary

PATCH \`/api/staff-chat/ai/settings\` returned **500** in prod (revision 00675) whenever the SHOP Bot Setup form was saved while PromptPay ID or Test LINE userId inputs were empty. Root cause walked end-to-end:

| Layer | What it does | Why it didn't catch null |
|---|---|---|
| Frontend | \`shopBotPromptpayId: promptpayId \|\| null\` for empty input | This is the intended shape — \"user didn't fill it in\" |
| DTO | \`@IsOptional() @IsString()\` | class-validator's \`@IsOptional\` accepts \`null\` |
| Service guard | \`if (dto.shopBotPromptpayId !== undefined)\` | \`null !== undefined\` is \`true\` → entry pushed with \`value: null\` |
| Prisma | \`SystemConfig.value\` non-nullable | Rejects with \`Argument value must not be null\` |

Fix: change all seven \`!== undefined\` guards to \`!= null\` so both \`undefined\` (key absent from PATCH body) and \`null\` (key explicitly cleared by client) skip the entry. Semantics: skipping = \"keep the previously-saved value,\" which matches what the form intends — there's no \"explicitly clear an existing value\" flow exposed in the UI.

Same null-skip applied to the \`invalidateCache()\` trigger so a payload with \`llmProvider: null\` doesn't churn the registry cache for no reason.

## Why fix all seven, not just the three SHOP Bot fields

The bug exists wherever the guard pattern exists. The four \`ai.auto*\` fields would exhibit the same crash if a future client sends them null. One-line consistency is cheaper than per-field branching, and reviewers can grep \`!= null\` to confirm completeness.

## Prod stack trace (2026-05-21 16:04 BKK, revision bestchoice-api-00675)

\`\`\`
PrismaClientValidationError:
Invalid \`prisma.systemConfig.upsert()\` invocation:
  where: { key: \"shop_bot_promptpay_id\" },
  create: { ..., value: String },
  update: { value: null, deletedAt: null }
Argument \`value\` must not be null.
  at AiAutoReplyService.updateSettings (apps/api/dist/src/modules/staff-chat/services/ai-auto-reply.service.js:214:13)
\`\`\`

## Pre-existing — when did this regress?

Service guard \`!== undefined\` has been in place since PR #1056 (LLMProvider abstraction). The three SHOP Bot Setup fields (\`shopBotCentralBranchId\` / \`shopBotPromptpayId\` / \`shopBotTestUserId\`) were added in the same PR. PR #1058 widened the user-facing surface — it added the \`llmProvider\` dropdown, which forced owners through the SHOP Bot Setup save mutation for the first time, exposing the latent bug.

The fix is in **PR #1058's surface area**, not its cause.

## Test plan

- [x] **2 new regression cases** in \`ai-auto-reply.service.spec.ts\` (now 18/18 pass):
  - \`updateSettings\` with mixed null + non-null fields → only the non-null ones get upserted, cache invalidation still fires when llmProvider is non-null
  - \`updateSettings\` with \`llmProvider: null\` → cache invalidation skipped
- [x] All 4 affected suites pass: 18 ai-auto-reply + 9 llm-provider-registry + 12 gemini.provider + 11 shop-ai-flow = 50/50
- [x] 0 new TypeScript errors
- [ ] After merge + deploy: re-test the original repro — load \`/settings/ai-chat\`, leave PromptPay + Test userId blank, change AI Provider to Gemini, save → should toast \"บันทึก SHOP Bot Setup เรียบร้อย\" (not the error one)

## Workaround for owner pending merge

Run in browser console at \`bestchoicephone.app\` while logged in as OWNER:

\`\`\`js
(async () => {
  const r = await fetch('/api/auth/refresh', {
    method: 'POST', credentials: 'include',
    headers: { 'X-Requested-With': 'XMLHttpRequest' }
  }).then(r => r.json());
  const upd = await fetch('/api/staff-chat/ai/settings', {
    method: 'PATCH', credentials: 'include',
    headers: {
      'Content-Type': 'application/json',
      'X-Requested-With': 'XMLHttpRequest',
      'Authorization': \`Bearer \${r.accessToken}\`
    },
    body: JSON.stringify({ llmProvider: 'gemini' })
  });
  console.log('status', upd.status, await upd.json());
})();
\`\`\`

Sends ONLY \`llmProvider\` (no null fields) → server flips SystemConfig + invalidates cache → Gemini live in <1s without redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)