### PR TITLE
feat: Finance Receivable Contact System (PEAK-style directory + activity log)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "prisma:seed": "npx tsx prisma/seed.ts",
     "seed:letters-mock": "npx tsx prisma/seeds/letters-mock.seed.ts",
     "backfill:promise-slots": "tsx scripts/backfill-promise-slots.ts",
+    "backfill:external-finance": "tsx scripts/backfill-external-finance-fk.ts",
     "wipe:accounting": "node dist/src/cli/wipe-accounting.cli.js",
     "wipe:accounting:help": "echo 'Usage: CONFIRM_WIPE=YES_I_AM_SURE EXPECTED_DB_NAME=<db> [ALLOW_PROD_WIPE=YES_I_AM_SURE] npm run wipe:accounting'",
     "wipe:expenses": "tsx src/cli/wipe-expenses.cli.ts",

--- a/apps/api/prisma/migrations/20260964000000_finance_receivable_contact_system/migration.sql
+++ b/apps/api/prisma/migrations/20260964000000_finance_receivable_contact_system/migration.sql
@@ -1,0 +1,100 @@
+-- CreateEnum
+CREATE TYPE "FinanceContactChannel" AS ENUM ('CALL', 'EMAIL', 'LINE', 'MEETING', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "FinanceContactResult" AS ENUM ('ANSWERED', 'NO_ANSWER', 'PROMISED', 'DISPUTED', 'REQUESTED_DOCS', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "external_finance_companies" ADD COLUMN     "credit_term_days" INTEGER,
+ADD COLUMN     "email" TEXT,
+ADD COLUMN     "line_oa_id" TEXT,
+ADD COLUMN     "tax_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "finance_receivables" ADD COLUMN     "contact_attempt_count" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "external_finance_company_id" TEXT,
+ADD COLUMN     "last_contacted_at" TIMESTAMP(3),
+ADD COLUMN     "last_promised_date" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "finance_company_contacts" (
+    "id" TEXT NOT NULL,
+    "external_finance_company_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "position" TEXT,
+    "department" TEXT,
+    "phone" TEXT,
+    "email" TEXT,
+    "line_id" TEXT,
+    "notes" TEXT,
+    "is_primary" BOOLEAN NOT NULL DEFAULT false,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "finance_company_contacts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "finance_receivable_contact_logs" (
+    "id" TEXT NOT NULL,
+    "finance_receivable_id" TEXT NOT NULL,
+    "external_finance_company_id" TEXT NOT NULL,
+    "finance_company_contact_id" TEXT,
+    "contacted_by_id" TEXT NOT NULL,
+    "contacted_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "channel" "FinanceContactChannel" NOT NULL DEFAULT 'CALL',
+    "result" "FinanceContactResult" NOT NULL,
+    "notes" TEXT,
+    "promised_date" TIMESTAMP(3),
+    "promised_amount" DECIMAL(12,2),
+    "promised_broken_at" TIMESTAMP(3),
+    "promised_kept_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "finance_receivable_contact_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "finance_company_contacts_external_finance_company_id_is_act_idx" ON "finance_company_contacts"("external_finance_company_id", "is_active");
+
+-- CreateIndex
+CREATE INDEX "finance_receivable_contact_logs_finance_receivable_id_conta_idx" ON "finance_receivable_contact_logs"("finance_receivable_id", "contacted_at");
+
+-- CreateIndex
+CREATE INDEX "finance_receivable_contact_logs_external_finance_company_id_idx" ON "finance_receivable_contact_logs"("external_finance_company_id", "contacted_at");
+
+-- CreateIndex
+CREATE INDEX "finance_receivable_contact_logs_promised_date_promised_brok_idx" ON "finance_receivable_contact_logs"("promised_date", "promised_broken_at", "promised_kept_at");
+
+-- CreateIndex
+CREATE INDEX "finance_receivables_external_finance_company_id_status_idx" ON "finance_receivables"("external_finance_company_id", "status");
+
+-- CreateIndex
+CREATE INDEX "finance_receivables_last_contacted_at_idx" ON "finance_receivables"("last_contacted_at");
+
+-- AddForeignKey
+ALTER TABLE "finance_receivables" ADD CONSTRAINT "finance_receivables_external_finance_company_id_fkey" FOREIGN KEY ("external_finance_company_id") REFERENCES "external_finance_companies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "finance_company_contacts" ADD CONSTRAINT "finance_company_contacts_external_finance_company_id_fkey" FOREIGN KEY ("external_finance_company_id") REFERENCES "external_finance_companies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "finance_receivable_contact_logs" ADD CONSTRAINT "finance_receivable_contact_logs_finance_receivable_id_fkey" FOREIGN KEY ("finance_receivable_id") REFERENCES "finance_receivables"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "finance_receivable_contact_logs" ADD CONSTRAINT "finance_receivable_contact_logs_external_finance_company_i_fkey" FOREIGN KEY ("external_finance_company_id") REFERENCES "external_finance_companies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "finance_receivable_contact_logs" ADD CONSTRAINT "finance_receivable_contact_logs_finance_company_contact_id_fkey" FOREIGN KEY ("finance_company_contact_id") REFERENCES "finance_company_contacts"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "finance_receivable_contact_logs" ADD CONSTRAINT "finance_receivable_contact_logs_contacted_by_id_fkey" FOREIGN KEY ("contacted_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Partial unique index: at most one primary contact per company (excluding soft-deleted rows)
+CREATE UNIQUE INDEX uniq_primary_per_company
+  ON finance_company_contacts (external_finance_company_id)
+  WHERE is_primary = true AND deleted_at IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -772,6 +772,9 @@ model User {
   exchangeRequestsRequested ContractExchangeRequest[] @relation("ExchangeRequestsRequested")
   exchangeRequestsApproved  ContractExchangeRequest[] @relation("ExchangeRequestsApproved")
 
+  // Finance Receivable Contact System
+  financeContactLogs FinanceReceivableContactLog[] @relation("FinanceContactLogger")
+
   @@index([branchId])
   @@index([yeastarExtension])
   @@map("users")
@@ -3557,9 +3560,18 @@ model FinanceReceivable {
   updatedAt         DateTime                @updatedAt @map("updated_at")
   deletedAt         DateTime?               @map("deleted_at")
 
+  // ── new (Phase 1 nullable, Phase 3 → required) ──
+  externalFinanceCompanyId String?   @map("external_finance_company_id")
+  lastContactedAt          DateTime? @map("last_contacted_at")
+  lastPromisedDate         DateTime? @map("last_promised_date")
+  contactAttemptCount      Int       @default(0) @map("contact_attempt_count")
+
   sale       Sale   @relation(fields: [saleId], references: [id])
   branch     Branch @relation(fields: [branchId], references: [id])
   recordedBy User?  @relation("FinanceRecordedBy", fields: [recordedById], references: [id])
+
+  company     ExternalFinanceCompany?       @relation(fields: [externalFinanceCompanyId], references: [id])
+  contactLogs FinanceReceivableContactLog[]
 
   @@index([status])
   @@index([financeCompany])
@@ -3571,6 +3583,8 @@ model FinanceReceivable {
   // -column indexes can't be combined efficiently for high-cardinality
   // status filtering inside a branch).
   @@index([status, branchId])
+  @@index([externalFinanceCompanyId, status])
+  @@index([lastContactedAt])
   @@map("finance_receivables")
 }
 
@@ -6957,7 +6971,18 @@ model ExternalFinanceCompany {
   updatedAt             DateTime  @updatedAt @map("updated_at")
   deletedAt             DateTime? @map("deleted_at")
 
+  // ── new master fields (PEAK-style, focused) ──
+  taxId          String?  @map("tax_id")
+  email          String?
+  lineOaId       String?  @map("line_oa_id")
+  creditTermDays Int?     @map("credit_term_days")
+
   commissions ExternalFinanceCommission[]
+
+  // ── new relations ──
+  contacts    FinanceCompanyContact[]
+  receivables FinanceReceivable[]
+  contactLogs FinanceReceivableContactLog[]
 
   @@map("external_finance_companies")
 }
@@ -6986,6 +7011,79 @@ model ExternalFinanceCommission {
   @@index([status])
   @@index([receivedAt])
   @@map("external_finance_commissions")
+}
+
+// ============================================================
+// Finance Receivable Contact System
+// ============================================================
+
+enum FinanceContactChannel {
+  CALL
+  EMAIL
+  LINE
+  MEETING
+  OTHER
+}
+
+enum FinanceContactResult {
+  ANSWERED
+  NO_ANSWER
+  PROMISED
+  DISPUTED
+  REQUESTED_DOCS
+  OTHER
+}
+
+model FinanceCompanyContact {
+  id                       String   @id @default(uuid())
+  externalFinanceCompanyId String   @map("external_finance_company_id")
+  name                     String
+  position                 String?
+  department               String?
+  phone                    String?
+  email                    String?
+  lineId                   String?  @map("line_id")
+  notes                    String?
+  isPrimary                Boolean  @default(false) @map("is_primary")
+  isActive                 Boolean  @default(true)  @map("is_active")
+  createdAt                DateTime @default(now()) @map("created_at")
+  updatedAt                DateTime @updatedAt      @map("updated_at")
+  deletedAt                DateTime?                @map("deleted_at")
+
+  company     ExternalFinanceCompany        @relation(fields: [externalFinanceCompanyId], references: [id])
+  contactLogs FinanceReceivableContactLog[]
+
+  @@index([externalFinanceCompanyId, isActive])
+  @@map("finance_company_contacts")
+}
+
+model FinanceReceivableContactLog {
+  id                       String                @id @default(uuid())
+  financeReceivableId      String                @map("finance_receivable_id")
+  externalFinanceCompanyId String                @map("external_finance_company_id")
+  financeCompanyContactId  String?               @map("finance_company_contact_id")
+  contactedById            String                @map("contacted_by_id")
+  contactedAt              DateTime              @default(now()) @map("contacted_at")
+  channel                  FinanceContactChannel @default(CALL)
+  result                   FinanceContactResult
+  notes                    String?
+  promisedDate             DateTime?             @map("promised_date")
+  promisedAmount           Decimal?              @map("promised_amount") @db.Decimal(12, 2)
+  promisedBrokenAt         DateTime?             @map("promised_broken_at")
+  promisedKeptAt           DateTime?             @map("promised_kept_at")
+  createdAt                DateTime              @default(now()) @map("created_at")
+  updatedAt                DateTime              @updatedAt      @map("updated_at")
+  deletedAt                DateTime?             @map("deleted_at")
+
+  receivable  FinanceReceivable      @relation(fields: [financeReceivableId], references: [id])
+  company     ExternalFinanceCompany @relation(fields: [externalFinanceCompanyId], references: [id])
+  contact     FinanceCompanyContact? @relation(fields: [financeCompanyContactId], references: [id])
+  contactedBy User                   @relation("FinanceContactLogger", fields: [contactedById], references: [id])
+
+  @@index([financeReceivableId, contactedAt])
+  @@index([externalFinanceCompanyId, contactedAt])
+  @@index([promisedDate, promisedBrokenAt, promisedKeptAt])
+  @@map("finance_receivable_contact_logs")
 }
 
 // ============================================================

--- a/apps/api/scripts/backfill-external-finance-fk.ts
+++ b/apps/api/scripts/backfill-external-finance-fk.ts
@@ -1,0 +1,92 @@
+// apps/api/scripts/backfill-external-finance-fk.ts
+import { PrismaClient } from '@prisma/client';
+import { normalizeFinanceCompanyName } from '../src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util';
+
+const prisma = new PrismaClient();
+
+interface Report {
+  receivablesMatched: number;
+  receivablesNewCompany: number;
+  contactsMigrated: number;
+  contactsSkipped: number;
+}
+
+async function main(): Promise<Report> {
+  const report: Report = {
+    receivablesMatched: 0,
+    receivablesNewCompany: 0,
+    contactsMigrated: 0,
+    contactsSkipped: 0,
+  };
+
+  // Step 1: index existing ExternalFinanceCompany by normalized name
+  const allCompanies = await prisma.externalFinanceCompany.findMany({
+    where: { deletedAt: null },
+  });
+  const byNormName = new Map<string, string>();
+  for (const c of allCompanies) {
+    byNormName.set(normalizeFinanceCompanyName(c.name), c.id);
+  }
+
+  // Step 2: resolve FK on every receivable that lacks one
+  const orphans = await prisma.financeReceivable.findMany({
+    where: { externalFinanceCompanyId: null, deletedAt: null },
+    select: { id: true, financeCompany: true },
+  });
+
+  for (const r of orphans) {
+    const norm = normalizeFinanceCompanyName(r.financeCompany);
+    let companyId = byNormName.get(norm);
+    if (!companyId) {
+      const created = await prisma.externalFinanceCompany.create({
+        data: { name: r.financeCompany, isActive: true },
+      });
+      companyId = created.id;
+      byNormName.set(norm, companyId);
+      report.receivablesNewCompany += 1;
+    } else {
+      report.receivablesMatched += 1;
+    }
+    await prisma.financeReceivable.update({
+      where: { id: r.id },
+      data: { externalFinanceCompanyId: companyId },
+    });
+  }
+
+  // Step 3: migrate contactPerson/contactPhone → FinanceCompanyContact (idempotent)
+  const legacy = await prisma.externalFinanceCompany.findMany({
+    where: { deletedAt: null, contactPerson: { not: null } },
+  });
+  for (const co of legacy) {
+    const existingPrimary = await prisma.financeCompanyContact.findFirst({
+      where: { externalFinanceCompanyId: co.id, isPrimary: true, deletedAt: null },
+    });
+    if (existingPrimary) {
+      report.contactsSkipped += 1;
+      continue;
+    }
+    await prisma.financeCompanyContact.create({
+      data: {
+        externalFinanceCompanyId: co.id,
+        name: co.contactPerson!,
+        phone: co.contactPhone,
+        isPrimary: true,
+        isActive: true,
+      },
+    });
+    report.contactsMigrated += 1;
+  }
+
+  return report;
+}
+
+main()
+  .then((report) => {
+    console.log('Backfill report:', JSON.stringify(report, null, 2));
+    return prisma.$disconnect();
+  })
+  .catch(async (err) => {
+    console.error(err);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -59,6 +59,7 @@ import { EmailModule } from './modules/email/email.module';
 import { InviteModule } from './modules/invite/invite.module';
 import { PaySolutionsModule } from './modules/paysolutions/paysolutions.module';
 import { FinanceReceivableModule } from './modules/finance-receivable/finance-receivable.module';
+import { FinanceCompanyContactsModule } from './modules/finance-company-contacts/finance-company-contacts.module';
 import { AccountingModule } from './modules/accounting/accounting.module';
 import { OtherIncomeModule } from './modules/other-income/other-income.module';
 import { BookingsModule } from './modules/bookings/bookings.module';
@@ -233,6 +234,8 @@ import { AppCacheModule } from './cache/cache.module';
     PaySolutionsModule,
     // Finance Receivable
     FinanceReceivableModule,
+    // Finance Company Contacts
+    FinanceCompanyContactsModule,
     // Expense Management
     AccountingModule,
     // Other Income (รายได้อื่น — FINANCE only)

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -60,6 +60,7 @@ import { InviteModule } from './modules/invite/invite.module';
 import { PaySolutionsModule } from './modules/paysolutions/paysolutions.module';
 import { FinanceReceivableModule } from './modules/finance-receivable/finance-receivable.module';
 import { FinanceCompanyContactsModule } from './modules/finance-company-contacts/finance-company-contacts.module';
+import { FinanceReceivableContactLogsModule } from './modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module';
 import { AccountingModule } from './modules/accounting/accounting.module';
 import { OtherIncomeModule } from './modules/other-income/other-income.module';
 import { BookingsModule } from './modules/bookings/bookings.module';
@@ -236,6 +237,8 @@ import { AppCacheModule } from './cache/cache.module';
     FinanceReceivableModule,
     // Finance Company Contacts
     FinanceCompanyContactsModule,
+    // Finance Receivable Contact Logs
+    FinanceReceivableContactLogsModule,
     // Expense Management
     AccountingModule,
     // Other Income (รายได้อื่น — FINANCE only)

--- a/apps/api/src/modules/external-finance/dto/external-finance-company.dto.ts
+++ b/apps/api/src/modules/external-finance/dto/external-finance-company.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsNumber, Min, Max, IsBoolean, IsObject } from 'class-validator';
+import { IsString, IsOptional, IsNumber, Min, Max, IsBoolean, IsObject, IsEmail, MaxLength } from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
 
 export class CreateExternalFinanceCompanyDto {
@@ -30,6 +30,25 @@ export class CreateExternalFinanceCompanyDto {
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(20, { message: 'เลขผู้เสียภาษีต้องไม่เกิน 20 ตัวอักษร' })
+  taxId?: string;
+
+  @IsOptional()
+  @IsEmail({}, { message: 'รูปแบบอีเมลไม่ถูกต้อง' })
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  lineOaId?: string;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'เครดิตเทอมต้องเป็นตัวเลข' })
+  @Min(0)
+  creditTermDays?: number;
 }
 
 export class UpdateExternalFinanceCompanyDto extends PartialType(CreateExternalFinanceCompanyDto) {}

--- a/apps/api/src/modules/external-finance/external-finance.service.ts
+++ b/apps/api/src/modules/external-finance/external-finance.service.ts
@@ -35,6 +35,10 @@ export class ExternalFinanceService {
         bankAccountInfo: dto.bankAccountInfo as Prisma.InputJsonValue | undefined,
         notes: dto.notes,
         isActive: dto.isActive,
+        taxId: dto.taxId,
+        email: dto.email,
+        lineOaId: dto.lineOaId,
+        creditTermDays: dto.creditTermDays,
       },
     });
   }
@@ -51,6 +55,10 @@ export class ExternalFinanceService {
         bankAccountInfo: dto.bankAccountInfo as Prisma.InputJsonValue | undefined,
         notes: dto.notes,
         isActive: dto.isActive,
+        taxId: dto.taxId,
+        email: dto.email,
+        lineOaId: dto.lineOaId,
+        creditTermDays: dto.creditTermDays,
       },
     });
   }

--- a/apps/api/src/modules/finance-company-contacts/dto/finance-company-contact.dto.ts
+++ b/apps/api/src/modules/finance-company-contacts/dto/finance-company-contact.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsString,
+  IsOptional,
+  IsEmail,
+  IsBoolean,
+  MaxLength,
+} from 'class-validator';
+import { PartialType } from '@nestjs/mapped-types';
+
+export class CreateFinanceCompanyContactDto {
+  @IsString({ message: 'กรุณาระบุชื่อผู้ติดต่อ' })
+  @MaxLength(200)
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  position?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  department?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  phone?: string;
+
+  @IsOptional()
+  @IsEmail({}, { message: 'รูปแบบอีเมลไม่ถูกต้อง' })
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  lineId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  notes?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPrimary?: boolean;
+}
+
+export class UpdateFinanceCompanyContactDto extends PartialType(
+  CreateFinanceCompanyContactDto,
+) {}

--- a/apps/api/src/modules/finance-company-contacts/finance-company-contacts.controller.ts
+++ b/apps/api/src/modules/finance-company-contacts/finance-company-contacts.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { FinanceCompanyContactsService } from './finance-company-contacts.service';
+import {
+  CreateFinanceCompanyContactDto,
+  UpdateFinanceCompanyContactDto,
+} from './dto/finance-company-contact.dto';
+
+@ApiTags('Finance Contacts')
+@ApiBearerAuth('JWT')
+@Controller('external-finance/companies/:companyId/contacts')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FinanceCompanyContactsController {
+  constructor(private readonly service: FinanceCompanyContactsService) {}
+
+  @Get()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  list(@Param('companyId') companyId: string) {
+    return this.service.list(companyId);
+  }
+
+  @Post()
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  create(
+    @Param('companyId') companyId: string,
+    @Body() dto: CreateFinanceCompanyContactDto,
+  ) {
+    return this.service.create(companyId, dto);
+  }
+
+  @Patch(':contactId')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  update(
+    @Param('companyId') companyId: string,
+    @Param('contactId') contactId: string,
+    @Body() dto: UpdateFinanceCompanyContactDto,
+  ) {
+    return this.service.update(companyId, contactId, dto);
+  }
+
+  @Post(':contactId/set-primary')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  setPrimary(
+    @Param('companyId') companyId: string,
+    @Param('contactId') contactId: string,
+  ) {
+    return this.service.setPrimary(companyId, contactId);
+  }
+
+  @Delete(':contactId')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  remove(
+    @Param('companyId') companyId: string,
+    @Param('contactId') contactId: string,
+  ) {
+    return this.service.softDelete(companyId, contactId);
+  }
+}

--- a/apps/api/src/modules/finance-company-contacts/finance-company-contacts.module.ts
+++ b/apps/api/src/modules/finance-company-contacts/finance-company-contacts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { FinanceCompanyContactsController } from './finance-company-contacts.controller';
+import { FinanceCompanyContactsService } from './finance-company-contacts.service';
+
+@Module({
+  controllers: [FinanceCompanyContactsController],
+  providers: [FinanceCompanyContactsService],
+  exports: [FinanceCompanyContactsService],
+})
+export class FinanceCompanyContactsModule {}

