### PR TITLE
fix(contracts): atomic installment-schedule generation on activation

### DIFF
--- a/apps/api/src/modules/contracts/contract-workflow.schedule.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.schedule.spec.ts
@@ -1,0 +1,98 @@
+import { Prisma } from '@prisma/client';
+import { ContractWorkflowService } from './contract-workflow.service';
+
+/**
+ * Characterization tests for ContractWorkflowService.generateInstallmentSchedules
+ * (Wave 3 backfill + review finding #9).
+ *
+ * The method now runs INSIDE the activation $transaction (it takes `tx` and is
+ * awaited at the call site) so a failure rolls the whole activation back instead
+ * of leaving an ACTIVE contract with no schedule rows. These tests:
+ *   - lock the per-installment money math (principal ROUND_DOWN, interest
+ *     ROUND_HALF_UP — matches the CPA golden 17000/12 = 1416.66, 1190/12 = 99.17),
+ *   - prove it writes via the passed `tx` (not this.prisma),
+ *   - cover the idempotency skip and the totalMonths<=0 guard.
+ *
+ * It's a private method that only touches `tx`, so the service is built with stub
+ * deps and the method is invoked via a typed accessor.
+ */
+
+const stub = {} as never;
+const service = new ContractWorkflowService(stub, stub, stub, stub, stub, stub);
+
+type Rows = Prisma.InstallmentScheduleCreateManyInput[];
+
+const makeTx = (existing: number, contract: unknown) => {
+  const createMany = jest.fn().mockResolvedValue({ count: 0 });
+  const tx = {
+    contract: { findUniqueOrThrow: jest.fn().mockResolvedValue(contract) },
+    installmentSchedule: {
+      count: jest.fn().mockResolvedValue(existing),
+      createMany,
+    },
+  };
+  return { tx, createMany };
+};
+
+const gen = (contract: { id: string; contractNumber: string }, tx: unknown) =>
+  (service as unknown as {
+    generateInstallmentSchedules: (c: typeof contract, t: unknown) => Promise<void>;
+  }).generateInstallmentSchedules(contract, tx);
+
+describe('ContractWorkflowService.generateInstallmentSchedules', () => {
+  it('writes 12 rows with CPA rounding via the passed tx', async () => {
+    const contract = {
+      id: 'c1',
+      contractNumber: 'CT-001',
+      totalMonths: 12,
+      financedAmount: new Prisma.Decimal('17000'),
+      interestTotal: new Prisma.Decimal('1190'),
+      monthlyPayment: new Prisma.Decimal('1515.83'),
+      createdAt: new Date(2026, 0, 15), // 15 Jan 2026
+      paymentDueDay: 5,
+    };
+    const { tx, createMany } = makeTx(0, contract);
+
+    await gen({ id: 'c1', contractNumber: 'CT-001' }, tx);
+
+    expect(createMany).toHaveBeenCalledTimes(1);
+    const rows = createMany.mock.calls[0][0].data as Rows;
+    expect(rows).toHaveLength(12);
+
+    const first = rows[0];
+    expect(first.installmentNo).toBe(1);
+    expect(first.contractId).toBe('c1');
+    expect((first.principal as Prisma.Decimal).toFixed(2)).toBe('1416.66'); // 17000/12 ROUND_DOWN
+    expect((first.interest as Prisma.Decimal).toFixed(2)).toBe('99.17'); // 1190/12 ROUND_HALF_UP
+    expect((first.amountDue as Prisma.Decimal).toFixed(2)).toBe('1515.83'); // = monthlyPayment
+
+    // due dates: startDate (createdAt) month + i, on paymentDueDay
+    const d1 = first.dueDate as Date;
+    expect([d1.getFullYear(), d1.getMonth(), d1.getDate()]).toEqual([2026, 1, 5]); // 5 Feb 2026
+    const d12 = rows[11].dueDate as Date;
+    expect([d12.getFullYear(), d12.getMonth(), d12.getDate()]).toEqual([2027, 0, 5]); // 5 Jan 2027
+  });
+
+  it('is idempotent: skips when schedule rows already exist', async () => {
+    const contract = { id: 'c2', contractNumber: 'CT-002', totalMonths: 12 };
+    const { tx, createMany } = makeTx(12, contract); // existing > 0
+    await gen({ id: 'c2', contractNumber: 'CT-002' }, tx);
+    expect(createMany).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when totalMonths <= 0', async () => {
+    const contract = {
+      id: 'c3',
+      contractNumber: 'CT-003',
+      totalMonths: 0,
+      financedAmount: new Prisma.Decimal('0'),
+      interestTotal: new Prisma.Decimal('0'),
+      monthlyPayment: new Prisma.Decimal('0'),
+      createdAt: new Date(2026, 0, 15),
+      paymentDueDay: 5,
+    };
+    const { tx, createMany } = makeTx(0, contract);
+    await gen({ id: 'c3', contractNumber: 'CT-003' }, tx);
+    expect(createMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.spec.ts
@@ -129,7 +129,16 @@ describe('ContractWorkflowService', () => {
     prisma = {
       contract: {
         findUnique: jest.fn().mockResolvedValue(mockContract),
+        findUniqueOrThrow: jest.fn().mockResolvedValue(mockContract),
         update: jest.fn().mockResolvedValue({ ...mockContract, status: 'ACTIVE' }),
+      },
+      installmentSchedule: {
+        // generateInstallmentSchedules now runs inside the activation tx. These
+        // activate() tests don't exercise schedule math (covered by
+        // contract-workflow.schedule.spec.ts) — report existing rows so it takes
+        // the idempotent skip path.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
       product: {
         findUnique: jest.fn().mockResolvedValue(mockProduct),

--- a/apps/api/src/modules/contracts/contract-workflow.service.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger, Optional, NotFoundException, BadRequestException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
-import * as Sentry from '@sentry/nestjs';
 import { formatDateShort } from '../../utils/thai-date.util';
 import { PrismaService } from '../../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -496,16 +495,13 @@ export class ContractWorkflowService {
 
       // Phase A.4 — generate installment_schedules rows so accrual cron + payment
       // preview API can find them. Per-installment due_date = startDate + (i × 1 month).
-      this.generateInstallmentSchedules(contract).catch((err) => {
-        this.logger.error(
-          `Failed to generate installment_schedules for contract ${contract.contractNumber}: ${err?.message || err}`,
-          err?.stack,
-        );
-        Sentry.captureException(err, {
-          tags: { module: 'contracts', event: 'schedule-generation-failure' },
-          extra: { contractId: contract.id, contractNumber: contract.contractNumber },
-        });
-      });
+      // Runs inside the activation $transaction (same `tx`) and is awaited: if it
+      // fails, the whole activation rolls back — contract stays DRAFT with no JE
+      // and no schedule — rather than committing an ACTIVE contract with no
+      // installment rows (which silently breaks the accrual cron + payment preview).
+      // (Was fire-and-forget on this.prisma: not awaited, off-transaction, and a
+      // failure left a broken ACTIVE contract behind a fire-and-forget log line.)
+      await this.generateInstallmentSchedules(contract, tx);
     });
 
     // Send LINE notification to customer (non-blocking)
@@ -525,11 +521,14 @@ export class ContractWorkflowService {
    *   amountDue = monthlyPayment (incl. VAT)
    *   dueDate   = startDate + (i months)
    */
-  private async generateInstallmentSchedules(contract: { id: string; contractNumber: string }) {
-    const c = await this.prisma.contract.findUniqueOrThrow({
+  private async generateInstallmentSchedules(
+    contract: { id: string; contractNumber: string },
+    tx: Prisma.TransactionClient,
+  ) {
+    const c = await tx.contract.findUniqueOrThrow({
       where: { id: contract.id },
     });
-    const existing = await this.prisma.installmentSchedule.count({
+    const existing = await tx.installmentSchedule.count({
       where: { contractId: c.id, deletedAt: null },
     });
     if (existing > 0) {
@@ -563,7 +562,7 @@ export class ContractWorkflowService {
         amountDue: monthly,
       });
     }
-    await this.prisma.installmentSchedule.createMany({ data: rows });
+    await tx.installmentSchedule.createMany({ data: rows });
     this.logger.log(`Generated ${rows.length} installment_schedules rows for contract ${c.contractNumber}`);
   }
 


### PR DESCRIPTION
Wave 1 (data-integrity) — review finding #9.

## Bug
Inside `activate()`'s `$transaction`, `generateInstallmentSchedules(contract)` was called **fire-and-forget on `this.prisma`**:
- **not awaited** → the transaction commits before it runs;
- **off-transaction** (`this.prisma`, not `tx`) → not part of activation atomicity;
- a failure only logged + Sentry'd.

Result: an **ACTIVE contract with a posted 1A JE but no `installment_schedules` rows** — which silently breaks the accrual cron and the payment-preview API. (Naively `await`-ing the old call would also risk a connection-pool **deadlock**, since it opened a second connection while the tx held one.)

## Fix
Pass the activation `tx` into the method and `await` it — mirroring the 1A-JE pattern already in the same block (moved in-tx for ปพพ.386 atomicity). Now if schedule generation fails, the **whole activation rolls back** (contract stays DRAFT, no JE, no sale) instead of committing a broken ACTIVE contract. Removed the now-dead `Sentry` import.

## Tests (13 passed)
- **New** `contract-workflow.schedule.spec.ts`: 12-row generation with CPA rounding (`17000/12 = 1416.66` ROUND_DOWN principal, `1190/12 = 99.17` ROUND_HALF_UP interest), due-date sequencing, idempotent skip, `totalMonths<=0` guard, and asserts it writes via the **passed `tx`**.
- **Updated** existing `contract-workflow.service.spec.ts` tx mock with `findUniqueOrThrow` + `installmentSchedule` (idempotent-skip path) — the 6 activate() tests that the refactor touched are green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)