### PR TITLE
fix(letters): add /letters menu for SALES + ACCOUNTANT

### DIFF
--- a/apps/web/src/config/menu.ts
+++ b/apps/web/src/config/menu.ts
@@ -164,6 +164,7 @@ const SALES_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'สัญญาผ่อนชำระ', path: '/contracts', icon: FileCheck },
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
+        { label: 'จัดการจดหมาย', path: '/letters', icon: Mail },
         { label: 'รับซ่อม/รับประกัน', path: '/insurance', icon: ShieldCheck },
         { label: 'เช็คประกัน', path: '/insurance/warranty-check', icon: ShieldCheck },
       ],
@@ -387,6 +388,7 @@ const ACCOUNTANT_CONFIG: RoleMenuConfig = {
       items: [
         { label: 'รับชำระค่างวด', path: '/payments', icon: HandCoins },
         { label: 'บันทึกรายจ่าย', path: '/expenses', icon: Receipt },
+        { label: 'จัดการจดหมาย', path: '/letters', icon: Mail },
         { label: 'พิมพ์สติกเกอร์', path: '/stickers', icon: Tag },
         { label: 'งานของทีม', path: '/todos', icon: CheckSquare },
       ],


### PR DESCRIPTION
## Summary
- Backend already allows SALES and ACCOUNTANT to access \`/letters\` but the sidebar menu was missing for them
- SALES: เพิ่ม "จัดการจดหมาย" ใต้ section "สัญญา & ชำระ" (ใต้รับชำระค่างวด)
- ACCOUNTANT: เพิ่ม "จัดการจดหมาย" ใต้ section "งานประจำวัน" (ใต้บันทึกรายจ่าย)

## Why missed in #1099
Task 20 told the agent "insert next to each /overdue entry" — SALES and ACCOUNTANT don't have /overdue in their menus (they reach Collections via other paths), so the agent skipped them.

## Test plan
- [ ] Login as SALES → verify "จัดการจดหมาย" visible in sidebar under "สัญญา & ชำระ"
- [ ] Login as ACCOUNTANT → verify "จัดการจดหมาย" visible in sidebar under "งานประจำวัน"
- [ ] Click → routes to /letters → page loads, list filtered to user's scope (SALES = own branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)