### PR TITLE
fix(facebook-webhook): resolve verify token + app secret from IntegrationConfig

### DIFF
--- a/apps/api/src/modules/chat-adapters/chat-adapters.module.ts
+++ b/apps/api/src/modules/chat-adapters/chat-adapters.module.ts
@@ -12,6 +12,7 @@ import { ChatEngineModule } from '../chat-engine/chat-engine.module';
 import { FacebookDomainModule } from '../facebook-domain/facebook-domain.module';
 import { MessageRouterService } from '../chat-engine/services/message-router.service';
 import { StaffChatModule } from '../staff-chat/staff-chat.module';
+import { IntegrationsModule } from '../integrations/integrations.module';
 
 /**
  * ChatAdaptersModule — provides IChannelAdapter implementations for all channels.
@@ -28,6 +29,8 @@ import { StaffChatModule } from '../staff-chat/staff-chat.module';
     LineOaModule,
     ChatEngineModule,
     FacebookDomainModule,
+    // FacebookWebhookController reads verify token + app secret from IntegrationConfig.
+    IntegrationsModule,
     // Phase 5 — FacebookWebhookController injects QuickReplyPostbackRouterService.
     forwardRef(() => StaffChatModule),
   ],

--- a/apps/api/src/modules/chat-adapters/facebook-webhook.controller.spec.ts
+++ b/apps/api/src/modules/chat-adapters/facebook-webhook.controller.spec.ts
@@ -9,6 +9,17 @@ import { MessageRouterService } from '../chat-engine/services/message-router.ser
 import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
 import { QuickReplyPostbackRouterService } from '../staff-chat/services/quick-reply-postback-router.service';
 import { PrismaService } from '../../prisma/prisma.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+
+/**
+ * Mock IntegrationConfigService.getConfig('facebook') — the controller now
+ * reads appSecret + verifyToken from here (DB → env fallback) instead of env.
+ */
+function fbConfigMock(appSecret = 'secret', verifyToken = 'verify-token') {
+  return {
+    getConfig: jest.fn().mockResolvedValue({ appSecret, verifyToken }),
+  };
+}
 
 jest.mock('@sentry/nestjs', () => ({
   captureException: jest.fn(),
@@ -55,6 +66,7 @@ describe('FacebookWebhookController.handleWebhook — rawBody SLO alert (T6-C14)
         { provide: WebhookAnomalyService, useValue: anomaly },
         { provide: QuickReplyPostbackRouterService, useValue: postbackRouter },
         { provide: PrismaService, useValue: prisma },
+        { provide: IntegrationConfigService, useValue: fbConfigMock() },
       ],
     }).compile();
 
@@ -130,6 +142,7 @@ describe('FacebookWebhookController.handleWebhook — message_echoes', () => {
         { provide: WebhookAnomalyService, useValue: anomaly },
         { provide: QuickReplyPostbackRouterService, useValue: postbackRouter },
         { provide: PrismaService, useValue: prisma },
+        { provide: IntegrationConfigService, useValue: fbConfigMock() },
       ],
     }).compile();
 
@@ -217,6 +230,7 @@ describe('FacebookWebhookController.handleWebhook — message_echoes', () => {
         { provide: WebhookAnomalyService, useValue: anomaly },
         { provide: QuickReplyPostbackRouterService, useValue: postbackRouter },
         { provide: PrismaService, useValue: prisma },
+        { provide: IntegrationConfigService, useValue: fbConfigMock() },
       ],
     }).compile();
     const localController = mod.get(FacebookWebhookController);
@@ -313,5 +327,59 @@ describe('FacebookWebhookController.handleWebhook — message_echoes', () => {
       }),
     );
     expect(router.mirrorOutbound).not.toHaveBeenCalled();
