### PR TITLE
fix(journal): make 2A installment-accrual atomic to stop duplicate accrual JEs

### DIFF
--- a/apps/api/src/modules/journal/cpa-templates/installment-accrual-2a.template.ts
+++ b/apps/api/src/modules/journal/cpa-templates/installment-accrual-2a.template.ts
@@ -63,17 +63,40 @@ export class InstallmentAccrual2ATemplate {
 
   async execute(
     installmentScheduleId: string,
-    tx?: Prisma.TransactionClient,
+    outerTx?: Prisma.TransactionClient,
   ): Promise<{ entryNo: string } | null> {
-    const client = tx ?? this.prisma;
-    const inst = await client.installmentSchedule.findUniqueOrThrow({
+    // Fast idempotency check outside the transaction (avoids opening a tx for
+    // already-accrued installments — the common case on repeated cron ticks).
+    const instCheck = await this.prisma.installmentSchedule.findUniqueOrThrow({
+      where: { id: installmentScheduleId },
+      select: { accrualJournalEntryId: true },
+    });
+    if (instCheck.accrualJournalEntryId) return null;
+
+    if (outerTx) {
+      return this.run(installmentScheduleId, outerTx);
+    }
+    // No outer tx — self-wrap so the JE post + accrualJournalEntryId stamp +
+    // advance-consume JE + contract/payment updates are one atomic unit.
+    // A crash between any of these steps can no longer produce a duplicate
+    // accrual JE on the next cron tick (the idempotency stamp is committed
+    // atomically with the JE).
+    return this.prisma.$transaction((tx) => this.run(installmentScheduleId, tx));
+  }
+
+  private async run(
+    installmentScheduleId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<{ entryNo: string } | null> {
+    const inst = await tx.installmentSchedule.findUniqueOrThrow({
       where: { id: installmentScheduleId },
     });
 
-    // Idempotency guard
+    // Idempotency guard (re-check inside tx in case two concurrent cron ticks
+    // both passed the outer fast-check before either committed).
     if (inst.accrualJournalEntryId) return null;
 
-    const c = await client.contract.findUniqueOrThrow({ where: { id: inst.contractId } });
+    const c = await tx.contract.findUniqueOrThrow({ where: { id: inst.contractId } });
 
     // Per-installment amounts via the shared single source of truth — same
     // rounding the 2B receipt / early-payoff use (ROUND_DOWN principal,
@@ -162,7 +185,7 @@ export class InstallmentAccrual2ATemplate {
     );
 
     // Mark installment as accrued (idempotency)
-    await client.installmentSchedule.update({
+    await tx.installmentSchedule.update({
       where: { id: inst.id },
       data: { accrualJournalEntryId: result.entryNumber },
     });
@@ -182,9 +205,9 @@ export class InstallmentAccrual2ATemplate {
     // JE: Dr 21-1103 (consume advance) / Cr 11-2103 (clear receivable)
     //   for amount = min(advanceBalance, installmentTotal).
     //
-    // Atomicity: posted in the same outer tx as the accrual JE +
-    // schedule update, so a JE-post failure rolls everything back —
-    // no partially-consumed advance with the receivable still showing.
+    // Atomicity: posted in the same tx as the accrual JE + schedule update,
+    // so a JE-post failure rolls everything back — no partially-consumed
+    // advance with the receivable still showing.
     const advanceBalance = new Decimal(c.advanceBalance.toString());
     if (advanceBalance.gt(0)) {
       const consume = Decimal.min(advanceBalance, installmentTotal);
@@ -221,7 +244,7 @@ export class InstallmentAccrual2ATemplate {
       );
 
       // Decrement contract's parked advance balance by the consumed amount.
-      await client.contract.update({
+      await tx.contract.update({
         where: { id: c.id },
         data: { advanceBalance: { decrement: consume } },
       });
@@ -229,7 +252,7 @@ export class InstallmentAccrual2ATemplate {
       // Reflect the consume on the existing Payment row (if one was
       // pre-created when the advance was first received). Fully covered
       // installments flip to PAID; partial covers stay PARTIALLY_PAID.
-      const payment = await client.payment.findFirst({
+      const payment = await tx.payment.findFirst({
         where: {
           contractId: c.id,
           installmentNo: inst.installmentNo,
@@ -241,7 +264,7 @@ export class InstallmentAccrual2ATemplate {
         const newAmountPaid = new Decimal(payment.amountPaid.toString()).plus(consume);
         const due = new Decimal((payment.amountDue ?? installmentTotal).toString());
         const isPaidInFull = newAmountPaid.gte(due);
-        await client.payment.update({
+        await tx.payment.update({
           where: { id: payment.id },
           data: {
             amountPaid: newAmountPaid,

--- a/apps/api/src/modules/journal/installment-accrual-2a.template.golden.spec.ts
+++ b/apps/api/src/modules/journal/installment-accrual-2a.template.golden.spec.ts
@@ -38,15 +38,20 @@ describe('InstallmentAccrual2ATemplate.execute (golden · mock-based)', () => {
       dueDate: new Date('2026-01-01'),
       accrualJournalEntryId: null as string | null,
     };
-    const prisma = {
+    // $transaction must pass the tx client into the callback. We use the same
+    // prisma stub as the tx so the mock calls resolve correctly.
+    const prismaStub: Record<string, unknown> = {
       installmentSchedule: {
         findUniqueOrThrow: jest.fn().mockResolvedValue(inst),
         update: jest.fn().mockResolvedValue({}),
       },
       contract: { findUniqueOrThrow: jest.fn().mockResolvedValue(contract) },
     };
+    prismaStub.$transaction = jest.fn().mockImplementation(
+      (cb: (tx: unknown) => Promise<unknown>) => cb(prismaStub),
+    );
     const journal = { createAndPost } as unknown;
-    tmpl = new InstallmentAccrual2ATemplate(journal as never, prisma as never);
+    tmpl = new InstallmentAccrual2ATemplate(journal as never, prismaStub as never);
     return inst;
   };
 


### PR DESCRIPTION
**Finding (Wave-2 triage, D5 — REAL/LIVE, highest ledger blast radius):** the nightly accrual cron calls `InstallmentAccrual2ATemplate.execute(inst.id)` with **no tx**, so `client = this.prisma` (not a transaction). It posts the accrual JE via `createAndPost`, then in a **separate** write stamps `installmentSchedule.accrualJournalEntryId`. A crash between them leaves the schedule unlinked → the next nightly tick (selects on `accrualJournalEntryId: null`) **re-posts a DUPLICATE** accrual JE: double interest (Cr 41-1101) + double VAT output (Cr 21-2101) on the VAT-registered FINANCE entity. The in-method comment *promised* atomicity, but only when a caller passed an outer tx — the cron doesn't.

**Fix:** `execute()` self-wraps in `this.prisma.$transaction` when no tx is supplied (body extracted verbatim to a private `run(id, tx)`), so the JE post + the `accrualJournalEntryId` stamp + any advance-consume writes commit together. Callers that already pass a tx are unchanged. **No posted-JE output change** — pure atomicity.

**Verify:** adversarial pass → SOLID/SHIP, validated against a **live Postgres**: window closed (both writes on the same tx), no nesting risk (no prod caller wraps execute in its own tx; none of the 5 vitest+DB specs do either), behavior byte-for-byte identical. jest unit spec 3/3 + `installment-accrual-2a` vitest 6/6 + the 4 chaining specs pass isolated. (Cross-suite parallel-DB contamination is pre-existing — identical on main.)

ACCOUNTANT-AWARE: changes no correct-path JE; only prevents a crash-retry duplicate. Core revenue-recognition engine, so flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)