### PR TITLE
test(wave3): golden tests for BC + GFIN installment money math

### DIFF
--- a/apps/api/src/modules/credit-check/credit-check.dti.spec.ts
+++ b/apps/api/src/modules/credit-check/credit-check.dti.spec.ts
@@ -1,0 +1,107 @@
+import { BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { CreditCheckService } from './credit-check.service';
+
+/**
+ * Characterization tests for CreditCheckService.calculateDtiRiskScore (Wave 3 backfill).
+ *
+ * The debt-to-income risk engine had no tests yet outputs LOW/MEDIUM/HIGH on
+ * regulated installment lending (review finding D7). These lock the DTI bands
+ * (<0.3 / <=0.5 / else → 0 / 1 / 2 points), the address factor (own −1 / rent +1),
+ * the returning-customer history factors, the salary-fallback resolution, the
+ * salary<=0 guard, and the suggested-due-day rule.
+ */
+
+const NON_RETURNING = {
+  isReturningCustomer: false,
+  completedContracts: 0,
+  onTimeRate: 0,
+  latePayments: 0,
+  onTimePayments: 0,
+};
+
+const makePrisma = (creditCheck: unknown) =>
+  ({
+    creditCheck: {
+      findUnique: jest.fn().mockResolvedValue(creditCheck),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  }) as unknown as PrismaService;
+
+const run = (
+  cc: unknown,
+  data: { salaryVerified?: number; monthlyPayment?: number; addressCurrentType?: string },
+  history: typeof NON_RETURNING = NON_RETURNING,
+) => {
+  const svc = new CreditCheckService(makePrisma(cc), {} as unknown as IntegrationConfigService);
+  jest.spyOn(svc as unknown as { getCustomerHistory: (id: string) => Promise<unknown> }, 'getCustomerHistory')
+    .mockResolvedValue(history);
+  return svc.calculateDtiRiskScore('cc-1', data);
+};
+
+const cc = (over: Record<string, unknown>) => ({
+  deletedAt: null,
+  salaryVerified: null,
+  customer: { id: 'cu-1', salary: 30000, addressCurrentType: null, salaryPayDay: 25 },
+  contract: { monthlyPayment: 6000 },
+  ...over,
+});
+
+describe('CreditCheckService.calculateDtiRiskScore', () => {
+  it('rates LOW for low DTI + own home', async () => {
+    const r = await run(
+      cc({ customer: { id: 'cu-1', salary: 30000, addressCurrentType: 'OWN', salaryPayDay: 25 }, contract: { monthlyPayment: 6000 } }),
+      {},
+    );
+    expect(r.riskScore).toBe('LOW'); // DTI 0.2 → 0 pts, OWN → −1
+    expect(r.debtToIncomeRatio).toBe(0.2);
+    expect(r.details.riskPoints).toBe(-1);
+    expect(r.suggestedDueDay).toBe(28); // min(28, 25 + 5)
+  });
+
+  it('rates MEDIUM for mid DTI + rented home', async () => {
+    const r = await run(
+      cc({ customer: { id: 'cu-1', salary: 30000, addressCurrentType: 'RENT', salaryPayDay: 1 }, contract: { monthlyPayment: 12000 } }),
+      {},
+    );
+    expect(r.riskScore).toBe('MEDIUM'); // DTI 0.4 → 1, RENT → +1 = 2
+    expect(r.debtToIncomeRatio).toBe(0.4);
+    expect(r.suggestedDueDay).toBe(6); // 1 + 5
+  });
+
+  it('rates HIGH when DTI is high and home is rented', async () => {
+    const r = await run(
+      cc({ customer: { id: 'cu-1', salary: 30000, addressCurrentType: 'RENT', salaryPayDay: null }, contract: { monthlyPayment: 18000 } }),
+      {},
+    );
+    expect(r.riskScore).toBe('HIGH'); // DTI 0.6 → 2, RENT → +1 = 3
+    expect(r.suggestedDueDay).toBeNull();
+  });
+
+  it('credits a good returning customer down to LOW', async () => {
+    const r = await run(
+      cc({ customer: { id: 'cu-1', salary: 30000, addressCurrentType: null, salaryPayDay: 10 }, contract: { monthlyPayment: 12000 } }),
+      {},
+      { isReturningCustomer: true, completedContracts: 2, onTimeRate: 0.9, latePayments: 1, onTimePayments: 10 },
+    );
+    // DTI 0.4 → 1; returning: completed −1, onTimeRate>0.8 −1 = −1 → LOW
+    expect(r.riskScore).toBe('LOW');
+    expect(r.details.riskPoints).toBe(-1);
+  });
+
+  it('lets the data argument override stored values', async () => {
+    const r = await run(
+      cc({ customer: { id: 'cu-1', salary: 99999, addressCurrentType: 'OWN', salaryPayDay: 1 }, contract: { monthlyPayment: 1 } }),
+      { salaryVerified: 30000, monthlyPayment: 12000, addressCurrentType: 'RENT' },
+    );
+    expect(r.riskScore).toBe('MEDIUM'); // uses data: DTI 0.4 → 1, RENT → +1 = 2
+    expect(r.debtToIncomeRatio).toBe(0.4);
+  });
+
+  it('throws when no income can be resolved', async () => {
+    await expect(
+      run(cc({ salaryVerified: null, customer: { id: 'cu-1', salary: 0, addressCurrentType: null, salaryPayDay: null }, contract: null }), {}),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/credit-check/credit-check.rule-based-analysis.spec.ts
+++ b/apps/api/src/modules/credit-check/credit-check.rule-based-analysis.spec.ts
@@ -1,0 +1,115 @@
+import { PrismaService } from '../../prisma/prisma.service';
+import { IntegrationConfigService } from '../integrations/integration-config.service';
+import { CreditCheckService } from './credit-check.service';
+
+/**
+ * Characterization tests for CreditCheckService.performRuleBasedAnalysis (Wave 3 backfill).
+ *
+ * This is the rule-based credit-approval scoring engine — the path that runs in
+ * production whenever the Claude API key is absent. It had ZERO tests yet its
+ * score drives APPROVED / MANUAL_REVIEW / REJECTED on regulated installment
+ * lending (review finding D7). These goldens lock the band boundaries
+ * (affordability 0.2 / 0.3 / 0.4) and the recommendation thresholds (70 / 50) so
+ * a refactor can't silently move an approval line.
+ *
+ * The method is pure (no DB), so the service is built with stub deps and the
+ * private method is invoked via a typed accessor.
+ */
+
+type Analysis = {
+  score: number;
+  summary: string;
+  recommendation: string;
+  analysis: {
+    monthlyIncome: number;
+    monthlyPayment: number;
+    affordabilityRatio: number | null;
+    riskFactors: string[];
+    positiveFactors: string[];
+    incomeConsistency: string;
+  };
+};
+
+const APPROVE = 'แนะนำอนุมัติ - ลูกค้ามีความสามารถในการชำระเพียงพอ';
+const REVIEW = 'พิจารณาเพิ่มเติม - ควรตรวจสอบข้อมูลเพิ่มเติม';
+const REJECT = 'ไม่แนะนำอนุมัติ - ความเสี่ยงสูง';
+
+describe('CreditCheckService.performRuleBasedAnalysis', () => {
+  const service = new CreditCheckService(
+    {} as unknown as PrismaService,
+    {} as unknown as IntegrationConfigService,
+  );
+  const analyze = (params: {
+    monthlyPayment: number;
+    customerSalary: number;
+    statementFileCount?: number;
+    customerOccupation?: string | null;
+  }): Analysis =>
+    (service as unknown as {
+      performRuleBasedAnalysis: (p: typeof params) => Analysis;
+    }).performRuleBasedAnalysis({ customerOccupation: null, ...params });
+
+  it('scores a strong applicant: affordability <=20% + full statements + occupation', () => {
+    const r = analyze({
+      monthlyPayment: 5000,
+      customerSalary: 30000, // ratio 0.1667 -> +30 (base 50 = 80)
+      statementFileCount: 3, // +10 = 90
+      customerOccupation: 'พนักงานบริษัท', // +5 = 95
+    });
+    expect(r.score).toBe(95);
+    expect(r.recommendation).toBe(APPROVE);
+    expect(r.analysis.affordabilityRatio).toBe(0.17); // round(0.1667 * 100)/100
+    expect(r.analysis.incomeConsistency).toBe('มีรายได้');
+    expect(r.analysis.riskFactors).toEqual([]);
+    expect(r.analysis.positiveFactors).toContain('ค่างวดไม่เกิน 20% ของรายได้');
+  });
+
+  it('treats ratio exactly 0.20 as the <=20% band (+30)', () => {
+    const r = analyze({ monthlyPayment: 6000, customerSalary: 30000 }); // ratio 0.20
+    expect(r.score).toBe(80); // 50 + 30
+    expect(r.analysis.positiveFactors).toContain('ค่างวดไม่เกิน 20% ของรายได้');
+  });
+
+  it('treats ratio exactly 0.30 as the <=30% band (+20)', () => {
+    const r = analyze({ monthlyPayment: 9000, customerSalary: 30000 }); // ratio 0.30
+    expect(r.score).toBe(70); // 50 + 20
+    expect(r.recommendation).toBe(APPROVE); // score 70 -> >= 70
+    expect(r.analysis.positiveFactors).toContain('ค่างวดไม่เกิน 30% ของรายได้');
+  });
+
+  it('treats ratio exactly 0.40 as the <=40% band (+10) and routes to manual review', () => {
+    const r = analyze({ monthlyPayment: 12000, customerSalary: 30000 }); // ratio 0.40
+    expect(r.score).toBe(60); // 50 + 10
+    expect(r.recommendation).toBe(REVIEW); // 50..69
+    expect(r.analysis.riskFactors).toContain('ค่างวดเกิน 30% ของรายได้');
+  });
+
+  it('penalises affordability above 40% (-10) and rejects', () => {
+    const r = analyze({ monthlyPayment: 15000, customerSalary: 30000 }); // ratio 0.50
+    expect(r.score).toBe(40); // 50 - 10
+    expect(r.recommendation).toBe(REJECT); // < 50
+    expect(r.analysis.riskFactors).toContain('ค่างวดเกิน 40% ของรายได้ - ความเสี่ยงสูง');
+  });
+
+  it('handles missing income (salary 0): -10, null ratio, rejects', () => {
+    const r = analyze({ monthlyPayment: 5000, customerSalary: 0 });
+    expect(r.score).toBe(40); // 50 - 10
+    expect(r.analysis.affordabilityRatio).toBeNull();
+    expect(r.analysis.incomeConsistency).toBe('ไม่มีข้อมูล');
+    expect(r.analysis.riskFactors).toContain('ไม่มีข้อมูลรายได้');
+    expect(r.recommendation).toBe(REJECT);
+  });
+
+  it('awards +5 (not +10) for an incomplete statement set (1-2 files)', () => {
+    const r = analyze({ monthlyPayment: 9000, customerSalary: 30000, statementFileCount: 1 });
+    expect(r.score).toBe(75); // 50 + 20 (ratio 0.30) + 5 (1 statement)
+    expect(r.analysis.riskFactors).toContain('Statement ไม่ครบ 3 เดือน');
+  });
+
+  it('builds a Thai summary string with income, payment and ratio', () => {
+    const r = analyze({ monthlyPayment: 6000, customerSalary: 30000 });
+    expect(r.summary).toContain('รายได้ 30,000 บาท/เดือน');
+    expect(r.summary).toContain('ค่างวด 6,000 บาท/เดือน');
+    expect(r.summary).toContain('สัดส่วน 20% ของรายได้');
+  });
+});

--- a/apps/api/src/modules/interest-config/interest-config.resolve.spec.ts
+++ b/apps/api/src/modules/interest-config/interest-config.resolve.spec.ts
@@ -1,0 +1,77 @@
+import { PrismaService } from '../../prisma/prisma.service';
+import { InterestConfigService } from './interest-config.service';
+
+/**
+ * Characterization tests for InterestConfigService.resolveConfig (Wave 3 backfill).
+ *
+ * resolveConfig is the interest-rate / down-payment / commission resolver that
+ * prices every installment contract, yet the existing spec only covered CRUD —
+ * resolveConfig had no test (review finding D7). These lock: the system-default
+ * fallback when no config matches, the per-month rate map (sorted allowedMonths),
+ * and the scalar→per-month synthesis (rate × months) used before the per-month
+ * backfill runs.
+ *
+ * NOTE: the synthesis path multiplies rates in raw JS floats (review finding D4 —
+ * `rate * m`), so e.g. 0.05 × 3 is 0.150000000000000…; asserted with toBeCloseTo
+ * to document, not hide, that imprecision.
+ */
+
+const makeSvc = (cfg: unknown) => {
+  const prisma = {
+    interestConfig: { findFirst: jest.fn().mockResolvedValue(cfg) },
+  } as unknown as PrismaService;
+  return new InterestConfigService(prisma);
+};
+
+describe('InterestConfigService.resolveConfig', () => {
+  it('returns system defaults when no config matches the category', async () => {
+    const r = await makeSvc(null).resolveConfig('PHONE_NEW');
+    expect(r).toEqual({
+      minDownPct: 0.15,
+      commissionPct: 0.1,
+      vatPct: 0.07,
+      ratePctByMonths: {},
+      allowedMonths: [],
+    });
+  });
+
+  it('builds the per-month rate map and sorts allowedMonths', async () => {
+    const r = await makeSvc({
+      minDownPaymentPct: 0.2,
+      storeCommissionPct: 0.1,
+      vatPct: 0.07,
+      interestRate: 0.03,
+      minInstallmentMonths: 6,
+      maxInstallmentMonths: 12,
+      rates: [
+        { months: 12, ratePct: 0.36, deletedAt: null },
+        { months: 6, ratePct: 0.18, deletedAt: null },
+      ],
+    }).resolveConfig('PHONE_NEW');
+
+    expect(r.minDownPct).toBe(0.2);
+    expect(r.commissionPct).toBe(0.1);
+    expect(r.vatPct).toBe(0.07);
+    expect(r.allowedMonths).toEqual([6, 12]); // sorted ascending
+    expect(r.ratePctByMonths).toEqual({ 6: 0.18, 12: 0.36 });
+  });
+
+  it('synthesises per-month rates from the scalar interestRate when no per-month rows exist', async () => {
+    const r = await makeSvc({
+      minDownPaymentPct: 0.15,
+      storeCommissionPct: 0.1,
+      vatPct: 0.07,
+      interestRate: 0.05, // scalar monthly rate
+      minInstallmentMonths: 3,
+      maxInstallmentMonths: 5,
+      rates: [],
+    }).resolveConfig('PHONE_NEW');
+
+    expect(r.allowedMonths).toEqual([3, 4, 5]);
+    expect(r.minDownPct).toBe(0.15);
+    // rate × months (raw JS float)
+    expect(r.ratePctByMonths[3]).toBeCloseTo(0.15, 10);
+    expect(r.ratePctByMonths[4]).toBeCloseTo(0.2, 10);
+    expect(r.ratePctByMonths[5]).toBeCloseTo(0.25, 10);
+  });
+});

--- a/apps/api/src/modules/line-oa/promptpay/promptpay-qr.service.spec.ts
+++ b/apps/api/src/modules/line-oa/promptpay/promptpay-qr.service.spec.ts
@@ -1,0 +1,104 @@
+import { ConfigService } from '@nestjs/config';
+import { BadRequestException } from '@nestjs/common';
+import { PromptPayQrService } from './promptpay-qr.service';
+
+/**
+ * Characterization tests for the PromptPay EMVCo QR payload builder (Wave 3 backfill).
+ * This service had no spec yet emits the exact string customers scan to pay — a wrong
+ * TLV field or CRC means a QR that fails or pays the wrong account.
+ *
+ * CRC oracle: `refCrc16` below is a CRC-16/CCITT-FALSE implementation anchored to the
+ * algorithm's canonical check value ("123456789" -> 0x29B1). Because the oracle is
+ * proven correct against the published check value, asserting the service's trailing
+ * CRC equals the oracle's output is an independent verification, not a tautology.
+ */
+
+// CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF, no reflection, no final xor).
+function refCrc16(data: string): string {
+  let crc = 0xffff;
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data.charCodeAt(i) << 8;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc.toString(16).toUpperCase().padStart(4, '0');
+}
+
+const makeService = (id?: string, name = 'Test Shop') => {
+  const svc = new PromptPayQrService({ get: () => undefined } as unknown as ConfigService);
+  if (id) svc.setConfig(id, name);
+  return svc;
+};
+
+describe('PromptPayQrService CRC oracle', () => {
+  it('matches the canonical CRC-16/CCITT-FALSE check value', () => {
+    expect(refCrc16('123456789')).toBe('29B1');
+  });
+});
+
+describe('PromptPayQrService.generatePayload', () => {
+  // EMVCo TLV blocks for phone 081-234-5678 (-> 0066 + 812345678):
+  const PFI = '000201'; // Payload Format Indicator
+  const POI = '010212'; // Point of Initiation Method (always "12" dynamic in this impl)
+  const MAI_PHONE = '2939000016A00000067701011101130066812345678'; // tag 29 merchant acct
+  const CURRENCY = '5303764'; // THB
+  const COUNTRY = '5802TH';
+
+  it('builds the full EMVCo payload (phone + amount) with a correct trailing CRC', () => {
+    const svc = makeService('0812345678');
+    const payload = svc.generatePayload(100);
+
+    const beforeCrc = PFI + POI + MAI_PHONE + CURRENCY + COUNTRY + '5406100.00' + '6304';
+    expect(payload).toBe(beforeCrc + refCrc16(beforeCrc));
+  });
+
+  it('omits the amount tag (54) when no amount is given, CRC still valid', () => {
+    const svc = makeService('0812345678');
+    const payload = svc.generatePayload();
+
+    const beforeCrc = PFI + POI + MAI_PHONE + CURRENCY + COUNTRY + '6304';
+    expect(payload).toBe(beforeCrc + refCrc16(beforeCrc));
+    expect(payload).not.toContain('5406');
+    // NOTE: POI stays "12" (dynamic) even with no amount — EMVCo would use "11"
+    // for a static QR. Characterized as current behaviour; see review (D1/D5).
+  });
+
+  it('formats a 13-digit national/tax ID as merchant sub-tag 02 (no 0066 prefix)', () => {
+    const svc = makeService('1234567890123');
+    const payload = svc.generatePayload(50);
+
+    // tag 29 -> aid: "00" + tlv(00, AID) + tlv(02, <13-digit id verbatim>)
+    expect(payload).toContain('2939000016A00000067701011102131234567890123');
+    expect(payload).toContain('540550.00'); // tlv(54, "50.00") -> len 05
+    expect(payload.endsWith(refCrc16(payload.slice(0, -4)))).toBe(true);
+  });
+
+  it('formats the trailing CRC as 4 upper-hex chars after the 6304 marker', () => {
+    const payload = makeService('0812345678').generatePayload(1);
+    const crc = payload.slice(-4);
+    expect(crc).toMatch(/^[0-9A-F]{4}$/);
+    expect(payload.slice(-8, -4)).toBe('6304');
+  });
+
+  it('throws BadRequestException when PROMPTPAY_ID is not configured', () => {
+    const svc = makeService(); // no setConfig, env returns undefined
+    expect(() => svc.generatePayload(100)).toThrow(BadRequestException);
+  });
+});
+
+describe('PromptPayQrService accessors', () => {
+  it('masks the PromptPay id keeping first 3 and last 4', () => {
+    expect(makeService('0812345678').getMaskedPromptPayId()).toBe('081-****-5678');
+  });
+
+  it('returns a short id unmasked and empty string when unset', () => {
+    expect(makeService('12').getMaskedPromptPayId()).toBe('12');
+    expect(makeService().getMaskedPromptPayId()).toBe('');
+  });
+
+  it('returns the configured account name (or empty string)', () => {
+    expect(makeService('0812345678', 'BestChoice').getAccountName()).toBe('BestChoice');
+    expect(makeService().getAccountName()).toBe('');
+  });
+});

--- a/apps/api/src/modules/quality-control/inspections.service.spec.ts
+++ b/apps/api/src/modules/quality-control/inspections.service.spec.ts
@@ -1,0 +1,90 @@
+import { PrismaService } from '../../prisma/prisma.service';
+import { InspectionsService } from './inspections.service';
+
+/**
+ * Characterization tests for InspectionsService.calculateGrade (Wave 3 backfill).
+ *
+ * calculateGrade is the weighted auto-grading engine for used-phone inspections;
+ * its A/B/C/D result feeds the resale price tier, yet the whole quality-control
+ * module had no spec (review finding D7). These lock the weighting math, the
+ * per-scoreType scoring, the "required item failed → cap at C" rule, the
+ * divide-by-zero guard, and the configurable thresholds.
+ *
+ * calculateGrade is private and only touches `this.prisma`, so the service is
+ * built with a mock Prisma and the method is called via a typed accessor.
+ */
+
+type Result = {
+  passFail?: boolean | null;
+  grade?: string | null;
+  score?: number | null;
+  numberValue?: number | null;
+  templateItem: { weight: number; scoreType: string; isRequired?: boolean };
+};
+
+const makePrisma = (results: Result[], configs: { key: string; value: string }[] = []) =>
+  ({
+    inspectionResult: { findMany: jest.fn().mockResolvedValue(results) },
+    systemConfig: { findMany: jest.fn().mockResolvedValue(configs) },
+  }) as unknown as PrismaService;
+
+const grade = (results: Result[], configs?: { key: string; value: string }[]) => {
+  const svc = new InspectionsService(makePrisma(results, configs));
+  return (svc as unknown as {
+    calculateGrade: (id: string) => Promise<'A' | 'B' | 'C' | 'D'>;
+  }).calculateGrade('insp-1');
+};
+
+describe('InspectionsService.calculateGrade', () => {
+  it('grades a perfect PASS_FAIL inspection as A (default thresholds 90/70/50)', async () => {
+    expect(await grade([{ passFail: true, templateItem: { weight: 1, scoreType: 'PASS_FAIL' } }])).toBe('A');
+  });
+
+  it('maps a GRADE item (B = 75%) to a B', async () => {
+    expect(await grade([{ grade: 'B', templateItem: { weight: 2, scoreType: 'GRADE' } }])).toBe('B');
+  });
+
+  it('scales SCORE_1_5 to a percentage (4/5 = 80% → B)', async () => {
+    expect(await grade([{ score: 4, templateItem: { weight: 1, scoreType: 'SCORE_1_5' } }])).toBe('B');
+  });
+
+  it('caps a NUMBER score at 100 (95 → A)', async () => {
+    expect(await grade([{ numberValue: 95, templateItem: { weight: 1, scoreType: 'NUMBER' } }])).toBe('A');
+  });
+
+  it('weights items: 90% raw score still grades A', async () => {
+    // item1 weight 3 @ 100, item2 weight 1 @ 60 → (300+60)/4 = 90
+    expect(
+      await grade([
+        { passFail: true, templateItem: { weight: 3, scoreType: 'PASS_FAIL' } },
+        { numberValue: 60, templateItem: { weight: 1, scoreType: 'NUMBER' } },
+      ]),
+    ).toBe('A');
+  });
+
+  it('caps the grade at C when a REQUIRED item fails, even at 90% weighted', async () => {
+    const results: Result[] = [
+      { passFail: false, templateItem: { weight: 1, scoreType: 'PASS_FAIL', isRequired: true } },
+      ...Array.from({ length: 9 }, () => ({
+        passFail: true,
+        templateItem: { weight: 1, scoreType: 'PASS_FAIL' },
+      })),
+    ];
+    // weighted % = 900/10 = 90 (would be A), but required-fail caps it
+    expect(await grade(results)).toBe('C');
+  });
+
+  it('returns D when there are no results (no divide-by-zero)', async () => {
+    expect(await grade([])).toBe('D');
+  });
+
+  it('returns D below the C threshold (40% < 50)', async () => {
+    expect(await grade([{ numberValue: 40, templateItem: { weight: 1, scoreType: 'NUMBER' } }])).toBe('D');
+  });
+
+  it('honours a configured grade_a_threshold (85% → A when A-threshold is 80)', async () => {
+    const results: Result[] = [{ numberValue: 85, templateItem: { weight: 1, scoreType: 'NUMBER' } }];
+    expect(await grade(results)).toBe('B'); // default A=90 → 85 is a B
+    expect(await grade(results, [{ key: 'grade_a_threshold', value: '80' }])).toBe('A');
+  });
+});

--- a/apps/api/src/modules/sales-bot/tools/calculate-installment.tool.spec.ts
+++ b/apps/api/src/modules/sales-bot/tools/calculate-installment.tool.spec.ts
@@ -1,0 +1,90 @@
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { CalculateInstallmentTool } from './calculate-installment.tool';
+
+/**
+ * Characterization tests for the sales-bot installment quote (Wave 3 backfill).
+ * `CalculateInstallmentTool.run` had no spec yet quotes regulated installment
+ * money to customers via the bot. It currently does the math in raw JS
+ * `Number()` + `Math.round` (review finding D4) — these goldens LOCK that
+ * behaviour so a Decimal refactor is a deliberate, reviewed change (update the
+ * goldens then), not a silent drift.
+ */
+
+const makePrisma = (
+  product: unknown,
+  cfg: unknown,
+): PrismaService =>
+  ({
+    product: { findFirst: jest.fn().mockResolvedValue(product) },
+    interestConfig: { findFirst: jest.fn().mockResolvedValue(cfg) },
+  }) as unknown as PrismaService;
+
+const productAt = (price: string) => ({
+  name: 'iPhone 15',
+  prices: [{ amount: new Prisma.Decimal(price) }],
+});
+const cfgAt = (rateFraction: string) => ({ interestRate: new Prisma.Decimal(rateFraction) });
+
+describe('CalculateInstallmentTool.run', () => {
+  it('quotes a 12-month deal: 20% down, 30% flat over full year', async () => {
+    const tool = new CalculateInstallmentTool(makePrisma(productAt('10000'), cfgAt('0.30')));
+    const r = await tool.run({ productId: 'p1', downPct: 20, tenureMonths: 12 });
+
+    expect(r).toEqual({
+      productName: 'iPhone 15',
+      priceThb: 10000,
+      downAmountThb: 2000, // round(10000 * 0.20)
+      financedThb: 8000,
+      tenureMonths: 12,
+      ratePct: 30, // 0.30 * 100
+      monthlyThb: 867, // round((8000 + 2400) / 12)
+      totalPaidThb: 12400, // 2000 + 10400
+    });
+  });
+
+  it('defaults down payment to 20% when downPct is omitted', async () => {
+    const tool = new CalculateInstallmentTool(makePrisma(productAt('10000'), cfgAt('0.30')));
+    const r = await tool.run({ productId: 'p1', tenureMonths: 12 });
+    expect(r).toMatchObject({ downAmountThb: 2000, financedThb: 8000 });
+  });
+
+  it('prorates interest by tenure/12 (6 months = half a year)', async () => {
+    const tool = new CalculateInstallmentTool(makePrisma(productAt('10000'), cfgAt('0.30')));
+    const r = await tool.run({ productId: 'p1', downPct: 20, tenureMonths: 6 });
+
+    // financed 8000, interest = round(8000 * 0.30 * 0.5) = 1200
+    expect(r).toMatchObject({
+      financedThb: 8000,
+      monthlyThb: 1533, // round((8000 + 1200) / 6)
+      totalPaidThb: 11200,
+    });
+  });
+
+  it('uses rate 0 when no active InterestConfig matches the tenure', async () => {
+    const tool = new CalculateInstallmentTool(makePrisma(productAt('10000'), null));
+    const r = await tool.run({ productId: 'p1', downPct: 20, tenureMonths: 10 });
+
+    expect(r).toMatchObject({
+      ratePct: 0,
+      monthlyThb: 800, // round(8000 / 10), no interest
+      totalPaidThb: 10000,
+    });
+  });
+
+  it('returns product_not_found when the product is missing', async () => {
+    const tool = new CalculateInstallmentTool(makePrisma(null, cfgAt('0.30')));
+    expect(await tool.run({ productId: 'nope', tenureMonths: 12 })).toEqual({
+      error: 'product_not_found',
+    });
+  });
+
+  it('returns price_not_configured when the product has no default price', async () => {
+    const tool = new CalculateInstallmentTool(
+      makePrisma({ name: 'iPhone 15', prices: [] }, cfgAt('0.30')),
+    );
+    expect(await tool.run({ productId: 'p1', tenureMonths: 12 })).toEqual({
+      error: 'price_not_configured',
+    });
+  });
+});

--- a/apps/api/src/utils/installment-calc.util.spec.ts
+++ b/apps/api/src/utils/installment-calc.util.spec.ts
@@ -1,0 +1,292 @@
+import Decimal from 'decimal.js';
+import {
+  calcBcInstallment,
+  calcGfinInstallment,
+  findGfinMapping,
+  findGfinOverpriceRule,
+} from './installment-calc.util';
+import type {
+  BcConfig,
+  GfinModelMappingRow,
+  GfinOverpriceRuleRow,
+  GfinRateFactorRow,
+  ProductForGfin,
+} from './installment-calc.types';
+
+/**
+ * Characterization (golden-value) tests for the BC + GFIN installment money math.
+ *
+ * Wave 3 test-backfill: this util had ZERO spec yet computes financed amount,
+ * interest, commission, VAT, monthly payment and GFIN payback — all customer-
+ * facing regulated money. These tests LOCK the CURRENT behaviour (including the
+ * module-level `Decimal.set({ rounding: ROUND_HALF_UP })`) so a refactor can't
+ * silently change a price. They intentionally do NOT assert what the numbers
+ * "should" be per accounting policy — if the ROUND_HALF_UP vs ROUND_DOWN policy
+ * question (see CODE_QUALITY review D6) is resolved, update the goldens here.
+ */
+
+const d = (n: Decimal.Value) => new Decimal(n);
+
+describe('calcBcInstallment', () => {
+  const config: BcConfig = {
+    minDownPct: d('0.20'),
+    commissionPct: d('0.10'),
+    vatPct: d('0.07'),
+    ratePctByMonths: new Map([
+      [6, d('0.18')],
+      [10, d('0.30')],
+      [12, d('0.36')],
+    ]),
+    allowedMonths: [6, 10, 12],
+  };
+
+  it('computes the full BC breakdown for a valid 20%-down / 10-month contract', () => {
+    const r = calcBcInstallment({
+      installmentPrice: d('10000'),
+      months: 10,
+      downPct: d('0.20'),
+      config,
+    });
+
+    expect(r.isValid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.downPct.toFixed(2)).toBe('0.20');
+    expect(r.downAmount.toFixed(2)).toBe('2000.00');
+    expect(r.financedAmount.toFixed(2)).toBe('8000.00');
+    expect(r.interestPct.toFixed(2)).toBe('0.30');
+    expect(r.interestAmount.toFixed(2)).toBe('2400.00');
+    expect(r.commissionPct.toFixed(2)).toBe('0.10');
+    expect(r.commissionAmount.toFixed(2)).toBe('800.00');
+    expect(r.subtotal.toFixed(2)).toBe('11200.00');
+    expect(r.vatAmount.toFixed(2)).toBe('784.00');
+    expect(r.totalWithVat.toFixed(2)).toBe('11984.00');
+    expect(r.monthlyPayment.toFixed(2)).toBe('1198.40');
+    expect(r.financeToShop.toFixed(2)).toBe('8800.00');
+  });
+
+  it('derives downPct from an explicit customDownAmount', () => {
+    const r = calcBcInstallment({
+      installmentPrice: d('10000'),
+      months: 10,
+      customDownAmount: d('2500'),
+      config,
+    });
+
+    expect(r.isValid).toBe(true);
+    expect(r.downPct.toFixed(2)).toBe('0.25'); // 2500 / 10000
+    expect(r.downAmount.toFixed(2)).toBe('2500.00');
+    expect(r.financedAmount.toFixed(2)).toBe('7500.00');
+    expect(r.interestAmount.toFixed(2)).toBe('2250.00');
+    expect(r.commissionAmount.toFixed(2)).toBe('750.00');
+    expect(r.subtotal.toFixed(2)).toBe('10500.00');
+    expect(r.vatAmount.toFixed(2)).toBe('735.00');
+    expect(r.totalWithVat.toFixed(2)).toBe('11235.00');
+    expect(r.monthlyPayment.toFixed(2)).toBe('1123.50');
+    expect(r.financeToShop.toFixed(2)).toBe('8250.00');
+  });
+
+  it('flags an out-of-table month and a below-minimum down payment, with rate 0', () => {
+    const r = calcBcInstallment({
+      installmentPrice: d('10000'),
+      months: 9, // not in allowedMonths
+      downPct: d('0.10'), // below minDownPct 0.20
+      config,
+    });
+
+    expect(r.isValid).toBe(false);
+    expect(r.errors).toHaveLength(2);
+    expect(r.errors[0]).toContain('จำนวนงวด 9');
+    expect(r.errors[1]).toContain('20%');
+    expect(r.interestPct.toFixed(2)).toBe('0.00'); // ratePctByMonths.get(9) ?? 0
+    expect(r.interestAmount.toFixed(2)).toBe('0.00');
+  });
+
+  it('rejects a down payment that meets or exceeds the selling price', () => {
+    const r = calcBcInstallment({
+      installmentPrice: d('10000'),
+      months: 10,
+      customDownAmount: d('10000'),
+      config,
+    });
+
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => e.includes('เงินดาวน์ต้องน้อยกว่าราคาขาย'))).toBe(true);
+  });
+
+  it('returns a zero monthly payment when months is 0 (no divide-by-zero)', () => {
+    const r = calcBcInstallment({
+      installmentPrice: d('10000'),
+      months: 0,
+      downPct: d('0.20'),
+      config,
+    });
+    expect(r.monthlyPayment.toFixed(2)).toBe('0.00');
+  });
+});
+
+describe('calcGfinInstallment', () => {
+  const rateFactor12: GfinRateFactorRow = {
+    months: 12,
+    factor: d('0.05'),
+    feePerInstallment: d('50'),
+    isActive: true,
+  };
+  const mapping: GfinModelMappingRow = {
+    id: 'm1',
+    gfinSeries: 'iPhone 14',
+    gfinVariant: null,
+    storage: '128GB',
+    condition: 'HAND_1',
+    maxPrice: d('11000'),
+    modelMatchPattern: 'iPhone 14 Pro',
+    isActive: true,
+  };
+  const overpriceRule: GfinOverpriceRuleRow = {
+    id: 'o1',
+    label: 'iPhone 14 series',
+    seriesPattern: 'iPhone 14|iPhone 15',
+    condition: 'HAND_1',
+    allowance: d('500'),
+    isActive: true,
+  };
+  const product: ProductForGfin = {
+    brand: 'Apple',
+    model: 'iPhone 14 Pro',
+    storage: '128GB',
+    category: 'PHONE_NEW',
+  };
+
+  it('computes submit price, down discount and monthly payback for a valid GFIN deal', () => {
+    const r = calcGfinInstallment({
+      installmentPrice: d('10000'),
+      product,
+      months: 12,
+      downPct: d('0.30'),
+      mapping,
+      overpriceRule,
+      rateFactor: rateFactor12,
+    });
+
+    expect(r.isValid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.gfinSubmitPrice.toFixed(2)).toBe('11500.00'); // 11000 + 500
+    expect(r.downDiscount.toFixed(2)).toBe('1500.00'); // max(11500 - 10000, 0)
+    expect(r.downPct.toFixed(2)).toBe('0.30');
+    expect(r.downAmountByFormula.toFixed(2)).toBe('3450.00'); // 11500 * 0.30
+    expect(r.downAmountActual.toFixed(2)).toBe('1950.00'); // max(3450 - 1500, 0)
+    expect(r.financedAmount.toFixed(2)).toBe('8050.00'); // 11500 - 3450
+    expect(r.monthlyPayment.toFixed(2)).toBe('452.50'); // 0.05 * 8050 + 50
+    expect(r.totalPayback.toFixed(2)).toBe('5430.00'); // 452.50 * 12
+    expect(r.feePerInstallment.toFixed(2)).toBe('50.00');
+  });
+
+  it('defaults downPct to 0.30 and handles a null overprice rule (no discount)', () => {
+    const r = calcGfinInstallment({
+      installmentPrice: d('12000'),
+      product,
+      months: 10,
+      mapping: { ...mapping, maxPrice: d('12000') },
+      overpriceRule: null,
+      rateFactor: { months: 10, factor: d('0.04'), feePerInstallment: d('0'), isActive: true },
+    });
+
+    expect(r.isValid).toBe(true);
+    expect(r.downPct.toFixed(2)).toBe('0.30'); // default
+    expect(r.gfinSubmitPrice.toFixed(2)).toBe('12000.00');
+    expect(r.downDiscount.toFixed(2)).toBe('0.00');
+    expect(r.downAmountByFormula.toFixed(2)).toBe('3600.00');
+    expect(r.downAmountActual.toFixed(2)).toBe('3600.00');
+    expect(r.financedAmount.toFixed(2)).toBe('8400.00');
+    expect(r.monthlyPayment.toFixed(2)).toBe('336.00'); // 0.04 * 8400 + 0
+    expect(r.totalPayback.toFixed(2)).toBe('3360.00');
+  });
+
+  it('flags a rate-factor month mismatch and an inactive rate', () => {
+    const r = calcGfinInstallment({
+      installmentPrice: d('10000'),
+      product,
+      months: 12,
+      mapping,
+      overpriceRule,
+      rateFactor: { months: 10, factor: d('0.05'), feePerInstallment: d('50'), isActive: false },
+    });
+
+    expect(r.isValid).toBe(false);
+    expect(r.errors).toHaveLength(2);
+    expect(r.errors[0]).toContain('12');
+    expect(r.errors.some((e) => e.includes('ปิดใช้งาน'))).toBe(true);
+  });
+});
+
+describe('findGfinMapping', () => {
+  const base = {
+    gfinVariant: null,
+    condition: 'HAND_1' as const,
+    maxPrice: new Decimal('0'),
+    isActive: true,
+  };
+  const mappings: GfinModelMappingRow[] = [
+    { ...base, id: 'a', gfinSeries: 'iPhone 14', storage: '128GB', modelMatchPattern: 'iPhone 14 Pro', maxPrice: d('20000') },
+    { ...base, id: 'b', gfinSeries: 'iPhone 14', storage: '128 GB', modelMatchPattern: 'iPhone 14 Pro Max', maxPrice: d('25000') },
+  ];
+
+  it('prefers the longer (more specific) pattern when both could match', () => {
+    const r = findGfinMapping(
+      { brand: 'Apple', model: 'iPhone 14 Pro Max', storage: '128GB', category: 'PHONE_NEW' },
+      mappings,
+    );
+    expect(r?.id).toBe('b'); // "iPhone 14 Pro Max" beats "iPhone 14 Pro"
+  });
+
+  it('falls back to the shorter pattern when the long one does not apply', () => {
+    const r = findGfinMapping(
+      { brand: 'Apple', model: 'iPhone 14 Pro', storage: '128GB', category: 'PHONE_NEW' },
+      mappings,
+    );
+    expect(r?.id).toBe('a');
+  });
+
+  it('does not match on a partial word boundary (Pro vs ProMax)', () => {
+    const r = findGfinMapping(
+      { brand: 'Apple', model: 'iPhone 14 ProMax', storage: '128GB', category: 'PHONE_NEW' },
+      mappings,
+    );
+    expect(r).toBeNull();
+  });
+
+  it('returns null when the condition (new vs used) does not match', () => {
+    const r = findGfinMapping(
+      { brand: 'Apple', model: 'iPhone 14 Pro', storage: '128GB', category: 'PHONE_USED' },
+      mappings,
+    );
+    expect(r).toBeNull();
+  });
+});
+
+describe('findGfinOverpriceRule', () => {
+  const rule: GfinOverpriceRuleRow = {
+    id: 'r1',
+    label: 'iPhone 14/15',
+    seriesPattern: 'iPhone 14 | iPhone 15',
+    condition: 'HAND_1',
+    allowance: new Decimal('500'),
+    isActive: true,
+  };
+  const mapping: GfinModelMappingRow = {
+    id: 'm', gfinSeries: 'iPhone 14', gfinVariant: null, storage: '128GB',
+    condition: 'HAND_1', maxPrice: new Decimal('0'), modelMatchPattern: 'iPhone 14', isActive: true,
+  };
+
+  it('matches when the mapping series is in the pipe-delimited (trimmed) pattern', () => {
+    expect(findGfinOverpriceRule(mapping, [rule])?.id).toBe('r1');
+  });
+
+  it('returns null when the series is not listed', () => {
+    expect(findGfinOverpriceRule({ ...mapping, gfinSeries: 'iPhone 13' }, [rule])).toBeNull();
+  });
+
+  it('skips inactive rules and condition mismatches', () => {
+    expect(findGfinOverpriceRule(mapping, [{ ...rule, isActive: false }])).toBeNull();
+    expect(findGfinOverpriceRule({ ...mapping, condition: 'HAND_2' }, [rule])).toBeNull();
+  });
+});


### PR DESCRIPTION
Wave 3 (test-backfill) of the apps/api code-quality remediation — see `CODE_QUALITY_REMEDIATION_PLAN.md`. Safe, zero-runtime-risk work that locks current behaviour and builds the safety net the surgical Wave 1/4 changes need.

## What
Adds **15 golden / characterization tests** for `utils/installment-calc.util.ts`, which had **no spec** despite computing customer-facing regulated money:
- `calcBcInstallment` — financed amount, interest, commission, VAT, monthly payment, finance-to-shop (full breakdown + customDownAmount path + validation errors + months=0 guard).
- `calcGfinInstallment` — submit price, down discount, financed amount, monthly payback (valid deal + null-overprice/default-down path + rate-factor mismatch errors).
- `findGfinMapping` — longest-pattern-first, whole-word boundary, condition/storage matching.
- `findGfinOverpriceRule` — pipe-delimited series matching, inactive/condition skips.

## Notes
- These are **characterization** tests: they lock *current* behaviour (including the module-level `Decimal.set({ rounding: ROUND_HALF_UP })`). They deliberately do not assert what the numbers "should" be — if the ROUND_HALF_UP-vs-ROUND_DOWN policy question (review finding D6) is resolved, update the goldens.
- Pure functions, no DB → runs in isolation: `npx jest src/utils/installment-calc.util.spec.ts --runInBand` → **15 passed (2.2s)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)