### PR TITLE
fix(web): polish vendor combobox UX + shadcn-align command primitives

### DIFF
--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -10,7 +10,7 @@ function Command({ className, ...props }: React.ComponentProps<typeof CommandPri
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        'flex h-full w-full flex-col overflow-hidden rounded-xl bg-popover text-popover-foreground',
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
         className,
       )}
       {...props}
@@ -23,12 +23,12 @@ function CommandInput({
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
-    <div className="flex items-center border-b border-border px-4" data-slot="command-input-wrapper">
-      <Search className="mr-2.5 size-4 shrink-0 opacity-50" />
+    <div className="flex items-center border-b border-border px-3" data-slot="command-input-wrapper">
+      <Search className="mr-2 size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          'flex h-12 w-full rounded-md bg-transparent text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-11 w-full bg-transparent text-sm outline-none focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         {...props}
@@ -41,7 +41,7 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
   return (
     <CommandPrimitive.List
       data-slot="command-list"
-      className={cn('max-h-[360px] overflow-y-auto overflow-x-hidden p-1', className)}
+      className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden p-1', className)}
       {...props}
     />
   );
@@ -61,7 +61,7 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        'overflow-hidden px-1 py-1.5 **:data-[slot=command-group-heading]:px-2 **:data-[slot=command-group-heading]:py-1.5 **:data-[slot=command-group-heading]:text-xs **:data-[slot=command-group-heading]:font-semibold **:data-[slot=command-group-heading]:text-muted-foreground',
+        'overflow-hidden px-1 py-1 **:data-[slot=command-group-heading]:px-2 **:data-[slot=command-group-heading]:py-1.5 **:data-[slot=command-group-heading]:text-xs **:data-[slot=command-group-heading]:font-semibold **:data-[slot=command-group-heading]:text-muted-foreground',
         className,
       )}
       {...props}
@@ -90,7 +90,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "relative flex cursor-pointer select-none items-center gap-2.5 rounded-lg px-2.5 py-2.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected='true']:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-muted-foreground",
+        "relative flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected='true']:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-muted-foreground",
         className,
       )}
       {...props}

