### PR TITLE
fix(payments): lazy-gen installment schedule so paid installments never lack a 2B JE

### DIFF
--- a/apps/api/src/cli/backfill-installment-schedules.cli.ts
+++ b/apps/api/src/cli/backfill-installment-schedules.cli.ts
@@ -12,7 +12,8 @@
  * Production invocation:
  *   gcloud run jobs execute backfill-schedules --region=asia-southeast1 --project=bestchoice-prod --wait
  */
-import { PrismaClient, Prisma } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
+import { buildInstallmentScheduleRows } from '../utils/installment-schedule.util';
 
 async function main(): Promise<void> {
   const expectedDb = process.env.EXPECTED_DB_NAME;
@@ -69,27 +70,9 @@ async function main(): Promise<void> {
         continue;
       }
 
-      const financed = new Prisma.Decimal(c.financedAmount.toString());
-      const interest = new Prisma.Decimal((c.interestTotal ?? 0).toString());
-      const monthly = new Prisma.Decimal((c.monthlyPayment ?? 0).toString());
-      const principalPerInst = financed.div(c.totalMonths).toDecimalPlaces(2, Prisma.Decimal.ROUND_DOWN);
-      const interestPerInst = interest.div(c.totalMonths).toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
-
-      const baseDate = c.createdAt;
-      const dueDay = c.paymentDueDay ?? baseDate.getDate();
-
-      const rows: Prisma.InstallmentScheduleCreateManyInput[] = [];
-      for (let i = 1; i <= c.totalMonths; i++) {
-        const dueDate = new Date(baseDate.getFullYear(), baseDate.getMonth() + i, dueDay);
-        rows.push({
-          contractId: c.id,
-          installmentNo: i,
-          dueDate,
-          principal: principalPerInst,
-          interest: interestPerInst,
-          amountDue: monthly,
-        });
-      }
+      // Algorithm consolidated into installment-schedule.util — single source of
+      // truth shared with contract-workflow activation + payment-receipt lazy-gen.
+      const rows = buildInstallmentScheduleRows(c);
       await prisma.installmentSchedule.createMany({ data: rows });
       console.log(`[backfill]   ${c.contractNumber} — ${rows.length} rows generated`);
       generated++;

--- a/apps/api/src/modules/contracts/contract-workflow.service.ts
+++ b/apps/api/src/modules/contracts/contract-workflow.service.ts
@@ -11,6 +11,7 @@ import {
   checkRequiredSignatures,
 } from '../../utils/validation.util';
 import { generateSaleNumber } from '../../utils/sequence.util';
+import { buildInstallmentScheduleRows } from '../../utils/installment-schedule.util';
 import { JournalAutoService } from '../journal/journal-auto.service';
 import { ContractActivation1ATemplate } from '../journal/cpa-templates/contract-activation-1a.template';
 import { ProductsService } from '../products/products.service';
@@ -541,27 +542,9 @@ export class ContractWorkflowService {
       return;
     }
 
-    const financed = new Prisma.Decimal(c.financedAmount.toString());
-    const interest = new Prisma.Decimal((c.interestTotal ?? 0).toString());
-    const monthly = new Prisma.Decimal((c.monthlyPayment ?? 0).toString());
-    const principalPerInst = financed.div(total).toDecimalPlaces(2, Prisma.Decimal.ROUND_DOWN);
-    const interestPerInst = interest.div(total).toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
-
-    const baseDate = c.createdAt;
-    const dueDay = c.paymentDueDay ?? baseDate.getDate();
-
-    const rows: Prisma.InstallmentScheduleCreateManyInput[] = [];
-    for (let i = 1; i <= total; i++) {
-      const dueDate = new Date(baseDate.getFullYear(), baseDate.getMonth() + i, dueDay);
-      rows.push({
-        contractId: c.id,
-        installmentNo: i,
-        dueDate,
-        principal: principalPerInst,
-        interest: interestPerInst,
-        amountDue: monthly,
-      });
-    }
+    // Algorithm consolidated into installment-schedule.util — single source of
+    // truth shared with the backfill CLI and the payment-receipt lazy-gen path.
+    const rows = buildInstallmentScheduleRows(c);
     await tx.installmentSchedule.createMany({ data: rows });
     this.logger.log(`Generated ${rows.length} installment_schedules rows for contract ${c.contractNumber}`);
   }

