### PR TITLE
fix(menu): stop bogus access-denied toast for OWNER on / Dashboard

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.15",
+  "version": "26.5.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -25,6 +25,12 @@ const SIDEBAR_COLLAPSED_W = 70;  // px
 const ZONE_LOOKUP_ORDER: Zone[] = ['shop', 'fin', 'settings'];
 const ALL_ROLES = ['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES', 'ACCOUNTANT'];
 
+/** Paths shared across every authenticated role — never treat as access-denied
+ * even if a role's menu config forgets to list them. Defense-in-depth against
+ * the bug pattern where a role omits a universal route (e.g. `/`) and the
+ * auto-zone resolver bogusly fires the "no permission" toast. */
+const COMMON_PATHS = new Set<string>(['/']);
+
 /**
  * Find which zone a path belongs to across the role's accessible zones.
  * Returns null if the path isn't in any of the role's zones (caller decides
@@ -108,6 +114,10 @@ function MainContent() {
     if (targetZone === null) {
       // Path is not in THIS role's sidebar — check if it's in any other role's
       // sidebar; if yes, it's an access-denied case; if no, it's a "common" route.
+      // COMMON_PATHS short-circuits the check for universally-accessible routes
+      // (e.g. `/` Dashboard) to prevent bogus access-denied toasts when a role's
+      // menu config omits them.
+      if (COMMON_PATHS.has(pathname)) return;
       const anyRoleHasIt = ALL_ROLES.some(
         (r) => r !== role && resolveZoneForPath(r, pathname) !== null
       );

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -507,6 +507,7 @@ const OWNER_CONFIG: RoleMenuConfig = {
       icon: Home,
       zone: 'fin',
       items: [
+        { label: 'Dashboard', path: '/', icon: Home },
         { label: 'Finance Overview', path: '/finance-portfolio', icon: CircleDollarSign },
       ],
     },


### PR DESCRIPTION
## Summary

Cherry-pick of `0c0bdf06` from the unmerged `feat/ai-menu-separate` branch — this fix has not yet shipped to main.

**Bug:** OWNER on \`/\` (Dashboard) sees toast "คุณไม่มีสิทธิ์เข้าถึงหน้านี้" — the auto-zone resolver in MainLayout treated \`/\` as "path in another role's sidebar but not mine" because OWNER's owner-overview section listed only \`/finance-portfolio\`.

Confirmed visible in prod after PR #1071 deploy (revision running v26.5.15+59f591f). Not caused by #1071 — bug existed on main before.

Web version 26.5.15 → 26.5.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)