### PR TITLE
fix(backfill): payroll-fk CLI writes CSV to /tmp (Cloud Run read-only FS)

### DIFF
--- a/apps/api/src/cli/backfill-payroll-user-fk.cli.ts
+++ b/apps/api/src/cli/backfill-payroll-user-fk.cli.ts
@@ -67,7 +67,10 @@ export function resolvePayrollMatch(
 // ─── Runnable glue ───────────────────────────────────────────────────────────
 const TAG = '[backfill-payroll-user-fk]';
 const BATCH_SIZE = 100;
-const CSV_PATH = 'matched-by-name.csv';
+// Cloud Run containers have a read-only root FS — only /tmp is writable.
+// The stdout dump (below) is the authoritative output for Cloud Logging; this
+// file is a convenience for local runs. Overridable via CSV_OUT.
+const CSV_PATH = process.env.CSV_OUT ?? '/tmp/matched-by-name.csv';
 
 interface LineRow {
   id: string;
@@ -160,8 +163,14 @@ async function main(): Promise<void> {
       ...tier2Ambiguous.map((t) =>
         `ambiguous,${t.line.id},${t.line.payrollId},"${t.line.employeeName}",${t.line.employeeTaxId ?? ''},${t.candidateIds.join(' ')},"${t.candidateIds.map((id) => nameById.get(id) ?? '').join(' | ')}"`),
     ];
-    writeFileSync(CSV_PATH, csvRows.join('\n'), 'utf-8');
-    console.log(`${TAG} wrote ${tier2.length + tier2Ambiguous.length} name-match row(s) to ${CSV_PATH} (local file).`);
+    // Best-effort local file — never fatal. On a read-only FS the stdout dump
+    // below is the real deliverable, so a write failure just logs a warning.
+    try {
+      writeFileSync(CSV_PATH, csvRows.join('\n'), 'utf-8');
+      console.log(`${TAG} wrote ${tier2.length + tier2Ambiguous.length} name-match row(s) to ${CSV_PATH} (local file).`);
+    } catch (e) {
+      console.warn(`${TAG} could not write ${CSV_PATH} (${(e as Error).message}) — using stdout dump below instead.`);
+    }
     // F1 — Cloud Run Jobs have an ephemeral FS; the local CSV is lost when the
     // job exits. Dump the FULL CSV to stdout so the owner can retrieve every
     // name-match row from Cloud Logging for review (not just a sample).


### PR DESCRIPTION
`backfill:payroll-user-fk` crashed at runtime in Cloud Run with `EACCES: permission denied, open 'matched-by-name.csv'` — it wrote the CSV to the container CWD (`/app`), which is read-only (only `/tmp` is writable). The crash happened AFTER classification, so it was harmless when there were 0 rows, but the CLI could never complete in prod once there's data.

Found while running the backfill in prod (co-pilot): CLI A succeeded (10 profiles); CLI B reported `0 unlinked payroll line(s)` (nothing to link) then crashed on the CSV write.

Fix:
- `CSV_PATH` → `/tmp/matched-by-name.csv` (writable in Cloud Run; overridable via `CSV_OUT`).
- Wrap the `writeFileSync` in try/catch — the full CSV is already dumped to stdout (Cloud Logging) which is the authoritative output, so a file-write failure is now a warning, not fatal.

The unit test (pure `resolvePayrollMatch`) is unaffected; tsc clean. Note: this is why the F5 dev-DB smoke (couldn't run in sandbox) is important — it would have caught the read-only-FS write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)