### PR TITLE
fix(finance-receivable): cap commissionRate at 1 to prevent a negative receivable

### DIFF
--- a/apps/api/src/modules/finance-receivable/dto/finance-receivable.dto.spec.ts
+++ b/apps/api/src/modules/finance-receivable/dto/finance-receivable.dto.spec.ts
@@ -1,0 +1,32 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { UpdateFinanceReceivableDto } from './finance-receivable.dto';
+
+/**
+ * #D5 — commissionRate is a fraction (0..1); the service recomputes
+ * commissionAmount = expectedAmount * rate and netExpectedAmount =
+ * expectedAmount - commissionAmount. A rate > 1 yields a NEGATIVE
+ * netExpectedAmount. Guard it at the DTO boundary.
+ */
+describe('UpdateFinanceReceivableDto.commissionRate bounds', () => {
+  async function errorsFor(commissionRate: number) {
+    const dto = plainToInstance(UpdateFinanceReceivableDto, { commissionRate });
+    return validate(dto);
+  }
+
+  it('rejects rate > 1 (would make netExpectedAmount negative)', async () => {
+    const errs = await errorsFor(1.5);
+    expect(errs.some((e) => e.property === 'commissionRate' && e.constraints?.max)).toBe(true);
+  });
+
+  it('rejects a negative rate', async () => {
+    const errs = await errorsFor(-0.1);
+    expect(errs.some((e) => e.property === 'commissionRate' && e.constraints?.min)).toBe(true);
+  });
+
+  it('accepts a valid fraction (0, 0.1, 1)', async () => {
+    expect(await errorsFor(0)).toHaveLength(0);
+    expect(await errorsFor(0.1)).toHaveLength(0);
+    expect(await errorsFor(1)).toHaveLength(0);
+  });
+});

--- a/apps/api/src/modules/finance-receivable/dto/finance-receivable.dto.ts
+++ b/apps/api/src/modules/finance-receivable/dto/finance-receivable.dto.ts
@@ -5,6 +5,7 @@ import {
   IsEnum,
   IsDateString,
   Min,
+  Max,
 } from 'class-validator';
 import { FinanceReceivableStatus } from '@prisma/client';
 
@@ -33,6 +34,11 @@ export class UpdateFinanceReceivableDto {
   @IsOptional()
   @IsNumber()
   @Min(0)
+  // commissionRate is a fraction (0..1) — service recomputes
+  // commissionAmount = expectedAmount * rate. Without @Max(1) a rate > 1 makes
+  // commissionAmount exceed expectedAmount and netExpectedAmount go NEGATIVE
+  // (an impossible receivable written straight to the books).
+  @Max(1)
   commissionRate?: number;
 
   @IsOptional()


### PR DESCRIPTION
**Finding (Wave-2 triage, D5 — REAL/LIVE):** `UpdateFinanceReceivableDto.commissionRate` was `@Min(0)` with no upper bound. The service recompute is `commissionAmount = expectedAmount.mul(rate)` / `netExpectedAmount = expectedAmount.sub(commissionAmount)`, so a `rate > 1` (e.g. 1.5) makes `commissionAmount` exceed `expectedAmount` and `netExpectedAmount` go **negative** — an impossible FINANCE receivable written to the books via `PATCH /finance-receivable/:id`.

**Fix:** add `@Max(1)` (the rate is a 0..1 fraction — confirmed: column is `Decimal(5,4)`, frontend divides the percent by 100 before POST, sibling commission DTOs are already `@Min(0)@Max(1)`). DTO-bounds spec asserts >1 and <0 reject, 0/0.1/1 pass.

**Verify:** adversarial pass → SOLID/SHIP. Global ValidationPipe (whitelist+transform) enforces it → HTTP 400 on rate>1. The create path has no HTTP endpoint (records created server-side from config-bounded `storeCommissionPct`), so the PATCH DTO was the only unguarded surface. No existing rate>1 data/tests. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)