### PR TITLE
fix(gemini): group multi-tool functionResponses into one user turn (prod 400)

### DIFF
--- a/apps/api/src/modules/sales-bot/providers/gemini.provider.spec.ts
+++ b/apps/api/src/modules/sales-bot/providers/gemini.provider.spec.ts
@@ -271,6 +271,123 @@ describe('GeminiProvider', () => {
     });
   });
 
+  // Regression — 2026-05-21 prod: Nai's "15 ธรรมดา" triggered persona's
+  // 3-Combo Anchor (search + calc×3 in one turn). Service pushed 4 tool
+  // results as 4 separate user turns; Gemini returned 400 "function response
+  // parts ≠ function call parts of the function call turn". This block
+  // verifies the grouping fix.
+  describe('multi-tool-call response grouping', () => {
+    it('groups N consecutive tool results into ONE user turn (the Nai case)', async () => {
+      const p = await buildProvider({ GOOGLE_CLOUD_PROJECT: 'bestchoice-prod' });
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+        usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 5 },
+      });
+
+      await p.chat({
+        systemPrompt: 'persona',
+        messages: [
+          { role: 'user', content: '15 ธรรมดา' },
+          {
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              { id: 'fn_0_search_products', name: 'search_products', input: { query: 'iPhone 15' } },
+              { id: 'fn_1_calculate_installment', name: 'calculate_installment', input: { productId: 'p1', downPct: 10, tenureMonths: 12 } },
+              { id: 'fn_2_calculate_installment', name: 'calculate_installment', input: { productId: 'p1', downPct: 20, tenureMonths: 12 } },
+              { id: 'fn_3_calculate_installment', name: 'calculate_installment', input: { productId: 'p1', downPct: 30, tenureMonths: 12 } },
+            ],
+          },
+          { role: 'tool', toolCallId: 'fn_0_search_products', content: '{"products":[{"id":"p1","priceThb":28900}]}' },
+          { role: 'tool', toolCallId: 'fn_1_calculate_installment', content: '{"monthly":2890}' },
+          { role: 'tool', toolCallId: 'fn_2_calculate_installment', content: '{"monthly":2570}' },
+          { role: 'tool', toolCallId: 'fn_3_calculate_installment', content: '{"monthly":2250}' },
+        ],
+      });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+
+      // Expected shape: 3 turns total — user (text), model (4 functionCalls),
+      // user (4 functionResponses grouped). NOT 6 turns (1+1+4 separate).
+      expect(body.contents).toHaveLength(3);
+      expect(body.contents[0]).toEqual({
+        role: 'user',
+        parts: [{ text: '15 ธรรมดา' }],
+      });
+      expect(body.contents[1].role).toBe('model');
+      expect(body.contents[1].parts).toHaveLength(4);
+      expect(body.contents[1].parts.every((p: any) => 'functionCall' in p)).toBe(true);
+      // The critical assertion: all 4 functionResponses live in ONE user turn,
+      // not split across 4 separate user turns.
+      expect(body.contents[2].role).toBe('user');
+      expect(body.contents[2].parts).toHaveLength(4);
+      expect(body.contents[2].parts.every((p: any) => 'functionResponse' in p)).toBe(true);
+      // Names preserved in correct order via positional iteration.
+      expect(body.contents[2].parts.map((p: any) => p.functionResponse.name)).toEqual([
+        'search_products',
+        'calculate_installment',
+        'calculate_installment',
+        'calculate_installment',
+      ]);
+    });
+
+    it('single tool result still produces its own user turn (no regression)', async () => {
+      const p = await buildProvider({ GOOGLE_CLOUD_PROJECT: 'bestchoice-prod' });
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 1 },
+      });
+
+      await p.chat({
+        systemPrompt: 'persona',
+        messages: [
+          { role: 'user', content: 'iPhone 15 ราคา' },
+          {
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              { id: 'fn_0_search_products', name: 'search_products', input: { query: 'iPhone 15' } },
+            ],
+          },
+          { role: 'tool', toolCallId: 'fn_0_search_products', content: '{"products":[]}' },
+        ],
+      });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+      // 3 turns: user, model (1 functionCall), user (1 functionResponse).
+      expect(body.contents).toHaveLength(3);
+      expect(body.contents[2].role).toBe('user');
+      expect(body.contents[2].parts).toHaveLength(1);
+      expect(body.contents[2].parts[0]).toHaveProperty('functionResponse.name', 'search_products');
+    });
+
+    it('does NOT group tool result into a user turn that contains text', async () => {
+      // Defensive: if a `tool` message arrives right after a regular user
+      // text turn (shouldn't happen via our service, but could via test or
+      // future caller), don't pollute the text turn. Start a fresh user turn.
+      const p = await buildProvider({ GOOGLE_CLOUD_PROJECT: 'bestchoice-prod' });
+      fakeFetchResponse(fetchSpy, {
+        candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 1 },
+      });
+
+      await p.chat({
+        systemPrompt: 'persona',
+        messages: [
+          { role: 'user', content: 'some text' },
+          { role: 'tool', toolCallId: 'fn_0_foo', content: '{"x":1}' },
+        ],
+      });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+      // 2 turns: user (text) + user (functionResponse). Separate.
+      expect(body.contents).toHaveLength(2);
+      expect(body.contents[0].parts[0]).toHaveProperty('text', 'some text');
+      expect(body.contents[1].parts[0]).toHaveProperty('functionResponse.name', 'foo');
+    });
+  });
+
   describe('thinkingConfig (2.5-series only)', () => {
     it('sets thinkingBudget=0 on gemini-2.5-flash to skip hidden reasoning', async () => {
       const p = await buildProvider({

--- a/apps/api/src/modules/sales-bot/providers/gemini.provider.ts
+++ b/apps/api/src/modules/sales-bot/providers/gemini.provider.ts
@@ -216,15 +216,38 @@ export class GeminiProvider implements ILlmProvider {
    * - user → { role: 'user', parts: [{ text }] }
    * - assistant text → { role: 'model', parts: [{ text }] }
    * - assistant tool_calls → { role: 'model', parts: [{ functionCall }, ...] }
-   * - tool result → { role: 'user', parts: [{ functionResponse: { name, response } }] }
+   * - tool result(s) → { role: 'user', parts: [{ functionResponse }, ...] }
    *
-   * Gemini does NOT use tool_call ids. The `functionResponse.name` must match
-   * the original functionCall name; the response object is opaque payload.
-   * If multiple tool calls/results exist for the same name, Gemini matches by
-   * position — order is preserved in projection.
+   * **Multi-tool turn handling** (Gemini-specific contract):
+   * When the assistant turn contains N functionCall parts, Gemini requires
+   * the next user turn to contain ALL N functionResponse parts in a SINGLE
+   * turn — NOT N separate user turns. Pushing N separate turns triggers a
+   * 400 INVALID_ARGUMENT: "Please ensure that the number of function
+   * response parts is equal to the number of function call parts of the
+   * function call turn."
+   *
+   * The persona's "3-Combo Anchor Pricing" playbook routinely calls 4 tools
+   * at once (search_products + calculate_installment × 3), so this isn't a
+   * corner case — it's the dominant tool-using path.
+   *
+   * Implementation: when projecting a `role: 'tool'` message, check whether
+   * the previous projected turn is already a user turn containing only
+   * functionResponse parts. If yes, APPEND the new functionResponse to that
+   * turn. Otherwise, start a fresh user turn. Single-tool flows still work
+   * — they just produce a user turn with one functionResponse part, same
+   * wire format.
+   *
+   * Repro that drove this fix (2026-05-21 prod): Nai sent "15 ธรรมดา" →
+   * Gemini called search + calc×3 in one turn → our service pushed 4
+   * separate user turns → Gemini 400 → no reply.
+   *
+   * Gemini does NOT use tool_call ids. The `functionResponse.name` must
+   * match the original functionCall name; the response object is opaque
+   * payload. Multiple tool calls/results with the same name match by
+   * position — preserved by iterating `messages` in order.
    */
   private projectMessages(messages: LlmChatMessage[]): unknown[] {
-    const out: unknown[] = [];
+    const out: { role: string; parts: unknown[] }[] = [];
     const idToName = new Map<string, string>();
 
     for (const msg of messages) {
@@ -253,18 +276,33 @@ export class GeminiProvider implements ILlmProvider {
       }
 
       // role === 'tool'
-      const name = idToName.get(msg.toolCallId) ?? msg.toolCallId.replace(/^fn_\d+_/, '');
-      out.push({
-        role: 'user',
-        parts: [
-          {
-            functionResponse: {
-              name,
-              response: this.parseToolContent(msg.content),
-            },
-          },
-        ],
-      });
+      const name =
+        idToName.get(msg.toolCallId) ?? msg.toolCallId.replace(/^fn_\d+_/, '');
+      const responsePart = {
+        functionResponse: {
+          name,
+          response: this.parseToolContent(msg.content),
+        },
+      };
+
+      // Group with previous tool-result turn if it's still "open" (i.e. the
+      // last projected turn is a user turn made entirely of functionResponse
+      // parts). Defensive `every()` check makes sure we never sneak a
+      // functionResponse into a turn that also carries `text` parts.
+      const last = out[out.length - 1];
+      const isOpenToolResultTurn =
+        last !== undefined &&
+        last.role === 'user' &&
+        last.parts.length > 0 &&
+        last.parts.every(
+          (p) => p !== null && typeof p === 'object' && 'functionResponse' in p,
+        );
+
+      if (isOpenToolResultTurn) {
+        last.parts.push(responsePart);
+      } else {
+        out.push({ role: 'user', parts: [responsePart] });
+      }
     }
 
     return out;


### PR DESCRIPTION
## Root cause (debug-mantra, H1 confirmed via curl)

Nai's 3rd FB message triggered Gemini 400 — bot silently stopped replying.

Gemini's contract: when an assistant turn has N functionCall parts, the next user turn must contain ALL N functionResponse parts in a SINGLE turn. Our projection was pushing each `role: 'tool'` message as its OWN user turn → N separate user turns instead of 1 with N parts → 400 INVALID_ARGUMENT.

Persona's 3-Combo Anchor Pricing rule calls search + calc×3 in one turn → this is the dominant path, not a corner case.

### Repro via curl (disproof series)
| Run | Result |
|---|---|
| Hop 0 with text-only history + tools | 200 ✓ |
| 1 fc + 1 fr in own user turn | 200 ✓ |
| 3 fc + 3 fr in 3 separate user turns | **400 same error** ✓ repro |
| 3 fc + 3 fr merged into 1 user turn | **200** ✓ fix |

## Fix

`projectMessages` — when projecting `role: 'tool'`, append the functionResponse to the previous user turn IF it's already populated exclusively with functionResponse parts. Otherwise start a fresh user turn.

Single-tool path unchanged (1 fr in own turn). Multi-tool path now produces 1 user turn with N parts. Defensive `every()` check prevents polluting a text user turn.

## Tests

3 new cases in gemini.provider.spec.ts (now 15/15):
1. **The Nai case** — 1 search + 3 calc → asserts body has 3 turns (user / model with 4 fcs / user with 4 frs grouped), names in positional order.
2. **Single tool result still own user turn** — no regression on existing 1:1 flow.
3. **Tool result after text user turn** — defensive: doesn't pollute text turn.

168/168 sales-bot + staff-chat suites pass. 0 new TS errors.

## Why this only surfaced now

PR #1058 LLM toggle landed today. SystemConfig 'gemini' flip happened later. Most prior bot traffic was Claude (handles multi-tool turns via content blocks). Gemini's position-based pairing is stricter — bug was latent until first tool-using FB test.

## Test plan after deploy

- [ ] Nai sends 'สวัสดี' → bot replies with new tone (BASE persona from #1062)
- [ ] Nai sends '15 ธรรมดา' → bot replies WITH tool-derived prices (no 400)
- [ ] Cloud Run logs show `AiAutoReply Replied to room ... with confidence=0.95` (= toolsUsed > 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)