### PR TITLE
feat(inbox): generated avatar fallback + link-customer-from-chat flow

### DIFF
--- a/apps/api/src/modules/chat-engine/services/room-manager.service.ts
+++ b/apps/api/src/modules/chat-engine/services/room-manager.service.ts
@@ -293,6 +293,35 @@ export class RoomManagerService {
     });
   }
 
+  /**
+   * Link an existing Customer record to a ChatRoom. Throws if the room is
+   * already linked to a different customer — relinking requires explicit
+   * unlink-then-link, not silent overwrite.
+   */
+  async linkCustomer(roomId: string, customerId: string) {
+    const room = await this.prisma.chatRoom.findUnique({
+      where: { id: roomId },
+      select: { id: true, customerId: true, deletedAt: true },
+    });
+    if (!room || room.deletedAt) {
+      throw new Error('ห้องแชทไม่พบหรือถูกลบ');
+    }
+    if (room.customerId && room.customerId !== customerId) {
+      throw new Error('ห้องแชทนี้ผูกกับลูกค้ารายอื่นอยู่แล้ว');
+    }
+    const customer = await this.prisma.customer.findUnique({
+      where: { id: customerId },
+      select: { id: true, deletedAt: true },
+    });
+    if (!customer || customer.deletedAt) {
+      throw new Error('ไม่พบลูกค้า');
+    }
+    return this.prisma.chatRoom.update({
+      where: { id: roomId },
+      data: { customerId },
+    });
+  }
+
   /** List rooms for the unified inbox with pagination and filters */
   async listRooms(params: {
     channel?: ChatChannel;

--- a/apps/api/src/modules/staff-chat/staff-chat.controller.ts
+++ b/apps/api/src/modules/staff-chat/staff-chat.controller.ts
@@ -14,6 +14,7 @@ import {
   ParseFilePipe,
   MaxFileSizeValidator,
   FileTypeValidator,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ConfigService } from '@nestjs/config';
@@ -168,6 +169,19 @@ export class StaffChatController {
     @Body('staffId') staffId: string,
   ) {
     await this.assignment.assign(id, staffId);
+    return { success: true };
+  }
+
+  @Patch('rooms/:id/customer')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'SALES')
+  async linkCustomerToRoom(
+    @Param('id') id: string,
+    @Body('customerId') customerId: string,
+  ) {
+    if (!customerId || typeof customerId !== 'string') {
+      throw new BadRequestException('กรุณาระบุ customerId');
+    }
+    await this.roomManager.linkCustomer(id, customerId);
     return { success: true };
   }
 

--- a/apps/web/src/lib/avatar.ts
+++ b/apps/web/src/lib/avatar.ts
@@ -1,0 +1,14 @@
+/**
+ * Deterministic fallback avatar for chat customers whose real profile picture
+ * cannot be fetched from the source channel (e.g. Facebook Messenger PSIDs
+ * which Graph API v25+ blocks for non-admin users until Messenger Profile
+ * App Review passes).
+ *
+ * Uses DiceBear's public SVG endpoint — no auth, CORS-enabled, deterministic
+ * per seed. Browser caches by URL so render cost amortises to one network
+ * fetch per unique customer.
+ */
+export function getGeneratedAvatarUrl(seed: string | null | undefined): string | null {
+  if (!seed) return null;
+  return `https://api.dicebear.com/9.x/avataaars/svg?seed=${encodeURIComponent(seed)}`;
+}

--- a/apps/web/src/pages/CustomersPage.tsx
+++ b/apps/web/src/pages/CustomersPage.tsx
@@ -3,7 +3,7 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useForm } from 'react-hook-form';
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { exportToExcel, type ExcelColumn } from '@/utils/excel.util';
 import { formatDateShort } from '@/utils/formatters';
 import { toast } from 'sonner';