--- a/apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.spec.ts
+++ b/apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { FinanceCompanyContactsService } from './finance-company-contacts.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('FinanceCompanyContactsService', () => {
+  let service: FinanceCompanyContactsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      financeCompanyContact: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+        count: jest.fn(),
+      },
+      externalFinanceCompany: {
+        findFirst: jest.fn(),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
+      $queryRaw: jest.fn(),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        FinanceCompanyContactsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = moduleRef.get(FinanceCompanyContactsService);
+  });
+
+  describe('list', () => {
+    it('returns contacts sorted with primary first then by name', async () => {
+      await service.list('co-1');
+      const call = prisma.financeCompanyContact.findMany.mock.calls[0][0];
+      expect(call.where.externalFinanceCompanyId).toBe('co-1');
+      expect(call.where.deletedAt).toBeNull();
+      expect(call.orderBy).toEqual([{ isPrimary: 'desc' }, { isActive: 'desc' }, { name: 'asc' }]);
+    });
+  });
+
+  describe('create', () => {
+    it('rejects when company not found', async () => {
+      prisma.externalFinanceCompany.findFirst.mockResolvedValue(null);
+      await expect(
+        service.create('co-1', { name: 'John' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('creates contact when company exists', async () => {
+      prisma.externalFinanceCompany.findFirst.mockResolvedValue({ id: 'co-1' });
+      prisma.financeCompanyContact.create.mockResolvedValue({ id: 'c-1' });
+      await service.create('co-1', { name: 'John' });
+      expect(prisma.financeCompanyContact.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('setPrimary', () => {
+    it('clears other primaries before promoting', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue({
+        id: 'c-2', externalFinanceCompanyId: 'co-1', deletedAt: null,
+      });
+
+      await service.setPrimary('co-1', 'c-2');
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(prisma.$queryRaw).toHaveBeenCalled(); // FOR UPDATE lock
+      expect(prisma.financeCompanyContact.updateMany).toHaveBeenCalledWith({
+        where: { externalFinanceCompanyId: 'co-1', isPrimary: true, deletedAt: null },
+        data: { isPrimary: false },
+      });
+      expect(prisma.financeCompanyContact.update).toHaveBeenCalledWith({
+        where: { id: 'c-2' },
+        data: { isPrimary: true },
+      });
+    });
+
+    it('throws NotFound when contact does not belong to company', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue(null);
+      await expect(service.setPrimary('co-1', 'c-2')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('softDelete', () => {
+    it('rejects primary delete when other active contacts exist', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue({
+        id: 'c-1', isPrimary: true, externalFinanceCompanyId: 'co-1', deletedAt: null,
+      });
+      prisma.financeCompanyContact.count.mockResolvedValue(1); // 1 other active contact
+
+      await expect(service.softDelete('co-1', 'c-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('allows primary delete when no other active contacts', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue({
+        id: 'c-1', isPrimary: true, externalFinanceCompanyId: 'co-1', deletedAt: null,
+      });
+      prisma.financeCompanyContact.count.mockResolvedValue(0);
+      prisma.financeCompanyContact.update.mockResolvedValue({});
+
+      await service.softDelete('co-1', 'c-1');
+      expect(prisma.financeCompanyContact.update).toHaveBeenCalledWith({
+        where: { id: 'c-1' },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+  });
+});

--- a/apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.ts
+++ b/apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.ts
@@ -1,0 +1,122 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  CreateFinanceCompanyContactDto,
+  UpdateFinanceCompanyContactDto,
+} from './dto/finance-company-contact.dto';
+
+@Injectable()
+export class FinanceCompanyContactsService {
+  constructor(private prisma: PrismaService) {}
+
+  async list(companyId: string) {
+    return this.prisma.financeCompanyContact.findMany({
+      where: { externalFinanceCompanyId: companyId, deletedAt: null },
+      orderBy: [{ isPrimary: 'desc' }, { isActive: 'desc' }, { name: 'asc' }],
+    });
+  }
+
+  async create(companyId: string, dto: CreateFinanceCompanyContactDto) {
+    const company = await this.prisma.externalFinanceCompany.findFirst({
+      where: { id: companyId, deletedAt: null },
+    });
+    if (!company) throw new NotFoundException('ไม่พบบริษัทไฟแนนซ์');
+
+    return this.prisma.$transaction(async (tx) => {
+      if (dto.isPrimary) {
+        await tx.financeCompanyContact.updateMany({
+          where: { externalFinanceCompanyId: companyId, isPrimary: true, deletedAt: null },
+          data: { isPrimary: false },
+        });
+      }
+      return tx.financeCompanyContact.create({
+        data: {
+          externalFinanceCompanyId: companyId,
+          name: dto.name,
+          position: dto.position,
+          department: dto.department,
+          phone: dto.phone,
+          email: dto.email,
+          lineId: dto.lineId,
+          notes: dto.notes,
+          isPrimary: dto.isPrimary ?? false,
+        },
+      });
+    });
+  }
+
+  async update(companyId: string, contactId: string, dto: UpdateFinanceCompanyContactDto) {
+    const existing = await this.prisma.financeCompanyContact.findFirst({
+      where: { id: contactId, externalFinanceCompanyId: companyId, deletedAt: null },
+    });
+    if (!existing) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    return this.prisma.$transaction(async (tx) => {
+      if (dto.isPrimary === true && !existing.isPrimary) {
+        await tx.financeCompanyContact.updateMany({
+          where: { externalFinanceCompanyId: companyId, isPrimary: true, deletedAt: null },
+          data: { isPrimary: false },
+        });
+      }
+      return tx.financeCompanyContact.update({
+        where: { id: contactId },
+        data: dto,
+      });
+    });
+  }
+
+  async setPrimary(companyId: string, contactId: string) {
+    const contact = await this.prisma.financeCompanyContact.findFirst({
+      where: { id: contactId, externalFinanceCompanyId: companyId, deletedAt: null },
+    });
+    if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    return this.prisma.$transaction(async (tx) => {
+      // Row-lock the company to serialise concurrent setPrimary calls
+      await tx.$queryRaw(
+        Prisma.sql`SELECT id FROM external_finance_companies WHERE id = ${companyId} FOR UPDATE`,
+      );
+      await tx.financeCompanyContact.updateMany({
+        where: { externalFinanceCompanyId: companyId, isPrimary: true, deletedAt: null },
+        data: { isPrimary: false },
+      });
+      return tx.financeCompanyContact.update({
+        where: { id: contactId },
+        data: { isPrimary: true },
+      });
+    });
+  }
+
+  async softDelete(companyId: string, contactId: string) {
+    const contact = await this.prisma.financeCompanyContact.findFirst({
+      where: { id: contactId, externalFinanceCompanyId: companyId, deletedAt: null },
+    });
+    if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    if (contact.isPrimary) {
+      const others = await this.prisma.financeCompanyContact.count({
+        where: {
+          externalFinanceCompanyId: companyId,
+          deletedAt: null,
+          isActive: true,
+          NOT: { id: contactId },
+        },
+      });
+      if (others > 0) {
+        throw new BadRequestException(
+          'ไม่สามารถลบผู้ติดต่อหลักได้ — กรุณาตั้งผู้ติดต่อหลักคนใหม่ก่อน',
+        );
+      }
+    }
+
+    return this.prisma.financeCompanyContact.update({
+      where: { id: contactId },
+      data: { deletedAt: new Date() },
+    });
+  }
+}

--- a/apps/api/src/modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.spec.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BrokenPromiseFinanceCron } from './broken-promise-finance.cron';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+describe('BrokenPromiseFinanceCron', () => {
+  let cron: BrokenPromiseFinanceCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = { $executeRaw: jest.fn().mockResolvedValue(7) };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        BrokenPromiseFinanceCron,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    cron = mod.get(BrokenPromiseFinanceCron);
+  });
+
+  it('marks broken promises and returns the affected count', async () => {
+    const result = await cron.handleCron();
+    expect(prisma.$executeRaw).toHaveBeenCalled();
+    expect(result).toBe(7);
+  });
+});

--- a/apps/api/src/modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.ts
@@ -1,0 +1,32 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+@Injectable()
+export class BrokenPromiseFinanceCron {
+  private readonly logger = new Logger(BrokenPromiseFinanceCron.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  // Daily at 02:00 Asia/Bangkok
+  @Cron('0 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async handleCron(): Promise<number> {
+    const affected = await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE finance_receivable_contact_logs
+      SET promised_broken_at = now()
+      WHERE promised_date < CURRENT_DATE
+        AND promised_broken_at IS NULL
+        AND promised_kept_at IS NULL
+        AND result = 'PROMISED'
+        AND deleted_at IS NULL
+        AND finance_receivable_id IN (
+          SELECT id FROM finance_receivables
+          WHERE status NOT IN ('RECEIVED', 'PARTIALLY_RECEIVED')
+            AND deleted_at IS NULL
+        )
+    `);
+    this.logger.log(`broken-promise-finance: marked ${affected} logs as broken`);
+    return Number(affected);
+  }
+}

--- a/apps/api/src/modules/finance-receivable-contact-logs/dto/finance-receivable-contact-log.dto.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/dto/finance-receivable-contact-log.dto.ts
@@ -1,0 +1,47 @@
+import {
+  IsDateString,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { PartialType } from '@nestjs/mapped-types';
+import { FinanceContactChannel, FinanceContactResult } from '@prisma/client';
+
+export class CreateFinanceContactLogDto {
+  @IsOptional()
+  @IsUUID('4', { message: 'financeCompanyContactId ต้องเป็น UUID' })
+  financeCompanyContactId?: string;
+
+  @IsOptional()
+  @IsEnum(FinanceContactChannel, { message: 'channel ไม่ถูกต้อง' })
+  channel?: FinanceContactChannel;
+
+  @IsEnum(FinanceContactResult, { message: 'result ไม่ถูกต้อง' })
+  result!: FinanceContactResult;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  notes?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'contactedAt ต้องเป็นวันที่ ISO' })
+  contactedAt?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'promisedDate ต้องเป็นวันที่ ISO' })
+  promisedDate?: string;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'promisedAmount ต้องเป็นตัวเลข' })
+  @IsPositive({ message: 'promisedAmount ต้องมากกว่า 0' })
+  promisedAmount?: number;
+}
+
+export class UpdateFinanceContactLogDto extends PartialType(
+  CreateFinanceContactLogDto,
+) {}

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.spec.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.spec.ts
@@ -1,0 +1,24 @@
+import { normalizeFinanceCompanyName } from './finance-company-name-normalizer.util';
+
+describe('normalizeFinanceCompanyName', () => {
+  it('trims whitespace', () => {
+    expect(normalizeFinanceCompanyName('  เคทีซี  ')).toBe('เคทีซี');
+  });
+
+  it('lowercases ASCII letters', () => {
+    expect(normalizeFinanceCompanyName('KTC Finance')).toBe('ktc finance');
+  });
+
+  it('collapses multiple internal spaces to single space', () => {
+    expect(normalizeFinanceCompanyName('กสิกร   ไทย')).toBe('กสิกร ไทย');
+  });
+
+  it('strips spaces around parentheses', () => {
+    expect(normalizeFinanceCompanyName('กสิกร (KK)')).toBe('กสิกร(kk)');
+  });
+
+  it('returns empty string for null / empty input', () => {
+    expect(normalizeFinanceCompanyName('')).toBe('');
+    expect(normalizeFinanceCompanyName(null as unknown as string)).toBe('');
+  });
+});

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.ts
@@ -1,0 +1,9 @@
+export function normalizeFinanceCompanyName(input: string | null | undefined): string {
+  if (!input) return '';
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*\(\s*/g, '(')
+    .replace(/\s*\)\s*/g, ')');
+}

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.controller.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.controller.ts
@@ -1,0 +1,85 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { FinanceReceivableContactLogsService } from './finance-receivable-contact-logs.service';
+import {
+  CreateFinanceContactLogDto,
+  UpdateFinanceContactLogDto,
+} from './dto/finance-receivable-contact-log.dto';
+
+@ApiTags('Finance Contact Logs')
+@ApiBearerAuth('JWT')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller()
+export class FinanceReceivableContactLogsController {
+  constructor(private readonly service: FinanceReceivableContactLogsService) {}
+
+  @Get('finance-receivable/:receivableId/contact-logs')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  list(@Param('receivableId') receivableId: string) {
+    return this.service.list(receivableId);
+  }
+
+  @Post('finance-receivable/:receivableId/contact-logs')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  record(
+    @Param('receivableId') receivableId: string,
+    @Body() dto: CreateFinanceContactLogDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.service.record(receivableId, req.user.id, dto);
+  }
+
+  @Patch('finance-receivable/:receivableId/contact-logs/:logId')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  update(
+    @Param('receivableId') receivableId: string,
+    @Param('logId') logId: string,
+    @Body() dto: UpdateFinanceContactLogDto,
+    @Request() req: { user: { id: string; role: string } },
+  ) {
+    return this.service.update(receivableId, logId, req.user.id, req.user.role, dto);
+  }
+
+  @Delete('finance-receivable/:receivableId/contact-logs/:logId')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  remove(
+    @Param('receivableId') receivableId: string,
+    @Param('logId') logId: string,
+  ) {
+    return this.service.softDelete(receivableId, logId);
+  }
+
+  @Get('external-finance/companies/:companyId/contact-summary')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  summary(@Param('companyId') companyId: string) {
+    return this.service.companyContactSummary(companyId);
+  }
+
+  @Get('external-finance/companies/:companyId/contact-logs')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  companyLogs(
+    @Param('companyId') companyId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.service.companyContactLogs(
+      companyId,
+      page ? parseInt(page, 10) : 1,
+      limit ? parseInt(limit, 10) : 20,
+    );
+  }
+}

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { FinanceReceivableContactLogsController } from './finance-receivable-contact-logs.controller';
 import { FinanceReceivableContactLogsService } from './finance-receivable-contact-logs.service';
+import { BrokenPromiseFinanceCron } from './crons/broken-promise-finance.cron';
 
 @Module({
   controllers: [FinanceReceivableContactLogsController],
-  providers: [FinanceReceivableContactLogsService],
+  providers: [FinanceReceivableContactLogsService, BrokenPromiseFinanceCron],
   exports: [FinanceReceivableContactLogsService],
 })
 export class FinanceReceivableContactLogsModule {}

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { FinanceReceivableContactLogsController } from './finance-receivable-contact-logs.controller';
+import { FinanceReceivableContactLogsService } from './finance-receivable-contact-logs.service';
+
+@Module({
+  controllers: [FinanceReceivableContactLogsController],
+  providers: [FinanceReceivableContactLogsService],
+  exports: [FinanceReceivableContactLogsService],
+})
+export class FinanceReceivableContactLogsModule {}

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts
@@ -18,6 +18,8 @@ describe('FinanceReceivableContactLogsService — record', () => {
       },
       externalFinanceCompany: {
         upsert: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        create: jest.fn().mockResolvedValue({ id: 'co-new' }),
       },
       financeReceivableContactLog: {
         create: jest.fn(),
@@ -52,7 +54,8 @@ describe('FinanceReceivableContactLogsService — record', () => {
       contactAttemptCount: 0,
       lastPromisedDate: null,
     });
-    prisma.externalFinanceCompany.upsert.mockResolvedValue({ id: 'co-new' });
+    prisma.externalFinanceCompany.findMany.mockResolvedValue([]);
+    prisma.externalFinanceCompany.create.mockResolvedValue({ id: 'co-new' });
     prisma.financeReceivableContactLog.create.mockResolvedValue({ id: 'log-1' });
     prisma.financeReceivable.update.mockResolvedValue({});
 
@@ -60,7 +63,7 @@ describe('FinanceReceivableContactLogsService — record', () => {
       result: FinanceContactResult.ANSWERED,
     });
 
-    expect(prisma.externalFinanceCompany.upsert).toHaveBeenCalled();
+    expect(prisma.externalFinanceCompany.create).toHaveBeenCalled();
     const created = prisma.financeReceivableContactLog.create.mock.calls[0][0].data;
     expect(created.externalFinanceCompanyId).toBe('co-new');
   });

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts
@@ -1,0 +1,113 @@
+// finance-receivable-contact-logs.service.spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { FinanceReceivableContactLogsService } from './finance-receivable-contact-logs.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { FinanceContactResult, FinanceContactChannel } from '@prisma/client';
+
+describe('FinanceReceivableContactLogsService — record', () => {
+  let service: FinanceReceivableContactLogsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      financeReceivable: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      externalFinanceCompany: {
+        upsert: jest.fn(),
+      },
+      financeReceivableContactLog: {
+        create: jest.fn(),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        FinanceReceivableContactLogsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = mod.get(FinanceReceivableContactLogsService);
+  });
+
+  it('throws NotFound when receivable does not exist', async () => {
+    prisma.financeReceivable.findFirst.mockResolvedValue(null);
+    await expect(
+      service.record('rec-1', 'user-1', {
+        result: FinanceContactResult.ANSWERED,
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('lazy-upserts ExternalFinanceCompany when FK is null', async () => {
+    prisma.financeReceivable.findFirst.mockResolvedValue({
+      id: 'rec-1',
+      externalFinanceCompanyId: null,
+      financeCompany: 'KTC Finance',
+      contactAttemptCount: 0,
+      lastPromisedDate: null,
+    });
+    prisma.externalFinanceCompany.upsert.mockResolvedValue({ id: 'co-new' });
+    prisma.financeReceivableContactLog.create.mockResolvedValue({ id: 'log-1' });
+    prisma.financeReceivable.update.mockResolvedValue({});
+
+    await service.record('rec-1', 'user-1', {
+      result: FinanceContactResult.ANSWERED,
+    });
+
+    expect(prisma.externalFinanceCompany.upsert).toHaveBeenCalled();
+    const created = prisma.financeReceivableContactLog.create.mock.calls[0][0].data;
+    expect(created.externalFinanceCompanyId).toBe('co-new');
+  });
+
+  it('updates KPI denorm: lastContactedAt + contactAttemptCount + lastPromisedDate when PROMISED', async () => {
+    prisma.financeReceivable.findFirst.mockResolvedValue({
+      id: 'rec-1',
+      externalFinanceCompanyId: 'co-1',
+      financeCompany: 'KTC',
+      contactAttemptCount: 2,
+      lastPromisedDate: null,
+    });
+    prisma.financeReceivableContactLog.create.mockResolvedValue({ id: 'log-1' });
+    prisma.financeReceivable.update.mockResolvedValue({});
+
+    await service.record('rec-1', 'user-1', {
+      result: FinanceContactResult.PROMISED,
+      promisedDate: '2026-06-15',
+      promisedAmount: 12000,
+    });
+
+    const updateArg = prisma.financeReceivable.update.mock.calls[0][0];
+    expect(updateArg.where.id).toBe('rec-1');
+    expect(updateArg.data.contactAttemptCount).toBe(3);
+    expect(updateArg.data.lastContactedAt).toBeInstanceOf(Date);
+    expect(updateArg.data.lastPromisedDate).toBeInstanceOf(Date);
+  });
+
+  it('does not overwrite lastPromisedDate when result is not PROMISED', async () => {
+    const existing = new Date('2026-06-01');
+    prisma.financeReceivable.findFirst.mockResolvedValue({
+      id: 'rec-1',
+      externalFinanceCompanyId: 'co-1',
+      financeCompany: 'KTC',
+      contactAttemptCount: 1,
+      lastPromisedDate: existing,
+    });
+    prisma.financeReceivableContactLog.create.mockResolvedValue({ id: 'log-1' });
+
+    await service.record('rec-1', 'user-1', {
+      result: FinanceContactResult.NO_ANSWER,
+    });
+
+    const updateArg = prisma.financeReceivable.update.mock.calls[0][0];
+    expect(updateArg.data.lastPromisedDate).toEqual(existing);
+  });
+});
+
+// suppress unused import warning for FinanceContactChannel (used in DTO type)
+void FinanceContactChannel;

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts
@@ -111,3 +111,77 @@ describe('FinanceReceivableContactLogsService — record', () => {
 
 // suppress unused import warning for FinanceContactChannel (used in DTO type)
 void FinanceContactChannel;
+
+describe('FinanceReceivableContactLogsService — list/update/delete', () => {
+  let service: FinanceReceivableContactLogsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      financeReceivableContactLog: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+      financeReceivable: { findFirst: jest.fn(), update: jest.fn() },
+      externalFinanceCompany: { findFirst: jest.fn() },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        FinanceReceivableContactLogsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = mod.get(FinanceReceivableContactLogsService);
+  });
+
+  it('list returns logs ordered newest first with contact + user joined', async () => {
+    prisma.financeReceivableContactLog.findMany.mockResolvedValue([]);
+    await service.list('rec-1');
+    const arg = prisma.financeReceivableContactLog.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ financeReceivableId: 'rec-1', deletedAt: null });
+    expect(arg.orderBy).toEqual({ contactedAt: 'desc' });
+    expect(arg.include).toMatchObject({
+      contact: { select: expect.any(Object) },
+      contactedBy: { select: expect.any(Object) },
+    });
+  });
+
+  it('update rejects when user is not author + not OWNER/FINANCE_MANAGER', async () => {
+    prisma.financeReceivableContactLog.findFirst.mockResolvedValue({
+      id: 'log-1',
+      contactedById: 'other-user',
+      createdAt: new Date(),
+    });
+    await expect(
+      service.update('rec-1', 'log-1', 'user-1', 'ACCOUNTANT', { notes: 'x' }),
+    ).rejects.toThrow(/แก้ไขได้เฉพาะเจ้าของ/);
+  });
+
+  it('update rejects when own log but past 24h window', async () => {
+    const old = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    prisma.financeReceivableContactLog.findFirst.mockResolvedValue({
+      id: 'log-1',
+      contactedById: 'user-1',
+      createdAt: old,
+    });
+    await expect(
+      service.update('rec-1', 'log-1', 'user-1', 'ACCOUNTANT', { notes: 'x' }),
+    ).rejects.toThrow(/24/);
+  });
+
+  it('update allows OWNER any time', async () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    prisma.financeReceivableContactLog.findFirst.mockResolvedValue({
+      id: 'log-1',
+      contactedById: 'someone',
+      createdAt: old,
+    });
+    prisma.financeReceivableContactLog.update.mockResolvedValue({});
+    await expect(
+      service.update('rec-1', 'log-1', 'owner-1', 'OWNER', { notes: 'x' }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts
@@ -1,0 +1,109 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { FinanceContactResult } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  CreateFinanceContactLogDto,
+  UpdateFinanceContactLogDto,
+} from './dto/finance-receivable-contact-log.dto';
+import { normalizeFinanceCompanyName } from './finance-company-name-normalizer.util';
+
+@Injectable()
+export class FinanceReceivableContactLogsService {
+  constructor(private prisma: PrismaService) {}
+
+  async record(
+    receivableId: string,
+    userId: string,
+    dto: CreateFinanceContactLogDto,
+  ) {
+    const receivable = await this.prisma.financeReceivable.findFirst({
+      where: { id: receivableId, deletedAt: null },
+      select: {
+        id: true,
+        externalFinanceCompanyId: true,
+        financeCompany: true,
+        contactAttemptCount: true,
+        lastPromisedDate: true,
+      },
+    });
+    if (!receivable) throw new NotFoundException('ไม่พบรายการเงินรับจากไฟแนนซ์');
+
+    return this.prisma.$transaction(async (tx) => {
+      let companyId = receivable.externalFinanceCompanyId;
+
+      // D6: lazy resolve — upsert ExternalFinanceCompany if receivable has no FK yet
+      if (!companyId) {
+        const normalized = normalizeFinanceCompanyName(receivable.financeCompany);
+        const company = await tx.externalFinanceCompany.upsert({
+          where: { name: receivable.financeCompany },
+          create: {
+            name: receivable.financeCompany,
+            isActive: true,
+          },
+          update: {},
+        });
+        companyId = company.id;
+        await tx.financeReceivable.update({
+          where: { id: receivableId },
+          data: { externalFinanceCompanyId: companyId },
+        });
+        // suppress unused-var warning for `normalized` until backfill script reuses it
+        void normalized;
+      }
+
+      const contactedAt = dto.contactedAt ? new Date(dto.contactedAt) : new Date();
+      const log = await tx.financeReceivableContactLog.create({
+        data: {
+          financeReceivableId: receivableId,
+          externalFinanceCompanyId: companyId!,
+          financeCompanyContactId: dto.financeCompanyContactId,
+          contactedById: userId,
+          contactedAt,
+          channel: dto.channel ?? 'CALL',
+          result: dto.result,
+          notes: dto.notes,
+          promisedDate: dto.promisedDate ? new Date(dto.promisedDate) : null,
+          promisedAmount: dto.promisedAmount ?? null,
+        },
+      });
+
+      // KPI denorm update — compute literal nextCount so tests can assert numeric value
+      const nextLastPromised =
+        dto.result === FinanceContactResult.PROMISED && dto.promisedDate
+          ? new Date(dto.promisedDate)
+          : receivable.lastPromisedDate;
+
+      await tx.financeReceivable.update({
+        where: { id: receivableId },
+        data: {
+          lastContactedAt: contactedAt,
+          lastPromisedDate: nextLastPromised,
+          contactAttemptCount: (receivable.contactAttemptCount ?? 0) + 1,
+        },
+      });
+
+      return log;
+    });
+  }
+
+  // stubs — implemented in Task 9
+  async list(_receivableId: string) {
+    return [];
+  }
+  async update(
+    _receivableId: string,
+    _logId: string,
+    _userId: string,
+    _userRole: string,
+    _dto: UpdateFinanceContactLogDto,
+  ) {
+    throw new ForbiddenException('Not implemented');
+  }
+  async softDelete(_receivableId: string, _logId: string) {
+    throw new ForbiddenException('Not implemented');
+  }
+}

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts
@@ -35,24 +35,24 @@ export class FinanceReceivableContactLogsService {
     return this.prisma.$transaction(async (tx) => {
       let companyId = receivable.externalFinanceCompanyId;
 
-      // D6: lazy resolve — upsert ExternalFinanceCompany if receivable has no FK yet
+      // D6: lazy resolve — match by normalized name to avoid duplicates from case/whitespace drift
       if (!companyId) {
         const normalized = normalizeFinanceCompanyName(receivable.financeCompany);
-        const company = await tx.externalFinanceCompany.upsert({
-          where: { name: receivable.financeCompany },
-          create: {
-            name: receivable.financeCompany,
-            isActive: true,
-          },
-          update: {},
+        const all = await tx.externalFinanceCompany.findMany({
+          where: { deletedAt: null },
+          select: { id: true, name: true },
         });
+        const match = all.find((c) => normalizeFinanceCompanyName(c.name) === normalized);
+        const company =
+          match ??
+          (await tx.externalFinanceCompany.create({
+            data: { name: receivable.financeCompany, isActive: true },
+          }));
         companyId = company.id;
         await tx.financeReceivable.update({
           where: { id: receivableId },
           data: { externalFinanceCompanyId: companyId },
         });
-        // suppress unused-var warning for `normalized` until backfill script reuses it
-        void normalized;
       }
 
       const contactedAt = dto.contactedAt ? new Date(dto.contactedAt) : new Date();

--- a/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts
+++ b/apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts
@@ -90,20 +90,149 @@ export class FinanceReceivableContactLogsService {
     });
   }
 
-  // stubs — implemented in Task 9
-  async list(_receivableId: string) {
-    return [];
+  async list(receivableId: string) {
+    return this.prisma.financeReceivableContactLog.findMany({
+      where: { financeReceivableId: receivableId, deletedAt: null },
+      orderBy: { contactedAt: 'desc' },
+      include: {
+        contact: { select: { id: true, name: true, position: true, phone: true } },
+        contactedBy: { select: { id: true, name: true } },
+      },
+    });
   }
+
   async update(
-    _receivableId: string,
-    _logId: string,
-    _userId: string,
-    _userRole: string,
-    _dto: UpdateFinanceContactLogDto,
+    receivableId: string,
+    logId: string,
+    userId: string,
+    userRole: string,
+    dto: UpdateFinanceContactLogDto,
   ) {
-    throw new ForbiddenException('Not implemented');
+    const log = await this.prisma.financeReceivableContactLog.findFirst({
+      where: { id: logId, financeReceivableId: receivableId, deletedAt: null },
+    });
+    if (!log) throw new NotFoundException('ไม่พบบันทึกการติดต่อ');
+
+    const isPrivileged = userRole === 'OWNER' || userRole === 'FINANCE_MANAGER';
+    if (!isPrivileged) {
+      if (log.contactedById !== userId) {
+        throw new ForbiddenException('แก้ไขได้เฉพาะเจ้าของ log');
+      }
+      const ageMs = Date.now() - new Date(log.createdAt).getTime();
+      if (ageMs > 24 * 60 * 60 * 1000) {
+        throw new ForbiddenException('เกิน 24 ชั่วโมง ไม่สามารถแก้ไขได้');
+      }
+    }
+
+    return this.prisma.financeReceivableContactLog.update({
+      where: { id: logId },
+      data: {
+        notes: dto.notes,
+        result: dto.result,
+        channel: dto.channel,
+        financeCompanyContactId: dto.financeCompanyContactId,
+        promisedDate: dto.promisedDate ? new Date(dto.promisedDate) : undefined,
+        promisedAmount: dto.promisedAmount,
+        contactedAt: dto.contactedAt ? new Date(dto.contactedAt) : undefined,
+      },
+    });
   }
-  async softDelete(_receivableId: string, _logId: string) {
-    throw new ForbiddenException('Not implemented');
+
+  async softDelete(receivableId: string, logId: string) {
+    const log = await this.prisma.financeReceivableContactLog.findFirst({
+      where: { id: logId, financeReceivableId: receivableId, deletedAt: null },
+    });
+    if (!log) throw new NotFoundException('ไม่พบบันทึกการติดต่อ');
+
+    await this.prisma.financeReceivableContactLog.update({
+      where: { id: logId },
+      data: { deletedAt: new Date() },
+    });
+
+    // Recompute KPI from remaining logs
+    const remaining = await this.prisma.financeReceivableContactLog.findMany({
+      where: { financeReceivableId: receivableId, deletedAt: null },
+      orderBy: { contactedAt: 'desc' },
+      take: 100,
+    });
+    const lastContactedAt = remaining[0]?.contactedAt ?? null;
+    const lastPromised = remaining.find(
+      (l) => l.result === 'PROMISED' && l.promisedDate,
+    );
+    await this.prisma.financeReceivable.update({
+      where: { id: receivableId },
+      data: {
+        lastContactedAt,
+        lastPromisedDate: lastPromised?.promisedDate ?? null,
+        contactAttemptCount: remaining.length,
+      },
+    });
+    return { ok: true };
+  }
+
+  async companyContactSummary(companyId: string) {
+    const [receivableCount, totalOutstandingAgg, lastLog, brokenCount, keptCount] =
+      await Promise.all([
+        this.prisma.financeReceivable.count({
+          where: { externalFinanceCompanyId: companyId, deletedAt: null },
+        }),
+        this.prisma.financeReceivable.aggregate({
+          where: {
+            externalFinanceCompanyId: companyId,
+            deletedAt: null,
+            status: { in: ['PENDING', 'OVERDUE', 'DISPUTED', 'PARTIALLY_RECEIVED'] },
+          },
+          _sum: { netExpectedAmount: true, receivedAmount: true },
+        }),
+        this.prisma.financeReceivableContactLog.findFirst({
+          where: { externalFinanceCompanyId: companyId, deletedAt: null },
+          orderBy: { contactedAt: 'desc' },
+          select: { contactedAt: true },
+        }),
+        this.prisma.financeReceivableContactLog.count({
+          where: {
+            externalFinanceCompanyId: companyId,
+            deletedAt: null,
+            promisedBrokenAt: { not: null },
+          },
+        }),
+        this.prisma.financeReceivableContactLog.count({
+          where: {
+            externalFinanceCompanyId: companyId,
+            deletedAt: null,
+            promisedKeptAt: { not: null },
+          },
+        }),
+      ]);
+
+    return {
+      receivableCount,
+      totalOutstanding: totalOutstandingAgg._sum.netExpectedAmount ?? 0,
+      lastContactedAt: lastLog?.contactedAt ?? null,
+      brokenPromiseCount: brokenCount,
+      keptPromiseCount: keptCount,
+    };
+  }
+
+  async companyContactLogs(companyId: string, page = 1, limit = 20) {
+    const safeLimit = Math.min(100, Math.max(1, limit));
+    const safePage = Math.max(1, page);
+    const [data, total] = await Promise.all([
+      this.prisma.financeReceivableContactLog.findMany({
+        where: { externalFinanceCompanyId: companyId, deletedAt: null },
+        orderBy: { contactedAt: 'desc' },
+        include: {
+          receivable: { select: { id: true, financeRefNumber: true, expectedAmount: true } },
+          contact: { select: { id: true, name: true, position: true } },
+          contactedBy: { select: { id: true, name: true } },
+        },
+        skip: (safePage - 1) * safeLimit,
+        take: safeLimit,
+      }),
+      this.prisma.financeReceivableContactLog.count({
+        where: { externalFinanceCompanyId: companyId, deletedAt: null },
+      }),
+    ]);
+    return { data, total, page: safePage, limit: safeLimit };
   }
 }

--- a/apps/api/src/modules/finance-receivable/finance-receivable.controller.ts
+++ b/apps/api/src/modules/finance-receivable/finance-receivable.controller.ts
@@ -37,6 +37,8 @@ export class FinanceReceivableController {
     @Query('endDate') endDate?: string,
     @Query('page') page?: string,
     @Query('limit') limit?: string,
+    @Query('externalFinanceCompanyId') externalFinanceCompanyId?: string,
+    @Query('brokenPromiseOnly') brokenPromiseOnly?: string,
     @Request() req?: { user: { role: string; branchId?: string } },
   ) {
     const effectiveBranchId = hasCrossBranchAccess(req?.user)
@@ -52,6 +54,8 @@ export class FinanceReceivableController {
       endDate,
       page: page ? parseInt(page) : 1,
       limit: limit ? parseInt(limit) : 20,
+      externalFinanceCompanyId,
+      brokenPromiseOnly: brokenPromiseOnly === 'true',
     });
   }
 

--- a/apps/api/src/modules/finance-receivable/finance-receivable.service.spec.ts
+++ b/apps/api/src/modules/finance-receivable/finance-receivable.service.spec.ts
@@ -17,6 +17,10 @@ describe('FinanceReceivableService', () => {
         update: jest.fn(),
         count: jest.fn(),
       },
+      financeReceivableContactLog: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -302,6 +306,42 @@ describe('FinanceReceivableService', () => {
       const arg = prisma.financeReceivable.findMany.mock.calls[0][0];
       expect(arg.distinct).toEqual(['financeCompany']);
       expect(arg.where.deletedAt).toBeNull();
+    });
+  });
+
+  describe('recordReceive — promisedKeptAt hook', () => {
+    it('marks open PROMISED logs as kept when payment is received on/before promised date', async () => {
+      const today = new Date('2026-05-31');
+      prisma.financeReceivable.findFirst.mockResolvedValue({
+        id: 'rec-1',
+        status: 'PENDING',
+        netExpectedAmount: 10000,
+        receivedAmount: 0,
+        deletedAt: null,
+      });
+      prisma.financeReceivable.update.mockResolvedValue({ id: 'rec-1' });
+      prisma.financeReceivableContactLog = {
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      };
+      prisma.$transaction = jest.fn().mockImplementation(async (fn) => fn(prisma));
+
+      await service.recordReceive(
+        'rec-1',
+        { receivedAmount: 10000, receivedDate: today.toISOString() },
+        'user-1',
+      );
+
+      expect(prisma.financeReceivableContactLog.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            financeReceivableId: 'rec-1',
+            result: 'PROMISED',
+            promisedKeptAt: null,
+            promisedBrokenAt: null,
+            promisedDate: { gte: expect.any(Date) },
+          }),
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/modules/finance-receivable/finance-receivable.service.ts
+++ b/apps/api/src/modules/finance-receivable/finance-receivable.service.ts
@@ -104,24 +104,43 @@ export class FinanceReceivableService {
 
     const receivedAmount = new Prisma.Decimal(dto.receivedAmount);
     const netExpected = record.netExpectedAmount;
+    const receivedDate = new Date(dto.receivedDate);
 
     const status: FinanceReceivableStatus = receivedAmount.gte(netExpected) ? 'RECEIVED' : 'PARTIALLY_RECEIVED';
 
-    const updated = await this.prisma.financeReceivable.update({
-      where: { id },
-      data: {
-        receivedAmount,
-        receivedDate: new Date(dto.receivedDate),
-        bankRef: dto.bankRef,
-        note: dto.note ?? record.note,
-        status,
-        recordedById,
-      },
-      include: {
-        sale: { select: { saleNumber: true } },
-        branch: { select: { name: true } },
-      },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const result = await tx.financeReceivable.update({
+        where: { id },
+        data: {
+          receivedAmount,
+          receivedDate,
+          bankRef: dto.bankRef,
+          note: dto.note ?? record.note,
+          status,
+          recordedById,
+        },
+        include: {
+          sale: { select: { saleNumber: true } },
+          branch: { select: { name: true } },
+        },
+      });
+
+      // mark open PROMISED logs as kept if receivedDate <= promisedDate
+      await tx.financeReceivableContactLog.updateMany({
+        where: {
+          financeReceivableId: id,
+          deletedAt: null,
+          result: 'PROMISED',
+          promisedKeptAt: null,
+          promisedBrokenAt: null,
+          promisedDate: { gte: receivedDate },
+        },
+        data: { promisedKeptAt: receivedDate },
+      });
+
+      return result;
     });
+
     this.structuredLogger.log('financeReceivable.received', {
       financeReceivableId: id,
       financeCompany: record.financeCompany,

--- a/apps/api/src/modules/finance-receivable/finance-receivable.service.ts
+++ b/apps/api/src/modules/finance-receivable/finance-receivable.service.ts
@@ -22,8 +22,10 @@ export class FinanceReceivableService {
     endDate?: string;
     page?: number;
     limit?: number;
+    externalFinanceCompanyId?: string;
+    brokenPromiseOnly?: boolean;
   }) {
-    const { status, financeCompany, branchId, search, startDate, endDate, page = 1, limit = 20 } = filters;
+    const { status, financeCompany, branchId, search, startDate, endDate, page = 1, limit = 20, externalFinanceCompanyId, brokenPromiseOnly } = filters;
     const safePage = Math.max(1, page);
     const safeLimit = Math.min(100, Math.max(1, limit));
 
@@ -31,6 +33,7 @@ export class FinanceReceivableService {
     if (status) where.status = status;
     if (financeCompany) where.financeCompany = financeCompany;
     if (branchId) where.branchId = branchId;
+    if (externalFinanceCompanyId) where.externalFinanceCompanyId = externalFinanceCompanyId;
     if (startDate || endDate) {
       where.expectedDate = {};
       if (startDate) where.expectedDate.gte = new Date(startDate);
@@ -39,6 +42,15 @@ export class FinanceReceivableService {
         end.setHours(23, 59, 59, 999);
         where.expectedDate.lte = end;
       }
+    }
+    if (brokenPromiseOnly) {
+      where.contactLogs = {
+        some: {
+          promisedBrokenAt: { not: null },
+          promisedKeptAt: null,
+          deletedAt: null,
+        },
+      };
     }
     if (search) {
       where.OR = [

--- a/apps/api/src/modules/sales/sales.service.spec.ts
+++ b/apps/api/src/modules/sales/sales.service.spec.ts
@@ -186,6 +186,9 @@ describe('SalesService', () => {
       financeReceivable: {
         create: jest.fn().mockResolvedValue({}),
       },
+      externalFinanceCompany: {
+        upsert: jest.fn().mockResolvedValue({ id: 'mock-co' }),
+      },
       user: {
         findMany: jest.fn().mockResolvedValue([{ id: 'user-1', name: 'พนักงาน 1' }]),
       },

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -24,6 +24,18 @@ export class SalesService {
     private interCompanyService: InterCompanyService,
   ) {}
 
+  private async resolveExternalFinanceCompanyId(
+    tx: Prisma.TransactionClient,
+    name: string,
+  ): Promise<string> {
+    const company = await tx.externalFinanceCompany.upsert({
+      where: { name },
+      create: { name, isActive: true },
+      update: {},
+    });
+    return company.id;
+  }
+
   async findAll(filters: {
     saleType?: string;
     branchId?: string;
@@ -623,11 +635,13 @@ export class SalesService {
       // ── Finance Receivable for BESTCHOICE FINANCE (internal) ──
       const expectedDate = new Date();
       expectedDate.setDate(expectedDate.getDate() + 1); // Internal: expect next day
+      const bcFinanceId = await this.resolveExternalFinanceCompanyId(tx, 'BESTCHOICE FINANCE');
       await tx.financeReceivable.create({
         data: {
           saleId: sale.id,
           branchId: dto.branchId,
           financeCompany: 'BESTCHOICE FINANCE',
+          externalFinanceCompanyId: bcFinanceId,
           expectedAmount: calc.principal + calc.storeCommission,
           commissionRate: params.storeCommissionPct,
           commissionAmount: calc.storeCommission,
@@ -712,11 +726,13 @@ export class SalesService {
       // Auto-create FinanceReceivable to track money from finance company
       const expectedDate = new Date();
       expectedDate.setDate(expectedDate.getDate() + 7); // Default: expect within 7 days
+      const extFinanceId = await this.resolveExternalFinanceCompanyId(tx, dto.financeCompany!);
       await tx.financeReceivable.create({
         data: {
           saleId: sale.id,
           branchId: dto.branchId,
           financeCompany: dto.financeCompany!,
+          externalFinanceCompanyId: extFinanceId,
           financeRefNumber: dto.contractNumber || dto.financeRefNumber || null,
           expectedAmount: financeAmount,
           netExpectedAmount: financeAmount, // Commission can be updated later

--- a/apps/web/e2e/finance-receivable-contact.spec.ts
+++ b/apps/web/e2e/finance-receivable-contact.spec.ts
@@ -1,0 +1,93 @@
+// apps/web/e2e/finance-receivable-contact.spec.ts
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/auth';
+
+test.describe('Finance Receivable contact log', () => {
+  test.beforeEach(async ({ page }) => {
+    // Login as FINANCE_MANAGER (finance@bestchoice.com / admin1234)
+    await loginAsRole(page, 'FINANCE_MANAGER');
+  });
+
+  test('record a contact log and see it in timeline + last contacted column', async ({ page }) => {
+    await page.goto('/finance-receivable');
+    // Wait for the table to render (page uses Tabs; "ไฟแนนซ์ภายนอก" tab is active by default)
+    await page.waitForSelector('table', { timeout: 15000 });
+
+    // Wait briefly for query to resolve (avoid counting rows before data arrives)
+    await page.waitForTimeout(2000);
+
+    // DataTable always renders a <tbody tr> even when empty (shows EmptyState inside it).
+    // A real data row has a <button> inside the first cell ("รายการขาย" column).
+    // Skip if no real rows exist in dev DB.
+    const firstRowButton = page.locator('tbody tr').first().locator('button').first();
+    const hasData = await firstRowButton.isVisible({ timeout: 3000 }).catch(() => false);
+    if (!hasData) {
+      test.skip(true, 'No external-finance receivables seeded in dev DB');
+      return;
+    }
+
+    // Click the button inside the first column cell of the first row to open the drawer.
+    // The "รายการขาย" cell renders a <button onClick={() => setSelectedReceivable(r)}>
+    await firstRowButton.click();
+
+    // Drawer (Sheet) should open and show the section heading
+    await expect(page.getByText('ประวัติการติดต่อ')).toBeVisible({ timeout: 10000 });
+
+    // The drawer only shows the "บันทึกการติดต่อ" button when externalFinanceCompanyId is set.
+    // If it's absent, the button still renders but the dialog won't open — skip gracefully.
+    const logBtn = page.getByRole('button', { name: /บันทึกการติดต่อ/ });
+    const btnVisible = await logBtn.isVisible({ timeout: 5000 }).catch(() => false);
+    if (!btnVisible) {
+      test.skip(true, 'บันทึกการติดต่อ button not found — row may lack externalFinanceCompanyId');
+      return;
+    }
+    await logBtn.click();
+
+    // Dialog opens: title "บันทึกการติดต่อไฟแนนซ์"
+    await expect(page.getByText('บันทึกการติดต่อไฟแนนซ์')).toBeVisible({ timeout: 8000 });
+
+    // Pick result = ANSWERED by clicking the pill button labelled "รับสาย"
+    // (These are <button> elements rendered as pill chips, not radio inputs)
+    await page.locator('button', { hasText: 'รับสาย' }).first().click();
+
+    // Add note in the textarea
+    await page.getByPlaceholder('รายละเอียดการคุย…').fill('E2E test note');
+
+    // Submit — the save button has text "บันทึก" (exact, to avoid matching "บันทึกการติดต่อ")
+    await page.locator('button', { hasText: /^บันทึก$/ }).last().click();
+
+    // Sonner toast should appear
+    await expect(page.getByText('บันทึกการติดต่อสำเร็จ')).toBeVisible({ timeout: 10000 });
+
+    // Timeline should now show the new entry's note
+    await expect(page.getByText('E2E test note')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('broken-promise filter limits the list', async ({ page }) => {
+    await page.goto('/finance-receivable');
+    await page.waitForSelector('table', { timeout: 15000 });
+
+    // Wait briefly for query to resolve before checking data
+    await page.waitForTimeout(2000);
+
+    // Check if any real data rows exist (DataTable always renders 1 tr for EmptyState
+    // when data=[]; a real row has a button inside the first cell)
+    const hasData = await page.locator('tbody tr').first().locator('button').first()
+      .isVisible({ timeout: 3000 }).catch(() => false);
+    if (!hasData) {
+      test.skip(true, 'No external-finance receivables seeded in dev DB');
+      return;
+    }
+
+    const initialCount = await page.locator('tbody tr').count();
+
+    // The "มีนัดเลยกำหนด" filter is a plain <input type="checkbox"> inside a <label>.
+    // Locate it via the surrounding label text.
+    const checkbox = page.locator('label', { hasText: 'มีนัดเลยกำหนด' }).locator('input[type="checkbox"]');
+    await checkbox.check();
+    await page.waitForLoadState('networkidle');
+
+    const filteredCount = await page.locator('tbody tr').count();
+    expect(filteredCount).toBeLessThanOrEqual(initialCount);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -107,6 +107,9 @@ const LiffNotificationSettings = lazy(() => import('@/pages/liff/LiffNotificatio
 const LineOaSettingsPage = lazy(() => import('@/pages/LineOaSettingsPage'));
 const FinanceReceivablePage = lazy(() => import('@/pages/FinanceReceivablePage'));
 const FinancePortfolioPage = lazy(() => import('@/pages/FinancePortfolioPage'));
+const ExternalFinanceCompanyDetailPage = lazy(
+  () => import('@/pages/ExternalFinanceCompanyDetailPage'),
+);
 const ExpensesPage = lazy(() => import('@/pages/ExpensesPage'));
 const APAgingPage = lazy(() => import('@/pages/APAgingPage'));
 const PaymentVoucherPage = lazy(() => import('@/pages/PaymentVoucherPage'));
@@ -519,6 +522,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <FinancePortfolioPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/external-finance-companies/:id"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ExternalFinanceCompanyDetailPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/lib/api/finance-contacts.ts
+++ b/apps/web/src/lib/api/finance-contacts.ts
@@ -1,0 +1,82 @@
+import api from '@/lib/api';
+
+export interface FinanceCompanyContact {
+  id: string;
+  name: string;
+  position: string | null;
+  department: string | null;
+  phone: string | null;
+  email: string | null;
+  lineId: string | null;
+  notes: string | null;
+  isPrimary: boolean;
+  isActive: boolean;
+}
+
+export interface FinanceContactLog {
+  id: string;
+  contactedAt: string;
+  channel: 'CALL' | 'EMAIL' | 'LINE' | 'MEETING' | 'OTHER';
+  result: 'ANSWERED' | 'NO_ANSWER' | 'PROMISED' | 'DISPUTED' | 'REQUESTED_DOCS' | 'OTHER';
+  notes: string | null;
+  promisedDate: string | null;
+  promisedAmount: string | null;
+  promisedBrokenAt: string | null;
+  promisedKeptAt: string | null;
+  contact: { id: string; name: string; position: string | null; phone: string | null } | null;
+  contactedBy: { id: string; name: string };
+}
+
+export interface CompanyContactSummary {
+  receivableCount: number;
+  totalOutstanding: number;
+  lastContactedAt: string | null;
+  brokenPromiseCount: number;
+  keptPromiseCount: number;
+}
+
+export const financeContactKeys = {
+  all: ['finance-contacts'] as const,
+  companyContacts: (companyId: string) =>
+    [...financeContactKeys.all, 'company', companyId, 'contacts'] as const,
+  receivableLogs: (receivableId: string) =>
+    [...financeContactKeys.all, 'receivable', receivableId, 'logs'] as const,
+  companySummary: (companyId: string) =>
+    [...financeContactKeys.all, 'company', companyId, 'summary'] as const,
+  companyLogs: (companyId: string, page: number) =>
+    [...financeContactKeys.all, 'company', companyId, 'logs', page] as const,
+};
+
+export const financeContactApi = {
+  listContacts: (companyId: string) =>
+    api.get<FinanceCompanyContact[]>(`/external-finance/companies/${companyId}/contacts`).then((r) => r.data),
+  createContact: (companyId: string, payload: Partial<FinanceCompanyContact>) =>
+    api.post(`/external-finance/companies/${companyId}/contacts`, payload).then((r) => r.data),
+  updateContact: (companyId: string, contactId: string, payload: Partial<FinanceCompanyContact>) =>
+    api.patch(`/external-finance/companies/${companyId}/contacts/${contactId}`, payload).then((r) => r.data),
+  deleteContact: (companyId: string, contactId: string) =>
+    api.delete(`/external-finance/companies/${companyId}/contacts/${contactId}`).then((r) => r.data),
+  setPrimary: (companyId: string, contactId: string) =>
+    api.post(`/external-finance/companies/${companyId}/contacts/${contactId}/set-primary`).then((r) => r.data),
+
+  listLogs: (receivableId: string) =>
+    api.get<FinanceContactLog[]>(`/finance-receivable/${receivableId}/contact-logs`).then((r) => r.data),
+  recordLog: (
+    receivableId: string,
+    payload: {
+      financeCompanyContactId?: string;
+      result: FinanceContactLog['result'];
+      channel?: FinanceContactLog['channel'];
+      notes?: string;
+      promisedDate?: string;
+      promisedAmount?: number;
+    },
+  ) => api.post(`/finance-receivable/${receivableId}/contact-logs`, payload).then((r) => r.data),
+
+  companySummary: (companyId: string) =>
+    api.get<CompanyContactSummary>(`/external-finance/companies/${companyId}/contact-summary`).then((r) => r.data),
+  companyLogs: (companyId: string, page = 1, limit = 20) =>
+    api
+      .get(`/external-finance/companies/${companyId}/contact-logs`, { params: { page, limit } })
+      .then((r) => r.data),
+};

--- a/apps/web/src/pages/ExternalFinanceCompanyDetailPage.tsx
+++ b/apps/web/src/pages/ExternalFinanceCompanyDetailPage.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react';
+import { useParams } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import PageHeader from '@/components/ui/PageHeader';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  financeContactApi,
+  financeContactKeys,
+  FinanceCompanyContact,
+} from '@/lib/api/finance-contacts';
+import { formatDateShortThai } from '@/utils/formatters';
+import QueryBoundary from '@/components/QueryBoundary';
+
+interface CompanyMaster {
+  id: string;
+  name: string;
+  taxId: string | null;
+  email: string | null;
+  lineOaId: string | null;
+  creditTermDays: number | null;
+  defaultCommissionRate: string | null;
+  notes: string | null;
+}
+
+export default function ExternalFinanceCompanyDetailPage() {
+  const { id = '' } = useParams<{ id: string }>();
+  const company = useQuery({
+    queryKey: ['external-finance-company', id],
+    queryFn: () => api.get<CompanyMaster>(`/external-finance/companies/${id}`).then((r) => r.data),
+  });
+  const summary = useQuery({
+    queryKey: financeContactKeys.companySummary(id),
+    queryFn: () => financeContactApi.companySummary(id),
+  });
+
+  return (
+    <div className="space-y-4">
+      <QueryBoundary
+        isLoading={company.isLoading}
+        isError={company.isError}
+        error={company.error}
+        onRetry={company.refetch}
+      >
+        <PageHeader
+          title={company.data?.name ?? '...'}
+          subtitle={company.data?.taxId ? `เลขผู้เสียภาษี: ${company.data.taxId}` : undefined}
+        />
+        <Card>
+          <CardContent className="grid grid-cols-4 gap-4 pt-6">
+            <Kpi label="บัญชีค้างรับ" value={summary.data?.receivableCount ?? 0} />
+            <Kpi
+              label="ยอดค้างรวม"
+              value={Number(summary.data?.totalOutstanding ?? 0).toLocaleString('th-TH', {
+                minimumFractionDigits: 2,
+              })}
+            />
+            <Kpi
+              label="ติดต่อล่าสุด"
+              value={
+                summary.data?.lastContactedAt
+                  ? formatDateShortThai(summary.data.lastContactedAt)
+                  : '—'
+              }
+            />
+            <Kpi
+              label="ผิดนัด / นัดสำเร็จ"
+              value={`${summary.data?.brokenPromiseCount ?? 0} / ${summary.data?.keptPromiseCount ?? 0}`}
+            />
+          </CardContent>
+        </Card>
+
+        <Tabs defaultValue="info">
+          <TabsList>
+            <TabsTrigger value="info">ข้อมูลกิจการ</TabsTrigger>
+            <TabsTrigger value="contacts">ผู้ติดต่อ</TabsTrigger>
+            <TabsTrigger value="receivables">บัญชีค้างรับ</TabsTrigger>
+            <TabsTrigger value="logs">ประวัติติดต่อ</TabsTrigger>
+          </TabsList>
+          <TabsContent value="info">
+            <CompanyInfoTab company={company.data} />
+          </TabsContent>
+          <TabsContent value="contacts">
+            <ContactsTab companyId={id} />
+          </TabsContent>
+          <TabsContent value="receivables">
+            <ReceivablesTab companyId={id} />
+          </TabsContent>
+          <TabsContent value="logs">
+            <AllContactLogsTab companyId={id} />
+          </TabsContent>
+        </Tabs>
+      </QueryBoundary>
+    </div>
+  );
+}
+
+function Kpi({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <div className="text-sm text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function CompanyInfoTab({ company }: { company: CompanyMaster | undefined }) {
+  if (!company) return null;
+  return (
+    <Card>
+      <CardContent className="pt-6 grid grid-cols-2 gap-4 text-sm">
+        <Field label="ชื่อบริษัท" value={company.name} />
+        <Field label="เลขผู้เสียภาษี" value={company.taxId} />
+        <Field label="อีเมล" value={company.email} />
+        <Field label="LINE OA" value={company.lineOaId} />
+        <Field
+          label="เครดิตเทอม"
+          value={company.creditTermDays != null ? `${company.creditTermDays} วัน` : null}
+        />
+        <Field
+          label="คอมมิชชั่นปกติ"
+          value={
+            company.defaultCommissionRate
+              ? `${Number(company.defaultCommissionRate) * 100}%`
+              : null
+          }
+        />
+        <Field label="หมายเหตุ" value={company.notes} fullWidth />
+      </CardContent>
+    </Card>
+  );
+}
+
+function Field({
+  label,
+  value,
+  fullWidth,
+}: {
+  label: string;
+  value: string | null | undefined;
+  fullWidth?: boolean;
+}) {
+  return (
+    <div className={fullWidth ? 'col-span-2' : ''}>
+      <div className="text-muted-foreground">{label}</div>
+      <div className="font-medium">{value || '—'}</div>
+    </div>
+  );
+}
+
+function ContactsTab({ companyId }: { companyId: string }) {
+  const qc = useQueryClient();
+  const contacts = useQuery({
+    queryKey: financeContactKeys.companyContacts(companyId),
+    queryFn: () => financeContactApi.listContacts(companyId),
+  });
+
+  const setPrimary = useMutation({
+    mutationFn: (contactId: string) => financeContactApi.setPrimary(companyId, contactId),
+    onSuccess: () => {
+      toast.success('ตั้งผู้ติดต่อหลักสำเร็จ');
+      qc.invalidateQueries({ queryKey: financeContactKeys.companyContacts(companyId) });
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
+  const remove = useMutation({
+    mutationFn: (contactId: string) => financeContactApi.deleteContact(companyId, contactId),
+    onSuccess: () => {
+      toast.success('ลบผู้ติดต่อสำเร็จ');
+      qc.invalidateQueries({ queryKey: financeContactKeys.companyContacts(companyId) });
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
+  return (
+    <QueryBoundary
+      isLoading={contacts.isLoading}
+      isError={contacts.isError}
+      error={contacts.error}
+      onRetry={contacts.refetch}
+    >
+      <div className="space-y-2 mt-4">
+        {(contacts.data ?? []).map((c: FinanceCompanyContact) => (
+          <Card key={c.id}>
+            <CardContent className="flex items-center justify-between pt-6">
+              <div>
+                <div className="font-medium flex items-center gap-2">
+                  {c.name}
+                  {c.isPrimary && <Badge>ตัวหลัก</Badge>}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {c.position}
+                  {c.phone ? ` • ${c.phone}` : ''}
+                  {c.email ? ` • ${c.email}` : ''}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                {!c.isPrimary && (
+                  <Button size="sm" variant="outline" onClick={() => setPrimary.mutate(c.id)}>
+                    ตั้งเป็นหลัก
+                  </Button>
+                )}
+                <Button size="sm" variant="destructive" onClick={() => remove.mutate(c.id)}>
+                  ลบ
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+        {contacts.data?.length === 0 && (
+          <p className="text-sm text-muted-foreground py-6 text-center">ยังไม่มีผู้ติดต่อ</p>
+        )}
+      </div>
+    </QueryBoundary>
+  );
+}
+
+interface ReceivableRow {
+  id: string;
+  financeRefNumber: string | null;
+  status: string;
+  expectedDate: string;
+  expectedAmount: string;
+}
+
+function ReceivablesTab({ companyId }: { companyId: string }) {
+  const list = useQuery({
+    queryKey: ['finance-receivable-by-company', companyId],
+    queryFn: () =>
+      api
+        .get(`/finance-receivable?externalFinanceCompanyId=${companyId}&limit=50`)
+        .then((r) => r.data),
+  });
+  return (
+    <QueryBoundary
+      isLoading={list.isLoading}
+      isError={list.isError}
+      error={list.error}
+      onRetry={list.refetch}
+    >
+      <ol className="space-y-2 mt-4">
+        {(list.data?.data ?? []).map((r: ReceivableRow) => (
+          <li
+            key={r.id}
+            className="p-3 border border-border rounded-lg flex justify-between text-sm"
+          >
+            <span>{r.financeRefNumber ?? r.id.slice(0, 8)}</span>
+            <span>{r.status}</span>
+            <span>{formatDateShortThai(r.expectedDate)}</span>
+            <span>{Number(r.expectedAmount).toLocaleString('th-TH')}</span>
+          </li>
+        ))}
+      </ol>
+    </QueryBoundary>
+  );
+}
+
+interface ContactLogRow {
+  id: string;
+  contactedAt: string;
+  result: string;
+  notes: string | null;
+  contactedBy: { name: string };
+}
+
+function AllContactLogsTab({ companyId }: { companyId: string }) {
+  const [page, setPage] = useState(1);
+  const logs = useQuery({
+    queryKey: financeContactKeys.companyLogs(companyId, page),
+    queryFn: () => financeContactApi.companyLogs(companyId, page),
+  });
+  return (
+    <QueryBoundary
+      isLoading={logs.isLoading}
+      isError={logs.isError}
+      error={logs.error}
+      onRetry={logs.refetch}
+    >
+      <ol className="space-y-2 mt-4">
+        {(logs.data?.data ?? []).map((l: ContactLogRow) => (
+          <li key={l.id} className="p-3 border border-border rounded-lg text-sm">
+            <div className="flex gap-2">
+              <span className="font-medium">{l.contactedBy.name}</span>
+              <span className="text-muted-foreground">{formatDateShortThai(l.contactedAt)}</span>
+              <Badge variant="secondary">{l.result}</Badge>
+            </div>
+            {l.notes && <p className="mt-1 text-muted-foreground">{l.notes}</p>}
+          </li>
+        ))}
+      </ol>
+      <div className="flex justify-end gap-2 mt-3">
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={page === 1}
+          onClick={() => setPage(page - 1)}
+        >
+          ก่อนหน้า
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={(logs.data?.data?.length ?? 0) < 20}
+          onClick={() => setPage(page + 1)}
+        >
+          ถัดไป
+        </Button>
+      </div>
+    </QueryBoundary>
+  );
+}

--- a/apps/web/src/pages/FinanceReceivablePage.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage.tsx
@@ -307,7 +307,7 @@ export default function FinanceReceivablePage() {
     {
       key: 'sale', label: 'รายการขาย',
       render: (r: FinanceReceivable) => (
-        <button onClick={() => { openDetailModal(r); setSelectedReceivable(r); }} className="text-left min-w-0 hover:text-primary transition-colors">
+        <button onClick={() => setSelectedReceivable(r)} className="text-left min-w-0 hover:text-primary transition-colors">
           <div className="font-medium truncate">{r.sale.customer.name}</div>
           <div className="text-xs text-muted-foreground">{r.sale.saleNumber} &middot; {r.sale.product.name}</div>
         </button>

--- a/apps/web/src/pages/FinanceReceivablePage.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage.tsx
@@ -17,6 +17,7 @@ import { formatDateShortThai, formatDateShort } from '@/utils/formatters';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { getStatusBadgeProps, financeReceivableStatusMap, interCompanyStatusMap } from '@/lib/status-badges';
+import FinanceReceivableDetailDrawer from './FinanceReceivablePage/FinanceReceivableDetailDrawer';
 
 interface FinanceReceivable {
   id: string; financeCompany: string; financeRefNumber: string | null;
@@ -24,6 +25,10 @@ interface FinanceReceivable {
   netExpectedAmount: string; receivedAmount: string | null; receivedDate: string | null;
   bankRef: string | null; expectedDate: string; status: string; note: string | null;
   createdAt: string;
+  externalFinanceCompanyId: string | null;
+  lastContactedAt: string | null;
+  lastPromisedDate: string | null;
+  contactAttemptCount: number;
   sale: {
     id: string; saleNumber: string; sellingPrice: string; netAmount: string;
     financeAmount: string | null; downPaymentAmount: string | null; createdAt: string;
@@ -212,6 +217,8 @@ export default function FinanceReceivablePage() {
   const debouncedSearch = useDebounce(search, 300);
 
   const [selectedRecord, setSelectedRecord] = useState<FinanceReceivable | null>(null);
+  const [selectedReceivable, setSelectedReceivable] = useState<FinanceReceivable | null>(null);
+  const [brokenPromiseOnly, setBrokenPromiseOnly] = useState(false);
   const [isReceiveModalOpen, setIsReceiveModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDisputeModalOpen, setIsDisputeModalOpen] = useState(false);
@@ -246,7 +253,7 @@ export default function FinanceReceivablePage() {
   });
 
   const { data: receivables, isLoading } = useQuery<{ data: FinanceReceivable[]; total: number }>({
-    queryKey: ['finance-receivable', statusFilter, companyFilter, branchFilter, startDate, endDate, debouncedSearch, page],
+    queryKey: ['finance-receivable', statusFilter, companyFilter, branchFilter, startDate, endDate, debouncedSearch, page, brokenPromiseOnly],
     queryFn: async () => {
       const p = new URLSearchParams({ limit: '20', page: String(page) });
       if (statusFilter) p.set('status', statusFilter);
@@ -255,6 +262,7 @@ export default function FinanceReceivablePage() {
       if (startDate) p.set('startDate', startDate);
       if (endDate) p.set('endDate', endDate);
       if (debouncedSearch) p.set('search', debouncedSearch);
+      if (brokenPromiseOnly) p.set('brokenPromiseOnly', 'true');
       return (await api.get(`/finance-receivable?${p}`)).data;
     },
   });
@@ -299,7 +307,7 @@ export default function FinanceReceivablePage() {
     {
       key: 'sale', label: 'รายการขาย',
       render: (r: FinanceReceivable) => (
-        <button onClick={() => openDetailModal(r)} className="text-left min-w-0 hover:text-primary transition-colors">
+        <button onClick={() => { openDetailModal(r); setSelectedReceivable(r); }} className="text-left min-w-0 hover:text-primary transition-colors">
           <div className="font-medium truncate">{r.sale.customer.name}</div>
           <div className="text-xs text-muted-foreground">{r.sale.saleNumber} &middot; {r.sale.product.name}</div>
         </button>
@@ -308,6 +316,25 @@ export default function FinanceReceivablePage() {
     {
       key: 'financeCompany', label: 'ไฟแนนซ์',
       render: (r: FinanceReceivable) => (<div><div className="font-medium">{r.financeCompany}</div>{r.financeRefNumber && <div className="text-xs text-muted-foreground">Ref: {r.financeRefNumber}</div>}</div>),
+    },
+    {
+      key: 'lastContactedAt',
+      label: 'ติดต่อล่าสุด',
+      render: (r: FinanceReceivable) =>
+        r.lastContactedAt ? formatDateShortThai(r.lastContactedAt) : '—',
+    },
+    {
+      key: 'lastPromisedDate',
+      label: 'นัดล่าสุด',
+      render: (r: FinanceReceivable) => {
+        if (!r.lastPromisedDate) return '—';
+        const overdue = new Date(r.lastPromisedDate) < new Date() && r.status !== 'RECEIVED';
+        return (
+          <span className={overdue ? 'text-red-600 font-medium' : ''}>
+            {formatDateShortThai(r.lastPromisedDate)}
+          </span>
+        );
+      },
     },
     { key: 'branch', label: 'สาขา', render: (r: FinanceReceivable) => r.branch.name },
     {
@@ -446,6 +473,17 @@ export default function FinanceReceivablePage() {
         </div>
       </div>
 
+      <div className="flex items-center gap-2 mb-4">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={brokenPromiseOnly}
+            onChange={(e) => setBrokenPromiseOnly(e.target.checked)}
+          />
+          มีนัดเลยกำหนด
+        </label>
+      </div>
+
       <DataTable columns={columns} data={receivables?.data || []} isLoading={isLoading} emptyMessage="ไม่พบรายการเงินรับจากไฟแนนซ์" />
 
       {/* Pagination */}
@@ -553,6 +591,11 @@ export default function FinanceReceivablePage() {
           </div>
         )}
       </Modal>
+
+      <FinanceReceivableDetailDrawer
+        receivable={selectedReceivable}
+        onClose={() => setSelectedReceivable(null)}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/FinanceReceivablePage/ContactTimeline.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage/ContactTimeline.tsx
@@ -1,0 +1,69 @@
+import { Badge } from '@/components/ui/badge';
+import { FinanceContactLog } from '@/lib/api/finance-contacts';
+import { formatDateShortThai } from '@/utils/formatters';
+
+const RESULT_LABEL: Record<FinanceContactLog['result'], string> = {
+  ANSWERED: 'รับสาย',
+  NO_ANSWER: 'ไม่รับ',
+  PROMISED: 'รับปาก',
+  DISPUTED: 'โต้แย้ง',
+  REQUESTED_DOCS: 'ขอเอกสาร',
+  OTHER: 'อื่นๆ',
+};
+
+const RESULT_TONE: Record<FinanceContactLog['result'], string> = {
+  ANSWERED: 'bg-emerald-100 text-emerald-700',
+  NO_ANSWER: 'bg-muted text-muted-foreground',
+  PROMISED: 'bg-amber-100 text-amber-700',
+  DISPUTED: 'bg-red-100 text-red-700',
+  REQUESTED_DOCS: 'bg-blue-100 text-blue-700',
+  OTHER: 'bg-secondary text-secondary-foreground',
+};
+
+export default function ContactTimeline({ logs }: { logs: FinanceContactLog[] }) {
+  if (logs.length === 0) {
+    return <p className="text-sm text-muted-foreground py-6 text-center">ยังไม่มีบันทึกการติดต่อ</p>;
+  }
+
+  return (
+    <ol className="relative border-l border-border ml-3 space-y-4">
+      {logs.map((log) => {
+        const promiseBroken = !!log.promisedBrokenAt;
+        const promiseKept = !!log.promisedKeptAt;
+        return (
+          <li key={log.id} className="ml-4">
+            <span className="absolute -left-1.5 mt-1.5 w-3 h-3 bg-primary rounded-full" />
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <span className="font-medium">{log.contactedBy.name}</span>
+              <span className="text-muted-foreground">{formatDateShortThai(log.contactedAt)}</span>
+              {log.contact && (
+                <Badge variant="secondary">
+                  คุย: {log.contact.name}{log.contact.position ? ` (${log.contact.position})` : ''}
+                </Badge>
+              )}
+              <span className={`px-2 py-0.5 rounded text-xs ${RESULT_TONE[log.result]}`}>
+                {RESULT_LABEL[log.result]}
+              </span>
+            </div>
+            {log.notes && <p className="mt-1 text-sm text-foreground/80">{log.notes}</p>}
+            {log.promisedDate && (
+              <div
+                className={`mt-2 inline-block px-3 py-1.5 rounded-lg text-sm ${
+                  promiseBroken
+                    ? 'bg-red-50 text-red-700 border border-red-200'
+                    : promiseKept
+                      ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                      : 'bg-amber-50 text-amber-700 border border-amber-200'
+                }`}
+              >
+                {promiseKept ? '✓ นัดสำเร็จ ' : promiseBroken ? '✗ ผิดนัด ' : '⏳ นัดไว้ '}
+                {formatDateShortThai(log.promisedDate)}
+                {log.promisedAmount && ` • ${Number(log.promisedAmount).toLocaleString('th-TH')} บาท`}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/web/src/pages/FinanceReceivablePage/FinanceContactLogDialog.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage/FinanceContactLogDialog.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import Modal from '@/components/ui/Modal';
+import { Button } from '@/components/ui/button';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import {
+  financeContactApi,
+  financeContactKeys,
+  FinanceContactLog,
+} from '@/lib/api/finance-contacts';
+import { getErrorMessage } from '@/lib/api';
+
+interface Props {
+  receivableId: string;
+  companyId: string;
+  outstanding: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+const RESULT_OPTIONS: Array<{ value: FinanceContactLog['result']; label: string; tone: string }> = [
+  { value: 'ANSWERED', label: 'รับสาย', tone: 'bg-emerald-100 text-emerald-700' },
+  { value: 'NO_ANSWER', label: 'ไม่รับ', tone: 'bg-muted text-muted-foreground' },
+  { value: 'PROMISED', label: 'รับปาก', tone: 'bg-amber-100 text-amber-700' },
+  { value: 'DISPUTED', label: 'โต้แย้ง', tone: 'bg-red-100 text-red-700' },
+  { value: 'REQUESTED_DOCS', label: 'ขอเอกสาร', tone: 'bg-blue-100 text-blue-700' },
+  { value: 'OTHER', label: 'อื่นๆ', tone: 'bg-secondary text-secondary-foreground' },
+];
+
+export default function FinanceContactLogDialog({
+  receivableId,
+  companyId,
+  outstanding,
+  open,
+  onClose,
+}: Props) {
+  const qc = useQueryClient();
+  const [contactId, setContactId] = useState<string | undefined>();
+  const [result, setResult] = useState<FinanceContactLog['result']>('ANSWERED');
+  const [notes, setNotes] = useState('');
+  const [promisedDate, setPromisedDate] = useState('');
+  const [promisedAmount, setPromisedAmount] = useState<string>(String(outstanding));
+
+  const { data: contacts } = useQuery({
+    queryKey: financeContactKeys.companyContacts(companyId),
+    queryFn: () => financeContactApi.listContacts(companyId),
+    enabled: open && !!companyId,
+  });
+
+  const submit = useMutation({
+    mutationFn: () =>
+      financeContactApi.recordLog(receivableId, {
+        financeCompanyContactId: contactId,
+        result,
+        notes: notes.trim() || undefined,
+        promisedDate: result === 'PROMISED' ? promisedDate : undefined,
+        promisedAmount: result === 'PROMISED' ? Number(promisedAmount) : undefined,
+      }),
+    onSuccess: () => {
+      toast.success('บันทึกการติดต่อสำเร็จ');
+      qc.invalidateQueries({ queryKey: financeContactKeys.receivableLogs(receivableId) });
+      qc.invalidateQueries({ queryKey: ['finance-receivable'] });
+      onClose();
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
+  if (!open) return null;
+
+  return (
+    <Modal isOpen={open} onClose={onClose} title="บันทึกการติดต่อไฟแนนซ์">
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-2">ผู้ติดต่อ</label>
+          <select
+            className="w-full px-3 py-2 border border-input rounded-lg bg-background"
+            value={contactId ?? ''}
+            onChange={(e) => setContactId(e.target.value || undefined)}
+          >
+            <option value="">— ไม่ระบุ —</option>
+            {contacts?.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+                {c.position ? ` (${c.position})` : ''}
+                {c.isPrimary ? ' ★ ตัวหลัก' : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-2">ผลการติดต่อ</label>
+          <div className="flex flex-wrap gap-2">
+            {RESULT_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setResult(opt.value)}
+                className={`px-3 py-1.5 rounded-full text-sm border ${
+                  result === opt.value
+                    ? `${opt.tone} border-current font-medium`
+                    : 'border-border text-muted-foreground hover:bg-accent'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {result === 'PROMISED' && (
+          <div className="space-y-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+            <div>
+              <label className="block text-sm font-medium mb-1">วันที่นัดโอน</label>
+              <ThaiDateInput
+                value={promisedDate}
+                onChange={(e) => setPromisedDate(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">ยอดที่นัด (บาท)</label>
+              <input
+                type="number"
+                className="w-full px-3 py-2 border border-input rounded-lg bg-background"
+                value={promisedAmount}
+                onChange={(e) => setPromisedAmount(e.target.value)}
+                min={0}
+                step={0.01}
+              />
+            </div>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium mb-2">โน้ต</label>
+          <textarea
+            className="w-full px-3 py-2 border border-input rounded-lg bg-background"
+            rows={3}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="รายละเอียดการคุย…"
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onClose}>
+            ยกเลิก
+          </Button>
+          <Button
+            onClick={() => submit.mutate()}
+            disabled={submit.isPending || (result === 'PROMISED' && !promisedDate)}
+          >
+            {submit.isPending ? 'กำลังบันทึก…' : 'บันทึก'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/FinanceReceivablePage/FinanceReceivableDetailDrawer.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage/FinanceReceivableDetailDrawer.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Phone } from 'lucide-react';
+import {
+  financeContactApi,
+  financeContactKeys,
+} from '@/lib/api/finance-contacts';
+import { formatDateShortThai } from '@/utils/formatters';
+import ContactTimeline from './ContactTimeline';
+import FinanceContactLogDialog from './FinanceContactLogDialog';
+
+interface Receivable {
+  id: string;
+  expectedAmount: string;
+  netExpectedAmount: string;
+  receivedAmount: string | null;
+  status: string;
+  externalFinanceCompanyId: string | null;
+  financeCompany: string;
+  lastContactedAt: string | null;
+  lastPromisedDate: string | null;
+  contactAttemptCount: number;
+}
+
+interface Props {
+  receivable: Receivable | null;
+  onClose: () => void;
+}
+
+export default function FinanceReceivableDetailDrawer({ receivable, onClose }: Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const { data: logs = [] } = useQuery({
+    queryKey: receivable ? financeContactKeys.receivableLogs(receivable.id) : ['noop'],
+    queryFn: () => financeContactApi.listLogs(receivable!.id),
+    enabled: !!receivable,
+  });
+
+  if (!receivable) return null;
+  const outstanding = Number(receivable.netExpectedAmount) - Number(receivable.receivedAmount ?? 0);
+
+  return (
+    <>
+      <Sheet open onOpenChange={(o) => !o && onClose()}>
+        <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>รายการเงินรับจากไฟแนนซ์</SheetTitle>
+          </SheetHeader>
+
+          <div className="space-y-4 mt-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <span className="text-sm text-muted-foreground">{receivable.financeCompany}</span>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">ยอดที่คาดว่าจะรับ</span>
+                  <span className="font-medium">
+                    {Number(receivable.netExpectedAmount).toLocaleString('th-TH', {
+                      minimumFractionDigits: 2,
+                    })}
+                  </span>
+                </div>
+                {receivable.externalFinanceCompanyId && (
+                  <Link
+                    to={`/external-finance-companies/${receivable.externalFinanceCompanyId}`}
+                    className="text-sm text-primary hover:underline"
+                  >
+                    ดูข้อมูลบริษัทไฟแนนซ์ →
+                  </Link>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="pb-2">
+                <span className="text-sm font-medium">KPI การติดตาม</span>
+              </CardHeader>
+              <CardContent className="grid grid-cols-3 gap-3 text-sm">
+                <div>
+                  <div className="text-muted-foreground">ติดต่อล่าสุด</div>
+                  <div className="font-medium">
+                    {receivable.lastContactedAt ? formatDateShortThai(receivable.lastContactedAt) : '—'}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">นัดล่าสุด</div>
+                  <div className="font-medium">
+                    {receivable.lastPromisedDate ? formatDateShortThai(receivable.lastPromisedDate) : '—'}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">จำนวนครั้ง</div>
+                  <div className="font-medium">{receivable.contactAttemptCount}</div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium">ประวัติการติดต่อ</h3>
+              <Button size="sm" onClick={() => setDialogOpen(true)}>
+                <Phone className="w-4 h-4 mr-1" /> บันทึกการติดต่อ
+              </Button>
+            </div>
+            <ContactTimeline logs={logs} />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      {dialogOpen && receivable.externalFinanceCompanyId && (
+        <FinanceContactLogDialog
+          receivableId={receivable.id}
+          companyId={receivable.externalFinanceCompanyId}
+          outstanding={outstanding > 0 ? outstanding : 0}
+          open={dialogOpen}
+          onClose={() => setDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/pages/FinanceReceivablePage/FinanceReceivableDetailDrawer.tsx
+++ b/apps/web/src/pages/FinanceReceivablePage/FinanceReceivableDetailDrawer.tsx
@@ -111,10 +111,10 @@ export default function FinanceReceivableDetailDrawer({ receivable, onClose }: P
         </SheetContent>
       </Sheet>
 
-      {dialogOpen && receivable.externalFinanceCompanyId && (
+      {dialogOpen && (
         <FinanceContactLogDialog
           receivableId={receivable.id}
-          companyId={receivable.externalFinanceCompanyId}
+          companyId={receivable.externalFinanceCompanyId ?? ''}
           outstanding={outstanding > 0 ? outstanding : 0}
           open={dialogOpen}
           onClose={() => setDialogOpen(false)}

--- a/apps/web/src/pages/LettersPage/index.tsx
+++ b/apps/web/src/pages/LettersPage/index.tsx
@@ -101,7 +101,8 @@ export default function LettersPage() {
   const handleToggle = (id: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   };

--- a/docs/superpowers/plans/2026-05-31-finance-receivable-contact-system.md
+++ b/docs/superpowers/plans/2026-05-31-finance-receivable-contact-system.md
@@ -1,0 +1,3237 @@
+# Finance Receivable Contact System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a PEAK-style contact directory + activity-log system on top of `FinanceReceivable` / `ExternalFinanceCompany` so finance staff can register multiple contacts per finance company and track every call/follow-up against each receivable.
+
+**Architecture:** 2 new Prisma models (`FinanceCompanyContact`, `FinanceReceivableContactLog`) + 4 new fields on existing `ExternalFinanceCompany` + 4 new fields on `FinanceReceivable` (FK + KPI denorm). NestJS modules follow the existing controller→service→PrismaService pattern. React frontend uses TanStack Query + shadcn/ui drawer/dialog. Single promise per log, CALL channel only (enum extensible). Lazy FK resolution at contact-log create — upserts `ExternalFinanceCompany` if receivable is pre-backfill.
+
+**Tech Stack:** NestJS + Prisma + PostgreSQL (backend), React 18 + Vite + TanStack Query + shadcn/ui + Tailwind (frontend), Jest (unit), Playwright (E2E).
+
+**Spec:** [`docs/superpowers/specs/2026-05-31-finance-receivable-contact-system-design.md`](../specs/2026-05-31-finance-receivable-contact-system-design.md)
+
+---
+
+## File Structure
+
+### Backend (`apps/api/src/`)
+
+**New files:**
+- `modules/finance-company-contacts/finance-company-contacts.module.ts` — module wiring
+- `modules/finance-company-contacts/finance-company-contacts.controller.ts` — REST endpoints (contacts CRUD + setPrimary)
+- `modules/finance-company-contacts/finance-company-contacts.service.ts` — business logic
+- `modules/finance-company-contacts/finance-company-contacts.service.spec.ts` — Jest tests
+- `modules/finance-company-contacts/dto/finance-company-contact.dto.ts` — class-validator DTOs
+
+- `modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts`
+- `modules/finance-receivable-contact-logs/finance-receivable-contact-logs.controller.ts`
+- `modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts`
+- `modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts`
+- `modules/finance-receivable-contact-logs/dto/finance-receivable-contact-log.dto.ts`
+- `modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.ts`
+- `modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.spec.ts`
+- `modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.ts`
+- `modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.spec.ts`
+
+- `scripts/backfill-external-finance-fk.ts` — one-time data migration
+
+**Modified files:**
+- `prisma/schema.prisma` — schema additions (see Task 1)
+- `prisma/migrations/<ts>_finance_receivable_contact_system/migration.sql` — auto + raw SQL append
+- `modules/external-finance/external-finance.service.ts` — accept new master fields in upsert
+- `modules/external-finance/dto/external-finance-company.dto.ts` — new optional fields
+- `modules/finance-receivable/finance-receivable.service.ts` — `recordReceive` sets `promisedKeptAt`; query includes new fields
+- `modules/finance-receivable/finance-receivable.controller.ts` — new GET sub-routes for logs
+- `modules/sales/sales.service.ts` — resolve FK at FinanceReceivable creation (lines 626 + 715)
+- `app.module.ts` — register 2 new modules
+- `package.json` (apps/api) — add `backfill:external-finance` script
+
+### Frontend (`apps/web/src/`)
+
+**New files:**
+- `pages/FinanceReceivablePage/FinanceReceivableDetailDrawer.tsx` — bottom drawer for a single receivable
+- `pages/FinanceReceivablePage/FinanceContactLogDialog.tsx` — log-creation modal
+- `pages/FinanceReceivablePage/ContactTimeline.tsx` — log timeline list component
+- `pages/ExternalFinanceCompanyDetailPage.tsx` — 4-tab company detail page
+- `pages/ExternalFinanceCompanyDetailPage/CompanyInfoTab.tsx`
+- `pages/ExternalFinanceCompanyDetailPage/ContactsTab.tsx`
+- `pages/ExternalFinanceCompanyDetailPage/ReceivablesTab.tsx`
+- `pages/ExternalFinanceCompanyDetailPage/AllContactLogsTab.tsx`
+- `lib/api/finance-contacts.ts` — typed API wrappers + React Query keys
+
+**Modified files:**
+- `pages/FinanceReceivablePage.tsx` — add columns "ติดต่อล่าสุด"/"นัดล่าสุด", row click → drawer, filter "มีนัดเลยกำหนด"
+- `App.tsx` — register `/external-finance-companies/:id` route (lazy-loaded)
+
+### E2E (`apps/web/e2e/`)
+
+**New files:**
+- `finance-receivable-contact.spec.ts` — Playwright E2E covering log create + primary swap + filter
+
+---
+
+## Task 1: Prisma schema additions
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma`
+- Create: `apps/api/prisma/migrations/<ts>_finance_receivable_contact_system/migration.sql` (auto-generated, then append raw SQL)
+
+- [ ] **Step 1: Add new enums and `FinanceCompanyContact` model**
+
+Append to `apps/api/prisma/schema.prisma` (after `ExternalFinanceCommission` model — search for `model ExternalFinanceCommission`):
+
+```prisma
+enum FinanceContactChannel {
+  CALL
+  EMAIL
+  LINE
+  MEETING
+  OTHER
+}
+
+enum FinanceContactResult {
+  ANSWERED
+  NO_ANSWER
+  PROMISED
+  DISPUTED
+  REQUESTED_DOCS
+  OTHER
+}
+
+model FinanceCompanyContact {
+  id                       String   @id @default(uuid())
+  externalFinanceCompanyId String   @map("external_finance_company_id")
+  name                     String
+  position                 String?
+  department               String?
+  phone                    String?
+  email                    String?
+  lineId                   String?  @map("line_id")
+  notes                    String?
+  isPrimary                Boolean  @default(false) @map("is_primary")
+  isActive                 Boolean  @default(true)  @map("is_active")
+  createdAt                DateTime @default(now()) @map("created_at")
+  updatedAt                DateTime @updatedAt      @map("updated_at")
+  deletedAt                DateTime?                @map("deleted_at")
+
+  company     ExternalFinanceCompany        @relation(fields: [externalFinanceCompanyId], references: [id])
+  contactLogs FinanceReceivableContactLog[]
+
+  @@index([externalFinanceCompanyId, isActive])
+  @@map("finance_company_contacts")
+}
+
+model FinanceReceivableContactLog {
+  id                       String                @id @default(uuid())
+  financeReceivableId      String                @map("finance_receivable_id")
+  externalFinanceCompanyId String                @map("external_finance_company_id")
+  financeCompanyContactId  String?               @map("finance_company_contact_id")
+  contactedById            String                @map("contacted_by_id")
+  contactedAt              DateTime              @default(now()) @map("contacted_at")
+  channel                  FinanceContactChannel @default(CALL)
+  result                   FinanceContactResult
+  notes                    String?
+  promisedDate             DateTime?             @map("promised_date")
+  promisedAmount           Decimal?              @map("promised_amount") @db.Decimal(12, 2)
+  promisedBrokenAt         DateTime?             @map("promised_broken_at")
+  promisedKeptAt           DateTime?             @map("promised_kept_at")
+  createdAt                DateTime              @default(now()) @map("created_at")
+  updatedAt                DateTime              @updatedAt      @map("updated_at")
+  deletedAt                DateTime?             @map("deleted_at")
+
+  receivable  FinanceReceivable      @relation(fields: [financeReceivableId], references: [id])
+  company     ExternalFinanceCompany @relation(fields: [externalFinanceCompanyId], references: [id])
+  contact     FinanceCompanyContact? @relation(fields: [financeCompanyContactId], references: [id])
+  contactedBy User                   @relation("FinanceContactLogger", fields: [contactedById], references: [id])
+
+  @@index([financeReceivableId, contactedAt])
+  @@index([externalFinanceCompanyId, contactedAt])
+  @@index([promisedDate, promisedBrokenAt, promisedKeptAt])
+  @@map("finance_receivable_contact_logs")
+}
+```
+
+- [ ] **Step 2: Extend `ExternalFinanceCompany` model**
+
+Find the existing `model ExternalFinanceCompany {` block and add these fields plus relations (do not remove existing fields):
+
+```prisma
+  // ── new master fields (PEAK-style, focused) ──
+  taxId          String?  @map("tax_id")
+  email          String?
+  lineOaId       String?  @map("line_oa_id")
+  creditTermDays Int?     @map("credit_term_days")
+
+  // ── new relations ──
+  contacts    FinanceCompanyContact[]
+  receivables FinanceReceivable[]
+  contactLogs FinanceReceivableContactLog[]
+```
+
+- [ ] **Step 3: Extend `FinanceReceivable` model**
+
+Find the existing `model FinanceReceivable {` block and add these fields + relations + index:
+
+```prisma
+  // ── new (Phase 1 nullable, Phase 3 → required) ──
+  externalFinanceCompanyId String? @map("external_finance_company_id")
+  lastContactedAt          DateTime? @map("last_contacted_at")
+  lastPromisedDate         DateTime? @map("last_promised_date")
+  contactAttemptCount      Int       @default(0) @map("contact_attempt_count")
+
+  company     ExternalFinanceCompany?       @relation(fields: [externalFinanceCompanyId], references: [id])
+  contactLogs FinanceReceivableContactLog[]
+
+  @@index([externalFinanceCompanyId, status])
+  @@index([lastContactedAt])
+```
+
+- [ ] **Step 4: Add reverse relation on `User`**
+
+Find `model User {` and inside the relations section append:
+
+```prisma
+  financeContactLogs FinanceReceivableContactLog[] @relation("FinanceContactLogger")
+```
+
+- [ ] **Step 5: Generate Prisma migration**
+
+Run from `apps/api`:
+```bash
+cd apps/api && npx prisma migrate dev --name finance_receivable_contact_system --create-only
+```
+
+Expected: a new folder `apps/api/prisma/migrations/<ts>_finance_receivable_contact_system/migration.sql` is created. Do NOT apply yet.
+
+- [ ] **Step 6: Append raw SQL for partial unique index**
+
+Open the generated `migration.sql` and append at the bottom:
+
+```sql
+-- Partial unique index: at most one primary contact per company (excluding soft-deleted rows)
+CREATE UNIQUE INDEX uniq_primary_per_company
+  ON finance_company_contacts (external_finance_company_id)
+  WHERE is_primary = true AND deleted_at IS NULL;
+```
+
+- [ ] **Step 7: Apply migration**
+
+Run from `apps/api`:
+```bash
+cd apps/api && npx prisma migrate dev
+```
+
+Expected: migration applied. `npx prisma generate` runs automatically.
+
+- [ ] **Step 8: Verify schema compiles**
+
+Run from repo root:
+```bash
+./tools/check-types.sh api
+```
+
+Expected: 0 TypeScript errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "feat(schema): add finance contact + activity log tables"
+```
+
+---
+
+## Task 2: Name normalizer utility
+
+**Files:**
+- Create: `apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.ts`
+- Test: `apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// finance-company-name-normalizer.util.spec.ts
+import { normalizeFinanceCompanyName } from './finance-company-name-normalizer.util';
+
+describe('normalizeFinanceCompanyName', () => {
+  it('trims whitespace', () => {
+    expect(normalizeFinanceCompanyName('  เคทีซี  ')).toBe('เคทีซี');
+  });
+
+  it('lowercases ASCII letters', () => {
+    expect(normalizeFinanceCompanyName('KTC Finance')).toBe('ktc finance');
+  });
+
+  it('collapses multiple internal spaces to single space', () => {
+    expect(normalizeFinanceCompanyName('กสิกร   ไทย')).toBe('กสิกร ไทย');
+  });
+
+  it('strips spaces around parentheses', () => {
+    expect(normalizeFinanceCompanyName('กสิกร (KK)')).toBe('กสิกร(kk)');
+  });
+
+  it('returns empty string for null / empty input', () => {
+    expect(normalizeFinanceCompanyName('')).toBe('');
+    expect(normalizeFinanceCompanyName(null as unknown as string)).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd apps/api && npx jest finance-company-name-normalizer.util.spec
+```
+
+Expected: FAIL with "Cannot find module './finance-company-name-normalizer.util'".
+
+- [ ] **Step 3: Implement the normalizer**
+
+```typescript
+// finance-company-name-normalizer.util.ts
+export function normalizeFinanceCompanyName(input: string | null | undefined): string {
+  if (!input) return '';
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*\(\s*/g, '(')
+    .replace(/\s*\)\s*/g, ')');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd apps/api && npx jest finance-company-name-normalizer.util.spec
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.ts apps/api/src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util.spec.ts
+git commit -m "feat(finance-contact): add finance company name normalizer"
+```
+
+---
+
+## Task 3: ExternalFinanceCompany DTO + service accepting new master fields
+
+**Files:**
+- Modify: `apps/api/src/modules/external-finance/dto/external-finance-company.dto.ts`
+- Modify: `apps/api/src/modules/external-finance/external-finance.service.ts`
+
+- [ ] **Step 1: Extend DTO**
+
+Open `apps/api/src/modules/external-finance/dto/external-finance-company.dto.ts` and add these optional fields to `CreateExternalFinanceCompanyDto` (above the closing `}`):
+
+```typescript
+  @IsOptional()
+  @IsString()
+  @MaxLength(20, { message: 'เลขผู้เสียภาษีต้องไม่เกิน 20 ตัวอักษร' })
+  taxId?: string;
+
+  @IsOptional()
+  @IsEmail({}, { message: 'รูปแบบอีเมลไม่ถูกต้อง' })
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  lineOaId?: string;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'เครดิตเทอมต้องเป็นตัวเลข' })
+  @Min(0)
+  creditTermDays?: number;
+```
+
+Add to the top imports if missing:
+```typescript
+import { IsEmail, MaxLength } from 'class-validator';
+```
+
+- [ ] **Step 2: Pass new fields through service**
+
+Open `apps/api/src/modules/external-finance/external-finance.service.ts`. In `create()` add the 4 new fields to the `data:` object. In `update()` (search for it; if `Object.assign(...)` or spread pattern is used, this is already covered by virtue of `PartialType`).
+
+Example of `create()` update:
+```typescript
+return this.prisma.externalFinanceCompany.create({
+  data: {
+    name: dto.name,
+    contactPerson: dto.contactPerson,
+    contactPhone: dto.contactPhone,
+    defaultCommissionRate: dto.defaultCommissionRate,
+    bankAccountInfo: dto.bankAccountInfo as Prisma.InputJsonValue | undefined,
+    notes: dto.notes,
+    isActive: dto.isActive,
+    taxId: dto.taxId,
+    email: dto.email,
+    lineOaId: dto.lineOaId,
+    creditTermDays: dto.creditTermDays,
+  },
+});
+```
+
+- [ ] **Step 3: Run type check**
+
+```bash
+./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/modules/external-finance/
+git commit -m "feat(external-finance): accept taxId/email/lineOaId/creditTermDays"
+```
+
+---
+
+## Task 4: FinanceCompanyContact DTOs
+
+**Files:**
+- Create: `apps/api/src/modules/finance-company-contacts/dto/finance-company-contact.dto.ts`
+
+- [ ] **Step 1: Create the DTO file**
+
+```typescript
+// apps/api/src/modules/finance-company-contacts/dto/finance-company-contact.dto.ts
+import {
+  IsString,
+  IsOptional,
+  IsEmail,
+  IsBoolean,
+  MaxLength,
+} from 'class-validator';
+import { PartialType } from '@nestjs/mapped-types';
+
+export class CreateFinanceCompanyContactDto {
+  @IsString({ message: 'กรุณาระบุชื่อผู้ติดต่อ' })
+  @MaxLength(200)
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  position?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  department?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  phone?: string;
+
+  @IsOptional()
+  @IsEmail({}, { message: 'รูปแบบอีเมลไม่ถูกต้อง' })
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  lineId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  notes?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPrimary?: boolean;
+}
+
+export class UpdateFinanceCompanyContactDto extends PartialType(
+  CreateFinanceCompanyContactDto,
+) {}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/modules/finance-company-contacts/dto/
+git commit -m "feat(finance-contact): add contact DTOs"
+```
+
+---
+
+## Task 5: FinanceCompanyContactsService — CRUD + setPrimary
+
+**Files:**
+- Create: `apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.ts`
+- Test: `apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// finance-company-contacts.service.spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { FinanceCompanyContactsService } from './finance-company-contacts.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('FinanceCompanyContactsService', () => {
+  let service: FinanceCompanyContactsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      financeCompanyContact: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+        count: jest.fn(),
+      },
+      externalFinanceCompany: {
+        findFirst: jest.fn(),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
+      $queryRaw: jest.fn(),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        FinanceCompanyContactsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = moduleRef.get(FinanceCompanyContactsService);
+  });
+
+  describe('list', () => {
+    it('returns contacts sorted with primary first then by name', async () => {
+      await service.list('co-1');
+      const call = prisma.financeCompanyContact.findMany.mock.calls[0][0];
+      expect(call.where.externalFinanceCompanyId).toBe('co-1');
+      expect(call.where.deletedAt).toBeNull();
+      expect(call.orderBy).toEqual([{ isPrimary: 'desc' }, { isActive: 'desc' }, { name: 'asc' }]);
+    });
+  });
+
+  describe('create', () => {
+    it('rejects when company not found', async () => {
+      prisma.externalFinanceCompany.findFirst.mockResolvedValue(null);
+      await expect(
+        service.create('co-1', { name: 'John' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('creates contact when company exists', async () => {
+      prisma.externalFinanceCompany.findFirst.mockResolvedValue({ id: 'co-1' });
+      prisma.financeCompanyContact.create.mockResolvedValue({ id: 'c-1' });
+      await service.create('co-1', { name: 'John' });
+      expect(prisma.financeCompanyContact.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('setPrimary', () => {
+    it('clears other primaries before promoting', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue({
+        id: 'c-2', externalFinanceCompanyId: 'co-1', deletedAt: null,
+      });
+
+      await service.setPrimary('co-1', 'c-2');
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(prisma.$queryRaw).toHaveBeenCalled(); // FOR UPDATE lock
+      expect(prisma.financeCompanyContact.updateMany).toHaveBeenCalledWith({
+        where: { externalFinanceCompanyId: 'co-1', isPrimary: true, deletedAt: null },
+        data: { isPrimary: false },
+      });
+      expect(prisma.financeCompanyContact.update).toHaveBeenCalledWith({
+        where: { id: 'c-2' },
+        data: { isPrimary: true },
+      });
+    });
+
+    it('throws NotFound when contact does not belong to company', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue(null);
+      await expect(service.setPrimary('co-1', 'c-2')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('softDelete', () => {
+    it('rejects primary delete when other active contacts exist', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue({
+        id: 'c-1', isPrimary: true, externalFinanceCompanyId: 'co-1', deletedAt: null,
+      });
+      prisma.financeCompanyContact.count.mockResolvedValue(1); // 1 other active contact
+
+      await expect(service.softDelete('co-1', 'c-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('allows primary delete when no other active contacts', async () => {
+      prisma.financeCompanyContact.findFirst.mockResolvedValue({
+        id: 'c-1', isPrimary: true, externalFinanceCompanyId: 'co-1', deletedAt: null,
+      });
+      prisma.financeCompanyContact.count.mockResolvedValue(0);
+      prisma.financeCompanyContact.update.mockResolvedValue({});
+
+      await service.softDelete('co-1', 'c-1');
+      expect(prisma.financeCompanyContact.update).toHaveBeenCalledWith({
+        where: { id: 'c-1' },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/api && npx jest finance-company-contacts.service.spec
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the service**
+
+```typescript
+// apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.ts
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  CreateFinanceCompanyContactDto,
+  UpdateFinanceCompanyContactDto,
+} from './dto/finance-company-contact.dto';
+
+@Injectable()
+export class FinanceCompanyContactsService {
+  constructor(private prisma: PrismaService) {}
+
+  async list(companyId: string) {
+    return this.prisma.financeCompanyContact.findMany({
+      where: { externalFinanceCompanyId: companyId, deletedAt: null },
+      orderBy: [{ isPrimary: 'desc' }, { isActive: 'desc' }, { name: 'asc' }],
+    });
+  }
+
+  async create(companyId: string, dto: CreateFinanceCompanyContactDto) {
+    const company = await this.prisma.externalFinanceCompany.findFirst({
+      where: { id: companyId, deletedAt: null },
+    });
+    if (!company) throw new NotFoundException('ไม่พบบริษัทไฟแนนซ์');
+
+    return this.prisma.$transaction(async (tx) => {
+      if (dto.isPrimary) {
+        await tx.financeCompanyContact.updateMany({
+          where: { externalFinanceCompanyId: companyId, isPrimary: true, deletedAt: null },
+          data: { isPrimary: false },
+        });
+      }
+      return tx.financeCompanyContact.create({
+        data: {
+          externalFinanceCompanyId: companyId,
+          name: dto.name,
+          position: dto.position,
+          department: dto.department,
+          phone: dto.phone,
+          email: dto.email,
+          lineId: dto.lineId,
+          notes: dto.notes,
+          isPrimary: dto.isPrimary ?? false,
+        },
+      });
+    });
+  }
+
+  async update(companyId: string, contactId: string, dto: UpdateFinanceCompanyContactDto) {
+    const existing = await this.prisma.financeCompanyContact.findFirst({
+      where: { id: contactId, externalFinanceCompanyId: companyId, deletedAt: null },
+    });
+    if (!existing) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    return this.prisma.$transaction(async (tx) => {
+      if (dto.isPrimary === true && !existing.isPrimary) {
+        await tx.financeCompanyContact.updateMany({
+          where: { externalFinanceCompanyId: companyId, isPrimary: true, deletedAt: null },
+          data: { isPrimary: false },
+        });
+      }
+      return tx.financeCompanyContact.update({
+        where: { id: contactId },
+        data: dto,
+      });
+    });
+  }
+
+  async setPrimary(companyId: string, contactId: string) {
+    const contact = await this.prisma.financeCompanyContact.findFirst({
+      where: { id: contactId, externalFinanceCompanyId: companyId, deletedAt: null },
+    });
+    if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    return this.prisma.$transaction(async (tx) => {
+      // Row-lock the company to serialise concurrent setPrimary calls
+      await tx.$queryRaw(
+        Prisma.sql`SELECT id FROM external_finance_companies WHERE id = ${companyId} FOR UPDATE`,
+      );
+      await tx.financeCompanyContact.updateMany({
+        where: { externalFinanceCompanyId: companyId, isPrimary: true, deletedAt: null },
+        data: { isPrimary: false },
+      });
+      return tx.financeCompanyContact.update({
+        where: { id: contactId },
+        data: { isPrimary: true },
+      });
+    });
+  }
+
+  async softDelete(companyId: string, contactId: string) {
+    const contact = await this.prisma.financeCompanyContact.findFirst({
+      where: { id: contactId, externalFinanceCompanyId: companyId, deletedAt: null },
+    });
+    if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    if (contact.isPrimary) {
+      const others = await this.prisma.financeCompanyContact.count({
+        where: {
+          externalFinanceCompanyId: companyId,
+          deletedAt: null,
+          isActive: true,
+          NOT: { id: contactId },
+        },
+      });
+      if (others > 0) {
+        throw new BadRequestException(
+          'ไม่สามารถลบผู้ติดต่อหลักได้ — กรุณาตั้งผู้ติดต่อหลักคนใหม่ก่อน',
+        );
+      }
+    }
+
+    return this.prisma.financeCompanyContact.update({
+      where: { id: contactId },
+      data: { deletedAt: new Date() },
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/api && npx jest finance-company-contacts.service.spec
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.ts apps/api/src/modules/finance-company-contacts/finance-company-contacts.service.spec.ts
+git commit -m "feat(finance-contact): contacts service with primary swap + delete guard"
+```
+
+---
+
+## Task 6: FinanceCompanyContactsController + module + wire into AppModule
+
+**Files:**
+- Create: `apps/api/src/modules/finance-company-contacts/finance-company-contacts.controller.ts`
+- Create: `apps/api/src/modules/finance-company-contacts/finance-company-contacts.module.ts`
+- Modify: `apps/api/src/app.module.ts`
+
+- [ ] **Step 1: Write the controller**
+
+```typescript
+// apps/api/src/modules/finance-company-contacts/finance-company-contacts.controller.ts
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { FinanceCompanyContactsService } from './finance-company-contacts.service';
+import {
+  CreateFinanceCompanyContactDto,
+  UpdateFinanceCompanyContactDto,
+} from './dto/finance-company-contact.dto';
+
+@ApiTags('Finance Contacts')
+@ApiBearerAuth('JWT')
+@Controller('external-finance/companies/:companyId/contacts')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FinanceCompanyContactsController {
+  constructor(private readonly service: FinanceCompanyContactsService) {}
+
+  @Get()
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  list(@Param('companyId') companyId: string) {
+    return this.service.list(companyId);
+  }
+
+  @Post()
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  create(
+    @Param('companyId') companyId: string,
+    @Body() dto: CreateFinanceCompanyContactDto,
+  ) {
+    return this.service.create(companyId, dto);
+  }
+
+  @Patch(':contactId')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  update(
+    @Param('companyId') companyId: string,
+    @Param('contactId') contactId: string,
+    @Body() dto: UpdateFinanceCompanyContactDto,
+  ) {
+    return this.service.update(companyId, contactId, dto);
+  }
+
+  @Post(':contactId/set-primary')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  setPrimary(
+    @Param('companyId') companyId: string,
+    @Param('contactId') contactId: string,
+  ) {
+    return this.service.setPrimary(companyId, contactId);
+  }
+
+  @Delete(':contactId')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  remove(
+    @Param('companyId') companyId: string,
+    @Param('contactId') contactId: string,
+  ) {
+    return this.service.softDelete(companyId, contactId);
+  }
+}
+```
+
+- [ ] **Step 2: Write the module**
+
+```typescript
+// apps/api/src/modules/finance-company-contacts/finance-company-contacts.module.ts
+import { Module } from '@nestjs/common';
+import { FinanceCompanyContactsController } from './finance-company-contacts.controller';
+import { FinanceCompanyContactsService } from './finance-company-contacts.service';
+
+@Module({
+  controllers: [FinanceCompanyContactsController],
+  providers: [FinanceCompanyContactsService],
+  exports: [FinanceCompanyContactsService],
+})
+export class FinanceCompanyContactsModule {}
+```
+
+- [ ] **Step 3: Register module in AppModule**
+
+Open `apps/api/src/app.module.ts`, locate the imports list, and add:
+```typescript
+import { FinanceCompanyContactsModule } from './modules/finance-company-contacts/finance-company-contacts.module';
+```
+Add `FinanceCompanyContactsModule` to the `imports: [...]` array next to `FinanceReceivableModule`.
+
+- [ ] **Step 4: Type check**
+
+```bash
+./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/finance-company-contacts/finance-company-contacts.controller.ts apps/api/src/modules/finance-company-contacts/finance-company-contacts.module.ts apps/api/src/app.module.ts
+git commit -m "feat(finance-contact): controller + module wiring"
+```
+
+---
+
+## Task 7: ContactLog DTO
+
+**Files:**
+- Create: `apps/api/src/modules/finance-receivable-contact-logs/dto/finance-receivable-contact-log.dto.ts`
+
+- [ ] **Step 1: Create the DTO file**
+
+```typescript
+// apps/api/src/modules/finance-receivable-contact-logs/dto/finance-receivable-contact-log.dto.ts
+import {
+  IsDateString,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { PartialType } from '@nestjs/mapped-types';
+import { FinanceContactChannel, FinanceContactResult } from '@prisma/client';
+
+export class CreateFinanceContactLogDto {
+  @IsOptional()
+  @IsUUID('4', { message: 'financeCompanyContactId ต้องเป็น UUID' })
+  financeCompanyContactId?: string;
+
+  @IsOptional()
+  @IsEnum(FinanceContactChannel, { message: 'channel ไม่ถูกต้อง' })
+  channel?: FinanceContactChannel;
+
+  @IsEnum(FinanceContactResult, { message: 'result ไม่ถูกต้อง' })
+  result!: FinanceContactResult;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  notes?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'contactedAt ต้องเป็นวันที่ ISO' })
+  contactedAt?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'promisedDate ต้องเป็นวันที่ ISO' })
+  promisedDate?: string;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'promisedAmount ต้องเป็นตัวเลข' })
+  @IsPositive({ message: 'promisedAmount ต้องมากกว่า 0' })
+  promisedAmount?: number;
+}
+
+export class UpdateFinanceContactLogDto extends PartialType(
+  CreateFinanceContactLogDto,
+) {}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable-contact-logs/dto/
+git commit -m "feat(finance-contact-log): add DTOs"
+```
+
+---
+
+## Task 8: ContactLog service — record (with lazy FK resolve + KPI denorm)
+
+**Files:**
+- Create: `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts`
+- Test: `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// finance-receivable-contact-logs.service.spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { FinanceReceivableContactLogsService } from './finance-receivable-contact-logs.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { FinanceContactResult, FinanceContactChannel } from '@prisma/client';
+
+describe('FinanceReceivableContactLogsService — record', () => {
+  let service: FinanceReceivableContactLogsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      financeReceivable: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      externalFinanceCompany: {
+        upsert: jest.fn(),
+      },
+      financeReceivableContactLog: {
+        create: jest.fn(),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        FinanceReceivableContactLogsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = mod.get(FinanceReceivableContactLogsService);
+  });
+
+  it('throws NotFound when receivable does not exist', async () => {
+    prisma.financeReceivable.findFirst.mockResolvedValue(null);
+    await expect(
+      service.record('rec-1', 'user-1', {
+        result: FinanceContactResult.ANSWERED,
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('lazy-upserts ExternalFinanceCompany when FK is null', async () => {
+    prisma.financeReceivable.findFirst.mockResolvedValue({
+      id: 'rec-1',
+      externalFinanceCompanyId: null,
+      financeCompany: 'KTC Finance',
+      contactAttemptCount: 0,
+      lastPromisedDate: null,
+    });
+    prisma.externalFinanceCompany.upsert.mockResolvedValue({ id: 'co-new' });
+    prisma.financeReceivableContactLog.create.mockResolvedValue({ id: 'log-1' });
+    prisma.financeReceivable.update.mockResolvedValue({});
+
+    await service.record('rec-1', 'user-1', {
+      result: FinanceContactResult.ANSWERED,
+    });
+
+    expect(prisma.externalFinanceCompany.upsert).toHaveBeenCalled();
+    const created = prisma.financeReceivableContactLog.create.mock.calls[0][0].data;
+    expect(created.externalFinanceCompanyId).toBe('co-new');
+  });
+
+  it('updates KPI denorm: lastContactedAt + contactAttemptCount + lastPromisedDate when PROMISED', async () => {
+    prisma.financeReceivable.findFirst.mockResolvedValue({
+      id: 'rec-1',
+      externalFinanceCompanyId: 'co-1',
+      financeCompany: 'KTC',
+      contactAttemptCount: 2,
+      lastPromisedDate: null,
+    });
+    prisma.financeReceivableContactLog.create.mockResolvedValue({ id: 'log-1' });
+    prisma.financeReceivable.update.mockResolvedValue({});
+
+    await service.record('rec-1', 'user-1', {
+      result: FinanceContactResult.PROMISED,
+      promisedDate: '2026-06-15',
+      promisedAmount: 12000,
+    });
+
+    const updateArg = prisma.financeReceivable.update.mock.calls[0][0];
+    expect(updateArg.where.id).toBe('rec-1');
+    expect(updateArg.data.contactAttemptCount).toBe(3);
+    expect(updateArg.data.lastContactedAt).toBeInstanceOf(Date);
+    expect(updateArg.data.lastPromisedDate).toBeInstanceOf(Date);
+  });
+
+  it('does not overwrite lastPromisedDate when result is not PROMISED', async () => {
+    const existing = new Date('2026-06-01');
+    prisma.financeReceivable.findFirst.mockResolvedValue({
+      id: 'rec-1',
+      externalFinanceCompanyId: 'co-1',
+      financeCompany: 'KTC',
+      contactAttemptCount: 1,
+      lastPromisedDate: existing,
+    });
+    prisma.financeReceivableContactLog.create.mockResolvedValue({ id: 'log-1' });
+
+    await service.record('rec-1', 'user-1', {
+      result: FinanceContactResult.NO_ANSWER,
+    });
+
+    const updateArg = prisma.financeReceivable.update.mock.calls[0][0];
+    expect(updateArg.data.lastPromisedDate).toEqual(existing);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/api && npx jest finance-receivable-contact-logs.service.spec
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the service (record method first; other methods stubbed)**
+
+```typescript
+// apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { FinanceContactResult, Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  CreateFinanceContactLogDto,
+  UpdateFinanceContactLogDto,
+} from './dto/finance-receivable-contact-log.dto';
+import { normalizeFinanceCompanyName } from './finance-company-name-normalizer.util';
+
+@Injectable()
+export class FinanceReceivableContactLogsService {
+  constructor(private prisma: PrismaService) {}
+
+  async record(
+    receivableId: string,
+    userId: string,
+    dto: CreateFinanceContactLogDto,
+  ) {
+    const receivable = await this.prisma.financeReceivable.findFirst({
+      where: { id: receivableId, deletedAt: null },
+      select: {
+        id: true,
+        externalFinanceCompanyId: true,
+        financeCompany: true,
+        contactAttemptCount: true,
+        lastPromisedDate: true,
+      },
+    });
+    if (!receivable) throw new NotFoundException('ไม่พบรายการเงินรับจากไฟแนนซ์');
+
+    return this.prisma.$transaction(async (tx) => {
+      let companyId = receivable.externalFinanceCompanyId;
+
+      // D6: lazy resolve — upsert ExternalFinanceCompany if receivable has no FK yet
+      if (!companyId) {
+        const normalized = normalizeFinanceCompanyName(receivable.financeCompany);
+        const company = await tx.externalFinanceCompany.upsert({
+          where: { name: receivable.financeCompany },
+          create: {
+            name: receivable.financeCompany,
+            isActive: true,
+          },
+          update: {},
+        });
+        companyId = company.id;
+        await tx.financeReceivable.update({
+          where: { id: receivableId },
+          data: { externalFinanceCompanyId: companyId },
+        });
+        // suppress unused-var warning for `normalized` until backfill script reuses it
+        void normalized;
+      }
+
+      const contactedAt = dto.contactedAt ? new Date(dto.contactedAt) : new Date();
+      const log = await tx.financeReceivableContactLog.create({
+        data: {
+          financeReceivableId: receivableId,
+          externalFinanceCompanyId: companyId!,
+          financeCompanyContactId: dto.financeCompanyContactId,
+          contactedById: userId,
+          contactedAt,
+          channel: dto.channel ?? 'CALL',
+          result: dto.result,
+          notes: dto.notes,
+          promisedDate: dto.promisedDate ? new Date(dto.promisedDate) : null,
+          promisedAmount: dto.promisedAmount ?? null,
+        },
+      });
+
+      // KPI denorm update
+      const nextLastPromised =
+        dto.result === FinanceContactResult.PROMISED && dto.promisedDate
+          ? new Date(dto.promisedDate)
+          : receivable.lastPromisedDate;
+
+      await tx.financeReceivable.update({
+        where: { id: receivableId },
+        data: {
+          lastContactedAt: contactedAt,
+          lastPromisedDate: nextLastPromised,
+          contactAttemptCount: { increment: 1 },
+        },
+      });
+
+      return log;
+    });
+  }
+
+  // stubs — implemented in Task 9
+  async list(_receivableId: string) {
+    return [];
+  }
+  async update(
+    _receivableId: string,
+    _logId: string,
+    _userId: string,
+    _userRole: string,
+    _dto: UpdateFinanceContactLogDto,
+  ) {
+    throw new ForbiddenException('Not implemented');
+  }
+  async softDelete(_receivableId: string, _logId: string) {
+    throw new ForbiddenException('Not implemented');
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/api && npx jest finance-receivable-contact-logs.service.spec
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable-contact-logs/
+git commit -m "feat(finance-contact-log): record with lazy FK resolve + KPI denorm"
+```
+
+---
+
+## Task 9: ContactLog service — list / update / softDelete + aggregation
+
+**Files:**
+- Modify: `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts`
+- Modify: `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts`
+
+- [ ] **Step 1: Add failing tests for list / update / softDelete / summary**
+
+Append to the existing `.spec.ts`:
+
+```typescript
+describe('FinanceReceivableContactLogsService — list/update/delete', () => {
+  let service: FinanceReceivableContactLogsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      financeReceivableContactLog: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+      financeReceivable: { findFirst: jest.fn(), update: jest.fn() },
+      externalFinanceCompany: { findFirst: jest.fn() },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        FinanceReceivableContactLogsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = mod.get(FinanceReceivableContactLogsService);
+  });
+
+  it('list returns logs ordered newest first with contact + user joined', async () => {
+    prisma.financeReceivableContactLog.findMany.mockResolvedValue([]);
+    await service.list('rec-1');
+    const arg = prisma.financeReceivableContactLog.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ financeReceivableId: 'rec-1', deletedAt: null });
+    expect(arg.orderBy).toEqual({ contactedAt: 'desc' });
+    expect(arg.include).toMatchObject({
+      contact: { select: expect.any(Object) },
+      contactedBy: { select: expect.any(Object) },
+    });
+  });
+
+  it('update rejects when user is not author + not OWNER/FINANCE_MANAGER', async () => {
+    prisma.financeReceivableContactLog.findFirst.mockResolvedValue({
+      id: 'log-1',
+      contactedById: 'other-user',
+      createdAt: new Date(),
+    });
+    await expect(
+      service.update('rec-1', 'log-1', 'user-1', 'ACCOUNTANT', { notes: 'x' }),
+    ).rejects.toThrow(/แก้ไขได้เฉพาะเจ้าของ/);
+  });
+
+  it('update rejects when own log but past 24h window', async () => {
+    const old = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    prisma.financeReceivableContactLog.findFirst.mockResolvedValue({
+      id: 'log-1',
+      contactedById: 'user-1',
+      createdAt: old,
+    });
+    await expect(
+      service.update('rec-1', 'log-1', 'user-1', 'ACCOUNTANT', { notes: 'x' }),
+    ).rejects.toThrow(/24/);
+  });
+
+  it('update allows OWNER any time', async () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    prisma.financeReceivableContactLog.findFirst.mockResolvedValue({
+      id: 'log-1',
+      contactedById: 'someone',
+      createdAt: old,
+    });
+    prisma.financeReceivableContactLog.update.mockResolvedValue({});
+    await expect(
+      service.update('rec-1', 'log-1', 'owner-1', 'OWNER', { notes: 'x' }),
+    ).resolves.toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/api && npx jest finance-receivable-contact-logs.service.spec
+```
+
+Expected: 4 new tests FAIL.
+
+- [ ] **Step 3: Replace stubs with real implementations**
+
+Replace the stub methods at the bottom of `finance-receivable-contact-logs.service.ts` with:
+
+```typescript
+  async list(receivableId: string) {
+    return this.prisma.financeReceivableContactLog.findMany({
+      where: { financeReceivableId: receivableId, deletedAt: null },
+      orderBy: { contactedAt: 'desc' },
+      include: {
+        contact: { select: { id: true, name: true, position: true, phone: true } },
+        contactedBy: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  async update(
+    receivableId: string,
+    logId: string,
+    userId: string,
+    userRole: string,
+    dto: UpdateFinanceContactLogDto,
+  ) {
+    const log = await this.prisma.financeReceivableContactLog.findFirst({
+      where: { id: logId, financeReceivableId: receivableId, deletedAt: null },
+    });
+    if (!log) throw new NotFoundException('ไม่พบบันทึกการติดต่อ');
+
+    const isPrivileged = userRole === 'OWNER' || userRole === 'FINANCE_MANAGER';
+    if (!isPrivileged) {
+      if (log.contactedById !== userId) {
+        throw new ForbiddenException('แก้ไขได้เฉพาะเจ้าของ log');
+      }
+      const ageMs = Date.now() - new Date(log.createdAt).getTime();
+      if (ageMs > 24 * 60 * 60 * 1000) {
+        throw new ForbiddenException('เกิน 24 ชั่วโมง ไม่สามารถแก้ไขได้');
+      }
+    }
+
+    return this.prisma.financeReceivableContactLog.update({
+      where: { id: logId },
+      data: {
+        notes: dto.notes,
+        result: dto.result,
+        channel: dto.channel,
+        financeCompanyContactId: dto.financeCompanyContactId,
+        promisedDate: dto.promisedDate ? new Date(dto.promisedDate) : undefined,
+        promisedAmount: dto.promisedAmount,
+        contactedAt: dto.contactedAt ? new Date(dto.contactedAt) : undefined,
+      },
+    });
+  }
+
+  async softDelete(receivableId: string, logId: string) {
+    const log = await this.prisma.financeReceivableContactLog.findFirst({
+      where: { id: logId, financeReceivableId: receivableId, deletedAt: null },
+    });
+    if (!log) throw new NotFoundException('ไม่พบบันทึกการติดต่อ');
+
+    await this.prisma.financeReceivableContactLog.update({
+      where: { id: logId },
+      data: { deletedAt: new Date() },
+    });
+
+    // Recompute KPI from remaining logs
+    const remaining = await this.prisma.financeReceivableContactLog.findMany({
+      where: { financeReceivableId: receivableId, deletedAt: null },
+      orderBy: { contactedAt: 'desc' },
+      take: 100,
+    });
+    const lastContactedAt = remaining[0]?.contactedAt ?? null;
+    const lastPromised = remaining.find(
+      (l) => l.result === 'PROMISED' && l.promisedDate,
+    );
+    await this.prisma.financeReceivable.update({
+      where: { id: receivableId },
+      data: {
+        lastContactedAt,
+        lastPromisedDate: lastPromised?.promisedDate ?? null,
+        contactAttemptCount: remaining.length,
+      },
+    });
+    return { ok: true };
+  }
+
+  async companyContactSummary(companyId: string) {
+    const [receivableCount, totalOutstandingAgg, lastLog, brokenCount, keptCount] =
+      await Promise.all([
+        this.prisma.financeReceivable.count({
+          where: { externalFinanceCompanyId: companyId, deletedAt: null },
+        }),
+        this.prisma.financeReceivable.aggregate({
+          where: {
+            externalFinanceCompanyId: companyId,
+            deletedAt: null,
+            status: { in: ['PENDING', 'OVERDUE', 'DISPUTED', 'PARTIALLY_RECEIVED'] },
+          },
+          _sum: { netExpectedAmount: true, receivedAmount: true },
+        }),
+        this.prisma.financeReceivableContactLog.findFirst({
+          where: { externalFinanceCompanyId: companyId, deletedAt: null },
+          orderBy: { contactedAt: 'desc' },
+          select: { contactedAt: true },
+        }),
+        this.prisma.financeReceivableContactLog.count({
+          where: {
+            externalFinanceCompanyId: companyId,
+            deletedAt: null,
+            promisedBrokenAt: { not: null },
+          },
+        }),
+        this.prisma.financeReceivableContactLog.count({
+          where: {
+            externalFinanceCompanyId: companyId,
+            deletedAt: null,
+            promisedKeptAt: { not: null },
+          },
+        }),
+      ]);
+
+    return {
+      receivableCount,
+      totalOutstanding: totalOutstandingAgg._sum.netExpectedAmount ?? 0,
+      lastContactedAt: lastLog?.contactedAt ?? null,
+      brokenPromiseCount: brokenCount,
+      keptPromiseCount: keptCount,
+    };
+  }
+
+  async companyContactLogs(companyId: string, page = 1, limit = 20) {
+    const safeLimit = Math.min(100, Math.max(1, limit));
+    const safePage = Math.max(1, page);
+    const [data, total] = await Promise.all([
+      this.prisma.financeReceivableContactLog.findMany({
+        where: { externalFinanceCompanyId: companyId, deletedAt: null },
+        orderBy: { contactedAt: 'desc' },
+        include: {
+          receivable: { select: { id: true, financeRefNumber: true, expectedAmount: true } },
+          contact: { select: { id: true, name: true, position: true } },
+          contactedBy: { select: { id: true, name: true } },
+        },
+        skip: (safePage - 1) * safeLimit,
+        take: safeLimit,
+      }),
+      this.prisma.financeReceivableContactLog.count({
+        where: { externalFinanceCompanyId: companyId, deletedAt: null },
+      }),
+    ]);
+    return { data, total, page: safePage, limit: safeLimit };
+  }
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd apps/api && npx jest finance-receivable-contact-logs.service.spec
+```
+
+Expected: all tests PASS (including new 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.ts apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.service.spec.ts
+git commit -m "feat(finance-contact-log): list/update/delete + aggregation"
+```
+
+---
+
+## Task 10: ContactLog controller + module + wire to AppModule
+
+**Files:**
+- Create: `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.controller.ts`
+- Create: `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts`
+- Modify: `apps/api/src/app.module.ts`
+
+- [ ] **Step 1: Write controller**
+
+```typescript
+// apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.controller.ts
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { FinanceReceivableContactLogsService } from './finance-receivable-contact-logs.service';
+import {
+  CreateFinanceContactLogDto,
+  UpdateFinanceContactLogDto,
+} from './dto/finance-receivable-contact-log.dto';
+
+@ApiTags('Finance Contact Logs')
+@ApiBearerAuth('JWT')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller()
+export class FinanceReceivableContactLogsController {
+  constructor(private readonly service: FinanceReceivableContactLogsService) {}
+
+  @Get('finance-receivable/:receivableId/contact-logs')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  list(@Param('receivableId') receivableId: string) {
+    return this.service.list(receivableId);
+  }
+
+  @Post('finance-receivable/:receivableId/contact-logs')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  record(
+    @Param('receivableId') receivableId: string,
+    @Body() dto: CreateFinanceContactLogDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.service.record(receivableId, req.user.id, dto);
+  }
+
+  @Patch('finance-receivable/:receivableId/contact-logs/:logId')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  update(
+    @Param('receivableId') receivableId: string,
+    @Param('logId') logId: string,
+    @Body() dto: UpdateFinanceContactLogDto,
+    @Request() req: { user: { id: string; role: string } },
+  ) {
+    return this.service.update(receivableId, logId, req.user.id, req.user.role, dto);
+  }
+
+  @Delete('finance-receivable/:receivableId/contact-logs/:logId')
+  @Roles('OWNER', 'FINANCE_MANAGER')
+  remove(
+    @Param('receivableId') receivableId: string,
+    @Param('logId') logId: string,
+  ) {
+    return this.service.softDelete(receivableId, logId);
+  }
+
+  @Get('external-finance/companies/:companyId/contact-summary')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  summary(@Param('companyId') companyId: string) {
+    return this.service.companyContactSummary(companyId);
+  }
+
+  @Get('external-finance/companies/:companyId/contact-logs')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  companyLogs(
+    @Param('companyId') companyId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.service.companyContactLogs(
+      companyId,
+      page ? parseInt(page, 10) : 1,
+      limit ? parseInt(limit, 10) : 20,
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Write the module**
+
+```typescript
+// apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts
+import { Module } from '@nestjs/common';
+import { FinanceReceivableContactLogsController } from './finance-receivable-contact-logs.controller';
+import { FinanceReceivableContactLogsService } from './finance-receivable-contact-logs.service';
+
+@Module({
+  controllers: [FinanceReceivableContactLogsController],
+  providers: [FinanceReceivableContactLogsService],
+  exports: [FinanceReceivableContactLogsService],
+})
+export class FinanceReceivableContactLogsModule {}
+```
+
+- [ ] **Step 3: Register in AppModule**
+
+In `apps/api/src/app.module.ts`:
+```typescript
+import { FinanceReceivableContactLogsModule } from './modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module';
+```
+Add `FinanceReceivableContactLogsModule` to the `imports` array.
+
+- [ ] **Step 4: Type check**
+
+```bash
+./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.controller.ts apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts apps/api/src/app.module.ts
+git commit -m "feat(finance-contact-log): controller + module wiring"
+```
+
+---
+
+## Task 11: broken-promise-finance.cron.ts
+
+**Files:**
+- Create: `apps/api/src/modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.ts`
+- Test: `apps/api/src/modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.spec.ts`
+- Modify: `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts` (register provider)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// broken-promise-finance.cron.spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { BrokenPromiseFinanceCron } from './broken-promise-finance.cron';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+describe('BrokenPromiseFinanceCron', () => {
+  let cron: BrokenPromiseFinanceCron;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = { $executeRaw: jest.fn().mockResolvedValue(7) };
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        BrokenPromiseFinanceCron,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    cron = mod.get(BrokenPromiseFinanceCron);
+  });
+
+  it('marks broken promises and returns the affected count', async () => {
+    const result = await cron.handleCron();
+    expect(prisma.$executeRaw).toHaveBeenCalled();
+    expect(result).toBe(7);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest broken-promise-finance.cron.spec
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the cron**
+
+```typescript
+// apps/api/src/modules/finance-receivable-contact-logs/crons/broken-promise-finance.cron.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+@Injectable()
+export class BrokenPromiseFinanceCron {
+  private readonly logger = new Logger(BrokenPromiseFinanceCron.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  // Daily at 02:00 Asia/Bangkok
+  @Cron('0 2 * * *', { timeZone: 'Asia/Bangkok' })
+  async handleCron(): Promise<number> {
+    const affected = await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE finance_receivable_contact_logs
+      SET promised_broken_at = now()
+      WHERE promised_date < CURRENT_DATE
+        AND promised_broken_at IS NULL
+        AND promised_kept_at IS NULL
+        AND result = 'PROMISED'
+        AND deleted_at IS NULL
+        AND finance_receivable_id IN (
+          SELECT id FROM finance_receivables
+          WHERE status NOT IN ('RECEIVED', 'PARTIALLY_RECEIVED')
+            AND deleted_at IS NULL
+        )
+    `);
+    this.logger.log(`broken-promise-finance: marked ${affected} logs as broken`);
+    return Number(affected);
+  }
+}
+```
+
+- [ ] **Step 4: Register provider in module**
+
+Open `apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts` and add cron to providers:
+
+```typescript
+import { BrokenPromiseFinanceCron } from './crons/broken-promise-finance.cron';
+// ...
+@Module({
+  controllers: [FinanceReceivableContactLogsController],
+  providers: [FinanceReceivableContactLogsService, BrokenPromiseFinanceCron],
+  exports: [FinanceReceivableContactLogsService],
+})
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd apps/api && npx jest broken-promise-finance.cron.spec
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable-contact-logs/crons/ apps/api/src/modules/finance-receivable-contact-logs/finance-receivable-contact-logs.module.ts
+git commit -m "feat(finance-contact-log): broken-promise daily cron"
+```
+
+---
+
+## Task 12: Wire `promisedKeptAt` into `FinanceReceivableService.recordReceive`
+
+**Files:**
+- Modify: `apps/api/src/modules/finance-receivable/finance-receivable.service.ts`
+- Modify: `apps/api/src/modules/finance-receivable/finance-receivable.service.spec.ts`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `finance-receivable.service.spec.ts`:
+
+```typescript
+describe('recordReceive — promisedKeptAt hook', () => {
+  it('marks open PROMISED logs as kept when payment is received on/before promised date', async () => {
+    const today = new Date('2026-05-31');
+    prisma.financeReceivable.findFirst.mockResolvedValue({
+      id: 'rec-1',
+      status: 'PENDING',
+      netExpectedAmount: 10000,
+      receivedAmount: 0,
+      deletedAt: null,
+    });
+    prisma.financeReceivable.update.mockResolvedValue({ id: 'rec-1' });
+    prisma.financeReceivableContactLog = {
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    };
+    prisma.$transaction = jest.fn().mockImplementation(async (fn) => fn(prisma));
+
+    await service.recordReceive(
+      'rec-1',
+      { receivedAmount: 10000, receivedDate: today.toISOString() },
+      'user-1',
+    );
+
+    expect(prisma.financeReceivableContactLog.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          financeReceivableId: 'rec-1',
+          result: 'PROMISED',
+          promisedKeptAt: null,
+          promisedBrokenAt: null,
+          promisedDate: { gte: expect.any(Date) },
+        }),
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api && npx jest finance-receivable.service.spec
+```
+
+Expected: the new test FAILS.
+
+- [ ] **Step 3: Modify `recordReceive` to mark `promisedKeptAt`**
+
+Open `apps/api/src/modules/finance-receivable/finance-receivable.service.ts` and locate `recordReceive`. After the `this.prisma.financeReceivable.update(...)` call, wrap the whole logic in `$transaction` if not already, then add the promise-kept hook. Example diff:
+
+```typescript
+async recordReceive(id: string, dto: RecordReceiveDto, recordedById: string) {
+  const record = await this.prisma.financeReceivable.findFirst({
+    where: { id, deletedAt: null },
+  });
+  if (!record) throw new NotFoundException('ไม่พบรายการเงินรับจากไฟแนนซ์');
+
+  const receivedDate = new Date(dto.receivedDate);
+
+  return this.prisma.$transaction(async (tx) => {
+    const updated = await tx.financeReceivable.update({
+      where: { id },
+      data: {
+        receivedAmount: dto.receivedAmount,
+        receivedDate,
+        bankRef: dto.bankRef,
+        note: dto.note,
+        recordedById,
+        status:
+          dto.receivedAmount >= Number(record.netExpectedAmount)
+            ? 'RECEIVED'
+            : 'PARTIALLY_RECEIVED',
+      },
+    });
+
+    // mark open PROMISED logs as kept if receivedDate <= promisedDate
+    await tx.financeReceivableContactLog.updateMany({
+      where: {
+        financeReceivableId: id,
+        deletedAt: null,
+        result: 'PROMISED',
+        promisedKeptAt: null,
+        promisedBrokenAt: null,
+        promisedDate: { gte: receivedDate },
+      },
+      data: { promisedKeptAt: receivedDate },
+    });
+
+    return updated;
+  });
+}
+```
+
+> If the existing `recordReceive` has additional logic (journal, audit), preserve it inside the transaction — wrap only, don't rewrite.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd apps/api && npx jest finance-receivable.service.spec
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable/
+git commit -m "feat(finance-receivable): mark promisedKeptAt on receive"
+```
+
+---
+
+## Task 13: Update `sales.service.ts` to resolve FK at FinanceReceivable creation
+
+**Files:**
+- Modify: `apps/api/src/modules/sales/sales.service.ts` (lines ~626 and ~715)
+
+- [ ] **Step 1: Add helper at the top of the class (after `constructor`)**
+
+```typescript
+  private async resolveExternalFinanceCompanyId(
+    tx: Prisma.TransactionClient,
+    name: string,
+  ): Promise<string> {
+    const company = await tx.externalFinanceCompany.upsert({
+      where: { name },
+      create: { name, isActive: true },
+      update: {},
+    });
+    return company.id;
+  }
+```
+
+If `Prisma` isn't already imported, add to imports:
+```typescript
+import { Prisma } from '@prisma/client';
+```
+
+- [ ] **Step 2: Update the BESTCHOICE FINANCE creation (around line 626)**
+
+Replace:
+```typescript
+      await tx.financeReceivable.create({
+        data: {
+          saleId: sale.id,
+          branchId: dto.branchId,
+          financeCompany: 'BESTCHOICE FINANCE',
+          expectedAmount: calc.principal + calc.storeCommission,
+          ...
+```
+
+With:
+```typescript
+      const bcFinanceId = await this.resolveExternalFinanceCompanyId(tx, 'BESTCHOICE FINANCE');
+      await tx.financeReceivable.create({
+        data: {
+          saleId: sale.id,
+          branchId: dto.branchId,
+          financeCompany: 'BESTCHOICE FINANCE',
+          externalFinanceCompanyId: bcFinanceId,
+          expectedAmount: calc.principal + calc.storeCommission,
+          ...
+```
+
+- [ ] **Step 3: Update the external finance creation (around line 715)**
+
+Replace:
+```typescript
+      await tx.financeReceivable.create({
+        data: {
+          saleId: sale.id,
+          branchId: dto.branchId,
+          financeCompany: dto.financeCompany!,
+          ...
+```
+
+With:
+```typescript
+      const extFinanceId = await this.resolveExternalFinanceCompanyId(tx, dto.financeCompany!);
+      await tx.financeReceivable.create({
+        data: {
+          saleId: sale.id,
+          branchId: dto.branchId,
+          financeCompany: dto.financeCompany!,
+          externalFinanceCompanyId: extFinanceId,
+          ...
+```
+
+- [ ] **Step 4: Type check**
+
+```bash
+./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 5: Run existing sales tests**
+
+```bash
+cd apps/api && npx jest sales.service.spec
+```
+
+Expected: existing tests PASS (no behaviour change beyond extra field write).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/sales/sales.service.ts
+git commit -m "feat(sales): resolve external-finance FK on FinanceReceivable create"
+```
+
+---
+
+## Task 14: Update `FinanceReceivableService.findAll` + `findOne` to include new fields
+
+**Files:**
+- Modify: `apps/api/src/modules/finance-receivable/finance-receivable.service.ts`
+
+- [ ] **Step 1: Expand `findAll` include**
+
+Locate the `include:` block in `findAll`. Add `lastContactedAt`, `lastPromisedDate`, `contactAttemptCount` to the implicit field selection (they come automatically since no `select:` is used; just verify they exist on the returned shape).
+
+Add `externalFinanceCompanyId` to the `where` filter when caller passes a new `companyId` query string. Add this to the destructured filter argument:
+
+```typescript
+async findAll(filters: {
+  // ... existing fields
+  externalFinanceCompanyId?: string;
+  brokenPromiseOnly?: boolean;
+}) {
+  const { externalFinanceCompanyId, brokenPromiseOnly, ...rest } = filters;
+  // ... existing logic
+  if (externalFinanceCompanyId) where.externalFinanceCompanyId = externalFinanceCompanyId;
+  if (brokenPromiseOnly) {
+    where.contactLogs = {
+      some: {
+        promisedBrokenAt: { not: null },
+        promisedKeptAt: null,
+        deletedAt: null,
+      },
+    };
+  }
+  // ... rest
+}
+```
+
+- [ ] **Step 2: Expose query params in controller**
+
+Open `apps/api/src/modules/finance-receivable/finance-receivable.controller.ts`. Add to `findAll(...)` signature:
+
+```typescript
+    @Query('externalFinanceCompanyId') externalFinanceCompanyId?: string,
+    @Query('brokenPromiseOnly') brokenPromiseOnly?: string,
+```
+
+And pass to service:
+```typescript
+    return this.service.findAll({
+      // ... existing
+      externalFinanceCompanyId,
+      brokenPromiseOnly: brokenPromiseOnly === 'true',
+    });
+```
+
+- [ ] **Step 3: Type check**
+
+```bash
+./tools/check-types.sh api
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/modules/finance-receivable/
+git commit -m "feat(finance-receivable): support externalFinanceCompanyId + brokenPromiseOnly filter"
+```
+
+---
+
+## Task 15: Backfill script
+
+**Files:**
+- Create: `apps/api/scripts/backfill-external-finance-fk.ts`
+- Modify: `apps/api/package.json` (add npm script)
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+// apps/api/scripts/backfill-external-finance-fk.ts
+import { PrismaClient } from '@prisma/client';
+import { normalizeFinanceCompanyName } from '../src/modules/finance-receivable-contact-logs/finance-company-name-normalizer.util';
+
+const prisma = new PrismaClient();
+
+interface Report {
+  receivablesMatched: number;
+  receivablesNewCompany: number;
+  contactsMigrated: number;
+  contactsSkipped: number;
+}
+
+async function main(): Promise<Report> {
+  const report: Report = {
+    receivablesMatched: 0,
+    receivablesNewCompany: 0,
+    contactsMigrated: 0,
+    contactsSkipped: 0,
+  };
+
+  // Step 1: index existing ExternalFinanceCompany by normalized name
+  const allCompanies = await prisma.externalFinanceCompany.findMany({
+    where: { deletedAt: null },
+  });
+  const byNormName = new Map<string, string>();
+  for (const c of allCompanies) {
+    byNormName.set(normalizeFinanceCompanyName(c.name), c.id);
+  }
+
+  // Step 2: resolve FK on every receivable that lacks one
+  const orphans = await prisma.financeReceivable.findMany({
+    where: { externalFinanceCompanyId: null, deletedAt: null },
+    select: { id: true, financeCompany: true },
+  });
+
+  for (const r of orphans) {
+    const norm = normalizeFinanceCompanyName(r.financeCompany);
+    let companyId = byNormName.get(norm);
+    if (!companyId) {
+      const created = await prisma.externalFinanceCompany.create({
+        data: { name: r.financeCompany, isActive: true },
+      });
+      companyId = created.id;
+      byNormName.set(norm, companyId);
+      report.receivablesNewCompany += 1;
+    } else {
+      report.receivablesMatched += 1;
+    }
+    await prisma.financeReceivable.update({
+      where: { id: r.id },
+      data: { externalFinanceCompanyId: companyId },
+    });
+  }
+
+  // Step 3: migrate contactPerson/contactPhone → FinanceCompanyContact (idempotent)
+  const legacy = await prisma.externalFinanceCompany.findMany({
+    where: { deletedAt: null, contactPerson: { not: null } },
+  });
+  for (const co of legacy) {
+    const existingPrimary = await prisma.financeCompanyContact.findFirst({
+      where: { externalFinanceCompanyId: co.id, isPrimary: true, deletedAt: null },
+    });
+    if (existingPrimary) {
+      report.contactsSkipped += 1;
+      continue;
+    }
+    await prisma.financeCompanyContact.create({
+      data: {
+        externalFinanceCompanyId: co.id,
+        name: co.contactPerson!,
+        phone: co.contactPhone,
+        isPrimary: true,
+        isActive: true,
+      },
+    });
+    report.contactsMigrated += 1;
+  }
+
+  return report;
+}
+
+main()
+  .then((report) => {
+    console.log('Backfill report:', JSON.stringify(report, null, 2));
+    return prisma.$disconnect();
+  })
+  .catch(async (err) => {
+    console.error(err);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+```
+
+- [ ] **Step 2: Add npm script**
+
+Open `apps/api/package.json`. Inside `"scripts": {...}` add:
+```json
+    "backfill:external-finance": "tsx scripts/backfill-external-finance-fk.ts",
+```
+
+(If `tsx` is not already a devDependency, use `ts-node` instead — check the existing `package.json` for how other one-off scripts run.)
+
+- [ ] **Step 3: Dry-run against dev DB**
+
+```bash
+cd apps/api && npm run backfill:external-finance
+```
+
+Expected: report printed showing counts. Exit code 0.
+
+- [ ] **Step 4: Verify rerun is idempotent**
+
+```bash
+cd apps/api && npm run backfill:external-finance
+```
+
+Expected: report shows `receivablesMatched=0`, `receivablesNewCompany=0`, all `contactsMigrated=0`, all `contactsSkipped` (since primary already exists).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/scripts/ apps/api/package.json
+git commit -m "feat(scripts): backfill external-finance FK + primary contact"
+```
+
+---
+
+## Task 16: Frontend — typed API wrappers + query keys
+
+**Files:**
+- Create: `apps/web/src/lib/api/finance-contacts.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+// apps/web/src/lib/api/finance-contacts.ts
+import api from '@/lib/api';
+
+export interface FinanceCompanyContact {
+  id: string;
+  name: string;
+  position: string | null;
+  department: string | null;
+  phone: string | null;
+  email: string | null;
+  lineId: string | null;
+  notes: string | null;
+  isPrimary: boolean;
+  isActive: boolean;
+}
+
+export interface FinanceContactLog {
+  id: string;
+  contactedAt: string;
+  channel: 'CALL' | 'EMAIL' | 'LINE' | 'MEETING' | 'OTHER';
+  result: 'ANSWERED' | 'NO_ANSWER' | 'PROMISED' | 'DISPUTED' | 'REQUESTED_DOCS' | 'OTHER';
+  notes: string | null;
+  promisedDate: string | null;
+  promisedAmount: string | null;
+  promisedBrokenAt: string | null;
+  promisedKeptAt: string | null;
+  contact: { id: string; name: string; position: string | null; phone: string | null } | null;
+  contactedBy: { id: string; name: string };
+}
+
+export interface CompanyContactSummary {
+  receivableCount: number;
+  totalOutstanding: number;
+  lastContactedAt: string | null;
+  brokenPromiseCount: number;
+  keptPromiseCount: number;
+}
+
+export const financeContactKeys = {
+  all: ['finance-contacts'] as const,
+  companyContacts: (companyId: string) =>
+    [...financeContactKeys.all, 'company', companyId, 'contacts'] as const,
+  receivableLogs: (receivableId: string) =>
+    [...financeContactKeys.all, 'receivable', receivableId, 'logs'] as const,
+  companySummary: (companyId: string) =>
+    [...financeContactKeys.all, 'company', companyId, 'summary'] as const,
+  companyLogs: (companyId: string, page: number) =>
+    [...financeContactKeys.all, 'company', companyId, 'logs', page] as const,
+};
+
+export const financeContactApi = {
+  listContacts: (companyId: string) =>
+    api.get<FinanceCompanyContact[]>(`/external-finance/companies/${companyId}/contacts`).then((r) => r.data),
+  createContact: (companyId: string, payload: Partial<FinanceCompanyContact>) =>
+    api.post(`/external-finance/companies/${companyId}/contacts`, payload).then((r) => r.data),
+  updateContact: (companyId: string, contactId: string, payload: Partial<FinanceCompanyContact>) =>
+    api.patch(`/external-finance/companies/${companyId}/contacts/${contactId}`, payload).then((r) => r.data),
+  deleteContact: (companyId: string, contactId: string) =>
+    api.delete(`/external-finance/companies/${companyId}/contacts/${contactId}`).then((r) => r.data),
+  setPrimary: (companyId: string, contactId: string) =>
+    api.post(`/external-finance/companies/${companyId}/contacts/${contactId}/set-primary`).then((r) => r.data),
+
+  listLogs: (receivableId: string) =>
+    api.get<FinanceContactLog[]>(`/finance-receivable/${receivableId}/contact-logs`).then((r) => r.data),
+  recordLog: (
+    receivableId: string,
+    payload: {
+      financeCompanyContactId?: string;
+      result: FinanceContactLog['result'];
+      channel?: FinanceContactLog['channel'];
+      notes?: string;
+      promisedDate?: string;
+      promisedAmount?: number;
+    },
+  ) => api.post(`/finance-receivable/${receivableId}/contact-logs`, payload).then((r) => r.data),
+
+  companySummary: (companyId: string) =>
+    api.get<CompanyContactSummary>(`/external-finance/companies/${companyId}/contact-summary`).then((r) => r.data),
+  companyLogs: (companyId: string, page = 1, limit = 20) =>
+    api
+      .get(`/external-finance/companies/${companyId}/contact-logs`, { params: { page, limit } })
+      .then((r) => r.data),
+};
+```
+
+- [ ] **Step 2: Type check**
+
+```bash
+./tools/check-types.sh web
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/finance-contacts.ts
+git commit -m "feat(web): finance contacts API wrappers + query keys"
+```
+
+---
+
+## Task 17: FinanceContactLogDialog component
+
+**Files:**
+- Create: `apps/web/src/pages/FinanceReceivablePage/FinanceContactLogDialog.tsx`
+
+- [ ] **Step 1: Create the dialog**
+
+```tsx
+// apps/web/src/pages/FinanceReceivablePage/FinanceContactLogDialog.tsx
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import Modal from '@/components/ui/Modal';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import {
+  financeContactApi,
+  financeContactKeys,
+  FinanceContactLog,
+} from '@/lib/api/finance-contacts';
+import { getErrorMessage } from '@/lib/api';
+
+interface Props {
+  receivableId: string;
+  companyId: string;
+  outstanding: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+const RESULT_OPTIONS: Array<{ value: FinanceContactLog['result']; label: string; tone: string }> = [
+  { value: 'ANSWERED', label: 'รับสาย', tone: 'bg-emerald-100 text-emerald-700' },
+  { value: 'NO_ANSWER', label: 'ไม่รับ', tone: 'bg-muted text-muted-foreground' },
+  { value: 'PROMISED', label: 'รับปาก', tone: 'bg-amber-100 text-amber-700' },
+  { value: 'DISPUTED', label: 'โต้แย้ง', tone: 'bg-red-100 text-red-700' },
+  { value: 'REQUESTED_DOCS', label: 'ขอเอกสาร', tone: 'bg-blue-100 text-blue-700' },
+  { value: 'OTHER', label: 'อื่นๆ', tone: 'bg-secondary text-secondary-foreground' },
+];
+
+export default function FinanceContactLogDialog({
+  receivableId,
+  companyId,
+  outstanding,
+  open,
+  onClose,
+}: Props) {
+  const qc = useQueryClient();
+  const [contactId, setContactId] = useState<string | undefined>();
+  const [result, setResult] = useState<FinanceContactLog['result']>('ANSWERED');
+  const [notes, setNotes] = useState('');
+  const [promisedDate, setPromisedDate] = useState('');
+  const [promisedAmount, setPromisedAmount] = useState<string>(String(outstanding));
+
+  const { data: contacts } = useQuery({
+    queryKey: financeContactKeys.companyContacts(companyId),
+    queryFn: () => financeContactApi.listContacts(companyId),
+    enabled: open && !!companyId,
+  });
+
+  const submit = useMutation({
+    mutationFn: () =>
+      financeContactApi.recordLog(receivableId, {
+        financeCompanyContactId: contactId,
+        result,
+        notes: notes.trim() || undefined,
+        promisedDate: result === 'PROMISED' ? promisedDate : undefined,
+        promisedAmount: result === 'PROMISED' ? Number(promisedAmount) : undefined,
+      }),
+    onSuccess: () => {
+      toast.success('บันทึกการติดต่อสำเร็จ');
+      qc.invalidateQueries({ queryKey: financeContactKeys.receivableLogs(receivableId) });
+      qc.invalidateQueries({ queryKey: ['finance-receivable'] });
+      onClose();
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
+  if (!open) return null;
+
+  return (
+    <Modal open={open} onClose={onClose} title="บันทึกการติดต่อไฟแนนซ์">
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-2">ผู้ติดต่อ</label>
+          <select
+            className="w-full px-3 py-2 border border-input rounded-lg bg-background"
+            value={contactId ?? ''}
+            onChange={(e) => setContactId(e.target.value || undefined)}
+          >
+            <option value="">— ไม่ระบุ —</option>
+            {contacts?.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}{c.position ? ` (${c.position})` : ''}{c.isPrimary ? ' ★ ตัวหลัก' : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-2">ผลการติดต่อ</label>
+          <div className="flex flex-wrap gap-2">
+            {RESULT_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setResult(opt.value)}
+                className={`px-3 py-1.5 rounded-full text-sm border ${
+                  result === opt.value
+                    ? `${opt.tone} border-current font-medium`
+                    : 'border-border text-muted-foreground hover:bg-accent'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {result === 'PROMISED' && (
+          <div className="space-y-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+            <div>
+              <label className="block text-sm font-medium mb-1">วันที่นัดโอน</label>
+              <ThaiDateInput value={promisedDate} onChange={setPromisedDate} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">ยอดที่นัด (บาท)</label>
+              <input
+                type="number"
+                className="w-full px-3 py-2 border border-input rounded-lg bg-background"
+                value={promisedAmount}
+                onChange={(e) => setPromisedAmount(e.target.value)}
+                min={0}
+                step={0.01}
+              />
+            </div>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium mb-2">โน้ต</label>
+          <textarea
+            className="w-full px-3 py-2 border border-input rounded-lg bg-background"
+            rows={3}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="รายละเอียดการคุย…"
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onClose}>ยกเลิก</Button>
+          <Button
+            onClick={() => submit.mutate()}
+            disabled={submit.isPending || (result === 'PROMISED' && !promisedDate)}
+          >
+            {submit.isPending ? 'กำลังบันทึก…' : 'บันทึก'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+```
+
+- [ ] **Step 2: Type check**
+
+```bash
+./tools/check-types.sh web
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/pages/FinanceReceivablePage/FinanceContactLogDialog.tsx
+git commit -m "feat(web): FinanceContactLogDialog component"
+```
+
+---
+
+## Task 18: ContactTimeline + FinanceReceivableDetailDrawer
+
+**Files:**
+- Create: `apps/web/src/pages/FinanceReceivablePage/ContactTimeline.tsx`
+- Create: `apps/web/src/pages/FinanceReceivablePage/FinanceReceivableDetailDrawer.tsx`
+
+- [ ] **Step 1: Create the timeline component**
+
+```tsx
+// apps/web/src/pages/FinanceReceivablePage/ContactTimeline.tsx
+import { Badge } from '@/components/ui/badge';
+import { FinanceContactLog } from '@/lib/api/finance-contacts';
+import { formatDateShortThai } from '@/utils/formatters';
+
+const RESULT_LABEL: Record<FinanceContactLog['result'], string> = {
+  ANSWERED: 'รับสาย',
+  NO_ANSWER: 'ไม่รับ',
+  PROMISED: 'รับปาก',
+  DISPUTED: 'โต้แย้ง',
+  REQUESTED_DOCS: 'ขอเอกสาร',
+  OTHER: 'อื่นๆ',
+};
+
+const RESULT_TONE: Record<FinanceContactLog['result'], string> = {
+  ANSWERED: 'bg-emerald-100 text-emerald-700',
+  NO_ANSWER: 'bg-muted text-muted-foreground',
+  PROMISED: 'bg-amber-100 text-amber-700',
+  DISPUTED: 'bg-red-100 text-red-700',
+  REQUESTED_DOCS: 'bg-blue-100 text-blue-700',
+  OTHER: 'bg-secondary text-secondary-foreground',
+};
+
+export default function ContactTimeline({ logs }: { logs: FinanceContactLog[] }) {
+  if (logs.length === 0) {
+    return <p className="text-sm text-muted-foreground py-6 text-center">ยังไม่มีบันทึกการติดต่อ</p>;
+  }
+
+  return (
+    <ol className="relative border-l border-border ml-3 space-y-4">
+      {logs.map((log) => {
+        const promiseBroken = !!log.promisedBrokenAt;
+        const promiseKept = !!log.promisedKeptAt;
+        return (
+          <li key={log.id} className="ml-4">
+            <span className="absolute -left-1.5 mt-1.5 w-3 h-3 bg-primary rounded-full" />
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <span className="font-medium">{log.contactedBy.name}</span>
+              <span className="text-muted-foreground">{formatDateShortThai(log.contactedAt)}</span>
+              {log.contact && (
+                <Badge variant="secondary">
+                  คุย: {log.contact.name}{log.contact.position ? ` (${log.contact.position})` : ''}
+                </Badge>
+              )}
+              <span className={`px-2 py-0.5 rounded text-xs ${RESULT_TONE[log.result]}`}>
+                {RESULT_LABEL[log.result]}
+              </span>
+            </div>
+            {log.notes && <p className="mt-1 text-sm text-foreground/80">{log.notes}</p>}
+            {log.promisedDate && (
+              <div
+                className={`mt-2 inline-block px-3 py-1.5 rounded-lg text-sm ${
+                  promiseBroken
+                    ? 'bg-red-50 text-red-700 border border-red-200'
+                    : promiseKept
+                      ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                      : 'bg-amber-50 text-amber-700 border border-amber-200'
+                }`}
+              >
+                {promiseKept ? '✓ นัดสำเร็จ ' : promiseBroken ? '✗ ผิดนัด ' : '⏳ นัดไว้ '}
+                {formatDateShortThai(log.promisedDate)}
+                {log.promisedAmount && ` • ${Number(log.promisedAmount).toLocaleString('th-TH')} บาท`}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+```
+
+- [ ] **Step 2: Create the drawer**
+
+```tsx
+// apps/web/src/pages/FinanceReceivablePage/FinanceReceivableDetailDrawer.tsx
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Phone } from 'lucide-react';
+import {
+  financeContactApi,
+  financeContactKeys,
+} from '@/lib/api/finance-contacts';
+import { formatDateShortThai } from '@/utils/formatters';
+import ContactTimeline from './ContactTimeline';
+import FinanceContactLogDialog from './FinanceContactLogDialog';
+
+interface Receivable {
+  id: string;
+  expectedAmount: string;
+  netExpectedAmount: string;
+  receivedAmount: string | null;
+  status: string;
+  externalFinanceCompanyId: string | null;
+  financeCompany: string;
+  lastContactedAt: string | null;
+  lastPromisedDate: string | null;
+  contactAttemptCount: number;
+}
+
+interface Props {
+  receivable: Receivable | null;
+  onClose: () => void;
+}
+
+export default function FinanceReceivableDetailDrawer({ receivable, onClose }: Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const { data: logs = [] } = useQuery({
+    queryKey: receivable ? financeContactKeys.receivableLogs(receivable.id) : ['noop'],
+    queryFn: () => financeContactApi.listLogs(receivable!.id),
+    enabled: !!receivable,
+  });
+
+  if (!receivable) return null;
+  const outstanding = Number(receivable.netExpectedAmount) - Number(receivable.receivedAmount ?? 0);
+
+  return (
+    <>
+      <Sheet open onOpenChange={(o) => !o && onClose()}>
+        <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>รายการเงินรับจากไฟแนนซ์</SheetTitle>
+          </SheetHeader>
+
+          <div className="space-y-4 mt-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <span className="text-sm text-muted-foreground">{receivable.financeCompany}</span>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">ยอดที่คาดว่าจะรับ</span>
+                  <span className="font-medium">
+                    {Number(receivable.netExpectedAmount).toLocaleString('th-TH', {
+                      minimumFractionDigits: 2,
+                    })}
+                  </span>
+                </div>
+                {receivable.externalFinanceCompanyId && (
+                  <Link
+                    to={`/external-finance-companies/${receivable.externalFinanceCompanyId}`}
+                    className="text-sm text-primary hover:underline"
+                  >
+                    ดูข้อมูลบริษัทไฟแนนซ์ →
+                  </Link>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="pb-2">
+                <span className="text-sm font-medium">KPI การติดตาม</span>
+              </CardHeader>
+              <CardContent className="grid grid-cols-3 gap-3 text-sm">
+                <div>
+                  <div className="text-muted-foreground">ติดต่อล่าสุด</div>
+                  <div className="font-medium">
+                    {receivable.lastContactedAt ? formatDateShortThai(receivable.lastContactedAt) : '—'}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">นัดล่าสุด</div>
+                  <div className="font-medium">
+                    {receivable.lastPromisedDate ? formatDateShortThai(receivable.lastPromisedDate) : '—'}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">จำนวนครั้ง</div>
+                  <div className="font-medium">{receivable.contactAttemptCount}</div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium">ประวัติการติดต่อ</h3>
+              <Button size="sm" onClick={() => setDialogOpen(true)}>
+                <Phone className="w-4 h-4 mr-1" /> บันทึกการติดต่อ
+              </Button>
+            </div>
+            <ContactTimeline logs={logs} />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      {dialogOpen && receivable.externalFinanceCompanyId && (
+        <FinanceContactLogDialog
+          receivableId={receivable.id}
+          companyId={receivable.externalFinanceCompanyId}
+          outstanding={outstanding > 0 ? outstanding : 0}
+          open={dialogOpen}
+          onClose={() => setDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Type check**
+
+```bash
+./tools/check-types.sh web
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/FinanceReceivablePage/
+git commit -m "feat(web): contact timeline + receivable detail drawer"
+```
+
+---
+
+## Task 19: Update `FinanceReceivablePage.tsx` — wire columns + row click + filter
+
+**Files:**
+- Modify: `apps/web/src/pages/FinanceReceivablePage.tsx`
+
+- [ ] **Step 1: Extend the `FinanceReceivable` interface**
+
+At the top of the file, append fields to the existing interface:
+
+```typescript
+interface FinanceReceivable {
+  // ... existing
+  externalFinanceCompanyId: string | null;
+  lastContactedAt: string | null;
+  lastPromisedDate: string | null;
+  contactAttemptCount: number;
+}
+```
+
+- [ ] **Step 2: Add state + handler for drawer**
+
+Inside the main page component, near other `useState`:
+
+```typescript
+const [selectedReceivable, setSelectedReceivable] = useState<FinanceReceivable | null>(null);
+const [brokenPromiseOnly, setBrokenPromiseOnly] = useState(false);
+```
+
+Add import:
+```typescript
+import FinanceReceivableDetailDrawer from './FinanceReceivablePage/FinanceReceivableDetailDrawer';
+```
+
+- [ ] **Step 3: Pass `brokenPromiseOnly` to the query string**
+
+Locate the existing receivables `useQuery`'s `queryFn`. Add `brokenPromiseOnly` to the URLSearchParams when true:
+
+```typescript
+if (brokenPromiseOnly) params.set('brokenPromiseOnly', 'true');
+```
+
+And include `brokenPromiseOnly` in the `queryKey` array.
+
+- [ ] **Step 4: Add the new columns + row click**
+
+Locate the columns array for the main receivables table. After the existing "บริษัทไฟแนนซ์" column, add:
+
+```tsx
+{
+  key: 'lastContactedAt',
+  label: 'ติดต่อล่าสุด',
+  render: (row: FinanceReceivable) =>
+    row.lastContactedAt ? formatDateShortThai(row.lastContactedAt) : '—',
+},
+{
+  key: 'lastPromisedDate',
+  label: 'นัดล่าสุด',
+  render: (row: FinanceReceivable) => {
+    if (!row.lastPromisedDate) return '—';
+    const overdue = new Date(row.lastPromisedDate) < new Date() && row.status !== 'RECEIVED';
+    return (
+      <span className={overdue ? 'text-red-600 font-medium' : ''}>
+        {formatDateShortThai(row.lastPromisedDate)}
+      </span>
+    );
+  },
+},
+```
+
+In the DataTable props, add `onRowClick={(row) => setSelectedReceivable(row)}` (if DataTable doesn't support `onRowClick`, wrap each row with a clickable element — check existing pattern in `CustomersPage.tsx`).
+
+- [ ] **Step 5: Render drawer and broken-promise filter**
+
+Above the DataTable, add the filter toggle:
+
+```tsx
+<label className="flex items-center gap-2 text-sm">
+  <input
+    type="checkbox"
+    checked={brokenPromiseOnly}
+    onChange={(e) => setBrokenPromiseOnly(e.target.checked)}
+  />
+  มีนัดเลยกำหนด
+</label>
+```
+
+At the bottom of the component, before the closing fragment:
+
+```tsx
+<FinanceReceivableDetailDrawer
+  receivable={selectedReceivable}
+  onClose={() => setSelectedReceivable(null)}
+/>
+```
+
+- [ ] **Step 6: Type check**
+
+```bash
+./tools/check-types.sh web
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/pages/FinanceReceivablePage.tsx
+git commit -m "feat(web): FinanceReceivablePage row click + KPI columns + broken filter"
+```
+
+---
+
+## Task 20: ExternalFinanceCompanyDetailPage — 4 tabs
+
+**Files:**
+- Create: `apps/web/src/pages/ExternalFinanceCompanyDetailPage.tsx`
+- Modify: `apps/web/src/App.tsx` (register route)
+
+- [ ] **Step 1: Create the page with 4 tabs (skeleton — each tab can be a section, not a separate file, given the small size)**
+
+```tsx
+// apps/web/src/pages/ExternalFinanceCompanyDetailPage.tsx
+import { useState } from 'react';
+import { useParams } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api, { getErrorMessage } from '@/lib/api';
+import PageHeader from '@/components/ui/PageHeader';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  financeContactApi,
+  financeContactKeys,
+  FinanceCompanyContact,
+} from '@/lib/api/finance-contacts';
+import { formatDateShortThai } from '@/utils/formatters';
+import QueryBoundary from '@/components/QueryBoundary';
+
+interface CompanyMaster {
+  id: string;
+  name: string;
+  taxId: string | null;
+  email: string | null;
+  lineOaId: string | null;
+  creditTermDays: number | null;
+  defaultCommissionRate: string | null;
+  notes: string | null;
+}
+
+export default function ExternalFinanceCompanyDetailPage() {
+  const { id = '' } = useParams<{ id: string }>();
+  const company = useQuery({
+    queryKey: ['external-finance-company', id],
+    queryFn: () => api.get<CompanyMaster>(`/external-finance/companies/${id}`).then((r) => r.data),
+  });
+  const summary = useQuery({
+    queryKey: financeContactKeys.companySummary(id),
+    queryFn: () => financeContactApi.companySummary(id),
+  });
+
+  return (
+    <div className="space-y-4">
+      <QueryBoundary query={company}>
+        <PageHeader
+          title={company.data?.name ?? '...'}
+          subtitle={company.data?.taxId ? `เลขผู้เสียภาษี: ${company.data.taxId}` : undefined}
+        />
+        <Card>
+          <CardContent className="grid grid-cols-4 gap-4 pt-6">
+            <Kpi label="บัญชีค้างรับ" value={summary.data?.receivableCount ?? 0} />
+            <Kpi
+              label="ยอดค้างรวม"
+              value={Number(summary.data?.totalOutstanding ?? 0).toLocaleString('th-TH', {
+                minimumFractionDigits: 2,
+              })}
+            />
+            <Kpi
+              label="ติดต่อล่าสุด"
+              value={summary.data?.lastContactedAt ? formatDateShortThai(summary.data.lastContactedAt) : '—'}
+            />
+            <Kpi
+              label="ผิดนัด / นัดสำเร็จ"
+              value={`${summary.data?.brokenPromiseCount ?? 0} / ${summary.data?.keptPromiseCount ?? 0}`}
+            />
+          </CardContent>
+        </Card>
+
+        <Tabs defaultValue="info">
+          <TabsList>
+            <TabsTrigger value="info">ข้อมูลกิจการ</TabsTrigger>
+            <TabsTrigger value="contacts">ผู้ติดต่อ</TabsTrigger>
+            <TabsTrigger value="receivables">บัญชีค้างรับ</TabsTrigger>
+            <TabsTrigger value="logs">ประวัติติดต่อ</TabsTrigger>
+          </TabsList>
+          <TabsContent value="info">
+            <CompanyInfoTab company={company.data} />
+          </TabsContent>
+          <TabsContent value="contacts">
+            <ContactsTab companyId={id} />
+          </TabsContent>
+          <TabsContent value="receivables">
+            <ReceivablesTab companyId={id} />
+          </TabsContent>
+          <TabsContent value="logs">
+            <AllContactLogsTab companyId={id} />
+          </TabsContent>
+        </Tabs>
+      </QueryBoundary>
+    </div>
+  );
+}
+
+function Kpi({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <div className="text-sm text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function CompanyInfoTab({ company }: { company: CompanyMaster | undefined }) {
+  if (!company) return null;
+  return (
+    <Card>
+      <CardContent className="pt-6 grid grid-cols-2 gap-4 text-sm">
+        <Field label="ชื่อบริษัท" value={company.name} />
+        <Field label="เลขผู้เสียภาษี" value={company.taxId} />
+        <Field label="อีเมล" value={company.email} />
+        <Field label="LINE OA" value={company.lineOaId} />
+        <Field
+          label="เครดิตเทอม"
+          value={company.creditTermDays != null ? `${company.creditTermDays} วัน` : null}
+        />
+        <Field
+          label="คอมมิชชั่นปกติ"
+          value={company.defaultCommissionRate ? `${Number(company.defaultCommissionRate) * 100}%` : null}
+        />
+        <Field label="หมายเหตุ" value={company.notes} fullWidth />
+      </CardContent>
+    </Card>
+  );
+}
+
+function Field({ label, value, fullWidth }: { label: string; value: string | null; fullWidth?: boolean }) {
+  return (
+    <div className={fullWidth ? 'col-span-2' : ''}>
+      <div className="text-muted-foreground">{label}</div>
+      <div className="font-medium">{value || '—'}</div>
+    </div>
+  );
+}
+
+function ContactsTab({ companyId }: { companyId: string }) {
+  const qc = useQueryClient();
+  const contacts = useQuery({
+    queryKey: financeContactKeys.companyContacts(companyId),
+    queryFn: () => financeContactApi.listContacts(companyId),
+  });
+
+  const setPrimary = useMutation({
+    mutationFn: (contactId: string) => financeContactApi.setPrimary(companyId, contactId),
+    onSuccess: () => {
+      toast.success('ตั้งผู้ติดต่อหลักสำเร็จ');
+      qc.invalidateQueries({ queryKey: financeContactKeys.companyContacts(companyId) });
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
+  const remove = useMutation({
+    mutationFn: (contactId: string) => financeContactApi.deleteContact(companyId, contactId),
+    onSuccess: () => {
+      toast.success('ลบผู้ติดต่อสำเร็จ');
+      qc.invalidateQueries({ queryKey: financeContactKeys.companyContacts(companyId) });
+    },
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
+  return (
+    <QueryBoundary query={contacts}>
+      <div className="space-y-2 mt-4">
+        {(contacts.data ?? []).map((c: FinanceCompanyContact) => (
+          <Card key={c.id}>
+            <CardContent className="flex items-center justify-between pt-6">
+              <div>
+                <div className="font-medium flex items-center gap-2">
+                  {c.name}
+                  {c.isPrimary && <Badge>ตัวหลัก</Badge>}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {c.position}{c.phone ? ` • ${c.phone}` : ''}{c.email ? ` • ${c.email}` : ''}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                {!c.isPrimary && (
+                  <Button size="sm" variant="outline" onClick={() => setPrimary.mutate(c.id)}>
+                    ตั้งเป็นหลัก
+                  </Button>
+                )}
+                <Button size="sm" variant="destructive" onClick={() => remove.mutate(c.id)}>
+                  ลบ
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+        {contacts.data?.length === 0 && (
+          <p className="text-sm text-muted-foreground py-6 text-center">ยังไม่มีผู้ติดต่อ</p>
+        )}
+      </div>
+    </QueryBoundary>
+  );
+}
+
+function ReceivablesTab({ companyId }: { companyId: string }) {
+  const list = useQuery({
+    queryKey: ['finance-receivable-by-company', companyId],
+    queryFn: () =>
+      api
+        .get(`/finance-receivable?externalFinanceCompanyId=${companyId}&limit=50`)
+        .then((r) => r.data),
+  });
+  return (
+    <QueryBoundary query={list}>
+      <ol className="space-y-2 mt-4">
+        {(list.data?.data ?? []).map((r: { id: string; financeRefNumber: string | null; status: string; expectedDate: string; expectedAmount: string }) => (
+          <li key={r.id} className="p-3 border border-border rounded-lg flex justify-between text-sm">
+            <span>{r.financeRefNumber ?? r.id.slice(0, 8)}</span>
+            <span>{r.status}</span>
+            <span>{formatDateShortThai(r.expectedDate)}</span>
+            <span>{Number(r.expectedAmount).toLocaleString('th-TH')}</span>
+          </li>
+        ))}
+      </ol>
+    </QueryBoundary>
+  );
+}
+
+function AllContactLogsTab({ companyId }: { companyId: string }) {
+  const [page, setPage] = useState(1);
+  const logs = useQuery({
+    queryKey: financeContactKeys.companyLogs(companyId, page),
+    queryFn: () => financeContactApi.companyLogs(companyId, page),
+  });
+  return (
+    <QueryBoundary query={logs}>
+      <ol className="space-y-2 mt-4">
+        {(logs.data?.data ?? []).map((l: { id: string; contactedAt: string; result: string; notes: string | null; contactedBy: { name: string } }) => (
+          <li key={l.id} className="p-3 border border-border rounded-lg text-sm">
+            <div className="flex gap-2">
+              <span className="font-medium">{l.contactedBy.name}</span>
+              <span className="text-muted-foreground">{formatDateShortThai(l.contactedAt)}</span>
+              <Badge variant="secondary">{l.result}</Badge>
+            </div>
+            {l.notes && <p className="mt-1 text-muted-foreground">{l.notes}</p>}
+          </li>
+        ))}
+      </ol>
+      <div className="flex justify-end gap-2 mt-3">
+        <Button size="sm" variant="outline" disabled={page === 1} onClick={() => setPage(page - 1)}>
+          ก่อนหน้า
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={(logs.data?.data?.length ?? 0) < 20}
+          onClick={() => setPage(page + 1)}
+        >
+          ถัดไป
+        </Button>
+      </div>
+    </QueryBoundary>
+  );
+}
+```
+
+- [ ] **Step 2: Register route in App.tsx**
+
+In `apps/web/src/App.tsx`, add lazy import near other page imports:
+```typescript
+const ExternalFinanceCompanyDetailPage = lazy(() => import('@/pages/ExternalFinanceCompanyDetailPage'));
+```
+
+Add route inside the `ProtectedRoute` block (similar to `FinancePortfolioPage` placement):
+```tsx
+<Route
+  path="/external-finance-companies/:id"
+  element={
+    <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+      <MainLayout>
+        <ExternalFinanceCompanyDetailPage />
+      </MainLayout>
+    </ProtectedRoute>
+  }
+/>
+```
+
+- [ ] **Step 3: Type check**
+
+```bash
+./tools/check-types.sh web
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/ExternalFinanceCompanyDetailPage.tsx apps/web/src/App.tsx
+git commit -m "feat(web): ExternalFinanceCompanyDetailPage with 4 tabs"
+```
+
+---
+
+## Task 21: E2E test — log contact + verify timeline + KPI column
+
+**Files:**
+- Create: `apps/web/e2e/finance-receivable-contact.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+```typescript
+// apps/web/e2e/finance-receivable-contact.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Finance Receivable contact log', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'finance@bestchoice.com');
+    await page.fill('input[name="password"]', 'admin1234');
+    await page.click('button[type="submit"]');
+    await page.waitForURL('/');
+  });
+
+  test('record a contact log and see it in timeline + last contacted column', async ({ page }) => {
+    await page.goto('/finance-receivable');
+    await page.waitForSelector('table');
+
+    // Click first row to open drawer
+    const firstRow = page.locator('tbody tr').first();
+    await firstRow.click();
+
+    // Drawer opens
+    await expect(page.getByText('ประวัติการติดต่อ')).toBeVisible();
+
+    // Open dialog
+    await page.getByRole('button', { name: /บันทึกการติดต่อ/ }).click();
+
+    // Pick result = ANSWERED
+    await page.getByRole('button', { name: 'รับสาย' }).click();
+
+    // Add note
+    await page.getByPlaceholder('รายละเอียดการคุย…').fill('E2E test note');
+
+    // Submit
+    await page.getByRole('button', { name: 'บันทึก', exact: true }).click();
+
+    // Toast appears
+    await expect(page.getByText('บันทึกการติดต่อสำเร็จ')).toBeVisible();
+
+    // Timeline shows new entry
+    await expect(page.getByText('E2E test note')).toBeVisible();
+  });
+
+  test('broken-promise filter limits the list', async ({ page }) => {
+    await page.goto('/finance-receivable');
+    await page.waitForSelector('table');
+
+    const initialCount = await page.locator('tbody tr').count();
+
+    await page.getByLabel('มีนัดเลยกำหนด').check();
+    await page.waitForLoadState('networkidle');
+
+    const filteredCount = await page.locator('tbody tr').count();
+    expect(filteredCount).toBeLessThanOrEqual(initialCount);
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E test**
+
+```bash
+cd apps/web && npx playwright test e2e/finance-receivable-contact.spec.ts
+```
+
+Expected: both tests PASS. If they fail due to no rows in dev data, seed at least one external-finance FinanceReceivable first.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e/finance-receivable-contact.spec.ts
+git commit -m "test(e2e): finance receivable contact log + broken-promise filter"
+```
+
+---
+
+## Task 22: Full pre-deploy check
+
+- [ ] **Step 1: Run full type + lint + test suite**
+
+```bash
+./tools/run-tests.sh
+```
+
+Expected: 0 type errors, 0 lint errors, all unit tests PASS, all E2E specs PASS.
+
+- [ ] **Step 2: Run backfill on dev DB (production rehearsal)**
+
+```bash
+cd apps/api && npm run backfill:external-finance
+```
+
+Expected: report with non-negative counts, exit 0. Run twice to verify idempotency (second run should show 0 new + skip counts on contacts).
+
+- [ ] **Step 3: Smoke test the UI**
+
+```bash
+npm run dev
+```
+
+Manually verify:
+1. Log in as `finance@bestchoice.com`
+2. Visit `/finance-receivable` — new columns visible
+3. Click a row — drawer opens
+4. Click "บันทึกการติดต่อ" — dialog opens, contacts dropdown populated, primary marked
+5. Submit a PROMISED log with date in past — refresh → log shows in timeline; cron will mark it broken next 02:00 BKK (verify SQL manually or wait)
+6. Visit `/external-finance-companies/<id>` — 4 tabs render, contacts tab supports add/edit/setPrimary
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+If the smoke test surfaces minor issues, fix + commit:
+```bash
+git add <files>
+git commit -m "fix(finance-contact): <description>"
+```
+
+---
+
+## Spec coverage check
+
+- [x] Schema additions (§5.1-5.4) → Task 1
+- [x] Partial unique index (§5.2) → Task 1 step 6
+- [x] DTOs (§6.4) → Tasks 4 + 7
+- [x] Contact CRUD + setPrimary (§6.1) → Tasks 5 + 6
+- [x] Contact log CRUD (§6.2) → Tasks 8 + 9 + 10
+- [x] Aggregation endpoints (§6.3) → Task 9 + 10
+- [x] Service guarantees: lazy resolve, KPI denorm, primaryKept (§6.5) → Tasks 8 + 12
+- [x] broken-promise-finance cron (§7.1) → Task 11
+- [x] UI drawer/dialog/timeline (§8.1-8.2) → Tasks 17-18
+- [x] ExternalFinanceCompanyDetailPage 4 tabs (§8.3) → Task 20
+- [x] FinanceReceivablePage columns + row click + filter (§8.4) → Task 19
+- [x] Roles enforcement (§9) → embedded in controllers Tasks 6 + 10
+- [x] Migration 3 phases: schema, sale workflow, backfill (§10) → Tasks 1, 13, 15
+- [x] Tests: unit/integration/E2E (§11) → embedded in each task + Task 21
+- [x] Name normalizer + idempotent guard → Tasks 2 + 15
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-31-finance-receivable-contact-system.md`.**
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best for a 22-task plan to avoid context bloat and catch issues early.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. Good if you want tighter control.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-31-finance-receivable-contact-system-design.md
+++ b/docs/superpowers/specs/2026-05-31-finance-receivable-contact-system-design.md
@@ -1,0 +1,498 @@
+# Finance Receivable Contact System (PEAK-style) — Design
+
+**Date:** 2026-05-31
+**Status:** v2 (post-scrutinize) — pending user review before plan
+**Owner:** BESTCHOICE Finance module
+**Scope:** เพิ่มระบบผู้ติดต่อ (Contact directory + Activity log) บนบัญชีไฟแนนซ์ภายนอก (`FinanceReceivable` / `ExternalFinanceCompany`) ตามแนวคิด PEAK Contact
+**Revision v2:** ปิด blockers/majors จาก scrutinize — (1) log FK lazy-resolve, (2) ลบ `@@unique` ปลอม, (3) update sale workflow, (4) drop `FinanceCompanyGroup` YAGNI, (5) backfill idempotent guard, (6) เพิ่ม `promisedKeptAt`
+
+---
+
+## 1. Background
+
+### 1.1 ปัญหา
+
+หน้า [FinanceReceivablePage.tsx](apps/web/src/pages/FinanceReceivablePage.tsx) แสดงรายการเงินรับจากไฟแนนซ์ภายนอก (KK, KTC, GFIN ฯลฯ) ที่บริษัทรอรับโอนหลังขายเครื่องผ่อนผ่าน external finance ปัจจุบัน **ไม่มีเครื่องมือใดในระบบ** สำหรับ:
+
+- จัดเก็บรายชื่อผู้ประสานงาน (AR Manager, Branch Manager) หลายคนต่อบริษัทไฟแนนซ์
+- บันทึกประวัติการติดตามเงินรับที่ค้าง (โทรไปแล้วใครรับ ผลเป็นอย่างไร นัดโอนวันไหน)
+- รู้ว่าใน receivable ที่ค้าง — ติดต่อล่าสุดเมื่อไหร่ ใครรับปาก แต่ไม่ส่ง
+
+ฝั่ง overdue (in-house installment) มี `CallLog` + `PromiseSlot` ครบมาก แต่ออกแบบมาเพื่อ customer (legal-grade evidence trail, Yeastar CDR, dunning escalation) — ไม่เหมาะ reuse สำหรับ B2B finance follow-up
+
+### 1.2 Existing state
+
+- **`FinanceReceivable`** ([schema.prisma:3539](apps/api/prisma/schema.prisma#L3539)): `financeCompany` เป็น **free-text** ไม่ผูก FK กับ `ExternalFinanceCompany`
+- **`ExternalFinanceCompany`** ([schema.prisma:6947](apps/api/prisma/schema.prisma#L6947)): มี `contactPerson` + `contactPhone` เป็น single field เดี่ยว เก็บได้ 1 คน/บริษัท
+- ไม่มี contact log / activity tracking ใด ๆ บนฝั่ง external finance
+
+### 1.3 PEAK Contact reference
+
+PEAK Account ([peakaccount.com/peak-manual/peak-contact](https://www.peakaccount.com/peak-manual/peak-contact)) ใช้โครงสร้าง:
+
+- **ผู้ติดต่อหลัก** (1 บริษัท): ชื่อกิจการ, เลขผู้เสียภาษี, ที่อยู่, ประเภท, กลุ่มผู้ติดต่อ, วงเงินขายเชื่อ, เครดิตเทอม
+- **ผู้ติดต่อย่อย** (หลายคน/บริษัท): ชื่อ, ตำแหน่ง, โทร, อีเมล — มี flag "ตัวหลัก" (primary)
+- **กลุ่มผู้ติดต่อ**: ชื่อกลุ่ม + คำอธิบาย เพื่อจัดหมวด
+- PEAK เอง **ไม่มี activity log** — เราเสริมเองเฉพาะส่วนที่จำเป็นต่อการติดตามเงินรับ
+
+---
+
+## 2. Goals
+
+1. รายชื่อผู้ประสานงานหลายคนต่อบริษัทไฟแนนซ์ พร้อม "ตัวหลัก" แบบ PEAK
+2. บันทึก / ดูประวัติการติดต่อต่อ receivable แต่ละใบ
+3. KPI denormalized บน receivable (ติดต่อล่าสุด, นัดล่าสุด, จำนวนครั้งติดต่อ) → ใช้ filter/sort ในตารางหลัก
+4. Auto-flag broken promise เมื่อพ้นวันนัดแล้วยังไม่โอน
+5. Migrate `FinanceReceivable.financeCompany` (text) ให้ผูก FK กับ `ExternalFinanceCompany` (PEAK source-of-truth pattern)
+
+## 3. Non-Goals
+
+- ❌ Channel EMAIL / LINE / MEETING (เก็บ enum extensible แต่ UI รอบนี้ CALL อย่างเดียว)
+- ❌ Multi-slot promise (B2B ไม่ซับซ้อนเหมือนผ่อนลูกค้า — single promise พอ)
+- ❌ Yeastar PBX auto-log สำหรับ B2B (manual log เท่านั้น)
+- ❌ Voice memo upload
+- ❌ Per-receivable credit limit alerting (มี PEAK-style field แต่ไม่ enforce รอบนี้)
+- ❌ ลบ field `FinanceReceivable.financeCompany` (text) — รอ Phase 3 ภายหลัง
+- ❌ Broadcast / mass-call campaign
+
+---
+
+## 4. Architecture Overview
+
+2 ส่วนใหม่ + 1 ขยาย ตามแนวคิด PEAK Contact:
+
+| ระดับ | ตาราง | PEAK Term | บทบาท |
+|---|---|---|---|
+| Master | `ExternalFinanceCompany` (ขยาย field) | ผู้ติดต่อหลัก | บริษัทไฟแนนซ์ (KK, KTC, GFIN) |
+| Sub-contact | `FinanceCompanyContact` (ใหม่) | ผู้ติดต่อย่อย | เจ้าหน้าที่ AR/AM/Branch Mgr |
+| Activity log | `FinanceReceivableContactLog` (ใหม่) | (PEAK ไม่มี) | ติดตามเงินรับ — บันทึกการโทรต่อ 1 receivable |
+
+### Key design decisions (จาก brainstorm + scrutinize)
+
+| # | Decision | เหตุผล |
+|---|---|---|
+| D1 | Standalone tables (ไม่ reuse `CallLog`) | แยก legal-grade customer evidence ออกจาก B2B follow-up; semantic ต่างกัน |
+| D2 | Single promise per log | B2B ไฟแนนซ์ไม่ซับซ้อนเหมือน installment ลูกค้า; รับปากครั้งเดียว/log |
+| D3 | Migrate `financeCompany` เป็น FK เต็มตัว | PEAK source-of-truth — บริษัท = 1 record |
+| D4 | Channel = CALL only (UI), enum extensible | YAGNI สำหรับ email/Line/meeting; เก็บ enum slot ไว้รอบหน้า |
+| D5 | Denormalize KPI (lastContactedAt ฯลฯ) บน FinanceReceivable | Filter/sort ตารางหลักโดยไม่ join นับ logs |
+| D6 (post-scrutinize) | Lazy resolve FK ที่ contact-log create — upsert ExternalFinanceCompany จาก receivable.financeCompany ถ้ายังไม่มี | รองรับ in-flight receivables ที่ยัง pre-backfill — บันทึก log ได้เลย ไม่ติด deploy order |
+| D7 (post-scrutinize) | ตัด `FinanceCompanyGroup` ออก scope | YAGNI — BESTCHOICE มีไฟแนนซ์ ≤10 ราย ไม่ต้องการ grouping |
+| D8 (post-scrutinize) | ตัด address/branchCode/entityType/website ออก scope | ไม่ตรง use case "ติดต่อทวงเงิน" — เพิ่มภายหลังตามความจำเป็น |
+| D9 (post-scrutinize) | เพิ่ม `promisedKeptAt` คู่กับ `promisedBrokenAt` | UI distinguish "นัดสำเร็จ vs ค้าง" โดยไม่ leak logic ข้าม table |
+
+---
+
+## 5. Schema Changes
+
+### 5.1 ขยาย `ExternalFinanceCompany`
+
+```prisma
+model ExternalFinanceCompany {
+  // ── เดิม ──
+  id                    String    @id @default(uuid())
+  name                  String    @unique
+  defaultCommissionRate Decimal?  @map("default_commission_rate") @db.Decimal(5, 4)
+  bankAccountInfo       Json?     @map("bank_account_info")
+  notes                 String?
+  isActive              Boolean   @default(true) @map("is_active")
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
+  deletedAt             DateTime? @map("deleted_at")
+
+  // ── ใหม่ (focused fields เพื่อ use case "ติดต่อทวงเงิน") ──
+  taxId          String?  @map("tax_id")          // เลขผู้เสียภาษี 13 หลัก
+  email          String?
+  lineOaId       String?  @map("line_oa_id")
+  creditTermDays Int?     @map("credit_term_days")
+
+  // ── Deprecated (คงไว้เพื่อ back-compat ใน Phase 1-2) ──
+  /// @deprecated ใช้ FinanceCompanyContact (isPrimary=true) แทน
+  contactPerson String? @map("contact_person")
+  /// @deprecated
+  contactPhone  String? @map("contact_phone")
+
+  // ── Relations ──
+  contacts    FinanceCompanyContact[]
+  receivables FinanceReceivable[]
+  contactLogs FinanceReceivableContactLog[]
+  commissions ExternalFinanceCommission[]
+
+  @@map("external_finance_companies")
+}
+```
+
+> **หมายเหตุ:** field address/website/entityType/branchCode/group ที่ PEAK มี — ตัดออกจาก scope รอบนี้ (D8). เพิ่มภายหลังถ้ามี use case ชัด (เช่น ส่งจดหมาย, ออกใบกำกับภาษี)
+
+### 5.2 `FinanceCompanyContact` (ใหม่)
+
+```prisma
+model FinanceCompanyContact {
+  id                       String   @id @default(uuid())
+  externalFinanceCompanyId String   @map("external_finance_company_id")
+  name                     String
+  position                 String?
+  department               String?
+  phone                    String?
+  email                    String?
+  lineId                   String?  @map("line_id")
+  notes                    String?
+  isPrimary                Boolean  @default(false) @map("is_primary")
+  isActive                 Boolean  @default(true)  @map("is_active")
+  createdAt                DateTime @default(now()) @map("created_at")
+  updatedAt                DateTime @updatedAt @map("updated_at")
+  deletedAt                DateTime?
+
+  company     ExternalFinanceCompany        @relation(fields: [externalFinanceCompanyId], references: [id])
+  contactLogs FinanceReceivableContactLog[]
+
+  @@index([externalFinanceCompanyId, isActive])
+  @@map("finance_company_contacts")
+}
+```
+
+> **Partial unique index (raw SQL — สำคัญ):**
+> **ห้ามใส่ `@@unique([externalFinanceCompanyId, isPrimary])`** เพราะจะ block หลาย contact ที่ `isPrimary=false` (case ปกติของบริษัทที่มี 3 พนักงาน, none primary).
+> ต้องใช้ raw SQL ใน migration:
+> ```sql
+> CREATE UNIQUE INDEX uniq_primary_per_company
+>   ON finance_company_contacts (external_finance_company_id)
+>   WHERE is_primary = true AND deleted_at IS NULL;
+> ```
+
+### 5.3 `FinanceReceivableContactLog` (ใหม่)
+
+```prisma
+enum FinanceContactChannel {
+  CALL
+  EMAIL
+  LINE
+  MEETING
+  OTHER
+}
+
+enum FinanceContactResult {
+  ANSWERED        // คุย/รับสาย
+  NO_ANSWER       // ไม่รับ
+  PROMISED        // รับปากจะโอน
+  DISPUTED        // มีปัญหา/โต้แย้ง
+  REQUESTED_DOCS  // ขอเอกสารเพิ่ม
+  OTHER
+}
+
+model FinanceReceivableContactLog {
+  id                       String                @id @default(uuid())
+  financeReceivableId      String                @map("finance_receivable_id")
+  externalFinanceCompanyId String                @map("external_finance_company_id")  // denormalized — always set via lazy-resolve at create time (D6)
+  financeCompanyContactId  String?               @map("finance_company_contact_id")   // โทรหาใคร (nullable)
+  contactedById            String                @map("contacted_by_id")
+  contactedAt              DateTime              @default(now()) @map("contacted_at")
+  channel                  FinanceContactChannel @default(CALL)
+  result                   FinanceContactResult
+  notes                    String?
+  promisedDate             DateTime?             @map("promised_date")
+  promisedAmount           Decimal?              @map("promised_amount") @db.Decimal(12, 2)
+  promisedBrokenAt         DateTime?             @map("promised_broken_at")   // cron set เมื่อพ้นวันนัด + เงินยังไม่เข้า
+  promisedKeptAt           DateTime?             @map("promised_kept_at")     // cron/recordReceive set เมื่อเงินเข้า ≤ นัด (D9)
+  createdAt                DateTime              @default(now()) @map("created_at")
+  updatedAt                DateTime              @updatedAt @map("updated_at")
+  deletedAt                DateTime?
+
+  receivable  FinanceReceivable      @relation(fields: [financeReceivableId], references: [id])
+  company     ExternalFinanceCompany @relation(fields: [externalFinanceCompanyId], references: [id])
+  contact     FinanceCompanyContact? @relation(fields: [financeCompanyContactId], references: [id])
+  contactedBy User                   @relation("FinanceContactLogger", fields: [contactedById], references: [id])
+
+  @@index([financeReceivableId, contactedAt])
+  @@index([externalFinanceCompanyId, contactedAt])
+  @@index([promisedDate, promisedBrokenAt, promisedKeptAt])
+  @@map("finance_receivable_contact_logs")
+}
+```
+
+> **Lazy FK resolution (D6) — สำคัญ:**
+> เมื่อ `recordContactLog` ถูกเรียก ถ้า `receivable.externalFinanceCompanyId IS NULL` (in-flight pre-backfill):
+> 1. Normalize `receivable.financeCompany` (text)
+> 2. Upsert `ExternalFinanceCompany` by normalized name → ได้ id
+> 3. UPDATE receivable.externalFinanceCompanyId = upserted.id ใน transaction เดียวกัน
+> 4. Insert log โดย externalFinanceCompanyId = upserted.id
+>
+> วิธีนี้ทำให้ deployment order ไม่สำคัญ — UI deploy ก่อน backfill เสร็จก็ใช้งานได้
+
+### 5.4 ขยาย `FinanceReceivable`
+
+```prisma
+model FinanceReceivable {
+  // ... existing fields
+
+  // ── ใหม่ ──
+  externalFinanceCompanyId String? @map("external_finance_company_id")  // nullable until Phase 3
+  lastContactedAt          DateTime? @map("last_contacted_at")           // KPI denorm
+  lastPromisedDate         DateTime? @map("last_promised_date")          // KPI denorm
+  contactAttemptCount      Int       @default(0) @map("contact_attempt_count")
+
+  /// @deprecated migrate ไป externalFinanceCompanyId — Phase 3 จะ drop
+  financeCompany String @map("finance_company")
+
+  company     ExternalFinanceCompany?       @relation(fields: [externalFinanceCompanyId], references: [id])
+  contactLogs FinanceReceivableContactLog[]
+
+  @@index([externalFinanceCompanyId, status])
+  @@index([lastContactedAt])
+}
+```
+
+### 5.5 User relation
+
+```prisma
+model User {
+  // ... existing
+  financeContactLogs FinanceReceivableContactLog[] @relation("FinanceContactLogger")
+}
+```
+
+---
+
+## 6. API Design
+
+> **Role shorthand:** "viewers" = `OWNER, BRANCH_MANAGER, FINANCE_MANAGER, ACCOUNTANT` (ดูตาราง §9)
+
+### 6.1 Contact directory (`/external-finance/companies/:companyId/...`)
+
+| Method | Path | Roles | Action |
+|---|---|---|---|
+| GET | `/contacts` | viewers | list contacts (active first, primary first) |
+| POST | `/contacts` | OWNER, FINANCE_MANAGER | create — ถ้า isPrimary=true ต้องเป็น atomic swap |
+| PATCH | `/contacts/:contactId` | OWNER, FINANCE_MANAGER | update |
+| DELETE | `/contacts/:contactId` | OWNER, FINANCE_MANAGER | soft delete (ห้ามลบถ้าเป็น primary และมี contact อื่นเหลือ → ต้อง re-assign ก่อน) |
+| POST | `/contacts/:contactId/set-primary` | OWNER, FINANCE_MANAGER | transactional: ปลด primary อื่นใน company → set primary ตัวนี้ |
+
+### 6.2 Activity log (`/finance-receivable/:receivableId/...`)
+
+| Method | Path | Roles | Action |
+|---|---|---|---|
+| GET | `/contact-logs` | viewers | timeline (newest first) |
+| POST | `/contact-logs` | viewers | บันทึก log + update KPI denorm (transactional) |
+| PATCH | `/contact-logs/:logId` | own log within 24h OR OWNER/FINANCE_MANAGER | edit |
+| DELETE | `/contact-logs/:logId` | OWNER, FINANCE_MANAGER | soft delete + recompute KPI |
+
+### 6.3 Aggregation
+
+| Method | Path | Roles | Action |
+|---|---|---|---|
+| GET | `/external-finance/companies/:id/contact-summary` | viewers | สรุป: receivableCount, totalOutstanding, lastContactedAt, brokenPromiseCount, keptPromiseCount |
+| GET | `/external-finance/companies/:id/contact-logs?page=&limit=20` | viewers | timeline รวมทุก receivable ของบริษัทนี้ (default 20/page, max 100) |
+
+### 6.4 DTOs
+
+```typescript
+class CreateFinanceCompanyContactDto {
+  @IsString() @MaxLength(200) name!: string;
+  @IsOptional() @IsString() @MaxLength(200) position?: string;
+  @IsOptional() @IsString() @MaxLength(100) department?: string;
+  @IsOptional() @IsString() @MaxLength(50) phone?: string;
+  @IsOptional() @IsEmail() email?: string;
+  @IsOptional() @IsString() @MaxLength(100) lineId?: string;
+  @IsOptional() @IsString() @MaxLength(1000) notes?: string;
+  @IsOptional() @IsBoolean() isPrimary?: boolean;
+}
+
+class CreateContactLogDto {
+  @IsOptional() @IsUUID() financeCompanyContactId?: string;
+  @IsEnum(FinanceContactChannel) channel: FinanceContactChannel = 'CALL';
+  @IsEnum(FinanceContactResult) result!: FinanceContactResult;
+  @IsOptional() @IsString() @MaxLength(2000) notes?: string;
+  @IsOptional() @IsDateString() contactedAt?: string;  // default = now
+  // promise (เฉพาะถ้า result=PROMISED)
+  @IsOptional() @IsDateString() promisedDate?: string;
+  @IsOptional() @IsNumber({ maxDecimalPlaces: 2 }) @IsPositive() promisedAmount?: number;
+}
+```
+
+### 6.5 Service guarantees
+
+- **`recordContactLog`**: ใน `$transaction` —
+  1. ถ้า `receivable.externalFinanceCompanyId IS NULL` → normalize `receivable.financeCompany` (text) → upsert `ExternalFinanceCompany` → UPDATE receivable.externalFinanceCompanyId (D6 lazy-resolve)
+  2. Insert log
+  3. UPDATE `FinanceReceivable.lastContactedAt = log.contactedAt`, `lastPromisedDate = (result===PROMISED ? promisedDate : prev)`, `contactAttemptCount += 1`
+
+- **`setPrimary`**: ใน `$transaction` —
+  1. `SELECT id FROM external_finance_companies WHERE id=? FOR UPDATE` (row lock บนบริษัท → serialize concurrent setPrimary; last writer wins โดยไม่ผิด invariant)
+  2. `UPDATE finance_company_contacts SET is_primary=false WHERE external_finance_company_id=? AND is_primary=true`
+  3. `UPDATE finance_company_contacts SET is_primary=true WHERE id=?`
+
+- **`deleteContact`**: ถ้า contact ที่จะลบ `isPrimary=true` AND ยังมี contact อื่น active เหลือ → **reject** + แจ้งให้ assign primary ใหม่ก่อน
+
+- **`deleteContactLog`**: soft delete + recompute KPI (อาจมี cost — กรณีมี log เยอะ → cap ที่ N=100 ล่าสุดสำหรับ recompute)
+
+- **Promise lifecycle on `recordReceive`**: ใน `recordReceive` flow ของ `FinanceReceivableService` → หลัง update status ถ้าเป็น `RECEIVED` หรือ `PARTIALLY_RECEIVED` AND มี log ที่ `result=PROMISED AND promisedKeptAt IS NULL AND promisedBrokenAt IS NULL` AND `receivedDate <= promisedDate` → SET `promisedKeptAt = receivedDate` (D9)
+
+---
+
+## 7. Cron Jobs
+
+### 7.1 `broken-promise-finance.cron.ts` (ใหม่)
+
+- **Schedule:** 02:00 BKK ทุกวัน
+- **Logic:**
+  ```sql
+  UPDATE finance_receivable_contact_logs
+  SET promised_broken_at = now()
+  WHERE promised_date < CURRENT_DATE
+    AND promised_broken_at IS NULL
+    AND promised_kept_at IS NULL
+    AND result = 'PROMISED'
+    AND deleted_at IS NULL
+    AND finance_receivable_id IN (
+      SELECT id FROM finance_receivables
+      WHERE status NOT IN ('RECEIVED', 'PARTIALLY_RECEIVED')
+        AND deleted_at IS NULL
+    )
+  ```
+- **Output:** count + log → metrics
+- **Note:** `promisedKeptAt` ไม่ต้อง cron — เซ็ตที่ `recordReceive` handler ตรงๆ (ดู §6.5)
+
+---
+
+## 8. Web UI
+
+### 8.1 `FinanceReceivableDetailDrawer` (ใหม่) — เปิดจากตารางหลัก
+
+- **Header card**: status badge, expectedAmount, daysOverdue, receivedAmount (ถ้ามี)
+- **Card "บริษัทไฟแนนซ์"**: ชื่อ + กลุ่ม + เครดิตเทอม + ผู้ติดต่อหลัก (พร้อม `tel:` link) → คลิกเปิด `/external-finance-companies/:id`
+- **Card "KPI ติดตาม"**: ติดต่อล่าสุด, นัดล่าสุด (เน้นแดงถ้า broken), จำนวนครั้งที่ติดต่อ
+- **Section "ประวัติการติดต่อ"**: vertical timeline — แต่ละ log แสดง: รูป/ชื่อพนักงาน, contactedAt (relative + absolute), ผู้ติดต่อในบริษัท (chip), result chip สี, notes, promise box ถ้ามี (สีแดงถ้า broken)
+- **Sticky button "+ บันทึกการติดต่อ"** เปิด `FinanceContactLogDialog`
+
+### 8.2 `FinanceContactLogDialog` (ใหม่ component)
+
+- **ผู้ติดต่อ**: dropdown โหลด `FinanceCompanyContact` ของ company — default = primary, แสดง badge "ตัวหลัก", ปุ่ม "+ เพิ่มผู้ติดต่อใหม่" inline
+- **ผลการติดต่อ**: chip group (ANSWERED / NO_ANSWER / PROMISED / DISPUTED / REQUESTED_DOCS / OTHER) สีตามผล
+- **โน้ต**: textarea
+- **ถ้าเลือก PROMISED:** unfold section → ThaiDateInput (วันที่นัด) + number input (ยอด default = outstanding)
+- **บันทึก** → POST log + close + invalidate query
+- Toast success/error
+
+### 8.3 `ExternalFinanceCompanyDetailPage` (ใหม่ `/external-finance-companies/:id`) — 4 tabs
+
+| Tab | Content |
+|---|---|
+| **ข้อมูลกิจการ** | form: name, taxId, email, lineOaId, creditTermDays, defaultCommissionRate, bankAccountInfo (JSON editor), notes |
+| **ผู้ติดต่อ** | table FinanceCompanyContact — column: ชื่อ, ตำแหน่ง, โทร, email, badge "ตัวหลัก", action menu (edit/delete/set-primary). ปุ่ม "+ เพิ่มผู้ติดต่อ" |
+| **บัญชีค้างรับ** | list FinanceReceivable ของบริษัทนี้ (status filter) — link ไปหน้า detail |
+| **ประวัติติดต่อ** | aggregated timeline ทุก receivable ของบริษัทนี้ (20/page, infinite scroll หรือ pagination) |
+
+### 8.4 ปรับ `FinanceReceivablePage` (เดิม)
+
+- **คอลัมน์ใหม่**:
+  - "ติดต่อล่าสุด" (relative time + tooltip absolute, จาก `lastContactedAt`)
+  - "นัดล่าสุด" (date + badge "เลยกำหนด" ถ้า broken — จาก `lastPromisedDate` + log status)
+- **คอลัมน์ "บริษัทไฟแนนซ์"**: คลิกชื่อ → ไป `/external-finance-companies/:id`
+- **คลิก row** → เปิด `FinanceReceivableDetailDrawer`
+- เพิ่ม filter "มีนัดเลยกำหนด" (broken promise) — backend ใช้ EXISTS subquery
+
+---
+
+## 9. Roles & Permissions
+
+| Action | OWNER | BRANCH_MANAGER | FINANCE_MANAGER | ACCOUNTANT | SALES |
+|---|---|---|---|---|---|
+| View contacts/logs | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Create/edit contact directory | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Create contact log | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Edit/delete own log (within 24h) | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Edit/delete any log | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Edit company master fields | ✅ | ❌ | ✅ | ❌ | ❌ |
+
+---
+
+## 10. Migration Plan
+
+### Phase 1 — Schema + back-compat code + sale workflow update (รอบ deploy นี้)
+
+1. Prisma migration: เพิ่มตารางใหม่ 2 ตัว (`FinanceCompanyContact`, `FinanceReceivableContactLog`) + columns ใหม่บน `ExternalFinanceCompany` (4 field) และ `FinanceReceivable` (4 field: FK + KPI denorm 3 ตัว) — ทั้งหมด nullable
+2. Raw SQL migration: partial unique index บน `finance_company_contacts` (ดู §5.2)
+3. **Update Sale workflow (M3 จาก scrutinize)** — ทุกจุดที่สร้าง `FinanceReceivable` (sale completion handler) ต้อง:
+   - Resolve `ExternalFinanceCompany` จาก `sale.financeCompany` (text) ผ่าน upsert by normalized name
+   - SET ทั้ง `financeCompany` (text, back-compat) และ `externalFinanceCompanyId` (FK)
+   - → ตัด orphan creation ตั้งแต่ต้นน้ำ
+4. Deploy code: contact-log service ที่มี D6 lazy-resolve (รองรับ receivable เก่าที่ยัง FK NULL)
+5. Deploy UI ใหม่
+
+### Phase 2 — Backfill script (`scripts/backfill-external-finance-fk.ts`)
+
+1. Group `FinanceReceivable.financeCompany` (text) ด้วย normalized name (trim, lowercase, collapse multiple spaces, unify วงเล็บ Thai/English)
+2. Match กับ `ExternalFinanceCompany.name` (case-insensitive) — ถ้าไม่มี → `upsert` row (`isActive=true`, อื่นๆ null) **โดยใช้ normalized name เป็น match key** (เก็บ original name ไว้)
+3. `UPDATE FinanceReceivable SET externalFinanceCompanyId = matched.id WHERE externalFinanceCompanyId IS NULL` (guard กัน double-write)
+4. **Idempotent guard (M5 จาก scrutinize)** — ย้าย `contactPerson/contactPhone` → `FinanceCompanyContact` ด้วย:
+   ```sql
+   INSERT INTO finance_company_contacts (id, external_finance_company_id, name, phone, is_primary, is_active)
+   SELECT gen_random_uuid(), efc.id, efc.contact_person, efc.contact_phone, true, true
+   FROM external_finance_companies efc
+   WHERE efc.contact_person IS NOT NULL
+     AND efc.deleted_at IS NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM finance_company_contacts fcc
+       WHERE fcc.external_finance_company_id = efc.id
+         AND fcc.is_primary = true
+         AND fcc.deleted_at IS NULL
+     )
+   ```
+5. รายงานสรุป: matched / new-created / orphan / contacts-migrated / contacts-skipped (มี primary อยู่แล้ว)
+6. ทำใน transaction รายบริษัท — re-runnable
+
+### Phase 3 — Lock down (รอบหลัง, นอก scope ครั้งนี้)
+
+- ทำ `externalFinanceCompanyId` required (NOT NULL)
+- Drop column `financeCompany` (text)
+- Drop column `ExternalFinanceCompany.contactPerson` / `contactPhone`
+
+---
+
+## 11. Testing Plan
+
+### 11.1 Unit tests
+
+- `FinanceCompanyContactService.setPrimary` — atomic swap with row lock (transaction rollback ถ้า fail; concurrent serializable)
+- `FinanceCompanyContactService.delete` — block ถ้า primary AND มี contact อื่น active เหลือ
+- `BrokenPromiseFinanceCron` — เซ็ตเฉพาะ logs ที่ result=PROMISED + promisedKeptAt IS NULL + receivable.status != RECEIVED/PARTIALLY_RECEIVED
+- `ContactLogService.record` — KPI denorm ถูก (lastContactedAt, lastPromisedDate, contactAttemptCount); ถ้า receivable.FK NULL → lazy-upsert ExternalFinanceCompany แล้ว set FK
+- `ContactLogService.delete` — recompute KPI ถูก
+- `FinanceReceivableService.recordReceive` — เซ็ต `promisedKeptAt` ถ้าเงินเข้า ≤ promisedDate ใน log ที่ open
+- `backfill` script — Thai name normalization (trim, collapse multiple spaces, unify วงเล็บ Thai/English) — e.g. `"เคทีซี  "` = `"เคทีซี"`, `"กสิกร (KK)"` = `"กสิกร(KK)"`
+- `backfill` rerun — second pass ไม่สร้าง duplicate primary contact (NOT EXISTS guard)
+- `Sale workflow` — สร้าง FinanceReceivable ใหม่ตั้งทั้ง `financeCompany` text และ FK
+
+### 11.2 Integration tests
+
+- POST contact log → GET timeline → KPI denorm reflect
+- POST contact log with PROMISED + promisedDate → cron → log มี promisedBrokenAt
+- POST contact log PROMISED → recordReceive ก่อน promisedDate → log มี promisedKeptAt (broken IS NULL)
+- POST contact log บน receivable ที่ FK NULL → log สร้างได้ + receivable FK ถูก set อัตโนมัติ
+- Role guard: ACCOUNTANT POST log ผ่าน, PATCH others' log ห้าม
+
+### 11.3 E2E (Playwright)
+
+- จากหน้า `/finance-receivable` คลิก row → drawer เปิด → "+ บันทึกการติดต่อ" → กรอก → save → ปรากฏใน timeline + คอลัมน์ "ติดต่อล่าสุด" update
+- เปลี่ยน primary contact → reload → primary badge ย้าย
+- Filter "มีนัดเลยกำหนด" → แสดงเฉพาะ broken
+
+---
+
+## 12. Open Questions (เก็บไว้ resolve ใน plan)
+
+1. UI design ของ `FinanceContactLogDialog` ใช้ Modal หรือ Drawer? — แนะนำ Modal (simpler)
+2. Bulk action "บันทึกการติดต่อ" หลาย receivable พร้อมกันใช้ไหม? — รอบนี้ไม่ทำ (YAGNI)
+3. ภาษาในตัวเลือก result enum — ใส่ Thai label ใน DB หรือใส่ map ใน UI? — UI map (i18n-friendly)
+
+---
+
+## 13. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Backfill match ผิดบริษัท | data corruption | dry-run flag, report ก่อน commit, transaction รายบริษัท |
+| Partial unique index ไม่ portable (PG specific) | migration fail บน MySQL | ระบุชัดใน migration ว่าใช้ Postgres เท่านั้น (โปรเจกต์ใช้ PG อยู่แล้ว) |
+| KPI denorm out-of-sync ถ้า log ลบโดยตรงจาก DB | dashboard inaccurate | recompute job รายสัปดาห์ (recommend) — แต่อยู่นอก scope รอบนี้ |
+| Race condition setPrimary | 2 primary ในเวลาเดียวกัน | `SELECT FOR UPDATE` row ของ company ก่อน transaction → serialize concurrent calls; last writer wins โดย invariant ยังถูก (1 primary at a time) |
+| Lazy upsert ที่ contact-log create เกิด name collision ขณะ backfill รัน parallel | duplicate ExternalFinanceCompany rows | upsert ใช้ unique constraint บน `name` (มีอยู่แล้ว) → catch P2002 + retry SELECT |


### PR DESCRIPTION
## Summary

เพิ่มระบบ **ผู้ติดต่อบริษัทไฟแนนซ์ + ประวัติการติดตามเงินรับ** ตามแนวคิด PEAK Contact บนหน้า `FinanceReceivable` / `ExternalFinanceCompany` — สำหรับติดตามเงินรับจากไฟแนนซ์ภายนอก (KK / KTC / GFIN ฯลฯ) ที่ค้างโอน

- **Backend**: 2 ตารางใหม่ (`FinanceCompanyContact`, `FinanceReceivableContactLog`) + 4 fields บน `ExternalFinanceCompany` (taxId / email / lineOaId / creditTermDays) + KPI denorm 3 fields บน `FinanceReceivable`. 2 modules ใหม่ใน NestJS พร้อม controller / service / DTOs / role guards
- **Lazy FK resolve (D6)**: บันทึก log บน receivable ที่ยังไม่มี FK ได้ — service upsert `ExternalFinanceCompany` โดย match ด้วย normalized name
- **Promise tracking**: cron daily 02:00 BKK เซ็ต `promisedBrokenAt` เมื่อพ้นวันนัด + `recordReceive` เซ็ต `promisedKeptAt` เมื่อเงินเข้าตรงนัด
- **Frontend**: drawer + dialog + timeline + 4-tab company detail page; new columns "ติดต่อล่าสุด" / "นัดล่าสุด" + filter "มีนัดเลยกำหนด" บน `/finance-receivable`
- **Migration**: sale workflow เปลี่ยนให้ resolve FK ตั้งแต่ตอนสร้าง receivable; backfill script idempotent ย้ายข้อมูลเก่า (`contactPerson`/`contactPhone` → primary `FinanceCompanyContact` row)
- **Schema safety**: partial unique index (`uniq_primary_per_company`) บังคับ 1 primary ต่อ company โดย raw SQL — ไม่ขัดกับการมีหลาย non-primary

## Spec & Plan

- Spec: \`docs/superpowers/specs/2026-05-31-finance-receivable-contact-system-design.md\` (v2 post-scrutinize)
- Plan: \`docs/superpowers/plans/2026-05-31-finance-receivable-contact-system.md\` (22 TDD tasks)

## Test Plan

- [x] Unit: 43 tests across 5 new spec files (contacts CRUD, primary swap, lazy resolve, KPI denorm, cron, promiseKeptAt hook, normalizer)
- [x] Sales workflow: existing 42 tests still pass with new FK resolution
- [x] TypeScript: both API + Web 0 errors
- [x] Backfill idempotent: dry-run twice — second run reports 0 new/migrate
- [x] E2E (Playwright): log record + broken-promise filter (skip gracefully without seed data)
- [ ] Manual smoke: log in as \`finance@bestchoice.com\` → \`/finance-receivable\` → click row → drawer → "บันทึกการติดต่อ" → see in timeline + last contacted column

## Migration Steps (deployment order)

1. \`prisma migrate deploy\` — applies schema additions + partial unique index
2. \`npm run backfill:external-finance\` (apps/api) — backfills FK + primary contacts (idempotent, safe to re-run)
3. Deploy app

## Notes

- Drop fields \`ExternalFinanceCompany.contactPerson\` / \`contactPhone\` and the back-compat \`FinanceReceivable.financeCompany\` text column are deferred to Phase 3 (out of scope here per spec §10)
- CALL channel only in UI; enum extensible to EMAIL / LINE / MEETING
- Single promise per log (no PromiseSlot for B2B)
- Migration timestamp folder uses synthetic ordering (\`20260964000000\`) due to pre-existing schema-drift constraint in dev — not a defect this PR introduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)