--- a/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
@@ -8,7 +8,7 @@ import { useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { Check, ChevronsUpDown, Pencil, Plus } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -28,7 +28,6 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from '@/components/ui/command';
 import {
   Dialog,
@@ -185,104 +184,123 @@ export function AssetEntrySection3Vendor() {
                 type="button"
                 variant="outline"
                 role="combobox"
-                aria-label="ผู้ขาย"
                 aria-expanded={popoverOpen}
+                aria-invalid={!!errors.supplierName}
                 className={cn(
                   'w-full justify-between font-normal',
                   !supplierName && 'text-muted-foreground',
                 )}
               >
-                <span className="truncate">{triggerLabel}</span>
-                <ChevronsUpDown className="ms-2 size-4 shrink-0 opacity-50" />
+                <span className="flex min-w-0 items-center gap-1.5">
+                  {vendorId ? (
+                    <Check className="size-3.5 shrink-0 text-primary" />
+                  ) : supplierName ? (
+                    <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : null}
+                  <span className="truncate leading-snug" title={supplierName || undefined}>
+                    {triggerLabel}
+                  </span>
+                </span>
+                <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
               <Command shouldFilter={false}>
                 <CommandInput
-                  placeholder="ค้นหาผู้ขาย..."
+                  placeholder="ค้นหา หรือพิมพ์ชื่อผู้ขายใหม่..."
                   value={searchValue}
                   onValueChange={setSearchValue}
+                  onKeyDown={(e) => {
+                    // Enter on a typed name with no supplier in the list → use it
+                    // as free text. The list is empty here so cmdk has nothing to
+                    // select; this never hijacks a real supplier pick.
+                    if (
+                      e.key === 'Enter' &&
+                      searchValue.trim() &&
+                      filteredSuppliers.length === 0
+                    ) {
+                      e.preventDefault();
+                      commitFreeText(searchValue);
+                    }
+                  }}
                 />
                 <CommandList>
                   {suppliersQuery.isLoading ? (
                     <CommandEmpty>กำลังโหลด...</CommandEmpty>
-                  ) : (
-                    <>
-                      {filteredSuppliers.length > 0 && (
-                        <CommandGroup heading="ผู้ขาย">
-                          {filteredSuppliers.map((s) => (
-                            <CommandItem
-                              key={s.id}
-                              value={s.id}
-                              onSelect={() => selectSupplier(s)}
-                            >
-                              <Check
-                                className={cn(
-                                  'me-2 size-4',
-                                  vendorId === s.id ? 'opacity-100' : 'opacity-0',
-                                )}
-                              />
-                              <div className="flex flex-col">
-                                <span>{s.name}</span>
-                                {s.taxId && (
-                                  <span className="text-xs text-muted-foreground">
-                                    {s.taxId}
-                                  </span>
-                                )}
-                              </div>
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      )}
-                      {filteredSuppliers.length === 0 && (
-                        <div className="px-3 py-2 text-sm text-muted-foreground leading-snug">
-                          {searchValue.trim()
-                            ? 'ไม่พบผู้ขายเดิม — กด "ใช้ชื่อนี้" เพื่อใช้ชื่อที่พิมพ์ได้เลย'
-                            : suppliers.length === 0
-                              ? 'ยังไม่มีผู้ขายในระบบ — พิมพ์ชื่อผู้ขายเพื่อใช้งานได้เลย'
-                              : 'พิมพ์เพื่อค้นหา'}
-                        </div>
-                      )}
-                      {/* Never a dead end: typing a name lets you "ใช้ชื่อนี้"
-                          (free-text supplierName, no master record needed), and
-                          optionally save it to the supplier master as well. */}
-                      {!hasExactMatch && (
-                        <>
-                          {filteredSuppliers.length > 0 && <CommandSeparator />}
-                          <CommandGroup>
-                            {searchValue.trim() && (
-                              <CommandItem
-                                onSelect={() => commitFreeText(searchValue)}
-                                value="__usetext__"
-                                className="text-foreground"
-                              >
-                                <Check className="me-2 size-4 text-primary" />
-                                <span className="truncate">
-                                  ใช้ชื่อ{' '}
-                                  <span className="font-medium">
-                                    &quot;{searchValue.trim()}&quot;
-                                  </span>
-                                </span>
-                              </CommandItem>
+                  ) : filteredSuppliers.length > 0 ? (
+                    <CommandGroup heading="ผู้ขายในทะเบียน">
+                      {filteredSuppliers.map((s) => (
+                        <CommandItem key={s.id} value={s.id} onSelect={() => selectSupplier(s)}>
+                          <Check
+                            className={cn(
+                              'mr-2 size-4 shrink-0',
+                              vendorId === s.id ? 'opacity-100' : 'opacity-0',
                             )}
-                            <CommandItem
-                              onSelect={openCreateDialog}
-                              value="__create__"
-                              className="text-muted-foreground"
-                            >
-                              <Plus className="me-2 size-4" />
-                              <span className="truncate">
-                                {searchValue.trim()
-                                  ? `บันทึก "${searchValue.trim()}" ลงทะเบียนผู้ขาย`
-                                  : 'เพิ่มผู้ขายใหม่'}
-                              </span>
-                            </CommandItem>
-                          </CommandGroup>
-                        </>
-                      )}
-                    </>
+                          />
+                          <div className="flex min-w-0 flex-col">
+                            <span className="truncate leading-snug" title={s.name}>
+                              {s.name}
+                            </span>
+                            {s.taxId && (
+                              <span className="text-xs text-muted-foreground">{s.taxId}</span>
+                            )}
+                          </div>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  ) : (
+                    <CommandEmpty className="px-3 py-6 text-center leading-snug">
+                      {searchValue.trim()
+                        ? 'ไม่พบผู้ขายในทะเบียน'
+                        : suppliers.length === 0
+                          ? 'ยังไม่มีผู้ขายในทะเบียน'
+                          : 'พิมพ์เพื่อค้นหา'}
+                    </CommandEmpty>
                   )}
                 </CommandList>
+                {/* Actions live OUTSIDE the list so they're never in cmdk's
+                    highlight/Enter cycle — typing a new name can't accidentally
+                    select a partial-match supplier, and the lone CTA is no longer
+                    rendered as a big auto-highlighted block. Never a dead end. */}
+                {!hasExactMatch && (
+                  <div className="border-t border-border p-1">
+                    {searchValue.trim() && (
+                      <button
+                        type="button"
+                        onClick={() => commitFreeText(searchValue)}
+                        className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent"
+                      >
+                        <Check className="mt-0.5 size-4 shrink-0 text-primary" />
+                        <span className="min-w-0">
+                          <span className="block truncate text-sm leading-snug text-foreground">
+                            ใช้ชื่อ{' '}
+                            <span className="font-medium">&quot;{searchValue.trim()}&quot;</span>
+                          </span>
+                          <span className="block text-xs leading-snug text-muted-foreground">
+                            ใช้ครั้งเดียว ไม่บันทึกลงทะเบียน
+                          </span>
+                        </span>
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={openCreateDialog}
+                      className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent"
+                    >
+                      <Plus className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm leading-snug text-foreground">
+                          {searchValue.trim()
+                            ? `บันทึก "${searchValue.trim()}" ลงทะเบียน`
+                            : 'เพิ่มผู้ขายใหม่'}
+                        </span>
+                        <span className="block text-xs leading-snug text-muted-foreground">
+                          บันทึกถาวร · ใช้ซ้ำได้ (ต้องมีเบอร์โทร)
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                )}
               </Command>
             </PopoverContent>
           </Popover>


### PR DESCRIPTION
## สรุป
รีวิว UX/UI ของ dropdown "ชื่อผู้ขาย / บริษัท" แบบละเอียด (workflow audit 3 มุม) แล้วเก็บงานจุดที่สะดุดตา + บั๊กที่เจอ

### แก้ที่ AssetEntrySection3Vendor
- **กรอบเขียวเรืองรอบช่องค้นหาหาย** — มาจาก global `*:focus-visible` ที่ยิง ring ใส่ช่องค้นหาตอน cmdk autofocus (ผิด convention shadcn) → ปิด ring ที่ CommandInput
- **ย้ายปุ่ม "ใช้ชื่อนี้" + "เพิ่มผู้ขายใหม่" ออกนอก list ไปเป็น footer** แก้ 2 อย่าง:
  1. ปุ่มเดี่ยวเดิมถูก cmdk ไฮไลต์เป็นบล็อกเทาทึบใหญ่ → หายไป
  2. **บั๊ก**: พิมพ์ชื่อใหม่ที่บังเอิญ substring ตรงกับผู้ขายเดิม แล้วกด Enter → เลือกผู้ขายผิดราย (ได้ vendorId/เลขภาษีผิด กระทบ JE/ภาษี) → footer ไม่อยู่ใน highlight/Enter cycle แล้ว
- **กด Enter** ตอนพิมพ์ชื่อใหม่ (ไม่มีในทะเบียน) → ใช้ชื่อนั้นเป็น free text ได้เลย
- **ปุ่ม trigger มี indicator** linked (เครื่องหมายถูกเขียว = ผู้ขายในทะเบียน) vs free-text (ดินสอ = ชื่ออิสระ) + tooltip ชื่อเต็ม
- แต่ละ action มีคำอธิบายย่อย: "ใช้ครั้งเดียว ไม่บันทึกทะเบียน" vs "บันทึกถาวร · ใช้ซ้ำได้"
- a11y: `aria-invalid`, ใช้ `<Label>` อ่านชื่อช่อง, `title` ชื่อยาว

### shadcn-align command.tsx (มีผลกับทุก combobox + Cmd+K ทั้งแอป)
- ปิด focus-ring glow ที่ search input, `h-12→h-11`
- CommandItem กระชับขึ้น `py-2.5→py-1.5`, `rounded-lg→rounded-md`, `gap-2.5→gap-2`
- radius ของ Command `rounded-xl→rounded-md` ให้ตรงกับ PopoverContent + ลด padding ที่ซ้อน

## ตรวจสอบ
- `tsc --noEmit` ✅ 0 errors
- `vitest run` ✅ 597 passed (89 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)