### PR TITLE
fix(test-mode): skip real OTP SMS send when test-mode on (KYC + LIFF)

### DIFF
--- a/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.spec.ts
@@ -116,6 +116,42 @@ describe('VerificationService', () => {
         service.requestOtp({ lineUserId: 'U123', phone: '0891234567' }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    // ─── test-mode skips real SMS send (OWNER-gated UAT) ───
+    describe('test-mode skip-send', () => {
+      it('ON: skips the real SMS send but still upserts the OTP row and returns success', async () => {
+        testMode.isEnabled.mockResolvedValue(true);
+        prisma.customer.findFirst.mockResolvedValue({
+          id: 'c1',
+          name: 'สมชาย',
+          phone: '0891234567',
+        });
+
+        const result = await service.requestOtp({ lineUserId: 'U123', phone: '0891234567' });
+
+        // No real SMS during UAT.
+        expect(notifications.sendSmsFromQueue).not.toHaveBeenCalled();
+        // Pending OTP row MUST still be created (verify-bypass precondition + UI countdown).
+        expect(prisma.chatbotOtpRequest.upsert).toHaveBeenCalled();
+        // Success return preserved.
+        expect(result.maskedPhone).toBe('089-***-4567');
+        expect(result.expiresInSeconds).toBe(300);
+      });
+
+      it('OFF: sends SMS normally (existing behavior)', async () => {
+        testMode.isEnabled.mockResolvedValue(false);
+        prisma.customer.findFirst.mockResolvedValue({
+          id: 'c1',
+          name: 'สมชาย',
+          phone: '0891234567',
+        });
+
+        await service.requestOtp({ lineUserId: 'U123', phone: '0891234567' });
+
+        expect(notifications.sendSmsFromQueue).toHaveBeenCalled();
+        expect(prisma.chatbotOtpRequest.upsert).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('verifyOtp', () => {

--- a/apps/api/src/modules/chatbot-finance/services/verification.service.ts
+++ b/apps/api/src/modules/chatbot-finance/services/verification.service.ts
@@ -183,21 +183,32 @@ export class VerificationService {
       },
     });
 
-    try {
-      await this.notifications.sendSmsFromQueue(
-        customer.phone,
-        `BESTCHOICE: รหัส OTP ของคุณคือ ${otp} (ใช้ได้ใน 5 นาที)`,
+    // Test-mode UAT skip — OWNER-gated SystemConfig (TEST_MODE_BYPASS), default OFF,
+    // fails safe to OFF on any DB error. When ON we skip the real SMS so UAT doesn't
+    // cost money / bother real numbers. The OTP row was already upserted above, so the
+    // verify-bypass precondition (a pending OTP session exists) + the UI countdown still
+    // hold, and we fall through to the normal success return. MUST be OFF before go-live.
+    if (await this.testMode.isEnabled()) {
+      this.logger.warn(
+        `[TEST MODE] Skipping real OTP SMS send for ${maskPhone(customer.phone)} (TEST_MODE_BYPASS ON)`,
       );
-      this.logger.log(`[Verify] OTP sent to ${maskPhone(customer.phone)}`);
-    } catch (err) {
-      this.logger.error(
-        `[Verify] SMS send failed: ${err instanceof Error ? err.message : err}`,
-      );
-      // Cleanup record so user can retry immediately
-      await this.prisma.chatbotOtpRequest.delete({
-        where: { lineUserId: params.lineUserId },
-      });
-      throw new BadRequestException('ส่ง SMS ไม่สำเร็จ กรุณาลองใหม่อีกครั้ง หรือติดต่อ 063-134-6356');
+    } else {
+      try {
+        await this.notifications.sendSmsFromQueue(
+          customer.phone,
+          `BESTCHOICE: รหัส OTP ของคุณคือ ${otp} (ใช้ได้ใน 5 นาที)`,
+        );
+        this.logger.log(`[Verify] OTP sent to ${maskPhone(customer.phone)}`);
+      } catch (err) {
+        this.logger.error(
+          `[Verify] SMS send failed: ${err instanceof Error ? err.message : err}`,
+        );
+        // Cleanup record so user can retry immediately
+        await this.prisma.chatbotOtpRequest.delete({
+          where: { lineUserId: params.lineUserId },
+        });
+        throw new BadRequestException('ส่ง SMS ไม่สำเร็จ กรุณาลองใหม่อีกครั้ง หรือติดต่อ 063-134-6356');
+      }
     }
 
     return {

--- a/apps/api/src/modules/kyc/kyc.service.spec.ts
+++ b/apps/api/src/modules/kyc/kyc.service.spec.ts
@@ -186,6 +186,46 @@ describe('KycService', () => {
       expect(prisma.kycVerification.create).not.toHaveBeenCalled();
       expect(prisma.kycVerification.updateMany).not.toHaveBeenCalled();
     });
+
+    // ─── test-mode skips real SMS send (OWNER-gated UAT) ───
+    describe('when test-mode is ON', () => {
+      beforeEach(() => {
+        testMode.isEnabled.mockResolvedValue(true);
+      });
+
+      it('skips the real SMS send but still creates the pending row and returns success', async () => {
+        const result = await service.sendOtp('contract-1', req);
+
+        // No real SMS — must NOT bother real numbers / cost during UAT.
+        expect(notifications.send).not.toHaveBeenCalled();
+        // Pending row MUST still be created (verify-bypass precondition + UI ref/countdown).
+        expect(prisma.kycVerification.create).toHaveBeenCalled();
+        // Success return preserved.
+        expect(result).toBeDefined();
+        expect(result.channel).toBe('SMS');
+        expect(result.refCode).toBeDefined();
+      });
+
+      it('still expires existing pending verifications when send is skipped', async () => {
+        await service.sendOtp('contract-1', req);
+
+        expect(prisma.kycVerification.updateMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ contractId: 'contract-1' }),
+            data: { status: 'EXPIRED' },
+          }),
+        );
+      });
+    });
+
+    it('sends SMS normally when test-mode is OFF (existing behavior)', async () => {
+      testMode.isEnabled.mockResolvedValue(false);
+
+      await service.sendOtp('contract-1', req);
+
+      expect(notifications.send).toHaveBeenCalled();
+      expect(prisma.kycVerification.create).toHaveBeenCalled();
+    });
   });
 
   // ─── verifyOtp ───────────────────────────────────────

--- a/apps/api/src/modules/kyc/kyc.service.ts
+++ b/apps/api/src/modules/kyc/kyc.service.ts
@@ -70,44 +70,56 @@ export class KycService {
     const refCode = crypto.randomBytes(2).toString('hex').toUpperCase().slice(0, 4);
     const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
 
-    // Send OTP via notification service FIRST (before creating DB record)
+    // Send OTP via notification service FIRST (before creating DB record).
+    //
+    // Test-mode UAT skip — OWNER-gated SystemConfig (TEST_MODE_BYPASS), default OFF,
+    // fails safe to OFF on any DB error. When ON we skip the real SMS so UAT doesn't
+    // cost money / bother real numbers, but we STILL fall through to the row create +
+    // success return below — the verify-bypass precondition ("a pending OTP exists")
+    // and the UI ref/countdown both depend on that row. MUST be OFF before go-live.
     const message = `[BESTCHOICE] รหัส OTP: ${otp} (Ref: ${refCode}) หมดอายุใน ${OTP_EXPIRY_MINUTES} นาที`;
-    try {
-      const result = await this.notificationsService.send({
-        channel: 'SMS',
-        recipient: customer.phone,
-        message,
-        relatedId: contractId,
-        noRetry: true, // OTP expires in 10 min — retry queue would only spam
-        customerId: customer.id,
-        category: NotificationCategory.TRANSACTIONAL,
-      });
-      if (result.status === 'FAILED') {
-        throw new InternalServerErrorException(
-          result.errorMsg || 'Notification service returned FAILED status',
-        );
-      }
-    } catch (err) {
-      const errMessage = err instanceof Error ? err.message : String(err);
-      this.logger.error(
-        `Failed to send OTP for contract ${contractId} via SMS: ${errMessage}`,
+    if (await this.testMode.isEnabled()) {
+      this.logger.warn(
+        `[TEST MODE] Skipping real OTP SMS send for contract ${contractId} (TEST_MODE_BYPASS ON)`,
       );
+    } else {
+      try {
+        const result = await this.notificationsService.send({
+          channel: 'SMS',
+          recipient: customer.phone,
+          message,
+          relatedId: contractId,
+          noRetry: true, // OTP expires in 10 min — retry queue would only spam
+          customerId: customer.id,
+          category: NotificationCategory.TRANSACTIONAL,
+        });
+        if (result.status === 'FAILED') {
+          throw new InternalServerErrorException(
+            result.errorMsg || 'Notification service returned FAILED status',
+          );
+        }
+      } catch (err) {
+        const errMessage = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `Failed to send OTP for contract ${contractId} via SMS: ${errMessage}`,
+        );
 
-      let userMessage = 'ไม่สามารถส่ง OTP ได้ กรุณาลองใหม่';
-      if (errMessage.includes('credentials invalid') || errMessage.includes('401')) {
-        userMessage = 'ระบบ SMS ขัดข้อง กรุณาติดต่อผู้ดูแลระบบ';
-      } else if (errMessage.includes('number invalid') || errMessage.includes('Invalid phone')) {
-        userMessage = 'เบอร์โทรศัพท์ไม่ถูกต้อง กรุณาตรวจสอบเบอร์โทร';
-      } else if (errMessage.includes('credit') || errMessage.includes('insufficient')) {
-        userMessage = 'ระบบ SMS ขัดข้อง กรุณาติดต่อผู้ดูแลระบบ';
-      } else if (errMessage.includes('not configured')) {
-        userMessage = 'ระบบ SMS ยังไม่ได้ตั้งค่า กรุณาติดต่อผู้ดูแลระบบ';
+        let userMessage = 'ไม่สามารถส่ง OTP ได้ กรุณาลองใหม่';
+        if (errMessage.includes('credentials invalid') || errMessage.includes('401')) {
+          userMessage = 'ระบบ SMS ขัดข้อง กรุณาติดต่อผู้ดูแลระบบ';
+        } else if (errMessage.includes('number invalid') || errMessage.includes('Invalid phone')) {
+          userMessage = 'เบอร์โทรศัพท์ไม่ถูกต้อง กรุณาตรวจสอบเบอร์โทร';
+        } else if (errMessage.includes('credit') || errMessage.includes('insufficient')) {
+          userMessage = 'ระบบ SMS ขัดข้อง กรุณาติดต่อผู้ดูแลระบบ';
+        } else if (errMessage.includes('not configured')) {
+          userMessage = 'ระบบ SMS ยังไม่ได้ตั้งค่า กรุณาติดต่อผู้ดูแลระบบ';
+        }
+
+        throw new BadRequestException(userMessage);
       }
-
-      throw new BadRequestException(userMessage);
     }
 
-    // OTP sent successfully — now persist to database
+    // OTP sent successfully (or skipped in test-mode) — now persist to database
     // Expire any existing pending verifications for this contract
     await this.prisma.kycVerification.updateMany({
       where: { contractId, status: { in: ['PENDING', 'OTP_VERIFIED'] } },


### PR DESCRIPTION
## สรุป
test-mode เดิม bypass แค่ "ตรวจโค้ด OTP" แต่ `sendOtp`/`requestOtp` ยัง**ยิง SMS จริง** (เสียค่า SMS + รบกวนเบอร์ลูกค้าจริงตอนเทสต์). PR นี้ให้ test-mode **ข้ามการส่ง SMS จริง** ด้วย:
- **KYC** `sendOtp` — guard `notificationsService.send({SMS})` ; เมื่อ ON ข้ามการส่ง แต่ยัง create kycVerification row + return ปกติ
- **LIFF** `requestOtp` — guard `sendSmsFromQueue` ; เมื่อ ON ข้ามการส่ง แต่ยัง upsert chatbotOtpRequest + return ปกติ

ยังคง pending row ไว้ (verify-bypass ต้องการ + UI ต้องการ ref/countdown) → ตอนเทสต์ใส่โค้ดอะไรก็ผ่าน โดย**ไม่มี SMS ออกจริง**

### ความปลอดภัย
- test-mode OFF = byte-for-byte เดิม (existing tests เขียว) — fail-safe: ถ้า service หาย/ปิด = ส่งปกติ
- 49 kyc/verification tests pass + 124 (test-mode/kyc/chatbot-finance), type-check OK, ไม่มี migration

## Test Plan
- [x] ON = ไม่เรียก send, ยัง create row + return ; OFF = ส่งปกติ
- [ ] smoke prod (เปิดโหมดทดสอบ): สร้างสัญญา → ขั้น OTP ขึ้น ref แต่**ไม่มี SMS เข้าเบอร์จริง** → ใส่ 000000 ผ่าน

🤖 Generated with [Claude Code](https://claude.com/claude-code)