### PR TITLE
feat(contacts): trade-in seller name on contact card + audit cleanup

### DIFF
--- a/apps/web/src/pages/ContactDetailPage.tsx
+++ b/apps/web/src/pages/ContactDetailPage.tsx
@@ -297,10 +297,20 @@ function TradeInTile({ tradeIn }: { tradeIn: ContactTradeInLink }) {
         <CardTitle className="leading-snug">คนขายมือสอง</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
-        <Field
-          label="วันที่รับซื้อ"
-          value={new Date(tradeIn.createdAt).toLocaleDateString('th-TH', { timeZone: 'Asia/Bangkok' })}
-        />
+        <div className="grid grid-cols-2 gap-3">
+          <Field
+            label="ชื่อผู้ขาย"
+            value={
+              tradeIn.sellerName
+                ? `${tradeIn.sellerName}${tradeIn.sellerPhone ? ` (${tradeIn.sellerPhone})` : ''}`
+                : tradeIn.sellerPhone
+            }
+          />
+          <Field
+            label="วันที่รับซื้อ"
+            value={new Date(tradeIn.createdAt).toLocaleDateString('th-TH', { timeZone: 'Asia/Bangkok' })}
+          />
+        </div>
         <CardLink to="/trade-in" label="ดูรายการรับซื้อ" />
       </CardContent>
     </Card>

--- a/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ContactDetailPage.test.tsx
@@ -237,4 +237,41 @@ describe('ContactDetailPage', () => {
     expect(screen.getByText('สถานะภาษี')).toBeInTheDocument();
     expect(screen.getAllByText('จด VAT').length).toBeGreaterThan(0);
   });
+
+  it('shows the seller name in the trade-in tile (not just the date)', async () => {
+    (contactsApi.detail as any).mockResolvedValue({
+      id: 'c1', contactCode: 'P-7', name: 'สมชาย', roles: ['TRADE_IN_SELLER'], isActive: true,
+      taxId: null, phone: '0812223333', email: null, address: null, lineId: null, peakContactCode: null,
+      customers: [], suppliers: [], externalFinanceCompany: [],
+      tradeInsAsSeller: [
+        { id: 't1', sellerName: 'สมชาย', sellerPhone: '0899998888', createdAt: '2026-05-01T03:00:00.000Z' },
+      ],
+    });
+    wrap('c1');
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'สมชาย' })).toBeInTheDocument());
+    // 'คนขายมือสอง' appears as both the hero role badge and the tile title
+    expect(screen.getAllByText('คนขายมือสอง').length).toBeGreaterThan(0);
+    // seller name + phone shown in the tile (parenthesised string is unique to the tile, not the hero h1)
+    expect(screen.getByText(/สมชาย \(0899998888\)/)).toBeInTheDocument();
+  });
+
+  it('hides the summary strip when the summary fetch fails, but still renders the card', async () => {
+    const { customersApi } = await import('@/lib/api/customers');
+    (customersApi.summary as any).mockRejectedValue(new Error('network'));
+    (contactsApi.detail as any).mockResolvedValue({
+      id: 'c1', contactCode: 'P-00001', name: 'ลูกค้าเอ', roles: ['CUSTOMER'], isActive: true,
+      taxId: null, phone: '08', email: null, address: null, lineId: null, peakContactCode: null,
+      suppliers: [], tradeInsAsSeller: [], externalFinanceCompany: [],
+      customers: [{ id: 'cus1', name: 'ลูกค้าเอ', prefix: 'คุณ', phone: '08' }],
+    });
+    wrap('c1');
+    // hero + customer tile still render despite the failed summary query
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'ลูกค้าเอ' })).toBeInTheDocument());
+    expect(screen.getByText('เปิดข้อมูลลูกค้า / แก้ไข')).toBeInTheDocument();
+    // the summary fetch WAS attempted (and rejected) — proves the hide is due to
+    // the failure path, not merely an un-fired query
+    await waitFor(() => expect(customersApi.summary).toHaveBeenCalledWith('cus1'));
+    // ...but the financial KPI strip is hidden (no half-strip on fetch failure)
+    expect(screen.queryByText('ยอดค้างชำระ')).not.toBeInTheDocument();
+  });
 });

--- a/docs/superpowers/specs/2026-06-01-contact-rich-fields-A1-design.md
+++ b/docs/superpowers/specs/2026-06-01-contact-rich-fields-A1-design.md
@@ -1,7 +1,7 @@
 # Contact Rich Detail — Read-Through (Sub-project A1, reworked)
 
 วันที่: 2026-06-01
