### PR TITLE
fix(contacts): epic follow-ups — repair-ticket FK, @IsUUID guards, vendor-FK backfill CLI

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,8 @@
     "backfill:schedules": "node dist/src/cli/backfill-installment-schedules.cli.js",
     "backfill:asset-vat": "node dist/src/cli/backfill-asset-vat-corrections.cli.js",
     "backfill:asset-vat:help": "echo 'Usage: EXPECTED_DB_NAME=<db> [DRY_RUN=true|false] [ALLOW_PROD_BACKFILL=YES_I_AM_SURE] npm run backfill:asset-vat'",
+    "backfill:expense-vendor-fk": "node dist/src/cli/backfill-expense-vendor-fk.cli.js",
+    "backfill:expense-vendor-fk:help": "echo 'Usage: EXPECTED_DB_NAME=<db> [APPLY=true] [ALLOW_PROD_BACKFILL=YES_I_AM_SURE] npm run backfill:expense-vendor-fk  (dry-run default; pass --apply or APPLY=true to write)'",
     "backfill:encrypt-pii": "tsx src/cli/encrypt-customer-pii.cli.ts",
     "backfill:encrypt-pii:help": "echo 'Usage: CONFIRM_BACKFILL=YES_I_AM_SURE EXPECTED_DB_NAME=<db> PII_ENCRYPTION_KEY=<64hex> PII_HASH_SALT=<>=32chars> [ALLOW_PROD_BACKFILL=YES_I_AM_SURE] [PDPA_BACKFILL_BATCH_SIZE=100] npm run backfill:encrypt-pii'",
     "backfill:user-companies": "tsx src/cli/backfill-user-companies.cli.ts",

--- a/apps/api/src/cli/backfill-expense-vendor-fk.cli.spec.ts
+++ b/apps/api/src/cli/backfill-expense-vendor-fk.cli.spec.ts
@@ -1,0 +1,65 @@
+import { resolveVendorMatch, SupplierRow } from './backfill-expense-vendor-fk.cli';
+
+describe('resolveVendorMatch — expense vendor FK backfill matching logic', () => {
+  const suppliers: SupplierRow[] = [
+    { id: 'sup-1', taxId: '0105568000001' },
+    { id: 'sup-2', taxId: '0105568000002' },
+    { id: 'sup-3', taxId: null }, // supplier with no taxId
+  ];
+
+  it('returns eligible when exactly one supplier matches the vendorTaxId', () => {
+    const result = resolveVendorMatch(suppliers, '0105568000001');
+    expect(result).toEqual({ kind: 'eligible', supplierId: 'sup-1' });
+  });
+
+  it('returns no-supplier when no supplier has the given taxId', () => {
+    const result = resolveVendorMatch(suppliers, '9999999999999');
+    expect(result).toEqual({ kind: 'no-supplier' });
+  });
+
+  it('returns ambiguous when two suppliers share the same taxId', () => {
+    const duplicates: SupplierRow[] = [
+      { id: 'sup-a', taxId: '0105568000099' },
+      { id: 'sup-b', taxId: '0105568000099' },
+    ];
+    const result = resolveVendorMatch(duplicates, '0105568000099');
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidateIds).toHaveLength(2);
+      expect(result.candidateIds).toContain('sup-a');
+      expect(result.candidateIds).toContain('sup-b');
+    }
+  });
+
+  it('returns no-supplier when vendorTaxId is null', () => {
+    const result = resolveVendorMatch(suppliers, null);
+    expect(result).toEqual({ kind: 'no-supplier' });
+  });
+
+  it('returns no-supplier when vendorTaxId is an empty string', () => {
+    const result = resolveVendorMatch(suppliers, '');
+    expect(result).toEqual({ kind: 'no-supplier' });
+  });
+
+  it('returns no-supplier when vendorTaxId is whitespace-only', () => {
+    const result = resolveVendorMatch(suppliers, '   ');
+    expect(result).toEqual({ kind: 'no-supplier' });
+  });
+
+  it('does NOT match a supplier whose taxId is null, even if vendorTaxId is set', () => {
+    // sup-3 has taxId=null; that must never match any real vendorTaxId
+    const onlyNullTaxId: SupplierRow[] = [{ id: 'sup-3', taxId: null }];
+    const result = resolveVendorMatch(onlyNullTaxId, '0105568000001');
+    expect(result).toEqual({ kind: 'no-supplier' });
+  });
+
+  it('returns eligible for the second supplier when first has different taxId', () => {
+    const result = resolveVendorMatch(suppliers, '0105568000002');
+    expect(result).toEqual({ kind: 'eligible', supplierId: 'sup-2' });
+  });
+
+  it('returns no-supplier when active supplier list is empty', () => {
+    const result = resolveVendorMatch([], '0105568000001');
+    expect(result).toEqual({ kind: 'no-supplier' });
+  });
+});

