### PR TITLE
fix(api): Wave-1 money — manual-JE exact balance (#10) + early-payoff false-100x (#4/#11)

### DIFF
--- a/apps/api/src/modules/contracts/contract-payment.service.ts
+++ b/apps/api/src/modules/contracts/contract-payment.service.ts
@@ -349,10 +349,22 @@ export class ContractPaymentService {
           const epRemainingGross = epInstallmentExclVat.times(epUnpaidD);
           const epRemainingDeferredInterest = epInterestPerInst.times(epUnpaidD);
           const epRemainingDeferredVat = epVatPerInst.times(epUnpaidD);
+          // NB (Wave-1 #4/#11): `quote.discountPct` is a PERCENTAGE 0..100
+          // (getEarlyPayoffQuote returns `discountPct: discountPct * 100`), so the
+          // `.div(100)` here is CORRECT and matches the quote's JE-preview epDiscount,
+          // which multiplies by the 0..1 fraction directly. This is NOT a 100× bug —
+          // do not "simplify" by removing the .div(100).
           const epDiscount = epRemainingDeferredInterest
             .times(new Decimal(quote.discountPct))
             .div(100)
             .toDecimalPlaces(2);
+          // ACCOUNTANT NOTE (Wave-1 #11, deeper than the false 100× alarm): epSettlement
+          // (this JE's cash debit) is built from the per-installment breakdown and discounts
+          // the DEFERRED INTEREST, while the cash the customer is quoted (quote.totalPayoff)
+          // is monthlyPayment-based, nets out creditBalance/advance, and discounts GROSS
+          // PROFIT. The two can diverge, so the cash debited here may differ from cash
+          // actually collected. Reconciling the payoff cash basis is an accounting-policy
+          // decision — left unchanged pending sign-off.
           const epSettlement = epRemainingGross.minus(epDiscount).plus(epRemainingDeferredVat);
 
           await this.journalAutoService.createAndPost(

--- a/apps/api/src/modules/journal/journal.service.spec.ts
+++ b/apps/api/src/modules/journal/journal.service.spec.ts
@@ -120,6 +120,37 @@ describe('JournalService.create — period lock enforcement', () => {
     ).rejects.toThrow(BadRequestException);
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
+
+  // ─── Wave-1 #10: exact-Decimal balance validation (was float + 0.001 epsilon) ───
+
+  it('rejects a sub-satang-unbalanced entry that the old 0.001 epsilon would have passed', async () => {
+    const dto = {
+      ...balancedDto(),
+      lines: [
+        { accountCode: '1100', description: 'd', debit: 100.0005, credit: 0 },
+        { accountCode: '2100', description: 'c', debit: 0, credit: 100 },
+      ],
+    };
+    await expect(service.create(dto, 'user-1')).rejects.toThrow(/สมดุล/);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('accepts a genuinely balanced entry with float-prone decimals (0.1 + 0.2 == 0.3, no false reject)', async () => {
+    prisma.chartOfAccount.findMany.mockResolvedValue([
+      { code: '1100', allowedCompanies: [] },
+      { code: '2100', allowedCompanies: [] },
+    ]);
+    const dto = {
+      ...balancedDto(),
+      lines: [
+        { accountCode: '1100', description: 'd1', debit: 0.1, credit: 0 },
+        { accountCode: '1100', description: 'd2', debit: 0.2, credit: 0 },
+        { accountCode: '2100', description: 'c', debit: 0, credit: 0.3 },
+      ],
+    };
+    await expect(service.create(dto, 'user-1')).resolves.toBeDefined();
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
 });
 
 /**

--- a/apps/api/src/modules/journal/journal.service.ts
+++ b/apps/api/src/modules/journal/journal.service.ts
@@ -32,11 +32,15 @@ export class JournalService {
   }
 
   async create(dto: CreateJournalEntryDto, userId: string) {
-    // 1. Validate balance: sum debits must equal sum credits
-    const totalDebit = dto.lines.reduce((sum, line) => sum + line.debit, 0);
-    const totalCredit = dto.lines.reduce((sum, line) => sum + line.credit, 0);
+    // 1. Validate balance: sum debits must equal sum credits.
+    // Wave-1 #10: this used a float sum + a 0.001 epsilon (Math.abs(...) > 0.001),
+    // so a manual JE off by up to ~0.001 — or one that only *looks* balanced after
+    // binary-float drift — could post and silently skew the trial balance. Use exact
+    // Decimal arithmetic + equals(), matching the void-revalidation path below.
+    const totalDebit = dto.lines.reduce((sum, line) => sum.add(new Decimal(line.debit)), new Decimal(0));
+    const totalCredit = dto.lines.reduce((sum, line) => sum.add(new Decimal(line.credit)), new Decimal(0));
 
-    if (Math.abs(totalDebit - totalCredit) > 0.001) {
+    if (!totalDebit.equals(totalCredit)) {
       throw new BadRequestException('ยอดเดบิตและเครดิตไม่สมดุล');
     }
 


### PR DESCRIPTION
- #10 journal: manual-JE balance now exact Decimal (was float + 0.001 epsilon). +2 tests. Strictly stricter.
- #4/#11 early-payoff: traced the alleged 100x bug → FALSE ALARM (quote.discountPct is a percentage; .div(100) correct). No calc changed; guard comment added + flagged the real cash-basis divergence for accountant.

Accountant sign-off requested before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)