### PR TITLE
feat(contacts): Party Master Mandatory P3+P4 — durable expense vendor FK + cleanup

### DIFF
--- a/apps/api/prisma/migrations/20260968000000_add_expense_vendor_supplier_fk/migration.sql
+++ b/apps/api/prisma/migrations/20260968000000_add_expense_vendor_supplier_fk/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "expense_documents" ADD COLUMN     "vendor_supplier_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "expense_lines" ADD COLUMN     "supplier_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "expense_documents_vendor_supplier_id_idx" ON "expense_documents"("vendor_supplier_id");
+
+-- CreateIndex
+CREATE INDEX "expense_lines_supplier_id_idx" ON "expense_lines"("supplier_id");
+
+-- AddForeignKey
+ALTER TABLE "expense_documents" ADD CONSTRAINT "expense_documents_vendor_supplier_id_fkey" FOREIGN KEY ("vendor_supplier_id") REFERENCES "suppliers"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "expense_lines" ADD CONSTRAINT "expense_lines_supplier_id_fkey" FOREIGN KEY ("supplier_id") REFERENCES "suppliers"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1422,6 +1422,11 @@ model Supplier {
   fixedAssets    FixedAsset[]            @relation("FixedAssetVendor")
   repairTickets  RepairTicket[]          @relation("RepairCenterTickets")
 
+  // Party-master link (Phase 3 P3) — durable FK from expense docs/lines that
+  // previously stored the vendor as free text only. Nullable on the expense side.
+  expenseDocuments ExpenseDocument[] @relation("ExpenseVendor")
+  expenseLines     ExpenseLine[]     @relation("ExpenseLineSupplier")
+
   // Unified contact party master (Phase 3) — nullable upward ref
   contactId String?  @map("contact_id")
   contact   Contact? @relation(fields: [contactId], references: [id])
@@ -3803,6 +3808,11 @@ model ExpenseDocument {
   documentDate DateTime     @map("document_date")
   vendorName   String?      @map("vendor_name")
   vendorTaxId  String?      @map("vendor_tax_id")
+  /// Party-master link (Phase 3 P3) — durable FK to the provisioned Supplier
+  /// behind `vendorName`. Nullable: several subtypes (payroll/custodian,
+  /// template, credit-note, settlement) legitimately set vendorName as free
+  /// text with no supplier, so no required-FK guard is enforced.
+  vendorSupplierId String?   @map("vendor_supplier_id")
   taxInvoiceNo String?      @map("tax_invoice_no")
   description  String?
 
@@ -3852,10 +3862,11 @@ model ExpenseDocument {
   updatedAt    DateTime  @updatedAt @map("updated_at")
   deletedAt    DateTime? @map("deleted_at")
 
-  branch       Branch           @relation(fields: [branchId], references: [id], onDelete: Restrict)
-  createdBy    User             @relation("ExpenseDocumentCreator", fields: [createdById], references: [id])
-  approvedBy   User?            @relation("ExpenseDocumentApprover", fields: [approvedById], references: [id])
-  fromTemplate ExpenseTemplate? @relation("ExpenseDocumentFromTemplate", fields: [fromTemplateId], references: [id], onDelete: SetNull)
+  branch         Branch           @relation(fields: [branchId], references: [id], onDelete: Restrict)
+  createdBy      User             @relation("ExpenseDocumentCreator", fields: [createdById], references: [id])
+  approvedBy     User?            @relation("ExpenseDocumentApprover", fields: [approvedById], references: [id])
+  fromTemplate   ExpenseTemplate? @relation("ExpenseDocumentFromTemplate", fields: [fromTemplateId], references: [id], onDelete: SetNull)
+  vendorSupplier Supplier?        @relation("ExpenseVendor", fields: [vendorSupplierId], references: [id])
 
   // SP5 Phase 2 — optional back-link to repair ticket that auto-created this doc
   repairTicket RepairTicket?
@@ -3867,6 +3878,7 @@ model ExpenseDocument {
   @@index([status, createdAt(sort: Desc)])
   @@index([fromTemplateId])
   @@index([taxDisallowed, deletedAt])
+  @@index([vendorSupplierId])
   @@map("expense_documents")
 }
 
@@ -3901,6 +3913,10 @@ model ExpenseLine {
   /// document carries receipts from multiple suppliers (relaxes 1-doc-1-supplier).
   /// For other DocumentTypes the doc-level `vendorName` is used and this stays null.
   supplierName    String?       @map("supplier_name")
+  /// Party-master link (Phase 3 P3) — durable FK to the provisioned Supplier
+  /// behind `supplierName`. Nullable: lines without a resolved supplier keep
+  /// just the free-text name.
+  supplierId      String?       @map("supplier_id")
   amountBeforeVat Decimal       @map("amount_before_vat") @db.Decimal(12, 2)
   vatAmount       Decimal       @default(0) @map("vat_amount") @db.Decimal(12, 2)
   whtAmount       Decimal       @default(0) @map("wht_amount") @db.Decimal(12, 2)
@@ -3915,7 +3931,10 @@ model ExpenseLine {
   createdAt       DateTime      @default(now()) @map("created_at")
   updatedAt       DateTime      @updatedAt @map("updated_at")
 
+  supplier        Supplier?     @relation("ExpenseLineSupplier", fields: [supplierId], references: [id])
+
   @@unique([expenseDetailId, lineNo])
+  @@index([supplierId])
   @@map("expense_lines")
 }
 

--- a/apps/api/src/modules/customers/customers.service.spec.ts
+++ b/apps/api/src/modules/customers/customers.service.spec.ts
@@ -458,6 +458,8 @@ describe('CustomersService.create — links Contact (party master)', () => {
     // customer ops the service uses; create/update echo their data back.
     const tx = {
       customer: {
+        // P4: stub-upgrade guard calls findFirst inside the tx; return null (no stub)
+        findFirst: jest.fn().mockResolvedValue(null),
         create: jest.fn((args) => Promise.resolve({ id: 'cust-new', ...args.data })),
         update: jest.fn((args) => Promise.resolve({ id: args.where.id, ...args.data })),
       },
@@ -527,5 +529,122 @@ describe('CustomersService.create — links Contact (party master)', () => {
     const [, input] = contactResolver.findOrCreateByNaturalKey.mock.calls[0];
     expect(input.role).toBe('CUSTOMER');
     expect(input.nationalIdHash ?? null).toBeNull();
+  });
+});
+
+/**
+ * P4 Cleanup 2 — stub-upgrade guard.
+ * When ensureRole creates a lightweight Customer stub (phone:'', no hashes),
+ * a subsequent /customers create for the same person must UPGRADE the stub
+ * (update in place) rather than create a second Customer row on the same
+ * contactId. The upgrade must populate full PII-encrypted fields.
+ */
+describe('CustomersService.create — stub-upgrade guard (P4)', () => {
+  let service: CustomersService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  beforeEach(async () => {
+    process.env.PII_ENCRYPTION_KEY = 'a'.repeat(64);
+    process.env.PII_HASH_SALT = 'b'.repeat(32);
+
+    const tx = {
+      customer: {
+        // findFirst returns null by default (no stub) — individual tests override.
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn((args) => Promise.resolve({ id: 'cust-new', ...args.data })),
+        update: jest.fn((args) => Promise.resolve({ id: args.where?.id ?? 'stub-id', ...args.data })),
+      },
+    };
+    prisma = {
+      customer: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn((args) => Promise.resolve({ id: 'cust-new', ...args.data })),
+        update: jest.fn((args) => Promise.resolve({ id: args.where?.id, ...args.data })),
+      },
+      $transaction: jest.fn((cb: (t: typeof tx) => unknown) => Promise.resolve(cb(tx))),
+      _tx: tx,
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        CustomersService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CustomerTierService, useValue: { getCustomerTier: jest.fn() } },
+        {
+          provide: ContactResolverService,
+          useValue: { findOrCreateByNaturalKey: jest.fn().mockResolvedValue({ id: 'contact-stub' }) },
+        },
+      ],
+    }).compile();
+    service = mod.get(CustomersService);
+  });
+
+  afterEach(() => {
+    delete process.env.PII_ENCRYPTION_KEY;
+    delete process.env.PII_HASH_SALT;
+  });
+
+  const baseDto = (overrides: Record<string, unknown> = {}) => ({
+    name: 'Stub Person',
+    nationalId: '1234567890123',
+    isForeigner: true, // skip checksum
+    phone: '0812345678',
+    ...overrides,
+  }) as unknown as Parameters<CustomersService['create']>[0];
+
+  it('creates a new Customer row when no stub exists for the resolved contactId', async () => {
+    // tx.customer.findFirst returns null → no stub
+    await service.create(baseDto());
+
+    expect(prisma._tx.customer.create).toHaveBeenCalledTimes(1);
+    expect(prisma._tx.customer.update).not.toHaveBeenCalled();
+    const createArgs = prisma._tx.customer.create.mock.calls[0][0];
+    expect(createArgs.data.contact).toEqual({ connect: { id: 'contact-stub' } });
+  });
+
+  it('upgrades the stub (update in place) when a Customer row already exists for that contactId', async () => {
+    // Simulate a pre-existing stub created by ensureRole
+    prisma._tx.customer.findFirst.mockResolvedValue({ id: 'stub-existing-id' });
+
+    await service.create(baseDto());
+
+    // Must update the stub, not create a second row
+    expect(prisma._tx.customer.create).not.toHaveBeenCalled();
+    expect(prisma._tx.customer.update).toHaveBeenCalledTimes(1);
+    const updateArgs = prisma._tx.customer.update.mock.calls[0][0];
+    expect(updateArgs.where).toEqual({ id: 'stub-existing-id' });
+    // Full contact link is applied on the upgrade
+    expect(updateArgs.data.contact).toEqual({ connect: { id: 'contact-stub' } });
+  });
+
+  it('populates PII-encrypted fields on the stub upgrade path', async () => {
+    prisma._tx.customer.findFirst.mockResolvedValue({ id: 'stub-existing-id' });
+
+    await service.create(baseDto());
+
+    const updateArgs = prisma._tx.customer.update.mock.calls[0][0];
+    // Encrypted columns must be written — format: iv:tag:cipher hex
+    expect(updateArgs.data.phoneEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+    expect(updateArgs.data.nationalIdEncrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+    // Hash columns must be written — sha256 = 64 hex chars
+    expect(updateArgs.data.phoneHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(updateArgs.data.nationalIdHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('stub lookup uses contactId + deletedAt:null filter', async () => {
+    await service.create(baseDto());
+
+    const findFirstCalls = prisma._tx.customer.findFirst.mock.calls;
+    expect(findFirstCalls.length).toBeGreaterThanOrEqual(1);
+    const stubLookup = findFirstCalls.find(
+      (c: unknown[]) =>
+        (c[0] as { where?: { contactId?: string } })?.where?.contactId === 'contact-stub',
+    );
+    expect(stubLookup).toBeDefined();
+    expect(
+      (stubLookup![0] as { where: { deletedAt: null } }).where.deletedAt,
+    ).toBeNull();
   });
 });

--- a/apps/api/src/modules/customers/customers.service.ts
+++ b/apps/api/src/modules/customers/customers.service.ts
@@ -631,6 +631,25 @@ export class CustomersService {
           data: { ...(data as Prisma.CustomerUpdateInput), contact: contactConnect, deletedAt: null },
         });
       }
+      // Stub-upgrade guard: ensureRole creates a lightweight Customer stub
+      // (phone:'', no phoneHash/nationalIdHash) that is invisible to the
+      // normalId/phone dedup checks above. If a proper /customers create is
+      // called later for the same person, we must UPGRADE the stub rather than
+      // create a second Customer row on the same contact (Customer.contactId
+      // is not @unique, so Prisma would silently allow a second row).
+      const existingStub = await tx.customer.findFirst({
+        where: { contactId: contact.id, deletedAt: null },
+        select: { id: true },
+      });
+      if (existingStub) {
+        // Upgrade the stub: overwrite with full create data (including all
+        // PII-encrypted fields) — same logic as a regular create, just on
+        // an existing row.
+        return tx.customer.update({
+          where: { id: existingStub.id },
+          data: { ...(data as Prisma.CustomerUpdateInput), contact: contactConnect },
+        });
+      }
       return tx.customer.create({ data: { ...data, contact: contactConnect } });
     });
   }

--- a/apps/api/src/modules/expense-documents/__tests__/multi-line-create.service.spec.ts
+++ b/apps/api/src/modules/expense-documents/__tests__/multi-line-create.service.spec.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { ExpenseDocumentsService } from '../expense-documents.service';
 import { LineAggregatorService } from '../services/line-aggregator.service';
 
@@ -28,6 +29,8 @@ describe('ExpenseDocumentsService.create — multi-line', () => {
           { code: '53-1404', type: 'ค่าใช้จ่าย' },
         ]),
       },
+      // readBoolFlag('petty_cash_enabled', true) → null row ⇒ default true
+      systemConfig: { findFirst: jest.fn().mockResolvedValue(null) },
     };
     aggregator = new LineAggregatorService();
     service = new ExpenseDocumentsService(
@@ -44,7 +47,14 @@ describe('ExpenseDocumentsService.create — multi-line', () => {
       { preview: jest.fn() } as never,
       { validateContribution: jest.fn().mockResolvedValue(undefined) } as never,
       { execute: jest.fn() } as never,
-      { getConfig: jest.fn(), validate: jest.fn() } as never,
+      {
+        getConfig: jest.fn().mockResolvedValue({
+          account: '11-1103',
+          limit: new Prisma.Decimal('5000'),
+          replenishThreshold: null,
+        }),
+        validate: jest.fn(),
+      } as never,
       { loadWhitelist: jest.fn().mockResolvedValue(new Set()), validateLine: jest.fn() } as never,
       { send: jest.fn().mockResolvedValue({ id: 'notif-1', status: 'SENT' }) } as never,
     );
@@ -83,5 +93,58 @@ describe('ExpenseDocumentsService.create — multi-line', () => {
         { category: '53-9999', quantity: 1, unitPrice: 100, vatPercent: 7, whtPercent: 0 },
       ],
     } as never, 'user-1')).rejects.toThrow(/53-9999.*ไม่พบ/);
