### PR TITLE
feat(contacts): customer financial snapshot (C, thin)

### DIFF
--- a/apps/web/src/lib/api/customers.ts
+++ b/apps/web/src/lib/api/customers.ts
@@ -1,0 +1,19 @@
+import api from '@/lib/api';
+
+export interface CustomerSummary {
+  id: string;
+  name: string;
+  phone: string | null;
+  activeContracts: number;
+  overdueCount: number;
+  totalOutstandingThb: number;
+}
+
+export const customerKeys = {
+  summary: (id: string) => ['customer-summary', id] as const,
+};
+
+export const customersApi = {
+  summary: (id: string) =>
+    api.get<CustomerSummary>(`/customers/${id}/summary`).then((r) => r.data),
+};

--- a/apps/web/src/pages/ContactDetailPage.tsx
+++ b/apps/web/src/pages/ContactDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   type ContactFinanceLink,
   type ContactTradeInLink,
 } from '@/lib/api/contacts';
+import { customersApi, customerKeys } from '@/lib/api/customers';
 
 const ROLE_LABELS: Record<ContactRole, string> = {
   CUSTOMER: 'ลูกค้า',
@@ -85,6 +86,11 @@ function SupplierCard({ supplier }: { supplier: ContactSupplierLink }) {
 }
 
 function CustomerCard({ customer }: { customer: ContactCustomerLink }) {
+  const { data: summary } = useQuery({
+    queryKey: customerKeys.summary(customer.id),
+    queryFn: () => customersApi.summary(customer.id),
+  });
+
   return (
     <Card>
       <CardHeader>
@@ -95,6 +101,23 @@ function CustomerCard({ customer }: { customer: ContactCustomerLink }) {
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <Field label="เบอร์" value={customer.phone} />
+        {summary && (
+          <div className="grid grid-cols-3 gap-3">
+            <Field
+              label="ยอดค้างชำระ"
+              value={`${summary.totalOutstandingThb.toLocaleString('th-TH')} ฿`}
+            />
+            <Field label="สัญญา active" value={String(summary.activeContracts)} />
+            <div>
+              <div className="text-xs text-muted-foreground mb-0.5 leading-snug">ค้างชำระ</div>
+              <div
+                className={`text-sm leading-snug ${summary.overdueCount > 0 ? 'text-destructive' : 'text-foreground'}`}
+              >
+                {summary.overdueCount}
+              </div>
+            </div>
+          </div>
+        )}
         <CardLink to={`/customers/${customer.id}`} label="เปิดข้อมูลลูกค้า / แก้ไข" />
       </CardContent>
     </Card>

--- a/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
@@ -10,6 +10,11 @@ vi.mock('@/lib/api/contacts', async (orig) => {
   return { ...actual, contactsApi: { ...actual.contactsApi, detail: vi.fn() } };
 });
 
+vi.mock('@/lib/api/customers', () => ({
+  customerKeys: { summary: (id: string) => ['customer-summary', id] },
+  customersApi: { summary: vi.fn() },
+}));
+
 function wrap(id: string) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
@@ -57,5 +62,36 @@ describe('ContactDetailPage', () => {
     await waitFor(() => expect(screen.getAllByText('บ.แอปเปิล').length).toBeGreaterThan(0));
     const link = screen.getByRole('link', { name: /แก้ไข|เปิดข้อมูล|ผู้ขาย/ });
     expect(link).toHaveAttribute('href', '/suppliers/s1');
+  });
+
+  it('shows customer financial snapshot from /summary on the customer card', async () => {
+    const { customersApi } = await import('@/lib/api/customers');
+    (customersApi.summary as any).mockResolvedValue({
+      id: 'cus1',
+      name: 'นราธิป',
+      phone: '08',
+      activeContracts: 2,
+      overdueCount: 1,
+      totalOutstandingThb: 15000,
+    });
+    (contactsApi.detail as any).mockResolvedValue({
+      id: 'c1',
+      contactCode: 'P-00001',
+      name: 'นราธิป',
+      roles: ['CUSTOMER'],
+      isActive: true,
+      taxId: null,
+      phone: '08',
+      email: null,
+      peakContactCode: null,
+      suppliers: [],
+      tradeInsAsSeller: [],
+      externalFinanceCompany: [],
+      customers: [{ id: 'cus1', name: 'นราธิป', prefix: 'คุณ', phone: '08' }],
+    });
+    wrap('c1');
+    await waitFor(() => expect(screen.getByText('นราธิป')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/15,000/)).toBeInTheDocument());
+    expect(screen.getByText('ค้างชำระ')).toBeInTheDocument();
   });
 });

--- a/docs/superpowers/plans/2026-06-02-contact-financial-snapshot-C.md
+++ b/docs/superpowers/plans/2026-06-02-contact-financial-snapshot-C.md
@@ -1,0 +1,157 @@
+# Contact Financial Snapshot (C, thin) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** โชว์ snapshot การเงินลูกค้า (ยอดค้าง + สัญญา active + ค้างชำระ) บน CustomerCard ของหน้า Contact detail โดย reuse `GET /customers/:id/summary` ที่มีอยู่
+
+**Architecture:** Frontend-only. เพิ่ม web api client `customersApi.summary()` เรียก endpoint เดิม, แล้วให้ `CustomerCard` (ใน ContactDetailPage) fetch ด้วย react-query มาแสดง. ไม่มี backend/schema change.
+
+**Tech Stack:** React + react-query + react-router + Vitest
+
+**Spec:** `docs/superpowers/specs/2026-06-02-contact-financial-snapshot-C-design.md`
+
+**Verified facts:** `GET /customers/:id/summary` (customers.controller.ts:233, roles incl. SALES) returns `{ id, name, phone, activeContracts: number, overdueCount: number, totalOutstandingThb: number }` (outstanding field name = `totalOutstandingThb`, already a number). `CustomerCard` lives in `apps/web/src/pages/ContactDetailPage.tsx` (~line 87) and the file already imports `useQuery`. No `apps/web/src/lib/api/customers.ts` exists yet.
+
+---
+
+## Task 1: web customers api client
+
+**Files:**
+- Create: `apps/web/src/lib/api/customers.ts`
+
+- [ ] **Step 1: Create the client**
+
+```typescript
+import api from '@/lib/api';
+
+export interface CustomerSummary {
+  id: string;
+  name: string;
+  phone: string | null;
+  activeContracts: number;
+  overdueCount: number;
+  totalOutstandingThb: number;
+}
+
+export const customerKeys = {
+  summary: (id: string) => ['customer-summary', id] as const,
+};
+
+export const customersApi = {
+  summary: (id: string) =>
+    api.get<CustomerSummary>(`/customers/${id}/summary`).then((r) => r.data),
+};
+```
+> Verify `api` is the default export of `apps/web/src/lib/api.ts` (it is, per `lib/api/contacts.ts`). Confirm field names against backend `getSummary` return (`customers.service.ts`): `activeContracts`, `overdueCount`, `totalOutstandingThb`.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web`
+Expected: 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && git add apps/web/src/lib/api/customers.ts && git commit -m "feat(contacts): web customers api client (summary)"
+```
+
+---
+
+## Task 2: CustomerCard financial snapshot
+
+**Files:**
+- Modify: `apps/web/src/pages/ContactDetailPage.tsx` (the `CustomerCard` component)
+- Test: `apps/web/src/pages/__tests__/ContactDetailPage.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+เพิ่ม test ในไฟล์ test เดิม (mirror the existing mock style; the file already mocks `@/lib/api/contacts`). Also mock the new customers client:
+```tsx
+vi.mock('@/lib/api/customers', () => ({
+  customerKeys: { summary: (id: string) => ['customer-summary', id] },
+  customersApi: { summary: vi.fn() },
+}));
+```
+```tsx
+it('shows customer financial snapshot from /summary on the customer card', async () => {
+  const { customersApi } = await import('@/lib/api/customers');
+  (customersApi.summary as any).mockResolvedValue({
+    id: 'cus1', name: 'นราธิป', phone: '08', activeContracts: 2, overdueCount: 1, totalOutstandingThb: 15000,
+  });
+  (contactsApi.detail as any).mockResolvedValue({
+    id: 'c1', contactCode: 'P-00001', name: 'นราธิป', roles: ['CUSTOMER'], isActive: true,
+    taxId: null, phone: '08', email: null, peakContactCode: null,
+    suppliers: [], tradeInsAsSeller: [], externalFinanceCompany: [],
+    customers: [{ id: 'cus1', name: 'นราธิป', prefix: 'คุณ', phone: '08' }],
+  });
+  wrap('c1');
+  await waitFor(() => expect(screen.getByText('นราธิป')).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText(/15,000/)).toBeInTheDocument()); // outstanding formatted
+  expect(screen.getByText(/ค้างชำระ/)).toBeInTheDocument();
+});
+```
+> Use the SAME `wrap()` + router/QueryClient helper already in this test file (from A1). Keep existing tests intact.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `cd apps/web && npx vitest run ContactDetailPage --silent`
+Expected: FAIL — no outstanding amount rendered
+
+- [ ] **Step 3: Implement — fetch + render snapshot in CustomerCard**
+
+ใน `ContactDetailPage.tsx`:
+- import: `import { customersApi, customerKeys } from '@/lib/api/customers';`
+- ใน `CustomerCard`, เพิ่มก่อน return:
+```tsx
+const { data: summary } = useQuery({
+  queryKey: customerKeys.summary(customer.id),
+  queryFn: () => customersApi.summary(customer.id),
+});
+```
+- ใน CardContent (เหนือ `<CardLink .../>`) เพิ่ม snapshot (แสดงเมื่อมี summary; ถ้ายังไม่มี/ error → ไม่แสดง ไม่พังการ์ด):
+```tsx
+{summary && (
+  <div className="grid grid-cols-3 gap-3">
+    <Field label="ยอดค้างชำระ" value={`${summary.totalOutstandingThb.toLocaleString('th-TH')} ฿`} />
+    <Field label="สัญญา active" value={String(summary.activeContracts)} />
+    <div>
+      <div className="text-xs text-muted-foreground mb-0.5 leading-snug">ค้างชำระ</div>
+      <div className={`text-sm leading-snug ${summary.overdueCount > 0 ? 'text-destructive' : 'text-foreground'}`}>
+        {summary.overdueCount}
+      </div>
+    </div>
+  </div>
+)}
+```
+- เก็บ `<Field label="เบอร์" .../>` และ `<CardLink to={`/customers/${customer.id}`} ... />` เดิมไว้
+- ใช้ semantic tokens, Thai `leading-snug`. (react-query default ไม่ retry ใน test แต่ใน prod ถ้า fail summary จะ undefined → snapshot ซ่อน — ตาม spec)
+
+- [ ] **Step 4: Run, expect PASS + type-check**
+
+Run: `cd apps/web && npx vitest run ContactDetailPage --silent && cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web`
+Expected: PASS (incl. existing A1 tests) + 0 type errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/iamnaii/Desktop/App/BESTCHOICE && git add apps/web/src/pages/ContactDetailPage.tsx apps/web/src/pages/__tests__/ContactDetailPage.test.tsx && git commit -m "feat(contacts): customer financial snapshot on contact card (reuse /summary)"
+```
+
+---
+
+## Task 3: Verify
+
+**Files:** none
+
+- [ ] **Step 1:** `cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web` → 0 errors
+- [ ] **Step 2:** `cd apps/web && npx vitest run Contact --silent` → all pass (A1 + new snapshot test)
+- [ ] **Step 3:** confirm NO backend/schema change: `git diff main --stat -- apps/api` → 0 lines
+
+---
+
+## Self-Review
+
+- **Spec coverage:** customersApi.summary (Task 1) ✓; CustomerCard snapshot of outstanding+active+overdue (Task 2) ✓; loading/error hides snapshot without breaking card (Task 2 — `summary &&` guard) ✓; frontend-only, no backend (Task 3 step 3 guards) ✓.
+- **Placeholders:** none — full code shown; `totalOutstandingThb`/`activeContracts`/`overdueCount` match backend `getSummary` return verified in service.
+- **Type consistency:** `CustomerSummary` (Task 1) field names match what CustomerCard reads (Task 2).
+- Out of scope per spec: supplier snapshot, charts/doc-list/aging, new backend endpoint.

