### PR TITLE
fix(sales-bot): grounding guard blocks LLM hallucinated prices

### DIFF
--- a/apps/api/src/modules/sales-bot/sales-bot.service.spec.ts
+++ b/apps/api/src/modules/sales-bot/sales-bot.service.spec.ts
@@ -207,4 +207,97 @@ describe('SalesBotService', () => {
       expect(c).toBe(0.3);
     });
   });
+
+  // Regression coverage for the 2026-05-21 Nai 7,000 hallucination: Gemini 2.5
+  // ignored anti-hallucinate persona rules in PR #1064 and reported "iPhone 15
+  // 7,000 บาท" though the tool returned only iPhone 13/16 at 14,691/17,000.
+  // The guard catches this without depending on model behaviour.
+  it('blocks reply with hallucinated price not seen in any tool result', async () => {
+    const chat = jest
+      .fn()
+      .mockResolvedValueOnce({
+        text: '',
+        toolCalls: [
+          { id: 'tu_1', name: 'search_products', input: { query: 'iPhone' } },
+        ],
+        inputTokens: 100,
+        outputTokens: 10,
+        modelName: 'gemini-2.5-flash',
+      } satisfies LlmChatResponse)
+      .mockResolvedValueOnce({
+        // Hallucinated reply: tool only returned 14,691 + 17,000.
+        text: 'iPhone 15 ราคาเริ่มต้น 7,000 บาทค่ะ',
+        toolCalls: [],
+        inputTokens: 120,
+        outputTokens: 25,
+        modelName: 'gemini-2.5-flash',
+      } satisfies LlmChatResponse);
+    const { svc, searchProducts } = await build(chat);
+    searchProducts.run.mockResolvedValue({
+      products: [
+        { id: 'p1', name: 'iPhone 13', priceThb: 14691 },
+        { id: 'p2', name: 'iPhone 16', priceThb: 17000 },
+      ],
+    });
+    const result = await svc.generateReply({
+      text: 'iPhone 15 มีไหม',
+      roomId: 'r1',
+      customerId: null,
+    });
+    // Should NOT auto-send the hallucinated reply — force handoff instead.
+    expect(result.reply).not.toContain('7,000');
+    expect(result.reply).toContain('staff');
+    expect(result.confidence).toBeLessThanOrEqual(0.3);
+  });
+
+  it('accepts reply citing a price within ±5% of a grounded tool result', async () => {
+    const chat = jest
+      .fn()
+      .mockResolvedValueOnce({
+        text: '',
+        toolCalls: [
+          { id: 'tu_1', name: 'search_products', input: { query: 'iPhone' } },
+        ],
+        inputTokens: 100,
+        outputTokens: 10,
+        modelName: 'claude-sonnet-4-6',
+      } satisfies LlmChatResponse)
+      .mockResolvedValueOnce({
+        // Tool returned 14,691; reply says 14,700 (rounded) — within 5% tolerance.
+        text: 'iPhone 13 ราคาเริ่มต้น 14,700 บาทค่ะ',
+        toolCalls: [],
+        inputTokens: 120,
+        outputTokens: 25,
+        modelName: 'claude-sonnet-4-6',
+      } satisfies LlmChatResponse);
+    const { svc, searchProducts } = await build(chat);
+    searchProducts.run.mockResolvedValue({
+      products: [{ id: 'p1', name: 'iPhone 13', priceThb: 14691 }],
+    });
+    const result = await svc.generateReply({
+      text: 'iPhone 13 ราคา',
+      roomId: 'r1',
+      customerId: null,
+    });
+    expect(result.reply).toContain('14,700');
+    expect(result.confidence).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('passes reply without any price mention even if no tools used', async () => {
+    const chat = jest.fn().mockResolvedValue({
+      text: 'สวัสดีค่ะ สนใจรุ่นไหนเป็นพิเศษคะ',
+      toolCalls: [],
+      inputTokens: 80,
+      outputTokens: 18,
+      modelName: 'claude-sonnet-4-6',
+    } satisfies LlmChatResponse);
+    const { svc } = await build(chat);
+    const result = await svc.generateReply({
+      text: 'สวัสดี',
+      roomId: 'r1',
+      customerId: null,
+    });
+    expect(result.reply).toContain('สวัสดี');
+    expect(result.confidence).toBeGreaterThanOrEqual(0.8);
+  });
 });

