### PR TITLE
feat(accounting): complete InternalControlActionBar rollout to Expense + Asset (+ audit fixes)

### DIFF
--- a/apps/api/src/modules/asset/__tests__/asset-receipt-pdf.controller.spec.ts
+++ b/apps/api/src/modules/asset/__tests__/asset-receipt-pdf.controller.spec.ts
@@ -1,0 +1,59 @@
+import { Test } from '@nestjs/testing';
+import { AssetController } from '../asset.controller';
+import { AssetService } from '../asset.service';
+import { AssetTransferService } from '../asset-transfer.service';
+import { AssetReceiptPdfService } from '../services/asset-receipt-pdf.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { BranchGuard } from '../../auth/guards/branch.guard';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * ใบรับสินทรัพย์ (Asset Goods-Receipt Voucher) PDF — controller delegation test.
+ * Mirrors the expense voucher controller spec: asserts the endpoint forwards to
+ * AssetReceiptPdfService.generate() and sets the PDF response headers. No real
+ * puppeteer is launched (the service is fully mocked).
+ */
+describe('AssetController — receipt PDF', () => {
+  let controller: AssetController;
+  let receiptPdf: { generate: jest.Mock };
+
+  beforeEach(async () => {
+    receiptPdf = { generate: jest.fn().mockResolvedValue(Buffer.from('%PDF-fake')) };
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AssetController],
+      providers: [
+        { provide: AssetService, useValue: {} },
+        { provide: AssetTransferService, useValue: {} },
+        { provide: AssetReceiptPdfService, useValue: receiptPdf },
+        // ReversePermissionGuard (method-level on reverse/reverseDispose) needs
+        // PrismaService — provide a minimal stub so the module compiles.
+        { provide: PrismaService, useValue: { systemConfig: { findFirst: jest.fn() } } },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(BranchGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = moduleRef.get(AssetController);
+  });
+
+  it('GET /:id/receipt.pdf delegates to AssetReceiptPdfService + sets PDF headers', async () => {
+    const headers: Record<string, string> = {};
+    const res = {
+      set: jest.fn((h: Record<string, string>) => {
+        Object.assign(headers, h);
+      }),
+      send: jest.fn(),
+    };
+    await controller.getReceiptPdf('asset-1', res as never);
+    expect(receiptPdf.generate).toHaveBeenCalledWith('asset-1');
+    expect(headers['Content-Type']).toBe('application/pdf');
+    expect(headers['Content-Disposition']).toBe('inline; filename="asset-receipt-asset-1.pdf"');
+    expect(headers['Content-Length']).toBe(Buffer.from('%PDF-fake').length.toString());
+    expect(res.send).toHaveBeenCalledWith(Buffer.from('%PDF-fake'));
+  });
+});

--- a/apps/api/src/modules/asset/__tests__/asset.controller.spec.ts
+++ b/apps/api/src/modules/asset/__tests__/asset.controller.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * AssetController — reverse-permission metadata tests.
+ *
+ * Audit Finding A: reverse permission must be UNIFORM across the three
+ * accounting modules (Other Income, Expense, Asset). Before this change the
+ * Asset reverse endpoints used a hardcoded `@Roles('OWNER')` and ignored the
+ * dynamic `reverse_permission` SystemConfig mode entirely — so a
+ * FINANCE_MANAGER could reverse Other Income / Expense documents but NOT
+ * Assets, and the Settings "สิทธิ์การยกเลิก/กลับรายการ" card had no effect on
+ * the Asset module.
+ *
+ * The fix mirrors the Expense `void` endpoint: a coarse `@Roles` superset
+ * (OWNER + FINANCE_MANAGER) so RolesGuard lets through anyone the dynamic
+ * guard might allow, then `ReversePermissionGuard` narrows per request.
+ *
+ * These are Reflector metadata tests (no DB / HTTP needed) — the dynamic
+ * narrowing logic itself is covered by the shared ReversePermissionGuard spec.
+ */
+import 'reflect-metadata';
+import { Reflector } from '@nestjs/core';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
+import { ReversePermissionGuard } from '../../auth/guards/reverse-permission.guard';
+import { AssetController } from '../asset.controller';
+
+describe('AssetController — reverse permission metadata (Audit Finding A)', () => {
+  const reflector = new Reflector();
+
+  const methodRoles = (methodName: string): string[] | undefined => {
+    const handler = (AssetController.prototype as unknown as Record<string, unknown>)[methodName];
+    if (typeof handler !== 'function') return undefined;
+    return reflector.get<string[]>(ROLES_KEY, handler as () => void);
+  };
+
+  const methodGuards = (methodName: string): unknown[] | undefined => {
+    const handler = (AssetController.prototype as unknown as Record<string, unknown>)[methodName];
+    if (typeof handler !== 'function') return undefined;
+    return Reflect.getMetadata(GUARDS_METADATA, handler as object) as unknown[] | undefined;
+  };
+
+  it.each(['reverse', 'reverseDispose'])(
+    '%s() coarse @Roles allows OWNER + FINANCE_MANAGER + ACCOUNTANT (no longer OWNER-only; guard narrows)',
+    (methodName) => {
+      const roles = methodRoles(methodName);
+      expect(roles).toBeDefined();
+      expect(roles).toEqual(
+        expect.arrayContaining(['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']),
+      );
+      expect(roles).not.toContain('SALES');
+    },
+  );
+
+  it.each(['reverse', 'reverseDispose'])(
+    '%s() is gated by ReversePermissionGuard (uniform dynamic mode)',
+    (methodName) => {
+      const guards = methodGuards(methodName);
+      expect(guards).toBeDefined();
+      expect(guards).toContain(ReversePermissionGuard);
+    },
+  );
+});

--- a/apps/api/src/modules/asset/asset.controller.ts
+++ b/apps/api/src/modules/asset/asset.controller.ts
@@ -24,6 +24,7 @@ import { PaginationDto } from '../../common/dto/pagination.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
+import { ReversePermissionGuard } from '../auth/guards/reverse-permission.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 
@@ -154,13 +155,20 @@ export class AssetController {
   }
 
   @Post(':id/reverse')
-  @Roles('OWNER')
+  // Coarse superset — ReversePermissionGuard narrows per the dynamic
+  // `reverse_permission` mode (default OWNER+FM mode rejects ACCOUNTANT;
+  // the +ACCOUNTANT / CUSTOM modes may allow it).
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @UseGuards(ReversePermissionGuard)
   reverse(
     @Param('id') id: string,
     @Body() dto: ReverseAssetDto,
     @CurrentUser('id') userId: string,
   ) {
-    return this.assetService.reverse(id, userId, dto.reason);
+    return this.assetService.reverse(id, userId, dto.reason, {
+      reasonLabel: dto.reasonLabel,
+      note: dto.note,
+    });
   }
 
   @Post(':id/transfer')
@@ -184,13 +192,20 @@ export class AssetController {
   }
 
   @Post(':id/reverse-dispose')
-  @Roles('OWNER')
+  // Coarse superset — ReversePermissionGuard narrows per the dynamic
+  // `reverse_permission` mode (default OWNER+FM mode rejects ACCOUNTANT;
+  // the +ACCOUNTANT / CUSTOM modes may allow it).
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @UseGuards(ReversePermissionGuard)
   reverseDispose(
     @Param('id') id: string,
     @Body() dto: ReverseDisposalDto,
     @CurrentUser('id') userId: string,
   ) {
-    return this.assetService.reverseDispose(id, dto.reason, userId);
+    return this.assetService.reverseDispose(id, dto.reason, userId, {
+      reasonLabel: dto.reasonLabel,
+      note: dto.note,
+    });
   }
 
   @Post(':id/invoice-received')

--- a/apps/api/src/modules/asset/asset.controller.ts
+++ b/apps/api/src/modules/asset/asset.controller.ts
@@ -9,11 +9,14 @@ import {
   Query,
   UseGuards,
   HttpCode,
+  Res,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { Response } from 'express';
 import { AssetCategory, AssetStatus } from '@prisma/client';
 import { AssetService } from './asset.service';
 import { AssetTransferService } from './asset-transfer.service';
+import { AssetReceiptPdfService } from './services/asset-receipt-pdf.service';
 import { CreateAssetDto } from './dto/create-asset.dto';
 import { UpdateAssetDto } from './dto/update-asset.dto';
 import { ReverseAssetDto } from './dto/reverse-asset.dto';
@@ -36,6 +39,7 @@ export class AssetController {
   constructor(
     private readonly assetService: AssetService,
     private readonly transferService: AssetTransferService,
+    private readonly receiptPdf: AssetReceiptPdfService,
   ) {}
 
   @Get()
@@ -109,6 +113,21 @@ export class AssetController {
       fromDate,
       toDate,
     });
+  }
+
+  // ใบรับสินทรัพย์ (Asset Goods-Receipt Voucher) PDF — mirrors the OI receipt /
+  // expense voucher. Declared before the generic :id route. POSTED/REVERSED only
+  // (gated inside the service). Print label "พิมพ์ใบรับสินทรัพย์".
+  @Get(':id/receipt.pdf')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  async getReceiptPdf(@Param('id') id: string, @Res() res: Response) {
+    const pdf = await this.receiptPdf.generate(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `inline; filename="asset-receipt-${id}.pdf"`,
+      'Content-Length': pdf.length.toString(),
+    });
+    res.send(pdf);
   }
 
   @Get(':id')

--- a/apps/api/src/modules/asset/asset.module.ts
+++ b/apps/api/src/modules/asset/asset.module.ts
@@ -7,6 +7,7 @@ import { AssetService } from './asset.service';
 import { AssetTransferService } from './asset-transfer.service';
 import { AssetJournalService } from './asset-journal.service';
 import { AssetReportsService } from './asset-reports.service';
