### PR TITLE
feat(chat): try direct Messenger User Profile API before workaround

### DIFF
--- a/apps/api/src/modules/chat-adapters/facebook.adapter.ts
+++ b/apps/api/src/modules/chat-adapters/facebook.adapter.ts
@@ -130,12 +130,51 @@ export class FacebookAdapter implements IChannelAdapter {
 
   async getUserProfile(externalUserId: string): Promise<UserProfile | null> {
     if (!this.pageAccessToken || !this.pageId) return null;
+
+    // Try 1 — Messenger User Profile API (returns name + profile_pic).
+    // Works only when pages_messaging is at Advanced Access tier (post App Review).
+    // Currently returns 400/100/33 in dev mode; falls through silently.
+    const direct = await this.fetchDirectProfile(externalUserId);
+    if (direct) return direct;
+
+    // Try 2 — Workaround via /me/conversations participants (returns name only,
+    // no profile_pic). Always works while pages_messaging is granted.
+    return this.fetchProfileViaConversations(externalUserId);
+  }
+
+  private async fetchDirectProfile(externalUserId: string): Promise<UserProfile | null> {
     try {
-      // FB v25 deprecated direct /{psid}?fields=name lookups even with pages_messaging.
-      // Targeted conversation lookup via user_id returns participants with name.
+      const url =
+        `https://graph.facebook.com/v25.0/${encodeURIComponent(externalUserId)}` +
+        `?fields=name,profile_pic&access_token=${encodeURIComponent(this.pageAccessToken!)}`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+      if (!res.ok) return null;
+      const json = (await res.json()) as { name?: string; profile_pic?: string };
+      if (!json.name) return null;
+      return { displayName: json.name, avatarUrl: json.profile_pic };
+    } catch (err) {
+      const isTimeout = err instanceof Error && err.name === 'TimeoutError';
+      if (isTimeout) {
+        this.logger.warn(`[FB] fetchDirectProfile timeout for PSID ${externalUserId}`);
+        Sentry.captureException(err, {
+          tags: {
+            module: 'chat-adapter-facebook',
+            action: 'fetch_direct_profile',
+            reason: 'timeout',
+          },
+        });
+      }
+      return null;
+    }
+  }
+
+  private async fetchProfileViaConversations(
+    externalUserId: string,
+  ): Promise<UserProfile | null> {
+    try {
       const url =
         `https://graph.facebook.com/v25.0/me/conversations?user_id=${encodeURIComponent(externalUserId)}` +
-        `&fields=participants&access_token=${encodeURIComponent(this.pageAccessToken)}`;
+        `&fields=participants&access_token=${encodeURIComponent(this.pageAccessToken!)}`;
       const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
       if (!res.ok) return null;
       const json = (await res.json()) as {
@@ -148,9 +187,15 @@ export class FacebookAdapter implements IChannelAdapter {
     } catch (err) {
       const isTimeout = err instanceof Error && err.name === 'TimeoutError';
       if (isTimeout) {
-        this.logger.warn(`[FB] getUserProfile timeout for PSID ${externalUserId}`);
+        this.logger.warn(
+          `[FB] fetchProfileViaConversations timeout for PSID ${externalUserId}`,
+        );
         Sentry.captureException(err, {
-          tags: { module: 'chat-adapter-facebook', action: 'get_user_profile', reason: 'timeout' },
+          tags: {
+            module: 'chat-adapter-facebook',
+            action: 'fetch_profile_via_conversations',
+            reason: 'timeout',
+          },
         });
       }
       return null;


### PR DESCRIPTION
## Summary
Forward-compatible refactor of \`facebook.adapter.ts:getUserProfile()\` — try the canonical Messenger User Profile endpoint first; fall through silently to the existing \`/me/conversations\` workaround when it returns 400 (current dev-mode behavior).

The moment Meta flips pages_messaging to Advanced Access (App Review currently pending — see screenshot in chat), real Facebook profile pictures start populating on the next inbound webhook for each customer. No further code change or deploy is needed at that point.

## Behavior matrix

| pages_messaging tier | Today | After approval |
|---|---|---|
| Direct \`/v25.0/{PSID}?fields=name,profile_pic\` | 400/100/33 | 200 with profile_pic URL |
| Adapter falls through to \`/me/conversations\` | Yes — name-only | No — short-circuits |
| Frontend \`room.pictureUrl\` | null → DiceBear fallback (PR #1091) | Real photo → DiceBear becomes invisible |

## Verification
- Verified 400 against 3 fresh PSIDs (Wiwat Leks, Nan Wichuda, ภัทรวดี บัวคีรี) on \`/v25.0/{PSID}?fields=name,profile_pic\` with current page token
- Verified \`pages_messaging\` send action (typing_on) still works — confirms permission is granted, just not at Advanced tier
- TS check: 0 errors on \`apps/api\`

## Test plan
- [ ] Today (dev mode): inbound FB message → \`room.pictureUrl\` stays null → DiceBear renders (no regression vs #1091)
- [ ] Post-approval: same flow → \`room.pictureUrl\` populated with \`platform-lookaside.fbsbx.com/...\` URL → real photo renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)