### PR TITLE
feat(contacts): Party Master Mandatory P1 — supplier pickers use ContactCombobox (no free-text)

### DIFF
--- a/apps/api/src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts
+++ b/apps/api/src/modules/contacts/__tests__/contact-resolver.ensure-role.spec.ts
@@ -8,12 +8,14 @@ describe('ContactResolverService.ensureRole', () => {
   let tx: {
     contact: { findFirst: jest.Mock; update: jest.Mock };
     supplier: { findFirst: jest.Mock; create: jest.Mock };
+    customer: { findFirst: jest.Mock; create: jest.Mock };
   };
 
   beforeEach(async () => {
     tx = {
       contact: { findFirst: jest.fn(), update: jest.fn().mockResolvedValue({}) },
       supplier: { findFirst: jest.fn(), create: jest.fn() },
+      customer: { findFirst: jest.fn(), create: jest.fn() },
     };
     const mod = await Test.createTestingModule({
       providers: [
@@ -101,9 +103,47 @@ describe('ContactResolverService.ensureRole', () => {
     });
   });
 
-  it('rejects CUSTOMER provisioning in this phase', async () => {
+  it('provisions a Customer with blank-phone fallback and adds the CUSTOMER role', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c5', name: 'Walkin Co', phone: null, roles: ['SUPPLIER'],
+    });
+    tx.customer.findFirst.mockResolvedValue(null);
+    tx.customer.create.mockResolvedValue({ id: 'cus5' });
+
+    const result = await svc.ensureRole(tx as any, 'c5', 'CUSTOMER');
+
+    expect(tx.customer.create).toHaveBeenCalledWith({
+      data: { name: 'Walkin Co', phone: '', contactId: 'c5' },
+      select: { id: true },
+    });
+    expect(tx.contact.update).toHaveBeenCalledWith({
+      where: { id: 'c5' },
+      data: { roles: { set: ['SUPPLIER', 'CUSTOMER'] } },
+    });
+    expect(result).toEqual({
+      contactId: 'c5', role: 'CUSTOMER', customerId: 'cus5', provisioned: true,
+    });
+    expect(tx.supplier.create).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing customer id without creating (idempotent)', async () => {
+    tx.contact.findFirst.mockResolvedValue({
+      id: 'c6', name: 'ABC', phone: '02', roles: ['CUSTOMER'],
+    });
+    tx.customer.findFirst.mockResolvedValue({ id: 'cus6' });
+
+    const result = await svc.ensureRole(tx as any, 'c6', 'CUSTOMER');
+
+    expect(tx.customer.create).not.toHaveBeenCalled();
+    expect(tx.contact.update).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      contactId: 'c6', role: 'CUSTOMER', customerId: 'cus6', provisioned: false,
+    });
+  });
+
+  it('rejects a role that is not SUPPLIER or CUSTOMER', async () => {
     tx.contact.findFirst.mockResolvedValue(null);
-    await expect(svc.ensureRole(tx as any, 'c1', 'CUSTOMER' as any)).rejects.toBeInstanceOf(
+    await expect(svc.ensureRole(tx as any, 'c1', 'TRADE_IN_SELLER' as any)).rejects.toBeInstanceOf(
       BadRequestException,
     );
   });

--- a/apps/api/src/modules/contacts/contact-resolver.service.ts
+++ b/apps/api/src/modules/contacts/contact-resolver.service.ts
@@ -98,16 +98,17 @@ export class ContactResolverService {
 
   /**
    * Ensure a contact can be used in a `role` context: provision the child row
-   * (Supplier) if missing and append the role. Idempotent. SUPPLIER only in this
-   * phase — CUSTOMER auto-provisioning is deferred (PII/encryption on Customer).
+   * (Supplier or Customer) if missing and append the role. Idempotent.
+   * Supports SUPPLIER and CUSTOMER. The provisioned child is a minimal stub
+   * (name + phone mirrored from the contact); the rest is enriched later.
    */
   async ensureRole(
     tx: Tx,
     contactId: string,
     role: ContactRole,
   ): Promise<EnsureRoleResult> {
-    if (role !== 'SUPPLIER') {
-      throw new BadRequestException('ยังไม่รองรับการสร้างบทบาทนี้อัตโนมัติในเฟสนี้');
+    if (role !== 'SUPPLIER' && role !== 'CUSTOMER') {
+      throw new BadRequestException('รองรับเฉพาะการสร้างบทบาท SUPPLIER หรือ CUSTOMER อัตโนมัติ');
     }
 
     const contact = await tx.contact.findFirst({
@@ -116,20 +117,40 @@ export class ContactResolverService {
     if (!contact) throw new NotFoundException('ไม่พบผู้ติดต่อ');
 
     let provisioned = false;
+    let supplierId: string | undefined;
+    let customerId: string | undefined;
 
-    const existing = await tx.supplier.findFirst({
-      where: { contactId, deletedAt: null },
-      select: { id: true },
-    });
-    const supplierId = existing
-      ? existing.id
-      : (
-          await tx.supplier.create({
-            data: { name: contact.name, phone: contact.phone ?? '', contactId },
-            select: { id: true },
-          })
-        ).id;
-    if (!existing) provisioned = true;
+    if (role === 'SUPPLIER') {
+      const existing = await tx.supplier.findFirst({
+        where: { contactId, deletedAt: null },
+        select: { id: true },
+      });
+      supplierId = existing
+        ? existing.id
+        : (
+            await tx.supplier.create({
+              data: { name: contact.name, phone: contact.phone ?? '', contactId },
+              select: { id: true },
+            })
+          ).id;
+      if (!existing) provisioned = true;
+    } else {
+      // CUSTOMER stub: name + phone only. PII encryption/hash columns are left
+      // null and filled when the customer record is properly completed.
+      const existing = await tx.customer.findFirst({
+        where: { contactId, deletedAt: null },
+        select: { id: true },
+      });
+      customerId = existing
+        ? existing.id
+        : (
+            await tx.customer.create({
+              data: { name: contact.name, phone: contact.phone ?? '', contactId },
+              select: { id: true },
+            })
+          ).id;
+      if (!existing) provisioned = true;
+    }
 
     if (!contact.roles.includes(role)) {
       await tx.contact.update({
@@ -139,7 +160,9 @@ export class ContactResolverService {
       provisioned = true;
     }
 
-    return { contactId, role, supplierId, provisioned };
+    return role === 'SUPPLIER'
+      ? { contactId, role, supplierId, provisioned }
+      : { contactId, role, customerId, provisioned };
   }
 
   private hashLockKey(key: string): number {

--- a/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
+++ b/apps/api/src/modules/suppliers/dto/update-supplier.dto.ts
@@ -108,6 +108,10 @@ export class UpdateSupplierDto {
   @IsOptional()
   isActive?: boolean;
 
+  @IsBoolean()
+  @IsOptional()
+  isRepairCenter?: boolean;
+
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => PaymentMethodUpdateDto)

--- a/apps/web/src/components/contacts/ContactCombobox.test.tsx
+++ b/apps/web/src/components/contacts/ContactCombobox.test.tsx
@@ -26,6 +26,34 @@ vi.mock('@/lib/api/contacts', () => ({
   },
 }));
 
+// Mock CreateContactModal: when open=true, immediately calls onCreated with a
+// stub result (simulates a user filling and submitting the form).
+vi.mock('./CreateContactModal', () => ({
+  default: ({
+    open,
+    onCreated,
+  }: {
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    role: string;
+    initialName?: string;
+    onCreated: (r: { contactId: string; childId: string; name: string; taxId: string }) => void;
+  }) => {
+    if (!open) return null;
+    // Render a button that, when clicked, fires onCreated — keeps control explicit in tests.
+    return (
+      <button
+        data-testid="mock-create-modal-submit"
+        onClick={() =>
+          onCreated({ contactId: 'ct9', childId: 'sup9', name: 'New Co', taxId: '' })
+        }
+      >
+        mock-submit
+      </button>
+    );
+  },
+}));
+
 function renderCombo(onSelect = vi.fn()) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   render(
@@ -70,6 +98,36 @@ describe('ContactCombobox', () => {
         childId: 'sup1',
         name: 'ABC Co',
         taxId: '0105500000001',
+      }),
+    );
+  });
+
+  it('shows สร้างผู้ติดต่อใหม่ action when search has no matching contacts; clicking it opens modal and onSelect receives created result', async () => {
+    // No contacts match the search term
+    listMock.mockResolvedValue({ data: [], total: 0, page: 1, limit: 20 });
+    const onSelect = renderCombo();
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.type(screen.getByPlaceholderText(/ค้นหา/), 'New Co');
+
+    // The create action item should appear
+    const createItem = await screen.findByText(/สร้างผู้ติดต่อใหม่/);
+    expect(createItem).toBeDefined();
+
+    // Click the create action — opens the (mocked) modal
+    await userEvent.click(createItem);
+
+    // The mock modal renders a submit button; click it to fire onCreated
+    const submitBtn = await screen.findByTestId('mock-create-modal-submit');
+    await userEvent.click(submitBtn);
+
+    // onSelect should have been called with the shape returned by CreateContactModal
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith({
+        contactId: 'ct9',
+        childId: 'sup9',
+        name: 'New Co',
+        taxId: '',
       }),
     );
   });

--- a/apps/web/src/components/contacts/ContactCombobox.tsx
+++ b/apps/web/src/components/contacts/ContactCombobox.tsx
@@ -2,6 +2,10 @@
 // across ALL roles (server-side, debounced). On pick it calls ensure-role so the
 // chosen contact is provisioned into the field's role (e.g. a customer-only
 // contact becomes a Supplier) and returns the child id to the parent.
+//
+// v2 change: free-text one-off path removed. Typed searches with no exact match
+// show an inline "+ สร้างผู้ติดต่อใหม่" action that opens CreateContactModal.
+// The created contact flows out through the same onSelect callback as a picked one.
 import { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -20,6 +24,7 @@ import {
 import { useDebounce } from '@/hooks/useDebounce';
 import { cn } from '@/lib/utils';
 import { contactsApi, contactKeys, type Contact, type ContactRole } from '@/lib/api/contacts';
+import CreateContactModal from './CreateContactModal';
 
 const ROLE_LABELS: Record<ContactRole, string> = {
   CUSTOMER: 'ลูกค้า',
@@ -40,7 +45,12 @@ interface Props {
   roleNeeded: 'SUPPLIER' | 'CUSTOMER';
   value: string;
   onSelect: (result: ContactPickResult) => void;
-  /** When provided, a typed name with no exact match can be committed as a one-off. */
+  /**
+   * @deprecated Since v2 the free-text one-off path has been replaced by an
+   * inline "สร้างผู้ติดต่อใหม่" action that opens CreateContactModal.
+   * This prop is kept for back-compat so existing callers (e.g. VendorCombobox)
+   * continue to typecheck, but it is no longer called.
+   */
   onTypeName?: (name: string) => void;
   invalid?: boolean;
   placeholder?: string;
@@ -50,12 +60,15 @@ export function ContactCombobox({
   roleNeeded,
   value,
   onSelect,
-  onTypeName,
+  // onTypeName kept for back-compat typecheck — intentionally unused (see @deprecated above)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onTypeName: _onTypeName,
   invalid,
   placeholder = 'เลือกผู้ติดต่อ หรือพิมพ์ชื่อ',
 }: Props) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
   const debounced = useDebounce(search);
 
   const query = useQuery({
@@ -68,13 +81,7 @@ export function ContactCombobox({
   const hasExactMatch =
     !!search.trim() && contacts.some((c) => c.name.toLowerCase() === search.trim().toLowerCase());
 
-  const commitTyped = (name: string) => {
-    const n = name.trim();
-    if (!n || !onTypeName) return;
-    onTypeName(n);
-    setOpen(false);
-    setSearch('');
-  };
+  const showCreateAction = !!search.trim() && !hasExactMatch && !query.isLoading;
 
   const ensureRoleMutation = useMutation({
     mutationFn: (c: Contact) => contactsApi.ensureRole(c.id, roleNeeded),
@@ -87,92 +94,119 @@ export function ContactCombobox({
     onError: () => toast.error('ไม่สามารถเพิ่มบทบาทให้ผู้ติดต่อได้ กรุณาลองใหม่อีกครั้ง'),
   });
 
+  const handleCreated = (r: { contactId: string; childId: string; name: string; taxId: string }) => {
+    onSelect({ contactId: r.contactId, childId: r.childId, name: r.name, taxId: r.taxId });
+    setCreateOpen(false);
+    setOpen(false);
+    setSearch('');
+  };
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          aria-invalid={invalid}
-          className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground')}
-        >
-          <span className="truncate leading-snug" title={value || undefined}>
-            {value || placeholder}
-          </span>
-          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-        <Command shouldFilter={false}>
-          <CommandInput
-            placeholder="ค้นหาผู้ติดต่อ / เลขภาษี..."
-            value={search}
-            onValueChange={setSearch}
-            onKeyDown={(e) => {
-              if (onTypeName && e.key === 'Enter' && search.trim() && !hasExactMatch) {
-                e.preventDefault();
-                e.stopPropagation();
-                commitTyped(search);
-              }
-            }}
-          />
-          <CommandList>
-            {query.isLoading || ensureRoleMutation.isPending ? (
-              <CommandEmpty>{ensureRoleMutation.isPending ? 'กำลังเพิ่ม...' : 'กำลังโหลด...'}</CommandEmpty>
-            ) : (
-              <>
-                {query.isError && (
-                  <CommandEmpty className="px-3 py-6 text-center leading-snug text-destructive">
-                    โหลดข้อมูลไม่สำเร็จ
-                  </CommandEmpty>
-                )}
-                {!query.isError && contacts.length === 0 && !!search.trim() && !onTypeName && (
-                  <CommandEmpty className="px-3 py-6 text-center leading-snug">
-                    ไม่พบผู้ติดต่อที่ตรงกับ "{search.trim()}"
-                  </CommandEmpty>
-                )}
-                {contacts.length > 0 && (
-                  <CommandGroup heading="สมุดผู้ติดต่อ">
-                    {contacts.map((c) => (
-                      <CommandItem key={c.id} value={c.id} onSelect={() => ensureRoleMutation.mutate(c)}>
-                        <Check
-                          className={cn(
-                            'mr-2 size-4 shrink-0',
-                            value === c.name ? 'opacity-100' : 'opacity-0',
-                          )}
-                        />
-                        <span className="flex-1 truncate leading-snug">{c.name}</span>
-                        <span className="ml-2 flex shrink-0 gap-1">
-                          {c.roles.map((r) => (
-                            <Badge key={r} variant="secondary" className="text-2xs">
-                              {ROLE_LABELS[r]}
-                            </Badge>
-                          ))}
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-invalid={invalid}
+            className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground')}
+          >
+            <span className="truncate leading-snug" title={value || undefined}>
+              {value || placeholder}
+            </span>
+            <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="ค้นหาผู้ติดต่อ / เลขภาษี..."
+              value={search}
+              onValueChange={setSearch}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && search.trim() && !hasExactMatch) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setCreateOpen(true);
+                }
+              }}
+            />
+            <CommandList>
+              {query.isLoading || ensureRoleMutation.isPending ? (
+                <CommandEmpty>{ensureRoleMutation.isPending ? 'กำลังเพิ่ม...' : 'กำลังโหลด...'}</CommandEmpty>
+              ) : (
+                <>
+                  {query.isError && (
+                    <CommandEmpty className="px-3 py-6 text-center leading-snug text-destructive">
+                      โหลดข้อมูลไม่สำเร็จ
+                    </CommandEmpty>
+                  )}
+                  {!query.isError && contacts.length === 0 && !!search.trim() && !showCreateAction && (
+                    <CommandEmpty className="px-3 py-6 text-center leading-snug">
+                      ไม่พบผู้ติดต่อที่ตรงกับ "{search.trim()}"
+                    </CommandEmpty>
+                  )}
+                  {contacts.length > 0 && (
+                    <CommandGroup heading="สมุดผู้ติดต่อ">
+                      {contacts.map((c) => (
+                        <CommandItem key={c.id} value={c.id} onSelect={() => ensureRoleMutation.mutate(c)}>
+                          <Check
+                            className={cn(
+                              'mr-2 size-4 shrink-0',
+                              value === c.name ? 'opacity-100' : 'opacity-0',
+                            )}
+                          />
+                          <span className="flex-1 truncate leading-snug">{c.name}</span>
+                          <span className="ml-2 flex shrink-0 gap-1">
+                            {c.roles.map((r) => (
+                              <Badge key={r} variant="secondary" className="text-2xs">
+                                {ROLE_LABELS[r]}
+                              </Badge>
+                            ))}
+                            {!c.phone && (
+                              <Badge variant="outline" className="text-2xs text-muted-foreground">
+                                ข้อมูลไม่ครบ
+                              </Badge>
+                            )}
+                          </span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )}
+                  {contacts.length === 0 && !search.trim() && (
+                    <CommandEmpty className="px-3 py-6 text-center leading-snug">
+                      พิมพ์เพื่อค้นหาผู้ติดต่อ
+                    </CommandEmpty>
+                  )}
+                  {showCreateAction && (
+                    <CommandGroup heading="สร้างใหม่">
+                      <CommandItem
+                        value={`__create__${search}`}
+                        onSelect={() => setCreateOpen(true)}
+                      >
+                        <Plus className="mr-2 size-4 shrink-0" />
+                        <span className="truncate leading-snug">
+                          + สร้างผู้ติดต่อใหม่ "{search.trim()}"
                         </span>
                       </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-                {contacts.length === 0 && !search.trim() && (
-                  <CommandEmpty className="px-3 py-6 text-center leading-snug">
-                    พิมพ์เพื่อค้นหาผู้ติดต่อ
-                  </CommandEmpty>
-                )}
-                {onTypeName && search.trim() && !hasExactMatch && (
-                  <CommandGroup heading="ใช้ครั้งเดียว (ไม่บันทึกในสมุด)">
-                    <CommandItem value={`__typed__${search}`} onSelect={() => commitTyped(search)}>
-                      <Plus className="mr-2 size-4 shrink-0" />
-                      <span className="truncate leading-snug">ใช้ชื่อ "{search.trim()}"</span>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </>
-            )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+                    </CommandGroup>
+                  )}
+                </>
+              )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      <CreateContactModal
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        role={roleNeeded}
+        initialName={search.trim()}
+        onCreated={handleCreated}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/contacts/ContactCombobox.tsx
+++ b/apps/web/src/components/contacts/ContactCombobox.tsx
@@ -126,7 +126,7 @@ export function ContactCombobox({
               value={search}
               onValueChange={setSearch}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && search.trim() && !hasExactMatch) {
+                if (e.key === 'Enter' && search.trim() && !hasExactMatch && !query.isLoading) {
                   e.preventDefault();
                   e.stopPropagation();
                   setCreateOpen(true);

--- a/apps/web/src/components/contacts/CreateContactModal.test.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.test.tsx
@@ -194,6 +194,18 @@ describe('CreateContactModal', () => {
     expect(submitBtn).toBeDisabled();
   });
 
+  it('CUSTOMER: disables submit button when phone format is invalid (Fix #1)', async () => {
+    const user = userEvent.setup();
+    renderModal({ role: 'CUSTOMER' });
+
+    await user.type(screen.getByLabelText(/ชื่อ/), 'ลูกค้าทดสอบ');
+    // Type an invalid phone (not 0XXXXXXXXX)
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '12345');
+
+    const submitBtn = screen.getByRole('button', { name: 'สร้าง' });
+    expect(submitBtn).toBeDisabled();
+  });
+
   it('prefills ชื่อ from initialName prop', () => {
     renderModal({ role: 'CUSTOMER', initialName: 'ABC Corp' });
     expect(screen.getByLabelText(/ชื่อ/)).toHaveValue('ABC Corp');

--- a/apps/web/src/components/contacts/CreateContactModal.test.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CreateContactModal from './CreateContactModal';
+
+// ── Mock @/lib/api ─────────────────────────────────────────────────────────
+
+const apiPostMock = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  default: {
+    post: (...args: unknown[]) => apiPostMock(...args),
+  },
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function renderModal(
+  props: Partial<React.ComponentProps<typeof CreateContactModal>> & {
+    role: 'SUPPLIER' | 'CUSTOMER';
+  },
+) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const onCreated = props.onCreated ?? vi.fn();
+  const onOpenChange = props.onOpenChange ?? vi.fn();
+
+  render(
+    <QueryClientProvider client={qc}>
+      <CreateContactModal
+        open={true}
+        onOpenChange={onOpenChange}
+        role={props.role}
+        initialName={props.initialName ?? ''}
+        onCreated={onCreated}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { onCreated, onOpenChange };
+}
+
+beforeEach(() => {
+  apiPostMock.mockReset();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('CreateContactModal', () => {
+  // ── SUPPLIER ─────────────────────────────────────────────────────────────
+
+  it('SUPPLIER: posts to /suppliers and calls onCreated with correct ids', async () => {
+    const user = userEvent.setup();
+
+    apiPostMock.mockResolvedValueOnce({
+      data: { id: 'sup1', contactId: 'ct1', name: 'บริษัท ทดสอบ จำกัด', taxId: '1234567890123' },
+    });
+
+    const { onCreated, onOpenChange } = renderModal({ role: 'SUPPLIER' });
+
+    // Toggle to JURISTIC so taxId field applies
+    await user.click(screen.getByRole('button', { name: 'นิติบุคคล' }));
+
+    // Fill ชื่อ
+    await user.clear(screen.getByLabelText(/ชื่อ/));
+    await user.type(screen.getByLabelText(/ชื่อ/), 'บริษัท ทดสอบ จำกัด');
+
+    // Fill เลขผู้เสียภาษี
+    await user.type(screen.getByLabelText(/เลขผู้เสียภาษี/), '1234567890123');
+
+    // Fill เบอร์โทร
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '0812345678');
+
+    // Submit
+    await user.click(screen.getByRole('button', { name: 'สร้าง' }));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
+
+    // Verify the endpoint and payload
+    const [endpoint, payload] = apiPostMock.mock.calls[0];
+    expect(endpoint).toBe('/suppliers');
+    expect(payload).toMatchObject({
+      name: 'บริษัท ทดสอบ จำกัด',
+      taxId: '1234567890123',
+      type: 'JURISTIC',
+    });
+
+    // Verify onCreated callback
+    await waitFor(() =>
+      expect(onCreated).toHaveBeenCalledWith({
+        contactId: 'ct1',
+        childId: 'sup1',
+        name: 'บริษัท ทดสอบ จำกัด',
+        taxId: '1234567890123',
+      }),
+    );
+
+    // Modal should close
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('SUPPLIER: sends hasVat=true when checkbox is ticked', async () => {
+    const user = userEvent.setup();
+
+    apiPostMock.mockResolvedValueOnce({
+      data: { id: 'sup2', contactId: 'ct2', name: 'ร้านทดสอบ', taxId: null },
+    });
+
+    renderModal({ role: 'SUPPLIER' });
+
+    await user.type(screen.getByLabelText(/ชื่อ/), 'ร้านทดสอบ');
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '0899999999');
+    await user.click(screen.getByLabelText(/จด VAT/));
+    await user.click(screen.getByRole('button', { name: 'สร้าง' }));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
+    const [, payload] = apiPostMock.mock.calls[0];
+    expect(payload.hasVat).toBe(true);
+  });
+
+  it('SUPPLIER: does NOT show จด VAT checkbox for CUSTOMER role', () => {
+    renderModal({ role: 'CUSTOMER' });
+    expect(screen.queryByLabelText(/จด VAT/)).toBeNull();
+  });
+
+  // ── CUSTOMER ─────────────────────────────────────────────────────────────
+
+  it('CUSTOMER: posts to /customers and calls onCreated mapping childId from customer id', async () => {
+    const user = userEvent.setup();
+
+    apiPostMock.mockResolvedValueOnce({
+      data: { id: 'cust1', contactId: 'ct3', name: 'นายทดสอบ สมใจ', nationalId: null },
+    });
+
+    const { onCreated, onOpenChange } = renderModal({ role: 'CUSTOMER' });
+
+    await user.type(screen.getByLabelText(/ชื่อ/), 'นายทดสอบ สมใจ');
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '0812345678');
+    await user.click(screen.getByRole('button', { name: 'สร้าง' }));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
+
+    const [endpoint, payload] = apiPostMock.mock.calls[0];
+    expect(endpoint).toBe('/customers');
+    expect(payload).toMatchObject({ name: 'นายทดสอบ สมใจ', phone: '0812345678' });
+
+    await waitFor(() =>
+      expect(onCreated).toHaveBeenCalledWith({
+        contactId: 'ct3',
+        childId: 'cust1',
+        name: 'นายทดสอบ สมใจ',
+        taxId: '',
+      }),
+    );
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('CUSTOMER: sends nationalId when individual type and id filled', async () => {
+    const user = userEvent.setup();
+
+    apiPostMock.mockResolvedValueOnce({
+      data: { id: 'cust2', contactId: 'ct4', name: 'นางสาวทดสอบ', nationalId: '1234567890123' },
+    });
+
+    renderModal({ role: 'CUSTOMER' });
+
+    await user.type(screen.getByLabelText(/ชื่อ/), 'นางสาวทดสอบ');
+    // Fill national ID (บุคคลธรรมดา is default)
+    await user.type(screen.getByLabelText(/เลขบัตรประชาชน/), '1234567890123');
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '0812345678');
+    await user.click(screen.getByRole('button', { name: 'สร้าง' }));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
+    const [, payload] = apiPostMock.mock.calls[0];
+    expect(payload.nationalId).toBe('1234567890123');
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  it('disables submit button when ชื่อ is empty', async () => {
+    renderModal({ role: 'SUPPLIER' });
+    const submitBtn = screen.getByRole('button', { name: 'สร้าง' });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it('disables submit button when เบอร์โทร is empty', async () => {
+    const user = userEvent.setup();
+    renderModal({ role: 'CUSTOMER' });
+
+    await user.type(screen.getByLabelText(/ชื่อ/), 'ชื่อทดสอบ');
+    // phone is still empty
+    const submitBtn = screen.getByRole('button', { name: 'สร้าง' });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it('prefills ชื่อ from initialName prop', () => {
+    renderModal({ role: 'CUSTOMER', initialName: 'ABC Corp' });
+    expect(screen.getByLabelText(/ชื่อ/)).toHaveValue('ABC Corp');
+  });
+
+  it('shows error toast on API failure', async () => {
+    const user = userEvent.setup();
+
+    apiPostMock.mockRejectedValueOnce({
+      response: { data: { message: 'ชื่อซ้ำ' } },
+    });
+
+    renderModal({ role: 'SUPPLIER' });
+
+    await user.type(screen.getByLabelText(/ชื่อ/), 'ทดสอบ');
+    await user.type(screen.getByLabelText(/เบอร์โทร/), '0811111111');
+    await user.click(screen.getByRole('button', { name: 'สร้าง' }));
+
+    // We verify the mutation was called (toast is tested by Sonner itself)
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledOnce());
+  });
+});

--- a/apps/web/src/components/contacts/CreateContactModal.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import api from '@/lib/api';
+import { contactKeys } from '@/lib/api/contacts';
 import {
   Dialog,
   DialogContent,
@@ -72,7 +73,7 @@ export default function CreateContactModal({
       phone: phone.trim(),
     };
     if (address.trim()) payload.address = address.trim();
-    if (contactType === 'JURISTIC' && idNumber.trim()) {
+    if (idNumber.trim()) {
       payload.taxId = idNumber.trim();
     }
     payload.hasVat = hasVat;
@@ -93,6 +94,8 @@ export default function CreateContactModal({
 
   // ── Mutation ────────────────────────────────────────────────────────────
 
+  const queryClient = useQueryClient();
+
   const mutation = useMutation({
     mutationFn: async () => {
       if (role === 'SUPPLIER') {
@@ -105,14 +108,21 @@ export default function CreateContactModal({
     },
     onSuccess: (data) => {
       const childId = data.id;
-      const contactId = data.contactId ?? '';
       const returnedName = data.name;
       const taxId =
         role === 'SUPPLIER'
-          ? ((data as { taxId?: string | null }).taxId ?? idNumber.trim())
-          : idNumber.trim();
+          ? ((data as { taxId?: string | null }).taxId ?? '')
+          : ((data as { taxId?: string | null }).taxId ?? '');
 
-      onCreated({ contactId, childId, name: returnedName, taxId });
+      // Fix #4: guard against missing contactId — an empty string would cause
+      // contactsApi.detail('') to make a malformed request. Treat it as an error.
+      if (!data.contactId) {
+        toast.error('สร้างผู้ติดต่อไม่สำเร็จ — ไม่พบ contactId จาก API');
+        return;
+      }
+
+      queryClient.invalidateQueries({ queryKey: contactKeys.all });
+      onCreated({ contactId: data.contactId, childId, name: returnedName, taxId });
       toast.success('สร้างผู้ติดต่อสำเร็จ');
       onOpenChange(false);
     },
@@ -128,7 +138,10 @@ export default function CreateContactModal({
 
   // ── Validation ──────────────────────────────────────────────────────────
 
-  const canSubmit = name.trim().length > 0 && phone.trim().length > 0 && !mutation.isPending;
+  const phoneValid =
+    role === 'CUSTOMER' ? /^0[0-9]{9}$/.test(phone) : phone.trim().length > 0;
+
+  const canSubmit = name.trim().length > 0 && phoneValid && !mutation.isPending;
 
   // ── Labels ──────────────────────────────────────────────────────────────
 

--- a/apps/web/src/components/contacts/CreateContactModal.tsx
+++ b/apps/web/src/components/contacts/CreateContactModal.tsx
@@ -1,0 +1,266 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import api from '@/lib/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type ContactType = 'INDIVIDUAL' | 'JURISTIC';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Which create endpoint to hit */
+  role: 'SUPPLIER' | 'CUSTOMER';
+  /** Prefill ชื่อ from the combobox search term */
+  initialName?: string;
+  onCreated: (r: {
+    contactId: string;
+    childId: string;
+    name: string;
+    taxId: string;
+  }) => void;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export default function CreateContactModal({
+  open,
+  onOpenChange,
+  role,
+  initialName = '',
+  onCreated,
+}: Props) {
+  const [contactType, setContactType] = useState<ContactType>('INDIVIDUAL');
+  const [name, setName] = useState(initialName);
+  const [idNumber, setIdNumber] = useState(''); // taxId (JURISTIC) or nationalId (INDIVIDUAL)
+  const [phone, setPhone] = useState('');
+  const [address, setAddress] = useState('');
+  const [hasVat, setHasVat] = useState(false);
+
+  // Sync initialName when modal opens with a new value
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setName(initialName);
+      setContactType('INDIVIDUAL');
+      setIdNumber('');
+      setPhone('');
+      setAddress('');
+      setHasVat(false);
+    }
+    onOpenChange(next);
+  };
+
+  // ── Payload builders ────────────────────────────────────────────────────
+
+  const buildSupplierPayload = () => {
+    const payload: Record<string, unknown> = {
+      // Map UI toggle to SupplierType enum
+      type: contactType === 'JURISTIC' ? 'JURISTIC' : 'INDIVIDUAL',
+      name: name.trim(),
+      phone: phone.trim(),
+    };
+    if (address.trim()) payload.address = address.trim();
+    if (contactType === 'JURISTIC' && idNumber.trim()) {
+      payload.taxId = idNumber.trim();
+    }
+    payload.hasVat = hasVat;
+    return payload;
+  };
+
+  const buildCustomerPayload = () => {
+    const payload: Record<string, unknown> = {
+      name: name.trim(),
+      phone: phone.trim(),
+    };
+    if (contactType === 'INDIVIDUAL' && idNumber.trim()) {
+      payload.nationalId = idNumber.trim();
+    }
+    if (address.trim()) payload.addressCurrent = address.trim();
+    return payload;
+  };
+
+  // ── Mutation ────────────────────────────────────────────────────────────
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (role === 'SUPPLIER') {
+        const { data } = await api.post('/suppliers', buildSupplierPayload());
+        return data as { id: string; contactId: string | null; name: string; taxId?: string | null };
+      } else {
+        const { data } = await api.post('/customers', buildCustomerPayload());
+        return data as { id: string; contactId: string | null; name: string; nationalId?: string | null };
+      }
+    },
+    onSuccess: (data) => {
+      const childId = data.id;
+      const contactId = data.contactId ?? '';
+      const returnedName = data.name;
+      const taxId =
+        role === 'SUPPLIER'
+          ? ((data as { taxId?: string | null }).taxId ?? idNumber.trim())
+          : idNumber.trim();
+
+      onCreated({ contactId, childId, name: returnedName, taxId });
+      toast.success('สร้างผู้ติดต่อสำเร็จ');
+      onOpenChange(false);
+    },
+    onError: (err: unknown) => {
+      const msg =
+        err &&
+        typeof err === 'object' &&
+        'response' in err &&
+        (err as { response?: { data?: { message?: string } } }).response?.data?.message;
+      toast.error(`สร้างผู้ติดต่อไม่สำเร็จ — ${msg || 'กรุณาลองใหม่อีกครั้ง'}`);
+    },
+  });
+
+  // ── Validation ──────────────────────────────────────────────────────────
+
+  const canSubmit = name.trim().length > 0 && phone.trim().length > 0 && !mutation.isPending;
+
+  // ── Labels ──────────────────────────────────────────────────────────────
+
+  const idLabel =
+    contactType === 'JURISTIC' ? 'เลขผู้เสียภาษี (13 หลัก)' : 'เลขบัตรประชาชน (13 หลัก)';
+
+  const titleLabel =
+    role === 'SUPPLIER' ? 'เพิ่มผู้จัดจำหน่าย' : 'เพิ่มลูกค้าใหม่';
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="leading-snug">{titleLabel}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* ── ประเภท toggle ── */}
+          <div>
+            <Label className="mb-2 block leading-snug">ประเภท</Label>
+            <div className="flex gap-2">
+              {(['INDIVIDUAL', 'JURISTIC'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => {
+                    setContactType(t);
+                    setIdNumber('');
+                    if (t === 'INDIVIDUAL') setHasVat(false);
+                  }}
+                  className={[
+                    'flex-1 rounded-lg border px-3 py-2 text-sm leading-snug transition-colors',
+                    contactType === t
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-border bg-background text-foreground hover:bg-accent',
+                  ].join(' ')}
+                >
+                  {t === 'INDIVIDUAL' ? 'บุคคลธรรมดา' : 'นิติบุคคล'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* ── ชื่อ (required) ── */}
+          <div className="space-y-1.5">
+            <Label htmlFor="ccm-name" className="leading-snug">
+              ชื่อ <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="ccm-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="ชื่อบริษัท หรือ ชื่อ-นามสกุล"
+              autoFocus
+            />
+          </div>
+
+          {/* ── เลขประจำตัว (optional) ── */}
+          <div className="space-y-1.5">
+            <Label htmlFor="ccm-idnumber" className="leading-snug">
+              {idLabel}
+            </Label>
+            <Input
+              id="ccm-idnumber"
+              value={idNumber}
+              onChange={(e) => setIdNumber(e.target.value.replace(/\D/g, '').slice(0, 13))}
+              placeholder="ตัวเลข 13 หลัก"
+              inputMode="numeric"
+            />
+          </div>
+
+          {/* ── เบอร์โทร (required) ── */}
+          <div className="space-y-1.5">
+            <Label htmlFor="ccm-phone" className="leading-snug">
+              เบอร์โทร <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="ccm-phone"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="0812345678"
+              inputMode="tel"
+            />
+            {role === 'CUSTOMER' && phone && !/^0[0-9]{9}$/.test(phone) && (
+              <p className="text-xs text-destructive leading-snug">
+                เบอร์โทรต้องเป็นเลข 10 หลัก ขึ้นต้นด้วย 0
+              </p>
+            )}
+          </div>
+
+          {/* ── ที่อยู่ (optional) ── */}
+          <div className="space-y-1.5">
+            <Label htmlFor="ccm-address" className="leading-snug">
+              ที่อยู่
+            </Label>
+            <Input
+              id="ccm-address"
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="ที่อยู่ (ไม่บังคับ)"
+            />
+          </div>
+
+          {/* ── จด VAT — SUPPLIER only ── */}
+          {role === 'SUPPLIER' && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="ccm-hasvat"
+                checked={hasVat}
+                onCheckedChange={(v) => setHasVat(v === true)}
+              />
+              <Label htmlFor="ccm-hasvat" className="cursor-pointer leading-snug">
+                จด VAT
+              </Label>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>
+            ยกเลิก
+          </Button>
+          <Button
+            onClick={() => mutation.mutate()}
+            disabled={!canSubmit}
+          >
+            {mutation.isPending ? 'กำลังสร้าง...' : 'สร้าง'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
@@ -10,7 +10,7 @@ import { ContactCombobox, type ContactPickResult } from '@/components/contacts/C
 interface Props {
   value: string;
   onSelectSupplier: (s: { name: string; taxId: string; whtFormType?: 'PND3' | 'PND53' }) => void;
-  onTypeName: (name: string) => void;
+  onTypeName?: (name: string) => void;
   invalid?: boolean;
 }
 

--- a/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
@@ -125,8 +125,7 @@ export function CreatePOModal({
                     invalid={!form.supplierId && suppliersError}
                     placeholder="เลือก/ค้นหาผู้ขาย"
                   />
-                  {/* Hidden required-field guard so native form validation fires when no supplier is chosen */}
-                  <input type="hidden" value={form.supplierId} required />
+                  <input type="hidden" value={form.supplierId} />
                   {selectedSupplier && (
                     <div className="mt-1 flex gap-2 flex-wrap">
                       <span

--- a/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/components/CreatePOModal.tsx
@@ -3,6 +3,8 @@ import { brands, getModels, getModelInfo } from '@/data/productCatalog';
 import { ItemForm } from '../types';
 import { accessoryTypes, chargerConnectorTypes } from '../constants';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
+import { ContactCombobox } from '@/components/contacts/ContactCombobox';
+import type { ContactPickResult } from '@/components/contacts/ContactCombobox';
 
 export interface CreatePOModalProps {
   isOpen: boolean;
@@ -30,6 +32,7 @@ export interface CreatePOModalProps {
   suppliersLoading: boolean;
   suppliersError: boolean;
   selectedSupplier: CreatePOModalProps['suppliers'][number] | undefined;
+  onSupplierSelect: (result: ContactPickResult) => Promise<void>;
   supplierHasVat: boolean;
   subtotal: number;
   discountNum: number;
@@ -61,6 +64,7 @@ export function CreatePOModal({
   suppliersLoading,
   suppliersError,
   selectedSupplier,
+  onSupplierSelect,
   supplierHasVat,
   subtotal,
   discountNum,
@@ -114,26 +118,15 @@ export function CreatePOModal({
               <div className="space-y-3">
                 <div>
                   <label className="block text-2xs font-medium text-muted-foreground uppercase tracking-wider mb-2">ผู้ขาย <span className="text-destructive">*</span></label>
-                  <select
-                    value={form.supplierId}
-                    onChange={(e) => {
-                      const sid = e.target.value;
-                      const sup = suppliers.find((s) => s.id === sid);
-                      const defaultPm = sup?.paymentMethods?.find((pm) => pm.isDefault) || sup?.paymentMethods?.[0];
-                      setForm({
-                        ...form,
-                        supplierId: sid,
-                        paymentMethod: defaultPm?.paymentMethod || form.paymentMethod,
-                      });
-                    }}
-                    className={selectClass}
-                    required
-                  >
-                    <option value="">{suppliersLoading ? 'กำลังโหลด...' : suppliersError ? 'โหลดข้อมูลไม่ได้' : '-- เลือกผู้ขาย --'}</option>
-                    {suppliers.map((s) => (
-                      <option key={s.id} value={s.id}>{s.name}{s.contactName && s.contactName !== s.name ? ` (${s.contactName})` : ''}{s.hasVat ? ' [VAT]' : ''}</option>
-                    ))}
-                  </select>
+                  <ContactCombobox
+                    roleNeeded="SUPPLIER"
+                    value={selectedSupplier?.name ?? (suppliersLoading ? 'กำลังโหลด...' : '')}
+                    onSelect={onSupplierSelect}
+                    invalid={!form.supplierId && suppliersError}
+                    placeholder="เลือก/ค้นหาผู้ขาย"
+                  />
+                  {/* Hidden required-field guard so native form validation fires when no supplier is chosen */}
+                  <input type="hidden" value={form.supplierId} required />
                   {selectedSupplier && (
                     <div className="mt-1 flex gap-2 flex-wrap">
                       <span

--- a/apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts
+++ b/apps/web/src/pages/PurchaseOrdersPage/hooks/usePOForm.ts
@@ -82,6 +82,10 @@ export function usePOForm({ createMutation, suppliers }: UsePOFormOptions) {
 
   const handleCreate = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!form.supplierId) {
+      toast.error('กรุณาเลือกผู้ขาย');
+      return;
+    }
     const invalidItems = items.filter((i) => !i.category || !i.quantity || !i.unitPrice);
     if (invalidItems.length > 0) {
       toast.error('กรุณากรอกหมวดหมู่ จำนวน และราคาให้ครบทุกรายการ');

--- a/apps/web/src/pages/PurchaseOrdersPage/index.tsx
+++ b/apps/web/src/pages/PurchaseOrdersPage/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import PageHeader from '@/components/ui/PageHeader';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -18,6 +19,7 @@ import { GoodsReceivingModal } from './components/GoodsReceivingModal';
 
 export default function PurchaseOrdersPage() {
   const resetFormRef = useRef<() => void>(() => {});
+  const queryClient = useQueryClient();
 
   const onCreateSuccess = useCallback(() => {
     resetFormRef.current();
@@ -32,6 +34,28 @@ export default function PurchaseOrdersPage() {
 
   // Keep ref in sync
   resetFormRef.current = poForm.resetForm;
+
+  // Supplier selection handler: invalidate + refetch suppliers-for-po so a newly-created
+  // supplier appears in the array, then set supplierId. The selectedSupplier/VAT/payment-method
+  // computation in usePOForm keys off form.supplierId against the (refetched) suppliers array
+  // so it will resolve correctly on the next render after invalidation completes.
+  const onSupplierSelect = useCallback(
+    async ({ childId }: { childId: string }) => {
+      // Invalidate and await refetch so the refetched suppliers array includes the chosen/newly-created supplier
+      await queryClient.invalidateQueries({ queryKey: ['suppliers-for-po'] });
+      // After invalidation the query will refetch; grab the updated list from the cache
+      const cached = queryClient.getQueryData<{ data: typeof data.suppliers }>(['suppliers-for-po']);
+      const updatedSuppliers = cached?.data ?? data.suppliers;
+      const sup = updatedSuppliers.find((s) => s.id === childId);
+      const defaultPm = sup?.paymentMethods?.find((pm) => pm.isDefault) ?? sup?.paymentMethods?.[0];
+      poForm.setForm((f) => ({
+        ...f,
+        supplierId: childId,
+        paymentMethod: defaultPm?.paymentMethod ?? f.paymentMethod,
+      }));
+    },
+    [queryClient, data.suppliers, poForm],
+  );
 
   return (
     <div>
@@ -154,6 +178,7 @@ export default function PurchaseOrdersPage() {
         suppliersLoading={data.suppliersLoading}
         suppliersError={data.suppliersError}
         selectedSupplier={poForm.selectedSupplier}
+        onSupplierSelect={onSupplierSelect}
         supplierHasVat={poForm.supplierHasVat}
         subtotal={poForm.subtotal}
         discountNum={poForm.discountNum}

--- a/apps/web/src/pages/assets/__tests__/AssetEntrySection3Vendor.test.tsx
+++ b/apps/web/src/pages/assets/__tests__/AssetEntrySection3Vendor.test.tsx
@@ -1,14 +1,13 @@
-// PR 2a Task 5 (P6) — AssetEntrySection3Vendor: vendor combobox + partial-payment.
+// P1a — AssetEntrySection3Vendor: bespoke vendor picker replaced with
+// shared <ContactCombobox roleNeeded="SUPPLIER">.
 //
 // Coverage:
-//  - Combobox role is exposed (a11y) and labeled "ผู้ขาย"
+//  - ContactCombobox is rendered with role=combobox (forwarded from the shared component)
 //  - "จำนวนเงินที่จ่าย" partial-payment input is rendered
-//  - Existing fields (เลขใบกำกับภาษี, อ้างอิง PR) are preserved
+//  - Existing fields (เลขใบกำกับภาษี, อ้างอิง PR, เลขประจำตัวผู้เสียภาษี) are preserved
 //
-// Deferred (combobox / dialog interaction): the Popover + cmdk combination uses
-// Radix portals which JSDOM cannot fully render in a way that exposes a stable
-// listbox to RTL queries. Auto-fill on select and dialog-create flows are
-// validated manually for this PR; future work can use Playwright for full e2e.
+// Strategy: mock ContactCombobox so we avoid Popover/cmdk portal rendering issues
+// in JSDOM and keep this test focused on the section's own wiring.
 
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -16,16 +15,31 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { AssetEntrySection3Vendor } from '../components/AssetEntrySection3Vendor';
 
-vi.mock('../api', () => ({
-  assetsApi: {
-    suppliersList: vi.fn().mockResolvedValue([
-      { id: 'sup-1', name: 'ABC Trading', taxId: '0105561234567' },
-      { id: 'sup-2', name: 'XYZ Co.,Ltd.', taxId: '0105567654321' },
-    ]),
-    suppliersCreate: vi
-      .fn()
-      .mockResolvedValue({ id: 'sup-new', name: 'New Vendor', taxId: null }),
-  },
+// Mock the shared ContactCombobox so the section can be rendered in JSDOM
+// without Radix portal issues. The mock renders a plain combobox button that
+// exposes the same role/aria-label as the real component.
+vi.mock('@/components/contacts/ContactCombobox', () => ({
+  ContactCombobox: ({
+    value,
+    placeholder,
+    invalid,
+  }: {
+    value: string;
+    placeholder?: string;
+    invalid?: boolean;
+    onSelect: (r: unknown) => void;
+    roleNeeded: string;
+  }) => (
+    <button
+      type="button"
+      role="combobox"
+      aria-label="ผู้ขาย"
+      aria-invalid={invalid}
+      aria-expanded={false}
+    >
+      {value || placeholder || 'เลือกผู้ขาย / บริษัท'}
+    </button>
+  ),
 }));
 
 function Wrapper({ children }: { children: React.ReactNode }) {
@@ -58,7 +72,7 @@ const renderSection = () => {
   );
 };
 
-describe('AssetEntrySection3Vendor — P6 supplier integration', () => {
+describe('AssetEntrySection3Vendor — P1a ContactCombobox integration', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('exposes a vendor combobox with role=combobox and an accessible name', async () => {
@@ -74,7 +88,6 @@ describe('AssetEntrySection3Vendor — P6 supplier integration', () => {
 
   it('uses the placeholder "ว่างไว้ = ชำระเต็มจำนวน" on the partial-payment field', async () => {
     renderSection();
-    // Placeholder copy explains optional partial payment behavior to the user.
     expect(await screen.findByPlaceholderText(/ว่างไว้ = ชำระเต็มจำนวน/)).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
@@ -25,6 +25,7 @@ import type { AssetEntryFormValues } from '../schema';
 import { CASH_ACCOUNTS } from '../types';
 import { AssetSectionHeader } from './AssetSectionHeader';
 import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
+import { contactsApi } from '@/lib/api/contacts';
 
 export function AssetEntrySection3Vendor() {
   const {
@@ -41,10 +42,30 @@ export function AssetEntrySection3Vendor() {
   const supplierName = watch('supplierName') ?? '';
 
   // Every selection is now a real Supplier contact — set all three fields.
-  const handleVendorSelect = ({ childId, name, taxId }: ContactPickResult) => {
+  // Also auto-fill whtFormType / hasVat / vatAccount from the supplier link
+  // (mirrors the old selectSupplier behaviour).
+  const handleVendorSelect = async ({ contactId, childId, name, taxId }: ContactPickResult) => {
     setValue('supplierName', name, { shouldDirty: true, shouldValidate: true });
-    setValue('vendorId', childId, { shouldDirty: true });
+    // Fix C: guard empty childId — z.string().uuid().optional() rejects ''
+    setValue('vendorId', childId || undefined, { shouldDirty: true });
     setValue('supplierTaxId', taxId ?? '', { shouldDirty: true });
+    // Auto-fill ประเภทผู้ขาย (แบบ ภ.ง.ด.) + VAT fields from the supplier link.
+    try {
+      const detail = await contactsApi.detail(contactId);
+      const link = detail.suppliers?.[0];
+      if (link) {
+        setValue('whtFormType', link.type === 'JURISTIC' ? 'PND53' : 'PND3', {
+          shouldDirty: true,
+        });
+        if (link.taxId) setValue('supplierTaxId', link.taxId, { shouldDirty: true });
+        setValue('hasVat', link.hasVat, { shouldDirty: true, shouldValidate: true });
+        if (link.hasVat && !watch('vatAccount')) {
+          setValue('vatAccount', '11-4101', { shouldValidate: true });
+        }
+      }
+    } catch {
+      // keep the basic name/vendorId/taxId already set above — don't throw
+    }
   };
 
   const clearSupplier = () => {

--- a/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
+++ b/apps/web/src/pages/assets/components/AssetEntrySection3Vendor.tsx
@@ -2,17 +2,16 @@
 // PR 2a Task 5 (P6): vendor master combobox + inline "+ เพิ่มผู้ขายใหม่" dialog
 // + partial-payment amount input ("จำนวนเงินที่จ่าย").
 //
+// P1a: bespoke Popover/Command picker replaced with shared <ContactCombobox>.
+// Free-text path removed; vendors must now be real Contacts (SUPPLIER role).
+// Previously-used names ("เคยใช้") also removed.
+//
 // Pure presentation. Uses parent FormProvider for state.
 
-import { useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { Check, ChevronsUpDown, Pencil, Plus } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import {
   Select,
   SelectContent,
@@ -20,32 +19,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import ThaiDateInput from '@/components/ui/ThaiDateInput';
-import { cn } from '@/lib/utils';
 import { accountDisplayName } from '@/utils/accountName';
-import { assetsApi } from '../api';
 import type { AssetEntryFormValues } from '../schema';
-import { CASH_ACCOUNTS, type SupplierLite } from '../types';
+import { CASH_ACCOUNTS } from '../types';
 import { AssetSectionHeader } from './AssetSectionHeader';
-import { getErrorMessage } from '@/lib/api';
-import { contactsApi } from '@/lib/api/contacts';
+import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
 
 export function AssetEntrySection3Vendor() {
   const {
@@ -54,7 +33,6 @@ export function AssetEntrySection3Vendor() {
     watch,
     formState: { errors },
   } = useFormContext<AssetEntryFormValues>();
-  const queryClient = useQueryClient();
 
   const purchaseDate = watch('purchaseDate');
   const invoiceDate = watch('invoiceDate');
@@ -62,119 +40,11 @@ export function AssetEntrySection3Vendor() {
   const paymentAccount = watch('paymentAccount');
   const supplierName = watch('supplierName') ?? '';
 
-  // Vendor master = สมุดผู้ติดต่อ (Contacts with the SUPPLIER role). Cached ~5 min;
-  // a freshly created entry is injected via invalidateQueries below.
-  const suppliersQuery = useQuery({
-    queryKey: ['vendor-contacts'],
-    queryFn: () => assetsApi.vendorContacts(),
-    staleTime: 5 * 60 * 1000,
-  });
-  const suppliers = suppliersQuery.data ?? [];
-
-  // Previously-used free-text vendor names (from past assets) — "เคยใช้"
-  // suggestions so a one-off name can be reused without registering a Supplier.
-  const vendorNamesQuery = useQuery({
-    queryKey: ['asset-vendor-names'],
-    queryFn: () => assetsApi.vendorNames(),
-    staleTime: 5 * 60 * 1000,
-  });
-  const usedNames = vendorNamesQuery.data ?? [];
-
-  // Combobox state
-  const [popoverOpen, setPopoverOpen] = useState(false);
-  const [searchValue, setSearchValue] = useState('');
-
-  // Create-supplier dialog state
-  const [createOpen, setCreateOpen] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [newPhone, setNewPhone] = useState('');
-  const [newTaxId, setNewTaxId] = useState('');
-
-  const filteredSuppliers = useMemo(() => {
-    const q = searchValue.trim().toLowerCase();
-    if (!q) return suppliers;
-    return suppliers.filter(
-      (s) =>
-        s.name.toLowerCase().includes(q) || (s.taxId ?? '').toLowerCase().includes(q),
-    );
-  }, [searchValue, suppliers]);
-
-  // Exact-name match (case-insensitive) used to decide whether to surface the
-  // "+ เพิ่มผู้ขายใหม่" CTA.
-  const hasExactMatch = useMemo(() => {
-    const q = searchValue.trim().toLowerCase();
-    if (!q) return false;
-    return suppliers.some((s) => s.name.toLowerCase() === q);
-  }, [searchValue, suppliers]);
-
-  // Past free-text names that match the query and aren't already registered.
-  const filteredUsedNames = useMemo(() => {
-    const regNames = new Set(suppliers.map((s) => s.name.trim().toLowerCase()));
-    const q = searchValue.trim().toLowerCase();
-    return usedNames
-      .filter((n) => {
-        const nl = n.trim().toLowerCase();
-        if (!nl || regNames.has(nl)) return false;
-        if (q && !nl.includes(q)) return false;
-        return true;
-      })
-      .slice(0, 20);
-  }, [usedNames, suppliers, searchValue]);
-
-  const hasExactUsedMatch = useMemo(() => {
-    const q = searchValue.trim().toLowerCase();
-    if (!q) return false;
-    return usedNames.some((n) => n.trim().toLowerCase() === q);
-  }, [searchValue, usedNames]);
-
-  // Is the current name a known contact (สมุดผู้ติดต่อ) vs a one-off free-text?
-  const isKnownVendor = useMemo(() => {
-    const n = supplierName.trim().toLowerCase();
-    return !!n && suppliers.some((s) => s.name.trim().toLowerCase() === n);
-  }, [suppliers, supplierName]);
-
-  // Pick a vendor from สมุดผู้ติดต่อ → fill name + taxId. We DON'T set vendorId:
-  // it's an FK to the legacy Supplier table, but list items are Contact ids.
-  const selectSupplier = async (s: SupplierLite) => {
-    setValue('supplierName', s.name, { shouldDirty: true, shouldValidate: true });
-    setValue('supplierTaxId', s.taxId ?? '', { shouldDirty: true });
-    setValue('vendorId', undefined, { shouldDirty: true });
-    setPopoverOpen(false);
-    setSearchValue('');
-    // Auto-fill ประเภทผู้ขาย (แบบ ภ.ง.ด.) from the supplier's type: JURISTIC →
-    // PND53 (นิติบุคคล), INDIVIDUAL → PND3 (บุคคล). The list payload omits the
-    // type, so read it from the contact detail. Best-effort — keep list values
-    // on failure. Only the WHT form type is touched; hasWht is left to the user.
-    try {
-      const detail = await contactsApi.detail(s.id);
-      const link = detail.suppliers?.[0];
-      if (link) {
-        setValue('whtFormType', link.type === 'JURISTIC' ? 'PND53' : 'PND3', {
-          shouldDirty: true,
-        });
-        if (link.taxId) setValue('supplierTaxId', link.taxId, { shouldDirty: true });
-        // VAT: mirror the supplier's VAT-registration status onto the purchase.
-        setValue('hasVat', link.hasVat, { shouldDirty: true, shouldValidate: true });
-        if (link.hasVat && !watch('vatAccount')) {
-          setValue('vatAccount', '11-4101', { shouldValidate: true });
-        }
-      }
-    } catch {
-      // keep the list values when the detail lookup fails
-    }
-  };
-
-  // Free-text path: use whatever the user typed as the vendor name WITHOUT
-  // forcing them to create a Supplier master record (which requires a phone).
-  // Most asset purchases are one-off vendors — this is the common case, so the
-  // combobox must never be a dead-end for a plain typed name.
-  const commitFreeText = (raw: string) => {
-    const name = raw.trim();
-    if (!name) return;
+  // Every selection is now a real Supplier contact — set all three fields.
+  const handleVendorSelect = ({ childId, name, taxId }: ContactPickResult) => {
     setValue('supplierName', name, { shouldDirty: true, shouldValidate: true });
-    setValue('vendorId', undefined, { shouldDirty: true });
-    setPopoverOpen(false);
-    setSearchValue('');
+    setValue('vendorId', childId, { shouldDirty: true });
+    setValue('supplierTaxId', taxId ?? '', { shouldDirty: true });
   };
 
   const clearSupplier = () => {
@@ -183,209 +53,19 @@ export function AssetEntrySection3Vendor() {
     setValue('supplierTaxId', '', { shouldDirty: true });
   };
 
-  const createMutation = useMutation({
-    mutationFn: (input: { name: string; phone: string; taxId?: string }) =>
-      assetsApi.suppliersCreate(input),
-    onSuccess: (created) => {
-      toast.success(`เพิ่มผู้ขาย "${created.name}" ลงสมุดผู้ติดต่อแล้ว`);
-      // suppliersCreate also creates a Contact (role SUPPLIER) — refresh the
-      // contact-backed vendor list so the new entry appears.
-      queryClient.invalidateQueries({ queryKey: ['vendor-contacts'] });
-      // Auto-fill the new name + taxId.
-      void selectSupplier(created);
-      setCreateOpen(false);
-      setNewName('');
-      setNewPhone('');
-      setNewTaxId('');
-    },
-    onError: (e) => toast.error(getErrorMessage(e) ?? 'เพิ่มผู้ขายไม่สำเร็จ'),
-  });
-
-  const openCreateDialog = () => {
-    // Prefill name with whatever the user typed in the combobox so they don't
-    // have to retype.
-    setNewName(searchValue.trim());
-    setNewPhone('');
-    setNewTaxId('');
-    setCreateOpen(true);
-    setPopoverOpen(false);
-  };
-
-  const submitCreate = () => {
-    if (!newName.trim()) {
-      toast.error('กรุณาระบุชื่อผู้ขาย');
-      return;
-    }
-    if (!newPhone.trim()) {
-      toast.error('กรุณาระบุเบอร์โทรผู้ขาย');
-      return;
-    }
-    createMutation.mutate({
-      name: newName.trim(),
-      phone: newPhone.trim(),
-      taxId: newTaxId.trim() ? newTaxId.trim() : undefined,
-    });
-  };
-
-  // Display label for the combobox trigger: prefer linked supplier name,
-  // fall back to free-text supplierName (legacy entries).
-  const triggerLabel = supplierName || 'เลือกผู้ขาย / บริษัท';
-
   return (
     <Card>
       <AssetSectionHeader number={3} title="ผู้ขาย & การชำระเงิน" />
       <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <Label htmlFor="vendor-combobox">ชื่อผู้ขาย / บริษัท *</Label>
-          <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                id="vendor-combobox"
-                type="button"
-                variant="outline"
-                role="combobox"
-                aria-expanded={popoverOpen}
-                aria-invalid={!!errors.supplierName}
-                className={cn(
-                  'w-full justify-between font-normal',
-                  !supplierName && 'text-muted-foreground',
-                )}
-              >
-                <span className="flex min-w-0 items-center gap-1.5">
-                  {isKnownVendor ? (
-                    <Check className="size-3.5 shrink-0 text-primary" />
-                  ) : supplierName ? (
-                    <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
-                  ) : null}
-                  <span className="truncate leading-snug" title={supplierName || undefined}>
-                    {triggerLabel}
-                  </span>
-                </span>
-                <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-              <Command shouldFilter={false}>
-                <CommandInput
-                  placeholder="ค้นหา หรือพิมพ์ชื่อผู้ขายใหม่..."
-                  value={searchValue}
-                  onValueChange={setSearchValue}
-                  onKeyDown={(e) => {
-                    // Enter on a typed name that isn't an exact existing suggestion
-                    // commits it as free text — and stops cmdk from selecting a
-                    // partial-match item (which would pick the wrong vendor/name).
-                    if (
-                      e.key === 'Enter' &&
-                      searchValue.trim() &&
-                      !hasExactMatch &&
-                      !hasExactUsedMatch
-                    ) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      commitFreeText(searchValue);
-                    }
-                  }}
-                />
-                <CommandList>
-                  {suppliersQuery.isLoading ? (
-                    <CommandEmpty>กำลังโหลด...</CommandEmpty>
-                  ) : filteredSuppliers.length === 0 && filteredUsedNames.length === 0 ? (
-                    <CommandEmpty className="px-3 py-6 text-center leading-snug">
-                      {searchValue.trim()
-                        ? 'ไม่พบชื่อผู้ขายที่ตรงกัน'
-                        : suppliers.length === 0 && usedNames.length === 0
-                          ? 'ยังไม่มีผู้ขาย — พิมพ์ชื่อเพื่อใช้ได้เลย'
-                          : 'พิมพ์เพื่อค้นหา'}
-                    </CommandEmpty>
-                  ) : (
-                    <>
-                      {filteredSuppliers.length > 0 && (
-                        <CommandGroup heading="ผู้ขาย (สมุดผู้ติดต่อ)">
-                          {filteredSuppliers.map((s) => (
-                            <CommandItem key={s.id} value={s.id} onSelect={() => void selectSupplier(s)}>
-                              <Check
-                                className={cn(
-                                  'mr-2 size-4 shrink-0',
-                                  s.name === supplierName ? 'opacity-100' : 'opacity-0',
-                                )}
-                              />
-                              <div className="flex min-w-0 flex-col">
-                                <span className="truncate leading-snug" title={s.name}>
-                                  {s.name}
-                                </span>
-                                {s.taxId && (
-                                  <span className="text-xs text-muted-foreground">{s.taxId}</span>
-                                )}
-                              </div>
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      )}
-                      {filteredUsedNames.length > 0 && (
-                        <CommandGroup heading="เคยใช้">
-                          {filteredUsedNames.map((name) => (
-                            <CommandItem
-                              key={`used:${name}`}
-                              value={`used:${name}`}
-                              onSelect={() => commitFreeText(name)}
-                            >
-                              <Pencil className="mr-2 size-4 shrink-0 opacity-60" />
-                              <span className="truncate leading-snug" title={name}>
-                                {name}
-                              </span>
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      )}
-                    </>
-                  )}
-                </CommandList>
-                {/* Actions live OUTSIDE the list so they're never in cmdk's
-                    highlight/Enter cycle — typing a new name can't accidentally
-                    select a partial-match supplier, and the lone CTA is no longer
-                    rendered as a big auto-highlighted block. Never a dead end. */}
-                {!hasExactMatch && (
-                  <div className="border-t border-border p-1">
-                    {searchValue.trim() && !hasExactUsedMatch && (
-                      <button
-                        type="button"
-                        onClick={() => commitFreeText(searchValue)}
-                        className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent"
-                      >
-                        <Check className="mt-0.5 size-4 shrink-0 text-primary" />
-                        <span className="min-w-0">
-                          <span className="block truncate text-sm leading-snug text-foreground">
-                            ใช้ชื่อ{' '}
-                            <span className="font-medium">&quot;{searchValue.trim()}&quot;</span>
-                          </span>
-                          <span className="block text-xs leading-snug text-muted-foreground">
-                            ใช้ครั้งเดียว ไม่บันทึกลงทะเบียน
-                          </span>
-                        </span>
-                      </button>
-                    )}
-                    <button
-                      type="button"
-                      onClick={openCreateDialog}
-                      className="flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent"
-                    >
-                      <Plus className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0">
-                        <span className="block truncate text-sm leading-snug text-foreground">
-                          {searchValue.trim()
-                            ? `บันทึก "${searchValue.trim()}" ลงสมุดผู้ติดต่อ`
-                            : 'เพิ่มผู้ขายใหม่'}
-                        </span>
-                        <span className="block text-xs leading-snug text-muted-foreground">
-                          บันทึกถาวร · ใช้ซ้ำได้ (ต้องมีเบอร์โทร)
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                )}
-              </Command>
-            </PopoverContent>
-          </Popover>
+          <ContactCombobox
+            roleNeeded="SUPPLIER"
+            value={supplierName}
+            invalid={!!errors.supplierName}
+            placeholder="เลือกผู้ขาย / บริษัท"
+            onSelect={handleVendorSelect}
+          />
           {supplierName && (
             <button
               type="button"
@@ -494,66 +174,6 @@ export function AssetEntrySection3Vendor() {
           )}
         </div>
       </CardContent>
-
-      {/* P6 — Inline "+ เพิ่มผู้ขายใหม่" dialog. Phone is required server-side */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>เพิ่มผู้ขายใหม่</DialogTitle>
-            <DialogDescription>
-              บันทึกผู้ขายลงฐานข้อมูลผู้ติดต่อ ใช้ได้ทั้งใน Asset และ Expense
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid grid-cols-1 gap-3">
-            <div>
-              <Label htmlFor="new-supplier-name">ชื่อผู้ขาย / บริษัท *</Label>
-              <Input
-                id="new-supplier-name"
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="บริษัท ABC จำกัด"
-                autoFocus
-              />
-            </div>
-            <div>
-              <Label htmlFor="new-supplier-phone">เบอร์โทร *</Label>
-              <Input
-                id="new-supplier-phone"
-                value={newPhone}
-                onChange={(e) => setNewPhone(e.target.value)}
-                placeholder="081-XXX-XXXX"
-              />
-            </div>
-            <div>
-              <Label htmlFor="new-supplier-tax-id">เลขประจำตัวผู้เสียภาษี</Label>
-              <Input
-                id="new-supplier-tax-id"
-                value={newTaxId}
-                onChange={(e) => setNewTaxId(e.target.value)}
-                maxLength={13}
-                placeholder="0123456789012 (ไม่บังคับ)"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setCreateOpen(false)}
-              disabled={createMutation.isPending}
-            >
-              ยกเลิก
-            </Button>
-            <Button
-              type="button"
-              onClick={submitCreate}
-              disabled={createMutation.isPending}
-            >
-              {createMutation.isPending ? 'กำลังบันทึก...' : 'บันทึกผู้ขาย'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </Card>
   );
 }

--- a/apps/web/src/pages/insurance/components/RepairCenterCombobox.tsx
+++ b/apps/web/src/pages/insurance/components/RepairCenterCombobox.tsx
@@ -1,167 +1,48 @@
-// Repair-center picker for the insurance/repair-ticket flow.
-// Adapts the UX of expense-form-v4/VendorCombobox but sources suppliers from the
-// same /suppliers endpoint SendDialog already uses (debounced search), then
-// filters isRepairCenter===true CLIENT-SIDE (the backend has no such param yet).
-// Selecting a repair center returns its supplier id + name; the field stores the
-// id in repairSupplierId. A typed name with no match is committed as a one-off
-// (id stays empty) to preserve the existing free-text fallback.
-import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Check, ChevronsUpDown, Pencil, Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { cn } from '@/lib/utils';
+// Repair-center picker — thin wrapper over ContactCombobox. A repair center must
+// be a real Supplier/Contact; picking/creating one marks it isRepairCenter=true
+// (PEAK-style tag-on-use via PATCH /suppliers/:id).
+//
+// UX CHANGE (P1b): the picker now shows ALL contacts (not only existing repair
+// centers). Any contact selected here is tagged isRepairCenter=true on pick.
+// This is deliberate per the party-master-mandatory epic.
+import { useMutation } from '@tanstack/react-query';
 import api from '@/lib/api';
-import { useDebounce } from '@/hooks/useDebounce';
-
-interface SupplierHit {
-  id: string;
-  name: string;
-  isRepairCenter?: boolean;
-}
+import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
 
 interface Props {
-  /** Current repairSupplierId (empty string when none/one-off). */
+  /** Current repairSupplierId (empty string when none). */
   value: string;
-  /** Display name for the current selection (or typed one-off name). */
-  displayName: string;
-  /** A repair center was picked (id) or a one-off name was typed (id=''). */
+  /** Display name for the current selection. */
+  displayName?: string;
+  /** A repair center was picked — always a real supplier (id never ''). */
   onSelect: (s: { id: string; name: string }) => void;
   invalid?: boolean;
 }
 
 export function RepairCenterCombobox({ value, displayName, onSelect, invalid }: Props) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-  const debouncedSearch = useDebounce(search, 350);
-
-  const { data: suppliers, isLoading } = useQuery<SupplierHit[]>({
-    queryKey: ['suppliers-repair-center', debouncedSearch],
-    queryFn: async () => {
-      if (!debouncedSearch || debouncedSearch.length < 1) return [];
-      // NOTE: The suppliers API does not yet filter on isRepairCenter server-side —
-      // filter client-side until backend exposes the param (TODO: add isRepairCenter
-      // query param to suppliers controller GET /suppliers).
-      const res = await api.get(`/suppliers?search=${encodeURIComponent(debouncedSearch)}&limit=20`);
-      const all: SupplierHit[] = res.data?.data ?? [];
-      return all.filter((s) => s.isRepairCenter === true);
-    },
-    enabled: debouncedSearch.length >= 1,
+  const mark = useMutation({
+    mutationFn: (supplierId: string) =>
+      api.patch(`/suppliers/${supplierId}`, { isRepairCenter: true }),
   });
 
-  const results = suppliers ?? [];
-
-  const hasExactMatch = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return !!q && results.some((s) => s.name.toLowerCase() === q);
-  }, [search, results]);
-
-  const isKnownCenter = !!value;
-
-  const commitTyped = (name: string) => {
-    const n = name.trim();
-    if (!n) return;
-    onSelect({ id: '', name: n });
-    setOpen(false);
-    setSearch('');
+  const handleSelect = async ({ childId, name }: ContactPickResult) => {
+    // Best-effort: tag the chosen supplier as a repair center, then report up.
+    // Non-fatal: if PATCH fails the selection still proceeds.
+    try {
+      await mark.mutateAsync(childId);
+    } catch {
+      /* non-fatal */
+    }
+    onSelect({ id: childId, name });
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          aria-invalid={invalid}
-          className={cn(
-            'w-full justify-between font-normal',
-            !displayName && 'text-muted-foreground',
-          )}
-        >
-          <span className="flex min-w-0 items-center gap-1.5">
-            {isKnownCenter ? (
-              <Check className="size-3.5 shrink-0 text-primary" />
-            ) : displayName ? (
-              <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
-            ) : null}
-            <span className="truncate leading-snug" title={displayName || undefined}>
-              {displayName || 'เลือกศูนย์ซ่อม หรือพิมพ์ชื่อ'}
-            </span>
-          </span>
-          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-        <Command shouldFilter={false}>
-          <CommandInput
-            placeholder="ค้นหาศูนย์ซ่อม หรือพิมพ์ชื่อใหม่..."
-            value={search}
-            onValueChange={setSearch}
-            onKeyDown={(e) => {
-              // Enter on a typed name with no exact match commits it as a one-off
-              // repair center (and blocks cmdk from picking a partial match).
-              if (e.key === 'Enter' && search.trim() && !hasExactMatch) {
-                e.preventDefault();
-                e.stopPropagation();
-                commitTyped(search);
-              }
-            }}
-          />
-          <CommandList>
-            {!search.trim() ? (
-              <CommandEmpty className="px-3 py-6 text-center leading-snug">
-                พิมพ์เพื่อค้นหาศูนย์ซ่อม
-              </CommandEmpty>
-            ) : isLoading ? (
-              <CommandEmpty>กำลังโหลด...</CommandEmpty>
-            ) : (
-              <>
-                {results.length > 0 && (
-                  <CommandGroup heading="ศูนย์ซ่อม">
-                    {results.map((s) => (
-                      <CommandItem
-                        key={s.id}
-                        value={s.id}
-                        onSelect={() => {
-                          onSelect({ id: s.id, name: s.name });
-                          setOpen(false);
-                          setSearch('');
-                        }}
-                      >
-                        <Check
-                          className={cn(
-                            'mr-2 size-4 shrink-0',
-                            value === s.id ? 'opacity-100' : 'opacity-0',
-                          )}
-                        />
-                        <span className="flex-1 truncate leading-snug">{s.name}</span>
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-                {!hasExactMatch && (
-                  <CommandGroup heading="ใช้ชื่อที่พิมพ์">
-                    <CommandItem value={`__typed__${search}`} onSelect={() => commitTyped(search)}>
-                      <Plus className="mr-2 size-4 shrink-0" />
-                      <span className="truncate leading-snug">ใช้ชื่อ “{search.trim()}”</span>
-                    </CommandItem>
-                  </CommandGroup>
-                )}
-              </>
-            )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <ContactCombobox
+      roleNeeded="SUPPLIER"
+      value={displayName ?? ''}
+      invalid={invalid}
+      placeholder="เลือก/ค้นหาศูนย์ซ่อม"
+      onSelect={handleSelect}
+    />
   );
 }

--- a/apps/web/src/pages/insurance/components/RepairCenterCombobox.tsx
+++ b/apps/web/src/pages/insurance/components/RepairCenterCombobox.tsx
@@ -6,6 +6,7 @@
 // centers). Any contact selected here is tagged isRepairCenter=true on pick.
 // This is deliberate per the party-master-mandatory epic.
 import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import api from '@/lib/api';
 import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
 
@@ -31,7 +32,7 @@ export function RepairCenterCombobox({ value, displayName, onSelect, invalid }: 
     try {
       await mark.mutateAsync(childId);
     } catch {
-      /* non-fatal */
+      toast.error('บันทึกเป็นศูนย์ซ่อมไม่สำเร็จ แต่เลือกผู้ขายแล้ว');
     }
     onSelect({ id: childId, name });
   };

--- a/docs/superpowers/specs/2026-06-04-party-master-mandatory-design.md
+++ b/docs/superpowers/specs/2026-06-04-party-master-mandatory-design.md
@@ -50,7 +50,22 @@
 | CustomerSelectStep (สัญญา) | ลูกค้าผ่อน | **full-customer** |
 | (Trade-in seller ถ้ามี UI) | คนขายมือสอง | mini |
 
-> ⚠️ **ลิสต์นี้ยังไม่ครบ** (scrutinize) — งานแรกของ P0 คือ **sweep ทั้ง repo** หา free-text touchpoint ทุกจุด (asset vendor combobox, trade-in seller, finance-company contacts, collections skip-tracing ฯลฯ) ก่อน claim "ทุกที่"
+### Inventory เต็มจาก sweep (P0a — 2026-06-04)
+
+**ใน scope (เป็น party-master contact จริง):**
+- **ผู้ขาย/vendor:** `VendorCombobox` (รายจ่าย, `onTypeName`), `PettyCashLinesSection` per-line `supplierName`, `AssetEntrySection3Vendor` (asset — มี dropdown "ชื่อที่เคยใช้"), PurchaseOrder supplier `<select>`
+- **ศูนย์ซ่อม:** `RepairCenterCombobox` (supplier + `isRepairCenter`)
+- **คู่ค้า/ลูกค้า:** `CounterpartyPicker` (รายรับอื่น)
+- **ลูกค้า:** `CustomerPickerStep` (ประกัน), `CustomerSelectStep` (สัญญา → full-customer)
+- **คนขายมือสอง:** TradeIn `sellerName`/`sellerPhone` (`AcceptModal`) — role `TRADE_IN_SELLER` มีใน party master
+
+Backend free-text fields ที่ต้องกัน (P3): `ExpenseDocument.vendorName`, `ExpenseLine.supplierName`, `OtherIncome.counterpartyName/TaxId/Address/Phone`, `TradeIn.sellerName/sellerPhone`, `FixedAsset.supplierName/supplierTaxId`
+
+**นอก scope ของ epic นี้ (ไม่ใช่ party-master contact — เคาะกับ owner):**
+- `PayrollLine.employeeName` — **พนักงาน ไม่ใช่ลูกค้า/ผู้ขาย** (`Contact` ไม่มี role EMPLOYEE) → ควรเป็น "employee master" แยก ไม่ใช่ epic นี้
+- `TradeIn.transferBankName/transferAccountName` — บัญชีธนาคารผู้รับเงิน ไม่ใช่ "ผู้ติดต่อ"
+- `Receipt.payerName/receiverName` — auto-fill จาก customer/company อยู่แล้ว → แค่กันการแก้มือ (low)
+- custodianName (`NameAutocomplete`, ผู้ถือเงินสดย่อย) — พนักงานภายใน ไม่ใช่ party
 
 ## เฟส (แต่ละเฟส = PR ที่ทำงาน/ทดสอบได้เอง)
 

--- a/docs/superpowers/specs/2026-06-04-party-master-mandatory-design.md
+++ b/docs/superpowers/specs/2026-06-04-party-master-mandatory-design.md
@@ -1,0 +1,78 @@
+# Party Master Mandatory — ห้าม free-text ผู้ติดต่อทั้งโปรแกรม
+
+วันที่: 2026-06-04
+สถานะ: รออนุมัติ spec จาก owner
+ต่อยอดจาก: [2026-06-01-unified-contact-party-master-design.md](2026-06-01-unified-contact-party-master-design.md) (party master) + [2026-06-04-peak-style-contact-picker-design.md](2026-06-04-peak-style-contact-picker-design.md) (slice 1 ผู้ขาย — merged)
+
+## ที่มา / ปัญหา
+
+แม้จะมี `Contact` (party master) แล้ว หลายจุดในแอปยัง**อ้างผู้ติดต่อเป็น free-text string** — `ExpenseDocument.vendorName`, `OtherIncome.counterpartyName`, `TradeIn.sellerName`, ช่องค้นที่พิมพ์ชื่อลอยได้ ฯลฯ → เกิด **"ผู้ติดต่อผี"** ที่ไม่ผูกเข้า Contact → AR/AP และเอกสารภาษีไม่ reconcile เข้า record เดียว ขัดทั้งหลักบัญชีและต้นแบบ PEAK
+
+## เป้าหมาย (end-state)
+
+**ทุกการอ้างอิงผู้ติดต่อ = Contact จริงเสมอ ไม่มี string ลอย** — ผู้ใช้เลือกผู้ติดต่อเดิม หรือสร้างใหม่ inline (เข้า party master ทันที); ข้อมูล free-text เดิมถูก migrate เป็น Contact
+
+## การตัดสินใจ (เคาะกับ owner แล้ว — 2026-06-04)
+
+1. **ห้าม free-text ทุกที่** — ไม่มีข้อยกเว้น one-off (แม้จ่ายครั้งเดียวก็ต้องเป็น Contact, สร้าง inline)
+2. **บังคับถึง backend ที่ write-path** — service ปฏิเสธการเขียน free-text ใหม่ทุก path (ไม่ใช่แค่ซ่อนปุ่มใน UI). ข้อมูล free-text **เก่า** ทำ cleanup แยกที่ review ทีละชุด — **ไม่** ทำ NOT-NULL migration + mass fuzzy-backfill (scrutinize: เสี่ยงแปลง free-text orphan เป็น Contact ผีซ้ำ)
+3. **create flow = context-aware** — ช่องผู้ขาย/คู่ค้า → mini-modal; ช่องลูกค้าผ่อน → ฟอร์มเต็ม; ทั้งคู่ติด badge "ข้อมูลไม่ครบ" ถ้ายังขาด
+
+## Design
+
+### 1. `ContactCombobox` v2 (enabler — ทุกอย่างพึ่งตัวนี้)
+
+- **ตัด `onTypeName` (free-text path) ออก** — เลือกได้เฉพาะผู้ติดต่อจริง หรือกด "สร้างผู้ติดต่อใหม่"
+- เพิ่ม inline create แบบ context-aware ผ่าน prop (เช่น `createMode: 'mini' | 'full-customer'`):
+  - **`mini`** → เปิด `<CreateContactModal>` เก็บ: ชื่อ, ประเภท (บุคคล/นิติบุคคล), เลขผู้เสียภาษี/บัตรปชช., เบอร์, ที่อยู่, (บริบทผู้ขาย: hasVat + ประเภท WHT) → `POST /contacts` สร้าง Contact + ensure-role child → คืน childId กลับช่องนั้น
+  - **`full-customer`** → นำทางไปฟอร์ม intake ลูกค้าเดิม (POS/contract) แทน mini (KYC ครบ)
+- **ปิดรอยรั่ว KYC (scrutinize):** ในบริบท lending ถ้าเลือกผู้ติดต่อ **เดิม** ที่ Customer link เป็น stub (เช่น ไม่มี `nationalId`) → บังคับเด้งฟอร์ม KYC ก่อนใช้ ไม่ใช่แค่ตอน create ใหม่ (กันสัญญาเดินด้วยลูกค้า KYC ไม่ครบ)
+- แถวที่ provision/สร้างใหม่แล้วข้อมูลไม่ครบ (เช่น phone ว่าง / ยังไม่มี KYC) → badge **"ข้อมูลไม่ครบ"**
+
+### 2. Backend
+
+- **เปิด CUSTOMER ใน `ensureRole`** (resolver) — สร้าง Customer stub (name + phone mirror, encryption/hash null ค่อยเติม) แบบเดียวกับ SUPPLIER
+- **mini-create reuse endpoint เดิม** (scrutinize: ไม่สร้าง `POST /contacts` ใหม่) — `POST /suppliers` / `POST /customers` **สร้าง Contact ให้อยู่แล้ว**ผ่าน `findOrCreateByNaturalKey`; mini-modal เรียกตัวนี้ด้วย slim DTO (field เท่าที่กรอก)
+- **write-path guard (P3):** service ของ Expense/OtherIncome/TradeIn **ปฏิเสธ**การบันทึกที่อ้างผู้ติดต่อแบบ free-text (ต้องมี contactId/childId) — กันของใหม่โดยไม่ต้อง migrate schema
+  - เพิ่ม FK แบบ **nullable** (`vendorContactId` ฯลฯ) ให้ของใหม่ผูกได้ — **ไม่บังคับ NOT-NULL** กับแถวเก่า
+  - `TradeIn` มี `sellerContactId` อยู่แล้ว; `OtherIncome` มี `customerId` บางส่วน
+  - ของเก่า (free-text orphan): **cleanup แยก (P3.5)** — เครื่องมือ match → Contact ทีละชุดให้คน review, **ไม่** auto fuzzy-backfill ทั้งตาราง (เลี่ยง Contact ผีซ้ำ)
+
+### 3. Picker inventory (ต้องแปลงให้ครบ)
+
+| Picker | ช่อง | createMode |
+|---|---|---|
+| VendorCombobox (รายจ่าย v4) | ผู้ขาย | mini |
+| PurchaseOrder supplier select | ผู้ขาย | mini |
+| RepairCenterCombobox (ประกัน) | ศูนย์ซ่อม | mini (+ isRepairCenter) |
+| CounterpartyPicker (รายรับอื่น) | คู่ค้า/ลูกค้า | mini |
+| CustomerPickerStep (ประกัน) | ลูกค้า | mini หรือ full |
+| CustomerSelectStep (สัญญา) | ลูกค้าผ่อน | **full-customer** |
+| (Trade-in seller ถ้ามี UI) | คนขายมือสอง | mini |
+
+> ⚠️ **ลิสต์นี้ยังไม่ครบ** (scrutinize) — งานแรกของ P0 คือ **sweep ทั้ง repo** หา free-text touchpoint ทุกจุด (asset vendor combobox, trade-in seller, finance-company contacts, collections skip-tracing ฯลฯ) ก่อน claim "ทุกที่"
+
+## เฟส (แต่ละเฟส = PR ที่ทำงาน/ทดสอบได้เอง)
+
+- **P0 — ContactCombobox v2 + backend create** _(เริ่มที่นี่)_
+  - **Sweep** หา free-text contact touchpoint ทั้ง repo → ทำ inventory จริงให้ครบ
+  - เปิด CUSTOMER ใน `ensureRole` + tests
+  - `CreateContactModal` (mini) **เรียก `POST /suppliers`/`POST /customers` เดิม** + ใส่ inline-create เข้า ContactCombobox, ตัด free-text path, badge "ข้อมูลไม่ครบ"
+  - อัปเดต VendorCombobox (merged) ให้เลิก free-text — **แต่ validate ความเร็ว mini-modal กับ flow รายจ่ายจริงก่อน lock** (เผื่อ quick-create เบอร์เดียวสำหรับ one-off)
+- **P1 — ช่องผู้ขายที่เหลือ:** PurchaseOrder supplier, RepairCenter
+- **P2 — ช่องลูกค้า:** CounterpartyPicker, CustomerPickerStep, CustomerSelectStep (full-customer + ปิดรอยรั่ว KYC)
+- **P3 — write-path guard + nullable FK:** service ปฏิเสธ free-text ใหม่, เพิ่ม FK nullable, ผูกของใหม่ — **ไม่บังคับ NOT-NULL/ไม่ mass-backfill** (ขึ้นกับ P1+P2 เสร็จครบ **ทุก write-path** ก่อน — P3 เป็น barrier ไม่ใช่ slice อิสระ)
+- **P3.5 (แยก, optional) — cleanup ของเก่า:** เครื่องมือ match free-text orphan → Contact ทีละชุดมีคน review
+- **P4 — เก็บกวาด:** badge ข้อมูลไม่ครบทุกหน้า detail, ลบ field free-text ที่ตายแล้ว, ลบ `onTypeName` ทุก caller
+
+## ความเสี่ยง / ข้อควรระวัง
+
+- **mass-backfill เสี่ยงสร้าง Contact ผีซ้ำ** (free-text ชื่อซ้ำ ไม่มีเลขภาษี) → ลดรูปเป็น cleanup ทีละชุดมีคน review (P3.5), ไม่ auto ทั้งตาราง
+- **รอยรั่ว KYC:** เลือก contact เดิมเข้า lending context ได้ stub → ต้องเด้ง KYC ถ้า Customer เป็น stub (ไม่ใช่แค่ตอน create)
+- **UX รายจ่าย one-off ช้าลง** (เลิกพิมพ์ลอย → ต้อง create) → validate ความเร็ว mini-modal ก่อน lock VendorCombobox
+- **party master ปน non-trade** (ธนาคารดอกเบี้ยฝาก ฯลฯ) จากนโยบาย "ห้ามทุกที่" → owner รับทราบ/หรือแยก group "ผู้รับเงินเบ็ดเตล็ด" ภายหลัง
+
+## ไม่ทำใน epic นี้ (YAGNI)
+
+- Import Excel / custom groups (อยู่ใน spec แม่)
+- Auto-fill จาก DBD (feature แยก)


### PR DESCRIPTION
## Summary
**P1** of the "Party Master Mandatory" epic — convert all **supplier-side** pickers to the shared `ContactCombobox` (no free-text). Stacked on #1144 (P0).

- **Asset vendor** (`AssetEntrySection3Vendor`) → ContactCombobox; removed ~360 lines of bespoke picker + free-text + previously-used-names + its own create dialog. Now links `vendorId` (FK) and restores `hasVat`/`whtFormType`/`vatAccount` auto-fill from the supplier (accounting-correct).
- **Repair center** (`RepairCenterCombobox`) → thin ContactCombobox wrapper; on pick/create it tags the Supplier `isRepairCenter=true` (`PATCH /suppliers/:id`; `UpdateSupplierDto` gained the field). Shows all contacts (tag-on-use).
- **Purchase Order** supplier `<select>` → ContactCombobox; on select invalidates `['suppliers-for-po']` then sets `supplierId`; VAT/payment-method recompute from the refreshed cache. Added a `handleCreate` guard (`กรุณาเลือกผู้ขาย`).
- PettyCash per-line vendor was already converted in P0 (uses VendorCombobox = ContactCombobox v2).
- **Review fixes applied:** PO supplier-required guard (hidden `required` was a no-op), asset VAT/WHT auto-fill restore, empty-vendorId guard, repair-center tag-failure toast.

## Test Plan
- [ ] Web: `cd apps/web && npx vitest run src/pages/assets src/pages/insurance src/pages/PurchaseOrdersPage src/components/contacts` → green
- [ ] API: `cd apps/api && npx jest --runInBand src/modules/suppliers` → green
- [ ] Types: `./tools/check-types.sh all`
- [ ] Manual: in each field (asset vendor, repair center, PO supplier) — pick existing contact AND type-a-new-name → create modal → real Supplier created, no free-text possible. Asset: VAT/WHT auto-fills for a JURISTIC VAT supplier.

## Known follow-ups (non-blocking)
- Repair-center field shows ALL contacts and tags on pick with no confirmation step — deliberate per the epic's tag-on-use model; consider a confirm if a customer-only contact is picked.
- Recurring pattern: several pickers do a `contactsApi.detail` round-trip to read supplier `type`/`hasVat` after pick — a future improvement is to return those from `ensureRole`/the list payload.

## Stacking
Base = `feat/party-master-mandatory-p0` (#1144). Merge P0 first; GitHub will retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)