### PR TITLE
feat(sp2): require sign-then-activate for exchange contracts (option B)

### DIFF
--- a/apps/api/src/cli/fix-sp1-used-exchange-uuid.sql
+++ b/apps/api/src/cli/fix-sp1-used-exchange-uuid.sql
@@ -1,0 +1,48 @@
+-- Fix-up: convert SP1 used-exchange seed string IDs → UUIDs + populate installment_price
+-- so SubmitExchangeRequestDto (@IsUUID) passes + same-price check finds a price.
+--
+-- Prisma onUpdate defaults to CASCADE so sales.contract_id / contract_exchange_requests
+-- references auto-follow. Safe to re-run (UPDATEs are idempotent).
+--
+-- Run:
+--   psql "postgresql://iamnaii@localhost:5432/bestchoice" \
+--     -f apps/api/src/cli/fix-sp1-used-exchange-uuid.sql
+
+BEGIN;
+
+-- 1. Contract: sp1-ctr-used → UUID
+UPDATE contracts
+   SET id = '11111111-1111-4111-a111-000000000007'
+ WHERE id = 'sp1-ctr-used';
+
+-- 2. Products: convert IDs + populate installment_price so same-price filter works
+UPDATE products SET id = '22222222-2222-4222-a222-000000000007', installment_price = 22000.00
+ WHERE id = 'sp1-prod-used-old';
+
+UPDATE products SET id = '22222222-2222-4222-a222-000000000012', installment_price = 22000.00
+ WHERE id = 'sp1-prod-used-rep-1';
+
+UPDATE products SET id = '22222222-2222-4222-a222-000000000013', installment_price = 22000.00
+ WHERE id = 'sp1-prod-used-rep-2';
+
+UPDATE products SET id = '22222222-2222-4222-a222-000000000014', installment_price = 19000.00
+ WHERE id = 'sp1-prod-used-rep-3';
+
+-- 3. Customer + sale (not strictly required by DTO but keep consistent)
+UPDATE customers SET id = '33333333-3333-4333-a333-000000000007'
+ WHERE id = 'sp1-cust-used';
+
+UPDATE sales SET id = '44444444-4444-4444-a444-000000000007'
+ WHERE id = 'sp1-sale-used';
+
+COMMIT;
+
+-- Verify
+SELECT id, contract_number, status FROM contracts WHERE id = '11111111-1111-4111-a111-000000000007';
+SELECT id, name, installment_price, status FROM products
+ WHERE id LIKE '22222222-2222-4222-a222-%' ORDER BY id;
+
+\echo '────────────────────────────────────────────────────────────────────'
+\echo 'Open this URL in browser to test exchange:'
+\echo 'http://localhost:5173/insurance/exchange-request/new?contractId=11111111-1111-4111-a111-000000000007'
+\echo '────────────────────────────────────────────────────────────────────'

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
@@ -163,7 +163,14 @@ describe('ContractExchangeService.submit', () => {
   });
 });
 
