### PR TITLE
test(api): Wave 3 — golden specs for money & regulated paths (+38, no prod changes)

### DIFF
--- a/apps/api/src/modules/assets/asset-invoice-received-template.spec.ts
+++ b/apps/api/src/modules/assets/asset-invoice-received-template.spec.ts
@@ -1,0 +1,205 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { AssetInvoiceReceivedTemplate } from '../journal/cpa-templates/asset-invoice-received.template';
+
+/**
+ * Characterization (golden) UNIT test for AssetInvoiceReceivedTemplate.
+ *
+ * Locks the deferred-input-VAT transfer that fires when the supplier tax
+ * invoice physically arrives for an asset that was POSTed before the invoice:
+ *
+ *   Dr 11-4101  ภาษีซื้อ (เครดิตได้ทันที)        [vatAmount]
+ *     Cr 11-4102 ภาษีซื้อรอเรียกเก็บ             [vatAmount]
+ *
+ * Mock-based — JournalAutoService.createAndPost + PrismaService are plain
+ * jest mocks; no real DB. Money is Prisma.Decimal, asserted via .toFixed(2).
+ *
+ * The existing cpa-templates/asset-invoice-received.template.spec.ts is a
+ * vitest + real-DB integration test that jest IGNORES (testPathIgnorePatterns
+ * matches /cpa-templates/). This file is the jest-visible safety net.
+ */
+describe('AssetInvoiceReceivedTemplate (mock unit)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let journal: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  let template: AssetInvoiceReceivedTemplate;
+
+  // Captured payload that the template handed to createAndPost.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let capturedPostArgs: any;
+  let auditLogArgs: { data: Record<string, unknown> } | undefined;
+
+  const POSTED_ASSET = {
+    id: 'asset-1',
+    assetCode: 'INV-0001',
+    name: 'Notebook with deferred VAT',
+    status: 'POSTED',
+    hasVat: true,
+    vatAccount: '11-4102',
+    // vatAmount comes off the DB row as a Decimal; template re-wraps via
+    // new Decimal(asset.vatAmount.toString()).
+    vatAmount: new Prisma.Decimal('700'),
+    deletedAt: null,
+  };
+
+  beforeEach(() => {
+    capturedPostArgs = undefined;
+    auditLogArgs = undefined;
+
+    journal = {
+      createAndPost: jest.fn().mockImplementation((payload: unknown) => {
+        capturedPostArgs = payload;
+        return Promise.resolve({ id: 'je-uuid-1', entryNumber: 'JE-260601-00001' });
+      }),
+    };
+
+    // tx client used inside $transaction — no existing JE (first run path).
+    const tx = {
+      journalEntry: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      journalPostAuditLog: {
+        create: jest.fn().mockImplementation((args: { data: Record<string, unknown> }) => {
+          auditLogArgs = args;
+          return Promise.resolve({ id: 'audit-1' });
+        }),
+      },
+    };
+
+    prisma = {
+      fixedAsset: {
+        findFirst: jest.fn().mockResolvedValue({ ...POSTED_ASSET }),
+      },
+      // template calls journal.createAndPost with the SAME tx, and createAndPost
+      // is fully mocked, so tx only needs journalEntry + journalPostAuditLog.
+      $transaction: jest.fn().mockImplementation(
+        async (fn: (t: unknown) => Promise<unknown>) => fn(tx),
+      ),
+      // expose for assertions
+      __tx: tx,
+    };
+
+    template = new AssetInvoiceReceivedTemplate(journal, prisma);
+  });
+
+  it('posts exactly two lines: Dr 11-4101 / Cr 11-4102 for the full vatAmount', async () => {
+    const out = await template.execute({ assetId: 'asset-1', triggeredById: 'user-1' });
+
+    // returns the entryNo / id from createAndPost
+    expect(out.entryNo).toBe('JE-260601-00001');
+    expect(out.journalEntryId).toBe('je-uuid-1');
+
+    const lines = capturedPostArgs.lines as Array<{
+      accountCode: string;
+      dr: Prisma.Decimal;
+      cr: Prisma.Decimal;
+    }>;
+    expect(lines).toHaveLength(2);
+
+    const drLine = lines[0];
+    const crLine = lines[1];
+
+    // Dr leg — claimable input tax 11-4101 = full VAT, credit side zero.
+    expect(drLine.accountCode).toBe('11-4101');
+    expect(drLine.dr.toFixed(2)).toBe('700.00');
+    expect(drLine.cr.toFixed(2)).toBe('0.00');
+
+    // Cr leg — clears deferred input VAT 11-4102 = full VAT, debit side zero.
+    expect(crLine.accountCode).toBe('11-4102');
+    expect(crLine.cr.toFixed(2)).toBe('700.00');
+    expect(crLine.dr.toFixed(2)).toBe('0.00');
+  });
+
+  it('produces a balanced JE (total Dr === total Cr === vatAmount)', async () => {
+    await template.execute({ assetId: 'asset-1', triggeredById: 'user-1' });
+
+    const lines = capturedPostArgs.lines as Array<{ dr: Prisma.Decimal; cr: Prisma.Decimal }>;
+    const totalDr = lines.reduce((s, l) => s.plus(l.dr), new Prisma.Decimal(0));
+    const totalCr = lines.reduce((s, l) => s.plus(l.cr), new Prisma.Decimal(0));
+
+    expect(totalDr.toFixed(2)).toBe('700.00');
+    expect(totalCr.toFixed(2)).toBe('700.00');
+    expect(totalDr.equals(totalCr)).toBe(true);
+  });
+
+  it('stamps idempotency metadata (flow + assetId) and vatAmount on the posted JE', async () => {
+    await template.execute({ assetId: 'asset-1', triggeredById: 'user-1' });
+
+    const meta = capturedPostArgs.metadata as Record<string, unknown>;
+    expect(meta.flow).toBe('asset-invoice-received');
+    expect(meta.tag).toBe('ASSET_INVOICE_RECEIVED');
+    expect(meta.assetId).toBe('asset-1');
+    expect(meta.assetCode).toBe('INV-0001');
+    // vatAmount is serialized to 2dp string on the metadata for audit/idempotency.
+    expect(meta.vatAmount).toBe('700.00');
+
+    // reference encodes asset id + flow so it's traceable.
+    expect(capturedPostArgs.reference).toBe('asset-1:asset-invoice-received');
+
+    // audit log is paired with the JE post in the same tx, attributed to the
+    // triggering user.
+    expect(auditLogArgs?.data.journalEntryId).toBe('je-uuid-1');
+    expect(auditLogArgs?.data.postedById).toBe('user-1');
+  });
+
+  it('idempotency short-circuit: when a JE already exists, returns it without re-posting', async () => {
+    // Re-wire the tx so the dedupe lookup finds an existing JE.
+    const existingTx = {
+      journalEntry: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'je-existing',
+          entryNumber: 'JE-260501-00099',
+        }),
+      },
+      journalPostAuditLog: { create: jest.fn() },
+    };
+    prisma.$transaction.mockImplementation(
+      async (fn: (t: unknown) => Promise<unknown>) => fn(existingTx),
+    );
+
+    const out = await template.execute({ assetId: 'asset-1', triggeredById: 'user-1' });
+
+    expect(out.entryNo).toBe('JE-260501-00099');
+    expect(out.journalEntryId).toBe('je-existing');
+    // No new JE posted, no audit log written.
+    expect(journal.createAndPost).not.toHaveBeenCalled();
+    expect(existingTx.journalPostAuditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects assets whose VAT sits in 11-4101 already (nothing to transfer)', async () => {
+    prisma.fixedAsset.findFirst.mockResolvedValue({
+      ...POSTED_ASSET,
+      vatAccount: '11-4101',
+    });
+
+    await expect(
+      template.execute({ assetId: 'asset-1', triggeredById: 'user-1' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(journal.createAndPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a zero-VAT asset (no transfer needed)', async () => {
+    prisma.fixedAsset.findFirst.mockResolvedValue({
+      ...POSTED_ASSET,
+      vatAmount: new Prisma.Decimal('0'),
+    });
+
+    await expect(
+      template.execute({ assetId: 'asset-1', triggeredById: 'user-1' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(journal.createAndPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-POSTED asset and a missing asset', async () => {
+    prisma.fixedAsset.findFirst.mockResolvedValueOnce({ ...POSTED_ASSET, status: 'DRAFT' });
+    await expect(
+      template.execute({ assetId: 'asset-1', triggeredById: 'user-1' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    prisma.fixedAsset.findFirst.mockResolvedValueOnce(null);
+    await expect(
+      template.execute({ assetId: 'missing', triggeredById: 'user-1' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/api/src/modules/contracts/contract-payment.service.early-payoff.spec.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.early-payoff.spec.ts
@@ -1,0 +1,165 @@
+import { Prisma } from '@prisma/client';
+import { ContractPaymentService } from './contract-payment.service';
+
+/**
+ * Characterization (golden) test for ContractPaymentService.getEarlyPayoffQuote —
+ * the EARLY-PAYOFF computation: remaining principal/gross, reversal of the
+ * unearned (deferred) interest, the early-payoff discount, and the final
+ * settlement (payoff) amount.
+ *
+ * A prior bug here was a 100× discount UNIT mismatch: the JE-preview discount
+ * is computed from the fraction form of discountPct (0..1, e.g. 0.5 for 50%),
+ * while the value RETURNED to callers is the percentage form (0..100). This
+ * test pins BOTH the discount unit and the exact computed payoff so the two
+ * paths can never silently drift by a factor of 100 again.
+ *
+ * Pure mock-based unit test — the service is constructed directly with plain
+ * mock deps; no real DB. Only getEarlyPayoffQuote is exercised, so the journal/
+ * product/template collaborators are never actually invoked.
+ *
+ * ── Concrete scenario (self-consistent FINANCE installment contract) ─────────
+ *   totalMonths      = 12
+ *   sellingPrice     = 20000, downPayment = 2000  → true principal = 18000
+ *   financedAmount   = 18000 (ยอดจัด base for JE gross)
+ *   storeCommission  = 1800  (= 18000 × 10%)
+ *   interestTotal    = 1800  (flat)
+ *   vatAmount        = 1512  (= (18000+1800+1800) × 7%)
+ *   monthlyPayment   = 1926  (= (21600 grossExclVat + 1512 vat) / 12, incl VAT)
+ *   creditBalance    = 0, vatPct = 0.07
+ *   6 installments PAID → 6 remaining
+ *   discountPct      = default (50% → fraction 0.5)
+ */
+describe('ContractPaymentService.getEarlyPayoffQuote (early-payoff golden)', () => {
+  const dec = (v: string | number) => new Prisma.Decimal(v);
+
+  // ── Contract fixture (mirrors findOne includes; only fields the math reads) ──
+  const contract = {
+    id: 'contract-ep-1',
+    status: 'ACTIVE',
+    deletedAt: null,
+    totalMonths: 12,
+    monthlyPayment: dec('1926.00'),
+    creditBalance: dec('0'),
+    vatPct: dec('0.07'),
+    sellingPrice: dec('20000'),
+    downPayment: dec('2000'),
+    storeCommission: dec('1800'),
+    financedAmount: dec('18000'),
+    interestTotal: dec('1800'),
+    vatAmount: dec('1512.00'),
+    // 6 PAID + 6 unpaid payment rows. Only status/installmentNo/amountPaid/
+    // lateFee/lateFeeWaived are read by the quote.
+    payments: [
+      ...Array.from({ length: 6 }, (_, i) => ({
+        installmentNo: i + 1,
+        status: 'PAID',
+        amountPaid: dec('1926.00'),
+        amountDue: dec('1926.00'),
+        lateFee: dec('0'),
+        lateFeeWaived: false,
+      })),
+      ...Array.from({ length: 6 }, (_, i) => ({
+        installmentNo: i + 7,
+        status: 'PENDING',
+        amountPaid: dec('0'),
+        amountDue: dec('1926.00'),
+        lateFee: dec('0'),
+        lateFeeWaived: false,
+      })),
+    ],
+  };
+
+  // installmentSchedule rows: 12 distinct installment numbers (1..12).
+  const installmentSchedules = Array.from({ length: 12 }, (_, i) => ({
+    installmentNo: i + 1,
+  }));
+
+  let prisma: {
+    contract: { findUnique: jest.Mock };
+    installmentSchedule: { findMany: jest.Mock };
+    chartOfAccount: { findMany: jest.Mock };
+  };
+  let service: ContractPaymentService;
+
+  beforeEach(() => {
+    prisma = {
+      contract: { findUnique: jest.fn().mockResolvedValue(contract) },
+      installmentSchedule: { findMany: jest.fn().mockResolvedValue(installmentSchedules) },
+      chartOfAccount: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    service = new ContractPaymentService(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma as any,
+      // ProductsService / JournalAutoService / EarlyPayoffJP4Template are never
+      // touched by getEarlyPayoffQuote — empty mocks are sufficient.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+    );
+  });
+
+  it('reverses the full remaining deferred interest (unearned interest reversal)', async () => {
+    const quote = await service.getEarlyPayoffQuote(contract.id);
+
+    // 6 of 12 installments remain. interestPerInst = 1800/12 = 150.00.
+    // Remaining deferred interest reversed = 150.00 × 6 = 900.00.
+    const interestLine = quote.journalPreview.lines.find((l) => l.accountCode === '11-2106');
+    expect(interestLine?.debit).toBe('900.00');
+  });
+
+  it('computes the early-payoff discount from the FRACTION form of discountPct (0..1, not 0..100)', async () => {
+    const quote = await service.getEarlyPayoffQuote(contract.id);
+
+    // discount = remainingDeferredInterest (900.00) × 0.5 (fraction) = 450.00.
+    // SUSPECTED BUG GUARD: if the JE preview ever read the returned percentage
+    // form (50) instead of the fraction (0.5), this would be 45000.00 — a 100×
+    // overstatement. Pin 450.00 to lock the unit.
+    const discountLine = quote.journalPreview.lines.find((l) => l.accountCode === '52-1106');
+    expect(discountLine?.debit).toBe('450.00');
+    expect(quote.discountAmount).toBe(450); // gross-profit path agrees (900 × 0.5)
+  });
+
+  it('returns discountPct in PERCENTAGE form (0..100) to the caller', async () => {
+    const quote = await service.getEarlyPayoffQuote(contract.id);
+    // Internally a fraction 0.5; surfaced to the API as 50.
+    expect(quote.discountPct).toBe(50);
+  });
+
+  it('computes the final settlement (cash payoff line) = remainingGross − discount + remainingVat', async () => {
+    const quote = await service.getEarlyPayoffQuote(contract.id);
+
+    // remainingGross (excl VAT) = 1800.00 × 6 = 10800.00
+    // remainingDeferredVat       = (1512/12 = 126.00) × 6 = 756.00
+    // settlement = 10800.00 − 450.00 + 756.00 = 11106.00
+    const cashLine = quote.journalPreview.lines.find((l) => l.accountCode === '11-1101');
+    expect(cashLine?.debit).toBe('11106.00');
+
+    // Top-level payoff (remainingBalance 11556 − discount 450, no late fees)
+    // must agree with the JE cash settlement exactly.
+    expect(quote.totalPayoff).toBe(11106);
+  });
+
+  it('produces a balanced early-payoff journal entry', async () => {
+    const quote = await service.getEarlyPayoffQuote(contract.id);
+    expect(quote.journalPreview.totalDebit).toBe('13212.00');
+    expect(quote.journalPreview.totalCredit).toBe('13212.00');
+    expect(quote.journalPreview.isBalanced).toBe(true);
+  });
+
+  it('scales the discount with an explicit discountPct override (30% → 270.00) and reflows the settlement', async () => {
+    const quote = await service.getEarlyPayoffQuote(contract.id, 30);
+
+    // discount = 900.00 × 0.30 = 270.00 (fraction 0.30, not 30).
+    const discountLine = quote.journalPreview.lines.find((l) => l.accountCode === '52-1106');
+    expect(discountLine?.debit).toBe('270.00');
+
+    // settlement = 10800.00 − 270.00 + 756.00 = 11286.00
+    const cashLine = quote.journalPreview.lines.find((l) => l.accountCode === '11-1101');
+    expect(cashLine?.debit).toBe('11286.00');
+    expect(quote.discountPct).toBe(30);
+  });
+});

--- a/apps/api/src/modules/line-oa/line-webhook.guard.spec.ts
+++ b/apps/api/src/modules/line-oa/line-webhook.guard.spec.ts
@@ -1,0 +1,211 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { createHmac } from 'crypto';
+import { LineWebhookGuard } from './line-webhook.guard';
+
+/**
+ * Characterization (golden) tests for LineWebhookGuard — the LINE webhook
+ * HMAC-SHA256 signature verification gate (X-Line-Signature).
+ *
+ * SECURITY PATH: locks the exact accept/reject behavior so a future refactor
+ * cannot silently weaken signature verification. Expected signatures are built
+ * here with node:crypto exactly as the guard does:
+ *     createHmac('SHA256', channelSecret).update(rawBody).digest('base64')
+ *
+ * Mock-based unit test — no DB. IntegrationConfigService + WebhookAnomalyService
+ * are plain object mocks injected through the constructor.
+ */
+
+const CHANNEL_SECRET = 'test-channel-secret-0123456789abcdef';
+
+/** Sign a raw body the same way LINE (and the guard) does. */
+function signBody(secret: string, rawBody: Buffer): string {
+  return createHmac('SHA256', secret).update(rawBody).digest('base64');
+}
+
+describe('LineWebhookGuard', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let integrationConfig: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let anomaly: any;
+  let guard: LineWebhookGuard;
+
+  // Preserve NODE_ENV across the suite (the "missing secret" branch reads it).
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    integrationConfig = {
+      getValue: jest.fn().mockResolvedValue(CHANNEL_SECRET),
+    };
+    anomaly = {
+      record: jest.fn().mockResolvedValue(undefined),
+    };
+    guard = new LineWebhookGuard(integrationConfig, anomaly);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    }
+  });
+
+  /** Build a minimal ExecutionContext wrapping a fake express request. */
+  function makeContext(req: Record<string, unknown>): ExecutionContext {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => req,
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  /** A valid LINE webhook payload (LINE sends a JSON envelope). */
+  const PAYLOAD = JSON.stringify({
+    destination: 'U1234567890',
+    events: [{ type: 'message', message: { type: 'text', text: 'สวัสดี' } }],
+  });
+  const RAW_BODY = Buffer.from(PAYLOAD, 'utf8');
+
+  it('accepts a request whose X-Line-Signature is a correct base64 HMAC-SHA256 of the raw body', async () => {
+    const signature = signBody(CHANNEL_SECRET, RAW_BODY);
+    // Sanity: the guard recomputes the same digest, so this is the exact value it expects.
+    expect(signature).toBe(
+      createHmac('SHA256', CHANNEL_SECRET).update(RAW_BODY).digest('base64'),
+    );
+
+    const ctx = makeContext({
+      ip: '203.0.113.9',
+      headers: { 'x-line-signature': signature, 'user-agent': 'LineBotWebhook/2.0' },
+      rawBody: RAW_BODY,
+      body: JSON.parse(PAYLOAD),
+    });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    // A successful verification must NOT record any anomaly.
+    expect(anomaly.record).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tampered body (valid signature for the ORIGINAL body, but rawBody mutated) and records invalid_signature', async () => {
+    // Signature is computed over the untampered payload...
+    const signature = signBody(CHANNEL_SECRET, RAW_BODY);
+    // ...but the request now carries a different raw body (attacker swapped the amount/text).
+    const tamperedBody = Buffer.from(
+      JSON.stringify({ destination: 'U1234567890', events: [{ type: 'evil' }] }),
+      'utf8',
+    );
+
+    const ctx = makeContext({
+      ip: '198.51.100.7',
+      headers: { 'x-line-signature': signature, 'user-agent': 'curl/8.0' },
+      rawBody: tamperedBody,
+      body: {},
+    });
+
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid LINE signature');
+    expect(anomaly.record).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'line-shop', reason: 'invalid_signature' }),
+    );
+  });
+
+  it('rejects a signature produced with the WRONG channel secret (forged sender)', async () => {
+    // Attacker signs the real body but does not know the channel secret.
+    const forgedSignature = signBody('attacker-guessed-secret', RAW_BODY);
+    expect(forgedSignature).not.toBe(signBody(CHANNEL_SECRET, RAW_BODY));
+
+    const ctx = makeContext({
+      ip: '198.51.100.20',
+      headers: { 'x-line-signature': forgedSignature },
+      rawBody: RAW_BODY,
+      body: JSON.parse(PAYLOAD),
+    });
+
+    await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid LINE signature');
+    expect(anomaly.record).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'line-shop', reason: 'invalid_signature' }),
+    );
+  });
+
+  it('rejects when the X-Line-Signature header is entirely absent (records missing_signature, not invalid_signature)', async () => {
+    const ctx = makeContext({
+      ip: '203.0.113.50',
+      headers: {}, // no x-line-signature
+      rawBody: RAW_BODY,
+      body: JSON.parse(PAYLOAD),
+    });
+
+    await expect(guard.canActivate(ctx)).rejects.toThrow('Missing LINE signature');
+    expect(anomaly.record).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'line-shop', reason: 'missing_signature' }),
+    );
+  });
+
+  it('falls back to JSON.stringify(request.body) when rawBody is absent — signature over the stringified body passes', async () => {
+    // The guard does: body = rawBody ?? Buffer.from(JSON.stringify(request.body)).
+    // With rawBody undefined, the HMAC is taken over Buffer.from(JSON.stringify(body)).
+    const parsed = { destination: 'U999', events: [] };
+    const stringified = Buffer.from(JSON.stringify(parsed));
+    const signature = signBody(CHANNEL_SECRET, stringified);
+
+    const ctx = makeContext({
+      ip: '203.0.113.77',
+      headers: { 'x-line-signature': signature },
+      // rawBody intentionally omitted → triggers the JSON.stringify fallback path
+      body: parsed,
+    });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(anomaly.record).not.toHaveBeenCalled();
+  });
+
+  it('an empty raw body is verifiable: HMAC of an empty buffer matches and passes', async () => {
+    const emptyBody = Buffer.from('', 'utf8');
+    const signature = signBody(CHANNEL_SECRET, emptyBody);
+
+    const ctx = makeContext({
+      ip: '203.0.113.88',
+      headers: { 'x-line-signature': signature },
+      rawBody: emptyBody,
+      body: {},
+    });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  describe('missing channel secret', () => {
+    it('in DEV (NODE_ENV !== production) skips verification and returns true even with a bogus signature', async () => {
+      process.env.NODE_ENV = 'development';
+      integrationConfig.getValue.mockResolvedValue(''); // secret not configured
+
+      const ctx = makeContext({
+        ip: '127.0.0.1',
+        headers: { 'x-line-signature': 'anything-goes-in-dev' },
+        rawBody: RAW_BODY,
+        body: JSON.parse(PAYLOAD),
+      });
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      // Dev skip must not flag an anomaly.
+      expect(anomaly.record).not.toHaveBeenCalled();
+    });
+
+    it('in PRODUCTION refuses the webhook and records missing_secret', async () => {
+      process.env.NODE_ENV = 'production';
+      integrationConfig.getValue.mockResolvedValue('');
+
+      const ctx = makeContext({
+        ip: '203.0.113.200',
+        headers: { 'x-line-signature': 'irrelevant' },
+        rawBody: RAW_BODY,
+        body: JSON.parse(PAYLOAD),
+      });
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Webhook signature verification not configured',
+      );
+      expect(anomaly.record).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'line-shop', reason: 'missing_secret' }),
+      );
+    });
+  });
+});

--- a/apps/api/src/modules/overdue/overdue.partial-payment-reschedule.spec.ts
+++ b/apps/api/src/modules/overdue/overdue.partial-payment-reschedule.spec.ts
@@ -1,0 +1,227 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { OverdueService } from './overdue.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { DunningEngineService } from './dunning-engine.service';
+import { OverdueKpiService } from './kpi.service';
+import { PromiseService } from './promise.service';
+import { PaymentsService } from '../payments/payments.service';
+import { ContractLetterService } from './contract-letter.service';
+import { MdmLockService } from './mdm-lock.service';
+import { OwnerAlertHelper } from './owner-alert.helper';
+
+/**
+ * Characterization (golden) test for OverdueService.partialPaymentReschedule
+ * (overdue.service.ts ~lines 1410-1535).
+ *
+ * Locks the outstanding-recompute math for "รับเงินบางส่วน + นัดส่วนที่เหลือ":
+ *   outstandingBefore = Σ (amountDue + lateFee − amountPaid) over PAST-DUE installments
+ *   outstandingAfter  = outstandingBefore − amountPaid
+ *   isFullPayment     = (amountPaid === outstandingBefore)
+ *
+ * The reschedule of the remaining balance is delegated to this.logContact
+ * (result=PROMISED, settlementAmount=outstandingAfter). That method has its own
+ * complex prisma+PromiseService side effects, so it is spied/stubbed here to keep
+ * this test focused on the money computation + branch flags. The returned
+ * settlementAmount passed INTO logContact is itself asserted (it is the recomputed
+ * remaining installment amount), so the reschedule value is still locked.
+ *
+ * All amounts are Prisma.Decimal under the hood; the method returns plain numbers
+ * via .toNumber(), so equality on whole/decimal values is exact.
+ */
+describe('OverdueService.partialPaymentReschedule (characterization)', () => {
+  let service: OverdueService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const mockDunningEngine = { executeEventTrigger: jest.fn().mockResolvedValue(undefined) };
+  const mockKpiService = { invalidate: jest.fn() };
+  const mockPromiseService = {
+    createPromise: jest.fn().mockResolvedValue({ id: 'promise-1' }),
+    findActivePromise: jest.fn().mockResolvedValue(null),
+    calcCycleDeadline: jest.fn(),
+  };
+  const mockLetterService = { createIfNotExists: jest.fn() };
+  const mockMdmLockService = { proposeManual: jest.fn() };
+  const mockOwnerAlertHelper = {
+    sendToAllOwners: jest.fn().mockResolvedValue({ sent: 0, failed: 0 }),
+  };
+  // autoAllocatePayment is the atomic money receipt — its return is opaque to the
+  // computation under test; we only echo a marker so we can confirm it was wired.
+  const mockPaymentsService = {
+    autoAllocatePayment: jest.fn().mockResolvedValue({ receiptId: 'rcpt-1' }),
+  };
+
+  // Helper: build a contract whose PAST-DUE payments produce a known outstanding.
+  // partialPaymentReschedule selects amountDue/amountPaid/lateFee for past-due rows.
+  const futureIso = (days: number) =>
+    new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+  const buildContract = () => ({
+    id: 'c-1',
+    payments: [
+      // remaining = 1000 + 50 - 0   = 1050
+      { amountDue: new Prisma.Decimal('1000'), lateFee: new Prisma.Decimal('50'), amountPaid: new Prisma.Decimal('0') },
+      // remaining = 1000 + 50 - 200 = 850
+      { amountDue: new Prisma.Decimal('1000'), lateFee: new Prisma.Decimal('50'), amountPaid: new Prisma.Decimal('200') },
+      // remaining = 1000 + 0  - 0   = 1000
+      { amountDue: new Prisma.Decimal('1000'), lateFee: new Prisma.Decimal('0'), amountPaid: new Prisma.Decimal('0') },
+    ],
+    // outstandingBefore = 1050 + 850 + 1000 = 2900.00
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    prisma = {
+      contract: { findFirst: jest.fn().mockResolvedValue(buildContract()) },
+    };
+
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        OverdueService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: DunningEngineService, useValue: mockDunningEngine },
+        { provide: OverdueKpiService, useValue: mockKpiService },
+        { provide: PromiseService, useValue: mockPromiseService },
+        { provide: PaymentsService, useValue: mockPaymentsService },
+        { provide: ContractLetterService, useValue: mockLetterService },
+        { provide: MdmLockService, useValue: mockMdmLockService },
+        { provide: OwnerAlertHelper, useValue: mockOwnerAlertHelper },
+      ],
+    }).compile();
+    service = mod.get(OverdueService);
+
+    // Isolate the reschedule-of-remainder side effect: logContact has its own
+    // prisma + PromiseService machinery (broken-promise count, FIFO targeting,
+    // Serializable $transaction). We stub it and assert the args it RECEIVES so the
+    // recomputed remaining amount is still locked without a real DB.
+    jest
+      .spyOn(service, 'logContact')
+      .mockResolvedValue({ id: 'cl-reschedule' } as never);
+  });
+
+  it('partial payment: recomputes outstanding and reschedules the EXACT remainder', async () => {
+    const settlementDate = futureIso(3);
+    const result = await service.partialPaymentReschedule('c-1', 'u-1', {
+      amountPaid: 500,
+      paymentMethod: 'CASH',
+      newSettlementDate: settlementDate,
+      notes: 'จ่าย 500 นัดที่เหลือ',
+    });
+
+    // outstandingBefore = 1050 + 850 + 1000 = 2900.00
+    expect(result.outstandingBefore).toBe(2900);
+    // outstandingAfter = 2900 - 500 = 2400.00 (the rescheduled remaining balance)
+    expect(result.outstandingAfter).toBe(2400);
+    expect(result.amountPaid).toBe(500);
+    expect(result.isFullPayment).toBe(false);
+    expect(result.newSettlementDate).toBe(settlementDate);
+
+    // Money receipt was wired with the paid amount + method.
+    expect(mockPaymentsService.autoAllocatePayment).toHaveBeenCalledWith(
+      'c-1',
+      500,
+      'CASH',
+      'u-1',
+      expect.anything(),
+      undefined,
+    );
+
+    // The reschedule (logContact PROMISED) carries the recomputed remainder 2400
+    // as settlementAmount — this is the load-bearing regulated value.
+    const logArgs = (service.logContact as jest.Mock).mock.calls[0];
+    expect(logArgs[2]).toMatchObject({
+      result: 'PROMISED',
+      settlementAmount: 2400,
+      settlementDate,
+    });
+  });
+
+  it('folds transactionRef into the notes passed to autoAllocatePayment', async () => {
+    await service.partialPaymentReschedule('c-1', 'u-1', {
+      amountPaid: 500,
+      paymentMethod: 'TRANSFER',
+      newSettlementDate: futureIso(3),
+      notes: 'โอนแล้ว',
+      transactionRef: 'KB-998877',
+    });
+
+    // ref + notes both present → "Ref: <ref> — <notes>"
+    const notesArg = mockPaymentsService.autoAllocatePayment.mock.calls[0][4];
+    expect(notesArg).toBe('Ref: KB-998877 — โอนแล้ว');
+  });
+
+  it('full payment (paid === outstandingBefore): outstandingAfter=0, no reschedule', async () => {
+    const result = await service.partialPaymentReschedule('c-1', 'u-1', {
+      amountPaid: 2900, // exactly clears the 2900.00 outstanding
+      paymentMethod: 'CASH',
+    });
+
+    expect(result.isFullPayment).toBe(true);
+    expect(result.outstandingBefore).toBe(2900);
+    expect(result.outstandingAfter).toBe(0);
+    expect(result.newSettlementDate).toBeNull();
+    // Full payment → no promise/reschedule logged.
+    expect(service.logContact).not.toHaveBeenCalled();
+  });
+
+  it('rejects overpayment beyond total outstanding', async () => {
+    await expect(
+      service.partialPaymentReschedule('c-1', 'u-1', {
+        amountPaid: 2900.01, // > 2900.00 outstanding
+        paymentMethod: 'CASH',
+        newSettlementDate: futureIso(3),
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(mockPaymentsService.autoAllocatePayment).not.toHaveBeenCalled();
+  });
+
+  it('rejects when contract has no outstanding (all past-due fully paid)', async () => {
+    prisma.contract.findFirst.mockResolvedValue({
+      id: 'c-1',
+      payments: [
+        { amountDue: new Prisma.Decimal('1000'), lateFee: new Prisma.Decimal('0'), amountPaid: new Prisma.Decimal('1000') },
+      ],
+    });
+    await expect(
+      service.partialPaymentReschedule('c-1', 'u-1', {
+        amountPaid: 100,
+        paymentMethod: 'CASH',
+        newSettlementDate: futureIso(3),
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('partial payment requires a future settlement date within 30 days', async () => {
+    // Missing newSettlementDate on a partial pay → reject before taking any money.
+    await expect(
+      service.partialPaymentReschedule('c-1', 'u-1', {
+        amountPaid: 500,
+        paymentMethod: 'CASH',
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    // > 30 days out → reject.
+    await expect(
+      service.partialPaymentReschedule('c-1', 'u-1', {
+        amountPaid: 500,
+        paymentMethod: 'CASH',
+        newSettlementDate: futureIso(31),
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(mockPaymentsService.autoAllocatePayment).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFound when the contract is missing', async () => {
+    prisma.contract.findFirst.mockResolvedValue(null);
+    await expect(
+      service.partialPaymentReschedule('missing', 'u-1', {
+        amountPaid: 500,
+        paymentMethod: 'CASH',
+        newSettlementDate: futureIso(3),
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api/src/modules/payments/payments.service.late-fee.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.late-fee.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * payments.service.late-fee.spec.ts
+ *
+ * Characterization (golden) test for the REAL-TIME late-fee computation in
+ * PaymentsService.recordPayment (payments.service.ts lines ~269-285).
+ *
+ * The late fee is recomputed at payment time (the daily cron may not have run
+ * yet). The formula is:
+ *
+ *   daysOverdue   = floor((now - dueDate) / 1 day)            // only if > 0
+ *   feePerDay     = SystemConfig 'late_fee_per_day' ?? 50
+ *   cap           = SystemConfig 'late_fee_cap'     ?? 1500   // absolute baht cap
+ *   pctCap        = amountDue * BUSINESS_RULES.LATE_FEE_CAP_PCT  // 5% of installment
+ *   calculatedFee = round2( min(feePerDay * daysOverdue, cap, pctCap) )
+ *
+ * The new fee is only written (and forwarded to the 2B receipt template) when
+ * calculatedFee > the stored payment.lateFee.
+ *
+ * These tests drive recordPayment end-to-end against a mocked Prisma (same unit
+ * pattern as payments.service.advance.spec.ts) and lock the exact Decimal late
+ * fee captured from BOTH the Payment.update write AND the lateFee forwarded to
+ * PaymentReceipt2BTemplate.execute.
+ *
+ * Money is Prisma.Decimal — asserted via .toFixed(2).
+ */
+
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+  SentryModule: class {},
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { PaymentsService } from './payments.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ReceiptsService } from '../receipts/receipts.service';
+import { AuditService } from '../audit/audit.service';
+import { JournalAutoService } from '../journal/journal-auto.service';
+import { ProductsService } from '../products/products.service';
+import { LineOaService } from '../line-oa/line-oa.service';
+import { FlexTemplatesService } from '../line-oa/flex-templates.service';
+import { QuickReplyService } from '../line-oa/quick-reply.service';
+import { PromiseService } from '../overdue/promise.service';
+import { MdmLockService } from '../overdue/mdm-lock.service';
+import { PaymentReceipt2BTemplate } from '../journal/cpa-templates/payment-receipt-2b.template';
+import { BadDebtService } from '../accounting/bad-debt.service';
+
+const D = (n: number | string) => new Prisma.Decimal(n);
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+/** A dueDate exactly `days` days in the past (+1s buffer so floor() lands on `days`). */
+const overdueDays = (days: number) => new Date(Date.now() - (days * DAY_MS + 1000));
+
+describe('PaymentsService — real-time late fee on payment', () => {
+  let service: PaymentsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let receipt2BExecute: any;
+
+  // Per-test config for the two SystemConfig late-fee keys (null = use defaults).
+  let lateFeePerDayCfg: string | null;
+  let lateFeeCapCfg: string | null;
+
+  const makeContract = () => ({
+    id: 'lf-contract-1',
+    contractNumber: 'BC-LF-001',
+    status: 'OVERDUE',
+    deletedAt: null,
+    branchId: 'branch-1',
+    customerId: 'cust-1',
+    advanceBalance: D(0),
+  });
+
+  const makePayment = (overrides: Record<string, unknown> = {}) => ({
+    id: 'lf-payment-1',
+    contractId: 'lf-contract-1',
+    installmentNo: 1,
+    amountDue: D(10000),
+    amountPaid: D(0),
+    lateFee: D(0),
+    lateFeeWaived: false,
+    dueDate: overdueDays(3),
+    status: 'OVERDUE',
+    evidenceUrl: null,
+    notes: null,
+    depositAccountCode: null,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    lateFeePerDayCfg = null;
+    lateFeeCapCfg = null;
+
+    const buildMockPrisma = () => ({
+      contract: {
+        findUnique: jest.fn().mockImplementation(() => Promise.resolve(makeContract())),
+        update: jest.fn().mockResolvedValue(makeContract()),
+      },
+      payment: {
+        findFirst: jest.fn().mockResolvedValue(makePayment()),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest
+          .fn()
+          .mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+            Promise.resolve({
+              id: 'lf-payment-1',
+              contractId: 'lf-contract-1',
+              installmentNo: 1,
+              amountDue: D(10000),
+              amountPaid: data.amountPaid ?? D(0),
+              lateFee: data.lateFee ?? D(0),
+              status: data.status ?? 'OVERDUE',
+              paidDate: data.paidDate ?? null,
+              depositAccountCode: data.depositAccountCode ?? null,
+            }),
+          ),
+        count: jest.fn().mockResolvedValue(1), // checkContractCompletion: not all paid
+        aggregate: jest.fn().mockResolvedValue({ _sum: { amountPaid: 0, lateFee: 0 } }),
+      },
+      user: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValue({ id: 'user-1', defaultCashAccountCode: null, deletedAt: null }),
+      },
+      companyInfo: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'co-FINANCE' }),
+      },
+      systemConfig: {
+        // Key-aware dispatch: period-lock keys return null (open period);
+        // late-fee keys return the per-test config.
+        findUnique: jest
+          .fn()
+          .mockImplementation(({ where }: { where: { key: string } }) => {
+            if (where.key === 'late_fee_per_day') {
+              return Promise.resolve(lateFeePerDayCfg ? { value: lateFeePerDayCfg } : null);
+            }
+            if (where.key === 'late_fee_cap') {
+              return Promise.resolve(lateFeeCapCfg ? { value: lateFeeCapCfg } : null);
+            }
+            return Promise.resolve(null);
+          }),
+      },
+      installmentSchedule: {
+        // Return a schedule so PaymentReceipt2BTemplate.execute is invoked and
+        // we can capture the forwarded lateFee.
+        findUnique: jest.fn().mockResolvedValue({ id: 'lf-sched-1' }),
+      },
+      callLog: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      partialPaymentLink: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      auditLog: {
+        create: jest.fn().mockResolvedValue({ id: 'al-1' }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: jest.fn((cb: (tx: any) => Promise<any>) => cb(mockPrismaInst)),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockPrismaInst: any = buildMockPrisma();
+    prisma = mockPrismaInst;
+
+    receipt2BExecute = jest.fn().mockResolvedValue({ entryNo: 'JE-LF' });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ReceiptsService, useValue: { generateReceipt: jest.fn().mockResolvedValue({ id: 'r-1' }) } },
+        {
+          provide: AuditService,
+          useValue: {
+            log: jest.fn().mockResolvedValue(undefined),
+            logPaymentEvent: jest.fn().mockResolvedValue(undefined),
+            logReceiptEvent: jest.fn().mockResolvedValue(undefined),
+            logContractFinancialEvent: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        { provide: JournalAutoService, useValue: { createAndPost: jest.fn().mockResolvedValue({ id: 'je-1' }) } },
+        { provide: ProductsService, useValue: { transferOwnership: jest.fn() } },
+        {
+          provide: LineOaService,
+          useValue: { buildPaymentSuccess: jest.fn().mockReturnValue({}), sendFlexMessage: jest.fn() },
+        },
+        {
+          provide: FlexTemplatesService,
+          useValue: { paymentReceipt: jest.fn().mockReturnValue({ type: 'flex', altText: 't', contents: {} }) },
+        },
+        { provide: QuickReplyService, useValue: { afterPayment: jest.fn().mockReturnValue([]) } },
+        { provide: PromiseService, useValue: { findActivePromise: jest.fn().mockResolvedValue(null) } },
+        { provide: MdmLockService, useValue: { autoUnlock: jest.fn().mockResolvedValue(undefined) } },
+        { provide: PaymentReceipt2BTemplate, useValue: { execute: receipt2BExecute } },
+        { provide: BadDebtService, useValue: { reverseStageOnPayment: jest.fn().mockResolvedValue(null) } },
+      ],
+    }).compile();
+
+    service = module.get<PaymentsService>(PaymentsService);
+  });
+
+  /** Pull the lateFee written by tx.payment.update (the line-282 write), if any. */
+  const lateFeeWritten = (): Prisma.Decimal | undefined => {
+    const call = prisma.payment.update.mock.calls.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c: any) => c[0]?.data && 'lateFee' in c[0].data && !('amountPaid' in c[0].data),
+    );
+    return call ? (call[0].data.lateFee as Prisma.Decimal) : undefined;
+  };
+
+  /** Pull the lateFee forwarded to PaymentReceipt2BTemplate.execute, if any. */
+  const lateFeeForwarded = (): Prisma.Decimal | undefined => {
+    const arg = receipt2BExecute.mock.calls[0]?.[0];
+    return arg?.lateFee;
+  };
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // On-time → zero late fee
+  // ───────────────────────────────────────────────────────────────────────────
+  it('on-time payment (future due date) computes NO late fee', async () => {
+    prisma.payment.findFirst.mockResolvedValue(
+      makePayment({ dueDate: new Date(Date.now() + 7 * DAY_MS) }),
+    );
+
+    await service.recordPayment(
+      'lf-contract-1',
+      1,
+      10000, // exactly amountDue, no late fee
+      'CASH',
+      'user-1',
+      'https://slip.test/ontime',
+      undefined,
+      'LF-ONTIME',
+      '11-1101',
+    );
+
+    // No lateFee-only Payment.update write happened.
+    expect(lateFeeWritten()).toBeUndefined();
+    // Template receives lateFee = undefined (lateFee.gt(0) is false).
+    expect(lateFeeForwarded()).toBeUndefined();
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Default per-day rate (50) — straight days × rate, below both caps
+  // ───────────────────────────────────────────────────────────────────────────
+  it('3 days overdue at default 50/day → late fee = 150.00 (below both caps)', async () => {
+    // amountDue 10000 → pctCap = 10000 * 0.05 = 500; cap (default) = 1500.
+    // min(50*3=150, 1500, 500) = 150.00
+    prisma.payment.findFirst.mockResolvedValue(makePayment({ dueDate: overdueDays(3) }));
+
+    await service.recordPayment(
+      'lf-contract-1',
+      1,
+      10150, // amountDue(10000) + lateFee(150)
+      'CASH',
+      'user-1',
+      'https://slip.test/3d',
+      undefined,
+      'LF-3DAY',
+      '11-1101',
+    );
+
+    expect(lateFeeWritten()?.toFixed(2)).toBe('150.00');
+    expect(lateFeeForwarded()?.toFixed(2)).toBe('150.00');
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 5% pctCap binds (per Thai law: LATE_FEE_CAP_PCT = 0.05)
+  // ───────────────────────────────────────────────────────────────────────────
+  it('5% pctCap clamps the fee when days × rate exceeds 5% of the installment', async () => {
+    // amountDue 1000 → pctCap = 1000 * 0.05 = 50.
+    // 10 days × default 50/day = 500; cap = 1500.
+    // min(500, 1500, 50) = 50.00  ← pctCap wins
+    prisma.payment.findFirst.mockResolvedValue(
+      makePayment({ amountDue: D(1000), dueDate: overdueDays(10) }),
+    );
+
+    await service.recordPayment(
+      'lf-contract-1',
+      1,
+      1050, // amountDue(1000) + lateFee(50)
+      'CASH',
+      'user-1',
+      'https://slip.test/pctcap',
+      undefined,
+      'LF-PCTCAP',
+      '11-1101',
+    );
+
+    expect(lateFeeWritten()?.toFixed(2)).toBe('50.00');
+    expect(lateFeeForwarded()?.toFixed(2)).toBe('50.00');
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Absolute baht cap binds (configured per-day rate, large installment)
+  // ───────────────────────────────────────────────────────────────────────────
+  it('absolute late_fee_cap (1500 default) clamps the fee for a long-overdue large installment', async () => {
+    // Configure 100/day; 40 days × 100 = 4000.
+    // amountDue 100000 → pctCap = 5000; cap (default) = 1500.
+    // min(4000, 1500, 5000) = 1500.00  ← absolute cap wins
+    lateFeePerDayCfg = '100';
+    prisma.payment.findFirst.mockResolvedValue(
+      makePayment({ amountDue: D(100000), dueDate: overdueDays(40) }),
+    );
+
+    await service.recordPayment(
+      'lf-contract-1',
+      1,
+      101500, // amountDue(100000) + lateFee(1500)
+      'CASH',
+      'user-1',
+      'https://slip.test/cap',
+      undefined,
+      'LF-CAP',
+      '11-1101',
+    );
+
+    expect(lateFeeWritten()?.toFixed(2)).toBe('1500.00');
+    expect(lateFeeForwarded()?.toFixed(2)).toBe('1500.00');
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Waiver flag suppresses real-time recompute entirely
+  // ───────────────────────────────────────────────────────────────────────────
+  it('lateFeeWaived=true skips recompute → no late fee charged even when overdue', async () => {
+    // 30 days overdue but waived → the `if (!payment.lateFeeWaived ...)` guard
+    // is skipped, so lateFee stays at the stored value (0).
+    prisma.payment.findFirst.mockResolvedValue(
+      makePayment({ dueDate: overdueDays(30), lateFeeWaived: true }),
+    );
+
+    await service.recordPayment(
+      'lf-contract-1',
+      1,
+      10000, // amountDue only — no late fee added
+      'CASH',
+      'user-1',
+      'https://slip.test/waived',
+      undefined,
+      'LF-WAIVED',
+      '11-1101',
+    );
+
+    expect(lateFeeWritten()).toBeUndefined();
+    expect(lateFeeForwarded()).toBeUndefined();
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Stored fee already >= computed fee → no new write (only writes when greater)
+  // ───────────────────────────────────────────────────────────────────────────
+  it('does NOT lower an already-stored late fee (write only when computed > stored)', async () => {
+    // Stored lateFee = 200; 3 days × 50 = 150 computed. 150 is NOT > 200, so the
+    // stored 200 is kept and no lateFee-only Payment.update fires.
+    prisma.payment.findFirst.mockResolvedValue(
+      makePayment({ dueDate: overdueDays(3), lateFee: D(200) }),
+    );
+
+    await service.recordPayment(
+      'lf-contract-1',
+      1,
+      10200, // amountDue(10000) + stored lateFee(200)
+      'CASH',
+      'user-1',
+      'https://slip.test/stored',
+      undefined,
+      'LF-STORED',
+      '11-1101',
+    );
+
+    // No lateFee-only write (computed 150 did not exceed stored 200).
+    expect(lateFeeWritten()).toBeUndefined();
+    // The stored 200 IS still forwarded to the template (lateFee.gt(0)).
+    expect(lateFeeForwarded()?.toFixed(2)).toBe('200.00');
+  });
+});

--- a/apps/api/src/modules/reports/reports.service.aging.spec.ts
+++ b/apps/api/src/modules/reports/reports.service.aging.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { ReportsService } from './reports.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AccountingService } from '../accounting/accounting.service';
+
+/**
+ * Characterization (golden) test for ReportsService.getAgingReport.
+ *
+ * Locks the in-JS aging-bucket aggregation: overdue payments are sorted into
+ * 1-30 / 31-60 / 61-90 / 90+ day buckets by `calculateDaysElapsed(dueDate, now)`
+ * (= floor((now - dueDate)/day)), and each bucket's `count`, `totalOutstanding`
+ * (Σ amountDue − amountPaid) and `totalLateFees` (Σ lateFee) are computed with
+ * Prisma.Decimal arithmetic.
+ *
+ * Mock-only: prisma.payment.findMany returns a fixed dataset. No real DB.
+ * Due dates are derived from the wall clock at call time (the service builds
+ * `now = new Date()` internally) minus exact day multiples plus a 12h cushion
+ * so the floor lands deterministically inside the intended bucket regardless of
+ * the hour the test runs.
+ */
+describe('ReportsService.getAgingReport (characterization)', () => {
+  let service: ReportsService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let prisma: any;
+
+  const DAY = 24 * 60 * 60 * 1000;
+  const HALF_DAY = 12 * 60 * 60 * 1000;
+
+  // dueDate `days` whole days in the past, +12h cushion below the boundary so
+  // floor((now - dueDate)/day) === days reliably (never `days - 1`).
+  const daysAgo = (days: number) => new Date(Date.now() - days * DAY - HALF_DAY);
+
+  const mkPayment = (
+    id: string,
+    days: number,
+    amountDue: number,
+    amountPaid: number,
+    lateFee: number,
+  ) => ({
+    id,
+    dueDate: daysAgo(days),
+    amountDue: new Prisma.Decimal(amountDue),
+    amountPaid: new Prisma.Decimal(amountPaid),
+    lateFee: new Prisma.Decimal(lateFee),
+    contract: {
+      contractNumber: `BC-${id}`,
+      customer: { name: `ลูกค้า ${id}`, phone: '0800000000' },
+      branch: { name: 'สาขาทดสอบ' },
+    },
+  });
+
+  // Fixed dataset spanning every bucket:
+  //  A,B → 1-30   | C → 31-60 | D → 61-90 | E → 90+
+  const overduePayments = [
+    mkPayment('A', 15, 1000, 200, 50),   // outstanding 800,  lateFee 50
+    mkPayment('B', 25, 2000, 0, 100),    // outstanding 2000, lateFee 100
+    mkPayment('C', 45, 1500, 500, 75),   // outstanding 1000, lateFee 75
+    mkPayment('D', 75, 3000, 1000, 200), // outstanding 2000, lateFee 200
+    mkPayment('E', 120, 5000, 0, 500),   // outstanding 5000, lateFee 500
+  ];
+
+  beforeEach(async () => {
+    prisma = {
+      payment: {
+        findMany: jest.fn().mockResolvedValue(overduePayments),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AccountingService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<ReportsService>(ReportsService);
+  });
+
+  it('buckets the 1-30 day group: count 2, outstanding 2800, late fees 150', async () => {
+    const report = await service.getAgingReport();
+
+    // A (15d) + B (25d) → both in 1-30
+    expect(report['1-30'].count).toBe(2);
+    // (1000-200) + (2000-0) = 800 + 2000 = 2800
+    expect(new Prisma.Decimal(report['1-30'].totalOutstanding).toFixed(2)).toBe('2800.00');
+    // 50 + 100 = 150
+    expect(new Prisma.Decimal(report['1-30'].totalLateFees).toFixed(2)).toBe('150.00');
+  });
+
+  it('buckets 31-60 (C), 61-90 (D), and 90+ (E) each with one payment', async () => {
+    const report = await service.getAgingReport();
+
+    expect(report['31-60'].count).toBe(1);
+    // 1500 - 500 = 1000
+    expect(new Prisma.Decimal(report['31-60'].totalOutstanding).toFixed(2)).toBe('1000.00');
+    expect(new Prisma.Decimal(report['31-60'].totalLateFees).toFixed(2)).toBe('75.00');
+
+    expect(report['61-90'].count).toBe(1);
+    // 3000 - 1000 = 2000
+    expect(new Prisma.Decimal(report['61-90'].totalOutstanding).toFixed(2)).toBe('2000.00');
+    expect(new Prisma.Decimal(report['61-90'].totalLateFees).toFixed(2)).toBe('200.00');
+
+    expect(report['90+'].count).toBe(1);
+    // 5000 - 0 = 5000
+    expect(new Prisma.Decimal(report['90+'].totalOutstanding).toFixed(2)).toBe('5000.00');
+    expect(new Prisma.Decimal(report['90+'].totalLateFees).toFixed(2)).toBe('500.00');
+  });
+
+  it('total row sums every payment: count 5, outstanding 10800, late fees 925', async () => {
+    const report = await service.getAgingReport();
+
+    expect(report.total.count).toBe(5);
+    // 800 + 2000 + 1000 + 2000 + 5000 = 10800
+    expect(new Prisma.Decimal(report.total.totalOutstanding).toFixed(2)).toBe('10800.00');
+    // 50 + 100 + 75 + 200 + 500 = 925
+    expect(new Prisma.Decimal(report.total.totalLateFees).toFixed(2)).toBe('925.00');
+  });
+
+  it('filters by branch via the contract relation when branchId is supplied', async () => {
+    await service.getAgingReport('branch-42');
+    const where = prisma.payment.findMany.mock.calls[0][0].where;
+    // branch filter is applied through the contract relation, not a flat branchId
+    expect(where.contract).toEqual({ branchId: 'branch-42', deletedAt: null });
+    // only still-owed installment statuses are pulled into the aging report
+    expect(where.status).toEqual({ in: ['PENDING', 'OVERDUE', 'PARTIALLY_PAID'] });
+  });
+});


### PR DESCRIPTION
Wave 3 test-backfill: characterization/golden specs for money & regulated code paths that had **no coverage**. **No production code is modified** — pure safety net, so this is low-risk and does not need accountant sign-off.

Built via a multi-agent workflow (one writer + one adversarial reviewer per target); every spec was run green and reviewed as non-shallow before inclusion, then re-verified locally (38/38 pass, 0 prod files touched).

| Spec | Locks | Tests |
|---|---|---|
| `line-oa/line-webhook.guard.spec.ts` | LINE webhook HMAC-SHA256 gate (valid passes, tampered/forged/missing rejected, dev-skip vs prod-strict) | 8 |
| `payments/payments.service.late-fee.spec.ts` | real-time late fee = `min(perDay×days, abs cap, 5% of due)` incl. waiver + write-only-when-greater | 6 |
| `assets/asset-invoice-received-template.spec.ts` | VAT transfer JE Dr 11-4101 / Cr 11-4102 + idempotency flow | 7 |
| `contracts/contract-payment.service.early-payoff.spec.ts` | early-payoff discount **unit** (0.5 fraction, not 50%) + payoff amount — guards the historical 100× discount bug | 6 |
| `reports/reports.service.aging.spec.ts` | aging buckets: count + Σ outstanding + Σ late fees | 4 |
| `overdue/overdue.partial-payment-reschedule.spec.ts` | partial-payment reschedule recompute | 7 |

No live bugs found; the one `SUSPECTED BUG GUARD` comment is a regression guard pinning the correct early-payoff unit. Safe to merge after CI (test-only).

🤖 Generated with Claude Code