### PR TITLE
fix(sp2): 3 blockers from PR #1085 review (#1086)

### DIFF
--- a/apps/api/src/modules/contract-exchange/contract-exchange.controller.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.controller.ts
@@ -14,7 +14,9 @@ export class ContractExchangeController {
   @Post()
   @Roles('SALES', 'BRANCH_MANAGER', 'OWNER')
   submit(@Body() dto: SubmitExchangeRequestDto, @Req() req: any) {
-    return this.svc.submit(dto, req.user.id);
+    // Pass the full user object — the service does an in-service branch check
+    // (issue #1086 item 2) and needs role + branchId, not just the id.
+    return this.svc.submit(dto, req.user);
   }
 
   @Get('pending')

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
@@ -252,6 +252,23 @@ describe('ContractExchangeService.approve', () => {
 
     await expect(service.approve('r1', 'u1')).rejects.toThrow(/จ่ายครบงวด/);
   });
+
+  // Issue #1086 item 5 — new contract must have downPayment=0
+  it('new contract is created with downPayment=0 even when old contract had a non-zero downPayment', async () => {
+    prisma.contractExchangeRequest.updateMany.mockResolvedValue({ count: 1 });
+    prisma.contractExchangeRequest.findUniqueOrThrow.mockResolvedValue({
+      id: 'r1', oldContractId: 'old', oldProductId: 'op', newProductId: 'np',
+      oldContract: makeOldContract(12, 4), // makeOldContract sets downPayment=4000
+    });
+    prisma.payment.count.mockResolvedValue(4);
+    prisma.contract.create.mockResolvedValue({ id: 'nc', contractNumber: 'EX' });
+
+    await service.approve('r1', 'u1');
+
+    const createData = prisma.contract.create.mock.calls[0][0].data;
+    // The new contract's downPayment must be a zero Decimal, not the old 4000.
+    expect(createData.downPayment.toString()).toBe('0');
+  });
 });
 
 describe('ContractExchangeService.reject', () => {

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
@@ -74,6 +74,27 @@ describe('ContractExchangeService.submit', () => {
     ).rejects.toThrow(/ราคา/);
   });
 
+  // Issue #1086 item 1 — silent same-price bypass when prices are null
+  it('BadRequestException when new product has BOTH sellingPrice and installmentPrice null (no silent same-price bypass)', async () => {
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.product.findUnique
+      .mockResolvedValueOnce({ id: 'op', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000', installmentPrice: '28000' })
+      .mockResolvedValueOnce({ id: 'np', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: null, installmentPrice: null, status: 'IN_STOCK' });
+    await expect(
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+    ).rejects.toThrow(/ราคาเครื่องไม่ถูกตั้งค่า/);
+  });
+
+  it('BadRequestException when OLD product has BOTH sellingPrice and installmentPrice null', async () => {
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.product.findUnique
+      .mockResolvedValueOnce({ id: 'op', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: null, installmentPrice: null })
+      .mockResolvedValueOnce({ id: 'np', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000', installmentPrice: '28000', status: 'IN_STOCK' });
+    await expect(
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+    ).rejects.toThrow(/ราคาเครื่องไม่ถูกตั้งค่า/);
+  });
+
   it('creates PENDING request when all checks pass', async () => {
     prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
     const same = { brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000' };

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
@@ -1,11 +1,18 @@
 import { Test } from '@nestjs/testing';
-import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ContractExchangeService } from './contract-exchange.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { ExchangeNewContract1ATemplate } from '../journal/cpa-templates/exchange-new-contract-1a.template';
 import { ExchangeCloseOld21_1106Template } from '../journal/cpa-templates/exchange-close-old-21-1106.template';
 import { ExchangeClearVendor21_1106Template } from '../journal/cpa-templates/exchange-clear-vendor-21-1106.template';
+
+// Default user shape used by submit() tests after Fix 2 (issue #1086 item 2).
+// SALES_BR1 matches the mock contract's branchId ('br-1') so legacy tests
+// pass the in-service branch check. Specific tests override as needed.
+const SALES_BR1 = { id: 'u-1', role: 'SALES', branchId: 'br-1' };
+const SALES_BR2 = { id: 'u-2', role: 'SALES', branchId: 'br-2' };
+const OWNER_USER = { id: 'owner-1', role: 'OWNER', branchId: null };
 
 describe('ContractExchangeService.submit', () => {
   let service: ContractExchangeService;
@@ -33,70 +40,93 @@ describe('ContractExchangeService.submit', () => {
   it('NotFoundException when old contract does not exist', async () => {
     prisma.contract.findUnique.mockResolvedValue(null);
     await expect(
-      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR1),
     ).rejects.toThrow(NotFoundException);
   });
 
   it('BadRequestException when old contract is not ACTIVE', async () => {
-    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'CANCELED', deletedAt: null });
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'CANCELED', deletedAt: null });
     await expect(
-      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR1),
     ).rejects.toThrow(BadRequestException);
   });
 
   it('BadRequestException when new product is not IN_STOCK', async () => {
-    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
     prisma.product.findUnique
       .mockResolvedValueOnce({ id: 'op', brand: 'A', model: 'X', storage: '256', sellingPrice: '28000', status: 'SOLD_INSTALLMENT' })
       .mockResolvedValueOnce({ id: 'np', brand: 'A', model: 'X', storage: '256', sellingPrice: '28000', status: 'SOLD_INSTALLMENT' });
     await expect(
-      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR1),
     ).rejects.toThrow(/IN_STOCK/);
   });
 
   it('BadRequestException when brand differs', async () => {
-    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
     prisma.product.findUnique
       .mockResolvedValueOnce({ id: 'op', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000' })
       .mockResolvedValueOnce({ id: 'np', brand: 'Samsung', model: 'iPhone 15', storage: '256', sellingPrice: '28000', status: 'IN_STOCK' });
     await expect(
-      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR1),
     ).rejects.toThrow(/รุ่นเดียวกัน/);
   });
 
   it('BadRequestException when sellingPrice differs', async () => {
-    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
     prisma.product.findUnique
       .mockResolvedValueOnce({ id: 'op', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000' })
       .mockResolvedValueOnce({ id: 'np', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '30000', status: 'IN_STOCK' });
     await expect(
-      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR1),
     ).rejects.toThrow(/ราคา/);
   });
 
   // Issue #1086 item 1 — silent same-price bypass when prices are null
   it('BadRequestException when new product has BOTH sellingPrice and installmentPrice null (no silent same-price bypass)', async () => {
-    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
     prisma.product.findUnique
       .mockResolvedValueOnce({ id: 'op', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000', installmentPrice: '28000' })
       .mockResolvedValueOnce({ id: 'np', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: null, installmentPrice: null, status: 'IN_STOCK' });
     await expect(
-      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR1),
     ).rejects.toThrow(/ราคาเครื่องไม่ถูกตั้งค่า/);
   });
 
   it('BadRequestException when OLD product has BOTH sellingPrice and installmentPrice null', async () => {
-    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
     prisma.product.findUnique
       .mockResolvedValueOnce({ id: 'op', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: null, installmentPrice: null })
       .mockResolvedValueOnce({ id: 'np', brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000', installmentPrice: '28000', status: 'IN_STOCK' });
     await expect(
-      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, 'u-1'),
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR1),
     ).rejects.toThrow(/ราคาเครื่องไม่ถูกตั้งค่า/);
   });
 
+  // Issue #1086 item 2 — in-service branch check
+  it('ForbiddenException when SALES user from another branch tries to submit', async () => {
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    await expect(
+      service.submit({ oldContractId: 'old', oldProductId: 'op', newProductId: 'np' }, SALES_BR2),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('OWNER (cross-branch role) can submit for a contract in any branch', async () => {
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    const same = { brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000' };
+    prisma.product.findUnique
+      .mockResolvedValueOnce({ id: 'op', ...same })
+      .mockResolvedValueOnce({ id: 'np', ...same, status: 'IN_STOCK' });
+    prisma.contractExchangeRequest.create.mockResolvedValue({ id: 'req-owner', status: 'PENDING' });
+
+    const result = await service.submit(
+      { oldContractId: 'old', oldProductId: 'op', newProductId: 'np' },
+      OWNER_USER,
+    );
+    expect(result.id).toBe('req-owner');
+  });
+
   it('creates PENDING request when all checks pass', async () => {
-    prisma.contract.findUnique.mockResolvedValue({ id: 'old', status: 'ACTIVE', productId: 'op', deletedAt: null });
+    prisma.contract.findUnique.mockResolvedValue({ id: 'old', branchId: 'br-1', status: 'ACTIVE', productId: 'op', deletedAt: null });
     const same = { brand: 'Apple', model: 'iPhone 15', storage: '256', sellingPrice: '28000' };
     prisma.product.findUnique
       .mockResolvedValueOnce({ id: 'op', ...same })
@@ -105,7 +135,7 @@ describe('ContractExchangeService.submit', () => {
 
     const result = await service.submit(
       { oldContractId: 'old', oldProductId: 'op', newProductId: 'np', conditionNote: 'good' },
-      'u-1',
+      SALES_BR1,
     );
 
     expect(result.id).toBe('req-1');

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
@@ -181,7 +181,10 @@ export class ContractExchangeService {
           interestRate: old.interestRate,
           vatAmount: old.vatAmount,
           sellingPrice: old.sellingPrice,
-          downPayment: old.downPayment,
+          // Same-price exchange: customer pays ฿0 at swap (spec v3). Copying
+          // old.downPayment would distort payment-history view and corrupt
+          // early-payoff calcs that reference downPayment. (Issue #1086 item 5.)
+          downPayment: new Decimal(0),
           creditBalance: new Decimal(0),
           contractDate: new Date(),
           exchangedFromContractId: old.id,

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
@@ -1,12 +1,29 @@
-import { Injectable, BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
+import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { SubmitExchangeRequestDto } from './dto/submit-exchange-request.dto';
 import { ExchangeNewContract1ATemplate } from '../journal/cpa-templates/exchange-new-contract-1a.template';
 import { ExchangeCloseOld21_1106Template } from '../journal/cpa-templates/exchange-close-old-21-1106.template';
 import { ExchangeClearVendor21_1106Template } from '../journal/cpa-templates/exchange-clear-vendor-21-1106.template';
+
+/**
+ * Subset of the request user that submit() needs to perform branch scoping.
+ * Matches the shape attached to `request.user` by JwtAuthGuard.
+ */
+interface RequestUser {
+  id: string;
+  role?: string | null;
+  branchId?: string | null;
+}
 
 /** Minimal product shape for same-price validation */
 interface ProductPriceSnapshot {
@@ -29,7 +46,7 @@ export class ContractExchangeService {
     private readonly t3: ExchangeClearVendor21_1106Template,
   ) {}
 
-  async submit(dto: SubmitExchangeRequestDto, userId: string) {
+  async submit(dto: SubmitExchangeRequestDto, user: RequestUser) {
     // 1. Old contract must exist + ACTIVE + not deleted
     const oldContract = await this.prisma.contract.findUnique({
       where: { id: dto.oldContractId },
@@ -37,6 +54,15 @@ export class ContractExchangeService {
     if (!oldContract || oldContract.deletedAt) {
       throw new NotFoundException('ไม่พบสัญญาเดิม');
     }
+
+    // Branch scoping (in-service because the DTO doesn't carry branchId — see
+    // issue #1086 item 2). BranchGuard isn't reachable from oldContractId
+    // without an extra controller-level resolver; doing the check here keeps
+    // the existing controller surface area unchanged.
+    if (!hasCrossBranchAccess(user) && oldContract.branchId !== user.branchId) {
+      throw new ForbiddenException('ไม่สามารถสร้างคำขอเปลี่ยนเครื่องของสาขาอื่นได้');
+    }
+
     if (oldContract.status !== 'ACTIVE') {
       throw new BadRequestException(`สัญญาเดิมสถานะ ${oldContract.status} — ต้องเป็น ACTIVE`);
     }
@@ -95,7 +121,7 @@ export class ContractExchangeService {
         conditionNote: dto.conditionNote,
         conditionPhotos: dto.conditionPhotos ?? [],
         status: 'PENDING',
-        requestedById: userId,
+        requestedById: user.id,
       },
     });
   }

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
@@ -49,17 +49,27 @@ export class ContractExchangeService {
       this.prisma.product.findUnique({ where: { id: dto.newProductId } }) as Promise<ProductPriceSnapshot | null>,
     ]);
 
-    // Resolve whichever price field is populated (installmentPrice in prod, sellingPrice in tests)
-    const resolvePrice = (p: any): Decimal =>
-      new Decimal(
-        ((p.sellingPrice ?? p.installmentPrice ?? '0') as { toString(): string } | string).toString(),
-      );
-
     if (!oldRaw) throw new NotFoundException('ไม่พบเครื่องเดิม');
     if (!newRaw) throw new NotFoundException('ไม่พบเครื่องใหม่');
 
     const oldProduct = oldRaw as any;
     const newProduct = newRaw as any;
+
+    // Resolve whichever price field is populated (installmentPrice in prod, sellingPrice in tests).
+    // Return null when both fields are null/missing so the caller can reject — silently
+    // coercing to 0 would let two null-priced products pass the same-price check.
+    // (Issue #1086 item 1.)
+    const resolvePriceOrNull = (p: any): Decimal | null => {
+      const raw = p?.sellingPrice ?? p?.installmentPrice;
+      if (raw === null || raw === undefined) return null;
+      return new Decimal((raw as { toString(): string } | string).toString());
+    };
+
+    const oldPrice = resolvePriceOrNull(oldProduct);
+    const newPrice = resolvePriceOrNull(newProduct);
+    if (oldPrice === null || newPrice === null) {
+      throw new BadRequestException('ราคาเครื่องไม่ถูกตั้งค่า — ตรวจสอบเครื่องในระบบ');
+    }
 
     if (newProduct.status !== 'IN_STOCK') {
       throw new BadRequestException('เครื่องใหม่ต้องอยู่ในสต็อก (IN_STOCK)');
@@ -71,8 +81,6 @@ export class ContractExchangeService {
     ) {
       throw new BadRequestException('เครื่องใหม่ต้องเป็นรุ่นเดียวกัน (brand/model/storage)');
     }
-    const oldPrice = resolvePrice(oldProduct);
-    const newPrice = resolvePrice(newProduct);
     if (!oldPrice.equals(newPrice)) {
       throw new BadRequestException(`ราคาเครื่องใหม่ต้องเท่ากับเครื่องเดิม (${oldPrice} vs ${newPrice})`);
     }


### PR DESCRIPTION
Closes items 1, 2, and 5 of #1086 (SP2 follow-up blockers from PR #1085 `/review`).

## Summary

- **Item 1 — `resolvePrice` null-price bypass.** If both `sellingPrice` and `installmentPrice` were `null` on either side, the helper coerced to `'0'` and two null-priced products silently passed the same-price check (`0.equals(0)`). Now throws `BadRequestException('ราคาเครื่องไม่ถูกตั้งค่า — ตรวจสอบเครื่องในระบบ')` when either side has no resolvable price.
- **Item 2 — missing branch scoping (security regression).** Controller had `JwtAuthGuard + RolesGuard` only; the DTO carries `oldContractId` (not `branchId`) so `BranchGuard` couldn't be wired without an extra resolver. Added in-service check after the existing contract fetch: non-cross-branch users (anyone outside `CROSS_BRANCH_ROLES`) get `ForbiddenException` when `oldContract.branchId !== user.branchId`. `submit()` now takes the full `req.user` object instead of `req.user.id`. `approve`/`reject` signatures unchanged (OWNER-only).
- **Item 5 — new contract copied old `downPayment`.** Spec v3 (same-price-only) guarantees the customer pays ฿0 at swap. Copying old `downPayment` corrupted payment-history view + early-payoff calcs. New contract now uses `new Decimal(0)`.

## Deferred to dedicated PRs

The remaining 3 blockers in #1086 are larger in scope and ship separately:

- **Item 3 — `computeOldOutstanding` must aggregate from `JournalLine`** instead of pro-rating `monthlyPayment × remaining`. Touches accounting integrity + needs JE-level integration tests; doing it correctly means replacing the current proration with `tx.journalLine.aggregate` grouped by accountCode against `journalEntry.reference = contractId`.
- **Item 4 — `contractNumber = 'EX-' + Date.now()`** collides with the `ExpenseDocument` prefix and violates `<TYPE>-YYYYMMDD-NNNN` per `.claude/rules/accounting.md`. Needs `DocNumberService` integration + a distinct prefix (e.g. `EXCH-`).
- **Item 6 — old device ownership not transferred SHOP→FINANCE on buyback** + missing `ShopInventoryReintakeTemplate` JE. Schema-touching (Product.ownedByCompanyId flip) + new JE template + paired-journal posting; reviewer flagged this as the highest-impact accounting hole.

## Test plan

- [x] `cd apps/api && npx jest contract-exchange.service.spec.ts` — **18/18 pass** (13 baseline + 5 new: 2 for null-price, 2 for branch check, 1 for downPayment=0)
- [x] `./tools/check-types.sh all` — 0 TS errors (api + web)
- [ ] Manual smoke after deploy: SALES on Ladprao branch tries to swap a Phaholyothin-branch contract → 403 Forbidden ("ไม่สามารถสร้างคำขอเปลี่ยนเครื่องของสาขาอื่นได้")
- [ ] Manual smoke: try to submit with a product whose prices were never set (null/null) → 400 Bad Request ("ราคาเครื่องไม่ถูกตั้งค่า — ตรวจสอบเครื่องในระบบ")
- [ ] After approve, inspect the new contract row — `down_payment = 0.00` regardless of old contract's down

🤖 Generated with [Claude Code](https://claude.com/claude-code)