### PR TITLE
debug(sales-bot): log tool args + result for Nai 7,000 diagnosis

### DIFF
--- a/apps/api/src/modules/sales-bot/sales-bot.service.ts
+++ b/apps/api/src/modules/sales-bot/sales-bot.service.ts
@@ -116,6 +116,9 @@ export class SalesBotService {
       modelUsed = resp.modelName;
 
       if (resp.toolCalls.length === 0) {
+        this.logger.log(
+          `[FinalReply] room=${input.roomId} hop=${hop} toolsUsed=${JSON.stringify(toolsUsed)} reply=${JSON.stringify(resp.text).slice(0, 400)}`,
+        );
         return {
           reply: resp.text,
           confidence: this.estimateConfidence(resp.text, toolsUsed),
@@ -132,6 +135,9 @@ export class SalesBotService {
       for (const tc of resp.toolCalls) {
         toolsUsed.push(tc.name);
         const result = await this.runTool(tc.name, tc.input, input.roomId);
+        this.logger.log(
+          `[ToolCall] room=${input.roomId} tool=${tc.name} args=${JSON.stringify(tc.input).slice(0, 300)} result=${JSON.stringify(result).slice(0, 600)}`,
+        );
         toolResults.push({
           role: 'tool',
           toolCallId: tc.id,


### PR DESCRIPTION
## Why
PR #1064 added anti-hallucinate rules to BOT_EXTRAS persona. Nai retest still showed bot reply: "iPhone 15 ราคาเริ่มต้น 7,000 บาท".

Catalog truth (verified via shop-catalog API): only iPhone 13 (14,691) + iPhone 16 (17,000). No iPhone 15. 7,000 doesn't match any product.

confidence=0.95 in the response confirms a tool was called — but we have no log of WHAT args Gemini passed to search_products and WHAT the tool returned. Without that breadcrumb we can't tell apart:
- **H3** — Gemini hallucinated despite tool returning correct catalog
- **H4** — search_products returned phantom data (bug in tool itself)

## What
Add 2 logs in SalesBotService tool loop:
- `[ToolCall]` per executed tool — name + args + result preview
- `[FinalReply]` when loop exits — toolsUsed + reply text

Caps slices at 300/600/400 chars to stay readable.

## Plan
1. Merge + deploy (admin bypass).
2. Owner reproduces Nai test once.
3. Inspect Cloud Run logs filtered by `[ToolCall]` to confirm root cause.
4. Open follow-up PR for real fix.

## Test plan
- [ ] Deploy lands (Cloud Run revision).
- [ ] Owner triggers 1 Nai chat that mentions a phone.
- [ ] `[ToolCall]` line appears in logs with args + result.
- [ ] `[FinalReply]` line appears in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)