### PR TITLE
feat(asset): suggest previously-used vendor names in the vendor combobox

### DIFF
--- a/apps/api/src/modules/asset/__tests__/asset.controller.spec.ts
+++ b/apps/api/src/modules/asset/__tests__/asset.controller.spec.ts
@@ -58,4 +58,18 @@ describe('AssetController — reverse permission metadata (Audit Finding A)', ()
       expect(guards).toContain(ReversePermissionGuard);
     },
   );
+
+  it('getVendorNames() is read-only — allows OWNER + BRANCH_MANAGER + FINANCE_MANAGER + ACCOUNTANT, not SALES', () => {
+    const roles = methodRoles('getVendorNames');
+    expect(roles).toBeDefined();
+    expect(roles).toEqual(
+      expect.arrayContaining([
+        'OWNER',
+        'BRANCH_MANAGER',
+        'FINANCE_MANAGER',
+        'ACCOUNTANT',
+      ]),
+    );
+    expect(roles).not.toContain('SALES');
+  });
 });

--- a/apps/api/src/modules/asset/asset.controller.ts
+++ b/apps/api/src/modules/asset/asset.controller.ts
@@ -74,6 +74,15 @@ export class AssetController {
     return this.assetService.generateAssetCode(undefined, category);
   }
 
+  // Distinct free-text vendor names previously used on assets — "เคยใช้"
+  // suggestions for the entry-form vendor combobox (reuse a one-off name without
+  // registering a Supplier master). Declared before the generic :id route.
+  @Get('vendor-names')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  getVendorNames() {
+    return this.assetService.vendorNames();
+  }
+
   @Get('register')
   @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
   getRegister(

--- a/apps/api/src/modules/asset/asset.service.ts
+++ b/apps/api/src/modules/asset/asset.service.ts
@@ -487,6 +487,22 @@ export class AssetService {
     return { data, total, page, limit };
   }
 
+  /**
+   * Distinct free-text vendor/supplier names previously used on assets — surfaced
+   * as "เคยใช้" suggestions in the asset entry vendor combobox so a one-off name
+   * typed before can be reused without re-registering a Supplier master.
+   */
+  async vendorNames(limit = 200): Promise<string[]> {
+    const rows = await this.prisma.fixedAsset.findMany({
+      where: { deletedAt: null, supplierName: { not: null } },
+      select: { supplierName: true },
+      distinct: ['supplierName'],
+      orderBy: { supplierName: 'asc' },
+      take: limit,
+    });
+    return rows.map((r) => r.supplierName?.trim() ?? '').filter((n) => n.length > 0);
+  }
+
   async findOne(id: string) {
     const asset = await this.prisma.fixedAsset.findFirst({
       where: { id, deletedAt: null },

--- a/apps/web/src/pages/assets/api.ts
+++ b/apps/web/src/pages/assets/api.ts
@@ -267,6 +267,13 @@ export const assetsApi = {
     return data?.data ?? [];
   },
 
+  // Distinct free-text vendor names previously used on assets — "เคยใช้"
+  // suggestions so a one-off name can be reused without registering a Supplier.
+  vendorNames: async (): Promise<string[]> => {
+    const { data } = await api.get<string[]>('/assets/vendor-names');
+    return Array.isArray(data) ? data : [];
+  },
+
   // POST /suppliers requires `phone` (NOT NULL in schema). Dialog form must
   // collect phone before submitting; taxId remains optional.
   suppliersCreate: async (input: {

--- a/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
@@ -71,6 +71,15 @@ export function AssetEntrySection3Vendor() {
   });
   const suppliers = suppliersQuery.data ?? [];
 
+  // Previously-used free-text vendor names (from past assets) — "เคยใช้"
+  // suggestions so a one-off name can be reused without registering a Supplier.
+  const vendorNamesQuery = useQuery({
+    queryKey: ['asset-vendor-names'],
+    queryFn: () => assetsApi.vendorNames(),
+    staleTime: 5 * 60 * 1000,
+  });
+  const usedNames = vendorNamesQuery.data ?? [];
+
   // Combobox state
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
@@ -97,6 +106,26 @@ export function AssetEntrySection3Vendor() {
     if (!q) return false;
     return suppliers.some((s) => s.name.toLowerCase() === q);
   }, [searchValue, suppliers]);
+
+  // Past free-text names that match the query and aren't already registered.
+  const filteredUsedNames = useMemo(() => {
+    const regNames = new Set(suppliers.map((s) => s.name.trim().toLowerCase()));
+    const q = searchValue.trim().toLowerCase();
+    return usedNames
+      .filter((n) => {
+        const nl = n.trim().toLowerCase();
+        if (!nl || regNames.has(nl)) return false;
+        if (q && !nl.includes(q)) return false;
+        return true;
+      })
+      .slice(0, 20);
+  }, [usedNames, suppliers, searchValue]);
+
+  const hasExactUsedMatch = useMemo(() => {
+    const q = searchValue.trim().toLowerCase();
+    if (!q) return false;
+    return usedNames.some((n) => n.trim().toLowerCase() === q);
+  }, [searchValue, usedNames]);
 
   const selectSupplier = (s: SupplierLite) => {
     setValue('vendorId', s.id, { shouldDirty: true });
@@ -211,15 +240,17 @@ export function AssetEntrySection3Vendor() {
                   value={searchValue}
                   onValueChange={setSearchValue}
                   onKeyDown={(e) => {
-                    // Enter on a typed name with no supplier in the list → use it
-                    // as free text. The list is empty here so cmdk has nothing to
-                    // select; this never hijacks a real supplier pick.
+                    // Enter on a typed name that isn't an exact existing suggestion
+                    // commits it as free text — and stops cmdk from selecting a
+                    // partial-match item (which would pick the wrong vendor/name).
                     if (
                       e.key === 'Enter' &&
                       searchValue.trim() &&
-                      filteredSuppliers.length === 0
+                      !hasExactMatch &&
+                      !hasExactUsedMatch
                     ) {
                       e.preventDefault();
+                      e.stopPropagation();
                       commitFreeText(searchValue);
                     }
                   }}
@@ -227,35 +258,55 @@ export function AssetEntrySection3Vendor() {
                 <CommandList>
                   {suppliersQuery.isLoading ? (
                     <CommandEmpty>กำลังโหลด...</CommandEmpty>
-                  ) : filteredSuppliers.length > 0 ? (
-                    <CommandGroup heading="ผู้ขายในทะเบียน">
-                      {filteredSuppliers.map((s) => (
-                        <CommandItem key={s.id} value={s.id} onSelect={() => selectSupplier(s)}>
-                          <Check
-                            className={cn(
-                              'mr-2 size-4 shrink-0',
-                              vendorId === s.id ? 'opacity-100' : 'opacity-0',
-                            )}
-                          />
-                          <div className="flex min-w-0 flex-col">
-                            <span className="truncate leading-snug" title={s.name}>
-                              {s.name}
-                            </span>
-                            {s.taxId && (
-                              <span className="text-xs text-muted-foreground">{s.taxId}</span>
-                            )}
-                          </div>
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  ) : (
+                  ) : filteredSuppliers.length === 0 && filteredUsedNames.length === 0 ? (
                     <CommandEmpty className="px-3 py-6 text-center leading-snug">
                       {searchValue.trim()
-                        ? 'ไม่พบผู้ขายในทะเบียน'
-                        : suppliers.length === 0
-                          ? 'ยังไม่มีผู้ขายในทะเบียน'
+                        ? 'ไม่พบชื่อผู้ขายที่ตรงกัน'
+                        : suppliers.length === 0 && usedNames.length === 0
+                          ? 'ยังไม่มีผู้ขาย — พิมพ์ชื่อเพื่อใช้ได้เลย'
                           : 'พิมพ์เพื่อค้นหา'}
                     </CommandEmpty>
+                  ) : (
+                    <>
+                      {filteredSuppliers.length > 0 && (
+                        <CommandGroup heading="ผู้ขายในทะเบียน">
+                          {filteredSuppliers.map((s) => (
+                            <CommandItem key={s.id} value={s.id} onSelect={() => selectSupplier(s)}>
+                              <Check
+                                className={cn(
+                                  'mr-2 size-4 shrink-0',
+                                  vendorId === s.id ? 'opacity-100' : 'opacity-0',
+                                )}
+                              />
+                              <div className="flex min-w-0 flex-col">
+                                <span className="truncate leading-snug" title={s.name}>
+                                  {s.name}
+                                </span>
+                                {s.taxId && (
+                                  <span className="text-xs text-muted-foreground">{s.taxId}</span>
+                                )}
+                              </div>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      )}
+                      {filteredUsedNames.length > 0 && (
+                        <CommandGroup heading="เคยใช้">
+                          {filteredUsedNames.map((name) => (
+                            <CommandItem
+                              key={`used:${name}`}
+                              value={`used:${name}`}
+                              onSelect={() => commitFreeText(name)}
+                            >
+                              <Pencil className="mr-2 size-4 shrink-0 opacity-60" />
+                              <span className="truncate leading-snug" title={name}>
+                                {name}
+                              </span>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      )}
+                    </>
                   )}
                 </CommandList>
                 {/* Actions live OUTSIDE the list so they're never in cmdk's
@@ -264,7 +315,7 @@ export function AssetEntrySection3Vendor() {
                     rendered as a big auto-highlighted block. Never a dead end. */}
                 {!hasExactMatch && (
                   <div className="border-t border-border p-1">
-                    {searchValue.trim() && (
+                    {searchValue.trim() && !hasExactUsedMatch && (
                       <button
                         type="button"
                         onClick={() => commitFreeText(searchValue)}


### PR DESCRIPTION
## สรุป
แก้ปัญหา "พิมพ์ชื่อผู้ขายแล้วใช้ (ใช้ชื่อนี้) ครั้งก่อน แต่ค้นหาครั้งหน้าไม่เจอ" — เพราะชื่อ free-text ไม่ได้ถูกบันทึกในทะเบียนผู้ขาย ตอนนี้ระบบ **จำชื่อผู้ขายที่เคยใช้** มาแนะนำให้เลือกซ้ำได้ โดยไม่ต้องกรอกเบอร์โทร/ลงทะเบียน

ผู้ใช้เลือกแนวทางนี้ผ่านคำถาม: "จำชื่อที่เคยใช้ มาแนะนำด้วย"

## ทำอะไร
**API**
- `GET /assets/vendor-names` → คืน `supplierName` ที่เคยใช้ในสินทรัพย์ (distinct, ไม่ว่าง, อ่านอย่างเดียว) — Roles: OWNER/BM/FM/ACC, ประกาศก่อน route `:id`
- เทสต์ guard ของ endpoint ใหม่ (Reflector metadata, ไม่แตะ DB)

**Web (`AssetEntrySection3Vendor`)**
- เพิ่มกลุ่มแนะนำ **"เคยใช้"** ใน dropdown — ชื่อ free-text ที่เคยใช้ + ตรงกับที่พิมพ์ + ยังไม่อยู่ในทะเบียน (กดเลือก = ใช้เป็น free text เลย)
- กลุ่ม "ผู้ขายในทะเบียน" ยังลิงก์ `vendorId` + เลขภาษีเหมือนเดิม
- กด **Enter** ตอนพิมพ์ชื่อใหม่ที่ไม่ตรง exact กับตัวเลือกใด = ใช้ชื่อที่พิมพ์ (กัน cmdk เลือก partial-match ผิด)
- ปรับ empty-state + footer ให้รองรับกลุ่มใหม่

> หมายเหตุ: ชื่อจะขึ้นใน "เคยใช้" ก็ต่อเมื่อ**บันทึกสินทรัพย์ที่ใช้ชื่อนั้นไปแล้ว** (เป็นการแนะนำจากประวัติ ไม่ใช่ภายในฟอร์มที่ยังไม่บันทึก)

## ตรวจสอบ
- web `tsc` ✅ 0 · api `tsc` ✅ 0
- web `vitest` ✅ 597 passed
- api `asset.controller.spec` ✅ 5 passed (รวมเทสต์ใหม่, --runInBand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)