### PR TITLE
fix(menu): dedupe OWNER FIN — overdue/mdm/repo only in ติดตามหนี้

### DIFF
--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -578,9 +578,6 @@ const OWNER_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
-        { label: 'ติดตามลูกค้าค้างชำระ', path: '/overdue', icon: AlertTriangle },
-        { label: 'ล็อคเครื่อง (MDM)', path: '/mdm', icon: Lock },
-        { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
         // CSV §2 placeholder — owner-flagged ✏ "ต้องสร้าง"
         { label: 'เอกสารยกเลิกสัญญา', path: '/finance/contract-cancellation', icon: FileText },
         { label: 'รายได้อื่น', path: '/other-income', icon: TrendingUp },


### PR DESCRIPTION
## Summary

OWNER ในโซน FINANCE เห็น 3 รายการซ้ำระหว่าง section **ติดตามหนี้** กับ **รายรับ**:

| ติดตามหนี้ | รายรับ (ซ้ำ) | path |
|-----------|-------------|------|
| ติดตามหนี้ | ติดตามลูกค้าค้างชำระ | \`/overdue\` |
| ยึดคืนเครื่อง | ยึดคืนเครื่อง | \`/repossessions\` |
| จัดการอุปกรณ์ | ล็อคเครื่อง (MDM) | \`/mdm\` |

ลบออกจาก **รายรับ** (collection workflow อยู่ที่ ติดตามหนี้ ครบแล้ว). **รายรับ** เหลือเฉพาะ revenue-recording: รับชำระค่างวด / เอกสารยกเลิกสัญญา / รายได้อื่น

## Test plan
- [ ] Login OWNER → FIN zone → sidebar ไม่เห็น "ติดตามลูกค้าค้างชำระ", "ยึดคืนเครื่อง", "ล็อคเครื่อง (MDM)" ใต้ "รายรับ"
- [ ] section "ติดตามหนี้" ยังครบ 3 รายการ (ติดตามหนี้, ยึดคืนเครื่อง, จัดการอุปกรณ์)
- [ ] section "รายรับ" เหลือ 3 รายการ (รับชำระค่างวด, เอกสารยกเลิกสัญญา, รายได้อื่น)

🤖 Generated with [Claude Code](https://claude.com/claude-code)