### PR TITLE
feat(employees): Employee Master backend — EmployeeProfile + employees module (PR-A)

### DIFF
--- a/apps/api/prisma/migrations/20260969000000_add_employee_profile/migration.sql
+++ b/apps/api/prisma/migrations/20260969000000_add_employee_profile/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "EmploymentType" AS ENUM ('MONTHLY', 'DAILY', 'CONTRACT');
+
+-- CreateTable
+CREATE TABLE "employee_profiles" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "position" TEXT,
+    "employment_type" "EmploymentType" NOT NULL DEFAULT 'MONTHLY',
+    "base_salary" DECIMAL(12,2),
+    "sso_eligible" BOOLEAN NOT NULL DEFAULT true,
+    "bank_name" TEXT,
+    "bank_account_no" TEXT,
+    "tax_id_override" TEXT,
+    "note" TEXT,
+    "resigned_date" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "employee_profiles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "employee_profiles_user_id_key" ON "employee_profiles"("user_id");
+
+-- CreateIndex
+CREATE INDEX "employee_profiles_deleted_at_idx" ON "employee_profiles"("deleted_at");
+
+-- AddForeignKey
+ALTER TABLE "employee_profiles" ADD CONSTRAINT "employee_profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -29,6 +29,12 @@ enum UserRole {
   VIEWER
 }
 
+enum EmploymentType {
+  MONTHLY
+  DAILY
+  CONTRACT
+}
+
 enum SupplierType {
   INDIVIDUAL
   JURISTIC
@@ -787,9 +793,33 @@ model User {
   // Finance Receivable Contact System
   financeContactLogs FinanceReceivableContactLog[] @relation("FinanceContactLogger")
 
+  // Employee Master (PR-A) — 1:1 payroll/employment profile
+  employeeProfile EmployeeProfile?
+
   @@index([branchId])
   @@index([yeastarExtension])
   @@map("users")
+}
+
+model EmployeeProfile {
+  id             String         @id @default(uuid())
+  userId         String         @unique @map("user_id")
+  user           User           @relation(fields: [userId], references: [id])
+  position       String?
+  employmentType EmploymentType @default(MONTHLY) @map("employment_type")
+  baseSalary     Decimal?       @map("base_salary") @db.Decimal(12, 2)
+  ssoEligible    Boolean        @default(true) @map("sso_eligible")
+  bankName       String?        @map("bank_name")
+  bankAccountNo  String?        @map("bank_account_no")
+  taxIdOverride  String?        @map("tax_id_override")
+  note           String?
+  resignedDate   DateTime?      @map("resigned_date")
+  createdAt      DateTime       @default(now()) @map("created_at")
+  updatedAt      DateTime       @updatedAt @map("updated_at")
+  deletedAt      DateTime?      @map("deleted_at")
+
+  @@index([deletedAt])
+  @@map("employee_profiles")
 }
 
 model Contact {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -136,6 +136,8 @@ import { BackupModule } from './modules/backup/backup.module';
 // SP7.4 — External Finance Companies + Commission (SHOP-side GFIN/Krungsri)
 import { ExternalFinanceModule } from './modules/external-finance/external-finance.module';
 import { ContactsModule } from './modules/contacts/contacts.module';
+// Employee Master (PR-A) — EmployeeProfile (1:1 User) + CRUD + PII-safe pickable
+import { EmployeesModule } from './modules/employees/employees.module';
 // P4-SP2 — Finance Tax (VAT/WHT monthly aggregation + auto-journal history)
 import { FinanceTaxModule } from './modules/finance-tax/finance-tax.module';
 // Task 18 — GFIN admin config (max prices, overprice rules, rate factors)
@@ -380,6 +382,8 @@ import { AppCacheModule } from './cache/cache.module';
     // SP7.4 — External Finance Companies + Commission (SHOP-side GFIN/Krungsri)
     ExternalFinanceModule,
     ContactsModule,
+    // Employee Master (PR-A) — EmployeeProfile (1:1 User) + CRUD + PII-safe pickable
+    EmployeesModule,
     // P4-SP2 — Finance Tax (VAT/WHT monthly aggregation + auto-journal history)
     FinanceTaxModule,
     // Task 18 — GFIN admin config (max prices, overprice rules, rate factors)

--- a/apps/api/src/modules/employees/dto/create-employee.dto.ts
+++ b/apps/api/src/modules/employees/dto/create-employee.dto.ts
@@ -1,0 +1,48 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
+import { EmploymentType } from '@prisma/client';
+
+export class CreateEmployeeDto {
+  @IsUUID(undefined, { message: 'กรุณาเลือกผู้ใช้ (พนักงาน)' })
+  userId!: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsEnum(EmploymentType, { message: 'ประเภทการจ้างไม่ถูกต้อง' })
+  employmentType?: EmploymentType;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'ฐานเงินเดือนต้องเป็นตัวเลข' })
+  @Min(0, { message: 'ฐานเงินเดือนต้องไม่ติดลบ' })
+  baseSalary?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  ssoEligible?: boolean;
+
+  @IsOptional()
+  @IsString()
+  bankName?: string;
+
+  @IsOptional()
+  @IsString()
+  bankAccountNo?: string;
+
+  @IsOptional()
+  @IsString()
+  taxIdOverride?: string;
+
+  @IsOptional()
+  @IsString()
+  note?: string;
+}

--- a/apps/api/src/modules/employees/dto/list-employees.dto.ts
+++ b/apps/api/src/modules/employees/dto/list-employees.dto.ts
@@ -1,0 +1,25 @@
+import { IsBooleanString, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ListEmployeesDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsBooleanString()
+  isActive?: string; // 'true' | 'false' — by EmployeeProfile.deletedAt + resigned
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+}

--- a/apps/api/src/modules/employees/dto/update-employee.dto.ts
+++ b/apps/api/src/modules/employees/dto/update-employee.dto.ts
@@ -1,0 +1,15 @@
+import { OmitType, PartialType } from '@nestjs/swagger';
+import { IsDateString, IsOptional } from 'class-validator';
+import { CreateEmployeeDto } from './create-employee.dto';
+
+// Update = all of Create's fields optional, minus userId (cannot reassign the
+// owning user), plus resignedDate. Mirrors the repo convention
+// (PartialType(OmitType(...)) from @nestjs/swagger — see update-asset.dto.ts,
+// expense-documents/dto/update.dto.ts).
+export class UpdateEmployeeDto extends PartialType(
+  OmitType(CreateEmployeeDto, ['userId'] as const),
+) {
+  @IsOptional()
+  @IsDateString({}, { message: 'วันที่ลาออกไม่ถูกต้อง' })
+  resignedDate?: string;
+}

--- a/apps/api/src/modules/employees/employees.controller.ts
+++ b/apps/api/src/modules/employees/employees.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { EmployeesService } from './employees.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import { ListEmployeesDto } from './dto/list-employees.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+type AuthRequest = Request & { user?: { id: string; role: string } };
+const actorOf = (req: AuthRequest) => ({
+  userId: req.user?.id,
+  ipAddress: req.ip,
+  userAgent: req.headers['user-agent'] as string | undefined,
+});
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('employees')
+export class EmployeesController {
+  constructor(private readonly employees: EmployeesService) {}
+
+  @Get()
+  @Roles('OWNER', 'ACCOUNTANT')
+  list(@Query() dto: ListEmployeesDto) {
+    return this.employees.list(dto);
+  }
+
+  @Get('pickable')
+  @Roles('OWNER', 'ACCOUNTANT', 'FINANCE_MANAGER')
+  pickable(@Query('search') search?: string) {
+    return this.employees.pickable(search);
+  }
+
+  @Get(':id')
+  @Roles('OWNER', 'ACCOUNTANT')
+  findOne(@Param('id') id: string) {
+    return this.employees.findOne(id);
+  }
+
+  @Post()
+  @Roles('OWNER', 'ACCOUNTANT')
+  provision(@Body() dto: CreateEmployeeDto, @Req() req: AuthRequest) {
+    return this.employees.provision(dto, actorOf(req));
+  }
+
+  @Patch(':id')
+  @Roles('OWNER', 'ACCOUNTANT')
+  update(@Param('id') id: string, @Body() dto: UpdateEmployeeDto, @Req() req: AuthRequest) {
+    return this.employees.update(id, dto, actorOf(req));
+  }
+
+  @Delete(':id')
+  @Roles('OWNER', 'ACCOUNTANT')
+  remove(@Param('id') id: string, @Req() req: AuthRequest) {
+    return this.employees.remove(id, actorOf(req));
+  }
+}

--- a/apps/api/src/modules/employees/employees.controller.ts
+++ b/apps/api/src/modules/employees/employees.controller.ts
@@ -34,6 +34,12 @@ export class EmployeesController {
     return this.employees.pickable(search);
   }
 
+  @Get('provisionable')
+  @Roles('OWNER', 'ACCOUNTANT')
+  provisionable(@Query('search') search?: string) {
+    return this.employees.provisionable(search);
+  }
+
   @Get(':id')
   @Roles('OWNER', 'ACCOUNTANT')
   findOne(@Param('id') id: string) {

--- a/apps/api/src/modules/employees/employees.module.ts
+++ b/apps/api/src/modules/employees/employees.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { EmployeesController } from './employees.controller';
+import { EmployeesService } from './employees.service';
+
+// PrismaModule + AuditModule are @Global() — no explicit import needed here
+// (mirrors contacts.module.ts).
+@Module({
+  controllers: [EmployeesController],
+  providers: [EmployeesService],
+  exports: [EmployeesService],
+})
+export class EmployeesModule {}

--- a/apps/api/src/modules/employees/employees.service.spec.ts
+++ b/apps/api/src/modules/employees/employees.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { EmployeesService } from './employees.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+describe('EmployeesService', () => {
+  let service: EmployeesService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let audit: { log: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      user: { findFirst: jest.fn() },
+      employeeProfile: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+    };
+    audit = { log: jest.fn() };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmployeesService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+
+    service = moduleRef.get(EmployeesService);
+  });
+
+  describe('provision', () => {
+    it('rejects when the user does not exist', async () => {
+      prisma.user.findFirst.mockResolvedValue(null);
+      await expect(service.provision({ userId: 'u-x' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('creates a profile + writes EMPLOYEE_PROFILE_CREATED audit', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'u-1', name: 'สมชาย' });
+      prisma.employeeProfile.create.mockResolvedValue({ id: 'e-1', userId: 'u-1' });
+      const res = await service.provision({ userId: 'u-1', position: 'ช่าง' }, { userId: 'admin' });
+      expect(prisma.employeeProfile.create).toHaveBeenCalled();
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'EMPLOYEE_PROFILE_CREATED', entity: 'employee_profile', entityId: 'e-1' }),
+      );
+      expect(res.id).toBe('e-1');
+    });
+
+    it('maps a duplicate (P2002) to ConflictException', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'u-1' });
+      prisma.employeeProfile.create.mockRejectedValue({ code: 'P2002' });
+      await expect(service.provision({ userId: 'u-1' })).rejects.toThrow(ConflictException);
+    });
+  });
+});

