### PR TITLE
fix(money): Wave 2 — commission + PO VAT via exact Decimal (money×rate float bug)

### DIFF
--- a/apps/api/src/modules/commission/commission.service.ts
+++ b/apps/api/src/modules/commission/commission.service.ts
@@ -10,6 +10,7 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateCommissionRuleDto, UpdateCommissionRuleDto } from './dto/commission.dto';
 import { GeneratePayoutDto, ApprovePayoutDto } from './dto/commission-payout.dto';
+import { computeCommissionAmount } from '../../utils/commission.util';
 
 @Injectable()
 export class CommissionService {
@@ -43,11 +44,9 @@ export class CommissionService {
   ) {
     const now = new Date();
     const period = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-    // Use Prisma.Decimal to avoid float rounding bugs (e.g. 0.1 * 0.1 !== 0.01).
-    // Result is a Decimal so the database stores exact baht/satang values.
-    const commissionAmount = new Prisma.Decimal(saleAmount)
-      .mul(commissionRate)
-      .toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
+    // Shared exact-Decimal helper (ROUND_HALF_UP) — same as sales.service uses,
+    // so both commission code paths round identically. Avoids float rounding bugs.
+    const commissionAmount = computeCommissionAmount(saleAmount, commissionRate);
 
     // T5-C19: capture rule version for audit + approve-time re-validation.
     let ruleVersionId: string | null = null;

--- a/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.service.ts
@@ -93,18 +93,23 @@ export class PurchaseOrdersService {
     if (!supplier || supplier.deletedAt) throw new NotFoundException('ไม่พบ Supplier');
 
     // Calculate total with discount & VAT (only if supplier has VAT)
-    const totalAmount = dto.items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0);
-    const discount = dto.discount || 0; // ส่วนลดก่อน VAT
-    const discountAfterVat = supplier.hasVat ? dto.discountAfterVat || 0 : 0; // ส่วนลดหลัง VAT (เฉพาะ supplier มี VAT)
-    const subtotalAfterDiscount = totalAmount - discount;
+    // Money math in Prisma.Decimal end-to-end. VAT = subtotal × rate can land on a
+    // half-satang that the old float `Math.round(subtotal * vatRate * 100) / 100`
+    // dropped (same class as commission.util) — books a 1-satang-off VAT on the PO.
+    const totalAmount = dSum(dto.items.map((item) => d(item.quantity).mul(item.unitPrice)));
+    const discount = d(dto.discount || 0); // ส่วนลดก่อน VAT
+    const discountAfterVat = supplier.hasVat ? d(dto.discountAfterVat || 0) : d(0); // ส่วนลดหลัง VAT (เฉพาะ supplier มี VAT)
+    const subtotalAfterDiscount = dSub(totalAmount, discount);
     // D1.1.3.1 — resolve VAT via canonical-key-first helper. Reads VAT_RATE
     // (percent) first, falls back to legacy vat_pct/vat_rate (decimal), or
     // 0.07 if all are absent. Replaces the previous direct `vat_pct` lookup
     // that silently returned the default when admins saved through the new
     // VatTab UI (which writes VAT_RATE).
     const vatRate = await loadVatRateDecimal(this.prisma);
-    const vatAmount = supplier.hasVat ? Math.round(subtotalAfterDiscount * vatRate * 100) / 100 : 0;
-    const netAmount = subtotalAfterDiscount + vatAmount - discountAfterVat;
+    const vatAmount = supplier.hasVat
+      ? subtotalAfterDiscount.mul(vatRate).toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP)
+      : d(0);
+    const netAmount = dSub(dAdd(subtotalAfterDiscount, vatAmount), discountAfterVat);
 
     // Calculate due date from supplier credit terms
     const orderDateObj = new Date(dto.orderDate);

--- a/apps/api/src/modules/sales/sales.service.ts
+++ b/apps/api/src/modules/sales/sales.service.ts
@@ -12,6 +12,7 @@ import {
   generatePaymentSchedule,
   roundBaht,
 } from '../../utils/installment.util';
+import { computeCommissionAmount } from '../../utils/commission.util';
 import { getRateForMonths } from '../../utils/get-rate-for-months.util';
 import { loadInstallmentConfig, resolveInstallmentParams, resolveVatPctForBranch } from '../../utils/config.util';
 import { generateContractNumber, generateSaleNumber } from '../../utils/sequence.util';
@@ -476,7 +477,7 @@ export class SalesService {
           period,
           saleAmount: netAmount,
           commissionRate,
-          commissionAmount: Math.round(netAmount * commissionRate * 100) / 100,
+          commissionAmount: computeCommissionAmount(netAmount, commissionRate),
           status: 'PENDING',
         },
       });
