### PR TITLE
chore(accounting): account pickers show NAME only (no code, no parens)

### DIFF
--- a/apps/web/src/components/CashAccountSelect.tsx
+++ b/apps/web/src/components/CashAccountSelect.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
+import { accountDisplayName } from '@/utils/accountName';
 import {
   Select,
   SelectContent,
@@ -63,8 +64,7 @@ export function CashAccountSelect({
       <SelectContent>
         {CASH_ACCOUNT_CODES.map((code) => (
           <SelectItem key={code} value={code}>
-            <span className="font-mono text-xs text-muted-foreground mr-2">{code}</span>
-            {nameMap.get(code) ?? ''}
+            {accountDisplayName(nameMap.get(code) ?? '')}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/web/src/components/expense-form-v4/AdjustmentSection.tsx
+++ b/apps/web/src/components/expense-form-v4/AdjustmentSection.tsx
@@ -13,6 +13,7 @@ import { Plus, Trash2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import type { ExpenseAdjustmentForm } from './types';
 import { newAdjustment } from './types';
 import { useUiFlags } from '@/hooks/useUiFlags';
+import { accountDisplayName } from '@/utils/accountName';
 
 interface Props {
   /** Reconciliation diff = amountPaid − (totalAmount − wht). Sign decides side. */
@@ -178,7 +179,7 @@ export function AdjustmentSection({
                     <option value="">— เลือกบัญชี —</option>
                     {effectiveSuggested.map((s) => (
                       <option key={s.code} value={s.code}>
-                        {s.code} — {s.name}
+                        {accountDisplayName(s.name)}
                       </option>
                     ))}
                   </select>

--- a/apps/web/src/components/expense-form-v4/CashAccountVisualPicker.tsx
+++ b/apps/web/src/components/expense-form-v4/CashAccountVisualPicker.tsx
@@ -3,6 +3,7 @@ import api from '@/lib/api';
 import { CASH_ACCOUNT_CODES } from '@/components/CashAccountSelect';
 import { Banknote, Landmark } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { accountDisplayName } from '@/utils/accountName';
 
 interface CoaRow { code: string; name: string }
 
@@ -41,8 +42,7 @@ export function CashAccountVisualPicker({ value, onChange }: Props) {
           >
             <Icon className={cn('size-4 mt-0.5', selected ? 'text-primary' : 'text-muted-foreground')} />
             <div className="flex-1 min-w-0">
-              <div className="font-mono text-xs text-muted-foreground">{code}</div>
-              <div className="text-sm leading-snug truncate">{nameMap.get(code) ?? '—'}</div>
+              <div className="text-sm leading-snug truncate">{accountDisplayName(nameMap.get(code) ?? '—')}</div>
             </div>
           </button>
         );

--- a/apps/web/src/components/expense-form-v4/ItemLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/ItemLinesSection.tsx
@@ -2,6 +2,7 @@ import { useCoaGroups } from '@/hooks/useCoa';
 import { Plus, Trash2 } from 'lucide-react';
 import { ExpenseLineForm, newLine } from './types';
 import { formatNumberDecimal } from '@/utils/formatters';
+import { accountDisplayName } from '@/utils/accountName';
 import { useUiFlags } from '@/hooks/useUiFlags';
 import { whtRatesToSelectOptions } from '@/lib/wht-rates';
 import TaxDisallowedHint from './TaxDisallowedHint';
@@ -70,7 +71,7 @@ export function ItemLinesSection({ lines, onChange, priceTypeLabel }: Props) {
                 {groups.flatMap((g) =>
                   g.accounts.map((a) => (
                     <option key={a.code} value={a.code}>
-                      {a.code} — {a.name}
+                      {accountDisplayName(a.name)}
                     </option>
                   )),
                 )}

--- a/apps/web/src/pages/AccountRolesPage.tsx
+++ b/apps/web/src/pages/AccountRolesPage.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
+import { accountDisplayName } from '@/utils/accountName';
 
 interface RoleMapRow {
   id: string;
@@ -304,8 +305,7 @@ function EditRoleMapDialog({
                             )}
                             aria-hidden
                           />
-                          <code className="mr-2 font-mono text-xs">{acc.code}</code>
-                          <span className="leading-snug">{acc.name}</span>
+                          <span className="leading-snug">{accountDisplayName(acc.name)}</span>
                         </CommandItem>
                       ))}
                     </CommandGroup>

--- a/apps/web/src/pages/AssetManagementPage/components/AssetForm.tsx
+++ b/apps/web/src/pages/AssetManagementPage/components/AssetForm.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { Asset, Branch, categoryOptions, inputClass, fmt, AssetForm as AssetFormType } from '../types';
 import { useCoaGroups } from '@/hooks/useCoa';
+import { accountDisplayName } from '@/utils/accountName';
 
 interface AssetFormProps {
   editingAsset: Asset | null;
@@ -310,7 +311,7 @@ export default function AssetForm({
                     <option value="">-- เลือก --</option>
                     {costAccounts.map((a) => (
                       <option key={a.code} value={a.code}>
-                        {a.code} {a.name}
+                        {accountDisplayName(a.name)}
                       </option>
                     ))}
                   </select>
@@ -327,7 +328,7 @@ export default function AssetForm({
                     <option value="">-- เลือก --</option>
                     {depAccounts.map((a) => (
                       <option key={a.code} value={a.code}>
-                        {a.code} {a.name}
+                        {accountDisplayName(a.name)}
                       </option>
                     ))}
                   </select>
@@ -344,7 +345,7 @@ export default function AssetForm({
                     <option value="">-- เลือก --</option>
                     {accumAccounts.map((a) => (
                       <option key={a.code} value={a.code}>
-                        {a.code} {a.name}
+                        {accountDisplayName(a.name)}
                       </option>
                     ))}
                   </select>

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -18,6 +18,7 @@ import { Receipt, Plus, Pencil, MoreVertical, Bookmark, Wallet, BarChart3, Searc
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { Button } from '@/components/ui/button';
 import { formatDateShortThai, formatNumberDecimal } from '@/utils/formatters';
+import { accountDisplayName } from '@/utils/accountName';
 import { ExpenseFormV4 } from '@/components/expense-form-v4/ExpenseFormV4';
 import { ReopenedPeriodBanner } from '@/components/accounting/ReopenedPeriodBanner';
 import { useApprovalActions, getApprovalReason, canApprove } from '@/hooks/useApprovalActions';
@@ -595,7 +596,7 @@ export default function ExpensesPage() {
             <optgroup key={g.category} label={g.category}>
               {g.accounts.map((a) => (
                 <option key={a.code} value={a.code}>
-                  {a.code} {a.name}
+                  {accountDisplayName(a.name)}
                 </option>
               ))}
             </optgroup>

--- a/apps/web/src/pages/PaymentMethodSettingsPage.tsx
+++ b/apps/web/src/pages/PaymentMethodSettingsPage.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
+import { accountDisplayName } from '@/utils/accountName';
 
 type Method = 'CASH' | 'TRANSFER' | 'QR';
 
@@ -355,8 +356,7 @@ function AddMappingDialog({ open, onOpenChange, coaAccounts, existing, onCreated
               <SelectContent>
                 {availableAccounts.map((a) => (
                   <SelectItem key={a.code} value={a.code}>
-                    <span className="font-mono text-xs mr-2">{a.code}</span>
-                    {a.name}
+                    {accountDisplayName(a.name)}
                   </SelectItem>
                 ))}
                 {availableAccounts.length === 0 && (

--- a/apps/web/src/pages/assets/AssetDisposePage.tsx
+++ b/apps/web/src/pages/assets/AssetDisposePage.tsx
@@ -27,6 +27,7 @@ import { Badge } from '@/components/ui/badge';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import QueryBoundary from '@/components/QueryBoundary';
 import { formatNumberDecimal } from '@/utils/formatters';
+import { accountDisplayName } from '@/utils/accountName';
 import { assetsApi } from './api';
 import { CATEGORY_LABEL, CASH_ACCOUNTS } from './types';
 import { disposalSchema, type DisposalFormValues } from './disposal-schema';
@@ -231,7 +232,7 @@ export default function AssetDisposePage() {
                         <SelectContent>
                           {CASH_ACCOUNTS.map((c) => (
                             <SelectItem key={c.code} value={c.code}>
-                              {c.code} {c.name}
+                              {accountDisplayName(c.name)}
                             </SelectItem>
                           ))}
                         </SelectContent>

--- a/apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection2Cost.tsx
@@ -184,8 +184,8 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
                   <SelectValue placeholder="เลือก" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="11-4101">11-4101 ภาษีซื้อ (เครดิตได้)</SelectItem>
-                  <SelectItem value="11-4102">11-4102 ภาษีซื้อรอเรียกเก็บ</SelectItem>
+                  <SelectItem value="11-4101">ภาษีซื้อ</SelectItem>
+                  <SelectItem value="11-4102">ภาษีซื้อรอเรียกเก็บ</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -236,8 +236,8 @@ export function AssetEntrySection2Cost({ calc }: { calc: CalculationResult }) {
                     <SelectValue placeholder="เลือก" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="21-3102">21-3102 PND3 ค้างจ่าย</SelectItem>
-                    <SelectItem value="21-3103">21-3103 PND53 ค้างจ่าย</SelectItem>
+                    <SelectItem value="21-3102">PND3 ค้างจ่าย</SelectItem>
+                    <SelectItem value="21-3103">PND53 ค้างจ่าย</SelectItem>
                   </SelectContent>
                 </Select>
                 {errors.whtAccount && (

--- a/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/components/ui/dialog';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { cn } from '@/lib/utils';
+import { accountDisplayName } from '@/utils/accountName';
 import { assetsApi } from '../api';
 import type { AssetEntryFormValues } from '../schema';
 import { CASH_ACCOUNTS, type SupplierLite } from '../types';
@@ -311,7 +312,7 @@ export function AssetEntrySection3Vendor() {
             <SelectContent>
               {CASH_ACCOUNTS.map((c) => (
                 <SelectItem key={c.code} value={c.code}>
-                  {c.code} {c.name}
+                  {accountDisplayName(c.name)}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
+++ b/apps/web/src/pages/other-income/OtherIncomeEntryPage.tsx
@@ -21,6 +21,7 @@ import QueryBoundary from '@/components/QueryBoundary';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDebounce } from '@/hooks/useDebounce';
 import { formatNumber, formatNumberDecimal } from '@/utils/formatters';
+import { accountDisplayName } from '@/utils/accountName';
 import { otherIncomeApi } from '@/lib/otherIncome';
 import { otherIncomeFormSchema, type OtherIncomeFormValues } from '@/lib/otherIncome.schema';
 import { ItemsTable } from './components/ItemsTable';
@@ -929,9 +930,8 @@ export default function OtherIncomeEntryPage() {
                         </div>
                         <div className="min-w-0">
                           <p className="text-sm font-semibold text-foreground leading-tight truncate">
-                            {a.name}
+                            {accountDisplayName(a.name)}
                           </p>
-                          <p className="text-[10px] font-mono text-muted-foreground">{a.code}</p>
                         </div>
                       </button>
                     );

--- a/apps/web/src/pages/other-income/components/AccountSearchDropdown.tsx
+++ b/apps/web/src/pages/other-income/components/AccountSearchDropdown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Search, CheckCircle2, ChevronUp, ChevronDown } from 'lucide-react';
 import { useCoaGroups } from '@/hooks/useCoa';
+import { accountDisplayName } from '@/utils/accountName';
 
 interface CoaItem {
   code: string;
@@ -72,8 +73,7 @@ export function AccountSearchDropdown({
       >
         {selected ? (
           <span className="flex items-baseline gap-2 truncate">
-            <span className="font-mono text-xs font-bold text-primary">{selected.code}</span>
-            <span className="truncate">{selected.name}</span>
+            <span className="truncate">{accountDisplayName(selected.name)}</span>
           </span>
         ) : (
           <span className="text-muted-foreground">{placeholder}</span>
@@ -127,14 +127,7 @@ export function AccountSearchDropdown({
                       isBlocked ? 'opacity-50 cursor-not-allowed bg-muted/40' : 'hover:bg-accent'
                     } ${isSel ? 'bg-accent' : ''}`}
                   >
-                    <span
-                      className={`font-mono w-16 font-bold flex-shrink-0 ${
-                        isBlocked ? 'text-muted-foreground' : 'text-primary'
-                      }`}
-                    >
-                      {a.code}
-                    </span>
-                    <span className="flex-1 truncate">{a.name}</span>
+                    <span className="flex-1 truncate">{accountDisplayName(a.name)}</span>
                     {isBlocked && (
                       <span className="text-[10px] text-muted-foreground shrink-0">
                         ยังไม่รองรับ

--- a/apps/web/src/utils/__tests__/accountName.test.ts
+++ b/apps/web/src/utils/__tests__/accountName.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { accountDisplayName } from '../accountName';
+
+describe('accountDisplayName', () => {
+  it('strips the "(...)" parenthetical', () => {
+    expect(accountDisplayName('ภาษีซื้อ (เครดิตได้)')).toBe('ภาษีซื้อ');
+    expect(accountDisplayName('ลูกหนี้ผ่อนชำระ (HP Receivable Gross)')).toBe('ลูกหนี้ผ่อนชำระ');
+  });
+
+  it('leaves a plain name untouched', () => {
+    expect(accountDisplayName('ภาษีซื้อรอเรียกเก็บ')).toBe('ภาษีซื้อรอเรียกเก็บ');
+    expect(accountDisplayName('เงินสด — สุทธินีย์ คงเดช')).toBe('เงินสด — สุทธินีย์ คงเดช');
+  });
+
+  it('drops a leading NN-NNNN / SNN-NNNN code if embedded in the name', () => {
+    expect(accountDisplayName('11-4101 ภาษีซื้อ (เครดิตได้)')).toBe('ภาษีซื้อ');
+    expect(accountDisplayName('S41-1101 รายได้ขายมือถือใหม่')).toBe('รายได้ขายมือถือใหม่');
+  });
+
+  it('handles null / undefined / empty', () => {
+    expect(accountDisplayName(null)).toBe('');
+    expect(accountDisplayName(undefined)).toBe('');
+    expect(accountDisplayName('')).toBe('');
+  });
+});

--- a/apps/web/src/utils/accountName.ts
+++ b/apps/web/src/utils/accountName.ts
@@ -1,0 +1,20 @@
+/**
+ * Format a chart-of-accounts account NAME for entry-form pickers.
+ *
+ * Owner preference: in the account-SELECTION dropdowns of data-entry forms, show
+ * the account name only — drop the `NN-NNNN` code prefix AND any "(...)"
+ * parenthetical (e.g. "ภาษีซื้อ (เครดิตได้)" → "ภาษีซื้อ"). The code is still kept
+ * in search values, the JE/journal preview, reports, the chart-of-accounts
+ * manager, and PEAK export, where it is accounting-essential.
+ *
+ * This only strips a leading code if it happens to be embedded in the name; the
+ * common case is that callers already pass just `account.name`.
+ */
+export function accountDisplayName(name: string | null | undefined): string {
+  if (!name) return '';
+  return name
+    .replace(/^\s*S?\d{2}-\d{4}\s+/, '') // drop a leading NN-NNNN / SNN-NNNN code
+    .replace(/\s*\([^)]*\)/g, '') // drop "(...)" parentheticals
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}


### PR DESCRIPTION
## สรุป
ตามที่เจ้าของแจ้ง: **dropdown เลือกบัญชีในฟอร์มบันทึก ให้โชว์ชื่อบัญชีล้วน** — ตัดรหัส `NN-NNNN` และวงเล็บ `(...)` ออก (เช่น "11-4101 ภาษีซื้อ (เครดิตได้)" → "ภาษีซื้อ")

## ทำอะไร
- helper ใหม่ `accountDisplayName()` (`utils/accountName.ts`) — ตัดรหัส + วงเล็บ
- ใช้กับ ~16 account-picker: เงินสด/ธนาคาร · หมวดค่าใช้จ่าย + บัญชีปรับปรุง · บัญชีสินทรัพย์/ค่าเสื่อม/ค่าเสื่อมสะสม · บัญชีรับ/จ่ายเงิน · VAT/WHT · payment-method mapping · account-roles
- **คงรหัสไว้** ที่จำเป็นทางบัญชี: JE/journal preview · งบดุล/GL/Trial Balance/P&L · จัดการผังบัญชี · PEAK/Excel export
- **คงรหัสใน search/filter ทุกตัว** → ผู้ใช้ยังพิมพ์รหัสค้นบัญชีได้

## ทดสอบ
- ✅ web tsc 0 · web vitest **597 passed** (รวม unit test ของ accountDisplayName) · กวาดจุดด้วย workflow (multi-angle) + classify ก่อนแก้

🤖 Generated with [Claude Code](https://claude.com/claude-code)