### PR TITLE
feat(assets): custodian comboboxes everywhere (transfer + petty-cash)

### DIFF
--- a/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
@@ -1,6 +1,7 @@
 import { Plus, Trash2, Users } from 'lucide-react';
 import { PettyCashFormFields, newPettyCashLine } from './types';
 import { formatNumberDecimal } from '@/utils/formatters';
+import { useUserNames } from '@/hooks/useUserNames';
 
 interface Props {
   value: PettyCashFormFields;
@@ -16,6 +17,7 @@ interface Props {
  * + system_config.
  */
 export function PettyCashLinesSection({ value, onChange }: Props) {
+  const custodianNames = useUserNames();
   const updateField = (patch: Partial<PettyCashFormFields>) => onChange({ ...value, ...patch });
 
   const updateLine = (uid: string, p: Partial<(typeof value.lines)[number]>) => {
@@ -56,8 +58,15 @@ export function PettyCashLinesSection({ value, onChange }: Props) {
               value={value.custodianName}
               onChange={(e) => updateField({ custodianName: e.target.value })}
               placeholder="ชื่อพนักงานที่ดูแลเงินสดย่อย"
+              list="petty-cash-custodian-options"
+              autoComplete="off"
               className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
             />
+            <datalist id="petty-cash-custodian-options">
+              {custodianNames.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
           </div>
         </div>
         <div className="flex items-end text-xs text-muted-foreground">

--- a/apps/web/src/hooks/useUserNames.ts
+++ b/apps/web/src/hooks/useUserNames.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+
+/**
+ * Distinct system-user display names — used to populate the `<datalist>` of
+ * custodian / responsible-person comboboxes (asset entry + transfer, petty-cash
+ * custodian, ...). The user can pick a name OR type a custom one, so these are
+ * suggestions only. `/users` returns paginated `{ data, total, page, limit }`.
+ */
+export function useUserNames(): string[] {
+  const query = useQuery({
+    queryKey: ['users', 'names'],
+    queryFn: async () => {
+      const res = await api.get('/users', { params: { limit: 500 } });
+      const list: { id: string; name: string }[] =
+        res.data?.data ?? (Array.isArray(res.data) ? res.data : []);
+      return list;
+    },
+    staleTime: 5 * 60_000,
+  });
+  return Array.from(new Set((query.data ?? []).map((u) => u.name).filter(Boolean)));
+}

--- a/apps/web/src/pages/assets/components/AssetEntrySection1Info.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection1Info.tsx
@@ -2,8 +2,7 @@
 // Pure presentation. Uses parent FormProvider for state.
 
 import { useFormContext } from 'react-hook-form';
-import { useQuery } from '@tanstack/react-query';
-import api from '@/lib/api';
+import { useUserNames } from '@/hooks/useUserNames';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
@@ -36,23 +35,8 @@ export function AssetEntrySection1Info({ assetCode, branches }: Props) {
   const category = watch('category');
   const branchId = watch('branchId');
   const warrantyExpire = watch('warrantyExpire');
-  // ผู้รับผิดชอบ (Custodian) — combobox: free-text <Input> + a <datalist> of
-  // system users, so the user can pick an existing user OR type a custom name
-  // (e.g. staff without a login). custodian stays a name string. /users returns
-  // paginated { data, total, page, limit }, so unwrap.
-  const usersQuery = useQuery({
-    queryKey: ['users', 'asset-custodian'],
-    queryFn: async () => {
-      const res = await api.get('/users', { params: { limit: 500 } });
-      const list: { id: string; name: string }[] =
-        res.data?.data ?? (Array.isArray(res.data) ? res.data : []);
-      return list;
-    },
-  });
-  // Distinct names for the suggestion list.
-  const custodianNames = Array.from(
-    new Set((usersQuery.data ?? []).map((u) => u.name).filter(Boolean)),
-  );
+  // ผู้รับผิดชอบ (Custodian) combobox suggestions — pick a user OR type a name.
+  const custodianNames = useUserNames();
 
   return (
     <Card>

--- a/apps/web/src/pages/assets/components/TransferAssetDialog.tsx
+++ b/apps/web/src/pages/assets/components/TransferAssetDialog.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { useUserNames } from '@/hooks/useUserNames';
 import type { Asset } from '../types';
 
 interface TransferAssetDialogProps {
@@ -38,6 +39,7 @@ export function TransferAssetDialog({
   isPending,
 }: TransferAssetDialogProps) {
   const today = new Date().toISOString().slice(0, 10);
+  const custodianNames = useUserNames();
   const [transferDate, setTransferDate] = useState(today);
   const [toCustodian, setToCustodian] = useState(asset.custodian ?? '');
   const [toLocation, setToLocation] = useState(asset.location ?? '');
@@ -68,7 +70,14 @@ export function TransferAssetDialog({
               value={toCustodian}
               onChange={(e) => setToCustodian(e.target.value)}
               placeholder={asset.custodian ?? '-'}
+              list="asset-transfer-custodian-options"
+              autoComplete="off"
             />
+            <datalist id="asset-transfer-custodian-options">
+              {custodianNames.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
             <p className="text-xs text-muted-foreground mt-1">
               ปัจจุบัน: {asset.custodian ?? '-'}
             </p>


### PR DESCRIPTION
ต่อจาก PR #1132 — ทำ custodian/ผู้ดูแล ที่เหลือให้เป็น combobox (เลือก user หรือพิมพ์เอง):
- **โอนสินทรัพย์ → "ผู้ดูแลใหม่"** (TransferAssetDialog)
- **เงินสดย่อย → "ผู้ดูแลเงินสดย่อย"** (PettyCashLinesSection)

ทั้งคู่มี `<datalist>` รายชื่อ user เหมือนฟอร์มบันทึกซื้อสินทรัพย์ · hook กลางใหม่ `useUserNames()` เป็น source เดียว (refactor ฟอร์ม entry มาใช้ตัวเดียวกัน)

> filter "ผู้ดูแล (contains)" ในหน้ารายการ = ช่องค้นหา ไม่ใช่ช่องกรอก จึงไม่แตะ

ทดสอบ: web tsc 0 · vitest 597 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)