--- a/apps/api/src/modules/employees/employees.service.spec.ts
+++ b/apps/api/src/modules/employees/employees.service.spec.ts
@@ -57,4 +57,35 @@ describe('EmployeesService', () => {
       await expect(service.provision({ userId: 'u-1' })).rejects.toThrow(ConflictException);
     });
   });
+
+  describe('list', () => {
+    it('filters out soft-deleted, masks nationalId, returns paginated shape', async () => {
+      prisma.employeeProfile.findMany.mockResolvedValue([
+        { id: 'e-1', position: 'ช่าง', employmentType: 'MONTHLY', deletedAt: null,
+          user: { id: 'u-1', name: 'สมชาย', nickname: 'ชาย', employeeId: 'EMP-001',
+            nationalId: '1100700000001', branchId: 'b1', isActive: true } },
+      ]);
+      prisma.employeeProfile.count.mockResolvedValue(1);
+      const res = await service.list({ page: 1, limit: 50 });
+      expect(prisma.employeeProfile.findMany.mock.calls[0][0].where.deletedAt).toBeNull();
+      expect(res).toEqual(expect.objectContaining({ total: 1, page: 1, limit: 50 }));
+      // masked: only last 4 visible
+      expect(res.data[0].nationalId).toBe('•••••••••0001');
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFound when missing', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue(null);
+      await expect(service.findOne('e-x')).rejects.toThrow(NotFoundException);
+    });
+    it('returns full nationalId on detail', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue({
+        id: 'e-1', deletedAt: null,
+        user: { id: 'u-1', name: 'สมชาย', nationalId: '1100700000001' },
+      });
+      const res = await service.findOne('e-1');
+      expect(res.user.nationalId).toBe('1100700000001');
+    });
+  });
 });

--- a/apps/api/src/modules/employees/employees.service.spec.ts
+++ b/apps/api/src/modules/employees/employees.service.spec.ts
@@ -117,4 +117,23 @@ describe('EmployeesService', () => {
       );
     });
   });
+
+  describe('pickable', () => {
+    it('returns active employees WITHOUT nationalId, excludes resigned/deleted', async () => {
+      prisma.employeeProfile.findMany.mockResolvedValue([
+        { id: 'e-1', baseSalary: '15000', ssoEligible: true,
+          user: { id: 'u-1', name: 'สมชาย', nickname: 'ชาย', employeeId: 'EMP-001' } },
+      ]);
+      const res = await service.pickable('สม');
+      const where = prisma.employeeProfile.findMany.mock.calls[0][0].where;
+      expect(where.deletedAt).toBeNull();
+      // resigned filter present
+      expect(where.OR ?? where.resignedDate).toBeDefined();
+      // response shape carries NO nationalId
+      expect(res[0]).toEqual(
+        expect.objectContaining({ userId: 'u-1', name: 'สมชาย', baseSalary: '15000', ssoEligible: true }),
+      );
+      expect(JSON.stringify(res)).not.toContain('nationalId');
+    });
+  });
 });

--- a/apps/api/src/modules/employees/employees.service.spec.ts
+++ b/apps/api/src/modules/employees/employees.service.spec.ts
@@ -12,7 +12,7 @@ describe('EmployeesService', () => {
 
   beforeEach(async () => {
     prisma = {
-      user: { findFirst: jest.fn() },
+      user: { findFirst: jest.fn(), findMany: jest.fn() },
       employeeProfile: {
         findMany: jest.fn(),
         findFirst: jest.fn(),
@@ -135,6 +135,37 @@ describe('EmployeesService', () => {
       );
       expect(JSON.stringify(res)).not.toContain('nationalId');
       expect(res[0]).toEqual(expect.not.objectContaining({ nationalId: expect.anything() }));
+    });
+  });
+
+  describe('provisionable', () => {
+    it('returns users with no profile, excludes system/inactive/deleted, carries NO nationalId', async () => {
+      prisma.user.findMany.mockResolvedValue([
+        { id: 'u-1', employeeId: 'EMP-001', name: 'สมชาย', nickname: 'ชาย' },
+      ]);
+      const res = await service.provisionable();
+      const where = prisma.user.findMany.mock.calls[0][0].where;
+      expect(where.isSystemUser).toBe(false);
+      expect(where.isActive).toBe(true);
+      expect(where.deletedAt).toBeNull();
+      expect(where.employeeProfile).toEqual({ is: null });
+      // response shape carries NO nationalId (PII)
+      expect(JSON.stringify(res)).not.toContain('nationalId');
+      expect(res[0]).toEqual(
+        expect.objectContaining({ userId: 'u-1', employeeId: 'EMP-001', name: 'สมชาย', nickname: 'ชาย' }),
+      );
+      expect(res[0]).toEqual(expect.not.objectContaining({ nationalId: expect.anything() }));
+    });
+
+    it('adds the name/nickname/employeeId OR filter when search is provided', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+      await service.provisionable('สม');
+      const where = prisma.user.findMany.mock.calls[0][0].where;
+      expect(where.OR).toEqual([
+        { name: { contains: 'สม', mode: 'insensitive' } },
+        { nickname: { contains: 'สม', mode: 'insensitive' } },
+        { employeeId: { contains: 'สม', mode: 'insensitive' } },
+      ]);
     });
   });
 });

--- a/apps/api/src/modules/employees/employees.service.spec.ts
+++ b/apps/api/src/modules/employees/employees.service.spec.ts
@@ -88,4 +88,33 @@ describe('EmployeesService', () => {
       expect(res.user.nationalId).toBe('1100700000001');
     });
   });
+
+  describe('update', () => {
+    it('updates fields + audits EMPLOYEE_PROFILE_UPDATED', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue({ id: 'e-1', deletedAt: null,
+        user: { id: 'u-1', name: 'สมชาย', nationalId: '1100700000001' } });
+      prisma.employeeProfile.update.mockResolvedValue({ id: 'e-1', position: 'หัวหน้า' });
+      await service.update('e-1', { position: 'หัวหน้า' }, { userId: 'admin' });
+      expect(prisma.employeeProfile.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'e-1' } }),
+      );
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'EMPLOYEE_PROFILE_UPDATED', entityId: 'e-1' }),
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes + audits EMPLOYEE_PROFILE_DELETED', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue({ id: 'e-1', deletedAt: null,
+        user: { id: 'u-1', name: 'สมชาย', nationalId: '1100700000001' } });
+      prisma.employeeProfile.update.mockResolvedValue({ id: 'e-1', deletedAt: new Date() });
+      await service.remove('e-1', { userId: 'admin' });
+      const call = prisma.employeeProfile.update.mock.calls.at(-1)[0];
+      expect(call.data.deletedAt).toBeInstanceOf(Date);
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'EMPLOYEE_PROFILE_DELETED', entityId: 'e-1' }),
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/employees/employees.service.spec.ts
+++ b/apps/api/src/modules/employees/employees.service.spec.ts
@@ -134,6 +134,7 @@ describe('EmployeesService', () => {
         expect.objectContaining({ userId: 'u-1', name: 'สมชาย', baseSalary: '15000', ssoEligible: true }),
       );
       expect(JSON.stringify(res)).not.toContain('nationalId');
+      expect(res[0]).toEqual(expect.not.objectContaining({ nationalId: expect.anything() }));
     });
   });
 });

--- a/apps/api/src/modules/employees/employees.service.ts
+++ b/apps/api/src/modules/employees/employees.service.ts
@@ -1,0 +1,57 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+
+type Actor = { userId?: string; ipAddress?: string; userAgent?: string };
+
+@Injectable()
+export class EmployeesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async provision(dto: CreateEmployeeDto, actor?: Actor) {
+    const user = await this.prisma.user.findFirst({
+      where: { id: dto.userId, deletedAt: null },
+    });
+    if (!user) throw new NotFoundException('ไม่พบผู้ใช้ที่จะตั้งเป็นพนักงาน');
+
+    try {
+      const profile = await this.prisma.employeeProfile.create({
+        data: {
+          userId: dto.userId,
+          position: dto.position,
+          employmentType: dto.employmentType,
+          baseSalary: dto.baseSalary != null ? new Prisma.Decimal(dto.baseSalary) : null,
+          ssoEligible: dto.ssoEligible,
+          bankName: dto.bankName,
+          bankAccountNo: dto.bankAccountNo,
+          taxIdOverride: dto.taxIdOverride,
+          note: dto.note,
+        },
+      });
+      await this.audit.log({
+        userId: actor?.userId,
+        action: 'EMPLOYEE_PROFILE_CREATED',
+        entity: 'employee_profile',
+        entityId: profile.id,
+        newValue: { userId: dto.userId, position: dto.position },
+        ipAddress: actor?.ipAddress,
+        userAgent: actor?.userAgent,
+      });
+      return profile;
+    } catch (e) {
+      if ((e as { code?: string })?.code === 'P2002') {
+        throw new ConflictException('พนักงานคนนี้มีทะเบียนแล้ว');
+      }
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/modules/employees/employees.service.ts
+++ b/apps/api/src/modules/employees/employees.service.ts
@@ -7,6 +7,7 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
 import { ListEmployeesDto } from './dto/list-employees.dto';
 
 type Actor = { userId?: string; ipAddress?: string; userAgent?: string };
@@ -105,5 +106,50 @@ export class EmployeesService {
     });
     if (!profile) throw new NotFoundException('ไม่พบทะเบียนพนักงาน');
     return profile; // full nationalId — endpoint is OWNER/ACCOUNTANT only
+  }
+
+  async update(id: string, dto: UpdateEmployeeDto, actor?: Actor) {
+    await this.findOne(id); // 404 if missing/deleted
+    const profile = await this.prisma.employeeProfile.update({
+      where: { id },
+      data: {
+        position: dto.position,
+        employmentType: dto.employmentType,
+        baseSalary: dto.baseSalary != null ? new Prisma.Decimal(dto.baseSalary) : undefined,
+        ssoEligible: dto.ssoEligible,
+        bankName: dto.bankName,
+        bankAccountNo: dto.bankAccountNo,
+        taxIdOverride: dto.taxIdOverride,
+        note: dto.note,
+        resignedDate: dto.resignedDate ? new Date(dto.resignedDate) : undefined,
+      },
+    });
+    await this.audit.log({
+      userId: actor?.userId,
+      action: 'EMPLOYEE_PROFILE_UPDATED',
+      entity: 'employee_profile',
+      entityId: id,
+      newValue: dto as Record<string, unknown>,
+      ipAddress: actor?.ipAddress,
+      userAgent: actor?.userAgent,
+    });
+    return profile;
+  }
+
+  async remove(id: string, actor?: Actor) {
+    await this.findOne(id);
+    const profile = await this.prisma.employeeProfile.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+    await this.audit.log({
+      userId: actor?.userId,
+      action: 'EMPLOYEE_PROFILE_DELETED',
+      entity: 'employee_profile',
+      entityId: id,
+      ipAddress: actor?.ipAddress,
+      userAgent: actor?.userAgent,
+    });
+    return profile;
   }
 }