+  });
+});
+
+describe('FacebookWebhookController.verifyWebhook — verify token from IntegrationConfig', () => {
+  let controller: FacebookWebhookController;
+  let integrationConfig: { getConfig: jest.Mock };
+
+  function makeRes() {
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    return res as unknown as import('express').Response & {
+      status: jest.Mock;
+      send: jest.Mock;
+    };
+  }
+
+  beforeEach(async () => {
+    integrationConfig = fbConfigMock('secret', 'verify-token');
+    const mod: TestingModule = await Test.createTestingModule({
+      controllers: [FacebookWebhookController],
+      providers: [
+        { provide: MessageRouterService, useValue: { routeInbound: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: WebhookAnomalyService, useValue: { record: jest.fn() } },
+        { provide: QuickReplyPostbackRouterService, useValue: { route: jest.fn() } },
+        { provide: PrismaService, useValue: {} },
+        { provide: IntegrationConfigService, useValue: integrationConfig },
+      ],
+    }).compile();
+    controller = mod.get(FacebookWebhookController);
+  });
+
+  it('returns the challenge when verify token matches the UI-configured value', async () => {
+    const res = makeRes();
+    await controller.verifyWebhook('subscribe', 'verify-token', 'CHALLENGE_123', res);
+    expect(integrationConfig.getConfig).toHaveBeenCalledWith('facebook');
+    expect((res as any).status).toHaveBeenCalledWith(200);
+    expect((res as any).send).toHaveBeenCalledWith('CHALLENGE_123');
+  });
+
+  it('rejects with 400 when the token does not match', async () => {
+    const res = makeRes();
+    await controller.verifyWebhook('subscribe', 'wrong-token', 'CHALLENGE_123', res);
+    expect((res as any).status).toHaveBeenCalledWith(400);
+    expect((res as any).send).not.toHaveBeenCalledWith('CHALLENGE_123');
+  });
+
+  it('rejects with 400 when no verify token is configured (fail closed)', async () => {
+    integrationConfig.getConfig.mockResolvedValueOnce({ appSecret: 'secret', verifyToken: '' });
+    const res = makeRes();
+    await controller.verifyWebhook('subscribe', '', 'CHALLENGE_123', res);
+    expect((res as any).status).toHaveBeenCalledWith(400);
   });
 });

--- a/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
+++ b/apps/api/src/modules/chat-adapters/facebook-webhook.controller.ts
@@ -24,6 +24,7 @@ import { RawBodyRequest } from '../../common/types/raw-body-request';
 import { WebhookAnomalyService } from '../webhook-security/webhook-anomaly.service';
 import { QuickReplyPostbackRouterService } from '../staff-chat/services/quick-reply-postback-router.service';
 import { PrismaService } from '../../prisma/prisma.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
 
 /**
  * Facebook Messenger Webhook Controller
@@ -33,8 +34,10 @@ import { PrismaService } from '../../prisma/prisma.service';
  * 2. POST — Inbound message/postback events (HMAC-SHA256 signed)
  *
  * Security:
- * - GET verification uses FB_VERIFY_TOKEN (shared secret set in FB App dashboard)
- * - POST payloads verified via HMAC-SHA256 using FB_APP_SECRET
+ * - GET verification uses the verify token from IntegrationConfig (Settings →
+ *   Integrations, with FB_VERIFY_TOKEN env as fallback)
+ * - POST payloads verified via HMAC-SHA256 using the app secret from
+ *   IntegrationConfig (FB_APP_SECRET env as fallback)
  * - Returns 200 immediately; Facebook retries on non-2xx after timeout
  *
  * This controller is intentionally public (no JwtAuthGuard) — it receives
@@ -50,7 +53,17 @@ export class FacebookWebhookController {
     private anomaly: WebhookAnomalyService,
     private postbackRouter: QuickReplyPostbackRouterService,
     private prisma: PrismaService,
+    private integrationConfig: IntegrationConfigService,
   ) {}
+
+  /**
+   * Resolve the Facebook App Secret from IntegrationConfig (DB → FB_APP_SECRET
+   * env fallback). Returns undefined when unset so callers fail closed.
+   */
+  private async getAppSecret(): Promise<string | undefined> {
+    const cfg = await this.integrationConfig.getConfig('facebook');
+    return cfg.appSecret || undefined;
+  }
 
   /**
    * Webhook verification — Facebook sends GET with hub.challenge on setup.
@@ -58,14 +71,15 @@ export class FacebookWebhookController {
    */
   @Get()
   @SkipCsrf()
-  verifyWebhook(
+  async verifyWebhook(
     @Query('hub.mode') mode: string,
     @Query('hub.verify_token') token: string,
     @Query('hub.challenge') challenge: string,
     @Res() res: Response,
-  ): void {
-    const verifyToken = this.configService.get<string>('FB_VERIFY_TOKEN');
-    if (mode === 'subscribe' && token === verifyToken) {
+  ): Promise<void> {
+    const cfg = await this.integrationConfig.getConfig('facebook');
+    const verifyToken = cfg.verifyToken || undefined;
+    if (mode === 'subscribe' && verifyToken && token === verifyToken) {
       this.logger.log('[FB Webhook] Verification succeeded');
       res.status(200).send(challenge);
       return;
@@ -114,7 +128,7 @@ export class FacebookWebhookController {
     }
 
     // 1. Verify HMAC-SHA256 signature against raw request bytes
-    if (!this.verifySignature(rawBody, signature)) {
+    if (!(await this.verifySignature(rawBody, signature))) {
       this.logger.warn('[FB Webhook] Invalid signature — rejecting payload');
       void this.anomaly.record({
         provider: 'facebook',
@@ -392,7 +406,7 @@ export class FacebookWebhookController {
   async handleDataDeletion(
     @Body() body: { signed_request?: string },
   ): Promise<{ url: string; confirmation_code: string }> {
-    const appSecret = this.configService.get<string>('FB_APP_SECRET');
+    const appSecret = await this.getAppSecret();
     if (!appSecret || !body.signed_request) {
       this.logger.warn('[FB Data Deletion] Missing app secret or signed_request');
       throw new BadRequestException('Invalid request');
@@ -448,7 +462,7 @@ export class FacebookWebhookController {
     if (body.signed_request) {
       const [sigB64, payloadB64] = body.signed_request.split('.');
       if (sigB64 && payloadB64) {
-        const appSecret = this.configService.get<string>('FB_APP_SECRET');
+        const appSecret = await this.getAppSecret();
         if (appSecret) {
           const expectedSig = createHmac('sha256', appSecret)
             .update(payloadB64)
@@ -472,8 +486,8 @@ export class FacebookWebhookController {
    * main.ts json() verify callback), not JSON.stringify(parsed), because
    * re-serialization can differ in whitespace/ordering and break verification.
    */
-  private verifySignature(rawBody: Buffer | undefined, signature: string): boolean {
-    const appSecret = this.configService.get<string>('FB_APP_SECRET');
+  private async verifySignature(rawBody: Buffer | undefined, signature: string): Promise<boolean> {
+    const appSecret = await this.getAppSecret();
     if (!appSecret || !signature) {
       this.logger.warn('[FB Webhook] Missing app secret or signature');
       return false;


### PR DESCRIPTION
## Summary
- Facebook webhook controller previously read `FB_VERIFY_TOKEN` and `FB_APP_SECRET` from **env only**, so values entered in Settings → Integrations (stored in DB) were ignored. Webhook verification (GET challenge) + inbound HMAC checks would fail in production unless env vars were set separately.
- Now the GET verify handler, POST signature check, `data-deletion`, and `deauthorize` handlers all resolve `verifyToken` / `appSecret` via `IntegrationConfig.getConfig('facebook')` (DB → env fallback) — consistent with the outgoing/app-review paths. Fails closed when unset.
- Wired `IntegrationsModule` into `ChatAdaptersModule` for DI.

## Test plan
- [x] `npx jest facebook-webhook.controller` → 10/10 pass (incl. new verify-token-from-config cases: match→challenge, mismatch→400, unset→fail-closed 400)
- [x] Typecheck of changed files clean (pre-existing `@prisma/client-finance` errors unrelated)
- [ ] After deploy: set FB App webhook Callback URL = `https://api.bestchoicephone.app/api/webhooks/facebook`, Verify Token = value from Settings → Integrations → confirm verification succeeds + inbound message lands in `/chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)