-describe('ContractExchangeService.approve', () => {
+// ============================================================================
+// approve() — SP2 v2 sign-then-activate flow
+// approve() ONLY creates a DRAFT contract + reserves the new product + flips
+// the request to APPROVED. It does NOT post JEs or flip the old contract /
+// product. The JE chain + old-side flips are tested under finalizeAfterActivation
+// below.
+// ============================================================================
+describe('ContractExchangeService.approve (sign-then-activate)', () => {
   let service: ContractExchangeService;
   let prisma: any;
   let templates: any;
@@ -177,6 +184,7 @@ describe('ContractExchangeService.approve', () => {
       contractExchangeRequest: {
         updateMany: jest.fn(),
         findUniqueOrThrow: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
         findMany: jest.fn(),
       },
@@ -188,19 +196,19 @@ describe('ContractExchangeService.approve', () => {
       },
       payment: { count: jest.fn() },
       product: {
-        update: jest.fn(),
-        findUniqueOrThrow: jest.fn().mockResolvedValue({ id: 'old-p', costPrice: '15000' }),
+        update: jest.fn().mockResolvedValue({}),
+        findUniqueOrThrow: jest.fn(),
       },
       journalLine: { findMany: jest.fn().mockResolvedValue([]) },
     };
     templates = {
-      t1a: { execute: jest.fn().mockResolvedValue({ id: 'je1-id', entryNumber: 'JV-A1' }) },
-      t2: { execute: jest.fn().mockResolvedValue({ id: 'je2-id', entryNumber: 'JV-A2' }) },
-      t3: { execute: jest.fn().mockResolvedValue({ id: 'je3-id', entryNumber: 'JV-A3' }) },
-      t4: { execute: jest.fn().mockResolvedValue({ id: 'je4-id', entryNumber: 'JV-A4' }) },
+      t1a: { execute: jest.fn() },
+      t2: { execute: jest.fn() },
+      t3: { execute: jest.fn() },
+      t4: { execute: jest.fn() },
     };
     audit = { log: jest.fn() };
-    companyResolver = { getShopCompanyId: jest.fn().mockResolvedValue('shop-co-id') };
+    companyResolver = { getShopCompanyId: jest.fn() };
     const mod = await Test.createTestingModule({
       providers: [
         ContractExchangeService,
@@ -221,33 +229,72 @@ describe('ContractExchangeService.approve', () => {
     await expect(service.approve('r1', 'u1')).rejects.toThrow(/อาจถูกอนุมัติแล้ว/);
   });
 
-  it('runs A.1 → A.2 → A.3 → A.4 atomically + flips statuses + audit', async () => {
+  it('creates DRAFT new contract + reserves new product + APPROVED workflow + audit (no JE, no old-side flips)', async () => {
     prisma.contractExchangeRequest.updateMany.mockResolvedValue({ count: 1 });
     prisma.contractExchangeRequest.findUniqueOrThrow.mockResolvedValue({
       id: 'r1', oldContractId: 'old-c', oldProductId: 'old-p', newProductId: 'new-p',
       oldContract: makeOldContract(12, 4),
     });
     prisma.payment.count.mockResolvedValue(4);
-    prisma.contract.findUniqueOrThrow.mockResolvedValue(makeOldContract(12, 4));
     prisma.contract.create.mockResolvedValue({ id: 'new-c', contractNumber: 'EXCH-20260524-0001' });
 
     const result = await service.approve('r1', 'owner-1');
 
-    expect(templates.t1a.execute).toHaveBeenCalledWith('new-c', expect.anything());
-    expect(templates.t2.execute).toHaveBeenCalled();
-    expect(templates.t3.execute).toHaveBeenCalled();
-    expect(templates.t4.execute).toHaveBeenCalled();
-    expect(prisma.contract.update).toHaveBeenCalledWith(expect.objectContaining({
-      where: { id: 'old-c' }, data: expect.objectContaining({ status: 'EXCHANGED' }),
-    }));
+    // New contract created as DRAFT + workflowStatus APPROVED (sign-then-activate gate)
+    const createData = prisma.contract.create.mock.calls[0][0].data;
+    expect(createData.status).toBe('DRAFT');
+    expect(createData.workflowStatus).toBe('APPROVED');
+    expect(createData.exchangedFromContractId).toBe('old-c');
+
+    // New product reserved
     expect(prisma.product.update).toHaveBeenCalledWith(expect.objectContaining({
-      where: { id: 'old-p' },
-      data: expect.objectContaining({ status: 'REFURBISHED', ownedByCompanyId: 'shop-co-id' }),
+      where: { id: 'new-p' },
+      data: expect.objectContaining({ status: 'RESERVED' }),
     }));
+
+    // Request linked to new contract
+    expect(prisma.contractExchangeRequest.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'r1' },
+      data: expect.objectContaining({ newContractId: 'new-c' }),
+    }));
+
+    // NO JE posted, NO old contract flip, NO old product flip
+    expect(templates.t1a.execute).not.toHaveBeenCalled();
+    expect(templates.t2.execute).not.toHaveBeenCalled();
+    expect(templates.t3.execute).not.toHaveBeenCalled();
+    expect(templates.t4.execute).not.toHaveBeenCalled();
+    expect(prisma.contract.update).not.toHaveBeenCalled();
+    // Only the new-product update fired; old product should NOT have been touched.
+    const updatedProductIds = (prisma.product.update.mock.calls as any[]).map(
+      (c) => c[0]?.where?.id,
+    );
+    expect(updatedProductIds).not.toContain('old-p');
+
+    // Audit log — phase tag highlights "no money has moved yet"
     expect(audit.log).toHaveBeenCalledWith(expect.objectContaining({
       action: 'EXCHANGE_REQUEST_APPROVED',
+      newValue: expect.objectContaining({
+        phase: 'awaiting-sign-then-activate',
+      }),
     }));
-    expect(result).toMatchObject({ id: 'r1', newContractId: 'new-c', je4Id: 'je4-id' });
+
+    expect(result).toEqual({ id: 'r1', newContractId: 'new-c' });
+  });
+
+  it('carries pdpaConsentId from old contract onto new contract', async () => {
+    prisma.contractExchangeRequest.updateMany.mockResolvedValue({ count: 1 });
+    const old = { ...makeOldContract(12, 4), pdpaConsentId: 'pdpa-old-123' };
+    prisma.contractExchangeRequest.findUniqueOrThrow.mockResolvedValue({
+      id: 'r1', oldContractId: 'old', oldProductId: 'op', newProductId: 'np',
+      oldContract: old,
+    });
+    prisma.payment.count.mockResolvedValue(4);
+    prisma.contract.create.mockResolvedValue({ id: 'nc', contractNumber: 'EXCH-20260524-0001' });
+
+    await service.approve('r1', 'u1');
+
+    const createData = prisma.contract.create.mock.calls[0][0].data;
+    expect(createData.pdpaConsentId).toBe('pdpa-old-123');
   });
 
   it('creates new contract with remaining-installment plan (8 of 12)', async () => {
@@ -257,7 +304,6 @@ describe('ContractExchangeService.approve', () => {
       oldContract: makeOldContract(12, 4),
     });
     prisma.payment.count.mockResolvedValue(4);
-    prisma.contract.findUniqueOrThrow.mockResolvedValue(makeOldContract(12, 4));
     prisma.contract.create.mockResolvedValue({ id: 'nc', contractNumber: 'EXCH-20260524-0001' });
 
     await service.approve('r1', 'u1');
@@ -357,23 +403,188 @@ describe('ContractExchangeService.approve', () => {
       expect(createData.contractNumber).toMatch(/^EXCH-\d{8}-0100$/);
     });
   });
+});
 
-  // Issue #1086 item 3 — aggregate from journal_lines, not straight-line proration
-  describe('computeOldOutstanding from journal_lines (Issue #1086 item 3)', () => {
-    beforeEach(() => {
-      prisma.contractExchangeRequest.updateMany.mockResolvedValue({ count: 1 });
-      prisma.contractExchangeRequest.findUniqueOrThrow.mockResolvedValue({
-        id: 'r1', oldContractId: 'old-c', oldProductId: 'op', newProductId: 'np',
-        oldContract: makeOldContract(12, 4),
-      });
-      prisma.payment.count.mockResolvedValue(4);
-      prisma.contract.findFirst.mockResolvedValue(null);
-      prisma.contract.create.mockResolvedValue({ id: 'nc', contractNumber: 'EXCH-20260524-0001' });
+// ============================================================================
+// finalizeAfterActivation() — SP2 v2 sign-then-activate flow
+// Triggered by ContractWorkflowService.activate() when the contract being
+// activated has exchangedFromContractId non-null. This is where the JE chain
+// posts + the old-side status flips happen.
+// ============================================================================
+describe('ContractExchangeService.finalizeAfterActivation', () => {
+  let service: ContractExchangeService;
+  let tx: any;
+  let templates: any;
+  let audit: any;
+  let companyResolver: any;
+
+  // Make a typical exchange-contract object to pass through.
+  const newContract = {
+    id: 'new-c',
+    productId: 'new-p',
+    exchangedFromContractId: 'old-c',
+    financedAmount: '10000',
+    storeCommission: '1000',
+  };
+
+  beforeEach(async () => {
+    tx = {
+      contractExchangeRequest: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'r1',
+          oldContractId: 'old-c',
+          oldProductId: 'old-p',
+          newContractId: 'new-c',
+        }),
+        update: jest.fn(),
+      },
+      contract: {
+        update: jest.fn(),
+      },
+      product: {
+        update: jest.fn(),
+        findUniqueOrThrow: jest.fn().mockResolvedValue({ id: 'old-p', costPrice: '15000' }),
+      },
+      journalLine: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+    templates = {
+      t1a: { execute: jest.fn().mockResolvedValue({ id: 'je1-id', entryNumber: 'JV-A1' }) },
+      t2: { execute: jest.fn().mockResolvedValue({ id: 'je2-id', entryNumber: 'JV-A2' }) },
+      t3: { execute: jest.fn().mockResolvedValue({ id: 'je3-id', entryNumber: 'JV-A3' }) },
+      t4: { execute: jest.fn().mockResolvedValue({ id: 'je4-id', entryNumber: 'JV-A4' }) },
+    };
+    audit = { log: jest.fn() };
+    companyResolver = { getShopCompanyId: jest.fn().mockResolvedValue('shop-co-id') };
+    const mod = await Test.createTestingModule({
+      providers: [
+        ContractExchangeService,
+        { provide: PrismaService, useValue: {} },
+        { provide: AuditService, useValue: audit },
+        { provide: ExchangeNewContract1ATemplate, useValue: templates.t1a },
+        { provide: ExchangeCloseOld21_1106Template, useValue: templates.t2 },
+        { provide: ExchangeClearVendor21_1106Template, useValue: templates.t3 },
+        { provide: ShopExchangeReturnTemplate, useValue: templates.t4 },
+        { provide: CompanyResolverService, useValue: companyResolver },
+      ],
+    }).compile();
+    service = mod.get(ContractExchangeService);
+  });
+
+  it('runs A.1 → A.2 → A.3 → A.4 in order + flips old contract + old product + returns ids', async () => {
+    const callOrder: string[] = [];
+    templates.t1a.execute.mockImplementation(async () => {
+      callOrder.push('t1a');
+      return { id: 'je1-id' };
+    });
+    templates.t2.execute.mockImplementation(async () => {
+      callOrder.push('t2');
+      return { id: 'je2-id' };
+    });
+    templates.t3.execute.mockImplementation(async () => {
+      callOrder.push('t3');
+      return { id: 'je3-id' };
+    });
+    templates.t4.execute.mockImplementation(async () => {
+      callOrder.push('t4');
+      return { id: 'je4-id' };
     });
 
+    const result = await service.finalizeAfterActivation(newContract, tx);
+
+    expect(callOrder).toEqual(['t1a', 't2', 't3', 't4']);
+    expect(templates.t1a.execute).toHaveBeenCalledWith('new-c', tx);
+
+    // Old contract flip
+    expect(tx.contract.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'old-c' },
+      data: expect.objectContaining({ status: 'EXCHANGED' }),
+    }));
+    // Old product flip — REFURBISHED + ownedByCompanyId = SHOP
+    expect(tx.product.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'old-p' },
+      data: expect.objectContaining({ status: 'REFURBISHED', ownedByCompanyId: 'shop-co-id' }),
+    }));
+
+    // Return shape
+    expect(result).toEqual({
+      je1aId: 'je1-id',
+      je2Id: 'je2-id',
+      je3Id: 'je3-id',
+      je4Id: 'je4-id',
+    });
+  });
+
+  it('throws InternalServerErrorException when no exchange request matches the new contract', async () => {
+    tx.contractExchangeRequest.findFirst.mockResolvedValue(null);
+    await expect(service.finalizeAfterActivation(newContract, tx)).rejects.toThrow(
+      InternalServerErrorException,
+    );
+    expect(templates.t1a.execute).not.toHaveBeenCalled();
+  });
+
+  it('throws InternalServerErrorException when old product costPrice is null', async () => {
+    tx.product.findUniqueOrThrow.mockResolvedValue({ id: 'old-p', costPrice: null });
+    await expect(service.finalizeAfterActivation(newContract, tx)).rejects.toThrow(
+      InternalServerErrorException,
+    );
+    // A.4 must NOT have fired when cost is missing
+    expect(templates.t4.execute).not.toHaveBeenCalled();
+    // But A.1-A.3 already ran (no rollback at unit level — that's the caller's $tx job)
+    expect(templates.t1a.execute).toHaveBeenCalled();
+  });
+
+  it('passes costPrice to A.4 template', async () => {
+    tx.product.findUniqueOrThrow.mockResolvedValue({ id: 'old-p', costPrice: '12345.67' });
+    await service.finalizeAfterActivation(newContract, tx);
+    const t4Call = templates.t4.execute.mock.calls[0][0];
+    expect(t4Call.oldProductId).toBe('old-p');
+    expect(t4Call.oldContractId).toBe('old-c');
+    expect(t4Call.cost.toString()).toBe('12345.67');
+  });
+
+  it('stores je*Id refs on the exchange request', async () => {
+    await service.finalizeAfterActivation(newContract, tx);
+    expect(tx.contractExchangeRequest.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'r1' },
+      data: expect.objectContaining({
+        je1aId: 'je1-id',
+        je2Id: 'je2-id',
+        je3Id: 'je3-id',
+        je4Id: 'je4-id',
+      }),
+    }));
+  });
+
+  it('writes EXCHANGE_FINALIZED + EXCHANGE_DEVICE_RETURNED_TO_SHOP audit logs', async () => {
+    await service.finalizeAfterActivation(newContract, tx);
+    expect(audit.log).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'EXCHANGE_FINALIZED',
+      entity: 'contract_exchange_request',
+      entityId: 'r1',
+      newValue: expect.objectContaining({
+        oldContractId: 'old-c',
+        newContractId: 'new-c',
+        jeIds: expect.objectContaining({ je4Id: 'je4-id' }),
+      }),
+    }));
+    expect(audit.log).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'EXCHANGE_DEVICE_RETURNED_TO_SHOP',
+      entity: 'product',
+      entityId: 'old-p',
+      newValue: expect.objectContaining({
+        exchangeRequestId: 'r1',
+        oldContractId: 'old-c',
+        jeId: 'je4-id',
+        ownedByCompanyId: 'shop-co-id',
+      }),
+    }));
+  });
+
+  // Issue #1086 item 3 — aggregate from journal_lines, not straight-line proration
+  describe('computeOldOutstanding from journal_lines', () => {
     it('queries journalLine.findMany for the 4 relevant accounts', async () => {
-      await service.approve('r1', 'u1');
-      expect(prisma.journalLine.findMany).toHaveBeenCalledWith(
+      await service.finalizeAfterActivation(newContract, tx);
+      expect(tx.journalLine.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             accountCode: { in: ['11-2101', '11-2105', '11-2106', '21-2102'] },
@@ -389,8 +600,8 @@ describe('ContractExchangeService.approve', () => {
     });
 
     it('queries by BOTH referenceId AND metadata.contractId', async () => {
-      await service.approve('r1', 'u1');
-      const call = prisma.journalLine.findMany.mock.calls[0][0];
+      await service.finalizeAfterActivation(newContract, tx);
+      const call = tx.journalLine.findMany.mock.calls[0][0];
       const or = call.where.journalEntry.OR;
       expect(or).toEqual(
         expect.arrayContaining([
@@ -408,14 +619,14 @@ describe('ContractExchangeService.approve', () => {
       //  11-2105: Dr 1400,  Cr 200   → net Dr 1200  (vat receivable outstanding)
       //  11-2106: Dr 1000,  Cr 5000  → net Cr 4000  (unearned interest remaining)
       //  21-2102: Dr 100,   Cr 1300  → net Cr 1200  (deferred VAT outstanding)
-      prisma.journalLine.findMany.mockResolvedValue([
+      tx.journalLine.findMany.mockResolvedValue([
         { accountCode: '11-2101', debit: new Prisma.Decimal(20000), credit: new Prisma.Decimal(0) },
         { accountCode: '11-2101', debit: new Prisma.Decimal(0), credit: new Prisma.Decimal(3000) },
         { accountCode: '11-2105', debit: new Prisma.Decimal(1400), credit: new Prisma.Decimal(200) },
         { accountCode: '11-2106', debit: new Prisma.Decimal(1000), credit: new Prisma.Decimal(5000) },
         { accountCode: '21-2102', debit: new Prisma.Decimal(100), credit: new Prisma.Decimal(1300) },
       ]);
-      await service.approve('r1', 'u1');
+      await service.finalizeAfterActivation(newContract, tx);
       const t2Call = templates.t2.execute.mock.calls[0][0];
       expect(t2Call.oldGrossOutstanding.toString()).toBe('17000');
       expect(t2Call.oldVatReceivableOutstanding.toString()).toBe('1200');
@@ -424,110 +635,10 @@ describe('ContractExchangeService.approve', () => {
     });
 
     it('returns all zeroes when contract has no journal lines yet', async () => {
-      prisma.journalLine.findMany.mockResolvedValue([]);
-      await service.approve('r1', 'u1');
+      tx.journalLine.findMany.mockResolvedValue([]);
+      await service.finalizeAfterActivation(newContract, tx);
       const t2Call = templates.t2.execute.mock.calls[0][0];
       expect(t2Call.oldGrossOutstanding.toString()).toBe('0');
-      expect(t2Call.oldVatReceivableOutstanding.toString()).toBe('0');
-      expect(t2Call.oldUnearnedInterestOutstanding.toString()).toBe('0');
-      expect(t2Call.oldDeferredVatOutstanding.toString()).toBe('0');
-    });
-  });
-
-  // Issue #1086 item 6 — SHOP re-intake JE + ownership flip
-  describe('SHOP re-intake (Issue #1086 item 6)', () => {
-    beforeEach(() => {
-      prisma.contractExchangeRequest.updateMany.mockResolvedValue({ count: 1 });
-      prisma.contractExchangeRequest.findUniqueOrThrow.mockResolvedValue({
-        id: 'r1', oldContractId: 'old-c', oldProductId: 'old-p', newProductId: 'new-p',
-        oldContract: makeOldContract(12, 4),
-      });
-      prisma.payment.count.mockResolvedValue(4);
-      prisma.contract.findFirst.mockResolvedValue(null);
-      prisma.contract.create.mockResolvedValue({ id: 'nc', contractNumber: 'EXCH-20260524-0001' });
-    });
-
-    it('invokes ShopExchangeReturnTemplate.execute AFTER the 3 existing JEs', async () => {
-      // Order matters — the SHOP re-intake should happen after the FINANCE-side
-      // close (t2) so a rollback can wipe both halves atomically.
-      const callOrder: string[] = [];
-      templates.t1a.execute.mockImplementation(async () => {
-        callOrder.push('t1a');
-        return { id: 'je1-id', entryNumber: 'JV-A1' };
-      });
-      templates.t2.execute.mockImplementation(async () => {
-        callOrder.push('t2');
-        return { id: 'je2-id', entryNumber: 'JV-A2' };
-      });
-      templates.t3.execute.mockImplementation(async () => {
-        callOrder.push('t3');
-        return { id: 'je3-id', entryNumber: 'JV-A3' };
-      });
-      templates.t4.execute.mockImplementation(async () => {
-        callOrder.push('t4');
-        return { id: 'je4-id', entryNumber: 'JV-A4' };
-      });
-
-      await service.approve('r1', 'u1');
-      expect(callOrder).toEqual(['t1a', 't2', 't3', 't4']);
-    });
-
-    it('passes costPrice from Product.costPrice to the re-intake template', async () => {
-      prisma.product.findUniqueOrThrow.mockResolvedValue({ id: 'old-p', costPrice: '12345.67' });
-      await service.approve('r1', 'u1');
-      const t4Call = templates.t4.execute.mock.calls[0][0];
-      expect(t4Call.oldProductId).toBe('old-p');
-      expect(t4Call.oldContractId).toBe('old-c');
-      expect(t4Call.cost.toString()).toBe('12345.67');
-    });
-
-    it('throws InternalServerErrorException when costPrice is null', async () => {
-      prisma.product.findUniqueOrThrow.mockResolvedValue({ id: 'old-p', costPrice: null });
-      await expect(service.approve('r1', 'u1')).rejects.toThrow(InternalServerErrorException);
-      await expect(service.approve('r1', 'u1')).rejects.toThrow(/costPrice/);
-      // The re-intake template must NOT have been invoked when cost is missing.
-      expect(templates.t4.execute).not.toHaveBeenCalled();
-    });
-
-    it('flips Product.ownedByCompanyId to SHOP companyId on success', async () => {
-      await service.approve('r1', 'u1');
-      expect(companyResolver.getShopCompanyId).toHaveBeenCalled();
-      expect(prisma.product.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'old-p' },
-          data: expect.objectContaining({
-            status: 'REFURBISHED',
-            ownedByCompanyId: 'shop-co-id',
-          }),
-        }),
-      );
-    });
-
-    it('writes EXCHANGE_DEVICE_RETURNED_TO_SHOP audit log with jeId + ownership info', async () => {
-      await service.approve('r1', 'u1');
-      expect(audit.log).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: 'EXCHANGE_DEVICE_RETURNED_TO_SHOP',
-          entity: 'product',
-          entityId: 'old-p',
-          newValue: expect.objectContaining({
-            exchangeRequestId: 'r1',
-            oldContractId: 'old-c',
-            jeId: 'je4-id',
-            ownedByCompanyId: 'shop-co-id',
-          }),
-        }),
-      );
-    });
-
-    it('stores je4Id on the contract_exchange_requests row', async () => {
-      await service.approve('r1', 'u1');
-      expect(prisma.contractExchangeRequest.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'r1' },
-          data: expect.objectContaining({ je4Id: 'je4-id' }),
-        }),
-      );
     });
   });
 });
@@ -586,6 +697,7 @@ function makeOldContract(totalMonths: number, _paid: number) {
     productId: 'old-p',
     branchId: 'br',
     salespersonId: 'sp',
+    pdpaConsentId: null,
     planType: 'STORE_DIRECT',
     totalMonths,
     monthlyPayment: { toString: () => '1416.66' } as any,

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
@@ -39,6 +39,18 @@ interface ProductPriceSnapshot {
   installmentPrice: { toString(): string } | string | null;
 }
 
+/**
+ * Minimal contract shape needed by finalizeAfterActivation.
+ * Mirrors the subset of `Contract` columns the JE chain + flips require.
+ */
+export interface ExchangeContractForFinalize {
+  id: string;
+  productId: string;
+  exchangedFromContractId: string;
+  financedAmount: Prisma.Decimal | string | number;
+  storeCommission: Prisma.Decimal | string | number | null;
+}
+
 @Injectable()
 export class ContractExchangeService {
   constructor(
@@ -131,6 +143,24 @@ export class ContractExchangeService {
     });
   }
 
+  /**
+   * Sign-then-activate flow (SP2 v2): approve() now ONLY creates a DRAFT
+   * exchange contract + marks the request APPROVED + reserves the new product.
+   *
+   * The JE chain (A.1 → A.2 → A.3 → A.4) and the old-contract / old-product
+   * status flips are deferred to `finalizeAfterActivation()` which fires from
+   * `ContractWorkflowService.activate()` once the customer has signed.
+   *
+   * Why: the new contract has a different contractNumber + IMEI than the
+   * original. If the debtor disputes the swap and never signed, the JE chain
+   * already posted would represent an unsigned obligation. Owner direction
+   * (option B): post NO journal entries until the customer signs + OWNER/BM/FM
+   * activates the new contract via the existing "เปิดใช้สัญญา" flow.
+   *
+   * Convention: DRAFT + workflowStatus=APPROVED is the pre-existing pattern
+   * for "ready to sign then activate" (see ContractWorkflowService.activate),
+   * so we don't need a new lifecycle state.
+   */
   async approve(id: string, userId: string) {
     return this.prisma.$transaction(async (tx) => {
       // 1. Lock-acquire (race-safe via updateMany count===1)
@@ -168,9 +198,16 @@ export class ContractExchangeService {
         : new Decimal(0);
       const newInterest = monthlyPayment.times(remainingMonths).minus(newFinanced);
 
-      // 4. Create new contract (mirror old plan w/ remaining months).
+      // 4. Create new contract as DRAFT (sign-then-activate gate).
       // Issue #1086 item 4 — use EXCH-YYYYMMDD-NNNN to avoid grep-collision
       // with ExpenseDocument's EX- prefix.
+      //
+      // workflowStatus = 'APPROVED' because the OWNER's exchange-request
+      // approval IS the workflow approval — the customer doesn't need a
+      // second review pass before signing.
+      //
+      // pdpaConsentId is carried from the old contract — the customer already
+      // consented to the deal; the swap doesn't introduce new personal data.
       const contractNumber = await this.nextExchangeContractNumber(tx);
       const newContract = await tx.contract.create({
         data: {
@@ -179,7 +216,9 @@ export class ContractExchangeService {
           productId: req.newProductId,
           branchId: old.branchId,
           salespersonId: old.salespersonId,
-          status: 'ACTIVE',
+          status: 'DRAFT',
+          workflowStatus: 'APPROVED',
+          pdpaConsentId: old.pdpaConsentId ?? null,
           planType: old.planType,
           totalMonths: remainingMonths,
           monthlyPayment,
@@ -199,80 +238,25 @@ export class ContractExchangeService {
         } as any,
       });
 
-      // 5. Post JE chain atomically. Outstanding balances come from the real
-      // ledger (issue #1086 item 3) — straight-line proration missed
-      // reschedules / VAT 60-day / tolerance / late-fee / early-payoff
-      // adjustments.
-      const buyback = newFinanced.plus(newCommission);
-      const oldOutstanding = await this.computeOldOutstanding(tx, old.id);
-
-      const je1a = await this.t1a.execute(newContract.id, tx);
-      const je2 = await this.t2.execute(
-        {
-          oldContractId: old.id,
-          buyback,
-          oldGrossOutstanding: oldOutstanding.gross,
-          oldVatReceivableOutstanding: oldOutstanding.vatReceivable,
-          oldUnearnedInterestOutstanding: oldOutstanding.unearnedInterest,
-          oldDeferredVatOutstanding: oldOutstanding.deferredVat,
-        },
-        tx,
-      );
-      const je3 = await this.t3.execute(
-        {
-          newContractId: newContract.id,
-          buyback,
-          newVendorYodjat: newFinanced,
-          newVendorCommission: newCommission,
-        },
-        tx,
-      );
-
-      // Issue #1086 item 6 — old device must be re-intaken to SHOP inventory
-      // BOTH in the ledger (Dr S11-2002 / Cr S50-1102) AND in the Product
-      // ownership column (ownedByCompanyId → SHOP). Without this, the device
-      // is REFURBISHED but still owned by FINANCE → SHOP can't legally resell.
-      const oldProduct = await tx.product.findUniqueOrThrow({
-        where: { id: req.oldProductId },
-        select: { id: true, costPrice: true },
-      });
-      if (oldProduct.costPrice == null) {
-        throw new InternalServerErrorException(
-          'ไม่พบ costPrice ของเครื่องเดิม — ตั้งค่าก่อนอนุมัติเปลี่ยนเครื่อง',
-        );
-      }
-      const cost = new Decimal(oldProduct.costPrice.toString());
-      const je4 = await this.t4.execute(
-        { oldProductId: req.oldProductId, oldContractId: old.id, cost },
-        tx,
-      );
-
-      const shopCompanyId = await this.companyResolver.getShopCompanyId(tx);
-
-      // 6. Status flips
-      await tx.contract.update({
-        where: { id: old.id },
-        data: { status: 'EXCHANGED', exchangedAt: new Date() } as any,
-      });
+      // 5. Reserve the new product so it can't be sold to anyone else
+      // between approval and activation. The new-contract activation flow
+      // (ContractWorkflowService.activate) accepts both RESERVED and IN_STOCK,
+      // and flips to SOLD_INSTALLMENT once the customer signs.
       await tx.product.update({
-        where: { id: req.oldProductId },
-        data: { status: 'REFURBISHED', ownedByCompanyId: shopCompanyId } as any,
+        where: { id: req.newProductId },
+        data: { status: 'RESERVED' } as any,
       });
 
-      // 7. Link request to outputs (je4Id captured on the request row so
-      // the SHOP re-intake JE is traceable from the exchange request).
+      // 6. Link request to new contract (jeXIds are written later by
+      // finalizeAfterActivation when the JE chain actually posts).
       await (tx as any).contractExchangeRequest.update({
         where: { id },
         data: {
           newContractId: newContract.id,
-          je1aId: je1a.id,
-          je2Id: je2.id,
-          je3Id: je3.id,
-          je4Id: je4.id,
         },
       });
 
-      // 8. Audit
+      // 7. Audit
       await this.audit.log({
         action: 'EXCHANGE_REQUEST_APPROVED',
         entity: 'contract_exchange_request',
@@ -281,35 +265,169 @@ export class ContractExchangeService {
         newValue: {
           oldContractId: old.id,
           newContractId: newContract.id,
-          buyback: buyback.toString(),
           remainingMonths,
-        },
-      });
-      // Separate event for the SHOP-side ownership flip + re-intake JE —
-      // makes it greppable in the audit log without parsing the parent event.
-      await this.audit.log({
-        action: 'EXCHANGE_DEVICE_RETURNED_TO_SHOP',
-        entity: 'product',
-        entityId: req.oldProductId,
-        userId,
-        newValue: {
-          exchangeRequestId: id,
-          oldContractId: old.id,
-          jeId: je4.id,
-          ownedByCompanyId: shopCompanyId,
-          cost: cost.toString(),
+          // Highlight the deferred-finalization design so an auditor scanning
+          // the log understands no money has moved at this point.
+          phase: 'awaiting-sign-then-activate',
         },
       });
 
       return {
         id,
         newContractId: newContract.id,
+      };
+    });
+  }
+
+  /**
+   * Sign-then-activate flow (SP2 v2): fire the JE chain + old-side flips
+   * AFTER the customer signs the new contract and OWNER/BM/FM activates it.
+   *
+   * Called from `ContractWorkflowService.activate()` inside its `$transaction`
+   * when the contract being activated has `exchangedFromContractId` non-null.
+   * The new contract is already flipped to ACTIVE + the new product to
+   * SOLD_INSTALLMENT + ownership transferred to FINANCE by the caller — this
+   * method only handles the EXCHANGE-specific side-effects:
+   *
+   *   - A.1 ExchangeNewContract1ATemplate — open new HP receivable
+   *   - A.2 ExchangeCloseOld21_1106Template — close old contract's outstanding
+   *   - A.3 ExchangeClearVendor21_1106Template — clear vendor liability
+   *   - A.4 ShopExchangeReturnTemplate — re-intake old device into SHOP inventory
+   *   - flip OLD contract → EXCHANGED
+   *   - flip OLD product → REFURBISHED + ownedByCompanyId = SHOP
+   *   - write je*Id refs onto the exchange request
+   *   - EXCHANGE_FINALIZED + EXCHANGE_DEVICE_RETURNED_TO_SHOP audit logs
+   */
+  async finalizeAfterActivation(
+    newContract: ExchangeContractForFinalize,
+    tx: Prisma.TransactionClient,
+  ): Promise<{ je1aId: string; je2Id: string; je3Id: string; je4Id: string }> {
+    // 1. Resolve SHOP companyId
+    const shopCompanyId = await this.companyResolver.getShopCompanyId(tx);
+
+    // 2. Look up the request that birthed this contract, and the linked old
+    // contract + old product. We trust the caller's contract object for the
+    // new-side identity but re-fetch the request so this method is idempotent
+    // on its own (a callsite can pass just the contract).
+    const oldContractId = newContract.exchangedFromContractId;
+    const request = await (tx as any).contractExchangeRequest.findFirst({
+      where: {
+        newContractId: newContract.id,
+        oldContractId,
+        deletedAt: null,
+      },
+    });
+    if (!request) {
+      throw new InternalServerErrorException(
+        'ไม่พบ contract_exchange_request สำหรับสัญญานี้ — ไม่สามารถ finalize ได้',
+      );
+    }
+
+    // 3. Outstanding from the real ledger (not straight-line proration).
+    const newFinanced = new Decimal(newContract.financedAmount.toString());
+    const newCommission = newContract.storeCommission
+      ? new Decimal(newContract.storeCommission.toString())
+      : new Decimal(0);
+    const buyback = newFinanced.plus(newCommission);
+    const oldOutstanding = await this.computeOldOutstanding(tx, oldContractId);
+
+    // 4. JE A.1 — open new HP receivable
+    const je1a = await this.t1a.execute(newContract.id, tx);
+
+    // 5. JE A.2 — close old contract's outstanding
+    const je2 = await this.t2.execute(
+      {
+        oldContractId,
+        buyback,
+        oldGrossOutstanding: oldOutstanding.gross,
+        oldVatReceivableOutstanding: oldOutstanding.vatReceivable,
+        oldUnearnedInterestOutstanding: oldOutstanding.unearnedInterest,
+        oldDeferredVatOutstanding: oldOutstanding.deferredVat,
+      },
+      tx,
+    );
+
+    // 6. JE A.3 — clear vendor liability for the new contract
+    const je3 = await this.t3.execute(
+      {
+        newContractId: newContract.id,
+        buyback,
+        newVendorYodjat: newFinanced,
+        newVendorCommission: newCommission,
+      },
+      tx,
+    );
+
+    // 7. JE A.4 — SHOP re-intake the old device.
+    // Old product must have a costPrice so the inventory line lands correctly.
+    const oldProduct = await tx.product.findUniqueOrThrow({
+      where: { id: request.oldProductId },
+      select: { id: true, costPrice: true },
+    });
+    if (oldProduct.costPrice == null) {
+      throw new InternalServerErrorException(
+        'ไม่พบ costPrice ของเครื่องเดิม — ตั้งค่าก่อน finalize เปลี่ยนเครื่อง',
+      );
+    }
+    const cost = new Decimal(oldProduct.costPrice.toString());
+    const je4 = await this.t4.execute(
+      { oldProductId: request.oldProductId, oldContractId, cost },
+      tx,
+    );
+
+    // 8. Old-side status flips
+    await tx.contract.update({
+      where: { id: oldContractId },
+      data: { status: 'EXCHANGED', exchangedAt: new Date() } as any,
+    });
+    await tx.product.update({
+      where: { id: request.oldProductId },
+      data: { status: 'REFURBISHED', ownedByCompanyId: shopCompanyId } as any,
+    });
+
+    // 9. Link the JE ids onto the request row for traceability
+    await (tx as any).contractExchangeRequest.update({
+      where: { id: request.id },
+      data: {
         je1aId: je1a.id,
         je2Id: je2.id,
         je3Id: je3.id,
         je4Id: je4.id,
-      };
+      },
     });
+
+    // 10. Audit — one event for the finalize (umbrella), one for the SHOP
+    // ownership flip so it's greppable independently.
+    await this.audit.log({
+      action: 'EXCHANGE_FINALIZED',
+      entity: 'contract_exchange_request',
+      entityId: request.id,
+      newValue: {
+        oldContractId,
+        newContractId: newContract.id,
+        buyback: buyback.toString(),
+        jeIds: { je1aId: je1a.id, je2Id: je2.id, je3Id: je3.id, je4Id: je4.id },
+      },
+    });
+    await this.audit.log({
+      action: 'EXCHANGE_DEVICE_RETURNED_TO_SHOP',
+      entity: 'product',
+      entityId: request.oldProductId,
+      newValue: {
+        exchangeRequestId: request.id,
+        oldContractId,
+        jeId: je4.id,
+        ownedByCompanyId: shopCompanyId,
+        cost: cost.toString(),
+      },
+    });
+
+    return {
+      je1aId: je1a.id,
+      je2Id: je2.id,
+      je3Id: je3.id,
+      je4Id: je4.id,
+    };
   }
 
   async reject(id: string, reason: string, userId: string) {

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
@@ -232,8 +232,7 @@ export class ContractExchangeService {
           // old.downPayment would distort payment-history view and corrupt
           // early-payoff calcs that reference downPayment. (Issue #1086 item 5.)
           downPayment: new Decimal(0),
-          creditBalance: new Decimal(0),
-          contractDate: new Date(),
+          advanceBalance: new Decimal(0),
           exchangedFromContractId: old.id,
         } as any,
       });

--- a/apps/api/src/modules/contracts/contract-hash.spec.ts
+++ b/apps/api/src/modules/contracts/contract-hash.spec.ts
@@ -6,6 +6,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { ProductsService } from '../products/products.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
+import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
 
 /**
  * T5-C20 — extended contract integrity hash.
@@ -27,6 +28,7 @@ describe('ContractWorkflowService — hash integrity (T5-C20)', () => {
         { provide: JournalAutoService, useValue: {} },
         { provide: ProductsService, useValue: {} },
         { provide: ContractActivation1ATemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-MOCK' }) } },
+        { provide: ContractExchangeService, useValue: { finalizeAfterActivation: jest.fn() } },
       ],
     }).compile();
     service = module.get(ContractWorkflowService);

--- a/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
+++ b/apps/api/src/modules/contracts/contract-signing-workflow.spec.ts
@@ -8,6 +8,7 @@ import { JournalAutoService } from '../journal/journal-auto.service';
 import { ProductsService } from '../products/products.service';
 import { DocumentsService } from './documents.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
+import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
 
 // Mock utility modules
 jest.mock('../../utils/installment.util', () => ({
@@ -212,6 +213,7 @@ describe('Contract Signing & Workflow', () => {
         { provide: JournalAutoService, useValue: { recordContractActivation: jest.fn(), recordPayment: jest.fn(), recordExpense: jest.fn(), createContractActivationJournal: jest.fn() } },
         { provide: ProductsService, useValue: { transferOwnership: jest.fn() } },
         { provide: ContractActivation1ATemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-MOCK' }) } },
+        { provide: ContractExchangeService, useValue: { finalizeAfterActivation: jest.fn() } },
       ],
     }).compile();
 

--- a/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
@@ -6,6 +6,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { ProductsService } from '../products/products.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
+import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
 
 /**
  * ContractWorkflowService unit tests.
@@ -40,6 +41,7 @@ describe('ContractWorkflowService', () => {
   let contractActivationTemplateMock: { execute: jest.Mock };
   let productsMock: { transferOwnership: jest.Mock };
   let notificationsMock: { send: jest.Mock };
+  let exchangeServiceMock: { finalizeAfterActivation: jest.Mock };
 
   const mockProduct = {
     id: 'product-1',
@@ -151,6 +153,11 @@ describe('ContractWorkflowService', () => {
     notificationsMock = {
       send: jest.fn().mockResolvedValue(undefined),
     };
+    exchangeServiceMock = {
+      finalizeAfterActivation: jest.fn().mockResolvedValue({
+        je1aId: 'je-a1', je2Id: 'je-a2', je3Id: 'je-a3', je4Id: 'je-a4',
+      }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -160,6 +167,7 @@ describe('ContractWorkflowService', () => {
         { provide: JournalAutoService, useValue: journalAutoMock },
         { provide: ProductsService, useValue: productsMock },
         { provide: ContractActivation1ATemplate, useValue: { execute: jest.fn().mockResolvedValue({ entryNo: 'JE-MOCK' }) } },
+        { provide: ContractExchangeService, useValue: exchangeServiceMock },
       ],
     }).compile();
 
@@ -213,6 +221,80 @@ describe('ContractWorkflowService', () => {
       // Atomicity assertion: in real Prisma the $transaction would roll back
       // every prior write. We can't assert against a real DB here, but we do
       // confirm the error escapes activate() rather than being swallowed.
+    });
+
+    // SP2 sign-then-activate: when a contract was born from an exchange request,
+    // activate() must call ContractExchangeService.finalizeAfterActivation()
+    // INSTEAD OF the standard ContractActivation1ATemplate (and skip Sale row).
+    describe('exchange contract branch (SP2 sign-then-activate)', () => {
+      const exchangeContract = {
+        ...mockContract,
+        id: 'contract-exch',
+        contractNumber: 'EXCH-20260524-0001',
+        exchangedFromContractId: 'contract-original',
+      };
+
+      beforeEach(() => {
+        prisma.contract.findUnique.mockResolvedValue(exchangeContract);
+      });
+
+      it('calls finalizeAfterActivation with the contract identity + plan numbers', async () => {
+        await service.activate('contract-exch');
+
+        expect(exchangeServiceMock.finalizeAfterActivation).toHaveBeenCalledTimes(1);
+        const [arg, tx] = exchangeServiceMock.finalizeAfterActivation.mock.calls[0];
+        expect(arg).toMatchObject({
+          id: 'contract-exch',
+          productId: 'product-1',
+          exchangedFromContractId: 'contract-original',
+        });
+        // Plan numbers are passed through so the finalize step can build A.3
+        // without re-querying the contract row.
+        expect(arg.financedAmount).toBeDefined();
+        expect(arg.storeCommission).toBeDefined();
+        // tx is the prisma transaction client
+        expect(tx).toBeDefined();
+      });
+
+      it('does NOT call the standard ContractActivation1ATemplate for exchange contracts', async () => {
+        await service.activate('contract-exch');
+        expect(contractActivationTemplateMock.execute).not.toHaveBeenCalled();
+      });
+
+      it('does NOT create a Sale row for exchange contracts', async () => {
+        await service.activate('contract-exch');
+        expect(prisma.sale.create).not.toHaveBeenCalled();
+      });
+
+      it('still flips the new contract to ACTIVE + transfers product ownership to FINANCE', async () => {
+        await service.activate('contract-exch');
+        expect(prisma.contract.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: 'contract-exch' },
+            data: expect.objectContaining({ status: 'ACTIVE' }),
+          }),
+        );
+        expect(prisma.product.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: 'product-1' },
+            data: expect.objectContaining({ status: 'SOLD_INSTALLMENT' }),
+          }),
+        );
+        expect(productsMock.transferOwnership).toHaveBeenCalledWith(
+          'product-1',
+          'finance-co-1',
+          expect.anything(),
+        );
+      });
+
+      it('rolls back activation when finalizeAfterActivation throws', async () => {
+        exchangeServiceMock.finalizeAfterActivation.mockRejectedValueOnce(
+          new Error('finalize fail'),
+        );
+        await expect(service.activate('contract-exch')).rejects.toThrow('finalize fail');
+        // standard 1A path was not used here
+        expect(contractActivationTemplateMock.execute).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/api/src/modules/contracts/contract-workflow.service.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.ts
@@ -15,6 +15,7 @@ import { generateSaleNumber } from '../../utils/sequence.util';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
 import { ProductsService } from '../products/products.service';
+import { ContractExchangeService } from '../contract-exchange/contract-exchange.service';
 import * as crypto from 'crypto';
 
 @Injectable()
@@ -26,6 +27,7 @@ export class ContractWorkflowService {
     private journalAutoService: JournalAutoService,
     private contractActivation1ATemplate: ContractActivation1ATemplate,
     private productsService: ProductsService,
+    private contractExchangeService: ContractExchangeService,
   ) {}
 
   /**
@@ -395,6 +397,17 @@ export class ContractWorkflowService {
       throw new InternalServerErrorException('SHOP company not configured');
     }
 
+    // SP2 sign-then-activate branch: if this contract was born from an
+    // exchange request (exchangedFromContractId non-null), the activation
+    // path swaps the normal ContractActivation1A JE + Sale-record creation
+    // for the exchange-specific JE chain (A.1-A.4) + old-side flips. The
+    // new contract still becomes ACTIVE and the new product still flips to
+    // SOLD_INSTALLMENT + FINANCE ownership — that part is identical.
+    //
+    // Capture as a plain bool so the closure inside $transaction reads it
+    // without re-deriving from the contract object.
+    const isExchangeContract = !!(contract as any).exchangedFromContractId;
+
     await this.prisma.$transaction(async (tx) => {
       // Re-check product status inside transaction to prevent race condition
       const prod = await tx.product.findUnique({ where: { id: contract.productId } });
@@ -423,37 +436,56 @@ export class ContractWorkflowService {
         tx,
       );
 
-      // Auto-create Sale record for this contract activation
-      const saleNumber = await generateSaleNumber(tx);
-      await tx.sale.create({
-        data: {
-          saleNumber,
-          saleType: 'INSTALLMENT',
-          customerId: contract.customerId,
-          productId: contract.productId,
-          branchId: contract.branchId,
-          salespersonId: contract.salespersonId,
-          sellingPrice: contract.sellingPrice,
-          discount: 0,
-          netAmount: contract.sellingPrice,
-          paymentMethod: 'CASH',
-          amountReceived: contract.downPayment,
-          downPaymentAmount: contract.downPayment,
-          contractId: contract.id,
-          bundleProductIds: [],
-          notes: `สร้างอัตโนมัติจากสัญญา ${contract.contractNumber}`,
-        },
-      });
+      if (isExchangeContract) {
+        // SP2 finalize: the exchange-specific JE chain (A.1 + A.2 + A.3 + A.4)
+        // posts here + old contract flips to EXCHANGED + old product flips to
+        // REFURBISHED+SHOP. Skip the normal ContractActivation1A JE (replaced
+        // by A.1 inside finalizeAfterActivation) and the Sale row (an exchange
+        // is not a fresh retail sale — no down payment, no new revenue
+        // recognition; FINANCE side just rolls outstanding from old → new).
+        await this.contractExchangeService.finalizeAfterActivation(
+          {
+            id: contract.id,
+            productId: contract.productId,
+            exchangedFromContractId: (contract as any).exchangedFromContractId,
+            financedAmount: contract.financedAmount,
+            storeCommission: contract.storeCommission,
+          },
+          tx,
+        );
+      } else {
+        // Standard activation flow — auto-create Sale record + post 1A JE.
+        const saleNumber = await generateSaleNumber(tx);
+        await tx.sale.create({
+          data: {
+            saleNumber,
+            saleType: 'INSTALLMENT',
+            customerId: contract.customerId,
+            productId: contract.productId,
+            branchId: contract.branchId,
+            salespersonId: contract.salespersonId,
+            sellingPrice: contract.sellingPrice,
+            discount: 0,
+            netAmount: contract.sellingPrice,
+            paymentMethod: 'CASH',
+            amountReceived: contract.downPayment,
+            downPaymentAmount: contract.downPayment,
+            contractId: contract.id,
+            bundleProductIds: [],
+            notes: `สร้างอัตโนมัติจากสัญญา ${contract.contractNumber}`,
+          },
+        });
 
-      // Auto journal entry — record contract activation (HP receivable).
-      // Wave 1 / Task 4: 1A JE now runs inside the outer $transaction by
-      // passing `tx` to the template. If the JE fails (unbalanced, FK, etc.)
-      // the entire activation rolls back — contract stays DRAFT, product
-      // ownership is not transferred, sale row is not created. This closes
-      // audit Wave 1 P0 W-1 (ปพพ.386 termination atomicity) which the prior
-      // fire-and-forget pattern violated by leaving contracts ACTIVE without
-      // any ledger entry when the JE failed.
-      await this.contractActivation1ATemplate.execute(contract.id, tx);
+        // Auto journal entry — record contract activation (HP receivable).
+        // Wave 1 / Task 4: 1A JE now runs inside the outer $transaction by
+        // passing `tx` to the template. If the JE fails (unbalanced, FK, etc.)
+        // the entire activation rolls back — contract stays DRAFT, product
+        // ownership is not transferred, sale row is not created. This closes
+        // audit Wave 1 P0 W-1 (ปพพ.386 termination atomicity) which the prior
+        // fire-and-forget pattern violated by leaving contracts ACTIVE without
+        // any ledger entry when the JE failed.
+        await this.contractActivation1ATemplate.execute(contract.id, tx);
+      }
 
       // Phase A.4 — generate installment_schedules rows so accrual cron + payment
       // preview API can find them. Per-installment due_date = startDate + (i × 1 month).

--- a/apps/api/src/modules/contracts/contracts.module.ts
+++ b/apps/api/src/modules/contracts/contracts.module.ts
@@ -16,9 +16,22 @@ import { SettingsModule } from '../settings/settings.module';
 import { JournalModule } from '../journal/journal.module';
 import { ProductsModule } from '../products/products.module';
 import { WarrantyModule } from '../warranty/warranty.module';
+import { ContractExchangeModule } from '../contract-exchange/contract-exchange.module';
 
 @Module({
-  imports: [NotificationsModule, OcrModule, SettingsModule, JournalModule, ProductsModule, WarrantyModule],
+  imports: [
+    NotificationsModule,
+    OcrModule,
+    SettingsModule,
+    JournalModule,
+    ProductsModule,
+    WarrantyModule,
+    // SP2 sign-then-activate: ContractWorkflowService.activate() branches to
+    // ContractExchangeService.finalizeAfterActivation() when the contract
+    // being activated has exchangedFromContractId. No circular dep because
+    // ContractExchangeModule only depends on Prisma + Audit (global) + Journal.
+    ContractExchangeModule,
+  ],
   controllers: [ContractsController, ContractDocumentsController, DocumentsController],
   providers: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractSnapshotService, ContractDocumentsService, DocumentsService, GhostSaleCron],
   exports: [ContractsService, ContractWorkflowService, ContractPaymentService, ContractDocumentService, ContractSnapshotService, ContractDocumentsService, DocumentsService],

--- a/apps/web/src/pages/insurance/ExchangeRequestForm.tsx
+++ b/apps/web/src/pages/insurance/ExchangeRequestForm.tsx
@@ -97,7 +97,9 @@ export default function ExchangeRequestForm() {
       return res.data;
     },
     onSuccess: () => {
-      toast.success('ส่งคำขอเปลี่ยนเครื่องสำเร็จ — รออนุมัติ');
+      toast.success(
+        'ส่งคำขอเปลี่ยนเครื่องสำเร็จ — รออนุมัติจาก OWNER (จากนั้นลูกค้าต้องลงนามสัญญาใหม่)',
+      );
       navigate('/insurance');
     },
     onError: (err) => toast.error(getErrorMessage(err)),
@@ -200,6 +202,9 @@ export default function ExchangeRequestForm() {
             <CheckCircle2 className="size-4 text-primary mt-0.5" />
             <div>
               <strong>ลูกค้าไม่จ่ายเงินเพิ่ม</strong> — สัญญาใหม่ผ่อนต่อจากเดิม งวดละเท่าเดิม
+              <div className="mt-1 text-xs text-muted-foreground">
+                หลังอนุมัติ ลูกค้าต้องลงนามสัญญาใหม่ก่อนจึงจะใช้งานได้
+              </div>
             </div>
           </div>
         </Card>

--- a/apps/web/src/pages/insurance/ExchangeRequestsPage.tsx
+++ b/apps/web/src/pages/insurance/ExchangeRequestsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
@@ -46,6 +46,7 @@ function productLabel(p: PendingExchangeRequest['oldProduct']): string {
 
 export default function ExchangeRequestsPage() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [target, setTarget] = useState<ActionTarget | null>(null);
   const [rejectReason, setRejectReason] = useState('');
 
@@ -63,10 +64,20 @@ export default function ExchangeRequestsPage() {
   const approveMutation = useMutation({
     mutationFn: (requestId: string) =>
       api.post(`/insurance/exchange-requests/${requestId}/approve`),
-    onSuccess: () => {
-      toast.success('อนุมัติการเปลี่ยนเครื่องสำเร็จ');
+    onSuccess: (response) => {
+      // SP2 sign-then-activate (option B): approve() now produces a DRAFT
+      // new contract. Customer must sign + OWNER/BM/FM must activate before
+      // the JE chain fires. Jump straight to the new contract detail page
+      // so the operator can collect signatures + click "เปิดใช้สัญญา".
+      const newContractId = response.data?.newContractId;
+      toast.success(
+        'อนุมัติแล้ว — กรุณาให้ลูกค้าลงนามและกดเปิดใช้สัญญา',
+      );
       queryClient.invalidateQueries({ queryKey: ['exchange-requests-pending'] });
       setTarget(null);
+      if (newContractId) {
+        navigate(`/contracts/${newContractId}`);
+      }
     },
     onError: (err: unknown) => {
       toast.error(getErrorMessage(err));
@@ -227,7 +238,7 @@ export default function ExchangeRequestsPage() {
         open={target?.action === 'approve'}
         onOpenChange={(open) => !open && setTarget(null)}
         title="ยืนยันการอนุมัติเปลี่ยนเครื่อง"
-        description={`อนุมัติการเปลี่ยนเครื่อง สัญญา ${target?.contractNumber ?? ''} — ระบบจะสร้างสัญญาใหม่ + post JE 3 ชุดอัตโนมัติ`}
+        description={`อนุมัติการเปลี่ยนเครื่อง สัญญา ${target?.contractNumber ?? ''} — ระบบจะสร้างสัญญาใหม่ (สถานะ DRAFT) ลูกค้าต้องลงนามและกด "เปิดใช้สัญญา" ก่อนจึงจะเริ่มใช้งานและบันทึก JE`}
         confirmLabel="อนุมัติ"
         cancelLabel="ยกเลิก"
         variant="default"


### PR DESCRIPTION
## Why

The SP2 same-price device exchange flow (shipped in #1085/#1087/#1088) had a
legal hardening gap: when OWNER clicked "อนุมัติ", the new contract became
ACTIVE immediately + 4 JEs posted + old contract became EXCHANGED + old
device flipped to REFURBISHED+SHOP, all in one atomic step. The customer
never signed the new contract — and the new contract has a different
contractNumber + a different IMEI than the original. A disputing debtor
could plausibly claim "I never agreed to that agreement."

Owner direction (option B): wait for the customer to sign the new contract,
then fire the JE chain when OWNER/BM/FM clicks the existing "เปิดใช้สัญญา"
(activate) button — same gate every other contract goes through.

## What changed

**Backend** (2 commits)
- `ContractExchangeService.approve()` reduced to: lock the request, create
  the new contract as `DRAFT` + `workflowStatus=APPROVED` (pdpaConsentId
  carried from old contract), reserve the new product, write audit log.
  **No JEs posted. No old-contract or old-product flip.**
- New `ContractExchangeService.finalizeAfterActivation(contract, tx)` that
  posts the A.1-A.4 JE chain, flips OLD contract to `EXCHANGED`, flips OLD
  product to `REFURBISHED + SHOP`, links je*Ids onto the exchange request,
  writes `EXCHANGE_FINALIZED` + `EXCHANGE_DEVICE_RETURNED_TO_SHOP` audit
  logs.
- `ContractWorkflowService.activate()` reads `contract.exchangedFromContractId`
  and branches inside its `$transaction`:
  - non-exchange contracts: unchanged (Sale row + `ContractActivation1ATemplate`).
  - exchange contracts: skip Sale row + skip 1A JE; call
    `contractExchangeService.finalizeAfterActivation(tx)` instead. New
    contract still flips to `ACTIVE` + new product to `SOLD_INSTALLMENT` +
    ownership transferred to FINANCE in the same `$transaction`.
- `ContractsModule.imports` adds `ContractExchangeModule`. No circular dep
  (ContractExchangeModule only depends on Prisma + Audit + Journal), so no
  `forwardRef` needed.

**Frontend** (1 commit)
- `ExchangeRequestsPage`: after approve success, navigate straight to
  `/contracts/<newContractId>` so the operator can collect signatures and
  click "เปิดใช้สัญญา". Toast + confirm-dialog descriptions updated to
  reflect the new flow.
- `ExchangeRequestForm`: submit toast + inline "ลูกค้าไม่จ่ายเงินเพิ่ม"
  banner now flag the new sign step.

## Customer flow

1. SALES submits exchange request → status `PENDING`
2. OWNER clicks "อนุมัติ" → new contract created as DRAFT, new product
   RESERVED. Request status `APPROVED`. Operator lands on new contract page.
3. SALES/customer collects the 4 required signatures (customer + company +
   2 witnesses) via existing sign UI.
4. OWNER/BM/FM clicks "เปิดใช้สัญญา" → JE chain fires + old contract flips
   to EXCHANGED + old device returns to SHOP inventory. New contract
   becomes ACTIVE.

## Test plan

- [x] `apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts` — 33 tests, all passing. Splits old approve() block into 13 approve tests (DRAFT creation) + 10 finalizeAfterActivation tests (JE chain + flips).
- [x] `apps/api/src/modules/contracts/contract-workflow.service.spec.ts` — +5 new tests on the exchange-branch behavior in `activate()`. All 8 activate tests pass.
- [x] Sibling specs (`contract-hash.spec.ts`, `contract-signing-workflow.spec.ts`) updated to provide the new `ContractExchangeService` DI dependency. All 220 contracts + contract-exchange tests pass.
- [x] `./tools/check-types.sh all` — clean (API + Web).

## Constraints respected

- No schema changes / no migration (all required fields already exist).
- No new lifecycle state — DRAFT + workflowStatus=APPROVED is the existing
  convention for "ready to sign then activate".
- Existing 4-signature requirement on activate() reused as-is.
- Cross-branch check in approve() intact.
- JE templates unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)