### PR TITLE
feat(contacts): read-through contact detail (A1)

### DIFF
--- a/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
@@ -72,6 +72,20 @@ describe('ContactsService.findOne', () => {
     prisma.contact.findFirst.mockResolvedValue(null);
     await expect(svc.findOne('nope')).rejects.toThrow('ไม่พบผู้ติดต่อ');
   });
+  it('selects read-through fields per role record (no customer PII address)', async () => {
+    prisma.contact.findFirst.mockResolvedValue({ id: 'c1', roles: ['SUPPLIER'], customers: [], suppliers: [], tradeInsAsSeller: [], externalFinanceCompany: [] });
+    await svc.findOne('c1');
+    const include = prisma.contact.findFirst.mock.calls[0][0].include;
+    expect(include.suppliers.select).toEqual(expect.objectContaining({
+      id: true, name: true, type: true, taxId: true, branchCode: true,
+      contactName: true, contactPhone: true, phone: true, hasVat: true, address: true,
+    }));
+    expect(include.customers.select).toEqual(expect.objectContaining({ id: true, name: true, prefix: true, phone: true }));
+    expect(include.customers.select.addressCurrent).toBeUndefined();
+    expect(include.customers.select.addressIdCard).toBeUndefined();
+    expect(include.externalFinanceCompany.select).toEqual(expect.objectContaining({ id: true, name: true, taxId: true, contactPhone: true, email: true, creditTermDays: true }));
+    expect(include.tradeInsAsSeller.select).toEqual(expect.objectContaining({ id: true, sellerName: true, sellerPhone: true, createdAt: true }));
+  });
 });
 
 describe('ContactsService.merge', () => {

--- a/apps/api/src/modules/contacts/contacts.service.ts
+++ b/apps/api/src/modules/contacts/contacts.service.ts
@@ -41,10 +41,26 @@ export class ContactsService {
     const contact = await this.prisma.contact.findFirst({
       where: { id, deletedAt: null },
       include: {
-        customers: { where: { deletedAt: null }, select: { id: true, name: true } },
-        suppliers: { where: { deletedAt: null }, select: { id: true, name: true } },
-        tradeInsAsSeller: { where: { deletedAt: null }, select: { id: true, createdAt: true } },
-        externalFinanceCompany: { where: { deletedAt: null }, select: { id: true, name: true } },
+        customers: {
+          where: { deletedAt: null },
+          // identity + non-sensitive only — NO encrypted address PII (deep-link to /customers/:id for full detail)
+          select: { id: true, name: true, prefix: true, phone: true },
+        },
+        suppliers: {
+          where: { deletedAt: null },
+          select: {
+            id: true, name: true, type: true, taxId: true, branchCode: true,
+            contactName: true, contactPhone: true, phone: true, hasVat: true, address: true,
+          },
+        },
+        tradeInsAsSeller: {
+          where: { deletedAt: null },
+          select: { id: true, sellerName: true, sellerPhone: true, createdAt: true },
+        },
+        externalFinanceCompany: {
+          where: { deletedAt: null },
+          select: { id: true, name: true, taxId: true, contactPhone: true, email: true, creditTermDays: true },
+        },
       },
     });
     if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');

--- a/apps/web/src/lib/api/contacts.ts
+++ b/apps/web/src/lib/api/contacts.ts
@@ -14,6 +14,45 @@ export interface Contact {
   isActive: boolean;
 }
 
+export interface ContactCustomerLink {
+  id: string;
+  name: string;
+  prefix: string | null;
+  phone: string | null;
+}
+export interface ContactSupplierLink {
+  id: string;
+  name: string;
+  type: 'JURISTIC' | 'INDIVIDUAL';
+  taxId: string | null;
+  branchCode: string | null;
+  contactName: string | null;
+  contactPhone: string | null;
+  phone: string | null;
+  hasVat: boolean;
+  address: string | null;
+}
+export interface ContactFinanceLink {
+  id: string;
+  name: string;
+  taxId: string | null;
+  contactPhone: string | null;
+  email: string | null;
+  creditTermDays: number | null;
+}
+export interface ContactTradeInLink {
+  id: string;
+  sellerName: string | null;
+  sellerPhone: string | null;
+  createdAt: string;
+}
+export interface ContactDetail extends Contact {
+  customers: ContactCustomerLink[];
+  suppliers: ContactSupplierLink[];
+  tradeInsAsSeller: ContactTradeInLink[];
+  externalFinanceCompany: ContactFinanceLink[];
+}
+
 export interface ContactListResult {
   data: Contact[];
   total: number;
@@ -41,8 +80,7 @@ export const contactsApi = {
     if (params.isActive !== undefined) query.isActive = String(params.isActive);
     return api.get<ContactListResult>('/contacts', { params: query }).then((r) => r.data);
   },
-  detail: (id: string) =>
-    api.get<Contact & Record<string, unknown>>(`/contacts/${id}`).then((r) => r.data),
+  detail: (id: string) => api.get<ContactDetail>(`/contacts/${id}`).then((r) => r.data),
   merge: (primaryId: string, duplicateId: string) =>
     api.post('/contacts/merge', { primaryId, duplicateId }).then((r) => r.data),
 };

--- a/apps/web/src/pages/ContactDetailPage.tsx
+++ b/apps/web/src/pages/ContactDetailPage.tsx
@@ -1,12 +1,20 @@
 import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { ChevronRight } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { contactKeys, contactsApi, type ContactRole } from '@/lib/api/contacts';
+import {
+  contactKeys,
+  contactsApi,
+  type ContactRole,
+  type ContactCustomerLink,
+  type ContactSupplierLink,
+  type ContactFinanceLink,
+  type ContactTradeInLink,
+} from '@/lib/api/contacts';
 
 const ROLE_LABELS: Record<ContactRole, string> = {
   CUSTOMER: 'ลูกค้า',
@@ -22,38 +30,106 @@ const ROLE_BADGE_VARIANT: Record<ContactRole, 'primary' | 'info' | 'warning' | '
   FINANCE_COMPANY: 'secondary',
 };
 
-interface LinkedRecord {
-  id: string;
-  name?: string | null;
-}
-
-/** A single group of linked role-records with links into the real module pages. */
-function LinkedSection({
-  title,
-  records,
-  hrefFor,
-}: {
-  title: string;
-  records: LinkedRecord[];
-  hrefFor: (r: LinkedRecord) => string;
-}) {
-  if (!records || records.length === 0) return null;
+/** One labelled value inside a read-through card. */
+function Field({ label, value }: { label: string; value: string | null | undefined }) {
   return (
     <div>
-      <h3 className="text-sm font-semibold text-foreground mb-2 leading-snug">{title}</h3>
-      <div className="flex flex-col gap-1.5">
-        {records.map((r) => (
-          <Link
-            key={r.id}
-            to={hrefFor(r)}
-            className="flex items-center justify-between rounded-lg border border-border px-3 py-2 text-sm hover:bg-accent transition-colors"
-          >
-            <span className="text-foreground leading-snug">{r.name || r.id}</span>
-            <ChevronRight className="size-4 text-muted-foreground" />
-          </Link>
-        ))}
-      </div>
+      <div className="text-xs text-muted-foreground mb-0.5 leading-snug">{label}</div>
+      <div className="text-sm text-foreground leading-snug">{value || '—'}</div>
     </div>
+  );
+}
+
+/** Footer deep-link into the source module page. */
+function CardLink({ to, label }: { to: string; label: string }) {
+  return (
+    <Link
+      to={to}
+      className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline leading-snug"
+    >
+      {label}
+      <ArrowRight className="size-4" />
+    </Link>
+  );
+}
+
+function SupplierCard({ supplier }: { supplier: ContactSupplierLink }) {
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="leading-snug">{supplier.name}</CardTitle>
+        <Badge variant="info" appearance="light" size="sm">
+          {supplier.type === 'JURISTIC' ? 'นิติบุคคล' : 'บุคคลธรรมดา'}
+        </Badge>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="เลขผู้เสียภาษี" value={supplier.taxId} />
+          <Field label="เลขสาขา" value={supplier.branchCode} />
+          <Field
+            label="ผู้ติดต่อ"
+            value={
+              supplier.contactName
+                ? `${supplier.contactName}${supplier.contactPhone ? ` (${supplier.contactPhone})` : ''}`
+                : supplier.contactPhone
+            }
+          />
+          <Field label="เบอร์" value={supplier.phone} />
+          <Field label="VAT" value={supplier.hasVat ? 'จด VAT' : 'ไม่จด VAT'} />
+          <Field label="ที่อยู่" value={supplier.address} />
+        </div>
+        <CardLink to={`/suppliers/${supplier.id}`} label="เปิดข้อมูลผู้ขาย / แก้ไข" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function CustomerCard({ customer }: { customer: ContactCustomerLink }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="leading-snug">
+          {customer.prefix ? `${customer.prefix} ` : ''}
+          {customer.name}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <Field label="เบอร์" value={customer.phone} />
+        <CardLink to={`/customers/${customer.id}`} label="เปิดข้อมูลลูกค้า / แก้ไข" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function FinanceCard({ finance }: { finance: ContactFinanceLink }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="leading-snug">{finance.name}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="เลขผู้เสียภาษี" value={finance.taxId} />
+          <Field label="เบอร์" value={finance.contactPhone} />
+          <Field label="อีเมล" value={finance.email} />
+        </div>
+        <CardLink to={`/external-finance-companies/${finance.id}`} label="เปิดข้อมูล / แก้ไข" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function TradeInCard({ tradeIn }: { tradeIn: ContactTradeInLink }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="leading-snug">{tradeIn.sellerName || 'คนขายมือสอง'}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <Field label="เบอร์" value={tradeIn.sellerPhone} />
+        <CardLink to="/trade-in" label="ดูรายการรับซื้อ" />
+      </CardContent>
+    </Card>
   );
 }
 
@@ -68,18 +144,27 @@ export default function ContactDetailPage() {
     enabled: !!id,
   });
 
-  const roles = (data?.roles ?? []) as ContactRole[];
-  const customers = (data?.customers as LinkedRecord[] | undefined) ?? [];
-  const suppliers = (data?.suppliers as LinkedRecord[] | undefined) ?? [];
-  const tradeInsAsSeller = (data?.tradeInsAsSeller as LinkedRecord[] | undefined) ?? [];
-  const externalFinanceCompany =
-    (data?.externalFinanceCompany as LinkedRecord[] | undefined) ?? [];
+  const roles = data?.roles ?? [];
+  const customers = data?.customers ?? [];
+  const suppliers = data?.suppliers ?? [];
+  const tradeInsAsSeller = data?.tradeInsAsSeller ?? [];
+  const externalFinanceCompany = data?.externalFinanceCompany ?? [];
+
+  const hasNoLinks =
+    customers.length === 0 &&
+    suppliers.length === 0 &&
+    tradeInsAsSeller.length === 0 &&
+    externalFinanceCompany.length === 0;
+
+  const isJuristic =
+    suppliers.some((s) => s.type === 'JURISTIC') || roles.includes('FINANCE_COMPANY');
+  const entityType = isJuristic ? 'นิติบุคคล' : 'บุคคลธรรมดา';
 
   return (
     <div>
       <PageHeader
         title={data ? data.name : 'ผู้ติดต่อ'}
-        subtitle={data?.contactCode}
+        subtitle={data ? `${data.contactCode} · ${entityType}` : undefined}
         onBack={() => navigate('/contacts')}
         badge={
           data && !data.isActive ? (
@@ -98,19 +183,23 @@ export default function ContactDetailPage() {
         errorTitle="ไม่สามารถโหลดข้อมูลผู้ติดต่อได้"
       >
         {data && (
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            {/* ข้อมูลทั่วไป */}
-            <Card className="lg:col-span-1">
+          <div className="flex flex-col gap-5">
+            <Card>
               <CardHeader>
                 <CardTitle>ข้อมูลทั่วไป</CardTitle>
               </CardHeader>
               <CardContent className="flex flex-col gap-3">
                 <div>
-                  <div className="text-xs text-muted-foreground mb-1">กลุ่ม</div>
+                  <div className="text-xs text-muted-foreground mb-1 leading-snug">กลุ่ม</div>
                   <div className="flex flex-wrap gap-1">
                     {roles.length > 0 ? (
                       roles.map((r) => (
-                        <Badge key={r} variant={ROLE_BADGE_VARIANT[r]} appearance="light" size="sm">
+                        <Badge
+                          key={r}
+                          variant={ROLE_BADGE_VARIANT[r]}
+                          appearance="light"
+                          size="sm"
+                        >
                           {ROLE_LABELS[r]}
                         </Badge>
                       ))
@@ -119,63 +208,48 @@ export default function ContactDetailPage() {
                     )}
                   </div>
                 </div>
-                <div>
-                  <div className="text-xs text-muted-foreground mb-0.5">เลขผู้เสียภาษี</div>
-                  <div className="text-sm text-foreground font-mono">{data.taxId || '—'}</div>
+                <div className="grid grid-cols-2 gap-3">
+                  <Field label="เลขผู้เสียภาษี" value={data.taxId} />
+                  <Field label="เบอร์โทร" value={data.phone} />
+                  <Field label="อีเมล" value={data.email} />
+                  {data.peakContactCode && (
+                    <Field label="รหัส PEAK" value={data.peakContactCode} />
+                  )}
                 </div>
-                <div>
-                  <div className="text-xs text-muted-foreground mb-0.5">เบอร์โทร</div>
-                  <div className="text-sm text-foreground tabular-nums">{data.phone || '—'}</div>
-                </div>
-                <div>
-                  <div className="text-xs text-muted-foreground mb-0.5">อีเมล</div>
-                  <div className="text-sm text-foreground">{data.email || '—'}</div>
-                </div>
-                {data.peakContactCode && (
-                  <div>
-                    <div className="text-xs text-muted-foreground mb-0.5">รหัส PEAK</div>
-                    <div className="text-sm text-foreground font-mono">{data.peakContactCode}</div>
-                  </div>
-                )}
               </CardContent>
             </Card>
 
-            {/* ระเบียนที่เชื่อมโยง */}
-            <Card className="lg:col-span-2">
-              <CardHeader>
-                <CardTitle>ระเบียนที่เชื่อมโยง</CardTitle>
-              </CardHeader>
-              <CardContent className="flex flex-col gap-5">
-                <LinkedSection
-                  title="ลูกค้า"
-                  records={customers}
-                  hrefFor={(r) => `/customers/${r.id}`}
-                />
-                <LinkedSection
-                  title="ผู้ขาย"
-                  records={suppliers}
-                  hrefFor={(r) => `/suppliers/${r.id}`}
-                />
-                <LinkedSection
-                  title="คนขายมือสอง"
-                  records={tradeInsAsSeller}
-                  hrefFor={() => '/trade-in'}
-                />
-                <LinkedSection
-                  title="ไฟแนนซ์"
-                  records={externalFinanceCompany}
-                  hrefFor={(r) => `/external-finance-companies/${r.id}`}
-                />
-                {customers.length === 0 &&
-                  suppliers.length === 0 &&
-                  tradeInsAsSeller.length === 0 &&
-                  externalFinanceCompany.length === 0 && (
+            <div>
+              <h2 className="text-base font-semibold text-foreground mb-3 leading-snug">
+                ข้อมูลกิจการ
+              </h2>
+              {hasNoLinks ? (
+                <Card>
+                  <CardContent className="flex flex-col gap-3 pt-6">
                     <p className="text-sm text-muted-foreground leading-snug">
-                      ยังไม่มีระเบียนที่เชื่อมโยงกับผู้ติดต่อนี้
+                      ยังไม่ผูกกับลูกค้า/ผู้ขาย
                     </p>
-                  )}
-              </CardContent>
-            </Card>
+                    <Field label="ชื่อ" value={data.name} />
+                    <Field label="เบอร์โทร" value={data.phone} />
+                  </CardContent>
+                </Card>
+              ) : (
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  {suppliers.map((s) => (
+                    <SupplierCard key={s.id} supplier={s} />
+                  ))}
+                  {customers.map((c) => (
+                    <CustomerCard key={c.id} customer={c} />
+                  ))}
+                  {externalFinanceCompany.map((f) => (
+                    <FinanceCard key={f.id} finance={f} />
+                  ))}
+                  {tradeInsAsSeller.map((t) => (
+                    <TradeInCard key={t.id} tradeIn={t} />
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         )}
       </QueryBoundary>

--- a/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import ContactDetailPage from '../ContactDetailPage';
+import { contactsApi } from '@/lib/api/contacts';
+
+vi.mock('@/lib/api/contacts', async (orig) => {
+  const actual = await orig<typeof import('@/lib/api/contacts')>();
+  return { ...actual, contactsApi: { ...actual.contactsApi, detail: vi.fn() } };
+});
+
+function wrap(id: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/contacts/${id}`]}>
+        <Routes>
+          <Route path="/contacts/:id" element={<ContactDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ContactDetailPage', () => {
+  it('renders a supplier read-through card with a deep-link to the supplier page', async () => {
+    (contactsApi.detail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'c1',
+      contactCode: 'P-00002',
+      name: 'บ.แอปเปิล',
+      roles: ['SUPPLIER'],
+      isActive: true,
+      taxId: '0105500000010',
+      phone: null,
+      email: null,
+      peakContactCode: null,
+      customers: [],
+      tradeInsAsSeller: [],
+      externalFinanceCompany: [],
+      suppliers: [
+        {
+          id: 's1',
+          name: 'บ.แอปเปิล',
+          type: 'JURISTIC',
+          taxId: '0105500000010',
+          branchCode: '00000',
+          contactName: 'คุณเอ',
+          contactPhone: '02',
+          phone: '02',
+          hasVat: true,
+          address: 'กทม',
+        },
+      ],
+    });
+    wrap('c1');
+    await waitFor(() => expect(screen.getAllByText('บ.แอปเปิล').length).toBeGreaterThan(0));
+    const link = screen.getByRole('link', { name: /แก้ไข|เปิดข้อมูล|ผู้ขาย/ });
+    expect(link).toHaveAttribute('href', '/suppliers/s1');
+  });
+});

--- a/docs/superpowers/plans/2026-06-01-contact-rich-detail-A1.md
+++ b/docs/superpowers/plans/2026-06-01-contact-rich-detail-A1.md
@@ -1,0 +1,222 @@
+# Contact Rich Detail (A1, read-through) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** หน้า Contact detail แสดงข้อมูลกิจการแบบ read-through จาก Customer/Supplier/ExternalFinanceCompany/TradeIn ที่ link อยู่ + ปุ่ม deep-link ไปแก้ที่หน้าต้นทางเดิม — โดยไม่เก็บ column ซ้ำบน Contact
+
+**Architecture:** ขยาย `select` ใน `ContactsService.findOne` ให้ดึงฟิลด์ระบุตัวตน/ไม่อ่อนไหวจาก role record ที่ link (ไม่ดึง address PII ของลูกค้า). Frontend แสดงการ์ดต่อ role record + ปุ่ม "เปิด/แก้ไข →" ที่ deep-link. ไม่มี Contact column ใหม่ / migration / PATCH.
+
+**Tech Stack:** NestJS + Prisma + Jest (api), React + react-query + react-router + shadcn/ui + Vitest (web)
+
+**Spec:** `docs/superpowers/specs/2026-06-01-contact-rich-fields-A1-design.md`
+
+---
+
+## File Structure
+
+- Modify: `apps/api/src/modules/contacts/contacts.service.ts` — expand `findOne` select
+- Modify: `apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts` — assert expanded select fields
+- Modify: `apps/web/src/lib/api/contacts.ts` — typed linked-record shapes on detail response
+- Modify: `apps/web/src/pages/ContactDetailPage.tsx` — read-through cards + deep-links
+
+---
+
+## Task 1: Backend — expand findOne select (read-through fields)
+
+**Files:**
+- Modify: `apps/api/src/modules/contacts/contacts.service.ts` (the `findOne` method)
+- Test: `apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts`
+
+- [ ] **Step 1: Write/extend the failing test**
+
+แทนที่/เพิ่ม test ใน describe `ContactsService.findOne` ให้ assert ว่า select ดึงฟิลด์ที่ขยาย และ **ไม่ดึง address PII ของลูกค้า**:
+```typescript
+it('selects read-through fields per role record (no customer PII address)', async () => {
+  prisma.contact.findFirst.mockResolvedValue({ id: 'c1', roles: ['SUPPLIER'], customers: [], suppliers: [], tradeInsAsSeller: [], externalFinanceCompany: [] });
+  await svc.findOne('c1');
+  const include = prisma.contact.findFirst.mock.calls[0][0].include;
+  // suppliers: rich non-PII fields
+  expect(include.suppliers.select).toEqual(expect.objectContaining({
+    id: true, name: true, type: true, taxId: true, branchCode: true,
+    contactName: true, contactPhone: true, phone: true, hasVat: true, address: true,
+  }));
+  // customers: identity only, NO encrypted address columns
+  expect(include.customers.select).toEqual(expect.objectContaining({ id: true, name: true, prefix: true, phone: true }));
+  expect(include.customers.select.addressCurrent).toBeUndefined();
+  expect(include.customers.select.addressIdCard).toBeUndefined();
+  // finance company
+  expect(include.externalFinanceCompany.select).toEqual(expect.objectContaining({ id: true, name: true, taxId: true, contactPhone: true, email: true, creditTermDays: true }));
+  // trade-in seller free-text
+  expect(include.tradeInsAsSeller.select).toEqual(expect.objectContaining({ id: true, sellerName: true, sellerPhone: true, createdAt: true }));
+});
+```
+> NB: the existing `findOne` tests in this describe (returns-linked-records, NotFound) must keep passing — adapt their mock `findFirst` return to still satisfy them; do not delete them.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api && npx jest contacts.service --silent`
+Expected: FAIL — select lacks the new fields
+
+- [ ] **Step 3: Implement — expand the include/select**
+
+แก้ `findOne` ใน `contacts.service.ts`:
+```typescript
+async findOne(id: string) {
+  const contact = await this.prisma.contact.findFirst({
+    where: { id, deletedAt: null },
+    include: {
+      customers: {
+        where: { deletedAt: null },
+        // identity + non-sensitive only — NO encrypted address PII (deep-link to /customers/:id for full detail)
+        select: { id: true, name: true, prefix: true, phone: true },
+      },
+      suppliers: {
+        where: { deletedAt: null },
+        select: {
+          id: true, name: true, type: true, taxId: true, branchCode: true,
+          contactName: true, contactPhone: true, phone: true, hasVat: true, address: true,
+        },
+      },
+      tradeInsAsSeller: {
+        where: { deletedAt: null },
+        select: { id: true, sellerName: true, sellerPhone: true, createdAt: true },
+      },
+      externalFinanceCompany: {
+        where: { deletedAt: null },
+        select: { id: true, name: true, taxId: true, contactPhone: true, email: true, creditTermDays: true },
+      },
+    },
+  });
+  if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+  return contact;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes + type-check**
+
+Run: `cd apps/api && npx jest contacts.service --silent && cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api`
+Expected: PASS + 0 type errors. (If `prefix`/`branchCode`/`hasVat`/`address`/`type` aren't valid select keys, the Prisma client type-check will fail — confirm the exact field names against `schema.prisma`: Supplier has `type`, `branchCode`, `contactName`, `contactPhone`, `phone`, `hasVat`, `address`, `taxId`; Customer has `prefix`, `phone`, `name`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && git add apps/api/src/modules/contacts && git commit -m "feat(contacts): expand findOne select for read-through detail (no customer PII)"
+```
+
+---
+
+## Task 2: Frontend — read-through cards + deep-links
+
+**Files:**
+- Modify: `apps/web/src/lib/api/contacts.ts` (typed detail response)
+- Modify: `apps/web/src/pages/ContactDetailPage.tsx`
+- Test: `apps/web/src/pages/__tests__/ContactDetailPage.test.tsx` (create)
+
+- [ ] **Step 1: Add typed linked-record shapes to the api client**
+
+ใน `apps/web/src/lib/api/contacts.ts` เพิ่ม types + ใช้กับ `detail`:
+```typescript
+export interface ContactCustomerLink { id: string; name: string; prefix: string | null; phone: string | null; }
+export interface ContactSupplierLink { id: string; name: string; type: 'JURISTIC' | 'INDIVIDUAL'; taxId: string | null; branchCode: string | null; contactName: string | null; contactPhone: string | null; phone: string | null; hasVat: boolean; address: string | null; }
+export interface ContactFinanceLink { id: string; name: string; taxId: string | null; contactPhone: string | null; email: string | null; creditTermDays: number | null; }
+export interface ContactTradeInLink { id: string; sellerName: string | null; sellerPhone: string | null; createdAt: string; }
+
+export interface ContactDetail extends Contact {
+  customers: ContactCustomerLink[];
+  suppliers: ContactSupplierLink[];
+  tradeInsAsSeller: ContactTradeInLink[];
+  externalFinanceCompany: ContactFinanceLink[];
+}
+```
+และเปลี่ยน `detail` ให้คืน `ContactDetail`:
+```typescript
+detail: (id: string) => api.get<ContactDetail>(`/contacts/${id}`).then((r) => r.data),
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`apps/web/src/pages/__tests__/ContactDetailPage.test.tsx`:
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { vi } from 'vitest';
+import ContactDetailPage from '../ContactDetailPage';
+import { contactsApi } from '@/lib/api/contacts';
+
+vi.mock('@/lib/api/contacts', async (orig) => {
+  const actual = await orig<typeof import('@/lib/api/contacts')>();
+  return { ...actual, contactsApi: { ...actual.contactsApi, detail: vi.fn() } };
+});
+
+function wrap(id: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/contacts/${id}`]}>
+        <Routes><Route path="/contacts/:id" element={<ContactDetailPage />} /></Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+it('renders a supplier read-through card with a deep-link to the supplier page', async () => {
+  (contactsApi.detail as any).mockResolvedValue({
+    id: 'c1', contactCode: 'P-00002', name: 'บ.แอปเปิล', roles: ['SUPPLIER'], isActive: true,
+    taxId: '0105500000010', phone: null, email: null, peakContactCode: null,
+    customers: [], tradeInsAsSeller: [], externalFinanceCompany: [],
+    suppliers: [{ id: 's1', name: 'บ.แอปเปิล', type: 'JURISTIC', taxId: '0105500000010', branchCode: '00000', contactName: 'คุณเอ', contactPhone: '02', phone: '02', hasVat: true, address: 'กทม' }],
+  });
+  wrap('c1');
+  await waitFor(() => expect(screen.getByText('บ.แอปเปิล')).toBeInTheDocument());
+  const link = screen.getByRole('link', { name: /แก้ไข|เปิดข้อมูล|ผู้ขาย/ });
+  expect(link).toHaveAttribute('href', '/suppliers/s1');
+});
+```
+> Match the repo's existing page-test idioms (router import path `react-router`, api-mock style) — mirror `ContactsPage.test.tsx`.
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd apps/web && npx vitest run ContactDetailPage --silent`
+Expected: FAIL — no supplier card / link yet
+
+- [ ] **Step 4: Implement the read-through cards**
+
+แก้ `ContactDetailPage.tsx` แท็บ "ข้อมูลกิจการ" ให้ render การ์ดต่อ role record จาก `ContactDetail`:
+- การ์ดผู้ขาย (suppliers[]): แสดง name, type (badge นิติบุคคล/บุคคล), taxId, เลขสาขา, ผู้ติดต่อ (contactName/contactPhone), เบอร์, VAT, address + `<Link to={`/suppliers/${s.id}`}>เปิดข้อมูลผู้ขาย / แก้ไข →</Link>`
+- การ์ดลูกค้า (customers[]): prefix+name, เบอร์ + `<Link to={`/customers/${c.id}`}>เปิดข้อมูลลูกค้า / แก้ไข →</Link>` (ไม่โชว์ที่อยู่ — อยู่หน้าลูกค้า)
+- การ์ดบริษัทไฟแนนซ์ (externalFinanceCompany[]): name, taxId, เบอร์, email + `<Link to={`/external-finance-companies/${f.id}`}>เปิด / แก้ไข →</Link>`
+- การ์ดคนขายมือสอง (tradeInsAsSeller[]): sellerName/sellerPhone (read-only) + `<Link to="/trade-in">ดูรายการรับซื้อ →</Link>`
+- ถ้าไม่มี role record เลย: แสดงข้อความ "ยังไม่ผูกกับลูกค้า/ผู้ขาย" + ข้อมูล Contact เท่าที่มี (name/phone)
+- derived entityType ที่หัว: ถ้ามี supplier.type==='JURISTIC' หรือ role FINANCE_COMPANY → "นิติบุคคล" ไม่งั้น "บุคคลธรรมดา"
+- ใช้ `Link` จาก `react-router`, semantic tokens, Thai `leading-snug`, ใช้ shadcn `Card`/`Badge` ตาม pattern หน้าอื่น (ดู ExternalFinanceCompanyDetailPage / CustomerDetailPage เป็น reference)
+
+- [ ] **Step 5: Run to verify it passes + type-check**
+
+Run: `cd apps/web && npx vitest run ContactDetailPage --silent && cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web`
+Expected: PASS + 0 type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && git add apps/web/src/lib/api/contacts.ts apps/web/src/pages/ContactDetailPage.tsx apps/web/src/pages/__tests__/ContactDetailPage.test.tsx && git commit -m "feat(contacts): read-through detail cards + deep-links to source records"
+```
+
+---
+
+## Task 3: Verify
+
+**Files:** none
+
+- [ ] **Step 1: Full type-check** — `cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh all` → 0 errors
+- [ ] **Step 2: Contacts tests** — `cd apps/api && npx jest contacts --silent` + `cd apps/web && npx vitest run Contact --silent` → green
+- [ ] **Step 3: Confirm no Contact schema change** — `git diff main --stat -- apps/api/prisma` → should show NO migration/schema changes (A1 is read-through only; if a migration appears, something went wrong)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** read-through select (Task 1) ✓; read-through cards + deep-links (Task 2) ✓; no new columns/migration/backfill/PATCH ✓ (Task 3 step 3 guards it); no customer PII via contacts endpoint (Task 1 asserts address columns absent) ✓; multi-role → multiple cards (Task 2) ✓; no-record fallback (Task 2) ✓; derived entityType (Task 2) ✓.
+- **Placeholders:** none — all code shown; field names verified against schema (Supplier.type/branchCode/contactName/contactPhone/phone/hasVat/address/taxId; Customer.prefix/phone/name; ExternalFinanceCompany.taxId/contactPhone/email/creditTermDays; TradeIn.sellerName/sellerPhone).
+- **Type consistency:** `ContactDetail` shape in api client (Task 2 step 1) matches the backend select (Task 1 step 3) field-for-field.
+- DBD lookup (A2), accounting fields (B), overview tab (C) are out of scope per spec.

--- a/docs/superpowers/specs/2026-06-01-contact-rich-fields-A1-design.md
+++ b/docs/superpowers/specs/2026-06-01-contact-rich-fields-A1-design.md
@@ -1,106 +1,67 @@
-# Contact Rich Fields + Edit Form (Sub-project A1)
+# Contact Rich Detail — Read-Through (Sub-project A1, reworked)
 
 วันที่: 2026-06-01
 สถานะ: รออนุมัติ spec จาก owner
 ส่วนหนึ่งของ: PEAK-style contact detail expansion (A → B → C). อันนี้คือ **A1**.
 
-## ที่มา
+> **เวอร์ชันนี้ rework หลัง /scrutinize** — เวอร์ชันแรกเก็บ column ซ้ำบน Contact (address/entityType/branchCode/prefix) ซึ่งซ้ำกับ Customer/Supplier และทำให้ข้อมูลแตก 2 ชุด (เอกสารกฎหมายอ่านจาก Customer/Supplier ไม่ใช่ Contact). เวอร์ชันนี้ใช้ **read-through**: Contact คงเป็น party key บางๆ, หน้า detail ดึงข้อมูลจาก record ต้นทางมาแสดง + ลิงก์ไปแก้ที่ต้นทาง.
 
-หน้า contact detail ปัจจุบันมีแค่ field พื้นฐาน (code, name, taxId, phone, email, address เดี่ยว, roles, isActive). owner ต้องการให้ครบแบบ PEAK ซึ่งแยกเป็นหลาย sub-project:
+## ปัญหาที่ scrutinize เจอ (เหตุผลของการ rework)
 
-- **A** = ฟิลด์ครบ + edit form  ← spec นี้ (A1) + DBD lookup (A2, ทีหลัง)
-- **B** = ผังบัญชีต่อ contact (AR/AP/IR-GR code, ครบกำหนดชำระ, ธนาคารคู่ค้า) — spec แยก
-- **C** = แท็บภาพรวมการเงิน (ยอดขาย/AR aging/เอกสาร/กราฟ) — spec แยก
+- ฟิลด์เกือบทั้งหมดที่อยากเพิ่มมีอยู่แล้ว: `entityType`↔`Supplier.type`, `prefix`↔`Customer.prefix`, `branchCode`↔`Supplier.branchCode`, address↔`Customer.addressIdCard/addressCurrent` + `Supplier.address`
+- สัญญา/ใบเสร็จอ่าน address จาก **Customer** ([contract-workflow.service.ts:176-177](../../apps/api/src/modules/contracts/contract-workflow.service.ts), [contracts.service.ts:173](../../apps/api/src/modules/contracts/contracts.service.ts)) → ถ้าเก็บซ้ำบน Contact แล้วแก้ที่ Contact จะไม่กระทบเอกสาร = ข้อมูลขัดกัน
+- มี `CustomerDetailPage.tsx` + `SupplierDetailPage.tsx` ฟอร์มแก้ไขครบอยู่แล้ว และเป็นตัวจริงที่ระบบใช้
 
-ลำดับ build: A1 → A2 → B → C.
+## หลักการ A1 (reworked)
 
-## ขอบเขต A1 (ชัดเจน)
+- **Contact = party key บางๆ** (identity + link + roles) — **ไม่เพิ่ม column ข้อมูลกิจการ/ที่อยู่**
+- หน้า detail แท็บ "ข้อมูลกิจการ" = **read-through** ประกอบจาก record ต้นทางที่ link อยู่ (Customer / Supplier / ExternalFinanceCompany)
+- **แก้ไข = deep-link ไปหน้าต้นทางเดิม** (ที่มีฟอร์มครบ + เป็นตัวที่เอกสารใช้) — ไม่มี PATCH ฟิลด์บน Contact, ไม่มี migration, ไม่มี backfill
+- **ไม่ duplicate PII inline**: ที่อยู่ลูกค้าเป็น PII เข้ารหัส — ไม่ดึงมาโชว์เต็มในหน้า contact (เลี่ยง PDPA/decrypt ผ่าน endpoint ใหม่) แสดงแค่ field ระบุตัวตน/ไม่อ่อนไหว + ลิงก์ไปดูเต็มที่หน้าต้นทาง
+
+## ขอบเขต A1
 
 ทำ:
-- ขยาย `Contact` model ด้วย field ระดับกิจการ + ที่อยู่ structured (เก็บเป็น text)
-- ฟอร์ม **แก้ไข** Contact (modal) บนหน้า detail + แท็บ "ข้อมูลกิจการ"
-- `PATCH /contacts/:id`
-- backfill `entityType` ของ 37 rows เดิม
+- ขยาย `GET /contacts/:id` ให้ `select` ฟิลด์ระบุตัวตน/ไม่อ่อนไหวเพิ่มจาก record ที่ link (Supplier: type, taxId, branchCode, contactName, contactPhone, phone, hasVat ; Customer: prefix, phone, email, nationalId — **ไม่ดึง address PII** ; ExternalFinanceCompany: taxId, contactPhone, email, creditTermDays)
+- หน้า `ContactDetailPage` แท็บ "ข้อมูลกิจการ" แสดง **การ์ดต่อ role record** + ปุ่ม "เปิดข้อมูลเต็ม / แก้ไข →" deep-link
+- derive `entityType` แบบ read-time (มี role SUPPLIER/FINANCE_COMPANY หรือ Supplier.type=JURISTIC → นิติบุคคล ; ไม่งั้น บุคคล) — ไม่ต้องเก็บ column
 
-ไม่ทำ (อยู่ sub-project อื่น / YAGNI):
-- DBD/สรรพากร tax-id lookup → **A2** (รอ owner มี API token; ออกแบบ field+form ให้รองรับการต่อทีหลังไว้)
-- ช่องบัญชี (AR/AP code, credit term, ธนาคารคู่ค้า) → **B**
-- แท็บภาพรวมการเงิน → **C**
-- การ **สร้าง** Contact ใหม่ตรงๆ จาก /contacts — ยังผ่านฟอร์มลูกค้า/ผู้ขายเดิม (เหมือน v1). A1 ทำแค่ **แก้ไข** รายที่มีอยู่
-- ผู้ติดต่อบุคคล (sub-contacts), แนบไฟล์, กลุ่มกำหนดเอง, วงเงินขายเชื่อ, แฟกซ์ — ตัด
+ไม่ทำ:
+- เพิ่ม column บน Contact / migration / backfill / PATCH ฟิลด์กิจการบน Contact
+- DBD lookup → A2 ; ช่องบัญชี → B ; ภาพรวมการเงิน → C
+- ฟิลด์ที่ไม่มีบน record ต้นทางใดเลย (เช่น website, fax) — ถ้าจำเป็นจริง เพิ่มที่ **record ต้นทาง** (เช่น Supplier) ไม่ใช่ Contact — แยกพิจารณานอก A1 (YAGNI)
 
-## 1. โครงข้อมูล (ขยาย Contact)
+## 1. Backend
 
-เพิ่ม field nullable ทั้งหมด (2-step migration ปลอดภัยกับ 37 rows):
+ขยาย `ContactsService.findOne(id)` include/select (ของเดิม select แค่ `{id,name}`):
+- `customers`: `{ id, name, prefix, phone, email, nationalId, customerCode? }` — **ไม่ดึง addressCurrent/addressIdCard (PII)**
+- `suppliers`: `{ id, name, type, taxId, branchCode, contactName, contactPhone, phone, hasVat, address }` (Supplier.address ไม่ใช่ PII เข้ารหัส — ดึงได้)
+- `tradeInsAsSeller`: `{ id, sellerName, sellerPhone, createdAt }` (free-text, read-only)
+- `externalFinanceCompany`: `{ id, name, taxId, contactPhone, email, creditTermDays }`
 
-```
-enum ContactEntityType { JURISTIC, INDIVIDUAL }
+ไม่เพิ่ม endpoint ใหม่. guard เดิม. respect `deletedAt: null` เดิม.
 
-Contact (เพิ่ม)
-  entityType      ContactEntityType?           // นิติบุคคล / บุคคลธรรมดา
-  titlePrefix     String?                        // คำนำหน้า (คุณ/นาย/นาง/บจก.)
-  firstName       String?                        // บุคคลธรรมดา
-  lastName        String?                        // บุคคลธรรมดา
-  branchCode      String?                        // เลขที่สาขา ("00000"=สำนักงานใหญ่) — นิติบุคคล
-  website         String?
+> NB: ถ้าต้องการโชว์ address ลูกค้าในหน้า contact จริงๆ ภายหลัง ให้ทำผ่าน CustomerPiiService decrypt + PDPA guard เป็นงานแยก — A1 ไม่ทำ (ลิงก์ไปดูที่ CustomerDetailPage แทน)
 
-  // ที่อยู่จดทะเบียน (text — ไม่ FK; reuse AddressForm ฝั่ง web)
-  regAddressLine  String?
-  regSubdistrict  String?                        // ชื่อตำบล/แขวง
-  regDistrict     String?                        // ชื่ออำเภอ/เขต
-  regProvince     String?                        // ชื่อจังหวัด
-  regPostalCode   String?
+## 2. Frontend
 
-  // ที่อยู่จัดส่งเอกสาร
-  shipSameAsReg   Boolean  @default(true)
-  shipAddressLine String?
-  shipSubdistrict String?
-  shipDistrict    String?
-  shipProvince    String?
-  shipPostalCode  String?
-```
+`ContactDetailPage` แท็บ "ข้อมูลกิจการ" (reworked):
+- หัว: contactCode, name (display), badge roles, derived entityType, isActive
+- **การ์ดต่อ role record** (วนตาม customers/suppliers/finance/tradeIns ที่มี):
+  - การ์ดลูกค้า: prefix+name, เบอร์, email, เลขบัตร(mask) + ปุ่ม **"เปิดข้อมูลลูกค้า / แก้ไข →"** → `/customers/{id}`
+  - การ์ดผู้ขาย: name, type, taxId, เลขสาขา, ผู้ติดต่อ, เบอร์, hasVat, address + ปุ่ม → `/suppliers/{id}`
+  - การ์ดบริษัทไฟแนนซ์: name, taxId, เบอร์, email + ปุ่ม → `/external-finance-companies/{id}`
+  - การ์ดคนขายมือสอง: sellerName/sellerPhone (read-only, อาจลิงก์ `/trade-in`)
+- ถ้า Contact ไม่มี role record เลย (กรณีหายาก) → แสดงข้อมูลเท่าที่ Contact มี (name/phone) + หมายเหตุ "ยังไม่ผูกกับลูกค้า/ผู้ขาย"
+- ใช้ semantic tokens, Thai `leading-snug`
+- ไม่ต้องมี edit modal/form ใน A1 (แก้ที่หน้าต้นทาง)
 
-หมายเหตุ:
-- `name` เดิม = display name (list/search ใช้ตัวนี้ ไม่เปลี่ยน). ที่อยู่เก็บเป็นชื่อ (string) ตามที่ทั้งแอปทำ — **ไม่มี DB address module ให้ FK** (`thai-address-data.ts` เป็น static ฝั่ง frontend, ไม่มีตาราง). UX dropdown ได้จาก component `AddressForm` ที่มีอยู่แล้ว.
-- ไม่แตะ `taxId` / `email` / `phone` / `lineId` / `roles` / `isActive` เดิม.
+## 3. ทดสอบ
 
-## 2. Backend
+- API: `findOne` คืน field ที่ขยายต่อ role record ครบ, **ไม่หลุด address PII ของลูกค้า**, soft-delete filter, NotFound
+- Web: แท็บข้อมูลกิจการ render การ์ดตาม role ที่มี, ปุ่ม deep-link ชี้ path ถูก (`/customers/:id` ฯลฯ), กรณีหลาย role โชว์หลายการ์ด, กรณีไม่มี record โชว์ fallback
 
-- `PATCH /contacts/:id` — รับ field ข้างบน (DTO `UpdateContactDto`, class-validator, ข้อความ error ไทย). guard `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles('OWNER','FINANCE_MANAGER','ACCOUNTANT')`. audit string `CONTACT_UPDATED` (ผ่าน AuditInterceptor เดิม).
-- **name-sync** ใน service ตอน update:
-  - `INDIVIDUAL` → `name = [titlePrefix] + firstName + lastName` (trim ช่องว่างซ้อน)
-  - `JURISTIC` → `name = <ชื่อกิจการที่ส่งมา>` (field เดียวกับ name)
-- soft-delete filter `deletedAt: null` เหมือนเดิม; โยน `NotFoundException('ไม่พบผู้ติดต่อ')` ถ้าไม่เจอ.
+## หมายเหตุต่อ B / C
 
-## 3. Frontend
-
-หน้า `ContactDetailPage` แท็บ **"ข้อมูลกิจการ"** (เลียน layout PEAK):
-- กลุ่ม **ข้อมูลจดทะเบียน**: ประเภท (badge นิติบุคคล/บุคคล), เลขภาษี, เลขสาขา, ที่อยู่จดทะเบียน (รวมเป็นบรรทัด)
-- กลุ่ม **ช่องทางติดต่อ**: เบอร์, อีเมล, เว็บไซต์, LINE, ที่อยู่จัดส่ง
-- toggle **เปิด/ปิดใช้งาน** (isActive) → PATCH
-- ปุ่ม **"แก้ไข"** → **modal** (react-hook-form + zod ตาม pattern โปรเจค):
-  - toggle **นิติบุคคล / บุคคลธรรมดา** → conditional: นิติบุคคล = ชื่อกิจการ + เลขสาขา ; บุคคล = คำนำหน้า + ชื่อ + สกุล
-  - taxId, website, phone, email, LINE
-  - `AddressForm` (component เดิม) สำหรับที่อยู่จดทะเบียน + checkbox "ที่อยู่จัดส่ง = ที่อยู่จดทะเบียน" → ติ๊กออกเพื่อโชว์ `AddressForm` ตัวที่สองสำหรับที่อยู่จัดส่ง
-  - submit → `PATCH /contacts/:id` → invalidate react-query → ปิด modal + toast success (sonner)
-- ใช้ semantic tokens เท่านั้น (frontend.md), Thai `leading-snug`
-- API client เพิ่ม `contactsApi.update(id, payload)` ใน `lib/api/contacts.ts`
-
-## 4. Migration + Backfill
-
-- Migration เพิ่ม column ข้างบน (nullable) + enum `ContactEntityType`. **ตั้งชื่อโฟลเดอร์ migration ด้วย synthetic timestamp ให้เรียงท้ายสุด** (สูงกว่า `20260966000000`) — กันบั๊กลำดับ migration ที่เคยทำ CI/prod พัง (วันที่จริงเรียงไปกลาง history ก่อนตารางที่อ้างถูกสร้าง). verify ด้วย `migrate reset` จาก dev DB ว่า apply ท้ายสุดสะอาด.
-- Backfill `entityType` ของ rows เดิม (CLI `src/cli/` แบบ compiled — ไม่ใช่ `tsx scripts/` — เพื่อรันเป็น Cloud Run Job บน prod ได้; บทเรียนจาก backfill ก่อน). guard `CONFIRM_BACKFILL` + `EXPECTED_DB_NAME` (prod = `bestchoice`, ไม่ใช่ `bestchoice_prod`):
-  - contact ที่มี role SUPPLIER/FINANCE_COMPANY หรือมี taxId 13 หลักของนิติบุคคล → `JURISTIC`
-  - ที่เหลือ (CUSTOMER/TRADE_IN_SELLER บุคคล) → `INDIVIDUAL`
-  - idempotent: ข้าม row ที่ entityType ไม่ null แล้ว
-  - ไม่ parse `name` เดิมเป็น firstName/lastName (เสี่ยง) — ปล่อย null ให้ผู้ใช้กรอกตอนแก้ไข
-
-## 5. ทดสอบ
-
-- API: `UpdateContactDto` validation; name-sync ถูกตาม entityType (INDIVIDUAL ประกอบ prefix+first+last / JURISTIC ใช้ชื่อกิจการ); conditional update; NotFound; RolesGuard (OWNER/FM/ACC).
-- Web: edit modal — toggle entityType โชว์ field ถูกชุด; AddressForm 2 ตัว + checkbox shipSameAsReg ซ่อน/โชว์; submit ยิง PATCH ด้วย payload ถูก.
-- Backfill: idempotent (รันซ้ำ entityType ไม่เปลี่ยน), จับ entityType ตาม role/taxId ถูก.
-
-## 6. รองรับ A2 (DBD lookup) ในอนาคต
-
-ออกแบบฟอร์มให้มีที่วางปุ่ม "ค้นหา" ข้างช่อง taxId ไว้ (A2 จะมาเติม handler ที่เรียก DBD API แล้ว auto-fill ชื่อ/ที่อยู่). A1 ปล่อยช่อง taxId ให้กรอกมือไปก่อน — ไม่มี handler lookup.
+- **B (ผังบัญชีต่อ contact)**: ทบทวนด้วยหลักเดียวกัน — Supplier มี payment method/bank อยู่แล้ว, chart-of-accounts มี per-account mapping ; ดูว่าควรเก็บ AR/AP code ที่ระดับ Contact (ตัวจริงที่ journal อ้างได้) หรือ derive — brainstorm แยกตอนเริ่ม B
+- **C (ภาพรวมการเงิน)**: aggregate read-only ข้าม sales/contract/payment ตาม contactId/ลิงก์ — read-through ล้วน ไม่เก็บซ้ำ

--- a/docs/superpowers/specs/2026-06-01-contact-rich-fields-A1-design.md
+++ b/docs/superpowers/specs/2026-06-01-contact-rich-fields-A1-design.md
@@ -1,0 +1,106 @@
+# Contact Rich Fields + Edit Form (Sub-project A1)
+
+วันที่: 2026-06-01
+สถานะ: รออนุมัติ spec จาก owner
+ส่วนหนึ่งของ: PEAK-style contact detail expansion (A → B → C). อันนี้คือ **A1**.
+
+## ที่มา
+
+หน้า contact detail ปัจจุบันมีแค่ field พื้นฐาน (code, name, taxId, phone, email, address เดี่ยว, roles, isActive). owner ต้องการให้ครบแบบ PEAK ซึ่งแยกเป็นหลาย sub-project:
+
+- **A** = ฟิลด์ครบ + edit form  ← spec นี้ (A1) + DBD lookup (A2, ทีหลัง)
+- **B** = ผังบัญชีต่อ contact (AR/AP/IR-GR code, ครบกำหนดชำระ, ธนาคารคู่ค้า) — spec แยก
+- **C** = แท็บภาพรวมการเงิน (ยอดขาย/AR aging/เอกสาร/กราฟ) — spec แยก
+
+ลำดับ build: A1 → A2 → B → C.
+
+## ขอบเขต A1 (ชัดเจน)
+
+ทำ:
+- ขยาย `Contact` model ด้วย field ระดับกิจการ + ที่อยู่ structured (เก็บเป็น text)
+- ฟอร์ม **แก้ไข** Contact (modal) บนหน้า detail + แท็บ "ข้อมูลกิจการ"
+- `PATCH /contacts/:id`
+- backfill `entityType` ของ 37 rows เดิม
+
+ไม่ทำ (อยู่ sub-project อื่น / YAGNI):
+- DBD/สรรพากร tax-id lookup → **A2** (รอ owner มี API token; ออกแบบ field+form ให้รองรับการต่อทีหลังไว้)
+- ช่องบัญชี (AR/AP code, credit term, ธนาคารคู่ค้า) → **B**
+- แท็บภาพรวมการเงิน → **C**
+- การ **สร้าง** Contact ใหม่ตรงๆ จาก /contacts — ยังผ่านฟอร์มลูกค้า/ผู้ขายเดิม (เหมือน v1). A1 ทำแค่ **แก้ไข** รายที่มีอยู่
+- ผู้ติดต่อบุคคล (sub-contacts), แนบไฟล์, กลุ่มกำหนดเอง, วงเงินขายเชื่อ, แฟกซ์ — ตัด
+
+## 1. โครงข้อมูล (ขยาย Contact)
+
+เพิ่ม field nullable ทั้งหมด (2-step migration ปลอดภัยกับ 37 rows):
+
+```
+enum ContactEntityType { JURISTIC, INDIVIDUAL }
+
+Contact (เพิ่ม)
+  entityType      ContactEntityType?           // นิติบุคคล / บุคคลธรรมดา
+  titlePrefix     String?                        // คำนำหน้า (คุณ/นาย/นาง/บจก.)
+  firstName       String?                        // บุคคลธรรมดา
+  lastName        String?                        // บุคคลธรรมดา
+  branchCode      String?                        // เลขที่สาขา ("00000"=สำนักงานใหญ่) — นิติบุคคล
+  website         String?
+
+  // ที่อยู่จดทะเบียน (text — ไม่ FK; reuse AddressForm ฝั่ง web)
+  regAddressLine  String?
+  regSubdistrict  String?                        // ชื่อตำบล/แขวง
+  regDistrict     String?                        // ชื่ออำเภอ/เขต
+  regProvince     String?                        // ชื่อจังหวัด
+  regPostalCode   String?
+
+  // ที่อยู่จัดส่งเอกสาร
+  shipSameAsReg   Boolean  @default(true)
+  shipAddressLine String?
+  shipSubdistrict String?
+  shipDistrict    String?
+  shipProvince    String?
+  shipPostalCode  String?
+```
+
+หมายเหตุ:
+- `name` เดิม = display name (list/search ใช้ตัวนี้ ไม่เปลี่ยน). ที่อยู่เก็บเป็นชื่อ (string) ตามที่ทั้งแอปทำ — **ไม่มี DB address module ให้ FK** (`thai-address-data.ts` เป็น static ฝั่ง frontend, ไม่มีตาราง). UX dropdown ได้จาก component `AddressForm` ที่มีอยู่แล้ว.
+- ไม่แตะ `taxId` / `email` / `phone` / `lineId` / `roles` / `isActive` เดิม.
+
+## 2. Backend
+
+- `PATCH /contacts/:id` — รับ field ข้างบน (DTO `UpdateContactDto`, class-validator, ข้อความ error ไทย). guard `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles('OWNER','FINANCE_MANAGER','ACCOUNTANT')`. audit string `CONTACT_UPDATED` (ผ่าน AuditInterceptor เดิม).
+- **name-sync** ใน service ตอน update:
+  - `INDIVIDUAL` → `name = [titlePrefix] + firstName + lastName` (trim ช่องว่างซ้อน)
+  - `JURISTIC` → `name = <ชื่อกิจการที่ส่งมา>` (field เดียวกับ name)
+- soft-delete filter `deletedAt: null` เหมือนเดิม; โยน `NotFoundException('ไม่พบผู้ติดต่อ')` ถ้าไม่เจอ.
+
+## 3. Frontend
+
+หน้า `ContactDetailPage` แท็บ **"ข้อมูลกิจการ"** (เลียน layout PEAK):
+- กลุ่ม **ข้อมูลจดทะเบียน**: ประเภท (badge นิติบุคคล/บุคคล), เลขภาษี, เลขสาขา, ที่อยู่จดทะเบียน (รวมเป็นบรรทัด)
+- กลุ่ม **ช่องทางติดต่อ**: เบอร์, อีเมล, เว็บไซต์, LINE, ที่อยู่จัดส่ง
+- toggle **เปิด/ปิดใช้งาน** (isActive) → PATCH
+- ปุ่ม **"แก้ไข"** → **modal** (react-hook-form + zod ตาม pattern โปรเจค):
+  - toggle **นิติบุคคล / บุคคลธรรมดา** → conditional: นิติบุคคล = ชื่อกิจการ + เลขสาขา ; บุคคล = คำนำหน้า + ชื่อ + สกุล
+  - taxId, website, phone, email, LINE
+  - `AddressForm` (component เดิม) สำหรับที่อยู่จดทะเบียน + checkbox "ที่อยู่จัดส่ง = ที่อยู่จดทะเบียน" → ติ๊กออกเพื่อโชว์ `AddressForm` ตัวที่สองสำหรับที่อยู่จัดส่ง
+  - submit → `PATCH /contacts/:id` → invalidate react-query → ปิด modal + toast success (sonner)
+- ใช้ semantic tokens เท่านั้น (frontend.md), Thai `leading-snug`
+- API client เพิ่ม `contactsApi.update(id, payload)` ใน `lib/api/contacts.ts`
+
+## 4. Migration + Backfill
+
+- Migration เพิ่ม column ข้างบน (nullable) + enum `ContactEntityType`. **ตั้งชื่อโฟลเดอร์ migration ด้วย synthetic timestamp ให้เรียงท้ายสุด** (สูงกว่า `20260966000000`) — กันบั๊กลำดับ migration ที่เคยทำ CI/prod พัง (วันที่จริงเรียงไปกลาง history ก่อนตารางที่อ้างถูกสร้าง). verify ด้วย `migrate reset` จาก dev DB ว่า apply ท้ายสุดสะอาด.
+- Backfill `entityType` ของ rows เดิม (CLI `src/cli/` แบบ compiled — ไม่ใช่ `tsx scripts/` — เพื่อรันเป็น Cloud Run Job บน prod ได้; บทเรียนจาก backfill ก่อน). guard `CONFIRM_BACKFILL` + `EXPECTED_DB_NAME` (prod = `bestchoice`, ไม่ใช่ `bestchoice_prod`):
+  - contact ที่มี role SUPPLIER/FINANCE_COMPANY หรือมี taxId 13 หลักของนิติบุคคล → `JURISTIC`
+  - ที่เหลือ (CUSTOMER/TRADE_IN_SELLER บุคคล) → `INDIVIDUAL`
+  - idempotent: ข้าม row ที่ entityType ไม่ null แล้ว
+  - ไม่ parse `name` เดิมเป็น firstName/lastName (เสี่ยง) — ปล่อย null ให้ผู้ใช้กรอกตอนแก้ไข
+
+## 5. ทดสอบ
+
+- API: `UpdateContactDto` validation; name-sync ถูกตาม entityType (INDIVIDUAL ประกอบ prefix+first+last / JURISTIC ใช้ชื่อกิจการ); conditional update; NotFound; RolesGuard (OWNER/FM/ACC).
+- Web: edit modal — toggle entityType โชว์ field ถูกชุด; AddressForm 2 ตัว + checkbox shipSameAsReg ซ่อน/โชว์; submit ยิง PATCH ด้วย payload ถูก.
+- Backfill: idempotent (รันซ้ำ entityType ไม่เปลี่ยน), จับ entityType ตาม role/taxId ถูก.
+
+## 6. รองรับ A2 (DBD lookup) ในอนาคต
+
+ออกแบบฟอร์มให้มีที่วางปุ่ม "ค้นหา" ข้างช่อง taxId ไว้ (A2 จะมาเติม handler ที่เรียก DBD API แล้ว auto-fill ชื่อ/ที่อยู่). A1 ปล่อยช่อง taxId ให้กรอกมือไปก่อน — ไม่มี handler lookup.


### PR DESCRIPTION
## สรุป (A1 — read-through)
หน้า Contact detail แสดงข้อมูลกิจการแบบ **read-through** จาก record ที่ link (ลูกค้า/ผู้ขาย/บริษัทไฟแนนซ์/คนขายมือสอง) + ปุ่ม **deep-link ไปแก้ที่หน้าต้นทางเดิม** — ไม่เก็บ column ซ้ำบน Contact

หลัง /scrutinize: เลิกแผนเดิมที่จะเก็บ address/entityType/branchCode/prefix ซ้ำบน Contact (ซ้ำกับ Customer/Supplier + เอกสารกฎหมายอ่านจากตรงนั้น → ข้อมูลแตก) เปลี่ยนเป็น read-through

- **Backend**: ขยาย `findOne` select ดึงฟิลด์ไม่อ่อนไหวจาก role record — **ไม่ดึง address PII ของลูกค้า** (ลิงก์ไปหน้าลูกค้าแทน)
- **Frontend**: การ์ดต่อ role record + deep-link `/suppliers/:id`, `/customers/:id`, `/external-finance-companies/:id`, `/trade-in`
- **ไม่มี** migration/backfill/PATCH/column ใหม่ (prisma diff = 0)

## Test Plan
- [x] type-check all OK
- [x] contacts tests: API 33 pass, Web 10 pass (รวม ContactDetailPage test ใหม่)
- [x] ยืนยัน prisma diff = 0 (read-through ล้วน ไม่แตะ prod schema/data)
- [ ] smoke prod: เปิด /contacts/:id เห็นการ์ด + ปุ่มลิงก์ไปหน้าต้นทางได้

## ต่อไป (queue)
A2 (DBD lookup), B (ผังบัญชีต่อ contact), C (ภาพรวมการเงิน) — ทบทวนด้วยหลัก read-through เดียวกัน

🤖 Generated with [Claude Code](https://claude.com/claude-code)