@@ -161,6 +161,8 @@ export default function CustomersPage() {
   const [sortBy, setSortBy] = useState('');
   const [sortOrder, setSortOrder] = useState('asc');
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [linkAfterCreate, setLinkAfterCreate] = useState<{ roomId: string } | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
   const form = useForm<CustomerFormData>({
     resolver: standardSchemaResolver(customerSchema),
     defaultValues: emptyForm,
@@ -181,6 +183,30 @@ export default function CustomersPage() {
   const [cardReaderLoading, setCardReaderLoading] = useState(false);
 
   useEffect(() => { setPage(1); }, [debouncedSearch, contractStatusFilter, hasOverdueFilter, creditStatusFilter, branchFilter, tierFilter, sortBy, sortOrder]);
+
+  // Prefill + auto-open modal when arriving from a chat room "create customer" CTA
+  // Expected query params: ?new=1&name=<displayName>&fromRoomId=<roomId>
+  useEffect(() => {
+    if (searchParams.get('new') !== '1') return;
+    const prefillName = searchParams.get('name') ?? '';
+    const fromRoomId = searchParams.get('fromRoomId');
+    if (prefillName) {
+      const parts = prefillName.trim().split(/\s+/);
+      form.setValue('firstName', parts[0] ?? '');
+      form.setValue('lastName', parts.slice(1).join(' '));
+    }
+    if (fromRoomId) {
+      setLinkAfterCreate({ roomId: fromRoomId });
+    }
+    setIsModalOpen(true);
+    // Clear params so refresh doesn't re-open the modal
+    const next = new URLSearchParams(searchParams);
+    next.delete('new');
+    next.delete('name');
+    next.delete('fromRoomId');
+    setSearchParams(next, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Sync current address when "same as ID card" is checked
   useEffect(() => {
@@ -255,10 +281,26 @@ export default function CustomersPage() {
 
       return api.post('/customers', payload);
     },
-    onSuccess: (res) => {
+    onSuccess: async (res) => {
       queryClient.invalidateQueries({ queryKey: ['customers'] });
       toast.success('เพิ่มลูกค้าสำเร็จ');
       setIsModalOpen(false);
+      // If we arrived here from a chat-room CTA, link the new customer to that room
+      if (linkAfterCreate?.roomId) {
+        try {
+          await api.patch(`/staff-chat/rooms/${linkAfterCreate.roomId}/customer`, {
+            customerId: res.data.id,
+          });
+          queryClient.invalidateQueries({ queryKey: ['chat-room', linkAfterCreate.roomId] });
+          toast.success('ผูกลูกค้ากับแชทแล้ว');
+          setLinkAfterCreate(null);
+          navigate('/inbox');
+          return;
+        } catch (err) {
+          toast.error(`ผูกลูกค้ากับแชทไม่สำเร็จ: ${getErrorMessage(err)}`);
+          // Fall through to default navigation
+        }
+      }
       navigate(`/customers/${res.data.id}`);
     },
     onError: (err: unknown) => {

--- a/apps/web/src/pages/UnifiedInboxPage/components/ChatPanel.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/ChatPanel.tsx
@@ -12,6 +12,7 @@ import CommandPalette from './CommandPalette';
 import AiSuggestPanel from './AiSuggestPanel';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import api from '@/lib/api';
+import { getGeneratedAvatarUrl } from '@/lib/avatar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 // ─── Emoji data ───────────────────────────────────────────────────────────────
@@ -288,7 +289,10 @@ export default function ChatPanel({
     session.lineUserId?.slice(0, 12) ??
     'ไม่ทราบชื่อ';
   const avatarUrl =
-    session.customer?.avatarUrl || session.customer?.lineAvatarUrl || session.pictureUrl;
+    session.customer?.avatarUrl ||
+    session.customer?.lineAvatarUrl ||
+    session.pictureUrl ||
+    getGeneratedAvatarUrl(session.id);
   const isResolved = session.sessionStatus === 'RESOLVED';
 
   return (

--- a/apps/web/src/pages/UnifiedInboxPage/components/ConversationItem.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/ConversationItem.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { th } from 'date-fns/locale';
 import { Badge } from '@/components/ui/badge';
 import { getStatusBadgeProps, sessionPriorityMap } from '@/lib/status-badges';
+import { getGeneratedAvatarUrl } from '@/lib/avatar';
 import { useState } from 'react';
 
 /** Map sentinel-prefixed message bodies to a human-friendly preview. */
@@ -106,7 +107,10 @@ const CHANNEL_CONFIG: Record<string, { bg: string; label: string; text: string }
 function Avatar({ session, displayName }: { session: ConversationItemProps['session']; displayName: string }) {
   const [imgError, setImgError] = useState(false);
   const avatarUrl =
-    session.customer?.avatarUrl || session.customer?.lineAvatarUrl || session.pictureUrl;
+    session.customer?.avatarUrl ||
+    session.customer?.lineAvatarUrl ||
+    session.pictureUrl ||
+    getGeneratedAvatarUrl(session.id);
   const channelCfg = CHANNEL_CONFIG[session.channel] ?? { bg: 'bg-muted-foreground', label: '?' };
 
   return (

--- a/apps/web/src/pages/UnifiedInboxPage/components/Customer360Panel.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/components/Customer360Panel.tsx
@@ -37,6 +37,9 @@ import { format, isPast, differenceInDays } from 'date-fns';
 import { th } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { UserPlus } from 'lucide-react';
+import { getGeneratedAvatarUrl } from '@/lib/avatar';
 
 type DialogView = null | 'send-link';
 
@@ -110,6 +113,17 @@ interface Customer360PanelProps {
   customerId: string | null;
   activeRoomId?: string | null;
   onSelectRoom?: (roomId: string) => void;
+  /**
+   * Lightweight session shape for rendering the no-customer-link empty state.
+   * Used only when `customerId` is null. Optional so existing call sites that
+   * don't pass it still compile (they just see the generic empty state).
+   */
+  session?: {
+    id?: string;
+    channel?: string;
+    displayName?: string | null;
+    pictureUrl?: string | null;
+  } | null;
 }
 
 const channelLabel: Record<string, string> = {
@@ -145,7 +159,7 @@ const sessionStatusLabel: Record<string, string> = {
   ARCHIVED: 'เก็บ',
 };
 
-export default function Customer360Panel({ customerId, activeRoomId, onSelectRoom }: Customer360PanelProps) {
+export default function Customer360Panel({ customerId, activeRoomId, onSelectRoom, session }: Customer360PanelProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [dialogView, setDialogView] = useState<DialogView>(null);
@@ -342,6 +356,61 @@ export default function Customer360Panel({ customerId, activeRoomId, onSelectRoo
   };
 
   if (!customerId) {
+    if (session && (session.displayName || session.id)) {
+      const fallbackName = session.displayName ?? 'ไม่ระบุชื่อ';
+      const avatarUrl = session.pictureUrl ?? getGeneratedAvatarUrl(session.id);
+      const channelName = session.channel ? channelLabel[session.channel] ?? session.channel : null;
+      const channelTone = session.channel ? channelColor[session.channel] : 'bg-muted text-muted-foreground';
+      return (
+        <div className="w-80 border-l border-border flex flex-col p-4 gap-3">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-full overflow-hidden bg-muted shrink-0 ring-1 ring-border">
+              {avatarUrl ? (
+                <img src={avatarUrl} alt={fallbackName} className="w-full h-full object-cover" />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-sm font-bold text-muted-foreground">
+                  {fallbackName.charAt(0)}
+                </div>
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-semibold leading-snug text-foreground truncate">
+                {fallbackName}
+              </div>
+              {channelName && (
+                <span
+                  className={cn(
+                    'inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold mt-1',
+                    channelTone,
+                  )}
+                >
+                  {channelName}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-md border border-dashed border-border bg-muted/30 p-3 text-[11px] leading-relaxed text-muted-foreground">
+            ยังไม่ได้จับคู่ลูกค้านี้กับบันทึกในระบบ — ข้อมูลสัญญา/ผ่อนชำระจะปรากฏหลังสร้างหรือผูกลูกค้า
+          </div>
+
+          <Button
+            variant="primary"
+            size="sm"
+            className="w-full"
+            onClick={() => {
+              const params = new URLSearchParams({ new: '1' });
+              if (session.displayName) params.set('name', session.displayName);
+              if (activeRoomId) params.set('fromRoomId', activeRoomId);
+              navigate(`/customers?${params.toString()}`);
+            }}
+          >
+            <UserPlus className="w-3.5 h-3.5 mr-1.5" />
+            สร้างลูกค้าจากแชทนี้
+          </Button>
+        </div>
+      );
+    }
     return (
       <div className="w-80 border-l border-border flex flex-col items-center justify-center text-center p-6">
         <div className="relative mb-4">

--- a/apps/web/src/pages/UnifiedInboxPage/index.tsx
+++ b/apps/web/src/pages/UnifiedInboxPage/index.tsx
@@ -299,7 +299,12 @@ export default function UnifiedInboxPage() {
 
       {/* Right panel: Customer 360 — always visible on xl+ */}
       <div className="hidden xl:block">
-        <Customer360Panel customerId={customerId} activeRoomId={activeRoomId} onSelectRoom={handleSelectRoom} />
+        <Customer360Panel
+          customerId={customerId}
+          activeRoomId={activeRoomId}
+          onSelectRoom={handleSelectRoom}
+          session={sessionQuery.data}
+        />
       </div>
 
       {/* Right panel as Drawer on < xl */}
@@ -313,6 +318,7 @@ export default function UnifiedInboxPage() {
               handleSelectRoom(id);
               setCustomerPanelOpen(false);
             }}
+            session={sessionQuery.data}
           />
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
## Summary
- Add DiceBear deterministic avatar fallback for chat customers whose real profile photo can't be fetched (FB PSIDs blocked by Graph API v25 in dev mode — internal-only deployment means we're not pursuing pages_messaging Advanced Access).
- Replace Customer360Panel generic empty state with session-aware card showing avatar + displayName + channel badge + "สร้างลูกค้าจากแชทนี้" CTA.
- New backend endpoint \`PATCH /staff-chat/rooms/:id/customer\` to atomically link a Customer record to a chat room. CustomersPage reads \`?new=1&name=&fromRoomId=\` query params to prefill the create-modal and auto-link on success.

## Files
- **lib util (new)**: \`apps/web/src/lib/avatar.ts\` — \`getGeneratedAvatarUrl(seed)\` (DiceBear avataaars SVG, URL-only, browser-cached)
- **Avatar chain**: \`ConversationItem.tsx\` + \`ChatPanel.tsx\` — DiceBear is the last fallback (real customer.avatarUrl / lineAvatarUrl / room.pictureUrl still win)
- **Customer panel UX**: \`Customer360Panel.tsx\` accepts new optional \`session\` prop; \`UnifiedInboxPage/index.tsx\` passes \`session={sessionQuery.data}\` to both desktop + drawer instances
- **Customer create flow**: \`CustomersPage.tsx\` reads \`?new=1\` to auto-open modal, splits \`?name=\` into firstName/lastName, saves \`?fromRoomId=\`, and \`createMutation.onSuccess\` PATCHes the room-customer link then navigates to \`/inbox\`
- **Backend**: \`RoomManager.linkCustomer\` guards relink + soft-deletion; \`staff-chat.controller.ts\` exposes endpoint to OWNER/BM/FM/SALES

## Why these are joined
Both gaps surfaced from the same root question ("ทำไม profile ไม่ขึ้น"). Bug A is the visible avatar; Bug B is the right panel that says "เลือกแชทเพื่อดูข้อมูลลูกค้า" even when chat IS selected. Both originate from missing customer linkage for FB rooms, so the CTA in the panel + the avatar fallback ship together as one inbox-UX delta.

## Test plan
- [ ] Open \`/inbox\` → FB customer (e.g. Ratta Nui) shows unique DiceBear avatar instead of bare initial
- [ ] Right panel shows displayName + Facebook badge + "สร้างลูกค้าจากแชทนี้" button
- [ ] Click CTA → \`/customers?new=1&name=Ratta+Nui&fromRoomId=…\` → modal opens with firstName="Ratta", lastName="Nui" prefilled
- [ ] Fill nationalId + phone → submit → toast "ผูกลูกค้ากับแชทแล้ว" → redirect to \`/inbox\` → right panel now shows full Customer360
- [ ] Relink attempt (different customerId to same room) → API returns "ห้องแชทนี้ผูกกับลูกค้ารายอื่นอยู่แล้ว"
- [ ] LINE customer with real avatar still shows their real photo (DiceBear doesn't override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)