### PR TITLE
feat(refunds): markReversed posts the ledger reversal JE + reverts the payment

### DIFF
--- a/apps/api/scripts/audit-trial-balance.ts
+++ b/apps/api/scripts/audit-trial-balance.ts
@@ -120,7 +120,9 @@ async function getOrphanPayments() {
       AND p.paid_at IS NOT NULL
       AND NOT EXISTS (
         SELECT 1 FROM journal_entries je
-        WHERE je.reference_type = 'PAYMENT'
+        -- Payment JEs are referenceType 'AUTO' (journal-auto from reference=payment.id),
+        -- NOT 'PAYMENT' — the old value matched nothing → every paid payment looked orphaned.
+        WHERE je.reference_type = 'AUTO'
           AND je.reference_id = p.id
           AND je.deleted_at IS NULL
       )

--- a/apps/api/src/modules/data-audit/data-audit.service.ts
+++ b/apps/api/src/modules/data-audit/data-audit.service.ts
@@ -523,7 +523,9 @@ export class DataAuditService {
         ? await this.prisma.journalEntry.findMany({
             where: {
               referenceId: { in: paymentIds },
-              referenceType: 'PAYMENT',
+              // Payment JEs are stored as referenceType 'AUTO' (journal-auto from
+              // reference=payment.id), NOT 'PAYMENT' — the old value matched nothing.
+              referenceType: 'AUTO',
               deletedAt: null,
               status: 'POSTED',
             },
@@ -1116,7 +1118,8 @@ export class DataAuditService {
         const existing = await this.prisma.journalEntry.findFirst({
           where: {
             referenceId: payment.id,
-            referenceType: 'PAYMENT',
+            // Payment JEs are referenceType 'AUTO' (not 'PAYMENT') — see above.
+            referenceType: 'AUTO',
             deletedAt: null,
             status: 'POSTED',
           },

--- a/apps/api/src/modules/data-audit/data-audit.service.ts
+++ b/apps/api/src/modules/data-audit/data-audit.service.ts
@@ -135,7 +135,7 @@ export class DataAuditService {
         AND NOT EXISTS (
           SELECT 1 FROM journal_entries je
           WHERE je.reference_id = p.id
-            AND je.reference_type = 'PAYMENT'
+            AND je.reference_type = 'AUTO'
             AND je.deleted_at IS NULL
             AND je.status = 'POSTED'
         )
@@ -214,7 +214,7 @@ export class DataAuditService {
       FROM journal_lines jl
       JOIN journal_entries je ON je.id = jl.journal_entry_id
       WHERE jl.account_code = '21-2101'
-        AND je.reference_type = 'PAYMENT'
+        AND je.reference_type = 'AUTO'
         AND je.status = 'POSTED'
         AND je.deleted_at IS NULL
         AND jl.deleted_at IS NULL
@@ -293,7 +293,7 @@ export class DataAuditService {
         p.late_fee, p.vat_amount as payment_vat,
         (SELECT COALESCE(SUM(jl.credit), 0) FROM journal_lines jl
          JOIN journal_entries je ON je.id = jl.journal_entry_id
-         WHERE je.reference_id = p.id::text AND je.reference_type = 'PAYMENT'
+         WHERE je.reference_id = p.id::text AND je.reference_type = 'AUTO'
          AND jl.account_code = '21-2101' AND je.deleted_at IS NULL AND jl.deleted_at IS NULL
          AND je.status = 'POSTED'
         ) as journal_vat
@@ -306,7 +306,7 @@ export class DataAuditService {
         AND ABS(
           COALESCE((SELECT SUM(jl2.credit) FROM journal_lines jl2
            JOIN journal_entries je2 ON je2.id = jl2.journal_entry_id
-           WHERE je2.reference_id = p.id::text AND je2.reference_type = 'PAYMENT'
+           WHERE je2.reference_id = p.id::text AND je2.reference_type = 'AUTO'
            AND jl2.account_code = '21-2101' AND je2.deleted_at IS NULL AND jl2.deleted_at IS NULL
            AND je2.status = 'POSTED'), 0)
           - COALESCE(p.vat_amount, 0)
@@ -414,7 +414,7 @@ export class DataAuditService {
         FROM journal_lines jl
         JOIN journal_entries je ON je.id = jl.journal_entry_id
         WHERE jl.account_code = '42-1105'
-          AND je.reference_type = 'PAYMENT'
+          AND je.reference_type = 'AUTO'
           AND je.status = 'POSTED'
           AND je.deleted_at IS NULL AND jl.deleted_at IS NULL
         GROUP BY je.reference_id

--- a/apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.ts
@@ -30,8 +30,10 @@ export class ReceiptVoidReversalTemplate {
   async voidReceipt(
     originalJournalEntryId: string,
     tx?: Prisma.TransactionClient,
+    opts?: { flow?: string },
   ): Promise<{ entryNo: string }> {
     const client = tx ?? this.prisma;
+    const flow = opts?.flow ?? 'receipt-void';
     // Idempotency check
     const existingReversal = await client.journalEntry.findFirst({
       where: {
@@ -39,7 +41,7 @@ export class ReceiptVoidReversalTemplate {
           {
             metadata: { path: ['originalEntryId'], equals: originalJournalEntryId },
           } as Prisma.JournalEntryWhereInput,
-          { metadata: { path: ['flow'], equals: 'receipt-void' } } as Prisma.JournalEntryWhereInput,
+          { metadata: { path: ['flow'], equals: flow } } as Prisma.JournalEntryWhereInput,
         ],
         deletedAt: null,
       },
@@ -93,7 +95,7 @@ export class ReceiptVoidReversalTemplate {
         reference: `${originalJournalEntryId}:void`,
         metadata: {
           tag: 'REVERSAL',
-          flow: 'receipt-void',
+          flow,
           originalEntryId: originalJournalEntryId,
           originalEntryNumber: originalJe.entryNumber,
         },

--- a/apps/api/src/modules/journal/receipt-void-reversal-flow.spec.ts
+++ b/apps/api/src/modules/journal/receipt-void-reversal-flow.spec.ts
@@ -1,0 +1,52 @@
+// Jest unit test for the `flow` param of ReceiptVoidReversalTemplate.
+// NOTE: lives in journal/ (not cpa-templates/) on purpose — jest ignores
+// /cpa-templates/*.spec.ts (those are vitest DB-integration specs run separately),
+// so a jest-runnable unit test for this logic must sit outside that folder.
+import { Prisma } from '@prisma/client';
+import { JournalAutoService } from './journal-auto.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ReceiptVoidReversalTemplate } from './cpa-templates/receipt-void-reversal.template';
+
+describe('ReceiptVoidReversalTemplate flow param', () => {
+  function setup() {
+    const findFirst = jest.fn().mockResolvedValue(null); // no existing reversal
+    const findUnique = jest.fn().mockResolvedValue({
+      id: 'je-1',
+      entryNumber: 'JE-0001',
+      status: 'POSTED',
+      metadata: {},
+      lines: [
+        { accountCode: '11-1201', debit: new Prisma.Decimal(100), credit: new Prisma.Decimal(0), description: 'x' },
+        { accountCode: '11-2101', debit: new Prisma.Decimal(0), credit: new Prisma.Decimal(100), description: 'y' },
+      ],
+    });
+    const update = jest.fn().mockResolvedValue({});
+    const prisma = {
+      journalEntry: { findFirst, findUnique, update },
+    } as unknown as PrismaService;
+    const createAndPost = jest.fn().mockResolvedValue({ entryNumber: 'JE-0002' });
+    const journal = { createAndPost } as unknown as JournalAutoService;
+    const tpl = new ReceiptVoidReversalTemplate(journal, prisma);
+    return { tpl, findFirst, createAndPost };
+  }
+
+  it('default flow is receipt-void (unchanged)', async () => {
+    const { tpl, findFirst, createAndPost } = setup();
+    await tpl.voidReceipt('je-1');
+    const idemWhere = findFirst.mock.calls[0][0].where.AND;
+    expect(idemWhere).toEqual(
+      expect.arrayContaining([{ metadata: { path: ['flow'], equals: 'receipt-void' } }]),
+    );
+    expect(createAndPost.mock.calls[0][0].metadata.flow).toBe('receipt-void');
+  });
+
+  it('opts.flow overrides both the idempotency lookup and the metadata stamp', async () => {
+    const { tpl, findFirst, createAndPost } = setup();
+    await tpl.voidReceipt('je-1', undefined, { flow: 'refund-reversal' });
+    const idemWhere = findFirst.mock.calls[0][0].where.AND;
+    expect(idemWhere).toEqual(
+      expect.arrayContaining([{ metadata: { path: ['flow'], equals: 'refund-reversal' } }]),
+    );
+    expect(createAndPost.mock.calls[0][0].metadata.flow).toBe('refund-reversal');
+  });
+});

--- a/apps/api/src/modules/receipts/receipts.service.spec.ts
+++ b/apps/api/src/modules/receipts/receipts.service.spec.ts
@@ -112,6 +112,13 @@ describe('ReceiptsService', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const template = (service as any).receiptVoidReversalTemplate;
       expect(template.voidReceipt).toHaveBeenCalledWith('je-1', expect.anything());
+
+      // Pin the prod-path fix: payment JEs are stored referenceType 'AUTO' (not
+      // 'PAYMENT'). Before this, the lookup matched nothing and voidReceipt silently
+      // posted NO reversal — the trial balance kept the voided receipt's 2B entry.
+      expect(tx.journalEntry.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ referenceType: 'AUTO' }) }),
+      );
     });
 
     it('JE reversal failure rolls the entire void back (Wave 1 P0 — atomicity)', async () => {

--- a/apps/api/src/modules/receipts/receipts.service.ts
+++ b/apps/api/src/modules/receipts/receipts.service.ts
@@ -504,10 +504,15 @@ export class ReceiptsService {
       // Phase A.5a: reverse the original payment JE.
       // Must propagate errors — receipt void without ledger reversal would
       // leave HP receivable cleared by 2B but no offsetting credit note JE.
+      // NOTE: payment JEs are stored with referenceType 'AUTO' (journal-auto
+      // createAndPost sets it from `reference = payment.id`), NOT 'PAYMENT'. The
+      // previous 'PAYMENT' filter matched nothing, so voids silently posted no
+      // reversal — the trial balance kept the voided receipt's 2B entry. (Bug found
+      // during the refund-reversal review; same root cause as refunds.markReversed.)
       if (receipt.paymentId) {
         const originalEntry = await tx.journalEntry.findFirst({
           where: {
-            referenceType: 'PAYMENT',
+            referenceType: 'AUTO',
             referenceId: receipt.paymentId,
             status: 'POSTED',
             deletedAt: null,

--- a/apps/api/src/modules/refunds/refunds.module.ts
+++ b/apps/api/src/modules/refunds/refunds.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RefundsController } from './refunds.controller';
 import { RefundsService } from './refunds.service';
+import { JournalModule } from '../journal/journal.module';
 
 @Module({
+  imports: [JournalModule],
   controllers: [RefundsController],
   providers: [RefundsService],
   exports: [RefundsService],

--- a/apps/api/src/modules/refunds/refunds.service.spec.ts
+++ b/apps/api/src/modules/refunds/refunds.service.spec.ts
@@ -1,9 +1,13 @@
+jest.mock('../../utils/period-lock.util', () => ({ validatePeriodOpen: jest.fn() }));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { Prisma } from '@prisma/client';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { RefundsService } from './refunds.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
+import { ReceiptVoidReversalTemplate } from '../journal/cpa-templates/receipt-void-reversal.template';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
 
 describe('RefundsService', () => {
   let service: RefundsService;
@@ -11,6 +15,8 @@ describe('RefundsService', () => {
   let prisma: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let audit: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let template: any;
 
   const paidPayment = (overrides: Record<string, unknown> = {}) => ({
     id: 'pay-1',
@@ -41,7 +47,11 @@ describe('RefundsService', () => {
 
   beforeEach(async () => {
     prisma = {
-      payment: { findUnique: jest.fn().mockResolvedValue(paidPayment()) },
+      payment: {
+        findUnique: jest.fn().mockResolvedValue(paidPayment()),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      journalEntry: { findFirst: jest.fn().mockResolvedValue(null) },
       refund: {
         create: jest.fn((args) => Promise.resolve({ id: 'rf-1', ...args.data })),
         update: jest.fn((args) => Promise.resolve({ ...refundRecord(), ...args.data })),
@@ -50,13 +60,20 @@ describe('RefundsService', () => {
         count: jest.fn().mockResolvedValue(0),
       },
     };
+    // $transaction runs the callback against the same mock (tx === prisma here).
+    prisma.$transaction = jest
+      .fn()
+      .mockImplementation(async (cb: (t: typeof prisma) => unknown) => cb(prisma));
     audit = { log: jest.fn().mockResolvedValue(undefined) };
+    template = { voidReceipt: jest.fn().mockResolvedValue({ entryNo: 'JE-REV-1' }) };
+    (validatePeriodOpen as jest.Mock).mockReset().mockResolvedValue(undefined);
 
     const mod: TestingModule = await Test.createTestingModule({
       providers: [
         RefundsService,
         { provide: PrismaService, useValue: prisma },
         { provide: AuditService, useValue: audit },
+        { provide: ReceiptVoidReversalTemplate, useValue: template },
       ],
     }).compile();
     service = mod.get(RefundsService);
@@ -188,6 +205,42 @@ describe('RefundsService', () => {
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'REFUND_PROCESSED' }),
       );
+    });
+  });
+
+  describe('markReversed — ledger reversal', () => {
+    it('reverses the original payment JE (flow refund-reversal) and reverts the payment to unpaid', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      prisma.journalEntry.findFirst.mockResolvedValue({ id: 'je-1' });
+      await service.markReversed('rf-1', { bankReversalRef: 'KBANK-1', notes: 'rev' }, 'u-owner', 'OWNER');
+
+      expect(prisma.journalEntry.findFirst).toHaveBeenCalledWith({
+        where: { referenceType: 'PAYMENT', referenceId: 'pay-1', status: 'POSTED', deletedAt: null },
+      });
+      expect(template.voidReceipt).toHaveBeenCalledWith('je-1', prisma, { flow: 'refund-reversal' });
+      expect(prisma.payment.update).toHaveBeenCalledWith({
+        where: { id: 'pay-1' },
+        data: { status: 'PENDING', amountPaid: 0, paidDate: null },
+      });
+      const data = prisma.refund.update.mock.calls[0][0].data;
+      expect(data.status).toBe('PROCESSED');
+    });
+
+    it('legacy payment with no POSTED JE: skips the reversal but still reverts the payment', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      prisma.journalEntry.findFirst.mockResolvedValue(null);
+      await service.markReversed('rf-1', { bankReversalRef: 'KBANK-2', notes: 'rev' }, 'u-owner', 'OWNER');
+      expect(template.voidReceipt).not.toHaveBeenCalled();
+      expect(prisma.payment.update).toHaveBeenCalled();
+    });
+
+    it('closed period: throws and reverts nothing', async () => {
+      prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      (validatePeriodOpen as jest.Mock).mockRejectedValue(new Error('period closed'));
+      await expect(
+        service.markReversed('rf-1', { bankReversalRef: 'KBANK-3', notes: 'rev' }, 'u-owner', 'OWNER'),
+      ).rejects.toThrow('period closed');
+      expect(prisma.payment.update).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/refunds/refunds.service.spec.ts
+++ b/apps/api/src/modules/refunds/refunds.service.spec.ts
@@ -82,9 +82,17 @@ describe('RefundsService', () => {
   });
 
   describe('requestRefund', () => {
+    it('rejects a partial refund (amount < amountPaid) — full refunds only', async () => {
+      // paidPayment amountPaid = 1000; a 500 request is partial → rejected up front.
+      await expect(
+        service.requestRefund({ paymentId: 'pay-1', amount: 500, reason: 'partial xxxxxxxx' }, 'u-staff'),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.refund.create).not.toHaveBeenCalled();
+    });
+
     it('creates REQUESTED refund + writes audit', async () => {
       const result = await service.requestRefund(
-        { paymentId: 'pay-1', amount: 500, reason: 'customer double-paid ชำระซ้ำ' },
+        { paymentId: 'pay-1', amount: 1000, reason: 'customer double-paid ชำระซ้ำ' }, // full = amountPaid
         'u-staff',
       );
       expect(result.id).toBe('rf-1');
@@ -241,7 +249,7 @@ describe('RefundsService', () => {
       });
       expect(prisma.receipt.updateMany).toHaveBeenCalledWith({
         where: { paymentId: 'pay-1', isVoided: false, deletedAt: null },
-        data: { isVoided: true },
+        data: expect.objectContaining({ isVoided: true, voidApprovedById: 'u-owner' }),
       });
       const data = prisma.refund.updateMany.mock.calls[0][0].data;
       expect(data.status).toBe('PROCESSED');

--- a/apps/api/src/modules/refunds/refunds.service.spec.ts
+++ b/apps/api/src/modules/refunds/refunds.service.spec.ts
@@ -52,9 +52,11 @@ describe('RefundsService', () => {
         update: jest.fn().mockResolvedValue({}),
       },
       journalEntry: { findFirst: jest.fn().mockResolvedValue(null) },
+      receipt: { updateMany: jest.fn().mockResolvedValue({ count: 0 }) },
       refund: {
         create: jest.fn((args) => Promise.resolve({ id: 'rf-1', ...args.data })),
         update: jest.fn((args) => Promise.resolve({ ...refundRecord(), ...args.data })),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }), // CAS: APPROVED → PROCESSED
         findUnique: jest.fn().mockResolvedValue(refundRecord()),
         findMany: jest.fn().mockResolvedValue([]),
         count: jest.fn().mockResolvedValue(0),
@@ -193,41 +195,61 @@ describe('RefundsService', () => {
 
     it('sets PROCESSED with bank ref + audit', async () => {
       prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      prisma.payment.findUnique.mockResolvedValue({ amountPaid: new Prisma.Decimal(500) }); // = refund.amount (full)
       await service.markReversed(
         'rf-1',
         { bankReversalRef: 'KBANK-12345', notes: 'confirmed phone call' },
         'u-fm',
         'FINANCE_MANAGER',
       );
-      const data = prisma.refund.update.mock.calls[0][0].data;
+      const data = prisma.refund.updateMany.mock.calls[0][0].data;
       expect(data.status).toBe('PROCESSED');
       expect(data.bankReversalRef).toBe('KBANK-12345');
       expect(audit.log).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'REFUND_PROCESSED' }),
       );
     });
+
+    it('rejects a partial refund (amount ≠ amountPaid) — full refunds only', async () => {
+      prisma.refund.findUnique.mockResolvedValue(
+        refundRecord({ status: 'APPROVED', amount: new Prisma.Decimal(500) }),
+      );
+      prisma.payment.findUnique.mockResolvedValue({ amountPaid: new Prisma.Decimal(1000) }); // 500 ≠ 1000
+      await expect(
+        service.markReversed('rf-1', { bankReversalRef: 'KBANK-x', notes: 'partial' }, 'u-owner', 'OWNER'),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.refund.updateMany).not.toHaveBeenCalled();
+    });
   });
 
   describe('markReversed — ledger reversal', () => {
-    it('reverses the original payment JE (flow refund-reversal) and reverts the payment to unpaid', async () => {
+    it('reverses the original payment JE (referenceType AUTO, flow refund-reversal), reverts the payment + voids its receipt', async () => {
       prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
-      prisma.journalEntry.findFirst.mockResolvedValue({ id: 'je-1' });
+      prisma.payment.findUnique.mockResolvedValue({ amountPaid: new Prisma.Decimal(500) }); // = refund.amount
+      prisma.journalEntry.findFirst.mockResolvedValue({ id: 'je-1', companyId: 'co-finance' });
       await service.markReversed('rf-1', { bankReversalRef: 'KBANK-1', notes: 'rev' }, 'u-owner', 'OWNER');
 
+      // Payment JEs are referenceType 'AUTO' (not 'PAYMENT'). Asserting the exact
+      // where-clause is what catches the no-op the review found — do NOT relax this.
       expect(prisma.journalEntry.findFirst).toHaveBeenCalledWith({
-        where: { referenceType: 'PAYMENT', referenceId: 'pay-1', status: 'POSTED', deletedAt: null },
+        where: { referenceType: 'AUTO', referenceId: 'pay-1', status: 'POSTED', deletedAt: null },
       });
       expect(template.voidReceipt).toHaveBeenCalledWith('je-1', prisma, { flow: 'refund-reversal' });
       expect(prisma.payment.update).toHaveBeenCalledWith({
         where: { id: 'pay-1' },
         data: { status: 'PENDING', amountPaid: 0, paidDate: null },
       });
-      const data = prisma.refund.update.mock.calls[0][0].data;
+      expect(prisma.receipt.updateMany).toHaveBeenCalledWith({
+        where: { paymentId: 'pay-1', isVoided: false, deletedAt: null },
+        data: { isVoided: true },
+      });
+      const data = prisma.refund.updateMany.mock.calls[0][0].data;
       expect(data.status).toBe('PROCESSED');
     });
 
     it('legacy payment with no POSTED JE: skips the reversal but still reverts the payment', async () => {
       prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      prisma.payment.findUnique.mockResolvedValue({ amountPaid: new Prisma.Decimal(500) });
       prisma.journalEntry.findFirst.mockResolvedValue(null);
       await service.markReversed('rf-1', { bankReversalRef: 'KBANK-2', notes: 'rev' }, 'u-owner', 'OWNER');
       expect(template.voidReceipt).not.toHaveBeenCalled();
@@ -236,6 +258,7 @@ describe('RefundsService', () => {
 
     it('closed period: throws and reverts nothing', async () => {
       prisma.refund.findUnique.mockResolvedValue(refundRecord({ status: 'APPROVED' }));
+      prisma.payment.findUnique.mockResolvedValue({ amountPaid: new Prisma.Decimal(500) });
       (validatePeriodOpen as jest.Mock).mockRejectedValue(new Error('period closed'));
       await expect(
         service.markReversed('rf-1', { bankReversalRef: 'KBANK-3', notes: 'rev' }, 'u-owner', 'OWNER'),
@@ -252,13 +275,14 @@ describe('RefundsService', () => {
       prisma.refund.findUnique.mockResolvedValue(
         refundRecord({ status: 'APPROVED', bankReversalLockedAt: null, bankReversalRef: null }),
       );
+      prisma.payment.findUnique.mockResolvedValue({ amountPaid: new Prisma.Decimal(500) }); // = refund.amount (full)
       await service.markReversed(
         'rf-1',
         { bankReversalRef: 'SCB-00001', notes: 'first write' },
         'u-owner',
         'OWNER',
       );
-      const data = prisma.refund.update.mock.calls[0][0].data;
+      const data = prisma.refund.updateMany.mock.calls[0][0].data;
       expect(data.bankReversalRef).toBe('SCB-00001');
       expect(data.bankReversalLockedAt).toBeInstanceOf(Date);
     });

--- a/apps/api/src/modules/refunds/refunds.service.ts
+++ b/apps/api/src/modules/refunds/refunds.service.ts
@@ -8,6 +8,8 @@ import {
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
+import { ReceiptVoidReversalTemplate } from '../journal/cpa-templates/receipt-void-reversal.template';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
 import {
   RequestRefundDto,
   MarkRefundReversedDto,
@@ -34,6 +36,7 @@ export class RefundsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly audit: AuditService,
+    private readonly receiptVoidReversalTemplate: ReceiptVoidReversalTemplate,
   ) {}
 
   async requestRefund(dto: RequestRefundDto, userId: string) {
@@ -202,16 +205,54 @@ export class RefundsService {
     }
 
     const now = new Date();
-    const updated = await this.prisma.refund.update({
-      where: { id: refundId },
-      data: {
-        status: 'PROCESSED',
-        bankReversalRef: dto.bankReversalRef,
-        bankReversalAt: now,
-        bankReversalNotes: dto.notes,
-        // T1-C8 — freeze bankReversalRef / bankReversalAt on first write.
-        bankReversalLockedAt: now,
-      },
+    const { updated, reversalEntryNo } = await this.prisma.$transaction(async (tx) => {
+      // The reversal JE posts to the current period — guard it's open (mirror voidReceipt).
+      await validatePeriodOpen(tx, now);
+
+      const updated = await tx.refund.update({
+        where: { id: refundId },
+        data: {
+          status: 'PROCESSED',
+          bankReversalRef: dto.bankReversalRef,
+          bankReversalAt: now,
+          bankReversalNotes: dto.notes,
+          // T1-C8 — freeze bankReversalRef / bankReversalAt on first write.
+          bankReversalLockedAt: now,
+        },
+      });
+
+      // Refund = correcting an erroneous booking → reverse the original payment JE
+      // in full (refunds are always full). Reuses the proven A.5a mirror.
+      let reversalEntryNo: string | null = null;
+      const originalEntry = await tx.journalEntry.findFirst({
+        where: {
+          referenceType: 'PAYMENT',
+          referenceId: refund.paymentId,
+          status: 'POSTED',
+          deletedAt: null,
+        },
+      });
+      if (originalEntry) {
+        const rev = await this.receiptVoidReversalTemplate.voidReceipt(originalEntry.id, tx, {
+          flow: 'refund-reversal',
+        });
+        reversalEntryNo = rev.entryNo;
+      } else {
+        this.logger.warn(
+          `[refund ${refundId}] no POSTED payment JE for payment ${refund.paymentId} — ` +
+            `reverting payment without a reversal JE (legacy)`,
+        );
+      }
+
+      // Restore the installment to its true unpaid state (the booking was wrong).
+      // Planned-schedule fields (monthlyPrincipal/Interest/Commission, amountDue) and
+      // lateFee are left as-is — they describe the plan, not this reverted payment.
+      await tx.payment.update({
+        where: { id: refund.paymentId },
+        data: { status: 'PENDING', amountPaid: 0, paidDate: null },
+      });
+
+      return { updated, reversalEntryNo };
     });
 
     await this.audit.log({
@@ -223,6 +264,7 @@ export class RefundsService {
       newValue: {
         status: 'PROCESSED',
         bankReversalRef: dto.bankReversalRef,
+        reversalEntryNo,
       },
     });
 

--- a/apps/api/src/modules/refunds/refunds.service.ts
+++ b/apps/api/src/modules/refunds/refunds.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   Logger,
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
@@ -204,13 +205,44 @@ export class RefundsService {
       );
     }
 
+    // Full-refund only: the reversal mirrors the WHOLE original payment JE, so the
+    // refund must equal the payment's amountPaid. Partial refunds need a proportional
+    // reversal (not built); owner policy is full refunds only.
+    const payment = await this.prisma.payment.findUnique({
+      where: { id: refund.paymentId },
+      select: { amountPaid: true },
+    });
+    if (!payment) throw new NotFoundException('ไม่พบรายการชำระเงินของคำขอคืนเงิน');
+    if (!new Prisma.Decimal(refund.amount).equals(new Prisma.Decimal(payment.amountPaid))) {
+      throw new BadRequestException(
+        'รองรับเฉพาะการคืนเงินเต็มจำนวนของงวด (ยอดคืน = ยอดที่ชำระ) — ' +
+          'การคืนบางส่วนต้องใช้กลไก proportional ซึ่งยังไม่รองรับ',
+      );
+    }
+
     const now = new Date();
     const { updated, reversalEntryNo } = await this.prisma.$transaction(async (tx) => {
-      // The reversal JE posts to the current period — guard it's open (mirror voidReceipt).
-      await validatePeriodOpen(tx, now);
+      // Find the original POSTED payment-receipt JE. Payment JEs are created via
+      // journal-auto.createAndPost with `reference = payment.id`, which stores
+      // referenceType **'AUTO'** (not 'PAYMENT'). The old 'PAYMENT' filter matched
+      // nothing and silently skipped the reversal — the no-op the review caught.
+      const originalEntry = await tx.journalEntry.findFirst({
+        where: {
+          referenceType: 'AUTO',
+          referenceId: refund.paymentId,
+          status: 'POSTED',
+          deletedAt: null,
+        },
+      });
 
-      const updated = await tx.refund.update({
-        where: { id: refundId },
+      // The reversal posts to the current period of the payment's company — guard it
+      // open (companyId-aware: runs the Tier-1 AccountingPeriod check, not just Tier-2).
+      await validatePeriodOpen(tx, now, originalEntry?.companyId ?? undefined);
+
+      // CAS: only flip APPROVED → PROCESSED if it is *still* APPROVED — closes the
+      // TOCTOU gap between the pre-tx read and this write.
+      const cas = await tx.refund.updateMany({
+        where: { id: refundId, status: 'APPROVED' },
         data: {
           status: 'PROCESSED',
           bankReversalRef: dto.bankReversalRef,
@@ -220,18 +252,13 @@ export class RefundsService {
           bankReversalLockedAt: now,
         },
       });
+      if (cas.count !== 1) {
+        throw new ConflictException('คำขอคืนเงินถูกเปลี่ยนสถานะโดยผู้อื่นแล้ว — กรุณาลองใหม่');
+      }
+      const updated = await tx.refund.findUnique({ where: { id: refundId } });
 
-      // Refund = correcting an erroneous booking → reverse the original payment JE
-      // in full (refunds are always full). Reuses the proven A.5a mirror.
+      // Reverse the original payment JE in full (A.5a mirror).
       let reversalEntryNo: string | null = null;
-      const originalEntry = await tx.journalEntry.findFirst({
-        where: {
-          referenceType: 'PAYMENT',
-          referenceId: refund.paymentId,
-          status: 'POSTED',
-          deletedAt: null,
-        },
-      });
       if (originalEntry) {
         const rev = await this.receiptVoidReversalTemplate.voidReceipt(originalEntry.id, tx, {
           flow: 'refund-reversal',
@@ -244,12 +271,16 @@ export class RefundsService {
         );
       }
 
-      // Restore the installment to its true unpaid state (the booking was wrong).
-      // Planned-schedule fields (monthlyPrincipal/Interest/Commission, amountDue) and
-      // lateFee are left as-is — they describe the plan, not this reverted payment.
+      // Restore the installment to its true unpaid state and void its receipt (the
+      // booking was wrong). Planned-schedule fields (monthlyPrincipal/Interest/
+      // Commission, amountDue) and lateFee describe the plan, not this reverted payment.
       await tx.payment.update({
         where: { id: refund.paymentId },
         data: { status: 'PENDING', amountPaid: 0, paidDate: null },
+      });
+      await tx.receipt.updateMany({
+        where: { paymentId: refund.paymentId, isVoided: false, deletedAt: null },
+        data: { isVoided: true },
       });
 
       return { updated, reversalEntryNo };

--- a/apps/api/src/modules/refunds/refunds.service.ts
+++ b/apps/api/src/modules/refunds/refunds.service.ts
@@ -74,6 +74,14 @@ export class RefundsService {
           `(${remaining.toFixed(2)} บาท)`,
       );
     }
+    // Full refunds only (owner policy): the reversal mirrors the WHOLE payment JE,
+    // so the refund must equal the payment's full amountPaid. Reject partials at
+    // request time (markReversed enforces the same — defense in depth).
+    if (!new Prisma.Decimal(dto.amount).equals(new Prisma.Decimal(payment.amountPaid))) {
+      throw new BadRequestException(
+        'รองรับเฉพาะการคืนเงินเต็มจำนวนของงวด (ยอดคืน = ยอดที่ชำระ) — การคืนบางส่วนยังไม่รองรับ',
+      );
+    }
 
     const refund = await this.prisma.refund.create({
       data: {
@@ -280,7 +288,12 @@ export class RefundsService {
       });
       await tx.receipt.updateMany({
         where: { paymentId: refund.paymentId, isVoided: false, deletedAt: null },
-        data: { isVoided: true },
+        data: {
+          isVoided: true,
+          voidReason: `คืนเงิน (refund ${refundId})`,
+          voidApprovedById: userId,
+          voidApprovedAt: now,
+        },
       });
 
       return { updated, reversalEntryNo };

--- a/docs/superpowers/plans/2026-06-07-refund-reversal-je.md
+++ b/docs/superpowers/plans/2026-06-07-refund-reversal-je.md
@@ -1,0 +1,382 @@
+# Refund Reversal JE — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a refund's bank reversal is confirmed (`RefundsService.markReversed`), atomically post the reversing JE for the original payment (reuse `ReceiptVoidReversalTemplate`) and restore the installment to its true unpaid state.
+
+**Architecture:** `markReversed` becomes a `$transaction`: period guard → flip refund→PROCESSED → reverse the original payment JE via the existing A.5a template → revert `payment` to unpaid → audit. A small backward-compatible `flow` param is added to `ReceiptVoidReversalTemplate` so the refund's reversal is labelled `'refund-reversal'`. Backend only.
+
+**Tech Stack:** NestJS 11, Prisma 6, `Prisma.Decimal`, Jest + ts-jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-refund-reversal-je-design.md`
+**Branch:** `feat/refund-reversal-je` (off main, already checked out)
+
+**Critical constraint:** Changes the ledger (posts a reversal JE + reverts the payment). Plan ends at **open PR — do NOT merge** (merge to `main` auto-deploys to prod). Accountant sign-off required.
+
+---
+
+## File Structure
+
+- **Modify:** `apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.ts` — add optional `opts?: { flow?: string }` (default `'receipt-void'`), used in the idempotency lookup + the metadata stamp.
+- **Modify:** `apps/api/src/modules/refunds/refunds.service.ts` — `markReversed` → `$transaction` with JE reversal + payment revert; inject the template + `Logger`; import `validatePeriodOpen`.
+- **Modify:** `apps/api/src/modules/refunds/refunds.module.ts` — `imports: [JournalModule]`.
+- **Test:** `apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts` (extend or create) — flow param.
+- **Test:** `apps/api/src/modules/refunds/refunds.service.spec.ts` (extend or create) — markReversed.
+
+---
+
+## Task 1: `flow` param on `ReceiptVoidReversalTemplate`
+
+**Files:**
+- Modify: `apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.ts`
+- Test: `apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts`
+
+- [ ] **Step 1: Inspect the existing spec (extend, don't clobber)**
+
+Run: `ls apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts && head -40 apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts`
+If it exists, you'll append a `describe`. If not, create the file with the full content from Step 2.
+
+- [ ] **Step 2: Write the failing test**
+
+Create/append `receipt-void-reversal.template.spec.ts`:
+
+```ts
+import { Prisma } from '@prisma/client';
+import { JournalAutoService } from '../journal-auto.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ReceiptVoidReversalTemplate } from './receipt-void-reversal.template';
+
+describe('ReceiptVoidReversalTemplate flow param', () => {
+  function setup() {
+    const findFirst = jest.fn().mockResolvedValue(null); // no existing reversal
+    const findUnique = jest.fn().mockResolvedValue({
+      id: 'je-1',
+      entryNumber: 'JE-0001',
+      status: 'POSTED',
+      metadata: {},
+      lines: [
+        { accountCode: '11-1201', debit: new Prisma.Decimal(100), credit: new Prisma.Decimal(0), description: 'x' },
+        { accountCode: '11-2101', debit: new Prisma.Decimal(0), credit: new Prisma.Decimal(100), description: 'y' },
+      ],
+    });
+    const update = jest.fn().mockResolvedValue({});
+    const prisma = {
+      journalEntry: { findFirst, findUnique, update },
+    } as unknown as PrismaService;
+    const createAndPost = jest.fn().mockResolvedValue({ entryNumber: 'JE-0002' });
+    const journal = { createAndPost } as unknown as JournalAutoService;
+    const tpl = new ReceiptVoidReversalTemplate(journal, prisma);
+    return { tpl, findFirst, createAndPost };
+  }
+
+  it('default flow is receipt-void (unchanged)', async () => {
+    const { tpl, findFirst, createAndPost } = setup();
+    await tpl.voidReceipt('je-1');
+    // idempotency keyed on default flow
+    const idemWhere = findFirst.mock.calls[0][0].where.AND;
+    expect(idemWhere).toEqual(
+      expect.arrayContaining([{ metadata: { path: ['flow'], equals: 'receipt-void' } }]),
+    );
+    expect(createAndPost.mock.calls[0][0].metadata.flow).toBe('receipt-void');
+  });
+
+  it('opts.flow overrides both the idempotency lookup and the metadata stamp', async () => {
+    const { tpl, findFirst, createAndPost } = setup();
+    await tpl.voidReceipt('je-1', undefined, { flow: 'refund-reversal' });
+    const idemWhere = findFirst.mock.calls[0][0].where.AND;
+    expect(idemWhere).toEqual(
+      expect.arrayContaining([{ metadata: { path: ['flow'], equals: 'refund-reversal' } }]),
+    );
+    expect(createAndPost.mock.calls[0][0].metadata.flow).toBe('refund-reversal');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts -t "flow param" --runInBand`
+Expected: FAIL — the second test gets `'receipt-void'` (param ignored), and/or `voidReceipt` rejects the 3rd arg type.
+
+- [ ] **Step 4: Implement the param**
+
+In `receipt-void-reversal.template.ts`:
+
+(4a) Change the signature:
+```ts
+  async voidReceipt(
+    originalJournalEntryId: string,
+    tx?: Prisma.TransactionClient,
+    opts?: { flow?: string },
+  ): Promise<{ entryNo: string }> {
+    const client = tx ?? this.prisma;
+    const flow = opts?.flow ?? 'receipt-void';
+```
+(The first line of the body — `const client = tx ?? this.prisma;` — already exists; add the `const flow` line right after it.)
+
+(4b) In the idempotency `findFirst`, replace the hardcoded flow:
+```ts
+          { metadata: { path: ['flow'], equals: flow } } as Prisma.JournalEntryWhereInput,
+```
+(4c) In the `createAndPost` metadata, replace `flow: 'receipt-void',` with:
+```ts
+          flow,
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts --runInBand`
+Expected: PASS (both new tests + any pre-existing ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.ts apps/api/src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts
+git commit -m "feat(journal): optional flow param on ReceiptVoidReversalTemplate (default receipt-void)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `markReversed` posts the reversal + reverts the payment
+
+**Files:**
+- Modify: `apps/api/src/modules/refunds/refunds.service.ts`
+- Modify: `apps/api/src/modules/refunds/refunds.module.ts`
+- Test: `apps/api/src/modules/refunds/refunds.service.spec.ts`
+
+- [ ] **Step 1: Inspect the existing service spec (extend, don't clobber)**
+
+Run: `ls apps/api/src/modules/refunds/refunds.service.spec.ts && grep -n "markReversed\|describe(" apps/api/src/modules/refunds/refunds.service.spec.ts`
+If it exists, append the `describe` below and reuse its construction helper if compatible. If not, create the file with the content from Step 2.
+
+- [ ] **Step 2: Write the failing test**
+
+Create/append `refunds.service.spec.ts`. Mock `validatePeriodOpen` at the top:
+
+```ts
+jest.mock('../../utils/period-lock.util', () => ({ validatePeriodOpen: jest.fn() }));
+
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { ReceiptVoidReversalTemplate } from '../journal/cpa-templates/receipt-void-reversal.template';
+import { RefundsService } from './refunds.service';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
+
+const APPROVED_REFUND = {
+  id: 'refund-1',
+  paymentId: 'pay-1',
+  status: 'APPROVED',
+  deletedAt: null,
+  bankReversalLockedAt: null,
+  bankReversalRef: null,
+};
+
+function setup(refund: Record<string, unknown> = APPROVED_REFUND, originalJe: unknown = { id: 'je-1' }) {
+  const tx = {
+    refund: { update: jest.fn().mockResolvedValue({ ...refund, status: 'PROCESSED' }) },
+    journalEntry: { findFirst: jest.fn().mockResolvedValue(originalJe) },
+    payment: { update: jest.fn().mockResolvedValue({}) },
+  };
+  const prisma = {
+    refund: { findUnique: jest.fn().mockResolvedValue(refund) },
+    $transaction: jest.fn().mockImplementation(async (cb: (t: typeof tx) => unknown) => cb(tx)),
+  } as unknown as PrismaService;
+  const audit = { log: jest.fn().mockResolvedValue(undefined) } as unknown as AuditService;
+  const voidReceipt = jest.fn().mockResolvedValue({ entryNo: 'JE-REV-1' });
+  const template = { voidReceipt } as unknown as ReceiptVoidReversalTemplate;
+  const svc = new RefundsService(prisma, audit, template);
+  return { svc, prisma, tx, audit, voidReceipt };
+}
+
+const DTO = { bankReversalRef: 'BANKREF-1', notes: 'reversed' } as never;
+
+describe('RefundsService.markReversed — ledger reversal', () => {
+  beforeEach(() => (validatePeriodOpen as jest.Mock).mockReset().mockResolvedValue(undefined));
+
+  it('reverses the original payment JE (flow refund-reversal) and reverts the payment to unpaid', async () => {
+    const { svc, tx, voidReceipt } = setup();
+    await svc.markReversed('refund-1', DTO, 'user-1', 'OWNER');
+
+    expect(tx.journalEntry.findFirst).toHaveBeenCalledWith({
+      where: { referenceType: 'PAYMENT', referenceId: 'pay-1', status: 'POSTED', deletedAt: null },
+    });
+    expect(voidReceipt).toHaveBeenCalledWith('je-1', tx, { flow: 'refund-reversal' });
+    expect(tx.payment.update).toHaveBeenCalledWith({
+      where: { id: 'pay-1' },
+      data: { status: 'PENDING', amountPaid: 0, paidDate: null },
+    });
+    expect(tx.refund.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'refund-1' }, data: expect.objectContaining({ status: 'PROCESSED' }) }),
+    );
+  });
+
+  it('legacy payment with no POSTED JE: skips the reversal but still reverts the payment', async () => {
+    const { svc, tx, voidReceipt } = setup(APPROVED_REFUND, null);
+    await svc.markReversed('refund-1', DTO, 'user-1', 'OWNER');
+    expect(voidReceipt).not.toHaveBeenCalled();
+    expect(tx.payment.update).toHaveBeenCalled();
+  });
+
+  it('closed period: throws and commits nothing', async () => {
+    const { svc, tx } = setup();
+    (validatePeriodOpen as jest.Mock).mockRejectedValue(new Error('period closed'));
+    await expect(svc.markReversed('refund-1', DTO, 'user-1', 'OWNER')).rejects.toThrow('period closed');
+    expect(tx.payment.update).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/api && npx jest src/modules/refunds/refunds.service.spec.ts -t "ledger reversal" --runInBand`
+Expected: FAIL — `RefundsService` constructor takes 2 args (no template), `markReversed` doesn't call the template / payment.update.
+
+- [ ] **Step 4: Wire DI — module + constructor + imports**
+
+(4a) `refunds.module.ts` — add the JournalModule import. Add at the top with the other imports:
+```ts
+import { JournalModule } from '../journal/journal.module';
+```
+and add an `imports` array to the `@Module({...})` (keep existing `controllers`/`providers`/`exports`):
+```ts
+  imports: [JournalModule],
+```
+
+(4b) `refunds.service.ts` — extend the imports at the top of the file:
+```ts
+import { Logger } from '@nestjs/common';
+import { validatePeriodOpen } from '../../utils/period-lock.util';
+import { ReceiptVoidReversalTemplate } from '../journal/cpa-templates/receipt-void-reversal.template';
+```
+(`Logger` may already be imported from `@nestjs/common` alongside the exceptions — if so, just add `Logger` to that existing import instead of a new line.)
+
+(4c) Add the logger field + inject the template in the constructor:
+```ts
+  private readonly logger = new Logger(RefundsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+    private readonly receiptVoidReversalTemplate: ReceiptVoidReversalTemplate,
+  ) {}
+```
+
+- [ ] **Step 5: Rewrite `markReversed` body (writes inside a `$transaction`)**
+
+Replace the section from `const now = new Date();` through `return updated;` with:
+
+```ts
+    const now = new Date();
+    const { updated, reversalEntryNo } = await this.prisma.$transaction(async (tx) => {
+      // The reversal JE posts to the current period — guard it's open (mirror voidReceipt).
+      await validatePeriodOpen(tx, now);
+
+      const updated = await tx.refund.update({
+        where: { id: refundId },
+        data: {
+          status: 'PROCESSED',
+          bankReversalRef: dto.bankReversalRef,
+          bankReversalAt: now,
+          bankReversalNotes: dto.notes,
+          // T1-C8 — freeze bankReversalRef / bankReversalAt on first write.
+          bankReversalLockedAt: now,
+        },
+      });
+
+      // Refund = correcting an erroneous booking → reverse the original payment JE
+      // in full (refunds are always full). Reuses the proven A.5a mirror.
+      let reversalEntryNo: string | null = null;
+      const originalEntry = await tx.journalEntry.findFirst({
+        where: { referenceType: 'PAYMENT', referenceId: refund.paymentId, status: 'POSTED', deletedAt: null },
+      });
+      if (originalEntry) {
+        const rev = await this.receiptVoidReversalTemplate.voidReceipt(originalEntry.id, tx, { flow: 'refund-reversal' });
+        reversalEntryNo = rev.entryNo;
+      } else {
+        this.logger.warn(
+          `[refund ${refundId}] no POSTED payment JE for payment ${refund.paymentId} — reverting payment without a reversal JE (legacy)`,
+        );
+      }
+
+      // Restore the installment to its true unpaid state (the booking was wrong).
+      // Planned-schedule fields (monthlyPrincipal/Interest/Commission, amountDue) and
+      // lateFee are left as-is — they describe the plan, not this reverted payment.
+      await tx.payment.update({
+        where: { id: refund.paymentId },
+        data: { status: 'PENDING', amountPaid: 0, paidDate: null },
+      });
+
+      return { updated, reversalEntryNo };
+    });
+
+    await this.audit.log({
+      userId,
+      action: 'REFUND_PROCESSED',
+      entity: 'Refund',
+      entityId: refundId,
+      oldValue: { status: 'APPROVED' },
+      newValue: {
+        status: 'PROCESSED',
+        bankReversalRef: dto.bankReversalRef,
+        reversalEntryNo,
+      },
+    });
+
+    return updated;
+```
+
+(The guard block above it — `findUnique`, the APPROVED / role / write-once-lock checks — stays unchanged, before the transaction.)
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/api && npx jest src/modules/refunds/refunds.service.spec.ts --runInBand`
+Expected: PASS (the 3 new tests + any pre-existing markReversed/refund tests).
+
+- [ ] **Step 7: Lint both changed files**
+
+Run: `cd apps/api && npx eslint 'src/modules/refunds/refunds.service.ts' 'src/modules/refunds/refunds.module.ts'`
+Expected: 0 errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/modules/refunds/refunds.service.ts apps/api/src/modules/refunds/refunds.module.ts apps/api/src/modules/refunds/refunds.service.spec.ts
+git commit -m "feat(refunds): markReversed posts reversal JE + reverts payment (error-correction)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Regression + PR (no merge)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the refunds + journal-template suites in isolation**
+
+Run: `cd apps/api && npx jest src/modules/refunds src/modules/journal/cpa-templates/receipt-void-reversal.template.spec.ts --runInBand`
+Expected: PASS. If a pre-existing refund spec asserted the old "no JE / no payment change" behavior, update that assertion to match the new behavior (the spec is now wrong, not the code) and note it in the commit.
+
+- [ ] **Step 2: Confirm receipts.voidReceipt still compiles against the new template signature**
+
+Run: `cd apps/api && npx jest src/modules/receipts --runInBand`
+Expected: PASS — `voidReceipt`'s existing 2-arg call `this.receiptVoidReversalTemplate.voidReceipt(originalEntry.id, tx)` is unaffected (3rd param optional, default `'receipt-void'`).
+
+- [ ] **Step 3: Push + open PR (do NOT merge)**
+
+```bash
+git push -u origin feat/refund-reversal-je
+gh pr create --base main --head feat/refund-reversal-je \
+  --title "feat(refunds): markReversed posts the ledger reversal JE + reverts the payment" \
+  --body "Implements docs/superpowers/specs/2026-06-07-refund-reversal-je-design.md. On a confirmed full bank-reversal refund, markReversed now (in one \$transaction) posts the reversing JE for the original payment (reuses ReceiptVoidReversalTemplate with flow='refund-reversal') and reverts the installment to its true unpaid state (PENDING/0/null). Period-guarded + idempotent. Refund = correcting an erroneous booking, so it deliberately reverts the payment (unlike voidReceipt's credit-note model) and lets normal overdue/dunning re-apply. **Changes the ledger — needs accountant sign-off before merge (merge auto-deploys to prod).** 🤖 Generated with Claude Code"
+```
+
+- [ ] **Step 4: STOP — do not merge.** Report the PR is open and needs accountant sign-off before merge/deploy.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** $transaction ✓ (T2 S5); period guard ✓ (T2 S5 validatePeriodOpen); reverse JE via template ✓ (T2 S5); flow param ✓ (T1); revert payment to PENDING/0/null ✓ (T2 S5); legacy no-JE edge ✓ (T2 S2/S5); DI wiring ✓ (T2 S4); idempotency = template's (unchanged) ✓; audit + reversalEntryNo ✓ (T2 S5). Out of scope (partial refunds, other states, frontend, dunning suppression) — not touched ✓.
+- **Placeholders:** none — exact code/commands throughout.
+- **Type consistency:** template `voidReceipt(id, tx?, opts?:{flow?:string})` matches the call `voidReceipt(originalEntry.id, tx, {flow:'refund-reversal'})`; `reversalEntryNo` typed `string | null` and read from `rev.entryNo`; constructor `(prisma, audit, receiptVoidReversalTemplate)` matches the spec's `new RefundsService(prisma, audit, template)`.

--- a/docs/superpowers/specs/2026-06-07-refund-reversal-je-design.md
+++ b/docs/superpowers/specs/2026-06-07-refund-reversal-je-design.md
@@ -1,0 +1,72 @@
+# Refund reversal JE — `markReversed` posts the ledger reversal (design)
+
+**Date:** 2026-06-07
+**Status:** approved (brainstorm + /scrutinize) → ready for implementation plan
+**Scope:** `apps/api` `RefundsService.markReversed` + `RefundsModule` wiring + a small backward-compatible param on `ReceiptVoidReversalTemplate`. Backend only — no frontend changes.
+
+## Problem
+
+When a refund's bank reversal is confirmed (`refunds.service.markReversed`), the code flips the refund to `PROCESSED` and locks the bank ref, but **posts no journal entry and doesn't touch the payment**. So after the bank reverses the customer's original charge, the ledger still shows the installment as received (HP-receivable cleared, cash/VAT booked) and `payment.status` stays `PAID` — the books disagree with reality.
+
+Unlike `receipts.voidReceipt`, which reverses the original payment JE (Phase A.5a, via `ReceiptVoidReversalTemplate`). The refund module (#541, T1-C1/P2Q7=F) was deliberately built tracking-only.
+
+**Owner intent (clarified):** a refund here represents **correcting an erroneous booking** — the payment was booked wrongly, so the system must fully **revert** it (reverse the JE *and* restore the installment to its true unpaid state).
+
+## /scrutinize findings + resolution
+
+- **"Mirror voidReceipt" was imprecise** — traced `voidReceipt`: it issues a credit note + reverses the JE but **never reverts `payment.status`** (leaves it `PAID`). So reverting the payment is a *new* behavior, not inherited.
+  **Resolution:** the two are different scenarios and SHOULD differ. `voidReceipt` = the *receipt document* was wrong but the payment genuinely happened → payment stays `PAID`. A refund = the *payment booking* was wrong → revert the payment to its true unpaid state. The divergence is deliberate and documented.
+- **Reverting `payment.status → PENDING` re-arms dunning/overdue/MDM-lock** ([dunning-engine.service.ts:306](../../../apps/api/src/modules/overdue/dunning-engine.service.ts) queries `status IN (PENDING,OVERDUE,PARTIALLY_PAID)` on `OVERDUE/DEFAULT` contracts).
+  **Resolution:** for an error-correction, restoring the true unpaid state is *correct* — the installment genuinely wasn't paid, so normal overdue/dunning applies. Intended, not a harm. (Documented so the accountant is aware.)
+
+## Goal
+
+On a confirmed full refund, atomically: post a reversing JE for the original payment, restore the installment to unpaid, and keep the existing refund-state/bank-lock/audit behavior — reusing the proven A.5a reversal mechanism.
+
+## Design
+
+`markReversed` becomes a single `$transaction`. Inside it, after the existing guards (APPROVED status, approver role, write-once bank lock):
+
+1. **Period guard** — `await validatePeriodOpen(tx, new Date())` (the reversal posts to the current period; mirror `voidReceipt` receipts.service.ts:460). Closed period → throw → rollback.
+2. **Flip refund → PROCESSED** + bankReversalRef/At/Notes/LockedAt (unchanged).
+3. **Post the reversing JE** — find the original payment JE:
+   `tx.journalEntry.findFirst({ referenceType:'PAYMENT', referenceId: refund.paymentId, status:'POSTED', deletedAt:null })`.
+   If found → `await this.receiptVoidReversalTemplate.voidReceipt(originalEntry.id, tx, { flow:'refund-reversal' })` (full mirror — refunds are always full, so no proportional/VAT math). If **not found** (legacy payment with no automated JE) → log and continue (still revert the payment + flip the refund).
+4. **Revert the payment to unpaid** —
+   `tx.payment.update({ where:{ id: refund.paymentId }, data:{ status:'PENDING', amountPaid: 0, paidDate: null } })`.
+   The planned-schedule fields (`monthlyPrincipal`/`monthlyInterest`/`monthlyCommission`, `amountDue`) are **left as-is** — they describe the installment plan, not the (now-reverted) payment. `lateFee`/`lateFeeWaived` are left unchanged (the late-fee accrual is independent of this payment's reversal).
+5. **Audit** — existing `REFUND_PROCESSED` log, plus the reversal JE entryNo in `newValue` for traceability.
+
+### Reuse, not new template
+
+No new JE template, no proportional math, no VAT logic — `ReceiptVoidReversalTemplate.voidReceipt` already posts the exact Dr/Cr mirror of `PaymentReceipt2B` and is idempotent.
+
+### Small template change: optional `flow` param
+
+`ReceiptVoidReversalTemplate.voidReceipt(originalJournalEntryId, tx?, opts?)` gains `opts?: { flow?: string }` defaulting to `'receipt-void'`. The value is used in **both** the `metadata.flow` stamp **and** the idempotency lookup, so a refund's reversal is labelled `'refund-reversal'` (correct audit trail) and dedupes against its own flow. `voidReceipt`'s existing call is unchanged (default preserves current behavior).
+
+### Wiring
+
+`RefundsModule` adds `imports: [JournalModule]` (which exports `ReceiptVoidReversalTemplate`, same as `ReceiptsModule`); `RefundsService` injects `private readonly receiptVoidReversalTemplate: ReceiptVoidReversalTemplate`.
+
+## Error handling
+
+Errors propagate → the whole `$transaction` rolls back (a refund without its ledger reversal is the exact inconsistency we're fixing). Period closed → `validatePeriodOpen` throws. Re-running a refund that's already PROCESSED is blocked by the existing `status !== 'APPROVED'` guard; the template's idempotency is a second line of defense.
+
+## Testing (unit, mock prisma + template)
+
+- **Happy path:** APPROVED refund → `markReversed` calls `receiptVoidReversalTemplate.voidReceipt(originalEntryId, tx, {flow:'refund-reversal'})`; payment updated to `{status:'PENDING', amountPaid:0, paidDate:null}`; refund → `PROCESSED`; all inside one `$transaction`.
+- **No original JE (legacy):** template not called; payment still reverted; refund still PROCESSED; a log emitted.
+- **Closed period:** `validatePeriodOpen` throws → nothing committed (refund stays APPROVED).
+- **Template `flow` param:** unit test on `ReceiptVoidReversalTemplate` — passing `{flow:'refund-reversal'}` stamps `metadata.flow='refund-reversal'` and the idempotency check keys on it; default call still uses `'receipt-void'`.
+
+## Out of scope
+
+- **Partial refunds** — refunds are always full (owner-confirmed); proportional/VAT reversal not built.
+- Other refund states (`requestRefund`/approve/reject/markFailed) — only `markReversed` posts the JE.
+- Frontend.
+- Suppressing dunning for reverted installments — intentionally NOT done (the installment is genuinely unpaid again).
+
+## Risk
+
+Low–moderate. Reuses the proven, idempotent A.5a reversal; the only shared-code change is a backward-compatible optional param. **Changes the ledger** (posts a reversal JE + reverts the payment), so **needs accountant sign-off; ends at PR — do NOT auto-merge** (merge auto-deploys to prod).


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-06-07-refund-reversal-je-design.md` (brainstorm → /scrutinize → plan → TDD).

## What
On a confirmed full bank-reversal refund, `RefundsService.markReversed` now — in one `$transaction` — posts the reversing JE for the original payment and restores the installment to its true unpaid state. Previously it only flipped the refund to PROCESSED + locked the bank ref, leaving the ledger showing the installment as received and `payment.status = PAID`.

- **Reverse JE:** finds the original POSTED `PAYMENT` JE and reverses it in full via the proven A.5a `ReceiptVoidReversalTemplate` (refunds are always full — no proportional/VAT math).
- **Revert payment:** `status → PENDING, amountPaid → 0, paidDate → null`. Planned-schedule fields + lateFee are left as-is.
- **Period guard** (`validatePeriodOpen`, current period) + **idempotency** (template-level) + audit logs the reversal entryNo.
- **Legacy edge:** a payment with no POSTED JE skips the reversal but still reverts (logged).
- **Template:** small backward-compatible `flow` param (`opts?.flow`, default `'receipt-void'`) so the refund's reversal is tagged `'refund-reversal'`. `voidReceipt`'s existing 2-arg call is unchanged.

## Why this differs from voidReceipt
`voidReceipt` (receipt correction — payment genuinely happened) issues a credit note and leaves `payment.status = PAID`. A refund here = **correcting an erroneous booking**, so it reverts the payment to unpaid. Normal overdue/dunning correctly re-applies (the installment is genuinely unpaid again) — intended.

## Tests
New flow-param unit spec + 3 new `markReversed` golden tests (reversal call, legacy no-JE, closed-period rollback). refunds + receipts + flow suites: **35 tests pass, 0 regression** (receipts.voidReceipt unaffected).

## Out of scope
Partial refunds (always full), other refund states, frontend, dunning suppression.

## ⚠️ DO NOT MERGE YET
Changes the ledger (posts a reversal JE + reverts the payment). Merge auto-deploys to prod (`deploy-gcp.yml`). **Needs accountant sign-off** on the reversal accounting + the payment-revert policy before merge.

🤖 Generated with Claude Code