@@ -670,7 +671,7 @@ export class SalesService {
           period,
           saleAmount: netAmount,
           commissionRate,
-          commissionAmount: Math.round(netAmount * commissionRate * 100) / 100,
+          commissionAmount: computeCommissionAmount(netAmount, commissionRate),
           status: 'PENDING',
         },
       });

--- a/apps/api/src/utils/commission.util.spec.ts
+++ b/apps/api/src/utils/commission.util.spec.ts
@@ -1,0 +1,27 @@
+import { Prisma } from '@prisma/client';
+import { computeCommissionAmount } from './commission.util';
+
+describe('computeCommissionAmount', () => {
+  it('exact half-up where float Math.round drops a satang (5.50 × 0.03 = 0.165 → 0.17)', () => {
+    // Current float `Math.round(5.5 * 0.03 * 100) / 100` yields 0.16 — one satang short.
+    expect(computeCommissionAmount(5.5, 0.03).toFixed(2)).toBe('0.17');
+  });
+
+  it('33.50 × 0.03 = 1.005 → 1.01 (float yields 1.00)', () => {
+    expect(computeCommissionAmount(33.5, 0.03).toFixed(2)).toBe('1.01');
+  });
+
+  it('normal case is unchanged (10000 × 0.03 = 300.00)', () => {
+    expect(computeCommissionAmount(10000, 0.03).toFixed(2)).toBe('300.00');
+  });
+
+  it('accepts Prisma.Decimal inputs (rate stored as Decimal)', () => {
+    expect(
+      computeCommissionAmount(new Prisma.Decimal('1675'), new Prisma.Decimal('0.03')).toFixed(2),
+    ).toBe('50.25');
+  });
+
+  it('returns a Prisma.Decimal', () => {
+    expect(computeCommissionAmount(1000, 0.03)).toBeInstanceOf(Prisma.Decimal);
+  });
+});

--- a/apps/api/src/utils/commission.util.ts
+++ b/apps/api/src/utils/commission.util.ts
@@ -1,0 +1,20 @@
+import { Prisma } from '@prisma/client';
+
+type DecimalInput = Prisma.Decimal | number | string;
+
+/**
+ * Sales commission = saleAmount × rate, rounded to 2 decimal places ROUND_HALF_UP.
+ *
+ * Uses Prisma.Decimal end-to-end. The previous `Math.round(saleAmount * rate * 100) / 100`
+ * dropped a satang whenever the exact product landed on a half-satang the float
+ * representation undershot (e.g. 5.50 × 0.03 = 0.165 → float 0.16, correct 0.17),
+ * systematically under/over-paying staff over many sales.
+ */
+export function computeCommissionAmount(
+  saleAmount: DecimalInput,
+  rate: DecimalInput,
+): Prisma.Decimal {
+  return new Prisma.Decimal(saleAmount)
+    .mul(new Prisma.Decimal(rate))
+    .toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
+}


### PR DESCRIPTION
Triaged the Wave 2 "Decimal→float" findings and fixed the **genuinely buggy** ones — the `money × rate → Math.round(float)` pattern that drops a satang when the exact product lands on a half-satang.

## Triage result
- **Benign (left alone):** `finance-tax` VAT/WHT (`sum → Math.round`) — summing 2dp values is always 2dp, never a half-satang, so the final round always recovers the exact value. `peak` `parseFloat` (lossless for 2dp). `intercompany` (subtraction), chatbot/LIFF (display), `credit-check` (ratio not money). `commission.service` already uses Decimal.
- **Genuine bugs fixed:** `money × rate → Math.round(float)` — the product *can* be `x.xx5`, and float undershoots it (e.g. `5.50 × 0.03 = 0.165` floats to `0.16`, correct `0.17`).

## Fixes
1. **`sales.service` commission** (×2 sites: cash + installment) — extracted `computeCommissionAmount()` (`Prisma.Decimal`, ROUND_HALF_UP) + golden tests (incl. the 0.165 and 1.005 cases). Staff commission was systematically mis-paid by a satang on boundary amounts.
2. **`purchase-orders` VAT** — `subtotal × vatRate` now Decimal end-to-end (file already imported the helpers). PO's booked VAT could be 1 satang off.

## Tests
`computeCommissionAmount` golden spec (5 tests) + sales (98) + PO (2) suites green. The PO VAT applies the identical proven Decimal pattern.

## Note for accountant
These are **corrections** (float-off-by-a-satang → exact) — the delta is always toward the mathematically correct value, only at half-satang boundary amounts. Affects newly-computed commission + PO VAT going forward. **Review before merge** (touches money figures; merge auto-deploys).

🤖 Generated with Claude Code