### PR TITLE
fix(integrations): allow ACCOUNTANT read-only access to integration config

### DIFF
--- a/apps/api/src/modules/integrations/integrations.controller.ts
+++ b/apps/api/src/modules/integrations/integrations.controller.ts
@@ -27,22 +27,22 @@ export class IntegrationsController {
   ) {}
 
   @Get()
-  @Roles('OWNER')
+  @Roles('OWNER', 'ACCOUNTANT')
   @ApiOperation({ summary: 'รายการ integration ทั้งหมดพร้อมสถานะ' })
   listAll() {
     return this.integrationsService.listAll();
   }
 
   @Get('registry')
-  @Roles('OWNER')
+  @Roles('OWNER', 'ACCOUNTANT')
   @ApiOperation({ summary: 'Integration definitions สำหรับสร้าง form ฝั่ง frontend' })
   getRegistry() {
     return INTEGRATIONS;
   }
 
   @Get(':key/config')
-  @Roles('OWNER')
-  @ApiOperation({ summary: 'ดู config ที่ masked สำหรับ integration' })
+  @Roles('OWNER', 'ACCOUNTANT')
+  @ApiOperation({ summary: 'ดู config ที่ masked สำหรับ integration (read-only สำหรับ ACCOUNTANT — reviewer panel)' })
   async getConfig(@Param('key') key: string) {
     const def = getIntegrationDef(key);
     const masked = await this.configService.getMaskedConfig(key);


### PR DESCRIPTION
## Summary
- The Meta App Review reviewer account (role ACCOUNTANT) could open `/settings/integrations` but the integration cards + Facebook App Review Panel failed to load: the GET endpoints (`/integrations`, `/integrations/registry`, `/integrations/:key/config`) were `@Roles('OWNER')` only → 403 for ACCOUNTANT → feature untestable.
- Opened the 3 GET endpoints to `OWNER, ACCOUNTANT`. Config is already masked via `getMaskedConfig` (no plaintext secrets). Writes (PUT / POST test / DELETE) remain OWNER-only.

## Test plan
- [x] Typecheck clean for changed file (pre-existing `@prisma/client-finance` errors unrelated)
- [ ] After deploy: log in as the ACCOUNTANT reviewer account → `/settings/integrations` → Facebook Messenger card + App Review Panel render → "ยิง API" buttons work; Save/Delete still hidden/blocked for ACCOUNTANT

🤖 Generated with [Claude Code](https://claude.com/claude-code)