### PR TITLE
fix(exchange): clone PDPA consent for new exchange contract

### DIFF
--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.spec.ts
@@ -200,6 +200,10 @@ describe('ContractExchangeService.approve (sign-then-activate)', () => {
         findUniqueOrThrow: jest.fn(),
       },
       journalLine: { findMany: jest.fn().mockResolvedValue([]) },
+      pDPAConsent: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'cloned-pdpa-uuid' }),
+      },
     };
     templates = {
       t1a: { execute: jest.fn() },
@@ -281,9 +285,53 @@ describe('ContractExchangeService.approve (sign-then-activate)', () => {
     expect(result).toEqual({ id: 'r1', newContractId: 'new-c' });
   });
 
-  it('carries pdpaConsentId from old contract onto new contract', async () => {
+  it('clones PDPA consent from old contract for new contract (unique constraint workaround)', async () => {
+    // Contract.pdpaConsentId is @unique so we can't reuse the old contract's
+    // consent row. Service clones into a new row so the new contract gets
+    // a fresh consent id while preserving the customer's consent semantics.
     prisma.contractExchangeRequest.updateMany.mockResolvedValue({ count: 1 });
     const old = { ...makeOldContract(12, 4), pdpaConsentId: 'pdpa-old-123' };
+    prisma.contractExchangeRequest.findUniqueOrThrow.mockResolvedValue({
+      id: 'r1', oldContractId: 'old', oldProductId: 'op', newProductId: 'np',
+      oldContract: old,
+    });
+    prisma.payment.count.mockResolvedValue(4);
+    prisma.pDPAConsent.findUnique.mockResolvedValue({
+      id: 'pdpa-old-123',
+      customerId: 'cust-1',
+      consentVersion: 'v1.0',
+      privacyNoticeText: 'Notice',
+      purposes: ['CONTRACT_PROCESSING'],
+      status: 'GRANTED',
+      grantedAt: new Date('2026-01-01'),
+      ipAddress: '127.0.0.1',
+      deviceInfo: null,
+      signatureImage: null,
+    });
+    prisma.pDPAConsent.create.mockResolvedValue({ id: 'pdpa-cloned-456' });
+    prisma.contract.create.mockResolvedValue({ id: 'nc', contractNumber: 'EXCH-20260524-0001' });
+
+    await service.approve('r1', 'u1');
+
+    expect(prisma.pDPAConsent.findUnique).toHaveBeenCalledWith({
+      where: { id: 'pdpa-old-123' },
+    });
+    expect(prisma.pDPAConsent.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        customerId: 'cust-1',
+        consentVersion: 'v1.0',
+        status: 'GRANTED',
+      }),
+    }));
+
+    const createData = prisma.contract.create.mock.calls[0][0].data;
+    expect(createData.pdpaConsentId).toBe('pdpa-cloned-456');
+    expect(createData.pdpaConsentId).not.toBe('pdpa-old-123');
+  });
+
+  it('sets pdpaConsentId=null when old contract has no consent', async () => {
+    prisma.contractExchangeRequest.updateMany.mockResolvedValue({ count: 1 });
+    const old = { ...makeOldContract(12, 4), pdpaConsentId: null };
     prisma.contractExchangeRequest.findUniqueOrThrow.mockResolvedValue({
       id: 'r1', oldContractId: 'old', oldProductId: 'op', newProductId: 'np',
       oldContract: old,
@@ -293,8 +341,10 @@ describe('ContractExchangeService.approve (sign-then-activate)', () => {
 
     await service.approve('r1', 'u1');
 
+    expect(prisma.pDPAConsent.findUnique).not.toHaveBeenCalled();
+    expect(prisma.pDPAConsent.create).not.toHaveBeenCalled();
     const createData = prisma.contract.create.mock.calls[0][0].data;
-    expect(createData.pdpaConsentId).toBe('pdpa-old-123');
+    expect(createData.pdpaConsentId).toBeNull();
   });
 
   it('creates new contract with remaining-installment plan (8 of 12)', async () => {

--- a/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
+++ b/apps/api/src/modules/contract-exchange/contract-exchange.service.ts
@@ -206,8 +206,32 @@ export class ContractExchangeService {
       // approval IS the workflow approval — the customer doesn't need a
       // second review pass before signing.
       //
-      // pdpaConsentId is carried from the old contract — the customer already
-      // consented to the deal; the swap doesn't introduce new personal data.
+      // PDPA consent: Contract.pdpaConsentId is @unique so we can't reuse
+      // the old contract's consent row. Clone it for the new contract — same
+      // customer + same consent semantics + fresh row id satisfies the unique
+      // constraint AND keeps the audit trail per-contract.
+      let clonedPdpaConsentId: string | null = null;
+      if (old.pdpaConsentId) {
+        const oldConsent = await tx.pDPAConsent.findUnique({
+          where: { id: old.pdpaConsentId },
+        });
+        if (oldConsent) {
+          const cloned = await tx.pDPAConsent.create({
+            data: {
+              customerId: oldConsent.customerId,
+              consentVersion: oldConsent.consentVersion,
+              privacyNoticeText: oldConsent.privacyNoticeText,
+              purposes: oldConsent.purposes,
+              status: oldConsent.status,
+              grantedAt: oldConsent.grantedAt,
+              ipAddress: oldConsent.ipAddress,
+              deviceInfo: oldConsent.deviceInfo,
+              signatureImage: oldConsent.signatureImage,
+            },
+          });
+          clonedPdpaConsentId = cloned.id;
+        }
+      }
       const contractNumber = await this.nextExchangeContractNumber(tx);
       const newContract = await tx.contract.create({
         data: {
@@ -218,7 +242,7 @@ export class ContractExchangeService {
           salespersonId: old.salespersonId,
           status: 'DRAFT',
           workflowStatus: 'APPROVED',
-          pdpaConsentId: old.pdpaConsentId ?? null,
+          pdpaConsentId: clonedPdpaConsentId,
           planType: old.planType,
           totalMonths: remainingMonths,
           monthlyPayment,


### PR DESCRIPTION
## Summary

PR #1089 (sign-then-activate flow) introduced a 500 on `approve()` for any exchange whose old contract has a PDPA consent record.

\`Contract.pdpaConsentId\` is \`@unique\` in the schema. PR #1089 copied the old contract's \`pdpaConsentId\` directly onto the new exchange contract, which violates the unique constraint.

```
PrismaClientKnownRequestError:
Invalid `tx.contract.create()` invocation
Unique constraint failed on the fields: (`pdpa_consent_id`)
```

## Fix

Clone the PDPA consent row inside the same \`\$transaction\` — same customer, same purposes, same status, fresh id. New contract gets its own consent row so:
- unique constraint passes
- per-contract audit trail stays accurate
- customer's consent intent is preserved (no need to re-collect)

If old contract has \`pdpaConsentId = null\` (no consent on file), skip the clone — new contract gets \`pdpaConsentId: null\` (activate() will reject if PDPA still required at sign time).

## Repro

Any exchange whose old contract has a non-null \`pdpaConsentId\` (essentially all real customers). Caught locally during sign-flow testing on \`SP2-SIGN-003\`.

## Tests

- 34/34 passing in \`contract-exchange.service.spec.ts\` (+1 new test for null-consent passthrough, +1 expanded test for clone path)
- Type-check clean

## Test plan
- [x] Local repro confirmed: 500 → 200 after fix
- [ ] Owner verifies in dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)