--- a/apps/api/src/modules/employees/employees.service.ts
+++ b/apps/api/src/modules/employees/employees.service.ts
@@ -189,4 +189,33 @@ export class EmployeesService {
       ssoEligible: r.ssoEligible,
     }));
   }
+
+  async provisionable(search?: string) {
+    const where: Prisma.UserWhereInput = {
+      isSystemUser: false,
+      isActive: true,
+      deletedAt: null,
+      employeeProfile: { is: null },
+    };
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { nickname: { contains: search, mode: 'insensitive' } },
+        { employeeId: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+    const rows = await this.prisma.user.findMany({
+      where,
+      orderBy: { name: 'asc' },
+      take: 20,
+      // Explicit projection — NEVER include nationalId here (PII).
+      select: { id: true, employeeId: true, name: true, nickname: true },
+    });
+    return rows.map((u) => ({
+      userId: u.id,
+      employeeId: u.employeeId,
+      name: u.name,
+      nickname: u.nickname,
+    }));
+  }
 }

--- a/apps/api/src/modules/employees/employees.service.ts
+++ b/apps/api/src/modules/employees/employees.service.ts
@@ -152,4 +152,42 @@ export class EmployeesService {
     });
     return profile;
   }
+
+  async pickable(search?: string) {
+    const where: Prisma.EmployeeProfileWhereInput = {
+      deletedAt: null,
+      OR: [{ resignedDate: null }, { resignedDate: { gt: new Date() } }],
+      user: { is: { isActive: true, deletedAt: null } },
+    };
+    if (search) {
+      where.user = {
+        is: {
+          isActive: true,
+          deletedAt: null,
+          OR: [
+            { name: { contains: search, mode: 'insensitive' } },
+            { nickname: { contains: search, mode: 'insensitive' } },
+            { employeeId: { contains: search, mode: 'insensitive' } },
+          ],
+        },
+      };
+    }
+    const rows = await this.prisma.employeeProfile.findMany({
+      where,
+      include: {
+        user: { select: { id: true, name: true, nickname: true, employeeId: true } },
+      },
+      orderBy: { user: { name: 'asc' } },
+      take: 20,
+    });
+    // Explicit projection — NEVER include nationalId here (PII).
+    return rows.map((r) => ({
+      userId: r.user.id,
+      employeeId: r.user.employeeId,
+      name: r.user.name,
+      nickname: r.user.nickname,
+      baseSalary: r.baseSalary, // Decimal → string in JSON; FE parseFloat
+      ssoEligible: r.ssoEligible,
+    }));
+  }
 }

--- a/apps/api/src/modules/employees/employees.service.ts
+++ b/apps/api/src/modules/employees/employees.service.ts
@@ -7,6 +7,7 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { ListEmployeesDto } from './dto/list-employees.dto';
 
 type Actor = { userId?: string; ipAddress?: string; userAgent?: string };
 
@@ -16,6 +17,16 @@ export class EmployeesService {
     private readonly prisma: PrismaService,
     private readonly audit: AuditService,
   ) {}
+
+  private maskNationalId(v: string | null): string | null {
+    if (!v) return v;
+    return '•••••••••' + v.slice(-4);
+  }
+
+  private userSelect = {
+    id: true, name: true, nickname: true, employeeId: true,
+    nationalId: true, startDate: true, branchId: true, isActive: true,
+  };
 
   async provision(dto: CreateEmployeeDto, actor?: Actor) {
     const user = await this.prisma.user.findFirst({
@@ -53,5 +64,46 @@ export class EmployeesService {
       }
       throw e;
     }
+  }
+
+  async list(dto: ListEmployeesDto) {
+    const page = dto.page ?? 1;
+    const limit = dto.limit ?? 50;
+    const where: Prisma.EmployeeProfileWhereInput = { deletedAt: null };
+    if (dto.isActive === 'true') where.resignedDate = null;
+    if (dto.search) {
+      where.user = {
+        OR: [
+          { name: { contains: dto.search, mode: 'insensitive' } },
+          { nickname: { contains: dto.search, mode: 'insensitive' } },
+          { employeeId: { contains: dto.search, mode: 'insensitive' } },
+        ],
+      };
+    }
+    const [rows, total] = await Promise.all([
+      this.prisma.employeeProfile.findMany({
+        where,
+        include: { user: { select: this.userSelect } },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.employeeProfile.count({ where }),
+    ]);
+    const data = rows.map((r) => ({
+      ...r,
+      nationalId: this.maskNationalId(r.user.nationalId),
+      user: { ...r.user, nationalId: this.maskNationalId(r.user.nationalId) },
+    }));
+    return { data, total, page, limit };
+  }
+
+  async findOne(id: string) {
+    const profile = await this.prisma.employeeProfile.findFirst({
+      where: { id, deletedAt: null },
+      include: { user: { select: this.userSelect } },
+    });
+    if (!profile) throw new NotFoundException('ไม่พบทะเบียนพนักงาน');
+    return profile; // full nationalId — endpoint is OWNER/ACCOUNTANT only
   }
 }

--- a/apps/api/src/modules/employees/employees.service.ts
+++ b/apps/api/src/modules/employees/employees.service.ts
@@ -91,11 +91,10 @@ export class EmployeesService {
       }),
       this.prisma.employeeProfile.count({ where }),
     ]);
-    const data = rows.map((r) => ({
-      ...r,
-      nationalId: this.maskNationalId(r.user.nationalId),
-      user: { ...r.user, nationalId: this.maskNationalId(r.user.nationalId) },
-    }));
+    const data = rows.map((r) => {
+      const maskedId = this.maskNationalId(r.user.nationalId);
+      return { ...r, nationalId: maskedId, user: { ...r.user, nationalId: maskedId } };
+    });
     return { data, total, page, limit };
   }
 