--- a/apps/api/src/modules/sales-bot/sales-bot.service.ts
+++ b/apps/api/src/modules/sales-bot/sales-bot.service.ts
@@ -101,6 +101,11 @@ export class SalesBotService {
     // time anyway.
     const systemPrompt = await this.persona.getBot();
     const toolsUsed: string[] = [];
+    // Grounding ledger: every priceThb the model has seen via tool results
+    // this session. Used by guardGrounding() to catch hallucinated prices
+    // (e.g. Gemini 2.5 ignored PR #1064 anti-hallucinate rules and replied
+    // "iPhone 15 7,000" though tool returned only iPhone 13/16 at 14,691/17,000).
+    const groundedPrices = new Set<number>();
     let totalIn = 0;
     let totalOut = 0;
     let modelUsed = '';
@@ -119,6 +124,20 @@ export class SalesBotService {
         this.logger.log(
           `[FinalReply] room=${input.roomId} hop=${hop} toolsUsed=${JSON.stringify(toolsUsed)} reply=${JSON.stringify(resp.text).slice(0, 400)}`,
         );
+        const grounding = this.guardGrounding(resp.text, groundedPrices);
+        if (!grounding.ok) {
+          this.logger.warn(
+            `[GroundingGuard] room=${input.roomId} HALLUCINATION_BLOCKED reason=${grounding.reason} reply=${JSON.stringify(resp.text).slice(0, 200)} grounded=${JSON.stringify([...groundedPrices])}`,
+          );
+          return {
+            reply: 'ขออนุญาตให้พี่ staff เช็คข้อมูลเพิ่มเติมสักครู่นะคะ',
+            confidence: 0.3,
+            toolsUsed,
+            inputTokens: totalIn,
+            outputTokens: totalOut,
+            modelUsed,
+          };
+        }
         return {
           reply: resp.text,
           confidence: this.estimateConfidence(resp.text, toolsUsed),
@@ -135,6 +154,7 @@ export class SalesBotService {
       for (const tc of resp.toolCalls) {
         toolsUsed.push(tc.name);
         const result = await this.runTool(tc.name, tc.input, input.roomId);
+        this.collectGroundedPrices(result, groundedPrices);
         this.logger.log(
           `[ToolCall] room=${input.roomId} tool=${tc.name} args=${JSON.stringify(tc.input).slice(0, 300)} result=${JSON.stringify(result).slice(0, 600)}`,
         );
@@ -212,5 +232,64 @@ export class SalesBotService {
     if (reply.trim().length < 20) return 0.6;
     if (toolsUsed.length > 0) return 0.95;
     return 0.9;
+  }
+
+  // Walk a tool result and collect every `priceThb` / `monthly` / `minPrice`
+  // numeric field. The model can name any of these as a "price" in its reply,
+  // so all three are valid grounding sources. We accept Decimal/string/number
+  // and coerce to Number — Decimal serialised across the LlmProvider boundary.
+  private collectGroundedPrices(value: unknown, into: Set<number>): void {
+    if (value == null) return;
+    if (Array.isArray(value)) {
+      for (const v of value) this.collectGroundedPrices(v, into);
+      return;
+    }
+    if (typeof value === 'object') {
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        if (
+          (k === 'priceThb' || k === 'monthly' || k === 'minPrice' || k === 'maxPrice') &&
+          v != null
+        ) {
+          const n = Number(v);
+          if (Number.isFinite(n) && n > 0) into.add(n);
+        }
+        this.collectGroundedPrices(v, into);
+      }
+    }
+  }
+
+  // Cheap programmatic grounding guard. After Gemini 2.5 ignored the
+  // anti-hallucinate persona rules in PR #1064 and replied "iPhone 15 7,000"
+  // though tool only returned iPhone 13 (14,691) + iPhone 16 (17,000), we
+  // need a deterministic backstop independent of model behaviour.
+  //
+  // Rule: every "<number> บาท|฿|baht" mention in the final reply must match
+  // (±5%) at least one price the model saw via a tool result this session.
+  // Sub-1000 numbers are skipped (could be late fee / interest rate / day
+  // count / etc — false-positive risk too high).
+  private guardGrounding(
+    reply: string,
+    grounded: Set<number>,
+  ): { ok: true } | { ok: false; reason: string } {
+    // Common Thai/English price suffix patterns
+    const priceRegex = /([\d][\d,]{2,})\s*(?:บาท|฿|baht|THB)/gi;
+    const matches = [...reply.matchAll(priceRegex)];
+    if (matches.length === 0) return { ok: true };
+
+    // If the bot mentions ANY price but no tool returned one, it cannot
+    // possibly be grounded — block.
+    if (grounded.size === 0) {
+      return { ok: false, reason: 'price-mentioned-no-tool-result' };
+    }
+
+    for (const m of matches) {
+      const num = Number(m[1].replace(/,/g, ''));
+      if (!Number.isFinite(num) || num < 1000) continue;
+      const closeMatch = [...grounded].some((g) => Math.abs(g - num) / g <= 0.05);
+      if (!closeMatch) {
+        return { ok: false, reason: `unmatched-price=${num}` };
+      }
+    }
+    return { ok: true };
   }
 }


### PR DESCRIPTION
## Root cause (Nai 7,000 bug — confirmed via debug-mantra disproof)

Gemini 2.5 Flash replied "iPhone 15 ราคาเริ่มต้น 7,000 บาท" though:
- shop-catalog (same query pattern as `search_products`) returns ONLY iPhone 13 (costPrice 14,691) and iPhone 16 (costPrice 17,000)
- No iPhone 15 exists in catalog
- No product with costPrice anywhere near 7,000

The PR #1064 anti-hallucinate persona rules were ignored by the model. Persona-level instructions are not a sufficient backstop against hallucination on a non-Claude provider. We need a deterministic programmatic check independent of model behaviour.

## Mechanism

1. Collect `priceThb` / `monthly` / `minPrice` / `maxPrice` from every tool result the model sees this session → `groundedPrices: Set<number>`
2. After the model returns its final text, scan it for `<number> บาท|฿|baht|THB` patterns
3. Every mention ≥1000 must match (±5%) at least one grounded price
4. If not → replace reply with standard handoff message + `confidence=0.3` (which `AiAutoReplyService.autoReply()` already treats as low-confidence handoff via `aiAutoConfidenceThreshold`)
5. Log `[GroundingGuard] HALLUCINATION_BLOCKED reason=…` for ongoing monitoring

Sub-1000 numbers skipped (late fees, interest %, day counts, etc — false-positive risk).
5% tolerance accommodates natural rounding ("14,691" tool → "14,700" reply).

## Behaviour vs existing PR #1064 anti-hallucinate persona

Persona rules and grounding guard are **defense in depth**:
- Persona: tells model to handoff when data missing — soft constraint, model can ignore (observed)
- Guard: replaces output AFTER generation — hard constraint, runs server-side

Both stay.

## Test plan
- [x] 11/11 specs pass — 3 new + 8 existing
- [x] Regression: simulate Nai scenario — tool returns iPhone 13/16 at 14,691/17,000, model replies "iPhone 15 7,000" → reply replaced with handoff, confidence=0.3
- [x] Positive: tool returns 14,691, model replies 14,700 (rounded) → passes (±5% tolerance)
- [x] No-price reply (greeting) → passes
- [ ] After merge: Nai retest in prod → verify [GroundingGuard] log appears if model still hallucinates, OR reply mentions correct grounded prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)