### PR TITLE
feat(contacts): PEAK-style contact picker — slice 1 (supplier field)

### DIFF
--- a/apps/api/src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts
@@ -1,0 +1,110 @@
+import { Test } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ContactResolverService } from '../contact-resolver.service';
+
+describe('ContactResolverService.ensureRole', () => {
+  let svc: ContactResolverService;
+  let tx: {
+    contact: { findFirst: jest.Mock; update: jest.Mock };
+    supplier: { findFirst: jest.Mock; create: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    tx = {
+      contact: { findFirst: jest.fn(), update: jest.fn().mockResolvedValue({}) },
+      supplier: { findFirst: jest.fn(), create: jest.fn() },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        ContactResolverService,
+        { provide: PrismaService, useValue: {} },
+      ],
+    }).compile();
+    svc = mod.get(ContactResolverService);
+  });
+
+  it('returns the existing supplier id without creating (idempotent)', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c1', name: 'ABC', phone: '0812345678', roles: ['SUPPLIER'],
+    });
+    tx.supplier.findFirst.mockResolvedValue({ id: 'sup1' });
+
+    const result = await svc.ensureRole(tx as any, 'c1', 'SUPPLIER');
+
+    expect(result).toEqual({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: false,
+    });
+    expect(tx.supplier.create).not.toHaveBeenCalled();
+    expect(tx.contact.update).not.toHaveBeenCalled();
+  });
+
+  it('creates a Supplier with blank-phone fallback and adds the role', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c2', name: 'NoPhone Co', phone: null, roles: ['CUSTOMER'],
+    });
+    tx.supplier.findFirst.mockResolvedValue(null);
+    tx.supplier.create.mockResolvedValue({ id: 'sup2' });
+
+    const result = await svc.ensureRole(tx as any, 'c2', 'SUPPLIER');
+
+    expect(tx.supplier.create).toHaveBeenCalledWith({
+      data: { name: 'NoPhone Co', phone: '', contactId: 'c2' },
+      select: { id: true },
+    });
+    expect(tx.contact.update).toHaveBeenCalledWith({
+      where: { id: 'c2' },
+      data: { roles: { set: ['CUSTOMER', 'SUPPLIER'] } },
+    });
+    expect(result).toEqual({
+      contactId: 'c2', role: 'SUPPLIER', supplierId: 'sup2', provisioned: true,
+    });
+  });
+
+  it('adds the role when a supplier row already exists but role is missing', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c3', name: 'ABC', phone: '02', roles: ['CUSTOMER'],
+    });
+    tx.supplier.findFirst.mockResolvedValue({ id: 'sup3' });
+
+    const result = await svc.ensureRole(tx as any, 'c3', 'SUPPLIER');
+
+    expect(tx.supplier.create).not.toHaveBeenCalled();
+    expect(tx.contact.update).toHaveBeenCalledWith({
+      where: { id: 'c3' },
+      data: { roles: { set: ['CUSTOMER', 'SUPPLIER'] } },
+    });
+    expect(result.provisioned).toBe(true);
+    expect(result.supplierId).toBe('sup3');
+  });
+
+  it('throws NotFound when the contact does not exist', async () => {
+    tx.contact.findFirst.mockResolvedValue(null);
+    await expect(svc.ensureRole(tx as any, 'missing', 'SUPPLIER')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('treats a soft-deleted supplier as absent (deletedAt: null filter) and provisions fresh', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c4', name: 'Revived Co', phone: '03', roles: ['CUSTOMER'],
+    });
+    // soft-deleted supplier is filtered out by deletedAt: null -> findFirst returns null
+    tx.supplier.findFirst.mockResolvedValue(null);
+    tx.supplier.create.mockResolvedValue({ id: 'sup4' });
+
+    const result = await svc.ensureRole(tx as any, 'c4', 'SUPPLIER');
+
+    expect(tx.supplier.create).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      contactId: 'c4', role: 'SUPPLIER', supplierId: 'sup4', provisioned: true,
+    });
+  });
+
+  it('rejects CUSTOMER provisioning in this phase', async () => {
+    tx.contact.findFirst.mockResolvedValue(null);
+    await expect(svc.ensureRole(tx as any, 'c1', 'CUSTOMER' as any)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+});

--- a/apps/api/src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts
@@ -1,0 +1,41 @@
+import { Test } from '@nestjs/testing';
+import { ContactsController } from '../contacts.controller';
+import { ContactsService } from '../contacts.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+
+describe('ContactsController.ensureRole', () => {
+  let controller: ContactsController;
+  let service: { ensureRole: jest.Mock };
+
+  beforeEach(async () => {
+    service = { ensureRole: jest.fn().mockResolvedValue({ supplierId: 'sup1', provisioned: true }) };
+    const mod = await Test.createTestingModule({
+      controllers: [ContactsController],
+      providers: [{ provide: ContactsService, useValue: service }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = mod.get(ContactsController);
+  });
+
+  it('passes id, role and actor to the service', async () => {
+    const req = {
+      user: { id: 'u1', role: 'OWNER' },
+      ip: '10.0.0.1',
+      headers: { 'user-agent': 'jest' },
+    } as any;
+
+    const result = await controller.ensureRole('c1', { role: 'SUPPLIER' }, req);
+
+    expect(service.ensureRole).toHaveBeenCalledWith('c1', 'SUPPLIER', {
+      userId: 'u1',
+      ipAddress: '10.0.0.1',
+      userAgent: 'jest',
+    });
+    expect(result).toEqual({ supplierId: 'sup1', provisioned: true });
+  });
+});

--- a/apps/api/src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts
@@ -1,0 +1,60 @@
+import { Test } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { AuditService } from '../../audit/audit.service';
+import { ContactResolverService } from '../contact-resolver.service';
+import { ContactsService } from '../contacts.service';
+
+describe('ContactsService.ensureRole', () => {
+  let svc: ContactsService;
+  let resolver: { ensureRole: jest.Mock };
+  let audit: { log: jest.Mock };
+  let prisma: { $transaction: jest.Mock };
+
+  beforeEach(async () => {
+    resolver = { ensureRole: jest.fn() };
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+    // run the callback with a dummy tx
+    prisma = { $transaction: jest.fn((cb: (tx: unknown) => Promise<unknown>) => cb({})) };
+
+    const mod = await Test.createTestingModule({
+      providers: [
+        ContactsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+        { provide: ContactResolverService, useValue: resolver },
+      ],
+    }).compile();
+    svc = mod.get(ContactsService);
+  });
+
+  it('audits CONTACT_ROLE_ADDED when a role was provisioned', async () => {
+    resolver.ensureRole.mockResolvedValue({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: true,
+    });
+
+    const result = await svc.ensureRole('c1', 'SUPPLIER', { userId: 'u1', ipAddress: '127.0.0.1' });
+
+    expect(resolver.ensureRole).toHaveBeenCalledWith({}, 'c1', 'SUPPLIER');
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'u1',
+        action: 'CONTACT_ROLE_ADDED',
+        entity: 'contact',
+        entityId: 'c1',
+        newValue: { role: 'SUPPLIER', supplierId: 'sup1' },
+        ipAddress: '127.0.0.1',
+      }),
+    );
+    expect(result.supplierId).toBe('sup1');
+  });
+
+  it('does NOT audit when nothing was provisioned (idempotent hit)', async () => {
+    resolver.ensureRole.mockResolvedValue({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: false,
+    });
+
+    await svc.ensureRole('c1', 'SUPPLIER', { userId: 'u1' });
+
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contacts.service.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { AuditService } from '../../audit/audit.service';
 import { ContactsService } from '../contacts.service';
+import { ContactResolverService } from '../contact-resolver.service';
 
 describe('ContactsService.list', () => {
   let svc: ContactsService;
@@ -13,6 +14,7 @@ describe('ContactsService.list', () => {
         ContactsService,
         { provide: PrismaService, useValue: prisma },
         { provide: AuditService, useValue: { log: jest.fn() } },
+        { provide: ContactResolverService, useValue: { ensureRole: jest.fn() } },
       ],
     }).compile();
     svc = mod.get(ContactsService);
@@ -60,6 +62,7 @@ describe('ContactsService.findOne', () => {
         ContactsService,
         { provide: PrismaService, useValue: prisma },
         { provide: AuditService, useValue: { log: jest.fn() } },
+        { provide: ContactResolverService, useValue: { ensureRole: jest.fn() } },
       ],
     }).compile();
     svc = mod.get(ContactsService);
@@ -116,6 +119,7 @@ describe('ContactsService.merge', () => {
         ContactsService,
         { provide: PrismaService, useValue: prisma },
         { provide: AuditService, useValue: audit },
+        { provide: ContactResolverService, useValue: { ensureRole: jest.fn() } },
       ],
     }).compile();
     svc = mod.get(ContactsService);

--- a/apps/api/src/modules/contacts/contact-resolver.service.ts
+++ b/apps/api/src/modules/contacts/contact-resolver.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { ContactRole, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 
@@ -11,6 +11,15 @@ export interface ResolveContactInput {
   phone?: string | null;
   email?: string | null;
   role: ContactRole;
+}
+
+export interface EnsureRoleResult {
+  contactId: string;
+  role: ContactRole;
+  supplierId?: string;
+  customerId?: string;
+  /** true when a child row was created and/or the role was newly added */
+  provisioned: boolean;
 }
 
 @Injectable()
@@ -85,6 +94,52 @@ export class ContactResolverService {
       }
       throw e;
     }
+  }
+
+  /**
+   * Ensure a contact can be used in a `role` context: provision the child row
+   * (Supplier) if missing and append the role. Idempotent. SUPPLIER only in this
+   * phase — CUSTOMER auto-provisioning is deferred (PII/encryption on Customer).
+   */
+  async ensureRole(
+    tx: Tx,
+    contactId: string,
+    role: ContactRole,
+  ): Promise<EnsureRoleResult> {
+    if (role !== 'SUPPLIER') {
+      throw new BadRequestException('ยังไม่รองรับการสร้างบทบาทนี้อัตโนมัติในเฟสนี้');
+    }
+
+    const contact = await tx.contact.findFirst({
+      where: { id: contactId, deletedAt: null },
+    });
+    if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    let provisioned = false;
+
+    const existing = await tx.supplier.findFirst({
+      where: { contactId, deletedAt: null },
+      select: { id: true },
+    });
+    const supplierId = existing
+      ? existing.id
+      : (
+          await tx.supplier.create({
+            data: { name: contact.name, phone: contact.phone ?? '', contactId },
+            select: { id: true },
+          })
+        ).id;
+    if (!existing) provisioned = true;
+
+    if (!contact.roles.includes(role)) {
+      await tx.contact.update({
+        where: { id: contactId },
+        data: { roles: { set: [...contact.roles, role] } },
+      });
+      provisioned = true;
+    }
+
+    return { contactId, role, supplierId, provisioned };
   }
 
   private hashLockKey(key: string): number {

--- a/apps/api/src/modules/contacts/contacts.controller.ts
+++ b/apps/api/src/modules/contacts/contacts.controller.ts
@@ -3,6 +3,7 @@ import type { Request } from 'express';
 import { ContactsService } from './contacts.service';
 import { ListContactsDto } from './dto/list-contacts.dto';
 import { MergeContactsDto } from './dto/merge-contacts.dto';
+import { EnsureRoleDto } from './dto/ensure-role.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -30,6 +31,16 @@ export class ContactsController {
   @Roles('OWNER')
   merge(@Body() dto: MergeContactsDto, @Req() req: AuthRequest) {
     return this.contacts.merge(dto, {
+      userId: req.user?.id,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'] as string | undefined,
+    });
+  }
+
+  @Post(':id/ensure-role')
+  @Roles('OWNER', 'BRANCH_MANAGER', 'FINANCE_MANAGER', 'ACCOUNTANT')
+  ensureRole(@Param('id') id: string, @Body() dto: EnsureRoleDto, @Req() req: AuthRequest) {
+    return this.contacts.ensureRole(id, dto.role, {
       userId: req.user?.id,
       ipAddress: req.ip,
       userAgent: req.headers['user-agent'] as string | undefined,

--- a/apps/api/src/modules/contacts/contacts.service.ts
+++ b/apps/api/src/modules/contacts/contacts.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { ContactRole, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
+import { ContactResolverService } from './contact-resolver.service';
 import { ListContactsDto } from './dto/list-contacts.dto';
 import { MergeContactsDto } from './dto/merge-contacts.dto';
 
@@ -10,6 +11,7 @@ export class ContactsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly audit: AuditService,
+    private readonly contactResolver: ContactResolverService,
   ) {}
 
   async list(dto: ListContactsDto) {
@@ -160,5 +162,35 @@ export class ContactsService {
 
       return { primaryId, mergedRoles: unionRoles };
     });
+  }
+
+  async ensureRole(
+    id: string,
+    role: 'SUPPLIER' | 'CUSTOMER',
+    actor: { userId?: string; ipAddress?: string; userAgent?: string },
+  ) {
+    const result = await this.prisma.$transaction((tx) =>
+      // role is the narrow caller union (⊆ ContactRole); cast bridges Prisma's
+      // enum type. Resolver guards non-SUPPLIER roles at runtime.
+      this.contactResolver.ensureRole(tx, id, role as ContactRole),
+    );
+
+    if (result.provisioned) {
+      await this.audit.log({
+        userId: actor.userId,
+        action: 'CONTACT_ROLE_ADDED',
+        entity: 'contact',
+        entityId: id,
+        newValue: {
+          role: result.role,
+          supplierId: result.supplierId,
+          ...(result.customerId !== undefined && { customerId: result.customerId }),
+        },
+        ipAddress: actor.ipAddress,
+        userAgent: actor.userAgent,
+      });
+    }
+
+    return result;
   }
 }

--- a/apps/api/src/modules/contacts/dto/ensure-role.dto.ts
+++ b/apps/api/src/modules/contacts/dto/ensure-role.dto.ts
@@ -1,8 +1,9 @@
-import { IsIn } from 'class-validator';
+import { IsIn, IsString } from 'class-validator';
 
 // Accepts SUPPLIER | CUSTOMER for forward-compat; the service implements
 // SUPPLIER provisioning in this phase and rejects CUSTOMER.
 export class EnsureRoleDto {
+  @IsString()
   @IsIn(['SUPPLIER', 'CUSTOMER'], { message: 'role ต้องเป็น SUPPLIER หรือ CUSTOMER' })
   role!: 'SUPPLIER' | 'CUSTOMER';
 }

--- a/apps/api/src/modules/contacts/dto/ensure-role.dto.ts
+++ b/apps/api/src/modules/contacts/dto/ensure-role.dto.ts
@@ -1,0 +1,8 @@
+import { IsIn } from 'class-validator';
+
+// Accepts SUPPLIER | CUSTOMER for forward-compat; the service implements
+// SUPPLIER provisioning in this phase and rejects CUSTOMER.
+export class EnsureRoleDto {
+  @IsIn(['SUPPLIER', 'CUSTOMER'], { message: 'role ต้องเป็น SUPPLIER หรือ CUSTOMER' })
+  role!: 'SUPPLIER' | 'CUSTOMER';
+}

--- a/apps/web/src/components/contacts/ContactCombobox.test.tsx
+++ b/apps/web/src/components/contacts/ContactCombobox.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ContactCombobox } from './ContactCombobox';
+
+// jsdom does not implement scrollIntoView; cmdk calls it on CommandItem mount.
+// Polyfill here (test-only) so the component can render without throwing.
+beforeAll(() => {
+  if (!window.HTMLElement.prototype.scrollIntoView) {
+    window.HTMLElement.prototype.scrollIntoView = () => {};
+  }
+});
+
+const listMock = vi.fn();
+const ensureRoleMock = vi.fn();
+vi.mock('@/lib/api/contacts', () => ({
+  contactsApi: {
+    list: (...a: unknown[]) => listMock(...a),
+    ensureRole: (...a: unknown[]) => ensureRoleMock(...a),
+  },
+  contactKeys: {
+    all: ['contacts'],
+    list: (p: unknown) => ['contacts', 'list', p],
+    detail: (id: string) => ['contacts', 'detail', id],
+  },
+}));
+
+function renderCombo(onSelect = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <ContactCombobox roleNeeded="SUPPLIER" value="" onSelect={onSelect} />
+    </QueryClientProvider>,
+  );
+  return onSelect;
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+  ensureRoleMock.mockReset();
+});
+
+describe('ContactCombobox', () => {
+  it('searches all contacts (no role filter) and provisions the role on pick', async () => {
+    listMock.mockResolvedValue({
+      data: [{ id: 'c1', name: 'ABC Co', taxId: '0105500000001', roles: ['CUSTOMER'] }],
+      total: 1, page: 1, limit: 20,
+    });
+    ensureRoleMock.mockResolvedValue({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: true,
+    });
+    const onSelect = renderCombo();
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.type(screen.getByPlaceholderText(/ค้นหา/), 'ABC');
+
+    const item = await screen.findByText('ABC Co');
+    await userEvent.click(item);
+
+    // list was called WITHOUT a role filter
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    expect(listMock.mock.calls.some(([arg]) => (arg as { role?: string }).role === undefined)).toBe(
+      true,
+    );
+    await waitFor(() => expect(ensureRoleMock).toHaveBeenCalledWith('c1', 'SUPPLIER'));
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith({
+        contactId: 'c1',
+        childId: 'sup1',
+        name: 'ABC Co',
+        taxId: '0105500000001',
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/contacts/ContactCombobox.tsx
+++ b/apps/web/src/components/contacts/ContactCombobox.tsx
@@ -1,0 +1,178 @@
+// Reusable PEAK-style contact picker. Searches the party master (สมุดผู้ติดต่อ)
+// across ALL roles (server-side, debounced). On pick it calls ensure-role so the
+// chosen contact is provisioned into the field's role (e.g. a customer-only
+// contact becomes a Supplier) and returns the child id to the parent.
+import { useState } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useDebounce } from '@/hooks/useDebounce';
+import { cn } from '@/lib/utils';
+import { contactsApi, contactKeys, type Contact, type ContactRole } from '@/lib/api/contacts';
+
+const ROLE_LABELS: Record<ContactRole, string> = {
+  CUSTOMER: 'ลูกค้า',
+  SUPPLIER: 'ผู้ขาย',
+  TRADE_IN_SELLER: 'คนขายมือสอง',
+  FINANCE_COMPANY: 'ไฟแนนซ์',
+};
+
+export interface ContactPickResult {
+  contactId: string;
+  childId: string;
+  name: string;
+  taxId: string;
+}
+
+interface Props {
+  // 'CUSTOMER' is forward-compat; backend provisions SUPPLIER now and 400s for CUSTOMER (surfaced via the onError toast).
+  roleNeeded: 'SUPPLIER' | 'CUSTOMER';
+  value: string;
+  onSelect: (result: ContactPickResult) => void;
+  /** When provided, a typed name with no exact match can be committed as a one-off. */
+  onTypeName?: (name: string) => void;
+  invalid?: boolean;
+  placeholder?: string;
+}
+
+export function ContactCombobox({
+  roleNeeded,
+  value,
+  onSelect,
+  onTypeName,
+  invalid,
+  placeholder = 'เลือกผู้ติดต่อ หรือพิมพ์ชื่อ',
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const debounced = useDebounce(search);
+
+  const query = useQuery({
+    queryKey: contactKeys.list({ search: debounced || undefined, isActive: true, limit: 20 }),
+    queryFn: () => contactsApi.list({ search: debounced || undefined, isActive: true, limit: 20 }),
+    staleTime: 60 * 1000,
+  });
+  const contacts = query.data?.data ?? [];
+
+  const hasExactMatch =
+    !!search.trim() && contacts.some((c) => c.name.toLowerCase() === search.trim().toLowerCase());
+
+  const commitTyped = (name: string) => {
+    const n = name.trim();
+    if (!n || !onTypeName) return;
+    onTypeName(n);
+    setOpen(false);
+    setSearch('');
+  };
+
+  const ensureRoleMutation = useMutation({
+    mutationFn: (c: Contact) => contactsApi.ensureRole(c.id, roleNeeded),
+    onSuccess: (res, c) => {
+      const childId = res.supplierId ?? res.customerId ?? '';
+      onSelect({ contactId: c.id, childId, name: c.name, taxId: c.taxId ?? '' });
+      setOpen(false);
+      setSearch('');
+    },
+    onError: () => toast.error('ไม่สามารถเพิ่มบทบาทให้ผู้ติดต่อได้ กรุณาลองใหม่อีกครั้ง'),
+  });
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-invalid={invalid}
+          className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground')}
+        >
+          <span className="truncate leading-snug" title={value || undefined}>
+            {value || placeholder}
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="ค้นหาผู้ติดต่อ / เลขภาษี..."
+            value={search}
+            onValueChange={setSearch}
+            onKeyDown={(e) => {
+              if (onTypeName && e.key === 'Enter' && search.trim() && !hasExactMatch) {
+                e.preventDefault();
+                e.stopPropagation();
+                commitTyped(search);
+              }
+            }}
+          />
+          <CommandList>
+            {query.isLoading || ensureRoleMutation.isPending ? (
+              <CommandEmpty>{ensureRoleMutation.isPending ? 'กำลังเพิ่ม...' : 'กำลังโหลด...'}</CommandEmpty>
+            ) : (
+              <>
+                {query.isError && (
+                  <CommandEmpty className="px-3 py-6 text-center leading-snug text-destructive">
+                    โหลดข้อมูลไม่สำเร็จ
+                  </CommandEmpty>
+                )}
+                {!query.isError && contacts.length === 0 && !!search.trim() && !onTypeName && (
+                  <CommandEmpty className="px-3 py-6 text-center leading-snug">
+                    ไม่พบผู้ติดต่อที่ตรงกับ "{search.trim()}"
+                  </CommandEmpty>
+                )}
+                {contacts.length > 0 && (
+                  <CommandGroup heading="สมุดผู้ติดต่อ">
+                    {contacts.map((c) => (
+                      <CommandItem key={c.id} value={c.id} onSelect={() => ensureRoleMutation.mutate(c)}>
+                        <Check
+                          className={cn(
+                            'mr-2 size-4 shrink-0',
+                            value === c.name ? 'opacity-100' : 'opacity-0',
+                          )}
+                        />
+                        <span className="flex-1 truncate leading-snug">{c.name}</span>
+                        <span className="ml-2 flex shrink-0 gap-1">
+                          {c.roles.map((r) => (
+                            <Badge key={r} variant="secondary" className="text-2xs">
+                              {ROLE_LABELS[r]}
+                            </Badge>
+                          ))}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+                {contacts.length === 0 && !search.trim() && (
+                  <CommandEmpty className="px-3 py-6 text-center leading-snug">
+                    พิมพ์เพื่อค้นหาผู้ติดต่อ
+                  </CommandEmpty>
+                )}
+                {onTypeName && search.trim() && !hasExactMatch && (
+                  <CommandGroup heading="ใช้ครั้งเดียว (ไม่บันทึกในสมุด)">
+                    <CommandItem value={`__typed__${search}`} onSelect={() => commitTyped(search)}>
+                      <Plus className="mr-2 size-4 shrink-0" />
+                      <span className="truncate leading-snug">ใช้ชื่อ "{search.trim()}"</span>
+                    </CommandItem>
+                  </CommandGroup>
+                )}
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/expense-form-v4/VendorCombobox.test.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorCombobox.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VendorCombobox } from './VendorCombobox';
+
+const detailMock = vi.fn();
+vi.mock('@/lib/api/contacts', () => ({
+  contactsApi: { detail: (...a: unknown[]) => detailMock(...a) },
+}));
+
+// Stub ContactCombobox: a button that fires onSelect with a fixed pick result.
+vi.mock('@/components/contacts/ContactCombobox', () => ({
+  ContactCombobox: ({ onSelect }: { onSelect: (r: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() => onSelect({ contactId: 'c1', childId: 'sup1', name: 'ABC Co', taxId: '0105' })}
+    >
+      pick
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  detailMock.mockReset();
+});
+
+describe('VendorCombobox.handleSelect WHT mapping', () => {
+  it('maps a JURISTIC supplier to PND53 and overrides taxId from the supplier link', async () => {
+    detailMock.mockResolvedValue({ suppliers: [{ type: 'JURISTIC', taxId: '9999' }] });
+    const onSelectSupplier = vi.fn();
+    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
+
+    await userEvent.click(screen.getByText('pick'));
+
+    await waitFor(() =>
+      expect(onSelectSupplier).toHaveBeenCalledWith({
+        name: 'ABC Co',
+        taxId: '9999',
+        whtFormType: 'PND53',
+      }),
+    );
+  });
+
+  it('maps an INDIVIDUAL supplier to PND3 and keeps the picked taxId when the link has none', async () => {
+    detailMock.mockResolvedValue({ suppliers: [{ type: 'INDIVIDUAL', taxId: null }] });
+    const onSelectSupplier = vi.fn();
+    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
+
+    await userEvent.click(screen.getByText('pick'));
+
+    await waitFor(() =>
+      expect(onSelectSupplier).toHaveBeenCalledWith({
+        name: 'ABC Co',
+        taxId: '0105',
+        whtFormType: 'PND3',
+      }),
+    );
+  });
+
+  it('falls back to the picked values (no whtFormType) when the detail lookup fails', async () => {
+    detailMock.mockRejectedValue(new Error('boom'));
+    const onSelectSupplier = vi.fn();
+    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
+
+    await userEvent.click(screen.getByText('pick'));
+
+    await waitFor(() =>
+      expect(onSelectSupplier).toHaveBeenCalledWith({
+        name: 'ABC Co',
+        taxId: '0105',
+        whtFormType: undefined,
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
@@ -1,187 +1,47 @@
 // Expense form V4 — vendor picker.
-// Replaces the free-text "ผู้ขาย" input with a searchable combobox sourced from
-// the Contact book (SUPPLIER role) — the same canonical vendor master the Asset
-// module uses. Selecting a supplier auto-fills name + tax id; a typed name that
-// matches no supplier is committed as a one-off vendor (preserves the legacy
-// free-text flow for vendors that aren't registered).
-import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Check, ChevronsUpDown, Pencil, Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { cn } from '@/lib/utils';
-import { contactsApi, type Contact } from '@/lib/api/contacts';
+// Thin wrapper over the shared ContactCombobox (searches the contact book across
+// ALL roles; picking a contact provisions the SUPPLIER role via ensure-role). A
+// typed name that matches no contact is still committed as a one-off vendor,
+// preserving the legacy free-text flow. The expense stores vendorName/vendorTaxId
+// as before — no FK — so this slice only adds the party-master link side effect.
+import { contactsApi } from '@/lib/api/contacts';
+import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
 
 interface Props {
   value: string;
-  /**
-   * A supplier was picked from the contact book — autofill name + taxId, and
-   * whtFormType inferred from the supplier's type (JURISTIC → PND53 นิติบุคคล,
-   * INDIVIDUAL → PND3 บุคคลธรรมดา) when available.
-   */
-  onSelectSupplier: (s: {
-    name: string;
-    taxId: string;
-    whtFormType?: 'PND3' | 'PND53';
-  }) => void;
-  /** A free-typed one-off name (no matching supplier in the contact book). */
+  onSelectSupplier: (s: { name: string; taxId: string; whtFormType?: 'PND3' | 'PND53' }) => void;
   onTypeName: (name: string) => void;
   invalid?: boolean;
 }
 
 export function VendorCombobox({ value, onSelectSupplier, onTypeName, invalid }: Props) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-
-  // Vendor master = สมุดผู้ติดต่อ (Contacts with the SUPPLIER role). Cached ~5 min.
-  const suppliersQuery = useQuery({
-    queryKey: ['vendor-contacts', 'supplier'],
-    queryFn: () => contactsApi.list({ role: 'SUPPLIER', isActive: true, limit: 200 }),
-    staleTime: 5 * 60 * 1000,
-  });
-  const suppliers = suppliersQuery.data?.data ?? [];
-
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return suppliers;
-    return suppliers.filter(
-      (s) => s.name.toLowerCase().includes(q) || (s.taxId ?? '').toLowerCase().includes(q),
-    );
-  }, [search, suppliers]);
-
-  const hasExactMatch = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return !!q && suppliers.some((s) => s.name.toLowerCase() === q);
-  }, [search, suppliers]);
-
-  const isKnownVendor = useMemo(
-    () => !!value && suppliers.some((s) => s.name === value),
-    [value, suppliers],
-  );
-
-  const commitTyped = (name: string) => {
-    const n = name.trim();
-    if (!n) return;
-    onTypeName(n);
-    setOpen(false);
-    setSearch('');
-  };
-
-  // On pick: fetch the contact detail to read the supplier link's type
-  // (the list payload omits it) and map JURISTIC→PND53 / INDIVIDUAL→PND3 so the
-  // "ประเภทผู้ขาย" field auto-fills. Falls back to list values if detail fails.
-  const handleSelect = async (c: Contact) => {
-    setOpen(false);
-    setSearch('');
-    let taxId = c.taxId ?? '';
+  // On pick: ensure-role already ran inside ContactCombobox (a Supplier row now
+  // exists). Read the supplier link's type to map JURISTIC→PND53 / INDIVIDUAL→PND3
+  // so "ประเภทผู้ขาย" auto-fills; fall back to the list values if detail fails.
+  const handleSelect = async ({ contactId, name, taxId }: ContactPickResult) => {
     let whtFormType: 'PND3' | 'PND53' | undefined;
+    let resolvedTaxId = taxId;
     try {
-      const detail = await contactsApi.detail(c.id);
+      const detail = await contactsApi.detail(contactId);
       const link = detail.suppliers?.[0];
       if (link) {
         whtFormType = link.type === 'JURISTIC' ? 'PND53' : 'PND3';
-        if (link.taxId) taxId = link.taxId;
+        if (link.taxId) resolvedTaxId = link.taxId;
       }
     } catch {
-      // keep list values when the detail lookup fails
+      // keep the list values when the detail lookup fails
     }
-    onSelectSupplier({ name: c.name, taxId, whtFormType });
+    onSelectSupplier({ name, taxId: resolvedTaxId, whtFormType });
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          aria-invalid={invalid}
-          className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground')}
-        >
-          <span className="flex min-w-0 items-center gap-1.5">
-            {isKnownVendor ? (
-              <Check className="size-3.5 shrink-0 text-primary" />
-            ) : value ? (
-              <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
-            ) : null}
-            <span className="truncate leading-snug" title={value || undefined}>
-              {value || 'เลือกผู้ขาย หรือพิมพ์ชื่อ'}
-            </span>
-          </span>
-          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-        <Command shouldFilter={false}>
-          <CommandInput
-            placeholder="ค้นหาผู้ขาย / เลขภาษี หรือพิมพ์ชื่อใหม่..."
-            value={search}
-            onValueChange={setSearch}
-            onKeyDown={(e) => {
-              // Enter on a typed name with no exact supplier match commits it as
-              // a one-off vendor (and blocks cmdk from picking a partial match).
-              if (e.key === 'Enter' && search.trim() && !hasExactMatch) {
-                e.preventDefault();
-                e.stopPropagation();
-                commitTyped(search);
-              }
-            }}
-          />
-          <CommandList>
-            {suppliersQuery.isLoading ? (
-              <CommandEmpty>กำลังโหลด...</CommandEmpty>
-            ) : suppliers.length === 0 && !search.trim() ? (
-              <CommandEmpty className="px-3 py-6 text-center leading-snug">
-                ยังไม่มีผู้ขายในสมุดผู้ติดต่อ — พิมพ์ชื่อเพื่อใช้ได้เลย
-              </CommandEmpty>
-            ) : (
-              <>
-                {filtered.length > 0 && (
-                  <CommandGroup heading="ผู้ขายในสมุดผู้ติดต่อ">
-                    {filtered.map((s) => (
-                      <CommandItem
-                        key={s.id}
-                        value={s.id}
-                        onSelect={() => void handleSelect(s)}
-                      >
-                        <Check
-                          className={cn(
-                            'mr-2 size-4 shrink-0',
-                            value === s.name ? 'opacity-100' : 'opacity-0',
-                          )}
-                        />
-                        <span className="flex-1 truncate leading-snug">{s.name}</span>
-                        {s.taxId && (
-                          <span className="ml-2 font-mono text-xs text-muted-foreground">
-                            {s.taxId}
-                          </span>
-                        )}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-                {search.trim() && !hasExactMatch && (
-                  <CommandGroup heading="ผู้ขายครั้งเดียว (ไม่บันทึกในสมุด)">
-                    <CommandItem value={`__typed__${search}`} onSelect={() => commitTyped(search)}>
-                      <Plus className="mr-2 size-4 shrink-0" />
-                      <span className="truncate leading-snug">ใช้ชื่อ “{search.trim()}”</span>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </>
-            )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <ContactCombobox
+      roleNeeded="SUPPLIER"
+      value={value}
+      invalid={invalid}
+      placeholder="เลือกผู้ขาย หรือพิมพ์ชื่อ"
+      onSelect={handleSelect}
+      onTypeName={onTypeName}
+    />
   );
 }

--- a/apps/web/src/lib/api/contacts.ts
+++ b/apps/web/src/lib/api/contacts.ts
@@ -62,6 +62,14 @@ export interface ContactListResult {
   limit: number;
 }
 
+export interface EnsureRoleResult {
+  contactId: string;
+  role: ContactRole;
+  supplierId?: string;
+  customerId?: string;
+  provisioned: boolean;
+}
+
 export const contactKeys = {
   all: ['contacts'] as const,
   list: (params: Record<string, unknown>) => [...contactKeys.all, 'list', params] as const,
@@ -85,4 +93,6 @@ export const contactsApi = {
   detail: (id: string) => api.get<ContactDetail>(`/contacts/${id}`).then((r) => r.data),
   merge: (primaryId: string, duplicateId: string) =>
     api.post('/contacts/merge', { primaryId, duplicateId }).then((r) => r.data),
+  ensureRole: (id: string, role: 'SUPPLIER' | 'CUSTOMER') =>
+    api.post<EnsureRoleResult>(`/contacts/${id}/ensure-role`, { role }).then((r) => r.data),
 };

--- a/docs/superpowers/plans/2026-06-04-peak-contact-picker-slice1.md
+++ b/docs/superpowers/plans/2026-06-04-peak-contact-picker-slice1.md
@@ -1,0 +1,926 @@
+# PEAK-style Contact Picker — Slice 1 (ช่องผู้ขาย) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ทำให้ช่องเลือกผู้ขาย (เริ่มที่ฟอร์มรายจ่าย) ค้นเจอผู้ติดต่อ **ทุก role** แบบ PEAK และพอเลือกผู้ติดต่อที่ยังไม่เป็นผู้ขาย ระบบสร้างแถว `Supplier` + เติม role ให้เงียบๆ
+
+**Architecture:** ต่อยอด party master (`Contact`) ที่มีอยู่แล้ว — เพิ่ม endpoint `POST /contacts/:id/ensure-role` ที่ provision แถวลูก (`Supplier`) ภายใน `$transaction` ผ่าน `ContactResolverService` แล้ว audit; ฝั่ง web สร้างคอมโพเนนต์กลาง `ContactCombobox` (server-side search ทุก role + badge + เรียก ensure-role ตอนเลือก) แล้วเสียบแทนไส้ใน `VendorCombobox`
+
+**Tech Stack:** NestJS + Prisma (apps/api, jest), React + Vite + @tanstack/react-query + shadcn/ui (apps/web, vitest + @testing-library)
+
+**Spec:** [2026-06-04-peak-style-contact-picker-design.md](../specs/2026-06-04-peak-style-contact-picker-design.md)
+
+---
+
+## File Structure
+
+**Backend (apps/api)**
+- Create `src/modules/contacts/dto/ensure-role.dto.ts` — validate body `{ role }`
+- Modify `src/modules/contacts/contact-resolver.service.ts` — add `ensureRole(tx, contactId, role)` (core provisioning)
+- Modify `src/modules/contacts/contacts.service.ts` — add `ensureRole(id, role, actor)` (transaction + audit), inject resolver
+- Modify `src/modules/contacts/contacts.controller.ts` — add `POST :id/ensure-role`
+- Create `src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts`
+- Create `src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts`
+- Create `src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts`
+
+**Frontend (apps/web)**
+- Modify `src/lib/api/contacts.ts` — add `contactsApi.ensureRole` + `EnsureRoleResult` type
+- Create `src/components/contacts/ContactCombobox.tsx` — reusable picker (server search, badges, ensure-role on pick, optional one-off typed name)
+- Create `src/components/contacts/ContactCombobox.test.tsx`
+- Modify `src/components/expense-form-v4/VendorCombobox.tsx` — become a thin wrapper over `ContactCombobox`
+
+---
+
+## Task 1: `ContactResolverService.ensureRole` — provisioning core
+
+**Files:**
+- Modify: `apps/api/src/modules/contacts/contact-resolver.service.ts`
+- Test: `apps/api/src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ContactResolverService } from '../contact-resolver.service';
+
+describe('ContactResolverService.ensureRole', () => {
+  let svc: ContactResolverService;
+  let tx: {
+    contact: { findFirst: jest.Mock; update: jest.Mock };
+    supplier: { findFirst: jest.Mock; create: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    tx = {
+      contact: { findFirst: jest.fn(), update: jest.fn().mockResolvedValue({}) },
+      supplier: { findFirst: jest.fn(), create: jest.fn() },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        ContactResolverService,
+        { provide: PrismaService, useValue: {} },
+      ],
+    }).compile();
+    svc = mod.get(ContactResolverService);
+  });
+
+  it('returns the existing supplier id without creating (idempotent)', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c1', name: 'ABC', phone: '0812345678', roles: ['SUPPLIER'],
+    });
+    tx.supplier.findFirst.mockResolvedValue({ id: 'sup1' });
+
+    const result = await svc.ensureRole(tx as any, 'c1', 'SUPPLIER');
+
+    expect(result).toEqual({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: false,
+    });
+    expect(tx.supplier.create).not.toHaveBeenCalled();
+    expect(tx.contact.update).not.toHaveBeenCalled();
+  });
+
+  it('creates a Supplier with blank-phone fallback and adds the role', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c2', name: 'NoPhone Co', phone: null, roles: ['CUSTOMER'],
+    });
+    tx.supplier.findFirst.mockResolvedValue(null);
+    tx.supplier.create.mockResolvedValue({ id: 'sup2' });
+
+    const result = await svc.ensureRole(tx as any, 'c2', 'SUPPLIER');
+
+    expect(tx.supplier.create).toHaveBeenCalledWith({
+      data: { name: 'NoPhone Co', phone: '', contactId: 'c2' },
+      select: { id: true },
+    });
+    expect(tx.contact.update).toHaveBeenCalledWith({
+      where: { id: 'c2' },
+      data: { roles: { set: ['CUSTOMER', 'SUPPLIER'] } },
+    });
+    expect(result).toEqual({
+      contactId: 'c2', role: 'SUPPLIER', supplierId: 'sup2', provisioned: true,
+    });
+  });
+
+  it('adds the role when a supplier row already exists but role is missing', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c3', name: 'ABC', phone: '02', roles: ['CUSTOMER'],
+    });
+    tx.supplier.findFirst.mockResolvedValue({ id: 'sup3' });
+
+    const result = await svc.ensureRole(tx as any, 'c3', 'SUPPLIER');
+
+    expect(tx.supplier.create).not.toHaveBeenCalled();
+    expect(tx.contact.update).toHaveBeenCalledWith({
+      where: { id: 'c3' },
+      data: { roles: { set: ['CUSTOMER', 'SUPPLIER'] } },
+    });
+    expect(result.provisioned).toBe(true);
+    expect(result.supplierId).toBe('sup3');
+  });
+
+  it('throws NotFound when the contact does not exist', async () => {
+    tx.contact.findFirst.mockResolvedValue(null);
+    await expect(svc.ensureRole(tx as any, 'missing', 'SUPPLIER')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('rejects CUSTOMER provisioning in this phase', async () => {
+    await expect(svc.ensureRole(tx as any, 'c1', 'CUSTOMER' as any)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts`
+Expected: FAIL — `svc.ensureRole is not a function`
+
+- [ ] **Step 3: Implement `ensureRole`**
+
+In `apps/api/src/modules/contacts/contact-resolver.service.ts`, change the imports on line 1 and add the method + result type.
+
+Replace line 1:
+```typescript
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+```
+
+Add this interface just below the existing `ResolveContactInput` interface (after line 14):
+```typescript
+export interface EnsureRoleResult {
+  contactId: string;
+  role: ContactRole;
+  supplierId?: string;
+  customerId?: string;
+  /** true when a child row was created and/or the role was newly added */
+  provisioned: boolean;
+}
+```
+
+Add this method inside the `ContactResolverService` class (e.g. after `findOrCreateByNaturalKey`, before `hashLockKey`):
+```typescript
+  /**
+   * Ensure a contact can be used in a `role` context: provision the child row
+   * (Supplier) if missing and append the role. Idempotent. SUPPLIER only in this
+   * phase — CUSTOMER auto-provisioning is deferred (PII/encryption on Customer).
+   */
+  async ensureRole(
+    tx: Tx,
+    contactId: string,
+    role: ContactRole,
+  ): Promise<EnsureRoleResult> {
+    if (role !== 'SUPPLIER') {
+      throw new BadRequestException('ยังไม่รองรับการสร้างบทบาทนี้อัตโนมัติในเฟสนี้');
+    }
+
+    const contact = await tx.contact.findFirst({
+      where: { id: contactId, deletedAt: null },
+    });
+    if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
+
+    let provisioned = false;
+
+    const existing = await tx.supplier.findFirst({
+      where: { contactId, deletedAt: null },
+      select: { id: true },
+    });
+    let supplierId: string;
+    if (existing) {
+      supplierId = existing.id;
+    } else {
+      const created = await tx.supplier.create({
+        data: { name: contact.name, phone: contact.phone ?? '', contactId },
+        select: { id: true },
+      });
+      supplierId = created.id;
+      provisioned = true;
+    }
+
+    if (!contact.roles.includes(role)) {
+      await tx.contact.update({
+        where: { id: contactId },
+        data: { roles: { set: [...contact.roles, role] } },
+      });
+      provisioned = true;
+    }
+
+    return { contactId, role, supplierId, provisioned };
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/contacts/contact-resolver.service.ts apps/api/src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts
+git commit -m "feat(contacts): ContactResolverService.ensureRole provisions Supplier + role (SUPPLIER)"
+```
+
+---
+
+## Task 2: `EnsureRoleDto`
+
+**Files:**
+- Create: `apps/api/src/modules/contacts/dto/ensure-role.dto.ts`
+
+- [ ] **Step 1: Create the DTO**
+
+```typescript
+import { IsIn } from 'class-validator';
+
+// Accepts SUPPLIER | CUSTOMER for forward-compat; the service implements
+// SUPPLIER provisioning in this phase and rejects CUSTOMER.
+export class EnsureRoleDto {
+  @IsIn(['SUPPLIER', 'CUSTOMER'], { message: 'role ต้องเป็น SUPPLIER หรือ CUSTOMER' })
+  role!: 'SUPPLIER' | 'CUSTOMER';
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd apps/api && npx tsc --noEmit -p tsconfig.json`
+Expected: no new errors referencing `ensure-role.dto.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/modules/contacts/dto/ensure-role.dto.ts
+git commit -m "feat(contacts): add EnsureRoleDto"
+```
+
+---
+
+## Task 3: `ContactsService.ensureRole` — transaction + audit
+
+**Files:**
+- Modify: `apps/api/src/modules/contacts/contacts.service.ts`
+- Test: `apps/api/src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { AuditService } from '../../audit/audit.service';
+import { ContactResolverService } from '../contact-resolver.service';
+import { ContactsService } from '../contacts.service';
+
+describe('ContactsService.ensureRole', () => {
+  let svc: ContactsService;
+  let resolver: { ensureRole: jest.Mock };
+  let audit: { log: jest.Mock };
+  let prisma: { $transaction: jest.Mock };
+
+  beforeEach(async () => {
+    resolver = { ensureRole: jest.fn() };
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+    // run the callback with a dummy tx
+    prisma = { $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb({})) };
+
+    const mod = await Test.createTestingModule({
+      providers: [
+        ContactsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+        { provide: ContactResolverService, useValue: resolver },
+      ],
+    }).compile();
+    svc = mod.get(ContactsService);
+  });
+
+  it('audits CONTACT_ROLE_ADDED when a role was provisioned', async () => {
+    resolver.ensureRole.mockResolvedValue({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: true,
+    });
+
+    const result = await svc.ensureRole('c1', 'SUPPLIER', { userId: 'u1', ipAddress: '127.0.0.1' });
+
+    expect(resolver.ensureRole).toHaveBeenCalledWith({}, 'c1', 'SUPPLIER');
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'u1',
+        action: 'CONTACT_ROLE_ADDED',
+        entity: 'contact',
+        entityId: 'c1',
+        newValue: { role: 'SUPPLIER', supplierId: 'sup1', customerId: undefined },
+        ipAddress: '127.0.0.1',
+      }),
+    );
+    expect(result.supplierId).toBe('sup1');
+  });
+
+  it('does NOT audit when nothing was provisioned (idempotent hit)', async () => {
+    resolver.ensureRole.mockResolvedValue({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: false,
+    });
+
+    await svc.ensureRole('c1', 'SUPPLIER', { userId: 'u1' });
+
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts`
+Expected: FAIL — `svc.ensureRole is not a function` (or DI error before the method exists)
+
+- [ ] **Step 3: Implement the method + inject the resolver**
+
+In `apps/api/src/modules/contacts/contacts.service.ts`:
+
+Add the import near the other relative imports at the top:
+```typescript
+import { ContactResolverService } from './contact-resolver.service';
+```
+
+Add `contactResolver` to the constructor (keep the existing `prisma` and `audit` params):
+```typescript
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+    private readonly contactResolver: ContactResolverService,
+  ) {}
+```
+
+Add this method to the class (e.g. just before the closing brace, after `merge`):
+```typescript
+  async ensureRole(
+    id: string,
+    role: 'SUPPLIER' | 'CUSTOMER',
+    actor: { userId?: string; ipAddress?: string; userAgent?: string },
+  ) {
+    const result = await this.prisma.$transaction((tx) =>
+      this.contactResolver.ensureRole(tx, id, role),
+    );
+
+    if (result.provisioned) {
+      await this.audit.log({
+        userId: actor.userId,
+        action: 'CONTACT_ROLE_ADDED',
+        entity: 'contact',
+        entityId: id,
+        newValue: {
+          role: result.role,
+          supplierId: result.supplierId,
+          customerId: result.customerId,
+        },
+        ipAddress: actor.ipAddress,
+        userAgent: actor.userAgent,
+      });
+    }
+
+    return result;
+  }
+```
+
+> Note: `ContactResolverService` is already registered in `contacts.module.ts` providers, so DI resolves without module changes.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/contacts/contacts.service.ts apps/api/src/modules/contacts/__tests__/contacts.service.ensure-role.spec.ts
+git commit -m "feat(contacts): ContactsService.ensureRole wraps provisioning in tx + audits CONTACT_ROLE_ADDED"
+```
+
+---
+
+## Task 4: Controller endpoint `POST /contacts/:id/ensure-role`
+
+**Files:**
+- Modify: `apps/api/src/modules/contacts/contacts.controller.ts`
+- Test: `apps/api/src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { ContactsController } from '../contacts.controller';
+import { ContactsService } from '../contacts.service';
+
+describe('ContactsController.ensureRole', () => {
+  let controller: ContactsController;
+  let service: { ensureRole: jest.Mock };
+
+  beforeEach(async () => {
+    service = { ensureRole: jest.fn().mockResolvedValue({ supplierId: 'sup1', provisioned: true }) };
+    const mod = await Test.createTestingModule({
+      controllers: [ContactsController],
+      providers: [{ provide: ContactsService, useValue: service }],
+    }).compile();
+    controller = mod.get(ContactsController);
+  });
+
+  it('passes id, role and actor to the service', async () => {
+    const req = {
+      user: { id: 'u1', role: 'OWNER' },
+      ip: '10.0.0.1',
+      headers: { 'user-agent': 'jest' },
+    } as any;
+
+    const result = await controller.ensureRole('c1', { role: 'SUPPLIER' }, req);
+
+    expect(service.ensureRole).toHaveBeenCalledWith('c1', 'SUPPLIER', {
+      userId: 'u1',
+      ipAddress: '10.0.0.1',
+      userAgent: 'jest',
+    });
+    expect(result).toEqual({ supplierId: 'sup1', provisioned: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts`
+Expected: FAIL — `controller.ensureRole is not a function`
+
+- [ ] **Step 3: Add the endpoint**
+
+In `apps/api/src/modules/contacts/contacts.controller.ts`:
+
+Add the DTO import below the existing imports:
+```typescript
+import { EnsureRoleDto } from './dto/ensure-role.dto';
+```
+
+Add this method inside the `ContactsController` class (after `merge`):
+```typescript
+  @Post(':id/ensure-role')
+  @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER', 'SALES')
+  ensureRole(@Param('id') id: string, @Body() dto: EnsureRoleDto, @Req() req: AuthRequest) {
+    return this.contacts.ensureRole(id, dto.role, {
+      userId: req.user?.id,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'] as string | undefined,
+    });
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts`
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Run the whole contacts suite + typecheck**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts && npx tsc --noEmit -p tsconfig.json`
+Expected: all contacts specs PASS, 0 type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/contacts/contacts.controller.ts apps/api/src/modules/contacts/__tests__/contacts.controller.ensure-role.spec.ts
+git commit -m "feat(contacts): POST /contacts/:id/ensure-role endpoint"
+```
+
+---
+
+## Task 5: Web API client `contactsApi.ensureRole`
+
+**Files:**
+- Modify: `apps/web/src/lib/api/contacts.ts`
+
+- [ ] **Step 1: Add the type + method**
+
+In `apps/web/src/lib/api/contacts.ts`, add this exported interface near the other interfaces (e.g. after `ContactListResult`):
+```typescript
+export interface EnsureRoleResult {
+  contactId: string;
+  role: ContactRole;
+  supplierId?: string;
+  customerId?: string;
+  provisioned: boolean;
+}
+```
+
+Add this method to the `contactsApi` object (after `merge`):
+```typescript
+  ensureRole: (id: string, role: 'SUPPLIER' | 'CUSTOMER') =>
+    api.post<EnsureRoleResult>(`/contacts/${id}/ensure-role`, { role }).then((r) => r.data),
+```
+
+- [ ] **Step 2: Verify it typechecks**
+
+Run: `cd apps/web && npx tsc --noEmit -p tsconfig.json`
+Expected: no new errors in `contacts.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/contacts.ts
+git commit -m "feat(web): contactsApi.ensureRole client"
+```
+
+---
+
+## Task 6: `ContactCombobox` component
+
+**Files:**
+- Create: `apps/web/src/components/contacts/ContactCombobox.tsx`
+- Test: `apps/web/src/components/contacts/ContactCombobox.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/contacts/ContactCombobox.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ContactCombobox } from './ContactCombobox';
+
+const listMock = vi.fn();
+const ensureRoleMock = vi.fn();
+vi.mock('@/lib/api/contacts', () => ({
+  contactsApi: {
+    list: (...a: unknown[]) => listMock(...a),
+    ensureRole: (...a: unknown[]) => ensureRoleMock(...a),
+  },
+}));
+
+function renderCombo(onSelect = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <ContactCombobox roleNeeded="SUPPLIER" value="" onSelect={onSelect} />
+    </QueryClientProvider>,
+  );
+  return onSelect;
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+  ensureRoleMock.mockReset();
+});
+
+describe('ContactCombobox', () => {
+  it('searches all contacts (no role filter) and provisions the role on pick', async () => {
+    listMock.mockResolvedValue({
+      data: [{ id: 'c1', name: 'ABC Co', taxId: '0105500000001', roles: ['CUSTOMER'] }],
+      total: 1, page: 1, limit: 20,
+    });
+    ensureRoleMock.mockResolvedValue({
+      contactId: 'c1', role: 'SUPPLIER', supplierId: 'sup1', provisioned: true,
+    });
+    const onSelect = renderCombo();
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.type(screen.getByPlaceholderText(/ค้นหา/), 'ABC');
+
+    const item = await screen.findByText('ABC Co');
+    await userEvent.click(item);
+
+    // list was called WITHOUT a role filter
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    expect(listMock.mock.calls.some(([arg]) => (arg as { role?: string }).role === undefined)).toBe(
+      true,
+    );
+    await waitFor(() => expect(ensureRoleMock).toHaveBeenCalledWith('c1', 'SUPPLIER'));
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith({
+        contactId: 'c1',
+        childId: 'sup1',
+        name: 'ABC Co',
+        taxId: '0105500000001',
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/components/contacts/ContactCombobox.test.tsx`
+Expected: FAIL — cannot resolve `./ContactCombobox`
+
+- [ ] **Step 3: Implement the component**
+
+Create `apps/web/src/components/contacts/ContactCombobox.tsx`:
+
+```tsx
+// Reusable PEAK-style contact picker. Searches the party master (สมุดผู้ติดต่อ)
+// across ALL roles (server-side, debounced). On pick it calls ensure-role so the
+// chosen contact is provisioned into the field's role (e.g. a customer-only
+// contact becomes a Supplier) and returns the child id to the parent.
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useDebounce } from '@/hooks/useDebounce';
+import { cn } from '@/lib/utils';
+import { contactsApi, type Contact, type ContactRole } from '@/lib/api/contacts';
+
+const ROLE_LABELS: Record<ContactRole, string> = {
+  CUSTOMER: 'ลูกค้า',
+  SUPPLIER: 'ผู้ขาย',
+  TRADE_IN_SELLER: 'คนขายมือสอง',
+  FINANCE_COMPANY: 'ไฟแนนซ์',
+};
+
+export interface ContactPickResult {
+  contactId: string;
+  childId: string;
+  name: string;
+  taxId: string;
+}
+
+interface Props {
+  roleNeeded: 'SUPPLIER' | 'CUSTOMER';
+  value: string;
+  onSelect: (result: ContactPickResult) => void;
+  /** When provided, a typed name with no exact match can be committed as a one-off. */
+  onTypeName?: (name: string) => void;
+  invalid?: boolean;
+  placeholder?: string;
+}
+
+export function ContactCombobox({
+  roleNeeded,
+  value,
+  onSelect,
+  onTypeName,
+  invalid,
+  placeholder = 'เลือกผู้ติดต่อ หรือพิมพ์ชื่อ',
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [pending, setPending] = useState(false);
+  const debounced = useDebounce(search);
+
+  const query = useQuery({
+    queryKey: ['contact-combobox', debounced],
+    queryFn: () => contactsApi.list({ search: debounced || undefined, isActive: true, limit: 20 }),
+    staleTime: 60 * 1000,
+  });
+  const contacts = query.data?.data ?? [];
+
+  const hasExactMatch =
+    !!search.trim() && contacts.some((c) => c.name.toLowerCase() === search.trim().toLowerCase());
+
+  const commitTyped = (name: string) => {
+    const n = name.trim();
+    if (!n || !onTypeName) return;
+    onTypeName(n);
+    setOpen(false);
+    setSearch('');
+  };
+
+  const handleSelect = async (c: Contact) => {
+    setPending(true);
+    try {
+      const res = await contactsApi.ensureRole(c.id, roleNeeded);
+      const childId = res.supplierId ?? res.customerId ?? '';
+      onSelect({ contactId: c.id, childId, name: c.name, taxId: c.taxId ?? '' });
+      setOpen(false);
+      setSearch('');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-invalid={invalid}
+          className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground')}
+        >
+          <span className="truncate leading-snug" title={value || undefined}>
+            {value || placeholder}
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="ค้นหาผู้ติดต่อ / เลขภาษี..."
+            value={search}
+            onValueChange={setSearch}
+            onKeyDown={(e) => {
+              if (onTypeName && e.key === 'Enter' && search.trim() && !hasExactMatch) {
+                e.preventDefault();
+                e.stopPropagation();
+                commitTyped(search);
+              }
+            }}
+          />
+          <CommandList>
+            {query.isLoading || pending ? (
+              <CommandEmpty>{pending ? 'กำลังเพิ่ม...' : 'กำลังโหลด...'}</CommandEmpty>
+            ) : (
+              <>
+                {contacts.length > 0 && (
+                  <CommandGroup heading="สมุดผู้ติดต่อ">
+                    {contacts.map((c) => (
+                      <CommandItem key={c.id} value={c.id} onSelect={() => void handleSelect(c)}>
+                        <Check
+                          className={cn(
+                            'mr-2 size-4 shrink-0',
+                            value === c.name ? 'opacity-100' : 'opacity-0',
+                          )}
+                        />
+                        <span className="flex-1 truncate leading-snug">{c.name}</span>
+                        <span className="ml-2 flex shrink-0 gap-1">
+                          {c.roles.map((r) => (
+                            <Badge key={r} variant="secondary" className="text-2xs">
+                              {ROLE_LABELS[r]}
+                            </Badge>
+                          ))}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+                {contacts.length === 0 && !search.trim() && (
+                  <CommandEmpty className="px-3 py-6 text-center leading-snug">
+                    พิมพ์เพื่อค้นหาผู้ติดต่อ
+                  </CommandEmpty>
+                )}
+                {onTypeName && search.trim() && !hasExactMatch && (
+                  <CommandGroup heading="ใช้ครั้งเดียว (ไม่บันทึกในสมุด)">
+                    <CommandItem value={`__typed__${search}`} onSelect={() => commitTyped(search)}>
+                      <Plus className="mr-2 size-4 shrink-0" />
+                      <span className="truncate leading-snug">ใช้ชื่อ “{search.trim()}”</span>
+                    </CommandItem>
+                  </CommandGroup>
+                )}
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web && npx vitest run src/components/contacts/ContactCombobox.test.tsx`
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/contacts/ContactCombobox.tsx apps/web/src/components/contacts/ContactCombobox.test.tsx
+git commit -m "feat(web): ContactCombobox — PEAK-style all-role picker with ensure-role provisioning"
+```
+
+---
+
+## Task 7: Wire `ContactCombobox` into `VendorCombobox`
+
+**Files:**
+- Modify: `apps/web/src/components/expense-form-v4/VendorCombobox.tsx`
+
+- [ ] **Step 1: Replace the body with a thin wrapper**
+
+Replace the ENTIRE contents of `apps/web/src/components/expense-form-v4/VendorCombobox.tsx` with:
+
+```tsx
+// Expense form V4 — vendor picker.
+// Thin wrapper over the shared ContactCombobox (searches the contact book across
+// ALL roles; picking a contact provisions the SUPPLIER role via ensure-role). A
+// typed name that matches no contact is still committed as a one-off vendor,
+// preserving the legacy free-text flow. The expense stores vendorName/vendorTaxId
+// as before — no FK — so this slice only adds the party-master link side effect.
+import { contactsApi } from '@/lib/api/contacts';
+import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
+
+interface Props {
+  value: string;
+  onSelectSupplier: (s: { name: string; taxId: string; whtFormType?: 'PND3' | 'PND53' }) => void;
+  onTypeName: (name: string) => void;
+  invalid?: boolean;
+}
+
+export function VendorCombobox({ value, onSelectSupplier, onTypeName, invalid }: Props) {
+  // On pick: ensure-role already ran inside ContactCombobox (a Supplier row now
+  // exists). Read the supplier link's type to map JURISTIC→PND53 / INDIVIDUAL→PND3
+  // so "ประเภทผู้ขาย" auto-fills; fall back to the list values if detail fails.
+  const handleSelect = async ({ contactId, name, taxId }: ContactPickResult) => {
+    let whtFormType: 'PND3' | 'PND53' | undefined;
+    let resolvedTaxId = taxId;
+    try {
+      const detail = await contactsApi.detail(contactId);
+      const link = detail.suppliers?.[0];
+      if (link) {
+        whtFormType = link.type === 'JURISTIC' ? 'PND53' : 'PND3';
+        if (link.taxId) resolvedTaxId = link.taxId;
+      }
+    } catch {
+      // keep the list values when the detail lookup fails
+    }
+    onSelectSupplier({ name, taxId: resolvedTaxId, whtFormType });
+  };
+
+  return (
+    <ContactCombobox
+      roleNeeded="SUPPLIER"
+      value={value}
+      invalid={invalid}
+      placeholder="เลือกผู้ขาย หรือพิมพ์ชื่อ"
+      onSelect={handleSelect}
+      onTypeName={onTypeName}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Verify the expense form still typechecks**
+
+Run: `cd apps/web && npx tsc --noEmit -p tsconfig.json`
+Expected: 0 errors (the `Props` interface is unchanged, so callers of `VendorCombobox` are unaffected)
+
+- [ ] **Step 3: Run the web test suite for the touched areas**
+
+Run: `cd apps/web && npx vitest run src/components/contacts src/components/expense-form-v4`
+Expected: PASS (ContactCombobox test passes; no regressions in expense-form-v4 tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/expense-form-v4/VendorCombobox.tsx
+git commit -m "feat(web): VendorCombobox uses ContactCombobox (all-role search + supplier provisioning)"
+```
+
+---
+
+## Task 8: Full verification
+
+- [ ] **Step 1: Typecheck the whole monorepo**
+
+Run: `./tools/check-types.sh all`
+Expected: 0 TypeScript errors
+
+- [ ] **Step 2: Run the full contacts API suite**
+
+Run: `cd apps/api && npx jest --runInBand src/modules/contacts`
+Expected: all PASS (existing specs + the 3 new ensure-role specs)
+
+- [ ] **Step 3: Run the web component tests**
+
+Run: `cd apps/web && npx vitest run src/components/contacts`
+Expected: PASS
+
+- [ ] **Step 4: Manual smoke (requires `npm run dev`)**
+
+1. Log in as `admin@bestchoice.com / admin1234`
+2. Open a contact that is **customer-only** in `/contacts` (note its name; `roles` shows ลูกค้า only)
+3. Go to the expense form (รายจ่าย), open the "ผู้ขาย" picker
+4. Search that contact's name → it now appears (with a ลูกค้า badge) and is selectable
+5. Pick it → the name autofills; re-open `/contacts` detail → it now also has a ผู้ขาย role
+6. Confirm an audit row `CONTACT_ROLE_ADDED` exists in `/audit-logs`
+
+- [ ] **Step 5: Final commit (if any doc/notes updated)**
+
+```bash
+git add -A
+git commit -m "chore(contacts): slice 1 verification notes" --allow-empty
+```
+
+---
+
+## Out of scope for this slice (see spec §5 Rollout)
+
+- Migrating the PurchaseOrder supplier `<select>`, RepairCenterCombobox, CustomerSelectStep, CustomerPickerStep, CounterpartyPicker
+- `CUSTOMER` auto-provisioning (endpoint currently rejects it)
+- "ข้อมูลไม่ครบ" badge on auto-provisioned rows with blank phone (spec §3 — follow-up)
+- Storing a vendor FK (`expenseSupplierId`) on ExpenseDocument

--- a/docs/superpowers/specs/2026-06-04-peak-style-contact-picker-design.md
+++ b/docs/superpowers/specs/2026-06-04-peak-style-contact-picker-design.md
@@ -53,7 +53,7 @@ party master (`Contact`) สร้างเสร็จแล้วตาม spe
 4. audit: `CONTACT_ROLE_ADDED` (string มีอยู่แล้วใน spec แม่ §5)
 5. คืน `{ contactId, role, supplierId?, customerId? }` ให้เอกสารผูก FK ตามเดิม
 
-**guard:** `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles('OWNER','FINANCE_MANAGER','ACCOUNTANT','BRANCH_MANAGER','SALES')` (ตามคนที่สร้างเอกสารผู้ขาย/ลูกค้าได้) + เคารพ branch-access เดิม
+**guard:** `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles('OWNER','BRANCH_MANAGER','FINANCE_MANAGER','ACCOUNTANT')` — **ตรงกับนโยบายสร้าง Supplier** (`POST /suppliers`) เพราะ endpoint นี้สร้างแถว Supplier; **ไม่รวม SALES** (สร้าง supplier ไม่ได้ผ่าน `/suppliers` อยู่แล้ว)
 
 **tracer bullet ทำเฉพาะ `SUPPLIER` ก่อน** — `CUSTOMER` provisioning (ต้องระวัง PII/encryption fields ของ Customer) ทำในเฟส rollout
 
@@ -80,7 +80,7 @@ party master (`Contact`) สร้างเสร็จแล้วตาม spe
 
 ### 2.3 เสียบเข้าช่องผู้ขาย (tracer bullet)
 
-เปลี่ยน supplier picker ของ PurchaseOrder ให้ใช้ `ContactCombobox roleNeeded="SUPPLIER"` → onSelect เก็บ `childId` (supplierId) ตามเดิม
+เปลี่ยนไส้ใน `VendorCombobox` (ฟอร์มรายจ่าย expense v4) ให้เป็น thin wrapper ครอบ `ContactCombobox roleNeeded="SUPPLIER"` โดยคง `Props` เดิม (`value`/`onSelectSupplier`/`onTypeName`/`invalid`) ไว้เป๊ะ — expense ยังเก็บ vendor เป็น free-text เหมือนเดิม การ provision Supplier เป็น side effect (childId ไม่ได้ถูกเก็บเป็น FK ในเฟสนี้); pick แล้ว fetch `contactsApi.detail` เพื่ออ่านชนิดผู้ขาย map เป็น whtFormType (JURISTIC→PND53 / INDIVIDUAL→PND3)
 
 ## 3. "ค่อยเติมทีหลัง" — data completeness
 

--- a/docs/superpowers/specs/2026-06-04-peak-style-contact-picker-design.md
+++ b/docs/superpowers/specs/2026-06-04-peak-style-contact-picker-design.md
@@ -1,0 +1,112 @@
+# PEAK-style Contact Picker — เลือกผู้ติดต่อข้าม role ได้ทุกช่อง
+
+วันที่: 2026-06-04
+สถานะ: รออนุมัติ spec จาก owner
+ต่อยอดจาก: [2026-06-01-unified-contact-party-master-design.md](2026-06-01-unified-contact-party-master-design.md) (party master ชั้นบน — สร้างเสร็จแล้ว)
+
+## ที่มา / ปัญหา
+
+party master (`Contact`) สร้างเสร็จแล้วตาม spec แม่ — 1 party = 1 record, มีได้หลาย role พร้อมกัน, `findOrCreateByNaturalKey()` ผูก role อัตโนมัติ และมีหน้า `/contacts` แล้ว
+
+**แต่ "ช่องเลือกผู้ติดต่อ" บนเอกสารยังไม่ได้ใช้ party master เต็มที่** — ยังเหมือน PEAK ไม่ครบ:
+
+1. **filter ตาม role** — `VendorCombobox` ([VendorCombobox.tsx:47](../../../apps/web/src/components/expense-form-v4/VendorCombobox.tsx#L47)) ค้น `contactsApi.list({ role: 'SUPPLIER' })` → ผู้ติดต่อที่ตอนนี้เป็น**ลูกค้าอย่างเดียว** ไม่โผล่ในช่องผู้ขาย ทั้งที่ใน PEAK แค่ติ๊ก "ผู้ขาย" เพิ่มก็ใช้ได้เลย
+2. **ไม่สม่ำเสมอ** — 5 picker ใช้ 3 แบบ: contacts API (v4), `/customers` ตรงๆ, `/suppliers` ตรงๆ
+3. **client-side filter** — `VendorCombobox` โหลด 200 รายการแล้ว filter ใน client (ไม่ใช่ server search) → เกิน 200 ค้นไม่เจอ
+
+### เป้าหมาย (อ้างอิงต้นแบบ PEAK)
+
+เลือกผู้ติดต่อ**รายไหนก็ได้**ในทุกช่อง (ลูกค้า/ผู้ขาย) — พอเลือกในช่องที่ผู้ติดต่อยังไม่มี role นั้น ระบบ **"สร้างเงียบๆ แล้วค่อยเติม"**: เติม role + สร้างแถวลูก (`Supplier`/`Customer`) ผูก Contact ให้อัตโนมัติ โดย field ที่ขาดปล่อยว่างไว้เติมทีหลัง
+
+สอดคล้องกับเป้าบัญชีของ spec แม่: AR + AP reconcile เข้า party record เดียว
+
+## ขอบเขต — tracer bullet ก่อน (ไม่รื้อทั้งแอปทีเดียว)
+
+ทำ **"ช่องผู้ขาย" ตัวเดียวให้ครบ end-to-end ก่อน** → ทดสอบจริง → แล้วค่อยทยอย migrate อีก 4 picker เป็น PR ย่อยแยกกัน
+
+**ช่องแรกที่เลือก:** supplier picker ของ **ฟอร์มรายจ่าย (`VendorCombobox`, expense v4)** — เป็น tracer bullet ที่สะอาดสุด (จากการอ่านโค้ดจริงตอนวางแผน):
+- ใช้ `contactsApi` อยู่แล้ว → เปลี่ยนแค่เลิก filter role + ค้น server-side + ใส่ badge + เรียก `ensure-role` ตอนเลือก
+- เก็บ vendor เป็น **free-text** (`vendorName`/`vendorTaxId`) ไม่มี FK/supplier-detail ให้พันกัน → wiring แตะไฟล์น้อย เสี่ยงต่ำ
+- ยัง exercise การ provision Supplier + เติม role ครบ (contact กลายเป็นผู้ขายจริงใน party master เพื่อ reconcile) — แค่ตัว expense เก็บ text ตามเดิม ไม่เพิ่ม schema
+
+> เหตุที่ **ไม่เริ่มที่ PurchaseOrder**: `<select>` ผู้ขายของ PO ผูกแน่นกับข้อมูล supplier เต็ม (`hasVat`, `paymentMethods`, query `['suppliers-for-po']`) → ต้อง refetch + แตะ 3 ไฟล์ ไม่ bite-sized พอจะเป็นช่องแรก เลยย้ายไป rollout (ตอนนั้นค่อยพิสูจน์ flow provision → `supplierId` FK → save). หมายเหตุ: ใน slice 1 endpoint `ensure-role` คืน `supplierId` + มี unit test ครบอยู่แล้ว ดังนั้น path การได้ FK ถูกพิสูจน์ระดับ unit แม้ยังไม่เสียบเข้าเอกสาร
+
+## 1. Backend
+
+### 1.1 ค้นผู้ติดต่อทุก role — ไม่ต้องแก้ backend
+
+`ContactsService.list()` ([contacts.service.ts:20](../../../apps/api/src/modules/contacts/contacts.service.ts#L20)) filter role เฉพาะเมื่อส่ง `dto.role` เข้ามา — **ถ้า picker ไม่ส่ง `role` มันคืนผู้ติดต่อทุก role อยู่แล้ว** และ search (ชื่อ/เบอร์/เลขภาษี/contactCode) เป็น server-side อยู่แล้ว
+
+→ ไม่ต้องแก้ backend ส่วนค้นหา แค่ฝั่ง frontend เลิกส่ง `role` แล้วใช้ debounced server search
+
+### 1.2 endpoint `ensure-role` (งานหลักฝั่ง backend)
+
+`POST /contacts/:id/ensure-role` body `{ role: 'SUPPLIER' | 'CUSTOMER' }` — ทำงานใน `$transaction`:
+
+1. โหลด Contact (`deletedAt: null`); ไม่เจอ → `NotFoundException`
+2. หาแถวลูกของ role นั้นที่ผูก `contactId` อยู่แล้ว
+   - **มีแล้ว** → คืน id เดิม (idempotent)
+   - **ยังไม่มี** → สร้างแถวลูก:
+     - `SUPPLIER` → `Supplier { name: contact.name, phone: contact.phone ?? '', contactId: contact.id }` (field อื่นมี default/null ได้หมด — required แค่ `name` + `phone`)
+     - `CUSTOMER` → `Customer { name, phone: contact.phone ?? '', contactId }` (nationalId nullable แบบ walk-in quick-create อยู่แล้ว)
+3. ถ้า role ยังไม่อยู่ใน `Contact.roles` → push เพิ่ม (reuse logic เดียวกับ [contact-resolver.service.ts:55-58](../../../apps/api/src/modules/contacts/contact-resolver.service.ts#L55-L58))
+4. audit: `CONTACT_ROLE_ADDED` (string มีอยู่แล้วใน spec แม่ §5)
+5. คืน `{ contactId, role, supplierId?, customerId? }` ให้เอกสารผูก FK ตามเดิม
+
+**guard:** `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles('OWNER','FINANCE_MANAGER','ACCOUNTANT','BRANCH_MANAGER','SALES')` (ตามคนที่สร้างเอกสารผู้ขาย/ลูกค้าได้) + เคารพ branch-access เดิม
+
+**tracer bullet ทำเฉพาะ `SUPPLIER` ก่อน** — `CUSTOMER` provisioning (ต้องระวัง PII/encryption fields ของ Customer) ทำในเฟส rollout
+
+### 1.3 ที่อยู่ของโค้ด
+
+เพิ่ม method `ensureRole(tx, contactId, role)` ใน `ContactResolverService` (มี advisory-lock contactCode + role-append อยู่แล้ว) แล้ว expose ผ่าน `ContactsController`
+
+## 2. Frontend
+
+### 2.1 คอมโพเนนต์กลาง `ContactCombobox`
+
+`apps/web/src/components/contacts/ContactCombobox.tsx` (reuse pattern จาก VendorCombobox เดิม)
+
+- **Props:** `roleNeeded: 'SUPPLIER' | 'CUSTOMER'`, `value`, `onSelect(result)`, `invalid?`
+- ค้นแบบ debounced server search → `contactsApi.list({ search, isActive: true, limit: 20 })` (**ไม่ส่ง role** = เห็นทุกผู้ติดต่อ) ผ่าน `useQuery` + `useDebounce`
+- แต่ละแถวโชว์ **badge บอก role ที่เป็นอยู่** (ลูกค้า/ผู้ขาย/คนขายมือสอง/ไฟแนนซ์) เพื่อให้เห็นว่าใครเป็นอะไรอยู่
+- **on pick** → `contactsApi.ensureRole(contactId, roleNeeded)` → ได้ `childId` → ส่ง `onSelect({ contactId, childId, name, taxId })`
+- ปุ่ม **"+ เพิ่มผู้ติดต่อใหม่"** → reuse flow เพิ่มผู้ติดต่อเดิม
+- tokens/sonner/leading-snug ตาม frontend.md
+
+### 2.2 เพิ่ม API client
+
+`apps/web/src/lib/api/contacts.ts` เพิ่ม `contactsApi.ensureRole(id, role)` → `POST /contacts/:id/ensure-role`
+
+### 2.3 เสียบเข้าช่องผู้ขาย (tracer bullet)
+
+เปลี่ยน supplier picker ของ PurchaseOrder ให้ใช้ `ContactCombobox roleNeeded="SUPPLIER"` → onSelect เก็บ `childId` (supplierId) ตามเดิม
+
+## 3. "ค่อยเติมทีหลัง" — data completeness
+
+แถวลูกที่ถูก auto-create อาจมี `phone` ว่าง → โชว์ badge **"ข้อมูลไม่ครบ"** ในหน้ารายละเอียดผู้ติดต่อ/ซัพพลายเออร์ (derive จาก `phone === ''`) เพื่อเตือนให้กลับมาเติม
+
+## 4. การทดสอบ
+
+- **API:** `ensureRole` idempotent (เรียกซ้ำไม่สร้างซ้ำ), union role ถูก, กรณี `phone` ว่าง, branch-access, audit `CONTACT_ROLE_ADDED`
+- **Web:** `ContactCombobox` — search เห็นทุก role, เลือกผู้ติดต่อที่เป็นลูกค้าอย่างเดียวในช่องผู้ขาย → provision Supplier + ผูก contact
+- **E2E:** สร้าง PO โดยเลือกผู้ติดต่อที่เป็นลูกค้าอย่างเดียว → บันทึกได้พร้อม supplierId
+
+## 5. Rollout (หลัง tracer bullet ผ่าน)
+
+ทยอย migrate ทีละตัว (PR ย่อย) ให้ใช้ `ContactCombobox`:
+
+| Picker | ช่อง | roleNeeded | หมายเหตุ |
+|---|---|---|---|
+| PurchaseOrder supplier select | ผู้ขาย | SUPPLIER | refetch `['suppliers-for-po']` หลัง provision เพื่อได้ `hasVat`/`paymentMethods` → เก็บ `supplierId` FK |
+| RepairCenterCombobox | ศูนย์ซ่อม | SUPPLIER | + คง filter `isRepairCenter` (ensure-role ต้อง set `isRepairCenter`) |
+| CustomerSelectStep (สัญญา) | ลูกค้า | CUSTOMER | ต้องเปิด CUSTOMER provisioning |
+| CustomerPickerStep (ประกัน) | ลูกค้า | CUSTOMER | — |
+| CounterpartyPicker (รายรับอื่น) | ลูกค้า | CUSTOMER | dual-mode อยู่แล้ว |
+
+## ไม่ทำใน v1 (YAGNI)
+
+- migrate ทุก picker พร้อมกัน (ทำทีละตัว)
+- `CUSTOMER` auto-provision (เลื่อนไปเฟส rollout — ต้องดู PII/encryption ของ Customer)
+- Import Excel / auto-fill เลขภาษี DBD (เป็น feature แยก — deferred ใน spec แม่อยู่แล้ว)
+- เพิ่ม `expenseSupplierId` ลง ExpenseDocument (รอเคาะตอน migrate VendorCombobox)


### PR DESCRIPTION
## Summary
Slice 1 of a PEAK-style contact picker so a "supplier" field can find **any** party-master contact and auto-make it a supplier (a customer-only contact becomes usable as a vendor — like ticking "ผู้ขาย" in PEAK).

- **Backend** `POST /contacts/:id/ensure-role` — provisions a `Supplier` row + appends the role inside a `$transaction`, **idempotent**, audits `CONTACT_ROLE_ADDED`. Guarded to the supplier-create policy (`OWNER, BRANCH_MANAGER, FINANCE_MANAGER, ACCOUNTANT` — no SALES). SUPPLIER-only this phase (CUSTOMER rejected).
- **Frontend** `ContactCombobox` — searches the contact book across **all roles** (server-side, debounced), shows role badges, calls `ensure-role` on pick (sonner error on failure).
- **Wiring** `VendorCombobox` (expense form) rewritten as a thin wrapper over `ContactCombobox`; public Props unchanged so callers are unaffected. Expense still stores free-text vendor — provisioning the Supplier is a party-master side effect.
- 12 new tests; full typecheck green.

Builds on the existing party-master design (`docs/superpowers/specs/2026-06-01-unified-contact-party-master-design.md`). Spec + plan for this slice are in the diff.

## Test Plan
- [ ] API: `cd apps/api && npx jest --runInBand src/modules/contacts` → 39 pass
- [ ] Web: `cd apps/web && npx vitest run src/components/contacts src/components/expense-form-v4` → 4 pass
- [ ] Types: `./tools/check-types.sh all` → API + Web OK
- [ ] Manual: in the expense form ผู้ขาย field, search a **customer-only** contact → it appears (with a ลูกค้า badge) and is selectable → after pick the contact gains the ผู้ขาย role; `/audit-logs` shows `CONTACT_ROLE_ADDED`

## Known follow-ups (non-blocking)
- Manual UI smoke pending a running stack
- Double round-trip on pick (ensure-role POST + detail GET) — could fold supplier `type` into the ensure-role response later
- Pencil/Check "known vendor" icon affordance dropped (cosmetic)
- Rollout phase: CUSTOMER provisioning + migrate the other 4 pickers (PurchaseOrder, RepairCenter, ContractCreate, insurance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)