### PR TITLE
fix(contacts): format supplier address on contact card

### DIFF
--- a/apps/web/src/pages/ContactDetailPage.tsx
+++ b/apps/web/src/pages/ContactDetailPage.tsx
@@ -10,6 +10,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import QueryBoundary from '@/components/QueryBoundary';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { displayAddress } from '@/components/ui/AddressForm';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -93,7 +94,7 @@ function SupplierCard({ supplier }: { supplier: ContactSupplierLink }) {
           />
           <Field label="เบอร์" value={supplier.phone} />
           <Field label="VAT" value={supplier.hasVat ? 'จด VAT' : 'ไม่จด VAT'} />
-          <Field label="ที่อยู่" value={supplier.address} />
+          <Field label="ที่อยู่" value={displayAddress(supplier.address) || supplier.address} />
         </div>
         <CardLink to={`/suppliers/${supplier.id}`} label="เปิดข้อมูลผู้ขาย / แก้ไข" />
       </CardContent>


### PR DESCRIPTION
การ์ด read-through บนหน้า Contact แสดง Supplier.address เป็น JSON ดิบ — reuse displayAddress() ให้ format เหมือนหน้า Supplier (fallback เป็น text เดิมถ้าไม่ใช่ JSON). frontend-only, 4 tests pass, type-check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)