--- a/docs/superpowers/specs/2026-06-02-contact-financial-snapshot-C-design.md
+++ b/docs/superpowers/specs/2026-06-02-contact-financial-snapshot-C-design.md
@@ -1,0 +1,56 @@
+# Contact Financial Snapshot (Sub-project C, thin)
+
+วันที่: 2026-06-02
+สถานะ: รออนุมัติ spec จาก owner
+ส่วนหนึ่งของ: PEAK-style contact expansion (A → B → C). อันนี้คือ **C** (thin หลัง scrutinize).
+
+> **C reworked หลัง scrutinize:** คำขอเดิม "แท็บภาพรวมการเงิน" (ยอดขาย/AR aging/doc list/กราฟ แบบ PEAK) ถูกตัดเหลือ **snapshot สั้นๆ** เพราะภาพการเงินลูกค้าเต็มมีอยู่แล้วบน `CustomerDetailPage` (ตาราง contracts, KPI active/overdue, risk panel) และมี endpoint `GET /customers/:id/summary` (outstanding + active/overdue) อยู่แล้ว. ทำเต็มบนหน้า contact = duplicate. A1 ก็ deep-link ไปหน้าลูกค้าเต็มได้อยู่แล้ว.
+
+## หลักการ
+
+- **reuse `GET /customers/:id/summary` ที่มีอยู่** — ไม่เขียน aggregate ใหม่
+- frontend ล้วน — **ไม่มี backend change / schema / migration**
+- โชว์ snapshot บน A1 CustomerCard (ที่ ContactDetailPage มีแล้ว) ไม่สร้างแท็บใหม่
+
+## ขอบเขต
+
+ทำ:
+- `customersApi.summary(id)` ใน web api client (เรียก `GET /customers/:id/summary`)
+- A1 `CustomerCard` (ใน `ContactDetailPage.tsx`) fetch summary ด้วย react-query → โชว์ **ยอดค้างชำระ (outstanding) + สัญญา active + ค้างชำระ (overdue)** เหนือปุ่ม deep-link เดิม
+- loading / error / empty handled (snapshot ไม่ขึ้นถ้า fetch fail — ไม่พังการ์ด)
+
+ไม่ทำ:
+- backend endpoint ใหม่ / aggregate ใหม่ / schema (reuse `/customers/:id/summary`)
+- กราฟ / doc list / AR aging / lifetime revenue (มีบน CustomerDetailPage / YAGNI)
+- snapshot ฝั่ง supplier (ไม่มี endpoint เทียบเท่า — นอก scope)
+- แท็บ "ภาพรวม" ใหม่ (โชว์ inline บน CustomerCard แทน)
+
+## 1. Backend
+ไม่มีการเปลี่ยนแปลง. ใช้ `GET /customers/:id/summary` เดิม (controller `customers.controller.ts:233`, roles OWNER/BM/FM/ACC/SALES) ที่คืน:
+```
+{ id, name, phone, activeContracts: number, overdueCount: number, outstanding: <Decimal aggregate> }
+```
+> NB: implementer ต้องยืนยัน shape จริง (`outstanding` อาจเป็น `{ _sum: { ... } }` หรือ number) จาก `customers.service.ts getSummary` แล้ว map ให้ถูกใน api client.
+
+## 2. Frontend
+
+`apps/web/src/lib/api/customers.ts` (หรือไฟล์ api client ลูกค้าที่มีอยู่ — ถ้าไม่มีให้สร้าง minimal):
+```ts
+export interface CustomerSummary { id: string; name: string; phone: string | null; activeContracts: number; overdueCount: number; outstanding: number; }
+export const customersApi = { summary: (id: string) => api.get<CustomerSummary>(`/customers/${id}/summary`).then(r => r.data) };
+```
+(map `outstanding` ให้เป็น number ตาม shape จริง)
+
+`apps/web/src/pages/ContactDetailPage.tsx` — `CustomerCard`:
+- `useQuery({ queryKey: ['customer-summary', customer.id], queryFn: () => customersApi.summary(customer.id) })`
+- โชว์ field: ยอดค้างชำระ (฿, format) · สัญญา active (จำนวน) · ค้างชำระ (overdueCount, เน้นสีถ้า >0)
+- ระหว่างโหลด: skeleton/`—` ; fetch fail: ซ่อน snapshot (การ์ดยังแสดงชื่อ+ปุ่มลิงก์ปกติ)
+- ปุ่ม deep-link `/customers/:id` เดิมคงไว้
+- semantic tokens, Thai `leading-snug`
+
+## 3. ทดสอบ
+- web: `CustomerCard` (ผ่าน ContactDetailPage test) — mock `customersApi.summary` → render ยอดค้าง + active + overdue; กรณี fetch reject → การ์ดยังขึ้นชื่อ+ลิงก์ (snapshot ซ่อน) ไม่ crash
+- ไม่มี backend test (ไม่แตะ backend)
+
+## หมายเหตุ
+ถ้าวันหน้าต้องการ snapshot ฝั่ง supplier ด้วย — ต้องมี supplier summary endpoint ก่อน (ยังไม่มี) แยกพิจารณานอก C


### PR DESCRIPTION
## สรุป (C — thin snapshot)
โชว์ snapshot การเงินลูกค้าบน CustomerCard ของหน้า contact: **ยอดค้างชำระ + สัญญา active + ค้างชำระ** โดย reuse `GET /customers/:id/summary` ที่มีอยู่

หลัง scrutinize: ตัดจากแผน "แท็บภาพรวมเต็มแบบ PEAK" เพราะภาพการเงินลูกค้าเต็มมีบน CustomerDetailPage แล้ว + endpoint summary มีอยู่ → C เหลือ snapshot บางๆ reuse ของเดิม

- **frontend ล้วน** — ไม่มี backend/schema/migration (apps/api diff = 0)
- snapshot โชว์เมื่อมีข้อมูล (fetch fail/loading → ซ่อน ไม่พังการ์ด)
- review approved (spec + code quality), 11 tests pass, ไม่ regression A1

## Test Plan
- [x] type-check web OK
- [x] Contact tests 11 pass (A1 + snapshot ใหม่)
- [x] apps/api diff = 0
- [ ] smoke prod: เปิด /contacts/:id ของลูกค้า → เห็นยอดค้าง/สัญญา

🤖 Generated with [Claude Code](https://claude.com/claude-code)