### PR TITLE
feat(assets): daily depreciation + expense-style cost entry

### DIFF
--- a/apps/api/prisma/migrations/20260964000000_add_daily_depr_to_fixed_assets/migration.sql
+++ b/apps/api/prisma/migrations/20260964000000_add_daily_depr_to_fixed_assets/migration.sql
@@ -1,0 +1,16 @@
+-- Daily straight-line depreciation: store the 4-dp daily rate alongside the
+-- nominal monthly figure. Additive + safe (default 0, then backfilled).
+-- dailyDepr = (cost − salvage) ÷ (usefulLifeMonths ÷ 12 × 365)
+
+ALTER TABLE "fixed_assets"
+  ADD COLUMN IF NOT EXISTS "daily_depr" DECIMAL(12, 4) NOT NULL DEFAULT 0;
+
+-- Backfill existing rows from the same formula the service uses.
+UPDATE "fixed_assets"
+SET "daily_depr" = ROUND(
+  ("purchase_cost" - "residual_value")
+    / (("useful_life_months"::numeric * 365) / 12),
+  4
+)
+WHERE "useful_life_months" > 0
+  AND ("purchase_cost" - "residual_value") > 0;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3267,7 +3267,8 @@ model FixedAsset {
   purchaseCost     Decimal @map("purchase_cost") @db.Decimal(12, 2) // basePrice + ship + install + other (no VAT/WHT)
   residualValue    Decimal @default(0) @map("residual_value") @db.Decimal(12, 2)
   usefulLifeMonths Int     @map("useful_life_months")
-  monthlyDepr      Decimal @map("monthly_depr") @db.Decimal(12, 4) // 4 decimals to avoid drift over months
+  monthlyDepr      Decimal @map("monthly_depr") @db.Decimal(12, 4) // nominal base/months (display only)
+  dailyDepr        Decimal @default(0) @map("daily_depr") @db.Decimal(12, 4) // (cost−salvage) ÷ (years×365); actual posting basis
   accumulatedDepr  Decimal @default(0) @map("accumulated_depr") @db.Decimal(12, 2)
   netBookValue     Decimal @map("net_book_value") @db.Decimal(12, 2)
 

--- a/apps/api/src/modules/asset/__tests__/asset.service.spec.ts
+++ b/apps/api/src/modules/asset/__tests__/asset.service.spec.ts
@@ -1244,8 +1244,8 @@ describe('AssetService — CRUD + helpers', () => {
   // Phase 3 — Task 2: getAssetSchedule (per-asset NBV month-by-month projection)
   // ==========================================================================
   describe('AssetService.getAssetSchedule', () => {
-    it('produces schedule rows from purchase to fully depreciated, capped at 60 months', async () => {
-      // basePrice 36000, usefulLife 36 → monthlyDepr = 1000, residual = 0
+    it('produces day-based schedule from purchase to fully depreciated', async () => {
+      // basePrice 36000, usefulLife 36, residual 0 → daily 36000/1095 = 32.8767
       const a = await createPostedAsset({
         purchaseDate: '2026-01-15',
         basePrice: 36000,
@@ -1253,9 +1253,18 @@ describe('AssetService — CRUD + helpers', () => {
       });
       const result = await service.getAssetSchedule(a.id);
       expect(result.assetId).toBe(a.id);
-      expect(result.rows.length).toBe(36); // 36 months for 36000 / 1000
-      expect(result.rows[35].status).toBe('FULLY_DEPRECIATED');
-      expect(new Decimal(result.rows[35].netBookValue).equals(0)).toBe(true);
+      // First period is partial: 15..31 Jan = 17 days
+      expect(result.rows[0].period).toBe('2026-01');
+      expect(result.rows[0].days).toBe(17);
+      // Ends fully depreciated, NBV 0, and Σ = depreciable base (36000)
+      const last = result.rows[result.rows.length - 1];
+      expect(last.status).toBe('FULLY_DEPRECIATED');
+      expect(new Decimal(last.netBookValue).equals(0)).toBe(true);
+      const sum = result.rows.reduce(
+        (s, r) => s.plus(r.monthlyDepr),
+        new Decimal(0),
+      );
+      expect(sum.equals(36000)).toBe(true);
     });
 
     it('last period adjusts to residualValue floor (no over-depreciation)', async () => {
@@ -1301,9 +1310,9 @@ describe('AssetService — CRUD + helpers', () => {
       const feb = result.rows.find((r) => r.period === '2026-02')!;
       expect(feb).toBeTruthy();
       expect(new Decimal(feb.monthlyDepr).equals(950)).toBe(true);
-      // Sanity: Jan still uses projection (1000)
+      // Sanity: Jan still uses day-based projection (32.8767 × 31 = 1019.18)
       const jan = result.rows.find((r) => r.period === '2026-01')!;
-      expect(new Decimal(jan.monthlyDepr).equals(1000)).toBe(true);
+      expect(new Decimal(jan.monthlyDepr).equals('1019.18')).toBe(true);
     });
   });
 });

--- a/apps/api/src/modules/asset/__tests__/depreciation-schedule.util.spec.ts
+++ b/apps/api/src/modules/asset/__tests__/depreciation-schedule.util.spec.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from '@jest/globals';
+import { Decimal } from '@prisma/client/runtime/library';
+import {
+  buildDepreciationSchedule,
+  depreciationForPeriod,
+} from '../depreciation-schedule.util';
+
+const sum = (rows: { amount: Decimal }[]) =>
+  rows.reduce((s, r) => s.plus(r.amount), new Decimal(0));
+
+describe('buildDepreciationSchedule — daily straight-line', () => {
+  describe('R2: first-period day count (start to month-end inclusive)', () => {
+    it('start on last day of month → 1 day', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 100000,
+        residualValue: 0,
+        usefulLifeMonths: 60,
+        startDate: new Date('2026-04-30'),
+      });
+      expect(rows[0].period).toBe('2026-04');
+      expect(rows[0].days).toBe(1);
+    });
+
+    it('start mid-month → remaining days of that month inclusive', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 100000,
+        residualValue: 0,
+        usefulLifeMonths: 60,
+        startDate: new Date('2026-04-15'),
+      });
+      expect(rows[0].period).toBe('2026-04');
+      expect(rows[0].days).toBe(16); // 15..30 Apr inclusive
+    });
+
+    it('first-period amount = dailyDepr × days', () => {
+      const sched = buildDepreciationSchedule({
+        purchaseCost: 100000,
+        residualValue: 0,
+        usefulLifeMonths: 60,
+        startDate: new Date('2026-04-15'),
+      });
+      const expected = sched.dailyDepr
+        .times(16)
+        .toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+      expect(sched.rows[0].amount.toString()).toBe(expected.toString());
+    });
+  });
+
+  describe('R3: daily rate uses fixed 365-day year', () => {
+    it('totalDays = months/12 × 365 and dailyDepr = base/totalDays (4dp)', () => {
+      const sched = buildDepreciationSchedule({
+        purchaseCost: 10000,
+        residualValue: 0,
+        usefulLifeMonths: 12,
+        startDate: new Date('2026-01-01'),
+      });
+      expect(sched.totalDays).toBe(365);
+      // 10000 / 365 = 27.39726… → 27.3973
+      expect(sched.dailyDepr.toString()).toBe('27.3973');
+    });
+
+    it('full 31-day month posts dailyDepr × 31 (HALF_UP)', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 10000,
+        residualValue: 0,
+        usefulLifeMonths: 12,
+        startDate: new Date('2026-01-01'),
+      });
+      // 27.3973 × 31 = 849.3163 → 849.32
+      expect(rows[0].period).toBe('2026-01');
+      expect(rows[0].days).toBe(31);
+      expect(rows[0].amount.toString()).toBe('849.32');
+    });
+  });
+
+  describe('R1: rounding + forced exact final period', () => {
+    it('Σ amounts equals (cost − salvage) exactly, no residue', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 30000,
+        residualValue: 0,
+        usefulLifeMonths: 36,
+        startDate: new Date('2026-01-01'),
+      });
+      expect(sum(rows).toString()).toBe('30000');
+    });
+
+    it('final period is flagged and final NBV = salvage value', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 100000,
+        residualValue: 10000,
+        usefulLifeMonths: 60,
+        startDate: new Date('2026-04-15'),
+      });
+      const last = rows[rows.length - 1];
+      expect(last.isFinal).toBe(true);
+      expect(rows.filter((r) => r.isFinal)).toHaveLength(1);
+      expect(last.netBookValue.toString()).toBe('10000');
+      expect(sum(rows).toString()).toBe('90000'); // depreciable base
+    });
+
+    it('accumulated is monotonic and never exceeds the depreciable base', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 55555,
+        residualValue: 1234,
+        usefulLifeMonths: 24,
+        startDate: new Date('2026-07-20'),
+      });
+      let prev = new Decimal(-1);
+      for (const r of rows) {
+        expect(r.accumulated.gt(prev)).toBe(true);
+        expect(r.accumulated.lte(new Decimal(55555 - 1234))).toBe(true);
+        prev = r.accumulated;
+      }
+      expect(rows[rows.length - 1].accumulated.toString()).toBe(
+        new Decimal(55555 - 1234).toString(),
+      );
+    });
+  });
+
+  describe('R4: disposal stops depreciation (no force-fill to salvage)', () => {
+    it('disposal month counts actual days and keeps remaining NBV', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 12000,
+        residualValue: 0,
+        usefulLifeMonths: 12, // totalDays 365, dailyDepr 32.8767
+        startDate: new Date('2026-01-01'),
+        disposalDate: new Date('2026-03-15'),
+      });
+      expect(rows).toHaveLength(3);
+      const last = rows[2];
+      expect(last.period).toBe('2026-03');
+      expect(last.days).toBe(15); // 1..15 Mar inclusive
+      expect(last.isFinal).toBe(true);
+      // 32.8767 × 15 = 493.1505 → 493.15
+      expect(last.amount.toString()).toBe('493.15');
+      // Early disposal: NBV is NOT driven to salvage.
+      expect(last.netBookValue.gt(new Decimal(0))).toBe(true);
+    });
+
+    it('disposal before start date yields an empty schedule', () => {
+      const { rows } = buildDepreciationSchedule({
+        purchaseCost: 12000,
+        residualValue: 0,
+        usefulLifeMonths: 12,
+        startDate: new Date('2026-05-01'),
+        disposalDate: new Date('2026-04-01'),
+      });
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('zero/negative depreciable base → empty schedule', () => {
+      expect(
+        buildDepreciationSchedule({
+          purchaseCost: 1000,
+          residualValue: 1000,
+          usefulLifeMonths: 12,
+          startDate: new Date('2026-01-01'),
+        }).rows,
+      ).toHaveLength(0);
+    });
+
+    it('usefulLifeMonths = 0 → empty schedule', () => {
+      expect(
+        buildDepreciationSchedule({
+          purchaseCost: 1000,
+          residualValue: 0,
+          usefulLifeMonths: 0,
+          startDate: new Date('2026-01-01'),
+        }).rows,
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('depreciationForPeriod lookup', () => {
+    it('returns the row matching a period, else null', () => {
+      const input = {
+        purchaseCost: 30000,
+        residualValue: 0,
+        usefulLifeMonths: 36,
+        startDate: new Date('2026-01-01'),
+      };
+      expect(depreciationForPeriod(input, '2026-05')?.period).toBe('2026-05');
+      expect(depreciationForPeriod(input, '2025-12')).toBeNull();
+      expect(depreciationForPeriod(input, '2099-01')).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/modules/asset/asset.service.ts
+++ b/apps/api/src/modules/asset/asset.service.ts
@@ -16,6 +16,7 @@ import { AssetDisposalTemplate } from '../journal/cpa-templates/asset-disposal.t
 import { AssetDisposalReverseTemplate } from '../journal/cpa-templates/asset-disposal-reverse.template';
 import { AssetInvoiceReceivedTemplate } from '../journal/cpa-templates/asset-invoice-received.template';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
+import { buildDepreciationSchedule } from './depreciation-schedule.util';
 
 const CATEGORY_PREFIX: Record<AssetCategory, string> = {
   EQUIPMENT: 'EQ',
@@ -200,9 +201,16 @@ export class AssetService {
       whtAmount = round2(whtBaseRaw.times(input.whtRate.toString()));
     }
 
+    // Nominal monthly figure (display only) — base / months.
     const monthlyDepr = round4(
       purchaseCost.minus(residualValue).div(input.usefulLifeMonths),
     );
+    // Daily rate (actual posting basis) — base ÷ (years × 365), years = months/12.
+    // Equivalent to base × 12 / (months × 365). 365-day fixed year per spec R3.
+    const totalDays = new Decimal(input.usefulLifeMonths).times(365).div(12);
+    const dailyDepr = totalDays.gt(0)
+      ? round4(purchaseCost.minus(residualValue).div(totalDays))
+      : new Decimal(0);
 
     return {
       basePrice,
@@ -210,6 +218,7 @@ export class AssetService {
       purchaseCost,
       whtAmount,
       monthlyDepr,
+      dailyDepr,
       // Echo back inputs that callers also need
       shippingCost,
       installationCost,
@@ -225,6 +234,7 @@ export class AssetService {
       purchaseCost,
       whtAmount,
       monthlyDepr,
+      dailyDepr,
       shippingCost,
       installationCost,
       otherCapitalized,
@@ -261,6 +271,7 @@ export class AssetService {
           residualValue,
           usefulLifeMonths: dto.usefulLifeMonths,
           monthlyDepr,
+          dailyDepr,
           netBookValue: purchaseCost,
           purchaseDate: new Date(dto.purchaseDate),
           invoiceDate: dto.invoiceDate ? new Date(dto.invoiceDate) : null,
@@ -357,6 +368,7 @@ export class AssetService {
         purchaseCost: computed.purchaseCost,
         whtAmount: computed.whtAmount,
         monthlyDepr: computed.monthlyDepr,
+        dailyDepr: computed.dailyDepr,
         netBookValue: computed.purchaseCost,
       };
     }
@@ -708,17 +720,17 @@ export class AssetService {
   }
 
   /**
-   * Per-asset Asset Schedule — month-by-month NBV projection from purchaseDate.
+   * Per-asset Asset Schedule — day-based month-by-month NBV projection.
    *
    * Behavior:
-   *  - Cursor starts at first day of asset.purchaseDate's month
-   *  - Each iteration: if a DepreciationEntry exists for the period, use its
-   *    actual amount; otherwise use the formula `monthlyDepr` (clamped so we
-   *    never depreciate below the residualValue floor)
+   *  - Projection comes from buildDepreciationSchedule (dailyRate × days/period,
+   *    partial first/last months, forced-exact final period) — the same source
+   *    of truth as the depreciation template + preview.
+   *  - Each row: if a DepreciationEntry exists for the period, its actual posted
+   *    amount overrides the projection; otherwise the scheduled amount is used
+   *    (clamped so we never depreciate below the residualValue floor)
    *  - Stops at the first FULLY_DEPRECIATED period (NBV ≤ residualValue)
-   *  - If asset.disposalDate is set, also stops when periodEnd > disposalDate
-   *  - Hard cap at 60 months as a sanity guard (unbounded loops shouldn't occur
-   *    given the residual-floor + disposalDate truncation, but guard anyway)
+   *  - asset.disposalDate truncates the schedule (R4)
    */
   async getAssetSchedule(assetId: string) {
     const asset = await this.prisma.fixedAsset.findFirst({
@@ -729,8 +741,10 @@ export class AssetService {
     const purchaseCost = new Decimal(asset.purchaseCost.toString());
     const residualValue = new Decimal(asset.residualValue.toString());
     const monthlyDepr = new Decimal(asset.monthlyDepr.toString());
+    const depreciableBase = purchaseCost.minus(residualValue);
 
-    // Load existing entries indexed by period (skip reversed)
+    // Load existing entries indexed by period (skip reversed) — actual posted
+    // amounts override the projection for past periods.
     const entries = await this.prisma.depreciationEntry.findMany({
       where: { assetId, reversedAt: null },
       select: { period: true, amount: true },
@@ -739,8 +753,18 @@ export class AssetService {
       entries.map((e) => [e.period, new Decimal(e.amount.toString())]),
     );
 
+    // Day-based projection — single source of truth shared with template/preview.
+    const schedule = buildDepreciationSchedule({
+      purchaseCost,
+      residualValue,
+      usefulLifeMonths: asset.usefulLifeMonths,
+      startDate: asset.purchaseDate,
+      disposalDate: asset.disposalDate,
+    });
+
     const rows: Array<{
       period: string;
+      days: number;
       monthlyDepr: string;
       accumulatedDepr: string;
       netBookValue: string;
@@ -748,26 +772,13 @@ export class AssetService {
     }> = [];
 
     let accumulated = new Decimal(0);
-    const cursor = new Date(asset.purchaseDate);
-    cursor.setDate(1);
-    const cutoff = asset.disposalDate ?? null;
-    const HARD_CAP = 60;
-
-    for (let i = 0; i < HARD_CAP; i++) {
-      const periodEnd = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 0);
-      if (cutoff && periodEnd > cutoff) break;
-
-      const period = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}`;
-      const remaining = purchaseCost.minus(accumulated).minus(residualValue);
-      if (remaining.lte(0)) break;
-
-      let thisMonth: Decimal;
-      if (entryByPeriod.has(period)) {
-        thisMonth = entryByPeriod.get(period)!;
-      } else {
-        // Last-period adjustment: never over-depreciate past residual floor
-        thisMonth = remaining.lt(monthlyDepr) ? remaining : monthlyDepr;
-      }
+    for (const r of schedule.rows) {
+      const posted = entryByPeriod.get(r.period);
+      let thisMonth = posted ?? r.amount;
+      // Never depreciate past the residual floor.
+      const remaining = depreciableBase.minus(accumulated);
+      if (thisMonth.gt(remaining)) thisMonth = remaining;
+      if (thisMonth.lte(0)) break;
 
       accumulated = accumulated.plus(thisMonth);
       const nbv = purchaseCost.minus(accumulated);
@@ -775,7 +786,8 @@ export class AssetService {
         nbv.lte(residualValue) ? 'FULLY_DEPRECIATED' : 'ACTIVE';
 
       rows.push({
-        period,
+        period: r.period,
+        days: r.days,
         monthlyDepr: thisMonth.toFixed(2),
         accumulatedDepr: accumulated.toFixed(2),
         netBookValue: nbv.toFixed(2),
@@ -783,7 +795,6 @@ export class AssetService {
       });
 
       if (status === 'FULLY_DEPRECIATED') break;
-      cursor.setMonth(cursor.getMonth() + 1);
     }
 
     return {
@@ -794,6 +805,7 @@ export class AssetService {
       purchaseCost: purchaseCost.toFixed(2),
       residualValue: residualValue.toFixed(2),
       monthlyDepr: monthlyDepr.toFixed(2),
+      dailyDepr: schedule.dailyDepr.toFixed(4),
       rows,
     };
   }

--- a/apps/api/src/modules/asset/depreciation-schedule.util.ts
+++ b/apps/api/src/modules/asset/depreciation-schedule.util.ts
@@ -1,0 +1,185 @@
+import { Decimal } from '@prisma/client/runtime/library';
+
+/**
+ * Daily straight-line depreciation schedule generator.
+ *
+ * Spec (ซื้อทรัพย์สิน — คำนวณค่าเสื่อมราคาแบบรายวัน):
+ *   ค่าเสื่อมต่อวัน  = (ราคาทุน − มูลค่าซาก) ÷ (อายุการใช้งานเป็นปี × 365)
+ *   ค่าเสื่อมต่องวด = ค่าเสื่อมต่อวัน × จำนวนวันในงวดนั้น
+ *
+ * Business rules:
+ *   R1 (rounding)   — each period ROUND_HALF_UP to 2 dp; the final period is
+ *                     forced so Σ = (cost − salvage) exactly, final NBV = salvage.
+ *   R2 (first period) — counts from startDate to month-end inclusive
+ *                     (start 30 Apr → 1 day; start 15 Apr → 16 days).
+ *   R3 (year)       — fixed 365 days/year.
+ *   R4 (disposal)   — stop on disposalDate; that period counts actual days used
+ *                     and is NOT force-filled to salvage (early disposal keeps NBV).
+ *   R5 (precision)  — dailyDepr kept at 4 dp; period amounts at 2 dp.
+ *
+ * Periods are calendar months keyed "YYYY-MM". All date math uses UTC calendar
+ * components so it is deterministic regardless of server timezone.
+ */
+
+export interface DepreciationScheduleInput {
+  purchaseCost: Decimal | number | string;
+  residualValue: Decimal | number | string;
+  usefulLifeMonths: number;
+  /** Depreciation start (= asset.purchaseDate). Time component is ignored. */
+  startDate: Date;
+  /** Optional disposal/sale date — stops depreciation on this day (R4). */
+  disposalDate?: Date | null;
+}
+
+export interface DepreciationScheduleRow {
+  /** "YYYY-MM" */
+  period: string;
+  /** Depreciable days that fall within this calendar month. */
+  days: number;
+  /** Posted amount for this period (2 dp). */
+  amount: Decimal;
+  /** Cumulative depreciation through this period (2 dp). */
+  accumulated: Decimal;
+  /** purchaseCost − accumulated (2 dp). */
+  netBookValue: Decimal;
+  /** True for the last period of the schedule. */
+  isFinal: boolean;
+}
+
+export interface DepreciationSchedule {
+  /** Daily depreciation rate (4 dp). */
+  dailyDepr: Decimal;
+  /** Nominal depreciable days = round(months × 365 / 12). */
+  totalDays: number;
+  rows: DepreciationScheduleRow[];
+}
+
+function round2(d: Decimal): Decimal {
+  return d.toDecimalPlaces(2, Decimal.ROUND_HALF_UP);
+}
+function round4(d: Decimal): Decimal {
+  return d.toDecimalPlaces(4, Decimal.ROUND_HALF_UP);
+}
+
+/** Last day-of-month (1-31) for the given UTC year/month0. */
+function lastDomUTC(year: number, month0: number): number {
+  return new Date(Date.UTC(year, month0 + 1, 0)).getUTCDate();
+}
+
+/** Inclusive day count between two UTC calendar dates (a ≤ b ⇒ ≥ 1). */
+function daysInclusive(
+  aY: number,
+  aM0: number,
+  aD: number,
+  bY: number,
+  bM0: number,
+  bD: number,
+): number {
+  const a = Date.UTC(aY, aM0, aD);
+  const b = Date.UTC(bY, bM0, bD);
+  return Math.round((b - a) / 86_400_000) + 1;
+}
+
+export function buildDepreciationSchedule(
+  input: DepreciationScheduleInput,
+): DepreciationSchedule {
+  const purchaseCost = new Decimal(input.purchaseCost.toString());
+  const residualValue = new Decimal(input.residualValue.toString());
+  const base = round2(purchaseCost.minus(residualValue));
+  const months = input.usefulLifeMonths;
+
+  if (base.lte(0) || months <= 0) {
+    return { dailyDepr: new Decimal(0), totalDays: 0, rows: [] };
+  }
+
+  // R3: fixed 365-day year. usefulLife is stored in months → years = months/12.
+  const totalDays = Math.round((months * 365) / 12);
+  const dailyDepr = round4(base.div(totalDays));
+
+  const sY = input.startDate.getUTCFullYear();
+  const sM0 = input.startDate.getUTCMonth();
+  const sD = input.startDate.getUTCDate();
+
+  const dispAbs =
+    input.disposalDate != null
+      ? Date.UTC(
+          input.disposalDate.getUTCFullYear(),
+          input.disposalDate.getUTCMonth(),
+          input.disposalDate.getUTCDate(),
+        )
+      : null;
+
+  const rows: DepreciationScheduleRow[] = [];
+  let accumulated = new Decimal(0);
+  let cy = sY;
+  let cm = sM0;
+  let cd = sD; // first period starts on the purchase day (R2); day 1 thereafter
+  const guardMax = months + 36;
+
+  for (let guard = 0; accumulated.lt(base) && guard < guardMax; guard++) {
+    const cursorStartAbs = Date.UTC(cy, cm, cd);
+    // Disposal already passed before this period begins — nothing left (R4 edge).
+    if (dispAbs != null && dispAbs < cursorStartAbs) break;
+
+    const lastDom = lastDomUTC(cy, cm);
+    const monthEndAbs = Date.UTC(cy, cm, lastDom);
+
+    let periodEndDom = lastDom;
+    let disposedHere = false;
+    if (dispAbs != null && dispAbs <= monthEndAbs) {
+      periodEndDom = new Date(dispAbs).getUTCDate();
+      disposedHere = true;
+    }
+
+    const days = daysInclusive(cy, cm, cd, cy, cm, periodEndDom);
+    if (days <= 0) break; // disposal before the cursor — nothing left to depreciate
+
+    let amount = round2(dailyDepr.times(days));
+    let isFinal = false;
+    const wouldReach = accumulated.plus(amount);
+
+    if (!disposedHere && wouldReach.gte(base)) {
+      // R1: natural end of life — force exact so Σ = base, final NBV = salvage.
+      amount = base.minus(accumulated);
+      isFinal = true;
+    } else if (disposedHere) {
+      // R4: early disposal — actual days, but never depreciate past base.
+      if (wouldReach.gt(base)) amount = base.minus(accumulated);
+      isFinal = true;
+    }
+
+    accumulated = accumulated.plus(amount);
+    rows.push({
+      period: `${cy}-${String(cm + 1).padStart(2, '0')}`,
+      days,
+      amount: round2(amount),
+      accumulated: round2(accumulated),
+      netBookValue: round2(purchaseCost.minus(accumulated)),
+      isFinal,
+    });
+
+    if (isFinal) break;
+
+    cm += 1;
+    if (cm > 11) {
+      cm = 0;
+      cy += 1;
+    }
+    cd = 1;
+  }
+
+  return { dailyDepr, totalDays, rows };
+}
+
+/**
+ * Convenience lookup — the posted amount for a single "YYYY-MM" period, or null
+ * if the period is outside the schedule window. Used by the depreciation
+ * template / preview to stay consistent with the full schedule.
+ */
+export function depreciationForPeriod(
+  input: DepreciationScheduleInput,
+  period: string,
+): DepreciationScheduleRow | null {
+  const { rows } = buildDepreciationSchedule(input);
+  return rows.find((r) => r.period === period) ?? null;
+}

--- a/apps/api/src/modules/depreciation/__tests__/depreciation.service.spec.ts
+++ b/apps/api/src/modules/depreciation/__tests__/depreciation.service.spec.ts
@@ -193,7 +193,8 @@ describe('DepreciationService.previewRun', () => {
     expect(preview.lines[0].assetId).toBe(a.id);
     expect(preview.lines[0].drAccount).toBe('53-1601');
     expect(preview.lines[0].crAccount).toBe('12-2102');
-    expect(parseFloat(preview.lines[0].monthlyDepr)).toBeCloseTo(833.33, 2);
+    // Daily: 30000 / ((36/12)×365) = 27.3973/day × 31 (May, full month) = 849.32
+    expect(parseFloat(preview.lines[0].monthlyDepr)).toBeCloseTo(849.32, 2);
   });
 
   it('excludes assets already depreciated for that period (reversedAt IS NULL)', async () => {
@@ -239,19 +240,20 @@ describe('DepreciationService.runManual', () => {
     const b = await postedAsset();
     const result = await service.runManual('2026-05', userId);
     expect(result.assetCount).toBe(2);
-    expect(parseFloat(result.totalAmount)).toBeCloseTo(1666.66, 2);
+    // Daily: 849.32 per asset (31-day May) × 2 = 1698.64
+    expect(parseFloat(result.totalAmount)).toBeCloseTo(1698.64, 2);
 
     const entries = await prisma.depreciationEntry.findMany({ where: { period: '2026-05' } });
     expect(entries).toHaveLength(2);
     const aEntry = entries.find((e) => e.assetId === a.id)!;
-    expect(parseFloat(aEntry.amount.toString())).toBeCloseTo(833.33, 2);
+    expect(parseFloat(aEntry.amount.toString())).toBeCloseTo(849.32, 2);
     expect(aEntry.journalEntryNo).toMatch(/^JE-\d{6}-\d{5}$/);
 
     // accumulatedDepr updated
     const aUpdated = await prisma.fixedAsset.findUnique({ where: { id: a.id } });
-    expect(parseFloat(aUpdated!.accumulatedDepr.toString())).toBeCloseTo(833.33, 2);
+    expect(parseFloat(aUpdated!.accumulatedDepr.toString())).toBeCloseTo(849.32, 2);
     const bUpdated = await prisma.fixedAsset.findUnique({ where: { id: b.id } });
-    expect(parseFloat(bUpdated!.accumulatedDepr.toString())).toBeCloseTo(833.33, 2);
+    expect(parseFloat(bUpdated!.accumulatedDepr.toString())).toBeCloseTo(849.32, 2);
   });
 
   it('idempotent: second runManual for same period returns existing entries (no duplicates)', async () => {

--- a/apps/api/src/modules/depreciation/depreciation.service.ts
+++ b/apps/api/src/modules/depreciation/depreciation.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { DepreciationTemplate } from '../journal/cpa-templates/depreciation.template';
 import { DepreciationReverseTemplate } from '../journal/cpa-templates/depreciation-reverse.template';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
+import { depreciationForPeriod } from '../asset/depreciation-schedule.util';
 
 /** Maps AssetCategory → [Dr expenseCode, Cr accumulatedCode] (fallback when asset.coa* snapshots are null) */
 const CATEGORY_ACCOUNT_MAP: Record<string, [string, string]> = {
@@ -152,8 +153,21 @@ export class DepreciationService {
 
       if (remainingBase.lte(0)) continue; // fully depreciated
 
-      const monthlyDepr = new Decimal(asset.monthlyDepr.toString());
-      const thisMonth = remainingBase.lt(monthlyDepr) ? remainingBase : monthlyDepr;
+      // Day-based amount for this period (shared schedule = template source of truth).
+      const row = depreciationForPeriod(
+        {
+          purchaseCost,
+          residualValue,
+          usefulLifeMonths: asset.usefulLifeMonths,
+          startDate: asset.purchaseDate,
+          disposalDate: asset.disposalDate,
+        },
+        period,
+      );
+      if (!row) continue; // period outside this asset's depreciation window
+
+      const scheduled = new Decimal(row.amount.toString());
+      const thisMonth = scheduled.gt(remainingBase) ? remainingBase : scheduled;
 
       const drAccount =
         asset.coaExpenseAccount ?? CATEGORY_ACCOUNT_MAP[asset.category]?.[0] ?? '53-1601';

--- a/apps/api/src/modules/integrations/integrations.controller.ts
+++ b/apps/api/src/modules/integrations/integrations.controller.ts
@@ -27,22 +27,22 @@ export class IntegrationsController {
   ) {}
 
   @Get()
-  @Roles('OWNER')
+  @Roles('OWNER', 'ACCOUNTANT')
   @ApiOperation({ summary: 'รายการ integration ทั้งหมดพร้อมสถานะ' })
   listAll() {
     return this.integrationsService.listAll();
   }
 
   @Get('registry')
-  @Roles('OWNER')
+  @Roles('OWNER', 'ACCOUNTANT')
   @ApiOperation({ summary: 'Integration definitions สำหรับสร้าง form ฝั่ง frontend' })
   getRegistry() {
     return INTEGRATIONS;
   }
 
   @Get(':key/config')
-  @Roles('OWNER')
-  @ApiOperation({ summary: 'ดู config ที่ masked สำหรับ integration' })
+  @Roles('OWNER', 'ACCOUNTANT')
+  @ApiOperation({ summary: 'ดู config ที่ masked สำหรับ integration (read-only สำหรับ ACCOUNTANT — reviewer panel)' })
   async getConfig(@Param('key') key: string) {
     const def = getIntegrationDef(key);
     const masked = await this.configService.getMaskedConfig(key);

--- a/apps/api/src/modules/journal/cpa-templates/depreciation-reverse.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/depreciation-reverse.template.spec.ts
@@ -111,7 +111,8 @@ describe('DepreciationReverseTemplate', () => {
     const asset = await postedAsset();
     await depr.execute({ assetId: asset.id, period: '2026-05' });
     const beforeReverse = await prisma.fixedAsset.findUnique({ where: { id: asset.id } });
-    expect(new Decimal(beforeReverse!.accumulatedDepr.toString()).toFixed(2)).toBe('833.33');
+    // Daily: 30000/((36/12)×365)=27.3973/day × 31 (May) = 849.32
+    expect(new Decimal(beforeReverse!.accumulatedDepr.toString()).toFixed(2)).toBe('849.32');
 
     const result = await reverseDepr.execute({ period: '2026-05', reversedById: userId, reason: 'test' });
     expect(result.reversedCount).toBe(1);

--- a/apps/api/src/modules/journal/cpa-templates/depreciation.template.spec.ts
+++ b/apps/api/src/modules/journal/cpa-templates/depreciation.template.spec.ts
@@ -89,7 +89,7 @@ describe('DepreciationTemplate', () => {
   });
 
   it('posts balanced JE for EQUIPMENT (Dr 53-1601 / Cr 12-2102)', async () => {
-    // 60,000 / 60 months = 1,000/month
+    // Daily: 60,000 / ((60/12)×365) = 32.8767/day × 30 (April) = 986.30
     const asset = await ensureTestAsset({
       category: 'EQUIPMENT',
       purchaseCost: 60000,
@@ -123,17 +123,17 @@ describe('DepreciationTemplate', () => {
 
     const drLine = lines.find((l) => l.accountCode === '53-1601');
     expect(drLine).toBeDefined();
-    expect(new Decimal(drLine!.debit.toString()).toFixed(2)).toBe('1000.00');
+    expect(new Decimal(drLine!.debit.toString()).toFixed(2)).toBe('986.30');
 
     const crLine = lines.find((l) => l.accountCode === '12-2102');
     expect(crLine).toBeDefined();
-    expect(new Decimal(crLine!.credit.toString()).toFixed(2)).toBe('1000.00');
+    expect(new Decimal(crLine!.credit.toString()).toFixed(2)).toBe('986.30');
 
     // Asset updated
     const updated = await prisma.fixedAsset.findFirst({ where: { id: asset.id } });
-    expect(new Decimal(updated!.accumulatedDepr.toString()).toFixed(2)).toBe('1000.00');
-    // netBookValue must be updated alongside accumulatedDepr: 60000 - 1000 = 59000
-    expect(new Decimal(updated!.netBookValue.toString()).toFixed(2)).toBe('59000.00');
+    expect(new Decimal(updated!.accumulatedDepr.toString()).toFixed(2)).toBe('986.30');
+    // netBookValue updated alongside accumulatedDepr: 60000 - 986.30 = 59013.70
+    expect(new Decimal(updated!.netBookValue.toString()).toFixed(2)).toBe('59013.70');
   });
 
   it('posts correct accounts per category: VEHICLE → Dr 53-1604 / Cr 12-2108', async () => {
@@ -227,8 +227,8 @@ describe('DepreciationTemplate', () => {
     expect(result).toBeNull();
   });
 
-  it('uses usefulLifeMonths to compute monthly depreciation', async () => {
-    // usefulLifeMonths=12 on 60,000 cost → 5,000/month
+  it('uses usefulLifeMonths to compute daily depreciation', async () => {
+    // usefulLifeMonths=12 on 60,000 → 60000/365 = 164.3836/day × 30 (Sep) = 4931.51
     const asset = await ensureTestAsset({
       category: 'EQUIPMENT',
       purchaseCost: 60000,
@@ -241,6 +241,6 @@ describe('DepreciationTemplate', () => {
     const entry = await prisma.depreciationEntry.findFirst({
       where: { assetId: asset.id, period: '2026-09' },
     });
-    expect(new Decimal(entry!.amount.toString()).toFixed(2)).toBe('5000.00');
+    expect(new Decimal(entry!.amount.toString()).toFixed(2)).toBe('4931.51');
   });
 });

--- a/apps/api/src/modules/journal/cpa-templates/depreciation.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/depreciation.template.ts
@@ -3,6 +3,7 @@ import { Decimal } from '@prisma/client/runtime/library';
 import { Prisma } from '@prisma/client';
 import { JournalAutoService } from '../journal-auto.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { depreciationForPeriod } from '../../asset/depreciation-schedule.util';
 
 /** Maps AssetCategory → [Dr expenseCode, Cr accumulatedCode] (fallback when asset.coa* snapshots are null) */
 const CATEGORY_ACCOUNT_MAP: Record<string, [string, string]> = {
@@ -26,11 +27,14 @@ export interface DepreciationTemplateInput {
 }
 
 /**
- * Template — Monthly straight-line depreciation (Phase 1).
+ * Template — Daily straight-line depreciation (per-period posting).
+ *
+ * The amount for a given month = dailyRate × days-in-period (partial first/last
+ * months handled by buildDepreciationSchedule). See depreciation-schedule.util.
  *
  * JE per asset:
- *   Dr 53-160X ค่าเสื่อมราคา - <category>         [monthlyAmount]
- *     Cr 12-210X ค่าเสื่อมราคาสะสม - <category>   [monthlyAmount]
+ *   Dr 53-160X ค่าเสื่อมราคา - <category>         [periodAmount]
+ *     Cr 12-210X ค่าเสื่อมราคาสะสม - <category>   [periodAmount]
  *
  * Account routing (in order of precedence):
  *   1. asset.coaExpenseAccount / asset.coaDeprAccount snapshots (set at POST time)
@@ -43,10 +47,10 @@ export interface DepreciationTemplateInput {
  * update run inside ONE $transaction. When the caller passes outerTx, we run
  * inside their transaction (no nested $transaction).
  *
- * Rounding: monthly depreciation uses ROUND_DOWN (per accounting.md) — same
- * convention as gross/12 in installment accruals.
+ * Rounding: each period ROUND_HALF_UP to 2 dp; final period force-filled so
+ * Σ posts = (cost − salvage) exactly (per spec R1).
  *
- * Guards: POSTED status only, not fully depreciated.
+ * Guards: POSTED status only, not fully depreciated, period within window.
  */
 @Injectable()
 export class DepreciationTemplate {
@@ -81,7 +85,7 @@ export class DepreciationTemplate {
       return null;
     }
 
-    // Compute monthly depreciation
+    // Depreciable base + remaining (guards below)
     const purchaseCost = new Decimal(asset.purchaseCost.toString());
     const residualValue = new Decimal(asset.residualValue.toString());
     const accumulatedDepr = new Decimal(asset.accumulatedDepr.toString());
@@ -103,13 +107,28 @@ export class DepreciationTemplate {
       return null;
     }
 
-    // ROUND_DOWN per accounting.md (matches installment accrual gross/12 convention).
-    // For the LAST month of the asset's life, post the remaining un-depreciated base
-    // instead of monthlyAmount — otherwise rounding drift (e.g. 107000 / 36 = 2972.22…)
-    // leaves a small residue on the balance sheet (NBV never reaches residualValue
-    // cleanly). monthsPostedSoFar must be queried inside the tx; actualAmount is
-    // therefore computed in `run` below.
-    const monthlyAmount = depreciableBase.div(lifeMonths).toDecimalPlaces(2, Decimal.ROUND_DOWN);
+    // Daily straight-line: the amount for this period = dailyRate × days-in-period
+    // (partial first/last months handled by the schedule). The final period is
+    // force-filled so Σ posts = depreciableBase exactly (NBV reaches residual
+    // cleanly). buildDepreciationSchedule is the single source of truth, shared
+    // with previewRun + getAssetSchedule. If the period is outside the asset's
+    // depreciation window, there is nothing to post.
+    const scheduleRow = depreciationForPeriod(
+      {
+        purchaseCost,
+        residualValue,
+        usefulLifeMonths: lifeMonths,
+        startDate: asset.purchaseDate,
+        disposalDate: asset.disposalDate,
+      },
+      period,
+    );
+    if (!scheduleRow) {
+      this.logger.log(
+        `[Phase1] DepreciationTemplate: asset ${asset.assetCode} period ${period} outside depreciation window — skipping`,
+      );
+      return null;
+    }
 
     // Resolve account codes — prefer asset.coa* snapshots (pinned at POST time)
     // over CATEGORY_ACCOUNT_MAP. Defensive fallback for legacy/test assets that
@@ -145,16 +164,11 @@ export class DepreciationTemplate {
           : null;
       }
 
-      // Decide actualAmount inside tx so monthsPostedSoFar is consistent with the
-      // DepreciationEntry insert that follows. Last-month detection cleans up
-      // rounding drift so Σ posts = depreciableBase exactly.
-      const monthsPostedSoFar = await tx.depreciationEntry.count({ where: { assetId } });
-      const isFinalMonth = monthsPostedSoFar + 1 >= lifeMonths;
-      const actualAmount = isFinalMonth
-        ? remainingBase
-        : monthlyAmount.gt(remainingBase)
-          ? remainingBase
-          : monthlyAmount;
+      // Post the scheduled day-based amount, capped at the remaining base so we
+      // never depreciate past the residual floor (guards against accumulated
+      // drift if a prior period was skipped).
+      const scheduled = new Decimal(scheduleRow.amount.toString());
+      const actualAmount = scheduled.gt(remainingBase) ? remainingBase : scheduled;
 
       const result = await this.journal.createAndPost(
         {

--- a/apps/web/src/pages/assets/AssetDetailPage.tsx
+++ b/apps/web/src/pages/assets/AssetDetailPage.tsx
@@ -314,7 +314,11 @@ export default function AssetDetailPage() {
                       <dd>{asset.usefulLifeMonths} เดือน</dd>
                     </div>
                     <div>
-                      <dt className="text-muted-foreground">ค่าเสื่อม/เดือน</dt>
+                      <dt className="text-muted-foreground">ค่าเสื่อม/วัน</dt>
+                      <dd className="tabular-nums">{fmt(asset.dailyDepr)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">ค่าเสื่อม/เดือน (เฉลี่ย)</dt>
                       <dd className="tabular-nums">{fmt(asset.monthlyDepr)}</dd>
                     </div>
                     <div>

--- a/apps/web/src/pages/assets/AssetEntryPage.tsx
+++ b/apps/web/src/pages/assets/AssetEntryPage.tsx
@@ -42,6 +42,9 @@ const today = () => new Date().toISOString().slice(0, 10);
 const defaultValues: AssetEntryFormValues = {
   name: '',
   category: 'EQUIPMENT',
+  quantity: 1,
+  unitPrice: 0,
+  discount: 0,
   basePrice: 0,
   shippingCost: 0,
   installationCost: 0,
@@ -124,6 +127,10 @@ export default function AssetEntryPage() {
         location: a.location ?? undefined,
         serialNo: a.serialNo ?? undefined,
         warrantyExpire: a.warrantyExpire?.slice(0, 10),
+        // Reconstruct the single line from the stored basePrice (qty 1, no discount).
+        quantity: 1,
+        unitPrice: Number(a.basePrice),
+        discount: 0,
         basePrice: Number(a.basePrice),
         shippingCost: Number(a.shippingCost),
         installationCost: Number(a.installationCost),

--- a/apps/web/src/pages/assets/AssetSchedulePage.tsx
+++ b/apps/web/src/pages/assets/AssetSchedulePage.tsx
@@ -44,7 +44,7 @@ export default function AssetSchedulePage() {
             <Card>
               <CardHeader><CardTitle>ข้อมูลสินทรัพย์</CardTitle></CardHeader>
               <CardContent>
-                <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+                <dl className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
                   <div>
                     <dt className="text-muted-foreground">ราคาทุน</dt>
                     <dd className="tabular-nums">{formatNumberDecimal(parseFloat(query.data.purchaseCost))}</dd>
@@ -54,7 +54,11 @@ export default function AssetSchedulePage() {
                     <dd className="tabular-nums">{formatNumberDecimal(parseFloat(query.data.residualValue))}</dd>
                   </div>
                   <div>
-                    <dt className="text-muted-foreground">ค่าเสื่อม/เดือน</dt>
+                    <dt className="text-muted-foreground">ค่าเสื่อม/วัน</dt>
+                    <dd className="tabular-nums">{formatNumberDecimal(parseFloat(query.data.dailyDepr))}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">ค่าเสื่อม/เดือน (เฉลี่ย)</dt>
                     <dd className="tabular-nums">{formatNumberDecimal(parseFloat(query.data.monthlyDepr))}</dd>
                   </div>
                   <div>
@@ -72,6 +76,7 @@ export default function AssetSchedulePage() {
                   <thead>
                     <tr className="border-b">
                       <th className="text-left py-2 px-2">งวด</th>
+                      <th className="text-right py-2 px-2">วัน</th>
                       <th className="text-right py-2 px-2">ค่าเสื่อม</th>
                       <th className="text-right py-2 px-2">ค่าเสื่อมสะสม</th>
                       <th className="text-right py-2 px-2">มูลค่าตามบัญชีสุทธิ (NBV)</th>
@@ -84,6 +89,7 @@ export default function AssetSchedulePage() {
                       return (
                         <tr key={r.period} className={`border-b ${isCurrent ? 'bg-muted/40' : ''}`}>
                           <td className="py-2 px-2 font-mono">{r.period}{isCurrent ? ' ←' : ''}</td>
+                          <td className="py-2 px-2 text-right tabular-nums">{r.days}</td>
                           <td className="py-2 px-2 text-right tabular-nums">{formatNumberDecimal(parseFloat(r.monthlyDepr))}</td>
                           <td className="py-2 px-2 text-right tabular-nums">{formatNumberDecimal(parseFloat(r.accumulatedDepr))}</td>
                           <td className="py-2 px-2 text-right tabular-nums font-semibold">{formatNumberDecimal(parseFloat(r.netBookValue))}</td>

--- a/apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx
@@ -1,11 +1,17 @@
-// Asset module — EntryPage Section 2 (cost + VAT/WHT live calc)
+// Asset module — EntryPage Section 2 (cost structure, expense-style line row)
 // Pure presentation. Uses parent FormProvider for state + useAssetCalculation result.
+//
+// Layout mirrors the expense-recording page (บันทึกรายจ่าย):
+//   line row (qty · unit price · discount · VAT% · WHT% · before-tax)
+//   + inclusive/exclusive toggle + capitalize fields + residual/life + summary.
+// basePrice is derived from the line (qty × unitPrice − discount) and kept in
+// sync via setValue so the rest of the form (calc, refines, submit) is unchanged.
 
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -13,7 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Receipt, ReceiptText, Coins, Gem, AlertTriangle } from 'lucide-react';
+import { Coins, Gem, AlertTriangle, PackagePlus } from 'lucide-react';
 import { formatNumberDecimal } from '@/utils/formatters';
 import type { AssetEntryFormValues } from '../schema';
 import type { CalculationResult } from '../hooks/useAssetCalculation';
@@ -29,148 +35,176 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
     watch,
     formState: { errors },
   } = useFormContext<AssetEntryFormValues>();
+
+  const quantity = watch('quantity');
+  const unitPrice = watch('unitPrice');
+  const discount = watch('discount');
   const hasVat = watch('hasVat');
   const vatInclusive = watch('vatInclusive');
   const vatAccount = watch('vatAccount');
   const hasWht = watch('hasWht');
+  const whtRate = watch('whtRate');
   const whtAccount = watch('whtAccount');
   const whtFormType = watch('whtFormType');
-  const whtRate = watch('whtRate');
-  const installationCost = watch('installationCost');
   const whtBaseAmount = watch('whtBaseAmount');
+  const installationCost = watch('installationCost');
+
+  // Derive basePrice = qty × unitPrice − discount (clamped ≥ 0). Effect deps are
+  // the line inputs only, so this never loops (basePrice doesn't feed derivedBase).
+  const derivedBase = Math.max(
+    0,
+    (Number(quantity) || 0) * (Number(unitPrice) || 0) - (Number(discount) || 0),
+  );
+  useEffect(() => {
+    setValue('basePrice', derivedBase, { shouldValidate: true });
+  }, [derivedBase, setValue]);
+
+  const vatPercent = hasVat ? '7' : '0';
+  const whtPercent = hasWht && whtRate ? String(Math.round(Number(whtRate) * 100)) : '0';
+
+  const onVatPercentChange = (v: string) => {
+    const on = v === '7';
+    setValue('hasVat', on, { shouldValidate: true });
+    if (on && !vatAccount) {
+      setValue('vatAccount', '11-4101', { shouldValidate: true });
+    }
+  };
+
+  const onWhtPercentChange = (v: string) => {
+    if (v === '0') {
+      setValue('hasWht', false, { shouldValidate: true });
+      setValue('whtRate', undefined, { shouldValidate: true });
+    } else {
+      setValue('hasWht', true);
+      setValue('whtRate', Number(v) / 100, { shouldValidate: true });
+      if (!whtAccount) setValue('whtAccount', '21-3103', { shouldValidate: true });
+      if (!whtFormType) setValue('whtFormType', 'PND53');
+    }
+  };
+
+  const noWhtBase =
+    hasWht && (Number(whtBaseAmount) || 0) === 0 && (Number(installationCost) || 0) === 0;
 
   return (
     <Card>
       <AssetSectionHeader number={2} title="โครงสร้างต้นทุน · VAT · WHT" />
       <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {/* Line-item row — same shape as the expense-recording page */}
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-6">
           <div>
-            <Label>{vatInclusive && hasVat ? 'ราคาที่กรอก (รวม VAT)' : 'ราคาก่อน VAT'} *</Label>
-            <Input type="number" step="0.01" {...register('basePrice')} />
-            <p className="mt-1 text-xs text-muted-foreground">Base Price</p>
-            {errors.basePrice && (
-              <p className="text-sm text-destructive mt-1">{errors.basePrice.message}</p>
+            <Label>จำนวน</Label>
+            <Input type="number" step="1" min="0" {...register('quantity')} />
+          </div>
+          <div>
+            <Label>ราคา/หน่วย</Label>
+            <Input type="number" step="0.01" min="0" {...register('unitPrice')} />
+          </div>
+          <div>
+            <Label>ส่วนลด</Label>
+            <Input type="number" step="0.01" min="0" {...register('discount')} />
+          </div>
+          <div>
+            <Label>VAT%</Label>
+            <Select value={vatPercent} onValueChange={onVatPercentChange}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">0%</SelectItem>
+                <SelectItem value="7">7%</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>WHT%</Label>
+            <Select value={whtPercent} onValueChange={onWhtPercentChange}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">0%</SelectItem>
+                <SelectItem value="1">1%</SelectItem>
+                <SelectItem value="2">2%</SelectItem>
+                <SelectItem value="3">3%</SelectItem>
+                <SelectItem value="5">5%</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>ก่อนภาษี</Label>
+            <Input
+              value={fmt(calc.basePrice)}
+              readOnly
+              className="bg-muted text-right tabular-nums"
+            />
+          </div>
+        </div>
+        {errors.basePrice && (
+          <p className="text-sm text-destructive">{errors.basePrice.message}</p>
+        )}
+
+        {/* VAT price-type toggle + purchase-tax account (only when VAT 7%) */}
+        {hasVat && (
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-3 rounded-r-lg border-l-4 border-info bg-info/5 p-3">
+            <div className="flex items-center gap-5 text-sm">
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="radio"
+                  name="vat-price-type"
+                  className="accent-primary"
+                  checked={!!vatInclusive}
+                  onChange={() => setValue('vatInclusive', true)}
+                />
+                ราคารวม VAT แล้ว (Inclusive)
+              </label>
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="radio"
+                  name="vat-price-type"
+                  className="accent-primary"
+                  checked={!vatInclusive}
+                  onChange={() => setValue('vatInclusive', false)}
+                />
+                ราคายังไม่รวม VAT (Exclusive)
+              </label>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label className="whitespace-nowrap text-xs text-muted-foreground">
+                บัญชีภาษีซื้อ
+              </Label>
+              <Select
+                value={vatAccount}
+                onValueChange={(v) =>
+                  setValue('vatAccount', v as AssetEntryFormValues['vatAccount'], {
+                    shouldValidate: true,
+                  })
+                }
+              >
+                <SelectTrigger className="h-9 w-[250px]">
+                  <SelectValue placeholder="เลือก" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="11-4101">11-4101 ภาษีซื้อ (เครดิตได้)</SelectItem>
+                  <SelectItem value="11-4102">11-4102 ภาษีซื้อรอเรียกเก็บ</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              ยอด VAT (คำนวณ):{' '}
+              <span className="font-semibold tabular-nums text-foreground">
+                {fmt(calc.vatAmount)}
+              </span>
+            </div>
+            {errors.vatAccount && (
+              <p className="w-full text-sm text-destructive">{errors.vatAccount.message}</p>
             )}
           </div>
-          <div>
-            <Label>ค่าขนส่ง</Label>
-            <Input type="number" step="0.01" {...register('shippingCost')} />
-            <p className="mt-1 text-xs text-muted-foreground">Capitalize → cost (TAS 16.16)</p>
-          </div>
-          <div>
-            <Label>ค่าติดตั้ง</Label>
-            <Input type="number" step="0.01" {...register('installationCost')} />
-            <p className="mt-1 text-xs text-muted-foreground">Capitalize → cost</p>
-          </div>
-          <div>
-            <Label>ต้นทุนสินทรัพย์อื่น ๆ (ค่า capitalize อื่น)</Label>
-            <Input type="number" step="0.01" {...register('otherCapitalized')} />
-            <p className="mt-1 text-xs text-muted-foreground">ทดสอบ เตรียม ฯลฯ</p>
-          </div>
-        </div>
+        )}
 
-        {/* VAT */}
-        <div className="border-l-4 border-violet-500 bg-violet-50/30 dark:bg-violet-950/30 rounded-r-lg p-3 space-y-3">
-          <div className="flex items-center gap-2">
-            <Switch
-              id="asset-has-vat"
-              checked={hasVat}
-              onCheckedChange={(v) => setValue('hasVat', v)}
-            />
-            <ReceiptText className="size-4 text-muted-foreground" />
-            <Label htmlFor="asset-has-vat" className="font-semibold cursor-pointer">
-              มีใบกำกับภาษี (VAT 7%)
-            </Label>
-            <span className="text-xs text-muted-foreground">· ม.82/3 ประมวลรัษฎากร</span>
-          </div>
-          {hasVat && (
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 ml-6">
-              <div className="flex items-center gap-2">
-                <Switch
-                  id="asset-vat-inclusive"
-                  checked={vatInclusive}
-                  onCheckedChange={(v) => setValue('vatInclusive', v)}
-                />
-                <Label htmlFor="asset-vat-inclusive" className="cursor-pointer">
-                  ราคารวม VAT แล้ว (inclusive)
-                </Label>
-              </div>
-              <div>
-                <Label>บัญชีภาษีซื้อ</Label>
-                <Select
-                  value={vatAccount}
-                  onValueChange={(v) =>
-                    setValue('vatAccount', v as AssetEntryFormValues['vatAccount'], {
-                      shouldValidate: true,
-                    })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="เลือก" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="11-4101">11-4101 ภาษีซื้อ (เครดิตได้)</SelectItem>
-                    <SelectItem value="11-4102">11-4102 ภาษีซื้อรอเรียกเก็บ</SelectItem>
-                  </SelectContent>
-                </Select>
-                {errors.vatAccount && (
-                  <p className="text-sm text-destructive mt-1">{errors.vatAccount.message}</p>
-                )}
-              </div>
-              <div>
-                <Label>ยอด VAT (คำนวณ)</Label>
-                <Input value={fmt(calc.vatAmount)} readOnly className="bg-muted" />
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* WHT */}
-        <div className="border-l-4 border-amber-500 bg-amber-50/30 dark:bg-amber-950/30 rounded-r-lg p-3 space-y-3">
-          <div className="flex items-center gap-2">
-            <Switch
-              id="asset-has-wht"
-              checked={hasWht}
-              onCheckedChange={(v) => setValue('hasWht', v)}
-            />
-            <Receipt className="size-4 text-muted-foreground" />
-            <Label htmlFor="asset-has-wht" className="font-semibold cursor-pointer">
-              หัก ณ ที่จ่าย WHT
-            </Label>
-            <span className="text-xs text-muted-foreground">
-              · ทป.4/2528 · หักเฉพาะ &ldquo;ค่าบริการ&rdquo; — ไม่ใช่ค่าสินค้า (ม.50 ทวิ)
-            </span>
-          </div>
-          {hasWht && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 ml-6">
-              <div>
-                <Label>ฐานคำนวณ WHT</Label>
-                <Input
-                  type="number"
-                  step="0.01"
-                  {...register('whtBaseAmount')}
-                  placeholder="default = ค่าติดตั้ง"
-                />
-              </div>
-              <div>
-                <Label>อัตรา</Label>
-                <Select
-                  value={whtRate?.toString() ?? ''}
-                  onValueChange={(v) =>
-                    setValue('whtRate', Number(v), { shouldValidate: true })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="เลือก" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="0.01">1%</SelectItem>
-                    <SelectItem value="0.02">2%</SelectItem>
-                    <SelectItem value="0.03">3%</SelectItem>
-                    <SelectItem value="0.05">5%</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+        {/* WHT detail (only when WHT > 0) — applies to the service/installation portion */}
+        {hasWht && (
+          <div className="space-y-3 rounded-r-lg border-l-4 border-warning bg-warning/5 p-3">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <div>
                 <Label>แบบ ภ.ง.ด.</Label>
                 <Select
@@ -207,27 +241,81 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
                   </SelectContent>
                 </Select>
                 {errors.whtAccount && (
-                  <p className="text-sm text-destructive mt-1">{errors.whtAccount.message}</p>
+                  <p className="mt-1 text-sm text-destructive">{errors.whtAccount.message}</p>
                 )}
               </div>
+              <div>
+                <Label>ฐานคำนวณ WHT (ค่าบริการ)</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  {...register('whtBaseAmount')}
+                  placeholder="default = ค่าติดตั้ง"
+                />
+              </div>
             </div>
-          )}
-          {hasWht && (Number(whtBaseAmount) || 0) === 0 && (Number(installationCost) || 0) === 0 && (
-            <div className="ml-6 rounded-md border border-warning/30 bg-warning/5 p-3 text-sm">
-              <p className="font-medium text-warning flex items-center gap-1.5">
-                <AlertTriangle className="size-4" />
-                ไม่มีฐานคำนวณ WHT
-              </p>
-              <p className="mt-1 text-muted-foreground">
-                ไม่มีค่าติดตั้งและไม่ระบุฐานคำนวณ WHT → ระบบจะไม่หัก WHT (= 0). WHT หักเฉพาะค่าบริการตาม ทป.4/2528 — ถ้าซื้อสินค้าอย่างเดียวให้ปิด toggle WHT
-              </p>
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              WHT หักเฉพาะ &ldquo;ค่าบริการ/ค่าติดตั้ง&rdquo; ตาม ทป.4/2528 — ไม่ใช่ค่าสินค้า · ยอดหัก:{' '}
+              <span className="font-semibold tabular-nums text-foreground">
+                {fmt(calc.whtAmount)}
+              </span>
+            </p>
+            {noWhtBase && (
+              <div className="rounded-md border border-warning/30 bg-warning/5 p-3 text-sm">
+                <p className="flex items-center gap-1.5 font-medium text-warning">
+                  <AlertTriangle className="size-4" />
+                  ไม่มีฐานคำนวณ WHT
+                </p>
+                <p className="mt-1 text-muted-foreground">
+                  ไม่มีค่าติดตั้งและไม่ระบุฐานคำนวณ WHT → ระบบจะไม่หัก WHT (= 0). ถ้าซื้อสินค้าอย่างเดียวให้ตั้ง WHT% = 0
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Capitalize fields (TAS 16.16 — included in asset cost) */}
+        <div>
+          <div className="mb-2 flex items-center gap-1.5 text-sm font-medium text-foreground">
+            <PackagePlus className="size-4 text-muted-foreground" />
+            ต้นทุนเพิ่มเติม (Capitalize เข้าราคาทุนสินทรัพย์)
+          </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <div>
+              <Label>ค่าขนส่ง</Label>
+              <Input type="number" step="0.01" min="0" {...register('shippingCost')} />
             </div>
-          )}
+            <div>
+              <Label>ค่าติดตั้ง</Label>
+              <Input type="number" step="0.01" min="0" {...register('installationCost')} />
+            </div>
+            <div>
+              <Label>ต้นทุนอื่น ๆ</Label>
+              <Input type="number" step="0.01" min="0" {...register('otherCapitalized')} />
+            </div>
+          </div>
         </div>
 
-        {/* Live totals — basePrice / purchaseCost (capitalized) / monthlyDepr / totalPayable.
-            (calc.netBookValue starts equal to purchaseCost; not used here to avoid confusion.) */}
-        <div className="rounded-lg bg-muted/60 p-4 grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        {/* Residual + useful life */}
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <div>
+            <Label>มูลค่าซาก (Residual)</Label>
+            <Input type="number" step="0.01" min="0" {...register('residualValue')} />
+            {errors.residualValue && (
+              <p className="mt-1 text-sm text-destructive">{errors.residualValue.message}</p>
+            )}
+          </div>
+          <div>
+            <Label>อายุการใช้งาน (เดือน) *</Label>
+            <Input type="number" step="1" min="1" {...register('usefulLifeMonths')} />
+            {errors.usefulLifeMonths && (
+              <p className="mt-1 text-sm text-destructive">{errors.usefulLifeMonths.message}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Summary */}
+        <div className="grid grid-cols-2 gap-3 rounded-lg bg-muted/60 p-4 text-sm md:grid-cols-4">
           <div>
             <div className="flex items-center gap-1.5 text-muted-foreground">
               <Coins className="size-3.5" />
@@ -243,9 +331,12 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
             <div className="text-xl font-semibold tabular-nums">{fmt(calc.purchaseCost)}</div>
           </div>
           <div>
-            <div className="text-muted-foreground">ค่าเสื่อม / เดือน</div>
+            <div className="text-muted-foreground">ค่าเสื่อม/เดือน</div>
             <div className="text-xl font-semibold tabular-nums text-warning">
               {fmt(calc.monthlyDepr)} <span className="text-xs">฿</span>
+            </div>
+            <div className="text-[11px] text-muted-foreground">
+              ค่าเสื่อม/วัน {fmt(calc.dailyDepr)} ฿
             </div>
           </div>
           <div>
@@ -253,24 +344,6 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
             <div className="text-xl font-semibold tabular-nums text-primary">
               {fmt(calc.totalPayable)} <span className="text-xs">฿</span>
             </div>
-          </div>
-        </div>
-
-        {/* Residual + life */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div>
-            <Label>มูลค่าซาก (residual)</Label>
-            <Input type="number" step="0.01" {...register('residualValue')} />
-            {errors.residualValue && (
-              <p className="text-sm text-destructive mt-1">{errors.residualValue.message}</p>
-            )}
-          </div>
-          <div>
-            <Label>อายุการใช้งาน (เดือน) *</Label>
-            <Input type="number" step="1" {...register('usefulLifeMonths')} />
-            {errors.usefulLifeMonths && (
-              <p className="text-sm text-destructive mt-1">{errors.usefulLifeMonths.message}</p>
-            )}
           </div>
         </div>
       </CardContent>

--- a/apps/web/src/pages/assets/hooks/useAssetCalculation.ts
+++ b/apps/web/src/pages/assets/hooks/useAssetCalculation.ts
@@ -24,7 +24,8 @@ export interface CalculationResult {
   whtAmount: number;
   purchaseCost: number; // basePrice + ship + install + other
   totalPayable: number; // purchaseCost + (excl ? vat : 0) - wht
-  monthlyDepr: number;
+  monthlyDepr: number; // nominal: base / months (display only)
+  dailyDepr: number; // base ÷ (years × 365) — actual posting basis
   netBookValue: number;
   journalLines: JournalLine[];
   totalDr: number;
@@ -91,7 +92,10 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
     // changes how basePrice is parsed. Cash out always = (ex-VAT cost) + VAT − WHT.
     // (Matches server-side asset-purchase.template.ts logic.)
     const totalPayable = round2(purchaseCost + vatAmount - whtAmount);
+    // Nominal monthly (display only) — base / months.
     const monthlyDepr = round4((purchaseCost - residual) / usefulLife);
+    // Daily rate (actual posting basis) — base ÷ (years × 365), 365-day fixed year.
+    const dailyDepr = round4((purchaseCost - residual) / ((usefulLife / 12) * 365));
 
     // JE preview lines — names resolved from chart_of_accounts (P13).
     const cat = values.category;
@@ -142,6 +146,7 @@ export function useAssetCalculation(values: Partial<AssetEntryFormValues>): Calc
       purchaseCost,
       totalPayable,
       monthlyDepr,
+      dailyDepr,
       netBookValue: purchaseCost,
       journalLines: lines,
       totalDr: round2(totalDr),

--- a/apps/web/src/pages/assets/schema.ts
+++ b/apps/web/src/pages/assets/schema.ts
@@ -18,6 +18,10 @@ export const assetEntrySchema = z
     warrantyExpire: z.string().optional(),
 
     // Section 2 — pricing / VAT / WHT / depreciation
+    // Line-item inputs (expense-style). basePrice is derived = qty × unitPrice − discount.
+    quantity: z.coerce.number().min(0).optional().default(1),
+    unitPrice: z.coerce.number().min(0).optional().default(0),
+    discount: z.coerce.number().min(0).optional().default(0),
     basePrice: z.coerce.number().positive('ราคาต้องมากกว่า 0'),
     shippingCost: z.coerce.number().min(0).optional().default(0),
     installationCost: z.coerce.number().min(0).optional().default(0),

--- a/apps/web/src/pages/assets/types.ts
+++ b/apps/web/src/pages/assets/types.ts
@@ -49,6 +49,7 @@ export interface Asset {
   residualValue: string;
   usefulLifeMonths: number;
   monthlyDepr: string;
+  dailyDepr: string;
   accumulatedDepr: string;
   netBookValue: string;
   coaCostAccount: string | null;
@@ -241,6 +242,7 @@ export interface AssetRegisterResponse {
 
 export interface AssetScheduleRow {
   period: string;
+  days: number;
   monthlyDepr: string;
   accumulatedDepr: string;
   netBookValue: string;
@@ -255,6 +257,7 @@ export interface AssetScheduleResponse {
   purchaseCost: string;
   residualValue: string;
   monthlyDepr: string;
+  dailyDepr: string;
   rows: AssetScheduleRow[];
 }
 


### PR DESCRIPTION
## Summary
- Fixed-asset depreciation is now **daily** straight-line: per-period amount = `dailyRate × days-in-period`, with partial first/last months, ROUND_HALF_UP, forced-exact final period (Σ = cost − salvage), and disposal-date stop. Single pure `buildDepreciationSchedule` is the shared source of truth for the posting template, `previewRun`, and `getAssetSchedule`.
- Asset-entry cost section rebuilt into an **expense-style line row** (qty · unit price · discount · VAT% · WHT% · before-tax) + inclusive/exclusive toggle + capitalize fields + summary; `basePrice` derived from the line. Daily rate + per-period days surfaced on schedule/detail pages.
- Adds `dailyDepr` column (additive, idempotent migration).

## Notes
- Also carries a pre-existing unrelated commit on this branch: `fix(integrations): allow ACCOUNTANT read-only access to integration config`.
- Behavior change: posted depreciation amounts differ going forward (TB/P&L impact) — intended per spec.
- Migration `20260964000000_add_daily_depr_to_fixed_assets` is additive + `IF NOT EXISTS` + default 0 + safe backfill.

## Test plan
- [x] Pure schedule unit tests (13) — all 5 business rules
- [x] jest asset + depreciation suites (119 passed)
- [x] vitest depreciation template specs (7 + 9)
- [x] type-check api + web, web production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)