### PR TITLE
feat(web): combobox UX — styled custodian + usable asset vendor field

### DIFF
--- a/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
@@ -1,7 +1,8 @@
-import { Plus, Trash2, Users } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import { PettyCashFormFields, newPettyCashLine } from './types';
 import { formatNumberDecimal } from '@/utils/formatters';
 import { useUserNames } from '@/hooks/useUserNames';
+import { NameAutocomplete } from '@/components/ui/NameAutocomplete';
 
 interface Props {
   value: PettyCashFormFields;
@@ -51,23 +52,12 @@ export function PettyCashLinesSection({ value, onChange }: Props) {
           <label className="block text-xs font-medium mb-1 text-muted-foreground">
             ผู้ดูแลเงินสดย่อย (custodian) — ทางเลือก
           </label>
-          <div className="relative">
-            <Users className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              value={value.custodianName}
-              onChange={(e) => updateField({ custodianName: e.target.value })}
-              placeholder="ชื่อพนักงานที่ดูแลเงินสดย่อย"
-              list="petty-cash-custodian-options"
-              autoComplete="off"
-              className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-            <datalist id="petty-cash-custodian-options">
-              {custodianNames.map((name) => (
-                <option key={name} value={name} />
-              ))}
-            </datalist>
-          </div>
+          <NameAutocomplete
+            value={value.custodianName}
+            onChange={(v) => updateField({ custodianName: v })}
+            options={custodianNames}
+            placeholder="ชื่อพนักงานที่ดูแลเงินสดย่อย"
+          />
         </div>
         <div className="flex items-end text-xs text-muted-foreground">
           <span>

--- a/apps/web/src/components/ui/NameAutocomplete.tsx
+++ b/apps/web/src/components/ui/NameAutocomplete.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+interface NameAutocompleteProps {
+  value: string;
+  onChange: (v: string) => void;
+  /** Suggestion list (e.g. system user names). */
+  options: string[];
+  placeholder?: string;
+  id?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+/**
+ * A free-text input with a styled suggestion dropdown — "type a name OR pick
+ * from the list". Used for custodian / responsible-person fields. Styled with the
+ * app's shadcn tokens (bg-popover / border-border / hover:bg-muted) so it matches
+ * the rest of the UI instead of the browser-native <datalist> look.
+ */
+export function NameAutocomplete({
+  value,
+  onChange,
+  options,
+  placeholder,
+  id,
+  className,
+  disabled,
+}: NameAutocompleteProps) {
+  const [open, setOpen] = useState(false);
+
+  const filtered = useMemo(() => {
+    const q = value.trim().toLowerCase();
+    const list = q ? options.filter((o) => o.toLowerCase().includes(q)) : options;
+    return list.slice(0, 50);
+  }, [value, options]);
+
+  return (
+    <div className={cn('relative', className)}>
+      <Input
+        id={id}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setOpen(true)}
+        // Delay close so a click on a suggestion registers first.
+        onBlur={() => window.setTimeout(() => setOpen(false), 120)}
+        placeholder={placeholder}
+        autoComplete="off"
+        className="pr-8"
+      />
+      <ChevronDown
+        className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
+        aria-hidden
+      />
+      {open && filtered.length > 0 && (
+        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-border bg-popover shadow-xl">
+          <ul className="max-h-56 overflow-y-auto py-1">
+            {filtered.map((name) => (
+              <li key={name}>
+                <button
+                  type="button"
+                  // onMouseDown (not onClick) so it fires before the input blur.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onChange(name);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    'w-full px-3 py-1.5 text-left text-sm leading-snug hover:bg-muted/60',
+                    name === value && 'bg-muted/40 font-medium',
+                  )}
+                >
+                  {name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useUserNames.ts
+++ b/apps/web/src/hooks/useUserNames.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 
 /**
- * Distinct system-user display names — used to populate the `<datalist>` of
- * custodian / responsible-person comboboxes (asset entry + transfer, petty-cash
- * custodian, ...). The user can pick a name OR type a custom one, so these are
- * suggestions only. `/users` returns paginated `{ data, total, page, limit }`.
+ * Distinct system-user display names — used to populate the suggestions of the
+ * `NameAutocomplete` custodian / responsible-person fields (asset entry + transfer,
+ * petty-cash custodian, ...). The user can pick a name OR type a custom one, so
+ * these are suggestions only. `/users` returns paginated `{ data, total, page, limit }`.
  */
 export function useUserNames(): string[] {
   const query = useQuery({

--- a/apps/web/src/pages/assets/components/AssetEntrySection1Info.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection1Info.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
+import { NameAutocomplete } from '@/components/ui/NameAutocomplete';
 import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
@@ -112,18 +113,14 @@ export function AssetEntrySection1Info({ assetCode, branches }: Props) {
           </Select>
         </div>
         <div>
-          <Label>ผู้รับผิดชอบ (Custodian) *</Label>
-          <Input
-            {...register('custodian')}
-            list="asset-custodian-options"
+          <Label htmlFor="custodian">ผู้รับผิดชอบ (Custodian) *</Label>
+          <NameAutocomplete
+            id="custodian"
+            value={watch('custodian') ?? ''}
+            onChange={(v) => setValue('custodian', v, { shouldValidate: true })}
+            options={custodianNames}
             placeholder="พิมพ์ชื่อ หรือเลือกจากรายการ"
-            autoComplete="off"
           />
-          <datalist id="asset-custodian-options">
-            {custodianNames.map((name) => (
-              <option key={name} value={name} />
-            ))}
-          </datalist>
           {errors.custodian && (
             <p className="text-sm text-destructive mt-1">{errors.custodian.message}</p>
           )}

--- a/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
@@ -101,14 +101,29 @@ export function AssetEntrySection3Vendor() {
 
   const selectSupplier = (s: SupplierLite) => {
     setValue('vendorId', s.id, { shouldDirty: true });
-    setValue('supplierName', s.name, { shouldDirty: true });
+    setValue('supplierName', s.name, { shouldDirty: true, shouldValidate: true });
     setValue('supplierTaxId', s.taxId ?? '', { shouldDirty: true });
+    setPopoverOpen(false);
+    setSearchValue('');
+  };
+
+  // Free-text path: use whatever the user typed as the vendor name WITHOUT
+  // forcing them to create a Supplier master record (which requires a phone).
+  // Most asset purchases are one-off vendors — this is the common case, so the
+  // combobox must never be a dead-end for a plain typed name.
+  const commitFreeText = (raw: string) => {
+    const name = raw.trim();
+    if (!name) return;
+    setValue('supplierName', name, { shouldDirty: true, shouldValidate: true });
+    setValue('vendorId', undefined, { shouldDirty: true });
     setPopoverOpen(false);
     setSearchValue('');
   };
 
   const clearSupplier = () => {
     setValue('vendorId', undefined, { shouldDirty: true });
+    setValue('supplierName', '', { shouldDirty: true, shouldValidate: true });
+    setValue('supplierTaxId', '', { shouldDirty: true });
   };
 
   const createMutation = useMutation({
@@ -221,22 +236,44 @@ export function AssetEntrySection3Vendor() {
                       )}
                       {filteredSuppliers.length === 0 && (
                         <div className="px-3 py-2 text-sm text-muted-foreground leading-snug">
-                          {suppliers.length === 0
-                            ? 'ยังไม่มีผู้ขายในระบบ — กด "เพิ่มผู้ขายใหม่" ด้านล่าง'
-                            : 'ไม่พบผู้ขายที่ตรงกัน'}
+                          {searchValue.trim()
+                            ? 'ไม่พบผู้ขายเดิม — กด "ใช้ชื่อนี้" เพื่อใช้ชื่อที่พิมพ์ได้เลย'
+                            : suppliers.length === 0
+                              ? 'ยังไม่มีผู้ขายในระบบ — พิมพ์ชื่อผู้ขายเพื่อใช้งานได้เลย'
+                              : 'พิมพ์เพื่อค้นหา'}
                         </div>
                       )}
-                      {/* Always offer the create action (even on an empty list or
-                          before typing) so the picker is never a dead end. */}
+                      {/* Never a dead end: typing a name lets you "ใช้ชื่อนี้"
+                          (free-text supplierName, no master record needed), and
+                          optionally save it to the supplier master as well. */}
                       {!hasExactMatch && (
                         <>
                           {filteredSuppliers.length > 0 && <CommandSeparator />}
                           <CommandGroup>
-                            <CommandItem onSelect={openCreateDialog} value="__create__">
+                            {searchValue.trim() && (
+                              <CommandItem
+                                onSelect={() => commitFreeText(searchValue)}
+                                value="__usetext__"
+                                className="text-foreground"
+                              >
+                                <Check className="me-2 size-4 text-primary" />
+                                <span className="truncate">
+                                  ใช้ชื่อ{' '}
+                                  <span className="font-medium">
+                                    &quot;{searchValue.trim()}&quot;
+                                  </span>
+                                </span>
+                              </CommandItem>
+                            )}
+                            <CommandItem
+                              onSelect={openCreateDialog}
+                              value="__create__"
+                              className="text-muted-foreground"
+                            >
                               <Plus className="me-2 size-4" />
-                              <span>
+                              <span className="truncate">
                                 {searchValue.trim()
-                                  ? `เพิ่มผู้ขายใหม่ "${searchValue.trim()}"`
+                                  ? `บันทึก "${searchValue.trim()}" ลงทะเบียนผู้ขาย`
                                   : 'เพิ่มผู้ขายใหม่'}
                               </span>
                             </CommandItem>
@@ -249,13 +286,13 @@ export function AssetEntrySection3Vendor() {
               </Command>
             </PopoverContent>
           </Popover>
-          {vendorId && (
+          {(vendorId || supplierName) && (
             <button
               type="button"
               onClick={clearSupplier}
               className="mt-1 text-xs text-muted-foreground hover:text-foreground underline"
             >
-              ล้างการเชื่อมผู้ขาย
+              {vendorId ? 'ล้างการเชื่อมผู้ขาย' : 'ล้างชื่อผู้ขาย'}
             </button>
           )}
           {errors.supplierName && (

--- a/apps/web/src/pages/assets/components/TransferAssetDialog.tsx
+++ b/apps/web/src/pages/assets/components/TransferAssetDialog.tsx
@@ -16,6 +16,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
 import { useUserNames } from '@/hooks/useUserNames';
+import { NameAutocomplete } from '@/components/ui/NameAutocomplete';
 import type { Asset } from '../types';
 
 interface TransferAssetDialogProps {
@@ -66,18 +67,12 @@ export function TransferAssetDialog({
           </div>
           <div>
             <Label>ผู้ดูแลใหม่</Label>
-            <Input
+            <NameAutocomplete
               value={toCustodian}
-              onChange={(e) => setToCustodian(e.target.value)}
+              onChange={setToCustodian}
+              options={custodianNames}
               placeholder={asset.custodian ?? '-'}
-              list="asset-transfer-custodian-options"
-              autoComplete="off"
             />
-            <datalist id="asset-transfer-custodian-options">
-              {custodianNames.map((name) => (
-                <option key={name} value={name} />
-              ))}
-            </datalist>
             <p className="text-xs text-muted-foreground mt-1">
               ปัจจุบัน: {asset.custodian ?? '-'}
             </p>


### PR DESCRIPTION
## สรุป
ปรับ combobox 2 จุดให้ใช้งานง่ายขึ้น + เข้ากับธีมแอป (2 commits)

### 1. ผู้รับผิดชอบ (Custodian) — dropdown สไตล์แอป
แทน `<datalist>` native (กล่องขาวสไตล์ browser) ด้วย component กลาง `NameAutocomplete` (input พิมพ์ได้ + dropdown สไตล์ shadcn `bg-popover`/`border-border`/`hover:bg-muted` + chevron) ใช้ครบ 3 จุด: เพิ่มสินทรัพย์, โอนสินทรัพย์, เงินสดย่อย

### 2. ชื่อผู้ขาย / บริษัท (Asset) — พิมพ์ชื่อแล้วใช้ได้เลย
**ปัญหา:** combobox เดิม set `supplierName` เฉพาะตอน "เลือกผู้ขายเดิม" หรือ "สร้างผู้ขายใหม่" (บังคับเบอร์โทร) — พิมพ์ชื่อลอยๆ แล้วปิด ชื่อหายทันที (อยู่แค่ใน local state) → ใช้งานจริงไม่ได้สำหรับผู้ขายครั้งเดียว

**แก้:**
- เพิ่มปุ่ม **"ใช้ชื่อนี้"** → ใส่ชื่อที่พิมพ์ลง `supplierName` ตรงๆ (ไม่ต้องสร้าง master / ไม่ต้องเบอร์โทร) — ปุ่มหลัก เครื่องหมายถูกสีเขียว
- เก็บ **"บันทึก ... ลงทะเบียนผู้ขาย"** เป็นปุ่มรอง (สีจาง) สำหรับเคสที่อยากบันทึกเข้าทะเบียน (ยัง autofill `vendorId` + `taxId`)
- ปุ่มล้าง รองรับล้างชื่อ free-text ด้วย
- ปรับข้อความ empty-state ให้สื่อว่าพิมพ์ชื่อใช้ได้เลย

วินิจฉัย root cause ด้วย diagnostic workflow (3 agents): ยืนยัน backend `POST /suppliers` + asset create รับค่าได้อยู่แล้ว ขาดแค่การ bind ฝั่ง frontend

## ตรวจสอบ
- `tsc --noEmit` ✅ 0 errors
- `vitest run` ✅ 597 passed (89 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)