### PR TITLE
fix(defect-exchange): show preset contract in dropdown

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@installment/web",
-  "version": "26.5.21",
+  "version": "26.5.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/pages/DefectExchangePage.tsx
+++ b/apps/web/src/pages/DefectExchangePage.tsx
@@ -98,11 +98,17 @@ export default function DefectExchangePage(props?: DefectExchangePageProps) {
   const [showConfirm, setShowConfirm] = useState(false);
 
   const contractsQ = useQuery<ContractRow[]>({
-    queryKey: ['defect-exchange-contracts'],
+    queryKey: ['defect-exchange-contracts', presetContractId ?? null],
     queryFn: async () => {
       const { data } = await api.get('/contracts?status=ACTIVE&limit=200');
       const rows: ContractRow[] = data.data || [];
-      return rows.filter((c) => c.product.category === 'PHONE_USED');
+      // Always include the preset contract (even if PHONE_NEW / outside filter) so
+      // the user sees the contract they came from. Eligibility check below will
+      // surface any rule violations as readable reasons — better than an empty
+      // dropdown that gives no feedback.
+      return rows.filter(
+        (c) => c.product.category === 'PHONE_USED' || c.id === presetContractId,
+      );
     },
   });
 


### PR DESCRIPTION
## Bug

User clicked "เปลี่ยนเครื่อง" on INSTALLMENT IMEI ...007 → routed to /defect-exchange?contractId=sp1-ctr-shop-warr. Page showed:
- Dropdown "เลือกสัญญา" with empty value (no contract visible)
- Eligibility error: "เปลี่ยนเครื่องได้เฉพาะมือสอง (PHONE_USED)" + "พ้นกำหนด 7 วันแล้ว"

User: "มันต้องขึ้นสัญญา ของเครื่องที่เรากดมาเลย"

## Root cause

`DefectExchangePage` contracts query at [DefectExchangePage.tsx:100-107](apps/web/src/pages/DefectExchangePage.tsx#L100-L107) filters to PHONE_USED only. When user arrives with `?contractId=X` for a PHONE_NEW device, that contract is silently dropped from dropdown options → presetContractId state has the ID but no `<option>` matches → dropdown shows empty.

## Fix

Include the preset contract in dropdown options regardless of category filter:

```ts
rows.filter((c) => c.product.category === 'PHONE_USED' || c.id === presetContractId)
```

Eligibility check still shows readable reasons in pink box — user now sees both the contract they came from AND why it's not eligible for defect-exchange.

## Note

This is a transitional UX fix. SP2 ([PR #1080](https://github.com/iamnaii/BESTCHOICE/pull/1080)) will replace DefectExchangePage entirely with the unified upgrade flow that has no PHONE_USED / 7-day constraints.

## Test plan
- [ ] Scan IMEI 999900000000007 → click "เปลี่ยนเครื่อง" → /defect-exchange?contractId=sp1-ctr-shop-warr
- [ ] Dropdown now SHOWS "BC-2026-04-... ทดสอบ ประกันร้านอย่างเดียว" (was empty)
- [ ] Eligibility pink box still explains why exchange not allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)