--- a/apps/api/src/modules/payments/payments-financial.spec.ts
+++ b/apps/api/src/modules/payments/payments-financial.spec.ts
@@ -78,6 +78,9 @@ describe('PaymentsService — Financial Integration', () => {
         updateMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
       installmentSchedule: {
+        // Lazy-gen recovery (#1170): count>0 → ensureInstallmentSchedules no-op.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
         findUnique: jest.fn().mockResolvedValue(null),
       },
       partialPaymentLink: {

--- a/apps/api/src/modules/payments/payments.credit-waive-summary.spec.ts
+++ b/apps/api/src/modules/payments/payments.credit-waive-summary.spec.ts
@@ -70,6 +70,16 @@ describe('PaymentsService — credit / waive / daily-summary / partial-preview (
     const inst: AnyObj = {
       contract: {
         findUnique: jest.fn(),
+        // Used by ensureInstallmentSchedules (#1170) only when the schedule is missing.
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: 'cr-contract-1',
+          totalMonths: 12,
+          financedAmount: D(10000),
+          interestTotal: D(1190),
+          monthlyPayment: D('1515.83'),
+          paymentDueDay: 5,
+          createdAt: new Date(2026, 0, 10),
+        }),
         update: jest.fn().mockResolvedValue({ id: 'co-1' }),
         count: jest.fn().mockResolvedValue(0),
       },
@@ -115,6 +125,9 @@ describe('PaymentsService — credit / waive / daily-summary / partial-preview (
         ]),
       },
       installmentSchedule: {
+        // Lazy-gen recovery (#1170): count>0 → ensureInstallmentSchedules no-op.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
         findUnique: jest.fn(),
       },
       auditLog: {
@@ -282,6 +295,35 @@ describe('PaymentsService — credit / waive / daily-summary / partial-preview (
         (c: AnyObj) => c[0]?.data?.action === 'CREDIT_APPLIED',
       );
       expect(creditApplied).toHaveLength(2);
+    });
+
+    it('PAID-no-JE (credit): alarms via Sentry + keeps the credit application (no throw) when the schedule is unpostable', async () => {
+      // #1170 — the credit path now mirrors recordPayment/handlePaymentCallback:
+      // lazy-gen the schedule before the receipt JE, and on a genuine anomaly
+      // (ungeneratable + still no row) alarm loudly instead of silently skipping.
+      (Sentry.captureException as jest.Mock).mockClear();
+      prisma.contract.findUnique.mockResolvedValue(mkContract(D(3000), [mkInstallment(1)]));
+      // Data anomaly: no rows AND ungeneratable (totalMonths=0); lookup stays null.
+      prisma.installmentSchedule.count.mockResolvedValueOnce(0);
+      prisma.contract.findUniqueOrThrow.mockResolvedValueOnce({
+        id: 'cr-contract-1',
+        totalMonths: 0,
+        financedAmount: D(0),
+        interestTotal: null,
+        monthlyPayment: null,
+        paymentDueDay: null,
+        createdAt: new Date(2026, 0, 10),
+      });
+      prisma.installmentSchedule.findUnique.mockResolvedValue(null);
+
+      // Does not throw — the customer's credit application is real and is applied.
+      await service.applyCreditBalance('cr-contract-1', 'user-1');
+
+      expect(prisma.installmentSchedule.createMany).not.toHaveBeenCalled();
+      expect(receiptExecute).not.toHaveBeenCalled();
+      expect(Sentry.captureException as jest.Mock).toHaveBeenCalled();
+      // The credit is still applied (Payment.update written) — no rollback.
+      expect(prisma.payment.update).toHaveBeenCalled();
     });
 
     it('credit=0 → throws BadRequestException "ไม่มียอดเครดิตในสัญญานี้"', async () => {

--- a/apps/api/src/modules/payments/payments.preview-journal-money.spec.ts
+++ b/apps/api/src/modules/payments/payments.preview-journal-money.spec.ts
@@ -138,6 +138,9 @@ describe('PaymentsService.previewJournal (characterization)', () => {
 
     prisma = {
       installmentSchedule: {
+        // Lazy-gen recovery (#1170): count>0 → ensureInstallmentSchedules no-op.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
         findUnique: jest.fn().mockImplementation(() => Promise.resolve(installment)),
       },
       chartOfAccount: {
@@ -530,6 +533,9 @@ describe('PaymentsService.recordPayment — tolerance gating (characterization)'
         findUnique: jest.fn().mockResolvedValue(null),
       },
       installmentSchedule: {
+        // Lazy-gen recovery (#1170): count>0 → ensureInstallmentSchedules no-op.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
         findUnique: jest.fn().mockResolvedValue(null), // template call skipped
       },
       callLog: {

--- a/apps/api/src/modules/payments/payments.service.advance.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.advance.spec.ts
@@ -135,6 +135,9 @@ describe('PaymentsService — advance balance (Task 4)', () => {
         findUnique: jest.fn().mockResolvedValue(null), // no period lock, no late-fee config
       },
       installmentSchedule: {
+        // Lazy-gen recovery (#1170): count>0 → ensureInstallmentSchedules no-op.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
         findUnique: jest.fn().mockResolvedValue(null), // template call skipped (instSched=null)
       },
       callLog: {

--- a/apps/api/src/modules/payments/payments.service.late-fee.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.late-fee.spec.ts
@@ -150,6 +150,9 @@ describe('PaymentsService — real-time late fee on payment', () => {
           }),
       },
       installmentSchedule: {
+        // Lazy-gen recovery (#1170): count>0 → ensureInstallmentSchedules no-op.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
         // Return a schedule so PaymentReceiptTemplate.execute is invoked and
         // we can capture the forwarded lateFee.
         findUnique: jest.fn().mockResolvedValue({ id: 'lf-sched-1' }),

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -60,6 +60,16 @@ describe('PaymentsService', () => {
         findUnique: jest.fn().mockResolvedValue(mockContract),
         findFirst: jest.fn().mockResolvedValue(mockContract),
         update: jest.fn().mockResolvedValue(mockContract),
+        // Used by ensureInstallmentSchedules only when the schedule is missing.
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: 'contract-1',
+          totalMonths: 12,
+          financedAmount: 10000,
+          interestTotal: 1190,
+          monthlyPayment: '1515.83',
+          paymentDueDay: 5,
+          createdAt: new Date(2026, 0, 10),
+        }),
       },
       payment: {
         findFirst: jest.fn().mockResolvedValue(mockPayment),
@@ -96,6 +106,10 @@ describe('PaymentsService', () => {
       },
       installmentSchedule: {
         findUnique: jest.fn().mockResolvedValue(null),
+        // `count`>0 => ensureInstallmentSchedules is a no-op (post-#753 default);
+        // `createMany` backs the lazy-gen recovery path.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
       // recordPayment auto-cancels active partial-payment QRs to prevent double-pay
       partialPaymentLink: {
@@ -308,16 +322,62 @@ describe('PaymentsService', () => {
       // primitive inside the $transaction (installmentScheduleId + paymentId + delta).
       const updatedPayment = { ...mockPayment, id: 'payment-1', amountPaid: 3000, status: 'PAID', paidDate: new Date() };
       prisma.payment.update.mockResolvedValue(updatedPayment);
+      // Schedule exists (post-#753 happy path) → 2B receipt JE must post.
+      prisma.installmentSchedule.findUnique.mockResolvedValue({ id: 'inst-sched-1' });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const templateMock = (service as any).paymentReceiptTemplate;
 
       await service.recordPayment('contract-1', 1, 3000, 'CASH', 'user-1', 'http://slip.jpg');
 
-      // InstallmentSchedule mock returns null → primitive.execute is NOT called (skipped path,
-      // logged as warn). This test verifies recordPayment succeeds without error.
       expect(updatedPayment.status).toBe('PAID');
+      // PAID-no-JE fix: a full payment ALWAYS posts the 2B receipt JE — no orphan.
+      expect(templateMock.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('PAID-no-JE: lazy-generates the schedule for a legacy contract then posts the 2B JE', async () => {
+      const updatedPayment = { ...mockPayment, id: 'payment-1', amountPaid: 3000, status: 'PAID', paidDate: new Date() };
+      prisma.payment.update.mockResolvedValue(updatedPayment);
+      // Legacy pre-#753 contract: no schedule rows yet → ensure generates in-tx.
+      prisma.installmentSchedule.count.mockResolvedValueOnce(0);
+      // After generation the lookup finds the row → receipt JE posts.
+      prisma.installmentSchedule.findUnique.mockResolvedValue({ id: 'inst-sched-1' });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const templateMock = (service as any).paymentReceiptTemplate;
+
+      await service.recordPayment('contract-1', 1, 3000, 'CASH', 'user-1', 'http://slip.jpg');
+
+      expect(prisma.installmentSchedule.createMany).toHaveBeenCalledTimes(1);
+      expect(templateMock.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('PAID-no-JE: alarms via Sentry (keeps PAID, no rollback) when the schedule is unpostable', async () => {
+      (Sentry.captureException as jest.Mock).mockClear();
+      const updatedPayment = { ...mockPayment, id: 'payment-1', amountPaid: 3000, status: 'PAID', paidDate: new Date() };
+      prisma.payment.update.mockResolvedValue(updatedPayment);
+      // Data anomaly: no rows AND ungeneratable (totalMonths=0); lookup stays null.
+      prisma.installmentSchedule.count.mockResolvedValueOnce(0);
+      prisma.contract.findUniqueOrThrow.mockResolvedValueOnce({
+        id: 'contract-1',
+        totalMonths: 0,
+        financedAmount: 0,
+        interestTotal: null,
+        monthlyPayment: null,
+        paymentDueDay: null,
+        createdAt: new Date(2026, 0, 10),
+      });
+      prisma.installmentSchedule.findUnique.mockResolvedValue(null);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const templateMock = (service as any).paymentReceiptTemplate;
+
+      // Does not throw — the payment is real and stays PAID.
+      await service.recordPayment('contract-1', 1, 3000, 'CASH', 'user-1', 'http://slip.jpg');
+
+      expect(prisma.installmentSchedule.createMany).not.toHaveBeenCalled();
       expect(templateMock.execute).not.toHaveBeenCalled();
+      expect(Sentry.captureException as jest.Mock).toHaveBeenCalled();
     });
 
     it('C1 fix: forwards computed lateFee to PaymentReceiptTemplate primitive (Cr 42-1103)', async () => {

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -1272,6 +1272,10 @@ export class PaymentsService {
         // find this JE via metadata.paymentId), and reconstructPrior now counts a
         // credit application as prior-cleared for any subsequent receipt.
         if (payAmount.gt(0)) {
+          // Lazy-gen schedule for legacy (pre-#753) contracts so the credit
+          // receipt JE can post — prevents an orphan applied-credit-without-ledger
+          // row. Idempotent: a no-op when rows already exist. Same serializable tx.
+          await ensureInstallmentSchedules(tx, contract.id);
           const instSched = await tx.installmentSchedule.findUnique({
             where: {
               contractId_installmentNo: {
@@ -1306,8 +1310,24 @@ export class PaymentsService {
               await this.vat60Reversal.execute(instSched.id, tx);
             }
           } else {
-            this.logger.warn(
-              `PaymentReceipt skipped (credit) — no InstallmentSchedule for contractId=${contract.id} installmentNo=${updated.installmentNo}`,
+            // Genuine data anomaly even after lazy-gen — alarm, never silently
+            // skip an applied-credit installment's ledger entry. Payment stays PAID.
+            Sentry.captureException(
+              new Error(
+                'Applied-credit installment has no postable 2B JE (credit; no InstallmentSchedule after lazy-gen)',
+              ),
+              {
+                level: 'error',
+                tags: { module: 'payments', flow: '2b-receipt-credit' },
+                extra: {
+                  contractId: contract.id,
+                  installmentNo: updated.installmentNo,
+                  paymentId: updated.id,
+                },
+              },
+            );
+            this.logger.error(
+              `PaymentReceipt2B UNPOSTABLE (credit) — no InstallmentSchedule for contractId=${contract.id} installmentNo=${updated.installmentNo} (Sentry-alarmed; manual reconcile needed)`,
             );
           }
         }

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -15,6 +15,7 @@ import { ProductsService } from '../products/products.service';
 import { hasCrossBranchAccess } from '../auth/branch-access.util';
 import { validatePeriodOpen } from '../../utils/period-lock.util';
 import { roundBaht } from '../../utils/installment.util';
+import { ensureInstallmentSchedules } from '../../utils/installment-schedule.util';
 import { BUSINESS_RULES } from '../../utils/config.util';
 import { d, dAdd, dSub, dMul, dRound, dGte } from '../../utils/decimal.util';
 import { LineOaService } from '../line-oa/line-oa.service';
@@ -400,6 +401,10 @@ export class PaymentsService {
       // It runs inside the same $transaction so a JE failure rolls back the
       // Payment.update — no orphan ledger entries.
       if (isPaidInFull || isPartialClear) {
+        // Lazy-gen schedule for legacy (pre-#753) contracts so the 2B receipt
+        // JE can post — prevents an orphan PAID-without-ledger row. Idempotent:
+        // a no-op when rows already exist. Runs inside the same serializable tx.
+        await ensureInstallmentSchedules(tx, contract.id);
         const instSched = await tx.installmentSchedule.findUnique({
           where: {
             contractId_installmentNo: {
@@ -464,8 +469,26 @@ export class PaymentsService {
             throw err;
           }
         } else {
-          this.logger.warn(
-            `PaymentReceipt2B skipped — no InstallmentSchedule found for contractId=${contract.id} installmentNo=${result.installmentNo}. TODO: verify schedule was generated.`,
+          // Even after lazy-gen the row is absent — a genuine data anomaly
+          // (totalMonths<=0, or installmentNo beyond the schedule). Do NOT
+          // silently skip and do NOT roll back the customer's real payment.
+          // Alarm so accounting posts the missing receipt JE manually.
+          Sentry.captureException(
+            new Error(
+              'PAID installment has no postable 2B JE (no InstallmentSchedule after lazy-gen)',
+            ),
+            {
+              level: 'error',
+              tags: { module: 'payments', flow: '2b-receipt' },
+              extra: {
+                contractId: contract.id,
+                installmentNo: result.installmentNo,
+                paymentId: result.id,
+              },
+            },
+          );
+          this.logger.error(
+            `PaymentReceipt2B UNPOSTABLE — no InstallmentSchedule for contractId=${contract.id} installmentNo=${result.installmentNo} (Sentry-alarmed; manual reconcile needed)`,
           );
         }
       }
@@ -712,6 +735,10 @@ export class PaymentsService {
         // No toleranceApproverId is passed here — see the documented Phase-5
         // 2A-trueup-residual seam (auto paths cannot approve a ≤1฿ underpay).
         if (payAmount.gt(0)) {
+          // Lazy-gen schedule for legacy (pre-#753) contracts so the 2B receipt
+          // JE can post — prevents an orphan PAID-without-ledger row. Idempotent:
+          // a no-op when rows already exist. Runs inside the same serializable tx.
+          await ensureInstallmentSchedules(tx, contract.id);
           const instSched = await tx.installmentSchedule.findUnique({
             where: {
               contractId_installmentNo: {
@@ -753,8 +780,24 @@ export class PaymentsService {
               await this.vat60Reversal.execute(instSched.id, tx);
             }
           } else {
-            this.logger.warn(
-              `PaymentReceipt skipped (bulk) — no InstallmentSchedule for contractId=${contract.id} installmentNo=${updated.installmentNo}`,
+            // Genuine data anomaly even after lazy-gen — alarm, never silently
+            // skip a PAID installment's ledger entry. Payment stays PAID.
+            Sentry.captureException(
+              new Error(
+                'PAID installment has no postable 2B JE (bulk; no InstallmentSchedule after lazy-gen)',
+              ),
+              {
+                level: 'error',
+                tags: { module: 'payments', flow: '2b-receipt-bulk' },
+                extra: {
+                  contractId: contract.id,
+                  installmentNo: updated.installmentNo,
+                  paymentId: updated.id,
+                },
+              },
+            );
+            this.logger.error(
+              `PaymentReceipt2B UNPOSTABLE (bulk) — no InstallmentSchedule for contractId=${contract.id} installmentNo=${updated.installmentNo} (Sentry-alarmed; manual reconcile needed)`,
             );
           }
         }

--- a/apps/api/src/modules/paysolutions/paysolutions.callback-money.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.callback-money.spec.ts
@@ -177,6 +177,9 @@ describe('PaySolutionsService.handlePaymentCallback — FIFO money + close (char
           .mockResolvedValue({ productId: opts.contractProductId ?? null }),
       },
       installmentSchedule: {
+        // Lazy-gen recovery (#1170): count>0 → ensureInstallmentSchedules no-op.
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         findUnique: jest.fn().mockImplementation((args: any) => {
           const instNo =

--- a/apps/api/src/modules/paysolutions/paysolutions.service.spec.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.spec.ts
@@ -74,14 +74,29 @@ describe('PaySolutionsService.handlePaymentCallback — payment JE (F-1-003)', (
       },
       contract: {
         update: jest.fn().mockResolvedValue({ productId: null }),
+        // Used by ensureInstallmentSchedules only when the schedule is missing.
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: contractId,
+          totalMonths: 12,
+          financedAmount: new Prisma.Decimal(10000),
+          interestTotal: new Prisma.Decimal(1190),
+          monthlyPayment: new Prisma.Decimal('1515.83'),
+          paymentDueDay: 5,
+          createdAt: new Date(2026, 0, 10),
+        }),
       },
       // C2 fix: in-tx JE post calls tx.installmentSchedule.findUnique to map
       // installmentNo → installmentScheduleId. PR-843/I2 Phase 3 3b: the select
       // now also reads vat60dayJournalEntryId (null here = no 60-day reversal).
+      // `count` + `createMany` back the lazy-gen recovery (ensureInstallmentSchedules);
+      // count>0 => skip generation (the common post-#753 case), so existing
+      // assertions are unaffected.
       installmentSchedule: {
         findUnique: jest
           .fn()
           .mockResolvedValue({ id: 'inst-sched-1', vat60dayJournalEntryId: null }),
+        count: jest.fn().mockResolvedValue(1),
+        createMany: jest.fn().mockResolvedValue({ count: 12 }),
       },
     };
 
@@ -199,6 +214,56 @@ describe('PaySolutionsService.handlePaymentCallback — payment JE (F-1-003)', (
     // Delta is the DELTA applied this webhook (1000), never cumulative.
     const jeInput = paymentReceiptTemplate.execute.mock.calls[0][0];
     expect(jeInput.delta.toString()).toBe('1000');
+  });
+
+  it('lazy-generates the schedule for a legacy contract (no rows) then still posts the 2B JE', async () => {
+    // PAID-no-JE fix: a pre-#753 contract has no installment_schedules. Before
+    // the fix the 2B JE was silently skipped → PAID installment with no ledger.
+    // Now ensureInstallmentSchedules materialises the schedule in-tx first.
+    prisma.__tx.installmentSchedule.count.mockResolvedValueOnce(0);
+
+    await service.handlePaymentCallback({
+      refno: 'refno-1',
+      result_code: '00',
+      order_no: 'order-1',
+      transaction_id: 'tx-1',
+      total: '1000',
+    });
+
+    // Schedule materialised in-tx ...
+    expect(prisma.__tx.installmentSchedule.createMany).toHaveBeenCalledTimes(1);
+    // ... and the receipt JE still posts — no orphan PAID-without-ledger.
+    expect(paymentReceiptTemplate.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('alarms via Sentry (keeps PAID, never rolls back) when the schedule cannot be generated', async () => {
+    (Sentry.captureException as jest.Mock).mockClear();
+    // Data anomaly: no schedule rows AND ungeneratable (totalMonths=0), and the
+    // post-gen lookup still finds nothing → must NOT silently skip the ledger.
+    prisma.__tx.installmentSchedule.count.mockResolvedValueOnce(0);
+    prisma.__tx.contract.findUniqueOrThrow.mockResolvedValueOnce({
+      id: contractId,
+      totalMonths: 0,
+      financedAmount: new Prisma.Decimal(0),
+      interestTotal: null,
+      monthlyPayment: null,
+      paymentDueDay: null,
+      createdAt: new Date(2026, 0, 10),
+    });
+    prisma.__tx.installmentSchedule.findUnique.mockResolvedValueOnce(null);
+
+    // Does not throw — the customer's payment is real and stays PAID.
+    await service.handlePaymentCallback({
+      refno: 'refno-1',
+      result_code: '00',
+      order_no: 'order-1',
+      transaction_id: 'tx-1',
+      total: '1000',
+    });
+
+    expect(prisma.__tx.installmentSchedule.createMany).not.toHaveBeenCalled();
+    expect(paymentReceiptTemplate.execute).not.toHaveBeenCalled();
+    expect(Sentry.captureException as jest.Mock).toHaveBeenCalled();
   });
 
   it('C2 fix: JE failure inside tx rolls back Payment.update — no orphan PAID rows', async () => {

--- a/apps/api/src/modules/paysolutions/paysolutions.service.ts
+++ b/apps/api/src/modules/paysolutions/paysolutions.service.ts
@@ -10,6 +10,7 @@ import {
 import * as Sentry from '@sentry/nestjs';
 import { formatDateLong } from '../../utils/thai-date.util';
 import { dAdd, dSub, dClose } from '../../utils/decimal.util';
+import { ensureInstallmentSchedules } from '../../utils/installment-schedule.util';
 import { OnlineOrderSaleAdapter } from '../shop-orders/online-order-sale.adapter';
 
 // Pay Solutions external API timeout. Their published SLA is "instant"
@@ -1235,6 +1236,17 @@ export class PaySolutionsService {
           // When the installment carried a 60-day mandatory VAT flag, the matching
           // reversal posts in the same tx so 21-2103 / 11-2104 clear 1:1.
           if (contractForJe && systemUserId) {
+            // Legacy contracts activated before PR #753 may have no
+            // installment_schedules rows; without them the receipt JE below
+            // would be silently skipped, leaving a PAID installment with no
+            // ledger entry (TB overstates receivable / understates cash + VAT
+            // under-reported). Lazily materialise the schedule inside this same
+            // serializable tx so the receipt JE can post. Idempotent — a no-op
+            // when rows already exist (the common post-#753 case). Gated on the
+            // loop collection so a no-touch webhook skips the count query.
+            if (touchedSnapshots.length > 0) {
+              await ensureInstallmentSchedules(tx, contractForJe.id);
+            }
             for (const snapshot of touchedSnapshots) {
               const instSchedPs = await tx.installmentSchedule.findUnique({
                 where: {
@@ -1270,8 +1282,28 @@ export class PaySolutionsService {
                   await this.vat60Reversal.execute(instSchedPs.id, tx);
                 }
               } else {
-                this.logger.warn(
-                  `PaySolutions: PaymentReceipt skipped — no InstallmentSchedule for contractId=${contractForJe.id} installmentNo=${snapshot.installmentNo}`,
+                // Even after lazy-gen the row is absent — a genuine data
+                // anomaly (totalMonths<=0, or installmentNo beyond the schedule).
+                // Do NOT silently skip and do NOT roll back: the customer's
+                // payment is real and already PAID; rolling back would discard
+                // it. Alarm loudly so accounting posts the missing receipt JE.
+                Sentry.captureException(
+                  new Error(
+                    'PAID installment has no postable 2B JE (no InstallmentSchedule after lazy-gen)',
+                  ),
+                  {
+                    level: 'error',
+                    tags: { module: 'paysolutions', flow: '2b-receipt' },
+                    extra: {
+                      contractId: contractForJe.id,
+                      installmentNo: snapshot.installmentNo,
+                      paymentId: snapshot.id,
+                      refno,
+                    },
+                  },
+                );
+                this.logger.error(
+                  `PaySolutions: PaymentReceipt2B UNPOSTABLE — no InstallmentSchedule for contractId=${contractForJe.id} installmentNo=${snapshot.installmentNo} (Sentry-alarmed; manual reconcile needed)`,
                 );
               }
             }

--- a/apps/api/src/utils/installment-schedule.util.spec.ts
+++ b/apps/api/src/utils/installment-schedule.util.spec.ts
@@ -1,0 +1,120 @@
+import { Prisma } from '@prisma/client';
+import {
+  buildInstallmentScheduleRows,
+  ensureInstallmentSchedules,
+  ScheduleSourceContract,
+} from './installment-schedule.util';
+
+describe('installment-schedule.util', () => {
+  describe('buildInstallmentScheduleRows', () => {
+    const base: ScheduleSourceContract = {
+      id: 'c1',
+      totalMonths: 12,
+      financedAmount: 17000,
+      interestTotal: 1190,
+      monthlyPayment: '1515.83',
+      paymentDueDay: 5,
+      createdAt: new Date(2026, 0, 10), // 2026-01-10 (local)
+    };
+
+    it('matches the CPA rounding golden values (17000/12 ROUND_DOWN, 1190/12 ROUND_HALF_UP)', () => {
+      const rows = buildInstallmentScheduleRows(base);
+      expect(rows).toHaveLength(12);
+      // principal = 17000/12 = 1416.6666… → ROUND_DOWN → 1416.66
+      expect(new Prisma.Decimal(rows[0].principal as Prisma.Decimal).toString()).toBe('1416.66');
+      // interest = 1190/12 = 99.1666… → ROUND_HALF_UP → 99.17
+      expect(new Prisma.Decimal(rows[0].interest as Prisma.Decimal).toString()).toBe('99.17');
+      // amountDue = monthlyPayment (incl VAT)
+      expect(new Prisma.Decimal(rows[0].amountDue as Prisma.Decimal).toString()).toBe('1515.83');
+      // every installment shares the same per-installment values
+      expect(new Prisma.Decimal(rows[11].principal as Prisma.Decimal).toString()).toBe('1416.66');
+    });
+
+    it('numbers installments 1..N and steps due dates by month on paymentDueDay', () => {
+      const rows = buildInstallmentScheduleRows(base);
+      expect(rows[0].installmentNo).toBe(1);
+      expect(rows[11].installmentNo).toBe(12);
+      // i=1 → 2026-02-05, i=12 → 2027-01-05 (JS Date month overflow normalises)
+      expect(rows[0].dueDate).toEqual(new Date(2026, 1, 5));
+      expect(rows[11].dueDate).toEqual(new Date(2027, 0, 5));
+    });
+
+    it('falls back to createdAt day-of-month when paymentDueDay is null', () => {
+      const rows = buildInstallmentScheduleRows({ ...base, paymentDueDay: null });
+      expect(rows[0].dueDate).toEqual(new Date(2026, 1, 10));
+    });
+
+    it('treats null interestTotal / monthlyPayment as zero', () => {
+      const rows = buildInstallmentScheduleRows({
+        ...base,
+        interestTotal: null,
+        monthlyPayment: null,
+      });
+      expect(new Prisma.Decimal(rows[0].interest as Prisma.Decimal).toString()).toBe('0');
+      expect(new Prisma.Decimal(rows[0].amountDue as Prisma.Decimal).toString()).toBe('0');
+    });
+
+    it('returns [] for a non-positive totalMonths (cannot divide)', () => {
+      expect(buildInstallmentScheduleRows({ ...base, totalMonths: 0 })).toEqual([]);
+      expect(buildInstallmentScheduleRows({ ...base, totalMonths: -3 })).toEqual([]);
+    });
+
+    it('accepts Prisma.Decimal money inputs (not just numbers/strings)', () => {
+      const rows = buildInstallmentScheduleRows({
+        ...base,
+        financedAmount: new Prisma.Decimal('17000'),
+        interestTotal: new Prisma.Decimal('1190'),
+      });
+      expect(new Prisma.Decimal(rows[0].principal as Prisma.Decimal).toString()).toBe('1416.66');
+    });
+  });
+
+  describe('ensureInstallmentSchedules', () => {
+    function mockTx(opts: { existingCount: number; contract?: Partial<ScheduleSourceContract> }) {
+      const createMany = jest.fn().mockResolvedValue({ count: 0 });
+      const tx = {
+        installmentSchedule: {
+          count: jest.fn().mockResolvedValue(opts.existingCount),
+          createMany,
+        },
+        contract: {
+          findUniqueOrThrow: jest.fn().mockResolvedValue({
+            id: 'c1',
+            totalMonths: 12,
+            financedAmount: new Prisma.Decimal('17000'),
+            interestTotal: new Prisma.Decimal('1190'),
+            monthlyPayment: new Prisma.Decimal('1515.83'),
+            paymentDueDay: 5,
+            createdAt: new Date(2026, 0, 10),
+            ...opts.contract,
+          }),
+        },
+      };
+      return { tx, createMany };
+    }
+
+    it('skips generation (idempotent) when schedule rows already exist', async () => {
+      const { tx, createMany } = mockTx({ existingCount: 12 });
+      const res = await ensureInstallmentSchedules(tx as never, 'c1');
+      expect(res).toEqual({ generated: 0 });
+      expect(tx.contract.findUniqueOrThrow).not.toHaveBeenCalled();
+      expect(createMany).not.toHaveBeenCalled();
+    });
+
+    it('generates N rows when none exist yet', async () => {
+      const { tx, createMany } = mockTx({ existingCount: 0 });
+      const res = await ensureInstallmentSchedules(tx as never, 'c1');
+      expect(res).toEqual({ generated: 12 });
+      expect(createMany).toHaveBeenCalledTimes(1);
+      const arg = createMany.mock.calls[0][0] as { data: unknown[] };
+      expect(arg.data).toHaveLength(12);
+    });
+
+    it('does not generate when the contract has totalMonths <= 0', async () => {
+      const { tx, createMany } = mockTx({ existingCount: 0, contract: { totalMonths: 0 } });
+      const res = await ensureInstallmentSchedules(tx as never, 'c1');
+      expect(res).toEqual({ generated: 0 });
+      expect(createMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/utils/installment-schedule.util.ts
+++ b/apps/api/src/utils/installment-schedule.util.ts
@@ -1,0 +1,104 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Single source of truth for `installment_schedules` row generation.
+ *
+ * The exact per-installment values + rounding modes below MUST match the CPA
+ * 2A/2B journal templates (see `.claude/rules/accounting.md` → Rounding Modes),
+ * otherwise the receipt JE base diverges from the schedule and golden fixtures
+ * fail:
+ *   principal = financedAmount / totalMonths  (ROUND_DOWN truncate)
+ *   interest  = interestTotal  / totalMonths  (ROUND_HALF_UP)
+ *   amountDue = monthlyPayment (incl. VAT)
+ *   dueDate   = createdAt month + i, on paymentDueDay (default = createdAt day)
+ *
+ * Historically this algorithm was copy-pasted in three places
+ * (contract-workflow activation, the backfill CLI, and the lazy-gen recovery
+ * path). They are now consolidated here so the schedule is identical no matter
+ * which flow first materialises it.
+ */
+export interface ScheduleSourceContract {
+  id: string;
+  totalMonths: number;
+  financedAmount: Prisma.Decimal | string | number;
+  interestTotal: Prisma.Decimal | string | number | null;
+  monthlyPayment: Prisma.Decimal | string | number | null;
+  paymentDueDay: number | null;
+  createdAt: Date;
+}
+
+export function buildInstallmentScheduleRows(
+  c: ScheduleSourceContract,
+): Prisma.InstallmentScheduleCreateManyInput[] {
+  if (c.totalMonths <= 0) return [];
+
+  const financed = new Prisma.Decimal(c.financedAmount.toString());
+  const interest = new Prisma.Decimal((c.interestTotal ?? 0).toString());
+  const monthly = new Prisma.Decimal((c.monthlyPayment ?? 0).toString());
+  const principalPerInst = financed
+    .div(c.totalMonths)
+    .toDecimalPlaces(2, Prisma.Decimal.ROUND_DOWN);
+  const interestPerInst = interest
+    .div(c.totalMonths)
+    .toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
+
+  const baseDate = c.createdAt;
+  const dueDay = c.paymentDueDay ?? baseDate.getDate();
+
+  const rows: Prisma.InstallmentScheduleCreateManyInput[] = [];
+  for (let i = 1; i <= c.totalMonths; i++) {
+    const dueDate = new Date(baseDate.getFullYear(), baseDate.getMonth() + i, dueDay);
+    rows.push({
+      contractId: c.id,
+      installmentNo: i,
+      dueDate,
+      principal: principalPerInst,
+      interest: interestPerInst,
+      amountDue: monthly,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Idempotent in-transaction ensure: generates the contract's
+ * `installment_schedules` rows if (and only if) none exist yet. Safe to call
+ * from any flow — activation, payment-receipt recovery, or backfill — because
+ * it short-circuits when rows are already present (`count > 0`).
+ *
+ * Returns the number of rows generated (0 = already existed, or ungeneratable
+ * because `totalMonths <= 0`). The caller must re-query the schedule after this
+ * returns; this helper deliberately does not return the rows so the caller's
+ * existing lookup remains the source of truth inside its own transaction.
+ *
+ * MUST be passed a transaction client so the generation is atomic with the
+ * caller's financial write (e.g. the PAID flip + receipt JE).
+ */
+export async function ensureInstallmentSchedules(
+  tx: Prisma.TransactionClient,
+  contractId: string,
+): Promise<{ generated: number }> {
+  const existing = await tx.installmentSchedule.count({
+    where: { contractId, deletedAt: null },
+  });
+  if (existing > 0) return { generated: 0 };
+
+  const c = await tx.contract.findUniqueOrThrow({
+    where: { id: contractId },
+    select: {
+      id: true,
+      totalMonths: true,
+      financedAmount: true,
+      interestTotal: true,
+      monthlyPayment: true,
+      paymentDueDay: true,
+      createdAt: true,
+    },
+  });
+
+  const rows = buildInstallmentScheduleRows(c);
+  if (rows.length === 0) return { generated: 0 };
+
+  await tx.installmentSchedule.createMany({ data: rows });
+  return { generated: rows.length };
+}


### PR DESCRIPTION
**Finding:** PAID-installment-without-2B-JE orphan (residual triage #1 — REAL/LIVE/High).

Legacy contracts activated before #753 have no `installment_schedules`. When such an installment was paid (QR webhook / manual / bulk), the 2B receipt JE lookup found no schedule and **silently skipped** the JE (logger.warn) — leaving the Payment PAID with no ledger entry: Trial Balance overstates 11-2101 / understates cash, VAT output reclass (21-2102→21-2101) never posts → **ภ.พ.30 under-reported**; a final installment could close the contract COMPLETED with a permanently missing receipt JE.

**Fix:** shared `installment-schedule.util` (one source of truth — contract-workflow activation + backfill CLI now delegate); lazy-generate the schedule **in-tx** before the 2B JE at all 3 sites; on a genuine anomaly (ungeneratable) `Sentry.captureException` + **keep PAID** (no throw — a rollback would discard a real customer payment).

**Verify:** adversarial pass → SOLID/SHIP. Refactor proven behavior-identical; lazy-gen idempotent + inside the existing serializable tx + paymentLink claim (no double-post). util(9) + paysolutions(+2) + payments(+2, fixed an anti-test) green; tsc + eslint clean.

⚠️ **ACCOUNTANT SIGN-OFF — do NOT merge yet:**
- Run the prod SQL (Q1/Q2) to size already-orphaned PAID rows → a **separate follow-up** (reconcile-sweep CLI + 2B `metadata.flow/idempotencyKey`) handles those + ภ.พ.30 amendment.
- Known latent edge (cannot fire today): if a schedule row were ever soft-deleted, `ensureInstallmentSchedules` count→0 would hit the unique index — no live code soft-deletes schedules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)