### PR TITLE
feat(contacts): hardening — trade-in unify + merge fix/UI + partial-unique keys

### DIFF
--- a/apps/api/prisma/migrations/20260967000000_contact_partial_unique/migration.sql
+++ b/apps/api/prisma/migrations/20260967000000_contact_partial_unique/migration.sql
@@ -1,0 +1,14 @@
+-- Replace full unique on contacts.tax_id with a PARTIAL unique index
+-- (only non-null, non-soft-deleted rows must be unique). Add the same
+-- partial unique on national_id_hash. Soft-deleted / keyless rows no
+-- longer occupy the key — foundation for merge + race-safety tasks.
+
+DROP INDEX IF EXISTS "contacts_tax_id_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "contacts_tax_id_active_key"
+  ON "contacts"("tax_id")
+  WHERE "deleted_at" IS NULL AND "tax_id" IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "contacts_national_id_hash_active_key"
+  ON "contacts"("national_id_hash")
+  WHERE "deleted_at" IS NULL AND "national_id_hash" IS NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -814,7 +814,6 @@ model Contact {
   tradeInsAsSeller       TradeIn[]                 @relation("TradeInSeller")
   externalFinanceCompany ExternalFinanceCompany[]
 
-  @@unique([taxId])
   @@index([nationalIdHash])
   @@index([deletedAt])
   @@map("contacts")

--- a/apps/api/src/modules/contacts/__tests__/contact-resolver.service.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contact-resolver.service.spec.ts
@@ -107,4 +107,16 @@ describe('ContactResolverService.findOrCreateByNaturalKey', () => {
     expect(prisma.contact.create).toHaveBeenCalled();
     expect(res.id).toBe('c2');
   });
+
+  it('translates a P2002 on create into a ConflictException (no in-tx re-query)', async () => {
+    prisma.contact.findFirst
+      .mockResolvedValueOnce(null) // initial natural-key lookup → no match
+      .mockResolvedValueOnce({ contactCode: 'P-00001' }); // nextContactCode lookup
+    const err: any = new Error('unique'); err.code = 'P2002';
+    prisma.contact.create.mockRejectedValue(err);
+    await expect(
+      svc.findOrCreateByNaturalKey(prisma, { name: 'X', taxId: '0105', nationalIdHash: null, role: 'SUPPLIER' }),
+    ).rejects.toThrow('ผู้ติดต่อนี้ถูกสร้างพร้อมกัน');
+    expect(prisma.contact.findFirst).toHaveBeenCalledTimes(2); // no third (no in-tx re-query)
+  });
 });

--- a/apps/api/src/modules/contacts/__tests__/contacts.controller.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.controller.spec.ts
@@ -35,10 +35,19 @@ describe('ContactsController', () => {
     expect(svc.findOne).toHaveBeenCalledWith('c1');
   });
 
-  it('merge delegates to service', () => {
+  it('merge delegates to service with the authenticated OWNER actor', () => {
     const dto = { primaryId: 'p1', duplicateId: 'd1' };
+    const req = {
+      user: { id: 'owner-1', role: 'OWNER' },
+      ip: '1.2.3.4',
+      headers: { 'user-agent': 'jest' },
+    } as any;
     svc.merge.mockReturnValue('MERGED');
-    expect(ctrl.merge(dto)).toBe('MERGED');
-    expect(svc.merge).toHaveBeenCalledWith(dto);
+    expect(ctrl.merge(dto, req)).toBe('MERGED');
+    expect(svc.merge).toHaveBeenCalledWith(dto, {
+      userId: 'owner-1',
+      ipAddress: '1.2.3.4',
+      userAgent: 'jest',
+    });
   });
 });

--- a/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
@@ -142,8 +142,8 @@ describe('ContactsService.merge', () => {
   });
   it('carries identity fields from duplicate to primary when primary lacks them + audits + soft-deletes duplicate FIRST', async () => {
     prisma._tx.contact.findMany.mockResolvedValue([
-      { id: 'p1', roles: ['CUSTOMER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
-      { id: 'd1', roles: ['SUPPLIER'], taxId: '0105', nationalIdHash: 'h', peakContactCode: 'C001', phone: '02', email: 'a@b.c' },
+      { id: 'p1', contactCode: 'P-00001', name: 'Primary', roles: ['CUSTOMER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
+      { id: 'd1', contactCode: 'P-00002', name: 'Duplicate', roles: ['SUPPLIER'], taxId: '0105', nationalIdHash: 'h', peakContactCode: 'C001', phone: '02', email: 'a@b.c' },
     ]);
     await svc.merge({ primaryId: 'p1', duplicateId: 'd1' });
     // duplicate soft-deleted
@@ -154,6 +154,14 @@ describe('ContactsService.merge', () => {
       data: expect.objectContaining({ taxId: '0105', nationalIdHash: 'h', peakContactCode: 'C001', phone: '02', email: 'a@b.c' }),
     }));
     expect(audit.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'CONTACTS_MERGED' }));
+    // duplicate's pre-merge identity is captured in oldValue for traceability
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oldValue: expect.objectContaining({
+          duplicate: expect.objectContaining({ id: 'd1', contactCode: 'P-00002', taxId: '0105' }),
+        }),
+      }),
+    );
     // ordering: duplicate soft-delete recorded before primary carry update
     const calls = prisma._tx.contact.update.mock.calls;
     const dupIdx = calls.findIndex((c: any) => c[0].where.id === 'd1');

