### PR TITLE
fix(migration): wrap importContracts row writes in a per-row $transaction (#17)

### DIFF
--- a/apps/api/src/modules/migration/migration.service.spec.ts
+++ b/apps/api/src/modules/migration/migration.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test } from '@nestjs/testing';
+import { MigrationService } from './migration.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ImportContractDto } from './dto/import.dto';
+
+/**
+ * #17 — importContracts must write Product + Contract + Payments atomically
+ * per row, so a mid-row failure leaves no orphan Product / Contract / partial
+ * schedule. These tests assert the writes go through a single $transaction
+ * (the tx client), not this.prisma directly.
+ */
+describe('MigrationService.importContracts — per-row atomicity (#17)', () => {
+  let service: MigrationService;
+  let prisma: any;
+  let txClient: any;
+
+  const dto: ImportContractDto = {
+    customerNationalId: '1234567890123',
+    productName: 'iPhone 13',
+    branchName: 'สาขาหลัก',
+    salespersonEmail: 'sales@bestchoice.com',
+    sellingPrice: 10000,
+    downPayment: 1000,
+    interestRate: 0.1,
+    totalMonths: 12,
+    status: 'ACTIVE',
+  } as ImportContractDto;
+
+  beforeEach(async () => {
+    txClient = {
+      product: { create: jest.fn().mockResolvedValue({ id: 'prod-1' }) },
+      contract: {
+        create: jest.fn().mockResolvedValue({ id: 'ct-1' }),
+        findFirst: jest.fn().mockResolvedValue(null), // generateContractNumber lookup
+      },
+      payment: {
+        create: jest.fn().mockResolvedValue({}),
+        createMany: jest.fn().mockResolvedValue({ count: 12 }),
+      },
+    };
+
+    prisma = {
+      customer: { findUnique: jest.fn().mockResolvedValue({ id: 'cust-1' }) },
+      branch: { findFirst: jest.fn().mockResolvedValue({ id: 'br-1' }) },
+      user: { findFirst: jest.fn().mockResolvedValue({ id: 'sales-1' }) },
+      $transaction: jest.fn(async (cb: any) => cb(txClient)),
+      // Direct (non-tx) write methods — these MUST NOT be used (would orphan).
+      product: { create: jest.fn() },
+      contract: { create: jest.fn(), findFirst: jest.fn() },
+      payment: { create: jest.fn(), createMany: jest.fn() },
+    };
+
+    const mod = await Test.createTestingModule({
+      providers: [MigrationService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+    service = mod.get(MigrationService);
+  });
+
+  it('commits a row through a single $transaction (writes use the tx client, not this.prisma)', async () => {
+    const res = await service.importContracts([dto]);
+
+    expect(res.success).toBe(1);
+    expect(res.failed).toBe(0);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    // All writes went through the tx client...
+    expect(txClient.product.create).toHaveBeenCalledTimes(1);
+    expect(txClient.contract.create).toHaveBeenCalledTimes(1);
+    expect(txClient.payment.createMany).toHaveBeenCalledTimes(1); // no payments[] → auto-gen
+    // ...never via the bare prisma client (which would not roll back).
+    expect(prisma.product.create).not.toHaveBeenCalled();
+    expect(prisma.contract.create).not.toHaveBeenCalled();
+  });
+
+  it('rolls the whole row back (failed++, error captured) when a write inside the tx throws', async () => {
+    txClient.contract.create.mockRejectedValueOnce(new Error('FK violation'));
+
+    const res = await service.importContracts([dto]);
+
+    expect(res.success).toBe(0);
+    expect(res.failed).toBe(1);
+    expect(res.errors[0].message).toMatch(/FK violation/);
+    // The product.create that preceded the failure was on the tx client, so a
+    // real DB rolls it back — no orphan leaks via the bare prisma client.
+    expect(prisma.product.create).not.toHaveBeenCalled();
+  });
+
+  it('uses one $transaction PER ROW (not a single tx around the whole import)', async () => {
+    const res = await service.importContracts([dto, { ...dto }, { ...dto }]);
+    expect(res.success).toBe(3);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/api/src/modules/migration/migration.service.ts
+++ b/apps/api/src/modules/migration/migration.service.ts
@@ -141,79 +141,91 @@ export class MigrationService {
           continue;
         }
 
-        // Create a placeholder product for imported contracts
-        const product = await this.prisma.product.create({
-          data: {
-            name: c.productName,
-            brand: 'Imported',
-            model: c.productName,
-            category: 'PHONE_USED',
-            costPrice: 0,
-            branchId: branch.id,
-            status: 'SOLD_INSTALLMENT',
-          },
-        });
-
-        // Generate contract number
-        const contractNumber = await generateContractNumber(this.prisma);
-
-        // Calculate financials
+        // Calculate financials (pure arithmetic — outside the tx)
         const principal = c.sellingPrice - c.downPayment;
         const interestTotal = principal * c.interestRate * c.totalMonths;
         const financedAmount = principal + interestTotal;
         const monthlyPayment = financedAmount / c.totalMonths;
 
-        const contract = await this.prisma.contract.create({
-          data: {
-            contractNumber,
-            customerId: customer.id,
-            productId: product.id,
-            branchId: branch.id,
-            salespersonId: salesperson.id,
-            planType: 'STORE_DIRECT',
-            sellingPrice: c.sellingPrice,
-            downPayment: c.downPayment,
-            interestRate: c.interestRate,
-            totalMonths: c.totalMonths,
-            interestTotal,
-            financedAmount,
-            monthlyPayment,
-            status: c.status as 'ACTIVE' | 'OVERDUE' | 'COMPLETED',
-            createdAt: c.createdAt ? new Date(c.createdAt) : undefined,
-          },
-        });
+        // Per-row atomicity: Product + Contract + Payments commit together or
+        // not at all, so a failure mid-row leaves NO orphan Product (status
+        // SOLD_INSTALLMENT) or Contract with a missing/partial payment schedule,
+        // and no burnt contract-number sequence. Deliberately PER-ROW, not one
+        // tx around the whole import: a multi-thousand-row historical import in
+        // a single tx would hold one connection + locks for the entire run
+        // (timeout/lock-contention risk) and turn one bad row into an
+        // all-or-nothing rollback, destroying the per-row success/failed
+        // reporting this method promises.
+        await this.prisma.$transaction(async (tx) => {
+          // Placeholder product for the imported contract
+          const product = await tx.product.create({
+            data: {
+              name: c.productName,
+              brand: 'Imported',
+              model: c.productName,
+              category: 'PHONE_USED',
+              costPrice: 0,
+              branchId: branch.id,
+              status: 'SOLD_INSTALLMENT',
+            },
+          });
 
-        // Create payment schedule
-        if (c.payments && c.payments.length > 0) {
-          for (const p of c.payments) {
-            await this.prisma.payment.create({
-              data: {
+          // Generate on the tx client so the sequence read rolls back with the
+          // row if a later write fails.
+          const contractNumber = await generateContractNumber(tx);
+
+          const contract = await tx.contract.create({
+            data: {
+              contractNumber,
+              customerId: customer.id,
+              productId: product.id,
+              branchId: branch.id,
+              salespersonId: salesperson.id,
+              planType: 'STORE_DIRECT',
+              sellingPrice: c.sellingPrice,
+              downPayment: c.downPayment,
+              interestRate: c.interestRate,
+              totalMonths: c.totalMonths,
+              interestTotal,
+              financedAmount,
+              monthlyPayment,
+              status: c.status as 'ACTIVE' | 'OVERDUE' | 'COMPLETED',
+              createdAt: c.createdAt ? new Date(c.createdAt) : undefined,
+            },
+          });
+
+          // Create payment schedule
+          if (c.payments && c.payments.length > 0) {
+            for (const p of c.payments) {
+              await tx.payment.create({
+                data: {
+                  contractId: contract.id,
+                  installmentNo: p.installmentNo,
+                  dueDate: new Date(p.dueDate),
+                  amountDue: p.amountDue,
+                  amountPaid: p.amountPaid,
+                  status: p.status as 'PENDING' | 'PAID' | 'PARTIALLY_PAID' | 'OVERDUE',
+                  paidDate: p.paidDate ? new Date(p.paidDate) : null,
+                },
+              });
+            }
+          } else {
+            // Auto-generate payment schedule
+            const createdAt = c.createdAt ? new Date(c.createdAt) : new Date();
+            const payments: { contractId: string; installmentNo: number; dueDate: Date; amountDue: number; status: 'PENDING' }[] = [];
+            for (let m = 1; m <= c.totalMonths; m++) {
+              const dueDate = new Date(createdAt.getFullYear(), createdAt.getMonth() + m, 1);
+              payments.push({
                 contractId: contract.id,
-                installmentNo: p.installmentNo,
-                dueDate: new Date(p.dueDate),
-                amountDue: p.amountDue,
-                amountPaid: p.amountPaid,
-                status: p.status as 'PENDING' | 'PAID' | 'PARTIALLY_PAID' | 'OVERDUE',
-                paidDate: p.paidDate ? new Date(p.paidDate) : null,
-              },
-            });
+                installmentNo: m,
+                dueDate,
+                amountDue: monthlyPayment,
+                status: 'PENDING' as const,
+              });
+            }
+            await tx.payment.createMany({ data: payments });
           }
-        } else {
-          // Auto-generate payment schedule
-          const createdAt = c.createdAt ? new Date(c.createdAt) : new Date();
-          const payments: { contractId: string; installmentNo: number; dueDate: Date; amountDue: number; status: 'PENDING' }[] = [];
-          for (let m = 1; m <= c.totalMonths; m++) {
-            const dueDate = new Date(createdAt.getFullYear(), createdAt.getMonth() + m, 1);
-            payments.push({
-              contractId: contract.id,
-              installmentNo: m,
-              dueDate,
-              amountDue: monthlyPayment,
-              status: 'PENDING' as const,
-            });
-          }
-          await this.prisma.payment.createMany({ data: payments });
-        }
+        });
 
         result.success++;
       } catch (err) {


### PR DESCRIPTION
**Finding #17 (REAL/LIVE — OWNER import tool):** `importContracts` wrote Product + contract-number + Contract + payments non-transactionally; a mid-row failure left an orphan Product (SOLD_INSTALLMENT) + a Contract with a missing/partial schedule + a burnt sequence. The try/catch only logged.

**Fix:** per-row `$transaction` (NOT one giant tx — preserves per-row success/failed reporting + avoids holding a connection for the whole import); `generateContractNumber(tx)` so its sequence read rolls back with the row; lookups stay outside. Money-on-`number`→Decimal deliberately **not** bundled (separately accountant-gated).

**Verify:** adversarial pass → SOLID/SHIP. Per-row confirmed; tx client threaded; lookups outside; no Decimal bundling. New atomicity spec (3) green; tsc + eslint clean.

Safe behavior change (rows that half-committed now roll back + report failed). Mergeable after a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)