### PR TITLE
Code-quality: Wave 0 lint guardrails + first data-integrity fix

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -19,6 +19,11 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      // Code-quality guardrails (Wave 0). Kept at 'warn' so they surface the
+      // remediation worklist without failing CI lint; promote to 'error' once
+      // the backlog (CODE_QUALITY_REMEDIATION_PLAN.md, Wave 2) is burned down.
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-misused-promises': 'warn',
     },
   },
   {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -222,4 +222,11 @@ async function bootstrap() {
   await app.listen(port);
   logger.log(`API server running on http://localhost:${port}`);
 }
-bootstrap();
+bootstrap().catch((err) => {
+  // A failed bootstrap must crash loudly with a non-zero exit so the
+  // orchestrator (Cloud Run) restarts the instance instead of leaving a
+  // half-initialised process running. (Was a floating promise — the new
+  // no-floating-promises guardrail flags it.)
+  console.error('Fatal: API bootstrap failed', err);
+  process.exit(1);
+});

--- a/apps/api/src/modules/overdue/overdue.service.ts
+++ b/apps/api/src/modules/overdue/overdue.service.ts
@@ -1382,7 +1382,10 @@ export class OverdueService {
   async getBrokenPromiseCount(contractId: string): Promise<number> {
     return this.prisma.auditLog.count({
       where: {
-        entity: 'Contract',
+        // Accept both casings: new code writes 'contract' (per audit.service.ts
+        // convention), legacy broken-promise.cron wrote 'Contract'. Mirrors the
+        // dual-read in queue.service.ts so recent rows aren't silently missed.
+        entity: { in: ['contract', 'Contract'] },
         entityId: contractId,
         action: 'BROKEN_PROMISE',
       },


### PR DESCRIPTION
First, small slice of the apps/api code-quality remediation (see `CODE_QUALITY_REMEDIATION_PLAN.md` — 536 confirmed findings + 97 from gap-fill). Demonstrates the per-batch cadence before the larger waves.

## Changes (2 commits)

**1. `chore(lint)` — Wave 0 guardrails (non-breaking)**
Enables `@typescript-eslint/no-floating-promises` + `no-misused-promises` at **`warn`**. Warn-level never makes eslint exit non-zero, so CI lint stays green; the rules surface the floating-promise worklist (e.g. it immediately flags `main.ts:225`, `credit-check` floating auto-score, the `contract-workflow` no-await-in-tx). Promote to `error` once Wave 2 is burned down.

**2. `fix(overdue)` — broken-promise count casing bug**
`getBrokenPromiseCount` filtered `AuditLog` on `entity:'Contract'` (capital C), but the current writers (`promise.service.ts`, `promise-resolution.cron.ts`) write `entity:'contract'` (lowercase) → the count was always **0**, silently disabling the escalation guardrail in `logContact` that blocks a new PROMISED when `broken >= 2`. Fix mirrors the dual-read already in `queue.service.ts:521`.

## Verification
- eslint on both files: **0 errors** (warn-level only).
- The fix is identical in shape to the CI-passing `queue.service.ts:521` precedent (type-safe).
- ⚠️ A DB-backed regression spec for `getBrokenPromiseCount`/`calculateLateFees`/`partialPaymentReschedule` is **not** included — `OverdueService` (1658-LOC god-service, 8 deps) has no harness for these methods; tracked as Wave 3 (D7 test backfill) in the plan.

## Not in this PR
The review artifacts (`CODE_QUALITY_REVIEW_API.md`, `.findings.json`, `.gapfill.json`, `CODE_QUALITY_REMEDIATION_PLAN.md`) are kept local for now; happy to add them in a docs commit if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)