### PR TITLE
fix(letters): drop evidence upload from dispatch dialog

### DIFF
--- a/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
+++ b/apps/web/src/pages/CollectionsPage/components/LetterDispatchDialog.tsx
@@ -275,31 +275,9 @@ interface DispatchSectionProps {
 
 function DispatchSection({ letter, onClose }: DispatchSectionProps) {
   const [tracking, setTracking] = useState('');
-  const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
-  const [evidenceVerified, setEvidenceVerified] = useState(false);
   const [busy, setBusy] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const { dispatch } = useLetterActions();
-
-  // Create a local preview URL for the selected evidence file
-  const evidencePreviewUrl = useMemo(
-    () => (evidenceFile ? URL.createObjectURL(evidenceFile) : null),
-    [evidenceFile],
-  );
-
-  // Revoke object URL when file changes or component unmounts
-  useEffect(() => {
-    return () => {
-      if (evidencePreviewUrl) URL.revokeObjectURL(evidencePreviewUrl);
-    };
-  }, [evidencePreviewUrl]);
-
-  // Reset verification whenever file changes — user must re-verify
-  useEffect(() => {
-    setEvidenceVerified(false);
-  }, [evidenceFile]);
-
-  const evidenceUrls = evidencePreviewUrl ? [evidencePreviewUrl] : [];
 
   const handleSubmit = async () => {
     if (tracking.trim().length < 5) {
@@ -308,28 +286,10 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
     }
     setBusy(true);
     try {
-      let evidencePhotoUrl: string | undefined;
-
-      if (evidenceFile) {
-        const { data: presigned } = await api.post('/shop/upload/signed-url', {
-          kind: 'LETTER_EVIDENCE',
-          contentType: evidenceFile.type,
-        });
-        const up = await fetch(presigned.uploadUrl, {
-          method: presigned.method ?? 'PUT',
-          body: evidenceFile,
-          headers: { 'Content-Type': evidenceFile.type },
-        });
-        if (!up.ok) throw new Error(`อัปโหลดรูปไม่สำเร็จ (HTTP ${up.status})`);
-        evidencePhotoUrl = presigned.publicUrl;
-      }
-
       await dispatch.mutateAsync({
         letterId: letter.id,
         trackingNumber: tracking.trim(),
-        evidencePhotoUrl,
       });
-
       onClose();
     } catch (err) {
       toast.error(getErrorMessage(err));
@@ -401,39 +361,6 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
         )}
       </div>
 
-      {/* Evidence photo upload + preview */}
-      <div className="space-y-2">
-        <label className="text-xs font-medium text-muted-foreground block leading-snug">
-          รูปใบรับส่งไปรษณีย์ (ไม่บังคับ)
-        </label>
-
-        <EvidenceThumbnailGrid
-          urls={evidenceUrls}
-          onRemove={() => setEvidenceFile(null)}
-        />
-
-        <input
-          type="file"
-          accept="image/*"
-          onChange={(e) => setEvidenceFile(e.target.files?.[0] ?? null)}
-          className="text-sm text-muted-foreground file:mr-3 file:rounded-lg file:border file:border-input file:bg-muted file:px-3 file:py-1 file:text-xs file:font-medium file:text-foreground hover:file:bg-accent cursor-pointer"
-        />
-        {evidenceFile && (
-          <p className="text-[10px] text-muted-foreground leading-snug">
-            {evidenceFile.name} ({(evidenceFile.size / 1024).toFixed(0)} KB)
-          </p>
-        )}
-
-        <label className="flex items-start gap-2 text-sm pt-1 cursor-pointer">
-          <Checkbox
-            checked={evidenceVerified}
-            onCheckedChange={(v) => setEvidenceVerified(v === true)}
-            className="mt-0.5"
-          />
-          <span className="leading-snug text-foreground">ตรวจสอบหลักฐานการส่งถูกต้องแล้ว</span>
-        </label>
-      </div>
-
       {/* Actions */}
       <div className="flex gap-2 justify-end pt-2">
         <button
@@ -446,7 +373,7 @@ function DispatchSection({ letter, onClose }: DispatchSectionProps) {
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={busy || !trackingValid || !evidenceVerified}
+          disabled={busy || !trackingValid}
           className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
           {busy ? (


### PR DESCRIPTION
Per owner request — เอา section รูปใบรับส่งไปรษณีย์ + checkbox ตรวจสอบหลักฐานออก. กรอกแค่เลข EMS ก็พอ.

Removed from DispatchSection:
- File picker + thumbnail
- Required "ตรวจสอบหลักฐานการส่งถูกต้องแล้ว" checkbox
- S3 presigned upload in handleSubmit
- Related state

Schema field `evidencePhotoUrl` kept (nullable) — future re-add doesn't need migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)