### PR TITLE
fix(letters): open dispatch dialog in correct mode for PDF_GENERATED rows

### DIFF
--- a/apps/web/src/pages/LettersPage/index.tsx
+++ b/apps/web/src/pages/LettersPage/index.tsx
@@ -198,7 +198,7 @@ export default function LettersPage() {
         <LetterDispatchDialog
           open={!!dispatchRow}
           letter={dispatchRow}
-          initialMode={dispatchRow.pdfUrl ? 'dispatch' : 'generate'}
+          initialMode={dispatchRow.status === 'PDF_GENERATED' ? 'dispatch' : 'generate'}
           onClose={() => setDispatchRow(null)}
         />
       )}


### PR DESCRIPTION
Tab 'พิมพ์แล้ว' (PDF_GENERATED) — clicking 'ส่ง' on a row was opening the dialog in 'generate' mode instead of showing the EMS tracking# input.

Root cause: condition was `dispatchRow.pdfUrl ? 'dispatch' : 'generate'`. But pdfUrl is null for letters auto-marked via the Download flow (we made pdfUrl optional in #1099-era). Status is the authoritative signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)