### PR TITLE
feat(accounting): /reports P&L expenses from journal (company-wide FINANCE)

### DIFF
--- a/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
@@ -112,3 +112,41 @@ describe('AccountingService.getProfitLossReport (expense wiring)', () => {
     expect(r.summary.totalExpenses).toBe(0);
   });
 });
+
+describe('AccountingService.getMonthlyPLSummary (expense wiring)', () => {
+  function makeMonthlyService(lines: { entryDate: Date; debit: Prisma.Decimal; credit: Prisma.Decimal }[]) {
+    const prisma = {
+      sale: { findMany: jest.fn().mockResolvedValue([]) },
+      payment: { findMany: jest.fn().mockResolvedValue([]) },
+      financeReceivable: { findMany: jest.fn().mockResolvedValue([]) },
+      journalLine: {
+        findMany: jest.fn().mockResolvedValue(
+          lines.map((l) => ({ debit: l.debit, credit: l.credit, journalEntry: { entryDate: l.entryDate } })),
+        ),
+      },
+    } as unknown as PrismaService;
+    const companyResolver = {
+      getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1'),
+    } as unknown as CompanyResolverService;
+    return new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+  }
+
+  it('company-wide: per-month FINANCE expenses subtracted from revenue', async () => {
+    const svc = makeMonthlyService([
+      { entryDate: new Date('2026-02-10'), debit: d('5000'), credit: d('0') }, // Feb
+      { entryDate: new Date('2026-02-20'), debit: d('1000'), credit: d('200') }, // Feb net 800
+    ]);
+    const r = await svc.getMonthlyPLSummary(2026);
+    const feb = r.months.find((m) => m.month === 2)!;
+    expect(feb.expenses).toBe(5800); // 5000 + 800
+    expect(feb.netProfit).toBe(-5800); // revenue 0
+    const jan = r.months.find((m) => m.month === 1)!;
+    expect(jan.expenses).toBe(0);
+  });
+
+  it('per-branch: expenses zero, journal not queried', async () => {
+    const svc = makeMonthlyService([{ entryDate: new Date('2026-02-10'), debit: d('5000'), credit: d('0') }]);
+    const r = await svc.getMonthlyPLSummary(2026, 'branch-1');
+    expect(r.months.every((m) => m.expenses === 0)).toBe(true);
+  });
+});

