### PR TITLE
debug(auto-reply): log silent skip paths to pin shouldAutoReply behavior

### DIFF
--- a/apps/api/src/modules/chat-engine/services/message-router.service.ts
+++ b/apps/api/src/modules/chat-engine/services/message-router.service.ts
@@ -155,6 +155,9 @@ export class MessageRouterService {
         .map((s) => s.trim())
         .filter(Boolean);
       if (!whitelist.includes(message.externalUserId ?? '')) {
+        this.logger.log(
+          `[FbBotKillSwitch] room=${room.id} psid=${message.externalUserId} not in whitelist=${JSON.stringify(whitelist)} — skipped`,
+        );
         return;
       }
     }

--- a/apps/api/src/modules/sales-bot/sales-bot.service.ts
+++ b/apps/api/src/modules/sales-bot/sales-bot.service.ts
@@ -116,6 +116,9 @@ export class SalesBotService {
       modelUsed = resp.modelName;
 
       if (resp.toolCalls.length === 0) {
+        this.logger.log(
+          `[FinalReply] room=${input.roomId} hop=${hop} toolsUsed=${JSON.stringify(toolsUsed)} reply=${JSON.stringify(resp.text).slice(0, 400)}`,
+        );
         return {
           reply: resp.text,
           confidence: this.estimateConfidence(resp.text, toolsUsed),
@@ -132,6 +135,9 @@ export class SalesBotService {
       for (const tc of resp.toolCalls) {
         toolsUsed.push(tc.name);
         const result = await this.runTool(tc.name, tc.input, input.roomId);
+        this.logger.log(
+          `[ToolCall] room=${input.roomId} tool=${tc.name} args=${JSON.stringify(tc.input).slice(0, 300)} result=${JSON.stringify(result).slice(0, 600)}`,
+        );
         toolResults.push({
           role: 'tool',
           toolCallId: tc.id,

--- a/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.ts
+++ b/apps/api/src/modules/staff-chat/services/ai-auto-reply.service.ts
@@ -32,27 +32,48 @@ export class AiAutoReplyService {
 
   async shouldAutoReply(session: any): Promise<boolean> {
     // Blocker fixes: respect take-over + handoff signals
-    if (session.aiPaused) return false;
-    if (session.handoffMode) return false;
+    if (session.aiPaused) {
+      this.logger.log(`[ShouldAutoReply] room=${session.id} skip=aiPaused`);
+      return false;
+    }
+    if (session.handoffMode) {
+      this.logger.log(`[ShouldAutoReply] room=${session.id} skip=handoffMode`);
+      return false;
+    }
 
     // Defense-in-depth: skip channels whose adapter is stub (TikTok)
     // Even if aiAutoChannels misconfigured to include TIKTOK, prevent wasted Claude tokens.
     const STUB_CHANNELS = new Set(['TIKTOK']);
-    if (STUB_CHANNELS.has(session.channel)) return false;
+    if (STUB_CHANNELS.has(session.channel)) {
+      this.logger.log(`[ShouldAutoReply] room=${session.id} skip=stubChannel channel=${session.channel}`);
+      return false;
+    }
 
     const settings = await this.getSettings();
 
-    if (!settings.aiAutoEnabled) return false;
+    if (!settings.aiAutoEnabled) {
+      this.logger.log(`[ShouldAutoReply] room=${session.id} skip=aiAutoEnabled=false`);
+      return false;
+    }
 
     // Check channel allowlist
-    if (settings.aiAutoChannels.length > 0 && !settings.aiAutoChannels.includes(session.channel))
+    if (settings.aiAutoChannels.length > 0 && !settings.aiAutoChannels.includes(session.channel)) {
+      this.logger.log(
+        `[ShouldAutoReply] room=${session.id} skip=channelNotInAllowlist channel=${session.channel} allowlist=${JSON.stringify(settings.aiAutoChannels)}`,
+      );
       return false;
+    }
 
     // Check per-room reply cap
     const sentCount = await this.prisma.aiAutoReplyLog.count({
       where: { roomId: session.id, autoSent: true },
     });
-    if (sentCount >= settings.aiAutoMaxRepliesPerSession) return false;
+    if (sentCount >= settings.aiAutoMaxRepliesPerSession) {
+      this.logger.log(
+        `[ShouldAutoReply] room=${session.id} skip=capHit sentCount=${sentCount} cap=${settings.aiAutoMaxRepliesPerSession}`,
+      );
+      return false;
+    }
 
     // Fail-loud guard: SHOP channels require central branch + promptpay configured
     const SHOP_CHANNELS = new Set(['LINE_SHOP', 'FACEBOOK', 'WEB']);
@@ -68,6 +89,7 @@ export class AiAutoReplyService {
       }
     }
 
+    this.logger.log(`[ShouldAutoReply] room=${session.id} pass channel=${session.channel}`);
     return true;
   }
 


### PR DESCRIPTION
## Why
PR #1065 added [ToolCall]/[FinalReply] instrumentation. Nai retest at 15:43 UTC produced 1 FB inbound msg — but those logs never fired. SalesBot was never reached.

Every silent-skip path in `shouldAutoReply()` returns `false` with no log, and the FB kill switch returns from `routeInbound` even earlier. We cannot tell which gate caused it.

## What
One log per silent skip path:
- `[ShouldAutoReply] skip=aiPaused | handoffMode | stubChannel | aiAutoEnabled=false | channelNotInAllowlist | capHit | pass`
- `[FbBotKillSwitch] psid=… not in whitelist`

Together with PR #1065's `[ToolCall]/[FinalReply]`, next Nai retest will deterministically pin either:
- the skip cause (we fix config), or
- the actual tool args + result (we confirm H3 vs H4 + ship real fix)

## Test plan
- [ ] Deploy lands.
- [ ] Owner triggers 1 Nai FB chat.
- [ ] Logs contain one of: `[FbBotKillSwitch]` or `[ShouldAutoReply]` (skip-X or pass) — never silent.
- [ ] If `pass`, `[ToolCall]` + `[FinalReply]` follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)