+  });
+
+  // Party-master link (Phase 3 P3) — durable supplier FK persistence.
+  it('persists doc-level vendorSupplierId when provided (party-master link)', async () => {
+    await service.create({
+      documentType: 'EXPENSE',
+      branchId: 'b1',
+      documentDate: '2026-05-11',
+      priceType: 'EXCLUSIVE',
+      vendorName: 'ร้านค้า A',
+      vendorSupplierId: 'sup-123',
+      lines: [
+        { category: '53-1101', quantity: 1, unitPrice: 5000, vatPercent: 7, whtPercent: 0 },
+      ],
+    } as never, 'user-1');
+
+    const callArg = prisma.expenseDocument.create.mock.calls[0][0];
+    expect(callArg.data.vendorSupplierId).toBe('sup-123');
+    expect(callArg.data.vendorName).toBe('ร้านค้า A');
+  });
+
+  it('defaults vendorSupplierId to null when omitted', async () => {
+    await service.create({
+      documentType: 'EXPENSE',
+      branchId: 'b1',
+      documentDate: '2026-05-11',
+      priceType: 'EXCLUSIVE',
+      lines: [
+        { category: '53-1101', quantity: 1, unitPrice: 5000, vatPercent: 7, whtPercent: 0 },
+      ],
+    } as never, 'user-1');
+
+    const callArg = prisma.expenseDocument.create.mock.calls[0][0];
+    expect(callArg.data.vendorSupplierId).toBeNull();
+  });
+
+  it('persists per-line supplierId on petty-cash lines (party-master link)', async () => {
+    await service.createPettyCash({
+      branchId: 'b1',
+      documentDate: '2026-05-11',
+      depositAccountCode: '11-1103',
+      custodianName: 'พนักงาน X',
+      lines: [
+        { supplierName: 'ร้าน A', supplierId: 'sup-aaa', category: '53-1101', amount: 100, vatPercent: 0 },
+        { supplierName: 'ร้าน B', category: '53-1101', amount: 50, vatPercent: 0 },
+      ],
+    } as never, { id: 'user-1', branchId: 'b1', role: 'OWNER' });
+
+    const callArg = prisma.expenseDocument.create.mock.calls[0][0];
+    const createdLines = callArg.data.expenseDetail.create.lines.create;
+    expect(createdLines[0].supplierId).toBe('sup-aaa');
+    // line without a resolved supplier persists null (free-text name only)
+    expect(createdLines[1].supplierId).toBeNull();
   });
 });

