### PR TITLE
fix(menu): merge OWNER ติดตามหนี้ into รายรับ (no more dup section)

### DIFF
--- a/apps/web/src/config/menu.test.ts
+++ b/apps/web/src/config/menu.test.ts
@@ -88,7 +88,7 @@ describe('getSidebarForRole — populated ZONE_CONFIG', () => {
     const keys = getSidebarForRole('OWNER', 'fin').map((s) => s.key);
     // Union of all FIN zone sections (SP5 + P4 SP1-5)
     expect(keys).toContain('owner-overview');
-    expect(keys).toContain('owner-fin-collection');
+    // owner-fin-collection removed — collection links merged into owner-fin-revenue
     expect(keys).toContain('owner-fin-revenue');
     expect(keys).toContain('owner-fin-expense');
     expect(keys).toContain('owner-tax');

--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -510,17 +510,6 @@ const OWNER_CONFIG: RoleMenuConfig = {
       ],
     },
     {
-      key: 'owner-fin-collection',
-      label: 'ติดตามหนี้',
-      icon: AlertTriangle,
-      zone: 'fin',
-      items: [
-        { label: 'ติดตามหนี้', path: '/overdue', icon: AlertTriangle },
-        { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
-        { label: 'จัดการอุปกรณ์', path: '/mdm', icon: Smartphone },
-      ],
-    },
-    {
       key: 'owner-inventory',
       label: 'คลัง & จัดซื้อ',
       icon: Warehouse,
@@ -578,6 +567,9 @@ const OWNER_CONFIG: RoleMenuConfig = {
       zone: 'fin',
       items: [
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
+        { label: 'ติดตามลูกค้าค้างชำระ', path: '/overdue', icon: AlertTriangle },
+        { label: 'ล็อคเครื่อง (MDM)', path: '/mdm', icon: Lock },
+        { label: 'ยึดคืนเครื่อง', path: '/repossessions', icon: Lock },
         // CSV §2 placeholder — owner-flagged ✏ "ต้องสร้าง"
         { label: 'เอกสารยกเลิกสัญญา', path: '/finance/contract-cancellation', icon: FileText },
         { label: 'รายได้อื่น', path: '/other-income', icon: TrendingUp },


### PR DESCRIPTION
## Summary

ตามคำสั่งเจ้าของ — เอา section "ติดตามหนี้" ของ OWNER ออก, ย้าย 3 รายการเข้า "รายรับ" แทน

ก่อน:
- ติดตามหนี้ — ติดตามหนี้ / ยึดคืนเครื่อง / จัดการอุปกรณ์
- รายรับ — รับชำระค่างวด / เอกสารยกเลิกสัญญา / รายได้อื่น

หลัง:
- (ลบ section ติดตามหนี้)
- รายรับ — รับชำระค่างวด / **ติดตามลูกค้าค้างชำระ / ล็อคเครื่อง (MDM) / ยึดคืนเครื่อง** / เอกสารยกเลิกสัญญา / รายได้อื่น

หมายเหตุ: รายการ collection ยังอยู่ใต้เมนู FM/ACC sidebar เหมือนเดิม (คนละ config) — change นี้กระทบเฉพาะ OWNER

## Test plan
- [ ] Login OWNER → FIN zone → sidebar ไม่มี section "ติดตามหนี้" แล้ว
- [ ] section "รายรับ" มี 6 รายการตามลำดับใหม่
- [ ] รายการ /overdue, /mdm, /repossessions เข้าถึงผ่าน "รายรับ" ได้ปกติ

🤖 Generated with [Claude Code](https://claude.com/claude-code)