--- a/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
@@ -89,13 +89,13 @@ function makeFullService(groupRows: GroupRow[]) {
 }
 
 describe('AccountingService.getProfitLossReport (expense wiring)', () => {
-  it('company-wide: section sums drive totals; granular lines populated; basis flagged', async () => {
+  it('includeFinanceExpenses=true: section sums drive totals; granular lines populated; basis flagged', async () => {
     const svc = makeFullService([
       { accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } },
       { accountCode: '52-1101', _sum: { debit: d('1000'), credit: d('0') } },
       { accountCode: '53-9999', _sum: { debit: d('700'), credit: d('0') } }, // unmapped, admin section
     ]);
-    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31');
+    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31', undefined, undefined, true);
 
     expect(r.adminExpenses.totalAdmin).toBe(30700); // Σ53 (incl. unmapped) — from section sum
     expect(r.adminExpenses.salary).toBe(30000); // granular line
@@ -104,18 +104,22 @@ describe('AccountingService.getProfitLossReport (expense wiring)', () => {
     expect((r as unknown as { expenseBasis: string }).expenseBasis).toBe('accrual-journal');
   });
 
-  it('per-branch: expenses stay zero, journal not queried', async () => {
+  it('default (flag omitted = single-branch / SHOP / per-branch): expenses zero, journal not queried', async () => {
     const svc = makeFullService([{ accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } }]);
-    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31', 'branch-1');
+    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31');
 
     expect(r.adminExpenses.totalAdmin).toBe(0);
     expect(r.summary.totalExpenses).toBe(0);
   });
 
-  it('company-wide via branchIds list (OWNER / all-branches path): expenses added', async () => {
+  it('the flag — NOT branchIds — controls expenses (a branchIds list must not auto-add them)', async () => {
     const svc = makeFullService([{ accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } }]);
-    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31', undefined, ['b1', 'b2']);
-    expect(r.adminExpenses.totalAdmin).toBe(30000); // branchIds list = company-wide, not a single-branch isolate
+    // e.g. a SHOP-company filter resolves to a branchIds list — it must NOT add FINANCE expenses.
+    const off = await svc.getProfitLossReport('2026-01-01', '2026-01-31', undefined, ['b1', 'b2'], false);
+    expect(off.adminExpenses.totalAdmin).toBe(0);
+    // The same shape with the flag ON does add them (caller decided it's FINANCE/whole-business).
+    const on = await svc.getProfitLossReport('2026-01-01', '2026-01-31', undefined, ['b1', 'b2'], true);
+    expect(on.adminExpenses.totalAdmin).toBe(30000);
   });
 });
 
@@ -137,12 +141,12 @@ describe('AccountingService.getMonthlyPLSummary (expense wiring)', () => {
     return new AccountingService(prisma, {} as JournalAutoService, companyResolver);
   }
 
-  it('company-wide: per-month FINANCE expenses subtracted from revenue', async () => {
+  it('includeFinanceExpenses=true: per-month FINANCE expenses subtracted from revenue', async () => {
     const svc = makeMonthlyService([
       { entryDate: new Date('2026-02-10'), debit: d('5000'), credit: d('0') }, // Feb
       { entryDate: new Date('2026-02-20'), debit: d('1000'), credit: d('200') }, // Feb net 800
     ]);
-    const r = await svc.getMonthlyPLSummary(2026);
+    const r = await svc.getMonthlyPLSummary(2026, undefined, undefined, true);
     const feb = r.months.find((m) => m.month === 2)!;
     expect(feb.expenses).toBe(5800); // 5000 + 800
     expect(feb.netProfit).toBe(-5800); // revenue 0

--- a/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
@@ -1,0 +1,74 @@
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { CompanyResolverService } from '../journal/company-resolver.service';
+import { AccountingService } from './accounting.service';
+
+type GroupRow = { accountCode: string; _sum: { debit: Prisma.Decimal | null; credit: Prisma.Decimal | null } };
+
+const d = (n: string | number) => new Prisma.Decimal(n);
+
+function makeService(groupRows: GroupRow[]) {
+  const journalLineGroupBy = jest.fn().mockResolvedValue(groupRows);
+  const prisma = {
+    journalLine: { groupBy: journalLineGroupBy },
+  } as unknown as PrismaService;
+  const companyResolver = {
+    getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1'),
+  } as unknown as CompanyResolverService;
+  const svc = new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+  return { svc, journalLineGroupBy };
+}
+
+const aggregate = (svc: AccountingService, companyWide: boolean) =>
+  (svc as unknown as {
+    aggregateFinanceExpenses: (
+      s: Date,
+      e: Date,
+      cw: boolean,
+    ) => Promise<{
+      byCategory: { category: string; totalAmount: Prisma.Decimal }[];
+      sectionTotals: { selling: Prisma.Decimal; admin: Prisma.Decimal; other: Prisma.Decimal };
+    }>;
+  }).aggregateFinanceExpenses(new Date('2026-01-01'), new Date('2026-01-31'), companyWide);
+
+describe('AccountingService.aggregateFinanceExpenses', () => {
+  it('company-wide: section totals + curated category rollups, net = debit - credit', async () => {
+    const { svc } = makeService([
+      { accountCode: '52-1101', _sum: { debit: d('1000'), credit: d('0') } }, // SELL_COMMISSION
+      { accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } }, // ADMIN_SALARY
+      { accountCode: '53-1102', _sum: { debit: d('1500'), credit: d('0') } }, // ADMIN_SOCIAL_SECURITY
+      { accountCode: '53-1601', _sum: { debit: d('2000'), credit: d('500') } }, // ADMIN_DEPRECIATION net 1500
+      { accountCode: '51-1102', _sum: { debit: d('800'), credit: d('0') } }, // OTHER_LOSS
+      { accountCode: '53-9999', _sum: { debit: d('700'), credit: d('0') } }, // unmapped → admin section only
+    ]);
+
+    const r = await aggregate(svc, true);
+
+    expect(r.sectionTotals.selling.toFixed(2)).toBe('1000.00'); // Σ52
+    expect(r.sectionTotals.admin.toFixed(2)).toBe('33700.00'); // 30000+1500+1500+700
+    expect(r.sectionTotals.other.toFixed(2)).toBe('800.00'); // Σ51
+
+    const byCat = Object.fromEntries(r.byCategory.map((c) => [c.category, c.totalAmount.toFixed(2)]));
+    expect(byCat['SELL_COMMISSION']).toBe('1000.00');
+    expect(byCat['ADMIN_SALARY']).toBe('30000.00');
+    expect(byCat['ADMIN_SOCIAL_SECURITY']).toBe('1500.00');
+    expect(byCat['ADMIN_DEPRECIATION']).toBe('1500.00'); // 2000 - 500
+    expect(byCat['OTHER_LOSS']).toBe('800.00');
+    expect(byCat['53-9999']).toBeUndefined(); // unmapped: no category line
+  });
+
+  it('per-branch (not company-wide): returns zeros and does NOT query the journal', async () => {
+    const { svc, journalLineGroupBy } = makeService([
+      { accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } },
+    ]);
+
+    const r = await aggregate(svc, false);
+
+    expect(journalLineGroupBy).not.toHaveBeenCalled();
+    expect(r.byCategory).toEqual([]);
+    expect(r.sectionTotals.selling.toFixed(2)).toBe('0.00');
+    expect(r.sectionTotals.admin.toFixed(2)).toBe('0.00');
+    expect(r.sectionTotals.other.toFixed(2)).toBe('0.00');
+  });
+});

--- a/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
@@ -111,6 +111,12 @@ describe('AccountingService.getProfitLossReport (expense wiring)', () => {
     expect(r.adminExpenses.totalAdmin).toBe(0);
     expect(r.summary.totalExpenses).toBe(0);
   });
+
+  it('company-wide via branchIds list (OWNER / all-branches path): expenses added', async () => {
+    const svc = makeFullService([{ accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } }]);
+    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31', undefined, ['b1', 'b2']);
+    expect(r.adminExpenses.totalAdmin).toBe(30000); // branchIds list = company-wide, not a single-branch isolate
+  });
 });
 
 describe('AccountingService.getMonthlyPLSummary (expense wiring)', () => {

--- a/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+++ b/apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
@@ -72,3 +72,43 @@ describe('AccountingService.aggregateFinanceExpenses', () => {
     expect(r.sectionTotals.other.toFixed(2)).toBe('0.00');
   });
 });
+
+function makeFullService(groupRows: GroupRow[]) {
+  const agg0 = { _sum: {} as Record<string, Prisma.Decimal | null> };
+  const prisma = {
+    sale: { aggregate: jest.fn().mockResolvedValue(agg0), findMany: jest.fn().mockResolvedValue([]) },
+    payment: { findMany: jest.fn().mockResolvedValue([]) },
+    financeReceivable: { aggregate: jest.fn().mockResolvedValue({ _sum: {} }) },
+    product: { findMany: jest.fn().mockResolvedValue([]) },
+    journalLine: { groupBy: jest.fn().mockResolvedValue(groupRows) },
+  } as unknown as PrismaService;
+  const companyResolver = {
+    getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1'),
+  } as unknown as CompanyResolverService;
+  return new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+}
+
+describe('AccountingService.getProfitLossReport (expense wiring)', () => {
+  it('company-wide: section sums drive totals; granular lines populated; basis flagged', async () => {
+    const svc = makeFullService([
+      { accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } },
+      { accountCode: '52-1101', _sum: { debit: d('1000'), credit: d('0') } },
+      { accountCode: '53-9999', _sum: { debit: d('700'), credit: d('0') } }, // unmapped, admin section
+    ]);
+    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31');
+
+    expect(r.adminExpenses.totalAdmin).toBe(30700); // Σ53 (incl. unmapped) — from section sum
+    expect(r.adminExpenses.salary).toBe(30000); // granular line
+    expect(r.sellingExpenses.totalSelling).toBe(1000);
+    expect(r.summary.totalExpenses).toBe(31700); // COGS 0 + 1000 + 30700 + 0
+    expect((r as unknown as { expenseBasis: string }).expenseBasis).toBe('accrual-journal');
+  });
+
+  it('per-branch: expenses stay zero, journal not queried', async () => {
+    const svc = makeFullService([{ accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } }]);
+    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31', 'branch-1');
+
+    expect(r.adminExpenses.totalAdmin).toBe(0);
+    expect(r.summary.totalExpenses).toBe(0);
+  });
+});

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -49,6 +49,13 @@ export const INVENTORY_COSTING_METHOD = 'SPECIFIC_IDENTIFICATION' as const;
  * 4. สินค้าคงเหลือ — Specific Identification (ระบุเฉพาะ)
  *    - สินค้าแต่ละชิ้นมี costPrice เฉพาะ (IMEI-level tracking)
  */
+type ReportExpenseCategory =
+  | 'SELL_COMMISSION' | 'SELL_ADVERTISING'
+  | 'ADMIN_SALARY' | 'ADMIN_SOCIAL_SECURITY' | 'ADMIN_OFFICE_SUPPLIES'
+  | 'ADMIN_UTILITIES' | 'ADMIN_TELEPHONE' | 'ADMIN_TRAVEL' | 'ADMIN_MAINTENANCE'
+  | 'ADMIN_TAX_FEE' | 'ADMIN_DEPRECIATION'
+  | 'OTHER_LOSS' | 'OTHER_FINE' | 'OTHER_MISC';
+
 @Injectable()
 export class AccountingService implements OnModuleInit {
   private readonly logger = new Logger(AccountingService.name);
@@ -59,6 +66,96 @@ export class AccountingService implements OnModuleInit {
     // P3-SP5 W7: defense-in-depth filter on companyId for SHOP/FINANCE scoping.
     private companyResolver: CompanyResolverService,
   ) {}
+
+  // Account → /reports P&L granular category (display only; totals come from
+  // section sums). Accountant-reviewable: rollups chosen from the FINANCE chart
+  // names (see docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md).
+  // Accounts not listed still count in their section total but show no granular line.
+  private static readonly EXPENSE_ACCOUNT_CATEGORY: Record<string, ReportExpenseCategory> = {
+    '52-1101': 'SELL_COMMISSION',
+    '52-1102': 'SELL_ADVERTISING', '52-1103': 'SELL_ADVERTISING',
+    '53-1101': 'ADMIN_SALARY', '53-1103': 'ADMIN_SALARY', '53-1104': 'ADMIN_SALARY',
+    '53-1105': 'ADMIN_SALARY', '53-1106': 'ADMIN_SALARY',
+    '53-1102': 'ADMIN_SOCIAL_SECURITY',
+    '53-1201': 'ADMIN_OFFICE_SUPPLIES', '53-1202': 'ADMIN_OFFICE_SUPPLIES', '53-1203': 'ADMIN_OFFICE_SUPPLIES',
+    '53-1301': 'ADMIN_UTILITIES', '53-1302': 'ADMIN_UTILITIES',
+    '53-1303': 'ADMIN_TELEPHONE',
+    '53-1304': 'ADMIN_TRAVEL',
+    '53-1305': 'ADMIN_MAINTENANCE', '53-1306': 'ADMIN_MAINTENANCE',
+    '53-1401': 'ADMIN_TAX_FEE', '53-1402': 'ADMIN_TAX_FEE', '53-1403': 'ADMIN_TAX_FEE',
+    '53-1404': 'ADMIN_TAX_FEE', '53-1501': 'ADMIN_TAX_FEE', '53-1502': 'ADMIN_TAX_FEE',
+    '53-1701': 'ADMIN_TAX_FEE', '53-1702': 'ADMIN_TAX_FEE',
+    '53-1601': 'ADMIN_DEPRECIATION', '53-1602': 'ADMIN_DEPRECIATION',
+    '53-1603': 'ADMIN_DEPRECIATION', '53-1604': 'ADMIN_DEPRECIATION',
+    '51-1102': 'OTHER_LOSS', '51-1103': 'OTHER_LOSS', '53-1605': 'OTHER_LOSS',
+    '51-1104': 'OTHER_FINE', '54-1103': 'OTHER_FINE', '54-1104': 'OTHER_FINE',
+    '51-1101': 'OTHER_MISC', '51-1105': 'OTHER_MISC', '53-1503': 'OTHER_MISC',
+    '54-1101': 'OTHER_MISC', '54-1102': 'OTHER_MISC',
+  };
+
+  /**
+   * Aggregate POSTED FINANCE journal expense lines (51-54) for a period into
+   * section totals (authoritative) + a curated category breakdown (display).
+   * Only runs for company-wide views — per-branch expense attribution is
+   * deferred until SHOP accounting exists (journal has no branchId).
+   */
+  private async aggregateFinanceExpenses(
+    start: Date,
+    end: Date,
+    companyWide: boolean,
+  ): Promise<{
+    byCategory: { category: string; totalAmount: Prisma.Decimal }[];
+    sectionTotals: { selling: Prisma.Decimal; admin: Prisma.Decimal; other: Prisma.Decimal };
+  }> {
+    const zero = () => new Prisma.Decimal(0);
+    if (!companyWide) {
+      return { byCategory: [], sectionTotals: { selling: zero(), admin: zero(), other: zero() } };
+    }
+
+    const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
+    const lineSums = await this.prisma.journalLine.groupBy({
+      by: ['accountCode'],
+      where: {
+        journalEntry: {
+          status: 'POSTED',
+          entryDate: { gte: start, lte: end },
+          deletedAt: null,
+          companyId: financeCompanyId,
+        },
+        deletedAt: null,
+        OR: [
+          { accountCode: { startsWith: '51-' } },
+          { accountCode: { startsWith: '52-' } },
+          { accountCode: { startsWith: '53-' } },
+          { accountCode: { startsWith: '54-' } },
+        ],
+      },
+      _sum: { debit: true, credit: true },
+    });
+
+    let selling = zero();
+    let admin = zero();
+    let other = zero();
+    const byCategoryMap = new Map<string, Prisma.Decimal>();
+
+    for (const row of lineSums) {
+      const net = new Prisma.Decimal(row._sum.debit ?? 0).sub(new Prisma.Decimal(row._sum.credit ?? 0));
+      const prefix = row.accountCode.slice(0, 2);
+      if (prefix === '52') selling = selling.add(net);
+      else if (prefix === '53') admin = admin.add(net);
+      else if (prefix === '51' || prefix === '54') other = other.add(net);
+
+      const category = AccountingService.EXPENSE_ACCOUNT_CATEGORY[row.accountCode];
+      if (category) {
+        byCategoryMap.set(category, (byCategoryMap.get(category) ?? zero()).add(net));
+      }
+    }
+
+    return {
+      byCategory: [...byCategoryMap.entries()].map(([category, totalAmount]) => ({ category, totalAmount })),
+      sectionTotals: { selling, admin, other },
+    };
+  }
 
   /**
    * Boot hook retained for future CoA validation needs. Legacy CATEGORY_CODE_MAP

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -239,10 +239,12 @@ export class AccountingService implements OnModuleInit {
       }),
     ]);
 
-    // Company-wide FINANCE expenses from the journal (51-54). Per-branch views
-    // leave expenses empty — branch-attributable expenses come from SHOP
-    // accounting, which is not built yet (journal has no branchId).
-    const companyWide = !branchId && (!branchIds || branchIds.length === 0);
+    // Company-wide FINANCE expenses from the journal (51-54). Only an isolated
+    // single branch (branchId) defers — its branch-attributable expenses come
+    // from SHOP accounting, not built yet (journal has no branchId). The OWNER /
+    // all-branches list view and monthly-close (which pass `branchIds`) are
+    // company-wide and DO get expenses.
+    const companyWide = !branchId;
     const { byCategory: expensesByCategory, sectionTotals } =
       await this.aggregateFinanceExpenses(start, end, companyWide);
 
@@ -485,9 +487,10 @@ export class AccountingService implements OnModuleInit {
       }),
     ]);
 
-    // Company-wide FINANCE expenses per month from the journal (51-54). Per-branch
-    // views leave expenses empty (deferred to SHOP accounting; journal has no branchId).
-    const companyWide = !branchId && (!branchIds || branchIds.length === 0);
+    // Company-wide FINANCE expenses per month from the journal (51-54). Only an
+    // isolated single branch (branchId) defers; OWNER/all-branches list views
+    // (branchIds) are company-wide. (Deferred branch expenses await SHOP accounting.)
+    const companyWide = !branchId;
     let expenses: { totalAmount: Prisma.Decimal; expenseDate: Date }[] = [];
     if (companyWide) {
       const financeCompanyId = await this.companyResolver.getFinanceCompanyId();

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -462,7 +462,7 @@ export class AccountingService implements OnModuleInit {
 
     const getMonth = (d: Date | string | null) => (d ? new Date(d).getMonth() : -1);
 
-    const [sales, payments, financeRecs, expenses, productSales] = await Promise.all([
+    const [sales, payments, financeRecs, productSales] = await Promise.all([
       this.prisma.sale.findMany({
         where: { createdAt: dateRange, ...branchFilter },
         select: { saleType: true, netAmount: true, downPaymentAmount: true, createdAt: true },
@@ -479,14 +479,43 @@ export class AccountingService implements OnModuleInit {
         where: { status: 'RECEIVED', receivedDate: dateRange, deletedAt: null, ...branchFilter },
         select: { receivedAmount: true, receivedDate: true },
       }),
-      // Legacy `expense` model removed — expense aggregation deferred to ExpenseDocument
-      // module integration in a follow-up PR. Returns empty list so downstream sums stay zero.
-      Promise.resolve([] as { totalAmount: Prisma.Decimal; expenseDate: Date }[]),
       this.prisma.sale.findMany({
         where: { createdAt: dateRange, ...branchFilter },
         select: { createdAt: true, product: { select: { costPrice: true } } },
       }),
     ]);
+
+    // Company-wide FINANCE expenses per month from the journal (51-54). Per-branch
+    // views leave expenses empty (deferred to SHOP accounting; journal has no branchId).
+    const companyWide = !branchId && (!branchIds || branchIds.length === 0);
+    let expenses: { totalAmount: Prisma.Decimal; expenseDate: Date }[] = [];
+    if (companyWide) {
+      const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
+      const start = new Date(year, 0, 1);
+      const end = new Date(year, 11, 31, 23, 59, 59, 999);
+      const expLines = await this.prisma.journalLine.findMany({
+        where: {
+          journalEntry: {
+            status: 'POSTED',
+            entryDate: { gte: start, lte: end },
+            deletedAt: null,
+            companyId: financeCompanyId,
+          },
+          deletedAt: null,
+          OR: [
+            { accountCode: { startsWith: '51-' } },
+            { accountCode: { startsWith: '52-' } },
+            { accountCode: { startsWith: '53-' } },
+            { accountCode: { startsWith: '54-' } },
+          ],
+        },
+        select: { debit: true, credit: true, journalEntry: { select: { entryDate: true } } },
+      });
+      expenses = expLines.map((l) => ({
+        totalAmount: new Prisma.Decimal(l.debit ?? 0).sub(new Prisma.Decimal(l.credit ?? 0)),
+        expenseDate: l.journalEntry.entryDate,
+      }));
+    }
 
     const months = Array.from({ length: 12 }, (_, i) => {
       let revenue = new Prisma.Decimal(0);

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -583,7 +583,13 @@ export class AccountingService implements OnModuleInit {
 
   // ─── W-012: Comparative P&L (MoM / YoY) ──────────────────────────────────────
 
-  async getComparativePL(year: number, month: number, branchId?: string, branchIds?: string[]) {
+  async getComparativePL(
+    year: number,
+    month: number,
+    branchId?: string,
+    branchIds?: string[],
+    includeFinanceExpenses = false,
+  ) {
     // Helper: get last day of month as YYYY-MM-DD string (local time, no UTC shift)
     const lastDayOf = (y: number, m: number) => {
       const d = new Date(y, m, 0); // day 0 of next month = last day of m
@@ -604,9 +610,9 @@ export class AccountingService implements OnModuleInit {
     const endYoY = lastDayOf(year - 1, month);
 
     const [current, prevPeriod, lastYear] = await Promise.all([
-      this.getProfitLossReport(startCurrent, endCurrent, branchId, branchIds),
-      this.getProfitLossReport(startPrev, endPrev, branchId, branchIds),
-      this.getProfitLossReport(startYoY, endYoY, branchId, branchIds),
+      this.getProfitLossReport(startCurrent, endCurrent, branchId, branchIds, includeFinanceExpenses),
+      this.getProfitLossReport(startPrev, endPrev, branchId, branchIds, includeFinanceExpenses),
+      this.getProfitLossReport(startYoY, endYoY, branchId, branchIds, includeFinanceExpenses),
     ]);
 
     const pctChange = (curr: number, prev: number) =>

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -180,7 +180,13 @@ export class AccountingService implements OnModuleInit {
 
   // ─── P&L Calculation ─────────────────────────────────────────────────────────
 
-  async getProfitLossReport(startDate: string, endDate: string, branchId?: string, branchIds?: string[]) {
+  async getProfitLossReport(
+    startDate: string,
+    endDate: string,
+    branchId?: string,
+    branchIds?: string[],
+    includeFinanceExpenses = false,
+  ) {
     const start = new Date(startDate);
     const end = new Date(endDate);
     end.setHours(23, 59, 59, 999);
@@ -239,14 +245,14 @@ export class AccountingService implements OnModuleInit {
       }),
     ]);
 
-    // Company-wide FINANCE expenses from the journal (51-54). Only an isolated
-    // single branch (branchId) defers — its branch-attributable expenses come
-    // from SHOP accounting, not built yet (journal has no branchId). The OWNER /
-    // all-branches list view and monthly-close (which pass `branchIds`) are
-    // company-wide and DO get expenses.
-    const companyWide = !branchId;
+    // FINANCE 51-54 central expenses are added only when the CALLER explicitly asks
+    // (includeFinanceExpenses). The caller — reports.service.shouldIncludeFinanceExpenses
+    // (role + branchId + companyId) or monthly-close (closing company) — has the full
+    // context; inferring it here from branchId alone was wrong (a single-branch filter
+    // arrives as branchIds=[one], and a SHOP-company view would leak FINANCE expenses).
+    // A single isolated branch and a SHOP-company view both pass false (separate work).
     const { byCategory: expensesByCategory, sectionTotals } =
-      await this.aggregateFinanceExpenses(start, end, companyWide);
+      await this.aggregateFinanceExpenses(start, end, includeFinanceExpenses);
 
     const cashSales = new Prisma.Decimal(cashSalesAgg._sum.netAmount ?? 0);
     const installmentDownPayments = new Prisma.Decimal(installmentSales._sum.downPaymentAmount ?? 0);
@@ -450,7 +456,12 @@ export class AccountingService implements OnModuleInit {
     };
   }
 
-  async getMonthlyPLSummary(year: number, branchId?: string, branchIds?: string[]) {
+  async getMonthlyPLSummary(
+    year: number,
+    branchId?: string,
+    branchIds?: string[],
+    includeFinanceExpenses = false,
+  ) {
     const thaiMonths = ['ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.', 'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.'];
     const yearStart = new Date(year, 0, 1);
     const yearEnd = new Date(year, 11, 31, 23, 59, 59, 999);
@@ -487,12 +498,10 @@ export class AccountingService implements OnModuleInit {
       }),
     ]);
 
-    // Company-wide FINANCE expenses per month from the journal (51-54). Only an
-    // isolated single branch (branchId) defers; OWNER/all-branches list views
-    // (branchIds) are company-wide. (Deferred branch expenses await SHOP accounting.)
-    const companyWide = !branchId;
+    // FINANCE 51-54 expenses are added only when the caller explicitly asks
+    // (includeFinanceExpenses) — see reports.service.shouldIncludeFinanceExpenses.
     let expenses: { totalAmount: Prisma.Decimal; expenseDate: Date }[] = [];
-    if (companyWide) {
+    if (includeFinanceExpenses) {
       const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
       const start = new Date(year, 0, 1);
       const end = new Date(year, 11, 31, 23, 59, 59, 999);

--- a/apps/api/src/modules/accounting/accounting.service.ts
+++ b/apps/api/src/modules/accounting/accounting.service.ts
@@ -198,7 +198,6 @@ export class AccountingService implements OnModuleInit {
       externalFinanceSales,
       paidPayments,
       financeReceived,
-      expensesByCategory,
       productCosts,
     ] = await Promise.all([
       this.prisma.sale.aggregate({
@@ -234,14 +233,18 @@ export class AccountingService implements OnModuleInit {
         where: { status: 'RECEIVED', receivedDate: dateRange, ...branchFilter },
         _sum: { receivedAmount: true },
       }),
-      // Legacy `expense` model removed — expense aggregation deferred to ExpenseDocument
-      // module integration in a follow-up PR. Returns empty list so downstream maps stay zero.
-      Promise.resolve([] as { category: string; totalAmount: Prisma.Decimal }[]),
       this.prisma.sale.findMany({
         where: { createdAt: dateRange, deletedAt: null, ...branchFilter },
         select: { product: { select: { costPrice: true } }, bundleProductIds: true },
       }),
     ]);
+
+    // Company-wide FINANCE expenses from the journal (51-54). Per-branch views
+    // leave expenses empty — branch-attributable expenses come from SHOP
+    // accounting, which is not built yet (journal has no branchId).
+    const companyWide = !branchId && (!branchIds || branchIds.length === 0);
+    const { byCategory: expensesByCategory, sectionTotals } =
+      await this.aggregateFinanceExpenses(start, end, companyWide);
 
     const cashSales = new Prisma.Decimal(cashSalesAgg._sum.netAmount ?? 0);
     const installmentDownPayments = new Prisma.Decimal(installmentSales._sum.downPaymentAmount ?? 0);
@@ -336,7 +339,8 @@ export class AccountingService implements OnModuleInit {
     const sellAdvertising = getExp('SELL_ADVERTISING');
     const sellTransport = getExp('SELL_TRANSPORT');
     const sellPackaging = getExp('SELL_PACKAGING');
-    const totalSelling = sellCommission.add(sellAdvertising).add(sellTransport).add(sellPackaging);
+    // Total from the journal section sum (52) — authoritative; granular SELL_* lines above are best-effort display.
+    const totalSelling = sectionTotals.selling;
 
     const sellingExpenses = {
       commission: sellCommission.toNumber(),
@@ -357,9 +361,8 @@ export class AccountingService implements OnModuleInit {
     const adminMaintenance = getExp('ADMIN_MAINTENANCE');
     const adminTravel = getExp('ADMIN_TRAVEL');
     const adminTelephone = getExp('ADMIN_TELEPHONE');
-    const totalAdmin = adminSalary.add(adminSocialSecurity).add(adminRent).add(adminUtilities)
-      .add(adminOfficeSupplies).add(adminDepreciation).add(adminInsurance).add(adminTaxFee)
-      .add(adminMaintenance).add(adminTravel).add(adminTelephone);
+    // Total from the journal section sum (53) — authoritative; granular ADMIN_* lines above are best-effort display.
+    const totalAdmin = sectionTotals.admin;
 
     const adminExpenses = {
       salary: adminSalary.toNumber(),
@@ -383,7 +386,8 @@ export class AccountingService implements OnModuleInit {
     const otherLoss = getExp('OTHER_LOSS');
     const otherFine = getExp('OTHER_FINE');
     const otherMisc = getExp('OTHER_MISC');
-    const totalOther = otherInterest.add(otherLoss).add(otherFine).add(otherMisc);
+    // Total from the journal section sums (51 + 54) — authoritative; granular OTHER_* lines above are best-effort display.
+    const totalOther = sectionTotals.other;
 
     const otherExpenses = {
       interest: otherInterest.toNumber(),
@@ -434,6 +438,7 @@ export class AccountingService implements OnModuleInit {
       operatingProfit: operatingProfit.toNumber(),
       otherExpenses,
       netProfit: netProfitNum,
+      expenseBasis: 'accrual-journal' as const,
       summary: {
         totalRevenue: totalRevenueNum,
         totalExpenses: totalExpenses.toNumber(),

--- a/apps/api/src/modules/accounting/monthly-close.service.spec.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.spec.ts
@@ -28,6 +28,10 @@ const makePrisma = () => {
     payment: {
       count: jest.fn(),
     },
+    companyInfo: {
+      // generateReportSnapshots resolves the closing company's code to gate FINANCE expenses
+      findUnique: jest.fn().mockResolvedValue({ companyCode: 'FINANCE' }),
+    },
     auditLog: {
       create: jest.fn(),
     },

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -603,12 +603,21 @@ export class MonthlyCloseService {
     // Get branch IDs for this company
     const branchIds = await this.accountingService.getBranchIdsForCompany(companyId);
 
+    // FINANCE 51-54 central expenses belong ONLY in the FINANCE company's snapshot.
+    // A SHOP close must NOT embed FINANCE expenses (SHOP P&L is separate work) — that
+    // would contaminate the SHOP snapshot and double-attribute company OpEx.
+    const closingCompany = await this.prisma.companyInfo.findUnique({
+      where: { id: companyId },
+      select: { companyCode: true },
+    });
+    const includeFinanceExpenses = closingCompany?.companyCode === 'FINANCE';
+
     const [trialBalance, profitLoss, balanceSheet, vatSummary] = await Promise.allSettled([
       // P3-SP5 W1: pass explicit 'ALL' scope so the monthly-close snapshot
       // includes BOTH FINANCE and SHOP rows. Without this the SHOP half
       // gets silently dropped because the default scope is 'FINANCE'.
       this.accountingService.getTrialBalance(new Date(asOfDate), 'ALL'),
-      this.accountingService.getProfitLossReport(startDate, asOfDate, undefined, branchIds),
+      this.accountingService.getProfitLossReport(startDate, asOfDate, undefined, branchIds, includeFinanceExpenses),
       this.accountingService.getBalanceSheet(asOfDate, undefined, branchIds),
       this.taxService.previewPP30(companyId, year, month),
     ]);

--- a/apps/api/src/modules/accounting/monthly-close.service.ts
+++ b/apps/api/src/modules/accounting/monthly-close.service.ts
@@ -612,6 +612,14 @@ export class MonthlyCloseService {
     });
     const includeFinanceExpenses = closingCompany?.companyCode === 'FINANCE';
 
+    // ACCOUNTANT NOTE: getProfitLossReport is sales-derived (revenue = cash sales /
+    // down-payments / installment collections). FINANCE has no branches/sales, so a
+    // FINANCE close resolves branchIds=[] → revenue 0, and now (with expenses on) the
+    // FINANCE profitLoss snapshot reads as an expense-only loss. The authoritative
+    // FINANCE P&L (interest income 41/42 + expenses 51-54) is the journal-sourced
+    // getProfitLossFromJournal / the trialBalance(scope 'ALL') already snapshotted
+    // above. A follow-up should switch the FINANCE close P&L snapshot to the journal
+    // source; until then the FINANCE profitLoss field here is expense-only by design.
     const [trialBalance, profitLoss, balanceSheet, vatSummary] = await Promise.allSettled([
       // P3-SP5 W1: pass explicit 'ALL' scope so the monthly-close snapshot
       // includes BOTH FINANCE and SHOP rows. Without this the SHOP half

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -89,17 +89,25 @@ export class ReportsController {
 
   @Get('comparative-pl')
   @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'VIEWER')
-  getComparativePL(
+  async getComparativePL(
     @Query('year') year: string,
     @Query('month') month: string,
     @CurrentUser() user: { role: string; branchId: string | null },
     @Query('branchId') branchId?: string,
   ) {
     const effectiveBranch = user.role === 'BRANCH_MANAGER' ? user.branchId || undefined : branchId;
+    // Same gate as /profit-loss so the dashboard MoM/YoY card reconciles with the P&L page.
+    const includeFinanceExpenses = await this.reportsService.shouldIncludeFinanceExpenses(
+      user.role,
+      effectiveBranch,
+      undefined,
+    );
     return this.reportsService.getComparativePL(
       parseInt(year) || new Date().getFullYear(),
       parseInt(month) || new Date().getMonth() + 1,
       effectiveBranch,
+      undefined,
+      includeFinanceExpenses,
     );
   }
 

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -47,10 +47,16 @@ export class ReportsController {
       return this.reportsService.getMonthlyPLSummary(parseInt(year) || new Date().getFullYear(), effectiveBranch);
     }
     const resolvedBranchIds = await this.reportsService.resolveCompanyBranches(companyId, branchId);
+    const includeFinanceExpenses = await this.reportsService.shouldIncludeFinanceExpenses(
+      user.role,
+      branchId,
+      companyId,
+    );
     return this.reportsService.getMonthlyPLSummary(
       parseInt(year) || new Date().getFullYear(),
       undefined,
       resolvedBranchIds,
+      includeFinanceExpenses,
     );
   }
 
@@ -67,7 +73,18 @@ export class ReportsController {
       return this.reportsService.getProfitLossReport(startDate, endDate, effectiveBranch);
     }
     const resolvedBranchIds = await this.reportsService.resolveCompanyBranches(companyId, branchId);
-    return this.reportsService.getProfitLossReport(startDate, endDate, undefined, resolvedBranchIds);
+    const includeFinanceExpenses = await this.reportsService.shouldIncludeFinanceExpenses(
+      user.role,
+      branchId,
+      companyId,
+    );
+    return this.reportsService.getProfitLossReport(
+      startDate,
+      endDate,
+      undefined,
+      resolvedBranchIds,
+      includeFinanceExpenses,
+    );
   }
 
   @Get('comparative-pl')
@@ -208,17 +225,26 @@ export class ReportsController {
 
   @Get('quarterly')
   @Roles('OWNER', 'FINANCE_MANAGER', 'ACCOUNTANT', 'BRANCH_MANAGER', 'VIEWER')
-  getQuarterly(
+  async getQuarterly(
     @Query('year') year: string,
     @Query('quarter') quarter: string,
     @CurrentUser() user: { role: string; branchId: string | null },
     @Query('branchId') branchId?: string,
   ) {
     const effectiveBranch = user.role === 'BRANCH_MANAGER' ? user.branchId || undefined : branchId;
+    // Same gate as /profit-loss so the two endpoints reconcile for the same filter
+    // (quarterly has no companyId param → whole-business or single-branch only).
+    const includeFinanceExpenses = await this.reportsService.shouldIncludeFinanceExpenses(
+      user.role,
+      effectiveBranch,
+      undefined,
+    );
     return this.reportsService.getQuarterlyReport(
       parseInt(year) || new Date().getFullYear(),
       parseInt(quarter) || 1,
       effectiveBranch,
+      undefined,
+      includeFinanceExpenses,
     );
   }
 

--- a/apps/api/src/modules/reports/reports.service.gating.spec.ts
+++ b/apps/api/src/modules/reports/reports.service.gating.spec.ts
@@ -1,0 +1,47 @@
+import { PrismaService } from '../../prisma/prisma.service';
+import { AccountingService } from '../accounting/accounting.service';
+import { ReportsService } from './reports.service';
+
+// Locks the company/branch gate that decides whether a /reports P&L includes the
+// central FINANCE 51-54 expenses. A wrong gate is what leaked company expenses onto
+// a single branch / SHOP view in the first cut (PR review blockers).
+describe('ReportsService.shouldIncludeFinanceExpenses', () => {
+  function make(companyCode?: 'SHOP' | 'FINANCE') {
+    const findUnique = jest.fn().mockResolvedValue(companyCode ? { companyCode } : null);
+    const prisma = { companyInfo: { findUnique } } as unknown as PrismaService;
+    const svc = new ReportsService(prisma, {} as AccountingService);
+    return { svc, findUnique };
+  }
+
+  it('BRANCH_MANAGER is always excluded (restricted to one branch)', async () => {
+    const { svc, findUnique } = make('FINANCE');
+    expect(await svc.shouldIncludeFinanceExpenses('BRANCH_MANAGER', undefined, 'co-finance')).toBe(false);
+    expect(findUnique).not.toHaveBeenCalled(); // short-circuits before the company lookup
+  });
+
+  it('a specific branchId is isolated → excluded (per-branch expenses await SHOP accounting)', async () => {
+    const { svc } = make('FINANCE');
+    expect(await svc.shouldIncludeFinanceExpenses('OWNER', 'branch-1', undefined)).toBe(false);
+  });
+
+  it('companyId = SHOP → excluded (FINANCE central expenses do not belong on the SHOP view)', async () => {
+    const { svc, findUnique } = make('SHOP');
+    expect(await svc.shouldIncludeFinanceExpenses('OWNER', undefined, 'co-shop')).toBe(false);
+    expect(findUnique).toHaveBeenCalledWith({ where: { id: 'co-shop' }, select: { companyCode: true } });
+  });
+
+  it('companyId = FINANCE → included', async () => {
+    const { svc } = make('FINANCE');
+    expect(await svc.shouldIncludeFinanceExpenses('OWNER', undefined, 'co-finance')).toBe(true);
+  });
+
+  it('no branch + no company (whole-business view) → included', async () => {
+    const { svc } = make();
+    expect(await svc.shouldIncludeFinanceExpenses('OWNER', undefined, undefined)).toBe(true);
+  });
+
+  it('FINANCE_MANAGER + SHOP filter → excluded (role does not override company)', async () => {
+    const { svc } = make('SHOP');
+    expect(await svc.shouldIncludeFinanceExpenses('FINANCE_MANAGER', undefined, 'co-shop')).toBe(false);
+  });
+});

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -192,8 +192,14 @@ export class ReportsService {
     return company?.companyCode === 'FINANCE';
   }
 
-  getComparativePL(year: number, month: number, branchId?: string, branchIds?: string[]) {
-    return this.accounting.getComparativePL(year, month, branchId, branchIds);
+  getComparativePL(
+    year: number,
+    month: number,
+    branchId?: string,
+    branchIds?: string[],
+    includeFinanceExpenses = false,
+  ) {
+    return this.accounting.getComparativePL(year, month, branchId, branchIds, includeFinanceExpenses);
   }
 
   // Balance Sheet & Cash Flow delegated to AccountingService

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -152,12 +152,44 @@ export class ReportsService {
   }
 
   // P&L calculation delegated to AccountingService
-  getProfitLossReport(startDate: string, endDate: string, branchId?: string, branchIds?: string[]) {
-    return this.accounting.getProfitLossReport(startDate, endDate, branchId, branchIds);
+  getProfitLossReport(
+    startDate: string,
+    endDate: string,
+    branchId?: string,
+    branchIds?: string[],
+    includeFinanceExpenses = false,
+  ) {
+    return this.accounting.getProfitLossReport(startDate, endDate, branchId, branchIds, includeFinanceExpenses);
   }
 
-  getMonthlyPLSummary(year: number, branchId?: string, branchIds?: string[]) {
-    return this.accounting.getMonthlyPLSummary(year, branchId, branchIds);
+  getMonthlyPLSummary(
+    year: number,
+    branchId?: string,
+    branchIds?: string[],
+    includeFinanceExpenses = false,
+  ) {
+    return this.accounting.getMonthlyPLSummary(year, branchId, branchIds, includeFinanceExpenses);
+  }
+
+  /**
+   * Whether a /reports P&L view should include the central FINANCE 51-54 expenses.
+   * The caller has the full context the report method lacks. FINANCE expenses are
+   * whole-business central costs — they belong only in a FINANCE or whole-business
+   * P&L, never on an isolated branch or a SHOP-company view (SHOP P&L = separate work).
+   */
+  async shouldIncludeFinanceExpenses(
+    role: string,
+    branchId?: string,
+    companyId?: string,
+  ): Promise<boolean> {
+    if (role === 'BRANCH_MANAGER') return false; // restricted to a single branch
+    if (branchId) return false; // a specific branch is isolated
+    if (!companyId) return true; // whole-business view
+    const company = await this.prisma.companyInfo.findUnique({
+      where: { id: companyId },
+      select: { companyCode: true },
+    });
+    return company?.companyCode === 'FINANCE';
   }
 
   getComparativePL(year: number, month: number, branchId?: string, branchIds?: string[]) {
@@ -885,7 +917,13 @@ export class ReportsService {
    * R-015: Quarterly P&L report aggregation
    * Calculates start/end dates for the given quarter and delegates to AccountingService.
    */
-  async getQuarterlyReport(year: number, quarter: number, branchId?: string, branchIds?: string[]) {
+  async getQuarterlyReport(
+    year: number,
+    quarter: number,
+    branchId?: string,
+    branchIds?: string[],
+    includeFinanceExpenses = false,
+  ) {
     if (quarter < 1 || quarter > 4) {
       throw new BadRequestException('ไตรมาสต้องอยู่ระหว่าง 1-4');
     }
@@ -893,6 +931,6 @@ export class ReportsService {
     const endMonth = startMonth + 2;
     const startDate = `${year}-${String(startMonth).padStart(2, '0')}-01`;
     const endDate = new Date(year, endMonth, 0).toISOString().split('T')[0];
-    return this.accounting.getProfitLossReport(startDate, endDate, branchId, branchIds);
+    return this.accounting.getProfitLossReport(startDate, endDate, branchId, branchIds, includeFinanceExpenses);
   }
 }

--- a/docs/superpowers/plans/2026-06-07-reports-pl-expense-migration.md
+++ b/docs/superpowers/plans/2026-06-07-reports-pl-expense-migration.md
@@ -1,0 +1,530 @@
+# /reports P&L Expense Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the company-wide FINANCE `/reports` P&L so its expense line is sourced from the real journal (accounts 51–54) instead of the `[]` stub, stopping the overstated profit on `/reports` and the monthly-close snapshot.
+
+**Architecture:** Backend-only change in `AccountingService` (`accounting.service.ts`). Add one private helper that aggregates FINANCE journal expense lines for a period into (a) section totals and (b) a curated category breakdown, plus a static account→category map. Wire it into `getProfitLossReport` and `getMonthlyPLSummary`, gated so only **company-wide** views get expenses (per-branch deferred until SHOP accounting exists). Return shape unchanged → no frontend changes.
+
+**Tech Stack:** NestJS 11, Prisma 6 (`journalLine.groupBy`), `Prisma.Decimal`, Jest + ts-jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md`
+**Branch:** `feat/reports-pl-expense-migration` (already checked out)
+
+**Critical constraint:** This changes a regulated financial figure (reported profit on the company-wide `/reports` P&L + the monthly-close snapshot). The plan ends at **open PR — do NOT merge** (merge to `main` auto-deploys to prod via `deploy-gcp.yml`). Accountant must sign off on the numbers shift before merge.
+
+---
+
+## File Structure
+
+- **Modify:** `apps/api/src/modules/accounting/accounting.service.ts`
+  - Add `type ReportExpenseCategory` + `static readonly EXPENSE_ACCOUNT_CATEGORY` map (top of class).
+  - Add `private async aggregateFinanceExpenses(start, end, companyWide)` helper.
+  - Wire `getProfitLossReport` (replace the `[]` stub at line ~142; switch section totals to journal sums; add `expenseBasis`).
+  - Wire `getMonthlyPLSummary` (replace the `[]` stub at line ~382 with per-month journal expenses).
+- **Create (test):** `apps/api/src/modules/accounting/accounting.pl-expense.spec.ts`
+
+Single responsibility: the helper owns "FINANCE journal expense → totals + categories"; the two report methods just consume it. The map is the one accountant-reviewable artifact.
+
+---
+
+## Task 1: Expense-aggregation helper + account→category map
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/accounting.service.ts`
+- Test: `apps/api/src/modules/accounting/accounting.pl-expense.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/modules/accounting/accounting.pl-expense.spec.ts`:
+
+```ts
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { CompanyResolverService } from '../journal/company-resolver.service';
+import { AccountingService } from './accounting.service';
+
+type GroupRow = { accountCode: string; _sum: { debit: Prisma.Decimal | null; credit: Prisma.Decimal | null } };
+
+const d = (n: string | number) => new Prisma.Decimal(n);
+
+function makeService(groupRows: GroupRow[]) {
+  const journalLineGroupBy = jest.fn().mockResolvedValue(groupRows);
+  const prisma = {
+    journalLine: { groupBy: journalLineGroupBy },
+  } as unknown as PrismaService;
+  const companyResolver = {
+    getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1'),
+  } as unknown as CompanyResolverService;
+  const svc = new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+  return { svc, journalLineGroupBy };
+}
+
+// Private helper accessor.
+const aggregate = (
+  svc: AccountingService,
+  companyWide: boolean,
+) =>
+  (svc as unknown as {
+    aggregateFinanceExpenses: (
+      s: Date,
+      e: Date,
+      cw: boolean,
+    ) => Promise<{
+      byCategory: { category: string; totalAmount: Prisma.Decimal }[];
+      sectionTotals: { selling: Prisma.Decimal; admin: Prisma.Decimal; other: Prisma.Decimal };
+    }>;
+  }).aggregateFinanceExpenses(new Date('2026-01-01'), new Date('2026-01-31'), companyWide);
+
+describe('AccountingService.aggregateFinanceExpenses', () => {
+  it('company-wide: section totals + curated category rollups, net = debit - credit', async () => {
+    const { svc } = makeService([
+      { accountCode: '52-1101', _sum: { debit: d('1000'), credit: d('0') } }, // SELL_COMMISSION
+      { accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } }, // ADMIN_SALARY
+      { accountCode: '53-1102', _sum: { debit: d('1500'), credit: d('0') } }, // ADMIN_SOCIAL_SECURITY
+      { accountCode: '53-1601', _sum: { debit: d('2000'), credit: d('500') } }, // ADMIN_DEPRECIATION net 1500
+      { accountCode: '51-1102', _sum: { debit: d('800'), credit: d('0') } }, // OTHER_LOSS
+      { accountCode: '53-9999', _sum: { debit: d('700'), credit: d('0') } }, // unmapped → admin section only
+    ]);
+
+    const r = await aggregate(svc, true);
+
+    // section totals (authoritative)
+    expect(r.sectionTotals.selling.toFixed(2)).toBe('1000.00'); // Σ52
+    expect(r.sectionTotals.admin.toFixed(2)).toBe('33700.00'); // 30000+1500+1500+700
+    expect(r.sectionTotals.other.toFixed(2)).toBe('800.00'); // Σ51
+
+    // curated category rollups (display)
+    const byCat = Object.fromEntries(r.byCategory.map((c) => [c.category, c.totalAmount.toFixed(2)]));
+    expect(byCat['SELL_COMMISSION']).toBe('1000.00');
+    expect(byCat['ADMIN_SALARY']).toBe('30000.00');
+    expect(byCat['ADMIN_SOCIAL_SECURITY']).toBe('1500.00');
+    expect(byCat['ADMIN_DEPRECIATION']).toBe('1500.00'); // 2000 - 500
+    expect(byCat['OTHER_LOSS']).toBe('800.00');
+    expect(byCat['53-9999']).toBeUndefined(); // unmapped: no category line
+  });
+
+  it('per-branch (not company-wide): returns zeros and does NOT query the journal', async () => {
+    const { svc, journalLineGroupBy } = makeService([
+      { accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } },
+    ]);
+
+    const r = await aggregate(svc, false);
+
+    expect(journalLineGroupBy).not.toHaveBeenCalled();
+    expect(r.byCategory).toEqual([]);
+    expect(r.sectionTotals.selling.toFixed(2)).toBe('0.00');
+    expect(r.sectionTotals.admin.toFixed(2)).toBe('0.00');
+    expect(r.sectionTotals.other.toFixed(2)).toBe('0.00');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest src/modules/accounting/accounting.pl-expense.spec.ts --runInBand`
+Expected: FAIL — `aggregateFinanceExpenses is not a function`.
+
+- [ ] **Step 3: Add the type + map + helper**
+
+Add the `type ReportExpenseCategory` **above the `@Injectable()` class** (top of file, with the other imports/types):
+
+```ts
+type ReportExpenseCategory =
+  | 'SELL_COMMISSION' | 'SELL_ADVERTISING'
+  | 'ADMIN_SALARY' | 'ADMIN_SOCIAL_SECURITY' | 'ADMIN_OFFICE_SUPPLIES'
+  | 'ADMIN_UTILITIES' | 'ADMIN_TELEPHONE' | 'ADMIN_TRAVEL' | 'ADMIN_MAINTENANCE'
+  | 'ADMIN_TAX_FEE' | 'ADMIN_DEPRECIATION'
+  | 'OTHER_LOSS' | 'OTHER_FINE' | 'OTHER_MISC';
+```
+
+Inside the class (next to `SECTION_MAP`), add the curated map:
+
+```ts
+  // Account → /reports P&L granular category (display only; totals come from
+  // section sums). Accountant-reviewable: rollups chosen from the FINANCE chart
+  // names (see 2026-06-07 spec). Accounts not listed still count in their
+  // section total but show no granular line.
+  private static readonly EXPENSE_ACCOUNT_CATEGORY: Record<string, ReportExpenseCategory> = {
+    '52-1101': 'SELL_COMMISSION',
+    '52-1102': 'SELL_ADVERTISING', '52-1103': 'SELL_ADVERTISING',
+    '53-1101': 'ADMIN_SALARY', '53-1103': 'ADMIN_SALARY', '53-1104': 'ADMIN_SALARY',
+    '53-1105': 'ADMIN_SALARY', '53-1106': 'ADMIN_SALARY',
+    '53-1102': 'ADMIN_SOCIAL_SECURITY',
+    '53-1201': 'ADMIN_OFFICE_SUPPLIES', '53-1202': 'ADMIN_OFFICE_SUPPLIES', '53-1203': 'ADMIN_OFFICE_SUPPLIES',
+    '53-1301': 'ADMIN_UTILITIES', '53-1302': 'ADMIN_UTILITIES',
+    '53-1303': 'ADMIN_TELEPHONE',
+    '53-1304': 'ADMIN_TRAVEL',
+    '53-1305': 'ADMIN_MAINTENANCE', '53-1306': 'ADMIN_MAINTENANCE',
+    '53-1401': 'ADMIN_TAX_FEE', '53-1402': 'ADMIN_TAX_FEE', '53-1403': 'ADMIN_TAX_FEE',
+    '53-1404': 'ADMIN_TAX_FEE', '53-1501': 'ADMIN_TAX_FEE', '53-1502': 'ADMIN_TAX_FEE',
+    '53-1701': 'ADMIN_TAX_FEE', '53-1702': 'ADMIN_TAX_FEE',
+    '53-1601': 'ADMIN_DEPRECIATION', '53-1602': 'ADMIN_DEPRECIATION',
+    '53-1603': 'ADMIN_DEPRECIATION', '53-1604': 'ADMIN_DEPRECIATION',
+    '51-1102': 'OTHER_LOSS', '51-1103': 'OTHER_LOSS', '53-1605': 'OTHER_LOSS',
+    '51-1104': 'OTHER_FINE', '54-1103': 'OTHER_FINE', '54-1104': 'OTHER_FINE',
+    '51-1101': 'OTHER_MISC', '51-1105': 'OTHER_MISC', '53-1503': 'OTHER_MISC',
+    '54-1101': 'OTHER_MISC', '54-1102': 'OTHER_MISC',
+  };
+```
+
+Add the helper as a private method in the class:
+
+```ts
+  /**
+   * Aggregate POSTED FINANCE journal expense lines (51-54) for a period into
+   * section totals (authoritative) + a curated category breakdown (display).
+   * Only runs for company-wide views — per-branch expense attribution is
+   * deferred until SHOP accounting exists (journal has no branchId).
+   */
+  private async aggregateFinanceExpenses(
+    start: Date,
+    end: Date,
+    companyWide: boolean,
+  ): Promise<{
+    byCategory: { category: string; totalAmount: Prisma.Decimal }[];
+    sectionTotals: { selling: Prisma.Decimal; admin: Prisma.Decimal; other: Prisma.Decimal };
+  }> {
+    const zero = () => new Prisma.Decimal(0);
+    if (!companyWide) {
+      return { byCategory: [], sectionTotals: { selling: zero(), admin: zero(), other: zero() } };
+    }
+
+    const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
+    const lineSums = await this.prisma.journalLine.groupBy({
+      by: ['accountCode'],
+      where: {
+        journalEntry: {
+          status: 'POSTED',
+          entryDate: { gte: start, lte: end },
+          deletedAt: null,
+          companyId: financeCompanyId,
+        },
+        deletedAt: null,
+        OR: [
+          { accountCode: { startsWith: '51-' } },
+          { accountCode: { startsWith: '52-' } },
+          { accountCode: { startsWith: '53-' } },
+          { accountCode: { startsWith: '54-' } },
+        ],
+      },
+      _sum: { debit: true, credit: true },
+    });
+
+    let selling = zero();
+    let admin = zero();
+    let other = zero();
+    const byCategoryMap = new Map<string, Prisma.Decimal>();
+
+    for (const row of lineSums) {
+      const net = new Prisma.Decimal(row._sum.debit ?? 0).sub(new Prisma.Decimal(row._sum.credit ?? 0));
+      const prefix = row.accountCode.slice(0, 2);
+      if (prefix === '52') selling = selling.add(net);
+      else if (prefix === '53') admin = admin.add(net);
+      else if (prefix === '51' || prefix === '54') other = other.add(net);
+
+      const category = AccountingService.EXPENSE_ACCOUNT_CATEGORY[row.accountCode];
+      if (category) {
+        byCategoryMap.set(category, (byCategoryMap.get(category) ?? zero()).add(net));
+      }
+    }
+
+    return {
+      byCategory: [...byCategoryMap.entries()].map(([category, totalAmount]) => ({ category, totalAmount })),
+      sectionTotals: { selling, admin, other },
+    };
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest src/modules/accounting/accounting.pl-expense.spec.ts --runInBand`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/modules/accounting/accounting.service.ts apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+git commit -m "feat(accounting): FINANCE expense aggregation helper + account→category map" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire `getProfitLossReport`
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/accounting.service.ts` (`getProfitLossReport`, lines ~86–347)
+- Test: `apps/api/src/modules/accounting/accounting.pl-expense.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `accounting.pl-expense.spec.ts`. This calls the real `getProfitLossReport` with the heavy revenue queries mocked to empty so we isolate the expense wiring:
+
+```ts
+function makeFullService(groupRows: GroupRow[]) {
+  const agg0 = { _sum: {} as Record<string, Prisma.Decimal | null> };
+  const prisma = {
+    sale: { aggregate: jest.fn().mockResolvedValue(agg0), findMany: jest.fn().mockResolvedValue([]) },
+    payment: { findMany: jest.fn().mockResolvedValue([]) },
+    financeReceivable: { aggregate: jest.fn().mockResolvedValue({ _sum: {} }) },
+    product: { findMany: jest.fn().mockResolvedValue([]) },
+    journalLine: { groupBy: jest.fn().mockResolvedValue(groupRows) },
+  } as unknown as PrismaService;
+  const companyResolver = { getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1') } as unknown as CompanyResolverService;
+  return new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+}
+
+describe('AccountingService.getProfitLossReport (expense wiring)', () => {
+  it('company-wide: section sums drive totals; granular lines populated; basis flagged', async () => {
+    const svc = makeFullService([
+      { accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } },
+      { accountCode: '52-1101', _sum: { debit: d('1000'), credit: d('0') } },
+      { accountCode: '53-9999', _sum: { debit: d('700'), credit: d('0') } }, // unmapped, admin section
+    ]);
+    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31');
+
+    expect(r.adminExpenses.totalAdmin).toBe(30700); // Σ53 (incl. unmapped) — from section sum
+    expect(r.adminExpenses.salary).toBe(30000); // granular line
+    expect(r.sellingExpenses.totalSelling).toBe(1000);
+    expect(r.summary.totalExpenses).toBe(31700); // COGS 0 + 1000 + 30700 + 0
+    expect((r as unknown as { expenseBasis: string }).expenseBasis).toBe('accrual-journal');
+  });
+
+  it('per-branch: expenses stay zero, journal not queried', async () => {
+    const svc = makeFullService([{ accountCode: '53-1101', _sum: { debit: d('30000'), credit: d('0') } }]);
+    const r = await svc.getProfitLossReport('2026-01-01', '2026-01-31', 'branch-1');
+
+    expect(r.adminExpenses.totalAdmin).toBe(0);
+    expect(r.summary.totalExpenses).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest src/modules/accounting/accounting.pl-expense.spec.ts -t "expense wiring" --runInBand`
+Expected: FAIL — `totalAdmin` is 0 (stub) and `expenseBasis` undefined.
+
+- [ ] **Step 3: Implement the wiring**
+
+In `getProfitLossReport`:
+
+**(3a)** Remove the stubbed expense element from the `Promise.all` (the `expensesByCategory` entry, currently lines ~104 in the destructure and ~140–142 the element):
+
+- Remove `expensesByCategory,` from the destructuring array (was line 104).
+- Remove the array element:
+```ts
+      // Legacy `expense` model removed — expense aggregation deferred to ExpenseDocument
+      // module integration in a follow-up PR. Returns empty list so downstream maps stay zero.
+      Promise.resolve([] as { category: string; totalAmount: Prisma.Decimal }[]),
+```
+
+**(3b)** Immediately after the `Promise.all([...])` block closes (after the destructuring `const [...] = await Promise.all([...])`), insert:
+
+```ts
+    const companyWide = !branchId && (!branchIds || branchIds.length === 0);
+    const { byCategory: expensesByCategory, sectionTotals } =
+      await this.aggregateFinanceExpenses(start, end, companyWide);
+```
+
+(`start` and `end` are the `Date` objects already built at the top of the method.)
+
+**(3c)** Replace the three section-total lines so totals come from `sectionTotals` instead of the granular sums:
+
+- Line ~242:
+```ts
+    const totalSelling = sectionTotals.selling;
+```
+- Lines ~263–265:
+```ts
+    const totalAdmin = sectionTotals.admin;
+```
+- Line ~289:
+```ts
+    const totalOther = sectionTotals.other;
+```
+
+(Leave the granular `sellCommission = getExp('SELL_COMMISSION')` etc. lines and the `sellingExpenses`/`adminExpenses`/`otherExpenses` display objects unchanged — they remain best-effort display fed by the curated `expensesByCategory`/`expMap`.)
+
+**(3d)** Add `expenseBasis` to the return object (inside the `return { ... }`, e.g. right after `netProfit: netProfitNum,`):
+
+```ts
+      expenseBasis: 'accrual-journal' as const,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest src/modules/accounting/accounting.pl-expense.spec.ts --runInBand`
+Expected: PASS (all 4 tests).
+
+- [ ] **Step 5: Typecheck the file compiles**
+
+Run: `cd apps/api && npx eslint 'src/modules/accounting/accounting.service.ts'`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/accounting/accounting.service.ts apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+git commit -m "feat(accounting): /reports P&L expenses from journal (company-wide), basis flag" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire `getMonthlyPLSummary`
+
+**Files:**
+- Modify: `apps/api/src/modules/accounting/accounting.service.ts` (`getMonthlyPLSummary`, lines ~349–439)
+- Test: `apps/api/src/modules/accounting/accounting.pl-expense.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the spec:
+
+```ts
+describe('AccountingService.getMonthlyPLSummary (expense wiring)', () => {
+  function makeMonthlyService(lines: { entryDate: Date; debit: Prisma.Decimal; credit: Prisma.Decimal }[]) {
+    const prisma = {
+      sale: { findMany: jest.fn().mockResolvedValue([]) },
+      payment: { findMany: jest.fn().mockResolvedValue([]) },
+      financeReceivable: { findMany: jest.fn().mockResolvedValue([]) },
+      journalLine: {
+        findMany: jest.fn().mockResolvedValue(
+          lines.map((l) => ({ debit: l.debit, credit: l.credit, journalEntry: { entryDate: l.entryDate } })),
+        ),
+      },
+    } as unknown as PrismaService;
+    const companyResolver = { getFinanceCompanyId: jest.fn().mockResolvedValue('finance-co-1') } as unknown as CompanyResolverService;
+    return new AccountingService(prisma, {} as JournalAutoService, companyResolver);
+  }
+
+  it('company-wide: per-month FINANCE expenses subtracted from revenue', async () => {
+    const svc = makeMonthlyService([
+      { entryDate: new Date('2026-02-10'), debit: d('5000'), credit: d('0') }, // Feb
+      { entryDate: new Date('2026-02-20'), debit: d('1000'), credit: d('200') }, // Feb net 800
+    ]);
+    const r = await svc.getMonthlyPLSummary(2026);
+    const feb = r.months.find((m) => m.month === 2)!;
+    expect(feb.expenses).toBe(5800); // 5000 + 800
+    expect(feb.netProfit).toBe(-5800); // revenue 0
+    const jan = r.months.find((m) => m.month === 1)!;
+    expect(jan.expenses).toBe(0);
+  });
+
+  it('per-branch: expenses zero, journal not queried', async () => {
+    const svc = makeMonthlyService([{ entryDate: new Date('2026-02-10'), debit: d('5000'), credit: d('0') }]);
+    const r = await svc.getMonthlyPLSummary(2026, 'branch-1');
+    expect(r.months.every((m) => m.expenses === 0)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest src/modules/accounting/accounting.pl-expense.spec.ts -t "getMonthlyPLSummary" --runInBand`
+Expected: FAIL — Feb `expenses` is 0 (stub).
+
+- [ ] **Step 3: Implement the wiring**
+
+In `getMonthlyPLSummary`:
+
+**(3a)** Remove the stubbed expense element from its `Promise.all` (the `expenses` entry — currently the destructured `expenses` name and the element at lines ~380–382):
+
+- Remove `expenses,` from the destructuring array.
+- Remove the array element:
+```ts
+      // Legacy `expense` model removed — expense aggregation deferred to ExpenseDocument
+      // module integration in a follow-up PR.
+      Promise.resolve([] as { totalAmount: Prisma.Decimal; expenseDate: Date }[]),
+```
+
+**(3b)** After the `Promise.all([...])` block closes, insert:
+
+```ts
+    const companyWide = !branchId && (!branchIds || branchIds.length === 0);
+    let expenses: { totalAmount: Prisma.Decimal; expenseDate: Date }[] = [];
+    if (companyWide) {
+      const financeCompanyId = await this.companyResolver.getFinanceCompanyId();
+      const start = new Date(year, 0, 1);
+      const end = new Date(year, 11, 31, 23, 59, 59, 999);
+      const expLines = await this.prisma.journalLine.findMany({
+        where: {
+          journalEntry: {
+            status: 'POSTED',
+            entryDate: { gte: start, lte: end },
+            deletedAt: null,
+            companyId: financeCompanyId,
+          },
+          deletedAt: null,
+          OR: [
+            { accountCode: { startsWith: '51-' } },
+            { accountCode: { startsWith: '52-' } },
+            { accountCode: { startsWith: '53-' } },
+            { accountCode: { startsWith: '54-' } },
+          ],
+        },
+        select: { debit: true, credit: true, journalEntry: { select: { entryDate: true } } },
+      });
+      expenses = expLines.map((l) => ({
+        totalAmount: new Prisma.Decimal(l.debit ?? 0).sub(new Prisma.Decimal(l.credit ?? 0)),
+        expenseDate: l.journalEntry.entryDate,
+      }));
+    }
+```
+
+The existing month loop (`for (const e of expenses) { if (getMonth(e.expenseDate) !== i) continue; expenseTotal = expenseTotal.add(new Prisma.Decimal(e.totalAmount)); }`) consumes this unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest src/modules/accounting/accounting.pl-expense.spec.ts --runInBand`
+Expected: PASS (all 6 tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `cd apps/api && npx eslint 'src/modules/accounting/accounting.service.ts'`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/accounting/accounting.service.ts apps/api/src/modules/accounting/accounting.pl-expense.spec.ts
+git commit -m "feat(accounting): monthly P&L summary expenses from journal (company-wide)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Regression check + PR (no merge)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the existing accounting suite in isolation (flaky in parallel — see memory)**
+
+Run: `cd apps/api && npx jest src/modules/accounting --runInBand`
+Expected: PASS (existing accounting specs + the new one). If a pre-existing DB-backed spec fails, confirm it fails on `main` too (not caused by this change).
+
+- [ ] **Step 2: Confirm `monthly-close` snapshot path**
+
+Read `apps/api/src/modules/accounting/monthly-close.service.ts` around line 611 — it calls `getProfitLossReport(startDate, asOfDate, undefined, branchIds)`. Verify the `branchIds` it passes is `undefined`/empty for the company-wide close so the snapshot gets the corrected (company-wide) profit. If it passes a specific list, note it in the PR as a follow-up (snapshot would still defer). Do NOT change monthly-close in this PR unless `branchIds` is trivially `undefined` there.
+
+- [ ] **Step 3: Push + open PR (do NOT merge)**
+
+```bash
+git push -u origin feat/reports-pl-expense-migration
+gh pr create --base main --head feat/reports-pl-expense-migration \
+  --title "feat(accounting): /reports P&L expenses from journal (company-wide FINANCE)" \
+  --body "Implements docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md. Company-wide /reports P&L (+ monthly P&L summary + monthly-close snapshot) now source expenses from FINANCE journal 51-54 instead of the [] stub; per-branch views unchanged (deferred to SHOP accounting). Totals from section sums; curated account→category map for display. **Changes reported profit — needs accountant sign-off on the numbers before merge (merge auto-deploys to prod).** 🤖 Generated with Claude Code"
+```
+
+- [ ] **Step 4: STOP — do not merge.** Report to the user that the PR is open and needs accountant sign-off on the profit-figure change before merge/deploy.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** journal-sourced expenses ✓ (Task 1 helper); company-wide branch guard ✓ (Tasks 2/3); section-sum totals ✓ (Task 2 3c); curated map ✓ (Task 1); `expenseBasis` flag ✓ (Task 2 3d); `getMonthlyPLSummary` ✓ (Task 3); monthly-close auto-benefit ✓ (Task 4 verify); per-branch deferred + SHOP/BS/CashFlow/refund out of scope ✓ (not touched). Frontend untouched ✓ (shape preserved).
+- **Placeholders:** none — every step has exact code/commands.
+- **Type consistency:** helper returns `{ byCategory, sectionTotals }` and Task 2 destructures `{ byCategory: expensesByCategory, sectionTotals }`; `ReportExpenseCategory` union matches the map values and the report's `getExp('...')` keys; `expenseBasis: 'accrual-journal'` consistent between Task 2 impl and its test.

--- a/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
+++ b/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
@@ -1,0 +1,109 @@
+# /reports P&L — expense migration to journal-sourced (design)
+
+**Date:** 2026-06-07
+**Status:** approved (brainstorm) → ready for implementation plan
+**Scope:** `apps/api` `AccountingService.getProfitLossReport` + `getMonthlyPLSummary` (the `/reports` P&L family). Backend only — **no frontend changes**.
+
+## Problem
+
+`/reports` shows a **cash-basis** P&L (`getProfitLossReport`) whose expense line is stubbed to `[]`:
+
+```ts
+// Legacy `expense` model removed — expense aggregation deferred to ExpenseDocument
+// module integration in a follow-up PR. Returns empty list so downstream maps stay zero.
+Promise.resolve([] as { category: string; totalAmount: Prisma.Decimal }[]),
+```
+
+So `/reports` (and the **monthly-close snapshot**, which calls this method) **overstate profit** — revenue with no expenses. The "follow-up PR" was never done because the report was built for a **removed `expense` model** with ~20 granular categories, and the new world is `ExpenseDocument → journal (account codes)`.
+
+The **correct accrual P&L already exists** (`getProfitLossFromJournal`, `/accounting`). Per owner decision, `/reports` stays a **distinct management view** (option A) but must source real expenses from the journal we already have — not a new aggregation.
+
+## Goal
+
+Populate the `/reports` P&L expense line from the **FINANCE journal expense accounts (51–54)** for the period, **preserving the exact return shape** (frontend untouched), so `/reports` and the monthly-close snapshot stop overstating profit.
+
+## Design
+
+### Expense source (replaces the `[]` stub)
+
+Aggregate `journalLine` for FINANCE expense accounts in the period:
+
+```
+journalLine.groupBy({ by: ['accountCode'], where: {
+  journalEntry: { entryDate: { gte: start, lte: end }, companyId: <FINANCE>, deletedAt: null },
+  accountCode: startsWith 5,           // 51/52/53/54
+}, _sum: { debit: true, credit: true } })
+```
+
+Per account, **net expense = Σdebit − Σcredit** (VAT → 11-4101, WHT → 21-31xx are *not* 5x accounts, so the journal already gives the net expense — no extra VAT handling needed). This mirrors `getProfitLossFromJournal`'s proven expense logic.
+
+### Totals come from SECTION sums (decision 1-ii)
+
+`totalSelling` / `totalAdmin` / `totalOther` are computed directly from the **2-digit section sums**, NOT from summing the granular sub-lines:
+
+| Report total | Journal section |
+|---|---|
+| `totalSelling` | Σ all `52-xxxx` |
+| `totalAdmin` | Σ all `53-xxxx` |
+| `totalOther` | Σ all `51-xxxx` + `54-xxxx` |
+| `totalCOGS` | unchanged — keeps `productCosts` (sale `costPrice`); FINANCE has no `50` COGS |
+
+This guarantees `totalExpenses` / `netProfit` are **correct regardless of granular mapping gaps**. The granular sub-lines (below) are **best-effort display** — if they don't sum to the section total, the residual is an implicit "unclassified within section" and totals are still right.
+
+### Curated granular map (display; accountant-reviewable)
+
+`accountCode → report category` for the sub-line breakdown. Initial mapping (accountant should confirm rollups):
+
+| Report category | Accounts |
+|---|---|
+| `SELL_COMMISSION` | 52-1101 |
+| `SELL_ADVERTISING` | 52-1102, 52-1103 (SMS) |
+| `SELL_TRANSPORT` | — (none yet; 53-1304 postage is admin) |
+| `SELL_PACKAGING` | — |
+| `ADMIN_SALARY` | 53-1101, 53-1103 (OT), 53-1104 (bonus), 53-1105 (training), 53-1106 (welfare) |
+| `ADMIN_SOCIAL_SECURITY` | 53-1102 |
+| `ADMIN_OFFICE_SUPPLIES` | 53-1201, 53-1202, 53-1203 |
+| `ADMIN_UTILITIES` | 53-1301 (water), 53-1302 (electricity) |
+| `ADMIN_TELEPHONE` | 53-1303 |
+| `ADMIN_TRAVEL` | 53-1304 (postage/transport) |
+| `ADMIN_MAINTENANCE` | 53-1305, 53-1306 |
+| `ADMIN_TAX_FEE` | 53-1501 (bank fee), 53-1502 (govt fee), 53-1401/1402/1403/1404 (professional fees), 53-1701/1702 (debt-collection/lawyer) |
+| `ADMIN_DEPRECIATION` | 53-1601, 53-1602, 53-1603, 53-1604 |
+| `ADMIN_RENT` | — (no rent account in current chart) |
+| `ADMIN_INSURANCE` | — (none) |
+| `OTHER_LOSS` | 51-1102, 51-1103, 53-1605 (asset-disposal loss) |
+| `OTHER_FINE` | 51-1104, 54-1103, 54-1104 |
+| `OTHER_INTEREST` | — (FINANCE earns interest; no interest expense) |
+| `OTHER_MISC` | 51-1101, 51-1105, 53-1503 (rounding), 54-1101, 54-1102 |
+
+The map lives as a single `static readonly EXPENSE_ACCOUNT_CATEGORY: Record<string, ReportCategory>` in `AccountingService` (one artifact; accountant reviews once). Accounts not in the map still count toward their **section total** (so totals stay correct) but don't show a granular line.
+
+### Decisions (flagged, approved)
+
+1. **Totals from section sums** (1-ii) — granular sub-lines are display-only; totals authoritative.
+2. **Branch filter** — FINANCE expenses are central (no branch split). When `branchId`/`branchIds` is passed, **revenue** still filters by branch (cash-basis sales), but **expenses return the full FINANCE total** (real: FINANCE bookkeeping is centralized). Documented on the report.
+3. **Mixed basis** — revenue stays cash-basis, expenses are accrual (journal). `netProfit` is a hybrid management figure — annotate the report response (`basis: 'cash-revenue/accrual-expense'`) and surface a note in the doc. The strict accrual P&L remains on `/accounting`.
+
+### Affected callers (auto-benefit)
+
+- `/reports` P&L endpoints (`reports.controller` → `reports.service` → `getProfitLossReport`).
+- `getMonthlyPLSummary` (dashboard MoM/YoY) — same `[]` stub; same journal-sourcing applied.
+- `monthly-close.service` snapshot — calls `getProfitLossReport`; the snapshot's P&L profit becomes correct automatically.
+
+## Testing
+
+Golden unit test (mock Prisma `journalLine.groupBy`):
+- Seed expense lines across sections (52-1101, 53-1101, 53-1102, 53-1601, 51-1102, 54-1103) → assert: `totalSelling`/`totalAdmin`/`totalOther` = section sums; granular `SELL_COMMISSION`/`ADMIN_SALARY`/`ADMIN_SOCIAL_SECURITY`/`ADMIN_DEPRECIATION`/`OTHER_LOSS`/`OTHER_FINE` rollups; `netProfit = revenue − totalExpenses`.
+- Account not in the map → still counted in its section total, no granular line.
+- Net expense uses `debit − credit` (a credit/reversal reduces the expense).
+
+## Out of scope (explicit — separate follow-ups)
+
+- `getBalanceSheet` / `getCashFlowStatement` accrued-liability / WHT stubs (different stubs; same pattern, later).
+- Unifying cash vs accrual basis / retiring the `/reports` P&L (owner chose to keep it — option A).
+- Refund reversal-JE (#5) — separate.
+- Frontend changes (none needed).
+
+## Risk
+
+Low–moderate. Backend-only, shape-preserving, totals are section-summed (robust to map gaps). The granular map is the only accountant-judgment artifact and is non-load-bearing for totals. Changes reported profit on `/reports` + snapshots (intended — it was overstated); flag to accountant before merge (do NOT auto-deploy to prod without sign-off on the numbers shift).

--- a/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
+++ b/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
@@ -1,12 +1,12 @@
-# /reports P&L — expense migration to journal-sourced (design)
+# /reports P&L — expense migration (journal-sourced, FINANCE company-wide)
 
 **Date:** 2026-06-07
-**Status:** approved (brainstorm) → ready for implementation plan
-**Scope:** `apps/api` `AccountingService.getProfitLossReport` + `getMonthlyPLSummary` (the `/reports` P&L family). Backend only — **no frontend changes**.
+**Status:** approved (brainstorm + /scrutinize rework) → ready for implementation plan
+**Scope:** `apps/api` `AccountingService.getProfitLossReport` + `getMonthlyPLSummary`. Backend only — **no frontend changes**.
 
 ## Problem
 
-`/reports` shows a **cash-basis** P&L (`getProfitLossReport`) whose expense line is stubbed to `[]`:
+`/reports` P&L (`/profit-loss` page) has its expense line stubbed to `[]`:
 
 ```ts
 // Legacy `expense` model removed — expense aggregation deferred to ExpenseDocument
@@ -14,96 +14,107 @@
 Promise.resolve([] as { category: string; totalAmount: Prisma.Decimal }[]),
 ```
 
-So `/reports` (and the **monthly-close snapshot**, which calls this method) **overstate profit** — revenue with no expenses. The "follow-up PR" was never done because the report was built for a **removed `expense` model** with ~20 granular categories, and the new world is `ExpenseDocument → journal (account codes)`.
+So `/reports` (and the **monthly-close snapshot** which calls it — `monthly-close.service.ts:611` stores `snapshot.profitLoss = getProfitLossReport(...)`) **overstate profit**: revenue with no expenses. The "follow-up PR" was never done because the report was built for a **removed `expense` model**.
 
-The **correct accrual P&L already exists** (`getProfitLossFromJournal`, `/accounting`). Per owner decision, `/reports` stays a **distinct management view** (option A) but must source real expenses from the journal we already have — not a new aggregation.
+## /scrutinize findings that shaped this design
+
+The first design (source from journal 51-54 for *all* views) was **reworked** after tracing the real usage:
+
+- **The page is used per-branch + per-company.** `ProfitLossPage.tsx:113-114` sends `branchId` + `companyId`; the page is in the BRANCH_MANAGER menu.
+- **The journal is NOT branch-attributable.** `JournalEntry` has `companyId` but **no `branchId`** — so journal-sourced expenses cannot be split per branch.
+- **`ExpenseLine.category` is free-text** (`category!: string`, no enum) and does NOT match the report's keys (`ADMIN_SALARY`…, which exist only in `accounting.service.ts`). `ExpenseLine` also has no GL account code. So ExpenseLine cannot drive the report's category breakdown either.
+- **Owner constraints:** SHOP-side accounting is **not built yet**; FINANCE is the central entity with **no branches** (all branches are under SHOP).
+
+**Conclusion:** a correct *per-branch* expense breakdown isn't possible today (its source = SHOP, which has no accounting yet). But the **FINANCE company-wide** P&L *can* be fixed now and is meaningful. So:
 
 ## Goal
 
-Populate the `/reports` P&L expense line from the **FINANCE journal expense accounts (51–54)** for the period, **preserving the exact return shape** (frontend untouched), so `/reports` and the monthly-close snapshot stop overstating profit.
+Make the **company-wide** `/reports` P&L show real FINANCE expenses (journal `51-54`) so the whole-business P&L + monthly-close snapshot stop overstating profit. **Per-branch views are explicitly left unchanged** (deferred until SHOP accounting exists).
 
 ## Design
 
-### Expense source (replaces the `[]` stub)
-
-Aggregate `journalLine` for FINANCE expense accounts in the period:
+### Branch guard (the key correctness gate)
 
 ```
-journalLine.groupBy({ by: ['accountCode'], where: {
-  journalEntry: { entryDate: { gte: start, lte: end }, companyId: <FINANCE>, deletedAt: null },
-  accountCode: startsWith 5,           // 51/52/53/54
-}, _sum: { debit: true, credit: true } })
+if (no branchId / branchIds passed)   → company-wide view → ADD FINANCE 51-54 expenses
+else (a specific branch is requested) → per-branch view   → leave expenses [] (deferred to SHOP accounting)
 ```
 
-Per account, **net expense = Σdebit − Σcredit** (VAT → 11-4101, WHT → 21-31xx are *not* 5x accounts, so the journal already gives the net expense — no extra VAT handling needed). This mirrors `getProfitLossFromJournal`'s proven expense logic.
+Rationale: company-wide revenue (all branches' sales) pairs with company-wide FINANCE expenses → coherent whole-business P&L. A per-branch view must NOT get central FINANCE expenses dumped on one branch's revenue.
 
-### Totals come from SECTION sums (decision 1-ii)
+### Expense source (company-wide only)
 
-`totalSelling` / `totalAdmin` / `totalOther` are computed directly from the **2-digit section sums**, NOT from summing the granular sub-lines:
+`journalLine.groupBy(accountCode)` for FINANCE expense accounts in the period:
 
-| Report total | Journal section |
+```
+where: { journalEntry: { entryDate: { gte, lte }, companyId: <FINANCE>, deletedAt: null },
+         accountCode: startsWith '5' }   // 51/52/53/54
+_sum: { debit, credit }
+```
+
+Per account, **net expense = Σdebit − Σcredit** (VAT → 11-4101, WHT → 21-31xx are not 5x accounts, so the journal already nets them out). Mirrors `getProfitLossFromJournal`. We use the **journal (GL codes)**, not ExpenseLine, precisely because the GL code is mappable to the report categories whereas `ExpenseLine.category` is unconstrained free text.
+
+### Totals from SECTION sums (robust to map gaps)
+
+| Report total | Source |
 |---|---|
 | `totalSelling` | Σ all `52-xxxx` |
 | `totalAdmin` | Σ all `53-xxxx` |
 | `totalOther` | Σ all `51-xxxx` + `54-xxxx` |
-| `totalCOGS` | unchanged — keeps `productCosts` (sale `costPrice`); FINANCE has no `50` COGS |
+| `totalCOGS` | unchanged (`productCosts`; FINANCE has no `50` COGS) |
 
-This guarantees `totalExpenses` / `netProfit` are **correct regardless of granular mapping gaps**. The granular sub-lines (below) are **best-effort display** — if they don't sum to the section total, the residual is an implicit "unclassified within section" and totals are still right.
+`totalExpenses` / `netProfit` are correct regardless of the granular map. Granular sub-lines are **best-effort display**.
 
-### Curated granular map (display; accountant-reviewable)
+### Curated GL→category map (display; accountant-reviewable)
 
-`accountCode → report category` for the sub-line breakdown. Initial mapping (accountant should confirm rollups):
+One `static readonly EXPENSE_ACCOUNT_CATEGORY: Record<string, ReportCategory>` in `AccountingService`. Initial mapping (accountant confirms rollups):
 
 | Report category | Accounts |
 |---|---|
 | `SELL_COMMISSION` | 52-1101 |
-| `SELL_ADVERTISING` | 52-1102, 52-1103 (SMS) |
-| `SELL_TRANSPORT` | — (none yet; 53-1304 postage is admin) |
-| `SELL_PACKAGING` | — |
-| `ADMIN_SALARY` | 53-1101, 53-1103 (OT), 53-1104 (bonus), 53-1105 (training), 53-1106 (welfare) |
+| `SELL_ADVERTISING` | 52-1102, 52-1103 |
+| `ADMIN_SALARY` | 53-1101, 53-1103, 53-1104, 53-1105, 53-1106 |
 | `ADMIN_SOCIAL_SECURITY` | 53-1102 |
 | `ADMIN_OFFICE_SUPPLIES` | 53-1201, 53-1202, 53-1203 |
-| `ADMIN_UTILITIES` | 53-1301 (water), 53-1302 (electricity) |
+| `ADMIN_UTILITIES` | 53-1301, 53-1302 |
 | `ADMIN_TELEPHONE` | 53-1303 |
-| `ADMIN_TRAVEL` | 53-1304 (postage/transport) |
+| `ADMIN_TRAVEL` | 53-1304 |
 | `ADMIN_MAINTENANCE` | 53-1305, 53-1306 |
-| `ADMIN_TAX_FEE` | 53-1501 (bank fee), 53-1502 (govt fee), 53-1401/1402/1403/1404 (professional fees), 53-1701/1702 (debt-collection/lawyer) |
+| `ADMIN_TAX_FEE` | 53-1401, 53-1402, 53-1403, 53-1404, 53-1501, 53-1502, 53-1701, 53-1702 |
 | `ADMIN_DEPRECIATION` | 53-1601, 53-1602, 53-1603, 53-1604 |
-| `ADMIN_RENT` | — (no rent account in current chart) |
-| `ADMIN_INSURANCE` | — (none) |
-| `OTHER_LOSS` | 51-1102, 51-1103, 53-1605 (asset-disposal loss) |
+| `OTHER_LOSS` | 51-1102, 51-1103, 53-1605 |
 | `OTHER_FINE` | 51-1104, 54-1103, 54-1104 |
-| `OTHER_INTEREST` | — (FINANCE earns interest; no interest expense) |
-| `OTHER_MISC` | 51-1101, 51-1105, 53-1503 (rounding), 54-1101, 54-1102 |
+| `OTHER_MISC` | 51-1101, 51-1105, 53-1503, 54-1101, 54-1102 |
 
-The map lives as a single `static readonly EXPENSE_ACCOUNT_CATEGORY: Record<string, ReportCategory>` in `AccountingService` (one artifact; accountant reviews once). Accounts not in the map still count toward their **section total** (so totals stay correct) but don't show a granular line.
+Unmapped accounts still count in their section total (totals stay correct), just no granular line. `SELL_TRANSPORT`/`SELL_PACKAGING`/`ADMIN_RENT`/`ADMIN_INSURANCE`/`OTHER_INTEREST` = 0 (no matching account in the current chart).
 
-### Decisions (flagged, approved)
+### Decisions
 
-1. **Totals from section sums** (1-ii) — granular sub-lines are display-only; totals authoritative.
-2. **Branch filter** — FINANCE expenses are central (no branch split). When `branchId`/`branchIds` is passed, **revenue** still filters by branch (cash-basis sales), but **expenses return the full FINANCE total** (real: FINANCE bookkeeping is centralized). Documented on the report.
-3. **Mixed basis** — revenue stays cash-basis, expenses are accrual (journal). `netProfit` is a hybrid management figure — annotate the report response (`basis: 'cash-revenue/accrual-expense'`) and surface a note in the doc. The strict accrual P&L remains on `/accounting`.
+1. **Branch guard** — expenses only on company-wide views; per-branch deferred. *(Resolves the /scrutinize per-branch blocker.)*
+2. **FINANCE-only** — SHOP `S5x` expenses out of scope (SHOP accounting not built).
+3. **Mixed basis** — revenue cash-basis, expense accrual. Annotate the response (`expenseBasis: 'accrual-journal'`) and surface a note; the strict accrual P&L stays on `/accounting`.
 
-### Affected callers (auto-benefit)
+### Affected callers (auto-benefit, company-wide)
 
-- `/reports` P&L endpoints (`reports.controller` → `reports.service` → `getProfitLossReport`).
-- `getMonthlyPLSummary` (dashboard MoM/YoY) — same `[]` stub; same journal-sourcing applied.
-- `monthly-close.service` snapshot — calls `getProfitLossReport`; the snapshot's P&L profit becomes correct automatically.
+- `/reports/profit-loss` company-wide view.
+- `getMonthlyPLSummary` (dashboard MoM/YoY) — same stub, same fix + same branch guard.
+- `monthly-close.service` snapshot — calls `getProfitLossReport(..., branchIds)`; if the snapshot is company-wide its profit becomes correct.
 
 ## Testing
 
-Golden unit test (mock Prisma `journalLine.groupBy`):
-- Seed expense lines across sections (52-1101, 53-1101, 53-1102, 53-1601, 51-1102, 54-1103) → assert: `totalSelling`/`totalAdmin`/`totalOther` = section sums; granular `SELL_COMMISSION`/`ADMIN_SALARY`/`ADMIN_SOCIAL_SECURITY`/`ADMIN_DEPRECIATION`/`OTHER_LOSS`/`OTHER_FINE` rollups; `netProfit = revenue − totalExpenses`.
-- Account not in the map → still counted in its section total, no granular line.
-- Net expense uses `debit − credit` (a credit/reversal reduces the expense).
+Golden unit test (mock `journalLine.groupBy`):
+- **Company-wide (no branch):** seed expense lines across sections → assert `totalSelling`/`totalAdmin`/`totalOther` = section sums; granular rollups for `SELL_COMMISSION`/`ADMIN_SALARY`/`ADMIN_SOCIAL_SECURITY`/`ADMIN_DEPRECIATION`/`OTHER_LOSS`/`OTHER_FINE`; `netProfit = revenue − totalExpenses`.
+- **Per-branch (branchId set):** expenses stay `0`/`[]` (deferred); journal is NOT queried for expenses.
+- Net uses `debit − credit` (a reversal reduces the expense). Unmapped account → counted in section total only.
 
-## Out of scope (explicit — separate follow-ups)
+## Out of scope (explicit follow-ups)
 
-- `getBalanceSheet` / `getCashFlowStatement` accrued-liability / WHT stubs (different stubs; same pattern, later).
-- Unifying cash vs accrual basis / retiring the `/reports` P&L (owner chose to keep it — option A).
-- Refund reversal-JE (#5) — separate.
-- Frontend changes (none needed).
+- **Per-branch expense breakdown** — needs SHOP accounting (branch-attributable `S5x` / ExpenseDocument.branchId source). Deferred.
+- `getBalanceSheet` / `getCashFlowStatement` accrued-liability stubs.
+- Unifying cash vs accrual basis / retiring `/reports` P&L (owner chose option A).
+- Refund reversal-JE (#5).
+- Frontend changes (none).
 
 ## Risk
 
-Low–moderate. Backend-only, shape-preserving, totals are section-summed (robust to map gaps). The granular map is the only accountant-judgment artifact and is non-load-bearing for totals. Changes reported profit on `/reports` + snapshots (intended — it was overstated); flag to accountant before merge (do NOT auto-deploy to prod without sign-off on the numbers shift).
+Low. Backend-only, shape-preserving, company-wide-gated, totals section-summed (robust). Changes reported profit on the **company-wide** `/reports` P&L + snapshot (intended — was overstated). **Flag to accountant before merge; do NOT auto-deploy without sign-off on the numbers shift.** The granular map is the only accountant-judgment artifact and is non-load-bearing for totals.

--- a/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
+++ b/docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md
@@ -31,16 +31,29 @@ The first design (source from journal 51-54 for *all* views) was **reworked** af
 
 Make the **company-wide** `/reports` P&L show real FINANCE expenses (journal `51-54`) so the whole-business P&L + monthly-close snapshot stop overstating profit. **Per-branch views are explicitly left unchanged** (deferred until SHOP accounting exists).
 
+## REWORK (2026-06-07, after PR-review + /scrutinize)
+
+Independent review of the first implementation found the `companyWide = !branchId` guard wrong: the real controller path sends a single-branch filter as `branchIds=[oneBranch]` (branchId undefined), so an isolated branch got full company-wide FINANCE expenses; and `getProfitLossReport` never receives `companyId`, so a `companyId=SHOP` filter ALSO leaked FINANCE expenses, and a SHOP monthly-close snapshot embedded FINANCE 51-54 expenses. /scrutinize confirmed: inferring "company-wide" *inside* the method is fragile and blind to company. **Fix: the caller (which knows role + branchId + companyId) computes an explicit `includeFinanceExpenses` boolean and passes it in.** Owner steer: make the FINANCE side correct now; SHOP P&L expenses are separate future work (FINANCE and SHOP must stay separated).
+
 ## Design
 
-### Branch guard (the key correctness gate)
+### Include-expenses gate (explicit, caller-computed)
+
+`getProfitLossReport` / `getMonthlyPLSummary` take an explicit `includeFinanceExpenses: boolean` (replacing the internal `companyWide = !branchId`). FINANCE 51-54 central expenses are added only when the flag is true; otherwise expenses stay `[]`.
+
+Each caller computes it from full context via `reports.service.shouldIncludeFinanceExpenses(role, branchId, companyId)`:
 
 ```
-if (no branchId / branchIds passed)   → company-wide view → ADD FINANCE 51-54 expenses
-else (a specific branch is requested) → per-branch view   → leave expenses [] (deferred to SHOP accounting)
+BRANCH_MANAGER            → false   (restricted to one branch)
+branchId present          → false   (a single branch is isolated — per-branch expenses await SHOP/branch accounting)
+companyId === SHOP        → false   (SHOP view — FINANCE central expenses don't belong; SHOP P&L is separate future work)
+companyId === FINANCE     → true
+no branch + no company    → true    (whole-business view)
 ```
 
-Rationale: company-wide revenue (all branches' sales) pairs with company-wide FINANCE expenses → coherent whole-business P&L. A per-branch view must NOT get central FINANCE expenses dumped on one branch's revenue.
+`monthly-close` computes it directly from the closing company: FINANCE close → true, SHOP close → false (fixes the SHOP-snapshot contamination).
+
+Rationale: FINANCE 51-54 are central whole-business expenses; they belong only in a FINANCE or whole-business P&L, never grafted onto an isolated branch or a SHOP-company view.
 
 ### Expense source (company-wide only)
 


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-06-07-reports-pl-expense-migration-design.md` (brainstorm → /scrutinize rework → plan → TDD).

## What
The company-wide `/reports` P&L (`getProfitLossReport`), the dashboard monthly summary (`getMonthlyPLSummary`), and the **monthly-close snapshot** now source expenses from the **FINANCE journal (accounts 51–54)** instead of the `[]` stub that made them overstate profit (revenue with no expenses).

- **Expense source:** `journalLine.groupBy` for POSTED FINANCE 51–54 in the period, net = `debit − credit` (mirrors `getProfitLossFromJournal`; VAT/WHT are not 5x accounts so they're already netted out).
- **Totals from section sums** (Σ52 selling, Σ53 admin, Σ51+54 other) → `totalExpenses`/`netProfit` correct regardless of the granular map.
- **Curated `EXPENSE_ACCOUNT_CATEGORY` map** (account → report category) drives the granular display lines — return shape unchanged, **no frontend changes**.
- **Branch guard (`companyWide = !branchId`):** an isolated single-branch view defers expenses (per-branch attribution needs SHOP accounting, not built — journal has no `branchId`); OWNER/all-branches list + monthly-close are company-wide and get expenses.
- Response annotated `expenseBasis: 'accrual-journal'`.

## Tests
New `accounting.pl-expense.spec.ts` — 7 golden tests (section totals, category rollups, debit−credit netting, unmapped-account-in-section-only, company-wide vs single-branch, OWNER branchIds-list, monthly per-month). Full accounting module: **177 tests pass, 0 regression.**

## Out of scope
Per-branch expense breakdown (SHOP accounting), SHOP `S5x`, `getBalanceSheet`/`getCashFlowStatement` stubs, refund #5, frontend.

## ⚠️ DO NOT MERGE YET
This **changes reported profit** on the company-wide `/reports` P&L + the immutable monthly-close snapshot. Merge auto-deploys to prod (`deploy-gcp.yml`). **Needs accountant sign-off on the numbers shift + a review of the account→category rollups** (esp. `ADMIN_TAX_FEE` lumping professional/bank/legal fees) before merge.

🤖 Generated with Claude Code