+import { AssetReceiptPdfService } from './services/asset-receipt-pdf.service';
 import { JournalModule } from '../journal/journal.module';
 
 @Module({
@@ -28,6 +29,7 @@ import { JournalModule } from '../journal/journal.module';
     AssetTransferService,
     AssetJournalService,
     AssetReportsService,
+    AssetReceiptPdfService,
   ],
   exports: [
     AssetService,

--- a/apps/api/src/modules/asset/asset.service.ts
+++ b/apps/api/src/modules/asset/asset.service.ts
@@ -893,6 +893,7 @@ export class AssetService {
     id: string,
     reversedById: string,
     reason: string,
+    meta?: { reasonLabel?: string | null; note?: string | null },
   ): Promise<{ entryNo: string }> {
     if (!reason || reason.trim().length === 0) {
       throw new BadRequestException('กรุณาระบุเหตุผลการกลับรายการ');
@@ -958,6 +959,8 @@ export class AssetService {
             status: 'REVERSED',
             reversedById,
             reversalReason: reason,
+            reverseReasonLabel: meta?.reasonLabel ?? null,
+            reverseNote: meta?.note ?? null,
             reversalEntryNumber: inner.entryNo,
           },
         },
@@ -1338,6 +1341,7 @@ export class AssetService {
     id: string,
     reason: string,
     userId: string,
+    meta?: { reasonLabel?: string | null; note?: string | null },
   ): Promise<{ entryNo: string }> {
     if (!reason || reason.trim().length === 0) {
       throw new BadRequestException('กรุณาระบุเหตุผลการกลับรายการ');
@@ -1394,6 +1398,8 @@ export class AssetService {
           newValue: {
             status: 'POSTED',
             reversalReason: reason,
+            reverseReasonLabel: meta?.reasonLabel ?? null,
+            reverseNote: meta?.note ?? null,
             reversalEntryNumber: inner.entryNo,
           },
         },

--- a/apps/api/src/modules/asset/dto/reverse-asset.dto.ts
+++ b/apps/api/src/modules/asset/dto/reverse-asset.dto.ts
@@ -1,8 +1,25 @@
-import { IsString, IsNotEmpty, MinLength } from 'class-validator';
+import { IsString, IsNotEmpty, MinLength, IsOptional, MaxLength } from 'class-validator';
 
 export class ReverseAssetDto {
   @IsString()
   @IsNotEmpty({ message: 'กรุณาระบุเหตุผลการกลับรายการ' })
   @MinLength(5, { message: 'เหตุผลต้องมีอย่างน้อย 5 ตัวอักษร' })
   reason: string;
+
+  /**
+   * Structured reverse reason carried by the shared InternalControlActionBar
+   * (`onReverse({ reasonId, reasonLabel, note })`). Optional + backward
+   * compatible: legacy callers send only `reason`. When present they are
+   * stamped into the AuditLog so the timeline renders the admin-managed label +
+   * free-text note separately (mirrors Other Income / Expense).
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  reasonLabel?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
 }

--- a/apps/api/src/modules/asset/dto/reverse-disposal.dto.ts
+++ b/apps/api/src/modules/asset/dto/reverse-disposal.dto.ts
@@ -1,8 +1,19 @@
-import { IsString, IsNotEmpty, MinLength } from 'class-validator';
+import { IsString, IsNotEmpty, MinLength, IsOptional, MaxLength } from 'class-validator';
 
 export class ReverseDisposalDto {
   @IsString()
   @IsNotEmpty({ message: 'กรุณาระบุเหตุผลการกลับรายการ' })
   @MinLength(5, { message: 'เหตุผลต้องมีอย่างน้อย 5 ตัวอักษร' })
   reason: string;
+
+  /** Structured reverse reason (see ReverseAssetDto) — optional, backward compatible. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  reasonLabel?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
 }

--- a/apps/api/src/modules/asset/services/asset-receipt-pdf.service.ts
+++ b/apps/api/src/modules/asset/services/asset-receipt-pdf.service.ts
@@ -1,0 +1,562 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as puppeteer from 'puppeteer';
+import * as QRCode from 'qrcode';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Self-hosted fonts (mirrors expense-documents/services/expense-voucher-pdf.service.ts).
+//
+// The four IBM Plex Sans Thai weights + Sriracha TTFs were committed once to
+// `src/modules/other-income/assets/fonts/` (OFL license). We embed them as
+// base64 data: URIs at boot time (cached in module scope) so puppeteer can wait
+// on `domcontentloaded` only — zero outbound network requests during render.
+//
+// The asset receipt reuses the EXACT same committed font files as the OI receipt
+// and the expense voucher; no duplicate copy is added under asset/.
+// ──────────────────────────────────────────────────────────────────────────────
+
+const FONT_DIR_CANDIDATES = [
+  // Dev: src/modules/other-income/assets/fonts/*.ttf (shared with OI receipt)
+  path.join(__dirname, '..', '..', 'other-income', 'assets', 'fonts'),
+  // Prod (nest build): dist/src/modules/other-income/assets/fonts/*.ttf
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'src',
+    'modules',
+    'other-income',
+    'assets',
+    'fonts',
+  ),
+  // Fallback when working directory matters
+  path.join(process.cwd(), 'src', 'modules', 'other-income', 'assets', 'fonts'),
+  path.join(
+    process.cwd(),
+    'apps',
+    'api',
+    'src',
+    'modules',
+    'other-income',
+    'assets',
+    'fonts',
+  ),
+];
+
+interface FontDef {
+  family: string;
+  weight: number;
+  file: string;
+}
+
+const FONT_FILES: FontDef[] = [
+  { family: 'IBM Plex Sans Thai', weight: 400, file: 'ibmplexsansthai-400.ttf' },
+  { family: 'IBM Plex Sans Thai', weight: 500, file: 'ibmplexsansthai-500.ttf' },
+  { family: 'IBM Plex Sans Thai', weight: 600, file: 'ibmplexsansthai-600.ttf' },
+  { family: 'IBM Plex Sans Thai', weight: 700, file: 'ibmplexsansthai-700.ttf' },
+  { family: 'Sriracha', weight: 400, file: 'sriracha-400.ttf' },
+];
+
+let cachedFontCss: string | null = null;
+
+/** Build the @font-face block once at first call, cache for the process lifetime. */
+function getEmbeddedFontCss(logger: Logger): string {
+  if (cachedFontCss !== null) return cachedFontCss;
+
+  const fontsDir =
+    FONT_DIR_CANDIDATES.find((dir) =>
+      fs.existsSync(path.join(dir, FONT_FILES[0].file)),
+    ) ?? FONT_DIR_CANDIDATES[0];
+
+  const blocks: string[] = [];
+  for (const f of FONT_FILES) {
+    const full = path.join(fontsDir, f.file);
+    try {
+      const b64 = fs.readFileSync(full).toString('base64');
+      blocks.push(
+        `@font-face{font-family:'${f.family}';font-style:normal;font-weight:${f.weight};font-display:block;` +
+          `src:url(data:font/ttf;base64,${b64}) format('truetype');}`,
+      );
+    } catch (err) {
+      logger.warn(
+        `Could not embed font ${f.file} (looked in ${fontsDir}): ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  cachedFontCss = blocks.join('\n');
+  return cachedFontCss;
+}
+
+type AssetWithRelations = Prisma.FixedAssetGetPayload<{
+  include: {
+    branch: { select: { id: true; name: true } };
+    createdBy: { select: { id: true; name: true; email: true } };
+    postedBy: { select: { id: true; name: true } };
+  };
+}>;
+
+const CATEGORY_LABEL_TH: Record<string, string> = {
+  EQUIPMENT: 'อุปกรณ์สำนักงาน',
+  IMPROVEMENT: 'ปรับปรุงอาคาร',
+  FURNITURE: 'เครื่องตกแต่ง',
+  VEHICLE: 'ยานพาหนะ',
+};
+
+function fmtDateShort(d: Date | string | null | undefined): string {
+  if (!d) return '—';
+  const dt = typeof d === 'string' ? new Date(d) : d;
+  if (isNaN(dt.getTime())) return '—';
+  // Pin to Asia/Bangkok so server TZ (Cloud Run UTC) doesn't shift the date
+  // by 1 day for late-evening BKK timestamps, and render year in Buddhist
+  // Era (พ.ศ.) — Thai accounting documents use พ.ศ.
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Bangkok',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).formatToParts(dt);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '';
+  const year = parseInt(get('year'), 10) + 543;
+  return `${get('day')}/${get('month')}/${year}`;
+}
+
+function fmtMoney(v: unknown): string {
+  const n = typeof v === 'string' ? parseFloat(v) : Number(v);
+  if (!isFinite(n)) return '0.00';
+  return n.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function escapeHtml(text: string | null | undefined): string {
+  if (!text) return '';
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function formatAddress(value: string | null | undefined): string {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{')) return trimmed;
+  try {
+    const addr = JSON.parse(trimmed) as Record<string, string | undefined>;
+    if (typeof addr !== 'object' || addr === null) return trimmed;
+    if (addr.raw && !addr.province) return addr.raw;
+    const parts: string[] = [];
+    if (addr.houseNo) parts.push(`เลขที่ ${addr.houseNo}`);
+    if (addr.moo) parts.push(`หมู่ ${addr.moo}`);
+    if (addr.village) parts.push(`หมู่บ้าน ${addr.village}`);
+    if (addr.soi) parts.push(`ซอย ${addr.soi}`);
+    if (addr.road) parts.push(`ถนน ${addr.road}`);
+    if (addr.subdistrict) parts.push(`ตำบล${addr.subdistrict}`);
+    if (addr.district) parts.push(`อำเภอ${addr.district}`);
+    if (addr.province) parts.push(`จังหวัด${addr.province}`);
+    if (addr.postalCode) parts.push(addr.postalCode);
+    return parts.length > 0 ? parts.join(' ') : trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/** Convert a number to its Thai-baht spelling. Handles negative + millions. */
+function numberToThaiText(num: number): string {
+  if (!isFinite(num)) return '(จำนวนเงินไม่ถูกต้อง)';
+  if (num < 0) return `ลบ${numberToThaiText(-num)}`;
+  if (num === 0) return 'ศูนย์บาทถ้วน';
+  // Cap at < 1e12 (999,999,999,999.99 baht) — extending readGroup beyond 6 digits
+  // would mis-spell the ล้านล้าน group; very unlikely for an asset doc.
+  if (num >= 1e12) return '(จำนวนเงินเกินขีดจำกัด)';
+  const digits = ['', 'หนึ่ง', 'สอง', 'สาม', 'สี่', 'ห้า', 'หก', 'เจ็ด', 'แปด', 'เก้า'];
+  const places = ['', 'สิบ', 'ร้อย', 'พัน', 'หมื่น', 'แสน'];
+  const readGroup = (n: number): string => {
+    if (n === 0) return '';
+    let s = '';
+    const str = String(Math.floor(n));
+    const len = str.length;
+    for (let i = 0; i < len; i++) {
+      const d = parseInt(str[i]);
+      const place = len - i - 1;
+      if (d === 0) continue;
+      if (place === 1 && d === 1) s += 'สิบ';
+      else if (place === 1 && d === 2) s += 'ยี่สิบ';
+      else if (place === 0 && d === 1 && len > 1) s += 'เอ็ด';
+      else s += digits[d] + places[place];
+    }
+    return s;
+  };
+  let text = '';
+  let remaining = Math.floor(num);
+  if (remaining >= 1000000) {
+    const millions = Math.floor(remaining / 1000000);
+    text += readGroup(millions) + 'ล้าน';
+    remaining = remaining - millions * 1000000;
+  }
+  if (remaining > 0) text += readGroup(remaining);
+  text += 'บาท';
+  const satang = Math.round((num - Math.floor(num)) * 100);
+  if (satang === 0) text += 'ถ้วน';
+  else text += readGroup(satang) + 'สตางค์';
+  return text;
+}
+
+// BESTCHOICE wordmark — reused from expense-voucher-pdf.service.ts.
+const BESTCHOICE_LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="395 285 710 425" fill="none"><defs><linearGradient id="bc-as" gradientUnits="userSpaceOnUse" x1="597.6" y1="434.1" x2="902.4" y2="434.1"><stop offset="0" stop-color="#39F0CF"/><stop offset="0.5" stop-color="#25BC93"/><stop offset="1" stop-color="#1DA579"/></linearGradient></defs><path fill="url(#bc-as)" d="M 603.769531 297.347656 C 600.023438 298.191406 597.769531 301.1875 597.597656 305.820312 C 597.414062 310.808594 599.695312 314.0625 603.605469 315.121094 C 605.0625 315.515625 606.605469 315.484375 608.132812 315.453125 C 608.550781 315.445312 608.96875 315.4375 609.382812 315.4375 C 623.914062 315.445312 638.449219 315.445312 652.980469 315.445312 C 662.1875 315.445312 671.390625 315.445312 680.59375 315.445312 C 692.277344 315.449219 696.074219 321.558594 693.207031 335.660156 C 687.417969 364.132812 681.613281 392.601562 675.878906 421.089844 C 673.085938 434.941406 678.320312 443.273438 689.765625 443.289062 C 717.367188 443.324219 744.976562 443.292969 772.582031 443.335938 C 782.101562 443.351562 785.0625 447.972656 782.789062 459.183594 C 777.746094 484.074219 772.6875 508.957031 767.59375 533.832031 C 764.777344 547.605469 759.269531 552.824219 747.617188 552.828125 C 701.550781 552.84375 655.484375 552.839844 609.414062 552.847656 C 608.996094 552.847656 608.578125 552.84375 608.160156 552.835938 C 606.816406 552.820312 605.472656 552.800781 604.144531 552.976562 C 599.992188 553.523438 597.800781 556.847656 597.597656 561.664062 C 597.402344 566.289062 599.542969 569.574219 603.199219 570.730469 C 604.714844 571.210938 606.347656 571.191406 607.960938 571.171875 C 608.292969 571.164062 608.628906 571.160156 608.960938 571.160156 C 650.808594 571.183594 692.65625 571.175781 734.503906 571.179688 C 776.878906 571.183594 819.257812 571.214844 861.632812 571.164062 C 873.066406 571.152344 879.71875 564.628906 882.480469 551.023438 C 888.8125 519.808594 895.195312 488.605469 901.441406 457.363281 C 905.367188 437.703125 897.210938 424.992188 880.769531 424.957031 C 868.933594 424.933594 857.101562 424.9375 845.265625 424.941406 C 833.714844 424.945312 822.164062 424.949219 810.613281 424.925781 C 799.550781 424.90625 794.933594 417.503906 797.613281 404.195312 C 802.675781 379.085938 807.78125 353.988281 812.839844 328.878906 C 816.617188 310.132812 808.339844 297.125 792.601562 297.121094 C 731.234375 297.097656 669.867188 297.109375 608.503906 297.117188 C 607.859375 297.117188 607.214844 297.097656 606.566406 297.097656 C 605.625 297.097656 604.683594 297.140625 603.769531 297.347656"/><path fill="#4D4D4D" d="M 434.851562 645.261719 L 432.128906 658.890625 L 446.460938 658.890625 C 450.027344 658.890625 452.738281 658.199219 454.589844 656.820312 C 456.4375 655.441406 457.363281 653.441406 457.363281 650.816406 C 457.363281 647.117188 454.570312 645.261719 448.984375 645.261719 Z M 452.214844 684.933594 C 454.234375 683.523438 455.246094 681.4375 455.246094 678.675781 C 455.246094 676.65625 454.503906 675.160156 453.023438 674.183594 C 451.542969 673.207031 449.523438 672.71875 446.964844 672.71875 L 429.300781 672.71875 L 426.476562 687.054688 L 443.835938 687.054688 C 447.402344 687.054688 450.199219 686.347656 452.214844 684.933594 M 472.65625 670.652344 C 474.304688 673.039062 475.128906 675.851562 475.128906 679.078125 C 475.128906 686.414062 472.136719 691.984375 466.148438 695.785156 C 460.15625 699.589844 452.351562 701.488281 442.726562 701.488281 L 403.863281 701.488281 L 417.996094 630.828125 L 453.730469 630.828125 C 461.667969 630.828125 467.746094 632.257812 471.949219 635.117188 C 476.15625 637.980469 478.257812 642.066406 478.257812 647.382812 C 478.257812 651.488281 477.148438 655.039062 474.929688 658.03125 C 472.707031 661.027344 469.613281 663.367188 465.640625 665.046875 C 468.667969 666.394531 471.007812 668.261719 472.65625 670.652344"/><path fill="#4D4D4D" d="M 512.175781 646.273438 L 509.855469 658.183594 L 541.25 658.183594 L 538.320312 673.125 L 506.828125 673.125 L 504.304688 686.042969 L 541.351562 686.042969 L 538.121094 701.488281 L 481.488281 701.488281 L 495.621094 630.828125 L 550.941406 630.828125 L 547.808594 646.273438 Z"/><path fill="#4D4D4D" d="M 559.015625 700.78125 C 553.765625 699.371094 549.492188 697.554688 546.195312 695.332031 L 554.070312 680.390625 C 557.632812 682.679688 561.4375 684.414062 565.472656 685.589844 C 569.511719 686.769531 573.550781 687.355469 577.589844 687.355469 C 581.425781 687.355469 584.402344 686.800781 586.523438 685.691406 C 588.640625 684.582031 589.703125 683.050781 589.703125 681.097656 C 589.703125 679.417969 588.742188 678.105469 586.824219 677.164062 C 584.90625 676.21875 581.929688 675.210938 577.890625 674.132812 C 573.3125 672.921875 569.511719 671.695312 566.484375 670.449219 C 563.457031 669.203125 560.847656 667.304688 558.660156 664.746094 C 556.472656 662.1875 555.378906 658.824219 555.378906 654.652344 C 555.378906 649.601562 556.757812 645.179688 559.519531 641.378906 C 562.277344 637.574219 566.214844 634.632812 571.328125 632.542969 C 576.445312 630.460938 582.433594 629.414062 589.296875 629.414062 C 594.34375 629.414062 599.054688 629.9375 603.429688 630.980469 C 607.804688 632.023438 611.574219 633.519531 614.738281 635.472656 L 607.46875 650.308594 C 604.707031 648.5625 601.664062 647.230469 598.332031 646.324219 C 595.003906 645.414062 591.585938 644.960938 588.085938 644.960938 C 584.117188 644.960938 581.003906 645.601562 578.75 646.878906 C 576.492188 648.15625 575.367188 649.804688 575.367188 651.824219 C 575.367188 653.574219 576.34375 654.921875 578.296875 655.863281 C 580.246094 656.804688 583.273438 657.816406 587.378906 658.890625 C 591.957031 660.035156 595.742188 661.210938 598.738281 662.425781 C 601.730469 663.636719 604.304688 665.484375 606.460938 667.976562 C 608.613281 670.464844 609.6875 673.730469 609.6875 677.765625 C 609.6875 682.75 608.292969 687.140625 605.5 690.941406 C 602.707031 694.742188 598.738281 697.6875 593.589844 699.773438 C 588.441406 701.859375 582.464844 702.902344 575.671875 702.902344 C 569.816406 702.902344 564.261719 702.195312 559.015625 700.78125"/><path fill="#4D4D4D" d="M 639.566406 646.675781 L 617.863281 646.675781 L 621.09375 630.828125 L 684.386719 630.828125 L 681.15625 646.675781 L 659.554688 646.675781 L 648.550781 701.488281 L 628.566406 701.488281 Z"/><path fill="#1DA579" d="M 717.195312 686.347656 C 711.878906 686.347656 707.671875 684.902344 704.574219 682.007812 C 701.480469 679.113281 699.933594 675.277344 699.933594 670.5 C 699.933594 665.855469 700.890625 661.667969 702.808594 657.933594 C 704.726562 654.195312 707.402344 651.269531 710.835938 649.148438 C 714.265625 647.03125 718.238281 645.96875 722.746094 645.96875 C 729.675781 645.96875 734.859375 648.730469 738.292969 654.246094 L 752.726562 642.738281 C 750.234375 638.5 746.46875 635.21875 741.421875 632.898438 C 736.375 630.578125 730.585938 629.414062 724.058594 629.414062 C 715.441406 629.414062 707.769531 631.230469 701.042969 634.867188 C 694.3125 638.5 689.082031 643.546875 685.347656 650.007812 C 681.609375 656.46875 679.742188 663.738281 679.742188 671.8125 C 679.742188 677.9375 681.191406 683.355469 684.085938 688.0625 C 686.976562 692.777344 691.117188 696.425781 696.5 699.015625 C 701.882812 701.605469 708.140625 702.902344 715.277344 702.902344 C 721.871094 702.902344 727.726562 701.875 732.839844 699.824219 C 737.953125 697.773438 742.429688 694.421875 746.265625 689.78125 L 734.457031 678.171875 C 729.675781 683.621094 723.921875 686.347656 717.195312 686.347656"/><path fill="#1DA579" d="M 807.234375 657.277344 L 780.082031 657.277344 L 785.332031 630.828125 L 765.34375 630.828125 L 751.210938 701.488281 L 771.199219 701.488281 L 776.648438 674.03125 L 803.804688 674.03125 L 798.351562 701.488281 L 818.339844 701.488281 L 832.472656 630.828125 L 812.484375 630.828125 Z"/><path fill="#1DA579" d="M 891.929688 674.082031 C 890.109375 677.816406 887.519531 680.796875 884.15625 683.015625 C 880.789062 685.238281 876.886719 686.347656 872.445312 686.347656 C 867.195312 686.347656 863.109375 684.917969 860.179688 682.058594 C 857.253906 679.199219 855.789062 675.378906 855.789062 670.601562 C 855.789062 666.09375 856.699219 661.96875 858.515625 658.234375 C 860.332031 654.5 862.921875 651.519531 866.289062 649.300781 C 869.652344 647.078125 873.554688 645.96875 877.996094 645.96875 C 883.246094 645.96875 887.335938 647.398438 890.261719 650.261719 C 893.191406 653.121094 894.652344 656.9375 894.652344 661.71875 C 894.652344 666.226562 893.746094 670.347656 891.929688 674.082031 M 898.339844 633.351562 C 893.054688 630.726562 886.847656 629.414062 879.714844 629.414062 C 871.167969 629.414062 863.546875 631.230469 856.851562 634.867188 C 850.152344 638.5 844.9375 643.546875 841.203125 650.007812 C 837.46875 656.46875 835.601562 663.734375 835.601562 671.8125 C 835.601562 677.867188 837.03125 683.253906 839.890625 687.964844 C 842.75 692.675781 846.820312 696.339844 852.105469 698.964844 C 857.386719 701.589844 863.597656 702.902344 870.730469 702.902344 C 879.273438 702.902344 886.898438 701.085938 893.59375 697.449219 C 900.289062 693.816406 905.503906 688.769531 909.238281 682.308594 C 912.976562 675.851562 914.84375 668.582031 914.84375 660.507812 C 914.84375 654.449219 913.410156 649.066406 910.550781 644.355469 C 907.691406 639.644531 903.621094 635.976562 898.339844 633.351562"/><path fill="#1DA579" d="M 917.972656 701.488281 L 937.957031 701.488281 L 952.089844 630.828125 L 932.101562 630.828125 Z"/><path fill="#1DA579" d="M 992.667969 686.347656 C 987.351562 686.347656 983.144531 684.902344 980.050781 682.007812 C 976.957031 679.113281 975.40625 675.277344 975.40625 670.5 C 975.40625 665.855469 976.367188 661.667969 978.285156 657.933594 C 980.203125 654.195312 982.878906 651.269531 986.308594 649.148438 C 989.742188 647.03125 993.710938 645.96875 998.222656 645.96875 C 1005.152344 645.96875 1010.335938 648.730469 1013.765625 654.246094 L 1028.203125 642.738281 C 1025.710938 638.5 1021.945312 635.21875 1016.894531 632.898438 C 1011.847656 630.578125 1006.058594 629.414062 999.535156 629.414062 C 990.917969 629.414062 983.246094 631.230469 976.519531 634.867188 C 969.789062 638.5 964.554688 643.546875 960.820312 650.007812 C 957.085938 656.46875 955.21875 663.738281 955.21875 671.8125 C 955.21875 677.9375 956.664062 683.355469 959.558594 688.0625 C 962.453125 692.777344 966.589844 696.425781 971.976562 699.015625 C 977.359375 701.605469 983.617188 702.902344 990.75 702.902344 C 997.347656 702.902344 1003.199219 701.875 1008.316406 699.824219 C 1013.429688 697.773438 1017.90625 694.421875 1021.742188 689.78125 L 1009.929688 678.171875 C 1005.152344 683.621094 999.398438 686.347656 992.667969 686.347656"/><path fill="#1DA579" d="M 1093.007812 646.273438 L 1096.136719 630.828125 L 1040.820312 630.828125 L 1026.6875 701.488281 L 1083.316406 701.488281 L 1086.546875 686.042969 L 1049.5 686.042969 L 1052.023438 673.125 L 1083.519531 673.125 L 1086.445312 658.183594 L 1055.050781 658.183594 L 1057.375 646.273438 Z"/></svg>`;
+
+@Injectable()
+export class AssetReceiptPdfService {
+  private readonly logger = new Logger(AssetReceiptPdfService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async generate(id: string): Promise<Buffer> {
+    const asset = await this.prisma.fixedAsset.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        branch: { select: { id: true, name: true } },
+        createdBy: { select: { id: true, name: true, email: true } },
+        postedBy: { select: { id: true, name: true } },
+      },
+    });
+    if (!asset) throw new NotFoundException('ไม่พบสินทรัพย์');
+    // Only POSTED/REVERSED assets carry a journal entry. The asset goods-receipt
+    // voucher certifies a capitalized acquisition recorded in the books —
+    // printing one for a DRAFT/DISPOSED/WRITTEN_OFF asset would attest to a
+    // recording that hasn't happened (or no longer reflects the acquisition).
+    if (asset.status !== 'POSTED' && asset.status !== 'REVERSED') {
+      throw new BadRequestException(
+        'สินทรัพย์ยังไม่ได้ลงบัญชี ไม่สามารถออกใบรับสินทรัพย์ได้',
+      );
+    }
+
+    const company = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE' },
+    });
+    if (!company) {
+      // Render still succeeds via the hardcoded fallback name, but a missing
+      // FINANCE CompanyInfo means every receipt mislabels the company — surface
+      // it so ops can fix the config instead of it failing silently.
+      this.logger.warn(
+        'CompanyInfo (companyCode=FINANCE) not found — asset receipt PDF will use the fallback company name',
+      );
+    }
+
+    const html = await this.renderHtml(asset, company);
+
+    const browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    try {
+      const page = await browser.newPage();
+      // Fonts are self-hosted (base64 data: URIs embedded in the HTML) so there
+      // are zero outbound network requests — wait only for the HTML to parse.
+      await page.setContent(html, {
+        waitUntil: 'domcontentloaded',
+        timeout: 10_000,
+      });
+      const pdf = await page.pdf({
+        format: 'A4',
+        margin: { top: '0', right: '0', bottom: '0', left: '0' },
+        printBackground: true,
+      });
+      return Buffer.from(pdf);
+    } finally {
+      await browser.close();
+    }
+  }
+
+  private async renderHtml(
+    asset: AssetWithRelations,
+    company:
+      | {
+          nameTh: string;
+          taxId: string | null;
+          address: string | null;
+          phone: string | null;
+        }
+      | null,
+  ): Promise<string> {
+    const verifyUrl = `https://bestchoicephone.app/assets/${asset.id}`;
+    const qrDataUrl = await QRCode.toDataURL(verifyUrl, {
+      margin: 0,
+      width: 260,
+      color: { dark: '#18181b', light: '#ffffff' },
+    });
+
+    const safe = {
+      companyName:
+        escapeHtml(company?.nameTh) || 'บริษัท เบสท์ช้อยส์ ไฟแนนท์ จำกัด',
+      companyAddress: escapeHtml(formatAddress(company?.address)),
+      companyPhone: escapeHtml(company?.phone),
+      taxId: escapeHtml(company?.taxId),
+      supplierName: escapeHtml(asset.supplierName || '—'),
+      supplierTaxId: escapeHtml(asset.supplierTaxId),
+      assetCode: escapeHtml(asset.assetCode),
+      docNo: escapeHtml(asset.docNo),
+      assetName: escapeHtml(asset.name),
+      categoryLabel: escapeHtml(CATEGORY_LABEL_TH[asset.category] || asset.category),
+      purchaseDateStr: fmtDateShort(asset.purchaseDate),
+      branchName: escapeHtml(asset.branch?.name),
+      taxInvoiceNo: escapeHtml(asset.taxInvoiceNo),
+      note: escapeHtml(asset.note),
+      preparerName: escapeHtml(asset.createdBy?.name) || 'ระบบ',
+      preparerSignName:
+        escapeHtml((asset.createdBy?.name || '').split(/\s+/)[0]) || 'ระบบ',
+      preparerEmail: escapeHtml(asset.createdBy?.email),
+      approverName: escapeHtml(asset.postedBy?.name),
+    };
+
+    const basePrice = Number(asset.basePrice);
+    const shippingCost = Number(asset.shippingCost);
+    const installationCost = Number(asset.installationCost);
+    const otherCapitalized = Number(asset.otherCapitalized);
+    const vatAmount = Number(asset.vatAmount);
+    const purchaseCost = Number(asset.purchaseCost);
+    const usefulLifeMonths = asset.usefulLifeMonths;
+    const hasVat = asset.hasVat;
+    // Grand total certified on the receipt = capitalized cost (purchaseCost,
+    // persisted at POST). VAT is shown for reference only — it is not part of
+    // the capitalized base (purchaseCost = basePrice + ship + install + other).
+    const thaiAmount = numberToThaiText(purchaseCost);
+    const isReversed = asset.status === 'REVERSED';
+
+    const embeddedFontCss = getEmbeddedFontCss(this.logger);
+
+    return `<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    /* Self-hosted fonts — no fonts.googleapis.com requests */
+    ${embeddedFontCss}
+    @page { size: A4; margin: 0; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --emerald-50:#ecfdf5; --emerald-100:#d1fae5; --emerald-700:#047857; --emerald-800:#065f46;
+      --zinc-200:#e4e4e7; --zinc-300:#d4d4d8; --zinc-400:#a1a1aa; --zinc-500:#71717a; --zinc-600:#52525b; --zinc-700:#3f3f46; --zinc-900:#18181b;
+      --red-500:#ef4444; --red-600:#dc2626;
+    }
+    body { font-family: 'IBM Plex Sans Thai', system-ui, -apple-system, sans-serif; color: var(--zinc-900); font-size: 9.5pt; line-height: 1.45; padding: 11mm 12mm 10mm; }
+    .header { display:flex; justify-content:space-between; align-items:flex-start; padding-bottom:10px; border-bottom:1.5px solid var(--zinc-300); }
+    .logo-block svg { height: 32px; width: auto; }
+    .doc-title { font-size:20pt; font-weight:700; color:var(--emerald-700); line-height:1; text-align:right; letter-spacing:-0.01em; }
+    .doc-title .en { display:block; font-size:9pt; font-weight:600; color:var(--zinc-500); margin-top:3px; letter-spacing:0.04em; }
+
+    .parties { display:grid; grid-template-columns: minmax(0, 1fr) 220px; gap:14px; padding:12px 0; border-bottom:1px solid var(--zinc-200); margin-bottom:12px; }
+    .party-row { display:grid; grid-template-columns: 86px 1fr; gap:6px; margin-bottom:4px; align-items:start; font-size:9.5pt; }
+    .party-label { color:var(--zinc-900); font-weight:700; white-space:nowrap; }
+    .party-name { font-weight:600; }
+    .party-divider { margin:10px 0; border:0; border-top:1px solid var(--zinc-200); }
+    .meta-card { background:var(--emerald-50); border:1px solid var(--emerald-100); border-radius:6px; padding:10px 14px; font-size:9pt; align-self:start; }
+    .meta-row { display:flex; justify-content:space-between; padding:3px 0; gap:8px; }
+    .meta-label { color:var(--emerald-800); font-weight:600; white-space:nowrap; }
+    .meta-value { color:var(--zinc-900); font-family:'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace; font-size:8.5pt; font-weight:500; text-align:right; word-break:break-all; }
+
+    .details-section { padding:0 0 12px; margin-bottom:12px; border-bottom:1px solid var(--zinc-200); }
+    .details-grid { display:grid; grid-template-columns:max-content 1fr; column-gap:18px; row-gap:5px; font-size:9.5pt; margin-top:4px; }
+    .details-grid .dlabel { color:var(--zinc-700); font-weight:600; white-space:nowrap; }
+    .details-grid .dval { color:var(--zinc-900); }
+
+    table.items { width:100%; border-collapse:collapse; font-size:9pt; }
+    table.items thead th { text-align:left; padding:6px 8px; background:var(--emerald-50); color:var(--emerald-800); font-size:8.5pt; font-weight:600; border-bottom:1.5px solid var(--emerald-700); }
+    table.items thead th.right { text-align:right; }
+    table.items tbody td { padding:8px; border-bottom:1px solid var(--zinc-200); vertical-align:top; font-variant-numeric:tabular-nums; }
+    table.items tbody td.right { text-align:right; }
+    table.items td.no { color:var(--zinc-500); width:22px; }
+    .item-name { font-weight:600; }
+
+    .summary { display:grid; grid-template-columns:1fr 1fr; gap:14px; padding:12px 0; margin-bottom:12px; border-bottom:1px solid var(--zinc-200); }
+    .summary-section { display:grid; grid-template-columns:18px 1fr; gap:8px; align-items:start; }
+    .summary-section .icon { width:16px; height:16px; color:var(--zinc-700); margin-top:2px; }
+    .breakdown { display:grid; grid-template-columns:max-content 1fr auto; column-gap:18px; row-gap:4px; font-size:9.5pt; }
+    .breakdown .label { color:var(--zinc-700); }
+    .breakdown .label.bold { font-weight:600; color:var(--zinc-900); }
+    .breakdown .text { color:var(--zinc-600); font-style:italic; font-size:9pt; }
+    .breakdown .num { text-align:right; font-variant-numeric:tabular-nums; color:var(--zinc-900); }
+    .grand-card { background:var(--emerald-50); border-radius:8px; padding:10px 14px; text-align:center; }
+    .grand-card .label { color:var(--emerald-800); font-size:9pt; font-weight:600; margin-bottom:3px; }
+    .grand-card .amount { color:var(--emerald-700); font-size:18pt; font-weight:700; line-height:1; font-variant-numeric:tabular-nums; }
+    .grand-card .amount-suffix { color:var(--emerald-700); font-size:11pt; font-weight:500; margin-left:4px; }
+    .summary-aux { margin-top:10px; display:grid; grid-template-columns:1fr auto; row-gap:4px; column-gap:18px; font-size:9.5pt; }
+    .summary-aux .label { color:var(--zinc-700); }
+    .summary-aux .num { text-align:right; font-variant-numeric:tabular-nums; }
+
+    .notes-section { padding-bottom:10px; margin-bottom:12px; font-size:9pt; border-bottom:1px solid var(--zinc-200); }
+    .sec-title { display:flex; align-items:center; gap:8px; font-size:10pt; font-weight:700; color:var(--zinc-900); margin-bottom:6px; }
+    .sec-title .icon-pill { width:22px; height:22px; background:var(--zinc-900); color:#fff; border-radius:6px; display:flex; align-items:center; justify-content:center; }
+    .sec-title .icon-pill svg { width:13px; height:13px; }
+    .notes-section .body { color:var(--zinc-600); min-height:10px; }
+
+    .approval { display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px; align-items:start; margin-top:8px; page-break-inside:avoid; break-inside:avoid; }
+    .qr-pane { text-align:center; }
+    .qr-caption-top { font-size:9pt; color:var(--zinc-700); margin-bottom:5px; }
+    .qr-pane img { width:104px; height:104px; }
+    .sig-block { text-align:left; }
+    .sig-role { font-size:9.5pt; color:var(--zinc-900); font-weight:600; margin-bottom:2px; }
+    .sig-handwriting { font-family:'Sriracha', 'Apple Chancery', 'Brush Script MT', cursive; font-size:20pt; color:var(--zinc-600); line-height:1; transform:rotate(-3deg); transform-origin:left center; display:inline-block; opacity:0.85; margin-top:4px; min-height:24px; }
+    .sig-rule { width:180px; border-top:1px dotted var(--zinc-300); margin:14px 0 5px; }
+    .sig-name { font-size:10pt; font-weight:700; color:var(--zinc-900); }
+    .sig-date { font-size:9pt; color:var(--zinc-500); margin-top:1px; font-variant-numeric:tabular-nums; }
+
+    .void-badge { display:inline-block; margin:10px 0 0; padding:4px 12px; border:1.5px solid var(--red-600); border-radius:6px; color:var(--red-600); font-weight:700; font-size:10pt; letter-spacing:0.02em; }
+    .void-overlay { position:fixed; top:50%; left:50%; transform:translate(-50%,-50%) rotate(-15deg); font-size:70pt; font-weight:900; color:rgba(220,38,38,0.16); letter-spacing:0.08em; pointer-events:none; text-align:center; }
+  </style>
+</head>
+<body>
+  ${isReversed ? `<div class="void-overlay">กลับรายการแล้ว</div>` : ''}
+
+  <!-- Header: Logo + Title -->
+  <div class="header">
+    <div class="logo-block">${BESTCHOICE_LOGO_SVG}</div>
+    <div class="doc-title">ใบรับสินทรัพย์<span class="en">ASSET GOODS RECEIPT</span></div>
+  </div>
+
+  ${isReversed ? `<div class="void-badge">กลับรายการแล้ว</div>` : ''}
+
+  <!-- Parties + meta -->
+  <div class="parties">
+    <div>
+      <div class="party-row"><span class="party-label">ผู้รับสินทรัพย์ :</span><span class="party-name">${safe.companyName}</span></div>
+      ${safe.companyAddress ? `<div class="party-row"><span class="party-label">ที่อยู่ :</span><span>${safe.companyAddress}</span></div>` : ''}
+      ${safe.taxId ? `<div class="party-row"><span class="party-label">เลขที่ภาษี :</span><span>${safe.taxId}</span></div>` : ''}
+
+      <hr class="party-divider"/>
+
+      <div class="party-row"><span class="party-label">ผู้ขาย/ผู้ส่งมอบ :</span><span class="party-name">${safe.supplierName}</span></div>
+      ${safe.supplierTaxId ? `<div class="party-row"><span class="party-label">เลขที่ภาษี :</span><span>${safe.supplierTaxId}</span></div>` : ''}
+      ${safe.branchName ? `<div class="party-row"><span class="party-label">สาขา/สถานที่ :</span><span>${safe.branchName}</span></div>` : ''}
+    </div>
+    <div>
+      <div class="meta-card">
+        <div class="meta-row"><span class="meta-label">รหัสสินทรัพย์ :</span><span class="meta-value">${safe.assetCode}</span></div>
+        <div class="meta-row"><span class="meta-label">เลขที่เอกสาร :</span><span class="meta-value">${safe.docNo}</span></div>
+        <div class="meta-row"><span class="meta-label">วันที่รับสินทรัพย์ :</span><span class="meta-value">${safe.purchaseDateStr}</span></div>
+        ${safe.taxInvoiceNo ? `<div class="meta-row"><span class="meta-label">เลขใบกำกับ :</span><span class="meta-value">${safe.taxInvoiceNo}</span></div>` : ''}
+      </div>
+    </div>
+  </div>
+
+  <!-- Asset details -->
+  <div class="details-section">
+    <div class="sec-title">
+      <span class="icon-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 7h-9M14 17H5M17 17a3 3 0 1 0 6 0 3 3 0 0 0-6 0M7 7a3 3 0 1 0-6 0 3 3 0 0 0 6 0"/></svg></span>
+      <span>รายละเอียดสินทรัพย์</span>
+    </div>
+    <div class="details-grid">
+      <span class="dlabel">ชื่อสินทรัพย์</span><span class="dval">${safe.assetName}</span>
+      <span class="dlabel">หมวดสินทรัพย์</span><span class="dval">${safe.categoryLabel}</span>
+      <span class="dlabel">อายุการใช้งาน</span><span class="dval">${usefulLifeMonths} เดือน</span>
+    </div>
+  </div>
+
+  <!-- Cost breakdown table -->
+  <table class="items">
+    <thead>
+      <tr>
+        <th></th>
+        <th>รายการต้นทุน</th>
+        <th class="right">จำนวนเงิน</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="no">1.</td>
+        <td><span class="item-name">ราคาทุน (มูลค่าซื้อ)</span></td>
+        <td class="right">${fmtMoney(basePrice)}</td>
+      </tr>
+      ${shippingCost > 0 ? `<tr><td class="no">2.</td><td><span class="item-name">ค่าขนส่ง</span></td><td class="right">${fmtMoney(shippingCost)}</td></tr>` : ''}
+      ${installationCost > 0 ? `<tr><td class="no">3.</td><td><span class="item-name">ค่าติดตั้ง</span></td><td class="right">${fmtMoney(installationCost)}</td></tr>` : ''}
+      ${otherCapitalized > 0 ? `<tr><td class="no">4.</td><td><span class="item-name">ค่าใช้จ่ายอื่นๆ ที่รวมเป็นต้นทุน</span></td><td class="right">${fmtMoney(otherCapitalized)}</td></tr>` : ''}
+    </tbody>
+  </table>
+
+  <!-- Summary -->
+  <div class="summary">
+    <div>
+      <div class="summary-section">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+        <div>
+          <div style="font-weight:700; margin-bottom:4px;">สรุป</div>
+          <div class="breakdown">
+            <span class="label">ราคาทุน</span><span></span><span class="num">${fmtMoney(basePrice)} บาท</span>
+            ${shippingCost > 0 ? `<span class="label">ค่าขนส่ง</span><span></span><span class="num">${fmtMoney(shippingCost)} บาท</span>` : ''}
+            ${installationCost > 0 ? `<span class="label">ค่าติดตั้ง</span><span></span><span class="num">${fmtMoney(installationCost)} บาท</span>` : ''}
+            ${otherCapitalized > 0 ? `<span class="label">ค่าใช้จ่ายอื่นๆ</span><span></span><span class="num">${fmtMoney(otherCapitalized)} บาท</span>` : ''}
+            ${hasVat ? `<span class="label">ภาษีมูลค่าเพิ่ม 7%</span><span></span><span class="num">${fmtMoney(vatAmount)} บาท</span>` : ''}
+            <span class="label bold">มูลค่าต้นทุนรวม</span>
+            <span class="text">${thaiAmount}</span>
+            <span></span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div class="grand-card">
+        <div class="label">มูลค่าต้นทุนรวม</div>
+        <div class="amount">${fmtMoney(purchaseCost)}<span class="amount-suffix">บาท</span></div>
+      </div>
+      <div class="summary-aux">
+        <span class="label">มูลค่าต้นทุนที่บันทึกเป็นสินทรัพย์</span><span class="num">${fmtMoney(purchaseCost)} บาท</span>
+        ${hasVat ? `<span class="label">ภาษีมูลค่าเพิ่ม 7%</span><span class="num">${fmtMoney(vatAmount)} บาท</span>` : ''}
+      </div>
+    </div>
+  </div>
+
+  <!-- Notes -->
+  <div class="notes-section">
+    <div class="sec-title">
+      <span class="icon-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+      <span>หมายเหตุ</span>
+    </div>
+    <div class="body">${safe.note || '&nbsp;'}</div>
+  </div>
+
+  <!-- Signatures (3-col): ผู้จัดทำ | ผู้ตรวจรับ/ผู้อนุมัติ | ผู้ส่งมอบ -->
+  <div class="approval">
+    <div class="sig-block">
+      <div class="sig-role">ผู้จัดทำ</div>
+      <div class="sig-handwriting">${safe.preparerSignName}</div>
+      <div class="sig-rule"></div>
+      <div class="sig-name">${safe.preparerName}</div>
+      <div class="sig-date">${safe.purchaseDateStr}</div>
+    </div>
+    <div class="sig-block">
+      <div class="sig-role">ผู้ตรวจรับ/ผู้อนุมัติ</div>
+      <div class="sig-handwriting">${safe.approverName ? escapeHtml((asset.postedBy?.name || '').split(/\s+/)[0]) : '&nbsp;'}</div>
+      <div class="sig-rule"></div>
+      <div class="sig-name">${safe.approverName || '&nbsp;'}</div>
+      <div class="sig-date">${safe.approverName ? safe.purchaseDateStr : '&nbsp;'}</div>
+    </div>
+    <div class="sig-block">
+      <div class="sig-role">ผู้ส่งมอบ</div>
+      <div class="sig-handwriting">&nbsp;</div>
+      <div class="sig-rule"></div>
+      <div class="sig-name">${safe.supplierName}</div>
+      <div class="sig-date">${safe.purchaseDateStr}</div>
+    </div>
+  </div>
+
+  <!-- QR verify -->
+  <div class="qr-pane" style="margin-top:14px;">
+    <div class="qr-caption-top">สแกนเพื่อตรวจสอบเอกสาร</div>
+    <img src="${qrDataUrl}" alt="QR"/>
+  </div>
+</body>
+</html>`;
+  }
+}

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { ExpenseDocumentsController } from '../expense-documents.controller';
 import { ExpenseDocumentsService } from '../expense-documents.service';
+import { ExpenseVoucherPdfService } from '../services/expense-voucher-pdf.service';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { PrismaService } from '../../../prisma/prisma.service';
@@ -8,6 +9,7 @@ import { PrismaService } from '../../../prisma/prisma.service';
 describe('ExpenseDocumentsController', () => {
   let controller: ExpenseDocumentsController;
   let service: jest.Mocked<Partial<ExpenseDocumentsService>>;
+  let voucherPdf: jest.Mocked<Partial<ExpenseVoucherPdfService>>;
 
   beforeEach(async () => {
     service = {
@@ -20,6 +22,7 @@ describe('ExpenseDocumentsController', () => {
         accrualUnpaidTotal: '0.00',
       }),
       findOne: jest.fn().mockResolvedValue({ id: 'doc-1' }),
+      getAuditTrail: jest.fn().mockResolvedValue([]),
       update: jest.fn().mockResolvedValue({ id: 'doc-1' }),
       post: jest.fn().mockResolvedValue({ entryNo: 'JE-1' }),
       voidDocument: jest.fn().mockResolvedValue({ id: 'doc-1' }),
@@ -29,10 +32,15 @@ describe('ExpenseDocumentsController', () => {
       createSettlement: jest.fn().mockResolvedValue({ id: 'se-1', number: 'SE-20260510-0001' }),
       previewJe: jest.fn().mockResolvedValue({ flow: 'expense-accrual', lines: [], totals: { balanced: true } }),
     };
+    voucherPdf = {
+      // Resolve a fake PDF Buffer — do NOT launch real puppeteer in the test.
+      generate: jest.fn().mockResolvedValue(Buffer.from('%PDF-fake')),
+    };
     const moduleRef = await Test.createTestingModule({
       controllers: [ExpenseDocumentsController],
       providers: [
         { provide: ExpenseDocumentsService, useValue: service },
+        { provide: ExpenseVoucherPdfService, useValue: voucherPdf },
         // D1.3.3.1 — ExportEnabledGuard depends on PrismaService. Provide a
         // minimal stub returning `null` for systemConfig.findFirst so the
         // export flag defaults to enabled (guard allows the request).
@@ -86,6 +94,29 @@ describe('ExpenseDocumentsController', () => {
   it('GET /:id calls findOne', async () => {
     await controller.findOne('doc-1');
     expect(service.findOne).toHaveBeenCalledWith('doc-1');
+  });
+
+  it('GET /:id/audit calls getAuditTrail (feeds InternalControlActionBar timeline)', async () => {
+    await controller.getAuditTrail('doc-1');
+    expect(service.getAuditTrail).toHaveBeenCalledWith('doc-1');
+  });
+
+  it('GET /:id/voucher.pdf delegates to ExpenseVoucherPdfService + sets PDF headers', async () => {
+    const headers: Record<string, string> = {};
+    const res = {
+      set: jest.fn((h: Record<string, string>) => {
+        Object.assign(headers, h);
+      }),
+      send: jest.fn(),
+    };
+    await controller.getVoucherPdf('doc-1', res as never);
+    expect(voucherPdf.generate).toHaveBeenCalledWith('doc-1');
+    expect(headers['Content-Type']).toBe('application/pdf');
+    expect(headers['Content-Disposition']).toBe(
+      'inline; filename="expense-voucher-doc-1.pdf"',
+    );
+    expect(headers['Content-Length']).toBe(Buffer.from('%PDF-fake').length.toString());
+    expect(res.send).toHaveBeenCalledWith(Buffer.from('%PDF-fake'));
   });
 
   it('POST /:id/post fires post', async () => {

--- a/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/expense-documents.controller.spec.ts
@@ -96,9 +96,10 @@ describe('ExpenseDocumentsController', () => {
     expect(service.findOne).toHaveBeenCalledWith('doc-1');
   });
 
-  it('GET /:id/audit calls getAuditTrail (feeds InternalControlActionBar timeline)', async () => {
-    await controller.getAuditTrail('doc-1');
-    expect(service.getAuditTrail).toHaveBeenCalledWith('doc-1');
+  it('GET /:id/audit calls getAuditTrail with user (timeline; branch-scoped)', async () => {
+    const user = { id: 'u', branchId: 'b1', role: 'OWNER' };
+    await controller.getAuditTrail('doc-1', user as never);
+    expect(service.getAuditTrail).toHaveBeenCalledWith('doc-1', user);
   });
 
   it('GET /:id/voucher.pdf delegates to ExpenseVoucherPdfService + sets PDF headers', async () => {

--- a/apps/api/src/modules/expense-documents/dto/void-expense.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/void-expense.dto.ts
@@ -48,6 +48,23 @@ export class VoidExpenseDocumentDto {
   reasonDetail?: string;
 
   /**
+   * Structured reverse reason from the shared InternalControlActionBar
+   * (`onReverse({ reasonId, reasonLabel, note })`). Optional + backward
+   * compatible. When present they are stamped into the AuditLog as
+   * `reverseReasonLabel` / `reverseNote` so the timeline renders the
+   * admin-managed label + free-text note (parity with Other Income / Asset).
+   */
+  @IsString()
+  @MaxLength(200)
+  @IsOptional()
+  reasonLabel?: string;
+
+  @IsString()
+  @MaxLength(500)
+  @IsOptional()
+  note?: string;
+
+  /**
    * ISO date string. When set, the reversal JE postedAt uses this date
    * (V19 period-open guard still applies). Omitted = today BKK noon.
    */

--- a/apps/api/src/modules/expense-documents/expense-documents.controller.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.controller.ts
@@ -8,8 +8,10 @@ import {
   Body,
   Query,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { BranchGuard } from '../auth/guards/branch.guard';
@@ -18,6 +20,7 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { PostPermissionGuard } from './post-permission.guard';
 import { ReversePermissionGuard } from './reverse-permission.guard';
 import { ExpenseDocumentsService } from './expense-documents.service';
+import { ExpenseVoucherPdfService } from './services/expense-voucher-pdf.service';
 import { CreateExpenseDocumentDto } from './dto/create.dto';
 import { UpdateExpenseDocumentDto } from './dto/update.dto';
 import { ListExpenseDocumentsQueryDto } from './dto/list-query.dto';
@@ -31,7 +34,10 @@ import { hasCrossBranchAccess } from '../auth/branch-access.util';
 @Controller('expense-documents')
 @UseGuards(JwtAuthGuard, RolesGuard, BranchGuard)
 export class ExpenseDocumentsController {
-  constructor(private readonly service: ExpenseDocumentsService) {}
+  constructor(
+    private readonly service: ExpenseDocumentsService,
+    private readonly voucherPdf: ExpenseVoucherPdfService,
+  ) {}
 
   @Post()
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
@@ -162,6 +168,30 @@ export class ExpenseDocumentsController {
     return this.service.getCreditNoteCap(id);
   }
 
+  // Per-document audit timeline — feeds the shared InternalControlActionBar
+  // timeline on the ExpenseDetailPage (mirrors GET /other-income/:id/audit).
+  @Get(':id/audit')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getAuditTrail(@Param('id') id: string) {
+    return this.service.getAuditTrail(id);
+  }
+
+  // ใบสำคัญจ่าย (Payment Voucher) PDF — mirrors GET /other-income/:id/receipt.pdf.
+  // Two-segment route declared BEFORE the generic :id route (module convention:
+  // :id/sub routes precede :id). No ExportEnabledGuard — this module does not
+  // wire the export-gate pattern (unlike other-income).
+  @Get(':id/voucher.pdf')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  async getVoucherPdf(@Param('id') id: string, @Res() res: Response) {
+    const pdf = await this.voucherPdf.generate(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `inline; filename="expense-voucher-${id}.pdf"`,
+      'Content-Length': pdf.length.toString(),
+    });
+    res.send(pdf);
+  }
+
   @Get(':id')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   findOne(@Param('id') id: string) {
@@ -237,14 +267,16 @@ export class ExpenseDocumentsController {
    * D1.3.2.4 — Reverse / void a posted doc.
    *
    * Class-level guards (JwtAuthGuard, RolesGuard, BranchGuard) run first.
-   * Method-level `@Roles(...)` matches the SUPERSET of any value that the
-   * dynamic SystemConfig key `reverse_permission` may select (OWNER +
-   * FINANCE_MANAGER). The `ReversePermissionGuard` then narrows
-   * per-request. Default `reverse_permission = 'OWNER+FINANCE_MANAGER'`
-   * preserves current behavior.
+   * Method-level `@Roles(...)` is the COARSE SUPERSET of any role the dynamic
+   * SystemConfig key `reverse_permission` may select — OWNER + FINANCE_MANAGER
+   * + ACCOUNTANT — so RolesGuard never pre-blocks a role the dynamic guard
+   * would allow (e.g. ACCOUNTANT under the 'OWNER+FINANCE_MANAGER+ACCOUNTANT'
+   * or CUSTOM modes). `ReversePermissionGuard` then narrows per-request; the
+   * default `reverse_permission = 'OWNER+FINANCE_MANAGER'` still rejects
+   * ACCOUNTANT, preserving current behavior.
    */
   @Post(':id/void')
-  @Roles('OWNER', 'FINANCE_MANAGER')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   @UseGuards(ReversePermissionGuard)
   void(
     @Param('id') id: string,

--- a/apps/api/src/modules/expense-documents/expense-documents.controller.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.controller.ts
@@ -172,8 +172,11 @@ export class ExpenseDocumentsController {
   // timeline on the ExpenseDetailPage (mirrors GET /other-income/:id/audit).
   @Get(':id/audit')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
-  getAuditTrail(@Param('id') id: string) {
-    return this.service.getAuditTrail(id);
+  getAuditTrail(
+    @Param('id') id: string,
+    @CurrentUser() user: { id: string; branchId?: string | null; role: string },
+  ) {
+    return this.service.getAuditTrail(id, user);
   }
 
   // ใบสำคัญจ่าย (Payment Voucher) PDF — mirrors GET /other-income/:id/receipt.pdf.

--- a/apps/api/src/modules/expense-documents/expense-documents.module.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.module.ts
@@ -15,6 +15,7 @@ import { DocNumberService } from './services/doc-number.service';
 import { StatusTransitionService } from './services/status-transition.service';
 import { LineAggregatorService } from './services/line-aggregator.service';
 import { JePreviewService } from './services/je-preview.service';
+import { ExpenseVoucherPdfService } from './services/expense-voucher-pdf.service';
 import { PettyCashService } from './services/petty-cash.service';
 import { PayrollCustomService } from './services/payroll-custom.service';
 import { ExpenseRecurringCron } from './crons/expense-recurring.cron';
@@ -48,6 +49,7 @@ import { ReversePermissionGuard } from './reverse-permission.guard';
     StatusTransitionService,
     LineAggregatorService,
     JePreviewService,
+    ExpenseVoucherPdfService,
     PettyCashService,
     PayrollCustomService,
     ExpenseRecurringCron,

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -1813,6 +1813,28 @@ export class ExpenseDocumentsService implements OnModuleInit {
     return this.jePreview.preview(dto, accountNames);
   }
 
+  // ─── Audit trail ─────────────────────────────────────────────────────
+  // Immutable event timeline for one expense document, consumed by the shared
+  // InternalControlActionBar audit timeline on the ExpenseDetailPage. Mirrors
+  // OtherIncomeService.getAuditTrail. Both entity casings are queried for
+  // resilience (services write 'expense_document'; defensive include of the
+  // PascalCase form in case a future writer / interceptor differs).
+  async getAuditTrail(id: string) {
+    // Verify the document exists (throws on unknown / soft-deleted id).
+    await this.findOne(id);
+    return this.prisma.auditLog.findMany({
+      where: {
+        entityId: id,
+        entity: { in: ['expense_document', 'ExpenseDocument'] },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+    });
+  }
+
   // ─── Find one ────────────────────────────────────────────────────────
   // I5 — include type-specific detail so single-doc views (PaymentVoucher,
   // CN view, payroll view, SE view) don't need a follow-up roundtrip. The
@@ -2610,6 +2632,10 @@ export class ExpenseDocumentsService implements OnModuleInit {
             reverseDate: reverseAt.toISOString(),
             reasonCode: dto.reasonCode ?? null,
             reasonDetail: dto.reasonDetail ?? null,
+            // Structured reverse reason — read by the shared timeline's
+            // mapAuditEvents (parity with other-income / asset modules).
+            reverseReasonLabel: dto.reasonLabel ?? null,
+            reverseNote: dto.note ?? null,
             documentNumber: doc.number,
             documentType: doc.documentType,
           },

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -1819,9 +1819,23 @@ export class ExpenseDocumentsService implements OnModuleInit {
   // OtherIncomeService.getAuditTrail. Both entity casings are queried for
   // resilience (services write 'expense_document'; defensive include of the
   // PascalCase form in case a future writer / interceptor differs).
-  async getAuditTrail(id: string) {
+  async getAuditTrail(
+    id: string,
+    user?: { branchId?: string | null; role?: string | null },
+  ) {
     // Verify the document exists (throws on unknown / soft-deleted id).
-    await this.findOne(id);
+    const doc = await this.findOne(id);
+    // Branch scoping (mirrors create()/list() guards) — a non-cross-branch role
+    // may only read the audit trail of documents in its OWN branch, so a
+    // BRANCH_MANAGER can't pull another branch's audit history by guessing an id.
+    if (
+      user &&
+      !hasCrossBranchAccess({ role: user.role ?? '' }) &&
+      doc.branchId &&
+      doc.branchId !== user.branchId
+    ) {
+      throw new ForbiddenException('ไม่มีสิทธิ์เข้าถึงเอกสารของสาขาอื่น');
+    }
     return this.prisma.auditLog.findMany({
       where: {
         entityId: id,

--- a/apps/api/src/modules/expense-documents/services/expense-voucher-pdf.service.ts
+++ b/apps/api/src/modules/expense-documents/services/expense-voucher-pdf.service.ts
@@ -302,10 +302,14 @@ export class ExpenseVoucherPdfService {
     const whtAmount = Number(doc.withholdingTax);
     const totalAmount = Number(doc.totalAmount);
     // net_payment is the cash actually paid out to the vendor (total − WHT
-    // withheld). Falls back to the arithmetic when the column is null on
-    // legacy rows.
-    const netPaid =
-      doc.netPayment != null ? Number(doc.netPayment) : totalAmount - whtAmount;
+    // withheld). Compute the legacy-null fallback with Prisma.Decimal so the
+    // satang in numberToThaiText() never drifts from a float subtraction —
+    // convert to Number once, at the end, for display only.
+    const netPaidDecimal =
+      doc.netPayment != null
+        ? doc.netPayment
+        : new Prisma.Decimal(doc.totalAmount).minus(doc.withholdingTax);
+    const netPaid = Number(netPaidDecimal);
     const thaiAmount = numberToThaiText(netPaid);
     const isVoided = doc.status === 'VOIDED';
 

--- a/apps/api/src/modules/expense-documents/services/expense-voucher-pdf.service.ts
+++ b/apps/api/src/modules/expense-documents/services/expense-voucher-pdf.service.ts
@@ -1,0 +1,538 @@
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as puppeteer from 'puppeteer';
+import * as QRCode from 'qrcode';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Self-hosted fonts (mirrors other-income/services/receipt-pdf.service.ts — Fix C15).
+//
+// The four IBM Plex Sans Thai weights + Sriracha TTFs were committed once to
+// `src/modules/other-income/assets/fonts/` (OFL license). We embed them as
+// base64 data: URIs at boot time (cached in module scope) so puppeteer can wait
+// on `domcontentloaded` only — zero outbound network requests during render.
+//
+// The voucher reuses the EXACT same committed font files as the OI receipt; no
+// duplicate copy is added under expense-documents/.
+// ──────────────────────────────────────────────────────────────────────────────
+
+const FONT_DIR_CANDIDATES = [
+  // Dev: src/modules/other-income/assets/fonts/*.ttf (shared with OI receipt)
+  path.join(__dirname, '..', '..', 'other-income', 'assets', 'fonts'),
+  // Prod (nest build): dist/src/modules/other-income/assets/fonts/*.ttf
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'src',
+    'modules',
+    'other-income',
+    'assets',
+    'fonts',
+  ),
+  // Fallback when working directory matters
+  path.join(process.cwd(), 'src', 'modules', 'other-income', 'assets', 'fonts'),
+  path.join(
+    process.cwd(),
+    'apps',
+    'api',
+    'src',
+    'modules',
+    'other-income',
+    'assets',
+    'fonts',
+  ),
+];
+
+interface FontDef {
+  family: string;
+  weight: number;
+  file: string;
+}
+
+const FONT_FILES: FontDef[] = [
+  { family: 'IBM Plex Sans Thai', weight: 400, file: 'ibmplexsansthai-400.ttf' },
+  { family: 'IBM Plex Sans Thai', weight: 500, file: 'ibmplexsansthai-500.ttf' },
+  { family: 'IBM Plex Sans Thai', weight: 600, file: 'ibmplexsansthai-600.ttf' },
+  { family: 'IBM Plex Sans Thai', weight: 700, file: 'ibmplexsansthai-700.ttf' },
+  { family: 'Sriracha', weight: 400, file: 'sriracha-400.ttf' },
+];
+
+let cachedFontCss: string | null = null;
+
+/** Build the @font-face block once at first call, cache for the process lifetime. */
+function getEmbeddedFontCss(logger: Logger): string {
+  if (cachedFontCss !== null) return cachedFontCss;
+
+  const fontsDir =
+    FONT_DIR_CANDIDATES.find((dir) =>
+      fs.existsSync(path.join(dir, FONT_FILES[0].file)),
+    ) ?? FONT_DIR_CANDIDATES[0];
+
+  const blocks: string[] = [];
+  for (const f of FONT_FILES) {
+    const full = path.join(fontsDir, f.file);
+    try {
+      const b64 = fs.readFileSync(full).toString('base64');
+      blocks.push(
+        `@font-face{font-family:'${f.family}';font-style:normal;font-weight:${f.weight};font-display:block;` +
+          `src:url(data:font/ttf;base64,${b64}) format('truetype');}`,
+      );
+    } catch (err) {
+      logger.warn(
+        `Could not embed font ${f.file} (looked in ${fontsDir}): ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  cachedFontCss = blocks.join('\n');
+  return cachedFontCss;
+}
+
+type ExpenseDocWithLines = Prisma.ExpenseDocumentGetPayload<{
+  include: {
+    expenseDetail: { include: { lines: true } };
+    branch: { select: { id: true; name: true } };
+    createdBy: { select: { id: true; name: true; email: true } };
+    approvedBy: { select: { id: true; name: true } };
+  };
+}>;
+
+function fmtDateShort(d: Date | string | null | undefined): string {
+  if (!d) return '—';
+  const dt = typeof d === 'string' ? new Date(d) : d;
+  if (isNaN(dt.getTime())) return '—';
+  // Pin to Asia/Bangkok so server TZ (Cloud Run UTC) doesn't shift the date
+  // by 1 day for late-evening BKK timestamps, and render year in Buddhist
+  // Era (พ.ศ.) — Thai accounting documents use พ.ศ.
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Bangkok',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).formatToParts(dt);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '';
+  const year = parseInt(get('year'), 10) + 543;
+  return `${get('day')}/${get('month')}/${year}`;
+}
+
+function fmtMoney(v: unknown): string {
+  const n = typeof v === 'string' ? parseFloat(v) : Number(v);
+  if (!isFinite(n)) return '0.00';
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function escapeHtml(text: string | null | undefined): string {
+  if (!text) return '';
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function formatAddress(value: string | null | undefined): string {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{')) return trimmed;
+  try {
+    const addr = JSON.parse(trimmed) as Record<string, string | undefined>;
+    if (typeof addr !== 'object' || addr === null) return trimmed;
+    if (addr.raw && !addr.province) return addr.raw;
+    const parts: string[] = [];
+    if (addr.houseNo) parts.push(`เลขที่ ${addr.houseNo}`);
+    if (addr.moo) parts.push(`หมู่ ${addr.moo}`);
+    if (addr.village) parts.push(`หมู่บ้าน ${addr.village}`);
+    if (addr.soi) parts.push(`ซอย ${addr.soi}`);
+    if (addr.road) parts.push(`ถนน ${addr.road}`);
+    if (addr.subdistrict) parts.push(`ตำบล${addr.subdistrict}`);
+    if (addr.district) parts.push(`อำเภอ${addr.district}`);
+    if (addr.province) parts.push(`จังหวัด${addr.province}`);
+    if (addr.postalCode) parts.push(addr.postalCode);
+    return parts.length > 0 ? parts.join(' ') : trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/** Convert a number to its Thai-baht spelling. Handles negative + millions. */
+function numberToThaiText(num: number): string {
+  if (!isFinite(num)) return '(จำนวนเงินไม่ถูกต้อง)';
+  if (num < 0) return `ลบ${numberToThaiText(-num)}`;
+  if (num === 0) return 'ศูนย์บาทถ้วน';
+  // Cap at < 1e12 (999,999,999,999.99 baht) — extending readGroup beyond 6 digits
+  // would mis-spell the ล้านล้าน group; very unlikely for an expense doc.
+  if (num >= 1e12) return '(จำนวนเงินเกินขีดจำกัด)';
+  const digits = ['', 'หนึ่ง', 'สอง', 'สาม', 'สี่', 'ห้า', 'หก', 'เจ็ด', 'แปด', 'เก้า'];
+  const places = ['', 'สิบ', 'ร้อย', 'พัน', 'หมื่น', 'แสน'];
+  const readGroup = (n: number): string => {
+    if (n === 0) return '';
+    let s = '';
+    const str = String(Math.floor(n));
+    const len = str.length;
+    for (let i = 0; i < len; i++) {
+      const d = parseInt(str[i]);
+      const place = len - i - 1;
+      if (d === 0) continue;
+      if (place === 1 && d === 1) s += 'สิบ';
+      else if (place === 1 && d === 2) s += 'ยี่สิบ';
+      else if (place === 0 && d === 1 && len > 1) s += 'เอ็ด';
+      else s += digits[d] + places[place];
+    }
+    return s;
+  };
+  let text = '';
+  let remaining = Math.floor(num);
+  if (remaining >= 1000000) {
+    const millions = Math.floor(remaining / 1000000);
+    text += readGroup(millions) + 'ล้าน';
+    remaining = remaining - millions * 1000000;
+  }
+  if (remaining > 0) text += readGroup(remaining);
+  text += 'บาท';
+  const satang = Math.round((num - Math.floor(num)) * 100);
+  if (satang === 0) text += 'ถ้วน';
+  else text += readGroup(satang) + 'สตางค์';
+  return text;
+}
+
+// BESTCHOICE wordmark — reused from receipt-pdf.service.ts.
+const BESTCHOICE_LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="395 285 710 425" fill="none"><defs><linearGradient id="bc-ex" gradientUnits="userSpaceOnUse" x1="597.6" y1="434.1" x2="902.4" y2="434.1"><stop offset="0" stop-color="#39F0CF"/><stop offset="0.5" stop-color="#25BC93"/><stop offset="1" stop-color="#1DA579"/></linearGradient></defs><path fill="url(#bc-ex)" d="M 603.769531 297.347656 C 600.023438 298.191406 597.769531 301.1875 597.597656 305.820312 C 597.414062 310.808594 599.695312 314.0625 603.605469 315.121094 C 605.0625 315.515625 606.605469 315.484375 608.132812 315.453125 C 608.550781 315.445312 608.96875 315.4375 609.382812 315.4375 C 623.914062 315.445312 638.449219 315.445312 652.980469 315.445312 C 662.1875 315.445312 671.390625 315.445312 680.59375 315.445312 C 692.277344 315.449219 696.074219 321.558594 693.207031 335.660156 C 687.417969 364.132812 681.613281 392.601562 675.878906 421.089844 C 673.085938 434.941406 678.320312 443.273438 689.765625 443.289062 C 717.367188 443.324219 744.976562 443.292969 772.582031 443.335938 C 782.101562 443.351562 785.0625 447.972656 782.789062 459.183594 C 777.746094 484.074219 772.6875 508.957031 767.59375 533.832031 C 764.777344 547.605469 759.269531 552.824219 747.617188 552.828125 C 701.550781 552.84375 655.484375 552.839844 609.414062 552.847656 C 608.996094 552.847656 608.578125 552.84375 608.160156 552.835938 C 606.816406 552.820312 605.472656 552.800781 604.144531 552.976562 C 599.992188 553.523438 597.800781 556.847656 597.597656 561.664062 C 597.402344 566.289062 599.542969 569.574219 603.199219 570.730469 C 604.714844 571.210938 606.347656 571.191406 607.960938 571.171875 C 608.292969 571.164062 608.628906 571.160156 608.960938 571.160156 C 650.808594 571.183594 692.65625 571.175781 734.503906 571.179688 C 776.878906 571.183594 819.257812 571.214844 861.632812 571.164062 C 873.066406 571.152344 879.71875 564.628906 882.480469 551.023438 C 888.8125 519.808594 895.195312 488.605469 901.441406 457.363281 C 905.367188 437.703125 897.210938 424.992188 880.769531 424.957031 C 868.933594 424.933594 857.101562 424.9375 845.265625 424.941406 C 833.714844 424.945312 822.164062 424.949219 810.613281 424.925781 C 799.550781 424.90625 794.933594 417.503906 797.613281 404.195312 C 802.675781 379.085938 807.78125 353.988281 812.839844 328.878906 C 816.617188 310.132812 808.339844 297.125 792.601562 297.121094 C 731.234375 297.097656 669.867188 297.109375 608.503906 297.117188 C 607.859375 297.117188 607.214844 297.097656 606.566406 297.097656 C 605.625 297.097656 604.683594 297.140625 603.769531 297.347656"/><path fill="#4D4D4D" d="M 434.851562 645.261719 L 432.128906 658.890625 L 446.460938 658.890625 C 450.027344 658.890625 452.738281 658.199219 454.589844 656.820312 C 456.4375 655.441406 457.363281 653.441406 457.363281 650.816406 C 457.363281 647.117188 454.570312 645.261719 448.984375 645.261719 Z M 452.214844 684.933594 C 454.234375 683.523438 455.246094 681.4375 455.246094 678.675781 C 455.246094 676.65625 454.503906 675.160156 453.023438 674.183594 C 451.542969 673.207031 449.523438 672.71875 446.964844 672.71875 L 429.300781 672.71875 L 426.476562 687.054688 L 443.835938 687.054688 C 447.402344 687.054688 450.199219 686.347656 452.214844 684.933594 M 472.65625 670.652344 C 474.304688 673.039062 475.128906 675.851562 475.128906 679.078125 C 475.128906 686.414062 472.136719 691.984375 466.148438 695.785156 C 460.15625 699.589844 452.351562 701.488281 442.726562 701.488281 L 403.863281 701.488281 L 417.996094 630.828125 L 453.730469 630.828125 C 461.667969 630.828125 467.746094 632.257812 471.949219 635.117188 C 476.15625 637.980469 478.257812 642.066406 478.257812 647.382812 C 478.257812 651.488281 477.148438 655.039062 474.929688 658.03125 C 472.707031 661.027344 469.613281 663.367188 465.640625 665.046875 C 468.667969 666.394531 471.007812 668.261719 472.65625 670.652344"/><path fill="#4D4D4D" d="M 512.175781 646.273438 L 509.855469 658.183594 L 541.25 658.183594 L 538.320312 673.125 L 506.828125 673.125 L 504.304688 686.042969 L 541.351562 686.042969 L 538.121094 701.488281 L 481.488281 701.488281 L 495.621094 630.828125 L 550.941406 630.828125 L 547.808594 646.273438 Z"/><path fill="#4D4D4D" d="M 559.015625 700.78125 C 553.765625 699.371094 549.492188 697.554688 546.195312 695.332031 L 554.070312 680.390625 C 557.632812 682.679688 561.4375 684.414062 565.472656 685.589844 C 569.511719 686.769531 573.550781 687.355469 577.589844 687.355469 C 581.425781 687.355469 584.402344 686.800781 586.523438 685.691406 C 588.640625 684.582031 589.703125 683.050781 589.703125 681.097656 C 589.703125 679.417969 588.742188 678.105469 586.824219 677.164062 C 584.90625 676.21875 581.929688 675.210938 577.890625 674.132812 C 573.3125 672.921875 569.511719 671.695312 566.484375 670.449219 C 563.457031 669.203125 560.847656 667.304688 558.660156 664.746094 C 556.472656 662.1875 555.378906 658.824219 555.378906 654.652344 C 555.378906 649.601562 556.757812 645.179688 559.519531 641.378906 C 562.277344 637.574219 566.214844 634.632812 571.328125 632.542969 C 576.445312 630.460938 582.433594 629.414062 589.296875 629.414062 C 594.34375 629.414062 599.054688 629.9375 603.429688 630.980469 C 607.804688 632.023438 611.574219 633.519531 614.738281 635.472656 L 607.46875 650.308594 C 604.707031 648.5625 601.664062 647.230469 598.332031 646.324219 C 595.003906 645.414062 591.585938 644.960938 588.085938 644.960938 C 584.117188 644.960938 581.003906 645.601562 578.75 646.878906 C 576.492188 648.15625 575.367188 649.804688 575.367188 651.824219 C 575.367188 653.574219 576.34375 654.921875 578.296875 655.863281 C 580.246094 656.804688 583.273438 657.816406 587.378906 658.890625 C 591.957031 660.035156 595.742188 661.210938 598.738281 662.425781 C 601.730469 663.636719 604.304688 665.484375 606.460938 667.976562 C 608.613281 670.464844 609.6875 673.730469 609.6875 677.765625 C 609.6875 682.75 608.292969 687.140625 605.5 690.941406 C 602.707031 694.742188 598.738281 697.6875 593.589844 699.773438 C 588.441406 701.859375 582.464844 702.902344 575.671875 702.902344 C 569.816406 702.902344 564.261719 702.195312 559.015625 700.78125"/><path fill="#4D4D4D" d="M 639.566406 646.675781 L 617.863281 646.675781 L 621.09375 630.828125 L 684.386719 630.828125 L 681.15625 646.675781 L 659.554688 646.675781 L 648.550781 701.488281 L 628.566406 701.488281 Z"/><path fill="#1DA579" d="M 717.195312 686.347656 C 711.878906 686.347656 707.671875 684.902344 704.574219 682.007812 C 701.480469 679.113281 699.933594 675.277344 699.933594 670.5 C 699.933594 665.855469 700.890625 661.667969 702.808594 657.933594 C 704.726562 654.195312 707.402344 651.269531 710.835938 649.148438 C 714.265625 647.03125 718.238281 645.96875 722.746094 645.96875 C 729.675781 645.96875 734.859375 648.730469 738.292969 654.246094 L 752.726562 642.738281 C 750.234375 638.5 746.46875 635.21875 741.421875 632.898438 C 736.375 630.578125 730.585938 629.414062 724.058594 629.414062 C 715.441406 629.414062 707.769531 631.230469 701.042969 634.867188 C 694.3125 638.5 689.082031 643.546875 685.347656 650.007812 C 681.609375 656.46875 679.742188 663.738281 679.742188 671.8125 C 679.742188 677.9375 681.191406 683.355469 684.085938 688.0625 C 686.976562 692.777344 691.117188 696.425781 696.5 699.015625 C 701.882812 701.605469 708.140625 702.902344 715.277344 702.902344 C 721.871094 702.902344 727.726562 701.875 732.839844 699.824219 C 737.953125 697.773438 742.429688 694.421875 746.265625 689.78125 L 734.457031 678.171875 C 729.675781 683.621094 723.921875 686.347656 717.195312 686.347656"/><path fill="#1DA579" d="M 807.234375 657.277344 L 780.082031 657.277344 L 785.332031 630.828125 L 765.34375 630.828125 L 751.210938 701.488281 L 771.199219 701.488281 L 776.648438 674.03125 L 803.804688 674.03125 L 798.351562 701.488281 L 818.339844 701.488281 L 832.472656 630.828125 L 812.484375 630.828125 Z"/><path fill="#1DA579" d="M 891.929688 674.082031 C 890.109375 677.816406 887.519531 680.796875 884.15625 683.015625 C 880.789062 685.238281 876.886719 686.347656 872.445312 686.347656 C 867.195312 686.347656 863.109375 684.917969 860.179688 682.058594 C 857.253906 679.199219 855.789062 675.378906 855.789062 670.601562 C 855.789062 666.09375 856.699219 661.96875 858.515625 658.234375 C 860.332031 654.5 862.921875 651.519531 866.289062 649.300781 C 869.652344 647.078125 873.554688 645.96875 877.996094 645.96875 C 883.246094 645.96875 887.335938 647.398438 890.261719 650.261719 C 893.191406 653.121094 894.652344 656.9375 894.652344 661.71875 C 894.652344 666.226562 893.746094 670.347656 891.929688 674.082031 M 898.339844 633.351562 C 893.054688 630.726562 886.847656 629.414062 879.714844 629.414062 C 871.167969 629.414062 863.546875 631.230469 856.851562 634.867188 C 850.152344 638.5 844.9375 643.546875 841.203125 650.007812 C 837.46875 656.46875 835.601562 663.734375 835.601562 671.8125 C 835.601562 677.867188 837.03125 683.253906 839.890625 687.964844 C 842.75 692.675781 846.820312 696.339844 852.105469 698.964844 C 857.386719 701.589844 863.597656 702.902344 870.730469 702.902344 C 879.273438 702.902344 886.898438 701.085938 893.59375 697.449219 C 900.289062 693.816406 905.503906 688.769531 909.238281 682.308594 C 912.976562 675.851562 914.84375 668.582031 914.84375 660.507812 C 914.84375 654.449219 913.410156 649.066406 910.550781 644.355469 C 907.691406 639.644531 903.621094 635.976562 898.339844 633.351562"/><path fill="#1DA579" d="M 917.972656 701.488281 L 937.957031 701.488281 L 952.089844 630.828125 L 932.101562 630.828125 Z"/><path fill="#1DA579" d="M 992.667969 686.347656 C 987.351562 686.347656 983.144531 684.902344 980.050781 682.007812 C 976.957031 679.113281 975.40625 675.277344 975.40625 670.5 C 975.40625 665.855469 976.367188 661.667969 978.285156 657.933594 C 980.203125 654.195312 982.878906 651.269531 986.308594 649.148438 C 989.742188 647.03125 993.710938 645.96875 998.222656 645.96875 C 1005.152344 645.96875 1010.335938 648.730469 1013.765625 654.246094 L 1028.203125 642.738281 C 1025.710938 638.5 1021.945312 635.21875 1016.894531 632.898438 C 1011.847656 630.578125 1006.058594 629.414062 999.535156 629.414062 C 990.917969 629.414062 983.246094 631.230469 976.519531 634.867188 C 969.789062 638.5 964.554688 643.546875 960.820312 650.007812 C 957.085938 656.46875 955.21875 663.738281 955.21875 671.8125 C 955.21875 677.9375 956.664062 683.355469 959.558594 688.0625 C 962.453125 692.777344 966.589844 696.425781 971.976562 699.015625 C 977.359375 701.605469 983.617188 702.902344 990.75 702.902344 C 997.347656 702.902344 1003.199219 701.875 1008.316406 699.824219 C 1013.429688 697.773438 1017.90625 694.421875 1021.742188 689.78125 L 1009.929688 678.171875 C 1005.152344 683.621094 999.398438 686.347656 992.667969 686.347656"/><path fill="#1DA579" d="M 1093.007812 646.273438 L 1096.136719 630.828125 L 1040.820312 630.828125 L 1026.6875 701.488281 L 1083.316406 701.488281 L 1086.546875 686.042969 L 1049.5 686.042969 L 1052.023438 673.125 L 1083.519531 673.125 L 1086.445312 658.183594 L 1055.050781 658.183594 L 1057.375 646.273438 Z"/></svg>`;
+
+@Injectable()
+export class ExpenseVoucherPdfService {
+  private readonly logger = new Logger(ExpenseVoucherPdfService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async generate(id: string): Promise<Buffer> {
+    const doc = await this.prisma.expenseDocument.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        expenseDetail: { include: { lines: { orderBy: { lineNo: 'asc' } } } },
+        branch: { select: { id: true, name: true } },
+        createdBy: { select: { id: true, name: true, email: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+    });
+    if (!doc) throw new NotFoundException('ไม่พบเอกสาร');
+    // Only POSTED/VOIDED documents reflect a recorded (or reversed) payment in
+    // the books. Printing a ใบสำคัญจ่าย for a DRAFT/PENDING/ACCRUAL doc would
+    // certify a payment the journal hasn't recognized. Mirrors the OI gate.
+    if (doc.status !== 'POSTED' && doc.status !== 'VOIDED') {
+      throw new BadRequestException(
+        'เอกสารยังไม่ได้บันทึกจ่าย ไม่สามารถออกใบสำคัญจ่ายได้',
+      );
+    }
+
+    const company = await this.prisma.companyInfo.findFirst({
+      where: { companyCode: 'FINANCE' },
+    });
+    if (!company) {
+      // Render still succeeds via the hardcoded fallback name, but a missing
+      // FINANCE CompanyInfo means every voucher mislabels the company — surface
+      // it so ops can fix the config instead of it failing silently.
+      this.logger.warn(
+        'CompanyInfo (companyCode=FINANCE) not found — voucher PDF will use the fallback company name',
+      );
+    }
+
+    const html = await this.renderHtml(doc, company);
+
+    const browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    try {
+      const page = await browser.newPage();
+      // Fonts are self-hosted (base64 data: URIs embedded in the HTML) so there
+      // are zero outbound network requests — wait only for the HTML to parse.
+      await page.setContent(html, { waitUntil: 'domcontentloaded', timeout: 10_000 });
+      const pdf = await page.pdf({
+        format: 'A4',
+        margin: { top: '0', right: '0', bottom: '0', left: '0' },
+        printBackground: true,
+      });
+      return Buffer.from(pdf);
+    } finally {
+      await browser.close();
+    }
+  }
+
+  private async renderHtml(
+    doc: ExpenseDocWithLines,
+    company:
+      | { nameTh: string; taxId: string | null; address: string | null; phone: string | null }
+      | null,
+  ): Promise<string> {
+    const verifyUrl = `https://bestchoicephone.app/expense-documents/${doc.id}`;
+    const qrDataUrl = await QRCode.toDataURL(verifyUrl, {
+      margin: 0,
+      width: 260,
+      color: { dark: '#18181b', light: '#ffffff' },
+    });
+
+    const safe = {
+      companyName: escapeHtml(company?.nameTh) || 'บริษัท เบสท์ช้อยส์ ไฟแนนท์ จำกัด',
+      companyAddress: escapeHtml(formatAddress(company?.address)),
+      companyPhone: escapeHtml(company?.phone),
+      taxId: escapeHtml(company?.taxId),
+      payeeName: escapeHtml(doc.vendorName || '—'),
+      payeeTaxId: escapeHtml(doc.vendorTaxId),
+      docNumber: escapeHtml(doc.number),
+      taxInvoiceNo: escapeHtml(doc.taxInvoiceNo),
+      documentDateStr: fmtDateShort(doc.documentDate),
+      paidAtStr: doc.paidAt ? fmtDateShort(doc.paidAt) : fmtDateShort(doc.documentDate),
+      branchName: escapeHtml(doc.branch?.name),
+      description: escapeHtml(doc.description),
+      note: escapeHtml(doc.note),
+      preparerName: escapeHtml(doc.createdBy?.name) || 'ระบบ',
+      preparerSignName:
+        escapeHtml((doc.createdBy?.name || '').split(/\s+/)[0]) || 'ระบบ',
+      preparerEmail: escapeHtml(doc.createdBy?.email),
+      approverName: escapeHtml(doc.approvedBy?.name),
+    };
+
+    const subtotal = Number(doc.subtotal);
+    const vatAmount = Number(doc.vatAmount);
+    const whtAmount = Number(doc.withholdingTax);
+    const totalAmount = Number(doc.totalAmount);
+    // net_payment is the cash actually paid out to the vendor (total − WHT
+    // withheld). Falls back to the arithmetic when the column is null on
+    // legacy rows.
+    const netPaid =
+      doc.netPayment != null ? Number(doc.netPayment) : totalAmount - whtAmount;
+    const thaiAmount = numberToThaiText(netPaid);
+    const isVoided = doc.status === 'VOIDED';
+
+    const lines = doc.expenseDetail?.lines ?? [];
+    const linesHtml = lines
+      .map((ln, idx) => {
+        const qty = Number(ln.quantity);
+        const unit = Number(ln.unitPrice);
+        const disc = Number(ln.discount);
+        const beforeVat = Number(ln.amountBeforeVat);
+        const desc = ln.description || ln.supplierName || '';
+        return `
+          <tr>
+            <td class="no">${idx + 1}.</td>
+            <td>
+              <div><span class="item-name">${escapeHtml(ln.category)}</span></div>
+              ${desc ? `<div class="item-meta">${escapeHtml(desc)}</div>` : ''}
+            </td>
+            <td class="right">${fmtMoney(qty)}</td>
+            <td class="right">${fmtMoney(unit)}</td>
+            <td class="right">${disc > 0 ? fmtMoney(disc) : '-'}</td>
+            <td class="right">${fmtMoney(beforeVat)}</td>
+          </tr>`;
+      })
+      .join('');
+
+    const embeddedFontCss = getEmbeddedFontCss(this.logger);
+
+    return `<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    /* Self-hosted fonts — no fonts.googleapis.com requests */
+    ${embeddedFontCss}
+    @page { size: A4; margin: 0; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --emerald-50:#ecfdf5; --emerald-100:#d1fae5; --emerald-700:#047857; --emerald-800:#065f46;
+      --zinc-200:#e4e4e7; --zinc-300:#d4d4d8; --zinc-400:#a1a1aa; --zinc-500:#71717a; --zinc-600:#52525b; --zinc-700:#3f3f46; --zinc-900:#18181b;
+      --red-500:#ef4444; --red-600:#dc2626;
+    }
+    body { font-family: 'IBM Plex Sans Thai', system-ui, -apple-system, sans-serif; color: var(--zinc-900); font-size: 9.5pt; line-height: 1.45; padding: 11mm 12mm 10mm; }
+    .header { display:flex; justify-content:space-between; align-items:flex-start; padding-bottom:10px; border-bottom:1.5px solid var(--zinc-300); }
+    .logo-block svg { height: 32px; width: auto; }
+    .doc-title { font-size:20pt; font-weight:700; color:var(--emerald-700); line-height:1; text-align:right; letter-spacing:-0.01em; }
+    .doc-title .en { display:block; font-size:9pt; font-weight:600; color:var(--zinc-500); margin-top:3px; letter-spacing:0.04em; }
+
+    .parties { display:grid; grid-template-columns: minmax(0, 1fr) 220px; gap:14px; padding:12px 0; border-bottom:1px solid var(--zinc-200); margin-bottom:12px; }
+    .party-row { display:grid; grid-template-columns: 78px 1fr; gap:6px; margin-bottom:4px; align-items:start; font-size:9.5pt; }
+    .party-label { color:var(--zinc-900); font-weight:700; white-space:nowrap; }
+    .party-name { font-weight:600; }
+    .party-divider { margin:10px 0; border:0; border-top:1px solid var(--zinc-200); }
+    .meta-card { background:var(--emerald-50); border:1px solid var(--emerald-100); border-radius:6px; padding:10px 14px; font-size:9pt; align-self:start; }
+    .meta-row { display:flex; justify-content:space-between; padding:3px 0; gap:8px; }
+    .meta-label { color:var(--emerald-800); font-weight:600; white-space:nowrap; }
+    .meta-value { color:var(--zinc-900); font-family:'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace; font-size:8.5pt; font-weight:500; text-align:right; word-break:break-all; }
+    .contact-info { margin-top:14px; font-size:9pt; }
+    .contact-info .heading { color:var(--zinc-700); margin-bottom:4px; }
+    .icon-line { display:grid; grid-template-columns:16px 1fr; gap:6px; align-items:start; color:var(--zinc-700); font-size:9pt; margin-top:2px; }
+    .icon-line svg { width:11px; height:11px; color:var(--zinc-500); margin-top:3px; }
+
+    table.items { width:100%; border-collapse:collapse; font-size:9pt; }
+    table.items thead th { text-align:left; padding:6px 8px; background:var(--emerald-50); color:var(--emerald-800); font-size:8.5pt; font-weight:600; border-bottom:1.5px solid var(--emerald-700); }
+    table.items thead th.right { text-align:right; }
+    table.items tbody td { padding:8px; border-bottom:1px solid var(--zinc-200); vertical-align:top; font-variant-numeric:tabular-nums; }
+    table.items tbody td.right { text-align:right; }
+    table.items td.no { color:var(--zinc-500); width:22px; }
+    .item-name { font-weight:600; }
+    .item-meta { color:var(--zinc-500); font-size:8.5pt; margin-top:2px; }
+
+    .summary { display:grid; grid-template-columns:1fr 1fr; gap:14px; padding:12px 0; margin-bottom:12px; border-bottom:1px solid var(--zinc-200); }
+    .summary-section { display:grid; grid-template-columns:18px 1fr; gap:8px; align-items:start; }
+    .summary-section .icon { width:16px; height:16px; color:var(--zinc-700); margin-top:2px; }
+    .breakdown { display:grid; grid-template-columns:max-content 1fr auto; column-gap:18px; row-gap:4px; font-size:9.5pt; }
+    .breakdown .label { color:var(--zinc-700); }
+    .breakdown .label.bold { font-weight:600; color:var(--zinc-900); }
+    .breakdown .text { color:var(--zinc-600); font-style:italic; font-size:9pt; }
+    .breakdown .num { text-align:right; font-variant-numeric:tabular-nums; color:var(--zinc-900); }
+    .grand-card { background:var(--emerald-50); border-radius:8px; padding:10px 14px; text-align:center; }
+    .grand-card .label { color:var(--emerald-800); font-size:9pt; font-weight:600; margin-bottom:3px; }
+    .grand-card .amount { color:var(--emerald-700); font-size:18pt; font-weight:700; line-height:1; font-variant-numeric:tabular-nums; }
+    .grand-card .amount-suffix { color:var(--emerald-700); font-size:11pt; font-weight:500; margin-left:4px; }
+    .summary-aux { margin-top:10px; display:grid; grid-template-columns:1fr auto; row-gap:4px; column-gap:18px; font-size:9.5pt; }
+    .summary-aux .label { color:var(--zinc-700); }
+    .summary-aux .num { text-align:right; font-variant-numeric:tabular-nums; }
+
+    .notes-section { padding-bottom:10px; margin-bottom:12px; font-size:9pt; border-bottom:1px solid var(--zinc-200); }
+    .sec-title { display:flex; align-items:center; gap:8px; font-size:10pt; font-weight:700; color:var(--zinc-900); margin-bottom:6px; }
+    .sec-title .icon-pill { width:22px; height:22px; background:var(--zinc-900); color:#fff; border-radius:6px; display:flex; align-items:center; justify-content:center; }
+    .sec-title .icon-pill svg { width:13px; height:13px; }
+    .notes-section .body { color:var(--zinc-600); min-height:10px; }
+
+    .approval { display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px; align-items:start; margin-top:8px; page-break-inside:avoid; break-inside:avoid; }
+    .qr-pane { text-align:center; }
+    .qr-caption-top { font-size:9pt; color:var(--zinc-700); margin-bottom:5px; }
+    .qr-pane img { width:104px; height:104px; }
+    .sig-block { text-align:left; }
+    .sig-role { font-size:9.5pt; color:var(--zinc-900); font-weight:600; margin-bottom:2px; }
+    .sig-handwriting { font-family:'Sriracha', 'Apple Chancery', 'Brush Script MT', cursive; font-size:20pt; color:var(--zinc-600); line-height:1; transform:rotate(-3deg); transform-origin:left center; display:inline-block; opacity:0.85; margin-top:4px; min-height:24px; }
+    .sig-rule { width:180px; border-top:1px dotted var(--zinc-300); margin:14px 0 5px; }
+    .sig-name { font-size:10pt; font-weight:700; color:var(--zinc-900); }
+    .sig-date { font-size:9pt; color:var(--zinc-500); margin-top:1px; font-variant-numeric:tabular-nums; }
+
+    .void-badge { display:inline-block; margin:10px 0 0; padding:4px 12px; border:1.5px solid var(--red-600); border-radius:6px; color:var(--red-600); font-weight:700; font-size:10pt; letter-spacing:0.02em; }
+    .void-overlay { position:fixed; top:50%; left:50%; transform:translate(-50%,-50%) rotate(-15deg); font-size:70pt; font-weight:900; color:rgba(220,38,38,0.16); letter-spacing:0.08em; pointer-events:none; text-align:center; }
+  </style>
+</head>
+<body>
+  ${isVoided ? `<div class="void-overlay">ยกเลิก / กลับรายการแล้ว</div>` : ''}
+
+  <!-- Header: Logo + Title -->
+  <div class="header">
+    <div class="logo-block">${BESTCHOICE_LOGO_SVG}</div>
+    <div class="doc-title">ใบสำคัญจ่าย<span class="en">PAYMENT VOUCHER</span></div>
+  </div>
+
+  ${isVoided ? `<div class="void-badge">ยกเลิก/กลับรายการแล้ว</div>` : ''}
+
+  <!-- Parties + meta -->
+  <div class="parties">
+    <div>
+      <div class="party-row"><span class="party-label">ผู้จ่าย :</span><span class="party-name">${safe.companyName}</span></div>
+      ${safe.companyAddress ? `<div class="party-row"><span class="party-label">ที่อยู่ :</span><span>${safe.companyAddress}</span></div>` : ''}
+      ${safe.taxId ? `<div class="party-row"><span class="party-label">เลขที่ภาษี :</span><span>${safe.taxId}</span></div>` : ''}
+
+      <hr class="party-divider"/>
+
+      <div class="party-row"><span class="party-label">ผู้รับเงิน :</span><span class="party-name">${safe.payeeName}</span></div>
+      ${safe.payeeTaxId ? `<div class="party-row"><span class="party-label">เลขที่ภาษี :</span><span>${safe.payeeTaxId}</span></div>` : ''}
+      ${safe.branchName ? `<div class="party-row"><span class="party-label">สาขา :</span><span>${safe.branchName}</span></div>` : ''}
+    </div>
+    <div>
+      <div class="meta-card">
+        <div class="meta-row"><span class="meta-label">เลขที่เอกสาร :</span><span class="meta-value">${safe.docNumber}</span></div>
+        <div class="meta-row"><span class="meta-label">วันที่เอกสาร :</span><span class="meta-value">${safe.documentDateStr}</span></div>
+        <div class="meta-row"><span class="meta-label">วันที่จ่าย :</span><span class="meta-value">${safe.paidAtStr}</span></div>
+        ${safe.taxInvoiceNo ? `<div class="meta-row"><span class="meta-label">เลขใบกำกับ :</span><span class="meta-value">${safe.taxInvoiceNo}</span></div>` : ''}
+      </div>
+    </div>
+  </div>
+
+  <!-- Line items table -->
+  <table class="items">
+    <thead>
+      <tr>
+        <th></th>
+        <th>รายการ/บัญชี</th>
+        <th class="right">จำนวน</th>
+        <th class="right">ราคาต่อหน่วย</th>
+        <th class="right">ส่วนลด</th>
+        <th class="right">จำนวนเงิน</th>
+      </tr>
+    </thead>
+    <tbody>${linesHtml}</tbody>
+  </table>
+
+  <!-- Summary -->
+  <div class="summary">
+    <div>
+      <div class="summary-section">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+        <div>
+          <div style="font-weight:700; margin-bottom:4px;">สรุป</div>
+          <div class="breakdown">
+            <span class="label">มูลค่าก่อนภาษี</span><span></span><span class="num">${fmtMoney(subtotal)} บาท</span>
+            ${vatAmount > 0 ? `<span class="label">ภาษีมูลค่าเพิ่ม 7%</span><span></span><span class="num">${fmtMoney(vatAmount)} บาท</span>` : ''}
+            ${whtAmount > 0 ? `<span class="label">หัก ณ ที่จ่าย</span><span></span><span class="num">- ${fmtMoney(whtAmount)} บาท</span>` : ''}
+            <span class="label bold">จำนวนเงินจ่ายสุทธิ</span>
+            <span class="text">${thaiAmount}</span>
+            <span></span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div class="grand-card">
+        <div class="label">จำนวนเงินจ่ายสุทธิ</div>
+        <div class="amount">${fmtMoney(netPaid)}<span class="amount-suffix">บาท</span></div>
+      </div>
+      <div class="summary-aux">
+        <span class="label">มูลค่ารวมก่อนหัก ณ ที่จ่าย</span><span class="num">${fmtMoney(totalAmount)} บาท</span>
+        ${whtAmount > 0 ? `<span class="label">ภาษีหัก ณ ที่จ่าย</span><span class="num">${fmtMoney(whtAmount)} บาท</span>` : ''}
+      </div>
+    </div>
+  </div>
+
+  <!-- Notes -->
+  <div class="notes-section">
+    <div class="sec-title">
+      <span class="icon-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+      <span>หมายเหตุ</span>
+    </div>
+    <div class="body">${safe.note || safe.description || '&nbsp;'}</div>
+  </div>
+
+  <!-- Signatures (3-col): ผู้จัดทำ | ผู้อนุมัติ | ผู้รับเงิน -->
+  <div class="approval">
+    <div class="sig-block">
+      <div class="sig-role">ผู้จัดทำ</div>
+      <div class="sig-handwriting">${safe.preparerSignName}</div>
+      <div class="sig-rule"></div>
+      <div class="sig-name">${safe.preparerName}</div>
+      <div class="sig-date">${safe.documentDateStr}</div>
+    </div>
+    <div class="sig-block">
+      <div class="sig-role">ผู้อนุมัติ</div>
+      <div class="sig-handwriting">${safe.approverName ? escapeHtml((doc.approvedBy?.name || '').split(/\s+/)[0]) : '&nbsp;'}</div>
+      <div class="sig-rule"></div>
+      <div class="sig-name">${safe.approverName || '&nbsp;'}</div>
+      <div class="sig-date">${safe.approverName ? safe.paidAtStr : '&nbsp;'}</div>
+    </div>
+    <div class="sig-block">
+      <div class="sig-role">ผู้รับเงิน</div>
+      <div class="sig-handwriting">&nbsp;</div>
+      <div class="sig-rule"></div>
+      <div class="sig-name">${safe.payeeName}</div>
+      <div class="sig-date">${safe.paidAtStr}</div>
+    </div>
+  </div>
+
+  <!-- QR verify -->
+  <div class="qr-pane" style="margin-top:14px;">
+    <div class="qr-caption-top">สแกนเพื่อตรวจสอบเอกสาร</div>
+    <img src="${qrDataUrl}" alt="QR"/>
+  </div>
+</body>
+</html>`;
+  }
+}

--- a/apps/api/src/modules/other-income/__tests__/other-income.controller.spec.ts
+++ b/apps/api/src/modules/other-income/__tests__/other-income.controller.spec.ts
@@ -16,8 +16,10 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { Reflector } from '@nestjs/core';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
+import { ReversePermissionGuard } from '../../auth/guards/reverse-permission.guard';
 import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
 import { OtherIncomeController } from '../other-income.controller';
 import { OtherIncomeService } from '../other-income.service';
@@ -79,12 +81,36 @@ describe('OtherIncomeController — @Roles metadata', () => {
     expect(roles).not.toContain('BRANCH_MANAGER');
   });
 
-  it('reverse() is restricted to OWNER + FINANCE_MANAGER — ACCOUNTANT excluded', () => {
+  // Audit Finding A (extended): @Roles is the COARSE superset that RolesGuard
+  // checks first; the dynamic ReversePermissionGuard is the authoritative narrower.
+  // ACCOUNTANT is included in the superset so the 'OWNER+FINANCE_MANAGER+ACCOUNTANT'
+  // mode and CUSTOM per-user grants can actually take effect — otherwise RolesGuard
+  // would pre-block the accountant before the dynamic guard ever runs. In the
+  // default OWNER+FM mode the guard still rejects ACCOUNTANT (covered by the
+  // ReversePermissionGuard spec). SALES / BRANCH_MANAGER stay out entirely.
+  it('reverse() coarse @Roles allows OWNER + FINANCE_MANAGER + ACCOUNTANT (guard narrows)', () => {
     const roles = methodRoles('reverse');
     expect(roles).toBeDefined();
-    expect(roles).toEqual(expect.arrayContaining(['OWNER', 'FINANCE_MANAGER']));
-    expect(roles).not.toContain('ACCOUNTANT');
+    expect(roles).toEqual(
+      expect.arrayContaining(['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT']),
+    );
     expect(roles).not.toContain('SALES');
+    expect(roles).not.toContain('BRANCH_MANAGER');
+  });
+
+  // Audit Finding A — reverse permission must be uniform across all 3 accounting
+  // modules. Other Income (like Expense's void) must additionally consult the
+  // dynamic `reverse_permission` SystemConfig mode via ReversePermissionGuard,
+  // not just the static @Roles bundle. (Previously OI relied on @Roles only.)
+  it('reverse() is additionally gated by ReversePermissionGuard (dynamic mode)', () => {
+    const handler = (OtherIncomeController.prototype as unknown as Record<string, unknown>)[
+      'reverse'
+    ];
+    const guards = Reflect.getMetadata(GUARDS_METADATA, handler as object) as
+      | unknown[]
+      | undefined;
+    expect(guards).toBeDefined();
+    expect(guards).toContain(ReversePermissionGuard);
   });
 
   it('list(), create(), post(), copy() have no method-level @Roles (inherit class)', () => {

--- a/apps/api/src/modules/other-income/other-income.controller.ts
+++ b/apps/api/src/modules/other-income/other-income.controller.ts
@@ -23,6 +23,7 @@ import { Response } from 'express';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
+import { ReversePermissionGuard } from '../auth/guards/reverse-permission.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { OtherIncomeService } from './other-income.service';
@@ -245,7 +246,11 @@ export class OtherIncomeController {
   }
 
   @Post(':id/reverse')
-  @Roles('OWNER', 'FINANCE_MANAGER')
+  // Coarse superset — ReversePermissionGuard narrows per the dynamic
+  // `reverse_permission` mode (default OWNER+FM mode rejects ACCOUNTANT;
+  // the +ACCOUNTANT / CUSTOM modes may allow it).
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  @UseGuards(ReversePermissionGuard)
   reverse(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dto: ReverseOtherIncomeDto,

--- a/apps/api/src/modules/other-income/other-income.service.ts
+++ b/apps/api/src/modules/other-income/other-income.service.ts
@@ -1212,7 +1212,7 @@ export class OtherIncomeService {
 
     const decodedName = Buffer.from(file.originalname, 'latin1').toString('utf8');
     // eslint-disable-next-line no-control-regex
-    const safeName = decodedName.replace(/[<>:"/\\|?* -\s]/g, '_');
+    const safeName = decodedName.replace(/[<>:"/\\|?*\x00-\s]/g, '_');
     const key = `other-income/${id}/${Date.now()}-${randomUUID()}-${safeName}`;
 
     await this.storage.upload(key, file.buffer, file.mimetype);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -113,6 +113,7 @@ const ExternalFinanceCompanyDetailPage = lazy(
   () => import('@/pages/ExternalFinanceCompanyDetailPage'),
 );
 const ExpensesPage = lazy(() => import('@/pages/ExpensesPage'));
+const ExpenseDetailPage = lazy(() => import('@/pages/ExpenseDetailPage'));
 const APAgingPage = lazy(() => import('@/pages/APAgingPage'));
 const PaymentVoucherPage = lazy(() => import('@/pages/PaymentVoucherPage'));
 const ExpenseDocumentNewPage = lazy(() => import('@/pages/ExpenseDocumentNewPage'));
@@ -574,6 +575,14 @@ function App() {
             element={
               <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
                 <PaymentVoucherPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/expenses/:id"
+            element={
+              <ProtectedRoute roles={['OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT']}>
+                <ExpenseDetailPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/components/accounting/__tests__/audit-events.test.ts
+++ b/apps/web/src/components/accounting/__tests__/audit-events.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { mapAuditEvents, type RawAuditEntry } from '../audit-events';
+
+const row = (over: Partial<RawAuditEntry>): RawAuditEntry => ({
+  id: 'a1',
+  action: 'CREATED',
+  createdAt: '2026-05-12T07:25:10.000Z',
+  user: { id: 'u1', name: 'เอกนรินทร์ คงเดช' },
+  ...over,
+});
+
+describe('mapAuditEvents — shared across the 3 accounting modules', () => {
+  it('preserves the action verbatim as event + maps user/timestamp', () => {
+    const [e] = mapAuditEvents([row({ action: 'POSTED' })]);
+    expect(e.event).toBe('POSTED');
+    expect(e.userId).toBe('u1');
+    expect(e.userName).toBe('เอกนรินทร์ คงเดช');
+    expect(e.timestamp).toBe('2026-05-12T07:25:10.000Z');
+  });
+
+  it('falls back to ระบบ / unknown when user is null', () => {
+    const [e] = mapAuditEvents([row({ user: null })]);
+    expect(e.userName).toBe('ระบบ');
+    expect(e.userId).toBe('unknown');
+  });
+
+  it('combines reverseReasonLabel + reverseNote into "label — note"', () => {
+    const [e] = mapAuditEvents([
+      row({ action: 'REVERSED', newValue: { reverseReasonLabel: 'บันทึกผิดบัญชี', reverseNote: 'ควรเป็น 42-1105' } }),
+    ]);
+    expect(e.reason).toBe('บันทึกผิดบัญชี — ควรเป็น 42-1105');
+  });
+
+  it('uses the label alone when note is absent', () => {
+    const [e] = mapAuditEvents([row({ newValue: { reverseReasonLabel: 'ผู้ขายผิด' } })]);
+    expect(e.reason).toBe('ผู้ขายผิด');
+  });
+
+  it('honours the asset-style reversalReason key as enum fallback', () => {
+    const [e] = mapAuditEvents([row({ newValue: { reversalReason: 'DISPOSAL_ERROR' } })]);
+    expect(e.reason).toBe('DISPOSAL_ERROR');
+  });
+
+  it('leaves reason undefined when newValue carries nothing useful', () => {
+    const [e] = mapAuditEvents([row({ newValue: { somethingElse: 1 } })]);
+    expect(e.reason).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/accounting/__tests__/reverse-permission.test.ts
+++ b/apps/web/src/components/accounting/__tests__/reverse-permission.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCanReverse } from '../reverse-permission';
+
+/**
+ * Mirrors the backend ReversePermissionGuard spec so the UI button-visibility
+ * stays in lock-step with what the server will actually allow (Audit Finding A).
+ */
+describe('resolveCanReverse — client mirror of backend canUserReverse', () => {
+  it('OWNER is always allowed, regardless of mode', () => {
+    expect(resolveCanReverse('OWNER_ONLY', 'OWNER')).toBe(true);
+    expect(resolveCanReverse('CUSTOM', 'OWNER', null)).toBe(true);
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER', 'OWNER')).toBe(true);
+  });
+
+  it('OWNER_ONLY rejects FINANCE_MANAGER and ACCOUNTANT', () => {
+    expect(resolveCanReverse('OWNER_ONLY', 'FINANCE_MANAGER')).toBe(false);
+    expect(resolveCanReverse('OWNER_ONLY', 'ACCOUNTANT')).toBe(false);
+  });
+
+  it('OWNER+FINANCE_MANAGER (default) allows FM, rejects ACCOUNTANT', () => {
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER', 'FINANCE_MANAGER')).toBe(true);
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER', 'ACCOUNTANT')).toBe(false);
+  });
+
+  it('OWNER+FINANCE_MANAGER+ACCOUNTANT widens to include ACCOUNTANT', () => {
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER+ACCOUNTANT', 'ACCOUNTANT')).toBe(true);
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER+ACCOUNTANT', 'FINANCE_MANAGER')).toBe(true);
+  });
+
+  it('CUSTOM consults canReverseOverride for non-owner roles', () => {
+    expect(resolveCanReverse('CUSTOM', 'ACCOUNTANT', true)).toBe(true);
+    expect(resolveCanReverse('CUSTOM', 'ACCOUNTANT', false)).toBe(false);
+    expect(resolveCanReverse('CUSTOM', 'ACCOUNTANT', null)).toBe(false);
+    expect(resolveCanReverse('CUSTOM', 'FINANCE_MANAGER', undefined)).toBe(false);
+  });
+
+  it('SALES / BRANCH_MANAGER never allowed via a static mode', () => {
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER+ACCOUNTANT', 'SALES')).toBe(false);
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER', 'BRANCH_MANAGER')).toBe(false);
+  });
+
+  it('missing role is rejected', () => {
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER', undefined)).toBe(false);
+    expect(resolveCanReverse('OWNER+FINANCE_MANAGER', null)).toBe(false);
+  });
+});

--- a/apps/web/src/components/accounting/audit-events.ts
+++ b/apps/web/src/components/accounting/audit-events.ts
@@ -1,0 +1,53 @@
+import type { IcabAuditEvent } from './types';
+
+/**
+ * Raw audit-log row as returned by the per-document audit endpoints
+ * (`GET /other-income/:id/audit`, `GET /expense-documents/:id/audit`,
+ * `POST /assets/:id/audit`). Only the fields the timeline needs are typed;
+ * `newValue` is an opaque JSON blob the reverse/void mutations stamp.
+ */
+export interface RawAuditEntry {
+  id: string;
+  action: string;
+  createdAt: string;
+  user: { id: string; name: string } | null;
+  newValue?: unknown;
+}
+
+/**
+ * Map server-side AuditLog rows to the `IcabAuditEvent` shape consumed by the
+ * shared InternalControlActionBar timeline. Shared across all three accounting
+ * modules so the reason-extraction precedence stays identical.
+ *
+ * The server `action` strings (CREATED / POSTED / VOIDED / REVERSED / ...) are
+ * preserved verbatim — the timeline's label registry handles the canonical set
+ * and falls back gracefully for unknown values.
+ *
+ * `reason` precedence: structured `reverseReasonLabel` (+ `reverseNote`) →
+ * free-form `reverseNote` → enum `reverseReason`. The asset module historically
+ * stamps `reversalReason`, so that key is honoured too.
+ */
+export function mapAuditEvents(entries: RawAuditEntry[]): IcabAuditEvent[] {
+  return entries.map((e) => {
+    const nv =
+      e.newValue && typeof e.newValue === 'object'
+        ? (e.newValue as Record<string, unknown>)
+        : null;
+    const str = (key: string): string | undefined => {
+      const v = nv?.[key];
+      return typeof v === 'string' && v.length > 0 ? v : undefined;
+    };
+    const label = str('reverseReasonLabel');
+    const note = str('reverseNote');
+    const enumFallback = str('reverseReason') ?? str('reversalReason');
+    const reason =
+      label && note && label !== note ? `${label} — ${note}` : (label ?? note ?? enumFallback);
+    return {
+      event: e.action,
+      userId: e.user?.id ?? 'unknown',
+      userName: e.user?.name ?? 'ระบบ',
+      timestamp: e.createdAt,
+      reason,
+    };
+  });
+}

--- a/apps/web/src/components/accounting/index.ts
+++ b/apps/web/src/components/accounting/index.ts
@@ -8,6 +8,10 @@ export { ReverseConfirmDialog } from './ReverseConfirmDialog';
 export type { ReverseConfirmDialogProps } from './ReverseConfirmDialog';
 export { AuditTimeline } from './AuditTimeline';
 export type { AuditTimelineProps } from './AuditTimeline';
+export { resolveCanReverse } from './reverse-permission';
+export type { ReversePermissionMode } from './reverse-permission';
+export { mapAuditEvents } from './audit-events';
+export type { RawAuditEntry } from './audit-events';
 export type {
   IcabAuditEvent,
   IcabCurrentUser,

--- a/apps/web/src/components/accounting/reverse-permission.ts
+++ b/apps/web/src/components/accounting/reverse-permission.ts
@@ -1,0 +1,47 @@
+/**
+ * InternalControlActionBar — client mirror of the backend reverse-permission
+ * resolver (`apps/api/src/modules/auth/guards/reverse-permission.guard.ts` →
+ * `canUserReverse`).
+ *
+ * Used by the three accounting modules (Other Income, Expense, Asset) to decide
+ * whether to SHOW the "↺ ยกเลิก / กลับรายการ" button, so the UI never offers an
+ * action the server will reject with 403. The server stays authoritative —
+ * `ReversePermissionGuard` re-validates every reverse/void request.
+ *
+ * Modes mirror SystemConfig `reverse_permission`:
+ *   - `OWNER_ONLY`
+ *   - `OWNER+FINANCE_MANAGER` (default)
+ *   - `OWNER+FINANCE_MANAGER+ACCOUNTANT`
+ *   - `CUSTOM` — per-user opt-in via `User.canReverseOverride`
+ * OWNER is always allowed regardless of mode.
+ */
+export type ReversePermissionMode =
+  | 'OWNER_ONLY'
+  | 'OWNER+FINANCE_MANAGER'
+  | 'OWNER+FINANCE_MANAGER+ACCOUNTANT'
+  | 'CUSTOM';
+
+const MODE_ROLE_SETS: Record<Exclude<ReversePermissionMode, 'CUSTOM'>, readonly string[]> = {
+  OWNER_ONLY: ['OWNER'],
+  'OWNER+FINANCE_MANAGER': ['OWNER', 'FINANCE_MANAGER'],
+  'OWNER+FINANCE_MANAGER+ACCOUNTANT': ['OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT'],
+};
+
+/**
+ * Resolve whether the given user may reverse, mirroring the server's
+ * `canUserReverse`. Pass the value straight to the bar's `canReverse` prop.
+ *
+ * @param mode               active reverse_permission mode (from `useUiFlags`)
+ * @param role               current user's role
+ * @param canReverseOverride per-user flag — only consulted when mode = CUSTOM
+ */
+export function resolveCanReverse(
+  mode: ReversePermissionMode,
+  role: string | undefined | null,
+  canReverseOverride?: boolean | null,
+): boolean {
+  if (!role) return false;
+  if (role === 'OWNER') return true;
+  if (mode === 'CUSTOM') return canReverseOverride === true;
+  return MODE_ROLE_SETS[mode]?.includes(role) ?? false;
+}

--- a/apps/web/src/pages/ExpenseDetailPage.tsx
+++ b/apps/web/src/pages/ExpenseDetailPage.tsx
@@ -1,0 +1,385 @@
+import { useNavigate, useParams } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Wallet } from 'lucide-react';
+import PageHeader from '@/components/ui/PageHeader';
+import QueryBoundary from '@/components/QueryBoundary';
+import {
+  InternalControlActionBar,
+  resolveCanReverse,
+  mapAuditEvents,
+  type RawAuditEntry,
+  type IcabStatus,
+} from '@/components/accounting';
+import api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useUiFlags } from '@/hooks/useUiFlags';
+import { formatNumberDecimal } from '@/utils/formatters';
+import { formatThaiDateShort } from '@/lib/date';
+
+/**
+ * ExpenseDetailPage — single-document view that hosts the shared
+ * InternalControlActionBar for the Expense module (mirrors OtherIncomeViewPage,
+ * the Other Income pilot). The bar is the unified "ควบคุมภายใน" control surface:
+ * audit timeline + state-machine buttons + reverse/void dialog.
+ *
+ * Per-module responsibility (the bar is presentation-only): this page maps the
+ * 6-state expense DocumentStatus into the bar's 4-state ICAB model and wires the
+ * existing expense mutations (post / submit / approve / void / print).
+ */
+
+type ExpenseStatus =
+  | 'DRAFT'
+  | 'PENDING_APPROVAL'
+  | 'APPROVED'
+  | 'ACCRUAL'
+  | 'POSTED'
+  | 'VOIDED';
+
+interface ExpenseLine {
+  lineNo?: number;
+  category: string;
+  description?: string | null;
+  amountBeforeVat?: string | null;
+  vatAmount?: string | null;
+  whtAmount?: string | null;
+}
+
+interface ExpenseDocument {
+  id: string;
+  number: string;
+  documentType: string;
+  status: ExpenseStatus;
+  documentDate: string;
+  vendorName: string | null;
+  vendorTaxId: string | null;
+  description: string | null;
+  subtotal: string;
+  vatAmount: string;
+  withholdingTax: string;
+  totalAmount: string;
+  netPayment: string | null;
+  branch?: { id: string; name: string } | null;
+  createdBy?: { id: string; name: string } | null;
+  expenseDetail?: { lines: ExpenseLine[] } | null;
+}
+
+const DOC_TYPE_LABELS: Record<string, string> = {
+  EXPENSE: 'ค่าใช้จ่าย',
+  CREDIT_NOTE: 'ใบลดหนี้',
+  PAYROLL: 'เงินเดือน',
+  VENDOR_SETTLEMENT: 'ชำระเจ้าหนี้',
+  PETTY_CASH_REIMBURSEMENT: 'เบิกเงินสดย่อย',
+  REPAIR_SERVICE: 'ค่าซ่อม',
+};
+
+/**
+ * Map the 6-state expense DocumentStatus onto the bar's 4-state ICAB model.
+ *   DRAFT            → DRAFT     (editable; post / submit-for-approval)
+ *   PENDING_APPROVAL → READY     (awaiting approval; approve)
+ *   APPROVED         → POSTED    (approved + booked; close / print / reverse)
+ *   ACCRUAL          → POSTED    (owner decision: a booked accrual has a JE)
+ *   POSTED           → POSTED
+ *   VOIDED           → REVERSED  (terminal)
+ * Void is allowed server-side from any non-VOIDED state, but the bar only
+ * surfaces the reverse button in POSTED — which the three "booked" states map
+ * to, so the reverse affordance lines up with what the server accepts.
+ */
+export function mapExpenseStatusToIcab(status: ExpenseStatus): IcabStatus {
+  switch (status) {
+    case 'DRAFT':
+      return 'DRAFT';
+    case 'PENDING_APPROVAL':
+      return 'READY';
+    case 'VOIDED':
+      return 'REVERSED';
+    case 'APPROVED':
+    case 'ACCRUAL':
+    case 'POSTED':
+    default:
+      return 'POSTED';
+  }
+}
+
+const STATUS_BADGE: Record<ExpenseStatus, { label: string; cls: string }> = {
+  DRAFT: { label: '📝 ฉบับร่าง', cls: 'border-warning/40 bg-warning/10 text-warning' },
+  PENDING_APPROVAL: { label: '⏳ รออนุมัติ', cls: 'border-info/40 bg-info/10 text-info' },
+  APPROVED: { label: '✓ อนุมัติแล้ว', cls: 'border-success/40 bg-success/10 text-success' },
+  ACCRUAL: { label: '📒 ตั้งค้างจ่าย', cls: 'border-info/40 bg-info/10 text-info' },
+  POSTED: { label: '✓ ลงบัญชีแล้ว', cls: 'border-success/40 bg-success/10 text-success' },
+  VOIDED: { label: '↺ กลับรายการแล้ว', cls: 'border-destructive/40 bg-destructive/10 text-destructive' },
+};
+
+function StatusBadge({ status }: { status: ExpenseStatus }) {
+  const b = STATUS_BADGE[status];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium leading-snug ${b.cls}`}
+    >
+      {b.label}
+    </span>
+  );
+}
+
+/** Fetch the server-rendered voucher PDF (JWT in-memory → axios) and open it. */
+async function openVoucherPdf(docId: string, docNumber: string): Promise<void> {
+  const res = await api.get(`/expense-documents/${docId}/voucher.pdf`, { responseType: 'blob' });
+  const blob = new Blob([res.data], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const win = window.open(url, '_blank');
+  if (!win) {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${docNumber}.pdf`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
+export default function ExpenseDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const flags = useUiFlags();
+
+  const docQuery = useQuery<ExpenseDocument>({
+    queryKey: ['expense-document', id],
+    queryFn: async () => (await api.get<ExpenseDocument>(`/expense-documents/${id}`)).data,
+    enabled: !!id,
+  });
+
+  const auditQuery = useQuery<RawAuditEntry[]>({
+    queryKey: ['expense-document', id, 'audit'],
+    queryFn: async () => (await api.get<RawAuditEntry[]>(`/expense-documents/${id}/audit`)).data,
+    enabled: !!id,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['expense-document', id] });
+    queryClient.invalidateQueries({ queryKey: ['expenses'] });
+    queryClient.invalidateQueries({ queryKey: ['expenses-summary'] });
+  };
+
+  const postMutation = useMutation({
+    mutationFn: () => api.post(`/expense-documents/${id}/post`, {}),
+    onSuccess: () => {
+      toast.success('บันทึกบัญชีเรียบร้อย');
+      invalidate();
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'บันทึกบัญชีไม่สำเร็จ'),
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: () => api.post(`/expense-documents/${id}/submit-for-approval`, {}),
+    onSuccess: () => {
+      toast.success('ส่งขออนุมัติแล้ว');
+      invalidate();
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'ส่งขออนุมัติไม่สำเร็จ'),
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: () => api.post(`/expense-documents/${id}/approve`, {}),
+    onSuccess: () => {
+      toast.success('อนุมัติเรียบร้อย');
+      invalidate();
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'อนุมัติไม่สำเร็จ'),
+  });
+
+  const voidMutation = useMutation({
+    mutationFn: ({ reasonLabel, note }: { reasonId: string; reasonLabel: string; note: string }) =>
+      api.post(`/expense-documents/${id}/void`, {
+        // The bar's reasons come from the admin-managed reverse-reasons table
+        // (uuid ids), which don't match the expense reasonCode whitelist — so we
+        // carry the human label/note under the catch-all 'other' code. The
+        // structured reasonLabel/note are stamped into the audit log as
+        // reverseReasonLabel/reverseNote so the timeline renders them (parity
+        // with other-income / asset). reverseDate omitted → server default (BKK noon).
+        reasonCode: 'other',
+        reasonDetail: note ? `${reasonLabel} — ${note}` : reasonLabel,
+        reasonLabel,
+        note,
+      }),
+    onSuccess: () => {
+      toast.success('กลับรายการเอกสารเรียบร้อย');
+      invalidate();
+    },
+    onError: (err: any) => toast.error(err?.response?.data?.message ?? 'กลับรายการไม่สำเร็จ'),
+  });
+
+  const printMutation = useMutation({
+    mutationFn: ({ docId, docNumber }: { docId: string; docNumber: string }) =>
+      openVoucherPdf(docId, docNumber),
+    onError: () => toast.error('ไม่สามารถสร้างใบสำคัญจ่าย PDF ได้'),
+  });
+
+  const doc = docQuery.data;
+  const makerCheckerEnabled = flags.approvalEnabled;
+  const icabStatus = doc ? mapExpenseStatusToIcab(doc.status) : 'DRAFT';
+
+  // Mode-aware reverse gate (Audit Finding A) — mirrors the backend
+  // ReversePermissionGuard so the button only shows when the server will allow.
+  const canReverse =
+    resolveCanReverse(flags.reversePermission, user?.role, user?.canReverseOverride) &&
+    icabStatus === 'POSTED';
+
+  const isOwnDoc = !!doc && doc.createdBy?.id === user?.id;
+  const isViewerApprover =
+    !!user &&
+    (user.role === 'OWNER' || user.role === 'FINANCE_MANAGER') &&
+    doc?.createdBy?.id !== user.id;
+
+  const isActionLoading =
+    postMutation.isPending ||
+    submitMutation.isPending ||
+    approveMutation.isPending ||
+    voidMutation.isPending;
+
+  const money = (v: string | null | undefined) => `${formatNumberDecimal(Number(v ?? 0), 2)} ฿`;
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto pb-44 md:pb-40">
+      <PageHeader
+        title="รายละเอียดเอกสารรายจ่าย"
+        icon={<Wallet size={20} />}
+        onBack={() => navigate('/expenses')}
+        badge={doc ? <StatusBadge status={doc.status} /> : undefined}
+      />
+
+      <QueryBoundary
+        isLoading={docQuery.isLoading}
+        isError={docQuery.isError}
+        error={docQuery.error as Error | null}
+        onRetry={docQuery.refetch}
+      >
+        {doc && (
+          <div className="space-y-6">
+            {/* Document header */}
+            <section className="rounded-lg border border-border bg-card p-5">
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                  <div className="text-lg font-semibold leading-snug">{doc.number}</div>
+                  <div className="text-sm text-muted-foreground leading-snug">
+                    {DOC_TYPE_LABELS[doc.documentType] ?? doc.documentType} ·{' '}
+                    {formatThaiDateShort(doc.documentDate)}
+                    {doc.branch?.name ? ` · ${doc.branch.name}` : ''}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-xs text-muted-foreground leading-snug">ยอดสุทธิที่จ่าย</div>
+                  <div className="text-xl font-semibold leading-snug">
+                    {money(doc.netPayment ?? doc.totalAmount)}
+                  </div>
+                </div>
+              </div>
+
+              <dl className="mt-4 grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2 text-sm">
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground leading-snug">ผู้ขาย / ผู้รับเงิน</dt>
+                  <dd className="font-medium leading-snug text-right">{doc.vendorName ?? '—'}</dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground leading-snug">เลขผู้เสียภาษีผู้ขาย</dt>
+                  <dd className="font-medium leading-snug text-right">{doc.vendorTaxId ?? '—'}</dd>
+                </div>
+                {doc.description ? (
+                  <div className="flex justify-between gap-3 sm:col-span-2">
+                    <dt className="text-muted-foreground leading-snug">รายละเอียด</dt>
+                    <dd className="font-medium leading-snug text-right">{doc.description}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            </section>
+
+            {/* Line items */}
+            {doc.expenseDetail?.lines?.length ? (
+              <section className="rounded-lg border border-border bg-card overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/50 text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium leading-snug">บัญชี / รายการ</th>
+                      <th className="px-4 py-2 text-right font-medium leading-snug">ก่อน VAT</th>
+                      <th className="px-4 py-2 text-right font-medium leading-snug">VAT</th>
+                      <th className="px-4 py-2 text-right font-medium leading-snug">หัก ณ ที่จ่าย</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {doc.expenseDetail.lines.map((ln, i) => (
+                      <tr key={ln.lineNo ?? i}>
+                        <td className="px-4 py-2 align-top leading-snug">
+                          <div className="font-medium">{ln.category}</div>
+                          {ln.description ? (
+                            <div className="text-xs text-muted-foreground">{ln.description}</div>
+                          ) : null}
+                        </td>
+                        <td className="px-4 py-2 text-right align-top tabular-nums">{money(ln.amountBeforeVat)}</td>
+                        <td className="px-4 py-2 text-right align-top tabular-nums">{money(ln.vatAmount)}</td>
+                        <td className="px-4 py-2 text-right align-top tabular-nums">{money(ln.whtAmount)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </section>
+            ) : null}
+
+            {/* Totals */}
+            <section className="rounded-lg border border-border bg-card p-5">
+              <dl className="space-y-1.5 text-sm max-w-xs ml-auto">
+                <div className="flex justify-between gap-6">
+                  <dt className="text-muted-foreground leading-snug">ยอดก่อนภาษี</dt>
+                  <dd className="tabular-nums leading-snug">{money(doc.subtotal)}</dd>
+                </div>
+                <div className="flex justify-between gap-6">
+                  <dt className="text-muted-foreground leading-snug">VAT</dt>
+                  <dd className="tabular-nums leading-snug">{money(doc.vatAmount)}</dd>
+                </div>
+                <div className="flex justify-between gap-6">
+                  <dt className="text-muted-foreground leading-snug">หัก ณ ที่จ่าย</dt>
+                  <dd className="tabular-nums leading-snug">- {money(doc.withholdingTax)}</dd>
+                </div>
+                <div className="flex justify-between gap-6 border-t border-border pt-1.5 font-semibold">
+                  <dt className="leading-snug">ยอดสุทธิที่จ่าย</dt>
+                  <dd className="tabular-nums leading-snug">{money(doc.netPayment ?? doc.totalAmount)}</dd>
+                </div>
+              </dl>
+            </section>
+          </div>
+        )}
+      </QueryBoundary>
+
+      {/* InternalControlActionBar — shared across all 3 accounting modules. */}
+      {doc && user && (
+        <InternalControlActionBar
+          module="expense"
+          status={icabStatus}
+          docNumber={doc.number}
+          docAmount={Number(doc.netPayment ?? doc.totalAmount)}
+          docSubtitle={doc.vendorName ?? undefined}
+          auditLog={mapAuditEvents(auditQuery.data ?? [])}
+          currentUser={{
+            id: user.id,
+            role: user.role,
+            name: user.name,
+            canReverseOverride: user.canReverseOverride,
+          }}
+          makerCheckerEnabled={makerCheckerEnabled}
+          isViewerApprover={isViewerApprover}
+          isOwnDoc={isOwnDoc}
+          isLoading={isActionLoading}
+          canReverse={Boolean(canReverse)}
+          onCancel={() => navigate('/expenses')}
+          onClose={() => navigate('/expenses')}
+          onPost={() => postMutation.mutate()}
+          onSubmitForApproval={() => submitMutation.mutate()}
+          onApprove={() => approveMutation.mutate()}
+          onReverse={(payload) => voidMutation.mutate(payload)}
+          onPrint={() => printMutation.mutate({ docId: doc.id, docNumber: doc.number })}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -344,9 +344,9 @@ export default function ExpensesPage() {
       render: (e: Expense) => (
         <div className="flex items-center gap-1">
           <button
-            onClick={(ev) => { ev.stopPropagation(); openEdit(e); }}
+            onClick={(ev) => { ev.stopPropagation(); navigate(`/expenses/${e.id}`); }}
             className="p-1.5 hover:bg-muted rounded transition-colors"
-            title="ดู / แก้ไข"
+            title="ดูรายละเอียด"
           >
             <Eye className="size-4 text-muted-foreground" />
           </button>

--- a/apps/web/src/pages/__tests__/ExpenseDetailPage.test.ts
+++ b/apps/web/src/pages/__tests__/ExpenseDetailPage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { mapExpenseStatusToIcab } from '../ExpenseDetailPage';
+
+/**
+ * The bar speaks the 4-state ICAB model; expense docs carry 6 states. This
+ * mapping is the contract that keeps the action bar's buttons aligned with the
+ * expense lifecycle (owner decision: ACCRUAL maps to POSTED).
+ */
+describe('mapExpenseStatusToIcab', () => {
+  it('DRAFT stays DRAFT', () => {
+    expect(mapExpenseStatusToIcab('DRAFT')).toBe('DRAFT');
+  });
+
+  it('PENDING_APPROVAL maps to READY (awaiting approval)', () => {
+    expect(mapExpenseStatusToIcab('PENDING_APPROVAL')).toBe('READY');
+  });
+
+  it('APPROVED / ACCRUAL / POSTED all map to POSTED (booked → close/print/reverse)', () => {
+    expect(mapExpenseStatusToIcab('APPROVED')).toBe('POSTED');
+    expect(mapExpenseStatusToIcab('ACCRUAL')).toBe('POSTED');
+    expect(mapExpenseStatusToIcab('POSTED')).toBe('POSTED');
+  });
+
+  it('VOIDED maps to REVERSED (terminal)', () => {
+    expect(mapExpenseStatusToIcab('VOIDED')).toBe('REVERSED');
+  });
+});

--- a/apps/web/src/pages/assets/AssetDetailPage.tsx
+++ b/apps/web/src/pages/assets/AssetDetailPage.tsx
@@ -13,7 +13,6 @@ import {
   ArrowRightLeft,
   Undo2,
   Trash2,
-  CheckSquare,
   TrendingDown,
   History,
   ReceiptText,
@@ -31,11 +30,31 @@ import {
 import QueryBoundary from '@/components/QueryBoundary';
 import { formatDateShortThai, formatDateTime, formatNumberDecimal } from '@/utils/formatters';
 import { getErrorMessage } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useUiFlags } from '@/hooks/useUiFlags';
 import { assetsApi } from './api';
 import { AssetStatusBadge } from './components/AssetStatusBadge';
 import { TransferAssetDialog } from './components/TransferAssetDialog';
-import { ReverseConfirmDialog } from '@/components/accounting';
+import {
+  InternalControlActionBar,
+  ReverseConfirmDialog,
+  resolveCanReverse,
+  mapAuditEvents,
+  type IcabStatus,
+} from '@/components/accounting';
 import { CATEGORY_LABEL } from './types';
+
+/**
+ * Map the asset lifecycle onto the bar's 4-state ICAB model. The bar only
+ * surfaces its (purchase) reverse button in POSTED — disposal reverse stays a
+ * separate dialog (owner decision), gated to DISPOSED/WRITTEN_OFF, so those map
+ * to POSTED here but `canReverse` is held false for them.
+ */
+export function mapAssetStatusToIcab(status: string): IcabStatus {
+  if (status === 'DRAFT') return 'DRAFT';
+  if (status === 'REVERSED') return 'REVERSED';
+  return 'POSTED'; // POSTED / DISPOSED / WRITTEN_OFF
+}
 
 const fmt = (n: string | number | null | undefined): string =>
   n == null ? '-' : formatNumberDecimal(Number(n));
@@ -44,6 +63,8 @@ export default function AssetDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const flags = useUiFlags();
 
   const assetQuery = useQuery({
     queryKey: ['asset', id],
@@ -57,27 +78,33 @@ export default function AssetDetailPage() {
     enabled: !!id,
   });
 
-  const [showReverse, setShowReverse] = useState(false);
+  // Purchase reverse now runs through the bar's own dialog; only the disposal
+  // reverse keeps a standalone dialog (owner decision — tailored impact notes).
   const [showReverseDisposal, setShowReverseDisposal] = useState(false);
   const [showTransfer, setShowTransfer] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
   const [showInvoiceReceived, setShowInvoiceReceived] = useState(false);
 
+  type ReversePayload = { reasonId: string; reasonLabel: string; note: string };
+  const composeReason = (p: ReversePayload) =>
+    p.note ? `${p.reasonLabel} — ${p.note}` : p.reasonLabel;
+
   /**
-   * Asset-purchase reverse — wired through the shared ReverseConfirmDialog.
-   * The legacy assetsApi.reverse takes a single `reason: string`; the new
-   * dialog returns `{reasonId, reasonLabel, note}`, so we collapse the
-   * label + note into the existing reason field at the boundary.
+   * Asset-purchase reverse — fired by the shared InternalControlActionBar's
+   * internal reverse dialog (POSTED → REVERSED). The bar emits the structured
+   * `{reasonId, reasonLabel, note}`; we send the composed `reason` (back-compat
+   * + reversalReason storage) plus the structured label/note so the audit
+   * timeline can render them separately.
    */
   const reverseMutation = useMutation({
-    mutationFn: (reason: string) => assetsApi.reverse(id!, reason),
+    mutationFn: (p: ReversePayload) =>
+      assetsApi.reverse(id!, composeReason(p), { reasonLabel: p.reasonLabel, note: p.note }),
     onSuccess: (r) => {
       toast.success(`กลับรายการแล้ว → ${r.entryNo}`);
       queryClient.invalidateQueries({ queryKey: ['asset', id] });
       queryClient.invalidateQueries({ queryKey: ['asset-audit', id] });
       queryClient.invalidateQueries({ queryKey: ['assets'] });
       queryClient.invalidateQueries({ queryKey: ['assets-summary'] });
-      setShowReverse(false);
     },
     onError: (e) => toast.error(getErrorMessage(e)),
   });
@@ -87,7 +114,8 @@ export default function AssetDetailPage() {
    * different module-context message + endpoint.
    */
   const reverseDisposeMutation = useMutation({
-    mutationFn: (reason: string) => assetsApi.reverseDispose(id!, reason),
+    mutationFn: (p: ReversePayload) =>
+      assetsApi.reverseDispose(id!, composeReason(p), { reasonLabel: p.reasonLabel, note: p.note }),
     onSuccess: (r) => {
       toast.success(`คืนสถานะแล้ว → ${r.entryNo}`);
       queryClient.invalidateQueries({ queryKey: ['asset', id] });
@@ -160,8 +188,15 @@ export default function AssetDetailPage() {
 
   const asset = assetQuery.data;
 
+  const icabStatus = asset ? mapAssetStatusToIcab(asset.status) : 'DRAFT';
+  // Mode-aware (Audit Finding A) + only pure POSTED → the bar's (purchase)
+  // reverse button. DISPOSED/WRITTEN_OFF use the separate disposal dialog.
+  const canReverse =
+    resolveCanReverse(flags.reversePermission, user?.role, user?.canReverseOverride) &&
+    asset?.status === 'POSTED';
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pb-44 md:pb-40">
       <PageHeader
         title={asset?.assetCode ?? 'กำลังโหลด...'}
         subtitle={asset?.name}
@@ -181,12 +216,7 @@ export default function AssetDetailPage() {
                     <DropdownMenuItem onClick={() => navigate(`/assets/${id}/edit`)}>
                       <Edit className="mr-2 size-4" /> แก้ไข
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => postMutation.mutate()}
-                      disabled={postMutation.isPending}
-                    >
-                      <CheckSquare className="mr-2 size-4" /> ลงบัญชี (POST)
-                    </DropdownMenuItem>
+                    {/* ลงบัญชี (POST) ย้ายไปอยู่บน InternalControlActionBar ด้านล่าง */}
                     <DropdownMenuItem
                       onClick={() => setShowDelete(true)}
                       className="text-destructive"
@@ -208,12 +238,7 @@ export default function AssetDetailPage() {
                     <DropdownMenuItem onClick={() => navigate(`/assets/${id}/dispose`)}>
                       <Trash2 className="mr-2 size-4" /> จำหน่ายสินทรัพย์
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setShowReverse(true)}
-                      className="text-destructive"
-                    >
-                      <Undo2 className="mr-2 size-4" /> กลับรายการ
-                    </DropdownMenuItem>
+                    {/* กลับรายการ (purchase reverse) ย้ายไปอยู่บน InternalControlActionBar ด้านล่าง */}
                   </>
                 )}
                 {(asset.status === 'DISPOSED' || asset.status === 'WRITTEN_OFF') && (
@@ -434,18 +459,6 @@ export default function AssetDetailPage() {
 
       {asset && (
         <>
-          {/* InternalControlActionBar — shared ReverseConfirmDialog for the
-              asset-purchase reverse path. */}
-          <ReverseConfirmDialog
-            open={showReverse}
-            onOpenChange={setShowReverse}
-            module="asset"
-            docNumber={asset.assetCode}
-            isLoading={reverseMutation.isPending}
-            onConfirm={({ reasonLabel, note }) =>
-              reverseMutation.mutate(note ? `${reasonLabel} — ${note}` : reasonLabel)
-            }
-          />
           <TransferAssetDialog
             asset={asset}
             open={showTransfer}
@@ -465,9 +478,7 @@ export default function AssetDetailPage() {
               'JE การจำหน่ายจะถูกกลับรายการ (สลับ Dr↔Cr)',
               'ค่าเสื่อมราคาที่หยุดไว้ตอนจำหน่ายจะเริ่มคำนวณใหม่',
             ]}
-            onConfirm={({ reasonLabel, note }) =>
-              reverseDisposeMutation.mutate(note ? `${reasonLabel} — ${note}` : reasonLabel)
-            }
+            onConfirm={(payload) => reverseDisposeMutation.mutate(payload)}
           />
           <ConfirmDialog
             open={showDelete}
@@ -488,6 +499,34 @@ export default function AssetDetailPage() {
             onConfirm={() => invoiceReceivedMutation.mutate()}
           />
         </>
+      )}
+
+      {/* InternalControlActionBar — shared "ควบคุมภายใน" control surface.
+          Handles the audit timeline + state machine + (purchase) reverse +
+          post + close. Disposal reverse stays a standalone dialog above. */}
+      {asset && user && (
+        <InternalControlActionBar
+          module="asset"
+          status={icabStatus}
+          docNumber={asset.assetCode}
+          docSubtitle={asset.name ?? undefined}
+          docAmount={asset.purchaseCost != null ? Number(asset.purchaseCost) : undefined}
+          auditLog={mapAuditEvents(auditQuery.data ?? [])}
+          currentUser={{
+            id: user.id,
+            role: user.role,
+            name: user.name,
+            canReverseOverride: user.canReverseOverride,
+          }}
+          isLoading={
+            reverseMutation.isPending || postMutation.isPending || reverseDisposeMutation.isPending
+          }
+          canReverse={Boolean(canReverse)}
+          onCancel={() => navigate('/assets')}
+          onClose={() => navigate('/assets')}
+          onPost={() => postMutation.mutate()}
+          onReverse={(payload) => reverseMutation.mutate(payload)}
+        />
       )}
     </div>
   );

--- a/apps/web/src/pages/assets/AssetDetailPage.tsx
+++ b/apps/web/src/pages/assets/AssetDetailPage.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import QueryBoundary from '@/components/QueryBoundary';
 import { formatDateShortThai, formatDateTime, formatNumberDecimal } from '@/utils/formatters';
-import { getErrorMessage } from '@/lib/api';
+import api, { getErrorMessage } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUiFlags } from '@/hooks/useUiFlags';
 import { assetsApi } from './api';
@@ -58,6 +58,23 @@ export function mapAssetStatusToIcab(status: string): IcabStatus {
 
 const fmt = (n: string | number | null | undefined): string =>
   n == null ? '-' : formatNumberDecimal(Number(n));
+
+/** Fetch the server-rendered ใบรับสินทรัพย์ PDF (JWT in-memory → axios) and open it. */
+async function openAssetReceiptPdf(assetId: string, assetCode: string): Promise<void> {
+  const res = await api.get(`/assets/${assetId}/receipt.pdf`, { responseType: 'blob' });
+  const blob = new Blob([res.data], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const win = window.open(url, '_blank');
+  if (!win) {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${assetCode}.pdf`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
 
 export default function AssetDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -125,6 +142,12 @@ export default function AssetDetailPage() {
       setShowReverseDisposal(false);
     },
     onError: (e) => toast.error(getErrorMessage(e)),
+  });
+
+  const printMutation = useMutation({
+    mutationFn: ({ assetId, assetCode }: { assetId: string; assetCode: string }) =>
+      openAssetReceiptPdf(assetId, assetCode),
+    onError: () => toast.error('ไม่สามารถสร้างใบรับสินทรัพย์ PDF ได้'),
   });
 
   const transferMutation = useMutation({
@@ -526,6 +549,7 @@ export default function AssetDetailPage() {
           onClose={() => navigate('/assets')}
           onPost={() => postMutation.mutate()}
           onReverse={(payload) => reverseMutation.mutate(payload)}
+          onPrint={() => printMutation.mutate({ assetId: asset.id, assetCode: asset.assetCode })}
         />
       )}
     </div>

--- a/apps/web/src/pages/assets/__tests__/AssetDetailPage.test.ts
+++ b/apps/web/src/pages/assets/__tests__/AssetDetailPage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { mapAssetStatusToIcab } from '../AssetDetailPage';
+
+/**
+ * Asset lifecycle → bar's 4-state ICAB model. POSTED is the only state that
+ * gets the bar's (purchase) reverse button; DISPOSED/WRITTEN_OFF map to POSTED
+ * for display but reverse is held off there (separate disposal dialog handles
+ * them — see canReverse gate in the page).
+ */
+describe('mapAssetStatusToIcab', () => {
+  it('DRAFT stays DRAFT', () => {
+    expect(mapAssetStatusToIcab('DRAFT')).toBe('DRAFT');
+  });
+
+  it('POSTED stays POSTED', () => {
+    expect(mapAssetStatusToIcab('POSTED')).toBe('POSTED');
+  });
+
+  it('REVERSED stays REVERSED (terminal)', () => {
+    expect(mapAssetStatusToIcab('REVERSED')).toBe('REVERSED');
+  });
+
+  it('DISPOSED / WRITTEN_OFF map to POSTED (booked; disposal reverse is separate)', () => {
+    expect(mapAssetStatusToIcab('DISPOSED')).toBe('POSTED');
+    expect(mapAssetStatusToIcab('WRITTEN_OFF')).toBe('POSTED');
+  });
+});

--- a/apps/web/src/pages/assets/api.ts
+++ b/apps/web/src/pages/assets/api.ts
@@ -97,8 +97,16 @@ export const assetsApi = {
     return data;
   },
 
-  reverse: async (id: string, reason: string): Promise<{ entryNo: string }> => {
-    const { data } = await api.post<{ entryNo: string }>(`/assets/${id}/reverse`, { reason });
+  reverse: async (
+    id: string,
+    reason: string,
+    extra?: { reasonLabel?: string; note?: string },
+  ): Promise<{ entryNo: string }> => {
+    const { data } = await api.post<{ entryNo: string }>(`/assets/${id}/reverse`, {
+      reason,
+      reasonLabel: extra?.reasonLabel,
+      note: extra?.note,
+    });
     return data;
   },
 
@@ -134,9 +142,15 @@ export const assetsApi = {
     return data;
   },
 
-  reverseDispose: async (id: string, reason: string): Promise<{ entryNo: string }> => {
+  reverseDispose: async (
+    id: string,
+    reason: string,
+    extra?: { reasonLabel?: string; note?: string },
+  ): Promise<{ entryNo: string }> => {
     const { data } = await api.post<{ entryNo: string }>(`/assets/${id}/reverse-dispose`, {
       reason,
+      reasonLabel: extra?.reasonLabel,
+      note: extra?.note,
     });
     return data;
   },

--- a/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeViewPage.tsx
@@ -20,12 +20,13 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { RejectModal } from './components/RejectModal';
 import { SaveAsTemplateModal } from './components/SaveAsTemplateModal';
 import { AutoJournalPreview } from './components/AutoJournalPreview';
-import { InternalControlActionBar } from '@/components/accounting';
+import { InternalControlActionBar, resolveCanReverse } from '@/components/accounting';
 import type { IcabAuditEvent } from '@/components/accounting';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import api from '@/lib/api';
 import type { OtherIncome, OtherIncomeStatus } from '@/lib/otherIncome.types';
 import { useAuth } from '@/contexts/AuthContext';
+import { useUiFlags } from '@/hooks/useUiFlags';
 import { formatThaiDateLong, formatThaiDateShort } from '@/lib/date';
 
 // ------------------------------------------------------------------
@@ -153,10 +154,6 @@ function buildJeFromDoc(doc: OtherIncome): JeLine[] {
   return lines;
 }
 
-// Roles that can reverse a POSTED document
-// B9: ACCOUNTANT removed — backend @Roles only allows OWNER/FINANCE_MANAGER on POST :id/reverse
-const REVERSE_ROLES = ['OWNER', 'FINANCE_MANAGER'];
-
 /**
  * Map server-side AuditLogEntry rows to the IcabAuditEvent shape consumed
  * by the shared InternalControlActionBar timeline.
@@ -233,6 +230,7 @@ export default function OtherIncomeViewPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const flags = useUiFlags();
 
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [showTemplateModal, setShowTemplateModal] = useState(false);
@@ -337,8 +335,12 @@ export default function OtherIncomeViewPage() {
     onError: () => toast.error('ไม่สามารถสร้างใบเสร็จ PDF ได้'),
   });
 
+  // Mode-aware (Audit Finding A): mirrors the backend ReversePermissionGuard so
+  // the "↺ ยกเลิก/กลับรายการ" button only shows when the server will allow it —
+  // respects OWNER_ONLY / +FM / +FM+ACCOUNTANT / CUSTOM modes uniformly.
   const canReverse =
-    user?.role && REVERSE_ROLES.includes(user.role) && docQuery.data?.status === 'POSTED';
+    resolveCanReverse(flags.reversePermission, user?.role, user?.canReverseOverride) &&
+    docQuery.data?.status === 'POSTED';
 
   const doc = docQuery.data;
   const jeLines = doc ? buildJeFromDoc(doc) : [];


### PR DESCRIPTION
## สรุป (Summary)

ทำตาม Developer Command **InternalControlActionBar v2.2** ให้ครบ — นำ shared control bar "ควบคุมภายใน" ไปใช้ครบทั้ง **3 modules** (Other Income มีอยู่แล้ว → เพิ่ม **Expense** + **Asset**) พร้อมแก้ผลจากการ audit ของเดิม

งานเริ่มจาก audit พบว่า component + 2 settings + Other Income pilot ถูก implement ไปแล้ว จึงโฟกัสที่ (A) ทำให้สิทธิ์ reverse ทำงานสม่ำเสมอทั้ง 3 module, (B) แก้บั๊กไฟล์, และ (7-8) นำ bar ไปลง Expense + Asset

## What changed

### Foundation (commit 1)
- **`resolveCanReverse()`** FE helper mirrors the backend `ReversePermissionGuard` (OWNER_ONLY / +FM / +FM+ACCOUNTANT / CUSTOM) → ปุ่ม reverse โชว์เฉพาะตอน server อนุญาตจริง. `OtherIncomeViewPage` เลิกใช้ static role list
- **`mapAuditEvents()`** shared helper สำหรับ audit timeline (ใช้ทั้ง 3 module)
- **Finding A** — reverse permission uniform: OI/Expense/Asset reverse|void ใช้ `@UseGuards(ReversePermissionGuard)` + `@Roles(OWNER, FINANCE_MANAGER, ACCOUNTANT)` coarse superset → mode `+ACCOUNTANT`/`CUSTOM` ใช้ได้จริง (เดิม OI/Asset hardcode ละเลย mode). Default OWNER+FM ยัง reject ACCOUNTANT ถูกต้อง
- **Finding B** — แก้ NUL byte ที่ `other-income.service.ts:1215` (raw NUL → `\x00` escape) ที่ทำให้ไฟล์เป็น "binary" ใน grep/git

### Expense (commit 2)
- **`ExpenseDetailPage`** ใหม่ (`/expenses/:id`) mount bar เต็มตัว (mirror OI gold standard); Eye action ใน list → navigate มาหน้านี้
- status adapter 6→4: `ACCRUAL`→`POSTED` (owner decision), `VOIDED`→`REVERSED`
- `GET /expense-documents/:id/audit` + void รับ structured `reasonLabel`/`note` → stamp `reverseReasonLabel`/`reverseNote` (parity timeline)
- **ใบสำคัญจ่าย PDF** `GET /expense-documents/:id/voucher.pdf` (puppeteer, POSTED/VOIDED เท่านั้น)

### Asset (commit 3)
- `AssetDetailPage` mount bar; **2 reverse flows แยกกัน** (owner decision): purchase reverse ผ่าน bar; disposal reverse คง dialog แยก (impact notes เฉพาะ)
- reverse + reverse-dispose endpoints รับ structured reason

## Decisions (จากเจ้าของ)
1. ทำ Expense ก่อน · 2. Expense `ACCRUAL`→`POSTED` · 3. Asset reverse รับ structured reason · 4. Asset disposal คง dialog แยก · (เพิ่ม) ขยายสิทธิ์ ACCOUNTANT ให้ mode ใช้ได้จริง

## Testing
- ✅ `tsc --noEmit` ผ่าน 0 errors ทั้ง api + web
- ✅ Web vitest เต็ม **593 passed**
- ✅ ทุก API suite ที่แตะ **ผ่านตอนรันเดี่ยว** (expense-documents.service 88, asset.service 54, other-income.service 15, controllers + guards)
- ✅ ผ่าน adversarial code review (46 agents): 19 confirmed → แก้ที่เป็นบั๊กจริง (expense void audit parity, companyInfo warn, audit cast, doc comments); 20 false-positive ถูกคัดออก
- ⚠️ **หมายเหตุ:** รัน API jest หลาย DB-backed module พร้อมกันมี ~20 fail จาก **parallel-DB contention เดิมของ repo** (suite เดียวกันผ่านตอนรันเดี่ยว) — ไม่ใช่จาก PR นี้ (เทียบ "fix-test-suite-hang" ใน history)

## Follow-ups / notes (ไม่อยู่ใน scope PR นี้)
- 🔒 **Cross-branch access (pre-existing):** `GET /expense-documents/:id/audit` + `findOne` ไม่ได้ scope ตาม branch (BranchManager เปิด doc ของสาขาอื่นด้วย id ได้) — เป็น pattern เดิมของ module (findOne/OI audit ก็เป็น) ควรแก้ระดับ access-model แยก
- QR/verify URL ใน voucher PDF hardcode domain (เหมือน OI receipt) — ควรย้ายเป็น env var
- Expense `REPAIR_SERVICE` doc type + per-doc `permissionConfig` (P7) — ทำ read-only ตามเดิม ยังไม่ handle พิเศษ

🤖 Generated with [Claude Code](https://claude.com/claude-code)