### PR TITLE
fix(asset): source vendor combobox from สมุดผู้ติดต่อ (Contacts)

### DIFF
--- a/apps/web/src/pages/assets/api.ts
+++ b/apps/web/src/pages/assets/api.ts
@@ -267,6 +267,18 @@ export const assetsApi = {
     return data?.data ?? [];
   },
 
+  // Vendor master = สมุดผู้ติดต่อ (Contact) rows with the SUPPLIER role — the
+  // canonical party book the owner maintains. The asset vendor combobox lists
+  // these (NOT the separate legacy Supplier table) so a contact added in
+  // สมุดผู้ติดต่อ shows up immediately.
+  vendorContacts: async (): Promise<SupplierLite[]> => {
+    const { data } = await api.get<{
+      data: Array<{ id: string; name: string; taxId: string | null }>;
+    }>('/contacts', { params: { role: 'SUPPLIER', limit: 200 } });
+    const rows = data?.data ?? [];
+    return rows.map((c) => ({ id: c.id, name: c.name, taxId: c.taxId }));
+  },
+
   // Distinct free-text vendor names previously used on assets — "เคยใช้"
   // suggestions so a one-off name can be reused without registering a Supplier.
   vendorNames: async (): Promise<string[]> => {

--- a/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
@@ -60,13 +60,12 @@ export function AssetEntrySection3Vendor() {
   const paymentMethod = watch('paymentMethod');
   const paymentAccount = watch('paymentAccount');
   const supplierName = watch('supplierName') ?? '';
-  const vendorId = watch('vendorId');
 
-  // Suppliers list (P6) — cached for ~5 min; freshly created entries are
-  // injected via invalidateQueries below.
+  // Vendor master = สมุดผู้ติดต่อ (Contacts with the SUPPLIER role). Cached ~5 min;
+  // a freshly created entry is injected via invalidateQueries below.
   const suppliersQuery = useQuery({
-    queryKey: ['suppliers-list'],
-    queryFn: () => assetsApi.suppliersList(),
+    queryKey: ['vendor-contacts'],
+    queryFn: () => assetsApi.vendorContacts(),
     staleTime: 5 * 60 * 1000,
   });
   const suppliers = suppliersQuery.data ?? [];
@@ -127,10 +126,18 @@ export function AssetEntrySection3Vendor() {
     return usedNames.some((n) => n.trim().toLowerCase() === q);
   }, [searchValue, usedNames]);
 
+  // Is the current name a known contact (สมุดผู้ติดต่อ) vs a one-off free-text?
+  const isKnownVendor = useMemo(() => {
+    const n = supplierName.trim().toLowerCase();
+    return !!n && suppliers.some((s) => s.name.trim().toLowerCase() === n);
+  }, [suppliers, supplierName]);
+
+  // Pick a vendor from สมุดผู้ติดต่อ → fill name + taxId. We DON'T set vendorId:
+  // it's an FK to the legacy Supplier table, but list items are Contact ids.
   const selectSupplier = (s: SupplierLite) => {
-    setValue('vendorId', s.id, { shouldDirty: true });
     setValue('supplierName', s.name, { shouldDirty: true, shouldValidate: true });
     setValue('supplierTaxId', s.taxId ?? '', { shouldDirty: true });
+    setValue('vendorId', undefined, { shouldDirty: true });
     setPopoverOpen(false);
     setSearchValue('');
   };
@@ -158,9 +165,11 @@ export function AssetEntrySection3Vendor() {
     mutationFn: (input: { name: string; phone: string; taxId?: string }) =>
       assetsApi.suppliersCreate(input),
     onSuccess: (created) => {
-      toast.success(`เพิ่มผู้ขาย "${created.name}" แล้ว`);
-      queryClient.invalidateQueries({ queryKey: ['suppliers-list'] });
-      // Auto-select the new entry so the form picks up vendorId + taxId.
+      toast.success(`เพิ่มผู้ขาย "${created.name}" ลงสมุดผู้ติดต่อแล้ว`);
+      // suppliersCreate also creates a Contact (role SUPPLIER) — refresh the
+      // contact-backed vendor list so the new entry appears.
+      queryClient.invalidateQueries({ queryKey: ['vendor-contacts'] });
+      // Auto-fill the new name + taxId.
       selectSupplier(created);
       setCreateOpen(false);
       setNewName('');
@@ -221,7 +230,7 @@ export function AssetEntrySection3Vendor() {
                 )}
               >
                 <span className="flex min-w-0 items-center gap-1.5">
-                  {vendorId ? (
+                  {isKnownVendor ? (
                     <Check className="size-3.5 shrink-0 text-primary" />
                   ) : supplierName ? (
                     <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
@@ -269,13 +278,13 @@ export function AssetEntrySection3Vendor() {
                   ) : (
                     <>
                       {filteredSuppliers.length > 0 && (
-                        <CommandGroup heading="ผู้ขายในทะเบียน">
+                        <CommandGroup heading="ผู้ขาย (สมุดผู้ติดต่อ)">
                           {filteredSuppliers.map((s) => (
                             <CommandItem key={s.id} value={s.id} onSelect={() => selectSupplier(s)}>
                               <Check
                                 className={cn(
                                   'mr-2 size-4 shrink-0',
-                                  vendorId === s.id ? 'opacity-100' : 'opacity-0',
+                                  s.name === supplierName ? 'opacity-100' : 'opacity-0',
                                 )}
                               />
                               <div className="flex min-w-0 flex-col">
@@ -342,7 +351,7 @@ export function AssetEntrySection3Vendor() {
                       <span className="min-w-0">
                         <span className="block truncate text-sm leading-snug text-foreground">
                           {searchValue.trim()
-                            ? `บันทึก "${searchValue.trim()}" ลงทะเบียน`
+                            ? `บันทึก "${searchValue.trim()}" ลงสมุดผู้ติดต่อ`
                             : 'เพิ่มผู้ขายใหม่'}
                         </span>
                         <span className="block text-xs leading-snug text-muted-foreground">
@@ -355,13 +364,13 @@ export function AssetEntrySection3Vendor() {
               </Command>
             </PopoverContent>
           </Popover>
-          {(vendorId || supplierName) && (
+          {supplierName && (
             <button
               type="button"
               onClick={clearSupplier}
               className="mt-1 text-xs text-muted-foreground hover:text-foreground underline"
             >
-              {vendorId ? 'ล้างการเชื่อมผู้ขาย' : 'ล้างชื่อผู้ขาย'}
+              ล้างชื่อผู้ขาย
             </button>
           )}
           {errors.supplierName && (


### PR DESCRIPTION
## สรุป
แก้ตามที่เจ้าของถาม — dropdown ผู้ขายในฟอร์มสินทรัพย์เดิม **ไม่ได้ดึงจากสมุดผู้ติดต่อ** แต่ดึงจากตาราง `Supplier` (คนละตาราง) → ผู้ขาย 6 รายที่เพิ่มในสมุดผู้ติดต่อ (role ผู้ขาย) เลยไม่ขึ้น

## ทำอะไร
- `api`: `vendorContacts()` → `GET /contacts?role=SUPPLIER` (สมุดผู้ติดต่อ = master จริง)
- dropdown ดึงรายชื่อจากสมุดผู้ติดต่อ — กดเลือกแล้วเติม **ชื่อ + เลขภาษี** ให้
- ไม่ set `vendorId` แล้ว (เป็น FK ของตาราง Supplier เดิม แต่ list items เป็น Contact id — ถ้า set จะพังตอนบันทึก)
- ตัวบ่งชี้ (✓ ผู้ขายในสมุด / ✏️ ชื่ออิสระ) + เครื่องหมายถูกในรายการ เปลี่ยนมาเช็คด้วย "ชื่อ" แทน vendorId
- ปุ่ม "บันทึก…ลงสมุดผู้ติดต่อ" ยังใช้ได้ (สร้าง Contact role ผู้ขาย → โผล่ในสมุดผู้ติดต่อ + list)

Frontend-only ใช้ endpoint `/contacts` ที่มีอยู่แล้ว (สิทธิ์ OWNER/FM/ACC/BM)

> รวม deploy นี้จะทำให้ API ที่ build fail รอบก่อน (endpoint `เคยใช้` /assets/vendor-names) ขึ้น prod ไปด้วย

## ตรวจสอบ
- web `tsc` ✅ 0 · `vitest` ✅ 597 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)