### PR TITLE
fix(internal-control): close 5 spec-conformance gaps in InternalControlActionBar

### DIFF
--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -281,6 +281,10 @@ export class AuthService {
         role: user.role,
         branchId: user.branchId,
         branchName: user.branch?.name || null,
+        // InternalControlActionBar — per-user reverse override (CUSTOM mode).
+        // Without this, a freshly-logged-in user keeps canReverseOverride
+        // undefined until the next /auth/me, hiding the reverse button.
+        canReverseOverride: user.canReverseOverride ?? null,
       },
     };
   }
@@ -349,6 +353,10 @@ export class AuthService {
         role: user.role,
         branchId: user.branchId,
         branchName: user.branch?.name || null,
+        // InternalControlActionBar — per-user reverse override (CUSTOM mode).
+        // Without this, a freshly-logged-in user keeps canReverseOverride
+        // undefined until the next /auth/me, hiding the reverse button.
+        canReverseOverride: user.canReverseOverride ?? null,
       },
     };
   }

--- a/apps/web/src/components/accounting/AuditTimeline.tsx
+++ b/apps/web/src/components/accounting/AuditTimeline.tsx
@@ -84,7 +84,10 @@ export function AuditTimeline({ events, compact = false }: AuditTimelineProps) {
                 {formatDateTime(evt.timestamp)}
                 {!compact && evt.detail ? ` · ${evt.detail}` : null}
               </div>
-              {!compact && evt.reason ? (
+              {/* Reason (e.g. reverse reason) is decoupled from `compact`:
+                  the inline preview is compact, yet a standard 3-event
+                  reversed doc must still show WHY it was reversed. */}
+              {evt.reason ? (
                 <div className="mt-1.5 rounded-md border border-border bg-muted/50 px-2.5 py-1.5 text-xs leading-snug">
                   <span className="font-semibold text-foreground">เหตุผล: </span>
                   <span className="text-muted-foreground">{evt.reason}</span>

--- a/apps/web/src/components/accounting/InternalControlActionBar.tsx
+++ b/apps/web/src/components/accounting/InternalControlActionBar.tsx
@@ -141,7 +141,7 @@ function Stepper({
               <span
                 className={`flex h-8 w-8 items-center justify-center rounded-full border ${
                   reached
-                    ? 'border-primary bg-primary/10 text-primary'
+                    ? 'border-accent-purple bg-accent-purple/10 text-accent-purple'
                     : 'border-border bg-muted/40 text-muted-foreground'
                 }`}
               >
@@ -162,7 +162,7 @@ function Stepper({
             {i < steps.length - 1 && (
               <span
                 className={`mx-1.5 -mt-5 h-0.5 flex-1 rounded-full sm:mx-2 ${
-                  i < currentIndex ? 'bg-primary' : 'bg-border'
+                  i < currentIndex ? 'bg-accent-purple' : 'bg-border'
                 }`}
                 aria-hidden
               />
@@ -230,12 +230,12 @@ export function InternalControlActionBar(props: InternalControlActionBarProps) {
         data-testid="icab-frame"
         data-module={module}
         data-status={status}
-        className="mt-4 rounded-xl border border-border bg-card text-card-foreground"
+        className="mt-4 rounded-xl border border-accent-purple/30 bg-card text-card-foreground"
       >
         {/* Zone 1 — Header */}
         <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-5">
           <div className="flex items-center gap-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-purple/10 text-accent-purple">
               <ShieldCheck size={18} aria-hidden />
             </span>
             <div className="leading-snug">
@@ -288,7 +288,7 @@ export function InternalControlActionBar(props: InternalControlActionBarProps) {
             <div className="mb-2 flex items-center justify-between">
               <span className="inline-flex items-center gap-1.5 text-sm font-medium leading-snug text-foreground">
                 <History size={14} className="text-muted-foreground" aria-hidden />
-                ประวัติ ({auditLog.length})
+                ประวัติการทำงาน ({auditLog.length})
               </span>
               {auditLog.length > 3 && (
                 <Popover>

--- a/apps/web/src/components/accounting/ReverseConfirmDialog.tsx
+++ b/apps/web/src/components/accounting/ReverseConfirmDialog.tsx
@@ -65,11 +65,13 @@ const DEFAULT_IMPACT_NOTES: Record<IcabModule, string[]> = {
     'ระบบจะสร้างเอกสาร Reverse Entry — สลับ Dr↔Cr ทุกบรรทัด',
     'เอกสารต้นฉบับจะเปลี่ยน status เป็น REVERSED (read-only)',
     'WHT / VAT ที่บันทึกไว้จะถูกกลับรายการอัตโนมัติ',
+    'ถ้างวด ภ.พ.30 ยื่นไปแล้ว — ต้องยื่นแก้ไข',
   ],
   asset: [
     'ระบบจะสร้างเอกสาร Reverse Entry — สลับ Dr↔Cr ทุกบรรทัด',
     'เอกสารต้นฉบับจะเปลี่ยน status เป็น REVERSED (read-only)',
     'หากบันทึกค่าเสื่อมราคาไปแล้ว — ต้องตรวจสอบ depreciation schedule',
+    'ถ้างวด ภ.พ.30 ยื่นไปแล้ว — ต้องยื่นแก้ไข',
   ],
 };
 

--- a/apps/web/src/components/accounting/__tests__/AuditTimeline.test.tsx
+++ b/apps/web/src/components/accounting/__tests__/AuditTimeline.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AuditTimeline } from '../AuditTimeline';
+import type { IcabAuditEvent } from '../types';
+
+/**
+ * The action bar renders a *compact* inline preview of the timeline
+ * (`<AuditTimeline ... compact />`). For a standard 3-event document
+ * (Created → Posted → Reversed) that compact preview is the ONLY place the
+ * timeline is shown — the "ดูทั้งหมด" popover only mounts when there are
+ * more than 3 events. So the reverse reason MUST survive compact mode,
+ * otherwise a reversed document never shows why it was reversed.
+ */
+const threeEventReversed: IcabAuditEvent[] = [
+  { event: 'CREATED', userId: 'u1', userName: 'เอกนรินทร์ คงเดช', timestamp: '2026-05-12T07:25:10.000Z' },
+  { event: 'POSTED', userId: 'u2', userName: 'สุทธินีย์ คงเดช', timestamp: '2026-05-12T07:30:25.000Z' },
+  {
+    event: 'REVERSED',
+    userId: 'u2',
+    userName: 'สุทธินีย์ คงเดช',
+    timestamp: '2026-05-13T02:15:00.000Z',
+    reason: 'บันทึกผิดบัญชี — ควรเป็น 42-1105 ไม่ใช่ 42-1102',
+    detail: 'รายละเอียดภายในที่ไม่ควรโชว์ใน compact',
+  },
+];
+
+describe('AuditTimeline', () => {
+  it('shows the reverse reason on the REVERSED event even in compact mode', () => {
+    render(<AuditTimeline events={threeEventReversed} compact />);
+    expect(
+      screen.getByText(/บันทึกผิดบัญชี — ควรเป็น 42-1105 ไม่ใช่ 42-1102/),
+    ).toBeInTheDocument();
+  });
+
+  it('still suppresses free-form detail in compact mode', () => {
+    render(<AuditTimeline events={threeEventReversed} compact />);
+    expect(
+      screen.queryByText(/รายละเอียดภายในที่ไม่ควรโชว์/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the reason in full (non-compact) mode too', () => {
+    render(<AuditTimeline events={threeEventReversed} />);
+    expect(
+      screen.getByText(/บันทึกผิดบัญชี — ควรเป็น 42-1105 ไม่ใช่ 42-1102/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/accounting/__tests__/InternalControlActionBar.test.tsx
+++ b/apps/web/src/components/accounting/__tests__/InternalControlActionBar.test.tsx
@@ -421,6 +421,24 @@ describe('InternalControlActionBar', () => {
     });
   });
 
+  describe('audit timeline header', () => {
+    it('labels the inline history section "ประวัติการทำงาน" even for a ≤3-event doc', () => {
+      render(
+        wrap(
+          <InternalControlActionBar
+            module="other_income"
+            status="POSTED"
+            auditLog={sampleAudit}
+            currentUser={baseUser}
+            docNumber="RT-202605-00006"
+            onCancel={vi.fn()}
+          />,
+        ),
+      );
+      expect(screen.getByText(/ประวัติการทำงาน/)).toBeInTheDocument();
+    });
+  });
+
   describe('module data attributes', () => {
     it('exposes module + status as data attributes', () => {
       const { container } = render(
@@ -438,6 +456,23 @@ describe('InternalControlActionBar', () => {
       const frame = container.querySelector('[data-testid="icab-frame"]');
       expect(frame?.getAttribute('data-module')).toBe('asset');
       expect(frame?.getAttribute('data-status')).toBe('POSTED');
+    });
+
+    it('frames the control bar with the purple internal-control accent', () => {
+      const { container } = render(
+        wrap(
+          <InternalControlActionBar
+            module="other_income"
+            status="POSTED"
+            auditLog={sampleAudit}
+            currentUser={baseUser}
+            docNumber="RT-1"
+            onCancel={vi.fn()}
+          />,
+        ),
+      );
+      const frame = container.querySelector('[data-testid="icab-frame"]');
+      expect(frame?.className).toMatch(/accent-purple/);
     });
   });
 });

--- a/apps/web/src/components/accounting/__tests__/ReverseConfirmDialog.test.tsx
+++ b/apps/web/src/components/accounting/__tests__/ReverseConfirmDialog.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReverseConfirmDialog } from '../ReverseConfirmDialog';
+import type { IcabModule } from '../types';
+
+vi.mock('@/hooks/useUiFlags', () => ({
+  useUiFlags: () => ({
+    reversePermission: 'OWNER+FINANCE_MANAGER',
+    reverseReasonRequired: true,
+    reverseReasons: [{ code: 'r1', label: 'บันทึกผิดบัญชี' }],
+  }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  default: { get: vi.fn(() => Promise.resolve({ data: [] })) },
+}));
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const wrap = (ui: React.ReactElement) => (
+  <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+);
+
+/**
+ * The reverse-dialog mockup lists a ภ.พ.30 (VAT-filing) impact warning so the
+ * accountant is reminded that an already-filed VAT period must be amended.
+ * It must appear for EVERY module (expense + asset have input VAT too),
+ * not just other_income.
+ */
+describe('ReverseConfirmDialog — impact notes', () => {
+  const modules: IcabModule[] = ['other_income', 'expense', 'asset'];
+
+  it.each(modules)('shows the ภ.พ.30 VAT-filing warning for module=%s', (module) => {
+    render(
+      wrap(
+        <ReverseConfirmDialog
+          open
+          module={module}
+          docNumber="DOC-1"
+          onOpenChange={vi.fn()}
+          onConfirm={vi.fn()}
+        />,
+      ),
+    );
+    expect(screen.getByText(/ภ\.พ\.30/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/contexts/AuthContext.test.tsx
+++ b/apps/web/src/contexts/AuthContext.test.tsx
@@ -32,6 +32,7 @@ function Harness() {
       <div data-testid="loading">{isLoading ? 'loading' : 'done'}</div>
       <div data-testid="auth">{isAuthenticated ? 'yes' : 'no'}</div>
       <div data-testid="user">{user ? `${user.id}:${user.role}` : 'none'}</div>
+      <div data-testid="can-reverse">{user ? String(user.canReverseOverride) : 'none'}</div>
       <button
         type="button"
         onClick={() => {
@@ -245,6 +246,60 @@ describe('<AuthProvider />', () => {
       expect(apiPostMock).toHaveBeenCalledWith('/auth/logout', {});
       expect(setAccessTokenMock).toHaveBeenCalledWith(null);
       expect(setUserMock).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('canReverseOverride propagation (reverse-permission CUSTOM mode)', () => {
+    it('carries canReverseOverride from /auth/me into the in-memory user', async () => {
+      getAccessTokenMock.mockReturnValue('token-abc');
+      apiGetMock.mockResolvedValueOnce({
+        data: {
+          id: 'user-9',
+          email: 'e@example.com',
+          name: 'E',
+          role: 'ACCOUNTANT',
+          branchId: null,
+          branch: null,
+          canReverseOverride: true,
+        },
+      });
+
+      renderHarness();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+      });
+      expect(screen.getByTestId('can-reverse')).toHaveTextContent('true');
+    });
+
+    it('carries canReverseOverride from the login response into the user', async () => {
+      getAccessTokenMock.mockReturnValue(null);
+      apiPostMock.mockResolvedValueOnce({
+        data: {
+          state: 'AUTHENTICATED',
+          accessToken: 'new-token',
+          user: {
+            id: 'user-10',
+            email: 'f@example.com',
+            name: 'F',
+            role: 'ACCOUNTANT',
+            branchId: null,
+            canReverseOverride: true,
+          },
+        },
+      });
+
+      renderHarness();
+      await waitFor(() =>
+        expect(screen.getByTestId('loading')).toHaveTextContent('done'),
+      );
+
+      await userEvent.click(screen.getByText('login'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+      });
+      expect(screen.getByTestId('can-reverse')).toHaveTextContent('true');
     });
   });
 

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -102,6 +102,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         preferences: data.preferences ?? null,
         accessibleCompanies: data.accessibleCompanies ?? [],
         primaryCompany: data.primaryCompany ?? null,
+        canReverseOverride: data.canReverseOverride ?? null,
       };
       setUser(nextUser);
       setSentryUser(nextUser);
@@ -180,6 +181,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         branchName: data.user.branchName ?? data.user.branch?.name ?? null,
         accessibleCompanies: data.user.accessibleCompanies ?? [],
         primaryCompany: data.user.primaryCompany ?? null,
+        canReverseOverride: data.user.canReverseOverride ?? null,
       };
       setUser(nextUser);
       setSentryUser(nextUser);


### PR DESCRIPTION
## Summary
Closes 5 spec-conformance gaps in the shared `InternalControlActionBar` (ควบคุมภายใน), found in a full audit against the v2.2 spec PDF.

| # | Fix | Files |
|---|-----|-------|
| 1 | **`canReverseOverride` now reaches the UI** — propagated into login, 2FA, and `/auth/me` responses + AuthContext. The CUSTOM per-user reverse permission was always `undefined` client-side, so a granted non-OWNER user never saw the reverse button (server would have permitted it). | `auth.service.ts`, `AuthContext.tsx` |
| 2 | **Reverse reason shows on the inline timeline** — decoupled `reason` from `compact` so a standard 3-event (Created → Posted → Reversed) doc shows *why* it was reversed. | `AuditTimeline.tsx` |
| 3 | **ภ.พ.30 VAT-filing warning** added to the expense + asset reverse dialogs (previously only other_income). | `ReverseConfirmDialog.tsx` |
| 4 | **Purple control-frame** per the mockup, via the existing `accent-purple` design token (no hardcoded hex). | `InternalControlActionBar.tsx` |
| 6 | Timeline header `ประวัติ` → `ประวัติการทำงาน`. | `InternalControlActionBar.tsx` |

**Item 5 (doc-number prefixes):** intentionally **not** changed. The PDF's `PV-`/`AS-` conflict with the documented `EX-`/`ASSET-` convention in `.claude/rules/accounting.md` (PEAK export + report parsing depend on it, and existing posted docs use it). Owner confirmed keeping the existing convention.

## Testing
- **+10 tests**, all written test-first (RED → GREEN): `AuthContext`, `AuditTimeline` (new), `ReverseConfirmDialog` (new), action bar.
- Full web suite: **603/603 pass**.
- `auth.service.spec`: **24/24 pass**.
- web + api typecheck: **0 errors**. eslint on changed files: clean.

## Risk
- Item 1 touches the login hot path (one additive field on each path; verified by its own spec).
- Item 4 is a visual change (emerald → purple) reversing an earlier redesign — owner-requested, trivially revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
