### PR TITLE
fix(sales-bot): search_products returns priceMissing flag instead of dropping product

### DIFF
--- a/apps/api/src/modules/sales-bot/tools/search-products.tool.ts
+++ b/apps/api/src/modules/sales-bot/tools/search-products.tool.ts
@@ -53,28 +53,39 @@ export class SearchProductsTool {
       orderBy: { createdAt: 'desc' },
     });
 
-    // Use the default ProductPrice (selling price). Products without a
-    // default price configured are SKIPPED from results — they cannot be
-    // quoted to a customer and the bot must not invent a price.
-    let products = rows
-      .map((r) => {
-        const price = r.prices[0]?.amount;
-        if (price == null) return null;
-        return {
-          id: r.id,
-          name: r.name,
-          brand: r.brand,
-          model: r.model,
-          priceThb: Number(price),
-          condition: r.conditionGrade ?? 'NEW',
-        };
-      })
-      .filter((p): p is NonNullable<typeof p> => p !== null);
+    // Use the default ProductPrice (selling price) when available. Products
+    // without a default ProductPrice row come back with `priceMissing: true`
+    // and NO priceThb field — the persona's "no-data → handoff" rule then
+    // takes over instead of the bot inventing a price. (Earlier draft of
+    // this fix dropped them silently — too aggressive when owner hasn't
+    // backfilled ProductPrice rows yet, would have nuked all bot quotes.)
+    type Hit =
+      | { id: string; name: string; brand: string; model: string; condition: string; priceThb: number }
+      | { id: string; name: string; brand: string; model: string; condition: string; priceMissing: true };
+
+    let products: Hit[] = rows.map((r): Hit => {
+      const base = {
+        id: r.id,
+        name: r.name,
+        brand: r.brand,
+        model: r.model,
+        condition: r.conditionGrade ?? 'NEW',
+      };
+      const price = r.prices[0]?.amount;
+      if (price == null) return { ...base, priceMissing: true };
+      return { ...base, priceThb: Number(price) };
+    });
 
     if (input.maxPriceThb !== undefined) {
-      products = products.filter((p) => p.priceThb <= input.maxPriceThb!);
+      const cap = input.maxPriceThb;
+      products = products.filter((p) => !('priceThb' in p) || p.priceThb <= cap);
     }
-    products.sort((a, b) => a.priceThb - b.priceThb);
+    // Sort: priced items by price ascending, missing-price items at the end.
+    products.sort((a, b) => {
+      const aP = 'priceThb' in a ? a.priceThb : Number.MAX_SAFE_INTEGER;
+      const bP = 'priceThb' in b ? b.priceThb : Number.MAX_SAFE_INTEGER;
+      return aP - bP;
+    });
     return { products: products.slice(0, 5) };
   }
 }


### PR DESCRIPTION
## Why

PR #1068 (just merged) introduced aggressive skip of products without a default ProductPrice row. Per mantra disproof step: I did NOT verify owner has populated ProductPrice for in-stock products. If owner hasn't (legacy POS flow only sets costPrice), PR #1068 makes search_products return [] for every query → bot handoffs on every chat → quality regression to 0%.

Owner picked Option A — soften.

## What

- Product **with** default ProductPrice → returned with `priceThb`.
- Product **without** default ProductPrice → returned with `priceMissing: true` (no `priceThb` field).
- Persona PR #1064 "no-data → handoff" rule handles the missing-price case → bot doesn't quote, gracefully handoffs.
- calculate_installment keeps strict `price_not_configured` error (quote with no price = meaningless).
- Sort: priced items by price asc, missing-price items at end.

## Verification on next Nai retest

Two diagnostic outcomes:
- If `[ToolCall]` log shows products with `priceMissing: true` → owner needs to populate ProductPrice for stock. Bot will safely handoff in meantime.
- If `[ToolCall]` log shows products with sensible `priceThb` → fix works, bot quotes selling price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)