-สถานะ: รออนุมัติ spec จาก owner
+สถานะ: ✅ DONE — merged เข้า main 2026-06-02 (PR #1121, commit `8a757600`). หมายเหตุ: customer card layout ถูก 360 redesign (merge `e52d2154`) รื้อทับภายหลัง — identity fields ย้ายไป hero, tile เหลือ role-specific. open item: เลขบัตร ปชช. (masked) ยังไม่โชว์บนหน้า contact (product decision ค้าง)
 ส่วนหนึ่งของ: PEAK-style contact detail expansion (A → B → C). อันนี้คือ **A1**.
 
 > **เวอร์ชันนี้ rework หลัง /scrutinize** — เวอร์ชันแรกเก็บ column ซ้ำบน Contact (address/entityType/branchCode/prefix) ซึ่งซ้ำกับ Customer/Supplier และทำให้ข้อมูลแตก 2 ชุด (เอกสารกฎหมายอ่านจาก Customer/Supplier ไม่ใช่ Contact). เวอร์ชันนี้ใช้ **read-through**: Contact คงเป็น party key บางๆ, หน้า detail ดึงข้อมูลจาก record ต้นทางมาแสดง + ลิงก์ไปแก้ที่ต้นทาง.

--- a/docs/superpowers/specs/2026-06-02-contact-360-presentation-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-02-contact-360-presentation-redesign-design.md
@@ -1,7 +1,7 @@
 # Contact 360° — Presentation Redesign
 
 วันที่: 2026-06-02
-สถานะ: รออนุมัติ spec จาก owner
+สถานะ: ✅ DONE — merged เข้า main 2026-06-02 (merge `e52d2154`; feat `2c2154ac` + schema `3bc5f6a6` + cleanup `41cf8b18`). 3 UX decision ที่ปล่อยให้ implementer เลือก: LINE=copy lineId, edit=ลิงก์ใน tile (ไม่มี dropdown), ไม่มี PageHeader (h1 เดียว). TradeIn tile โชว์ sellerName เพิ่มใน cleanup ภายหลัง
 ส่วนหนึ่งของ: PEAK-style contact expansion. อันนี้คือ **ชั้น presentation** ที่รวบ A1 (read-through) + C (financial snapshot) ที่ implement ไปแล้ว ให้เป็น layout เดียวที่อ่านง่ายขึ้นและไม่โชว์ข้อมูลซ้ำ
 
 ## ที่มา / ปัญหา (จาก /scrutinize)

--- a/docs/superpowers/specs/2026-06-02-contact-financial-snapshot-C-design.md
+++ b/docs/superpowers/specs/2026-06-02-contact-financial-snapshot-C-design.md
@@ -1,7 +1,7 @@
 # Contact Financial Snapshot (Sub-project C, thin)
 
 วันที่: 2026-06-02
-สถานะ: รออนุมัติ spec จาก owner
+สถานะ: ✅ DONE — merged เข้า main 2026-06-02 (PR #1122, commit `6255e66c`). `outstanding` shape (จุดเสี่ยงที่ spec เตือน) = `Number(_sum.amountDue)` number ตรง ๆ, FE map ถูก. error-case test เพิ่มใน cleanup ภายหลัง
 ส่วนหนึ่งของ: PEAK-style contact expansion (A → B → C). อันนี้คือ **C** (thin หลัง scrutinize).
 
 > **C reworked หลัง scrutinize:** คำขอเดิม "แท็บภาพรวมการเงิน" (ยอดขาย/AR aging/doc list/กราฟ แบบ PEAK) ถูกตัดเหลือ **snapshot สั้นๆ** เพราะภาพการเงินลูกค้าเต็มมีอยู่แล้วบน `CustomerDetailPage` (ตาราง contracts, KPI active/overdue, risk panel) และมี endpoint `GET /customers/:id/summary` (outstanding + active/overdue) อยู่แล้ว. ทำเต็มบนหน้า contact = duplicate. A1 ก็ deep-link ไปหน้าลูกค้าเต็มได้อยู่แล้ว.

--- a/docs/superpowers/specs/2026-06-02-contact-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-02-contact-hardening-design.md
@@ -1,7 +1,7 @@
 # Contact Hardening — unify trade-in sellers, fix merge, partial-unique keys
 
 วันที่: 2026-06-02
-สถานะ: รออนุมัติ spec จาก owner
+สถานะ: ✅ DONE — merged เข้า main 2026-06-02 (PR #1124, commit `64758b2b`). deviation: P2002 → throw `ConflictException` (ไม่ re-fetch ตาม spec) เพราะ Postgres query ต่อใน tx ที่ abort แล้วไม่ได้ — caller retry ทั้ง op แทน (ถูกต้องกว่า spec เดิม). pre-deploy dedup = manual SOP (ไม่มี code guard ตาม design)
 
 ## ที่มา
 จาก audit ระบบ contact party-master พบ edge cases หลายจุด. owner เลือกแก้ชุด 1+2+3:


### PR DESCRIPTION
## บริบท
Audit ของ 4 spec contact ที่ merge เข้า main ไปแล้ว (A1 #1121 / C #1122 / Hardening #1124 / 360 `e52d2154`, ทั้งหมด 2026-06-02) — **ไม่พบหนี้ทางเทคนิคสำคัญ**. PR นี้ปิด gap เล็ก ๆ ที่ audit เจอ (ไม่เปลี่ยน behavior อื่น).

## เปลี่ยนอะไร
1. **360 conformance** — `TradeInTile` โชว์ `ชื่อผู้ขาย` (sellerName + sellerPhone) คู่กับวันที่ ตาม spec §2 (เดิมโชว์แต่วันที่)
2. **C regression test** — เมื่อ `GET /customers/:id/summary` reject: KPI strip ซ่อน แต่การ์ดลูกค้า + hero ยัง render (assert ว่า fetch ถูกเรียกจริง → test ผ่านด้วยเหตุผลถูก ไม่ใช่ query ที่ยังไม่ยิง)
3. **docs** — header 4 spec จาก stale `รออนุมัติ` → `✅ DONE` + PR/commit จริง (งานชิป 2026-06-02 แต่ header ค้าง)

## ไม่ได้อยู่ใน PR นี้ (open item)
- **เลขบัตร ปชช. (masked)** บนหน้า contact = product decision ค้าง (โชว์บนหน้า contact หรือคลิกเข้า `/customers/:id`) — owner ยังไม่เคาะ

## Tests
- `apps/web` ContactDetailPage **9/9 green**
- web `tsc` OK
- 2-stage review: scrutinize + code-review subagent — ไม่มี critical/regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)