--- a/docs/superpowers/plans/2026-06-04-employee-master-prA-backend.md
+++ b/docs/superpowers/plans/2026-06-04-employee-master-prA-backend.md
@@ -1,0 +1,818 @@
+# Employee Master — PR-A (Backend Master) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the backend of the Employee Master — an `EmployeeProfile` (1:1 with `User`) plus an `employees` NestJS module (CRUD + a PII-safe `pickable` endpoint) that later PRs (frontend, payroll link) build on.
+
+**Architecture:** New `EmployeeProfile` table keyed by `userId @unique` holds payroll/employment data (position, employmentType, baseSalary, ssoEligible, bank, taxIdOverride, resignedDate). Identity/PII (`name`, `nationalId`, `startDate`…) stays on the existing `User`. `nationalId` is returned only via OWNER/ACCOUNTANT endpoints (masked in list, full in detail) and **never** via `pickable`. This PR does NOT touch payroll (that is PR-C).
+
+**Tech Stack:** NestJS + Prisma + PostgreSQL. Jest (run `--runInBand`). class-validator (Thai messages). Pattern reference: `apps/api/src/modules/contacts/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-employee-master-design.md` (§2 data model, §4.1 API, §6 testing). Scope of THIS plan = PR-A only.
+
+**Branch:** `feat/employee-master` (already created off main).
+
+---
+
+## File Structure (PR-A)
+
+- Modify: `apps/api/prisma/schema.prisma` — add `EmploymentType` enum, `EmployeeProfile` model, `User.employeeProfile` back-relation
+- Create: `apps/api/prisma/migrations/<ts>_add_employee_profile/migration.sql` (generated)
+- Create: `apps/api/src/modules/employees/dto/create-employee.dto.ts`
+- Create: `apps/api/src/modules/employees/dto/update-employee.dto.ts`
+- Create: `apps/api/src/modules/employees/dto/list-employees.dto.ts`
+- Create: `apps/api/src/modules/employees/employees.service.ts`
+- Create: `apps/api/src/modules/employees/employees.controller.ts`
+- Create: `apps/api/src/modules/employees/employees.module.ts`
+- Create: `apps/api/src/modules/employees/employees.service.spec.ts`
+- Modify: `apps/api/src/app.module.ts` — register `EmployeesModule`
+
+**Audit actions:** `EMPLOYEE_PROFILE_CREATED` / `EMPLOYEE_PROFILE_UPDATED` / `EMPLOYEE_PROFILE_DELETED` (entity `employee_profile`).
+
+---
+
+## Task 1: Schema + migration
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma`
+- Create (generated): `apps/api/prisma/migrations/<ts>_add_employee_profile/migration.sql`
+
+- [ ] **Step 1: Add the enum + model to `schema.prisma`** (place enum near the other enums at top; model near `User`)
+
+```prisma
+enum EmploymentType {
+  MONTHLY
+  DAILY
+  CONTRACT
+}
+
+model EmployeeProfile {
+  id             String         @id @default(uuid())
+  userId         String         @unique @map("user_id")
+  user           User           @relation(fields: [userId], references: [id])
+  position       String?
+  employmentType EmploymentType @default(MONTHLY) @map("employment_type")
+  baseSalary     Decimal?       @map("base_salary") @db.Decimal(12, 2)
+  ssoEligible    Boolean        @default(true) @map("sso_eligible")
+  bankName       String?        @map("bank_name")
+  bankAccountNo  String?        @map("bank_account_no")
+  taxIdOverride  String?        @map("tax_id_override")
+  note           String?
+  resignedDate   DateTime?      @map("resigned_date")
+  createdAt      DateTime       @default(now()) @map("created_at")
+  updatedAt      DateTime       @updatedAt @map("updated_at")
+  deletedAt      DateTime?      @map("deleted_at")
+
+  @@index([deletedAt])
+  @@map("employee_profiles")
+}
+```
+
+- [ ] **Step 2: Add the back-relation on `User`** — inside `model User { ... }` add one line alongside the other relations:
+
+```prisma
+  employeeProfile EmployeeProfile?
+```
+
+- [ ] **Step 3: Generate the migration**
+
+Run (from `apps/api`): `npm run prisma:migrate -- --name add_employee_profile`
+Expected: a new folder `apps/api/prisma/migrations/<timestamp>_add_employee_profile/` with `migration.sql` creating the `EmploymentType` enum + `employee_profiles` table + unique index on `user_id`; Prisma Client regenerates. No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations
+git commit -m "feat(employees): EmployeeProfile schema + migration"
+```
+
+---
+
+## Task 2: DTOs
+
+**Files:**
+- Create: `apps/api/src/modules/employees/dto/create-employee.dto.ts`
+- Create: `apps/api/src/modules/employees/dto/update-employee.dto.ts`
+- Create: `apps/api/src/modules/employees/dto/list-employees.dto.ts`
+
+- [ ] **Step 1: Create `create-employee.dto.ts`**
+
+```typescript
+import {
+  IsBoolean,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
+import { EmploymentType } from '@prisma/client';
+
+export class CreateEmployeeDto {
+  @IsUUID(undefined, { message: 'กรุณาเลือกผู้ใช้ (พนักงาน)' })
+  userId!: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsEnum(EmploymentType, { message: 'ประเภทการจ้างไม่ถูกต้อง' })
+  employmentType?: EmploymentType;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'ฐานเงินเดือนต้องเป็นตัวเลข' })
+  @Min(0, { message: 'ฐานเงินเดือนต้องไม่ติดลบ' })
+  baseSalary?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  ssoEligible?: boolean;
+
+  @IsOptional()
+  @IsString()
+  bankName?: string;
+
+  @IsOptional()
+  @IsString()
+  bankAccountNo?: string;
+
+  @IsOptional()
+  @IsString()
+  taxIdOverride?: string;
+
+  @IsOptional()
+  @IsString()
+  note?: string;
+}
+```
+
+- [ ] **Step 2: Create `update-employee.dto.ts`** (every field optional; resignedDate added)
+
+```typescript
+import { IsDateString, IsOptional } from 'class-validator';
+import { CreateEmployeeDto } from './create-employee.dto';
+
+// Update = all of Create's fields optional, minus userId (cannot reassign the
+// owning user), plus resignedDate.
+export class UpdateEmployeeDto implements Partial<Omit<CreateEmployeeDto, 'userId'>> {
+  position?: string;
+  employmentType?: CreateEmployeeDto['employmentType'];
+  baseSalary?: number;
+  ssoEligible?: boolean;
+  bankName?: string;
+  bankAccountNo?: string;
+  taxIdOverride?: string;
+  note?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'วันที่ลาออกไม่ถูกต้อง' })
+  resignedDate?: string;
+}
+```
+
+> Note: validators on the inherited fields come from a hand-written body here for clarity. If the repo uses `@nestjs/mapped-types` `PartialType` elsewhere, prefer `extends PartialType(OmitType(CreateEmployeeDto, ['userId']))` + add `resignedDate`. Check `apps/api/src/modules/*/dto` for an existing `PartialType` usage before choosing; mirror it.
+
+- [ ] **Step 3: Create `list-employees.dto.ts`**
+
+```typescript
+import { IsBooleanString, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ListEmployeesDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsBooleanString()
+  isActive?: string; // 'true' | 'false' — by EmployeeProfile.deletedAt + resigned
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/modules/employees/dto
+git commit -m "feat(employees): DTOs (create/update/list) with Thai validation"
+```
+
+---
+
+## Task 3: Service — `provision` (create) with audit + P2002
+
+**Files:**
+- Create: `apps/api/src/modules/employees/employees.service.ts`
+- Create: `apps/api/src/modules/employees/employees.service.spec.ts`
+
+- [ ] **Step 1: Write the failing test** (`employees.service.spec.ts`)
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { EmployeesService } from './employees.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+describe('EmployeesService', () => {
+  let service: EmployeesService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let audit: { log: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      user: { findFirst: jest.fn() },
+      employeeProfile: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+    };
+    audit = { log: jest.fn() };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmployeesService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+
+    service = moduleRef.get(EmployeesService);
+  });
+
+  describe('provision', () => {
+    it('rejects when the user does not exist', async () => {
+      prisma.user.findFirst.mockResolvedValue(null);
+      await expect(service.provision({ userId: 'u-x' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('creates a profile + writes EMPLOYEE_PROFILE_CREATED audit', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'u-1', name: 'สมชาย' });
+      prisma.employeeProfile.create.mockResolvedValue({ id: 'e-1', userId: 'u-1' });
+      const res = await service.provision({ userId: 'u-1', position: 'ช่าง' }, { userId: 'admin' });
+      expect(prisma.employeeProfile.create).toHaveBeenCalled();
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'EMPLOYEE_PROFILE_CREATED', entity: 'employee_profile', entityId: 'e-1' }),
+      );
+      expect(res.id).toBe('e-1');
+    });
+
+    it('maps a duplicate (P2002) to ConflictException', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'u-1' });
+      prisma.employeeProfile.create.mockRejectedValue({ code: 'P2002' });
+      await expect(service.provision({ userId: 'u-1' })).rejects.toThrow(ConflictException);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run (from `apps/api`): `npm test -- --runInBand src/modules/employees/employees.service.spec.ts`
+Expected: FAIL — `Cannot find module './employees.service'`.
+
+- [ ] **Step 3: Write minimal `employees.service.ts`**
+
+```typescript
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+
+type Actor = { userId?: string; ipAddress?: string; userAgent?: string };
+
+@Injectable()
+export class EmployeesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async provision(dto: CreateEmployeeDto, actor?: Actor) {
+    const user = await this.prisma.user.findFirst({
+      where: { id: dto.userId, deletedAt: null },
+    });
+    if (!user) throw new NotFoundException('ไม่พบผู้ใช้ที่จะตั้งเป็นพนักงาน');
+
+    try {
+      const profile = await this.prisma.employeeProfile.create({
+        data: {
+          userId: dto.userId,
+          position: dto.position,
+          employmentType: dto.employmentType,
+          baseSalary: dto.baseSalary != null ? new Prisma.Decimal(dto.baseSalary) : null,
+          ssoEligible: dto.ssoEligible,
+          bankName: dto.bankName,
+          bankAccountNo: dto.bankAccountNo,
+          taxIdOverride: dto.taxIdOverride,
+          note: dto.note,
+        },
+      });
+      await this.audit.log({
+        userId: actor?.userId,
+        action: 'EMPLOYEE_PROFILE_CREATED',
+        entity: 'employee_profile',
+        entityId: profile.id,
+        newValue: { userId: dto.userId, position: dto.position },
+        ipAddress: actor?.ipAddress,
+        userAgent: actor?.userAgent,
+      });
+      return profile;
+    } catch (e) {
+      if ((e as { code?: string })?.code === 'P2002') {
+        throw new ConflictException('พนักงานคนนี้มีทะเบียนแล้ว');
+      }
+      throw e;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `npm test -- --runInBand src/modules/employees/employees.service.spec.ts`
+Expected: PASS (3 tests in `provision`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/employees/employees.service.ts apps/api/src/modules/employees/employees.service.spec.ts
+git commit -m "feat(employees): service.provision with audit + P2002 conflict"
+```
+
+---
+
+## Task 4: Service — `list` (masked nationalId) + `findOne` (full)
+
+**Files:**
+- Modify: `apps/api/src/modules/employees/employees.service.ts`
+- Modify: `apps/api/src/modules/employees/employees.service.spec.ts`
+
+- [ ] **Step 1: Add the failing tests** (append inside the top-level `describe`)
+
+```typescript
+  describe('list', () => {
+    it('filters out soft-deleted, masks nationalId, returns paginated shape', async () => {
+      prisma.employeeProfile.findMany.mockResolvedValue([
+        { id: 'e-1', position: 'ช่าง', employmentType: 'MONTHLY', deletedAt: null,
+          user: { id: 'u-1', name: 'สมชาย', nickname: 'ชาย', employeeId: 'EMP-001',
+            nationalId: '1100700000001', branchId: 'b1', isActive: true } },
+      ]);
+      prisma.employeeProfile.count.mockResolvedValue(1);
+      const res = await service.list({ page: 1, limit: 50 });
+      expect(prisma.employeeProfile.findMany.mock.calls[0][0].where.deletedAt).toBeNull();
+      expect(res).toEqual(expect.objectContaining({ total: 1, page: 1, limit: 50 }));
+      // masked: only last 4 visible
+      expect(res.data[0].nationalId).toBe('•••••••••0001');
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFound when missing', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue(null);
+      await expect(service.findOne('e-x')).rejects.toThrow(NotFoundException);
+    });
+    it('returns full nationalId on detail', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue({
+        id: 'e-1', deletedAt: null,
+        user: { id: 'u-1', name: 'สมชาย', nationalId: '1100700000001' },
+      });
+      const res = await service.findOne('e-1');
+      expect(res.user.nationalId).toBe('1100700000001');
+    });
+  });
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `npm test -- --runInBand src/modules/employees/employees.service.spec.ts`
+Expected: FAIL — `service.list is not a function`.
+
+- [ ] **Step 3: Implement `list` + `findOne` + a mask helper** (add to the service class; add `ListEmployeesDto` import)
+
+```typescript
+  // add import at top:
+  // import { ListEmployeesDto } from './dto/list-employees.dto';
+
+  private maskNationalId(v: string | null): string | null {
+    if (!v) return v;
+    return '•••••••••' + v.slice(-4);
+  }
+
+  private userSelect = {
+    id: true, name: true, nickname: true, employeeId: true,
+    nationalId: true, startDate: true, branchId: true, isActive: true,
+  };
+
+  async list(dto: ListEmployeesDto) {
+    const page = dto.page ?? 1;
+    const limit = dto.limit ?? 50;
+    const where: Prisma.EmployeeProfileWhereInput = { deletedAt: null };
+    if (dto.isActive === 'true') where.resignedDate = null;
+    if (dto.search) {
+      where.user = {
+        OR: [
+          { name: { contains: dto.search, mode: 'insensitive' } },
+          { nickname: { contains: dto.search, mode: 'insensitive' } },
+          { employeeId: { contains: dto.search, mode: 'insensitive' } },
+        ],
+      };
+    }
+    const [rows, total] = await Promise.all([
+      this.prisma.employeeProfile.findMany({
+        where,
+        include: { user: { select: this.userSelect } },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.employeeProfile.count({ where }),
+    ]);
+    const data = rows.map((r) => ({
+      ...r,
+      nationalId: this.maskNationalId(r.user.nationalId),
+      user: { ...r.user, nationalId: this.maskNationalId(r.user.nationalId) },
+    }));
+    return { data, total, page, limit };
+  }
+
+  async findOne(id: string) {
+    const profile = await this.prisma.employeeProfile.findFirst({
+      where: { id, deletedAt: null },
+      include: { user: { select: this.userSelect } },
+    });
+    if (!profile) throw new NotFoundException('ไม่พบทะเบียนพนักงาน');
+    return profile; // full nationalId — endpoint is OWNER/ACCOUNTANT only
+  }
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npm test -- --runInBand src/modules/employees/employees.service.spec.ts`
+Expected: PASS (list + findOne tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/employees/employees.service.ts apps/api/src/modules/employees/employees.service.spec.ts
+git commit -m "feat(employees): list (masked nationalId) + findOne (full)"
+```
+
+---
+
+## Task 5: Service — `update` + `remove` (soft-delete) with audit
+
+**Files:** modify service + spec.
+
+- [ ] **Step 1: Add failing tests**
+
+```typescript
+  describe('update', () => {
+    it('updates fields + audits EMPLOYEE_PROFILE_UPDATED', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue({ id: 'e-1', deletedAt: null,
+        user: { id: 'u-1', name: 'สมชาย', nationalId: '1100700000001' } });
+      prisma.employeeProfile.update.mockResolvedValue({ id: 'e-1', position: 'หัวหน้า' });
+      await service.update('e-1', { position: 'หัวหน้า' }, { userId: 'admin' });
+      expect(prisma.employeeProfile.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'e-1' } }),
+      );
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'EMPLOYEE_PROFILE_UPDATED', entityId: 'e-1' }),
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes + audits EMPLOYEE_PROFILE_DELETED', async () => {
+      prisma.employeeProfile.findFirst.mockResolvedValue({ id: 'e-1', deletedAt: null,
+        user: { id: 'u-1', name: 'สมชาย', nationalId: '1100700000001' } });
+      prisma.employeeProfile.update.mockResolvedValue({ id: 'e-1', deletedAt: new Date() });
+      await service.remove('e-1', { userId: 'admin' });
+      const call = prisma.employeeProfile.update.mock.calls.at(-1)[0];
+      expect(call.data.deletedAt).toBeInstanceOf(Date);
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'EMPLOYEE_PROFILE_DELETED', entityId: 'e-1' }),
+      );
+    });
+  });
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `npm test -- --runInBand src/modules/employees/employees.service.spec.ts`
+Expected: FAIL — `service.update is not a function`.
+
+- [ ] **Step 3: Implement** (add `UpdateEmployeeDto` import; reuse `findOne`)
+
+```typescript
+  // import { UpdateEmployeeDto } from './dto/update-employee.dto';
+
+  async update(id: string, dto: UpdateEmployeeDto, actor?: Actor) {
+    await this.findOne(id); // 404 if missing/deleted
+    const profile = await this.prisma.employeeProfile.update({
+      where: { id },
+      data: {
+        position: dto.position,
+        employmentType: dto.employmentType,
+        baseSalary: dto.baseSalary != null ? new Prisma.Decimal(dto.baseSalary) : undefined,
+        ssoEligible: dto.ssoEligible,
+        bankName: dto.bankName,
+        bankAccountNo: dto.bankAccountNo,
+        taxIdOverride: dto.taxIdOverride,
+        note: dto.note,
+        resignedDate: dto.resignedDate ? new Date(dto.resignedDate) : undefined,
+      },
+    });
+    await this.audit.log({
+      userId: actor?.userId,
+      action: 'EMPLOYEE_PROFILE_UPDATED',
+      entity: 'employee_profile',
+      entityId: id,
+      newValue: dto as Record<string, unknown>,
+      ipAddress: actor?.ipAddress,
+      userAgent: actor?.userAgent,
+    });
+    return profile;
+  }
+
+  async remove(id: string, actor?: Actor) {
+    await this.findOne(id);
+    const profile = await this.prisma.employeeProfile.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+    await this.audit.log({
+      userId: actor?.userId,
+      action: 'EMPLOYEE_PROFILE_DELETED',
+      entity: 'employee_profile',
+      entityId: id,
+      ipAddress: actor?.ipAddress,
+      userAgent: actor?.userAgent,
+    });
+    return profile;
+  }
+```
+
+- [ ] **Step 4: Run, verify pass** — `npm test -- --runInBand src/modules/employees/employees.service.spec.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/employees/employees.service.ts apps/api/src/modules/employees/employees.service.spec.ts
+git commit -m "feat(employees): update + soft-delete with audit"
+```
+
+---
+
+## Task 6: Service — `pickable` (no PII, resigned filter)
+
+**Files:** modify service + spec.
+
+- [ ] **Step 1: Add failing tests**
+
+```typescript
+  describe('pickable', () => {
+    it('returns active employees WITHOUT nationalId, excludes resigned/deleted', async () => {
+      prisma.employeeProfile.findMany.mockResolvedValue([
+        { id: 'e-1', baseSalary: '15000', ssoEligible: true,
+          user: { id: 'u-1', name: 'สมชาย', nickname: 'ชาย', employeeId: 'EMP-001' } },
+      ]);
+      const res = await service.pickable('สม');
+      const where = prisma.employeeProfile.findMany.mock.calls[0][0].where;
+      expect(where.deletedAt).toBeNull();
+      // resigned filter present
+      expect(where.OR ?? where.resignedDate).toBeDefined();
+      // response shape carries NO nationalId
+      expect(res[0]).toEqual(
+        expect.objectContaining({ userId: 'u-1', name: 'สมชาย', baseSalary: '15000', ssoEligible: true }),
+      );
+      expect(JSON.stringify(res)).not.toContain('nationalId');
+    });
+  });
+```
+
+- [ ] **Step 2: Run, verify fail** — `service.pickable is not a function`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+  async pickable(search?: string) {
+    const where: Prisma.EmployeeProfileWhereInput = {
+      deletedAt: null,
+      OR: [{ resignedDate: null }, { resignedDate: { gt: new Date() } }],
+      user: { is: { isActive: true, deletedAt: null } },
+    };
+    if (search) {
+      where.user = {
+        is: {
+          isActive: true,
+          deletedAt: null,
+          OR: [
+            { name: { contains: search, mode: 'insensitive' } },
+            { nickname: { contains: search, mode: 'insensitive' } },
+            { employeeId: { contains: search, mode: 'insensitive' } },
+          ],
+        },
+      };
+    }
+    const rows = await this.prisma.employeeProfile.findMany({
+      where,
+      include: {
+        user: { select: { id: true, name: true, nickname: true, employeeId: true } },
+      },
+      orderBy: { user: { name: 'asc' } },
+      take: 20,
+    });
+    // Explicit projection — NEVER include nationalId here (PII).
+    return rows.map((r) => ({
+      userId: r.user.id,
+      employeeId: r.user.employeeId,
+      name: r.user.name,
+      nickname: r.user.nickname,
+      baseSalary: r.baseSalary, // Decimal → string in JSON; FE parseFloat
+      ssoEligible: r.ssoEligible,
+    }));
+  }
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/employees/employees.service.ts apps/api/src/modules/employees/employees.service.spec.ts
+git commit -m "feat(employees): pickable endpoint (PII-safe, resigned filter)"
+```
+
+---
+
+## Task 7: Controller + module + registration
+
+**Files:**
+- Create: `apps/api/src/modules/employees/employees.controller.ts`
+- Create: `apps/api/src/modules/employees/employees.module.ts`
+- Modify: `apps/api/src/app.module.ts`
+
+- [ ] **Step 1: Create `employees.controller.ts`**
+
+```typescript
+import {
+  Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { EmployeesService } from './employees.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import { ListEmployeesDto } from './dto/list-employees.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+type AuthRequest = Request & { user?: { id: string; role: string } };
+const actorOf = (req: AuthRequest) => ({
+  userId: req.user?.id,
+  ipAddress: req.ip,
+  userAgent: req.headers['user-agent'] as string | undefined,
+});
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('employees')
+export class EmployeesController {
+  constructor(private readonly employees: EmployeesService) {}
+
+  @Get()
+  @Roles('OWNER', 'ACCOUNTANT')
+  list(@Query() dto: ListEmployeesDto) {
+    return this.employees.list(dto);
+  }
+
+  @Get('pickable')
+  @Roles('OWNER', 'ACCOUNTANT', 'FINANCE_MANAGER')
+  pickable(@Query('search') search?: string) {
+    return this.employees.pickable(search);
+  }
+
+  @Get(':id')
+  @Roles('OWNER', 'ACCOUNTANT')
+  findOne(@Param('id') id: string) {
+    return this.employees.findOne(id);
+  }
+
+  @Post()
+  @Roles('OWNER', 'ACCOUNTANT')
+  provision(@Body() dto: CreateEmployeeDto, @Req() req: AuthRequest) {
+    return this.employees.provision(dto, actorOf(req));
+  }
+
+  @Patch(':id')
+  @Roles('OWNER', 'ACCOUNTANT')
+  update(@Param('id') id: string, @Body() dto: UpdateEmployeeDto, @Req() req: AuthRequest) {
+    return this.employees.update(id, dto, actorOf(req));
+  }
+
+  @Delete(':id')
+  @Roles('OWNER', 'ACCOUNTANT')
+  remove(@Param('id') id: string, @Req() req: AuthRequest) {
+    return this.employees.remove(id, actorOf(req));
+  }
+}
+```
+
+> Route ordering: `@Get('pickable')` is declared BEFORE `@Get(':id')` so `/employees/pickable` is not captured by the `:id` param route.
+
+- [ ] **Step 2: Create `employees.module.ts`**
+
+```typescript
+import { Module } from '@nestjs/common';
+import { EmployeesController } from './employees.controller';
+import { EmployeesService } from './employees.service';
+
+// PrismaModule + AuditModule are @Global() — no explicit import needed here
+// (mirrors contacts.module.ts).
+@Module({
+  controllers: [EmployeesController],
+  providers: [EmployeesService],
+  exports: [EmployeesService],
+})
+export class EmployeesModule {}
+```
+
+> Before running, verify `AuditModule` is `@Global()` (grep `@Global` in `apps/api/src/modules/audit/audit.module.ts`). If it is NOT global, add `imports: [AuditModule]` to this module.
+
+- [ ] **Step 3: Register in `app.module.ts`**
+
+Add the import near the other module imports, and add `EmployeesModule` to the `imports` array:
+
+```typescript
+import { EmployeesModule } from './modules/employees/employees.module';
+// ... in @Module({ imports: [ ... , EmployeesModule, ... ] })
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run (from repo root): `./tools/check-types.sh api`
+Expected: `API: OK` / passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/employees apps/api/src/app.module.ts
+git commit -m "feat(employees): controller + module + app registration"
+```
+
+---
+
+## Task 8: Full suite + open PR
+
+- [ ] **Step 1: Run the employees suite + a quick broad sanity check**
+
+Run (from `apps/api`): `npm test -- --runInBand src/modules/employees`
+Expected: all green.
+
+- [ ] **Step 2: Typecheck whole API**
+
+Run: `./tools/check-types.sh api` → OK.
+
+- [ ] **Step 3: Push + open PR (leave merge to owner, per project workflow)**
+
+```bash
+git push -u origin feat/employee-master
+gh pr create --base main --head feat/employee-master \
+  --title "feat(employees): Employee Master backend — EmployeeProfile + employees module (PR-A)" \
+  --body "Implements PR-A of the Employee Master spec (docs/superpowers/specs/2026-06-04-employee-master-design.md): EmployeeProfile (1:1 User) + employees module (CRUD + PII-safe pickable). No payroll changes (PR-C). nationalId never returned by pickable; masked in list, full in OWNER/ACCOUNTANT detail. Tests: employees.service.spec --runInBand green; api tsc OK."
+```
+
+> After this PR merges, write the PR-B plan (frontend master page + EmployeeCombobox).
+
+---
+
+## Self-Review checklist (done while writing)
+
+- **Spec coverage (PR-A scope):** EmployeeProfile model ✅ (Task 1); enum ✅; migration ✅; module CRUD ✅ (Tasks 3-7); pickable no-nationalId + resigned filter ✅ (Task 6); masked list / full detail ✅ (Task 4); RBAC OWNER/ACC (+FM pickable) ✅ (Task 7); audit create/update/delete ✅; P2002 conflict ✅. Payroll link, frontend, backfill = OUT of PR-A (PR-C/B/D).
+- **Placeholders:** none — every step has real code + exact commands.
+- **Type consistency:** service methods `provision/list/findOne/update/remove/pickable` match controller calls; DTO field names match service `data:` keys; `userSelect`/`maskNationalId` reused consistently.
+- **Assumptions verified (2026-06-04):** ✅ `AuditModule` is `@Global()` (audit.module.ts:8) — no import needed. ✅ `AuditService.log(entry)` takes `{ userId?, action, entity, entityId?, oldValue?, newValue?, ipAddress?, userAgent? }` (audit.service.ts:58 + AuditEntry interface) — matches the plan's calls exactly. NB: `log()` early-returns when `userId` is falsy (audit.service.ts:60), so always pass a real actor.userId in runtime callers (the controller does via `actorOf(req)`).
+- **Still verify at execution:** whether the repo prefers `PartialType` (from `@nestjs/mapped-types`) for UpdateDto — grep `PartialType` in `apps/api/src/modules/*/dto`; if common, refactor `UpdateEmployeeDto` to `PartialType(OmitType(CreateEmployeeDto, ['userId']))` + `resignedDate`.

--- a/docs/superpowers/specs/2026-06-04-employee-master-design.md
+++ b/docs/superpowers/specs/2026-06-04-employee-master-design.md
@@ -1,0 +1,208 @@
+# Employee Master — ทะเบียนพนักงาน + ปิด free-text payroll
+
+วันที่: 2026-06-04
+สถานะ: รออนุมัติ spec จาก owner (brainstorm เสร็จ — รอ review ก่อนทำ implementation plan)
+ส่วนหนึ่งของ: ขยายหลัก "ห้าม free-text คน" (party-master) จาก Contact ไปถึง **พนักงาน**
+
+> **ที่มา:** epic Party Master Mandatory (#1143–1149) ปิด free-text "คน" ทุก picker ฝั่งคู่ค้า
+> (ลูกค้า/ผู้ขาย/คนขายมือสอง/ไฟแนนซ์) ผ่าน `Contact`. free-text "คน" ที่ยังเหลือคือ **พนักงาน**:
+> `PayrollLine.employeeName` (required) + `employeeTaxId` (optional) ที่พิมพ์มือใน
+> `PayrollLinesSection.tsx`. (custodian เงินสดย่อยเป็น User FK อยู่แล้ว — ไม่ใช่ free-text)
+
+---
+
+## 1. การตัดสินใจสถาปัตยกรรม (decisions log)
+
+| # | คำถาม | คำตอบที่เคาะ |
+|---|---|---|
+| 1 | ขอบเขต | **HR-lite เต็ม** (ทะเบียน + ประวัติ + เอกสาร + lifecycle) — แต่ spec นี้ทำ **Phase 1+2**, Phase 3 เป็น roadmap |
+| 2 | พนักงาน vs User | **พนักงานทุกคน = User อยู่แล้ว** (มี login ครบ) |
+| 3 | วางข้อมูลที่ไหน | **`EmployeeProfile` 1:1 กับ User** (ไม่ใช่ Contact role, ไม่ยัดลง User ตรงๆ) |
+| 4 | phasing | spec **Phase 1+2 รวมกัน** (master + payroll pre-fill/tax fields) |
+| 5 | PII (เลขบัตร/SSO) | **Plaintext + RBAC** (อ่านได้เฉพาะ OWNER/ACCOUNTANT — ต้องใช้เลขจริงยื่น ภงด.1/สปส.1-10) |
+
+**ทำไม EmployeeProfile แทน Contact+role EMPLOYEE:** พนักงาน = คนภายในที่มี User อยู่แล้ว;
+Contact มีไว้สำหรับคู่ค้า**ภายนอก** — เอาพนักงานไปปนสมุดผู้ขาย/ลูกค้า + บันทึกซ้ำ (User+Contact คนเดียว)
+ไม่สมเหตุผล. EmployeeProfile ผูก User ตรง ใช้ FK แบบเดียวกับ custodian.
+
+**ทำไม EmployeeProfile แทนยัดลง User:** (1) HR-lite Phase 3 (ประวัติเงินเดือน/เอกสาร/lifecycle)
+hang ตารางลูกจาก EmployeeProfile ได้สะอาด (2) การมี profile = flag "เป็นพนักงาน payroll" ชัด
+(User integration/ระบบ ไม่มี profile) (3) salary/bank/SSO เป็น payroll concern ไม่ใช่ auth.
+
+**ของจริงที่ User มีอยู่แล้ว (ไม่สร้างซ้ำ):** `employeeId` (รหัสพนักงาน, @unique), `name`, `nickname`,
+`nationalId` (เลข 13 หลัก plaintext = เลขผู้เสียภาษี + SSO id), `startDate`, `birthDate`, `phone`,
+`address`, `branchId`, `isActive`, `isSystemUser`.
+
+---
+
+## 2. Data Model
+
+### 2.1 `User` (เดิม — ไม่แตะ schema)
+ใช้ field ที่มี: `employeeId`, `name`, `nickname`, `nationalId`, `startDate`, `birthDate`,
+`phone`, `address`, `branchId`, `isActive`, `isSystemUser`.
+
+### 2.2 `EmployeeProfile` (ใหม่ — 1:1 User)
+```prisma
+enum EmploymentType { MONTHLY DAILY CONTRACT }
+
+model EmployeeProfile {
+  id             String         @id @default(uuid())
+  userId         String         @unique @map("user_id")   // FK → User ; presence = "เป็นพนักงาน payroll"
+  user           User           @relation(fields: [userId], references: [id])
+  position       String?                                   // ตำแหน่ง
+  employmentType EmploymentType @default(MONTHLY) @map("employment_type")
+  baseSalary     Decimal?       @map("base_salary") @db.Decimal(12, 2)   // ฐานเงินเดือน default → pre-fill
+  ssoEligible    Boolean        @default(true) @map("sso_eligible")      // เข้าประกันสังคมไหม
+  bankName       String?        @map("bank_name")
+  bankAccountNo  String?        @map("bank_account_no")
+  taxIdOverride  String?        @map("tax_id_override")    // เผื่อ taxId ≠ nationalId (ต่างด้าว) ; null = ใช้ User.nationalId
+  note           String?
+  resignedDate   DateTime?      @map("resigned_date")      // startDate อยู่ที่ User แล้ว
+  createdAt      DateTime       @default(now()) @map("created_at")
+  updatedAt      DateTime       @updatedAt @map("updated_at")
+  deletedAt      DateTime?      @map("deleted_at")
+
+  @@map("employee_profiles")
+}
+```
+(User เพิ่ม relation back: `employeeProfile EmployeeProfile?`)
+
+### 2.3 `PayrollLine` (แก้ — เพิ่ม FK + คง snapshot)
+```prisma
+model PayrollLine {
+  // ...เดิม...
+  userId        String?  @map("user_id")          // ใหม่: FK → User (= ปิด free-text)
+  user          User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  employeeName  String                            // คงไว้เป็น SNAPSHOT (ตั้งจาก User ตอนสร้าง)
+  employeeTaxId String?                           // คง SNAPSHOT
+  // ...
+  @@index([userId])
+}
+```
+> `userId` **optional** (เหมือน `ExpenseDocument.vendorSupplierId`) — แถวเก่า backfill ทีหลัง, ไม่ break.
+> snapshot `employeeName`/`employeeTaxId` = หลักเดียวกับ party-master (เก็บค่า ณ เวลาทำรายการ —
+> ประวัติ payroll ต้องไม่เปลี่ยนตามชื่อที่แก้ทีหลัง = historical correctness).
+
+---
+
+## 3. UI
+
+### 3.1 หน้า Employee Master `/employees` (RBAC: OWNER, ACCOUNTANT)
+- **List**: ค้นหา/กรอง active, คอลัมน์ รหัสพนักงาน · ชื่อ(เล่น) · ตำแหน่ง · ประเภทจ้าง · สาขา · สถานะ
+- **Detail/Edit**: provision `EmployeeProfile` จาก User ที่ยังไม่มี profile (เลือก User → กรอก
+  position/baseSalary/bank/ssoEligible) + แก้ field payroll. `nationalId`/`startDate` แก้บนข้อมูล User
+  (deep-link `/users` หรือ inline) — ไม่ทำซ้ำ.
+- `nationalId` แสดง **เฉพาะ OWNER/ACCOUNTANT** (RBAC ตาม PII).
+- pattern ตาม `CustomersPage.tsx` (list) + react-query + semantic tokens + Thai `leading-snug`.
+
+### 3.2 Payroll picker — แก้ `PayrollLinesSection.tsx` คอลัมน์ "ชื่อ"
+- free-text input → **`EmployeeCombobox`** (search active employees ; pattern คล้าย `ContactCombobox`
+  แต่ **ไม่มี inline-create** — พนักงาน=User สร้างที่ `/users`/master ก่อน ; ถ้าไม่เจอโชว์
+  "เพิ่มพนักงานที่หน้าทะเบียน").
+- เลือกแล้ว set `userId` + auto-fill: `employeeName` (snapshot), `เลขบัตร`=`nationalId`/`taxIdOverride`
+  (snapshot, read-only), **pre-fill** `ฐาน`=`baseSalary`, `SSO`=`min(ฐาน×5%, 750)` ถ้า `ssoEligible`.
+- ตัวเลขทุกช่อง **แก้มือได้** (เงินเดือนจริงต่างกันแต่ละงวด) — pre-fill เป็นแค่ค่าเริ่มต้น.
+- `WHT` กรอกมือ (ขึ้นกับฐานสะสมทั้งปี — ไม่ pre-fill ใน phase นี้).
+- **Backward-compat**: แถว payroll เดิม (free-text, ไม่มี userId) แสดง/แก้ได้ — combobox โชว์ชื่อ snapshot เดิม.
+
+---
+
+## 4. Backend
+
+### 4.1 โมดูลใหม่ `employees` (controller → service → PrismaService ; gate ทั้ง class `@UseGuards(JwtAuthGuard, RolesGuard)`)
+
+| Method | Path | Roles | หมายเหตุ |
+|---|---|---|---|
+| GET | `/employees` | OWNER, ACCOUNTANT, FINANCE_MANAGER | list + search, `{data,total,page,limit}` |
+| GET | `/employees/pickable?search=` | OWNER, ACCOUNTANT, FINANCE_MANAGER | สำหรับ `EmployeeCombobox` — `{userId, employeeId, name, nickname, nationalId, baseSalary, ssoEligible}` active เท่านั้น |
+| GET | `/employees/:id` | OWNER, ACCOUNTANT, FINANCE_MANAGER | detail |
+| POST | `/employees` | OWNER, ACCOUNTANT | provision profile ให้ `userId` (CreateEmployeeDto) |
+| PATCH | `/employees/:id` | OWNER, ACCOUNTANT | UpdateEmployeeDto (ทุก field optional) |
+| DELETE | `/employees/:id` | OWNER, ACCOUNTANT | soft-delete = เลิกเป็นพนักงาน payroll |
+
+- **PII gating**: ทั้งโมดูล gate payroll roles → `nationalId` ไม่รั่วถึง SALES/BRANCH_MANAGER.
+- **DTO ภาษาไทย** validation ; `userId` unique → P2002 → `ConflictException('พนักงานคนนี้มีทะเบียนแล้ว')`.
+- **Audit**: `EMPLOYEE_PROFILE_CREATED` / `EMPLOYEE_PROFILE_UPDATED` (action string ตาม pattern เดิม).
+- **Soft-delete query**: ทุก query `where: { deletedAt: null }`.
+
+### 4.2 ผูกเข้า payroll (create-payroll DTO/service)
+- `PayrollLineInput.userId?` (optional). ถ้ามี → **server derive snapshot** (`employeeName = User.name`,
+  `employeeTaxId = User.nationalId` หรือ `taxIdOverride`) — ไม่เชื่อ snapshot จาก client (integrity).
+  ถ้าไม่มี `userId` → ต้องมี `employeeName` (พฤติกรรมเดิม/legacy).
+- `userId` ที่ส่งมาต้องเป็นพนักงาน active (มี EmployeeProfile, ไม่ถูก soft-delete) ไม่งั้น reject.
+- `baseSalary`/`ssoEmployee`/`whtAmount` ที่ client ส่ง = ค่าจริงที่จ่าย — server ไม่ override ตัวเลข.
+
+### 4.3 JE — ไม่เปลี่ยน
+`payroll.template.ts` คิดจากตัวเลข (base/sso/wht) เหมือนเดิม. `userId` เป็น metadata link ไม่กระทบ
+JE/SSO accounts (21-3105/3106/53-1102). มี anti-regression test ยืนยัน JE คงเดิม.
+
+---
+
+## 5. Migration & Backfill
+
+### 5.1 Migration (additive — ไม่ต้อง 2-step เพราะ nullable)
+```
++ enum EmploymentType { MONTHLY DAILY CONTRACT }
++ table employee_profiles (userId @unique FK, ...)
++ payroll_lines.user_id nullable FK → users (onDelete SET NULL)
++ @@index([user_id]) บน payroll_lines
+```
+
+### 5.2 Backfill CLI (รันมือ dry-run → `--apply` ; pattern ตาม `backfill:expense-vendor-fk`)
+1. **`backfill:employee-profiles`** — provision `EmployeeProfile` ให้ User ที่เป็นพนักงานจริง
+   - candidate = `isSystemUser=false AND deletedAt IS NULL`
+   - สร้าง profile (position/baseSalary = null ให้ OWNER เติมในหน้า master)
+   - dry-run โชว์รายชื่อ → `--apply` ; idempotent (มี profile แล้วข้าม)
+2. **`backfill:payroll-user-fk`** — ผูก `PayrollLine` เก่าเข้า User
+   - tier 1: match `employeeTaxId === User.nationalId` (exact, แม่นสุด)
+   - tier 2: match ชื่อ exact (รายงานให้ review ก่อน apply)
+   - **ไม่แตะ** snapshot ; เติมแค่ `userId` ; ที่ match ไม่ได้ → ปล่อย null (ของเก่ายังอยู่ได้)
+   - dry-run โชว์ matched/unmatched → `--apply` ; idempotent
+
+> ทั้งคู่ manual + idempotent + ไม่ทำลายข้อมูลเดิม (เหมือน epic party-master). บันทึกใน memory ว่าต้องรันมือ.
+
+---
+
+## 6. Testing
+
+**API (jest, รัน `--runInBand` — memory: parallel-DB flaky):**
+- `employees.service.spec` — provision (P2002 dup → Conflict), update, soft-delete, list/search,
+  `pickable` คืน active เท่านั้น
+- RBAC — SALES/BRANCH_MANAGER → 403
+- payroll create: `userId` → server derive snapshot ถูก ; ไม่มี userId → legacy path ;
+  userId ของคน soft-deleted/ไม่ใช่พนักงาน → reject
+- payroll JE anti-regression — JE/SSO เหมือนเดิมเมื่อมี userId
+- backfill CLI specs — dry-run≠apply, idempotent, match `taxId=nationalId`, unmatched=null
+
+**Web (vitest):**
+- `EmployeeCombobox` — search, select set userId+snapshot, ไม่มี inline-create
+- `PayrollLinesSection` — pre-fill ฐาน/SSO ตอน select, แก้มือแล้วค่าคงอยู่, แถว legacy (ไม่มี userId) ยังแก้ได้
+- Employee master page — list/provision/edit, nationalId โชว์ตาม RBAC, validation
+
+---
+
+## 7. Edge cases (ออกแบบรองรับ)
+- พนักงานลาออก (soft-delete) แต่มี payroll เก่า → snapshot คงอยู่ (ประวัติไม่หาย), combobox ไม่โชว์สำหรับแถวใหม่
+- User เปลี่ยนชื่อหลังทำ payroll → snapshot เดิมไม่เปลี่ยน (historical correctness)
+- `ssoEligible=false` → pre-fill SSO = 0
+- ต่างด้าว `taxId ≠ บัตรปชช.` → snapshot ใช้ `taxIdOverride` ถ้ามี ไม่งั้น `nationalId`
+- provision profile ซ้ำ (userId เดิม) → ConflictException
+
+---
+
+## 8. Phase 3 roadmap (นอก spec นี้)
+- `SalaryHistory` — ประวัติปรับฐานเงินเดือน (effectiveDate, baseSalary, reason)
+- `EmploymentEvent` — lifecycle จ้าง/เลื่อน/ลาออก (type, date, note)
+- `EmployeeDocument` — สัญญาจ้าง/สำเนาบัตร บน S3 (เหมือน ContractDocument pattern)
+- resignation flow + กันออกจาก payroll picker อัตโนมัติเมื่อ `resignedDate` ผ่าน
+
+---
+
+## 9. ลำดับการทำ (phased PR — merge ก่อนทำต่อ, ไม่ stack ลึก)
+รายละเอียดทำเป็น implementation plan แยก (writing-plans) — ภาพคร่าว:
+1. **PR-A (backend master)**: schema + migration + โมดูล `employees` (CRUD + pickable) + tests
+2. **PR-B (frontend master)**: หน้า `/employees` + EmployeeCombobox + tests
+3. **PR-C (payroll link)**: PayrollLine.userId + create-payroll DTO/service derive snapshot + pre-fill UI + tests
+4. **PR-D (backfill)**: 2 CLI + tests (รันมือหลัง deploy)
+
+> หมายเหตุ: PR-A/B/C/D เรียงตาม dependency. backfill (D) รันมือหลัง A–C ขึ้น prod.

--- a/docs/superpowers/specs/2026-06-04-employee-master-design.md
+++ b/docs/superpowers/specs/2026-06-04-employee-master-design.md
@@ -1,7 +1,9 @@
 # Employee Master — ทะเบียนพนักงาน + ปิด free-text payroll
 
 วันที่: 2026-06-04
-สถานะ: รออนุมัติ spec จาก owner (brainstorm เสร็จ — รอ review ก่อนทำ implementation plan)
+สถานะ: รออนุมัติ spec จาก owner (brainstorm + scrutinize เสร็จ — รอ review ก่อนทำ implementation plan)
+
+> **แก้หลัง scrutinize (2026-06-04):** (1) ปิด PII leak — `pickable` ไม่คืน `nationalId` แล้ว, gate nationalId เฉพาะ OWNER/ACCOUNTANT (2) นิยาม pickable filter พนักงานลาออก (3) backfill tier-2 (ชื่อ) ต้อง manual review + audit (4) ระบุ ไม่ branch-scope. `employmentType`/`resignedDate` **คงไว้** (load-bearing: คอลัมน์ master + filter picker).
 ส่วนหนึ่งของ: ขยายหลัก "ห้าม free-text คน" (party-master) จาก Contact ไปถึง **พนักงาน**
 
 > **ที่มา:** epic Party Master Mandatory (#1143–1149) ปิด free-text "คน" ทุก picker ฝั่งคู่ค้า
@@ -99,8 +101,10 @@ model PayrollLine {
 - free-text input → **`EmployeeCombobox`** (search active employees ; pattern คล้าย `ContactCombobox`
   แต่ **ไม่มี inline-create** — พนักงาน=User สร้างที่ `/users`/master ก่อน ; ถ้าไม่เจอโชว์
   "เพิ่มพนักงานที่หน้าทะเบียน").
-- เลือกแล้ว set `userId` + auto-fill: `employeeName` (snapshot), `เลขบัตร`=`nationalId`/`taxIdOverride`
-  (snapshot, read-only), **pre-fill** `ฐาน`=`baseSalary`, `SSO`=`min(ฐาน×5%, 750)` ถ้า `ssoEligible`.
+- เลือกแล้ว set `userId` + auto-fill: `employeeName` (จากชื่อใน pickable), **pre-fill** `ฐาน`=`baseSalary`,
+  `SSO`=`min(ฐาน×5%, 750)` ถ้า `ssoEligible`.
+- คอลัมน์ `เลขบัตร`: **server เป็นคน derive ตอนบันทึก** (pickable ไม่ส่ง nationalId มา — PII) → ในฟอร์มก่อน save
+  โชว์ read-only placeholder "(ดึงเลขบัตรอัตโนมัติตอนบันทึก)"; แถว legacy free-text ยังพิมพ์เลขบัตรเองได้.
 - ตัวเลขทุกช่อง **แก้มือได้** (เงินเดือนจริงต่างกันแต่ละงวด) — pre-fill เป็นแค่ค่าเริ่มต้น.
 - `WHT` กรอกมือ (ขึ้นกับฐานสะสมทั้งปี — ไม่ pre-fill ใน phase นี้).
 - **Backward-compat**: แถว payroll เดิม (free-text, ไม่มี userId) แสดง/แก้ได้ — combobox โชว์ชื่อ snapshot เดิม.
@@ -111,19 +115,21 @@ model PayrollLine {
 
 ### 4.1 โมดูลใหม่ `employees` (controller → service → PrismaService ; gate ทั้ง class `@UseGuards(JwtAuthGuard, RolesGuard)`)
 
-| Method | Path | Roles | หมายเหตุ |
-|---|---|---|---|
-| GET | `/employees` | OWNER, ACCOUNTANT, FINANCE_MANAGER | list + search, `{data,total,page,limit}` |
-| GET | `/employees/pickable?search=` | OWNER, ACCOUNTANT, FINANCE_MANAGER | สำหรับ `EmployeeCombobox` — `{userId, employeeId, name, nickname, nationalId, baseSalary, ssoEligible}` active เท่านั้น |
-| GET | `/employees/:id` | OWNER, ACCOUNTANT, FINANCE_MANAGER | detail |
-| POST | `/employees` | OWNER, ACCOUNTANT | provision profile ให้ `userId` (CreateEmployeeDto) |
-| PATCH | `/employees/:id` | OWNER, ACCOUNTANT | UpdateEmployeeDto (ทุก field optional) |
-| DELETE | `/employees/:id` | OWNER, ACCOUNTANT | soft-delete = เลิกเป็นพนักงาน payroll |
+| Method | Path | Roles | คืน `nationalId`? | หมายเหตุ |
+|---|---|---|---|---|
+| GET | `/employees` | OWNER, ACCOUNTANT | masked (4 ท้าย) | list + search, `{data,total,page,limit}` |
+| GET | `/employees/pickable?search=` | OWNER, ACCOUNTANT, FINANCE_MANAGER | **ไม่คืน** | `EmployeeCombobox` — `{userId, employeeId, name, nickname, baseSalary, ssoEligible}` (ไม่มี PII) |
+| GET | `/employees/:id` | OWNER, ACCOUNTANT | full | detail (หน้า master) |
+| POST | `/employees` | OWNER, ACCOUNTANT | — | provision profile ให้ `userId` (CreateEmployeeDto) |
+| PATCH | `/employees/:id` | OWNER, ACCOUNTANT | — | UpdateEmployeeDto (ทุก field optional) |
+| DELETE | `/employees/:id` | OWNER, ACCOUNTANT | — | soft-delete = เลิกเป็นพนักงาน payroll |
 
-- **PII gating**: ทั้งโมดูล gate payroll roles → `nationalId` ไม่รั่วถึง SALES/BRANCH_MANAGER.
+- **PII gating (แก้หลัง scrutinize — blocker เดิม)**: `nationalId` คืน**เฉพาะ endpoint ที่ gate OWNER/ACCOUNTANT** (list=masked, detail=full). `pickable` (ที่ FINANCE_MANAGER เข้าได้) **ไม่คืน nationalId เลย** — combobox ไม่ต้องใช้ เพราะ taxId snapshot derive ฝั่ง server ตอน payroll create (§4.2). แก้ความขัดแย้งกับ decision-5 + harden PII.
+- **`pickable` filter (แก้หลัง scrutinize — gap)**: คืนเฉพาะ `deletedAt IS NULL AND (resignedDate IS NULL OR resignedDate > today)` — พนักงานลาออก/ถูกลบ ไม่ขึ้นให้เลือกในแถวใหม่. แถว payroll legacy (มี userId แต่คนลาออกแล้ว) ยังโชว์ snapshot ได้ (read-only, ไม่ re-link).
 - **DTO ภาษาไทย** validation ; `userId` unique → P2002 → `ConflictException('พนักงานคนนี้มีทะเบียนแล้ว')`.
-- **Audit**: `EMPLOYEE_PROFILE_CREATED` / `EMPLOYEE_PROFILE_UPDATED` (action string ตาม pattern เดิม).
+- **Audit**: `EMPLOYEE_PROFILE_CREATED` / `_UPDATED` / `_DELETED` (action string ตาม pattern เดิม).
 - **Soft-delete query**: ทุก query `where: { deletedAt: null }`.
+- **ไม่ branch-scope**: HR/payroll เป็นฟังก์ชันกลาง (OWNER/ACCOUNTANT เห็นพนักงานทุกสาขา) — ไม่ใส่ BranchGuard (สอดคล้องกับ payroll ที่เป็น FINANCE-level).
 
 ### 4.2 ผูกเข้า payroll (create-payroll DTO/service)
 - `PayrollLineInput.userId?` (optional). ถ้ามี → **server derive snapshot** (`employeeName = User.name`,
@@ -154,10 +160,12 @@ JE/SSO accounts (21-3105/3106/53-1102). มี anti-regression test ยืนย
    - สร้าง profile (position/baseSalary = null ให้ OWNER เติมในหน้า master)
    - dry-run โชว์รายชื่อ → `--apply` ; idempotent (มี profile แล้วข้าม)
 2. **`backfill:payroll-user-fk`** — ผูก `PayrollLine` เก่าเข้า User
-   - tier 1: match `employeeTaxId === User.nationalId` (exact, แม่นสุด)
-   - tier 2: match ชื่อ exact (รายงานให้ review ก่อน apply)
-   - **ไม่แตะ** snapshot ; เติมแค่ `userId` ; ที่ match ไม่ได้ → ปล่อย null (ของเก่ายังอยู่ได้)
-   - dry-run โชว์ matched/unmatched → `--apply` ; idempotent
+   - **tier 1** (`employeeTaxId === User.nationalId`, exact): มั่นใจสูง → `--apply` ได้เลย, idempotent
+   - **tier 2** (match ชื่อ exact): **เสี่ยง false-positive → ต้อง manual review ก่อน** — dry-run ออก
+     `matched-by-name.csv` ให้ owner ตรวจ แล้ว apply แยก flag (เช่น `--apply --tier=2`) + เขียน audit
+     `PAYROLL_FK_MATCHED_BY_NAME` ทุกแถวที่ผูกด้วยชื่อ (เผื่อ dispute/rollback ภายหลัง)
+   - **ไม่แตะ** snapshot ; เติมแค่ `userId` ; ที่ match ไม่ได้ → ปล่อย null (ของเก่า free-text ยังอยู่/แก้ได้ ไม่ re-link)
+   - dry-run โชว์ matched(tier1/tier2)/unmatched → apply
 
 > ทั้งคู่ manual + idempotent + ไม่ทำลายข้อมูลเดิม (เหมือน epic party-master). บันทึกใน memory ว่าต้องรันมือ.
 
@@ -168,7 +176,9 @@ JE/SSO accounts (21-3105/3106/53-1102). มี anti-regression test ยืนย
 **API (jest, รัน `--runInBand` — memory: parallel-DB flaky):**
 - `employees.service.spec` — provision (P2002 dup → Conflict), update, soft-delete, list/search,
   `pickable` คืน active เท่านั้น
-- RBAC — SALES/BRANCH_MANAGER → 403
+- **PII** — `pickable` **ไม่คืน `nationalId`** ; GET /employees คืน masked, /:id คืน full
+- **resigned filter** — `pickable` ไม่คืนพนักงาน `resignedDate ≤ today` หรือ soft-deleted
+- RBAC — SALES/BRANCH_MANAGER → 403 ทุก endpoint ; FINANCE_MANAGER → 403 บน list/detail/CUD (เข้าได้แค่ `pickable`)
 - payroll create: `userId` → server derive snapshot ถูก ; ไม่มี userId → legacy path ;
   userId ของคน soft-deleted/ไม่ใช่พนักงาน → reject
 - payroll JE anti-regression — JE/SSO เหมือนเดิมเมื่อมี userId


### PR DESCRIPTION
PR-A (backend master) of the Employee Master feature — extends the "no free-text people" party-master principle toward payroll staff.

**Spec:** docs/superpowers/specs/2026-06-04-employee-master-design.md · **Plan:** docs/superpowers/plans/2026-06-04-employee-master-prA-backend.md

## What's in PR-A
- **`EmployeeProfile`** model (1:1 with `User` via `userId @unique`) — payroll/employment data: position, employmentType, baseSalary (Decimal), ssoEligible, bank, taxIdOverride, resignedDate. Identity/PII (`nationalId`, `startDate`…) stays on `User`. + migration `20260969000000_add_employee_profile`.
- **`employees` NestJS module** — `provision` / `list` / `findOne` / `update` / `remove` (soft-delete) / `pickable`.
- **PII gating (the key constraint):** `nationalId` is **masked** in `GET /employees` (list), **full** in `GET /employees/:id` (detail), and **never returned** by `GET /employees/pickable`. List/detail/CUD = OWNER/ACCOUNTANT; `pickable` = OWNER/ACCOUNTANT/FINANCE_MANAGER.
- **`pickable` filter:** active only — excludes soft-deleted + resigned (`resignedDate ≤ today`) + inactive users.
- Audit `EMPLOYEE_PROFILE_CREATED/_UPDATED/_DELETED`; P2002 → ConflictException (Thai).

## Out of scope (later PRs)
PayrollLine.userId link + pre-fill (PR-C), frontend master page + EmployeeCombobox (PR-B), backfill CLIs (PR-D). PayrollLine is intentionally untouched here.

## Tests / verification
- `employees.service.spec` — **9/9 green** (`--runInBand`); covers provision/P2002, list masking, findOne full, update/remove audit, pickable PII-absence + resigned filter.
- `./tools/check-types.sh api` — OK.
- Two-stage review (spec-compliance ✅ + code-quality ✅) passed.

## ⚠️ Migration note
The migration SQL was **hand-authored** (the local dev DB had pre-existing drift on unrelated tables, so `prisma migrate dev` couldn't run cleanly). It was validated + dry-run-applied inside a rolled-back transaction. **Run `prisma migrate deploy` in a clean/CI environment** to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)