--- a/apps/api/src/modules/expense-documents/dto/create-credit-note.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-credit-note.dto.ts
@@ -57,6 +57,14 @@ export class CreateCreditNoteDto {
   @MaxLength(20)
   vendorTaxId?: string;
 
+  /**
+   * Party-master link (Phase 3 P3). Durable FK to the Supplier behind
+   * `vendorName` (STANDALONE mode). Optional.
+   */
+  @IsString()
+  @IsOptional()
+  vendorSupplierId?: string;
+
   @IsString()
   @MinLength(3, { message: 'เหตุผลต้องมีอย่างน้อย 3 ตัวอักษร' })
   reason!: string;

--- a/apps/api/src/modules/expense-documents/dto/create-petty-cash.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-petty-cash.dto.ts
@@ -30,6 +30,14 @@ class PettyCashLineInput {
   @MinLength(2, { message: 'ชื่อผู้ขาย/ผู้รับเงินต้องมีอย่างน้อย 2 ตัวอักษร' })
   supplierName!: string;
 
+  /**
+   * Party-master link (Phase 3 P3). Durable FK to the Supplier the UI picker
+   * provisioned for `supplierName`. Optional.
+   */
+  @IsString()
+  @IsOptional()
+  supplierId?: string;
+
   /** CoA code — must be type='ค่าใช้จ่าย' (53-xxxx range typically). */
   @IsString()
   @Matches(/^\d{2}-\d{4}$/, { message: 'หมวดบัญชีต้องเป็นรูปแบบ XX-XXXX' })

--- a/apps/api/src/modules/expense-documents/dto/create-settlement.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-settlement.dto.ts
@@ -34,6 +34,14 @@ export class CreateSettlementDto {
   @IsOptional()
   vendorName?: string;
 
+  /**
+   * Party-master link (Phase 3 P3). Durable FK to the Supplier behind
+   * `vendorName`. Optional.
+   */
+  @IsString()
+  @IsOptional()
+  vendorSupplierId?: string;
+
   @IsString()
   @IsOptional()
   description?: string;

--- a/apps/api/src/modules/expense-documents/dto/create.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create.dto.ts
@@ -34,6 +34,15 @@ export class CreateExpenseDocumentDto {
   @IsOptional()
   vendorTaxId?: string;
 
+  /**
+   * Party-master link (Phase 3 P3). Durable FK to the Supplier the UI picker
+   * provisioned for `vendorName`. Optional — no required-FK guard (several
+   * subtypes set vendorName programmatically with no supplier).
+   */
+  @IsString()
+  @IsOptional()
+  vendorSupplierId?: string;
+
   @IsString()
   @IsOptional()
   taxInvoiceNo?: string;

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -496,6 +496,8 @@ export class ExpenseDocumentsService implements OnModuleInit {
           documentDate,
           vendorName: dto.vendorName ?? null,
           vendorTaxId: dto.vendorTaxId ?? null,
+          // Party-master link (Phase 3 P3) — durable FK when the picker resolved a supplier.
+          vendorSupplierId: dto.vendorSupplierId ?? null,
           taxInvoiceNo: dto.taxInvoiceNo ?? null,
           description: dto.description ?? null,
           subtotal: totals.subtotal,
@@ -694,6 +696,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
       // STANDALONE-mode skips this — there is no source document.
       let originalVendorName: string | null = null;
       let originalVendorTaxId: string | null = null;
+      let originalVendorSupplierId: string | null = null;
       if (mode === 'LINKED') {
         // I2 fix — acquire the advisory lock BEFORE loading the original so a
         // concurrent void/edit can't slip between the read and the cap check.
@@ -748,6 +751,8 @@ export class ExpenseDocumentsService implements OnModuleInit {
         // Inherit vendor info from source for traceability on the CN doc.
         originalVendorName = original.vendorName;
         originalVendorTaxId = original.vendorTaxId;
+        // Party-master link (Phase 3 P3) — carry the source doc's supplier FK forward.
+        originalVendorSupplierId = original.vendorSupplierId;
       }
 
       const documentDate = new Date(dto.documentDate);
@@ -764,6 +769,9 @@ export class ExpenseDocumentsService implements OnModuleInit {
             mode === 'STANDALONE' ? (dto.vendorName?.trim() ?? null) : originalVendorName,
           vendorTaxId:
             mode === 'STANDALONE' ? (dto.vendorTaxId?.trim() ?? null) : originalVendorTaxId,
+          // Party-master link (Phase 3 P3) — STANDALONE from DTO, LINKED from source.
+          vendorSupplierId:
+            mode === 'STANDALONE' ? (dto.vendorSupplierId ?? null) : originalVendorSupplierId,
           description: dto.description ?? null,
           subtotal: totals.subtotal,
           vatAmount: totals.vatAmount,
@@ -1122,6 +1130,8 @@ export class ExpenseDocumentsService implements OnModuleInit {
           branchId: dto.branchId,
           documentDate,
           vendorName: dto.vendorName ?? null,
+          // Party-master link (Phase 3 P3) — durable FK to the settled supplier.
+          vendorSupplierId: dto.vendorSupplierId ?? null,
           description: dto.description ?? null,
           subtotal: sumSettled,
           vatAmount: new Prisma.Decimal(0),
@@ -1202,6 +1212,8 @@ export class ExpenseDocumentsService implements OnModuleInit {
         category: l.category,
         description: l.description ?? null,
         supplierName: l.supplierName,
+        // Party-master link (Phase 3 P3) — durable FK to the per-line supplier.
+        supplierId: l.supplierId ?? null,
         quantity: new Prisma.Decimal(1),
         unitPrice: base,
         discount: new Prisma.Decimal(0),
@@ -1283,6 +1295,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
                   category: l.category,
                   description: l.description,
                   supplierName: l.supplierName,
+                  supplierId: l.supplierId,
                   quantity: l.quantity,
                   unitPrice: l.unitPrice,
                   discount: l.discount,
@@ -1910,6 +1923,12 @@ export class ExpenseDocumentsService implements OnModuleInit {
       if (dto.documentDate) data.documentDate = new Date(dto.documentDate);
       if (dto.vendorName !== undefined) data.vendorName = dto.vendorName;
       if (dto.vendorTaxId !== undefined) data.vendorTaxId = dto.vendorTaxId;
+      // Party-master link (Phase 3 P3) — set/clear the supplier FK on edit.
+      if (dto.vendorSupplierId !== undefined) {
+        data.vendorSupplier = dto.vendorSupplierId
+          ? { connect: { id: dto.vendorSupplierId } }
+          : { disconnect: true };
+      }
       if (dto.taxInvoiceNo !== undefined) data.taxInvoiceNo = dto.taxInvoiceNo;
       if (dto.description !== undefined) data.description = dto.description;
       if (dto.whtFormType !== undefined) data.whtFormType = dto.whtFormType;

--- a/apps/web/src/components/contacts/ContactCombobox.tsx
+++ b/apps/web/src/components/contacts/ContactCombobox.tsx
@@ -47,13 +47,6 @@ interface Props {
   roleNeeded: 'SUPPLIER' | 'CUSTOMER' | 'TRADE_IN_SELLER';
   value: string;
   onSelect: (result: ContactPickResult) => void;
-  /**
-   * @deprecated Since v2 the free-text one-off path has been replaced by an
-   * inline "สร้างผู้ติดต่อใหม่" action that opens CreateContactModal.
-   * This prop is kept for back-compat so existing callers (e.g. VendorCombobox)
-   * continue to typecheck, but it is no longer called.
-   */
-  onTypeName?: (name: string) => void;
   invalid?: boolean;
   placeholder?: string;
 }
@@ -62,11 +55,8 @@ export function ContactCombobox({
   roleNeeded,
   value,
   onSelect,
-  // onTypeName kept for back-compat typecheck — intentionally unused (see @deprecated above)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onTypeName: _onTypeName,
   invalid,
-  placeholder = 'เลือกผู้ติดต่อ หรือพิมพ์ชื่อ',
+  placeholder = 'เลือก/ค้นหาผู้ติดต่อ',
 }: Props) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');

--- a/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
+++ b/apps/web/src/components/expense-form-v4/ExpenseFormV4.tsx
@@ -57,6 +57,7 @@ const initial = (branchId: string, defaultCash: string): ExpenseFormState => {
     documentDate: todayBkkIso(),
     vendorName: '',
     vendorTaxId: '',
+    vendorSupplierId: '',
     taxInvoiceNo: '',
     priceType: 'EXCLUSIVE',
     whtFormType: '',
@@ -80,6 +81,7 @@ const initial = (branchId: string, defaultCash: string): ExpenseFormState => {
     settlement: {
       selections: new Map(),
       vendorName: '',
+      vendorSupplierId: '',
       whtAmount: '0',
       whtFormType: '',
     },
@@ -161,6 +163,7 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
           priceType: state.priceType,
           vendorName: state.vendorName || undefined,
           vendorTaxId: state.vendorTaxId || undefined,
+          vendorSupplierId: state.vendorSupplierId || undefined,
           taxInvoiceNo: state.taxInvoiceNo || undefined,
           whtFormType: state.whtFormType || undefined,
           paymentMethod: state.docType === 'EXPENSE_SAMEDAY' ? state.paymentMethod : undefined,
@@ -259,6 +262,7 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
           depositAccountCode: state.depositAccountCode,
           paymentMethod: 'BANK_TRANSFER',
           vendorName: state.settlement.vendorName || undefined,
+          vendorSupplierId: state.settlement.vendorSupplierId || undefined,
           whtFormType: state.settlement.whtFormType || undefined,
           withholdingTax: parseFloat(state.settlement.whtAmount) || undefined,
           lines: [...state.settlement.selections.values()].map((s) => ({
@@ -294,6 +298,7 @@ export function ExpenseFormV4({ branchId, onClose, onSaved }: Props) {
           description: state.note || undefined,
           lines: validLines.map((l) => ({
             supplierName: l.supplierName.trim(),
+            supplierId: l.supplierId || undefined,
             category: l.category,
             description: l.description || undefined,
             amount: parseFloat(l.amount),

--- a/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
@@ -94,7 +94,6 @@ export function PettyCashLinesSection({ value, onChange }: Props) {
                     onSelectSupplier={(s) =>
                       updateLine(l.uid, { supplierName: s.name, supplierId: s.supplierId })
                     }
-                    onTypeName={(name) => updateLine(l.uid, { supplierName: name, supplierId: '' })}
                   />
                 </td>
                 <td className="px-2 py-1.5">

--- a/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/PettyCashLinesSection.tsx
@@ -91,8 +91,10 @@ export function PettyCashLinesSection({ value, onChange }: Props) {
                 <td className="px-2 py-1.5">
                   <VendorCombobox
                     value={l.supplierName}
-                    onSelectSupplier={(s) => updateLine(l.uid, { supplierName: s.name })}
-                    onTypeName={(name) => updateLine(l.uid, { supplierName: name })}
+                    onSelectSupplier={(s) =>
+                      updateLine(l.uid, { supplierName: s.name, supplierId: s.supplierId })
+                    }
+                    onTypeName={(name) => updateLine(l.uid, { supplierName: name, supplierId: '' })}
                   />
                 </td>
                 <td className="px-2 py-1.5">

--- a/apps/web/src/components/expense-form-v4/SettlementLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/SettlementLinesSection.tsx
@@ -163,10 +163,11 @@ export function SettlementLinesSection({ branchId, value, onChange }: Props) {
               onChange({
                 ...value,
                 vendorName: s.name,
+                vendorSupplierId: s.supplierId,
                 ...(s.whtFormType ? { whtFormType: s.whtFormType } : {}),
               })
             }
-            onTypeName={(name) => onChange({ ...value, vendorName: name })}
+            onTypeName={(name) => onChange({ ...value, vendorName: name, vendorSupplierId: '' })}
           />
         </div>
         <div>

--- a/apps/web/src/components/expense-form-v4/SettlementLinesSection.tsx
+++ b/apps/web/src/components/expense-form-v4/SettlementLinesSection.tsx
@@ -167,7 +167,6 @@ export function SettlementLinesSection({ branchId, value, onChange }: Props) {
                 ...(s.whtFormType ? { whtFormType: s.whtFormType } : {}),
               })
             }
-            onTypeName={(name) => onChange({ ...value, vendorName: name, vendorSupplierId: '' })}
           />
         </div>
         <div>

--- a/apps/web/src/components/expense-form-v4/VendorCombobox.test.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorCombobox.test.tsx
@@ -28,7 +28,7 @@ describe('VendorCombobox.handleSelect WHT mapping', () => {
   it('maps a JURISTIC supplier to PND53, overrides taxId from the supplier link, and passes supplierId', async () => {
     detailMock.mockResolvedValue({ suppliers: [{ type: 'JURISTIC', taxId: '9999' }] });
     const onSelectSupplier = vi.fn();
-    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
+    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} />);
 
     await userEvent.click(screen.getByText('pick'));
 
@@ -45,7 +45,7 @@ describe('VendorCombobox.handleSelect WHT mapping', () => {
   it('maps an INDIVIDUAL supplier to PND3, keeps the picked taxId, and passes supplierId', async () => {
     detailMock.mockResolvedValue({ suppliers: [{ type: 'INDIVIDUAL', taxId: null }] });
     const onSelectSupplier = vi.fn();
-    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
+    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} />);
 
     await userEvent.click(screen.getByText('pick'));
 
@@ -62,7 +62,7 @@ describe('VendorCombobox.handleSelect WHT mapping', () => {
   it('falls back to the picked values (no whtFormType) when the detail lookup fails, still passes supplierId', async () => {
     detailMock.mockRejectedValue(new Error('boom'));
     const onSelectSupplier = vi.fn();
-    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
+    render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} />);
 
     await userEvent.click(screen.getByText('pick'));
 

--- a/apps/web/src/components/expense-form-v4/VendorCombobox.test.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorCombobox.test.tsx
@@ -25,7 +25,7 @@ beforeEach(() => {
 });
 
 describe('VendorCombobox.handleSelect WHT mapping', () => {
-  it('maps a JURISTIC supplier to PND53 and overrides taxId from the supplier link', async () => {
+  it('maps a JURISTIC supplier to PND53, overrides taxId from the supplier link, and passes supplierId', async () => {
     detailMock.mockResolvedValue({ suppliers: [{ type: 'JURISTIC', taxId: '9999' }] });
     const onSelectSupplier = vi.fn();
     render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
@@ -36,12 +36,13 @@ describe('VendorCombobox.handleSelect WHT mapping', () => {
       expect(onSelectSupplier).toHaveBeenCalledWith({
         name: 'ABC Co',
         taxId: '9999',
+        supplierId: 'sup1',
         whtFormType: 'PND53',
       }),
     );
   });
 
-  it('maps an INDIVIDUAL supplier to PND3 and keeps the picked taxId when the link has none', async () => {
+  it('maps an INDIVIDUAL supplier to PND3, keeps the picked taxId, and passes supplierId', async () => {
     detailMock.mockResolvedValue({ suppliers: [{ type: 'INDIVIDUAL', taxId: null }] });
     const onSelectSupplier = vi.fn();
     render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
@@ -52,12 +53,13 @@ describe('VendorCombobox.handleSelect WHT mapping', () => {
       expect(onSelectSupplier).toHaveBeenCalledWith({
         name: 'ABC Co',
         taxId: '0105',
+        supplierId: 'sup1',
         whtFormType: 'PND3',
       }),
     );
   });
 
-  it('falls back to the picked values (no whtFormType) when the detail lookup fails', async () => {
+  it('falls back to the picked values (no whtFormType) when the detail lookup fails, still passes supplierId', async () => {
     detailMock.mockRejectedValue(new Error('boom'));
     const onSelectSupplier = vi.fn();
     render(<VendorCombobox value="" onSelectSupplier={onSelectSupplier} onTypeName={vi.fn()} />);
@@ -68,6 +70,7 @@ describe('VendorCombobox.handleSelect WHT mapping', () => {
       expect(onSelectSupplier).toHaveBeenCalledWith({
         name: 'ABC Co',
         taxId: '0105',
+        supplierId: 'sup1',
         whtFormType: undefined,
       }),
     );

--- a/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
@@ -3,13 +3,19 @@
 // ALL roles; picking a contact provisions the SUPPLIER role via ensure-role). A
 // typed name that matches no contact is still committed as a one-off vendor,
 // preserving the legacy free-text flow. The expense stores vendorName/vendorTaxId
-// as before — no FK — so this slice only adds the party-master link side effect.
+// as before; supplierId (the provisioned Supplier FK) is now surfaced so the
+// form can persist vendorSupplierId (doc-level) and per-line supplierId.
 import { contactsApi } from '@/lib/api/contacts';
 import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
 
 interface Props {
   value: string;
-  onSelectSupplier: (s: { name: string; taxId: string; whtFormType?: 'PND3' | 'PND53' }) => void;
+  onSelectSupplier: (s: {
+    name: string;
+    taxId: string;
+    supplierId: string;
+    whtFormType?: 'PND3' | 'PND53';
+  }) => void;
   onTypeName?: (name: string) => void;
   invalid?: boolean;
 }
@@ -18,7 +24,9 @@ export function VendorCombobox({ value, onSelectSupplier, onTypeName, invalid }:
   // On pick: ensure-role already ran inside ContactCombobox (a Supplier row now
   // exists). Read the supplier link's type to map JURISTIC→PND53 / INDIVIDUAL→PND3
   // so "ประเภทผู้ขาย" auto-fills; fall back to the list values if detail fails.
-  const handleSelect = async ({ contactId, name, taxId }: ContactPickResult) => {
+  // childId is the provisioned Supplier id returned by ContactCombobox when
+  // roleNeeded="SUPPLIER" — always present after ensure-role.
+  const handleSelect = async ({ contactId, childId, name, taxId }: ContactPickResult) => {
     let whtFormType: 'PND3' | 'PND53' | undefined;
     let resolvedTaxId = taxId;
     try {
@@ -31,7 +39,7 @@ export function VendorCombobox({ value, onSelectSupplier, onTypeName, invalid }:
     } catch {
       // keep the list values when the detail lookup fails
     }
-    onSelectSupplier({ name, taxId: resolvedTaxId, whtFormType });
+    onSelectSupplier({ name, taxId: resolvedTaxId, supplierId: childId ?? '', whtFormType });
   };
 
   return (

--- a/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorCombobox.tsx
@@ -1,10 +1,11 @@
 // Expense form V4 — vendor picker.
-// Thin wrapper over the shared ContactCombobox (searches the contact book across
-// ALL roles; picking a contact provisions the SUPPLIER role via ensure-role). A
-// typed name that matches no contact is still committed as a one-off vendor,
-// preserving the legacy free-text flow. The expense stores vendorName/vendorTaxId
-// as before; supplierId (the provisioned Supplier FK) is now surfaced so the
-// form can persist vendorSupplierId (doc-level) and per-line supplierId.
+// Thin wrapper over the shared ContactCombobox (searches the party master across
+// ALL roles; picking a contact provisions the SUPPLIER role via ensure-role).
+// Typing a name with no match shows an inline "+ สร้างผู้ติดต่อใหม่" action that
+// opens CreateContactModal. No free-text one-off path — every vendor must be a
+// real Supplier contact. The expense stores vendorName/vendorTaxId as before;
+// supplierId (the provisioned Supplier FK) is surfaced so the form can persist
+// vendorSupplierId (doc-level) and per-line supplierId.
 import { contactsApi } from '@/lib/api/contacts';
 import { ContactCombobox, type ContactPickResult } from '@/components/contacts/ContactCombobox';
 
@@ -16,11 +17,10 @@ interface Props {
     supplierId: string;
     whtFormType?: 'PND3' | 'PND53';
   }) => void;
-  onTypeName?: (name: string) => void;
   invalid?: boolean;
 }
 
-export function VendorCombobox({ value, onSelectSupplier, onTypeName, invalid }: Props) {
+export function VendorCombobox({ value, onSelectSupplier, invalid }: Props) {
   // On pick: ensure-role already ran inside ContactCombobox (a Supplier row now
   // exists). Read the supplier link's type to map JURISTIC→PND53 / INDIVIDUAL→PND3
   // so "ประเภทผู้ขาย" auto-fills; fall back to the list values if detail fails.
@@ -47,9 +47,8 @@ export function VendorCombobox({ value, onSelectSupplier, onTypeName, invalid }:
       roleNeeded="SUPPLIER"
       value={value}
       invalid={invalid}
-      placeholder="เลือกผู้ขาย หรือพิมพ์ชื่อ"
+      placeholder="เลือก/ค้นหาผู้ขาย"
       onSelect={handleSelect}
-      onTypeName={onTypeName}
     />
   );
 }

--- a/apps/web/src/components/expense-form-v4/VendorSection.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorSection.tsx
@@ -20,10 +20,11 @@ export function VendorSection({ state, onChange }: Props) {
               onChange({
                 vendorName: s.name,
                 vendorTaxId: s.taxId,
+                vendorSupplierId: s.supplierId,
                 ...(s.whtFormType ? { whtFormType: s.whtFormType } : {}),
               })
             }
-            onTypeName={(name) => onChange({ vendorName: name })}
+            onTypeName={(name) => onChange({ vendorName: name, vendorSupplierId: '' })}
           />
         </div>
         <div>

--- a/apps/web/src/components/expense-form-v4/VendorSection.tsx
+++ b/apps/web/src/components/expense-form-v4/VendorSection.tsx
@@ -24,7 +24,6 @@ export function VendorSection({ state, onChange }: Props) {
                 ...(s.whtFormType ? { whtFormType: s.whtFormType } : {}),
               })
             }
-            onTypeName={(name) => onChange({ vendorName: name, vendorSupplierId: '' })}
           />
         </div>
         <div>

--- a/apps/web/src/components/expense-form-v4/types.ts
+++ b/apps/web/src/components/expense-form-v4/types.ts
@@ -94,6 +94,8 @@ export interface SettlementSelection {
 export interface SettlementFormFields {
   selections: Map<string, SettlementSelection>;
   vendorName: string;
+  /** Supplier FK from the picker — persisted as vendorSupplierId on the SE document. */
+  vendorSupplierId: string;
   whtAmount: string;
   whtFormType: WhtFormType | '';
 }
@@ -108,6 +110,8 @@ export interface SettlementFormFields {
 export interface PettyCashLineForm {
   uid: string;
   supplierName: string;
+  /** Supplier FK from the picker — persisted as supplierId on the petty-cash line. */
+  supplierId: string;
   category: string;
   description: string;
   amount: string;
@@ -126,6 +130,8 @@ export interface ExpenseFormState {
   documentDate: string;
   vendorName: string;
   vendorTaxId: string;
+  /** Supplier FK from the picker — persisted as vendorSupplierId on the expense document. */
+  vendorSupplierId: string;
   taxInvoiceNo: string;
   priceType: PriceType;
   whtFormType: WhtFormType | '';
@@ -251,6 +257,7 @@ export const newPettyCashLine = (
 ): PettyCashLineForm => ({
   uid: Math.random().toString(36).slice(2),
   supplierName: '',
+  supplierId: '',
   category: '',
   description: '',
   amount: '',


### PR DESCRIPTION
## Summary
**Final phase (P3+P4)** of the "Party Master Mandatory" epic — the last document type (Expense) gains a durable supplier FK, plus cleanup.

### P3 — durable expense vendor link
- **Schema + migration** (`20260968000000_add_expense_vendor_supplier_fk`): nullable `ExpenseDocument.vendorSupplierId` + `ExpenseLine.supplierId` → `suppliers` (the only document type still storing the vendor as free-text-only; all others already had an FK). Hand-written migration verified deterministic vs Prisma's optional-relation output (`ON DELETE SET NULL ON UPDATE CASCADE`).
- DTO + service persist the FK on create / credit-note / settlement / petty-cash / update.
- **No required-FK guard** (intentional — payroll/custodian, template, credit-note set `vendorName` programmatically; a blanket required-FK would break them). The UI pickers already prevent free-text; this makes the link durable.
- Frontend: `VendorCombobox` surfaces the provisioned `supplierId`; the 3 expense sections thread `vendorSupplierId` / per-line `supplierId` into the payload (empty values normalized to `undefined`).

### P4 — cleanup
- Removed the dead `onTypeName` free-text chain (ContactCombobox + VendorCombobox + 3 expense sections) + fixed stale comments/placeholders.
- **Stub-duplicate-Customer guard**: `customers.service.create()` now upgrades an existing stub Customer for the contact (from `ensureRole`) instead of creating a 2nd row (`Customer.contactId` isn't unique; stubs lack phoneHash so were invisible to dedup).

Reviewed (opus, cohesive): **ready-to-merge, no blockers** — migration correct/deterministic, `''`-FK hazard defused at the payload boundary, stub guard can't mismatch (ConflictException upstream), PII preserved.

## Test Plan
- [ ] `cd apps/api && npx prisma validate` → valid
- [ ] `cd apps/api && npx jest --runInBand src/modules/expense-documents src/modules/customers src/modules/contacts` → green (388 + 136)
- [ ] `cd apps/web && npx vitest run src/components/expense-form-v4 src/components/contacts` → green
- [ ] `./tools/check-types.sh all`
- [ ] After deploy: confirm the migration applied (`prisma migrate status`) and an expense saved via the form persists `vendorSupplierId`.

## Non-blocking follow-ups (from review)
1. Repair-ticket auto-created expense knows `repairSupplierId` but doesn't thread it into `vendorSupplierId` — highest-value follow-up to fully realize the link there.
2. FK DTO fields are `@IsString() @IsOptional()` (UI safe); add `@IsUUID()` for defense-in-depth against a direct API caller sending `''`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)