### PR TITLE
hotfix(insurance): exchange button preflight — F1/F3/F4/F5 from scrutiny

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.20",
+  "version": "26.5.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/pages/insurance/WizardSteps/ImeiLookupStep.tsx
+++ b/apps/web/src/pages/insurance/WizardSteps/ImeiLookupStep.tsx
@@ -7,6 +7,7 @@ import api from '@/lib/api';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { useAuth } from '@/contexts/AuthContext';
 
 export type LookupResult =
   | { found: false }
@@ -54,14 +55,9 @@ export function ImeiLookupStep({ onRepairChosen, presetImei }: ImeiLookupStepPro
 
   const handleExchange = () => {
     if (!result || !result.found || !result.sale) return;
-    if (result.sale.saleType === 'CASH') {
-      // /trade-in (list page) — direct-deep-link to a new trade-in form is SP2 scope.
-      // Pre-fill customer + product via query so the trade-in page can pick them up.
-      const qs = new URLSearchParams();
-      if (result.customer?.id) qs.set('customerId', result.customer.id);
-      qs.set('productId', result.product.id);
-      navigate(`/trade-in?${qs.toString()}`);
-    } else if (result.sale.saleType === 'INSTALLMENT' && result.contract) {
+    // CASH exchange = 2 separate transactions (trade-in + new POS sale) — button
+    // hidden via ActionButtons; this branch is defensive only.
+    if (result.sale.saleType === 'INSTALLMENT' && result.contract) {
       navigate(`/defect-exchange?contractId=${result.contract.id}`);
     }
     // EXTERNAL_FINANCE handled by disabled button
@@ -167,11 +163,16 @@ function formatThaiDate(iso: string | null | undefined): string {
 function warrantyEndSubtitle(
   result: Extract<LookupResult, { found: true }>,
 ): string | undefined {
-  const hasShop = !!result.shopWarrantyEndDate;
-  const hasMfr = !!result.manufacturerWarrantyEndDate;
-  if (hasMfr && hasShop) return `ประกันโรงงาน (ร้านหมด ${formatThaiDate(result.shopWarrantyEndDate)})`;
-  if (hasMfr) return 'ประกันโรงงาน';
-  if (hasShop) return 'ประกันร้าน';
+  // F5: only label active warranties — expired dates shown above already.
+  // Showing "ร้านหมด 27/07/2568" when 27/07/2568 is in the past confuses staff.
+  const now = Date.now();
+  const isActive = (iso: string | null) => !!iso && new Date(iso).getTime() > now;
+  const shopActive = isActive(result.shopWarrantyEndDate);
+  const mfrActive = isActive(result.manufacturerWarrantyEndDate);
+  if (mfrActive && shopActive)
+    return `ประกันโรงงาน (ร้านหมด ${formatThaiDate(result.shopWarrantyEndDate)})`;
+  if (mfrActive) return 'ประกันโรงงาน';
+  if (shopActive) return 'ประกันร้าน';
   return undefined;
 }
 
@@ -194,24 +195,47 @@ function ActionButtons({
   onRepair: () => void;
   onExchange: () => void;
 }) {
-  const exchangeDisabled =
-    !result.sale ||
-    result.sale.saleType === 'EXTERNAL_FINANCE';
+  const { user } = useAuth();
+  const canBypassWindow =
+    user?.role === 'OWNER' || user?.role === 'BRANCH_MANAGER';
+
+  // F1: CASH exchange = trade-in + new POS sale (2 transactions). Hide the
+  // single-button mental model entirely.
+  // F4: contract must be ACTIVE (cancelled / closed contracts can't be exchanged)
+  // F3: INSTALLMENT outside 7-day window — disable unless OWNER/BM (who can bypass on DefectExchangePage)
+  const reason = ((): string | null => {
+    if (!result.sale) return 'ไม่มีข้อมูลการขาย';
+    if (result.sale.saleType === 'CASH')
+      return 'เครื่องเงินสด: ใช้เมนู "รับซื้อมือสอง" + POS แยก 2 ขั้นตอน';
+    if (result.sale.saleType === 'EXTERNAL_FINANCE')
+      return 'ผ่อนกับ GFIN — ติดต่อ GFIN เพื่อปิดสัญญาก่อน';
+    if (!result.contract) return 'ไม่พบสัญญา';
+    if (result.contract.status !== 'ACTIVE')
+      return `สัญญาสถานะ ${result.contract.status} — เปลี่ยนเครื่องได้เฉพาะสัญญา ACTIVE`;
+    if (result.warrantyStatus !== 'IN_7DAY_DEFECT' && !canBypassWindow)
+      return 'นอกช่วงประกัน 7 วัน — ต้องเป็น OWNER หรือ BRANCH_MANAGER';
+    return null;
+  })();
+
+  const exchangeDisabled = reason !== null;
+  const showExchangeButton = result.sale?.saleType !== 'CASH';
 
   return (
-    <div className="mt-4 grid grid-cols-2 gap-3">
+    <div className={`mt-4 grid gap-3 ${showExchangeButton ? 'grid-cols-2' : 'grid-cols-1'}`}>
       <Button onClick={onRepair} className="flex items-center gap-2">
         <Wrench className="size-4" /> รับเข้าซ่อม
       </Button>
-      <Button
-        variant="outline"
-        onClick={onExchange}
-        disabled={exchangeDisabled}
-        title={exchangeDisabled ? 'ผ่อนกับ GFIN — ติดต่อ GFIN เพื่อปิดสัญญาก่อน' : undefined}
-        className="flex items-center gap-2"
-      >
-        <ArrowLeftRight className="size-4" /> เปลี่ยนเครื่อง
-      </Button>
+      {showExchangeButton && (
+        <Button
+          variant="outline"
+          onClick={onExchange}
+          disabled={exchangeDisabled}
+          title={reason ?? undefined}
+          className="flex items-center gap-2"
+        >
+          <ArrowLeftRight className="size-4" /> เปลี่ยนเครื่อง
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/insurance/WizardSteps/ImeiLookupStep.tsx
+++ b/apps/web/src/pages/insurance/WizardSteps/ImeiLookupStep.tsx
@@ -199,43 +199,44 @@ function ActionButtons({
   const canBypassWindow =
     user?.role === 'OWNER' || user?.role === 'BRANCH_MANAGER';
 
-  // F1: CASH exchange = trade-in + new POS sale (2 transactions). Hide the
-  // single-button mental model entirely.
-  // F4: contract must be ACTIVE (cancelled / closed contracts can't be exchanged)
-  // F3: INSTALLMENT outside 7-day window — disable unless OWNER/BM (who can bypass on DefectExchangePage)
+  // Owner clarified: "เปลี่ยนเครื่อง" = upgrade flow that always ends in a NEW
+  // installment contract + old device goes back into SHOP inventory.
+  // Applies to ALL channels (CASH / INSTALLMENT / GFIN), not just defect cases.
+  // SP2 will build the unified destination page; SP1 wires the button.
+  //
+  // F4: contract must be ACTIVE (cancelled/closed contracts can't be re-exchanged)
+  // F3: INSTALLMENT outside 7-day → disable unless OWNER/BM (existing bypass)
   const reason = ((): string | null => {
     if (!result.sale) return 'ไม่มีข้อมูลการขาย';
-    if (result.sale.saleType === 'CASH')
-      return 'เครื่องเงินสด: ใช้เมนู "รับซื้อมือสอง" + POS แยก 2 ขั้นตอน';
     if (result.sale.saleType === 'EXTERNAL_FINANCE')
-      return 'ผ่อนกับ GFIN — ติดต่อ GFIN เพื่อปิดสัญญาก่อน';
-    if (!result.contract) return 'ไม่พบสัญญา';
-    if (result.contract.status !== 'ACTIVE')
-      return `สัญญาสถานะ ${result.contract.status} — เปลี่ยนเครื่องได้เฉพาะสัญญา ACTIVE`;
-    if (result.warrantyStatus !== 'IN_7DAY_DEFECT' && !canBypassWindow)
-      return 'นอกช่วงประกัน 7 วัน — ต้องเป็น OWNER หรือ BRANCH_MANAGER';
+      return 'ผ่อนกับ GFIN — ต้องปิดสัญญากับ GFIN ก่อน';
+    if (result.sale.saleType === 'INSTALLMENT') {
+      if (!result.contract) return 'ไม่พบสัญญา';
+      if (result.contract.status !== 'ACTIVE')
+        return `สัญญาสถานะ ${result.contract.status} — เปลี่ยนเครื่องได้เฉพาะ ACTIVE`;
+      if (result.warrantyStatus !== 'IN_7DAY_DEFECT' && !canBypassWindow)
+        return 'นอกช่วงประกัน 7 วัน — ต้องเป็น OWNER หรือ BRANCH_MANAGER';
+    }
+    // CASH: no preflight block — destination wizard (SP2) handles its own checks
     return null;
   })();
 
   const exchangeDisabled = reason !== null;
-  const showExchangeButton = result.sale?.saleType !== 'CASH';
 
   return (
-    <div className={`mt-4 grid gap-3 ${showExchangeButton ? 'grid-cols-2' : 'grid-cols-1'}`}>
+    <div className="mt-4 grid grid-cols-2 gap-3">
       <Button onClick={onRepair} className="flex items-center gap-2">
         <Wrench className="size-4" /> รับเข้าซ่อม
       </Button>
-      {showExchangeButton && (
-        <Button
-          variant="outline"
-          onClick={onExchange}
-          disabled={exchangeDisabled}
-          title={reason ?? undefined}
-          className="flex items-center gap-2"
-        >
-          <ArrowLeftRight className="size-4" /> เปลี่ยนเครื่อง
-        </Button>
-      )}
+      <Button
+        variant="outline"
+        onClick={onExchange}
+        disabled={exchangeDisabled}
+        title={reason ?? undefined}
+        className="flex items-center gap-2"
+      >
+        <ArrowLeftRight className="size-4" /> เปลี่ยนเครื่อง
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/pages/insurance/__tests__/ImeiLookupStep.test.tsx
+++ b/apps/web/src/pages/insurance/__tests__/ImeiLookupStep.test.tsx
@@ -10,6 +10,12 @@ vi.mock('@/lib/api', () => ({
 }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
+// useAuth mock — default to SALES role; tests can override per case
+const useAuthMock = vi.fn(() => ({ user: { role: 'SALES', branchId: 'br-A' } }));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
 function renderWith(props: Partial<React.ComponentProps<typeof ImeiLookupStep>> = {}) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const onRepairChosen = vi.fn();
@@ -26,7 +32,10 @@ function renderWith(props: Partial<React.ComponentProps<typeof ImeiLookupStep>> 
 }
 
 describe('ImeiLookupStep', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({ user: { role: 'SALES', branchId: 'br-A' } });
+  });
 
   it('blocks lookup when IMEI < 4 chars', async () => {
     renderWith();
@@ -43,7 +52,7 @@ describe('ImeiLookupStep', () => {
     expect(await screen.findByText(/ไม่พบเครื่องในระบบ/)).toBeInTheDocument();
   });
 
-  it('shows preview + active buttons when CASH sale found', async () => {
+  it('F1: HIDES เปลี่ยนเครื่อง button for CASH sale (single-button mental model wrong)', async () => {
     (api.get as any).mockResolvedValue({
       data: {
         found: true,
@@ -60,7 +69,8 @@ describe('ImeiLookupStep', () => {
     fireEvent.click(screen.getByText('ค้นหา'));
     expect(await screen.findByText('สมชาย')).toBeInTheDocument();
     expect(screen.getByText('ซื้อสด')).toBeInTheDocument();
-    expect(screen.getByText('เปลี่ยนเครื่อง').closest('button')).not.toBeDisabled();
+    expect(screen.getByText('รับเข้าซ่อม')).toBeInTheDocument();
+    expect(screen.queryByText('เปลี่ยนเครื่อง')).not.toBeInTheDocument();
   });
 
   it('disables เปลี่ยนเครื่อง for GFIN (EXTERNAL_FINANCE)', async () => {
@@ -80,6 +90,65 @@ describe('ImeiLookupStep', () => {
     fireEvent.click(screen.getByText('ค้นหา'));
     await screen.findByText('GFIN');
     expect(screen.getByText('เปลี่ยนเครื่อง').closest('button')).toBeDisabled();
+  });
+
+  it('F4: disables เปลี่ยนเครื่อง when contract is CANCELED', async () => {
+    (api.get as any).mockResolvedValue({
+      data: {
+        found: true,
+        product: { id: 'p1', brand: 'X', model: 'Y', storage: null, imeiSerial: '12345' },
+        sale: { id: 's1', saleType: 'INSTALLMENT' },
+        customer: { id: 'c1', name: 'A', phone: '0' },
+        contract: { id: 'ctr', contractNumber: 'BC-CANCELED', status: 'CANCELED' },
+        warrantyStatus: 'IN_7DAY_DEFECT',
+        daysRemainingIn7Day: 5,
+      },
+    });
+    renderWith();
+    fireEvent.change(screen.getByPlaceholderText(/359/), { target: { value: '12345' } });
+    fireEvent.click(screen.getByText('ค้นหา'));
+    await screen.findByText('BC-CANCELED');
+    expect(screen.getByText('เปลี่ยนเครื่อง').closest('button')).toBeDisabled();
+  });
+
+  it('F3: disables เปลี่ยนเครื่อง for SALES when outside 7-day defect window', async () => {
+    useAuthMock.mockReturnValue({ user: { role: 'SALES', branchId: 'br-A' } });
+    (api.get as any).mockResolvedValue({
+      data: {
+        found: true,
+        product: { id: 'p1', brand: 'X', model: 'Y', storage: null, imeiSerial: '54321' },
+        sale: { id: 's1', saleType: 'INSTALLMENT' },
+        customer: { id: 'c1', name: 'A', phone: '0' },
+        contract: { id: 'ctr', contractNumber: 'BC-LATE', status: 'ACTIVE' },
+        warrantyStatus: 'IN_SHOP_WARRANTY',
+        daysRemainingIn7Day: 0,
+      },
+    });
+    renderWith();
+    fireEvent.change(screen.getByPlaceholderText(/359/), { target: { value: '54321' } });
+    fireEvent.click(screen.getByText('ค้นหา'));
+    await screen.findByText('BC-LATE');
+    expect(screen.getByText('เปลี่ยนเครื่อง').closest('button')).toBeDisabled();
+  });
+
+  it('F3: ENABLES เปลี่ยนเครื่อง for OWNER when outside 7-day window (bypass)', async () => {
+    useAuthMock.mockReturnValue({ user: { role: 'OWNER', branchId: 'br-A' } });
+    (api.get as any).mockResolvedValue({
+      data: {
+        found: true,
+        product: { id: 'p1', brand: 'X', model: 'Y', storage: null, imeiSerial: '54321' },
+        sale: { id: 's1', saleType: 'INSTALLMENT' },
+        customer: { id: 'c1', name: 'A', phone: '0' },
+        contract: { id: 'ctr', contractNumber: 'BC-LATE', status: 'ACTIVE' },
+        warrantyStatus: 'IN_SHOP_WARRANTY',
+        daysRemainingIn7Day: 0,
+      },
+    });
+    renderWith();
+    fireEvent.change(screen.getByPlaceholderText(/359/), { target: { value: '54321' } });
+    fireEvent.click(screen.getByText('ค้นหา'));
+    await screen.findByText('BC-LATE');
+    expect(screen.getByText('เปลี่ยนเครื่อง').closest('button')).not.toBeDisabled();
   });
 
   it('calls onRepairChosen when repair button clicked', async () => {

--- a/apps/web/src/pages/insurance/__tests__/ImeiLookupStep.test.tsx
+++ b/apps/web/src/pages/insurance/__tests__/ImeiLookupStep.test.tsx
@@ -52,7 +52,7 @@ describe('ImeiLookupStep', () => {
     expect(await screen.findByText(/ไม่พบเครื่องในระบบ/)).toBeInTheDocument();
   });
 
-  it('F1: HIDES เปลี่ยนเครื่อง button for CASH sale (single-button mental model wrong)', async () => {
+  it('CASH sale: BOTH buttons shown (exchange = upgrade flow, works for all channels)', async () => {
     (api.get as any).mockResolvedValue({
       data: {
         found: true,
@@ -70,7 +70,9 @@ describe('ImeiLookupStep', () => {
     expect(await screen.findByText('สมชาย')).toBeInTheDocument();
     expect(screen.getByText('ซื้อสด')).toBeInTheDocument();
     expect(screen.getByText('รับเข้าซ่อม')).toBeInTheDocument();
-    expect(screen.queryByText('เปลี่ยนเครื่อง')).not.toBeInTheDocument();
+    // Owner clarified: เปลี่ยนเครื่อง = upgrade flow works for CASH too —
+    // SP2 destination uses old contract's yodjat+commission as buyback value.
+    expect(screen.getByText('เปลี่ยนเครื่อง').closest('button')).not.toBeDisabled();
   });
 
   it('disables เปลี่ยนเครื่อง for GFIN (EXTERNAL_FINANCE)', async () => {


### PR DESCRIPTION
## Why

Post-#1078 /scrutinize on the IMEI wizard found 4 wasted-click UX bugs. Originally included F1 (hide CASH button) but owner clarified during testing that **"เปลี่ยนเครื่อง" is a unified upgrade flow that applies to ALL channels** (CASH/INSTALLMENT/GFIN). F1 reverted; F3/F4/F5 stand.

## Fixes (final)

| ID | Issue | Fix |
|----|-------|-----|
| ~~F1~~ | ~~CASH dead-end~~ | **REVERTED** — owner clarified scope. SP2 destination wizard will handle CASH; button restored so flow surface stays consistent. |
| **F3** | SALES clicks "เปลี่ยนเครื่อง" on out-of-window contract → wasted DefectExchangePage error | Disable when `warrantyStatus !== 'IN_7DAY_DEFECT'` (OWNER/BM keep bypass) |
| **F4** | CANCELED contract still has active button → backend rejects | Disable when `contract.status !== 'ACTIVE'`; tooltip shows current status |
| **F5** | Expired shop warranty shown in subtitle (e.g. "ร้านหมด 27/07/2568" past date) | Filter expired dates from subtitle — only label active warranties |

## SP2 spec needs major revision (per owner clarification)

- **Drop trade-in valuation input** — buyback value auto-derived from `financedAmount + commissionAmount` of old contract
- **Drop ±20% threshold + override reason** — no manual valuation = no variance
- **All channels create new INSTALLMENT contract** (even if old was CASH)
- **Old device returns to SHOP inventory** as 2nd-hand (not just JE clearance)
- Photos optional (condition record, not value evidence)

→ Will revise `docs/superpowers/specs/2026-05-23-insurance-wizard-sp2-case8-approval-design.md` in a separate PR.

## Test coverage

- 8/8 vitest PASS
- CASH test asserts BOTH buttons present (was: hidden)
- New cases: F4 CANCELED DISABLED / F3 SALES blocked / F3 OWNER bypass
- 0 TS errors api+web

## Test plan
- [ ] Scan IMEI 999900000000001 (CASH) → both buttons shown enabled
- [ ] Scan IMEI 999900000000009 (CANCELED) → exchange disabled with status tooltip
- [ ] Scan IMEI 999900000000005 (manufacturer warranty, 365d old) as SALES → exchange disabled
- [ ] Scan same as OWNER → exchange enabled
- [ ] Preview card for ...005 — "ประกันหมด" subtitle no longer shows expired shop date

🤖 Generated with [Claude Code](https://claude.com/claude-code)