--- a/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { AuditService } from '../../audit/audit.service';
 import { ContactsService } from '../contacts.service';
 
 describe('ContactsService.list', () => {
@@ -8,7 +9,11 @@ describe('ContactsService.list', () => {
   beforeEach(async () => {
     prisma = { contact: { findMany: jest.fn(), count: jest.fn() } };
     const mod = await Test.createTestingModule({
-      providers: [ContactsService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        ContactsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: { log: jest.fn() } },
+      ],
     }).compile();
     svc = mod.get(ContactsService);
   });
@@ -51,7 +56,11 @@ describe('ContactsService.findOne', () => {
   beforeEach(async () => {
     prisma = { contact: { findFirst: jest.fn() } };
     const mod = await Test.createTestingModule({
-      providers: [ContactsService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        ContactsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: { log: jest.fn() } },
+      ],
     }).compile();
     svc = mod.get(ContactsService);
   });
@@ -91,6 +100,7 @@ describe('ContactsService.findOne', () => {
 describe('ContactsService.merge', () => {
   let svc: ContactsService;
   let prisma: any;
+  let audit: any;
   beforeEach(async () => {
     const tx = {
       contact: { findMany: jest.fn(), update: jest.fn() },
@@ -100,15 +110,20 @@ describe('ContactsService.merge', () => {
       externalFinanceCompany: { updateMany: jest.fn() },
     };
     prisma = { $transaction: jest.fn(async (cb: any) => cb(tx)), _tx: tx };
+    audit = { log: jest.fn() };
     const mod = await Test.createTestingModule({
-      providers: [ContactsService, { provide: PrismaService, useValue: prisma }],
+      providers: [
+        ContactsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+      ],
     }).compile();
     svc = mod.get(ContactsService);
   });
   it('repoints role records to primary, unions roles, soft-deletes duplicate', async () => {
     prisma._tx.contact.findMany.mockResolvedValue([
-      { id: 'p1', roles: ['CUSTOMER'] },
-      { id: 'd1', roles: ['SUPPLIER'] },
+      { id: 'p1', roles: ['CUSTOMER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
+      { id: 'd1', roles: ['SUPPLIER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
     ]);
     await svc.merge({ primaryId: 'p1', duplicateId: 'd1' });
     expect(prisma._tx.customer.updateMany).toHaveBeenCalledWith({
@@ -124,6 +139,38 @@ describe('ContactsService.merge', () => {
         data: expect.objectContaining({ deletedAt: expect.any(Date) }),
       }),
     );
+  });
+  it('carries identity fields from duplicate to primary when primary lacks them + audits + soft-deletes duplicate FIRST', async () => {
+    prisma._tx.contact.findMany.mockResolvedValue([
+      { id: 'p1', roles: ['CUSTOMER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
+      { id: 'd1', roles: ['SUPPLIER'], taxId: '0105', nationalIdHash: 'h', peakContactCode: 'C001', phone: '02', email: 'a@b.c' },
+    ]);
+    await svc.merge({ primaryId: 'p1', duplicateId: 'd1' });
+    // duplicate soft-deleted
+    expect(prisma._tx.contact.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'd1' }, data: expect.objectContaining({ deletedAt: expect.any(Date) }) }));
+    // primary updated with carried fields + union roles
+    expect(prisma._tx.contact.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'p1' },
+      data: expect.objectContaining({ taxId: '0105', nationalIdHash: 'h', peakContactCode: 'C001', phone: '02', email: 'a@b.c' }),
+    }));
+    expect(audit.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'CONTACTS_MERGED' }));
+    // ordering: duplicate soft-delete recorded before primary carry update
+    const calls = prisma._tx.contact.update.mock.calls;
+    const dupIdx = calls.findIndex((c: any) => c[0].where.id === 'd1');
+    const primIdx = calls.findIndex((c: any) => c[0].where.id === 'p1');
+    expect(dupIdx).toBeGreaterThanOrEqual(0);
+    expect(primIdx).toBeGreaterThanOrEqual(0);
+    expect(dupIdx).toBeLessThan(primIdx);
+  });
+  it('does not overwrite identity fields already set on primary', async () => {
+    prisma._tx.contact.findMany.mockResolvedValue([
+      { id: 'p1', roles: [], taxId: '9999', nationalIdHash: null, peakContactCode: null, phone: '08', email: null },
+      { id: 'd1', roles: [], taxId: '0105', nationalIdHash: null, peakContactCode: null, phone: '02', email: null },
+    ]);
+    await svc.merge({ primaryId: 'p1', duplicateId: 'd1' });
+    const primaryCall = prisma._tx.contact.update.mock.calls.find((c: any) => c[0].where.id === 'p1');
+    expect(primaryCall[0].data.taxId).toBe('9999');
+    expect(primaryCall[0].data.phone).toBe('08');
   });
   it('rejects merging a contact into itself', async () => {
     await expect(svc.merge({ primaryId: 'x', duplicateId: 'x' })).rejects.toThrow(

--- a/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
@@ -162,6 +162,19 @@ describe('ContactsService.merge', () => {
     expect(primIdx).toBeGreaterThanOrEqual(0);
     expect(dupIdx).toBeLessThan(primIdx);
   });
+  it('threads the OWNER actor userId into the CONTACTS_MERGED audit entry', async () => {
+    prisma._tx.contact.findMany.mockResolvedValue([
+      { id: 'p1', roles: ['CUSTOMER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
+      { id: 'd1', roles: ['SUPPLIER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
+    ]);
+    await svc.merge(
+      { primaryId: 'p1', duplicateId: 'd1' },
+      { userId: 'owner-1', ipAddress: '1.2.3.4', userAgent: 'jest' },
+    );
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTACTS_MERGED', userId: 'owner-1' }),
+    );
+  });
   it('does not overwrite identity fields already set on primary', async () => {
     prisma._tx.contact.findMany.mockResolvedValue([
       { id: 'p1', roles: [], taxId: '9999', nationalIdHash: null, peakContactCode: null, phone: '08', email: null },

--- a/apps/api/src/modules/contacts/contact-resolver.service.ts
+++ b/apps/api/src/modules/contacts/contact-resolver.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 import { ContactRole, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 
@@ -63,17 +63,28 @@ export class ContactResolverService {
     }
 
     const contactCode = await this.nextContactCode(tx);
-    return tx.contact.create({
-      data: {
-        contactCode,
-        name: input.name,
-        taxId: input.taxId ?? null,
-        nationalIdHash: input.nationalIdHash ?? null,
-        phone: input.phone ?? null,
-        email: input.email ?? null,
-        roles: [input.role],
-      },
-    });
+    try {
+      return await tx.contact.create({
+        data: {
+          contactCode,
+          name: input.name,
+          taxId: input.taxId ?? null,
+          nationalIdHash: input.nationalIdHash ?? null,
+          phone: input.phone ?? null,
+          email: input.email ?? null,
+          roles: [input.role],
+        },
+      });
+    } catch (e) {
+      // A concurrent create of the same party can pass the findFirst lookup and
+      // then lose the race on the partial-unique index → P2002. The tx is now
+      // aborted (Postgres), so we cannot re-query/recover here. Translate to a
+      // retryable ConflictException; the caller's tx rolls back and the user retries.
+      if ((e as { code?: string })?.code === 'P2002') {
+        throw new ConflictException('ผู้ติดต่อนี้ถูกสร้างพร้อมกัน กรุณาลองใหม่อีกครั้ง');
+      }
+      throw e;
+    }
   }
 
   private hashLockKey(key: string): number {

--- a/apps/api/src/modules/contacts/contacts.controller.ts
+++ b/apps/api/src/modules/contacts/contacts.controller.ts
@@ -1,10 +1,13 @@
-import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
 import { ContactsService } from './contacts.service';
 import { ListContactsDto } from './dto/list-contacts.dto';
 import { MergeContactsDto } from './dto/merge-contacts.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+
+type AuthRequest = Request & { user?: { id: string; role: string } };
 
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('contacts')
@@ -25,7 +28,11 @@ export class ContactsController {
 
   @Post('merge')
   @Roles('OWNER')
-  merge(@Body() dto: MergeContactsDto) {
-    return this.contacts.merge(dto);
+  merge(@Body() dto: MergeContactsDto, @Req() req: AuthRequest) {
+    return this.contacts.merge(dto, {
+      userId: req.user?.id,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'] as string | undefined,
+    });
   }
 }

--- a/apps/api/src/modules/contacts/contacts.service.ts
+++ b/apps/api/src/modules/contacts/contacts.service.ts
@@ -1,12 +1,16 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { ContactRole, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import { ListContactsDto } from './dto/list-contacts.dto';
 import { MergeContactsDto } from './dto/merge-contacts.dto';
 
 @Injectable()
 export class ContactsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
 
   async list(dto: ListContactsDto) {
     const page = dto.page ?? 1;
@@ -104,13 +108,33 @@ export class ContactsService {
       const unionRoles = Array.from(
         new Set<ContactRole>([...primary.roles, ...duplicate.roles]),
       );
-      await tx.contact.update({
-        where: { id: primaryId },
-        data: { roles: { set: unionRoles } },
-      });
+      // Primary-wins coalesce — never overwrite an identity field already set on
+      // the primary; only fill the gaps from the duplicate.
+      const carry = {
+        taxId: primary.taxId ?? duplicate.taxId,
+        nationalIdHash: primary.nationalIdHash ?? duplicate.nationalIdHash,
+        peakContactCode: primary.peakContactCode ?? duplicate.peakContactCode,
+        phone: primary.phone ?? duplicate.phone,
+        email: primary.email ?? duplicate.email,
+      };
+      // ORDER MATTERS: soft-delete the duplicate FIRST so it leaves the
+      // partial-unique scope (WHERE deleted_at IS NULL) before we carry its
+      // tax_id/national_id_hash onto the primary — otherwise two ACTIVE rows
+      // would briefly hold the same key and trip the partial-unique index (P2002).
       await tx.contact.update({
         where: { id: duplicateId },
         data: { deletedAt: new Date() },
+      });
+      await tx.contact.update({
+        where: { id: primaryId },
+        data: { roles: { set: unionRoles }, ...carry },
+      });
+
+      await this.audit.log({
+        action: 'CONTACTS_MERGED',
+        entity: 'contact',
+        entityId: primaryId,
+        newValue: { duplicateId, mergedRoles: unionRoles, carried: carry },
       });
 
       return { primaryId, mergedRoles: unionRoles };

--- a/apps/api/src/modules/contacts/contacts.service.ts
+++ b/apps/api/src/modules/contacts/contacts.service.ts
@@ -71,7 +71,10 @@ export class ContactsService {
     return contact;
   }
 
-  async merge(dto: MergeContactsDto) {
+  async merge(
+    dto: MergeContactsDto,
+    actor?: { userId?: string; ipAddress?: string; userAgent?: string },
+  ) {
     const { primaryId, duplicateId } = dto;
     if (primaryId === duplicateId) {
       throw new BadRequestException('ไม่สามารถรวมผู้ติดต่อกับตัวเองได้');
@@ -131,10 +134,13 @@ export class ContactsService {
       });
 
       await this.audit.log({
+        userId: actor?.userId,
         action: 'CONTACTS_MERGED',
         entity: 'contact',
         entityId: primaryId,
         newValue: { duplicateId, mergedRoles: unionRoles, carried: carry },
+        ipAddress: actor?.ipAddress,
+        userAgent: actor?.userAgent,
       });
 
       return { primaryId, mergedRoles: unionRoles };

--- a/apps/api/src/modules/contacts/contacts.service.ts
+++ b/apps/api/src/modules/contacts/contacts.service.ts
@@ -138,6 +138,21 @@ export class ContactsService {
         action: 'CONTACTS_MERGED',
         entity: 'contact',
         entityId: primaryId,
+        // Capture the duplicate's pre-merge identity so the irreversible
+        // soft-delete + carry remains fully traceable.
+        oldValue: {
+          duplicate: {
+            id: duplicate.id,
+            contactCode: duplicate.contactCode,
+            name: duplicate.name,
+            taxId: duplicate.taxId,
+            nationalIdHash: duplicate.nationalIdHash,
+            peakContactCode: duplicate.peakContactCode,
+            phone: duplicate.phone,
+            email: duplicate.email,
+            roles: duplicate.roles,
+          },
+        },
         newValue: { duplicateId, mergedRoles: unionRoles, carried: carry },
         ipAddress: actor?.ipAddress,
         userAgent: actor?.userAgent,

--- a/apps/api/src/modules/trade-in/trade-in.module.ts
+++ b/apps/api/src/modules/trade-in/trade-in.module.ts
@@ -3,9 +3,10 @@ import { TradeInController } from './trade-in.controller';
 import { TradeInService } from './trade-in.service';
 import { TradeInVoucherService } from './services/voucher.service';
 import { ContactsModule } from '../contacts/contacts.module';
+import { CustomerPiiModule } from '../customers/customer-pii.module';
 
 @Module({
-  imports: [ContactsModule],
+  imports: [ContactsModule, CustomerPiiModule],
   controllers: [TradeInController],
   providers: [TradeInService, TradeInVoucherService],
   exports: [TradeInService],

--- a/apps/api/src/modules/trade-in/trade-in.service.spec.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.spec.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { StorageService } from '../storage/storage.service';
 import { TradeInVoucherService } from './services/voucher.service';
 import { ContactResolverService } from '../contacts/contact-resolver.service';
+import { CustomerPiiService } from '../customers/customer-pii.service';
 import { encryptPII } from '../../utils/crypto.util';
 
 // ---------------------------------------------------------------------------
@@ -63,6 +64,8 @@ describe('TradeInService', () => {
   let voucher: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let contactResolver: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let pii: any;
 
   beforeEach(async () => {
     prisma = {
@@ -113,6 +116,10 @@ describe('TradeInService', () => {
         .mockResolvedValue({ id: 'contact-1', name: 'สมหญิง รักดี' }),
     };
 
+    pii = {
+      hash: jest.fn().mockReturnValue(null),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TradeInService,
@@ -120,6 +127,7 @@ describe('TradeInService', () => {
         { provide: StorageService, useValue: storage },
         { provide: TradeInVoucherService, useValue: voucher },
         { provide: ContactResolverService, useValue: contactResolver },
+        { provide: CustomerPiiService, useValue: pii },
       ],
     }).compile();
 
@@ -258,6 +266,80 @@ describe('TradeInService', () => {
           name: 'ไม่ระบุชื่อ',
           role: 'TRADE_IN_SELLER',
         }),
+      );
+    });
+
+    // ── Task 3: unify trade-in seller with existing Customer/Contact ──
+    it('keys trade-in seller by the customer nationalIdHash when customerId given', async () => {
+      // outer guard: customer exists + inside-tx lookup returns the hash
+      prisma.customer.findUnique.mockResolvedValue({ nationalIdHash: 'h1' });
+      prisma.tradeIn.findMany.mockResolvedValue([]);
+      prisma.tradeIn.create.mockResolvedValue(makeTradeIn());
+      contactResolver.findOrCreateByNaturalKey.mockResolvedValue({ id: 'cShared' });
+
+      await service.create({
+        branchId: 'branch-1',
+        deviceBrand: 'Samsung',
+        deviceModel: 'Galaxy S22',
+        customerId: 'cus1',
+        sellerName: 'A',
+      } as never);
+
+      expect(contactResolver.findOrCreateByNaturalKey).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ role: 'TRADE_IN_SELLER', nationalIdHash: 'h1' }),
+      );
+    });
+
+    it('keys by hashed normalized sellerIdCardNumber when no customerId', async () => {
+      pii.hash.mockReturnValue('hcard');
+      prisma.tradeIn.findMany.mockResolvedValue([]);
+      prisma.tradeIn.create.mockResolvedValue(makeTradeIn());
+      contactResolver.findOrCreateByNaturalKey.mockResolvedValue({ id: 'c2' });
+
+      // formatted ID — normalizes to the valid-checksum VALID_THAI_ID
+      await service.create({
+        branchId: 'branch-1',
+        deviceBrand: 'Samsung',
+        deviceModel: 'Galaxy S22',
+        sellerName: 'B',
+        sellerIdCardNumber: VALID_THAI_ID,
+      } as never);
+
+      expect(pii.hash).toHaveBeenCalledWith(VALID_THAI_ID);
+      expect(contactResolver.findOrCreateByNaturalKey).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ nationalIdHash: 'hcard' }),
+      );
+    });
+
+    it('normalizes sellerIdCardNumber (strip spaces/dashes, uppercase) before hashing', async () => {
+      pii.hash.mockReturnValue('hcard');
+      prisma.tradeIn.findMany.mockResolvedValue([]);
+      prisma.tradeIn.create.mockResolvedValue(makeTradeIn());
+
+      // sellerIdCardNumber DTO is @Length(13,13) so a formatted string can't
+      // arrive here; instead assert the service-level normalization helper
+      // collapses spaces/dashes + uppercases EXACTLY like CustomersService.
+      const normalized = (service as any).normalizeNationalId('3-1006 00717899');
+      expect(normalized).toBe(VALID_THAI_ID);
+    });
+
+    it('stays keyless (nationalIdHash null) when neither customerId nor sellerIdCardNumber', async () => {
+      prisma.tradeIn.findMany.mockResolvedValue([]);
+      prisma.tradeIn.create.mockResolvedValue(makeTradeIn());
+      contactResolver.findOrCreateByNaturalKey.mockResolvedValue({ id: 'c3' });
+
+      await service.create({
+        branchId: 'branch-1',
+        deviceBrand: 'Samsung',
+        deviceModel: 'Galaxy S22',
+        sellerName: 'C',
+      } as never);
+
+      expect(contactResolver.findOrCreateByNaturalKey).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ nationalIdHash: null }),
       );
     });
   });

--- a/apps/api/src/modules/trade-in/trade-in.service.ts
+++ b/apps/api/src/modules/trade-in/trade-in.service.ts
@@ -17,6 +17,7 @@ import {
 } from './dto/trade-in.dto';
 import { TradeInVoucherService } from './services/voucher.service';
 import { ContactResolverService } from '../contacts/contact-resolver.service';
+import { CustomerPiiService } from '../customers/customer-pii.service';
 import { encryptPII, decryptPII, isEncrypted } from '../../utils/crypto.util';
 import { Prisma, PrismaClient } from '@prisma/client';
 
@@ -30,7 +31,19 @@ export class TradeInService {
     private storage: StorageService,
     private voucher: TradeInVoucherService,
     private contactResolver: ContactResolverService,
+    private pii: CustomerPiiService,
   ) {}
+
+  /**
+   * Normalize a Thai national id the SAME way CustomersService does
+   * (customers.service.ts) — strip spaces + dashes, uppercase — BEFORE
+   * hashing. Without identical normalization the trade-in seller hash would
+   * never collide with the customer's nationalIdHash and the resolver would
+   * fail to unify a seller who is also an existing customer.
+   */
+  private normalizeNationalId(raw: string): string {
+    return raw.replace(/[\s-]/g, '').toUpperCase();
+  }
 
   // ─── PII encryption helpers (Phase 3) ────────────────────
   private get piiKey(): string {
@@ -189,14 +202,32 @@ export class TradeInService {
     }
 
     return this.prisma.$transaction(async (tx) => {
-      // Task 11: link a Contact (party master) for the trade-in seller.
-      // Trade-in sellers are KEYLESS (free-text sellerName/sellerPhone, no
-      // taxId / national-id hash) → pass both keys as null so the resolver
-      // ALWAYS creates a fresh Contact (safe no-auto-merge policy).
+      // Task 3 (contact-hardening): unify the trade-in seller with their
+      // existing party Contact when we can derive a national-id hash.
+      //  - customerId present → reuse the customer's own nationalIdHash so a
+      //    buyer who also sells maps onto the SAME Contact.
+      //  - else sellerIdCardNumber present → hash it the SAME way Customer
+      //    does (normalize spaces/dashes + uppercase, then sha256) so the
+      //    resolver matches an existing party keyed by that id.
+      //  - neither → keyless (null): resolver creates a fresh Contact
+      //    (safe no-auto-merge policy for anonymous walk-ins).
+      let sellerNationalIdHash: string | null = null;
+      if (dto.customerId) {
+        const cust = await tx.customer.findUnique({
+          where: { id: dto.customerId },
+          select: { nationalIdHash: true },
+        });
+        sellerNationalIdHash = cust?.nationalIdHash ?? null;
+      } else if (dto.sellerIdCardNumber) {
+        sellerNationalIdHash = this.pii.hash(
+          this.normalizeNationalId(dto.sellerIdCardNumber),
+        );
+      }
+
       const sellerContact = await this.contactResolver.findOrCreateByNaturalKey(tx, {
         name: dto.sellerName ?? 'ไม่ระบุชื่อ',
         taxId: null,
-        nationalIdHash: null,
+        nationalIdHash: sellerNationalIdHash,
         phone: dto.sellerPhone ?? null,
         role: 'TRADE_IN_SELLER',
       });

--- a/apps/web/src/pages/ContactDetailPage.tsx
+++ b/apps/web/src/pages/ContactDetailPage.tsx
@@ -1,14 +1,30 @@
+import { useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { ArrowRight } from 'lucide-react';
+import { useDebounce } from '@/hooks/useDebounce';
+import { useAuth } from '@/contexts/AuthContext';
+import { ArrowRight, Merge, Search } from 'lucide-react';
 import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import {
   contactKeys,
   contactsApi,
+  type Contact,
+  type ContactDetail,
   type ContactRole,
   type ContactCustomerLink,
   type ContactSupplierLink,
@@ -156,9 +172,145 @@ function TradeInCard({ tradeIn }: { tradeIn: ContactTradeInLink }) {
   );
 }
 
+/**
+ * OWNER-only dialog: search for another contact and merge it INTO the current
+ * one. The current contact is the primary (kept); the selected contact is the
+ * duplicate (absorbed + soft-deleted by the backend).
+ */
+function MergeContactsDialog({
+  open,
+  onOpenChange,
+  current,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  current: ContactDetail;
+}) {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 300);
+  const [selected, setSelected] = useState<Contact | null>(null);
+
+  const { data, isFetching } = useQuery({
+    queryKey: contactKeys.list({ search: debouncedSearch, merge: current.id }),
+    queryFn: () => contactsApi.list({ search: debouncedSearch }),
+    enabled: open && debouncedSearch.trim().length > 0,
+  });
+
+  const candidates = (data?.data ?? []).filter((c) => c.id !== current.id);
+
+  const mergeMutation = useMutation({
+    mutationFn: (duplicateId: string) => contactsApi.merge(current.id, duplicateId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: contactKeys.detail(current.id) });
+      queryClient.invalidateQueries({ queryKey: contactKeys.all });
+      toast.success('รวมผู้ติดต่อแล้ว');
+      setSelected(null);
+      setSearch('');
+      onOpenChange(false);
+    },
+    onError: () => {
+      toast.error('รวมผู้ติดต่อไม่สำเร็จ');
+    },
+  });
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setSearch('');
+      setSelected(null);
+    }
+    onOpenChange(next);
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="leading-snug">รวมผู้ติดต่อซ้ำ</DialogTitle>
+            <DialogDescription className="leading-snug">
+              ค้นหาผู้ติดต่อที่ซ้ำกับ {current.name} แล้วเลือกเพื่อยุบเข้าอันนี้
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="ค้นหาด้วยชื่อ / รหัส / เบอร์"
+                className="pl-9"
+                autoFocus
+              />
+            </div>
+            <div className="flex flex-col gap-1.5 max-h-72 overflow-y-auto">
+              {debouncedSearch.trim().length === 0 ? (
+                <p className="text-sm text-muted-foreground leading-snug py-2">
+                  พิมพ์เพื่อค้นหาผู้ติดต่อที่จะยุบเข้าอันนี้
+                </p>
+              ) : isFetching ? (
+                <p className="text-sm text-muted-foreground leading-snug py-2">กำลังค้นหา...</p>
+              ) : candidates.length === 0 ? (
+                <p className="text-sm text-muted-foreground leading-snug py-2">ไม่พบผู้ติดต่อ</p>
+              ) : (
+                candidates.map((c) => (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => setSelected(c)}
+                    className="flex flex-col gap-1 rounded-md border border-border p-2.5 text-left hover:bg-accent transition-colors"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-foreground leading-snug">
+                        {c.name}
+                      </span>
+                      <span className="text-xs text-muted-foreground leading-snug">
+                        {c.contactCode}
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {c.roles.map((r) => (
+                        <Badge key={r} variant={ROLE_BADGE_VARIANT[r]} appearance="light" size="sm">
+                          {ROLE_LABELS[r]}
+                        </Badge>
+                      ))}
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={!!selected}
+        onOpenChange={(next) => {
+          if (!next) setSelected(null);
+        }}
+        title="ยืนยันการรวมผู้ติดต่อ"
+        description={
+          selected
+            ? `ยุบ ${selected.contactCode} ${selected.name} เข้า ${current.name} — role/ข้อมูลจะรวมเข้าอันนี้ ตัวที่เลือกจะถูกปิด`
+            : ''
+        }
+        confirmLabel="รวมผู้ติดต่อ"
+        variant="destructive"
+        loading={mergeMutation.isPending}
+        onConfirm={() => {
+          if (selected) mergeMutation.mutate(selected.id);
+        }}
+      />
+    </>
+  );
+}
+
 export default function ContactDetailPage() {
   const { id = '' } = useParams();
   const navigate = useNavigate();
+  const { user } = useAuth();
+  const isOwner = user?.role === 'OWNER';
+  const [mergeOpen, setMergeOpen] = useState(false);
   useDocumentTitle('ผู้ติดต่อ');
 
   const { data, isLoading, isError, error, refetch } = useQuery({
@@ -189,6 +341,14 @@ export default function ContactDetailPage() {
         title={data ? data.name : 'ผู้ติดต่อ'}
         subtitle={data ? `${data.contactCode} · ${entityType}` : undefined}
         onBack={() => navigate('/contacts')}
+        action={
+          isOwner && data ? (
+            <Button variant="outline" size="sm" onClick={() => setMergeOpen(true)}>
+              <Merge className="size-4" />
+              รวมผู้ติดต่อซ้ำ
+            </Button>
+          ) : undefined
+        }
         badge={
           data && !data.isActive ? (
             <Badge variant="secondary" appearance="light" size="sm">
@@ -197,6 +357,10 @@ export default function ContactDetailPage() {
           ) : undefined
         }
       />
+
+      {isOwner && data && (
+        <MergeContactsDialog open={mergeOpen} onOpenChange={setMergeOpen} current={data} />
+      )}
 
       <QueryBoundary
         isLoading={isLoading}

--- a/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
@@ -1,19 +1,40 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router';
 import ContactDetailPage from '../ContactDetailPage';
 import { contactsApi } from '@/lib/api/contacts';
+import { useAuth } from '@/contexts/AuthContext';
 
 vi.mock('@/lib/api/contacts', async (orig) => {
   const actual = await orig<typeof import('@/lib/api/contacts')>();
-  return { ...actual, contactsApi: { ...actual.contactsApi, detail: vi.fn() } };
+  return {
+    ...actual,
+    contactsApi: { ...actual.contactsApi, detail: vi.fn(), list: vi.fn(), merge: vi.fn() },
+  };
 });
 
 vi.mock('@/lib/api/customers', () => ({
   customerKeys: { summary: (id: string) => ['customer-summary', id] },
   customersApi: { summary: vi.fn() },
 }));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 'u1', role: 'OWNER', branchId: null },
+    isLoading: false,
+    isAuthenticated: true,
+  })),
+}));
+
+function asOwner() {
+  (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    user: { id: 'u1', role: 'OWNER', branchId: null },
+    isLoading: false,
+    isAuthenticated: true,
+  });
+}
 
 function wrap(id: string) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -93,5 +114,85 @@ describe('ContactDetailPage', () => {
     await waitFor(() => expect(screen.getByText('นราธิป')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText(/15,000/)).toBeInTheDocument());
     expect(screen.getByText('ค้างชำระ')).toBeInTheDocument();
+  });
+
+  it('OWNER merges a searched duplicate into the current contact', async () => {
+    asOwner();
+    (contactsApi.detail as any).mockResolvedValue({
+      id: 'c1',
+      contactCode: 'P-1',
+      name: 'A',
+      roles: ['CUSTOMER'],
+      isActive: true,
+      taxId: null,
+      phone: null,
+      email: null,
+      peakContactCode: null,
+      customers: [],
+      suppliers: [],
+      tradeInsAsSeller: [],
+      externalFinanceCompany: [],
+    });
+    (contactsApi.list as any).mockResolvedValue({
+      data: [
+        {
+          id: 'c2',
+          contactCode: 'P-2',
+          name: 'A dup',
+          roles: ['SUPPLIER'],
+          isActive: true,
+          taxId: '0105',
+          phone: null,
+          email: null,
+          peakContactCode: null,
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 50,
+    });
+    const mergeSpy = ((contactsApi.merge as any) = vi.fn().mockResolvedValue({ primaryId: 'c1' }));
+
+    const user = userEvent.setup();
+    wrap('c1');
+    await waitFor(() => expect(screen.getByText('ข้อมูลทั่วไป')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'รวมผู้ติดต่อซ้ำ' }));
+    const searchInput = await screen.findByPlaceholderText(/ค้นหา/);
+    await user.type(searchInput, 'A dup');
+
+    const candidate = await screen.findByText('A dup');
+    await user.click(candidate);
+
+    const confirmBtn = await screen.findByRole('button', { name: 'รวมผู้ติดต่อ' });
+    await user.click(confirmBtn);
+
+    await waitFor(() => expect(mergeSpy).toHaveBeenCalledWith('c1', 'c2'));
+  });
+
+  it('hides the merge action for non-OWNER roles', async () => {
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      user: { id: 'u2', role: 'SALES', branchId: null },
+      isLoading: false,
+      isAuthenticated: true,
+    });
+    (contactsApi.detail as any).mockResolvedValue({
+      id: 'c1',
+      contactCode: 'P-1',
+      name: 'A',
+      roles: ['CUSTOMER'],
+      isActive: true,
+      taxId: null,
+      phone: null,
+      email: null,
+      peakContactCode: null,
+      customers: [],
+      suppliers: [],
+      tradeInsAsSeller: [],
+      externalFinanceCompany: [],
+    });
+    wrap('c1');
+    await waitFor(() => expect(screen.getByText('ข้อมูลทั่วไป')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'รวมผู้ติดต่อซ้ำ' })).not.toBeInTheDocument();
   });
 });

--- a/docs/superpowers/plans/2026-06-02-contact-hardening.md
+++ b/docs/superpowers/plans/2026-06-02-contact-hardening.md
@@ -1,0 +1,274 @@
+# Contact Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** (1) trade-in sellers unify with their existing Customer/Contact, (2) merge() carries identity fields + audit + a search-based UI, (3) partial-unique indexes on Contact.taxId/nationalIdHash (WHERE deleted_at IS NULL) + P2002 retry.
+
+**Architecture:** Backend-first. Part 3 (schema + resolver retry) is the foundation; Part 1 keys trade-in via customerId/sellerIdCardNumber; Part 2 fixes merge + adds UI. Partial unique makes uniqueness a DB guarantee (durable) and lets merge carry taxId to the primary while the soft-deleted duplicate's row is excluded from the constraint.
+
+**Tech Stack:** NestJS + Prisma + Postgres + Jest (api), React + react-query + Vitest (web)
+
+**Spec:** `docs/superpowers/specs/2026-06-02-contact-hardening-design.md`
+
+**Verified facts:** `normalizeNationalId` = `raw.replace(/[\s-]/g,'').toUpperCase()` (`customers.service.ts:459-461`). `CustomerPiiService.hash(value)` returns sha256(salt) or null. `TradeIn` has `customerId?`, `sellerName`, `sellerPhone`, `sellerIdCardNumber` (plaintext 13-digit), `sellerContactId`. `merge()` (`contacts.service.ts`) currently unions roles + repoints + soft-deletes, does NOT carry identity fields nor audit. Resolver create block has no P2002 handling. Task-1 (prior) migration named the taxId unique `contacts_tax_id_key` (Prisma default — confirm).
+
+---
+
+## PART 3 — partial unique + retry
+
+### Task 1: Partial unique indexes (migration)
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma` (model Contact: remove `@@unique([taxId])`; keep field)
+- Create: `apps/api/prisma/migrations/<synthetic-ts>_contact_partial_unique/migration.sql`
+
+- [ ] **Step 1: Pre-check dev DB for existing duplicate keys (must be empty before adding unique)**
+
+Run (psql via DATABASE_URL, or `prisma db execute`):
+```sql
+SELECT tax_id, count(*) FROM contacts WHERE deleted_at IS NULL AND tax_id IS NOT NULL GROUP BY tax_id HAVING count(*) > 1;
+SELECT national_id_hash, count(*) FROM contacts WHERE deleted_at IS NULL AND national_id_hash IS NOT NULL GROUP BY national_id_hash HAVING count(*) > 1;
+```
+Expected: 0 rows each. If any rows → STOP, report (must dedupe via merge first). (At ~37 clean rows this should be empty.)
+
+- [ ] **Step 2: Edit schema** — in `model Contact` remove the line `@@unique([taxId])`. Keep `taxId String? @map("tax_id")` and `nationalIdHash String? @map("national_id_hash")` + their `@@index`. (We replace the full unique with a partial one in raw SQL.)
+
+- [ ] **Step 3: Hand-author the migration** (synthetic timestamp folder sorting LAST, e.g. `20260967000000_contact_partial_unique`). `migration.sql`:
+```sql
+-- Drop the full unique on tax_id (created as contacts_tax_id_key by the add_contact_party_master migration)
+DROP INDEX IF EXISTS "contacts_tax_id_key";
+-- Partial unique: only non-null, non-deleted rows are unique (keyless/soft-deleted excluded)
+CREATE UNIQUE INDEX IF NOT EXISTS "contacts_tax_id_active_key" ON "contacts"("tax_id") WHERE "deleted_at" IS NULL AND "tax_id" IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "contacts_national_id_hash_active_key" ON "contacts"("national_id_hash") WHERE "deleted_at" IS NULL AND "national_id_hash" IS NOT NULL;
+```
+> Confirm the real existing index name first: `\d contacts` (psql) or check the add_contact_party_master migration.sql — use the actual name in DROP INDEX. The pre-existing `@@index([nationalIdHash])` (non-unique) can stay; the new partial unique is additional.
+
+- [ ] **Step 4: Apply on dev + regenerate client + verify**
+
+Run: `cd apps/api && npx prisma migrate reset --force --skip-seed` (dev throwaway — replays all incl. new) — confirm it applies cleanly and `\d contacts` shows the two `*_active_key` partial unique indexes. Then `npx prisma generate`. (`prisma migrate reset` needs `PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=1` env in this harness, per prior tasks.)
+- Verify partial-unique semantics with a quick check: inserting two non-deleted rows with same tax_id fails; with deleted_at set on one, allowed. (Optional manual psql check.)
+
+- [ ] **Step 5: Type-check + commit** — `./tools/check-types.sh api` (0 errors) ; `git add apps/api/prisma && git commit -m "feat(contacts): partial unique on taxId/nationalIdHash (WHERE deleted_at IS NULL)"`
+
+---
+
+### Task 2: Resolver P2002 → friendly ConflictException
+
+> SCRUTINIZE FIX: the original plan re-fetched in the SAME transaction after a P2002. In Postgres a failed statement ABORTS the transaction ("current transaction is aborted") — and the resolver always runs inside the caller's `$transaction`, so an in-tx re-query throws. We CANNOT recover in-tx without a savepoint. Instead, translate P2002 to a clear `ConflictException`; the caller's tx rolls back and the user retries. (C3 race is low-probability; the goal is just a sane error, not a silent attach.)
+
+**Files:**
+- Modify: `apps/api/src/modules/contacts/contact-resolver.service.ts` (`findOrCreateByNaturalKey`)
+- Test: `apps/api/src/modules/contacts/__tests__/contact-resolver.service.spec.ts`
+
+- [ ] **Step 1: Failing test**
+```typescript
+it('translates a P2002 on create into a ConflictException (no in-tx re-query)', async () => {
+  prisma.contact.findFirst
+    .mockResolvedValueOnce(null)             // initial natural-key lookup → no match
+    .mockResolvedValueOnce({ contactCode: 'P-00001' }); // nextContactCode
+  const err: any = new Error('unique'); err.code = 'P2002';
+  prisma.contact.create.mockRejectedValue(err);
+  await expect(
+    svc.findOrCreateByNaturalKey(prisma, { name: 'X', taxId: '0105', nationalIdHash: null, role: 'SUPPLIER' }),
+  ).rejects.toThrow('ผู้ติดต่อนี้ถูกสร้างพร้อมกัน');
+  // must NOT attempt a second findFirst after the failed create (no in-tx re-query)
+  expect(prisma.contact.findFirst).toHaveBeenCalledTimes(2);
+});
+```
+
+- [ ] **Step 2: Run FAIL** — `cd apps/api && npx jest contact-resolver --silent`
+
+- [ ] **Step 3: Implement** — wrap ONLY the create; on P2002 throw a ConflictException (do NOT query again in this tx):
+```typescript
+import { ConflictException } from '@nestjs/common';
+// ... inside findOrCreateByNaturalKey, replace the final create block:
+const contactCode = await this.nextContactCode(tx);
+try {
+  return await tx.contact.create({
+    data: { contactCode, name: input.name, taxId: input.taxId ?? null, nationalIdHash: input.nationalIdHash ?? null, phone: input.phone ?? null, email: input.email ?? null, roles: [input.role] },
+  });
+} catch (e) {
+  if ((e as { code?: string })?.code === 'P2002') {
+    // Concurrent create of the same party (partial-unique race). The tx is now
+    // aborted, so we cannot recover here — surface a retryable conflict.
+    throw new ConflictException('ผู้ติดต่อนี้ถูกสร้างพร้อมกัน กรุณาลองใหม่อีกครั้ง');
+  }
+  throw e;
+}
+```
+
+- [ ] **Step 4: Run PASS + type-check** — `cd apps/api && npx jest contact-resolver --silent && cd /Users/iamnaii/Desktop/App/BESTCHOICE && ./tools/check-types.sh api`
+- [ ] **Step 5: Commit** — `git add apps/api/src/modules/contacts && git commit -m "feat(contacts): translate resolver P2002 to retryable ConflictException"`
+
+---
+
+## PART 1 — trade-in unify
+
+### Task 3: Key trade-in seller by customerId/sellerIdCardNumber
+
+**Files:**
+- Modify: `apps/api/src/modules/trade-in/trade-in.service.ts` (create, ~line 196) + `trade-in.module.ts`
+- Test: `apps/api/src/modules/trade-in/__tests__/trade-in.service.spec.ts`
+
+- [ ] **Step 1: Failing tests**
+```typescript
+it('keys trade-in seller by customer nationalIdHash when customerId given (unifies)', async () => {
+  // mock prisma.customer.findUnique -> { id:'cus1', nationalIdHash:'h1' }
+  resolver.findOrCreateByNaturalKey.mockResolvedValue({ id: 'cShared' });
+  const res = await service.create({ customerId: 'cus1', sellerName: 'A', /* ...required fields */ } as any);
+  expect(resolver.findOrCreateByNaturalKey).toHaveBeenCalledWith(expect.anything(),
+    expect.objectContaining({ role: 'TRADE_IN_SELLER', nationalIdHash: 'h1' }));
+});
+it('keys by hashed sellerIdCardNumber (normalized) when no customerId', async () => {
+  pii.hash.mockReturnValue('hcard');
+  resolver.findOrCreateByNaturalKey.mockResolvedValue({ id: 'c2' });
+  await service.create({ sellerName: 'B', sellerIdCardNumber: '1-1019 00201390', /* ... */ } as any);
+  expect(pii.hash).toHaveBeenCalledWith('1101900201390'); // normalized: strip space/dash, upper
+  expect(resolver.findOrCreateByNaturalKey).toHaveBeenCalledWith(expect.anything(),
+    expect.objectContaining({ nationalIdHash: 'hcard' }));
+});
+it('stays keyless when neither customerId nor sellerIdCardNumber', async () => {
+  resolver.findOrCreateByNaturalKey.mockResolvedValue({ id: 'c3' });
+  await service.create({ sellerName: 'C', /* ... */ } as any);
+  expect(resolver.findOrCreateByNaturalKey).toHaveBeenCalledWith(expect.anything(),
+    expect.objectContaining({ nationalIdHash: null }));
+});
+```
+> Adapt to the real `create` mock setup + required DTO fields (read the spec file's existing tests). Inject mocked `CustomerPiiService` (as `pii`) + `ContactResolverService` (as `resolver`).
+
+- [ ] **Step 2: Run FAIL** — `cd apps/api && npx jest trade-in.service --silent`
+
+- [ ] **Step 3: Implement** — inject `CustomerPiiService`; add a private normalizer identical to Customer's; compute the seller hash before the resolver call:
+```typescript
+private normalizeNationalId(raw: string): string { return raw.replace(/[\s-]/g, '').toUpperCase(); }
+
+// inside create, before findOrCreateByNaturalKey:
+let sellerNationalIdHash: string | null = null;
+if (dto.customerId) {
+  const cust = await tx.customer.findUnique({ where: { id: dto.customerId }, select: { nationalIdHash: true } });
+  sellerNationalIdHash = cust?.nationalIdHash ?? null;
+} else if (dto.sellerIdCardNumber) {
+  sellerNationalIdHash = this.pii.hash(this.normalizeNationalId(dto.sellerIdCardNumber));
+}
+const sellerContact = await this.contactResolver.findOrCreateByNaturalKey(tx, {
+  name: dto.sellerName ?? 'ไม่ระบุชื่อ',
+  taxId: null,
+  nationalIdHash: sellerNationalIdHash,
+  phone: dto.sellerPhone ?? null,
+  role: 'TRADE_IN_SELLER',
+});
+```
+Add `imports: [CustomersModule]` (or whichever module exports `CustomerPiiService`) to `trade-in.module.ts` — confirm `CustomerPiiService` is exported; if not, export it. Watch for circular deps (customers↔trade-in); if cyclic, instead import the smaller `CustomerPiiModule` if one exists, or duplicate the tiny hash via the crypto util directly. Report if cyclic.
+
+- [ ] **Step 4: Run PASS + type-check** — `cd apps/api && npx jest trade-in --silent && ./tools/check-types.sh api`
+- [ ] **Step 5: Commit** — `git add apps/api/src/modules/trade-in apps/api/src/modules/customers && git commit -m "feat(contacts): unify trade-in seller with customer via id-card/customerId"`
+
+---
+
+## PART 2 — merge fix + UI
+
+### Task 4: merge carries identity fields + audit
+
+**Files:**
+- Modify: `apps/api/src/modules/contacts/contacts.service.ts` (`merge`)
+- Test: `apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts`
+
+- [ ] **Step 1: Failing test**
+```typescript
+it('carries identity fields from duplicate to primary when primary lacks them + audits', async () => {
+  prisma._tx.contact.findMany.mockResolvedValue([
+    { id: 'p1', roles: ['CUSTOMER'], taxId: null, nationalIdHash: null, peakContactCode: null, phone: null, email: null },
+    { id: 'd1', roles: ['SUPPLIER'], taxId: '0105', nationalIdHash: 'h', peakContactCode: 'C001', phone: '02', email: 'a@b.c' },
+  ]);
+  await svc.merge({ primaryId: 'p1', duplicateId: 'd1' });
+  // primary updated with carried fields + union roles
+  expect(prisma._tx.contact.update).toHaveBeenCalledWith(expect.objectContaining({
+    where: { id: 'p1' },
+    data: expect.objectContaining({ taxId: '0105', nationalIdHash: 'h', peakContactCode: 'C001', phone: '02', email: 'a@b.c' }),
+  }));
+  // audit written
+  expect(audit.log).toHaveBeenCalledWith(expect.objectContaining({ action: 'CONTACTS_MERGED' }));
+});
+it('does NOT overwrite primary fields that are already set', async () => {
+  prisma._tx.contact.findMany.mockResolvedValue([
+    { id: 'p1', roles: [], taxId: '9999', nationalIdHash: null, peakContactCode: null, phone: '08', email: null },
+    { id: 'd1', roles: [], taxId: '0105', nationalIdHash: null, peakContactCode: null, phone: '02', email: null },
+  ]);
+  await svc.merge({ primaryId: 'p1', duplicateId: 'd1' });
+  const primaryUpdate = prisma._tx.contact.update.mock.calls.find((c: any) => c[0].where.id === 'p1');
+  expect(primaryUpdate[0].data.taxId).toBe('9999'); // kept primary's
+  expect(primaryUpdate[0].data.phone).toBe('08');
+});
+```
+> Add a mocked `AuditService` (`audit`) to the merge test module. Update the existing merge test's `findMany` mock to include the new fields (taxId/nationalIdHash/etc.) so it still passes.
+
+- [ ] **Step 2: Run FAIL** — `cd apps/api && npx jest contacts.service --silent`
+
+- [ ] **Step 3: Implement** — inject `AuditService`; compute carried fields with coalesce; **soft-delete the duplicate FIRST, then update the primary** (order is critical — see note):
+```typescript
+const carry = {
+  taxId: primary.taxId ?? duplicate.taxId,
+  nationalIdHash: primary.nationalIdHash ?? duplicate.nationalIdHash,
+  peakContactCode: primary.peakContactCode ?? duplicate.peakContactCode,
+  phone: primary.phone ?? duplicate.phone,
+  email: primary.email ?? duplicate.email,
+};
+// 1) Soft-delete the duplicate FIRST so it leaves the partial-unique scope,
+//    otherwise setting the carried taxId/nationalIdHash on the (still-active)
+//    primary collides with the (still-active) duplicate → P2002.
+await tx.contact.update({ where: { id: duplicateId }, data: { deletedAt: new Date() } });
+// 2) Now the carried keys are unique among active rows.
+await tx.contact.update({ where: { id: primaryId }, data: { roles: { set: unionRoles }, ...carry } });
+await this.audit.log({ action: 'CONTACTS_MERGED', entity: 'contact', entityId: primaryId, newValue: { duplicateId, mergedRoles: unionRoles, carried: carry } });
+return { primaryId, mergedRoles: unionRoles };
+```
+> SCRUTINIZE FIX: the original order (update primary → then soft-delete duplicate) would, at the primary update, have TWO active rows (deletedAt null) holding the same taxId/nationalIdHash → partial-unique P2002. Soft-deleting the duplicate first removes it from the `WHERE deleted_at IS NULL` index so the carry succeeds. The FK repoints (customer/supplier/tradeIn/finance) can stay where they are (before or after) — they don't touch the unique. Inject AuditService via its `@Global` module (no import needed) like the bypass tasks did. Confirm `AuditService.log` signature from prior usage.
+
+- [ ] **Step 4: Run PASS + type-check** — `cd apps/api && npx jest contacts.service --silent && ./tools/check-types.sh api`
+- [ ] **Step 5: Commit** — `git add apps/api/src/modules/contacts && git commit -m "feat(contacts): merge carries identity fields from duplicate + audit"`
+
+---
+
+### Task 5: Merge UI (search-based)
+
+**Files:**
+- Modify: `apps/web/src/pages/ContactDetailPage.tsx` (add "รวมผู้ติดต่อซ้ำ" — OWNER)
+- Possibly: `apps/web/src/lib/api/contacts.ts` (merge already exists; add a search helper if needed — `contactsApi.list` exists)
+- Test: `apps/web/src/pages/__tests__/ContactDetailPage.test.tsx`
+
+- [ ] **Step 1: Failing test**
+```tsx
+it('OWNER can search a duplicate and merge it into the current contact', async () => {
+  // mock useAuth/role = OWNER (match how the app exposes role in tests)
+  (contactsApi.detail as any).mockResolvedValue({ id: 'c1', contactCode: 'P-1', name: 'A', roles: ['CUSTOMER'], isActive: true, taxId: null, phone: null, email: null, peakContactCode: null, customers: [], suppliers: [], tradeInsAsSeller: [], externalFinanceCompany: [] });
+  (contactsApi.list as any).mockResolvedValue({ data: [{ id: 'c2', contactCode: 'P-2', name: 'A dup', roles: ['SUPPLIER'], isActive: true, taxId: '0105', phone: null, email: null, peakContactCode: null }], total: 1, page: 1, limit: 50 });
+  (contactsApi.merge as any) = vi.fn().mockResolvedValue({ primaryId: 'c1' });
+  // render page as OWNER, click "รวมผู้ติดต่อซ้ำ", search, pick c2, confirm
+  // assert contactsApi.merge called with (primaryId='c1', duplicateId='c2')
+});
+```
+> Adapt to how the app provides current user role in tests (find an existing test that renders an OWNER-gated control). If role wiring in tests is heavy, at minimum test: the merge dialog calls `contactsApi.merge('c1','c2')` on confirm.
+
+- [ ] **Step 2: Run FAIL** — `cd apps/web && npx vitest run ContactDetailPage --silent`
+
+- [ ] **Step 3: Implement** — add an OWNER-only "รวมผู้ติดต่อซ้ำ" button on ContactDetailPage header that opens a dialog: a debounced search input → `contactsApi.list({ search })` results (exclude the current contact id) → pick one → ConfirmDialog (destructive) showing "ยุบ [P-2 name] เข้า [current] — role/ข้อมูลจะรวมเข้าอันนี้ ตัวที่เลือกจะถูกปิด" → on confirm `contactsApi.merge(currentId, selectedId)` → invalidate `contactKeys.detail(currentId)` + toast.success + close. Gate the button by OWNER role (use the app's existing role hook/context — find how other OWNER-only UI gates). Semantic tokens, Thai leading-snug, reuse ConfirmDialog.
+
+- [ ] **Step 4: Run PASS + type-check** — `cd apps/web && npx vitest run ContactDetailPage --silent && ./tools/check-types.sh web`
+- [ ] **Step 5: Commit** — `git add apps/web && git commit -m "feat(contacts): merge duplicate contacts UI (OWNER, search-based)"`
+
+---
+
+## Task 6: Verify
+- [ ] `./tools/check-types.sh all` → 0 errors
+- [ ] `cd apps/api && npx jest contact-resolver contacts.service trade-in --silent` → green
+- [ ] `cd apps/web && npx vitest run ContactDetailPage --silent` → green
+- [ ] Confirm migration present + partial indexes exist on dev (`\d contacts`)
+
+---
+
+## Self-Review
+- **Spec coverage:** partial unique + pre-check (T1) ✓; P2002 retry/C3 (T2) ✓; trade-in unify/I2 (T3) ✓; merge carry/C1 + audit/M2 (T4) ✓; merge UI (T5) ✓.
+- **Placeholders:** test bodies note "adapt to real DTO/role wiring" — implementer must read the actual create-DTO + role hook; behavior fully specified. Index name in DROP must be confirmed against the real migration.
+- **Type consistency:** `findOrCreateByNaturalKey` input unchanged; `merge` return unchanged; `nationalIdHash` carried as string|null throughout; normalizeNationalId identical to Customer's.
+- **Dependency order:** T1 (partial unique) before T4 (merge carry) — T4 relies on the soft-deleted duplicate being excluded from the unique so carrying taxId doesn't P2002.
+- Backlog (not done): I1, I3, I4, I5, M1, M3.

--- a/docs/superpowers/specs/2026-06-02-contact-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-02-contact-hardening-design.md
@@ -1,0 +1,85 @@
+# Contact Hardening — unify trade-in sellers, fix merge, partial-unique keys
+
+วันที่: 2026-06-02
+สถานะ: รออนุมัติ spec จาก owner
+
+## ที่มา
+จาก audit ระบบ contact party-master พบ edge cases หลายจุด. owner เลือกแก้ชุด 1+2+3:
+1. **(I2)** trade-in seller ไม่รวมกับลูกค้า/ผู้ขายเดิม (keyless เสมอ) → ผู้ซื้อที่เอาเครื่องมาขาย = 2 contacts
+2. **(C1+M2)** `merge()` ทิ้ง identity fields ของตัวซ้ำ (ข้อมูลหาย) + ไม่มี audit + ไม่มี UI
+3. **(C2+C3)** unique เต็มตาราง + ไม่มี unique บน nationalIdHash → soft-deleted จอง key (re-create = 500) + race สร้าง contact ซ้ำ
+
+ลำดับทำ (พึ่งกัน): **3 → 1 → 2**.
+
+---
+
+## ส่วนที่ 3 — Partial unique index + P2002 retry (รากฐาน)
+
+### Schema
+- เอา `@@unique([taxId])` ออกจาก `model Contact` (เก็บ field `taxId`).
+- เพิ่ม **partial unique index แบบ raw SQL** ใน migration:
+  - `CREATE UNIQUE INDEX IF NOT EXISTS contacts_tax_id_active_key ON contacts(tax_id) WHERE deleted_at IS NULL;`
+  - `CREATE UNIQUE INDEX IF NOT EXISTS contacts_national_id_hash_active_key ON contacts(national_id_hash) WHERE deleted_at IS NULL;`
+  - (Postgres unique ปล่อย NULL ซ้ำได้ → keyless contacts หลายตัว national_id_hash/tax_id = NULL ไม่ชนกัน; เฉพาะ non-null ที่ unique ต่อ "ยังไม่ถูกลบ")
+- `contactCode` คง `@unique` เดิม (ไม่ reuse code อยู่แล้ว).
+- migration ตั้ง synthetic timestamp ให้เรียงท้ายสุด (> ตัวล่าสุดใน history) — บทเรียนลำดับ migration เดิม.
+
+### ⚠️ Deploy-safety (สำคัญ — migration อาจ fail บน prod ถ้ามีข้อมูลซ้ำ)
+ก่อน `CREATE UNIQUE INDEX` ต้องไม่มี non-null `tax_id`/`national_id_hash` ซ้ำในแถว deleted_at IS NULL. แผนจะมี **pre-check query** (รันก่อน): 
+```sql
+SELECT tax_id, count(*) FROM contacts WHERE deleted_at IS NULL AND tax_id IS NOT NULL GROUP BY tax_id HAVING count(*)>1;
+-- เช่นเดียวกับ national_id_hash
+```
+ถ้าเจอซ้ำ → dedupe (merge ด้วยมือ/CLI) ก่อน แล้วค่อย apply index. รันบน dev (37 rows) ก่อน — น่าจะไม่มีซ้ำ (resolver/backfill กันไว้แล้ว) แต่ต้องเช็คจริงก่อน prod.
+
+### Resolver (`contact-resolver.service.ts`)
+`findOrCreateByNaturalKey`: ห่อ `create` ด้วย try/catch — ถ้า `P2002` (unique race) → re-fetch by natural key (taxId/nationalIdHash) แล้ว attach role + return (เหมือน existing-match path). กัน race C3 + กรณีตกค้าง.
+
+### ทดสอบ
+- migration apply บน dev สะอาด (reset replay) + index มีจริง
+- resolver: จำลอง create โยน P2002 → re-fetch + attach role (ไม่ throw)
+- unit: keyless (null) สร้างหลายตัวได้ ; non-null ซ้ำ → match เดิม ไม่สร้างใหม่
+
+---
+
+## ส่วนที่ 1 — Trade-in auto-merge (I2)
+
+### Backend (`trade-in.service.ts` create, ~line 196)
+แทน `nationalIdHash: null` คงที่ ด้วย logic:
+- ถ้า `dto.customerId` → load customer, ใช้ `customer.nationalIdHash` (หรือถ้ามี `customer.contactId` แล้ว set `sellerContactId = customer.contactId` ตรงๆ + attach role) — เลือกทางที่ตรงสุด: ส่ง `nationalIdHash: customer.nationalIdHash` ให้ resolver (จะ match contact เดิมของลูกค้า)
+- else ถ้า `dto.sellerIdCardNumber` → `nationalIdHash = pii.hash(normalizeNationalId(sellerIdCardNumber))` โดย **normalize เหมือน Customer เป๊ะ**: `raw.replace(/[\s-]/g,'').toUpperCase()` ([customers.service.ts:459-461](../../apps/api/src/modules/customers/customers.service.ts)) แล้ว `CustomerPiiService.hash()` (salt เดียวกัน)
+- else → `nationalIdHash: null` (keyless เดิม)
+- ส่งให้ `findOrCreateByNaturalKey(tx, { name: sellerName, taxId: null, nationalIdHash: <above>, phone: sellerPhone, role: 'TRADE_IN_SELLER' })`
+- inject `CustomerPiiService` เข้า trade-in.service (+ TestModeModule/CustomersModule ตามที่ export `hash`)
+
+### ทดสอบ
+- trade-in ของลูกค้าที่มี `nationalIdHash` เดิม → ได้ contact เดียวกัน, roles เพิ่ม `TRADE_IN_SELLER` (ไม่สร้างใหม่)
+- มี `sellerIdCardNumber` ตรงกับลูกค้า (normalize ก่อน) → match contact ลูกค้า
+- ไม่มี key → keyless สร้างใหม่เหมือนเดิม
+- existing trade-in tests เขียว
+
+---
+
+## ส่วนที่ 2 — Merge: C1 + audit (M2) + UI
+
+### Backend (`contacts.service.ts` merge)
+ใน `$transaction` ก่อน soft-delete duplicate:
+- **carry identity fields**: สำหรับ `taxId, nationalIdHash, peakContactCode, phone, email` — ถ้า primary เป็น null/ว่าง แต่ duplicate มี → set ค่าจาก duplicate ลง primary (coalesce). ทำพร้อม `roles: { set: unionRoles }` ในการ update primary เดียว.
+  - (partial unique จากส่วน 3 ทำให้ copy taxId ลง primary ได้ เพราะ duplicate ถูก soft-delete → ออกจาก unique scope)
+- เขียน audit `CONTACTS_MERGED` (entity `contact`, entityId primaryId, newValue `{ duplicateId, mergedRoles, carriedFields }`) ใน tx เดียวกัน
+- คง repoint FK (customer/supplier/tradeIn/finance) + soft-delete duplicate เดิม
+
+### Frontend
+- `contactsApi.merge` มีแล้ว — เพิ่ม UI:
+- หน้า ContactDetailPage (OWNER): ปุ่ม **"รวมผู้ติดต่อซ้ำ"** → เปิด dialog ที่ **ค้นหา contact อื่น** (reuse `GET /contacts?search=`) → เลือกตัวที่จะยุบเข้า contact นี้ (contact ปัจจุบัน = primary, ตัวที่เลือก = duplicate) → ConfirmDialog destructive แสดงสรุป (role/ฟิลด์ที่จะรวม) → `contactsApi.merge(primaryId=current, duplicateId=selected)` → invalidate + toast + (duplicate ถูกยุบ → อาจ refetch/นำทาง)
+- OWNER เท่านั้น (ปุ่มซ่อนสำหรับ role อื่น)
+
+### ทดสอบ
+- backend merge: primary ไม่มี taxId + duplicate มี → หลัง merge primary ได้ taxId ; audit เขียน ; role union ; duplicate soft-deleted ; FK repointed
+- merge ตัวเอง → BadRequest (เดิม)
+- web: ปุ่ม + search dialog + confirm + เรียก merge ด้วย id ถูก
+
+---
+
+## นอก scope (backlog จาก audit — ไม่ทำรอบนี้)
+I1 (supplier taxId ซ้ำ — share เป็น policy ที่ตั้งใจ, แค่ handle P2002 ซึ่งส่วน 3 ช่วยแล้ว), I3 (PII_HASH_SALT plaintext fallback — ควรแก้แยกเป็น security cleanup), I4 (stale roles), I5 (stale name/phone), M1 (P-99999 ceiling), M3 (findOne PII to SALES). บันทึกไว้ทำรอบหน้า.


### PR DESCRIPTION
## สรุป (จาก audit contact party-master, owner เลือก 1+2+3)
1. **Trade-in unify** — seller key ด้วย customerId / sellerIdCardNumber (normalize เหมือน Customer เป๊ะ) → ผู้ซื้อที่เอาเครื่องมาขาย = **contact เดียว 2 role** (CUSTOMER + TRADE_IN_SELLER) ไม่แตกเป็น 2 อันอีก
2. **Merge fix + UI** — merge carry identity fields (taxId/nationalIdHash/peakCode/phone/email, primary-wins) จากตัวซ้ำ → ไม่ข้อมูลหาย (C1) + audit `CONTACTS_MERGED` (มี actor + snapshot ตัวซ้ำใน oldValue) + **ปุ่ม UI ค้นหาตัวซ้ำมายุบ (OWNER)**
3. **Partial unique** — `taxId`/`nationalIdHash` เป็น unique `WHERE deleted_at IS NULL` → soft-deleted ไม่จอง key (C2) + กัน contact ซ้ำระดับ DB (C3) + resolver แปลง P2002 → ConflictException

### ความถูกต้อง (จาก scrutinize + final review)
- scrutinize ก่อน build จับ 2 บั๊ก → แก้ในแผน: (a) P2002 ไม่ re-query ใน tx ที่ abort, (b) **merge soft-delete duplicate ก่อน carry key** (ไม่งั้นชน partial unique) — ล็อกด้วย ordering assertion ใน test
- migration deploy-safe (pre-check 0 dup, drop index ถูกตัว, เรียงท้ายสุด)
- final review = SHIP, 88 api tests + 4 web pass, type-check OK

### Backlog (audit findings ไม่ทำรอบนี้)
I1 (supplier taxId ซ้ำ), I3 (PII_HASH_SALT plaintext fallback), I4 (stale roles), I5 (stale name/phone), M1 (P-99999), M3 (findOne PII to SALES)

## Test Plan
- [x] api 88 tests (resolver/merge/trade-in) + web 4 pass, type-check all OK
- [x] migration apply สะอาดบน dev (partial indexes verified)
- [ ] smoke prod: ลูกค้าเอาเครื่องมาขาย (ใส่เลขบัตร/เลือกลูกค้า) → contact เดียว 2 role ; ปุ่มรวมผู้ติดต่อซ้ำ (OWNER) ทำงาน

🤖 Generated with [Claude Code](https://claude.com/claude-code)