### PR TITLE
feat(test-mode): OWNER toggle to bypass credit/OTP/2FA for pre-go-live UAT

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { ProductsModule } from './modules/products/products.module';
 import { QualityControlModule } from './modules/quality-control/quality-control.module';
 import { StickersModule } from './modules/stickers/stickers.module';
 import { CustomersModule } from './modules/customers/customers.module';
+import { TestModeModule } from './modules/test-mode/test-mode.module';
 import { ContractsModule } from './modules/contracts/contracts.module';
 import { PaymentsModule } from './modules/payments/payments.module';
 // MASTER-only modules
@@ -184,6 +185,7 @@ import { AppCacheModule } from './cache/cache.module';
     QualityControlModule,
     StickersModule,
     CustomersModule,
+    TestModeModule,
     ContractsModule,
     InterestConfigModule,
     PricingTemplatesModule,

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -12,6 +12,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAudienceGuard } from './guards/jwt-audience.guard';
 import { EmailModule } from '../email/email.module';
 import { LineOaModule } from '../line-oa/line-oa.module';
+import { TestModeModule } from '../test-mode/test-mode.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { LineOaModule } from '../line-oa/line-oa.module';
     }),
     EmailModule,
     forwardRef(() => LineOaModule),
+    TestModeModule,
   ],
   controllers: [AuthController],
   providers: [

--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -7,12 +7,17 @@ import { AuthService } from './auth.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
 import { LoginAuditService } from './login-audit.service';
+import { TestModeService } from '../test-mode/test-mode.service';
+import { AuditService } from '../audit/audit.service';
 
 const mockEmailSender = { sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined) };
 
 describe('AuthService', () => {
   let service: AuthService;
   let prisma: PrismaService;
+  let loginAudit: { record: jest.Mock };
+  let testMode: { isEnabled: jest.Mock; setEnabled: jest.Mock };
+  let audit: { log: jest.Mock };
 
   const mockUser = {
     id: 'user-1',
@@ -36,6 +41,12 @@ describe('AuthService', () => {
 
   beforeEach(async () => {
     mockEmailSender.sendPasswordResetEmail.mockClear();
+    loginAudit = { record: jest.fn().mockResolvedValue(undefined) };
+    testMode = {
+      isEnabled: jest.fn().mockResolvedValue(false),
+      setEnabled: jest.fn().mockResolvedValue(false),
+    };
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
@@ -92,7 +103,15 @@ describe('AuthService', () => {
         },
         {
           provide: LoginAuditService,
-          useValue: { record: jest.fn().mockResolvedValue(undefined) },
+          useValue: loginAudit,
+        },
+        {
+          provide: TestModeService,
+          useValue: testMode,
+        },
+        {
+          provide: AuditService,
+          useValue: audit,
         },
       ],
     }).compile();
@@ -316,6 +335,82 @@ describe('AuthService', () => {
       }
       // Full tokens must NOT be returned
       expect((result as Record<string, unknown>)).not.toHaveProperty('accessToken');
+    });
+
+    // ─── Test-mode 2FA bypass (Task 6) ───────────────────────────────────
+    it('bypasses 2FA and issues FULL session when test-mode is ON (2FA user + correct password)', async () => {
+      testMode.isEnabled.mockResolvedValue(true);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        ...mockUser,
+        twoFactorEnabled: true,
+        twoFactorRequiredAfter: null,
+      });
+
+      const result = await service.login(
+        { email: 'test@test.com', password: 'password123' },
+        { ipAddress: '1.2.3.4', userAgent: 'jest' },
+      );
+
+      // Full session, NOT the OTP_REQUIRED temp-token response
+      expect(result.state).toBe('AUTHENTICATED');
+      expect(result).toHaveProperty('accessToken');
+      expect(result).toHaveProperty('refreshToken');
+      expect((result as Record<string, unknown>)).not.toHaveProperty('tempToken');
+      expect(prisma.refreshToken.create).toHaveBeenCalled();
+
+      // loginAudit recorded a SUCCESSFUL login with twoFactorUsed: false
+      const successCall = loginAudit.record.mock.calls.find(
+        (c) => c[0].success === true,
+      );
+      expect(successCall).toBeDefined();
+      expect(successCall![0]).toMatchObject({ success: true, twoFactorUsed: false });
+
+      // Bypass is audited
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          action: 'LOGIN_2FA_BYPASSED_TEST_MODE',
+          entity: 'user',
+          entityId: 'user-1',
+        }),
+      );
+    });
+
+    it('keeps the OTP_REQUIRED temp-token flow UNCHANGED when test-mode is OFF (2FA user)', async () => {
+      testMode.isEnabled.mockResolvedValue(false);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        ...mockUser,
+        twoFactorEnabled: true,
+        twoFactorRequiredAfter: null,
+      });
+
+      const result = await service.login({ email: 'test@test.com', password: 'password123' });
+
+      expect(result.state).toBe('OTP_REQUIRED');
+      if (result.state === 'OTP_REQUIRED') {
+        expect(typeof result.tempToken).toBe('string');
+      }
+      expect((result as Record<string, unknown>)).not.toHaveProperty('accessToken');
+      // No full session issued
+      expect(prisma.refreshToken.create).not.toHaveBeenCalled();
+      // No bypass audit
+      expect(audit.log).not.toHaveBeenCalled();
+    });
+
+    it('still rejects wrong password for a 2FA user even when test-mode is ON', async () => {
+      testMode.isEnabled.mockResolvedValue(true);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        ...mockUser,
+        twoFactorEnabled: true,
+        twoFactorRequiredAfter: null,
+      });
+
+      await expect(
+        service.login({ email: 'test@test.com', password: 'wrongpassword' }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(prisma.refreshToken.create).not.toHaveBeenCalled();
+      expect(audit.log).not.toHaveBeenCalled();
     });
 
     it('skips 2FA enrollment enforcement (P1Q6 deferred) — issues full JWT even with past deadline', async () => {

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -15,6 +15,8 @@ import { LoginDto } from './dto/login.dto';
 import { ForgotPasswordDto, ResetPasswordDto } from './dto/password-reset.dto';
 import { EmailService } from '../email/email.service';
 import { LoginAuditService, LoginFailureKind } from './login-audit.service';
+import { TestModeService } from '../test-mode/test-mode.service';
+import { AuditService } from '../audit/audit.service';
 
 // Account lockout configuration. Tunable via env if needed later.
 const LOCKOUT_THRESHOLD = 5; // failures before lock
@@ -54,6 +56,8 @@ export class AuthService {
     private configService: ConfigService,
     private emailService: EmailService,
     private loginAudit: LoginAuditService,
+    private testMode: TestModeService,
+    private audit: AuditService,
   ) {}
 
   /**
@@ -210,11 +214,33 @@ export class AuthService {
     });
 
     // ── 2-step login state machine ──────────────────────────────────────
-    // State 1: 2FA is enabled → require OTP before issuing full JWT
-    if (user.twoFactorEnabled) {
+    // State 1: 2FA is enabled → require OTP before issuing full JWT.
+    //
+    // Test-mode UAT bypass (OWNER-gated SystemConfig TEST_MODE_BYPASS, default
+    // OFF, audited; MUST be turned OFF before go-live). When ON, the SECOND
+    // FACTOR is skipped — the password above was ALWAYS verified, so credentials
+    // are never weakened. We fall through to the same full-session issuance path
+    // as a non-2FA user (no change to token signing/expiry). Same pattern as the
+    // KYC OTP / LIFF OTP / credit-precheck bypasses.
+    if (user.twoFactorEnabled && !(await this.testMode.isEnabled())) {
       const tempToken = this.signTempToken(user.id, '2fa_login');
       await this.auditLogin(loginDto.email, false, meta, user.id, 'other');
       return { state: 'OTP_REQUIRED', tempToken };
+    }
+
+    if (user.twoFactorEnabled) {
+      // Reached here only when test-mode is ON: the 2FA step was bypassed.
+      // Record a dedicated audit marker (AuditService is @Global; userId is a
+      // real FK so this always persists for an authenticated staff user).
+      await this.audit.log({
+        userId: user.id,
+        action: 'LOGIN_2FA_BYPASSED_TEST_MODE',
+        entity: 'user',
+        entityId: user.id,
+        newValue: { reason: 'TEST_MODE_BYPASS' },
+        ipAddress: meta?.ipAddress,
+        userAgent: meta?.userAgent,
+      });
     }
 
     // 2FA enrollment enforcement is disabled by product decision (P1Q6 deferred).

--- a/apps/api/src/modules/chatbot-finance/chatbot-finance.module.ts
+++ b/apps/api/src/modules/chatbot-finance/chatbot-finance.module.ts
@@ -30,6 +30,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { StaffChatModule } from '../staff-chat/staff-chat.module';
 import { IntegrationsModule } from '../integrations/integrations.module';
 import { ChatAiDraftModule } from '../chat-ai-draft/chat-ai-draft.module';
+import { TestModeModule } from '../test-mode/test-mode.module';
 
 /**
  * Finance Bot Module ("น้องเบส")
@@ -45,7 +46,7 @@ import { ChatAiDraftModule } from '../chat-ai-draft/chat-ai-draft.module';
  *   E  ✅ admin endpoints + analytics/sessions/KB UI
  */
 @Module({
-  imports: [forwardRef(() => NotificationsModule), forwardRef(() => StaffChatModule), IntegrationsModule, forwardRef(() => ChatAiDraftModule)], // SMS for OTP + WS events to Unified Inbox
+  imports: [forwardRef(() => NotificationsModule), forwardRef(() => StaffChatModule), IntegrationsModule, forwardRef(() => ChatAiDraftModule), TestModeModule], // SMS for OTP + WS events to Unified Inbox; TestModeModule for LIFF OTP bypass (UAT)
   controllers: [
     ChatbotFinanceController,
     ChatbotFinanceLiffController,

--- a/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
@@ -3,6 +3,8 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { VerificationService } from './verification.service';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { NotificationsService } from '../../notifications/notifications.service';
+import { TestModeService } from '../../test-mode/test-mode.service';
+import { AuditService } from '../../audit/audit.service';
 
 describe('VerificationService', () => {
   let service: VerificationService;
@@ -10,6 +12,10 @@ describe('VerificationService', () => {
   let prisma: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let notifications: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let testMode: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let audit: any;
 
   beforeEach(async () => {
     prisma = {
@@ -44,12 +50,21 @@ describe('VerificationService', () => {
     notifications = {
       sendSmsFromQueue: jest.fn().mockResolvedValue(undefined),
     };
+    testMode = {
+      // Default OFF — existing tests assert byte-for-byte existing behavior.
+      isEnabled: jest.fn().mockResolvedValue(false),
+    };
+    audit = {
+      log: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         VerificationService,
         { provide: PrismaService, useValue: prisma },
         { provide: NotificationsService, useValue: notifications },
+        { provide: TestModeService, useValue: testMode },
+        { provide: AuditService, useValue: audit },
       ],
     }).compile();
 
@@ -180,6 +195,55 @@ describe('VerificationService', () => {
       await expect(
         service.verifyOtp({ lineUserId: 'U123', otp: '123456' }),
       ).rejects.toThrow('ขอ OTP ใหม่');
+    });
+
+    // ─────────────────────────────────────────────────────────────
+    // Test-mode bypass (Task 5 — test-mode-bypass feature)
+    // ─────────────────────────────────────────────────────────────
+    describe('test-mode bypass', () => {
+      it('ON: succeeds with wrong OTP, replicates success mutations, writes audit', async () => {
+        testMode.isEnabled.mockResolvedValue(true);
+        // Pending OTP session exists (wrong hash — would normally fail).
+        prisma.chatbotOtpRequest.findUnique.mockResolvedValue(makeRecord('wrong-hash'));
+        prisma.customer.findUnique.mockResolvedValue({ id: 'c1', name: 'สมชาย' });
+
+        const result = await service.verifyOtp({ lineUserId: 'U123', otp: '999999' });
+
+        // Same success return shape as the real success branch.
+        expect(result.customerId).toBe('c1');
+        expect(result.customerName).toBe('สมชาย');
+        // Success mutations replicated: bind (transaction) + delete OTP row.
+        expect(prisma.$transaction).toHaveBeenCalled();
+        expect(prisma.chatbotOtpRequest.delete).toHaveBeenCalled();
+        // Audit written with the bypass action.
+        expect(audit.log).toHaveBeenCalledWith(
+          expect.objectContaining({ action: 'LIFF_OTP_BYPASSED_TEST_MODE' }),
+        );
+        // The wrong-OTP attempt increment must NOT run (code check skipped).
+        expect(prisma.chatbotOtpRequest.update).not.toHaveBeenCalled();
+      });
+
+      it('ON: still requires an existing pending OTP session', async () => {
+        testMode.isEnabled.mockResolvedValue(true);
+        prisma.chatbotOtpRequest.findUnique.mockResolvedValue(null);
+
+        await expect(
+          service.verifyOtp({ lineUserId: 'U123', otp: '999999' }),
+        ).rejects.toThrow('ขอ OTP ใหม่');
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+        expect(audit.log).not.toHaveBeenCalled();
+      });
+
+      it('OFF: wrong OTP still fails (existing validation unchanged)', async () => {
+        testMode.isEnabled.mockResolvedValue(false);
+        prisma.chatbotOtpRequest.findUnique.mockResolvedValue(makeRecord('wrong-hash', 0));
+        prisma.chatbotOtpRequest.update.mockResolvedValue({ attempts: 1 });
+
+        await expect(
+          service.verifyOtp({ lineUserId: 'U123', otp: '999999' }),
+        ).rejects.toThrow('ไม่ถูกต้อง');
+        expect(audit.log).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/api/src/modules/chatbot-finance/services/verification.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.ts
@@ -4,6 +4,8 @@ import * as Sentry from '@sentry/nestjs';
 import { createHash, randomInt } from 'crypto';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { NotificationsService } from '../../notifications/notifications.service';
+import { TestModeService } from '../../test-mode/test-mode.service';
+import { AuditService } from '../../audit/audit.service';
 import { LineChannelType } from '@prisma/client';
 import { maskPhone } from '../utils/mask-phone';
 
@@ -48,6 +50,8 @@ export class VerificationService {
   constructor(
     private prisma: PrismaService,
     private notifications: NotificationsService,
+    private testMode: TestModeService,
+    private audit: AuditService,
   ) {}
 
   /**
@@ -220,6 +224,46 @@ export class VerificationService {
 
     if (!record) {
       throw new BadRequestException('กรุณาขอ OTP ใหม่');
+    }
+
+    // Test-mode UAT bypass — OWNER-gated SystemConfig (TEST_MODE_BYPASS), default OFF,
+    // audited, app-wide banner. For pre-go-live testing only — MUST be turned OFF before
+    // go-live (TestModeService.isEnabled fails safe to OFF on any DB error).
+    //
+    // We still require that an OTP session exists (the `record` found above), so the LIFF
+    // flow can only advance if requestOtp ran — we only skip the expiry/attempt/hash code
+    // checks. The success side-effects below (resolve customer → bind → delete OTP row →
+    // same return value) are byte-for-byte identical to the real success branch so the
+    // downstream LIFF flow proceeds unchanged.
+    if (await this.testMode.isEnabled()) {
+      const customer = await this.prisma.customer.findUnique({
+        where: { id: record.customerId },
+        select: { id: true, name: true },
+      });
+      if (!customer) {
+        await this.prisma.chatbotOtpRequest.delete({ where: { id: record.id } });
+        throw new NotFoundException('ไม่พบข้อมูลลูกค้า');
+      }
+
+      await this.bind(params.lineUserId, customer.id);
+      await this.prisma.chatbotOtpRequest.delete({ where: { id: record.id } });
+
+      // Best-effort audit. This is a customer-facing LIFF path with no staff JWT, so no
+      // userId FK is available — AuditService.log no-ops without a valid userId. We still
+      // call it for consistency with the KYC bypass; it persists only if an actor is ever
+      // threaded through. Not threading an actor here is acceptable for this path.
+      await this.audit.log({
+        action: 'LIFF_OTP_BYPASSED_TEST_MODE',
+        entity: 'customer',
+        entityId: customer.id,
+        newValue: {
+          lineUserId: params.lineUserId,
+          otpRequestId: record.id,
+          reason: 'TEST_MODE_BYPASS',
+        },
+      });
+
+      return { customerId: customer.id, customerName: customer.name };
     }
 
     if (record.expiresAt < new Date()) {

--- a/apps/api/src/modules/customers/customer-precheck.service.spec.ts
+++ b/apps/api/src/modules/customers/customer-precheck.service.spec.ts
@@ -2,6 +2,8 @@ import { Test } from '@nestjs/testing';
 import { CustomerPreCheckService } from './customer-precheck.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CustomerTierService } from './customer-tier.service';
+import { TestModeService } from '../test-mode/test-mode.service';
+import { AuditService } from '../audit/audit.service';
 
 describe('CustomerPreCheckService — decideOutcome (pure)', () => {
   let service: CustomerPreCheckService;
@@ -12,6 +14,8 @@ describe('CustomerPreCheckService — decideOutcome (pure)', () => {
         CustomerPreCheckService,
         { provide: PrismaService, useValue: {} },
         { provide: CustomerTierService, useValue: {} },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
+        { provide: AuditService, useValue: { log: jest.fn() } },
       ],
     }).compile();
     service = mod.get(CustomerPreCheckService);
@@ -93,6 +97,8 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
         CustomerPreCheckService,
         { provide: PrismaService, useValue: prisma },
         { provide: CustomerTierService, useValue: tierService },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
+        { provide: AuditService, useValue: { log: jest.fn() } },
       ],
     }).compile();
     service = mod.get(CustomerPreCheckService);
@@ -174,6 +180,8 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
             getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }),
           },
         },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
+        { provide: AuditService, useValue: { log: jest.fn() } },
       ],
     }).compile();
     const svc = fresh.get(CustomerPreCheckService);
@@ -204,6 +212,8 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
             getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }),
           },
         },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
+        { provide: AuditService, useValue: { log: jest.fn() } },
       ],
     }).compile();
     const svc = fresh.get(CustomerPreCheckService);
@@ -308,6 +318,8 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
             getCustomerTier: jest.fn().mockResolvedValue({ tier: 'NEW', reasons: [] }),
           },
         },
+        { provide: TestModeService, useValue: { isEnabled: jest.fn().mockResolvedValue(false) } },
+        { provide: AuditService, useValue: { log: jest.fn() } },
       ],
     }).compile();
     const svc = fresh.get(CustomerPreCheckService);
@@ -328,5 +340,88 @@ describe('CustomerPreCheckService — runPreCheck soft-delete revival', () => {
       (call: [{ data: { creditCheckStatus?: string } }]) => call[0].data.creditCheckStatus !== undefined,
     );
     expect(statusUpdateCall).toBeDefined();
+  });
+});
+
+// ─── Test-mode bypass (Task 3) ──────────────────────────────────────────────
+describe('CustomerPreCheckService — test-mode bypass', () => {
+  let service: CustomerPreCheckService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let testMode: { isEnabled: jest.Mock };
+  let audit: { log: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      customer: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+      creditCheck: { findFirst: jest.fn(), create: jest.fn() },
+      $transaction: jest.fn(),
+    };
+    testMode = { isEnabled: jest.fn() };
+    audit = { log: jest.fn() };
+    const mod = await Test.createTestingModule({
+      providers: [
+        CustomerPreCheckService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: CustomerTierService,
+          // If the bypass ever falls through to the real logic, this throws
+          // loudly so the test can't accidentally pass via real checks.
+          useValue: {
+            getCustomerTier: jest.fn(() => {
+              throw new Error('real precheck must NOT run when test-mode is ON');
+            }),
+          },
+        },
+        { provide: TestModeService, useValue: testMode },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+    service = mod.get(CustomerPreCheckService);
+  });
+
+  it('returns PASS + TEST_MODE_BYPASS reason WITHOUT running real checks when test-mode is ON', async () => {
+    testMode.isEnabled.mockResolvedValue(true);
+
+    const result = await service.runPreCheck({
+      nationalId: '1111111111111',
+      phone: '0810000000',
+    });
+
+    expect(result.decision).toBe('PASS');
+    expect(result.reasons.map((r) => r.code)).toContain('TEST_MODE_BYPASS');
+    // No real-check side effects — no DB reads/writes, no tier lookup.
+    expect(prisma.customer.findFirst).not.toHaveBeenCalled();
+    expect(prisma.customer.create).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('writes a CREDIT_PRECHECK_BYPASSED_TEST_MODE audit marker when bypassing', async () => {
+    testMode.isEnabled.mockResolvedValue(true);
+
+    await service.runPreCheck(
+      { nationalId: '2222222222222', phone: '0820000000' },
+      { userId: 'user-1', ipAddress: '127.0.0.1' },
+    );
+
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'CREDIT_PRECHECK_BYPASSED_TEST_MODE',
+        entity: 'customer',
+        userId: 'user-1',
+      }),
+    );
+  });
+
+  it('falls through to real logic when test-mode is OFF', async () => {
+    testMode.isEnabled.mockResolvedValue(false);
+    // Let the real path reach the tier lookup, where the throwing mock proves
+    // the bypass did NOT short-circuit.
+    prisma.customer.findFirst.mockResolvedValue({ id: 'cust-real', deletedAt: null });
+    await expect(
+      service.runPreCheck({ nationalId: '3333333333333', phone: '0830000000' }),
+    ).rejects.toThrow('real precheck must NOT run when test-mode is ON');
+    expect(prisma.customer.findFirst).toHaveBeenCalled();
+    expect(audit.log).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/customers/customer-precheck.service.ts
+++ b/apps/api/src/modules/customers/customer-precheck.service.ts
@@ -2,8 +2,17 @@ import { Injectable, Logger } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CustomerTierService } from './customer-tier.service';
+import { TestModeService } from '../test-mode/test-mode.service';
+import { AuditService } from '../audit/audit.service';
 import type { CustomerTier } from './dto/tier.dto';
 import type { CustomerPreCheckResponse, PreCheckDecision } from './dto/precheck.dto';
+
+/** Actor context for audit trails (optional — controller threads it through). */
+export interface PreCheckActor {
+  userId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
 
 const PASS_THRESHOLD = 50;
 const REVIEW_THRESHOLD = 40;
@@ -22,6 +31,8 @@ export class CustomerPreCheckService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly tierService: CustomerTierService,
+    private readonly testMode: TestModeService,
+    private readonly audit: AuditService,
   ) {}
 
   decideOutcome(
@@ -101,12 +112,45 @@ export class CustomerPreCheckService {
     return createHash('sha256').update(files.join('|')).digest('hex').slice(0, 16);
   }
 
-  async runPreCheck(input: {
-    nationalId: string;
-    phone: string;
-    bankName?: string;
-    statementFiles?: string[];
-  }): Promise<CustomerPreCheckResponse> {
+  async runPreCheck(
+    input: {
+      nationalId: string;
+      phone: string;
+      bankName?: string;
+      statementFiles?: string[];
+    },
+    actor?: PreCheckActor,
+  ): Promise<CustomerPreCheckResponse> {
+    if (await this.testMode.isEnabled()) {
+      // Test-mode UAT bypass (OWNER-gated SystemConfig TEST_MODE_BYPASS,
+      // default off, audited). Turn OFF before go-live. Skips real credit
+      // precheck so the system can be exercised end-to-end without external
+      // dependencies. No placeholder customer exists yet at this point, so the
+      // audit marker carries the nationalId for traceability instead of a
+      // customerId (audit.log is a no-op without a valid userId FK, so this
+      // only persists when an authenticated actor is threaded through).
+      await this.audit.log({
+        userId: actor?.userId,
+        action: 'CREDIT_PRECHECK_BYPASSED_TEST_MODE',
+        entity: 'customer',
+        newValue: { nationalId: input.nationalId, reason: 'TEST_MODE_BYPASS' },
+        ipAddress: actor?.ipAddress,
+        userAgent: actor?.userAgent,
+      });
+      return {
+        customerId: '',
+        isNewCustomer: false,
+        tier: 'NEW',
+        decision: 'PASS',
+        reasons: [
+          {
+            code: 'TEST_MODE_BYPASS',
+            message: 'โหมดทดสอบเปิดอยู่ — ข้ามการตรวจเครดิตจริง',
+          },
+        ],
+      };
+    }
+
     const stmtHash = this.hashStatement(input.statementFiles);
     const key = this.cacheKey(input.nationalId, stmtHash);
     const cached = this.cache.get(key);

--- a/apps/api/src/modules/customers/customers.controller.spec.ts
+++ b/apps/api/src/modules/customers/customers.controller.spec.ts
@@ -153,8 +153,16 @@ describe('CustomersController PII (Phase 5)', () => {
       };
       const spy = jest.spyOn(preCheckService, 'runPreCheck').mockResolvedValue(mockResp);
       const body = { nationalId: '1234567890123', phone: '0812345678' };
-      const result = await controller.preCheck(body);
-      expect(spy).toHaveBeenCalledWith(body);
+      const req = {
+        user: { id: 'user-1', role: 'SALES' },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'jest' },
+      } as unknown as Parameters<typeof controller.preCheck>[1];
+      const result = await controller.preCheck(body, req);
+      expect(spy).toHaveBeenCalledWith(
+        body,
+        expect.objectContaining({ userId: 'user-1' }),
+      );
       expect(result.decision).toBe('REVIEW');
     });
   });

--- a/apps/api/src/modules/customers/customers.controller.ts
+++ b/apps/api/src/modules/customers/customers.controller.ts
@@ -260,8 +260,15 @@ export class CustomersController {
 
   @Post('pre-check')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'SALES')
-  async preCheck(@Body() body: CustomerPreCheckDto): Promise<CustomerPreCheckResponse> {
-    return this.preCheckService.runPreCheck(body);
+  async preCheck(
+    @Body() body: CustomerPreCheckDto,
+    @Req() req: AuthRequest,
+  ): Promise<CustomerPreCheckResponse> {
+    return this.preCheckService.runPreCheck(body, {
+      userId: req.user?.id,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'] as string | undefined,
+    });
   }
 
   @Post('pre-check/:customerId/abandon')

--- a/apps/api/src/modules/customers/customers.module.ts
+++ b/apps/api/src/modules/customers/customers.module.ts
@@ -7,9 +7,10 @@ import { SkipTracingService } from './skip-tracing.service';
 import { CustomerPiiModule } from './customer-pii.module';
 import { OverdueModule } from '../overdue/overdue.module';
 import { ContactsModule } from '../contacts/contacts.module';
+import { TestModeModule } from '../test-mode/test-mode.module';
 
 @Module({
-  imports: [OverdueModule, CustomerPiiModule, ContactsModule],
+  imports: [OverdueModule, CustomerPiiModule, ContactsModule, TestModeModule],
   controllers: [CustomersController],
   providers: [
     CustomersService,

--- a/apps/api/src/modules/kyc/kyc.controller.ts
+++ b/apps/api/src/modules/kyc/kyc.controller.ts
@@ -8,6 +8,8 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 
+type AuthRequest = Request & { user?: { id: string; role: string } };
+
 @ApiTags('Customers')
 @ApiBearerAuth('JWT')
 @Controller('contracts')
@@ -37,8 +39,14 @@ export class KycController {
   verifyOtp(
     @Param('id') id: string,
     @Body() dto: VerifyOtpDto,
+    @Req() req: AuthRequest,
   ) {
-    return this.kycService.verifyOtp(id, dto.otp);
+    // Actor threaded through for the test-mode bypass audit trail.
+    return this.kycService.verifyOtp(id, dto.otp, {
+      userId: req.user?.id,
+      ipAddress: req.ip,
+      userAgent: req.headers?.['user-agent'],
+    });
   }
 
   @Post(':id/kyc/upload-id-card')

--- a/apps/api/src/modules/kyc/kyc.module.ts
+++ b/apps/api/src/modules/kyc/kyc.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { KycController } from './kyc.controller';
 import { KycService } from './kyc.service';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { TestModeModule } from '../test-mode/test-mode.module';
 
 @Module({
-  imports: [NotificationsModule],
+  imports: [NotificationsModule, TestModeModule],
   controllers: [KycController],
   providers: [KycService],
   exports: [KycService],

--- a/apps/api/src/modules/kyc/kyc.service.spec.ts
+++ b/apps/api/src/modules/kyc/kyc.service.spec.ts
@@ -4,6 +4,8 @@ import * as crypto from 'crypto';
 import { KycService } from './kyc.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { TestModeService } from '../test-mode/test-mode.service';
+import { AuditService } from '../audit/audit.service';
 
 describe('KycService', () => {
   let service: KycService;
@@ -11,6 +13,10 @@ describe('KycService', () => {
   let prisma: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let notifications: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let testMode: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let audit: any;
 
   const mockContract = {
     id: 'contract-1',
@@ -59,6 +65,15 @@ describe('KycService', () => {
     send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }),
   };
 
+  const mockTestMode = {
+    // Default OFF — every existing validation test runs the real path unchanged.
+    isEnabled: jest.fn().mockResolvedValue(false),
+  };
+
+  const mockAudit = {
+    log: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     // Reset mocks
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -66,6 +81,8 @@ describe('KycService', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Object.values(mockPrisma.kycVerification).forEach((fn: any) => fn.mockClear());
     mockNotifications.send.mockClear();
+    mockTestMode.isEnabled.mockClear();
+    mockAudit.log.mockClear();
 
     // Reset default return values
     mockPrisma.contract.findUnique.mockResolvedValue(mockContract);
@@ -74,18 +91,24 @@ describe('KycService', () => {
     mockPrisma.kycVerification.findFirst.mockResolvedValue(mockKycRecord);
     mockPrisma.kycVerification.update.mockResolvedValue(mockKycRecord);
     mockNotifications.send.mockResolvedValue({ id: 'notif-1', status: 'SENT' });
+    mockTestMode.isEnabled.mockResolvedValue(false);
+    mockAudit.log.mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KycService,
         { provide: PrismaService, useValue: mockPrisma },
         { provide: NotificationsService, useValue: mockNotifications },
+        { provide: TestModeService, useValue: mockTestMode },
+        { provide: AuditService, useValue: mockAudit },
       ],
     }).compile();
 
     service = module.get<KycService>(KycService);
     prisma = module.get(PrismaService);
     notifications = module.get(NotificationsService);
+    testMode = module.get(TestModeService);
+    audit = module.get(AuditService);
   });
 
   // ─── sendOtp ─────────────────────────────────────────
@@ -261,6 +284,66 @@ describe('KycService', () => {
       prisma.kycVerification.findFirst.mockResolvedValueOnce(null);
 
       await expect(service.verifyOtp('contract-1', '123456')).rejects.toThrow(BadRequestException);
+    });
+
+    // ─── test-mode bypass (OWNER-gated UAT) ───────────────
+    describe('when test-mode is ON', () => {
+      beforeEach(() => {
+        testMode.isEnabled.mockResolvedValue(true);
+      });
+
+      it('should succeed even with a wrong OTP and mark the row OTP_VERIFIED', async () => {
+        // Wrong code — would normally throw "OTP ไม่ถูกต้อง". Test-mode bypasses
+        // the hash check but MUST still reproduce the real success side-effect.
+        prisma.kycVerification.findFirst.mockResolvedValueOnce({
+          ...mockKycRecord,
+          otpHash: 'correct-hash-that-wont-match',
+        });
+
+        const result = await service.verifyOtp('contract-1', '000000');
+
+        expect(result.verified).toBe(true);
+        // Same mutation the real success branch performs.
+        expect(prisma.kycVerification.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: mockKycRecord.id },
+            data: expect.objectContaining({ status: 'OTP_VERIFIED' }),
+          }),
+        );
+        // otpAttempts must NOT be incremented (no failed-attempt path taken).
+        expect(prisma.kycVerification.update).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ otpAttempts: expect.anything() }),
+          }),
+        );
+      });
+
+      it('should write a KYC_OTP_BYPASSED_TEST_MODE audit log', async () => {
+        await service.verifyOtp('contract-1', '000000', {
+          userId: 'user-1',
+          ipAddress: '127.0.0.1',
+          userAgent: 'test-agent',
+        });
+
+        expect(audit.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: 'KYC_OTP_BYPASSED_TEST_MODE',
+            entity: 'contract',
+            entityId: 'contract-1',
+            userId: 'user-1',
+          }),
+        );
+      });
+
+      it('should still require a pending KYC record (OTP must have been sent)', async () => {
+        // Bypass skips the code check, not the "an OTP session exists" precondition.
+        prisma.kycVerification.findFirst.mockResolvedValueOnce(null);
+
+        await expect(service.verifyOtp('contract-1', '000000')).rejects.toThrow(
+          BadRequestException,
+        );
+        expect(prisma.kycVerification.update).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/api/src/modules/kyc/kyc.service.ts
+++ b/apps/api/src/modules/kyc/kyc.service.ts
@@ -2,11 +2,20 @@ import { Injectable, NotFoundException, BadRequestException, InternalServerError
 import { PrismaService } from '../../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationCategory } from '../notifications/notification-category.enum';
+import { TestModeService } from '../test-mode/test-mode.service';
+import { AuditService } from '../audit/audit.service';
 import * as crypto from 'crypto';
 
 const OTP_EXPIRY_MINUTES = 10;
 const MAX_OTP_ATTEMPTS = 5;
 const MAX_OTP_SENDS_PER_HOUR = 3;
+
+/** Actor context for audit trails (optional — controller threads it through). */
+export interface KycActor {
+  userId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
 
 @Injectable()
 export class KycService {
@@ -15,6 +24,8 @@ export class KycService {
   constructor(
     private prisma: PrismaService,
     private notificationsService: NotificationsService,
+    private testMode: TestModeService,
+    private audit: AuditService,
   ) {}
 
   /**
@@ -133,16 +144,47 @@ export class KycService {
   /**
    * Verify OTP entered by customer
    */
-  async verifyOtp(contractId: string, otp: string) {
+  async verifyOtp(contractId: string, otp: string, actor?: KycActor) {
     const kyc = await this.prisma.kycVerification.findFirst({
       where: { contractId, status: 'PENDING' },
       orderBy: { createdAt: 'desc' },
     });
     if (!kyc) throw new BadRequestException('ไม่พบ OTP ที่รอยืนยัน กรุณาส่ง OTP ใหม่');
 
+    // Test-mode UAT bypass — OWNER-gated SystemConfig (TEST_MODE_BYPASS), default OFF,
+    // audited, app-wide banner. Intentionally overrides the prior always-validate stance
+    // per owner decision for pre-go-live testing. MUST be turned OFF before go-live.
+    //
+    // We still require that an OTP session exists (the PENDING row found above), so the
+    // contract flow can only advance if send-otp ran — we only skip the hash/expiry/
+    // attempt checks. The success side-effects below are byte-for-byte identical to the
+    // real success branch (mark the row OTP_VERIFIED + same return value) so the
+    // downstream contract flow (uploadIdCard → VERIFIED) proceeds unchanged.
+    if (await this.testMode.isEnabled()) {
+      await this.prisma.kycVerification.update({
+        where: { id: kyc.id },
+        data: { otpVerifiedAt: new Date(), status: 'OTP_VERIFIED' },
+      });
+
+      // Best-effort audit (AuditService.log is a no-op without a valid userId FK,
+      // so this only persists when an authenticated actor is threaded through).
+      await this.audit.log({
+        userId: actor?.userId,
+        action: 'KYC_OTP_BYPASSED_TEST_MODE',
+        entity: 'contract',
+        entityId: contractId,
+        newValue: { kycVerificationId: kyc.id, reason: 'TEST_MODE_BYPASS' },
+        ipAddress: actor?.ipAddress,
+        userAgent: actor?.userAgent,
+      });
+
+      return { verified: true, message: 'OTP ถูกต้อง' };
+    }
+
     // OTP must always be validated via hash + expiry + attempt count,
     // even in non-production environments, to prevent accidental auth bypass
-    // if NODE_ENV is mis-set in prod.
+    // if NODE_ENV is mis-set in prod. (Exception: the OWNER-gated test-mode
+    // bypass above — see comment there.)
 
     // Check expiry
     if (new Date() > kyc.expiresAt) {

--- a/apps/api/src/modules/test-mode/__tests__/test-mode.controller.spec.ts
+++ b/apps/api/src/modules/test-mode/__tests__/test-mode.controller.spec.ts
@@ -1,0 +1,32 @@
+import { Test } from '@nestjs/testing';
+import { TestModeController } from '../test-mode.controller';
+import { TestModeService } from '../test-mode.service';
+
+describe('TestModeController', () => {
+  let ctrl: TestModeController;
+  const svc = { isEnabled: jest.fn(), setEnabled: jest.fn() };
+
+  beforeEach(async () => {
+    const mod = await Test.createTestingModule({
+      controllers: [TestModeController],
+      providers: [{ provide: TestModeService, useValue: svc }],
+    })
+      .overrideGuard(require('../../auth/guards/jwt-auth.guard').JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(require('../../auth/guards/roles.guard').RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    ctrl = mod.get(TestModeController);
+  });
+
+  it('GET returns status', async () => {
+    svc.isEnabled.mockResolvedValue(true);
+    expect(await ctrl.get()).toEqual({ enabled: true });
+  });
+
+  it('PUT sets + returns', async () => {
+    svc.setEnabled.mockResolvedValue(false);
+    expect(await ctrl.set({ enabled: false })).toEqual({ enabled: false });
+    expect(svc.setEnabled).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/api/src/modules/test-mode/__tests__/test-mode.service.spec.ts
+++ b/apps/api/src/modules/test-mode/__tests__/test-mode.service.spec.ts
@@ -1,0 +1,39 @@
+import { Test } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { TestModeService } from '../test-mode.service';
+
+describe('TestModeService', () => {
+  let svc: TestModeService;
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = { systemConfig: { findFirst: jest.fn(), upsert: jest.fn() } };
+    const mod = await Test.createTestingModule({
+      providers: [TestModeService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    svc = mod.get(TestModeService);
+  });
+
+  it('isEnabled true only when value "true"', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+    expect(await svc.isEnabled()).toBe(true);
+  });
+
+  it('isEnabled false when missing', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue(null);
+    expect(await svc.isEnabled()).toBe(false);
+  });
+
+  it('isEnabled false on db error', async () => {
+    prisma.systemConfig.findFirst.mockRejectedValue(new Error('x'));
+    expect(await svc.isEnabled()).toBe(false);
+  });
+
+  it('setEnabled upserts', async () => {
+    prisma.systemConfig.upsert.mockResolvedValue({});
+    await svc.setEnabled(true);
+    expect(prisma.systemConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { key: 'TEST_MODE_BYPASS' } }),
+    );
+  });
+});

--- a/apps/api/src/modules/test-mode/test-mode.controller.ts
+++ b/apps/api/src/modules/test-mode/test-mode.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Get, Put, UseGuards } from '@nestjs/common';
+import { IsBoolean } from 'class-validator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { TestModeService } from './test-mode.service';
+
+class SetTestModeDto {
+  @IsBoolean({ message: 'กรุณาระบุสถานะโหมดทดสอบ (true/false)' })
+  enabled!: boolean;
+}
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('settings/test-mode')
+export class TestModeController {
+  constructor(private readonly testMode: TestModeService) {}
+
+  @Get()
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER', 'SALES')
+  async get() {
+    return { enabled: await this.testMode.isEnabled() };
+  }
+
+  @Put()
+  @Roles('OWNER')
+  async set(@Body() dto: SetTestModeDto) {
+    return { enabled: await this.testMode.setEnabled(dto.enabled) };
+  }
+}

--- a/apps/api/src/modules/test-mode/test-mode.module.ts
+++ b/apps/api/src/modules/test-mode/test-mode.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TestModeService } from './test-mode.service';
+import { TestModeController } from './test-mode.controller';
+
+@Module({
+  controllers: [TestModeController],
+  providers: [TestModeService],
+  exports: [TestModeService],
+})
+export class TestModeModule {}

--- a/apps/api/src/modules/test-mode/test-mode.service.ts
+++ b/apps/api/src/modules/test-mode/test-mode.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/**
+ * OWNER-controlled "test mode" toggle.
+ *
+ * When enabled, downstream control points (credit check, OTP, 2FA, etc.)
+ * bypass their real-world checks so the system can be exercised end-to-end
+ * without external dependencies. Stored in SystemConfig under a single key.
+ *
+ * Mirrors CustomerPiiService.isStrictMode / setStrictMode — same SystemConfig
+ * read/upsert shape, same fail-safe semantics: any DB error makes isEnabled()
+ * return false (bypass OFF) so a transient outage can never silently disable
+ * production safety checks.
+ */
+@Injectable()
+export class TestModeService {
+  /** SystemConfig key that controls the test-mode bypass. */
+  static readonly KEY = 'TEST_MODE_BYPASS';
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Read the toggle. Returns true ONLY when the stored value is the literal
+   * string "true". Missing row or DB error → false (fail-safe to OFF).
+   *
+   * No in-process cache (same rationale as CustomerPiiService.isStrictMode):
+   * the SELECT is sub-millisecond on the indexed `key` column, and caching
+   * would produce cross-pod inconsistency.
+   */
+  async isEnabled(): Promise<boolean> {
+    try {
+      const row = await this.prisma.systemConfig.findFirst({
+        where: { key: TestModeService.KEY, deletedAt: null },
+        select: { value: true },
+      });
+      return row?.value?.trim().toLowerCase() === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  /** Set the toggle. Upserts SystemConfig. Returns the new effective value. */
+  async setEnabled(enabled: boolean): Promise<boolean> {
+    await this.prisma.systemConfig.upsert({
+      where: { key: TestModeService.KEY },
+      update: {
+        value: enabled ? 'true' : 'false',
+        updatedAt: new Date(),
+        deletedAt: null,
+      },
+      create: {
+        key: TestModeService.KEY,
+        value: enabled ? 'true' : 'false',
+        label: 'โหมดทดสอบ — ปิดเช็คเครดิต/OTP/2FA (ห้ามเปิดบน prod ที่มีลูกค้าจริง)',
+      },
+    });
+    return enabled;
+  }
+}

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -13,6 +13,7 @@ import CommandPalette from '@/components/CommandPalette';
 import ShortcutsHelpOverlay from '@/components/ShortcutsHelpOverlay';
 import MobileBottomNav from './MobileBottomNav';
 import { SkipLink } from './SkipLink';
+import TestModeBanner from './TestModeBanner';
 import { InboundCallPopup } from '@/components/InboundCallPopup';
 import { getSidebarForRole, getZoneConfigForRole } from '@/config/menu';
 import type { Zone } from '@/config/menu';
@@ -154,8 +155,13 @@ function MainContent() {
       : SIDEBAR_EXPANDED_W;
 
   return (
-    <div className="flex min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <SkipLink />
+
+      {/* App-wide test-mode banner — shows on every page when test-mode is ON */}
+      <TestModeBanner />
+
+      <div className="flex flex-1 min-h-0">
 
       {/* Desktop Sidebar */}
       {!isMobile && <Sidebar />}
@@ -184,6 +190,7 @@ function MainContent() {
             </div>
           )}
         </main>
+      </div>
       </div>
 
       {/* Mobile bottom tab bar */}

--- a/apps/web/src/components/layout/TestModeBanner.tsx
+++ b/apps/web/src/components/layout/TestModeBanner.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { testModeApi, testModeKeys } from '@/lib/api/test-mode';
+
+/**
+ * App-wide loud banner shown on every page when test-mode is ON.
+ * Test-mode bypasses credit check + OTP + 2FA — must be visually impossible
+ * to miss so staff never run it against real customers.
+ */
+export default function TestModeBanner() {
+  const { data } = useQuery({
+    queryKey: testModeKeys.status,
+    queryFn: testModeApi.get,
+  });
+
+  if (!data?.enabled) return null;
+
+  return (
+    <div
+      data-testid="test-mode-banner"
+      role="alert"
+      className="bg-destructive text-destructive-foreground px-4 py-2 text-center text-sm font-semibold leading-snug"
+    >
+      ⚠️ โหมดทดสอบ — เช็คเครดิต/OTP/2FA ถูกปิด ห้ามใช้กับลูกค้าจริง
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/__tests__/TestModeBanner.test.tsx
+++ b/apps/web/src/components/layout/__tests__/TestModeBanner.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+import TestModeBanner from '../TestModeBanner';
+import { testModeApi } from '@/lib/api/test-mode';
+
+vi.mock('@/lib/api/test-mode', async (orig) => {
+  const a = await orig<typeof import('@/lib/api/test-mode')>();
+  return { ...a, testModeApi: { ...a.testModeApi, get: vi.fn() } };
+});
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+it('shows banner when enabled', async () => {
+  (testModeApi.get as any).mockResolvedValue({ enabled: true });
+  wrap(<TestModeBanner />);
+  await waitFor(() => expect(screen.getByText(/โหมดทดสอบ/)).toBeInTheDocument());
+});
+
+it('renders nothing when disabled', async () => {
+  (testModeApi.get as any).mockResolvedValue({ enabled: false });
+  const { container } = wrap(<TestModeBanner />);
+  await waitFor(() => expect(testModeApi.get).toHaveBeenCalled());
+  expect(container.querySelector('[data-testid="test-mode-banner"]')).toBeNull();
+});

--- a/apps/web/src/lib/api/test-mode.ts
+++ b/apps/web/src/lib/api/test-mode.ts
@@ -1,0 +1,9 @@
+import api from '@/lib/api';
+
+export const testModeKeys = { status: ['test-mode-status'] as const };
+
+export const testModeApi = {
+  get: () => api.get<{ enabled: boolean }>('/settings/test-mode').then((r) => r.data),
+  set: (enabled: boolean) =>
+    api.put<{ enabled: boolean }>('/settings/test-mode', { enabled }).then((r) => r.data),
+};

--- a/apps/web/src/pages/SettingsPage/components/TestModeToggle.tsx
+++ b/apps/web/src/pages/SettingsPage/components/TestModeToggle.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { toast } from 'sonner';
+import { AlertTriangle } from 'lucide-react';
+import { testModeApi, testModeKeys } from '@/lib/api/test-mode';
+
+export function TestModeToggle() {
+  const { user } = useAuth();
+  const isOwner = user?.role === 'OWNER';
+  const queryClient = useQueryClient();
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const statusQuery = useQuery({
+    queryKey: testModeKeys.status,
+    queryFn: testModeApi.get,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (enabled: boolean) => testModeApi.set(enabled),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: testModeKeys.status });
+      toast.success(data.enabled ? 'เปิดโหมดทดสอบแล้ว' : 'ปิดโหมดทดสอบแล้ว');
+    },
+    onError: () => toast.error('ไม่สามารถบันทึกการตั้งค่าได้'),
+  });
+
+  const currentEnabled = statusQuery.data?.enabled ?? false;
+
+  const handleToggle = (next: boolean) => {
+    if (!isOwner) return;
+    if (next) {
+      // Turning ON bypasses safety checks — require explicit confirmation.
+      setShowConfirm(true);
+    } else {
+      // Turning OFF restores safety — no confirm needed.
+      mutation.mutate(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>โหมดทดสอบ (ปิดเช็คเครดิต/OTP/2FA)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-3">
+          <Switch
+            checked={currentEnabled}
+            onCheckedChange={handleToggle}
+            disabled={!isOwner || mutation.isPending}
+            aria-label="Toggle Test Mode"
+          />
+          <span className="text-sm font-medium">
+            {currentEnabled ? 'เปิดใช้งาน' : 'ปิดใช้งาน'}
+          </span>
+        </div>
+
+        {!isOwner && (
+          <p className="text-xs text-muted-foreground leading-snug">
+            เฉพาะ OWNER เท่านั้นที่เปลี่ยนได้
+          </p>
+        )}
+
+        <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3">
+          <AlertTriangle className="w-4 h-4 mt-0.5 text-destructive shrink-0" />
+          <p className="text-xs text-destructive leading-snug">
+            เมื่อเปิด — ระบบจะข้ามการเช็คเครดิต, OTP และ 2FA ใช้เฉพาะตอนทดสอบเท่านั้น
+            ห้ามเปิดตอนมีลูกค้าจริง
+          </p>
+        </div>
+
+        <ConfirmDialog
+          open={showConfirm}
+          onOpenChange={setShowConfirm}
+          title="เปิดโหมดทดสอบ?"
+          description="จะปิดเช็คเครดิต/OTP/2FA — ใช้เฉพาะตอนทดสอบ ห้ามเปิดตอนมีลูกค้าจริง"
+          confirmLabel="เปิดโหมดทดสอบ"
+          variant="destructive"
+          loading={mutation.isPending}
+          onConfirm={() => mutation.mutate(true)}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/SettingsPage/tabs/UsersTab.tsx
+++ b/apps/web/src/pages/SettingsPage/tabs/UsersTab.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router';
 import { MakerCheckerToggle } from '../components/MakerCheckerToggle';
+import { TestModeToggle } from '../components/TestModeToggle';
 import { PettyCashCustodianCard } from '../components/PettyCashCustodianCard';
 import { ReversePermissionCard } from '../components/ReversePermissionCard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -10,6 +11,11 @@ export function UsersTab() {
   return (
     <div className="space-y-4">
       <MakerCheckerToggle />
+
+      {/* Test-mode bypass — OWNER toggle that disables credit check / OTP / 2FA.
+          Sits with the other authority/security controls. */}
+      <TestModeToggle />
+
 
       {/* InternalControlActionBar — Setting 1: reverse-permission mode +
           per-user override. Sits next to MakerCheckerToggle because both

--- a/docs/superpowers/plans/2026-06-02-test-mode-bypass.md
+++ b/docs/superpowers/plans/2026-06-02-test-mode-bypass.md
@@ -1,0 +1,363 @@
+# Test-Mode Bypass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** OWNER-controlled SystemConfig toggle `TEST_MODE_BYPASS` that, when on, skips 4 friction controls (credit precheck, KYC OTP, LIFF OTP, login 2FA) for pre-go-live UAT — with a loud app-wide banner + audit on every bypass.
+
+**Architecture:** A `TestModeService` reads/writes SystemConfig `TEST_MODE_BYPASS` (mirrors `CustomerPiiService.isStrictMode/setStrictMode`, read-fresh no-cache). Each of the 4 control points injects it and, when enabled, short-circuits with an audit marker; when disabled, behaves exactly as today. Frontend shows a banner + an OWNER settings toggle.
+
+**Tech Stack:** NestJS + Prisma + Jest (api), React + react-query + Vitest (web)
+
+**Spec:** `docs/superpowers/specs/2026-06-02-test-mode-bypass-design.md`
+
+**Security note:** This deliberately overrides the in-code comment in `kyc.service.ts` that forbids OTP bypass (it feared an env-based bypass mis-set in prod). Owner approved. Our toggle is safer than that feared case: SystemConfig (not NODE_ENV), default OFF, OWNER-only, audited, app-wide banner, documented go-live runbook. When editing kyc.service, REPLACE the old "must always validate" comment with one explaining the intentional OWNER-gated test-mode bypass.
+
+---
+
+## File Structure
+- Create: `apps/api/src/modules/test-mode/test-mode.service.ts` + `.module.ts` + `__tests__/test-mode.service.spec.ts` — the toggle
+- Create: `apps/api/src/modules/test-mode/test-mode.controller.ts` — GET/PUT /settings/test-mode
+- Modify: `apps/api/src/app.module.ts` — register TestModeModule
+- Modify: 4 control points (customer-precheck, kyc, liff verification, auth) — inject + bypass
+- Create: `apps/web/src/lib/api/test-mode.ts`
+- Create: `apps/web/src/components/layout/TestModeBanner.tsx` + wire into MainLayout
+- Modify: a Settings page — OWNER toggle
+
+---
+
+## Task 1: TestModeService (SystemConfig toggle)
+
+**Files:**
+- Create: `apps/api/src/modules/test-mode/test-mode.service.ts`
+- Create: `apps/api/src/modules/test-mode/test-mode.module.ts`
+- Test: `apps/api/src/modules/test-mode/__tests__/test-mode.service.spec.ts`
+
+- [ ] **Step 1: Failing test**
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { TestModeService } from '../test-mode.service';
+
+describe('TestModeService', () => {
+  let svc: TestModeService;
+  let prisma: any;
+  beforeEach(async () => {
+    prisma = { systemConfig: { findFirst: jest.fn(), upsert: jest.fn() } };
+    const mod = await Test.createTestingModule({
+      providers: [TestModeService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    svc = mod.get(TestModeService);
+  });
+  it('isEnabled true only when config value is "true"', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue({ value: 'true' });
+    expect(await svc.isEnabled()).toBe(true);
+  });
+  it('isEnabled false when missing', async () => {
+    prisma.systemConfig.findFirst.mockResolvedValue(null);
+    expect(await svc.isEnabled()).toBe(false);
+  });
+  it('isEnabled false on db error (fail-safe)', async () => {
+    prisma.systemConfig.findFirst.mockRejectedValue(new Error('db down'));
+    expect(await svc.isEnabled()).toBe(false);
+  });
+  it('setEnabled upserts the flag', async () => {
+    prisma.systemConfig.upsert.mockResolvedValue({});
+    await svc.setEnabled(true);
+    expect(prisma.systemConfig.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { key: 'TEST_MODE_BYPASS' },
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cd apps/api && npx jest test-mode.service --silent`
+
+- [ ] **Step 3: Implement** (mirror `CustomerPiiService.isStrictMode/setStrictMode`)
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable()
+export class TestModeService {
+  static readonly KEY = 'TEST_MODE_BYPASS';
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Read fresh (no cache) — cross-pod consistency. Fail-safe to false. */
+  async isEnabled(): Promise<boolean> {
+    try {
+      const row = await this.prisma.systemConfig.findFirst({
+        where: { key: TestModeService.KEY, deletedAt: null },
+        select: { value: true },
+      });
+      return row?.value?.trim().toLowerCase() === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  async setEnabled(enabled: boolean): Promise<boolean> {
+    await this.prisma.systemConfig.upsert({
+      where: { key: TestModeService.KEY },
+      update: { value: enabled ? 'true' : 'false', updatedAt: new Date(), deletedAt: null },
+      create: {
+        key: TestModeService.KEY,
+        value: enabled ? 'true' : 'false',
+        label: 'โหมดทดสอบ — ปิดเช็คเครดิต/OTP/2FA (ห้ามเปิดบน prod ที่มีลูกค้าจริง)',
+      },
+    });
+    return enabled;
+  }
+}
+```
+`test-mode.module.ts`:
+```typescript
+import { Module } from '@nestjs/common';
+import { TestModeService } from './test-mode.service';
+@Module({ providers: [TestModeService], exports: [TestModeService] })
+export class TestModeModule {}
+```
+> Confirm `SystemConfig` has `key`/`value`/`label`/`deletedAt` and PrismaModule is global (it is). Mirror exact field usage from `customer-pii.service.ts` setStrictMode.
+
+- [ ] **Step 4: Run, expect PASS** — `cd apps/api && npx jest test-mode.service --silent`
+- [ ] **Step 5: Commit** — `git add apps/api/src/modules/test-mode && git commit -m "feat(test-mode): TestModeService toggle (SystemConfig, fail-safe)"`
+
+---
+
+## Task 2: Settings endpoint (GET status + PUT OWNER toggle + audit)
+
+**Files:**
+- Create: `apps/api/src/modules/test-mode/test-mode.controller.ts`
+- Modify: `apps/api/src/modules/test-mode/test-mode.module.ts` (add controller)
+- Modify: `apps/api/src/app.module.ts` (register TestModeModule)
+- Test: `apps/api/src/modules/test-mode/__tests__/test-mode.controller.spec.ts`
+
+- [ ] **Step 1: Failing controller test**
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { TestModeController } from '../test-mode.controller';
+import { TestModeService } from '../test-mode.service';
+
+describe('TestModeController', () => {
+  let ctrl: TestModeController;
+  const svc = { isEnabled: jest.fn(), setEnabled: jest.fn() };
+  beforeEach(async () => {
+    const mod = await Test.createTestingModule({
+      controllers: [TestModeController],
+      providers: [{ provide: TestModeService, useValue: svc }],
+    }).compile();
+    ctrl = mod.get(TestModeController);
+  });
+  it('GET returns status', async () => {
+    svc.isEnabled.mockResolvedValue(true);
+    expect(await ctrl.get()).toEqual({ enabled: true });
+  });
+  it('PUT sets + returns status', async () => {
+    svc.setEnabled.mockResolvedValue(false);
+    expect(await ctrl.set({ enabled: false })).toEqual({ enabled: false });
+    expect(svc.setEnabled).toHaveBeenCalledWith(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `cd apps/api && npx jest test-mode.controller --silent`
+
+- [ ] **Step 3: Implement controller** (copy guard/Roles/Audit imports verbatim from `customers.controller.ts`)
+
+```typescript
+import { Body, Controller, Get, Put, UseGuards } from '@nestjs/common';
+import { IsBoolean } from 'class-validator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { TestModeService } from './test-mode.service';
+
+class SetTestModeDto { @IsBoolean() enabled!: boolean; }
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('settings/test-mode')
+export class TestModeController {
+  constructor(private readonly testMode: TestModeService) {}
+
+  @Get()
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER', 'SALES')
+  async get() { return { enabled: await this.testMode.isEnabled() }; }
+
+  @Put()
+  @Roles('OWNER')
+  async set(@Body() dto: SetTestModeDto) {
+    return { enabled: await this.testMode.setEnabled(dto.enabled) };
+  }
+}
+```
+GET allows all roles (banner needs to read it); PUT OWNER-only. The global AuditInterceptor records the PUT (audit string `TEST_MODE_TOGGLED` is emitted by the interceptor for mutating endpoints — confirm interceptor covers PUT; if a custom action string is needed, add an `@AuditAction('TEST_MODE_TOGGLED')` per the codebase's audit decorator pattern — check how other OWNER toggles like MakerCheckerToggle audit).
+
+Add controller to `test-mode.module.ts` (`controllers: [TestModeController]`) and register `TestModeModule` in `app.module.ts` imports.
+
+- [ ] **Step 4: Run PASS + type-check** — `cd apps/api && npx jest test-mode --silent && cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api`
+- [ ] **Step 5: Commit** — `git add apps/api/src/modules/test-mode apps/api/src/app.module.ts && git commit -m "feat(test-mode): GET/PUT settings/test-mode (OWNER toggle)"`
+
+---
+
+## Task 3: Bypass — customer credit precheck
+
+**Files:**
+- Modify: `apps/api/src/modules/customers/customer-precheck.service.ts`
+- Modify: `apps/api/src/modules/customers/customers.module.ts` (import TestModeModule)
+- Test: `apps/api/src/modules/customers/customer-precheck.service.spec.ts`
+
+- [ ] **Step 1: Failing test** — when test-mode on, precheck returns `decision: 'PASS'` without running checks + writes audit.
+
+```typescript
+it('returns PASS (bypass) when test-mode enabled', async () => {
+  testMode.isEnabled.mockResolvedValue(true);
+  const res = await service.<precheckMethod>(<minimal valid input>);
+  expect(res.decision).toBe('PASS');
+  expect(res.reasons).toContain('TEST_MODE_BYPASS');
+});
+```
+> Read the file to get the exact public method name + input shape (it returns `{ decision: 'PASS'|'REVIEW'|'FAIL', reasons: string[] }`). Inject a mocked `TestModeService`.
+
+- [ ] **Step 2: Run, expect FAIL** — `cd apps/api && npx jest customer-precheck --silent`
+
+- [ ] **Step 3: Implement** — inject `TestModeService`; at the TOP of the precheck method:
+```typescript
+if (await this.testMode.isEnabled()) {
+  // Test-mode UAT bypass (OWNER-gated, audited). Turn off before go-live.
+  await this.audit.log({ action: 'CREDIT_PRECHECK_BYPASSED_TEST_MODE', entity: 'customer', /* entityId if available */ });
+  return { decision: 'PASS', reasons: ['TEST_MODE_BYPASS'] };
+}
+```
+Use the audit service the module already uses (check how customers writes audit; if precheck has no audit dep, use AuditService or AuditInterceptor-compatible call — match existing pattern). Add `imports: [TestModeModule]` to `customers.module.ts`.
+
+- [ ] **Step 4: Run PASS + type-check** — `cd apps/api && npx jest customer-precheck --silent && ./tools/check-types.sh api` (from repo root)
+- [ ] **Step 5: Commit** — `git add apps/api/src/modules/customers && git commit -m "feat(test-mode): bypass credit precheck when test-mode on"`
+
+---
+
+## Task 4: Bypass — KYC OTP (contract signing)
+
+**Files:**
+- Modify: `apps/api/src/modules/kyc/kyc.service.ts` (`verifyOtp`, ~line 136) + `kyc.module.ts`
+- Test: kyc service spec (find existing or create)
+
+- [ ] **Step 1: Failing test** — `verifyOtp` succeeds without a valid OTP when test-mode on.
+```typescript
+it('passes verifyOtp without checking code when test-mode on', async () => {
+  testMode.isEnabled.mockResolvedValue(true);
+  // arrange minimal contract/kyc mocks as the success path needs
+  const res = await service.verifyOtp('contract-1', '000000');
+  expect(res).toBeTruthy(); // matches the method's success return shape
+});
+```
+> Inspect `verifyOtp`'s success return + what it mutates (it likely marks kyc VERIFIED + advances contract). The bypass must produce the SAME success side-effects (mark verified) so the contract flow proceeds — not just return early. Read the success branch and replicate its state changes in the bypass.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+- [ ] **Step 3: Implement** — at top of `verifyOtp`, REPLACE the existing "OTP must always be validated…" comment with:
+```typescript
+// Test-mode UAT bypass (OWNER-gated SystemConfig TEST_MODE_BYPASS, default off,
+// audited, app-wide banner). Replaces the former always-validate stance per
+// owner decision for pre-go-live testing. MUST be off before go-live.
+if (await this.testMode.isEnabled()) {
+  // perform the SAME success side-effects as a real verify (mark kyc verified,
+  // advance contract) then audit + return the success shape
+  ...replicate success path mutations...
+  await this.audit.log({ action: 'KYC_OTP_BYPASSED_TEST_MODE', entity: 'contract', entityId: contractId });
+  return <success shape>;
+}
+```
+Inject `TestModeService`, add `imports: [TestModeModule]` to kyc.module.ts.
+
+- [ ] **Step 4: Run PASS + type-check**
+- [ ] **Step 5: Commit** — `git commit -m "feat(test-mode): bypass KYC OTP when test-mode on (replaces always-validate per owner)"`
+
+---
+
+## Task 5: Bypass — LIFF OTP
+
+**Files:**
+- Modify: `apps/api/src/modules/chatbot-finance/services/verification.service.ts` (`verifyOtp`, ~line 208) + its module
+- Test: verification service spec
+
+- [ ] **Step 1: Failing test** — verifyOtp returns success without valid code when test-mode on (replicate success side-effects). Same shape as Task 4.
+- [ ] **Step 2: Run FAIL**
+- [ ] **Step 3: Implement** — inject TestModeService; at top of verifyOtp, if enabled → replicate the success path's state changes + `audit.log({ action: 'LIFF_OTP_BYPASSED_TEST_MODE', ... })` + return success. Add TestModeModule import.
+- [ ] **Step 4: Run PASS + type-check**
+- [ ] **Step 5: Commit** — `git commit -m "feat(test-mode): bypass LIFF OTP when test-mode on"`
+
+---
+
+## Task 6: Bypass — login 2FA
+
+**Files:**
+- Modify: `apps/api/src/modules/auth/auth.service.ts` (`login`, the 2FA branch) + auth.module.ts
+- Test: auth service spec
+
+- [ ] **Step 1: Failing test** — when a 2FA-enabled user logs in with correct password and test-mode on, `login` returns full tokens directly (no `requiresTwoFactor`/temp-token step).
+> Read `login()` (~line 149): it currently, for a 2FA user, returns a temp token + `requiresTwoFactor: true`. The bypass: when test-mode on, skip that branch and issue the full session as if 2FA passed.
+- [ ] **Step 2: Run FAIL**
+- [ ] **Step 3: Implement** — inject TestModeService; in `login`, guard the 2FA branch: `if (user.twoFactorEnabled && !(await this.testMode.isEnabled())) { ...existing temp-token 2FA path... }` else issue full tokens. When bypassing, `loginAudit.record({... twoFactorUsed: false})` + audit `LOGIN_2FA_BYPASSED_TEST_MODE`. Add TestModeModule import to auth.module.ts (watch for circular dep — TestModeModule only depends on global Prisma, safe).
+- [ ] **Step 4: Run PASS + type-check** (run full auth suite — auth is sensitive)
+- [ ] **Step 5: Commit** — `git commit -m "feat(test-mode): bypass login 2FA when test-mode on"`
+
+---
+
+## Task 7: Frontend — banner + settings toggle
+
+**Files:**
+- Create: `apps/web/src/lib/api/test-mode.ts`
+- Create: `apps/web/src/components/layout/TestModeBanner.tsx`
+- Modify: `apps/web/src/components/layout/MainLayout.tsx` (render banner)
+- Modify: a Settings page/tab (OWNER) — add the toggle
+- Test: `apps/web/src/components/layout/__tests__/TestModeBanner.test.tsx`
+
+- [ ] **Step 1: api client**
+```typescript
+import api from '@/lib/api';
+export const testModeKeys = { status: ['test-mode-status'] as const };
+export const testModeApi = {
+  get: () => api.get<{ enabled: boolean }>('/settings/test-mode').then((r) => r.data),
+  set: (enabled: boolean) => api.put<{ enabled: boolean }>('/settings/test-mode', { enabled }).then((r) => r.data),
+};
+```
+
+- [ ] **Step 2: Failing banner test**
+```tsx
+it('shows banner when test-mode enabled', async () => {
+  (testModeApi.get as any).mockResolvedValue({ enabled: true });
+  // render TestModeBanner inside QueryClientProvider
+  await waitFor(() => expect(screen.getByText(/โหมดทดสอบ/)).toBeInTheDocument());
+});
+it('hides banner when disabled', async () => {
+  (testModeApi.get as any).mockResolvedValue({ enabled: false });
+  // render → expect no banner text
+});
+```
+
+- [ ] **Step 3: Implement banner** — `useQuery(testModeKeys.status, testModeApi.get)`; if `data?.enabled` render a `bg-destructive text-destructive-foreground` strip (semantic tokens) "⚠️ โหมดทดสอบ — เช็คเครดิต/OTP/2FA ถูกปิด ห้ามใช้กับลูกค้าจริง" + (OWNER) link to settings. Render `<TestModeBanner />` at top of MainLayout. Thai `leading-snug`.
+
+- [ ] **Step 4: Settings toggle** — in the OWNER settings page (e.g. `/settings#users` hub or GeneralSettings), add a toggle "โหมดทดสอบ (ปิดเช็คเครดิต/OTP)" calling `testModeApi.set`, with a confirm dialog (ConfirmDialog, NOT window.confirm) when turning ON, then `queryClient.invalidateQueries(testModeKeys.status)` + toast. Match how MakerCheckerToggle is built (reference).
+
+- [ ] **Step 5: Run tests + type-check** — `cd apps/web && npx vitest run TestModeBanner --silent && cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh web`
+- [ ] **Step 6: Commit** — `git add apps/web && git commit -m "feat(test-mode): app-wide banner + OWNER settings toggle"`
+
+---
+
+## Task 8: Verify
+
+- [ ] `./tools/check-types.sh all` → 0 errors
+- [ ] `cd apps/api && npx jest test-mode customer-precheck kyc verification auth --silent` → green (incl. existing control tests when flag off)
+- [ ] `cd apps/web && npx vitest run TestModeBanner --silent` → green
+- [ ] Manual: PUT /settings/test-mode as non-OWNER → 403
+
+---
+
+## Self-Review
+- **Spec coverage:** toggle service (T1) ✓; endpoint+audit (T2) ✓; 4 bypass points (T3-T6) ✓; banner+settings toggle (T7) ✓; off=unchanged behaviour asserted in each bypass task ✓; runbook in spec ✓.
+- **Security override (kyc):** T4 explicitly replaces the always-validate comment with the gated-bypass rationale, per owner decision.
+- **Placeholders:** bypass tasks reference "the success path side-effects" which the implementer must read from each method (OTP verify mutates state) — this is a read-the-method instruction, not a vague requirement; behavior (replicate success + audit + return success shape) is specified. Exact method names/lines to be confirmed by implementer against cited files.
+- **Type consistency:** `TestModeService.isEnabled()/setEnabled()` + `KEY='TEST_MODE_BYPASS'` used consistently; audit action strings consistent (`*_BYPASSED_TEST_MODE`, `TEST_MODE_TOGGLED`).
+- **Circular deps:** TestModeModule depends only on global PrismaModule → safe to import anywhere.

--- a/docs/superpowers/specs/2026-06-02-test-mode-bypass-design.md
+++ b/docs/superpowers/specs/2026-06-02-test-mode-bypass-design.md
@@ -1,0 +1,50 @@
+# Test-Mode Bypass (pre-go-live UAT)
+
+วันที่: 2026-06-02
+สถานะ: รออนุมัติ spec จาก owner
+
+## ที่มา
+Owner ต้องการทดสอบระบบจริง (ที่ deploy แล้ว) แบบ end-to-end ก่อน go-live โดยไม่ติดขั้นตอนที่ต้องใช้ข้อมูล/อุปกรณ์จริง: เช็คเครดิต + OTP หลายจุด. ยังไม่มีลูกค้าจริงในช่วงนี้ จึง bypass ได้ชั่วคราว แต่ต้องทำเป็น **toggle ที่ปิดได้ + เตือนชัด** ไม่ใช่ลบ control ถาวร.
+
+## หลักการ + ความปลอดภัย
+- **toggle เดียวคุม 4 จุด**, OWNER เท่านั้น, default `false`
+- ปิด control บน **server จริง** → ต้องมี safety: banner เด่น + audit ตอน toggle + มาร์ค record ที่ bypass + ต้องปิดก่อน go-live
+- mirror pattern `CustomerPiiService.isStrictMode/setStrictMode` (SystemConfig, อ่านสดไม่ cache)
+
+## ขอบเขต
+
+### 1. Toggle
+- SystemConfig key `TEST_MODE_BYPASS` (`'true'`/`'false'`, default false)
+- service helper `TestModeService.isEnabled(): Promise<boolean>` (อ่าน SystemConfig สด) + `setEnabled(boolean)` (upsert + audit)
+- endpoint `GET /settings/test-mode` (อ่านสถานะ) + `PUT /settings/test-mode` (OWNER เท่านั้น) → audit string `TEST_MODE_TOGGLED` (`newValue: { enabled }`)
+- helper inject ได้ในทุก module ที่ต้อง bypass (อยู่ใน shared module / หรือ provide ผ่าน module ที่เหมาะ)
+
+### 2. จุด bypass 4 จุด (เมื่อ enabled = true)
+| จุด | ไฟล์ | พฤติกรรมเมื่อ ON |
+|---|---|---|
+| customer precheck | `apps/api/src/modules/customers/customer-precheck.service.ts` | คืนผล "ผ่าน" สังเคราะห์ (ไม่ยิงเช็คเครดิตจริง) + เขียน audit `CREDIT_PRECHECK_BYPASSED_TEST_MODE` |
+| KYC OTP (เซ็นสัญญา) | `apps/api/src/modules/kyc/kyc.service.ts` `verifyOtp(contractId, otp)` | ผ่านทันที ไม่ตรวจโค้ด + audit `KYC_OTP_BYPASSED_TEST_MODE` (entity=contract) |
+| LIFF OTP | `apps/api/src/modules/chatbot-finance/services/verification.service.ts` `verifyOtp(params)` | ผ่านทันที + audit `LIFF_OTP_BYPASSED_TEST_MODE` |
+| 2FA login | auth login flow (จุดที่ตรวจ 2FA หลังรหัสผ่าน — implementer หา exact call ใน `auth.service.ts`/`two-factor.service.ts`) | ข้าม step 2FA หลัง password ถูก + audit `LOGIN_2FA_BYPASSED_TEST_MODE` |
+
+- แต่ละจุด: ถ้า `isEnabled()` = false → พฤติกรรมเดิมเป๊ะ (control ทำงานปกติ). ถ้า true → bypass + audit/มาร์ค
+- การ bypass แต่ละครั้งเขียน audit (ผ่าน AuditService/Interceptor) เพื่อให้รู้ว่า record ไหนข้าม control → ตามลบ/ตรวจก่อน go-live
+
+### 3. Frontend safety
+- **Banner เด่นทั่วแอป** (ใน MainLayout) เมื่อ test-mode ON: สีเตือน (destructive) ข้อความ "⚠️ โหมดทดสอบ — เช็คเครดิต/OTP ถูกปิด ห้ามใช้กับลูกค้าจริง" + ปุ่มลิงก์ไปปิด (OWNER)
+- หน้า Settings เพิ่ม toggle "โหมดทดสอบ (ปิดเช็คเครดิต/OTP)" — OWNER เท่านั้น, มีคำเตือน + confirm dialog ตอนเปิด
+- Banner อ่านสถานะจาก `GET /settings/test-mode` (react-query, refetch สม่ำเสมอ)
+
+## ไม่ทำ (YAGNI)
+- แยก toggle ต่อ step (ใช้ตัวเดียวคุมหมดตามที่ตกลง)
+- env-var gate เพิ่ม (toggle SystemConfig + OWNER + banner พอสำหรับช่วง pre-go-live; ถ้าต้องการเข้มกว่าค่อยเพิ่ม env gate ภายหลัง)
+- auto-expire toggle (ปิดเอง) — owner ปิดเองตอน go-live (banner ช่วยเตือน)
+
+## ทดสอบ
+- API ต่อจุด: `isEnabled=false` → control เดิมทำงาน (test เดิมเขียว) ; `isEnabled=true` → bypass + audit ถูกเขียน
+- `TestModeService`: setEnabled upsert + audit ; isEnabled อ่านสด
+- endpoint: PUT OWNER-only (role อื่น 403)
+- web: banner ขึ้นเมื่อ ON / หายเมื่อ OFF ; settings toggle + confirm
+
+## ⚠️ Runbook go-live
+ก่อนเปิดใช้จริง: ปิด `TEST_MODE_BYPASS` → ตรวจ audit `*_BYPASSED_TEST_MODE` หา record ที่สร้างช่วงเทสต์ → ลบข้อมูลทดสอบ → ยืนยัน banner หาย


### PR DESCRIPTION
## สรุป
Toggle `TEST_MODE_BYPASS` (SystemConfig, OWNER เท่านั้น, default OFF) สำหรับทดสอบระบบจริงก่อน go-live — เมื่อเปิด จะข้าม 4 control: **เช็คเครดิต (precheck) + KYC OTP + LIFF OTP + login 2FA**

### ความปลอดภัย (สำคัญ)
- **default OFF + fail-safe** (config หาย/DB error → false) — ไม่เปิดเองเด็ดขาด
- **OFF = พฤติกรรมเดิม byte-for-byte** (guard early-return, ไม่รื้อ logic จริง)
- **password ยัง verify เสมอ** — ข้ามแค่ second factor ; **OTP bypass ต้องมี session จริง** (ขอ OTP มาก่อน) ข้ามแค่ตรวจโค้ด
- ทุก bypass เขียน audit `*_BYPASSED_TEST_MODE` → ตามหา record ทดสอบมาลบก่อน go-live
- **banner เด่นทุกหน้า** เมื่อเปิด + toggle มี ConfirmDialog เตือน
- ผ่าน adversarial security review: invariants 7/7 PASS
- ⚠️ จงใจ override comment "always-validate" ใน kyc.service (owner อนุมัติ) — แทนด้วยคำอธิบายว่า gated

### หมายเหตุ
- ไม่มี schema/migration (ใช้ SystemConfig เดิม), prisma diff = 0
- feature tests 101 pass (toggle/endpoint/4 bypass) + banner 2 pass, type-check all OK

## ⚠️ Runbook ก่อน go-live
ปิด toggle → ตรวจ audit `*_BYPASSED_TEST_MODE` → ลบข้อมูลทดสอบ → ยืนยัน banner หาย

## Test Plan
- [x] OFF = control เดิมทำงาน (existing security-regression tests เขียว)
- [x] ON = bypass + audit + banner
- [ ] smoke prod: เปิด toggle (OWNER) → banner ขึ้น → สร้างลูกค้า/สัญญาผ่านโดยไม่ติดเครดิต/OTP → ปิด toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)