### PR TITLE
fix(journal): atomic outbox claim + DB-attempts finality + reconcile spec (#6)

### DIFF
--- a/apps/api/src/modules/journal/outbox-processor.service.spec.ts
+++ b/apps/api/src/modules/journal/outbox-processor.service.spec.ts
@@ -10,7 +10,7 @@ describe('OutboxProcessorService.processOutbox', () => {
   beforeEach(() => {
     outboxMock = {
       findPending: jest.fn(),
-      markProcessing: jest.fn(),
+      claimPending: jest.fn(),
       markProcessed: jest.fn(),
       markFailed: jest.fn(),
     };
@@ -20,22 +20,10 @@ describe('OutboxProcessorService.processOutbox', () => {
 
   it('processes pending events successfully (stub flow)', async () => {
     outboxMock.findPending.mockResolvedValue([
-      {
-        id: 'e1',
-        flowType: 'CONTRACT_ACTIVATION',
-        payload: {},
-        attempts: 0,
-        idempotencyKey: 'k1',
-      },
-      {
-        id: 'e2',
-        flowType: 'PAYMENT_RECEIPT',
-        payload: {},
-        attempts: 0,
-        idempotencyKey: 'k2',
-      },
+      { id: 'e1', flowType: 'CONTRACT_ACTIVATION', payload: {}, attempts: 0, idempotencyKey: 'k1' },
+      { id: 'e2', flowType: 'PAYMENT_RECEIPT', payload: {}, attempts: 0, idempotencyKey: 'k2' },
     ]);
-    outboxMock.markProcessing.mockResolvedValue({});
+    outboxMock.claimPending.mockResolvedValue({ claimed: true, attempts: 1 });
     outboxMock.markProcessed.mockResolvedValue({});
 
     const result = await svc.processOutbox(10);
@@ -44,37 +32,56 @@ describe('OutboxProcessorService.processOutbox', () => {
     expect(outboxMock.markProcessed).toHaveBeenCalledTimes(2);
   });
 
-  it('marks event PENDING for retry on transient failure (attempts < 5)', async () => {
+  it('skips an event whose atomic claim was lost to another worker (no double-process)', async () => {
     outboxMock.findPending.mockResolvedValue([
-      {
-        id: 'e1',
-        flowType: 'CONTRACT_ACTIVATION',
-        payload: {},
-        attempts: 2,
-        idempotencyKey: 'k1',
-      },
+      { id: 'e1', flowType: 'CONTRACT_ACTIVATION', payload: {}, attempts: 0, idempotencyKey: 'k1' },
     ]);
-    outboxMock.markProcessing.mockRejectedValue(new Error('transient'));
+    // Another tick/pod already claimed it → count 0 → claimed:false.
+    outboxMock.claimPending.mockResolvedValue({ claimed: false, attempts: 0 });
+
+    const result = await svc.processOutbox(10);
+    expect(result.processed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(outboxMock.markProcessed).not.toHaveBeenCalled();
+    expect(outboxMock.markFailed).not.toHaveBeenCalled();
+  });
+
+  it('marks event PENDING for retry on transient failure, using the DB attempts (not the stale in-memory value)', async () => {
+    // In-memory event.attempts=4 would compute isFinal via the OLD `event.attempts+1=5` path.
+    // The DB-persisted post-claim attempts is 2 → finality must be driven off THAT (not final).
+    outboxMock.findPending.mockResolvedValue([
+      { id: 'e1', flowType: 'CONTRACT_ACTIVATION', payload: {}, attempts: 4, idempotencyKey: 'k1' },
+    ]);
+    outboxMock.claimPending.mockResolvedValue({ claimed: true, attempts: 2 });
+    jest.spyOn(svc as never, 'writeFinanceJournal').mockRejectedValue(new Error('transient') as never);
 
     const result = await svc.processOutbox(10);
     expect(result.failed).toBe(1);
     expect(outboxMock.markFailed).toHaveBeenCalledWith('e1', 'transient', false);
   });
 
-  it('marks event FAILED on final failure (attempts >= 5)', async () => {
+  it('marks event FAILED on final failure when DB attempts reaches the limit', async () => {
     outboxMock.findPending.mockResolvedValue([
-      {
-        id: 'e1',
-        flowType: 'CONTRACT_ACTIVATION',
-        payload: {},
-        attempts: 4,
-        idempotencyKey: 'k1',
-      },
+      { id: 'e1', flowType: 'CONTRACT_ACTIVATION', payload: {}, attempts: 0, idempotencyKey: 'k1' },
     ]);
-    outboxMock.markProcessing.mockRejectedValue(new Error('permanent'));
+    outboxMock.claimPending.mockResolvedValue({ claimed: true, attempts: 5 });
+    jest.spyOn(svc as never, 'writeFinanceJournal').mockRejectedValue(new Error('permanent') as never);
 
     const result = await svc.processOutbox(10);
     expect(result.failed).toBe(1);
     expect(outboxMock.markFailed).toHaveBeenCalledWith('e1', 'permanent', true);
+  });
+
+  it('counts a claim DB error as a transient failure and does not process the row', async () => {
+    outboxMock.findPending.mockResolvedValue([
+      { id: 'e1', flowType: 'CONTRACT_ACTIVATION', payload: {}, attempts: 0, idempotencyKey: 'k1' },
+    ]);
+    outboxMock.claimPending.mockRejectedValue(new Error('DB down'));
+
+    const result = await svc.processOutbox(10);
+    expect(result.processed).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(outboxMock.markProcessed).not.toHaveBeenCalled();
+    expect(outboxMock.markFailed).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/journal/outbox-processor.service.ts
+++ b/apps/api/src/modules/journal/outbox-processor.service.ts
@@ -31,14 +31,29 @@ export class OutboxProcessorService {
     let failed = 0;
 
     for (const event of events) {
+      // Atomic claim: only one overlapping tick/pod wins the PENDING→PROCESSING
+      // transition. A lost claim (count 0) means another worker already took
+      // this row — skip it (do NOT proceed to writeFinanceJournal).
+      let claim: { claimed: boolean; attempts: number };
       try {
-        await this.outbox.markProcessing(event.id);
+        claim = await this.outbox.claimPending(event.id);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`Outbox event ${event.id} claim failed (transient): ${msg}`);
+        failed++;
+        continue;
+      }
+      if (!claim.claimed) continue;
+
+      try {
         await this.writeFinanceJournal(event);
         await this.outbox.markProcessed(event.id);
         processed++;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        const attemptsAfter = event.attempts + 1;
+        // Finality from the DB-persisted attempts (post-claim increment), NOT a
+        // stale in-memory `event.attempts + 1`.
+        const attemptsAfter = claim.attempts;
         const isFinal = attemptsAfter >= MAX_ATTEMPTS;
         await this.outbox.markFailed(event.id, msg, isFinal);
 

--- a/apps/api/src/modules/journal/outbox.service.spec.ts
+++ b/apps/api/src/modules/journal/outbox.service.spec.ts
@@ -11,8 +11,10 @@ describe('OutboxService', () => {
       outboxEvent: {
         create: jest.fn(),
         findUniqueOrThrow: jest.fn(),
+        findUnique: jest.fn(),
         findMany: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
       },
     };
     svc = new OutboxService(prismaMock);
@@ -64,6 +66,27 @@ describe('OutboxService', () => {
       take: 10,
     });
     expect(events).toHaveLength(1);
+  });
+
+  it('claimPending wins the row with a status=PENDING guard and returns DB attempts', async () => {
+    prismaMock.outboxEvent.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.outboxEvent.findUnique.mockResolvedValue({ attempts: 3 });
+
+    const res = await svc.claimPending('e1');
+    expect(res).toEqual({ claimed: true, attempts: 3 });
+    expect(prismaMock.outboxEvent.updateMany).toHaveBeenCalledWith({
+      where: { id: 'e1', status: 'PENDING', deletedAt: null },
+      data: { status: 'PROCESSING', attempts: { increment: 1 } },
+    });
+  });
+
+  it('claimPending loses (claimed=false) when another worker already claimed the row', async () => {
+    prismaMock.outboxEvent.updateMany.mockResolvedValue({ count: 0 });
+
+    const res = await svc.claimPending('e1');
+    expect(res).toEqual({ claimed: false, attempts: 0 });
+    // No re-read when the claim was lost.
+    expect(prismaMock.outboxEvent.findUnique).not.toHaveBeenCalled();
   });
 
   it('markFailed with isFinal=true sets status FAILED', async () => {

--- a/apps/api/src/modules/journal/outbox.service.ts
+++ b/apps/api/src/modules/journal/outbox.service.ts
@@ -67,11 +67,29 @@ export class OutboxService {
     });
   }
 
-  async markProcessing(id: string) {
-    return this.prisma.outboxEvent.update({
-      where: { id },
+  /**
+   * Atomically claim a PENDING event for this worker.
+   *
+   * The status='PENDING' guard in the WHERE clause means only ONE overlapping
+   * cron tick / pod can transition a given row PENDING→PROCESSING — the loser's
+   * updateMany matches 0 rows. This replaces the prior bare update-by-id (no
+   * status guard), which let two workers both "claim" the same row and both
+   * proceed (a latent double-post once writeFinanceJournal is wired in SP7.4+).
+   *
+   * Returns the DB-persisted post-increment `attempts` so the caller drives its
+   * finality decision off the source of truth, not a stale in-memory value.
+   */
+  async claimPending(id: string): Promise<{ claimed: boolean; attempts: number }> {
+    const res = await this.prisma.outboxEvent.updateMany({
+      where: { id, status: 'PENDING', deletedAt: null },
       data: { status: 'PROCESSING', attempts: { increment: 1 } },
     });
+    if (res.count === 0) return { claimed: false, attempts: 0 };
+    const row = await this.prisma.outboxEvent.findUnique({
+      where: { id },
+      select: { attempts: true },
+    });
+    return { claimed: true, attempts: row?.attempts ?? 0 };
   }
 
   async markProcessed(id: string) {

--- a/apps/api/src/modules/journal/reconcile.controller.spec.ts
+++ b/apps/api/src/modules/journal/reconcile.controller.spec.ts
@@ -1,0 +1,34 @@
+import { ReconcileController } from './reconcile.controller';
+import { OutboxService } from './outbox.service';
+
+/**
+ * #6c — the OWNER-facing outbox recovery dashboard had zero coverage. retry()
+ * is a state-mutating recovery action on the cross-entity money saga, so it
+ * should at least have a smoke test that pins what it delegates to. The
+ * controller is instantiated directly (guards are request-time concerns, not
+ * under test here).
+ */
+describe('ReconcileController', () => {
+  let controller: ReconcileController;
+  let outbox: { findFailed: jest.Mock; retry: jest.Mock };
+
+  beforeEach(() => {
+    outbox = {
+      findFailed: jest.fn().mockResolvedValue([{ id: 'e1', status: 'FAILED' }]),
+      retry: jest.fn().mockResolvedValue({ id: 'e1', status: 'PENDING', attempts: 0 }),
+    };
+    controller = new ReconcileController(outbox as unknown as OutboxService);
+  });
+
+  it('GET failed → delegates to OutboxService.findFailed', async () => {
+    const res = await controller.listFailed();
+    expect(outbox.findFailed).toHaveBeenCalledTimes(1);
+    expect(res).toEqual([{ id: 'e1', status: 'FAILED' }]);
+  });
+
+  it('POST :id/retry → delegates to OutboxService.retry with the id (resets to PENDING/attempts 0)', async () => {
+    const res = await controller.retry('e1');
+    expect(outbox.retry).toHaveBeenCalledWith('e1');
+    expect(res).toMatchObject({ status: 'PENDING', attempts: 0 });
+  });
+});


### PR DESCRIPTION
**Finding #6 (PARTIALLY_REAL — dormant scaffolding):** the SP7 SHOP↔FINANCE outbox saga had a non-atomic claim (bare update-by-id, no status guard → two ticks/pods both "claim" a row), finality computed from a stale in-memory `attempts`, and an untested OWNER retry endpoint. Currently **dormant** (no producer enqueues, `writeFinanceJournal` is a no-op, bc_finance unprovisioned), so this is preventative hardening before SP7.4 wires real templates.

**Fix:** `claimPending()` = atomic `updateMany WHERE status='PENDING'` (only one worker wins); processOutbox checks the claim + `continue`s on loss before any write; finality from the DB-persisted post-claim `attempts`; claim-DB-error → transient skip; added the reconcile.controller delegation spec. `markFailed` unchanged (still does NOT reset attempts). Idempotency probe **deferred** to SP7.4 (needs the not-yet-built finance JE schema).

**Verify:** adversarial pass → SOLID/SHIP. All traps refuted (no attempts-reset, DB-attempts finality proven by discriminating spec, lost-claim continue). 14 specs green; tsc clean.

⚠️ **OWNER:** ship as pure internal hardening now, or **bundle into SP7.4** when the finance templates land? Your call (no accounting output changes either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)