--- a/apps/api/src/cli/backfill-expense-vendor-fk.cli.ts
+++ b/apps/api/src/cli/backfill-expense-vendor-fk.cli.ts
@@ -1,0 +1,345 @@
+/**
+ * One-time backfill CLI: link historical ExpenseDocument.vendorSupplierId
+ * by exact taxId match against the active Supplier master.
+ *
+ * Safe de-risk policy (matches contacts-followups epic):
+ *   - CONFIDENT match only: vendorTaxId → exactly ONE active Supplier.taxId
+ *   - Zero matches  → reported as "no-supplier"   (skipped, never guessed)
+ *   - 2+ matches    → reported as "ambiguous"      (skipped, listed)
+ *   - No fuzzy name matching, no auto-create of Supplier records
+ *
+ * ExpenseLine.supplierId is NOT touched here — line-level matching would
+ * require name-only (fuzzy) matching, which is out-of-scope. A count of
+ * ExpenseLines with supplierId IS NULL AND supplierName != NULL is printed
+ * as "needs manual review".
+ *
+ * Idempotent: only rows with vendorSupplierId IS NULL are scanned.
+ * Re-running after a partial apply is safe — already-linked rows are
+ * untouched because they no longer satisfy the WHERE clause.
+ *
+ * Dry-run by default.  Run with --apply to write.
+ *
+ * Usage (dev, dry-run):
+ *   EXPECTED_DB_NAME=bestchoice_dev npm --prefix apps/api run backfill:expense-vendor-fk
+ *
+ * Usage (dev, apply):
+ *   EXPECTED_DB_NAME=bestchoice_dev npm --prefix apps/api run backfill:expense-vendor-fk -- --apply
+ *
+ * Usage (production, dry-run):
+ *   gcloud run jobs execute backfill-expense-vendor-fk --region=asia-southeast1 \
+ *     --project=bestchoice-prod \
+ *     --update-env-vars=EXPECTED_DB_NAME=bestchoice_prod \
+ *     --wait
+ *
+ * Usage (production, apply):
+ *   ... --update-env-vars=EXPECTED_DB_NAME=bestchoice_prod,APPLY=true,ALLOW_PROD_BACKFILL=YES_I_AM_SURE
+ *
+ * Notes:
+ *   - The pure decision helper `resolveVendorMatch` is unit-tested in
+ *     backfill-expense-vendor-fk.cli.spec.ts. The runnable main() is
+ *     operational glue guarded by `require.main === module` so importing
+ *     this file in Jest does NOT connect to a DB or run anything.
+ */
+import { PrismaClient } from '@prisma/client';
+
+// ─── Pure matching logic (exported for unit tests) ───────────────────────────
+
+export interface SupplierRow {
+  id: string;
+  taxId: string | null;
+}
+
+export type VendorMatchResult =
+  | { kind: 'eligible'; supplierId: string }
+  | { kind: 'no-supplier' }
+  | { kind: 'ambiguous'; candidateIds: string[] };
+
+/**
+ * Pure function: given the active suppliers and one expense doc's vendorTaxId,
+ * decide the backfill action.
+ *
+ *   - Exactly one Supplier with taxId === vendorTaxId → eligible
+ *   - Zero matches                                    → no-supplier
+ *   - 2+ matches                                      → ambiguous
+ *   - null / empty vendorTaxId                        → no-supplier
+ *     (callers should pre-filter, but this stays safe if they don't)
+ */
+export function resolveVendorMatch(
+  activeSuppliers: SupplierRow[],
+  vendorTaxId: string | null,
+): VendorMatchResult {
+  if (!vendorTaxId || vendorTaxId.trim() === '') {
+    return { kind: 'no-supplier' };
+  }
+  const matches = activeSuppliers.filter(
+    (s) => s.taxId !== null && s.taxId === vendorTaxId,
+  );
+  if (matches.length === 1) {
+    return { kind: 'eligible', supplierId: matches[0].id };
+  }
+  if (matches.length === 0) {
+    return { kind: 'no-supplier' };
+  }
+  return { kind: 'ambiguous', candidateIds: matches.map((s) => s.id) };
+}
+
+// ─── Runnable glue — only executes under `require.main === module` ──────────
+
+interface ExpenseDocRow {
+  id: string;
+  number: string;
+  vendorTaxId: string | null;
+  vendorName: string | null;
+}
+
+const SAMPLE_SIZE = 5; // how many example doc numbers to show per bucket
+
+async function main(): Promise<void> {
+  const expectedDb = process.env.EXPECTED_DB_NAME;
+  if (!expectedDb) {
+    console.error(
+      'ERROR: EXPECTED_DB_NAME is required (e.g. EXPECTED_DB_NAME=bestchoice_dev).',
+    );
+    process.exit(1);
+  }
+
+  // --apply flag can come from CLI args OR from env (for Cloud Run Job invocation)
+  const applyMode =
+    process.argv.includes('--apply') ||
+    (process.env.APPLY ?? '').toLowerCase() === 'true';
+
+  const prisma = new PrismaClient();
+
+  // DB name guard — prevents wrong-DB accidents
+  const [{ current_database: actualDb }] = await prisma.$queryRaw<
+    { current_database: string }[]
+  >`SELECT current_database()`;
+  if (actualDb !== expectedDb) {
+    console.error(
+      `ERROR: DB mismatch: connected to "${actualDb}" but EXPECTED_DB_NAME="${expectedDb}". Aborting.`,
+    );
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+
+  // Extra guard for production live runs
+  if (applyMode && actualDb === 'bestchoice_prod') {
+    if (process.env.ALLOW_PROD_BACKFILL !== 'YES_I_AM_SURE') {
+      console.error(
+        'ERROR: production --apply requires ALLOW_PROD_BACKFILL=YES_I_AM_SURE',
+      );
+      await prisma.$disconnect();
+      process.exit(1);
+    }
+    console.warn(
+      '[backfill-expense-vendor-fk] LIVE prod run starting in 5s — Ctrl+C to abort.',
+    );
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+
+  console.log(
+    `[backfill-expense-vendor-fk] DB: ${actualDb}  mode: ${applyMode ? 'APPLY' : 'DRY_RUN'}`,
+  );
+
+  try {
+    // ── 1. Load active Supplier taxIds into memory ────────────────────────
+    const activeSuppliers: SupplierRow[] = await prisma.supplier.findMany({
+      where: { deletedAt: null },
+      select: { id: true, taxId: true },
+    });
+    console.log(
+      `[backfill-expense-vendor-fk] Loaded ${activeSuppliers.length} active supplier(s).`,
+    );
+
+    // ── 2. Load target expense documents ─────────────────────────────────
+    const docs: ExpenseDocRow[] = await prisma.expenseDocument.findMany({
+      where: {
+        vendorSupplierId: null,
+        deletedAt: null,
+        vendorTaxId: { not: null },
+      },
+      select: {
+        id: true,
+        number: true,
+        vendorTaxId: true,
+        vendorName: true,
+      },
+      orderBy: { number: 'asc' },
+    });
+    console.log(
+      `[backfill-expense-vendor-fk] Found ${docs.length} doc(s) with vendorTaxId set but vendorSupplierId NULL.`,
+    );
+
+    // ── 3. Classify ────────────────────────────────────────────────────────
+    const eligible: Array<{ doc: ExpenseDocRow; supplierId: string }> = [];
+    const noSupplier: ExpenseDocRow[] = [];
+    const ambiguous: Array<{ doc: ExpenseDocRow; candidateIds: string[] }> = [];
+
+    for (const doc of docs) {
+      const result = resolveVendorMatch(activeSuppliers, doc.vendorTaxId);
+      switch (result.kind) {
+        case 'eligible':
+          eligible.push({ doc, supplierId: result.supplierId });
+          break;
+        case 'no-supplier':
+          noSupplier.push(doc);
+          break;
+        case 'ambiguous':
+          ambiguous.push({ doc, candidateIds: result.candidateIds });
+          break;
+      }
+    }
+
+    // ── 4. ExpenseLine report-only (no auto-link) ──────────────────────────
+    // Lines with supplierId IS NULL + non-empty supplierName require name-only
+    // matching which would be fuzzy — out of scope. Just report the count.
+    const expenseLineNeedsReview = await prisma.expenseLine.count({
+      where: {
+        supplierId: null,
+        supplierName: { not: null },
+      },
+    });
+
+    // ── 5. Summary print ──────────────────────────────────────────────────
+    console.log('');
+    console.log('[backfill-expense-vendor-fk] ===== CLASSIFICATION SUMMARY =====');
+    console.log(
+      `[backfill-expense-vendor-fk]   total scanned      : ${docs.length}`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   eligible (1 match) : ${eligible.length}${applyMode ? '' : '  (would-link)'}`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   no-supplier        : ${noSupplier.length}  (skipped — no active supplier with that taxId)`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   ambiguous          : ${ambiguous.length}  (skipped — multiple suppliers share that taxId)`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   ExpenseLines needing manual review (supplierName set, supplierId null): ${expenseLineNeedsReview}`,
+    );
+    console.log('');
+
+    if (eligible.length > 0) {
+      const sample = eligible.slice(0, SAMPLE_SIZE);
+      console.log(
+        `[backfill-expense-vendor-fk]   ELIGIBLE sample (up to ${SAMPLE_SIZE}):`,
+      );
+      for (const { doc, supplierId } of sample) {
+        console.log(
+          `    doc=${doc.number}  vendorTaxId=${doc.vendorTaxId}  vendorName=${doc.vendorName ?? '(null)'}  → supplier=${supplierId}`,
+        );
+      }
+      if (eligible.length > SAMPLE_SIZE) {
+        console.log(`    ... and ${eligible.length - SAMPLE_SIZE} more`);
+      }
+      console.log('');
+    }
+
+    if (noSupplier.length > 0) {
+      const sample = noSupplier.slice(0, SAMPLE_SIZE);
+      console.log(
+        `[backfill-expense-vendor-fk]   NO-SUPPLIER sample (up to ${SAMPLE_SIZE}):`,
+      );
+      for (const doc of sample) {
+        console.log(
+          `    doc=${doc.number}  vendorTaxId=${doc.vendorTaxId}  vendorName=${doc.vendorName ?? '(null)'}`,
+        );
+      }
+      if (noSupplier.length > SAMPLE_SIZE) {
+        console.log(`    ... and ${noSupplier.length - SAMPLE_SIZE} more`);
+      }
+      console.log('');
+    }
+
+    if (ambiguous.length > 0) {
+      console.log(
+        `[backfill-expense-vendor-fk]   AMBIGUOUS sample (up to ${SAMPLE_SIZE}):`,
+      );
+      for (const { doc, candidateIds } of ambiguous.slice(0, SAMPLE_SIZE)) {
+        console.log(
+          `    doc=${doc.number}  vendorTaxId=${doc.vendorTaxId}  vendorName=${doc.vendorName ?? '(null)'}  candidates=[${candidateIds.join(', ')}]`,
+        );
+      }
+      if (ambiguous.length > SAMPLE_SIZE) {
+        console.log(`    ... and ${ambiguous.length - SAMPLE_SIZE} more`);
+      }
+      console.log('');
+    }
+
+    // ── 6. Dry-run exit ────────────────────────────────────────────────────
+    if (!applyMode) {
+      console.log(
+        '[backfill-expense-vendor-fk] DRY_RUN — no rows updated. Re-run with --apply (or APPLY=true) to commit changes.',
+      );
+      return;
+    }
+
+    // ── 7. Apply eligible rows ────────────────────────────────────────────
+    if (eligible.length === 0) {
+      console.log('[backfill-expense-vendor-fk] Nothing to apply.');
+      return;
+    }
+
+    console.log(
+      `[backfill-expense-vendor-fk] Applying ${eligible.length} update(s)...`,
+    );
+
+    let linked = 0;
+    let failed = 0;
+
+    // Process in batches of 100 to keep memory + lock contention bounded.
+    const BATCH_SIZE = 100;
+    for (let i = 0; i < eligible.length; i += BATCH_SIZE) {
+      const batch = eligible.slice(i, i + BATCH_SIZE);
+      // Use a transaction per batch for atomicity within the batch.
+      await prisma.$transaction(async (tx) => {
+        for (const { doc, supplierId } of batch) {
+          await tx.expenseDocument.update({
+            where: {
+              id: doc.id,
+              // Idempotency guard: only update if still null (concurrent safety)
+              vendorSupplierId: null,
+            },
+            data: { vendorSupplierId: supplierId },
+          });
+        }
+      });
+      linked += batch.length;
+      console.log(
+        `[backfill-expense-vendor-fk]   ...linked ${linked}/${eligible.length}`,
+      );
+    }
+
+    console.log('');
+    console.log('[backfill-expense-vendor-fk] ===== APPLY SUMMARY =====');
+    console.log(
+      `[backfill-expense-vendor-fk]   linked    : ${linked}`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   failed    : ${failed}`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   no-match  : ${noSupplier.length}  (manual review required)`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   ambiguous : ${ambiguous.length}  (manual review required)`,
+    );
+    console.log(
+      `[backfill-expense-vendor-fk]   ExpenseLines needing manual review: ${expenseLineNeedsReview}`,
+    );
+    console.log('[backfill-expense-vendor-fk] Done.');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(
+      '[backfill-expense-vendor-fk] FATAL:',
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exit(1);
+  });
+}

--- a/apps/api/src/modules/expense-documents/dto/create-credit-note.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-credit-note.dto.ts
@@ -61,7 +61,7 @@ export class CreateCreditNoteDto {
    * Party-master link (Phase 3 P3). Durable FK to the Supplier behind
    * `vendorName` (STANDALONE mode). Optional.
    */
-  @IsString()
+  @IsUUID('4', { message: 'รหัสซัพพลายเออร์ไม่ถูกต้อง' })
   @IsOptional()
   vendorSupplierId?: string;
 

--- a/apps/api/src/modules/expense-documents/dto/create-petty-cash.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-petty-cash.dto.ts
@@ -4,6 +4,7 @@ import {
   IsIn,
   IsDateString,
   IsNumber,
+  IsUUID,
   Min,
   Matches,
   ValidateNested,
@@ -34,7 +35,7 @@ class PettyCashLineInput {
    * Party-master link (Phase 3 P3). Durable FK to the Supplier the UI picker
    * provisioned for `supplierName`. Optional.
    */
-  @IsString()
+  @IsUUID('4')
   @IsOptional()
   supplierId?: string;
 

--- a/apps/api/src/modules/expense-documents/dto/create-settlement.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create-settlement.dto.ts
@@ -38,7 +38,7 @@ export class CreateSettlementDto {
    * Party-master link (Phase 3 P3). Durable FK to the Supplier behind
    * `vendorName`. Optional.
    */
-  @IsString()
+  @IsUUID('4')
   @IsOptional()
   vendorSupplierId?: string;
 

--- a/apps/api/src/modules/expense-documents/dto/create.dto.ts
+++ b/apps/api/src/modules/expense-documents/dto/create.dto.ts
@@ -8,6 +8,7 @@ import {
   IsIn,
   IsNumberString,
   IsBoolean,
+  IsUUID,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ExpenseLineInput } from './expense-line-input.dto';
@@ -39,7 +40,7 @@ export class CreateExpenseDocumentDto {
    * provisioned for `vendorName`. Optional — no required-FK guard (several
    * subtypes set vendorName programmatically with no supplier).
    */
-  @IsString()
+  @IsUUID('4')
   @IsOptional()
   vendorSupplierId?: string;
 

--- a/apps/api/src/modules/expense-documents/expense-documents.service.ts
+++ b/apps/api/src/modules/expense-documents/expense-documents.service.ts
@@ -581,6 +581,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
   async createDraftForRepair(
     dto: {
       vendorName: string;
+      vendorSupplierId?: string;
       amount: Prisma.Decimal;
       accountCode: string;
       description: string;
@@ -612,6 +613,7 @@ export class ExpenseDocumentsService implements OnModuleInit {
         branchId: dto.branchId,
         documentDate,
         vendorName: dto.vendorName,
+        ...(dto.vendorSupplierId ? { vendorSupplierId: dto.vendorSupplierId } : {}),
         description: dto.description,
         subtotal: totals.subtotal,
         vatAmount: totals.vatAmount,

--- a/apps/api/src/modules/repair-tickets/__tests__/repair-tickets.service.spec.ts
+++ b/apps/api/src/modules/repair-tickets/__tests__/repair-tickets.service.spec.ts
@@ -920,6 +920,7 @@ describe('RepairTicketsService.returnToCustomer', () => {
     expect(expenseDocs.createDraftForRepair).toHaveBeenCalledWith(
       expect.objectContaining({
         vendorName: 'ซัพพลายเออร์ A',
+        vendorSupplierId: 'sup-1',
         amount: new Prisma.Decimal(2500),
       }),
       expect.anything(), // tx

--- a/apps/api/src/modules/repair-tickets/repair-tickets.service.ts
+++ b/apps/api/src/modules/repair-tickets/repair-tickets.service.ts
@@ -380,6 +380,7 @@ export class RepairTicketsService {
         const doc = await this.expenseDocs.createDraftForRepair(
           {
             vendorName: supplier?.name ?? ticket.repairSupplierId,
+            vendorSupplierId: ticket.repairSupplierId,
             // actualCost is Prisma.Decimal from DB — passed through unchanged (no Number() drift).
             amount: ticket.actualCost,
             accountCode,

--- a/apps/api/src/modules/trade-in/dto/trade-in.dto.ts
+++ b/apps/api/src/modules/trade-in/dto/trade-in.dto.ts
@@ -4,6 +4,7 @@ import {
   IsNumber,
   IsIn,
   IsBoolean,
+  IsUUID,
   Length,
   Matches,
 } from 'class-validator';
@@ -59,7 +60,7 @@ export class CreateTradeInDto {
   // ─── Seller info (walk-in) ──────────────────────────
   /** Party-master contactId for the seller. Stored for traceability alongside
    *  sellerName/sellerPhone (which are kept for display purposes). */
-  @IsString()
+  @IsUUID('4')
   @IsOptional()
   sellerContactId?: string;
 
@@ -179,7 +180,7 @@ export class AcceptTradeInDto {
  */
 export class QuickBuyTradeInDto {
   // Seller (walk-in) — party-master contact resolved by the picker upstream
-  @IsString()
+  @IsUUID('4')
   @IsOptional()
   sellerContactId?: string;
 


### PR DESCRIPTION
## Summary
Follow-ups closing out the "Party Master Mandatory" epic.

- **Repair-ticket auto-doc** now sets `vendorSupplierId` from `ticket.repairSupplierId` (was leaving the party-master link unrealized on SHOP-paid repair expenses).
- **`@IsUUID()` on FK DTO fields** (expense `vendorSupplierId` ×3 DTOs, petty-cash line `supplierId`, trade-in `sellerContactId` ×2) — a direct API caller sending `''` now gets a clean 400 instead of a raw Postgres P2003.
- **Safe backfill CLI** `backfill:expense-vendor-fk` — links historical `ExpenseDocument` to a Supplier by **exact `vendorTaxId` match** (single match only); ambiguous/unmatched are reported, never guessed. Dry-run by default; `--apply` + DB-name guard + prod opt-in. `ExpenseLine` (name-only) is report-only. 9 unit tests on the matcher.

## Deliberately NOT done (with rationale)
- **Strict API write-path guard** (reject free-text vendor writes): analysed and skipped — the UI already enforces no-free-text via pickers, and the remaining `vendorName`-without-FK paths are **legitimate** (payroll custodian, template-load copy, credit-note/settlement). A blanket guard would break them; this was the original P3 de-risk decision and it stands.

## Test Plan
- [ ] `cd apps/api && npx jest --runInBand src/modules/repair-tickets src/modules/expense-documents src/cli` → green
- [ ] `./tools/check-types.sh all`
- [ ] Run the backfill in dry-run on a DB copy: `EXPECTED_DB_NAME=<db> npm --prefix apps/api run backfill:expense-vendor-fk` → review counts before `--apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)