### PR TITLE
feat(assets): Custodian field becomes a combobox (pick a user or type)

### DIFF
--- a/apps/web/src/pages/assets/components/AssetEntrySection1Info.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection1Info.tsx
@@ -2,6 +2,8 @@
 // Pure presentation. Uses parent FormProvider for state.
 
 import { useFormContext } from 'react-hook-form';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
@@ -34,6 +36,23 @@ export function AssetEntrySection1Info({ assetCode, branches }: Props) {
   const category = watch('category');
   const branchId = watch('branchId');
   const warrantyExpire = watch('warrantyExpire');
+  // ผู้รับผิดชอบ (Custodian) — combobox: free-text <Input> + a <datalist> of
+  // system users, so the user can pick an existing user OR type a custom name
+  // (e.g. staff without a login). custodian stays a name string. /users returns
+  // paginated { data, total, page, limit }, so unwrap.
+  const usersQuery = useQuery({
+    queryKey: ['users', 'asset-custodian'],
+    queryFn: async () => {
+      const res = await api.get('/users', { params: { limit: 500 } });
+      const list: { id: string; name: string }[] =
+        res.data?.data ?? (Array.isArray(res.data) ? res.data : []);
+      return list;
+    },
+  });
+  // Distinct names for the suggestion list.
+  const custodianNames = Array.from(
+    new Set((usersQuery.data ?? []).map((u) => u.name).filter(Boolean)),
+  );
 
   return (
     <Card>
@@ -110,7 +129,17 @@ export function AssetEntrySection1Info({ assetCode, branches }: Props) {
         </div>
         <div>
           <Label>ผู้รับผิดชอบ (Custodian) *</Label>
-          <Input {...register('custodian')} placeholder="ชื่อพนักงานผู้ดูแล" />
+          <Input
+            {...register('custodian')}
+            list="asset-custodian-options"
+            placeholder="พิมพ์ชื่อ หรือเลือกจากรายการ"
+            autoComplete="off"
+          />
+          <datalist id="asset-custodian-options">
+            {custodianNames.map((name) => (
+              <option key={name} value={name} />
+            ))}
+          </datalist>
           {errors.custodian && (
             <p className="text-sm text-destructive mt-1">{errors.custodian.message}</p>
           )}


### PR DESCRIPTION
ช่อง **ผู้รับผิดชอบ (Custodian)** ในฟอร์มบันทึกซื้อสินทรัพย์ เปลี่ยนจาก text input ล้วน → **combobox**: พิมพ์ชื่อเองได้ หรือเลือกจากรายการ user ในระบบ (`<Input>` + `<datalist>` ของ users)

- ยังเก็บเป็นชื่อ (string) เหมือนเดิม — ไม่แตะ schema/backend
- รองรับทั้งพนักงานที่เป็น user ในระบบ และคนที่ไม่มี login (พิมพ์เอง)

ทดสอบ: web tsc 0 · vitest 597 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)